### PR TITLE
Reframe plugin package readmes around adapters

### DIFF
--- a/packages/plugins/netopia/README.md
+++ b/packages/plugins/netopia/README.md
@@ -1,6 +1,6 @@
 # `@voyantjs/plugin-netopia`
 
-Netopia hosted-card payment support for Voyant finance.
+Netopia payment adapter for Voyant finance. It starts hosted-card collection flows, stores provider references on `payment_sessions`, and reconciles callback payloads back into Voyant finance state. The package is distributed as a plugin bundle, but the core role is a finance and checkout provider integration.
 
 This package sits on top of `@voyantjs/finance` and its `payment_sessions` model. It does not replace finance state. It starts a hosted Netopia checkout, stores provider references on the session, and reconciles callback payloads back into Voyant payments, captures, authorizations, invoices, and booking payment schedules.
 
@@ -53,7 +53,7 @@ Then include the returned extension in `createApp({ extensions: [...] })`.
 3. Redirect the customer to the returned provider `paymentURL`.
 4. Optionally send a payment-link or invoice notification as part of the collect flow.
 5. Netopia calls the callback route.
-6. The plugin completes, fails, or updates the session in finance.
+6. The adapter completes, fails, or updates the session in finance.
 
 ## Notes
 

--- a/packages/plugins/payload-cms/README.md
+++ b/packages/plugins/payload-cms/README.md
@@ -1,6 +1,6 @@
 # @voyantjs/plugin-payload-cms
 
-Payload CMS sync plugin for Voyant. Subscribes to module events and mirrors documents into a Payload collection keyed by a `voyantId` field.
+Payload CMS sync adapter for Voyant. It subscribes to module events and mirrors documents into a Payload collection keyed by a `voyantId` field. The package is distributed as a Voyant plugin bundle so it can be mounted directly in app composition.
 
 ## Install
 
@@ -26,14 +26,14 @@ const app = createApp({
 })
 ```
 
-By default the plugin wires up 3 subscribers (`product.created`, `product.updated`, `product.deleted`) that upsert/delete documents keyed by `voyantId`. All error handling is fire-and-forget per the EventBus contract.
+By default the bundle wires up 3 subscribers (`product.created`, `product.updated`, `product.deleted`) that upsert/delete documents keyed by `voyantId`. All error handling is fire-and-forget per the EventBus contract.
 
 ## Exports
 
 | Entry | Description |
 | --- | --- |
 | `.` | Barrel re-exports |
-| `./plugin` | `payloadCmsPlugin(options)` |
+| `./plugin` | `payloadCmsPlugin(options)` plugin bundle factory |
 | `./client` | `createPayloadClient` — `upsertByVoyantId`, `deleteByVoyantId`, `findByVoyantId` |
 | `./types` | Plugin option types |
 

--- a/packages/plugins/sanity-cms/README.md
+++ b/packages/plugins/sanity-cms/README.md
@@ -1,6 +1,6 @@
 # @voyantjs/plugin-sanity-cms
 
-Sanity CMS sync plugin for Voyant. Subscribes to module events and mirrors documents into a Sanity dataset keyed by a `voyantId` field.
+Sanity CMS sync adapter for Voyant. It subscribes to module events and mirrors documents into a Sanity dataset keyed by a `voyantId` field. The package is distributed as a Voyant plugin bundle so it can be mounted directly in app composition.
 
 ## Install
 
@@ -27,14 +27,14 @@ const app = createApp({
 })
 ```
 
-Uses GROQ for reads and Sanity Mutations API for writes. Default `apiVersion` is `"2024-01-01"`. By default the plugin wires up 3 subscribers (`product.created`, `product.updated`, `product.deleted`).
+Uses GROQ for reads and Sanity Mutations API for writes. Default `apiVersion` is `"2024-01-01"`. By default the bundle wires up 3 subscribers (`product.created`, `product.updated`, `product.deleted`).
 
 ## Exports
 
 | Entry | Description |
 | --- | --- |
 | `.` | Barrel re-exports |
-| `./plugin` | `sanityCmsPlugin(options)` |
+| `./plugin` | `sanityCmsPlugin(options)` plugin bundle factory |
 | `./client` | `createSanityClient` — `upsertByVoyantId`, `deleteByVoyantId`, `findByVoyantId` |
 | `./types` | Plugin option types |
 

--- a/packages/plugins/smartbill/README.md
+++ b/packages/plugins/smartbill/README.md
@@ -1,6 +1,6 @@
 # @voyantjs/plugin-smartbill
 
-SmartBill e-invoicing plugin for Voyant. Subscribes to invoice events and creates/cancels/syncs invoices via the SmartBill REST API for Romanian tax compliance.
+SmartBill e-invoicing adapter for Voyant. It subscribes to invoice events and creates, cancels, and syncs invoices via the SmartBill REST API for Romanian tax compliance. The package is distributed as a Voyant plugin bundle so it can be mounted directly in app composition.
 
 ## Install
 
@@ -27,14 +27,14 @@ const app = createApp({
 })
 ```
 
-By default the plugin wires up 3 subscribers (`invoice.issued`, `invoice.voided`, `invoice.external.sync.requested`) that create, cancel, and check payment status on SmartBill. All error handling is fire-and-forget per the EventBus contract.
+By default the bundle wires up 3 subscribers (`invoice.issued`, `invoice.voided`, `invoice.external.sync.requested`) that create, cancel, and check payment status on SmartBill. All error handling is fire-and-forget per the EventBus contract.
 
 ## Exports
 
 | Entry | Description |
 | --- | --- |
 | `.` | Barrel re-exports |
-| `./plugin` | `smartbillPlugin(options)` |
+| `./plugin` | `smartbillPlugin(options)` plugin bundle factory |
 | `./client` | `createSmartbillClient` — `createInvoice`, `cancelInvoice`, `viewPdf`, `getPaymentStatus`, etc. |
 | `./types` | SmartBill invoice types |
 


### PR DESCRIPTION
## Summary
- lead the Payload, Sanity, SmartBill, and Netopia package READMEs with their adapter/subscriber role instead of plugin-first wording
- describe the plugin bundle as the distribution wrapper on top of those integrations
- tighten the exports tables so `./plugin` is clearly a bundle factory, not the primary architecture concept

## Testing
- `git diff --check`
