### PR TITLE
Use shared route parsers in customer portal routes

### DIFF
--- a/packages/customer-portal/src/routes.ts
+++ b/packages/customer-portal/src/routes.ts
@@ -1,5 +1,6 @@
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
+import { parseQuery } from "@voyantjs/hono"
 
 import { publicCustomerPortalService } from "./service-public.js"
 import {
@@ -15,9 +16,7 @@ type Env = {
 
 export const customerPortalRoutes = new Hono<Env>()
   .get("/contact-exists", async (c) => {
-    const query = customerPortalContactExistsQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, customerPortalContactExistsQuerySchema)
 
     return c.json({
       data: await publicCustomerPortalService.contactExists(c.get("db"), query.email),
@@ -25,9 +24,7 @@ export const customerPortalRoutes = new Hono<Env>()
   })
 
   .get("/contact-exists/phone", async (c) => {
-    const query = customerPortalPhoneContactExistsQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, customerPortalPhoneContactExistsQuerySchema)
 
     return c.json({
       data: await publicCustomerPortalService.phoneContactExists(c.get("db"), query.phone),


### PR DESCRIPTION
## Summary
- replace manual query parsing in internal customer portal routes with the shared Hono query parser
- keep the tiny internal route surface aligned with the broader transport cleanup

## Testing
- pnpm -C packages/customer-portal typecheck
- pnpm -C packages/customer-portal test