### PR TITLE
feat(bookings): accept slotId on convertProductSchema

### DIFF
--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -108,6 +108,18 @@ export interface ConvertProductData {
     pax: number | null
   }
   option: { id: string; name: string } | null
+  /**
+   * Availability slot the caller chose, if any. When set, the resulting booking
+   * pins its startDate/endDate to the slot so recurring/scheduled products don't
+   * land with null dates.
+   */
+  slot?: {
+    id: string
+    dateLocal: string
+    startsAt: Date
+    endsAt: Date | null
+    timezone: string
+  } | null
   dayServices: Array<{
     supplierServiceId: string | null
     name: string
@@ -467,6 +479,36 @@ async function getConvertProductData(
           .where(eq(optionUnitsRef.optionId, option.id))
           .orderBy(asc(optionUnitsRef.sortOrder), asc(optionUnitsRef.createdAt))
 
+  let slot: ConvertProductData["slot"] = null
+  if (data.slotId) {
+    const [selectedSlot] = await db
+      .select()
+      .from(availabilitySlotsRef)
+      .where(
+        and(
+          eq(availabilitySlotsRef.id, data.slotId),
+          eq(availabilitySlotsRef.productId, product.id),
+        ),
+      )
+      .limit(1)
+
+    if (!selectedSlot) {
+      return null
+    }
+
+    if (option && selectedSlot.optionId && selectedSlot.optionId !== option.id) {
+      return null
+    }
+
+    slot = {
+      id: selectedSlot.id,
+      dateLocal: selectedSlot.dateLocal,
+      startsAt: selectedSlot.startsAt,
+      endsAt: selectedSlot.endsAt,
+      timezone: selectedSlot.timezone,
+    }
+  }
+
   return {
     product: {
       id: product.id,
@@ -481,6 +523,7 @@ async function getConvertProductData(
       pax: product.pax,
     },
     option: option ? { id: option.id, name: option.name } : null,
+    slot,
     dayServices,
     units: units.map((unit) => ({
       id: unit.id,
@@ -1259,7 +1302,17 @@ export const bookingsService = {
     productData: ConvertProductData,
     userId?: string,
   ) {
-    const { product, option, dayServices, units } = productData
+    const { product, option, slot, dayServices, units } = productData
+
+    // Slot dates win over product dates so scheduled/recurring products don't
+    // land with null dates. endsAt is a timestamp; fall back to the slot's
+    // dateLocal when the slot has no explicit end timestamp.
+    const startDate = slot?.dateLocal ?? product.startDate
+    const endDate = slot
+      ? slot.endsAt
+        ? slot.endsAt.toISOString().slice(0, 10)
+        : slot.dateLocal
+      : product.endDate
 
     const [booking] = await db
       .insert(bookings)
@@ -1272,8 +1325,8 @@ export const bookingsService = {
         sellAmountCents: product.sellAmountCents,
         costAmountCents: product.costAmountCents,
         marginPercent: product.marginPercent,
-        startDate: product.startDate,
-        endDate: product.endDate,
+        startDate,
+        endDate,
         pax: product.pax,
         internalNotes: data.internalNotes ?? null,
       })
@@ -1304,6 +1357,15 @@ export const bookingsService = {
         : selectedUnits.length === 1
           ? selectedUnits
           : []
+
+    const slotFields = slot
+      ? {
+          serviceDate: slot.dateLocal,
+          startsAt: slot.startsAt,
+          endsAt: slot.endsAt,
+          metadata: { availabilitySlotId: slot.id } as Record<string, unknown>,
+        }
+      : { metadata: null as Record<string, unknown> | null }
 
     const itemRows =
       unitsToSeed.length > 0
@@ -1341,6 +1403,7 @@ export const bookingsService = {
               productId: product.id,
               optionId: option?.id ?? null,
               optionUnitId: unit.id,
+              ...slotFields,
             }
           })
         : [
@@ -1360,6 +1423,7 @@ export const bookingsService = {
               productId: product.id,
               optionId: option?.id ?? null,
               optionUnitId: null,
+              ...slotFields,
             },
           ]
 
@@ -1398,7 +1462,12 @@ export const bookingsService = {
       actorId: userId ?? "system",
       activityType: "booking_converted",
       description: `Booking converted from product "${product.name}"`,
-      metadata: { productId: product.id, productName: product.name, optionId: option?.id ?? null },
+      metadata: {
+        productId: product.id,
+        productName: product.name,
+        optionId: option?.id ?? null,
+        slotId: slot?.id ?? null,
+      },
     })
 
     return booking

--- a/packages/bookings/src/validation.ts
+++ b/packages/bookings/src/validation.ts
@@ -83,6 +83,7 @@ export const bookingListQuerySchema = z.object({
 export const convertProductSchema = z.object({
   productId: z.string().min(1),
   optionId: z.string().optional().nullable(),
+  slotId: z.string().optional().nullable(),
   bookingNumber: z.string().min(1).max(50),
   personId: z.string().optional().nullable(),
   organizationId: z.string().optional().nullable(),

--- a/packages/bookings/tests/unit/validation-booking.test.ts
+++ b/packages/bookings/tests/unit/validation-booking.test.ts
@@ -166,4 +166,21 @@ describe("Convert product schema", () => {
   it("rejects missing bookingNumber", () => {
     expect(() => convertProductSchema.parse({ productId: "prod_abc" })).toThrow()
   })
+
+  it("accepts an optional slotId", () => {
+    const result = convertProductSchema.parse({
+      productId: "prod_abc",
+      bookingNumber: "BK-001",
+      slotId: "slot_dep_2026_06_01",
+    })
+    expect(result.slotId).toBe("slot_dep_2026_06_01")
+  })
+
+  it("allows omitting slotId (single-date products)", () => {
+    const result = convertProductSchema.parse({
+      productId: "prod_abc",
+      bookingNumber: "BK-001",
+    })
+    expect(result.slotId).toBeUndefined()
+  })
 })


### PR DESCRIPTION
## Summary
`bookingsService.createBookingFromProduct` had no way to accept the departure the operator actually picked — scheduled/recurring products (the common operator case) landed with null `startDate`/`endDate` and no slot association. This made it the #1 friction point for the create-booking flow (#223 called this out as its concrete blocker).

- `convertProductSchema` gains an optional `slotId`.
- `getConvertProductData` loads the slot, validates it against the resolved product + option. Mismatched slot returns `null` — same signal as a mismatched product/option.
- `convertProductToBooking`:
  - Prefers the slot's `dateLocal` / `endsAt` over product dates for `bookings.startDate` / `endDate`.
  - Stamps each `booking_item`'s `serviceDate` / `startsAt` / `endsAt` from the slot and records the slot id in `booking_items.metadata`.
  - Records the slot id in the `booking_converted` activity-log entry.
- `ConvertProductData` gains an optional `slot` field — callers that construct the value themselves continue to compile unchanged.

Closes #224.

Out of scope, per the issue: a dedicated `booking_items.availability_slot_id` column that would let "bookings for slot X" be a single indexed query — will follow as a separate schema migration PR.

## Test plan
- [x] `pnpm -F @voyantjs/bookings typecheck`
- [x] `pnpm -F @voyantjs/bookings test` — 107 passing, two new cases confirm `slotId` is accepted as optional.
- [x] `pnpm typecheck` — 136/136 tasks (full monorepo typecheck — no downstream consumer breaks).
- [ ] Smoke on operator: converting a scheduled product without `slotId` still works (null dates, as before); passing a `slotId` writes correct dates + serviceDate/startsAt on items and the slot id lands in the activity log.