### PR TITLE
feat(hospitality): rate-card resolver from rate plan + room type + date range (#312)

### DIFF
--- a/packages/hospitality/src/service.ts
+++ b/packages/hospitality/src/service.ts
@@ -229,7 +229,145 @@ export type ReserveStayResult =
   | { status: "inventory_missing"; date: string }
   | { status: "rate_count_mismatch"; expected: number; received: number }
 
+/**
+ * Per-night rate row produced by {@link resolveStayDailyRates}. Shape
+ * matches the input expected by {@link reserveStay}'s `dailyRates`.
+ */
+export interface ResolvedDailyRate {
+  date: string
+  sellCurrency: string
+  sellAmountCents: number | null
+  extraAdultAmountCents: number | null
+  extraChildAmountCents: number | null
+  extraInfantAmountCents: number | null
+}
+
+export type ResolveStayDailyRatesResult =
+  | { status: "ok"; rates: ResolvedDailyRate[] }
+  | { status: "rate_not_found"; ratePlanId: string; roomTypeId: string }
+  | { status: "stop_sell"; date: string }
+  | { status: "closed_to_arrival"; date: string }
+  | { status: "closed_to_departure"; date: string }
+
+export interface ResolveStayDailyRatesInput {
+  ratePlanId: string
+  roomTypeId: string
+  /** Inclusive ISO YYYY-MM-DD. */
+  startDate: string
+  /** Exclusive ISO YYYY-MM-DD (hotel checkout convention). */
+  endDate: string
+}
+
 export const hospitalityService = {
+  /**
+   * Resolve the per-night rate card for a (rate plan, room type, date
+   * range) tuple — produces the array shape that
+   * {@link reserveStay}'s `dailyRates` consumes.
+   *
+   * **Resolution rules:**
+   *
+   * 1. The base rate comes from `room_type_rates.baseAmountCents` for
+   *    the (ratePlanId, roomTypeId) pair. Currently flat — every night
+   *    in the range gets the same base amount.
+   * 2. `rate_plan_inventory_overrides` is consulted for restrictions
+   *    only:
+   *    - `stop_sell` on any night → typed `stop_sell` failure
+   *    - `closed_to_arrival` on the FIRST night → `closed_to_arrival`
+   *    - `closed_to_departure` on the night BEFORE the checkout date
+   *      → `closed_to_departure`
+   * 3. Currency is taken from `room_type_rates.currencyCode`.
+   *
+   * **What this resolver does NOT (yet) do:**
+   *
+   * - Date-scoped rate variation (weekend bumps, seasonal pricing).
+   *   The schema's `room_type_rates` is flat per (rate plan, room
+   *   type); date-scoped variation lives on the linked
+   *   `priceScheduleId` in the pricing module, which this resolver
+   *   does not yet consult. Wiring price-schedule resolution is a
+   *   follow-up.
+   * - Length-of-stay discounts.
+   * - Promo codes.
+   *
+   * Pass the result directly to `reserveStay`'s `dailyRates`.
+   */
+  async resolveStayDailyRates(
+    db: PostgresJsDatabase,
+    input: ResolveStayDailyRatesInput,
+  ): Promise<ResolveStayDailyRatesResult> {
+    const nights = eachNight(input.startDate, input.endDate)
+    if (nights.length === 0) {
+      return { status: "ok", rates: [] }
+    }
+
+    const [rate] = await db
+      .select()
+      .from(roomTypeRates)
+      .where(
+        and(
+          eq(roomTypeRates.ratePlanId, input.ratePlanId),
+          eq(roomTypeRates.roomTypeId, input.roomTypeId),
+          eq(roomTypeRates.active, true),
+        ),
+      )
+      .limit(1)
+
+    if (!rate) {
+      return {
+        status: "rate_not_found",
+        ratePlanId: input.ratePlanId,
+        roomTypeId: input.roomTypeId,
+      }
+    }
+
+    const overrides = await db
+      .select()
+      .from(ratePlanInventoryOverrides)
+      .where(
+        and(
+          eq(ratePlanInventoryOverrides.ratePlanId, input.ratePlanId),
+          eq(ratePlanInventoryOverrides.roomTypeId, input.roomTypeId),
+          gte(ratePlanInventoryOverrides.date, nights[0]!),
+          lte(ratePlanInventoryOverrides.date, nights[nights.length - 1]!),
+        ),
+      )
+    const overridesByDate = new Map<string, (typeof overrides)[number]>()
+    for (const ov of overrides) {
+      overridesByDate.set(ov.date, ov)
+    }
+
+    // Stop-sell on any night → reject the whole range
+    for (const date of nights) {
+      const ov = overridesByDate.get(date)
+      if (ov?.stopSell) {
+        return { status: "stop_sell", date }
+      }
+    }
+    // Closed-to-arrival on the first night → reject
+    const firstNight = nights[0]!
+    if (overridesByDate.get(firstNight)?.closedToArrival) {
+      return { status: "closed_to_arrival", date: firstNight }
+    }
+    // Closed-to-departure on the last night before checkout → reject.
+    // The "last night" is the night before endDate; eachNight() returned
+    // the inclusive list, so it's the array's tail.
+    const lastNight = nights[nights.length - 1]!
+    if (overridesByDate.get(lastNight)?.closedToDeparture) {
+      return { status: "closed_to_departure", date: lastNight }
+    }
+
+    return {
+      status: "ok",
+      rates: nights.map((date) => ({
+        date,
+        sellCurrency: rate.currencyCode,
+        sellAmountCents: rate.baseAmountCents,
+        extraAdultAmountCents: rate.extraAdultAmountCents,
+        extraChildAmountCents: rate.extraChildAmountCents,
+        extraInfantAmountCents: rate.extraInfantAmountCents,
+      })),
+    }
+  },
+
   /**
    * Atomically reserve a stay against the property's pooled inventory.
    *

--- a/packages/hospitality/tests/integration/rate-resolver.test.ts
+++ b/packages/hospitality/tests/integration/rate-resolver.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Closes #312.
+ *
+ * Verifies `hospitalityService.resolveStayDailyRates` reads the flat
+ * base rate from `room_type_rates` for a (rate plan, room type) pair
+ * and applies `rate_plan_inventory_overrides` restrictions on the
+ * date range.
+ *
+ * Date-scoped rate variation (weekend bumps via the linked
+ * `priceScheduleId` in the pricing module) is NOT covered here — see
+ * the resolver's JSDoc and the follow-up filed as #312's notes.
+ */
+
+import { facilities, properties } from "@voyantjs/facilities/schema"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import {
+  ratePlanInventoryOverrides,
+  ratePlans,
+  roomTypeRates,
+  roomTypes,
+} from "../../src/schema.js"
+import { hospitalityService } from "../../src/service.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+let counter = 0
+function id(prefix: string) {
+  counter += 1
+  return `${prefix}_resolver${counter}`
+}
+
+describe.skipIf(!DB_AVAILABLE)("hospitality.resolveStayDailyRates", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test db
+  let db: any
+  let propertyId: string
+  let roomTypeId: string
+  let ratePlanId: string
+
+  beforeAll(async () => {
+    const { createTestDb, cleanupTestDb } = await import("@voyantjs/db/test-utils")
+    db = createTestDb()
+    await cleanupTestDb(db)
+  })
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyantjs/db/test-utils")
+    await closeTestDb()
+  })
+
+  beforeEach(async () => {
+    const { cleanupTestDb } = await import("@voyantjs/db/test-utils")
+    await cleanupTestDb(db)
+
+    const facilityId = id("fac")
+    await db.insert(facilities).values({ id: facilityId, name: "Resolver Hotel", type: "property" })
+    propertyId = id("prop")
+    await db.insert(properties).values({ id: propertyId, facilityId, propertyType: "hotel" })
+    roomTypeId = id("hrmt")
+    await db.insert(roomTypes).values({ id: roomTypeId, propertyId, code: "STD", name: "Standard" })
+    ratePlanId = id("hrpl")
+    await db.insert(ratePlans).values({
+      id: ratePlanId,
+      propertyId,
+      code: "BAR",
+      name: "Best Available Rate",
+      currencyCode: "EUR",
+    })
+  })
+
+  async function seedRate(amount: number) {
+    await db.insert(roomTypeRates).values({
+      id: id("hrtr"),
+      ratePlanId,
+      roomTypeId,
+      currencyCode: "EUR",
+      baseAmountCents: amount,
+      extraAdultAmountCents: 2000,
+      extraChildAmountCents: 1000,
+    })
+  }
+
+  it("flat rate plan returns N identical nightly rows", async () => {
+    await seedRate(15000)
+
+    const result = await hospitalityService.resolveStayDailyRates(db, {
+      ratePlanId,
+      roomTypeId,
+      startDate: "2026-09-10",
+      endDate: "2026-09-13", // 3 nights
+    })
+    expect(result.status).toBe("ok")
+    if (result.status !== "ok") throw new Error()
+
+    expect(result.rates).toHaveLength(3)
+    expect(result.rates.map((r) => r.date)).toEqual(["2026-09-10", "2026-09-11", "2026-09-12"])
+    for (const r of result.rates) {
+      expect(r.sellAmountCents).toBe(15000)
+      expect(r.sellCurrency).toBe("EUR")
+      expect(r.extraAdultAmountCents).toBe(2000)
+    }
+  })
+
+  it("returns rate_not_found when no room_type_rates row exists for the pair", async () => {
+    const result = await hospitalityService.resolveStayDailyRates(db, {
+      ratePlanId,
+      roomTypeId,
+      startDate: "2026-09-10",
+      endDate: "2026-09-13",
+    })
+    expect(result.status).toBe("rate_not_found")
+    if (result.status !== "rate_not_found") throw new Error()
+    expect(result.ratePlanId).toBe(ratePlanId)
+  })
+
+  it("returns stop_sell when an override on any night blocks the sale", async () => {
+    await seedRate(15000)
+    await db.insert(ratePlanInventoryOverrides).values({
+      id: id("hrio"),
+      ratePlanId,
+      roomTypeId,
+      date: "2026-09-11",
+      stopSell: true,
+    })
+
+    const result = await hospitalityService.resolveStayDailyRates(db, {
+      ratePlanId,
+      roomTypeId,
+      startDate: "2026-09-10",
+      endDate: "2026-09-13",
+    })
+    expect(result.status).toBe("stop_sell")
+    if (result.status !== "stop_sell") throw new Error()
+    expect(result.date).toBe("2026-09-11")
+  })
+
+  it("returns closed_to_arrival when the first night is CTA", async () => {
+    await seedRate(15000)
+    await db.insert(ratePlanInventoryOverrides).values({
+      id: id("hrio"),
+      ratePlanId,
+      roomTypeId,
+      date: "2026-09-10",
+      closedToArrival: true,
+    })
+
+    const result = await hospitalityService.resolveStayDailyRates(db, {
+      ratePlanId,
+      roomTypeId,
+      startDate: "2026-09-10",
+      endDate: "2026-09-13",
+    })
+    expect(result.status).toBe("closed_to_arrival")
+  })
+
+  it("returns closed_to_departure when the last night is CTD", async () => {
+    await seedRate(15000)
+    await db.insert(ratePlanInventoryOverrides).values({
+      id: id("hrio"),
+      ratePlanId,
+      roomTypeId,
+      date: "2026-09-12",
+      closedToDeparture: true,
+    })
+
+    const result = await hospitalityService.resolveStayDailyRates(db, {
+      ratePlanId,
+      roomTypeId,
+      startDate: "2026-09-10",
+      endDate: "2026-09-13",
+    })
+    expect(result.status).toBe("closed_to_departure")
+  })
+
+  it("ignores CTA/CTD overrides on non-edge nights", async () => {
+    await seedRate(15000)
+    // Mid-stay night flagged CTA — should NOT reject because we're not
+    // arriving on that date.
+    await db.insert(ratePlanInventoryOverrides).values({
+      id: id("hrio"),
+      ratePlanId,
+      roomTypeId,
+      date: "2026-09-11",
+      closedToArrival: true,
+    })
+
+    const result = await hospitalityService.resolveStayDailyRates(db, {
+      ratePlanId,
+      roomTypeId,
+      startDate: "2026-09-10",
+      endDate: "2026-09-13",
+    })
+    expect(result.status).toBe("ok")
+  })
+
+  it("returns empty rates for zero-night range (defensive)", async () => {
+    await seedRate(15000)
+    const result = await hospitalityService.resolveStayDailyRates(db, {
+      ratePlanId,
+      roomTypeId,
+      startDate: "2026-09-10",
+      endDate: "2026-09-10",
+    })
+    expect(result.status).toBe("ok")
+    if (result.status !== "ok") throw new Error()
+    expect(result.rates).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Closes #312.

## Summary

Adds \`hospitalityService.resolveStayDailyRates(db, input)\` that produces the per-night rate card array \`reserveStay\`'s \`dailyRates\` expects.

## Resolution rules

1. Base rate from \`room_type_rates.baseAmountCents\` for the (ratePlanId, roomTypeId) pair. **Currently flat** — every night in the range gets the same base amount.
2. \`rate_plan_inventory_overrides\` is consulted for restrictions only:
   - \`stop_sell\` on any night → typed failure
   - \`closed_to_arrival\` on the **first** night → typed failure
   - \`closed_to_departure\` on the **last** night before checkout → typed failure
3. Currency comes from \`room_type_rates.currencyCode\`.

## What this does NOT yet do

- **Date-scoped rate variation** (weekend bumps, seasonal pricing). The schema's \`room_type_rates\` is flat per (rate plan, room type); date-scoped variation lives on the linked \`priceScheduleId\` in the pricing module, which this resolver doesn't yet consult. Wiring price-schedule resolution is a separate follow-up.
- Length-of-stay discounts.
- Promo codes.

## Test plan

- [x] 7 integration tests:
  - Flat rate plan returns N identical nightly rows
  - \`rate_not_found\` when no \`room_type_rates\` row for the pair
  - \`stop_sell\` on any mid-range night
  - \`closed_to_arrival\` on the first night
  - \`closed_to_departure\` on the last night before checkout
  - Mid-range CTA override does NOT reject (only first-night CTA)
  - Empty rates for zero-night range
- [x] \`pnpm typecheck\` clean