### PR TITLE
feat(finance): voucher data migration from payment_instruments (#227)

### DIFF
--- a/packages/finance/package.json
+++ b/packages/finance/package.json
@@ -17,7 +17,8 @@
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
     "clean": "rm -rf dist",
-    "prepack": "pnpm run build"
+    "prepack": "pnpm run build",
+    "migrate:vouchers": "node --experimental-strip-types --experimental-transform-types scripts/migrate-vouchers.ts"
   },
   "dependencies": {
     "@voyantjs/bookings": "workspace:*",

--- a/packages/finance/scripts/migrate-vouchers.ts
+++ b/packages/finance/scripts/migrate-vouchers.ts
@@ -1,0 +1,85 @@
+#!/usr/bin/env -S node --experimental-strip-types --experimental-transform-types
+/**
+ * One-shot data migration: legacy vouchers living as payment_instruments rows
+ * with instrumentType='voucher' and balance in metadata JSONB → first-class
+ * vouchers table introduced in #227. Idempotent; safe to re-run.
+ *
+ * Usage:
+ *   DATABASE_URL=postgres://... pnpm -F @voyantjs/finance migrate:vouchers
+ *   DATABASE_URL=postgres://... pnpm -F @voyantjs/finance migrate:vouchers --dry-run
+ */
+import { createDbClient } from "@voyantjs/db"
+
+import { migrateVouchersFromPaymentInstruments } from "../src/service-vouchers-migration.ts"
+
+function parseArgs(argv: string[]): { dryRun: boolean; help: boolean } {
+  let dryRun = false
+  let help = false
+  for (const arg of argv) {
+    if (arg === "--dry-run" || arg === "-n") dryRun = true
+    else if (arg === "--help" || arg === "-h") help = true
+  }
+  return { dryRun, help }
+}
+
+const HELP = `migrate-vouchers — backfill vouchers table from legacy payment_instruments rows
+
+Usage:
+  DATABASE_URL=postgres://... tsx scripts/migrate-vouchers.ts [options]
+
+Options:
+  -n, --dry-run    Report what would be migrated without writing
+  -h, --help       Show this message
+
+The script is idempotent: rows whose code already exists in the vouchers
+table are skipped, so partial runs can be resumed safely.`
+
+async function main(argv: string[]) {
+  const { dryRun, help } = parseArgs(argv.slice(2))
+
+  if (help) {
+    process.stdout.write(`${HELP}\n`)
+    return 0
+  }
+
+  const url = process.env.DATABASE_URL
+  if (!url) {
+    process.stderr.write("DATABASE_URL is required\n")
+    return 1
+  }
+
+  const db = createDbClient(url, { adapter: "node" })
+
+  const started = Date.now()
+  const result = await migrateVouchersFromPaymentInstruments(db, {
+    dryRun,
+    onRowMigrated: ({ voucherCode }) => {
+      process.stdout.write(`  ${dryRun ? "would migrate" : "migrated"} ${voucherCode}\n`)
+    },
+  })
+
+  const elapsed = ((Date.now() - started) / 1000).toFixed(2)
+  process.stdout.write(`\nDone in ${elapsed}s${dryRun ? " (dry run)" : ""}\n`)
+  process.stdout.write(`  candidates: ${result.candidates}\n`)
+  process.stdout.write(`  migrated:   ${result.migrated}\n`)
+  process.stdout.write(`  skipped:    ${result.skipped.length}\n`)
+
+  if (result.skipped.length > 0) {
+    const reasons = result.skipped.reduce<Record<string, number>>((acc, entry) => {
+      acc[entry.reason] = (acc[entry.reason] ?? 0) + 1
+      return acc
+    }, {})
+    for (const [reason, count] of Object.entries(reasons)) {
+      process.stdout.write(`    - ${reason}: ${count}\n`)
+    }
+  }
+
+  return 0
+}
+
+main(process.argv)
+  .then((code) => process.exit(code))
+  .catch((error) => {
+    process.stderr.write(`${error instanceof Error ? (error.stack ?? error.message) : error}\n`)
+    process.exit(1)
+  })

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -198,6 +198,12 @@ export type {
 } from "./service-settlement.js"
 export { financeSettlementService } from "./service-settlement.js"
 export { VoucherServiceError, vouchersService } from "./service-vouchers.js"
+export {
+  migrateVouchersFromPaymentInstruments,
+  type VoucherMigrationOptions,
+  type VoucherMigrationResult,
+  type VoucherMigrationSkip,
+} from "./service-vouchers-migration.js"
 export type {
   GeneratedInvoiceDocumentResult,
   GenerateInvoiceDocumentInput,

--- a/packages/finance/src/service-vouchers-migration.ts
+++ b/packages/finance/src/service-vouchers-migration.ts
@@ -1,0 +1,189 @@
+import { eq, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { paymentInstruments, vouchers } from "./schema.js"
+
+/**
+ * Pulls a (possibly nested, array-wrapped, or null) value out of a JSONB
+ * metadata column. Keeps the narrow runtime checks local so callers can stay
+ * declarative about the shape they expect.
+ */
+function asRecord(metadata: unknown): Record<string, unknown> | null {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return null
+  }
+  return metadata as Record<string, unknown>
+}
+
+function asString(record: Record<string, unknown> | null, key: string): string | null {
+  const value = record?.[key]
+  return typeof value === "string" && value.length > 0 ? value : null
+}
+
+function asNumber(record: Record<string, unknown> | null, key: string): number | null {
+  const value = record?.[key]
+  return typeof value === "number" && Number.isFinite(value) ? value : null
+}
+
+function asStringArray(record: Record<string, unknown> | null, key: string): string[] {
+  const value = record?.[key]
+  if (!Array.isArray(value)) return []
+  return value.filter((entry): entry is string => typeof entry === "string" && entry.length > 0)
+}
+
+function asDate(value: string | null): Date | null {
+  if (!value) return null
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+export interface VoucherMigrationOptions {
+  /**
+   * When true, report what would happen without writing. Defaults to false.
+   */
+  dryRun?: boolean
+  /**
+   * Per-row hook for progress reporting. Not called on skipped rows.
+   */
+  onRowMigrated?: (info: { paymentInstrumentId: string; voucherCode: string }) => void
+}
+
+export interface VoucherMigrationSkip {
+  paymentInstrumentId: string
+  reason:
+    | "already_migrated"
+    | "missing_code"
+    | "missing_currency"
+    | "missing_amount"
+    | "duplicate_code_collision"
+}
+
+export interface VoucherMigrationResult {
+  candidates: number
+  migrated: number
+  skipped: VoucherMigrationSkip[]
+  dryRun: boolean
+}
+
+/**
+ * Backfill the `vouchers` table from legacy voucher rows in
+ * `payment_instruments`. A legacy voucher is a row with `instrumentType =
+ * 'voucher'` whose code lives in one of `metadata.code`, `external_token`, or
+ * `direct_bill_reference`, and whose balance lives in
+ * `metadata.remainingAmountCents` (falling back to `metadata.amountCents` when
+ * no redemption has touched the row).
+ *
+ * The migration is idempotent: rows whose code already exists in the new
+ * `vouchers` table are skipped so re-running the script after a partial run
+ * (or after issuing new vouchers via the first-class API) is safe.
+ *
+ * Why skip rather than update: the new table treats `code` as a primary lookup
+ * key and the legacy path has already been read-only-fallback since #256
+ * landed, so any voucher that exists in both tables is by definition already
+ * migrated. Picking one source of truth avoids clobbering balances the
+ * operator may have adjusted through the new redemption flow.
+ */
+export async function migrateVouchersFromPaymentInstruments(
+  db: PostgresJsDatabase,
+  options: VoucherMigrationOptions = {},
+): Promise<VoucherMigrationResult> {
+  const dryRun = options.dryRun ?? false
+  const skipped: VoucherMigrationSkip[] = []
+  let migrated = 0
+
+  const candidates = await db
+    .select()
+    .from(paymentInstruments)
+    .where(eq(paymentInstruments.instrumentType, "voucher"))
+
+  for (const instrument of candidates) {
+    const metadata = asRecord(instrument.metadata)
+
+    const code =
+      asString(metadata, "code") ?? instrument.externalToken ?? instrument.directBillReference
+    if (!code) {
+      skipped.push({ paymentInstrumentId: instrument.id, reason: "missing_code" })
+      continue
+    }
+
+    const currency = asString(metadata, "currency")
+    if (!currency || currency.length !== 3) {
+      skipped.push({ paymentInstrumentId: instrument.id, reason: "missing_currency" })
+      continue
+    }
+
+    const initialAmountCents = asNumber(metadata, "amountCents")
+    if (initialAmountCents === null || initialAmountCents <= 0) {
+      skipped.push({ paymentInstrumentId: instrument.id, reason: "missing_amount" })
+      continue
+    }
+    const remainingAmountCents = asNumber(metadata, "remainingAmountCents") ?? initialAmountCents
+
+    const [existing] = await db
+      .select({ id: vouchers.id })
+      .from(vouchers)
+      .where(sql`lower(${vouchers.code}) = ${code.toLowerCase()}`)
+      .limit(1)
+    if (existing) {
+      skipped.push({ paymentInstrumentId: instrument.id, reason: "already_migrated" })
+      continue
+    }
+
+    const expiresAt = asDate(asString(metadata, "expiresAt"))
+    const bookingIds = asStringArray(metadata, "bookingIds")
+    const sourceBookingId = asString(metadata, "bookingId") ?? bookingIds[0] ?? null
+
+    // Collapse the legacy status/balance pair onto the new enum. If there's no
+    // balance left, treat as already spent; otherwise follow the instrument's
+    // own active/inactive flag.
+    const status: "active" | "redeemed" | "void" =
+      remainingAmountCents <= 0 ? "redeemed" : instrument.status === "active" ? "active" : "void"
+
+    if (dryRun) {
+      migrated++
+      options.onRowMigrated?.({ paymentInstrumentId: instrument.id, voucherCode: code })
+      continue
+    }
+
+    try {
+      await db.insert(vouchers).values({
+        code,
+        status,
+        currency: currency.toUpperCase(),
+        initialAmountCents,
+        remainingAmountCents: Math.max(0, remainingAmountCents),
+        issuedToPersonId: instrument.personId ?? null,
+        issuedToOrganizationId: instrument.organizationId ?? null,
+        // We don't know the original source (refund vs gift vs promo) from the
+        // legacy shape, so mark everything as `manual` — operators can reclassify
+        // later via PATCH /vouchers/:id.
+        sourceType: "manual",
+        sourceBookingId,
+        notes: instrument.notes ?? null,
+        expiresAt,
+        createdAt: instrument.createdAt,
+        updatedAt: instrument.updatedAt,
+      })
+      migrated++
+      options.onRowMigrated?.({ paymentInstrumentId: instrument.id, voucherCode: code })
+    } catch (error) {
+      // Unique-index collision is the only realistic insert failure here
+      // (another concurrent migration or a race with a manual issuance). Record
+      // it as a skip rather than aborting the batch so a retry finishes the
+      // rest.
+      const message = error instanceof Error ? error.message : String(error)
+      if (message.includes("uidx_vouchers_code") || message.includes("duplicate key")) {
+        skipped.push({ paymentInstrumentId: instrument.id, reason: "duplicate_code_collision" })
+        continue
+      }
+      throw error
+    }
+  }
+
+  return {
+    candidates: candidates.length,
+    migrated,
+    skipped,
+    dryRun,
+  }
+}

--- a/packages/finance/tests/integration/migrate-vouchers.test.ts
+++ b/packages/finance/tests/integration/migrate-vouchers.test.ts
@@ -1,0 +1,300 @@
+import { eq, sql } from "drizzle-orm"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { paymentInstruments, vouchers } from "../../src/schema.js"
+import { migrateVouchersFromPaymentInstruments } from "../../src/service-vouchers-migration.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+async function resetTables(
+  // biome-ignore lint/suspicious/noExplicitAny: test db typing
+  db: any,
+) {
+  const tableNames = ["voucher_redemptions", "vouchers", "payment_instruments"]
+
+  const existingTables = (await db.execute<{ tablename: string }>(sql`
+    SELECT tablename
+    FROM pg_tables
+    WHERE schemaname = 'public'
+      AND tablename IN (${sql.join(
+        tableNames.map((name) => sql`${name}`),
+        sql`, `,
+      )})
+  `)) as Array<{ tablename: string }>
+
+  if (existingTables.length === 0) return
+
+  const names = existingTables.map((row) => `"${row.tablename}"`).join(", ")
+  await db.execute(sql.raw(`TRUNCATE ${names} CASCADE`))
+}
+
+describe.skipIf(!DB_AVAILABLE)("migrateVouchersFromPaymentInstruments", () => {
+  let db: ReturnType<typeof import("@voyantjs/db/test-utils").createTestDb>
+
+  beforeAll(async () => {
+    const { createTestDb } = await import("@voyantjs/db/test-utils")
+    db = createTestDb()
+    await resetTables(db)
+  })
+
+  beforeEach(async () => {
+    await resetTables(db)
+  })
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyantjs/db/test-utils")
+    await closeTestDb()
+  })
+
+  it("migrates legacy voucher with metadata.code and remainingAmountCents", async () => {
+    await db.insert(paymentInstruments).values({
+      ownerType: "client",
+      instrumentType: "voucher",
+      status: "active",
+      label: "Voucher ABC",
+      personId: "pers_demo_client",
+      metadata: {
+        code: "GIFT-ABC-2025",
+        currency: "EUR",
+        amountCents: 50000,
+        remainingAmountCents: 30000,
+        expiresAt: "2026-12-31T23:59:59.000Z",
+      },
+    })
+
+    const result = await migrateVouchersFromPaymentInstruments(db)
+
+    expect(result.candidates).toBe(1)
+    expect(result.migrated).toBe(1)
+    expect(result.skipped).toHaveLength(0)
+
+    const [row] = await db.select().from(vouchers).limit(1)
+    expect(row).toMatchObject({
+      code: "GIFT-ABC-2025",
+      currency: "EUR",
+      initialAmountCents: 50000,
+      remainingAmountCents: 30000,
+      status: "active",
+      sourceType: "manual",
+      issuedToPersonId: "pers_demo_client",
+    })
+    expect(row?.expiresAt?.toISOString()).toBe("2026-12-31T23:59:59.000Z")
+  })
+
+  it("falls back to external_token when metadata.code missing", async () => {
+    await db.insert(paymentInstruments).values({
+      ownerType: "client",
+      instrumentType: "voucher",
+      status: "active",
+      label: "Legacy voucher",
+      externalToken: "LEGACY-123",
+      metadata: { currency: "USD", amountCents: 10000 },
+    })
+
+    const result = await migrateVouchersFromPaymentInstruments(db)
+
+    expect(result.migrated).toBe(1)
+    const [row] = await db.select().from(vouchers).limit(1)
+    expect(row?.code).toBe("LEGACY-123")
+    // No redemption info → remaining defaults to initial.
+    expect(row?.remainingAmountCents).toBe(10000)
+  })
+
+  it("falls back to direct_bill_reference when metadata.code and external_token missing", async () => {
+    await db.insert(paymentInstruments).values({
+      ownerType: "client",
+      instrumentType: "voucher",
+      status: "active",
+      label: "DBR voucher",
+      directBillReference: "DBR-001",
+      metadata: { currency: "RON", amountCents: 5000 },
+    })
+
+    const result = await migrateVouchersFromPaymentInstruments(db)
+
+    expect(result.migrated).toBe(1)
+    const [row] = await db.select().from(vouchers).limit(1)
+    expect(row?.code).toBe("DBR-001")
+  })
+
+  it("is idempotent — re-running skips already-migrated rows", async () => {
+    await db.insert(paymentInstruments).values({
+      ownerType: "client",
+      instrumentType: "voucher",
+      status: "active",
+      label: "Repeat me",
+      metadata: { code: "REPEAT-1", currency: "EUR", amountCents: 1000 },
+    })
+
+    const first = await migrateVouchersFromPaymentInstruments(db)
+    expect(first.migrated).toBe(1)
+    expect(first.skipped).toHaveLength(0)
+
+    const second = await migrateVouchersFromPaymentInstruments(db)
+    expect(second.migrated).toBe(0)
+    expect(second.skipped).toEqual([expect.objectContaining({ reason: "already_migrated" })])
+
+    const [count] = await db
+      .select({ c: sql<number>`count(*)::int` })
+      .from(vouchers)
+      .where(eq(vouchers.code, "REPEAT-1"))
+    expect(count?.c).toBe(1)
+  })
+
+  it("skips rows missing a code", async () => {
+    await db.insert(paymentInstruments).values({
+      ownerType: "client",
+      instrumentType: "voucher",
+      status: "active",
+      label: "No code here",
+      metadata: { currency: "EUR", amountCents: 2500 },
+    })
+
+    const result = await migrateVouchersFromPaymentInstruments(db)
+    expect(result.migrated).toBe(0)
+    expect(result.skipped[0]).toMatchObject({ reason: "missing_code" })
+  })
+
+  it("skips rows missing currency", async () => {
+    await db.insert(paymentInstruments).values({
+      ownerType: "client",
+      instrumentType: "voucher",
+      status: "active",
+      label: "No currency",
+      externalToken: "NOCURR",
+      metadata: { amountCents: 2500 },
+    })
+
+    const result = await migrateVouchersFromPaymentInstruments(db)
+    expect(result.skipped[0]).toMatchObject({ reason: "missing_currency" })
+  })
+
+  it("skips rows missing amount", async () => {
+    await db.insert(paymentInstruments).values({
+      ownerType: "client",
+      instrumentType: "voucher",
+      status: "active",
+      label: "No amount",
+      externalToken: "NOAMT",
+      metadata: { currency: "EUR" },
+    })
+
+    const result = await migrateVouchersFromPaymentInstruments(db)
+    expect(result.skipped[0]).toMatchObject({ reason: "missing_amount" })
+  })
+
+  it("flips status to redeemed when remainingAmountCents is 0", async () => {
+    await db.insert(paymentInstruments).values({
+      ownerType: "client",
+      instrumentType: "voucher",
+      status: "active",
+      label: "Spent",
+      metadata: {
+        code: "SPENT-0",
+        currency: "EUR",
+        amountCents: 1000,
+        remainingAmountCents: 0,
+      },
+    })
+
+    await migrateVouchersFromPaymentInstruments(db)
+    const [row] = await db.select().from(vouchers).limit(1)
+    expect(row?.status).toBe("redeemed")
+    expect(row?.remainingAmountCents).toBe(0)
+  })
+
+  it("flips status to void when source instrument is inactive", async () => {
+    await db.insert(paymentInstruments).values({
+      ownerType: "client",
+      instrumentType: "voucher",
+      status: "inactive",
+      label: "Archived voucher",
+      metadata: {
+        code: "VOIDME",
+        currency: "EUR",
+        amountCents: 10000,
+        remainingAmountCents: 10000,
+      },
+    })
+
+    await migrateVouchersFromPaymentInstruments(db)
+    const [row] = await db.select().from(vouchers).limit(1)
+    expect(row?.status).toBe("void")
+  })
+
+  it("picks up sourceBookingId from metadata.bookingId or bookingIds[0]", async () => {
+    await db.insert(paymentInstruments).values([
+      {
+        ownerType: "client",
+        instrumentType: "voucher",
+        status: "active",
+        label: "Single booking",
+        metadata: {
+          code: "SRC-1",
+          currency: "EUR",
+          amountCents: 1000,
+          bookingId: "book_legacy_aaa",
+        },
+      },
+      {
+        ownerType: "client",
+        instrumentType: "voucher",
+        status: "active",
+        label: "Array bookings",
+        metadata: {
+          code: "SRC-2",
+          currency: "EUR",
+          amountCents: 1000,
+          bookingIds: ["book_legacy_bbb", "book_legacy_ccc"],
+        },
+      },
+    ])
+
+    await migrateVouchersFromPaymentInstruments(db)
+
+    const [rowA] = await db.select().from(vouchers).where(eq(vouchers.code, "SRC-1"))
+    expect(rowA?.sourceBookingId).toBe("book_legacy_aaa")
+    const [rowB] = await db.select().from(vouchers).where(eq(vouchers.code, "SRC-2"))
+    expect(rowB?.sourceBookingId).toBe("book_legacy_bbb")
+  })
+
+  it("dry run reports counts without writing", async () => {
+    await db.insert(paymentInstruments).values({
+      ownerType: "client",
+      instrumentType: "voucher",
+      status: "active",
+      label: "Dry run candidate",
+      metadata: { code: "DRY-1", currency: "EUR", amountCents: 2000 },
+    })
+
+    const result = await migrateVouchersFromPaymentInstruments(db, { dryRun: true })
+    expect(result.dryRun).toBe(true)
+    expect(result.migrated).toBe(1)
+
+    const rows = await db.select().from(vouchers)
+    expect(rows).toHaveLength(0)
+  })
+
+  it("leaves non-voucher payment_instruments alone", async () => {
+    await db.insert(paymentInstruments).values([
+      {
+        ownerType: "client",
+        instrumentType: "credit_card",
+        status: "active",
+        label: "Amex ending 1234",
+        last4: "1234",
+      },
+      {
+        ownerType: "client",
+        instrumentType: "voucher",
+        status: "active",
+        label: "Real voucher",
+        metadata: { code: "REAL-1", currency: "EUR", amountCents: 1000 },
+      },
+    ])
+
+    const result = await migrateVouchersFromPaymentInstruments(db)
+    expect(result.candidates).toBe(1)
+    expect(result.migrated).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
Final slice of #227. Backfill the first-class `vouchers` table from legacy voucher rows living in `payment_instruments.metadata`. After this lands (and ops runs it), we can drop the fallback read-path from `publicFinanceService.validateVoucher` that #256 introduced as a bridge.

## What's new
- `migrateVouchersFromPaymentInstruments(db, opts)` in `@voyantjs/finance`. Reads `payment_instruments` with `instrumentType='voucher'`, pulls:
  - `code` from `metadata.code` → `external_token` → `direct_bill_reference`
  - `currency`, `amountCents`, `remainingAmountCents`, `expiresAt`, `bookingId`/`bookingIds[0]` from metadata JSONB
  - `personId` / `organizationId` / `notes` / timestamps from the instrument columns
- Status collapses onto the new enum: `remainingAmountCents=0` → `redeemed`, inactive instrument → `void`, else `active`.
- Idempotent: rows whose `code` already exists in `vouchers` are skipped. Safe to re-run after a partial batch; won't clobber balances touched via the new redemption flow.
- CLI wrapper `packages/finance/scripts/migrate-vouchers.ts` with `--dry-run`. Registered as `pnpm -F @voyantjs/finance migrate:vouchers`.

## Skip reasons surfaced in the result
- `already_migrated` — code already present in `vouchers`
- `missing_code` — none of the three code fields have a value
- `missing_currency` — metadata has no 3-letter currency
- `missing_amount` — metadata has no positive `amountCents`
- `duplicate_code_collision` — race with another insert path

## Test plan
- [x] 12 integration tests — code fallback chain, idempotency, status collapse, dry-run, non-voucher instruments left alone
- [ ] Dry-run against staging to review the candidate count and skip reasons before actual cutover
- [ ] After prod run: follow-up PR removes the `payment_instruments` fallback from `validateVoucher`