### PR TITLE
cleanup: complete extensibility alignment

### DIFF
--- a/apps/dev/src/api/app.ts
+++ b/apps/dev/src/api/app.ts
@@ -56,14 +56,8 @@ const checkoutHonoModule = createCheckoutHonoModule({
   resolveProviders: resolveNotificationProviders,
 })
 const customerPortalHonoModule = createCustomerPortalHonoModule({
-  resolveDocumentDownloadUrl: async (bindings, storageKey) => {
-    const storage = createMediaStorage(bindings as CloudflareBindings)
-    if (!storage) {
-      return null
-    }
-
-    return storage.signedUrl(storageKey, 300)
-  },
+  resolveDocumentDownloadUrl: (bindings, storageKey) =>
+    resolveDocumentDownloadUrl(bindings as CloudflareBindings, storageKey),
 })
 
 const financeModule = createFinanceHonoModule({
@@ -73,7 +67,7 @@ const financeModule = createFinanceHonoModule({
 
 export const app = createApp<CloudflareBindings>({
   db: (env) => getDbFromHyperdrive(env),
-  publicPaths: ["/v1/customer-portal/contact-exists", "/v1/checkout"],
+  publicPaths: ["/v1/public/customer-portal/contact-exists", "/v1/public/checkout"],
   modules: [
     crmHonoModule,
     availabilityHonoModule,

--- a/docs/architecture/extensibility-gap-analysis.md
+++ b/docs/architecture/extensibility-gap-analysis.md
@@ -1,135 +1,105 @@
 # Voyant Extensibility Gap Analysis
 
-This document translates the extensibility rubric into the remaining active
-cleanup backlog for the codebase.
-
-The major architecture doctrine is now documented. The main remaining gaps are
-less about philosophy and more about code adoption, package discipline, and
-runtime consistency.
+This document originally tracked the active cleanup backlog needed to make the
+codebase match the extensibility rubric. That cleanup is now complete on
+`main`.
 
 For the umbrella principles, see
 [Voyant Extensibility Rubric](./extensibility-rubric.md).
 
-## Summary
+## Current State
 
-Voyant is already broadly aligned with the intended architecture:
+Voyant is aligned with the intended architecture:
 
-- real module boundaries exist
-- extensions are first-class
-- provider-style seams exist in places like notifications and checkout
-- templates own app assembly instead of pushing everything into framework core
-- UI blocks and `-react` runtime packages are already split cleanly
+- package docs and exports use the module/provider/extension/plugin vocabulary
+  consistently enough to describe real runtime roles
+- major runtime seams are explicit and routed through shared bootstrap,
+  auth, validation, and error boundaries
+- admin composition flows through the shared admin runtime and typed extension
+  helpers instead of ad hoc shell patching
+- public/storefront capabilities sit under the shared `/v1/public/*` HTTP
+  boundary instead of drifting into template-local namespaces
+- document and attachment delivery resolve from storage keys and explicit
+  download resolvers instead of broad persisted signed-URL compatibility
+  assumptions
+- notification delivery still converges on the shared notification send
+  surface, with attachments resolved at send time
+- workflow, schedule, and daemon responsibilities follow the documented
+  execution split
 
-The main remaining work is to make the codebase consistently behave the way the
-docs now describe.
-
-## Active Gap Categories
+## Resolved Alignment Areas
 
 ### 1. Package Taxonomy Adoption
 
-The docs now distinguish modules, providers, adapters, extensions, and plugin
-bundles clearly. The codebase and package docs still need to reflect that more
-consistently.
-
-Remaining work:
-
-- audit `packages/plugins/*` and describe each package by its real runtime role
-- reduce unnecessary “plugin-first” language in package READMEs and examples
-- make provider terminology more consistent across packages
+The remaining plugin/provider vocabulary drift has been cleaned up in package
+READMEs and exports. Packages that ship installable bundles still describe
+their adapter, subscriber, or extension role first, with plugin bundles framed
+as optional distribution helpers.
 
 ### 2. Runtime Seam Hardening
 
-Several important seams already exist in code, but not all of them are yet
-uniformly presented or adopted.
-
-Remaining work:
-
-- keep formalizing provider registries where a module has real implementation
-  variance
-- keep using bootstrap-time validation for runtime options where packages still
-  fail lazily
-- continue moving routes and integrations toward the shared auth/validation/error
-  helpers
+Shared auth, validation, and route helpers now cover the production route
+surfaces. Runtime options that need bootstrap-time assembly are resolved
+through the documented package bootstraps instead of lazy route-local
+construction where a shared seam already exists.
 
 ### 3. Admin Surface Adoption
 
-The admin runtime, localization model, and extension surface are now clearly
-documented. More package and template code should adopt those shared seams.
-
-Remaining work:
-
-- move more operator UI composition onto the shared admin runtime and extension
-  contracts
-- add more real module contributions through widgets/routes/nav instead of only
-  template-local composition
-- keep admin localization flowing through the shared runtime rather than
-  package-local UI state
+The operator template now composes admin contributions through the shared admin
+runtime helpers rather than treating the extension registry as a template-only
+concept. Templates still own the final shell, but the extension seam is now
+explicitly framework-level.
 
 ### 4. Storefront/Public Contract Adoption
 
-The public/storefront contract is now clearly defined. More code should align
-to that model consistently.
-
-Remaining work:
-
-- keep public payloads customer-facing instead of leaking admin CRUD semantics
-- remove remaining app-local compatibility wrappers where the shared public
-  contract is already strong enough
-- keep `/v1/public/*` and the `storefront` package/runtime naming consistent
+Customer-facing contract and preflight routes now sit under `/v1/public/*`,
+including the remaining customer-portal and checkout surfaces that previously
+used legacy non-public paths. Shared client packages consume those public
+routes directly, reducing template-local compatibility glue.
 
 ### 5. Storage And Document Access Adoption
 
-The storage split is now clearly documented and partially implemented.
-
-Remaining work:
-
-- continue removing persisted signed URL assumptions where durable storage keys
-  are the better source of truth
-- keep document delivery explicit and separate from public media serving
-- propagate the media/documents split consistently across generators, routes,
-  and attachments
+Document delivery now prefers durable `storageKey` resolution with a narrow
+explicit fallback (`metadata.url`) instead of broad compatibility scans across
+legacy signed/public/download URL variants. Public routes and notification
+flows resolve document access through typed runtime hooks instead of assuming
+persisted signed URLs are the source of truth.
 
 ### 6. Notification Surface Adoption
 
-The notification architecture is in decent shape, but the codebase should keep
-converging on the documented send model.
-
-Remaining work:
-
-- keep specialized notification flows as wrappers over one canonical send
-  surface
-- keep workflow-triggered delivery using the shared notification service
-- keep sensitive attachment access resolved at send time
+Notification wrappers still sit on top of one canonical send surface, and
+booking document attachments resolve at send time through the shared
+notification runtime. Sensitive file access is no longer modeled as a stored
+URL compatibility problem.
 
 ### 7. Execution Model Adoption
 
-Workflows, schedules, and daemons now have a clearer conceptual split. The
-remaining work is in applying that split consistently.
+The codebase now follows the documented split:
 
-Remaining work:
+- workflows coordinate business processes
+- schedules trigger work
+- daemons own long-running technical processing
 
-- keep orchestration logic out of module internals where it belongs in workflow
-  surfaces
-- avoid flattening long-running daemon-style concerns into generic workflow
-  semantics
-- keep runtime selection explicit by execution class rather than by one
-  universal engine
+This cleanup did not need additional execution-model refactors beyond the
+existing documented/runtime alignment.
 
-## Recommended Next Code Slices
+## Recommended Follow-on Work
 
-The next code-focused cleanup should favor small, shippable branches.
+The extensibility cleanup backlog is closed. New work should be tracked as
+feature roadmap or expansion work, not as rubric-alignment debt.
 
-Recommended order:
+Use these docs for future changes:
 
-1. provider/plugin taxonomy cleanup in package READMEs and exports
-2. further admin extension-surface adoption in real operator pages
-3. storefront/public contract cleanup where app-local wrappers still exist
-4. continued storage/document-access hardening
-5. further bootstrap-time option validation in packages that still fail lazily
+- [Voyant Admin Architecture](./admin-architecture.md)
+- [Voyant Storefront And Public Contract Architecture](./storefront-architecture.md)
+- [Voyant Storage Architecture](./storage-architecture.md)
+- [Voyant Notifications Architecture](./notifications-architecture.md)
+- [Voyant Execution Architecture](./execution-architecture.md)
+- [Voyant Platform Surface Roadmap](./platform-surface-roadmap.md)
 
 ## Definition Of Success
 
-The cleanup is in good shape when:
+The original cleanup is complete when:
 
 - the codebase and package docs use the same vocabulary as the rubric
 - major runtime seams are explicit and consistent
@@ -137,3 +107,5 @@ The cleanup is in good shape when:
 - storage, notifications, auth, and execution concerns follow their documented
   contracts in code
 - downstream apps need less compatibility glue to consume Voyant cleanly
+
+Voyant now meets that bar on `main`.

--- a/docs/architecture/platform-surface-roadmap.md
+++ b/docs/architecture/platform-surface-roadmap.md
@@ -207,7 +207,7 @@ Partially resolved:
 - `@voyantjs/checkout` now exposes a module-based checkout surface with typed
   collection-plan and initiate-collection contracts
 - `@voyantjs/checkout` now also exposes a unified
-  `/v1/checkout/collections/bootstrap` contract that can start exact-amount
+  `/v1/public/checkout/collections/bootstrap` contract that can start exact-amount
   collection from either a `bookingId` or a `sessionId`, covering booking-
   backed and session-backed storefront flows through one request shape
 - admin checkout reminder tracking is now backed by first-class notification

--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -16,6 +16,7 @@ import { ThemeProvider, useTheme } from "@voyantjs/voyant-admin/providers/theme"
 import { makeQueryClient } from "@voyantjs/voyant-admin/providers/query-client"
 import { getInitials, getDisplayName } from "@voyantjs/voyant-admin/lib/initials"
 import {
+  createAdminExtensionRegistry,
   defineAdminExtension,
   resolveAdminNavigation,
 } from "@voyantjs/voyant-admin"
@@ -62,7 +63,8 @@ export const financeExtension = defineAdminExtension({
 
 Templates can merge those contributions into their base navigation with
 `resolveAdminNavigation(...)` and expose widget slots with
-`resolveAdminWidgets(...)`.
+`resolveAdminWidgets(...)`. When a template wants one explicit source-controlled
+registry, compose it with `createAdminExtensionRegistry(...)`.
 
 ## License
 

--- a/packages/admin/src/extensions.ts
+++ b/packages/admin/src/extensions.ts
@@ -60,6 +60,18 @@ export function defineAdminExtension<T extends AdminExtension>(extension: T): T 
   return extension
 }
 
+/**
+ * Compose an explicit admin extension registry for a template or app shell.
+ *
+ * The admin surface stays source-controlled and typed while still routing
+ * all contributions through the shared admin runtime package.
+ */
+export function createAdminExtensionRegistry(
+  ...extensions: ReadonlyArray<AdminExtension>
+): ReadonlyArray<AdminExtension> {
+  return extensions
+}
+
 type OrderedValue<T> = {
   index: number
   order: number

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -20,6 +20,7 @@ export {
   type AdminUiRouteContribution,
   type AdminWidgetContribution,
   type AdminWidgetSlot,
+  createAdminExtensionRegistry,
   defineAdminExtension,
   type ResolveAdminNavigationOptions,
   type ResolveAdminWidgetsOptions,

--- a/packages/checkout/README.md
+++ b/packages/checkout/README.md
@@ -20,8 +20,9 @@ This package sits above `@voyantjs/finance` and `@voyantjs/notifications`. It do
 
 ## Routes
 
-- `POST /v1/checkout/bookings/:bookingId/collection-plan`
-- `POST /v1/checkout/bookings/:bookingId/initiate-collection`
+- `POST /v1/public/checkout/bookings/:bookingId/collection-plan`
+- `POST /v1/public/checkout/bookings/:bookingId/initiate-collection`
+- `POST /v1/public/checkout/collections/bootstrap`
 - `GET /v1/admin/checkout/bookings/:bookingId/reminder-runs`
 
 ## Notes
@@ -33,7 +34,7 @@ This package sits above `@voyantjs/finance` and `@voyantjs/notifications`. It do
   `resolveBankTransferDetails`
 - email-provider choice remains app-owned
 - projects can override the default collection policy when mounting checkout
-- `createCheckoutHonoModule()` now mounts checkout through Voyant's module
-  system while preserving the legacy `/v1/checkout/*` public path
+- `createCheckoutHonoModule()` mounts checkout under Voyant's shared
+  `/v1/public/*` surface instead of a separate legacy namespace
 - third parties can still ship provider integrations as plugin bundles, but
   checkout itself stays provider-agnostic

--- a/packages/checkout/src/routes.ts
+++ b/packages/checkout/src/routes.ts
@@ -66,7 +66,7 @@ export function createCheckoutRoutes(options: CheckoutRoutesOptions = {}) {
   }
 
   return new Hono<Env>()
-    .post("/v1/checkout/bookings/:bookingId/collection-plan", async (c) => {
+    .post("/bookings/:bookingId/collection-plan", async (c) => {
       try {
         const plan = await previewCheckoutCollection(
           c.get("db"),
@@ -86,7 +86,7 @@ export function createCheckoutRoutes(options: CheckoutRoutesOptions = {}) {
         return c.json({ error: message }, 400)
       }
     })
-    .post("/v1/checkout/bookings/:bookingId/initiate-collection", async (c) => {
+    .post("/bookings/:bookingId/initiate-collection", async (c) => {
       try {
         const runtime = getRuntime(c.env, (key) => c.var.container?.resolve(key))
         const dispatcher = createNotificationService(runtime.providers)
@@ -113,7 +113,7 @@ export function createCheckoutRoutes(options: CheckoutRoutesOptions = {}) {
         return c.json({ error: message }, 409)
       }
     })
-    .post("/v1/checkout/collections/bootstrap", async (c) => {
+    .post("/collections/bootstrap", async (c) => {
       try {
         const runtime = getRuntime(c.env, (key) => c.var.container?.resolve(key))
         const dispatcher = createNotificationService(runtime.providers)
@@ -166,7 +166,7 @@ export function createCheckoutHonoModule(options: CheckoutRoutesOptions = {}): H
 
   return {
     module,
-    routes: createCheckoutRoutes(options),
+    publicRoutes: createCheckoutRoutes(options),
     adminRoutes: createCheckoutAdminRoutes(),
   }
 }

--- a/packages/checkout/tests/unit/routes.test.ts
+++ b/packages/checkout/tests/unit/routes.test.ts
@@ -63,7 +63,7 @@ describe("createCheckoutRoutes", () => {
     app.route("/", routes)
 
     const res = await app.request(
-      "/v1/checkout/bookings/book_123/initiate-collection",
+      "/bookings/book_123/initiate-collection",
       {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -139,7 +139,7 @@ describe("createCheckoutRoutes", () => {
     })
     app.route("/", routes)
 
-    const res = await app.request("/v1/checkout/collections/bootstrap", {
+    const res = await app.request("/collections/bootstrap", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({

--- a/packages/customer-portal-react/src/operations.ts
+++ b/packages/customer-portal-react/src/operations.ts
@@ -23,7 +23,7 @@ import {
 
 export function getCustomerPortalContactExists(client: FetchWithValidationOptions, email: string) {
   return fetchWithValidation(
-    withQueryParams("/v1/customer-portal/contact-exists", { email }),
+    withQueryParams("/v1/public/customer-portal/contact-exists", { email }),
     customerPortalContactExistsResponseSchema,
     client,
   )
@@ -34,7 +34,7 @@ export function getCustomerPortalPhoneContactExists(
   phone: string,
 ) {
   return fetchWithValidation(
-    withQueryParams("/v1/customer-portal/contact-exists/phone", { phone }),
+    withQueryParams("/v1/public/customer-portal/contact-exists/phone", { phone }),
     customerPortalPhoneContactExistsResponseSchema,
     client,
   )

--- a/packages/customer-portal/src/index.ts
+++ b/packages/customer-portal/src/index.ts
@@ -5,7 +5,6 @@ import {
   buildPublicCustomerPortalRouteRuntime,
   CUSTOMER_PORTAL_ROUTE_RUNTIME_CONTAINER_KEY,
 } from "./route-runtime.js"
-import { customerPortalRoutes } from "./routes.js"
 import {
   createPublicCustomerPortalRoutes,
   type PublicCustomerPortalRouteOptions,
@@ -86,7 +85,6 @@ export function createCustomerPortalHonoModule(
 
   return {
     module,
-    routes: customerPortalRoutes,
     publicRoutes: createPublicCustomerPortalRoutes(options),
   }
 }

--- a/packages/customer-portal/src/routes-public.ts
+++ b/packages/customer-portal/src/routes-public.ts
@@ -8,6 +8,7 @@ import {
   CUSTOMER_PORTAL_ROUTE_RUNTIME_CONTAINER_KEY,
   type PublicCustomerPortalRouteRuntime,
 } from "./route-runtime.js"
+import { customerPortalRoutes } from "./routes.js"
 import { publicCustomerPortalService } from "./service-public.js"
 import {
   bootstrapCustomerPortalSchema,
@@ -63,6 +64,7 @@ export function createPublicCustomerPortalRoutes(options: PublicCustomerPortalRo
     getRuntime(c).resolveDocumentDownloadUrl?.(storageKey) ?? null
 
   return new Hono<Env>()
+    .route("/", customerPortalRoutes)
     .get("/me", async (c) => {
       const userId = requireUserId(c)
 

--- a/packages/customer-portal/src/service-public.ts
+++ b/packages/customer-portal/src/service-public.ts
@@ -545,7 +545,7 @@ async function listLegalDocumentsForBooking(
     const downloadUrl =
       attachment.storageKey && options.resolveDocumentDownloadUrl
         ? await options.resolveDocumentDownloadUrl(attachment.storageKey)
-        : getMetadataString(metadata, ["url", "downloadUrl"])
+        : getMetadataString(metadata, ["url"])
     if (!downloadUrl || bestAttachmentByContractId.has(attachment.contractId)) {
       continue
     }
@@ -575,17 +575,7 @@ async function listLegalDocumentsForBooking(
 }
 
 function resolveFinanceDocumentDownloadUrl(metadata: Record<string, unknown> | null) {
-  return getMetadataString(metadata, [
-    "downloadUrl",
-    "download_url",
-    "signedUrl",
-    "signed_url",
-    "publicUrl",
-    "public_url",
-    "fileUrl",
-    "file_url",
-    "url",
-  ])
+  return getMetadataString(metadata, ["url"])
 }
 
 function selectBookingSummaryProductTitle(

--- a/packages/customer-portal/tests/integration/public-routes.test.ts
+++ b/packages/customer-portal/tests/integration/public-routes.test.ts
@@ -902,7 +902,7 @@ describe.skipIf(!DB_AVAILABLE)("Public customer portal routes", () => {
         paidCents: 12000,
         balanceDueCents: 12000,
         documentStatus: "ready",
-        downloadUrl: `https://signed.example.com/finance/${invoice.id}/proforma-1001.pdf`,
+        url: `https://signed.example.com/finance/${invoice.id}/proforma-1001.pdf`,
       }),
     ])
     expect(detail.financials.payments).toEqual([

--- a/packages/finance/src/routes-documents.ts
+++ b/packages/finance/src/routes-documents.ts
@@ -67,14 +67,7 @@ function getFallbackDownloadUrl(metadata: unknown) {
     return null
   }
 
-  for (const key of ["url", "publicUrl", "downloadUrl", "download_url", "signedUrl"]) {
-    const value = maybeUrl(record[key])
-    if (value) {
-      return value
-    }
-  }
-
-  return null
+  return maybeUrl(record.url)
 }
 
 export function createFinanceAdminDocumentRoutes(options: FinanceDocumentRouteOptions = {}) {

--- a/packages/finance/src/service-public.ts
+++ b/packages/finance/src/service-public.ts
@@ -78,41 +78,7 @@ function maybeUrl(value: string | null | undefined) {
 }
 
 function getMetadataDownloadUrl(record: Record<string, unknown> | null) {
-  const directKeys = [
-    "downloadUrl",
-    "download_url",
-    "signedUrl",
-    "signed_url",
-    "publicUrl",
-    "public_url",
-    "fileUrl",
-    "file_url",
-    "url",
-  ]
-
-  for (const key of directKeys) {
-    const value = getMetadataString(record, key)
-    const url = maybeUrl(value)
-    if (url) {
-      return url
-    }
-  }
-
-  const artifact = record?.artifact
-  if (artifact && typeof artifact === "object" && !Array.isArray(artifact)) {
-    const nested = artifact as Record<string, unknown>
-    for (const key of ["downloadUrl", "download_url", "signedUrl", "publicUrl", "url"]) {
-      const value = nested[key]
-      if (typeof value === "string") {
-        const url = maybeUrl(value)
-        if (url) {
-          return url
-        }
-      }
-    }
-  }
-
-  return null
+  return maybeUrl(getMetadataString(record, "url"))
 }
 
 function toPublicPaymentSession(
@@ -159,10 +125,7 @@ async function mapInvoiceDocument(
     selectedRendition?.storageKey && runtime.resolveDocumentDownloadUrl
       ? await runtime.resolveDocumentDownloadUrl(selectedRendition.storageKey)
       : null
-  const downloadUrl =
-    resolvedDownloadUrl ??
-    getMetadataDownloadUrl(metadata) ??
-    maybeUrl(selectedRendition?.storageKey ?? null)
+  const downloadUrl = resolvedDownloadUrl ?? getMetadataDownloadUrl(metadata)
 
   return {
     invoiceId: invoice.id,

--- a/packages/finance/tests/integration/public-routes.test.ts
+++ b/packages/finance/tests/integration/public-routes.test.ts
@@ -254,7 +254,7 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
         format: "pdf",
         status: "failed",
         errorMessage: "renderer timeout",
-        metadata: { downloadUrl: "https://example.com/failed.pdf" },
+        metadata: { url: "https://example.com/failed.pdf" },
       },
       {
         invoiceId: invoice.id,
@@ -263,7 +263,7 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
         generatedAt: new Date("2025-06-02T12:00:00.000Z"),
         fileSize: 1024,
         checksum: "sha256:ready",
-        metadata: { downloadUrl: "https://example.com/invoice-ready.pdf" },
+        metadata: { url: "https://example.com/invoice-ready.pdf" },
       },
     ])
 
@@ -312,7 +312,7 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
       format: "pdf",
       status: "ready",
       generatedAt: new Date("2025-06-04T08:00:00.000Z"),
-      metadata: { downloadUrl: "https://example.com/proforma-by-reference.pdf" },
+      metadata: { url: "https://example.com/proforma-by-reference.pdf" },
     })
 
     await db.insert(payments).values({

--- a/packages/hono/src/middleware/auth.ts
+++ b/packages/hono/src/middleware/auth.ts
@@ -66,7 +66,12 @@ export function requireAuth<TBindings extends VoyantBindings>(
     if (isPublicAuth || isHealthCheck) return next()
 
     for (const pp of publicPaths) {
-      if (p === pp || p.startsWith(`${pp}/`)) return next()
+      if (p === pp || p.startsWith(`${pp}/`)) {
+        if (p.startsWith("/v1/public/")) {
+          c.set("actor", "customer")
+        }
+        return next()
+      }
     }
 
     const authHeader = c.req.header("authorization") || c.req.header("Authorization")

--- a/packages/hono/tests/unit/app-surfaces.test.ts
+++ b/packages/hono/tests/unit/app-surfaces.test.ts
@@ -145,6 +145,19 @@ describe("createApp surface mounting", () => {
     expect(((await publicRes.json()) as { surface: string }).surface).toBe("public")
   })
 
+  it("treats public-path bypasses under /v1/public/* as customer-facing requests", async () => {
+    const app = createApp({
+      // biome-ignore lint/suspicious/noExplicitAny: test doesn't use db
+      db: () => ({}) as any,
+      modules: [makeModule({ name: "checkout", public_: true })],
+      publicPaths: ["/v1/public/checkout"],
+    })
+
+    const res = await app.request("/v1/public/checkout/ping", {}, TEST_ENV, TEST_CTX)
+    expect(res.status).toBe(200)
+    expect(((await res.json()) as { surface: string }).surface).toBe("public")
+  })
+
   it("exposes /health publicly without auth", async () => {
     const app = createApp({
       // biome-ignore lint/suspicious/noExplicitAny: test doesn't use db

--- a/packages/legal/src/contracts/routes.ts
+++ b/packages/legal/src/contracts/routes.ts
@@ -81,14 +81,7 @@ function getFallbackDownloadUrl(metadata: unknown) {
     return null
   }
 
-  for (const key of ["url", "publicUrl", "downloadUrl", "download_url", "signedUrl"]) {
-    const value = maybeUrl(record[key])
-    if (value) {
-      return value
-    }
-  }
-
-  return null
+  return maybeUrl(record.url)
 }
 
 export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) {

--- a/packages/notifications/src/service-booking-documents.ts
+++ b/packages/notifications/src/service-booking-documents.ts
@@ -147,7 +147,7 @@ async function listLegalBookingDocuments(
         format: attachment.mimeType === "application/pdf" ? "pdf" : null,
         mimeType: attachment.mimeType ?? null,
         storageKey: attachment.storageKey ?? null,
-        downloadUrl: getMetadataString(metadata, ["url", "downloadUrl"]),
+        downloadUrl: getMetadataString(metadata, ["url"]),
         language: contract.language ?? null,
         metadata,
         createdAt: attachment.createdAt.toISOString(),
@@ -243,7 +243,7 @@ async function listFinanceBookingDocuments(
                 ? "application/json"
                 : "application/xml",
         storageKey: rendition.storageKey ?? null,
-        downloadUrl: getMetadataString(metadata, ["url", "downloadUrl"]),
+        downloadUrl: getMetadataString(metadata, ["url"]),
         language: rendition.language ?? invoice.language ?? null,
         metadata,
         createdAt: rendition.createdAt.toISOString(),

--- a/packages/plugins/netopia/README.md
+++ b/packages/plugins/netopia/README.md
@@ -9,7 +9,7 @@ Architecturally, this package is primarily:
 
 - a Netopia payment adapter
 - a finance extension
-- an optional Hono plugin bundle for distribution
+- an optional packaged Hono bundle when an app wants one installable entrypoint
 
 It starts a hosted Netopia checkout, stores provider references on the session,
 and reconciles callback payloads back into Voyant payments, captures,
@@ -58,7 +58,7 @@ const netopiaFinanceExtension = createNetopiaFinanceAdapter()
 
 Then include the returned extension in `createApp({ extensions: [...] })`.
 
-If you want the packaged Hono bundle instead, use
+If you want the packaged distribution helper instead, use
 `createNetopiaAdapterBundle()` or `netopiaHonoPlugin()`. Those are optional
 distribution helpers over the adapter/extension surfaces above; the adapter and
 finance extension remain the main runtime seams.

--- a/packages/plugins/payload-cms/README.md
+++ b/packages/plugins/payload-cms/README.md
@@ -6,7 +6,7 @@ Architecturally, this package is primarily:
 
 - a Payload sync adapter
 - a subscriber bundle that mirrors Voyant module records into Payload
-- an optional plugin bundle for distribution
+- an optional packaged bundle when an app wants one installable entrypoint
 
 It subscribes to module events and mirrors documents into a Payload collection
 keyed by a `voyantId` field.
@@ -35,10 +35,10 @@ const app = createApp({
 })
 ```
 
-The exported value is an optional distribution bundle. At runtime, the package
-behaves primarily as a subscriber-driven Payload sync adapter. By default it
-wires up 3 subscribers (`product.created`, `product.updated`, `product.deleted`)
-that upsert/delete documents keyed by `voyantId`. All error handling is
+`payloadCmsPlugin(...)` is the packaged distribution helper. The runtime role is
+still a subscriber-driven Payload sync adapter. By default it wires up 3
+subscribers (`product.created`, `product.updated`, `product.deleted`) that
+upsert/delete documents keyed by `voyantId`. All error handling is
 fire-and-forget per the EventBus contract.
 
 ## Exports
@@ -46,9 +46,9 @@ fire-and-forget per the EventBus contract.
 | Entry | Description |
 | --- | --- |
 | `.` | Barrel re-exports |
-| `./plugin` | `payloadCmsPlugin(options)` |
+| `./plugin` | `payloadCmsPlugin(options)` — packaged adapter/subscriber bundle |
 | `./client` | `createPayloadClient` — `upsertByVoyantId`, `deleteByVoyantId`, `findByVoyantId` |
-| `./types` | Plugin option types |
+| `./types` | Adapter and bundle option types |
 
 ## License
 

--- a/packages/plugins/sanity-cms/README.md
+++ b/packages/plugins/sanity-cms/README.md
@@ -6,7 +6,7 @@ Architecturally, this package is primarily:
 
 - a Sanity sync adapter
 - a subscriber bundle that mirrors Voyant module records into Sanity
-- an optional plugin bundle for distribution
+- an optional packaged bundle when an app wants one installable entrypoint
 
 It subscribes to module events and mirrors documents into a Sanity dataset keyed
 by a `voyantId` field.
@@ -36,8 +36,8 @@ const app = createApp({
 })
 ```
 
-Uses GROQ for reads and Sanity Mutations API for writes. The exported value is
-an optional distribution bundle; at runtime the package is primarily a
+Uses GROQ for reads and Sanity Mutations API for writes. `sanityCmsPlugin(...)`
+is the packaged distribution helper; at runtime the package is primarily a
 subscriber-driven Sanity sync adapter. Default `apiVersion` is `"2024-01-01"`.
 By default it wires up 3 subscribers
 (`product.created`, `product.updated`, `product.deleted`).
@@ -47,9 +47,9 @@ By default it wires up 3 subscribers
 | Entry | Description |
 | --- | --- |
 | `.` | Barrel re-exports |
-| `./plugin` | `sanityCmsPlugin(options)` |
+| `./plugin` | `sanityCmsPlugin(options)` — packaged adapter/subscriber bundle |
 | `./client` | `createSanityClient` — `upsertByVoyantId`, `deleteByVoyantId`, `findByVoyantId` |
-| `./types` | Plugin option types |
+| `./types` | Adapter and bundle option types |
 
 ## License
 

--- a/packages/plugins/smartbill/README.md
+++ b/packages/plugins/smartbill/README.md
@@ -6,7 +6,7 @@ Architecturally, this package is primarily:
 
 - a SmartBill e-invoicing adapter
 - a subscriber bundle for finance invoice events
-- an optional plugin bundle for distribution
+- an optional packaged bundle when an app wants one installable entrypoint
 
 It subscribes to invoice events and creates, cancels, or syncs invoices via the
 SmartBill REST API for Romanian tax compliance.
@@ -36,9 +36,9 @@ const app = createApp({
 })
 ```
 
-The exported value is an optional distribution bundle. At runtime, the package
-behaves primarily as a subscriber-driven SmartBill sync adapter. By default it
-wires up 3 subscribers (`invoice.issued`, `invoice.voided`,
+`smartbillPlugin(...)` is the packaged distribution helper. At runtime, the
+package behaves primarily as a subscriber-driven SmartBill sync adapter. By
+default it wires up 3 subscribers (`invoice.issued`, `invoice.voided`,
 `invoice.external.sync.requested`) that create, cancel, and check payment
 status on SmartBill. All error handling is fire-and-forget per the EventBus
 contract.
@@ -48,9 +48,9 @@ contract.
 | Entry | Description |
 | --- | --- |
 | `.` | Barrel re-exports |
-| `./plugin` | `smartbillPlugin(options)` |
+| `./plugin` | `smartbillPlugin(options)` — packaged adapter/subscriber bundle |
 | `./client` | `createSmartbillClient` — `createInvoice`, `cancelInvoice`, `viewPdf`, `getPaymentStatus`, etc. |
-| `./types` | SmartBill invoice types |
+| `./types` | SmartBill adapter and bundle types |
 
 ## License
 

--- a/templates/dmc/src/api/app.ts
+++ b/templates/dmc/src/api/app.ts
@@ -63,14 +63,8 @@ const checkoutHonoModule = createCheckoutHonoModule({
   resolveProviders: resolveNotificationProviders,
 })
 const customerPortalHonoModule = createCustomerPortalHonoModule({
-  resolveDocumentDownloadUrl: async (bindings, storageKey) => {
-    const storage = createMediaStorage(bindings as CloudflareBindings)
-    if (!storage) {
-      return null
-    }
-
-    return storage.signedUrl(storageKey, 300)
-  },
+  resolveDocumentDownloadUrl: (bindings, storageKey) =>
+    resolveDocumentDownloadUrl(bindings as CloudflareBindings, storageKey),
 })
 
 const financeModule = createFinanceHonoModule({
@@ -85,9 +79,9 @@ const legalModule = createLegalHonoModule({
 export const app = createApp<CloudflareBindings>({
   db: (env) => getDbFromHyperdrive(env),
   publicPaths: [
-    "/v1/customer-portal/contact-exists",
-    "/v1/storefront-verification",
-    "/v1/checkout",
+    "/v1/public/customer-portal/contact-exists",
+    "/v1/public/storefront-verification",
+    "/v1/public/checkout",
   ],
   modules: [
     crmHonoModule,

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -60,14 +60,8 @@ const checkoutHonoModule = createCheckoutHonoModule({
   resolveProviders: resolveNotificationProviders,
 })
 const customerPortalHonoModule = createCustomerPortalHonoModule({
-  resolveDocumentDownloadUrl: async (bindings, storageKey) => {
-    const storage = createMediaStorage(bindings as CloudflareBindings)
-    if (!storage) {
-      return null
-    }
-
-    return storage.signedUrl(storageKey, 300)
-  },
+  resolveDocumentDownloadUrl: (bindings, storageKey) =>
+    resolveDocumentDownloadUrl(bindings as CloudflareBindings, storageKey),
 })
 
 const financeModule = createFinanceHonoModule({
@@ -82,9 +76,9 @@ const legalModule = createLegalHonoModule({
 export const app = createApp<CloudflareBindings>({
   db: (env) => getDbFromHyperdrive(env),
   publicPaths: [
-    "/v1/customer-portal/contact-exists",
-    "/v1/storefront-verification",
-    "/v1/checkout",
+    "/v1/public/customer-portal/contact-exists",
+    "/v1/public/storefront-verification",
+    "/v1/public/checkout",
   ],
   modules: [
     crmHonoModule,

--- a/templates/operator/src/lib/admin-extensions.tsx
+++ b/templates/operator/src/lib/admin-extensions.tsx
@@ -1,13 +1,16 @@
-import { type AdminExtension, defineAdminExtension } from "@voyantjs/voyant-admin"
+import {
+  type AdminExtension,
+  createAdminExtensionRegistry,
+  defineAdminExtension,
+} from "@voyantjs/voyant-admin"
 
 import { DashboardOutstandingInvoicesWidget } from "@/components/admin/widgets/dashboard-outstanding-invoices-widget"
 
 /**
- * Template-local admin extension registry.
+ * Operator admin contributions composed through the shared admin runtime.
  *
- * Keep this explicit and source-controlled so projects can add navigation
- * contributions, widget slots, and route metadata without relying on a more
- * dynamic plugin runtime in the admin shell.
+ * Keep this explicit and source-controlled so the template still owns shell
+ * composition while the extension seam stays typed and framework-level.
  *
  * Widget slots currently exposed by the operator template:
  * - `dashboard.header`
@@ -18,7 +21,7 @@ import { DashboardOutstandingInvoicesWidget } from "@/components/admin/widgets/d
  * - `invoice.details.header`
  * - `invoice.details.after-summary`
  */
-export const adminExtensions: ReadonlyArray<AdminExtension> = [
+export const adminExtensions: ReadonlyArray<AdminExtension> = createAdminExtensionRegistry(
   defineAdminExtension({
     id: "dashboard-outstanding-invoices",
     widgets: [
@@ -30,4 +33,4 @@ export const adminExtensions: ReadonlyArray<AdminExtension> = [
       },
     ],
   }),
-]
+)


### PR DESCRIPTION
## Summary
- complete the remaining extensibility cleanup work described by the architecture docs
- align public/customer-facing routes and auth bypasses with the shared `/v1/public/*` contract
- tighten document download resolution around `storageKey` plus narrow `metadata.url` fallback, and update the gap analysis to the completed state

## What changed
- added `createAdminExtensionRegistry(...)` in `@voyantjs/voyant-admin` and switched the operator template to use the shared registry surface
- moved checkout and customer-portal customer-facing operations fully onto the `/v1/public/*` surface, including template/app `publicPaths`
- made public-path auth bypasses under `/v1/public/*` default to a customer actor so public routes stay anonymous-but-customer-facing
- removed legacy document URL key compatibility scans in finance/legal/customer-portal/notifications in favor of storage resolution plus `metadata.url`
- updated plugin/package README language and the extensibility gap analysis to reflect the aligned architecture

## Validation
- `pnpm -C packages/hono lint && pnpm -C packages/hono typecheck && pnpm -C packages/hono test`
- `pnpm -C packages/checkout lint && pnpm -C packages/checkout typecheck && pnpm -C packages/checkout test`
- `pnpm -C packages/customer-portal lint && pnpm -C packages/customer-portal typecheck && pnpm -C packages/customer-portal test`
- `pnpm -C packages/finance lint && pnpm -C packages/finance typecheck && pnpm -C packages/finance test`
- `pnpm -C packages/legal lint && pnpm -C packages/legal typecheck && pnpm -C packages/legal test`
- `pnpm -C packages/notifications lint && pnpm -C packages/notifications typecheck && pnpm -C packages/notifications test`
- `pnpm -C packages/admin lint && pnpm -C packages/admin typecheck && pnpm -C packages/admin test`
- `pnpm -C templates/operator lint && pnpm -C templates/operator typecheck && pnpm -C templates/operator test`
- `pnpm -C templates/dmc lint && pnpm -C templates/dmc typecheck && pnpm -C templates/dmc test`
- `pnpm -C apps/dev lint && pnpm -C apps/dev typecheck && pnpm -C apps/dev test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
