### PR TITLE
feat(bookings-ui): post-create confirm + notify toggle (#223)

### DIFF
--- a/packages/bookings-react/src/hooks/index.ts
+++ b/packages/bookings-react/src/hooks/index.ts
@@ -73,7 +73,9 @@ export {
   useBookingQuickCreateMutation,
 } from "./use-booking-quick-create-mutation.js"
 export {
+  type UpdateBookingStatusByIdInput,
   type UpdateBookingStatusInput,
+  useBookingStatusByIdMutation,
   useBookingStatusMutation,
 } from "./use-booking-status-mutation.js"
 export { type UseBookingsOptions, useBookings } from "./use-bookings.js"

--- a/packages/bookings-react/src/hooks/use-booking-status-mutation.ts
+++ b/packages/bookings-react/src/hooks/use-booking-status-mutation.ts
@@ -33,3 +33,38 @@ export function useBookingStatusMutation(bookingId: string) {
     },
   })
 }
+
+export interface UpdateBookingStatusByIdInput extends UpdateBookingStatusInput {
+  bookingId: string
+}
+
+/**
+ * Variant of `useBookingStatusMutation` that accepts the booking id at call
+ * time instead of at hook-setup time. Used by flows that create a booking
+ * and immediately transition its status in the same handler — the id only
+ * exists after the create returns, so the per-booking hook shape doesn't
+ * fit.
+ */
+export function useBookingStatusByIdMutation() {
+  const { baseUrl, fetcher } = useVoyantBookingsContext()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ bookingId, ...input }: UpdateBookingStatusByIdInput) => {
+      const { data } = await fetchWithValidation(
+        `/v1/bookings/${bookingId}/status`,
+        bookingSingleResponse,
+        { baseUrl, fetcher },
+        { method: "PATCH", body: JSON.stringify(input) },
+      )
+      return data
+    },
+    onSuccess: (data, variables) => {
+      void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.bookings() })
+      queryClient.setQueryData(bookingsQueryKeys.booking(variables.bookingId), { data })
+      void queryClient.invalidateQueries({
+        queryKey: bookingsQueryKeys.activity(variables.bookingId),
+      })
+    },
+  })
+}

