### PR TITLE
Add admin extension surface for nav and widgets

### DIFF
--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -15,6 +15,10 @@ import { AdminProvider } from "@voyantjs/voyant-admin/providers/admin-provider"
 import { ThemeProvider, useTheme } from "@voyantjs/voyant-admin/providers/theme"
 import { makeQueryClient } from "@voyantjs/voyant-admin/providers/query-client"
 import { getInitials, getDisplayName } from "@voyantjs/voyant-admin/lib/initials"
+import {
+  defineAdminExtension,
+  resolveAdminNavigation,
+} from "@voyantjs/voyant-admin"
 
 function App() {
   return (
@@ -30,11 +34,35 @@ function App() {
 | Entry | Description |
 | --- | --- |
 | `.` | Barrel re-exports |
+| `./extensions` | Admin extension types and helpers |
 | `./providers/admin-provider` | `AdminProvider` composing QueryClient + Theme |
 | `./providers/theme` | `ThemeProvider`, `useTheme` with system-theme support |
 | `./providers/query-client` | `makeQueryClient(config?)` factory with Voyant defaults |
 | `./lib/initials` | `getInitials`, `getDisplayName` helpers |
 | `./types` | `AdminUser`, `NavItem`, `NavSubItem`, `ThemeMode`, `AuthActions` |
+
+## Admin Extensions
+
+Use `defineAdminExtension(...)` to declare shared admin contributions and keep
+the extension surface explicit:
+
+```ts
+import { defineAdminExtension } from "@voyantjs/voyant-admin"
+
+export const financeExtension = defineAdminExtension({
+  id: "finance-tools",
+  navigation: [
+    {
+      order: 10,
+      items: [{ id: "settlements", title: "Settlements", url: "/finance/settlements" }],
+    },
+  ],
+})
+```
+
+Templates can merge those contributions into their base navigation with
+`resolveAdminNavigation(...)` and expose widget slots with
+`resolveAdminWidgets(...)`.
 
 ## License
 

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./extensions": "./src/extensions.ts",
     "./providers/theme": "./src/providers/theme.tsx",
     "./providers/locale": "./src/providers/locale.tsx",
     "./providers/query-client": "./src/providers/query-client.ts",

--- a/packages/admin/src/extensions.ts
+++ b/packages/admin/src/extensions.ts
@@ -1,0 +1,122 @@
+import type * as React from "react"
+
+import type { NavItem } from "./types.js"
+
+/**
+ * A named route contribution for the admin shell.
+ *
+ * This is metadata only in the initial implementation. Templates remain free
+ * to decide how route registration is wired into their router/runtime.
+ */
+export interface AdminUiRouteContribution {
+  id: string
+  path: string
+  title: string
+}
+
+/**
+ * Contribute one or more navigation items to the shared admin shell.
+ *
+ * Contributions are appended after the template's base navigation and sorted
+ * by `order`.
+ */
+export interface AdminNavigationContribution {
+  items: ReadonlyArray<NavItem>
+  order?: number
+}
+
+/**
+ * Named widget slot identifier.
+ *
+ * Templates define the slots they expose on specific admin pages and modules
+ * or extensions can target them with React components.
+ */
+export type AdminWidgetSlot = string
+
+/**
+ * A widget contribution that can be rendered inside a template-defined slot.
+ */
+export interface AdminWidgetContribution<Props = Record<string, unknown>> {
+  id: string
+  slot: AdminWidgetSlot
+  order?: number
+  component: React.ComponentType<Props>
+}
+
+/**
+ * Shared admin extension bundle.
+ *
+ * This keeps the extension surface explicit and typed without forcing a more
+ * dynamic plugin runtime into templates.
+ */
+export interface AdminExtension {
+  id: string
+  navigation?: ReadonlyArray<AdminNavigationContribution>
+  routes?: ReadonlyArray<AdminUiRouteContribution>
+  widgets?: ReadonlyArray<AdminWidgetContribution>
+}
+
+export function defineAdminExtension<T extends AdminExtension>(extension: T): T {
+  return extension
+}
+
+type OrderedValue<T> = {
+  index: number
+  order: number
+  value: T
+}
+
+function sortOrderedValues<T>(values: ReadonlyArray<OrderedValue<T>>): T[] {
+  return [...values]
+    .sort((a, b) => {
+      if (a.order !== b.order) {
+        return a.order - b.order
+      }
+
+      return a.index - b.index
+    })
+    .map((entry) => entry.value)
+}
+
+export interface ResolveAdminNavigationOptions {
+  baseItems: ReadonlyArray<NavItem>
+  extensions?: ReadonlyArray<AdminExtension>
+}
+
+export function resolveAdminNavigation({
+  baseItems,
+  extensions = [],
+}: ResolveAdminNavigationOptions): NavItem[] {
+  const contributions = extensions.flatMap((extension) => extension.navigation ?? [])
+  const orderedContributions = sortOrderedValues(
+    contributions.map((contribution, index) => ({
+      index,
+      order: contribution.order ?? 0,
+      value: contribution,
+    })),
+  )
+
+  return [...baseItems, ...orderedContributions.flatMap((contribution) => contribution.items)]
+}
+
+export interface ResolveAdminWidgetsOptions {
+  slot: AdminWidgetSlot
+  extensions?: ReadonlyArray<AdminExtension>
+}
+
+export function resolveAdminWidgets({
+  slot,
+  extensions = [],
+}: ResolveAdminWidgetsOptions): AdminWidgetContribution[] {
+  const widgets = extensions
+    .flatMap((extension) => extension.widgets ?? [])
+    .filter((widget) => widget.slot === slot)
+
+  return sortOrderedValues(
+    widgets.map((widget, index) => ({
+      index,
+      order: widget.order ?? 0,
+      value: widget,
+    })),
+  )
+}

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -9,10 +9,23 @@
  *   resolution and persistence.
  * - Query client factory: `makeQueryClient()` with Voyant's admin defaults.
  * - `AdminProvider` composing QueryClient + ThemeProvider + LocaleProvider.
+ * - Admin extension helpers for navigation contributions and widget slots.
  * - User utilities: `getInitials`, `getDisplayName`.
  * - Types: `AdminUser`, `NavItem`, `NavSubItem`, `AuthActions`, `ThemeMode`.
  */
 
+export {
+  type AdminExtension,
+  type AdminNavigationContribution,
+  type AdminUiRouteContribution,
+  type AdminWidgetContribution,
+  type AdminWidgetSlot,
+  defineAdminExtension,
+  type ResolveAdminNavigationOptions,
+  type ResolveAdminWidgetsOptions,
+  resolveAdminNavigation,
+  resolveAdminWidgets,
+} from "./extensions.js"
 export { getDisplayName, getInitials } from "./lib/initials.js"
 export { AdminProvider, type AdminProviderProps } from "./providers/admin-provider.js"
 export {

--- a/packages/admin/src/types.ts
+++ b/packages/admin/src/types.ts
@@ -25,6 +25,8 @@ export type NavItemStatus = typeof COMING_SOON | typeof BETA
  * or elsewhere) so templates control the icon set.
  */
 export interface NavItem {
+  /** Stable identifier for extension merging and UI keys. */
+  id?: string
   title: string
   url: string
   icon?: React.ComponentType<{ className?: string }>
@@ -36,6 +38,7 @@ export interface NavItem {
 }
 
 export interface NavSubItem {
+  id?: string
   title: string
   url: string
   icon?: React.ComponentType<{ className?: string }>

--- a/packages/admin/tests/unit/extensions.test.tsx
+++ b/packages/admin/tests/unit/extensions.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  type AdminExtension,
+  defineAdminExtension,
+  resolveAdminNavigation,
+  resolveAdminWidgets,
+} from "../../src/extensions.js"
+
+describe("admin extensions", () => {
+  it("keeps the extension object shape intact", () => {
+    const extension = defineAdminExtension({
+      id: "finance-sync",
+      routes: [{ id: "finance-sync-route", path: "/finance/sync", title: "Finance sync" }],
+    })
+
+    expect(extension.id).toBe("finance-sync")
+    expect(extension.routes?.[0]?.path).toBe("/finance/sync")
+  })
+
+  it("appends navigation contributions after the base items in order", () => {
+    const baseItems = [{ id: "dashboard", title: "Dashboard", url: "/" }]
+    const extensions: AdminExtension[] = [
+      defineAdminExtension({
+        id: "late",
+        navigation: [{ order: 20, items: [{ id: "reports", title: "Reports", url: "/reports" }] }],
+      }),
+      defineAdminExtension({
+        id: "early",
+        navigation: [{ order: 10, items: [{ id: "sync", title: "Sync", url: "/sync" }] }],
+      }),
+    ]
+
+    const items = resolveAdminNavigation({ baseItems, extensions })
+
+    expect(items.map((item) => item.id)).toEqual(["dashboard", "sync", "reports"])
+  })
+
+  it("returns widgets for one slot in order", () => {
+    function BookingStatusCard() {
+      return null
+    }
+
+    function BookingAuditCard() {
+      return null
+    }
+
+    const extensions: AdminExtension[] = [
+      defineAdminExtension({
+        id: "booking-status",
+        widgets: [
+          {
+            id: "status",
+            slot: "booking.details.sidebar",
+            order: 20,
+            component: BookingStatusCard,
+          },
+          {
+            id: "ignored",
+            slot: "finance.invoice.sidebar",
+            order: 5,
+            component: BookingStatusCard,
+          },
+        ],
+      }),
+      defineAdminExtension({
+        id: "booking-audit",
+        widgets: [
+          { id: "audit", slot: "booking.details.sidebar", order: 10, component: BookingAuditCard },
+        ],
+      }),
+    ]
+
+    const widgets = resolveAdminWidgets({ slot: "booking.details.sidebar", extensions })
+
+    expect(widgets.map((widget) => widget.id)).toEqual(["audit", "status"])
+  })
+})

--- a/templates/operator/src/components/navigation/app-sidebar.tsx
+++ b/templates/operator/src/components/navigation/app-sidebar.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "@tanstack/react-router"
+import { type NavItem, resolveAdminNavigation } from "@voyantjs/voyant-admin"
 import {
   Building,
   Building2,
@@ -30,10 +31,8 @@ import {
   SidebarHeader,
   SidebarRail,
 } from "@/components/ui"
+import { adminExtensions } from "@/lib/admin-extensions"
 import { useAdminMessages } from "@/lib/admin-i18n"
-
-export const COMING_SOON = "COMING_SOON" as const
-export const BETA = "BETA" as const
 
 type AppSidebarProps = React.ComponentProps<typeof Sidebar> & {
   user?: {
@@ -103,59 +102,75 @@ export function AppSidebar({ user, ...props }: AppSidebarProps) {
     email: user?.email ?? "",
     avatar: user?.avatar ?? "",
   }
-  const navMain = [
+  const baseNavMain: ReadonlyArray<NavItem> = [
     {
+      id: "dashboard",
       title: messages.nav.dashboard,
       url: "/",
       icon: LayoutDashboard,
     },
     {
+      id: "products",
       title: messages.nav.products,
       url: "/products",
       icon: Package,
-      items: [{ title: messages.nav.categories, url: "/products/categories" }],
+      items: [
+        { id: "product-categories", title: messages.nav.categories, url: "/products/categories" },
+      ],
     },
     {
+      id: "bookings",
       title: messages.nav.bookings,
       url: "/bookings",
       icon: CalendarCheck,
     },
     {
+      id: "suppliers",
       title: messages.nav.suppliers,
       url: "/suppliers",
       icon: Building2,
     },
     {
+      id: "people",
       title: messages.nav.people,
       url: "/people",
       icon: Users,
     },
     {
+      id: "organizations",
       title: messages.nav.organizations,
       url: "/organizations",
       icon: Building,
     },
     {
+      id: "availability",
       title: messages.nav.availability,
       url: "/availability",
       icon: CalendarDays,
     },
     {
+      id: "resources",
       title: messages.nav.resources,
       url: "/resources",
       icon: Wrench,
     },
     {
+      id: "finance",
       title: messages.nav.finance,
       url: "/finance",
       icon: DollarSign,
     },
     {
+      id: "settings",
       title: messages.nav.settings,
       url: "/settings",
       icon: Settings,
     },
-  ] as const
+  ]
+  const navMain = resolveAdminNavigation({
+    baseItems: baseNavMain,
+    extensions: adminExtensions,
+  })
 
   return (
     <Sidebar collapsible="icon" {...props}>

--- a/templates/operator/src/components/navigation/nav-group.tsx
+++ b/templates/operator/src/components/navigation/nav-group.tsx
@@ -1,5 +1,5 @@
 import { Link, useRouterState } from "@tanstack/react-router"
-import type { LucideIcon } from "lucide-react"
+import { BETA, COMING_SOON, type NavItem } from "@voyantjs/voyant-admin"
 import * as React from "react"
 import {
   Badge,
@@ -15,8 +15,6 @@ import {
   useSidebar,
 } from "@/components/ui"
 
-import { BETA, COMING_SOON } from "./app-sidebar"
-
 export function NavGroup({
   items,
   label,
@@ -24,21 +22,7 @@ export function NavGroup({
 }: {
   label?: string
   className?: string
-  items: readonly {
-    title: string
-    url: string
-    icon: LucideIcon | React.ComponentType<{ className?: string }>
-    isActive?: boolean
-    status?: typeof COMING_SOON | typeof BETA
-    target?: string
-    items?: readonly {
-      title: string
-      url: string
-      icon?: LucideIcon | React.ComponentType<{ className?: string }>
-      status?: typeof COMING_SOON | typeof BETA
-      target?: string
-    }[]
-  }[]
+  items: ReadonlyArray<NavItem>
 }) {
   const currentPath = useRouterState({ select: (s) => s.location.pathname })
   const { isMobile, setOpenMobile } = useSidebar()
@@ -101,12 +85,14 @@ export function NavGroup({
             const expanded = parentActive || anyChildActive
 
             return (
-              <SidebarMenuItem key={item.title}>
+              <SidebarMenuItem key={item.id ?? item.url ?? item.title}>
                 <SidebarMenuButton asChild tooltip={item.title} isActive={parentActive}>
                   <Link to={item.url} onClick={handleLinkClick}>
-                    {React.createElement(item.icon, {
-                      className: "h-4 w-4",
-                    })}
+                    {item.icon
+                      ? React.createElement(item.icon, {
+                          className: "h-4 w-4",
+                        })
+                      : null}
                     <span>{item.title}</span>
                     {renderBadge(item.status)}
                   </Link>
@@ -114,7 +100,7 @@ export function NavGroup({
                 {expanded && (
                   <SidebarMenuSub>
                     {item.items?.map((subItem) => (
-                      <SidebarMenuSubItem key={subItem.title}>
+                      <SidebarMenuSubItem key={subItem.id ?? subItem.url ?? subItem.title}>
                         {subItem.status === COMING_SOON ? (
                           <SidebarMenuSubButton
                             className={cn(subItem.status === COMING_SOON && "opacity-50")}
@@ -150,10 +136,10 @@ export function NavGroup({
             )
           } else {
             return (
-              <SidebarMenuItem key={item.title}>
+              <SidebarMenuItem key={item.id ?? item.url ?? item.title}>
                 {item.status === COMING_SOON ? (
                   <SidebarMenuButton tooltip={item.title} disabled>
-                    {React.createElement(item.icon, { className: "h-4 w-4" })}
+                    {item.icon ? React.createElement(item.icon, { className: "h-4 w-4" }) : null}
                     <span>{item.title}</span>
                     {renderBadge(item.status)}
                   </SidebarMenuButton>
@@ -165,7 +151,7 @@ export function NavGroup({
                       rel={item.target === "_blank" ? "noopener noreferrer" : undefined}
                       onClick={handleLinkClick}
                     >
-                      {React.createElement(item.icon, { className: "h-4 w-4" })}
+                      {item.icon ? React.createElement(item.icon, { className: "h-4 w-4" }) : null}
                       <span>{item.title}</span>
                       {renderBadge(item.status)}
                     </a>
@@ -173,7 +159,7 @@ export function NavGroup({
                 ) : (
                   <SidebarMenuButton asChild tooltip={item.title} isActive={isActive(item.url)}>
                     <Link to={item.url} onClick={handleLinkClick}>
-                      {React.createElement(item.icon, { className: "h-4 w-4" })}
+                      {item.icon ? React.createElement(item.icon, { className: "h-4 w-4" }) : null}
                       <span>{item.title}</span>
                       {renderBadge(item.status)}
                     </Link>

--- a/templates/operator/src/lib/admin-extensions.tsx
+++ b/templates/operator/src/lib/admin-extensions.tsx
@@ -1,0 +1,10 @@
+import type { AdminExtension } from "@voyantjs/voyant-admin"
+
+/**
+ * Template-local admin extension registry.
+ *
+ * Keep this explicit and source-controlled so projects can add navigation
+ * contributions, widget slots, and route metadata without relying on a more
+ * dynamic plugin runtime in the admin shell.
+ */
+export const adminExtensions: ReadonlyArray<AdminExtension> = []


### PR DESCRIPTION
## Summary
- add a small typed admin extension surface in @voyantjs/voyant-admin
- support navigation contributions and widget-slot resolution without introducing a dynamic admin plugin runtime
- wire the operator sidebar through a template-local admin extension registry

## Testing
- pnpm -C packages/admin test
- pnpm -C packages/admin typecheck
- pnpm -C templates/operator typecheck
- node scripts/run-tests.cjs