### PR TITLE
Enrich availability list responses with product names

### DIFF
--- a/apps/dev/src/components/voyant/availability/availability-overview.tsx
+++ b/apps/dev/src/components/voyant/availability/availability-overview.tsx
@@ -102,7 +102,7 @@ export function AvailabilityOverview({
                   onClick={() => onOpenSlot(slot.id)}
                 >
                   <div className="font-medium">
-                    {productNameById(products, slot.productId)} · {slot.dateLocal}
+                    {productNameById(products, slot.productId, slot.productName)} · {slot.dateLocal}
                   </div>
                   <div className="text-muted-foreground">
                     {formatDateTime(slot.startsAt)} · {slot.status.replace("_", " ")} · Remaining

--- a/apps/dev/src/components/voyant/availability/availability-page.tsx
+++ b/apps/dev/src/components/voyant/availability/availability-page.tsx
@@ -92,13 +92,17 @@ export function AvailabilityPage() {
   const filteredRules = rules.filter(
     (rule) =>
       matchesProduct(rule.productId) &&
-      matchesSearch(productNameById(products, rule.productId), rule.timezone, rule.recurrenceRule),
+      matchesSearch(
+        productNameById(products, rule.productId, rule.productName),
+        rule.timezone,
+        rule.recurrenceRule,
+      ),
   )
   const filteredStartTimes = startTimes.filter(
     (startTime) =>
       matchesProduct(startTime.productId) &&
       matchesSearch(
-        productNameById(products, startTime.productId),
+        productNameById(products, startTime.productId, startTime.productName),
         startTime.label,
         startTime.startTimeLocal,
       ),
@@ -107,7 +111,7 @@ export function AvailabilityPage() {
     (slot) =>
       matchesProduct(slot.productId) &&
       matchesSearch(
-        productNameById(products, slot.productId),
+        productNameById(products, slot.productId, slot.productName),
         slot.dateLocal,
         slot.startsAt,
         slot.status,
@@ -118,7 +122,7 @@ export function AvailabilityPage() {
     (closeout) =>
       matchesProduct(closeout.productId) &&
       matchesSearch(
-        productNameById(products, closeout.productId),
+        productNameById(products, closeout.productId, closeout.productName),
         closeout.dateLocal,
         closeout.slotId,
         closeout.reason,
@@ -129,7 +133,7 @@ export function AvailabilityPage() {
     (pickupPoint) =>
       matchesProduct(pickupPoint.productId) &&
       matchesSearch(
-        productNameById(products, pickupPoint.productId),
+        productNameById(products, pickupPoint.productId, pickupPoint.productName),
         pickupPoint.name,
         pickupPoint.locationText,
         pickupPoint.description,

--- a/apps/dev/src/components/voyant/availability/availability-shared.tsx
+++ b/apps/dev/src/components/voyant/availability/availability-shared.tsx
@@ -66,7 +66,7 @@ export const ruleColumns = (
   {
     accessorKey: "productId",
     header: ({ column }) => <DataTableColumnHeader column={column} title="Product" />,
-    cell: ({ row }) => productNameById(products, row.original.productId),
+    cell: ({ row }) => productNameById(products, row.original.productId, row.original.productName),
   },
   {
     accessorKey: "timezone",
@@ -120,7 +120,7 @@ export const startTimeColumns = (
   {
     accessorKey: "productId",
     header: ({ column }) => <DataTableColumnHeader column={column} title="Product" />,
-    cell: ({ row }) => productNameById(products, row.original.productId),
+    cell: ({ row }) => productNameById(products, row.original.productId, row.original.productName),
   },
   {
     accessorKey: "label",
@@ -172,7 +172,7 @@ export const slotColumns = (
   {
     accessorKey: "productId",
     header: ({ column }) => <DataTableColumnHeader column={column} title="Product" />,
-    cell: ({ row }) => productNameById(products, row.original.productId),
+    cell: ({ row }) => productNameById(products, row.original.productId, row.original.productName),
   },
   {
     accessorKey: "dateLocal",
@@ -222,7 +222,7 @@ export const closeoutColumns = (
   {
     accessorKey: "productId",
     header: ({ column }) => <DataTableColumnHeader column={column} title="Product" />,
-    cell: ({ row }) => productNameById(products, row.original.productId),
+    cell: ({ row }) => productNameById(products, row.original.productId, row.original.productName),
   },
   {
     accessorKey: "dateLocal",
@@ -246,7 +246,7 @@ export const pickupPointColumns = (
   {
     accessorKey: "productId",
     header: ({ column }) => <DataTableColumnHeader column={column} title="Product" />,
-    cell: ({ row }) => productNameById(products, row.original.productId),
+    cell: ({ row }) => productNameById(products, row.original.productId, row.original.productName),
   },
   {
     accessorKey: "name",

--- a/packages/availability-react/src/schemas.ts
+++ b/packages/availability-react/src/schemas.ts
@@ -29,6 +29,7 @@ export type ProductOption = z.infer<typeof productOptionSchema>
 export const availabilityRuleRecordSchema = z.object({
   id: z.string(),
   productId: z.string(),
+  productName: z.string().nullable().optional(),
   optionId: z.string().nullable(),
   facilityId: z.string().nullable(),
   timezone: z.string(),
@@ -47,6 +48,7 @@ export type AvailabilityRuleRow = AvailabilityRuleRecord
 export const availabilityStartTimeRecordSchema = z.object({
   id: z.string(),
   productId: z.string(),
+  productName: z.string().nullable().optional(),
   optionId: z.string().nullable(),
   facilityId: z.string().nullable(),
   label: z.string().nullable(),
@@ -62,6 +64,7 @@ export type AvailabilityStartTimeRow = AvailabilityStartTimeRecord
 export const availabilitySlotRecordSchema = z.object({
   id: z.string(),
   productId: z.string(),
+  productName: z.string().nullable().optional(),
   optionId: z.string().nullable(),
   facilityId: z.string().nullable(),
   availabilityRuleId: z.string().nullable(),
@@ -97,6 +100,7 @@ export type AvailabilitySlotDetail = z.infer<typeof availabilitySlotDetailSchema
 export const availabilityCloseoutRecordSchema = z.object({
   id: z.string(),
   productId: z.string(),
+  productName: z.string().nullable().optional(),
   slotId: z.string().nullable(),
   dateLocal: z.string(),
   reason: z.string().nullable(),
@@ -118,6 +122,7 @@ export type AvailabilitySlotPickupRow = z.infer<typeof availabilitySlotPickupRec
 export const availabilityPickupPointRecordSchema = z.object({
   id: z.string(),
   productId: z.string(),
+  productName: z.string().nullable().optional(),
   name: z.string(),
   description: z.string().nullable(),
   locationText: z.string().nullable(),

--- a/packages/availability-react/src/utils.ts
+++ b/packages/availability-react/src/utils.ts
@@ -24,7 +24,12 @@ export function formatDateTime(value: string | null) {
   return value ? value.replace("T", " ").slice(0, 16) : "-"
 }
 
-export function productNameById(products: ProductOption[], productId: string) {
+export function productNameById(
+  products: ProductOption[],
+  productId: string,
+  productName?: string | null,
+) {
+  if (productName) return productName
   return products.find((product) => product.id === productId)?.name ?? productId
 }
 

--- a/packages/availability/src/products-ref.ts
+++ b/packages/availability/src/products-ref.ts
@@ -1,0 +1,7 @@
+import { pgTable, text } from "drizzle-orm/pg-core"
+
+/** Minimal reference to the products table for LEFT JOIN enrichment. */
+export const productsRef = pgTable("products", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+})

--- a/packages/availability/src/service-core.ts
+++ b/packages/availability/src/service-core.ts
@@ -1,6 +1,7 @@
-import { and, asc, desc, eq, sql } from "drizzle-orm"
+import { and, asc, desc, eq, getTableColumns, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
+import { productsRef } from "./products-ref.js"
 import {
   availabilityCloseouts,
   availabilityRules,
@@ -33,8 +34,9 @@ export async function listRules(db: PostgresJsDatabase, query: AvailabilityRuleL
   const where = conditions.length ? and(...conditions) : undefined
   return paginate(
     db
-      .select()
+      .select({ ...getTableColumns(availabilityRules), productName: productsRef.name })
       .from(availabilityRules)
+      .leftJoin(productsRef, eq(availabilityRules.productId, productsRef.id))
       .where(where)
       .limit(query.limit)
       .offset(query.offset)
@@ -93,8 +95,9 @@ export async function listStartTimes(
 
   return paginate(
     db
-      .select()
+      .select({ ...getTableColumns(availabilityStartTimes), productName: productsRef.name })
       .from(availabilityStartTimes)
+      .leftJoin(productsRef, eq(availabilityStartTimes.productId, productsRef.id))
       .where(where)
       .limit(query.limit)
       .offset(query.offset)
@@ -158,8 +161,9 @@ export async function listSlots(db: PostgresJsDatabase, query: AvailabilitySlotL
 
   return paginate(
     db
-      .select()
+      .select({ ...getTableColumns(availabilitySlots), productName: productsRef.name })
       .from(availabilitySlots)
+      .leftJoin(productsRef, eq(availabilitySlots.productId, productsRef.id))
       .where(where)
       .limit(query.limit)
       .offset(query.offset)
@@ -228,8 +232,9 @@ export async function listCloseouts(db: PostgresJsDatabase, query: AvailabilityC
 
   return paginate(
     db
-      .select()
+      .select({ ...getTableColumns(availabilityCloseouts), productName: productsRef.name })
       .from(availabilityCloseouts)
+      .leftJoin(productsRef, eq(availabilityCloseouts.productId, productsRef.id))
       .where(where)
       .limit(query.limit)
       .offset(query.offset)

--- a/packages/availability/src/service-pickups.ts
+++ b/packages/availability/src/service-pickups.ts
@@ -1,6 +1,7 @@
-import { and, asc, desc, eq, sql } from "drizzle-orm"
+import { and, asc, desc, eq, getTableColumns, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
+import { productsRef } from "./products-ref.js"
 import {
   availabilityPickupPoints,
   availabilitySlotPickups,
@@ -47,8 +48,9 @@ export async function listPickupPoints(
 
   return paginate(
     db
-      .select()
+      .select({ ...getTableColumns(availabilityPickupPoints), productName: productsRef.name })
       .from(availabilityPickupPoints)
+      .leftJoin(productsRef, eq(availabilityPickupPoints.productId, productsRef.id))
       .where(where)
       .limit(query.limit)
       .offset(query.offset)
@@ -174,8 +176,9 @@ export async function listMeetingConfigs(
 
   return paginate(
     db
-      .select()
+      .select({ ...getTableColumns(productMeetingConfigs), productName: productsRef.name })
       .from(productMeetingConfigs)
+      .leftJoin(productsRef, eq(productMeetingConfigs.productId, productsRef.id))
       .where(where)
       .limit(query.limit)
       .offset(query.offset)

--- a/templates/dmc/src/components/voyant/availability/availability-overview.tsx
+++ b/templates/dmc/src/components/voyant/availability/availability-overview.tsx
@@ -105,7 +105,7 @@ export function AvailabilityOverview({
                   onClick={() => onOpenSlot(slot.id)}
                 >
                   <div className="font-medium">
-                    {productNameById(products, slot.productId)} · {slot.dateLocal}
+                    {productNameById(products, slot.productId, slot.productName)} · {slot.dateLocal}
                   </div>
                   <div className="text-muted-foreground">
                     {formatDateTime(slot.startsAt)} · {slot.status.replace("_", " ")} · Remaining

--- a/templates/dmc/src/components/voyant/availability/availability-page.tsx
+++ b/templates/dmc/src/components/voyant/availability/availability-page.tsx
@@ -92,13 +92,17 @@ export function AvailabilityPage() {
   const filteredRules = rules.filter(
     (rule) =>
       matchesProduct(rule.productId) &&
-      matchesSearch(productNameById(products, rule.productId), rule.timezone, rule.recurrenceRule),
+      matchesSearch(
+        productNameById(products, rule.productId, rule.productName),
+        rule.timezone,
+        rule.recurrenceRule,
+      ),
   )
   const filteredStartTimes = startTimes.filter(
     (startTime) =>
       matchesProduct(startTime.productId) &&
       matchesSearch(
-        productNameById(products, startTime.productId),
+        productNameById(products, startTime.productId, startTime.productName),
         startTime.label,
         startTime.startTimeLocal,
       ),
@@ -107,7 +111,7 @@ export function AvailabilityPage() {
     (slot) =>
       matchesProduct(slot.productId) &&
       matchesSearch(
-        productNameById(products, slot.productId),
+        productNameById(products, slot.productId, slot.productName),
         slot.dateLocal,
         slot.startsAt,
         slot.status,
@@ -118,7 +122,7 @@ export function AvailabilityPage() {
     (closeout) =>
       matchesProduct(closeout.productId) &&
       matchesSearch(
-        productNameById(products, closeout.productId),
+        productNameById(products, closeout.productId, closeout.productName),
         closeout.dateLocal,
         closeout.slotId,
         closeout.reason,
@@ -129,7 +133,7 @@ export function AvailabilityPage() {
     (pickupPoint) =>
       matchesProduct(pickupPoint.productId) &&
       matchesSearch(
-        productNameById(products, pickupPoint.productId),
+        productNameById(products, pickupPoint.productId, pickupPoint.productName),
         pickupPoint.name,
         pickupPoint.locationText,
         pickupPoint.description,

--- a/templates/dmc/src/components/voyant/availability/availability-shared.tsx
+++ b/templates/dmc/src/components/voyant/availability/availability-shared.tsx
@@ -66,7 +66,7 @@ export const ruleColumns = (
   {
     accessorKey: "productId",
     header: ({ column }) => <DataTableColumnHeader column={column} title="Product" />,
-    cell: ({ row }) => productNameById(products, row.original.productId),
+    cell: ({ row }) => productNameById(products, row.original.productId, row.original.productName),
   },
   {
     accessorKey: "timezone",
@@ -120,7 +120,7 @@ export const startTimeColumns = (
   {
     accessorKey: "productId",
     header: ({ column }) => <DataTableColumnHeader column={column} title="Product" />,
-    cell: ({ row }) => productNameById(products, row.original.productId),
+    cell: ({ row }) => productNameById(products, row.original.productId, row.original.productName),
   },
   {
     accessorKey: "label",
@@ -172,7 +172,7 @@ export const slotColumns = (
   {
     accessorKey: "productId",
     header: ({ column }) => <DataTableColumnHeader column={column} title="Product" />,
-    cell: ({ row }) => productNameById(products, row.original.productId),
+    cell: ({ row }) => productNameById(products, row.original.productId, row.original.productName),
   },
   {
     accessorKey: "dateLocal",
@@ -222,7 +222,7 @@ export const closeoutColumns = (
   {
     accessorKey: "productId",
     header: ({ column }) => <DataTableColumnHeader column={column} title="Product" />,
-    cell: ({ row }) => productNameById(products, row.original.productId),
+    cell: ({ row }) => productNameById(products, row.original.productId, row.original.productName),
   },
   {
     accessorKey: "dateLocal",
@@ -246,7 +246,7 @@ export const pickupPointColumns = (
   {
     accessorKey: "productId",
     header: ({ column }) => <DataTableColumnHeader column={column} title="Product" />,
-    cell: ({ row }) => productNameById(products, row.original.productId),
+    cell: ({ row }) => productNameById(products, row.original.productId, row.original.productName),
   },
   {
     accessorKey: "name",

--- a/templates/operator/src/components/voyant/availability/availability-overview.tsx
+++ b/templates/operator/src/components/voyant/availability/availability-overview.tsx
@@ -105,7 +105,7 @@ export function AvailabilityOverview({
                   onClick={() => onOpenSlot(slot.id)}
                 >
                   <div className="font-medium">
-                    {productNameById(products, slot.productId)} · {slot.dateLocal}
+                    {productNameById(products, slot.productId, slot.productName)} · {slot.dateLocal}
                   </div>
                   <div className="text-muted-foreground">
                     {formatDateTime(slot.startsAt)} · {slot.status.replace("_", " ")} · Remaining

--- a/templates/operator/src/components/voyant/availability/availability-page.tsx
+++ b/templates/operator/src/components/voyant/availability/availability-page.tsx
@@ -92,13 +92,17 @@ export function AvailabilityPage() {
   const filteredRules = rules.filter(
     (rule) =>
       matchesProduct(rule.productId) &&
-      matchesSearch(productNameById(products, rule.productId), rule.timezone, rule.recurrenceRule),
+      matchesSearch(
+        productNameById(products, rule.productId, rule.productName),
+        rule.timezone,
+        rule.recurrenceRule,
+      ),
   )
   const filteredStartTimes = startTimes.filter(
     (startTime) =>
       matchesProduct(startTime.productId) &&
       matchesSearch(
-        productNameById(products, startTime.productId),
+        productNameById(products, startTime.productId, startTime.productName),
         startTime.label,
         startTime.startTimeLocal,
       ),
@@ -107,7 +111,7 @@ export function AvailabilityPage() {
     (slot) =>
       matchesProduct(slot.productId) &&
       matchesSearch(
-        productNameById(products, slot.productId),
+        productNameById(products, slot.productId, slot.productName),
         slot.dateLocal,
         slot.startsAt,
         slot.status,
@@ -118,7 +122,7 @@ export function AvailabilityPage() {
     (closeout) =>
       matchesProduct(closeout.productId) &&
       matchesSearch(
-        productNameById(products, closeout.productId),
+        productNameById(products, closeout.productId, closeout.productName),
         closeout.dateLocal,
         closeout.slotId,
         closeout.reason,
@@ -129,7 +133,7 @@ export function AvailabilityPage() {
     (pickupPoint) =>
       matchesProduct(pickupPoint.productId) &&
       matchesSearch(
-        productNameById(products, pickupPoint.productId),
+        productNameById(products, pickupPoint.productId, pickupPoint.productName),
         pickupPoint.name,
         pickupPoint.locationText,
         pickupPoint.description,

--- a/templates/operator/src/components/voyant/availability/availability-shared.tsx
+++ b/templates/operator/src/components/voyant/availability/availability-shared.tsx
@@ -66,7 +66,7 @@ export const ruleColumns = (
   {
     accessorKey: "productId",
     header: ({ column }) => <DataTableColumnHeader column={column} title="Product" />,
-    cell: ({ row }) => productNameById(products, row.original.productId),
+    cell: ({ row }) => productNameById(products, row.original.productId, row.original.productName),
   },
   {
     accessorKey: "timezone",
@@ -120,7 +120,7 @@ export const startTimeColumns = (
   {
     accessorKey: "productId",
     header: ({ column }) => <DataTableColumnHeader column={column} title="Product" />,
-    cell: ({ row }) => productNameById(products, row.original.productId),
+    cell: ({ row }) => productNameById(products, row.original.productId, row.original.productName),
   },
   {
     accessorKey: "label",
@@ -172,7 +172,7 @@ export const slotColumns = (
   {
     accessorKey: "productId",
     header: ({ column }) => <DataTableColumnHeader column={column} title="Product" />,
-    cell: ({ row }) => productNameById(products, row.original.productId),
+    cell: ({ row }) => productNameById(products, row.original.productId, row.original.productName),
   },
   {
     accessorKey: "dateLocal",
@@ -222,7 +222,7 @@ export const closeoutColumns = (
   {
     accessorKey: "productId",
     header: ({ column }) => <DataTableColumnHeader column={column} title="Product" />,
-    cell: ({ row }) => productNameById(products, row.original.productId),
+    cell: ({ row }) => productNameById(products, row.original.productId, row.original.productName),
   },
   {
     accessorKey: "dateLocal",
@@ -246,7 +246,7 @@ export const pickupPointColumns = (
   {
     accessorKey: "productId",
     header: ({ column }) => <DataTableColumnHeader column={column} title="Product" />,
-    cell: ({ row }) => productNameById(products, row.original.productId),
+    cell: ({ row }) => productNameById(products, row.original.productId, row.original.productName),
   },
   {
     accessorKey: "name",


### PR DESCRIPTION
## Summary

- Add `productName` to all availability list endpoints (rules, start-times, slots, closeouts, pickup-points, meeting-configs) via LEFT JOIN against a minimal products table reference
- Eliminates the secondary product fetch the operator UI relied on to render display labels
- `productNameById()` now prefers server-provided names, falling back to client-side lookup for backward compatibility

Closes #11

## Test plan

- [x] `pnpm typecheck` passes
- [x] `GET /v1/admin/availability/slots` returns `productName` in each row
- [x] Operator availability tables render product names without a secondary product fetch
- [x] Tables still render correctly when `productName` is null (orphaned product ID)