### PR TITLE
Mount storefront module in templates

### DIFF
--- a/apps/dev/package.json
+++ b/apps/dev/package.json
@@ -72,6 +72,7 @@
     "@voyantjs/resources-react": "workspace:*",
     "@voyantjs/sellability": "workspace:*",
     "@voyantjs/sellability-react": "workspace:*",
+    "@voyantjs/storefront": "workspace:*",
     "@voyantjs/suppliers": "workspace:*",
     "@voyantjs/suppliers-react": "workspace:*",
     "@voyantjs/transactions": "workspace:*",

--- a/apps/dev/src/api/app.ts
+++ b/apps/dev/src/api/app.ts
@@ -22,6 +22,7 @@ import { pricingHonoModule } from "@voyantjs/pricing"
 import { productsBookingExtension, productsHonoModule } from "@voyantjs/products"
 import { resourcesHonoModule } from "@voyantjs/resources"
 import { sellabilityHonoModule } from "@voyantjs/sellability"
+import { createStorefrontHonoModule } from "@voyantjs/storefront"
 import { suppliersHonoModule } from "@voyantjs/suppliers"
 import { transactionsBookingExtension, transactionsHonoModule } from "@voyantjs/transactions"
 
@@ -33,6 +34,7 @@ import { resolveNotificationProviders } from "../lib/notifications"
 const notificationsHonoModule = createNotificationsHonoModule({
   resolveProviders: resolveNotificationProviders,
 })
+const storefrontHonoModule = createStorefrontHonoModule()
 const checkoutHonoModule = createCheckoutHonoModule({
   resolveProviders: resolveNotificationProviders,
 })
@@ -72,6 +74,7 @@ export const app = createApp<CloudflareBindings>({
     productsHonoModule,
     bookingsHonoModule,
     financeHonoModule,
+    storefrontHonoModule,
     customerPortalHonoModule,
     checkoutHonoModule,
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,6 +241,9 @@ importers:
       '@voyantjs/sellability-react':
         specifier: workspace:*
         version: link:../../packages/sellability-react
+      '@voyantjs/storefront':
+        specifier: workspace:*
+        version: link:../../packages/storefront
       '@voyantjs/suppliers':
         specifier: workspace:*
         version: link:../../packages/suppliers
@@ -2768,6 +2771,9 @@ importers:
       '@voyantjs/sellability':
         specifier: workspace:*
         version: link:../../packages/sellability
+      '@voyantjs/storefront':
+        specifier: workspace:*
+        version: link:../../packages/storefront
       '@voyantjs/storefront-verification':
         specifier: workspace:*
         version: link:../../packages/storefront-verification
@@ -3045,6 +3051,9 @@ importers:
       '@voyantjs/sellability':
         specifier: workspace:*
         version: link:../../packages/sellability
+      '@voyantjs/storefront':
+        specifier: workspace:*
+        version: link:../../packages/storefront
       '@voyantjs/storefront-verification':
         specifier: workspace:*
         version: link:../../packages/storefront-verification

--- a/templates/dmc/package.json
+++ b/templates/dmc/package.json
@@ -59,6 +59,7 @@
     "@voyantjs/resources": "workspace:*",
     "@voyantjs/resources-react": "workspace:*",
     "@voyantjs/sellability": "workspace:*",
+    "@voyantjs/storefront": "workspace:*",
     "@voyantjs/storefront-verification": "workspace:*",
     "@voyantjs/suppliers": "workspace:*",
     "@voyantjs/suppliers-react": "workspace:*",

--- a/templates/dmc/src/api/app.ts
+++ b/templates/dmc/src/api/app.ts
@@ -22,6 +22,7 @@ import { pricingHonoModule } from "@voyantjs/pricing"
 import { productsBookingExtension, productsHonoModule } from "@voyantjs/products"
 import { resourcesHonoModule } from "@voyantjs/resources"
 import { sellabilityHonoModule } from "@voyantjs/sellability"
+import { createStorefrontHonoModule } from "@voyantjs/storefront"
 import { createStorefrontVerificationHonoModule } from "@voyantjs/storefront-verification"
 import { suppliersHonoModule } from "@voyantjs/suppliers"
 import { transactionsBookingExtension, transactionsHonoModule } from "@voyantjs/transactions"
@@ -40,6 +41,7 @@ const storefrontVerificationHonoModule = createStorefrontVerificationHonoModule(
     subject: "Your verification code",
   },
 })
+const storefrontHonoModule = createStorefrontHonoModule()
 const checkoutHonoModule = createCheckoutHonoModule({
   resolveProviders: resolveNotificationProviders,
 })
@@ -83,6 +85,7 @@ export const app = createApp<CloudflareBindings>({
     bookingsHonoModule,
     financeHonoModule,
     legalHonoModule,
+    storefrontHonoModule,
     customerPortalHonoModule,
     storefrontVerificationHonoModule,
     checkoutHonoModule,

--- a/templates/operator/package.json
+++ b/templates/operator/package.json
@@ -63,6 +63,7 @@
     "@voyantjs/resources": "workspace:*",
     "@voyantjs/resources-react": "workspace:*",
     "@voyantjs/sellability": "workspace:*",
+    "@voyantjs/storefront": "workspace:*",
     "@voyantjs/storefront-verification": "workspace:*",
     "@voyantjs/suppliers": "workspace:*",
     "@voyantjs/suppliers-react": "workspace:*",

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -19,6 +19,7 @@ import { pricingHonoModule } from "@voyantjs/pricing"
 import { productsBookingExtension, productsHonoModule } from "@voyantjs/products"
 import { resourcesHonoModule } from "@voyantjs/resources"
 import { sellabilityHonoModule } from "@voyantjs/sellability"
+import { createStorefrontHonoModule } from "@voyantjs/storefront"
 import { createStorefrontVerificationHonoModule } from "@voyantjs/storefront-verification"
 import { suppliersHonoModule } from "@voyantjs/suppliers"
 import { transactionsBookingExtension, transactionsHonoModule } from "@voyantjs/transactions"
@@ -37,6 +38,7 @@ const storefrontVerificationHonoModule = createStorefrontVerificationHonoModule(
     subject: "Your verification code",
   },
 })
+const storefrontHonoModule = createStorefrontHonoModule()
 const checkoutHonoModule = createCheckoutHonoModule({
   resolveProviders: resolveNotificationProviders,
 })
@@ -77,6 +79,7 @@ export const app = createApp<CloudflareBindings>({
     bookingsHonoModule,
     financeHonoModule,
     legalHonoModule,
+    storefrontHonoModule,
     customerPortalHonoModule,
     storefrontVerificationHonoModule,
     checkoutHonoModule,


### PR DESCRIPTION
## Summary
- mount the shared  public module in operator, dmc, and dev
- add the missing workspace dependency declarations and lockfile updates
- align the template public API surface with the shared storefront contract

## Testing
- git diff --check
- pnpm -C templates/operator typecheck
- pnpm -C templates/dmc typecheck
- pnpm -C apps/dev typecheck
- pnpm test