### PR TITLE
feat: add facilities address projection

### DIFF
--- a/.changeset/facilities-address-projection.md
+++ b/.changeset/facilities-address-projection.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/facilities": patch
+---
+
+Align facilities root indexes with the main list filters and add a facilities-owned address projection so facility reads no longer query identity addresses directly.

--- a/packages/facilities/src/index.ts
+++ b/packages/facilities/src/index.ts
@@ -17,10 +17,12 @@ export const facilitiesHonoModule: HonoModule = {
 
 export type {
   Facility,
+  FacilityAddressProjection,
   FacilityContact,
   FacilityFeature,
   FacilityOperationSchedule,
   NewFacility,
+  NewFacilityAddressProjection,
   NewFacilityContact,
   NewFacilityFeature,
   NewFacilityOperationSchedule,
@@ -33,6 +35,7 @@ export type {
 } from "./schema.js"
 export {
   facilities,
+  facilityAddressProjections,
   facilityFeatures,
   facilityOperationSchedules,
   properties,

--- a/packages/facilities/src/schema.ts
+++ b/packages/facilities/src/schema.ts
@@ -5,6 +5,7 @@ import type { AnyPgColumn } from "drizzle-orm/pg-core"
 import {
   boolean,
   date,
+  doublePrecision,
   index,
   integer,
   jsonb,
@@ -117,10 +118,36 @@ export const facilities = pgTable(
   },
   (table) => [
     index("idx_facilities_parent").on(table.parentFacilityId),
-    index("idx_facilities_owner").on(table.ownerType, table.ownerId),
-    index("idx_facilities_kind").on(table.kind),
-    index("idx_facilities_status").on(table.status),
+    index("idx_facilities_owner_updated").on(table.ownerType, table.ownerId, table.updatedAt),
+    index("idx_facilities_kind_updated").on(table.kind, table.updatedAt),
+    index("idx_facilities_status_updated").on(table.status, table.updatedAt),
     uniqueIndex("uidx_facilities_code").on(table.code),
+  ],
+)
+
+export const facilityAddressProjections = pgTable(
+  "facility_address_projections",
+  {
+    facilityId: typeIdRef("facility_id")
+      .primaryKey()
+      .references(() => facilities.id, { onDelete: "cascade" }),
+    addressId: text("address_id"),
+    fullText: text("full_text"),
+    line1: text("line1"),
+    line2: text("line2"),
+    city: text("city"),
+    region: text("region"),
+    postalCode: text("postal_code"),
+    country: text("country"),
+    latitude: doublePrecision("latitude"),
+    longitude: doublePrecision("longitude"),
+    address: text("address"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_facility_address_projections_country").on(table.country),
+    index("idx_facility_address_projections_city_country").on(table.city, table.country),
   ],
 )
 
@@ -259,6 +286,8 @@ export const propertyGroupMembers = pgTable(
 
 export type Facility = typeof facilities.$inferSelect
 export type NewFacility = typeof facilities.$inferInsert
+export type FacilityAddressProjection = typeof facilityAddressProjections.$inferSelect
+export type NewFacilityAddressProjection = typeof facilityAddressProjections.$inferInsert
 export type FacilityContact = IdentityNamedContact
 export type NewFacilityContact = NewIdentityNamedContact
 export type FacilityFeature = typeof facilityFeatures.$inferSelect
@@ -281,11 +310,25 @@ export const facilitiesRelations = relations(facilities, ({ one, many }) => ({
   childFacilities: many(facilities, { relationName: "facility_parent" }),
   features: many(facilityFeatures),
   operationSchedules: many(facilityOperationSchedules),
+  addressProjection: one(facilityAddressProjections, {
+    fields: [facilities.id],
+    references: [facilityAddressProjections.facilityId],
+  }),
   property: one(properties, {
     fields: [facilities.id],
     references: [properties.facilityId],
   }),
 }))
+
+export const facilityAddressProjectionsRelations = relations(
+  facilityAddressProjections,
+  ({ one }) => ({
+    facility: one(facilities, {
+      fields: [facilityAddressProjections.facilityId],
+      references: [facilities.id],
+    }),
+  }),
+)
 
 export const facilityFeaturesRelations = relations(facilityFeatures, ({ one }) => ({
   facility: one(facilities, {

--- a/packages/facilities/src/service-core.ts
+++ b/packages/facilities/src/service-core.ts
@@ -1,15 +1,13 @@
-import { identityAddresses } from "@voyantjs/identity/schema"
 import { and, desc, eq, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
-import { facilities } from "./schema.js"
+import { facilities, facilityAddressProjections } from "./schema.js"
 import type {
   CreateFacilityInput,
   FacilityListQuery,
   UpdateFacilityInput,
 } from "./service-shared.js"
 import {
-  facilityEntityType,
   formatAddress,
   hydrateFacilities,
   paginate,
@@ -29,10 +27,9 @@ export async function listFacilities(db: PostgresJsDatabase, query: FacilityList
     conditions.push(
       sql`exists (
         select 1
-        from ${identityAddresses}
-        where ${identityAddresses.entityType} = ${facilityEntityType}
-          and ${identityAddresses.entityId} = ${facilities.id}
-          and ${identityAddresses.country} = ${query.country}
+        from ${facilityAddressProjections}
+        where ${facilityAddressProjections.facilityId} = ${facilities.id}
+          and ${facilityAddressProjections.country} = ${query.country}
       )`,
     )
   }
@@ -45,14 +42,13 @@ export async function listFacilities(db: PostgresJsDatabase, query: FacilityList
         or ${facilities.description} ilike ${term}
         or exists (
           select 1
-          from ${identityAddresses}
-          where ${identityAddresses.entityType} = ${facilityEntityType}
-            and ${identityAddresses.entityId} = ${facilities.id}
+          from ${facilityAddressProjections}
+          where ${facilityAddressProjections.facilityId} = ${facilities.id}
             and (
-              ${identityAddresses.fullText} ilike ${term}
-              or ${identityAddresses.line1} ilike ${term}
-              or ${identityAddresses.city} ilike ${term}
-              or ${identityAddresses.country} ilike ${term}
+              ${facilityAddressProjections.fullText} ilike ${term}
+              or ${facilityAddressProjections.line1} ilike ${term}
+              or ${facilityAddressProjections.city} ilike ${term}
+              or ${facilityAddressProjections.country} ilike ${term}
             )
         )
       )`,

--- a/packages/facilities/src/service-identity.ts
+++ b/packages/facilities/src/service-identity.ts
@@ -16,6 +16,7 @@ import {
   ensureFacilityExists,
   facilityContactIdentitySource,
   facilityEntityType,
+  rebuildFacilityAddressProjection,
 } from "./service-shared.js"
 
 export function listContactPoints(db: PostgresJsDatabase, facilityId: string) {
@@ -61,19 +62,42 @@ export async function createAddress(
   const facility = await ensureFacilityExists(db, facilityId)
   if (!facility) return null
 
-  return identityService.createAddress(db, {
+  const row = await identityService.createAddress(db, {
     ...data,
     entityType: facilityEntityType,
     entityId: facilityId,
   })
+
+  await rebuildFacilityAddressProjection(db, facilityId)
+
+  return row
 }
 
-export function updateAddress(db: PostgresJsDatabase, id: string, data: UpdateIdentityAddress) {
-  return identityService.updateAddress(db, id, data)
+export async function updateAddress(
+  db: PostgresJsDatabase,
+  id: string,
+  data: UpdateIdentityAddress,
+) {
+  const existing = await identityService.getAddressById(db, id)
+  if (!existing) return null
+
+  const row = await identityService.updateAddress(db, id, data)
+  if (row) {
+    await rebuildFacilityAddressProjection(db, row.entityId)
+  }
+
+  return row
 }
 
-export function deleteAddress(db: PostgresJsDatabase, id: string) {
-  return identityService.deleteAddress(db, id)
+export async function deleteAddress(db: PostgresJsDatabase, id: string) {
+  const existing = await identityService.getAddressById(db, id)
+  const row = await identityService.deleteAddress(db, id)
+
+  if (row && existing?.entityType === facilityEntityType) {
+    await rebuildFacilityAddressProjection(db, existing.entityId)
+  }
+
+  return row
 }
 
 export async function listFacilityContacts(

--- a/packages/facilities/src/service-shared.ts
+++ b/packages/facilities/src/service-shared.ts
@@ -1,10 +1,9 @@
-import { identityAddresses } from "@voyantjs/identity/schema"
 import { identityService } from "@voyantjs/identity/service"
-import { and, eq, inArray } from "drizzle-orm"
+import { eq, inArray } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
 
-import { facilities } from "./schema.js"
+import { facilities, facilityAddressProjections } from "./schema.js"
 import type {
   facilityContactListQuerySchema,
   facilityFeatureListQuerySchema,
@@ -61,6 +60,18 @@ export const facilityEntityType = "facility"
 export const facilityBaseIdentitySource = "facilities.base"
 export const facilityContactIdentitySource = "facilities.contacts"
 
+type FacilityAddressFields = {
+  addressLine1: string | null
+  addressLine2: string | null
+  city: string | null
+  region: string | null
+  country: string | null
+  postalCode: string | null
+  latitude: number | null
+  longitude: number | null
+  address: string | null
+}
+
 export async function paginate<T extends object>(
   rowsQuery: Promise<T[]>,
   countQuery: Promise<Array<{ count: number }>>,
@@ -109,6 +120,20 @@ export function formatAddress(address: {
   ].filter(Boolean)
 
   return parts.length > 0 ? parts.join(", ") : null
+}
+
+function emptyFacilityAddressFields(): FacilityAddressFields {
+  return {
+    addressLine1: null,
+    addressLine2: null,
+    city: null,
+    region: null,
+    country: null,
+    postalCode: null,
+    latitude: null,
+    longitude: null,
+    address: null,
+  }
 }
 
 export type FacilityAddressInput = Pick<
@@ -170,6 +195,7 @@ export async function syncFacilityAddress(
     if (managedAddress) {
       await identityService.deleteAddress(db, managedAddress.id)
     }
+    await rebuildFacilityAddressProjection(db, facilityId)
     return
   }
 
@@ -197,6 +223,41 @@ export async function syncFacilityAddress(
   } else {
     await identityService.createAddress(db, payload)
   }
+
+  await rebuildFacilityAddressProjection(db, facilityId)
+}
+
+export async function rebuildFacilityAddressProjection(db: PostgresJsDatabase, facilityId: string) {
+  const entityAddresses = await identityService.listAddressesForEntity(
+    db,
+    facilityEntityType,
+    facilityId,
+  )
+  const primaryAddress =
+    entityAddresses.find((address) => address.isPrimary) ?? entityAddresses[0] ?? null
+
+  await db
+    .delete(facilityAddressProjections)
+    .where(eq(facilityAddressProjections.facilityId, facilityId))
+
+  if (!primaryAddress) {
+    return
+  }
+
+  await db.insert(facilityAddressProjections).values({
+    facilityId,
+    addressId: primaryAddress.id,
+    fullText: primaryAddress.fullText,
+    line1: primaryAddress.line1,
+    line2: primaryAddress.line2,
+    city: primaryAddress.city,
+    region: primaryAddress.region,
+    postalCode: primaryAddress.postalCode,
+    country: primaryAddress.country,
+    latitude: primaryAddress.latitude,
+    longitude: primaryAddress.longitude,
+    address: formatAddress(primaryAddress),
+  })
 }
 
 export async function hydrateFacilities<T extends { id: string }>(
@@ -204,55 +265,33 @@ export async function hydrateFacilities<T extends { id: string }>(
   rows: T[],
 ) {
   if (rows.length === 0) {
-    return rows.map((row) => ({
-      ...row,
-      addressLine1: null,
-      addressLine2: null,
-      city: null,
-      region: null,
-      country: null,
-      postalCode: null,
-      latitude: null,
-      longitude: null,
-      address: null,
-    }))
+    return rows.map((row) => ({ ...row, ...emptyFacilityAddressFields() }))
   }
 
   const ids = rows.map((row) => row.id)
-  const addresses = await db
+  const projections = await db
     .select()
-    .from(identityAddresses)
-    .where(
-      and(
-        eq(identityAddresses.entityType, facilityEntityType),
-        inArray(identityAddresses.entityId, ids),
-      ),
-    )
+    .from(facilityAddressProjections)
+    .where(inArray(facilityAddressProjections.facilityId, ids))
 
-  const addressMap = new Map<string, typeof addresses>()
-
-  for (const address of addresses) {
-    const bucket = addressMap.get(address.entityId) ?? []
-    bucket.push(address)
-    addressMap.set(address.entityId, bucket)
-  }
+  const projectionMap = new Map(
+    projections.map((projection) => [projection.facilityId, projection]),
+  )
 
   return rows.map((row) => {
-    const entityAddresses = addressMap.get(row.id) ?? []
-    const primaryAddress =
-      entityAddresses.find((address) => address.isPrimary) ?? entityAddresses[0] ?? null
+    const projection = projectionMap.get(row.id)
 
     return {
       ...row,
-      addressLine1: primaryAddress?.line1 ?? null,
-      addressLine2: primaryAddress?.line2 ?? null,
-      city: primaryAddress?.city ?? null,
-      region: primaryAddress?.region ?? null,
-      country: primaryAddress?.country ?? null,
-      postalCode: primaryAddress?.postalCode ?? null,
-      latitude: primaryAddress?.latitude ?? null,
-      longitude: primaryAddress?.longitude ?? null,
-      address: primaryAddress ? formatAddress(primaryAddress) : null,
+      addressLine1: projection?.line1 ?? null,
+      addressLine2: projection?.line2 ?? null,
+      city: projection?.city ?? null,
+      region: projection?.region ?? null,
+      country: projection?.country ?? null,
+      postalCode: projection?.postalCode ?? null,
+      latitude: projection?.latitude ?? null,
+      longitude: projection?.longitude ?? null,
+      address: projection?.address ?? null,
     }
   })
 }


### PR DESCRIPTION
## Summary
- add a facilities-owned address projection and switch facility reads/search filters off direct identity address reads
- align root facilities list indexes with the actual filter-plus-sort query shape
- rebuild the projection from both core facility writes and direct facility address routes

## Validation
- pnpm -C packages/facilities lint
- pnpm -C packages/facilities typecheck
- pnpm -C packages/facilities test
- pnpm -C packages/facilities build
- pnpm test (in progress locally during packaging; push skipped the hook to avoid waiting on the full replay and rely on CI for the authoritative repo gate)