### PR TITLE
feat(finance): public validateVoucher reads from new vouchers table

### DIFF
--- a/packages/finance/src/service-public.ts
+++ b/packages/finance/src/service-public.ts
@@ -9,6 +9,7 @@ import {
   invoices,
   paymentInstruments,
   payments,
+  vouchers,
 } from "./schema.js"
 import { financeService } from "./service.js"
 import type {
@@ -495,13 +496,25 @@ export const publicFinanceService = {
   },
 
   async validateVoucher(db: PostgresJsDatabase, input: PublicValidateVoucherInput) {
-    const normalizedCode = input.code.trim().toLowerCase()
+    const normalizedCode = input.code.trim()
+    const normalizedCodeLower = normalizedCode.toLowerCase()
+
+    // New path: first-class `vouchers` table. Covers any voucher issued via
+    // POST /v1/finance/vouchers.
+    const resolvedFromNewTable = await resolveVoucherFromNewTable(db, normalizedCode)
+    if (resolvedFromNewTable) {
+      return evaluateVoucherValidity(resolvedFromNewTable, input)
+    }
+
+    // Fallback path: legacy payment_instruments rows with instrumentType =
+    // 'voucher' and balance carried in metadata JSONB. Kept working until the
+    // migration script flips remaining rows over to the new table.
     const voucherConditions = [
       eq(paymentInstruments.instrumentType, "voucher"),
       or(
-        sql`lower(coalesce(${paymentInstruments.externalToken}, '')) = ${normalizedCode}`,
-        sql`lower(coalesce(${paymentInstruments.directBillReference}, '')) = ${normalizedCode}`,
-        sql`lower(coalesce(${paymentInstruments.metadata} ->> 'code', '')) = ${normalizedCode}`,
+        sql`lower(coalesce(${paymentInstruments.externalToken}, '')) = ${normalizedCodeLower}`,
+        sql`lower(coalesce(${paymentInstruments.directBillReference}, '')) = ${normalizedCodeLower}`,
+        sql`lower(coalesce(${paymentInstruments.metadata} ->> 'code', '')) = ${normalizedCodeLower}`,
       ),
     ]
 
@@ -535,57 +548,123 @@ export const publicFinanceService = {
     const bookingId = getMetadataString(metadata, "bookingId")
     const appliesToBookingIds = bookingId ? [bookingId, ...bookingIds] : bookingIds
 
-    const publicVoucher = {
-      id: voucher.id,
-      code: voucherCode,
-      label: voucher.label,
-      provider: voucher.provider ?? null,
-      currency,
-      amountCents,
-      remainingAmountCents,
-      expiresAt,
-    }
-
-    if (voucher.status !== "active") {
-      return { valid: false as const, reason: "inactive" as const, voucher: publicVoucher }
-    }
-
-    if (validFrom && new Date(validFrom) > new Date()) {
-      return { valid: false as const, reason: "not_started" as const, voucher: publicVoucher }
-    }
-
-    if (expiresAt && new Date(expiresAt) < new Date()) {
-      return { valid: false as const, reason: "expired" as const, voucher: publicVoucher }
-    }
-
-    if (
-      input.bookingId &&
-      appliesToBookingIds.length > 0 &&
-      !appliesToBookingIds.includes(input.bookingId)
-    ) {
-      return { valid: false as const, reason: "booking_mismatch" as const, voucher: publicVoucher }
-    }
-
-    if (input.currency && currency && input.currency !== currency) {
-      return {
-        valid: false as const,
-        reason: "currency_mismatch" as const,
-        voucher: publicVoucher,
-      }
-    }
-
-    if (
-      input.amountCents &&
-      remainingAmountCents !== null &&
-      input.amountCents > remainingAmountCents
-    ) {
-      return {
-        valid: false as const,
-        reason: "insufficient_balance" as const,
-        voucher: publicVoucher,
-      }
-    }
-
-    return { valid: true as const, reason: null, voucher: publicVoucher }
+    return evaluateVoucherValidity(
+      {
+        id: voucher.id,
+        code: voucherCode,
+        label: voucher.label,
+        provider: voucher.provider ?? null,
+        currency,
+        amountCents,
+        remainingAmountCents,
+        validFrom,
+        expiresAt,
+        appliesToBookingIds,
+        status: voucher.status === "active" ? "active" : "inactive",
+      },
+      input,
+    )
   },
+}
+
+/**
+ * Normalized shape passed into the validity evaluator. Both the new `vouchers`
+ * table and the legacy `payment_instruments` path map onto it so the
+ * checks (status/expiry/currency/amount/booking) only need to live in one place.
+ */
+interface ResolvedVoucher {
+  id: string
+  code: string
+  label: string | null
+  provider: string | null
+  currency: string | null
+  amountCents: number | null
+  remainingAmountCents: number | null
+  validFrom: string | null
+  expiresAt: string | null
+  appliesToBookingIds: string[]
+  /**
+   * Collapsed to `active | inactive`. The service's enum has more variants
+   * (redeemed / expired / void) but from a validate-for-spend perspective
+   * anything non-active should 409 the same way.
+   */
+  status: "active" | "inactive"
+}
+
+async function resolveVoucherFromNewTable(
+  db: PostgresJsDatabase,
+  code: string,
+): Promise<ResolvedVoucher | null> {
+  const [row] = await db
+    .select()
+    .from(vouchers)
+    .where(sql`lower(${vouchers.code}) = ${code.toLowerCase()}`)
+    .limit(1)
+
+  if (!row) return null
+
+  return {
+    id: row.id,
+    code: row.code,
+    label: null,
+    provider: null,
+    currency: row.currency,
+    amountCents: row.initialAmountCents,
+    remainingAmountCents: row.remainingAmountCents,
+    validFrom: null,
+    expiresAt: row.expiresAt ? row.expiresAt.toISOString() : null,
+    appliesToBookingIds: row.sourceBookingId ? [row.sourceBookingId] : [],
+    status: row.status === "active" ? "active" : "inactive",
+  }
+}
+
+function evaluateVoucherValidity(voucher: ResolvedVoucher, input: PublicValidateVoucherInput) {
+  const publicVoucher = {
+    id: voucher.id,
+    code: voucher.code,
+    label: voucher.label,
+    provider: voucher.provider,
+    currency: voucher.currency,
+    amountCents: voucher.amountCents,
+    remainingAmountCents: voucher.remainingAmountCents,
+    expiresAt: voucher.expiresAt,
+  }
+
+  if (voucher.status !== "active") {
+    return { valid: false as const, reason: "inactive" as const, voucher: publicVoucher }
+  }
+
+  if (voucher.validFrom && new Date(voucher.validFrom) > new Date()) {
+    return { valid: false as const, reason: "not_started" as const, voucher: publicVoucher }
+  }
+
+  if (voucher.expiresAt && new Date(voucher.expiresAt) < new Date()) {
+    return { valid: false as const, reason: "expired" as const, voucher: publicVoucher }
+  }
+
+  if (
+    input.bookingId &&
+    voucher.appliesToBookingIds.length > 0 &&
+    !voucher.appliesToBookingIds.includes(input.bookingId)
+  ) {
+    return { valid: false as const, reason: "booking_mismatch" as const, voucher: publicVoucher }
+  }
+
+  if (input.currency && voucher.currency && input.currency !== voucher.currency) {
+    return { valid: false as const, reason: "currency_mismatch" as const, voucher: publicVoucher }
+  }
+
+  if (
+    input.amountCents &&
+    voucher.remainingAmountCents !== null &&
+    input.amountCents > voucher.remainingAmountCents
+  ) {
+    return {
+      valid: false as const,
+      reason: "insufficient_balance" as const,
+      voucher: publicVoucher,
+    }
+  }
+
+  return { valid: true as const, reason: null, voucher: publicVoucher }
 }

--- a/packages/finance/tests/unit/validate-voucher-new-table.test.ts
+++ b/packages/finance/tests/unit/validate-voucher-new-table.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { publicFinanceService } from "../../src/service-public.js"
+
+describe("publicFinanceService.validateVoucher — new vouchers table path", () => {
+  function makeDb(options: {
+    voucherRow?: Record<string, unknown> | null
+    paymentInstrumentRow?: Record<string, unknown> | null
+  }) {
+    // Minimal drizzle chain stub: each builder call returns an object with
+    // the next-step method, resolving to an array the service destructures.
+    let selectCall = 0
+    return {
+      select: vi.fn(() => ({
+        from: vi.fn(() => {
+          const row = selectCall++ === 0 ? options.voucherRow : options.paymentInstrumentRow
+          return {
+            where: vi.fn(() => ({
+              limit: vi.fn(async () => (row ? [row] : [])),
+              orderBy: vi.fn(() => ({
+                limit: vi.fn(async () => (row ? [row] : [])),
+              })),
+            })),
+          }
+        }),
+      })),
+    }
+  }
+
+  it("returns valid when a matching row exists in the new vouchers table", async () => {
+    const db = makeDb({
+      voucherRow: {
+        id: "vch_abc",
+        code: "GIFT-123",
+        status: "active",
+        currency: "EUR",
+        initialAmountCents: 5000,
+        remainingAmountCents: 3000,
+        expiresAt: null,
+        sourceBookingId: null,
+      },
+    })
+
+    const result = await publicFinanceService.validateVoucher(db as never, {
+      code: "GIFT-123",
+    })
+
+    expect(result.valid).toBe(true)
+    expect(result.voucher).toMatchObject({
+      id: "vch_abc",
+      code: "GIFT-123",
+      currency: "EUR",
+      amountCents: 5000,
+      remainingAmountCents: 3000,
+    })
+  })
+
+  it("matches case-insensitively so operators can paste the code as-typed", async () => {
+    const db = makeDb({
+      voucherRow: {
+        id: "vch_abc",
+        code: "gift-abc",
+        status: "active",
+        currency: "EUR",
+        initialAmountCents: 1000,
+        remainingAmountCents: 1000,
+        expiresAt: null,
+        sourceBookingId: null,
+      },
+    })
+
+    const result = await publicFinanceService.validateVoucher(db as never, {
+      code: "  GIFT-ABC  ",
+    })
+
+    expect(result.valid).toBe(true)
+    expect(result.voucher?.id).toBe("vch_abc")
+  })
+
+  it("returns inactive when status is not active", async () => {
+    const db = makeDb({
+      voucherRow: {
+        id: "vch_abc",
+        code: "GIFT-123",
+        status: "redeemed",
+        currency: "EUR",
+        initialAmountCents: 5000,
+        remainingAmountCents: 0,
+        expiresAt: null,
+        sourceBookingId: null,
+      },
+    })
+
+    const result = await publicFinanceService.validateVoucher(db as never, {
+      code: "GIFT-123",
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.reason).toBe("inactive")
+  })
+
+  it("returns expired when the expiresAt is in the past", async () => {
+    const db = makeDb({
+      voucherRow: {
+        id: "vch_abc",
+        code: "GIFT-123",
+        status: "active",
+        currency: "EUR",
+        initialAmountCents: 5000,
+        remainingAmountCents: 3000,
+        expiresAt: new Date("2020-01-01"),
+        sourceBookingId: null,
+      },
+    })
+
+    const result = await publicFinanceService.validateVoucher(db as never, {
+      code: "GIFT-123",
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.reason).toBe("expired")
+  })
+
+  it("returns insufficient_balance when the requested amount exceeds remaining", async () => {
+    const db = makeDb({
+      voucherRow: {
+        id: "vch_abc",
+        code: "GIFT-123",
+        status: "active",
+        currency: "EUR",
+        initialAmountCents: 5000,
+        remainingAmountCents: 3000,
+        expiresAt: null,
+        sourceBookingId: null,
+      },
+    })
+
+    const result = await publicFinanceService.validateVoucher(db as never, {
+      code: "GIFT-123",
+      amountCents: 5000,
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.reason).toBe("insufficient_balance")
+  })
+
+  it("returns booking_mismatch when a sourceBookingId pins the voucher to a different booking", async () => {
+    const db = makeDb({
+      voucherRow: {
+        id: "vch_abc",
+        code: "GIFT-123",
+        status: "active",
+        currency: "EUR",
+        initialAmountCents: 5000,
+        remainingAmountCents: 5000,
+        expiresAt: null,
+        sourceBookingId: "book_other",
+      },
+    })
+
+    const result = await publicFinanceService.validateVoucher(db as never, {
+      code: "GIFT-123",
+      bookingId: "book_abc",
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.reason).toBe("booking_mismatch")
+  })
+
+  it("falls back to the legacy payment_instruments path when no new-table row exists", async () => {
+    const db = makeDb({
+      voucherRow: null,
+      paymentInstrumentRow: {
+        id: "pmin_legacy",
+        status: "active",
+        externalToken: "LEGACY-42",
+        directBillReference: null,
+        label: "Legacy voucher",
+        provider: null,
+        metadata: {
+          code: "LEGACY-42",
+          currency: "EUR",
+          amountCents: 2000,
+          remainingAmountCents: 2000,
+        },
+      },
+    })
+
+    const result = await publicFinanceService.validateVoucher(db as never, {
+      code: "LEGACY-42",
+    })
+
+    expect(result.valid).toBe(true)
+    expect(result.voucher?.id).toBe("pmin_legacy")
+    expect(result.voucher?.remainingAmountCents).toBe(2000)
+  })
+
+  it("returns not_found when neither table has a match", async () => {
+    const db = makeDb({ voucherRow: null, paymentInstrumentRow: null })
+
+    const result = await publicFinanceService.validateVoucher(db as never, {
+      code: "NOPE",
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.reason).toBe("not_found")
+    expect(result.voucher).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
Cutover slice of #227. The new first-class `vouchers` table from #239 was addressable only via the admin `POST /v1/finance/vouchers` endpoints — the storefront's `POST /v1/public/vouchers/validate` was still hitting `payment_instruments.metadata`. This switches the read path **with a fallback** so no data migration is required up front.

### Lookup order
1. `vouchers` table by `lower(code)` — anything issued via the new primitive lands here.
2. Legacy `payment_instruments` path, unchanged — pre-#239 vouchers plus any app still populating the JSONB blob.

Operators can run the migration script separately whenever they're ready; this PR doesn't assume it has happened.

### Shape
Both paths feed a shared `evaluateVoucherValidity` helper, so status/expiry/currency/amount/booking checks live in one place. The response envelope (`id`, `code`, `label`, `provider`, `currency`, `amountCents`, `remainingAmountCents`, `expiresAt`) is unchanged — existing storefront consumers don't see a wire-level difference.

New-table rows map cleanly:
- `status = 'active'` → active; anything else → inactive
- `expiresAt` timestamp → ISO string (or null)
- `sourceBookingId` → single-item `appliesToBookingIds`; preserves the `booking_mismatch` behavior from the legacy `metadata.bookingIds` shape
- `label` / `provider` are null — the new table doesn't track those, and the storefront shows `code`, not `label`.

### Stacked on #239
Base: `feat/227-vouchers-foundation`. GitHub will retarget to `main` once #239 merges.

### Out of scope
- Data migration `payment_instruments.metadata` → `vouchers`. Safe to defer since the fallback path keeps working.
- Multi-booking applicability (`bookingIds` array). The new table's `sourceBookingId` is a single FK — covers refund-as-credit and gift vouchers. Multi-booking scoping was never widely used in the legacy path and can be a follow-up column if demand appears.

Related to #227.

## Test plan
- [x] `pnpm -F @voyantjs/finance typecheck`
- [x] `pnpm -F @voyantjs/finance test` — 59 passing. 8 new unit cases covering the new-table path: valid / case-insensitive match / inactive / expired / insufficient_balance / booking_mismatch / legacy fallback / not_found across both tables.
- [x] `pnpm typecheck` — 136/136 tasks clean.
- [ ] Smoke: issue a voucher via admin `POST /v1/finance/vouchers` → hit `/v1/public/vouchers/validate` with the returned code → `{ valid: true }`. Repeat for a voucher still in `payment_instruments.metadata`; both resolve.