### PR TITLE
Use shared route parsers in checkout routes

### DIFF
--- a/packages/checkout/src/routes.ts
+++ b/packages/checkout/src/routes.ts
@@ -1,4 +1,5 @@
 import type { Module } from "@voyantjs/core"
+import { parseJsonBody, parseOptionalJsonBody, parseQuery } from "@voyantjs/hono"
 import type { HonoModule } from "@voyantjs/hono/module"
 import type { NotificationProvider } from "@voyantjs/notifications"
 import { createNotificationService } from "@voyantjs/notifications"
@@ -59,7 +60,7 @@ export function createCheckoutRoutes(
         const plan = await previewCheckoutCollection(
           c.get("db"),
           c.req.param("bookingId"),
-          previewCheckoutCollectionSchema.parse(await c.req.json().catch(() => ({}))),
+          await parseOptionalJsonBody(c, previewCheckoutCollectionSchema),
           options.policy,
         )
 
@@ -82,7 +83,7 @@ export function createCheckoutRoutes(
         const result = await initiateCheckoutCollection(
           c.get("db"),
           c.req.param("bookingId"),
-          initiateCheckoutCollectionSchema.parse(await c.req.json()),
+          await parseJsonBody(c, initiateCheckoutCollectionSchema),
           options.policy,
           dispatcher,
           createCheckoutRuntime(c.env),
@@ -109,7 +110,7 @@ export function createCheckoutRoutes(
         )
         const result = await bootstrapCheckoutCollection(
           c.get("db"),
-          bootstrapCheckoutCollectionSchema.parse(await c.req.json()),
+          await parseJsonBody(c, bootstrapCheckoutCollectionSchema),
           options.policy,
           dispatcher,
           createCheckoutRuntime(c.env),
@@ -133,9 +134,7 @@ export function createCheckoutRoutes(
 
 export function createCheckoutAdminRoutes() {
   return new Hono<Env>().get("/bookings/:bookingId/reminder-runs", async (c) => {
-    const query = checkoutReminderRunListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = await parseQuery(c, checkoutReminderRunListQuerySchema)
 
     return c.json(await listBookingReminderRuns(c.get("db"), c.req.param("bookingId"), query))
   })


### PR DESCRIPTION
## Summary
- move checkout collection preview/initiation/bootstrap routes onto the shared Hono body parsers
- move the admin reminder-run list route onto the shared query parser
- keep optional-empty-body preview behavior unchanged via `parseOptionalJsonBody`

## Testing
- git diff --check
- pnpm -C packages/checkout lint
- pnpm -C packages/checkout typecheck
- pnpm -C packages/checkout test
- full repo pre-push suite