### PR TITLE
Use shared route parsers in sellability routes

### DIFF
--- a/packages/sellability/src/routes.ts
+++ b/packages/sellability/src/routes.ts
@@ -1,3 +1,4 @@
+import { parseJsonBody, parseQuery } from "@voyantjs/hono"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
 
@@ -34,15 +35,15 @@ type Env = {
 
 export const sellabilityRoutes = new Hono<Env>()
   .post("/resolve", async (c) => {
-    const input = sellabilityResolveQuerySchema.parse(await c.req.json())
+    const input = await parseJsonBody(c, sellabilityResolveQuerySchema)
     return c.json(await sellabilityService.resolve(c.get("db"), input))
   })
   .post("/resolve-and-persist", async (c) => {
-    const input = sellabilityPersistSnapshotSchema.parse(await c.req.json())
+    const input = await parseJsonBody(c, sellabilityPersistSnapshotSchema)
     return c.json(await sellabilityService.persistSnapshot(c.get("db"), input), 201)
   })
   .post("/construct-offer", async (c) => {
-    const input = sellabilityConstructOfferSchema.parse(await c.req.json())
+    const input = await parseJsonBody(c, sellabilityConstructOfferSchema)
     const result = await sellabilityService.constructOffer(c.get("db"), input)
     if (!result) {
       return c.json({ error: "Sellable candidate not found" }, 404)
@@ -50,9 +51,7 @@ export const sellabilityRoutes = new Hono<Env>()
     return c.json({ data: result }, 201)
   })
   .get("/snapshots", async (c) => {
-    const query = sellabilitySnapshotListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = await parseQuery(c, sellabilitySnapshotListQuerySchema)
     return c.json(await sellabilityService.listSnapshots(c.get("db"), query))
   })
   .get("/snapshots/:id", async (c) => {
@@ -61,15 +60,11 @@ export const sellabilityRoutes = new Hono<Env>()
     return c.json({ data: row })
   })
   .get("/snapshot-items", async (c) => {
-    const query = sellabilitySnapshotItemListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = await parseQuery(c, sellabilitySnapshotItemListQuerySchema)
     return c.json(await sellabilityService.listSnapshotItems(c.get("db"), query))
   })
   .get("/policies", async (c) => {
-    const query = sellabilityPolicyListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = await parseQuery(c, sellabilityPolicyListQuerySchema)
     return c.json(await sellabilityService.listPolicies(c.get("db"), query))
   })
   .post("/policies", async (c) => {
@@ -77,7 +72,7 @@ export const sellabilityRoutes = new Hono<Env>()
       {
         data: await sellabilityService.createPolicy(
           c.get("db"),
-          insertSellabilityPolicySchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertSellabilityPolicySchema),
         ),
       },
       201,
@@ -92,7 +87,7 @@ export const sellabilityRoutes = new Hono<Env>()
     const row = await sellabilityService.updatePolicy(
       c.get("db"),
       c.req.param("id"),
-      updateSellabilityPolicySchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateSellabilityPolicySchema),
     )
     if (!row) return c.json({ error: "Sellability policy not found" }, 404)
     return c.json({ data: row })
@@ -103,9 +98,7 @@ export const sellabilityRoutes = new Hono<Env>()
     return c.json({ success: true })
   })
   .get("/policy-results", async (c) => {
-    const query = sellabilityPolicyResultListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = await parseQuery(c, sellabilityPolicyResultListQuerySchema)
     return c.json(await sellabilityService.listPolicyResults(c.get("db"), query))
   })
   .post("/policy-results", async (c) => {
@@ -113,7 +106,7 @@ export const sellabilityRoutes = new Hono<Env>()
       {
         data: await sellabilityService.createPolicyResult(
           c.get("db"),
-          insertSellabilityPolicyResultSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertSellabilityPolicyResultSchema),
         ),
       },
       201,
@@ -128,7 +121,7 @@ export const sellabilityRoutes = new Hono<Env>()
     const row = await sellabilityService.updatePolicyResult(
       c.get("db"),
       c.req.param("id"),
-      updateSellabilityPolicyResultSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateSellabilityPolicyResultSchema),
     )
     if (!row) return c.json({ error: "Sellability policy result not found" }, 404)
     return c.json({ data: row })
