### PR TITLE
Formalize event envelopes for subscribers

### DIFF
--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -1,7 +1,59 @@
 /**
+ * High-level classification for public event consumers.
+ *
+ * - `domain` events represent business milestones that other modules or
+ *   external integrations may reasonably care about.
+ * - `internal` events are service/process signals that remain useful for
+ *   subscribers, diagnostics, and automation, but are not part of the core
+ *   business language.
+ */
+export type EventCategory = "domain" | "internal"
+
+/**
+ * Where an event was emitted from. This helps consumers understand whether
+ * an event originated from a workflow boundary, a lower-level service, or a
+ * transport/runtime edge.
+ */
+export type EventSource = "workflow" | "service" | "route" | "subscriber" | "system"
+
+/**
+ * Optional metadata attached to an emitted event.
+ *
+ * Templates and adapters may extend this with runtime-specific fields such as
+ * correlation identifiers or delivery handles.
+ */
+export interface EventMetadata {
+  category?: EventCategory
+  source?: EventSource
+  correlationId?: string
+  causationId?: string
+  [key: string]: unknown
+}
+
+/**
+ * Standard event envelope delivered to subscribers.
+ */
+export interface EventEnvelope<
+  TData = unknown,
+  TMetadata extends EventMetadata | undefined = EventMetadata | undefined,
+> {
+  /** Event name, following the `<resource>.<pastTenseAction>` convention. */
+  name: string
+  /** Business payload emitted by the caller. */
+  data: TData
+  /** Optional metadata for source/taxonomy/tracing. */
+  metadata?: TMetadata
+  /** ISO timestamp indicating when the event was emitted. */
+  emittedAt: string
+}
+
+/**
  * Event handler callback invoked when a subscribed event is emitted.
  */
-export type EventHandler<TData = unknown> = (data: TData) => Promise<void> | void
+export type EventHandler<
+  TData = unknown,
+  TMetadata extends EventMetadata | undefined = EventMetadata | undefined,
+> = (event: EventEnvelope<TData, TMetadata>) => Promise<void> | void
 
 /**
  * Subscription handle returned from {@link EventBus.subscribe}.
@@ -25,10 +77,17 @@ export interface Subscription {
  */
 export interface EventBus {
   /** Emit an event. Fire-and-forget; subscribers cannot affect the emitter. */
-  emit(event: string, data: unknown): Promise<void>
+  emit<TData, TMetadata extends EventMetadata | undefined = EventMetadata | undefined>(
+    event: string,
+    data: TData,
+    metadata?: TMetadata,
+  ): Promise<void>
 
   /** Subscribe to an event by name. Returns an unsubscribe handle. */
-  subscribe(event: string, handler: EventHandler): Subscription
+  subscribe<TData, TMetadata extends EventMetadata | undefined = EventMetadata | undefined>(
+    event: string,
+    handler: EventHandler<TData, TMetadata>,
+  ): Subscription
 }
 
 /**
@@ -43,28 +102,41 @@ export function createEventBus(): EventBus {
   const handlers = new Map<string, Set<EventHandler>>()
 
   return {
-    async emit(event, data) {
+    async emit<TData, TMetadata extends EventMetadata | undefined = EventMetadata | undefined>(
+      event: string,
+      data: TData,
+      metadata?: TMetadata,
+    ) {
       const set = handlers.get(event)
       if (!set) return
+      const envelope: EventEnvelope<TData, TMetadata> = {
+        name: event,
+        data,
+        emittedAt: new Date().toISOString(),
+        ...(metadata === undefined ? {} : { metadata }),
+      }
       for (const handler of set) {
         try {
-          await handler(data)
+          await handler(envelope)
         } catch (err) {
           // Subscribers are fire-and-forget — log and continue.
           console.error(`[events] subscriber error for "${event}":`, err)
         }
       }
     },
-    subscribe(event, handler) {
+    subscribe<TData, TMetadata extends EventMetadata | undefined = EventMetadata | undefined>(
+      event: string,
+      handler: EventHandler<TData, TMetadata>,
+    ) {
       let set = handlers.get(event)
       if (!set) {
         set = new Set()
         handlers.set(event, set)
       }
-      set.add(handler)
+      set.add(handler as EventHandler)
       return {
         unsubscribe() {
-          set?.delete(handler)
+          set?.delete(handler as EventHandler)
         },
       }
     },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,7 +18,15 @@ export type {
   VoyantPermission,
   VoyantVariables,
 } from "./env.js"
-export type { EventBus, EventHandler, Subscription } from "./events.js"
+export type {
+  EventBus,
+  EventCategory,
+  EventEnvelope,
+  EventHandler,
+  EventMetadata,
+  EventSource,
+  Subscription,
+} from "./events.js"
 export { createEventBus } from "./events.js"
 export { hooks } from "./hooks.js"
 export type {

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -12,7 +12,7 @@
  * contract to carry route bundles.
  */
 
