### PR TITLE
Await shared query parser in remaining public routes

### DIFF
--- a/packages/booking-requirements/src/routes-public.ts
+++ b/packages/booking-requirements/src/routes-public.ts
@@ -15,7 +15,7 @@ type Env = {
 export const publicBookingRequirementsRoutes = new Hono<Env>().get(
   "/products/:productId/transport-requirements",
   async (c) => {
-    const query = parseQuery(c, publicTransportRequirementsQuerySchema)
+    const query = await parseQuery(c, publicTransportRequirementsQuerySchema)
 
     const result = await bookingRequirementsService.getPublicTransportRequirements(
       c.get("db"),

--- a/packages/storefront/src/routes-public.ts
+++ b/packages/storefront/src/routes-public.ts
@@ -37,7 +37,7 @@ export function createStorefrontPublicRoutes(options?: StorefrontServiceOptions)
         await storefrontService.listProductDepartures(
           c.get("db" as never),
           c.req.param("productId"),
-          parseQuery(c, storefrontDepartureListQuerySchema),
+          await parseQuery(c, storefrontDepartureListQuerySchema),
         ),
       )
     })
@@ -53,11 +53,13 @@ export function createStorefrontPublicRoutes(options?: StorefrontServiceOptions)
         : c.json({ error: "Storefront departure not found" }, 404)
     })
     .get("/products/:productId/extensions", async (c) => {
+      const query = await parseQuery(c, storefrontProductExtensionsQuerySchema)
+
       return c.json({
         data: await storefrontService.getProductExtensions(
           c.get("db" as never),
           c.req.param("productId"),
-          parseQuery(c, storefrontProductExtensionsQuerySchema).optionId,
+          query.optionId,
         ),
       })
     })
@@ -72,7 +74,7 @@ export function createStorefrontPublicRoutes(options?: StorefrontServiceOptions)
         : c.json({ error: "Storefront itinerary not found" }, 404)
     })
     .get("/products/:productId/offers", async (c) => {
-      const query = parseQuery(c, storefrontPromotionalOfferListQuerySchema)
+      const query = await parseQuery(c, storefrontPromotionalOfferListQuerySchema)
 
       return c.json({
         data: await storefrontService.listApplicableOffers({
@@ -83,7 +85,7 @@ export function createStorefrontPublicRoutes(options?: StorefrontServiceOptions)
       })
     })
     .get("/offers/:slug", async (c) => {
-      const query = parseQuery(c, storefrontPromotionalOfferListQuerySchema)
+      const query = await parseQuery(c, storefrontPromotionalOfferListQuerySchema)
       const offer = await storefrontService.getOfferBySlug({
         slug: c.req.param("slug"),
         locale: query.locale,


### PR DESCRIPTION
## Summary
- await the shared Hono query parser consistently in the remaining public route files
- align storefront public offer and extension lookups with the async parser contract
- align public booking requirements transport requirements lookup with the same contract

## Testing
- pnpm -C packages/storefront typecheck
- pnpm -C packages/storefront test
- pnpm -C packages/booking-requirements typecheck
- pnpm -C packages/booking-requirements test