### PR TITLE
Bootstrap bookings route runtime

### DIFF
--- a/packages/bookings/src/index.ts
+++ b/packages/bookings/src/index.ts
@@ -1,6 +1,7 @@
 import type { LinkableDefinition, Module } from "@voyantjs/core"
 import type { HonoModule } from "@voyantjs/hono/module"
 
+import { BOOKING_ROUTE_RUNTIME_CONTAINER_KEY, buildBookingRouteRuntime } from "./route-runtime.js"
 import { bookingRoutes } from "./routes.js"
 import { publicBookingRoutes } from "./routes-public.js"
 
@@ -43,13 +44,32 @@ export const bookingsModule: Module = {
   linkable: bookingsLinkable,
 }
 
-export const bookingsHonoModule: HonoModule = {
-  module: bookingsModule,
-  adminRoutes: bookingRoutes,
-  publicRoutes: publicBookingRoutes,
-  routes: bookingRoutes,
+export function createBookingsHonoModule(): HonoModule {
+  const module: Module = {
+    ...bookingsModule,
+    bootstrap: ({ bindings, container }) => {
+      container.register(
+        BOOKING_ROUTE_RUNTIME_CONTAINER_KEY,
+        buildBookingRouteRuntime(bindings as Record<string, unknown>),
+      )
+    },
+  }
+
+  return {
+    module,
+    adminRoutes: bookingRoutes,
+    publicRoutes: publicBookingRoutes,
+    routes: bookingRoutes,
+  }
 }
 
+export const bookingsHonoModule: HonoModule = createBookingsHonoModule()
+
+export type { BookingRouteRuntime } from "./route-runtime.js"
+export {
+  BOOKING_ROUTE_RUNTIME_CONTAINER_KEY,
+  buildBookingRouteRuntime,
+} from "./route-runtime.js"
 export type { BookingRoutes } from "./routes.js"
 export type { PublicBookingRoutes } from "./routes-public.js"
 export { publicBookingRoutes } from "./routes-public.js"

--- a/packages/bookings/src/route-runtime.ts
+++ b/packages/bookings/src/route-runtime.ts
@@ -1,0 +1,33 @@
+import { createKmsProviderFromEnv, type KmsProvider } from "@voyantjs/utils"
+
+import type { KmsBindings } from "./routes-shared.js"
+
+export const BOOKING_ROUTE_RUNTIME_CONTAINER_KEY = "runtime.bookings.routes"
+
+export interface BookingRouteRuntime {
+  getKmsProvider(): KmsProvider
+}
+
+function buildRuntimeEnv(bindings: KmsBindings): Record<string, string | undefined> {
+  const processEnv =
+    (
+      globalThis as typeof globalThis & {
+        process?: { env?: Record<string, string | undefined> }
+      }
+    ).process?.env ?? {}
+
+  return {
+    ...processEnv,
+    ...(bindings ?? {}),
+  }
+}
+
+export function buildBookingRouteRuntime(bindings: KmsBindings): BookingRouteRuntime {
+  const runtimeEnv = buildRuntimeEnv(bindings)
+
+  return {
+    getKmsProvider() {
+      return createKmsProviderFromEnv(runtimeEnv)
+    },
+  }
+}

--- a/packages/bookings/src/routes-shared.ts
+++ b/packages/bookings/src/routes-shared.ts
@@ -1,3 +1,4 @@
+import type { ModuleContainer } from "@voyantjs/core"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
 
@@ -24,6 +25,7 @@ export type KmsBindings = Partial<{
 export type Env = {
   Bindings: KmsBindings
   Variables: {
+    container?: ModuleContainer
     db: PostgresJsDatabase
     userId?: string
     actor?: "staff" | "customer" | "partner" | "supplier"

--- a/packages/bookings/src/routes.ts
+++ b/packages/bookings/src/routes.ts
@@ -1,10 +1,14 @@
-import { createKmsProviderFromEnv } from "@voyantjs/utils"
 import { type Context, Hono } from "hono"
 
 import { createBookingPiiService } from "./pii.js"
+import {
+  BOOKING_ROUTE_RUNTIME_CONTAINER_KEY,
+  type BookingRouteRuntime,
+  buildBookingRouteRuntime,
+} from "./route-runtime.js"
 import { bookingGroupRoutes } from "./routes-groups.js"
 import type { publicBookingRoutes } from "./routes-public.js"
-import { type Env, getRuntimeEnv } from "./routes-shared.js"
+import type { Env } from "./routes-shared.js"
 import { bookingPiiAccessLog } from "./schema.js"
 import { bookingsService } from "./service.js"
 import { bookingGroupsService } from "./service-groups.js"
@@ -154,6 +158,38 @@ function handleKmsConfigError(c: Context<Env>, error: unknown) {
   }
 
   return c.json({ error: "Booking PII encryption is not configured" }, 500)
+}
+
+function getRouteRuntime(c: Context<Env>): BookingRouteRuntime {
+  try {
+    return (
+      c.var.container?.resolve<BookingRouteRuntime>(BOOKING_ROUTE_RUNTIME_CONTAINER_KEY) ??
+      buildBookingRouteRuntime(c.env)
+    )
+  } catch {
+    return buildBookingRouteRuntime(c.env)
+  }
+}
+
+function createAuditedBookingPiiService(c: Context<Env>, bookingId: string) {
+  const runtime = getRouteRuntime(c)
+
+  return createBookingPiiService({
+    kms: runtime.getKmsProvider(),
+    onAudit: async (event) => {
+      await logBookingPiiAccess(c, {
+        bookingId,
+        participantId: event.participantId,
+        action:
+          event.action === "encrypt"
+            ? "update"
+            : event.action === "decrypt"
+              ? "read"
+              : event.action,
+        outcome: "allowed",
+      })
+    },
+  })
 }
 
 // ==========================================================================
@@ -552,22 +588,7 @@ export const bookingRoutes = new Hono<Env>()
     }
 
     try {
-      const pii = createBookingPiiService({
-        kms: createKmsProviderFromEnv(getRuntimeEnv(c)),
-        onAudit: async (event) => {
-          await logBookingPiiAccess(c, {
-            bookingId: participant.bookingId,
-            participantId: event.participantId,
-            action:
-              event.action === "encrypt"
-                ? "update"
-                : event.action === "decrypt"
-                  ? "read"
-                  : event.action,
-            outcome: "allowed",
-          })
-        },
-      })
+      const pii = createAuditedBookingPiiService(c, participant.bookingId)
       const details = await pii.getParticipantTravelDetails(
         c.get("db"),
         participant.id,
@@ -636,22 +657,7 @@ export const bookingRoutes = new Hono<Env>()
     }
 
     try {
-      const pii = createBookingPiiService({
-        kms: createKmsProviderFromEnv(getRuntimeEnv(c)),
-        onAudit: async (event) => {
-          await logBookingPiiAccess(c, {
-            bookingId: participant.bookingId,
-            participantId: event.participantId,
-            action:
-              event.action === "encrypt"
-                ? "update"
-                : event.action === "decrypt"
-                  ? "read"
-                  : event.action,
-            outcome: "allowed",
-          })
-        },
-      })
+      const pii = createAuditedBookingPiiService(c, participant.bookingId)
       const row = await pii.upsertParticipantTravelDetails(
         c.get("db"),
         participant.id,
@@ -713,22 +719,7 @@ export const bookingRoutes = new Hono<Env>()
     }
 
     try {
-      const pii = createBookingPiiService({
-        kms: createKmsProviderFromEnv(getRuntimeEnv(c)),
-        onAudit: async (event) => {
-          await logBookingPiiAccess(c, {
-            bookingId: participant.bookingId,
-            participantId: event.participantId,
-            action:
-              event.action === "encrypt"
-                ? "update"
-                : event.action === "decrypt"
-                  ? "read"
-                  : event.action,
-            outcome: "allowed",
-          })
-        },
-      })
+      const pii = createAuditedBookingPiiService(c, participant.bookingId)
       const row = await pii.deleteParticipantTravelDetails(
         c.get("db"),
         participant.id,

--- a/packages/bookings/tests/unit/module.test.ts
+++ b/packages/bookings/tests/unit/module.test.ts
@@ -1,0 +1,26 @@
+import { createContainer, createEventBus } from "@voyantjs/core"
+import { describe, expect, it } from "vitest"
+
+import { BOOKING_ROUTE_RUNTIME_CONTAINER_KEY, createBookingsHonoModule } from "../../src/index.js"
+
+describe("createBookingsHonoModule.bootstrap", () => {
+  it("registers the shared bookings route runtime once", async () => {
+    const module = createBookingsHonoModule()
+    const container = createContainer()
+
+    await module.module.bootstrap?.({
+      bindings: {
+        KMS_PROVIDER: "env",
+        KMS_LOCAL_KEY: "test-key",
+      },
+      container,
+      eventBus: createEventBus(),
+    })
+
+    const runtime = container.resolve<{
+      getKmsProvider: () => unknown
+    }>(BOOKING_ROUTE_RUNTIME_CONTAINER_KEY)
+
+    expect(runtime.getKmsProvider).toBeTypeOf("function")
+  })
+})


### PR DESCRIPTION
## Summary
- add a shared bookings route runtime with lazy KMS resolution
- register the bookings route runtime at module bootstrap and reuse it in the PII endpoints
- add a focused bookings module bootstrap test

## Testing
- git diff --check
- pnpm -C packages/bookings lint
- pnpm -C packages/bookings typecheck
- pnpm -C packages/bookings test