### PR TITLE
Add SmartBill sync runtime helper

### DIFF
--- a/packages/plugins/smartbill/src/index.ts
+++ b/packages/plugins/smartbill/src/index.ts
@@ -9,6 +9,8 @@ export type {
   SmartbillSyncEventNames,
 } from "./plugin.js"
 export { smartbillPlugin } from "./plugin.js"
+export type { ResolvedSmartbillSyncEventNames, SmartbillSyncRuntime } from "./runtime.js"
+export { createSmartbillSyncRuntime } from "./runtime.js"
 export type {
   SmartbillInvoiceSettlementPoller,
   SmartbillInvoiceSettlementPollerOptions,

--- a/packages/plugins/smartbill/src/plugin.ts
+++ b/packages/plugins/smartbill/src/plugin.ts
@@ -1,7 +1,8 @@
 import type { Plugin, Subscriber } from "@voyantjs/core"
 
-import { createSmartbillClient, type SmartbillClientOptions } from "./client.js"
-import { mapVoyantInvoiceToSmartbill, type SmartbillMappingOptions } from "./mapping.js"
+import type { SmartbillClientOptions } from "./client.js"
+import type { mapVoyantInvoiceToSmartbill, SmartbillMappingOptions } from "./mapping.js"
+import { createSmartbillSyncRuntime } from "./runtime.js"
 import type { VoyantInvoiceEvent } from "./types.js"
 
 /**
@@ -67,23 +68,7 @@ function coerceEvent(data: unknown): VoyantInvoiceEvent | null {
  * EventBus contract, so a SmartBill outage never blocks the emitter.
  */
 export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
-  const client = createSmartbillClient(options)
-  const logger = options.logger ?? console
-  const mappingOptions: SmartbillMappingOptions = {
-    companyVatCode: options.companyVatCode,
-    seriesName: options.seriesName,
-    language: options.language,
-    isTaxIncluded: options.isTaxIncluded,
-    art311SpecialRegime: options.art311SpecialRegime,
-  }
-  const mapEvent =
-    options.mapEvent ??
-    ((ev: VoyantInvoiceEvent) => mapVoyantInvoiceToSmartbill(ev, mappingOptions))
-  const eventNames = {
-    issued: options.events?.issued ?? "invoice.issued",
-    voided: options.events?.voided ?? "invoice.voided",
-    syncRequested: options.events?.syncRequested ?? "invoice.external.sync.requested",
-  }
+  const { client, logger, mapEvent, eventNames } = createSmartbillSyncRuntime(options)
 
   const subscribers: Subscriber[] = [
     {

--- a/packages/plugins/smartbill/src/runtime.ts
+++ b/packages/plugins/smartbill/src/runtime.ts
@@ -1,0 +1,44 @@
+import { createSmartbillClient } from "./client.js"
+import { mapVoyantInvoiceToSmartbill, type SmartbillMappingOptions } from "./mapping.js"
+import type { SmartbillLogger, SmartbillMapFn, SmartbillPluginOptions } from "./plugin.js"
+import type { VoyantInvoiceEvent } from "./types.js"
+
+export interface ResolvedSmartbillSyncEventNames {
+  issued: string
+  voided: string
+  syncRequested: string
+}
+
+export interface SmartbillSyncRuntime {
+  client: ReturnType<typeof createSmartbillClient>
+  logger: SmartbillLogger
+  mapEvent: SmartbillMapFn
+  eventNames: ResolvedSmartbillSyncEventNames
+}
+
+export function createSmartbillSyncRuntime(options: SmartbillPluginOptions): SmartbillSyncRuntime {
+  const client = createSmartbillClient(options)
+  const logger = options.logger ?? console
+  const mappingOptions: SmartbillMappingOptions = {
+    companyVatCode: options.companyVatCode,
+    seriesName: options.seriesName,
+    language: options.language,
+    isTaxIncluded: options.isTaxIncluded,
+    art311SpecialRegime: options.art311SpecialRegime,
+  }
+  const mapEvent: SmartbillMapFn =
+    options.mapEvent ??
+    ((event: VoyantInvoiceEvent) => mapVoyantInvoiceToSmartbill(event, mappingOptions))
+  const eventNames: ResolvedSmartbillSyncEventNames = {
+    issued: options.events?.issued ?? "invoice.issued",
+    voided: options.events?.voided ?? "invoice.voided",
+    syncRequested: options.events?.syncRequested ?? "invoice.external.sync.requested",
+  }
+
+  return {
+    client,
+    logger,
+    mapEvent,
+    eventNames,
+  }
+}

--- a/packages/plugins/smartbill/tests/unit/runtime.test.ts
+++ b/packages/plugins/smartbill/tests/unit/runtime.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createSmartbillSyncRuntime } from "../../src/runtime.js"
+import type { SmartbillFetch } from "../../src/types.js"
+
+const baseOptions = {
+  username: "user@test.com",
+  apiToken: "tok",
+  companyVatCode: "RO12345678",
+  seriesName: "A",
+}
+
+describe("createSmartbillSyncRuntime", () => {
+  it("builds the default client, logger, mapper, and event names", () => {
+    const fetchMock = vi.fn<SmartbillFetch>()
+    const runtime = createSmartbillSyncRuntime({
+      ...baseOptions,
+      fetch: fetchMock,
+    })
+
+    expect(runtime.client).toBeDefined()
+    expect(runtime.logger).toBe(console)
+    expect(runtime.eventNames).toEqual({
+      issued: "invoice.issued",
+      voided: "invoice.voided",
+      syncRequested: "invoice.external.sync.requested",
+    })
+    expect(
+      runtime.mapEvent({
+        id: "inv_123",
+        clientName: "Client SRL",
+        currency: "RON",
+        lineItems: [{ name: "Tour", quantity: 1, unitPrice: 50000 }],
+      }),
+    ).toMatchObject({
+      companyVatCode: "RO12345678",
+      seriesName: "A",
+      client: { name: "Client SRL" },
+    })
+  })
+
+  it("honors custom logger, mapper, and event names", () => {
+    const fetchMock = vi.fn<SmartbillFetch>()
+    const logger = { error: vi.fn(), info: vi.fn() }
+    const mapEvent = vi.fn().mockReturnValue({
+      companyVatCode: "CUSTOM",
+      client: { name: "Custom" },
+      seriesName: "Z",
+      currency: "EUR",
+      products: [],
+    })
+
+    const runtime = createSmartbillSyncRuntime({
+      ...baseOptions,
+      fetch: fetchMock,
+      logger,
+      mapEvent,
+      events: {
+        issued: "custom.issued",
+        voided: "custom.voided",
+        syncRequested: "custom.sync",
+      },
+    })
+
+    expect(runtime.logger).toBe(logger)
+    expect(runtime.mapEvent).toBe(mapEvent)
+    expect(runtime.eventNames).toEqual({
+      issued: "custom.issued",
+      voided: "custom.voided",
+      syncRequested: "custom.sync",
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- extract SmartBill client/logger/mapper/event-name assembly into a shared sync runtime helper
- refactor the SmartBill plugin to build subscribers from that runtime instead of inlining setup
- add focused unit coverage for the new helper while keeping plugin behavior the same

## Testing
- git diff --check
- pnpm -C packages/plugins/smartbill lint
- pnpm -C packages/plugins/smartbill typecheck
- pnpm -C packages/plugins/smartbill test