### PR TITLE
Tighten sync plugin taxonomy

### DIFF
--- a/packages/plugins/payload-cms/README.md
+++ b/packages/plugins/payload-cms/README.md
@@ -20,12 +20,12 @@ pnpm add @voyantjs/plugin-payload-cms
 ## Usage
 
 ```typescript
-import { createPayloadCmsSyncPlugin } from "@voyantjs/plugin-payload-cms"
+import { payloadCmsPlugin } from "@voyantjs/plugin-payload-cms"
 import { createApp } from "@voyantjs/hono"
 
 const app = createApp({
   plugins: [
-    createPayloadCmsSyncPlugin({
+    payloadCmsPlugin({
       apiUrl: "https://cms.example.com/api",
       apiKey: env.PAYLOAD_API_KEY,
       collection: "products",
@@ -42,7 +42,7 @@ By default the plugin wires up 3 subscribers (`product.created`, `product.update
 | Entry | Description |
 | --- | --- |
 | `.` | Barrel re-exports |
-| `./plugin` | `payloadCmsPlugin(options)` and `createPayloadCmsSyncPlugin(options)` |
+| `./plugin` | `payloadCmsPlugin(options)` |
 | `./client` | `createPayloadClient` — `upsertByVoyantId`, `deleteByVoyantId`, `findByVoyantId` |
 | `./types` | Plugin option types |
 

--- a/packages/plugins/payload-cms/src/index.ts
+++ b/packages/plugins/payload-cms/src/index.ts
@@ -6,5 +6,5 @@ export type {
   PayloadMapFn,
   PayloadSyncEventNames,
 } from "./plugin.js"
-export { payloadCmsPlugin, payloadCmsPlugin as createPayloadCmsSyncPlugin } from "./plugin.js"
+export { payloadCmsPlugin } from "./plugin.js"
 export type { PayloadDocBody, PayloadFetch, VoyantEntityEvent } from "./types.js"

--- a/packages/plugins/sanity-cms/README.md
+++ b/packages/plugins/sanity-cms/README.md
@@ -20,12 +20,12 @@ pnpm add @voyantjs/plugin-sanity-cms
 ## Usage
 
 ```typescript
-import { createSanityCmsSyncPlugin } from "@voyantjs/plugin-sanity-cms"
+import { sanityCmsPlugin } from "@voyantjs/plugin-sanity-cms"
 import { createApp } from "@voyantjs/hono"
 
 const app = createApp({
   plugins: [
-    createSanityCmsSyncPlugin({
+    sanityCmsPlugin({
       projectId: env.SANITY_PROJECT_ID,
       dataset: "production",
       token: env.SANITY_TOKEN,
@@ -43,7 +43,7 @@ Uses GROQ for reads and Sanity Mutations API for writes. Default `apiVersion` is
 | Entry | Description |
 | --- | --- |
 | `.` | Barrel re-exports |
-| `./plugin` | `sanityCmsPlugin(options)` and `createSanityCmsSyncPlugin(options)` |
+| `./plugin` | `sanityCmsPlugin(options)` |
 | `./client` | `createSanityClient` — `upsertByVoyantId`, `deleteByVoyantId`, `findByVoyantId` |
 | `./types` | Plugin option types |
 

--- a/packages/plugins/sanity-cms/src/index.ts
+++ b/packages/plugins/sanity-cms/src/index.ts
@@ -6,5 +6,5 @@ export type {
   SanityMapFn,
   SanitySyncEventNames,
 } from "./plugin.js"
-export { sanityCmsPlugin, sanityCmsPlugin as createSanityCmsSyncPlugin } from "./plugin.js"
+export { sanityCmsPlugin } from "./plugin.js"
 export type { SanityDocBody, SanityFetch, VoyantEntityEvent } from "./types.js"

--- a/packages/plugins/smartbill/README.md
+++ b/packages/plugins/smartbill/README.md
@@ -20,12 +20,12 @@ pnpm add @voyantjs/plugin-smartbill
 ## Usage
 
 ```typescript
-import { createSmartbillSyncPlugin } from "@voyantjs/plugin-smartbill"
+import { smartbillPlugin } from "@voyantjs/plugin-smartbill"
 import { createApp } from "@voyantjs/hono"
 
 const app = createApp({
   plugins: [
-    createSmartbillSyncPlugin({
+    smartbillPlugin({
       username: env.SMARTBILL_USERNAME,
       apiToken: env.SMARTBILL_API_TOKEN,
       companyVatCode: "RO12345678",
@@ -43,7 +43,7 @@ By default the plugin wires up 3 subscribers (`invoice.issued`, `invoice.voided`
 | Entry | Description |
 | --- | --- |
 | `.` | Barrel re-exports |
-| `./plugin` | `smartbillPlugin(options)` and `createSmartbillSyncPlugin(options)` |
+| `./plugin` | `smartbillPlugin(options)` |
 | `./client` | `createSmartbillClient` — `createInvoice`, `cancelInvoice`, `viewPdf`, `getPaymentStatus`, etc. |
 | `./types` | SmartBill invoice types |
 

--- a/packages/plugins/smartbill/src/index.ts
+++ b/packages/plugins/smartbill/src/index.ts
@@ -8,7 +8,7 @@ export type {
   SmartbillPluginOptions,
   SmartbillSyncEventNames,
 } from "./plugin.js"
-export { smartbillPlugin, smartbillPlugin as createSmartbillSyncPlugin } from "./plugin.js"
+export { smartbillPlugin } from "./plugin.js"
 export type {
   SmartbillInvoiceSettlementPoller,
   SmartbillInvoiceSettlementPollerOptions,


### PR DESCRIPTION
## Summary
- remove sync-plugin alias exports that reinforce a plugin-first mental model where we only need canonical package exports
- update SmartBill, Payload CMS, and Sanity CMS README examples to use their direct plugin factory exports
- keep the package surface aligned with the documented module/provider/plugin taxonomy

## Testing
- git diff --check
- pnpm -C packages/plugins/smartbill typecheck
- pnpm -C packages/plugins/payload-cms typecheck
- pnpm -C packages/plugins/sanity-cms typecheck
- full pre-commit lint/typecheck/build sweep
- full pre-push repo test pipeline