### PR TITLE
feat(notifications): POST /bookings/:id/confirm-and-dispatch

### DIFF
--- a/packages/notifications/src/routes.ts
+++ b/packages/notifications/src/routes.ts
@@ -8,6 +8,8 @@ import type { BookingDocumentAttachmentResolver } from "./service-booking-docume
 import type { NotificationProvider } from "./types.js"
 import {
   bookingDocumentBundleSchema,
+  confirmAndDispatchBookingResultSchema,
+  confirmAndDispatchBookingSchema,
   insertNotificationReminderRuleSchema,
   insertNotificationTemplateSchema,
   notificationDeliveryListQuerySchema,
@@ -211,6 +213,62 @@ export function createNotificationsRoutes(options?: NotificationsRoutesOptions) 
       )
       if (!bundle) return c.json({ error: "Booking not found" }, 404)
       return c.json({ data: bookingDocumentBundleSchema.parse(bundle) })
+    })
+    .post("/bookings/:id/confirm-and-dispatch", async (c) => {
+      try {
+        const runtime = getRuntime(c.env, options, (key) => c.var.container.resolve(key))
+        const dispatcher = createNotificationService(runtime.providers)
+        const result = await notificationsService.confirmAndDispatchBooking(
+          c.get("db"),
+          dispatcher,
+          c.req.param("id"),
+          await parseOptionalJsonBody(c, confirmAndDispatchBookingSchema),
+          {
+            attachmentResolver: runtime.documentAttachmentResolver,
+            eventBus: runtime.eventBus,
+          },
+        )
+        if (result.status === "not_found") return c.json({ error: "Booking not found" }, 404)
+        if (result.status === "preview") {
+          return c.json({
+            data: confirmAndDispatchBookingResultSchema.parse({
+              bookingId: result.bookingId,
+              documents: result.documents,
+              notification: null,
+              skipReason: "preview_only",
+            }),
+          })
+        }
+        if (result.status === "skipped") {
+          return c.json({
+            data: confirmAndDispatchBookingResultSchema.parse({
+              bookingId: result.bookingId,
+              documents: result.documents,
+              notification: null,
+              skipReason: result.skipReason,
+            }),
+          })
+        }
+        return c.json(
+          {
+            data: confirmAndDispatchBookingResultSchema.parse({
+              bookingId: result.bookingId,
+              documents: result.documents,
+              notification: {
+                recipient: result.recipient,
+                deliveryId: result.delivery.id,
+                provider: result.delivery.provider,
+                status: result.delivery.status,
+              },
+              skipReason: null,
+            }),
+          },
+          201,
+        )
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Confirm-and-dispatch failed"
+        return c.json({ error: message }, 400)
+      }
     })
     .post("/bookings/:id/send-documents", async (c) => {
       try {

--- a/packages/notifications/src/service-booking-documents.ts
+++ b/packages/notifications/src/service-booking-documents.ts
@@ -394,6 +394,68 @@ export const bookingDocumentNotificationsService = {
       delivery,
     }
   },
+
+  /**
+   * Confirm-and-dispatch — single orchestrated call for the operator flow
+   * that wants "list the booking's documents, then send them to the client"
+   * to be one action instead of two round-trips.
+   *
+   * With `sendNotification: false`, the caller gets the bundle back without
+   * attempting a send — useful for rendering a preview/checkbox list before
+   * the operator confirms. With `sendNotification: true`, the same send
+   * guards as `sendBookingDocumentsNotification` apply (no_documents,
+   * no_recipient, no_attachments, send_failed); the result keeps the bundle
+   * regardless so the UI always has something to show.
+   */
+  async confirmAndDispatchBooking(
+    db: PostgresJsDatabase,
+    dispatcher: NotificationService,
+    bookingId: string,
+    input: { sendNotification?: boolean } & SendBookingDocumentsNotificationInput,
+    runtime: SendBookingDocumentsRuntimeOptions = {},
+  ) {
+    const bundle = await this.listBookingDocumentBundle(db, bookingId)
+    if (!bundle) return { status: "not_found" as const }
+
+    const documents = bundle.documents
+    const sendNotification = input.sendNotification ?? true
+    if (!sendNotification) {
+      return {
+        status: "preview" as const,
+        bookingId,
+        documents,
+      }
+    }
+
+    const result = await this.sendBookingDocumentsNotification(
+      db,
+      dispatcher,
+      bookingId,
+      input,
+      runtime,
+    )
+
+    if (result.status === "not_found") {
+      return { status: "not_found" as const }
+    }
+
+    if (result.status !== "sent") {
+      return {
+        status: "skipped" as const,
+        bookingId,
+        documents,
+        skipReason: result.status,
+      }
+    }
+
+    return {
+      status: "dispatched" as const,
+      bookingId: result.bookingId,
+      documents: result.documents,
+      recipient: result.recipient,
+      delivery: result.delivery,
+    }
+  },
 }
 
 export { createDefaultAttachmentFromDocument as createDefaultBookingDocumentAttachment }

--- a/packages/notifications/src/service.ts
+++ b/packages/notifications/src/service.ts
@@ -57,5 +57,6 @@ export const notificationsService = {
   listBookingDocumentBundle: bookingDocumentNotificationsService.listBookingDocumentBundle,
   sendBookingDocumentsNotification:
     bookingDocumentNotificationsService.sendBookingDocumentsNotification,
+  confirmAndDispatchBooking: bookingDocumentNotificationsService.confirmAndDispatchBooking,
   createDefaultBookingDocumentAttachment,
 }

--- a/packages/notifications/src/validation.ts
+++ b/packages/notifications/src/validation.ts
@@ -331,3 +331,41 @@ export const sendBookingDocumentsNotificationResultSchema = z.object({
   provider: z.string().optional().nullable(),
   status: notificationDeliveryStatusSchema,
 })
+
+/**
+ * Confirm-and-dispatch — single orchestrated request that lists the booking's
+ * document bundle and (optionally) sends it to the client in one round-trip.
+ *
+ * `sendNotification: false` turns the call into a preview: the bundle comes
+ * back but no delivery is attempted. Templates use the preview to render the
+ * "here's what's ready" checkbox list before the operator confirms.
+ */
+export const confirmAndDispatchBookingSchema = sendBookingDocumentsNotificationSchema.extend({
+  sendNotification: z.boolean().default(true),
+})
+
+export const confirmAndDispatchBookingResultSchema = z.object({
+  bookingId: z.string().min(1),
+  documents: z.array(bookingDocumentBundleItemSchema),
+  /**
+   * Non-null when `sendNotification` was true and a delivery actually went
+   * out. Null when either the operator asked for a preview only, or the send
+   * couldn't proceed (no recipient / no attachments / no matching documents).
+   */
+  notification: z
+    .object({
+      recipient: z.string().min(1),
+      deliveryId: z.string().min(1),
+      provider: z.string().optional().nullable(),
+      status: notificationDeliveryStatusSchema,
+    })
+    .nullable(),
+  /**
+   * When `sendNotification` was true but the dispatcher declined to send,
+   * this captures which guard tripped so the UI can explain it — e.g.
+   * "No recipient on file, add an email to the lead traveler and retry".
+   */
+  skipReason: z
+    .enum(["preview_only", "no_documents", "no_recipient", "no_attachments", "send_failed"])
+    .nullable(),
+})

--- a/packages/notifications/tests/unit/confirm-and-dispatch.test.ts
+++ b/packages/notifications/tests/unit/confirm-and-dispatch.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  confirmAndDispatchBookingResultSchema,
+  confirmAndDispatchBookingSchema,
+} from "../../src/validation.js"
+
+describe("confirmAndDispatchBookingSchema", () => {
+  it("defaults sendNotification to true so the happy path is one-shot", () => {
+    const result = confirmAndDispatchBookingSchema.parse({})
+    expect(result.sendNotification).toBe(true)
+  })
+
+  it("accepts preview-only mode", () => {
+    const result = confirmAndDispatchBookingSchema.parse({ sendNotification: false })
+    expect(result.sendNotification).toBe(false)
+  })
+
+  it("forwards the underlying send-documents fields", () => {
+    const result = confirmAndDispatchBookingSchema.parse({
+      templateSlug: "booking-confirmation",
+      documentTypes: ["invoice", "contract"],
+      subject: "Your booking is confirmed",
+      to: "traveler@example.com",
+    })
+    expect(result.templateSlug).toBe("booking-confirmation")
+    expect(result.documentTypes).toEqual(["invoice", "contract"])
+    expect(result.subject).toBe("Your booking is confirmed")
+  })
+})
+
+describe("confirmAndDispatchBookingResultSchema", () => {
+  const documents = [
+    {
+      key: "inv_abc::pdf",
+      source: "finance" as const,
+      documentType: "invoice" as const,
+      bookingId: "book_abc",
+      invoiceId: "inv_abc",
+      renditionId: "invr_abc",
+      name: "invoice.pdf",
+      createdAt: "2026-04-23T10:00:00.000Z",
+    },
+  ]
+
+  it("parses a dispatched result", () => {
+    const result = confirmAndDispatchBookingResultSchema.parse({
+      bookingId: "book_abc",
+      documents,
+      notification: {
+        recipient: "traveler@example.com",
+        deliveryId: "ntdl_abc",
+        provider: "resend",
+        status: "sent",
+      },
+      skipReason: null,
+    })
+    expect(result.notification?.deliveryId).toBe("ntdl_abc")
+    expect(result.skipReason).toBeNull()
+  })
+
+  it("parses a preview result (no notification, preview_only reason)", () => {
+    const result = confirmAndDispatchBookingResultSchema.parse({
+      bookingId: "book_abc",
+      documents,
+      notification: null,
+      skipReason: "preview_only",
+    })
+    expect(result.notification).toBeNull()
+    expect(result.skipReason).toBe("preview_only")
+  })
+
+  it("parses skip reasons surfaced from the send pipeline", () => {
+    for (const reason of ["no_documents", "no_recipient", "no_attachments", "send_failed"]) {
+      const result = confirmAndDispatchBookingResultSchema.parse({
+        bookingId: "book_abc",
+        documents,
+        notification: null,
+        skipReason: reason,
+      })
+      expect(result.skipReason).toBe(reason)
+    }
+  })
+
+  it("rejects unknown skip reasons", () => {
+    expect(() =>
+      confirmAndDispatchBookingResultSchema.parse({
+        bookingId: "book_abc",
+        documents,
+        notification: null,
+        skipReason: "bogus",
+      }),
+    ).toThrow()
+  })
+})


