### PR TITLE
Tighten permission and CRM route auth helpers

### DIFF
--- a/packages/crm/src/routes/accounts.ts
+++ b/packages/crm/src/routes/accounts.ts
@@ -1,3 +1,4 @@
+import { parseJsonBody, requireUserId } from "@voyantjs/hono"
 import {
   insertAddressSchema,
   insertContactPointSchema,
@@ -114,13 +115,12 @@ export const accountRoutes = new Hono<Env>()
     })
   })
   .post("/organizations/:id/notes", async (c) => {
-    const userId = c.get("userId")
-    if (!userId) return c.json({ error: "User ID required to create notes" }, 400)
+    const userId = requireUserId(c)
     const row = await crmService.createOrganizationNote(
       c.get("db"),
       c.req.param("id"),
       userId,
-      insertOrganizationNoteSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertOrganizationNoteSchema),
     )
     if (!row) return c.json({ error: "Organization not found" }, 404)
     return c.json({ data: row }, 201)
@@ -218,13 +218,12 @@ export const accountRoutes = new Hono<Env>()
     })
   })
   .post("/people/:id/notes", async (c) => {
-    const userId = c.get("userId")
-    if (!userId) return c.json({ error: "User ID required to create notes" }, 400)
+    const userId = requireUserId(c)
     const row = await crmService.createPersonNote(
       c.get("db"),
       c.req.param("id"),
       userId,
-      insertPersonNoteSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertPersonNoteSchema),
     )
     if (!row) return c.json({ error: "Person not found" }, 404)
     return c.json({ data: row }, 201)

--- a/packages/crm/tests/integration/accounts.test.ts
+++ b/packages/crm/tests/integration/accounts.test.ts
@@ -109,6 +109,24 @@ describe.skipIf(!DB_AVAILABLE)("Account routes", () => {
       })
       expect(res.status).toBe(404)
     })
