### PR TITLE
Bootstrap checkout route runtime

### DIFF
--- a/packages/checkout/src/index.ts
+++ b/packages/checkout/src/index.ts
@@ -1,9 +1,12 @@
 export {
+  buildCheckoutRouteRuntime,
+  CHECKOUT_ROUTE_RUNTIME_CONTAINER_KEY,
   checkoutModule,
   createCheckoutAdminRoutes,
   createCheckoutHonoModule,
   createCheckoutRoutes,
 } from "./routes.js"
+export type { CheckoutRouteRuntime, CheckoutRoutesOptions } from "./routes.js"
 export type {
   BootstrappedCheckoutCollection,
   CheckoutBankTransferDetails,

--- a/packages/checkout/src/routes.ts
+++ b/packages/checkout/src/routes.ts
@@ -1,4 +1,4 @@
-import type { Module } from "@voyantjs/core"
+import type { Module, ModuleContainer } from "@voyantjs/core"
 import type { HonoModule } from "@voyantjs/hono/module"
 import type { NotificationProvider } from "@voyantjs/notifications"
 import { createNotificationService } from "@voyantjs/notifications"
@@ -24,33 +24,46 @@ import {
 type Env = {
   Bindings: Record<string, unknown>
   Variables: {
+    container: ModuleContainer
     db: PostgresJsDatabase
     userId?: string
   }
 }
 
+export type CheckoutRoutesOptions = {
+  policy?: CheckoutPolicyOptions
+  providers?: ReadonlyArray<NotificationProvider>
+  resolveProviders?: (bindings: Record<string, unknown>) => ReadonlyArray<NotificationProvider>
+  paymentStarters?: Record<string, CheckoutPaymentStarter>
+  resolvePaymentStarters?: (
+    bindings: Record<string, unknown>,
+  ) => Record<string, CheckoutPaymentStarter>
+  bankTransferDetails?: CheckoutBankTransferDetails | null
+  resolveBankTransferDetails?: (
+    bindings: Record<string, unknown>,
+  ) => CheckoutBankTransferDetails | null
+}
+
+export type CheckoutRouteRuntime = {
+  bindings: Record<string, unknown>
+  providers: ReadonlyArray<NotificationProvider>
+  paymentStarters: Record<string, CheckoutPaymentStarter>
+  bankTransferDetails: CheckoutBankTransferDetails | null
+}
+
+export const CHECKOUT_ROUTE_RUNTIME_CONTAINER_KEY = "providers.checkout.runtime"
+
 export function createCheckoutRoutes(
-  options: {
-    policy?: CheckoutPolicyOptions
-    providers?: ReadonlyArray<NotificationProvider>
-    resolveProviders?: (bindings: Record<string, unknown>) => ReadonlyArray<NotificationProvider>
-    paymentStarters?: Record<string, CheckoutPaymentStarter>
-    resolvePaymentStarters?: (
-      bindings: Record<string, unknown>,
-    ) => Record<string, CheckoutPaymentStarter>
-    bankTransferDetails?: CheckoutBankTransferDetails | null
-    resolveBankTransferDetails?: (
-      bindings: Record<string, unknown>,
-    ) => CheckoutBankTransferDetails | null
-  } = {},
+  options: CheckoutRoutesOptions = {},
 ) {
-  function createCheckoutRuntime(bindings: Record<string, unknown>) {
-    return {
-      bindings,
-      paymentStarters: options.resolvePaymentStarters?.(bindings) ?? options.paymentStarters ?? {},
-      bankTransferDetails:
-        options.resolveBankTransferDetails?.(bindings) ?? options.bankTransferDetails ?? null,
-    }
+  function getRuntime(
+    bindings: Record<string, unknown>,
+    resolveFromContainer?: (key: string) => CheckoutRouteRuntime | undefined,
+  ) {
+    return (
+      resolveFromContainer?.(CHECKOUT_ROUTE_RUNTIME_CONTAINER_KEY) ??
+      buildCheckoutRouteRuntime(bindings, options)
+    )
   }
 
   return new Hono<Env>()
@@ -76,16 +89,15 @@ export function createCheckoutRoutes(
     })
     .post("/v1/checkout/bookings/:bookingId/initiate-collection", async (c) => {
       try {
-        const dispatcher = createNotificationService(
-          options.resolveProviders?.(c.env) ?? options.providers ?? [],
-        )
+        const runtime = getRuntime(c.env, (key) => c.var.container?.resolve(key))
+        const dispatcher = createNotificationService(runtime.providers)
         const result = await initiateCheckoutCollection(
           c.get("db"),
           c.req.param("bookingId"),
           initiateCheckoutCollectionSchema.parse(await c.req.json()),
           options.policy,
           dispatcher,
-          createCheckoutRuntime(c.env),
+          runtime,
         )
 
         if (!result) {
@@ -104,15 +116,14 @@ export function createCheckoutRoutes(
     })
     .post("/v1/checkout/collections/bootstrap", async (c) => {
       try {
-        const dispatcher = createNotificationService(
-          options.resolveProviders?.(c.env) ?? options.providers ?? [],
-        )
+        const runtime = getRuntime(c.env, (key) => c.var.container?.resolve(key))
+        const dispatcher = createNotificationService(runtime.providers)
         const result = await bootstrapCheckoutCollection(
           c.get("db"),
           bootstrapCheckoutCollectionSchema.parse(await c.req.json()),
           options.policy,
           dispatcher,
-          createCheckoutRuntime(c.env),
+          runtime,
         )
 
         if (!result) {
@@ -146,11 +157,34 @@ export const checkoutModule: Module = {
 }
 
 export function createCheckoutHonoModule(
-  options?: Parameters<typeof createCheckoutRoutes>[0],
+  options: CheckoutRoutesOptions = {},
 ): HonoModule {
+  const module: Module = {
+    ...checkoutModule,
+    bootstrap: ({ bindings, container }) => {
+      container.register(
+        CHECKOUT_ROUTE_RUNTIME_CONTAINER_KEY,
+        buildCheckoutRouteRuntime(bindings as Record<string, unknown>, options),
+      )
+    },
+  }
+
   return {
-    module: checkoutModule,
+    module,
     routes: createCheckoutRoutes(options),
     adminRoutes: createCheckoutAdminRoutes(),
+  }
+}
+
+export function buildCheckoutRouteRuntime(
+  bindings: Record<string, unknown>,
+  options: CheckoutRoutesOptions = {},
+): CheckoutRouteRuntime {
+  return {
+    bindings,
+    providers: options.resolveProviders?.(bindings) ?? options.providers ?? [],
+    paymentStarters: options.resolvePaymentStarters?.(bindings) ?? options.paymentStarters ?? {},
+    bankTransferDetails:
+      options.resolveBankTransferDetails?.(bindings) ?? options.bankTransferDetails ?? null,
   }
 }

--- a/packages/checkout/tests/unit/module.test.ts
+++ b/packages/checkout/tests/unit/module.test.ts
@@ -1,0 +1,53 @@
+import { createContainer } from "@voyantjs/core"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  CHECKOUT_ROUTE_RUNTIME_CONTAINER_KEY,
+  createCheckoutHonoModule,
+} from "../../src/index.js"
+
+describe("createCheckoutHonoModule", () => {
+  it("registers checkout route runtime during bootstrap", () => {
+    const resolveProviders = vi.fn(() => [
+      {
+        channels: ["email"] as const,
+        deliver: vi.fn(async () => ({ provider: "email" })),
+      },
+    ])
+
+    const resolvePaymentStarters = vi.fn(() => ({
+      card: vi.fn(async () => ({ provider: "card", sessionId: "session_123" })),
+    }))
+
+    const resolveBankTransferDetails = vi.fn(() => ({
+      bankName: "Voyant Bank",
+      iban: "RO49AAAA1B31007593840000",
+      accountHolder: "Voyant",
+    }))
+
+    const container = createContainer()
+    const bindings = { NETOPIA_SIGNATURE: "sig" }
+    const module = createCheckoutHonoModule({
+      resolveProviders,
+      resolvePaymentStarters,
+      resolveBankTransferDetails,
+    }).module
+
+    module.bootstrap?.({ bindings, container })
+
+    expect(resolveProviders).toHaveBeenCalledTimes(1)
+    expect(resolvePaymentStarters).toHaveBeenCalledTimes(1)
+    expect(resolveBankTransferDetails).toHaveBeenCalledTimes(1)
+    const runtime = container.resolve(CHECKOUT_ROUTE_RUNTIME_CONTAINER_KEY)
+
+    expect(runtime?.bindings).toEqual(bindings)
+    expect(runtime?.providers).toHaveLength(1)
+    expect(runtime?.providers[0]?.channels).toEqual(["email"])
+    expect(runtime?.paymentStarters.card).toBeTypeOf("function")
+    expect(runtime?.bankTransferDetails).toEqual({
+      bankName: "Voyant Bank",
+      iban: "RO49AAAA1B31007593840000",
+      accountHolder: "Voyant",
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- register checkout route runtime dependencies once at bootstrap
- resolve notification providers, payment starters, and bank transfer details from the shared container in Hono routes
- add focused unit coverage for bootstrap registration

## Testing
- git diff --check
- pnpm -C .codex-worktrees/checkout-bootstrap-runtime/packages/checkout typecheck
- pnpm -C .codex-worktrees/checkout-bootstrap-runtime/packages/checkout test
- git -C .codex-worktrees/checkout-bootstrap-runtime push -u origin cleanup/checkout-bootstrap-runtime