### PR TITLE
docs(security): ADR-0001 single-tenant per deployment (#287)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,17 @@ Voyant keeps a strict boundary:
 - Core packages stay framework-agnostic even when first-party starters use React, TanStack Start, Hono, Better Auth, and Cloudflare Workers
 - Transport adapters stay thin and call shared domain services rather than owning business logic
 
+Architecture decisions live in [`docs/adr/`](./docs/adr/); domain
+conventions live in [`docs/architecture/`](./docs/architecture/).
+
+## Security model
+
+**One Postgres database + one runtime per organization.** Tenancy is
+enforced at the deployment boundary, not by in-process middleware. See
+[ADR-0001](./docs/adr/0001-tenant-scoping.md) for the full rationale,
+the alternatives considered, and the conditions under which the decision
+should be revisited.
+
 ## License
 
 Functional Source License, Version 1.1, Apache 2.0 Future License (`FSL-1.1-Apache-2.0`). See [LICENSE](./LICENSE).

--- a/docs/adr/0001-tenant-scoping.md
+++ b/docs/adr/0001-tenant-scoping.md
@@ -1,0 +1,129 @@
+# ADR-0001: Tenant scoping is enforced at the deployment boundary, not in-process
+
+- **Status:** Accepted (2026-04-25)
+- **Closes:** [#287](https://github.com/voyantjs/voyant/issues/287)
+
+## Context
+
+Voyant is a modular framework for travel-domain back-office software (DMC,
+operator, supplier, distribution). Every domain module — bookings,
+products, finance, transactions, etc. — runs against a single Postgres
+database and is mounted into a single Hono app at deploy time.
+
+Customers buy Voyant per organization. Voyant Cloud's commercial offering
+provisions **one Postgres database + one Worker (or one Node runtime)
+per customer organization**. Customers self-hosting Voyant own their own
+infra and run the same one-DB-per-org topology.
+
+There is no shared-tier today. There has never been one in the framework's
+history. There are no schema columns named `organizationId` whose purpose
+is to scope queries inside a domain module.
+
+The question this ADR answers is whether to harden the framework with
+defense-in-depth (mandatory in-process organization scoping at every
+domain query) or to formalise the deployment-boundary contract as the
+sole tenancy enforcement mechanism.
+
+## Decision
+
+**The deployment boundary IS the tenancy boundary.** Voyant does not ship
+in-process organization-scoping middleware, an org-scoped Drizzle proxy,
+or any query interceptor that auto-applies an `organizationId` filter.
+
+Concretely, this means:
+
+- No `requireOrgId` middleware in `@voyantjs/hono`.
+- No org-scoped wrapper around `createDbClient(...)`.
+- No `organizationId` parameter is threaded through the request context
+  for the purpose of filtering.
+- Domain modules MAY include an `organizationId` column for reporting
+  or grouping, but the framework does not enforce it at the query layer.
+
+When asked "how is one customer's data isolated from another customer's?"
+the answer is: **separate Postgres database, separate compute runtime.**
+Voyant Cloud's provisioning is the enforcement; customers self-hosting
+inherit the same model.
+
+## Consequences
+
+### Positive
+
+- **No per-query overhead.** Every domain module's read path stays exactly
+  one round-trip without an injected predicate.
+- **No confused-deputy class of bugs.** There is no shared schema where a
+  forgotten filter could leak across tenants — there's literally no
+  cross-tenant data in the same database to leak to.
+- **Deploy-time enforcement is hard to bypass accidentally.** A
+  misconfigured Worker can't accidentally read another customer's DB
+  unless someone hard-codes the wrong connection string.
+- **Module authors don't carry tenancy concerns.** A bookings package author
+  writes a list query and ships it; tenancy is somebody else's problem
+  (specifically: Voyant Cloud's provisioning, or the self-hoster's infra).
+
+### Negative
+
+- **No defense in depth.** If Voyant Cloud's provisioning is ever
+  misconfigured to point two customers at the same database, every
+  domain module is a vector. There is no in-process safety net.
+- **Self-hosters are on their own.** Customers running their own
+  deployment must understand that tenancy is not enforced by the
+  framework. A customer who tries to consolidate two organizations into
+  one DB to save costs has zero protection.
+- **Future shared-tier work would require a re-architecture.** If
+  Voyant ever adds a "shared starter tier" (multiple orgs in one DB),
+  every domain module would need to be audited for organization-scoping
+  and a middleware/proxy layer would need to be added. This is a real
+  cost; it was weighed and accepted.
+
+### Mitigations
+
+- **Provisioning audit.** Voyant Cloud's provisioning code MUST refuse
+  to issue a connection string that points two organizations at the same
+  database. This is a config-level invariant, not a code-level one.
+- **Documentation.** This ADR + the customer-facing security posture
+  doc are the disclosure mechanism for self-hosters.
+- **Revisit gate.** If a shared-tier feature is ever proposed, this ADR
+  must be revisited *before* that work starts, not after.
+
+## Alternatives considered
+
+### Alternative A: Defense-in-depth middleware
+
+Add a mandatory `requireOrgId` middleware that pre-filters every domain
+query on `organizationId`. Either via an org-scoped Drizzle proxy or a
+query interceptor.
+
+**Why rejected.** It imposes per-query cost on every domain module across
+the framework for a threat that doesn't exist in any current deployment
+topology. Adding it later (if a shared-tier ever ships) is feasible;
+ripping it out if it bloats every read path is harder. The current
+single-tenant deployment model is the actual product reality.
+
+If the threat model ever shifts (shared-tier, multi-org dashboards on a
+shared DB, etc.), this ADR is the place to mark superseded and the work
+to add Alternative A becomes the new baseline.
+
+### Alternative B: Hybrid (chosen)
+
+Formalise the deployment-boundary contract as the security model. Document
+that "single-tenant per deployment" is the explicit posture. Voyant
+Cloud's provisioning enforces it. CI / lint checks prevent accidental
+shared-DB configurations from landing in templates.
+
+This is the path taken.
+
+## How to apply this decision
+
+When you are tempted to thread `organizationId` through a query for the
+purpose of filtering by tenant, **stop and ask whether you're about to
+violate this ADR.** If your code's correctness depends on a filter that
+would only matter in a shared-tier deployment that doesn't exist, you're
+adding cost for no benefit.
+
+Fields named `organizationId` are fine as data — for example, "which
+organization owns this booking" within a single-tenant deployment, where
+the question is metadata, not isolation. The distinction is whether the
+column exists for **partitioning data across customers** (forbidden by
+this ADR — that's the deployment boundary's job) versus **labeling data
+within one customer's installation** (fine — purely an organizational
+concern of that customer's own model).

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "i18n:check": "tsx scripts/check-i18n-parity.ts",
     "verify:package-exports": "tsx scripts/verify-package-exports.ts",
     "verify:publish-tarballs": "node scripts/verify-package-tarballs.mjs",
+    "verify:tenant-scoping": "tsx scripts/check-tenant-scoping.ts",
     "prepare": "husky",
     "seed:operator": "pnpm -C apps/scripts seed:operator",
     "regen:routes": "tsx scripts/regen-route-tree.ts",

--- a/scripts/check-tenant-scoping.ts
+++ b/scripts/check-tenant-scoping.ts
@@ -1,0 +1,73 @@
+/**
+ * Enforces ADR-0001: tenant scoping is enforced at the deployment boundary,
+ * NOT by in-process middleware. Fails CI if forbidden patterns appear in
+ * framework code (`packages/`).
+ *
+ * Templates and apps may legitimately reference org-scoping concerns
+ * (e.g. for organisation-aware UI within a single-tenant deployment),
+ * so they're scoped out.
+ *
+ * If you intentionally introduce tenant-scoping middleware, you are
+ * proposing to revisit ADR-0001 — do that explicitly, not by adding
+ * to this allowlist.
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs"
+import { dirname, join, relative } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(__dirname, "..")
+const PACKAGES_DIR = join(ROOT, "packages")
+
+const FORBIDDEN_PATTERNS = [
+  /\brequireOrgId\b/,
+  /\borgScopedDb\b/,
+  /\bcreateOrgScopedDbClient\b/,
+  /\btenantScopedDb\b/,
+] as const
+
+const SKIP_DIRS = new Set(["node_modules", "dist", ".turbo", ".next", "coverage"])
+
+function* walkTs(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_DIRS.has(entry)) continue
+    const full = join(dir, entry)
+    const stats = statSync(full)
+    if (stats.isDirectory()) {
+      yield* walkTs(full)
+    } else if (stats.isFile() && /\.(ts|tsx)$/.test(entry)) {
+      yield full
+    }
+  }
+}
+
+const violations: Array<{ file: string; line: number; pattern: RegExp; text: string }> = []
+
+for (const file of walkTs(PACKAGES_DIR)) {
+  // Don't flag this checker file itself.
+  if (file === join(ROOT, "scripts", "check-tenant-scoping.ts")) continue
+  const lines = readFileSync(file, "utf-8").split("\n")
+  for (let i = 0; i < lines.length; i++) {
+    const text = lines[i] ?? ""
+    for (const pattern of FORBIDDEN_PATTERNS) {
+      if (pattern.test(text)) {
+        violations.push({ file: relative(ROOT, file), line: i + 1, pattern, text: text.trim() })
+      }
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error("ADR-0001 violation: in-process tenant-scoping symbols found in framework code.")
+  console.error("See docs/adr/0001-tenant-scoping.md for context.\n")
+  for (const v of violations) {
+    console.error(`  ${v.file}:${v.line} (matched ${v.pattern.source})`)
+    console.error(`    ${v.text}`)
+  }
+  console.error(
+    "\nIf you are proposing to revisit ADR-0001, do so explicitly in a follow-up ADR — do not add to this script's allowlist.",
+  )
+  process.exit(1)
+}
+
+console.log(`check-tenant-scoping: OK (scanned ${PACKAGES_DIR})`)


### PR DESCRIPTION
Closes #287.

## Summary

- Establishes \`docs/adr/\` and ships \`0001-tenant-scoping.md\` capturing Voyant's tenancy model: **one Postgres DB + one runtime per customer organization**, enforced by Voyant Cloud's provisioning. The framework does not ship in-process org-scoping middleware.
- Adds a security-model section to the README pointing at the ADR so customers and self-hosters can find the disclosure.
- Adds \`pnpm verify:tenant-scoping\` (\`scripts/check-tenant-scoping.ts\`) that fails CI if forbidden symbols (\`requireOrgId\` / \`orgScopedDb\` / \`tenantScopedDb\` / \`createOrgScopedDbClient\`) appear in framework code (\`packages/\`).

## Decision details

This is **option (b)** from the issue — formalize the deployment-boundary contract rather than add defense-in-depth middleware. The ADR documents what would force a revisit (specifically: a shared-tier feature appearing on the roadmap).

The \`verify:tenant-scoping\` allowlist is intentionally short. If a future contributor proposes adding a new tenant-scoping primitive, they must revisit ADR-0001 explicitly, not extend the script.

## Test plan

- [x] \`pnpm verify:tenant-scoping\` — clean, no violations
- [x] \`pnpm typecheck\` — green (script is standalone, doesn't change framework code)
- [x] Pre-commit lint passes