### PR TITLE
Centralize app notification runtime helpers

### DIFF
--- a/apps/dev/src/api/app.ts
+++ b/apps/dev/src/api/app.ts
@@ -15,7 +15,6 @@ import { hospitalityHonoModule } from "@voyantjs/hospitality"
 import { identityHonoModule } from "@voyantjs/identity"
 import { marketsHonoModule } from "@voyantjs/markets"
 import {
-  createDefaultNotificationProviders,
   createNotificationsHonoModule,
 } from "@voyantjs/notifications"
 import { octoHonoModule } from "@voyantjs/octo"
@@ -29,9 +28,7 @@ import { transactionsBookingExtension, transactionsHonoModule } from "@voyantjs/
 import authHandler, { hasAuthPermission, resolveAuthRequest } from "./auth/handler"
 import { getDbFromHyperdrive } from "./lib/db"
 import { createMediaStorage, guessMimeType } from "./lib/storage"
-
-const resolveNotificationProviders = (env: Record<string, unknown>) =>
-  createDefaultNotificationProviders(env, { emailProvider: "resend" })
+import { resolveNotificationProviders } from "../lib/notifications"
 
 const notificationsHonoModule = createNotificationsHonoModule({
   resolveProviders: resolveNotificationProviders,

--- a/apps/dev/src/lib/notifications.ts
+++ b/apps/dev/src/lib/notifications.ts
@@ -1,0 +1,12 @@
+import {
+  buildNotificationTaskRuntime,
+  createDefaultNotificationProviders,
+} from "@voyantjs/notifications"
+
+export const resolveNotificationProviders = (env: Record<string, unknown>) =>
+  createDefaultNotificationProviders(env, { emailProvider: "resend" })
+
+export const getNotificationTaskRuntime = (env: Record<string, unknown>) =>
+  buildNotificationTaskRuntime(env, {
+    resolveProviders: resolveNotificationProviders,
+  })

--- a/apps/dev/src/worker.ts
+++ b/apps/dev/src/worker.ts
@@ -1,27 +1,16 @@
 import { generateAvailabilitySlots } from "@voyantjs/availability"
 import { expireStaleBookingHolds } from "@voyantjs/bookings/tasks"
 import { createDbClient } from "@voyantjs/db"
-import {
-  buildNotificationTaskRuntime,
-  createDefaultNotificationProviders,
-} from "@voyantjs/notifications"
 import { sendDueNotificationReminders } from "@voyantjs/notifications/tasks"
 import { generateProductPdf } from "@voyantjs/products/tasks"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { hatchet } from "./hatchet-client.js"
+import { getNotificationTaskRuntime } from "./lib/notifications.js"
 
 function getDb() {
   return createDbClient(process.env.DATABASE_URL!, { adapter: "node" }) as PostgresJsDatabase
 }
-
-const resolveNotificationProviders = (env: Record<string, unknown>) =>
-  createDefaultNotificationProviders(env, { emailProvider: "resend" })
-
-const getNotificationTaskRuntime = () =>
-  buildNotificationTaskRuntime(process.env, {
-    resolveProviders: resolveNotificationProviders,
-  })
 
 const generatePdf = hatchet.task({
   name: "products.generate-pdf",
@@ -69,7 +58,7 @@ const sendPaymentReminders = hatchet.workflow({
 sendPaymentReminders.task({
   name: "run",
   fn: async (input: { now?: string | null }) => {
-    return sendDueNotificationReminders(getDb(), process.env, input, getNotificationTaskRuntime())
+    return sendDueNotificationReminders(getDb(), process.env, input, getNotificationTaskRuntime(process.env))
   },
 })
 

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -10,12 +10,10 @@ import {
 import { financeRoutes } from "./routes.js"
 import {
   createFinanceAdminDocumentRoutes,
-  type FinanceDocumentRouteOptions,
 } from "./routes-documents.js"
 import { publicFinanceRoutes } from "./routes-public.js"
 import {
   createFinanceAdminSettlementRoutes,
-  type FinanceSettlementRouteOptions,
 } from "./routes-settlement.js"
 
 export type { FinanceRoutes } from "./routes.js"

--- a/templates/dmc/src/api/app.ts
+++ b/templates/dmc/src/api/app.ts
@@ -16,7 +16,6 @@ import { identityHonoModule } from "@voyantjs/identity"
 import { legalHonoModule } from "@voyantjs/legal"
 import { marketsHonoModule } from "@voyantjs/markets"
 import {
-  createDefaultNotificationProviders,
   createNotificationsHonoModule,
 } from "@voyantjs/notifications"
 import { pricingHonoModule } from "@voyantjs/pricing"
@@ -30,12 +29,7 @@ import { transactionsBookingExtension, transactionsHonoModule } from "@voyantjs/
 import authHandler, { hasAuthPermission, resolveAuthRequest } from "./auth/handler"
 import { getDbFromHyperdrive } from "./lib/db"
 import { createMediaStorage, guessMimeType } from "./lib/storage"
-
-const resolveNotificationProviders = (env: Record<string, unknown>) =>
-  createDefaultNotificationProviders(env, {
-    emailProvider: "resend",
-    smsProvider: "twilio",
-  })
+import { resolveNotificationProviders } from "../lib/notifications"
 
 const notificationsHonoModule = createNotificationsHonoModule({
   resolveProviders: resolveNotificationProviders,

--- a/templates/dmc/src/lib/notifications.ts
+++ b/templates/dmc/src/lib/notifications.ts
@@ -1,0 +1,15 @@
+import {
+  buildNotificationTaskRuntime,
+  createDefaultNotificationProviders,
+} from "@voyantjs/notifications"
+
+export const resolveNotificationProviders = (env: Record<string, unknown>) =>
+  createDefaultNotificationProviders(env, {
+    emailProvider: "resend",
+    smsProvider: "twilio",
+  })
+
+export const getNotificationTaskRuntime = (env: Record<string, unknown>) =>
+  buildNotificationTaskRuntime(env, {
+    resolveProviders: resolveNotificationProviders,
+  })

--- a/templates/dmc/src/worker.ts
+++ b/templates/dmc/src/worker.ts
@@ -1,27 +1,16 @@
 import { generateAvailabilitySlots } from "@voyantjs/availability"
 import { expireStaleBookingHolds } from "@voyantjs/bookings/tasks"
 import { createDbClient } from "@voyantjs/db"
-import {
-  buildNotificationTaskRuntime,
-  createDefaultNotificationProviders,
-} from "@voyantjs/notifications"
 import { sendDueNotificationReminders } from "@voyantjs/notifications/tasks"
 import { generateProductPdf } from "@voyantjs/products/tasks"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { hatchet } from "./hatchet-client.js"
+import { getNotificationTaskRuntime } from "./lib/notifications.js"
 
 function getDb() {
   return createDbClient(process.env.DATABASE_URL!, { adapter: "node" }) as PostgresJsDatabase
 }
-
-const resolveNotificationProviders = (env: Record<string, unknown>) =>
-  createDefaultNotificationProviders(env, { emailProvider: "resend" })
-
-const getNotificationTaskRuntime = () =>
-  buildNotificationTaskRuntime(process.env, {
-    resolveProviders: resolveNotificationProviders,
-  })
 
 const generatePdf = hatchet.task({
   name: "products.generate-pdf",
@@ -69,7 +58,7 @@ const sendPaymentReminders = hatchet.workflow({
 sendPaymentReminders.task({
   name: "run",
   fn: async (input: { now?: string | null }) => {
-    return sendDueNotificationReminders(getDb(), process.env, input, getNotificationTaskRuntime())
+    return sendDueNotificationReminders(getDb(), process.env, input, getNotificationTaskRuntime(process.env))
   },
 })
 

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -13,7 +13,6 @@ import { identityHonoModule } from "@voyantjs/identity"
 import { legalHonoModule } from "@voyantjs/legal"
 import { marketsHonoModule } from "@voyantjs/markets"
 import {
-  createDefaultNotificationProviders,
   createNotificationsHonoModule,
 } from "@voyantjs/notifications"
 import { pricingHonoModule } from "@voyantjs/pricing"
@@ -27,12 +26,7 @@ import { transactionsBookingExtension, transactionsHonoModule } from "@voyantjs/
 import authHandler, { hasAuthPermission, resolveAuthRequest } from "./auth/handler"
 import { getDbFromHyperdrive } from "./lib/db"
 import { createMediaStorage, guessMimeType } from "./lib/storage"
-
-const resolveNotificationProviders = (env: Record<string, unknown>) =>
-  createDefaultNotificationProviders(env, {
-    emailProvider: "resend",
-    smsProvider: "twilio",
-  })
+import { resolveNotificationProviders } from "../lib/notifications"
 
 const notificationsHonoModule = createNotificationsHonoModule({
   resolveProviders: resolveNotificationProviders,

--- a/templates/operator/src/lib/notifications.ts
+++ b/templates/operator/src/lib/notifications.ts
@@ -1,0 +1,15 @@
+import {
+  buildNotificationTaskRuntime,
+  createDefaultNotificationProviders,
+} from "@voyantjs/notifications"
+
+export const resolveNotificationProviders = (env: Record<string, unknown>) =>
+  createDefaultNotificationProviders(env, {
+    emailProvider: "resend",
+    smsProvider: "twilio",
+  })
+
+export const getNotificationTaskRuntime = (env: Record<string, unknown>) =>
+  buildNotificationTaskRuntime(env, {
+    resolveProviders: resolveNotificationProviders,
+  })

--- a/templates/operator/src/worker.ts
+++ b/templates/operator/src/worker.ts
@@ -1,29 +1,15 @@
 import { expireStaleBookingHolds } from "@voyantjs/bookings/tasks"
 import { createDbClient } from "@voyantjs/db"
-import {
-  buildNotificationTaskRuntime,
-  createDefaultNotificationProviders,
-} from "@voyantjs/notifications"
 import { sendDueNotificationReminders } from "@voyantjs/notifications/tasks"
 import { generateProductPdf } from "@voyantjs/products/tasks"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { hatchet } from "./hatchet-client.js"
+import { getNotificationTaskRuntime } from "./lib/notifications.js"
 
 function getDb() {
   return createDbClient(process.env.DATABASE_URL!, { adapter: "node" }) as PostgresJsDatabase
 }
-
-const resolveNotificationProviders = (env: Record<string, unknown>) =>
-  createDefaultNotificationProviders(env, {
-    emailProvider: "resend",
-    smsProvider: "twilio",
-  })
-
-const getNotificationTaskRuntime = () =>
-  buildNotificationTaskRuntime(process.env, {
-    resolveProviders: resolveNotificationProviders,
-  })
 
 const generatePdf = hatchet.task({
   name: "products.generate-pdf",
@@ -61,7 +47,7 @@ const sendPaymentReminders = hatchet.workflow({
 sendPaymentReminders.task({
   name: "run",
   fn: async (input: { now?: string | null }) => {
-    return sendDueNotificationReminders(getDb(), process.env, input, getNotificationTaskRuntime())
+    return sendDueNotificationReminders(getDb(), process.env, input, getNotificationTaskRuntime(process.env))
   },
 })
 


### PR DESCRIPTION
## Summary
- centralize app-level notification provider selection into one local helper per template/app
- reuse the same helper from API composition and worker notification tasks
- remove repeated app-owned notification runtime glue from operator, dmc, and dev

## Testing
- git diff --check
- pnpm -C templates/operator typecheck
- pnpm -C templates/dmc typecheck
- pnpm -C apps/dev typecheck
- pnpm test