### PR TITLE
feat(distribution): add 'connect' channel kind

### DIFF
--- a/apps/dev/src/components/voyant/distribution/distribution-dialogs-commercial.tsx
+++ b/apps/dev/src/components/voyant/distribution/distribution-dialogs-commercial.tsx
@@ -36,7 +36,7 @@ import {
 
 const channelFormSchema = z.object({
   name: z.string().min(1, "Name is required"),
-  kind: z.enum(["direct", "affiliate", "ota", "reseller", "marketplace", "api_partner"]),
+  kind: z.enum(["direct", "affiliate", "ota", "reseller", "marketplace", "api_partner", "connect"]),
   status: z.enum(["active", "inactive", "pending", "archived"]),
   website: z.string().optional(),
   contactName: z.string().optional(),

--- a/packages/distribution-react/src/constants.ts
+++ b/packages/distribution-react/src/constants.ts
@@ -7,6 +7,7 @@ export const channelKindOptions = [
   { value: "reseller", label: "Reseller" },
   { value: "marketplace", label: "Marketplace" },
   { value: "api_partner", label: "API Partner" },
+  { value: "connect", label: "Connect" },
 ] as const
 
 export const channelStatusOptions = [

--- a/packages/distribution-react/src/hooks/use-channel-mutation.ts
+++ b/packages/distribution-react/src/hooks/use-channel-mutation.ts
@@ -6,12 +6,12 @@ import { z } from "zod"
 import { fetchWithValidation } from "../client.js"
 import { useVoyantDistributionContext } from "../provider.js"
 import { distributionQueryKeys } from "../query-keys.js"
-import { channelSingleResponse, successEnvelope } from "../schemas.js"
+import { channelKindSchema, channelSingleResponse, successEnvelope } from "../schemas.js"
 
 const channelInputSchema = z.object({
   name: z.string().min(1).max(255),
   description: z.string().nullable().optional(),
-  kind: z.enum(["direct", "affiliate", "ota", "reseller", "marketplace", "api_partner"]),
+  kind: channelKindSchema,
   status: z.enum(["active", "inactive", "pending", "archived"]).optional(),
   website: z.string().url().nullable().optional(),
   contactName: z.string().nullable().optional(),

--- a/packages/distribution-react/src/schemas.ts
+++ b/packages/distribution-react/src/schemas.ts
@@ -39,6 +39,7 @@ export const channelKindSchema = z.enum([
   "reseller",
   "marketplace",
   "api_partner",
+  "connect",
 ])
 
 export const channelStatusSchema = z.enum(["active", "inactive", "pending", "archived"])

--- a/packages/distribution/src/schema-shared.ts
+++ b/packages/distribution/src/schema-shared.ts
@@ -7,6 +7,7 @@ export const channelKindEnum = pgEnum("channel_kind", [
   "reseller",
   "marketplace",
   "api_partner",
+  "connect",
 ])
 
 export const channelStatusEnum = pgEnum("channel_status", [

--- a/packages/distribution/src/validation.ts
+++ b/packages/distribution/src/validation.ts
@@ -16,6 +16,7 @@ export const channelKindSchema = z.enum([
   "reseller",
   "marketplace",
   "api_partner",
+  "connect",
 ])
 export const channelStatusSchema = z.enum(["active", "inactive", "pending", "archived"])
 export const channelContractStatusSchema = z.enum(["draft", "active", "expired", "terminated"])

--- a/packages/i18n/src/admin/distribution-dmc.ts
+++ b/packages/i18n/src/admin/distribution-dmc.ts
@@ -66,6 +66,7 @@ const distributionEn = {
         reseller: "Reseller",
         marketplace: "Marketplace",
         api_partner: "API Partner",
+        connect: "Connect",
       },
       channelStatus: {
         active: "Active",
@@ -654,6 +655,7 @@ const distributionRo = {
         reseller: "Revanzator",
         marketplace: "Marketplace",
         api_partner: "Partener API",
+        connect: "Connect",
       },
       channelStatus: {
         active: "Activ",

--- a/packages/i18n/src/admin/settings-operator.ts
+++ b/packages/i18n/src/admin/settings-operator.ts
@@ -56,6 +56,7 @@ export const operatorAdminSettingsMessages = {
         kindReseller: "Reseller",
         kindMarketplace: "Marketplace",
         kindApiPartner: "API Partner",
+        kindConnect: "Connect",
       },
       productTypesPage: {
         title: "Product Types",
@@ -182,6 +183,7 @@ export const operatorAdminSettingsMessages = {
         kindReseller: "Revanzator",
         kindMarketplace: "Marketplace",
         kindApiPartner: "Partener API",
+        kindConnect: "Connect",
       },
       productTypesPage: {
         title: "Tipuri de produs",

--- a/packages/ui/registry/distribution/distribution-dialogs-commercial.tsx
+++ b/packages/ui/registry/distribution/distribution-dialogs-commercial.tsx
@@ -36,7 +36,7 @@ import {
 
 const channelFormSchema = z.object({
   name: z.string().min(1, "Name is required"),
-  kind: z.enum(["direct", "affiliate", "ota", "reseller", "marketplace", "api_partner"]),
+  kind: z.enum(["direct", "affiliate", "ota", "reseller", "marketplace", "api_partner", "connect"]),
   status: z.enum(["active", "inactive", "pending", "archived"]),
   website: z.string().optional(),
   contactName: z.string().optional(),

--- a/templates/dmc/src/components/voyant/distribution/distribution-dialogs-commercial.tsx
+++ b/templates/dmc/src/components/voyant/distribution/distribution-dialogs-commercial.tsx
@@ -38,7 +38,15 @@ import {
 function createChannelFormSchema(nameRequired: string) {
   return z.object({
     name: z.string().min(1, nameRequired),
-    kind: z.enum(["direct", "affiliate", "ota", "reseller", "marketplace", "api_partner"]),
+    kind: z.enum([
+      "direct",
+      "affiliate",
+      "ota",
+      "reseller",
+      "marketplace",
+      "api_partner",
+      "connect",
+    ]),
     status: z.enum(["active", "inactive", "pending", "archived"]),
     website: z.string().optional(),
     contactName: z.string().optional(),

--- a/templates/operator/src/components/voyant/settings/channels-page.tsx
+++ b/templates/operator/src/components/voyant/settings/channels-page.tsx
@@ -37,7 +37,15 @@ const PAGE_SIZE = 25
 function getChannelFormSchema(messages: AdminMessages) {
   return z.object({
     name: z.string().min(1, messages.settings.validationNameRequired).max(255),
-    kind: z.enum(["direct", "affiliate", "ota", "reseller", "marketplace", "api_partner"]),
+    kind: z.enum([
+      "direct",
+      "affiliate",
+      "ota",
+      "reseller",
+      "marketplace",
+      "api_partner",
+      "connect",
+    ]),
     status: z.enum(["active", "inactive", "pending", "archived"]),
     website: z
       .string()
@@ -80,6 +88,7 @@ export function ChannelsPage() {
     reseller: messages.settings.channelsPage.kindReseller,
     marketplace: messages.settings.channelsPage.kindMarketplace,
     api_partner: messages.settings.channelsPage.kindApiPartner,
+    connect: messages.settings.channelsPage.kindConnect,
   }
   const channelStatusLabels: Record<string, string> = {
     active: messages.settings.channelsPage.statusActive,
@@ -244,6 +253,7 @@ function ChannelSheet({
     { value: "reseller", label: messages.settings.channelsPage.kindReseller },
     { value: "marketplace", label: messages.settings.channelsPage.kindMarketplace },
     { value: "api_partner", label: messages.settings.channelsPage.kindApiPartner },
+    { value: "connect", label: messages.settings.channelsPage.kindConnect },
   ] as const
   const channelFormSchema = useMemo(() => getChannelFormSchema(messages), [messages])
 


### PR DESCRIPTION
Adds a \`connect\` value to \`channelKindEnum\` for partners running Voyant Connect (the inbound API integration surface — operators using Voyant infrastructure to publish into a third-party network). Distinguishes from \`api_partner\`, which is a generic third-party API integration without the Voyant Connect commercial relationship.

## Mirrors synchronised

- Schema + Zod: \`packages/distribution/src/{schema-shared,validation}.ts\`
- React: \`packages/distribution-react/src/{schemas,constants}.ts\`, \`hooks/use-channel-mutation.ts\` (now imports \`channelKindSchema\` instead of inlining)
- Registry source: \`packages/ui/registry/distribution/distribution-dialogs-commercial.tsx\`
- Templates + dev app: \`templates/{dmc,operator}\`, \`apps/dev\`
- i18n: \`packages/i18n/src/admin/{distribution-dmc,settings-operator}.ts\` (en + ro)

Registry JSON artifacts will be regenerated at the next \`pnpm registry:build\`.

## Test plan

- [x] \`pnpm typecheck\` — 136/136 (pre-commit hook passed)
- [x] \`pnpm i18n:check\` — clean