### PR TITLE
Add optional JSON body parser for finance routes

### DIFF
--- a/packages/finance/src/routes-documents.ts
+++ b/packages/finance/src/routes-documents.ts
@@ -1,4 +1,5 @@
 import type { EventBus } from "@voyantjs/core"
+import { parseOptionalJsonBody } from "@voyantjs/hono"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
 
@@ -51,7 +52,7 @@ export function createFinanceAdminDocumentRoutes(options: FinanceDocumentRouteOp
       const result = await financeDocumentsService.generateInvoiceDocument(
         c.get("db"),
         c.req.param("id"),
-        generateInvoiceDocumentInputSchema.parse(await c.req.json().catch(() => ({}))),
+        await parseOptionalJsonBody(c, generateInvoiceDocumentInputSchema),
         { generator, bindings: c.env, eventBus: resolveEventBus(options, c.env) },
       )
 
@@ -71,7 +72,7 @@ export function createFinanceAdminDocumentRoutes(options: FinanceDocumentRouteOp
       const result = await financeDocumentsService.regenerateInvoiceDocument(
         c.get("db"),
         c.req.param("id"),
-        generateInvoiceDocumentInputSchema.parse(await c.req.json().catch(() => ({}))),
+        await parseOptionalJsonBody(c, generateInvoiceDocumentInputSchema),
         { generator, bindings: c.env, eventBus: resolveEventBus(options, c.env) },
       )
 

--- a/packages/finance/src/routes-settlement.ts
+++ b/packages/finance/src/routes-settlement.ts
@@ -1,4 +1,5 @@
 import type { EventBus } from "@voyantjs/core"
+import { parseOptionalJsonBody } from "@voyantjs/hono"
 import { Hono } from "hono"
 
 import { financeSettlementService, type InvoiceSettlementPoller } from "./service-settlement.js"
@@ -42,7 +43,7 @@ export function createFinanceAdminSettlementRoutes(options: FinanceSettlementRou
     const result = await financeSettlementService.pollInvoiceSettlement(
       c.get("db"),
       c.req.param("id"),
-      pollInvoiceSettlementInputSchema.parse(await c.req.json().catch(() => ({}))),
+      await parseOptionalJsonBody(c, pollInvoiceSettlementInputSchema),
       {
         bindings: c.env,
         invoiceSettlementPollers: resolveInvoiceSettlementPollers(options, c.env),

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -45,6 +45,7 @@ export type {
 export {
   normalizeValidationError,
   parseJsonBody,
+  parseOptionalJsonBody,
   parseQuery,
   RequestValidationError,
 } from "./validation.js"

--- a/packages/hono/src/validation.ts
+++ b/packages/hono/src/validation.ts
@@ -48,6 +48,25 @@ export async function parseJsonBody<T>(
   return validate(schema, input, options?.invalidBodyMessage)
 }
 
+export async function parseOptionalJsonBody<T>(
+  c: Context,
+  schema: ZodType<T>,
+  options?: {
+    defaultValue?: unknown
+    invalidBodyMessage?: string
+  },
+): Promise<T> {
+  let input: unknown
+
+  try {
+    input = await c.req.json()
+  } catch {
+    input = options?.defaultValue ?? {}
+  }
+
+  return validate(schema, input, options?.invalidBodyMessage)
+}
+
 export function parseQuery<T>(
   c: Context,
   schema: ZodType<T>,

--- a/packages/hono/tests/unit/validation.test.ts
+++ b/packages/hono/tests/unit/validation.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { z } from "zod"
 
 import { handleApiError, requestId } from "../../src/middleware/error-boundary.js"
-import { parseJsonBody, parseQuery } from "../../src/validation.js"
+import { parseJsonBody, parseOptionalJsonBody, parseQuery } from "../../src/validation.js"
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -58,5 +58,29 @@ describe("validation helpers", () => {
       error: "Invalid JSON body",
       code: "invalid_request",
     })
+  })
+
+  it("falls back to an empty body when optional JSON parsing is used", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const app = new Hono()
+    app.onError(handleApiError)
+    app.use("*", requestId)
+    app.post("/search", async (c) => {
+      const body = await parseOptionalJsonBody(
+        c,
+        z.object({ includeDrafts: z.boolean().default(false) }),
+      )
+      return c.json({ includeDrafts: body.includeDrafts })
+    })
+
+    const response = await app.request("http://example.com/search", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "",
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ includeDrafts: false })
   })
 })


### PR DESCRIPTION
## Summary
- add a shared `parseOptionalJsonBody(...)` helper to the Hono validation surface
- keep empty-body admin finance actions explicit without repeating `await c.req.json().catch(() => ({}))`
- apply the helper to finance document generation/regeneration and settlement polling routes

## Testing
- `git diff --check`
- `pnpm -C packages/hono lint`
- `pnpm -C packages/hono typecheck`
- `pnpm -C packages/hono test`
- `pnpm -C packages/finance lint`
- `pnpm -C packages/finance typecheck`
- `pnpm -C packages/finance test`
