### PR TITLE
[codex] execute sellability index policy in code

### DIFF
--- a/.changeset/sellability-index-policy-execution.md
+++ b/.changeset/sellability-index-policy-execution.md
@@ -1,0 +1,7 @@
+---
+"@voyantjs/sellability": patch
+---
+
+Align sellability schema indexes with the active index policy by replacing
+decorative single-column list indexes with parent-and-sort composite indexes
+for snapshot items, policy results, explanations, and offer lifecycle runs.

--- a/packages/sellability/src/schema.ts
+++ b/packages/sellability/src/schema.ts
@@ -137,7 +137,11 @@ export const sellabilitySnapshotItems = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_sellability_snapshot_items_snapshot").on(table.snapshotId),
+    index("idx_sellability_snapshot_items_snapshot_order").on(
+      table.snapshotId,
+      table.candidateIndex,
+      table.componentIndex,
+    ),
     index("idx_sellability_snapshot_items_candidate").on(table.candidateIndex),
     index("idx_sellability_snapshot_items_component").on(table.componentKind),
     index("idx_sellability_snapshot_items_product").on(table.productId),
@@ -198,7 +202,7 @@ export const sellabilityPolicyResults = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_sellability_policy_results_snapshot").on(table.snapshotId),
+    index("idx_sellability_policy_results_snapshot_created").on(table.snapshotId, table.createdAt),
     index("idx_sellability_policy_results_snapshot_item").on(table.snapshotItemId),
     index("idx_sellability_policy_results_policy").on(table.policyId),
     index("idx_sellability_policy_results_status").on(table.status),
@@ -222,7 +226,7 @@ export const offerRefreshRuns = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_offer_refresh_runs_offer").on(table.offerId),
+    index("idx_offer_refresh_runs_offer_started").on(table.offerId, table.startedAt),
     index("idx_offer_refresh_runs_snapshot").on(table.snapshotId),
     index("idx_offer_refresh_runs_status").on(table.status),
   ],
@@ -245,7 +249,7 @@ export const offerExpirationEvents = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_offer_expiration_events_offer").on(table.offerId),
+    index("idx_offer_expiration_events_offer_expires").on(table.offerId, table.expiresAt),
     index("idx_offer_expiration_events_snapshot").on(table.snapshotId),
     index("idx_offer_expiration_events_status").on(table.status),
   ],
@@ -269,7 +273,7 @@ export const sellabilityExplanations = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_sellability_explanations_snapshot").on(table.snapshotId),
+    index("idx_sellability_explanations_snapshot_created").on(table.snapshotId, table.createdAt),
     index("idx_sellability_explanations_snapshot_item").on(table.snapshotItemId),
     index("idx_sellability_explanations_type").on(table.explanationType),
   ],


### PR DESCRIPTION
## What changed

This executes the first real slice of the new index policy in code, in `@voyantjs/sellability`.

It replaces several decorative single-column list indexes with composite parent-and-sort indexes that match the actual read paths in the package:

- `sellability_snapshot_items(snapshot_id, candidate_index, component_index)`
- `sellability_policy_results(snapshot_id, created_at)`
- `offer_refresh_runs(offer_id, started_at)`
- `offer_expiration_events(offer_id, expires_at)`
- `sellability_explanations(snapshot_id, created_at)`

## Why

The newly promoted architecture guidance says index choices should start from stable query shape rather than column-by-column habit.

`@voyantjs/sellability` was still using single-column indexes for several scoped list queries that always read through a dominant parent and stable sort order.

This PR is the first concrete execution of that policy.

## Impact

- keeps the package API unchanged
- narrows the schema toward the real list/query workload
- makes the first future-architecture item an actual runtime/schema change rather than docs only

## Validation

- `pnpm -C packages/sellability lint`
- `pnpm -C packages/sellability typecheck`
- `pnpm -C packages/sellability test`
- `pnpm -C packages/sellability build`
- repo pre-push `pnpm test`
