### PR TITLE
[codex] Fix operator SSR API cookie forwarding

### DIFF
--- a/templates/operator/src/components/voyant/dashboard/dashboard-shared.ts
+++ b/templates/operator/src/components/voyant/dashboard/dashboard-shared.ts
@@ -40,7 +40,7 @@ export function getDashboardProductsQueryOptions() {
 export function getDashboardSuppliersQueryOptions() {
   return queryOptions({
     queryKey: ["dashboard-suppliers"],
-    queryFn: () => api.get<{ data: SupplierRow[]; total: number }>("/v1/admin/suppliers?limit=100"),
+    queryFn: () => api.get<{ data: SupplierRow[]; total: number }>("/v1/suppliers?limit=100"),
     staleTime: 60_000,
   })
 }

--- a/templates/operator/src/lib/api-client.server.ts
+++ b/templates/operator/src/lib/api-client.server.ts
@@ -1,0 +1,5 @@
+import { getRequestHeaders } from "@tanstack/react-start/server"
+
+export function getServerCookieHeader(): string | undefined {
+  return getRequestHeaders().get("cookie") ?? undefined
+}

--- a/templates/operator/src/lib/api-client.ts
+++ b/templates/operator/src/lib/api-client.ts
@@ -34,6 +34,19 @@ interface ApiCallOptions extends Omit<RequestInit, "headers"> {
   headers?: Record<string, string>
 }
 
+async function getServerCookieHeader(): Promise<string | undefined> {
+  if (!import.meta.env.SSR) {
+    return undefined
+  }
+
+  try {
+    const { getServerCookieHeader: readServerCookieHeader } = await import("./api-client.server")
+    return readServerCookieHeader()
+  } catch {
+    return undefined
+  }
+}
+
 function extractErrorMessage(status: number, statusText: string, body: unknown): string {
   let message = `API error: ${status} ${statusText}`
   if (typeof body === "object" && body !== null && "error" in body) {
@@ -50,11 +63,16 @@ function extractErrorMessage(status: number, statusText: string, body: unknown):
 export async function apiCall<T = unknown>(path: string, options: ApiCallOptions = {}): Promise<T> {
   const { headers: customHeaders, ...fetchOptions } = options
   const apiUrl = getApiUrl()
+  const serverCookie = await getServerCookieHeader()
 
   const headers = new Headers({
     "Content-Type": "application/json",
     ...customHeaders,
   })
+
+  if (serverCookie && !headers.has("cookie")) {
+    headers.set("cookie", serverCookie)
+  }
 
   const response = await fetch(`${apiUrl}${path}`, {
     ...fetchOptions,

--- a/templates/operator/src/routes/__root.tsx
+++ b/templates/operator/src/routes/__root.tsx
@@ -6,10 +6,14 @@ import {
   Scripts,
   useRouteContext,
 } from "@tanstack/react-router"
+import { RefreshCcw } from "lucide-react"
 import type { ReactNode } from "react"
-import { Toaster } from "@/components/ui"
+import { Button, Toaster } from "@/components/ui"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Empty, EmptyContent, EmptyHeader, EmptyMedia, EmptyTitle } from "@/components/ui/empty"
 
 import { Providers } from "../components/providers"
+import { ApiError } from "../lib/api-client"
 import appCss from "../styles.css?url"
 
 export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()({
@@ -33,6 +37,7 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
   // shellComponent is always SSR'd — renders the <html> document shell
   shellComponent: RootShell,
   component: RootComponent,
+  errorComponent: RootErrorBoundary,
 })
 
 function RootShell({ children }: { children: ReactNode }) {
@@ -60,5 +65,40 @@ function RootComponent() {
       <Outlet />
       <Toaster />
     </Providers>
+  )
+}
+
+function RootErrorBoundary({ error, reset }: { error: unknown; reset: () => void }) {
+  const message =
+    error instanceof ApiError
+      ? error.message
+      : error instanceof Error
+        ? error.message
+        : "Something went wrong while loading this page."
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-6">
+      <Empty className="max-w-xl border border-border bg-card p-8">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <RefreshCcw className="size-5" />
+          </EmptyMedia>
+          <EmptyTitle>Something went wrong</EmptyTitle>
+        </EmptyHeader>
+        <EmptyContent>
+          <Alert variant="destructive" className="text-left">
+            <AlertTitle>Request failed</AlertTitle>
+            <AlertDescription>{message}</AlertDescription>
+          </Alert>
+          <div className="flex items-center gap-3">
+            <Button onClick={() => reset()}>Try again</Button>
+            <Button variant="outline" onClick={() => window.location.assign("/")}>
+              Go to dashboard
+            </Button>
+          </div>
+        </EmptyContent>
+      </Empty>
+      <Toaster />
+    </div>
   )
 }


### PR DESCRIPTION
## What changed
- forward request cookies from TanStack Start SSR into the operator template API client
- add a root-level operator error boundary for failed API-driven page loads
- switch the dashboard suppliers widget to the active `/v1/suppliers` endpoint

## Why
The operator template could lose authenticated server-side API access during SSR because the legacy API helper did not forward the incoming request cookie. The dashboard also still referenced an older suppliers endpoint shape.

## Impact
- SSR fetches from the operator template can reuse the active session cookie
- operator users get a controlled root error screen instead of a raw crash
- dashboard supplier loading matches the rest of the template

## Validation
- `pnpm -C templates/operator exec biome check src/lib/api-client.ts src/lib/api-client.server.ts src/routes/__root.tsx src/components/voyant/dashboard/dashboard-shared.ts`
- `pnpm -C templates/operator typecheck`
- `pnpm -C templates/operator test`

## Notes
- `pnpm -C templates/operator lint` still reports unrelated pre-existing formatting/import-order issues elsewhere in the operator template and was not widened in this PR.
