### PR TITLE
feat(bookings-ui): price breakdown section with live tiered computation (#223)

### DIFF
--- a/packages/ui/registry.json
+++ b/packages/ui/registry.json
@@ -845,6 +845,21 @@
       ]
     },
     {
+      "name": "voyant-bookings-price-breakdown-section",
+      "type": "registry:component",
+      "title": "Booking Price Breakdown Section",
+      "description": "Read-only live price breakdown for booking-create flows. Reads the catalog-resolved pricing snapshot via usePricingPreview and computes per-unit tiered lines + total against the operator's current unit quantities — same math the storefront runs.",
+      "dependencies": ["@voyantjs/bookings-react"],
+      "registryDependencies": ["label"],
+      "files": [
+        {
+          "path": "registry/bookings/price-breakdown-section.tsx",
+          "type": "registry:component",
+          "target": "components/voyant/bookings/price-breakdown-section.tsx"
+        }
+      ]
+    },
+    {
       "name": "voyant-bookings-quick-book-dialog",
       "type": "registry:component",
       "title": "Quick Book Dialog",

--- a/packages/ui/registry/bookings/price-breakdown-section.tsx
+++ b/packages/ui/registry/bookings/price-breakdown-section.tsx
@@ -1,0 +1,264 @@
+"use client"
+
+import { usePricingPreview } from "@voyantjs/bookings-react"
+import * as React from "react"
+
+import { Label } from "@/components/ui"
+
+export interface PriceBreakdownLine {
+  unitId: string
+  label: string
+  quantity: number
+  /** Per-unit price for the matched tier/row. `null` = on-request pricing. */
+  unitAmountCents: number | null
+  /** `unitAmountCents * quantity` or null when on-request. */
+  totalAmountCents: number | null
+  /**
+   * Populated when a non-default tier matched — operator-visible "N × 100 EUR
+   * — group rate" kind of hint. Null for the default tier / single-price row.
+   */
+  tierLabel: string | null
+  isGroupRate: boolean
+}
+
+export interface PriceBreakdownSectionProps {
+  productId?: string
+  optionId?: string | null
+  /** Quantity per option_unit id, typically from RoomsStepperSection. */
+  unitQuantities: Record<string, number>
+  /**
+   * Force a specific catalog. Defaults to the public catalog the storefront
+   * uses — matches what a customer would see.
+   */
+  catalogId?: string | null
+  labels?: {
+    heading?: string
+    total?: string
+    onRequest?: string
+    groupRate?: string
+    empty?: string
+    noPricing?: string
+  }
+}
+
+const DEFAULT_LABELS = {
+  heading: "Price breakdown",
+  total: "Total",
+  onRequest: "On request",
+  groupRate: "group rate",
+  empty: "Pick units above to see the breakdown.",
+  noPricing: "No pricing catalog available for this product.",
+} as const
+
+function formatCents(cents: number | null, currency: string | null | undefined): string {
+  if (cents === null) return ""
+  const major = (cents / 100).toFixed(2)
+  return currency ? `${major} ${currency}` : major
+}
+
+interface TierRow {
+  minQuantity: number
+  maxQuantity: number | null
+  sellAmountCents: number | null
+}
+
+/**
+ * Picks the tier whose quantity range contains `qty`. Tiers are expected
+ * oldest-to-newest, `minQuantity`-ascending. Ties are broken by first-match —
+ * the server sorts by sort_order and then min_quantity, so the selection here
+ * mirrors the storefront engine.
+ */
+function matchTier(tiers: ReadonlyArray<TierRow>, qty: number): TierRow | null {
+  for (const tier of tiers) {
+    if (qty >= tier.minQuantity && (tier.maxQuantity === null || qty <= tier.maxQuantity)) {
+      return tier
+    }
+  }
+  return null
+}
+
+/**
+ * Live price-breakdown preview for booking-create flows. Read-only — uses
+ * `usePricingPreview` (#237) to fetch the catalog-resolved snapshot the
+ * storefront also uses, then computes lines against the operator's current
+ * unit quantities so the operator sees the same numbers the customer would.
+ *
+ * ### Pricing mode handling
+ *
+ * - `per_unit` — multiply the matched tier's `sellAmountCents` by quantity.
+ * - `free` / `included` — render 0.00 without an on-request badge.
+ * - `on_request` / anything else — render "On request"; total excludes it.
+ */
+export function PriceBreakdownSection({
+  productId,
+  optionId,
+  unitQuantities,
+  catalogId,
+  labels,
+}: PriceBreakdownSectionProps) {
+  const merged = { ...DEFAULT_LABELS, ...labels }
+  const preview = usePricingPreview({
+    productId: productId ?? "",
+    optionId: optionId ?? null,
+    catalogId: catalogId ?? null,
+    enabled: Boolean(productId),
+  })
+
+  const snapshot = preview.data?.data
+  const currency = snapshot?.catalog.currencyCode ?? null
+
+  const { lines, total } = React.useMemo(() => {
+    const out: PriceBreakdownLine[] = []
+    let runningTotal = 0
+    let anyOnRequest = false
+
+    if (!snapshot) return { lines: out, total: null as number | null }
+
+    // Pick the default price rule for the resolved option (snapshot already
+    // filters options by the caller's optionId; rules keep isDefault-first
+    // ordering from the server).
+    const rulesByOption = new Map<string, (typeof snapshot.rules)[number][]>()
+    for (const rule of snapshot.rules) {
+      const existing = rulesByOption.get(rule.optionId) ?? []
+      existing.push(rule)
+      rulesByOption.set(rule.optionId, existing)
+    }
+
+    const unitPricesByUnit = new Map<string, (typeof snapshot.unitPrices)[number]>()
+    for (const up of snapshot.unitPrices) {
+      if (!unitPricesByUnit.has(up.unitId)) {
+        unitPricesByUnit.set(up.unitId, up)
+      }
+    }
+
+    for (const [unitId, quantity] of Object.entries(unitQuantities)) {
+      if (quantity <= 0) continue
+      const up = unitPricesByUnit.get(unitId)
+      if (!up) {
+        // The unit isn't priced in this catalog — show it on-request so the
+        // operator knows they need to quote manually.
+        out.push({
+          unitId,
+          label: unitId,
+          quantity,
+          unitAmountCents: null,
+          totalAmountCents: null,
+          tierLabel: null,
+          isGroupRate: false,
+        })
+        anyOnRequest = true
+        continue
+      }
+
+      const label = up.unitName || unitId
+
+      if (up.pricingMode === "on_request") {
+        out.push({
+          unitId,
+          label,
+          quantity,
+          unitAmountCents: null,
+          totalAmountCents: null,
+          tierLabel: merged.onRequest,
+          isGroupRate: false,
+        })
+        anyOnRequest = true
+        continue
+      }
+
+      if (up.pricingMode === "free" || up.pricingMode === "included") {
+        out.push({
+          unitId,
+          label,
+          quantity,
+          unitAmountCents: 0,
+          totalAmountCents: 0,
+          tierLabel: null,
+          isGroupRate: false,
+        })
+        continue
+      }
+
+      // per_unit (and anything else that falls through to explicit amounts).
+      const matchedTier = matchTier(up.tiers, quantity)
+      const unitAmount = matchedTier?.sellAmountCents ?? up.sellAmountCents
+      if (unitAmount === null) {
+        out.push({
+          unitId,
+          label,
+          quantity,
+          unitAmountCents: null,
+          totalAmountCents: null,
+          tierLabel: merged.onRequest,
+          isGroupRate: false,
+        })
+        anyOnRequest = true
+        continue
+      }
+
+      const lineTotal = unitAmount * quantity
+      const isGroupRate = matchedTier !== null && matchedTier.minQuantity > 1
+      out.push({
+        unitId,
+        label,
+        quantity,
+        unitAmountCents: unitAmount,
+        totalAmountCents: lineTotal,
+        tierLabel: isGroupRate ? merged.groupRate : null,
+        isGroupRate,
+      })
+      runningTotal += lineTotal
+    }
+
+    return { lines: out, total: anyOnRequest ? null : runningTotal }
+  }, [snapshot, unitQuantities, merged.onRequest, merged.groupRate])
+
+  // Empty states
+  if (!productId) return null
+  if (preview.isError || (preview.isSuccess && !snapshot)) {
+    return (
+      <div className="flex flex-col gap-2 rounded-md border p-3">
+        <Label>{merged.heading}</Label>
+        <p className="text-xs text-muted-foreground">{merged.noPricing}</p>
+      </div>
+    )
+  }
+  if (lines.length === 0) {
+    return (
+      <div className="flex flex-col gap-2 rounded-md border p-3">
+        <Label>{merged.heading}</Label>
+        <p className="text-xs text-muted-foreground">{merged.empty}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border p-3">
+      <Label>{merged.heading}</Label>
+      <div className="flex flex-col gap-1.5">
+        {lines.map((line) => (
+          <div key={line.unitId} className="flex items-baseline justify-between text-sm">
+            <div className="flex items-baseline gap-2">
+              <span className="tabular-nums">{line.quantity}×</span>
+              <span>{line.label}</span>
+              {line.tierLabel ? (
+                <span className="text-xs text-muted-foreground">· {line.tierLabel}</span>
+              ) : null}
+            </div>
+            <div className="tabular-nums">
+              {line.totalAmountCents === null
+                ? merged.onRequest
+                : formatCents(line.totalAmountCents, currency)}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-1 flex items-baseline justify-between border-t pt-2 text-sm font-medium">
+        <span>{merged.total}</span>
+        <span className="tabular-nums">
+          {total === null ? merged.onRequest : formatCents(total, currency)}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/templates/operator/src/components/voyant/bookings/price-breakdown-section.tsx
+++ b/templates/operator/src/components/voyant/bookings/price-breakdown-section.tsx
@@ -1,0 +1,264 @@
+"use client"
+
+import { usePricingPreview } from "@voyantjs/bookings-react"
+import * as React from "react"
+
+import { Label } from "@/components/ui"
+
+export interface PriceBreakdownLine {
+  unitId: string
+  label: string
+  quantity: number
+  /** Per-unit price for the matched tier/row. `null` = on-request pricing. */
+  unitAmountCents: number | null
+  /** `unitAmountCents * quantity` or null when on-request. */
+  totalAmountCents: number | null
+  /**
+   * Populated when a non-default tier matched — operator-visible "N × 100 EUR
+   * — group rate" kind of hint. Null for the default tier / single-price row.
+   */
+  tierLabel: string | null
+  isGroupRate: boolean
+}
+
+export interface PriceBreakdownSectionProps {
+  productId?: string
+  optionId?: string | null
+  /** Quantity per option_unit id, typically from RoomsStepperSection. */
+  unitQuantities: Record<string, number>
+  /**
+   * Force a specific catalog. Defaults to the public catalog the storefront
+   * uses — matches what a customer would see.
+   */
+  catalogId?: string | null
+  labels?: {
+    heading?: string
+    total?: string
+    onRequest?: string
+    groupRate?: string
+    empty?: string
+    noPricing?: string
+  }
+}
+
+const DEFAULT_LABELS = {
+  heading: "Price breakdown",
+  total: "Total",
+  onRequest: "On request",
+  groupRate: "group rate",
+  empty: "Pick units above to see the breakdown.",
+  noPricing: "No pricing catalog available for this product.",
+} as const
+
+function formatCents(cents: number | null, currency: string | null | undefined): string {
+  if (cents === null) return ""
+  const major = (cents / 100).toFixed(2)
+  return currency ? `${major} ${currency}` : major
+}
+
+interface TierRow {
+  minQuantity: number
+  maxQuantity: number | null
+  sellAmountCents: number | null
+}
+
+/**
+ * Picks the tier whose quantity range contains `qty`. Tiers are expected
+ * oldest-to-newest, `minQuantity`-ascending. Ties are broken by first-match —
+ * the server sorts by sort_order and then min_quantity, so the selection here
+ * mirrors the storefront engine.
+ */
+function matchTier(tiers: ReadonlyArray<TierRow>, qty: number): TierRow | null {
+  for (const tier of tiers) {
+    if (qty >= tier.minQuantity && (tier.maxQuantity === null || qty <= tier.maxQuantity)) {
+      return tier
+    }
+  }
+  return null
+}
+
+/**
+ * Live price-breakdown preview for booking-create flows. Read-only — uses
+ * `usePricingPreview` (#237) to fetch the catalog-resolved snapshot the
+ * storefront also uses, then computes lines against the operator's current
+ * unit quantities so the operator sees the same numbers the customer would.
+ *
+ * ### Pricing mode handling
+ *
+ * - `per_unit` — multiply the matched tier's `sellAmountCents` by quantity.
+ * - `free` / `included` — render 0.00 without an on-request badge.
+ * - `on_request` / anything else — render "On request"; total excludes it.
+ */
+export function PriceBreakdownSection({
+  productId,
+  optionId,
+  unitQuantities,
+  catalogId,
+  labels,
+}: PriceBreakdownSectionProps) {
+  const merged = { ...DEFAULT_LABELS, ...labels }
+  const preview = usePricingPreview({
+    productId: productId ?? "",
+    optionId: optionId ?? null,
+    catalogId: catalogId ?? null,
+    enabled: Boolean(productId),
+  })
+
+  const snapshot = preview.data?.data
+  const currency = snapshot?.catalog.currencyCode ?? null
+
+  const { lines, total } = React.useMemo(() => {
+    const out: PriceBreakdownLine[] = []
+    let runningTotal = 0
+    let anyOnRequest = false
+
+    if (!snapshot) return { lines: out, total: null as number | null }
+
+    // Pick the default price rule for the resolved option (snapshot already
+    // filters options by the caller's optionId; rules keep isDefault-first
+    // ordering from the server).
+    const rulesByOption = new Map<string, (typeof snapshot.rules)[number][]>()
+    for (const rule of snapshot.rules) {
+      const existing = rulesByOption.get(rule.optionId) ?? []
+      existing.push(rule)
+      rulesByOption.set(rule.optionId, existing)
+    }
+
+    const unitPricesByUnit = new Map<string, (typeof snapshot.unitPrices)[number]>()
+    for (const up of snapshot.unitPrices) {
+      if (!unitPricesByUnit.has(up.unitId)) {
+        unitPricesByUnit.set(up.unitId, up)
+      }
+    }
+
+    for (const [unitId, quantity] of Object.entries(unitQuantities)) {
+      if (quantity <= 0) continue
+      const up = unitPricesByUnit.get(unitId)
+      if (!up) {
+        // The unit isn't priced in this catalog — show it on-request so the
+        // operator knows they need to quote manually.
+        out.push({
+          unitId,
+          label: unitId,
+          quantity,
+          unitAmountCents: null,
+          totalAmountCents: null,
+          tierLabel: null,
+          isGroupRate: false,
+        })
+        anyOnRequest = true
+        continue
+      }
+
+      const label = up.unitName || unitId
+
+      if (up.pricingMode === "on_request") {
+        out.push({
+          unitId,
+          label,
+          quantity,
+          unitAmountCents: null,
+          totalAmountCents: null,
+          tierLabel: merged.onRequest,
+          isGroupRate: false,
+        })
+        anyOnRequest = true
+        continue
+      }
+
+      if (up.pricingMode === "free" || up.pricingMode === "included") {
+        out.push({
+          unitId,
+          label,
+          quantity,
+          unitAmountCents: 0,
+          totalAmountCents: 0,
+          tierLabel: null,
+          isGroupRate: false,
+        })
+        continue
+      }
+
+      // per_unit (and anything else that falls through to explicit amounts).
+      const matchedTier = matchTier(up.tiers, quantity)
+      const unitAmount = matchedTier?.sellAmountCents ?? up.sellAmountCents
+      if (unitAmount === null) {
+        out.push({
+          unitId,
+          label,
+          quantity,
+          unitAmountCents: null,
+          totalAmountCents: null,
+          tierLabel: merged.onRequest,
+          isGroupRate: false,
+        })
+        anyOnRequest = true
+        continue
+      }
+
+      const lineTotal = unitAmount * quantity
+      const isGroupRate = matchedTier !== null && matchedTier.minQuantity > 1
+      out.push({
+        unitId,
+        label,
+        quantity,
+        unitAmountCents: unitAmount,
+        totalAmountCents: lineTotal,
+        tierLabel: isGroupRate ? merged.groupRate : null,
+        isGroupRate,
+      })
+      runningTotal += lineTotal
+    }
+
+    return { lines: out, total: anyOnRequest ? null : runningTotal }
+  }, [snapshot, unitQuantities, merged.onRequest, merged.groupRate])
+
+  // Empty states
+  if (!productId) return null
+  if (preview.isError || (preview.isSuccess && !snapshot)) {
+    return (
+      <div className="flex flex-col gap-2 rounded-md border p-3">
+        <Label>{merged.heading}</Label>
+        <p className="text-xs text-muted-foreground">{merged.noPricing}</p>
+      </div>
+    )
+  }
+  if (lines.length === 0) {
+    return (
+      <div className="flex flex-col gap-2 rounded-md border p-3">
+        <Label>{merged.heading}</Label>
+        <p className="text-xs text-muted-foreground">{merged.empty}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border p-3">
+      <Label>{merged.heading}</Label>
+      <div className="flex flex-col gap-1.5">
+        {lines.map((line) => (
+          <div key={line.unitId} className="flex items-baseline justify-between text-sm">
+            <div className="flex items-baseline gap-2">
+              <span className="tabular-nums">{line.quantity}×</span>
+              <span>{line.label}</span>
+              {line.tierLabel ? (
+                <span className="text-xs text-muted-foreground">· {line.tierLabel}</span>
+              ) : null}
+            </div>
+            <div className="tabular-nums">
+              {line.totalAmountCents === null
+                ? merged.onRequest
+                : formatCents(line.totalAmountCents, currency)}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-1 flex items-baseline justify-between border-t pt-2 text-sm font-medium">
+        <span>{merged.total}</span>
+        <span className="tabular-nums">
+          {total === null ? merged.onRequest : formatCents(total, currency)}
+        </span>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Re-opened from closed #253 after base branches merged. Read-only live price breakdown driven by usePricingPreview; mirrors the storefront's tier matching so operator numbers match public pricing.