### PR TITLE
feat(bookings): pricing-preview admin endpoint + react hook

### DIFF
--- a/packages/bookings-react/src/hooks/index.ts
+++ b/packages/bookings-react/src/hooks/index.ts
@@ -61,6 +61,7 @@ export {
   useBookingStatusMutation,
 } from "./use-booking-status-mutation.js"
 export { type UseBookingsOptions, useBookings } from "./use-bookings.js"
+export { type UsePricingPreviewOptions, usePricingPreview } from "./use-pricing-preview.js"
 export {
   type UsePublicBookingSessionOptions,
   usePublicBookingSession,

--- a/packages/bookings-react/src/hooks/use-pricing-preview.ts
+++ b/packages/bookings-react/src/hooks/use-pricing-preview.ts
@@ -1,0 +1,26 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+
+import { useVoyantBookingsContext } from "../provider.js"
+import type { PricingPreviewFilters } from "../query-keys.js"
+import { getPricingPreviewQueryOptions } from "../query-options.js"
+
+export interface UsePricingPreviewOptions extends PricingPreviewFilters {
+  enabled?: boolean
+}
+
+/**
+ * Catalog-resolved pricing snapshot for a product + option (+ optional
+ * catalog). Consumers match the returned `unitPrices` / `tiers` against their
+ * passenger/unit selection to render a breakdown. The snapshot is the same
+ * data the storefront session uses, so operator-side numbers stay in sync
+ * with customer-facing ones.
+ */
+export function usePricingPreview({ enabled = true, ...filters }: UsePricingPreviewOptions) {
+  const client = useVoyantBookingsContext()
+  return useQuery({
+    ...getPricingPreviewQueryOptions(client, filters),
+    enabled: enabled && Boolean(filters.productId),
+  })
+}

--- a/packages/bookings-react/src/index.ts
+++ b/packages/bookings-react/src/index.ts
@@ -23,6 +23,7 @@ export {
   getBookingQueryOptions,
   getBookingsQueryOptions,
   getBookingTravelerDocumentsQueryOptions,
+  getPricingPreviewQueryOptions,
   getPublicBookingSessionQueryOptions,
   getPublicBookingSessionStateQueryOptions,
   getSupplierStatusesQueryOptions,

--- a/packages/bookings-react/src/query-keys.ts
+++ b/packages/bookings-react/src/query-keys.ts
@@ -13,6 +13,12 @@ export interface BookingGroupsListFilters {
   offset?: number | undefined
 }
 
+export interface PricingPreviewFilters {
+  productId: string
+  optionId?: string | null | undefined
+  catalogId?: string | null | undefined
+}
+
 export const bookingsQueryKeys = {
   all: ["voyant", "bookings"] as const,
 
@@ -47,4 +53,7 @@ export const bookingsQueryKeys = {
   groupMembers: (id: string) => [...bookingsQueryKeys.group(id), "members"] as const,
   groupForBooking: (bookingId: string) =>
     [...bookingsQueryKeys.booking(bookingId), "group"] as const,
+
+  pricingPreview: (filters: PricingPreviewFilters) =>
+    [...bookingsQueryKeys.all, "pricing-preview", filters] as const,
 } as const

--- a/packages/bookings-react/src/query-options.ts
+++ b/packages/bookings-react/src/query-options.ts
@@ -15,7 +15,7 @@ import type { UseBookingNotesOptions } from "./hooks/use-booking-notes.js"
 import type { UseBookingsOptions } from "./hooks/use-bookings.js"
 import type { UseSupplierStatusesOptions } from "./hooks/use-supplier-statuses.js"
 import type { UseTravelersOptions } from "./hooks/use-travelers.js"
-import { bookingsQueryKeys } from "./query-keys.js"
+import { bookingsQueryKeys, type PricingPreviewFilters } from "./query-keys.js"
 import {
   bookingActivityResponse,
   bookingGroupDetailResponse,
@@ -29,6 +29,7 @@ import {
   bookingSupplierStatusesResponse,
   bookingTravelerDocumentsResponse,
   bookingTravelersResponse,
+  pricingPreviewResponse,
   publicBookingSessionResponse,
   publicBookingSessionStateResponse,
 } from "./schemas.js"
@@ -263,5 +264,29 @@ export function getBookingGroupForBookingQueryOptions(
         bookingGroupForBookingResponse,
         client,
       ),
+  })
+}
+
+/**
+ * Pricing preview — resolves the storefront pricing snapshot for a product
+ * without creating a booking session. Use it for operator create dialogs,
+ * tour-sheet quotes, and reconciliation where the question is "what would the
+ * customer see?"
+ */
+export function getPricingPreviewQueryOptions(
+  client: FetchWithValidationOptions,
+  filters: PricingPreviewFilters,
+) {
+  return queryOptions({
+    queryKey: bookingsQueryKeys.pricingPreview(filters),
+    queryFn: () =>
+      fetchWithValidation("/v1/bookings/pricing-preview", pricingPreviewResponse, client, {
+        method: "POST",
+        body: JSON.stringify({
+          productId: filters.productId,
+          optionId: filters.optionId ?? null,
+          catalogId: filters.catalogId ?? null,
+        }),
+      }),
   })
 }

--- a/packages/bookings-react/src/schemas.ts
+++ b/packages/bookings-react/src/schemas.ts
@@ -276,3 +276,49 @@ export const publicBookingSessionStateResponse = singleEnvelope(publicBookingSes
 export const publicBookingSessionRepriceResponse = singleEnvelope(
   publicBookingSessionRepriceResultSchema,
 )
+
+// Pricing preview — the catalog-resolved snapshot the storefront engine uses
+// to compute totals. Consumers match it against their passenger/unit selection
+// to render a breakdown; see @voyantjs/bookings/validation for the request.
+const pricingPreviewCatalogSchema = z.object({
+  id: z.string(),
+  currencyCode: z.string(),
+})
+const pricingPreviewOptionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  isDefault: z.boolean(),
+})
+const pricingPreviewRuleSchema = z.object({
+  id: z.string(),
+  optionId: z.string(),
+  pricingMode: z.string(),
+  baseSellAmountCents: z.number().int().nullable(),
+  isDefault: z.boolean(),
+})
+const pricingPreviewUnitTierSchema = z.object({
+  minQuantity: z.number().int(),
+  maxQuantity: z.number().int().nullable(),
+  sellAmountCents: z.number().int().nullable(),
+})
+const pricingPreviewUnitPriceSchema = z.object({
+  id: z.string(),
+  optionPriceRuleId: z.string(),
+  unitId: z.string(),
+  unitName: z.string(),
+  unitType: z.string(),
+  pricingCategoryId: z.string().nullable(),
+  pricingMode: z.string(),
+  sellAmountCents: z.number().int().nullable(),
+  minQuantity: z.number().int().nullable(),
+  maxQuantity: z.number().int().nullable(),
+  tiers: z.array(pricingPreviewUnitTierSchema),
+})
+export const pricingPreviewSnapshotSchema = z.object({
+  catalog: pricingPreviewCatalogSchema,
+  options: z.array(pricingPreviewOptionSchema),
+  rules: z.array(pricingPreviewRuleSchema),
+  unitPrices: z.array(pricingPreviewUnitPriceSchema),
+})
+export type PricingPreviewSnapshot = z.infer<typeof pricingPreviewSnapshotSchema>
+export const pricingPreviewResponse = singleEnvelope(pricingPreviewSnapshotSchema)

