### PR TITLE
fix(bookings): list redaction + audit-on-read for contact PII (#283)

### DIFF
--- a/docs/architecture/booking-pii.md
+++ b/docs/architecture/booking-pii.md
@@ -1,0 +1,110 @@
+# Booking PII handling
+
+This document describes how Voyant treats personally identifiable
+information (PII) on bookings and travelers.
+
+## Surface area
+
+There are three classes of PII on a booking:
+
+1. **High-sensitivity identity** — passport, national ID, date of birth,
+   nationality, dietary requirements with medical implications. Stored
+   in `booking_traveler_travel_details` as KMS-encrypted JSON envelopes.
+   See `packages/bookings/src/schema/travel-details.ts` and
+   `createBookingPiiService`.
+2. **Contact identifiers** — first/last name, email, phone, address,
+   postal code. Stored as plaintext columns on `bookings.contact_*` and
+   `booking_travelers.{first,last}_name / email / phone`. Plaintext is a
+   deliberate choice so the operator UI can search and sort.
+3. **Operational notes** — `accessibility_needs`, `special_requests`,
+   `notes`. Plaintext, treated as PII for redaction purposes because
+   they often contain medical or personal context.
+
+## Posture
+
+| Class | At rest | In flight (default) | In flight (with `bookings-pii:read` scope) |
+|---|---|---|---|
+| High-sensitivity identity | Encrypted (KMS envelope) | Not returned by list/get unless explicitly requested through the travel-details endpoint, which always audits | Decrypted and returned |
+| Contact identifiers | Plaintext | **Redacted** (email → `a***e@host`, phone → `***1234`, name/address → `***`) | Returned verbatim |
+| Operational notes | Plaintext | **Redacted** to `***` | Returned verbatim |
+
+## Authorisation gate — `shouldRevealBookingPii(ctx)`
+
+Returns `true` when ANY of:
+
+- `ctx.isInternalRequest === true` (server-to-server inside the trust boundary)
+- `ctx.scopes` contains `*` (superuser)
+- `ctx.scopes` contains `bookings-pii:*`
+- `ctx.scopes` contains `bookings-pii:read`
+
+Plain staff sessions WITHOUT the scope do NOT reveal — staff are
+authorised to operate on bookings but not necessarily to read every
+contact identifier on every booking. Granting `bookings-pii:read` is an
+explicit decision, defaulted off in role templates.
+
+## Audit
+
+Every PII access — both reveals and redactions — is recorded in
+`booking_pii_access_log` with:
+
+- `actor_id` (the user id from auth)
+- `actor_type` (staff / customer / partner / supplier)
+- `caller_type` (session / api_key / internal)
+- `action` (read / update / delete)
+- `outcome` (allowed / denied)
+- `reason` (free-form, e.g. `list_redacted`, `detail_reveal`,
+  `insufficient_scope`)
+- `metadata` (arbitrary JSON — current contents include `rowCount`,
+  `reveal: boolean`)
+
+The list endpoints log a single row per request, not per row, with the
+`rowCount` in metadata.
+
+## Encryption follow-up
+
+This document codifies "redact-in-flight + plaintext-on-disk" as the
+current posture. A follow-up issue tracks **encrypting contact
+identifiers at rest** — that requires:
+
+- A schema migration to replace text columns with encrypted JSON envelopes
+- A search-tokenisation strategy (deterministic encryption or a
+  separate `*_search_token` column produced from a salted-hash of the
+  email/phone) so the operator UI's "find by email" still works
+- A migration script to decrypt-and-re-encrypt existing rows
+
+Until that ships, contact identifiers are protected by access control
+and audit logging — not by cryptography on disk. Self-hosters with
+stricter requirements can encrypt the underlying Postgres at the disk
+layer (managed Postgres providers handle this; CF Hyperdrive does not).
+
+## How to apply this in route code
+
+Use the helpers from `@voyantjs/voyant-bookings`:
+
+```ts
+import {
+  redactBookingContact,
+  redactTravelerIdentity,
+  shouldRevealBookingPii,
+} from "@voyantjs/voyant-bookings"
+
+const reveal = shouldRevealBookingPii({
+  actor: c.get("actor"),
+  scopes: c.get("scopes"),
+  callerType: c.get("callerType"),
+  isInternalRequest: c.get("isInternalRequest"),
+})
+await logBookingPiiAccess(c, {
+  bookingId: row.id,
+  action: "read",
+  outcome: "allowed",
+  reason: reveal ? "detail_reveal" : "detail_redacted",
+  metadata: { reveal },
+})
+return c.json({ data: reveal ? row : redactBookingContact(row) })
+```
+
+The bookings module's admin routes (`GET /v1/admin/bookings`,
+`GET /v1/admin/bookings/:id`, `GET /v1/admin/bookings/:id/travelers`)
+already follow this pattern. Public routes (`/v1/public/*`) currently
+do not return contact identifiers, so they do not need redaction.

