### PR TITLE
Use shared runtime and body parsing in Netopia finance routes

### DIFF
--- a/packages/plugins/netopia/src/plugin.ts
+++ b/packages/plugins/netopia/src/plugin.ts
@@ -1,5 +1,5 @@
 import type { Extension, ModuleContainer } from "@voyantjs/core"
-import { defineHonoPlugin, type HonoPlugin } from "@voyantjs/hono"
+import { defineHonoPlugin, type HonoPlugin, parseJsonBody } from "@voyantjs/hono"
 import type { HonoExtension } from "@voyantjs/hono/module"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
@@ -67,12 +67,16 @@ export function createNetopiaFinanceRoutes(options: NetopiaRuntimeOptions = {}) 
     }
     return { status: 502 as const, message }
   }
+  const resolveRuntime = (c: {
+    env: Record<string, unknown>
+    var: { container: ModuleContainer }
+  }) => getNetopiaRuntime(c.env, options, (key) => c.var.container.resolve(key))
 
   return new Hono<Env>()
     .post("/providers/netopia/payment-sessions/:sessionId/start", async (c) => {
       try {
-        const data = netopiaStartPaymentSessionSchema.parse(await c.req.json())
-        const runtime = getNetopiaRuntime(c.env, options, (key) => c.var.container.resolve(key))
+        const data = await parseJsonBody(c, netopiaStartPaymentSessionSchema)
+        const runtime = resolveRuntime(c)
         const result = await netopiaService.startPaymentSession(
           c.get("db"),
           c.req.param("sessionId"),
@@ -99,8 +103,8 @@ export function createNetopiaFinanceRoutes(options: NetopiaRuntimeOptions = {}) 
       "/providers/netopia/bookings/:bookingId/payment-schedules/:scheduleId/collect",
       async (c) => {
         try {
-          const data = netopiaCollectBookingScheduleSchema.parse(await c.req.json())
-          const runtime = getNetopiaRuntime(c.env, options, (key) => c.var.container.resolve(key))
+          const data = await parseJsonBody(c, netopiaCollectBookingScheduleSchema)
+          const runtime = resolveRuntime(c)
           const result = await netopiaService.collectBookingSchedule(
             c.get("db"),
             c.req.param("scheduleId"),
@@ -121,8 +125,8 @@ export function createNetopiaFinanceRoutes(options: NetopiaRuntimeOptions = {}) 
     )
     .post("/providers/netopia/bookings/:bookingId/guarantees/:guaranteeId/collect", async (c) => {
       try {
-        const data = netopiaCollectBookingGuaranteeSchema.parse(await c.req.json())
-        const runtime = getNetopiaRuntime(c.env, options, (key) => c.var.container.resolve(key))
+        const data = await parseJsonBody(c, netopiaCollectBookingGuaranteeSchema)
+        const runtime = resolveRuntime(c)
         const result = await netopiaService.collectBookingGuarantee(
           c.get("db"),
           c.req.param("guaranteeId"),
@@ -142,8 +146,8 @@ export function createNetopiaFinanceRoutes(options: NetopiaRuntimeOptions = {}) 
     })
     .post("/providers/netopia/invoices/:invoiceId/collect", async (c) => {
       try {
-        const data = netopiaCollectInvoiceSchema.parse(await c.req.json())
-        const runtime = getNetopiaRuntime(c.env, options, (key) => c.var.container.resolve(key))
+        const data = await parseJsonBody(c, netopiaCollectInvoiceSchema)
+        const runtime = resolveRuntime(c)
         const result = await netopiaService.collectInvoice(
           c.get("db"),
           c.req.param("invoiceId"),
@@ -161,14 +165,14 @@ export function createNetopiaFinanceRoutes(options: NetopiaRuntimeOptions = {}) 
       }
     })
     .post("/providers/netopia/callback", async (c) => {
-      const payload = netopiaWebhookPayloadSchema.parse(await c.req.json())
-      const runtime = getNetopiaRuntime(c.env, options, (key) => c.var.container.resolve(key))
+      const payload = await parseJsonBody(c, netopiaWebhookPayloadSchema)
+      const runtime = resolveRuntime(c)
       const result = await netopiaService.handleCallback(c.get("db"), payload, runtime)
       return c.json({ data: result })
     })
     .get("/providers/netopia/config", async (c) => {
       try {
-        const runtime = getNetopiaRuntime(c.env, options, (key) => c.var.container.resolve(key))
+        const runtime = resolveRuntime(c)
         return c.json({
           data: {
             apiUrl: runtime.apiUrl,


### PR DESCRIPTION
## Summary
- replace manual JSON parsing in the Netopia finance routes with the shared Hono body parser
- resolve the Netopia runtime once per request through a local helper instead of repeating container lookups
- keep bootstrap-time runtime registration as the canonical source of resolved Netopia config

## Testing
- git diff --check
- pnpm -C packages/plugins/netopia lint
- pnpm -C packages/plugins/netopia typecheck
- pnpm -C packages/plugins/netopia test