### PR TITLE
Use shared optional body parsing in product version route

### DIFF
--- a/packages/products/src/routes.ts
+++ b/packages/products/src/routes.ts
@@ -1,4 +1,4 @@
-import { parseJsonBody, parseQuery } from "@voyantjs/hono"
+import { parseJsonBody, parseOptionalJsonBody, parseQuery } from "@voyantjs/hono"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
 import { z } from "zod"
@@ -1384,7 +1384,7 @@ export const productRoutes = new Hono<Env>()
       c.get("db"),
       c.req.param("id"),
       userId,
-      insertVersionSchema.parse(await c.req.json().catch(() => ({}))),
+      await parseOptionalJsonBody(c, insertVersionSchema),
     )
 
     if (!row) {


### PR DESCRIPTION
Summary:
- move the product version snapshot route onto the shared optional Hono body parser
- keep the existing route behavior where an empty body is allowed and normalized through the schema
- finish the remaining optional-empty-body transport cleanup in packages/products/src/routes.ts

Testing:
- git diff --check
- pnpm -C packages/products lint
- pnpm -C packages/products typecheck
- pnpm -C packages/products test
- full repo pre-push suite