### PR TITLE
Add changesets for recently-merged work

### DIFF
--- a/.changeset/availability-product-name-enrichment.md
+++ b/.changeset/availability-product-name-enrichment.md
@@ -1,0 +1,8 @@
+---
+"@voyantjs/availability": minor
+"@voyantjs/availability-react": minor
+---
+
+Enrich availability list responses with product names via LEFT JOIN
+
+Availability list endpoints (rules, start-times, slots, closeouts, pickup-points, meeting-configs) now return `productName` alongside the raw `productId`, resolved via a LEFT JOIN against a minimal products table reference. Operator UIs no longer need a secondary product lookup query just to render display labels. The `productNameById` utility in `@voyantjs/availability-react` now accepts the server-provided name as a third argument and falls back to the client-side lookup.

--- a/.changeset/operator-booking-workspace.md
+++ b/.changeset/operator-booking-workspace.md
@@ -1,0 +1,11 @@
+---
+"@voyantjs/bookings-react": minor
+"@voyantjs/finance-react": minor
+"@voyantjs/legal-react": minor
+---
+
+Flesh out the operator booking workspace with React hooks for the sections that already existed on the backend.
+
+- `@voyantjs/bookings-react`: add hooks for booking items (`useBookingItems`, `useBookingItemMutation`), item-participant assignment (`useBookingItemParticipants`, `useBookingItemParticipantMutation`), documents (`useBookingDocuments`, `useBookingDocumentMutation`), cancellation (`useBookingCancelMutation`), and convert-from-product (`useBookingConvertMutation`).
+- `@voyantjs/finance-react`: add hooks for booking payment schedules (`useBookingPaymentSchedules`, `useBookingPaymentScheduleMutation`) and booking guarantees (`useBookingGuarantees`, `useBookingGuaranteeMutation`).
+- `@voyantjs/legal-react`: add policy resolution (`useResolvePolicy`) and cancellation evaluation (`useEvaluateCancellation`) hooks that power the structured booking cancellation workflow.

--- a/.changeset/shared-room-booking-groups.md
+++ b/.changeset/shared-room-booking-groups.md
@@ -1,0 +1,15 @@
+---
+"@voyantjs/bookings": minor
+"@voyantjs/bookings-react": minor
+"@voyantjs/db": patch
+---
+
+Add a shared-room / split-booking group model
+
+Multiple separate bookings can now intentionally share one room/accommodation while each booking keeps its own finance + traveler records. Inspired by the ProTravel v3 `sharing_groups` pattern: flat peer bookings, a lightweight `booking_groups` + `booking_group_members` schema, smart cleanup on cancellation.
+
+`@voyantjs/bookings`: new `bookingGroups` and `bookingGroupMembers` tables (TypeID prefixes `bkgr` / `bkgm`), service functions for CRUD plus reverse lookup, unified passenger list across members, and automatic group dissolution when a cancellation leaves ≤1 active members. New routes under `/v1/bookings/groups` plus the REST-nested `GET /v1/bookings/:id/group`.
+
+`@voyantjs/bookings-react`: hooks for `useBookingGroups`, `useBookingGroup`, `useBookingGroupForBooking`, `useBookingGroupMutation`, and `useBookingGroupMemberMutation` (stateless — accepts `groupId` per-call so create-then-add flows work with a single hook instance).
+
+`@voyantjs/db`: register TypeID prefixes `bkgr` (booking_groups) and `bkgm` (booking_group_members).


### PR DESCRIPTION
## Summary

None of the feature PRs merged after v0.4.5 included changesets, so the release-train workflow has been idle and the version is stale.

This PR adds three thematic changesets:

- **availability product-name enrichment** → minor bump of \`@voyantjs/availability\` + \`@voyantjs/availability-react\`
- **operator booking workspace** → minor bump of \`@voyantjs/bookings-react\`, \`@voyantjs/finance-react\`, \`@voyantjs/legal-react\` (hooks for items, item-participants, payment schedules, guarantees, documents, cancellation, richer timeline, quick-book)
- **shared-room booking groups** → minor bump of \`@voyantjs/bookings\` + \`@voyantjs/bookings-react\`, patch bump of \`@voyantjs/db\` (new TypeID prefixes)

Once merged, the release-train workflow should generate the version PR automatically.