### PR TITLE
fix(hono): default actor to fail-closed, not 'staff' (#285)

### DIFF
--- a/.changeset/hono-actor-fail-closed.md
+++ b/.changeset/hono-actor-fail-closed.md
@@ -1,0 +1,14 @@
+---
+"@voyantjs/hono": major
+---
+
+**BREAKING:** `requireActor` middleware now returns `401 Unauthorized` when no actor is set on the request, instead of defaulting to `"staff"`.
+
+Earlier versions silently granted operator privileges to anonymous traffic if `requireAuth` was missing, misordered, or a route mounted before auth. The fail-open default has been replaced with fail-closed.
+
+**Migration:**
+
+- `requireAuth` now sets `actor: "staff"` explicitly on the core-owned API key path (`voy_` prefix), so server-to-server integrations behave the same.
+- Custom `auth.resolve` integrations that previously relied on the implicit `"staff"` fallback must now return an explicit `actor` from `resolve()`.
+- Anonymous requests on `/v1/admin/*` now return `401` instead of `200`. Anonymous requests on `/v1/public/*` continue to receive `actor: "customer"` via the `publicPaths` bypass when applicable, and `401` otherwise.
+- The differentiation between `401` (no actor) and `403` (actor not in the allowed list) is now reliable — earlier the no-actor path returned `403` for some surfaces and `200` for others.

--- a/packages/hono/src/middleware/auth.ts
+++ b/packages/hono/src/middleware/auth.ts
@@ -145,6 +145,10 @@ export function requireAuth<TBindings extends VoyantBindings>(
           scopes,
           callerType: "api_key",
           apiKeyId: row.id,
+          // Core-owned API keys (`voy_` prefix) are server-to-server credentials
+          // issued to operator staff. The actor stays explicit here so that
+          // `requireActor` doesn't have to default unset callers to "staff".
+          actor: "staff",
         })
 
         return next()

--- a/packages/hono/src/middleware/require-actor.ts
+++ b/packages/hono/src/middleware/require-actor.ts
@@ -14,9 +14,11 @@ import type { VoyantBindings, VoyantVariables } from "../types.js"
  * custom `auth.resolve` integration. Internal requests
  * (`isInternalRequest === true`) bypass the check.
  *
- * When the caller has no explicit actor, this middleware treats them as
- * `"staff"` to preserve backwards compatibility with existing deployments
- * that predate the actor concept.
+ * When the caller has no resolved actor, this middleware returns `401
+ * Unauthorized`. Earlier versions defaulted unset callers to `"staff"` for
+ * backwards compatibility, but that meant a misordered or missing auth
+ * middleware silently granted operator privileges to anonymous traffic.
+ * The default is now fail-closed.
  *
  * @example
  * app.use("/v1/admin/*", requireActor("staff"))
@@ -40,7 +42,10 @@ export function requireActor<TBindings extends VoyantBindings = VoyantBindings>(
       return next()
     }
 
-    const actor: Actor = c.get("actor") ?? "staff"
+    const actor = c.get("actor") as Actor | undefined
+    if (!actor) {
+      return c.json({ error: "Unauthorized: actor not resolved" }, 401)
+    }
     if (!allowSet.has(actor)) {
       return c.json({ error: "Forbidden: actor not permitted on this surface" }, 403)
     }

--- a/packages/hono/tests/unit/app-surfaces.test.ts
+++ b/packages/hono/tests/unit/app-surfaces.test.ts
@@ -115,10 +115,10 @@ describe("createApp surface mounting", () => {
     expect(res.status).toBe(200)
   })
 
-  it("treats missing actor as staff on admin surface", async () => {
+  it("returns 401 on /v1/admin/* when actor is unresolved", async () => {
     const app = build(undefined, [makeModule({ name: "things", admin: true })])
     const res = await app.request("/v1/admin/things/ping", {}, TEST_ENV, TEST_CTX)
-    expect(res.status).toBe(200)
+    expect(res.status).toBe(401)
   })
 
   it("supports a module exposing both admin and public routes", async () => {

--- a/packages/hono/tests/unit/require-actor.test.ts
+++ b/packages/hono/tests/unit/require-actor.test.ts
@@ -42,26 +42,42 @@ describe("requireActor", () => {
     expect(body.error).toMatch(/Forbidden/)
   })
 
-  it("treats a request with no actor as 'staff'", async () => {
+  it("returns 401 when no actor is set on a staff-only surface", async () => {
     const app = makeApp(() => {
-      // do not set actor
+      // do not set actor — auth middleware was missing or misordered
     })
     app.use("*", requireActor("staff"))
     app.get("/", (c) => c.json({ ok: true }))
 
     const res = await app.request("/")
-    expect(res.status).toBe(200)
+    expect(res.status).toBe(401)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toMatch(/Unauthorized/)
   })
 
-  it("rejects a request with no actor on a public-only surface", async () => {
+  it("returns 401 when no actor is set on a public-only surface", async () => {
     const app = makeApp(() => {
-      // do not set actor → defaults to "staff"
+      // do not set actor
     })
     app.use("*", requireActor("customer", "partner"))
     app.get("/", (c) => c.json({ ok: true }))
 
     const res = await app.request("/")
-    expect(res.status).toBe(403)
+    expect(res.status).toBe(401)
+  })
+
+  it("differentiates 401 (no actor) from 403 (wrong actor)", async () => {
+    const wrongActor = makeApp((c) => c.set("actor", "customer"))
+    wrongActor.use("*", requireActor("staff"))
+    wrongActor.get("/", (c) => c.json({ ok: true }))
+    const wrong = await wrongActor.request("/")
+    expect(wrong.status).toBe(403)
+
+    const noActor = makeApp(() => {})
+    noActor.use("*", requireActor("staff"))
+    noActor.get("/", (c) => c.json({ ok: true }))
+    const none = await noActor.request("/")
+    expect(none.status).toBe(401)
   })
 
   it("bypasses the check for internal requests", async () => {


### PR DESCRIPTION
Closes #285.

## Summary

\`requireActor\` previously defaulted to \`actor = "staff"\` when the request had no resolved actor. The comment said "preserve backwards compatibility" — in practice, if auth middleware was missing, misordered, or a route mounted before auth, every unauth request was granted operator privileges silently.

Default behaviour is now fail-closed:

- \`requireActor\` returns \`401 Unauthorized\` when no actor is set
- The no-actor (\`401\`) and wrong-actor (\`403\`) cases are now distinguishable
- \`requireAuth\` now sets \`actor: "staff"\` explicitly on the core-owned API key path (\`voy_\` prefix), documenting the assumption that they're server-to-server credentials issued to operator staff
- Anonymous requests on \`/v1/admin/*\` now return \`401\` instead of \`200\`
- Anonymous requests on \`/v1/public/*\` continue to receive \`actor: "customer"\` via the \`publicPaths\` bypass when applicable

## Breaking change

Custom \`auth.resolve\` integrations that relied on the implicit \`"staff"\` fallback must now return an explicit \`actor\` from \`resolve()\`. Documented in \`.changeset/hono-actor-fail-closed.md\` (major bump).

## Test plan

- [x] \`pnpm -F @voyantjs/hono test\` — 42 passed (existing "treats missing actor as staff" cases flipped to assert 401)
- [x] Pre-commit lint + monorepo typecheck pass