### PR TITLE
Bootstrap customer portal route runtime

### DIFF
--- a/packages/customer-portal/src/index.ts
+++ b/packages/customer-portal/src/index.ts
@@ -1,6 +1,10 @@
 import type { Module } from "@voyantjs/core"
 import type { HonoModule } from "@voyantjs/hono/module"
 
+import {
+  buildPublicCustomerPortalRouteRuntime,
+  CUSTOMER_PORTAL_ROUTE_RUNTIME_CONTAINER_KEY,
+} from "./route-runtime.js"
 import { customerPortalRoutes } from "./routes.js"
 import {
   createPublicCustomerPortalRoutes,
@@ -70,11 +74,28 @@ export const customerPortalModule: Module = {
 export function createCustomerPortalHonoModule(
   options: PublicCustomerPortalRouteOptions = {},
 ): HonoModule {
+  const module: Module = {
+    ...customerPortalModule,
+    bootstrap: ({ bindings, container }) => {
+      container.register(
+        CUSTOMER_PORTAL_ROUTE_RUNTIME_CONTAINER_KEY,
+        buildPublicCustomerPortalRouteRuntime(bindings, options),
+      )
+    },
+  }
+
   return {
-    module: customerPortalModule,
+    module,
     routes: customerPortalRoutes,
     publicRoutes: createPublicCustomerPortalRoutes(options),
   }
 }
 
 export const customerPortalHonoModule: HonoModule = createCustomerPortalHonoModule()
+
+export {
+  buildPublicCustomerPortalRouteRuntime,
+  CUSTOMER_PORTAL_ROUTE_RUNTIME_CONTAINER_KEY,
+  type PublicCustomerPortalRouteRuntime,
+  type PublicCustomerPortalRuntimeOptions,
+} from "./route-runtime.js"

--- a/packages/customer-portal/src/route-runtime.ts
+++ b/packages/customer-portal/src/route-runtime.ts
@@ -1,0 +1,26 @@
+export type PublicCustomerPortalRouteRuntime = {
+  resolveDocumentDownloadUrl?: (storageKey: string) => Promise<string | null> | string | null
+}
+
+export const CUSTOMER_PORTAL_ROUTE_RUNTIME_CONTAINER_KEY =
+  "providers.customerPortal.public.runtime"
+
+export interface PublicCustomerPortalRuntimeOptions {
+  resolveDocumentDownloadUrl?: (
+    bindings: unknown,
+    storageKey: string,
+  ) => Promise<string | null> | string | null
+}
+
+export function buildPublicCustomerPortalRouteRuntime(
+  bindings: unknown,
+  options: PublicCustomerPortalRuntimeOptions = {},
+): PublicCustomerPortalRouteRuntime {
+  const resolveDocumentDownloadUrl = options.resolveDocumentDownloadUrl
+    ? (storageKey: string) => options.resolveDocumentDownloadUrl?.(bindings, storageKey) ?? null
+    : undefined
+
+  return {
+    resolveDocumentDownloadUrl,
+  }
+}

--- a/packages/customer-portal/src/routes-public.ts
+++ b/packages/customer-portal/src/routes-public.ts
@@ -3,6 +3,11 @@ import { createKmsProviderFromEnv } from "@voyantjs/utils"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { type Context, Hono } from "hono"
 
+import {
+  buildPublicCustomerPortalRouteRuntime,
+  CUSTOMER_PORTAL_ROUTE_RUNTIME_CONTAINER_KEY,
+  type PublicCustomerPortalRouteRuntime,
+} from "./route-runtime.js"
 import { publicCustomerPortalService } from "./service-public.js"
 import {
   bootstrapCustomerPortalSchema,
@@ -15,6 +20,7 @@ import {
 type Env = {
   Bindings: Record<string, unknown>
   Variables: {
+    container: import("@voyantjs/core").ModuleContainer
     db: PostgresJsDatabase
     userId?: string
   }
@@ -64,8 +70,13 @@ export interface PublicCustomerPortalRouteOptions {
 }
 
 export function createPublicCustomerPortalRoutes(options: PublicCustomerPortalRouteOptions = {}) {
+  const getRuntime = (c: Context<Env>) =>
+    c.var.container?.resolve<PublicCustomerPortalRouteRuntime>(
+      CUSTOMER_PORTAL_ROUTE_RUNTIME_CONTAINER_KEY,
+    ) ?? buildPublicCustomerPortalRouteRuntime(c.env, options)
+
   const resolveDocumentDownloadUrl = (c: Context<Env>, storageKey: string) =>
-    options.resolveDocumentDownloadUrl?.(c.env, storageKey) ?? null
+    getRuntime(c).resolveDocumentDownloadUrl?.(storageKey) ?? null
 
   return new Hono<Env>()
     .get("/me", async (c) => {

--- a/packages/customer-portal/tests/unit/module.test.ts
+++ b/packages/customer-portal/tests/unit/module.test.ts
@@ -1,0 +1,27 @@
+import { createContainer } from "@voyantjs/core"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  createCustomerPortalHonoModule,
+  CUSTOMER_PORTAL_ROUTE_RUNTIME_CONTAINER_KEY,
+} from "../../src/index.js"
+
+describe("createCustomerPortalHonoModule", () => {
+  it("registers public customer portal route runtime during bootstrap", () => {
+    const resolveDocumentDownloadUrl = vi.fn((_bindings, storageKey: string) => `signed:${storageKey}`)
+    const container = createContainer()
+    const bindings = { DOCUMENTS_BUCKET: "documents" }
+
+    const module = createCustomerPortalHonoModule({
+      resolveDocumentDownloadUrl,
+    }).module
+
+    module.bootstrap?.({ bindings, container })
+
+    const runtime = container.resolve(CUSTOMER_PORTAL_ROUTE_RUNTIME_CONTAINER_KEY)
+
+    expect(runtime?.resolveDocumentDownloadUrl).toBeTypeOf("function")
+    expect(runtime?.resolveDocumentDownloadUrl?.("doc_123")).toBe("signed:doc_123")
+    expect(resolveDocumentDownloadUrl).toHaveBeenCalledWith(bindings, "doc_123")
+  })
+})


### PR DESCRIPTION
## Summary
- register customer portal public route runtime dependencies once at bootstrap
- resolve signed document URL generation from the shared container in customer portal public routes
- add focused unit coverage for bootstrap registration

## Testing
- git diff --check
- pnpm -C .codex-worktrees/customer-portal-bootstrap-runtime/packages/customer-portal typecheck
- pnpm -C .codex-worktrees/customer-portal-bootstrap-runtime/packages/customer-portal test
- git -C .codex-worktrees/customer-portal-bootstrap-runtime push -u origin cleanup/customer-portal-bootstrap-runtime