### PR TITLE
Tighten package taxonomy wording

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,8 +2,8 @@
 
 Module system and framework primitives for Voyant. Transport-agnostic —
 provides the contracts, registry, container, event bus, links, query,
-workflows, plugin bundles, and config shape that every Voyant module and
-transport adapter builds on.
+workflows, optional plugin bundles, and config shape that every Voyant module
+and transport adapter builds on.
 
 ## Install
 
@@ -23,7 +23,7 @@ import { createWorkflow, step } from "@voyantjs/core/workflows"
 
 In Voyant, modules, providers, extensions, and workflows are the main runtime
 primitives. Plugins are optional distribution bundles that package those pieces
-together for reuse across projects.
+together for reuse across projects when a broader bundle is helpful.
 
 ## Exports
 

--- a/packages/plugins/netopia/README.md
+++ b/packages/plugins/netopia/README.md
@@ -59,8 +59,9 @@ const netopiaFinanceExtension = createNetopiaFinanceAdapter()
 Then include the returned extension in `createApp({ extensions: [...] })`.
 
 If you want the packaged Hono bundle instead, use
-`createNetopiaAdapterBundle()` or `netopiaHonoPlugin()`. Both are optional
-distribution helpers over the adapter/extension surfaces above.
+`createNetopiaAdapterBundle()` or `netopiaHonoPlugin()`. Those are optional
+distribution helpers over the adapter/extension surfaces above; the adapter and
+finance extension remain the main runtime seams.
 
 ## Flow
 

--- a/packages/plugins/payload-cms/README.md
+++ b/packages/plugins/payload-cms/README.md
@@ -35,10 +35,10 @@ const app = createApp({
 })
 ```
 
-The exported value is a distribution bundle. At runtime, the package behaves
-primarily as a subscriber-driven Payload sync adapter. By default it wires up
-3 subscribers (`product.created`, `product.updated`, `product.deleted`) that
-upsert/delete documents keyed by `voyantId`. All error handling is
+The exported value is an optional distribution bundle. At runtime, the package
+behaves primarily as a subscriber-driven Payload sync adapter. By default it
+wires up 3 subscribers (`product.created`, `product.updated`, `product.deleted`)
+that upsert/delete documents keyed by `voyantId`. All error handling is
 fire-and-forget per the EventBus contract.
 
 ## Exports

--- a/packages/plugins/smartbill/README.md
+++ b/packages/plugins/smartbill/README.md
@@ -36,9 +36,9 @@ const app = createApp({
 })
 ```
 
-The exported value is a distribution bundle. At runtime, the package behaves
-primarily as a subscriber-driven SmartBill sync adapter. By default it wires up
-3 subscribers (`invoice.issued`, `invoice.voided`,
+The exported value is an optional distribution bundle. At runtime, the package
+behaves primarily as a subscriber-driven SmartBill sync adapter. By default it
+wires up 3 subscribers (`invoice.issued`, `invoice.voided`,
 `invoice.external.sync.requested`) that create, cancel, and check payment
 status on SmartBill. All error handling is fire-and-forget per the EventBus
 contract.


### PR DESCRIPTION
## Summary
- reduce plugin-first wording in core and integration package READMEs
- describe adapters, subscribers, and extensions as the main runtime seams
- keep plugin bundles positioned as optional distribution helpers

## Testing
- git diff --check