### PR TITLE
Use shared route parsers in storefront routes

### DIFF
--- a/packages/storefront/src/routes-public.ts
+++ b/packages/storefront/src/routes-public.ts
@@ -1,3 +1,4 @@
+import { parseJsonBody, parseQuery } from "@voyantjs/hono"
 import { Hono } from "hono"
 
 import { createStorefrontService, type StorefrontServiceOptions } from "./service.js"
@@ -36,9 +37,7 @@ export function createStorefrontPublicRoutes(options?: StorefrontServiceOptions)
         await storefrontService.listProductDepartures(
           c.get("db" as never),
           c.req.param("productId"),
-          storefrontDepartureListQuerySchema.parse(
-            Object.fromEntries(new URL(c.req.url).searchParams),
-          ),
+          parseQuery(c, storefrontDepartureListQuerySchema),
         ),
       )
     })
@@ -46,7 +45,7 @@ export function createStorefrontPublicRoutes(options?: StorefrontServiceOptions)
       const preview = await storefrontService.previewDeparturePrice(
         c.get("db" as never),
         c.req.param("departureId"),
-        storefrontDeparturePricePreviewInputSchema.parse(await c.req.json().catch(() => ({}))),
+        await parseJsonBody(c, storefrontDeparturePricePreviewInputSchema),
       )
 
       return preview
@@ -58,9 +57,7 @@ export function createStorefrontPublicRoutes(options?: StorefrontServiceOptions)
         data: await storefrontService.getProductExtensions(
           c.get("db" as never),
           c.req.param("productId"),
-          storefrontProductExtensionsQuerySchema.parse(
-            Object.fromEntries(new URL(c.req.url).searchParams),
-          ).optionId,
+          parseQuery(c, storefrontProductExtensionsQuerySchema).optionId,
         ),
       })
     })
@@ -75,9 +72,7 @@ export function createStorefrontPublicRoutes(options?: StorefrontServiceOptions)
         : c.json({ error: "Storefront itinerary not found" }, 404)
     })
     .get("/products/:productId/offers", async (c) => {
-      const query = storefrontPromotionalOfferListQuerySchema.parse(
-        Object.fromEntries(new URL(c.req.url).searchParams),
-      )
+      const query = parseQuery(c, storefrontPromotionalOfferListQuerySchema)
 
       return c.json({
         data: await storefrontService.listApplicableOffers({
@@ -88,9 +83,7 @@ export function createStorefrontPublicRoutes(options?: StorefrontServiceOptions)
       })
     })
     .get("/offers/:slug", async (c) => {
-      const query = storefrontPromotionalOfferListQuerySchema.parse(
-        Object.fromEntries(new URL(c.req.url).searchParams),
-      )
+      const query = parseQuery(c, storefrontPromotionalOfferListQuerySchema)
       const offer = await storefrontService.getOfferBySlug({
         slug: c.req.param("slug"),
         locale: query.locale,


### PR DESCRIPTION
## Summary
- replace manual query/body parsing in storefront public routes with the shared Hono helpers
- keep the storefront public surface aligned with the route-authoring conventions already adopted elsewhere
- leave route behavior unchanged aside from using the shared transport parsing path

## Testing
- pnpm -C packages/storefront test
- pnpm -C packages/storefront typecheck
- git push (full repo pre-push suite)