### PR TITLE
Use shared route parsers in public pricing routes

### DIFF
--- a/packages/pricing/src/routes-public.ts
+++ b/packages/pricing/src/routes-public.ts
@@ -1,3 +1,4 @@
+import { parseQuery } from "@voyantjs/hono"
 import { Hono } from "hono"
 import { type Env, notFound } from "./routes-shared.js"
 import { publicPricingService } from "./service-public.js"
@@ -11,7 +12,7 @@ export const publicPricingRoutes = new Hono<Env>()
     const snapshot = await publicPricingService.getProductPricingSnapshot(
       c.get("db"),
       c.req.param("productId"),
-      publicProductPricingQuerySchema.parse(Object.fromEntries(new URL(c.req.url).searchParams)),
+      parseQuery(c, publicProductPricingQuerySchema),
     )
 
     return snapshot ? c.json({ data: snapshot }) : notFound(c, "Public pricing snapshot not found")
@@ -20,9 +21,7 @@ export const publicPricingRoutes = new Hono<Env>()
     const snapshot = await publicPricingService.getAvailabilitySnapshot(
       c.get("db"),
       c.req.param("productId"),
-      publicAvailabilitySnapshotQuerySchema.parse(
-        Object.fromEntries(new URL(c.req.url).searchParams),
-      ),
+      parseQuery(c, publicAvailabilitySnapshotQuerySchema),
     )
 
     return snapshot ? c.json(snapshot) : notFound(c, "Public availability snapshot not found")


### PR DESCRIPTION
## Summary
- replace manual query parsing in public pricing routes with the shared Hono parser helper
- keep the public pricing surface aligned with the shared route-authoring conventions
- leave route behavior unchanged while removing repeated URLSearchParams parsing

## Testing
- pnpm -C packages/pricing typecheck
- pnpm -C packages/pricing test
- git push (full repo pre-push suite)