### PR TITLE
feat(bookings-ui): rooms stepper section driven by slot unit availability

### DIFF
--- a/packages/ui/registry.json
+++ b/packages/ui/registry.json
@@ -755,6 +755,21 @@
       ]
     },
     {
+      "name": "voyant-bookings-rooms-stepper-section",
+      "type": "registry:component",
+      "title": "Booking Rooms Stepper Section",
+      "description": "Per-option-unit quantity stepper for booking-create, driven by GET /v1/availability/slots/:id/unit-availability. Shows live 'N left' counters; min/max enforced against the server's remaining count so the UI can't queue up a 409.",
+      "dependencies": ["@voyantjs/availability-react", "lucide-react"],
+      "registryDependencies": ["button", "label"],
+      "files": [
+        {
+          "path": "registry/bookings/rooms-stepper-section.tsx",
+          "type": "registry:component",
+          "target": "components/voyant/bookings/rooms-stepper-section.tsx"
+        }
+      ]
+    },
+    {
       "name": "voyant-bookings-quick-book-dialog",
       "type": "registry:component",
       "title": "Quick Book Dialog",

--- a/packages/ui/registry/bookings/rooms-stepper-section.tsx
+++ b/packages/ui/registry/bookings/rooms-stepper-section.tsx
@@ -1,0 +1,151 @@
+"use client"
+
+import { useSlotUnitAvailability } from "@voyantjs/availability-react"
+import { Minus, Plus } from "lucide-react"
+
+import { Button, Label } from "@/components/ui"
+
+/** Quantity per option_unit id; omitted ids are treated as 0. */
+export interface RoomsStepperValue {
+  quantities: Record<string, number>
+}
+
+export const emptyRoomsStepperValue: RoomsStepperValue = { quantities: {} }
+
+export interface RoomsStepperSectionProps {
+  value: RoomsStepperValue
+  onChange: (value: RoomsStepperValue) => void
+  /**
+   * Departure the operator picked. Section renders nothing until a slot is
+   * chosen — per-unit availability is a property of the slot, not the
+   * product, so there's nothing to show before then.
+   */
+  slotId?: string
+  enabled?: boolean
+  labels?: {
+    heading?: string
+    noSlot?: string
+    noUnits?: string
+    remaining?: string
+    unlimited?: string
+  }
+}
+
+const DEFAULT_LABELS = {
+  heading: "Rooms",
+  noSlot: "Pick a departure first to see available rooms.",
+  noUnits: "This departure has no per-unit availability configured.",
+  remaining: "left",
+  unlimited: "unlimited",
+} as const
+
+/**
+ * Rooms / per-unit stepper for booking-create flows. Drives
+ * `GET /v1/availability/slots/:id/unit-availability` from #235 so the
+ * operator sees authoritative "3 doubles available" numbers instead of
+ * client-side math against a sampled booking list.
+ *
+ * The section only tracks **intent** (how many of each unit the operator
+ * wants to book). Actual hold/reservation happens when the parent submits
+ * the booking — capacity drops the moment the reservation transaction
+ * commits; the next refetch of `useSlotUnitAvailability` reflects it.
+ *
+ * ### Stepper bounds
+ *
+ * - Minimum is 0 (operator can deselect).
+ * - Maximum is the unit's `remaining` count from the server. Unlimited
+ *   pools (`remaining === null`) have no upper bound.
+ * - The server is the truth: entering `3 doubles` when only 2 remain just
+ *   disables the "+" button — we don't let the UI submit a request that
+ *   would 409 at insert time.
+ */
+export function RoomsStepperSection({
+  value,
+  onChange,
+  slotId,
+  enabled = true,
+  labels,
+}: RoomsStepperSectionProps) {
+  const merged = { ...DEFAULT_LABELS, ...labels }
+  const availability = useSlotUnitAvailability({ slotId, enabled: enabled && Boolean(slotId) })
+  const units = availability.data?.data ?? []
+
+  if (!slotId) {
+    return (
+      <div className="flex flex-col gap-2 rounded-md border p-3">
+        <Label>{merged.heading}</Label>
+        <p className="text-xs text-muted-foreground">{merged.noSlot}</p>
+      </div>
+    )
+  }
+
+  if (availability.isSuccess && units.length === 0) {
+    return (
+      <div className="flex flex-col gap-2 rounded-md border p-3">
+        <Label>{merged.heading}</Label>
+        <p className="text-xs text-muted-foreground">{merged.noUnits}</p>
+      </div>
+    )
+  }
+
+  const setQuantity = (unitId: string, qty: number) => {
+    const next = { ...value.quantities }
+    if (qty <= 0) {
+      delete next[unitId]
+    } else {
+      next[unitId] = qty
+    }
+    onChange({ quantities: next })
+  }
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border p-3">
+      <Label>{merged.heading}</Label>
+      <div className="flex flex-col gap-2">
+        {units.map((unit) => {
+          const qty = value.quantities[unit.optionUnitId] ?? 0
+          const remainingLabel =
+            unit.remaining === null ? merged.unlimited : `${unit.remaining} ${merged.remaining}`
+          const atMax = unit.remaining !== null && qty >= unit.remaining
+
+          return (
+            <div
+              key={unit.optionUnitId}
+              className="flex items-center gap-3 rounded-md border px-3 py-2"
+            >
+              <div className="flex-1">
+                <div className="text-sm font-medium">{unit.unitName}</div>
+                <div className="text-xs text-muted-foreground">{remainingLabel}</div>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 p-0"
+                  onClick={() => setQuantity(unit.optionUnitId, Math.max(0, qty - 1))}
+                  disabled={qty <= 0}
+                  aria-label={`Decrease ${unit.unitName}`}
+                >
+                  <Minus className="h-3.5 w-3.5" />
+                </Button>
+                <span className="min-w-[1.5rem] text-center text-sm tabular-nums">{qty}</span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 p-0"
+                  onClick={() => setQuantity(unit.optionUnitId, qty + 1)}
+                  disabled={atMax}
+                  aria-label={`Increase ${unit.unitName}`}
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/templates/operator/src/components/voyant/bookings/rooms-stepper-section.tsx
+++ b/templates/operator/src/components/voyant/bookings/rooms-stepper-section.tsx
@@ -1,0 +1,151 @@
+"use client"
+
+import { useSlotUnitAvailability } from "@voyantjs/availability-react"
+import { Minus, Plus } from "lucide-react"
+
+import { Button, Label } from "@/components/ui"
+
+/** Quantity per option_unit id; omitted ids are treated as 0. */
+export interface RoomsStepperValue {
+  quantities: Record<string, number>
+}
+
+export const emptyRoomsStepperValue: RoomsStepperValue = { quantities: {} }
+
+export interface RoomsStepperSectionProps {
+  value: RoomsStepperValue
+  onChange: (value: RoomsStepperValue) => void
+  /**
+   * Departure the operator picked. Section renders nothing until a slot is
+   * chosen — per-unit availability is a property of the slot, not the
+   * product, so there's nothing to show before then.
+   */
+  slotId?: string
+  enabled?: boolean
+  labels?: {
+    heading?: string
+    noSlot?: string
+    noUnits?: string
+    remaining?: string
+    unlimited?: string
+  }
+}
+
+const DEFAULT_LABELS = {
+  heading: "Rooms",
+  noSlot: "Pick a departure first to see available rooms.",
+  noUnits: "This departure has no per-unit availability configured.",
+  remaining: "left",
+  unlimited: "unlimited",
+} as const
+
+/**
+ * Rooms / per-unit stepper for booking-create flows. Drives
+ * `GET /v1/availability/slots/:id/unit-availability` from #235 so the
+ * operator sees authoritative "3 doubles available" numbers instead of
+ * client-side math against a sampled booking list.
+ *
+ * The section only tracks **intent** (how many of each unit the operator
+ * wants to book). Actual hold/reservation happens when the parent submits
+ * the booking — capacity drops the moment the reservation transaction
+ * commits; the next refetch of `useSlotUnitAvailability` reflects it.
+ *
+ * ### Stepper bounds
+ *
+ * - Minimum is 0 (operator can deselect).
+ * - Maximum is the unit's `remaining` count from the server. Unlimited
+ *   pools (`remaining === null`) have no upper bound.
+ * - The server is the truth: entering `3 doubles` when only 2 remain just
+ *   disables the "+" button — we don't let the UI submit a request that
+ *   would 409 at insert time.
+ */
+export function RoomsStepperSection({
+  value,
+  onChange,
+  slotId,
+  enabled = true,
+  labels,
+}: RoomsStepperSectionProps) {
+  const merged = { ...DEFAULT_LABELS, ...labels }
+  const availability = useSlotUnitAvailability({ slotId, enabled: enabled && Boolean(slotId) })
+  const units = availability.data?.data ?? []
+
+  if (!slotId) {
+    return (
+      <div className="flex flex-col gap-2 rounded-md border p-3">
+        <Label>{merged.heading}</Label>
+        <p className="text-xs text-muted-foreground">{merged.noSlot}</p>
+      </div>
+    )
+  }
+
+  if (availability.isSuccess && units.length === 0) {
+    return (
+      <div className="flex flex-col gap-2 rounded-md border p-3">
+        <Label>{merged.heading}</Label>
+        <p className="text-xs text-muted-foreground">{merged.noUnits}</p>
+      </div>
+    )
+  }
+
+  const setQuantity = (unitId: string, qty: number) => {
+    const next = { ...value.quantities }
+    if (qty <= 0) {
+      delete next[unitId]
+    } else {
+      next[unitId] = qty
+    }
+    onChange({ quantities: next })
+  }
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border p-3">
+      <Label>{merged.heading}</Label>
+      <div className="flex flex-col gap-2">
+        {units.map((unit) => {
+          const qty = value.quantities[unit.optionUnitId] ?? 0
+          const remainingLabel =
+            unit.remaining === null ? merged.unlimited : `${unit.remaining} ${merged.remaining}`
+          const atMax = unit.remaining !== null && qty >= unit.remaining
+
+          return (
+            <div
+              key={unit.optionUnitId}
+              className="flex items-center gap-3 rounded-md border px-3 py-2"
+            >
+              <div className="flex-1">
+                <div className="text-sm font-medium">{unit.unitName}</div>
+                <div className="text-xs text-muted-foreground">{remainingLabel}</div>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 p-0"
+                  onClick={() => setQuantity(unit.optionUnitId, Math.max(0, qty - 1))}
+                  disabled={qty <= 0}
+                  aria-label={`Decrease ${unit.unitName}`}
+                >
+                  <Minus className="h-3.5 w-3.5" />
+                </Button>
+                <span className="min-w-[1.5rem] text-center text-sm tabular-nums">{qty}</span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 p-0"
+                  onClick={() => setQuantity(unit.optionUnitId, qty + 1)}
+                  disabled={atMax}
+                  aria-label={`Increase ${unit.unitName}`}
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
Next slice of #223. First UI consumer of the per-option-unit endpoint from #235 — operators get authoritative "N doubles left" counters instead of client-side math against a sampled booking list.

### Surface

New registry component `voyant-bookings-rooms-stepper-section`:

- **`RoomsStepperValue`** — `{ quantities: Record<optionUnitId, number> }`. Zero quantities are deleted so downstream iteration doesn't have to filter.
- `emptyRoomsStepperValue` exported for reset.
- Calls `useSlotUnitAvailability({ slotId })` (#235) to fetch live `{ optionUnitId, unitName, occupancyMax, initial, reserved, remaining }` rows; renders one stepper per unit with a remaining-count hint.
- **Min=0, Max=`unit.remaining`** (or unbounded when `remaining === null` for an unlimited pool). "+" is disabled at max so we don't let the UI submit a request that would 409 at the reservation transaction.
- Three empty-states:
  - No `slotId` → "Pick a departure first to see available rooms."
  - Slot has no option_units → "This departure has no per-unit availability configured."
  - Loading → renders nothing (surrounding dialog already has progress affordances).

### Template mirror

Section file copied into `templates/operator/src/components/voyant/bookings/` so the template remains buildable. **Not yet mounted** inside `BookingDialog` — the composition slice wires all sections together after the last create-flow piece (passengers + price breakdown) lands.

### Stacked on #235

Base: `feat/225-slot-unit-availability`. GitHub will retarget to `main` when #235 merges.

Related to #223.

## Test plan
- [x] `pnpm -F operator typecheck`
- [x] `pnpm typecheck` — 136/136 tasks clean.
- [ ] Smoke: seed a slot with 2-person double + 1-person single, initial 3 each. With no bookings, stepper shows "3 left" for both. Add a booking allocating 2 doubles → double counter drops to "1 left", "+" disabled at qty=1.
- [ ] Slot with no `option_id` (single-unit product) → `noUnits` hint renders.