### PR TITLE
fix(hono): isolate bootstrap failures per plugin/module/extension

### DIFF
--- a/packages/hono/src/app.ts
+++ b/packages/hono/src/app.ts
@@ -63,14 +63,29 @@ export function createApp<TBindings extends VoyantBindings>(
       bootstrapPromise = (async () => {
         const ctx = { bindings, container, eventBus }
 
+        // Run each bootstrap in isolation — a single failing plugin/module/extension
+        // must not poison the cached promise and kill the whole app's request pipeline.
+        const runIsolated = async (label: string, fn?: (c: typeof ctx) => unknown) => {
+          if (!fn) return
+          try {
+            await fn(ctx)
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error)
+            console.error(`[voyant] bootstrap failed for ${label}: ${message}`)
+          }
+        }
+
         for (const plugin of config.plugins ?? []) {
-          await plugin.bootstrap?.(ctx)
+          await runIsolated(`plugin:${plugin.name}`, plugin.bootstrap)
         }
         for (const mod of allModules) {
-          await mod.module.bootstrap?.(ctx)
+          await runIsolated(`module:${mod.module.name}`, mod.module.bootstrap)
         }
         for (const ext of allExtensions) {
-          await ext.extension.bootstrap?.(ctx)
+          await runIsolated(
+            `extension:${ext.extension.module}/${ext.extension.name}`,
+            ext.extension.bootstrap,
+          )
         }
       })()
     }

--- a/packages/hono/tests/unit/plugin.test.ts
+++ b/packages/hono/tests/unit/plugin.test.ts
@@ -217,6 +217,48 @@ describe("createApp with plugins", () => {
     expect(calls).toEqual(["plugin", "module", "extension"])
   })
 
+  it("isolates bootstrap failures — a throwing plugin must not break unrelated routes", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const goodModule: HonoModule = {
+      module: {
+        name: "good",
+        bootstrap: ({ container }) => {
+          container.register("good.runtime", { ok: true })
+        },
+      },
+      adminRoutes: new Hono().get("/ping", (c) => {
+        const runtime = c.var.container.resolve<{ ok: boolean }>("good.runtime")
+        return c.json(runtime)
+      }),
+    }
+    const throwingPlugin = defineHonoPlugin({
+      name: "throwing",
+      bootstrap: () => {
+        throw new Error("missing env NETOPIA_URL")
+      },
+    })
+
+    const app = createApp({
+      // biome-ignore lint/suspicious/noExplicitAny: test doesn't use db
+      db: () => ({}) as any,
+      plugins: [throwingPlugin],
+      modules: [goodModule],
+      auth: { resolve: () => ({ userId: "u1", actor: "staff" as Actor }) },
+    })
+
+    // First request: bootstrap runs; throwing plugin is logged but does not block pipeline.
+    const r1 = await app.request("/v1/admin/good/ping", {}, TEST_ENV, TEST_CTX)
+    expect(r1.status).toBe(200)
+    await expect(r1.json()).resolves.toEqual({ ok: true })
+
+    // Second request: cached bootstrap promise must resolve (not reject), so this still succeeds.
+    const r2 = await app.request("/v1/admin/good/ping", {}, TEST_ENV, TEST_CTX)
+    expect(r2.status).toBe(200)
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringMatching(/plugin:throwing/))
+    errorSpy.mockRestore()
+  })
+
   it("exposes bootstrap-registered runtime services through the shared container", async () => {
     const app = createApp({
       // biome-ignore lint/suspicious/noExplicitAny: test doesn't use db


### PR DESCRIPTION
## Summary
- `createApp` previously cached the bootstrap promise including rejections, so a single plugin/module/extension that threw in its `bootstrap` handler would make every subsequent request fail — including unrelated `/auth` and org routes. Surfaced in #216 via the Netopia plugin, but the issue is general.
- Each bootstrap handler now runs inside an isolated try/catch, failures are logged as `[voyant] bootstrap failed for <label>: <message>`, and the outer promise always resolves.
- A misconfigured plugin can still fail its own routes via per-request resolution; it just can't take out the pipeline.

Companion to #229 (netopia-side fix for #216).

## Test plan
- [x] `pnpm -F @voyantjs/hono test` — 41 passing, includes a new regression test that mounts a throwing plugin alongside a working module and asserts the working route still responds 200 across multiple requests.
- [x] `pnpm -F @voyantjs/hono typecheck`