### PR TITLE
feat(bookings-react): auto-resolve productId from booking items (#36)

### DIFF
--- a/.changeset/auto-resolve-booking-primary-product.md
+++ b/.changeset/auto-resolve-booking-primary-product.md
@@ -1,0 +1,10 @@
+---
+"@voyantjs/bookings-react": minor
+"@voyantjs/voyant-ui": minor
+---
+
+Add `useBookingPrimaryProduct(bookingId)` hook and make `BookingCancellationDialog` + `BookingGroupSection` self-resolve `productId` (and `optionUnitId`) from the booking's items.
+
+The hook returns `{ productId, optionUnitId, isPending, isLoading }`, using the canonical "first item with a non-null productId" rule — the same heuristic every consumer was duplicating. Components auto-resolve by default when the prop is `undefined`; pass an explicit string or `null` as an override for multi-product bookings or to force the non-product-scoped policy.
+
+This fixes a quiet correctness regression where callers who forgot to wire `productId` silently fell back to the default cancellation policy instead of the product-scoped one.

--- a/apps/dev/src/components/voyant/bookings/booking-cancellation-dialog.tsx
+++ b/apps/dev/src/components/voyant/bookings/booking-cancellation-dialog.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { type BookingRecord, useBookingCancelMutation } from "@voyantjs/bookings-react"
+import {
+  type BookingRecord,
+  useBookingCancelMutation,
+  useBookingPrimaryProduct,
+} from "@voyantjs/bookings-react"
 import { useEvaluateCancellation, useResolvePolicy } from "@voyantjs/legal-react"
 import { AlertTriangle, Loader2 } from "lucide-react"
 import * as React from "react"
@@ -49,7 +53,14 @@ export interface BookingCancellationDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   booking: BookingRecord
-  /** Optional product ID used to resolve the applicable cancellation policy. */
+  /**
+   * Product ID used to resolve the applicable cancellation policy.
+   *
+   * Leave unset (or pass `undefined`) to auto-resolve from the booking's items
+   * — this is what you want for single-product bookings. Pass an explicit
+   * string or `null` to override (e.g. for multi-product bookings or to force
+   * the default non-product-scoped policy).
+   */
   productId?: string | null
   onSuccess?: () => void
 }
@@ -68,8 +79,17 @@ export function BookingCancellationDialog({
     return daysBetween(new Date(), new Date(booking.startDate))
   }, [booking.startDate])
 
+  // When the caller didn't specify a productId, derive one from the booking's
+  // items so the consumer doesn't have to wire up `useBookingItems` just for
+  // this. Explicit `null` is respected as an override.
+  const shouldAutoResolveProduct = productId === undefined
+  const autoResolved = useBookingPrimaryProduct(booking.id, {
+    enabled: open && shouldAutoResolveProduct,
+  })
+  const effectiveProductId = shouldAutoResolveProduct ? autoResolved.productId : productId
+
   const { data: resolved, isLoading: resolveLoading } = useResolvePolicy(
-    { kind: "cancellation", productId: productId ?? undefined },
+    { kind: "cancellation", productId: effectiveProductId ?? undefined },
     { enabled: open },
   )
 

--- a/apps/dev/src/components/voyant/bookings/booking-detail-page.tsx
+++ b/apps/dev/src/components/voyant/bookings/booking-detail-page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useNavigate } from "@tanstack/react-router"
-import { useBooking, useBookingItems, useBookingMutation } from "@voyantjs/bookings-react"
+import { useBooking, useBookingMutation } from "@voyantjs/bookings-react"
 import { ArrowLeft, Ban, Loader2, Pencil, RefreshCw, Trash2 } from "lucide-react"
 import { useState } from "react"
 
@@ -51,7 +51,6 @@ export function BookingDetailPage({ id }: { id: string }) {
   const [statusDialogOpen, setStatusDialogOpen] = useState(false)
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false)
   const { data: bookingData, isPending } = useBooking(id)
