### PR TITLE
feat(operator): wire auto-generate contract + seed Liquid template (D)

### DIFF
--- a/packages/ui/registry/legal/booking-contract-card.tsx
+++ b/packages/ui/registry/legal/booking-contract-card.tsx
@@ -215,7 +215,7 @@ function AttachmentDownloadRow({
       className="flex items-center justify-between gap-2 rounded-md border px-2 py-1.5 text-xs hover:bg-muted"
     >
       <span className="flex min-w-0 items-center gap-1.5">
-        <FileText className="h-3.5 w-3.5 flex-shrink-0" />
+        <FileText className="h-3.5 w-3.5 shrink-0" />
         <span className="truncate">{attachment.name}</span>
         {sizeKb ? <span className="text-muted-foreground">· {sizeKb}</span> : null}
       </span>

--- a/templates/operator/scripts/seed.ts
+++ b/templates/operator/scripts/seed.ts
@@ -76,7 +76,11 @@ import {
   identityContactPoints,
   identityNamedContacts,
 } from "@voyantjs/identity/schema"
-import { contracts, contractTemplates } from "@voyantjs/legal/contracts/schema"
+import {
+  contracts,
+  contractTemplates,
+  contractTemplateVersions,
+} from "@voyantjs/legal/contracts/schema"
 import {
   policies,
   policyAcceptances,
@@ -1774,6 +1778,7 @@ async function seedAvailability() {
 
 const CANCEL_POLICY = { id: newId("policies"), versionId: newId("policy_versions") }
 const CONTRACT_TMPL = newId("contract_templates")
+const CONTRACT_TMPL_VERSION = newId("contract_template_versions")
 const SALES_CONTRACT = newId("contracts")
 
 async function seedLegal() {
@@ -1834,15 +1839,59 @@ async function seedLegal() {
     },
   ])
 
+  // Template body uses Liquid so auto-generated contracts can iterate over
+  // travelers, format dates/currency via the built-in filters, and gate
+  // optional sections. The utils template renderer auto-detects `{% %}` or
+  // filter syntax and switches from mustache to Liquid.
+  const contractBody = `<h1>Sales Agreement — Booking {{ booking.number }}</h1>
+
+<p>Issued on <strong>{{ contract.date | format_date: "long" }}</strong>.</p>
+
+<h2>Lead traveler</h2>
+{% if leadTraveler %}
+<p>{{ leadTraveler.firstName }} {{ leadTraveler.lastName }}{% if leadTraveler.email %} &lt;{{ leadTraveler.email }}&gt;{% endif %}</p>
+{% else %}
+<p><em>No lead traveler on file.</em></p>
+{% endif %}
+
+<h2>Travelers ({{ travelers.size }})</h2>
+<ol>
+{% for t in travelers %}
+  <li>{{ t.firstName }} {{ t.lastName }}{% if t.participantType != "traveler" %} — {{ t.participantType }}{% endif %}</li>
+{% endfor %}
+</ol>
+
+<h2>Trip</h2>
+<ul>
+  <li>Start: {% if booking.startDate %}{{ booking.startDate | format_date: "long" }}{% else %}TBD{% endif %}</li>
+  <li>End: {% if booking.endDate %}{{ booking.endDate | format_date: "long" }}{% else %}TBD{% endif %}</li>
+  <li>Pax: {{ booking.pax | default: "TBD" }}</li>
+</ul>
+
+<h2>Total</h2>
+<p><strong>{{ booking.totalAmountCents | cents: booking.currency }}</strong></p>
+
+<p>Our standard cancellation policy applies per the attached terms.</p>`
+
   await db.insert(contractTemplates).values({
     id: CONTRACT_TMPL,
     name: "Customer Sales Agreement",
     slug: "customer-sales-agreement",
     scope: "customer",
-    body: "<h1>Sales Agreement</h1><p>This agreement is between {{operator.name}} and {{customer.name}}.</p><p>Booking: {{booking.number}}.</p><p>Total amount: {{booking.total}}.</p><p>Cancellation policy applies per attached terms.</p>",
-    description: "Default customer sales contract.",
+    body: contractBody,
+    description: "Default customer sales contract (Liquid-templated).",
     language: "en",
     active: true,
+    currentVersionId: CONTRACT_TMPL_VERSION,
+  })
+
+  await db.insert(contractTemplateVersions).values({
+    id: CONTRACT_TMPL_VERSION,
+    templateId: CONTRACT_TMPL,
+    version: 1,
+    body: contractBody,
+    changelog: "Initial seed",
+    createdBy: USERS[1]!.id,
   })
 
   await db.insert(contracts).values({

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -10,7 +10,7 @@ import { extrasHonoModule } from "@voyantjs/extras"
 import { bookingsQuickCreateExtension, createFinanceHonoModule } from "@voyantjs/finance"
 import { createApp } from "@voyantjs/hono"
 import { identityHonoModule } from "@voyantjs/identity"
-import { createLegalHonoModule } from "@voyantjs/legal"
+import { createLegalHonoModule, createPdfContractDocumentGenerator } from "@voyantjs/legal"
 import { marketsHonoModule } from "@voyantjs/markets"
 import {
   createDefaultBookingDocumentAttachment,
@@ -28,7 +28,12 @@ import { resolveNotificationProviders } from "../lib/notifications"
 import authHandler, { hasAuthPermission, resolveAuthRequest } from "./auth/handler"
 import { createInvitationsRoutes } from "./invitations"
 import { getDbFromHyperdrive } from "./lib/db"
-import { createMediaStorage, guessMimeType, resolveDocumentDownloadUrl } from "./lib/storage"
+import {
+  createDocumentStorage,
+  createMediaStorage,
+  guessMimeType,
+  resolveDocumentDownloadUrl,
+} from "./lib/storage"
 
 const notificationsHonoModule = createNotificationsHonoModule({
   resolveProviders: resolveNotificationProviders,
@@ -87,8 +92,38 @@ const financeModule = createFinanceHonoModule({
     resolveDocumentDownloadUrl(bindings as unknown as CloudflareBindings, storageKey),
 })
 const legalModule = createLegalHonoModule({
+  // Same union-narrowing trick notifications uses — see the comment on
+  // notificationsHonoModule's resolveDb. Contract operations are all
+  // compatible across the hyperdrive/neon-http drizzle flavors.
+  resolveDb: (bindings) =>
+    getDbFromHyperdrive(
+      bindings as unknown as CloudflareBindings,
+    ) as unknown as import("drizzle-orm/postgres-js").PostgresJsDatabase,
   resolveDocumentDownloadUrl: (bindings: unknown, storageKey: string) =>
     resolveDocumentDownloadUrl(bindings as unknown as CloudflareBindings, storageKey),
+  // Wire a PDF document generator against the private DOCUMENTS_BUCKET so
+  // auto-generated contracts + manual regeneration land in R2. Returning
+  // `undefined` when no bucket is configured keeps the module wired but
+  // inert — the generate-document endpoint falls back to a 501.
+  resolveDocumentGenerator: (bindings) => {
+    const storage = createDocumentStorage(bindings as CloudflareBindings)
+    if (!storage) return undefined
+    return createPdfContractDocumentGenerator({ storage })
+  },
+  // Opt into the booking.confirmed subscriber. Template slug must match a
+  // row in `contract_templates`; seed one named "customer-services" via
+  // the admin UI (see the template README) or via a DB migration.
+  // Opt into the booking.confirmed subscriber. `templateSlug` must match a
+  // row in `contract_templates` that has a `currentVersionId` pointing at a
+  // template version with Liquid body. The operator seed script creates
+  // `customer-sales-agreement` with a Liquid body + published version; any
+  // other slug is fine as long as it exists before the first confirm.
+  autoGenerateContractOnConfirmed: {
+    enabled: true,
+    templateSlug: "customer-sales-agreement",
+    scope: "customer",
+    language: "en",
+  },
 })
 
 export const app = createApp<CloudflareBindings>({

--- a/templates/operator/src/components/voyant/legal/booking-contract-card.tsx
+++ b/templates/operator/src/components/voyant/legal/booking-contract-card.tsx
@@ -215,7 +215,7 @@ function AttachmentDownloadRow({
       className="flex items-center justify-between gap-2 rounded-md border px-2 py-1.5 text-xs hover:bg-muted"
     >
       <span className="flex min-w-0 items-center gap-1.5">
-        <FileText className="h-3.5 w-3.5 flex-shrink-0" />
+        <FileText className="h-3.5 w-3.5 shrink-0" />
         <span className="truncate">{attachment.name}</span>
         {sizeKb ? <span className="text-muted-foreground">· {sizeKb}</span> : null}
       </span>


### PR DESCRIPTION
Final slice of the contract workflow (A=#270 filters, B=#271 subscriber, C=#272 UI, **D=this PR** wiring). Operator template now has the end-to-end flow live:

1. Booking confirmed → legal subscriber creates the contract
2. Subscriber renders the template via Liquid + the storage-backed PDF generator wired here
3. PDF lands in the private `DOCUMENTS_BUCKET` R2 bucket
4. `BookingContractCard` on the operator booking detail page shows the attachment with Download + Regenerate

## Operator app.ts
`legalModule` now configures:
- **resolveDb** — same hyperdrive → postgres-js cast that notifications uses
- **resolveDocumentGenerator** — `createPdfContractDocumentGenerator({ storage: createDocumentStorage(env) })`. Returns `undefined` when `DOCUMENTS_BUCKET` isn't bound so the subscriber logs + skips rather than silently dropping contracts
- **autoGenerateContractOnConfirmed** — `{ enabled, templateSlug: "customer-sales-agreement", scope: "customer", language: "en" }`

## Operator seed
- Contract template body rewritten as Liquid — iterates travelers, uses `format_date` / `cents` filters from slice A, gates missing-lead-traveler with `{% if %}`
- Adds a `contractTemplateVersions` row + sets `currentVersionId` on the template so `autoGenerateContractForBooking` can resolve the version without a manual publish

## Nit
Fixed a stale `flex-shrink-0` → `shrink-0` in `BookingContractCard` per biome's `suggestCanonicalClasses`.

## Test plan
- [x] Typecheck clean on operator, dmc, legal, legal-react
- [ ] Manual: `pnpm -F operator seed -- --confirm`, confirm a booking → card shows the auto-generated contract; download link opens the signed PDF; Regenerate swaps the attachment
- [ ] Release PR covering slices A–D bundled as one minor bump

## DMC template
Intentionally unchanged — no booking-auto-contracts requirement there yet. It can opt in by mirroring the operator block.