### PR TITLE
Use shared route parsers in products booking extension

### DIFF
--- a/packages/products/src/booking-extension.ts
+++ b/packages/products/src/booking-extension.ts
@@ -1,4 +1,5 @@
 import type { Extension } from "@voyantjs/core"
+import { parseJsonBody } from "@voyantjs/hono"
 import type { HonoExtension } from "@voyantjs/hono/module"
 import { eq } from "drizzle-orm"
 import { index, pgTable, text, timestamp } from "drizzle-orm/pg-core"
@@ -172,7 +173,7 @@ const bookingProductExtensionRoutes = new Hono<Env>()
   })
 
   .put("/:bookingId/product-details", async (c) => {
-    const data = bookingProductDetailSchema.parse(await c.req.json())
+    const data = await parseJsonBody(c, bookingProductDetailSchema)
     const row = await bookingProductExtensionService.upsertBookingDetails(
       c.get("db"),
       c.req.param("bookingId"),
@@ -204,7 +205,7 @@ const bookingProductExtensionRoutes = new Hono<Env>()
   })
 
   .put("/:bookingId/items/:itemId/product-details", async (c) => {
-    const data = bookingItemProductDetailSchema.parse(await c.req.json())
+    const data = await parseJsonBody(c, bookingItemProductDetailSchema)
     const row = await bookingProductExtensionService.upsertItemDetails(
       c.get("db"),
       c.req.param("itemId"),


### PR DESCRIPTION
## Summary
- switch the products booking extension write routes to the shared Hono body parser
- keep booking-linked extension transport aligned across packages
- preserve existing booking and booking-item product detail upsert behavior while removing manual JSON parsing

## Testing
- git diff --check
- pnpm -C packages/products lint
- pnpm -C packages/products typecheck
- pnpm -C packages/products test