### PR TITLE
Use shared route parsers in remaining admin routes

### DIFF
--- a/packages/bookings/src/routes.ts
+++ b/packages/bookings/src/routes.ts
@@ -1,6 +1,7 @@
 import {
   ForbiddenApiError,
   handleApiError,
+  normalizeValidationError,
   parseJsonBody,
   parseQuery,
   requireUserId,
@@ -370,25 +371,34 @@ export const bookingRoutes = new Hono<Env>()
 
   // 4. POST / — Create booking (manual/backoffice only)
   .post("/", async (c) => {
-    const payload = await c.req.json()
-    const parsed = createBookingSchema.safeParse(payload)
-
-    if (!parsed.success) {
+    try {
       return c.json(
         {
-          error: parsed.error.issues[0]?.message ?? "Invalid booking create payload",
-          details: parsed.error.flatten(),
+          data: await bookingsService.createBooking(
+            c.get("db"),
+            await parseJsonBody(c, createBookingSchema, {
+              invalidBodyMessage: "Invalid booking create payload",
+            }),
+            c.get("userId"),
+          ),
         },
-        400,
+        201,
       )
-    }
+    } catch (error) {
+      const validationError = normalizeValidationError(error)
 
-    return c.json(
-      {
-        data: await bookingsService.createBooking(c.get("db"), parsed.data, c.get("userId")),
-      },
-      201,
-    )
+      if (validationError?.status === 400) {
+        return c.json(
+          {
+            error: validationError.message,
+            details: validationError.details?.fields ?? validationError.details,
+          },
+          400,
+        )
+      }
+
+      throw error
+    }
   })
 
   // 5. PATCH /:id — Update booking

--- a/packages/bookings/src/routes.ts
+++ b/packages/bookings/src/routes.ts
@@ -254,7 +254,7 @@ export const bookingRoutes = new Hono<Env>()
   .post("/reserve", async (c) => {
     const result = await bookingsService.reserveBooking(
       c.get("db"),
-      reserveBookingSchema.parse(await c.req.json()),
+      await parseJsonBody(c, reserveBookingSchema),
       c.get("userId"),
     )
 
@@ -285,7 +285,7 @@ export const bookingRoutes = new Hono<Env>()
   .post("/from-product", async (c) => {
     const row = await bookingsService.createBookingFromProduct(
       c.get("db"),
-      convertProductSchema.parse(await c.req.json()),
+      await parseJsonBody(c, convertProductSchema),
       c.get("userId"),
     )
 
@@ -301,7 +301,7 @@ export const bookingRoutes = new Hono<Env>()
     const result = await bookingsService.reserveBookingFromOffer(
       c.get("db"),
       c.req.param("offerId"),
-      reserveBookingFromTransactionSchema.parse(await c.req.json()),
+      await parseJsonBody(c, reserveBookingFromTransactionSchema),
       c.get("userId"),
     )
 
@@ -337,7 +337,7 @@ export const bookingRoutes = new Hono<Env>()
     const result = await bookingsService.reserveBookingFromOrder(
       c.get("db"),
       c.req.param("orderId"),
-      reserveBookingFromTransactionSchema.parse(await c.req.json()),
+      await parseJsonBody(c, reserveBookingFromTransactionSchema),
       c.get("userId"),
     )
 
@@ -396,7 +396,7 @@ export const bookingRoutes = new Hono<Env>()
     const row = await bookingsService.updateBooking(
       c.get("db"),
       c.req.param("id"),
-      updateBookingSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateBookingSchema),
     )
 
     if (!row) {
@@ -426,7 +426,7 @@ export const bookingRoutes = new Hono<Env>()
     const result = await bookingsService.updateBookingStatus(
       c.get("db"),
       c.req.param("id"),
-      updateBookingStatusSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateBookingStatusSchema),
       c.get("userId"),
     )
 
@@ -450,7 +450,7 @@ export const bookingRoutes = new Hono<Env>()
     const result = await bookingsService.confirmBooking(
       c.get("db"),
       c.req.param("id"),
-      confirmBookingSchema.parse(await c.req.json()),
+      await parseJsonBody(c, confirmBookingSchema),
       c.get("userId"),
     )
 
@@ -478,7 +478,7 @@ export const bookingRoutes = new Hono<Env>()
     const result = await bookingsService.extendBookingHold(
       c.get("db"),
       c.req.param("id"),
-      extendBookingHoldSchema.parse(await c.req.json()),
+      await parseJsonBody(c, extendBookingHoldSchema),
       c.get("userId"),
     )
 
@@ -506,7 +506,7 @@ export const bookingRoutes = new Hono<Env>()
     const result = await bookingsService.expireBooking(
       c.get("db"),
       c.req.param("id"),
-      expireBookingSchema.parse(await c.req.json()),
+      await parseJsonBody(c, expireBookingSchema),
       c.get("userId"),
     )
 
@@ -530,7 +530,7 @@ export const bookingRoutes = new Hono<Env>()
     return c.json(
       await bookingsService.expireStaleBookings(
         c.get("db"),
-        expireStaleBookingsSchema.parse(await c.req.json()),
+        await parseJsonBody(c, expireStaleBookingsSchema),
         c.get("userId"),
       ),
     )
@@ -541,7 +541,7 @@ export const bookingRoutes = new Hono<Env>()
     const result = await bookingsService.cancelBooking(
       c.get("db"),
       c.req.param("id"),
-      cancelBookingSchema.parse(await c.req.json()),
+      await parseJsonBody(c, cancelBookingSchema),
       c.get("userId"),
     )
 
@@ -632,7 +632,7 @@ export const bookingRoutes = new Hono<Env>()
     const row = await bookingsService.createParticipant(
       c.get("db"),
       c.req.param("id"),
-      insertParticipantSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertParticipantSchema),
       c.get("userId"),
     )
 
@@ -695,7 +695,7 @@ export const bookingRoutes = new Hono<Env>()
     const row = await bookingsService.updateParticipant(
       c.get("db"),
       c.req.param("participantId"),
-      updateParticipantSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateParticipantSchema),
     )
 
     if (!row) {
@@ -776,7 +776,7 @@ export const bookingRoutes = new Hono<Env>()
     const row = await bookingsService.createPassenger(
       c.get("db"),
       c.req.param("id"),
-      insertPassengerSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertPassengerSchema),
       c.get("userId"),
     )
 
@@ -792,7 +792,7 @@ export const bookingRoutes = new Hono<Env>()
     const row = await bookingsService.updatePassenger(
       c.get("db"),
       c.req.param("passengerId"),
-      updatePassengerSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updatePassengerSchema),
     )
 
     if (!row) {
@@ -827,7 +827,7 @@ export const bookingRoutes = new Hono<Env>()
     const row = await bookingsService.createItem(
       c.get("db"),
       c.req.param("id"),
-      insertBookingItemSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertBookingItemSchema),
       c.get("userId"),
     )
 
@@ -843,7 +843,7 @@ export const bookingRoutes = new Hono<Env>()
     const row = await bookingsService.updateItem(
       c.get("db"),
       c.req.param("itemId"),
-      updateBookingItemSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateBookingItemSchema),
     )
 
     if (!row) {
@@ -876,7 +876,7 @@ export const bookingRoutes = new Hono<Env>()
     const row = await bookingsService.addItemParticipant(
       c.get("db"),
       c.req.param("itemId"),
-      insertBookingItemParticipantSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertBookingItemParticipantSchema),
     )
 
     if (!row) {
@@ -911,7 +911,7 @@ export const bookingRoutes = new Hono<Env>()
     const row = await bookingsService.createSupplierStatus(
       c.get("db"),
       c.req.param("id"),
-      insertSupplierStatusSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertSupplierStatusSchema),
       c.get("userId"),
     )
 
