### PR TITLE
Adopt shared user auth in mutation routes

### DIFF
--- a/packages/bookings/src/routes.ts
+++ b/packages/bookings/src/routes.ts
@@ -1,3 +1,4 @@
+import { parseJsonBody, requireUserId } from "@voyantjs/hono"
 import { createKmsProviderFromEnv } from "@voyantjs/utils"
 import { type Context, Hono } from "hono"
 
@@ -1025,16 +1026,12 @@ export const bookingRoutes = new Hono<Env>()
 
   // 28. POST /:id/notes — Add note
   .post("/:id/notes", async (c) => {
-    const userId = c.get("userId")
-
-    if (!userId) {
-      return c.json({ error: "User ID required to create notes" }, 400)
-    }
+    const userId = requireUserId(c)
     const row = await bookingsService.createNote(
       c.get("db"),
       c.req.param("id"),
       userId,
-      insertBookingNoteSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertBookingNoteSchema),
     )
 
     if (!row) {

--- a/packages/finance/src/routes.ts
+++ b/packages/finance/src/routes.ts
@@ -1,3 +1,4 @@
+import { parseJsonBody, requireUserId } from "@voyantjs/hono"
 import { Hono } from "hono"
 
 import type { publicFinanceRoutes } from "./routes-public.js"
@@ -894,17 +895,13 @@ export const financeRoutes = new Hono<Env>()
 
   // POST /invoices/:id/notes — Add note
   .post("/invoices/:id/notes", async (c) => {
-    const userId = c.get("userId")
-
-    if (!userId) {
-      return c.json({ error: "User ID required to create notes" }, 400)
-    }
+    const userId = requireUserId(c)
 
     const row = await financeService.createNote(
       c.get("db"),
       c.req.param("id"),
       userId,
-      insertFinanceNoteSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertFinanceNoteSchema),
     )
 
     if (!row) {

--- a/packages/products/src/routes.ts
+++ b/packages/products/src/routes.ts
@@ -1,3 +1,4 @@
+import { parseJsonBody, RequestValidationError, requireUserId } from "@voyantjs/hono"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
 
@@ -1411,16 +1412,20 @@ export const productRoutes = new Hono<Env>()
 
   // POST /:id/versions — Create version snapshot
   .post("/:id/versions", async (c) => {
-    const userId = c.get("userId")
-
-    if (!userId) {
-      return c.json({ error: "User ID required to create versions" }, 400)
-    }
+    const userId = requireUserId(c)
     const row = await productsService.createVersion(
       c.get("db"),
       c.req.param("id"),
       userId,
-      insertVersionSchema.parse(await c.req.json().catch(() => ({}))),
+      await parseJsonBody(c, insertVersionSchema, {
+        invalidJsonMessage: "Invalid JSON body",
+      }).catch((error) => {
+        if (error instanceof RequestValidationError && error.message === "Invalid JSON body") {
+          return {}
+        }
+
+        throw error
+      }),
     )
 
     if (!row) {
@@ -1441,16 +1446,12 @@ export const productRoutes = new Hono<Env>()
 
   // POST /:id/notes — Add note to product
   .post("/:id/notes", async (c) => {
-    const userId = c.get("userId")
-
-    if (!userId) {
-      return c.json({ error: "User ID required to create notes" }, 400)
-    }
+    const userId = requireUserId(c)
     const row = await productsService.createNote(
       c.get("db"),
       c.req.param("id"),
       userId,
-      insertProductNoteSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertProductNoteSchema),
     )
 
     if (!row) {

--- a/packages/suppliers/src/routes.ts
+++ b/packages/suppliers/src/routes.ts
@@ -1,3 +1,4 @@
+import { parseJsonBody, requireUserId } from "@voyantjs/hono"
 import {
   insertAddressForEntitySchema,
   insertContactPointForEntitySchema,
@@ -349,17 +350,13 @@ export const supplierRoutes = new Hono<Env>()
 
   // POST /:id/notes — Add note to supplier
   .post("/:id/notes", async (c) => {
-    const userId = c.get("userId")
-
-    if (!userId) {
-      return c.json({ error: "User ID required to create notes" }, 400)
-    }
+    const userId = requireUserId(c)
 
     const row = await suppliersService.createNote(
       c.get("db"),
       c.req.param("id"),
       userId,
-      insertSupplierNoteSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertSupplierNoteSchema),
     )
 
     if (!row) {


### PR DESCRIPTION
## Summary
- adopt  in remaining authenticated mutation routes
- switch note creation routes to shared  handling
- preserve the products version snapshot fallback for invalid or missing JSON bodies

## Testing
- pnpm -C packages/finance test
- pnpm -C packages/products test
- pnpm -C packages/suppliers test
- pnpm -C packages/bookings test
- pnpm -C packages/finance typecheck
- pnpm -C packages/products typecheck
- pnpm -C packages/suppliers typecheck
- pnpm -C packages/bookings typecheck
- pnpm -C packages/finance build
- pnpm -C packages/products build
- pnpm -C packages/suppliers build
- pnpm -C packages/bookings build
- full pre-push repo test pipeline