### PR TITLE
feat(utils): currency, cents, format_date liquid filters

### DIFF
--- a/packages/utils/src/template-renderer.ts
+++ b/packages/utils/src/template-renderer.ts
@@ -17,6 +17,66 @@ const liquid = new Liquid({
 
 liquid.registerFilter("json", (value: unknown) => JSON.stringify(value ?? null))
 
+function parseNumber(value: unknown): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null
+  if (typeof value === "string" && value.trim() !== "") {
+    const n = Number.parseFloat(value)
+    return Number.isFinite(n) ? n : null
+  }
+  return null
+}
+
+/**
+ * `currency` — Intl.NumberFormat currency style. Expects a decimal amount
+ * (`123.45`). Example: `{{ amount | currency: "EUR", "en-US" }}` →
+ * `"€123.45"`. Falls back to `String(value)` when the value isn't a number.
+ */
+liquid.registerFilter("currency", (value: unknown, currency = "EUR", locale = "en-US") => {
+  const num = parseNumber(value)
+  if (num === null) return String(value ?? "")
+  return new Intl.NumberFormat(String(locale), {
+    style: "currency",
+    currency: String(currency || "EUR"),
+  }).format(num)
+})
+
+/**
+ * `cents` — Shortcut for formatting integer cents (`12345` → `"€123.45"`).
+ * Saves every template from `{{ (amountCents | divided_by: 100) | currency: ... }}`.
+ */
+liquid.registerFilter("cents", (value: unknown, currency = "EUR", locale = "en-US") => {
+  const num = parseNumber(value)
+  if (num === null) return String(value ?? "")
+  return new Intl.NumberFormat(String(locale), {
+    style: "currency",
+    currency: String(currency || "EUR"),
+  }).format(num / 100)
+})
+
+/**
+ * `format_date` — ISO/string/Date → locale-formatted date. Second arg chooses
+ * the preset: `"short"` (`01/15/2026`), `"medium"` (default, `Jan 15, 2026`),
+ * `"long"` (`January 15, 2026`), or `"iso"` (`2026-01-15`). Pair with a
+ * locale for Romanian/etc.: `{{ startsAt | format_date: "medium", "ro-RO" }}`.
+ */
+liquid.registerFilter(
+  "format_date",
+  (value: unknown, preset: unknown = "medium", locale = "en-US") => {
+    if (value === null || value === undefined || value === "") return ""
+    const date = value instanceof Date ? value : new Date(String(value))
+    if (Number.isNaN(date.getTime())) return String(value)
+    const p = String(preset ?? "medium").toLowerCase()
+    if (p === "iso") return date.toISOString().slice(0, 10)
+    const options: Intl.DateTimeFormatOptions =
+      p === "short"
+        ? { year: "numeric", month: "2-digit", day: "2-digit" }
+        : p === "long"
+          ? { year: "numeric", month: "long", day: "numeric" }
+          : { year: "numeric", month: "short", day: "numeric" }
+    return date.toLocaleDateString(String(locale), options)
+  },
+)
+
 function resolvePath(obj: unknown, path: string): unknown {
   if (obj === null || obj === undefined) return undefined
   const segments: Array<string | number> = []

--- a/packages/utils/tests/template-renderer.test.ts
+++ b/packages/utils/tests/template-renderer.test.ts
@@ -44,4 +44,83 @@ describe("renderStructuredTemplate", () => {
 
     expect(JSON.parse(output).root.children[0].children[0].text).toBe('Travelers: [{"name":"Ana"}]')
   })
+
+  describe("currency filter", () => {
+    it("formats decimal amounts with default EUR/en-US", () => {
+      expect(
+        renderStructuredTemplate("{{ total | currency }}", "markdown", { total: 123.45 }),
+      ).toBe("€123.45")
+    })
+
+    it("honors currency + locale args", () => {
+      // en-US uses "USD" as just "$"; ro-RO uses "EUR" as "123,45 €". Smoke-check
+      // that the args round-trip — exact chars vary by ICU version so just
+      // assert the amount and currency symbol appear.
+      const out = renderStructuredTemplate('{{ total | currency: "USD", "en-US" }}', "markdown", {
+        total: 1500,
+      })
+      expect(out).toContain("1,500.00")
+      expect(out).toContain("$")
+    })
+
+    it("returns the raw value when it can't parse a number", () => {
+      expect(renderStructuredTemplate("{{ total | currency }}", "markdown", { total: "n/a" })).toBe(
+        "n/a",
+      )
+    })
+  })
+
+  describe("cents filter", () => {
+    it("divides by 100 and formats", () => {
+      expect(
+        renderStructuredTemplate("{{ priceCents | cents }}", "markdown", { priceCents: 12345 }),
+      ).toBe("€123.45")
+    })
+
+    it("accepts currency + locale overrides", () => {
+      const out = renderStructuredTemplate('{{ priceCents | cents: "RON", "en-US" }}', "markdown", {
+        priceCents: 50000,
+      })
+      expect(out).toContain("500.00")
+      expect(out).toContain("RON")
+    })
+  })
+
+  describe("format_date filter", () => {
+    it("formats ISO strings with medium preset by default", () => {
+      const out = renderStructuredTemplate("{{ d | format_date }}", "markdown", {
+        d: "2026-07-01",
+      })
+      expect(out).toContain("Jul")
+      expect(out).toContain("2026")
+    })
+
+    it("short preset uses numeric day/month", () => {
+      const out = renderStructuredTemplate('{{ d | format_date: "short" }}', "markdown", {
+        d: "2026-07-01",
+      })
+      expect(out).toMatch(/\d{2}/)
+      expect(out).toContain("2026")
+    })
+
+    it("iso preset returns YYYY-MM-DD", () => {
+      expect(
+        renderStructuredTemplate('{{ d | format_date: "iso" }}', "markdown", {
+          d: new Date("2026-07-01T12:34:56Z"),
+        }),
+      ).toBe("2026-07-01")
+    })
+
+    it("returns empty string for null/undefined", () => {
+      expect(renderStructuredTemplate("[{{ d | format_date }}]", "markdown", { d: null })).toBe(
+        "[]",
+      )
+    })
+
+    it("returns the raw value when date is unparseable", () => {
+      expect(
+        renderStructuredTemplate("{{ d | format_date }}", "markdown", { d: "not-a-date" }),
+      ).toBe("not-a-date")
+    })
+  })
 })


### PR DESCRIPTION
First slice of the operator contract-generation workflow. Adds three Liquid filters to `@voyantjs/utils`' template renderer so contract templates (and any other Liquid-rendered document) can express money + date formatting without unrolling `Intl.NumberFormat` in every template:

- **currency**: decimal → currency string, default EUR/en-US
- **cents**: integer cents → currency string (divides by 100 then formats)
- **format_date**: ISO/string/Date → locale-formatted with `short` / `medium` / `long` / `iso` presets

Registered on the shared Liquid engine already powering `renderStructuredTemplate`, so `@voyantjs/legal`, `@voyantjs/notifications`, and anywhere else using the utils renderer picks them up automatically.

## Test plan
- [x] 10 new cases cover defaults, arg overrides, unparseable/null fallback, cents division, iso preset
- [x] 13/13 tests pass, typecheck clean
- [ ] Follow-ups unlock: `booking.confirmed` → legal subscriber (PR B), operator contract card (PR C), template wiring (PR D)