### PR TITLE
Use shared route parsers in transaction routes

### DIFF
--- a/packages/transactions/src/routes-offers.ts
+++ b/packages/transactions/src/routes-offers.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono"
+import { parseJsonBody, parseQuery } from "@voyantjs/hono"
 import {
   authorizeTransactionPiiAccess,
   createPiiService,
@@ -25,7 +26,7 @@ import {
 
 export const transactionOfferRoutes = new Hono<Env>()
   .get("/offers", async (c) => {
-    const query = offerListQuerySchema.parse(Object.fromEntries(new URL(c.req.url).searchParams))
+    const query = parseQuery(c, offerListQuerySchema)
     return c.json(await transactionsService.listOffers(c.get("db"), query))
   })
   .post("/offers", async (c) =>
@@ -33,7 +34,7 @@ export const transactionOfferRoutes = new Hono<Env>()
       {
         data: await transactionsService.createOffer(
           c.get("db"),
-          insertOfferSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertOfferSchema),
         ),
       },
       201,
@@ -47,7 +48,7 @@ export const transactionOfferRoutes = new Hono<Env>()
     const row = await transactionsService.updateOffer(
       c.get("db"),
       c.req.param("id"),
-      updateOfferSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateOfferSchema),
     )
     return row ? c.json({ data: row }) : notFound(c, "Offer not found")
   })
@@ -56,13 +57,11 @@ export const transactionOfferRoutes = new Hono<Env>()
     return row ? c.json({ success: true }) : notFound(c, "Offer not found")
   })
   .get("/offer-participants", async (c) => {
-    const query = offerParticipantListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, offerParticipantListQuerySchema)
     return c.json(await transactionsService.listOfferParticipants(c.get("db"), query))
   })
   .post("/offer-participants", async (c) => {
-    const payload = insertOfferParticipantSchema.parse(await c.req.json())
+    const payload = await parseJsonBody(c, insertOfferParticipantSchema)
     const row = await transactionsService.createOfferParticipant(c.get("db"), payload)
     if (!row) return c.json({ data: row }, 201)
     if (hasParticipantIdentityInput(payload)) {
@@ -80,7 +79,7 @@ export const transactionOfferRoutes = new Hono<Env>()
     return row ? c.json({ data: row }) : notFound(c, "Offer participant not found")
   })
   .patch("/offer-participants/:id", async (c) => {
-    const payload = updateOfferParticipantSchema.parse(await c.req.json())
+    const payload = await parseJsonBody(c, updateOfferParticipantSchema)
     const row = await transactionsService.updateOfferParticipant(
       c.get("db"),
       c.req.param("id"),
@@ -147,7 +146,7 @@ export const transactionOfferRoutes = new Hono<Env>()
       c.get("db"),
       "offer",
       participant.id,
-      updateOfferParticipantSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateOfferParticipantSchema),
       c.get("userId"),
     )
     return row ? c.json({ data: row }) : notFound(c, "Offer participant not found")
@@ -181,9 +180,7 @@ export const transactionOfferRoutes = new Hono<Env>()
     return row ? c.json({ success: true }) : notFound(c, "Offer participant not found")
   })
   .get("/offer-items", async (c) => {
-    const query = offerItemListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, offerItemListQuerySchema)
     return c.json(await transactionsService.listOfferItems(c.get("db"), query))
   })
   .post("/offer-items", async (c) =>
@@ -191,7 +188,7 @@ export const transactionOfferRoutes = new Hono<Env>()
       {
         data: await transactionsService.createOfferItem(
           c.get("db"),
-          insertOfferItemSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertOfferItemSchema),
         ),
       },
       201,
@@ -205,7 +202,7 @@ export const transactionOfferRoutes = new Hono<Env>()
     const row = await transactionsService.updateOfferItem(
       c.get("db"),
       c.req.param("id"),
-      updateOfferItemSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateOfferItemSchema),
     )
     return row ? c.json({ data: row }) : notFound(c, "Offer item not found")
   })
@@ -214,9 +211,7 @@ export const transactionOfferRoutes = new Hono<Env>()
     return row ? c.json({ success: true }) : notFound(c, "Offer item not found")
   })
   .get("/offer-item-participants", async (c) => {
-    const query = offerItemParticipantListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, offerItemParticipantListQuerySchema)
     return c.json(await transactionsService.listOfferItemParticipants(c.get("db"), query))
   })
   .post("/offer-item-participants", async (c) =>
@@ -224,7 +219,7 @@ export const transactionOfferRoutes = new Hono<Env>()
       {
         data: await transactionsService.createOfferItemParticipant(
           c.get("db"),
-          insertOfferItemParticipantSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertOfferItemParticipantSchema),
         ),
       },
       201,
@@ -241,7 +236,7 @@ export const transactionOfferRoutes = new Hono<Env>()
     const row = await transactionsService.updateOfferItemParticipant(
       c.get("db"),
       c.req.param("id"),
-      updateOfferItemParticipantSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateOfferItemParticipantSchema),
     )
     return row ? c.json({ data: row }) : notFound(c, "Offer item participant not found")
   })

