### PR TITLE
Bootstrap transactions route runtime

### DIFF
--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -8,6 +8,10 @@ export {
   type UpsertTransactionParticipantIdentityInput,
 } from "./pii.js"
 
+import {
+  buildTransactionsRouteRuntime,
+  TRANSACTIONS_ROUTE_RUNTIME_CONTAINER_KEY,
+} from "./route-runtime.js"
 import { transactionsRoutes } from "./routes.js"
 import { transactionsService } from "./service.js"
 
@@ -37,12 +41,31 @@ export const transactionsModule: Module = {
   linkable: transactionsLinkable,
 }
 
-export const transactionsHonoModule: HonoModule = {
-  module: transactionsModule,
-  routes: transactionsRoutes,
+export function createTransactionsHonoModule(): HonoModule {
+  const module: Module = {
+    ...transactionsModule,
+    bootstrap: ({ bindings, container }) => {
+      container.register(
+        TRANSACTIONS_ROUTE_RUNTIME_CONTAINER_KEY,
+        buildTransactionsRouteRuntime(bindings as Record<string, unknown>),
+      )
+    },
+  }
+
+  return {
+    module,
+    routes: transactionsRoutes,
+  }
 }
 
+export const transactionsHonoModule: HonoModule = createTransactionsHonoModule()
+
 export { transactionsBookingExtension } from "./booking-extension.js"
+export type { TransactionsRouteRuntime } from "./route-runtime.js"
+export {
+  buildTransactionsRouteRuntime,
+  TRANSACTIONS_ROUTE_RUNTIME_CONTAINER_KEY,
+} from "./route-runtime.js"
 export type {
   DecryptedTransactionParticipantIdentity,
   TransactionParticipantIdentity,

--- a/packages/transactions/src/route-runtime.ts
+++ b/packages/transactions/src/route-runtime.ts
@@ -1,0 +1,33 @@
+import { createKmsProviderFromEnv, type KmsProvider } from "@voyantjs/utils"
+
+import type { KmsBindings } from "./routes-shared.js"
+
+export const TRANSACTIONS_ROUTE_RUNTIME_CONTAINER_KEY = "runtime.transactions.routes"
+
+export interface TransactionsRouteRuntime {
+  getKmsProvider(): KmsProvider
+}
+
+function buildRuntimeEnv(bindings: KmsBindings): Record<string, string | undefined> {
+  const processEnv =
+    (
+      globalThis as typeof globalThis & {
+        process?: { env?: Record<string, string | undefined> }
+      }
+    ).process?.env ?? {}
+
+  return {
+    ...processEnv,
+    ...(bindings ?? {}),
+  }
+}
+
+export function buildTransactionsRouteRuntime(bindings: KmsBindings): TransactionsRouteRuntime {
+  const runtimeEnv = buildRuntimeEnv(bindings)
+
+  return {
+    getKmsProvider() {
+      return createKmsProviderFromEnv(runtimeEnv)
+    },
+  }
+}

--- a/packages/transactions/src/routes-shared.ts
+++ b/packages/transactions/src/routes-shared.ts
@@ -1,32 +1,40 @@
-import { createKmsProviderFromEnv } from "@voyantjs/utils"
+import type { ModuleContainer } from "@voyantjs/core"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
 
 import { createTransactionPiiService } from "./pii.js"
+import {
+  buildTransactionsRouteRuntime,
+  TRANSACTIONS_ROUTE_RUNTIME_CONTAINER_KEY,
+  type TransactionsRouteRuntime,
+} from "./route-runtime.js"
 import { transactionPiiAccessLog } from "./schema.js"
 
+export type KmsBindings = Partial<{
+  KMS_PROVIDER: string
+  KMS_ENV_KEY: string
+  KMS_LOCAL_KEY: string
+  GCP_PROJECT_ID: string
+  GCP_SERVICE_ACCOUNT_EMAIL: string
+  GCP_PRIVATE_KEY: string
+  GCP_KMS_KEYRING: string
+  GCP_KMS_LOCATION: string
+  GCP_KMS_PEOPLE_KEY_NAME: string
+  GCP_KMS_INTEGRATIONS_KEY_NAME: string
+  AWS_REGION: string
+  AWS_ACCESS_KEY_ID: string
+  AWS_SECRET_ACCESS_KEY: string
+  AWS_SESSION_TOKEN: string
+  AWS_KMS_ENDPOINT: string
+  AWS_KMS_PEOPLE_KEY_ID: string
+  AWS_KMS_INTEGRATIONS_KEY_ID: string
+}>
+
 export type Env = {
-  Bindings: Partial<{
-    KMS_PROVIDER: string
-    KMS_ENV_KEY: string
-    KMS_LOCAL_KEY: string
-    GCP_PROJECT_ID: string
-    GCP_SERVICE_ACCOUNT_EMAIL: string
-    GCP_PRIVATE_KEY: string
-    GCP_KMS_KEYRING: string
-    GCP_KMS_LOCATION: string
-    GCP_KMS_PEOPLE_KEY_NAME: string
-    GCP_KMS_INTEGRATIONS_KEY_NAME: string
-    AWS_REGION: string
-    AWS_ACCESS_KEY_ID: string
-    AWS_SECRET_ACCESS_KEY: string
-    AWS_SESSION_TOKEN: string
-    AWS_KMS_ENDPOINT: string
-    AWS_KMS_PEOPLE_KEY_ID: string
-    AWS_KMS_INTEGRATIONS_KEY_ID: string
-  }>
+  Bindings: KmsBindings
   Variables: {
     db: PostgresJsDatabase
+    container?: ModuleContainer
     userId?: string
     actor?: "staff" | "customer" | "partner" | "supplier"
     callerType?: "session" | "api_key" | "internal"
@@ -44,20 +52,6 @@ export type Env = {
       parentId: string
       action: "read" | "update" | "delete"
     }) => boolean | Promise<boolean>
-  }
-}
-
-export function getRuntimeEnv(c: Context<Env>) {
-  const processEnv =
-    (
-      globalThis as typeof globalThis & {
-        process?: { env?: Record<string, string | undefined> }
-      }
-    ).process?.env ?? {}
-
-  return {
-    ...processEnv,
-    ...(c.env ?? {}),
   }
 }
 
@@ -163,13 +157,23 @@ export async function authorizeTransactionPiiAccess(
   return { allowed: true as const }
 }
 
+function getRouteRuntime(c: Context<Env>): TransactionsRouteRuntime {
+  const runtime = c.var.container?.resolve<TransactionsRouteRuntime>(
+    TRANSACTIONS_ROUTE_RUNTIME_CONTAINER_KEY,
+  )
+
+  return runtime ?? buildTransactionsRouteRuntime(c.env)
+}
+
 export function createPiiService(
   c: Context<Env>,
   _participantKind: "offer" | "order",
   parentId: string,
 ) {
+  const runtime = getRouteRuntime(c)
+
   return createTransactionPiiService({
-    kms: createKmsProviderFromEnv(getRuntimeEnv(c)),
+    kms: runtime.getKmsProvider(),
     onAudit: async (event) => {
       await logTransactionPiiAccess(c, {
         participantKind: event.participantKind,

--- a/packages/transactions/tests/unit/module.test.ts
+++ b/packages/transactions/tests/unit/module.test.ts
@@ -1,0 +1,29 @@
+import { createContainer, createEventBus } from "@voyantjs/core"
+import { describe, expect, it } from "vitest"
+
+import {
+  createTransactionsHonoModule,
+  TRANSACTIONS_ROUTE_RUNTIME_CONTAINER_KEY,
+} from "../../src/index.js"
+
+describe("createTransactionsHonoModule.bootstrap", () => {
+  it("registers the shared transactions route runtime once", async () => {
+    const module = createTransactionsHonoModule()
+    const container = createContainer()
+
+    await module.module.bootstrap?.({
+      bindings: {
+        KMS_PROVIDER: "env",
+        KMS_LOCAL_KEY: "test-key",
+      },
+      container,
+      eventBus: createEventBus(),
+    })
+
+    const runtime = container.resolve<{
+      getKmsProvider: () => unknown
+    }>(TRANSACTIONS_ROUTE_RUNTIME_CONTAINER_KEY)
+
+    expect(runtime.getKmsProvider).toBeTypeOf("function")
+  })
+})


### PR DESCRIPTION
## Summary
- add a shared lazy transactions route runtime for KMS-backed participant identity access
- register the runtime at Hono module bootstrap and resolve it from the request container first
- cover the bootstrap registration with a focused unit test

## Testing
- git diff --check
- pnpm -C packages/transactions lint
- pnpm -C packages/transactions typecheck
- pnpm -C packages/transactions test
- pnpm test
