### PR TITLE
feat: align hospitality parent-list indexes

### DIFF
--- a/.changeset/hospitality-index-policy-execution.md
+++ b/.changeset/hospitality-index-policy-execution.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/hospitality": patch
+---
+
+Align hospitality parent-list indexes with the active index policy.

--- a/packages/hospitality/src/schema-bookings.ts
+++ b/packages/hospitality/src/schema-bookings.ts
@@ -55,7 +55,7 @@ export const stayBookingItems = pgTable(
   },
   (table) => [
     index("idx_stay_booking_items_booking_item").on(table.bookingItemId),
-    index("idx_stay_booking_items_property").on(table.propertyId),
+    index("idx_stay_booking_items_property_check_in").on(table.propertyId, table.checkInDate),
     index("idx_stay_booking_items_room_type").on(table.roomTypeId),
     index("idx_stay_booking_items_room_unit").on(table.roomUnitId),
     index("idx_stay_booking_items_rate_plan").on(table.ratePlanId),
@@ -109,7 +109,7 @@ export const roomBlocks = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_room_blocks_property").on(table.propertyId),
+    index("idx_room_blocks_property_starts_on").on(table.propertyId, table.startsOn),
     index("idx_room_blocks_room_type").on(table.roomTypeId),
     index("idx_room_blocks_room_unit").on(table.roomUnitId),
     index("idx_room_blocks_status").on(table.status),
@@ -133,7 +133,10 @@ export const roomUnitStatusEvents = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_room_unit_status_events_room_unit").on(table.roomUnitId),
+    index("idx_room_unit_status_events_room_unit_effective_from").on(
+      table.roomUnitId,
+      table.effectiveFrom,
+    ),
     index("idx_room_unit_status_events_status").on(table.statusCode),
     index("idx_room_unit_status_events_effective_from").on(table.effectiveFrom),
   ],
@@ -158,7 +161,7 @@ export const maintenanceBlocks = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_maintenance_blocks_property").on(table.propertyId),
+    index("idx_maintenance_blocks_property_starts_on").on(table.propertyId, table.startsOn),
     index("idx_maintenance_blocks_room_type").on(table.roomTypeId),
     index("idx_maintenance_blocks_room_unit").on(table.roomUnitId),
     index("idx_maintenance_blocks_status").on(table.status),
@@ -192,7 +195,11 @@ export const housekeepingTasks = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_housekeeping_tasks_property").on(table.propertyId),
+    index("idx_housekeeping_tasks_property_priority_due_at").on(
+      table.propertyId,
+      table.priority,
+      table.dueAt,
+    ),
     index("idx_housekeeping_tasks_room_unit").on(table.roomUnitId),
     index("idx_housekeeping_tasks_stay_booking_item").on(table.stayBookingItemId),
     index("idx_housekeeping_tasks_status").on(table.status),

--- a/packages/hospitality/src/schema-inventory.ts
+++ b/packages/hospitality/src/schema-inventory.ts
@@ -49,7 +49,7 @@ export const roomTypes = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_room_types_property").on(table.propertyId),
+    index("idx_room_types_property_sort_name").on(table.propertyId, table.sortOrder, table.name),
     index("idx_room_types_active").on(table.active),
     index("idx_room_types_inventory_mode").on(table.inventoryMode),
     uniqueIndex("uidx_room_types_property_code").on(table.propertyId, table.code),
@@ -71,7 +71,11 @@ export const roomTypeBedConfigs = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_room_type_bed_configs_room_type").on(table.roomTypeId),
+    index("idx_room_type_bed_configs_room_type_primary_created").on(
+      table.roomTypeId,
+      table.isPrimary,
+      table.createdAt,
+    ),
     index("idx_room_type_bed_configs_primary").on(table.isPrimary),
   ],
 )
@@ -100,7 +104,11 @@ export const roomUnits = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_room_units_property").on(table.propertyId),
+    index("idx_room_units_property_room_number_code").on(
+      table.propertyId,
+      table.roomNumber,
+      table.code,
+    ),
     index("idx_room_units_room_type").on(table.roomTypeId),
     index("idx_room_units_status").on(table.status),
     uniqueIndex("uidx_room_units_property_code").on(table.propertyId, table.code),
@@ -128,7 +136,7 @@ export const mealPlans = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_meal_plans_property").on(table.propertyId),
+    index("idx_meal_plans_property_sort_name").on(table.propertyId, table.sortOrder, table.name),
     index("idx_meal_plans_active").on(table.active),
     uniqueIndex("uidx_meal_plans_property_code").on(table.propertyId, table.code),
   ],
@@ -160,7 +168,7 @@ export const ratePlans = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_rate_plans_property").on(table.propertyId),
+    index("idx_rate_plans_property_sort_name").on(table.propertyId, table.sortOrder, table.name),
     index("idx_rate_plans_meal_plan").on(table.mealPlanId),
     index("idx_rate_plans_catalog").on(table.priceCatalogId),
     index("idx_rate_plans_policy").on(table.cancellationPolicyId),
