### PR TITLE
Clarify adapter roles in plugin packages

### DIFF
--- a/packages/plugins/netopia/README.md
+++ b/packages/plugins/netopia/README.md
@@ -1,8 +1,19 @@
 # `@voyantjs/plugin-netopia`
 
-Netopia hosted-card payment support for Voyant finance.
+Netopia hosted-card payment adapter bundle for Voyant finance.
 
-This package sits on top of `@voyantjs/finance` and its `payment_sessions` model. It does not replace finance state. It starts a hosted Netopia checkout, stores provider references on the session, and reconciles callback payloads back into Voyant payments, captures, authorizations, invoices, and booking payment schedules.
+This package sits on top of `@voyantjs/finance` and its `payment_sessions`
+model. It does not replace finance state.
+
+Architecturally, this package is primarily:
+
+- a Netopia payment adapter
+- a finance extension
+- an optional Hono plugin bundle for distribution
+
+It starts a hosted Netopia checkout, stores provider references on the session,
+and reconciles callback payloads back into Voyant payments, captures,
+authorizations, invoices, and booking payment schedules.
 
 ## Environment
 
@@ -29,22 +40,26 @@ Mounted as a finance extension, the package exposes:
 
 ## Checkout integration
 
-If you use `@voyantjs/checkout`, the plugin now also exports
+If you use `@voyantjs/checkout`, the package also exports
 `createNetopiaCheckoutStarter()`. That lets checkout create the payment session
 and start the Netopia redirect flow in one request while keeping provider
 startup optional in core checkout.
 
-Because this is a finance extension, these routes mount under the finance module path in the app.
+Because this is a finance extension, these routes mount under the finance module
+path in the app.
 
 ## Usage
 
 ```ts
-import { createNetopiaFinanceExtension } from "@voyantjs/plugin-netopia"
+import { createNetopiaFinanceAdapter } from "@voyantjs/plugin-netopia"
 
-const netopiaFinanceExtension = createNetopiaFinanceExtension()
+const netopiaFinanceExtension = createNetopiaFinanceAdapter()
 ```
 
 Then include the returned extension in `createApp({ extensions: [...] })`.
+
+If you want the packaged Hono bundle instead, use
+`createNetopiaAdapterBundle()` or the existing `netopiaHonoPlugin()` export.
 
 ## Flow
 
@@ -53,7 +68,7 @@ Then include the returned extension in `createApp({ extensions: [...] })`.
 3. Redirect the customer to the returned provider `paymentURL`.
 4. Optionally send a payment-link or invoice notification as part of the collect flow.
 5. Netopia calls the callback route.
-6. The plugin completes, fails, or updates the session in finance.
+6. The adapter completes, fails, or updates the session in finance.
 
 ## Notes
 

