### PR TITLE
feat(notifications): auto-dispatch subscriber for booking.confirmed (#228)

### DIFF
--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -1,5 +1,6 @@
 import type { Module } from "@voyantjs/core"
 import type { HonoModule } from "@voyantjs/hono/module"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import {
   buildNotificationsRouteRuntime,
@@ -8,6 +9,8 @@ import {
   type NotificationsRoutesOptions,
 } from "./routes.js"
 import { notificationsModule } from "./schema.js"
+import { createNotificationService } from "./service.js"
+import { bookingDocumentNotificationsService } from "./service-booking-documents.js"
 
 export {
   notificationLiquidEngine,
@@ -136,16 +139,84 @@ export {
   updateNotificationTemplateSchema,
 } from "./validation.js"
 
-export function createNotificationsHonoModule(options?: NotificationsRoutesOptions): HonoModule {
+/**
+ * Auto-dispatch policy for the `booking.confirmed` subscriber. Set `enabled:
+ * false` (or leave the option off entirely) to opt out.
+ */
+export interface NotificationsAutoConfirmAndDispatchOptions {
+  enabled?: boolean
+  /** Notification template slug used when the handler fires. */
+  templateSlug?: string
+  /** Optional allowlist of document types to attach; defaults to all. */
+  documentTypes?: Array<"contract" | "invoice" | "proforma">
+}
+
+export interface CreateNotificationsHonoModuleOptions extends NotificationsRoutesOptions {
+  /**
+   * Resolves a database from runtime bindings. Required for
+   * `autoConfirmAndDispatch` — the `booking.confirmed` subscriber fires
+   * outside a request scope and needs its own db handle.
+   */
+  resolveDb?: (bindings: Record<string, unknown>) => PostgresJsDatabase
+  autoConfirmAndDispatch?: NotificationsAutoConfirmAndDispatchOptions
+}
+
+export function createNotificationsHonoModule(
+  options?: CreateNotificationsHonoModuleOptions,
+): HonoModule {
   const routes = createNotificationsRoutes(options)
 
   const module: Module = {
     ...notificationsModule,
-    bootstrap: ({ bindings, container }) => {
+    bootstrap: ({ bindings, container, eventBus }) => {
       container.register(
         NOTIFICATIONS_ROUTE_RUNTIME_CONTAINER_KEY,
         buildNotificationsRouteRuntime(bindings as Record<string, unknown>, options),
       )
+
+      // Auto-dispatch wiring — opt-in. When enabled, every `booking.confirmed`
+      // event triggers a `confirmAndDispatchBooking` call so the operator
+      // doesn't have to click a second button. The handler runs in the same
+      // process as the emitter (the in-process event bus) but outside the
+      // request scope, so we resolve our own db handle from bindings.
+      if (options?.autoConfirmAndDispatch?.enabled && options.resolveDb) {
+        const resolveDb = options.resolveDb
+        const autoOptions = options.autoConfirmAndDispatch
+        const runtime = buildNotificationsRouteRuntime(bindings as Record<string, unknown>, options)
+        const dispatcher = createNotificationService(runtime.providers)
+
+        eventBus.subscribe(
+          "booking.confirmed",
+          async (event: {
+            data: { bookingId: string; bookingNumber: string; actorId: string | null }
+          }) => {
+            try {
+              const db = resolveDb(bindings as Record<string, unknown>)
+              await bookingDocumentNotificationsService.confirmAndDispatchBooking(
+                db,
+                dispatcher,
+                event.data.bookingId,
+                {
+                  templateSlug: autoOptions.templateSlug ?? null,
+                  documentTypes: autoOptions.documentTypes ?? null,
+                },
+                {
+                  attachmentResolver: runtime.documentAttachmentResolver,
+                  eventBus,
+                },
+              )
+            } catch (error) {
+              // Per the EventBus contract, handler failures are logged, not
+              // rethrown. We surface the context so ops can diagnose without
+              // digging through stack traces.
+              const message = error instanceof Error ? error.message : String(error)
+              console.error(
+                `[notifications] auto-dispatch failed for booking ${event.data.bookingId}: ${message}`,
+              )
+            }
+          },
+        )
+      }
     },
   }
 

--- a/packages/notifications/tests/unit/auto-dispatch.test.ts
+++ b/packages/notifications/tests/unit/auto-dispatch.test.ts
@@ -1,0 +1,127 @@
+import { createContainer, createEventBus } from "@voyantjs/core"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { describe, expect, it, vi } from "vitest"
+
+import { createNotificationsHonoModule } from "../../src/index.js"
+import { bookingDocumentNotificationsService } from "../../src/service-booking-documents.js"
+
+function fakeBindings() {
+  return {} as Record<string, unknown>
+}
+
+describe("createNotificationsHonoModule — autoConfirmAndDispatch", () => {
+  it("does NOT subscribe when autoConfirmAndDispatch is off", async () => {
+    const eventBus = createEventBus()
+    const container = createContainer()
+    const subscribeSpy = vi.spyOn(eventBus, "subscribe")
+
+    const module = createNotificationsHonoModule({
+      // resolveDb intentionally omitted — the check requires both anyway.
+    })
+
+    await module.module.bootstrap?.({ bindings: fakeBindings(), container, eventBus })
+
+    expect(subscribeSpy).not.toHaveBeenCalled()
+  })
+
+  it("does NOT subscribe when autoConfirmAndDispatch.enabled is false", async () => {
+    const eventBus = createEventBus()
+    const container = createContainer()
+    const subscribeSpy = vi.spyOn(eventBus, "subscribe")
+
+    const module = createNotificationsHonoModule({
+      resolveDb: () => ({}) as PostgresJsDatabase,
+      autoConfirmAndDispatch: { enabled: false, templateSlug: "booking-confirmation" },
+    })
+
+    await module.module.bootstrap?.({ bindings: fakeBindings(), container, eventBus })
+
+    expect(subscribeSpy).not.toHaveBeenCalled()
+  })
+
+  it("does NOT subscribe when resolveDb is missing — guard against partial config", async () => {
+    const eventBus = createEventBus()
+    const container = createContainer()
+    const subscribeSpy = vi.spyOn(eventBus, "subscribe")
+
+    const module = createNotificationsHonoModule({
+      autoConfirmAndDispatch: { enabled: true, templateSlug: "booking-confirmation" },
+    })
+
+    await module.module.bootstrap?.({ bindings: fakeBindings(), container, eventBus })
+
+    expect(subscribeSpy).not.toHaveBeenCalled()
+  })
+
+  it("subscribes to booking.confirmed and forwards to confirmAndDispatchBooking when enabled", async () => {
+    const eventBus = createEventBus()
+    const container = createContainer()
+    const db = { fake: true } as unknown as PostgresJsDatabase
+
+    const dispatchSpy = vi
+      .spyOn(bookingDocumentNotificationsService, "confirmAndDispatchBooking")
+      .mockResolvedValue({
+        status: "preview" as const,
+        bookingId: "book_abc",
+        documents: [],
+      })
+
+    const module = createNotificationsHonoModule({
+      resolveDb: () => db,
+      autoConfirmAndDispatch: {
+        enabled: true,
+        templateSlug: "booking-confirmation",
+        documentTypes: ["invoice", "contract"],
+      },
+    })
+
+    await module.module.bootstrap?.({ bindings: fakeBindings(), container, eventBus })
+    await eventBus.emit("booking.confirmed", {
+      bookingId: "book_abc",
+      bookingNumber: "BK-001",
+      actorId: "user_1",
+    })
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1)
+    const call = dispatchSpy.mock.calls[0]
+    expect(call?.[0]).toBe(db) // first arg = db
+    expect(call?.[2]).toBe("book_abc") // third arg = bookingId
+    expect(call?.[3]).toMatchObject({
+      templateSlug: "booking-confirmation",
+      documentTypes: ["invoice", "contract"],
+    })
+
+    dispatchSpy.mockRestore()
+  })
+
+  it("swallows subscriber errors — a failing dispatch never propagates back to the emitter", async () => {
+    const eventBus = createEventBus()
+    const container = createContainer()
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+
+    vi.spyOn(bookingDocumentNotificationsService, "confirmAndDispatchBooking").mockRejectedValue(
+      new Error("boom"),
+    )
+
+    const module = createNotificationsHonoModule({
+      resolveDb: () => ({}) as PostgresJsDatabase,
+      autoConfirmAndDispatch: { enabled: true, templateSlug: "booking-confirmation" },
+    })
+
+    await module.module.bootstrap?.({ bindings: fakeBindings(), container, eventBus })
+
+    // emit should resolve cleanly — if the handler threw through, this would
+    // await a rejected promise and throw here.
+    await expect(
+      eventBus.emit("booking.confirmed", {
+        bookingId: "book_abc",
+        bookingNumber: "BK-001",
+        actorId: null,
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringMatching(/auto-dispatch failed.*book_abc/))
+    errorSpy.mockRestore()
+    vi.restoreAllMocks()
+  })
+})


### PR DESCRIPTION
Re-opened from closed #246 after base branches merged. Extends createNotificationsHonoModule with resolveDb + autoConfirmAndDispatch options; bootstrap subscribes to booking.confirmed when both are set.