--- a/packages/i18n/src/admin/bookings.ts
+++ b/packages/i18n/src/admin/bookings.ts
@@ -90,6 +90,9 @@ export const adminBookingsMessages = {
           "A new group will be created with this booking as the primary member.",
         notesLabel: "Internal Notes",
         notesPlaceholder: "Quick context for this booking...",
+        confirmAfterCreateLabel: "Confirm & notify traveler after creating",
+        confirmAfterCreateHint:
+          "Transitions the booking to confirmed and — when the notifications module's auto-dispatch is on — sends the booking docs to the lead traveler. Leave off to keep the booking in draft.",
         errorSelectProduct: "Select a product",
         errorSelectPerson: "Select a person or switch to create mode",
         errorNameRequired: "First and last name are required",
@@ -622,6 +625,9 @@ export const adminBookingsMessages = {
         sharedRoomCreateHint: "Va fi creat un grup nou cu aceasta rezervare ca membru principal.",
         notesLabel: "Note interne",
         notesPlaceholder: "Context rapid pentru aceasta rezervare...",
+        confirmAfterCreateLabel: "Confirma & notifica calatorul dupa creare",
+        confirmAfterCreateHint:
+          "Trece rezervarea in confirmata si, cand modulul de notificari are auto-dispatch activ, trimite documentele rezervarii catre calatorul principal. Lasa nebifat pentru a ramane in draft.",
         errorSelectProduct: "Selecteaza un produs",
         errorSelectPerson: "Selecteaza o persoana sau treci pe modul creare",
         errorNameRequired: "Prenumele si numele sunt obligatorii",

--- a/packages/ui/registry.json
+++ b/packages/ui/registry.json
@@ -872,6 +872,7 @@
       ],
       "registryDependencies": [
         "button",
+        "checkbox",
         "dialog",
         "label",
         "select",

--- a/packages/ui/registry/bookings/quick-book-dialog.tsx
+++ b/packages/ui/registry/bookings/quick-book-dialog.tsx
@@ -8,6 +8,7 @@ import {
   type QuickCreateTravelerInput,
   type QuickCreateVoucherRedemptionInput,
   useBookingQuickCreateMutation,
+  useBookingStatusByIdMutation,
 } from "@voyantjs/bookings-react"
 import { usePersonMutation } from "@voyantjs/crm-react"
 import { Loader2 } from "lucide-react"
@@ -15,6 +16,7 @@ import * as React from "react"
 
 import {
   Button,
+  Checkbox,
   Dialog,
   DialogBody,
   DialogContent,
@@ -194,6 +196,14 @@ export function QuickBookDialog({
   const [paymentSchedule, setPaymentSchedule] =
     React.useState<PaymentScheduleValue>(emptyPaymentScheduleValue)
   const [notes, setNotes] = React.useState("")
+  /**
+   * Optional post-create transition: set status to `confirmed` right after
+   * create succeeds. When the parent app has the notifications module's
+   * `autoConfirmAndDispatch` enabled, this fires the doc bundle + traveler
+   * email via the `booking.confirmed` subscriber. When it isn't, the
+   * booking simply lands in `confirmed` instead of `draft`.
+   */
+  const [confirmAfterCreate, setConfirmAfterCreate] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
 
   React.useEffect(() => {
@@ -207,6 +217,7 @@ export function QuickBookDialog({
       setVoucher(emptyVoucherPickerValue)
       setPaymentSchedule(emptyPaymentScheduleValue)
       setNotes("")
+      setConfirmAfterCreate(false)
       setError(null)
     } else if (defaultProductId) {
       setProduct((prev) =>
@@ -282,6 +293,7 @@ export function QuickBookDialog({
 
   const { create: createPerson } = usePersonMutation()
   const quickCreateMutation = useBookingQuickCreateMutation()
+  const statusMutation = useBookingStatusByIdMutation()
 
   const handleSubmit = async () => {
     setError(null)
@@ -360,14 +372,38 @@ export function QuickBookDialog({
         groupMembership,
       })
 
+      // Optional post-create confirm. If the app has autoConfirmAndDispatch
+      // wired on the notifications module, the status transition triggers
+      // the doc bundle + traveler email subscriber. A failed status change
+      // doesn't roll back the booking — it exists, operator can confirm
+      // manually later.
+      let finalBooking = booking
+      if (confirmAfterCreate) {
+        try {
+          finalBooking = await statusMutation.mutateAsync({
+            bookingId: booking.id,
+            status: "confirmed",
+          })
+        } catch (statusErr) {
+          setError(
+            statusErr instanceof Error
+              ? `Booking created but confirm failed: ${statusErr.message}`
+              : "Booking created but confirm failed",
+          )
+          onCreated?.(booking)
+          return
+        }
+      }
+
       onOpenChange(false)
-      onCreated?.(booking)
+      onCreated?.(finalBooking)
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to create booking")
     }
   }
 
-  const isSubmitting = quickCreateMutation.isPending || createPerson.isPending
+  const isSubmitting =
+    quickCreateMutation.isPending || createPerson.isPending || statusMutation.isPending
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -455,6 +491,25 @@ export function QuickBookDialog({
               onChange={(e) => setNotes(e.target.value)}
               placeholder="Quick context for this booking..."
             />
+          </div>
+
+          <div className="flex items-start gap-2 rounded-md border p-3">
+            <Checkbox
+              id="quickbook-confirm-after-create"
+              checked={confirmAfterCreate}
+              onCheckedChange={(v) => setConfirmAfterCreate(v === true)}
+              className="mt-0.5"
+            />
+            <div className="flex flex-col gap-1">
+              <Label htmlFor="quickbook-confirm-after-create" className="cursor-pointer text-sm">
+                Confirm & notify traveler after creating
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                Transitions to confirmed after create. When the notifications module's auto-dispatch
+                is on, this fires the doc bundle + traveler email via the booking.confirmed
+                subscriber.
+              </p>
+            </div>
           </div>
 
           {error && <p className="text-xs text-destructive">{error}</p>}

--- a/templates/operator/src/components/voyant/bookings/quick-book-dialog.tsx
+++ b/templates/operator/src/components/voyant/bookings/quick-book-dialog.tsx
@@ -8,6 +8,7 @@ import {
   type QuickCreateTravelerInput,
   type QuickCreateVoucherRedemptionInput,
   useBookingQuickCreateMutation,
+  useBookingStatusByIdMutation,
 } from "@voyantjs/bookings-react"
 import { usePersonMutation } from "@voyantjs/crm-react"
 import { Loader2 } from "lucide-react"
@@ -15,6 +16,7 @@ import * as React from "react"
 
 import {
   Button,
+  Checkbox,
   Dialog,
   DialogBody,
   DialogContent,
@@ -192,6 +194,10 @@ export function QuickBookDialog({
   const [paymentSchedule, setPaymentSchedule] =
     React.useState<PaymentScheduleValue>(emptyPaymentScheduleValue)
   const [notes, setNotes] = React.useState("")
+  // Post-create: confirm + fire auto-dispatch. The operator template wires
+  // `autoConfirmAndDispatch` on the notifications module so a booking.confirmed
+  // transition auto-sends the doc bundle — no separate notify call needed.
+  const [confirmAfterCreate, setConfirmAfterCreate] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
 
   React.useEffect(() => {
@@ -205,6 +211,7 @@ export function QuickBookDialog({
       setVoucher(emptyVoucherPickerValue)
       setPaymentSchedule(emptyPaymentScheduleValue)
       setNotes("")
+      setConfirmAfterCreate(false)
       setError(null)
     } else if (defaultProductId) {
       setProduct((prev) =>
@@ -285,6 +292,7 @@ export function QuickBookDialog({
 
   const { create: createPerson } = usePersonMutation()
   const quickCreateMutation = useBookingQuickCreateMutation()
+  const statusMutation = useBookingStatusByIdMutation()
 
   const handleSubmit = async () => {
     setError(null)
@@ -369,14 +377,40 @@ export function QuickBookDialog({
         groupMembership,
       })
 
+      // Optional post-create: transition to confirmed. In operator's app.ts
+      // the notifications module has autoConfirmAndDispatch enabled, so this
+      // status change automatically triggers the doc bundle + traveler email
+      // via the booking.confirmed subscriber. If the status call fails we
+      // don't roll back — the booking exists, the operator can confirm later.
+      let finalBooking = booking
+      if (confirmAfterCreate) {
+        try {
+          finalBooking = await statusMutation.mutateAsync({
+            bookingId: booking.id,
+            status: "confirmed",
+          })
+        } catch (statusErr) {
+          setError(
+            statusErr instanceof Error
+              ? `Booking created but confirm failed: ${statusErr.message}`
+              : messages.errorCreateFailed,
+          )
+          // Still fire onCreated so the parent closes & refreshes — the
+          // booking did land, only the confirm step tripped.
+          onCreated?.(booking)
+          return
+        }
+      }
+
       onOpenChange(false)
-      onCreated?.(booking)
+      onCreated?.(finalBooking)
     } catch (err) {
       setError(err instanceof Error ? err.message : messages.errorCreateFailed)
     }
   }
 
-  const isSubmitting = quickCreateMutation.isPending || createPerson.isPending
+  const isSubmitting =
+    quickCreateMutation.isPending || createPerson.isPending || statusMutation.isPending
 
   const productLabels = {
     product: messages.productLabel,
@@ -507,6 +541,21 @@ export function QuickBookDialog({
               onChange={(e) => setNotes(e.target.value)}
               placeholder={messages.notesPlaceholder}
             />
+          </div>
+
+          <div className="flex items-start gap-2 rounded-md border p-3">
+            <Checkbox
+              id="quickbook-confirm-after-create"
+              checked={confirmAfterCreate}
+              onCheckedChange={(v) => setConfirmAfterCreate(v === true)}
+              className="mt-0.5"
+            />
+            <div className="flex flex-col gap-1">
+              <Label htmlFor="quickbook-confirm-after-create" className="cursor-pointer text-sm">
+                {messages.confirmAfterCreateLabel}
+              </Label>
+              <p className="text-xs text-muted-foreground">{messages.confirmAfterCreateHint}</p>
+            </div>
           </div>
 
           {error && <p className="text-xs text-destructive">{error}</p>}


### PR DESCRIPTION
## Summary
Last unchecked item on the #223 issue: post-create doc + notification toggles. Adds a **\"Confirm & notify traveler after creating\"** checkbox to \`QuickBookDialog\`. When checked, the submit handler transitions the fresh booking to \`confirmed\` right after \`quickCreate\` returns. In the operator template (where \`autoConfirmAndDispatch\` is wired via #257), that event fires the doc bundle + traveler email automatically.

## Why one toggle, not two
The underlying pipeline is already a single subscriber — 'booking.confirmed' → auto-dispatch → docs + email. Exposing separate \"generate docs\" / \"notify\" booleans in the UI would be a footgun since they map to the same backend action.

## Package changes
- **\`useBookingStatusByIdMutation\`** in \`@voyantjs/bookings-react\`. Variant of \`useBookingStatusMutation\` that accepts the booking id at call time instead of hook-setup time — the quick-create flow only knows the id after the POST returns.
- **i18n keys**: \`confirmAfterCreateLabel\` + \`confirmAfterCreateHint\` for the operator template (en + ro, parity preserved).

## Failure isolation
If the status change errors after \`quickCreate\` already committed, we surface the error and still fire \`onCreated(booking)\` so the parent dialog closes and the booking doesn't vanish from the list. The booking exists — only the confirm step tripped; operator can retry from the detail page.

## Registry mirror
\`packages/ui/registry/bookings/quick-book-dialog.tsx\` carries the same toggle with plain English copy. A comment in the registry version notes the auto-dispatch behaviour depends on the consuming app wiring \`autoConfirmAndDispatch\` — absent that, the toggle just transitions to \`confirmed\` without sending anything. \`registry.json\` gains a \`checkbox\` entry in registryDependencies.

## Test plan
- [x] Typecheck passes on bookings-react, i18n, operator, dmc
- [ ] Manual: create booking with toggle off → booking in draft, no email
- [ ] Manual: create booking with toggle on → booking in confirmed, email delivered (when notifications module has auto-dispatch)
- [ ] Manual: create booking with toggle on but notifications not configured → booking in confirmed, no email (subscriber no-op)

## #223 status after this PR
All 10 original \"sections, in order\" from the issue are in. Composition surface complete; #223 can close.