### PR TITLE
chore: release changeset for #223 + #227 batch

### DIFF
--- a/.changeset/booking-create-and-vouchers-batch.md
+++ b/.changeset/booking-create-and-vouchers-batch.md
@@ -1,0 +1,21 @@
+---
+"@voyantjs/finance": minor
+"@voyantjs/bookings": minor
+"@voyantjs/bookings-react": minor
+"@voyantjs/i18n": minor
+---
+
+Bookings-create composition surface (#223) and vouchers-as-first-class (#227) — the packages on the release train all move together, so this covers the batch.
+
+**Atomic booking create (#263, #264, #265, #266)**
+
+- `POST /v1/admin/bookings/quick-create` — one-shot endpoint that converts a product, inserts travelers + payment schedules, redeems a voucher, and creates/joins a `booking_group` inside a single DB transaction. `quickCreateBooking(db, input, { userId, runtime })` service in `@voyantjs/finance`; `useBookingQuickCreateMutation` in `@voyantjs/bookings-react`.
+- `POST /v1/admin/bookings/dual-create` — partaj flow: two bookings + one shared-room group, also atomic. `dualCreateBooking` service, `useBookingDualCreateMutation` hook.
+- `booking.quick-created` and `booking.dual-created` events emitted post-commit when a runtime eventBus is wired.
+- `QuickBookDialog` now mounts all nine picker sections (product, departure, rooms, person, shared-room, passengers, price breakdown, voucher, payment schedule) and submits via quick-create. Post-create "Confirm & notify traveler" toggle uses the new `useBookingStatusByIdMutation` to transition the fresh booking to `confirmed` — which (when `autoConfirmAndDispatch` is on) fires the doc bundle + traveler email through the existing `booking.confirmed` subscriber.
+- Bookings fix: `productDaysRef` / `getConvertProductData` now join through `product_itineraries` to match the real products schema; the existing `POST /v1/bookings/from-product` convert path works again.
+
+**Vouchers as first-class financial instruments (#262, #267)**
+
+- One-shot data migration: `migrateVouchersFromPaymentInstruments(db, opts)` in `@voyantjs/finance` (CLI wrapper `pnpm -F @voyantjs/finance migrate:vouchers`, `--dry-run` supported). Idempotent; pulls code, currency, amount, expiry from legacy JSONB metadata into the new `vouchers` table.
+- `vouchers.validFrom` (start-of-validity, maps to OpenTravel `Finance.Voucher.effectiveDate`) and `vouchers.seriesCode` (batch/campaign id, maps to `Finance.Voucher.seriesCode`) columns added. Redeem guard returns `voucher_not_started` when now < validFrom; the public `validateVoucher` `not_started` branch is now reachable. `seriesCode` exposed as a list filter. Migration pulls both from legacy metadata (honouring OpenTravel's `effectiveDate` alias).


### PR DESCRIPTION
Bundles PRs #262–#267 into one minor bump on the shared `@voyantjs` release train (currently 0.6.9 → 0.6.10). Covers:

- #262 — voucher data migration from payment_instruments
- #263 — atomic `POST /v1/admin/bookings/quick-create` + bookings day-itinerary schema fix
- #264 — BookingDialog composition (all 9 sections via quick-create)
- #265 — dual-booking / partaj `POST /v1/admin/bookings/dual-create`
- #266 — post-create confirm + notify toggle
- #267 — `vouchers.validFrom` + `vouchers.seriesCode` (OpenTravel alignment)

After merge, the Release workflow will open a "chore: release packages" PR that bumps `0.6.9 → 0.6.10` across the train and publishes to npm on merge.