### PR TITLE
Add Hono request validation helpers

### DIFF
--- a/packages/extras/src/routes.ts
+++ b/packages/extras/src/routes.ts
@@ -1,3 +1,4 @@
+import { parseJsonBody, parseQuery } from "@voyantjs/hono"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
 
@@ -23,9 +24,7 @@ type Env = {
 
 export const extrasRoutes = new Hono<Env>()
   .get("/product-extras", async (c) => {
-    const query = productExtraListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, productExtraListQuerySchema)
     return c.json(await extrasService.listProductExtras(c.get("db"), query))
   })
   .post("/product-extras", async (c) => {
@@ -33,7 +32,7 @@ export const extrasRoutes = new Hono<Env>()
       {
         data: await extrasService.createProductExtra(
           c.get("db"),
-          insertProductExtraSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertProductExtraSchema),
         ),
       },
       201,
@@ -48,7 +47,7 @@ export const extrasRoutes = new Hono<Env>()
     const row = await extrasService.updateProductExtra(
       c.get("db"),
       c.req.param("id"),
-      updateProductExtraSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateProductExtraSchema),
     )
     if (!row) return c.json({ error: "Product extra not found" }, 404)
     return c.json({ data: row })
@@ -59,9 +58,7 @@ export const extrasRoutes = new Hono<Env>()
     return c.json({ success: true })
   })
   .get("/option-extra-configs", async (c) => {
-    const query = optionExtraConfigListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, optionExtraConfigListQuerySchema)
     return c.json(await extrasService.listOptionExtraConfigs(c.get("db"), query))
   })
   .post("/option-extra-configs", async (c) => {
@@ -69,7 +66,7 @@ export const extrasRoutes = new Hono<Env>()
       {
         data: await extrasService.createOptionExtraConfig(
           c.get("db"),
-          insertOptionExtraConfigSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertOptionExtraConfigSchema),
         ),
       },
       201,
@@ -84,7 +81,7 @@ export const extrasRoutes = new Hono<Env>()
     const row = await extrasService.updateOptionExtraConfig(
       c.get("db"),
       c.req.param("id"),
-      updateOptionExtraConfigSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateOptionExtraConfigSchema),
     )
     if (!row) return c.json({ error: "Option extra config not found" }, 404)
     return c.json({ data: row })
@@ -95,9 +92,7 @@ export const extrasRoutes = new Hono<Env>()
     return c.json({ success: true })
   })
   .get("/booking-extras", async (c) => {
-    const query = bookingExtraListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, bookingExtraListQuerySchema)
     return c.json(await extrasService.listBookingExtras(c.get("db"), query))
   })
   .post("/booking-extras", async (c) => {
@@ -105,7 +100,7 @@ export const extrasRoutes = new Hono<Env>()
       {
         data: await extrasService.createBookingExtra(
           c.get("db"),
-          insertBookingExtraSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertBookingExtraSchema),
         ),
       },
       201,
@@ -120,7 +115,7 @@ export const extrasRoutes = new Hono<Env>()
     const row = await extrasService.updateBookingExtra(
       c.get("db"),
       c.req.param("id"),
-      updateBookingExtraSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateBookingExtraSchema),
     )
     if (!row) return c.json({ error: "Booking extra not found" }, 404)
     return c.json({ data: row })

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -36,7 +36,8 @@
     "@voyantjs/types": "workspace:*",
     "@voyantjs/utils": "workspace:*",
     "drizzle-orm": "^0.45.2",
-    "hono": "^4.12.10"
+    "hono": "^4.12.10",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260403.1",

--- a/packages/hono/src/app.ts
+++ b/packages/hono/src/app.ts
@@ -4,7 +4,7 @@ import { Hono } from "hono"
 import { requireAuth } from "./middleware/auth.js"
 import { cors } from "./middleware/cors.js"
 import { db } from "./middleware/db.js"
-import { errorBoundary, requestId } from "./middleware/error-boundary.js"
+import { handleApiError, requestId } from "./middleware/error-boundary.js"
 import { logger } from "./middleware/logger.js"
 import { requireActor } from "./middleware/require-actor.js"
 import { expandHonoPlugins } from "./plugin.js"
