### PR TITLE
Await shared query parser in product public routes

### DIFF
--- a/packages/products/src/routes-public.ts
+++ b/packages/products/src/routes-public.ts
@@ -20,11 +20,11 @@ type Env = {
 
 export const publicProductRoutes = new Hono<Env>()
   .get("/", async (c) => {
-    const query = parseQuery(c, publicCatalogProductListQuerySchema)
+    const query = await parseQuery(c, publicCatalogProductListQuerySchema)
     return c.json(await publicProductsService.listCatalogProducts(c.get("db"), query))
   })
   .get("/slug/:slug", async (c) => {
-    const query = parseQuery(c, publicCatalogProductLookupBySlugQuerySchema)
+    const query = await parseQuery(c, publicCatalogProductLookupBySlugQuerySchema)
     const row = await publicProductsService.getCatalogProductBySlug(
       c.get("db"),
       c.req.param("slug"),
@@ -38,19 +38,19 @@ export const publicProductRoutes = new Hono<Env>()
     return c.json({ data: row })
   })
   .get("/categories", async (c) => {
-    const query = parseQuery(c, publicCatalogCategoryListQuerySchema)
+    const query = await parseQuery(c, publicCatalogCategoryListQuerySchema)
     return c.json(await publicProductsService.listCatalogCategories(c.get("db"), query))
   })
   .get("/tags", async (c) => {
-    const query = parseQuery(c, publicCatalogTagListQuerySchema)
+    const query = await parseQuery(c, publicCatalogTagListQuerySchema)
     return c.json(await publicProductsService.listCatalogTags(c.get("db"), query))
   })
   .get("/destinations", async (c) => {
-    const query = parseQuery(c, publicCatalogDestinationListQuerySchema)
+    const query = await parseQuery(c, publicCatalogDestinationListQuerySchema)
     return c.json(await publicProductsService.listCatalogDestinations(c.get("db"), query))
   })
   .get("/:id", async (c) => {
-    const query = parseQuery(c, publicCatalogProductLookupBySlugQuerySchema)
+    const query = await parseQuery(c, publicCatalogProductLookupBySlugQuerySchema)
     const row = await publicProductsService.getCatalogProductById(
       c.get("db"),
       c.req.param("id"),
@@ -64,7 +64,7 @@ export const publicProductRoutes = new Hono<Env>()
     return c.json({ data: row })
   })
   .get("/:id/brochure", async (c) => {
-    const query = parseQuery(c, publicCatalogProductLookupBySlugQuerySchema)
+    const query = await parseQuery(c, publicCatalogProductLookupBySlugQuerySchema)
     const row = await publicProductsService.getCatalogProductBrochure(
       c.get("db"),
       c.req.param("id"),


### PR DESCRIPTION
## Summary
- await the shared Hono query parser consistently in product public routes
- keep the product public surface aligned with the broader transport cleanup
- remove the last synchronous parser calls from the product public route file

## Testing
- pnpm -C packages/products typecheck
- pnpm -C packages/products test