### PR TITLE
feat(legal): auto-generate contract on booking.confirmed

### DIFF
--- a/packages/legal/package.json
+++ b/packages/legal/package.json
@@ -25,6 +25,7 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
+    "@voyantjs/bookings": "workspace:*",
     "@voyantjs/core": "workspace:*",
     "@voyantjs/crm": "workspace:*",
     "@voyantjs/db": "workspace:*",

--- a/packages/legal/src/contracts/service-auto-generate.ts
+++ b/packages/legal/src/contracts/service-auto-generate.ts
@@ -1,0 +1,250 @@
+import { bookingsService } from "@voyantjs/bookings"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { contractRecordsService } from "./service-contracts.js"
+import type { ContractDocumentGenerator } from "./service-documents.js"
+import { contractDocumentsService } from "./service-documents.js"
+import { contractSeriesService } from "./service-series.js"
+import { contractTemplatesService } from "./service-templates.js"
+
+/**
+ * Event shape emitted by `@voyantjs/bookings` on confirm. Duplicated here so
+ * legal doesn't have to import the bookings service just for the interface —
+ * the concrete `bookingsService` lookup happens inside the handler.
+ */
+export interface BookingConfirmedLikeEvent {
+  bookingId: string
+  bookingNumber: string
+  actorId: string | null
+}
+
+/**
+ * Variables passed to the contract template at render time. Consumers can
+ * augment via `resolveVariables`; the built-in resolver supplies the fields
+ * the default contract template expects.
+ */
+export interface DefaultContractVariables {
+  contract: {
+    issuedAt: string
+    date: string
+  }
+  booking: {
+    id: string
+    number: string
+    status: string
+    currency: string | null
+    startDate: string | null
+    endDate: string | null
+    pax: number | null
+    internalNotes: string | null
+    totalAmountCents: number | null
+  }
+  travelers: Array<{
+    id: string
+    firstName: string
+    lastName: string
+    email: string | null
+    phone: string | null
+    isPrimary: boolean
+    participantType: string
+  }>
+  leadTraveler: {
+    id: string
+    firstName: string
+    lastName: string
+    email: string | null
+    phone: string | null
+  } | null
+}
+
+/**
+ * Hook point so consumers can extend (or replace) the template variables.
+ * Receives the default payload plus the raw booking/travelers so the
+ * consumer can fold in product/person/etc. lookups without re-fetching.
+ */
+export type ResolveContractVariablesFn = (context: {
+  db: PostgresJsDatabase
+  booking: NonNullable<Awaited<ReturnType<typeof bookingsService.getBookingById>>>
+  travelers: Awaited<ReturnType<typeof bookingsService.listTravelers>>
+  defaults: DefaultContractVariables
+}) => Promise<Record<string, unknown>> | Record<string, unknown>
+
+export interface AutoGenerateContractOptions {
+  enabled?: boolean
+  /**
+   * Slug of the contract template to use. The contract is created against
+   * that template's `currentVersionId`. If the template has no current
+   * version, the handler logs + bails.
+   */
+  templateSlug: string
+  /**
+   * Scope the contract defaults to when creating. Matches
+   * `contractScopeEnum`; the default `"customer"` is right for the common
+   * operator-issues-to-traveler case.
+   */
+  scope?: "customer" | "supplier" | "partner" | "channel" | "other"
+  /**
+   * When set, the contract tries to allocate a number from the matching
+   * active series on issuance. Without it, the contract issues unnumbered.
+   */
+  seriesName?: string
+  /**
+   * Language code written onto the contract row. Used by the PDF
+   * renderer to pick the right locale for date/currency filters.
+   */
+  language?: string
+  /**
+   * Optional variable extender — see `ResolveContractVariablesFn`.
+   */
+  resolveVariables?: ResolveContractVariablesFn
+}
+
+export interface AutoGenerateContractRuntime {
+  generator: ContractDocumentGenerator
+  eventBus?: import("@voyantjs/core").EventBus
+}
+
+/**
+ * Core auto-generate handler. Fire this from a `booking.confirmed` subscriber.
+ * On success, the booking now has an issued contract with an attachment
+ * (the PDF / storage object produced by the configured generator) and a
+ * `contract.document.generated` event has been emitted post-commit.
+ *
+ * Failure modes (all surfaced via the returned status):
+ *  - `template_not_found`       — no active template matches the slug
+ *  - `template_version_missing` — template exists but has no published version
+ *  - `booking_not_found`        — booking disappeared between confirm + fire
+ *  - `contract_create_failed`   — insert returned null
+ *  - `document_<…>`             — pass-through of generateContractDocument statuses
+ *
+ * Callers (the subscriber wrapper) log these and move on — per the EventBus
+ * contract, handler throws are swallowed anyway; returning a discriminated
+ * status keeps tests honest.
+ */
+export async function autoGenerateContractForBooking(
+  db: PostgresJsDatabase,
+  event: BookingConfirmedLikeEvent,
+  options: AutoGenerateContractOptions,
+  runtime: AutoGenerateContractRuntime,
+): Promise<
+  | { status: "ok"; contractId: string; attachmentId: string }
+  | { status: "template_not_found" }
+  | { status: "template_version_missing" }
+  | { status: "booking_not_found" }
+  | { status: "contract_create_failed" }
+  | { status: "document_failed"; reason: string }
+> {
+  // Resolve the template + its current version. Consumers configure the slug
+  // once at module bootstrap; we look up on every fire so template body
+  // edits are picked up without restart.
+  const template = await contractTemplatesService.findTemplateBySlug(db, options.templateSlug)
+  if (!template) {
+    return { status: "template_not_found" }
+  }
+  if (!template.currentVersionId) {
+    return { status: "template_version_missing" }
+  }
+
+  const booking = await bookingsService.getBookingById(db, event.bookingId)
+  if (!booking) {
+    return { status: "booking_not_found" }
+  }
+
+  const travelers = await bookingsService.listTravelers(db, event.bookingId)
+  const leadTraveler =
+    travelers.find((t) => t.isPrimary) ??
+    travelers.find((t) => t.participantType === "traveler") ??
+    travelers[0] ??
+    null
+
+  const now = new Date()
+  const defaults: DefaultContractVariables = {
+    contract: {
+      issuedAt: now.toISOString(),
+      date: now.toISOString().slice(0, 10),
+    },
+    booking: {
+      id: booking.id,
+      number: booking.bookingNumber,
+      status: booking.status,
+      currency: booking.sellCurrency ?? null,
+      startDate: booking.startDate,
+      endDate: booking.endDate,
+      pax: booking.pax,
+      internalNotes: booking.internalNotes,
+      totalAmountCents: booking.sellAmountCents ?? null,
+    },
+    travelers: travelers.map((t) => ({
+      id: t.id,
+      firstName: t.firstName,
+      lastName: t.lastName,
+      email: t.email,
+      phone: t.phone,
+      isPrimary: t.isPrimary,
+      participantType: t.participantType,
+    })),
+    leadTraveler: leadTraveler
+      ? {
+          id: leadTraveler.id,
+          firstName: leadTraveler.firstName,
+          lastName: leadTraveler.lastName,
+          email: leadTraveler.email,
+          phone: leadTraveler.phone,
+        }
+      : null,
+  }
+
+  const variables = options.resolveVariables
+    ? await options.resolveVariables({ db, booking, travelers, defaults })
+    : (defaults as unknown as Record<string, unknown>)
+
+  // Resolve a series id if the consumer gave a name — failure to find is
+  // non-fatal since a contract can issue without a number (some operators
+  // use templates as standalone records and number externally).
+  let seriesId: string | null = null
+  if (options.seriesName) {
+    const series = await contractSeriesService.findSeriesByName(db, options.seriesName)
+    seriesId = series?.id ?? null
+  }
+
+  const contract = await contractRecordsService.createContract(db, {
+    scope: options.scope ?? "customer",
+    status: "draft",
+    title: `${template.name} — ${booking.bookingNumber}`,
+    templateVersionId: template.currentVersionId,
+    seriesId,
+    bookingId: event.bookingId,
+    personId: booking.personId ?? null,
+    organizationId: booking.organizationId ?? null,
+    language: options.language ?? template.language ?? "en",
+    variables,
+    metadata: {
+      autoGenerated: true,
+      trigger: "booking.confirmed",
+      triggerActorId: event.actorId,
+    },
+  })
+  if (!contract) {
+    return { status: "contract_create_failed" }
+  }
+
+  const result = await contractDocumentsService.generateContractDocument(
+    db,
+    contract.id,
+    {
+      issueIfDraft: true,
+      replaceExisting: true,
+      kind: "document",
+    },
+    {
+      generator: runtime.generator,
+      eventBus: runtime.eventBus,
+    },
+  )
+
+  if (result.status === "generated") {
+    return { status: "ok", contractId: contract.id, attachmentId: result.attachment.id }
+  }
+
+  return { status: "document_failed", reason: result.status }
+}

