### PR TITLE
feat: products/suppliers/availability aggregates endpoints

### DIFF
--- a/packages/availability/src/routes-core.ts
+++ b/packages/availability/src/routes-core.ts
@@ -10,6 +10,7 @@ import {
 } from "./routes-shared.js"
 import { availabilityService } from "./service.js"
 import {
+  availabilityAggregatesQuerySchema,
   availabilityCloseoutListQuerySchema,
   availabilityRuleListQuerySchema,
   availabilitySlotListQuerySchema,
@@ -34,6 +35,12 @@ const batchUpdateAvailabilityCloseoutSchema = createBatchUpdateSchema(
 )
 
 export const availabilityCoreRoutes = new Hono<Env>()
+  .get("/aggregates", async (c) => {
+    const query = await parseQuery(c, availabilityAggregatesQuerySchema)
+    return c.json({
+      data: await availabilityService.getAvailabilityAggregates(c.get("db"), query),
+    })
+  })
   .get("/rules", async (c) => {
     const query = await parseQuery(c, availabilityRuleListQuerySchema)
     return c.json(await availabilityService.listRules(c.get("db"), query))

--- a/packages/availability/src/service-aggregates.ts
+++ b/packages/availability/src/service-aggregates.ts
@@ -1,0 +1,94 @@
+import { and, eq, gte, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { availabilitySlots } from "./schema.js"
+
+type SlotStatus = (typeof availabilitySlots.$inferSelect)["status"]
+
+const ALL_SLOT_STATUSES: readonly SlotStatus[] = ["open", "closed", "sold_out", "cancelled"]
+
+export interface AvailabilityAggregates {
+  /** Total slots in the (optional) `startsAt` range. */
+  total: number
+  countsByStatus: Array<{ status: SlotStatus; count: number }>
+  /**
+   * Open slots from `now` forward, irrespective of the `from..to` range.
+   * Point-in-time KPI — operator's "how many departures are still sellable".
+   */
+  upcomingSlots: number
+  /**
+   * Sum of `remaining_pax` across the same `upcomingSlots` set, excluding
+   * slots flagged `unlimited` (they'd inflate the number to meaningless
+   * without a reasonable cap).
+   */
+  upcomingPax: number
+  /**
+   * Departure count bucketed by `starts_at` UTC yearMonth (within the range
+   * when set). Counts every non-cancelled slot so inventory that went
+   * sold-out still appears on the calendar.
+   */
+  monthlyDepartures: Array<{ yearMonth: string; count: number }>
+}
+
+export async function getAvailabilityAggregates(
+  db: PostgresJsDatabase,
+  options: { from?: string; to?: string } = {},
+): Promise<AvailabilityAggregates> {
+  const fromDate = options.from ? new Date(options.from) : undefined
+  const toDate = options.to ? new Date(options.to) : undefined
+
+  // Availability aggregates are anchored on `starts_at` (when the departure
+  // actually happens), not `created_at` — dashboard users think in terms of
+  // the calendar, not when the slot was provisioned.
+  const rangeConditions = []
+  if (fromDate) rangeConditions.push(sql`${availabilitySlots.startsAt} >= ${fromDate}`)
+  if (toDate) rangeConditions.push(sql`${availabilitySlots.startsAt} < ${toDate}`)
+  const rangeWhere = rangeConditions.length ? and(...rangeConditions) : undefined
+
+  const [totalRow] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(availabilitySlots)
+    .where(rangeWhere)
+
+  const statusRows = await db
+    .select({ status: availabilitySlots.status, count: sql<number>`count(*)::int` })
+    .from(availabilitySlots)
+    .where(rangeWhere)
+    .groupBy(availabilitySlots.status)
+
+  const statusMap = new Map<SlotStatus, number>(statusRows.map((r) => [r.status, r.count]))
+
+  const now = new Date()
+
+  const [upcomingRow] = await db
+    .select({
+      count: sql<number>`count(*)::int`,
+      pax: sql<number>`coalesce(sum(case when ${availabilitySlots.unlimited} then 0 else coalesce(${availabilitySlots.remainingPax}, 0) end), 0)::bigint`,
+    })
+    .from(availabilitySlots)
+    .where(and(eq(availabilitySlots.status, "open"), gte(availabilitySlots.startsAt, now)))
+
+  const monthlyDeparturesRows = await db
+    .select({
+      yearMonth: sql<string>`to_char(${availabilitySlots.startsAt} at time zone 'UTC', 'YYYY-MM')`,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(availabilitySlots)
+    .where(rangeWhere)
+    .groupBy(sql`to_char(${availabilitySlots.startsAt} at time zone 'UTC', 'YYYY-MM')`)
+    .orderBy(sql`to_char(${availabilitySlots.startsAt} at time zone 'UTC', 'YYYY-MM')`)
+
+  return {
+    total: totalRow?.count ?? 0,
+    countsByStatus: ALL_SLOT_STATUSES.map((status) => ({
+      status,
+      count: statusMap.get(status) ?? 0,
+    })),
+    upcomingSlots: upcomingRow?.count ?? 0,
+    upcomingPax: Number(upcomingRow?.pax ?? 0),
+    monthlyDepartures: monthlyDeparturesRows.map((row) => ({
+      yearMonth: row.yearMonth,
+      count: row.count,
+    })),
+  }
+}

--- a/packages/availability/src/service.ts
+++ b/packages/availability/src/service.ts
@@ -1,3 +1,4 @@
+import { getAvailabilityAggregates } from "./service-aggregates.js"
 import {
   createCloseout,
   createRule,
@@ -61,6 +62,7 @@ import { getSlotUnitAvailability } from "./service-unit-availability.js"
 
 export const availabilityService = {
   getSlotUnitAvailability,
+  getAvailabilityAggregates,
   listRules,
   getRuleById,
   createRule,

--- a/packages/availability/src/validation.ts
+++ b/packages/availability/src/validation.ts
@@ -95,6 +95,11 @@ export const availabilitySlotListQuerySchema = paginationSchema.extend({
   status: availabilitySlotStatusSchema.optional(),
 })
 
+export const availabilityAggregatesQuerySchema = z.object({
+  from: z.string().datetime().optional(),
+  to: z.string().datetime().optional(),
+})
+
 export const availabilityCloseoutCoreSchema = z.object({
   productId: z.string(),
   slotId: z.string().nullable().optional(),

--- a/packages/availability/tests/unit/aggregates-query.test.ts
+++ b/packages/availability/tests/unit/aggregates-query.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+
+import { availabilityAggregatesQuerySchema } from "../../src/validation.js"
+
+describe("availabilityAggregatesQuerySchema", () => {
+  it("accepts an empty object", () => {
+    const result = availabilityAggregatesQuerySchema.parse({})
+    expect(result.from).toBeUndefined()
+    expect(result.to).toBeUndefined()
+  })
+
+  it("accepts ISO datetime bounds", () => {
+    const result = availabilityAggregatesQuerySchema.parse({
+      from: "2026-01-01T00:00:00.000Z",
+      to: "2026-04-01T00:00:00.000Z",
+    })
+    expect(result.from).toBe("2026-01-01T00:00:00.000Z")
+  })
+
+  it("rejects non-datetime strings", () => {
+    expect(() => availabilityAggregatesQuerySchema.parse({ from: "yesterday" })).toThrow()
+  })
+})

--- a/packages/products/src/routes.ts
+++ b/packages/products/src/routes.ts
@@ -37,6 +37,7 @@ import {
   optionUnitListQuerySchema,
   optionUnitTranslationListQuerySchema,
   productActivationSettingListQuerySchema,
+  productAggregatesQuerySchema,
   productCapabilityListQuerySchema,
   productCategoryListQuerySchema,
   productDeliveryFormatListQuerySchema,
@@ -92,6 +93,12 @@ type Env = {
 // ==========================================================================
 
 export const productRoutes = new Hono<Env>()
+
+  // GET /aggregates — dashboard KPIs (before /:id so the matcher doesn't swallow it)
+  .get("/aggregates", async (c) => {
+    const query = parseQuery(c, productAggregatesQuerySchema)
+    return c.json({ data: await productsService.getProductAggregates(c.get("db"), query) })
+  })
 
   // GET / — List products
   .get("/", async (c) => {

--- a/packages/products/src/service-aggregates.ts
+++ b/packages/products/src/service-aggregates.ts
@@ -1,0 +1,88 @@
+import { and, eq, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { products } from "./schema-core.js"
+
+type ProductStatus = (typeof products.$inferSelect)["status"]
+
+const ALL_PRODUCT_STATUSES: readonly ProductStatus[] = ["draft", "active", "archived"]
+
+export interface ProductAggregates {
+  total: number
+  countsByStatus: Array<{ status: ProductStatus; count: number }>
+  /** Shorthand for the `active` bucket — dashboard KPI card. */
+  active: number
+  /**
+   * Products publicly listed on the storefront: `status = active` AND
+   * `activated = true` AND `visibility = 'public'`. Distinct from `active`,
+   * which includes internal-only active products.
+   */
+  publicActive: number
+  /** Product creation count bucketed by UTC yearMonth, oldest first. */
+  monthlyCreatedCounts: Array<{ yearMonth: string; count: number }>
+}
+
+export async function getProductAggregates(
+  db: PostgresJsDatabase,
+  options: { from?: string; to?: string } = {},
+): Promise<ProductAggregates> {
+  const fromDate = options.from ? new Date(options.from) : undefined
+  const toDate = options.to ? new Date(options.to) : undefined
+
+  const rangeConditions = []
+  if (fromDate) rangeConditions.push(sql`${products.createdAt} >= ${fromDate}`)
+  if (toDate) rangeConditions.push(sql`${products.createdAt} < ${toDate}`)
+  const rangeWhere = rangeConditions.length ? and(...rangeConditions) : undefined
+
+  const [totalRow] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(products)
+    .where(rangeWhere)
+
+  const statusRows = await db
+    .select({ status: products.status, count: sql<number>`count(*)::int` })
+    .from(products)
+    .where(rangeWhere)
+    .groupBy(products.status)
+
+  const statusMap = new Map<ProductStatus, number>(statusRows.map((r) => [r.status, r.count]))
+
+  // Publicly-listed count ignores the date range — it's a point-in-time KPI
+  // ("what's live on the storefront right now"). The range-bound `active`
+  // bucket serves the "how many active products did we create this quarter"
+  // question instead.
+  const [publicActiveRow] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(products)
+    .where(
+      and(
+        eq(products.status, "active"),
+        eq(products.activated, true),
+        eq(products.visibility, "public"),
+      ),
+    )
+
+  const monthlyCreatedCountsRows = await db
+    .select({
+      yearMonth: sql<string>`to_char(${products.createdAt} at time zone 'UTC', 'YYYY-MM')`,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(products)
+    .where(rangeWhere)
+    .groupBy(sql`to_char(${products.createdAt} at time zone 'UTC', 'YYYY-MM')`)
+    .orderBy(sql`to_char(${products.createdAt} at time zone 'UTC', 'YYYY-MM')`)
+
+  return {
+    total: totalRow?.count ?? 0,
+    countsByStatus: ALL_PRODUCT_STATUSES.map((status) => ({
+      status,
+      count: statusMap.get(status) ?? 0,
+    })),
+    active: statusMap.get("active") ?? 0,
+    publicActive: publicActiveRow?.count ?? 0,
+    monthlyCreatedCounts: monthlyCreatedCountsRows.map((row) => ({
+      yearMonth: row.yearMonth,
+      count: row.count,
+    })),
+  }
+}

--- a/packages/products/src/service.ts
+++ b/packages/products/src/service.ts
@@ -32,6 +32,7 @@ import {
   productVersions,
   productVisibilitySettings,
 } from "./schema.js"
+import { getProductAggregates } from "./service-aggregates.js"
 import type {
   destinationListQuerySchema,
   destinationTranslationListQuerySchema,
@@ -312,6 +313,8 @@ async function promoteFallbackItinerary(db: PostgresJsDatabase, productId: strin
 }
 
 export const productsService = {
+  getProductAggregates,
+
   async listProducts(db: PostgresJsDatabase, query: ProductListQuery) {
     const conditions = []
 

--- a/packages/products/src/validation-core.ts
+++ b/packages/products/src/validation-core.ts
@@ -55,6 +55,11 @@ export const productListQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(50),
   offset: z.coerce.number().int().min(0).default(0),
 })
+
+export const productAggregatesQuerySchema = z.object({
+  from: z.string().datetime().optional(),
+  to: z.string().datetime().optional(),
+})
 export type InsertProduct = z.infer<typeof insertProductSchema>
 export type UpdateProduct = z.infer<typeof updateProductSchema>
 export type SelectProduct = z.infer<typeof selectProductSchema>

--- a/packages/products/tests/unit/aggregates-query.test.ts
+++ b/packages/products/tests/unit/aggregates-query.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+
+import { productAggregatesQuerySchema } from "../../src/validation-core.js"
+
+describe("productAggregatesQuerySchema", () => {
+  it("accepts an empty object", () => {
+    const result = productAggregatesQuerySchema.parse({})
+    expect(result.from).toBeUndefined()
+    expect(result.to).toBeUndefined()
+  })
+
+  it("accepts ISO datetime bounds", () => {
+    const result = productAggregatesQuerySchema.parse({
+      from: "2026-01-01T00:00:00.000Z",
+      to: "2026-04-01T00:00:00.000Z",
+    })
+    expect(result.from).toBe("2026-01-01T00:00:00.000Z")
+    expect(result.to).toBe("2026-04-01T00:00:00.000Z")
+  })
+
+  it("rejects non-datetime strings", () => {
+    expect(() => productAggregatesQuerySchema.parse({ from: "yesterday" })).toThrow()
+  })
+})

--- a/packages/suppliers/src/routes.ts
+++ b/packages/suppliers/src/routes.ts
@@ -20,6 +20,7 @@ import {
   insertServiceSchema,
   insertSupplierNoteSchema,
   insertSupplierSchema,
+  supplierAggregatesQuerySchema,
   supplierListQuerySchema,
   updateContractSchema,
   updateRateSchema,
@@ -39,6 +40,16 @@ type Env = {
 // ==========================================================================
 
 export const supplierRoutes = new Hono<Env>()
+
+  // ========================================================================
+  // Dashboard aggregates
+  // ========================================================================
+
+  // GET /aggregates — dashboard KPIs (before /:id so the matcher doesn't swallow it)
+  .get("/aggregates", async (c) => {
+    const query = parseQuery(c, supplierAggregatesQuerySchema)
+    return c.json({ data: await suppliersService.getSupplierAggregates(c.get("db"), query) })
+  })
 
   // ========================================================================
   // Suppliers CRUD

--- a/packages/suppliers/src/service-aggregates.ts
+++ b/packages/suppliers/src/service-aggregates.ts
@@ -1,0 +1,72 @@
+import { and, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { suppliers } from "./schema.js"
+
+type SupplierStatus = (typeof suppliers.$inferSelect)["status"]
+type SupplierType = (typeof suppliers.$inferSelect)["type"]
+
+const ALL_SUPPLIER_STATUSES: readonly SupplierStatus[] = ["active", "inactive", "pending"]
+const ALL_SUPPLIER_TYPES: readonly SupplierType[] = [
+  "hotel",
+  "transfer",
+  "guide",
+  "experience",
+  "airline",
+  "restaurant",
+  "other",
+]
+
+export interface SupplierAggregates {
+  total: number
+  countsByStatus: Array<{ status: SupplierStatus; count: number }>
+  countsByType: Array<{ type: SupplierType; count: number }>
+  /** Shorthand for the `active` bucket — dashboard KPI card. */
+  active: number
+}
+
+export async function getSupplierAggregates(
+  db: PostgresJsDatabase,
+  options: { from?: string; to?: string } = {},
+): Promise<SupplierAggregates> {
+  const fromDate = options.from ? new Date(options.from) : undefined
+  const toDate = options.to ? new Date(options.to) : undefined
+
+  const rangeConditions = []
+  if (fromDate) rangeConditions.push(sql`${suppliers.createdAt} >= ${fromDate}`)
+  if (toDate) rangeConditions.push(sql`${suppliers.createdAt} < ${toDate}`)
+  const rangeWhere = rangeConditions.length ? and(...rangeConditions) : undefined
+
+  const [totalRow] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(suppliers)
+    .where(rangeWhere)
+
+  const statusRows = await db
+    .select({ status: suppliers.status, count: sql<number>`count(*)::int` })
+    .from(suppliers)
+    .where(rangeWhere)
+    .groupBy(suppliers.status)
+
+  const typeRows = await db
+    .select({ type: suppliers.type, count: sql<number>`count(*)::int` })
+    .from(suppliers)
+    .where(rangeWhere)
+    .groupBy(suppliers.type)
+
+  const statusMap = new Map<SupplierStatus, number>(statusRows.map((r) => [r.status, r.count]))
+  const typeMap = new Map<SupplierType, number>(typeRows.map((r) => [r.type, r.count]))
+
+  return {
+    total: totalRow?.count ?? 0,
+    countsByStatus: ALL_SUPPLIER_STATUSES.map((status) => ({
+      status,
+      count: statusMap.get(status) ?? 0,
+    })),
+    countsByType: ALL_SUPPLIER_TYPES.map((type) => ({
+      type,
+      count: typeMap.get(type) ?? 0,
+    })),
+    active: statusMap.get("active") ?? 0,
+  }
+}

--- a/packages/suppliers/src/service.ts
+++ b/packages/suppliers/src/service.ts
@@ -1,3 +1,4 @@
+import { getSupplierAggregates } from "./service-aggregates.js"
 import {
   createSupplier,
   deleteSupplier,
@@ -39,6 +40,7 @@ import {
 } from "./service-operations.js"
 
 export const suppliersService = {
+  getSupplierAggregates,
   listSuppliers,
   getSupplierById,
   createSupplier,

--- a/packages/suppliers/src/validation.ts
+++ b/packages/suppliers/src/validation.ts
@@ -63,6 +63,11 @@ export const supplierListQuerySchema = z.object({
   offset: z.coerce.number().int().min(0).default(0),
 })
 
+export const supplierAggregatesQuerySchema = z.object({
+  from: z.string().datetime().optional(),
+  to: z.string().datetime().optional(),
+})
+
 export type InsertSupplier = z.infer<typeof insertSupplierSchema>
 export type UpdateSupplier = z.infer<typeof updateSupplierSchema>
 export type SelectSupplier = z.infer<typeof selectSupplierSchema>

--- a/packages/suppliers/tests/unit/aggregates-query.test.ts
+++ b/packages/suppliers/tests/unit/aggregates-query.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+
+import { supplierAggregatesQuerySchema } from "../../src/validation.js"
+
+describe("supplierAggregatesQuerySchema", () => {
+  it("accepts an empty object", () => {
+    const result = supplierAggregatesQuerySchema.parse({})
+    expect(result.from).toBeUndefined()
+    expect(result.to).toBeUndefined()
+  })
+
+  it("accepts ISO datetime bounds", () => {
+    const result = supplierAggregatesQuerySchema.parse({
+      from: "2026-01-01T00:00:00.000Z",
+      to: "2026-04-01T00:00:00.000Z",
+    })
+    expect(result.from).toBe("2026-01-01T00:00:00.000Z")
+  })
+
+  it("rejects non-datetime strings", () => {
+    expect(() => supplierAggregatesQuerySchema.parse({ from: "yesterday" })).toThrow()
+  })
+})


### PR DESCRIPTION
## Summary
Closes out **#217**. Same shape as bookings (#236) and finance (#242) aggregates, applied to the remaining three modules called out in the issue: product count, supplier count, upcoming departures.

### `GET /v1/admin/products/aggregates`
- `total`
- `countsByStatus[]` — draft / active / archived, zero-filled
- `active` — shorthand for the `active` bucket
- `publicActive` — `status=active AND activated=true AND visibility=public`. Point-in-time (ignores `from..to`) since "what's live on the storefront right now" must include everything, not just recent.
- `monthlyCreatedCounts[]` — UTC yearMonth, range-bounded

### `GET /v1/admin/suppliers/aggregates`
- `total`
- `countsByStatus[]` — active / inactive / pending, zero-filled
- `countsByType[]` — hotel / transfer / guide / experience / airline / restaurant / other, zero-filled
- `active` — shorthand

### `GET /v1/admin/availability/aggregates`
Anchored on `starts_at` instead of `created_at` — dashboard users think in calendar dates, not provisioning dates.

- `total` — slots in the range
- `countsByStatus[]` — open / closed / sold_out / cancelled, zero-filled
- `upcomingSlots` — point-in-time: `status=open AND starts_at >= now`
- `upcomingPax` — `sum(remaining_pax)` over `upcomingSlots`, excluding `unlimited=true` rows so the number stays meaningful
- `monthlyDepartures[]` — slot count per UTC yearMonth (range-bounded)

Each module gets a `service-aggregates.ts` sibling file, a route before its `/:id` matcher, and a small `*AggregatesQuerySchema` unit test for the from/to bounds. Follow-ups can add `-react` hooks if a dashboard wants first-class query options; all four endpoints now share the same shape.

Closes #217.

## Test plan
- [x] `pnpm -F @voyantjs/products -F @voyantjs/suppliers -F @voyantjs/availability typecheck` / `test` — 3 new schema tests per package, all green.
- [x] `pnpm typecheck` — 136/136 tasks clean.
- [ ] Smoke against a seeded DB: the four `/aggregates` endpoints return consistent shapes across modules — yearMonth + currency/status buckets zero-filled, and point-in-time fields (`upcomingPax`, `publicActive`, `outstanding`) independent of `from`/`to`.