### PR TITLE
Add extensibility rubric and gap analysis

### DIFF
--- a/docs/architecture/extensibility-gap-analysis.md
+++ b/docs/architecture/extensibility-gap-analysis.md
@@ -1,0 +1,139 @@
+# Voyant Extensibility Gap Analysis
+
+This document translates the extensibility rubric into the remaining active
+cleanup backlog for the codebase.
+
+The major architecture doctrine is now documented. The main remaining gaps are
+less about philosophy and more about code adoption, package discipline, and
+runtime consistency.
+
+For the umbrella principles, see
+[Voyant Extensibility Rubric](./extensibility-rubric.md).
+
+## Summary
+
+Voyant is already broadly aligned with the intended architecture:
+
+- real module boundaries exist
+- extensions are first-class
+- provider-style seams exist in places like notifications and checkout
+- templates own app assembly instead of pushing everything into framework core
+- UI blocks and `-react` runtime packages are already split cleanly
+
+The main remaining work is to make the codebase consistently behave the way the
+docs now describe.
+
+## Active Gap Categories
+
+### 1. Package Taxonomy Adoption
+
+The docs now distinguish modules, providers, adapters, extensions, and plugin
+bundles clearly. The codebase and package docs still need to reflect that more
+consistently.
+
+Remaining work:
+
+- audit `packages/plugins/*` and describe each package by its real runtime role
+- reduce unnecessary “plugin-first” language in package READMEs and examples
+- make provider terminology more consistent across packages
+
+### 2. Runtime Seam Hardening
+
+Several important seams already exist in code, but not all of them are yet
+uniformly presented or adopted.
+
+Remaining work:
+
+- keep formalizing provider registries where a module has real implementation
+  variance
+- keep using bootstrap-time validation for runtime options where packages still
+  fail lazily
+- continue moving routes and integrations toward the shared auth/validation/error
+  helpers
+
+### 3. Admin Surface Adoption
+
+The admin runtime, localization model, and extension surface are now clearly
+documented. More package and template code should adopt those shared seams.
+
+Remaining work:
+
+- move more operator UI composition onto the shared admin runtime and extension
+  contracts
+- add more real module contributions through widgets/routes/nav instead of only
+  template-local composition
+- keep admin localization flowing through the shared runtime rather than
+  package-local UI state
+
+### 4. Storefront/Public Contract Adoption
+
+The public/storefront contract is now clearly defined. More code should align
+to that model consistently.
+
+Remaining work:
+
+- keep public payloads customer-facing instead of leaking admin CRUD semantics
+- remove remaining app-local compatibility wrappers where the shared public
+  contract is already strong enough
+- keep `/v1/public/*` and the `storefront` package/runtime naming consistent
+
+### 5. Storage And Document Access Adoption
+
+The storage split is now clearly documented and partially implemented.
+
+Remaining work:
+
+- continue removing persisted signed URL assumptions where durable storage keys
+  are the better source of truth
+- keep document delivery explicit and separate from public media serving
+- propagate the media/documents split consistently across generators, routes,
+  and attachments
+
+### 6. Notification Surface Adoption
+
+The notification architecture is in decent shape, but the codebase should keep
+converging on the documented send model.
+
+Remaining work:
+
+- keep specialized notification flows as wrappers over one canonical send
+  surface
+- keep workflow-triggered delivery using the shared notification service
+- keep sensitive attachment access resolved at send time
+
+### 7. Execution Model Adoption
+
+Workflows, schedules, and daemons now have a clearer conceptual split. The
+remaining work is in applying that split consistently.
+
+Remaining work:
+
+- keep orchestration logic out of module internals where it belongs in workflow
+  surfaces
+- avoid flattening long-running daemon-style concerns into generic workflow
+  semantics
+- keep runtime selection explicit by execution class rather than by one
+  universal engine
+
+## Recommended Next Code Slices
+
+The next code-focused cleanup should favor small, shippable branches.
+
+Recommended order:
+
+1. provider/plugin taxonomy cleanup in package READMEs and exports
+2. further admin extension-surface adoption in real operator pages
+3. storefront/public contract cleanup where app-local wrappers still exist
+4. continued storage/document-access hardening
+5. further bootstrap-time option validation in packages that still fail lazily
+
+## Definition Of Success
+
+The cleanup is in good shape when:
+
+- the codebase and package docs use the same vocabulary as the rubric
+- major runtime seams are explicit and consistent
+- admin and storefront/public surfaces feel like deliberate framework layers
+- storage, notifications, auth, and execution concerns follow their documented
+  contracts in code
+- downstream apps need less compatibility glue to consume Voyant cleanly