--- a/packages/transactions/src/routes-orders.ts
+++ b/packages/transactions/src/routes-orders.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono"
+import { parseJsonBody, parseQuery } from "@voyantjs/hono"
 import {
   authorizeTransactionPiiAccess,
   createPiiService,
@@ -28,7 +29,7 @@ import {
 
 export const transactionOrderRoutes = new Hono<Env>()
   .get("/orders", async (c) => {
-    const query = orderListQuerySchema.parse(Object.fromEntries(new URL(c.req.url).searchParams))
+    const query = parseQuery(c, orderListQuerySchema)
     return c.json(await transactionsService.listOrders(c.get("db"), query))
   })
   .post("/orders", async (c) =>
@@ -36,7 +37,7 @@ export const transactionOrderRoutes = new Hono<Env>()
       {
         data: await transactionsService.createOrder(
           c.get("db"),
-          insertOrderSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertOrderSchema),
         ),
       },
       201,
@@ -50,7 +51,7 @@ export const transactionOrderRoutes = new Hono<Env>()
     const row = await transactionsService.updateOrder(
       c.get("db"),
       c.req.param("id"),
-      updateOrderSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateOrderSchema),
     )
     return row ? c.json({ data: row }) : notFound(c, "Order not found")
   })
@@ -59,13 +60,11 @@ export const transactionOrderRoutes = new Hono<Env>()
     return row ? c.json({ success: true }) : notFound(c, "Order not found")
   })
   .get("/order-participants", async (c) => {
-    const query = orderParticipantListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, orderParticipantListQuerySchema)
     return c.json(await transactionsService.listOrderParticipants(c.get("db"), query))
   })
   .post("/order-participants", async (c) => {
-    const payload = insertOrderParticipantSchema.parse(await c.req.json())
+    const payload = await parseJsonBody(c, insertOrderParticipantSchema)
     const row = await transactionsService.createOrderParticipant(c.get("db"), payload)
     if (!row) return c.json({ data: row }, 201)
     if (hasParticipantIdentityInput(payload)) {
@@ -83,7 +82,7 @@ export const transactionOrderRoutes = new Hono<Env>()
     return row ? c.json({ data: row }) : notFound(c, "Order participant not found")
   })
   .patch("/order-participants/:id", async (c) => {
-    const payload = updateOrderParticipantSchema.parse(await c.req.json())
+    const payload = await parseJsonBody(c, updateOrderParticipantSchema)
     const row = await transactionsService.updateOrderParticipant(
       c.get("db"),
       c.req.param("id"),
@@ -150,7 +149,7 @@ export const transactionOrderRoutes = new Hono<Env>()
       c.get("db"),
       "order",
       participant.id,
-      updateOrderParticipantSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateOrderParticipantSchema),
       c.get("userId"),
     )
     return row ? c.json({ data: row }) : notFound(c, "Order participant not found")
@@ -184,9 +183,7 @@ export const transactionOrderRoutes = new Hono<Env>()
     return row ? c.json({ success: true }) : notFound(c, "Order participant not found")
   })
   .get("/order-items", async (c) => {
-    const query = orderItemListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, orderItemListQuerySchema)
     return c.json(await transactionsService.listOrderItems(c.get("db"), query))
   })
   .post("/order-items", async (c) =>
@@ -194,7 +191,7 @@ export const transactionOrderRoutes = new Hono<Env>()
       {
         data: await transactionsService.createOrderItem(
           c.get("db"),
-          insertOrderItemSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertOrderItemSchema),
         ),
       },
       201,
@@ -208,7 +205,7 @@ export const transactionOrderRoutes = new Hono<Env>()
     const row = await transactionsService.updateOrderItem(
       c.get("db"),
       c.req.param("id"),
-      updateOrderItemSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateOrderItemSchema),
     )
     return row ? c.json({ data: row }) : notFound(c, "Order item not found")
   })
@@ -217,9 +214,7 @@ export const transactionOrderRoutes = new Hono<Env>()
     return row ? c.json({ success: true }) : notFound(c, "Order item not found")
   })
   .get("/order-item-participants", async (c) => {
-    const query = orderItemParticipantListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, orderItemParticipantListQuerySchema)
     return c.json(await transactionsService.listOrderItemParticipants(c.get("db"), query))
   })
   .post("/order-item-participants", async (c) =>
@@ -227,7 +222,7 @@ export const transactionOrderRoutes = new Hono<Env>()
       {
         data: await transactionsService.createOrderItemParticipant(
           c.get("db"),
-          insertOrderItemParticipantSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertOrderItemParticipantSchema),
         ),
       },
       201,
@@ -244,7 +239,7 @@ export const transactionOrderRoutes = new Hono<Env>()
     const row = await transactionsService.updateOrderItemParticipant(
       c.get("db"),
       c.req.param("id"),
-      updateOrderItemParticipantSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateOrderItemParticipantSchema),
     )
     return row ? c.json({ data: row }) : notFound(c, "Order item participant not found")
   })
@@ -253,9 +248,7 @@ export const transactionOrderRoutes = new Hono<Env>()
     return row ? c.json({ success: true }) : notFound(c, "Order item participant not found")
   })
   .get("/order-terms", async (c) => {
-    const query = orderTermListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, orderTermListQuerySchema)
     return c.json(await transactionsService.listOrderTerms(c.get("db"), query))
   })
   .post("/order-terms", async (c) =>
@@ -263,7 +256,7 @@ export const transactionOrderRoutes = new Hono<Env>()
       {
         data: await transactionsService.createOrderTerm(
           c.get("db"),
-          insertOrderTermSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertOrderTermSchema),
         ),
       },
       201,
@@ -277,7 +270,7 @@ export const transactionOrderRoutes = new Hono<Env>()
     const row = await transactionsService.updateOrderTerm(
       c.get("db"),
       c.req.param("id"),
-      updateOrderTermSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateOrderTermSchema),
     )
     return row ? c.json({ data: row }) : notFound(c, "Order term not found")
   })


### PR DESCRIPTION
## Summary
- replace manual query parsing in transaction offer and order routes with the shared Hono query parser
- replace repeated direct JSON parsing in transaction routes with the shared Hono body parser
- keep the transactions route surface aligned with the broader transport cleanup

## Testing
- pnpm -C packages/transactions typecheck
- pnpm -C packages/transactions test