@@ -189,7 +197,11 @@ export const ratePlanRoomTypes = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_rate_plan_room_types_rate_plan").on(table.ratePlanId),
+    index("idx_rate_plan_room_types_rate_plan_sort_created").on(
+      table.ratePlanId,
+      table.sortOrder,
+      table.createdAt,
+    ),
     index("idx_rate_plan_room_types_room_type").on(table.roomTypeId),
     index("idx_rate_plan_room_types_product").on(table.productId),
     index("idx_rate_plan_room_types_option").on(table.optionId),

--- a/packages/hospitality/src/schema-operations.ts
+++ b/packages/hospitality/src/schema-operations.ts
@@ -45,7 +45,7 @@ export const stayOperations = pgTable(
   },
   (table) => [
     uniqueIndex("uidx_stay_operations_stay_booking_item").on(table.stayBookingItemId),
-    index("idx_stay_operations_property").on(table.propertyId),
+    index("idx_stay_operations_property_created").on(table.propertyId, table.createdAt),
     index("idx_stay_operations_room_unit").on(table.roomUnitId),
     index("idx_stay_operations_status").on(table.operationStatus),
   ],
@@ -66,7 +66,7 @@ export const stayCheckpoints = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_stay_checkpoints_operation").on(table.stayOperationId),
+    index("idx_stay_checkpoints_operation_occurred_at").on(table.stayOperationId, table.occurredAt),
     index("idx_stay_checkpoints_type").on(table.checkpointType),
     index("idx_stay_checkpoints_occurred_at").on(table.occurredAt),
   ],
@@ -95,7 +95,10 @@ export const stayServicePosts = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_stay_service_posts_operation").on(table.stayOperationId),
+    index("idx_stay_service_posts_operation_service_date").on(
+      table.stayOperationId,
+      table.serviceDate,
+    ),
     index("idx_stay_service_posts_booking_item").on(table.bookingItemId),
     index("idx_stay_service_posts_service_date").on(table.serviceDate),
     index("idx_stay_service_posts_kind").on(table.kind),
@@ -119,7 +122,7 @@ export const stayFolios = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_stay_folios_operation").on(table.stayOperationId),
+    index("idx_stay_folios_operation_opened_at").on(table.stayOperationId, table.openedAt),
     index("idx_stay_folios_status").on(table.status),
   ],
 )
@@ -147,7 +150,7 @@ export const stayFolioLines = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_stay_folio_lines_folio").on(table.stayFolioId),
+    index("idx_stay_folio_lines_folio_posted_at").on(table.stayFolioId, table.postedAt),
     index("idx_stay_folio_lines_service_post").on(table.servicePostId),
     index("idx_stay_folio_lines_posted_at").on(table.postedAt),
   ],

--- a/packages/hospitality/src/schema-pricing.ts
+++ b/packages/hospitality/src/schema-pricing.ts
@@ -43,7 +43,11 @@ export const stayRules = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_stay_rules_property").on(table.propertyId),
+    index("idx_stay_rules_property_priority_created").on(
+      table.propertyId,
+      table.priority,
+      table.createdAt,
+    ),
     index("idx_stay_rules_rate_plan").on(table.ratePlanId),
     index("idx_stay_rules_room_type").on(table.roomTypeId),
     index("idx_stay_rules_active").on(table.active),
@@ -73,7 +77,7 @@ export const roomInventory = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_room_inventory_property").on(table.propertyId),
+    index("idx_room_inventory_property_date").on(table.propertyId, table.date),
     index("idx_room_inventory_room_type").on(table.roomTypeId),
     index("idx_room_inventory_date").on(table.date),
     uniqueIndex("uidx_room_inventory_room_type_date").on(table.roomTypeId, table.date),
@@ -101,7 +105,7 @@ export const ratePlanInventoryOverrides = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_rate_plan_inventory_overrides_rate_plan").on(table.ratePlanId),
+    index("idx_rate_plan_inventory_overrides_rate_plan_date").on(table.ratePlanId, table.date),
     index("idx_rate_plan_inventory_overrides_room_type").on(table.roomTypeId),
     index("idx_rate_plan_inventory_overrides_date").on(table.date),
     uniqueIndex("uidx_rate_plan_inventory_overrides_unique").on(
@@ -134,7 +138,7 @@ export const roomTypeRates = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_room_type_rates_rate_plan").on(table.ratePlanId),
+    index("idx_room_type_rates_rate_plan_created").on(table.ratePlanId, table.createdAt),
     index("idx_room_type_rates_room_type").on(table.roomTypeId),
     index("idx_room_type_rates_price_schedule").on(table.priceScheduleId),
     index("idx_room_type_rates_active").on(table.active),


### PR DESCRIPTION
## Summary
- align hospitality parent-list indexes with the active index policy
- replace single parent indexes with parent-plus-sort/date composites for the audited list query paths
- add a patch changeset for @voyantjs/hospitality

## Validation
- pnpm -C packages/hospitality lint
- pnpm -C packages/hospitality typecheck
- pnpm -C packages/hospitality test
- pnpm -C packages/hospitality build
- git diff --check
- pnpm test