### PR TITLE
Add support for read-only links

### DIFF
--- a/packages/core/src/links.ts
+++ b/packages/core/src/links.ts
@@ -54,6 +54,16 @@ export interface LinkDefinitionOptions {
     /** Override the auto-generated right-side ID column name. */
     rightColumn?: string
   }
+  /**
+   * Mark the link as externally-owned and non-materialized.
+   *
+   * Read-only links participate in cross-module query traversal, but they do
+   * not create a neutral-territory pivot table and cannot be mutated through
+   * the runtime link service.
+   */
+  readOnly?: {
+    list(filter?: { leftId?: string; rightId?: string }): Promise<LinkRow[]>
+  }
 }
 
 export type LinkCardinality = "one-to-one" | "one-to-many" | "many-to-one" | "many-to-many"
@@ -74,6 +84,13 @@ export interface LinkDefinition {
   /** Inferred cardinality from the `isList` flags on each side. */
   cardinality: LinkCardinality
   deleteCascade: boolean
+  /**
+   * Read-only links are resolved from an externally-owned relation instead of
+   * a generated pivot table.
+   */
+  readOnly?: {
+    list(filter?: { leftId?: string; rightId?: string }): Promise<LinkRow[]>
+  }
 }
 
 /**
@@ -124,6 +141,7 @@ export function defineLink(
     rightColumn,
     cardinality: cardinalityFor(leftSide, rightSide),
     deleteCascade: options?.deleteCascade ?? false,
+    readOnly: options?.readOnly,
   }
 }
 
@@ -167,6 +185,12 @@ export interface LinkTableSql {
  * link's cardinality so the database enforces the relationship shape.
  */
 export function generateLinkTableSql(def: LinkDefinition): LinkTableSql {
+  if (def.readOnly) {
+    throw new Error(
+      `generateLinkTableSql: read-only link "${def.tableName}" is externally owned and does not materialize a pivot table`,
+    )
+  }
+
   const { tableName, leftColumn, rightColumn } = def
 
   const createTable = [

--- a/packages/core/tests/unit/links.test.ts
+++ b/packages/core/tests/unit/links.test.ts
@@ -93,6 +93,14 @@ describe("defineLink", () => {
     expect(a.cardinality).toBe("one-to-one")
     expect(b.cardinality).toBe("one-to-one")
   })
+
+  it("supports read-only links backed by an external resolver", () => {
+    const list = async () => []
+    const def = defineLink(person, product, {
+      readOnly: { list },
+    })
+    expect(def.readOnly?.list).toBe(list)
+  })
 })
 
 describe("generateLinkTableSql", () => {
@@ -176,6 +184,13 @@ describe("generateLinkTableSql", () => {
     const uniques = indexes.filter((s) => s.startsWith("CREATE UNIQUE INDEX"))
     expect(uniques.length).toBe(1)
     expect(uniques[0]).toContain("_pair_idx")
+  })
+
+  it("throws for read-only links because no pivot table should be materialized", () => {
+    const def = defineLink(person, product, {
+      readOnly: { list: async () => [] },
+    })
+    expect(() => generateLinkTableSql(def)).toThrow(/read-only link/)
   })
 })
 

