### PR TITLE
Refresh customer portal document urls

### DIFF
--- a/apps/dev/src/api/app.ts
+++ b/apps/dev/src/api/app.ts
@@ -3,7 +3,7 @@ import { bookingRequirementsHonoModule } from "@voyantjs/booking-requirements"
 import { bookingsHonoModule, bookingsSupplierExtension } from "@voyantjs/bookings"
 import { createCheckoutHonoModule } from "@voyantjs/checkout"
 import { crmBookingExtension, crmHonoModule } from "@voyantjs/crm"
-import { customerPortalHonoModule } from "@voyantjs/customer-portal"
+import { createCustomerPortalHonoModule } from "@voyantjs/customer-portal"
 import { distributionBookingExtension, distributionHonoModule } from "@voyantjs/distribution"
 import { externalRefsHonoModule } from "@voyantjs/external-refs"
 import { extrasHonoModule } from "@voyantjs/extras"
@@ -38,6 +38,16 @@ const notificationsHonoModule = createNotificationsHonoModule({
 })
 const checkoutHonoModule = createCheckoutHonoModule({
   resolveProviders: resolveNotificationProviders,
+})
+const customerPortalHonoModule = createCustomerPortalHonoModule({
+  resolveDocumentDownloadUrl: async (bindings, storageKey) => {
+    const storage = createMediaStorage(bindings as CloudflareBindings)
+    if (!storage) {
+      return null
+    }
+
+    return storage.signedUrl(storageKey, 300)
+  },
 })
 
 export const app = createApp<CloudflareBindings>({

--- a/packages/customer-portal/src/index.ts
+++ b/packages/customer-portal/src/index.ts
@@ -2,12 +2,15 @@ import type { Module } from "@voyantjs/core"
 import type { HonoModule } from "@voyantjs/hono/module"
 
 import { customerPortalRoutes } from "./routes.js"
-import { publicCustomerPortalRoutes } from "./routes-public.js"
+import {
+  createPublicCustomerPortalRoutes,
+  type PublicCustomerPortalRouteOptions,
+} from "./routes-public.js"
 
 export type { CustomerPortalRoutes } from "./routes.js"
 export { customerPortalRoutes } from "./routes.js"
 export type { PublicCustomerPortalRoutes } from "./routes-public.js"
-export { publicCustomerPortalRoutes } from "./routes-public.js"
+export { createPublicCustomerPortalRoutes, publicCustomerPortalRoutes } from "./routes-public.js"
 export { publicCustomerPortalService } from "./service-public.js"
 export type {
   BootstrapCustomerPortalInput,
@@ -64,8 +67,14 @@ export const customerPortalModule: Module = {
   name: "customer-portal",
 }
 
-export const customerPortalHonoModule: HonoModule = {
-  module: customerPortalModule,
-  routes: customerPortalRoutes,
-  publicRoutes: publicCustomerPortalRoutes,
+export function createCustomerPortalHonoModule(
+  options: PublicCustomerPortalRouteOptions = {},
+): HonoModule {
+  return {
+    module: customerPortalModule,
+    routes: customerPortalRoutes,
+    publicRoutes: createPublicCustomerPortalRoutes(options),
+  }
 }
+
+export const customerPortalHonoModule: HonoModule = createCustomerPortalHonoModule()

--- a/packages/customer-portal/src/routes-public.ts
+++ b/packages/customer-portal/src/routes-public.ts
@@ -56,176 +56,202 @@ function hasBootstrapErrorResult(
   return "error" in value
 }
 
-export const publicCustomerPortalRoutes = new Hono<Env>()
-  .get("/me", async (c) => {
-    const userId = requireUserId(c)
+export interface PublicCustomerPortalRouteOptions {
+  resolveDocumentDownloadUrl?: (
+    bindings: unknown,
+    storageKey: string,
+  ) => Promise<string | null> | string | null
+}
 
-    const profile = await publicCustomerPortalService.getProfileWithOptions(c.get("db"), userId, {
-      kms: resolveOptionalKms(c),
-    })
-    return profile ? c.json({ data: profile }) : notFound(c, "Customer profile not found")
-  })
-  .patch("/me", async (c) => {
-    const userId = requireUserId(c)
+export function createPublicCustomerPortalRoutes(options: PublicCustomerPortalRouteOptions = {}) {
+  const resolveDocumentDownloadUrl = (c: Context<Env>, storageKey: string) =>
+    options.resolveDocumentDownloadUrl?.(c.env, storageKey) ?? null
 
-    const result = await publicCustomerPortalService.updateProfileWithOptions(
-      c.get("db"),
-      userId,
-      await parseJsonBody(c, updateCustomerPortalProfileSchema),
-      {
+  return new Hono<Env>()
+    .get("/me", async (c) => {
+      const userId = requireUserId(c)
+
+      const profile = await publicCustomerPortalService.getProfileWithOptions(c.get("db"), userId, {
         kms: resolveOptionalKms(c),
-      },
-    )
+      })
+      return profile ? c.json({ data: profile }) : notFound(c, "Customer profile not found")
+    })
+    .patch("/me", async (c) => {
+      const userId = requireUserId(c)
 
-    if (hasErrorResult(result)) {
-      if (result.error === "not_found") {
-        return notFound(c, "Customer profile not found")
+      const result = await publicCustomerPortalService.updateProfileWithOptions(
+        c.get("db"),
+        userId,
+        await parseJsonBody(c, updateCustomerPortalProfileSchema),
+        {
+          kms: resolveOptionalKms(c),
+        },
+      )
+
+      if (hasErrorResult(result)) {
+        if (result.error === "not_found") {
+          return notFound(c, "Customer profile not found")
+        }
+
+        return c.json({ error: "Customer record is not linked to this account" }, 409)
       }
 
-      return c.json({ error: "Customer record is not linked to this account" }, 409)
-    }
+      return c.json({ data: result.profile })
+    })
+    .post("/bootstrap", async (c) => {
+      const userId = requireUserId(c)
 
-    return c.json({ data: result.profile })
-  })
-  .post("/bootstrap", async (c) => {
-    const userId = requireUserId(c)
+      const result = await publicCustomerPortalService.bootstrap(
+        c.get("db"),
+        userId,
+        await parseJsonBody(c, bootstrapCustomerPortalSchema),
+      )
 
-    const result = await publicCustomerPortalService.bootstrap(
-      c.get("db"),
-      userId,
-      await parseJsonBody(c, bootstrapCustomerPortalSchema),
-    )
+      if (hasBootstrapErrorResult(result)) {
+        if (result.error === "not_found") {
+          return notFound(c, "Customer profile not found")
+        }
 
-    if (hasBootstrapErrorResult(result)) {
-      if (result.error === "not_found") {
-        return notFound(c, "Customer profile not found")
+        if (result.error === "customer_record_not_found") {
+          return notFound(c, "Customer record not found")
+        }
+
+        return c.json({ error: "Customer record is already linked to another account" }, 409)
       }
 
-      if (result.error === "customer_record_not_found") {
-        return notFound(c, "Customer record not found")
+      if (result.status === "customer_selection_required") {
+        return c.json({ data: result }, 409)
       }
 
-      return c.json({ error: "Customer record is already linked to another account" }, 409)
-    }
+      return c.json({ data: result })
+    })
+    .get("/companions", async (c) => {
+      const userId = requireUserId(c)
 
-    if (result.status === "customer_selection_required") {
-      return c.json({ data: result }, 409)
-    }
+      return c.json({ data: await publicCustomerPortalService.listCompanions(c.get("db"), userId) })
+    })
+    .post("/companions", async (c) => {
+      const userId = requireUserId(c)
 
-    return c.json({ data: result })
-  })
-  .get("/companions", async (c) => {
-    const userId = requireUserId(c)
+      const companion = await publicCustomerPortalService.createCompanion(
+        c.get("db"),
+        userId,
+        await parseJsonBody(c, createCustomerPortalCompanionSchema),
+      )
 
-    return c.json({ data: await publicCustomerPortalService.listCompanions(c.get("db"), userId) })
-  })
-  .post("/companions", async (c) => {
-    const userId = requireUserId(c)
+      if (!companion) {
+        return c.json({ error: "Customer record is not linked to this account" }, 409)
+      }
 
-    const companion = await publicCustomerPortalService.createCompanion(
-      c.get("db"),
-      userId,
-      await parseJsonBody(c, createCustomerPortalCompanionSchema),
-    )
+      return c.json({ data: companion }, 201)
+    })
+    .post("/companions/import-booking-participants", async (c) => {
+      const userId = requireUserId(c)
 
-    if (!companion) {
-      return c.json({ error: "Customer record is not linked to this account" }, 409)
-    }
+      const result = await publicCustomerPortalService.importBookingParticipantsAsCompanions(
+        c.get("db"),
+        userId,
+        await parseJsonBody(c, importCustomerPortalBookingParticipantsSchema),
+      )
 
-    return c.json({ data: companion }, 201)
-  })
-  .post("/companions/import-booking-participants", async (c) => {
-    const userId = requireUserId(c)
+      if (!result) {
+        return c.json({ error: "Customer record is not linked to this account" }, 409)
+      }
 
-    const result = await publicCustomerPortalService.importBookingParticipantsAsCompanions(
-      c.get("db"),
-      userId,
-      await parseJsonBody(c, importCustomerPortalBookingParticipantsSchema),
-    )
+      return c.json({ data: result })
+    })
+    .patch("/companions/:companionId", async (c) => {
+      const userId = requireUserId(c)
 
-    if (!result) {
-      return c.json({ error: "Customer record is not linked to this account" }, 409)
-    }
+      const companion = await publicCustomerPortalService.updateCompanion(
+        c.get("db"),
+        userId,
+        c.req.param("companionId"),
+        await parseJsonBody(c, updateCustomerPortalCompanionSchema),
+      )
 
-    return c.json({ data: result })
-  })
-  .patch("/companions/:companionId", async (c) => {
-    const userId = requireUserId(c)
+      if (companion === "forbidden") {
+        return handleApiError(
+          new ForbiddenApiError("Companion does not belong to this customer"),
+          c,
+        )
+      }
 
-    const companion = await publicCustomerPortalService.updateCompanion(
-      c.get("db"),
-      userId,
-      c.req.param("companionId"),
-      await parseJsonBody(c, updateCustomerPortalCompanionSchema),
-    )
+      if (!companion) {
+        return notFound(c, "Companion not found")
+      }
 
-    if (companion === "forbidden") {
-      return handleApiError(new ForbiddenApiError("Companion does not belong to this customer"), c)
-    }
+      return c.json({ data: companion })
+    })
+    .delete("/companions/:companionId", async (c) => {
+      const userId = requireUserId(c)
 
-    if (!companion) {
-      return notFound(c, "Companion not found")
-    }
+      const result = await publicCustomerPortalService.deleteCompanion(
+        c.get("db"),
+        userId,
+        c.req.param("companionId"),
+      )
 
-    return c.json({ data: companion })
-  })
-  .delete("/companions/:companionId", async (c) => {
-    const userId = requireUserId(c)
+      if (result === "forbidden") {
+        return handleApiError(
+          new ForbiddenApiError("Companion does not belong to this customer"),
+          c,
+        )
+      }
 
-    const result = await publicCustomerPortalService.deleteCompanion(
-      c.get("db"),
-      userId,
-      c.req.param("companionId"),
-    )
+      if (result === "not_found") {
+        return notFound(c, "Companion not found")
+      }
 
-    if (result === "forbidden") {
-      return handleApiError(new ForbiddenApiError("Companion does not belong to this customer"), c)
-    }
+      return c.json({ success: true })
+    })
+    .get("/bookings", async (c) => {
+      const userId = requireUserId(c)
 
-    if (result === "not_found") {
-      return notFound(c, "Companion not found")
-    }
+      const bookings = await publicCustomerPortalService.listBookings(c.get("db"), userId)
+      return bookings ? c.json({ data: bookings }) : notFound(c, "Customer profile not found")
+    })
+    .get("/bookings/:bookingId", async (c) => {
+      const userId = requireUserId(c)
 
-    return c.json({ success: true })
-  })
-  .get("/bookings", async (c) => {
-    const userId = requireUserId(c)
+      const booking = await publicCustomerPortalService.getBooking(
+        c.get("db"),
+        userId,
+        c.req.param("bookingId"),
+        {
+          resolveDocumentDownloadUrl: (storageKey) => resolveDocumentDownloadUrl(c, storageKey),
+        },
+      )
 
-    const bookings = await publicCustomerPortalService.listBookings(c.get("db"), userId)
-    return bookings ? c.json({ data: bookings }) : notFound(c, "Customer profile not found")
-  })
-  .get("/bookings/:bookingId", async (c) => {
-    const userId = requireUserId(c)
+      return booking ? c.json({ data: booking }) : notFound(c, "Booking not found")
+    })
+    .get("/bookings/:bookingId/documents", async (c) => {
+      const userId = requireUserId(c)
 
-    const booking = await publicCustomerPortalService.getBooking(
-      c.get("db"),
-      userId,
-      c.req.param("bookingId"),
-    )
+      const documents = await publicCustomerPortalService.listBookingDocuments(
+        c.get("db"),
+        userId,
+        c.req.param("bookingId"),
+        {
+          resolveDocumentDownloadUrl: (storageKey) => resolveDocumentDownloadUrl(c, storageKey),
+        },
+      )
 
-    return booking ? c.json({ data: booking }) : notFound(c, "Booking not found")
-  })
-  .get("/bookings/:bookingId/documents", async (c) => {
-    const userId = requireUserId(c)
+      return documents ? c.json({ data: documents }) : notFound(c, "Booking not found")
+    })
+    .get("/bookings/:bookingId/billing-contact", async (c) => {
+      const userId = requireUserId(c)
 
-    const documents = await publicCustomerPortalService.listBookingDocuments(
-      c.get("db"),
-      userId,
-      c.req.param("bookingId"),
-    )
+      const billingContact = await publicCustomerPortalService.getBookingBillingContact(
+        c.get("db"),
+        userId,
+        c.req.param("bookingId"),
+      )
 
-    return documents ? c.json({ data: documents }) : notFound(c, "Booking not found")
-  })
-  .get("/bookings/:bookingId/billing-contact", async (c) => {
-    const userId = requireUserId(c)
+      return billingContact ? c.json({ data: billingContact }) : notFound(c, "Booking not found")
+    })
+}
 
-    const billingContact = await publicCustomerPortalService.getBookingBillingContact(
-      c.get("db"),
-      userId,
-      c.req.param("bookingId"),
-    )
-
-    return billingContact ? c.json({ data: billingContact }) : notFound(c, "Booking not found")
-  })
+export const publicCustomerPortalRoutes = createPublicCustomerPortalRoutes()
 
 export type PublicCustomerPortalRoutes = typeof publicCustomerPortalRoutes

--- a/packages/customer-portal/src/service-public.ts
+++ b/packages/customer-portal/src/service-public.ts
@@ -58,6 +58,7 @@ const peopleKeyRef = { keyType: "people" as const }
 
 interface CustomerPortalServiceOptions {
   kms?: KmsProvider | null
+  resolveDocumentDownloadUrl?: (storageKey: string) => Promise<string | null> | string | null
 }
 
 function resolveMarketingConsentState(params: {
@@ -503,7 +504,11 @@ function resolveFinanceDocumentFileName(
   return `${invoiceType}-${invoiceNumber}.${extension}`
 }
 
-async function listLegalDocumentsForBooking(db: PostgresJsDatabase, bookingId: string) {
+async function listLegalDocumentsForBooking(
+  db: PostgresJsDatabase,
+  bookingId: string,
+  options: CustomerPortalServiceOptions = {},
+) {
   const contractRows = await db
     .select({
       id: contracts.id,
@@ -528,27 +533,31 @@ async function listLegalDocumentsForBooking(db: PostgresJsDatabase, bookingId: s
     )
     .orderBy(desc(contractAttachments.createdAt))
 
-  const bestAttachmentByContractId = new Map<string, typeof contractAttachments.$inferSelect>()
+  const bestAttachmentByContractId = new Map<
+    string,
+    {
+      attachment: typeof contractAttachments.$inferSelect
+      downloadUrl: string
+    }
+  >()
   for (const attachment of attachmentRows) {
     const metadata = getMetadataRecord(attachment.metadata)
-    const downloadUrl = getMetadataString(metadata, ["url", "downloadUrl"])
+    const downloadUrl =
+      attachment.storageKey && options.resolveDocumentDownloadUrl
+        ? await options.resolveDocumentDownloadUrl(attachment.storageKey)
+        : getMetadataString(metadata, ["url", "downloadUrl"])
     if (!downloadUrl || bestAttachmentByContractId.has(attachment.contractId)) {
       continue
     }
-    bestAttachmentByContractId.set(attachment.contractId, attachment)
+    bestAttachmentByContractId.set(attachment.contractId, { attachment, downloadUrl })
   }
 
   return contractRows.flatMap<CustomerPortalBookingDocument>((contract) => {
-    const attachment = bestAttachmentByContractId.get(contract.id)
-    if (!attachment) {
+    const document = bestAttachmentByContractId.get(contract.id)
+    if (!document) {
       return []
     }
-
-    const metadata = getMetadataRecord(attachment.metadata)
-    const downloadUrl = getMetadataString(metadata, ["url", "downloadUrl"])
-    if (!downloadUrl) {
-      return []
-    }
+    const { attachment, downloadUrl } = document
 
     return [
       {
@@ -641,6 +650,7 @@ function deriveBookingSummaryPaymentStatus(
 async function getFinanceDataForBooking(
   db: PostgresJsDatabase,
   bookingId: string,
+  options: CustomerPortalServiceOptions = {},
 ): Promise<{
   documents: CustomerPortalBookingFinancialDocument[]
   payments: CustomerPortalBookingPayment[]
@@ -677,30 +687,35 @@ async function getFinanceDataForBooking(
 
   const invoiceById = new Map(invoiceRows.map((invoice) => [invoice.id, invoice]))
 
-  const documents = invoiceRows.map<CustomerPortalBookingFinancialDocument>((invoice) => {
-    const renditions = renditionByInvoiceId.get(invoice.id) ?? []
-    const selectedRendition =
-      renditions.find((rendition) => rendition.status === "ready") ?? renditions[0] ?? null
-    const metadata = getMetadataRecord(selectedRendition?.metadata ?? null)
-    const downloadUrl = resolveFinanceDocumentDownloadUrl(metadata)
+  const resolvedDocuments = await Promise.all(
+    invoiceRows.map(async (invoice): Promise<CustomerPortalBookingFinancialDocument> => {
+      const renditions = renditionByInvoiceId.get(invoice.id) ?? []
+      const selectedRendition =
+        renditions.find((rendition) => rendition.status === "ready") ?? renditions[0] ?? null
+      const metadata = getMetadataRecord(selectedRendition?.metadata ?? null)
+      const downloadUrl =
+        selectedRendition?.storageKey && options.resolveDocumentDownloadUrl
+          ? await options.resolveDocumentDownloadUrl(selectedRendition.storageKey)
+          : resolveFinanceDocumentDownloadUrl(metadata)
 
-    return {
-      invoiceId: invoice.id,
-      invoiceNumber: invoice.invoiceNumber,
-      invoiceType: invoice.invoiceType,
-      invoiceStatus: invoice.status,
-      currency: invoice.currency,
-      totalCents: invoice.totalCents,
-      paidCents: invoice.paidCents,
-      balanceDueCents: invoice.balanceDueCents,
-      issueDate: invoice.issueDate,
-      dueDate: invoice.dueDate,
-      documentStatus: selectedRendition?.status ?? "missing",
-      format: selectedRendition?.format ?? null,
-      generatedAt: normalizeDateTime(selectedRendition?.generatedAt ?? null),
-      downloadUrl,
-    }
-  })
+      return {
+        invoiceId: invoice.id,
+        invoiceNumber: invoice.invoiceNumber,
+        invoiceType: invoice.invoiceType,
+        invoiceStatus: invoice.status,
+        currency: invoice.currency,
+        totalCents: invoice.totalCents,
+        paidCents: invoice.paidCents,
+        balanceDueCents: invoice.balanceDueCents,
+        issueDate: invoice.issueDate,
+        dueDate: invoice.dueDate,
+        documentStatus: selectedRendition?.status ?? "missing",
+        format: selectedRendition?.format ?? null,
+        generatedAt: normalizeDateTime(selectedRendition?.generatedAt ?? null),
+        downloadUrl,
+      }
+    }),
+  )
 
   const paymentHistory = paymentRows.flatMap<CustomerPortalBookingPayment>((payment) => {
     const invoice = invoiceById.get(payment.invoiceId)
@@ -725,7 +740,7 @@ async function getFinanceDataForBooking(
     ]
   })
 
-  const portalDocuments = documents.flatMap<CustomerPortalBookingDocument>((document) => {
+  const portalDocuments = resolvedDocuments.flatMap<CustomerPortalBookingDocument>((document) => {
     if (!document.downloadUrl) {
       return []
     }
@@ -748,7 +763,7 @@ async function getFinanceDataForBooking(
     ]
   })
 
-  return { documents, payments: paymentHistory, portalDocuments }
+  return { documents: resolvedDocuments, payments: paymentHistory, portalDocuments }
 }
 
 function toCustomerCompanion(
@@ -1192,6 +1207,7 @@ async function buildBookingDetail(
   db: PostgresJsDatabase,
   bookingId: string,
   customerRecord: Awaited<ReturnType<typeof getCustomerRecord>> | null = null,
+  options: CustomerPortalServiceOptions = {},
 ): Promise<CustomerPortalBookingDetail | null> {
   const [booking] = await db.select().from(bookings).where(eq(bookings.id, bookingId)).limit(1)
   if (!booking) {
@@ -1240,8 +1256,8 @@ async function buildBookingDetail(
       .from(bookingFulfillments)
       .where(eq(bookingFulfillments.bookingId, booking.id))
       .orderBy(asc(bookingFulfillments.createdAt)),
-    listLegalDocumentsForBooking(db, booking.id),
-    getFinanceDataForBooking(db, booking.id),
+    listLegalDocumentsForBooking(db, booking.id, options),
+    getFinanceDataForBooking(db, booking.id, options),
     getBookingBillingContact(db, booking.id, customerRecord),
   ])
 
@@ -2204,6 +2220,7 @@ export const publicCustomerPortalService = {
     db: PostgresJsDatabase,
     userId: string,
     bookingId: string,
+    options: CustomerPortalServiceOptions = {},
   ): Promise<CustomerPortalBookingDetail | null> {
     const authProfile = await getAuthProfileRow(db, userId)
     if (!authProfile) {
@@ -2227,11 +2244,16 @@ export const publicCustomerPortalService = {
       return null
     }
 
-    return buildBookingDetail(db, bookingId, customerRecord)
+    return buildBookingDetail(db, bookingId, customerRecord, options)
   },
 
-  async listBookingDocuments(db: PostgresJsDatabase, userId: string, bookingId: string) {
-    const detail = await this.getBooking(db, userId, bookingId)
+  async listBookingDocuments(
+    db: PostgresJsDatabase,
+    userId: string,
+    bookingId: string,
+    options: CustomerPortalServiceOptions = {},
+  ) {
+    const detail = await this.getBooking(db, userId, bookingId, options)
     return detail?.documents ?? null
   },
 

--- a/packages/customer-portal/tests/integration/public-routes.test.ts
+++ b/packages/customer-portal/tests/integration/public-routes.test.ts
@@ -17,7 +17,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
 import { invoiceRenditions, invoices, payments } from "../../../finance/src/schema.js"
 import { contractAttachments, contracts } from "../../../legal/src/contracts/schema.js"
 import { customerPortalRoutes } from "../../src/routes.js"
-import { publicCustomerPortalRoutes } from "../../src/routes-public.js"
+import { createPublicCustomerPortalRoutes } from "../../src/routes-public.js"
 
 const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
 
@@ -52,7 +52,13 @@ describe.skipIf(!DB_AVAILABLE)("Public customer portal routes", () => {
         c.set("userId" as never, "user_customer_portal")
         await next()
       })
-      .route("/", publicCustomerPortalRoutes)
+      .route(
+        "/",
+        createPublicCustomerPortalRoutes({
+          resolveDocumentDownloadUrl: (_bindings, storageKey) =>
+            `https://signed.example.com/${storageKey}`,
+        }),
+      )
 
     preflightApp = new Hono()
       .use("*", async (c, next) => {
@@ -779,9 +785,7 @@ describe.skipIf(!DB_AVAILABLE)("Public customer portal routes", () => {
       kind: "document",
       name: "travel-contract.pdf",
       mimeType: "application/pdf",
-      metadata: {
-        url: "https://example.com/contracts/travel-contract.pdf",
-      },
+      storageKey: `contracts/${contract.id}/travel-contract.pdf`,
     })
 
     const [invoice] = await db
@@ -806,9 +810,7 @@ describe.skipIf(!DB_AVAILABLE)("Public customer portal routes", () => {
       invoiceId: invoice.id,
       format: "pdf",
       status: "ready",
-      metadata: {
-        url: "https://example.com/finance/proforma-1001.pdf",
-      },
+      storageKey: `finance/${invoice.id}/proforma-1001.pdf`,
       generatedAt: new Date("2026-05-02T00:00:00.000Z"),
     })
 
@@ -900,7 +902,7 @@ describe.skipIf(!DB_AVAILABLE)("Public customer portal routes", () => {
         paidCents: 12000,
         balanceDueCents: 12000,
         documentStatus: "ready",
-        downloadUrl: "https://example.com/finance/proforma-1001.pdf",
+        downloadUrl: `https://signed.example.com/finance/${invoice.id}/proforma-1001.pdf`,
       }),
     ])
     expect(detail.financials.payments).toEqual([
@@ -925,11 +927,13 @@ describe.skipIf(!DB_AVAILABLE)("Public customer portal routes", () => {
           source: "legal",
           type: "contract",
           fileName: "travel-contract.pdf",
+          fileUrl: `https://signed.example.com/contracts/${contract.id}/travel-contract.pdf`,
           reference: "CTR-1001",
         }),
         expect.objectContaining({
           source: "finance",
           type: "proforma",
+          fileUrl: `https://signed.example.com/finance/${invoice.id}/proforma-1001.pdf`,
           reference: "INV-1001",
         }),
       ]),

--- a/templates/dmc/src/api/app.ts
+++ b/templates/dmc/src/api/app.ts
@@ -3,7 +3,7 @@ import { bookingRequirementsHonoModule } from "@voyantjs/booking-requirements"
 import { bookingsHonoModule, bookingsSupplierExtension } from "@voyantjs/bookings"
 import { createCheckoutHonoModule } from "@voyantjs/checkout"
 import { crmBookingExtension, crmHonoModule } from "@voyantjs/crm"
-import { customerPortalHonoModule } from "@voyantjs/customer-portal"
+import { createCustomerPortalHonoModule } from "@voyantjs/customer-portal"
 import { distributionBookingExtension, distributionHonoModule } from "@voyantjs/distribution"
 import { externalRefsHonoModule } from "@voyantjs/external-refs"
 import { extrasHonoModule } from "@voyantjs/extras"
@@ -48,6 +48,16 @@ const storefrontVerificationHonoModule = createStorefrontVerificationHonoModule(
 })
 const checkoutHonoModule = createCheckoutHonoModule({
   resolveProviders: resolveNotificationProviders,
+})
+const customerPortalHonoModule = createCustomerPortalHonoModule({
+  resolveDocumentDownloadUrl: async (bindings, storageKey) => {
+    const storage = createMediaStorage(bindings as CloudflareBindings)
+    if (!storage) {
+      return null
+    }
+
+    return storage.signedUrl(storageKey, 300)
+  },
 })
 
 export const app = createApp<CloudflareBindings>({

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -3,7 +3,7 @@ import { bookingRequirementsHonoModule } from "@voyantjs/booking-requirements"
 import { bookingsHonoModule, bookingsSupplierExtension } from "@voyantjs/bookings"
 import { createCheckoutHonoModule } from "@voyantjs/checkout"
 import { crmBookingExtension, crmHonoModule } from "@voyantjs/crm"
-import { customerPortalHonoModule } from "@voyantjs/customer-portal"
+import { createCustomerPortalHonoModule } from "@voyantjs/customer-portal"
 import { distributionBookingExtension, distributionHonoModule } from "@voyantjs/distribution"
 import { externalRefsHonoModule } from "@voyantjs/external-refs"
 import { extrasHonoModule } from "@voyantjs/extras"
@@ -45,6 +45,16 @@ const storefrontVerificationHonoModule = createStorefrontVerificationHonoModule(
 })
 const checkoutHonoModule = createCheckoutHonoModule({
   resolveProviders: resolveNotificationProviders,
+})
+const customerPortalHonoModule = createCustomerPortalHonoModule({
+  resolveDocumentDownloadUrl: async (bindings, storageKey) => {
+    const storage = createMediaStorage(bindings as CloudflareBindings)
+    if (!storage) {
+      return null
+    }
+
+    return storage.signedUrl(storageKey, 300)
+  },
 })
 
 export const app = createApp<CloudflareBindings>({


### PR DESCRIPTION
## Summary
- add a public customer portal route factory with a document URL resolver hook
- prefer storage-key-backed signed URLs for finance and legal customer portal documents
- wire operator, dmc, and dev templates through the existing storage provider for fresh per-request URLs

## Testing
- git diff --check
- pnpm -C packages/customer-portal typecheck
- pnpm -C packages/customer-portal test -- --runInBand
- pnpm -C templates/operator typecheck
- pnpm -C templates/dmc typecheck
- pnpm -C apps/dev typecheck