### PR TITLE
Use shared body parsing in manual booking create route

### DIFF
--- a/packages/bookings/src/routes.ts
+++ b/packages/bookings/src/routes.ts
@@ -1,6 +1,7 @@
 import { parseJsonBody, parseQuery } from "@voyantjs/hono"
 import { createKmsProviderFromEnv } from "@voyantjs/utils"
 import { type Context, Hono } from "hono"
+import { z } from "zod"
 
 import { createBookingPiiService } from "./pii.js"
 import { bookingGroupRoutes } from "./routes-groups.js"
@@ -318,7 +319,7 @@ export const bookingRoutes = new Hono<Env>()
 
   // 4. POST / — Create booking (manual/backoffice only)
   .post("/", async (c) => {
-    const payload = await c.req.json()
+    const payload = await parseJsonBody(c, z.unknown())
     const parsed = createBookingSchema.safeParse(payload)
 
     if (!parsed.success) {


### PR DESCRIPTION
Summary:
- route the manual backoffice booking-create endpoint through the shared Hono JSON parser
- keep the existing createBookingSchema.safeParse path so the custom validation response shape stays intact
- leave the encrypted travel-details route on its separate KMS-focused cleanup chain

Testing:
- git diff --check
- pnpm -C packages/bookings lint
- pnpm -C packages/bookings typecheck
- pnpm -C packages/bookings test
- full repo pre-push suite