### PR TITLE
feat: align booking group indexes

### DIFF
--- a/.changeset/bookings-group-index-policy-execution.md
+++ b/.changeset/bookings-group-index-policy-execution.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/bookings": patch
+---
+
+Align booking group and booking group member indexes with the actual parent-and-created-at list query shapes used by rooming and shared-booking group management.

--- a/packages/bookings/src/schema-groups.ts
+++ b/packages/bookings/src/schema-groups.ts
@@ -21,9 +21,9 @@ export const bookingGroups = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_booking_groups_kind").on(table.kind),
-    index("idx_booking_groups_product").on(table.productId),
-    index("idx_booking_groups_option_unit").on(table.optionUnitId),
+    index("idx_booking_groups_kind_created").on(table.kind, table.createdAt),
+    index("idx_booking_groups_product_created").on(table.productId, table.createdAt),
+    index("idx_booking_groups_option_unit_created").on(table.optionUnitId, table.createdAt),
   ],
 )
 
@@ -42,7 +42,7 @@ export const bookingGroupMembers = pgTable(
   },
   (table) => [
     uniqueIndex("booking_group_members_booking_unique").on(table.bookingId),
-    index("idx_booking_group_members_group").on(table.groupId),
+    index("idx_booking_group_members_group_created").on(table.groupId, table.createdAt),
   ],
 )
 


### PR DESCRIPTION
## Summary
- align booking group and booking group member indexes with the parent-and-created-at list queries used by shared-room and group management flows
- replace the weaker single-column filter indexes where the service layer always sorts by created time
- keep this slice schema-only and focused on the index policy rollout

## Testing
- pnpm -C packages/bookings lint
- pnpm -C packages/bookings typecheck
- pnpm -C packages/bookings test
- pnpm -C packages/bookings build
- pnpm test