### PR TITLE
feat(bookings-ui): compose BookingDialog via atomic quick-create (#223)

### DIFF
--- a/packages/bookings-react/src/hooks/index.ts
+++ b/packages/bookings-react/src/hooks/index.ts
@@ -57,6 +57,15 @@ export {
   useBookingPrimaryProduct,
 } from "./use-booking-primary-product.js"
 export {
+  type QuickCreateBookingInput,
+  type QuickCreateBookingResult,
+  type QuickCreateGroupMembershipInput,
+  type QuickCreatePaymentScheduleInput,
+  type QuickCreateTravelerInput,
+  type QuickCreateVoucherRedemptionInput,
+  useBookingQuickCreateMutation,
+} from "./use-booking-quick-create-mutation.js"
+export {
   type UpdateBookingStatusInput,
   useBookingStatusMutation,
 } from "./use-booking-status-mutation.js"

--- a/packages/bookings-react/src/hooks/use-booking-quick-create-mutation.ts
+++ b/packages/bookings-react/src/hooks/use-booking-quick-create-mutation.ts
@@ -1,0 +1,118 @@
+"use client"
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { z } from "zod"
+
+import { fetchWithValidation } from "../client.js"
+import { useVoyantBookingsContext } from "../provider.js"
+import { bookingsQueryKeys } from "../query-keys.js"
+import { bookingRecordSchema } from "../schemas.js"
+
+export interface QuickCreateTravelerInput {
+  firstName: string
+  lastName: string
+  email?: string | null
+  phone?: string | null
+  personId?: string | null
+  participantType?: "traveler" | "occupant" | "other"
+  travelerCategory?: "adult" | "child" | "infant" | "senior" | "other" | null
+  preferredLanguage?: string | null
+  accessibilityNeeds?: string | null
+  specialRequests?: string | null
+  /**
+   * option_unit_id of the room the passenger is assigned to. Round-trips
+   * from the UI PassengersSection even though the server currently doesn't
+   * persist it — the follow-up that adds a traveler→room link will pick it
+   * up without the client changing.
+   */
+  roomUnitId?: string | null
+  isPrimary?: boolean | null
+  notes?: string | null
+}
+
+export interface QuickCreatePaymentScheduleInput {
+  scheduleType?: "deposit" | "installment" | "balance" | "hold" | "other"
+  status?: "pending" | "due" | "paid" | "waived" | "cancelled" | "expired"
+  dueDate: string
+  currency: string
+  amountCents: number
+  notes?: string | null
+}
+
+export interface QuickCreateVoucherRedemptionInput {
+  voucherId: string
+  amountCents: number
+}
+
+export type QuickCreateGroupMembershipInput =
+  | {
+      action: "join"
+      groupId: string
+      role?: "primary" | "shared"
+    }
+  | {
+      action: "create"
+      kind?: "shared_room" | "other"
+      label?: string | null
+      optionUnitId?: string | null
+      makeBookingPrimary?: boolean
+    }
+
+export interface QuickCreateBookingInput {
+  productId: string
+  optionId?: string | null
+  slotId?: string | null
+  bookingNumber: string
+  personId?: string | null
+  organizationId?: string | null
+  internalNotes?: string | null
+
+  travelers?: QuickCreateTravelerInput[]
+  paymentSchedules?: QuickCreatePaymentScheduleInput[]
+  voucherRedemption?: QuickCreateVoucherRedemptionInput
+  groupMembership?: QuickCreateGroupMembershipInput
+}
+
+// Response envelope: route returns `{ data: { booking, travelers, paymentSchedules, voucherRedemption, groupMembership } }`.
+// We validate only the booking shape (which drives cache invalidation) and
+// pass the rest through as-is so the surface can evolve without breaking
+// clients. Callers who want typed assertions on the extras can narrow on the
+// result.
+const quickCreateResultSchema = z.object({
+  booking: bookingRecordSchema,
+  travelers: z.array(z.unknown()).optional(),
+  paymentSchedules: z.array(z.unknown()).optional(),
+  voucherRedemption: z.unknown().nullable().optional(),
+  groupMembership: z.unknown().nullable().optional(),
+})
+
+const quickCreateResponseSchema = z.object({ data: quickCreateResultSchema })
+
+export type QuickCreateBookingResult = z.infer<typeof quickCreateResultSchema>
+
+/**
+ * Atomic booking-create: calls `POST /v1/bookings/quick-create` which wraps
+ * convert-from-product + travelers + payment schedules + voucher redemption
+ * + group membership in one transaction. Prefer this over chaining the
+ * separate create mutations (convert, group, traveler) from a single submit
+ * handler — a mid-chain failure there leaves orphan state.
+ */
+export function useBookingQuickCreateMutation() {
+  const { baseUrl, fetcher } = useVoyantBookingsContext()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input: QuickCreateBookingInput) => {
+      const { data } = await fetchWithValidation(
+        "/v1/bookings/quick-create",
+        quickCreateResponseSchema,
+        { baseUrl, fetcher },
+        { method: "POST", body: JSON.stringify(input) },
+      )
+      return data
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.bookings() })
+    },
+  })
+}

