### PR TITLE
Bootstrap customer portal route runtime

### DIFF
--- a/packages/customer-portal/src/index.ts
+++ b/packages/customer-portal/src/index.ts
@@ -1,6 +1,10 @@
 import type { Module } from "@voyantjs/core"
 import type { HonoModule } from "@voyantjs/hono/module"
 
+import {
+  buildCustomerPortalRouteRuntime,
+  CUSTOMER_PORTAL_ROUTE_RUNTIME_CONTAINER_KEY,
+} from "./route-runtime.js"
 import { customerPortalRoutes } from "./routes.js"
 import { publicCustomerPortalRoutes } from "./routes-public.js"
 
@@ -64,8 +68,27 @@ export const customerPortalModule: Module = {
   name: "customer-portal",
 }
 
-export const customerPortalHonoModule: HonoModule = {
-  module: customerPortalModule,
-  routes: customerPortalRoutes,
-  publicRoutes: publicCustomerPortalRoutes,
+export function createCustomerPortalHonoModule(): HonoModule {
+  const module: Module = {
+    ...customerPortalModule,
+    bootstrap: ({ bindings, container }) => {
+      container.register(
+        CUSTOMER_PORTAL_ROUTE_RUNTIME_CONTAINER_KEY,
+        buildCustomerPortalRouteRuntime(bindings as Record<string, unknown>),
+      )
+    },
+  }
+
+  return {
+    module,
+    routes: customerPortalRoutes,
+    publicRoutes: publicCustomerPortalRoutes,
+  }
 }
+
+export const customerPortalHonoModule: HonoModule = createCustomerPortalHonoModule()
+export type { CustomerPortalRouteRuntime } from "./route-runtime.js"
+export {
+  buildCustomerPortalRouteRuntime,
+  CUSTOMER_PORTAL_ROUTE_RUNTIME_CONTAINER_KEY,
+} from "./route-runtime.js"

--- a/packages/customer-portal/src/route-runtime.ts
+++ b/packages/customer-portal/src/route-runtime.ts
@@ -1,0 +1,37 @@
+import { createKmsProviderFromEnv, type KmsProvider } from "@voyantjs/utils"
+
+export const CUSTOMER_PORTAL_ROUTE_RUNTIME_CONTAINER_KEY = "runtime.customer-portal.routes"
+
+type KmsBindings = Record<string, unknown>
+
+export interface CustomerPortalRouteRuntime {
+  getOptionalKmsProvider(): KmsProvider | null
+}
+
+function buildRuntimeEnv(bindings: KmsBindings): Record<string, string | undefined> {
+  const processEnv =
+    (
+      globalThis as typeof globalThis & {
+        process?: { env?: Record<string, string | undefined> }
+      }
+    ).process?.env ?? {}
+
+  return {
+    ...processEnv,
+    ...(bindings ?? {}),
+  } as Record<string, string | undefined>
+}
+
+export function buildCustomerPortalRouteRuntime(bindings: KmsBindings): CustomerPortalRouteRuntime {
+  const runtimeEnv = buildRuntimeEnv(bindings)
+
+  return {
+    getOptionalKmsProvider() {
+      try {
+        return createKmsProviderFromEnv(runtimeEnv)
+      } catch {
+        return null
+      }
+    },
+  }
+}

--- a/packages/customer-portal/src/routes-public.ts
+++ b/packages/customer-portal/src/routes-public.ts
@@ -1,8 +1,13 @@
+import type { ModuleContainer } from "@voyantjs/core"
 import { parseJsonBody } from "@voyantjs/hono"
-import { createKmsProviderFromEnv } from "@voyantjs/utils"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { type Context, Hono } from "hono"
 
+import {
+  buildCustomerPortalRouteRuntime,
+  CUSTOMER_PORTAL_ROUTE_RUNTIME_CONTAINER_KEY,
+  type CustomerPortalRouteRuntime,
+} from "./route-runtime.js"
 import { publicCustomerPortalService } from "./service-public.js"
 import {
   bootstrapCustomerPortalSchema,
@@ -16,26 +21,17 @@ type Env = {
   Bindings: Record<string, unknown>
   Variables: {
     db: PostgresJsDatabase
+    container?: ModuleContainer
     userId?: string
   }
 }
 
-function getRuntimeEnv(c: Context<Env>) {
-  const processEnv =
-    (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? {}
-
-  return {
-    ...processEnv,
-    ...(c.env ?? {}),
-  } as Record<string, string | undefined>
-}
-
 function resolveOptionalKms(c: Context<Env>) {
-  try {
-    return createKmsProviderFromEnv(getRuntimeEnv(c))
-  } catch {
-    return null
-  }
+  const runtime = c.var.container?.resolve<CustomerPortalRouteRuntime>(
+    CUSTOMER_PORTAL_ROUTE_RUNTIME_CONTAINER_KEY,
+  )
+
+  return (runtime ?? buildCustomerPortalRouteRuntime(c.env)).getOptionalKmsProvider()
 }
 
 function unauthorized<T extends Env>(c: Context<T>) {

--- a/packages/customer-portal/tests/unit/module.test.ts
+++ b/packages/customer-portal/tests/unit/module.test.ts
@@ -1,0 +1,29 @@
+import { createContainer, createEventBus } from "@voyantjs/core"
+import { describe, expect, it } from "vitest"
+
+import {
+  createCustomerPortalHonoModule,
+  CUSTOMER_PORTAL_ROUTE_RUNTIME_CONTAINER_KEY,
+} from "../../src/index.js"
+
+describe("createCustomerPortalHonoModule.bootstrap", () => {
+  it("registers the shared customer portal route runtime once", async () => {
+    const module = createCustomerPortalHonoModule()
+    const container = createContainer()
+
+    await module.module.bootstrap?.({
+      bindings: {
+        KMS_PROVIDER: "env",
+        KMS_LOCAL_KEY: "test-key",
+      },
+      container,
+      eventBus: createEventBus(),
+    })
+
+    const runtime = container.resolve<{
+      getOptionalKmsProvider: () => unknown
+    }>(CUSTOMER_PORTAL_ROUTE_RUNTIME_CONTAINER_KEY)
+
+    expect(runtime.getOptionalKmsProvider).toBeTypeOf("function")
+  })
+})


### PR DESCRIPTION
## Summary
- add a shared lazy customer portal route runtime for optional KMS-backed profile reads
- register the runtime at Hono module bootstrap and resolve it from the request container first
- cover the bootstrap registration with a focused unit test

## Testing
- git diff --check
- pnpm -C packages/customer-portal lint
- pnpm -C packages/customer-portal typecheck
- pnpm -C packages/customer-portal test
- pnpm test