@@ -927,7 +927,7 @@ export const bookingRoutes = new Hono<Env>()
       c.get("db"),
       c.req.param("id"),
       c.req.param("statusId"),
-      updateSupplierStatusSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateSupplierStatusSchema),
       c.get("userId"),
     )
 
@@ -950,7 +950,7 @@ export const bookingRoutes = new Hono<Env>()
     const row = await bookingsService.issueFulfillment(
       c.get("db"),
       c.req.param("id"),
-      insertBookingFulfillmentSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertBookingFulfillmentSchema),
       c.get("userId"),
     )
 
@@ -966,7 +966,7 @@ export const bookingRoutes = new Hono<Env>()
       c.get("db"),
       c.req.param("id"),
       c.req.param("fulfillmentId"),
-      updateBookingFulfillmentSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateBookingFulfillmentSchema),
       c.get("userId"),
     )
 
@@ -991,7 +991,7 @@ export const bookingRoutes = new Hono<Env>()
     const row = await bookingsService.recordRedemption(
       c.get("db"),
       c.req.param("id"),
-      recordBookingRedemptionSchema.parse(await c.req.json()),
+      await parseJsonBody(c, recordBookingRedemptionSchema),
       c.get("userId"),
     )
 
@@ -1060,7 +1060,7 @@ export const bookingRoutes = new Hono<Env>()
     const row = await bookingsService.createDocument(
       c.get("db"),
       c.req.param("id"),
-      insertBookingDocumentSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertBookingDocumentSchema),
     )
 
     if (!row) {

--- a/packages/bookings/src/routes.ts
+++ b/packages/bookings/src/routes.ts
@@ -2,6 +2,7 @@ import {
   ForbiddenApiError,
   handleApiError,
   parseJsonBody,
+  parseQuery,
   requireUserId,
   UnauthorizedApiError,
 } from "@voyantjs/hono"
@@ -220,7 +221,7 @@ export const bookingRoutes = new Hono<Env>()
 
   // 1. GET / — List bookings
   .get("/", async (c) => {
-    const query = bookingListQuerySchema.parse(Object.fromEntries(new URL(c.req.url).searchParams))
+    const query = parseQuery(c, bookingListQuerySchema)
     return c.json(await bookingsService.listBookings(c.get("db"), query))
   })
 
@@ -228,9 +229,7 @@ export const bookingRoutes = new Hono<Env>()
   .get("/overview", async (c) => {
     const overview = await publicBookingsService.getOverviewByLookup(
       c.get("db"),
-      internalBookingOverviewLookupQuerySchema.parse(
-        Object.fromEntries(new URL(c.req.url).searchParams),
-      ),
+      parseQuery(c, internalBookingOverviewLookupQuerySchema),
     )
 
     if (!overview) {

--- a/packages/crm/src/routes/accounts.ts
+++ b/packages/crm/src/routes/accounts.ts
@@ -46,7 +46,7 @@ export const accountRoutes = new Hono<Env>()
       {
         data: await crmService.createOrganization(
           c.get("db"),
-          insertOrganizationSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertOrganizationSchema),
         ),
       },
       201,
@@ -61,7 +61,7 @@ export const accountRoutes = new Hono<Env>()
     const row = await crmService.updateOrganization(
       c.get("db"),
       c.req.param("id"),
-      updateOrganizationSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateOrganizationSchema),
     )
     if (!row) return c.json({ error: "Organization not found" }, 404)
     return c.json({ data: row })
@@ -83,7 +83,7 @@ export const accountRoutes = new Hono<Env>()
           c.get("db"),
           organizationEntity,
           c.req.param("id"),
-          insertContactPointSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertContactPointSchema),
         ),
       },
       201,
@@ -101,7 +101,7 @@ export const accountRoutes = new Hono<Env>()
           c.get("db"),
           organizationEntity,
           c.req.param("id"),
-          insertAddressSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertAddressSchema),
         ),
       },
       201,
@@ -124,7 +124,7 @@ export const accountRoutes = new Hono<Env>()
     return c.json({ data: row }, 201)
   })
   .patch("/organization-notes/:id", async (c) => {
-    const body = updateOrganizationNoteSchema.parse(await c.req.json())
+    const body = await parseJsonBody(c, updateOrganizationNoteSchema)
     const row = await crmService.updateOrganizationNote(
       c.get("db"),
       c.req.param("id"),
@@ -149,7 +149,7 @@ export const accountRoutes = new Hono<Env>()
       {
         data: await crmService.createPerson(
           c.get("db"),
-          insertPersonSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertPersonSchema),
         ),
       },
       201,
@@ -164,7 +164,7 @@ export const accountRoutes = new Hono<Env>()
     const row = await crmService.updatePerson(
       c.get("db"),
       c.req.param("id"),
-      updatePersonSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updatePersonSchema),
     )
     if (!row) return c.json({ error: "Person not found" }, 404)
     return c.json({ data: row })
@@ -186,7 +186,7 @@ export const accountRoutes = new Hono<Env>()
           c.get("db"),
           personEntity,
           c.req.param("id"),
-          insertContactPointSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertContactPointSchema),
         ),
       },
       201,
