### PR TITLE
Bootstrap finance route runtime

### DIFF
--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -2,6 +2,11 @@ import type { LinkableDefinition, Module } from "@voyantjs/core"
 import type { HonoModule } from "@voyantjs/hono/module"
 import { Hono } from "hono"
 
+import {
+  buildFinanceRouteRuntime,
+  FINANCE_ROUTE_RUNTIME_CONTAINER_KEY,
+  type FinanceRuntimeOptions,
+} from "./route-runtime.js"
 import { financeRoutes } from "./routes.js"
 import {
   createFinanceAdminDocumentRoutes,
@@ -50,9 +55,7 @@ export const financeModule: Module = {
   linkable: financeLinkable,
 }
 
-export interface FinanceHonoModuleOptions
-  extends FinanceDocumentRouteOptions,
-    FinanceSettlementRouteOptions {}
+export interface FinanceHonoModuleOptions extends FinanceRuntimeOptions {}
 
 export function createFinanceHonoModule(options: FinanceHonoModuleOptions = {}): HonoModule {
   const adminRoutes = new Hono()
@@ -60,8 +63,18 @@ export function createFinanceHonoModule(options: FinanceHonoModuleOptions = {}):
     .route("/", createFinanceAdminDocumentRoutes(options))
     .route("/", createFinanceAdminSettlementRoutes(options))
 
+  const module: Module = {
+    ...financeModule,
+    bootstrap: ({ bindings, container }) => {
+      container.register(
+        FINANCE_ROUTE_RUNTIME_CONTAINER_KEY,
+        buildFinanceRouteRuntime(bindings as Record<string, unknown>, options),
+      )
+    },
+  }
+
   return {
-    module: financeModule,
+    module,
     adminRoutes,
     publicRoutes: publicFinanceRoutes,
     routes: adminRoutes,
@@ -75,6 +88,12 @@ export {
   type FinanceDocumentRouteOptions,
   type InvoiceDocumentGenerator,
 } from "./routes-documents.js"
+export {
+  buildFinanceRouteRuntime,
+  FINANCE_ROUTE_RUNTIME_CONTAINER_KEY,
+  type FinanceRouteRuntime,
+  type FinanceRuntimeOptions,
+} from "./route-runtime.js"
 export {
   createFinanceAdminSettlementRoutes,
   type FinanceSettlementRouteOptions,

--- a/packages/finance/src/route-runtime.ts
+++ b/packages/finance/src/route-runtime.ts
@@ -1,0 +1,32 @@
+import type { EventBus } from "@voyantjs/core"
+
+import type { FinanceDocumentRouteOptions, InvoiceDocumentGenerator } from "./routes-documents.js"
+import type {
+  FinanceSettlementRouteOptions,
+  InvoiceSettlementPoller,
+} from "./routes-settlement.js"
+
+export type FinanceRouteRuntime = {
+  invoiceDocumentGenerator?: InvoiceDocumentGenerator
+  invoiceSettlementPollers: Record<string, InvoiceSettlementPoller>
+  eventBus?: EventBus
+}
+
+export const FINANCE_ROUTE_RUNTIME_CONTAINER_KEY = "providers.finance.runtime"
+
+export interface FinanceRuntimeOptions
+  extends FinanceDocumentRouteOptions,
+    FinanceSettlementRouteOptions {}
+
+export function buildFinanceRouteRuntime(
+  bindings: Record<string, unknown>,
+  options: FinanceRuntimeOptions = {},
+): FinanceRouteRuntime {
+  return {
+    invoiceDocumentGenerator:
+      options.resolveInvoiceDocumentGenerator?.(bindings) ?? options.invoiceDocumentGenerator,
+    invoiceSettlementPollers:
+      options.resolveInvoiceSettlementPollers?.(bindings) ?? options.invoiceSettlementPollers ?? {},
+    eventBus: options.resolveEventBus?.(bindings) ?? options.eventBus,
+  }
+}

--- a/packages/finance/src/routes-documents.ts
+++ b/packages/finance/src/routes-documents.ts
@@ -1,13 +1,19 @@
-import type { EventBus } from "@voyantjs/core"
+import type { EventBus, ModuleContainer } from "@voyantjs/core"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
 
+import {
+  buildFinanceRouteRuntime,
+  FINANCE_ROUTE_RUNTIME_CONTAINER_KEY,
+  type FinanceRouteRuntime,
+} from "./route-runtime.js"
 import { financeDocumentsService } from "./service-documents.js"
 import { generateInvoiceDocumentInputSchema } from "./validation.js"
 
 type Env = {
   Bindings: Record<string, unknown>
   Variables: {
+    container: ModuleContainer
     db: PostgresJsDatabase
     userId?: string
   }
@@ -26,24 +32,22 @@ export interface FinanceDocumentRouteOptions {
   resolveEventBus?: (bindings: Record<string, unknown>) => EventBus | undefined
 }
 
-function resolveInvoiceDocumentGenerator(
+function getRuntime(
   options: FinanceDocumentRouteOptions | undefined,
   bindings: Record<string, unknown>,
+  resolveFromContainer?: (key: string) => FinanceRouteRuntime | undefined,
 ) {
-  return options?.resolveInvoiceDocumentGenerator?.(bindings) ?? options?.invoiceDocumentGenerator
-}
-
-function resolveEventBus(
-  options: FinanceDocumentRouteOptions | undefined,
-  bindings: Record<string, unknown>,
-) {
-  return options?.resolveEventBus?.(bindings) ?? options?.eventBus
+  return (
+    resolveFromContainer?.(FINANCE_ROUTE_RUNTIME_CONTAINER_KEY) ??
+    buildFinanceRouteRuntime(bindings, options)
+  )
 }
 
 export function createFinanceAdminDocumentRoutes(options: FinanceDocumentRouteOptions = {}) {
   return new Hono<Env>()
     .post("/invoices/:id/generate-document", async (c) => {
-      const generator = resolveInvoiceDocumentGenerator(options, c.env)
+      const runtime = getRuntime(options, c.env, (key) => c.var.container?.resolve(key))
+      const generator = runtime.invoiceDocumentGenerator
       if (!generator) {
         return c.json({ error: "Invoice document generator is not configured" }, 501)
       }
@@ -52,7 +56,7 @@ export function createFinanceAdminDocumentRoutes(options: FinanceDocumentRouteOp
         c.get("db"),
         c.req.param("id"),
         generateInvoiceDocumentInputSchema.parse(await c.req.json().catch(() => ({}))),
-        { generator, bindings: c.env, eventBus: resolveEventBus(options, c.env) },
+        { generator, bindings: c.env, eventBus: runtime.eventBus },
       )
 
       if (result.status === "not_found") return c.json({ error: "Invoice not found" }, 404)
@@ -63,7 +67,8 @@ export function createFinanceAdminDocumentRoutes(options: FinanceDocumentRouteOp
       return c.json({ data: result }, 201)
     })
     .post("/invoices/:id/regenerate-document", async (c) => {
-      const generator = resolveInvoiceDocumentGenerator(options, c.env)
+      const runtime = getRuntime(options, c.env, (key) => c.var.container?.resolve(key))
+      const generator = runtime.invoiceDocumentGenerator
       if (!generator) {
         return c.json({ error: "Invoice document generator is not configured" }, 501)
       }
@@ -72,7 +77,7 @@ export function createFinanceAdminDocumentRoutes(options: FinanceDocumentRouteOp
         c.get("db"),
         c.req.param("id"),
         generateInvoiceDocumentInputSchema.parse(await c.req.json().catch(() => ({}))),
-        { generator, bindings: c.env, eventBus: resolveEventBus(options, c.env) },
+        { generator, bindings: c.env, eventBus: runtime.eventBus },
       )
 
       if (result.status === "not_found") return c.json({ error: "Invoice not found" }, 404)

--- a/packages/finance/src/routes-settlement.ts
+++ b/packages/finance/src/routes-settlement.ts
@@ -1,12 +1,18 @@
-import type { EventBus } from "@voyantjs/core"
+import type { EventBus, ModuleContainer } from "@voyantjs/core"
 import { Hono } from "hono"
 
+import {
+  buildFinanceRouteRuntime,
+  FINANCE_ROUTE_RUNTIME_CONTAINER_KEY,
+  type FinanceRouteRuntime,
+} from "./route-runtime.js"
 import { financeSettlementService, type InvoiceSettlementPoller } from "./service-settlement.js"
 import { pollInvoiceSettlementInputSchema } from "./validation.js"
 
 type Env = {
   Bindings: Record<string, unknown>
   Variables: {
+    container: ModuleContainer
     db: import("drizzle-orm/postgres-js").PostgresJsDatabase
     userId?: string
   }
@@ -21,32 +27,29 @@ export interface FinanceSettlementRouteOptions {
   resolveEventBus?: (bindings: Record<string, unknown>) => EventBus | undefined
 }
 
-function resolveInvoiceSettlementPollers(
+function getRuntime(
   options: FinanceSettlementRouteOptions | undefined,
   bindings: Record<string, unknown>,
+  resolveFromContainer?: (key: string) => FinanceRouteRuntime | undefined,
 ) {
   return (
-    options?.resolveInvoiceSettlementPollers?.(bindings) ?? options?.invoiceSettlementPollers ?? {}
+    resolveFromContainer?.(FINANCE_ROUTE_RUNTIME_CONTAINER_KEY) ??
+    buildFinanceRouteRuntime(bindings, options)
   )
-}
-
-function resolveEventBus(
-  options: FinanceSettlementRouteOptions | undefined,
-  bindings: Record<string, unknown>,
-) {
-  return options?.resolveEventBus?.(bindings) ?? options?.eventBus
 }
 
 export function createFinanceAdminSettlementRoutes(options: FinanceSettlementRouteOptions = {}) {
   return new Hono<Env>().post("/invoices/:id/poll-settlement", async (c) => {
+    const runtime = getRuntime(options, c.env, (key) => c.var.container?.resolve(key))
+
     const result = await financeSettlementService.pollInvoiceSettlement(
       c.get("db"),
       c.req.param("id"),
       pollInvoiceSettlementInputSchema.parse(await c.req.json().catch(() => ({}))),
       {
         bindings: c.env,
-        invoiceSettlementPollers: resolveInvoiceSettlementPollers(options, c.env),
-        eventBus: resolveEventBus(options, c.env),
+        invoiceSettlementPollers: runtime.invoiceSettlementPollers,
+        eventBus: runtime.eventBus,
       },
     )
 

--- a/packages/finance/tests/unit/module.test.ts
+++ b/packages/finance/tests/unit/module.test.ts
@@ -1,0 +1,37 @@
+import { createContainer, createEventBus } from "@voyantjs/core"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  createFinanceHonoModule,
+  FINANCE_ROUTE_RUNTIME_CONTAINER_KEY,
+} from "../../src/index.js"
+
+describe("createFinanceHonoModule", () => {
+  it("registers finance route runtime during bootstrap", () => {
+    const generator = vi.fn()
+    const poller = vi.fn()
+    const eventBus = createEventBus()
+    const resolveInvoiceDocumentGenerator = vi.fn(() => generator)
+    const resolveInvoiceSettlementPollers = vi.fn(() => ({ netopia: poller }))
+    const resolveEventBus = vi.fn(() => eventBus)
+    const container = createContainer()
+    const bindings = { NETOPIA_SIGNATURE: "sig" }
+
+    const module = createFinanceHonoModule({
+      resolveInvoiceDocumentGenerator,
+      resolveInvoiceSettlementPollers,
+      resolveEventBus,
+    }).module
+
+    module.bootstrap?.({ bindings, container })
+
+    const runtime = container.resolve(FINANCE_ROUTE_RUNTIME_CONTAINER_KEY)
+
+    expect(resolveInvoiceDocumentGenerator).toHaveBeenCalledTimes(1)
+    expect(resolveInvoiceSettlementPollers).toHaveBeenCalledTimes(1)
+    expect(resolveEventBus).toHaveBeenCalledTimes(1)
+    expect(runtime?.invoiceDocumentGenerator).toBe(generator)
+    expect(runtime?.invoiceSettlementPollers.netopia).toBe(poller)
+    expect(runtime?.eventBus).toBe(eventBus)
+  })
+})


### PR DESCRIPTION
## Summary
- register finance document and settlement runtime dependencies once at bootstrap
- resolve invoice generators, settlement pollers, and the event bus from the shared container in finance Hono routes
- add focused unit coverage for bootstrap registration

## Testing
- git diff --check
- pnpm -C .codex-worktrees/finance-bootstrap-runtime/packages/finance typecheck
- pnpm -C .codex-worktrees/finance-bootstrap-runtime/packages/finance test
- git -C .codex-worktrees/finance-bootstrap-runtime push -u origin cleanup/finance-bootstrap-runtime