-  const { data: itemsData } = useBookingItems(id)
   const { remove } = useBookingMutation()
 
   if (isPending) {
@@ -206,11 +205,7 @@ export function BookingDetailPage({ id }: { id: string }) {
 
       <PassengerList bookingId={id} />
       <BookingItemList bookingId={id} />
-      <BookingGroupSection
-        bookingId={id}
-        productId={itemsData?.data?.[0]?.productId}
-        optionUnitId={itemsData?.data?.[0]?.optionUnitId}
-      />
+      <BookingGroupSection bookingId={id} />
       <BookingPaymentScheduleList bookingId={id} />
       <BookingGuaranteeList bookingId={id} />
       <BookingPaymentsSummary bookingId={id} />
@@ -232,7 +227,6 @@ export function BookingDetailPage({ id }: { id: string }) {
         open={cancelDialogOpen}
         onOpenChange={setCancelDialogOpen}
         booking={booking}
-        productId={itemsData?.data?.[0]?.productId}
       />
     </div>
   )

--- a/apps/dev/src/components/voyant/bookings/booking-group-section.tsx
+++ b/apps/dev/src/components/voyant/bookings/booking-group-section.tsx
@@ -4,6 +4,7 @@ import {
   useBookingGroup,
   useBookingGroupForBooking,
   useBookingGroupMemberMutation,
+  useBookingPrimaryProduct,
 } from "@voyantjs/bookings-react"
 import { Link2, Unlink, Users } from "lucide-react"
 import * as React from "react"
@@ -14,7 +15,17 @@ import { BookingGroupLinkDialog } from "./booking-group-link-dialog"
 
 export interface BookingGroupSectionProps {
   bookingId: string
+  /**
+   * Product ID used to scope shared-room group context. Leave unset to
+   * auto-resolve from the booking's items; pass an explicit string or `null`
+   * to override.
+   */
   productId?: string | null
+  /**
+   * Option unit ID used to scope shared-room group context. Leave unset to
+   * auto-resolve from the booking's items; pass an explicit string or `null`
+   * to override.
+   */
   optionUnitId?: string | null
 }
 
@@ -24,6 +35,14 @@ export function BookingGroupSection({
   optionUnitId,
 }: BookingGroupSectionProps) {
   const [linkDialogOpen, setLinkDialogOpen] = React.useState(false)
+
+  // Auto-resolve product/option-unit from items when the caller hasn't
+  // supplied them. Explicit `null` is respected as an override.
+  const shouldAutoResolve = productId === undefined || optionUnitId === undefined
+  const autoResolved = useBookingPrimaryProduct(bookingId, { enabled: shouldAutoResolve })
+  const effectiveProductId = productId === undefined ? autoResolved.productId : productId
+  const effectiveOptionUnitId =
+    optionUnitId === undefined ? autoResolved.optionUnitId : optionUnitId
 
   const { data: groupForBookingData } = useBookingGroupForBooking(bookingId)
   const group = groupForBookingData?.data ?? null
@@ -127,8 +146,8 @@ export function BookingGroupSection({
         open={linkDialogOpen}
         onOpenChange={setLinkDialogOpen}
         bookingId={bookingId}
-        productId={productId}
-        optionUnitId={optionUnitId}
+        productId={effectiveProductId}
+        optionUnitId={effectiveOptionUnitId}
       />
     </Card>
   )

--- a/packages/bookings-react/src/hooks/index.ts
+++ b/packages/bookings-react/src/hooks/index.ts
@@ -52,6 +52,11 @@ export {
 } from "./use-booking-note-mutation.js"
 export { type UseBookingNotesOptions, useBookingNotes } from "./use-booking-notes.js"
 export {
+  type UseBookingPrimaryProductOptions,
+  type UseBookingPrimaryProductResult,
+  useBookingPrimaryProduct,
+} from "./use-booking-primary-product.js"
+export {
   type UpdateBookingStatusInput,
   useBookingStatusMutation,
 } from "./use-booking-status-mutation.js"

--- a/packages/bookings-react/src/hooks/use-booking-primary-product.ts
+++ b/packages/bookings-react/src/hooks/use-booking-primary-product.ts
@@ -1,0 +1,45 @@
+"use client"
+
+import { type UseBookingItemsOptions, useBookingItems } from "./use-booking-items.js"
+
+export type UseBookingPrimaryProductOptions = UseBookingItemsOptions
+
+export interface UseBookingPrimaryProductResult {
+  /**
+   * The productId of the first booking item that has a non-null productId,
+   * or null if no item has one (or items haven't loaded yet).
+   */
+  productId: string | null
+  /**
+   * The optionUnitId from the same item the `productId` was sourced from,
+   * or null if that item has none (or no item resolved).
+   */
+  optionUnitId: string | null
+  /** True while the underlying items query has no data yet. */
+  isPending: boolean
+  /** True while the underlying items query is loading for the first time. */
+  isLoading: boolean
+}
+
+/**
+ * Derive the "primary product" of a booking from its items.
+ *
+ * Tour-operator-style bookings are almost always scoped to a single product,
+ * but the product association lives on `bookingItem`, not `booking`. This hook
+ * encapsulates the canonical resolution — "first item with a non-null
+ * productId" — so consumers don't duplicate it.
+ */
+export function useBookingPrimaryProduct(
+  bookingId: string | null | undefined,
+  options: UseBookingPrimaryProductOptions = {},
+): UseBookingPrimaryProductResult {
+  const query = useBookingItems(bookingId, options)
+  const primary = query.data?.data.find((i) => i.productId) ?? null
+
+  return {
+    productId: primary?.productId ?? null,
+    optionUnitId: primary?.optionUnitId ?? null,
+    isPending: query.isPending,
+    isLoading: query.isLoading,
+  }
+}

--- a/packages/ui/registry/bookings/booking-cancellation-dialog.tsx
+++ b/packages/ui/registry/bookings/booking-cancellation-dialog.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { type BookingRecord, useBookingCancelMutation } from "@voyantjs/bookings-react"
+import {
+  type BookingRecord,
+  useBookingCancelMutation,
+  useBookingPrimaryProduct,
+} from "@voyantjs/bookings-react"
 import { useEvaluateCancellation, useResolvePolicy } from "@voyantjs/legal-react"
 import { AlertTriangle, Loader2 } from "lucide-react"
 import * as React from "react"
@@ -49,7 +53,14 @@ export interface BookingCancellationDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   booking: BookingRecord
-  /** Optional product ID used to resolve the applicable cancellation policy. */
+  /**
+   * Product ID used to resolve the applicable cancellation policy.
+   *
+   * Leave unset (or pass `undefined`) to auto-resolve from the booking's items
+   * — this is what you want for single-product bookings. Pass an explicit
+   * string or `null` to override (e.g. for multi-product bookings or to force
+   * the default non-product-scoped policy).
+   */
   productId?: string | null
   onSuccess?: () => void
 }
@@ -68,8 +79,17 @@ export function BookingCancellationDialog({
     return daysBetween(new Date(), new Date(booking.startDate))
   }, [booking.startDate])
 
+  // When the caller didn't specify a productId, derive one from the booking's
+  // items so the consumer doesn't have to wire up `useBookingItems` just for
+  // this. Explicit `null` is respected as an override.
+  const shouldAutoResolveProduct = productId === undefined
+  const autoResolved = useBookingPrimaryProduct(booking.id, {
+    enabled: open && shouldAutoResolveProduct,
+  })
+  const effectiveProductId = shouldAutoResolveProduct ? autoResolved.productId : productId
+
   const { data: resolved, isLoading: resolveLoading } = useResolvePolicy(
-    { kind: "cancellation", productId: productId ?? undefined },
+    { kind: "cancellation", productId: effectiveProductId ?? undefined },
     { enabled: open },
   )
 

--- a/packages/ui/registry/bookings/booking-group-section.tsx
+++ b/packages/ui/registry/bookings/booking-group-section.tsx
@@ -4,6 +4,7 @@ import {
   useBookingGroup,
   useBookingGroupForBooking,
   useBookingGroupMemberMutation,
+  useBookingPrimaryProduct,
 } from "@voyantjs/bookings-react"
 import { Link2, Unlink, Users } from "lucide-react"
 import * as React from "react"
@@ -14,7 +15,17 @@ import { BookingGroupLinkDialog } from "./booking-group-link-dialog"
 
 export interface BookingGroupSectionProps {
   bookingId: string
+  /**
+   * Product ID used to scope shared-room group context. Leave unset to
+   * auto-resolve from the booking's items; pass an explicit string or `null`
+   * to override.
+   */
   productId?: string | null
+  /**
+   * Option unit ID used to scope shared-room group context. Leave unset to
+   * auto-resolve from the booking's items; pass an explicit string or `null`
+   * to override.
+   */
   optionUnitId?: string | null
 }
 
@@ -24,6 +35,14 @@ export function BookingGroupSection({
   optionUnitId,
 }: BookingGroupSectionProps) {
   const [linkDialogOpen, setLinkDialogOpen] = React.useState(false)
+
+  // Auto-resolve product/option-unit from items when the caller hasn't
+  // supplied them. Explicit `null` is respected as an override.
+  const shouldAutoResolve = productId === undefined || optionUnitId === undefined
+  const autoResolved = useBookingPrimaryProduct(bookingId, { enabled: shouldAutoResolve })
+  const effectiveProductId = productId === undefined ? autoResolved.productId : productId
+  const effectiveOptionUnitId =
+    optionUnitId === undefined ? autoResolved.optionUnitId : optionUnitId
 
   const { data: groupForBookingData } = useBookingGroupForBooking(bookingId)
   const group = groupForBookingData?.data ?? null
@@ -127,8 +146,8 @@ export function BookingGroupSection({
         open={linkDialogOpen}
         onOpenChange={setLinkDialogOpen}
         bookingId={bookingId}
-        productId={productId}
-        optionUnitId={optionUnitId}
+        productId={effectiveProductId}
+        optionUnitId={effectiveOptionUnitId}
       />
     </Card>
   )

--- a/templates/dmc/src/components/voyant/bookings/booking-cancellation-dialog.tsx
+++ b/templates/dmc/src/components/voyant/bookings/booking-cancellation-dialog.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { type BookingRecord, useBookingCancelMutation } from "@voyantjs/bookings-react"
+import {
+  type BookingRecord,
+  useBookingCancelMutation,
+  useBookingPrimaryProduct,
+} from "@voyantjs/bookings-react"
 import { useEvaluateCancellation, useResolvePolicy } from "@voyantjs/legal-react"
 import { AlertTriangle, Loader2 } from "lucide-react"
 import * as React from "react"
@@ -49,7 +53,14 @@ export interface BookingCancellationDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   booking: BookingRecord
-  /** Optional product ID used to resolve the applicable cancellation policy. */
+  /**
+   * Product ID used to resolve the applicable cancellation policy.
+   *
+   * Leave unset (or pass `undefined`) to auto-resolve from the booking's items
+   * — this is what you want for single-product bookings. Pass an explicit
+   * string or `null` to override (e.g. for multi-product bookings or to force
+   * the default non-product-scoped policy).
+   */
   productId?: string | null
   onSuccess?: () => void
 }
@@ -68,8 +79,17 @@ export function BookingCancellationDialog({
     return daysBetween(new Date(), new Date(booking.startDate))
   }, [booking.startDate])
 
+  // When the caller didn't specify a productId, derive one from the booking's
+  // items so the consumer doesn't have to wire up `useBookingItems` just for
+  // this. Explicit `null` is respected as an override.
+  const shouldAutoResolveProduct = productId === undefined
+  const autoResolved = useBookingPrimaryProduct(booking.id, {
+    enabled: open && shouldAutoResolveProduct,
+  })
+  const effectiveProductId = shouldAutoResolveProduct ? autoResolved.productId : productId
+
   const { data: resolved, isLoading: resolveLoading } = useResolvePolicy(
-    { kind: "cancellation", productId: productId ?? undefined },
+    { kind: "cancellation", productId: effectiveProductId ?? undefined },
     { enabled: open },
   )
 

--- a/templates/dmc/src/components/voyant/bookings/booking-detail-page.tsx
+++ b/templates/dmc/src/components/voyant/bookings/booking-detail-page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useNavigate } from "@tanstack/react-router"
-import { useBooking, useBookingItems, useBookingMutation } from "@voyantjs/bookings-react"
+import { useBooking, useBookingMutation } from "@voyantjs/bookings-react"
 import { ArrowLeft, Ban, Loader2, Pencil, RefreshCw, Trash2 } from "lucide-react"
 import { useState } from "react"
 
@@ -51,7 +51,6 @@ export function BookingDetailPage({ id }: { id: string }) {
   const [statusDialogOpen, setStatusDialogOpen] = useState(false)
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false)
   const { data: bookingData, isPending } = useBooking(id)
-  const { data: itemsData } = useBookingItems(id)
   const { remove } = useBookingMutation()
 
   if (isPending) {
@@ -206,11 +205,7 @@ export function BookingDetailPage({ id }: { id: string }) {
 
       <PassengerList bookingId={id} />
       <BookingItemList bookingId={id} />
-      <BookingGroupSection
-        bookingId={id}
-        productId={itemsData?.data?.[0]?.productId}
-        optionUnitId={itemsData?.data?.[0]?.optionUnitId}
-      />
+      <BookingGroupSection bookingId={id} />
       <BookingPaymentScheduleList bookingId={id} />
       <BookingGuaranteeList bookingId={id} />
       <BookingPaymentsSummary bookingId={id} />
@@ -232,7 +227,6 @@ export function BookingDetailPage({ id }: { id: string }) {
         open={cancelDialogOpen}
         onOpenChange={setCancelDialogOpen}
         booking={booking}
-        productId={itemsData?.data?.[0]?.productId}
       />
     </div>
   )

--- a/templates/dmc/src/components/voyant/bookings/booking-group-section.tsx
+++ b/templates/dmc/src/components/voyant/bookings/booking-group-section.tsx
@@ -4,6 +4,7 @@ import {
   useBookingGroup,
   useBookingGroupForBooking,
   useBookingGroupMemberMutation,
+  useBookingPrimaryProduct,
 } from "@voyantjs/bookings-react"
 import { Link2, Unlink, Users } from "lucide-react"
 import * as React from "react"
@@ -14,7 +15,17 @@ import { BookingGroupLinkDialog } from "./booking-group-link-dialog"
 
 export interface BookingGroupSectionProps {
   bookingId: string
+  /**
+   * Product ID used to scope shared-room group context. Leave unset to
+   * auto-resolve from the booking's items; pass an explicit string or `null`
+   * to override.
+   */
   productId?: string | null
+  /**
+   * Option unit ID used to scope shared-room group context. Leave unset to
+   * auto-resolve from the booking's items; pass an explicit string or `null`
+   * to override.
+   */
   optionUnitId?: string | null
 }
 
@@ -24,6 +35,14 @@ export function BookingGroupSection({
   optionUnitId,
 }: BookingGroupSectionProps) {
   const [linkDialogOpen, setLinkDialogOpen] = React.useState(false)
+
+  // Auto-resolve product/option-unit from items when the caller hasn't
+  // supplied them. Explicit `null` is respected as an override.
+  const shouldAutoResolve = productId === undefined || optionUnitId === undefined
+  const autoResolved = useBookingPrimaryProduct(bookingId, { enabled: shouldAutoResolve })
+  const effectiveProductId = productId === undefined ? autoResolved.productId : productId
+  const effectiveOptionUnitId =
+    optionUnitId === undefined ? autoResolved.optionUnitId : optionUnitId
 
   const { data: groupForBookingData } = useBookingGroupForBooking(bookingId)
   const group = groupForBookingData?.data ?? null
@@ -127,8 +146,8 @@ export function BookingGroupSection({
         open={linkDialogOpen}
         onOpenChange={setLinkDialogOpen}
         bookingId={bookingId}
-        productId={productId}
-        optionUnitId={optionUnitId}
+        productId={effectiveProductId}
+        optionUnitId={effectiveOptionUnitId}
       />
     </Card>
   )

--- a/templates/operator/src/components/voyant/bookings/booking-cancellation-dialog.tsx
+++ b/templates/operator/src/components/voyant/bookings/booking-cancellation-dialog.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { type BookingRecord, useBookingCancelMutation } from "@voyantjs/bookings-react"
+import {
+  type BookingRecord,
+  useBookingCancelMutation,
+  useBookingPrimaryProduct,
+} from "@voyantjs/bookings-react"
 import { useEvaluateCancellation, useResolvePolicy } from "@voyantjs/legal-react"
 import { AlertTriangle, Loader2 } from "lucide-react"
 import * as React from "react"
@@ -49,7 +53,14 @@ export interface BookingCancellationDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   booking: BookingRecord
-  /** Optional product ID used to resolve the applicable cancellation policy. */
+  /**
+   * Product ID used to resolve the applicable cancellation policy.
+   *
+   * Leave unset (or pass `undefined`) to auto-resolve from the booking's items
+   * — this is what you want for single-product bookings. Pass an explicit
+   * string or `null` to override (e.g. for multi-product bookings or to force
+   * the default non-product-scoped policy).
+   */
   productId?: string | null
   onSuccess?: () => void
 }
@@ -68,8 +79,17 @@ export function BookingCancellationDialog({
     return daysBetween(new Date(), new Date(booking.startDate))
   }, [booking.startDate])
 
+  // When the caller didn't specify a productId, derive one from the booking's
+  // items so the consumer doesn't have to wire up `useBookingItems` just for
+  // this. Explicit `null` is respected as an override.
+  const shouldAutoResolveProduct = productId === undefined
+  const autoResolved = useBookingPrimaryProduct(booking.id, {
+    enabled: open && shouldAutoResolveProduct,
+  })
+  const effectiveProductId = shouldAutoResolveProduct ? autoResolved.productId : productId
+
   const { data: resolved, isLoading: resolveLoading } = useResolvePolicy(
-    { kind: "cancellation", productId: productId ?? undefined },
+    { kind: "cancellation", productId: effectiveProductId ?? undefined },
     { enabled: open },
   )
 

--- a/templates/operator/src/components/voyant/bookings/booking-detail-page.tsx
+++ b/templates/operator/src/components/voyant/bookings/booking-detail-page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useNavigate } from "@tanstack/react-router"
-import { useBooking, useBookingItems, useBookingMutation } from "@voyantjs/bookings-react"
+import { useBooking, useBookingMutation } from "@voyantjs/bookings-react"
 import { ArrowLeft, Ban, Loader2, Pencil, RefreshCw, Trash2 } from "lucide-react"
 import { useState } from "react"
 
@@ -51,7 +51,6 @@ export function BookingDetailPage({ id }: { id: string }) {
   const [statusDialogOpen, setStatusDialogOpen] = useState(false)
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false)
   const { data: bookingData, isPending } = useBooking(id)
-  const { data: itemsData } = useBookingItems(id)
   const { remove } = useBookingMutation()
 
   if (isPending) {
@@ -206,11 +205,7 @@ export function BookingDetailPage({ id }: { id: string }) {
 
       <PassengerList bookingId={id} />
       <BookingItemList bookingId={id} />
-      <BookingGroupSection
-        bookingId={id}
-        productId={itemsData?.data?.[0]?.productId}
-        optionUnitId={itemsData?.data?.[0]?.optionUnitId}
-      />
+      <BookingGroupSection bookingId={id} />
       <BookingPaymentScheduleList bookingId={id} />
       <BookingGuaranteeList bookingId={id} />
       <BookingPaymentsSummary bookingId={id} />
@@ -232,7 +227,6 @@ export function BookingDetailPage({ id }: { id: string }) {
         open={cancelDialogOpen}
         onOpenChange={setCancelDialogOpen}
         booking={booking}
-        productId={itemsData?.data?.[0]?.productId}
       />
     </div>
   )

--- a/templates/operator/src/components/voyant/bookings/booking-group-section.tsx
+++ b/templates/operator/src/components/voyant/bookings/booking-group-section.tsx
@@ -4,6 +4,7 @@ import {
   useBookingGroup,
   useBookingGroupForBooking,
   useBookingGroupMemberMutation,
+  useBookingPrimaryProduct,
 } from "@voyantjs/bookings-react"
 import { Link2, Unlink, Users } from "lucide-react"
 import * as React from "react"
@@ -14,7 +15,17 @@ import { BookingGroupLinkDialog } from "./booking-group-link-dialog"
 
 export interface BookingGroupSectionProps {
   bookingId: string
+  /**
+   * Product ID used to scope shared-room group context. Leave unset to
+   * auto-resolve from the booking's items; pass an explicit string or `null`
+   * to override.
+   */
   productId?: string | null
+  /**
+   * Option unit ID used to scope shared-room group context. Leave unset to
+   * auto-resolve from the booking's items; pass an explicit string or `null`
+   * to override.
+   */
   optionUnitId?: string | null
 }
 
@@ -24,6 +35,14 @@ export function BookingGroupSection({
   optionUnitId,
 }: BookingGroupSectionProps) {
   const [linkDialogOpen, setLinkDialogOpen] = React.useState(false)
+
+  // Auto-resolve product/option-unit from items when the caller hasn't
+  // supplied them. Explicit `null` is respected as an override.
+  const shouldAutoResolve = productId === undefined || optionUnitId === undefined
+  const autoResolved = useBookingPrimaryProduct(bookingId, { enabled: shouldAutoResolve })
+  const effectiveProductId = productId === undefined ? autoResolved.productId : productId
+  const effectiveOptionUnitId =
+    optionUnitId === undefined ? autoResolved.optionUnitId : optionUnitId
 
   const { data: groupForBookingData } = useBookingGroupForBooking(bookingId)
   const group = groupForBookingData?.data ?? null
@@ -127,8 +146,8 @@ export function BookingGroupSection({
         open={linkDialogOpen}
         onOpenChange={setLinkDialogOpen}
         bookingId={bookingId}
-        productId={productId}
-        optionUnitId={optionUnitId}
+        productId={effectiveProductId}
+        optionUnitId={effectiveOptionUnitId}
       />
     </Card>
   )


### PR DESCRIPTION
Closes #36.

## Summary
- Add `useBookingPrimaryProduct(bookingId)` hook to `@voyantjs/bookings-react`. Returns `{ productId, optionUnitId, isPending, isLoading }` using the canonical "first item with a non-null productId" rule every consumer was duplicating.
- Make `BookingCancellationDialog` + `BookingGroupSection` (in `@voyantjs/voyant-ui` registry) self-resolve `productId`/`optionUnitId` from items when the prop is `undefined`. Explicit `string | null` still overrides for multi-product bookings or to force the default non-product-scoped policy.
- Drop the redundant `useBookingItems` + `itemsData?.data?.[0]?.productId` boilerplate from `booking-detail-page.tsx` in `templates/dmc`, `templates/operator`, and `apps/dev`. Sync the updated registry copies across all three.

This fixes a quiet correctness regression: callers who forgot to wire `productId` silently fell back to the default cancellation policy instead of the product-scoped one. No loud type error, just wrong refund math.

## Why A+B
Option A (components self-resolve) keeps the call site clean. Option B (shared hook) makes the same resolution reusable anywhere else (e.g. deep-linking from a booking row). Shipping both: components auto-resolve by default, hook is available for reuse.

## Test plan
- [x] `pnpm typecheck` — 125/125 pass
- [x] `pnpm -F @voyantjs/bookings-react lint` + `test` green
- [x] `pnpm -F @voyantjs/voyant-ui lint` green
- [ ] Manually exercise `BookingCancellationDialog` in `apps/dev`: verify the resolved policy is the product-scoped one (not the default) without passing `productId` explicitly
- [ ] Manually exercise `BookingGroupSection` link flow: confirm `BookingGroupLinkDialog` still receives the right `productId`/`optionUnitId` via auto-resolution