### PR DESCRIPTION
## Summary
First slice of #228. One orchestrated request for the operator flow that wants "list the booking's documents, then send them to the client" to be a single action instead of two round-trips.

Operators today stack `list-bundle` + `send-documents` to wire the "send confirmation" checkbox on the booking detail page. That leaves the UI fielding partial-failure states across two requests and every app reinventing the same stitching. This endpoint consolidates both paths:

- **Preview** (`sendNotification: false`): returns the bundle. UI renders a pre-checked list of what will be sent before the operator confirms.
- **Dispatch** (`sendNotification: true`, default): returns the bundle plus either the delivery details or a `skipReason` (`no_documents` / `no_recipient` / `no_attachments` / `send_failed`) when dispatch couldn't happen — UI can say "No recipient on file, add one and retry" instead of silently swallowing the send.

Either way the bundle comes back, so the UI always has something to show.

### Wiring
- `confirmAndDispatchBookingSchema` extends `sendBookingDocumentsNotificationSchema` with `sendNotification: z.boolean().default(true)`.
- `confirmAndDispatchBookingResultSchema` — one envelope, one set of parse errors, no per-status branching at the call site.
- `bookingDocumentNotificationsService.confirmAndDispatchBooking` wraps `listBookingDocumentBundle` + `sendBookingDocumentsNotification`. 404 on unknown booking, otherwise preview / skipped (with reason) / dispatched.
- Route uses the existing runtime factory so providers + attachmentResolver + eventBus flow through unchanged.

Closes part of #228.

### Out of scope — follow-ups for the rest of #228
- **Ensure-invoice-rendition** before sending. Needs the finance document runtime (`InvoiceDocumentGenerator`, pdf/storage wiring) which is template-owned. Once the template wires that into the notifications runtime, this endpoint can opportunistically generate a missing rendition with no client-side change.
- **Auto-run on booking status transition `draft → confirmed`**. Depends on `bookings.databaseHooks` or a drizzle transaction callback; orthogonal to the endpoint.
- **Template config** (`voyant.config.ts bookingConfirmation`) + UI — separate PR against the operator template.

## Test plan
- [x] `pnpm -F @voyantjs/notifications typecheck`
- [x] `pnpm -F @voyantjs/notifications test` — 52 passing, 7 new around the schema and envelope: `sendNotification` defaults to `true`, preview mode, every skip reason round-trips, unknown reasons are rejected.
- [x] `pnpm typecheck` — 136/136 tasks clean.
- [ ] Smoke on a template: `POST /v1/notifications/bookings/:id/confirm-and-dispatch { sendNotification: false }` returns the bundle; `{ sendNotification: true }` sends when a recipient + attachments exist, otherwise 200 with a skipReason.