### PR TITLE
feat(bookings-react): canonical status badge variant + label helpers (#37)

### DIFF
--- a/.changeset/booking-status-presentation-helpers.md
+++ b/.changeset/booking-status-presentation-helpers.md
@@ -1,0 +1,13 @@
+---
+"@voyantjs/bookings-react": minor
+"@voyantjs/voyant-ui": minor
+---
+
+Add canonical booking status presentation helpers to `@voyantjs/bookings-react`:
+
+- `bookingStatusBadgeVariant: Record<BookingStatus, 'default' | 'secondary' | 'outline' | 'destructive'>` — exhaustive (not `Record<string, …>`), so adding a new booking status becomes a compile error here instead of a silent UX miss in every app.
+- `formatBookingStatus(status)` — humanized label (`"in_progress"` → `"In Progress"`).
+- `bookingStatuses` / `bookingStatusOptions` — status list derived from the Zod schema, ready for Select pickers.
+- `BookingStatus` type (now exported from `./schemas`).
+
+Registry components in `@voyantjs/voyant-ui` (`booking-list`, `booking-detail-page` copies, `status-change-dialog`) drop their duplicated local `statusVariant` / `formatStatus` / `BOOKING_STATUSES` constants and consume these instead — single source of truth.

--- a/apps/dev/src/components/voyant/bookings/booking-detail-page.tsx
+++ b/apps/dev/src/components/voyant/bookings/booking-detail-page.tsx
@@ -1,7 +1,12 @@
 "use client"
 
 import { useNavigate } from "@tanstack/react-router"
-import { useBooking, useBookingMutation } from "@voyantjs/bookings-react"
+import {
+  bookingStatusBadgeVariant,
+  formatBookingStatus,
+  useBooking,
+  useBookingMutation,
+} from "@voyantjs/bookings-react"
 import { ArrowLeft, Ban, Loader2, Pencil, RefreshCw, Trash2 } from "lucide-react"
 import { useState } from "react"
 
@@ -21,16 +26,6 @@ import { PassengerList } from "./passenger-list"
 import { StatusChangeDialog } from "./status-change-dialog"
 import { SupplierStatusList } from "./supplier-status-list"
 
-const statusVariant: Record<string, "default" | "secondary" | "outline" | "destructive"> = {
-  draft: "outline",
-  on_hold: "secondary",
-  confirmed: "default",
-  in_progress: "secondary",
-  completed: "default",
-  expired: "secondary",
-  cancelled: "destructive",
-}
-
 function formatAmount(cents: number | null, currency: string): string {
   if (cents == null) return "-"
   return `${(cents / 100).toFixed(2)} ${currency}`
@@ -39,10 +34,6 @@ function formatAmount(cents: number | null, currency: string): string {
 function formatMargin(percent: number | null): string {
   if (percent == null) return "-"
   return `${(percent / 100).toFixed(2)}%`
-}
-
-function formatStatus(status: string): string {
-  return status.replace("_", " ")
 }
 
 export function BookingDetailPage({ id }: { id: string }) {
@@ -82,8 +73,8 @@ export function BookingDetailPage({ id }: { id: string }) {
         <div className="flex-1">
           <h1 className="text-2xl font-bold tracking-tight">{booking.bookingNumber}</h1>
           <div className="mt-1 flex items-center gap-2">
-            <Badge variant={statusVariant[booking.status] ?? "secondary"} className="capitalize">
-              {formatStatus(booking.status)}
+            <Badge variant={bookingStatusBadgeVariant[booking.status]}>
+              {formatBookingStatus(booking.status)}
             </Badge>
           </div>
         </div>

--- a/apps/dev/src/components/voyant/bookings/booking-list.tsx
+++ b/apps/dev/src/components/voyant/bookings/booking-list.tsx
@@ -1,6 +1,11 @@
 "use client"
 
-import { type BookingRecord, useBookings } from "@voyantjs/bookings-react"
+import {
+  type BookingRecord,
+  bookingStatusBadgeVariant,
+  formatBookingStatus,
+  useBookings,
+} from "@voyantjs/bookings-react"
 import { Loader2, Plus, Search, Zap } from "lucide-react"
 import * as React from "react"
 
@@ -24,23 +29,9 @@ export interface BookingListProps {
   onSelectBooking?: (booking: BookingRecord) => void
 }
 
-const statusVariant: Record<string, "default" | "secondary" | "outline" | "destructive"> = {
-  draft: "outline",
-  on_hold: "secondary",
-  confirmed: "default",
-  in_progress: "secondary",
-  completed: "default",
-  expired: "secondary",
-  cancelled: "destructive",
-}
-
 function formatAmount(cents: number | null, currency: string): string {
   if (cents == null) return "—"
   return `${(cents / 100).toFixed(2)} ${currency}`
-}
-
-function formatStatus(status: string): string {
-  return status.replace("_", " ")
 }
 
 export function BookingList({ pageSize = 25, onSelectBooking }: BookingListProps = {}) {
@@ -141,11 +132,8 @@ export function BookingList({ pageSize = 25, onSelectBooking }: BookingListProps
                 >
                   <TableCell className="font-medium">{booking.bookingNumber}</TableCell>
                   <TableCell>
-                    <Badge
-                      variant={statusVariant[booking.status] ?? "secondary"}
-                      className="capitalize"
-                    >
-                      {formatStatus(booking.status)}
+                    <Badge variant={bookingStatusBadgeVariant[booking.status]}>
+                      {formatBookingStatus(booking.status)}
                     </Badge>
                   </TableCell>
                   <TableCell>

--- a/apps/dev/src/components/voyant/bookings/status-change-dialog.tsx
+++ b/apps/dev/src/components/voyant/bookings/status-change-dialog.tsx
@@ -1,6 +1,11 @@
 "use client"
 
-import { type BookingRecord, useBookingStatusMutation } from "@voyantjs/bookings-react"
+import {
+  type BookingRecord,
+  bookingStatusOptions,
+  bookingStatusSchema,
+  useBookingStatusMutation,
+} from "@voyantjs/bookings-react"
 import { Loader2 } from "lucide-react"
 import { useEffect } from "react"
 import { useForm } from "react-hook-form"
@@ -25,15 +30,7 @@ import {
 import { zodResolver } from "@/lib/zod-resolver"
 
 const statusChangeFormSchema = z.object({
-  status: z.enum([
-    "draft",
-    "on_hold",
-    "confirmed",
-    "in_progress",
-    "completed",
-    "expired",
-    "cancelled",
-  ]),
+  status: bookingStatusSchema,
   note: z.string().optional().nullable(),
 })
 
@@ -47,16 +44,6 @@ export interface StatusChangeDialogProps {
   currentStatus: BookingRecord["status"]
   onSuccess?: () => void
 }
-
-const BOOKING_STATUSES = [
-  { value: "draft", label: "Draft" },
-  { value: "on_hold", label: "On Hold" },
-  { value: "confirmed", label: "Confirmed" },
-  { value: "in_progress", label: "In Progress" },
-  { value: "completed", label: "Completed" },
-  { value: "expired", label: "Expired" },
-  { value: "cancelled", label: "Cancelled" },
-] as const
 
 export function StatusChangeDialog({
   open,
@@ -111,13 +98,13 @@ export function StatusChangeDialog({
                 onValueChange={(value) =>
                   form.setValue("status", value as StatusChangeFormValues["status"])
                 }
-                items={BOOKING_STATUSES}
+                items={bookingStatusOptions}
               >
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {BOOKING_STATUSES.map((status) => (
+                  {bookingStatusOptions.map((status) => (
                     <SelectItem key={status.value} value={status.value}>
                       {status.label}
                     </SelectItem>

--- a/packages/bookings-react/src/index.ts
+++ b/packages/bookings-react/src/index.ts
@@ -29,3 +29,10 @@ export {
   getSupplierStatusesQueryOptions,
 } from "./query-options.js"
 export * from "./schemas.js"
+export {
+  type BookingStatusBadgeVariant,
+  bookingStatusBadgeVariant,
+  bookingStatuses,
+  bookingStatusOptions,
+  formatBookingStatus,
+} from "./status-presentation.js"

--- a/packages/bookings-react/src/schemas.ts
+++ b/packages/bookings-react/src/schemas.ts
@@ -27,6 +27,8 @@ export const bookingStatusSchema = z.enum([
   "cancelled",
 ])
 
+export type BookingStatus = z.infer<typeof bookingStatusSchema>
+
 export const supplierConfirmationStatusSchema = z.enum([
   "pending",
   "confirmed",

--- a/packages/bookings-react/src/status-presentation.ts
+++ b/packages/bookings-react/src/status-presentation.ts
@@ -1,0 +1,49 @@
+import { type BookingStatus, bookingStatusSchema } from "./schemas.js"
+
+/**
+ * Badge variant palette used by the shadcn default theme. Exported as a named
+ * type so downstream code can keep its local `Badge` component loosely coupled
+ * to this package — we don't import shadcn here.
+ */
+export type BookingStatusBadgeVariant = "default" | "secondary" | "outline" | "destructive"
+
+/**
+ * Canonical status → badge-variant mapping for bookings.
+ *
+ * Typed as `Record<BookingStatus, …>` (not `Record<string, …>`) so that adding
+ * a new booking status becomes a compile error here, instead of a silent UX
+ * fallback in every app that kept its own local copy of this map.
+ */
+export const bookingStatusBadgeVariant: Record<BookingStatus, BookingStatusBadgeVariant> = {
+  draft: "outline",
+  on_hold: "secondary",
+  confirmed: "default",
+  in_progress: "secondary",
+  completed: "default",
+  expired: "secondary",
+  cancelled: "destructive",
+}
+
+/**
+ * Humanize a booking status for display. `"in_progress"` → `"In Progress"`.
+ */
+export function formatBookingStatus(status: BookingStatus): string {
+  return status
+    .split("_")
+    .map((part) => (part.length > 0 ? `${part[0]!.toUpperCase()}${part.slice(1)}` : part))
+    .join(" ")
+}
+
+/**
+ * All booking status values in their canonical order — derived from the Zod
+ * enum so this list can never drift out of sync with the schema.
+ */
+export const bookingStatuses = bookingStatusSchema.options
+
+/**
+ * Pre-built `{ value, label }` list for rendering status pickers (e.g. a
+ * Select in a status-change dialog). Uses `formatBookingStatus` for labels so
+ * there's exactly one place to tweak capitalization or wording.
+ */
+export const bookingStatusOptions: ReadonlyArray<{ value: BookingStatus; label: string }> =
+  bookingStatuses.map((value) => ({ value, label: formatBookingStatus(value) }))

--- a/packages/ui/registry/bookings/booking-list.tsx
+++ b/packages/ui/registry/bookings/booking-list.tsx
@@ -1,6 +1,11 @@
 "use client"
 
-import { type BookingRecord, useBookings } from "@voyantjs/bookings-react"
+import {
+  type BookingRecord,
+  bookingStatusBadgeVariant,
+  formatBookingStatus,
+  useBookings,
+} from "@voyantjs/bookings-react"
 import { Loader2, Plus, Search, Zap } from "lucide-react"
 import * as React from "react"
 
@@ -24,23 +29,9 @@ export interface BookingListProps {
   onSelectBooking?: (booking: BookingRecord) => void
 }
 
-const statusVariant: Record<string, "default" | "secondary" | "outline" | "destructive"> = {
-  draft: "outline",
-  on_hold: "secondary",
-  confirmed: "default",
-  in_progress: "secondary",
-  completed: "default",
-  expired: "secondary",
-  cancelled: "destructive",
-}
-
 function formatAmount(cents: number | null, currency: string): string {
   if (cents == null) return "—"
   return `${(cents / 100).toFixed(2)} ${currency}`
-}
-
-function formatStatus(status: string): string {
-  return status.replace("_", " ")
 }
 
 export function BookingList({ pageSize = 25, onSelectBooking }: BookingListProps = {}) {
@@ -141,11 +132,8 @@ export function BookingList({ pageSize = 25, onSelectBooking }: BookingListProps
                 >
                   <TableCell className="font-medium">{booking.bookingNumber}</TableCell>
                   <TableCell>
-                    <Badge
-                      variant={statusVariant[booking.status] ?? "secondary"}
-                      className="capitalize"
-                    >
-                      {formatStatus(booking.status)}
+                    <Badge variant={bookingStatusBadgeVariant[booking.status]}>
+                      {formatBookingStatus(booking.status)}
                     </Badge>
                   </TableCell>
                   <TableCell>

--- a/packages/ui/registry/bookings/status-change-dialog.tsx
+++ b/packages/ui/registry/bookings/status-change-dialog.tsx
@@ -1,6 +1,11 @@
 "use client"
 
-import { type BookingRecord, useBookingStatusMutation } from "@voyantjs/bookings-react"
+import {
+  type BookingRecord,
+  bookingStatusOptions,
+  bookingStatusSchema,
+  useBookingStatusMutation,
+} from "@voyantjs/bookings-react"
 import { Loader2 } from "lucide-react"
 import { useEffect } from "react"
 import { useForm } from "react-hook-form"
@@ -25,15 +30,7 @@ import {
 import { zodResolver } from "@/lib/zod-resolver"
 
 const statusChangeFormSchema = z.object({
-  status: z.enum([
-    "draft",
-    "on_hold",
-    "confirmed",
-    "in_progress",
-    "completed",
-    "expired",
-    "cancelled",
-  ]),
+  status: bookingStatusSchema,
   note: z.string().optional().nullable(),
 })
 
@@ -47,16 +44,6 @@ export interface StatusChangeDialogProps {
   currentStatus: BookingRecord["status"]
   onSuccess?: () => void
 }
-
-const BOOKING_STATUSES = [
-  { value: "draft", label: "Draft" },
-  { value: "on_hold", label: "On Hold" },
-  { value: "confirmed", label: "Confirmed" },
-  { value: "in_progress", label: "In Progress" },
-  { value: "completed", label: "Completed" },
-  { value: "expired", label: "Expired" },
-  { value: "cancelled", label: "Cancelled" },
-] as const
 
 export function StatusChangeDialog({
   open,
@@ -111,13 +98,13 @@ export function StatusChangeDialog({
                 onValueChange={(value) =>
                   form.setValue("status", value as StatusChangeFormValues["status"])
                 }
-                items={BOOKING_STATUSES}
+                items={bookingStatusOptions}
               >
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {BOOKING_STATUSES.map((status) => (
+                  {bookingStatusOptions.map((status) => (
                     <SelectItem key={status.value} value={status.value}>
                       {status.label}
                     </SelectItem>

--- a/templates/dmc/src/components/voyant/bookings/booking-detail-page.tsx
+++ b/templates/dmc/src/components/voyant/bookings/booking-detail-page.tsx
@@ -1,7 +1,12 @@
 "use client"
 
 import { useNavigate } from "@tanstack/react-router"
-import { useBooking, useBookingMutation } from "@voyantjs/bookings-react"
+import {
+  bookingStatusBadgeVariant,
+  formatBookingStatus,
+  useBooking,
+  useBookingMutation,
+} from "@voyantjs/bookings-react"
 import { ArrowLeft, Ban, Loader2, Pencil, RefreshCw, Trash2 } from "lucide-react"
 import { useState } from "react"
 
@@ -21,16 +26,6 @@ import { PassengerList } from "./passenger-list"
 import { StatusChangeDialog } from "./status-change-dialog"
 import { SupplierStatusList } from "./supplier-status-list"
 
-const statusVariant: Record<string, "default" | "secondary" | "outline" | "destructive"> = {
-  draft: "outline",
-  on_hold: "secondary",
-  confirmed: "default",
-  in_progress: "secondary",
-  completed: "default",
-  expired: "secondary",
-  cancelled: "destructive",
-}
-
 function formatAmount(cents: number | null, currency: string): string {
   if (cents == null) return "-"
   return `${(cents / 100).toFixed(2)} ${currency}`
@@ -39,10 +34,6 @@ function formatAmount(cents: number | null, currency: string): string {
 function formatMargin(percent: number | null): string {
   if (percent == null) return "-"
   return `${(percent / 100).toFixed(2)}%`
-}
-
-function formatStatus(status: string): string {
-  return status.replace("_", " ")
 }
 
 export function BookingDetailPage({ id }: { id: string }) {
@@ -82,8 +73,8 @@ export function BookingDetailPage({ id }: { id: string }) {
         <div className="flex-1">
           <h1 className="text-2xl font-bold tracking-tight">{booking.bookingNumber}</h1>
           <div className="mt-1 flex items-center gap-2">
-            <Badge variant={statusVariant[booking.status] ?? "secondary"} className="capitalize">
-              {formatStatus(booking.status)}
+            <Badge variant={bookingStatusBadgeVariant[booking.status]}>
+              {formatBookingStatus(booking.status)}
             </Badge>
           </div>
         </div>

--- a/templates/dmc/src/components/voyant/bookings/booking-list.tsx
+++ b/templates/dmc/src/components/voyant/bookings/booking-list.tsx
@@ -1,6 +1,11 @@
 "use client"
 
-import { type BookingRecord, useBookings } from "@voyantjs/bookings-react"
+import {
+  type BookingRecord,
+  bookingStatusBadgeVariant,
+  formatBookingStatus,
+  useBookings,
+} from "@voyantjs/bookings-react"
 import { Loader2, Plus, Search, Zap } from "lucide-react"
 import * as React from "react"
 
@@ -24,23 +29,9 @@ export interface BookingListProps {
   onSelectBooking?: (booking: BookingRecord) => void
 }
 
-const statusVariant: Record<string, "default" | "secondary" | "outline" | "destructive"> = {
-  draft: "outline",
-  on_hold: "secondary",
-  confirmed: "default",
-  in_progress: "secondary",
-  completed: "default",
-  expired: "secondary",
-  cancelled: "destructive",
-}
-
 function formatAmount(cents: number | null, currency: string): string {
   if (cents == null) return "—"
   return `${(cents / 100).toFixed(2)} ${currency}`
-}
-
-function formatStatus(status: string): string {
-  return status.replace("_", " ")
 }
 
 export function BookingList({ pageSize = 25, onSelectBooking }: BookingListProps = {}) {
@@ -141,11 +132,8 @@ export function BookingList({ pageSize = 25, onSelectBooking }: BookingListProps
                 >
                   <TableCell className="font-medium">{booking.bookingNumber}</TableCell>
                   <TableCell>
-                    <Badge
-                      variant={statusVariant[booking.status] ?? "secondary"}
-                      className="capitalize"
-                    >
-                      {formatStatus(booking.status)}
+                    <Badge variant={bookingStatusBadgeVariant[booking.status]}>
+                      {formatBookingStatus(booking.status)}
                     </Badge>
                   </TableCell>
                   <TableCell>

--- a/templates/dmc/src/components/voyant/bookings/status-change-dialog.tsx
+++ b/templates/dmc/src/components/voyant/bookings/status-change-dialog.tsx
@@ -1,6 +1,11 @@
 "use client"
 
-import { type BookingRecord, useBookingStatusMutation } from "@voyantjs/bookings-react"
+import {
+  type BookingRecord,
+  bookingStatusOptions,
+  bookingStatusSchema,
+  useBookingStatusMutation,
+} from "@voyantjs/bookings-react"
 import { Loader2 } from "lucide-react"
 import { useEffect } from "react"
 import { useForm } from "react-hook-form"
@@ -25,15 +30,7 @@ import {
 import { zodResolver } from "@/lib/zod-resolver"
 
 const statusChangeFormSchema = z.object({
-  status: z.enum([
-    "draft",
-    "on_hold",
-    "confirmed",
-    "in_progress",
-    "completed",
-    "expired",
-    "cancelled",
-  ]),
+  status: bookingStatusSchema,
   note: z.string().optional().nullable(),
 })
 
@@ -47,16 +44,6 @@ export interface StatusChangeDialogProps {
   currentStatus: BookingRecord["status"]
   onSuccess?: () => void
 }
-
-const BOOKING_STATUSES = [
-  { value: "draft", label: "Draft" },
-  { value: "on_hold", label: "On Hold" },
-  { value: "confirmed", label: "Confirmed" },
-  { value: "in_progress", label: "In Progress" },
-  { value: "completed", label: "Completed" },
-  { value: "expired", label: "Expired" },
-  { value: "cancelled", label: "Cancelled" },
-] as const
 
 export function StatusChangeDialog({
   open,
@@ -111,13 +98,13 @@ export function StatusChangeDialog({
                 onValueChange={(value) =>
                   form.setValue("status", value as StatusChangeFormValues["status"])
                 }
-                items={BOOKING_STATUSES}
+                items={bookingStatusOptions}
               >
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {BOOKING_STATUSES.map((status) => (
+                  {bookingStatusOptions.map((status) => (
                     <SelectItem key={status.value} value={status.value}>
                       {status.label}
                     </SelectItem>
@@ -136,7 +123,7 @@ export function StatusChangeDialog({
               Cancel
             </Button>
             <Button type="submit" size="sm" disabled={mutation.isPending}>
-              {mutation.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+              {mutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               Update Status
             </Button>
           </DialogFooter>

--- a/templates/operator/src/components/voyant/bookings/booking-detail-page.tsx
+++ b/templates/operator/src/components/voyant/bookings/booking-detail-page.tsx
@@ -1,7 +1,12 @@
 "use client"
 
 import { useNavigate } from "@tanstack/react-router"
-import { useBooking, useBookingMutation } from "@voyantjs/bookings-react"
+import {
+  bookingStatusBadgeVariant,
+  formatBookingStatus,
+  useBooking,
+  useBookingMutation,
+} from "@voyantjs/bookings-react"
 import { ArrowLeft, Ban, Loader2, Pencil, RefreshCw, Trash2 } from "lucide-react"
 import { useState } from "react"
 
@@ -21,16 +26,6 @@ import { PassengerList } from "./passenger-list"
 import { StatusChangeDialog } from "./status-change-dialog"
 import { SupplierStatusList } from "./supplier-status-list"
 
-const statusVariant: Record<string, "default" | "secondary" | "outline" | "destructive"> = {
-  draft: "outline",
-  on_hold: "secondary",
-  confirmed: "default",
-  in_progress: "secondary",
-  completed: "default",
-  expired: "secondary",
-  cancelled: "destructive",
-}
-
 function formatAmount(cents: number | null, currency: string): string {
   if (cents == null) return "-"
   return `${(cents / 100).toFixed(2)} ${currency}`
@@ -39,10 +34,6 @@ function formatAmount(cents: number | null, currency: string): string {
 function formatMargin(percent: number | null): string {
   if (percent == null) return "-"
   return `${(percent / 100).toFixed(2)}%`
-}
-
-function formatStatus(status: string): string {
-  return status.replace("_", " ")
 }
 
 export function BookingDetailPage({ id }: { id: string }) {
@@ -82,8 +73,8 @@ export function BookingDetailPage({ id }: { id: string }) {
         <div className="flex-1">
           <h1 className="text-2xl font-bold tracking-tight">{booking.bookingNumber}</h1>
           <div className="mt-1 flex items-center gap-2">
-            <Badge variant={statusVariant[booking.status] ?? "secondary"} className="capitalize">
-              {formatStatus(booking.status)}
+            <Badge variant={bookingStatusBadgeVariant[booking.status]}>
+              {formatBookingStatus(booking.status)}
             </Badge>
           </div>
         </div>

--- a/templates/operator/src/components/voyant/bookings/booking-list.tsx
+++ b/templates/operator/src/components/voyant/bookings/booking-list.tsx
@@ -1,6 +1,11 @@
 "use client"
 
-import { type BookingRecord, useBookings } from "@voyantjs/bookings-react"
+import {
+  type BookingRecord,
+  bookingStatusBadgeVariant,
+  formatBookingStatus,
+  useBookings,
+} from "@voyantjs/bookings-react"
 import { Loader2, Plus, Search, Zap } from "lucide-react"
 import * as React from "react"
 
@@ -24,23 +29,9 @@ export interface BookingListProps {
   onSelectBooking?: (booking: BookingRecord) => void
 }
 
-const statusVariant: Record<string, "default" | "secondary" | "outline" | "destructive"> = {
-  draft: "outline",
-  on_hold: "secondary",
-  confirmed: "default",
-  in_progress: "secondary",
-  completed: "default",
-  expired: "secondary",
-  cancelled: "destructive",
-}
-
 function formatAmount(cents: number | null, currency: string): string {
   if (cents == null) return "—"
   return `${(cents / 100).toFixed(2)} ${currency}`
-}
-
-function formatStatus(status: string): string {
-  return status.replace("_", " ")
 }
 
 export function BookingList({ pageSize = 25, onSelectBooking }: BookingListProps = {}) {
@@ -141,11 +132,8 @@ export function BookingList({ pageSize = 25, onSelectBooking }: BookingListProps
                 >
                   <TableCell className="font-medium">{booking.bookingNumber}</TableCell>
                   <TableCell>
-                    <Badge
-                      variant={statusVariant[booking.status] ?? "secondary"}
-                      className="capitalize"
-                    >
-                      {formatStatus(booking.status)}
+                    <Badge variant={bookingStatusBadgeVariant[booking.status]}>
+                      {formatBookingStatus(booking.status)}
                     </Badge>
                   </TableCell>
                   <TableCell>

--- a/templates/operator/src/components/voyant/bookings/status-change-dialog.tsx
+++ b/templates/operator/src/components/voyant/bookings/status-change-dialog.tsx
@@ -1,6 +1,11 @@
 "use client"
 
-import { type BookingRecord, useBookingStatusMutation } from "@voyantjs/bookings-react"
+import {
+  type BookingRecord,
+  bookingStatusOptions,
+  bookingStatusSchema,
+  useBookingStatusMutation,
+} from "@voyantjs/bookings-react"
 import { Loader2 } from "lucide-react"
 import { useEffect } from "react"
 import { useForm } from "react-hook-form"
@@ -25,15 +30,7 @@ import {
 import { zodResolver } from "@/lib/zod-resolver"
 
 const statusChangeFormSchema = z.object({
-  status: z.enum([
-    "draft",
-    "on_hold",
-    "confirmed",
-    "in_progress",
-    "completed",
-    "expired",
-    "cancelled",
-  ]),
+  status: bookingStatusSchema,
   note: z.string().optional().nullable(),
 })
 
@@ -47,16 +44,6 @@ export interface StatusChangeDialogProps {
   currentStatus: BookingRecord["status"]
   onSuccess?: () => void
 }
-
-const BOOKING_STATUSES = [
-  { value: "draft", label: "Draft" },
-  { value: "on_hold", label: "On Hold" },
-  { value: "confirmed", label: "Confirmed" },
-  { value: "in_progress", label: "In Progress" },
-  { value: "completed", label: "Completed" },
-  { value: "expired", label: "Expired" },
-  { value: "cancelled", label: "Cancelled" },
-] as const
 
 export function StatusChangeDialog({
   open,
@@ -111,13 +98,13 @@ export function StatusChangeDialog({
                 onValueChange={(value) =>
                   form.setValue("status", value as StatusChangeFormValues["status"])
                 }
-                items={BOOKING_STATUSES}
+                items={bookingStatusOptions}
               >
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {BOOKING_STATUSES.map((status) => (
+                  {bookingStatusOptions.map((status) => (
                     <SelectItem key={status.value} value={status.value}>
                       {status.label}
                     </SelectItem>


### PR DESCRIPTION
Closes #37.

## Summary
- Add `bookingStatusBadgeVariant: Record<BookingStatus, 'default' | 'secondary' | 'outline' | 'destructive'>` and `formatBookingStatus(status)` to `@voyantjs/bookings-react`. The variant map is **exhaustive** (not `Record<string, …>`), so adding a new booking status becomes a compile error here instead of a silent UX regression in every consumer.
- Also export `bookingStatuses` + `bookingStatusOptions` (derived from `bookingStatusSchema.options`, can't drift from the schema) and the `BookingStatus` type.
- Registry components (`booking-list`, `status-change-dialog`) and `booking-detail-page` copies in `templates/dmc`, `templates/operator`, `apps/dev` drop their local `statusVariant` / `formatStatus` / `BOOKING_STATUSES` constants and consume the shared helpers.

## Why this matters
Context from the issue: when `on_hold` and `expired` were added, every app with a pre-existing local map silently fell through to the default variant because the maps were typed `Record<string, …>`. The exhaustive `Record<BookingStatus, …>` shape turns that failure mode from "quiet UX bug" into "compile error at the publish site." Same reasoning for the status list used by Select pickers — deriving it from `bookingStatusSchema.options` makes it impossible to go stale.

## Note on label casing
Old local formatters did `status.replace("_", " ")` → `"in progress"` (relying on `className="capitalize"` to cosmetically title-case it). `formatBookingStatus` now returns `"In Progress"` directly, matching the spec in the issue. The old `className="capitalize"` was removed from the two sites that used it since the helper output is already title-cased.

## Test plan
- [x] `pnpm typecheck` — 125/125 pass
- [x] `pnpm -F @voyantjs/bookings-react lint` + `test` green
- [x] `pnpm -F @voyantjs/voyant-ui lint` green
- [ ] Manually verify booking list + detail page render the correct badge variant and title-cased labels for each status (especially `on_hold` → "On Hold" and `in_progress` → "In Progress")
- [ ] Verify the status-change dialog Select still shows all 7 statuses in the canonical order

## Follow-up
The issue flags `bookingItemStatusSchema` + `supplierConfirmationStatusSchema` as candidates for the same treatment — not included here.