--- a/packages/db/src/links.ts
+++ b/packages/db/src/links.ts
@@ -146,6 +146,9 @@ export function createLinkService(
 
   async function dismissImpl(spec: ResolvedLinkSpec): Promise<void> {
     const { definition: def, leftId, rightId } = spec
+    if (def.readOnly) {
+      throw new Error(`createLinkService: read-only link "${def.tableName}" cannot be dismissed`)
+    }
     const table = sql.identifier(def.tableName)
     const leftCol = sql.identifier(def.leftColumn)
     const rightCol = sql.identifier(def.rightColumn)
@@ -157,6 +160,9 @@ export function createLinkService(
 
   async function deleteImpl(spec: ResolvedLinkSpec): Promise<void> {
     const { definition: def, leftId, rightId } = spec
+    if (def.readOnly) {
+      throw new Error(`createLinkService: read-only link "${def.tableName}" cannot be deleted`)
+    }
     const table = sql.identifier(def.tableName)
     const leftCol = sql.identifier(def.leftColumn)
     const rightCol = sql.identifier(def.rightColumn)
@@ -170,6 +176,10 @@ export function createLinkService(
     filter: { leftId?: string; rightId?: string } = {},
   ): Promise<LinkRow[]> {
     const def = lookupByKey(linkKey)
+    if (def.readOnly) {
+      return def.readOnly.list(filter)
+    }
+
     const table = sql.identifier(def.tableName)
     const leftCol = sql.identifier(def.leftColumn)
     const rightCol = sql.identifier(def.rightColumn)
@@ -193,7 +203,13 @@ export function createLinkService(
 
   return {
     async create(keyOrSpec: string | LinkSpec, leftId?: string, rightId?: string) {
-      return createImpl(resolveArgs(keyOrSpec, leftId, rightId))
+      const spec = resolveArgs(keyOrSpec, leftId, rightId)
+      if (spec.definition.readOnly) {
+        throw new Error(
+          `createLinkService: read-only link "${spec.definition.tableName}" cannot be created`,
+        )
+      }
+      return createImpl(spec)
     },
     async dismiss(keyOrSpec: string | LinkSpec, leftId?: string, rightId?: string) {
       return dismissImpl(resolveArgs(keyOrSpec, leftId, rightId))
@@ -213,6 +229,7 @@ export function createLinkService(
  */
 export async function syncLinks(db: DrizzleClient, definitions: LinkDefinition[]): Promise<void> {
   for (const def of definitions) {
+    if (def.readOnly) continue
     const { createTable, indexes } = generateLinkTableSql(def)
     // biome-ignore lint/suspicious/noExplicitAny: drizzle adapter execute typing varies
     await (db as any).execute(sql.raw(createTable))

--- a/packages/db/tests/unit/links.test.ts
+++ b/packages/db/tests/unit/links.test.ts
@@ -1,0 +1,73 @@
+import { defineLink, type LinkableDefinition, type LinkRow } from "@voyantjs/core"
+import { describe, expect, it, vi } from "vitest"
+
+import { createLinkService, syncLinks } from "../../src/links.js"
+
+const person: LinkableDefinition = {
+  module: "crm",
+  entity: "person",
+  table: "people",
+  idPrefix: "pers",
+}
+
+const product: LinkableDefinition = {
+  module: "products",
+  entity: "product",
+  table: "products",
+  idPrefix: "prod",
+}
+
+function makeRow(id: string, leftId: string, rightId: string): LinkRow {
+  const now = new Date()
+  return {
+    id,
+    leftId,
+    rightId,
+    createdAt: now,
+    updatedAt: now,
+    deletedAt: null,
+  }
+}
+
+describe("read-only links", () => {
+  it("lists rows from the externally-owned resolver", async () => {
+    const list = vi.fn(async () => [makeRow("lnk_1", "pers_a", "prod_1")])
+    const link = defineLink(person, { linkable: product, isList: true }, { readOnly: { list } })
+    const svc = createLinkService(() => ({ execute: vi.fn() }) as never, [link])
+
+    const rows = await svc.list(link.tableName, { leftId: "pers_a" })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.rightId).toBe("prod_1")
+    expect(list).toHaveBeenCalledWith({ leftId: "pers_a" })
+  })
+
+  it("rejects mutations against read-only links", async () => {
+    const link = defineLink(person, product, {
+      readOnly: { list: async () => [] },
+    })
+    const svc = createLinkService(() => ({ execute: vi.fn() }) as never, [link])
+
+    await expect(svc.create(link.tableName, "pers_a", "prod_1")).rejects.toThrow(/read-only link/)
+    await expect(svc.dismiss(link.tableName, "pers_a", "prod_1")).rejects.toThrow(/read-only link/)
+    await expect(svc.delete(link.tableName, "pers_a", "prod_1")).rejects.toThrow(/read-only link/)
+  })
+
+  it("skips read-only links during sync", async () => {
+    const execute = vi.fn()
+    const db = { execute } as never
+    const managed = defineLink(person, product)
+    const readOnly = defineLink(
+      person,
+      { linkable: product, isList: true },
+      {
+        database: { tableName: "crm_person_products_product_read_only" },
+        readOnly: { list: async () => [] },
+      },
+    )
+
+    await syncLinks(db, [managed, readOnly])
+
+    expect(execute).toHaveBeenCalledTimes(4)
+  })
+})


### PR DESCRIPTION
## Summary
- allow link definitions to be backed by an externally-owned read-only resolver
- skip read-only links during link-table materialization and reject runtime mutations against them
- add focused core/db test coverage for read-only link definitions and service behavior

## Testing
- pnpm -C packages/core test
- pnpm -C packages/db test
- pnpm -C packages/core typecheck
- pnpm -C packages/db typecheck
- git diff --check
- full pre-push repo test pipeline
