### PR TITLE
feat(operator): collapse BookingDialog + QuickBookDialog into one entry

### DIFF
--- a/templates/operator/src/components/voyant/bookings/booking-dialog.tsx
+++ b/templates/operator/src/components/voyant/bookings/booking-dialog.tsx
@@ -28,6 +28,8 @@ import { DateRangePicker } from "@/components/ui/date-picker"
 import { useAdminMessages } from "@/lib/admin-i18n"
 import { zodResolver } from "@/lib/zod-resolver"
 
+import { QuickBookDialog } from "./quick-book-dialog"
+
 type BookingDialogMessages = ReturnType<typeof useAdminMessages>["bookings"]["dialog"]
 
 const buildBookingFormSchema = (messages: BookingDialogMessages) =>
@@ -52,20 +54,64 @@ export interface BookingDialogProps {
   onOpenChange: (open: boolean) => void
   booking?: BookingRecord
   onSuccess?: (booking: BookingRecord) => void
+  /**
+   * Pre-seeds the product picker in create mode. Useful when opened from a
+   * product detail page. Ignored when editing an existing booking.
+   */
+  defaultProductId?: string
 }
 
-function generateBookingNumber(): string {
-  const now = new Date()
-  const y = now.getFullYear().toString().slice(-2)
-  const m = String(now.getMonth() + 1).padStart(2, "0")
-  const seq = String(Math.floor(Math.random() * 9000) + 1000)
-  return `BK-${y}${m}-${seq}`
+/**
+ * Single booking dialog that handles both create and edit:
+ * - Create (no `booking` prop): renders the rich product → option → person
+ *   picker flow via `QuickBookDialog`, so the draft booking inherits pricing,
+ *   dates, and currency from the catalogue instead of being hand-entered.
+ * - Edit (with `booking` prop): renders the flat form that patches the
+ *   existing row's metadata (status, amounts, dates, notes).
+ *
+ * The two modes used to live in separate `BookingDialog` and
+ * `QuickBookDialog` CTAs. Once a real catalogue was loaded, the flat create
+ * form orphaned bookings from the catalog and always lost to Quick Book —
+ * #222 collapses them so the template ships a single create entry point.
+ */
+export function BookingDialog({
+  open,
+  onOpenChange,
+  booking,
+  onSuccess,
+  defaultProductId,
+}: BookingDialogProps) {
+  if (!booking) {
+    return (
+      <QuickBookDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        defaultProductId={defaultProductId}
+        onCreated={onSuccess}
+      />
+    )
+  }
+
+  return (
+    <BookingEditDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      booking={booking}
+      onSuccess={onSuccess}
+    />
+  )
 }
 
-export function BookingDialog({ open, onOpenChange, booking, onSuccess }: BookingDialogProps) {
+interface BookingEditDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  booking: BookingRecord
+  onSuccess?: (booking: BookingRecord) => void
+}
+
+function BookingEditDialog({ open, onOpenChange, booking, onSuccess }: BookingEditDialogProps) {
   const dialogMessages = useAdminMessages().bookings.dialog
-  const isEditing = Boolean(booking)
-  const { create, update } = useBookingMutation()
+  const { update } = useBookingMutation()
   const bookingFormSchema = buildBookingFormSchema(dialogMessages)
   const bookingStatuses = [
     { value: "draft", label: dialogMessages.statusDraft },
@@ -91,32 +137,19 @@ export function BookingDialog({ open, onOpenChange, booking, onSuccess }: Bookin
   })
 
   useEffect(() => {
-    if (open && booking) {
-      form.reset({
-        bookingNumber: booking.bookingNumber,
-        status:
-          booking.status === "on_hold" || booking.status === "expired" ? "draft" : booking.status,
-        sellCurrency: booking.sellCurrency,
-        sellAmountCents: booking.sellAmountCents ?? "",
-        costAmountCents: booking.costAmountCents ?? "",
-        startDate: booking.startDate ?? "",
-        endDate: booking.endDate ?? "",
-        pax: booking.pax ?? "",
-        internalNotes: booking.internalNotes ?? "",
-      })
-    } else if (open) {
-      form.reset({
-        bookingNumber: generateBookingNumber(),
-        status: "draft",
-        sellCurrency: "EUR",
-        sellAmountCents: "",
-        costAmountCents: "",
-        startDate: "",
-        endDate: "",
-        pax: "",
-        internalNotes: "",
-      })
-    }
+    if (!open) return
+    form.reset({
+      bookingNumber: booking.bookingNumber,
+      status:
+        booking.status === "on_hold" || booking.status === "expired" ? "draft" : booking.status,
+      sellCurrency: booking.sellCurrency,
+      sellAmountCents: booking.sellAmountCents ?? "",
+      costAmountCents: booking.costAmountCents ?? "",
+      startDate: booking.startDate ?? "",
+      endDate: booking.endDate ?? "",
+      pax: booking.pax ?? "",
+      internalNotes: booking.internalNotes ?? "",
+    })
   }, [booking, form, open])
 
   const onSubmit = async (values: BookingFormOutput) => {
@@ -138,23 +171,19 @@ export function BookingDialog({ open, onOpenChange, booking, onSuccess }: Bookin
       internalNotes: values.internalNotes || null,
     }
 
-    const saved = isEditing
-      ? await update.mutateAsync({ id: booking!.id, input: payload })
-      : await create.mutateAsync(payload)
+    const saved = await update.mutateAsync({ id: booking.id, input: payload })
 
     onOpenChange(false)
     onSuccess?.(saved)
   }
 
-  const isSubmitting = create.isPending || update.isPending
+  const isSubmitting = update.isPending
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent size="lg">
         <DialogHeader>
-          <DialogTitle>
-            {isEditing ? dialogMessages.editTitle : dialogMessages.newTitle}
-          </DialogTitle>
+          <DialogTitle>{dialogMessages.editTitle}</DialogTitle>
         </DialogHeader>
         <form
           onSubmit={form.handleSubmit(onSubmit)}
@@ -262,7 +291,7 @@ export function BookingDialog({ open, onOpenChange, booking, onSuccess }: Bookin
             </Button>
             <Button type="submit" size="sm" disabled={isSubmitting}>
               {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {isEditing ? dialogMessages.saveChanges : dialogMessages.create}
+              {dialogMessages.saveChanges}
             </Button>
           </DialogFooter>
         </form>

--- a/templates/operator/src/components/voyant/bookings/booking-list.tsx
+++ b/templates/operator/src/components/voyant/bookings/booking-list.tsx
@@ -6,7 +6,7 @@ import {
   useBookings,
 } from "@voyantjs/bookings-react"
 import { formatMessage } from "@voyantjs/voyant-admin"
-import { Plus, Search, Zap } from "lucide-react"
+import { Plus, Search } from "lucide-react"
 import * as React from "react"
 
 import { Badge } from "@/components/ui/badge"
@@ -24,7 +24,6 @@ import {
 import { useAdminMessages } from "@/lib/admin-i18n"
 
 import { BookingDialog } from "./booking-dialog"
-import { QuickBookDialog } from "./quick-book-dialog"
 
 export interface BookingListProps {
   pageSize?: number
@@ -61,7 +60,6 @@ export function BookingList({ pageSize = 25, onSelectBooking }: BookingListProps
   const [search, setSearch] = React.useState("")
   const [offset, setOffset] = React.useState(0)
   const [dialogOpen, setDialogOpen] = React.useState(false)
-  const [quickBookOpen, setQuickBookOpen] = React.useState(false)
   const [editing, setEditing] = React.useState<BookingRecord | undefined>(undefined)
 
   const { data, isPending, isError } = useBookings({
@@ -100,10 +98,6 @@ export function BookingList({ pageSize = 25, onSelectBooking }: BookingListProps
           />
         </div>
         <div className="flex items-center gap-2">
-          <Button variant="outline" onClick={() => setQuickBookOpen(true)}>
-            <Zap className="mr-2 size-4" />
-            {bookingMessages.quickBook}
-          </Button>
           <Button
             onClick={() => {
               setEditing(undefined)
@@ -212,14 +206,6 @@ export function BookingList({ pageSize = 25, onSelectBooking }: BookingListProps
         onOpenChange={setDialogOpen}
         booking={editing}
         onSuccess={(booking) => {
-          onSelectBooking?.(booking)
-        }}
-      />
-
-      <QuickBookDialog
-        open={quickBookOpen}
-        onOpenChange={setQuickBookOpen}
-        onCreated={(booking) => {
           onSelectBooking?.(booking)
         }}
       />

--- a/templates/operator/src/components/voyant/products/product-detail-page.tsx
+++ b/templates/operator/src/components/voyant/products/product-detail-page.tsx
@@ -5,7 +5,7 @@ import { useState } from "react"
 import { Button } from "@/components/ui"
 import { useAdminMessages } from "@/lib/admin-i18n"
 import { api } from "@/lib/api-client"
-import { QuickBookDialog } from "../bookings/quick-book-dialog"
+import { BookingDialog } from "../bookings/booking-dialog"
 import { DepartureDialog, type DepartureSlot } from "./product-departure-dialog"
 import { ProductDialog } from "./product-detail-dialog"
 import { ProductDetailHeader } from "./product-detail-header"
@@ -254,11 +254,11 @@ export function ProductDetailPage({ id }: { id: string }) {
       </div>
 
       {/* Dialogs */}
-      <QuickBookDialog
+      <BookingDialog
         open={quickBookOpen}
         onOpenChange={setQuickBookOpen}
         defaultProductId={id}
-        onCreated={(booking) => {
+        onSuccess={(booking) => {
           setQuickBookOpen(false)
           void navigate({ to: "/bookings/$id", params: { id: booking.id } })
         }}


### PR DESCRIPTION
## Summary
The operator toolbar shipped two creation paths side-by-side — "Quick Book" (product → option → person picker; converts a product via `useBookingConvertMutation`) and "+ New Booking" (flat 8-field form that doesn't pick a product and leaves the booking orphaned from the catalogue). Once a real catalogue is loaded, the flat create flow is strictly worse: no product resolution, no lead traveler, hand-entered dates and currency the product already knows.

`BookingDialog` now handles both modes:
- **Create** (no `booking` prop): delegates to `QuickBookDialog` for the rich picker flow. `defaultProductId` is forwarded so the product detail page still pre-seeds the picker.
- **Edit** (with `booking` prop): the existing flat form, extracted into `BookingEditDialog` — purely edit (no `isEditing` branching, no booking-number generator, no `create` mutation).

`booking-list.tsx`: loses the "Quick Book" CTA (and the `Zap` icon import). Single **"+ New booking"** button opens `BookingDialog` in create mode. Editing still triggers on row click.

`product-detail-page.tsx`: swaps its `QuickBookDialog` usage for `BookingDialog` with `defaultProductId={id}` — same UX, one dialog.

`QuickBookDialog` stays as an internal component (BookingDialog's create mode delegates to it) so follow-up work against it — e.g. the departure picker in #234 — still has a home. No public API removal.

Closes #222.

Out of scope per the issue: exporting the sub-sections (product/person/shared-room pickers) individually from the registry. That's a nice-to-have; this PR focuses on the template consolidation.

## Test plan
- [x] `pnpm -F operator typecheck`
- [x] `pnpm typecheck` — 136/136 tasks.
- [ ] Smoke in the operator UI: toolbar shows a single "+ New booking" button → clicking opens the product picker flow; clicking an existing row opens the flat edit form.
- [ ] Smoke on the product detail page: "+ New booking" (or equivalent) still pre-selects the product.