### PR TITLE
feat(bookings): auto-rollup booking total from booking_items (#313)

### DIFF
--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -2809,88 +2809,157 @@ export const bookingsService = {
       .orderBy(asc(bookingItems.createdAt))
   },
 
+  /**
+   * Re-derive `bookings.sellAmountCents` and `bookings.costAmountCents`
+   * from `Σ(booking_items.total*AmountCents)` and persist the parent.
+   *
+   * Called automatically inside the item-mutation methods on this service
+   * so callers that go through `createItem` / `updateItem` / `deleteItem`
+   * never have to remember to roll the parent. Public so external flows
+   * (saga compensations, ad-hoc fix-ups) can also invoke it.
+   *
+   * Pass a tx-bound `db` to compose with an existing transaction; this
+   * method does NOT wrap its own transaction.
+   *
+   * NOTE: the base-currency totals (`baseSellAmountCents` /
+   * `baseCostAmountCents`) are NOT recomputed here — they're derived from
+   * FX which lives outside this rollup. Callers that mutate items in a
+   * non-base-currency context must run their own FX rollup separately.
+   */
+  async recomputeBookingTotal(db: PostgresJsDatabase, bookingId: string) {
+    const [exists] = await db
+      .select({ id: bookings.id })
+      .from(bookings)
+      .where(eq(bookings.id, bookingId))
+      .limit(1)
+    if (!exists) {
+      return null
+    }
+
+    const [totals] = await db
+      .select({
+        sellAmountCents: sql<number>`coalesce(sum(${bookingItems.totalSellAmountCents}), 0)::int`,
+        costAmountCents: sql<number>`coalesce(sum(${bookingItems.totalCostAmountCents}), 0)::int`,
+      })
+      .from(bookingItems)
+      .where(eq(bookingItems.bookingId, bookingId))
+
+    const sellAmountCents = totals?.sellAmountCents ?? 0
+    const costAmountCents = totals?.costAmountCents ?? 0
+
+    await db
+      .update(bookings)
+      .set({ sellAmountCents, costAmountCents, updatedAt: new Date() })
+      .where(eq(bookings.id, bookingId))
+
+    return { sellAmountCents, costAmountCents }
+  },
+
   async createItem(
     db: PostgresJsDatabase,
     bookingId: string,
     data: CreateBookingItemInput,
     userId?: string,
   ) {
-    const [booking] = await db
-      .select({ id: bookings.id, sellCurrency: bookings.sellCurrency })
-      .from(bookings)
-      .where(eq(bookings.id, bookingId))
-      .limit(1)
+    return db.transaction(async (tx) => {
+      const [booking] = await tx
+        .select({ id: bookings.id, sellCurrency: bookings.sellCurrency })
+        .from(bookings)
+        .where(eq(bookings.id, bookingId))
+        .limit(1)
 
-    if (!booking) {
-      return null
-    }
+      if (!booking) {
+        return null
+      }
 
-    const [row] = await db
-      .insert(bookingItems)
-      .values({
+      const [row] = await tx
+        .insert(bookingItems)
+        .values({
+          bookingId,
+          title: data.title,
+          description: data.description ?? null,
+          itemType: data.itemType,
+          status: data.status,
+          serviceDate: data.serviceDate ?? null,
+          startsAt: toTimestamp(data.startsAt),
+          endsAt: toTimestamp(data.endsAt),
+          quantity: data.quantity,
+          sellCurrency: data.sellCurrency ?? booking.sellCurrency,
+          unitSellAmountCents: data.unitSellAmountCents ?? null,
+          totalSellAmountCents: data.totalSellAmountCents ?? null,
+          costCurrency: data.costCurrency ?? null,
+          unitCostAmountCents: data.unitCostAmountCents ?? null,
+          totalCostAmountCents: data.totalCostAmountCents ?? null,
+          notes: data.notes ?? null,
+          productId: data.productId ?? null,
+          optionId: data.optionId ?? null,
+          optionUnitId: data.optionUnitId ?? null,
+          pricingCategoryId: data.pricingCategoryId ?? null,
+          sourceSnapshotId: data.sourceSnapshotId ?? null,
+          sourceOfferId: data.sourceOfferId ?? null,
+          metadata: data.metadata ?? null,
+        })
+        .returning()
+
+      if (!row) {
+        return null
+      }
+
+      await tx.insert(bookingActivityLog).values({
         bookingId,
-        title: data.title,
-        description: data.description ?? null,
-        itemType: data.itemType,
-        status: data.status,
-        serviceDate: data.serviceDate ?? null,
-        startsAt: toTimestamp(data.startsAt),
-        endsAt: toTimestamp(data.endsAt),
-        quantity: data.quantity,
-        sellCurrency: data.sellCurrency ?? booking.sellCurrency,
-        unitSellAmountCents: data.unitSellAmountCents ?? null,
-        totalSellAmountCents: data.totalSellAmountCents ?? null,
-        costCurrency: data.costCurrency ?? null,
-        unitCostAmountCents: data.unitCostAmountCents ?? null,
-        totalCostAmountCents: data.totalCostAmountCents ?? null,
-        notes: data.notes ?? null,
-        productId: data.productId ?? null,
-        optionId: data.optionId ?? null,
-        optionUnitId: data.optionUnitId ?? null,
-        pricingCategoryId: data.pricingCategoryId ?? null,
-        sourceSnapshotId: data.sourceSnapshotId ?? null,
-        sourceOfferId: data.sourceOfferId ?? null,
-        metadata: data.metadata ?? null,
+        actorId: userId ?? "system",
+        activityType: "item_update",
+        description: `Booking item "${data.title}" added`,
+        metadata: { bookingItemId: row.id, itemType: data.itemType },
       })
-      .returning()
 
-    if (!row) {
-      return null
-    }
+      await bookingsService.recomputeBookingTotal(tx as PostgresJsDatabase, bookingId)
 
-    await db.insert(bookingActivityLog).values({
-      bookingId,
-      actorId: userId ?? "system",
-      activityType: "item_update",
-      description: `Booking item "${data.title}" added`,
-      metadata: { bookingItemId: row.id, itemType: data.itemType },
+      return row
     })
-
-    return row
   },
 
   async updateItem(db: PostgresJsDatabase, itemId: string, data: UpdateBookingItemInput) {
-    const [row] = await db
-      .update(bookingItems)
-      .set({
-        ...data,
-        startsAt: data.startsAt === undefined ? undefined : toTimestamp(data.startsAt),
-        endsAt: data.endsAt === undefined ? undefined : toTimestamp(data.endsAt),
-        updatedAt: new Date(),
-      })
-      .where(eq(bookingItems.id, itemId))
-      .returning()
+    return db.transaction(async (tx) => {
+      const [row] = await tx
+        .update(bookingItems)
+        .set({
+          ...data,
+          startsAt: data.startsAt === undefined ? undefined : toTimestamp(data.startsAt),
+          endsAt: data.endsAt === undefined ? undefined : toTimestamp(data.endsAt),
+          updatedAt: new Date(),
+        })
+        .where(eq(bookingItems.id, itemId))
+        .returning()
 
-    return row ?? null
+      if (!row) return null
+
+      await bookingsService.recomputeBookingTotal(tx as PostgresJsDatabase, row.bookingId)
+      return row
+    })
   },
 
   async deleteItem(db: PostgresJsDatabase, itemId: string) {
-    const [row] = await db
-      .delete(bookingItems)
-      .where(eq(bookingItems.id, itemId))
-      .returning({ id: bookingItems.id })
+    return db.transaction(async (tx) => {
+      // Look up the parent booking BEFORE the delete so we can roll up
+      // afterwards.
+      const [item] = await tx
+        .select({ bookingId: bookingItems.bookingId })
+        .from(bookingItems)
+        .where(eq(bookingItems.id, itemId))
+        .limit(1)
 
-    return row ?? null
+      const [row] = await tx
+        .delete(bookingItems)
+        .where(eq(bookingItems.id, itemId))
+        .returning({ id: bookingItems.id })
+
+      if (item) {
+        await bookingsService.recomputeBookingTotal(tx as PostgresJsDatabase, item.bookingId)
+      }
+
+      return row ?? null
+    })
   },
 
   listItemParticipants(db: PostgresJsDatabase, itemId: string) {

--- a/packages/bookings/tests/integration/auto-rollup-total.test.ts
+++ b/packages/bookings/tests/integration/auto-rollup-total.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Verifies that mutations going through `bookingsService.{createItem,
+ * updateItem, deleteItem}` keep `bookings.sellAmountCents` /
+ * `bookings.costAmountCents` consistent with `Σ(booking_items.total*)`.
+ *
+ * Closes #313.
+ */
+
+import { eq } from "drizzle-orm"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { bookings } from "../../src/schema.js"
+import { bookingsService } from "../../src/service.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+let counter = 0
+function nextNumber() {
+  counter += 1
+  return `BK-ROLL-${String(counter).padStart(6, "0")}`
+}
+
+describe.skipIf(!DB_AVAILABLE)("bookings auto-rollup", () => {
+  let db: ReturnType<typeof import("@voyantjs/db/test-utils").createTestDb>
+
+  beforeAll(async () => {
+    const { createTestDb, cleanupTestDb } = await import("@voyantjs/db/test-utils")
+    db = createTestDb()
+    await cleanupTestDb(db)
+  })
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyantjs/db/test-utils")
+    await closeTestDb()
+  })
+
+  beforeEach(async () => {
+    const { cleanupTestDb } = await import("@voyantjs/db/test-utils")
+    await cleanupTestDb(db)
+  })
+
+  async function seedBooking() {
+    const [row] = await db
+      .insert(bookings)
+      .values({
+        bookingNumber: nextNumber(),
+        sellCurrency: "EUR",
+      })
+      .returning()
+    if (!row) throw new Error("seedBooking: insert returned no rows")
+    return row
+  }
+
+  async function getTotals(bookingId: string) {
+    const [row] = await db
+      .select({
+        sellAmountCents: bookings.sellAmountCents,
+        costAmountCents: bookings.costAmountCents,
+      })
+      .from(bookings)
+      .where(eq(bookings.id, bookingId))
+    return row
+  }
+
+  it("createItem rolls up sellAmountCents and costAmountCents on the parent", async () => {
+    const booking = await seedBooking()
+
+    expect((await getTotals(booking.id))?.sellAmountCents).toBeNull()
+
+    await bookingsService.createItem(db, booking.id, {
+      title: "Half-day tour",
+      itemType: "unit",
+      status: "draft",
+      quantity: 2,
+      sellCurrency: "EUR",
+      unitSellAmountCents: 5000,
+      totalSellAmountCents: 10000,
+      costCurrency: "EUR",
+      unitCostAmountCents: 3000,
+      totalCostAmountCents: 6000,
+    })
+
+    expect(await getTotals(booking.id)).toEqual({
+      sellAmountCents: 10000,
+      costAmountCents: 6000,
+    })
+
+    await bookingsService.createItem(db, booking.id, {
+      title: "Pickup",
+      itemType: "extra",
+      status: "draft",
+      quantity: 1,
+      sellCurrency: "EUR",
+      unitSellAmountCents: 1500,
+      totalSellAmountCents: 1500,
+    })
+
+    expect(await getTotals(booking.id)).toEqual({
+      sellAmountCents: 11500,
+      costAmountCents: 6000,
+    })
+  })
+
+  it("updateItem re-rolls when totalSellAmountCents changes", async () => {
+    const booking = await seedBooking()
+    const created = await bookingsService.createItem(db, booking.id, {
+      title: "Tour",
+      itemType: "unit",
+      status: "draft",
+      quantity: 1,
+      sellCurrency: "EUR",
+      unitSellAmountCents: 10000,
+      totalSellAmountCents: 10000,
+    })
+    expect(created).not.toBeNull()
+    if (!created) throw new Error("createItem returned null")
+
+    await bookingsService.updateItem(db, created.id, {
+      totalSellAmountCents: 17500,
+    })
+
+    expect((await getTotals(booking.id))?.sellAmountCents).toBe(17500)
+  })
+
+  it("deleteItem re-rolls without the removed item", async () => {
+    const booking = await seedBooking()
+    const a = await bookingsService.createItem(db, booking.id, {
+      title: "Tour",
+      itemType: "unit",
+      status: "draft",
+      quantity: 1,
+      sellCurrency: "EUR",
+      unitSellAmountCents: 10000,
+      totalSellAmountCents: 10000,
+    })
+    await bookingsService.createItem(db, booking.id, {
+      title: "Pickup",
+      itemType: "extra",
+      status: "draft",
+      quantity: 1,
+      sellCurrency: "EUR",
+      unitSellAmountCents: 2000,
+      totalSellAmountCents: 2000,
+    })
+    expect((await getTotals(booking.id))?.sellAmountCents).toBe(12000)
+
+    if (!a) throw new Error("createItem returned null")
+    await bookingsService.deleteItem(db, a.id)
+
+    expect((await getTotals(booking.id))?.sellAmountCents).toBe(2000)
+  })
+
+  it("recomputeBookingTotal is idempotent and exposed for ad-hoc invocation", async () => {
+    const booking = await seedBooking()
+    await bookingsService.createItem(db, booking.id, {
+      title: "Tour",
+      itemType: "unit",
+      status: "draft",
+      quantity: 1,
+      sellCurrency: "EUR",
+      unitSellAmountCents: 5000,
+      totalSellAmountCents: 5000,
+    })
+
+    // Manually set the parent total to a stale value to simulate a prior
+    // bug — recompute should restore truth.
+    await db
+      .update(bookings)
+      .set({ sellAmountCents: 999, updatedAt: new Date() })
+      .where(eq(bookings.id, booking.id))
+
+    const result = await bookingsService.recomputeBookingTotal(db, booking.id)
+    expect(result).toEqual({ sellAmountCents: 5000, costAmountCents: 0 })
+    expect((await getTotals(booking.id))?.sellAmountCents).toBe(5000)
+
+    // Idempotent — calling again is a no-op.
+    const second = await bookingsService.recomputeBookingTotal(db, booking.id)
+    expect(second).toEqual({ sellAmountCents: 5000, costAmountCents: 0 })
+  })
+
+  it("treats null totalSellAmountCents as 0 — never NaN, never error", async () => {
+    const booking = await seedBooking()
+    await bookingsService.createItem(db, booking.id, {
+      title: "Pricing TBD",
+      itemType: "unit",
+      status: "draft",
+      quantity: 1,
+      sellCurrency: "EUR",
+      // unit/total left null intentionally
+    })
+
+    expect(await getTotals(booking.id)).toEqual({
+      sellAmountCents: 0,
+      costAmountCents: 0,
+    })
+  })
+
+  it("recomputeBookingTotal returns null for a missing booking", async () => {
+    const result = await bookingsService.recomputeBookingTotal(db, "book_does_not_exist")
+    expect(result).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #313.

## Summary

Adds \`bookingsService.recomputeBookingTotal(db, bookingId)\` and wires it into \`createItem\` / \`updateItem\` / \`deleteItem\` so callers never have to remember to re-roll the parent. Also exposed publicly for ad-hoc invocation (saga compensation, fix-up scripts).

## What ships

- \`recomputeBookingTotal\` sums \`booking_items.totalSellAmountCents\` and \`totalCostAmountCents\`, updates the parent. Returns computed totals or null if the booking is missing.
- \`createItem\` / \`updateItem\` / \`deleteItem\` now wrap their writes in \`db.transaction\` and call \`recomputeBookingTotal\` before committing — partial failures can never leave the parent total stale.

## Scope note

Base-currency totals (\`baseSellAmountCents\` / \`baseCostAmountCents\`) are NOT recomputed here — those are derived from FX which lives outside this rollup. Documented in the helper's JSDoc.

## Test plan

- [x] 6 integration tests:
  - createItem rolls up sell + cost on first add and on subsequent adds
  - updateItem re-rolls when totalSellAmountCents changes
  - deleteItem re-rolls without the removed item
  - recomputeBookingTotal exposed + idempotent + restores after manual stale state
  - null totalSellAmountCents treated as 0 (no NaN)
  - missing booking returns null
- [x] \`pnpm typecheck\` clean