### PR TITLE
Align booking portal with shared public client

### DIFF
--- a/examples/nextjs-booking-portal/README.md
+++ b/examples/nextjs-booking-portal/README.md
@@ -25,7 +25,7 @@ examples/nextjs-booking-portal/
 │       ├── products/[id]/route.ts   GET /api/products/:id
 │       └── inquiries/route.ts       POST /api/inquiries
 ├── lib/
-│   ├── voyant-client.ts             Server-side REST client + mock fallback
+│   ├── voyant-client.ts             Server-side public client + mock fallback
 │   ├── mock-data.ts                 Demo product catalog
 │   ├── types.ts                     Public product / inquiry types
 │   └── format.ts                    Formatting helpers
@@ -60,8 +60,9 @@ backend.
    ```
 3. Restart `pnpm -F nextjs-booking-portal dev`.
 
-The client in `lib/voyant-client.ts` expects Voyant to return product payloads
-in the shape described by `lib/types.ts#PublicProduct`. In a real deployment
+The client in `lib/voyant-client.ts` uses the shared public fetch/error
+contract from `@voyantjs/storefront-react`, but keeps example-local response
+schemas for the simplified product and inquiry payloads. In a real deployment
 you would either:
 
 - Map Voyant's `selectProductSchema` to the public shape in a server-side

--- a/examples/nextjs-booking-portal/app/api/inquiries/route.ts
+++ b/examples/nextjs-booking-portal/app/api/inquiries/route.ts
@@ -1,23 +1,9 @@
 import { NextResponse } from "next/server"
 
-import type { InquiryInput } from "../../../lib/types"
+import { inquiryInputSchema } from "../../../lib/types"
 import { submitInquiry } from "../../../lib/voyant-client"
 
 export const dynamic = "force-dynamic"
-
-function isValidInquiry(body: unknown): body is InquiryInput {
-  if (typeof body !== "object" || body === null) return false
-  const b = body as Record<string, unknown>
-  if (typeof b.productId !== "string") return false
-  if (typeof b.travelDate !== "string") return false
-  if (typeof b.partySize !== "number") return false
-  const contact = b.contact as Record<string, unknown> | undefined
-  if (!contact) return false
-  if (typeof contact.firstName !== "string") return false
-  if (typeof contact.lastName !== "string") return false
-  if (typeof contact.email !== "string") return false
-  return true
-}
 
 export async function POST(request: Request): Promise<NextResponse> {
   let body: unknown
@@ -26,9 +12,12 @@ export async function POST(request: Request): Promise<NextResponse> {
   } catch {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
   }
-  if (!isValidInquiry(body)) {
+
+  const parsed = inquiryInputSchema.safeParse(body)
+  if (!parsed.success) {
     return NextResponse.json({ error: "Invalid inquiry payload" }, { status: 400 })
   }
-  const response = await submitInquiry(body)
+
+  const response = await submitInquiry(parsed.data)
   return NextResponse.json(response, { status: 201 })
 }

--- a/examples/nextjs-booking-portal/lib/types.ts
+++ b/examples/nextjs-booking-portal/lib/types.ts
@@ -1,3 +1,5 @@
+import { z } from "zod"
+
 /**
  * Booking-portal types — these intentionally mirror a **subset** of Voyant's
  * `products` module shapes so the example stays self-contained. In a real
@@ -10,45 +12,50 @@
  * We keep the fields small here to make the example readable.
  */
 
-export interface PublicProduct {
-  id: string
-  name: string
-  summary: string
-  description: string
-  destination: string
-  durationDays: number
-  basePriceCents: number
-  currency: string
-  heroImage: string
-  highlights: readonly string[]
-}
+export const publicProductSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  summary: z.string(),
+  description: z.string(),
+  destination: z.string(),
+  durationDays: z.number(),
+  basePriceCents: z.number(),
+  currency: z.string(),
+  heroImage: z.string(),
+  highlights: z.array(z.string()),
+})
 
-export interface PublicProductList {
-  items: readonly PublicProduct[]
-  total: number
-}
+export const publicProductListSchema = z.object({
+  items: z.array(publicProductSchema),
+  total: z.number(),
+})
 
 /**
  * Customer inquiry submitted from the `/inquire/[id]` form. A real customer
  * actor posts this to `/v1/public/bookings` (or a dedicated inquiries
  * module) with `Content-Type: application/json`.
  */
-export interface InquiryInput {
-  productId: string
-  travelDate: string
-  partySize: number
-  contact: {
-    firstName: string
-    lastName: string
-    email: string
-    phone?: string
-  }
-  message?: string
-}
+export const inquiryInputSchema = z.object({
+  productId: z.string(),
+  travelDate: z.string(),
+  partySize: z.number(),
+  contact: z.object({
+    firstName: z.string(),
+    lastName: z.string(),
+    email: z.string(),
+    phone: z.string().optional(),
+  }),
+  message: z.string().optional(),
+})
 
-export interface InquiryResponse {
-  id: string
-  status: "received" | "error"
-  productId: string
-  createdAt: string
-}
+export const inquiryResponseSchema = z.object({
+  id: z.string(),
+  status: z.enum(["received", "error"]),
+  productId: z.string(),
+  createdAt: z.string(),
+})
+
+export type PublicProduct = z.infer<typeof publicProductSchema>
+export type PublicProductList = z.infer<typeof publicProductListSchema>
+export type InquiryInput = z.infer<typeof inquiryInputSchema>
+export type InquiryResponse = z.infer<typeof inquiryResponseSchema>