--- a/packages/plugins/netopia/src/index.ts
+++ b/packages/plugins/netopia/src/index.ts
@@ -7,9 +7,11 @@ export {
 } from "./client.js"
 export {
   createNetopiaFinanceExtension,
+  createNetopiaFinanceExtension as createNetopiaFinanceAdapter,
   createNetopiaFinanceRoutes,
   NETOPIA_RUNTIME_CONTAINER_KEY,
   netopiaFinanceExtension,
+  netopiaHonoPlugin as createNetopiaAdapterBundle,
   netopiaHonoPlugin,
 } from "./plugin.js"
 export {

--- a/packages/plugins/payload-cms/README.md
+++ b/packages/plugins/payload-cms/README.md
@@ -1,6 +1,15 @@
 # @voyantjs/plugin-payload-cms
 
-Payload CMS sync plugin for Voyant. Subscribes to module events and mirrors documents into a Payload collection keyed by a `voyantId` field.
+Payload CMS sync adapter bundle for Voyant.
+
+Architecturally, this package is primarily:
+
+- a Payload sync adapter
+- a subscriber bundle that mirrors Voyant module records into Payload
+- an optional plugin bundle for distribution
+
+It subscribes to module events and mirrors documents into a Payload collection
+keyed by a `voyantId` field.
 
 ## Install
 
@@ -11,12 +20,12 @@ pnpm add @voyantjs/plugin-payload-cms
 ## Usage
 
 ```typescript
-import { payloadCmsPlugin } from "@voyantjs/plugin-payload-cms"
+import { createPayloadCmsSyncPlugin } from "@voyantjs/plugin-payload-cms"
 import { createApp } from "@voyantjs/hono"
 
 const app = createApp({
   plugins: [
-    payloadCmsPlugin({
+    createPayloadCmsSyncPlugin({
       apiUrl: "https://cms.example.com/api",
       apiKey: env.PAYLOAD_API_KEY,
       collection: "products",
@@ -33,7 +42,7 @@ By default the plugin wires up 3 subscribers (`product.created`, `product.update
 | Entry | Description |
 | --- | --- |
 | `.` | Barrel re-exports |
-| `./plugin` | `payloadCmsPlugin(options)` |
+| `./plugin` | `payloadCmsPlugin(options)` and `createPayloadCmsSyncPlugin(options)` |
 | `./client` | `createPayloadClient` — `upsertByVoyantId`, `deleteByVoyantId`, `findByVoyantId` |
 | `./types` | Plugin option types |
 

--- a/packages/plugins/payload-cms/src/index.ts
+++ b/packages/plugins/payload-cms/src/index.ts
@@ -6,5 +6,5 @@ export type {
   PayloadMapFn,
   PayloadSyncEventNames,
 } from "./plugin.js"
-export { payloadCmsPlugin } from "./plugin.js"
+export { payloadCmsPlugin, payloadCmsPlugin as createPayloadCmsSyncPlugin } from "./plugin.js"
 export type { PayloadDocBody, PayloadFetch, VoyantEntityEvent } from "./types.js"

--- a/packages/plugins/sanity-cms/README.md
+++ b/packages/plugins/sanity-cms/README.md
@@ -1,6 +1,15 @@
 # @voyantjs/plugin-sanity-cms
 
-Sanity CMS sync plugin for Voyant. Subscribes to module events and mirrors documents into a Sanity dataset keyed by a `voyantId` field.
+Sanity CMS sync adapter bundle for Voyant.
+
+Architecturally, this package is primarily:
+
+- a Sanity sync adapter
+- a subscriber bundle that mirrors Voyant module records into Sanity
+- an optional plugin bundle for distribution
+
+It subscribes to module events and mirrors documents into a Sanity dataset keyed
+by a `voyantId` field.
 
 ## Install
 
@@ -11,12 +20,12 @@ pnpm add @voyantjs/plugin-sanity-cms
 ## Usage
 
 ```typescript
-import { sanityCmsPlugin } from "@voyantjs/plugin-sanity-cms"
+import { createSanityCmsSyncPlugin } from "@voyantjs/plugin-sanity-cms"
 import { createApp } from "@voyantjs/hono"
 
 const app = createApp({
   plugins: [
-    sanityCmsPlugin({
+    createSanityCmsSyncPlugin({
       projectId: env.SANITY_PROJECT_ID,
       dataset: "production",
       token: env.SANITY_TOKEN,
@@ -34,7 +43,7 @@ Uses GROQ for reads and Sanity Mutations API for writes. Default `apiVersion` is
 | Entry | Description |
 | --- | --- |
 | `.` | Barrel re-exports |
-| `./plugin` | `sanityCmsPlugin(options)` |
+| `./plugin` | `sanityCmsPlugin(options)` and `createSanityCmsSyncPlugin(options)` |
 | `./client` | `createSanityClient` — `upsertByVoyantId`, `deleteByVoyantId`, `findByVoyantId` |
 | `./types` | Plugin option types |
 

--- a/packages/plugins/sanity-cms/src/index.ts
+++ b/packages/plugins/sanity-cms/src/index.ts
@@ -6,5 +6,5 @@ export type {
   SanityMapFn,
   SanitySyncEventNames,
 } from "./plugin.js"
-export { sanityCmsPlugin } from "./plugin.js"
+export { sanityCmsPlugin, sanityCmsPlugin as createSanityCmsSyncPlugin } from "./plugin.js"
 export type { SanityDocBody, SanityFetch, VoyantEntityEvent } from "./types.js"

--- a/packages/plugins/smartbill/README.md
+++ b/packages/plugins/smartbill/README.md
@@ -1,6 +1,15 @@
 # @voyantjs/plugin-smartbill
 
-SmartBill e-invoicing plugin for Voyant. Subscribes to invoice events and creates/cancels/syncs invoices via the SmartBill REST API for Romanian tax compliance.
+SmartBill e-invoicing sync adapter bundle for Voyant.
+
+Architecturally, this package is primarily:
+
+- a SmartBill e-invoicing adapter
+- a subscriber bundle for finance invoice events
+- an optional plugin bundle for distribution
+
+It subscribes to invoice events and creates, cancels, or syncs invoices via the
+SmartBill REST API for Romanian tax compliance.
 
 ## Install
 
@@ -11,12 +20,12 @@ pnpm add @voyantjs/plugin-smartbill
 ## Usage
 
 ```typescript
-import { smartbillPlugin } from "@voyantjs/plugin-smartbill"
+import { createSmartbillSyncPlugin } from "@voyantjs/plugin-smartbill"
 import { createApp } from "@voyantjs/hono"
 
 const app = createApp({
   plugins: [
-    smartbillPlugin({
+    createSmartbillSyncPlugin({
       username: env.SMARTBILL_USERNAME,
       apiToken: env.SMARTBILL_API_TOKEN,
       companyVatCode: "RO12345678",
@@ -34,7 +43,7 @@ By default the plugin wires up 3 subscribers (`invoice.issued`, `invoice.voided`
 | Entry | Description |
 | --- | --- |
 | `.` | Barrel re-exports |
-| `./plugin` | `smartbillPlugin(options)` |
+| `./plugin` | `smartbillPlugin(options)` and `createSmartbillSyncPlugin(options)` |
 | `./client` | `createSmartbillClient` — `createInvoice`, `cancelInvoice`, `viewPdf`, `getPaymentStatus`, etc. |
 | `./types` | SmartBill invoice types |
 

--- a/packages/plugins/smartbill/src/index.ts
+++ b/packages/plugins/smartbill/src/index.ts
@@ -8,7 +8,7 @@ export type {
   SmartbillPluginOptions,
   SmartbillSyncEventNames,
 } from "./plugin.js"
-export { smartbillPlugin } from "./plugin.js"
+export { smartbillPlugin, smartbillPlugin as createSmartbillSyncPlugin } from "./plugin.js"
 export type {
   SmartbillInvoiceSettlementPoller,
   SmartbillInvoiceSettlementPollerOptions,


### PR DESCRIPTION
## Summary
- clarify the runtime role of netopia, smartbill, payload-cms, and sanity-cms as adapters/sync bundles in their package docs
- add additive export aliases so downstream code can use less plugin-heavy names without breaking current imports
- keep package names and runtime behavior unchanged

## Testing
- git diff --check
- pnpm -C packages/plugins/netopia typecheck
- pnpm -C packages/plugins/smartbill typecheck
- pnpm -C packages/plugins/payload-cms typecheck
- pnpm -C packages/plugins/sanity-cms typecheck
- pnpm -C packages/plugins/netopia build
- pnpm -C packages/plugins/smartbill build
- pnpm -C packages/plugins/payload-cms build
- pnpm -C packages/plugins/sanity-cms build