--- a/docs/architecture/extensibility-rubric.md
+++ b/docs/architecture/extensibility-rubric.md
@@ -1,0 +1,191 @@
+# Voyant Extensibility Rubric
+
+This document defines how Voyant should scale its architecture and
+extensibility without collapsing into a generic plugin platform.
+
+The goal is not to make every part of the framework swappable. The goal is to
+ship a coherent shared language for travel software that gets most teams most
+of the way there, while making the real variance points explicit and safe to
+customize.
+
+For the current implementation backlog relative to this rubric, see
+[Voyant Extensibility Gap Analysis](./extensibility-gap-analysis.md).
+
+## Product Position
+
+Voyant should ship:
+
+- domain primitives
+- reusable modules
+- orchestration layers for cross-module flows
+- shared runtime packages
+- source-installable UI blocks
+- starter templates
+- explicit extension seams
+
+Voyant should not try to ship:
+
+- a generic runtime where every concern is dynamically pluggable
+- abstractions for variance that does not happen often in real travel products
+- a lowest-common-denominator platform that is technically flexible but hard to
+  understand or build with
+
+The promise to developers should be:
+
+- strong defaults
+- a common domain language
+- clear override points
+- local ownership of the last 20%
+
+## Core Principle
+
+Build a framework with strong defaults and narrow escape hatches.
+
+Do not optimize for “everything is replaceable”.
+
+Optimize for:
+
+- composability
+- clarity
+- explicit contracts
+- package-level reuse
+- local customization where businesses actually differ
+
+## Simplicity Bias
+
+Voyant should prefer the simplest architecture that preserves clarity,
+composability, and long-term maintainability.
+
+In practice, that means:
+
+- use the fewest framework primitives necessary
+- prefer explicit module, provider, workflow, route, and UI-block patterns over
+  meta-abstractions
+- keep app-owned code local when a concern is not yet stable enough to
+  standardize
+- introduce a new framework primitive only when the same pattern is clearly
+  repeating and the abstraction reduces total complexity
+
+Rule:
+
+If a problem can be solved cleanly with an existing module, provider,
+extension, workflow, route, or block, do that first.
+
+## Layer Model
+
+Voyant should be understood as a small set of layers with different
+responsibilities.
+
+### Core
+
+Core defines the framework language and composition model.
+
+Core owns:
+
+- module and extension contracts
+- event bus contracts
+- link/query primitives
+- app/workflow-time container and runtime composition primitives
+- transport-agnostic types and conventions
+
+Core should not own travel-specific business workflows or app-level UX
+decisions.
+
+### Modules
+
+Modules are first-class bounded capabilities.
+
+Voyant should distinguish between:
+
+- travel/domain modules
+- infrastructure modules
+
+Modules own:
+
+- canonical data model for their domain
+- domain services and state transitions
+- typed route/service surfaces
+- events emitted by that domain
+
+Travel modules define Voyant’s travel language.
+Infrastructure modules provide reusable technical capabilities used by travel
+modules, workflows, and apps.
+
+### Workflows And Orchestration
+
+Workflows coordinate business operations that span multiple modules or require
+step-by-step execution, retries, approvals, or asynchronous side effects.
+
+This layer sits above modules rather than inside them.
+
+Workflows own:
+
+- cross-module coordination
+- retries, compensation, and failure handling
+- approvals and human-in-the-loop steps
+- scheduling and automation that orchestrate module services
+
+### Providers And Adapters
+
+Providers are the main swap point.
+
+Providers and adapters connect Voyant to external systems through narrow,
+explicit seams.
+
+They own:
+
+- provider-specific API calls
+- request/response mapping
+- provider auth/config
+- provider capability declarations
+
+They should not redefine the core domain.
+
+### Extensions
+
+Extensions attach custom logic to an existing Voyant module without forcing the
+framework to absorb that logic as a first-class module.
+
+They own:
+
+- extra hooks on existing lifecycle events
+- route additions scoped to an existing module
+- synchronization logic for external systems
+- extra policy or orchestration layered on top of a module
+
+### Plugins
+
+Plugins are a packaging concept, not the default extensibility primitive.
+
+Use a plugin when the problem is package distribution of multiple framework
+contributions together. Do not use a plugin when a typed adapter contract is
+sufficient.
+
+## Supported Surface Guides
+
+The focused guides below define the concrete rules for each major framework
+surface:
+
+- [Voyant Data Model And Schema Authoring](./data-model-schema-authoring.md)
+- [Voyant API Route Authoring](./api-route-authoring.md)
+- [Voyant Module, Provider, Extension, And Plugin Taxonomy](./module-provider-plugin-taxonomy.md)
+- [Voyant Execution Architecture](./execution-architecture.md)
+- [Voyant Caching Architecture](./caching-architecture.md)
+- [Voyant Storage Architecture](./storage-architecture.md)
+- [Voyant Notifications Architecture](./notifications-architecture.md)
+- [Voyant Auth And Identity Architecture](./auth-identity-architecture.md)
+- [Voyant Admin Architecture](./admin-architecture.md)
+- [Voyant Storefront And Public Contract Architecture](./storefront-architecture.md)
+- [Voyant Future Architecture Considerations](./future-architecture-considerations.md)
+
+## Summary Rules
+
+Voyant should bias toward:
+
+- modules over meta-frameworks
+- providers over generic plugins
+- workflows over hidden cross-module coupling
+- source-installed UI blocks over opaque theming systems
+- app composition over premature standardization
+
+The framework should feel coherent first, extensible second.

--- a/docs/architecture/platform-surface-roadmap.md
+++ b/docs/architecture/platform-surface-roadmap.md
@@ -3,6 +3,10 @@
 This roadmap turns downstream integration friction into an upstream package and
 API plan for Voyant itself.
 
+For the umbrella architecture doctrine and the remaining cleanup backlog, see
+[Voyant Extensibility Rubric](./extensibility-rubric.md) and
+[Voyant Extensibility Gap Analysis](./extensibility-gap-analysis.md).
+
 For schema and migration conventions across modules, see
 [Voyant Data Model And Schema Authoring](./data-model-schema-authoring.md).
 


### PR DESCRIPTION
## Summary
- add the umbrella extensibility rubric and the remaining active code-adoption backlog
- link both from the platform surface roadmap
- keep the focused surface guides under those top-level architecture docs

## Testing
- git diff --check