@@ -204,7 +204,7 @@ export const accountRoutes = new Hono<Env>()
           c.get("db"),
           personEntity,
           c.req.param("id"),
-          insertAddressSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertAddressSchema),
         ),
       },
       201,
@@ -227,7 +227,7 @@ export const accountRoutes = new Hono<Env>()
     return c.json({ data: row }, 201)
   })
   .patch("/person-notes/:id", async (c) => {
-    const body = updatePersonNoteSchema.parse(await c.req.json())
+    const body = await parseJsonBody(c, updatePersonNoteSchema)
     const row = await crmService.updatePersonNote(c.get("db"), c.req.param("id"), body.content)
     if (!row) return c.json({ error: "Note not found" }, 404)
     return c.json({ data: row })
@@ -247,7 +247,7 @@ export const accountRoutes = new Hono<Env>()
     const row = await crmService.createCommunication(
       c.get("db"),
       c.req.param("id"),
-      insertCommunicationLogSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertCommunicationLogSchema),
     )
     if (!row) return c.json({ error: "Person not found" }, 404)
     return c.json({ data: row }, 201)
@@ -262,7 +262,7 @@ export const accountRoutes = new Hono<Env>()
       {
         data: await crmService.createSegment(
           c.get("db"),
-          insertSegmentSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertSegmentSchema),
         ),
       },
       201,
@@ -297,7 +297,7 @@ export const accountRoutes = new Hono<Env>()
     const row = await crmService.updateContactMethod(
       c.get("db"),
       c.req.param("id"),
-      updateContactPointSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateContactPointSchema),
     )
     if (!row) return c.json({ error: "Contact method not found" }, 404)
     return c.json({ data: row })
@@ -311,7 +311,7 @@ export const accountRoutes = new Hono<Env>()
     const row = await crmService.updateAddress(
       c.get("db"),
       c.req.param("id"),
-      updateAddressSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateAddressSchema),
     )
     if (!row) return c.json({ error: "Address not found" }, 404)
     return c.json({ data: row })

--- a/packages/crm/src/routes/accounts.ts
+++ b/packages/crm/src/routes/accounts.ts
@@ -1,4 +1,4 @@
-import { parseJsonBody, requireUserId } from "@voyantjs/hono"
+import { parseJsonBody, parseQuery, requireUserId } from "@voyantjs/hono"
 import {
   insertAddressSchema,
   insertContactPointSchema,
@@ -38,9 +38,7 @@ const personEntity = "person" as const
 export const accountRoutes = new Hono<Env>()
   // Organizations
   .get("/organizations", async (c) => {
-    const query = organizationListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, organizationListQuerySchema)
     return c.json(await crmService.listOrganizations(c.get("db"), query))
   })
   .post("/organizations", async (c) => {
@@ -143,7 +141,7 @@ export const accountRoutes = new Hono<Env>()
 
   // People
   .get("/people", async (c) => {
-    const query = personListQuerySchema.parse(Object.fromEntries(new URL(c.req.url).searchParams))
+    const query = parseQuery(c, personListQuerySchema)
     return c.json(await crmService.listPeople(c.get("db"), query))
   })
   .post("/people", async (c) => {
@@ -240,9 +238,7 @@ export const accountRoutes = new Hono<Env>()
     return c.json({ success: true })
   })
   .get("/people/:id/communications", async (c) => {
-    const query = communicationListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, communicationListQuerySchema)
     return c.json({
       data: await crmService.listCommunications(c.get("db"), c.req.param("id"), query),
     })

--- a/packages/finance/src/routes.ts
+++ b/packages/finance/src/routes.ts
@@ -84,7 +84,7 @@ export const financeRoutes = new Hono<Env>()
       {
         data: await financeService.createPaymentSession(
           c.get("db"),
-          insertPaymentSessionSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertPaymentSessionSchema),
         ),
       },
       201,
@@ -101,7 +101,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.updatePaymentSession(
       c.get("db"),
       c.req.param("id"),
-      updatePaymentSessionSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updatePaymentSessionSchema),
     )
     if (!row) return c.json({ error: "Payment session not found" }, 404)
     return c.json({ data: row })
@@ -111,7 +111,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.markPaymentSessionRequiresRedirect(
       c.get("db"),
       c.req.param("id"),
-      markPaymentSessionRequiresRedirectSchema.parse(await c.req.json()),
+      await parseJsonBody(c, markPaymentSessionRequiresRedirectSchema),
     )
     if (!row) return c.json({ error: "Payment session not found" }, 404)
     return c.json({ data: row })
@@ -121,7 +121,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.completePaymentSession(
       c.get("db"),
       c.req.param("id"),
-      completePaymentSessionSchema.parse(await c.req.json()),
+      await parseJsonBody(c, completePaymentSessionSchema),
     )
     if (!row) return c.json({ error: "Payment session not found" }, 404)
     return c.json({ data: row })
@@ -131,7 +131,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.failPaymentSession(
       c.get("db"),
       c.req.param("id"),
-      failPaymentSessionSchema.parse(await c.req.json()),
+      await parseJsonBody(c, failPaymentSessionSchema),
     )
     if (!row) return c.json({ error: "Payment session not found" }, 404)
     return c.json({ data: row })
@@ -141,7 +141,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.cancelPaymentSession(
       c.get("db"),
       c.req.param("id"),
-      cancelPaymentSessionSchema.parse(await c.req.json()),
+      await parseJsonBody(c, cancelPaymentSessionSchema),
     )
     if (!row) return c.json({ error: "Payment session not found" }, 404)
     return c.json({ data: row })
@@ -151,7 +151,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.expirePaymentSession(
       c.get("db"),
       c.req.param("id"),
-      expirePaymentSessionSchema.parse(await c.req.json()),
+      await parseJsonBody(c, expirePaymentSessionSchema),
     )
     if (!row) return c.json({ error: "Payment session not found" }, 404)
     return c.json({ data: row })
@@ -171,7 +171,7 @@ export const financeRoutes = new Hono<Env>()
       {
         data: await financeService.createPaymentInstrument(
           c.get("db"),
-          insertPaymentInstrumentSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertPaymentInstrumentSchema),
         ),
       },
       201,