@@ -139,9 +132,7 @@ export const sellabilityRoutes = new Hono<Env>()
     return c.json({ success: true })
   })
   .get("/offer-refresh-runs", async (c) => {
-    const query = offerRefreshRunListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = await parseQuery(c, offerRefreshRunListQuerySchema)
     return c.json(await sellabilityService.listOfferRefreshRuns(c.get("db"), query))
   })
   .post("/offer-refresh-runs", async (c) => {
@@ -149,7 +140,7 @@ export const sellabilityRoutes = new Hono<Env>()
       {
         data: await sellabilityService.createOfferRefreshRun(
           c.get("db"),
-          insertOfferRefreshRunSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertOfferRefreshRunSchema),
         ),
       },
       201,
@@ -164,7 +155,7 @@ export const sellabilityRoutes = new Hono<Env>()
     const row = await sellabilityService.updateOfferRefreshRun(
       c.get("db"),
       c.req.param("id"),
-      updateOfferRefreshRunSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateOfferRefreshRunSchema),
     )
     if (!row) return c.json({ error: "Offer refresh run not found" }, 404)
     return c.json({ data: row })
@@ -175,9 +166,7 @@ export const sellabilityRoutes = new Hono<Env>()
     return c.json({ success: true })
   })
   .get("/offer-expiration-events", async (c) => {
-    const query = offerExpirationEventListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = await parseQuery(c, offerExpirationEventListQuerySchema)
     return c.json(await sellabilityService.listOfferExpirationEvents(c.get("db"), query))
   })
   .post("/offer-expiration-events", async (c) => {
@@ -185,7 +174,7 @@ export const sellabilityRoutes = new Hono<Env>()
       {
         data: await sellabilityService.createOfferExpirationEvent(
           c.get("db"),
-          insertOfferExpirationEventSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertOfferExpirationEventSchema),
         ),
       },
       201,
@@ -200,7 +189,7 @@ export const sellabilityRoutes = new Hono<Env>()
     const row = await sellabilityService.updateOfferExpirationEvent(
       c.get("db"),
       c.req.param("id"),
-      updateOfferExpirationEventSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateOfferExpirationEventSchema),
     )
     if (!row) return c.json({ error: "Offer expiration event not found" }, 404)
     return c.json({ data: row })
@@ -211,9 +200,7 @@ export const sellabilityRoutes = new Hono<Env>()
     return c.json({ success: true })
   })
   .get("/explanations", async (c) => {
-    const query = sellabilityExplanationListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = await parseQuery(c, sellabilityExplanationListQuerySchema)
     return c.json(await sellabilityService.listExplanations(c.get("db"), query))
   })
   .post("/explanations", async (c) => {
@@ -221,7 +208,7 @@ export const sellabilityRoutes = new Hono<Env>()
       {
         data: await sellabilityService.createExplanation(
           c.get("db"),
-          insertSellabilityExplanationSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertSellabilityExplanationSchema),
         ),
       },
       201,
@@ -236,7 +223,7 @@ export const sellabilityRoutes = new Hono<Env>()
     const row = await sellabilityService.updateExplanation(
       c.get("db"),
       c.req.param("id"),
-      updateSellabilityExplanationSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateSellabilityExplanationSchema),
     )
     if (!row) return c.json({ error: "Sellability explanation not found" }, 404)
     return c.json({ data: row })


### PR DESCRIPTION
## Summary
- replace manual query parsing in sellability routes with the shared Hono query parser
- replace direct JSON body parsing in sellability routes with the shared Hono body parser
- keep route behavior unchanged while aligning the package with the transport conventions

## Testing
- git diff --check
- pnpm -C packages/sellability lint
- pnpm -C packages/sellability typecheck
- pnpm -C packages/sellability test