### PR TITLE
Add Payload CMS sync runtime helper

### DIFF
--- a/packages/plugins/payload-cms/src/index.ts
+++ b/packages/plugins/payload-cms/src/index.ts
@@ -7,4 +7,6 @@ export type {
   PayloadSyncEventNames,
 } from "./plugin.js"
 export { payloadCmsPlugin } from "./plugin.js"
+export type { PayloadSyncRuntime, ResolvedPayloadSyncEventNames } from "./runtime.js"
+export { createPayloadSyncRuntime } from "./runtime.js"
 export type { PayloadDocBody, PayloadFetch, VoyantEntityEvent } from "./types.js"

--- a/packages/plugins/payload-cms/src/plugin.ts
+++ b/packages/plugins/payload-cms/src/plugin.ts
@@ -1,6 +1,7 @@
 import type { Plugin, Subscriber } from "@voyantjs/core"
 
-import { createPayloadClient, type PayloadClientOptions } from "./client.js"
+import type { PayloadClientOptions } from "./client.js"
+import { createPayloadSyncRuntime } from "./runtime.js"
 import type { PayloadDocBody, VoyantEntityEvent } from "./types.js"
 
 /**
@@ -48,11 +49,6 @@ export interface PayloadCmsPluginOptions extends PayloadClientOptions {
   logger?: PayloadLogger
 }
 
-function defaultMapEvent(event: VoyantEntityEvent): PayloadDocBody {
-  const { id: _id, ...rest } = event
-  return rest
-}
-
 function coerceEvent(data: unknown): VoyantEntityEvent | null {
   if (data == null || typeof data !== "object") return null
   const maybe = data as Record<string, unknown>
@@ -74,14 +70,7 @@ function coerceEvent(data: unknown): VoyantEntityEvent | null {
  * EventBus contract, so a Payload outage never blocks the emitter.
  */
 export function payloadCmsPlugin(options: PayloadCmsPluginOptions): Plugin {
-  const client = createPayloadClient(options)
-  const mapEvent = options.mapEvent ?? defaultMapEvent
-  const logger = options.logger ?? console
-  const eventNames = {
-    created: options.events?.created ?? "product.created",
-    updated: options.events?.updated ?? "product.updated",
-    deleted: options.events?.deleted ?? "product.deleted",
-  }
+  const { client, mapEvent, logger, eventNames } = createPayloadSyncRuntime(options)
 
   const subscribers: Subscriber[] = [
     {

--- a/packages/plugins/payload-cms/src/runtime.ts
+++ b/packages/plugins/payload-cms/src/runtime.ts
@@ -1,0 +1,34 @@
+import { createPayloadClient } from "./client.js"
+import type { PayloadCmsPluginOptions, PayloadLogger, PayloadMapFn } from "./plugin.js"
+import type { PayloadDocBody, VoyantEntityEvent } from "./types.js"
+
+export interface ResolvedPayloadSyncEventNames {
+  created: string
+  updated: string
+  deleted: string
+}
+
+export interface PayloadSyncRuntime {
+  client: ReturnType<typeof createPayloadClient>
+  logger: PayloadLogger
+  mapEvent: PayloadMapFn
+  eventNames: ResolvedPayloadSyncEventNames
+}
+
+function defaultMapEvent(event: VoyantEntityEvent): PayloadDocBody {
+  const { id: _id, ...rest } = event
+  return rest
+}
+
+export function createPayloadSyncRuntime(options: PayloadCmsPluginOptions): PayloadSyncRuntime {
+  return {
+    client: createPayloadClient(options),
+    logger: options.logger ?? console,
+    mapEvent: options.mapEvent ?? defaultMapEvent,
+    eventNames: {
+      created: options.events?.created ?? "product.created",
+      updated: options.events?.updated ?? "product.updated",
+      deleted: options.events?.deleted ?? "product.deleted",
+    },
+  }
+}

--- a/packages/plugins/payload-cms/tests/unit/runtime.test.ts
+++ b/packages/plugins/payload-cms/tests/unit/runtime.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createPayloadSyncRuntime } from "../../src/runtime.js"
+import type { PayloadFetch } from "../../src/types.js"
+
+const baseOptions = {
+  apiUrl: "https://cms.example.com/api",
+  apiKey: "test-key",
+  collection: "products",
+}
+
+describe("createPayloadSyncRuntime", () => {
+  it("builds the default client, logger, mapper, and event names", () => {
+    const fetchMock = vi.fn<PayloadFetch>()
+    const runtime = createPayloadSyncRuntime({
+      ...baseOptions,
+      fetch: fetchMock,
+    })
+
+    expect(runtime.client).toBeDefined()
+    expect(runtime.logger).toBe(console)
+    expect(runtime.eventNames).toEqual({
+      created: "product.created",
+      updated: "product.updated",
+      deleted: "product.deleted",
+    })
+    expect(runtime.mapEvent({ id: "prod_1", name: "Tour A" })).toEqual({ name: "Tour A" })
+  })
+
+  it("honors custom logger, mapper, and event names", () => {
+    const fetchMock = vi.fn<PayloadFetch>()
+    const logger = { error: vi.fn(), info: vi.fn() }
+    const mapEvent = vi.fn().mockReturnValue({
+      title: "Custom Tour",
+      _syncedAt: "2024-01-01",
+    })
+
+    const runtime = createPayloadSyncRuntime({
+      ...baseOptions,
+      fetch: fetchMock,
+      logger,
+      mapEvent,
+      events: {
+        created: "departure.created",
+        updated: "departure.updated",
+        deleted: "departure.deleted",
+      },
+    })
+
+    expect(runtime.logger).toBe(logger)
+    expect(runtime.mapEvent).toBe(mapEvent)
+    expect(runtime.eventNames).toEqual({
+      created: "departure.created",
+      updated: "departure.updated",
+      deleted: "departure.deleted",
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- extract Payload CMS client/logger/mapper/event-name assembly into a shared sync runtime helper
- refactor the Payload CMS plugin to build subscribers from that runtime instead of inlining setup
- add focused unit coverage for the new helper while keeping plugin behavior the same

## Testing
- git diff --check
- pnpm -C packages/plugins/payload-cms lint
- pnpm -C packages/plugins/payload-cms typecheck
- pnpm -C packages/plugins/payload-cms test