@@ -188,7 +188,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.updatePaymentInstrument(
       c.get("db"),
       c.req.param("id"),
-      updatePaymentInstrumentSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updatePaymentInstrumentSchema),
     )
     if (!row) return c.json({ error: "Payment instrument not found" }, 404)
     return c.json({ data: row })
@@ -214,7 +214,7 @@ export const financeRoutes = new Hono<Env>()
       {
         data: await financeService.createPaymentAuthorization(
           c.get("db"),
-          insertPaymentAuthorizationSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertPaymentAuthorizationSchema),
         ),
       },
       201,
@@ -231,7 +231,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.updatePaymentAuthorization(
       c.get("db"),
       c.req.param("id"),
-      updatePaymentAuthorizationSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updatePaymentAuthorizationSchema),
     )
     if (!row) return c.json({ error: "Payment authorization not found" }, 404)
     return c.json({ data: row })
@@ -257,7 +257,7 @@ export const financeRoutes = new Hono<Env>()
       {
         data: await financeService.createPaymentCapture(
           c.get("db"),
-          insertPaymentCaptureSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertPaymentCaptureSchema),
         ),
       },
       201,
@@ -274,7 +274,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.updatePaymentCapture(
       c.get("db"),
       c.req.param("id"),
-      updatePaymentCaptureSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updatePaymentCaptureSchema),
     )
     if (!row) return c.json({ error: "Payment capture not found" }, 404)
     return c.json({ data: row })
