### PR TITLE
Use shared route parsers in hospitality stay routes

### DIFF
--- a/packages/hospitality/src/routes-stays.ts
+++ b/packages/hospitality/src/routes-stays.ts
@@ -1,3 +1,4 @@
+import { parseJsonBody, parseQuery } from "@voyantjs/hono"
 import { Hono } from "hono"
 import type { Env } from "./routes-shared.js"
 import { notFound } from "./routes-shared.js"
@@ -31,7 +32,7 @@ import {
 
 export const hospitalityStayRoutes = new Hono<Env>()
   .get("/stay-rules", async (c) => {
-    const query = stayRuleListQuerySchema.parse(Object.fromEntries(new URL(c.req.url).searchParams))
+    const query = await parseQuery(c, stayRuleListQuerySchema)
     return c.json(await hospitalityService.listStayRules(c.get("db"), query))
   })
   .post("/stay-rules", async (c) => {
@@ -39,7 +40,7 @@ export const hospitalityStayRoutes = new Hono<Env>()
       {
         data: await hospitalityService.createStayRule(
           c.get("db"),
-          insertStayRuleSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertStayRuleSchema),
         ),
       },
       201,
@@ -54,7 +55,7 @@ export const hospitalityStayRoutes = new Hono<Env>()
     const row = await hospitalityService.updateStayRule(
       c.get("db"),
       c.req.param("id"),
-      updateStayRuleSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateStayRuleSchema),
     )
     if (!row) return c.json(notFound("Stay rule"), 404)
     return c.json({ data: row })
@@ -65,9 +66,7 @@ export const hospitalityStayRoutes = new Hono<Env>()
     return c.json({ success: true })
   })
   .get("/stay-booking-items", async (c) => {
-    const query = stayBookingItemListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = await parseQuery(c, stayBookingItemListQuerySchema)
     return c.json(await hospitalityService.listStayBookingItems(c.get("db"), query))
   })
   .post("/stay-booking-items", async (c) => {
@@ -75,7 +74,7 @@ export const hospitalityStayRoutes = new Hono<Env>()
       {
         data: await hospitalityService.createStayBookingItem(
           c.get("db"),
-          insertStayBookingItemSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertStayBookingItemSchema),
         ),
       },
       201,
@@ -90,7 +89,7 @@ export const hospitalityStayRoutes = new Hono<Env>()
     const row = await hospitalityService.updateStayBookingItem(
       c.get("db"),
       c.req.param("id"),
-      updateStayBookingItemSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateStayBookingItemSchema),
     )
     if (!row) return c.json(notFound("Stay booking item"), 404)
     return c.json({ data: row })
@@ -101,9 +100,7 @@ export const hospitalityStayRoutes = new Hono<Env>()
     return c.json({ success: true })
   })
   .get("/stay-daily-rates", async (c) => {
-    const query = stayDailyRateListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = await parseQuery(c, stayDailyRateListQuerySchema)
     return c.json(await hospitalityService.listStayDailyRates(c.get("db"), query))
   })
   .post("/stay-daily-rates", async (c) => {
@@ -111,7 +108,7 @@ export const hospitalityStayRoutes = new Hono<Env>()
       {
         data: await hospitalityService.createStayDailyRate(
           c.get("db"),
-          insertStayDailyRateSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertStayDailyRateSchema),
         ),
       },
       201,
@@ -126,7 +123,7 @@ export const hospitalityStayRoutes = new Hono<Env>()
     const row = await hospitalityService.updateStayDailyRate(
       c.get("db"),
       c.req.param("id"),
-      updateStayDailyRateSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateStayDailyRateSchema),
     )
     if (!row) return c.json(notFound("Stay daily rate"), 404)
     return c.json({ data: row })
@@ -137,9 +134,7 @@ export const hospitalityStayRoutes = new Hono<Env>()
     return c.json({ success: true })
   })
   .get("/stay-operations", async (c) => {
-    const query = stayOperationListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = await parseQuery(c, stayOperationListQuerySchema)
     return c.json(await hospitalityService.listStayOperations(c.get("db"), query))
   })
   .post("/stay-operations", async (c) =>
@@ -147,7 +142,7 @@ export const hospitalityStayRoutes = new Hono<Env>()
       {
         data: await hospitalityService.createStayOperation(
           c.get("db"),
-          insertStayOperationSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertStayOperationSchema),
         ),
       },
       201,
@@ -162,7 +157,7 @@ export const hospitalityStayRoutes = new Hono<Env>()
     const row = await hospitalityService.updateStayOperation(
       c.get("db"),
       c.req.param("id"),
-      updateStayOperationSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateStayOperationSchema),
     )
     if (!row) return c.json(notFound("Stay operation"), 404)
     return c.json({ data: row })
