### PR TITLE
Add Netopia notification runtime helper

### DIFF
--- a/packages/plugins/netopia/src/index.ts
+++ b/packages/plugins/netopia/src/index.ts
@@ -14,6 +14,11 @@ export {
   netopiaHonoPlugin as createNetopiaAdapterBundle,
   netopiaHonoPlugin,
 } from "./plugin.js"
+export type {
+  NetopiaNotificationRuntime,
+  NetopiaNotificationRuntimeOptions,
+} from "./notification-runtime.js"
+export { buildNetopiaNotificationRuntime } from "./notification-runtime.js"
 export {
   deriveNetopiaOrderId,
   mapNetopiaPaymentStatus,

--- a/packages/plugins/netopia/src/notification-runtime.ts
+++ b/packages/plugins/netopia/src/notification-runtime.ts
@@ -1,0 +1,40 @@
+import {
+  createDefaultNotificationProviders,
+  createNotificationService,
+  type NotificationProvider,
+  type NotificationService,
+} from "@voyantjs/notifications"
+
+import type { NetopiaRuntimeOptions } from "./types.js"
+
+export type NetopiaNotificationRuntime = {
+  dispatcher: NotificationService
+}
+
+export type NetopiaNotificationRuntimeOptions = Pick<
+  NetopiaRuntimeOptions,
+  "resolveNotificationProviders"
+> & {
+  notificationProviders?: ReadonlyArray<NotificationProvider>
+}
+
+export function buildNetopiaNotificationRuntime(
+  bindings: Record<string, unknown> | undefined,
+  runtimeOptions: NetopiaNotificationRuntimeOptions = {},
+  dispatcherOverride?: NotificationService,
+): NetopiaNotificationRuntime {
+  if (dispatcherOverride) {
+    return {
+      dispatcher: dispatcherOverride,
+    }
+  }
+
+  const providers =
+    runtimeOptions.resolveNotificationProviders?.(bindings ?? {}) ??
+    runtimeOptions.notificationProviders ??
+    createDefaultNotificationProviders(bindings ?? {})
+
+  return {
+    dispatcher: createNotificationService(providers),
+  }
+}

--- a/packages/plugins/netopia/src/service-shared.ts
+++ b/packages/plugins/netopia/src/service-shared.ts
@@ -1,12 +1,8 @@
 import { financeService, type PaymentSession } from "@voyantjs/finance"
-import {
-  createDefaultNotificationProviders,
-  createNotificationService,
-  type NotificationDelivery,
-  type NotificationService,
-} from "@voyantjs/notifications"
+import { type NotificationDelivery, type NotificationService } from "@voyantjs/notifications"
 import type { z } from "zod"
 
+import { buildNetopiaNotificationRuntime } from "./notification-runtime.js"
 import type {
   NetopiaProductLine,
   NetopiaRuntimeOptions,
@@ -96,14 +92,7 @@ export function resolveNotificationDispatcher(
   runtimeOptions: NetopiaRuntimeOptions,
   dispatcherOverride?: NotificationService,
 ) {
-  if (dispatcherOverride) {
-    return dispatcherOverride
-  }
-
-  return createNotificationService(
-    runtimeOptions.resolveNotificationProviders?.(bindings ?? {}) ??
-      createDefaultNotificationProviders(bindings ?? {}),
-  )
+  return buildNetopiaNotificationRuntime(bindings, runtimeOptions, dispatcherOverride).dispatcher
 }
 
 export { financeService }

--- a/packages/plugins/netopia/tests/unit/notification-runtime.test.ts
+++ b/packages/plugins/netopia/tests/unit/notification-runtime.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { buildNetopiaNotificationRuntime } from "../../src/notification-runtime.js"
+
+describe("buildNetopiaNotificationRuntime", () => {
+  it("uses resolved notification providers once", () => {
+    const resolveNotificationProviders = vi.fn(() => [
+      {
+        name: "email-provider",
+        channels: ["email"],
+        send: vi.fn(async () => ({ id: "ntf_123", provider: "email-provider" })),
+      },
+    ])
+
+    const runtime = buildNetopiaNotificationRuntime(
+      { RESEND_API_KEY: "resend_test", EMAIL_FROM: "hello@example.com" },
+      { resolveNotificationProviders },
+    )
+
+    expect(resolveNotificationProviders).toHaveBeenCalledOnce()
+    expect(runtime.dispatcher).toBeTruthy()
+  })
+
+  it("prefers an explicit dispatcher override", () => {
+    const dispatcher = {
+      send: vi.fn(async () => ({
+        id: "ntf_123",
+        channel: "email",
+        provider: "email-provider",
+      })),
+    }
+
+    const runtime = buildNetopiaNotificationRuntime({}, {}, dispatcher as never)
+
+    expect(runtime.dispatcher).toBe(dispatcher)
+  })
+})


### PR DESCRIPTION
## Summary
- add a shared notification runtime helper inside the Netopia plugin
- route Netopia collection flows through the shared helper instead of building default providers inline
- add focused unit coverage for the Netopia notification runtime helper

## Testing
- git diff --check
- pnpm -C packages/plugins/netopia typecheck
- pnpm -C packages/plugins/netopia test
- pnpm test
