### PR TITLE
Use shared optional body parsing in contract document routes

### DIFF
--- a/packages/legal/src/contracts/routes.ts
+++ b/packages/legal/src/contracts/routes.ts
@@ -1,5 +1,5 @@
 import type { EventBus } from "@voyantjs/core"
-import { parseJsonBody, parseQuery } from "@voyantjs/hono"
+import { parseJsonBody, parseOptionalJsonBody, parseQuery } from "@voyantjs/hono"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
 
@@ -243,7 +243,7 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
       const result = await contractsService.generateContractDocument(
         c.get("db"),
         c.req.param("id"),
-        generateContractDocumentInputSchema.parse(await c.req.json().catch(() => ({}))),
+        await parseOptionalJsonBody(c, generateContractDocumentInputSchema),
         { generator, bindings: c.env, eventBus: resolveEventBus(options, c.env) },
       )
 
@@ -272,7 +272,7 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
       const result = await contractsService.regenerateContractDocument(
         c.get("db"),
         c.req.param("id"),
-        generateContractDocumentInputSchema.parse(await c.req.json().catch(() => ({}))),
+        await parseOptionalJsonBody(c, generateContractDocumentInputSchema),
         { generator, bindings: c.env, eventBus: resolveEventBus(options, c.env) },
       )
 


### PR DESCRIPTION
Summary:
- move the contract document generation endpoints onto the shared optional Hono body parser
- replace the remaining c.req.json().catch(() => ({})) calls in packages/legal/src/contracts/routes.ts
- keep the existing optional-empty-body route behavior unchanged

Testing:
- git diff --check
- pnpm -C packages/legal lint
- pnpm -C packages/legal typecheck
- pnpm -C packages/legal test
- full repo pre-push suite