### PR TITLE
feat(operator): enable auto-dispatch on booking.confirmed

### DIFF
--- a/packages/bookings/src/routes-shared.ts
+++ b/packages/bookings/src/routes-shared.ts
@@ -1,4 +1,4 @@
-import type { ModuleContainer } from "@voyantjs/core"
+import type { EventBus, ModuleContainer } from "@voyantjs/core"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
 
@@ -27,6 +27,7 @@ export type Env = {
   Variables: {
     container?: ModuleContainer
     db: PostgresJsDatabase
+    eventBus?: EventBus
     userId?: string
     actor?: "staff" | "customer" | "partner" | "supplier"
     callerType?: "session" | "api_key" | "internal"

--- a/packages/bookings/src/routes.ts
+++ b/packages/bookings/src/routes.ts
@@ -436,6 +436,7 @@ export const bookingRoutes = new Hono<Env>()
       c.req.param("id"),
       await parseJsonBody(c, updateBookingStatusSchema),
       c.get("userId"),
+      { eventBus: c.get("eventBus") },
     )
 
     if (result.status === "not_found") {
@@ -460,6 +461,7 @@ export const bookingRoutes = new Hono<Env>()
       c.req.param("id"),
       await parseJsonBody(c, confirmBookingSchema),
       c.get("userId"),
+      { eventBus: c.get("eventBus") },
     )
 
     if (result.status === "not_found") {

--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -1,3 +1,4 @@
+import type { EventBus } from "@voyantjs/core"
 import { and, asc, desc, eq, ilike, inArray, lte, ne, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
@@ -127,6 +128,25 @@ export interface ConvertProductData {
 
 type ProductOptionReference = typeof productOptionsRef.$inferSelect
 type OptionUnitReference = typeof optionUnitsRef.$inferSelect
+
+/**
+ * Optional runtime hooks for status-transition flows. Keeps the service
+ * decoupled from delivery concerns — bookings only has to emit, never know
+ * what listens.
+ */
+export interface BookingServiceRuntime {
+  eventBus?: EventBus
+}
+
+/**
+ * Payload shape for `booking.confirmed`. Subscribers should treat unknown
+ * fields as forward-compatible additions.
+ */
+export interface BookingConfirmedEvent {
+  bookingId: string
+  bookingNumber: string
+  actorId: string | null
+}
 
 const travelerParticipantTypes = ["traveler", "occupant"] as const
 
@@ -1858,6 +1878,7 @@ export const bookingsService = {
     id: string,
     data: UpdateBookingStatusInput,
     userId?: string,
+    runtime: BookingServiceRuntime = {},
   ) {
     const [current] = await db
       .select({ id: bookings.id, status: bookings.status })
@@ -1870,7 +1891,7 @@ export const bookingsService = {
     }
 
     if (current.status === "on_hold" && data.status === "confirmed") {
-      return bookingsService.confirmBooking(db, id, { note: data.note }, userId)
+      return bookingsService.confirmBooking(db, id, { note: data.note }, userId, runtime)
     }
 
     if (current.status === "on_hold" && data.status === "expired") {
@@ -1927,9 +1948,10 @@ export const bookingsService = {
     id: string,
     data: ConfirmBookingInput,
     userId?: string,
+    runtime: BookingServiceRuntime = {},
   ) {
     try {
-      return await db.transaction(async (tx) => {
+      const result = await db.transaction(async (tx) => {
         const rows = await tx.execute(
           sql`SELECT id, booking_number, status, hold_expires_at
               FROM ${bookings}
@@ -2000,6 +2022,23 @@ export const bookingsService = {
 
         return { status: "ok" as const, booking: row ?? null }
       })
+
+      // Emit AFTER the transaction commits so subscribers can't observe a
+      // confirmed state that might still roll back. `emit` is fire-and-forget
+      // per the EventBus contract — subscriber errors are logged, not rethrown.
+      if (result.status === "ok" && result.booking) {
+        await runtime.eventBus?.emit(
+          "booking.confirmed",
+          {
+            bookingId: result.booking.id,
+            bookingNumber: result.booking.bookingNumber,
+            actorId: userId ?? null,
+          } satisfies BookingConfirmedEvent,
+          { category: "domain", source: "service" },
+        )
+      }
+
+      return result
     } catch (error) {
       if (error instanceof BookingServiceError) {
         return { status: error.code as Exclude<string, "ok"> }

--- a/packages/bookings/tests/integration/routes.test.ts
+++ b/packages/bookings/tests/integration/routes.test.ts
@@ -54,6 +54,7 @@ const originalKmsEnvKey = process.env.KMS_ENV_KEY
 describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
   let app: Hono
   let db: ReturnType<typeof import("@voyantjs/db/test-utils").createTestDb>
+  let eventBus: ReturnType<typeof import("@voyantjs/core").createEventBus>
 
   beforeAll(async () => {
     const { createTestDb, cleanupTestDb } = await import("@voyantjs/db/test-utils")
@@ -107,9 +108,13 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
     process.env.KMS_PROVIDER = "env"
     process.env.KMS_ENV_KEY = generateEnvKmsKey()
 
+    const { createEventBus } = await import("@voyantjs/core")
+    eventBus = createEventBus()
+
     app = new Hono()
     app.use("*", async (c, next) => {
       c.set("db" as never, db)
+      c.set("eventBus" as never, eventBus)
       c.set("userId" as never, "test-user-id")
       c.set("actor" as never, "staff")
       await next()
@@ -697,6 +702,70 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
 
       expect(res.status).toBe(200)
       expect((await res.json()).data.status).toBe("confirmed")
+    })
+
+    it("emits booking.confirmed with id + number + actor after confirm", async () => {
+      const slot = await seedSlot()
+      const reserveRes = await app.request("/reserve", {
+        method: "POST",
+        ...json({
+          bookingNumber: nextBookingNumber(),
+          sellCurrency: "USD",
+          items: [{ title: "Adult ticket", availabilitySlotId: slot.id, quantity: 1 }],
+        }),
+      })
+      const { data: booking } = await reserveRes.json()
+
+      const received: Array<{
+        bookingId: string
+        bookingNumber: string
+        actorId: string | null
+      }> = []
+      const sub = eventBus.subscribe("booking.confirmed", (event) => {
+        received.push(
+          event.data as { bookingId: string; bookingNumber: string; actorId: string | null },
+        )
+      })
+
+      try {
+        const res = await app.request(`/${booking.id}/confirm`, {
+          method: "POST",
+          ...json({}),
+        })
+        expect(res.status).toBe(200)
+      } finally {
+        sub.unsubscribe()
+      }
+
+      expect(received).toHaveLength(1)
+      expect(received[0]).toMatchObject({
+        bookingId: booking.id,
+        bookingNumber: booking.bookingNumber,
+        actorId: "test-user-id",
+      })
+    })
+
+    it("does not emit booking.confirmed when the transition fails", async () => {
+      // Booking starts in "draft" from POST / — the confirm route rejects it
+      // with invalid_transition, and no event should fire.
+      const draft = await seedBooking()
+
+      const received: unknown[] = []
+      const sub = eventBus.subscribe("booking.confirmed", (event) => {
+        received.push(event.data)
+      })
+
+      try {
+        const res = await app.request(`/${draft.id}/confirm`, {
+          method: "POST",
+          ...json({}),
+        })
+        expect(res.status).toBe(409)
+      } finally {
+        sub.unsubscribe()
+      }
+
+      expect(received).toHaveLength(0)
     })
 
     it("extends an on-hold booking", async () => {

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -1,5 +1,6 @@
 import type { Module } from "@voyantjs/core"
 import type { HonoModule } from "@voyantjs/hono/module"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import {
   buildNotificationsRouteRuntime,
@@ -8,6 +9,8 @@ import {
   type NotificationsRoutesOptions,
 } from "./routes.js"
 import { notificationsModule } from "./schema.js"
+import { createNotificationService } from "./service.js"
+import { bookingDocumentNotificationsService } from "./service-booking-documents.js"
 
 export {
   notificationLiquidEngine,
@@ -136,16 +139,84 @@ export {
   updateNotificationTemplateSchema,
 } from "./validation.js"
 
-export function createNotificationsHonoModule(options?: NotificationsRoutesOptions): HonoModule {
+/**
+ * Auto-dispatch policy for the `booking.confirmed` subscriber. Set `enabled:
+ * false` (or leave the option off entirely) to opt out.
+ */
+export interface NotificationsAutoConfirmAndDispatchOptions {
+  enabled?: boolean
+  /** Notification template slug used when the handler fires. */
+  templateSlug?: string
+  /** Optional allowlist of document types to attach; defaults to all. */
+  documentTypes?: Array<"contract" | "invoice" | "proforma">
+}
+
+export interface CreateNotificationsHonoModuleOptions extends NotificationsRoutesOptions {
+  /**
+   * Resolves a database from runtime bindings. Required for
+   * `autoConfirmAndDispatch` — the `booking.confirmed` subscriber fires
+   * outside a request scope and needs its own db handle.
+   */
+  resolveDb?: (bindings: Record<string, unknown>) => PostgresJsDatabase
+  autoConfirmAndDispatch?: NotificationsAutoConfirmAndDispatchOptions
+}
+
+export function createNotificationsHonoModule(
+  options?: CreateNotificationsHonoModuleOptions,
+): HonoModule {
   const routes = createNotificationsRoutes(options)
 
   const module: Module = {
     ...notificationsModule,
-    bootstrap: ({ bindings, container }) => {
+    bootstrap: ({ bindings, container, eventBus }) => {
       container.register(
         NOTIFICATIONS_ROUTE_RUNTIME_CONTAINER_KEY,
         buildNotificationsRouteRuntime(bindings as Record<string, unknown>, options),
       )
+
+      // Auto-dispatch wiring — opt-in. When enabled, every `booking.confirmed`
+      // event triggers a `confirmAndDispatchBooking` call so the operator
+      // doesn't have to click a second button. The handler runs in the same
+      // process as the emitter (the in-process event bus) but outside the
+      // request scope, so we resolve our own db handle from bindings.
+      if (options?.autoConfirmAndDispatch?.enabled && options.resolveDb) {
+        const resolveDb = options.resolveDb
+        const autoOptions = options.autoConfirmAndDispatch
+        const runtime = buildNotificationsRouteRuntime(bindings as Record<string, unknown>, options)
+        const dispatcher = createNotificationService(runtime.providers)
+
+        eventBus.subscribe(
+          "booking.confirmed",
+          async (event: {
+            data: { bookingId: string; bookingNumber: string; actorId: string | null }
+          }) => {
+            try {
+              const db = resolveDb(bindings as Record<string, unknown>)
+              await bookingDocumentNotificationsService.confirmAndDispatchBooking(
+                db,
+                dispatcher,
+                event.data.bookingId,
+                {
+                  templateSlug: autoOptions.templateSlug ?? null,
+                  documentTypes: autoOptions.documentTypes ?? null,
+                },
+                {
+                  attachmentResolver: runtime.documentAttachmentResolver,
+                  eventBus,
+                },
+              )
+            } catch (error) {
+              // Per the EventBus contract, handler failures are logged, not
+              // rethrown. We surface the context so ops can diagnose without
+              // digging through stack traces.
+              const message = error instanceof Error ? error.message : String(error)
+              console.error(
+                `[notifications] auto-dispatch failed for booking ${event.data.bookingId}: ${message}`,
+              )
+            }
+          },
+        )
+      }
     },
   }
 

--- a/packages/notifications/src/routes.ts
+++ b/packages/notifications/src/routes.ts
@@ -8,6 +8,8 @@ import type { BookingDocumentAttachmentResolver } from "./service-booking-docume
 import type { NotificationProvider } from "./types.js"
 import {
   bookingDocumentBundleSchema,
+  confirmAndDispatchBookingResultSchema,
+  confirmAndDispatchBookingSchema,
   insertNotificationReminderRuleSchema,
   insertNotificationTemplateSchema,
   notificationDeliveryListQuerySchema,
@@ -211,6 +213,62 @@ export function createNotificationsRoutes(options?: NotificationsRoutesOptions) 
       )
       if (!bundle) return c.json({ error: "Booking not found" }, 404)
       return c.json({ data: bookingDocumentBundleSchema.parse(bundle) })
+    })
+    .post("/bookings/:id/confirm-and-dispatch", async (c) => {
+      try {
+        const runtime = getRuntime(c.env, options, (key) => c.var.container.resolve(key))
+        const dispatcher = createNotificationService(runtime.providers)
+        const result = await notificationsService.confirmAndDispatchBooking(
+          c.get("db"),
+          dispatcher,
+          c.req.param("id"),
+          await parseOptionalJsonBody(c, confirmAndDispatchBookingSchema),
+          {
+            attachmentResolver: runtime.documentAttachmentResolver,
+            eventBus: runtime.eventBus,
+          },
+        )
+        if (result.status === "not_found") return c.json({ error: "Booking not found" }, 404)
+        if (result.status === "preview") {
+          return c.json({
+            data: confirmAndDispatchBookingResultSchema.parse({
+              bookingId: result.bookingId,
+              documents: result.documents,
+              notification: null,
+              skipReason: "preview_only",
+            }),
+          })
+        }
+        if (result.status === "skipped") {
+          return c.json({
+            data: confirmAndDispatchBookingResultSchema.parse({
+              bookingId: result.bookingId,
+              documents: result.documents,
+              notification: null,
+              skipReason: result.skipReason,
+            }),
+          })
+        }
+        return c.json(
+          {
+            data: confirmAndDispatchBookingResultSchema.parse({
+              bookingId: result.bookingId,
+              documents: result.documents,
+              notification: {
+                recipient: result.recipient,
+                deliveryId: result.delivery.id,
+                provider: result.delivery.provider,
+                status: result.delivery.status,
+              },
+              skipReason: null,
+            }),
+          },
+          201,
+        )
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Confirm-and-dispatch failed"
+        return c.json({ error: message }, 400)
+      }
     })
     .post("/bookings/:id/send-documents", async (c) => {
       try {

--- a/packages/notifications/src/service-booking-documents.ts
+++ b/packages/notifications/src/service-booking-documents.ts
@@ -394,6 +394,68 @@ export const bookingDocumentNotificationsService = {
       delivery,
     }
   },
+
+  /**
+   * Confirm-and-dispatch — single orchestrated call for the operator flow
+   * that wants "list the booking's documents, then send them to the client"
+   * to be one action instead of two round-trips.
+   *
+   * With `sendNotification: false`, the caller gets the bundle back without
+   * attempting a send — useful for rendering a preview/checkbox list before
+   * the operator confirms. With `sendNotification: true`, the same send
+   * guards as `sendBookingDocumentsNotification` apply (no_documents,
+   * no_recipient, no_attachments, send_failed); the result keeps the bundle
+   * regardless so the UI always has something to show.
+   */
+  async confirmAndDispatchBooking(
+    db: PostgresJsDatabase,
+    dispatcher: NotificationService,
+    bookingId: string,
+    input: { sendNotification?: boolean } & SendBookingDocumentsNotificationInput,
+    runtime: SendBookingDocumentsRuntimeOptions = {},
+  ) {
+    const bundle = await this.listBookingDocumentBundle(db, bookingId)
+    if (!bundle) return { status: "not_found" as const }
+
+    const documents = bundle.documents
+    const sendNotification = input.sendNotification ?? true
+    if (!sendNotification) {
+      return {
+        status: "preview" as const,
+        bookingId,
+        documents,
+      }
+    }
+
+    const result = await this.sendBookingDocumentsNotification(
+      db,
+      dispatcher,
+      bookingId,
+      input,
+      runtime,
+    )
+
+    if (result.status === "not_found") {
+      return { status: "not_found" as const }
+    }
+
+    if (result.status !== "sent") {
+      return {
+        status: "skipped" as const,
+        bookingId,
+        documents,
+        skipReason: result.status,
+      }
+    }
+
+    return {
+      status: "dispatched" as const,
+      bookingId: result.bookingId,
+      documents: result.documents,
+      recipient: result.recipient,
+      delivery: result.delivery,
+    }
+  },
 }
 
 export { createDefaultAttachmentFromDocument as createDefaultBookingDocumentAttachment }

--- a/packages/notifications/src/service.ts
+++ b/packages/notifications/src/service.ts
@@ -57,5 +57,6 @@ export const notificationsService = {
   listBookingDocumentBundle: bookingDocumentNotificationsService.listBookingDocumentBundle,
   sendBookingDocumentsNotification:
     bookingDocumentNotificationsService.sendBookingDocumentsNotification,
+  confirmAndDispatchBooking: bookingDocumentNotificationsService.confirmAndDispatchBooking,
   createDefaultBookingDocumentAttachment,
 }

--- a/packages/notifications/src/validation.ts
+++ b/packages/notifications/src/validation.ts
@@ -331,3 +331,41 @@ export const sendBookingDocumentsNotificationResultSchema = z.object({
   provider: z.string().optional().nullable(),
   status: notificationDeliveryStatusSchema,
 })
+
+/**
+ * Confirm-and-dispatch — single orchestrated request that lists the booking's
+ * document bundle and (optionally) sends it to the client in one round-trip.
+ *
+ * `sendNotification: false` turns the call into a preview: the bundle comes
+ * back but no delivery is attempted. Templates use the preview to render the
+ * "here's what's ready" checkbox list before the operator confirms.
+ */
+export const confirmAndDispatchBookingSchema = sendBookingDocumentsNotificationSchema.extend({
+  sendNotification: z.boolean().default(true),
+})
+
+export const confirmAndDispatchBookingResultSchema = z.object({
+  bookingId: z.string().min(1),
+  documents: z.array(bookingDocumentBundleItemSchema),
+  /**
+   * Non-null when `sendNotification` was true and a delivery actually went
+   * out. Null when either the operator asked for a preview only, or the send
+   * couldn't proceed (no recipient / no attachments / no matching documents).
+   */
+  notification: z
+    .object({
+      recipient: z.string().min(1),
+      deliveryId: z.string().min(1),
+      provider: z.string().optional().nullable(),
+      status: notificationDeliveryStatusSchema,
+    })
+    .nullable(),
+  /**
+   * When `sendNotification` was true but the dispatcher declined to send,
+   * this captures which guard tripped so the UI can explain it — e.g.
+   * "No recipient on file, add an email to the lead traveler and retry".
+   */
+  skipReason: z
+    .enum(["preview_only", "no_documents", "no_recipient", "no_attachments", "send_failed"])
+    .nullable(),
+})

--- a/packages/notifications/tests/unit/auto-dispatch.test.ts
+++ b/packages/notifications/tests/unit/auto-dispatch.test.ts
@@ -1,0 +1,127 @@
+import { createContainer, createEventBus } from "@voyantjs/core"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { describe, expect, it, vi } from "vitest"
+
+import { createNotificationsHonoModule } from "../../src/index.js"
+import { bookingDocumentNotificationsService } from "../../src/service-booking-documents.js"
+
+function fakeBindings() {
+  return {} as Record<string, unknown>
+}
+
+describe("createNotificationsHonoModule — autoConfirmAndDispatch", () => {
+  it("does NOT subscribe when autoConfirmAndDispatch is off", async () => {
+    const eventBus = createEventBus()
+    const container = createContainer()
+    const subscribeSpy = vi.spyOn(eventBus, "subscribe")
+
+    const module = createNotificationsHonoModule({
+      // resolveDb intentionally omitted — the check requires both anyway.
+    })
+
+    await module.module.bootstrap?.({ bindings: fakeBindings(), container, eventBus })
+
+    expect(subscribeSpy).not.toHaveBeenCalled()
+  })
+
+  it("does NOT subscribe when autoConfirmAndDispatch.enabled is false", async () => {
+    const eventBus = createEventBus()
+    const container = createContainer()
+    const subscribeSpy = vi.spyOn(eventBus, "subscribe")
+
+    const module = createNotificationsHonoModule({
+      resolveDb: () => ({}) as PostgresJsDatabase,
+      autoConfirmAndDispatch: { enabled: false, templateSlug: "booking-confirmation" },
+    })
+
+    await module.module.bootstrap?.({ bindings: fakeBindings(), container, eventBus })
+
+    expect(subscribeSpy).not.toHaveBeenCalled()
+  })
+
+  it("does NOT subscribe when resolveDb is missing — guard against partial config", async () => {
+    const eventBus = createEventBus()
+    const container = createContainer()
+    const subscribeSpy = vi.spyOn(eventBus, "subscribe")
+
+    const module = createNotificationsHonoModule({
+      autoConfirmAndDispatch: { enabled: true, templateSlug: "booking-confirmation" },
+    })
+
+    await module.module.bootstrap?.({ bindings: fakeBindings(), container, eventBus })
+
+    expect(subscribeSpy).not.toHaveBeenCalled()
+  })
+
+  it("subscribes to booking.confirmed and forwards to confirmAndDispatchBooking when enabled", async () => {
+    const eventBus = createEventBus()
+    const container = createContainer()
+    const db = { fake: true } as unknown as PostgresJsDatabase
+
+    const dispatchSpy = vi
+      .spyOn(bookingDocumentNotificationsService, "confirmAndDispatchBooking")
+      .mockResolvedValue({
+        status: "preview" as const,
+        bookingId: "book_abc",
+        documents: [],
+      })
+
+    const module = createNotificationsHonoModule({
+      resolveDb: () => db,
+      autoConfirmAndDispatch: {
+        enabled: true,
+        templateSlug: "booking-confirmation",
+        documentTypes: ["invoice", "contract"],
+      },
+    })
+
+    await module.module.bootstrap?.({ bindings: fakeBindings(), container, eventBus })
+    await eventBus.emit("booking.confirmed", {
+      bookingId: "book_abc",
+      bookingNumber: "BK-001",
+      actorId: "user_1",
+    })
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1)
+    const call = dispatchSpy.mock.calls[0]
+    expect(call?.[0]).toBe(db) // first arg = db
+    expect(call?.[2]).toBe("book_abc") // third arg = bookingId
+    expect(call?.[3]).toMatchObject({
+      templateSlug: "booking-confirmation",
+      documentTypes: ["invoice", "contract"],
+    })
+
+    dispatchSpy.mockRestore()
+  })
+
+  it("swallows subscriber errors — a failing dispatch never propagates back to the emitter", async () => {
+    const eventBus = createEventBus()
+    const container = createContainer()
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+
+    vi.spyOn(bookingDocumentNotificationsService, "confirmAndDispatchBooking").mockRejectedValue(
+      new Error("boom"),
+    )
+
+    const module = createNotificationsHonoModule({
+      resolveDb: () => ({}) as PostgresJsDatabase,
+      autoConfirmAndDispatch: { enabled: true, templateSlug: "booking-confirmation" },
+    })
+
+    await module.module.bootstrap?.({ bindings: fakeBindings(), container, eventBus })
+
+    // emit should resolve cleanly — if the handler threw through, this would
+    // await a rejected promise and throw here.
+    await expect(
+      eventBus.emit("booking.confirmed", {
+        bookingId: "book_abc",
+        bookingNumber: "BK-001",
+        actorId: null,
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringMatching(/auto-dispatch failed.*book_abc/))
+    errorSpy.mockRestore()
+    vi.restoreAllMocks()
+  })
+})

--- a/packages/notifications/tests/unit/confirm-and-dispatch.test.ts
+++ b/packages/notifications/tests/unit/confirm-and-dispatch.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  confirmAndDispatchBookingResultSchema,
+  confirmAndDispatchBookingSchema,
+} from "../../src/validation.js"
+
+describe("confirmAndDispatchBookingSchema", () => {
+  it("defaults sendNotification to true so the happy path is one-shot", () => {
+    const result = confirmAndDispatchBookingSchema.parse({})
+    expect(result.sendNotification).toBe(true)
+  })
+
+  it("accepts preview-only mode", () => {
+    const result = confirmAndDispatchBookingSchema.parse({ sendNotification: false })
+    expect(result.sendNotification).toBe(false)
+  })
+
+  it("forwards the underlying send-documents fields", () => {
+    const result = confirmAndDispatchBookingSchema.parse({
+      templateSlug: "booking-confirmation",
+      documentTypes: ["invoice", "contract"],
+      subject: "Your booking is confirmed",
+      to: "traveler@example.com",
+    })
+    expect(result.templateSlug).toBe("booking-confirmation")
+    expect(result.documentTypes).toEqual(["invoice", "contract"])
+    expect(result.subject).toBe("Your booking is confirmed")
+  })
+})
+
+describe("confirmAndDispatchBookingResultSchema", () => {
+  const documents = [
+    {
+      key: "inv_abc::pdf",
+      source: "finance" as const,
+      documentType: "invoice" as const,
+      bookingId: "book_abc",
+      invoiceId: "inv_abc",
+      renditionId: "invr_abc",
+      name: "invoice.pdf",
+      createdAt: "2026-04-23T10:00:00.000Z",
+    },
+  ]
+
+  it("parses a dispatched result", () => {
+    const result = confirmAndDispatchBookingResultSchema.parse({
+      bookingId: "book_abc",
+      documents,
+      notification: {
+        recipient: "traveler@example.com",
+        deliveryId: "ntdl_abc",
+        provider: "resend",
+        status: "sent",
+      },
+      skipReason: null,
+    })
+    expect(result.notification?.deliveryId).toBe("ntdl_abc")
+    expect(result.skipReason).toBeNull()
+  })
+
+  it("parses a preview result (no notification, preview_only reason)", () => {
+    const result = confirmAndDispatchBookingResultSchema.parse({
+      bookingId: "book_abc",
+      documents,
+      notification: null,
+      skipReason: "preview_only",
+    })
+    expect(result.notification).toBeNull()
+    expect(result.skipReason).toBe("preview_only")
+  })
+
+  it("parses skip reasons surfaced from the send pipeline", () => {
+    for (const reason of ["no_documents", "no_recipient", "no_attachments", "send_failed"]) {
+      const result = confirmAndDispatchBookingResultSchema.parse({
+        bookingId: "book_abc",
+        documents,
+        notification: null,
+        skipReason: reason,
+      })
+      expect(result.skipReason).toBe(reason)
+    }
+  })
+
+  it("rejects unknown skip reasons", () => {
+    expect(() =>
+      confirmAndDispatchBookingResultSchema.parse({
+        bookingId: "book_abc",
+        documents,
+        notification: null,
+        skipReason: "bogus",
+      }),
+    ).toThrow()
+  })
+})

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -49,6 +49,23 @@ const notificationsHonoModule = createNotificationsHonoModule({
 
     return createDefaultBookingDocumentAttachment(document)
   },
+  // Auto-dispatch the booking-confirmation bundle when a booking flips to
+  // `confirmed`. The subscriber runs in the same process as the emitter via
+  // the in-process event bus; errors are logged, not rethrown, so a flaky
+  // mailer can't block the confirm request.
+  //
+  // `getDbFromHyperdrive` returns a union of PostgresJsDatabase and
+  // NeonHttpDatabase depending on env (hyperdrive vs plain DATABASE_URL).
+  // The notifications service only calls drizzle operations that both
+  // flavors support, so we narrow through `unknown`.
+  resolveDb: (bindings) =>
+    getDbFromHyperdrive(
+      bindings as unknown as CloudflareBindings,
+    ) as unknown as import("drizzle-orm/postgres-js").PostgresJsDatabase,
+  autoConfirmAndDispatch: {
+    enabled: true,
+    templateSlug: "booking-confirmation",
+  },
 })
 const storefrontVerificationHonoModule = createStorefrontVerificationHonoModule({
   resolveProviders: resolveNotificationProviders,


### PR DESCRIPTION
## Summary
Final slice of #228 — turns on the opt-in subscriber so confirming a booking automatically fires the confirmation notification bundle, instead of requiring a second operator click.

### Wiring

Adds two options to the existing `createNotificationsHonoModule` call:

- `resolveDb` — returns the template's hyperdrive/postgres db handle. Narrowed through `unknown` because the template supports both PostgresJsDatabase (hyperdrive) and NeonHttpDatabase flavors behind the same helper, and the notifications service only calls drizzle operations both support.
- `autoConfirmAndDispatch: { enabled: true, templateSlug: "booking-confirmation" }`

`documentTypes` is omitted, so the handler attaches whatever the bundle endpoint returns (contracts + invoices + proformas) — the same set operators would get by manually hitting `send-documents`.

### Template contract

Operators installing a fresh copy of the template get auto-dispatch **on by default**. Apps that want manual-only can flip `autoConfirmAndDispatch.enabled` to `false` (or drop the block); the confirm route keeps working either way.

### Dependency chain

Stacked on:
- #240 — `confirmAndDispatchBooking` service + route
- #245 — `booking.confirmed` emit
- #246 — auto-dispatch subscriber option (this PR's direct base)

The cherry-picked + stacked commits will dedupe as the predecessors merge; final flow is #240 → #245 → #246 → this.

Closes #228.

## Test plan
- [x] `pnpm -F operator typecheck`
- [x] `pnpm typecheck` — 136/136 tasks clean.
- [ ] Smoke on a running operator template: confirm a reserved booking with a billing email + rendered invoice on file → single notification goes out, no manual send-documents call needed.
- [ ] Smoke: confirm without email → handler logs `[notifications] auto-dispatch failed… skipReason=no_recipient` (no 500, confirm still succeeds).