@@ -32,6 +32,7 @@ export function createApp<TBindings extends VoyantBindings>(
   config: VoyantAppConfig<TBindings>,
 ): Hono<{ Bindings: TBindings; Variables: VoyantVariables }> {
   const app = new Hono<{ Bindings: TBindings; Variables: VoyantVariables }>()
+  app.onError(handleApiError)
 
   // Expand plugins into their constituent modules/extensions before mounting
   const expanded = config.plugins ? expandHonoPlugins(config.plugins) : null
@@ -95,9 +96,6 @@ export function createApp<TBindings extends VoyantBindings>(
 
   // Structured logger
   app.use("*", logger(config.logger))
-
-  // Global error boundary
-  app.use("*", errorBoundary)
 
   // CORS (allowlist via env CORS_ALLOWLIST)
   app.use("*", cors())

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -15,6 +15,7 @@ export {
   cors,
   db,
   errorBoundary,
+  handleApiError,
   LIVE_LIMITS,
   logger,
   rateLimit,
@@ -41,3 +42,9 @@ export type {
   VoyantRequestAuthContext,
   VoyantVariables,
 } from "./types.js"
+export {
+  normalizeValidationError,
+  parseJsonBody,
+  parseQuery,
+  RequestValidationError,
+} from "./validation.js"

--- a/packages/hono/src/middleware/error-boundary.ts
+++ b/packages/hono/src/middleware/error-boundary.ts
@@ -1,5 +1,7 @@
 import { apiErrorSchema } from "@voyantjs/types"
-import type { MiddlewareHandler } from "hono"
+import type { Context, MiddlewareHandler } from "hono"
+
+import { normalizeValidationError } from "../validation.js"
 
 function generateRequestId(): string {
   const bytes = new Uint8Array(16)
@@ -18,39 +20,61 @@ export const requestId: MiddlewareHandler = async (c, next) => {
 
 const REDACT_HEADERS = new Set(["authorization", "x-api-key"])
 
+export function handleApiError(err: unknown, c: Context): Response {
+  const id = c.res.headers.get("X-Request-Id") || generateRequestId()
+  const validationError = normalizeValidationError(err)
+  const errRecord = err instanceof Object ? (err as Record<string, unknown>) : {}
+  const code =
+    validationError?.code ?? (typeof errRecord.code === "string" ? errRecord.code : undefined)
+  const status =
+    validationError?.status ?? (typeof errRecord.status === "number" ? errRecord.status : 500)
+  const details =
+    validationError?.details ??
+    (status < 500 && errRecord.details && typeof errRecord.details === "object"
+      ? (errRecord.details as Record<string, unknown>)
+      : undefined)
+  const errorMessage =
+    status < 500
+      ? (validationError?.message ??
+        (typeof errRecord.message === "string" ? errRecord.message : "Bad Request"))
+      : "Internal Server Error"
+
+  try {
+    const headers: Record<string, string> = {}
+    c.req.raw.headers.forEach((value, key) => {
+      const lowerKey = key.toLowerCase()
+      headers[lowerKey] = REDACT_HEADERS.has(lowerKey) ? "[redacted]" : value
+    })
+
+    console.error("[API:error]", {
+      id,
+      status,
+      code,
+      path: c.req.path,
+      method: c.req.method,
+      headers,
+      err: err instanceof Error ? err.message : String(err),
+    })
+  } catch {
+    /* ignore logging errors */
+  }
+
+  const statusCode = status >= 100 && status <= 599 ? status : 500
+  return new Response(
+    JSON.stringify(apiErrorSchema.parse({ error: errorMessage, code, requestId: id, details })),
+    {
+      status: statusCode,
+      headers: {
+        "content-type": "application/json",
+      },
+    },
+  )
+}
+
 export const errorBoundary: MiddlewareHandler = async (c, next) => {
   try {
     await next()
   } catch (err: unknown) {
-    const id = c.res.headers.get("X-Request-Id") || generateRequestId()
-    const errRecord = err instanceof Object ? (err as Record<string, unknown>) : {}
-    const code = typeof errRecord.code === "string" ? errRecord.code : undefined
-    const status = typeof errRecord.status === "number" ? errRecord.status : 500
-
-    try {
-      const headers: Record<string, string> = {}
-      c.req.raw.headers.forEach((value, key) => {
-        const lowerKey = key.toLowerCase()
-        headers[lowerKey] = REDACT_HEADERS.has(lowerKey) ? "[redacted]" : value
-      })
-
-      console.error("[API:error]", {
-        id,
-        status,
-        code,
-        path: c.req.path,
-        method: c.req.method,
-        headers,
-        err: err instanceof Error ? err.message : String(err),
-      })
-    } catch {
-      /* ignore logging errors */
-    }
-
-    const statusCode = (status >= 100 && status <= 599 ? status : 500) as 500
-    return c.json(
-      apiErrorSchema.parse({ error: "Internal Server Error", code, requestId: id }),
-      statusCode,
-    )
+    return handleApiError(err, c)
   }
 }

--- a/packages/hono/src/middleware/index.ts
+++ b/packages/hono/src/middleware/index.ts
@@ -1,7 +1,7 @@
 export { requireAuth } from "./auth.js"
 export { cors } from "./cors.js"
 export { db } from "./db.js"
-export { errorBoundary, requestId } from "./error-boundary.js"
+export { errorBoundary, handleApiError, requestId } from "./error-boundary.js"
 export { consoleLoggerProvider, logger } from "./logger.js"
 export { LIVE_LIMITS, rateLimit } from "./rate-limit.js"
 export { requireActor } from "./require-actor.js"

--- a/packages/hono/src/validation.ts
+++ b/packages/hono/src/validation.ts
@@ -1,0 +1,73 @@
+import type { Context } from "hono"
+import { ZodError, type ZodType } from "zod"
+
+export class RequestValidationError extends Error {
+  readonly status = 400
+  readonly code = "invalid_request"
+  readonly details?: Record<string, unknown>
+
+  constructor(message: string, details?: Record<string, unknown>) {
+    super(message)
+    this.name = "RequestValidationError"
+    this.details = details
+  }
+}
+
+function toValidationError(
+  error: ZodError,
+  fallbackMessage = "Invalid request",
+): RequestValidationError {
+  return new RequestValidationError(error.issues[0]?.message ?? fallbackMessage, {
+    issues: error.issues,
+    fields: error.flatten(),
+  })
+}
+
+function validate<T>(schema: ZodType<T>, input: unknown, fallbackMessage?: string): T {
+  const parsed = schema.safeParse(input)
+  if (!parsed.success) {
+    throw toValidationError(parsed.error, fallbackMessage)
+  }
+
+  return parsed.data
+}
+
+export async function parseJsonBody<T>(
+  c: Context,
+  schema: ZodType<T>,
+  options?: { invalidJsonMessage?: string; invalidBodyMessage?: string },
+): Promise<T> {
+  let input: unknown
+
+  try {
+    input = await c.req.json()
+  } catch {
+    throw new RequestValidationError(options?.invalidJsonMessage ?? "Invalid JSON body")
+  }
+
+  return validate(schema, input, options?.invalidBodyMessage)
+}
+
+export function parseQuery<T>(
+  c: Context,
+  schema: ZodType<T>,
+  options?: { invalidQueryMessage?: string },
+): T {
+  return validate(
+    schema,
+    Object.fromEntries(new URL(c.req.url).searchParams),
+    options?.invalidQueryMessage ?? "Invalid query parameters",
+  )
+}
+
+export function normalizeValidationError(error: unknown): RequestValidationError | undefined {
+  if (error instanceof RequestValidationError) {
+    return error
+  }
+
+  if (error instanceof ZodError) {
+    return toValidationError(error)
+  }
+
+  return undefined
+}

--- a/packages/hono/tests/unit/validation.test.ts
+++ b/packages/hono/tests/unit/validation.test.ts
@@ -1,0 +1,62 @@
+import { Hono } from "hono"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { z } from "zod"
+
+import { handleApiError, requestId } from "../../src/middleware/error-boundary.js"
+import { parseJsonBody, parseQuery } from "../../src/validation.js"
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("validation helpers", () => {
+  it("returns a structured 400 for invalid query parameters", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const app = new Hono()
+    app.onError(handleApiError)
+    app.use("*", requestId)
+    app.get("/search", (c) => {
+      const query = parseQuery(c, z.object({ limit: z.coerce.number().int().positive() }))
+      return c.json({ limit: query.limit })
+    })
+
+    const response = await app.request("http://example.com/search?limit=nope")
+    expect(response.status).toBe(400)
+    expect(await response.json()).toMatchObject({
+      error: "Invalid input: expected number, received NaN",
+      code: "invalid_request",
+      details: {
+        fields: {
+          fieldErrors: {
+            limit: expect.any(Array),
+          },
+          formErrors: [],
+        },
+      },
+    })
+  })
+
+  it("returns a structured 400 for invalid JSON bodies", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const app = new Hono()
+    app.onError(handleApiError)
+    app.use("*", requestId)
+    app.post("/search", async (c) => {
+      const body = await parseJsonBody(c, z.object({ name: z.string().min(2) }))
+      return c.json({ name: body.name })
+    })
+
+    const response = await app.request("http://example.com/search", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{invalid-json",
+    })
+    expect(response.status).toBe(400)
+    expect(await response.json()).toMatchObject({
+      error: "Invalid JSON body",
+      code: "invalid_request",
+    })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1461,6 +1461,9 @@ importers:
       hono:
         specifier: ^4.12.10
         version: 4.12.10
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20260403.1


### PR DESCRIPTION
## Summary
- add shared Hono helpers for JSON body and query parsing
- route validation failures through a structured Hono onError handler
- migrate extras routes to the new helpers as the first consumer

## Testing
- pnpm -C packages/hono test
- pnpm -C packages/hono typecheck
- pnpm -C packages/extras typecheck
- pnpm -C packages/hono build
- pnpm -C packages/extras build