### PR TITLE
Bootstrap notifications route runtime

### DIFF
--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -1,6 +1,12 @@
+import type { Module } from "@voyantjs/core"
 import type { HonoModule } from "@voyantjs/hono/module"
 
-import { createNotificationsRoutes } from "./routes.js"
+import {
+  buildNotificationsRouteRuntime,
+  createNotificationsRoutes,
+  NOTIFICATIONS_ROUTE_RUNTIME_CONTAINER_KEY,
+  type NotificationsRoutesOptions,
+} from "./routes.js"
 import { notificationsModule } from "./schema.js"
 
 export type { DefaultNotificationProviderOptions } from "./provider-resolution.js"
@@ -19,7 +25,12 @@ export type {
 export { createResendProvider } from "./providers/resend.js"
 export type { TwilioFetch, TwilioProviderOptions, TwilioRenderedSms } from "./providers/twilio.js"
 export { createTwilioProvider } from "./providers/twilio.js"
-export { createNotificationsRoutes } from "./routes.js"
+export type { NotificationsRouteRuntime, NotificationsRoutesOptions } from "./routes.js"
+export {
+  buildNotificationsRouteRuntime,
+  createNotificationsRoutes,
+  NOTIFICATIONS_ROUTE_RUNTIME_CONTAINER_KEY,
+} from "./routes.js"
 export type {
   NewNotificationDelivery,
   NewNotificationReminderRule,
@@ -102,11 +113,19 @@ export {
   updateNotificationTemplateSchema,
 } from "./validation.js"
 
-export function createNotificationsHonoModule(
-  options?: Parameters<typeof createNotificationsRoutes>[0],
-): HonoModule {
+export function createNotificationsHonoModule(options?: NotificationsRoutesOptions): HonoModule {
+  const module: Module = {
+    ...notificationsModule,
+    bootstrap: ({ bindings, container }) => {
+      container.register(
+        NOTIFICATIONS_ROUTE_RUNTIME_CONTAINER_KEY,
+        buildNotificationsRouteRuntime(bindings as Record<string, unknown>, options),
+      )
+    },
+  }
+
   return {
-    module: notificationsModule,
+    module,
     routes: createNotificationsRoutes(options),
   }
 }

--- a/packages/notifications/src/routes.ts
+++ b/packages/notifications/src/routes.ts
@@ -1,4 +1,4 @@
-import type { EventBus } from "@voyantjs/core"
+import type { EventBus, ModuleContainer } from "@voyantjs/core"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
 
@@ -26,12 +26,13 @@ import {
 type Env = {
   Bindings: Record<string, unknown>
   Variables: {
+    container: ModuleContainer
     db: PostgresJsDatabase
     userId?: string
   }
 }
 
-export function createNotificationsRoutes(options?: {
+export type NotificationsRoutesOptions = {
   providers?: ReadonlyArray<NotificationProvider>
   resolveProviders?: (bindings: Record<string, unknown>) => ReadonlyArray<NotificationProvider>
   documentAttachmentResolver?: BookingDocumentAttachmentResolver
@@ -40,7 +41,41 @@ export function createNotificationsRoutes(options?: {
   ) => BookingDocumentAttachmentResolver | undefined
   eventBus?: EventBus
   resolveEventBus?: (bindings: Record<string, unknown>) => EventBus | undefined
-}) {
+}
+
+export type NotificationsRouteRuntime = {
+  providers: ReadonlyArray<NotificationProvider>
+  documentAttachmentResolver?: BookingDocumentAttachmentResolver
+  eventBus?: EventBus
+}
+
+export const NOTIFICATIONS_ROUTE_RUNTIME_CONTAINER_KEY = "providers.notifications.runtime"
+
+export function buildNotificationsRouteRuntime(
+  bindings: Record<string, unknown>,
+  options?: NotificationsRoutesOptions,
+): NotificationsRouteRuntime {
+  return {
+    providers: options?.resolveProviders?.(bindings) ?? options?.providers ?? [],
+    documentAttachmentResolver:
+      options?.resolveDocumentAttachmentResolver?.(bindings) ?? options?.documentAttachmentResolver,
+    eventBus: options?.resolveEventBus?.(bindings) ?? options?.eventBus,
+  }
+}
+
+function getRuntime(
+  bindings: Record<string, unknown>,
+  options: NotificationsRoutesOptions | undefined,
+  resolveFromContainer: (key: string) => NotificationsRouteRuntime,
+): NotificationsRouteRuntime {
+  try {
+    return resolveFromContainer(NOTIFICATIONS_ROUTE_RUNTIME_CONTAINER_KEY)
+  } catch {
+    return buildNotificationsRouteRuntime(bindings, options)
+  }
+}
+
+export function createNotificationsRoutes(options?: NotificationsRoutesOptions) {
   return new Hono<Env>()
     .get("/templates", async (c) => {
       const query = notificationTemplateListQuerySchema.parse(
@@ -120,9 +155,8 @@ export function createNotificationsRoutes(options?: {
     })
     .post("/reminders/run-due", async (c) => {
       try {
-        const dispatcher = createNotificationService(
-          options?.resolveProviders?.(c.env) ?? options?.providers ?? [],
-        )
+        const runtime = getRuntime(c.env, options, (key) => c.var.container.resolve(key))
+        const dispatcher = createNotificationService(runtime.providers)
         const result = await notificationsService.runDueReminders(
           c.get("db"),
           dispatcher,
@@ -136,9 +170,8 @@ export function createNotificationsRoutes(options?: {
     })
     .post("/payment-sessions/:id/send", async (c) => {
       try {
-        const dispatcher = createNotificationService(
-          options?.resolveProviders?.(c.env) ?? options?.providers ?? [],
-        )
+        const runtime = getRuntime(c.env, options, (key) => c.var.container.resolve(key))
+        const dispatcher = createNotificationService(runtime.providers)
         const row = await notificationsService.sendPaymentSessionNotification(
           c.get("db"),
           dispatcher,
@@ -155,9 +188,8 @@ export function createNotificationsRoutes(options?: {
     })
     .post("/invoices/:id/send", async (c) => {
       try {
-        const dispatcher = createNotificationService(
-          options?.resolveProviders?.(c.env) ?? options?.providers ?? [],
-        )
+        const runtime = getRuntime(c.env, options, (key) => c.var.container.resolve(key))
+        const dispatcher = createNotificationService(runtime.providers)
         const row = await notificationsService.sendInvoiceNotification(
           c.get("db"),
           dispatcher,
@@ -181,19 +213,16 @@ export function createNotificationsRoutes(options?: {
     })
     .post("/bookings/:id/send-documents", async (c) => {
       try {
-        const dispatcher = createNotificationService(
-          options?.resolveProviders?.(c.env) ?? options?.providers ?? [],
-        )
+        const runtime = getRuntime(c.env, options, (key) => c.var.container.resolve(key))
+        const dispatcher = createNotificationService(runtime.providers)
         const result = await notificationsService.sendBookingDocumentsNotification(
           c.get("db"),
           dispatcher,
           c.req.param("id"),
           sendBookingDocumentsNotificationSchema.parse(await c.req.json().catch(() => ({}))),
           {
-            attachmentResolver:
-              options?.resolveDocumentAttachmentResolver?.(c.env) ??
-              options?.documentAttachmentResolver,
-            eventBus: options?.resolveEventBus?.(c.env) ?? options?.eventBus,
+            attachmentResolver: runtime.documentAttachmentResolver,
+            eventBus: runtime.eventBus,
           },
         )
         if (result.status === "not_found") return c.json({ error: "Booking not found" }, 404)
@@ -227,9 +256,8 @@ export function createNotificationsRoutes(options?: {
     })
     .post("/send", async (c) => {
       try {
-        const dispatcher = createNotificationService(
-          options?.resolveProviders?.(c.env) ?? options?.providers ?? [],
-        )
+        const runtime = getRuntime(c.env, options, (key) => c.var.container.resolve(key))
+        const dispatcher = createNotificationService(runtime.providers)
         const row = await notificationsService.sendNotification(
           c.get("db"),
           dispatcher,

--- a/packages/notifications/tests/unit/module.test.ts
+++ b/packages/notifications/tests/unit/module.test.ts
@@ -1,0 +1,45 @@
+import { createContainer, createEventBus } from "@voyantjs/core"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  createNotificationsHonoModule,
+  NOTIFICATIONS_ROUTE_RUNTIME_CONTAINER_KEY,
+} from "../../src/index.js"
+
+describe("createNotificationsHonoModule.bootstrap", () => {
+  it("registers the resolved route runtime once", async () => {
+    const resolveProviders = vi.fn(() => [
+      {
+        name: "email-provider",
+        channels: ["email"],
+        send: vi.fn(async () => ({ id: "ntf_123", provider: "email-provider" })),
+      },
+    ])
+    const documentAttachmentResolver = vi.fn(async () => null)
+    const eventBus = createEventBus()
+    const module = createNotificationsHonoModule({
+      resolveProviders,
+      documentAttachmentResolver,
+      eventBus,
+    })
+    const container = createContainer()
+
+    await module.module.bootstrap?.({
+      bindings: {},
+      container,
+      eventBus: createEventBus(),
+    })
+
+    const runtime = container.resolve<{
+      providers: ReadonlyArray<{ name: string }>
+      documentAttachmentResolver?: typeof documentAttachmentResolver
+      eventBus?: typeof eventBus
+    }>(NOTIFICATIONS_ROUTE_RUNTIME_CONTAINER_KEY)
+
+    expect(resolveProviders).toHaveBeenCalledOnce()
+    expect(runtime.providers).toHaveLength(1)
+    expect(runtime.providers[0]?.name).toBe("email-provider")
+    expect(runtime.documentAttachmentResolver).toBe(documentAttachmentResolver)
+    expect(runtime.eventBus).toBe(eventBus)
+  })
+})


### PR DESCRIPTION
## Summary
- register notification route runtime dependencies once at bootstrap
- resolve providers, attachment resolvers, and the event bus from the shared container in Hono routes
- add focused unit coverage for bootstrap registration

## Testing
- git diff --check
- pnpm -C packages/notifications typecheck
- pnpm -C packages/notifications test
- git push -u origin cleanup/notifications-bootstrap-runtime