--- a/packages/bookings/src/index.ts
+++ b/packages/bookings/src/index.ts
@@ -145,7 +145,7 @@ export {
   bookings,
   bookingTravelers,
 } from "./schema.js"
-export { publicBookingsService } from "./service-public.js"
+export { publicBookingsService, resolveSessionPricingSnapshot } from "./service-public.js"
 export {
   addBookingGroupMemberSchema,
   bookingGroupKindSchema,
@@ -171,6 +171,7 @@ export {
   insertSupplierStatusSchema,
   insertTravelerSchema,
   internalBookingOverviewLookupQuerySchema,
+  pricingPreviewSchema,
   publicBookingOverviewLookupQuerySchema,
   publicBookingSessionMutationSchema,
   publicBookingSessionRepriceItemSchema,

--- a/packages/bookings/src/routes.ts
+++ b/packages/bookings/src/routes.ts
@@ -21,7 +21,7 @@ import type { Env } from "./routes-shared.js"
 import { bookingPiiAccessLog } from "./schema.js"
 import { bookingsService } from "./service.js"
 import { bookingGroupsService } from "./service-groups.js"
-import { publicBookingsService } from "./service-public.js"
+import { publicBookingsService, resolveSessionPricingSnapshot } from "./service-public.js"
 import {
   bookingListQuerySchema,
   cancelBookingSchema,
@@ -39,6 +39,7 @@ import {
   insertSupplierStatusSchema,
   insertTravelerSchema,
   internalBookingOverviewLookupQuerySchema,
+  pricingPreviewSchema,
   recordBookingRedemptionSchema,
   reserveBookingFromTransactionSchema,
   reserveBookingSchema,
@@ -224,7 +225,20 @@ export const bookingRoutes = new Hono<Env>()
     return c.json(await bookingsService.listBookings(c.get("db"), query))
   })
 
-  // 1a. GET /overview — Internal/admin booking overview lookup
+  // 1a. POST /pricing-preview — Resolve a pricing snapshot without creating a session.
+  .post("/pricing-preview", async (c) => {
+    const body = await parseJsonBody(c, pricingPreviewSchema)
+    const snapshot = await resolveSessionPricingSnapshot(c.get("db"), body.productId, {
+      optionId: body.optionId ?? undefined,
+      catalogId: body.catalogId ?? undefined,
+    })
+    if (!snapshot) {
+      return c.json({ error: "Pricing unavailable for this selection" }, 404)
+    }
+    return c.json({ data: snapshot })
+  })
+
+  // 1b. GET /overview — Internal/admin booking overview lookup
   .get("/overview", async (c) => {
     const overview = await publicBookingsService.getOverviewByLookup(
       c.get("db"),

--- a/packages/bookings/src/service-public.ts
+++ b/packages/bookings/src/service-public.ts
@@ -504,7 +504,19 @@ function buildUnitWarnings(
   return warnings
 }
 
-async function resolveSessionPricingSnapshot(
+/**
+ * Resolves the catalog-scoped pricing snapshot for a product (options → option
+ * price rules → per-unit price rules → tiers). The snapshot is the same data
+ * the storefront booking session uses to compute a total — exposing it as a
+ * standalone admin preview lets operator dialogs, tour-sheet exports, and
+ * reconciliation flows see the same numbers the customer would see, without
+ * creating a throwaway session.
+ *
+ * Returns `null` when the product isn't publicly visible or there's no active
+ * catalog / matching option (caller can decide whether to 404 or surface a
+ * "pricing unavailable for this selection" message).
+ */
+export async function resolveSessionPricingSnapshot(
   db: PostgresJsDatabase,
   productId: string,
   input: { catalogId?: string | undefined; optionId?: string | undefined },

--- a/packages/bookings/src/validation.ts
+++ b/packages/bookings/src/validation.ts
@@ -89,6 +89,17 @@ export const convertProductSchema = z.object({
   internalNotes: z.string().optional().nullable(),
 })
 
+/**
+ * Admin pricing-preview request. Mirrors the storefront pricing session
+ * resolver input so the operator dialog sees the same numbers the customer
+ * would see for the same product + option + catalog.
+ */
+export const pricingPreviewSchema = z.object({
+  productId: z.string().min(1),
+  optionId: z.string().optional().nullable(),
+  catalogId: z.string().optional().nullable(),
+})
+
 export const updateBookingStatusSchema = z.object({
   status: bookingStatusSchema,
   note: z.string().optional().nullable(),

--- a/packages/bookings/tests/unit/validation-booking.test.ts
+++ b/packages/bookings/tests/unit/validation-booking.test.ts
@@ -4,6 +4,7 @@ import {
   convertProductSchema,
   createBookingSchema,
   insertBookingSchema,
+  pricingPreviewSchema,
   updateBookingSchema,
   updateBookingStatusSchema,
 } from "../../src/validation.js"
@@ -165,5 +166,29 @@ describe("Convert product schema", () => {
 
   it("rejects missing bookingNumber", () => {
     expect(() => convertProductSchema.parse({ productId: "prod_abc" })).toThrow()
+  })
+})
+
+describe("Pricing preview schema", () => {
+  it("requires a productId", () => {
+    expect(() => pricingPreviewSchema.parse({})).toThrow()
+    expect(() => pricingPreviewSchema.parse({ productId: "" })).toThrow()
+  })
+
+  it("accepts optional option + catalog ids", () => {
+    const result = pricingPreviewSchema.parse({
+      productId: "prod_abc",
+      optionId: "opt_def",
+      catalogId: "ctlg_ghi",
+    })
+    expect(result.productId).toBe("prod_abc")
+    expect(result.optionId).toBe("opt_def")
+    expect(result.catalogId).toBe("ctlg_ghi")
+  })
+
+  it("allows option + catalog to be omitted (catalog defaults to public)", () => {
+    const result = pricingPreviewSchema.parse({ productId: "prod_abc" })
+    expect(result.optionId).toBeUndefined()
+    expect(result.catalogId).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
Makes the storefront pricing engine's snapshot reachable without creating a throwaway booking session. Before this, operator admin, tour-sheet exports, and reconciliation flows had to either spin up a fake session and tear it down, or re-derive pricing app-side and drift from what the customer actually sees.

- Export `resolveSessionPricingSnapshot` from `@voyantjs/bookings`. The function is unchanged — it was already used internally by the storefront session; this PR promotes its visibility and adds a short docstring.
- New validation schema `pricingPreviewSchema` (`productId` + optional `optionId` / `catalogId`). Omitting the catalog selects the default public one.
- New admin route `POST /v1/admin/bookings/pricing-preview` returning `{ data: snapshot }` with the same shape the storefront engine consumes (`catalog`, `options`, `rules`, `unitPrices` with `tiers`). Returns 404 with "Pricing unavailable for this selection" when the resolver returns null.
- `bookings-react` hook `usePricingPreview({ productId, optionId?, catalogId? })` + `getPricingPreviewQueryOptions` + query key + `PricingPreviewSnapshot` zod type. Same shape as the rest of the package.

Out of scope (per the issue): voucher math, commission/margin, a `lines`/`totalAmountCents` compute shape. Those are downstream derivations consumers can build on top of the snapshot.

Closes #226. Unblocks #223's price-breakdown slice.

## Test plan
- [x] `pnpm -F @voyantjs/bookings -F @voyantjs/bookings-react typecheck`
- [x] `pnpm -F @voyantjs/bookings test` — 108 passing; new unit tests cover the pricing-preview query schema.
- [x] `pnpm typecheck` — 136/136 tasks.
- [ ] Smoke: `POST /v1/admin/bookings/pricing-preview { productId: "prod_…" }` against a DB with a public catalog returns the same snapshot shape the storefront session consumes.