### PR TITLE
feat(bookings-ui): export picker sub-sections from the registry

### DIFF
--- a/packages/ui/registry.json
+++ b/packages/ui/registry.json
@@ -755,17 +755,65 @@
       ]
     },
     {
+      "name": "voyant-bookings-product-picker-section",
+      "type": "registry:component",
+      "title": "Booking Product Picker Section",
+      "description": "Controlled product + option picker for booking-create flows. Cascades option list from the selected product; accepts a pre-locked productId for product-page entry points.",
+      "dependencies": ["@voyantjs/products-react"],
+      "registryDependencies": ["input", "label", "select"],
+      "files": [
+        {
+          "path": "registry/bookings/product-picker-section.tsx",
+          "type": "registry:component",
+          "target": "components/voyant/bookings/product-picker-section.tsx"
+        }
+      ]
+    },
+    {
+      "name": "voyant-bookings-person-picker-section",
+      "type": "registry:component",
+      "title": "Booking Person Picker Section",
+      "description": "Controlled person picker with inline-create and optional organization attachment. Parent owns the create-person mutation so the dialog can defer it to submit time.",
+      "dependencies": ["@voyantjs/crm-react", "lucide-react"],
+      "registryDependencies": ["button", "input", "label", "select"],
+      "files": [
+        {
+          "path": "registry/bookings/person-picker-section.tsx",
+          "type": "registry:component",
+          "target": "components/voyant/bookings/person-picker-section.tsx"
+        }
+      ]
+    },
+    {
+      "name": "voyant-bookings-shared-room-section",
+      "type": "registry:component",
+      "title": "Booking Shared-Room Section",
+      "description": "Partaj (shared-room) section for booking create: toggle + create/join mode + group selector. Parent owns the booking_groups mutations (they fire after booking insert).",
+      "dependencies": ["@voyantjs/bookings-react"],
+      "registryDependencies": ["button", "label", "select"],
+      "files": [
+        {
+          "path": "registry/bookings/shared-room-section.tsx",
+          "type": "registry:component",
+          "target": "components/voyant/bookings/shared-room-section.tsx"
+        }
+      ]
+    },
+    {
       "name": "voyant-bookings-quick-book-dialog",
       "type": "registry:component",
       "title": "Quick Book Dialog",
-      "description": "Operator quick-book workflow: pick a product, select or create a person, and create a draft booking via the convert-from-product endpoint.",
-      "dependencies": [
-        "@voyantjs/bookings-react",
-        "@voyantjs/crm-react",
-        "@voyantjs/products-react",
-        "lucide-react"
+      "description": "Operator quick-book workflow: pick a product, select or create a person, and create a draft booking via the convert-from-product endpoint. Composes the standalone picker sections so apps that need a custom flow can swap individual steps.",
+      "dependencies": ["@voyantjs/bookings-react", "@voyantjs/crm-react", "lucide-react"],
+      "registryDependencies": [
+        "button",
+        "dialog",
+        "label",
+        "textarea",
+        "voyant-bookings-product-picker-section",
+        "voyant-bookings-person-picker-section",
+        "voyant-bookings-shared-room-section"
       ],
-      "registryDependencies": ["button", "dialog", "input", "label", "select", "textarea"],
       "files": [
         {
           "path": "registry/bookings/quick-book-dialog.tsx",

--- a/packages/ui/registry/bookings/person-picker-section.tsx
+++ b/packages/ui/registry/bookings/person-picker-section.tsx
@@ -1,0 +1,267 @@
+"use client"
+
+import { useOrganizations, usePeople } from "@voyantjs/crm-react"
+import { UserPlus } from "lucide-react"
+import * as React from "react"
+
+import {
+  Button,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui"
+
+const ORG_NONE = "__none__"
+
+export type PersonPickerMode = "existing" | "new"
+
+export interface NewPersonValue {
+  firstName: string
+  lastName: string
+  email: string
+  phone: string
+}
+
+export interface PersonPickerValue {
+  mode: PersonPickerMode
+  /** Set when mode === "existing". */
+  personId: string
+  /** Used when mode === "new". */
+  newPerson: NewPersonValue
+  /** `null` = no organization attached. */
+  organizationId: string | null
+}
+
+export const emptyNewPerson: NewPersonValue = {
+  firstName: "",
+  lastName: "",
+  email: "",
+  phone: "",
+}
+
+export const emptyPersonPickerValue: PersonPickerValue = {
+  mode: "existing",
+  personId: "",
+  newPerson: emptyNewPerson,
+  organizationId: null,
+}
+
+export interface PersonPickerSectionProps {
+  value: PersonPickerValue
+  onChange: (value: PersonPickerValue) => void
+  enabled?: boolean
+  showOrganization?: boolean
+  labels?: {
+    person?: string
+    createNewPerson?: string
+    selectExistingPerson?: string
+    personSearchPlaceholder?: string
+    personSelectPlaceholder?: string
+    firstName?: string
+    firstNamePlaceholder?: string
+    lastName?: string
+    lastNamePlaceholder?: string
+    email?: string
+    emailPlaceholder?: string
+    phone?: string
+    phonePlaceholder?: string
+    organization?: string
+    organizationSearchPlaceholder?: string
+    organizationNone?: string
+  }
+}
+
+const DEFAULT_LABELS = {
+  person: "Person",
+  createNewPerson: "Create new",
+  selectExistingPerson: "Select existing",
+  personSearchPlaceholder: "Search people by name or email...",
+  personSelectPlaceholder: "Select a person...",
+  firstName: "First Name",
+  firstNamePlaceholder: "John",
+  lastName: "Last Name",
+  lastNamePlaceholder: "Smith",
+  email: "Email",
+  emailPlaceholder: "john@example.com",
+  phone: "Phone",
+  phonePlaceholder: "+44 7911 123456",
+  organization: "Organization (optional)",
+  organizationSearchPlaceholder: "Search organizations...",
+  organizationNone: "No organization",
+} as const
+
+/**
+ * Person picker with inline-create + optional organization attachment.
+ *
+ * State is fully controlled — the caller owns both existing-person selection
+ * and the inline-create form. The section does *not* call any mutation itself;
+ * the parent decides when to commit a newly-created person (typically at
+ * submit time, so we don't leak orphan CRM records when the dialog is
+ * cancelled).
+ */
+export function PersonPickerSection({
+  value,
+  onChange,
+  enabled = true,
+  showOrganization = true,
+  labels,
+}: PersonPickerSectionProps) {
+  const [personSearch, setPersonSearch] = React.useState("")
+  const [orgSearch, setOrgSearch] = React.useState("")
+  const merged = { ...DEFAULT_LABELS, ...labels }
+
+  const { data: peopleData } = usePeople({
+    search: personSearch || undefined,
+    limit: 20,
+    enabled: enabled && value.mode === "existing",
+  })
+  const people = peopleData?.data ?? []
+
+  const { data: orgsData } = useOrganizations({
+    search: orgSearch || undefined,
+    limit: 20,
+    enabled: enabled && showOrganization,
+  })
+  const orgs = orgsData?.data ?? []
+
+  const setPerson = (patch: Partial<PersonPickerValue>) => onChange({ ...value, ...patch })
+
+  return (
+    <>
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <Label>
+            {merged.person} <span className="text-destructive">*</span>
+          </Label>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7"
+            onClick={() => setPerson({ mode: value.mode === "existing" ? "new" : "existing" })}
+          >
+            {value.mode === "existing" ? (
+              <>
+                <UserPlus className="mr-1 h-3.5 w-3.5" />
+                {merged.createNewPerson}
+              </>
+            ) : (
+              merged.selectExistingPerson
+            )}
+          </Button>
+        </div>
+
+        {value.mode === "existing" ? (
+          <>
+            <Input
+              placeholder={merged.personSearchPlaceholder}
+              value={personSearch}
+              onChange={(e) => setPersonSearch(e.target.value)}
+            />
+            <Select
+              items={people.map((p) => ({
+                label: `${p.firstName} ${p.lastName}${p.email ? ` · ${p.email}` : ""}`,
+                value: p.id,
+              }))}
+              value={value.personId}
+              onValueChange={(v) => setPerson({ personId: v ?? "" })}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder={merged.personSelectPlaceholder} />
+              </SelectTrigger>
+              <SelectContent>
+                {people.map((p) => (
+                  <SelectItem key={p.id} value={p.id}>
+                    {p.firstName} {p.lastName}
+                    {p.email ? ` · ${p.email}` : ""}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </>
+        ) : (
+          <div className="grid grid-cols-2 gap-2 rounded-md border p-3">
+            <div className="flex flex-col gap-1">
+              <Label className="text-xs">{merged.firstName}</Label>
+              <Input
+                value={value.newPerson.firstName}
+                onChange={(e) =>
+                  setPerson({ newPerson: { ...value.newPerson, firstName: e.target.value } })
+                }
+                placeholder={merged.firstNamePlaceholder}
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <Label className="text-xs">{merged.lastName}</Label>
+              <Input
+                value={value.newPerson.lastName}
+                onChange={(e) =>
+                  setPerson({ newPerson: { ...value.newPerson, lastName: e.target.value } })
+                }
+                placeholder={merged.lastNamePlaceholder}
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <Label className="text-xs">{merged.email}</Label>
+              <Input
+                type="email"
+                value={value.newPerson.email}
+                onChange={(e) =>
+                  setPerson({ newPerson: { ...value.newPerson, email: e.target.value } })
+                }
+                placeholder={merged.emailPlaceholder}
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <Label className="text-xs">{merged.phone}</Label>
+              <Input
+                value={value.newPerson.phone}
+                onChange={(e) =>
+                  setPerson({ newPerson: { ...value.newPerson, phone: e.target.value } })
+                }
+                placeholder={merged.phonePlaceholder}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {showOrganization && (
+        <div className="flex flex-col gap-2">
+          <Label>{merged.organization}</Label>
+          <Input
+            placeholder={merged.organizationSearchPlaceholder}
+            value={orgSearch}
+            onChange={(e) => setOrgSearch(e.target.value)}
+          />
+          <Select
+            items={[
+              { label: merged.organizationNone, value: ORG_NONE },
+              ...orgs.map((o) => ({ label: o.name, value: o.id })),
+            ]}
+            value={value.organizationId ?? ORG_NONE}
+            onValueChange={(v) =>
+              setPerson({ organizationId: v === ORG_NONE ? null : (v ?? null) })
+            }
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder={merged.organizationNone} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ORG_NONE}>{merged.organizationNone}</SelectItem>
+              {orgs.map((o) => (
+                <SelectItem key={o.id} value={o.id}>
+                  {o.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+    </>
+  )
+}

--- a/packages/ui/registry/bookings/product-picker-section.tsx
+++ b/packages/ui/registry/bookings/product-picker-section.tsx
@@ -1,0 +1,140 @@
+"use client"
+
+import { useProductOptions, useProducts } from "@voyantjs/products-react"
+import * as React from "react"
+
+import {
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui"
+
+const OPTION_NONE = "__none__"
+
+export interface ProductPickerValue {
+  productId: string
+  /** `null` means "no specific option" — the product has options but none was picked. */
+  optionId: string | null
+}
+
+export interface ProductPickerSectionProps {
+  value: ProductPickerValue
+  onChange: (value: ProductPickerValue) => void
+  /** When true, skip data fetches (dialog closed / parent gated). */
+  enabled?: boolean
+  /** When true, hide the product picker and fix the productId (e.g., launched from a product page). */
+  lockProduct?: boolean
+  labels?: {
+    product?: string
+    productSearchPlaceholder?: string
+    productSelectPlaceholder?: string
+    option?: string
+    optionNone?: string
+  }
+}
+
+const DEFAULT_LABELS = {
+  product: "Product",
+  productSearchPlaceholder: "Search products...",
+  productSelectPlaceholder: "Select a product...",
+  option: "Option",
+  optionNone: "No specific option",
+} as const
+
+/**
+ * Controlled product + option picker. Splits `value` + `onChange` so apps can
+ * replace the whole section (e.g., with a typeahead against a custom catalog)
+ * without reimplementing the cascade logic, or keep this one and swap labels.
+ */
+export function ProductPickerSection({
+  value,
+  onChange,
+  enabled = true,
+  lockProduct = false,
+  labels,
+}: ProductPickerSectionProps) {
+  const [productSearch, setProductSearch] = React.useState("")
+  const merged = { ...DEFAULT_LABELS, ...labels }
+
+  const { data: productsData } = useProducts({
+    search: productSearch || undefined,
+    limit: 20,
+    enabled: enabled && !lockProduct,
+  })
+  const products = productsData?.data ?? []
+
+  const { data: optionsData } = useProductOptions({
+    productId: value.productId || undefined,
+    limit: 50,
+    enabled: enabled && Boolean(value.productId),
+  })
+  const options = optionsData?.data ?? []
+
+  return (
+    <>
+      {!lockProduct && (
+        <div className="flex flex-col gap-2">
+          <Label>
+            {merged.product} <span className="text-destructive">*</span>
+          </Label>
+          <Input
+            placeholder={merged.productSearchPlaceholder}
+            value={productSearch}
+            onChange={(e) => setProductSearch(e.target.value)}
+          />
+          <Select
+            items={products.map((p) => ({ label: p.name, value: p.id }))}
+            value={value.productId}
+            onValueChange={(v) => onChange({ productId: v ?? "", optionId: null })}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder={merged.productSelectPlaceholder} />
+            </SelectTrigger>
+            <SelectContent>
+              {products.map((p) => (
+                <SelectItem key={p.id} value={p.id}>
+                  {p.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      {value.productId && options.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <Label>{merged.option}</Label>
+          <Select
+            items={[
+              { label: merged.optionNone, value: OPTION_NONE },
+              ...options.map((o) => ({ label: o.name, value: o.id })),
+            ]}
+            value={value.optionId ?? OPTION_NONE}
+            onValueChange={(v) =>
+              onChange({
+                productId: value.productId,
+                optionId: v === OPTION_NONE ? null : (v ?? null),
+              })
+            }
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={OPTION_NONE}>{merged.optionNone}</SelectItem>
+              {options.map((o) => (
+                <SelectItem key={o.id} value={o.id}>
+                  {o.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+    </>
+  )
+}

--- a/packages/ui/registry/bookings/quick-book-dialog.tsx
+++ b/packages/ui/registry/bookings/quick-book-dialog.tsx
@@ -5,11 +5,9 @@ import {
   useBookingConvertMutation,
   useBookingGroupMemberMutation,
   useBookingGroupMutation,
-  useBookingGroups,
 } from "@voyantjs/bookings-react"
-import { useOrganizations, usePeople, usePersonMutation } from "@voyantjs/crm-react"
-import { useProductOptions, useProducts } from "@voyantjs/products-react"
-import { Loader2, UserPlus } from "lucide-react"
+import { usePersonMutation } from "@voyantjs/crm-react"
+import { Loader2 } from "lucide-react"
 import * as React from "react"
 
 import {
@@ -20,15 +18,21 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  Input,
   Label,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
   Textarea,
 } from "@/components/ui"
+
+import {
+  emptyPersonPickerValue,
+  PersonPickerSection,
+  type PersonPickerValue,
+} from "./person-picker-section"
+import { ProductPickerSection, type ProductPickerValue } from "./product-picker-section"
+import {
+  emptySharedRoomValue,
+  SharedRoomSection,
+  type SharedRoomValue,
+} from "./shared-room-section"
 
 function generateBookingNumber(): string {
   const now = new Date()
@@ -38,158 +42,103 @@ function generateBookingNumber(): string {
   return `BK-${y}${m}-${seq}`
 }
 
-const NONE = "__none__"
-
 export interface QuickBookDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   onCreated?: (booking: BookingRecord) => void
 }
 
-type PersonMode = "existing" | "new"
-
+/**
+ * Default operator quick-book dialog. Composes three registry sections —
+ * product picker, person picker, shared-room — into the standard create flow
+ * (product → option → person + organization → shared-room → notes → create).
+ *
+ * Apps that need a custom flow can install the sections individually
+ * (`voyant-bookings-product-picker-section`, `…-person-picker-section`,
+ * `…-shared-room-section`) and assemble their own dialog, instead of forking
+ * this file.
+ */
 export function QuickBookDialog({ open, onOpenChange, onCreated }: QuickBookDialogProps) {
-  const [productId, setProductId] = React.useState("")
-  const [productSearch, setProductSearch] = React.useState("")
-  const [optionId, setOptionId] = React.useState<string>(NONE)
-  const [organizationId, setOrganizationId] = React.useState<string>(NONE)
-  const [orgSearch, setOrgSearch] = React.useState("")
-  const [notes, setNotes] = React.useState("")
-
-  const [personMode, setPersonMode] = React.useState<PersonMode>("existing")
-  const [personId, setPersonId] = React.useState("")
-  const [personSearch, setPersonSearch] = React.useState("")
-  const [newPerson, setNewPerson] = React.useState({
-    firstName: "",
-    lastName: "",
-    email: "",
-    phone: "",
+  const [product, setProduct] = React.useState<ProductPickerValue>({
+    productId: "",
+    optionId: null,
   })
-
+  const [person, setPerson] = React.useState<PersonPickerValue>(emptyPersonPickerValue)
+  const [sharedRoom, setSharedRoom] = React.useState<SharedRoomValue>(emptySharedRoomValue)
+  const [notes, setNotes] = React.useState("")
   const [error, setError] = React.useState<string | null>(null)
-
-  // Shared-room state
-  const [sharedRoomEnabled, setSharedRoomEnabled] = React.useState(false)
-  const [sharedRoomMode, setSharedRoomMode] = React.useState<"create" | "join">("create")
-  const [sharedRoomGroupId, setSharedRoomGroupId] = React.useState("")
 
   React.useEffect(() => {
     if (!open) {
-      setProductId("")
-      setProductSearch("")
-      setOptionId(NONE)
-      setOrganizationId(NONE)
-      setOrgSearch("")
+      setProduct({ productId: "", optionId: null })
+      setPerson(emptyPersonPickerValue)
+      setSharedRoom(emptySharedRoomValue)
       setNotes("")
-      setPersonMode("existing")
-      setPersonId("")
-      setPersonSearch("")
-      setNewPerson({ firstName: "", lastName: "", email: "", phone: "" })
-      setSharedRoomEnabled(false)
-      setSharedRoomMode("create")
-      setSharedRoomGroupId("")
       setError(null)
     }
   }, [open])
-
-  const { data: productsData } = useProducts({
-    search: productSearch || undefined,
-    limit: 20,
-    enabled: open,
-  })
-  const products = productsData?.data ?? []
-
-  const { data: optionsData } = useProductOptions({
-    productId: productId || undefined,
-    limit: 50,
-    enabled: open && Boolean(productId),
-  })
-  const options = optionsData?.data ?? []
-
-  const { data: peopleData } = usePeople({
-    search: personSearch || undefined,
-    limit: 20,
-    enabled: open && personMode === "existing",
-  })
-  const people = peopleData?.data ?? []
-
-  const { data: orgsData } = useOrganizations({
-    search: orgSearch || undefined,
-    limit: 20,
-    enabled: open,
-  })
-  const orgs = orgsData?.data ?? []
 
   const { create: createPerson } = usePersonMutation()
   const convertMutation = useBookingConvertMutation()
   const { create: createGroup } = useBookingGroupMutation()
   const { add: addGroupMember } = useBookingGroupMemberMutation()
 
-  // Only load groups when shared-room+join is selected and we have a product
-  const { data: groupsData } = useBookingGroups({
-    productId: productId || undefined,
-    limit: 50,
-    enabled: open && sharedRoomEnabled && sharedRoomMode === "join" && Boolean(productId),
-  })
-  const existingGroups = groupsData?.data ?? []
-
   const handleSubmit = async () => {
     setError(null)
 
-    if (!productId) {
+    if (!product.productId) {
       setError("Select a product")
       return
     }
 
     let resolvedPersonId: string | null = null
     try {
-      if (personMode === "existing") {
-        if (!personId) {
+      if (person.mode === "existing") {
+        if (!person.personId) {
           setError("Select a person or switch to create mode")
           return
         }
-        resolvedPersonId = personId
+        resolvedPersonId = person.personId
       } else {
-        if (!newPerson.firstName.trim() || !newPerson.lastName.trim()) {
+        if (!person.newPerson.firstName.trim() || !person.newPerson.lastName.trim()) {
           setError("First and last name are required")
           return
         }
-        const person = await createPerson.mutateAsync({
-          firstName: newPerson.firstName.trim(),
-          lastName: newPerson.lastName.trim(),
-          email: newPerson.email.trim() || null,
-          phone: newPerson.phone.trim() || null,
+        const created = await createPerson.mutateAsync({
+          firstName: person.newPerson.firstName.trim(),
+          lastName: person.newPerson.lastName.trim(),
+          email: person.newPerson.email.trim() || null,
+          phone: person.newPerson.phone.trim() || null,
         })
-        resolvedPersonId = person.id
+        resolvedPersonId = created.id
       }
 
       // Validate shared-room selection before creating the booking so we don't
-      // create an orphan booking if the user picked "join" without a group.
-      if (sharedRoomEnabled && sharedRoomMode === "join" && !sharedRoomGroupId) {
+      // leave an orphan booking if the user picked "join" without a group.
+      if (sharedRoom.enabled && sharedRoom.mode === "join" && !sharedRoom.groupId) {
         setError("Select a shared-room group to join")
         return
       }
 
       const booking = await convertMutation.mutateAsync({
-        productId,
+        productId: product.productId,
         bookingNumber: generateBookingNumber(),
-        optionId: optionId === NONE ? null : optionId,
+        optionId: product.optionId,
         personId: resolvedPersonId,
-        organizationId: organizationId === NONE ? null : organizationId,
+        organizationId: person.organizationId,
         internalNotes: notes.trim() || null,
       })
 
-      // Shared-room group linkage happens after booking creation.
-      if (sharedRoomEnabled) {
-        let targetGroupId = sharedRoomGroupId
+      if (sharedRoom.enabled) {
+        let targetGroupId = sharedRoom.groupId
         let role: "primary" | "shared" = "shared"
 
-        if (sharedRoomMode === "create") {
+        if (sharedRoom.mode === "create") {
           const group = await createGroup.mutateAsync({
             kind: "shared_room",
             label: `Shared room — ${booking.bookingNumber}`,
-            productId: productId || null,
-            optionUnitId: optionId === NONE ? null : optionId,
+            productId: product.productId || null,
+            optionUnitId: product.optionId,
             primaryBookingId: booking.id,
           })
           targetGroupId = group.id
@@ -223,258 +172,15 @@ export function QuickBookDialog({ open, onOpenChange, onCreated }: QuickBookDial
           <DialogTitle>Quick Book</DialogTitle>
         </DialogHeader>
         <DialogBody className="grid gap-4">
-          {/* Product */}
-          <div className="flex flex-col gap-2">
-            <Label>
-              Product <span className="text-destructive">*</span>
-            </Label>
-            <Input
-              placeholder="Search products..."
-              value={productSearch}
-              onChange={(e) => setProductSearch(e.target.value)}
-            />
-            <Select
-              items={products.map((p) => ({ label: p.name, value: p.id }))}
-              value={productId}
-              onValueChange={(v) => {
-                setProductId(v ?? "")
-                setOptionId(NONE)
-              }}
-            >
-              <SelectTrigger className="w-full">
-                <SelectValue placeholder="Select a product..." />
-              </SelectTrigger>
-              <SelectContent>
-                {products.map((p) => (
-                  <SelectItem key={p.id} value={p.id}>
-                    {p.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
+          <ProductPickerSection value={product} onChange={setProduct} enabled={open} />
+          <PersonPickerSection value={person} onChange={setPerson} enabled={open} />
+          <SharedRoomSection
+            value={sharedRoom}
+            onChange={setSharedRoom}
+            productId={product.productId || undefined}
+            enabled={open}
+          />
 
-          {/* Option (if product has options) */}
-          {productId && options.length > 0 && (
-            <div className="flex flex-col gap-2">
-              <Label>Option</Label>
-              <Select
-                items={[
-                  { label: "No specific option", value: NONE },
-                  ...options.map((o) => ({ label: o.name, value: o.id })),
-                ]}
-                value={optionId}
-                onValueChange={(v) => setOptionId(v ?? NONE)}
-              >
-                <SelectTrigger className="w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={NONE}>No specific option</SelectItem>
-                  {options.map((o) => (
-                    <SelectItem key={o.id} value={o.id}>
-                      {o.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          )}
-
-          {/* Person */}
-          <div className="flex flex-col gap-2">
-            <div className="flex items-center justify-between">
-              <Label>
-                Person <span className="text-destructive">*</span>
-              </Label>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="h-7"
-                onClick={() => setPersonMode(personMode === "existing" ? "new" : "existing")}
-              >
-                {personMode === "existing" ? (
-                  <>
-                    <UserPlus className="mr-1 h-3.5 w-3.5" />
-                    Create new
-                  </>
-                ) : (
-                  "Select existing"
-                )}
-              </Button>
-            </div>
-
-            {personMode === "existing" ? (
-              <>
-                <Input
-                  placeholder="Search people by name or email..."
-                  value={personSearch}
-                  onChange={(e) => setPersonSearch(e.target.value)}
-                />
-                <Select
-                  items={people.map((p) => ({
-                    label: `${p.firstName} ${p.lastName}${p.email ? ` · ${p.email}` : ""}`,
-                    value: p.id,
-                  }))}
-                  value={personId}
-                  onValueChange={(v) => setPersonId(v ?? "")}
-                >
-                  <SelectTrigger className="w-full">
-                    <SelectValue placeholder="Select a person..." />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {people.map((p) => (
-                      <SelectItem key={p.id} value={p.id}>
-                        {p.firstName} {p.lastName}
-                        {p.email ? ` · ${p.email}` : ""}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </>
-            ) : (
-              <div className="grid grid-cols-2 gap-2 rounded-md border p-3">
-                <div className="flex flex-col gap-1">
-                  <Label className="text-xs">First Name</Label>
-                  <Input
-                    value={newPerson.firstName}
-                    onChange={(e) => setNewPerson({ ...newPerson, firstName: e.target.value })}
-                    placeholder="John"
-                  />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <Label className="text-xs">Last Name</Label>
-                  <Input
-                    value={newPerson.lastName}
-                    onChange={(e) => setNewPerson({ ...newPerson, lastName: e.target.value })}
-                    placeholder="Smith"
-                  />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <Label className="text-xs">Email</Label>
-                  <Input
-                    type="email"
-                    value={newPerson.email}
-                    onChange={(e) => setNewPerson({ ...newPerson, email: e.target.value })}
-                    placeholder="john@example.com"
-                  />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <Label className="text-xs">Phone</Label>
-                  <Input
-                    value={newPerson.phone}
-                    onChange={(e) => setNewPerson({ ...newPerson, phone: e.target.value })}
-                    placeholder="+44 7911 123456"
-                  />
-                </div>
-              </div>
-            )}
-          </div>
-
-          {/* Organization (optional) */}
-          <div className="flex flex-col gap-2">
-            <Label>Organization (optional)</Label>
-            <Input
-              placeholder="Search organizations..."
-              value={orgSearch}
-              onChange={(e) => setOrgSearch(e.target.value)}
-            />
-            <Select
-              items={[
-                { label: "No organization", value: NONE },
-                ...orgs.map((o) => ({ label: o.name, value: o.id })),
-              ]}
-              value={organizationId}
-              onValueChange={(v) => setOrganizationId(v ?? NONE)}
-            >
-              <SelectTrigger className="w-full">
-                <SelectValue placeholder="No organization" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={NONE}>No organization</SelectItem>
-                {orgs.map((o) => (
-                  <SelectItem key={o.id} value={o.id}>
-                    {o.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          {/* Shared room */}
-          <div className="flex flex-col gap-2 rounded-md border p-3">
-            <div className="flex items-center gap-2">
-              <input
-                id="quick-book-shared-room"
-                type="checkbox"
-                checked={sharedRoomEnabled}
-                onChange={(e) => setSharedRoomEnabled(e.target.checked)}
-              />
-              <Label htmlFor="quick-book-shared-room" className="text-sm">
-                Link to a shared-room group
-              </Label>
-            </div>
-
-            {sharedRoomEnabled && (
-              <div className="flex flex-col gap-2 pl-6">
-                <div className="flex items-center gap-2">
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant={sharedRoomMode === "create" ? "default" : "ghost"}
-                    onClick={() => setSharedRoomMode("create")}
-                  >
-                    Create new group
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant={sharedRoomMode === "join" ? "default" : "ghost"}
-                    onClick={() => setSharedRoomMode("join")}
-                  >
-                    Join existing
-                  </Button>
-                </div>
-
-                {sharedRoomMode === "join" && (
-                  <Select
-                    items={
-                      existingGroups.length === 0
-                        ? [{ label: "No existing groups for this product", value: NONE }]
-                        : existingGroups.map((g) => ({ label: g.label, value: g.id }))
-                    }
-                    value={sharedRoomGroupId || NONE}
-                    onValueChange={(v) => setSharedRoomGroupId(v === NONE ? "" : (v ?? ""))}
-                  >
-                    <SelectTrigger className="w-full">
-                      <SelectValue placeholder="Select a group..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {existingGroups.length === 0 ? (
-                        <SelectItem value={NONE} disabled>
-                          No existing groups for this product
-                        </SelectItem>
-                      ) : (
-                        existingGroups.map((g) => (
-                          <SelectItem key={g.id} value={g.id}>
-                            {g.label}
-                          </SelectItem>
-                        ))
-                      )}
-                    </SelectContent>
-                  </Select>
-                )}
-                {sharedRoomMode === "create" && (
-                  <p className="text-xs text-muted-foreground">
-                    A new group will be created with this booking as the primary member.
-                  </p>
-                )}
-              </div>
-            )}
-          </div>
-
-          {/* Notes */}
           <div className="flex flex-col gap-2">
             <Label>Internal Notes</Label>
             <Textarea
@@ -500,7 +206,7 @@ export function QuickBookDialog({ open, onOpenChange, onCreated }: QuickBookDial
             type="button"
             size="sm"
             onClick={handleSubmit}
-            disabled={isSubmitting || !productId}
+            disabled={isSubmitting || !product.productId}
           >
             {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             Create Draft Booking

--- a/packages/ui/registry/bookings/shared-room-section.tsx
+++ b/packages/ui/registry/bookings/shared-room-section.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import { useBookingGroups } from "@voyantjs/bookings-react"
+
+import {
+  Button,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui"
+
+const GROUP_NONE = "__none__"
+
+export type SharedRoomMode = "create" | "join"
+
+export interface SharedRoomValue {
+  enabled: boolean
+  mode: SharedRoomMode
+  /** Only meaningful in "join" mode. */
+  groupId: string
+}
+
+export const emptySharedRoomValue: SharedRoomValue = {
+  enabled: false,
+  mode: "create",
+  groupId: "",
+}
+
+export interface SharedRoomSectionProps {
+  value: SharedRoomValue
+  onChange: (value: SharedRoomValue) => void
+  /**
+   * The product context for fetching joinable groups. When unset, the join
+   * dropdown is disabled even if the user toggles into join mode.
+   */
+  productId?: string
+  enabled?: boolean
+  labels?: {
+    toggle?: string
+    createMode?: string
+    joinMode?: string
+    selectPlaceholder?: string
+    noGroups?: string
+    createHint?: string
+  }
+}
+
+const DEFAULT_LABELS = {
+  toggle: "Link to a shared-room group",
+  createMode: "Create new group",
+  joinMode: "Join existing",
+  selectPlaceholder: "Select a group...",
+  noGroups: "No existing groups for this product",
+  createHint: "A new group will be created with this booking as the primary member.",
+} as const
+
+/**
+ * Shared-room (partaj) attachment section. Operators use it to either create a
+ * new `booking_groups` row at booking-create time or join an existing group
+ * that already has a primary booking.
+ *
+ * The section only handles the *selection* — the parent dialog owns the
+ * create-group + add-member mutations because they fire *after* the booking
+ * insert (we need the new booking id to attach).
+ */
+export function SharedRoomSection({
+  value,
+  onChange,
+  productId,
+  enabled = true,
+  labels,
+}: SharedRoomSectionProps) {
+  const merged = { ...DEFAULT_LABELS, ...labels }
+
+  const { data: groupsData } = useBookingGroups({
+    productId: productId || undefined,
+    limit: 50,
+    enabled: enabled && value.enabled && value.mode === "join" && Boolean(productId),
+  })
+  const existingGroups = groupsData?.data ?? []
+
+  const set = (patch: Partial<SharedRoomValue>) => onChange({ ...value, ...patch })
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border p-3">
+      <div className="flex items-center gap-2">
+        <input
+          id="shared-room-toggle"
+          type="checkbox"
+          checked={value.enabled}
+          onChange={(e) => set({ enabled: e.target.checked })}
+        />
+        <Label htmlFor="shared-room-toggle" className="text-sm">
+          {merged.toggle}
+        </Label>
+      </div>
+
+      {value.enabled && (
+        <div className="flex flex-col gap-2 pl-6">
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant={value.mode === "create" ? "default" : "ghost"}
+              onClick={() => set({ mode: "create" })}
+            >
+              {merged.createMode}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant={value.mode === "join" ? "default" : "ghost"}
+              onClick={() => set({ mode: "join" })}
+            >
+              {merged.joinMode}
+            </Button>
+          </div>
+
+          {value.mode === "join" && (
+            <Select
+              items={
+                existingGroups.length === 0
+                  ? [{ label: merged.noGroups, value: GROUP_NONE }]
+                  : existingGroups.map((g) => ({ label: g.label, value: g.id }))
+              }
+              value={value.groupId || GROUP_NONE}
+              onValueChange={(v) => set({ groupId: v === GROUP_NONE ? "" : (v ?? "") })}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder={merged.selectPlaceholder} />
+              </SelectTrigger>
+              <SelectContent>
+                {existingGroups.length === 0 ? (
+                  <SelectItem value={GROUP_NONE} disabled>
+                    {merged.noGroups}
+                  </SelectItem>
+                ) : (
+                  existingGroups.map((g) => (
+                    <SelectItem key={g.id} value={g.id}>
+                      {g.label}
+                    </SelectItem>
+                  ))
+                )}
+              </SelectContent>
+            </Select>
+          )}
+
+          {value.mode === "create" && (
+            <p className="text-xs text-muted-foreground">{merged.createHint}</p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/templates/operator/src/components/voyant/bookings/person-picker-section.tsx
+++ b/templates/operator/src/components/voyant/bookings/person-picker-section.tsx
@@ -1,0 +1,267 @@
+"use client"
+
+import { useOrganizations, usePeople } from "@voyantjs/crm-react"
+import { UserPlus } from "lucide-react"
+import * as React from "react"
+
+import {
+  Button,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui"
+
+const ORG_NONE = "__none__"
+
+export type PersonPickerMode = "existing" | "new"
+
+export interface NewPersonValue {
+  firstName: string
+  lastName: string
+  email: string
+  phone: string
+}
+
+export interface PersonPickerValue {
+  mode: PersonPickerMode
+  /** Set when mode === "existing". */
+  personId: string
+  /** Used when mode === "new". */
+  newPerson: NewPersonValue
+  /** `null` = no organization attached. */
+  organizationId: string | null
+}
+
+export const emptyNewPerson: NewPersonValue = {
+  firstName: "",
+  lastName: "",
+  email: "",
+  phone: "",
+}
+
+export const emptyPersonPickerValue: PersonPickerValue = {
+  mode: "existing",
+  personId: "",
+  newPerson: emptyNewPerson,
+  organizationId: null,
+}
+
+export interface PersonPickerSectionProps {
+  value: PersonPickerValue
+  onChange: (value: PersonPickerValue) => void
+  enabled?: boolean
+  showOrganization?: boolean
+  labels?: {
+    person?: string
+    createNewPerson?: string
+    selectExistingPerson?: string
+    personSearchPlaceholder?: string
+    personSelectPlaceholder?: string
+    firstName?: string
+    firstNamePlaceholder?: string
+    lastName?: string
+    lastNamePlaceholder?: string
+    email?: string
+    emailPlaceholder?: string
+    phone?: string
+    phonePlaceholder?: string
+    organization?: string
+    organizationSearchPlaceholder?: string
+    organizationNone?: string
+  }
+}
+
+const DEFAULT_LABELS = {
+  person: "Person",
+  createNewPerson: "Create new",
+  selectExistingPerson: "Select existing",
+  personSearchPlaceholder: "Search people by name or email...",
+  personSelectPlaceholder: "Select a person...",
+  firstName: "First Name",
+  firstNamePlaceholder: "John",
+  lastName: "Last Name",
+  lastNamePlaceholder: "Smith",
+  email: "Email",
+  emailPlaceholder: "john@example.com",
+  phone: "Phone",
+  phonePlaceholder: "+44 7911 123456",
+  organization: "Organization (optional)",
+  organizationSearchPlaceholder: "Search organizations...",
+  organizationNone: "No organization",
+} as const
+
+/**
+ * Person picker with inline-create + optional organization attachment.
+ *
+ * State is fully controlled — the caller owns both existing-person selection
+ * and the inline-create form. The section does *not* call any mutation itself;
+ * the parent decides when to commit a newly-created person (typically at
+ * submit time, so we don't leak orphan CRM records when the dialog is
+ * cancelled).
+ */
+export function PersonPickerSection({
+  value,
+  onChange,
+  enabled = true,
+  showOrganization = true,
+  labels,
+}: PersonPickerSectionProps) {
+  const [personSearch, setPersonSearch] = React.useState("")
+  const [orgSearch, setOrgSearch] = React.useState("")
+  const merged = { ...DEFAULT_LABELS, ...labels }
+
+  const { data: peopleData } = usePeople({
+    search: personSearch || undefined,
+    limit: 20,
+    enabled: enabled && value.mode === "existing",
+  })
+  const people = peopleData?.data ?? []
+
+  const { data: orgsData } = useOrganizations({
+    search: orgSearch || undefined,
+    limit: 20,
+    enabled: enabled && showOrganization,
+  })
+  const orgs = orgsData?.data ?? []
+
+  const setPerson = (patch: Partial<PersonPickerValue>) => onChange({ ...value, ...patch })
+
+  return (
+    <>
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <Label>
+            {merged.person} <span className="text-destructive">*</span>
+          </Label>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7"
+            onClick={() => setPerson({ mode: value.mode === "existing" ? "new" : "existing" })}
+          >
+            {value.mode === "existing" ? (
+              <>
+                <UserPlus className="mr-1 h-3.5 w-3.5" />
+                {merged.createNewPerson}
+              </>
+            ) : (
+              merged.selectExistingPerson
+            )}
+          </Button>
+        </div>
+
+        {value.mode === "existing" ? (
+          <>
+            <Input
+              placeholder={merged.personSearchPlaceholder}
+              value={personSearch}
+              onChange={(e) => setPersonSearch(e.target.value)}
+            />
+            <Select
+              items={people.map((p) => ({
+                label: `${p.firstName} ${p.lastName}${p.email ? ` · ${p.email}` : ""}`,
+                value: p.id,
+              }))}
+              value={value.personId}
+              onValueChange={(v) => setPerson({ personId: v ?? "" })}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder={merged.personSelectPlaceholder} />
+              </SelectTrigger>
+              <SelectContent>
+                {people.map((p) => (
+                  <SelectItem key={p.id} value={p.id}>
+                    {p.firstName} {p.lastName}
+                    {p.email ? ` · ${p.email}` : ""}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </>
+        ) : (
+          <div className="grid grid-cols-2 gap-2 rounded-md border p-3">
+            <div className="flex flex-col gap-1">
+              <Label className="text-xs">{merged.firstName}</Label>
+              <Input
+                value={value.newPerson.firstName}
+                onChange={(e) =>
+                  setPerson({ newPerson: { ...value.newPerson, firstName: e.target.value } })
+                }
+                placeholder={merged.firstNamePlaceholder}
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <Label className="text-xs">{merged.lastName}</Label>
+              <Input
+                value={value.newPerson.lastName}
+                onChange={(e) =>
+                  setPerson({ newPerson: { ...value.newPerson, lastName: e.target.value } })
+                }
+                placeholder={merged.lastNamePlaceholder}
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <Label className="text-xs">{merged.email}</Label>
+              <Input
+                type="email"
+                value={value.newPerson.email}
+                onChange={(e) =>
+                  setPerson({ newPerson: { ...value.newPerson, email: e.target.value } })
+                }
+                placeholder={merged.emailPlaceholder}
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <Label className="text-xs">{merged.phone}</Label>
+              <Input
+                value={value.newPerson.phone}
+                onChange={(e) =>
+                  setPerson({ newPerson: { ...value.newPerson, phone: e.target.value } })
+                }
+                placeholder={merged.phonePlaceholder}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {showOrganization && (
+        <div className="flex flex-col gap-2">
+          <Label>{merged.organization}</Label>
+          <Input
+            placeholder={merged.organizationSearchPlaceholder}
+            value={orgSearch}
+            onChange={(e) => setOrgSearch(e.target.value)}
+          />
+          <Select
+            items={[
+              { label: merged.organizationNone, value: ORG_NONE },
+              ...orgs.map((o) => ({ label: o.name, value: o.id })),
+            ]}
+            value={value.organizationId ?? ORG_NONE}
+            onValueChange={(v) =>
+              setPerson({ organizationId: v === ORG_NONE ? null : (v ?? null) })
+            }
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder={merged.organizationNone} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ORG_NONE}>{merged.organizationNone}</SelectItem>
+              {orgs.map((o) => (
+                <SelectItem key={o.id} value={o.id}>
+                  {o.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+    </>
+  )
+}

--- a/templates/operator/src/components/voyant/bookings/product-picker-section.tsx
+++ b/templates/operator/src/components/voyant/bookings/product-picker-section.tsx
@@ -1,0 +1,140 @@
+"use client"
+
+import { useProductOptions, useProducts } from "@voyantjs/products-react"
+import * as React from "react"
+
+import {
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui"
+
+const OPTION_NONE = "__none__"
+
+export interface ProductPickerValue {
+  productId: string
+  /** `null` means "no specific option" — the product has options but none was picked. */
+  optionId: string | null
+}
+
+export interface ProductPickerSectionProps {
+  value: ProductPickerValue
+  onChange: (value: ProductPickerValue) => void
+  /** When true, skip data fetches (dialog closed / parent gated). */
+  enabled?: boolean
+  /** When true, hide the product picker and fix the productId (e.g., launched from a product page). */
+  lockProduct?: boolean
+  labels?: {
+    product?: string
+    productSearchPlaceholder?: string
+    productSelectPlaceholder?: string
+    option?: string
+    optionNone?: string
+  }
+}
+
+const DEFAULT_LABELS = {
+  product: "Product",
+  productSearchPlaceholder: "Search products...",
+  productSelectPlaceholder: "Select a product...",
+  option: "Option",
+  optionNone: "No specific option",
+} as const
+
+/**
+ * Controlled product + option picker. Splits `value` + `onChange` so apps can
+ * replace the whole section (e.g., with a typeahead against a custom catalog)
+ * without reimplementing the cascade logic, or keep this one and swap labels.
+ */
+export function ProductPickerSection({
+  value,
+  onChange,
+  enabled = true,
+  lockProduct = false,
+  labels,
+}: ProductPickerSectionProps) {
+  const [productSearch, setProductSearch] = React.useState("")
+  const merged = { ...DEFAULT_LABELS, ...labels }
+
+  const { data: productsData } = useProducts({
+    search: productSearch || undefined,
+    limit: 20,
+    enabled: enabled && !lockProduct,
+  })
+  const products = productsData?.data ?? []
+
+  const { data: optionsData } = useProductOptions({
+    productId: value.productId || undefined,
+    limit: 50,
+    enabled: enabled && Boolean(value.productId),
+  })
+  const options = optionsData?.data ?? []
+
+  return (
+    <>
+      {!lockProduct && (
+        <div className="flex flex-col gap-2">
+          <Label>
+            {merged.product} <span className="text-destructive">*</span>
+          </Label>
+          <Input
+            placeholder={merged.productSearchPlaceholder}
+            value={productSearch}
+            onChange={(e) => setProductSearch(e.target.value)}
+          />
+          <Select
+            items={products.map((p) => ({ label: p.name, value: p.id }))}
+            value={value.productId}
+            onValueChange={(v) => onChange({ productId: v ?? "", optionId: null })}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder={merged.productSelectPlaceholder} />
+            </SelectTrigger>
+            <SelectContent>
+              {products.map((p) => (
+                <SelectItem key={p.id} value={p.id}>
+                  {p.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      {value.productId && options.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <Label>{merged.option}</Label>
+          <Select
+            items={[
+              { label: merged.optionNone, value: OPTION_NONE },
+              ...options.map((o) => ({ label: o.name, value: o.id })),
+            ]}
+            value={value.optionId ?? OPTION_NONE}
+            onValueChange={(v) =>
+              onChange({
+                productId: value.productId,
+                optionId: v === OPTION_NONE ? null : (v ?? null),
+              })
+            }
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={OPTION_NONE}>{merged.optionNone}</SelectItem>
+              {options.map((o) => (
+                <SelectItem key={o.id} value={o.id}>
+                  {o.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+    </>
+  )
+}

--- a/templates/operator/src/components/voyant/bookings/quick-book-dialog.tsx
+++ b/templates/operator/src/components/voyant/bookings/quick-book-dialog.tsx
@@ -5,11 +5,9 @@ import {
   useBookingConvertMutation,
   useBookingGroupMemberMutation,
   useBookingGroupMutation,
-  useBookingGroups,
 } from "@voyantjs/bookings-react"
-import { useOrganizations, usePeople, usePersonMutation } from "@voyantjs/crm-react"
-import { useProductOptions, useProducts } from "@voyantjs/products-react"
-import { Loader2, UserPlus } from "lucide-react"
+import { usePersonMutation } from "@voyantjs/crm-react"
+import { Loader2 } from "lucide-react"
 import * as React from "react"
 
 import {
@@ -20,16 +18,22 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  Input,
   Label,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
   Textarea,
 } from "@/components/ui"
 import { useAdminMessages } from "@/lib/admin-i18n"
+
+import {
+  emptyPersonPickerValue,
+  PersonPickerSection,
+  type PersonPickerValue,
+} from "./person-picker-section"
+import { ProductPickerSection, type ProductPickerValue } from "./product-picker-section"
+import {
+  emptySharedRoomValue,
+  SharedRoomSection,
+  type SharedRoomValue,
+} from "./shared-room-section"
 
 function generateBookingNumber(): string {
   const now = new Date()
@@ -39,8 +43,6 @@ function generateBookingNumber(): string {
   return `BK-${y}${m}-${seq}`
 }
 
-const NONE = "__none__"
-
 export interface QuickBookDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -49,158 +51,135 @@ export interface QuickBookDialogProps {
   defaultProductId?: string
 }
 
-type PersonMode = "existing" | "new"
-
 export function QuickBookDialog({
   open,
   onOpenChange,
   onCreated,
   defaultProductId,
 }: QuickBookDialogProps) {
-  const quickBookMessages = useAdminMessages().bookings.quickBook
-  const [productId, setProductId] = React.useState(defaultProductId ?? "")
-  const [productSearch, setProductSearch] = React.useState("")
-  const [optionId, setOptionId] = React.useState<string>(NONE)
-  const [organizationId, setOrganizationId] = React.useState<string>(NONE)
-  const [orgSearch, setOrgSearch] = React.useState("")
-  const [notes, setNotes] = React.useState("")
-
-  const [personMode, setPersonMode] = React.useState<PersonMode>("existing")
-  const [personId, setPersonId] = React.useState("")
-  const [personSearch, setPersonSearch] = React.useState("")
-  const [newPerson, setNewPerson] = React.useState({
-    firstName: "",
-    lastName: "",
-    email: "",
-    phone: "",
+  const messages = useAdminMessages().bookings.quickBook
+  const [product, setProduct] = React.useState<ProductPickerValue>({
+    productId: defaultProductId ?? "",
+    optionId: null,
   })
-
+  const [person, setPerson] = React.useState<PersonPickerValue>(emptyPersonPickerValue)
+  const [sharedRoom, setSharedRoom] = React.useState<SharedRoomValue>(emptySharedRoomValue)
+  const [notes, setNotes] = React.useState("")
   const [error, setError] = React.useState<string | null>(null)
-
-  // Shared-room state
-  const [sharedRoomEnabled, setSharedRoomEnabled] = React.useState(false)
-  const [sharedRoomMode, setSharedRoomMode] = React.useState<"create" | "join">("create")
-  const [sharedRoomGroupId, setSharedRoomGroupId] = React.useState("")
 
   React.useEffect(() => {
     if (!open) {
-      setProductId(defaultProductId ?? "")
-      setProductSearch("")
-      setOptionId(NONE)
-      setOrganizationId(NONE)
-      setOrgSearch("")
+      setProduct({ productId: defaultProductId ?? "", optionId: null })
+      setPerson(emptyPersonPickerValue)
+      setSharedRoom(emptySharedRoomValue)
       setNotes("")
-      setPersonMode("existing")
-      setPersonId("")
-      setPersonSearch("")
-      setNewPerson({ firstName: "", lastName: "", email: "", phone: "" })
-      setSharedRoomEnabled(false)
-      setSharedRoomMode("create")
-      setSharedRoomGroupId("")
       setError(null)
     } else if (defaultProductId) {
-      setProductId(defaultProductId)
+      setProduct((prev) =>
+        prev.productId === defaultProductId
+          ? prev
+          : { productId: defaultProductId, optionId: null },
+      )
     }
   }, [open, defaultProductId])
-
-  const { data: productsData } = useProducts({
-    search: productSearch || undefined,
-    limit: 20,
-    enabled: open,
-  })
-  const products = productsData?.data ?? []
-
-  const { data: optionsData } = useProductOptions({
-    productId: productId || undefined,
-    limit: 50,
-    enabled: open && Boolean(productId),
-  })
-  const options = optionsData?.data ?? []
-
-  const { data: peopleData } = usePeople({
-    search: personSearch || undefined,
-    limit: 20,
-    enabled: open && personMode === "existing",
-  })
-  const people = peopleData?.data ?? []
-
-  const { data: orgsData } = useOrganizations({
-    search: orgSearch || undefined,
-    limit: 20,
-    enabled: open,
-  })
-  const orgs = orgsData?.data ?? []
 
   const { create: createPerson } = usePersonMutation()
   const convertMutation = useBookingConvertMutation()
   const { create: createGroup } = useBookingGroupMutation()
   const { add: addGroupMember } = useBookingGroupMemberMutation()
 
-  // Only load groups when shared-room+join is selected and we have a product
-  const { data: groupsData } = useBookingGroups({
-    productId: productId || undefined,
-    limit: 50,
-    enabled: open && sharedRoomEnabled && sharedRoomMode === "join" && Boolean(productId),
-  })
-  const existingGroups = groupsData?.data ?? []
+  const productLabels = {
+    product: messages.productLabel,
+    productSearchPlaceholder: messages.productSearchPlaceholder,
+    productSelectPlaceholder: messages.productSelectPlaceholder,
+    option: messages.optionLabel,
+    optionNone: messages.optionNone,
+  }
+
+  const personLabels = {
+    person: messages.personLabel,
+    createNewPerson: messages.createNewPerson,
+    selectExistingPerson: messages.selectExistingPerson,
+    personSearchPlaceholder: messages.personSearchPlaceholder,
+    personSelectPlaceholder: messages.personSelectPlaceholder,
+    firstName: messages.firstNameLabel,
+    firstNamePlaceholder: messages.firstNamePlaceholder,
+    lastName: messages.lastNameLabel,
+    lastNamePlaceholder: messages.lastNamePlaceholder,
+    email: messages.emailLabel,
+    emailPlaceholder: messages.emailPlaceholder,
+    phone: messages.phoneLabel,
+    phonePlaceholder: messages.phonePlaceholder,
+    organization: messages.organizationLabel,
+    organizationSearchPlaceholder: messages.organizationSearchPlaceholder,
+    organizationNone: messages.organizationNone,
+  }
+
+  const sharedRoomLabels = {
+    toggle: messages.sharedRoomLabel,
+    createMode: messages.sharedRoomCreate,
+    joinMode: messages.sharedRoomJoin,
+    selectPlaceholder: messages.sharedRoomSelectPlaceholder,
+    noGroups: messages.sharedRoomNoGroups,
+    createHint: messages.sharedRoomCreateHint,
+  }
 
   const handleSubmit = async () => {
     setError(null)
 
-    if (!productId) {
-      setError(quickBookMessages.errorSelectProduct)
+    if (!product.productId) {
+      setError(messages.errorSelectProduct)
       return
     }
 
     let resolvedPersonId: string | null = null
     try {
-      if (personMode === "existing") {
-        if (!personId) {
-          setError(quickBookMessages.errorSelectPerson)
+      if (person.mode === "existing") {
+        if (!person.personId) {
+          setError(messages.errorSelectPerson)
           return
         }
-        resolvedPersonId = personId
+        resolvedPersonId = person.personId
       } else {
-        if (!newPerson.firstName.trim() || !newPerson.lastName.trim()) {
-          setError(quickBookMessages.errorNameRequired)
+        if (!person.newPerson.firstName.trim() || !person.newPerson.lastName.trim()) {
+          setError(messages.errorNameRequired)
           return
         }
-        const person = await createPerson.mutateAsync({
-          firstName: newPerson.firstName.trim(),
-          lastName: newPerson.lastName.trim(),
-          email: newPerson.email.trim() || null,
-          phone: newPerson.phone.trim() || null,
+        const created = await createPerson.mutateAsync({
+          firstName: person.newPerson.firstName.trim(),
+          lastName: person.newPerson.lastName.trim(),
+          email: person.newPerson.email.trim() || null,
+          phone: person.newPerson.phone.trim() || null,
         })
-        resolvedPersonId = person.id
+        resolvedPersonId = created.id
       }
 
       // Validate shared-room selection before creating the booking so we don't
-      // create an orphan booking if the user picked "join" without a group.
-      if (sharedRoomEnabled && sharedRoomMode === "join" && !sharedRoomGroupId) {
-        setError(quickBookMessages.errorSelectSharedRoom)
+      // leave an orphan booking if the user picked "join" without a group.
+      if (sharedRoom.enabled && sharedRoom.mode === "join" && !sharedRoom.groupId) {
+        setError(messages.errorSelectSharedRoom)
         return
       }
 
       const booking = await convertMutation.mutateAsync({
-        productId,
+        productId: product.productId,
         bookingNumber: generateBookingNumber(),
-        optionId: optionId === NONE ? null : optionId,
+        optionId: product.optionId,
         personId: resolvedPersonId,
-        organizationId: organizationId === NONE ? null : organizationId,
+        organizationId: person.organizationId,
         internalNotes: notes.trim() || null,
       })
 
-      // Shared-room group linkage happens after booking creation.
-      if (sharedRoomEnabled) {
-        let targetGroupId = sharedRoomGroupId
+      if (sharedRoom.enabled) {
+        let targetGroupId = sharedRoom.groupId
         let role: "primary" | "shared" = "shared"
 
-        if (sharedRoomMode === "create") {
+        if (sharedRoom.mode === "create") {
           const group = await createGroup.mutateAsync({
             kind: "shared_room",
             label: `Shared room — ${booking.bookingNumber}`,
-            productId: productId || null,
-            optionUnitId: optionId === NONE ? null : optionId,
+            productId: product.productId || null,
+            optionUnitId: product.optionId,
             primaryBookingId: booking.id,
           })
           targetGroupId = group.id
@@ -217,7 +196,7 @@ export function QuickBookDialog({
       onOpenChange(false)
       onCreated?.(booking)
     } catch (err) {
-      setError(err instanceof Error ? err.message : quickBookMessages.errorCreateFailed)
+      setError(err instanceof Error ? err.message : messages.errorCreateFailed)
     }
   }
 
@@ -231,250 +210,38 @@ export function QuickBookDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent size="lg">
         <DialogHeader>
-          <DialogTitle>{quickBookMessages.title}</DialogTitle>
+          <DialogTitle>{messages.title}</DialogTitle>
         </DialogHeader>
         <DialogBody className="grid gap-4">
-          {/* Product — hidden when pre-selected from a product page */}
-          {!defaultProductId ? (
-            <div className="flex flex-col gap-2">
-              <Label>
-                {quickBookMessages.productLabel} <span className="text-destructive">*</span>
-              </Label>
-              <Input
-                placeholder={quickBookMessages.productSearchPlaceholder}
-                value={productSearch}
-                onChange={(e) => setProductSearch(e.target.value)}
-              />
-              <Select
-                items={products.map((product) => ({ label: product.name, value: product.id }))}
-                value={productId}
-                onValueChange={(v) => {
-                  setProductId(v ?? "")
-                  setOptionId(NONE)
-                }}
-              >
-                <SelectTrigger className="w-full">
-                  <SelectValue placeholder={quickBookMessages.productSelectPlaceholder} />
-                </SelectTrigger>
-                <SelectContent>
-                  {products.map((p) => (
-                    <SelectItem key={p.id} value={p.id}>
-                      {p.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          ) : null}
+          <ProductPickerSection
+            value={product}
+            onChange={setProduct}
+            enabled={open}
+            lockProduct={Boolean(defaultProductId)}
+            labels={productLabels}
+          />
 
-          {/* Option (if product has options) */}
-          {productId && options.length > 0 && (
-            <div className="flex flex-col gap-2">
-              <Label>{quickBookMessages.optionLabel}</Label>
-              <Select value={optionId} onValueChange={(v) => setOptionId(v ?? NONE)}>
-                <SelectTrigger className="w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={NONE}>{quickBookMessages.optionNone}</SelectItem>
-                  {options.map((o) => (
-                    <SelectItem key={o.id} value={o.id}>
-                      {o.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          )}
+          <PersonPickerSection
+            value={person}
+            onChange={setPerson}
+            enabled={open}
+            labels={personLabels}
+          />
 
-          {/* Person */}
+          <SharedRoomSection
+            value={sharedRoom}
+            onChange={setSharedRoom}
+            productId={product.productId || undefined}
+            enabled={open}
+            labels={sharedRoomLabels}
+          />
+
           <div className="flex flex-col gap-2">
-            <div className="flex items-center justify-between">
-              <Label>
-                {quickBookMessages.personLabel} <span className="text-destructive">*</span>
-              </Label>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="h-7"
-                onClick={() => setPersonMode(personMode === "existing" ? "new" : "existing")}
-              >
-                {personMode === "existing" ? (
-                  <>
-                    <UserPlus className="mr-1 h-3.5 w-3.5" />
-                    {quickBookMessages.createNewPerson}
-                  </>
-                ) : (
-                  quickBookMessages.selectExistingPerson
-                )}
-              </Button>
-            </div>
-
-            {personMode === "existing" ? (
-              <>
-                <Input
-                  placeholder={quickBookMessages.personSearchPlaceholder}
-                  value={personSearch}
-                  onChange={(e) => setPersonSearch(e.target.value)}
-                />
-                <Select
-                  value={personId}
-                  onValueChange={(v) => setPersonId(v ?? "")}
-                  items={people.map((p) => ({
-                    label: `${p.firstName} ${p.lastName}${p.email ? ` · ${p.email}` : ""}`,
-                    value: p.id,
-                  }))}
-                >
-                  <SelectTrigger className="w-full">
-                    <SelectValue placeholder={quickBookMessages.personSelectPlaceholder} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {people.map((p) => (
-                      <SelectItem key={p.id} value={p.id}>
-                        {p.firstName} {p.lastName}
-                        {p.email ? ` · ${p.email}` : ""}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </>
-            ) : (
-              <div className="grid grid-cols-2 gap-2 rounded-md border p-3">
-                <div className="flex flex-col gap-1">
-                  <Label className="text-xs">{quickBookMessages.firstNameLabel}</Label>
-                  <Input
-                    value={newPerson.firstName}
-                    onChange={(e) => setNewPerson({ ...newPerson, firstName: e.target.value })}
-                    placeholder={quickBookMessages.firstNamePlaceholder}
-                  />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <Label className="text-xs">{quickBookMessages.lastNameLabel}</Label>
-                  <Input
-                    value={newPerson.lastName}
-                    onChange={(e) => setNewPerson({ ...newPerson, lastName: e.target.value })}
-                    placeholder={quickBookMessages.lastNamePlaceholder}
-                  />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <Label className="text-xs">{quickBookMessages.emailLabel}</Label>
-                  <Input
-                    type="email"
-                    value={newPerson.email}
-                    onChange={(e) => setNewPerson({ ...newPerson, email: e.target.value })}
-                    placeholder={quickBookMessages.emailPlaceholder}
-                  />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <Label className="text-xs">{quickBookMessages.phoneLabel}</Label>
-                  <Input
-                    value={newPerson.phone}
-                    onChange={(e) => setNewPerson({ ...newPerson, phone: e.target.value })}
-                    placeholder={quickBookMessages.phonePlaceholder}
-                  />
-                </div>
-              </div>
-            )}
-          </div>
-
-          {/* Organization (optional) */}
-          <div className="flex flex-col gap-2">
-            <Label>{quickBookMessages.organizationLabel}</Label>
-            <Input
-              placeholder={quickBookMessages.organizationSearchPlaceholder}
-              value={orgSearch}
-              onChange={(e) => setOrgSearch(e.target.value)}
-            />
-            <Select value={organizationId} onValueChange={(v) => setOrganizationId(v ?? NONE)}>
-              <SelectTrigger className="w-full">
-                <SelectValue placeholder={quickBookMessages.organizationNone} />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={NONE}>{quickBookMessages.organizationNone}</SelectItem>
-                {orgs.map((o) => (
-                  <SelectItem key={o.id} value={o.id}>
-                    {o.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          {/* Shared room */}
-          <div className="flex flex-col gap-2 rounded-md border p-3">
-            <div className="flex items-center gap-2">
-              <input
-                id="quick-book-shared-room"
-                type="checkbox"
-                checked={sharedRoomEnabled}
-                onChange={(e) => setSharedRoomEnabled(e.target.checked)}
-              />
-              <Label htmlFor="quick-book-shared-room" className="text-sm">
-                {quickBookMessages.sharedRoomLabel}
-              </Label>
-            </div>
-
-            {sharedRoomEnabled && (
-              <div className="flex flex-col gap-2 pl-6">
-                <div className="flex items-center gap-2">
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant={sharedRoomMode === "create" ? "default" : "ghost"}
-                    onClick={() => setSharedRoomMode("create")}
-                  >
-                    {quickBookMessages.sharedRoomCreate}
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant={sharedRoomMode === "join" ? "default" : "ghost"}
-                    onClick={() => setSharedRoomMode("join")}
-                  >
-                    {quickBookMessages.sharedRoomJoin}
-                  </Button>
-                </div>
-
-                {sharedRoomMode === "join" && (
-                  <Select
-                    value={sharedRoomGroupId || NONE}
-                    onValueChange={(v) => setSharedRoomGroupId(v === NONE ? "" : (v ?? ""))}
-                  >
-                    <SelectTrigger className="w-full">
-                      <SelectValue placeholder={quickBookMessages.sharedRoomSelectPlaceholder} />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {existingGroups.length === 0 ? (
-                        <SelectItem value={NONE} disabled>
-                          {quickBookMessages.sharedRoomNoGroups}
-                        </SelectItem>
-                      ) : (
-                        existingGroups.map((g) => (
-                          <SelectItem key={g.id} value={g.id}>
-                            {g.label}
-                          </SelectItem>
-                        ))
-                      )}
-                    </SelectContent>
-                  </Select>
-                )}
-                {sharedRoomMode === "create" && (
-                  <p className="text-xs text-muted-foreground">
-                    {quickBookMessages.sharedRoomCreateHint}
-                  </p>
-                )}
-              </div>
-            )}
-          </div>
-
-          {/* Notes */}
-          <div className="flex flex-col gap-2">
-            <Label>{quickBookMessages.notesLabel}</Label>
+            <Label>{messages.notesLabel}</Label>
             <Textarea
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
-              placeholder={quickBookMessages.notesPlaceholder}
+              placeholder={messages.notesPlaceholder}
             />
           </div>
 
@@ -488,16 +255,16 @@ export function QuickBookDialog({
             onClick={() => onOpenChange(false)}
             disabled={isSubmitting}
           >
-            {quickBookMessages.cancel}
+            {messages.cancel}
           </Button>
           <Button
             type="button"
             size="sm"
             onClick={handleSubmit}
-            disabled={isSubmitting || !productId}
+            disabled={isSubmitting || !product.productId}
           >
             {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            {quickBookMessages.create}
+            {messages.create}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/templates/operator/src/components/voyant/bookings/shared-room-section.tsx
+++ b/templates/operator/src/components/voyant/bookings/shared-room-section.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import { useBookingGroups } from "@voyantjs/bookings-react"
+
+import {
+  Button,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui"
+
+const GROUP_NONE = "__none__"
+
+export type SharedRoomMode = "create" | "join"
+
+export interface SharedRoomValue {
+  enabled: boolean
+  mode: SharedRoomMode
+  /** Only meaningful in "join" mode. */
+  groupId: string
+}
+
+export const emptySharedRoomValue: SharedRoomValue = {
+  enabled: false,
+  mode: "create",
+  groupId: "",
+}
+
+export interface SharedRoomSectionProps {
+  value: SharedRoomValue
+  onChange: (value: SharedRoomValue) => void
+  /**
+   * The product context for fetching joinable groups. When unset, the join
+   * dropdown is disabled even if the user toggles into join mode.
+   */
+  productId?: string
+  enabled?: boolean
+  labels?: {
+    toggle?: string
+    createMode?: string
+    joinMode?: string
+    selectPlaceholder?: string
+    noGroups?: string
+    createHint?: string
+  }
+}
+
+const DEFAULT_LABELS = {
+  toggle: "Link to a shared-room group",
+  createMode: "Create new group",
+  joinMode: "Join existing",
+  selectPlaceholder: "Select a group...",
+  noGroups: "No existing groups for this product",
+  createHint: "A new group will be created with this booking as the primary member.",
+} as const
+
+/**
+ * Shared-room (partaj) attachment section. Operators use it to either create a
+ * new `booking_groups` row at booking-create time or join an existing group
+ * that already has a primary booking.
+ *
+ * The section only handles the *selection* — the parent dialog owns the
+ * create-group + add-member mutations because they fire *after* the booking
+ * insert (we need the new booking id to attach).
+ */
+export function SharedRoomSection({
+  value,
+  onChange,
+  productId,
+  enabled = true,
+  labels,
+}: SharedRoomSectionProps) {
+  const merged = { ...DEFAULT_LABELS, ...labels }
+
+  const { data: groupsData } = useBookingGroups({
+    productId: productId || undefined,
+    limit: 50,
+    enabled: enabled && value.enabled && value.mode === "join" && Boolean(productId),
+  })
+  const existingGroups = groupsData?.data ?? []
+
+  const set = (patch: Partial<SharedRoomValue>) => onChange({ ...value, ...patch })
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border p-3">
+      <div className="flex items-center gap-2">
+        <input
+          id="shared-room-toggle"
+          type="checkbox"
+          checked={value.enabled}
+          onChange={(e) => set({ enabled: e.target.checked })}
+        />
+        <Label htmlFor="shared-room-toggle" className="text-sm">
+          {merged.toggle}
+        </Label>
+      </div>
+
+      {value.enabled && (
+        <div className="flex flex-col gap-2 pl-6">
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant={value.mode === "create" ? "default" : "ghost"}
+              onClick={() => set({ mode: "create" })}
+            >
+              {merged.createMode}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant={value.mode === "join" ? "default" : "ghost"}
+              onClick={() => set({ mode: "join" })}
+            >
+              {merged.joinMode}
+            </Button>
+          </div>
+
+          {value.mode === "join" && (
+            <Select
+              items={
+                existingGroups.length === 0
+                  ? [{ label: merged.noGroups, value: GROUP_NONE }]
+                  : existingGroups.map((g) => ({ label: g.label, value: g.id }))
+              }
+              value={value.groupId || GROUP_NONE}
+              onValueChange={(v) => set({ groupId: v === GROUP_NONE ? "" : (v ?? "") })}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder={merged.selectPlaceholder} />
+              </SelectTrigger>
+              <SelectContent>
+                {existingGroups.length === 0 ? (
+                  <SelectItem value={GROUP_NONE} disabled>
+                    {merged.noGroups}
+                  </SelectItem>
+                ) : (
+                  existingGroups.map((g) => (
+                    <SelectItem key={g.id} value={g.id}>
+                      {g.label}
+                    </SelectItem>
+                  ))
+                )}
+              </SelectContent>
+            </Select>
+          )}
+
+          {value.mode === "create" && (
+            <p className="text-xs text-muted-foreground">{merged.createHint}</p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
Closes the last out-of-scope item on #222. The quick-book dialog was one file with three embedded sections — product+option, person+organization, shared-room — and apps that wanted a different flow had to fork ~500 lines to swap a single piece. Each section is now a standalone registry component with a controlled `value`+`onChange` API; the dialog composes them.

### New registry components (`packages/ui/registry/bookings/`)
- **`product-picker-section.tsx`** — `ProductPickerSection` with `ProductPickerValue` (`{productId, optionId}`). Owns internal search state, cascades option list from `productId`, accepts `lockProduct` for product-page entry points.
- **`person-picker-section.tsx`** — `PersonPickerSection` with `PersonPickerValue` (`mode`, `personId`, `newPerson`, `organizationId`). Owns internal search state; does **not** call any mutation itself — the parent decides when to commit a newly-created person (typically at submit time, so cancelled dialogs don't leak orphan CRM records). Exports `emptyPersonPickerValue` for resets.
- **`shared-room-section.tsx`** — `SharedRoomSection` with `SharedRoomValue` (`enabled`, `mode`, `groupId`). Fetches joinable groups only when enabled+join+productId are all set. Parent still owns the `booking_groups` mutations because they fire *after* the booking insert. Exports `emptySharedRoomValue`.

All three accept an optional `labels` prop with sane English defaults, so apps that don't care about i18n get a working section out of the box and apps that do (operator template) pass their i18n strings in.

### Dialog refactor
`QuickBookDialog` now composes the three sections. ~180 lines shorter and easier to read — each section renders one field-group and owns its own sub-state + data fetches.

### Registry wiring
`registry.json` adds three new entries and makes `voyant-bookings-quick-book-dialog` depend on them via `registryDependencies`, so `shadcn add voyant-bookings-quick-book-dialog` transitively installs the sections. Apps that only want one picker can install it directly:
```bash
shadcn add voyant-bookings-product-picker-section
```

### Operator template
Mirrored: section files live next to `quick-book-dialog.tsx` in the template. The operator dialog passes its i18n messages through as `labels`, keeps `defaultProductId`, and is otherwise identical in behavior to before.

Closes the last out-of-scope item on #222.

## Test plan
- [x] `pnpm -F operator typecheck`
- [x] `pnpm typecheck` — 136/136 tasks clean.
- [ ] Smoke: open the operator "+ New booking" dialog, confirm all three sections render, product cascade still disables option until a product is picked, and shared-room/join only fetches groups after the toggle flips.
- [ ] Smoke: open from the product detail page → product picker is locked to the current product, option cascade still appears.
- [ ] `pnpm registry:build` regenerates `apps/registry/public/r/*.json` from the new entries.