### PR TITLE
feat(finance): vouchers.validFrom + seriesCode (#227)

### DIFF
--- a/packages/finance/src/routes-bookings-quick-create.ts
+++ b/packages/finance/src/routes-bookings-quick-create.ts
@@ -46,6 +46,8 @@ const quickCreateRoutes = new Hono<{
         return c.json({ error: "Voucher not found" }, 404)
       case "voucher_inactive":
         return c.json({ error: "Voucher is not active" }, 409)
+      case "voucher_not_started":
+        return c.json({ error: "Voucher is not yet valid" }, 409)
       case "voucher_expired":
         return c.json({ error: "Voucher has expired" }, 409)
       case "voucher_insufficient_balance":
@@ -88,6 +90,8 @@ const quickCreateRoutes = new Hono<{
         return c.json({ ...body, error: `${which}: voucher not found` }, 404)
       case "voucher_inactive":
         return c.json({ ...body, error: `${which}: voucher is not active` }, 409)
+      case "voucher_not_started":
+        return c.json({ ...body, error: `${which}: voucher is not yet valid` }, 409)
       case "voucher_expired":
         return c.json({ ...body, error: `${which}: voucher has expired` }, 409)
       case "voucher_insufficient_balance":

--- a/packages/finance/src/schema.ts
+++ b/packages/finance/src/schema.ts
@@ -239,6 +239,15 @@ export const vouchers = pgTable(
   {
     id: typeId("vouchers"),
     code: text("code").notNull(),
+    /**
+     * Batch / campaign identifier. Optional grouping used when a supplier or
+     * promo issues many vouchers at once ("GIFT-2026-Q1") and wants to
+     * aggregate/revoke them by series. Not indexed uniquely — multiple rows
+     * can share the same seriesCode.
+     *
+     * Aligned with OpenTravel 2019A Finance.Voucher.seriesCode.
+     */
+    seriesCode: text("series_code"),
     status: voucherStatusEnum("status").notNull().default("active"),
     currency: text("currency").notNull(),
     initialAmountCents: integer("initial_amount_cents").notNull(),
@@ -248,6 +257,15 @@ export const vouchers = pgTable(
     sourceType: voucherSourceTypeEnum("source_type").notNull(),
     sourceBookingId: text("source_booking_id"),
     sourcePaymentId: text("source_payment_id"),
+    /**
+     * Start-of-validity. Nullable — when set, a redemption attempt before
+     * this timestamp returns `voucher_not_started`. Needed for gift
+     * vouchers that are issued immediately but shouldn't be redeemable
+     * until the recipient's birthday, new year, etc.
+     *
+     * Aligned with OpenTravel 2019A Finance.Voucher.effectiveDate.
+     */
+    validFrom: timestamp("valid_from", { withTimezone: true }),
     expiresAt: timestamp("expires_at", { withTimezone: true }),
     notes: text("notes"),
     issuedByUserId: text("issued_by_user_id"),
@@ -256,10 +274,12 @@ export const vouchers = pgTable(
   },
   (table) => [
     uniqueIndex("uidx_vouchers_code").on(table.code),
+    index("idx_vouchers_series").on(table.seriesCode),
     index("idx_vouchers_status").on(table.status),
     index("idx_vouchers_person").on(table.issuedToPersonId),
     index("idx_vouchers_organization").on(table.issuedToOrganizationId),
     index("idx_vouchers_source_booking").on(table.sourceBookingId),
+    index("idx_vouchers_valid_from").on(table.validFrom),
     index("idx_vouchers_expires_at").on(table.expiresAt),
     index("idx_vouchers_remaining").on(table.remainingAmountCents),
   ],

--- a/packages/finance/src/service-bookings-quick-create.ts
+++ b/packages/finance/src/service-bookings-quick-create.ts
@@ -140,6 +140,7 @@ export type QuickCreateBookingOutcome =
   | { status: "product_not_found" }
   | { status: "voucher_not_found" }
   | { status: "voucher_inactive" }
+  | { status: "voucher_not_started" }
   | { status: "voucher_expired" }
   | { status: "voucher_insufficient_balance" }
   | { status: "group_not_found" }
@@ -202,6 +203,9 @@ export async function quickCreateBooking(
       .limit(1)
     if (!voucher) return { status: "voucher_not_found" }
     if (voucher.status !== "active") return { status: "voucher_inactive" }
+    if (voucher.validFrom && voucher.validFrom.getTime() > Date.now()) {
+      return { status: "voucher_not_started" }
+    }
     if (voucher.expiresAt && voucher.expiresAt.getTime() < Date.now()) {
       return { status: "voucher_expired" }
     }
@@ -360,6 +364,7 @@ export async function quickCreateBooking(
     if (error instanceof VoucherServiceError) {
       if (error.code === "voucher_not_found") return { status: "voucher_not_found" }
       if (error.code === "voucher_inactive") return { status: "voucher_inactive" }
+      if (error.code === "voucher_not_started") return { status: "voucher_not_started" }
       if (error.code === "voucher_expired") return { status: "voucher_expired" }
       if (error.code === "insufficient_balance") return { status: "voucher_insufficient_balance" }
     }

--- a/packages/finance/src/service-public.ts
+++ b/packages/finance/src/service-public.ts
@@ -611,7 +611,7 @@ async function resolveVoucherFromNewTable(
     currency: row.currency,
     amountCents: row.initialAmountCents,
     remainingAmountCents: row.remainingAmountCents,
-    validFrom: null,
+    validFrom: row.validFrom ? row.validFrom.toISOString() : null,
     expiresAt: row.expiresAt ? row.expiresAt.toISOString() : null,
     appliesToBookingIds: row.sourceBookingId ? [row.sourceBookingId] : [],
     status: row.status === "active" ? "active" : "inactive",

--- a/packages/finance/src/service-vouchers-migration.ts
+++ b/packages/finance/src/service-vouchers-migration.ts
@@ -130,6 +130,12 @@ export async function migrateVouchersFromPaymentInstruments(
     }
 
     const expiresAt = asDate(asString(metadata, "expiresAt"))
+    // OpenTravel uses `effectiveDate`; some legacy payloads also wrote
+    // `validFrom` directly. Check both so existing rows aren't silently
+    // dropped.
+    const validFrom =
+      asDate(asString(metadata, "validFrom")) ?? asDate(asString(metadata, "effectiveDate"))
+    const seriesCode = asString(metadata, "seriesCode")
     const bookingIds = asStringArray(metadata, "bookingIds")
     const sourceBookingId = asString(metadata, "bookingId") ?? bookingIds[0] ?? null
 
@@ -148,6 +154,7 @@ export async function migrateVouchersFromPaymentInstruments(
     try {
       await db.insert(vouchers).values({
         code,
+        seriesCode,
         status,
         currency: currency.toUpperCase(),
         initialAmountCents,
@@ -160,6 +167,7 @@ export async function migrateVouchersFromPaymentInstruments(
         sourceType: "manual",
         sourceBookingId,
         notes: instrument.notes ?? null,
+        validFrom,
         expiresAt,
         createdAt: instrument.createdAt,
         updatedAt: instrument.updatedAt,

--- a/packages/finance/src/service-vouchers.ts
+++ b/packages/finance/src/service-vouchers.ts
@@ -21,6 +21,7 @@ type VoucherListQuery = z.infer<typeof voucherListQuerySchema>
  *  - `code_in_use`        — supplied code collides with an existing voucher
  *  - `voucher_not_found`  — id-not-found / code-not-found read path
  *  - `voucher_inactive`   — redeem attempted against non-active status
+ *  - `voucher_not_started`— validFrom is set and hasn't happened yet
  *  - `voucher_expired`    — expiresAt has passed
  *  - `insufficient_balance` — requested amount > remainingAmountCents
  */
@@ -30,6 +31,7 @@ export class VoucherServiceError extends Error {
       | "code_in_use"
       | "voucher_not_found"
       | "voucher_inactive"
+      | "voucher_not_started"
       | "voucher_expired"
       | "insufficient_balance",
     message?: string,
@@ -63,6 +65,7 @@ export const vouchersService = {
   async list(db: PostgresJsDatabase, query: VoucherListQuery) {
     const conditions = []
     if (query.status) conditions.push(eq(vouchers.status, query.status))
+    if (query.seriesCode) conditions.push(eq(vouchers.seriesCode, query.seriesCode))
     if (query.issuedToPersonId) {
       conditions.push(eq(vouchers.issuedToPersonId, query.issuedToPersonId))
     }
@@ -124,6 +127,7 @@ export const vouchersService = {
       .insert(vouchers)
       .values({
         code,
+        seriesCode: input.seriesCode ?? null,
         currency: input.currency,
         initialAmountCents: input.amountCents,
         remainingAmountCents: input.amountCents,
@@ -132,6 +136,7 @@ export const vouchersService = {
         sourceType: input.sourceType,
         sourceBookingId: input.sourceBookingId ?? null,
         sourcePaymentId: input.sourcePaymentId ?? null,
+        validFrom: input.validFrom ? new Date(input.validFrom) : null,
         expiresAt: input.expiresAt ? new Date(input.expiresAt) : null,
         notes: input.notes ?? null,
         issuedByUserId: issuedByUserId ?? null,
@@ -145,6 +150,10 @@ export const vouchersService = {
       .update(vouchers)
       .set({
         ...(input.status !== undefined ? { status: input.status } : {}),
+        ...(input.seriesCode !== undefined ? { seriesCode: input.seriesCode } : {}),
+        ...(input.validFrom !== undefined
+          ? { validFrom: input.validFrom ? new Date(input.validFrom) : null }
+          : {}),
         ...(input.expiresAt !== undefined
           ? { expiresAt: input.expiresAt ? new Date(input.expiresAt) : null }
           : {}),
@@ -180,6 +189,9 @@ export const vouchersService = {
 
       if (!voucher) throw new VoucherServiceError("voucher_not_found")
       if (voucher.status !== "active") throw new VoucherServiceError("voucher_inactive")
+      if (voucher.validFrom && voucher.validFrom.getTime() > Date.now()) {
+        throw new VoucherServiceError("voucher_not_started")
+      }
       if (voucher.expiresAt && voucher.expiresAt.getTime() < Date.now()) {
         throw new VoucherServiceError("voucher_expired")
       }

--- a/packages/finance/src/validation-vouchers.ts
+++ b/packages/finance/src/validation-vouchers.ts
@@ -5,6 +5,7 @@ import { voucherSourceTypeSchema, voucherStatusSchema } from "./validation-share
 /** Issue a new voucher. Code is generated server-side when not supplied. */
 export const insertVoucherSchema = z.object({
   code: z.string().min(1).max(64).optional().nullable(),
+  seriesCode: z.string().max(64).optional().nullable(),
   currency: z.string().min(3).max(3),
   amountCents: z.number().int().positive(),
   issuedToPersonId: z.string().optional().nullable(),
@@ -12,6 +13,7 @@ export const insertVoucherSchema = z.object({
   sourceType: voucherSourceTypeSchema,
   sourceBookingId: z.string().optional().nullable(),
   sourcePaymentId: z.string().optional().nullable(),
+  validFrom: z.string().datetime().optional().nullable(),
   expiresAt: z.string().datetime().optional().nullable(),
   notes: z.string().optional().nullable(),
 })
@@ -22,6 +24,8 @@ export const insertVoucherSchema = z.object({
  */
 export const updateVoucherSchema = z.object({
   status: voucherStatusSchema.optional(),
+  seriesCode: z.string().max(64).optional().nullable(),
+  validFrom: z.string().datetime().optional().nullable(),
   expiresAt: z.string().datetime().optional().nullable(),
   notes: z.string().optional().nullable(),
   issuedToPersonId: z.string().optional().nullable(),
@@ -37,6 +41,7 @@ export const redeemVoucherSchema = z.object({
 
 export const voucherListQuerySchema = z.object({
   status: voucherStatusSchema.optional(),
+  seriesCode: z.string().optional(),
   issuedToPersonId: z.string().optional(),
   issuedToOrganizationId: z.string().optional(),
   search: z.string().optional(),

--- a/packages/finance/tests/integration/voucher-valid-from.test.ts
+++ b/packages/finance/tests/integration/voucher-valid-from.test.ts
@@ -1,0 +1,253 @@
+import { eq, sql } from "drizzle-orm"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { paymentInstruments, vouchers } from "../../src/schema.js"
+import { publicFinanceService } from "../../src/service-public.js"
+import { VoucherServiceError, vouchersService } from "../../src/service-vouchers.js"
+import { migrateVouchersFromPaymentInstruments } from "../../src/service-vouchers-migration.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+async function resetTables(
+  // biome-ignore lint/suspicious/noExplicitAny: test db
+  db: any,
+) {
+  const tableNames = ["voucher_redemptions", "vouchers", "payment_instruments"]
+  const existing = (await db.execute<{ tablename: string }>(sql`
+    SELECT tablename FROM pg_tables
+    WHERE schemaname = 'public' AND tablename IN (${sql.join(
+      tableNames.map((n) => sql`${n}`),
+      sql`, `,
+    )})
+  `)) as Array<{ tablename: string }>
+  if (existing.length === 0) return
+  const names = existing.map((r) => `"${r.tablename}"`).join(", ")
+  await db.execute(sql.raw(`TRUNCATE ${names} CASCADE`))
+}
+
+describe.skipIf(!DB_AVAILABLE)("voucher validFrom + seriesCode", () => {
+  let db: ReturnType<typeof import("@voyantjs/db/test-utils").createTestDb>
+
+  beforeAll(async () => {
+    const { createTestDb } = await import("@voyantjs/db/test-utils")
+    db = createTestDb()
+    await resetTables(db)
+  })
+  beforeEach(async () => {
+    await resetTables(db)
+  })
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyantjs/db/test-utils")
+    await closeTestDb()
+  })
+
+  async function seedVoucher(
+    overrides: {
+      code?: string
+      validFrom?: Date | null
+      expiresAt?: Date | null
+      seriesCode?: string | null
+      status?: "active" | "redeemed" | "expired" | "void"
+    } = {},
+  ) {
+    const [row] = await db
+      .insert(vouchers)
+      .values({
+        code: overrides.code ?? `VF-${Date.now()}`,
+        seriesCode: overrides.seriesCode ?? null,
+        currency: "EUR",
+        initialAmountCents: 10000,
+        remainingAmountCents: 10000,
+        status: overrides.status ?? "active",
+        sourceType: "manual",
+        validFrom: overrides.validFrom ?? null,
+        expiresAt: overrides.expiresAt ?? null,
+      })
+      .returning()
+    return row!
+  }
+
+  describe("service-vouchers redeem guard", () => {
+    it("rejects redeem when validFrom is in the future", async () => {
+      const voucher = await seedVoucher({
+        validFrom: new Date(Date.now() + 60_000),
+      })
+
+      let error: VoucherServiceError | null = null
+      try {
+        await vouchersService.redeem(db, voucher.id, {
+          bookingId: "book_fake",
+          amountCents: 100,
+        })
+      } catch (err) {
+        if (err instanceof VoucherServiceError) error = err
+      }
+      expect(error?.code).toBe("voucher_not_started")
+    })
+
+    it("allows redeem when validFrom has already passed", async () => {
+      const voucher = await seedVoucher({
+        validFrom: new Date(Date.now() - 60_000),
+      })
+
+      const result = await vouchersService.redeem(db, voucher.id, {
+        bookingId: "book_real",
+        amountCents: 100,
+      })
+      expect(result.voucher.remainingAmountCents).toBe(9900)
+    })
+
+    it("allows redeem when validFrom is null (no start-of-validity)", async () => {
+      const voucher = await seedVoucher({ validFrom: null })
+
+      const result = await vouchersService.redeem(db, voucher.id, {
+        bookingId: "book_real",
+        amountCents: 100,
+      })
+      expect(result.voucher.remainingAmountCents).toBe(9900)
+    })
+
+    it("prefers inactive over not_started when status is non-active", async () => {
+      // Inactive + future validFrom → the inactive check runs first, so the
+      // error surfaces as voucher_inactive (rules compose top-to-bottom).
+      const voucher = await seedVoucher({
+        status: "void",
+        validFrom: new Date(Date.now() + 60_000),
+      })
+
+      let error: VoucherServiceError | null = null
+      try {
+        await vouchersService.redeem(db, voucher.id, {
+          bookingId: "book_fake",
+          amountCents: 100,
+        })
+      } catch (err) {
+        if (err instanceof VoucherServiceError) error = err
+      }
+      expect(error?.code).toBe("voucher_inactive")
+    })
+  })
+
+  describe("public validateVoucher not_started branch", () => {
+    it("returns reason=not_started when validFrom is in the future", async () => {
+      const future = new Date(Date.now() + 60_000)
+      await seedVoucher({ code: "NOTYET-1", validFrom: future })
+
+      const result = await publicFinanceService.validateVoucher(db, { code: "NOTYET-1" })
+      expect(result.valid).toBe(false)
+      expect(result.reason).toBe("not_started")
+    })
+
+    it("returns valid when validFrom is in the past", async () => {
+      await seedVoucher({ code: "STARTED-1", validFrom: new Date(Date.now() - 60_000) })
+
+      const result = await publicFinanceService.validateVoucher(db, { code: "STARTED-1" })
+      expect(result.valid).toBe(true)
+    })
+  })
+
+  describe("create + update round-trip", () => {
+    it("persists seriesCode and validFrom on create", async () => {
+      const row = await vouchersService.create(db, {
+        currency: "EUR",
+        amountCents: 5000,
+        sourceType: "promo",
+        seriesCode: "GIFT-2026-Q1",
+        validFrom: "2026-06-01T00:00:00.000Z",
+      })
+      expect(row?.seriesCode).toBe("GIFT-2026-Q1")
+      expect(row?.validFrom?.toISOString()).toBe("2026-06-01T00:00:00.000Z")
+    })
+
+    it("updates seriesCode and validFrom via patch", async () => {
+      const voucher = await seedVoucher({ seriesCode: null, validFrom: null })
+      const updated = await vouchersService.update(db, voucher.id, {
+        seriesCode: "NEWSERIES",
+        validFrom: "2026-07-01T00:00:00.000Z",
+      })
+      expect(updated?.seriesCode).toBe("NEWSERIES")
+      expect(updated?.validFrom?.toISOString()).toBe("2026-07-01T00:00:00.000Z")
+    })
+
+    it("patches seriesCode to null explicitly", async () => {
+      const voucher = await seedVoucher({ seriesCode: "OLD" })
+      const updated = await vouchersService.update(db, voucher.id, { seriesCode: null })
+      expect(updated?.seriesCode).toBeNull()
+    })
+  })
+
+  describe("list filter by seriesCode", () => {
+    it("returns only vouchers in the requested series", async () => {
+      await seedVoucher({ code: "A", seriesCode: "PROMO-1" })
+      await seedVoucher({ code: "B", seriesCode: "PROMO-1" })
+      await seedVoucher({ code: "C", seriesCode: "PROMO-2" })
+      await seedVoucher({ code: "D", seriesCode: null })
+
+      const result = await vouchersService.list(db, {
+        seriesCode: "PROMO-1",
+        limit: 50,
+        offset: 0,
+      })
+      expect(result.total).toBe(2)
+      expect(result.data.map((r) => r.code).sort()).toEqual(["A", "B"])
+    })
+  })
+
+  describe("migration", () => {
+    it("pulls validFrom and effectiveDate from legacy metadata", async () => {
+      await db.insert(paymentInstruments).values([
+        {
+          ownerType: "client",
+          instrumentType: "voucher",
+          status: "active",
+          label: "Has validFrom",
+          metadata: {
+            code: "LEGACY-VF",
+            currency: "EUR",
+            amountCents: 2000,
+            validFrom: "2026-08-01T00:00:00.000Z",
+          },
+        },
+        {
+          ownerType: "client",
+          instrumentType: "voucher",
+          status: "active",
+          label: "Has effectiveDate",
+          metadata: {
+            code: "LEGACY-ED",
+            currency: "EUR",
+            amountCents: 2500,
+            effectiveDate: "2026-09-01T00:00:00.000Z",
+          },
+        },
+      ])
+
+      const result = await migrateVouchersFromPaymentInstruments(db)
+      expect(result.migrated).toBe(2)
+
+      const [rowA] = await db.select().from(vouchers).where(eq(vouchers.code, "LEGACY-VF"))
+      const [rowB] = await db.select().from(vouchers).where(eq(vouchers.code, "LEGACY-ED"))
+      expect(rowA?.validFrom?.toISOString()).toBe("2026-08-01T00:00:00.000Z")
+      expect(rowB?.validFrom?.toISOString()).toBe("2026-09-01T00:00:00.000Z")
+    })
+
+    it("pulls seriesCode from legacy metadata", async () => {
+      await db.insert(paymentInstruments).values({
+        ownerType: "client",
+        instrumentType: "voucher",
+        status: "active",
+        label: "Has series",
+        metadata: {
+          code: "LEGACY-SC",
+          currency: "EUR",
+          amountCents: 1000,
+          seriesCode: "LEGACY-SERIES",
+        },
+      })
+
+      await migrateVouchersFromPaymentInstruments(db)
+      const [row] = await db.select().from(vouchers).where(eq(vouchers.code, "LEGACY-SC"))
+      expect(row?.seriesCode).toBe("LEGACY-SERIES")
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Close the OpenTravel Voucher alignment gap flagged in post-merge review:

- **validFrom** (timestamp with tz, nullable) — start-of-validity. Maps to OpenTravel 2019A \`Finance.Voucher.effectiveDate\`. The redeem guard returns \`voucher_not_started\` when now < validFrom; the \`not_started\` branch in \`publicFinanceService.validateVoucher\` was already wired but unreachable without the column.
- **seriesCode** (text, nullable, indexed) — batch/campaign identifier for promo runs and recall operations. Maps to OpenTravel \`Finance.Voucher.seriesCode\`. Added to the list query as a filter.

## Service wiring
- \`VoucherServiceError\` gets a new \`voucher_not_started\` code
- \`vouchersService.create/update/list\` persist + filter the new fields
- \`quickCreate\` + \`dual-create\` orchestrators surface \`voucher_not_started\` as an outcome; routes map to 409 (same bucket as inactive/expired)
- Migration script pulls \`validFrom\` (or legacy \`effectiveDate\`) and \`seriesCode\` from \`payment_instruments.metadata\` JSONB so rows minted with those attrs before the table existed round-trip correctly

## Test plan
- [x] 12 new integration cases — redeem guard ordering (inactive > not_started), public validate branch, create/update/list round-trip, migration extraction from legacy metadata
- [x] Existing 29 integration tests still pass
- [x] Typecheck across finance, bookings, dmc, operator

## OpenTravel alignment
See the comment discussion thread — OCTO's \`voucher\` = admission/redemption artifact (→ \`booking_fulfillments\`); OpenTravel \`Finance.Voucher\` = financial instrument (→ \`vouchers\`). Both concepts live in the right tables. Remaining unimplemented OpenTravel attrs (\`billingNumber\`, \`electronicIndicatorInd\`, \`expireDateExclusiveInd\`) are low-value for our use cases — deferred without follow-up.