### PR TITLE
Use shared route parsers in customer portal routes

### DIFF
--- a/packages/customer-portal/src/routes.ts
+++ b/packages/customer-portal/src/routes.ts
@@ -1,3 +1,4 @@
+import { parseQuery } from "@voyantjs/hono"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
 
@@ -15,9 +16,7 @@ type Env = {
 
 export const customerPortalRoutes = new Hono<Env>()
   .get("/contact-exists", async (c) => {
-    const query = customerPortalContactExistsQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = await parseQuery(c, customerPortalContactExistsQuerySchema)
 
     return c.json({
       data: await publicCustomerPortalService.contactExists(c.get("db"), query.email),
@@ -25,9 +24,7 @@ export const customerPortalRoutes = new Hono<Env>()
   })
 
   .get("/contact-exists/phone", async (c) => {
-    const query = customerPortalPhoneContactExistsQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = await parseQuery(c, customerPortalPhoneContactExistsQuerySchema)
 
     return c.json({
       data: await publicCustomerPortalService.phoneContactExists(c.get("db"), query.phone),


### PR DESCRIPTION
## Summary
- replace manual query parsing in customer portal routes with the shared Hono query parser
- keep route behavior unchanged while aligning the package with the transport conventions

## Testing
- git diff --check
- pnpm -C packages/customer-portal lint
- pnpm -C packages/customer-portal typecheck
- pnpm -C packages/customer-portal test