### PR TITLE
Add module and provider taxonomy guide

### DIFF
--- a/docs/architecture/module-provider-plugin-taxonomy.md
+++ b/docs/architecture/module-provider-plugin-taxonomy.md
@@ -1,0 +1,275 @@
+# Voyant Module, Provider, Extension, And Plugin Taxonomy
+
+This guide defines how Voyant should classify reusable packages and extension
+surfaces.
+
+The goal is straightforward:
+
+- keep the architecture vocabulary small
+- avoid turning every package into a “plugin”
+- make the primary customization seams obvious
+- keep distribution concerns separate from runtime concerns
+
+Voyant should prefer a few explicit categories over a large generic extension
+system.
+
+## Core Rules
+
+### 1. Modules are the main architecture unit
+
+Modules are the primary way Voyant packages business and infrastructure
+capabilities.
+
+Examples:
+
+- `bookings`
+- `products`
+- `finance`
+- `legal`
+- `notifications`
+
+Modules should own:
+
+- their core services
+- their data model
+- their route surfaces
+- their local domain logic
+
+Rule:
+
+If a package defines a real capability with its own records and behavior, it is
+usually a module first.
+
+### 2. Travel modules and infrastructure modules are different
+
+Voyant modules fall into two broad categories:
+
+- travel/domain modules
+- infrastructure modules
+
+Travel modules define the travel language of the framework:
+
+- bookings
+- departures
+- pricing
+- suppliers
+- finance
+- legal
+
+Infrastructure modules provide technical support capabilities:
+
+- notifications
+- auth/identity
+- storage
+- verification
+
+Rule:
+
+Business capabilities should be treated as travel modules. Technical support
+capabilities should be treated as infrastructure modules.
+
+### 3. Providers are the main swap point
+
+Providers are the primary way to make concrete implementations replaceable.
+
+Examples:
+
+- payment providers
+- notification providers
+- storage providers
+- bank-transfer instruction resolvers
+
+Providers should:
+
+- implement a narrow contract
+- stay focused on one execution seam
+- hide vendor-specific details behind that contract
+
+Rule:
+
+If the question is “how do I swap one implementation for another?”, the answer
+should usually be a provider, not a plugin.
+
+### 4. Adapters connect Voyant to external systems
+
+Adapters are integration packages that connect Voyant capabilities to external
+vendors or services.
+
+Examples:
+
+- Netopia
+- SmartBill
+- CMS sync packages
+
+An adapter may expose:
+
+- one or more providers
+- a small extension
+- route or webhook wiring
+- workflow helpers
+
+Rule:
+
+If a package exists primarily to talk to an external system, treat it as an
+adapter package even if it also exports a plugin bundle.
+
+### 5. Extensions customize existing module behavior
+
+Extensions add or modify behavior around existing module surfaces.
+
+Examples:
+
+- finance sync hooks
+- supplier-specific booking logic
+- custom link/query hydration
+- admin widgets for an existing module
+
+Extensions should not be treated as new domain modules unless they introduce a
+new bounded capability with its own records and lifecycle.
+
+Rule:
+
+If the package customizes an existing module rather than defining a new
+capability, it is an extension.
+
+### 6. Plugins are distribution bundles
+
+Plugins are packaging and distribution units.
+
+A plugin may bundle:
+
+- modules
+- extensions
+- providers
+- routes
+- subscribers
+- admin contributions
+
+But that does not make “plugin” the main runtime abstraction.
+
+Rule:
+
+Use plugins when you want to ship a reusable bundle across projects. Do not use
+plugins as the default answer to every customization problem.
+
+## Decision Rules
+
+### 7. Start with the narrowest category that fits
+
+When introducing a new package or extension point, choose the narrowest correct
+classification first.
+
+Use this order:
+
+1. provider
+2. adapter
+3. extension
+4. module
+5. plugin bundle
+
+That keeps the architecture honest and avoids inflating simple seams into a
+meta-framework.
+
+Rule:
+
+Do not start with “plugin”. Start with the smallest seam that actually matches
+the job.
+
+### 8. Keep distribution separate from runtime semantics
+
+The runtime question is:
+
+- module?
+- provider?
+- extension?
+
+The packaging question is:
+
+- should this ship as a plugin bundle?
+
+Those are not the same decision.
+
+Rule:
+
+A package can be distributed as a plugin bundle while still being, at runtime,
+primarily a provider or extension package.
+
+### 9. Avoid leaking internal implementation structure as public API
+
+Packages may contain many internal helpers and supporting services.
+
+That does not mean every internal part should become part of the supported
+cross-package surface.
+
+Modules should expose one main public service surface where possible.
+Providers should expose one narrow contract.
+Extensions should expose the specific registration points they need.
+
+Rule:
+
+Keep the public package surface smaller than the internal implementation
+surface.
+
+## Packaging Guidance
+
+### 10. Prefer clear names that reveal the package role
+
+Prefer names that reveal whether the package is:
+
+- a core module
+- a provider/adapter
+- a frontend runtime package
+- a UI/block package
+
+Examples:
+
+- `@voyantjs/bookings`
+- `@voyantjs/storefront-react`
+- `@voyantjs/voyant-admin`
+- `@voyantjs/plugin-netopia`
+
+The package name does not have to carry the full taxonomy, but it should not
+hide the package’s role either.
+
+Rule:
+
+Package naming should reinforce the architecture, not blur it.
+
+### 11. Plugin authoring should stay lightweight
+
+When a reusable bundle does need to ship as a plugin, Voyant should keep the
+authoring model simple:
+
+- clear exports
+- clear allowed bundle contents
+- lightweight scaffold path
+- predictable registration shape
+
+Do not turn plugin authoring into a second framework within the framework.
+
+Rule:
+
+Plugin packaging should be deliberate and ergonomic, not magical.
+
+## Practical Checklist
+
+When classifying a new reusable capability:
+
+1. Ask whether it is defining a real capability or only swapping an
+   implementation.
+2. If it swaps an implementation, prefer a provider.
+3. If it connects to an external vendor, treat it as an adapter package.
+4. If it customizes existing module behavior, treat it as an extension.
+5. If it introduces a new bounded capability, make it a module.
+6. Only wrap the result as a plugin when you need to distribute a reusable
+   bundle across projects.
+
+## Non-Goals
+
+This guide does not introduce:
+
+- a universal plugin system
+- a requirement that every reusable package ship as a plugin
+- a ban on bundled packages that combine multiple seams
+
+The point is clear package taxonomy, not extra ceremony.

--- a/docs/architecture/platform-surface-roadmap.md
+++ b/docs/architecture/platform-surface-roadmap.md
@@ -9,6 +9,9 @@ For schema and migration conventions across modules, see
 For HTTP route conventions across the admin and public API surfaces, see
 [Voyant API Route Authoring](./api-route-authoring.md).
 
+For package and extension-surface classification, see
+[Voyant Module, Provider, Extension, And Plugin Taxonomy](./module-provider-plugin-taxonomy.md).
+
 ## Principles
 
 - Do not preserve Payload semantics as a long-term public contract.


### PR DESCRIPTION
## Summary
- add a concrete taxonomy guide for modules, providers, adapters, extensions, and plugin bundles
- document decision rules for choosing the right seam before reaching for plugins
- link the guide from the platform surface roadmap

## Testing
- git diff --check