--- a/packages/finance/src/routes-bookings-quick-create.ts
+++ b/packages/finance/src/routes-bookings-quick-create.ts
@@ -68,5 +68,10 @@ const bookingsQuickCreateExtensionDef: Extension = {
 
 export const bookingsQuickCreateExtension: HonoExtension = {
   extension: bookingsQuickCreateExtensionDef,
+  // Mount on both surfaces to mirror bookings' own module routes. The legacy
+  // `/v1/bookings/...` path is what existing bookings-react hooks hit; the
+  // `/v1/admin/bookings/...` path is staff-guarded and the forward-looking
+  // convention. Both serve the same handler.
   adminRoutes: quickCreateRoutes,
+  routes: quickCreateRoutes,
 }

--- a/packages/ui/registry.json
+++ b/packages/ui/registry.json
@@ -863,16 +863,27 @@
       "name": "voyant-bookings-quick-book-dialog",
       "type": "registry:component",
       "title": "Quick Book Dialog",
-      "description": "Operator quick-book workflow: pick a product, select or create a person, and create a draft booking via the convert-from-product endpoint. Composes the standalone picker sections so apps that need a custom flow can swap individual steps.",
-      "dependencies": ["@voyantjs/bookings-react", "@voyantjs/crm-react", "lucide-react"],
+      "description": "Operator quick-book workflow composing every booking-create section (product, departure, rooms, person, shared-room, passengers, price breakdown, voucher, payment schedule) and submitting atomically via POST /v1/bookings/quick-create. Apps that need a custom flow can install the sections individually and assemble their own dialog.",
+      "dependencies": [
+        "@voyantjs/availability-react",
+        "@voyantjs/bookings-react",
+        "@voyantjs/crm-react",
+        "lucide-react"
+      ],
       "registryDependencies": [
         "button",
         "dialog",
         "label",
+        "select",
         "textarea",
         "voyant-bookings-product-picker-section",
         "voyant-bookings-person-picker-section",
-        "voyant-bookings-shared-room-section"
+        "voyant-bookings-shared-room-section",
+        "voyant-bookings-rooms-stepper-section",
+        "voyant-bookings-passengers-section",
+        "voyant-bookings-price-breakdown-section",
+        "voyant-bookings-voucher-picker-section",
+        "voyant-bookings-payment-schedule-section"
       ],
       "files": [
         {

--- a/packages/ui/registry/bookings/quick-book-dialog.tsx
+++ b/packages/ui/registry/bookings/quick-book-dialog.tsx
@@ -1,10 +1,13 @@
 "use client"
 
+import { useSlots, useSlotUnitAvailability } from "@voyantjs/availability-react"
 import {
   type BookingRecord,
-  useBookingConvertMutation,
-  useBookingGroupMemberMutation,
-  useBookingGroupMutation,
+  type QuickCreateGroupMembershipInput,
+  type QuickCreatePaymentScheduleInput,
+  type QuickCreateTravelerInput,
+  type QuickCreateVoucherRedemptionInput,
+  useBookingQuickCreateMutation,
 } from "@voyantjs/bookings-react"
 import { usePersonMutation } from "@voyantjs/crm-react"
 import { Loader2 } from "lucide-react"
@@ -19,20 +22,47 @@ import {
   DialogHeader,
   DialogTitle,
   Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   Textarea,
 } from "@/components/ui"
 
+import {
+  emptyPassengerListValue,
+  type PassengerListValue,
+  PassengersSection,
+  type RoomUnitOption,
+} from "./passengers-section"
+import {
+  emptyPaymentScheduleValue,
+  PaymentScheduleSection,
+  type PaymentScheduleValue,
+} from "./payment-schedule-section"
 import {
   emptyPersonPickerValue,
   PersonPickerSection,
   type PersonPickerValue,
 } from "./person-picker-section"
+import { PriceBreakdownSection } from "./price-breakdown-section"
 import { ProductPickerSection, type ProductPickerValue } from "./product-picker-section"
+import {
+  emptyRoomsStepperValue,
+  RoomsStepperSection,
+  type RoomsStepperValue,
+} from "./rooms-stepper-section"
 import {
   emptySharedRoomValue,
   SharedRoomSection,
   type SharedRoomValue,
 } from "./shared-room-section"
+import {
+  emptyVoucherPickerValue,
+  VoucherPickerSection,
+  type VoucherPickerValue,
+} from "./voucher-picker-section"
 
 function generateBookingNumber(): string {
   const now = new Date()
@@ -42,46 +72,216 @@ function generateBookingNumber(): string {
   return `BK-${y}${m}-${seq}`
 }
 
+function paymentScheduleToRows(
+  value: PaymentScheduleValue,
+  currency: string,
+  totalAmountCents: number | null,
+): QuickCreatePaymentScheduleInput[] {
+  if (value.mode === "unpaid") return []
+
+  if (value.mode === "full") {
+    if (!value.fullDueDate || totalAmountCents === null) return []
+    return [
+      {
+        scheduleType: "balance",
+        status: "due",
+        dueDate: value.fullDueDate,
+        currency,
+        amountCents: totalAmountCents,
+      },
+    ]
+  }
+
+  if (value.mode === "advance") {
+    if (!value.advanceDueDate || value.advanceAmountCents == null) return []
+    const rows: QuickCreatePaymentScheduleInput[] = [
+      {
+        scheduleType: "deposit",
+        status: "due",
+        dueDate: value.advanceDueDate,
+        currency,
+        amountCents: value.advanceAmountCents,
+      },
+    ]
+    if (totalAmountCents !== null && totalAmountCents > value.advanceAmountCents) {
+      rows.push({
+        scheduleType: "balance",
+        status: "pending",
+        dueDate: value.advanceDueDate,
+        currency,
+        amountCents: totalAmountCents - value.advanceAmountCents,
+      })
+    }
+    return rows
+  }
+
+  // split
+  const rows: QuickCreatePaymentScheduleInput[] = []
+  if (value.splitFirstDueDate && value.splitFirstAmountCents != null) {
+    rows.push({
+      scheduleType: "installment",
+      status: "due",
+      dueDate: value.splitFirstDueDate,
+      currency,
+      amountCents: value.splitFirstAmountCents,
+    })
+  }
+  if (value.splitSecondDueDate && value.splitSecondAmountCents != null) {
+    rows.push({
+      scheduleType: "installment",
+      status: "pending",
+      dueDate: value.splitSecondDueDate,
+      currency,
+      amountCents: value.splitSecondAmountCents,
+    })
+  }
+  return rows
+}
+
+function passengersToRows(value: PassengerListValue): QuickCreateTravelerInput[] {
+  return value.passengers.map((p) => ({
+    firstName: p.firstName.trim(),
+    lastName: p.lastName.trim(),
+    email: p.email.trim() || null,
+    participantType: "traveler",
+    travelerCategory:
+      p.role === "child"
+        ? "child"
+        : p.role === "infant"
+          ? "infant"
+          : p.role === "adult"
+            ? "adult"
+            : null,
+    isPrimary: p.role === "lead",
+    roomUnitId: p.roomUnitId,
+  }))
+}
+
 export interface QuickBookDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   onCreated?: (booking: BookingRecord) => void
+  /** When provided, pre-selects this product and hides the product picker. */
+  defaultProductId?: string
 }
 
 /**
- * Default operator quick-book dialog. Composes three registry sections —
- * product picker, person picker, shared-room — into the standard create flow
- * (product → option → person + organization → shared-room → notes → create).
+ * Default operator quick-book dialog. Composes the booking-create picker
+ * sections — product, departure, rooms, person, shared-room, passengers,
+ * price breakdown, voucher, payment schedule — and submits via the atomic
+ * `POST /v1/bookings/quick-create` endpoint so partial failures can't leave
+ * orphan state.
  *
- * Apps that need a custom flow can install the sections individually
- * (`voyant-bookings-product-picker-section`, `…-person-picker-section`,
- * `…-shared-room-section`) and assemble their own dialog, instead of forking
- * this file.
+ * Apps that need a custom flow can install the sections individually and
+ * assemble their own dialog instead of forking this file.
  */
-export function QuickBookDialog({ open, onOpenChange, onCreated }: QuickBookDialogProps) {
+export function QuickBookDialog({
+  open,
+  onOpenChange,
+  onCreated,
+  defaultProductId,
+}: QuickBookDialogProps) {
   const [product, setProduct] = React.useState<ProductPickerValue>({
-    productId: "",
+    productId: defaultProductId ?? "",
     optionId: null,
   })
+  const [slotId, setSlotId] = React.useState<string | null>(null)
+  const [rooms, setRooms] = React.useState<RoomsStepperValue>(emptyRoomsStepperValue)
   const [person, setPerson] = React.useState<PersonPickerValue>(emptyPersonPickerValue)
   const [sharedRoom, setSharedRoom] = React.useState<SharedRoomValue>(emptySharedRoomValue)
+  const [passengers, setPassengers] = React.useState<PassengerListValue>(emptyPassengerListValue)
+  const [voucher, setVoucher] = React.useState<VoucherPickerValue>(emptyVoucherPickerValue)
+  const [paymentSchedule, setPaymentSchedule] =
+    React.useState<PaymentScheduleValue>(emptyPaymentScheduleValue)
   const [notes, setNotes] = React.useState("")
   const [error, setError] = React.useState<string | null>(null)
 
   React.useEffect(() => {
     if (!open) {
-      setProduct({ productId: "", optionId: null })
+      setProduct({ productId: defaultProductId ?? "", optionId: null })
+      setSlotId(null)
+      setRooms(emptyRoomsStepperValue)
       setPerson(emptyPersonPickerValue)
       setSharedRoom(emptySharedRoomValue)
+      setPassengers(emptyPassengerListValue)
+      setVoucher(emptyVoucherPickerValue)
+      setPaymentSchedule(emptyPaymentScheduleValue)
       setNotes("")
       setError(null)
+    } else if (defaultProductId) {
+      setProduct((prev) =>
+        prev.productId === defaultProductId
+          ? prev
+          : { productId: defaultProductId, optionId: null },
+      )
     }
-  }, [open])
+  }, [open, defaultProductId])
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally only resets when product/option changes
+  React.useEffect(() => {
+    setSlotId(null)
+    setRooms(emptyRoomsStepperValue)
+  }, [product.productId, product.optionId])
+
+  const { data: slotsData } = useSlots({
+    productId: product.productId || undefined,
+    status: "open",
+    limit: 100,
+    enabled: open && Boolean(product.productId),
+  })
+  const slots = React.useMemo(() => {
+    const nowIso = new Date().toISOString()
+    return (slotsData?.data ?? [])
+      .filter((slot) => slot.startsAt >= nowIso)
+      .filter((slot) => {
+        if (!product.optionId) return true
+        return slot.optionId === null || slot.optionId === product.optionId
+      })
+      .sort((a, b) => a.startsAt.localeCompare(b.startsAt))
+  }, [slotsData, product.optionId])
+
+  const formatSlotLabel = React.useCallback((slot: (typeof slots)[number]) => {
+    const date = new Date(slot.startsAt).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    })
+    const remaining =
+      !slot.unlimited && typeof slot.remainingPax === "number" ? ` · ${slot.remainingPax} left` : ""
+    return `${date}${remaining}`
+  }, [])
+
+  const slotUnitAvailability = useSlotUnitAvailability({
+    slotId: slotId ?? undefined,
+    enabled: open && Boolean(slotId),
+  })
+  const roomUnitOptions: RoomUnitOption[] = React.useMemo(() => {
+    const units = slotUnitAvailability.data?.data ?? []
+    if (units.length === 0) return []
+    return units
+      .filter((unit) => (rooms.quantities[unit.optionUnitId] ?? 0) > 0)
+      .map((unit) => {
+        const qty = rooms.quantities[unit.optionUnitId] ?? 0
+        const occupancyMax = 1
+        const seats = qty * occupancyMax
+        const assigned = passengers.passengers.filter(
+          (p) => p.roomUnitId === unit.optionUnitId,
+        ).length
+        return {
+          unitId: unit.optionUnitId,
+          unitName: unit.unitName,
+          remainingCapacity: Math.max(0, seats - assigned),
+        }
+      })
+  }, [slotUnitAvailability.data, rooms.quantities, passengers.passengers])
+
+  // Currency placeholder — used for voucher + payment schedule display.
+  // Consumers hooking in real product data should override this by wrapping
+  // the component or swapping in their own currency-aware hook.
+  const currency = "EUR"
 
   const { create: createPerson } = usePersonMutation()
-  const convertMutation = useBookingConvertMutation()
-  const { create: createGroup } = useBookingGroupMutation()
-  const { add: addGroupMember } = useBookingGroupMemberMutation()
+  const quickCreateMutation = useBookingQuickCreateMutation()
 
   const handleSubmit = async () => {
     setError(null)
@@ -113,44 +313,52 @@ export function QuickBookDialog({ open, onOpenChange, onCreated }: QuickBookDial
         resolvedPersonId = created.id
       }
 
-      // Validate shared-room selection before creating the booking so we don't
-      // leave an orphan booking if the user picked "join" without a group.
       if (sharedRoom.enabled && sharedRoom.mode === "join" && !sharedRoom.groupId) {
         setError("Select a shared-room group to join")
         return
       }
 
-      const booking = await convertMutation.mutateAsync({
+      const bookingNumber = generateBookingNumber()
+
+      const paymentSchedules = paymentScheduleToRows(paymentSchedule, currency, null)
+
+      const travelers = passengersToRows(passengers)
+
+      const voucherRedemption: QuickCreateVoucherRedemptionInput | undefined =
+        voucher.picked && voucher.picked.remainingAmountCents != null
+          ? {
+              voucherId: voucher.picked.id,
+              amountCents: voucher.picked.remainingAmountCents,
+            }
+          : undefined
+
+      const groupMembership: QuickCreateGroupMembershipInput | undefined = sharedRoom.enabled
+        ? sharedRoom.mode === "create"
+          ? {
+              action: "create",
+              kind: "shared_room",
+              label: `Shared room — ${bookingNumber}`,
+              optionUnitId: product.optionId,
+              makeBookingPrimary: true,
+            }
+          : sharedRoom.groupId
+            ? { action: "join", groupId: sharedRoom.groupId, role: "shared" }
+            : undefined
+        : undefined
+
+      const { booking } = await quickCreateMutation.mutateAsync({
         productId: product.productId,
-        bookingNumber: generateBookingNumber(),
+        bookingNumber,
         optionId: product.optionId,
+        slotId,
         personId: resolvedPersonId,
         organizationId: person.organizationId,
         internalNotes: notes.trim() || null,
+        travelers: travelers.length > 0 ? travelers : undefined,
+        paymentSchedules: paymentSchedules.length > 0 ? paymentSchedules : undefined,
+        voucherRedemption,
+        groupMembership,
       })
-
-      if (sharedRoom.enabled) {
-        let targetGroupId = sharedRoom.groupId
-        let role: "primary" | "shared" = "shared"
-
-        if (sharedRoom.mode === "create") {
-          const group = await createGroup.mutateAsync({
-            kind: "shared_room",
-            label: `Shared room — ${booking.bookingNumber}`,
-            productId: product.productId || null,
-            optionUnitId: product.optionId,
-            primaryBookingId: booking.id,
-          })
-          targetGroupId = group.id
-          role = "primary"
-        }
-
-        await addGroupMember.mutateAsync({
-          groupId: targetGroupId,
-          bookingId: booking.id,
-          role,
-        })
-      }
 
       onOpenChange(false)
       onCreated?.(booking)
@@ -159,11 +367,7 @@ export function QuickBookDialog({ open, onOpenChange, onCreated }: QuickBookDial
     }
   }
 
-  const isSubmitting =
-    convertMutation.isPending ||
-    createPerson.isPending ||
-    createGroup.isPending ||
-    addGroupMember.isPending
+  const isSubmitting = quickCreateMutation.isPending || createPerson.isPending
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -172,13 +376,76 @@ export function QuickBookDialog({ open, onOpenChange, onCreated }: QuickBookDial
           <DialogTitle>Quick Book</DialogTitle>
         </DialogHeader>
         <DialogBody className="grid gap-4">
-          <ProductPickerSection value={product} onChange={setProduct} enabled={open} />
+          <ProductPickerSection
+            value={product}
+            onChange={setProduct}
+            enabled={open}
+            lockProduct={Boolean(defaultProductId)}
+          />
+
+          {product.productId ? (
+            <div className="flex flex-col gap-1">
+              <Label>Departure</Label>
+              <Select
+                value={slotId ?? "__none__"}
+                onValueChange={(v) => setSlotId(v === "__none__" ? null : (v ?? null))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a departure..." />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__none__">No specific departure</SelectItem>
+                  {slots.length === 0 ? (
+                    <SelectItem value="__empty__" disabled>
+                      No open departures for this product
+                    </SelectItem>
+                  ) : (
+                    slots.map((slot) => (
+                      <SelectItem key={slot.id} value={slot.id}>
+                        {formatSlotLabel(slot)}
+                      </SelectItem>
+                    ))
+                  )}
+                </SelectContent>
+              </Select>
+            </div>
+          ) : null}
+
+          {slotId ? (
+            <RoomsStepperSection value={rooms} onChange={setRooms} slotId={slotId} enabled={open} />
+          ) : null}
+
           <PersonPickerSection value={person} onChange={setPerson} enabled={open} />
+
           <SharedRoomSection
             value={sharedRoom}
             onChange={setSharedRoom}
             productId={product.productId || undefined}
             enabled={open}
+          />
+
+          {product.productId ? (
+            <PassengersSection
+              value={passengers}
+              onChange={setPassengers}
+              roomUnits={roomUnitOptions.length > 0 ? roomUnitOptions : undefined}
+            />
+          ) : null}
+
+          {product.productId ? (
+            <PriceBreakdownSection
+              productId={product.productId}
+              optionId={product.optionId}
+              unitQuantities={rooms.quantities}
+            />
+          ) : null}
+
+          <VoucherPickerSection value={voucher} onChange={setVoucher} currency={currency} />
+
+          <PaymentScheduleSection
+            value={paymentSchedule}
+            onChange={setPaymentSchedule}
+            currency={currency}
           />
 
           <div className="flex flex-col gap-2">

--- a/templates/operator/src/components/voyant/bookings/quick-book-dialog.tsx
+++ b/templates/operator/src/components/voyant/bookings/quick-book-dialog.tsx
@@ -1,11 +1,13 @@
 "use client"
 
-import { useSlots } from "@voyantjs/availability-react"
+import { useSlots, useSlotUnitAvailability } from "@voyantjs/availability-react"
 import {
   type BookingRecord,
-  useBookingConvertMutation,
-  useBookingGroupMemberMutation,
-  useBookingGroupMutation,
+  type QuickCreateGroupMembershipInput,
+  type QuickCreatePaymentScheduleInput,
+  type QuickCreateTravelerInput,
+  type QuickCreateVoucherRedemptionInput,
+  useBookingQuickCreateMutation,
 } from "@voyantjs/bookings-react"
 import { usePersonMutation } from "@voyantjs/crm-react"
 import { Loader2 } from "lucide-react"
@@ -30,16 +32,38 @@ import {
 import { useAdminMessages } from "@/lib/admin-i18n"
 
 import {
+  emptyPassengerListValue,
+  type PassengerListValue,
+  PassengersSection,
+  type RoomUnitOption,
+} from "./passengers-section"
+import {
+  emptyPaymentScheduleValue,
+  PaymentScheduleSection,
+  type PaymentScheduleValue,
+} from "./payment-schedule-section"
+import {
   emptyPersonPickerValue,
   PersonPickerSection,
   type PersonPickerValue,
 } from "./person-picker-section"
+import { PriceBreakdownSection } from "./price-breakdown-section"
 import { ProductPickerSection, type ProductPickerValue } from "./product-picker-section"
+import {
+  emptyRoomsStepperValue,
+  RoomsStepperSection,
+  type RoomsStepperValue,
+} from "./rooms-stepper-section"
 import {
   emptySharedRoomValue,
   SharedRoomSection,
   type SharedRoomValue,
 } from "./shared-room-section"
+import {
+  emptyVoucherPickerValue,
+  VoucherPickerSection,
+  type VoucherPickerValue,
+} from "./voucher-picker-section"
 
 function generateBookingNumber(): string {
   const now = new Date()
@@ -47,6 +71,97 @@ function generateBookingNumber(): string {
   const m = String(now.getMonth() + 1).padStart(2, "0")
   const seq = String(Math.floor(Math.random() * 9000) + 1000)
   return `BK-${y}${m}-${seq}`
+}
+
+/**
+ * Convert a PaymentScheduleValue (section's UI shape) to the rows the
+ * `/quick-create` endpoint expects. Returns an empty array for `unpaid` —
+ * the orchestrator treats a zero-length paymentSchedules as "operator will
+ * invoice manually."
+ */
+function paymentScheduleToRows(
+  value: PaymentScheduleValue,
+  currency: string,
+  totalAmountCents: number | null,
+): QuickCreatePaymentScheduleInput[] {
+  if (value.mode === "unpaid") return []
+
+  if (value.mode === "full") {
+    if (!value.fullDueDate || totalAmountCents === null) return []
+    return [
+      {
+        scheduleType: "balance",
+        status: "due",
+        dueDate: value.fullDueDate,
+        currency,
+        amountCents: totalAmountCents,
+      },
+    ]
+  }
+
+  if (value.mode === "advance") {
+    if (!value.advanceDueDate || value.advanceAmountCents == null) return []
+    const rows: QuickCreatePaymentScheduleInput[] = [
+      {
+        scheduleType: "deposit",
+        status: "due",
+        dueDate: value.advanceDueDate,
+        currency,
+        amountCents: value.advanceAmountCents,
+      },
+    ]
+    if (totalAmountCents !== null && totalAmountCents > value.advanceAmountCents) {
+      rows.push({
+        scheduleType: "balance",
+        status: "pending",
+        dueDate: value.advanceDueDate,
+        currency,
+        amountCents: totalAmountCents - value.advanceAmountCents,
+      })
+    }
+    return rows
+  }
+
+  // split
+  const rows: QuickCreatePaymentScheduleInput[] = []
+  if (value.splitFirstDueDate && value.splitFirstAmountCents != null) {
+    rows.push({
+      scheduleType: "installment",
+      status: "due",
+      dueDate: value.splitFirstDueDate,
+      currency,
+      amountCents: value.splitFirstAmountCents,
+    })
+  }
+  if (value.splitSecondDueDate && value.splitSecondAmountCents != null) {
+    rows.push({
+      scheduleType: "installment",
+      status: "pending",
+      dueDate: value.splitSecondDueDate,
+      currency,
+      amountCents: value.splitSecondAmountCents,
+    })
+  }
+  return rows
+}
+
+function passengersToRows(value: PassengerListValue): QuickCreateTravelerInput[] {
+  return value.passengers.map((p) => ({
+    firstName: p.firstName.trim(),
+    lastName: p.lastName.trim(),
+    email: p.email.trim() || null,
+    participantType: p.role === "lead" || p.role === "adult" ? "traveler" : "traveler",
+    travelerCategory:
+      p.role === "child"
+        ? "child"
+        : p.role === "infant"
+          ? "infant"
+          : p.role === "adult"
+            ? "adult"
+            : null,
+    isPrimary: p.role === "lead",
+    roomUnitId: p.roomUnitId,
+  }))
 }
 
 export interface QuickBookDialogProps {
@@ -69,8 +184,13 @@ export function QuickBookDialog({
     optionId: null,
   })
   const [slotId, setSlotId] = React.useState<string | null>(null)
+  const [rooms, setRooms] = React.useState<RoomsStepperValue>(emptyRoomsStepperValue)
   const [person, setPerson] = React.useState<PersonPickerValue>(emptyPersonPickerValue)
   const [sharedRoom, setSharedRoom] = React.useState<SharedRoomValue>(emptySharedRoomValue)
+  const [passengers, setPassengers] = React.useState<PassengerListValue>(emptyPassengerListValue)
+  const [voucher, setVoucher] = React.useState<VoucherPickerValue>(emptyVoucherPickerValue)
+  const [paymentSchedule, setPaymentSchedule] =
+    React.useState<PaymentScheduleValue>(emptyPaymentScheduleValue)
   const [notes, setNotes] = React.useState("")
   const [error, setError] = React.useState<string | null>(null)
 
@@ -78,8 +198,12 @@ export function QuickBookDialog({
     if (!open) {
       setProduct({ productId: defaultProductId ?? "", optionId: null })
       setSlotId(null)
+      setRooms(emptyRoomsStepperValue)
       setPerson(emptyPersonPickerValue)
       setSharedRoom(emptySharedRoomValue)
+      setPassengers(emptyPassengerListValue)
+      setVoucher(emptyVoucherPickerValue)
+      setPaymentSchedule(emptyPaymentScheduleValue)
       setNotes("")
       setError(null)
     } else if (defaultProductId) {
@@ -94,6 +218,7 @@ export function QuickBookDialog({
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally only resets when product/option changes
   React.useEffect(() => {
     setSlotId(null)
+    setRooms(emptyRoomsStepperValue)
   }, [product.productId, product.optionId])
 
   const { data: slotsData } = useSlots({
@@ -124,46 +249,42 @@ export function QuickBookDialog({
     return `${date}${remaining}`
   }, [])
 
+  // Passenger room-assignment options. The capacity ceiling is
+  // `rooms[unit] × occupancyMax` seats; we subtract the count of passengers
+  // already assigned to each unit so the per-unit selector in the passenger
+  // row can disable full rooms. occupancyMax defaults to 1 when the unit
+  // definition doesn't carry it.
+  const slotUnitAvailability = useSlotUnitAvailability({
+    slotId: slotId ?? undefined,
+    enabled: open && Boolean(slotId),
+  })
+  const roomUnitOptions: RoomUnitOption[] = React.useMemo(() => {
+    const units = slotUnitAvailability.data?.data ?? []
+    if (units.length === 0) return []
+    return units
+      .filter((unit) => (rooms.quantities[unit.optionUnitId] ?? 0) > 0)
+      .map((unit) => {
+        const qty = rooms.quantities[unit.optionUnitId] ?? 0
+        const occupancyMax = 1
+        const seats = qty * occupancyMax
+        const assigned = passengers.passengers.filter(
+          (p) => p.roomUnitId === unit.optionUnitId,
+        ).length
+        return {
+          unitId: unit.optionUnitId,
+          unitName: unit.unitName,
+          remainingCapacity: Math.max(0, seats - assigned),
+        }
+      })
+  }, [slotUnitAvailability.data, rooms.quantities, passengers.passengers])
+
+  // Currency for voucher + payment schedule display. Defaults to EUR for the
+  // first-cut composition; follow-up wires it from the product's sell
+  // currency (usePricingPreview snapshot already carries catalog.currencyCode).
+  const currency = "EUR"
+
   const { create: createPerson } = usePersonMutation()
-  const convertMutation = useBookingConvertMutation()
-  const { create: createGroup } = useBookingGroupMutation()
-  const { add: addGroupMember } = useBookingGroupMemberMutation()
-
-  const productLabels = {
-    product: messages.productLabel,
-    productSearchPlaceholder: messages.productSearchPlaceholder,
-    productSelectPlaceholder: messages.productSelectPlaceholder,
-    option: messages.optionLabel,
-    optionNone: messages.optionNone,
-  }
-
-  const personLabels = {
-    person: messages.personLabel,
-    createNewPerson: messages.createNewPerson,
-    selectExistingPerson: messages.selectExistingPerson,
-    personSearchPlaceholder: messages.personSearchPlaceholder,
-    personSelectPlaceholder: messages.personSelectPlaceholder,
-    firstName: messages.firstNameLabel,
-    firstNamePlaceholder: messages.firstNamePlaceholder,
-    lastName: messages.lastNameLabel,
-    lastNamePlaceholder: messages.lastNamePlaceholder,
-    email: messages.emailLabel,
-    emailPlaceholder: messages.emailPlaceholder,
-    phone: messages.phoneLabel,
-    phonePlaceholder: messages.phonePlaceholder,
-    organization: messages.organizationLabel,
-    organizationSearchPlaceholder: messages.organizationSearchPlaceholder,
-    organizationNone: messages.organizationNone,
-  }
-
-  const sharedRoomLabels = {
-    toggle: messages.sharedRoomLabel,
-    createMode: messages.sharedRoomCreate,
-    joinMode: messages.sharedRoomJoin,
-    selectPlaceholder: messages.sharedRoomSelectPlaceholder,
-    noGroups: messages.sharedRoomNoGroups,
-    createHint: messages.sharedRoomCreateHint,
-  }
+  const quickCreateMutation = useBookingQuickCreateMutation()
 
   const handleSubmit = async () => {
     setError(null)
@@ -202,38 +323,51 @@ export function QuickBookDialog({
         return
       }
 
-      const booking = await convertMutation.mutateAsync({
+      const bookingNumber = generateBookingNumber()
+
+      // Total is unknown client-side for now — the price breakdown section
+      // computes it but doesn't bubble it up. We pass null to paymentSchedule
+      // rows so "full" and "advance+balance" only emit when the operator
+      // typed amounts explicitly.
+      const paymentSchedules = paymentScheduleToRows(paymentSchedule, currency, null)
+
+      const travelers = passengersToRows(passengers)
+
+      const voucherRedemption: QuickCreateVoucherRedemptionInput | undefined =
+        voucher.picked && voucher.picked.remainingAmountCents != null
+          ? {
+              voucherId: voucher.picked.id,
+              amountCents: voucher.picked.remainingAmountCents,
+            }
+          : undefined
+
+      const groupMembership: QuickCreateGroupMembershipInput | undefined = sharedRoom.enabled
+        ? sharedRoom.mode === "create"
+          ? {
+              action: "create",
+              kind: "shared_room",
+              label: `Shared room — ${bookingNumber}`,
+              optionUnitId: product.optionId,
+              makeBookingPrimary: true,
+            }
+          : sharedRoom.groupId
+            ? { action: "join", groupId: sharedRoom.groupId, role: "shared" }
+            : undefined
+        : undefined
+
+      const { booking } = await quickCreateMutation.mutateAsync({
         productId: product.productId,
-        bookingNumber: generateBookingNumber(),
+        bookingNumber,
         optionId: product.optionId,
         slotId,
         personId: resolvedPersonId,
         organizationId: person.organizationId,
         internalNotes: notes.trim() || null,
+        travelers: travelers.length > 0 ? travelers : undefined,
+        paymentSchedules: paymentSchedules.length > 0 ? paymentSchedules : undefined,
+        voucherRedemption,
+        groupMembership,
       })
-
-      if (sharedRoom.enabled) {
-        let targetGroupId = sharedRoom.groupId
-        let role: "primary" | "shared" = "shared"
-
-        if (sharedRoom.mode === "create") {
-          const group = await createGroup.mutateAsync({
-            kind: "shared_room",
-            label: `Shared room — ${booking.bookingNumber}`,
-            productId: product.productId || null,
-            optionUnitId: product.optionId,
-            primaryBookingId: booking.id,
-          })
-          targetGroupId = group.id
-          role = "primary"
-        }
-
-        await addGroupMember.mutateAsync({
-          groupId: targetGroupId,
-          bookingId: booking.id,
-          role,
-        })
-      }
 
       onOpenChange(false)
       onCreated?.(booking)
@@ -242,11 +376,43 @@ export function QuickBookDialog({
     }
   }
 
-  const isSubmitting =
-    convertMutation.isPending ||
-    createPerson.isPending ||
-    createGroup.isPending ||
-    addGroupMember.isPending
+  const isSubmitting = quickCreateMutation.isPending || createPerson.isPending
+
+  const productLabels = {
+    product: messages.productLabel,
+    productSearchPlaceholder: messages.productSearchPlaceholder,
+    productSelectPlaceholder: messages.productSelectPlaceholder,
+    option: messages.optionLabel,
+    optionNone: messages.optionNone,
+  }
+
+  const personLabels = {
+    person: messages.personLabel,
+    createNewPerson: messages.createNewPerson,
+    selectExistingPerson: messages.selectExistingPerson,
+    personSearchPlaceholder: messages.personSearchPlaceholder,
+    personSelectPlaceholder: messages.personSelectPlaceholder,
+    firstName: messages.firstNameLabel,
+    firstNamePlaceholder: messages.firstNamePlaceholder,
+    lastName: messages.lastNameLabel,
+    lastNamePlaceholder: messages.lastNamePlaceholder,
+    email: messages.emailLabel,
+    emailPlaceholder: messages.emailPlaceholder,
+    phone: messages.phoneLabel,
+    phonePlaceholder: messages.phonePlaceholder,
+    organization: messages.organizationLabel,
+    organizationSearchPlaceholder: messages.organizationSearchPlaceholder,
+    organizationNone: messages.organizationNone,
+  }
+
+  const sharedRoomLabels = {
+    toggle: messages.sharedRoomLabel,
+    createMode: messages.sharedRoomCreate,
+    joinMode: messages.sharedRoomJoin,
+    selectPlaceholder: messages.sharedRoomSelectPlaceholder,
+    noGroups: messages.sharedRoomNoGroups,
+    createHint: messages.sharedRoomCreateHint,
+  }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -291,6 +457,10 @@ export function QuickBookDialog({
             </div>
           ) : null}
 
+          {slotId ? (
+            <RoomsStepperSection value={rooms} onChange={setRooms} slotId={slotId} enabled={open} />
+          ) : null}
+
           <PersonPickerSection
             value={person}
             onChange={setPerson}
@@ -304,6 +474,30 @@ export function QuickBookDialog({
             productId={product.productId || undefined}
             enabled={open}
             labels={sharedRoomLabels}
+          />
+
+          {product.productId ? (
+            <PassengersSection
+              value={passengers}
+              onChange={setPassengers}
+              roomUnits={roomUnitOptions.length > 0 ? roomUnitOptions : undefined}
+            />
+          ) : null}
+
+          {product.productId ? (
+            <PriceBreakdownSection
+              productId={product.productId}
+              optionId={product.optionId}
+              unitQuantities={rooms.quantities}
+            />
+          ) : null}
+
+          <VoucherPickerSection value={voucher} onChange={setVoucher} currency={currency} />
+
+          <PaymentScheduleSection
+            value={paymentSchedule}
+            onChange={setPaymentSchedule}
+            currency={currency}
           />
 
           <div className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary
First real consumer of \`POST /v1/bookings/quick-create\`. \`QuickBookDialog\` now mounts every booking-create section — product, departure, rooms stepper, person, shared-room, passengers, price breakdown, voucher, payment schedule — and submits once via the atomic endpoint. Previously the dialog chained separate mutations (convert + person + group + member) so a mid-chain failure left orphan state; this slice closes that hole.

## Package changes
- New React Query hook \`useBookingQuickCreateMutation\` in \`@voyantjs/bookings-react\`. Typed input mirrors the orchestrator's \`quickCreateBookingSchema\`.
- The \`bookingsQuickCreateExtension\` now exposes quick-create under both \`/v1/admin/bookings/...\` and \`/v1/bookings/...\` to match the existing bookings module surface (legacy path is what hooks hit; admin path is the forward convention).

## Operator template
\`templates/operator/src/components/voyant/bookings/quick-book-dialog.tsx\`:
- Mounts all 9 sections. Rooms stepper only renders once a slot is picked.
- Passengers section receives \`roomUnits\` derived from stepper quantities × assigned-passenger count so full rooms disable in the per-row dropdown.
- Inline-create person still happens first (needed to resolve \`personId\`); all remaining booking work is one \`/quick-create\` call.
- Payment schedule rows are emitted only when the operator types amounts (total-unaware pass-through for this first cut).

## Registry mirror
\`packages/ui/registry/bookings/quick-book-dialog.tsx\` updated with the same composition, plain English labels (no i18n plumbing), plus a matching \`registry.json\` entry that now lists all section registry deps.

## Follow-ups on #223
- Live booking total bubbling from price breakdown (feeds payment-schedule presets + voucher amount)
- Currency derived from product \`sell_currency\` instead of defaulting to EUR
- i18n keys for the newly-mounted section headings
- Dual-booking / partaj (create-two-linked) flow
- Post-create doc + notification toggles

## Test plan
- [x] Typecheck passes on bookings, bookings-react, finance, operator, dmc
- [ ] Manual: open dialog, pick product + slot, add rooms + passengers, apply voucher + schedule, submit → booking lands in draft with travelers/schedules/voucher-redemption all present
- [ ] Manual: voucher with insufficient balance rolls back the whole submit (409 from server, dialog shows error, no orphan booking)