@@ -322,7 +322,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.createBookingPaymentSchedule(
       c.get("db"),
       c.req.param("bookingId"),
-      insertBookingPaymentScheduleSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertBookingPaymentScheduleSchema),
     )
 
     if (!row) {
@@ -336,7 +336,7 @@ export const financeRoutes = new Hono<Env>()
     const rows = await financeService.applyDefaultBookingPaymentPlan(
       c.get("db"),
       c.req.param("bookingId"),
-      applyDefaultBookingPaymentPlanSchema.parse(await c.req.json()),
+      await parseJsonBody(c, applyDefaultBookingPaymentPlanSchema),
     )
 
     if (!rows) {
@@ -350,7 +350,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.updateBookingPaymentSchedule(
       c.get("db"),
       c.req.param("scheduleId"),
-      updateBookingPaymentScheduleSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateBookingPaymentScheduleSchema),
     )
 
     if (!row) {
@@ -365,7 +365,7 @@ export const financeRoutes = new Hono<Env>()
       const row = await financeService.createPaymentSessionFromBookingSchedule(
         c.get("db"),
         c.req.param("scheduleId"),
-        createPaymentSessionFromScheduleSchema.parse(await c.req.json()),
+        await parseJsonBody(c, createPaymentSessionFromScheduleSchema),
       )
 
       if (!row) {
@@ -406,7 +406,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.createBookingGuarantee(
       c.get("db"),
       c.req.param("bookingId"),
-      insertBookingGuaranteeSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertBookingGuaranteeSchema),
     )
 
     if (!row) {
@@ -421,7 +421,7 @@ export const financeRoutes = new Hono<Env>()
       const row = await financeService.createPaymentSessionFromBookingGuarantee(
         c.get("db"),
         c.req.param("guaranteeId"),
-        createPaymentSessionFromGuaranteeSchema.parse(await c.req.json()),
+        await parseJsonBody(c, createPaymentSessionFromGuaranteeSchema),
       )
 
       if (!row) {
@@ -439,7 +439,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.updateBookingGuarantee(
       c.get("db"),
       c.req.param("guaranteeId"),
-      updateBookingGuaranteeSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateBookingGuaranteeSchema),
     )
 
     if (!row) {
@@ -473,7 +473,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.createBookingItemTaxLine(
       c.get("db"),
       c.req.param("bookingItemId"),
-      insertBookingItemTaxLineSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertBookingItemTaxLineSchema),
     )
 
     if (!row) {
@@ -487,7 +487,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.updateBookingItemTaxLine(
       c.get("db"),
       c.req.param("taxLineId"),
-      updateBookingItemTaxLineSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateBookingItemTaxLineSchema),
     )
 
     if (!row) {
@@ -524,7 +524,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.createBookingItemCommission(
       c.get("db"),
       c.req.param("bookingItemId"),
-      insertBookingItemCommissionSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertBookingItemCommissionSchema),
     )
 
     if (!row) {
@@ -538,7 +538,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.updateBookingItemCommission(
       c.get("db"),
       c.req.param("commissionId"),
-      updateBookingItemCommissionSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateBookingItemCommissionSchema),
     )
 
     if (!row) {
@@ -577,7 +577,7 @@ export const financeRoutes = new Hono<Env>()
       {
         data: await financeService.createSupplierPayment(
           c.get("db"),
-          insertSupplierPaymentSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertSupplierPaymentSchema),
         ),
       },
       201,
@@ -589,7 +589,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.updateSupplierPayment(
       c.get("db"),
       c.req.param("id"),
-      updateSupplierPaymentSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateSupplierPaymentSchema),
     )
 
     if (!row) {
@@ -615,7 +615,7 @@ export const financeRoutes = new Hono<Env>()
       {
         data: await financeService.createInvoice(
           c.get("db"),
-          insertInvoiceSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertInvoiceSchema),
         ),
       },
       201,
@@ -624,7 +624,7 @@ export const financeRoutes = new Hono<Env>()
 
   // POST /invoices/from-booking — Create draft invoice from booking + booking items
   .post("/invoices/from-booking", async (c) => {
-    const input = invoiceFromBookingSchema.parse(await c.req.json())
+    const input = await parseJsonBody(c, invoiceFromBookingSchema)
     const db = c.get("db")
     const [{ bookingItems, bookings }, { eq }] = await Promise.all([
       import("@voyantjs/bookings/schema"),
@@ -683,7 +683,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.updateInvoice(
       c.get("db"),
       c.req.param("id"),
-      updateInvoiceSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateInvoiceSchema),
     )
 
     if (!row) {
@@ -713,7 +713,7 @@ export const financeRoutes = new Hono<Env>()
       const row = await financeService.createPaymentSessionFromInvoice(
         c.get("db"),
         c.req.param("id"),
-        createPaymentSessionFromInvoiceSchema.parse(await c.req.json()),
+        await parseJsonBody(c, createPaymentSessionFromInvoiceSchema),
       )
 
       if (!row) {
@@ -743,7 +743,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.createInvoiceLineItem(
       c.get("db"),
       c.req.param("id"),
-      insertInvoiceLineItemSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertInvoiceLineItemSchema),
     )
 
     if (!row) {
@@ -758,7 +758,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.updateInvoiceLineItem(
       c.get("db"),
       c.req.param("lineId"),
-      updateInvoiceLineItemSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateInvoiceLineItemSchema),
     )
 
     if (!row) {
@@ -793,7 +793,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.createPayment(
       c.get("db"),
       c.req.param("id"),
-      insertPaymentSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertPaymentSchema),
     )
 
     if (!row) {
@@ -819,7 +819,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.createCreditNote(
       c.get("db"),
       c.req.param("id"),
-      insertCreditNoteSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertCreditNoteSchema),
     )
 
     if (!row) {
@@ -834,7 +834,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.updateCreditNote(
       c.get("db"),
       c.req.param("creditNoteId"),
-      updateCreditNoteSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateCreditNoteSchema),
     )
 
     if (!row) {
@@ -860,7 +860,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.createCreditNoteLineItem(
       c.get("db"),
       c.req.param("creditNoteId"),
-      insertCreditNoteLineItemSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertCreditNoteLineItemSchema),
     )
 
     if (!row) {
@@ -909,7 +909,7 @@ export const financeRoutes = new Hono<Env>()
   .post("/invoice-number-series", async (c) => {
     const row = await financeService.createInvoiceNumberSeries(
       c.get("db"),
-      insertInvoiceNumberSeriesSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertInvoiceNumberSeriesSchema),
     )
     return c.json({ data: row }, 201)
   })
@@ -924,7 +924,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.updateInvoiceNumberSeries(
       c.get("db"),
       c.req.param("id"),
-      updateInvoiceNumberSeriesSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateInvoiceNumberSeriesSchema),
     )
     if (!row) return c.json({ error: "Invoice number series not found" }, 404)
     return c.json({ data: row })
@@ -961,7 +961,7 @@ export const financeRoutes = new Hono<Env>()
   .post("/invoice-templates", async (c) => {
     const row = await financeService.createInvoiceTemplate(
       c.get("db"),
-      insertInvoiceTemplateSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertInvoiceTemplateSchema),
     )
     return c.json({ data: row }, 201)
   })
@@ -976,7 +976,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.updateInvoiceTemplate(
       c.get("db"),
       c.req.param("id"),
-      updateInvoiceTemplateSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateInvoiceTemplateSchema),
     )
     if (!row) return c.json({ error: "Invoice template not found" }, 404)
     return c.json({ data: row })
@@ -1000,7 +1000,7 @@ export const financeRoutes = new Hono<Env>()
   .post("/tax-regimes", async (c) => {
     const row = await financeService.createTaxRegime(
       c.get("db"),
-      insertTaxRegimeSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertTaxRegimeSchema),
     )
     return c.json({ data: row }, 201)
   })
@@ -1015,7 +1015,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.updateTaxRegime(
       c.get("db"),
       c.req.param("id"),
-      updateTaxRegimeSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateTaxRegimeSchema),
     )
     if (!row) return c.json({ error: "Tax regime not found" }, 404)
     return c.json({ data: row })
@@ -1037,7 +1037,7 @@ export const financeRoutes = new Hono<Env>()
   })
 
   .post("/invoices/:id/render", async (c) => {
-    const input = renderInvoiceInputSchema.parse(await c.req.json())
+    const input = await parseJsonBody(c, renderInvoiceInputSchema)
     const result = await financeService.renderInvoice(c.get("db"), c.req.param("id"), input)
     if (result.status === "not_found") return c.json({ error: "Invoice not found" }, 404)
     return c.json({ data: result.rendition }, 201)
@@ -1052,7 +1052,7 @@ export const financeRoutes = new Hono<Env>()
     const row = await financeService.registerInvoiceExternalRef(
       c.get("db"),
       c.req.param("id"),
-      insertInvoiceExternalRefSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertInvoiceExternalRefSchema),
     )
     if (!row) return c.json({ error: "Invoice not found" }, 404)
     return c.json({ data: row }, 201)

--- a/packages/products/src/routes.ts
+++ b/packages/products/src/routes.ts
@@ -1,6 +1,7 @@
 import { parseJsonBody, parseQuery, RequestValidationError, requireUserId } from "@voyantjs/hono"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
+import { z } from "zod"
 
 import { productsService } from "./service.js"
 import {
@@ -101,7 +102,7 @@ export const productRoutes = new Hono<Env>()
       {
         data: await productsService.createProduct(
           c.get("db"),
-          insertProductSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertProductSchema),
         ),
       },
       201,
@@ -130,7 +131,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.upsertActivationSetting(
       c.get("db"),
       c.req.param("id"),
-      insertProductActivationSettingSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertProductActivationSettingSchema),
     )
 
     if (!row) {
@@ -144,7 +145,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.updateActivationSetting(
       c.get("db"),
       c.req.param("id"),
-      updateProductActivationSettingSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateProductActivationSettingSchema),
     )
 
     if (!row) {
@@ -182,7 +183,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.upsertTicketSetting(
       c.get("db"),
       c.req.param("id"),
-      insertProductTicketSettingSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertProductTicketSettingSchema),
     )
 
     if (!row) {
@@ -196,7 +197,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.updateTicketSetting(
       c.get("db"),
       c.req.param("id"),
-      updateProductTicketSettingSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateProductTicketSettingSchema),
     )
 
     if (!row) {
@@ -234,7 +235,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.upsertVisibilitySetting(
       c.get("db"),
       c.req.param("id"),
-      insertProductVisibilitySettingSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertProductVisibilitySettingSchema),
     )
 
     if (!row) {
@@ -248,7 +249,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.updateVisibilitySetting(
       c.get("db"),
       c.req.param("id"),
-      updateProductVisibilitySettingSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateProductVisibilitySettingSchema),
     )
 
     if (!row) {
@@ -286,7 +287,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.createCapability(
       c.get("db"),
       c.req.param("id"),
-      insertProductCapabilitySchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertProductCapabilitySchema),
     )
 
     if (!row) {
@@ -300,7 +301,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.updateCapability(
       c.get("db"),
       c.req.param("id"),
-      updateProductCapabilitySchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateProductCapabilitySchema),
     )
 
     if (!row) {
@@ -338,7 +339,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.createDeliveryFormat(
       c.get("db"),
       c.req.param("id"),
-      insertProductDeliveryFormatSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertProductDeliveryFormatSchema),
     )
 
     if (!row) {
@@ -352,7 +353,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.updateDeliveryFormat(
       c.get("db"),
       c.req.param("id"),
-      updateProductDeliveryFormatSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateProductDeliveryFormatSchema),
     )
 
     if (!row) {
@@ -390,7 +391,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.createFeature(
       c.get("db"),
       c.req.param("id"),
-      insertProductFeatureSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertProductFeatureSchema),
     )
 
     if (!row) {
@@ -404,7 +405,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.updateFeature(
       c.get("db"),
       c.req.param("id"),
-      updateProductFeatureSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateProductFeatureSchema),
     )
 
     if (!row) {
@@ -442,7 +443,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.createFaq(
       c.get("db"),
       c.req.param("id"),
-      insertProductFaqSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertProductFaqSchema),
     )
 
     if (!row) {
@@ -456,7 +457,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.updateFaq(
       c.get("db"),
       c.req.param("id"),
-      updateProductFaqSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateProductFaqSchema),
     )
 
     if (!row) {
@@ -494,7 +495,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.createLocation(
       c.get("db"),
       c.req.param("id"),
-      insertProductLocationSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertProductLocationSchema),
     )
 
     if (!row) {
@@ -508,7 +509,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.updateLocation(
       c.get("db"),
       c.req.param("id"),
-      updateProductLocationSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateProductLocationSchema),
     )
 
     if (!row) {
@@ -545,7 +546,7 @@ export const productRoutes = new Hono<Env>()
   .post("/destinations", async (c) => {
     const row = await productsService.createDestination(
       c.get("db"),
-      insertDestinationSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertDestinationSchema),
     )
 
     return c.json({ data: row }, 201)
@@ -555,7 +556,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.updateDestination(
       c.get("db"),
       c.req.param("id"),
-      updateDestinationSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateDestinationSchema),
     )
 
     if (!row) {
@@ -584,7 +585,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.upsertDestinationTranslation(
       c.get("db"),
       c.req.param("id"),
-      insertDestinationTranslationSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertDestinationTranslationSchema),
     )
 
     if (!row) {
@@ -598,7 +599,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.updateDestinationTranslation(
       c.get("db"),
       c.req.param("id"),
-      updateDestinationTranslationSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateDestinationTranslationSchema),
     )
 
     if (!row) {
@@ -627,7 +628,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.assignProductDestination(
       c.get("db"),
       c.req.param("id"),
-      insertProductDestinationSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertProductDestinationSchema),
     )
 
     if (!row) {
@@ -677,7 +678,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.createOption(
       c.get("db"),
       c.req.param("id"),
-      insertProductOptionSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertProductOptionSchema),
     )
 
     if (!row) {
@@ -692,7 +693,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.updateOption(
       c.get("db"),
       c.req.param("optionId"),
-      updateProductOptionSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateProductOptionSchema),
     )
 
     if (!row) {
@@ -739,7 +740,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.createUnit(
       c.get("db"),
       c.req.param("optionId"),
-      insertOptionUnitSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertOptionUnitSchema),
     )
 
     if (!row) {
@@ -754,7 +755,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.updateUnit(
       c.get("db"),
       c.req.param("unitId"),
-      updateOptionUnitSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateOptionUnitSchema),
     )
 
     if (!row) {
@@ -801,7 +802,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.createProductTranslation(
       c.get("db"),
       c.req.param("id"),
-      insertProductTranslationSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertProductTranslationSchema),
     )
 
     if (!row) {
@@ -815,7 +816,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.updateProductTranslation(
       c.get("db"),
       c.req.param("translationId"),
-      updateProductTranslationSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateProductTranslationSchema),
     )
 
     if (!row) {
@@ -860,7 +861,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.createOptionTranslation(
       c.get("db"),
       c.req.param("optionId"),
-      insertProductOptionTranslationSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertProductOptionTranslationSchema),
     )
 
     if (!row) {
@@ -874,7 +875,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.updateOptionTranslation(
       c.get("db"),
       c.req.param("translationId"),
-      updateProductOptionTranslationSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateProductOptionTranslationSchema),
     )
 
     if (!row) {
@@ -919,7 +920,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.createUnitTranslation(
       c.get("db"),
       c.req.param("unitId"),
-      insertOptionUnitTranslationSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertOptionUnitTranslationSchema),
     )
 
     if (!row) {
@@ -933,7 +934,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.updateUnitTranslation(
       c.get("db"),
       c.req.param("translationId"),
-      updateOptionUnitTranslationSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateOptionUnitTranslationSchema),
     )
 
     if (!row) {
@@ -978,7 +979,7 @@ export const productRoutes = new Hono<Env>()
       {
         data: await productsService.createProductType(
           c.get("db"),
-          insertProductTypeSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertProductTypeSchema),
         ),
       },
       201,
@@ -989,7 +990,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.updateProductType(
       c.get("db"),
       c.req.param("typeId"),
-      updateProductTypeSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateProductTypeSchema),
     )
     if (!row) {
       return c.json({ error: "Product type not found" }, 404)
@@ -1027,7 +1028,7 @@ export const productRoutes = new Hono<Env>()
       {
         data: await productsService.createProductCategory(
           c.get("db"),
-          insertProductCategorySchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertProductCategorySchema),
         ),
       },
       201,