-import type { EventBus, EventHandler } from "./events.js"
+import type { EventBus, EventHandler, EventMetadata } from "./events.js"
 import type { LinkDefinition } from "./links.js"
 import type { BootstrapHandler, Extension, Module } from "./module.js"
 
@@ -22,11 +22,14 @@ import type { BootstrapHandler, Extension, Module } from "./module.js"
  * When the plugin is registered, `handler` is attached to the provided
  * {@link EventBus} for the given `event` name.
  */
-export interface Subscriber<TData = unknown> {
+export interface Subscriber<
+  TData = unknown,
+  TMetadata extends EventMetadata | undefined = EventMetadata | undefined,
+> {
   /** Event name, following `<resource>.<pastTenseAction>` convention. */
   event: string
   /** Callback invoked when the event is emitted. */
-  handler: EventHandler<TData>
+  handler: EventHandler<TData, TMetadata>
 }
 
 /**

--- a/packages/core/tests/unit/events.test.ts
+++ b/packages/core/tests/unit/events.test.ts
@@ -11,7 +11,13 @@ describe("createEventBus", () => {
     await bus.emit("booking.created", { id: "book_1" })
 
     expect(handler).toHaveBeenCalledOnce()
-    expect(handler).toHaveBeenCalledWith({ id: "book_1" })
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "booking.created",
+        data: { id: "book_1" },
+        emittedAt: expect.any(String),
+      }),
+    )
   })
 
   it("delivers to multiple subscribers for the same event", async () => {
@@ -23,8 +29,42 @@ describe("createEventBus", () => {
 
     await bus.emit("quote.sent", { id: "q1" })
 
-    expect(a).toHaveBeenCalledWith({ id: "q1" })
-    expect(b).toHaveBeenCalledWith({ id: "q1" })
+    expect(a).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "quote.sent",
+        data: { id: "q1" },
+      }),
+    )
+    expect(b).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "quote.sent",
+        data: { id: "q1" },
+      }),
+    )
+  })
+
+  it("includes metadata in the delivered envelope when provided", async () => {
+    const bus = createEventBus()
+    const handler = vi.fn()
+    bus.subscribe("invoice.settled", handler)
+
+    await bus.emit(
+      "invoice.settled",
+      { id: "inv_1" },
+      { category: "domain", source: "service", correlationId: "corr_123" },
+    )
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "invoice.settled",
+        data: { id: "inv_1" },
+        metadata: {
+          category: "domain",
+          source: "service",
+          correlationId: "corr_123",
+        },
+      }),
+    )
   })
 
   it("does nothing when no subscribers are registered", async () => {

--- a/packages/core/tests/unit/plugin.test.ts
+++ b/packages/core/tests/unit/plugin.test.ts
@@ -72,7 +72,12 @@ describe("registerPlugins", () => {
 
     await bus.emit("booking.created", { id: "b1" })
     expect(handler).toHaveBeenCalledOnce()
-    expect(handler).toHaveBeenCalledWith({ id: "b1" })
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "booking.created",
+        data: { id: "b1" },
+      }),
+    )
   })
 
   it("subscriptions can be unsubscribed", async () => {
@@ -125,7 +130,17 @@ describe("registerPlugins", () => {
     })
     registerPlugins([p1, p2], { eventBus: bus })
     await bus.emit("e", "hi")
-    expect(h1).toHaveBeenCalledWith("hi")
-    expect(h2).toHaveBeenCalledWith("hi")
+    expect(h1).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "e",
+        data: "hi",
+      }),
+    )
+    expect(h2).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "e",
+        data: "hi",
+      }),
+    )
   })
 })

--- a/packages/finance/src/service-documents.ts
+++ b/packages/finance/src/service-documents.ts
@@ -356,15 +356,22 @@ export const financeDocumentsService = {
       return { status: "not_found" }
     }
 
-    await runtime.eventBus?.emit("invoice.document.generated", {
-      invoiceId: prepared.invoice.id,
-      invoiceStatus: prepared.invoice.status,
-      invoiceType: prepared.invoice.invoiceType,
-      renditionId: rendition.id,
-      format: rendition.format,
-      renderedBodyFormat: prepared.renderedBodyFormat,
-      regenerated: options.regenerated ?? false,
-    } satisfies InvoiceDocumentGeneratedEvent)
+    await runtime.eventBus?.emit(
+      "invoice.document.generated",
+      {
+        invoiceId: prepared.invoice.id,
+        invoiceStatus: prepared.invoice.status,
+        invoiceType: prepared.invoice.invoiceType,
+        renditionId: rendition.id,
+        format: rendition.format,
+        renderedBodyFormat: prepared.renderedBodyFormat,
+        regenerated: options.regenerated ?? false,
+      } satisfies InvoiceDocumentGeneratedEvent,
+      {
+        category: "internal",
+        source: "service",
+      },
+    )
 
     return {
       status: "generated",

--- a/packages/finance/src/service-settlement.ts
+++ b/packages/finance/src/service-settlement.ts
@@ -211,14 +211,21 @@ export const financeSettlementService = {
             invoice = (await financeService.getInvoiceById(db, invoice.id)) ?? invoice
 
             if (createdPaymentId) {
-              await runtime.eventBus?.emit("invoice.settled", {
-                invoiceId: invoice.id,
-                paymentId: createdPaymentId,
-                provider: externalRef.provider,
-                newlyAppliedAmountCents,
-                paidCents: invoice.paidCents,
-                balanceDueCents: invoice.balanceDueCents,
-              } satisfies InvoiceSettledEvent)
+              await runtime.eventBus?.emit(
+                "invoice.settled",
+                {
+                  invoiceId: invoice.id,
+                  paymentId: createdPaymentId,
+                  provider: externalRef.provider,
+                  newlyAppliedAmountCents,
+                  paidCents: invoice.paidCents,
+                  balanceDueCents: invoice.balanceDueCents,
+                } satisfies InvoiceSettledEvent,
+                {
+                  category: "domain",
+                  source: "service",
+                },
+              )
             }
           }
         }

--- a/packages/finance/tests/integration/document-routes.test.ts
+++ b/packages/finance/tests/integration/document-routes.test.ts
@@ -150,16 +150,30 @@ describe.skipIf(!DB_AVAILABLE)("Finance document routes", () => {
     expect(renditions.filter((entry) => entry.status === "stale")).toHaveLength(1)
     expect(documentEvents).toEqual([
       expect.objectContaining({
-        invoiceId: invoice.id,
-        invoiceType: "invoice",
-        format: "pdf",
-        regenerated: false,
+        name: "invoice.document.generated",
+        metadata: {
+          category: "internal",
+          source: "service",
+        },
+        data: expect.objectContaining({
+          invoiceId: invoice.id,
+          invoiceType: "invoice",
+          format: "pdf",
+          regenerated: false,
+        }),
       }),
       expect.objectContaining({
-        invoiceId: invoice.id,
-        invoiceType: "invoice",
-        format: "pdf",
-        regenerated: true,
+        name: "invoice.document.generated",
+        metadata: {
+          category: "internal",
+          source: "service",
+        },
+        data: expect.objectContaining({
+          invoiceId: invoice.id,
+          invoiceType: "invoice",
+          format: "pdf",
+          regenerated: true,
+        }),
       }),
     ])
   })

--- a/packages/finance/tests/integration/settlement-routes.test.ts
+++ b/packages/finance/tests/integration/settlement-routes.test.ts
@@ -150,11 +150,18 @@ describe.skipIf(!DB_AVAILABLE)("Finance settlement routes", () => {
     expect(syncedRef?.syncError).toBeNull()
     expect(settlementEvents).toEqual([
       expect.objectContaining({
-        invoiceId: invoice.id,
-        provider: "smartbill",
-        newlyAppliedAmountCents: 30000,
-        paidCents: 60000,
-        balanceDueCents: 40000,
+        name: "invoice.settled",
+        metadata: {
+          category: "domain",
+          source: "service",
+        },
+        data: expect.objectContaining({
+          invoiceId: invoice.id,
+          provider: "smartbill",
+          newlyAppliedAmountCents: 30000,
+          paidCents: 60000,
+          balanceDueCents: 40000,
+        }),
       }),
     ])
   })

--- a/packages/hono/tests/unit/plugin.test.ts
+++ b/packages/hono/tests/unit/plugin.test.ts
@@ -154,7 +154,12 @@ describe("createApp with plugins", () => {
     const res = await app.request("/v1/admin/events/emit", { method: "POST" }, TEST_ENV, TEST_CTX)
     expect(res.status).toBe(200)
     expect(handler).toHaveBeenCalledTimes(1)
-    expect(handler).toHaveBeenCalledWith({ bookingId: "b_123" })
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "booking.created",
+        data: { bookingId: "b_123" },
+      }),
+    )
   })
 
   it("runs plugin, module, and extension bootstraps once in order", async () => {
@@ -250,6 +255,11 @@ describe("createApp with plugins", () => {
     const res = await app.request("/v1/admin/bus/emit", { method: "POST" }, TEST_ENV, TEST_CTX)
     expect(res.status).toBe(200)
     expect(handler).toHaveBeenCalledTimes(1)
-    expect(handler).toHaveBeenCalledWith({ bookingId: "b_234" })
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "booking.updated",
+        data: { bookingId: "b_234" },
+      }),
+    )
   })
 })

--- a/packages/legal/src/contracts/service-documents.ts
+++ b/packages/legal/src/contracts/service-documents.ts
@@ -388,15 +388,22 @@ export const contractDocumentsService = {
       return { status: "not_found" }
     }
 
-    await runtime.eventBus?.emit("contract.document.generated", {
-      contractId: prepared.contract.id,
-      contractStatus: prepared.contract.status,
-      attachmentId: attachment.id,
-      attachmentKind: attachment.kind,
-      attachmentName: attachment.name,
-      renderedBodyFormat: prepared.renderedBodyFormat,
-      regenerated: options.regenerated ?? false,
-    } satisfies ContractDocumentGeneratedEvent)
+    await runtime.eventBus?.emit(
+      "contract.document.generated",
+      {
+        contractId: prepared.contract.id,
+        contractStatus: prepared.contract.status,
+        attachmentId: attachment.id,
+        attachmentKind: attachment.kind,
+        attachmentName: attachment.name,
+        renderedBodyFormat: prepared.renderedBodyFormat,
+        regenerated: options.regenerated ?? false,
+      } satisfies ContractDocumentGeneratedEvent,
+      {
+        category: "internal",
+        source: "service",
+      },
+    )
 
     return {
       status: "generated",

--- a/packages/legal/tests/integration/public-routes.test.ts
+++ b/packages/legal/tests/integration/public-routes.test.ts
@@ -222,16 +222,30 @@ describe.skipIf(!DB_AVAILABLE)("Legal public routes", () => {
     expect(attachments[0]?.storageKey).toContain("contract-2.pdf")
     expect(documentEvents).toEqual([
       expect.objectContaining({
-        contractId: contract.id,
-        attachmentKind: "document",
-        attachmentName: "contract-1.pdf",
-        regenerated: false,
+        name: "contract.document.generated",
+        metadata: {
+          category: "internal",
+          source: "service",
+        },
+        data: expect.objectContaining({
+          contractId: contract.id,
+          attachmentKind: "document",
+          attachmentName: "contract-1.pdf",
+          regenerated: false,
+        }),
       }),
       expect.objectContaining({
-        contractId: contract.id,
-        attachmentKind: "document",
-        attachmentName: "contract-2.pdf",
-        regenerated: true,
+        name: "contract.document.generated",
+        metadata: {
+          category: "internal",
+          source: "service",
+        },
+        data: expect.objectContaining({
+          contractId: contract.id,
+          attachmentKind: "document",
+          attachmentName: "contract-2.pdf",
+          regenerated: true,
+        }),
       }),
     ])
   })

--- a/packages/notifications/src/service-booking-documents.ts
+++ b/packages/notifications/src/service-booking-documents.ts
@@ -360,13 +360,20 @@ export const bookingDocumentNotificationsService = {
       return { status: "send_failed" as const }
     }
 
-    await runtime.eventBus?.emit("booking.documents.sent", {
-      bookingId: booking.id,
-      recipient: to,
-      deliveryId: delivery.id,
-      provider: delivery.provider ?? null,
-      documentKeys: documents.map((document) => document.key),
-    } satisfies BookingDocumentsSentEvent)
+    await runtime.eventBus?.emit(
+      "booking.documents.sent",
+      {
+        bookingId: booking.id,
+        recipient: to,
+        deliveryId: delivery.id,
+        provider: delivery.provider ?? null,
+        documentKeys: documents.map((document) => document.key),
+      } satisfies BookingDocumentsSentEvent,
+      {
+        category: "domain",
+        source: "service",
+      },
+    )
 
     return {
       status: "sent" as const,

--- a/packages/notifications/tests/integration/booking-documents.test.ts
+++ b/packages/notifications/tests/integration/booking-documents.test.ts
@@ -146,10 +146,17 @@ describe.skipIf(!DB_AVAILABLE)("Booking document notification routes", () => {
     })
     expect(sentEvents).toEqual([
       expect.objectContaining({
-        bookingId: "book_docs_1",
-        recipient: "ana@example.com",
-        provider: "local",
-        documentKeys: ["legal:ctat_docs_1", "finance:invr_docs_1"],
+        name: "booking.documents.sent",
+        metadata: {
+          category: "domain",
+          source: "service",
+        },
+        data: expect.objectContaining({
+          bookingId: "book_docs_1",
+          recipient: "ana@example.com",
+          provider: "local",
+          documentKeys: ["legal:ctat_docs_1", "finance:invr_docs_1"],
+        }),
       }),
     ])
   })

--- a/packages/plugins/payload-cms/src/plugin.ts
+++ b/packages/plugins/payload-cms/src/plugin.ts
@@ -86,8 +86,8 @@ export function payloadCmsPlugin(options: PayloadCmsPluginOptions): Plugin {
   const subscribers: Subscriber[] = [
     {
       event: eventNames.created,
-      handler: async (data) => {
-        const event = coerceEvent(data)
+      handler: async (envelope) => {
+        const event = coerceEvent(envelope.data)
         if (!event) return
         try {
           await client.upsertByVoyantId(options.collection, event.id, mapEvent(event))
@@ -101,8 +101,8 @@ export function payloadCmsPlugin(options: PayloadCmsPluginOptions): Plugin {
     },
     {
       event: eventNames.updated,
-      handler: async (data) => {
-        const event = coerceEvent(data)
+      handler: async (envelope) => {
+        const event = coerceEvent(envelope.data)
         if (!event) return
         try {
           await client.upsertByVoyantId(options.collection, event.id, mapEvent(event))
@@ -116,8 +116,8 @@ export function payloadCmsPlugin(options: PayloadCmsPluginOptions): Plugin {
     },
     {
       event: eventNames.deleted,
-      handler: async (data) => {
-        const event = coerceEvent(data)
+      handler: async (envelope) => {
+        const event = coerceEvent(envelope.data)
         if (!event) return
         try {
           await client.deleteByVoyantId(options.collection, event.id)

--- a/packages/plugins/sanity-cms/src/plugin.ts
+++ b/packages/plugins/sanity-cms/src/plugin.ts
@@ -88,8 +88,8 @@ export function sanityCmsPlugin(options: SanityCmsPluginOptions): Plugin {
   const subscribers: Subscriber[] = [
     {
       event: eventNames.created,
-      handler: async (data) => {
-        const event = coerceEvent(data)
+      handler: async (envelope) => {
+        const event = coerceEvent(envelope.data)
         if (!event) return
         try {
           await client.upsertByVoyantId(options.documentType, event.id, mapEvent(event))
@@ -100,8 +100,8 @@ export function sanityCmsPlugin(options: SanityCmsPluginOptions): Plugin {
     },
     {
       event: eventNames.updated,
-      handler: async (data) => {
-        const event = coerceEvent(data)
+      handler: async (envelope) => {
+        const event = coerceEvent(envelope.data)
         if (!event) return
         try {
           await client.upsertByVoyantId(options.documentType, event.id, mapEvent(event))
@@ -112,8 +112,8 @@ export function sanityCmsPlugin(options: SanityCmsPluginOptions): Plugin {
     },
     {
       event: eventNames.deleted,
-      handler: async (data) => {
-        const event = coerceEvent(data)
+      handler: async (envelope) => {
+        const event = coerceEvent(envelope.data)
         if (!event) return
         try {
           await client.deleteByVoyantId(options.documentType, event.id)

--- a/packages/plugins/smartbill/src/plugin.ts
+++ b/packages/plugins/smartbill/src/plugin.ts
@@ -88,8 +88,8 @@ export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
   const subscribers: Subscriber[] = [
     {
       event: eventNames.issued,
-      handler: async (data) => {
-        const event = coerceEvent(data)
+      handler: async (envelope) => {
+        const event = coerceEvent(envelope.data)
         if (!event) return
         try {
           const body = mapEvent(event)
@@ -108,8 +108,8 @@ export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
     },
     {
       event: eventNames.voided,
-      handler: async (data) => {
-        const event = coerceEvent(data)
+      handler: async (envelope) => {
+        const event = coerceEvent(envelope.data)
         if (!event) return
         try {
           const seriesName =
@@ -138,8 +138,8 @@ export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
     },
     {
       event: eventNames.syncRequested,
-      handler: async (data) => {
-        const event = coerceEvent(data)
+      handler: async (envelope) => {
+        const event = coerceEvent(envelope.data)
         if (!event) return
         try {
           const seriesName =

--- a/packages/plugins/smartbill/tests/unit/plugin.test.ts
+++ b/packages/plugins/smartbill/tests/unit/plugin.test.ts
@@ -3,6 +3,14 @@ import { describe, expect, it, vi } from "vitest"
 import { smartbillPlugin } from "../../src/plugin.js"
 import type { SmartbillFetch } from "../../src/types.js"
 
+function eventEnvelope<T>(data: T) {
+  return {
+    name: "test.event",
+    data,
+    emittedAt: "2026-01-01T00:00:00.000Z",
+  }
+}
+
 function jsonResponse(status: number, body: unknown) {
   const text = JSON.stringify(body)
   return {
@@ -79,12 +87,14 @@ describe("smartbillPlugin — invoice.issued subscriber", () => {
     const plugin = smartbillPlugin({ ...baseOptions, fetch: fetchMock, logger })
     const handler = plugin.subscribers![0]!.handler
 
-    await handler({
-      id: "inv_123",
-      clientName: "Test SRL",
-      currency: "RON",
-      lineItems: [{ name: "Tour", quantity: 1, unitPrice: 50000 }],
-    })
+    await handler(
+      eventEnvelope({
+        id: "inv_123",
+        clientName: "Test SRL",
+        currency: "RON",
+        lineItems: [{ name: "Tour", quantity: 1, unitPrice: 50000 }],
+      }),
+    )
 
     expect(fetchMock).toHaveBeenCalledOnce()
     const [url, init] = fetchMock.mock.calls[0]!
@@ -104,7 +114,7 @@ describe("smartbillPlugin — invoice.issued subscriber", () => {
     const handler = plugin.subscribers![0]!.handler
 
     // Should not throw
-    await handler({ id: "inv_fail", lineItems: [] })
+    await handler(eventEnvelope({ id: "inv_fail", lineItems: [] }))
 
     expect(logger.error).toHaveBeenCalledOnce()
     expect(logger.error.mock.calls[0]![0]).toContain("createInvoice")
@@ -114,14 +124,14 @@ describe("smartbillPlugin — invoice.issued subscriber", () => {
   it("ignores null data", async () => {
     const fetchMock = vi.fn<SmartbillFetch>()
     const plugin = smartbillPlugin({ ...baseOptions, fetch: fetchMock })
-    await plugin.subscribers![0]!.handler(null)
+    await plugin.subscribers![0]!.handler(eventEnvelope(null))
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it("ignores data without id", async () => {
     const fetchMock = vi.fn<SmartbillFetch>()
     const plugin = smartbillPlugin({ ...baseOptions, fetch: fetchMock })
-    await plugin.subscribers![0]!.handler({ noId: true })
+    await plugin.subscribers![0]!.handler(eventEnvelope({ noId: true }))
     expect(fetchMock).not.toHaveBeenCalled()
   })
 })
@@ -133,11 +143,13 @@ describe("smartbillPlugin — invoice.voided subscriber", () => {
     const plugin = smartbillPlugin({ ...baseOptions, fetch: fetchMock, logger })
     const handler = plugin.subscribers![1]!.handler
 
-    await handler({
-      id: "inv_void",
-      externalSeriesName: "B",
-      externalNumber: "42",
-    })
+    await handler(
+      eventEnvelope({
+        id: "inv_void",
+        externalSeriesName: "B",
+        externalNumber: "42",
+      }),
+    )
 
     expect(fetchMock).toHaveBeenCalledOnce()
     const body = JSON.parse(fetchMock.mock.calls[0]![1].body ?? "{}")
@@ -155,7 +167,7 @@ describe("smartbillPlugin — invoice.voided subscriber", () => {
     const plugin = smartbillPlugin({ ...baseOptions, fetch: fetchMock, logger })
     const handler = plugin.subscribers![1]!.handler
 
-    await handler({ id: "inv_void2", invoiceNumber: "99" })
+    await handler(eventEnvelope({ id: "inv_void2", invoiceNumber: "99" }))
 
     const body = JSON.parse(fetchMock.mock.calls[0]![1].body ?? "{}")
     expect(body.seriesName).toBe("A") // falls back to options.seriesName
@@ -168,7 +180,7 @@ describe("smartbillPlugin — invoice.voided subscriber", () => {
     const plugin = smartbillPlugin({ ...baseOptions, fetch: fetchMock, logger })
     const handler = plugin.subscribers![1]!.handler
 
-    await handler({ id: "inv_no_num" })
+    await handler(eventEnvelope({ id: "inv_no_num" }))
 
     expect(fetchMock).not.toHaveBeenCalled()
     expect(logger.error).toHaveBeenCalledOnce()
@@ -181,7 +193,7 @@ describe("smartbillPlugin — invoice.voided subscriber", () => {
     const plugin = smartbillPlugin({ ...baseOptions, fetch: fetchMock, logger })
     const handler = plugin.subscribers![1]!.handler
 
-    await handler({ id: "inv_err", externalNumber: "1" })
+    await handler(eventEnvelope({ id: "inv_err", externalNumber: "1" }))
 
     expect(logger.error).toHaveBeenCalledOnce()
     expect(logger.error.mock.calls[0]![0]).toContain("cancelInvoice")
@@ -197,7 +209,7 @@ describe("smartbillPlugin — invoice.external.sync.requested subscriber", () =>
     const plugin = smartbillPlugin({ ...baseOptions, fetch: fetchMock, logger })
     const handler = plugin.subscribers![2]!.handler
 
-    await handler({ id: "inv_sync", externalNumber: "55" })
+    await handler(eventEnvelope({ id: "inv_sync", externalNumber: "55" }))
 
     expect(fetchMock).toHaveBeenCalledOnce()
     const [url] = fetchMock.mock.calls[0]!
@@ -212,7 +224,7 @@ describe("smartbillPlugin — invoice.external.sync.requested subscriber", () =>
     const plugin = smartbillPlugin({ ...baseOptions, fetch: fetchMock, logger })
     const handler = plugin.subscribers![2]!.handler
 
-    await handler({ id: "inv_no_num" })
+    await handler(eventEnvelope({ id: "inv_no_num" }))
 
     expect(fetchMock).not.toHaveBeenCalled()
     expect(logger.error).toHaveBeenCalledOnce()
@@ -225,7 +237,7 @@ describe("smartbillPlugin — invoice.external.sync.requested subscriber", () =>
     const plugin = smartbillPlugin({ ...baseOptions, fetch: fetchMock, logger })
     const handler = plugin.subscribers![2]!.handler
 
-    await handler({ id: "inv_err", externalNumber: "1" })
+    await handler(eventEnvelope({ id: "inv_err", externalNumber: "1" }))
 
     expect(logger.error).toHaveBeenCalledOnce()
     expect(logger.error.mock.calls[0]![0]).toContain("getPaymentStatus")
@@ -253,7 +265,7 @@ describe("smartbillPlugin — custom mapEvent", () => {
     })
     const handler = plugin.subscribers![0]!.handler
 
-    await handler({ id: "inv_custom" })
+    await handler(eventEnvelope({ id: "inv_custom" }))
 
     expect(customMapper).toHaveBeenCalledOnce()
     expect(customMapper.mock.calls[0]![0].id).toBe("inv_custom")


### PR DESCRIPTION
## Summary
- standardize the event bus around a structured event envelope
- update emitting services and plugin subscribers to use the new envelope shape
- refresh tests across core, hono, finance, legal, notifications, and sync plugins

## Testing
- pnpm -C packages/core test
- pnpm -C packages/plugins/smartbill test
- pnpm -C packages/plugins/payload-cms test
- pnpm -C packages/plugins/sanity-cms test
- pnpm -C packages/notifications test
- pnpm -C packages/finance test
- pnpm -C packages/legal test
- pnpm -C packages/hono test