### PR TITLE
feat(finance): add GET /finance/aggregates dashboard endpoint

### DIFF
--- a/packages/finance/src/routes.ts
+++ b/packages/finance/src/routes.ts
@@ -15,6 +15,7 @@ import {
   createPaymentSessionFromScheduleSchema,
   expirePaymentSessionSchema,
   failPaymentSessionSchema,
+  financeAggregatesQuerySchema,
   insertBookingGuaranteeSchema,
   insertBookingItemCommissionSchema,
   insertBookingItemTaxLineSchema,
@@ -74,6 +75,15 @@ import {
 // ==========================================================================
 
 export const financeRoutes = new Hono<Env>()
+
+  // ========================================================================
+  // Dashboard aggregates
+  // ========================================================================
+
+  .get("/aggregates", async (c) => {
+    const query = parseQuery(c, financeAggregatesQuerySchema)
+    return c.json({ data: await financeService.getFinanceAggregates(c.get("db"), query) })
+  })
 
   // ========================================================================
   // Payment Sessions

--- a/packages/finance/src/service-aggregates.ts
+++ b/packages/finance/src/service-aggregates.ts
@@ -1,0 +1,158 @@
+import { and, inArray, ne, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { invoices } from "./schema.js"
+
+type InvoiceStatus = (typeof invoices.$inferSelect)["status"]
+
+const ALL_INVOICE_STATUSES: readonly InvoiceStatus[] = [
+  "draft",
+  "sent",
+  "partially_paid",
+  "paid",
+  "overdue",
+  "void",
+]
+
+/** Statuses where balance_due_cents > 0 is meaningful money we're owed. */
+const OUTSTANDING_STATUSES: readonly InvoiceStatus[] = ["sent", "partially_paid", "overdue"]
+
+export interface FinanceAggregates {
+  total: number
+  countsByStatus: Array<{ status: InvoiceStatus; count: number }>
+  /** Issued total (total_cents) grouped by UTC yearMonth + currency. Void excluded. */
+  monthlyRevenue: Array<{ yearMonth: string; currency: string; totalCents: number }>
+  /** Invoice count per UTC yearMonth, all statuses in range. */
+  monthlyInvoiceCounts: Array<{ yearMonth: string; count: number }>
+  /**
+   * Sum of `balance_due_cents` for invoices still expecting payment — sent /
+   * partially_paid / overdue — grouped by currency. Matches the "how much
+   * are we owed" dashboard card.
+   */
+  outstanding: Array<{ currency: string; balanceDueCents: number; count: number }>
+  /**
+   * Same as outstanding but restricted to invoices whose `due_date` has
+   * passed (`due_date < today`). Counts remaining balance, not the original
+   * total, so partial payments reduce the number.
+   */
+  overdue: Array<{ currency: string; balanceDueCents: number; count: number }>
+}
+
+export async function getFinanceAggregates(
+  db: PostgresJsDatabase,
+  options: { from?: string; to?: string } = {},
+): Promise<FinanceAggregates> {
+  const fromDate = options.from ? new Date(options.from) : undefined
+  const toDate = options.to ? new Date(options.to) : undefined
+
+  const rangeConditions = []
+  if (fromDate) rangeConditions.push(sql`${invoices.createdAt} >= ${fromDate}`)
+  if (toDate) rangeConditions.push(sql`${invoices.createdAt} < ${toDate}`)
+  const rangeWhere = rangeConditions.length ? and(...rangeConditions) : undefined
+
+  const [totalRow] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(invoices)
+    .where(rangeWhere)
+
+  const statusRows = await db
+    .select({
+      status: invoices.status,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(invoices)
+    .where(rangeWhere)
+    .groupBy(invoices.status)
+
+  const countsByStatusMap = new Map<InvoiceStatus, number>(
+    statusRows.map((row) => [row.status, row.count]),
+  )
+
+  const monthlyInvoiceCountsRows = await db
+    .select({
+      yearMonth: sql<string>`to_char(${invoices.createdAt} at time zone 'UTC', 'YYYY-MM')`,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(invoices)
+    .where(rangeWhere)
+    .groupBy(sql`to_char(${invoices.createdAt} at time zone 'UTC', 'YYYY-MM')`)
+    .orderBy(sql`to_char(${invoices.createdAt} at time zone 'UTC', 'YYYY-MM')`)
+
+  const monthlyRevenueRows = await db
+    .select({
+      yearMonth: sql<string>`to_char(${invoices.createdAt} at time zone 'UTC', 'YYYY-MM')`,
+      currency: invoices.currency,
+      totalCents: sql<number>`coalesce(sum(${invoices.totalCents}), 0)::bigint`,
+    })
+    .from(invoices)
+    .where(and(...(rangeConditions.length ? rangeConditions : []), ne(invoices.status, "void")))
+    .groupBy(sql`to_char(${invoices.createdAt} at time zone 'UTC', 'YYYY-MM')`, invoices.currency)
+    .orderBy(sql`to_char(${invoices.createdAt} at time zone 'UTC', 'YYYY-MM')`, invoices.currency)
+
+  // Outstanding + overdue always look at the whole book (not the date range),
+  // since "what are we owed right now" is a point-in-time question — bounding
+  // it by `from..to` would hide old unpaid invoices.
+  const outstandingRows = await db
+    .select({
+      currency: invoices.currency,
+      balanceDueCents: sql<number>`coalesce(sum(${invoices.balanceDueCents}), 0)::bigint`,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(invoices)
+    .where(
+      and(
+        inArray(invoices.status, [...OUTSTANDING_STATUSES]),
+        sql`${invoices.balanceDueCents} > 0`,
+      ),
+    )
+    .groupBy(invoices.currency)
+    .orderBy(invoices.currency)
+
+  const todayUtc = new Date()
+  todayUtc.setUTCHours(0, 0, 0, 0)
+  const todayDateString = todayUtc.toISOString().slice(0, 10)
+
+  const overdueRows = await db
+    .select({
+      currency: invoices.currency,
+      balanceDueCents: sql<number>`coalesce(sum(${invoices.balanceDueCents}), 0)::bigint`,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(invoices)
+    .where(
+      and(
+        inArray(invoices.status, [...OUTSTANDING_STATUSES]),
+        sql`${invoices.balanceDueCents} > 0`,
+        sql`${invoices.dueDate} < ${todayDateString}`,
+      ),
+    )
+    .groupBy(invoices.currency)
+    .orderBy(invoices.currency)
+
+  return {
+    total: totalRow?.count ?? 0,
+    countsByStatus: ALL_INVOICE_STATUSES.map((status) => ({
+      status,
+      count: countsByStatusMap.get(status) ?? 0,
+    })),
+    monthlyRevenue: monthlyRevenueRows.map((row) => ({
+      yearMonth: row.yearMonth,
+      currency: row.currency,
+      totalCents: Number(row.totalCents),
+    })),
+    monthlyInvoiceCounts: monthlyInvoiceCountsRows.map((row) => ({
+      yearMonth: row.yearMonth,
+      count: row.count,
+    })),
+    outstanding: outstandingRows.map((row) => ({
+      currency: row.currency,
+      balanceDueCents: Number(row.balanceDueCents),
+      count: row.count,
+    })),
+    overdue: overdueRows.map((row) => ({
+      currency: row.currency,
+      balanceDueCents: Number(row.balanceDueCents),
+      count: row.count,
+    })),
+  }
+}

--- a/packages/finance/src/service.ts
+++ b/packages/finance/src/service.ts
@@ -26,6 +26,7 @@ import {
   supplierPayments,
   taxRegimes,
 } from "./schema.js"
+import { getFinanceAggregates } from "./service-aggregates.js"
 import { vouchersService } from "./service-vouchers.js"
 import type {
   agingReportQuerySchema,
@@ -279,6 +280,8 @@ async function paginate<T extends object>(
 
 export const financeService = {
   vouchers: vouchersService,
+  getFinanceAggregates,
+
   async listPaymentInstruments(db: PostgresJsDatabase, query: PaymentInstrumentListQuery) {
     const conditions = []
     if (query.ownerType) conditions.push(eq(paymentInstruments.ownerType, query.ownerType))

--- a/packages/finance/src/validation-shared.ts
+++ b/packages/finance/src/validation-shared.ts
@@ -140,3 +140,8 @@ export const voucherSourceTypeSchema = z.enum([
   "manual",
   "promo",
 ])
+
+export const financeAggregatesQuerySchema = z.object({
+  from: z.string().datetime().optional(),
+  to: z.string().datetime().optional(),
+})

--- a/packages/finance/tests/unit/finance-aggregates-query.test.ts
+++ b/packages/finance/tests/unit/finance-aggregates-query.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+
+import { financeAggregatesQuerySchema } from "../../src/validation-shared.js"
+
+describe("financeAggregatesQuerySchema", () => {
+  it("accepts an empty object", () => {
+    const result = financeAggregatesQuerySchema.parse({})
+    expect(result.from).toBeUndefined()
+    expect(result.to).toBeUndefined()
+  })
+
+  it("accepts ISO datetime bounds", () => {
+    const result = financeAggregatesQuerySchema.parse({
+      from: "2026-01-01T00:00:00.000Z",
+      to: "2026-04-01T00:00:00.000Z",
+    })
+    expect(result.from).toBe("2026-01-01T00:00:00.000Z")
+    expect(result.to).toBe("2026-04-01T00:00:00.000Z")
+  })
+
+  it("rejects non-datetime strings", () => {
+    expect(() => financeAggregatesQuerySchema.parse({ from: "yesterday" })).toThrow()
+    expect(() => financeAggregatesQuerySchema.parse({ from: "2026-01-01" })).toThrow()
+  })
+})


### PR DESCRIPTION
## Summary
Second slice of #217 — after bookings aggregates (#236), this brings invoice-side KPIs onto the same first-class read surface. Replaces the dashboard pattern of fetching a `limit=200` invoice page and deriving "how much are we owed" client-side — incomplete once the dataset grows past the page cap, and every app disagreed on which statuses count.

`financeService.getFinanceAggregates(db, { from?, to? })` returns:

- `total` — invoices in range (all statuses)
- `countsByStatus[]` — one row per status, stable shape with zero counts included
- `monthlyRevenue[]` — UTC yearMonth + currency + `totalCents` (void excluded)
- `monthlyInvoiceCounts[]` — count per UTC yearMonth, all statuses
- `outstanding[]` — `sum(balanceDueCents)` + count per currency, status ∈ {`sent`, `partially_paid`, `overdue`} and `balance_due_cents > 0`. **Point-in-time — NOT bounded by `from..to`**, since "what are we owed right now" must include old unpaid invoices.
- `overdue[]` — same as `outstanding` but `due_date < today`. Uses the remaining balance so partial payments already reduce the number.

Route: `GET /v1/admin/finance/aggregates` (before any `/:id` risk).

Shape mirrors the bookings endpoint (yearMonth + currency grouping, stable counts-by-status, optional range bounds) so one dashboard hook can consume both without branching per module.

### Out of scope — remaining #217 slices
Products aggregates (active product count, recently-published series), suppliers aggregates (supplier count, confirmation status breakdown), availability aggregates (upcoming-departures counters). All follow the same `service-aggregates.ts` pattern.

## Test plan
- [x] `pnpm -F @voyantjs/finance typecheck`
- [x] `pnpm -F @voyantjs/finance test` — 42 passing, 3 new around the aggregates query schema (empty, ISO datetime bounds, rejection of non-datetime strings).
- [x] `pnpm typecheck` — 136/136 tasks clean.
- [ ] Smoke against a seeded DB: `GET /v1/admin/finance/aggregates` numbers match the invoice list for the same date range, and `outstanding` picks up older unpaid invoices regardless of the `from`/`to` bounds.