### PR TITLE
feat: serialize worker reminder sweeps

### DIFF
--- a/.changeset/reminder-sweep-locking.md
+++ b/.changeset/reminder-sweep-locking.md
@@ -1,0 +1,7 @@
+---
+"@voyantjs/core": patch
+"@voyantjs/db": patch
+"@voyantjs/notifications": patch
+---
+
+Add a narrow execution lock surface and use it to serialize worker-driven notification reminder sweeps across processes.

--- a/apps/dev/package.json
+++ b/apps/dev/package.json
@@ -36,6 +36,7 @@
     "@voyantjs/bookings": "workspace:*",
     "@voyantjs/bookings-react": "workspace:*",
     "@voyantjs/checkout": "workspace:*",
+    "@voyantjs/core": "workspace:*",
     "@voyantjs/crm": "workspace:*",
     "@voyantjs/crm-react": "workspace:*",
     "@voyantjs/customer-portal": "workspace:*",

--- a/apps/dev/src/lib/notifications.ts
+++ b/apps/dev/src/lib/notifications.ts
@@ -1,3 +1,4 @@
+import { createInMemoryExecutionLockManager } from "@voyantjs/core"
 import {
   buildNotificationTaskRuntime,
   createDefaultNotificationProviders,
@@ -6,7 +7,10 @@ import {
 export const resolveNotificationProviders = (env: Record<string, unknown>) =>
   createDefaultNotificationProviders(env, { emailProvider: "resend" })
 
+const reminderSweepLockManager = createInMemoryExecutionLockManager()
+
 export const getNotificationTaskRuntime = (env: Record<string, unknown>) =>
   buildNotificationTaskRuntime(env, {
     resolveProviders: resolveNotificationProviders,
+    reminderSweepLockManager,
   })

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,7 @@
     "./env": "./src/env.ts",
     "./module": "./src/module.ts",
     "./hooks": "./src/hooks.ts",
+    "./locking": "./src/locking.ts",
     "./registry": "./src/registry.ts",
     "./container": "./src/container.ts",
     "./events": "./src/events.ts",
@@ -52,6 +53,10 @@
       "./hooks": {
         "types": "./dist/hooks.d.ts",
         "import": "./dist/hooks.js"
+      },
+      "./locking": {
+        "types": "./dist/locking.d.ts",
+        "import": "./dist/locking.js"
       },
       "./registry": {
         "types": "./dist/registry.d.ts",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,6 +44,11 @@ export type {
   ResolvedLinkSpec,
 } from "./links.js"
 export { defineLink, generateLinkTableSql, resolveLinkFromSpec } from "./links.js"
+export type {
+  ExclusiveExecutionResult,
+  ExecutionLockManager,
+} from "./locking.js"
+export { createInMemoryExecutionLockManager } from "./locking.js"
 export type { BootstrapContext, BootstrapHandler, Extension, Module } from "./module.js"
 export type { JobOptions, JobRunner } from "./orchestration.js"
 export type {

--- a/packages/core/src/locking.ts
+++ b/packages/core/src/locking.ts
@@ -1,0 +1,28 @@
+export type ExclusiveExecutionResult<T> = { executed: true; value: T } | { executed: false }
+
+export interface ExecutionLockManager {
+  runExclusive<T>(key: string, task: () => Promise<T>): Promise<ExclusiveExecutionResult<T>>
+  dispose?(): Promise<void>
+}
+
+export function createInMemoryExecutionLockManager(): ExecutionLockManager {
+  const activeKeys = new Set<string>()
+
+  return {
+    async runExclusive<T>(key: string, task: () => Promise<T>) {
+      if (activeKeys.has(key)) {
+        return { executed: false }
+      }
+
+      activeKeys.add(key)
+      try {
+        return {
+          executed: true,
+          value: await task(),
+        }
+      } finally {
+        activeKeys.delete(key)
+      }
+    },
+  }
+}

--- a/packages/core/tests/unit/locking.test.ts
+++ b/packages/core/tests/unit/locking.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest"
+
+import { createInMemoryExecutionLockManager } from "../../src/locking.js"
+
+describe("createInMemoryExecutionLockManager", () => {
+  it("skips a concurrent run for the same key", async () => {
+    const manager = createInMemoryExecutionLockManager()
+    let releaseFirstRun!: () => void
+
+    const firstRun = manager.runExclusive("notifications:due-reminders", async () => {
+      await new Promise<void>((resolve) => {
+        releaseFirstRun = resolve
+      })
+      return "first"
+    })
+
+    await Promise.resolve()
+
+    const secondRun = await manager.runExclusive("notifications:due-reminders", async () => {
+      return "second"
+    })
+
+    expect(secondRun).toEqual({ executed: false })
+
+    releaseFirstRun()
+
+    await expect(firstRun).resolves.toEqual({
+      executed: true,
+      value: "first",
+    })
+  })
+
+  it("allows different keys and reruns after release", async () => {
+    const manager = createInMemoryExecutionLockManager()
+
+    await expect(
+      manager.runExclusive("notifications:due-reminders", async () => "first"),
+    ).resolves.toEqual({
+      executed: true,
+      value: "first",
+    })
+
+    await expect(
+      manager.runExclusive("notifications:due-reminders", async () => "second"),
+    ).resolves.toEqual({
+      executed: true,
+      value: "second",
+    })
+
+    await expect(
+      manager.runExclusive("bookings:expire-stale-holds", async () => "other"),
+    ).resolves.toEqual({
+      executed: true,
+      value: "other",
+    })
+  })
+})

--- a/packages/db/src/runtime/index.ts
+++ b/packages/db/src/runtime/index.ts
@@ -1,2 +1,3 @@
 // Runtime exports for compatibility with edge/node adapters
 export { createDbClient, type DbAdapter, db, getDb } from "../index"
+export { createPostgresAdvisoryLockManager } from "./locks"

--- a/packages/db/src/runtime/locks.ts
+++ b/packages/db/src/runtime/locks.ts
@@ -1,0 +1,47 @@
+import type { ExecutionLockManager } from "@voyantjs/core"
+import postgres from "postgres"
+
+type AdvisoryLockRow = { locked: boolean }
+
+export function createPostgresAdvisoryLockManager(
+  connectionString: string,
+  options: {
+    namespace?: string
+  } = {},
+): ExecutionLockManager {
+  const sql = postgres(connectionString, {
+    max: 1,
+  })
+
+  const resolveKey = (key: string) => {
+    const namespace = options.namespace?.trim()
+    return namespace ? `${namespace}:${key}` : key
+  }
+
+  return {
+    async runExclusive<T>(key: string, task: () => Promise<T>) {
+      const lockKey = resolveKey(key)
+      const acquireResult = await sql<AdvisoryLockRow[]>`
+        SELECT pg_try_advisory_lock(hashtextextended(${lockKey}, 0)) AS locked
+      `
+
+      if (!acquireResult[0]?.locked) {
+        return { executed: false }
+      }
+
+      try {
+        return {
+          executed: true,
+          value: await task(),
+        }
+      } finally {
+        await sql`
+          SELECT pg_advisory_unlock(hashtextextended(${lockKey}, 0))
+        `
+      }
+    },
+    async dispose() {
+      await sql.end({ timeout: 0 })
+    },
+  }
+}

--- a/packages/db/tests/integration/locks.test.ts
+++ b/packages/db/tests/integration/locks.test.ts
@@ -1,0 +1,62 @@
+import { afterAll, describe, expect, it } from "vitest"
+
+import { createPostgresAdvisoryLockManager } from "../../src/runtime/locks.js"
+import { createTestDb } from "../../src/test-utils.js"
+
+const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
+let DB_AVAILABLE = false
+
+if (TEST_DATABASE_URL) {
+  try {
+    const probe = createTestDb()
+    await probe.execute(/* sql */ `SELECT 1`)
+    DB_AVAILABLE = true
+  } catch {
+    DB_AVAILABLE = false
+  }
+}
+
+describe.skipIf(!DB_AVAILABLE || !TEST_DATABASE_URL)("createPostgresAdvisoryLockManager", () => {
+  const firstManager = createPostgresAdvisoryLockManager(TEST_DATABASE_URL!, {
+    namespace: "test",
+  })
+  const secondManager = createPostgresAdvisoryLockManager(TEST_DATABASE_URL!, {
+    namespace: "test",
+  })
+
+  afterAll(async () => {
+    await firstManager.dispose?.()
+    await secondManager.dispose?.()
+  })
+
+  it("skips a concurrent run for the same key and allows it after release", async () => {
+    let releaseFirstRun!: () => void
+
+    const firstRun = firstManager.runExclusive("notifications:due-reminders", async () => {
+      await new Promise<void>((resolve) => {
+        releaseFirstRun = resolve
+      })
+      return "first"
+    })
+
+    await Promise.resolve()
+
+    await expect(
+      secondManager.runExclusive("notifications:due-reminders", async () => "second"),
+    ).resolves.toEqual({ executed: false })
+
+    releaseFirstRun()
+
+    await expect(firstRun).resolves.toEqual({
+      executed: true,
+      value: "first",
+    })
+
+    await expect(
+      secondManager.runExclusive("notifications:due-reminders", async () => "third"),
+    ).resolves.toEqual({
+      executed: true,
+      value: "third",
+    })
+  })
+})

--- a/packages/notifications/src/task-runtime.ts
+++ b/packages/notifications/src/task-runtime.ts
@@ -1,3 +1,5 @@
+import type { ExecutionLockManager } from "@voyantjs/core"
+
 import { createDefaultNotificationProviders } from "./provider-resolution.js"
 import type { NotificationProvider } from "./types.js"
 
@@ -8,10 +10,12 @@ export type NotificationTaskEnv = {
 
 export type NotificationTaskRuntime = {
   providers: ReadonlyArray<NotificationProvider>
+  reminderSweepLockManager?: ExecutionLockManager
 }
 
 export type NotificationTaskRuntimeOptions = {
   providers?: ReadonlyArray<NotificationProvider>
+  reminderSweepLockManager?: ExecutionLockManager
   resolveProviders?: (env: NotificationTaskEnv) => ReadonlyArray<NotificationProvider>
 }
 
@@ -24,5 +28,6 @@ export function buildNotificationTaskRuntime(
       options.resolveProviders?.(env) ??
       options.providers ??
       createDefaultNotificationProviders(env),
+    reminderSweepLockManager: options.reminderSweepLockManager,
   }
 }

--- a/packages/notifications/src/tasks/send-due-reminders.ts
+++ b/packages/notifications/src/tasks/send-due-reminders.ts
@@ -14,5 +14,25 @@ export async function sendDueNotificationReminders(
 ) {
   const runtime = buildNotificationTaskRuntime(env, options)
   const dispatcher = createNotificationService(runtime.providers)
-  return notificationsService.runDueReminders(db, dispatcher, input)
+  const runSweep = () => notificationsService.runDueReminders(db, dispatcher, input)
+
+  if (!runtime.reminderSweepLockManager) {
+    return runSweep()
+  }
+
+  const result = await runtime.reminderSweepLockManager.runExclusive(
+    "notifications:due-reminders",
+    runSweep,
+  )
+
+  if (result.executed) {
+    return result.value
+  }
+
+  return {
+    processed: 0,
+    sent: 0,
+    skipped: 0,
+    failed: 0,
+  }
 }

--- a/packages/notifications/tests/unit/send-due-reminders.test.ts
+++ b/packages/notifications/tests/unit/send-due-reminders.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const buildNotificationTaskRuntimeMock = vi.fn()
+const createNotificationServiceMock = vi.fn()
+const runDueRemindersMock = vi.fn()
+
+vi.mock("../../src/task-runtime.js", () => ({
+  buildNotificationTaskRuntime: buildNotificationTaskRuntimeMock,
+}))
+
+vi.mock("../../src/service.js", () => ({
+  createNotificationService: createNotificationServiceMock,
+  notificationsService: {
+    runDueReminders: runDueRemindersMock,
+  },
+}))
+
+describe("sendDueNotificationReminders", () => {
+  beforeEach(() => {
+    buildNotificationTaskRuntimeMock.mockReset()
+    createNotificationServiceMock.mockReset()
+    runDueRemindersMock.mockReset()
+  })
+
+  it("skips the sweep when an execution lock is not acquired", async () => {
+    const reminderSweepLockManager = {
+      runExclusive: vi.fn(async () => ({ executed: false })),
+    }
+
+    buildNotificationTaskRuntimeMock.mockReturnValue({
+      providers: [],
+      reminderSweepLockManager,
+    })
+    createNotificationServiceMock.mockReturnValue({ send: vi.fn() })
+
+    const { sendDueNotificationReminders } = await import("../../src/tasks/send-due-reminders.js")
+
+    await expect(sendDueNotificationReminders({} as never, {}, { now: null })).resolves.toEqual({
+      processed: 0,
+      sent: 0,
+      skipped: 0,
+      failed: 0,
+    })
+
+    expect(runDueRemindersMock).not.toHaveBeenCalled()
+    expect(reminderSweepLockManager.runExclusive).toHaveBeenCalledOnce()
+  })
+
+  it("runs the sweep inside the lock when acquired", async () => {
+    const reminderSweepLockManager = {
+      runExclusive: vi.fn(async (_key: string, task: () => Promise<unknown>) => ({
+        executed: true as const,
+        value: await task(),
+      })),
+    }
+
+    buildNotificationTaskRuntimeMock.mockReturnValue({
+      providers: [],
+      reminderSweepLockManager,
+    })
+    createNotificationServiceMock.mockReturnValue({ send: vi.fn() })
+    runDueRemindersMock.mockResolvedValue({
+      processed: 2,
+      sent: 1,
+      skipped: 1,
+      failed: 0,
+    })
+
+    const { sendDueNotificationReminders } = await import("../../src/tasks/send-due-reminders.js")
+
+    await expect(sendDueNotificationReminders({} as never, {}, { now: null })).resolves.toEqual({
+      processed: 2,
+      sent: 1,
+      skipped: 1,
+      failed: 0,
+    })
+
+    expect(runDueRemindersMock).toHaveBeenCalledOnce()
+    expect(reminderSweepLockManager.runExclusive).toHaveBeenCalledWith(
+      "notifications:due-reminders",
+      expect.any(Function),
+    )
+  })
+})

--- a/packages/notifications/tests/unit/task-runtime.test.ts
+++ b/packages/notifications/tests/unit/task-runtime.test.ts
@@ -21,4 +21,17 @@ describe("buildNotificationTaskRuntime", () => {
     expect(runtime.providers).toHaveLength(1)
     expect(runtime.providers[0]?.name).toBe("email-provider")
   })
+
+  it("preserves the reminder sweep lock manager", () => {
+    const reminderSweepLockManager = {
+      runExclusive: vi.fn(),
+    }
+
+    const runtime = buildNotificationTaskRuntime(
+      { RESEND_API_KEY: "resend_test", EMAIL_FROM: "hello@example.com" },
+      { providers: [], reminderSweepLockManager },
+    )
+
+    expect(runtime.reminderSweepLockManager).toBe(reminderSweepLockManager)
+  })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       '@voyantjs/checkout':
         specifier: workspace:*
         version: link:../../packages/checkout
+      '@voyantjs/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@voyantjs/crm':
         specifier: workspace:*
         version: link:../../packages/crm

--- a/templates/dmc/src/lib/notifications.ts
+++ b/templates/dmc/src/lib/notifications.ts
@@ -1,3 +1,4 @@
+import { createPostgresAdvisoryLockManager } from "@voyantjs/db/runtime"
 import {
   buildNotificationTaskRuntime,
   createDefaultNotificationProviders,
@@ -9,7 +10,19 @@ export const resolveNotificationProviders = (env: Record<string, unknown>) =>
     smsProvider: "twilio",
   })
 
+function resolveReminderSweepLockManager(env: Record<string, unknown>) {
+  const connectionString =
+    typeof env.DATABASE_URL === "string" && env.DATABASE_URL.length > 0 ? env.DATABASE_URL : null
+
+  return connectionString
+    ? createPostgresAdvisoryLockManager(connectionString, {
+        namespace: "dmc",
+      })
+    : undefined
+}
+
 export const getNotificationTaskRuntime = (env: Record<string, unknown>) =>
   buildNotificationTaskRuntime(env, {
     resolveProviders: resolveNotificationProviders,
+    reminderSweepLockManager: resolveReminderSweepLockManager(env),
   })

--- a/templates/operator/src/lib/notifications.ts
+++ b/templates/operator/src/lib/notifications.ts
@@ -1,3 +1,4 @@
+import { createPostgresAdvisoryLockManager } from "@voyantjs/db/runtime"
 import {
   buildNotificationTaskRuntime,
   createDefaultNotificationProviders,
@@ -9,7 +10,19 @@ export const resolveNotificationProviders = (env: Record<string, unknown>) =>
     smsProvider: "twilio",
   })
 
+function resolveReminderSweepLockManager(env: Record<string, unknown>) {
+  const connectionString =
+    typeof env.DATABASE_URL === "string" && env.DATABASE_URL.length > 0 ? env.DATABASE_URL : null
+
+  return connectionString
+    ? createPostgresAdvisoryLockManager(connectionString, {
+        namespace: "operator",
+      })
+    : undefined
+}
+
 export const getNotificationTaskRuntime = (env: Record<string, unknown>) =>
   buildNotificationTaskRuntime(env, {
     resolveProviders: resolveNotificationProviders,
+    reminderSweepLockManager: resolveReminderSweepLockManager(env),
   })


### PR DESCRIPTION
## Summary
- add a shared execution lock contract in `@voyantjs/core`
- add a Postgres advisory-lock manager in `@voyantjs/db/runtime`
- serialize worker-driven `notifications.send-due-reminders` sweeps without changing the manual admin route

## Why
This is the first concrete implementation slice for the locking and concurrency policy. The reminder sweep is the smallest real cross-process ownership hotspot: individual reminder delivery already has item-level dedupe, but the sweep itself could still be triggered concurrently by multiple workers.

## Scope
- `@voyantjs/core`: `ExecutionLockManager` and in-memory implementation
- `@voyantjs/db`: Postgres advisory-lock implementation
- `@voyantjs/notifications`: wrap the worker task path for due reminders
- `apps/dev`, `templates/operator`, `templates/dmc`: wire the appropriate lock manager into notification task runtime

## Validation
- `pnpm -C packages/core lint && pnpm -C packages/core typecheck && pnpm -C packages/core test && pnpm -C packages/core build`
- `pnpm -C packages/db lint && pnpm -C packages/db typecheck && pnpm -C packages/db test && pnpm -C packages/db build`
- `pnpm -C packages/notifications lint && pnpm -C packages/notifications typecheck && pnpm -C packages/notifications test && pnpm -C packages/notifications build`
- `pnpm -C apps/dev lint && pnpm -C apps/dev typecheck && pnpm -C apps/dev build`
- `pnpm -C templates/operator lint && pnpm -C templates/operator typecheck && pnpm -C templates/operator build`
- `pnpm -C templates/dmc lint && pnpm -C templates/dmc typecheck && pnpm -C templates/dmc build`
- repo-wide `pnpm typecheck`
- repo-wide `pnpm test`

## Notes
- The manual `/reminders/run-due` route is intentionally unchanged. This PR only adds singleton-style ownership to the worker task path.
- The new DB integration test skips unless `TEST_DATABASE_URL` is available, matching the existing integration-test pattern.
