### PR TITLE
Use shared parser in booking travel details route

### DIFF
--- a/packages/bookings/src/routes.ts
+++ b/packages/bookings/src/routes.ts
@@ -1,3 +1,4 @@
+import { parseJsonBody } from "@voyantjs/hono"
 import { type Context, Hono } from "hono"
 
 import { createBookingPiiService } from "./pii.js"
@@ -661,7 +662,7 @@ export const bookingRoutes = new Hono<Env>()
       const row = await pii.upsertParticipantTravelDetails(
         c.get("db"),
         participant.id,
-        upsertParticipantTravelDetailsSchema.parse(await c.req.json()),
+        await parseJsonBody(c, upsertParticipantTravelDetailsSchema),
         c.get("userId"),
       )
 


### PR DESCRIPTION
## Summary
- switch the encrypted booking travel-details write route to the shared Hono body parser
- keep the change stacked on the bookings KMS/runtime branch instead of mixing it into the broader route-helper chain
- preserve the existing travel-details authorization and runtime behavior

## Testing
- git diff --check
- pnpm -C packages/bookings lint
- pnpm -C packages/bookings typecheck
- pnpm -C packages/bookings test