### PR TITLE
fix(finance): add CHECK constraints on currency/amount nullable pairs (#288)

### DIFF
--- a/packages/bookings/src/schema-core.ts
+++ b/packages/bookings/src/schema-core.ts
@@ -1,5 +1,16 @@
 import { typeId, typeIdRef } from "@voyantjs/db/lib/typeid-column"
-import { boolean, date, index, integer, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core"
+import { sql } from "drizzle-orm"
+import {
+  boolean,
+  check,
+  date,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core"
 
 import {
   bookingParticipantTypeEnum,
@@ -58,6 +69,14 @@ export const bookings = pgTable(
     index("idx_bookings_organization").on(table.organizationId),
     index("idx_bookings_source_type").on(table.sourceType),
     index("idx_bookings_number").on(table.bookingNumber),
+    // base_currency covers the base_*_amount_cents columns. If any base
+    // amount is set, base_currency must be set so downstream FX/reporting
+    // code can interpret it. Both null is fine (FX deferred until quote
+    // becomes a confirmed booking).
+    check(
+      "ck_bookings_base_currency_amounts",
+      sql`(${table.baseSellAmountCents} IS NULL AND ${table.baseCostAmountCents} IS NULL) OR ${table.baseCurrency} IS NOT NULL`,
+    ),
   ],
 )
 

--- a/packages/bookings/src/schema-items.ts
+++ b/packages/bookings/src/schema-items.ts
@@ -1,5 +1,16 @@
 import { typeId, typeIdRef } from "@voyantjs/db/lib/typeid-column"
-import { boolean, date, index, integer, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core"
+import { sql } from "drizzle-orm"
+import {
+  boolean,
+  check,
+  date,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core"
 
 import { availabilitySlotsRef } from "./availability-ref.js"
 import { bookings, bookingTravelers } from "./schema-core"
@@ -51,6 +62,13 @@ export const bookingItems = pgTable(
     index("idx_booking_items_booking").on(table.bookingId),
     index("idx_booking_items_booking_created").on(table.bookingId, table.createdAt),
     index("idx_booking_items_status").on(table.status),
+    // cost_currency is optional on items (not every line has cost data) but
+    // if any cost amount is set, the currency MUST be set so reporting can
+    // interpret it.
+    check(
+      "ck_booking_items_cost_currency_amounts",
+      sql`(${table.unitCostAmountCents} IS NULL AND ${table.totalCostAmountCents} IS NULL) OR ${table.costCurrency} IS NOT NULL`,
+    ),
   ],
 )
 

--- a/packages/finance/src/schema.ts
+++ b/packages/finance/src/schema.ts
@@ -1,7 +1,8 @@
 import { typeId, typeIdRef } from "@voyantjs/db/lib/typeid-column"
-import { relations } from "drizzle-orm"
+import { relations, sql } from "drizzle-orm"
 import {
   boolean,
+  check,
   date,
   index,
   integer,
@@ -627,6 +628,10 @@ export const bookingGuarantees = pgTable(
     index("idx_booking_guarantees_instrument").on(table.paymentInstrumentId),
     index("idx_booking_guarantees_authorization").on(table.paymentAuthorizationId),
     index("idx_booking_guarantees_status").on(table.status),
+    check(
+      "ck_booking_guarantees_currency_amount",
+      sql`(${table.currency} IS NULL) = (${table.amountCents} IS NULL)`,
+    ),
   ],
 )
 
@@ -692,6 +697,10 @@ export const bookingItemCommissions = pgTable(
     index("idx_booking_item_commissions_item_created").on(table.bookingItemId, table.createdAt),
     index("idx_booking_item_commissions_channel").on(table.channelId),
     index("idx_booking_item_commissions_status").on(table.status),
+    check(
+      "ck_booking_item_commissions_currency_amount",
+      sql`(${table.currency} IS NULL) = (${table.amountCents} IS NULL)`,
+    ),
   ],
 )
 
@@ -750,6 +759,18 @@ export const invoices = pgTable(
     index("idx_invoices_fx_rate_set").on(table.fxRateSetId),
     index("idx_invoices_number").on(table.invoiceNumber),
     index("idx_invoices_due_date").on(table.dueDate),
+    // base_currency covers every base_*_cents column. If any base amount is
+    // present, base_currency must be set so reporting can interpret it.
+    check(
+      "ck_invoices_base_currency_amounts",
+      sql`(
+        ${table.baseSubtotalCents} IS NULL
+        AND ${table.baseTaxCents} IS NULL
+        AND ${table.baseTotalCents} IS NULL
+        AND ${table.basePaidCents} IS NULL
+        AND ${table.baseBalanceDueCents} IS NULL
+      ) OR ${table.baseCurrency} IS NOT NULL`,
+    ),
   ],
 )
 
@@ -832,6 +853,10 @@ export const payments = pgTable(
     index("idx_payments_capture").on(table.paymentCaptureId),
     index("idx_payments_status").on(table.status),
     index("idx_payments_date").on(table.paymentDate),
+    check(
+      "ck_payments_base_currency_amount",
+      sql`(${table.baseCurrency} IS NULL) = (${table.baseAmountCents} IS NULL)`,
+    ),
   ],
 )
 

--- a/packages/finance/tests/integration/currency-amount-checks.test.ts
+++ b/packages/finance/tests/integration/currency-amount-checks.test.ts
@@ -1,0 +1,343 @@
+import { bookingItems, bookings } from "@voyantjs/bookings/schema"
+import { createTestDb } from "@voyantjs/db/test-utils"
+import { sql } from "drizzle-orm"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { bookingGuarantees, bookingItemCommissions, invoices, payments } from "../../src/schema.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+async function reset(
+  // biome-ignore lint/suspicious/noExplicitAny: test db
+  db: any,
+) {
+  const tables = [
+    "payments",
+    "invoice_line_items",
+    "invoices",
+    "booking_item_commissions",
+    "booking_guarantees",
+    "booking_payment_schedules",
+    "booking_items",
+    "bookings",
+  ]
+  const existing = (await db.execute<{ tablename: string }>(sql`
+    SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename IN (${sql.join(
+      tables.map((t) => sql`${t}`),
+      sql`, `,
+    )})
+  `)) as Array<{ tablename: string }>
+  if (existing.length === 0) return
+  await db.execute(
+    sql.raw(`TRUNCATE ${existing.map((r) => `"${r.tablename}"`).join(", ")} CASCADE`),
+  )
+}
+
+let counter = 0
+function id(prefix: string) {
+  counter += 1
+  return `${prefix}_chk_${counter}`
+}
+
+describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test db
+  let db: any
+
+  beforeAll(() => {
+    db = createTestDb()
+  })
+
+  afterAll(async () => {
+    if (db?.$client?.end) await db.$client.end()
+  })
+
+  beforeEach(async () => {
+    await reset(db)
+  })
+
+  describe("bookings.bookings — base_currency + base_*_amount_cents", () => {
+    it("rejects baseSellAmountCents without baseCurrency", async () => {
+      await expect(
+        db.insert(bookings).values({
+          id: id("book"),
+          bookingNumber: `BK-${counter}`,
+          sellCurrency: "EUR",
+          baseCurrency: null,
+          baseSellAmountCents: 10000,
+        }),
+      ).rejects.toThrow(/ck_bookings_base_currency_amounts/)
+    })
+
+    it("rejects baseCostAmountCents without baseCurrency", async () => {
+      await expect(
+        db.insert(bookings).values({
+          id: id("book"),
+          bookingNumber: `BK-${counter}`,
+          sellCurrency: "EUR",
+          baseCurrency: null,
+          baseCostAmountCents: 5000,
+        }),
+      ).rejects.toThrow(/ck_bookings_base_currency_amounts/)
+    })
+
+    it("accepts both base_*_amount_cents null with null baseCurrency", async () => {
+      await expect(
+        db.insert(bookings).values({
+          id: id("book"),
+          bookingNumber: `BK-${counter}`,
+          sellCurrency: "EUR",
+          baseCurrency: null,
+          baseSellAmountCents: null,
+          baseCostAmountCents: null,
+        }),
+      ).resolves.toBeDefined()
+    })
+
+    it("accepts base amounts when baseCurrency is set", async () => {
+      await expect(
+        db.insert(bookings).values({
+          id: id("book"),
+          bookingNumber: `BK-${counter}`,
+          sellCurrency: "EUR",
+          baseCurrency: "USD",
+          baseSellAmountCents: 12000,
+          baseCostAmountCents: 9000,
+        }),
+      ).resolves.toBeDefined()
+    })
+  })
+
+  describe("bookings.booking_items — cost_currency + cost amounts", () => {
+    async function insertBooking() {
+      const bookingId = id("book")
+      await db.insert(bookings).values({
+        id: bookingId,
+        bookingNumber: `BK-${counter}`,
+        sellCurrency: "EUR",
+      })
+      return bookingId
+    }
+
+    it("rejects unitCostAmountCents without costCurrency", async () => {
+      const bookingId = await insertBooking()
+      await expect(
+        db.insert(bookingItems).values({
+          id: id("bkit"),
+          bookingId,
+          title: "Test",
+          sellCurrency: "EUR",
+          costCurrency: null,
+          unitCostAmountCents: 5000,
+        }),
+      ).rejects.toThrow(/ck_booking_items_cost_currency_amounts/)
+    })
+
+    it("accepts cost amounts with costCurrency set", async () => {
+      const bookingId = await insertBooking()
+      await expect(
+        db.insert(bookingItems).values({
+          id: id("bkit"),
+          bookingId,
+          title: "Test",
+          sellCurrency: "EUR",
+          costCurrency: "EUR",
+          unitCostAmountCents: 5000,
+          totalCostAmountCents: 5000,
+        }),
+      ).resolves.toBeDefined()
+    })
+  })
+
+  describe("finance.booking_guarantees — currency + amount XNOR", () => {
+    it("rejects amount without currency", async () => {
+      await expect(
+        db.insert(bookingGuarantees).values({
+          id: id("bkgu"),
+          bookingId: id("book"),
+          status: "pending",
+          currency: null,
+          amountCents: 10000,
+        }),
+      ).rejects.toThrow(/ck_booking_guarantees_currency_amount/)
+    })
+
+    it("rejects currency without amount", async () => {
+      await expect(
+        db.insert(bookingGuarantees).values({
+          id: id("bkgu"),
+          bookingId: id("book"),
+          status: "pending",
+          currency: "EUR",
+          amountCents: null,
+        }),
+      ).rejects.toThrow(/ck_booking_guarantees_currency_amount/)
+    })
+
+    it("accepts both null", async () => {
+      await expect(
+        db.insert(bookingGuarantees).values({
+          id: id("bkgu"),
+          bookingId: id("book"),
+          status: "pending",
+          currency: null,
+          amountCents: null,
+        }),
+      ).resolves.toBeDefined()
+    })
+
+    it("accepts both set", async () => {
+      await expect(
+        db.insert(bookingGuarantees).values({
+          id: id("bkgu"),
+          bookingId: id("book"),
+          status: "pending",
+          currency: "EUR",
+          amountCents: 10000,
+        }),
+      ).resolves.toBeDefined()
+    })
+  })
+
+  describe("finance.booking_item_commissions — currency + amount XNOR", () => {
+    it("rejects amount without currency", async () => {
+      await expect(
+        db.insert(bookingItemCommissions).values({
+          id: id("bcom"),
+          bookingItemId: id("bkit"),
+          recipientType: "channel",
+          currency: null,
+          amountCents: 1000,
+        }),
+      ).rejects.toThrow(/ck_booking_item_commissions_currency_amount/)
+    })
+
+    it("accepts both null (commission-as-percentage row)", async () => {
+      await expect(
+        db.insert(bookingItemCommissions).values({
+          id: id("bcom"),
+          bookingItemId: id("bkit"),
+          recipientType: "channel",
+          commissionModel: "percentage",
+          rateBasisPoints: 1500,
+          currency: null,
+          amountCents: null,
+        }),
+      ).resolves.toBeDefined()
+    })
+  })
+
+  describe("finance.invoices — base_currency + base_*_cents", () => {
+    async function bookingId() {
+      const bid = id("book")
+      await db.insert(bookings).values({
+        id: bid,
+        bookingNumber: `BK-${counter}`,
+        sellCurrency: "EUR",
+      })
+      return bid
+    }
+
+    it("rejects baseSubtotalCents without baseCurrency", async () => {
+      const bid = await bookingId()
+      await expect(
+        db.insert(invoices).values({
+          id: id("inv"),
+          invoiceNumber: `INV-${counter}`,
+          bookingId: bid,
+          status: "draft",
+          currency: "EUR",
+          baseCurrency: null,
+          baseSubtotalCents: 5000,
+          issueDate: "2026-04-25",
+          dueDate: "2026-05-25",
+        }),
+      ).rejects.toThrow(/ck_invoices_base_currency_amounts/)
+    })
+
+    it("accepts every base_*_cents null with baseCurrency null", async () => {
+      const bid = await bookingId()
+      await expect(
+        db.insert(invoices).values({
+          id: id("inv"),
+          invoiceNumber: `INV-${counter}`,
+          bookingId: bid,
+          status: "draft",
+          currency: "EUR",
+          baseCurrency: null,
+          issueDate: "2026-04-25",
+          dueDate: "2026-05-25",
+        }),
+      ).resolves.toBeDefined()
+    })
+  })
+
+  describe("finance.payments — base_currency + base_amount XNOR", () => {
+    async function invoiceId() {
+      const bid = id("book")
+      await db.insert(bookings).values({
+        id: bid,
+        bookingNumber: `BK-${counter}`,
+        sellCurrency: "EUR",
+      })
+      const iid = id("inv")
+      await db.insert(invoices).values({
+        id: iid,
+        invoiceNumber: `INV-${counter}`,
+        bookingId: bid,
+        status: "draft",
+        currency: "EUR",
+        issueDate: "2026-04-25",
+        dueDate: "2026-05-25",
+      })
+      return iid
+    }
+
+    it("rejects baseAmountCents without baseCurrency", async () => {
+      const iid = await invoiceId()
+      await expect(
+        db.insert(payments).values({
+          id: id("pay"),
+          invoiceId: iid,
+          amountCents: 10000,
+          currency: "EUR",
+          baseCurrency: null,
+          baseAmountCents: 12000,
+          paymentMethod: "bank_transfer",
+          paymentDate: "2026-04-25",
+        }),
+      ).rejects.toThrow(/ck_payments_base_currency_amount/)
+    })
+
+    it("rejects baseCurrency without baseAmountCents", async () => {
+      const iid = await invoiceId()
+      await expect(
+        db.insert(payments).values({
+          id: id("pay"),
+          invoiceId: iid,
+          amountCents: 10000,
+          currency: "EUR",
+          baseCurrency: "USD",
+          baseAmountCents: null,
+          paymentMethod: "bank_transfer",
+          paymentDate: "2026-04-25",
+        }),
+      ).rejects.toThrow(/ck_payments_base_currency_amount/)
+    })
+
+    it("accepts both null", async () => {
+      const iid = await invoiceId()
+      await expect(
+        db.insert(payments).values({
+          id: id("pay"),
+          invoiceId: iid,
+          amountCents: 10000,
+          currency: "EUR",
+          baseCurrency: null,
+          baseAmountCents: null,
+          paymentMethod: "bank_transfer",
+          paymentDate: "2026-04-25",
+        }),
+      ).resolves.toBeDefined()
+    })
+  })
+})

