### PR TITLE
Use shared route parsers in booking status routes

### DIFF
--- a/packages/bookings/src/routes.ts
+++ b/packages/bookings/src/routes.ts
@@ -374,7 +374,7 @@ export const bookingRoutes = new Hono<Env>()
     const result = await bookingsService.updateBookingStatus(
       c.get("db"),
       c.req.param("id"),
-      updateBookingStatusSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateBookingStatusSchema),
       c.get("userId"),
     )
 
@@ -398,7 +398,7 @@ export const bookingRoutes = new Hono<Env>()
     const result = await bookingsService.confirmBooking(
       c.get("db"),
       c.req.param("id"),
-      confirmBookingSchema.parse(await c.req.json()),
+      await parseJsonBody(c, confirmBookingSchema),
       c.get("userId"),
     )
 
@@ -426,7 +426,7 @@ export const bookingRoutes = new Hono<Env>()
     const result = await bookingsService.extendBookingHold(
       c.get("db"),
       c.req.param("id"),
-      extendBookingHoldSchema.parse(await c.req.json()),
+      await parseJsonBody(c, extendBookingHoldSchema),
       c.get("userId"),
     )
 
@@ -454,7 +454,7 @@ export const bookingRoutes = new Hono<Env>()
     const result = await bookingsService.expireBooking(
       c.get("db"),
       c.req.param("id"),
-      expireBookingSchema.parse(await c.req.json()),
+      await parseJsonBody(c, expireBookingSchema),
       c.get("userId"),
     )
 
@@ -478,7 +478,7 @@ export const bookingRoutes = new Hono<Env>()
     return c.json(
       await bookingsService.expireStaleBookings(
         c.get("db"),
-        expireStaleBookingsSchema.parse(await c.req.json()),
+        await parseJsonBody(c, expireStaleBookingsSchema),
         c.get("userId"),
       ),
     )
@@ -489,7 +489,7 @@ export const bookingRoutes = new Hono<Env>()
     const result = await bookingsService.cancelBooking(
       c.get("db"),
       c.req.param("id"),
-      cancelBookingSchema.parse(await c.req.json()),
+      await parseJsonBody(c, cancelBookingSchema),
       c.get("userId"),
     )
 


### PR DESCRIPTION
## Summary
- use the shared Hono body parser for booking status transition routes
- cover confirm, extend-hold, expire, expire-stale, and cancel
- leave participant and PII routes for a later bounded pass

## Testing
- git diff --check
- pnpm -C packages/bookings lint
- pnpm -C packages/bookings typecheck
- pnpm -C packages/bookings test
- full repo pre-push suite
