### PR TITLE
Adopt shared actor guard responses in PII routes

### DIFF
--- a/packages/bookings/src/routes.ts
+++ b/packages/bookings/src/routes.ts
@@ -1,4 +1,10 @@
-import { parseJsonBody, requireUserId } from "@voyantjs/hono"
+import {
+  ForbiddenApiError,
+  handleApiError,
+  parseJsonBody,
+  requireUserId,
+  UnauthorizedApiError,
+} from "@voyantjs/hono"
 import { createKmsProviderFromEnv } from "@voyantjs/utils"
 import { type Context, Hono } from "hono"
 
@@ -99,7 +105,10 @@ async function authorizeBookingPiiAccess(
       outcome: "denied",
       reason: "missing_user",
     })
-    return { allowed: false as const, response: c.json({ error: "Unauthorized" }, 401) }
+    return {
+      allowed: false as const,
+      response: handleApiError(new UnauthorizedApiError(), c),
+    }
   }
 
   const customAuthorizer = c.get("authorizeBookingPii")
@@ -120,7 +129,10 @@ async function authorizeBookingPiiAccess(
         outcome: "denied",
         reason: "custom_policy_denied",
       })
-      return { allowed: false as const, response: c.json({ error: "Forbidden" }, 403) }
+      return {
+        allowed: false as const,
+        response: handleApiError(new ForbiddenApiError(), c),
+      }
     }
 
     return { allowed: true as const }
@@ -137,7 +149,10 @@ async function authorizeBookingPiiAccess(
       reason: "insufficient_scope",
       metadata: { actor: actor ?? null },
     })
-    return { allowed: false as const, response: c.json({ error: "Forbidden" }, 403) }
+    return {
+      allowed: false as const,
+      response: handleApiError(new ForbiddenApiError(), c),
+    }
   }
 
   return { allowed: true as const }

--- a/packages/bookings/tests/integration/routes.test.ts
+++ b/packages/bookings/tests/integration/routes.test.ts
@@ -1195,6 +1195,10 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
       )
 
       expect(res.status).toBe(403)
+      expect(await res.json()).toMatchObject({
+        error: "Forbidden",
+        code: "forbidden",
+      })
 
       const rows = await db
         .select()

--- a/packages/transactions/src/routes-shared.ts
+++ b/packages/transactions/src/routes-shared.ts
@@ -1,3 +1,4 @@
+import { ForbiddenApiError, handleApiError, UnauthorizedApiError } from "@voyantjs/hono"
 import { createKmsProviderFromEnv } from "@voyantjs/utils"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
@@ -122,7 +123,10 @@ export async function authorizeTransactionPiiAccess(
   const userId = c.get("userId")
   if (!userId) {
     await logTransactionPiiAccess(c, { ...input, outcome: "denied", reason: "missing_user" })
-    return { allowed: false as const, response: c.json({ error: "Unauthorized" }, 401) }
+    return {
+      allowed: false as const,
+      response: handleApiError(new UnauthorizedApiError(), c),
+    }
   }
 
   const customAuthorizer = c.get("authorizeTransactionPii")
@@ -143,7 +147,10 @@ export async function authorizeTransactionPiiAccess(
         outcome: "denied",
         reason: "custom_policy_denied",
       })
-      return { allowed: false as const, response: c.json({ error: "Forbidden" }, 403) }
+      return {
+        allowed: false as const,
+        response: handleApiError(new ForbiddenApiError(), c),
+      }
     }
 
     return { allowed: true as const }
@@ -157,7 +164,10 @@ export async function authorizeTransactionPiiAccess(
       reason: "insufficient_scope",
       metadata: { actor: c.get("actor") ?? null },
     })
-    return { allowed: false as const, response: c.json({ error: "Forbidden" }, 403) }
+    return {
+      allowed: false as const,
+      response: handleApiError(new ForbiddenApiError(), c),
+    }
   }
 
   return { allowed: true as const }

--- a/packages/transactions/tests/integration/routes.test.ts
+++ b/packages/transactions/tests/integration/routes.test.ts
@@ -520,6 +520,10 @@ describe.skipIf(!DB_AVAILABLE)("Transactions routes (integration)", () => {
         `/offer-participants/${participant.id}/travel-details`,
       )
       expect(denied.status).toBe(403)
+      expect(await denied.json()).toMatchObject({
+        error: "Forbidden",
+        code: "forbidden",
+      })
 
       const rows = await db
         .select()


### PR DESCRIPTION
## Summary
- route bookings and transactions PII authorization failures through the shared Hono API error serializer
- replace package-local 401/403 payload construction with `UnauthorizedApiError` and `ForbiddenApiError`
- tighten integration assertions so denied PII reads now verify the shared `forbidden` error code

## Validation
- pnpm -C packages/bookings test
- pnpm -C packages/transactions test
- pnpm -C packages/bookings typecheck
- pnpm -C packages/transactions typecheck
- pnpm -C packages/bookings build
- pnpm -C packages/transactions build
- git diff --check