### PR TITLE
Add query context to cross-module reads

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,7 @@ export type {
   EntityFetcher,
   EntityFetcherArgs,
   EntityRecord,
+  QueryContextValue,
   QueryFilters,
   QueryGraphConfig,
   QueryGraphContext,

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -15,6 +15,8 @@ import type { LinkDefinition, LinkService } from "./links.js"
 
 /** Filters applied to the underlying entity fetcher. */
 export type QueryFilters = Record<string, unknown>
+/** Per-request hints threaded through cross-module reads. */
+export type QueryContextValue = Record<string, unknown>
 
 export interface QueryPagination {
   skip?: number
@@ -26,6 +28,7 @@ export interface EntityFetcherArgs {
   filters?: QueryFilters
   ids?: string[]
   pagination?: QueryPagination
+  context?: QueryContextValue
 }
 
 /**
@@ -61,6 +64,12 @@ export interface QueryGraphConfig {
   fields: string[]
   filters?: QueryFilters
   pagination?: QueryPagination
+  /**
+   * Per-request runtime hints such as locale, market, actor, or pricing
+   * context. The query planner passes this through unchanged to every
+   * participating entity fetcher.
+   */
+  context?: QueryContextValue
 }
 
 export interface QueryGraphResult {
@@ -163,7 +172,7 @@ export async function queryGraph(
   config: QueryGraphConfig,
 ): Promise<QueryGraphResult> {
   const { fetchers, links, linkService } = ctx
-  const { entity, fields, filters, pagination } = config
+  const { entity, fields, filters, pagination, context } = config
 
   const baseFetcher = fetchers.get(entity)
   if (!baseFetcher) {
@@ -171,7 +180,7 @@ export async function queryGraph(
   }
 
   const plans = parseRelations(fields)
-  const baseRecords = await baseFetcher.list({ filters, pagination })
+  const baseRecords = await baseFetcher.list({ filters, pagination, context })
   if (baseRecords.length === 0) return { data: [] }
 
   for (const { relation } of plans) {
@@ -213,7 +222,7 @@ export async function queryGraph(
     // Hydrate all target records in one call.
     const allTargetIds = unique(Array.from(idMap.values()).flat())
     const targetRecords =
-      allTargetIds.length > 0 ? await targetFetcher.list({ ids: allTargetIds }) : []
+      allTargetIds.length > 0 ? await targetFetcher.list({ ids: allTargetIds, context }) : []
     const byTargetId = new Map(targetRecords.map((r) => [r.id, r]))
 
     // Attach to each base record.

--- a/packages/core/tests/unit/query.test.ts
+++ b/packages/core/tests/unit/query.test.ts
@@ -123,6 +123,7 @@ describe("queryGraph — base fetch", () => {
     expect(fetcher.list).toHaveBeenCalledWith({
       filters: undefined,
       pagination: undefined,
+      context: undefined,
     })
   })
 
@@ -145,6 +146,24 @@ describe("queryGraph — base fetch", () => {
     expect(fetcher.list).toHaveBeenCalledWith({
       filters: { country: "FR" },
       pagination: { skip: 1, take: 1 },
+      context: undefined,
+    })
+  })
+
+  it("passes query context through to the base fetcher", async () => {
+    const fetcher = makeFetcher([{ id: "pers_a", name: "Alice" }])
+    const ctx = createQueryContext({ person: fetcher }, [], makeLinkService({}))
+
+    await queryGraph(ctx, {
+      entity: "person",
+      fields: ["id"],
+      context: { locale: "ro", market: "ro" },
+    })
+
+    expect(fetcher.list).toHaveBeenCalledWith({
+      filters: undefined,
+      pagination: undefined,
+      context: { locale: "ro", market: "ro" },
     })
   })
 
@@ -207,6 +226,30 @@ describe("queryGraph — relation traversal", () => {
     expect((alice?.product as EntityRecord[]).map((p) => p.id).sort()).toEqual(["prod_1", "prod_2"])
     expect(bob?.product as EntityRecord[]).toHaveLength(1)
     expect((bob?.product as EntityRecord[])[0]?.id).toBe("prod_3")
+  })
+
+  it("passes query context through to related entity hydration", async () => {
+    const personFetcher = makeFetcher([{ id: "pers_a", name: "Alice" }])
+    const productFetcher = makeFetcher([{ id: "prod_1", title: "Safari" }])
+    const linkService = makeLinkService({
+      [personProductLink.tableName]: [makeRow("lnk_1", "pers_a", "prod_1")],
+    })
+    const ctx = createQueryContext(
+      { person: personFetcher, product: productFetcher },
+      [personProductLink],
+      linkService,
+    )
+
+    await queryGraph(ctx, {
+      entity: "person",
+      fields: ["id", "product.*"],
+      context: { locale: "en", market: "uk" },
+    })
+
+    expect(productFetcher.list).toHaveBeenCalledWith({
+      ids: ["prod_1"],
+      context: { locale: "en", market: "uk" },
+    })
   })
 
   it("attaches an empty list when no links exist for a record", async () => {


### PR DESCRIPTION
## Summary
- let query graph calls carry an optional context object through base and linked fetchers
- expose the new QueryContextValue type from core
- cover context propagation in unit tests for both base and linked entity reads

## Testing
- pnpm -C packages/core test
- pnpm -C packages/core typecheck
- git diff --check
- full pre-push repo test pipeline
