### PR TITLE
Await shared route parsers in external refs routes

### DIFF
--- a/packages/external-refs/src/routes.ts
+++ b/packages/external-refs/src/routes.ts
@@ -19,7 +19,7 @@ type Env = {
 
 export const externalRefsRoutes = new Hono<Env>()
   .get("/refs", async (c) => {
-    const query = parseQuery(c, externalRefListQuerySchema)
+    const query = await parseQuery(c, externalRefListQuerySchema)
     return c.json(await externalRefsService.listExternalRefs(c.get("db"), query))
   })
   .post("/refs", async (c) => {
@@ -55,7 +55,7 @@ export const externalRefsRoutes = new Hono<Env>()
   .get("/entities/:entityType/:entityId/refs", async (c) => {
     const params = c.req.param()
     const query = externalRefListQuerySchema.parse({
-      ...parseQuery(c, externalRefListQuerySchema.partial()),
+      ...(await parseQuery(c, externalRefListQuerySchema.partial())),
       entityType: params.entityType,
       entityId: params.entityId,
     })


### PR DESCRIPTION
## Summary
- await the shared Hono query parser in external ref list routes
- await the partial shared query parser before overlaying entity-scoped params
- keep external refs aligned with the parser-adoption transport cleanup

## Testing
- git diff --check
- pnpm -C packages/external-refs lint
- pnpm -C packages/external-refs typecheck
- pnpm -C packages/external-refs test
- full repo pre-push suite