--- a/packages/bookings/src/index.ts
+++ b/packages/bookings/src/index.ts
@@ -13,6 +13,15 @@ export {
   createBookingPiiService,
   type UpsertBookingTravelerTravelDetailInput,
 } from "./pii.js"
+export {
+  type PiiAccessContext,
+  redactBookingContact,
+  redactEmail,
+  redactPhone,
+  redactString,
+  redactTravelerIdentity,
+  shouldRevealBookingPii,
+} from "./pii-redaction.js"
 export type { ConvertProductData } from "./service.js"
 export { bookingsService } from "./service.js"
 export {

--- a/packages/bookings/src/pii-redaction.ts
+++ b/packages/bookings/src/pii-redaction.ts
@@ -1,0 +1,144 @@
+/**
+ * Booking PII redaction.
+ *
+ * Booking rows and traveler rows store contact identifiers (name, email,
+ * phone) as plaintext columns so the operator UI can search and sort. The
+ * `bookings-pii:*` scope (or `*` superuser scope) gates the right to see
+ * those identifiers verbatim. Callers without that scope receive a redacted
+ * shape that retains enough signal for operational triage but not enough to
+ * exfiltrate a full contact list.
+ *
+ * **Scope of this module:** route-layer redaction at the API boundary.
+ * Internal callers (cron jobs, workflows, in-process tasks) bypass redaction
+ * because they need the full record to do their job.
+ *
+ * **What this does NOT do:** encrypt the columns at rest. That is a
+ * follow-up requiring a schema migration + a search-tokenisation strategy
+ * (see issue #283 follow-up). For now plaintext-on-disk + redact-in-flight
+ * is the documented posture.
+ */
+
+const PII_SCOPE_ANY = "bookings-pii:*"
+const PII_SCOPE_READ = "bookings-pii:read"
+const SUPERUSER_SCOPE = "*"
+
+export interface PiiAccessContext {
+  actor?: string | null
+  scopes?: string[] | null
+  callerType?: string | null
+  isInternalRequest?: boolean
+}
+
+/**
+ * Returns true when the caller has earned the right to see PII in the clear.
+ *
+ * Internal requests (server-to-server inside the trust boundary) and API
+ * keys with explicit `bookings-pii:read` scope (or superuser `*`) reveal.
+ * Plain staff sessions WITHOUT the scope do NOT reveal — staff are
+ * authorised to see *some* booking data but not necessarily the contact
+ * identifiers. This makes "give the new agent a read-only role" safe by
+ * default; granting `bookings-pii:read` is an explicit decision.
+ */
+export function shouldRevealBookingPii(ctx: PiiAccessContext): boolean {
+  if (ctx.isInternalRequest) return true
+  const scopes = ctx.scopes ?? []
+  return (
+    scopes.includes(SUPERUSER_SCOPE) ||
+    scopes.includes(PII_SCOPE_ANY) ||
+    scopes.includes(PII_SCOPE_READ)
+  )
+}
+
+/**
+ * Mask the local-part of an email, preserving the domain so the operator
+ * can tell at a glance which provider is involved.
+ *
+ * `alice@example.com` → `a***e@example.com`
+ * `bo@example.com`    → `**@example.com`
+ */
+export function redactEmail(email: string | null | undefined): string | null {
+  if (email == null) return email ?? null
+  const at = email.lastIndexOf("@")
+  if (at < 1) return "***"
+  const local = email.slice(0, at)
+  const domain = email.slice(at)
+  if (local.length <= 2) return `${"*".repeat(local.length)}${domain}`
+  return `${local[0]}***${local[local.length - 1]}${domain}`
+}
+
+/**
+ * Mask all but the last four digits of a phone number, dropping
+ * non-digit characters from the masked region so the result is recognisable
+ * as a phone fragment.
+ *
+ * `+40 712 345 678` → `***5678`
+ */
+export function redactPhone(phone: string | null | undefined): string | null {
+  if (phone == null) return phone ?? null
+  const digits = phone.replace(/\D/g, "")
+  if (digits.length <= 4) return "***"
+  return `***${digits.slice(-4)}`
+}
+
+/**
+ * Masks an arbitrary identifier like a postal address or city to a single-
+ * char marker. We keep the field present so client schemas don't break,
+ * but the value is effectively absent.
+ */
+export function redactString(value: string | null | undefined): string | null {
+  if (value == null) return value ?? null
+  return value.length === 0 ? value : "***"
+}
+
+/**
+ * Booking row contact-PII redaction. Returns a shallow copy with the
+ * `contact*` columns masked. Caller is responsible for not running this on
+ * already-redacted rows.
+ */
+export function redactBookingContact<
+  T extends {
+    contactFirstName?: string | null
+    contactLastName?: string | null
+    contactEmail?: string | null
+    contactPhone?: string | null
+    contactAddressLine1?: string | null
+    contactPostalCode?: string | null
+  },
+>(row: T): T {
+  return {
+    ...row,
+    contactFirstName: redactString(row.contactFirstName),
+    contactLastName: redactString(row.contactLastName),
+    contactEmail: redactEmail(row.contactEmail),
+    contactPhone: redactPhone(row.contactPhone),
+    contactAddressLine1: redactString(row.contactAddressLine1),
+    contactPostalCode: redactString(row.contactPostalCode),
+  }
+}
+
+/**
+ * Traveler row redaction. Same shape as `redactBookingContact` but for
+ * traveler identity columns.
+ */
+export function redactTravelerIdentity<
+  T extends {
+    firstName?: string | null
+    lastName?: string | null
+    email?: string | null
+    phone?: string | null
+    accessibilityNeeds?: string | null
+    specialRequests?: string | null
+    notes?: string | null
+  },
+>(row: T): T {
+  return {
+    ...row,
+    firstName: redactString(row.firstName),
+    lastName: redactString(row.lastName),
+    email: redactEmail(row.email),
+    phone: redactPhone(row.phone),
+    accessibilityNeeds: redactString(row.accessibilityNeeds),
+    specialRequests: redactString(row.specialRequests),
+    notes: redactString(row.notes),
+  }
+}

--- a/packages/bookings/src/routes.ts
+++ b/packages/bookings/src/routes.ts
@@ -12,6 +12,11 @@ import { type Context, Hono } from "hono"
 
 import { createBookingPiiService } from "./pii.js"
 import {
+  redactBookingContact,
+  redactTravelerIdentity,
+  shouldRevealBookingPii,
+} from "./pii-redaction.js"
+import {
   BOOKING_ROUTE_RUNTIME_CONTAINER_KEY,
   type BookingRouteRuntime,
   buildBookingRouteRuntime,
@@ -224,7 +229,24 @@ export const bookingRoutes = new Hono<Env>()
   // 1. GET / — List bookings
   .get("/", async (c) => {
     const query = parseQuery(c, bookingListQuerySchema)
-    return c.json(await bookingsService.listBookings(c.get("db"), query))
+    const result = await bookingsService.listBookings(c.get("db"), query)
+    const reveal = shouldRevealBookingPii({
+      actor: c.get("actor"),
+      scopes: c.get("scopes"),
+      callerType: c.get("callerType"),
+      isInternalRequest: c.get("isInternalRequest"),
+    })
+    await logBookingPiiAccess(c, {
+      action: "read",
+      outcome: "allowed",
+      reason: reveal ? "list_reveal" : "list_redacted",
+      metadata: { rowCount: result.data.length, reveal },
+    })
+    if (reveal) return c.json(result)
+    return c.json({
+      ...result,
+      data: result.data.map((row) => redactBookingContact(row)),
+    })
   })
 
   // 1a. POST /pricing-preview — Resolve a pricing snapshot without creating a session.
@@ -268,7 +290,20 @@ export const bookingRoutes = new Hono<Env>()
       return c.json({ error: "Booking not found" }, 404)
     }
 
-    return c.json({ data: row })
+    const reveal = shouldRevealBookingPii({
+      actor: c.get("actor"),
+      scopes: c.get("scopes"),
+      callerType: c.get("callerType"),
+      isInternalRequest: c.get("isInternalRequest"),
+    })
+    await logBookingPiiAccess(c, {
+      bookingId: row.id,
+      action: "read",
+      outcome: "allowed",
+      reason: reveal ? "detail_reveal" : "detail_redacted",
+      metadata: { reveal },
+    })
+    return c.json({ data: reveal ? row : redactBookingContact(row) })
   })
 
   // 3. POST /reserve — Reserve inventory and create on-hold booking
