### PR TITLE
feat(bookings): filter list by productId/optionId/personId/organizationId

### DIFF
--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, ilike, inArray, lte, ne, or, sql } from "drizzle-orm"
+import { and, asc, desc, eq, exists, ilike, inArray, lte, ne, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
 
@@ -1230,6 +1230,32 @@ export const bookingsService = {
     if (query.search) {
       const term = `%${query.search}%`
       conditions.push(or(ilike(bookings.bookingNumber, term), ilike(bookings.internalNotes, term)))
+    }
+
+    if (query.personId) {
+      conditions.push(eq(bookings.personId, query.personId))
+    }
+
+    if (query.organizationId) {
+      conditions.push(eq(bookings.organizationId, query.organizationId))
+    }
+
+    if (query.productId || query.optionId) {
+      const itemConditions = [eq(bookingItems.bookingId, bookings.id)]
+      if (query.productId) {
+        itemConditions.push(eq(bookingItems.productId, query.productId))
+      }
+      if (query.optionId) {
+        itemConditions.push(eq(bookingItems.optionId, query.optionId))
+      }
+      conditions.push(
+        exists(
+          db
+            .select({ one: sql`1` })
+            .from(bookingItems)
+            .where(and(...itemConditions)),
+        ),
+      )
     }
 
     const where = conditions.length > 0 ? and(...conditions) : undefined

--- a/packages/bookings/src/validation.ts
+++ b/packages/bookings/src/validation.ts
@@ -76,6 +76,10 @@ export const createBookingSchema = bookingCoreSchema
 export const bookingListQuerySchema = z.object({
   status: bookingStatusSchema.optional(),
   search: z.string().optional(),
+  productId: z.string().optional(),
+  optionId: z.string().optional(),
+  personId: z.string().optional(),
+  organizationId: z.string().optional(),
   limit: z.coerce.number().int().min(1).max(100).default(50),
   offset: z.coerce.number().int().min(0).default(0),
 })

--- a/packages/bookings/tests/unit/validation-queries.test.ts
+++ b/packages/bookings/tests/unit/validation-queries.test.ts
@@ -84,4 +84,17 @@ describe("Booking list query schema", () => {
     expect(result.status).toBe("confirmed")
     expect(result.search).toBe("hotel")
   })
+
+  it("accepts productId, optionId, personId, organizationId filters", () => {
+    const result = bookingListQuerySchema.parse({
+      productId: "prod_abc",
+      optionId: "opto_def",
+      personId: "pers_ghi",
+      organizationId: "org_jkl",
+    })
+    expect(result.productId).toBe("prod_abc")
+    expect(result.optionId).toBe("opto_def")
+    expect(result.personId).toBe("pers_ghi")
+    expect(result.organizationId).toBe("org_jkl")
+  })
 })


### PR DESCRIPTION
## Summary
- `bookingListQuerySchema` used plain `z.object({…})`, so unknown query keys (e.g. `?productId=…`) were silently dropped. The React client (`@voyantjs/bookings-react`) already forwards `productId`, so clients looked fine but got an unfiltered list.
- Extended the schema with `productId`, `optionId`, `personId`, `organizationId` (all optional) and wired the service:
  - `personId` / `organizationId` → direct `eq` on `bookings`.
  - `productId` / `optionId` → `exists` subquery over `booking_items`. `idx_booking_items_booking` covers the correlated lookup; extra product_id/option_id narrowing happens in-place on the matched rows.

Closes #221

## Test plan
- [x] `pnpm -F @voyantjs/bookings typecheck`
- [x] `pnpm -F @voyantjs/bookings test` — 106 passing, new case confirms the schema plumbs the filter fields through.
- [ ] Smoke: `GET /v1/bookings?productId=prod_abc` on an operator instance with a booking that has an item for `prod_abc` returns only that booking; without the FK the list is unchanged.