### PR TITLE
Adopt Hono bundle aliases in Netopia plugin

### DIFF
--- a/packages/plugins/netopia/src/index.ts
+++ b/packages/plugins/netopia/src/index.ts
@@ -10,6 +10,7 @@ export {
   createNetopiaFinanceRoutes,
   NETOPIA_RUNTIME_CONTAINER_KEY,
   netopiaFinanceExtension,
+  netopiaHonoBundle,
   netopiaHonoPlugin,
 } from "./plugin.js"
 export {

--- a/packages/plugins/netopia/src/plugin.ts
+++ b/packages/plugins/netopia/src/plugin.ts
@@ -1,5 +1,5 @@
 import type { Extension, ModuleContainer } from "@voyantjs/core"
-import { defineHonoPlugin, type HonoPlugin, parseJsonBody } from "@voyantjs/hono"
+import { defineHonoBundle, type HonoBundle, parseJsonBody } from "@voyantjs/hono"
 import type { HonoExtension } from "@voyantjs/hono/module"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
@@ -199,8 +199,8 @@ export function createNetopiaFinanceExtension(options: NetopiaRuntimeOptions = {
   }
 }
 
-export function netopiaHonoPlugin(options: NetopiaRuntimeOptions = {}): HonoPlugin {
-  return defineHonoPlugin({
+export function netopiaHonoBundle(options: NetopiaRuntimeOptions = {}): HonoBundle {
+  return defineHonoBundle({
     name: "netopia",
     version: "0.1.0",
     bootstrap: ({ bindings, container }) => {
@@ -212,5 +212,8 @@ export function netopiaHonoPlugin(options: NetopiaRuntimeOptions = {}): HonoPlug
     extensions: [createNetopiaFinanceExtension(options)],
   })
 }
+
+/** @deprecated Prefer {@link netopiaHonoBundle}. */
+export const netopiaHonoPlugin = netopiaHonoBundle
 
 export const netopiaFinanceExtension = createNetopiaFinanceExtension()

--- a/packages/plugins/netopia/tests/unit/plugin.test.ts
+++ b/packages/plugins/netopia/tests/unit/plugin.test.ts
@@ -3,7 +3,11 @@ import { financeService, type PaymentSession } from "@voyantjs/finance"
 import { notificationsService } from "@voyantjs/notifications"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import type { NetopiaClientApi } from "../../src/client.js"
-import { NETOPIA_RUNTIME_CONTAINER_KEY, netopiaHonoPlugin } from "../../src/plugin.js"
+import {
+  NETOPIA_RUNTIME_CONTAINER_KEY,
+  netopiaHonoBundle,
+  netopiaHonoPlugin,
+} from "../../src/plugin.js"
 import { deriveNetopiaOrderId, mapNetopiaPaymentStatus, netopiaService } from "../../src/service.js"
 import * as startService from "../../src/service-start.js"
 
@@ -77,6 +81,11 @@ afterEach(() => {
 })
 
 describe("netopiaHonoPlugin.bootstrap", () => {
+  it("exposes the bundle alias", () => {
+    const bundle = netopiaHonoBundle()
+    expect(bundle.name).toBe("netopia")
+  })
+
   it("validates and registers the resolved runtime once", async () => {
     const plugin = netopiaHonoPlugin({
       apiUrl: "https://secure.mobilpay.ro/pay",


### PR DESCRIPTION
Summary:
- switch Netopia to the preferred HonoBundle and defineHonoBundle surface
- keep netopiaHonoPlugin as a compatibility alias
- export and cover the new netopiaHonoBundle helper

Testing:
- git diff --check
- pnpm -C packages/plugins/netopia lint
- pnpm -C packages/plugins/netopia typecheck
- pnpm -C packages/plugins/netopia test
- full repo pre-push suite