### PR TITLE
chore(db): document schema discipline + soft-delete helper (#286)

### DIFF
--- a/docs/architecture/schema-discipline.md
+++ b/docs/architecture/schema-discipline.md
@@ -1,0 +1,99 @@
+# Schema discipline
+
+This document captures the rules that keep Voyant's per-module schemas
+shippable as independent packages.
+
+## The FK rule
+
+> **Intra-domain FKs are fine. Cross-domain FKs MUST go through a link table.**
+
+Concretely:
+
+- A reference between two tables defined in **the same package** uses
+  Drizzle's `.references(() => other.id, { onDelete: ... })` and creates a
+  real Postgres FK constraint.
+- A reference between two tables defined in **different packages** uses a
+  plain `text("foo_id")` column plus a `defineLink(...)` declaration at the
+  template level.
+
+### Why
+
+Each module is a separately publishable package. Cross-package
+`.references()` calls force schema co-installation: a consumer who
+installs `@voyantjs/ground` but not `@voyantjs/facilities` cannot create
+the `facility_id` foreign-key constraint that `ground.transport_pickups`
+declares. That breaks the module-as-a-package boundary.
+
+Links keep the wiring explicit at the template (deployment) layer:
+- The source package exports a `LinkableDefinition` (e.g.
+  `personLinkable`, `productLinkable`).
+- The template declares `defineLink(personLinkable, productLinkable)` in
+  `templates/<name>/src/links/`.
+- `voyant db sync-links` materialises a pivot table whose lifecycle is
+  owned by the template, not either feature module.
+
+### When you're adding a column
+
+1. Is the target table defined in the same package?
+   - **Yes.** Use `.references()`. Done.
+2. Is the column for an association the *template* manages, not the
+   module itself?
+   - **Yes.** Add `text("foo_id")` (indexed if appropriate), export a
+     `*Linkable` from each side, and call `defineLink(...)` in the
+     consuming template's `src/links/`.
+3. Is the column for a *required vertical extension* (e.g.
+   `booking_product_details.booking_id` → `bookings.id`)?
+   - In rare cases, this is allowed even cross-package because the
+     extension package depends on the parent (one-way) and is never used
+     without it. Document the exception in code with a comment.
+
+## Known violations (as of 2026-04-25)
+
+The audit below was produced by grepping `\.references\(.*=>.*\.id` across
+every `packages/*/src/schema*.ts` and `packages/*/src/schema/*.ts` file,
+then filtering to imports that cross package boundaries (excluding shared
+helpers like `@voyantjs/db/lib/typeid-column` and type-only imports of
+`KmsEnvelope`).
+
+Type-only imports (`import type { ... }`) and `relations(...)`-only
+references are excluded — they don't create FK constraints.
+
+| Source package | Target package (table) | File(s) | Count |
+|---|---|---|---|
+| `ground` | `facilities` (`facilities`) | `schema-dispatch.ts`, `schema-operations.ts`, `schema-operators.ts` | 7 |
+| `ground` | `identity` (`identity_addresses`) | `schema-dispatch.ts`, `schema-operations.ts` | 6 |
+| `hospitality` | `facilities` (`properties`) | `schema-bookings.ts`, `schema-inventory.ts`, `schema-operations.ts`, `schema-pricing.ts` | 11 |
+| `hospitality` | `bookings` (`booking_items`) | `schema-bookings.ts`, `schema-operations.ts` | 2 |
+| `suppliers` | `facilities` (`facilities`) | `schema.ts` | 2 |
+
+Each of these is a follow-up issue: convert the `.references()` call to a
+plain `text()` column + `defineLink()` at the template level. File issues
+per-package so the work parallelises.
+
+## Soft-delete discipline
+
+Tables that declare `deletedAt` are filtered automatically by
+`createCrudService(...)`'s `list` / `count` / `listAndCount` / `retrieve`
+methods. The default is "active rows only"; pass `includeDeleted: true`
+to opt back in (admin recycle bins, audit reports, reconciliation jobs).
+
+For ad-hoc queries that don't go through `createCrudService`, compose
+`whereActive(table)` from `@voyantjs/db/lifecycle` into the WHERE clause:
+
+```ts
+import { and, eq } from "drizzle-orm"
+import { whereActive } from "@voyantjs/db/lifecycle"
+
+await db
+  .select()
+  .from(bookings)
+  .where(and(eq(bookings.organizationId, orgId), whereActive(bookings)))
+```
+
+`whereActive(table)` returns `undefined` for tables without `deletedAt`,
+so `and(other, undefined)` collapses cleanly — the helper is safe to
+apply unconditionally.
+
+`hasSoftDelete(table)` is exported alongside for code paths that need to
+branch on whether soft-delete applies (e.g. when generating dynamic
+clauses).

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -87,6 +87,10 @@
         "types": "./dist/crud.d.ts",
         "import": "./dist/crud.js"
       },
