### PR TITLE
Add shared user route auth helper

### DIFF
--- a/packages/customer-portal/src/routes-public.ts
+++ b/packages/customer-portal/src/routes-public.ts
@@ -1,4 +1,4 @@
-import { parseJsonBody } from "@voyantjs/hono"
+import { parseJsonBody, requireUserId } from "@voyantjs/hono"
 import { createKmsProviderFromEnv } from "@voyantjs/utils"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { type Context, Hono } from "hono"
@@ -38,10 +38,6 @@ function resolveOptionalKms(c: Context<Env>) {
   }
 }
 
-function unauthorized<T extends Env>(c: Context<T>) {
-  return c.json({ error: "Unauthorized" }, 401)
-}
-
 function notFound<T extends Env>(c: Context<T>, error: string) {
   return c.json({ error }, 404)
 }
@@ -62,10 +58,7 @@ function hasBootstrapErrorResult(
 
 export const publicCustomerPortalRoutes = new Hono<Env>()
   .get("/me", async (c) => {
-    const userId = c.get("userId")
-    if (!userId) {
-      return unauthorized(c)
-    }
+    const userId = requireUserId(c)
 
     const profile = await publicCustomerPortalService.getProfileWithOptions(c.get("db"), userId, {
       kms: resolveOptionalKms(c),
@@ -73,10 +66,7 @@ export const publicCustomerPortalRoutes = new Hono<Env>()
     return profile ? c.json({ data: profile }) : notFound(c, "Customer profile not found")
   })
   .patch("/me", async (c) => {
-    const userId = c.get("userId")
-    if (!userId) {
-      return unauthorized(c)
-    }
+    const userId = requireUserId(c)
 
     const result = await publicCustomerPortalService.updateProfileWithOptions(
       c.get("db"),
@@ -98,10 +88,7 @@ export const publicCustomerPortalRoutes = new Hono<Env>()
     return c.json({ data: result.profile })
   })
   .post("/bootstrap", async (c) => {
-    const userId = c.get("userId")
-    if (!userId) {
-      return unauthorized(c)
-    }
+    const userId = requireUserId(c)
 
     const result = await publicCustomerPortalService.bootstrap(
       c.get("db"),
@@ -128,18 +115,12 @@ export const publicCustomerPortalRoutes = new Hono<Env>()
     return c.json({ data: result })
   })
   .get("/companions", async (c) => {
-    const userId = c.get("userId")
-    if (!userId) {
-      return unauthorized(c)
-    }
+    const userId = requireUserId(c)
 
     return c.json({ data: await publicCustomerPortalService.listCompanions(c.get("db"), userId) })
   })
   .post("/companions", async (c) => {
-    const userId = c.get("userId")
-    if (!userId) {
-      return unauthorized(c)
-    }
+    const userId = requireUserId(c)
 
     const companion = await publicCustomerPortalService.createCompanion(
       c.get("db"),
@@ -154,10 +135,7 @@ export const publicCustomerPortalRoutes = new Hono<Env>()
     return c.json({ data: companion }, 201)
   })
   .post("/companions/import-booking-participants", async (c) => {
-    const userId = c.get("userId")
-    if (!userId) {
-      return unauthorized(c)
-    }
+    const userId = requireUserId(c)
 
     const result = await publicCustomerPortalService.importBookingParticipantsAsCompanions(
       c.get("db"),
@@ -172,10 +150,7 @@ export const publicCustomerPortalRoutes = new Hono<Env>()
     return c.json({ data: result })
   })
   .patch("/companions/:companionId", async (c) => {
-    const userId = c.get("userId")
-    if (!userId) {
-      return unauthorized(c)
-    }
+    const userId = requireUserId(c)
 
     const companion = await publicCustomerPortalService.updateCompanion(
       c.get("db"),
@@ -195,10 +170,7 @@ export const publicCustomerPortalRoutes = new Hono<Env>()
     return c.json({ data: companion })
   })
   .delete("/companions/:companionId", async (c) => {
-    const userId = c.get("userId")
-    if (!userId) {
-      return unauthorized(c)
-    }
+    const userId = requireUserId(c)
 
     const result = await publicCustomerPortalService.deleteCompanion(
       c.get("db"),
@@ -217,19 +189,13 @@ export const publicCustomerPortalRoutes = new Hono<Env>()
     return c.json({ success: true })
   })
   .get("/bookings", async (c) => {
-    const userId = c.get("userId")
-    if (!userId) {
-      return unauthorized(c)
-    }
+    const userId = requireUserId(c)
 
     const bookings = await publicCustomerPortalService.listBookings(c.get("db"), userId)
     return bookings ? c.json({ data: bookings }) : notFound(c, "Customer profile not found")
   })
   .get("/bookings/:bookingId", async (c) => {
-    const userId = c.get("userId")
-    if (!userId) {
-      return unauthorized(c)
-    }
+    const userId = requireUserId(c)
 
     const booking = await publicCustomerPortalService.getBooking(
       c.get("db"),
@@ -240,10 +206,7 @@ export const publicCustomerPortalRoutes = new Hono<Env>()
     return booking ? c.json({ data: booking }) : notFound(c, "Booking not found")
   })
   .get("/bookings/:bookingId/documents", async (c) => {
-    const userId = c.get("userId")
-    if (!userId) {
-      return unauthorized(c)
-    }
+    const userId = requireUserId(c)
 
     const documents = await publicCustomerPortalService.listBookingDocuments(
       c.get("db"),
@@ -254,10 +217,7 @@ export const publicCustomerPortalRoutes = new Hono<Env>()
     return documents ? c.json({ data: documents }) : notFound(c, "Booking not found")
   })
   .get("/bookings/:bookingId/billing-contact", async (c) => {
-    const userId = c.get("userId")
-    if (!userId) {
-      return unauthorized(c)
-    }
+    const userId = requireUserId(c)
 
     const billingContact = await publicCustomerPortalService.getBookingBillingContact(
       c.get("db"),

--- a/packages/hono/src/auth/index.ts
+++ b/packages/hono/src/auth/index.ts
@@ -5,5 +5,6 @@ export {
   sha256Hex,
   unsignCookie,
 } from "./crypto.js"
+export { requireUserId } from "./require-user.js"
 export type { SessionAuthContext } from "./session-jwt.js"
 export { extractBearerToken, verifySession } from "./session-jwt.js"

--- a/packages/hono/src/auth/require-user.ts
+++ b/packages/hono/src/auth/require-user.ts
@@ -1,0 +1,12 @@
+import type { Context } from "hono"
+
+import { UnauthorizedApiError } from "../validation.js"
+
+export function requireUserId(c: Context): string {
+  const userId = c.get("userId")
+  if (!userId) {
+    throw new UnauthorizedApiError()
+  }
+
+  return userId
+}

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -5,6 +5,7 @@ export {
   extractBearerToken,
   generateNumericCode,
   randomBytesHex,
+  requireUserId,
   sha256Base64Url,
   sha256Hex,
   unsignCookie,
@@ -43,8 +44,10 @@ export type {
   VoyantVariables,
 } from "./types.js"
 export {
+  ApiHttpError,
   normalizeValidationError,
   parseJsonBody,
   parseQuery,
   RequestValidationError,
+  UnauthorizedApiError,
 } from "./validation.js"

--- a/packages/hono/src/middleware/error-boundary.ts
+++ b/packages/hono/src/middleware/error-boundary.ts
@@ -22,20 +22,18 @@ const REDACT_HEADERS = new Set(["authorization", "x-api-key"])
 
 export function handleApiError(err: unknown, c: Context): Response {
   const id = c.res.headers.get("X-Request-Id") || generateRequestId()
-  const validationError = normalizeValidationError(err)
+  const apiError = normalizeValidationError(err)
   const errRecord = err instanceof Object ? (err as Record<string, unknown>) : {}
-  const code =
-    validationError?.code ?? (typeof errRecord.code === "string" ? errRecord.code : undefined)
-  const status =
-    validationError?.status ?? (typeof errRecord.status === "number" ? errRecord.status : 500)
+  const code = apiError?.code ?? (typeof errRecord.code === "string" ? errRecord.code : undefined)
+  const status = apiError?.status ?? (typeof errRecord.status === "number" ? errRecord.status : 500)
   const details =
-    validationError?.details ??
+    apiError?.details ??
     (status < 500 && errRecord.details && typeof errRecord.details === "object"
       ? (errRecord.details as Record<string, unknown>)
       : undefined)
   const errorMessage =
     status < 500
-      ? (validationError?.message ??
+      ? (apiError?.message ??
         (typeof errRecord.message === "string" ? errRecord.message : "Bad Request"))
       : "Internal Server Error"
 

--- a/packages/hono/src/validation.ts
+++ b/packages/hono/src/validation.ts
@@ -1,15 +1,45 @@
 import type { Context } from "hono"
 import { ZodError, type ZodType } from "zod"
 
-export class RequestValidationError extends Error {
-  readonly status = 400
-  readonly code = "invalid_request"
+export class ApiHttpError extends Error {
+  readonly status: number
+  readonly code?: string
   readonly details?: Record<string, unknown>
 
-  constructor(message: string, details?: Record<string, unknown>) {
+  constructor(
+    message: string,
+    options: {
+      status: number
+      code?: string
+      details?: Record<string, unknown>
+    },
+  ) {
     super(message)
+    this.name = "ApiHttpError"
+    this.status = options.status
+    this.code = options.code
+    this.details = options.details
+  }
+}
+
+export class RequestValidationError extends ApiHttpError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super(message, {
+      status: 400,
+      code: "invalid_request",
+      details,
+    })
     this.name = "RequestValidationError"
-    this.details = details
+  }
+}
+
+export class UnauthorizedApiError extends ApiHttpError {
+  constructor(message = "Unauthorized") {
+    super(message, {
+      status: 401,
+      code: "unauthorized",
+    })
+    this.name = "UnauthorizedApiError"
   }
 }
 
@@ -60,8 +90,8 @@ export function parseQuery<T>(
   )
 }
 
-export function normalizeValidationError(error: unknown): RequestValidationError | undefined {
-  if (error instanceof RequestValidationError) {
+export function normalizeValidationError(error: unknown): ApiHttpError | undefined {
+  if (error instanceof ApiHttpError) {
     return error
   }
 

--- a/packages/hono/tests/unit/validation.test.ts
+++ b/packages/hono/tests/unit/validation.test.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { z } from "zod"
 
+import { requireUserId } from "../../src/auth/require-user.js"
 import { handleApiError, requestId } from "../../src/middleware/error-boundary.js"
 import { parseJsonBody, parseQuery } from "../../src/validation.js"
 
@@ -57,6 +58,25 @@ describe("validation helpers", () => {
     expect(await response.json()).toMatchObject({
       error: "Invalid JSON body",
       code: "invalid_request",
+    })
+  })
+
+  it("returns a structured 401 when a route requires a user id", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const app = new Hono()
+    app.onError(handleApiError)
+    app.use("*", requestId)
+    app.get("/me", (c) => {
+      const userId = requireUserId(c)
+      return c.json({ userId })
+    })
+
+    const response = await app.request("http://example.com/me")
+    expect(response.status).toBe(401)
+    expect(await response.json()).toMatchObject({
+      error: "Unauthorized",
+      code: "unauthorized",
     })
   })
 })


### PR DESCRIPTION
## Summary
- add a shared Hono helper for routes that require an authenticated user id
- promote request validation errors onto a general API HTTP error shape and add a 401 unauthorized variant
- adopt the helper across the public customer portal routes to remove repeated auth boilerplate

## Testing
- pnpm -C packages/hono test
- pnpm -C packages/hono typecheck
- pnpm -C packages/hono build
- pnpm -C packages/customer-portal test
- pnpm -C packages/customer-portal typecheck
- pnpm -C packages/customer-portal build