@@ -1038,7 +1039,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.updateProductCategory(
       c.get("db"),
       c.req.param("categoryId"),
-      updateProductCategorySchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateProductCategorySchema),
     )
     if (!row) {
       return c.json({ error: "Product category not found" }, 404)
@@ -1076,7 +1077,7 @@ export const productRoutes = new Hono<Env>()
       {
         data: await productsService.createProductTag(
           c.get("db"),
-          insertProductTagSchema.parse(await c.req.json()),
+          await parseJsonBody(c, insertProductTagSchema),
         ),
       },
       201,
@@ -1087,7 +1088,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.updateProductTag(
       c.get("db"),
       c.req.param("tagId"),
-      updateProductTagSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateProductTagSchema),
     )
     if (!row) {
       return c.json({ error: "Product tag not found" }, 404)
@@ -1121,7 +1122,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.updateMedia(
       c.get("db"),
       c.req.param("mediaId"),
-      updateProductMediaSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateProductMediaSchema),
     )
     if (!row) {
       return c.json({ error: "Media not found" }, 404)
@@ -1175,7 +1176,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.upsertBrochure(
       c.get("db"),
       c.req.param("id"),
-      upsertProductBrochureSchema.parse(await c.req.json()),
+      await parseJsonBody(c, upsertProductBrochureSchema),
     )
     if (!row) {
       return c.json({ error: "Product not found" }, 404)
@@ -1234,7 +1235,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.updateProduct(
       c.get("db"),
       c.req.param("id"),
-      updateProductSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateProductSchema),
     )
 
     if (!row) {
@@ -1269,7 +1270,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.createDay(
       c.get("db"),
       c.req.param("id"),
-      insertDaySchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertDaySchema),
     )
 
     if (!row) {
@@ -1284,7 +1285,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.updateDay(
       c.get("db"),
       c.req.param("dayId"),
-      updateDaySchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateDaySchema),
     )
 
     if (!row) {
@@ -1322,7 +1323,7 @@ export const productRoutes = new Hono<Env>()
       c.get("db"),
       c.req.param("id"),
       c.req.param("dayId"),
-      insertDayServiceSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertDayServiceSchema),
     )
 
     if (!row) {
@@ -1338,7 +1339,7 @@ export const productRoutes = new Hono<Env>()
       c.get("db"),
       c.req.param("id"),
       c.req.param("serviceId"),
-      updateDayServiceSchema.parse(await c.req.json()),
+      await parseJsonBody(c, updateDayServiceSchema),
     )
 
     if (!row) {
@@ -1434,10 +1435,13 @@ export const productRoutes = new Hono<Env>()
   })
 
   .post("/:id/categories", async (c) => {
-    const { categoryId, sortOrder } = (await c.req.json()) as {
-      categoryId: string
-      sortOrder?: number
-    }
+    const { categoryId, sortOrder } = await parseJsonBody(
+      c,
+      z.object({
+        categoryId: z.string(),
+        sortOrder: z.number().optional(),
+      }),
+    )
     const row = await productsService.addProductToCategory(
       c.get("db"),
       c.req.param("id"),
@@ -1473,7 +1477,12 @@ export const productRoutes = new Hono<Env>()
   })
 
   .post("/:id/tags", async (c) => {
-    const { tagId } = (await c.req.json()) as { tagId: string }
+    const { tagId } = await parseJsonBody(
+      c,
+      z.object({
+        tagId: z.string(),
+      }),
+    )
     const row = await productsService.addProductTag(c.get("db"), c.req.param("id"), tagId)
     if (!row) {
       return c.json({ error: "Already assigned or not found" }, 409)
@@ -1510,7 +1519,7 @@ export const productRoutes = new Hono<Env>()
     const row = await productsService.createMedia(
       c.get("db"),
       c.req.param("id"),
-      insertProductMediaSchema.parse(await c.req.json()),
+      await parseJsonBody(c, insertProductMediaSchema),
     )
     if (!row) {
       return c.json({ error: "Product not found or invalid dayId" }, 404)
@@ -1520,7 +1529,7 @@ export const productRoutes = new Hono<Env>()
 
   // POST /:id/media/reorder — Batch reorder media
   .post("/:id/media/reorder", async (c) => {
-    const data = reorderProductMediaSchema.parse(await c.req.json())
+    const data = await parseJsonBody(c, reorderProductMediaSchema)
     const results = await productsService.reorderMedia(c.get("db"), data)
     return c.json({ data: results })
   })
@@ -1538,7 +1547,7 @@ export const productRoutes = new Hono<Env>()
 
   // POST /:id/days/:dayId/media — Create day media
   .post("/:id/days/:dayId/media", async (c) => {
-    const body = insertProductMediaSchema.parse(await c.req.json())
+    const body = await parseJsonBody(c, insertProductMediaSchema)
     const row = await productsService.createMedia(c.get("db"), c.req.param("id"), {
       ...body,
       dayId: c.req.param("dayId"),

--- a/packages/products/src/routes.ts
+++ b/packages/products/src/routes.ts
@@ -1,4 +1,4 @@
-import { parseJsonBody, RequestValidationError, requireUserId } from "@voyantjs/hono"
+import { parseJsonBody, parseQuery, RequestValidationError, requireUserId } from "@voyantjs/hono"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
 
@@ -91,7 +91,7 @@ export const productRoutes = new Hono<Env>()
 
   // GET / — List products
   .get("/", async (c) => {
-    const query = productListQuerySchema.parse(Object.fromEntries(new URL(c.req.url).searchParams))
+    const query = parseQuery(c, productListQuerySchema)
     return c.json(await productsService.listProducts(c.get("db"), query))
   })
 
@@ -113,9 +113,7 @@ export const productRoutes = new Hono<Env>()
   // ==========================================================================
 
   .get("/activation-settings", async (c) => {
-    const query = productActivationSettingListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, productActivationSettingListQuerySchema)
     return c.json(await productsService.listActivationSettings(c.get("db"), query))
   })
 
@@ -167,9 +165,7 @@ export const productRoutes = new Hono<Env>()
   })
 
   .get("/ticket-settings", async (c) => {
-    const query = productTicketSettingListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, productTicketSettingListQuerySchema)
     return c.json(await productsService.listTicketSettings(c.get("db"), query))
   })
 
@@ -221,9 +217,7 @@ export const productRoutes = new Hono<Env>()
   })
 
   .get("/visibility-settings", async (c) => {
-    const query = productVisibilitySettingListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, productVisibilitySettingListQuerySchema)
     return c.json(await productsService.listVisibilitySettings(c.get("db"), query))
   })
 
@@ -275,9 +269,7 @@ export const productRoutes = new Hono<Env>()
   })
 
   .get("/capabilities", async (c) => {
-    const query = productCapabilityListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, productCapabilityListQuerySchema)
     return c.json(await productsService.listCapabilities(c.get("db"), query))
   })
 
