### PR TITLE
fix(netopia): defer runtime resolution when env is missing

### DIFF
--- a/packages/plugins/netopia/src/plugin.ts
+++ b/packages/plugins/netopia/src/plugin.ts
@@ -208,10 +208,18 @@ export function netopiaHonoBundle(options: NetopiaRuntimeOptions = {}): HonoBund
     name: "netopia",
     version: "0.1.0",
     bootstrap: ({ bindings, container }) => {
-      container.register(
-        NETOPIA_RUNTIME_CONTAINER_KEY,
-        resolveNetopiaRuntimeOptions(bindings as Record<string, unknown> | undefined, options),
-      )
+      try {
+        container.register(
+          NETOPIA_RUNTIME_CONTAINER_KEY,
+          resolveNetopiaRuntimeOptions(bindings as Record<string, unknown> | undefined, options),
+        )
+      } catch (error) {
+        // Defer resolution to per-request handlers. Missing env should only fail
+        // Netopia-owned routes, not the whole app — `getNetopiaRuntime` will retry
+        // from bindings on each request and surface the same error on Netopia calls.
+        const message = error instanceof Error ? error.message : String(error)
+        console.warn(`[netopia] Runtime bootstrap skipped: ${message}`)
+      }
     },
     extensions: [createNetopiaFinanceExtension(options)],
   })

--- a/packages/plugins/netopia/tests/unit/plugin.test.ts
+++ b/packages/plugins/netopia/tests/unit/plugin.test.ts
@@ -1,6 +1,7 @@
 import { createContainer, createEventBus } from "@voyantjs/core"
 import { financeService, type PaymentSession } from "@voyantjs/finance"
 import { notificationsService } from "@voyantjs/notifications"
+import { Hono } from "hono"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import type { NetopiaClientApi } from "../../src/client.js"
 import {
@@ -115,16 +116,45 @@ describe("netopiaHonoPlugin.bootstrap", () => {
     })
   })
 
-  it("fails fast when required runtime config is missing", async () => {
+  it("defers resolution and logs a warning when runtime config is missing", async () => {
     const plugin = netopiaHonoPlugin()
+    const container = createContainer()
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined)
 
-    expect(() =>
-      plugin.bootstrap?.({
-        bindings: {},
-        container: createContainer(),
-        eventBus: createEventBus(),
-      }),
-    ).toThrow(/NETOPIA_URL/)
+    await plugin.bootstrap?.({
+      bindings: {},
+      container,
+      eventBus: createEventBus(),
+    })
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/NETOPIA_URL/))
+    expect(() => container.resolve(NETOPIA_RUNTIME_CONTAINER_KEY)).toThrow()
+  })
+
+  it("still fails Netopia-owned routes when runtime config is missing", async () => {
+    const bundle = netopiaHonoPlugin()
+    const container = createContainer()
+    vi.spyOn(console, "warn").mockImplementation(() => undefined)
+    await bundle.bootstrap?.({
+      bindings: {},
+      container,
+      eventBus: createEventBus(),
+    })
+
+    const [extension] = bundle.extensions ?? []
+    expect(extension).toBeDefined()
+
+    // The config route resolves runtime per-request; without config, it returns 500.
+    const app = new Hono().use("*", async (c, next) => {
+      c.set("container", container)
+      await next()
+    })
+    app.route("/", extension!.routes)
+
+    const res = await app.request("/providers/netopia/config", { method: "GET" })
+    expect(res.status).toBe(500)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toMatch(/NETOPIA_URL/)
   })
 })
 


### PR DESCRIPTION
## Summary
- `netopiaHonoBundle` bootstrap now catches missing-config errors, logs a warning, and skips container registration instead of throwing.
- Because `createApp` caches the bootstrap promise, the previous eager throw made every subsequent request — including `/auth/*` and org reads — fail with `Missing Netopia config: NETOPIA_URL`. Now only Netopia-owned routes fail when env is absent (as per-request resolution still throws on the Netopia paths).
- Updated unit tests: bootstrap no longer throws; a new test asserts the `/providers/netopia/config` route still returns 500 with the missing-env message.

Closes #216

## Test plan
- [x] `pnpm -F @voyantjs/plugin-netopia test` (25 passing)
- [x] `pnpm -F @voyantjs/plugin-netopia typecheck`
- [ ] Verify in an integration app: mounting `netopiaHonoPlugin()` with no `NETOPIA_*` env no longer breaks `/auth/me` etc.