### PR TITLE
Reduce plugin-first package docs

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,9 @@
 # @voyantjs/core
 
-Module system and framework primitives for Voyant. Transport-agnostic — provides the contracts, registry, container, event bus, links, query, workflows, plugins, and config shape that every Voyant module and transport adapter builds on.
+Module system and framework primitives for Voyant. Transport-agnostic —
+provides the contracts, registry, container, event bus, links, query,
+workflows, plugin bundles, and config shape that every Voyant module and
+transport adapter builds on.
 
 ## Install
 
@@ -17,6 +20,10 @@ import { definePlugin } from "@voyantjs/core/plugin"
 import { defineVoyantConfig } from "@voyantjs/core/config"
 import { createWorkflow, step } from "@voyantjs/core/workflows"
 ```
+
+In Voyant, modules, providers, extensions, and workflows are the main runtime
+primitives. Plugins are optional distribution bundles that package those pieces
+together for reuse across projects.
 
 ## Exports
 

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -1,10 +1,12 @@
 /**
- * Plugins — distributable bundles that group modules, extensions, event
- * subscribers, and link definitions into a single unit.
+ * Plugins — optional distributable bundles that group modules, extensions,
+ * event subscribers, and link definitions into a single unit.
  *
  * A plugin is the unit of "distribution" in Voyant: a customer, vendor, or
  * integrator ships a plugin package and it can be registered alongside core
- * modules without touching the framework itself.
+ * modules without touching the framework itself. It is not the default runtime
+ * customization unit — modules, providers, extensions, and workflows should be
+ * preferred when a smaller seam fits.
  *
  * Core plugins are transport-agnostic — they contain {@link Module} and
  * {@link Extension} values (no HTTP routes). Transport adapters (such as

--- a/packages/hono/README.md
+++ b/packages/hono/README.md
@@ -1,6 +1,7 @@
 # @voyantjs/hono
 
-Hono transport adapter for Voyant. Provides `createApp()`, middleware, auth helpers, and plugin expansion for mounting Voyant modules behind a Hono app.
+Hono transport adapter for Voyant. Provides `createApp()`, middleware, auth
+helpers, and plugin expansion for mounting Voyant modules behind a Hono app.
 
 ## Install
 
@@ -17,9 +18,18 @@ const app = createApp({
   db: (env) => getDb(env),
   auth: { handler, resolve },
   modules: [crmModule, productsModule, bookingsModule],
-  plugins: [payloadCmsPlugin({ /* ... */ })],
+  extensions: [smartbillFinanceExtension],
+  plugins: [
+    payloadCmsPlugin({
+      /* optional distribution bundle */
+    }),
+  ],
 })
 ```
+
+Use `modules`, `extensions`, and provider-backed route helpers as the default
+composition surface. Use `plugins` when you want to register a reusable
+distribution bundle that packages those pieces together.
 
 The middleware chain is: container → requestId → logger → errorBoundary → CORS → health → auth handler → requireAuth → db → actor guards → module routes.
 

--- a/packages/plugins/netopia/README.md
+++ b/packages/plugins/netopia/README.md
@@ -59,7 +59,8 @@ const netopiaFinanceExtension = createNetopiaFinanceAdapter()
 Then include the returned extension in `createApp({ extensions: [...] })`.
 
 If you want the packaged Hono bundle instead, use
-`createNetopiaAdapterBundle()` or the existing `netopiaHonoPlugin()` export.
+`createNetopiaAdapterBundle()` or `netopiaHonoPlugin()`. Both are optional
+distribution helpers over the adapter/extension surfaces above.
 
 ## Flow
 

--- a/packages/plugins/payload-cms/README.md
+++ b/packages/plugins/payload-cms/README.md
@@ -23,19 +23,23 @@ pnpm add @voyantjs/plugin-payload-cms
 import { payloadCmsPlugin } from "@voyantjs/plugin-payload-cms"
 import { createApp } from "@voyantjs/hono"
 