+
+    it("creates an organization note", async () => {
+      const createRes = await app.request("/organizations", {
+        method: "POST",
+        ...json({ name: "Notes Org" }),
+      })
+      const { data: created } = await createRes.json()
+
+      const res = await app.request(`/organizations/${created.id}/notes`, {
+        method: "POST",
+        ...json({ content: "Call back next week" }),
+      })
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.data.content).toBe("Call back next week")
+      expect(body.data.authorUserId).toBe("test-user-id")
+    })
   })
 
   describe("People", () => {
@@ -189,6 +207,24 @@ describe.skipIf(!DB_AVAILABLE)("Account routes", () => {
         method: "GET",
       })
       expect(res.status).toBe(404)
+    })
+
+    it("creates a person note", async () => {
+      const createRes = await app.request("/people", {
+        method: "POST",
+        ...json({ firstName: "Note", lastName: "Person" }),
+      })
+      const { data: created } = await createRes.json()
+
+      const res = await app.request(`/people/${created.id}/notes`, {
+        method: "POST",
+        ...json({ content: "Prefers email outreach" }),
+      })
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.data.content).toBe("Prefers email outreach")
+      expect(body.data.authorUserId).toBe("test-user-id")
     })
   })
 })

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -45,6 +45,7 @@ export type {
 } from "./types.js"
 export {
   ApiHttpError,
+  ForbiddenApiError,
   normalizeValidationError,
   parseJsonBody,
   parseQuery,

--- a/packages/hono/src/middleware/require-permission.ts
+++ b/packages/hono/src/middleware/require-permission.ts
@@ -1,7 +1,9 @@
 import type { VoyantPermission } from "@voyantjs/core"
 import type { MiddlewareHandler } from "hono"
 
+import { requireUserId } from "../auth/require-user.js"
 import type { DbFactory, VoyantAuthIntegration, VoyantBindings, VoyantVariables } from "../types.js"
+import { ForbiddenApiError } from "../validation.js"
 
 function hasScope(scopes: string[] | null | undefined, permission: VoyantPermission): boolean {
   if (!scopes || scopes.length === 0) return false
@@ -38,10 +40,7 @@ export function requirePermission<TBindings extends VoyantBindings>(
       return next()
     }
 
-    const userId = c.get("userId")
-    if (!userId) {
-      return c.json({ error: "Unauthorized" }, 401)
-    }
+    const userId = requireUserId(c)
 
     if (!opts?.auth?.hasPermission) {
       return c.json({ error: "No auth permission checker configured" }, 500)
@@ -65,7 +64,7 @@ export function requirePermission<TBindings extends VoyantBindings>(
     })
 
     if (!allowed) {
-      return c.json({ error: "Forbidden" }, 403)
+      throw new ForbiddenApiError()
     }
 
     return next()

--- a/packages/hono/src/validation.ts
+++ b/packages/hono/src/validation.ts
@@ -43,6 +43,16 @@ export class UnauthorizedApiError extends ApiHttpError {
   }
 }
 
+export class ForbiddenApiError extends ApiHttpError {
+  constructor(message = "Forbidden") {
+    super(message, {
+      status: 403,
+      code: "forbidden",
+    })
+    this.name = "ForbiddenApiError"
+  }
+}
+
 function toValidationError(
   error: ZodError,
   fallbackMessage = "Invalid request",

--- a/packages/hono/tests/unit/require-permission.test.ts
+++ b/packages/hono/tests/unit/require-permission.test.ts
@@ -1,0 +1,83 @@
+import { Hono } from "hono"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { handleApiError, requestId } from "../../src/middleware/error-boundary.js"
+import { requirePermission } from "../../src/middleware/require-permission.js"
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("requirePermission", () => {
+  it("returns a structured 401 when the request has no user id", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const app = new Hono()
+    app.onError(handleApiError)
+    app.use("*", requestId)
+    app.use(
+      "*",
+      requirePermission(() => ({}) as never, "crm", "write", {
+        auth: {
+          hasPermission: vi.fn().mockResolvedValue(true),
+        },
+      }),
+    )
+    app.get("/secure", (c) => c.json({ ok: true }))
+
+    const response = await app.fetch(
+      new Request("http://example.com/secure"),
+      {},
+      mockExecutionCtx(),
+    )
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toMatchObject({
+      error: "Unauthorized",
+      code: "unauthorized",
+    })
+  })
+
+  it("returns a structured 403 when the permission check fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const hasPermission = vi.fn().mockResolvedValue(false)
+
+    const app = new Hono()
+    app.onError(handleApiError)
+    app.use("*", requestId)
+    app.use("*", async (c, next) => {
+      c.set("userId", "user_123")
+      await next()
+    })
+    app.use(
+      "*",
+      requirePermission(() => ({}) as never, "crm", "write", {
+        auth: {
+          hasPermission,
+        },
+      }),
+    )
+    app.get("/secure", (c) => c.json({ ok: true }))
+
+    const response = await app.fetch(
+      new Request("http://example.com/secure"),
+      {},
+      mockExecutionCtx(),
+    )
+
+    expect(response.status).toBe(403)
+    expect(await response.json()).toMatchObject({
+      error: "Forbidden",
+      code: "forbidden",
+    })
+    expect(hasPermission).toHaveBeenCalledTimes(1)
+  })
+})
+
+function mockExecutionCtx(): ExecutionContext {
+  return {
+    waitUntil() {},
+    passThroughOnException() {},
+  }
+}


### PR DESCRIPTION
## Summary
- add a structured `ForbiddenApiError` and use shared auth/error helpers in `requirePermission`
- switch CRM note creation routes to `requireUserId(...)` and shared JSON body parsing
- add focused Hono and CRM coverage for the tightened auth path

## Validation
- pnpm -C packages/hono test
- pnpm -C packages/crm test
- pnpm -C packages/hono typecheck
- pnpm -C packages/crm typecheck
- pnpm -C packages/hono build
- pnpm -C packages/crm build
- git diff --check