### PR TITLE
feat(bookings): introduce explicit state machine + transition guards (#281)

### DIFF
--- a/packages/bookings/src/index.ts
+++ b/packages/bookings/src/index.ts
@@ -25,6 +25,14 @@ export {
   type UpdateBookingGroupInput,
 } from "./service-groups.js"
 export {
+  BOOKING_TRANSITIONS,
+  type BookingStatus,
+  type BookingStatusPatch,
+  BookingTransitionError,
+  canTransitionBooking,
+  transitionBooking,
+} from "./state-machine.js"
+export {
   type ExpireStaleBookingHoldsInput,
   type ExpireStaleBookingHoldsResult,
   expireStaleBookingHolds,

--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -31,6 +31,12 @@ import {
 } from "./schema.js"
 import { cleanupGroupOnBookingCancelled } from "./service-groups.js"
 import {
+  type BookingStatus,
+  BookingTransitionError,
+  canTransitionBooking,
+  transitionBooking,
+} from "./state-machine.js"
+import {
   bookingTransactionDetailsRef,
   offerItemParticipantsRef,
   offerItemsRef,
@@ -590,22 +596,6 @@ async function getConvertProductData(
   }
 }
 
-type BookingStatus = (typeof bookings.$inferSelect)["status"]
-
-const VALID_BOOKING_TRANSITIONS: Record<BookingStatus, BookingStatus[]> = {
-  draft: ["on_hold", "confirmed", "cancelled"],
-  on_hold: ["confirmed", "expired", "cancelled"],
-  confirmed: ["in_progress", "cancelled"],
-  in_progress: ["completed", "cancelled"],
-  completed: [],
-  expired: [],
-  cancelled: [],
-}
-
-function isValidBookingTransition(from: BookingStatus, to: BookingStatus) {
-  return VALID_BOOKING_TRANSITIONS[from].includes(to)
-}
-
 function computeHoldExpiresAt(input: { holdMinutes?: number; holdExpiresAt?: string | null }) {
   if (input.holdExpiresAt) {
     return new Date(input.holdExpiresAt)
@@ -613,16 +603,6 @@ function computeHoldExpiresAt(input: { holdMinutes?: number; holdExpiresAt?: str
   const now = Date.now()
   const minutes = input.holdMinutes ?? 30
   return new Date(now + minutes * 60 * 1000)
-}
-
-function toBookingStatusTimestamps(status: BookingStatus) {
-  const now = new Date()
-  return {
-    confirmedAt: status === "confirmed" ? now : undefined,
-    expiredAt: status === "expired" ? now : undefined,
-    cancelledAt: status === "cancelled" ? now : undefined,
-    completedAt: status === "completed" ? now : undefined,
-  }
 }
 
 async function lockAvailabilitySlot(db: PostgresJsDatabase, slotId: string) {
@@ -2162,19 +2142,25 @@ export const bookingsService = {
       return bookingsService.cancelBooking(db, id, { note: data.note }, userId, runtime)
     }
 
+    // `on_hold` is only reachable through `reserveBooking`, never via direct status PATCH.
     if (data.status === "on_hold") {
       return { status: "invalid_transition" as const }
     }
 
-    if (!isValidBookingTransition(current.status, data.status)) {
-      return { status: "invalid_transition" as const }
+    let patch: ReturnType<typeof transitionBooking>
+    try {
+      patch = transitionBooking(current.status, data.status)
+    } catch (error) {
+      if (error instanceof BookingTransitionError) {
+        return { status: "invalid_transition" as const }
+      }
+      throw error
     }
 
     const [row] = await db
       .update(bookings)
       .set({
-        status: data.status,
-        ...toBookingStatusTimestamps(data.status),
+        ...patch,
         updatedAt: new Date(),
       })
       .where(eq(bookings.id, id))
@@ -2230,12 +2216,17 @@ export const bookingsService = {
         if (!booking) {
           throw new BookingServiceError("not_found")
         }
+        if (!canTransitionBooking(booking.status, "confirmed")) {
+          throw new BookingServiceError("invalid_transition")
+        }
         if (booking.status !== "on_hold") {
           throw new BookingServiceError("invalid_transition")
         }
         if (booking.hold_expires_at && booking.hold_expires_at < new Date()) {
           throw new BookingServiceError("hold_expired")
         }
+
+        const patch = transitionBooking(booking.status, "confirmed")
 
         await tx
           .update(bookingAllocations)
@@ -2254,9 +2245,8 @@ export const bookingsService = {
         const [row] = await tx
           .update(bookings)
           .set({
-            status: "confirmed",
+            ...patch,
             holdExpiresAt: null,
-            confirmedAt: new Date(),
             updatedAt: new Date(),
           })
           .where(eq(bookings.id, id))
@@ -2402,9 +2392,14 @@ export const bookingsService = {
         if (!booking) {
           throw new BookingServiceError("not_found")
         }
+        if (!canTransitionBooking(booking.status, "expired")) {
+          throw new BookingServiceError("invalid_transition")
+        }
         if (booking.status !== "on_hold") {
           throw new BookingServiceError("invalid_transition")
         }
+
+        const patch = transitionBooking(booking.status, "expired")
 
         const allocations = await tx
           .select()
@@ -2432,9 +2427,8 @@ export const bookingsService = {
         const [row] = await tx
           .update(bookings)
           .set({
-            status: "expired",
+            ...patch,
             holdExpiresAt: null,
-            expiredAt: new Date(),
             updatedAt: new Date(),
           })
           .where(eq(bookings.id, id))
@@ -2544,10 +2538,11 @@ export const bookingsService = {
         if (!booking) {
           throw new BookingServiceError("not_found")
         }
-        if (!["draft", "on_hold", "confirmed", "in_progress"].includes(booking.status)) {
+        if (!canTransitionBooking(booking.status, "cancelled")) {
           throw new BookingServiceError("invalid_transition")
         }
 
+        const patch = transitionBooking(booking.status, "cancelled")
         const previousStatus = booking.status as BookingCancelledEvent["previousStatus"]
 
         const allocations = await tx
@@ -2593,9 +2588,8 @@ export const bookingsService = {
         const [row] = await tx
           .update(bookings)
           .set({
-            status: "cancelled",
+            ...patch,
             holdExpiresAt: null,
-            cancelledAt: new Date(),
             updatedAt: new Date(),
           })
           .where(eq(bookings.id, id))

--- a/packages/bookings/src/state-machine.ts
+++ b/packages/bookings/src/state-machine.ts
@@ -1,0 +1,57 @@
+import type { bookings } from "./schema-core.js"
+
+export type BookingStatus = (typeof bookings.$inferSelect)["status"]
+
+export const BOOKING_TRANSITIONS = {
+  draft: ["on_hold", "confirmed", "cancelled"],
+  on_hold: ["confirmed", "expired", "cancelled"],
+  confirmed: ["in_progress", "cancelled"],
+  in_progress: ["completed", "cancelled"],
+  completed: [],
+  expired: [],
+  cancelled: [],
+} as const satisfies Record<BookingStatus, readonly BookingStatus[]>
+
+export class BookingTransitionError extends Error {
+  readonly code = "INVALID_BOOKING_TRANSITION"
+
+  constructor(
+    readonly from: BookingStatus,
+    readonly to: BookingStatus,
+  ) {
+    super(`Illegal booking status transition: ${from} → ${to}`)
+    this.name = "BookingTransitionError"
+  }
+}
+
+export function canTransitionBooking(from: BookingStatus, to: BookingStatus): boolean {
+  return (BOOKING_TRANSITIONS[from] as readonly BookingStatus[]).includes(to)
+}
+
+export interface BookingStatusPatch {
+  status: BookingStatus
+  confirmedAt?: Date
+  expiredAt?: Date
+  cancelledAt?: Date
+  completedAt?: Date
+}
+
+export function transitionBooking(
+  from: BookingStatus,
+  to: BookingStatus,
+  opts: { now?: Date } = {},
+): BookingStatusPatch {
+  if (!canTransitionBooking(from, to)) {
+    throw new BookingTransitionError(from, to)
+  }
+
+  const now = opts.now ?? new Date()
+  const patch: BookingStatusPatch = { status: to }
+
+  if (to === "confirmed") patch.confirmedAt = now
+  if (to === "expired") patch.expiredAt = now
+  if (to === "cancelled") patch.cancelledAt = now
+  if (to === "completed") patch.completedAt = now
+
+  return patch
+}

--- a/packages/bookings/tests/unit/status-transitions.test.ts
+++ b/packages/bookings/tests/unit/status-transitions.test.ts
@@ -1,112 +1,125 @@
 import { describe, expect, it } from "vitest"
 
-/**
- * Unit tests for booking status transitions and number generation.
- */
+import {
+  BOOKING_TRANSITIONS,
+  type BookingStatus,
+  BookingTransitionError,
+  canTransitionBooking,
+  transitionBooking,
+} from "../../src/state-machine.js"
 
-type BookingStatus =
-  | "draft"
-  | "on_hold"
-  | "confirmed"
-  | "in_progress"
-  | "completed"
-  | "expired"
-  | "cancelled"
-
-const VALID_TRANSITIONS: Record<BookingStatus, BookingStatus[]> = {
-  draft: ["on_hold", "confirmed", "cancelled"],
-  on_hold: ["confirmed", "expired", "cancelled"],
-  confirmed: ["in_progress", "cancelled"],
-  in_progress: ["completed", "cancelled"],
-  completed: [],
-  expired: [],
-  cancelled: [],
-}
-
-function isValidTransition(from: BookingStatus, to: BookingStatus): boolean {
-  return VALID_TRANSITIONS[from].includes(to)
-}
+const ALL_STATUSES = Object.keys(BOOKING_TRANSITIONS) as BookingStatus[]
 
 function generateBookingNumber(prefix: string, sequence: number): string {
   const padded = String(sequence).padStart(6, "0")
   return `${prefix}-${padded}`
 }
 
-describe("Booking status transitions", () => {
-  describe("valid transitions", () => {
-    it("allows draft → on_hold", () => {
-      expect(isValidTransition("draft", "on_hold")).toBe(true)
-    })
+describe("BOOKING_TRANSITIONS — full matrix", () => {
+  for (const from of ALL_STATUSES) {
+    for (const to of ALL_STATUSES) {
+      const expected = (BOOKING_TRANSITIONS[from] as readonly BookingStatus[]).includes(to)
+      it(`${from} → ${to} is ${expected ? "allowed" : "rejected"}`, () => {
+        expect(canTransitionBooking(from, to)).toBe(expected)
+      })
+    }
+  }
+})
 
-    it("allows draft → confirmed", () => {
-      expect(isValidTransition("draft", "confirmed")).toBe(true)
-    })
-
-    it("allows draft → cancelled", () => {
-      expect(isValidTransition("draft", "cancelled")).toBe(true)
-    })
-
-    it("allows on_hold → confirmed", () => {
-      expect(isValidTransition("on_hold", "confirmed")).toBe(true)
-    })
-
-    it("allows on_hold → expired", () => {
-      expect(isValidTransition("on_hold", "expired")).toBe(true)
-    })
-
-    it("allows on_hold → cancelled", () => {
-      expect(isValidTransition("on_hold", "cancelled")).toBe(true)
-    })
-
-    it("allows confirmed → in_progress", () => {
-      expect(isValidTransition("confirmed", "in_progress")).toBe(true)
-    })
-
-    it("allows confirmed → cancelled", () => {
-      expect(isValidTransition("confirmed", "cancelled")).toBe(true)
-    })
-
-    it("allows in_progress → completed", () => {
-      expect(isValidTransition("in_progress", "completed")).toBe(true)
-    })
-
-    it("allows in_progress → cancelled", () => {
-      expect(isValidTransition("in_progress", "cancelled")).toBe(true)
-    })
+describe("BOOKING_TRANSITIONS — domain rules", () => {
+  it("allows the manual confirmed-booking flow (draft → confirmed without on_hold)", () => {
+    expect(canTransitionBooking("draft", "confirmed")).toBe(true)
   })
 
-  describe("invalid transitions", () => {
-    it("rejects draft → in_progress (must go through confirmed)", () => {
-      expect(isValidTransition("draft", "in_progress")).toBe(false)
-    })
+  it("requires confirmed before in_progress (no draft → in_progress)", () => {
+    expect(canTransitionBooking("draft", "in_progress")).toBe(false)
+    expect(canTransitionBooking("on_hold", "in_progress")).toBe(false)
+  })
 
-    it("rejects on_hold → completed", () => {
-      expect(isValidTransition("on_hold", "completed")).toBe(false)
-    })
+  it("requires in_progress before completed", () => {
+    expect(canTransitionBooking("draft", "completed")).toBe(false)
+    expect(canTransitionBooking("on_hold", "completed")).toBe(false)
+    expect(canTransitionBooking("confirmed", "completed")).toBe(false)
+  })
 
-    it("rejects draft → completed", () => {
-      expect(isValidTransition("draft", "completed")).toBe(false)
-    })
+  it("treats completed, cancelled, expired as terminal", () => {
+    for (const terminal of ["completed", "cancelled", "expired"] as const) {
+      for (const target of ALL_STATUSES) {
+        expect(canTransitionBooking(terminal, target)).toBe(false)
+      }
+    }
+  })
+})
 
-    it("rejects confirmed → completed (must go through in_progress)", () => {
-      expect(isValidTransition("confirmed", "completed")).toBe(false)
-    })
+describe("transitionBooking()", () => {
+  it("returns a patch with the new status", () => {
+    const patch = transitionBooking("on_hold", "confirmed")
+    expect(patch.status).toBe("confirmed")
+  })
 
-    it("rejects completed → any", () => {
-      expect(isValidTransition("completed", "draft")).toBe(false)
-      expect(isValidTransition("completed", "confirmed")).toBe(false)
-      expect(isValidTransition("completed", "cancelled")).toBe(false)
-    })
+  it("stamps confirmedAt when transitioning to confirmed", () => {
+    const now = new Date("2026-01-01T00:00:00Z")
+    const patch = transitionBooking("on_hold", "confirmed", { now })
+    expect(patch.confirmedAt).toEqual(now)
+    expect(patch.cancelledAt).toBeUndefined()
+    expect(patch.expiredAt).toBeUndefined()
+    expect(patch.completedAt).toBeUndefined()
+  })
 
-    it("rejects cancelled → any", () => {
-      expect(isValidTransition("cancelled", "draft")).toBe(false)
-      expect(isValidTransition("cancelled", "confirmed")).toBe(false)
-    })
+  it("stamps cancelledAt when transitioning to cancelled", () => {
+    const now = new Date("2026-01-01T00:00:00Z")
+    const patch = transitionBooking("confirmed", "cancelled", { now })
+    expect(patch.cancelledAt).toEqual(now)
+    expect(patch.confirmedAt).toBeUndefined()
+  })
 
-    it("rejects expired → any", () => {
-      expect(isValidTransition("expired", "draft")).toBe(false)
-      expect(isValidTransition("expired", "confirmed")).toBe(false)
-    })
+  it("stamps expiredAt when transitioning to expired", () => {
+    const now = new Date("2026-01-01T00:00:00Z")
+    const patch = transitionBooking("on_hold", "expired", { now })
+    expect(patch.expiredAt).toEqual(now)
+  })
+
+  it("stamps completedAt when transitioning to completed", () => {
+    const now = new Date("2026-01-01T00:00:00Z")
+    const patch = transitionBooking("in_progress", "completed", { now })
+    expect(patch.completedAt).toEqual(now)
+  })
+
+  it("does not stamp a timestamp when moving to in_progress (no dedicated column)", () => {
+    const patch = transitionBooking("confirmed", "in_progress")
+    expect(patch.confirmedAt).toBeUndefined()
+    expect(patch.cancelledAt).toBeUndefined()
+    expect(patch.expiredAt).toBeUndefined()
+    expect(patch.completedAt).toBeUndefined()
+  })
+
+  it("uses Date.now() when opts.now is omitted", () => {
+    const before = Date.now()
+    const patch = transitionBooking("on_hold", "confirmed")
+    const after = Date.now()
+    expect(patch.confirmedAt).toBeInstanceOf(Date)
+    const stampedAt = patch.confirmedAt?.getTime() ?? 0
+    expect(stampedAt).toBeGreaterThanOrEqual(before)
+    expect(stampedAt).toBeLessThanOrEqual(after)
+  })
+
+  it("throws BookingTransitionError for illegal moves", () => {
+    expect(() => transitionBooking("completed", "draft")).toThrow(BookingTransitionError)
+    expect(() => transitionBooking("draft", "completed")).toThrow(BookingTransitionError)
+  })
+
+  it("BookingTransitionError exposes from/to + a stable code", () => {
+    try {
+      transitionBooking("completed", "draft")
+      expect.unreachable("should have thrown")
+    } catch (err) {
+      expect(err).toBeInstanceOf(BookingTransitionError)
+      const e = err as BookingTransitionError
+      expect(e.from).toBe("completed")
+      expect(e.to).toBe("draft")
+      expect(e.code).toBe("INVALID_BOOKING_TRANSITION")
+      expect(e.message).toMatch(/completed.*draft/)
+    }
   })
 })
 


### PR DESCRIPTION
Closes #281.

## Summary

- Promotes the internal `VALID_BOOKING_TRANSITIONS` map out of `service.ts` into a dedicated `state-machine.ts` module exported from `@voyantjs/bookings`.
- Ships `BOOKING_TRANSITIONS`, `canTransitionBooking()`, `transitionBooking()`, and `BookingTransitionError`.
- Refactors `updateBookingStatus`, `confirmBooking`, `expireBooking`, and `cancelBooking` to route status mutations + timestamp stamping through the helper instead of duplicating the dance.
- Removes the legacy `toBookingStatusTimestamps` helper.

## Domain notes

The issue body referenced an 8-status enum including \`pending\` and \`redeemed\`. Both were already gone from `bookingStatusEnum` — `pending` lives on `supplierConfirmationStatusEnum` (a different field), and `redeemed` was correctly identified as a per-traveler check-in event living in `booking_redemption_events`, not a booking-level status.

The state machine reflects the actual 7 statuses + the agreed transition graph (see [memory](../tree/main#) — \`project_bookings_state_machine.md\` decision):

- \`draft → on_hold, confirmed, cancelled\`
- \`on_hold → confirmed, expired, cancelled\`
- \`confirmed → in_progress, cancelled\`
- \`in_progress → completed, cancelled\` (mid-trip cancellation = force-majeure / refund saga)
- \`completed\`, \`expired\`, \`cancelled\` are terminal

\`in_progress\` was added so day-2-of-7 isn't ambiguously \`confirmed\` or \`completed\`. Mid-trip cancellation policy differs from pre-departure cancellation, so the operational state warrants its own enum value.

## Test plan

- [x] \`pnpm -F @voyantjs/bookings test\` — 159 passed (full 7×7 transition matrix + patch shape + error behavior)
- [x] \`pnpm typecheck\` — 136/136 tasks green
- [x] Pre-commit lint + typecheck passed