### PR TITLE
feat(bookings): add GET /bookings/aggregates dashboard endpoint

### DIFF
--- a/packages/bookings/src/routes.ts
+++ b/packages/bookings/src/routes.ts
@@ -23,6 +23,7 @@ import { bookingsService } from "./service.js"
 import { bookingGroupsService } from "./service-groups.js"
 import { publicBookingsService, resolveSessionPricingSnapshot } from "./service-public.js"
 import {
+  bookingAggregatesQuerySchema,
   bookingListQuerySchema,
   cancelBookingSchema,
   confirmBookingSchema,
@@ -236,6 +237,12 @@ export const bookingRoutes = new Hono<Env>()
       return c.json({ error: "Pricing unavailable for this selection" }, 404)
     }
     return c.json({ data: snapshot })
+  })
+
+  // 1b. GET /aggregates — Pre-aggregated dashboard metrics
+  .get("/aggregates", async (c) => {
+    const query = parseQuery(c, bookingAggregatesQuerySchema)
+    return c.json({ data: await bookingsService.getBookingAggregates(c.get("db"), query) })
   })
 
   // 1b. GET /overview — Internal/admin booking overview lookup

--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -1307,7 +1307,139 @@ async function autoIssueFulfillmentsForBooking(
   })
 }
 
+/**
+ * Booking statuses that count as "active" for aggregate purposes (matches the
+ * slot-unit-availability counting rules — cancelled and expired drop out).
+ */
+const AGGREGATE_ACTIVE_STATUSES: readonly BookingStatus[] = [
+  "draft",
+  "on_hold",
+  "confirmed",
+  "in_progress",
+  "completed",
+]
+
+export interface BookingAggregates {
+  /** Total bookings across all statuses in range. */
+  total: number
+  /** One row per booking status (including zero counts for active statuses). */
+  countsByStatus: Array<{ status: BookingStatus; count: number }>
+  /** Booking counts bucketed by YYYY-MM (UTC), oldest first. */
+  monthlyCounts: Array<{ yearMonth: string; count: number }>
+  /**
+   * Sell revenue bucketed by YYYY-MM (UTC), grouped by currency. Null currency
+   * rows are dropped since a booking without a sell currency is malformed.
+   */
+  monthlyRevenue: Array<{ yearMonth: string; currency: string; sellAmountCents: number }>
+  /** Count of active bookings with `startDate >= today`. */
+  upcomingDepartures: number
+}
+
 export const bookingsService = {
+  /**
+   * Pre-aggregated dashboard numbers for the admin bookings surface. Replaces
+   * the pattern of fetching a large `listBookings` page and deriving KPIs
+   * client-side — which broke past the page limit and disagreed across apps
+   * on which statuses count.
+   *
+   * All ranges are UTC-based.
+   */
+  async getBookingAggregates(
+    db: PostgresJsDatabase,
+    options: { from?: string; to?: string } = {},
+  ): Promise<BookingAggregates> {
+    const fromDate = options.from ? new Date(options.from) : undefined
+    const toDate = options.to ? new Date(options.to) : undefined
+
+    const rangeConditions = []
+    if (fromDate) rangeConditions.push(sql`${bookings.createdAt} >= ${fromDate}`)
+    if (toDate) rangeConditions.push(sql`${bookings.createdAt} < ${toDate}`)
+    const rangeWhere = rangeConditions.length ? and(...rangeConditions) : undefined
+
+    const [totalRow] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(bookings)
+      .where(rangeWhere)
+
+    const statusRows = await db
+      .select({
+        status: bookings.status,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(bookings)
+      .where(rangeWhere)
+      .groupBy(bookings.status)
+
+    const countsByStatusMap = new Map<BookingStatus, number>(
+      statusRows.map((row) => [row.status, row.count]),
+    )
+
+    const monthlyCountsRows = await db
+      .select({
+        yearMonth: sql<string>`to_char(${bookings.createdAt} at time zone 'UTC', 'YYYY-MM')`,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(bookings)
+      .where(rangeWhere)
+      .groupBy(sql`to_char(${bookings.createdAt} at time zone 'UTC', 'YYYY-MM')`)
+      .orderBy(sql`to_char(${bookings.createdAt} at time zone 'UTC', 'YYYY-MM')`)
+
+    const monthlyRevenueRows = await db
+      .select({
+        yearMonth: sql<string>`to_char(${bookings.createdAt} at time zone 'UTC', 'YYYY-MM')`,
+        currency: bookings.sellCurrency,
+        sellAmountCents: sql<number>`coalesce(sum(${bookings.sellAmountCents}), 0)::bigint`,
+      })
+      .from(bookings)
+      .where(
+        and(
+          ...(rangeConditions.length ? rangeConditions : []),
+          sql`${bookings.sellAmountCents} IS NOT NULL`,
+          inArray(bookings.status, [...AGGREGATE_ACTIVE_STATUSES]),
+        ),
+      )
+      .groupBy(
+        sql`to_char(${bookings.createdAt} at time zone 'UTC', 'YYYY-MM')`,
+        bookings.sellCurrency,
+      )
+      .orderBy(
+        sql`to_char(${bookings.createdAt} at time zone 'UTC', 'YYYY-MM')`,
+        bookings.sellCurrency,
+      )
+
+    const todayUtc = new Date()
+    todayUtc.setUTCHours(0, 0, 0, 0)
+    const todayDateString = todayUtc.toISOString().slice(0, 10)
+
+    const [upcomingRow] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(bookings)
+      .where(
+        and(
+          inArray(bookings.status, [...AGGREGATE_ACTIVE_STATUSES]),
+          sql`${bookings.startDate} >= ${todayDateString}`,
+        ),
+      )
+
+    return {
+      total: totalRow?.count ?? 0,
+      countsByStatus: AGGREGATE_ACTIVE_STATUSES.concat(["expired", "cancelled"]).map((status) => ({
+        status,
+        count: countsByStatusMap.get(status) ?? 0,
+      })),
+      monthlyCounts: monthlyCountsRows.map((row) => ({
+        yearMonth: row.yearMonth,
+        count: row.count,
+      })),
+      monthlyRevenue: monthlyRevenueRows.map((row) => ({
+        yearMonth: row.yearMonth,
+        currency: row.currency,
+        sellAmountCents: Number(row.sellAmountCents),
+      })),
+      upcomingDepartures: upcomingRow?.count ?? 0,
+    }
+  },
+
   async listBookings(db: PostgresJsDatabase, query: BookingListQuery) {
     const conditions = []
 

--- a/packages/bookings/src/validation.ts
+++ b/packages/bookings/src/validation.ts
@@ -84,6 +84,11 @@ export const bookingListQuerySchema = z.object({
   offset: z.coerce.number().int().min(0).default(0),
 })
 
+export const bookingAggregatesQuerySchema = z.object({
+  from: z.string().datetime().optional(),
+  to: z.string().datetime().optional(),
+})
+
 export const convertProductSchema = z.object({
   productId: z.string().min(1),
   optionId: z.string().optional().nullable(),

--- a/packages/bookings/tests/integration/routes.test.ts
+++ b/packages/bookings/tests/integration/routes.test.ts
@@ -501,6 +501,48 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
       expect(body.total).toBeGreaterThanOrEqual(1)
     })
 
+    it("returns dashboard aggregates", async () => {
+      // Future-dated confirmed booking → counted in upcomingDepartures.
+      const future = new Date()
+      future.setUTCMonth(future.getUTCMonth() + 2)
+      await seedBooking({
+        status: "confirmed",
+        startDate: future.toISOString().slice(0, 10),
+        sellAmountCents: 15000,
+      })
+      // Past cancelled booking → must drop out of monthlyRevenue + upcoming.
+      await seedBooking({
+        status: "cancelled",
+        startDate: "2020-01-01",
+        sellAmountCents: 99999,
+      })
+
+      const res = await app.request("/aggregates", { method: "GET" })
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data.total).toBeGreaterThanOrEqual(2)
+      // countsByStatus includes all 7 statuses with zeroes for unused ones.
+      const statuses = body.data.countsByStatus.map((row: { status: string }) => row.status)
+      expect(statuses).toEqual(
+        expect.arrayContaining([
+          "draft",
+          "on_hold",
+          "confirmed",
+          "in_progress",
+          "completed",
+          "expired",
+          "cancelled",
+        ]),
+      )
+      expect(body.data.upcomingDepartures).toBeGreaterThanOrEqual(1)
+      // Revenue only counts the confirmed booking (cancelled is excluded).
+      const revenueTotal = body.data.monthlyRevenue.reduce(
+        (sum: number, row: { sellAmountCents: number }) => sum + row.sellAmountCents,
+        0,
+      )
+      expect(revenueTotal).toBe(15000)
+    })
+
     it("gets a booking by id", async () => {
       const booking = await seedBooking()
       const res = await app.request(`/${booking.id}`, { method: "GET" })

--- a/packages/bookings/tests/unit/validation-queries.test.ts
+++ b/packages/bookings/tests/unit/validation-queries.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  bookingAggregatesQuerySchema,
   bookingListQuerySchema,
   insertBookingDocumentSchema,
   insertBookingNoteSchema,
@@ -96,5 +97,27 @@ describe("Booking list query schema", () => {
     expect(result.optionId).toBe("opto_def")
     expect(result.personId).toBe("pers_ghi")
     expect(result.organizationId).toBe("org_jkl")
+  })
+})
+
+describe("Booking aggregates query schema", () => {
+  it("accepts an empty object", () => {
+    const result = bookingAggregatesQuerySchema.parse({})
+    expect(result.from).toBeUndefined()
+    expect(result.to).toBeUndefined()
+  })
+
+  it("accepts ISO datetime bounds", () => {
+    const result = bookingAggregatesQuerySchema.parse({
+      from: "2026-01-01T00:00:00.000Z",
+      to: "2026-04-01T00:00:00.000Z",
+    })
+    expect(result.from).toBe("2026-01-01T00:00:00.000Z")
+    expect(result.to).toBe("2026-04-01T00:00:00.000Z")
+  })
+
+  it("rejects non-datetime strings", () => {
+    expect(() => bookingAggregatesQuerySchema.parse({ from: "yesterday" })).toThrow()
+    expect(() => bookingAggregatesQuerySchema.parse({ from: "2026-01-01" })).toThrow()
   })
 })


### PR DESCRIPTION
## Summary
First slice of #217. Replaces the "fetch a large list page and derive KPIs client-side" pattern — which was fragile (pagination caps made totals incomplete once datasets grew) and forced every app to invent its own definition of which statuses count — with a first-class aggregate read.

`bookingsService.getBookingAggregates(db, { from?, to? })` returns:

- `total` — bookings in range across all statuses
- `countsByStatus[]` — one row per status, including zero counts for unused statuses (stable shape for dashboard cards)
- `monthlyCounts[]` — `yearMonth` (UTC `YYYY-MM`) + count
- `monthlyRevenue[]` — `yearMonth` + `currency` + `sellAmountCents`, active statuses only, grouped by currency
- `upcomingDepartures` — active bookings with `startDate >= today`

**Active statuses counted**: `draft`, `on_hold`, `confirmed`, `in_progress`, `completed`. `cancelled` + `expired` drop out of revenue and upcomingDepartures — matches the slot-unit-availability rules from #235.

Route: `GET /v1/admin/bookings/aggregates` (sits before `/:id` in the Hono router so the param matcher doesn't hijack it).

Related to #217. Finance / products / suppliers / availability should follow the same shape as follow-up PRs; the issue asks for dashboard aggregates across several modules.

## Test plan
- [x] `pnpm -F @voyantjs/bookings typecheck`
- [x] `pnpm -F @voyantjs/bookings test` — 108 passing; new unit test covers the query schema, new integration test seeds a future-confirmed + past-cancelled booking and verifies revenue counts only the confirmed one and `upcomingDepartures` picks up the future one.
- [x] `pnpm typecheck` — 136/136 tasks.
- [ ] Smoke on an operator DB with a real dataset: confirm monthly series align with the list view and currencies split cleanly.