### PR TITLE
Use shared route parsers in public booking requirements routes

### DIFF
--- a/packages/booking-requirements/src/routes-public.ts
+++ b/packages/booking-requirements/src/routes-public.ts
@@ -1,5 +1,6 @@
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
+import { parseQuery } from "@voyantjs/hono"
 
 import { bookingRequirementsService } from "./service.js"
 import { publicTransportRequirementsQuerySchema } from "./validation.js"
@@ -14,9 +15,7 @@ type Env = {
 export const publicBookingRequirementsRoutes = new Hono<Env>().get(
   "/products/:productId/transport-requirements",
   async (c) => {
-    const query = publicTransportRequirementsQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, publicTransportRequirementsQuerySchema)
 
     const result = await bookingRequirementsService.getPublicTransportRequirements(
       c.get("db"),


### PR DESCRIPTION
## Summary
- replace manual search-param parsing in public booking requirements routes with the shared Hono query parser
- keep the route surface aligned with the recent storefront/products/pricing/finance public transport cleanup

## Testing
- pnpm -C packages/booking-requirements typecheck
- pnpm -C packages/booking-requirements test