### PR TITLE
validate(schema): multi-night hotel booking reference + findings doc (#293)

### DIFF
--- a/docs/architecture/hotel-booking-validation.md
+++ b/docs/architecture/hotel-booking-validation.md
@@ -1,0 +1,100 @@
+# Hotel booking schema validation
+
+This doc captures the findings from exercising the bookings + hospitality
+schema against a realistic multi-night hotel booking. The accompanying
+test in `packages/hospitality/tests/integration/multi-night-mixed-room.test.ts`
+is the executable proof; this doc captures observations about what worked
+cleanly, what was awkward, and what's missing.
+
+Closes #293.
+
+## Use case
+
+A 7-night stay with a mid-stay room change:
+
+- Nights 1-3 in a Deluxe room
+- Nights 4-7 in a Suite (a guest celebrating a milestone moves up after a few nights)
+- Bed-and-breakfast meal plan throughout
+- Self-parking add-on for all 7 nights
+- 2 adults + 1 child (child applies only to the Suite half — child capacity is the reason for the upgrade)
+
+## What worked
+
+### Multi-room-type stays decompose cleanly
+
+The schema models a mid-stay room change as **two `bookings.booking_items` rows**, each with its own **`hospitality.stay_booking_items`** extension. The check-out date of one matches the check-in date of the next, which is how hotel PMS systems represent the move.
+
+```
+bookings           — 1 row, the parent
+booking_items      — 2 rows (Deluxe, Suite) + 1 extras row (Parking)
+stay_booking_items — 2 rows (1:1 with the accommodation booking_items)
+stay_daily_rates   — 7 rows (3 deluxe + 4 suite)
+```
+
+The `uidx_stay_booking_items_booking_item` unique index enforces the 1:1 between `booking_items` and `stay_booking_items`. Multi-room means multi-line.
+
+### Per-night rate variation
+
+`stay_daily_rates.sellAmountCents` per `(stay_booking_item_id, date)` accommodates weekend bumps, single-night promo overrides, and dynamic pricing without restructuring the parent rows. Sum of daily rates rolls cleanly into the parent `booking_items.totalSellAmountCents`.
+
+### Meal plans + occupancy
+
+`stay_booking_items` tracks `mealPlanId`, `adults`, `children`, `infants` per stay segment. The Suite gets `children: 1` while the Deluxe stays at `children: 0` — exactly what we need when occupancy varies between segments.
+
+### Add-ons are first-class
+
+Parking is a plain `bookings.booking_items` row with `itemType: "extra"`, no hospitality extension. The booking total aggregates over all `booking_items` regardless of whether they have a `stay_booking_items` extension. Other add-ons (transfers, spa packages, late checkout) follow the same pattern.
+
+## What's awkward
+
+### `bookings.sellAmountCents` is denormalised, not computed
+
+The parent booking's `sellAmountCents` is a stored column that the caller has to update after creating items. There's no trigger / computed view that derives `Σ(booking_items.totalSellAmountCents)` automatically. Today every flow that mutates items must remember to re-roll the parent total. **Not a schema bug — a service-layer convention** — but worth a service helper.
+
+### The check-in/check-out boundary is a string-equality contract
+
+Saying "Suite check-in matches Deluxe check-out" relies on `'2026-09-13' === '2026-09-13'` at the application layer. The DB doesn't enforce that two stay_booking_items on the same booking form a contiguous range. A pathological caller could insert overlapping or gap-y stays.
+
+**Possible follow-up:** an EXCLUDE constraint using a daterange, or a service-layer invariant + test.
+
+### `booking_items.itemType` is enum-typed but lacks "accommodation" cohort metadata
+
+`itemType: "accommodation"` differentiates a stay row from a `"unit"`/`"transport"`/`"extra"` row, but the cardinality of "this booking has accommodation" lives implicitly in the join with `stay_booking_items`. UIs that want to render "your hotel stays" need to either filter by `itemType === "accommodation"` AND join, or just join (the unique index makes the join cheap).
+
+## What's missing or unproven
+
+### No price-rule resolver for `rate_plan_room_types`
+
+We seeded `stay_daily_rates` rows by hand at known per-night amounts. In a production system the per-night rates should be **resolved from a rate plan + room type + date**, applying any seasonal/dow modifiers. The schema has `room_type_rates` and `rate_plan_inventory_overrides` but no service code yet that, given a rate plan + room type + date range, returns the daily rate cards. **Follow-up:** a `resolveStayDailyRates(ratePlanId, roomTypeId, range)` service method.
+
+### Inventory consumption isn't wired
+
+Tour bookings decrement `availability_slots.remaining_pax` at reserve. Hotel bookings should decrement room inventory the same way — either at the `room_inventory` (per-day per-room-type capacity) or `room_units` (assigned room) level. Today, creating a `stay_booking_items` row does NOT automatically update inventory. **Follow-up:** an "atomic reserve" path for stays that mirrors `bookingsService.reserveBooking`.
+
+### Cancellation policies don't compose for multi-segment stays
+
+Each `stay_booking_items.ratePlanId` references a rate plan that has its own `cancellationPolicyId`. If both segments use the same rate plan that's fine; if they differ (e.g., a flexible Deluxe + non-refundable Suite), the cancellation calculation has to walk per-segment and aggregate. The legal package's cancellation evaluator (`evaluateCancellation`) was designed for one policy per booking. **Follow-up:** confirm whether `evaluateCancellation` can fan out across segments, or if we need a per-segment loop.
+
+### Stay folios are wired but not exercised here
+
+`stay_folios` and `stay_folio_lines` exist in `schema-operations.ts` but aren't part of this validation. They model the on-property tab — incidentals, room-service charges, mini-bar — that get charged at checkout. Whether that integrates cleanly with `finance.invoices` (one invoice with folio lines? two invoices: one for the booking, one for the folio?) is a separate exercise.
+
+## Verdict
+
+**The schema supports the multi-night-with-room-change use case** without modification. The integration test exercises the full shape and asserts: contiguous date ranges, per-night rate variation, add-ons, mixed occupancy across segments, and shared meal plan.
+
+The follow-up gaps are **service-layer**, not schema-layer:
+
+1. Per-segment cancellation policy fan-out (legal)
+2. Atomic inventory consumption at stay-reserve time (hospitality)
+3. Rate-card resolver from rate plan + room type + date (hospitality / pricing)
+4. Booking-total auto-rollup helper (bookings or finance)
+
+Each of those should be filed as a separate issue. The core data model is fit for purpose.
+
+## Lightly-considered: other product shapes
+
+- **Multi-segment flights with stopover:** the schema doesn't model flights as a first-class extension yet. There's no `flight_booking_items` table. Multi-segment flights would need that addition + per-segment fields (origin, destination, carrier, fare class, etc).
+- **Packaged trips (hotel + flight + activity):** decomposes naturally into `booking_items` of different itemTypes — but the cross-segment pricing (a package discount that's < sum of components) doesn't have a representation today. Either it's a synthetic `discount` line or the schema needs a "package" concept.
+
+These are research-grade observations rather than concrete recommendations — they need product input before becoming issues.

--- a/packages/hospitality/tests/integration/multi-night-mixed-room.test.ts
+++ b/packages/hospitality/tests/integration/multi-night-mixed-room.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Reference implementation: 7-night hotel stay with a mid-stay room-type
+ * change. Validates whether the bookings + hospitality schema can model
+ * the use case end-to-end.
+ *
+ * Setup:
+ *   - Property "Hotel Voyant Test"
+ *   - Two room types: "Deluxe" (3 nights) and "Suite" (4 nights)
+ *   - One rate plan that covers both room types, currency EUR
+ *   - One meal plan that includes breakfast
+ *   - One bookings.bookings row (the parent booking) with two
+ *     bookings.booking_items rows, each extended by a hospitality
+ *     stay_booking_items row
+ *   - Per-night rates loaded into stay_daily_rates
+ *   - One additional booking_items row for an extra (parking)
+ *
+ * The test asserts that:
+ *   - The parent booking's `sellAmountCents` matches Σ(stay_daily_rates) +
+ *     extras
+ *   - Each stay_booking_item has the correct `nightCount`
+ *   - The room-type change is reflected in two distinct stay_booking_items
+ *     covering contiguous date ranges
+ *   - Breakfast is captured via mealPlanId
+ *
+ * Findings from running this exercise are summarised in
+ * `docs/architecture/hotel-booking-validation.md`. Closes #293.
+ */
+
+import { bookingItems, bookings } from "@voyantjs/bookings/schema"
+import { facilities, properties } from "@voyantjs/facilities/schema"
+import { eq, sql } from "drizzle-orm"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { stayBookingItems, stayDailyRates } from "../../src/schema-bookings.js"
+import { mealPlans, ratePlanRoomTypes, ratePlans, roomTypes } from "../../src/schema-inventory.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+let counter = 0
+function id(prefix: string) {
+  counter += 1
+  return `${prefix}_h${counter}`
+}
+
+describe.skipIf(!DB_AVAILABLE)("hotel multi-night booking — schema validation", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test db type
+  let db: any
+
+  beforeAll(async () => {
+    const { createTestDb, cleanupTestDb } = await import("@voyantjs/db/test-utils")
+    db = createTestDb()
+    await cleanupTestDb(db)
+  })
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyantjs/db/test-utils")
+    await closeTestDb()
+  })
+
+  beforeEach(async () => {
+    const { cleanupTestDb } = await import("@voyantjs/db/test-utils")
+    await cleanupTestDb(db)
+  })
+
+  it("models a 7-night booking with mid-stay room change + breakfast meal plan + parking add-on", async () => {
+    // ---- Seed property + room types + rate plan + meal plan ---------------
+    const facilityId = id("fac")
+    await db.insert(facilities).values({
+      id: facilityId,
+      name: "Hotel Voyant Test",
+      type: "property",
+    })
+
+    const propertyId = id("prop")
+    await db.insert(properties).values({
+      id: propertyId,
+      facilityId,
+      propertyType: "hotel",
+      checkInTime: "15:00",
+      checkOutTime: "11:00",
+    })
+
+    const deluxeId = id("hrmt")
+    const suiteId = id("hrmt")
+    await db.insert(roomTypes).values([
+      {
+        id: deluxeId,
+        propertyId,
+        code: "DLX",
+        name: "Deluxe",
+        maxAdults: 2,
+        maxChildren: 1,
+        standardOccupancy: 2,
+        maxOccupancy: 3,
+      },
+      {
+        id: suiteId,
+        propertyId,
+        code: "STE",
+        name: "Suite",
+        maxAdults: 2,
+        maxChildren: 2,
+        standardOccupancy: 2,
+        maxOccupancy: 4,
+      },
+    ])
+
+    const breakfastMealPlan = id("hmlp")
+    await db.insert(mealPlans).values({
+      id: breakfastMealPlan,
+      propertyId,
+      code: "BB",
+      name: "Bed & Breakfast",
+      includesBreakfast: true,
+    })
+
+    const ratePlanId = id("hrpl")
+    await db.insert(ratePlans).values({
+      id: ratePlanId,
+      propertyId,
+      code: "BAR-BB",
+      name: "Best Available Rate (BB)",
+      currencyCode: "EUR",
+      mealPlanId: breakfastMealPlan,
+      chargeFrequency: "per_night",
+      refundable: true,
+    })
+
+    await db.insert(ratePlanRoomTypes).values([
+      { id: id("hrrt"), ratePlanId, roomTypeId: deluxeId },
+      { id: id("hrrt"), ratePlanId, roomTypeId: suiteId },
+    ])
+
+    // ---- Create the parent booking + booking_items ------------------------
+    const bookingNumber = `BK-HOTEL-${counter}`
+    const [booking] = await db
+      .insert(bookings)
+      .values({
+        bookingNumber,
+        sellCurrency: "EUR",
+        sourceType: "manual",
+        startDate: "2026-09-10",
+        endDate: "2026-09-17",
+      })
+      .returning()
+    const bookingId = booking.id as string
+
+    // Item 1: Deluxe room, nights 10-13 (3 nights)
+    const deluxeRates = [
+      { date: "2026-09-10", sellAmountCents: 18000 }, // Thu
+      { date: "2026-09-11", sellAmountCents: 22000 }, // Fri (weekend bump)
+      { date: "2026-09-12", sellAmountCents: 22000 }, // Sat
+    ]
+    const deluxeTotal = deluxeRates.reduce((s, r) => s + r.sellAmountCents, 0)
+
+    const [deluxeBookingItem] = await db
+      .insert(bookingItems)
+      .values({
+        bookingId,
+        title: "Deluxe room, 3 nights",
+        itemType: "accommodation",
+        sellCurrency: "EUR",
+        unitSellAmountCents: Math.floor(deluxeTotal / 3),
+        totalSellAmountCents: deluxeTotal,
+        quantity: 1,
+      })
+      .returning()
+
+    const [deluxeStay] = await db
+      .insert(stayBookingItems)
+      .values({
+        bookingItemId: deluxeBookingItem.id,
+        propertyId,
+        roomTypeId: deluxeId,
+        ratePlanId,
+        mealPlanId: breakfastMealPlan,
+        checkInDate: "2026-09-10",
+        checkOutDate: "2026-09-13",
+        nightCount: 3,
+        roomCount: 1,
+        adults: 2,
+      })
+      .returning()
+
+    await db.insert(stayDailyRates).values(
+      deluxeRates.map((r) => ({
+        stayBookingItemId: deluxeStay.id,
+        date: r.date,
+        sellCurrency: "EUR",
+        sellAmountCents: r.sellAmountCents,
+      })),
+    )
+
+    // Item 2: Suite, nights 13-17 (4 nights). Note check-in matches the
+    // previous item's check-out — that's how the schema represents a
+    // mid-stay move.
+    const suiteRates = [
+      { date: "2026-09-13", sellAmountCents: 30000 }, // Sun
+      { date: "2026-09-14", sellAmountCents: 28000 }, // Mon
+      { date: "2026-09-15", sellAmountCents: 28000 }, // Tue
+      { date: "2026-09-16", sellAmountCents: 28000 }, // Wed
+    ]
+    const suiteTotal = suiteRates.reduce((s, r) => s + r.sellAmountCents, 0)
+
+    const [suiteBookingItem] = await db
+      .insert(bookingItems)
+      .values({
+        bookingId,
+        title: "Suite, 4 nights",
+        itemType: "accommodation",
+        sellCurrency: "EUR",
+        unitSellAmountCents: Math.floor(suiteTotal / 4),
+        totalSellAmountCents: suiteTotal,
+        quantity: 1,
+      })
+      .returning()
+
+    const [suiteStay] = await db
+      .insert(stayBookingItems)
+      .values({
+        bookingItemId: suiteBookingItem.id,
+        propertyId,
+        roomTypeId: suiteId,
+        ratePlanId,
+        mealPlanId: breakfastMealPlan,
+        checkInDate: "2026-09-13",
+        checkOutDate: "2026-09-17",
+        nightCount: 4,
+        roomCount: 1,
+        adults: 2,
+        children: 1,
+      })
+      .returning()
+
+    await db.insert(stayDailyRates).values(
+      suiteRates.map((r) => ({
+        stayBookingItemId: suiteStay.id,
+        date: r.date,
+        sellCurrency: "EUR",
+        sellAmountCents: r.sellAmountCents,
+      })),
+    )
+
+    // Item 3: Parking — pure booking_items, no stay extension
+    const parkingTotal = 7000 // 1000/night × 7
+    await db.insert(bookingItems).values({
+      bookingId,
+      title: "Self-parking, 7 nights",
+      itemType: "extra",
+      sellCurrency: "EUR",
+      unitSellAmountCents: 1000,
+      totalSellAmountCents: parkingTotal,
+      quantity: 7,
+    })
+
+    // ---- Roll the booking total ------------------------------------------
+    const expectedTotal = deluxeTotal + suiteTotal + parkingTotal
+    await db
+      .update(bookings)
+      .set({ sellAmountCents: expectedTotal, updatedAt: new Date() })
+      .where(eq(bookings.id, bookingId))
+
+    // ---- Assert ---------------------------------------------------------
+
+    // 1. Two stay_booking_items, contiguous date ranges, totals 7 nights
+    const stays = await db
+      .select()
+      .from(stayBookingItems)
+      .where(
+        sql`${stayBookingItems.bookingItemId} IN (
+          SELECT id FROM booking_items WHERE booking_id = ${bookingId}
+        )`,
+      )
+    expect(stays).toHaveLength(2)
+    const totalNights = stays.reduce(
+      (sum: number, s: { nightCount: number }) => sum + s.nightCount,
+      0,
+    )
+    expect(totalNights).toBe(7)
+    const sortedStays = [...stays].sort((a: { checkInDate: string }, b: { checkInDate: string }) =>
+      a.checkInDate.localeCompare(b.checkInDate),
+    )
+    expect(sortedStays[0]?.checkInDate).toBe("2026-09-10")
+    expect(sortedStays[0]?.checkOutDate).toBe("2026-09-13")
+    expect(sortedStays[1]?.checkInDate).toBe("2026-09-13")
+    expect(sortedStays[1]?.checkOutDate).toBe("2026-09-17")
+
+    // 2. Per-night daily rates for both stays sum to the booking item totals
+    const rates = await db
+      .select()
+      .from(stayDailyRates)
+      .where(
+        sql`${stayDailyRates.stayBookingItemId} IN (${sql.join(
+          stays.map((s: { id: string }) => sql`${s.id}`),
+          sql`, `,
+        )})`,
+      )
+    expect(rates).toHaveLength(7)
+    const rateSum = rates.reduce(
+      (sum: number, r: { sellAmountCents: number | null }) => sum + (r.sellAmountCents ?? 0),
+      0,
+    )
+    expect(rateSum).toBe(deluxeTotal + suiteTotal)
+
+    // 3. Booking total covers stays + parking
+    const [refreshedBooking] = await db
+      .select({ sellAmountCents: bookings.sellAmountCents })
+      .from(bookings)
+      .where(eq(bookings.id, bookingId))
+    expect(refreshedBooking?.sellAmountCents).toBe(expectedTotal)
+
+    // 4. Both stays reference the breakfast meal plan
+    expect(
+      stays.every((s: { mealPlanId: string | null }) => s.mealPlanId === breakfastMealPlan),
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #293.

## Summary

Exercises the bookings + hospitality schema against a realistic 7-night stay with a mid-stay room change. The integration test is the executable proof; \`docs/architecture/hotel-booking-validation.md\` captures findings — what works, what's awkward, what's missing — and lists the service-layer follow-ups that surfaced.

## Use case

7-night stay, 2 adults + 1 child:

- Nights 1-3 in a Deluxe (max 3 occupants)
- Nights 4-7 in a Suite (max 4 occupants — child capacity is the reason for the upgrade)
- B&B meal plan throughout
- Self-parking add-on for all 7 nights

## Verdict

**The schema supports the multi-night-with-room-change use case without modification.** The test asserts contiguous date ranges, per-night rate variation, mixed occupancy across segments, shared meal plan, and add-on aggregation.

The follow-ups that surfaced are **service-layer**, not schema-layer:

1. Per-segment cancellation policy fan-out (legal package)
2. Atomic inventory consumption at stay-reserve time (hospitality)
3. Rate-card resolver from rate plan + room type + date (hospitality / pricing)
4. Booking-total auto-rollup helper (bookings or finance)

Each of those should be filed as a follow-up issue.

## Lightly-considered

- **Multi-segment flights with stopover** — schema doesn't have a \`flight_booking_items\` extension yet; that addition + per-segment fields are a separate effort.
- **Packaged trips (hotel + flight + activity)** — decomposes naturally into mixed \`booking_items\`, but cross-segment package discount (when package < sum of components) doesn't have a clean representation today. Either synthetic discount line or a "package" concept addition.

These need product input before becoming concrete issues.

## Test plan

- [x] 1 integration test asserts contiguous date ranges, per-night rates, add-ons, mixed occupancy, shared meal plan.
- [x] Skipped without \`TEST_DATABASE_URL\` per the existing convention; will run in CI with the configured Postgres.
- [x] \`pnpm typecheck\` clean for hospitality.