### PR TITLE
Validate Netopia runtime options at bootstrap

### DIFF
--- a/packages/plugins/netopia/src/client.ts
+++ b/packages/plugins/netopia/src/client.ts
@@ -1,3 +1,4 @@
+import { ZodError } from "zod"
 import type {
   NetopiaFetch,
   NetopiaRuntimeOptions,
@@ -5,6 +6,7 @@ import type {
   NetopiaStartPaymentResponse,
   ResolvedNetopiaRuntimeOptions,
 } from "./types.js"
+import { resolvedNetopiaRuntimeOptionsSchema } from "./validation.js"
 
 export interface NetopiaClientApi {
   startCardPayment(request: NetopiaStartPaymentRequest): Promise<NetopiaStartPaymentResponse>
@@ -32,17 +34,30 @@ export function resolveNetopiaRuntimeOptions(
   if (!notifyUrl) throw new Error("Missing Netopia config: NETOPIA_NOTIFY_URL")
   if (!redirectUrl) throw new Error("Missing Netopia config: NETOPIA_REDIRECT_URL")
 
-  return {
-    apiUrl,
-    apiKey,
-    posSignature,
-    notifyUrl,
-    redirectUrl,
-    emailTemplate: options.emailTemplate ?? "confirm",
-    language: options.language ?? "ro",
-    successStatuses: options.successStatuses ?? [3, 5],
-    processingStatuses: options.processingStatuses ?? [1, 15],
-    fetch: options.fetch,
+  try {
+    return resolvedNetopiaRuntimeOptionsSchema.parse({
+      apiUrl,
+      apiKey,
+      posSignature,
+      notifyUrl,
+      redirectUrl,
+      emailTemplate: options.emailTemplate,
+      language: options.language,
+      successStatuses: options.successStatuses,
+      processingStatuses: options.processingStatuses,
+      fetch: options.fetch,
+    })
+  } catch (error) {
+    if (error instanceof ZodError) {
+      const detail = error.issues
+        .map((issue) => {
+          const path = issue.path.join(".") || "runtimeOptions"
+          return `${path}: ${issue.message}`
+        })
+        .join("; ")
+      throw new Error(`Invalid Netopia runtime options: ${detail}`)
+    }
+    throw error
   }
 }
 

--- a/packages/plugins/netopia/src/index.ts
+++ b/packages/plugins/netopia/src/index.ts
@@ -8,6 +8,7 @@ export {
 export {
   createNetopiaFinanceExtension,
   createNetopiaFinanceRoutes,
+  NETOPIA_RUNTIME_CONTAINER_KEY,
   netopiaFinanceExtension,
   netopiaHonoPlugin,
 } from "./plugin.js"
@@ -44,6 +45,8 @@ export {
   netopiaPaymentInstrumentSchema,
   netopiaPaymentOptionsSchema,
   netopiaProductLineSchema,
+  netopiaRuntimeOptionsSchema,
   netopiaStartPaymentSessionSchema,
   netopiaWebhookPayloadSchema,
+  resolvedNetopiaRuntimeOptionsSchema,
 } from "./validation.js"

--- a/packages/plugins/netopia/src/plugin.ts
+++ b/packages/plugins/netopia/src/plugin.ts
@@ -1,4 +1,4 @@
-import type { Extension } from "@voyantjs/core"
+import type { Extension, ModuleContainer } from "@voyantjs/core"
 import { defineHonoPlugin, type HonoPlugin } from "@voyantjs/hono"
 import type { HonoExtension } from "@voyantjs/hono/module"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -6,7 +6,7 @@ import { Hono } from "hono"
 
 import { resolveNetopiaRuntimeOptions } from "./client.js"
 import { netopiaService } from "./service.js"
-import type { NetopiaRuntimeOptions } from "./types.js"
+import type { NetopiaRuntimeOptions, ResolvedNetopiaRuntimeOptions } from "./types.js"
 import {
   netopiaCollectBookingGuaranteeSchema,
   netopiaCollectBookingScheduleSchema,
@@ -18,9 +18,28 @@ import {
 type Env = {
   Bindings: Record<string, unknown>
   Variables: {
+    container: ModuleContainer
     db: PostgresJsDatabase
     userId?: string
   }
+}
+
+export const NETOPIA_RUNTIME_CONTAINER_KEY = "providers.netopia.runtime"
+
+function getNetopiaRuntime(
+  bindings: Record<string, unknown>,
+  options: NetopiaRuntimeOptions,
+  resolveFromContainer?: <T>(key: string) => T,
+): ResolvedNetopiaRuntimeOptions {
+  if (resolveFromContainer) {
+    try {
+      return resolveFromContainer<ResolvedNetopiaRuntimeOptions>(NETOPIA_RUNTIME_CONTAINER_KEY)
+    } catch {
+      // Fall through to per-request resolution when bootstrap has not run.
+    }
+  }
+
+  return resolveNetopiaRuntimeOptions(bindings, options)
 }
 
 export function createNetopiaFinanceRoutes(options: NetopiaRuntimeOptions = {}) {
@@ -53,13 +72,13 @@ export function createNetopiaFinanceRoutes(options: NetopiaRuntimeOptions = {}) 
     .post("/providers/netopia/payment-sessions/:sessionId/start", async (c) => {
       try {
         const data = netopiaStartPaymentSessionSchema.parse(await c.req.json())
+        const runtime = getNetopiaRuntime(c.env, options, (key) => c.var.container.resolve(key))
         const result = await netopiaService.startPaymentSession(
           c.get("db"),
           c.req.param("sessionId"),
           data,
-          options,
+          runtime,
           undefined,
-          c.env,
         )
         return c.json({ data: result }, 201)
       } catch (error) {
@@ -81,11 +100,12 @@ export function createNetopiaFinanceRoutes(options: NetopiaRuntimeOptions = {}) 
       async (c) => {
         try {
           const data = netopiaCollectBookingScheduleSchema.parse(await c.req.json())
+          const runtime = getNetopiaRuntime(c.env, options, (key) => c.var.container.resolve(key))
           const result = await netopiaService.collectBookingSchedule(
             c.get("db"),
             c.req.param("scheduleId"),
             data,
-            options,
+            runtime,
             undefined,
             undefined,
             c.env,
@@ -102,11 +122,12 @@ export function createNetopiaFinanceRoutes(options: NetopiaRuntimeOptions = {}) 
     .post("/providers/netopia/bookings/:bookingId/guarantees/:guaranteeId/collect", async (c) => {
       try {
         const data = netopiaCollectBookingGuaranteeSchema.parse(await c.req.json())
+        const runtime = getNetopiaRuntime(c.env, options, (key) => c.var.container.resolve(key))
         const result = await netopiaService.collectBookingGuarantee(
           c.get("db"),
           c.req.param("guaranteeId"),
           data,
-          options,
+          runtime,
           undefined,
           undefined,
           c.env,
@@ -122,11 +143,12 @@ export function createNetopiaFinanceRoutes(options: NetopiaRuntimeOptions = {}) 
     .post("/providers/netopia/invoices/:invoiceId/collect", async (c) => {
       try {
         const data = netopiaCollectInvoiceSchema.parse(await c.req.json())
+        const runtime = getNetopiaRuntime(c.env, options, (key) => c.var.container.resolve(key))
         const result = await netopiaService.collectInvoice(
           c.get("db"),
           c.req.param("invoiceId"),
           data,
-          options,
+          runtime,
           undefined,
           undefined,
           c.env,
@@ -140,12 +162,13 @@ export function createNetopiaFinanceRoutes(options: NetopiaRuntimeOptions = {}) 
     })
     .post("/providers/netopia/callback", async (c) => {
       const payload = netopiaWebhookPayloadSchema.parse(await c.req.json())
-      const result = await netopiaService.handleCallback(c.get("db"), payload, options, c.env)
+      const runtime = getNetopiaRuntime(c.env, options, (key) => c.var.container.resolve(key))
+      const result = await netopiaService.handleCallback(c.get("db"), payload, runtime)
       return c.json({ data: result })
     })
     .get("/providers/netopia/config", async (c) => {
       try {
-        const runtime = resolveNetopiaRuntimeOptions(c.env, options)
+        const runtime = getNetopiaRuntime(c.env, options, (key) => c.var.container.resolve(key))
         return c.json({
           data: {
             apiUrl: runtime.apiUrl,
@@ -180,6 +203,12 @@ export function netopiaHonoPlugin(options: NetopiaRuntimeOptions = {}): HonoPlug
   return defineHonoPlugin({
     name: "netopia",
     version: "0.1.0",
+    bootstrap: ({ bindings, container }) => {
+      container.register(
+        NETOPIA_RUNTIME_CONTAINER_KEY,
+        resolveNetopiaRuntimeOptions(bindings as Record<string, unknown> | undefined, options),
+      )
+    },
     extensions: [createNetopiaFinanceExtension(options)],
   })
 }

--- a/packages/plugins/netopia/src/validation.ts
+++ b/packages/plugins/netopia/src/validation.ts
@@ -8,6 +8,7 @@ import {
   sendPaymentSessionNotificationSchema,
 } from "@voyantjs/notifications"
 import { z } from "zod"
+import type { NetopiaFetch, NetopiaRuntimeOptions } from "./types.js"
 
 export const netopiaBillingAddressSchema = z.object({
   email: z.string().email(),
@@ -49,6 +50,49 @@ export const netopiaPaymentInstrumentSchema = z.object({
 })
 
 export const netopiaBrowserDataSchema = z.record(z.string(), z.string().optional())
+
+const optionalRuntimeUrl = z.string().trim().url().optional()
+
+const optionalRuntimeString = z.string().trim().min(1).optional()
+
+const optionalIntegerArray = z.array(z.number().int()).min(1).optional()
+
+const optionalFetch = z.custom<NetopiaFetch | undefined>(
+  (value) => value === undefined || typeof value === "function",
+  "Expected a fetch implementation function",
+)
+
+const optionalProviderResolver = z.custom<NetopiaRuntimeOptions["resolveNotificationProviders"]>(
+  (value) => value === undefined || typeof value === "function",
+  "Expected a notification provider resolver function",
+)
+
+export const netopiaRuntimeOptionsSchema = z.object({
+  apiUrl: optionalRuntimeUrl,
+  apiKey: optionalRuntimeString,
+  posSignature: optionalRuntimeString,
+  notifyUrl: optionalRuntimeUrl,
+  redirectUrl: optionalRuntimeUrl,
+  emailTemplate: optionalRuntimeString,
+  language: optionalRuntimeString,
+  successStatuses: optionalIntegerArray,
+  processingStatuses: optionalIntegerArray,
+  fetch: optionalFetch.optional(),
+  resolveNotificationProviders: optionalProviderResolver.optional(),
+})
+
+export const resolvedNetopiaRuntimeOptionsSchema = z.object({
+  apiUrl: z.string().trim().url(),
+  apiKey: z.string().trim().min(1),
+  posSignature: z.string().trim().min(1),
+  notifyUrl: z.string().trim().url(),
+  redirectUrl: z.string().trim().url(),
+  emailTemplate: z.string().trim().min(1).default("confirm"),
+  language: z.string().trim().min(1).default("ro"),
+  successStatuses: z.array(z.number().int()).min(1).default([3, 5]),
+  processingStatuses: z.array(z.number().int()).min(1).default([1, 15]),
+  fetch: optionalFetch.optional(),
+})
 
 export const netopiaStartPaymentSessionSchema = z.object({
   description: z.string().optional(),

--- a/packages/plugins/netopia/tests/unit/client.test.ts
+++ b/packages/plugins/netopia/tests/unit/client.test.ts
@@ -41,6 +41,23 @@ describe("resolveNetopiaRuntimeOptions", () => {
   it("throws when required config is missing", () => {
     expect(() => resolveNetopiaRuntimeOptions({})).toThrow(/NETOPIA_URL/)
   })
+
+  it("throws when configured runtime values are invalid", () => {
+    expect(() =>
+      resolveNetopiaRuntimeOptions(
+        {
+          NETOPIA_URL: "https://secure.mobilpay.ro/pay",
+          NETOPIA_API_KEY: "api-key",
+          NETOPIA_POS_SIGNATURE: "pos-signature",
+          NETOPIA_NOTIFY_URL: "https://api.example.com/netopia/callback",
+          NETOPIA_REDIRECT_URL: "https://app.example.com/checkout/return",
+        },
+        {
+          successStatuses: [3.5] as unknown as number[],
+        },
+      ),
+    ).toThrow(/Invalid Netopia runtime options/)
+  })
 })
 
 describe("createNetopiaClient.startCardPayment", () => {

--- a/packages/plugins/netopia/tests/unit/plugin.test.ts
+++ b/packages/plugins/netopia/tests/unit/plugin.test.ts
@@ -1,7 +1,9 @@
+import { createContainer, createEventBus } from "@voyantjs/core"
 import { financeService, type PaymentSession } from "@voyantjs/finance"
 import { notificationsService } from "@voyantjs/notifications"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import type { NetopiaClientApi } from "../../src/client.js"
+import { NETOPIA_RUNTIME_CONTAINER_KEY, netopiaHonoPlugin } from "../../src/plugin.js"
 import { deriveNetopiaOrderId, mapNetopiaPaymentStatus, netopiaService } from "../../src/service.js"
 import * as startService from "../../src/service-start.js"
 
@@ -72,6 +74,49 @@ const billingInput = {
 
 afterEach(() => {
   vi.restoreAllMocks()
+})
+
+describe("netopiaHonoPlugin.bootstrap", () => {
+  it("validates and registers the resolved runtime once", async () => {
+    const plugin = netopiaHonoPlugin({
+      apiUrl: "https://secure.mobilpay.ro/pay",
+      apiKey: "api-key",
+      posSignature: "pos-signature",
+      notifyUrl: "https://api.example.com/netopia/callback",
+      redirectUrl: "https://app.example.com/checkout/return",
+    })
+    const container = createContainer()
+
+    await plugin.bootstrap?.({
+      bindings: {},
+      container,
+      eventBus: createEventBus(),
+    })
+
+    expect(container.resolve(NETOPIA_RUNTIME_CONTAINER_KEY)).toMatchObject({
+      apiUrl: "https://secure.mobilpay.ro/pay",
+      apiKey: "api-key",
+      posSignature: "pos-signature",
+      notifyUrl: "https://api.example.com/netopia/callback",
+      redirectUrl: "https://app.example.com/checkout/return",
+      emailTemplate: "confirm",
+      language: "ro",
+      successStatuses: [3, 5],
+      processingStatuses: [1, 15],
+    })
+  })
+
+  it("fails fast when required runtime config is missing", async () => {
+    const plugin = netopiaHonoPlugin()
+
+    expect(() =>
+      plugin.bootstrap?.({
+        bindings: {},
+        container: createContainer(),
+        eventBus: createEventBus(),
+      }),
+    ).toThrow(/NETOPIA_URL/)
+  })
 })
 
 describe("deriveNetopiaOrderId", () => {


### PR DESCRIPTION
## Summary
- add typed Netopia runtime option schemas for env-plus-option resolution
- validate and register the resolved Netopia runtime once during plugin bootstrap
- consume the bootstrapped runtime from Netopia routes instead of re-resolving it on every request

## Verification
- pnpm -C packages/plugins/netopia typecheck
- pnpm -C packages/plugins/netopia test
- pnpm -C packages/plugins/netopia build
- git push -u origin cleanup/options-and-bootstrap-validation