### PR TITLE
feat(hospitality): atomic inventory consumption at stay-reserve (#311)

### DIFF
--- a/packages/hospitality/src/service.ts
+++ b/packages/hospitality/src/service.ts
@@ -169,7 +169,200 @@ function toDateOrNull(value: string | null | undefined) {
   return value ? new Date(value) : null
 }
 
+/**
+ * Iterate the dates from `start` (inclusive) to `end` (exclusive) as
+ * ISO YYYY-MM-DD strings. Hotel "nights" — checking out on the
+ * `endDate` does not consume that date's inventory.
+ */
+function eachNight(startDate: string, endDate: string): string[] {
+  const out: string[] = []
+  const start = new Date(`${startDate}T00:00:00Z`)
+  const end = new Date(`${endDate}T00:00:00Z`)
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    throw new Error("eachNight: invalid date input")
+  }
+  for (
+    let cursor = start;
+    cursor < end;
+    cursor = new Date(cursor.getTime() + 24 * 60 * 60 * 1000)
+  ) {
+    out.push(cursor.toISOString().slice(0, 10))
+  }
+  return out
+}
+
+/**
+ * Input for {@link reserveStay}. Mirrors the schema's stay_booking_items
+ * shape but consumes inventory atomically.
+ */
+export interface ReserveStayInput {
+  bookingItemId: string
+  propertyId: string
+  roomTypeId: string
+  ratePlanId: string
+  checkInDate: string
+  checkOutDate: string
+  roomCount?: number
+  adults?: number
+  children?: number
+  infants?: number
+  mealPlanId?: string | null
+  /**
+   * Per-night sell amounts. Length must equal nightCount; each row is
+   * inserted into `stay_daily_rates` for the corresponding night.
+   */
+  dailyRates: Array<{
+    sellCurrency: string
+    sellAmountCents?: number | null
+    costCurrency?: string | null
+    costAmountCents?: number | null
+    taxAmountCents?: number | null
+    feeAmountCents?: number | null
+    commissionAmountCents?: number | null
+  }>
+}
+
+export type ReserveStayResult =
+  | { status: "ok"; stayBookingItemId: string; nightCount: number }
+  | { status: "insufficient_capacity"; date: string; available: number; needed: number }
+  | { status: "stop_sell"; date: string }
+  | { status: "inventory_missing"; date: string }
+  | { status: "rate_count_mismatch"; expected: number; received: number }
+
 export const hospitalityService = {
+  /**
+   * Atomically reserve a stay against the property's pooled inventory.
+   *
+   * Steps inside one `db.transaction`:
+   * 1. Compute the per-night date range
+   * 2. For each night, lock the `room_inventory` row for
+   *    `(roomTypeId, date)` with `SELECT ... FOR UPDATE`
+   * 3. Reject if any night has `stopSell = true`, missing inventory, or
+   *    `availableUnits < roomCount`
+   * 4. Decrement `availableUnits`, increment `heldUnits` per night
+   * 5. Insert the `stay_booking_items` row
+   * 6. Insert the `stay_daily_rates` rows
+   *
+   * Concurrency: two callers reserving the last available room of a type
+   * for an overlapping date range serialize through the per-night
+   * `room_inventory` row lock; the loser receives
+   * `{ status: "insufficient_capacity" }` and never mutates inventory.
+   *
+   * **Scope:** pooled-mode room types only. Instance-mode (one
+   * `room_unit` per actual physical room, with check-in assignment) is
+   * out of scope here — instance reservation needs to also lock the
+   * specific room_unit and check `room_blocks` / maintenance overlap.
+   * Tracked separately.
+   */
+  async reserveStay(db: PostgresJsDatabase, input: ReserveStayInput): Promise<ReserveStayResult> {
+    const nights = eachNight(input.checkInDate, input.checkOutDate)
+    if (nights.length === 0) {
+      return { status: "rate_count_mismatch", expected: 0, received: input.dailyRates.length }
+    }
+    if (input.dailyRates.length !== nights.length) {
+      return {
+        status: "rate_count_mismatch",
+        expected: nights.length,
+        received: input.dailyRates.length,
+      }
+    }
+
+    const roomCount = input.roomCount ?? 1
+
+    return db.transaction(async (tx) => {
+      // Lock + check inventory for every night. Order by date so two
+      // concurrent reserves with overlapping ranges always grab locks in
+      // the same order — no deadlock possible.
+      for (const date of nights) {
+        const rows = await tx.execute(sql`
+          SELECT id, available_units, stop_sell
+          FROM ${roomInventory}
+          WHERE ${roomInventory.roomTypeId} = ${input.roomTypeId}
+            AND ${roomInventory.date} = ${date}
+          FOR UPDATE
+        `)
+        const row = (
+          rows as unknown as Array<{
+            id: string
+            available_units: number
+            stop_sell: boolean
+          }>
+        )[0]
+
+        if (!row) {
+          return { status: "inventory_missing" as const, date }
+        }
+        if (row.stop_sell) {
+          return { status: "stop_sell" as const, date }
+        }
+        if (row.available_units < roomCount) {
+          return {
+            status: "insufficient_capacity" as const,
+            date,
+            available: row.available_units,
+            needed: roomCount,
+          }
+        }
+      }
+
+      // All nights have capacity. Decrement.
+      for (const date of nights) {
+        await tx
+          .update(roomInventory)
+          .set({
+            availableUnits: sql`${roomInventory.availableUnits} - ${roomCount}`,
+            heldUnits: sql`${roomInventory.heldUnits} + ${roomCount}`,
+            updatedAt: new Date(),
+          })
+          .where(and(eq(roomInventory.roomTypeId, input.roomTypeId), eq(roomInventory.date, date)))
+      }
+
+      // Insert the stay row.
+      const [stayRow] = await tx
+        .insert(stayBookingItems)
+        .values({
+          bookingItemId: input.bookingItemId,
+          propertyId: input.propertyId,
+          roomTypeId: input.roomTypeId,
+          ratePlanId: input.ratePlanId,
+          mealPlanId: input.mealPlanId ?? null,
+          checkInDate: input.checkInDate,
+          checkOutDate: input.checkOutDate,
+          nightCount: nights.length,
+          roomCount,
+          adults: input.adults ?? 1,
+          children: input.children ?? 0,
+          infants: input.infants ?? 0,
+          status: "reserved",
+        })
+        .returning()
+
+      if (!stayRow) {
+        throw new Error("reserveStay: stay_booking_items insert returned no rows")
+      }
+
+      // Insert the per-night rate rows in lockstep with the date range.
+      await tx.insert(stayDailyRates).values(
+        nights.map((date, idx) => {
+          const rate = input.dailyRates[idx]!
+          return {
+            stayBookingItemId: stayRow.id,
+            date,
+            sellCurrency: rate.sellCurrency,
+            sellAmountCents: rate.sellAmountCents ?? null,
+            costCurrency: rate.costCurrency ?? null,
+            costAmountCents: rate.costAmountCents ?? null,
+            taxAmountCents: rate.taxAmountCents ?? null,
+            feeAmountCents: rate.feeAmountCents ?? null,
+            commissionAmountCents: rate.commissionAmountCents ?? null,
+          }
+        }),
+      )
+
+      return { status: "ok" as const, stayBookingItemId: stayRow.id, nightCount: nights.length }
+    })
+  },
+
   async listRoomTypes(db: PostgresJsDatabase, query: RoomTypeListQuery) {
     const conditions = []
     if (query.propertyId) conditions.push(eq(roomTypes.propertyId, query.propertyId))

--- a/packages/hospitality/tests/integration/atomic-stay-reserve.test.ts
+++ b/packages/hospitality/tests/integration/atomic-stay-reserve.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Closes #311.
+ *
+ * Verifies that concurrent stay reservations against pooled-mode room
+ * inventory serialize through the per-night `room_inventory` row lock,
+ * so exactly the right number of reserves succeed and the rest receive
+ * a typed `insufficient_capacity` failure.
+ *
+ * Pattern mirrors `packages/bookings/tests/integration/concurrency.test.ts`.
+ */
+
+import { bookingItems, bookings } from "@voyantjs/bookings/schema"
+import { facilities, properties } from "@voyantjs/facilities/schema"
+import { and, eq } from "drizzle-orm"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { ratePlanRoomTypes, ratePlans, roomInventory, roomTypes } from "../../src/schema.js"
+import { stayBookingItems } from "../../src/schema-bookings.js"
+import { hospitalityService } from "../../src/service.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+let counter = 0
+function id(prefix: string) {
+  counter += 1
+  return `${prefix}_atomic${counter}`
+}
+
+describe.skipIf(!DB_AVAILABLE)("hospitality.reserveStay — atomic inventory consumption", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test db
+  let db: any
+  let propertyId: string
+  let roomTypeId: string
+  let ratePlanId: string
+
+  beforeAll(async () => {
+    const { createTestDb, cleanupTestDb } = await import("@voyantjs/db/test-utils")
+    db = createTestDb()
+    await cleanupTestDb(db)
+  })
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyantjs/db/test-utils")
+    await closeTestDb()
+  })
+
+  beforeEach(async () => {
+    const { cleanupTestDb } = await import("@voyantjs/db/test-utils")
+    await cleanupTestDb(db)
+
+    const facilityId = id("fac")
+    await db.insert(facilities).values({ id: facilityId, name: "Test Hotel", type: "property" })
+    propertyId = id("prop")
+    await db.insert(properties).values({
+      id: propertyId,
+      facilityId,
+      propertyType: "hotel",
+    })
+    roomTypeId = id("hrmt")
+    await db.insert(roomTypes).values({
+      id: roomTypeId,
+      propertyId,
+      code: "STD",
+      name: "Standard",
+    })
+    ratePlanId = id("hrpl")
+    await db.insert(ratePlans).values({
+      id: ratePlanId,
+      propertyId,
+      code: "BAR",
+      name: "Best Available Rate",
+      currencyCode: "EUR",
+    })
+    await db.insert(ratePlanRoomTypes).values({ id: id("hrrt"), ratePlanId, roomTypeId })
+  })
+
+  async function seedInventory(dates: string[], totalUnits: number, available: number) {
+    await db.insert(roomInventory).values(
+      dates.map((date) => ({
+        id: id("hriv"),
+        propertyId,
+        roomTypeId,
+        date,
+        totalUnits,
+        availableUnits: available,
+      })),
+    )
+  }
+
+  async function seedBooking() {
+    const [booking] = await db
+      .insert(bookings)
+      .values({
+        bookingNumber: `BK-STAY-${counter}`,
+        sellCurrency: "EUR",
+      })
+      .returning()
+    const [item] = await db
+      .insert(bookingItems)
+      .values({
+        bookingId: booking.id,
+        title: "Stay placeholder",
+        itemType: "accommodation",
+        sellCurrency: "EUR",
+      })
+      .returning()
+    return { bookingId: booking.id as string, bookingItemId: item.id as string }
+  }
+
+  function reservePayload(bookingItemId: string, checkInDate: string, checkOutDate: string) {
+    const nightCount = Math.round(
+      (new Date(`${checkOutDate}T00:00:00Z`).getTime() -
+        new Date(`${checkInDate}T00:00:00Z`).getTime()) /
+        (24 * 60 * 60 * 1000),
+    )
+    return {
+      bookingItemId,
+      propertyId,
+      roomTypeId,
+      ratePlanId,
+      checkInDate,
+      checkOutDate,
+      adults: 2,
+      dailyRates: Array.from({ length: nightCount }, () => ({
+        sellCurrency: "EUR" as const,
+        sellAmountCents: 12000,
+      })),
+    }
+  }
+
+  it("two concurrent reserves on the last available room — exactly one succeeds, one returns insufficient_capacity", async () => {
+    await seedInventory(["2026-09-10", "2026-09-11"], 5, 1)
+    const a = await seedBooking()
+    const b = await seedBooking()
+
+    const [resultA, resultB] = await Promise.all([
+      hospitalityService.reserveStay(
+        db,
+        reservePayload(a.bookingItemId, "2026-09-10", "2026-09-12"),
+      ),
+      hospitalityService.reserveStay(
+        db,
+        reservePayload(b.bookingItemId, "2026-09-10", "2026-09-12"),
+      ),
+    ])
+
+    const successes = [resultA, resultB].filter((r) => r.status === "ok")
+    const conflicts = [resultA, resultB].filter((r) => r.status === "insufficient_capacity")
+    expect(successes).toHaveLength(1)
+    expect(conflicts).toHaveLength(1)
+
+    // Inventory rolled correctly: both nights at 0 available, 1 held
+    const inventoryRows = await db
+      .select()
+      .from(roomInventory)
+      .where(eq(roomInventory.roomTypeId, roomTypeId))
+    expect(inventoryRows).toHaveLength(2)
+    for (const row of inventoryRows) {
+      expect(row.availableUnits).toBe(0)
+      expect(row.heldUnits).toBe(1)
+    }
+
+    // Exactly one stay_booking_items row created
+    const stays = await db.select().from(stayBookingItems)
+    expect(stays).toHaveLength(1)
+  })
+
+  it("ten concurrent reserves on a 5-room slot — exactly five succeed", async () => {
+    await seedInventory(["2026-09-10", "2026-09-11"], 5, 5)
+    const seeded = await Promise.all(Array.from({ length: 10 }, () => seedBooking()))
+
+    const results = await Promise.all(
+      seeded.map((b) =>
+        hospitalityService.reserveStay(
+          db,
+          reservePayload(b.bookingItemId, "2026-09-10", "2026-09-12"),
+        ),
+      ),
+    )
+
+    const ok = results.filter((r) => r.status === "ok")
+    const conflicts = results.filter((r) => r.status === "insufficient_capacity")
+    expect(ok).toHaveLength(5)
+    expect(conflicts).toHaveLength(5)
+
+    const inventoryRows = await db
+      .select()
+      .from(roomInventory)
+      .where(eq(roomInventory.roomTypeId, roomTypeId))
+    for (const row of inventoryRows) {
+      expect(row.availableUnits).toBe(0)
+      expect(row.heldUnits).toBe(5)
+    }
+  })
+
+  it("rejects when a single night within the range is sold out", async () => {
+    // Day 1 has 5 available, day 2 has 0 available — reserve fails on day 2,
+    // day 1 inventory MUST NOT be touched (atomic check).
+    await seedInventory(["2026-09-10"], 5, 5)
+    await seedInventory(["2026-09-11"], 5, 0)
+    const a = await seedBooking()
+
+    const result = await hospitalityService.reserveStay(
+      db,
+      reservePayload(a.bookingItemId, "2026-09-10", "2026-09-12"),
+    )
+    expect(result.status).toBe("insufficient_capacity")
+    if (result.status !== "insufficient_capacity") throw new Error()
+    expect(result.date).toBe("2026-09-11")
+
+    // Day 1 inventory must be untouched
+    const [day1] = await db
+      .select()
+      .from(roomInventory)
+      .where(and(eq(roomInventory.roomTypeId, roomTypeId), eq(roomInventory.date, "2026-09-10")))
+    expect(day1.availableUnits).toBe(5)
+    expect(day1.heldUnits).toBe(0)
+  })
+
+  it("rejects when stop_sell is true on any night", async () => {
+    await db.insert(roomInventory).values([
+      {
+        id: id("hriv"),
+        propertyId,
+        roomTypeId,
+        date: "2026-09-10",
+        totalUnits: 5,
+        availableUnits: 5,
+      },
+      {
+        id: id("hriv"),
+        propertyId,
+        roomTypeId,
+        date: "2026-09-11",
+        totalUnits: 5,
+        availableUnits: 5,
+        stopSell: true,
+      },
+    ])
+    const a = await seedBooking()
+
+    const result = await hospitalityService.reserveStay(
+      db,
+      reservePayload(a.bookingItemId, "2026-09-10", "2026-09-12"),
+    )
+    expect(result.status).toBe("stop_sell")
+  })
+
+  it("rejects with inventory_missing when no row exists for a night", async () => {
+    await seedInventory(["2026-09-10"], 5, 5) // only one of the two nights
+    const a = await seedBooking()
+
+    const result = await hospitalityService.reserveStay(
+      db,
+      reservePayload(a.bookingItemId, "2026-09-10", "2026-09-12"),
+    )
+    expect(result.status).toBe("inventory_missing")
+    if (result.status !== "inventory_missing") throw new Error()
+    expect(result.date).toBe("2026-09-11")
+  })
+
+  it("rejects rate_count_mismatch when dailyRates length doesn't match the night count", async () => {
+    await seedInventory(["2026-09-10", "2026-09-11"], 5, 5)
+    const a = await seedBooking()
+
+    const result = await hospitalityService.reserveStay(db, {
+      bookingItemId: a.bookingItemId,
+      propertyId,
+      roomTypeId,
+      ratePlanId,
+      checkInDate: "2026-09-10",
+      checkOutDate: "2026-09-12",
+      adults: 2,
+      dailyRates: [{ sellCurrency: "EUR", sellAmountCents: 12000 }], // wrong length
+    })
+    expect(result.status).toBe("rate_count_mismatch")
+    if (result.status !== "rate_count_mismatch") throw new Error()
+    expect(result.expected).toBe(2)
+    expect(result.received).toBe(1)
+
+    // Inventory not touched
+    const inventoryRows = await db
+      .select()
+      .from(roomInventory)
+      .where(eq(roomInventory.roomTypeId, roomTypeId))
+    for (const row of inventoryRows) {
+      expect(row.availableUnits).toBe(5)
+    }
+  })
+})


