### PR TITLE
Clarify shared container and module isolation semantics

### DIFF
--- a/packages/core/src/container.ts
+++ b/packages/core/src/container.ts
@@ -1,9 +1,9 @@
 /**
- * A lightweight module container providing per-request service resolution.
+ * A lightweight shared app/runtime container for explicit service resolution.
  *
- * Modules register services at app boot; routes resolve them per request.
- * The container is intentionally minimal (Map-based) — for richer DI
- * (scoping, factory lifetimes) a template can wrap or replace it.
+ * Routes, workflows, subscribers, and bootstraps use this container to resolve
+ * app-owned runtime services. It is intentionally minimal (Map-based) — for
+ * richer DI (scoping, factory lifetimes) a template can wrap or replace it.
  */
 export interface ModuleContainer {
   /** Register a service by name. Overwrites any existing registration. */

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -29,8 +29,14 @@ export interface Module {
   hooks?: Record<string, (...args: unknown[]) => Promise<void> | void>
 
   /**
-   * Optional service instance registered in the container under {@link name}.
-   * Other modules resolve it via `container.resolve<T>(name)`.
+   * Optional service instance registered in the shared app/runtime container
+   * under {@link name}.
+   *
+   * This is intended for explicit runtime wiring in routes, workflows,
+   * subscribers, or bootstrap-time registrations. Modules should prefer links
+   * and query for cross-module data, and workflows/orchestration for
+   * cross-module behavior, rather than treating the container as their default
+   * module-to-module integration surface.
    */
   service?: unknown
 

--- a/packages/core/src/orchestration.ts
+++ b/packages/core/src/orchestration.ts
@@ -21,8 +21,9 @@ export interface JobOptions {
  * step delegation — a Hatchet adapter can bridge enqueue/schedule calls to
  * the Hatchet API.
  *
- * Templates wire their chosen adapter into the container as `"jobs"`.
- * Framework code that needs to kick off async work does so via
+ * Templates wire their chosen adapter into the shared app/runtime container as
+ * `"jobs"`. Framework code that needs to kick off async work does so via
+ * explicit runtime resolution such as
  * `container.resolve<JobRunner>("jobs").enqueue(...)`.
  */
 export interface JobRunner {

--- a/packages/hono/src/types.ts
+++ b/packages/hono/src/types.ts
@@ -34,6 +34,7 @@ export interface VoyantBindings {
 export type VoyantDb = PostgresJsDatabase | NeonHttpDatabase
 export type VoyantVariables = CoreVoyantVariables & {
   db: VoyantDb
+  /** Shared app/runtime container for explicit service resolution. */
   container: ModuleContainer
   eventBus: EventBus
 }

--- a/packages/hono/tests/unit/plugin.test.ts
+++ b/packages/hono/tests/unit/plugin.test.ts
@@ -102,7 +102,7 @@ describe("createApp with plugins", () => {
     expect(r2.status).toBe(200)
   })
 
-  it("registers plugin module services in the container", async () => {
+  it("registers plugin runtime services in the shared container", async () => {
     const spy = { called: false }
     const mod: HonoModule = {
       module: { name: "svc", service: { ping: () => "pong" } },
@@ -200,7 +200,7 @@ describe("createApp with plugins", () => {
     expect(calls).toEqual(["plugin", "module", "extension"])
   })
 
-  it("exposes bootstrap-registered services through the shared container", async () => {
+  it("exposes bootstrap-registered runtime services through the shared container", async () => {
     const app = createApp({
       // biome-ignore lint/suspicious/noExplicitAny: test doesn't use db
       db: () => ({}) as any,


### PR DESCRIPTION
## Summary
- clarify that the shared container is an app/runtime primitive rather than the default module-to-module seam
- update core comments to point cross-module data to links/query and cross-module behavior to workflows/orchestration
- rename Hono tests to reflect runtime service registration semantics

## Testing
- pnpm -C packages/core test
- pnpm -C packages/hono test
- full pre-push repo test pipeline