### PR TITLE
chore: remove stale Hatchet references in framework docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Voyant currently ships two first-party starters:
 
 | Starter | Purpose | Stack |
 | --- | --- | --- |
-| [`templates/dmc`](./templates/dmc/README.md) | Destination management company workflows | Cloudflare Workers, TanStack Start, Hono, Better Auth, Drizzle, Hatchet |
-| [`templates/operator`](./templates/operator/README.md) | Tour operator workflows | Cloudflare Workers, TanStack Start, Hono, Better Auth, Drizzle, Hatchet |
+| [`templates/dmc`](./templates/dmc/README.md) | Destination management company workflows | Cloudflare Workers, TanStack Start, Hono, Better Auth, Drizzle |
+| [`templates/operator`](./templates/operator/README.md) | Tour operator workflows | Cloudflare Workers, TanStack Start, Hono, Better Auth, Drizzle |
 
 ## What you get
 

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -69,8 +69,8 @@ export interface Subscription {
  *
  * Adapter examples:
  * - In-process (default, ships with core)
- * - Hatchet — emit enqueues a durable task
  * - Cloudflare Queues — edge-native
+ * - Postgres-backed durable queue — for refund-saga-grade durability
  *
  * Event naming convention: `<resource>.<pastTenseAction>` in dot-case.
  * Examples: `booking.created`, `quote.accepted`, `payment.received`.

--- a/packages/core/src/orchestration.ts
+++ b/packages/core/src/orchestration.ts
@@ -16,14 +16,10 @@ export interface JobOptions {
  * Abstract durable job runner interface. Implementations live in templates
  * or adapter packages; core never reaches for a specific runtime.
  *
- * Voyant uses Hatchet (`@hatchet-dev/typescript-sdk`) as the durable job
- * engine. This interface remains for the in-process `createWorkflow` async
- * step delegation — a Hatchet adapter can bridge enqueue/schedule calls to
- * the Hatchet API.
- *
- * Templates wire their chosen adapter into the shared app/runtime container as
- * `"jobs"`. Framework code that needs to kick off async work does so via
- * explicit runtime resolution such as
+ * Voyant Cloud chooses an edge or node runner per workflow step at deploy
+ * time. Templates wire their chosen adapter into the shared app/runtime
+ * container as `"jobs"`. Framework code that needs to kick off async work
+ * does so via explicit runtime resolution such as
  * `container.resolve<JobRunner>("jobs").enqueue(...)`.
  */
 export interface JobRunner {

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -16,7 +16,7 @@ import { createDbClient } from "@voyantjs/db"
 // Edge/Serverless (Cloudflare Workers) — Neon HTTP adapter
 const db = createDbClient(url)
 
-// Node.js (Hatchet worker, scripts) — Postgres.js adapter
+// Node.js (workers, scripts) — Postgres.js adapter
 const db = createDbClient(url, { adapter: "node" })
 ```
 


### PR DESCRIPTION
Drive-by cleanup. Templates moved off \`@hatchet-dev/typescript-sdk\` onto the in-house workflows orchestrator, but several doc strings and READMEs still claimed Hatchet was the durable job engine:

- \`README.md\` — DMC + operator template stack tables listed Hatchet
- \`packages/core/src/orchestration.ts\` — JobRunner doc
- \`packages/core/src/events.ts\` — adapter examples
- \`packages/db/README.md\` — Node adapter usage example

The historical migration plan in \`docs/architecture/workflows-monorepo-migration-plan.md\` is left intact as a record.

Spotted while triaging #281 / #286 / #287.

## Test plan

- [x] Pre-commit lint + monorepo typecheck pass