--- a/examples/nextjs-booking-portal/lib/voyant-client.ts
+++ b/examples/nextjs-booking-portal/lib/voyant-client.ts
@@ -1,5 +1,15 @@
+import { fetchWithValidation, VoyantApiError, type VoyantFetcher } from "@voyantjs/storefront-react"
+
 import { findMockProduct, MOCK_PRODUCTS } from "./mock-data"
-import type { InquiryInput, InquiryResponse, PublicProduct, PublicProductList } from "./types"
+import {
+  type InquiryInput,
+  type InquiryResponse,
+  inquiryResponseSchema,
+  type PublicProduct,
+  type PublicProductList,
+  publicProductListSchema,
+  publicProductSchema,
+} from "./types"
 
 /**
  * Server-side Voyant REST client.
@@ -18,39 +28,42 @@ const API_URL = process.env.VOYANT_API_URL?.replace(/\/$/, "") ?? ""
 const API_KEY = process.env.VOYANT_API_KEY ?? ""
 const MOCK = process.env.USE_MOCK_DATA === "1" || API_URL === ""
 
-function headers(): HeadersInit {
-  const h: Record<string, string> = { "Content-Type": "application/json" }
+function createApiHeaders(init?: HeadersInit): Headers {
+  const h = new Headers(init)
   if (API_KEY) {
-    h.Authorization = `Bearer ${API_KEY}`
+    h.set("Authorization", `Bearer ${API_KEY}`)
   }
   return h
 }
 
-async function voyantFetch<T>(path: string, init?: RequestInit): Promise<T> {
-  if (!API_URL) {
-    throw new Error("VOYANT_API_URL is not configured")
-  }
-  const res = await fetch(`${API_URL}${path}`, {
+const apiFetcher: VoyantFetcher = (url, init) =>
+  fetch(url, {
     ...init,
-    headers: { ...headers(), ...init?.headers },
+    headers: createApiHeaders(init?.headers),
     // Customer portals rarely need cached responses in the BFF layer; let
     // Next.js decide at the route-handler level.
     cache: "no-store",
   })
-  if (!res.ok) {
-    const body = await res.text()
-    throw new Error(`Voyant ${res.status}: ${body}`)
+
+async function voyantFetch<T>(
+  path: string,
+  schema: Parameters<typeof fetchWithValidation<T>>[1],
+  init?: RequestInit,
+): Promise<T> {
+  if (!API_URL) {
+    throw new Error("VOYANT_API_URL is not configured")
   }
-  return (await res.json()) as T
+
+  return fetchWithValidation(path, schema, { baseUrl: API_URL, fetcher: apiFetcher }, init)
 }
 
 export async function listProducts(): Promise<PublicProductList> {
   if (MOCK) {
-    return { items: MOCK_PRODUCTS, total: MOCK_PRODUCTS.length }
+    return { items: [...MOCK_PRODUCTS], total: MOCK_PRODUCTS.length }
   }
   // Real Voyant call — adapt the mapping to your product schema's public
   // projection. The DMC template returns `{ items, total }` by convention.
-  return voyantFetch<PublicProductList>("/v1/public/products")
+  return voyantFetch("/v1/public/products", publicProductListSchema)
 }
 
 export async function getProduct(id: string): Promise<PublicProduct | null> {
@@ -58,9 +71,9 @@ export async function getProduct(id: string): Promise<PublicProduct | null> {
     return findMockProduct(id)
   }
   try {
-    return await voyantFetch<PublicProduct>(`/v1/public/products/${encodeURIComponent(id)}`)
+    return await voyantFetch(`/v1/public/products/${encodeURIComponent(id)}`, publicProductSchema)
   } catch (err) {
-    if (err instanceof Error && err.message.startsWith("Voyant 404")) {
+    if (err instanceof VoyantApiError && err.status === 404) {
       return null
     }
     throw err
@@ -78,7 +91,7 @@ export async function submitInquiry(input: InquiryInput): Promise<InquiryRespons
       createdAt: new Date().toISOString(),
     }
   }
-  return voyantFetch<InquiryResponse>("/v1/public/inquiries", {
+  return voyantFetch("/v1/public/inquiries", inquiryResponseSchema, {
     method: "POST",
     body: JSON.stringify(input),
   })

--- a/examples/nextjs-booking-portal/package.json
+++ b/examples/nextjs-booking-portal/package.json
@@ -17,6 +17,7 @@
     "@voyantjs/customer-portal-react": "workspace:*",
     "@voyantjs/finance": "workspace:*",
     "@voyantjs/finance-react": "workspace:*",
+    "@voyantjs/storefront-react": "workspace:*",
     "next": "^15.5.7",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,6 +422,9 @@ importers:
       '@voyantjs/finance-react':
         specifier: workspace:*
         version: link:../../packages/finance-react
+      '@voyantjs/storefront-react':
+        specifier: workspace:*
+        version: link:../../packages/storefront-react
       next:
         specifier: ^15.5.7
         version: 15.5.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4)


### PR DESCRIPTION
## Summary
- adopt the shared public fetch/error contract from @voyantjs/storefront-react in the Next.js booking portal example
- replace ad hoc inquiry payload guards with shared local zod schemas
- document the example as a public-contract consumer rather than a bespoke REST client

## Testing
- pnpm -C examples/nextjs-booking-portal typecheck
- pnpm -C examples/nextjs-booking-portal lint