### PR TITLE
feat(legal-ui): booking contract card with download + regenerate

### DIFF
--- a/packages/legal-react/src/hooks/use-contract-mutation.ts
+++ b/packages/legal-react/src/hooks/use-contract-mutation.ts
@@ -2,6 +2,7 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import type {
+  generateContractDocumentInputSchema,
   insertContractSchema,
   updateContractSchema,
 } from "@voyantjs/legal/contracts/validation"
@@ -10,10 +11,15 @@ import type { z } from "zod"
 import { fetchWithValidation } from "../client.js"
 import { useVoyantLegalContext } from "../provider.js"
 import { legalQueryKeys } from "../query-keys.js"
-import { legalContractSingleResponse, successEnvelope } from "../schemas.js"
+import {
+  legalContractGenerateDocumentResponse,
+  legalContractSingleResponse,
+  successEnvelope,
+} from "../schemas.js"
 
 export type CreateLegalContractInput = z.input<typeof insertContractSchema>
 export type UpdateLegalContractInput = z.input<typeof updateContractSchema>
+export type GenerateLegalContractDocumentInput = z.input<typeof generateContractDocumentInputSchema>
 
 export function useLegalContractMutation() {
   const { baseUrl, fetcher } = useVoyantLegalContext()
@@ -133,5 +139,75 @@ export function useLegalContractMutation() {
     },
   })
 
-  return { create, update, remove, issue, send, execute, voidContract }
+  /**
+   * Trigger a fresh document render for a contract. First call issues the
+   * draft + generates via the server's configured generator; subsequent
+   * calls (see `regenerate`) replace the attachment.
+   */
+  const generateDocument = useMutation({
+    mutationFn: async ({
+      id,
+      input = {},
+    }: {
+      id: string
+      input?: GenerateLegalContractDocumentInput
+    }) => {
+      const { data } = await fetchWithValidation(
+        `/v1/admin/legal/contracts/${id}/generate-document`,
+        legalContractGenerateDocumentResponse,
+        { baseUrl, fetcher },
+        { method: "POST", body: JSON.stringify(input) },
+      )
+      return data
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({ queryKey: legalQueryKeys.contract(variables.id) })
+      void queryClient.invalidateQueries({
+        queryKey: legalQueryKeys.contractAttachments(variables.id),
+      })
+      void queryClient.invalidateQueries({ queryKey: legalQueryKeys.contracts() })
+    },
+  })
+
+  /**
+   * Same as `generateDocument` but explicit about replacing an existing
+   * attachment of the same kind. Use this for the operator's "Regenerate"
+   * button so stale PDFs don't accumulate.
+   */
+  const regenerateDocument = useMutation({
+    mutationFn: async ({
+      id,
+      input = {},
+    }: {
+      id: string
+      input?: GenerateLegalContractDocumentInput
+    }) => {
+      const { data } = await fetchWithValidation(
+        `/v1/admin/legal/contracts/${id}/regenerate-document`,
+        legalContractGenerateDocumentResponse,
+        { baseUrl, fetcher },
+        { method: "POST", body: JSON.stringify(input) },
+      )
+      return data
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({ queryKey: legalQueryKeys.contract(variables.id) })
+      void queryClient.invalidateQueries({
+        queryKey: legalQueryKeys.contractAttachments(variables.id),
+      })
+      void queryClient.invalidateQueries({ queryKey: legalQueryKeys.contracts() })
+    },
+  })
+
+  return {
+    create,
+    update,
+    remove,
+    issue,
+    send,
+    execute,
+    voidContract,
+    generateDocument,
+    regenerateDocument,
+  }
 }

--- a/packages/legal-react/src/query-keys.ts
+++ b/packages/legal-react/src/query-keys.ts
@@ -2,6 +2,10 @@ export interface LegalContractsListFilters {
   search?: string | undefined
   scope?: string | undefined
   status?: string | undefined
+  /** Restrict to contracts linked to this booking. */
+  bookingId?: string | undefined
+  personId?: string | undefined
+  organizationId?: string | undefined
   limit?: number | undefined
   offset?: number | undefined
 }

