### PR TITLE
Use shared route parsers in transactions booking extension

### DIFF
--- a/packages/transactions/src/booking-extension.ts
+++ b/packages/transactions/src/booking-extension.ts
@@ -1,4 +1,5 @@
 import type { Extension } from "@voyantjs/core"
+import { parseJsonBody } from "@voyantjs/hono"
 import type { HonoExtension } from "@voyantjs/hono/module"
 import { eq } from "drizzle-orm"
 import { index, pgTable, text, timestamp } from "drizzle-orm/pg-core"
@@ -95,7 +96,7 @@ const bookingTransactionExtensionRoutes = new Hono<Env>()
   })
 
   .put("/:bookingId/transaction-details", async (c) => {
-    const data = bookingTransactionDetailSchema.parse(await c.req.json())
+    const data = await parseJsonBody(c, bookingTransactionDetailSchema)
     const row = await bookingTransactionExtensionService.upsert(
       c.get("db"),
       c.req.param("bookingId"),


### PR DESCRIPTION
## Summary
- switch the transactions booking extension write route to the shared Hono body parser
- keep booking-linked extension transport aligned across packages
- preserve existing transaction detail upsert behavior while removing manual JSON parsing

## Testing
- git diff --check
- pnpm -C packages/transactions lint
- pnpm -C packages/transactions typecheck
- pnpm -C packages/transactions test