@@ -329,9 +321,7 @@ export const productRoutes = new Hono<Env>()
   })
 
   .get("/delivery-formats", async (c) => {
-    const query = productDeliveryFormatListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, productDeliveryFormatListQuerySchema)
     return c.json(await productsService.listDeliveryFormats(c.get("db"), query))
   })
 
@@ -383,9 +373,7 @@ export const productRoutes = new Hono<Env>()
   })
 
   .get("/features", async (c) => {
-    const query = productFeatureListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, productFeatureListQuerySchema)
     return c.json(await productsService.listFeatures(c.get("db"), query))
   })
 
@@ -437,9 +425,7 @@ export const productRoutes = new Hono<Env>()
   })
 
   .get("/faqs", async (c) => {
-    const query = productFaqListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, productFaqListQuerySchema)
     return c.json(await productsService.listFaqs(c.get("db"), query))
   })
 
@@ -491,9 +477,7 @@ export const productRoutes = new Hono<Env>()
   })
 
   .get("/locations", async (c) => {
-    const query = productLocationListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, productLocationListQuerySchema)
     return c.json(await productsService.listLocations(c.get("db"), query))
   })
 
@@ -545,9 +529,7 @@ export const productRoutes = new Hono<Env>()
   })
 
   .get("/destinations", async (c) => {
-    const query = destinationListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, destinationListQuerySchema)
     return c.json(await productsService.listDestinations(c.get("db"), query))
   })
 
