### PR TITLE
Use shared route parsers in CRM booking extension

### DIFF
--- a/packages/crm/src/booking-extension.ts
+++ b/packages/crm/src/booking-extension.ts
@@ -1,4 +1,5 @@
 import type { Extension } from "@voyantjs/core"
+import { parseJsonBody } from "@voyantjs/hono"
 import type { HonoExtension } from "@voyantjs/hono/module"
 import { eq } from "drizzle-orm"
 import { index, pgTable, text, timestamp } from "drizzle-orm/pg-core"
@@ -95,7 +96,7 @@ const bookingCrmExtensionRoutes = new Hono<Env>()
   })
 
   .put("/:bookingId/crm-details", async (c) => {
-    const data = bookingCrmDetailSchema.parse(await c.req.json())
+    const data = await parseJsonBody(c, bookingCrmDetailSchema)
     const row = await bookingCrmExtensionService.upsert(c.get("db"), c.req.param("bookingId"), data)
     return c.json({ data: row })
   })


### PR DESCRIPTION
## Summary
- switch the CRM booking extension write route to the shared Hono body parser
- keep booking-linked extension transport aligned with the framework conventions
- preserve existing CRM detail upsert behavior while removing manual JSON parsing

## Testing
- git diff --check
- pnpm -C packages/crm lint
- pnpm -C packages/crm typecheck
- pnpm -C packages/crm test