### PR TITLE
feat(bookings): emit booking.confirmed event on status transition

### DIFF
--- a/packages/bookings/src/routes-shared.ts
+++ b/packages/bookings/src/routes-shared.ts
@@ -1,4 +1,4 @@
-import type { ModuleContainer } from "@voyantjs/core"
+import type { EventBus, ModuleContainer } from "@voyantjs/core"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
 
@@ -27,6 +27,7 @@ export type Env = {
   Variables: {
     container?: ModuleContainer
     db: PostgresJsDatabase
+    eventBus?: EventBus
     userId?: string
     actor?: "staff" | "customer" | "partner" | "supplier"
     callerType?: "session" | "api_key" | "internal"

--- a/packages/bookings/src/routes.ts
+++ b/packages/bookings/src/routes.ts
@@ -450,6 +450,7 @@ export const bookingRoutes = new Hono<Env>()
       c.req.param("id"),
       await parseJsonBody(c, updateBookingStatusSchema),
       c.get("userId"),
+      { eventBus: c.get("eventBus") },
     )
 
     if (result.status === "not_found") {
@@ -474,6 +475,7 @@ export const bookingRoutes = new Hono<Env>()
       c.req.param("id"),
       await parseJsonBody(c, confirmBookingSchema),
       c.get("userId"),
+      { eventBus: c.get("eventBus") },
     )
 
     if (result.status === "not_found") {

--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -1,3 +1,4 @@
+import type { EventBus } from "@voyantjs/core"
 import { and, asc, desc, eq, exists, ilike, inArray, lte, ne, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
@@ -139,6 +140,25 @@ export interface ConvertProductData {
 
 type ProductOptionReference = typeof productOptionsRef.$inferSelect
 type OptionUnitReference = typeof optionUnitsRef.$inferSelect
+
+/**
+ * Optional runtime hooks for status-transition flows. Keeps the service
+ * decoupled from delivery concerns — bookings only has to emit, never know
+ * what listens.
+ */
+export interface BookingServiceRuntime {
+  eventBus?: EventBus
+}
+
+/**
+ * Payload shape for `booking.confirmed`. Subscribers should treat unknown
+ * fields as forward-compatible additions.
+ */
+export interface BookingConfirmedEvent {
+  bookingId: string
+  bookingNumber: string
+  actorId: string | null
+}
 
 const travelerParticipantTypes = ["traveler", "occupant"] as const
 
@@ -1953,6 +1973,7 @@ export const bookingsService = {
     id: string,
     data: UpdateBookingStatusInput,
     userId?: string,
+    runtime: BookingServiceRuntime = {},
   ) {
     const [current] = await db
       .select({ id: bookings.id, status: bookings.status })
@@ -1965,7 +1986,7 @@ export const bookingsService = {
     }
 
     if (current.status === "on_hold" && data.status === "confirmed") {
-      return bookingsService.confirmBooking(db, id, { note: data.note }, userId)
+      return bookingsService.confirmBooking(db, id, { note: data.note }, userId, runtime)
     }
 
     if (current.status === "on_hold" && data.status === "expired") {
@@ -2022,9 +2043,10 @@ export const bookingsService = {
     id: string,
     data: ConfirmBookingInput,
     userId?: string,
+    runtime: BookingServiceRuntime = {},
   ) {
     try {
-      return await db.transaction(async (tx) => {
+      const result = await db.transaction(async (tx) => {
         const rows = await tx.execute(
           sql`SELECT id, booking_number, status, hold_expires_at
               FROM ${bookings}
@@ -2095,6 +2117,23 @@ export const bookingsService = {
 
         return { status: "ok" as const, booking: row ?? null }
       })
+
+      // Emit AFTER the transaction commits so subscribers can't observe a
+      // confirmed state that might still roll back. `emit` is fire-and-forget
+      // per the EventBus contract — subscriber errors are logged, not rethrown.
+      if (result.status === "ok" && result.booking) {
+        await runtime.eventBus?.emit(
+          "booking.confirmed",
+          {
+            bookingId: result.booking.id,
+            bookingNumber: result.booking.bookingNumber,
+            actorId: userId ?? null,
+          } satisfies BookingConfirmedEvent,
+          { category: "domain", source: "service" },
+        )
+      }
+
+      return result
     } catch (error) {
       if (error instanceof BookingServiceError) {
         return { status: error.code as Exclude<string, "ok"> }

--- a/packages/bookings/tests/integration/routes.test.ts
+++ b/packages/bookings/tests/integration/routes.test.ts
@@ -54,6 +54,7 @@ const originalKmsEnvKey = process.env.KMS_ENV_KEY
 describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
   let app: Hono
   let db: ReturnType<typeof import("@voyantjs/db/test-utils").createTestDb>
+  let eventBus: ReturnType<typeof import("@voyantjs/core").createEventBus>
 
   beforeAll(async () => {
     const { createTestDb, cleanupTestDb } = await import("@voyantjs/db/test-utils")
@@ -107,9 +108,13 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
     process.env.KMS_PROVIDER = "env"
     process.env.KMS_ENV_KEY = generateEnvKmsKey()
 
+    const { createEventBus } = await import("@voyantjs/core")
+    eventBus = createEventBus()
+
     app = new Hono()
     app.use("*", async (c, next) => {
       c.set("db" as never, db)
+      c.set("eventBus" as never, eventBus)
       c.set("userId" as never, "test-user-id")
       c.set("actor" as never, "staff")
       await next()
@@ -697,6 +702,70 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
 
       expect(res.status).toBe(200)
       expect((await res.json()).data.status).toBe("confirmed")
+    })
+
+    it("emits booking.confirmed with id + number + actor after confirm", async () => {
+      const slot = await seedSlot()
+      const reserveRes = await app.request("/reserve", {
+        method: "POST",
+        ...json({
+          bookingNumber: nextBookingNumber(),
+          sellCurrency: "USD",
+          items: [{ title: "Adult ticket", availabilitySlotId: slot.id, quantity: 1 }],
+        }),
+      })
+      const { data: booking } = await reserveRes.json()
+
+      const received: Array<{
+        bookingId: string
+        bookingNumber: string
+        actorId: string | null
+      }> = []
+      const sub = eventBus.subscribe("booking.confirmed", (event) => {
+        received.push(
+          event.data as { bookingId: string; bookingNumber: string; actorId: string | null },
+        )
+      })
+
+      try {
+        const res = await app.request(`/${booking.id}/confirm`, {
+          method: "POST",
+          ...json({}),
+        })
+        expect(res.status).toBe(200)
+      } finally {
+        sub.unsubscribe()
+      }
+
+      expect(received).toHaveLength(1)
+      expect(received[0]).toMatchObject({
+        bookingId: booking.id,
+        bookingNumber: booking.bookingNumber,
+        actorId: "test-user-id",
+      })
+    })
+
+    it("does not emit booking.confirmed when the transition fails", async () => {
+      // Booking starts in "draft" from POST / — the confirm route rejects it
+      // with invalid_transition, and no event should fire.
+      const draft = await seedBooking()
+
+      const received: unknown[] = []
+      const sub = eventBus.subscribe("booking.confirmed", (event) => {
+        received.push(event.data)
+      })
+
+      try {
+        const res = await app.request(`/${draft.id}/confirm`, {
+          method: "POST",
+          ...json({}),
+        })
+        expect(res.status).toBe(409)
+      } finally {
+        sub.unsubscribe()
+      }
+
+      expect(received).toHaveLength(0)
     })
 
     it("extends an on-hold booking", async () => {


### PR DESCRIPTION
## Summary
Second slice of #228. The confirm-and-dispatch endpoint from #240 is the *on-demand* entry point; this adds the event hook that lets templates auto-run it when a booking transitions `draft`/`on_hold` → `confirmed` — instead of requiring an explicit operator click.

### Wiring
- `bookingsService.confirmBooking` and `updateBookingStatus` accept an optional `runtime: { eventBus? }` arg. Additive — existing callers keep compiling.
- After the transaction commits, `confirmBooking` emits `booking.confirmed` with `{ bookingId, bookingNumber, actorId }` and `{ category: "domain", source: "service" }`. **Emitted after commit** so subscribers can't observe a confirmed state that might still roll back. Fire-and-forget per the EventBus contract — subscriber errors are logged, not rethrown into the route.
- `BookingConfirmedEvent` + `BookingServiceRuntime` are exported from the service so template subscribers can type their handlers.
- Route handlers (`POST /:id/confirm`, `PATCH /:id/status`) forward `c.var.eventBus` — populated by `createApp`'s global middleware from #230.
- `Env.Variables.eventBus?: EventBus` added to the shared route env.

### Template integration pattern
```ts
app.eventBus.subscribe("booking.confirmed", async (event) => {
  await notificationsService.confirmAndDispatchBooking(
    db, dispatcher, event.data.bookingId,
    { templateSlug: "booking-confirmation" },
    { attachmentResolver, eventBus: app.eventBus },
  )
})
```

Gated by template config (the `autoRun` flag from the #228 issue body).

### Out of scope
- Template-side subscriber wiring (operator template config + `bookingConfirmation` block in `voyant.config.ts`) — follow-up PR.
- `booking.cancelled` / `booking.expired` — same pattern, separate PRs so each transition's emission landing is independently reviewable.

Related to #228.

## Test plan
- [x] `pnpm -F @voyantjs/bookings typecheck`
- [x] `pnpm -F @voyantjs/bookings test` — 105 passing. Two new integration tests (skipped without `TEST_DATABASE_URL`):
  - "emits booking.confirmed with id + number + actor after confirm" — subscribes before the route call, asserts the payload shape.
  - "does not emit booking.confirmed when the transition fails" — draft → confirmed directly (without reserve) returns 409 and no event fires.
- [x] `pnpm typecheck` — 136/136 tasks clean.
- [ ] Smoke against a running operator template: subscribe a log handler to `app.eventBus`, confirm a reserved booking, see the payload in the log.