### PR TITLE
Adopt admin widget slots on detail pages

### DIFF
--- a/templates/operator/src/components/voyant/bookings/booking-detail-page.tsx
+++ b/templates/operator/src/components/voyant/bookings/booking-detail-page.tsx
@@ -10,6 +10,7 @@ import {
 import { ArrowLeft, Ban, Loader2, Pencil, RefreshCw, Trash2 } from "lucide-react"
 import { useState } from "react"
 
+import { AdminWidgetSlotRenderer } from "@/components/admin/admin-widget-slot"
 import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from "@/components/ui"
 
 import { BookingActivityTimeline } from "./booking-activity-timeline"
@@ -108,6 +109,7 @@ export function BookingDetailPage({ id }: { id: string }) {
           </Button>
         </div>
       </div>
+      <AdminWidgetSlotRenderer slot="booking.details.header" props={{ booking }} />
 
       <div className="grid gap-6 md:grid-cols-2">
         <Card>
@@ -193,6 +195,7 @@ export function BookingDetailPage({ id }: { id: string }) {
           </CardContent>
         </Card>
       </div>
+      <AdminWidgetSlotRenderer slot="booking.details.after-summary" props={{ booking }} />
 
       <PassengerList bookingId={id} />
       <BookingItemList bookingId={id} />

--- a/templates/operator/src/components/voyant/finance/invoice-detail-page.tsx
+++ b/templates/operator/src/components/voyant/finance/invoice-detail-page.tsx
@@ -12,6 +12,7 @@ import {
 import { ArrowLeft, Loader2, Pencil, Trash2 } from "lucide-react"
 import { useState } from "react"
 
+import { AdminWidgetSlotRenderer } from "@/components/admin/admin-widget-slot"
 import { Badge, Button } from "@/components/ui"
 
 import { CreditNoteDialog } from "./credit-note-dialog"
@@ -65,6 +66,11 @@ export function InvoiceDetailPage({ id }: { id: string }) {
     )
   }
 
+  const lineItems = lineItemsData?.data ?? []
+  const payments = paymentsData?.data ?? []
+  const creditNotes = creditNotesData?.data ?? []
+  const notes = notesData?.data ?? []
+
   return (
     <div className="flex flex-col gap-6 p-6">
       <div className="flex items-center gap-4">
@@ -106,6 +112,7 @@ export function InvoiceDetailPage({ id }: { id: string }) {
           </Button>
         </div>
       </div>
+      <AdminWidgetSlotRenderer slot="invoice.details.header" props={{ invoice }} />
 
       <InvoiceInfoCards
         invoice={invoice}
@@ -116,9 +123,13 @@ export function InvoiceDetailPage({ id }: { id: string }) {
           })
         }
       />
+      <AdminWidgetSlotRenderer
+        slot="invoice.details.after-summary"
+        props={{ invoice, lineItems, payments, creditNotes, notes }}
+      />
 
       <InvoiceLineItemsCard
-        lineItems={lineItemsData?.data ?? []}
+        lineItems={lineItems}
         onCreate={() => {
           setEditingLineItem(undefined)
           setLineItemDialogOpen(true)
@@ -134,20 +145,17 @@ export function InvoiceDetailPage({ id }: { id: string }) {
         }}
       />
 
-      <InvoicePaymentsCard
-        payments={paymentsData?.data ?? []}
-        onCreate={() => setPaymentDialogOpen(true)}
-      />
+      <InvoicePaymentsCard payments={payments} onCreate={() => setPaymentDialogOpen(true)} />
 
       <InvoiceCreditNotesCard
-        creditNotes={creditNotesData?.data ?? []}
+        creditNotes={creditNotes}
         onCreate={() => setCreditNoteDialogOpen(true)}
       />
 
       <InvoiceNotesCard
         noteContent={noteContent}
         isAdding={addNoteMutation.isPending}
-        notes={notesData?.data ?? []}
+        notes={notes}
         onNoteChange={setNoteContent}
         onAddNote={() =>
           addNoteMutation.mutate(

--- a/templates/operator/src/lib/admin-extensions.tsx
+++ b/templates/operator/src/lib/admin-extensions.tsx
@@ -6,5 +6,14 @@ import type { AdminExtension } from "@voyantjs/voyant-admin"
  * Keep this explicit and source-controlled so projects can add navigation
  * contributions, widget slots, and route metadata without relying on a more
  * dynamic plugin runtime in the admin shell.
+ *
+ * Widget slots currently exposed by the operator template:
+ * - `dashboard.header`
+ * - `dashboard.after-kpis`
+ * - `dashboard.footer`
+ * - `booking.details.header`
+ * - `booking.details.after-summary`
+ * - `invoice.details.header`
+ * - `invoice.details.after-summary`
  */
 export const adminExtensions: ReadonlyArray<AdminExtension> = []


### PR DESCRIPTION
## Summary
- expose booking detail widget slots in the operator template so admin extensions can attach to a real workflow page
- expose invoice detail widget slots in the operator template with page-specific data for finance extensions
- document the currently supported operator widget slot ids in the template-local admin extension registry

## Testing
- git diff --check
- pnpm -C packages/admin test
- pnpm -C templates/operator typecheck
- full pre-commit lint/typecheck/build sweep
- full pre-push repo test pipeline