+const payloadCmsSync = payloadCmsPlugin({
+  apiUrl: "https://cms.example.com/api",
+  apiKey: env.PAYLOAD_API_KEY,
+  collection: "products",
+  // optional: events, mapEvent, logger, apiKeyAuthScheme
+})
+
 const app = createApp({
-  plugins: [
-    payloadCmsPlugin({
-      apiUrl: "https://cms.example.com/api",
-      apiKey: env.PAYLOAD_API_KEY,
-      collection: "products",
-      // optional: events, mapEvent, logger, apiKeyAuthScheme
-    }),
-  ],
+  plugins: [payloadCmsSync],
 })
 ```
 
-By default the plugin wires up 3 subscribers (`product.created`, `product.updated`, `product.deleted`) that upsert/delete documents keyed by `voyantId`. All error handling is fire-and-forget per the EventBus contract.
+The exported value is a distribution bundle. At runtime, the package behaves
+primarily as a subscriber-driven Payload sync adapter. By default it wires up
+3 subscribers (`product.created`, `product.updated`, `product.deleted`) that
+upsert/delete documents keyed by `voyantId`. All error handling is
+fire-and-forget per the EventBus contract.
 
 ## Exports
 

--- a/packages/plugins/sanity-cms/README.md
+++ b/packages/plugins/sanity-cms/README.md
@@ -23,20 +23,24 @@ pnpm add @voyantjs/plugin-sanity-cms
 import { sanityCmsPlugin } from "@voyantjs/plugin-sanity-cms"
 import { createApp } from "@voyantjs/hono"
 
+const sanitySync = sanityCmsPlugin({
+  projectId: env.SANITY_PROJECT_ID,
+  dataset: "production",
+  token: env.SANITY_TOKEN,
+  documentType: "product",
+  // optional: apiVersion, voyantIdField, apiHost, events, mapEvent, logger
+})
+
 const app = createApp({
-  plugins: [
-    sanityCmsPlugin({
-      projectId: env.SANITY_PROJECT_ID,
-      dataset: "production",
-      token: env.SANITY_TOKEN,
-      documentType: "product",
-      // optional: apiVersion, voyantIdField, apiHost, events, mapEvent, logger
-    }),
-  ],
+  plugins: [sanitySync],
 })
 ```
 
-Uses GROQ for reads and Sanity Mutations API for writes. Default `apiVersion` is `"2024-01-01"`. By default the plugin wires up 3 subscribers (`product.created`, `product.updated`, `product.deleted`).
+Uses GROQ for reads and Sanity Mutations API for writes. The exported value is
+an optional distribution bundle; at runtime the package is primarily a
+subscriber-driven Sanity sync adapter. Default `apiVersion` is `"2024-01-01"`.
+By default it wires up 3 subscribers
+(`product.created`, `product.updated`, `product.deleted`).
 
 ## Exports
 

--- a/packages/plugins/smartbill/README.md
+++ b/packages/plugins/smartbill/README.md
@@ -23,20 +23,25 @@ pnpm add @voyantjs/plugin-smartbill
 import { smartbillPlugin } from "@voyantjs/plugin-smartbill"
 import { createApp } from "@voyantjs/hono"
 
+const smartbillSync = smartbillPlugin({
+  username: env.SMARTBILL_USERNAME,
+  apiToken: env.SMARTBILL_API_TOKEN,
+  companyVatCode: "RO12345678",
+  seriesName: "A",
+  // optional: language, art311SpecialRegime, events, mapEvent, logger
+})
+
 const app = createApp({
-  plugins: [
-    smartbillPlugin({
-      username: env.SMARTBILL_USERNAME,
-      apiToken: env.SMARTBILL_API_TOKEN,
-      companyVatCode: "RO12345678",
-      seriesName: "A",
-      // optional: language, art311SpecialRegime, events, mapEvent, logger
-    }),
-  ],
+  plugins: [smartbillSync],
 })
 ```
 
-By default the plugin wires up 3 subscribers (`invoice.issued`, `invoice.voided`, `invoice.external.sync.requested`) that create, cancel, and check payment status on SmartBill. All error handling is fire-and-forget per the EventBus contract.
+The exported value is a distribution bundle. At runtime, the package behaves
+primarily as a subscriber-driven SmartBill sync adapter. By default it wires up
+3 subscribers (`invoice.issued`, `invoice.voided`,
+`invoice.external.sync.requested`) that create, cancel, and check payment
+status on SmartBill. All error handling is fire-and-forget per the EventBus
+contract.
 
 ## Exports
 


### PR DESCRIPTION
## Summary
- tighten Hono and core package docs so plugins are framed as optional distribution bundles
- update sync plugin READMEs to present their adapter/subscriber role first and plugin usage second
- keep package examples aligned with the module/provider/extension/plugin taxonomy

## Testing
- git diff --check