--- a/packages/transactions/src/schema-offers.ts
+++ b/packages/transactions/src/schema-offers.ts
@@ -1,7 +1,9 @@
 import { typeId, typeIdRef } from "@voyantjs/db/lib/typeid-column"
 import type { KmsEnvelope } from "@voyantjs/db/schema/iam"
+import { sql } from "drizzle-orm"
 import {
   boolean,
+  check,
   date,
   index,
   integer,
@@ -145,6 +147,10 @@ export const offerItems = pgTable(
     index("idx_offer_items_unit_created").on(table.unitId, table.createdAt),
     index("idx_offer_items_slot_created").on(table.slotId, table.createdAt),
     index("idx_offer_items_status_created").on(table.status, table.createdAt),
+    check(
+      "ck_offer_items_cost_currency_amounts",
+      sql`(${table.unitCostAmountCents} IS NULL AND ${table.totalCostAmountCents} IS NULL) OR ${table.costCurrency} IS NOT NULL`,
+    ),
   ],
 )
 

--- a/packages/transactions/src/schema-orders.ts
+++ b/packages/transactions/src/schema-orders.ts
@@ -1,7 +1,9 @@
 import { typeId, typeIdRef } from "@voyantjs/db/lib/typeid-column"
 import type { KmsEnvelope } from "@voyantjs/db/schema/iam"
