### PR TITLE
feat(finance): atomic POST /v1/admin/bookings/quick-create (#223)

### DIFF
--- a/packages/bookings/src/products-ref.ts
+++ b/packages/bookings/src/products-ref.ts
@@ -46,9 +46,21 @@ export const optionUnitsRef = pgTable("option_units", {
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 })
 
+export const productItinerariesRef = pgTable("product_itineraries", {
+  id: typeId("product_itineraries").primaryKey(),
+  productId: typeIdRef("product_id").notNull(),
+  name: text("name").notNull(),
+  isDefault: boolean("is_default").notNull().default(false),
+  sortOrder: integer("sort_order").notNull().default(0),
+})
+
+// product_days was re-parented to product_itineraries in products, so the
+// historical `product_days.product_id` column no longer exists. Bookings'
+// getConvertProductData joins through product_itineraries to keep the
+// per-product day lookup working.
 export const productDaysRef = pgTable("product_days", {
   id: typeId("product_days").primaryKey(),
-  productId: typeIdRef("product_id").notNull(),
+  itineraryId: typeIdRef("itinerary_id").notNull(),
   dayNumber: integer("day_number").notNull(),
 })
 

--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -10,6 +10,7 @@ import {
   optionUnitsRef,
   productDayServicesRef,
   productDaysRef,
+  productItinerariesRef,
   productOptionsRef,
   productsRef,
   productTicketSettingsRef,
@@ -490,10 +491,15 @@ async function getConvertProductData(
     option = defaultOption ?? null
   }
 
+  // product_days is keyed by itinerary_id (products re-parented days onto
+  // product_itineraries); getConvertProductData joins through the itinerary
+  // ref so the per-product day lookup still works for converts that want to
+  // seed booking supplier statuses from the product's day services.
   const days = await db
-    .select()
+    .select({ id: productDaysRef.id, dayNumber: productDaysRef.dayNumber })
     .from(productDaysRef)
-    .where(eq(productDaysRef.productId, product.id))
+    .innerJoin(productItinerariesRef, eq(productDaysRef.itineraryId, productItinerariesRef.id))
+    .where(eq(productItinerariesRef.productId, product.id))
     .orderBy(asc(productDaysRef.dayNumber))
 
   const dayServices = days.length
@@ -509,7 +515,9 @@ async function getConvertProductData(
           sql`${productDayServicesRef.dayId} IN (
             SELECT ${productDaysRef.id}
             FROM ${productDaysRef}
-            WHERE ${productDaysRef.productId} = ${product.id}
+            INNER JOIN ${productItinerariesRef}
+              ON ${productDaysRef.itineraryId} = ${productItinerariesRef.id}
+            WHERE ${productItinerariesRef.productId} = ${product.id}
           )`,
         )
         .orderBy(asc(productDayServicesRef.sortOrder), asc(productDayServicesRef.id))

--- a/packages/bookings/tests/integration/routes.test.ts
+++ b/packages/bookings/tests/integration/routes.test.ts
@@ -9,6 +9,7 @@ import {
   optionUnitsRef,
   productDayServicesRef,
   productDaysRef,
+  productItinerariesRef,
   productOptionsRef,
   productsRef,
   productTicketSettingsRef,
@@ -326,10 +327,15 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
       })
       .returning()
 
+    const [itinerary] = await db
+      .insert(productItinerariesRef)
+      .values({ productId: product.id, name: "Default itinerary", isDefault: true })
+      .returning()
+
     const [day] = await db
       .insert(productDaysRef)
       .values({
-        productId: product.id,
+        itineraryId: itinerary.id,
         dayNumber: 1,
       })
       .returning()

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -89,6 +89,7 @@ export {
   type FinanceRouteRuntime,
   type FinanceRuntimeOptions,
 } from "./route-runtime.js"
+export { bookingsQuickCreateExtension } from "./routes-bookings-quick-create.js"
 export {
   createFinanceAdminDocumentRoutes,
   type FinanceDocumentRouteOptions,
@@ -173,6 +174,18 @@ export {
 } from "./schema.js"
 export type { InvoiceFromBookingData } from "./service.js"
 export { financeService, renderInvoiceBody } from "./service.js"
+export type {
+  BookingQuickCreatedEvent,
+  BookingQuickCreateRuntime,
+  QuickCreateBookingInput,
+  QuickCreateBookingOutcome,
+  QuickCreateBookingResult,
+  QuickCreateTravelerInput,
+} from "./service-bookings-quick-create.js"
+export {
+  quickCreateBooking,
+  quickCreateBookingSchema,
+} from "./service-bookings-quick-create.js"
 export type {
   GeneratedInvoiceDocumentRecord,
   GeneratedInvoiceRenditionArtifact,

--- a/packages/finance/src/routes-bookings-quick-create.ts
+++ b/packages/finance/src/routes-bookings-quick-create.ts
@@ -1,0 +1,72 @@
+import type { Extension } from "@voyantjs/core"
+import { parseJsonBody } from "@voyantjs/hono"
+import type { HonoExtension } from "@voyantjs/hono/module"
+import { Hono } from "hono"
+
+import { FINANCE_ROUTE_RUNTIME_CONTAINER_KEY, type FinanceRouteRuntime } from "./route-runtime.js"
+import { quickCreateBooking, quickCreateBookingSchema } from "./service-bookings-quick-create.js"
+
+function resolveRuntime(container: { resolve: <T>(key: string) => T }): FinanceRouteRuntime | null {
+  try {
+    return container.resolve<FinanceRouteRuntime>(FINANCE_ROUTE_RUNTIME_CONTAINER_KEY)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Mounted under `/v1/admin/bookings/*` via the extension's `module` target, so
+ * the endpoint's public-facing path lands at `POST /v1/admin/bookings/quick-create`
+ * even though the code lives in `@voyantjs/finance`. See the header comment in
+ * service-bookings-quick-create.ts for why finance owns this orchestration.
+ */
+const quickCreateRoutes = new Hono<{
+  Variables: {
+    db: import("drizzle-orm/postgres-js").PostgresJsDatabase
+    userId?: string
+    container: { resolve: <T>(key: string) => T }
+  }
+}>().post("/quick-create", async (c) => {
+  const input = await parseJsonBody(c, quickCreateBookingSchema)
+  const runtime = resolveRuntime(c.var.container)
+
+  const outcome = await quickCreateBooking(c.get("db"), input, {
+    userId: c.get("userId"),
+    runtime: runtime ? { eventBus: runtime.eventBus } : undefined,
+  })
+
+  switch (outcome.status) {
+    case "ok":
+      return c.json({ data: outcome.result }, 201)
+    case "product_not_found":
+      return c.json({ error: "Product not found or unavailable" }, 404)
+    case "voucher_not_found":
+      return c.json({ error: "Voucher not found" }, 404)
+    case "voucher_inactive":
+      return c.json({ error: "Voucher is not active" }, 409)
+    case "voucher_expired":
+      return c.json({ error: "Voucher has expired" }, 409)
+    case "voucher_insufficient_balance":
+      return c.json({ error: "Voucher does not have enough balance" }, 409)
+    case "group_not_found":
+      return c.json({ error: "Booking group not found" }, 404)
+    case "booking_already_in_group":
+      return c.json(
+        {
+          error: "Booking is already a member of a group",
+          currentGroupId: outcome.currentGroupId,
+        },
+        409,
+      )
+  }
+})
+
+const bookingsQuickCreateExtensionDef: Extension = {
+  name: "bookings-quick-create",
+  module: "bookings",
+}
+
+export const bookingsQuickCreateExtension: HonoExtension = {
+  extension: bookingsQuickCreateExtensionDef,
+  adminRoutes: quickCreateRoutes,
+}

--- a/packages/finance/src/service-bookings-quick-create.ts
+++ b/packages/finance/src/service-bookings-quick-create.ts
@@ -1,0 +1,390 @@
+import { bookingGroupsService, bookingsService } from "@voyantjs/bookings"
+import type { Booking, BookingGroupMember, BookingTraveler } from "@voyantjs/bookings/schema"
+import { bookingTravelers } from "@voyantjs/bookings/schema"
+import type { EventBus } from "@voyantjs/core"
+import { eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { z } from "zod"
+
+import type { BookingPaymentSchedule, Voucher, VoucherRedemption } from "./schema.js"
+import { bookingPaymentSchedules, vouchers } from "./schema.js"
+import { VoucherServiceError, vouchersService } from "./service-vouchers.js"
+import { paymentScheduleStatusSchema, paymentScheduleTypeSchema } from "./validation-shared.js"
+
+// ---------- validation ----------
+
+const travelerInputSchema = z.object({
+  firstName: z.string().min(1).max(255),
+  lastName: z.string().min(1).max(255),
+  email: z.string().email().optional().nullable(),
+  phone: z.string().max(50).optional().nullable(),
+  personId: z.string().optional().nullable(),
+  participantType: z.enum(["traveler", "occupant", "other"]).default("traveler"),
+  travelerCategory: z.enum(["adult", "child", "infant", "senior", "other"]).optional().nullable(),
+  preferredLanguage: z.string().max(35).optional().nullable(),
+  accessibilityNeeds: z.string().optional().nullable(),
+  specialRequests: z.string().optional().nullable(),
+  /**
+   * option_unit_id the passenger is assigned to. Accepted by the input
+   * schema so the UI's PassengerListValue can round-trip, but not yet
+   * persisted — bookingTravelers has no room-assignment column and the
+   * allocation flow is owned by the items slice. Follow-up: add a traveler
+   * metadata JSONB or wire into booking_allocations.
+   */
+  roomUnitId: z.string().optional().nullable(),
+  isPrimary: z.boolean().optional().nullable(),
+  notes: z.string().optional().nullable(),
+})
+
+const paymentScheduleInputSchema = z.object({
+  scheduleType: paymentScheduleTypeSchema.default("balance"),
+  status: paymentScheduleStatusSchema.default("pending"),
+  dueDate: z.string().min(1),
+  currency: z.string().min(3).max(3),
+  amountCents: z.number().int().min(0),
+  notes: z.string().optional().nullable(),
+})
+
+const voucherRedemptionInputSchema = z.object({
+  voucherId: z.string().min(1),
+  amountCents: z.number().int().min(1),
+})
+
+const groupJoinSchema = z.object({
+  action: z.literal("join"),
+  groupId: z.string().min(1),
+  role: z.enum(["primary", "shared"]).default("shared"),
+})
+
+const groupCreateSchema = z.object({
+  action: z.literal("create"),
+  kind: z.enum(["shared_room", "other"]).default("shared_room"),
+  label: z.string().max(255).optional().nullable(),
+  optionUnitId: z.string().optional().nullable(),
+  /**
+   * When true (the default), the freshly-created booking becomes the group's
+   * primary booking. Operators creating a dual-booking can set this false and
+   * supply a different primaryBookingId — not wired in this slice, but the
+   * field is reserved.
+   */
+  makeBookingPrimary: z.boolean().default(true),
+})
+
+const groupMembershipInputSchema = z.discriminatedUnion("action", [
+  groupJoinSchema,
+  groupCreateSchema,
+])
+
+export const quickCreateBookingSchema = z.object({
+  // Convert-product fields (mirrors convertProductSchema in bookings)
+  productId: z.string().min(1),
+  optionId: z.string().optional().nullable(),
+  slotId: z.string().optional().nullable(),
+  bookingNumber: z.string().min(1),
+  personId: z.string().optional().nullable(),
+  organizationId: z.string().optional().nullable(),
+  internalNotes: z.string().optional().nullable(),
+
+  // Orchestration fields
+  travelers: z.array(travelerInputSchema).optional(),
+  paymentSchedules: z.array(paymentScheduleInputSchema).optional(),
+  voucherRedemption: voucherRedemptionInputSchema.optional(),
+  groupMembership: groupMembershipInputSchema.optional(),
+})
+
+export type QuickCreateBookingInput = z.infer<typeof quickCreateBookingSchema>
+export type QuickCreateTravelerInput = z.infer<typeof travelerInputSchema>
+
+// ---------- runtime ----------
+
+/**
+ * Fire-and-forget post-commit events. The orchestrator only knows about
+ * `booking.quick-created` — downstream confirm/cancel lifecycle events stay
+ * with the booking service itself (the booking lands in `draft` status so no
+ * `booking.confirmed` should fire here).
+ */
+export interface BookingQuickCreateRuntime {
+  eventBus?: EventBus
+}
+
+export interface BookingQuickCreatedEvent {
+  bookingId: string
+  bookingNumber: string
+  productId: string
+  travelerCount: number
+  paymentScheduleCount: number
+  voucherRedeemedCents: number | null
+  groupId: string | null
+  createdByUserId: string | null
+  occurredAt: Date
+}
+
+// ---------- result shape ----------
+
+export interface QuickCreateBookingResult {
+  booking: Booking
+  travelers: BookingTraveler[]
+  paymentSchedules: BookingPaymentSchedule[]
+  voucherRedemption: {
+    voucher: Voucher
+    redemption: VoucherRedemption
+  } | null
+  groupMembership: {
+    groupId: string
+    member: BookingGroupMember
+  } | null
+}
+
+export type QuickCreateBookingOutcome =
+  | { status: "ok"; result: QuickCreateBookingResult }
+  | { status: "product_not_found" }
+  | { status: "voucher_not_found" }
+  | { status: "voucher_inactive" }
+  | { status: "voucher_expired" }
+  | { status: "voucher_insufficient_balance" }
+  | { status: "group_not_found" }
+  | { status: "booking_already_in_group"; currentGroupId: string }
+
+// ---------- service ----------
+
+/**
+ * Atomic booking-create orchestrator. Runs product conversion + travelers +
+ * payment schedules + voucher redemption + group membership inside a single
+ * transaction so partial failures (e.g. voucher insufficient-balance after
+ * schedules have been written) roll the whole thing back.
+ *
+ * Event emission is post-commit — if the tx rolls back, subscribers never
+ * hear about it.
+ *
+ * Why the orchestrator lives in `@voyantjs/finance`: finance already imports
+ * from `@voyantjs/bookings` (invoices-from-bookings, voucher service, payment
+ * schedules all sit here), so this is the one place that can compose the
+ * three packages without creating a new workspace dep cycle. The route wires
+ * it under `/v1/admin/bookings/quick-create` via a HonoExtension whose
+ * `module` targets `"bookings"`.
+ */
+/**
+ * Sentinel thrown inside the tx to force drizzle to roll back. Returning a
+ * non-ok result from the tx callback doesn't abort the tx — only a thrown
+ * error does — so the orchestrator uses this to unwind cleanly when a
+ * downstream step discovers a precondition failure.
+ */
+class QuickCreateAbort extends Error {
+  constructor(readonly outcome: Exclude<QuickCreateBookingOutcome, { status: "ok" }>) {
+    super(`quick-create aborted: ${outcome.status}`)
+    this.name = "QuickCreateAbort"
+  }
+}
+
+export async function quickCreateBooking(
+  db: PostgresJsDatabase,
+  rawInput: QuickCreateBookingInput,
+  options: {
+    userId?: string
+    runtime?: BookingQuickCreateRuntime
+  } = {},
+): Promise<QuickCreateBookingOutcome> {
+  const { userId, runtime } = options
+  // Parse through the schema so defaults (makeBookingPrimary, role,
+  // participantType, etc.) are applied even when callers bypass validation —
+  // unit tests and hand-written integrations commonly do.
+  const input = quickCreateBookingSchema.parse(rawInput)
+
+  // Validate voucher up-front so we can short-circuit before the tx starts.
+  // This is a cheap read — the authoritative balance check still happens
+  // inside the redeem savepoint so two concurrent redemptions can't double-
+  // spend.
+  if (input.voucherRedemption) {
+    const [voucher] = await db
+      .select()
+      .from(vouchers)
+      .where(eq(vouchers.id, input.voucherRedemption.voucherId))
+      .limit(1)
+    if (!voucher) return { status: "voucher_not_found" }
+    if (voucher.status !== "active") return { status: "voucher_inactive" }
+    if (voucher.expiresAt && voucher.expiresAt.getTime() < Date.now()) {
+      return { status: "voucher_expired" }
+    }
+    if (input.voucherRedemption.amountCents > voucher.remainingAmountCents) {
+      return { status: "voucher_insufficient_balance" }
+    }
+  }
+
+  let result: QuickCreateBookingResult
+  try {
+    result = await db.transaction(async (tx) => {
+      // 1. Booking from product
+      const booking = await bookingsService.createBookingFromProduct(tx, {
+        productId: input.productId,
+        optionId: input.optionId ?? null,
+        slotId: input.slotId ?? null,
+        bookingNumber: input.bookingNumber,
+        personId: input.personId ?? null,
+        organizationId: input.organizationId ?? null,
+        internalNotes: input.internalNotes ?? null,
+      })
+      if (!booking) {
+        // Caller gave us a product that doesn't resolve. Throw so drizzle
+        // rolls back any writes the convert helper may have made.
+        throw new QuickCreateAbort({ status: "product_not_found" })
+      }
+
+      // 2. Travelers. roomUnitId is accepted on the input but not persisted
+      // yet — see travelerInputSchema for the follow-up note.
+      const travelers: BookingTraveler[] = []
+      for (const traveler of input.travelers ?? []) {
+        const [row] = await tx
+          .insert(bookingTravelers)
+          .values({
+            bookingId: booking.id,
+            personId: traveler.personId ?? null,
+            participantType: traveler.participantType,
+            travelerCategory: traveler.travelerCategory ?? null,
+            firstName: traveler.firstName,
+            lastName: traveler.lastName,
+            email: traveler.email ?? null,
+            phone: traveler.phone ?? null,
+            preferredLanguage: traveler.preferredLanguage ?? null,
+            accessibilityNeeds: traveler.accessibilityNeeds ?? null,
+            specialRequests: traveler.specialRequests ?? null,
+            isPrimary: traveler.isPrimary ?? false,
+            notes: traveler.notes ?? null,
+          })
+          .returning()
+        if (row) travelers.push(row)
+      }
+
+      // 3. Payment schedules
+      const paymentSchedules: BookingPaymentSchedule[] = []
+      for (const schedule of input.paymentSchedules ?? []) {
+        const [row] = await tx
+          .insert(bookingPaymentSchedules)
+          .values({
+            bookingId: booking.id,
+            scheduleType: schedule.scheduleType,
+            status: schedule.status,
+            dueDate: schedule.dueDate,
+            currency: schedule.currency,
+            amountCents: schedule.amountCents,
+            notes: schedule.notes ?? null,
+          })
+          .returning()
+        if (row) paymentSchedules.push(row)
+      }
+
+      // 4. Voucher redemption. Delegates to vouchersService so the balance
+      // decrement + redemption-log insert share the savepoint. If anything
+      // goes wrong (race with a concurrent redemption, mostly), the thrown
+      // VoucherServiceError surfaces as the outcome below.
+      let voucherRedemption: QuickCreateBookingResult["voucherRedemption"] = null
+      if (input.voucherRedemption) {
+        const { voucher, redemption } = await vouchersService.redeem(
+          tx,
+          input.voucherRedemption.voucherId,
+          {
+            bookingId: booking.id,
+            amountCents: input.voucherRedemption.amountCents,
+          },
+          userId,
+        )
+        if (redemption) {
+          voucherRedemption = { voucher, redemption }
+        }
+      }
+
+      // 5. Group membership (partaj). Either attach to an existing group or
+      // spin up a new one with this booking as the primary.
+      let groupMembership: QuickCreateBookingResult["groupMembership"] = null
+      if (input.groupMembership) {
+        if (input.groupMembership.action === "create") {
+          const group = await bookingGroupsService.createBookingGroup(tx, {
+            kind: input.groupMembership.kind,
+            label: input.groupMembership.label ?? `Shared — ${booking.bookingNumber}`,
+            productId: input.productId,
+            optionUnitId: input.groupMembership.optionUnitId ?? null,
+            primaryBookingId: input.groupMembership.makeBookingPrimary ? booking.id : null,
+          })
+          const memberResult = await bookingGroupsService.addGroupMember(tx, group.id, {
+            bookingId: booking.id,
+            role: input.groupMembership.makeBookingPrimary ? "primary" : "shared",
+          })
+          if (memberResult.status !== "ok") {
+            // Shouldn't happen — we just created both rows — but throw so
+            // the tx rolls back instead of leaving a half-created group.
+            throw new QuickCreateAbort({ status: "group_not_found" })
+          }
+          groupMembership = { groupId: group.id, member: memberResult.member }
+        } else {
+          const memberResult = await bookingGroupsService.addGroupMember(
+            tx,
+            input.groupMembership.groupId,
+            {
+              bookingId: booking.id,
+              role: input.groupMembership.role,
+            },
+          )
+          if (memberResult.status === "group_not_found") {
+            throw new QuickCreateAbort({ status: "group_not_found" })
+          }
+          if (memberResult.status === "booking_not_found") {
+            // Same booking we just inserted. Pg transaction visibility should
+            // prevent this; surface as group_not_found for the caller — we
+            // can't tell them the booking we created doesn't exist.
+            throw new QuickCreateAbort({ status: "group_not_found" })
+          }
+          if (memberResult.status === "already_in_group") {
+            throw new QuickCreateAbort({
+              status: "booking_already_in_group",
+              currentGroupId: memberResult.currentGroupId,
+            })
+          }
+          groupMembership = {
+            groupId: input.groupMembership.groupId,
+            member: memberResult.member,
+          }
+        }
+      }
+
+      return {
+        booking,
+        travelers,
+        paymentSchedules,
+        voucherRedemption,
+        groupMembership,
+      }
+    })
+  } catch (error) {
+    if (error instanceof QuickCreateAbort) {
+      return error.outcome
+    }
+    if (error instanceof VoucherServiceError) {
+      if (error.code === "voucher_not_found") return { status: "voucher_not_found" }
+      if (error.code === "voucher_inactive") return { status: "voucher_inactive" }
+      if (error.code === "voucher_expired") return { status: "voucher_expired" }
+      if (error.code === "insufficient_balance") return { status: "voucher_insufficient_balance" }
+    }
+    throw error
+  }
+
+  // Post-commit event emission. Fire-and-forget (the eventBus contract
+  // handles subscriber errors); callers that need strict delivery can
+  // re-emit from their own subscriber chain.
+  if (runtime?.eventBus) {
+    const event: BookingQuickCreatedEvent = {
+      bookingId: result.booking.id,
+      bookingNumber: result.booking.bookingNumber,
+      productId: input.productId,
+      travelerCount: result.travelers.length,
+      paymentScheduleCount: result.paymentSchedules.length,
+      voucherRedeemedCents: result.voucherRedemption
+        ? result.voucherRedemption.redemption.amountCents
+        : null,
+      groupId: result.groupMembership?.groupId ?? null,
+      createdByUserId: userId ?? null,
+      occurredAt: new Date(),
+    }
+    await runtime.eventBus.emit("booking.quick-created", event)
+  }
+
+  return { status: "ok", result }
+}

--- a/packages/finance/tests/integration/quick-create.test.ts
+++ b/packages/finance/tests/integration/quick-create.test.ts
@@ -1,0 +1,435 @@
+import { bookingGroups, bookings, bookingTravelers } from "@voyantjs/bookings/schema"
+import { createEventBus } from "@voyantjs/core"
+import { eq, sql } from "drizzle-orm"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import {
+  bookingPaymentSchedules,
+  paymentInstruments,
+  voucherRedemptions,
+  vouchers,
+} from "../../src/schema.js"
+import { quickCreateBooking } from "../../src/service-bookings-quick-create.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+async function resetTables(
+  // biome-ignore lint/suspicious/noExplicitAny: test db
+  db: any,
+) {
+  const tableNames = [
+    "voucher_redemptions",
+    "vouchers",
+    "payment_instruments",
+    "booking_payment_schedules",
+    "booking_allocations",
+    "booking_travelers",
+    "booking_group_members",
+    "booking_groups",
+    "booking_supplier_statuses",
+    "booking_items",
+    "bookings",
+    "option_units",
+    "product_day_services",
+    "product_days",
+    "product_ticket_settings",
+    "product_options",
+    "products",
+  ]
+  const existing = (await db.execute<{ tablename: string }>(sql`
+    SELECT tablename
+    FROM pg_tables
+    WHERE schemaname = 'public'
+      AND tablename IN (${sql.join(
+        tableNames.map((name) => sql`${name}`),
+        sql`, `,
+      )})
+  `)) as Array<{ tablename: string }>
+
+  if (existing.length === 0) return
+  const names = existing.map((r) => `"${r.tablename}"`).join(", ")
+  await db.execute(sql.raw(`TRUNCATE ${names} CASCADE`))
+}
+
+let productSeq = 0
+let bookingSeq = 0
+function nextBookingNumber() {
+  bookingSeq += 1
+  return `BK-QC-${String(bookingSeq).padStart(5, "0")}`
+}
+
+describe.skipIf(!DB_AVAILABLE)("quickCreateBooking", () => {
+  let db: ReturnType<typeof import("@voyantjs/db/test-utils").createTestDb>
+
+  beforeAll(async () => {
+    const { createTestDb } = await import("@voyantjs/db/test-utils")
+    db = createTestDb()
+    await resetTables(db)
+  })
+
+  beforeEach(async () => {
+    await resetTables(db)
+  })
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyantjs/db/test-utils")
+    await closeTestDb()
+  })
+
+  async function seedProduct() {
+    productSeq += 1
+    // Raw SQL keeps this free of a cross-package schema import. The quick-
+    // create path only needs products + a default option + one option_unit;
+    // we skip itinerary/day seeding because the orchestrator tolerates zero
+    // day services (supplier statuses just stay empty).
+    const productId = `prod_qc_${productSeq}`
+    const optionId = `popt_qc_${productSeq}`
+    const unitId = `opun_qc_${productSeq}`
+    const itineraryId = `piti_qc_${productSeq}`
+    await db.execute(sql`
+      INSERT INTO products (id, name, sell_currency, sell_amount_cents, cost_amount_cents, margin_percent, start_date, end_date, pax)
+      VALUES (
+        ${productId},
+        ${`Quick Create Product ${productSeq}`},
+        'EUR',
+        50000,
+        30000,
+        40,
+        '2026-07-01',
+        '2026-07-03',
+        2
+      )
+    `)
+    await db.execute(sql`
+      INSERT INTO product_options (id, product_id, name, status, is_default, sort_order)
+      VALUES (${optionId}, ${productId}, 'Standard', 'active', true, 0)
+    `)
+    await db.execute(sql`
+      INSERT INTO option_units (id, option_id, name, unit_type, is_required, min_quantity, sort_order)
+      VALUES (${unitId}, ${optionId}, 'Adult', 'person', true, 1, 0)
+    `)
+    await db.execute(sql`
+      INSERT INTO product_itineraries (id, product_id, name, is_default, sort_order)
+      VALUES (${itineraryId}, ${productId}, 'Default', true, 0)
+    `)
+    await db.execute(sql`
+      INSERT INTO product_ticket_settings (id, product_id, fulfillment_mode, default_delivery_format, ticket_per_unit)
+      VALUES (${`ptix_qc_${productSeq}`}, ${productId}, 'per_item', 'qr_code', false)
+    `)
+
+    return { productId, optionId, unitId }
+  }
+
+  async function seedVoucher(
+    overrides: {
+      code?: string
+      remainingAmountCents?: number
+      status?: "active" | "redeemed" | "void"
+      expiresAt?: Date | null
+    } = {},
+  ) {
+    const [row] = await db
+      .insert(vouchers)
+      .values({
+        code: overrides.code ?? `QC-${productSeq}-${Date.now()}`,
+        currency: "EUR",
+        initialAmountCents: overrides.remainingAmountCents ?? 20000,
+        remainingAmountCents: overrides.remainingAmountCents ?? 20000,
+        status: overrides.status ?? "active",
+        sourceType: "manual",
+        expiresAt: overrides.expiresAt ?? null,
+      })
+      .returning()
+    return row!
+  }
+
+  async function seedBookingGroup() {
+    const [group] = await db
+      .insert(bookingGroups)
+      .values({
+        kind: "shared_room",
+        label: "Existing group",
+      })
+      .returning()
+    return group!
+  }
+
+  it("creates booking + travelers + payment schedules atomically", async () => {
+    const { productId } = await seedProduct()
+
+    const outcome = await quickCreateBooking(db, {
+      productId,
+      bookingNumber: nextBookingNumber(),
+      travelers: [
+        {
+          firstName: "Alice",
+          lastName: "Lead",
+          email: "alice@example.com",
+          participantType: "traveler",
+          isPrimary: true,
+        },
+        {
+          firstName: "Bob",
+          lastName: "Companion",
+          participantType: "traveler",
+          travelerCategory: "adult",
+        },
+      ],
+      paymentSchedules: [
+        {
+          scheduleType: "deposit",
+          status: "due",
+          dueDate: "2026-06-15",
+          currency: "EUR",
+          amountCents: 20000,
+        },
+        {
+          scheduleType: "balance",
+          status: "pending",
+          dueDate: "2026-06-30",
+          currency: "EUR",
+          amountCents: 30000,
+        },
+      ],
+    })
+
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+    expect(outcome.result.booking.status).toBe("draft")
+    expect(outcome.result.travelers).toHaveLength(2)
+    expect(outcome.result.travelers[0]?.firstName).toBe("Alice")
+    expect(outcome.result.paymentSchedules).toHaveLength(2)
+    expect(outcome.result.voucherRedemption).toBeNull()
+    expect(outcome.result.groupMembership).toBeNull()
+
+    const bookingsRows = await db.select().from(bookings)
+    expect(bookingsRows).toHaveLength(1)
+    const travelerRows = await db
+      .select()
+      .from(bookingTravelers)
+      .where(eq(bookingTravelers.bookingId, outcome.result.booking.id))
+    expect(travelerRows).toHaveLength(2)
+    const scheduleRows = await db
+      .select()
+      .from(bookingPaymentSchedules)
+      .where(eq(bookingPaymentSchedules.bookingId, outcome.result.booking.id))
+    expect(scheduleRows).toHaveLength(2)
+  })
+
+  it("redeems voucher and decrements remaining balance", async () => {
+    const { productId } = await seedProduct()
+    const voucher = await seedVoucher({ remainingAmountCents: 25000 })
+
+    const outcome = await quickCreateBooking(db, {
+      productId,
+      bookingNumber: nextBookingNumber(),
+      voucherRedemption: {
+        voucherId: voucher.id,
+        amountCents: 10000,
+      },
+    })
+
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+    expect(outcome.result.voucherRedemption?.voucher.remainingAmountCents).toBe(15000)
+    expect(outcome.result.voucherRedemption?.redemption.amountCents).toBe(10000)
+
+    const [updatedVoucher] = await db.select().from(vouchers).where(eq(vouchers.id, voucher.id))
+    expect(updatedVoucher?.remainingAmountCents).toBe(15000)
+
+    const redemptionRows = await db
+      .select()
+      .from(voucherRedemptions)
+      .where(eq(voucherRedemptions.voucherId, voucher.id))
+    expect(redemptionRows).toHaveLength(1)
+    expect(redemptionRows[0]?.bookingId).toBe(outcome.result.booking.id)
+  })
+
+  it("rolls back booking + travelers when voucher has insufficient balance", async () => {
+    const { productId } = await seedProduct()
+    const voucher = await seedVoucher({ remainingAmountCents: 500 })
+
+    const outcome = await quickCreateBooking(db, {
+      productId,
+      bookingNumber: nextBookingNumber(),
+      travelers: [{ firstName: "Will", lastName: "Rollback", participantType: "traveler" }],
+      paymentSchedules: [
+        {
+          scheduleType: "balance",
+          dueDate: "2026-06-30",
+          currency: "EUR",
+          amountCents: 10000,
+        },
+      ],
+      voucherRedemption: { voucherId: voucher.id, amountCents: 2000 },
+    })
+
+    expect(outcome.status).toBe("voucher_insufficient_balance")
+    expect(await db.select().from(bookings)).toHaveLength(0)
+    expect(await db.select().from(bookingTravelers)).toHaveLength(0)
+    expect(await db.select().from(bookingPaymentSchedules)).toHaveLength(0)
+
+    // Voucher balance untouched.
+    const [same] = await db.select().from(vouchers).where(eq(vouchers.id, voucher.id))
+    expect(same?.remainingAmountCents).toBe(500)
+  })
+
+  it("returns voucher_not_found for unknown voucher id (no booking created)", async () => {
+    const { productId } = await seedProduct()
+
+    const outcome = await quickCreateBooking(db, {
+      productId,
+      bookingNumber: nextBookingNumber(),
+      voucherRedemption: { voucherId: "vchr_missing", amountCents: 1000 },
+    })
+
+    expect(outcome.status).toBe("voucher_not_found")
+    expect(await db.select().from(bookings)).toHaveLength(0)
+  })
+
+  it("returns voucher_inactive for non-active voucher", async () => {
+    const { productId } = await seedProduct()
+    const voucher = await seedVoucher({ status: "void" })
+
+    const outcome = await quickCreateBooking(db, {
+      productId,
+      bookingNumber: nextBookingNumber(),
+      voucherRedemption: { voucherId: voucher.id, amountCents: 1000 },
+    })
+    expect(outcome.status).toBe("voucher_inactive")
+  })
+
+  it("returns voucher_expired for past expiresAt", async () => {
+    const { productId } = await seedProduct()
+    const voucher = await seedVoucher({ expiresAt: new Date("2020-01-01") })
+
+    const outcome = await quickCreateBooking(db, {
+      productId,
+      bookingNumber: nextBookingNumber(),
+      voucherRedemption: { voucherId: voucher.id, amountCents: 1000 },
+    })
+    expect(outcome.status).toBe("voucher_expired")
+  })
+
+  it("creates a new booking group and attaches the booking as primary", async () => {
+    const { productId } = await seedProduct()
+
+    const outcome = await quickCreateBooking(db, {
+      productId,
+      bookingNumber: nextBookingNumber(),
+      groupMembership: {
+        action: "create",
+        kind: "shared_room",
+        label: "My shared group",
+      },
+    })
+
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+    expect(outcome.result.groupMembership?.member.role).toBe("primary")
+
+    const groupRows = await db.select().from(bookingGroups)
+    expect(groupRows).toHaveLength(1)
+    expect(groupRows[0]?.label).toBe("My shared group")
+    expect(groupRows[0]?.primaryBookingId).toBe(outcome.result.booking.id)
+  })
+
+  it("joins an existing booking group", async () => {
+    const { productId } = await seedProduct()
+    const group = await seedBookingGroup()
+
+    const outcome = await quickCreateBooking(db, {
+      productId,
+      bookingNumber: nextBookingNumber(),
+      groupMembership: {
+        action: "join",
+        groupId: group.id,
+        role: "shared",
+      },
+    })
+
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+    expect(outcome.result.groupMembership?.groupId).toBe(group.id)
+    expect(outcome.result.groupMembership?.member.role).toBe("shared")
+  })
+
+  it("returns group_not_found for missing group (nothing written)", async () => {
+    const { productId } = await seedProduct()
+
+    const outcome = await quickCreateBooking(db, {
+      productId,
+      bookingNumber: nextBookingNumber(),
+      travelers: [{ firstName: "Orphan", lastName: "Ghost", participantType: "traveler" }],
+      groupMembership: { action: "join", groupId: "bgrp_missing", role: "shared" },
+    })
+
+    expect(outcome.status).toBe("group_not_found")
+    expect(await db.select().from(bookings)).toHaveLength(0)
+    expect(await db.select().from(bookingTravelers)).toHaveLength(0)
+  })
+
+  it("returns product_not_found for unknown productId", async () => {
+    const outcome = await quickCreateBooking(db, {
+      productId: "prod_nope",
+      bookingNumber: nextBookingNumber(),
+    })
+
+    expect(outcome.status).toBe("product_not_found")
+    expect(await db.select().from(bookings)).toHaveLength(0)
+  })
+
+  it("emits booking.quick-created event after commit when runtime provided", async () => {
+    const { productId } = await seedProduct()
+    const eventBus = createEventBus()
+    const received: unknown[] = []
+    eventBus.subscribe("booking.quick-created", (event) => {
+      received.push(event)
+    })
+
+    const outcome = await quickCreateBooking(
+      db,
+      {
+        productId,
+        bookingNumber: nextBookingNumber(),
+        travelers: [{ firstName: "Evt", lastName: "Listener", participantType: "traveler" }],
+      },
+      { runtime: { eventBus }, userId: "usrp_tester" },
+    )
+
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+
+    // Give the event bus a tick since subscribers run async.
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(received).toHaveLength(1)
+    const envelope = received[0] as {
+      name: string
+      data: {
+        bookingId: string
+        travelerCount: number
+        createdByUserId: string | null
+      }
+    }
+    expect(envelope.name).toBe("booking.quick-created")
+    expect(envelope.data.bookingId).toBe(outcome.result.booking.id)
+    expect(envelope.data.travelerCount).toBe(1)
+    expect(envelope.data.createdByUserId).toBe("usrp_tester")
+  })
+
+  it("leaves payment_instruments untouched even when voucher orchestration runs", async () => {
+    // Regression guard: the fallback voucher path reads payment_instruments;
+    // the new orchestrator should never write to it.
+    const { productId } = await seedProduct()
+    const voucher = await seedVoucher({ remainingAmountCents: 20000 })
+
+    await quickCreateBooking(db, {
+      productId,
+      bookingNumber: nextBookingNumber(),
+      voucherRedemption: { voucherId: voucher.id, amountCents: 5000 },
+    })
+
+    expect(await db.select().from(paymentInstruments)).toHaveLength(0)
+  })
+})

--- a/templates/dmc/src/api/app.ts
+++ b/templates/dmc/src/api/app.ts
@@ -8,7 +8,7 @@ import { distributionBookingExtension, distributionHonoModule } from "@voyantjs/
 import { externalRefsHonoModule } from "@voyantjs/external-refs"
 import { extrasHonoModule } from "@voyantjs/extras"
 import { facilitiesHonoModule } from "@voyantjs/facilities"
-import { createFinanceHonoModule } from "@voyantjs/finance"
+import { bookingsQuickCreateExtension, createFinanceHonoModule } from "@voyantjs/finance"
 import { groundHonoModule } from "@voyantjs/ground"
 import { createApp } from "@voyantjs/hono"
 import { hospitalityHonoModule } from "@voyantjs/hospitality"
@@ -114,6 +114,7 @@ export const app = createApp<CloudflareBindings>({
   ],
   extensions: [
     bookingsSupplierExtension,
+    bookingsQuickCreateExtension,
     productsBookingExtension,
     crmBookingExtension,
     transactionsBookingExtension,

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -7,7 +7,7 @@ import { createCustomerPortalHonoModule } from "@voyantjs/customer-portal"
 import { distributionBookingExtension, distributionHonoModule } from "@voyantjs/distribution"
 import { externalRefsHonoModule } from "@voyantjs/external-refs"
 import { extrasHonoModule } from "@voyantjs/extras"
-import { createFinanceHonoModule } from "@voyantjs/finance"
+import { bookingsQuickCreateExtension, createFinanceHonoModule } from "@voyantjs/finance"
 import { createApp } from "@voyantjs/hono"
 import { identityHonoModule } from "@voyantjs/identity"
 import { createLegalHonoModule } from "@voyantjs/legal"
@@ -126,6 +126,7 @@ export const app = createApp<CloudflareBindings>({
   ],
   extensions: [
     bookingsSupplierExtension,
+    bookingsQuickCreateExtension,
     productsBookingExtension,
     crmBookingExtension,
     transactionsBookingExtension,


### PR DESCRIPTION
## Summary
Next slice of #223. One-shot endpoint that creates a booking together with travelers, payment schedules, voucher redemption, and shared-room group membership inside a single transaction. Operator consumers previously had to chain 4-5 mutations from the client, so a mid-chain failure (voucher insufficient-balance after travelers were already inserted) left orphan state.

## What's new
- \`quickCreateBooking(db, input, { userId, runtime })\` in \`@voyantjs/finance\`. Runs inside \`db.transaction\`: convert product → booking → insert travelers → insert payment schedules → redeem voucher → create-or-join booking_group. Any step that discovers a precondition failure throws \`QuickCreateAbort\` so drizzle rolls the whole tx back; no orphans.
- Post-commit \`booking.quick-created\` event when a runtime.eventBus is wired.
- \`bookingsQuickCreateExtension\` (HonoExtension with \`extension.module='bookings'\`) mounts \`POST /quick-create\` under \`/v1/admin/bookings/*\`. Registered in \`templates/dmc\` and \`templates/operator\` alongside the other bookings extensions.
- \`quickCreateBookingSchema\` exported for callers that want full input validation. Discriminated-union \`groupMembership\` (join | create) plus typed voucher redemption payload.
- Returns a structured outcome discriminated by \`status\` — the route maps to HTTP: 404 product/voucher/group not found, 409 voucher inactive/expired/insufficient/booking already in group, 201 ok.

## Bonus: fix pre-existing convert-from-product drift
\`productDaysRef\` in bookings expected a \`product_id\` column that products removed when days were re-parented onto \`product_itineraries\`. The existing \`POST /v1/bookings/from-product\` endpoint and its integration test have been silently broken ever since.
- New \`productItinerariesRef\` stub; \`productDaysRef\` updated to \`itineraryId\`.
- \`getConvertProductData\` joins through itineraries so day services still seed supplier_statuses.
- \`seedProductBundle\` in the bookings integration tests updated accordingly. The \"creates a booking from a product\" test passes again (all 67 routes tests pass).

## Follow-ups (tracked on #223)
- Passenger \`roomUnitId\` is accepted on the input for round-trip with the UI PassengersSection, but not persisted yet (bookingTravelers has no assignment column). Either add a traveler metadata JSONB or wire \`booking_allocations\`.
- BookingDialog composition slice will be the first consumer of this endpoint.

## Test plan
- [x] 12 integration tests on \`quickCreateBooking\` — happy path, voucher redemption, insufficient-balance rollback, voucher not-found / inactive / expired, create group as primary, join existing group, group-not-found rollback, product-not-found, event emission, payment_instruments untouched
- [x] Existing bookings routes tests (67) still pass after the itinerary fix
- [x] Typecheck passes on bookings, finance, operator, dmc