### PR TITLE
Bootstrap storefront verification senders

### DIFF
--- a/packages/storefront-verification/src/index.ts
+++ b/packages/storefront-verification/src/index.ts
@@ -1,13 +1,22 @@
+import type { Module } from "@voyantjs/core"
 import type { HonoModule } from "@voyantjs/hono/module"
-
-import { createStorefrontVerificationPublicRoutes } from "./routes-public.js"
+import {
+  buildStorefrontVerificationSenders,
+  createStorefrontVerificationPublicRoutes,
+  STOREFRONT_VERIFICATION_SENDERS_CONTAINER_KEY,
+  type StorefrontVerificationRoutesOptions,
+} from "./routes-public.js"
 import { storefrontVerificationModule } from "./schema.js"
 
 export type {
   StorefrontVerificationPublicRoutes,
   StorefrontVerificationRoutesOptions,
 } from "./routes-public.js"
-export { createStorefrontVerificationPublicRoutes } from "./routes-public.js"
+export {
+  buildStorefrontVerificationSenders,
+  createStorefrontVerificationPublicRoutes,
+  STOREFRONT_VERIFICATION_SENDERS_CONTAINER_KEY,
+} from "./routes-public.js"
 export type {
   NewStorefrontVerificationChallenge,
   StorefrontVerificationChallenge,
@@ -56,10 +65,20 @@ export {
 } from "./validation.js"
 
 export function createStorefrontVerificationHonoModule(
-  options?: Parameters<typeof createStorefrontVerificationPublicRoutes>[0],
+  options?: StorefrontVerificationRoutesOptions,
 ): HonoModule {
+  const module: Module = {
+    ...storefrontVerificationModule,
+    bootstrap: ({ bindings, container }) => {
+      container.register(
+        STOREFRONT_VERIFICATION_SENDERS_CONTAINER_KEY,
+        buildStorefrontVerificationSenders(bindings as Record<string, unknown>, options),
+      )
+    },
+  }
+
   return {
-    module: storefrontVerificationModule,
+    module,
     publicRoutes: createStorefrontVerificationPublicRoutes(options),
   }
 }

--- a/packages/storefront-verification/src/routes-public.ts
+++ b/packages/storefront-verification/src/routes-public.ts
@@ -1,3 +1,4 @@
+import type { ModuleContainer } from "@voyantjs/core"
 import { parseJsonBody } from "@voyantjs/hono"
 import type { NotificationProvider } from "@voyantjs/notifications"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -20,6 +21,7 @@ import {
 type Env = {
   Bindings: Record<string, unknown>
   Variables: {
+    container: ModuleContainer
     db: PostgresJsDatabase
     userId?: string
   }
@@ -34,7 +36,10 @@ export interface StorefrontVerificationRoutesOptions
   resolveProviders?: (bindings: Record<string, unknown>) => ReadonlyArray<NotificationProvider>
 }
 
-function getSenders(
+export const STOREFRONT_VERIFICATION_SENDERS_CONTAINER_KEY =
+  "providers.storefrontVerification.senders"
+
+export function buildStorefrontVerificationSenders(
   bindings: Record<string, unknown>,
   options?: StorefrontVerificationRoutesOptions,
 ): StorefrontVerificationSenders {
@@ -53,6 +58,24 @@ function getSenders(
   }
 
   return senders
+}
+
+function getSenders(
+  bindings: Record<string, unknown>,
+  options: StorefrontVerificationRoutesOptions | undefined,
+  resolveFromContainer?: <T>(key: string) => T,
+): StorefrontVerificationSenders {
+  if (resolveFromContainer) {
+    try {
+      return resolveFromContainer<StorefrontVerificationSenders>(
+        STOREFRONT_VERIFICATION_SENDERS_CONTAINER_KEY,
+      )
+    } catch {
+      // Fall back to per-request sender construction when bootstrap has not run.
+    }
+  }
+
+  return buildStorefrontVerificationSenders(bindings, options)
 }
 
 function errorResponse(error: unknown) {
@@ -89,7 +112,7 @@ export function createStorefrontVerificationPublicRoutes(
         const result = await service.startEmailChallenge(
           c.get("db"),
           await parseJsonBody(c, startEmailVerificationChallengeSchema),
-          getSenders(c.env, options),
+          getSenders(c.env, options, (key) => c.var.container.resolve(key)),
         )
         return c.json({ data: result }, 201)
       } catch (error) {
@@ -114,7 +137,7 @@ export function createStorefrontVerificationPublicRoutes(
         const result = await service.startSmsChallenge(
           c.get("db"),
           await parseJsonBody(c, startSmsVerificationChallengeSchema),
-          getSenders(c.env, options),
+          getSenders(c.env, options, (key) => c.var.container.resolve(key)),
         )
         return c.json({ data: result }, 201)
       } catch (error) {

--- a/packages/storefront-verification/tests/unit/module.test.ts
+++ b/packages/storefront-verification/tests/unit/module.test.ts
@@ -1,0 +1,54 @@
+import { createContainer, createEventBus } from "@voyantjs/core"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  createStorefrontVerificationHonoModule,
+  STOREFRONT_VERIFICATION_SENDERS_CONTAINER_KEY,
+} from "../../src/index.js"
+
+describe("createStorefrontVerificationHonoModule.bootstrap", () => {
+  it("registers the resolved sender bundle once", async () => {
+    const resolveProviders = vi.fn(() => [
+      {
+        name: "email-provider",
+        channels: ["email"],
+        send: vi.fn(async () => ({ id: "ntf_123", provider: "email-provider" })),
+      },
+      {
+        name: "sms-provider",
+        channels: ["sms"],
+        send: vi.fn(async () => ({ id: "ntf_456", provider: "sms-provider" })),
+      },
+    ])
+
+    const module = createStorefrontVerificationHonoModule({
+      resolveProviders,
+    })
+    const container = createContainer()
+
+    await module.module.bootstrap?.({
+      bindings: {},
+      container,
+      eventBus: createEventBus(),
+    })
+
+    const senders = container.resolve<{
+      sendEmailChallenge?: (input: {
+        email: string
+        code: string
+        purpose: string
+        expiresAt: Date
+      }) => Promise<unknown>
+      sendSmsChallenge?: (input: {
+        phone: string
+        code: string
+        purpose: string
+        expiresAt: Date
+      }) => Promise<unknown>
+    }>(STOREFRONT_VERIFICATION_SENDERS_CONTAINER_KEY)
+
+    expect(resolveProviders).toHaveBeenCalledOnce()
+    expect(senders.sendEmailChallenge).toBeTypeOf("function")
+    expect(senders.sendSmsChallenge).toBeTypeOf("function")
+  })
+})


### PR DESCRIPTION
## Summary
- register provider-derived storefront verification senders once at bootstrap
- resolve public route senders from the shared container before falling back to per-request construction
- add focused unit coverage for bootstrap registration

## Testing
- git diff --check
- pnpm -C packages/storefront-verification typecheck
- pnpm -C packages/storefront-verification test
- git push -u origin cleanup/storefront-verification-bootstrap
