### PR TITLE
Use shared route parsers in checkout routes

### DIFF
--- a/packages/checkout/src/routes.ts
+++ b/packages/checkout/src/routes.ts
@@ -1,5 +1,6 @@
 import type { Module, ModuleContainer } from "@voyantjs/core"
 import type { HonoModule } from "@voyantjs/hono/module"
+import { parseJsonBody, parseQuery } from "@voyantjs/hono"
 import type { NotificationProvider } from "@voyantjs/notifications"
 import { createNotificationService } from "@voyantjs/notifications"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -94,7 +95,7 @@ export function createCheckoutRoutes(
         const result = await initiateCheckoutCollection(
           c.get("db"),
           c.req.param("bookingId"),
-          initiateCheckoutCollectionSchema.parse(await c.req.json()),
+          await parseJsonBody(c, initiateCheckoutCollectionSchema),
           options.policy,
           dispatcher,
           runtime,
@@ -120,7 +121,7 @@ export function createCheckoutRoutes(
         const dispatcher = createNotificationService(runtime.providers)
         const result = await bootstrapCheckoutCollection(
           c.get("db"),
-          bootstrapCheckoutCollectionSchema.parse(await c.req.json()),
+          await parseJsonBody(c, bootstrapCheckoutCollectionSchema),
           options.policy,
           dispatcher,
           runtime,
@@ -144,9 +145,7 @@ export function createCheckoutRoutes(
 
 export function createCheckoutAdminRoutes() {
   return new Hono<Env>().get("/bookings/:bookingId/reminder-runs", async (c) => {
-    const query = checkoutReminderRunListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, checkoutReminderRunListQuerySchema)
 
     return c.json(await listBookingReminderRuns(c.get("db"), c.req.param("bookingId"), query))
   })


### PR DESCRIPTION
## Summary
- replace direct JSON parsing in checkout collection routes with the shared Hono body parser
- replace manual query parsing in checkout admin reminder routes with the shared Hono query parser
- keep the preview endpoint's optional-empty-body behavior unchanged

## Testing
- pnpm -C packages/checkout typecheck
- pnpm -C packages/checkout test