@@ -617,7 +652,22 @@ export const bookingRoutes = new Hono<Env>()
   // ==========================================================================
 
   .get("/:id/travelers", async (c) => {
-    return c.json({ data: await bookingsService.listTravelers(c.get("db"), c.req.param("id")) })
+    const travelers = await bookingsService.listTravelers(c.get("db"), c.req.param("id"))
+    const reveal = shouldRevealBookingPii({
+      actor: c.get("actor"),
+      scopes: c.get("scopes"),
+      callerType: c.get("callerType"),
+      isInternalRequest: c.get("isInternalRequest"),
+    })
+    await logBookingPiiAccess(c, {
+      bookingId: c.req.param("id"),
+      action: "read",
+      outcome: "allowed",
+      reason: reveal ? "travelers_reveal" : "travelers_redacted",
+      metadata: { rowCount: travelers.length, reveal },
+    })
+    if (reveal) return c.json({ data: travelers })
+    return c.json({ data: travelers.map((row) => redactTravelerIdentity(row)) })
   })
 
   .get("/:id/travelers/:travelerId/travel-details", async (c) => {

--- a/packages/bookings/tests/unit/pii-redaction.test.ts
+++ b/packages/bookings/tests/unit/pii-redaction.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  redactBookingContact,
+  redactEmail,
+  redactPhone,
+  redactString,
+  redactTravelerIdentity,
+  shouldRevealBookingPii,
+} from "../../src/pii-redaction.js"
+
+describe("shouldRevealBookingPii()", () => {
+  it("reveals on internal requests regardless of scopes", () => {
+    expect(shouldRevealBookingPii({ isInternalRequest: true })).toBe(true)
+    expect(shouldRevealBookingPii({ isInternalRequest: true, scopes: [] })).toBe(true)
+  })
+
+  it("reveals when scope includes superuser '*' or 'bookings-pii:read' or 'bookings-pii:*'", () => {
+    expect(shouldRevealBookingPii({ scopes: ["*"] })).toBe(true)
+    expect(shouldRevealBookingPii({ scopes: ["bookings-pii:*"] })).toBe(true)
+    expect(shouldRevealBookingPii({ scopes: ["bookings-pii:read"] })).toBe(true)
+  })
+
+  it("does NOT reveal for plain staff sessions without the scope", () => {
+    expect(shouldRevealBookingPii({ actor: "staff", scopes: [] })).toBe(false)
+    expect(shouldRevealBookingPii({ actor: "staff", scopes: ["bookings:read"] })).toBe(false)
+  })
+
+  it("does NOT reveal for customer / partner / supplier actors", () => {
+    expect(shouldRevealBookingPii({ actor: "customer", scopes: [] })).toBe(false)
+    expect(shouldRevealBookingPii({ actor: "partner", scopes: ["bookings:read"] })).toBe(false)
+  })
+
+  it("does NOT reveal when no scopes/actor at all", () => {
+    expect(shouldRevealBookingPii({})).toBe(false)
+  })
+})
+
+describe("redactEmail()", () => {
+  it("masks the local-part but keeps the domain", () => {
+    expect(redactEmail("alice@example.com")).toBe("a***e@example.com")
+  })
+
+  it("masks short local parts entirely", () => {
+    expect(redactEmail("bo@example.com")).toBe("**@example.com")
+    expect(redactEmail("a@example.com")).toBe("*@example.com")
+  })
+
+  it("returns *** for malformed addresses", () => {
+    expect(redactEmail("not-an-email")).toBe("***")
+    expect(redactEmail("@example.com")).toBe("***")
+  })
+
+  it("preserves null and undefined", () => {
+    expect(redactEmail(null)).toBeNull()
+    expect(redactEmail(undefined)).toBeNull()
+  })
+})
+
+describe("redactPhone()", () => {
+  it("keeps the last four digits", () => {
+    expect(redactPhone("+40 712 345 678")).toBe("***5678")
+    expect(redactPhone("0712345678")).toBe("***5678")
+  })
+
+  it("returns *** for short values", () => {
+    expect(redactPhone("123")).toBe("***")
+    expect(redactPhone("1234")).toBe("***")
+  })
+
+  it("preserves null and undefined", () => {
+    expect(redactPhone(null)).toBeNull()
+    expect(redactPhone(undefined)).toBeNull()
+  })
+})
+
+describe("redactString()", () => {
+  it("masks any non-empty string with ***", () => {
+    expect(redactString("Bucharest")).toBe("***")
+  })
+
+  it("preserves empty strings (so client schemas don't break)", () => {
+    expect(redactString("")).toBe("")
+  })
+
+  it("preserves null and undefined", () => {
+    expect(redactString(null)).toBeNull()
+    expect(redactString(undefined)).toBeNull()
+  })
+})
+
+describe("redactBookingContact()", () => {
+  it("masks contactFirstName/Last/Email/Phone/Address/PostalCode and leaves other fields alone", () => {
+    const input = {
+      id: "book_1",
+      bookingNumber: "BK-1",
+      status: "confirmed" as const,
+      contactFirstName: "Alice",
+      contactLastName: "Smith",
+      contactEmail: "alice@example.com",
+      contactPhone: "+40712345678",
+      contactAddressLine1: "Str. Lipscani 1",
+      contactPostalCode: "030031",
+      contactCity: "Bucharest",
+    }
+    const output = redactBookingContact(input)
+    expect(output.id).toBe("book_1")
+    expect(output.bookingNumber).toBe("BK-1")
+    expect(output.status).toBe("confirmed")
+    expect(output.contactFirstName).toBe("***")
+    expect(output.contactLastName).toBe("***")
+    expect(output.contactEmail).toBe("a***e@example.com")
+    expect(output.contactPhone).toBe("***5678")
+    expect(output.contactAddressLine1).toBe("***")
+    expect(output.contactPostalCode).toBe("***")
+    // contactCity is NOT in the redaction set — it's coarse-grained
+    expect((output as unknown as { contactCity: string }).contactCity).toBe("Bucharest")
+  })
+
+  it("passes nulls through", () => {
+    const input = {
+      id: "book_1",
+      contactFirstName: null,
+      contactLastName: null,
+      contactEmail: null,
+      contactPhone: null,
+      contactAddressLine1: null,
+      contactPostalCode: null,
+    }
+    const output = redactBookingContact(input)
+    expect(output.contactEmail).toBeNull()
+    expect(output.contactPhone).toBeNull()
+  })
+})
+
+describe("redactTravelerIdentity()", () => {
+  it("masks identity columns + accessibility/specialRequests/notes", () => {
+    const input = {
+      id: "bkpt_1",
+      bookingId: "book_1",
+      participantType: "traveler" as const,
+      firstName: "Mihai",
+      lastName: "Popa",
+      email: "mihai@example.com",
+      phone: "+40712345678",
+      accessibilityNeeds: "wheelchair",
+      specialRequests: "kosher meal",
+      notes: "VIP guest",
+      isPrimary: true,
+    }
+    const output = redactTravelerIdentity(input)
+    expect(output.firstName).toBe("***")
+    expect(output.lastName).toBe("***")
+    expect(output.email).toBe("m***i@example.com")
+    expect(output.phone).toBe("***5678")
+    expect(output.accessibilityNeeds).toBe("***")
+    expect(output.specialRequests).toBe("***")
+    expect(output.notes).toBe("***")
+    // Untouched
+    expect(output.id).toBe("bkpt_1")
+    expect(output.participantType).toBe("traveler")
+    expect(output.isPrimary).toBe(true)
+  })
+})


### PR DESCRIPTION
Addresses the **list redaction + mandatory audit** halves of #283. The **encrypt-all-PII at rest** half is scoped out as a follow-up — see "Scope notes" below.

## What ships

- New \`packages/bookings/src/pii-redaction.ts\` with:
  - \`shouldRevealBookingPii(ctx)\` — gate based on actor / scopes / callerType / isInternalRequest
  - \`redactEmail\` (\`alice@example.com\` → \`a***e@example.com\`)
  - \`redactPhone\` (digit-only last-4 — \`+40 712 345 678\` → \`***5678\`)
  - \`redactString\` (any non-empty → \`***\`)
  - \`redactBookingContact(row)\` — masks \`contact_*\` columns
  - \`redactTravelerIdentity(row)\` — masks \`first_name\` / \`last_name\` / \`email\` / \`phone\` / \`accessibility_needs\` / \`special_requests\` / \`notes\`
- Three admin GET routes wired:
  - \`GET /v1/admin/bookings\`
  - \`GET /v1/admin/bookings/:id\`
  - \`GET /v1/admin/bookings/:id/travelers\`

  Each now: checks \`shouldRevealBookingPii\` against the request context, calls \`logBookingPiiAccess\` with reason (\`list_redacted\` / \`detail_reveal\` / \`travelers_redacted\`) and metadata (\`{ rowCount, reveal }\`), and masks contact PII unless the caller has explicit \`bookings-pii:read\` (or \`bookings-pii:*\` / \`*\` superuser) scope, OR the request is internal.
- \`docs/architecture/booking-pii.md\` documents the surface area, the posture (redact-in-flight + plaintext-on-disk), the audit model, and the encryption-at-rest follow-up.
- 18 unit tests cover redaction helpers + the authorisation gate.

## Breaking change

Plain staff sessions WITHOUT \`bookings-pii:read\` now see redacted data on the three admin GET endpoints. To restore previous behaviour for an existing role, attach \`bookings-pii:read\` (or \`bookings-pii:*\`) scope to the role's permissions.

## Scope notes

The **encrypt-all-PII at rest** part of the issue is intentionally not in this PR. Encrypting \`contact_email\` / \`contact_phone\` / traveler \`first_name\`/\`last_name\` at rest needs:

- a search-tokenisation strategy (deterministic encryption or salted search tokens) so the operator UI's "find by email" still works
- a schema migration replacing text columns with encrypted JSON envelopes
- a coordinated rollout across bookings + transactions packages

Filing as a follow-up issue with founder sign-off on the search-tokenisation choice.

## Test plan

- [x] \`pnpm -F @voyantjs/bookings test\` — 177 passed (was 159)
- [x] \`pnpm -F @voyantjs/bookings typecheck\` clean