### PR TITLE
feat(bookings): emit booking.cancelled + booking.expired events

### DIFF
--- a/packages/bookings/src/routes.ts
+++ b/packages/bookings/src/routes.ts
@@ -532,6 +532,7 @@ export const bookingRoutes = new Hono<Env>()
       c.req.param("id"),
       await parseJsonBody(c, expireBookingSchema),
       c.get("userId"),
+      { eventBus: c.get("eventBus"), cause: "route" },
     )
 
     if (result.status === "not_found") {
@@ -556,6 +557,7 @@ export const bookingRoutes = new Hono<Env>()
         c.get("db"),
         await parseJsonBody(c, expireStaleBookingsSchema),
         c.get("userId"),
+        { eventBus: c.get("eventBus") },
       ),
     )
   })
@@ -567,6 +569,7 @@ export const bookingRoutes = new Hono<Env>()
       c.req.param("id"),
       await parseJsonBody(c, cancelBookingSchema),
       c.get("userId"),
+      { eventBus: c.get("eventBus") },
     )
 
     if (result.status === "not_found") {

--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -160,6 +160,31 @@ export interface BookingConfirmedEvent {
   actorId: string | null
 }
 
+/**
+ * Payload for `booking.cancelled`. `previousStatus` is the state the booking
+ * transitioned *out of* — useful for subscribers that care about cancelling a
+ * confirmed booking (refund flow) vs cancelling a draft/hold (no side effects).
+ */
+export interface BookingCancelledEvent {
+  bookingId: string
+  bookingNumber: string
+  previousStatus: "draft" | "on_hold" | "confirmed" | "in_progress"
+  actorId: string | null
+}
+
+/**
+ * Payload for `booking.expired`. Fires when an on-hold booking's timer runs
+ * out. `cause` flags whether it was the explicit route call or the sweep job —
+ * subscribers that want to email the customer should probably skip
+ * sweep-originated events to avoid pager noise during backfills.
+ */
+export interface BookingExpiredEvent {
+  bookingId: string
+  bookingNumber: string
+  cause: "route" | "sweep"
+  actorId: string | null
+}
+
 const travelerParticipantTypes = ["traveler", "occupant"] as const
 
 class BookingServiceError extends Error {
@@ -1990,11 +2015,11 @@ export const bookingsService = {
     }
 
     if (current.status === "on_hold" && data.status === "expired") {
-      return bookingsService.expireBooking(db, id, { note: data.note }, userId)
+      return bookingsService.expireBooking(db, id, { note: data.note }, userId, runtime)
     }
 
     if (data.status === "cancelled") {
-      return bookingsService.cancelBooking(db, id, { note: data.note }, userId)
+      return bookingsService.cancelBooking(db, id, { note: data.note }, userId, runtime)
     }
 
     if (data.status === "on_hold") {
@@ -2216,9 +2241,10 @@ export const bookingsService = {
     id: string,
     data: ExpireBookingInput,
     userId?: string,
+    runtime: BookingServiceRuntime & { cause?: "route" | "sweep" } = {},
   ) {
     try {
-      return await db.transaction(async (tx) => {
+      const result = await db.transaction(async (tx) => {
         const rows = await tx.execute(
           sql`SELECT id, status, hold_expires_at
               FROM ${bookings}
@@ -2293,6 +2319,21 @@ export const bookingsService = {
 
         return { status: "ok" as const, booking: row ?? null }
       })
+
+      if (result.status === "ok" && result.booking) {
+        await runtime.eventBus?.emit(
+          "booking.expired",
+          {
+            bookingId: result.booking.id,
+            bookingNumber: result.booking.bookingNumber,
+            cause: runtime.cause ?? "route",
+            actorId: userId ?? null,
+          } satisfies BookingExpiredEvent,
+          { category: "domain", source: "service" },
+        )
+      }
+
+      return result
     } catch (error) {
       if (error instanceof BookingServiceError) {
         return { status: error.code as Exclude<string, "ok"> }
@@ -2305,6 +2346,7 @@ export const bookingsService = {
     db: PostgresJsDatabase,
     data: ExpireStaleBookingsInput,
     userId?: string,
+    runtime: BookingServiceRuntime = {},
   ) {
     const cutoff = data.before ? new Date(data.before) : new Date()
     const staleBookings = await db
@@ -2327,6 +2369,7 @@ export const bookingsService = {
         booking.id,
         { note: data.note ?? "Hold expired by sweep" },
         userId,
+        { ...runtime, cause: "sweep" },
       )
 
       if ("booking" in result && result.booking) {
@@ -2346,9 +2389,10 @@ export const bookingsService = {
     id: string,
     data: CancelBookingInput,
     userId?: string,
+    runtime: BookingServiceRuntime = {},
   ) {
     try {
-      return await db.transaction(async (tx) => {
+      const result = await db.transaction(async (tx) => {
         const rows = await tx.execute(
           sql`SELECT id, status
               FROM ${bookings}
@@ -2363,6 +2407,8 @@ export const bookingsService = {
         if (!["draft", "on_hold", "confirmed", "in_progress"].includes(booking.status)) {
           throw new BookingServiceError("invalid_transition")
         }
+
+        const previousStatus = booking.status as BookingCancelledEvent["previousStatus"]
 
         const allocations = await tx
           .select()
@@ -2436,8 +2482,23 @@ export const bookingsService = {
         // Clean up any booking-group membership (dissolve if ≤1 active members remain).
         await cleanupGroupOnBookingCancelled(tx as PostgresJsDatabase, id)
 
-        return { status: "ok" as const, booking: row ?? null }
+        return { status: "ok" as const, booking: row ?? null, previousStatus }
       })
+
+      if (result.status === "ok" && result.booking) {
+        await runtime.eventBus?.emit(
+          "booking.cancelled",
+          {
+            bookingId: result.booking.id,
+            bookingNumber: result.booking.bookingNumber,
+            previousStatus: result.previousStatus,
+            actorId: userId ?? null,
+          } satisfies BookingCancelledEvent,
+          { category: "domain", source: "service" },
+        )
+      }
+
+      return { status: result.status, booking: result.booking }
     } catch (error) {
       if (error instanceof BookingServiceError) {
         return { status: error.code as Exclude<string, "ok"> }

--- a/packages/bookings/tests/integration/routes.test.ts
+++ b/packages/bookings/tests/integration/routes.test.ts
@@ -847,6 +847,113 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
       expect(updatedSlot?.remainingPax).toBe(3)
     })
 
+    it("emits booking.cancelled with previousStatus after cancel", async () => {
+      const slot = await seedSlot({ initialPax: 3, remainingPax: 3 })
+      const reserveRes = await app.request("/reserve", {
+        method: "POST",
+        ...json({
+          bookingNumber: nextBookingNumber(),
+          sellCurrency: "USD",
+          items: [{ title: "Adult ticket", availabilitySlotId: slot.id, quantity: 1 }],
+        }),
+      })
+      const { data: booking } = await reserveRes.json()
+      await app.request(`/${booking.id}/confirm`, { method: "POST", ...json({}) })
+
+      const received: Array<{
+        bookingId: string
+        bookingNumber: string
+        previousStatus: string
+        actorId: string | null
+      }> = []
+      const sub = eventBus.subscribe("booking.cancelled", (event) => {
+        received.push(event.data as (typeof received)[number])
+      })
+
+      try {
+        const res = await app.request(`/${booking.id}/cancel`, {
+          method: "POST",
+          ...json({}),
+        })
+        expect(res.status).toBe(200)
+      } finally {
+        sub.unsubscribe()
+      }
+
+      expect(received).toHaveLength(1)
+      expect(received[0]).toMatchObject({
+        bookingId: booking.id,
+        bookingNumber: booking.bookingNumber,
+        previousStatus: "confirmed",
+        actorId: "test-user-id",
+      })
+    })
+
+    it("emits booking.expired with cause=route when /:id/expire fires", async () => {
+      const slot = await seedSlot({ initialPax: 2, remainingPax: 2 })
+      const reserveRes = await app.request("/reserve", {
+        method: "POST",
+        ...json({
+          bookingNumber: nextBookingNumber(),
+          sellCurrency: "USD",
+          items: [{ title: "Adult ticket", availabilitySlotId: slot.id, quantity: 1 }],
+        }),
+      })
+      const { data: booking } = await reserveRes.json()
+
+      const received: Array<{ bookingId: string; cause: string; actorId: string | null }> = []
+      const sub = eventBus.subscribe("booking.expired", (event) => {
+        received.push(event.data as (typeof received)[number])
+      })
+
+      try {
+        const res = await app.request(`/${booking.id}/expire`, {
+          method: "POST",
+          ...json({}),
+        })
+        expect(res.status).toBe(200)
+      } finally {
+        sub.unsubscribe()
+      }
+
+      expect(received).toHaveLength(1)
+      expect(received[0]).toMatchObject({ bookingId: booking.id, cause: "route" })
+    })
+
+    it("emits booking.expired with cause=sweep from expireStaleBookings", async () => {
+      const slot = await seedSlot({ initialPax: 4, remainingPax: 4 })
+      const reserveRes = await app.request("/reserve", {
+        method: "POST",
+        ...json({
+          bookingNumber: nextBookingNumber(),
+          sellCurrency: "USD",
+          items: [{ title: "Adult ticket", availabilitySlotId: slot.id, quantity: 1 }],
+        }),
+      })
+      const { data: booking } = await reserveRes.json()
+      await app.request(`/${booking.id}/extend-hold`, {
+        method: "POST",
+        ...json({ holdExpiresAt: "2020-01-01T00:00:00.000Z" }),
+      })
+
+      const received: Array<{ bookingId: string; cause: string }> = []
+      const sub = eventBus.subscribe("booking.expired", (event) => {
+        received.push(event.data as (typeof received)[number])
+      })
+
+      try {
+        const res = await app.request("/expire-stale", {
+          method: "POST",
+          ...json({ before: "2026-12-31T00:00:00.000Z" }),
+        })
+        expect(res.status).toBe(200)
+      } finally {
+        sub.unsubscribe()
+      }
+
+      expect(received.some((r) => r.bookingId === booking.id && r.cause === "sweep")).toBe(true)
+    })
+
     it("expires stale on-hold bookings in batch", async () => {
       const slot = await seedSlot({ initialPax: 4, remainingPax: 4 })
       const reserveRes = await app.request("/reserve", {


### PR DESCRIPTION
## Summary
Same pattern as the `booking.confirmed` emit (#245) applied to the two remaining terminal transitions. Closes out the domain-event set #228 called for.

### Payload shapes

- **`BookingCancelledEvent`** — `{ bookingId, bookingNumber, previousStatus, actorId }`. `previousStatus` is one of `draft | on_hold | confirmed | in_progress`, captured inside the transaction before the update, so subscribers that care about "confirmed booking got cancelled" (refund flow) can tell it apart from draft cancellation (no side effects).
- **`BookingExpiredEvent`** — `{ bookingId, bookingNumber, cause, actorId }`. `cause` is `"route"` (operator hit `POST /:id/expire` directly) or `"sweep"` (background `expireStaleBookings`). Subscribers that send a customer email should probably skip `sweep` events to avoid pager noise during backfills.

### Emission points

- `cancelBooking(runtime?)` — emits `booking.cancelled` after commit. `previousStatus` is read from the `FOR UPDATE` row, not inferred post-hoc.
- `expireBooking(runtime?: BookingServiceRuntime & { cause? })` — defaults to `cause: "route"`.
- `expireStaleBookings(runtime?)` — forwards `{ ...runtime, cause: "sweep" }` to each per-booking `expireBooking`.
- `updateBookingStatus` now forwards `runtime` to cancel as well as confirm/expire.

### Route wiring
`/:id/cancel`, `/:id/expire`, and `/expire-stale` all pass `c.var.eventBus` through. Mechanical mirror of the `/:id/confirm` path from #245 so the diff stays boring.

### Cherry-pick

Bundled the `booking.confirmed` commit onto this branch so the PR is buildable + testable end-to-end. Git will dedupe it when #245 merges.

Related to #228.

## Test plan
- [x] `pnpm -F @voyantjs/bookings typecheck`
- [x] `pnpm -F @voyantjs/bookings test` — 105 passing. Three new integration tests (skipped without `TEST_DATABASE_URL`):
  - `emits booking.cancelled with previousStatus after cancel` — confirmed-then-cancelled path, expects `previousStatus: "confirmed"`.
  - `emits booking.expired with cause=route when /:id/expire fires`.
  - `emits booking.expired with cause=sweep from expireStaleBookings`.
- [x] `pnpm typecheck` — 136/136 tasks clean.
- [ ] Smoke: subscribe a log handler to `app.eventBus`; cancel a confirmed booking, expire one via route, then run `/expire-stale`. All three events surface with the right payloads.