### PR DESCRIPTION
Closes #311.

## Summary

Adds \`hospitalityService.reserveStay(db, input)\` that wraps inventory check + decrement + \`stay_booking_items\` insert + \`stay_daily_rates\` insert in a single \`db.transaction\`. Two callers reserving the last available room of a type for overlapping dates serialize through per-night \`room_inventory\` row locks; the loser receives a typed \`insufficient_capacity\` failure without touching inventory.

## Steps

1. Compute the per-night date range
2. \`SELECT ... FOR UPDATE\` each night's \`room_inventory\` row, in **date-sorted order** so concurrent reserves with overlapping ranges always grab locks in the same order — no deadlock possible
3. Reject if any night is \`stop_sell = true\`, missing, or has \`available_units < roomCount\`
4. Decrement \`available_units\` and increment \`held_units\` per night
5. Insert \`stay_booking_items\`
6. Insert \`stay_daily_rates\` rows in lockstep with the date range

## Scope

**Pooled-mode room types only.** Instance-mode (one \`room_unit\` per physical room with check-in assignment) needs to also lock the specific \`room_unit\` and check \`room_blocks\` / maintenance overlap. That's a follow-up.

## Test plan

- [x] 6 integration tests:
  - 2 concurrent reserves on the last available room → 1 succeeds, 1 fails
  - 10 concurrent reserves on a 5-room slot → 5 succeed, 5 conflict
  - Day-mid sold out → fails on day 2; day 1 inventory untouched (atomicity check)
  - \`stop_sell\` on any night → typed \`stop_sell\` failure
  - Missing inventory row for any night → \`inventory_missing\`
  - \`dailyRates\` length mismatch → \`rate_count_mismatch\`, no inventory mutation
- [x] \`pnpm typecheck\` clean