### PR TITLE
Make link and query first-class Hono runtimes

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,8 +62,9 @@ export type {
   QueryGraphContext,
   QueryGraphResult,
   QueryPagination,
+  QueryRunner,
 } from "./query.js"
-export { createQueryContext, queryGraph } from "./query.js"
+export { createQueryContext, createQueryRunner, queryGraph } from "./query.js"
 export type { RegistryOptions } from "./registry.js"
 export { createRegistry } from "./registry.js"
 export type {

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -67,6 +67,14 @@ export interface QueryGraphResult {
   data: EntityRecord[]
 }
 
+/**
+ * Callable query runtime exposed to routes and workflows.
+ *
+ * It wraps a fixed {@link QueryGraphContext} so callers only supply the
+ * per-request graph config.
+ */
+export type QueryRunner = (config: QueryGraphConfig) => Promise<QueryGraphResult>
+
 export interface QueryGraphContext {
   /** Entity name → fetcher. */
   fetchers: Map<string, EntityFetcher>
@@ -85,6 +93,13 @@ export function createQueryContext(
   linkService: LinkService,
 ): QueryGraphContext {
   return { fetchers: new Map(Object.entries(fetchers)), links, linkService }
+}
+
+/**
+ * Wrap a fixed {@link QueryGraphContext} in a callable runtime.
+ */
+export function createQueryRunner(ctx: QueryGraphContext): QueryRunner {
+  return (config) => queryGraph(ctx, config)
 }
 
 interface RelationPlan {

--- a/packages/hono/src/app.ts
+++ b/packages/hono/src/app.ts
@@ -1,4 +1,4 @@
-import { createContainer, createEventBus } from "@voyantjs/core"
+import { createContainer, createEventBus, createQueryRunner } from "@voyantjs/core"
 import { Hono } from "hono"
 
 import { requireAuth } from "./middleware/auth.js"
@@ -38,6 +38,12 @@ export function createApp<TBindings extends VoyantBindings>(
   const allModules = [...(config.modules ?? []), ...(expanded?.modules ?? [])]
   const allExtensions = [...(config.extensions ?? []), ...(expanded?.extensions ?? [])]
   const eventBus = config.eventBus ?? createEventBus()
+  const query =
+    typeof config.query === "function"
+      ? config.query
+      : config.query
+        ? createQueryRunner(config.query)
+        : undefined
 
   // Module container — registered services are resolvable from routes
   const container = createContainer()
@@ -74,6 +80,12 @@ export function createApp<TBindings extends VoyantBindings>(
   app.use("*", async (c, next) => {
     c.set("container", container)
     c.set("eventBus", eventBus)
+    if (config.link) {
+      c.set("link", config.link)
+    }
+    if (query) {
+      c.set("query", query)
+    }
     await ensureRuntimeBootstrapped(c.env)
     return next()
   })

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -37,6 +37,7 @@ export type {
   VoyantBindings,
   VoyantDb,
   VoyantExecutionContext,
+  VoyantQueryRuntime,
   VoyantRequestAuthContext,
   VoyantVariables,
 } from "./types.js"

--- a/packages/hono/src/types.ts
+++ b/packages/hono/src/types.ts
@@ -1,7 +1,10 @@
 import type {
   VoyantVariables as CoreVoyantVariables,
   EventBus,
+  LinkService,
   ModuleContainer,
+  QueryGraphContext,
+  QueryRunner,
   VoyantAuthContext,
   VoyantPermission,
 } from "@voyantjs/core"
@@ -32,11 +35,17 @@ export interface VoyantBindings {
 }
 
 export type VoyantDb = PostgresJsDatabase | NeonHttpDatabase
+export type VoyantQueryRuntime = QueryRunner
+
 export type VoyantVariables = CoreVoyantVariables & {
   db: VoyantDb
   /** Shared app/runtime container for explicit service resolution. */
   container: ModuleContainer
   eventBus: EventBus
+  /** Shared cross-module link runtime, when the app wires one in. */
+  link?: LinkService
+  /** Shared cross-module query runtime, when the app wires one in. */
+  query?: VoyantQueryRuntime
 }
 
 export type DbFactory<TBindings extends VoyantBindings = VoyantBindings> = (
@@ -91,6 +100,8 @@ export interface VoyantAppConfig<TBindings extends VoyantBindings = VoyantBindin
   extensions?: HonoExtension[]
   plugins?: HonoPlugin[]
   eventBus?: EventBus
+  link?: LinkService
+  query?: QueryGraphContext | VoyantQueryRuntime
   auth?: VoyantAuthIntegration<TBindings>
   publicPaths?: string[]
   logger?: LoggerProvider

--- a/packages/hono/tests/unit/app-surfaces.test.ts
+++ b/packages/hono/tests/unit/app-surfaces.test.ts
@@ -1,6 +1,12 @@
-import type { Actor } from "@voyantjs/core"
+import {
+  type Actor,
+  createQueryContext,
+  defineLink,
+  type EntityFetcher,
+  type LinkService,
+} from "@voyantjs/core"
 import { Hono } from "hono"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import { createApp } from "../../src/app.js"
 import type { HonoModule } from "../../src/module.js"
@@ -149,5 +155,54 @@ describe("createApp surface mounting", () => {
     expect(res.status).toBe(200)
     const body = (await res.json()) as { status: string }
     expect(body.status).toBe("ok")
+  })
+
+  it("exposes caller-supplied link and query runtimes on the request context", async () => {
+    const person = { module: "crm", entity: "person", table: "people" }
+    const product = { module: "catalog", entity: "product", table: "products" }
+    const link = defineLink(person, { linkable: product, isList: true })
+    const linkService: LinkService = {
+      create: vi.fn(),
+      dismiss: vi.fn(),
+      delete: vi.fn(),
+      list: vi.fn(async () => []),
+      // biome-ignore lint/suspicious/noExplicitAny: LinkService has overloaded signatures
+    } as any
+    const fetcher: EntityFetcher = {
+      list: vi.fn(async () => [{ id: "pers_1", name: "Alice" }]),
+    }
+    const query = createQueryContext({ person: fetcher }, [link], linkService)
+
+    const app = createApp({
+      // biome-ignore lint/suspicious/noExplicitAny: test doesn't use db
+      db: () => ({}) as any,
+      link: linkService,
+      query,
+      modules: [
+        {
+          module: { name: "runtime" },
+          adminRoutes: new Hono().get("/inspect", async (c) => {
+            const rows = await c.var.link?.list(link.tableName, { leftId: "pers_1" })
+            const result = await c.var.query?.({ entity: "person", fields: ["id", "name"] })
+            return c.json({
+              hasLink: c.var.link === linkService,
+              rowCount: rows?.length ?? -1,
+              resultCount: result?.data.length ?? -1,
+            })
+          }),
+        },
+      ],
+      auth: { resolve: () => ({ userId: "u1", actor: "staff" }) },
+    })
+
+    const res = await app.request("/v1/admin/runtime/inspect", {}, TEST_ENV, TEST_CTX)
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({
+      hasLink: true,
+      rowCount: 0,
+      resultCount: 1,
+    })
+    expect(linkService.list).toHaveBeenCalledWith(link.tableName, { leftId: "pers_1" })
+    expect(fetcher.list).toHaveBeenCalledWith({ filters: undefined, pagination: undefined })
   })
 })


### PR DESCRIPTION
## Summary
- add a tiny core query runner helper for request/runtime use
- expose optional link and query runtimes on the Hono request context
- cover the new runtime surface with a focused Hono integration-style unit test

## Testing
- pnpm -C packages/core test
- pnpm -C packages/hono test
- pnpm -C packages/hono typecheck
- git push -u origin cleanup/link-query-runtime-primitives