@@ -594,9 +576,7 @@ export const productRoutes = new Hono<Env>()
   })
 
   .get("/destination-translations", async (c) => {
-    const query = destinationTranslationListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, destinationTranslationListQuerySchema)
     return c.json(await productsService.listDestinationTranslations(c.get("db"), query))
   })
 
@@ -639,9 +619,7 @@ export const productRoutes = new Hono<Env>()
   })
 
   .get("/destination-links", async (c) => {
-    const query = productDestinationListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, productDestinationListQuerySchema)
     return c.json(await productsService.listProductDestinations(c.get("db"), query))
   })
 
@@ -679,9 +657,7 @@ export const productRoutes = new Hono<Env>()
 
   // GET /options — List options
   .get("/options", async (c) => {
-    const query = productOptionListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, productOptionListQuerySchema)
     return c.json(await productsService.listOptions(c.get("db"), query))
   })
 
@@ -743,9 +719,7 @@ export const productRoutes = new Hono<Env>()
 
   // GET /units — List units
   .get("/units", async (c) => {
-    const query = optionUnitListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, optionUnitListQuerySchema)
     return c.json(await productsService.listUnits(c.get("db"), query))
   })
 
@@ -806,9 +780,7 @@ export const productRoutes = new Hono<Env>()
   // ==========================================================================
 
   .get("/translations", async (c) => {
-    const query = productTranslationListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, productTranslationListQuerySchema)
     return c.json(await productsService.listProductTranslations(c.get("db"), query))
   })
 
@@ -867,9 +839,7 @@ export const productRoutes = new Hono<Env>()
   })
 
   .get("/option-translations", async (c) => {
-    const query = productOptionTranslationListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, productOptionTranslationListQuerySchema)
     return c.json(await productsService.listOptionTranslations(c.get("db"), query))
   })
 
@@ -928,9 +898,7 @@ export const productRoutes = new Hono<Env>()
   })
 
   .get("/unit-translations", async (c) => {
-    const query = optionUnitTranslationListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, optionUnitTranslationListQuerySchema)
     return c.json(await productsService.listUnitTranslations(c.get("db"), query))
   })
 
@@ -993,9 +961,7 @@ export const productRoutes = new Hono<Env>()
   // ==========================================================================
 
   .get("/product-types", async (c) => {
-    const query = productTypeListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, productTypeListQuerySchema)
     return c.json(await productsService.listProductTypes(c.get("db"), query))
   })
 
@@ -1044,9 +1010,7 @@ export const productRoutes = new Hono<Env>()
   // ==========================================================================
 
   .get("/product-categories", async (c) => {
-    const query = productCategoryListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, productCategoryListQuerySchema)
     return c.json(await productsService.listProductCategories(c.get("db"), query))
   })
 
@@ -1095,9 +1059,7 @@ export const productRoutes = new Hono<Env>()
   // ==========================================================================
 
   .get("/product-tags", async (c) => {
-    const query = productTagListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, productTagListQuerySchema)
     return c.json(await productsService.listProductTags(c.get("db"), query))
   })
 
@@ -1537,9 +1499,7 @@ export const productRoutes = new Hono<Env>()
 
   // GET /:id/media — List product-level media
   .get("/:id/media", async (c) => {
-    const query = productMediaListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, productMediaListQuerySchema)
     return c.json(
       await productsService.listProductLevelMedia(c.get("db"), c.req.param("id"), query),
     )
@@ -1567,9 +1527,7 @@ export const productRoutes = new Hono<Env>()
 
   // GET /:id/days/:dayId/media — List day media
   .get("/:id/days/:dayId/media", async (c) => {
-    const query = productMediaListQuerySchema.parse(
-      Object.fromEntries(new URL(c.req.url).searchParams),
-    )
+    const query = parseQuery(c, productMediaListQuerySchema)
     return c.json(
       await productsService.listMedia(c.get("db"), c.req.param("id"), {
         ...query,


### PR DESCRIPTION
## Summary\n- replace remaining manual query parsing in products admin routes\n- replace remaining manual query parsing in CRM account routes\n- replace remaining manual query parsing in bookings admin routes\n\n## Verification\n- pnpm -C packages/products lint\n- pnpm -C packages/products typecheck\n- pnpm -C packages/products test\n- pnpm -C packages/crm lint\n- pnpm -C packages/crm typecheck\n- pnpm -C packages/crm test\n- pnpm -C packages/bookings lint\n- pnpm -C packages/bookings typecheck\n- pnpm -C packages/bookings test\n- git diff --check