### PR TITLE
Use shared route parsers in finance booking item routes

### DIFF
--- a/packages/finance/src/routes.ts
+++ b/packages/finance/src/routes.ts
@@ -473,7 +473,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.createBookingItemTaxLine(
       c.get("db"),
       c.req.param("bookingItemId"),
-      insertBookingItemTaxLineSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertBookingItemTaxLineSchema),
     )
 
     if (!row) {
@@ -487,7 +487,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.updateBookingItemTaxLine(
       c.get("db"),
       c.req.param("taxLineId"),
-      updateBookingItemTaxLineSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateBookingItemTaxLineSchema),
     )
 
     if (!row) {
@@ -524,7 +524,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.createBookingItemCommission(
       c.get("db"),
       c.req.param("bookingItemId"),
-      insertBookingItemCommissionSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertBookingItemCommissionSchema),
     )
 
     if (!row) {
@@ -538,7 +538,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.updateBookingItemCommission(
       c.get("db"),
       c.req.param("commissionId"),
-      updateBookingItemCommissionSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateBookingItemCommissionSchema),
     )
 
     if (!row) {


### PR DESCRIPTION
Summary:
- move finance booking item tax-line and commission writes onto the shared Hono body parser
- replace the remaining direct c.req.json parsing in that bounded section of packages/finance/src/routes.ts
- leave supplier payments and invoices for later slices

Testing:
- git diff --check
- pnpm -C packages/finance lint
- pnpm -C packages/finance typecheck
- pnpm -C packages/finance test
- full repo pre-push suite