### PR TITLE
feat: make reminder delivery durable

### DIFF
--- a/.changeset/notification-durable-reminders.md
+++ b/.changeset/notification-durable-reminders.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/notifications": patch
+---
+
+Make worker-driven due reminder processing durable by queueing reminder runs before provider delivery and delivering each run in its own retryable background task.

--- a/apps/dev/src/lib/notifications.ts
+++ b/apps/dev/src/lib/notifications.ts
@@ -2,6 +2,7 @@ import { createInMemoryExecutionLockManager } from "@voyantjs/core"
 import {
   buildNotificationTaskRuntime,
   createDefaultNotificationProviders,
+  type NotificationTaskRuntimeOptions,
 } from "@voyantjs/notifications"
 
 export const resolveNotificationProviders = (env: Record<string, unknown>) =>
@@ -9,8 +10,12 @@ export const resolveNotificationProviders = (env: Record<string, unknown>) =>
 
 const reminderSweepLockManager = createInMemoryExecutionLockManager()
 
-export const getNotificationTaskRuntime = (env: Record<string, unknown>) =>
+export const getNotificationTaskRuntime = (
+  env: Record<string, unknown>,
+  options: Pick<NotificationTaskRuntimeOptions, "enqueueReminderDelivery"> = {},
+) =>
   buildNotificationTaskRuntime(env, {
     resolveProviders: resolveNotificationProviders,
     reminderSweepLockManager,
+    enqueueReminderDelivery: options.enqueueReminderDelivery,
   })

--- a/apps/dev/src/worker.ts
+++ b/apps/dev/src/worker.ts
@@ -1,7 +1,10 @@
 import { generateAvailabilitySlots } from "@voyantjs/availability"
 import { expireStaleBookingHolds } from "@voyantjs/bookings/tasks"
 import { createDbClient } from "@voyantjs/db"
-import { sendDueNotificationReminders } from "@voyantjs/notifications/tasks"
+import {
+  deliverQueuedNotificationReminder,
+  sendDueNotificationReminders,
+} from "@voyantjs/notifications/tasks"
 import { generateProductPdf } from "@voyantjs/products/tasks"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
@@ -48,6 +51,23 @@ expireBookingHolds.task({
   },
 })
 
