### PR TITLE
fix: remove ignored packages from mixed changesets

### DIFF
--- a/.changeset/auto-resolve-booking-primary-product.md
+++ b/.changeset/auto-resolve-booking-primary-product.md
@@ -1,6 +1,5 @@
 ---
 "@voyantjs/bookings-react": minor
-"@voyantjs/voyant-ui": minor
 ---
 
 Add `useBookingPrimaryProduct(bookingId)` hook and make `BookingCancellationDialog` + `BookingGroupSection` self-resolve `productId` (and `optionUnitId`) from the booking's items.

--- a/.changeset/booking-status-presentation-helpers.md
+++ b/.changeset/booking-status-presentation-helpers.md
@@ -1,6 +1,5 @@
 ---
 "@voyantjs/bookings-react": minor
-"@voyantjs/voyant-ui": minor
 ---
 
 Add canonical booking status presentation helpers to `@voyantjs/bookings-react`:


### PR DESCRIPTION
## Summary
- remove the ignored `@voyantjs/voyant-ui` entries from the two mixed changesets on `main`
- keep the publishable `@voyantjs/bookings-react` releases intact
- restore the release workflow by making the changeset set valid for publish planning

## Root cause
The release workflow failed in `scripts/detect-pending-publication.cjs` because Changesets refuses mixed changesets that contain both ignored and non-ignored packages.\n\nThe two offending files were:\n- `.changeset/auto-resolve-booking-primary-product.md`\n- `.changeset/booking-status-presentation-helpers.md`

## Validation
- `node scripts/detect-pending-publication.cjs`
- repo hooks on commit/push (lint/test sweep)