--- a/packages/legal/src/contracts/service-series.ts
+++ b/packages/legal/src/contracts/service-series.ts
@@ -1,4 +1,4 @@
-import { desc, eq } from "drizzle-orm"
+import { and, desc, eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { contractNumberSeries } from "./schema.js"
@@ -16,6 +16,21 @@ export const contractSeriesService = {
       .select()
       .from(contractNumberSeries)
       .where(eq(contractNumberSeries.id, id))
+      .limit(1)
+    return row ?? null
+  },
+  /**
+   * Find the most-recently-updated active series matching a name. Used by
+   * the auto-generate subscriber so consumers can pin a named series
+   * (`"2026 Customer"`) in config and let operators rename the row via
+   * the admin UI without breaking the wiring.
+   */
+  async findSeriesByName(db: PostgresJsDatabase, name: string) {
+    const [row] = await db
+      .select()
+      .from(contractNumberSeries)
+      .where(and(eq(contractNumberSeries.name, name), eq(contractNumberSeries.active, true)))
+      .orderBy(desc(contractNumberSeries.updatedAt))
       .limit(1)
     return row ?? null
   },

--- a/packages/legal/src/contracts/service-templates.ts
+++ b/packages/legal/src/contracts/service-templates.ts
@@ -50,6 +50,18 @@ export const contractTemplatesService = {
       .limit(1)
     return row ?? null
   },
+  /**
+   * Slug lookup, used by the auto-generate subscriber. Slug is unique so the
+   * result is either the row or null — no disambiguation needed.
+   */
+  async findTemplateBySlug(db: PostgresJsDatabase, slug: string) {
+    const [row] = await db
+      .select()
+      .from(contractTemplates)
+      .where(eq(contractTemplates.slug, slug))
+      .limit(1)
+    return row ?? null
+  },
   async getDefaultTemplate(
     db: PostgresJsDatabase,
     query: {

--- a/packages/legal/src/index.ts
+++ b/packages/legal/src/index.ts
@@ -1,5 +1,6 @@
 import type { Module } from "@voyantjs/core"
 import type { HonoModule } from "@voyantjs/hono/module"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
 import { contractsLinkable } from "./contracts/index.js"
 import {
@@ -11,6 +12,10 @@ import {
   createContractsAdminRoutes,
   createContractsPublicRoutes,
 } from "./contracts/routes.js"
+import {
+  type AutoGenerateContractOptions,
+  autoGenerateContractForBooking,
+} from "./contracts/service-auto-generate.js"
 import { policiesLinkable } from "./policies/index.js"
 import { policiesAdminRoutes, policiesPublicRoutes } from "./policies/routes.js"
 
@@ -24,7 +29,24 @@ export const legalModule: Module = {
   linkable: legalLinkable,
 }
 
-export function createLegalHonoModule(options: ContractsRouteOptions = {}): HonoModule {
+export interface CreateLegalHonoModuleOptions extends ContractsRouteOptions {
+  /**
+   * Required when `autoGenerateContractOnConfirmed.enabled` is true. The
+   * `booking.confirmed` subscriber fires outside request scope, so it
+   * needs its own db handle from runtime bindings.
+   */
+  resolveDb?: (bindings: Record<string, unknown>) => PostgresJsDatabase
+  /**
+   * Opt-in auto-generate on `booking.confirmed`. When enabled + a
+   * `templateSlug` is supplied + a `documentGenerator` is resolvable, every
+   * booking.confirmed event creates a contract against the template's
+   * current version and generates its attachment via the configured
+   * generator (R2-backed PDF, etc.).
+   */
+  autoGenerateContractOnConfirmed?: AutoGenerateContractOptions
+}
+
+export function createLegalHonoModule(options: CreateLegalHonoModuleOptions = {}): HonoModule {
   const legalAdminRoutes = new Hono()
     .route("/contracts", createContractsAdminRoutes(options))
     .route("/policies", policiesAdminRoutes)
@@ -35,11 +57,57 @@ export function createLegalHonoModule(options: ContractsRouteOptions = {}): Hono
 
   const module: Module = {
     ...legalModule,
-    bootstrap: ({ bindings, container }) => {
+    bootstrap: ({ bindings, container, eventBus }) => {
       container.register(
         CONTRACTS_ROUTE_RUNTIME_CONTAINER_KEY,
         buildContractsRouteRuntime(bindings as Record<string, unknown>, options),
       )
+
+      // Auto-generate wiring — opt-in. Mirrors the notifications
+      // autoConfirmAndDispatch subscriber pattern. Both fire on the same
+      // booking.confirmed event; legal's handler just needs to run first
+      // so the contract attachment exists before notifications looks it
+      // up via listLegalBookingDocuments. Module-registration order in the
+      // template controls this.
+      const auto = options.autoGenerateContractOnConfirmed
+      if (auto?.enabled && options.resolveDb) {
+        const resolveDb = options.resolveDb
+        const runtime = buildContractsRouteRuntime(bindings as Record<string, unknown>, options)
+        if (!runtime.documentGenerator) {
+          // Mis-configuration — don't silently drop contracts. Log and
+          // skip; the template operator will notice on the first confirm.
+          console.error(
+            "[legal] autoGenerateContractOnConfirmed.enabled=true but no documentGenerator resolved; skipping subscriber.",
+          )
+          return
+        }
+        const generator = runtime.documentGenerator
+
+        eventBus.subscribe(
+          "booking.confirmed",
+          async (event: {
+            data: { bookingId: string; bookingNumber: string; actorId: string | null }
+          }) => {
+            try {
+              const db = resolveDb(bindings as Record<string, unknown>)
+              const result = await autoGenerateContractForBooking(db, event.data, auto, {
+                generator,
+                eventBus,
+              })
+              if (result.status !== "ok") {
+                console.error(
+                  `[legal] auto-generate contract skipped for booking ${event.data.bookingId}: ${result.status}`,
+                )
+              }
+            } catch (error) {
+              const message = error instanceof Error ? error.message : String(error)
+              console.error(
+                `[legal] auto-generate contract failed for booking ${event.data.bookingId}: ${message}`,
+              )
+            }
+          },
+        )
+      }
     },
   }
 
@@ -59,4 +127,12 @@ export {
   type ContractsRouteRuntime,
 } from "./contracts/route-runtime.js"
 export type { ContractsRouteOptions } from "./contracts/routes.js"
+export {
+  type AutoGenerateContractOptions,
+  type AutoGenerateContractRuntime,
+  autoGenerateContractForBooking,
+  type BookingConfirmedLikeEvent,
+  type DefaultContractVariables,
+  type ResolveContractVariablesFn,
+} from "./contracts/service-auto-generate.js"
 export * from "./policies/index.js"

--- a/packages/legal/tests/integration/auto-generate.test.ts
+++ b/packages/legal/tests/integration/auto-generate.test.ts
@@ -1,0 +1,314 @@
+import { bookings, bookingTravelers } from "@voyantjs/bookings/schema"
+import { createEventBus } from "@voyantjs/core"
+import { eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import {
+  contractAttachments,
+  contracts,
+  contractTemplates,
+  contractTemplateVersions,
+} from "../../src/contracts/schema.js"
+import { autoGenerateContractForBooking } from "../../src/contracts/service-auto-generate.js"
+import { contractRecordsService } from "../../src/contracts/service-contracts.js"
+import type { ContractDocumentGenerator } from "../../src/contracts/service-documents.js"
+import { contractSeriesService } from "../../src/contracts/service-series.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+let testSeq = 0
+function nextBookingNumber() {
+  testSeq += 1
+  return `BK-CONTRACT-AUTO-${String(testSeq).padStart(5, "0")}`
+}
+
+describe.skipIf(!DB_AVAILABLE)("autoGenerateContractForBooking", () => {
+  let db: PostgresJsDatabase
+
+  beforeAll(async () => {
+    const { createTestDb, cleanupTestDb } = await import("@voyantjs/db/test-utils")
+    db = createTestDb()
+    await cleanupTestDb(db)
+  })
+
+  beforeEach(async () => {
+    const { cleanupTestDb } = await import("@voyantjs/db/test-utils")
+    await cleanupTestDb(db)
+  })
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyantjs/db/test-utils")
+    await closeTestDb()
+  })
+
+  async function seedTemplate(slug: string) {
+    const [template] = await db
+      .insert(contractTemplates)
+      .values({
+        slug,
+        name: "Customer Services Contract",
+        scope: "customer",
+        language: "en",
+        body: "",
+        active: true,
+      })
+      .returning()
+    const [version] = await db
+      .insert(contractTemplateVersions)
+      .values({
+        templateId: template!.id,
+        version: 1,
+        body: 'Contract for {{ booking.number }}. Lead: {{ leadTraveler.firstName }} {{ leadTraveler.lastName }}. Travelers: {% for t in travelers %}{{ t.firstName }}{% unless forloop.last %}, {% endunless %}{% endfor %}. Total: {{ booking.totalAmountCents | cents: booking.currency }}. Issued: {{ contract.date | format_date: "short" }}.',
+      })
+      .returning()
+    // Point template at the version we just made.
+    await db
+      .update(contractTemplates)
+      .set({ currentVersionId: version!.id, updatedAt: new Date() })
+      .where(eq(contractTemplates.id, template!.id))
+    return { template: template!, version: version! }
+  }
+
+  async function seedBooking(overrides: Partial<typeof bookings.$inferInsert> = {}) {
+    const [row] = await db
+      .insert(bookings)
+      .values({
+        bookingNumber: nextBookingNumber(),
+        status: "confirmed",
+        sellCurrency: "EUR",
+        sellAmountCents: 125000,
+        costAmountCents: 80000,
+        marginPercent: 36,
+        startDate: "2026-07-01",
+        pax: 2,
+        ...overrides,
+      })
+      .returning()
+    return row!
+  }
+
+  function makeGenerator(captureBody: string[] = []): ContractDocumentGenerator {
+    return async (ctx) => {
+      captureBody.push(ctx.renderedBody)
+      return {
+        kind: "document",
+        name: `contract-${ctx.contract.id}.pdf`,
+        mimeType: "application/pdf",
+        fileSize: 4096,
+        storageKey: `contracts/${ctx.contract.id}/document.pdf`,
+        metadata: { source: "test" },
+      }
+    }
+  }
+
+  it("creates contract, renders liquid, and attaches generated document", async () => {
+    const { template } = await seedTemplate("cust-services-1")
+    const booking = await seedBooking()
+    await db.insert(bookingTravelers).values([
+      {
+        bookingId: booking.id,
+        participantType: "traveler",
+        firstName: "Ana",
+        lastName: "Primary",
+        email: "ana@example.com",
+        isPrimary: true,
+      },
+      {
+        bookingId: booking.id,
+        participantType: "traveler",
+        firstName: "Bob",
+        lastName: "Second",
+        isPrimary: false,
+      },
+    ])
+
+    const renderedBodies: string[] = []
+    const outcome = await autoGenerateContractForBooking(
+      db,
+      { bookingId: booking.id, bookingNumber: booking.bookingNumber, actorId: "usrp_tester" },
+      { enabled: true, templateSlug: template.slug },
+      { generator: makeGenerator(renderedBodies) },
+    )
+
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+
+    // Contract row persisted + linked to booking.
+    const [contract] = await db.select().from(contracts).where(eq(contracts.id, outcome.contractId))
+    expect(contract?.bookingId).toBe(booking.id)
+    expect(contract?.status).toBe("issued")
+    // Template's currentVersionId was set after seedTemplate returned — refetch.
+    const [refreshedTemplate] = await db
+      .select()
+      .from(contractTemplates)
+      .where(eq(contractTemplates.id, template.id))
+    expect(contract?.templateVersionId).toBe(refreshedTemplate?.currentVersionId ?? null)
+    expect(contract?.language).toBe("en")
+
+    // Attachment created and linked to contract.
+    const attachmentRows = await db
+      .select()
+      .from(contractAttachments)
+      .where(eq(contractAttachments.contractId, outcome.contractId))
+    expect(attachmentRows).toHaveLength(1)
+    expect(attachmentRows[0]?.kind).toBe("document")
+
+    // Liquid was actually executed — lead traveler + total should be interpolated.
+    expect(renderedBodies).toHaveLength(1)
+    const body = renderedBodies[0] ?? ""
+    expect(body).toContain(booking.bookingNumber)
+    expect(body).toContain("Ana Primary")
+    expect(body).toContain("Ana, Bob")
+    expect(body).toContain("1,250.00") // 125000 cents → 1,250.00 EUR
+  })
+
+  it("emits contract.document.generated event on the runtime bus", async () => {
+    const { template } = await seedTemplate("cust-evt-1")
+    const booking = await seedBooking()
+
+    const eventBus = createEventBus()
+    const received: Array<{ name: string; data: { contractId: string } }> = []
+    eventBus.subscribe("contract.document.generated", (envelope) => {
+      received.push(envelope as { name: string; data: { contractId: string } })
+    })
+
+    const outcome = await autoGenerateContractForBooking(
+      db,
+      { bookingId: booking.id, bookingNumber: booking.bookingNumber, actorId: null },
+      { enabled: true, templateSlug: template.slug },
+      { generator: makeGenerator(), eventBus },
+    )
+    expect(outcome.status).toBe("ok")
+
+    await new Promise((r) => setTimeout(r, 10))
+    expect(received).toHaveLength(1)
+    expect(received[0]?.name).toBe("contract.document.generated")
+    if (outcome.status === "ok") {
+      expect(received[0]?.data.contractId).toBe(outcome.contractId)
+    }
+  })
+
+  it("returns template_not_found when slug doesn't resolve", async () => {
+    const booking = await seedBooking()
+    const outcome = await autoGenerateContractForBooking(
+      db,
+      { bookingId: booking.id, bookingNumber: booking.bookingNumber, actorId: null },
+      { enabled: true, templateSlug: "does-not-exist" },
+      { generator: makeGenerator() },
+    )
+    expect(outcome.status).toBe("template_not_found")
+    expect(await db.select().from(contracts)).toHaveLength(0)
+  })
+
+  it("returns template_version_missing when template exists but has no current version", async () => {
+    const [template] = await db
+      .insert(contractTemplates)
+      .values({
+        slug: "no-versions",
+        name: "Empty Template",
+        scope: "customer",
+        language: "en",
+        body: "",
+        active: true,
+      })
+      .returning()
+    const booking = await seedBooking()
+
+    const outcome = await autoGenerateContractForBooking(
+      db,
+      { bookingId: booking.id, bookingNumber: booking.bookingNumber, actorId: null },
+      { enabled: true, templateSlug: template!.slug },
+      { generator: makeGenerator() },
+    )
+    expect(outcome.status).toBe("template_version_missing")
+  })
+
+  it("returns booking_not_found when the booking was deleted between confirm and handler fire", async () => {
+    const { template } = await seedTemplate("cust-ghost-1")
+
+    const outcome = await autoGenerateContractForBooking(
+      db,
+      { bookingId: "book_does_not_exist", bookingNumber: "BK-GHOST", actorId: null },
+      { enabled: true, templateSlug: template.slug },
+      { generator: makeGenerator() },
+    )
+    expect(outcome.status).toBe("booking_not_found")
+    expect(await db.select().from(contracts)).toHaveLength(0)
+  })
+
+  it("uses resolveVariables to override defaults when supplied", async () => {
+    const { template } = await seedTemplate("cust-override-1")
+    const booking = await seedBooking()
+
+    const bodies: string[] = []
+    const outcome = await autoGenerateContractForBooking(
+      db,
+      { bookingId: booking.id, bookingNumber: booking.bookingNumber, actorId: null },
+      {
+        enabled: true,
+        templateSlug: template.slug,
+        resolveVariables: ({ defaults }) => ({
+          ...defaults,
+          leadTraveler: {
+            id: "ovr",
+            firstName: "Overridden",
+            lastName: "Lead",
+            email: null,
+            phone: null,
+          },
+        }),
+      },
+      { generator: makeGenerator(bodies) },
+    )
+    expect(outcome.status).toBe("ok")
+    expect(bodies[0]).toContain("Overridden Lead")
+  })
+
+  it("resolves a series by name and writes seriesId onto the contract", async () => {
+    const { template } = await seedTemplate("cust-series-1")
+    const booking = await seedBooking()
+    const series = await contractSeriesService.createSeries(db, {
+      name: "2026 Customer",
+      prefix: "CS",
+      separator: "-",
+      padLength: 5,
+      resetStrategy: "never",
+      scope: "customer",
+      active: true,
+    })
+
+    const outcome = await autoGenerateContractForBooking(
+      db,
+      { bookingId: booking.id, bookingNumber: booking.bookingNumber, actorId: null },
+      { enabled: true, templateSlug: template.slug, seriesName: "2026 Customer" },
+      { generator: makeGenerator() },
+    )
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+
+    const contract = await contractRecordsService.getContractById(db, outcome.contractId)
+    expect(contract?.seriesId).toBe(series!.id)
+    expect(contract?.contractNumber).toBeTruthy() // allocated from series
+  })
+
+  it("records trigger metadata on the created contract", async () => {
+    const { template } = await seedTemplate("cust-meta-1")
+    const booking = await seedBooking()
+
+    const outcome = await autoGenerateContractForBooking(
+      db,
+      { bookingId: booking.id, bookingNumber: booking.bookingNumber, actorId: "usrp_meta" },
+      { enabled: true, templateSlug: template.slug },
+      { generator: makeGenerator() },
+    )
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+
+    const contract = await contractRecordsService.getContractById(db, outcome.contractId)
+    const metadata = contract?.metadata as Record<string, unknown> | null
+    expect(metadata?.autoGenerated).toBe(true)
+    expect(metadata?.trigger).toBe("booking.confirmed")
+    expect(metadata?.triggerActorId).toBe("usrp_meta")
+  })
+})

--- a/packages/legal/vitest.config.ts
+++ b/packages/legal/vitest.config.ts
@@ -1,5 +1,14 @@
 import { defineConfig } from "vitest/config"
 
 export default defineConfig({
-  test: { include: ["tests/**/*.test.ts"], passWithNoTests: true, hookTimeout: 60000 },
+  test: {
+    include: ["tests/**/*.test.ts"],
+    passWithNoTests: true,
+    hookTimeout: 60000,
+    // Integration tests share a single voyant_test DB and clean it in
+    // beforeEach; running files in parallel truncates mid-flight. Stick to
+    // serial — legal's suite is small (≈60 tests / ~10s) so the cost is
+    // negligible and the reliability win is big.
+    fileParallelism: false,
+  },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,7 @@ importers:
         version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260403.1)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(better-auth@1.5.6(147937edba8663fd99b9bdbfb02e61a0))
       '@cloudflare/vite-plugin':
         specifier: ^1.31.0
-        version: 1.31.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260415.1)(wrangler@4.80.0(@cloudflare/workers-types@4.20260403.1))
+        version: 1.31.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260401.1)(wrangler@4.80.0(@cloudflare/workers-types@4.20260403.1))
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1891,6 +1891,9 @@ importers:
 
   packages/legal:
     dependencies:
+      '@voyantjs/bookings':
+        specifier: workspace:*
+        version: link:../bookings
       '@voyantjs/core':
         specifier: workspace:*
         version: link:../core
@@ -3531,7 +3534,7 @@ importers:
         version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260403.1)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(better-auth@1.5.6(147937edba8663fd99b9bdbfb02e61a0))
       '@cloudflare/vite-plugin':
         specifier: ^1.31.0
-        version: 1.31.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260401.1)(wrangler@4.80.0(@cloudflare/workers-types@4.20260403.1))
+        version: 1.31.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260415.1)(wrangler@4.80.0(@cloudflare/workers-types@4.20260403.1))
       '@fontsource-variable/inter':
         specifier: ^5.2.8
         version: 5.2.8


### PR DESCRIPTION
Slice B of the operator contract workflow. Closes the end-to-end gap: `booking.confirmed` → contract created → Liquid template rendered → PDF attachment persisted via configured generator → `contract.document.generated` event fires so notifications picks the attachment up for auto-dispatch.

## Service
`autoGenerateContractForBooking(db, event, options, runtime)` in `@voyantjs/legal/contracts/service-auto-generate.ts` — pure orchestrator testable in isolation. Looks up template by slug, loads booking + travelers, assembles `DefaultContractVariables`, optionally calls `resolveVariables` so the consumer can fold in product/person data, creates the draft contract, then delegates to `contractDocumentsService.generateContractDocument` with `issueIfDraft=true` (which renders Liquid, allocates a contract number if a series is configured, uploads via the generator, emits `contract.document.generated`).

Discriminated outcome: `ok` | `template_not_found` | `template_version_missing` | `booking_not_found` | `contract_create_failed` | `document_failed`. Two new service helpers (`contractTemplatesService.findTemplateBySlug`, `contractSeriesService.findSeriesByName`) support the lookup.

## Module wiring
`createLegalHonoModule` now accepts:

```ts
{
  resolveDb: (bindings) => PostgresJsDatabase,
  autoGenerateContractOnConfirmed: {
    enabled: true,
    templateSlug: "customer-contract-v1",
    scope?: "customer",
    seriesName?: "2026 Customer",
    language?: "ro",
    resolveVariables?: ({ db, booking, travelers, defaults }) => {...}
  }
}
```

When enabled, the module bootstrap subscribes to `booking.confirmed` and fires the orchestrator. Subscriber swallows + logs errors per the EventBus contract; misconfig (enabled but no generator) logs + skips rather than silently dropping contracts.

## Dependency change
`@voyantjs/legal` now depends on `@voyantjs/bookings` so the orchestrator can load booking + travelers. No cycle — bookings does not depend on legal.

## Test plan
- [x] 8 integration tests covering happy path (Liquid `cents` + `format_date` filters verified in rendered body), event emission, template-not-found, template-version-missing, booking-not-found, `resolveVariables` override, series resolution + contract number allocation, trigger metadata
- [x] 60/60 legal tests pass; pinned `vitest` to `fileParallelism: false` since integration tests share `voyant_test` and clean in beforeEach (files running in parallel truncate mid-flight)
- [x] Typecheck clean on legal, bookings, utils, dmc, operator
- [ ] PR C: operator UI — contract card on booking detail (download + regenerate)
- [ ] PR D: operator template wiring + starter contract template seed