### PR TITLE
Adopt shared forbidden responses in customer portal

### DIFF
--- a/packages/customer-portal/src/routes-public.ts
+++ b/packages/customer-portal/src/routes-public.ts
@@ -1,4 +1,4 @@
-import { parseJsonBody, requireUserId } from "@voyantjs/hono"
+import { ForbiddenApiError, handleApiError, parseJsonBody, requireUserId } from "@voyantjs/hono"
 import { createKmsProviderFromEnv } from "@voyantjs/utils"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { type Context, Hono } from "hono"
@@ -160,7 +160,7 @@ export const publicCustomerPortalRoutes = new Hono<Env>()
     )
 
     if (companion === "forbidden") {
-      return c.json({ error: "Companion does not belong to this customer" }, 403)
+      return handleApiError(new ForbiddenApiError("Companion does not belong to this customer"), c)
     }
 
     if (!companion) {
@@ -179,7 +179,7 @@ export const publicCustomerPortalRoutes = new Hono<Env>()
     )
 
     if (result === "forbidden") {
-      return c.json({ error: "Companion does not belong to this customer" }, 403)
+      return handleApiError(new ForbiddenApiError("Companion does not belong to this customer"), c)
     }
 
     if (result === "not_found") {


### PR DESCRIPTION
## Summary
- route customer portal companion ownership failures through the shared Hono API error serializer
- reuse `ForbiddenApiError` instead of package-local 403 payload construction
- keep the customer portal auth/transport surface aligned with the other route guard cleanup slices

## Validation
- pnpm -C packages/customer-portal test
- pnpm -C packages/customer-portal typecheck
- pnpm -C packages/customer-portal build
- git diff --check