### PR TITLE
chore: release changeset for QuickBookDialog rename

### DIFF
--- a/.changeset/rename-quickbook-to-booking-create.md
+++ b/.changeset/rename-quickbook-to-booking-create.md
@@ -1,0 +1,16 @@
+---
+"@voyantjs/bookings-react": minor
+---
+
+**Rename**: `QuickBookDialog` → `BookingCreateDialog` across the registry, operator, and dmc templates. The dialog was originally a lightweight create alternative to a flat-form CTA, but since the composition slice landed (#264 — product / departure / rooms / person / shared-room / passengers / price breakdown / voucher / payment schedule all wired through the atomic `/quick-create` endpoint) it IS the booking-create workflow. Keeping "Quick Book" in the name actively misled operators.
+
+**Bumped via this changeset but not code-changed on npm**: this package is on the fixed release train with everything else, so it ships the version bump alongside the others. The actual rename lives in `@voyantjs/voyant-ui` (registry, in the ignore list), `@voyantjs/i18n` (private), and the templates — consumers see the effect via fresh starter archives (`voyant new`) or the next `shadcn add`.
+
+Breaking for consumers who copied the registry component earlier:
+- `QuickBookDialog` → `BookingCreateDialog` (symbol)
+- `quick-book-dialog.tsx` → `booking-create-dialog.tsx` (file path)
+- Registry entry `voyant-bookings-quick-book-dialog` → `voyant-bookings-booking-create-dialog`
+- i18n namespace `bookings.quickBook` → `bookings.create`; `bookings.list.quickBook` removed (booking list now has a single "+ New Booking" CTA)
+- `BookingDialog` now declares `voyant-bookings-booking-create-dialog` as a registry dep, so `shadcn add voyant-bookings-booking-dialog` pulls both in automatically
+
+Consumers who migrated the files locally can drop the old `QuickBookDialog` copy and regenerate via the registry, or run the equivalent of `grep -rl 'QuickBookDialog\|quick-book-dialog\|bookings\\.quickBook' | xargs sed -i ''` on their app.


### PR DESCRIPTION
Bundles PR #276 into a minor bump on the fixed train (currently 0.8.0 → 0.9.0).

No publishable package's code changed — the rename lives in `@voyantjs/voyant-ui` (on the ignore list), `@voyantjs/i18n` (private), and templates. The bump value:

- **Starter archives**: the next GitHub release ships templates with the rename, so `voyant new` picks them up
- **Registry host rebuild**: the `apps/registry` Cloudflare Worker serves the renamed `voyant-bookings-booking-create-dialog` entry; `shadcn add` fetches the new path
- **Changelog**: consumers who previously copied `QuickBookDialog` see the breaking rename surfaced on `@voyantjs/bookings-react`'s changelog (closest conceptual home)

After merge, the Release workflow opens "chore: release packages" as usual.