### PR TITLE
Add Sanity CMS sync runtime helper

### DIFF
--- a/packages/plugins/sanity-cms/src/index.ts
+++ b/packages/plugins/sanity-cms/src/index.ts
@@ -7,4 +7,6 @@ export type {
   SanitySyncEventNames,
 } from "./plugin.js"
 export { sanityCmsPlugin } from "./plugin.js"
+export type { ResolvedSanitySyncEventNames, SanitySyncRuntime } from "./runtime.js"
+export { createSanitySyncRuntime } from "./runtime.js"
 export type { SanityDocBody, SanityFetch, VoyantEntityEvent } from "./types.js"

--- a/packages/plugins/sanity-cms/src/plugin.ts
+++ b/packages/plugins/sanity-cms/src/plugin.ts
@@ -1,6 +1,7 @@
 import type { Plugin, Subscriber } from "@voyantjs/core"
 
-import { createSanityClient, type SanityClientOptions } from "./client.js"
+import type { SanityClientOptions } from "./client.js"
+import { createSanitySyncRuntime } from "./runtime.js"
 import type { SanityDocBody, VoyantEntityEvent } from "./types.js"
 
 /**
@@ -50,11 +51,6 @@ export interface SanityCmsPluginOptions extends SanityClientOptions {
   logger?: SanityLogger
 }
 
-function defaultMapEvent(event: VoyantEntityEvent): SanityDocBody {
-  const { id: _id, ...rest } = event
-  return rest
-}
-
 function coerceEvent(data: unknown): VoyantEntityEvent | null {
   if (data == null || typeof data !== "object") return null
   const maybe = data as Record<string, unknown>
@@ -76,14 +72,7 @@ function coerceEvent(data: unknown): VoyantEntityEvent | null {
  * EventBus contract, so a Sanity outage never blocks the emitter.
  */
 export function sanityCmsPlugin(options: SanityCmsPluginOptions): Plugin {
-  const client = createSanityClient(options)
-  const mapEvent = options.mapEvent ?? defaultMapEvent
-  const logger = options.logger ?? console
-  const eventNames = {
-    created: options.events?.created ?? "product.created",
-    updated: options.events?.updated ?? "product.updated",
-    deleted: options.events?.deleted ?? "product.deleted",
-  }
+  const { client, mapEvent, logger, eventNames } = createSanitySyncRuntime(options)
 
   const subscribers: Subscriber[] = [
     {

--- a/packages/plugins/sanity-cms/src/runtime.ts
+++ b/packages/plugins/sanity-cms/src/runtime.ts
@@ -1,0 +1,34 @@
+import { createSanityClient } from "./client.js"
+import type { SanityCmsPluginOptions, SanityLogger, SanityMapFn } from "./plugin.js"
+import type { SanityDocBody, VoyantEntityEvent } from "./types.js"
+
+export interface ResolvedSanitySyncEventNames {
+  created: string
+  updated: string
+  deleted: string
+}
+
+export interface SanitySyncRuntime {
+  client: ReturnType<typeof createSanityClient>
+  logger: SanityLogger
+  mapEvent: SanityMapFn
+  eventNames: ResolvedSanitySyncEventNames
+}
+
+function defaultMapEvent(event: VoyantEntityEvent): SanityDocBody {
+  const { id: _id, ...rest } = event
+  return rest
+}
+
+export function createSanitySyncRuntime(options: SanityCmsPluginOptions): SanitySyncRuntime {
+  return {
+    client: createSanityClient(options),
+    logger: options.logger ?? console,
+    mapEvent: options.mapEvent ?? defaultMapEvent,
+    eventNames: {
+      created: options.events?.created ?? "product.created",
+      updated: options.events?.updated ?? "product.updated",
+      deleted: options.events?.deleted ?? "product.deleted",
+    },
+  }
+}

--- a/packages/plugins/sanity-cms/tests/unit/runtime.test.ts
+++ b/packages/plugins/sanity-cms/tests/unit/runtime.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createSanitySyncRuntime } from "../../src/runtime.js"
+import type { SanityFetch } from "../../src/types.js"
+
+const baseOptions = {
+  projectId: "abc123",
+  dataset: "production",
+  token: "test-token",
+  documentType: "product",
+}
+
+describe("createSanitySyncRuntime", () => {
+  it("builds the default client, logger, mapper, and event names", () => {
+    const fetchMock = vi.fn<SanityFetch>()
+    const runtime = createSanitySyncRuntime({
+      ...baseOptions,
+      fetch: fetchMock,
+    })
+
+    expect(runtime.client).toBeDefined()
+    expect(runtime.logger).toBe(console)
+    expect(runtime.eventNames).toEqual({
+      created: "product.created",
+      updated: "product.updated",
+      deleted: "product.deleted",
+    })
+    expect(runtime.mapEvent({ id: "prod_1", name: "Tour A" })).toEqual({ name: "Tour A" })
+  })
+
+  it("honors custom logger, mapper, and event names", () => {
+    const fetchMock = vi.fn<SanityFetch>()
+    const logger = { error: vi.fn(), info: vi.fn() }
+    const mapEvent = vi.fn().mockReturnValue({
+      title: "Custom Tour",
+      _syncedAt: "2024-01-01",
+    })
+
+    const runtime = createSanitySyncRuntime({
+      ...baseOptions,
+      fetch: fetchMock,
+      logger,
+      mapEvent,
+      events: {
+        created: "departure.created",
+        updated: "departure.updated",
+        deleted: "departure.deleted",
+      },
+    })
+
+    expect(runtime.logger).toBe(logger)
+    expect(runtime.mapEvent).toBe(mapEvent)
+    expect(runtime.eventNames).toEqual({
+      created: "departure.created",
+      updated: "departure.updated",
+      deleted: "departure.deleted",
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- extract Sanity CMS client/logger/mapper/event-name assembly into a shared sync runtime helper
- refactor the Sanity CMS plugin to build subscribers from that runtime instead of inlining setup
- add focused unit coverage for the new helper while keeping plugin behavior the same

## Testing
- git diff --check
- pnpm -C packages/plugins/sanity-cms lint
- pnpm -C packages/plugins/sanity-cms typecheck
- pnpm -C packages/plugins/sanity-cms test