### PR TITLE
Align storefront public routes with public root

### DIFF
--- a/packages/hono/src/app.ts
+++ b/packages/hono/src/app.ts
@@ -10,6 +10,24 @@ import { requireActor } from "./middleware/require-actor.js"
 import { expandHonoPlugins } from "./plugin.js"
 import type { VoyantAppConfig, VoyantBindings, VoyantVariables } from "./types.js"
 
+function resolveSurfaceMountPath(
+  prefix: string,
+  path: string | undefined,
+  fallback: string,
+): string {
+  const normalized = path?.trim()
+
+  if (!normalized) {
+    return `${prefix}/${fallback}`
+  }
+
+  if (normalized === "/") {
+    return prefix
+  }
+
+  return `${prefix}/${normalized.replace(/^\/+|\/+$/g, "")}`
+}
+
 export function createApp<TBindings extends VoyantBindings>(
   config: VoyantAppConfig<TBindings>,
 ): Hono<{ Bindings: TBindings; Variables: VoyantVariables }> {
@@ -100,7 +118,10 @@ export function createApp<TBindings extends VoyantBindings>(
       app.route(`/v1/admin/${mod.module.name}`, mod.adminRoutes)
     }
     if (mod.publicRoutes) {
-      app.route(`/v1/public/${mod.module.name}`, mod.publicRoutes)
+      app.route(
+        resolveSurfaceMountPath("/v1/public", mod.publicPath, mod.module.name),
+        mod.publicRoutes,
+      )
     }
     if (mod.routes) {
       app.route(`/v1/${mod.module.name}`, mod.routes)
@@ -113,7 +134,10 @@ export function createApp<TBindings extends VoyantBindings>(
       app.route(`/v1/admin/${ext.extension.module}`, ext.adminRoutes)
     }
     if (ext.publicRoutes) {
-      app.route(`/v1/public/${ext.extension.module}`, ext.publicRoutes)
+      app.route(
+        resolveSurfaceMountPath("/v1/public", ext.publicPath, ext.extension.module),
+        ext.publicRoutes,
+      )
     }
     if (ext.routes) {
       app.route(`/v1/${ext.extension.module}`, ext.routes)

--- a/packages/hono/src/module.ts
+++ b/packages/hono/src/module.ts
@@ -18,6 +18,13 @@ export interface HonoModule {
   /** Customer/partner/supplier-facing routes — mounted at `/v1/public/{module.name}`. */
   // biome-ignore lint/suspicious/noExplicitAny: Hono sub-apps have varied env generics
   publicRoutes?: Hono<any>
+  /**
+   * Optional override for the public mount path relative to `/v1/public`.
+   *
+   * Defaults to `{module.name}`. Use `"/"` to mount a module directly at the
+   * public root and omit the extra module segment.
+   */
+  publicPath?: string
 }
 
 export interface HonoExtension {
@@ -31,4 +38,11 @@ export interface HonoExtension {
   /** Customer/partner/supplier-facing routes — mounted at `/v1/public/{extension.module}`. */
   // biome-ignore lint/suspicious/noExplicitAny: Hono sub-apps have varied env generics
   publicRoutes?: Hono<any>
+  /**
+   * Optional override for the public mount path relative to `/v1/public`.
+   *
+   * Defaults to `{extension.module}`. Use `"/"` to mount an extension directly
+   * at the public root and omit the extra module segment.
+   */
+  publicPath?: string
 }

--- a/packages/hono/tests/unit/app-surfaces.test.ts
+++ b/packages/hono/tests/unit/app-surfaces.test.ts
@@ -19,6 +19,7 @@ function makeModule(options: {
   admin?: boolean
   public_?: boolean
   legacy?: boolean
+  publicPath?: string
 }): HonoModule {
   const admin = new Hono().get("/ping", (c) => c.json({ surface: "admin", name: options.name }))
   const pub = new Hono().get("/ping", (c) => c.json({ surface: "public", name: options.name }))
@@ -28,6 +29,7 @@ function makeModule(options: {
     module: { name: options.name },
     ...(options.admin ? { adminRoutes: admin } : {}),
     ...(options.public_ ? { publicRoutes: pub } : {}),
+    ...(options.publicPath ? { publicPath: options.publicPath } : {}),
     ...(options.legacy ? { routes: legacy } : {}),
   }
 }
@@ -60,6 +62,16 @@ describe("createApp surface mounting", () => {
   it("mounts publicRoutes under /v1/public/{name}", async () => {
     const app = build("customer", [makeModule({ name: "things", public_: true })])
     const res = await app.request("/v1/public/things/ping", {}, TEST_ENV, TEST_CTX)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { surface: string }
+    expect(body.surface).toBe("public")
+  })
+
+  it("allows modules to mount publicRoutes at the public root", async () => {
+    const app = build("customer", [
+      makeModule({ name: "storefront", public_: true, publicPath: "/" }),
+    ])
+    const res = await app.request("/v1/public/ping", {}, TEST_ENV, TEST_CTX)
     expect(res.status).toBe(200)
     const body = (await res.json()) as { surface: string }
     expect(body.surface).toBe("public")

--- a/packages/storefront-react/src/operations.ts
+++ b/packages/storefront-react/src/operations.ts
@@ -18,16 +18,12 @@ import {
 } from "./schemas.js"
 
 export function getStorefrontSettings(client: FetchWithValidationOptions) {
-  return fetchWithValidation(
-    "/v1/public/storefront/settings",
-    storefrontSettingsResponseSchema,
-    client,
-  )
+  return fetchWithValidation("/v1/public/settings", storefrontSettingsResponseSchema, client)
 }
 
 export function getStorefrontDeparture(client: FetchWithValidationOptions, departureId: string) {
   return fetchWithValidation(
-    `/v1/public/storefront/departures/${departureId}`,
+    `/v1/public/departures/${departureId}`,
     storefrontDepartureResponseSchema,
     client,
   )
@@ -39,7 +35,7 @@ export function listStorefrontProductDepartures(
   query?: StorefrontDepartureListQuery,
 ) {
   return fetchWithValidation(
-    withQueryParams(`/v1/public/storefront/products/${productId}/departures`, query),
+    withQueryParams(`/v1/public/products/${productId}/departures`, query),
     storefrontDepartureListResponseSchema,
     client,
   )
@@ -53,7 +49,7 @@ export function previewStorefrontDeparturePrice(
   const parsed = storefrontDeparturePricePreviewInputSchema.parse(input)
 
   return fetchWithValidation(
-    `/v1/public/storefront/departures/${departureId}/price`,
+    `/v1/public/departures/${departureId}/price`,
     storefrontDeparturePricePreviewResponseSchema,
     client,
     { method: "POST", body: JSON.stringify(parsed) },
@@ -66,7 +62,7 @@ export function listStorefrontProductExtensions(
   query?: StorefrontProductExtensionsQuery,
 ) {
   return fetchWithValidation(
-    withQueryParams(`/v1/public/storefront/products/${productId}/extensions`, query),
+    withQueryParams(`/v1/public/products/${productId}/extensions`, query),
     storefrontProductExtensionsResponseSchema,
     client,
   )
@@ -78,7 +74,7 @@ export function getStorefrontDepartureItinerary(
   departureId: string,
 ) {
   return fetchWithValidation(
-    `/v1/public/storefront/products/${productId}/departures/${departureId}/itinerary`,
+    `/v1/public/products/${productId}/departures/${departureId}/itinerary`,
     storefrontDepartureItineraryResponseSchema,
     client,
   )
@@ -90,7 +86,7 @@ export function listStorefrontProductOffers(
   query?: StorefrontPromotionalOfferListQuery,
 ) {
   return fetchWithValidation(
-    withQueryParams(`/v1/public/storefront/products/${productId}/offers`, query),
+    withQueryParams(`/v1/public/products/${productId}/offers`, query),
     storefrontPromotionalOfferListResponseSchema,
     client,
   )
@@ -102,7 +98,7 @@ export function getStorefrontOfferBySlug(
   query?: Pick<StorefrontPromotionalOfferListQuery, "locale">,
 ) {
   return fetchWithValidation(
-    withQueryParams(`/v1/public/storefront/offers/${slug}`, query),
+    withQueryParams(`/v1/public/offers/${slug}`, query),
     storefrontPromotionalOfferResponseSchema,
     client,
   )

--- a/packages/storefront/src/index.ts
+++ b/packages/storefront/src/index.ts
@@ -51,6 +51,7 @@ export function createStorefrontHonoModule(
 ): HonoModule {
   return {
     module: storefrontModule,
+    publicPath: "/",
     publicRoutes: createStorefrontPublicRoutes(options),
   }
 }


### PR DESCRIPTION
## Summary
- add a public mount-path override to Hono module and extension surfaces
- mount storefront public routes at /v1/public/* instead of /v1/public/storefront/*
- update storefront-react operations to match the new public contract

## Testing
- pnpm -C packages/hono test
- pnpm -C packages/storefront typecheck
- pnpm -C packages/storefront-react typecheck
- pnpm -C packages/storefront build