### PR TITLE
refactor: QuickBookDialog → BookingCreateDialog, collapse dual dialogs

### DIFF
--- a/packages/i18n/src/admin/bookings.ts
+++ b/packages/i18n/src/admin/bookings.ts
@@ -7,7 +7,6 @@ export const adminBookingsMessages = {
         pageTitle: "Bookings",
         pageDescription: "Manage bookings, confirmations, and travelers.",
         searchPlaceholder: "Search bookings…",
-        quickBook: "Quick Book",
         newBooking: "New booking",
         tableBookingNumber: "Booking #",
         tableStatus: "Status",
@@ -53,7 +52,7 @@ export const adminBookingsMessages = {
         saveChanges: "Save Changes",
         create: "Create Booking",
       },
-      quickBook: {
+      create: {
         title: "Quick Book",
         productLabel: "Product",
         productSearchPlaceholder: "Search products...",
@@ -543,7 +542,6 @@ export const adminBookingsMessages = {
         pageTitle: "Rezervari",
         pageDescription: "Administreaza rezervarile, confirmarile si calatorii.",
         searchPlaceholder: "Cauta rezervari…",
-        quickBook: "Rezervare rapida",
         newBooking: "Rezervare noua",
         tableBookingNumber: "Nr. rezervare",
         tableStatus: "Status",
@@ -589,7 +587,7 @@ export const adminBookingsMessages = {
         saveChanges: "Salveaza modificarile",
         create: "Creeaza rezervarea",
       },
-      quickBook: {
+      create: {
         title: "Rezervare rapida",
         productLabel: "Produs",
         productSearchPlaceholder: "Cauta produse...",

--- a/packages/ui/registry.json
+++ b/packages/ui/registry.json
@@ -686,9 +686,16 @@
       "name": "voyant-bookings-booking-dialog",
       "type": "registry:component",
       "title": "Booking Dialog",
-      "description": "Modal wrapper around the core booking create/edit form.",
+      "description": "Single booking dialog for both create and edit: delegates to BookingCreateDialog (composed picker sections) when no booking prop is supplied, renders a flat edit form when one is. Use this from booking list/detail pages rather than BookingCreateDialog directly — the wrapper keeps state handling identical for both modes.",
       "dependencies": ["@voyantjs/bookings-react", "lucide-react"],
-      "registryDependencies": ["dialog", "input", "label", "select", "textarea"],
+      "registryDependencies": [
+        "dialog",
+        "input",
+        "label",
+        "select",
+        "textarea",
+        "voyant-bookings-booking-create-dialog"
+      ],
       "files": [
         {
           "path": "registry/bookings/booking-dialog.tsx",
@@ -701,15 +708,14 @@
       "name": "voyant-bookings-booking-list",
       "type": "registry:component",
       "title": "Booking List",
-      "description": "Searchable booking table with create/edit dialog and operator quick-book CTA.",
+      "description": "Searchable booking table with create/edit dialog.",
       "dependencies": ["@voyantjs/bookings-react", "lucide-react"],
       "registryDependencies": [
         "badge",
         "button",
         "input",
         "table",
-        "voyant-bookings-booking-dialog",
-        "voyant-bookings-quick-book-dialog"
+        "voyant-bookings-booking-dialog"
       ],
       "files": [
         {
@@ -860,10 +866,10 @@
       ]
     },
     {
-      "name": "voyant-bookings-quick-book-dialog",
+      "name": "voyant-bookings-booking-create-dialog",
       "type": "registry:component",
-      "title": "Quick Book Dialog",
-      "description": "Operator quick-book workflow composing every booking-create section (product, departure, rooms, person, shared-room, passengers, price breakdown, voucher, payment schedule) and submitting atomically via POST /v1/bookings/quick-create. Apps that need a custom flow can install the sections individually and assemble their own dialog.",
+      "title": "Booking Create Dialog",
+      "description": "Operator booking-create workflow composing every picker section (product, departure, rooms, person, shared-room, passengers, price breakdown, voucher, payment schedule) and submitting atomically via POST /v1/bookings/quick-create. Consumed by BookingDialog for the create branch; apps that need a bespoke flow can install the sections individually and assemble their own dialog.",
       "dependencies": [
         "@voyantjs/availability-react",
         "@voyantjs/bookings-react",
@@ -888,9 +894,9 @@
       ],
       "files": [
         {
-          "path": "registry/bookings/quick-book-dialog.tsx",
+          "path": "registry/bookings/booking-create-dialog.tsx",
           "type": "registry:component",
-          "target": "components/voyant/bookings/quick-book-dialog.tsx"
+          "target": "components/voyant/bookings/booking-create-dialog.tsx"
         }
       ]
     },

--- a/packages/ui/registry/bookings/booking-create-dialog.tsx
+++ b/packages/ui/registry/bookings/booking-create-dialog.tsx
@@ -31,7 +31,6 @@ import {
   SelectValue,
   Textarea,
 } from "@/components/ui"
-import { useAdminMessages } from "@/lib/admin-i18n"
 
 import {
   emptyPassengerListValue,
@@ -75,12 +74,6 @@ function generateBookingNumber(): string {
   return `BK-${y}${m}-${seq}`
 }
 
-/**
- * Convert a PaymentScheduleValue (section's UI shape) to the rows the
- * `/quick-create` endpoint expects. Returns an empty array for `unpaid` —
- * the orchestrator treats a zero-length paymentSchedules as "operator will
- * invoice manually."
- */
 function paymentScheduleToRows(
   value: PaymentScheduleValue,
   currency: string,
@@ -152,7 +145,7 @@ function passengersToRows(value: PassengerListValue): QuickCreateTravelerInput[]
     firstName: p.firstName.trim(),
     lastName: p.lastName.trim(),
     email: p.email.trim() || null,
-    participantType: p.role === "lead" || p.role === "adult" ? "traveler" : "traveler",
+    participantType: "traveler",
     travelerCategory:
       p.role === "child"
         ? "child"
@@ -166,7 +159,7 @@ function passengersToRows(value: PassengerListValue): QuickCreateTravelerInput[]
   }))
 }
 
-export interface QuickBookDialogProps {
+export interface BookingCreateDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   onCreated?: (booking: BookingRecord) => void
@@ -174,13 +167,23 @@ export interface QuickBookDialogProps {
   defaultProductId?: string
 }
 
-export function QuickBookDialog({
+/**
+ * Operator booking-create dialog. Composes the booking-create picker
+ * sections — product, departure, rooms, person, shared-room, passengers,
+ * price breakdown, voucher, payment schedule — and submits via the atomic
+ * `POST /v1/bookings/quick-create` endpoint so partial failures can't
+ * leave orphan state.
+ *
+ * Normally consumed via `BookingDialog` which delegates here when no
+ * `booking` prop is passed. Apps that need a bespoke flow can install the
+ * sections individually and assemble their own dialog instead of forking.
+ */
+export function BookingCreateDialog({
   open,
   onOpenChange,
   onCreated,
   defaultProductId,
-}: QuickBookDialogProps) {
-  const messages = useAdminMessages().bookings.quickBook
+}: BookingCreateDialogProps) {
   const [product, setProduct] = React.useState<ProductPickerValue>({
     productId: defaultProductId ?? "",
     optionId: null,
@@ -194,9 +197,13 @@ export function QuickBookDialog({
   const [paymentSchedule, setPaymentSchedule] =
     React.useState<PaymentScheduleValue>(emptyPaymentScheduleValue)
   const [notes, setNotes] = React.useState("")
-  // Post-create: confirm + fire auto-dispatch. The operator template wires
-  // `autoConfirmAndDispatch` on the notifications module so a booking.confirmed
-  // transition auto-sends the doc bundle — no separate notify call needed.
+  /**
+   * Optional post-create transition: set status to `confirmed` right after
+   * create succeeds. When the parent app has the notifications module's
+   * `autoConfirmAndDispatch` enabled, this fires the doc bundle + traveler
+   * email via the `booking.confirmed` subscriber. When it isn't, the
+   * booking simply lands in `confirmed` instead of `draft`.
+   */
   const [confirmAfterCreate, setConfirmAfterCreate] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
 
@@ -256,11 +263,6 @@ export function QuickBookDialog({
     return `${date}${remaining}`
   }, [])
 
-  // Passenger room-assignment options. The capacity ceiling is
-  // `rooms[unit] × occupancyMax` seats; we subtract the count of passengers
-  // already assigned to each unit so the per-unit selector in the passenger
-  // row can disable full rooms. occupancyMax defaults to 1 when the unit
-  // definition doesn't carry it.
   const slotUnitAvailability = useSlotUnitAvailability({
     slotId: slotId ?? undefined,
     enabled: open && Boolean(slotId),
@@ -285,9 +287,9 @@ export function QuickBookDialog({
       })
   }, [slotUnitAvailability.data, rooms.quantities, passengers.passengers])
 
-  // Currency for voucher + payment schedule display. Defaults to EUR for the
-  // first-cut composition; follow-up wires it from the product's sell
-  // currency (usePricingPreview snapshot already carries catalog.currencyCode).
+  // Currency placeholder — used for voucher + payment schedule display.
+  // Consumers hooking in real product data should override this by wrapping
+  // the component or swapping in their own currency-aware hook.
   const currency = "EUR"
 
   const { create: createPerson } = usePersonMutation()
@@ -298,7 +300,7 @@ export function QuickBookDialog({
     setError(null)
 
     if (!product.productId) {
-      setError(messages.errorSelectProduct)
+      setError("Select a product")
       return
     }
 
@@ -306,13 +308,13 @@ export function QuickBookDialog({
     try {
       if (person.mode === "existing") {
         if (!person.personId) {
-          setError(messages.errorSelectPerson)
+          setError("Select a person or switch to create mode")
           return
         }
         resolvedPersonId = person.personId
       } else {
         if (!person.newPerson.firstName.trim() || !person.newPerson.lastName.trim()) {
-          setError(messages.errorNameRequired)
+          setError("First and last name are required")
           return
         }
         const created = await createPerson.mutateAsync({
@@ -324,19 +326,13 @@ export function QuickBookDialog({
         resolvedPersonId = created.id
       }
 
-      // Validate shared-room selection before creating the booking so we don't
-      // leave an orphan booking if the user picked "join" without a group.
       if (sharedRoom.enabled && sharedRoom.mode === "join" && !sharedRoom.groupId) {
-        setError(messages.errorSelectSharedRoom)
+        setError("Select a shared-room group to join")
         return
       }
 
       const bookingNumber = generateBookingNumber()
 
-      // Total is unknown client-side for now — the price breakdown section
-      // computes it but doesn't bubble it up. We pass null to paymentSchedule
-      // rows so "full" and "advance+balance" only emit when the operator
-      // typed amounts explicitly.
       const paymentSchedules = paymentScheduleToRows(paymentSchedule, currency, null)
 
       const travelers = passengersToRows(passengers)
@@ -377,11 +373,11 @@ export function QuickBookDialog({
         groupMembership,
       })
 
-      // Optional post-create: transition to confirmed. In operator's app.ts
-      // the notifications module has autoConfirmAndDispatch enabled, so this
-      // status change automatically triggers the doc bundle + traveler email
-      // via the booking.confirmed subscriber. If the status call fails we
-      // don't roll back — the booking exists, the operator can confirm later.
+      // Optional post-create confirm. If the app has autoConfirmAndDispatch
+      // wired on the notifications module, the status transition triggers
+      // the doc bundle + traveler email subscriber. A failed status change
+      // doesn't roll back the booking — it exists, operator can confirm
+      // manually later.
       let finalBooking = booking
       if (confirmAfterCreate) {
         try {
@@ -393,10 +389,8 @@ export function QuickBookDialog({
           setError(
             statusErr instanceof Error
               ? `Booking created but confirm failed: ${statusErr.message}`
-              : messages.errorCreateFailed,
+              : "Booking created but confirm failed",
           )
-          // Still fire onCreated so the parent closes & refreshes — the
-          // booking did land, only the confirm step tripped.
           onCreated?.(booking)
           return
         }
@@ -405,54 +399,18 @@ export function QuickBookDialog({
       onOpenChange(false)
       onCreated?.(finalBooking)
     } catch (err) {
-      setError(err instanceof Error ? err.message : messages.errorCreateFailed)
+      setError(err instanceof Error ? err.message : "Failed to create booking")
     }
   }
 
   const isSubmitting =
     quickCreateMutation.isPending || createPerson.isPending || statusMutation.isPending
 
-  const productLabels = {
-    product: messages.productLabel,
-    productSearchPlaceholder: messages.productSearchPlaceholder,
-    productSelectPlaceholder: messages.productSelectPlaceholder,
-    option: messages.optionLabel,
-    optionNone: messages.optionNone,
-  }
-
-  const personLabels = {
-    person: messages.personLabel,
-    createNewPerson: messages.createNewPerson,
-    selectExistingPerson: messages.selectExistingPerson,
-    personSearchPlaceholder: messages.personSearchPlaceholder,
-    personSelectPlaceholder: messages.personSelectPlaceholder,
-    firstName: messages.firstNameLabel,
-    firstNamePlaceholder: messages.firstNamePlaceholder,
-    lastName: messages.lastNameLabel,
-    lastNamePlaceholder: messages.lastNamePlaceholder,
-    email: messages.emailLabel,
-    emailPlaceholder: messages.emailPlaceholder,
-    phone: messages.phoneLabel,
-    phonePlaceholder: messages.phonePlaceholder,
-    organization: messages.organizationLabel,
-    organizationSearchPlaceholder: messages.organizationSearchPlaceholder,
-    organizationNone: messages.organizationNone,
-  }
-
-  const sharedRoomLabels = {
-    toggle: messages.sharedRoomLabel,
-    createMode: messages.sharedRoomCreate,
-    joinMode: messages.sharedRoomJoin,
-    selectPlaceholder: messages.sharedRoomSelectPlaceholder,
-    noGroups: messages.sharedRoomNoGroups,
-    createHint: messages.sharedRoomCreateHint,
-  }
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent size="lg">
         <DialogHeader>
-          <DialogTitle>{messages.title}</DialogTitle>
+          <DialogTitle>Quick Book</DialogTitle>
         </DialogHeader>
         <DialogBody className="grid gap-4">
           <ProductPickerSection
@@ -460,24 +418,23 @@ export function QuickBookDialog({
             onChange={setProduct}
             enabled={open}
             lockProduct={Boolean(defaultProductId)}
-            labels={productLabels}
           />
 
           {product.productId ? (
             <div className="flex flex-col gap-1">
-              <Label>{messages.departureLabel}</Label>
+              <Label>Departure</Label>
               <Select
                 value={slotId ?? "__none__"}
                 onValueChange={(v) => setSlotId(v === "__none__" ? null : (v ?? null))}
               >
                 <SelectTrigger>
-                  <SelectValue placeholder={messages.departureSelectPlaceholder} />
+                  <SelectValue placeholder="Select a departure..." />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="__none__">{messages.departureNone}</SelectItem>
+                  <SelectItem value="__none__">No specific departure</SelectItem>
                   {slots.length === 0 ? (
                     <SelectItem value="__empty__" disabled>
-                      {messages.departureEmpty}
+                      No open departures for this product
                     </SelectItem>
                   ) : (
                     slots.map((slot) => (
@@ -495,19 +452,13 @@ export function QuickBookDialog({
             <RoomsStepperSection value={rooms} onChange={setRooms} slotId={slotId} enabled={open} />
           ) : null}
 
-          <PersonPickerSection
-            value={person}
-            onChange={setPerson}
-            enabled={open}
-            labels={personLabels}
-          />
+          <PersonPickerSection value={person} onChange={setPerson} enabled={open} />
 
           <SharedRoomSection
             value={sharedRoom}
             onChange={setSharedRoom}
             productId={product.productId || undefined}
             enabled={open}
-            labels={sharedRoomLabels}
           />
 
           {product.productId ? (
@@ -535,11 +486,11 @@ export function QuickBookDialog({
           />
 
           <div className="flex flex-col gap-2">
-            <Label>{messages.notesLabel}</Label>
+            <Label>Internal Notes</Label>
             <Textarea
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
-              placeholder={messages.notesPlaceholder}
+              placeholder="Quick context for this booking..."
             />
           </div>
 
@@ -552,9 +503,13 @@ export function QuickBookDialog({
             />
             <div className="flex flex-col gap-1">
               <Label htmlFor="quickbook-confirm-after-create" className="cursor-pointer text-sm">
-                {messages.confirmAfterCreateLabel}
+                Confirm & notify traveler after creating
               </Label>
-              <p className="text-xs text-muted-foreground">{messages.confirmAfterCreateHint}</p>
+              <p className="text-xs text-muted-foreground">
+                Transitions to confirmed after create. When the notifications module's auto-dispatch
+                is on, this fires the doc bundle + traveler email via the booking.confirmed
+                subscriber.
+              </p>
             </div>
           </div>
 
@@ -568,7 +523,7 @@ export function QuickBookDialog({
             onClick={() => onOpenChange(false)}
             disabled={isSubmitting}
           >
-            {messages.cancel}
+            Cancel
           </Button>
           <Button
             type="button"
@@ -577,7 +532,7 @@ export function QuickBookDialog({
             disabled={isSubmitting || !product.productId}
           >
             {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            {messages.create}
+            Create Draft Booking
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/packages/ui/registry/bookings/booking-dialog.tsx
+++ b/packages/ui/registry/bookings/booking-dialog.tsx
@@ -27,6 +27,8 @@ import { CurrencyCombobox } from "@/components/ui/currency-combobox"
 import { DateRangePicker } from "@/components/ui/date-picker"
 import { zodResolver } from "@/lib/zod-resolver"
 
+import { BookingCreateDialog } from "./booking-create-dialog"
+
 const bookingFormSchema = z.object({
   bookingNumber: z.string().min(1, "Booking number is required"),
   status: z.enum(["draft", "confirmed", "in_progress", "completed", "cancelled"]),
@@ -47,6 +49,11 @@ export interface BookingDialogProps {
   onOpenChange: (open: boolean) => void
   booking?: BookingRecord
   onSuccess?: (booking: BookingRecord) => void
+  /**
+   * Pre-seeds the product picker in create mode. Useful when opened from
+   * a product detail page. Ignored when editing an existing booking.
+   */
+  defaultProductId?: string
 }
 
 const BOOKING_STATUSES = [
@@ -57,17 +64,52 @@ const BOOKING_STATUSES = [
   { value: "cancelled", label: "Cancelled" },
 ] as const
 
-function generateBookingNumber(): string {
-  const now = new Date()
-  const y = now.getFullYear().toString().slice(-2)
-  const m = String(now.getMonth() + 1).padStart(2, "0")
-  const seq = String(Math.floor(Math.random() * 9000) + 1000)
-  return `BK-${y}${m}-${seq}`
+/**
+ * Single booking dialog that handles both create and edit:
+ * - Create (no `booking` prop): renders the rich product → option → person
+ *   picker flow via `BookingCreateDialog`, so the draft booking inherits
+ *   pricing, dates, and currency from the catalogue instead of being
+ *   hand-entered.
+ * - Edit (with `booking` prop): renders the flat form below that patches
+ *   the existing row's metadata (status, amounts, dates, notes).
+ */
+export function BookingDialog({
+  open,
+  onOpenChange,
+  booking,
+  onSuccess,
+  defaultProductId,
+}: BookingDialogProps) {
+  if (!booking) {
+    return (
+      <BookingCreateDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        defaultProductId={defaultProductId}
+        onCreated={onSuccess}
+      />
+    )
+  }
+
+  return (
+    <BookingEditDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      booking={booking}
+      onSuccess={onSuccess}
+    />
+  )
 }
 
-export function BookingDialog({ open, onOpenChange, booking, onSuccess }: BookingDialogProps) {
-  const isEditing = Boolean(booking)
-  const { create, update } = useBookingMutation()
+interface BookingEditDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  booking: BookingRecord
+  onSuccess?: (booking: BookingRecord) => void
+}
+
+function BookingEditDialog({ open, onOpenChange, booking, onSuccess }: BookingEditDialogProps) {
+  const { update } = useBookingMutation()
 
   const form = useForm<BookingFormValues, unknown, BookingFormOutput>({
     resolver: zodResolver(bookingFormSchema),
@@ -85,32 +127,19 @@ export function BookingDialog({ open, onOpenChange, booking, onSuccess }: Bookin
   })
 
   useEffect(() => {
-    if (open && booking) {
-      form.reset({
-        bookingNumber: booking.bookingNumber,
-        status:
-          booking.status === "on_hold" || booking.status === "expired" ? "draft" : booking.status,
-        sellCurrency: booking.sellCurrency,
-        sellAmountCents: booking.sellAmountCents ?? "",
-        costAmountCents: booking.costAmountCents ?? "",
-        startDate: booking.startDate ?? "",
-        endDate: booking.endDate ?? "",
-        pax: booking.pax ?? "",
-        internalNotes: booking.internalNotes ?? "",
-      })
-    } else if (open) {
-      form.reset({
-        bookingNumber: generateBookingNumber(),
-        status: "draft",
-        sellCurrency: "EUR",
-        sellAmountCents: "",
-        costAmountCents: "",
-        startDate: "",
-        endDate: "",
-        pax: "",
-        internalNotes: "",
-      })
-    }
+    if (!open) return
+    form.reset({
+      bookingNumber: booking.bookingNumber,
+      status:
+        booking.status === "on_hold" || booking.status === "expired" ? "draft" : booking.status,
+      sellCurrency: booking.sellCurrency,
+      sellAmountCents: booking.sellAmountCents ?? "",
+      costAmountCents: booking.costAmountCents ?? "",
+      startDate: booking.startDate ?? "",
+      endDate: booking.endDate ?? "",
+      pax: booking.pax ?? "",
+      internalNotes: booking.internalNotes ?? "",
+    })
   }, [booking, form, open])
 
   const onSubmit = async (values: BookingFormOutput) => {
@@ -132,21 +161,19 @@ export function BookingDialog({ open, onOpenChange, booking, onSuccess }: Bookin
       internalNotes: values.internalNotes || null,
     }
 
-    const saved = isEditing
-      ? await update.mutateAsync({ id: booking!.id, input: payload })
-      : await create.mutateAsync(payload)
+    const saved = await update.mutateAsync({ id: booking.id, input: payload })
 
     onOpenChange(false)
     onSuccess?.(saved)
   }
 
-  const isSubmitting = create.isPending || update.isPending
+  const isSubmitting = update.isPending
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent size="lg">
         <DialogHeader>
-          <DialogTitle>{isEditing ? "Edit Booking" : "New Booking"}</DialogTitle>
+          <DialogTitle>Edit Booking</DialogTitle>
         </DialogHeader>
         <form
           onSubmit={form.handleSubmit(onSubmit)}
@@ -171,7 +198,6 @@ export function BookingDialog({ open, onOpenChange, booking, onSuccess }: Bookin
                   onValueChange={(value) =>
                     form.setValue("status", value as BookingFormValues["status"])
                   }
-                  items={BOOKING_STATUSES}
                 >
                   <SelectTrigger className="w-full">
                     <SelectValue />
@@ -246,7 +272,7 @@ export function BookingDialog({ open, onOpenChange, booking, onSuccess }: Bookin
             </Button>
             <Button type="submit" size="sm" disabled={isSubmitting}>
               {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {isEditing ? "Save Changes" : "Create Booking"}
+              Save Changes
             </Button>
           </DialogFooter>
         </form>

--- a/packages/ui/registry/bookings/booking-list.tsx
+++ b/packages/ui/registry/bookings/booking-list.tsx
@@ -6,7 +6,7 @@ import {
   formatBookingStatus,
   useBookings,
 } from "@voyantjs/bookings-react"
-import { Loader2, Plus, Search, Zap } from "lucide-react"
+import { Loader2, Plus, Search } from "lucide-react"
 import * as React from "react"
 
 import { Badge } from "@/components/ui/badge"
@@ -22,7 +22,6 @@ import {
 } from "@/components/ui/table"
 
 import { BookingDialog } from "./booking-dialog"
-import { QuickBookDialog } from "./quick-book-dialog"
 
 export interface BookingListProps {
   pageSize?: number
@@ -38,7 +37,6 @@ export function BookingList({ pageSize = 25, onSelectBooking }: BookingListProps
   const [search, setSearch] = React.useState("")
   const [offset, setOffset] = React.useState(0)
   const [dialogOpen, setDialogOpen] = React.useState(false)
-  const [quickBookOpen, setQuickBookOpen] = React.useState(false)
   const [editing, setEditing] = React.useState<BookingRecord | undefined>(undefined)
 
   const { data, isPending, isError } = useBookings({
@@ -77,10 +75,6 @@ export function BookingList({ pageSize = 25, onSelectBooking }: BookingListProps
           />
         </div>
         <div className="flex items-center gap-2">
-          <Button variant="outline" onClick={() => setQuickBookOpen(true)}>
-            <Zap className="mr-2 size-4" />
-            Quick Book
-          </Button>
           <Button
             onClick={() => {
               setEditing(undefined)
@@ -180,14 +174,6 @@ export function BookingList({ pageSize = 25, onSelectBooking }: BookingListProps
         onOpenChange={setDialogOpen}
         booking={editing}
         onSuccess={(booking) => {
-          onSelectBooking?.(booking)
-        }}
-      />
-
-      <QuickBookDialog
-        open={quickBookOpen}
-        onOpenChange={setQuickBookOpen}
-        onCreated={(booking) => {
           onSelectBooking?.(booking)
         }}
       />

--- a/templates/dmc/src/components/voyant/bookings/booking-create-dialog.tsx
+++ b/templates/dmc/src/components/voyant/bookings/booking-create-dialog.tsx
@@ -41,7 +41,7 @@ function generateBookingNumber(): string {
 
 const NONE = "__none__"
 
-export interface QuickBookDialogProps {
+export interface BookingCreateDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   onCreated?: (booking: BookingRecord) => void
@@ -51,13 +51,13 @@ export interface QuickBookDialogProps {
 
 type PersonMode = "existing" | "new"
 
-export function QuickBookDialog({
+export function BookingCreateDialog({
   open,
   onOpenChange,
   onCreated,
   defaultProductId,
-}: QuickBookDialogProps) {
-  const quickBookMessages = useAdminMessages().bookings.quickBook
+}: BookingCreateDialogProps) {
+  const messages = useAdminMessages().bookings.create
   const [productId, setProductId] = React.useState(defaultProductId ?? "")
   const [productSearch, setProductSearch] = React.useState("")
   const [optionId, setOptionId] = React.useState<string>(NONE)
@@ -148,7 +148,7 @@ export function QuickBookDialog({
     setError(null)
 
     if (!productId) {
-      setError(quickBookMessages.errorSelectProduct)
+      setError(messages.errorSelectProduct)
       return
     }
 
@@ -156,13 +156,13 @@ export function QuickBookDialog({
     try {
       if (personMode === "existing") {
         if (!personId) {
-          setError(quickBookMessages.errorSelectPerson)
+          setError(messages.errorSelectPerson)
           return
         }
         resolvedPersonId = personId
       } else {
         if (!newPerson.firstName.trim() || !newPerson.lastName.trim()) {
-          setError(quickBookMessages.errorNameRequired)
+          setError(messages.errorNameRequired)
           return
         }
         const person = await createPerson.mutateAsync({
@@ -177,7 +177,7 @@ export function QuickBookDialog({
       // Validate shared-room selection before creating the booking so we don't
       // create an orphan booking if the user picked "join" without a group.
       if (sharedRoomEnabled && sharedRoomMode === "join" && !sharedRoomGroupId) {
-        setError(quickBookMessages.errorSelectSharedRoom)
+        setError(messages.errorSelectSharedRoom)
         return
       }
 
@@ -217,7 +217,7 @@ export function QuickBookDialog({
       onOpenChange(false)
       onCreated?.(booking)
     } catch (err) {
-      setError(err instanceof Error ? err.message : quickBookMessages.errorCreateFailed)
+      setError(err instanceof Error ? err.message : messages.errorCreateFailed)
     }
   }
 
@@ -231,17 +231,17 @@ export function QuickBookDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent size="lg">
         <DialogHeader>
-          <DialogTitle>{quickBookMessages.title}</DialogTitle>
+          <DialogTitle>{messages.title}</DialogTitle>
         </DialogHeader>
         <DialogBody className="grid gap-4">
           {/* Product — hidden when pre-selected from a product page */}
           {!defaultProductId ? (
             <div className="flex flex-col gap-2">
               <Label>
-                {quickBookMessages.productLabel} <span className="text-destructive">*</span>
+                {messages.productLabel} <span className="text-destructive">*</span>
               </Label>
               <Input
-                placeholder={quickBookMessages.productSearchPlaceholder}
+                placeholder={messages.productSearchPlaceholder}
                 value={productSearch}
                 onChange={(e) => setProductSearch(e.target.value)}
               />
@@ -254,7 +254,7 @@ export function QuickBookDialog({
                 }}
               >
                 <SelectTrigger className="w-full">
-                  <SelectValue placeholder={quickBookMessages.productSelectPlaceholder} />
+                  <SelectValue placeholder={messages.productSelectPlaceholder} />
                 </SelectTrigger>
                 <SelectContent>
                   {products.map((p) => (
@@ -270,10 +270,10 @@ export function QuickBookDialog({
           {/* Option (if product has options) */}
           {productId && options.length > 0 && (
             <div className="flex flex-col gap-2">
-              <Label>{quickBookMessages.optionLabel}</Label>
+              <Label>{messages.optionLabel}</Label>
               <Select
                 items={[
-                  { label: quickBookMessages.optionNone, value: NONE },
+                  { label: messages.optionNone, value: NONE },
                   ...options.map((o) => ({ label: o.name, value: o.id })),
                 ]}
                 value={optionId}
@@ -283,7 +283,7 @@ export function QuickBookDialog({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value={NONE}>{quickBookMessages.optionNone}</SelectItem>
+                  <SelectItem value={NONE}>{messages.optionNone}</SelectItem>
                   {options.map((o) => (
                     <SelectItem key={o.id} value={o.id}>
                       {o.name}
@@ -298,7 +298,7 @@ export function QuickBookDialog({
           <div className="flex flex-col gap-2">
             <div className="flex items-center justify-between">
               <Label>
-                {quickBookMessages.personLabel} <span className="text-destructive">*</span>
+                {messages.personLabel} <span className="text-destructive">*</span>
               </Label>
               <Button
                 type="button"
@@ -310,10 +310,10 @@ export function QuickBookDialog({
                 {personMode === "existing" ? (
                   <>
                     <UserPlus className="mr-1 h-3.5 w-3.5" />
-                    {quickBookMessages.createNewPerson}
+                    {messages.createNewPerson}
                   </>
                 ) : (
-                  quickBookMessages.selectExistingPerson
+                  messages.selectExistingPerson
                 )}
               </Button>
             </div>
@@ -321,7 +321,7 @@ export function QuickBookDialog({
             {personMode === "existing" ? (
               <>
                 <Input
-                  placeholder={quickBookMessages.personSearchPlaceholder}
+                  placeholder={messages.personSearchPlaceholder}
                   value={personSearch}
                   onChange={(e) => setPersonSearch(e.target.value)}
                 />
@@ -334,7 +334,7 @@ export function QuickBookDialog({
                   }))}
                 >
                   <SelectTrigger className="w-full">
-                    <SelectValue placeholder={quickBookMessages.personSelectPlaceholder} />
+                    <SelectValue placeholder={messages.personSelectPlaceholder} />
                   </SelectTrigger>
                   <SelectContent>
                     {people.map((p) => (
@@ -349,36 +349,36 @@ export function QuickBookDialog({
             ) : (
               <div className="grid grid-cols-2 gap-2 rounded-md border p-3">
                 <div className="flex flex-col gap-1">
-                  <Label className="text-xs">{quickBookMessages.firstNameLabel}</Label>
+                  <Label className="text-xs">{messages.firstNameLabel}</Label>
                   <Input
                     value={newPerson.firstName}
                     onChange={(e) => setNewPerson({ ...newPerson, firstName: e.target.value })}
-                    placeholder={quickBookMessages.firstNamePlaceholder}
+                    placeholder={messages.firstNamePlaceholder}
                   />
                 </div>
                 <div className="flex flex-col gap-1">
-                  <Label className="text-xs">{quickBookMessages.lastNameLabel}</Label>
+                  <Label className="text-xs">{messages.lastNameLabel}</Label>
                   <Input
                     value={newPerson.lastName}
                     onChange={(e) => setNewPerson({ ...newPerson, lastName: e.target.value })}
-                    placeholder={quickBookMessages.lastNamePlaceholder}
+                    placeholder={messages.lastNamePlaceholder}
                   />
                 </div>
                 <div className="flex flex-col gap-1">
-                  <Label className="text-xs">{quickBookMessages.emailLabel}</Label>
+                  <Label className="text-xs">{messages.emailLabel}</Label>
                   <Input
                     type="email"
                     value={newPerson.email}
                     onChange={(e) => setNewPerson({ ...newPerson, email: e.target.value })}
-                    placeholder={quickBookMessages.emailPlaceholder}
+                    placeholder={messages.emailPlaceholder}
                   />
                 </div>
                 <div className="flex flex-col gap-1">
-                  <Label className="text-xs">{quickBookMessages.phoneLabel}</Label>
+                  <Label className="text-xs">{messages.phoneLabel}</Label>
                   <Input
                     value={newPerson.phone}
                     onChange={(e) => setNewPerson({ ...newPerson, phone: e.target.value })}
-                    placeholder={quickBookMessages.phonePlaceholder}
+                    placeholder={messages.phonePlaceholder}
                   />
                 </div>
               </div>
@@ -387,25 +387,25 @@ export function QuickBookDialog({
 
           {/* Organization (optional) */}
           <div className="flex flex-col gap-2">
-            <Label>{quickBookMessages.organizationLabel}</Label>
+            <Label>{messages.organizationLabel}</Label>
             <Input
-              placeholder={quickBookMessages.organizationSearchPlaceholder}
+              placeholder={messages.organizationSearchPlaceholder}
               value={orgSearch}
               onChange={(e) => setOrgSearch(e.target.value)}
             />
             <Select
               items={[
-                { label: quickBookMessages.organizationNone, value: NONE },
+                { label: messages.organizationNone, value: NONE },
                 ...orgs.map((o) => ({ label: o.name, value: o.id })),
               ]}
               value={organizationId}
               onValueChange={(v) => setOrganizationId(v ?? NONE)}
             >
               <SelectTrigger className="w-full">
-                <SelectValue placeholder={quickBookMessages.organizationNone} />
+                <SelectValue placeholder={messages.organizationNone} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value={NONE}>{quickBookMessages.organizationNone}</SelectItem>
+                <SelectItem value={NONE}>{messages.organizationNone}</SelectItem>
                 {orgs.map((o) => (
                   <SelectItem key={o.id} value={o.id}>
                     {o.name}
@@ -419,13 +419,13 @@ export function QuickBookDialog({
           <div className="flex flex-col gap-2 rounded-md border p-3">
             <div className="flex items-center gap-2">
               <input
-                id="quick-book-shared-room"
+                id="booking-create-shared-room"
                 type="checkbox"
                 checked={sharedRoomEnabled}
                 onChange={(e) => setSharedRoomEnabled(e.target.checked)}
               />
-              <Label htmlFor="quick-book-shared-room" className="text-sm">
-                {quickBookMessages.sharedRoomLabel}
+              <Label htmlFor="booking-create-shared-room" className="text-sm">
+                {messages.sharedRoomLabel}
               </Label>
             </div>
 
@@ -438,7 +438,7 @@ export function QuickBookDialog({
                     variant={sharedRoomMode === "create" ? "default" : "ghost"}
                     onClick={() => setSharedRoomMode("create")}
                   >
-                    {quickBookMessages.sharedRoomCreate}
+                    {messages.sharedRoomCreate}
                   </Button>
                   <Button
                     type="button"
@@ -446,7 +446,7 @@ export function QuickBookDialog({
                     variant={sharedRoomMode === "join" ? "default" : "ghost"}
                     onClick={() => setSharedRoomMode("join")}
                   >
-                    {quickBookMessages.sharedRoomJoin}
+                    {messages.sharedRoomJoin}
                   </Button>
                 </div>
 
@@ -454,19 +454,19 @@ export function QuickBookDialog({
                   <Select
                     items={
                       existingGroups.length === 0
-                        ? [{ label: quickBookMessages.sharedRoomNoGroups, value: NONE }]
+                        ? [{ label: messages.sharedRoomNoGroups, value: NONE }]
                         : existingGroups.map((g) => ({ label: g.label, value: g.id }))
                     }
                     value={sharedRoomGroupId || NONE}
                     onValueChange={(v) => setSharedRoomGroupId(v === NONE ? "" : (v ?? ""))}
                   >
                     <SelectTrigger className="w-full">
-                      <SelectValue placeholder={quickBookMessages.sharedRoomSelectPlaceholder} />
+                      <SelectValue placeholder={messages.sharedRoomSelectPlaceholder} />
                     </SelectTrigger>
                     <SelectContent>
                       {existingGroups.length === 0 ? (
                         <SelectItem value={NONE} disabled>
-                          {quickBookMessages.sharedRoomNoGroups}
+                          {messages.sharedRoomNoGroups}
                         </SelectItem>
                       ) : (
                         existingGroups.map((g) => (
@@ -479,9 +479,7 @@ export function QuickBookDialog({
                   </Select>
                 )}
                 {sharedRoomMode === "create" && (
-                  <p className="text-xs text-muted-foreground">
-                    {quickBookMessages.sharedRoomCreateHint}
-                  </p>
+                  <p className="text-xs text-muted-foreground">{messages.sharedRoomCreateHint}</p>
                 )}
               </div>
             )}
@@ -489,11 +487,11 @@ export function QuickBookDialog({
 
           {/* Notes */}
           <div className="flex flex-col gap-2">
-            <Label>{quickBookMessages.notesLabel}</Label>
+            <Label>{messages.notesLabel}</Label>
             <Textarea
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
-              placeholder={quickBookMessages.notesPlaceholder}
+              placeholder={messages.notesPlaceholder}
             />
           </div>
 
@@ -507,7 +505,7 @@ export function QuickBookDialog({
             onClick={() => onOpenChange(false)}
             disabled={isSubmitting}
           >
-            {quickBookMessages.cancel}
+            {messages.cancel}
           </Button>
           <Button
             type="button"
@@ -516,7 +514,7 @@ export function QuickBookDialog({
             disabled={isSubmitting || !productId}
           >
             {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            {quickBookMessages.create}
+            {messages.create}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/templates/dmc/src/components/voyant/bookings/booking-dialog.tsx
+++ b/templates/dmc/src/components/voyant/bookings/booking-dialog.tsx
@@ -28,6 +28,8 @@ import { DateRangePicker } from "@/components/ui/date-picker"
 import { useAdminMessages } from "@/lib/admin-i18n"
 import { zodResolver } from "@/lib/zod-resolver"
 
+import { BookingCreateDialog } from "./booking-create-dialog"
+
 type BookingDialogMessages = ReturnType<typeof useAdminMessages>["bookings"]["dialog"]
 
 const buildBookingFormSchema = (messages: BookingDialogMessages) =>
@@ -52,20 +54,59 @@ export interface BookingDialogProps {
   onOpenChange: (open: boolean) => void
   booking?: BookingRecord
   onSuccess?: (booking: BookingRecord) => void
+  /**
+   * Pre-seeds the product picker in create mode. Useful when opened from
+   * a product detail page. Ignored when editing an existing booking.
+   */
+  defaultProductId?: string
 }
 
-function generateBookingNumber(): string {
-  const now = new Date()
-  const y = now.getFullYear().toString().slice(-2)
-  const m = String(now.getMonth() + 1).padStart(2, "0")
-  const seq = String(Math.floor(Math.random() * 9000) + 1000)
-  return `BK-${y}${m}-${seq}`
+/**
+ * Single booking dialog for both create and edit:
+ * - Create (no `booking` prop) → delegates to `BookingCreateDialog`, the
+ *   composed product/option/person/shared-room picker flow that submits
+ *   via POST /v1/admin/bookings/quick-create.
+ * - Edit (with `booking` prop) → renders the flat form below that patches
+ *   status/amounts/dates/notes on the existing row.
+ */
+export function BookingDialog({
+  open,
+  onOpenChange,
+  booking,
+  onSuccess,
+  defaultProductId,
+}: BookingDialogProps) {
+  if (!booking) {
+    return (
+      <BookingCreateDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        defaultProductId={defaultProductId}
+        onCreated={onSuccess}
+      />
+    )
+  }
+
+  return (
+    <BookingEditDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      booking={booking}
+      onSuccess={onSuccess}
+    />
+  )
 }
 
-export function BookingDialog({ open, onOpenChange, booking, onSuccess }: BookingDialogProps) {
+interface BookingEditDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  booking: BookingRecord
+  onSuccess?: (booking: BookingRecord) => void
+}
+
+function BookingEditDialog({ open, onOpenChange, booking, onSuccess }: BookingEditDialogProps) {
   const dialogMessages = useAdminMessages().bookings.dialog
-  const isEditing = Boolean(booking)
-  const { create, update } = useBookingMutation()
+  const { update } = useBookingMutation()
   const bookingFormSchema = buildBookingFormSchema(dialogMessages)
   const bookingStatuses = [
     { value: "draft", label: dialogMessages.statusDraft },
@@ -91,32 +132,19 @@ export function BookingDialog({ open, onOpenChange, booking, onSuccess }: Bookin
   })
 
   useEffect(() => {
-    if (open && booking) {
-      form.reset({
-        bookingNumber: booking.bookingNumber,
-        status:
-          booking.status === "on_hold" || booking.status === "expired" ? "draft" : booking.status,
-        sellCurrency: booking.sellCurrency,
-        sellAmountCents: booking.sellAmountCents ?? "",
-        costAmountCents: booking.costAmountCents ?? "",
-        startDate: booking.startDate ?? "",
-        endDate: booking.endDate ?? "",
-        pax: booking.pax ?? "",
-        internalNotes: booking.internalNotes ?? "",
-      })
-    } else if (open) {
-      form.reset({
-        bookingNumber: generateBookingNumber(),
-        status: "draft",
-        sellCurrency: "EUR",
-        sellAmountCents: "",
-        costAmountCents: "",
-        startDate: "",
-        endDate: "",
-        pax: "",
-        internalNotes: "",
-      })
-    }
+    if (!open) return
+    form.reset({
+      bookingNumber: booking.bookingNumber,
+      status:
+        booking.status === "on_hold" || booking.status === "expired" ? "draft" : booking.status,
+      sellCurrency: booking.sellCurrency,
+      sellAmountCents: booking.sellAmountCents ?? "",
+      costAmountCents: booking.costAmountCents ?? "",
+      startDate: booking.startDate ?? "",
+      endDate: booking.endDate ?? "",
+      pax: booking.pax ?? "",
+      internalNotes: booking.internalNotes ?? "",
+    })
   }, [booking, form, open])
 
   const onSubmit = async (values: BookingFormOutput) => {
@@ -138,23 +166,19 @@ export function BookingDialog({ open, onOpenChange, booking, onSuccess }: Bookin
       internalNotes: values.internalNotes || null,
     }
 
-    const saved = isEditing
-      ? await update.mutateAsync({ id: booking!.id, input: payload })
-      : await create.mutateAsync(payload)
+    const saved = await update.mutateAsync({ id: booking.id, input: payload })
 
     onOpenChange(false)
     onSuccess?.(saved)
   }
 
-  const isSubmitting = create.isPending || update.isPending
+  const isSubmitting = update.isPending
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent size="lg">
         <DialogHeader>
-          <DialogTitle>
-            {isEditing ? dialogMessages.editTitle : dialogMessages.newTitle}
-          </DialogTitle>
+          <DialogTitle>{dialogMessages.editTitle}</DialogTitle>
         </DialogHeader>
         <form
           onSubmit={form.handleSubmit(onSubmit)}
@@ -262,7 +286,7 @@ export function BookingDialog({ open, onOpenChange, booking, onSuccess }: Bookin
             </Button>
             <Button type="submit" size="sm" disabled={isSubmitting}>
               {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {isEditing ? dialogMessages.saveChanges : dialogMessages.create}
+              {dialogMessages.saveChanges}
             </Button>
           </DialogFooter>
         </form>

--- a/templates/dmc/src/components/voyant/bookings/booking-list.tsx
+++ b/templates/dmc/src/components/voyant/bookings/booking-list.tsx
@@ -6,7 +6,7 @@ import {
   useBookings,
 } from "@voyantjs/bookings-react"
 import { formatMessage } from "@voyantjs/voyant-admin"
-import { Plus, Search, Zap } from "lucide-react"
+import { Plus, Search } from "lucide-react"
 import * as React from "react"
 
 import { Badge } from "@/components/ui/badge"
@@ -24,7 +24,6 @@ import {
 import { useAdminMessages } from "@/lib/admin-i18n"
 
 import { BookingDialog } from "./booking-dialog"
-import { QuickBookDialog } from "./quick-book-dialog"
 
 export interface BookingListProps {
   pageSize?: number
@@ -61,7 +60,6 @@ export function BookingList({ pageSize = 25, onSelectBooking }: BookingListProps
   const [search, setSearch] = React.useState("")
   const [offset, setOffset] = React.useState(0)
   const [dialogOpen, setDialogOpen] = React.useState(false)
-  const [quickBookOpen, setQuickBookOpen] = React.useState(false)
   const [editing, setEditing] = React.useState<BookingRecord | undefined>(undefined)
 
   const { data, isPending, isError } = useBookings({
@@ -100,10 +98,6 @@ export function BookingList({ pageSize = 25, onSelectBooking }: BookingListProps
           />
         </div>
         <div className="flex items-center gap-2">
-          <Button variant="outline" onClick={() => setQuickBookOpen(true)}>
-            <Zap className="mr-2 size-4" />
-            {bookingMessages.quickBook}
-          </Button>
           <Button
             onClick={() => {
               setEditing(undefined)
@@ -212,14 +206,6 @@ export function BookingList({ pageSize = 25, onSelectBooking }: BookingListProps
         onOpenChange={setDialogOpen}
         booking={editing}
         onSuccess={(booking) => {
-          onSelectBooking?.(booking)
-        }}
-      />
-
-      <QuickBookDialog
-        open={quickBookOpen}
-        onOpenChange={setQuickBookOpen}
-        onCreated={(booking) => {
           onSelectBooking?.(booking)
         }}
       />

--- a/templates/operator/src/components/voyant/bookings/booking-create-dialog.tsx
+++ b/templates/operator/src/components/voyant/bookings/booking-create-dialog.tsx
@@ -31,6 +31,7 @@ import {
   SelectValue,
   Textarea,
 } from "@/components/ui"
+import { useAdminMessages } from "@/lib/admin-i18n"
 
 import {
   emptyPassengerListValue,
@@ -74,6 +75,12 @@ function generateBookingNumber(): string {
   return `BK-${y}${m}-${seq}`
 }
 
+/**
+ * Convert a PaymentScheduleValue (section's UI shape) to the rows the
+ * `/quick-create` endpoint expects. Returns an empty array for `unpaid` —
+ * the orchestrator treats a zero-length paymentSchedules as "operator will
+ * invoice manually."
+ */
 function paymentScheduleToRows(
   value: PaymentScheduleValue,
   currency: string,
@@ -145,7 +152,7 @@ function passengersToRows(value: PassengerListValue): QuickCreateTravelerInput[]
     firstName: p.firstName.trim(),
     lastName: p.lastName.trim(),
     email: p.email.trim() || null,
-    participantType: "traveler",
+    participantType: p.role === "lead" || p.role === "adult" ? "traveler" : "traveler",
     travelerCategory:
       p.role === "child"
         ? "child"
@@ -159,7 +166,7 @@ function passengersToRows(value: PassengerListValue): QuickCreateTravelerInput[]
   }))
 }
 
-export interface QuickBookDialogProps {
+export interface BookingCreateDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   onCreated?: (booking: BookingRecord) => void
@@ -167,22 +174,13 @@ export interface QuickBookDialogProps {
   defaultProductId?: string
 }
 
-/**
- * Default operator quick-book dialog. Composes the booking-create picker
- * sections — product, departure, rooms, person, shared-room, passengers,
- * price breakdown, voucher, payment schedule — and submits via the atomic
- * `POST /v1/bookings/quick-create` endpoint so partial failures can't leave
- * orphan state.
- *
- * Apps that need a custom flow can install the sections individually and
- * assemble their own dialog instead of forking this file.
- */
-export function QuickBookDialog({
+export function BookingCreateDialog({
   open,
   onOpenChange,
   onCreated,
   defaultProductId,
-}: QuickBookDialogProps) {
+}: BookingCreateDialogProps) {
+  const messages = useAdminMessages().bookings.create
   const [product, setProduct] = React.useState<ProductPickerValue>({
     productId: defaultProductId ?? "",
     optionId: null,
@@ -196,13 +194,9 @@ export function QuickBookDialog({
   const [paymentSchedule, setPaymentSchedule] =
     React.useState<PaymentScheduleValue>(emptyPaymentScheduleValue)
   const [notes, setNotes] = React.useState("")
-  /**
-   * Optional post-create transition: set status to `confirmed` right after
-   * create succeeds. When the parent app has the notifications module's
-   * `autoConfirmAndDispatch` enabled, this fires the doc bundle + traveler
-   * email via the `booking.confirmed` subscriber. When it isn't, the
-   * booking simply lands in `confirmed` instead of `draft`.
-   */
+  // Post-create: confirm + fire auto-dispatch. The operator template wires
+  // `autoConfirmAndDispatch` on the notifications module so a booking.confirmed
+  // transition auto-sends the doc bundle — no separate notify call needed.
   const [confirmAfterCreate, setConfirmAfterCreate] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
 
@@ -262,6 +256,11 @@ export function QuickBookDialog({
     return `${date}${remaining}`
   }, [])
 
+  // Passenger room-assignment options. The capacity ceiling is
+  // `rooms[unit] × occupancyMax` seats; we subtract the count of passengers
+  // already assigned to each unit so the per-unit selector in the passenger
+  // row can disable full rooms. occupancyMax defaults to 1 when the unit
+  // definition doesn't carry it.
   const slotUnitAvailability = useSlotUnitAvailability({
     slotId: slotId ?? undefined,
     enabled: open && Boolean(slotId),
@@ -286,9 +285,9 @@ export function QuickBookDialog({
       })
   }, [slotUnitAvailability.data, rooms.quantities, passengers.passengers])
 
-  // Currency placeholder — used for voucher + payment schedule display.
-  // Consumers hooking in real product data should override this by wrapping
-  // the component or swapping in their own currency-aware hook.
+  // Currency for voucher + payment schedule display. Defaults to EUR for the
+  // first-cut composition; follow-up wires it from the product's sell
+  // currency (usePricingPreview snapshot already carries catalog.currencyCode).
   const currency = "EUR"
 
   const { create: createPerson } = usePersonMutation()
@@ -299,7 +298,7 @@ export function QuickBookDialog({
     setError(null)
 
     if (!product.productId) {
-      setError("Select a product")
+      setError(messages.errorSelectProduct)
       return
     }
 
@@ -307,13 +306,13 @@ export function QuickBookDialog({
     try {
       if (person.mode === "existing") {
         if (!person.personId) {
-          setError("Select a person or switch to create mode")
+          setError(messages.errorSelectPerson)
           return
         }
         resolvedPersonId = person.personId
       } else {
         if (!person.newPerson.firstName.trim() || !person.newPerson.lastName.trim()) {
-          setError("First and last name are required")
+          setError(messages.errorNameRequired)
           return
         }
         const created = await createPerson.mutateAsync({
@@ -325,13 +324,19 @@ export function QuickBookDialog({
         resolvedPersonId = created.id
       }
 
+      // Validate shared-room selection before creating the booking so we don't
+      // leave an orphan booking if the user picked "join" without a group.
       if (sharedRoom.enabled && sharedRoom.mode === "join" && !sharedRoom.groupId) {
-        setError("Select a shared-room group to join")
+        setError(messages.errorSelectSharedRoom)
         return
       }
 
       const bookingNumber = generateBookingNumber()
 
+      // Total is unknown client-side for now — the price breakdown section
+      // computes it but doesn't bubble it up. We pass null to paymentSchedule
+      // rows so "full" and "advance+balance" only emit when the operator
+      // typed amounts explicitly.
       const paymentSchedules = paymentScheduleToRows(paymentSchedule, currency, null)
 
       const travelers = passengersToRows(passengers)
@@ -372,11 +377,11 @@ export function QuickBookDialog({
         groupMembership,
       })
 
-      // Optional post-create confirm. If the app has autoConfirmAndDispatch
-      // wired on the notifications module, the status transition triggers
-      // the doc bundle + traveler email subscriber. A failed status change
-      // doesn't roll back the booking — it exists, operator can confirm
-      // manually later.
+      // Optional post-create: transition to confirmed. In operator's app.ts
+      // the notifications module has autoConfirmAndDispatch enabled, so this
+      // status change automatically triggers the doc bundle + traveler email
+      // via the booking.confirmed subscriber. If the status call fails we
+      // don't roll back — the booking exists, the operator can confirm later.
       let finalBooking = booking
       if (confirmAfterCreate) {
         try {
@@ -388,8 +393,10 @@ export function QuickBookDialog({
           setError(
             statusErr instanceof Error
               ? `Booking created but confirm failed: ${statusErr.message}`
-              : "Booking created but confirm failed",
+              : messages.errorCreateFailed,
           )
+          // Still fire onCreated so the parent closes & refreshes — the
+          // booking did land, only the confirm step tripped.
           onCreated?.(booking)
           return
         }
@@ -398,18 +405,54 @@ export function QuickBookDialog({
       onOpenChange(false)
       onCreated?.(finalBooking)
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to create booking")
+      setError(err instanceof Error ? err.message : messages.errorCreateFailed)
     }
   }
 
   const isSubmitting =
     quickCreateMutation.isPending || createPerson.isPending || statusMutation.isPending
 
+  const productLabels = {
+    product: messages.productLabel,
+    productSearchPlaceholder: messages.productSearchPlaceholder,
+    productSelectPlaceholder: messages.productSelectPlaceholder,
+    option: messages.optionLabel,
+    optionNone: messages.optionNone,
+  }
+
+  const personLabels = {
+    person: messages.personLabel,
+    createNewPerson: messages.createNewPerson,
+    selectExistingPerson: messages.selectExistingPerson,
+    personSearchPlaceholder: messages.personSearchPlaceholder,
+    personSelectPlaceholder: messages.personSelectPlaceholder,
+    firstName: messages.firstNameLabel,
+    firstNamePlaceholder: messages.firstNamePlaceholder,
+    lastName: messages.lastNameLabel,
+    lastNamePlaceholder: messages.lastNamePlaceholder,
+    email: messages.emailLabel,
+    emailPlaceholder: messages.emailPlaceholder,
+    phone: messages.phoneLabel,
+    phonePlaceholder: messages.phonePlaceholder,
+    organization: messages.organizationLabel,
+    organizationSearchPlaceholder: messages.organizationSearchPlaceholder,
+    organizationNone: messages.organizationNone,
+  }
+
+  const sharedRoomLabels = {
+    toggle: messages.sharedRoomLabel,
+    createMode: messages.sharedRoomCreate,
+    joinMode: messages.sharedRoomJoin,
+    selectPlaceholder: messages.sharedRoomSelectPlaceholder,
+    noGroups: messages.sharedRoomNoGroups,
+    createHint: messages.sharedRoomCreateHint,
+  }
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent size="lg">
         <DialogHeader>
-          <DialogTitle>Quick Book</DialogTitle>
+          <DialogTitle>{messages.title}</DialogTitle>
         </DialogHeader>
         <DialogBody className="grid gap-4">
           <ProductPickerSection
@@ -417,23 +460,24 @@ export function QuickBookDialog({
             onChange={setProduct}
             enabled={open}
             lockProduct={Boolean(defaultProductId)}
+            labels={productLabels}
           />
 
           {product.productId ? (
             <div className="flex flex-col gap-1">
-              <Label>Departure</Label>
+              <Label>{messages.departureLabel}</Label>
               <Select
                 value={slotId ?? "__none__"}
                 onValueChange={(v) => setSlotId(v === "__none__" ? null : (v ?? null))}
               >
                 <SelectTrigger>
-                  <SelectValue placeholder="Select a departure..." />
+                  <SelectValue placeholder={messages.departureSelectPlaceholder} />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="__none__">No specific departure</SelectItem>
+                  <SelectItem value="__none__">{messages.departureNone}</SelectItem>
                   {slots.length === 0 ? (
                     <SelectItem value="__empty__" disabled>
-                      No open departures for this product
+                      {messages.departureEmpty}
                     </SelectItem>
                   ) : (
                     slots.map((slot) => (
@@ -451,13 +495,19 @@ export function QuickBookDialog({
             <RoomsStepperSection value={rooms} onChange={setRooms} slotId={slotId} enabled={open} />
           ) : null}
 
-          <PersonPickerSection value={person} onChange={setPerson} enabled={open} />
+          <PersonPickerSection
+            value={person}
+            onChange={setPerson}
+            enabled={open}
+            labels={personLabels}
+          />
 
           <SharedRoomSection
             value={sharedRoom}
             onChange={setSharedRoom}
             productId={product.productId || undefined}
             enabled={open}
+            labels={sharedRoomLabels}
           />
 
           {product.productId ? (
@@ -485,11 +535,11 @@ export function QuickBookDialog({
           />
 
           <div className="flex flex-col gap-2">
-            <Label>Internal Notes</Label>
+            <Label>{messages.notesLabel}</Label>
             <Textarea
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
-              placeholder="Quick context for this booking..."
+              placeholder={messages.notesPlaceholder}
             />
           </div>
 
@@ -502,13 +552,9 @@ export function QuickBookDialog({
             />
             <div className="flex flex-col gap-1">
               <Label htmlFor="quickbook-confirm-after-create" className="cursor-pointer text-sm">
-                Confirm & notify traveler after creating
+                {messages.confirmAfterCreateLabel}
               </Label>
-              <p className="text-xs text-muted-foreground">
-                Transitions to confirmed after create. When the notifications module's auto-dispatch
-                is on, this fires the doc bundle + traveler email via the booking.confirmed
-                subscriber.
-              </p>
+              <p className="text-xs text-muted-foreground">{messages.confirmAfterCreateHint}</p>
             </div>
           </div>
 
@@ -522,7 +568,7 @@ export function QuickBookDialog({
             onClick={() => onOpenChange(false)}
             disabled={isSubmitting}
           >
-            Cancel
+            {messages.cancel}
           </Button>
           <Button
             type="button"
@@ -531,7 +577,7 @@ export function QuickBookDialog({
             disabled={isSubmitting || !product.productId}
           >
             {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            Create Draft Booking
+            {messages.create}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/templates/operator/src/components/voyant/bookings/booking-dialog.tsx
+++ b/templates/operator/src/components/voyant/bookings/booking-dialog.tsx
@@ -28,7 +28,7 @@ import { DateRangePicker } from "@/components/ui/date-picker"
 import { useAdminMessages } from "@/lib/admin-i18n"
 import { zodResolver } from "@/lib/zod-resolver"
 
-import { QuickBookDialog } from "./quick-book-dialog"
+import { BookingCreateDialog } from "./booking-create-dialog"
 
 type BookingDialogMessages = ReturnType<typeof useAdminMessages>["bookings"]["dialog"]
 
@@ -64,13 +64,13 @@ export interface BookingDialogProps {
 /**
  * Single booking dialog that handles both create and edit:
  * - Create (no `booking` prop): renders the rich product → option → person
- *   picker flow via `QuickBookDialog`, so the draft booking inherits pricing,
+ *   picker flow via `BookingCreateDialog`, so the draft booking inherits pricing,
  *   dates, and currency from the catalogue instead of being hand-entered.
  * - Edit (with `booking` prop): renders the flat form that patches the
  *   existing row's metadata (status, amounts, dates, notes).
  *
  * The two modes used to live in separate `BookingDialog` and
- * `QuickBookDialog` CTAs. Once a real catalogue was loaded, the flat create
+ * `BookingCreateDialog` CTAs. Once a real catalogue was loaded, the flat create
  * form orphaned bookings from the catalog and always lost to Quick Book —
  * #222 collapses them so the template ships a single create entry point.
  */
@@ -83,7 +83,7 @@ export function BookingDialog({
 }: BookingDialogProps) {
   if (!booking) {
     return (
-      <QuickBookDialog
+      <BookingCreateDialog
         open={open}
         onOpenChange={onOpenChange}
         defaultProductId={defaultProductId}

--- a/templates/operator/src/components/voyant/products/product-detail-page.tsx
+++ b/templates/operator/src/components/voyant/products/product-detail-page.tsx
@@ -38,7 +38,7 @@ export function ProductDetailPage({ id }: { id: string }) {
   const queryClient = useQueryClient()
 
   const [editOpen, setEditOpen] = useState(false)
-  const [quickBookOpen, setQuickBookOpen] = useState(false)
+  const [bookingCreateOpen, setBookingCreateOpen] = useState(false)
   const [departureDialogOpen, setDepartureDialogOpen] = useState(false)
   const [editingDeparture, setEditingDeparture] = useState<DepartureSlot | undefined>()
   const [scheduleDialogOpen, setScheduleDialogOpen] = useState(false)
@@ -165,7 +165,7 @@ export function ProductDetailPage({ id }: { id: string }) {
         product={product}
         isDeleting={deleteMutation.isPending}
         onEdit={() => setEditOpen(true)}
-        onAddBooking={() => setQuickBookOpen(true)}
+        onAddBooking={() => setBookingCreateOpen(true)}
         onDelete={() => {
           if (confirm(productMessages.deleteConfirm)) {
             deleteMutation.mutate()
@@ -255,11 +255,11 @@ export function ProductDetailPage({ id }: { id: string }) {
 
       {/* Dialogs */}
       <BookingDialog
-        open={quickBookOpen}
-        onOpenChange={setQuickBookOpen}
+        open={bookingCreateOpen}
+        onOpenChange={setBookingCreateOpen}
         defaultProductId={id}
         onSuccess={(booking) => {
-          setQuickBookOpen(false)
+          setBookingCreateOpen(false)
           void navigate({ to: "/bookings/$id", params: { id: booking.id } })
         }}
       />


### PR DESCRIPTION
Quick Book was a legacy label from when this dialog was a lightweight alternative to a flat-form create. Now that it IS the booking-create workflow (9 composed picker sections, atomic /quick-create submit), keeping the 'Quick' name is actively misleading — operators see two CTAs ("Quick Book" + "New Booking") and have no idea which is canonical.

## Changes
- **Symbol/file rename**: `QuickBookDialog` → `BookingCreateDialog`, `quick-book-dialog.tsx` → `booking-create-dialog.tsx`, in registry + both templates (git mv so history follows)
- **Consolidated booking-list CTAs**: registry + dmc booking-list.tsx no longer render two dialog instances (`dialogOpen` + `quickBookOpen`). A single `BookingDialog` handles both modes via its `booking` prop — no prop = create, prop = edit. "Quick Book" button + the `Zap` icon import gone.
- **dmc BookingDialog upgraded** to the same wrap-around pattern operator uses: create branch delegates to `BookingCreateDialog` (composed picker flow), edit branch renders the flat form. Previously dmc had no such delegation — the flat form did both. This is a net upgrade: dmc now gets the composed create flow for free.
- **i18n**: `bookings.list.quickBook` label removed; `bookings.quickBook` namespace renamed to `bookings.create` (en + ro preserved parity)
- **Registry JSON**: `voyant-bookings-quick-book-dialog` → `voyant-bookings-booking-create-dialog` (name, path, target); `voyant-bookings-booking-dialog` now declares the create dialog as a registry dep so `shadcn add voyant-bookings-booking-dialog` pulls it in automatically

## Architecture after
- `BookingDialog` — front door, used everywhere (booking list, product detail, booking detail). Wraps both modes.
- `BookingCreateDialog` — internal-ish create workflow, 9 composed sections. Consumers can install directly for bespoke flows, but `BookingDialog` is the default entry point.

## Test plan
- [x] Typecheck clean on i18n, operator, dmc
- [x] No residual `QuickBook` identifiers, `quickBook` i18n keys, or `quick-book` paths anywhere outside CHANGELOGs
- [ ] Manual in operator: booking list "+ New Booking" opens the composed create dialog; clicking a row opens the flat edit dialog; product detail "Add booking" opens the composed create dialog pre-seeded with that product