### PR TITLE
Adopt admin widget extension surface

### DIFF
--- a/templates/operator/src/components/admin/widgets/dashboard-outstanding-invoices-widget.tsx
+++ b/templates/operator/src/components/admin/widgets/dashboard-outstanding-invoices-widget.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { AlertCircle } from "lucide-react"
+
+import { Badge, Card, CardContent, CardHeader, CardTitle } from "@/components/ui"
+
+type DashboardOutstandingInvoicesWidgetProps = {
+  metrics?: {
+    outstandingAmount?: number
+    outstandingInvoiceCount?: number
+    defaultCurrency?: string
+  }
+}
+
+function formatCurrency(amountInMinor: number, currency: string): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+  }).format(amountInMinor / 100)
+}
+
+export function DashboardOutstandingInvoicesWidget({
+  metrics,
+}: DashboardOutstandingInvoicesWidgetProps) {
+  const outstandingInvoiceCount = metrics?.outstandingInvoiceCount ?? 0
+  const outstandingAmount = metrics?.outstandingAmount ?? 0
+  const defaultCurrency = metrics?.defaultCurrency ?? "EUR"
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">Outstanding Invoices</CardTitle>
+        <AlertCircle className="h-4 w-4 text-muted-foreground" />
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <div className="text-2xl font-semibold">
+          {formatCurrency(outstandingAmount, defaultCurrency)}
+        </div>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Badge variant={outstandingInvoiceCount > 0 ? "secondary" : "outline"}>
+            {outstandingInvoiceCount}
+          </Badge>
+          <span>{outstandingInvoiceCount === 1 ? "invoice needs attention" : "invoices need attention"}</span>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/templates/operator/src/lib/admin-extensions.tsx
+++ b/templates/operator/src/lib/admin-extensions.tsx
@@ -1,4 +1,6 @@
-import type { AdminExtension } from "@voyantjs/voyant-admin"
+import { defineAdminExtension, type AdminExtension } from "@voyantjs/voyant-admin"
+
+import { DashboardOutstandingInvoicesWidget } from "@/components/admin/widgets/dashboard-outstanding-invoices-widget"
 
 /**
  * Template-local admin extension registry.
@@ -16,4 +18,16 @@ import type { AdminExtension } from "@voyantjs/voyant-admin"
  * - `invoice.details.header`
  * - `invoice.details.after-summary`
  */
-export const adminExtensions: ReadonlyArray<AdminExtension> = []
+export const adminExtensions: ReadonlyArray<AdminExtension> = [
+  defineAdminExtension({
+    id: "dashboard-outstanding-invoices",
+    widgets: [
+      {
+        id: "dashboard-outstanding-invoices.card",
+        slot: "dashboard.after-kpis",
+        order: 10,
+        component: DashboardOutstandingInvoicesWidget,
+      },
+    ],
+  }),
+]


### PR DESCRIPTION
## Summary
- add a real operator dashboard widget through the admin extension registry
- keep the widget contribution template-local so the extension surface is exercised without adding a dynamic plugin runtime
- use the existing dashboard metrics widget slot instead of duplicating page wiring

## Testing
- git diff --check
- pnpm -C templates/operator typecheck
- pnpm test