### PR TITLE
Add admin architecture guide

### DIFF
--- a/docs/architecture/admin-architecture.md
+++ b/docs/architecture/admin-architecture.md
@@ -1,0 +1,227 @@
+# Voyant Admin Architecture
+
+This guide defines how Voyant should treat the admin surface as a shared runtime
+and extension boundary.
+
+The goal is simple:
+
+- keep the admin shell and runtime shared
+- make extension points explicit instead of ad hoc
+- keep UI blocks, runtime hooks, and admin extensions as separate layers
+- support admin localization without confusing it for business-content
+  translation
+
+The admin should be a first-class framework surface, not just template-local UI.
+
+## Core Rules
+
+### 1. Keep the admin shell and runtime shared
+
+Voyant should keep a shared admin runtime layer for:
+
+- shared providers
+- auth-aware admin context
+- locale/timezone runtime
+- base layout primitives and shared admin concerns
+
+That shared layer should live in the common admin/runtime packages rather than
+being reimplemented in each template.
+
+Rule:
+
+The admin runtime should be framework-owned even when the final shell/layout is
+template-owned.
+
+### 2. Keep the final admin shell template-owned
+
+Starter templates should still own:
+
+- the final admin shell composition
+- overall layout decisions
+- product-specific navigation defaults
+- app-owned route composition
+
+This keeps Voyant flexible without making the admin surface unstructured.
+
+Rule:
+
+Voyant should own the shared admin runtime and extension seams, while templates
+own the final shell and composition.
+
+## Extension Surface
+
+### 3. Make admin extension points explicit
+
+The admin should expose stable extension points such as:
+
+- admin UI routes
+- navigation contributions
+- widget or injection slots
+- detail-panel or summary-card contributions where appropriate
+
+These should be treated as first-class extension seams, not as informal app
+patch points.
+
+Rule:
+
+Admin customization should happen through explicit extension points before full
+route/shell override.
+
+### 4. Admin UI routes are part of the extension model
+
+Modules, extensions, or app-owned code may need dedicated admin pages.
+
+Those should plug into the admin surface as a recognized route class rather than
+feeling like unrelated template-local pages.
+
+Rule:
+
+Admin pages contributed by packages should be treated as a supported extension
+surface.
+
+### 5. Navigation contributions should stay narrow and predictable
+
+The admin should allow packages to contribute navigation entries without
+turning navigation into an opaque runtime registry.
+
+Navigation contributions should stay:
+
+- typed
+- explicit
+- predictable in placement and labeling
+
+Rule:
+
+Navigation contribution is an admin extension seam, not a generic dynamic menu
+system.
+
+### 6. Widgets and injection zones should be selective
+
+Not every admin screen should be endlessly injectable.
+
+Voyant should expose widget/injection zones only where extensibility is
+genuinely useful, such as:
+
+- booking detail side panels
+- finance summary cards
+- legal/document action areas
+- product detail operational add-ons
+
+Rule:
+
+Admin widget slots should be intentional and few, not everywhere by default.
+
+## UI Layering
+
+### 7. Keep runtime hooks and source-installed UI blocks separate
+
+Voyant already has complementary frontend layers:
+
+- shared React/runtime packages
+- source-installed UI blocks and registry components
+- admin extension points
+
+These are not competing ideas.
+
+The layering should be:
+
+- admin extension surface decides where UI may attach
+- shared runtime packages provide hooks/providers and admin context
+- source-installed UI blocks provide editable presentation building blocks
+
+Rule:
+
+Do not replace source-installed UI blocks with the admin extension surface, and
+do not use blocks as a substitute for explicit admin extension points.
+
+### 8. Preserve the source-installed UI strategy
+
+Voyant should keep:
+
+- `@voyantjs/*-react`
+- `@voyantjs/voyant-admin`
+- the registry/source-installed UI approach
+
+That strategy gives teams editable UI while the framework still owns the runtime
+and extension contracts.
+
+Rule:
+
+Editable UI blocks are part of the frontend strategy and should remain
+complementary to admin extension points.
+
+## Localization
+
+### 9. Separate admin UI locale from business-content locale
+
+Admin UI language is not the same thing as product or content translation.
+
+Examples:
+
+- admin labels, actions, and navigation are UI locale concerns
+- product titles, descriptions, and contract copy are business-content concerns
+
+A Romanian customer may want the admin UI in Romanian while still managing
+English or German travel content.
+
+Rule:
+
+Admin UI localization and business-content localization must stay separate.
+
+### 10. Use a clear admin locale resolution order
+
+The admin locale should resolve through a simple preference hierarchy:
+
+1. explicit user override
+2. organization default admin locale
+3. browser language on first sign-in
+4. fallback to `en`
+
+This keeps the model simple while supporting mixed-language teams.
+
+Rule:
+
+Admin locale resolution should prefer user choice first, then organization
+default, then browser-derived bootstrap, then English fallback.
+
+### 11. Locale formatting should include timezone-aware presentation
+
+Admin locale/runtime should drive:
+
+- text translations
+- date formatting
+- time formatting
+- number and currency formatting
+
+Timezone should remain user-driven where appropriate.
+
+Rule:
+
+Admin localization should include formatting/runtime concerns, not just string
+translation.
+
+## Practical Checklist
+
+When adding or reviewing an admin capability in Voyant:
+
+1. Decide whether it belongs in the shared admin runtime or the template-owned
+   shell.
+2. Prefer explicit admin UI routes, nav contributions, or widget slots over
+   shell patching.
+3. Keep the extension point narrow and typed.
+4. Use shared runtime hooks/providers instead of duplicating admin context.
+5. Keep source-installed UI blocks as the editable presentation layer.
+6. Treat admin UI locale separately from business-content translation.
+7. Resolve admin locale through user override, org default, browser bootstrap,
+   then English fallback.
+
+## Non-Goals
+
+This guide does not introduce:
+
+- a fully closed admin product
+- a giant plugin runtime for admin UI
+- a replacement for the source-installed UI strategy
+
+The point is a clear shared admin runtime and extension surface, not a more
+rigid dashboard framework.

--- a/docs/architecture/platform-surface-roadmap.md
+++ b/docs/architecture/platform-surface-roadmap.md
@@ -27,6 +27,9 @@ For canonical notification delivery and provider-resolution rules, see
 For shared authentication, identity, and actor-context rules, see
 [Voyant Auth And Identity Architecture](./auth-identity-architecture.md).
 
+For the shared admin runtime, extension surface, and localization model, see
+[Voyant Admin Architecture](./admin-architecture.md).
+
 ## Principles
 
 - Do not preserve Payload semantics as a long-term public contract.


### PR DESCRIPTION
## Summary
- add a concrete admin guide for the shared runtime, explicit extension points, and source-installed UI layering
- document the admin localization model separately from business-content translation
- link the guide from the platform surface roadmap

## Testing
- git diff --check