### PR TITLE
feat(notifications): auto-dispatch subscriber for booking.confirmed

### DIFF
--- a/packages/bookings/src/routes-shared.ts
+++ b/packages/bookings/src/routes-shared.ts
@@ -1,4 +1,4 @@
-import type { ModuleContainer } from "@voyantjs/core"
+import type { EventBus, ModuleContainer } from "@voyantjs/core"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
 
@@ -27,6 +27,7 @@ export type Env = {
   Variables: {
     container?: ModuleContainer
     db: PostgresJsDatabase
+    eventBus?: EventBus
     userId?: string
     actor?: "staff" | "customer" | "partner" | "supplier"
     callerType?: "session" | "api_key" | "internal"

--- a/packages/bookings/src/routes.ts
+++ b/packages/bookings/src/routes.ts
@@ -436,6 +436,7 @@ export const bookingRoutes = new Hono<Env>()
       c.req.param("id"),
       await parseJsonBody(c, updateBookingStatusSchema),
       c.get("userId"),
+      { eventBus: c.get("eventBus") },
     )
 
     if (result.status === "not_found") {
@@ -460,6 +461,7 @@ export const bookingRoutes = new Hono<Env>()
       c.req.param("id"),
       await parseJsonBody(c, confirmBookingSchema),
       c.get("userId"),
+      { eventBus: c.get("eventBus") },
     )
 
     if (result.status === "not_found") {

--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -1,3 +1,4 @@
+import type { EventBus } from "@voyantjs/core"
 import { and, asc, desc, eq, ilike, inArray, lte, ne, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
@@ -127,6 +128,25 @@ export interface ConvertProductData {
 
 type ProductOptionReference = typeof productOptionsRef.$inferSelect
 type OptionUnitReference = typeof optionUnitsRef.$inferSelect
+
+/**
+ * Optional runtime hooks for status-transition flows. Keeps the service
+ * decoupled from delivery concerns — bookings only has to emit, never know
+ * what listens.
+ */
+export interface BookingServiceRuntime {
+  eventBus?: EventBus
+}
+
+/**
+ * Payload shape for `booking.confirmed`. Subscribers should treat unknown
+ * fields as forward-compatible additions.
+ */
+export interface BookingConfirmedEvent {
+  bookingId: string
+  bookingNumber: string
+  actorId: string | null
+}
 
 const travelerParticipantTypes = ["traveler", "occupant"] as const
 
@@ -1858,6 +1878,7 @@ export const bookingsService = {
     id: string,
     data: UpdateBookingStatusInput,
     userId?: string,
+    runtime: BookingServiceRuntime = {},
   ) {
     const [current] = await db
       .select({ id: bookings.id, status: bookings.status })
@@ -1870,7 +1891,7 @@ export const bookingsService = {
     }
 
     if (current.status === "on_hold" && data.status === "confirmed") {
-      return bookingsService.confirmBooking(db, id, { note: data.note }, userId)
+      return bookingsService.confirmBooking(db, id, { note: data.note }, userId, runtime)
     }
 
     if (current.status === "on_hold" && data.status === "expired") {
@@ -1927,9 +1948,10 @@ export const bookingsService = {
     id: string,
     data: ConfirmBookingInput,
     userId?: string,
+    runtime: BookingServiceRuntime = {},
   ) {
     try {
-      return await db.transaction(async (tx) => {
+      const result = await db.transaction(async (tx) => {
         const rows = await tx.execute(
           sql`SELECT id, booking_number, status, hold_expires_at
               FROM ${bookings}
@@ -2000,6 +2022,23 @@ export const bookingsService = {
 
         return { status: "ok" as const, booking: row ?? null }
       })
+
+      // Emit AFTER the transaction commits so subscribers can't observe a
+      // confirmed state that might still roll back. `emit` is fire-and-forget
+      // per the EventBus contract — subscriber errors are logged, not rethrown.
+      if (result.status === "ok" && result.booking) {
+        await runtime.eventBus?.emit(
+          "booking.confirmed",
+          {
+            bookingId: result.booking.id,
+            bookingNumber: result.booking.bookingNumber,
+            actorId: userId ?? null,
+          } satisfies BookingConfirmedEvent,
+          { category: "domain", source: "service" },
+        )
+      }
+
+      return result
     } catch (error) {
       if (error instanceof BookingServiceError) {
         return { status: error.code as Exclude<string, "ok"> }

--- a/packages/bookings/tests/integration/routes.test.ts
+++ b/packages/bookings/tests/integration/routes.test.ts
@@ -54,6 +54,7 @@ const originalKmsEnvKey = process.env.KMS_ENV_KEY
 describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
   let app: Hono
   let db: ReturnType<typeof import("@voyantjs/db/test-utils").createTestDb>
+  let eventBus: ReturnType<typeof import("@voyantjs/core").createEventBus>
 
   beforeAll(async () => {
     const { createTestDb, cleanupTestDb } = await import("@voyantjs/db/test-utils")
@@ -107,9 +108,13 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
     process.env.KMS_PROVIDER = "env"
     process.env.KMS_ENV_KEY = generateEnvKmsKey()
 
+    const { createEventBus } = await import("@voyantjs/core")
+    eventBus = createEventBus()
+
     app = new Hono()
     app.use("*", async (c, next) => {
       c.set("db" as never, db)
+      c.set("eventBus" as never, eventBus)
       c.set("userId" as never, "test-user-id")
       c.set("actor" as never, "staff")
       await next()
@@ -697,6 +702,70 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
 
       expect(res.status).toBe(200)
       expect((await res.json()).data.status).toBe("confirmed")
+    })
+
+    it("emits booking.confirmed with id + number + actor after confirm", async () => {
+      const slot = await seedSlot()
+      const reserveRes = await app.request("/reserve", {
+        method: "POST",
+        ...json({
+          bookingNumber: nextBookingNumber(),
+          sellCurrency: "USD",
+          items: [{ title: "Adult ticket", availabilitySlotId: slot.id, quantity: 1 }],
+        }),
+      })
+      const { data: booking } = await reserveRes.json()
+
+      const received: Array<{
+        bookingId: string
+        bookingNumber: string
+        actorId: string | null
+      }> = []
+      const sub = eventBus.subscribe("booking.confirmed", (event) => {
+        received.push(
+          event.data as { bookingId: string; bookingNumber: string; actorId: string | null },
+        )
+      })
+
+      try {
+        const res = await app.request(`/${booking.id}/confirm`, {
+          method: "POST",
+          ...json({}),
+        })
+        expect(res.status).toBe(200)
+      } finally {
+        sub.unsubscribe()
+      }
+
+      expect(received).toHaveLength(1)
+      expect(received[0]).toMatchObject({
+        bookingId: booking.id,
+        bookingNumber: booking.bookingNumber,
+        actorId: "test-user-id",
+      })
+    })
+
+    it("does not emit booking.confirmed when the transition fails", async () => {
+      // Booking starts in "draft" from POST / — the confirm route rejects it
+      // with invalid_transition, and no event should fire.
+      const draft = await seedBooking()
+
+      const received: unknown[] = []
+      const sub = eventBus.subscribe("booking.confirmed", (event) => {
+        received.push(event.data)
+      })
+
+      try {
+        const res = await app.request(`/${draft.id}/confirm`, {
+          method: "POST",
+          ...json({}),
+        })
+        expect(res.status).toBe(409)
+      } finally {
+        sub.unsubscribe()
+      }
+
+      expect(received).toHaveLength(0)
     })
 
     it("extends an on-hold booking", async () => {

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -1,5 +1,6 @@
 import type { Module } from "@voyantjs/core"
 import type { HonoModule } from "@voyantjs/hono/module"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import {
   buildNotificationsRouteRuntime,
@@ -8,6 +9,8 @@ import {
   type NotificationsRoutesOptions,
 } from "./routes.js"
 import { notificationsModule } from "./schema.js"
+import { createNotificationService } from "./service.js"
+import { bookingDocumentNotificationsService } from "./service-booking-documents.js"
 
 export {
   notificationLiquidEngine,
@@ -136,16 +139,84 @@ export {
   updateNotificationTemplateSchema,
 } from "./validation.js"
 
-export function createNotificationsHonoModule(options?: NotificationsRoutesOptions): HonoModule {
+/**
+ * Auto-dispatch policy for the `booking.confirmed` subscriber. Set `enabled:
+ * false` (or leave the option off entirely) to opt out.
+ */
+export interface NotificationsAutoConfirmAndDispatchOptions {
+  enabled?: boolean
+  /** Notification template slug used when the handler fires. */
+  templateSlug?: string
+  /** Optional allowlist of document types to attach; defaults to all. */
+  documentTypes?: Array<"contract" | "invoice" | "proforma">
+}
+
+export interface CreateNotificationsHonoModuleOptions extends NotificationsRoutesOptions {
+  /**
+   * Resolves a database from runtime bindings. Required for
+   * `autoConfirmAndDispatch` — the `booking.confirmed` subscriber fires
+   * outside a request scope and needs its own db handle.
+   */
+  resolveDb?: (bindings: Record<string, unknown>) => PostgresJsDatabase
+  autoConfirmAndDispatch?: NotificationsAutoConfirmAndDispatchOptions
+}
+
+export function createNotificationsHonoModule(
+  options?: CreateNotificationsHonoModuleOptions,
+): HonoModule {
   const routes = createNotificationsRoutes(options)
 
   const module: Module = {
     ...notificationsModule,
-    bootstrap: ({ bindings, container }) => {
+    bootstrap: ({ bindings, container, eventBus }) => {
       container.register(
         NOTIFICATIONS_ROUTE_RUNTIME_CONTAINER_KEY,
         buildNotificationsRouteRuntime(bindings as Record<string, unknown>, options),
       )
+
+      // Auto-dispatch wiring — opt-in. When enabled, every `booking.confirmed`
+      // event triggers a `confirmAndDispatchBooking` call so the operator
+      // doesn't have to click a second button. The handler runs in the same
+      // process as the emitter (the in-process event bus) but outside the
+      // request scope, so we resolve our own db handle from bindings.
+      if (options?.autoConfirmAndDispatch?.enabled && options.resolveDb) {
+        const resolveDb = options.resolveDb
+        const autoOptions = options.autoConfirmAndDispatch
+        const runtime = buildNotificationsRouteRuntime(bindings as Record<string, unknown>, options)
+        const dispatcher = createNotificationService(runtime.providers)
+
+        eventBus.subscribe(
+          "booking.confirmed",
+          async (event: {
+            data: { bookingId: string; bookingNumber: string; actorId: string | null }
+          }) => {
+            try {
+              const db = resolveDb(bindings as Record<string, unknown>)
+              await bookingDocumentNotificationsService.confirmAndDispatchBooking(
+                db,
+                dispatcher,
+                event.data.bookingId,
+                {
+                  templateSlug: autoOptions.templateSlug ?? null,
+                  documentTypes: autoOptions.documentTypes ?? null,
+                },
+                {
+                  attachmentResolver: runtime.documentAttachmentResolver,
+                  eventBus,
+                },
+              )
+            } catch (error) {
+              // Per the EventBus contract, handler failures are logged, not
+              // rethrown. We surface the context so ops can diagnose without
+              // digging through stack traces.
+              const message = error instanceof Error ? error.message : String(error)
+              console.error(
+                `[notifications] auto-dispatch failed for booking ${event.data.bookingId}: ${message}`,
+              )
+            }
+          },
+        )
+      }
     },
   }
 

--- a/packages/notifications/tests/unit/auto-dispatch.test.ts
+++ b/packages/notifications/tests/unit/auto-dispatch.test.ts
@@ -1,0 +1,127 @@
+import { createContainer, createEventBus } from "@voyantjs/core"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { describe, expect, it, vi } from "vitest"
+
+import { createNotificationsHonoModule } from "../../src/index.js"
+import { bookingDocumentNotificationsService } from "../../src/service-booking-documents.js"
+
+function fakeBindings() {
+  return {} as Record<string, unknown>
+}
+
+describe("createNotificationsHonoModule — autoConfirmAndDispatch", () => {
+  it("does NOT subscribe when autoConfirmAndDispatch is off", async () => {
+    const eventBus = createEventBus()
+    const container = createContainer()
+    const subscribeSpy = vi.spyOn(eventBus, "subscribe")
+
+    const module = createNotificationsHonoModule({
+      // resolveDb intentionally omitted — the check requires both anyway.
+    })
+
+    await module.module.bootstrap?.({ bindings: fakeBindings(), container, eventBus })
+
+    expect(subscribeSpy).not.toHaveBeenCalled()
+  })
+
+  it("does NOT subscribe when autoConfirmAndDispatch.enabled is false", async () => {
+    const eventBus = createEventBus()
+    const container = createContainer()
+    const subscribeSpy = vi.spyOn(eventBus, "subscribe")
+
+    const module = createNotificationsHonoModule({
+      resolveDb: () => ({}) as PostgresJsDatabase,
+      autoConfirmAndDispatch: { enabled: false, templateSlug: "booking-confirmation" },
+    })
+
+    await module.module.bootstrap?.({ bindings: fakeBindings(), container, eventBus })
+
+    expect(subscribeSpy).not.toHaveBeenCalled()
+  })
+
+  it("does NOT subscribe when resolveDb is missing — guard against partial config", async () => {
+    const eventBus = createEventBus()
+    const container = createContainer()
+    const subscribeSpy = vi.spyOn(eventBus, "subscribe")
+
+    const module = createNotificationsHonoModule({
+      autoConfirmAndDispatch: { enabled: true, templateSlug: "booking-confirmation" },
+    })
+
+    await module.module.bootstrap?.({ bindings: fakeBindings(), container, eventBus })
+
+    expect(subscribeSpy).not.toHaveBeenCalled()
+  })
+
+  it("subscribes to booking.confirmed and forwards to confirmAndDispatchBooking when enabled", async () => {
+    const eventBus = createEventBus()
+    const container = createContainer()
+    const db = { fake: true } as unknown as PostgresJsDatabase
+
+    const dispatchSpy = vi
+      .spyOn(bookingDocumentNotificationsService, "confirmAndDispatchBooking")
+      .mockResolvedValue({
+        status: "preview" as const,
+        bookingId: "book_abc",
+        documents: [],
+      })
+
+    const module = createNotificationsHonoModule({
+      resolveDb: () => db,
+      autoConfirmAndDispatch: {
+        enabled: true,
+        templateSlug: "booking-confirmation",
+        documentTypes: ["invoice", "contract"],
+      },
+    })
+
+    await module.module.bootstrap?.({ bindings: fakeBindings(), container, eventBus })
+    await eventBus.emit("booking.confirmed", {
+      bookingId: "book_abc",
+      bookingNumber: "BK-001",
+      actorId: "user_1",
+    })
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1)
+    const call = dispatchSpy.mock.calls[0]
+    expect(call?.[0]).toBe(db) // first arg = db
+    expect(call?.[2]).toBe("book_abc") // third arg = bookingId
+    expect(call?.[3]).toMatchObject({
+      templateSlug: "booking-confirmation",
+      documentTypes: ["invoice", "contract"],
+    })
+
+    dispatchSpy.mockRestore()
+  })
+
+  it("swallows subscriber errors — a failing dispatch never propagates back to the emitter", async () => {
+    const eventBus = createEventBus()
+    const container = createContainer()
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+
+    vi.spyOn(bookingDocumentNotificationsService, "confirmAndDispatchBooking").mockRejectedValue(
+      new Error("boom"),
+    )
+
+    const module = createNotificationsHonoModule({
+      resolveDb: () => ({}) as PostgresJsDatabase,
+      autoConfirmAndDispatch: { enabled: true, templateSlug: "booking-confirmation" },
+    })
+
+    await module.module.bootstrap?.({ bindings: fakeBindings(), container, eventBus })
+
+    // emit should resolve cleanly — if the handler threw through, this would
+    // await a rejected promise and throw here.
+    await expect(
+      eventBus.emit("booking.confirmed", {
+        bookingId: "book_abc",
+        bookingNumber: "BK-001",
+        actorId: null,
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringMatching(/auto-dispatch failed.*book_abc/))
+    errorSpy.mockRestore()
+    vi.restoreAllMocks()
+  })
+})


### PR DESCRIPTION
## Summary
Third slice of #228. Closes the auto-run loop — `#240` gave the on-demand endpoint, `#245` gave the event emit, this wires the handler that actually calls `confirmAndDispatchBooking` when a booking transitions to `confirmed`.

### Stacking
- Base: `feat/228-confirm-and-dispatch` (#240) — needed for `confirmAndDispatchBooking`.
- Also cherry-picked the `booking.confirmed` emit from `feat/228-booking-confirmed-event` (#245) so the PR is buildable + testable end-to-end. GitHub will dedupe the cherry-picked commit when #245 merges; final flow will be #240 → #245 → this.

### Module surface

`createNotificationsHonoModule` gains two optional, paired options:
- `resolveDb: (bindings) => PostgresJsDatabase` — the `booking.confirmed` handler fires *inside* the request that triggered the transition (in-process event bus), but the subscription itself is registered in `bootstrap` — outside any request. So we can't lean on `c.var.db`; the resolver closes over the first isolate's bindings and is reused across events.
- `autoConfirmAndDispatch: { enabled, templateSlug?, documentTypes? }` — opt-in. `{ enabled: false }` or leaving the option off entirely skips the subscribe call, so existing templates are unaffected.

When both are set, bootstrap subscribes a handler that:
1. Resolves the db via `resolveDb(bindings)`.
2. Builds a dispatcher from the same providers the routes use.
3. Calls `bookingDocumentNotificationsService.confirmAndDispatchBooking` with the configured `templateSlug` + `documentTypes`, using the module's `attachmentResolver` + `eventBus`.

### Failure handling
Subscriber errors are caught and logged as `[notifications] auto-dispatch failed for booking <id>: <message>` — never rethrown. Matches the EventBus contract (handlers are fire-and-forget; emitters can't be blocked by a bad handler).

### Template wiring example
```ts
const notificationsHonoModule = createNotificationsHonoModule({
  resolveProviders,
  resolveDb: (bindings) => getDbFromHyperdrive(bindings as CloudflareBindings),
  autoConfirmAndDispatch: {
    enabled: true,
    templateSlug: "booking-confirmation",
  },
})
```

### Out of scope
- Operator template actually enabling the flag in `voyant.config.ts`. Separate PR against the template — needs product alignment on default slug + documentTypes.
- `booking.cancelled` / `booking.expired` variants — same pattern per event.

Related to #228.

## Test plan
- [x] `pnpm -F @voyantjs/notifications typecheck`
- [x] `pnpm -F @voyantjs/notifications test` — 57 passing. 5 new cases:
  - off by default (no subscribe call)
  - `enabled: false` still skips
  - `resolveDb` missing + `enabled: true` → skip (guard against partial config)
  - happy path — subscribes + forwards bookingId / templateSlug / documentTypes to `confirmAndDispatchBooking`
  - subscriber errors are swallowed (emit() resolves; `console.error` gets the booking id for ops diagnosis)
- [x] `pnpm typecheck` — 136/136 tasks clean.
- [ ] Smoke against a running operator template: enable the flag, confirm a reserved booking, verify the notification goes out without a second API call.