### PR TITLE
Add notifications task runtime helper

### DIFF
--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -32,6 +32,12 @@ export {
   NOTIFICATIONS_ROUTE_RUNTIME_CONTAINER_KEY,
 } from "./routes.js"
 export type {
+  NotificationTaskEnv,
+  NotificationTaskRuntime,
+  NotificationTaskRuntimeOptions,
+} from "./task-runtime.js"
+export { buildNotificationTaskRuntime } from "./task-runtime.js"
+export type {
   NewNotificationDelivery,
   NewNotificationReminderRule,
   NewNotificationReminderRun,

--- a/packages/notifications/src/task-runtime.ts
+++ b/packages/notifications/src/task-runtime.ts
@@ -1,0 +1,25 @@
+import { createDefaultNotificationProviders } from "./provider-resolution.js"
+import type { NotificationProvider } from "./types.js"
+
+export type NotificationTaskEnv = {
+  RESEND_API_KEY?: unknown
+  EMAIL_FROM?: unknown
+}
+
+export type NotificationTaskRuntime = {
+  providers: ReadonlyArray<NotificationProvider>
+}
+
+export type NotificationTaskRuntimeOptions = {
+  providers?: ReadonlyArray<NotificationProvider>
+  resolveProviders?: (env: NotificationTaskEnv) => ReadonlyArray<NotificationProvider>
+}
+
+export function buildNotificationTaskRuntime(
+  env: NotificationTaskEnv,
+  options: NotificationTaskRuntimeOptions = {},
+): NotificationTaskRuntime {
+  return {
+    providers: options.resolveProviders?.(env) ?? options.providers ?? createDefaultNotificationProviders(env),
+  }
+}

--- a/packages/notifications/src/tasks/send-due-reminders.ts
+++ b/packages/notifications/src/tasks/send-due-reminders.ts
@@ -1,23 +1,18 @@
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-import { createDefaultNotificationProviders } from "../provider-resolution.js"
 import { createNotificationService, notificationsService } from "../service.js"
-import type { NotificationProvider } from "../types.js"
-
-type NotificationTaskEnv = {
-  RESEND_API_KEY?: unknown
-  EMAIL_FROM?: unknown
-}
+import {
+  buildNotificationTaskRuntime,
+  type NotificationTaskEnv,
+  type NotificationTaskRuntimeOptions,
+} from "../task-runtime.js"
 
 export async function sendDueNotificationReminders(
   db: PostgresJsDatabase,
   env: NotificationTaskEnv,
   input: { now?: string | null } = {},
-  options: {
-    resolveProviders?: (env: NotificationTaskEnv) => ReadonlyArray<NotificationProvider>
-  } = {},
+  options: NotificationTaskRuntimeOptions = {},
 ) {
-  const dispatcher = createNotificationService(
-    options.resolveProviders?.(env) ?? createDefaultNotificationProviders(env),
-  )
+  const runtime = buildNotificationTaskRuntime(env, options)
+  const dispatcher = createNotificationService(runtime.providers)
   return notificationsService.runDueReminders(db, dispatcher, input)
 }

--- a/packages/notifications/tests/unit/task-runtime.test.ts
+++ b/packages/notifications/tests/unit/task-runtime.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { buildNotificationTaskRuntime } from "../../src/task-runtime.js"
+
+describe("buildNotificationTaskRuntime", () => {
+  it("registers resolved providers once", () => {
+    const resolveProviders = vi.fn(() => [
+      {
+        name: "email-provider",
+        channels: ["email"],
+        send: vi.fn(async () => ({ id: "ntf_123", provider: "email-provider" })),
+      },
+    ])
+
+    const runtime = buildNotificationTaskRuntime(
+      { RESEND_API_KEY: "resend_test", EMAIL_FROM: "hello@example.com" },
+      { resolveProviders },
+    )
+
+    expect(resolveProviders).toHaveBeenCalledOnce()
+    expect(runtime.providers).toHaveLength(1)
+    expect(runtime.providers[0]?.name).toBe("email-provider")
+  })
+})


### PR DESCRIPTION
## Summary
- add a shared notifications task runtime helper for provider resolution
- move due-reminder dispatch onto the shared task runtime instead of resolving providers ad hoc
- add focused unit coverage for the task runtime helper

## Testing
- git diff --check
- pnpm -C packages/notifications typecheck
- pnpm -C packages/notifications test
- pnpm test
