### PR TITLE
fix(operator): prevent product detail two-column grid from overflowing

### DIFF
--- a/templates/operator/src/components/voyant/products/product-detail-page.tsx
+++ b/templates/operator/src/components/voyant/products/product-detail-page.tsx
@@ -174,9 +174,9 @@ export function ProductDetailPage({ id }: { id: string }) {
       />
 
       {/* Content — two-column layout */}
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_320px]">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
         {/* ── Left column (main) ── */}
-        <div className="flex flex-col gap-6">
+        <div className="flex min-w-0 flex-col gap-6">
           {/* Product Details */}
           <ProductDetailsSection product={product} onEdit={() => setEditOpen(true)} />
 

--- a/templates/operator/src/components/voyant/products/product-detail-skeleton.tsx
+++ b/templates/operator/src/components/voyant/products/product-detail-skeleton.tsx
@@ -13,9 +13,9 @@ export function ProductDetailSkeleton() {
     <div className="flex flex-col gap-6 p-6">
       <ProductDetailHeaderSkeleton />
 
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_320px]">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
         {/* Left column */}
-        <div className="flex flex-col gap-6">
+        <div className="flex min-w-0 flex-col gap-6">
           <ProductDetailsSectionSkeleton />
           <ProductDeparturesSectionSkeleton />
           <ProductSchedulesSectionSkeleton />
@@ -24,7 +24,7 @@ export function ProductDetailSkeleton() {
         </div>
 
         {/* Right column */}
-        <div className="flex flex-col gap-6">
+        <div className="flex min-w-0 flex-col gap-6">
           <ProductChannelsSectionSkeleton />
           <ProductOrganizeSectionSkeleton />
           <ProductMediaSectionSkeleton />


### PR DESCRIPTION
## Summary
- The product detail layout used `grid-cols-[1fr_320px]`. CSS grid tracks default to `min-width: auto`, so a `1fr` track cannot shrink below its intrinsic content — once the embla carousel rendered a full-resolution product image, the left track grew past its share and pushed the right column (Channels, Organize) off-screen on normal desktop widths.
- Switched the track to `minmax(0, 1fr)` and added `min-w-0` to the left flex column, applied to both the live page and the loading skeleton.

Closes #220

## Test plan
- [x] `pnpm -F operator typecheck`
- [ ] Open `/products/<id>` at 1440px with a product that has at least one image in `product_media` — right column (Channels / Organize) is fully visible; titles no longer truncate to `Channe…` / `Organiz…`.
- [ ] Verify the skeleton state still matches the rendered layout.