+import { sql } from "drizzle-orm"
 import {
   boolean,
+  check,
   date,
   index,
   integer,
@@ -152,6 +154,10 @@ export const orderItems = pgTable(
     index("idx_order_items_unit_created").on(table.unitId, table.createdAt),
     index("idx_order_items_slot_created").on(table.slotId, table.createdAt),
     index("idx_order_items_status_created").on(table.status, table.createdAt),
+    check(
+      "ck_order_items_cost_currency_amounts",
+      sql`(${table.unitCostAmountCents} IS NULL AND ${table.totalCostAmountCents} IS NULL) OR ${table.costCurrency} IS NOT NULL`,
+    ),
   ],
 )
 


### PR DESCRIPTION
Closes #288.

## Summary

Adds Postgres CHECK constraints across finance, transactions, and bookings schemas to enforce: if any \`*_amount_cents\` column is set, its companion currency column must also be set.

## Constraint shapes

- **Strict XNOR** (\`(currency IS NULL) = (amount IS NULL)\`) — one currency pairs with exactly one amount:
  - \`booking_guarantees.currency / amount_cents\`
  - \`booking_item_commissions.currency / amount_cents\`
  - \`payments.base_currency / base_amount_cents\`

- **Implication** (\`(amounts NULL) OR (currency NOT NULL)\`) — one currency covers multiple amounts:
  - \`bookings.base_currency\` covers \`base_sell_amount_cents\` + \`base_cost_amount_cents\`
  - \`booking_items.cost_currency\` covers \`unit_cost_amount_cents\` + \`total_cost_amount_cents\`
  - \`offer_items.cost_currency\` (same shape)
  - \`order_items.cost_currency\` (same shape)
  - \`invoices.base_currency\` covers \`base_subtotal_cents\` / \`base_tax_cents\` / \`base_total_cents\` / \`base_paid_cents\` / \`base_balance_due_cents\`

A "currency without amount" is allowed in the implication form because the currency may be pre-declared before the sum is computed; only the strict-XNOR pairs reject that case.

Tables where both currency and amount are \`notNull\` (\`offers\`, \`orders\`, \`payment_sessions\`, most invoice line / voucher columns) need no CHECK — Postgres already enforces both must be present.

## Test plan

- [x] 14 new integration tests in \`packages/finance/tests/integration/currency-amount-checks.test.ts\` exercise both rejection paths and acceptance cases. Skipped without \`TEST_DATABASE_URL\` per the existing convention.
- [x] \`pnpm typecheck\` clean for bookings, transactions, finance.