### PR TITLE
Add lazy runtime bootstraps to Hono app setup

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,7 +36,7 @@ export type {
   ResolvedLinkSpec,
 } from "./links.js"
 export { defineLink, generateLinkTableSql, resolveLinkFromSpec } from "./links.js"
-export type { Extension, Module } from "./module.js"
+export type { BootstrapContext, BootstrapHandler, Extension, Module } from "./module.js"
 export type { JobOptions, JobRunner } from "./orchestration.js"
 export type {
   Plugin,

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -1,4 +1,19 @@
+import type { ModuleContainer } from "./container.js"
+import type { EventBus } from "./events.js"
 import type { LinkableDefinition } from "./links.js"
+
+export interface BootstrapContext<TBindings = unknown> {
+  /** Runtime bindings/environment available to the current app/isolate. */
+  bindings: TBindings
+  /** Shared app container used for explicit runtime registrations. */
+  container: ModuleContainer
+  /** Canonical event bus for the current app runtime. */
+  eventBus: EventBus
+}
+
+export type BootstrapHandler<TBindings = unknown> = (
+  ctx: BootstrapContext<TBindings>,
+) => Promise<void> | void
 
 /**
  * A Voyant module provides domain identity and lifecycle hooks.
@@ -20,6 +35,16 @@ export interface Module {
   service?: unknown
 
   /**
+   * Optional lazy runtime bootstrap executed once per app/isolate, on the
+   * first request where bindings are available.
+   *
+   * Use this to validate runtime configuration, register app-owned provider
+   * instances, or perform other lightweight startup wiring. Do not use it for
+   * long-running syncs or scheduled background work.
+   */
+  bootstrap?: BootstrapHandler
+
+  /**
    * Entities this module exposes for cross-module linking via `defineLink`.
    * Keyed by entity name (e.g. `{ person: ..., organization: ... }`).
    */
@@ -39,4 +64,10 @@ export interface Extension {
 
   /** Hook handlers keyed by event name */
   hooks?: Record<string, (...args: unknown[]) => Promise<void> | void>
+
+  /**
+   * Optional lazy runtime bootstrap executed once per app/isolate, on the
+   * first request where bindings are available.
+   */
+  bootstrap?: BootstrapHandler
 }

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -14,7 +14,7 @@
 
 import type { EventBus, EventHandler } from "./events.js"
 import type { LinkDefinition } from "./links.js"
-import type { Extension, Module } from "./module.js"
+import type { BootstrapHandler, Extension, Module } from "./module.js"
 
 /**
  * A single event subscription contributed by a plugin.
@@ -46,6 +46,11 @@ export interface Plugin {
   name: string
   /** Optional version tag for diagnostics. */
   version?: string
+  /**
+   * Optional lazy runtime bootstrap executed once per app/isolate, on the
+   * first request where bindings are available.
+   */
+  bootstrap?: BootstrapHandler
   /** Modules contributed by the plugin. */
   modules?: Module[]
   /** Extensions contributed by the plugin. */

--- a/packages/hono/src/app.ts
+++ b/packages/hono/src/app.ts
@@ -1,4 +1,4 @@
-import { createContainer } from "@voyantjs/core"
+import { createContainer, createEventBus } from "@voyantjs/core"
 import { Hono } from "hono"
 
 import { requireAuth } from "./middleware/auth.js"
@@ -19,6 +19,7 @@ export function createApp<TBindings extends VoyantBindings>(
   const expanded = config.plugins ? expandHonoPlugins(config.plugins) : null
   const allModules = [...(config.modules ?? []), ...(expanded?.modules ?? [])]
   const allExtensions = [...(config.extensions ?? []), ...(expanded?.extensions ?? [])]
+  const eventBus = config.eventBus ?? createEventBus()
 
   // Module container — registered services are resolvable from routes
   const container = createContainer()
@@ -27,8 +28,35 @@ export function createApp<TBindings extends VoyantBindings>(
       container.register(mod.module.name, mod.module.service)
     }
   }
+  for (const sub of expanded?.subscribers ?? []) {
+    eventBus.subscribe(sub.event, sub.handler)
+  }
+
+  let bootstrapPromise: Promise<void> | null = null
+  function ensureRuntimeBootstrapped(bindings: TBindings) {
+    if (!bootstrapPromise) {
+      bootstrapPromise = (async () => {
+        const ctx = { bindings, container, eventBus }
+
+        for (const plugin of config.plugins ?? []) {
+          await plugin.bootstrap?.(ctx)
+        }
+        for (const mod of allModules) {
+          await mod.module.bootstrap?.(ctx)
+        }
+        for (const ext of allExtensions) {
+          await ext.extension.bootstrap?.(ctx)
+        }
+      })()
+    }
+
+    return bootstrapPromise
+  }
+
   app.use("*", async (c, next) => {
     c.set("container", container)
+    c.set("eventBus", eventBus)
+    await ensureRuntimeBootstrapped(c.env)
     return next()
   })
 

--- a/packages/hono/src/plugin.ts
+++ b/packages/hono/src/plugin.ts
@@ -1,4 +1,4 @@
-import type { LinkDefinition, Subscriber } from "@voyantjs/core"
+import type { BootstrapHandler, LinkDefinition, Subscriber } from "@voyantjs/core"
 
 import type { HonoExtension, HonoModule } from "./module.js"
 
@@ -18,6 +18,8 @@ export interface HonoPlugin {
   name: string
   /** Optional version tag for diagnostics. */
   version?: string
+  /** Optional lazy runtime bootstrap executed once per app/isolate. */
+  bootstrap?: BootstrapHandler
   /** Hono modules (module + routes) contributed by the plugin. */
   modules?: HonoModule[]
   /** Hono extensions (extension + routes) contributed by the plugin. */

--- a/packages/hono/src/types.ts
+++ b/packages/hono/src/types.ts
@@ -1,5 +1,6 @@
 import type {
   VoyantVariables as CoreVoyantVariables,
+  EventBus,
   ModuleContainer,
   VoyantAuthContext,
   VoyantPermission,
@@ -34,6 +35,7 @@ export type VoyantDb = PostgresJsDatabase | NeonHttpDatabase
 export type VoyantVariables = CoreVoyantVariables & {
   db: VoyantDb
   container: ModuleContainer
+  eventBus: EventBus
 }
 
 export type DbFactory<TBindings extends VoyantBindings = VoyantBindings> = (
@@ -87,6 +89,7 @@ export interface VoyantAppConfig<TBindings extends VoyantBindings = VoyantBindin
   modules?: HonoModule[]
   extensions?: HonoExtension[]
   plugins?: HonoPlugin[]
+  eventBus?: EventBus
   auth?: VoyantAuthIntegration<TBindings>
   publicPaths?: string[]
   logger?: LoggerProvider

--- a/packages/hono/tests/unit/plugin.test.ts
+++ b/packages/hono/tests/unit/plugin.test.ts
@@ -1,9 +1,9 @@
-import type { Actor } from "@voyantjs/core"
+import { type Actor, createEventBus } from "@voyantjs/core"
 import { Hono } from "hono"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import { createApp } from "../../src/app.js"
-import type { HonoModule } from "../../src/module.js"
+import type { HonoExtension, HonoModule } from "../../src/module.js"
 import { defineHonoPlugin, expandHonoPlugins } from "../../src/plugin.js"
 import type { VoyantBindings } from "../../src/types.js"
 
@@ -132,5 +132,124 @@ describe("createApp with plugins", () => {
         plugins: [p1, p2],
       }),
     ).toThrow(/Duplicate plugin name/)
+  })
+
+  it("wires plugin subscribers to the app event bus", async () => {
+    const handler = vi.fn()
+    const plugin = defineHonoPlugin({
+      name: "events",
+      subscribers: [{ event: "booking.created", handler }],
+      modules: [
+        {
+          module: { name: "events" },
+          adminRoutes: new Hono().post("/emit", async (c) => {
+            await c.var.eventBus.emit("booking.created", { bookingId: "b_123" })
+            return c.json({ ok: true })
+          }),
+        },
+      ],
+    })
+
+    const app = build([plugin])
+    const res = await app.request("/v1/admin/events/emit", { method: "POST" }, TEST_ENV, TEST_CTX)
+    expect(res.status).toBe(200)
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith({ bookingId: "b_123" })
+  })
+
+  it("runs plugin, module, and extension bootstraps once in order", async () => {
+    const calls: string[] = []
+    const mod: HonoModule = {
+      module: {
+        name: "boot",
+        bootstrap: () => {
+          calls.push("module")
+        },
+      },
+      adminRoutes: new Hono().get("/ping", (c) => c.json({ ok: true })),
+    }
+    const ext: HonoExtension = {
+      extension: {
+        name: "boot-ext",
+        module: "boot",
+        bootstrap: () => {
+          calls.push("extension")
+        },
+      },
+    }
+    const plugin = defineHonoPlugin({
+      name: "boot-plugin",
+      bootstrap: () => {
+        calls.push("plugin")
+      },
+      modules: [mod],
+      extensions: [ext],
+    })
+
+    const app = createApp({
+      // biome-ignore lint/suspicious/noExplicitAny: test doesn't use db
+      db: () => ({}) as any,
+      plugins: [plugin],
+      auth: { resolve: () => ({ userId: "u1", actor: "staff" }) },
+    })
+
+    const r1 = await app.request("/v1/admin/boot/ping", {}, TEST_ENV, TEST_CTX)
+    const r2 = await app.request("/v1/admin/boot/ping", {}, TEST_ENV, TEST_CTX)
+    expect(r1.status).toBe(200)
+    expect(r2.status).toBe(200)
+    expect(calls).toEqual(["plugin", "module", "extension"])
+  })
+
+  it("exposes bootstrap-registered services through the shared container", async () => {
+    const app = createApp({
+      // biome-ignore lint/suspicious/noExplicitAny: test doesn't use db
+      db: () => ({}) as any,
+      modules: [
+        {
+          module: {
+            name: "runtime",
+            bootstrap: ({ container }) => {
+              container.register("runtime.registry", { status: "ready" })
+            },
+          },
+          adminRoutes: new Hono().get("/check", (c) => {
+            const runtime = c.var.container.resolve<{ status: string }>("runtime.registry")
+            return c.json(runtime)
+          }),
+        },
+      ],
+      auth: { resolve: () => ({ userId: "u1", actor: "staff" }) },
+    })
+
+    const res = await app.request("/v1/admin/runtime/check", {}, TEST_ENV, TEST_CTX)
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ status: "ready" })
+  })
+
+  it("uses a caller-provided event bus when supplied", async () => {
+    const bus = createEventBus()
+    const handler = vi.fn()
+    bus.subscribe("booking.updated", handler)
+
+    const app = createApp({
+      // biome-ignore lint/suspicious/noExplicitAny: test doesn't use db
+      db: () => ({}) as any,
+      eventBus: bus,
+      modules: [
+        {
+          module: { name: "bus" },
+          adminRoutes: new Hono().post("/emit", async (c) => {
+            await c.var.eventBus.emit("booking.updated", { bookingId: "b_234" })
+            return c.json({ ok: true })
+          }),
+        },
+      ],
+      auth: { resolve: () => ({ userId: "u1", actor: "staff" }) },
+    })
+
+    const res = await app.request("/v1/admin/bus/emit", { method: "POST" }, TEST_ENV, TEST_CTX)
+    expect(res.status).toBe(200)
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith({ bookingId: "b_234" })
   })
 })


### PR DESCRIPTION
## Summary
- add a lazy bootstrap lifecycle for modules, extensions, and plugins
- expose the canonical app event bus through the Hono request context
- wire Hono plugin subscribers into the shared app event bus once per app setup

## Verification
- pnpm -C packages/core build
- pnpm -C packages/core test
- pnpm -C packages/hono build
- pnpm -C packages/hono test
- git push -u origin cleanup/provider-registry-and-runtime-seams