@@ -173,9 +168,7 @@ export const hospitalityStayRoutes = new Hono<Env>()
     return c.json({ success: true })
   })
   .get("/stay-checkpoints", async (c) => {
-    const query = stayCheckpointListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = await parseQuery(c, stayCheckpointListQuerySchema)
     return c.json(await hospitalityService.listStayCheckpoints(c.get("db"), query))
   })
   .post("/stay-checkpoints", async (c) =>
@@ -183,7 +176,7 @@ export const hospitalityStayRoutes = new Hono<Env>()
       {
         data: await hospitalityService.createStayCheckpoint(
           c.get("db"),
-          insertStayCheckpointSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertStayCheckpointSchema),
         ),
       },
       201,
@@ -198,7 +191,7 @@ export const hospitalityStayRoutes = new Hono<Env>()
     const row = await hospitalityService.updateStayCheckpoint(
       c.get("db"),
       c.req.param("id"),
-      updateStayCheckpointSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateStayCheckpointSchema),
     )
     if (!row) return c.json(notFound("Stay checkpoint"), 404)
     return c.json({ data: row })
@@ -209,9 +202,7 @@ export const hospitalityStayRoutes = new Hono<Env>()
     return c.json({ success: true })
   })
   .get("/stay-service-posts", async (c) => {
-    const query = stayServicePostListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = await parseQuery(c, stayServicePostListQuerySchema)
     return c.json(await hospitalityService.listStayServicePosts(c.get("db"), query))
   })
   .post("/stay-service-posts", async (c) =>
@@ -219,7 +210,7 @@ export const hospitalityStayRoutes = new Hono<Env>()
       {
         data: await hospitalityService.createStayServicePost(
           c.get("db"),
-          insertStayServicePostSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertStayServicePostSchema),
         ),
       },
       201,
@@ -234,7 +225,7 @@ export const hospitalityStayRoutes = new Hono<Env>()
     const row = await hospitalityService.updateStayServicePost(
       c.get("db"),
       c.req.param("id"),
-      updateStayServicePostSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateStayServicePostSchema),
     )
     if (!row) return c.json(notFound("Stay service post"), 404)
     return c.json({ data: row })
@@ -245,9 +236,7 @@ export const hospitalityStayRoutes = new Hono<Env>()
     return c.json({ success: true })
   })
   .get("/stay-folios", async (c) => {
-    const query = stayFolioListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = await parseQuery(c, stayFolioListQuerySchema)
     return c.json(await hospitalityService.listStayFolios(c.get("db"), query))
   })
   .post("/stay-folios", async (c) =>
@@ -255,7 +244,7 @@ export const hospitalityStayRoutes = new Hono<Env>()
       {
         data: await hospitalityService.createStayFolio(
           c.get("db"),
-          insertStayFolioSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertStayFolioSchema),
         ),
       },
       201,
@@ -270,7 +259,7 @@ export const hospitalityStayRoutes = new Hono<Env>()
     const row = await hospitalityService.updateStayFolio(
       c.get("db"),
       c.req.param("id"),
-      updateStayFolioSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateStayFolioSchema),
     )
     if (!row) return c.json(notFound("Stay folio"), 404)
     return c.json({ data: row })
@@ -281,9 +270,7 @@ export const hospitalityStayRoutes = new Hono<Env>()
     return c.json({ success: true })
   })
   .get("/stay-folio-lines", async (c) => {
-    const query = stayFolioLineListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = await parseQuery(c, stayFolioLineListQuerySchema)
     return c.json(await hospitalityService.listStayFolioLines(c.get("db"), query))
   })
   .post("/stay-folio-lines", async (c) =>
@@ -291,7 +278,7 @@ export const hospitalityStayRoutes = new Hono<Env>()
       {
         data: await hospitalityService.createStayFolioLine(
           c.get("db"),
-          insertStayFolioLineSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertStayFolioLineSchema),
         ),
       },
       201,
@@ -306,7 +293,7 @@ export const hospitalityStayRoutes = new Hono<Env>()
     const row = await hospitalityService.updateStayFolioLine(
       c.get("db"),
       c.req.param("id"),
-      updateStayFolioLineSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateStayFolioLineSchema),
     )
     if (!row) return c.json(notFound("Stay folio line"), 404)
     return c.json({ data: row })


### PR DESCRIPTION
## Summary
- replace manual query parsing in hospitality stay routes with the shared Hono query parser
- replace repeated direct JSON parsing in hospitality stay write routes with the shared Hono body parser
- keep the remaining hospitality operational routes aligned with the broader transport cleanup

## Testing
- pnpm -C packages/hospitality lint
- pnpm -C packages/hospitality typecheck
- pnpm -C packages/hospitality test