### PR TITLE
feat(finance): atomic POST /v1/admin/bookings/dual-create partaj flow (#223)

### DIFF
--- a/packages/bookings-react/src/hooks/index.ts
+++ b/packages/bookings-react/src/hooks/index.ts
@@ -14,6 +14,13 @@ export {
   useBookingTravelerDocumentMutation,
   useBookingTravelerDocuments,
 } from "./use-booking-documents.js"
+export {
+  type DualCreateBookingInput,
+  type DualCreateBookingResult,
+  type DualCreateGroupInput,
+  type DualCreateSubBookingInput,
+  useBookingDualCreateMutation,
+} from "./use-booking-dual-create-mutation.js"
 export { type UseBookingGroupOptions, useBookingGroup } from "./use-booking-group.js"
 export {
   type UseBookingGroupForBookingOptions,

--- a/packages/bookings-react/src/hooks/use-booking-dual-create-mutation.ts
+++ b/packages/bookings-react/src/hooks/use-booking-dual-create-mutation.ts
@@ -1,0 +1,82 @@
+"use client"
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { z } from "zod"
+
+import { fetchWithValidation } from "../client.js"
+import { useVoyantBookingsContext } from "../provider.js"
+import { bookingsQueryKeys } from "../query-keys.js"
+import { bookingRecordSchema } from "../schemas.js"
+import type { QuickCreateBookingInput } from "./use-booking-quick-create-mutation.js"
+
+/**
+ * Sub-booking payload for dual-create. Same shape as quickCreate input
+ * minus `groupMembership` — the dual endpoint manages the group itself.
+ */
+export type DualCreateSubBookingInput = Omit<QuickCreateBookingInput, "groupMembership">
+
+export interface DualCreateGroupInput {
+  kind?: "shared_room" | "other"
+  label?: string | null
+  /**
+   * option_unit the shared group occupies. The dual flow lives-or-dies on
+   * matching this across both bookings — when set, both sub-bookings should
+   * target the same optionUnitId in their passengers/allocations.
+   */
+  optionUnitId?: string | null
+}
+
+export interface DualCreateBookingInput {
+  primary: DualCreateSubBookingInput
+  secondary: DualCreateSubBookingInput
+  group?: DualCreateGroupInput
+}
+
+const dualCreateResultSchema = z.object({
+  primary: z.object({
+    booking: bookingRecordSchema,
+    travelers: z.array(z.unknown()).optional(),
+    paymentSchedules: z.array(z.unknown()).optional(),
+    voucherRedemption: z.unknown().nullable().optional(),
+  }),
+  secondary: z.object({
+    booking: bookingRecordSchema,
+    travelers: z.array(z.unknown()).optional(),
+    paymentSchedules: z.array(z.unknown()).optional(),
+    voucherRedemption: z.unknown().nullable().optional(),
+  }),
+  group: z.unknown(),
+  primaryMember: z.unknown(),
+  secondaryMember: z.unknown(),
+})
+
+const dualCreateResponseSchema = z.object({ data: dualCreateResultSchema })
+
+export type DualCreateBookingResult = z.infer<typeof dualCreateResultSchema>
+
+/**
+ * Atomic dual-booking (partaj) create: calls `POST /v1/bookings/dual-create`
+ * which wraps two quickCreate calls + one booking_group in a single
+ * transaction. Use this over calling useBookingQuickCreateMutation twice
+ * from a submit handler — a failure on the second call there would leave
+ * the first booking orphaned.
+ */
+export function useBookingDualCreateMutation() {
+  const { baseUrl, fetcher } = useVoyantBookingsContext()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input: DualCreateBookingInput) => {
+      const { data } = await fetchWithValidation(
+        "/v1/bookings/dual-create",
+        dualCreateResponseSchema,
+        { baseUrl, fetcher },
+        { method: "POST", body: JSON.stringify(input) },
+      )
+      return data
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.bookings() })
+    },
+  })
+}

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -175,6 +175,17 @@ export {
 export type { InvoiceFromBookingData } from "./service.js"
 export { financeService, renderInvoiceBody } from "./service.js"
 export type {
+  BookingDualCreatedEvent,
+  DualCreateBookingInput,
+  DualCreateBookingOutcome,
+  DualCreateBookingResult,
+  DualCreateBookingRuntime,
+} from "./service-bookings-dual-create.js"
+export {
+  dualCreateBooking,
+  dualCreateBookingSchema,
+} from "./service-bookings-dual-create.js"
+export type {
   BookingQuickCreatedEvent,
   BookingQuickCreateRuntime,
   QuickCreateBookingInput,

--- a/packages/finance/src/routes-bookings-quick-create.ts
+++ b/packages/finance/src/routes-bookings-quick-create.ts
@@ -4,6 +4,7 @@ import type { HonoExtension } from "@voyantjs/hono/module"
 import { Hono } from "hono"
 
 import { FINANCE_ROUTE_RUNTIME_CONTAINER_KEY, type FinanceRouteRuntime } from "./route-runtime.js"
+import { dualCreateBooking, dualCreateBookingSchema } from "./service-bookings-dual-create.js"
 import { quickCreateBooking, quickCreateBookingSchema } from "./service-bookings-quick-create.js"
 
 function resolveRuntime(container: { resolve: <T>(key: string) => T }): FinanceRouteRuntime | null {
@@ -26,40 +27,84 @@ const quickCreateRoutes = new Hono<{
     userId?: string
     container: { resolve: <T>(key: string) => T }
   }
-}>().post("/quick-create", async (c) => {
-  const input = await parseJsonBody(c, quickCreateBookingSchema)
-  const runtime = resolveRuntime(c.var.container)
+}>()
+  .post("/quick-create", async (c) => {
+    const input = await parseJsonBody(c, quickCreateBookingSchema)
+    const runtime = resolveRuntime(c.var.container)
 
-  const outcome = await quickCreateBooking(c.get("db"), input, {
-    userId: c.get("userId"),
-    runtime: runtime ? { eventBus: runtime.eventBus } : undefined,
+    const outcome = await quickCreateBooking(c.get("db"), input, {
+      userId: c.get("userId"),
+      runtime: runtime ? { eventBus: runtime.eventBus } : undefined,
+    })
+
+    switch (outcome.status) {
+      case "ok":
+        return c.json({ data: outcome.result }, 201)
+      case "product_not_found":
+        return c.json({ error: "Product not found or unavailable" }, 404)
+      case "voucher_not_found":
+        return c.json({ error: "Voucher not found" }, 404)
+      case "voucher_inactive":
+        return c.json({ error: "Voucher is not active" }, 409)
+      case "voucher_expired":
+        return c.json({ error: "Voucher has expired" }, 409)
+      case "voucher_insufficient_balance":
+        return c.json({ error: "Voucher does not have enough balance" }, 409)
+      case "group_not_found":
+        return c.json({ error: "Booking group not found" }, 404)
+      case "booking_already_in_group":
+        return c.json(
+          {
+            error: "Booking is already a member of a group",
+            currentGroupId: outcome.currentGroupId,
+          },
+          409,
+        )
+    }
   })
+  .post("/dual-create", async (c) => {
+    const input = await parseJsonBody(c, dualCreateBookingSchema)
+    const runtime = resolveRuntime(c.var.container)
 
-  switch (outcome.status) {
-    case "ok":
+    const outcome = await dualCreateBooking(c.get("db"), input, {
+      userId: c.get("userId"),
+      runtime: runtime ? { eventBus: runtime.eventBus } : undefined,
+    })
+
+    if (outcome.status === "ok") {
       return c.json({ data: outcome.result }, 201)
-    case "product_not_found":
-      return c.json({ error: "Product not found or unavailable" }, 404)
-    case "voucher_not_found":
-      return c.json({ error: "Voucher not found" }, 404)
-    case "voucher_inactive":
-      return c.json({ error: "Voucher is not active" }, 409)
-    case "voucher_expired":
-      return c.json({ error: "Voucher has expired" }, 409)
-    case "voucher_insufficient_balance":
-      return c.json({ error: "Voucher does not have enough balance" }, 409)
-    case "group_not_found":
-      return c.json({ error: "Booking group not found" }, 404)
-    case "booking_already_in_group":
-      return c.json(
-        {
-          error: "Booking is already a member of a group",
-          currentGroupId: outcome.currentGroupId,
-        },
-        409,
-      )
-  }
-})
+    }
+
+    // Both failure branches carry a nested quick-create reason. Map them to
+    // the same HTTP codes the single quick-create endpoint uses so callers
+    // can treat them uniformly, and surface which sub-booking tripped.
+    const which = outcome.status === "primary_failed" ? "primary" : "secondary"
+    const reason = outcome.reason
+    const body: Record<string, unknown> = { which, reasonStatus: reason.status }
+    switch (reason.status) {
+      case "product_not_found":
+        return c.json({ ...body, error: `${which}: product not found or unavailable` }, 404)
+      case "voucher_not_found":
+        return c.json({ ...body, error: `${which}: voucher not found` }, 404)
+      case "voucher_inactive":
+        return c.json({ ...body, error: `${which}: voucher is not active` }, 409)
+      case "voucher_expired":
+        return c.json({ ...body, error: `${which}: voucher has expired` }, 409)
+      case "voucher_insufficient_balance":
+        return c.json({ ...body, error: `${which}: voucher does not have enough balance` }, 409)
+      case "group_not_found":
+        return c.json({ ...body, error: `${which}: group linking failed` }, 500)
+      case "booking_already_in_group":
+        return c.json(
+          {
+            ...body,
+            error: `${which}: booking is already in a group`,
+            currentGroupId: reason.currentGroupId,
+          },
+          409,
+        )
+    }
+  })
 
 const bookingsQuickCreateExtensionDef: Extension = {
   name: "bookings-quick-create",

--- a/packages/finance/src/service-bookings-dual-create.ts
+++ b/packages/finance/src/service-bookings-dual-create.ts
@@ -1,0 +1,197 @@
+import { bookingGroupsService } from "@voyantjs/bookings"
+import type { BookingGroup, BookingGroupMember } from "@voyantjs/bookings/schema"
+import type { EventBus } from "@voyantjs/core"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { z } from "zod"
+
+import {
+  type QuickCreateBookingOutcome,
+  type QuickCreateBookingResult,
+  quickCreateBooking,
+  quickCreateBookingSchema,
+} from "./service-bookings-quick-create.js"
+
+// ---------- validation ----------
+
+/**
+ * Sub-booking input. Takes the full quick-create payload minus `group
+ * Membership` — dual-create owns the group lifecycle (one new group, both
+ * bookings linked as members) so accepting a nested group override would
+ * just be an opportunity for the caller to desync.
+ */
+const dualSubBookingSchema = quickCreateBookingSchema.omit({ groupMembership: true })
+
+const dualCreateGroupSchema = z.object({
+  kind: z.enum(["shared_room", "other"]).default("shared_room"),
+  label: z.string().max(255).optional().nullable(),
+  optionUnitId: z.string().optional().nullable(),
+})
+
+export const dualCreateBookingSchema = z.object({
+  primary: dualSubBookingSchema,
+  secondary: dualSubBookingSchema,
+  group: dualCreateGroupSchema.default({ kind: "shared_room" }),
+})
+
+export type DualCreateBookingInput = z.infer<typeof dualCreateBookingSchema>
+
+// ---------- runtime ----------
+
+export interface DualCreateBookingRuntime {
+  eventBus?: EventBus
+}
+
+export interface BookingDualCreatedEvent {
+  groupId: string
+  primaryBookingId: string
+  secondaryBookingId: string
+  productId: string
+  createdByUserId: string | null
+  occurredAt: Date
+}
+
+// ---------- result shape ----------
+
+export interface DualCreateBookingResult {
+  primary: QuickCreateBookingResult
+  secondary: QuickCreateBookingResult
+  group: BookingGroup
+  primaryMember: BookingGroupMember
+  secondaryMember: BookingGroupMember
+}
+
+export type DualCreateBookingOutcome =
+  | { status: "ok"; result: DualCreateBookingResult }
+  | {
+      status: "primary_failed" | "secondary_failed"
+      reason: Exclude<QuickCreateBookingOutcome, { status: "ok" }>
+    }
+
+/**
+ * Thrown inside the outer tx to force drizzle to roll back both bookings +
+ * the group when one of the inner quick-create calls returns non-ok.
+ * Drizzle doesn't abort on a non-throwing tx callback, so we convert the
+ * discriminated outcome into a throw here.
+ */
+class DualCreateAbort extends Error {
+  constructor(readonly outcome: DualCreateBookingOutcome) {
+    super(
+      outcome.status === "ok"
+        ? "dual-create aborted: ok (unexpected)"
+        : `dual-create aborted: ${outcome.status}:${outcome.reason.status}`,
+    )
+    this.name = "DualCreateAbort"
+  }
+}
+
+// ---------- service ----------
+
+/**
+ * Create two bookings linked via a new `booking_group`, atomically. The
+ * canonical operator flow: two travelers book a shared room ("partaj"), each
+ * gets their own booking, and both are attached to a new shared_room group
+ * so subsequent payment / cancellation decisions can fan out across the
+ * pair.
+ *
+ * Transaction shape:
+ *  - Outer tx opens via `db.transaction`.
+ *  - Inner: two savepoint-scoped `quickCreateBooking(tx, ...)` calls — the
+ *    nested transactions drizzle opens use SAVEPOINTs, so partial failures
+ *    surface up to this layer as non-ok outcomes.
+ *  - If either fails, the outer tx throws `DualCreateAbort` so the whole
+ *    thing rolls back (no orphan booking, no orphan group).
+ *  - Group creation + both memberships run last, inside the same outer tx.
+ *
+ * Event emission (`booking.dual-created`) is post-commit — subscribers only
+ * hear about successful pairs.
+ */
+export async function dualCreateBooking(
+  db: PostgresJsDatabase,
+  rawInput: DualCreateBookingInput,
+  options: {
+    userId?: string
+    runtime?: DualCreateBookingRuntime
+  } = {},
+): Promise<DualCreateBookingOutcome> {
+  const { userId, runtime } = options
+  const input = dualCreateBookingSchema.parse(rawInput)
+
+  let result: DualCreateBookingResult
+  try {
+    result = await db.transaction(async (tx) => {
+      const primaryOutcome = await quickCreateBooking(tx, input.primary, { userId })
+      if (primaryOutcome.status !== "ok") {
+        throw new DualCreateAbort({ status: "primary_failed", reason: primaryOutcome })
+      }
+
+      const secondaryOutcome = await quickCreateBooking(tx, input.secondary, { userId })
+      if (secondaryOutcome.status !== "ok") {
+        throw new DualCreateAbort({ status: "secondary_failed", reason: secondaryOutcome })
+      }
+
+      const primaryBooking = primaryOutcome.result.booking
+      const secondaryBooking = secondaryOutcome.result.booking
+
+      const group = await bookingGroupsService.createBookingGroup(tx, {
+        kind: input.group.kind,
+        label:
+          input.group.label ??
+          `Shared — ${primaryBooking.bookingNumber} + ${secondaryBooking.bookingNumber}`,
+        productId: input.primary.productId,
+        optionUnitId: input.group.optionUnitId ?? null,
+        primaryBookingId: primaryBooking.id,
+      })
+
+      const primaryMemberResult = await bookingGroupsService.addGroupMember(tx, group.id, {
+        bookingId: primaryBooking.id,
+        role: "primary",
+      })
+      if (primaryMemberResult.status !== "ok") {
+        // Shouldn't happen — we just created both rows in this tx — but bail
+        // through the same abort path to unwind cleanly.
+        throw new DualCreateAbort({
+          status: "primary_failed",
+          reason: { status: "group_not_found" },
+        })
+      }
+
+      const secondaryMemberResult = await bookingGroupsService.addGroupMember(tx, group.id, {
+        bookingId: secondaryBooking.id,
+        role: "shared",
+      })
+      if (secondaryMemberResult.status !== "ok") {
+        throw new DualCreateAbort({
+          status: "secondary_failed",
+          reason: { status: "group_not_found" },
+        })
+      }
+
+      return {
+        primary: primaryOutcome.result,
+        secondary: secondaryOutcome.result,
+        group,
+        primaryMember: primaryMemberResult.member,
+        secondaryMember: secondaryMemberResult.member,
+      }
+    })
+  } catch (error) {
+    if (error instanceof DualCreateAbort) {
+      return error.outcome
+    }
+    throw error
+  }
+
+  if (runtime?.eventBus) {
+    const event: BookingDualCreatedEvent = {
+      groupId: result.group.id,
+      primaryBookingId: result.primary.booking.id,
+      secondaryBookingId: result.secondary.booking.id,
+      productId: input.primary.productId,
+      createdByUserId: userId ?? null,
+      occurredAt: new Date(),
+    }
+    await runtime.eventBus.emit("booking.dual-created", event)
+  }
+
+  return { status: "ok", result }
+}

--- a/packages/finance/tests/integration/dual-create.test.ts
+++ b/packages/finance/tests/integration/dual-create.test.ts
@@ -1,0 +1,283 @@
+import { bookingGroupMembers, bookingGroups, bookings } from "@voyantjs/bookings/schema"
+import { createEventBus } from "@voyantjs/core"
+import { eq, sql } from "drizzle-orm"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { vouchers } from "../../src/schema.js"
+import { dualCreateBooking } from "../../src/service-bookings-dual-create.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+async function resetTables(
+  // biome-ignore lint/suspicious/noExplicitAny: test db
+  db: any,
+) {
+  const tableNames = [
+    "voucher_redemptions",
+    "vouchers",
+    "payment_instruments",
+    "booking_payment_schedules",
+    "booking_allocations",
+    "booking_travelers",
+    "booking_group_members",
+    "booking_groups",
+    "booking_supplier_statuses",
+    "booking_items",
+    "bookings",
+    "option_units",
+    "product_day_services",
+    "product_days",
+    "product_itineraries",
+    "product_ticket_settings",
+    "product_options",
+    "products",
+  ]
+  const existing = (await db.execute<{ tablename: string }>(sql`
+    SELECT tablename FROM pg_tables
+    WHERE schemaname = 'public' AND tablename IN (${sql.join(
+      tableNames.map((n) => sql`${n}`),
+      sql`, `,
+    )})
+  `)) as Array<{ tablename: string }>
+  if (existing.length === 0) return
+  const names = existing.map((r) => `"${r.tablename}"`).join(", ")
+  await db.execute(sql.raw(`TRUNCATE ${names} CASCADE`))
+}
+
+let seq = 0
+function seqId(prefix: string) {
+  seq += 1
+  return `${prefix}_dual_${seq}`
+}
+
+describe.skipIf(!DB_AVAILABLE)("dualCreateBooking", () => {
+  let db: ReturnType<typeof import("@voyantjs/db/test-utils").createTestDb>
+
+  beforeAll(async () => {
+    const { createTestDb } = await import("@voyantjs/db/test-utils")
+    db = createTestDb()
+    await resetTables(db)
+  })
+  beforeEach(async () => {
+    await resetTables(db)
+  })
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyantjs/db/test-utils")
+    await closeTestDb()
+  })
+
+  async function seedProduct() {
+    const productId = seqId("prod")
+    const optionId = seqId("popt")
+    const unitId = seqId("opun")
+    const itineraryId = seqId("piti")
+    await db.execute(sql`
+      INSERT INTO products (id, name, sell_currency, sell_amount_cents, cost_amount_cents, margin_percent, start_date, end_date, pax)
+      VALUES (${productId}, 'Dual Create', 'EUR', 50000, 30000, 40, '2026-07-01', '2026-07-03', 2)
+    `)
+    await db.execute(sql`
+      INSERT INTO product_options (id, product_id, name, status, is_default, sort_order)
+      VALUES (${optionId}, ${productId}, 'Standard', 'active', true, 0)
+    `)
+    await db.execute(sql`
+      INSERT INTO option_units (id, option_id, name, unit_type, is_required, min_quantity, sort_order)
+      VALUES (${unitId}, ${optionId}, 'Adult', 'person', true, 1, 0)
+    `)
+    await db.execute(sql`
+      INSERT INTO product_itineraries (id, product_id, name, is_default, sort_order)
+      VALUES (${itineraryId}, ${productId}, 'Default', true, 0)
+    `)
+    await db.execute(sql`
+      INSERT INTO product_ticket_settings (id, product_id, fulfillment_mode, default_delivery_format, ticket_per_unit)
+      VALUES (${seqId("ptix")}, ${productId}, 'per_item', 'qr_code', false)
+    `)
+    return { productId, optionId, unitId }
+  }
+
+  it("creates two bookings, one shared group, and two memberships atomically", async () => {
+    const { productId, unitId } = await seedProduct()
+
+    const outcome = await dualCreateBooking(db, {
+      primary: {
+        productId,
+        bookingNumber: "BK-DUAL-P-1",
+        internalNotes: "Primary traveler",
+      },
+      secondary: {
+        productId,
+        bookingNumber: "BK-DUAL-S-1",
+        internalNotes: "Room-sharing partner",
+      },
+      group: {
+        kind: "shared_room",
+        label: "Shared double — demo",
+        optionUnitId: unitId,
+      },
+    })
+
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+    expect(outcome.result.primary.booking.bookingNumber).toBe("BK-DUAL-P-1")
+    expect(outcome.result.secondary.booking.bookingNumber).toBe("BK-DUAL-S-1")
+    expect(outcome.result.group.primaryBookingId).toBe(outcome.result.primary.booking.id)
+    expect(outcome.result.primaryMember.role).toBe("primary")
+    expect(outcome.result.secondaryMember.role).toBe("shared")
+
+    expect(await db.select().from(bookings)).toHaveLength(2)
+    expect(await db.select().from(bookingGroups)).toHaveLength(1)
+    const memberRows = await db
+      .select()
+      .from(bookingGroupMembers)
+      .where(eq(bookingGroupMembers.groupId, outcome.result.group.id))
+    expect(memberRows).toHaveLength(2)
+  })
+
+  it("rolls back both bookings and the group when the second booking's voucher is invalid", async () => {
+    const { productId } = await seedProduct()
+    // Voucher that exists but has zero balance — secondary's redeem attempt
+    // will abort.
+    const [voucher] = await db
+      .insert(vouchers)
+      .values({
+        code: "DUAL-ZERO",
+        currency: "EUR",
+        initialAmountCents: 0,
+        remainingAmountCents: 0,
+        status: "redeemed",
+        sourceType: "manual",
+      })
+      .returning()
+
+    const outcome = await dualCreateBooking(db, {
+      primary: {
+        productId,
+        bookingNumber: "BK-DUAL-P-ROLLBACK",
+      },
+      secondary: {
+        productId,
+        bookingNumber: "BK-DUAL-S-ROLLBACK",
+        voucherRedemption: { voucherId: voucher!.id, amountCents: 100 },
+      },
+      group: { kind: "shared_room" },
+    })
+
+    expect(outcome.status).toBe("secondary_failed")
+    if (outcome.status !== "secondary_failed") return
+    expect(outcome.reason.status).toBe("voucher_inactive")
+
+    // Nothing should have landed — primary's inner savepoint committed but
+    // the outer tx aborts on the DualCreateAbort throw, so both bookings
+    // disappear with the group.
+    expect(await db.select().from(bookings)).toHaveLength(0)
+    expect(await db.select().from(bookingGroups)).toHaveLength(0)
+    expect(await db.select().from(bookingGroupMembers)).toHaveLength(0)
+  })
+
+  it("rolls back when the primary booking fails up-front (unknown product)", async () => {
+    await seedProduct()
+
+    const outcome = await dualCreateBooking(db, {
+      primary: {
+        productId: "prod_missing",
+        bookingNumber: "BK-DUAL-P-NOPROD",
+      },
+      secondary: {
+        productId: (await seedProduct()).productId,
+        bookingNumber: "BK-DUAL-S-NOPROD",
+      },
+      group: { kind: "shared_room" },
+    })
+
+    expect(outcome.status).toBe("primary_failed")
+    if (outcome.status !== "primary_failed") return
+    expect(outcome.reason.status).toBe("product_not_found")
+    expect(await db.select().from(bookings)).toHaveLength(0)
+    expect(await db.select().from(bookingGroups)).toHaveLength(0)
+  })
+
+  it("applies vouchers and travelers on both sub-bookings", async () => {
+    const { productId } = await seedProduct()
+    const [voucherA] = await db
+      .insert(vouchers)
+      .values({
+        code: "DUAL-A",
+        currency: "EUR",
+        initialAmountCents: 10000,
+        remainingAmountCents: 10000,
+        status: "active",
+        sourceType: "manual",
+      })
+      .returning()
+    const [voucherB] = await db
+      .insert(vouchers)
+      .values({
+        code: "DUAL-B",
+        currency: "EUR",
+        initialAmountCents: 5000,
+        remainingAmountCents: 5000,
+        status: "active",
+        sourceType: "manual",
+      })
+      .returning()
+
+    const outcome = await dualCreateBooking(db, {
+      primary: {
+        productId,
+        bookingNumber: "BK-DUAL-PAIR-P",
+        travelers: [
+          { firstName: "Ana", lastName: "Primary", participantType: "traveler", isPrimary: true },
+        ],
+        voucherRedemption: { voucherId: voucherA!.id, amountCents: 4000 },
+      },
+      secondary: {
+        productId,
+        bookingNumber: "BK-DUAL-PAIR-S",
+        travelers: [
+          { firstName: "Bob", lastName: "Secondary", participantType: "traveler", isPrimary: true },
+        ],
+        voucherRedemption: { voucherId: voucherB!.id, amountCents: 2000 },
+      },
+      group: { kind: "shared_room" },
+    })
+
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+
+    const [primaryVoucher] = await db.select().from(vouchers).where(eq(vouchers.id, voucherA!.id))
+    const [secondaryVoucher] = await db.select().from(vouchers).where(eq(vouchers.id, voucherB!.id))
+    expect(primaryVoucher?.remainingAmountCents).toBe(6000)
+    expect(secondaryVoucher?.remainingAmountCents).toBe(3000)
+
+    expect(outcome.result.primary.travelers[0]?.firstName).toBe("Ana")
+    expect(outcome.result.secondary.travelers[0]?.firstName).toBe("Bob")
+  })
+
+  it("emits booking.dual-created event after commit when runtime provided", async () => {
+    const { productId } = await seedProduct()
+    const eventBus = createEventBus()
+    const received: unknown[] = []
+    eventBus.subscribe("booking.dual-created", (envelope) => {
+      received.push(envelope)
+    })
+
+    const outcome = await dualCreateBooking(
+      db,
+      {
+        primary: { productId, bookingNumber: "BK-DUAL-EVT-P" },
+        secondary: { productId, bookingNumber: "BK-DUAL-EVT-S" },
+        group: { kind: "shared_room" },
+      },
+      { runtime: { eventBus }, userId: "usrp_dual" },
+    )
+
+    expect(outcome.status).toBe("ok")
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(received).toHaveLength(1)
+    const envelope = received[0] as {
+      name: string
+      data: { primaryBookingId: string; secondaryBookingId: string; createdByUserId: string | null }
+    }
+    expect(envelope.name).toBe("booking.dual-created")
+    expect(envelope.data.createdByUserId).toBe("usrp_dual")
+  })
+})


### PR DESCRIPTION
## Summary
Slice #4 of the #223 backlog: dual-booking / partaj — two travelers each get their own booking linked via one shared \`booking_group\`, all in one atomic transaction. Builds on the single-booking quickCreate plumbing from #263; if either sub-booking fails we throw \`DualCreateAbort\` from the outer tx so nothing lands half-created.

## Service
- \`dualCreateBooking(db, input, { userId, runtime })\` in \`@voyantjs/finance\` wraps two \`quickCreateBooking(tx, ...)\` calls inside one \`db.transaction\`. Nested tx uses PG savepoints — primary's savepoint only commits when the whole outer tx commits, so a secondary failure unwinds both.
- Input schema reuses \`quickCreateBookingSchema.omit({ groupMembership })\` for each sub-booking. The group is owned by dual-create itself: one shared_room row, primary booking as primary member, secondary as shared.
- Outcome discriminated by status: \`ok\` | \`primary_failed\` | \`secondary_failed\`. Failure branches carry the nested quickCreate reason so the route maps to HTTP uniformly.
- Post-commit \`booking.dual-created\` event when \`runtime.eventBus\` is wired.

## Route
\`POST /dual-create\` added alongside the existing \`/quick-create\` on the same extension. Status mapping mirrors quickCreate's (404/409) with an extra \`which: primary | secondary\` field surfacing which sub-booking tripped.

## React hook
\`useBookingDualCreateMutation\` in \`@voyantjs/bookings-react\`. Input composes \`DualCreateSubBookingInput\` (= \`QuickCreateBookingInput\` minus groupMembership) × 2 plus an optional group config.

## Test plan
- [x] 5 integration tests — happy path (2 bookings + group + memberships), secondary voucher redeem failure rolls back everything, primary product-not-found rolls back, vouchers applied on both sides, event emission
- [x] Typecheck passes on finance, bookings-react
- [ ] DualBookDialog UI (follow-up slice)