### PR TITLE
[codex] execute transaction child-list index policy

### DIFF
--- a/.changeset/transactions-index-policy-execution.md
+++ b/.changeset/transactions-index-policy-execution.md
@@ -1,0 +1,8 @@
+---
+"@voyantjs/transactions": patch
+---
+
+Align transaction child-list indexes with dominant parent-scoped query shapes
+by replacing single-column parent indexes with composite parent-and-sort
+indexes for offer participants, offer items, order participants, order items,
+order item participants, and order terms.

--- a/packages/transactions/src/schema-offers.ts
+++ b/packages/transactions/src/schema-offers.ts
@@ -89,7 +89,7 @@ export const offerParticipants = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_offer_participants_offer").on(table.offerId),
+    index("idx_offer_participants_offer_created").on(table.offerId, table.createdAt),
     index("idx_offer_participants_person").on(table.personId),
     index("idx_offer_participants_type").on(table.participantType),
   ],
@@ -128,7 +128,7 @@ export const offerItems = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_offer_items_offer").on(table.offerId),
+    index("idx_offer_items_offer_created").on(table.offerId, table.createdAt),
     index("idx_offer_items_product").on(table.productId),
     index("idx_offer_items_option").on(table.optionId),
     index("idx_offer_items_unit").on(table.unitId),
@@ -152,7 +152,7 @@ export const offerItemParticipants = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_offer_item_participants_item").on(table.offerItemId),
+    index("idx_offer_item_participants_item_created").on(table.offerItemId, table.createdAt),
     index("idx_offer_item_participants_participant").on(table.participantId),
     uniqueIndex("uidx_offer_item_participants").on(table.offerItemId, table.participantId),
   ],

--- a/packages/transactions/src/schema-orders.ts
+++ b/packages/transactions/src/schema-orders.ts
@@ -92,7 +92,7 @@ export const orderParticipants = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_order_participants_order").on(table.orderId),
+    index("idx_order_participants_order_created").on(table.orderId, table.createdAt),
     index("idx_order_participants_person").on(table.personId),
     index("idx_order_participants_type").on(table.participantType),
   ],
@@ -134,7 +134,7 @@ export const orderItems = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_order_items_order").on(table.orderId),
+    index("idx_order_items_order_created").on(table.orderId, table.createdAt),
     index("idx_order_items_offer_item").on(table.offerItemId),
     index("idx_order_items_product").on(table.productId),
     index("idx_order_items_option").on(table.optionId),
@@ -159,7 +159,7 @@ export const orderItemParticipants = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_order_item_participants_item").on(table.orderItemId),
+    index("idx_order_item_participants_item_created").on(table.orderItemId, table.createdAt),
     index("idx_order_item_participants_participant").on(table.participantId),
     uniqueIndex("uidx_order_item_participants").on(table.orderItemId, table.participantId),
   ],
@@ -188,7 +188,7 @@ export const orderTerms = pgTable(
   },
   (table) => [
     index("idx_order_terms_offer").on(table.offerId),
-    index("idx_order_terms_order").on(table.orderId),
+    index("idx_order_terms_order_sort").on(table.orderId, table.sortOrder, table.createdAt),
     index("idx_order_terms_type").on(table.termType),
     index("idx_order_terms_acceptance").on(table.acceptanceStatus),
   ],


### PR DESCRIPTION
## What changed

This executes the next real slice of the active index policy in `@voyantjs/transactions`.

It replaces single-column parent-key indexes with composite parent-and-sort indexes for transaction child lists that are always read inside a parent scope:

- `offer_participants(offer_id, created_at)`
- `offer_items(offer_id, created_at)`
- `offer_item_participants(offer_item_id, created_at)`
- `order_participants(order_id, created_at)`
- `order_items(order_id, created_at)`
- `order_item_participants(order_item_id, created_at)`
- `order_terms(order_id, sort_order, created_at)`

## Why

These tables back dominant list queries in `service-offers.ts` and `service-orders.ts` that filter by a parent id and then sort within that parent.

The old schema kept only the parent-key index, which is the same decorative single-column pattern the new architecture policy is intended to remove.

## Impact

- no API changes
- no domain behavior changes
- tighter alignment between the transactions schema and the query shapes it actually serves

## Validation

- `pnpm -C packages/transactions lint`
- `pnpm -C packages/transactions typecheck`
- `pnpm -C packages/transactions test`
- `pnpm -C packages/transactions build`
- repo pre-push `pnpm test`
