### PR TITLE
Validate sync plugin options upfront

### DIFF
--- a/packages/plugins/payload-cms/package.json
+++ b/packages/plugins/payload-cms/package.json
@@ -18,7 +18,8 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
-    "@voyantjs/core": "workspace:*"
+    "@voyantjs/core": "workspace:*",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@voyantjs/voyant-typescript-config": "workspace:*",

--- a/packages/plugins/payload-cms/src/plugin.ts
+++ b/packages/plugins/payload-cms/src/plugin.ts
@@ -1,7 +1,9 @@
 import type { Plugin, Subscriber } from "@voyantjs/core"
+import { ZodError } from "zod"
 
 import { createPayloadClient, type PayloadClientOptions } from "./client.js"
 import type { PayloadDocBody, VoyantEntityEvent } from "./types.js"
+import { payloadCmsPluginOptionsSchema } from "./validation.js"
 
 /**
  * Event names the plugin subscribes to. Defaults match the `<resource>.<pastTenseAction>`
@@ -74,13 +76,14 @@ function coerceEvent(data: unknown): VoyantEntityEvent | null {
  * EventBus contract, so a Payload outage never blocks the emitter.
  */
 export function payloadCmsPlugin(options: PayloadCmsPluginOptions): Plugin {
-  const client = createPayloadClient(options)
-  const mapEvent = options.mapEvent ?? defaultMapEvent
-  const logger = options.logger ?? console
+  const validatedOptions = parsePayloadCmsPluginOptions(options)
+  const client = createPayloadClient(validatedOptions)
+  const mapEvent = validatedOptions.mapEvent ?? defaultMapEvent
+  const logger = validatedOptions.logger ?? console
   const eventNames = {
-    created: options.events?.created ?? "product.created",
-    updated: options.events?.updated ?? "product.updated",
-    deleted: options.events?.deleted ?? "product.deleted",
+    created: validatedOptions.events?.created ?? "product.created",
+    updated: validatedOptions.events?.updated ?? "product.updated",
+    deleted: validatedOptions.events?.deleted ?? "product.deleted",
   }
 
   const subscribers: Subscriber[] = [
@@ -90,7 +93,7 @@ export function payloadCmsPlugin(options: PayloadCmsPluginOptions): Plugin {
         const event = coerceEvent(envelope.data)
         if (!event) return
         try {
-          await client.upsertByVoyantId(options.collection, event.id, mapEvent(event))
+          await client.upsertByVoyantId(validatedOptions.collection, event.id, mapEvent(event))
         } catch (err) {
           logger.error(
             `[payload-cms] upsert on "${eventNames.created}" failed for ${event.id}`,
@@ -105,7 +108,7 @@ export function payloadCmsPlugin(options: PayloadCmsPluginOptions): Plugin {
         const event = coerceEvent(envelope.data)
         if (!event) return
         try {
-          await client.upsertByVoyantId(options.collection, event.id, mapEvent(event))
+          await client.upsertByVoyantId(validatedOptions.collection, event.id, mapEvent(event))
         } catch (err) {
           logger.error(
             `[payload-cms] upsert on "${eventNames.updated}" failed for ${event.id}`,
@@ -120,7 +123,7 @@ export function payloadCmsPlugin(options: PayloadCmsPluginOptions): Plugin {
         const event = coerceEvent(envelope.data)
         if (!event) return
         try {
-          await client.deleteByVoyantId(options.collection, event.id)
+          await client.deleteByVoyantId(validatedOptions.collection, event.id)
         } catch (err) {
           logger.error(
             `[payload-cms] delete on "${eventNames.deleted}" failed for ${event.id}`,
@@ -135,5 +138,22 @@ export function payloadCmsPlugin(options: PayloadCmsPluginOptions): Plugin {
     name: "payload-cms",
     version: "0.1.0",
     subscribers,
+  }
+}
+
+function parsePayloadCmsPluginOptions(options: PayloadCmsPluginOptions): PayloadCmsPluginOptions {
+  try {
+    return payloadCmsPluginOptionsSchema.parse(options)
+  } catch (error) {
+    if (error instanceof ZodError) {
+      const detail = error.issues
+        .map((issue) => {
+          const path = issue.path.join(".") || "options"
+          return `${path}: ${issue.message}`
+        })
+        .join("; ")
+      throw new Error(`Invalid Payload CMS plugin options: ${detail}`)
+    }
+    throw error
   }
 }

--- a/packages/plugins/payload-cms/src/validation.ts
+++ b/packages/plugins/payload-cms/src/validation.ts
@@ -1,0 +1,52 @@
+import { z } from "zod"
+import type {
+  PayloadCmsPluginOptions,
+  PayloadLogger,
+  PayloadMapFn,
+  PayloadSyncEventNames,
+} from "./plugin.js"
+import type { PayloadFetch } from "./types.js"
+
+const optionalString = z.string().trim().min(1).optional()
+
+const optionalFetch = z.custom<PayloadFetch | undefined>(
+  (value) => value === undefined || typeof value === "function",
+  "Expected a fetch implementation function",
+)
+
+const optionalLogger = z.custom<PayloadLogger | undefined>(
+  (value) =>
+    value === undefined ||
+    (typeof value === "object" &&
+      value !== null &&
+      typeof (value as PayloadLogger).error === "function" &&
+      (((value as PayloadLogger).info ?? undefined) === undefined ||
+        typeof (value as PayloadLogger).info === "function")),
+  "Expected a logger with an error function",
+)
+
+const optionalMapEvent = z.custom<PayloadMapFn | undefined>(
+  (value) => value === undefined || typeof value === "function",
+  "Expected a mapEvent function",
+)
+
+const optionalEvents = z.custom<PayloadSyncEventNames | undefined>((value) => {
+  if (value === undefined) return true
+  if (typeof value !== "object" || value === null) return false
+  const events = value as PayloadSyncEventNames
+  return [events.created, events.updated, events.deleted].every(
+    (entry) => entry === undefined || (typeof entry === "string" && entry.trim().length > 0),
+  )
+}, "Expected event names to be non-empty strings")
+
+export const payloadCmsPluginOptionsSchema = z.object({
+  apiUrl: z.string().trim().url(),
+  apiKey: z.string().trim().min(1),
+  collection: z.string().trim().min(1),
+  voyantIdField: optionalString,
+  apiKeyAuthScheme: optionalString,
+  fetch: optionalFetch.optional(),
+  events: optionalEvents.optional(),
+  mapEvent: optionalMapEvent.optional(),
+  logger: optionalLogger.optional(),
+}) satisfies z.ZodType<PayloadCmsPluginOptions>

--- a/packages/plugins/payload-cms/tests/unit/plugin.test.ts
+++ b/packages/plugins/payload-cms/tests/unit/plugin.test.ts
@@ -47,6 +47,15 @@ describe("payloadCmsPlugin", () => {
     expect(names).toEqual(["departure.created", "departure.updated", "departure.deleted"])
   })
 
+  it("fails fast on invalid plugin options", () => {
+    expect(() =>
+      payloadCmsPlugin({
+        ...baseOptions,
+        apiUrl: "not-a-url",
+      }),
+    ).toThrowError(/Invalid Payload CMS plugin options/)
+  })
+
   it("pushes product.created to Payload as an upsert", async () => {
     const fetchMock = vi
       .fn<PayloadFetch>()

--- a/packages/plugins/sanity-cms/package.json
+++ b/packages/plugins/sanity-cms/package.json
@@ -18,7 +18,8 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
-    "@voyantjs/core": "workspace:*"
+    "@voyantjs/core": "workspace:*",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@voyantjs/voyant-typescript-config": "workspace:*",

--- a/packages/plugins/sanity-cms/src/plugin.ts
+++ b/packages/plugins/sanity-cms/src/plugin.ts
@@ -1,7 +1,9 @@
 import type { Plugin, Subscriber } from "@voyantjs/core"
+import { ZodError } from "zod"
 
 import { createSanityClient, type SanityClientOptions } from "./client.js"
 import type { SanityDocBody, VoyantEntityEvent } from "./types.js"
+import { sanityCmsPluginOptionsSchema } from "./validation.js"
 
 /**
  * Event names the plugin subscribes to. Defaults match the
@@ -76,13 +78,14 @@ function coerceEvent(data: unknown): VoyantEntityEvent | null {
  * EventBus contract, so a Sanity outage never blocks the emitter.
  */
 export function sanityCmsPlugin(options: SanityCmsPluginOptions): Plugin {
-  const client = createSanityClient(options)
-  const mapEvent = options.mapEvent ?? defaultMapEvent
-  const logger = options.logger ?? console
+  const validatedOptions = parseSanityCmsPluginOptions(options)
+  const client = createSanityClient(validatedOptions)
+  const mapEvent = validatedOptions.mapEvent ?? defaultMapEvent
+  const logger = validatedOptions.logger ?? console
   const eventNames = {
-    created: options.events?.created ?? "product.created",
-    updated: options.events?.updated ?? "product.updated",
-    deleted: options.events?.deleted ?? "product.deleted",
+    created: validatedOptions.events?.created ?? "product.created",
+    updated: validatedOptions.events?.updated ?? "product.updated",
+    deleted: validatedOptions.events?.deleted ?? "product.deleted",
   }
 
   const subscribers: Subscriber[] = [
@@ -92,7 +95,7 @@ export function sanityCmsPlugin(options: SanityCmsPluginOptions): Plugin {
         const event = coerceEvent(envelope.data)
         if (!event) return
         try {
-          await client.upsertByVoyantId(options.documentType, event.id, mapEvent(event))
+          await client.upsertByVoyantId(validatedOptions.documentType, event.id, mapEvent(event))
         } catch (err) {
           logger.error(`[sanity-cms] upsert on "${eventNames.created}" failed for ${event.id}`, err)
         }
@@ -104,7 +107,7 @@ export function sanityCmsPlugin(options: SanityCmsPluginOptions): Plugin {
         const event = coerceEvent(envelope.data)
         if (!event) return
         try {
-          await client.upsertByVoyantId(options.documentType, event.id, mapEvent(event))
+          await client.upsertByVoyantId(validatedOptions.documentType, event.id, mapEvent(event))
         } catch (err) {
           logger.error(`[sanity-cms] upsert on "${eventNames.updated}" failed for ${event.id}`, err)
         }
@@ -116,7 +119,7 @@ export function sanityCmsPlugin(options: SanityCmsPluginOptions): Plugin {
         const event = coerceEvent(envelope.data)
         if (!event) return
         try {
-          await client.deleteByVoyantId(options.documentType, event.id)
+          await client.deleteByVoyantId(validatedOptions.documentType, event.id)
         } catch (err) {
           logger.error(`[sanity-cms] delete on "${eventNames.deleted}" failed for ${event.id}`, err)
         }
@@ -128,5 +131,22 @@ export function sanityCmsPlugin(options: SanityCmsPluginOptions): Plugin {
     name: "sanity-cms",
     version: "0.1.0",
     subscribers,
+  }
+}
+
+function parseSanityCmsPluginOptions(options: SanityCmsPluginOptions): SanityCmsPluginOptions {
+  try {
+    return sanityCmsPluginOptionsSchema.parse(options)
+  } catch (error) {
+    if (error instanceof ZodError) {
+      const detail = error.issues
+        .map((issue) => {
+          const path = issue.path.join(".") || "options"
+          return `${path}: ${issue.message}`
+        })
+        .join("; ")
+      throw new Error(`Invalid Sanity CMS plugin options: ${detail}`)
+    }
+    throw error
   }
 }

--- a/packages/plugins/sanity-cms/src/validation.ts
+++ b/packages/plugins/sanity-cms/src/validation.ts
@@ -1,0 +1,54 @@
+import { z } from "zod"
+import type {
+  SanityCmsPluginOptions,
+  SanityLogger,
+  SanityMapFn,
+  SanitySyncEventNames,
+} from "./plugin.js"
+import type { SanityFetch } from "./types.js"
+
+const optionalString = z.string().trim().min(1).optional()
+
+const optionalFetch = z.custom<SanityFetch | undefined>(
+  (value) => value === undefined || typeof value === "function",
+  "Expected a fetch implementation function",
+)
+
+const optionalLogger = z.custom<SanityLogger | undefined>(
+  (value) =>
+    value === undefined ||
+    (typeof value === "object" &&
+      value !== null &&
+      typeof (value as SanityLogger).error === "function" &&
+      (((value as SanityLogger).info ?? undefined) === undefined ||
+        typeof (value as SanityLogger).info === "function")),
+  "Expected a logger with an error function",
+)
+
+const optionalMapEvent = z.custom<SanityMapFn | undefined>(
+  (value) => value === undefined || typeof value === "function",
+  "Expected a mapEvent function",
+)
+
+const optionalEvents = z.custom<SanitySyncEventNames | undefined>((value) => {
+  if (value === undefined) return true
+  if (typeof value !== "object" || value === null) return false
+  const events = value as SanitySyncEventNames
+  return [events.created, events.updated, events.deleted].every(
+    (entry) => entry === undefined || (typeof entry === "string" && entry.trim().length > 0),
+  )
+}, "Expected event names to be non-empty strings")
+
+export const sanityCmsPluginOptionsSchema = z.object({
+  projectId: z.string().trim().min(1),
+  dataset: z.string().trim().min(1),
+  token: z.string().trim().min(1),
+  documentType: z.string().trim().min(1),
+  apiVersion: optionalString,
+  voyantIdField: optionalString,
+  apiHost: optionalString,
+  fetch: optionalFetch.optional(),
+  events: optionalEvents.optional(),
+  mapEvent: optionalMapEvent.optional(),
+  logger: optionalLogger.optional(),
+}) satisfies z.ZodType<SanityCmsPluginOptions>

--- a/packages/plugins/sanity-cms/tests/unit/plugin.test.ts
+++ b/packages/plugins/sanity-cms/tests/unit/plugin.test.ts
@@ -48,6 +48,15 @@ describe("sanityCmsPlugin", () => {
     expect(names).toEqual(["departure.created", "departure.updated", "departure.deleted"])
   })
 
+  it("fails fast on invalid plugin options", () => {
+    expect(() =>
+      sanityCmsPlugin({
+        ...baseOptions,
+        token: "",
+      }),
+    ).toThrowError(/Invalid Sanity CMS plugin options/)
+  })
+
   it("pushes product.created to Sanity as a create mutation", async () => {
     const fetchMock = vi
       .fn<SanityFetch>()

--- a/packages/plugins/smartbill/package.json
+++ b/packages/plugins/smartbill/package.json
@@ -19,7 +19,8 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
-    "@voyantjs/core": "workspace:*"
+    "@voyantjs/core": "workspace:*",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@voyantjs/voyant-typescript-config": "workspace:*",

--- a/packages/plugins/smartbill/src/plugin.ts
+++ b/packages/plugins/smartbill/src/plugin.ts
@@ -1,8 +1,10 @@
 import type { Plugin, Subscriber } from "@voyantjs/core"
+import { ZodError } from "zod"
 
 import { createSmartbillClient, type SmartbillClientOptions } from "./client.js"
 import { mapVoyantInvoiceToSmartbill, type SmartbillMappingOptions } from "./mapping.js"
 import type { VoyantInvoiceEvent } from "./types.js"
+import { smartbillPluginOptionsSchema } from "./validation.js"
 
 /**
  * Event names the plugin subscribes to. Defaults match the
@@ -67,22 +69,23 @@ function coerceEvent(data: unknown): VoyantInvoiceEvent | null {
  * EventBus contract, so a SmartBill outage never blocks the emitter.
  */
 export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
-  const client = createSmartbillClient(options)
-  const logger = options.logger ?? console
+  const validatedOptions = parseSmartbillPluginOptions(options)
+  const client = createSmartbillClient(validatedOptions)
+  const logger = validatedOptions.logger ?? console
   const mappingOptions: SmartbillMappingOptions = {
-    companyVatCode: options.companyVatCode,
-    seriesName: options.seriesName,
-    language: options.language,
-    isTaxIncluded: options.isTaxIncluded,
-    art311SpecialRegime: options.art311SpecialRegime,
+    companyVatCode: validatedOptions.companyVatCode,
+    seriesName: validatedOptions.seriesName,
+    language: validatedOptions.language,
+    isTaxIncluded: validatedOptions.isTaxIncluded,
+    art311SpecialRegime: validatedOptions.art311SpecialRegime,
   }
   const mapEvent =
-    options.mapEvent ??
+    validatedOptions.mapEvent ??
     ((ev: VoyantInvoiceEvent) => mapVoyantInvoiceToSmartbill(ev, mappingOptions))
   const eventNames = {
-    issued: options.events?.issued ?? "invoice.issued",
-    voided: options.events?.voided ?? "invoice.voided",
-    syncRequested: options.events?.syncRequested ?? "invoice.external.sync.requested",
+    issued: validatedOptions.events?.issued ?? "invoice.issued",
+    voided: validatedOptions.events?.voided ?? "invoice.voided",
+    syncRequested: validatedOptions.events?.syncRequested ?? "invoice.external.sync.requested",
   }
 
   const subscribers: Subscriber[] = [
@@ -115,7 +118,7 @@ export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
           const seriesName =
             typeof event.externalSeriesName === "string"
               ? event.externalSeriesName
-              : options.seriesName
+              : validatedOptions.seriesName
           const number =
             typeof event.externalNumber === "string"
               ? event.externalNumber
@@ -126,7 +129,7 @@ export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
             logger.error(`[smartbill] cannot cancel invoice ${event.id}: missing external number`)
             return
           }
-          await client.cancelInvoice(options.companyVatCode, seriesName, number)
+          await client.cancelInvoice(validatedOptions.companyVatCode, seriesName, number)
           logger.info?.(`[smartbill] invoice cancelled: ${seriesName}-${number} for ${event.id}`)
         } catch (err) {
           logger.error(
@@ -145,7 +148,7 @@ export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
           const seriesName =
             typeof event.externalSeriesName === "string"
               ? event.externalSeriesName
-              : options.seriesName
+              : validatedOptions.seriesName
           const number =
             typeof event.externalNumber === "string"
               ? event.externalNumber
@@ -156,7 +159,11 @@ export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
             logger.error(`[smartbill] cannot sync invoice ${event.id}: missing external number`)
             return
           }
-          const status = await client.getPaymentStatus(options.companyVatCode, seriesName, number)
+          const status = await client.getPaymentStatus(
+            validatedOptions.companyVatCode,
+            seriesName,
+            number,
+          )
           logger.info?.(
             `[smartbill] payment status for ${seriesName}-${number}: ${status.status}`,
             status,
@@ -175,5 +182,22 @@ export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
     name: "smartbill",
     version: "0.1.0",
     subscribers,
+  }
+}
+
+function parseSmartbillPluginOptions(options: SmartbillPluginOptions): SmartbillPluginOptions {
+  try {
+    return smartbillPluginOptionsSchema.parse(options)
+  } catch (error) {
+    if (error instanceof ZodError) {
+      const detail = error.issues
+        .map((issue) => {
+          const path = issue.path.join(".") || "options"
+          return `${path}: ${issue.message}`
+        })
+        .join("; ")
+      throw new Error(`Invalid SmartBill plugin options: ${detail}`)
+    }
+    throw error
   }
 }

--- a/packages/plugins/smartbill/src/validation.ts
+++ b/packages/plugins/smartbill/src/validation.ts
@@ -1,0 +1,56 @@
+import { z } from "zod"
+import type {
+  SmartbillLogger,
+  SmartbillMapFn,
+  SmartbillPluginOptions,
+  SmartbillSyncEventNames,
+} from "./plugin.js"
+import type { SmartbillFetch } from "./types.js"
+
+const optionalString = z.string().trim().min(1).optional()
+const optionalUrl = z.string().trim().url().optional()
+
+const optionalFetch = z.custom<SmartbillFetch | undefined>(
+  (value) => value === undefined || typeof value === "function",
+  "Expected a fetch implementation function",
+)
+
+const optionalLogger = z.custom<SmartbillLogger | undefined>(
+  (value) =>
+    value === undefined ||
+    (typeof value === "object" &&
+      value !== null &&
+      typeof (value as SmartbillLogger).error === "function" &&
+      (((value as SmartbillLogger).info ?? undefined) === undefined ||
+        typeof (value as SmartbillLogger).info === "function")),
+  "Expected a logger with an error function",
+)
+
+const optionalMapEvent = z.custom<SmartbillMapFn | undefined>(
+  (value) => value === undefined || typeof value === "function",
+  "Expected a mapEvent function",
+)
+
+const optionalEvents = z.custom<SmartbillSyncEventNames | undefined>((value) => {
+  if (value === undefined) return true
+  if (typeof value !== "object" || value === null) return false
+  const events = value as SmartbillSyncEventNames
+  return [events.issued, events.voided, events.syncRequested].every(
+    (entry) => entry === undefined || (typeof entry === "string" && entry.trim().length > 0),
+  )
+}, "Expected event names to be non-empty strings")
+
+export const smartbillPluginOptionsSchema = z.object({
+  username: z.string().trim().min(1),
+  apiToken: z.string().trim().min(1),
+  companyVatCode: z.string().trim().min(1),
+  seriesName: z.string().trim().min(1),
+  apiUrl: optionalUrl,
+  fetch: optionalFetch.optional(),
+  language: optionalString,
+  isTaxIncluded: z.boolean().optional(),
+  art311SpecialRegime: z.boolean().optional(),
+  events: optionalEvents.optional(),
+  mapEvent: optionalMapEvent.optional(),
+  logger: optionalLogger.optional(),
+}) satisfies z.ZodType<SmartbillPluginOptions>

--- a/packages/plugins/smartbill/tests/unit/plugin.test.ts
+++ b/packages/plugins/smartbill/tests/unit/plugin.test.ts
@@ -76,6 +76,15 @@ describe("smartbillPlugin structure", () => {
     const events = plugin.subscribers!.map((s) => s.event)
     expect(events).toEqual(["custom.issued", "custom.voided", "custom.sync"])
   })
+
+  it("fails fast on invalid plugin options", () => {
+    expect(() =>
+      smartbillPlugin({
+        ...baseOptions,
+        username: "",
+      }),
+    ).toThrowError(/Invalid SmartBill plugin options/)
+  })
 })
 
 describe("smartbillPlugin — invoice.issued subscriber", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1909,6 +1909,9 @@ importers:
       '@voyantjs/core':
         specifier: workspace:*
         version: link:../../core
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@voyantjs/voyant-typescript-config':
         specifier: workspace:*
@@ -1925,6 +1928,9 @@ importers:
       '@voyantjs/core':
         specifier: workspace:*
         version: link:../../core
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@voyantjs/voyant-typescript-config':
         specifier: workspace:*
@@ -1941,6 +1947,9 @@ importers:
       '@voyantjs/core':
         specifier: workspace:*
         version: link:../../core
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@voyantjs/voyant-typescript-config':
         specifier: workspace:*


### PR DESCRIPTION
## Summary
- add upfront zod-based validation for SmartBill, Payload CMS, and Sanity CMS plugin options
- fail fast during plugin construction instead of deferring invalid config to subscribers or client calls
- cover the new validation behavior in plugin unit tests

## Testing
- pnpm -C packages/plugins/smartbill lint
- pnpm -C packages/plugins/smartbill typecheck
- pnpm -C packages/plugins/smartbill test
- pnpm -C packages/plugins/payload-cms lint
- pnpm -C packages/plugins/payload-cms typecheck
- pnpm -C packages/plugins/payload-cms test
- pnpm -C packages/plugins/sanity-cms lint
- pnpm -C packages/plugins/sanity-cms typecheck
- pnpm -C packages/plugins/sanity-cms test
- full pre-push repo test pipeline