--- a/packages/legal-react/src/schemas.ts
+++ b/packages/legal-react/src/schemas.ts
@@ -205,6 +205,20 @@ export const legalContractSignatureListResponse = singleEnvelope(
 export const legalContractAttachmentListResponse = singleEnvelope(
   z.array(legalContractAttachmentRecordSchema),
 )
+/**
+ * Response envelope for POST /contracts/:id/(re)generate-document. The
+ * server returns the rendered body + the attachment that now holds the
+ * generated PDF/HTML bytes.
+ */
+export const legalContractGenerateDocumentResponse = singleEnvelope(
+  z.object({
+    contractId: z.string(),
+    contractStatus: z.string(),
+    renderedBodyFormat: z.string(),
+    renderedBody: z.string(),
+    attachment: legalContractAttachmentRecordSchema,
+  }),
+)
 export const legalContractTemplateListResponse = paginatedEnvelope(
   legalContractTemplateRecordSchema,
 )

--- a/packages/ui/registry.json
+++ b/packages/ui/registry.json
@@ -3417,6 +3417,21 @@
       ]
     },
     {
+      "name": "voyant-legal-booking-contract-card",
+      "type": "registry:component",
+      "title": "Booking Contract Card",
+      "description": "Operator booking-detail card that lists the contracts linked to a booking, shows each contract's status + number, lets the operator download the generated PDF (opens in a new tab), and offers a Regenerate action that forces a fresh render via POST /contracts/:id/regenerate-document.",
+      "dependencies": ["lucide-react", "@voyantjs/legal-react"],
+      "registryDependencies": ["badge", "button", "card"],
+      "files": [
+        {
+          "path": "registry/legal/booking-contract-card.tsx",
+          "type": "registry:component",
+          "target": "components/voyant/legal/booking-contract-card.tsx"
+        }
+      ]
+    },
+    {
       "name": "voyant-legal-contract-detail-page",
       "type": "registry:component",
       "title": "Contract Detail Page",

--- a/packages/ui/registry/legal/booking-contract-card.tsx
+++ b/packages/ui/registry/legal/booking-contract-card.tsx
@@ -1,0 +1,228 @@
+"use client"
+
+import {
+  type LegalContractAttachmentRecord,
+  type LegalContractRecord,
+  useLegalContractAttachments,
+  useLegalContractMutation,
+  useLegalContracts,
+} from "@voyantjs/legal-react"
+import { Download, FileText, Loader2, RotateCw } from "lucide-react"
+
+import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from "@/components/ui"
+
+/**
+ * Status → badge style map. Keeps the card visually in sync with the
+ * contract detail page (same variant names, same ordering of severity).
+ */
+const STATUS_VARIANT: Record<string, "default" | "secondary" | "outline" | "destructive"> = {
+  draft: "outline",
+  issued: "secondary",
+  sent: "secondary",
+  signed: "default",
+  executed: "default",
+  expired: "destructive",
+  void: "destructive",
+}
+
+export interface BookingContractCardLabels {
+  heading?: string
+  empty?: string
+  /** Button text when the contract has no document yet. */
+  generate?: string
+  /** Button text when the contract already has a document. */
+  regenerate?: string
+  download?: string
+  noAttachments?: string
+  issuedAt?: string
+  contractNumber?: string
+  unsaved?: string
+}
+
+const DEFAULT_LABELS = {
+  heading: "Contract",
+  empty: "No contract has been generated for this booking yet.",
+  generate: "Generate",
+  regenerate: "Regenerate",
+  download: "Download",
+  noAttachments: "No documents attached yet.",
+  issuedAt: "Issued",
+  contractNumber: "#",
+  unsaved: "Pending",
+} as const
+
+export interface BookingContractCardProps {
+  /** Booking whose contracts we list. Required — the card filters server-side. */
+  bookingId: string
+  /**
+   * API base for attachment download redirects (default: same origin). Use
+   * this when the operator admin app proxies through a different host than
+   * the API — the browser needs an absolute URL to open the 302 in a new
+   * tab correctly.
+   */
+  apiBaseUrl?: string
+  labels?: BookingContractCardLabels
+}
+
+/**
+ * Operator booking-detail "Contract" card. Mount next to the payments / docs
+ * card on the booking detail page. Responsibilities are deliberately narrow:
+ *  - List contracts linked to this booking
+ *  - Show each contract's latest status + number
+ *  - Let the operator download the generated PDF (opens in a new tab)
+ *  - Let the operator force a regeneration when the template or booking
+ *    data has changed
+ *
+ * Contract creation itself is handled by the `booking.confirmed` auto-
+ * generate subscriber (or manually from the contract-template admin page).
+ * This card is the consumer surface — if no contract exists, the empty
+ * state explains the flow rather than offering a "Create" button (which
+ * would require a template picker, out of scope here).
+ */
+export function BookingContractCard({ bookingId, apiBaseUrl, labels }: BookingContractCardProps) {
+  const merged = { ...DEFAULT_LABELS, ...labels }
+  const contractsQuery = useLegalContracts({ bookingId, limit: 25 })
+  const contracts = contractsQuery.data?.data ?? []
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <FileText className="h-4 w-4" />
+          {merged.heading}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        {contractsQuery.isLoading ? (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          </div>
+        ) : contracts.length === 0 ? (
+          <p className="text-xs text-muted-foreground">{merged.empty}</p>
+        ) : (
+          contracts.map((contract) => (
+            <BookingContractRow
+              key={contract.id}
+              contract={contract}
+              apiBaseUrl={apiBaseUrl}
+              labels={merged}
+            />
+          ))
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function BookingContractRow({
+  contract,
+  apiBaseUrl,
+  labels,
+}: {
+  contract: LegalContractRecord
+  apiBaseUrl?: string
+  labels: Required<BookingContractCardLabels>
+}) {
+  const attachmentsQuery = useLegalContractAttachments({ contractId: contract.id })
+  const attachments = attachmentsQuery.data ?? []
+  const documentAttachments = attachments.filter(
+    (a: LegalContractAttachmentRecord) => a.kind === "document",
+  )
+  const { generateDocument, regenerateDocument } = useLegalContractMutation()
+
+  const isPending = generateDocument.isPending || regenerateDocument.isPending
+  const hasDocument = documentAttachments.length > 0
+
+  const handleGenerate = () => {
+    const mutation = hasDocument ? regenerateDocument : generateDocument
+    mutation.mutate({ id: contract.id, input: { replaceExisting: true, kind: "document" } })
+  }
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border p-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 text-sm">
+          <span className="font-medium">
+            {labels.contractNumber}
+            {contract.contractNumber ?? labels.unsaved}
+          </span>
+          <Badge variant={STATUS_VARIANT[contract.status] ?? "outline"} className="text-[10px]">
+            {contract.status}
+          </Badge>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleGenerate}
+          disabled={isPending}
+        >
+          {isPending ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <RotateCw className="h-3.5 w-3.5" />
+          )}
+          <span className="ml-1 text-xs">{hasDocument ? labels.regenerate : labels.generate}</span>
+        </Button>
+      </div>
+
+      {contract.issuedAt ? (
+        <p className="text-[11px] text-muted-foreground">
+          {labels.issuedAt}: {new Date(contract.issuedAt).toLocaleDateString()}
+        </p>
+      ) : null}
+
+      {documentAttachments.length > 0 ? (
+        <div className="flex flex-col gap-1">
+          {documentAttachments.map((attachment) => (
+            <AttachmentDownloadRow
+              key={attachment.id}
+              attachment={attachment}
+              apiBaseUrl={apiBaseUrl}
+              downloadLabel={labels.download}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="text-[11px] text-muted-foreground">{labels.noAttachments}</p>
+      )}
+    </div>
+  )
+}
+
+function AttachmentDownloadRow({
+  attachment,
+  apiBaseUrl,
+  downloadLabel,
+}: {
+  attachment: LegalContractAttachmentRecord
+  apiBaseUrl?: string
+  downloadLabel: string
+}) {
+  // The download endpoint returns a 302 to the signed URL. A plain <a> link
+  // with target="_blank" lets the browser follow it and open the file in a
+  // new tab. When apiBaseUrl is omitted we fall back to a relative URL,
+  // which is correct for same-origin admin apps.
+  const href = `${apiBaseUrl ?? ""}/v1/admin/legal/contracts/attachments/${attachment.id}/download`
+  const sizeKb =
+    typeof attachment.fileSize === "number" ? `${Math.round(attachment.fileSize / 1024)} KB` : null
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center justify-between gap-2 rounded-md border px-2 py-1.5 text-xs hover:bg-muted"
+    >
+      <span className="flex min-w-0 items-center gap-1.5">
+        <FileText className="h-3.5 w-3.5 flex-shrink-0" />
+        <span className="truncate">{attachment.name}</span>
+        {sizeKb ? <span className="text-muted-foreground">· {sizeKb}</span> : null}
+      </span>
+      <span className="flex items-center gap-1 text-muted-foreground">
+        <Download className="h-3 w-3" />
+        {downloadLabel}
+      </span>
+    </a>
+  )
+}

--- a/templates/operator/src/components/voyant/bookings/booking-detail-page.tsx
+++ b/templates/operator/src/components/voyant/bookings/booking-detail-page.tsx
@@ -28,6 +28,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useAdminMessages } from "@/lib/admin-i18n"
 
+import { BookingContractCard } from "../legal/booking-contract-card"
 import { BookingActivityTimeline } from "./booking-activity-timeline"
 import { BookingCancellationDialog } from "./booking-cancellation-dialog"
 import { BookingDetailSkeleton } from "./booking-detail-skeleton"
@@ -279,7 +280,8 @@ export function BookingDetailPage({ id }: { id: string }) {
           <SupplierStatusList bookingId={id} />
         </TabsContent>
 
-        <TabsContent value="documents" className="mt-4">
+        <TabsContent value="documents" className="mt-4 flex flex-col gap-4">
+          <BookingContractCard bookingId={id} />
           <BookingDocumentList bookingId={id} />
         </TabsContent>
 

--- a/templates/operator/src/components/voyant/legal/booking-contract-card.tsx
+++ b/templates/operator/src/components/voyant/legal/booking-contract-card.tsx
@@ -1,0 +1,228 @@
+"use client"
+
+import {
+  type LegalContractAttachmentRecord,
+  type LegalContractRecord,
+  useLegalContractAttachments,
+  useLegalContractMutation,
+  useLegalContracts,
+} from "@voyantjs/legal-react"
+import { Download, FileText, Loader2, RotateCw } from "lucide-react"
+
+import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from "@/components/ui"
+
+/**
+ * Status → badge style map. Keeps the card visually in sync with the
+ * contract detail page (same variant names, same ordering of severity).
+ */
+const STATUS_VARIANT: Record<string, "default" | "secondary" | "outline" | "destructive"> = {
+  draft: "outline",
+  issued: "secondary",
+  sent: "secondary",
+  signed: "default",
+  executed: "default",
+  expired: "destructive",
+  void: "destructive",
+}
+
+export interface BookingContractCardLabels {
+  heading?: string
+  empty?: string
+  /** Button text when the contract has no document yet. */
+  generate?: string
+  /** Button text when the contract already has a document. */
+  regenerate?: string
+  download?: string
+  noAttachments?: string
+  issuedAt?: string
+  contractNumber?: string
+  unsaved?: string
+}
+
+const DEFAULT_LABELS = {
+  heading: "Contract",
+  empty: "No contract has been generated for this booking yet.",
+  generate: "Generate",
+  regenerate: "Regenerate",
+  download: "Download",
+  noAttachments: "No documents attached yet.",
+  issuedAt: "Issued",
+  contractNumber: "#",
+  unsaved: "Pending",
+} as const
+
+export interface BookingContractCardProps {
+  /** Booking whose contracts we list. Required — the card filters server-side. */
+  bookingId: string
+  /**
+   * API base for attachment download redirects (default: same origin). Use
+   * this when the operator admin app proxies through a different host than
+   * the API — the browser needs an absolute URL to open the 302 in a new
+   * tab correctly.
+   */
+  apiBaseUrl?: string
+  labels?: BookingContractCardLabels
+}
+
+/**
+ * Operator booking-detail "Contract" card. Mount next to the payments / docs
+ * card on the booking detail page. Responsibilities are deliberately narrow:
+ *  - List contracts linked to this booking
+ *  - Show each contract's latest status + number
+ *  - Let the operator download the generated PDF (opens in a new tab)
+ *  - Let the operator force a regeneration when the template or booking
+ *    data has changed
+ *
+ * Contract creation itself is handled by the `booking.confirmed` auto-
+ * generate subscriber (or manually from the contract-template admin page).
+ * This card is the consumer surface — if no contract exists, the empty
+ * state explains the flow rather than offering a "Create" button (which
+ * would require a template picker, out of scope here).
+ */
+export function BookingContractCard({ bookingId, apiBaseUrl, labels }: BookingContractCardProps) {
+  const merged = { ...DEFAULT_LABELS, ...labels }
+  const contractsQuery = useLegalContracts({ bookingId, limit: 25 })
+  const contracts = contractsQuery.data?.data ?? []
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <FileText className="h-4 w-4" />
+          {merged.heading}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        {contractsQuery.isLoading ? (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          </div>
+        ) : contracts.length === 0 ? (
+          <p className="text-xs text-muted-foreground">{merged.empty}</p>
+        ) : (
+          contracts.map((contract) => (
+            <BookingContractRow
+              key={contract.id}
+              contract={contract}
+              apiBaseUrl={apiBaseUrl}
+              labels={merged}
+            />
+          ))
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function BookingContractRow({
+  contract,
+  apiBaseUrl,
+  labels,
+}: {
+  contract: LegalContractRecord
+  apiBaseUrl?: string
+  labels: Required<BookingContractCardLabels>
+}) {
+  const attachmentsQuery = useLegalContractAttachments({ contractId: contract.id })
+  const attachments = attachmentsQuery.data ?? []
+  const documentAttachments = attachments.filter(
+    (a: LegalContractAttachmentRecord) => a.kind === "document",
+  )
+  const { generateDocument, regenerateDocument } = useLegalContractMutation()
+
+  const isPending = generateDocument.isPending || regenerateDocument.isPending
+  const hasDocument = documentAttachments.length > 0
+
+  const handleGenerate = () => {
+    const mutation = hasDocument ? regenerateDocument : generateDocument
+    mutation.mutate({ id: contract.id, input: { replaceExisting: true, kind: "document" } })
+  }
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border p-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 text-sm">
+          <span className="font-medium">
+            {labels.contractNumber}
+            {contract.contractNumber ?? labels.unsaved}
+          </span>
+          <Badge variant={STATUS_VARIANT[contract.status] ?? "outline"} className="text-[10px]">
+            {contract.status}
+          </Badge>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleGenerate}
+          disabled={isPending}
+        >
+          {isPending ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <RotateCw className="h-3.5 w-3.5" />
+          )}
+          <span className="ml-1 text-xs">{hasDocument ? labels.regenerate : labels.generate}</span>
+        </Button>
+      </div>
+
+      {contract.issuedAt ? (
+        <p className="text-[11px] text-muted-foreground">
+          {labels.issuedAt}: {new Date(contract.issuedAt).toLocaleDateString()}
+        </p>
+      ) : null}
+
+      {documentAttachments.length > 0 ? (
+        <div className="flex flex-col gap-1">
+          {documentAttachments.map((attachment) => (
+            <AttachmentDownloadRow
+              key={attachment.id}
+              attachment={attachment}
+              apiBaseUrl={apiBaseUrl}
+              downloadLabel={labels.download}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="text-[11px] text-muted-foreground">{labels.noAttachments}</p>
+      )}
+    </div>
+  )
+}
+
+function AttachmentDownloadRow({
+  attachment,
+  apiBaseUrl,
+  downloadLabel,
+}: {
+  attachment: LegalContractAttachmentRecord
+  apiBaseUrl?: string
+  downloadLabel: string
+}) {
+  // The download endpoint returns a 302 to the signed URL. A plain <a> link
+  // with target="_blank" lets the browser follow it and open the file in a
+  // new tab. When apiBaseUrl is omitted we fall back to a relative URL,
+  // which is correct for same-origin admin apps.
+  const href = `${apiBaseUrl ?? ""}/v1/admin/legal/contracts/attachments/${attachment.id}/download`
+  const sizeKb =
+    typeof attachment.fileSize === "number" ? `${Math.round(attachment.fileSize / 1024)} KB` : null
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center justify-between gap-2 rounded-md border px-2 py-1.5 text-xs hover:bg-muted"
+    >
+      <span className="flex min-w-0 items-center gap-1.5">
+        <FileText className="h-3.5 w-3.5 flex-shrink-0" />
+        <span className="truncate">{attachment.name}</span>
+        {sizeKb ? <span className="text-muted-foreground">· {sizeKb}</span> : null}
+      </span>
+      <span className="flex items-center gap-1 text-muted-foreground">
+        <Download className="h-3 w-3" />
+        {downloadLabel}
+      </span>
+    </a>
+  )
+}


### PR DESCRIPTION
Slice C of the operator contract workflow. Operator-facing surface for the auto-generated contract PDFs from slice B (#271).

## Component
`packages/ui/registry/legal/booking-contract-card.tsx`:
- Lists contracts linked to the booking via the existing `GET /v1/admin/legal/contracts?bookingId=<id>` filter
- For each contract: status badge + contract number (or "Pending" when unnumbered), issued date, document attachments rendered as download links that open the signed URL in a new tab
- **Regenerate** action — forces a fresh render via `POST /contracts/:id/regenerate-document`; invalidates the contract + attachments query keys so the card reflects the fresh attachment
- **Generate** button when no document exists yet (same endpoint, first call auto-issues the draft)

Mirror copy at `templates/operator/src/components/voyant/legal/booking-contract-card.tsx`; the operator booking detail page's **Documents** tab now shows the contract card above `BookingDocumentList`.

## Hook plumbing (`@voyantjs/legal-react`)
- `useLegalContractMutation` gains `generateDocument` + `regenerateDocument`
- `LegalContractsListFilters` gains `bookingId` / `personId` / `organizationId` (already accepted server-side; now routed through `toQueryString`)
- New `legalContractGenerateDocumentResponse` schema covers the generate/regenerate payload

## Registry
`voyant-legal-booking-contract-card` entry in `packages/ui/registry.json` with `badge` / `button` / `card` deps.

## Test plan
- [x] Typecheck clean on `legal`, `legal-react`, `operator`, `dmc`
- [ ] Manual (waits for PR D): confirm a booking → card shows the auto-generated contract; download link opens the signed PDF; Regenerate swaps the attachment
- [ ] PR D next: wire the legal module's auto-generate subscriber in the operator template + seed a starter contract template