### PR TITLE
Use notification task runtime in workers

### DIFF
--- a/apps/dev/src/worker.ts
+++ b/apps/dev/src/worker.ts
@@ -1,7 +1,10 @@
 import { generateAvailabilitySlots } from "@voyantjs/availability"
 import { expireStaleBookingHolds } from "@voyantjs/bookings/tasks"
 import { createDbClient } from "@voyantjs/db"
-import { createDefaultNotificationProviders } from "@voyantjs/notifications"
+import {
+  buildNotificationTaskRuntime,
+  createDefaultNotificationProviders,
+} from "@voyantjs/notifications"
 import { sendDueNotificationReminders } from "@voyantjs/notifications/tasks"
 import { generateProductPdf } from "@voyantjs/products/tasks"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -14,6 +17,11 @@ function getDb() {
 
 const resolveNotificationProviders = (env: Record<string, unknown>) =>
   createDefaultNotificationProviders(env, { emailProvider: "resend" })
+
+const getNotificationTaskRuntime = () =>
+  buildNotificationTaskRuntime(process.env, {
+    resolveProviders: resolveNotificationProviders,
+  })
 
 const generatePdf = hatchet.task({
   name: "products.generate-pdf",
@@ -61,9 +69,7 @@ const sendPaymentReminders = hatchet.workflow({
 sendPaymentReminders.task({
   name: "run",
   fn: async (input: { now?: string | null }) => {
-    return sendDueNotificationReminders(getDb(), process.env, input, {
-      resolveProviders: resolveNotificationProviders,
-    })
+    return sendDueNotificationReminders(getDb(), process.env, input, getNotificationTaskRuntime())
   },
 })
 

--- a/templates/dmc/src/worker.ts
+++ b/templates/dmc/src/worker.ts
@@ -1,7 +1,10 @@
 import { generateAvailabilitySlots } from "@voyantjs/availability"
 import { expireStaleBookingHolds } from "@voyantjs/bookings/tasks"
 import { createDbClient } from "@voyantjs/db"
-import { createDefaultNotificationProviders } from "@voyantjs/notifications"
+import {
+  buildNotificationTaskRuntime,
+  createDefaultNotificationProviders,
+} from "@voyantjs/notifications"
 import { sendDueNotificationReminders } from "@voyantjs/notifications/tasks"
 import { generateProductPdf } from "@voyantjs/products/tasks"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -14,6 +17,11 @@ function getDb() {
 
 const resolveNotificationProviders = (env: Record<string, unknown>) =>
   createDefaultNotificationProviders(env, { emailProvider: "resend" })
+
+const getNotificationTaskRuntime = () =>
+  buildNotificationTaskRuntime(process.env, {
+    resolveProviders: resolveNotificationProviders,
+  })
 
 const generatePdf = hatchet.task({
   name: "products.generate-pdf",
@@ -61,9 +69,7 @@ const sendPaymentReminders = hatchet.workflow({
 sendPaymentReminders.task({
   name: "run",
   fn: async (input: { now?: string | null }) => {
-    return sendDueNotificationReminders(getDb(), process.env, input, {
-      resolveProviders: resolveNotificationProviders,
-    })
+    return sendDueNotificationReminders(getDb(), process.env, input, getNotificationTaskRuntime())
   },
 })
 

--- a/templates/operator/src/worker.ts
+++ b/templates/operator/src/worker.ts
@@ -1,6 +1,9 @@
 import { expireStaleBookingHolds } from "@voyantjs/bookings/tasks"
 import { createDbClient } from "@voyantjs/db"
-import { createDefaultNotificationProviders } from "@voyantjs/notifications"
+import {
+  buildNotificationTaskRuntime,
+  createDefaultNotificationProviders,
+} from "@voyantjs/notifications"
 import { sendDueNotificationReminders } from "@voyantjs/notifications/tasks"
 import { generateProductPdf } from "@voyantjs/products/tasks"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -15,6 +18,11 @@ const resolveNotificationProviders = (env: Record<string, unknown>) =>
   createDefaultNotificationProviders(env, {
     emailProvider: "resend",
     smsProvider: "twilio",
+  })
+
+const getNotificationTaskRuntime = () =>
+  buildNotificationTaskRuntime(process.env, {
+    resolveProviders: resolveNotificationProviders,
   })
 
 const generatePdf = hatchet.task({
@@ -53,9 +61,7 @@ const sendPaymentReminders = hatchet.workflow({
 sendPaymentReminders.task({
   name: "run",
   fn: async (input: { now?: string | null }) => {
-    return sendDueNotificationReminders(getDb(), process.env, input, {
-      resolveProviders: resolveNotificationProviders,
-    })
+    return sendDueNotificationReminders(getDb(), process.env, input, getNotificationTaskRuntime())
   },
 })
 


### PR DESCRIPTION
## Summary
- move operator, dmc, and dev worker entrypoints onto the shared notifications task runtime
- keep template-specific provider selection, but stop reconstructing providers ad hoc at each reminder task call
- align cron/worker notification dispatch with the shared package runtime seam

## Testing
- git diff --check
- pnpm test