+      "./lifecycle": {
+        "types": "./dist/lifecycle.d.ts",
+        "import": "./dist/lifecycle.js"
+      },
       "./links": {
         "types": "./dist/links.d.ts",
         "import": "./dist/links.js"

--- a/packages/db/src/crud.ts
+++ b/packages/db/src/crud.ts
@@ -1,4 +1,4 @@
-import { eq, getTableColumns, type SQL, sql } from "drizzle-orm"
+import { and, eq, getTableColumns, isNull, type SQL, sql } from "drizzle-orm"
 import type { AnyPgTable, PgColumn } from "drizzle-orm/pg-core"
 import type { z } from "zod"
 
@@ -33,6 +33,20 @@ export interface ListOptions {
    * `asc(table.column)` / `desc(table.column)` builders.
    */
   orderBy?: SQL | SQL[]
+  /**
+   * When the table has a `deletedAt` column, soft-deleted rows are filtered
+   * out by default. Pass `true` to include them — useful for admin recycle
+   * bins, audit reports, or background reconciliation jobs.
+   */
+  includeDeleted?: boolean
+}
+
+/**
+ * Options for retrieve-style lookups by id.
+ */
+export interface RetrieveOptions {
+  /** Include soft-deleted rows. Default: false. */
+  includeDeleted?: boolean
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: Drizzle generic inference breaks on TTable extends AnyPgTable — casts are isolated to the query-builder boundary
@@ -82,9 +96,22 @@ export function createCrudService<
   // db to AnyDb only at the Drizzle call site; return types stay strict.
   const asDb = (db: DrizzleClient): AnyDb => db
 
+  function activeFilter(): SQL | undefined {
+    return deletedAtColumn ? isNull(deletedAtColumn) : undefined
+  }
+
+  function composeWhere(opts: { where?: SQL; includeDeleted?: boolean }): SQL | undefined {
+    if (opts.includeDeleted) return opts.where
+    const active = activeFilter()
+    if (!active) return opts.where
+    if (!opts.where) return active
+    return and(opts.where, active)
+  }
+
   async function list(db: DrizzleClient, opts: ListOptions = {}): Promise<Row[]> {
     let query = asDb(db).select().from(table)
-    if (opts.where) query = query.where(opts.where)
+    const where = composeWhere(opts)
+    if (where) query = query.where(where)
     if (opts.orderBy) {
       const orders = Array.isArray(opts.orderBy) ? opts.orderBy : [opts.orderBy]
       query = query.orderBy(...orders)
@@ -95,9 +122,14 @@ export function createCrudService<
     return rows
   }
 
-  async function count(db: DrizzleClient, where?: SQL): Promise<number> {
+  async function count(
+    db: DrizzleClient,
+    where?: SQL,
+    opts: { includeDeleted?: boolean } = {},
+  ): Promise<number> {
     const base = asDb(db).select({ count: sql<number>`count(*)::int` }).from(table)
-    const rows = (where ? await base.where(where) : await base) as Array<{ count: number }>
+    const composed = composeWhere({ where, includeDeleted: opts.includeDeleted })
+    const rows = (composed ? await base.where(composed) : await base) as Array<{ count: number }>
     return rows[0]?.count ?? 0
   }
 
@@ -105,12 +137,20 @@ export function createCrudService<
     db: DrizzleClient,
     opts: ListOptions = {},
   ): Promise<{ data: Row[]; total: number }> {
-    const [data, total] = await Promise.all([list(db, opts), count(db, opts.where)])
+    const [data, total] = await Promise.all([
+      list(db, opts),
+      count(db, opts.where, { includeDeleted: opts.includeDeleted }),
+    ])
     return { data, total }
   }
 
-  async function retrieve(db: DrizzleClient, id: string): Promise<Row | null> {
-    const rows = (await asDb(db).select().from(table).where(eq(idColumn, id)).limit(1)) as Row[]
+  async function retrieve(
+    db: DrizzleClient,
+    id: string,
+    opts: RetrieveOptions = {},
+  ): Promise<Row | null> {
+    const where = composeWhere({ where: eq(idColumn, id), includeDeleted: opts.includeDeleted })
+    const rows = (await asDb(db).select().from(table).where(where).limit(1)) as Row[]
     return rows[0] ?? null
   }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -95,6 +95,7 @@ export const db = new Proxy({} as ReturnType<typeof createDbClient>, {
 // Re-export lib utilities
 export * from "./helpers"
 export * from "./lib"
+export * from "./lifecycle"
 // Re-export queries
 export * from "./queries"
 export * from "./types"

--- a/packages/db/src/lifecycle.ts
+++ b/packages/db/src/lifecycle.ts
@@ -1,0 +1,32 @@
+import { getTableColumns, isNull, type SQL } from "drizzle-orm"
+import type { AnyPgTable, PgColumn } from "drizzle-orm/pg-core"
+
+/**
+ * Returns true when the table declares a `deletedAt` column.
+ *
+ * Use this to branch in code paths that need to know whether a soft-delete
+ * filter applies (e.g. when composing dynamic WHERE clauses).
+ */
+export function hasSoftDelete(table: AnyPgTable): boolean {
+  const columns = getTableColumns(table) as Record<string, PgColumn>
+  return Boolean(columns.deletedAt)
+}
+
+/**
+ * Returns a `deletedAt IS NULL` predicate for tables that declare a
+ * `deletedAt` column. Returns `undefined` for tables without one, so callers
+ * can compose the result with `and(...)` without conditional branching:
+ *
+ * ```ts
+ * await db.select().from(bookings).where(and(eq(bookings.id, id), whereActive(bookings)))
+ * ```
+ *
+ * The naming is "active" rather than "not deleted" because the predicate
+ * filters to the active (non-tombstoned) rows. `and(undefined, x)` collapses
+ * to `x` in drizzle, so the helper is safe to apply unconditionally.
+ */
+export function whereActive(table: AnyPgTable): SQL | undefined {
+  const columns = getTableColumns(table) as Record<string, PgColumn>
+  const deletedAt = columns.deletedAt
+  return deletedAt ? isNull(deletedAt) : undefined
+}

--- a/packages/db/tests/integration/crud.test.ts
+++ b/packages/db/tests/integration/crud.test.ts
@@ -271,6 +271,75 @@ describe.skipIf(!DB_AVAILABLE)("createCrudService", () => {
     })
   })
 
+  describe("auto-filter on soft-deleted rows", () => {
+    it("excludes soft-deleted rows from list() by default", async () => {
+      const svc = createCrudService(crudItems)
+      await svc.create(db, { id: "a1", name: "Alive" })
+      await svc.create(db, { id: "a2", name: "Tombstoned" })
+      await svc.softDelete(db, "a2")
+
+      const rows = await svc.list(db)
+      expect(rows.map((r) => r.id)).toEqual(["a1"])
+    })
+
+    it("excludes soft-deleted rows from count() and listAndCount() by default", async () => {
+      const svc = createCrudService(crudItems)
+      await svc.create(db, { id: "b1", name: "A" })
+      await svc.create(db, { id: "b2", name: "B" })
+      await svc.create(db, { id: "b3", name: "C" })
+      await svc.softDelete(db, "b3")
+
+      expect(await svc.count(db)).toBe(2)
+      const { data, total } = await svc.listAndCount(db)
+      expect(data).toHaveLength(2)
+      expect(total).toBe(2)
+    })
+
+    it("excludes soft-deleted rows from retrieve() by default", async () => {
+      const svc = createCrudService(crudItems)
+      await svc.create(db, { id: "r1", name: "Alive" })
+      await svc.softDelete(db, "r1")
+      expect(await svc.retrieve(db, "r1")).toBeNull()
+    })
+
+    it("includes soft-deleted rows when includeDeleted: true", async () => {
+      const svc = createCrudService(crudItems)
+      await svc.create(db, { id: "i1", name: "Alive" })
+      await svc.create(db, { id: "i2", name: "Tombstoned" })
+      await svc.softDelete(db, "i2")
+
+      const rows = await svc.list(db, { includeDeleted: true, orderBy: asc(crudItems.id) })
+      expect(rows.map((r) => r.id)).toEqual(["i1", "i2"])
+
+      expect(await svc.count(db, undefined, { includeDeleted: true })).toBe(2)
+      const retrieved = await svc.retrieve(db, "i2", { includeDeleted: true })
+      expect(retrieved?.id).toBe("i2")
+
+      const { data, total } = await svc.listAndCount(db, { includeDeleted: true })
+      expect(data).toHaveLength(2)
+      expect(total).toBe(2)
+    })
+
+    it("composes user-supplied where clauses with the soft-delete filter", async () => {
+      const svc = createCrudService(crudItems)
+      await svc.create(db, { id: "c1", name: "Alive A", tag: "x" })
+      await svc.create(db, { id: "c2", name: "Tombstoned X", tag: "x" })
+      await svc.create(db, { id: "c3", name: "Alive B", tag: "y" })
+      await svc.softDelete(db, "c2")
+
+      const rows = await svc.list(db, { where: eq(crudItems.tag, "x") })
+      expect(rows.map((r) => r.id)).toEqual(["c1"])
+    })
+
+    it("on tables without deletedAt, list() behaviour is unchanged", async () => {
+      const svc = createCrudService(crudMinimal)
+      await svc.create(db, { id: "n1", label: "A" })
+      await svc.create(db, { id: "n2", label: "B" })
+      const rows = await svc.list(db)
+      expect(rows).toHaveLength(2)
+    })
+  })
+
   describe("composition", () => {
     it("supports spreading for custom service extensions", async () => {
       const crud = createCrudService(crudItems)

--- a/packages/db/tests/unit/lifecycle.test.ts
+++ b/packages/db/tests/unit/lifecycle.test.ts
@@ -1,0 +1,35 @@
+import { pgTable, text, timestamp } from "drizzle-orm/pg-core"
+import { describe, expect, it } from "vitest"
+
+import { hasSoftDelete, whereActive } from "../../src/lifecycle.js"
+
+const tableWithDeletedAt = pgTable("with_deleted_at", {
+  id: text("id").primaryKey(),
+  deletedAt: timestamp("deleted_at", { withTimezone: true }),
+})
+
+const tableWithoutDeletedAt = pgTable("without_deleted_at", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+})
+
+describe("hasSoftDelete()", () => {
+  it("returns true for tables with a deletedAt column", () => {
+    expect(hasSoftDelete(tableWithDeletedAt)).toBe(true)
+  })
+
+  it("returns false for tables without a deletedAt column", () => {
+    expect(hasSoftDelete(tableWithoutDeletedAt)).toBe(false)
+  })
+})
+
+describe("whereActive()", () => {
+  it("returns a SQL predicate for tables with deletedAt", () => {
+    const predicate = whereActive(tableWithDeletedAt)
+    expect(predicate).toBeDefined()
+  })
+
+  it("returns undefined for tables without deletedAt", () => {
+    expect(whereActive(tableWithoutDeletedAt)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Closes #286.

## Summary

- Codifies the FK rule in \`docs/architecture/schema-discipline.md\`: **intra-domain FKs are fine; cross-domain FKs MUST go through a link table.**
- Inventories current cross-domain \`.references()\` violations (\`ground → facilities/identity\`, \`hospitality → facilities/bookings\`, \`suppliers → facilities\`) so they can be filed as per-package follow-up issues.
- Adds \`@voyantjs/db/lifecycle\` with \`whereActive(table)\` and \`hasSoftDelete(table)\` helpers.
- \`createCrudService(...)\` now auto-filters soft-deleted rows from \`list\` / \`count\` / \`listAndCount\` / \`retrieve\` when the table has a \`deletedAt\` column. Opt back in via \`includeDeleted: true\`.

## Behaviour change note

Tables that have a \`deletedAt\` column will no longer return soft-deleted rows from \`createCrudService(...)\` defaults. Inspecting the codebase, no domain table currently uses soft-delete (only link tables do, and link operations don't go through CRUD), so the behaviour change has no current callers — but the helper is now in place for new modules. The CLI's module template (\`packages/cli/src/templates/module-files.ts\`) already generates a \`deletedAt\` column for new modules, so adoption is forward-looking.

## Test plan

- [x] \`pnpm -F @voyantjs/db test\` — 59 passed (5 new auto-filter integration cases + 4 lifecycle unit cases)
- [x] \`pnpm -F @voyantjs/db typecheck\`
- [x] Pre-commit lint + monorepo typecheck pass