+const deliverReminder = hatchet.task({
+  name: "notifications.deliver-reminder",
+  retries: 3,
+  backoff: {
+    factor: 2,
+    maxSeconds: 300,
+  },
+  fn: async (input: { reminderRunId: string }) => {
+    return deliverQueuedNotificationReminder(
+      getDb(),
+      process.env,
+      input,
+      getNotificationTaskRuntime(process.env),
+    )
+  },
+})
+
 const sendPaymentReminders = hatchet.workflow({
   name: "notifications.send-due-reminders",
   on: {
@@ -62,14 +82,24 @@ sendPaymentReminders.task({
       getDb(),
       process.env,
       input,
-      getNotificationTaskRuntime(process.env),
+      getNotificationTaskRuntime(process.env, {
+        enqueueReminderDelivery: async (job) => {
+          await deliverReminder.runNoWait(job)
+        },
+      }),
     )
   },
 })
 
 async function main() {
   const worker = await hatchet.worker("dev-worker", {
-    workflows: [generatePdf, generateSlots, expireBookingHolds, sendPaymentReminders],
+    workflows: [
+      generatePdf,
+      generateSlots,
+      expireBookingHolds,
+      deliverReminder,
+      sendPaymentReminders,
+    ],
   })
 
   await worker.start()

--- a/packages/checkout/src/service.ts
+++ b/packages/checkout/src/service.ts
@@ -141,7 +141,7 @@ export interface CheckoutReminderRunSummary {
   bookingId: string | null
   paymentSessionId: string | null
   notificationDeliveryId: string | null
-  status: "processing" | "sent" | "skipped" | "failed"
+  status: "queued" | "processing" | "sent" | "skipped" | "failed"
   deliveryStatus: "pending" | "sent" | "failed" | "cancelled" | null
   channel: "email" | "sms" | null
   provider: string | null

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -74,9 +74,10 @@ export type {
   NotificationTaskEnv,
   NotificationTaskRuntime,
   NotificationTaskRuntimeOptions,
+  ReminderDeliveryJob,
 } from "./task-runtime.js"
 export { buildNotificationTaskRuntime } from "./task-runtime.js"
-export { sendDueNotificationReminders } from "./tasks/index.js"
+export { deliverQueuedNotificationReminder, sendDueNotificationReminders } from "./tasks/index.js"
 export type {
   NotificationAttachment,
   NotificationChannel,

--- a/packages/notifications/src/schema.ts
+++ b/packages/notifications/src/schema.ts
@@ -52,6 +52,7 @@ export const notificationReminderTargetTypeEnum = pgEnum("notification_reminder_
 ])
 
 export const notificationReminderRunStatusEnum = pgEnum("notification_reminder_run_status", [
+  "queued",
   "processing",
   "sent",
   "skipped",

--- a/packages/notifications/src/service-reminders.ts
+++ b/packages/notifications/src/service-reminders.ts
@@ -9,6 +9,7 @@ import type {
   BookingPaymentScheduleRow,
   NotificationReminderRuleRow,
   NotificationService,
+  ReminderQueueResult,
   ReminderSweepResult,
   RunDueRemindersInput,
 } from "./service-shared.js"
@@ -20,6 +21,348 @@ import {
   toDateString,
   toTimestamp,
 } from "./service-shared.js"
+
+type ReminderDeliveryEnqueuer = (input: { reminderRunId: string }) => Promise<void>
+
+type NotificationReminderRunRow = typeof notificationReminderRuns.$inferSelect
+
+function buildReminderSweepSummary(): ReminderSweepResult {
+  return {
+    processed: 0,
+    sent: 0,
+    skipped: 0,
+    failed: 0,
+  }
+}
+
+function buildReminderQueueSummary(): ReminderQueueResult {
+  return {
+    processed: 0,
+    queued: 0,
+    skipped: 0,
+    failed: 0,
+  }
+}
+
+function isRetryableReminderRun(
+  run: Pick<NotificationReminderRunRow, "status"> | null | undefined,
+) {
+  return run?.status === "failed"
+}
+
+async function getReminderRuleById(db: PostgresJsDatabase, reminderRuleId: string) {
+  const [rule] = await db
+    .select()
+    .from(notificationReminderRules)
+    .where(eq(notificationReminderRules.id, reminderRuleId))
+    .limit(1)
+  return rule ?? null
+}
+
+async function getReminderRunById(db: PostgresJsDatabase, reminderRunId: string) {
+  const [run] = await db
+    .select()
+    .from(notificationReminderRuns)
+    .where(eq(notificationReminderRuns.id, reminderRunId))
+    .limit(1)
+  return run ?? null
+}
+
+async function markReminderRunQueued(
+  db: PostgresJsDatabase,
+  reminderRunId: string,
+  now: Date,
+  recipient?: string | null,
+) {
+  const [run] = await db
+    .update(notificationReminderRuns)
+    .set({
+      status: "queued",
+      errorMessage: null,
+      recipient: recipient ?? undefined,
+      processedAt: now,
+      updatedAt: now,
+    })
+    .where(eq(notificationReminderRuns.id, reminderRunId))
+    .returning()
+
+  return run ?? null
+}
+
+async function markReminderRunSkipped(
+  db: PostgresJsDatabase,
+  reminderRunId: string,
+  now: Date,
+  errorMessage: string,
+) {
+  const [run] = await db
+    .update(notificationReminderRuns)
+    .set({
+      status: "skipped",
+      errorMessage,
+      processedAt: now,
+      updatedAt: now,
+    })
+    .where(eq(notificationReminderRuns.id, reminderRunId))
+    .returning()
+
+  return run ?? null
+}
+
+async function markReminderRunFailed(
+  db: PostgresJsDatabase,
+  reminderRunId: string,
+  now: Date,
+  errorMessage: string,
+) {
+  const [run] = await db
+    .update(notificationReminderRuns)
+    .set({
+      status: "failed",
+      errorMessage,
+      processedAt: now,
+      updatedAt: now,
+    })
+    .where(eq(notificationReminderRuns.id, reminderRunId))
+    .returning()
+
+  return run ?? null
+}
+
+async function markReminderRunSent(
+  db: PostgresJsDatabase,
+  reminderRunId: string,
+  now: Date,
+  notificationDeliveryId: string | null,
+) {
+  const [run] = await db
+    .update(notificationReminderRuns)
+    .set({
+      notificationDeliveryId,
+      status: "sent",
+      processedAt: now,
+      updatedAt: now,
+      errorMessage: null,
+    })
+    .where(eq(notificationReminderRuns.id, reminderRunId))
+    .returning()
+
+  return run ?? null
+}
+
+async function enqueueReminderRun(
+  db: PostgresJsDatabase,
+  enqueueDelivery: ReminderDeliveryEnqueuer,
+  run: NotificationReminderRunRow,
+  now: Date,
+) {
+  const queuedRun = await markReminderRunQueued(db, run.id, now, run.recipient)
+  if (!queuedRun) {
+    return null
+  }
+
+  try {
+    await enqueueDelivery({ reminderRunId: queuedRun.id })
+    return queuedRun
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to enqueue reminder delivery"
+    return markReminderRunFailed(db, queuedRun.id, new Date(), message)
+  }
+}
+
+async function queueBookingPaymentScheduleReminder(
+  db: PostgresJsDatabase,
+  enqueueDelivery: ReminderDeliveryEnqueuer,
+  rule: NotificationReminderRuleRow,
+  schedule: BookingPaymentScheduleRow,
+  now: Date,
+) {
+  const runDate = toDateString(startOfUtcDay(now))
+  const dedupeKey = buildReminderDedupeKey(rule.id, schedule.id, runDate)
+
+  const [existingRun] = await db
+    .select()
+    .from(notificationReminderRuns)
+    .where(eq(notificationReminderRuns.dedupeKey, dedupeKey))
+    .limit(1)
+
+  if (existingRun && !isRetryableReminderRun(existingRun)) {
+    return null
+  }
+
+  const [booking] = await db
+    .select()
+    .from(bookings)
+    .where(eq(bookings.id, schedule.bookingId))
+    .limit(1)
+
+  const reminderRun =
+    existingRun && isRetryableReminderRun(existingRun)
+      ? existingRun
+      : ((
+          await db
+            .insert(notificationReminderRuns)
+            .values({
+              reminderRuleId: rule.id,
+              targetType: "booking_payment_schedule",
+              targetId: schedule.id,
+              dedupeKey,
+              bookingId: schedule.bookingId,
+              personId: booking?.personId ?? null,
+              organizationId: booking?.organizationId ?? null,
+              paymentSessionId: null,
+              notificationDeliveryId: null,
+              status: "queued",
+              recipient: null,
+              scheduledFor: now,
+              processedAt: now,
+              errorMessage: null,
+              metadata: {
+                dueDate: schedule.dueDate,
+                relativeDaysFromDueDate: rule.relativeDaysFromDueDate,
+                bookingNumber: booking?.bookingNumber ?? null,
+              },
+            })
+            .onConflictDoNothing({ target: notificationReminderRuns.dedupeKey })
+            .returning()
+        )[0] ?? null)
+
+  if (!reminderRun) {
+    return null
+  }
+
+  if (!booking) {
+    return markReminderRunSkipped(db, reminderRun.id, now, "Booking not found for payment schedule")
+  }
+
+  const participants = await db
+    .select({
+      id: bookingParticipants.id,
+      firstName: bookingParticipants.firstName,
+      lastName: bookingParticipants.lastName,
+      email: bookingParticipants.email,
+      participantType: bookingParticipants.participantType,
+      isPrimary: bookingParticipants.isPrimary,
+    })
+    .from(bookingParticipants)
+    .where(eq(bookingParticipants.bookingId, booking.id))
+    .orderBy(desc(bookingParticipants.isPrimary), bookingParticipants.createdAt)
+
+  const recipient = resolveReminderRecipient(participants)
+  if (!recipient?.email) {
+    return markReminderRunSkipped(
+      db,
+      reminderRun.id,
+      now,
+      "No participant email available for booking payment reminder",
+    )
+  }
+
+  return enqueueReminderRun(
+    db,
+    enqueueDelivery,
+    { ...reminderRun, recipient: recipient.email },
+    now,
+  )
+}
+
+async function queueInvoiceReminder(
+  db: PostgresJsDatabase,
+  enqueueDelivery: ReminderDeliveryEnqueuer,
+  rule: NotificationReminderRuleRow,
+  invoice: typeof invoices.$inferSelect,
+  now: Date,
+) {
+  const runDate = toDateString(startOfUtcDay(now))
+  const dedupeKey = buildReminderDedupeKey(rule.id, invoice.id, runDate)
+
+  const [existingRun] = await db
+    .select()
+    .from(notificationReminderRuns)
+    .where(eq(notificationReminderRuns.dedupeKey, dedupeKey))
+    .limit(1)
+
+  if (existingRun && !isRetryableReminderRun(existingRun)) {
+    return null
+  }
+
+  const [booking] = await db
+    .select()
+    .from(bookings)
+    .where(eq(bookings.id, invoice.bookingId))
+    .limit(1)
+
+  const reminderRun =
+    existingRun && isRetryableReminderRun(existingRun)
+      ? existingRun
+      : ((
+          await db
+            .insert(notificationReminderRuns)
+            .values({
+              reminderRuleId: rule.id,
+              targetType: "invoice",
+              targetId: invoice.id,
+              dedupeKey,
+              bookingId: invoice.bookingId,
+              personId: invoice.personId ?? booking?.personId ?? null,
+              organizationId: invoice.organizationId ?? booking?.organizationId ?? null,
+              paymentSessionId: null,
+              notificationDeliveryId: null,
+              status: "queued",
+              recipient: null,
+              scheduledFor: now,
+              processedAt: now,
+              errorMessage: null,
+              metadata: {
+                dueDate: invoice.dueDate,
+                relativeDaysFromDueDate: rule.relativeDaysFromDueDate,
+                bookingNumber: booking?.bookingNumber ?? null,
+                invoiceNumber: invoice.invoiceNumber,
+                invoiceType: invoice.invoiceType,
+              },
+            })
+            .onConflictDoNothing({ target: notificationReminderRuns.dedupeKey })
+            .returning()
+        )[0] ?? null)
+
+  if (!reminderRun) {
+    return null
+  }
+
+  if (!booking) {
+    return markReminderRunSkipped(db, reminderRun.id, now, "Booking not found for invoice reminder")
+  }
+
+  const participants = await db
+    .select({
+      id: bookingParticipants.id,
+      firstName: bookingParticipants.firstName,
+      lastName: bookingParticipants.lastName,
+      email: bookingParticipants.email,
+      participantType: bookingParticipants.participantType,
+      isPrimary: bookingParticipants.isPrimary,
+    })
+    .from(bookingParticipants)
+    .where(eq(bookingParticipants.bookingId, booking.id))
+    .orderBy(desc(bookingParticipants.isPrimary), bookingParticipants.createdAt)
+
+  const recipient = resolveReminderRecipient(participants)
+  if (!recipient?.email) {
+    return markReminderRunSkipped(
+      db,
+      reminderRun.id,
+      now,
+      "No participant email available for invoice reminder",
+    )
+  }
+
+  return enqueueReminderRun(
+    db,
+    enqueueDelivery,
+    { ...reminderRun, recipient: recipient.email },
+    now,
+  )
+}
 
 async function sendBookingPaymentScheduleReminder(
   db: PostgresJsDatabase,
@@ -117,17 +460,12 @@ async function sendBookingPaymentScheduleReminder(
   }
 
   if (!recipient?.email) {
-    const [run] = await db
-      .update(notificationReminderRuns)
-      .set({
-        status: "skipped",
-        errorMessage: "No participant email available for booking payment reminder",
-        processedAt: now,
-        updatedAt: now,
-      })
-      .where(eq(notificationReminderRuns.id, processingRun.id))
-      .returning()
-    return run ?? null
+    return markReminderRunSkipped(
+      db,
+      processingRun.id,
+      now,
+      "No participant email available for booking payment reminder",
+    )
   }
 
   try {
@@ -179,31 +517,10 @@ async function sendBookingPaymentScheduleReminder(
       scheduledFor: now.toISOString(),
     })
 
-    const [run] = await db
-      .update(notificationReminderRuns)
-      .set({
-        notificationDeliveryId: delivery?.id ?? null,
-        status: "sent",
-        processedAt: new Date(),
-        updatedAt: new Date(),
-        errorMessage: null,
-      })
-      .where(eq(notificationReminderRuns.id, processingRun.id))
-      .returning()
-    return run ?? null
+    return markReminderRunSent(db, processingRun.id, new Date(), delivery?.id ?? null)
   } catch (error) {
     const message = error instanceof Error ? error.message : "Notification reminder failed"
-    const [run] = await db
-      .update(notificationReminderRuns)
-      .set({
-        status: "failed",
-        errorMessage: message,
-        processedAt: new Date(),
-        updatedAt: new Date(),
-      })
-      .where(eq(notificationReminderRuns.id, processingRun.id))
-      .returning()
-    return run ?? null
+    return markReminderRunFailed(db, processingRun.id, new Date(), message)
   }
 }
 
@@ -308,17 +625,12 @@ async function sendInvoiceReminder(
   }
 
   if (!recipient?.email) {
-    const [run] = await db
-      .update(notificationReminderRuns)
-      .set({
-        status: "skipped",
-        errorMessage: "No participant email available for invoice reminder",
-        processedAt: now,
-        updatedAt: now,
-      })
-      .where(eq(notificationReminderRuns.id, processingRun.id))
-      .returning()
-    return run ?? null
+    return markReminderRunSkipped(
+      db,
+      processingRun.id,
+      now,
+      "No participant email available for invoice reminder",
+    )
   }
 
   try {
@@ -339,31 +651,302 @@ async function sendInvoiceReminder(
       scheduledFor: now.toISOString(),
     })
 
-    const [run] = await db
-      .update(notificationReminderRuns)
-      .set({
-        notificationDeliveryId: delivery?.id ?? null,
-        status: "sent",
-        processedAt: new Date(),
-        updatedAt: new Date(),
-        errorMessage: null,
-      })
-      .where(eq(notificationReminderRuns.id, processingRun.id))
-      .returning()
-    return run ?? null
+    return markReminderRunSent(db, processingRun.id, new Date(), delivery?.id ?? null)
   } catch (error) {
     const message = error instanceof Error ? error.message : "Invoice reminder failed"
-    const [run] = await db
-      .update(notificationReminderRuns)
-      .set({
-        status: "failed",
-        errorMessage: message,
-        processedAt: new Date(),
-        updatedAt: new Date(),
-      })
-      .where(eq(notificationReminderRuns.id, processingRun.id))
-      .returning()
-    return run ?? null
+    return markReminderRunFailed(db, processingRun.id, new Date(), message)
+  }
+}
+
+async function sendQueuedBookingPaymentScheduleReminder(
+  db: PostgresJsDatabase,
+  dispatcher: NotificationService,
+  run: NotificationReminderRunRow,
+  rule: NotificationReminderRuleRow,
+  now: Date,
+) {
+  const [schedule] = await db
+    .select()
+    .from(bookingPaymentSchedules)
+    .where(eq(bookingPaymentSchedules.id, run.targetId))
+    .limit(1)
+
+  if (!schedule) {
+    return markReminderRunSkipped(
+      db,
+      run.id,
+      now,
+      "Booking payment schedule not found for reminder run",
+    )
+  }
+
+  const [booking] = await db
+    .select()
+    .from(bookings)
+    .where(eq(bookings.id, schedule.bookingId))
+    .limit(1)
+
+  if (!booking) {
+    return markReminderRunSkipped(db, run.id, now, "Booking not found for payment schedule")
+  }
+
+  const participants = await db
+    .select({
+      id: bookingParticipants.id,
+      firstName: bookingParticipants.firstName,
+      lastName: bookingParticipants.lastName,
+      email: bookingParticipants.email,
+      participantType: bookingParticipants.participantType,
+      isPrimary: bookingParticipants.isPrimary,
+    })
+    .from(bookingParticipants)
+    .where(eq(bookingParticipants.bookingId, booking.id))
+    .orderBy(desc(bookingParticipants.isPrimary), bookingParticipants.createdAt)
+
+  const fallbackRecipient = resolveReminderRecipient(participants)
+  const participant =
+    participants.find((entry) => entry.email === run.recipient) ?? fallbackRecipient ?? null
+  const recipientEmail = run.recipient ?? participant?.email ?? null
+
+  if (!recipientEmail) {
+    return markReminderRunSkipped(
+      db,
+      run.id,
+      now,
+      "No participant email available for booking payment reminder",
+    )
+  }
+
+  try {
+    const delivery = await sendNotification(db, dispatcher, {
+      templateId: rule.templateId ?? null,
+      templateSlug: rule.templateSlug ?? null,
+      channel: rule.channel,
+      provider: rule.provider ?? null,
+      to: recipientEmail,
+      data: {
+        bookingId: booking.id,
+        bookingNumber: booking.bookingNumber,
+        dueDate: schedule.dueDate,
+        amountCents: schedule.amountCents,
+        currency: schedule.currency,
+        scheduleType: schedule.scheduleType,
+        reminderOffsetDays: rule.relativeDaysFromDueDate,
+        participant: participant
+          ? {
+              firstName: participant.firstName,
+              lastName: participant.lastName,
+              email: recipientEmail,
+            }
+          : null,
+        booking: {
+          id: booking.id,
+          bookingNumber: booking.bookingNumber,
+          startDate: booking.startDate,
+          endDate: booking.endDate,
+          sellCurrency: booking.sellCurrency,
+          sellAmountCents: booking.sellAmountCents,
+        },
+        paymentSchedule: {
+          id: schedule.id,
+          dueDate: schedule.dueDate,
+          amountCents: schedule.amountCents,
+          currency: schedule.currency,
+          scheduleType: schedule.scheduleType,
+          status: schedule.status,
+        },
+      },
+      targetType: "booking_payment_schedule",
+      targetId: schedule.id,
+      bookingId: booking.id,
+      personId: booking.personId ?? null,
+      organizationId: booking.organizationId ?? null,
+      metadata: {
+        reminderRuleId: rule.id,
+        reminderRunId: run.id,
+      },
+      scheduledFor: run.scheduledFor.toISOString(),
+    })
+
+    return markReminderRunSent(db, run.id, new Date(), delivery?.id ?? null)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Notification reminder failed"
+    return markReminderRunFailed(db, run.id, new Date(), message)
+  }
+}
+
+async function sendQueuedInvoiceReminder(
+  db: PostgresJsDatabase,
+  dispatcher: NotificationService,
+  run: NotificationReminderRunRow,
+  rule: NotificationReminderRuleRow,
+  now: Date,
+) {
+  const delivery = await sendInvoiceNotification(db, dispatcher, run.targetId, {
+    templateId: rule.templateId ?? null,
+    templateSlug: rule.templateSlug ?? null,
+    channel: rule.channel,
+    provider: rule.provider ?? null,
+    to: run.recipient ?? undefined,
+    data: {
+      reminderOffsetDays: rule.relativeDaysFromDueDate,
+      reminderRunId: run.id,
+    },
+    metadata: {
+      reminderRuleId: rule.id,
+      reminderRunId: run.id,
+    },
+    scheduledFor: run.scheduledFor.toISOString(),
+  })
+
+  if (!delivery) {
+    return markReminderRunSkipped(db, run.id, now, "Invoice not found for reminder run")
+  }
+
+  return markReminderRunSent(db, run.id, new Date(), delivery.id ?? null)
+}
+
+export async function queueDueReminders(
+  db: PostgresJsDatabase,
+  input: RunDueRemindersInput = {},
+  enqueueDelivery: ReminderDeliveryEnqueuer,
+) {
+  const now = toTimestamp(input.now) ?? new Date()
+  const today = startOfUtcDay(now)
+  const activeRules = await db
+    .select()
+    .from(notificationReminderRules)
+    .where(eq(notificationReminderRules.status, "active"))
+    .orderBy(notificationReminderRules.createdAt)
+
+  const summary = buildReminderQueueSummary()
+
+  for (const rule of activeRules) {
+    const matchingDueDate = toDateString(addUtcDays(today, -rule.relativeDaysFromDueDate))
+
+    if (rule.targetType === "booking_payment_schedule") {
+      const schedules = await db
+        .select()
+        .from(bookingPaymentSchedules)
+        .where(
+          and(
+            eq(bookingPaymentSchedules.dueDate, matchingDueDate),
+            or(
+              eq(bookingPaymentSchedules.status, "pending"),
+              eq(bookingPaymentSchedules.status, "due"),
+            ),
+          ),
+        )
+        .orderBy(bookingPaymentSchedules.createdAt)
+
+      for (const schedule of schedules) {
+        const run = await queueBookingPaymentScheduleReminder(
+          db,
+          enqueueDelivery,
+          rule,
+          schedule,
+          now,
+        )
+
+        if (!run) {
+          continue
+        }
+
+        summary.processed += 1
+        if (run.status === "queued") summary.queued += 1
+        if (run.status === "skipped") summary.skipped += 1
+        if (run.status === "failed") summary.failed += 1
+      }
+      continue
+    }
+
+    if (rule.targetType === "invoice") {
+      const dueInvoices = await db
+        .select()
+        .from(invoices)
+        .where(
+          and(
+            eq(invoices.dueDate, matchingDueDate),
+            gt(invoices.balanceDueCents, 0),
+            or(eq(invoices.invoiceType, "invoice"), eq(invoices.invoiceType, "proforma")),
+            or(
+              eq(invoices.status, "sent"),
+              eq(invoices.status, "partially_paid"),
+              eq(invoices.status, "overdue"),
+            ),
+          ),
+        )
+        .orderBy(invoices.createdAt)
+
+      for (const invoice of dueInvoices) {
+        const run = await queueInvoiceReminder(db, enqueueDelivery, rule, invoice, now)
+        if (!run) {
+          continue
+        }
+
+        summary.processed += 1
+        if (run.status === "queued") summary.queued += 1
+        if (run.status === "skipped") summary.skipped += 1
+        if (run.status === "failed") summary.failed += 1
+      }
+    }
+  }
+
+  return summary
+}
+
+export async function deliverReminderRun(
+  db: PostgresJsDatabase,
+  dispatcher: NotificationService,
+  input: { reminderRunId: string },
+) {
+  const now = new Date()
+  const [claimedRun] = await db
+    .update(notificationReminderRuns)
+    .set({
+      status: "processing",
+      errorMessage: null,
+      processedAt: now,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(notificationReminderRuns.id, input.reminderRunId),
+        or(
+          eq(notificationReminderRuns.status, "queued"),
+          eq(notificationReminderRuns.status, "failed"),
+        ),
+      ),
+    )
+    .returning()
+
+  const run = claimedRun ?? (await getReminderRunById(db, input.reminderRunId))
+  if (!run) {
+    return null
+  }
+
+  if (!claimedRun) {
+    return run
+  }
+
+  const rule = await getReminderRuleById(db, run.reminderRuleId)
+  if (!rule) {
+    return markReminderRunFailed(db, run.id, new Date(), "Reminder rule not found")
+  }
+
+  try {
+    if (run.targetType === "booking_payment_schedule") {
+      return await sendQueuedBookingPaymentScheduleReminder(db, dispatcher, run, rule, now)
+    }
+
+    if (run.targetType === "invoice") {
+      return await sendQueuedInvoiceReminder(db, dispatcher, run, rule, now)
+    }
+
+    return markReminderRunSkipped(db, run.id, now, "Unsupported reminder target type")
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Reminder delivery failed"
+    return markReminderRunFailed(db, run.id, new Date(), message)
   }
 }
 
@@ -380,12 +963,7 @@ export async function runDueReminders(
     .where(eq(notificationReminderRules.status, "active"))
     .orderBy(notificationReminderRules.createdAt)
 
-  const summary: ReminderSweepResult = {
-    processed: 0,
-    sent: 0,
-    skipped: 0,
-    failed: 0,
-  }
+  const summary = buildReminderSweepSummary()
 
   for (const rule of activeRules) {
     const matchingDueDate = toDateString(addUtcDays(today, -rule.relativeDaysFromDueDate))

--- a/packages/notifications/src/service-shared.ts
+++ b/packages/notifications/src/service-shared.ts
@@ -66,6 +66,13 @@ export type ReminderSweepResult = {
   failed: number
 }
 
+export type ReminderQueueResult = {
+  processed: number
+  queued: number
+  skipped: number
+  failed: number
+}
+
 export type NotificationReminderRuleRow = typeof notificationReminderRules.$inferSelect
 export type BookingPaymentScheduleRow = typeof bookingPaymentSchedules.$inferSelect
 

--- a/packages/notifications/src/service-templates.ts
+++ b/packages/notifications/src/service-templates.ts
@@ -35,7 +35,7 @@ function normalizeReminderRun(row: {
   organizationId: string | null
   paymentSessionId: string | null
   notificationDeliveryId: string | null
-  status: "processing" | "sent" | "skipped" | "failed"
+  status: "queued" | "processing" | "sent" | "skipped" | "failed"
   recipient: string | null
   scheduledFor: Date | string
   processedAt: Date | string

--- a/packages/notifications/src/task-runtime.ts
+++ b/packages/notifications/src/task-runtime.ts
@@ -8,14 +8,20 @@ export type NotificationTaskEnv = {
   EMAIL_FROM?: unknown
 }
 
+export type ReminderDeliveryJob = {
+  reminderRunId: string
+}
+
 export type NotificationTaskRuntime = {
   providers: ReadonlyArray<NotificationProvider>
   reminderSweepLockManager?: ExecutionLockManager
+  enqueueReminderDelivery?: (job: ReminderDeliveryJob) => Promise<void>
 }
 
 export type NotificationTaskRuntimeOptions = {
   providers?: ReadonlyArray<NotificationProvider>
   reminderSweepLockManager?: ExecutionLockManager
+  enqueueReminderDelivery?: (job: ReminderDeliveryJob) => Promise<void>
   resolveProviders?: (env: NotificationTaskEnv) => ReadonlyArray<NotificationProvider>
 }
 
@@ -29,5 +35,6 @@ export function buildNotificationTaskRuntime(
       options.providers ??
       createDefaultNotificationProviders(env),
     reminderSweepLockManager: options.reminderSweepLockManager,
+    enqueueReminderDelivery: options.enqueueReminderDelivery,
   }
 }

--- a/packages/notifications/src/tasks/deliver-reminder.ts
+++ b/packages/notifications/src/tasks/deliver-reminder.ts
@@ -1,0 +1,25 @@
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { createNotificationService } from "../service.js"
+import { deliverReminderRun } from "../service-reminders.js"
+import {
+  buildNotificationTaskRuntime,
+  type NotificationTaskEnv,
+  type NotificationTaskRuntimeOptions,
+} from "../task-runtime.js"
+
+export async function deliverQueuedNotificationReminder(
+  db: PostgresJsDatabase,
+  env: NotificationTaskEnv,
+  input: { reminderRunId: string },
+  options: NotificationTaskRuntimeOptions = {},
+) {
+  const runtime = buildNotificationTaskRuntime(env, options)
+  const dispatcher = createNotificationService(runtime.providers)
+  const result = await deliverReminderRun(db, dispatcher, input)
+
+  return {
+    reminderRunId: input.reminderRunId,
+    status: result?.status ?? null,
+  }
+}

--- a/packages/notifications/src/tasks/index.ts
+++ b/packages/notifications/src/tasks/index.ts
@@ -1,1 +1,2 @@
+export { deliverQueuedNotificationReminder } from "./deliver-reminder.js"
 export { sendDueNotificationReminders } from "./send-due-reminders.js"

--- a/packages/notifications/src/tasks/send-due-reminders.ts
+++ b/packages/notifications/src/tasks/send-due-reminders.ts
@@ -1,5 +1,8 @@
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-import { createNotificationService, notificationsService } from "../service.js"
+
+import { createNotificationService } from "../service.js"
+import { queueDueReminders, runDueReminders } from "../service-reminders.js"
+import type { ReminderQueueResult, ReminderSweepResult } from "../service-shared.js"
 import {
   buildNotificationTaskRuntime,
   type NotificationTaskEnv,
@@ -14,7 +17,10 @@ export async function sendDueNotificationReminders(
 ) {
   const runtime = buildNotificationTaskRuntime(env, options)
   const dispatcher = createNotificationService(runtime.providers)
-  const runSweep = () => notificationsService.runDueReminders(db, dispatcher, input)
+  const runSweep: () => Promise<ReminderQueueResult | ReminderSweepResult> = () =>
+    runtime.enqueueReminderDelivery
+      ? queueDueReminders(db, input, runtime.enqueueReminderDelivery)
+      : runDueReminders(db, dispatcher, input)
 
   if (!runtime.reminderSweepLockManager) {
     return runSweep()
@@ -29,9 +35,18 @@ export async function sendDueNotificationReminders(
     return result.value
   }
 
+  if (!runtime.enqueueReminderDelivery) {
+    return {
+      processed: 0,
+      sent: 0,
+      skipped: 0,
+      failed: 0,
+    }
+  }
+
   return {
     processed: 0,
-    sent: 0,
+    queued: 0,
     skipped: 0,
     failed: 0,
   }

--- a/packages/notifications/src/validation.ts
+++ b/packages/notifications/src/validation.ts
@@ -16,6 +16,7 @@ export const notificationTargetTypeSchema = z.enum([
 export const notificationReminderStatusSchema = z.enum(["draft", "active", "archived"])
 export const notificationReminderTargetTypeSchema = z.enum(["booking_payment_schedule", "invoice"])
 export const notificationReminderRunStatusSchema = z.enum([
+  "queued",
   "processing",
   "sent",
   "skipped",

--- a/packages/notifications/tests/integration/reminder-tasks.test.ts
+++ b/packages/notifications/tests/integration/reminder-tasks.test.ts
@@ -1,0 +1,115 @@
+import { sql } from "drizzle-orm"
+import { describe, expect, it } from "vitest"
+
+import { createLocalProvider } from "../../src/providers/local.js"
+import { createNotificationService } from "../../src/service.js"
+import { deliverReminderRun, queueDueReminders } from "../../src/service-reminders.js"
+import { createNotificationsTestContext, DB_AVAILABLE, json } from "./test-helpers"
+
+describe.skipIf(!DB_AVAILABLE)("Notification reminder tasks", () => {
+  const ctx = createNotificationsTestContext()
+
+  it("queues due reminder runs before sending them durably", async () => {
+    const createTemplateRes = await ctx.request("/templates", {
+      method: "POST",
+      ...json({
+        slug: "queued-payment-reminder",
+        name: "Queued Payment Reminder",
+        channel: "email",
+        provider: "local",
+        status: "active",
+        subjectTemplate: "Payment due for {{ booking.bookingNumber }}",
+        textTemplate: "Due {{ paymentSchedule.dueDate }} amount {{ paymentSchedule.amountCents }}",
+      }),
+    })
+    const { data: template } = await createTemplateRes.json()
+
+    await ctx.db.execute(sql`
+      INSERT INTO bookings (id, booking_number, person_id, sell_currency, sell_amount_cents)
+      VALUES ('book_queue', 'BK-QUEUE-1', 'person_queue', 'EUR', 45000)
+    `)
+    await ctx.db.execute(sql`
+      INSERT INTO booking_participants (id, booking_id, first_name, last_name, email, participant_type, is_primary)
+      VALUES ('bkpt_queue', 'book_queue', 'Mia', 'Traveler', 'mia@example.com', 'traveler', true)
+    `)
+    await ctx.db.execute(sql`
+      INSERT INTO booking_payment_schedules (
+        id,
+        booking_id,
+        schedule_type,
+        status,
+        due_date,
+        currency,
+        amount_cents
+      )
+      VALUES (
+        'bkpy_queue',
+        'book_queue',
+        'balance',
+        'pending',
+        DATE '2026-04-10',
+        'EUR',
+        25000
+      )
+    `)
+
+    const createRuleRes = await ctx.request("/reminder-rules", {
+      method: "POST",
+      ...json({
+        slug: "queued-balance-due-2-days-before",
+        name: "Queued Balance Due 2 Days Before",
+        status: "active",
+        targetType: "booking_payment_schedule",
+        channel: "email",
+        provider: "local",
+        templateId: template.id,
+        relativeDaysFromDueDate: -2,
+      }),
+    })
+    expect(createRuleRes.status).toBe(201)
+
+    const enqueuedReminderRuns: string[] = []
+    const queueResult = await queueDueReminders(
+      ctx.db,
+      { now: "2026-04-08T09:00:00.000Z" },
+      async ({ reminderRunId }) => {
+        enqueuedReminderRuns.push(reminderRunId)
+      },
+    )
+
+    expect(queueResult).toEqual({
+      processed: 1,
+      queued: 1,
+      skipped: 0,
+      failed: 0,
+    })
+    expect(ctx.sink).not.toHaveBeenCalled()
+    expect(enqueuedReminderRuns).toHaveLength(1)
+
+    const queuedRunsRes = await ctx.request("/reminder-runs?bookingId=book_queue")
+    expect(queuedRunsRes.status).toBe(200)
+    const queuedRunsBody = await queuedRunsRes.json()
+    expect(queuedRunsBody.total).toBe(1)
+    expect(queuedRunsBody.data[0].status).toBe("queued")
+    expect(queuedRunsBody.data[0].delivery).toBeNull()
+
+    const dispatcher = createNotificationService([
+      createLocalProvider({
+        sink: ctx.sink,
+      }),
+    ])
+
+    const deliveredRun = await deliverReminderRun(ctx.db, dispatcher, {
+      reminderRunId: enqueuedReminderRuns[0]!,
+    })
+
+    expect(deliveredRun?.status).toBe("sent")
+    expect(ctx.sink).toHaveBeenCalledOnce()
+
+    const deliveredRunsRes = await ctx.request("/reminder-runs?bookingId=book_queue")
+    expect(deliveredRunsRes.status).toBe(200)
+    const deliveredRunsBody = await deliveredRunsRes.json()
+    expect(deliveredRunsBody.data[0].status).toBe("sent")
+    expect(deliveredRunsBody.data[0].delivery.status).toBe("sent")
+  })
+})

--- a/packages/notifications/tests/integration/test-helpers.ts
+++ b/packages/notifications/tests/integration/test-helpers.ts
@@ -113,10 +113,13 @@ export function createNotificationsTestContext(options?: { eventBus?: EventBus }
     await db.execute(sql`
       DO $$
       BEGIN
-        CREATE TYPE notification_reminder_run_status AS ENUM ('processing', 'sent', 'skipped', 'failed');
+        CREATE TYPE notification_reminder_run_status AS ENUM ('queued', 'processing', 'sent', 'skipped', 'failed');
       EXCEPTION
         WHEN duplicate_object THEN NULL;
       END $$;
+    `)
+    await db.execute(sql`
+      ALTER TYPE notification_reminder_run_status ADD VALUE IF NOT EXISTS 'queued';
     `)
     await db.execute(sql`
       CREATE TABLE IF NOT EXISTS bookings (

--- a/packages/notifications/tests/unit/deliver-reminder.test.ts
+++ b/packages/notifications/tests/unit/deliver-reminder.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const buildNotificationTaskRuntimeMock = vi.fn()
+const createNotificationServiceMock = vi.fn()
+const deliverReminderRunMock = vi.fn()
+
+vi.mock("../../src/task-runtime.js", () => ({
+  buildNotificationTaskRuntime: buildNotificationTaskRuntimeMock,
+}))
+
+vi.mock("../../src/service.js", () => ({
+  createNotificationService: createNotificationServiceMock,
+}))
+
+vi.mock("../../src/service-reminders.js", () => ({
+  deliverReminderRun: deliverReminderRunMock,
+}))
+
+describe("deliverQueuedNotificationReminder", () => {
+  beforeEach(() => {
+    buildNotificationTaskRuntimeMock.mockReset()
+    createNotificationServiceMock.mockReset()
+    deliverReminderRunMock.mockReset()
+  })
+
+  it("builds the runtime providers and delivers a single queued reminder run", async () => {
+    const dispatcher = { send: vi.fn(), sendWith: vi.fn(), getProvider: vi.fn() }
+
+    buildNotificationTaskRuntimeMock.mockReturnValue({
+      providers: [],
+    })
+    createNotificationServiceMock.mockReturnValue(dispatcher)
+    deliverReminderRunMock.mockResolvedValue({ id: "ntrn_123", status: "sent" })
+
+    const { deliverQueuedNotificationReminder } = await import(
+      "../../src/tasks/deliver-reminder.js"
+    )
+
+    await expect(
+      deliverQueuedNotificationReminder({} as never, {}, { reminderRunId: "ntrn_123" }),
+    ).resolves.toEqual({ reminderRunId: "ntrn_123", status: "sent" })
+
+    expect(createNotificationServiceMock).toHaveBeenCalledWith([])
+    expect(deliverReminderRunMock).toHaveBeenCalledWith({} as never, dispatcher, {
+      reminderRunId: "ntrn_123",
+    })
+  })
+})

--- a/packages/notifications/tests/unit/send-due-reminders.test.ts
+++ b/packages/notifications/tests/unit/send-due-reminders.test.ts
@@ -3,16 +3,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const buildNotificationTaskRuntimeMock = vi.fn()
 const createNotificationServiceMock = vi.fn()
 const runDueRemindersMock = vi.fn()
+const queueDueRemindersMock = vi.fn()
 
 vi.mock("../../src/task-runtime.js", () => ({
   buildNotificationTaskRuntime: buildNotificationTaskRuntimeMock,
 }))
 
+vi.mock("../../src/service-reminders.js", () => ({
+  queueDueReminders: queueDueRemindersMock,
+  runDueReminders: runDueRemindersMock,
+}))
+
 vi.mock("../../src/service.js", () => ({
   createNotificationService: createNotificationServiceMock,
-  notificationsService: {
-    runDueReminders: runDueRemindersMock,
-  },
 }))
 
 describe("sendDueNotificationReminders", () => {
@@ -20,6 +23,7 @@ describe("sendDueNotificationReminders", () => {
     buildNotificationTaskRuntimeMock.mockReset()
     createNotificationServiceMock.mockReset()
     runDueRemindersMock.mockReset()
+    queueDueRemindersMock.mockReset()
   })
 
   it("skips the sweep when an execution lock is not acquired", async () => {
@@ -37,12 +41,39 @@ describe("sendDueNotificationReminders", () => {
 
     await expect(sendDueNotificationReminders({} as never, {}, { now: null })).resolves.toEqual({
       processed: 0,
+      skipped: 0,
       sent: 0,
+      failed: 0,
+    })
+
+    expect(runDueRemindersMock).not.toHaveBeenCalled()
+    expect(queueDueRemindersMock).not.toHaveBeenCalled()
+    expect(reminderSweepLockManager.runExclusive).toHaveBeenCalledOnce()
+  })
+
+  it("returns queue-shaped zero results when a durable sweep lock is not acquired", async () => {
+    const reminderSweepLockManager = {
+      runExclusive: vi.fn(async () => ({ executed: false })),
+    }
+
+    buildNotificationTaskRuntimeMock.mockReturnValue({
+      providers: [],
+      reminderSweepLockManager,
+      enqueueReminderDelivery: vi.fn(),
+    })
+    createNotificationServiceMock.mockReturnValue({ send: vi.fn() })
+
+    const { sendDueNotificationReminders } = await import("../../src/tasks/send-due-reminders.js")
+
+    await expect(sendDueNotificationReminders({} as never, {}, { now: null })).resolves.toEqual({
+      processed: 0,
+      queued: 0,
       skipped: 0,
       failed: 0,
     })
 
     expect(runDueRemindersMock).not.toHaveBeenCalled()
+    expect(queueDueRemindersMock).not.toHaveBeenCalled()
     expect(reminderSweepLockManager.runExclusive).toHaveBeenCalledOnce()
   })
 
@@ -80,5 +111,37 @@ describe("sendDueNotificationReminders", () => {
       "notifications:due-reminders",
       expect.any(Function),
     )
+  })
+
+  it("queues reminder deliveries when the runtime provides an enqueue callback", async () => {
+    const enqueueReminderDelivery = vi.fn()
+
+    buildNotificationTaskRuntimeMock.mockReturnValue({
+      providers: [],
+      enqueueReminderDelivery,
+    })
+    createNotificationServiceMock.mockReturnValue({ send: vi.fn() })
+    queueDueRemindersMock.mockResolvedValue({
+      processed: 2,
+      queued: 2,
+      skipped: 0,
+      failed: 0,
+    })
+
+    const { sendDueNotificationReminders } = await import("../../src/tasks/send-due-reminders.js")
+
+    await expect(sendDueNotificationReminders({} as never, {}, { now: null })).resolves.toEqual({
+      processed: 2,
+      queued: 2,
+      skipped: 0,
+      failed: 0,
+    })
+
+    expect(queueDueRemindersMock).toHaveBeenCalledWith(
+      {} as never,
+      { now: null },
+      enqueueReminderDelivery,
+    )
+    expect(runDueRemindersMock).not.toHaveBeenCalled()
   })
 })

--- a/templates/dmc/src/lib/notifications.ts
+++ b/templates/dmc/src/lib/notifications.ts
@@ -2,6 +2,7 @@ import { createPostgresAdvisoryLockManager } from "@voyantjs/db/runtime"
 import {
   buildNotificationTaskRuntime,
   createDefaultNotificationProviders,
+  type NotificationTaskRuntimeOptions,
 } from "@voyantjs/notifications"
 
 export const resolveNotificationProviders = (env: Record<string, unknown>) =>
@@ -21,8 +22,12 @@ function resolveReminderSweepLockManager(env: Record<string, unknown>) {
     : undefined
 }
 
-export const getNotificationTaskRuntime = (env: Record<string, unknown>) =>
+export const getNotificationTaskRuntime = (
+  env: Record<string, unknown>,
+  options: Pick<NotificationTaskRuntimeOptions, "enqueueReminderDelivery"> = {},
+) =>
   buildNotificationTaskRuntime(env, {
     resolveProviders: resolveNotificationProviders,
     reminderSweepLockManager: resolveReminderSweepLockManager(env),
+    enqueueReminderDelivery: options.enqueueReminderDelivery,
   })

--- a/templates/dmc/src/worker.ts
+++ b/templates/dmc/src/worker.ts
@@ -1,7 +1,10 @@
 import { generateAvailabilitySlots } from "@voyantjs/availability"
 import { expireStaleBookingHolds } from "@voyantjs/bookings/tasks"
 import { createDbClient } from "@voyantjs/db"
-import { sendDueNotificationReminders } from "@voyantjs/notifications/tasks"
+import {
+  deliverQueuedNotificationReminder,
+  sendDueNotificationReminders,
+} from "@voyantjs/notifications/tasks"
 import { generateProductPdf } from "@voyantjs/products/tasks"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
@@ -48,6 +51,23 @@ expireBookingHolds.task({
   },
 })
 
+const deliverReminder = hatchet.task({
+  name: "notifications.deliver-reminder",
+  retries: 3,
+  backoff: {
+    factor: 2,
+    maxSeconds: 300,
+  },
+  fn: async (input: { reminderRunId: string }) => {
+    return deliverQueuedNotificationReminder(
+      getDb(),
+      process.env,
+      input,
+      getNotificationTaskRuntime(process.env),
+    )
+  },
+})
+
 const sendPaymentReminders = hatchet.workflow({
   name: "notifications.send-due-reminders",
   on: {
@@ -62,14 +82,24 @@ sendPaymentReminders.task({
       getDb(),
       process.env,
       input,
-      getNotificationTaskRuntime(process.env),
+      getNotificationTaskRuntime(process.env, {
+        enqueueReminderDelivery: async (job) => {
+          await deliverReminder.runNoWait(job)
+        },
+      }),
     )
   },
 })
 
 async function main() {
   const worker = await hatchet.worker("dmc-worker", {
-    workflows: [generatePdf, generateSlots, expireBookingHolds, sendPaymentReminders],
+    workflows: [
+      generatePdf,
+      generateSlots,
+      expireBookingHolds,
+      deliverReminder,
+      sendPaymentReminders,
+    ],
   })
 
   await worker.start()

--- a/templates/operator/src/lib/notifications.ts
+++ b/templates/operator/src/lib/notifications.ts
@@ -2,6 +2,7 @@ import { createPostgresAdvisoryLockManager } from "@voyantjs/db/runtime"
 import {
   buildNotificationTaskRuntime,
   createDefaultNotificationProviders,
+  type NotificationTaskRuntimeOptions,
 } from "@voyantjs/notifications"
 
 export const resolveNotificationProviders = (env: Record<string, unknown>) =>
@@ -21,8 +22,12 @@ function resolveReminderSweepLockManager(env: Record<string, unknown>) {
     : undefined
 }
 
-export const getNotificationTaskRuntime = (env: Record<string, unknown>) =>
+export const getNotificationTaskRuntime = (
+  env: Record<string, unknown>,
+  options: Pick<NotificationTaskRuntimeOptions, "enqueueReminderDelivery"> = {},
+) =>
   buildNotificationTaskRuntime(env, {
     resolveProviders: resolveNotificationProviders,
     reminderSweepLockManager: resolveReminderSweepLockManager(env),
+    enqueueReminderDelivery: options.enqueueReminderDelivery,
   })

--- a/templates/operator/src/worker.ts
+++ b/templates/operator/src/worker.ts
@@ -1,6 +1,9 @@
 import { expireStaleBookingHolds } from "@voyantjs/bookings/tasks"
 import { createDbClient } from "@voyantjs/db"
-import { sendDueNotificationReminders } from "@voyantjs/notifications/tasks"
+import {
+  deliverQueuedNotificationReminder,
+  sendDueNotificationReminders,
+} from "@voyantjs/notifications/tasks"
 import { generateProductPdf } from "@voyantjs/products/tasks"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
@@ -37,6 +40,23 @@ expireBookingHolds.task({
   },
 })
 
+const deliverReminder = hatchet.task({
+  name: "notifications.deliver-reminder",
+  retries: 3,
+  backoff: {
+    factor: 2,
+    maxSeconds: 300,
+  },
+  fn: async (input: { reminderRunId: string }) => {
+    return deliverQueuedNotificationReminder(
+      getDb(),
+      process.env,
+      input,
+      getNotificationTaskRuntime(process.env),
+    )
+  },
+})
+
 const sendPaymentReminders = hatchet.workflow({
   name: "notifications.send-due-reminders",
   on: {
@@ -51,14 +71,18 @@ sendPaymentReminders.task({
       getDb(),
       process.env,
       input,
-      getNotificationTaskRuntime(process.env),
+      getNotificationTaskRuntime(process.env, {
+        enqueueReminderDelivery: async (job) => {
+          await deliverReminder.runNoWait(job)
+        },
+      }),
     )
   },
 })
 
 async function main() {
   const worker = await hatchet.worker("operator-worker", {
-    workflows: [generatePdf, expireBookingHolds, sendPaymentReminders],
+    workflows: [generatePdf, expireBookingHolds, deliverReminder, sendPaymentReminders],
   })
 
   await worker.start()


### PR DESCRIPTION
## Summary
- make worker-driven due reminder processing durable by queueing reminder runs before provider delivery
- add a retryable `notifications.deliver-reminder` worker task in dev, operator, and dmc
- cover queued reminder execution with unit and integration tests, and add a notifications patch changeset

## Validation
- pnpm -C packages/notifications lint
- pnpm -C packages/notifications typecheck
- pnpm -C packages/notifications test
- pnpm -C packages/notifications build
- pnpm -C templates/operator typecheck
- pnpm -C templates/dmc typecheck
- pnpm -C apps/dev typecheck
- pnpm typecheck
- pnpm test
