### PR TITLE
feat(legal): per-segment cancellation policy fan-out (#310)

### DIFF
--- a/packages/legal/src/policies/index.ts
+++ b/packages/legal/src/policies/index.ts
@@ -48,8 +48,18 @@ export {
   policyRules,
   policyVersions,
 } from "./schema.js"
-export type { CancellationResult, CancellationRule } from "./service.js"
-export { evaluateCancellationPolicy, policiesService } from "./service.js"
+export type {
+  CancellationResult,
+  CancellationRule,
+  CancellationSegment,
+  SegmentedCancellationInput,
+  SegmentedCancellationResult,
+} from "./service.js"
+export {
+  evaluateCancellationPolicy,
+  evaluateSegmentedCancellation,
+  policiesService,
+} from "./service.js"
 export {
   evaluateCancellationInputSchema,
   insertPolicyAcceptanceSchema,

--- a/packages/legal/src/policies/service-core.ts
+++ b/packages/legal/src/policies/service-core.ts
@@ -17,11 +17,13 @@ import {
   type CreatePolicyVersionInput,
   type EvaluateCancellationInput,
   evaluateCancellationPolicy,
+  evaluateSegmentedCancellation,
   type PolicyAcceptanceListQuery,
   type PolicyAssignmentListQuery,
   type PolicyListQuery,
   paginate,
   type ResolvePolicyInput,
+  type SegmentedCancellationResult,
   toDateString,
   type UpdatePolicyAssignmentInput,
   type UpdatePolicyInput,
@@ -400,6 +402,70 @@ export const policiesCoreService = {
       label: r.label,
     }))
     return evaluateCancellationPolicy(mapped, input)
+  },
+
+  /**
+   * DB variant of {@link evaluateSegmentedCancellation} that resolves
+   * each segment's rules from a `policyId`. Use this for multi-segment
+   * cancellations where each line item may carry a different
+   * cancellation policy (e.g. mid-stay room change with mixed
+   * flexible/non-refundable rate plans).
+   *
+   * Segments referencing a missing or version-less policy are passed
+   * through with empty `rules`, which produces a zero refund — surfaces
+   * as a per-segment `appliedRule: null` for ops triage rather than
+   * throwing on the whole cancellation.
+   */
+  async evaluateMultiPolicyCancellation(
+    db: PostgresJsDatabase,
+    segments: Array<{
+      id?: string
+      label?: string
+      policyId: string
+      totalCents: number
+    }>,
+    input: { daysBeforeDeparture: number; currency?: string },
+  ): Promise<SegmentedCancellationResult> {
+    const policyIds = [...new Set(segments.map((segment) => segment.policyId))]
+
+    const rulesByPolicyId = new Map<string, CancellationRule[]>()
+    for (const policyId of policyIds) {
+      const [policy] = await db
+        .select({ id: policies.id, currentVersionId: policies.currentVersionId })
+        .from(policies)
+        .where(eq(policies.id, policyId))
+        .limit(1)
+      if (!policy?.currentVersionId) {
+        rulesByPolicyId.set(policyId, [])
+        continue
+      }
+      const rules = await db
+        .select()
+        .from(policyRules)
+        .where(eq(policyRules.policyVersionId, policy.currentVersionId))
+      rulesByPolicyId.set(
+        policyId,
+        rules.map((r) => ({
+          id: r.id,
+          daysBeforeDeparture: r.daysBeforeDeparture,
+          refundPercent: r.refundPercent,
+          refundType: r.refundType,
+          flatAmountCents: r.flatAmountCents,
+          label: r.label,
+        })),
+      )
+    }
+
+    return evaluateSegmentedCancellation({
+      daysBeforeDeparture: input.daysBeforeDeparture,
+      currency: input.currency,
+      segments: segments.map((segment) => ({
+        id: segment.id,
+        label: segment.label,
+        totalCents: segment.totalCents,
+        rules: rulesByPolicyId.get(segment.policyId) ?? [],
+      })),
+    })
   },
   async listPolicyAcceptances(db: PostgresJsDatabase, query: PolicyAcceptanceListQuery) {
     const conditions = []

--- a/packages/legal/src/policies/service-shared.ts
+++ b/packages/legal/src/policies/service-shared.ts
@@ -97,4 +97,106 @@ export function evaluateCancellationPolicy(
   return { refundPercent, refundCents, refundType, appliedRule: applied }
 }
 
+/**
+ * One revenue line in a multi-segment cancellation. Each segment carries
+ * its own rule set + own amount; segments that share a policy still need
+ * to be passed in separately so the per-segment refund tracks the
+ * specific line item.
+ */
+export type CancellationSegment = {
+  /** Optional caller-supplied id — typically the booking_item id. */
+  id?: string
+  /** Optional human-readable label (e.g. "Deluxe room, 3 nights"). */
+  label?: string
+  rules: CancellationRule[]
+  totalCents: number
+}
+
+export type SegmentedCancellationInput = {
+  daysBeforeDeparture: number
+  currency?: string
+  segments: CancellationSegment[]
+}
+
+export type SegmentedCancellationResult = {
+  /** Σ(segments.totalCents). */
+  totalCents: number
+  /** Σ(per-segment refundCents). */
+  refundCents: number
+  /** Aggregate refund as basis points: refundCents / totalCents × 10000. */
+  refundPercent: number
+  /**
+   * "mixed" when the segments resolve to different refundTypes (e.g. one
+   * segment is `cash` and another is `none`). When all non-zero
+   * segments resolve to the same refundType, that value is preserved.
+   * "none" when every segment resolves to 0 refund.
+   */
+  refundType: "cash" | "credit" | "cash_or_credit" | "none" | "mixed"
+  segments: Array<{
+    id?: string
+    label?: string
+    totalCents: number
+    result: CancellationResult
+  }>
+}
+
+/**
+ * Evaluate a multi-segment cancellation. Each segment runs through
+ * {@link evaluateCancellationPolicy} with the shared
+ * `daysBeforeDeparture`; per-segment refunds are summed and a coarse
+ * `refundType` is computed for the aggregate.
+ *
+ * Use case: hotel bookings with mid-stay room changes where each
+ * `stay_booking_items.ratePlanId` carries a different
+ * `cancellationPolicyId` (e.g. flexible Deluxe + non-refundable Suite).
+ * The customer cancels and we owe a partial refund — the flexible
+ * portion's refundCents + 0 from the non-refundable portion.
+ *
+ * Pure: no I/O. Caller resolves rules from policy IDs first (see
+ * {@link policiesService.evaluateMultiPolicyCancellation} for the DB
+ * variant).
+ */
+export function evaluateSegmentedCancellation(
+  input: SegmentedCancellationInput,
+): SegmentedCancellationResult {
+  const totalCents = input.segments.reduce((sum, segment) => sum + segment.totalCents, 0)
+
+  const segmentResults = input.segments.map((segment) => ({
+    id: segment.id,
+    label: segment.label,
+    totalCents: segment.totalCents,
+    result: evaluateCancellationPolicy(segment.rules, {
+      daysBeforeDeparture: input.daysBeforeDeparture,
+      totalCents: segment.totalCents,
+      currency: input.currency,
+    }),
+  }))
+
+  const refundCents = segmentResults.reduce((sum, segment) => sum + segment.result.refundCents, 0)
+  const refundPercent = totalCents > 0 ? Math.floor((refundCents * 10000) / totalCents) : 0
+
+  const nonZeroTypes = new Set<string>(
+    segmentResults
+      .filter((segment) => segment.result.refundCents > 0)
+      .map((segment) => segment.result.refundType),
+  )
+
+  let refundType: SegmentedCancellationResult["refundType"]
+  if (nonZeroTypes.size === 0) {
+    refundType = "none"
+  } else if (nonZeroTypes.size === 1) {
+    refundType = [...nonZeroTypes][0] as SegmentedCancellationResult["refundType"]
+  } else {
+    refundType = "mixed"
+  }
+
+  return {
+    totalCents,
+    refundCents,
+    refundPercent,
+    refundType,
+    segments: segmentResults,
+  }
+}
+
 export const _unused = inArray

--- a/packages/legal/src/policies/service.ts
+++ b/packages/legal/src/policies/service.ts
@@ -3,10 +3,23 @@ import {
   _unused,
   type CancellationResult,
   type CancellationRule,
+  type CancellationSegment,
   evaluateCancellationPolicy,
+  evaluateSegmentedCancellation,
+  type SegmentedCancellationInput,
+  type SegmentedCancellationResult,
 } from "./service-shared.js"
 
-export { _unused, type CancellationResult, type CancellationRule, evaluateCancellationPolicy }
+export {
+  _unused,
+  type CancellationResult,
+  type CancellationRule,
+  type CancellationSegment,
+  evaluateCancellationPolicy,
+  evaluateSegmentedCancellation,
+  type SegmentedCancellationInput,
+  type SegmentedCancellationResult,
+}
 
 export const policiesService = {
   ...policiesCoreService,

--- a/packages/legal/tests/unit/evaluate-segmented-cancellation.test.ts
+++ b/packages/legal/tests/unit/evaluate-segmented-cancellation.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest"
+
+import type { CancellationRule } from "../../src/policies/service.js"
+import { evaluateSegmentedCancellation } from "../../src/policies/service.js"
+
+/**
+ * Closes #310 — per-segment cancellation policy fan-out.
+ *
+ * Validates aggregate refund computation when a single booking has
+ * multiple line items, each governed by a different cancellation
+ * policy.
+ */
+
+function flexible(): CancellationRule[] {
+  return [
+    {
+      daysBeforeDeparture: 30,
+      refundPercent: 10000,
+      refundType: "cash",
+      flatAmountCents: null,
+      label: "30+",
+    },
+    {
+      daysBeforeDeparture: 7,
+      refundPercent: 5000,
+      refundType: "cash",
+      flatAmountCents: null,
+      label: "7-29",
+    },
+    {
+      daysBeforeDeparture: 0,
+      refundPercent: 0,
+      refundType: "none",
+      flatAmountCents: null,
+      label: "<7",
+    },
+  ]
+}
+
+function nonRefundable(): CancellationRule[] {
+  return [
+    {
+      daysBeforeDeparture: 0,
+      refundPercent: 0,
+      refundType: "none",
+      flatAmountCents: null,
+      label: "Always 0",
+    },
+  ]
+}
+
+function creditOnly(): CancellationRule[] {
+  return [
+    {
+      daysBeforeDeparture: 14,
+      refundPercent: 8000,
+      refundType: "credit",
+      flatAmountCents: null,
+      label: "14+",
+    },
+    {
+      daysBeforeDeparture: 0,
+      refundPercent: 0,
+      refundType: "none",
+      flatAmountCents: null,
+      label: "<14",
+    },
+  ]
+}
+
+describe("evaluateSegmentedCancellation", () => {
+  it("returns zero refund when there are no segments", () => {
+    const result = evaluateSegmentedCancellation({
+      daysBeforeDeparture: 30,
+      segments: [],
+    })
+    expect(result).toEqual({
+      totalCents: 0,
+      refundCents: 0,
+      refundPercent: 0,
+      refundType: "none",
+      segments: [],
+    })
+  })
+
+  it("aggregates a single fully-refundable segment cleanly", async () => {
+    const result = evaluateSegmentedCancellation({
+      daysBeforeDeparture: 60,
+      segments: [{ id: "bkit_1", rules: flexible(), totalCents: 50000 }],
+    })
+    expect(result.totalCents).toBe(50000)
+    expect(result.refundCents).toBe(50000)
+    expect(result.refundPercent).toBe(10000)
+    expect(result.refundType).toBe("cash")
+    expect(result.segments).toHaveLength(1)
+    expect(result.segments[0]?.result.refundCents).toBe(50000)
+  })
+
+  it("mixed flexible + non-refundable: full refund on the flexible portion only", async () => {
+    const result = evaluateSegmentedCancellation({
+      daysBeforeDeparture: 60,
+      segments: [
+        { id: "bkit_deluxe", label: "Deluxe", rules: flexible(), totalCents: 60000 },
+        { id: "bkit_suite", label: "Suite", rules: nonRefundable(), totalCents: 100000 },
+      ],
+    })
+    // Σ totals = 160000. Flexible refunds 60000 (100%), non-refundable 0.
+    expect(result.totalCents).toBe(160000)
+    expect(result.refundCents).toBe(60000)
+    // Aggregate basis-points: 60000/160000 = 37.5% → 3750 bp
+    expect(result.refundPercent).toBe(3750)
+    // Only the flexible segment refunded (cash); non-refundable contributed 0.
+    expect(result.refundType).toBe("cash")
+    expect(result.segments[0]?.result.refundCents).toBe(60000)
+    expect(result.segments[1]?.result.refundCents).toBe(0)
+  })
+
+  it("multi-type non-zero refunds resolve to refundType: 'mixed'", async () => {
+    const result = evaluateSegmentedCancellation({
+      daysBeforeDeparture: 60,
+      segments: [
+        { id: "a", rules: flexible(), totalCents: 50000 },
+        { id: "b", rules: creditOnly(), totalCents: 30000 },
+      ],
+    })
+    // Both segments produce a non-zero refund — one cash, one credit.
+    expect(result.refundCents).toBe(50000 + Math.floor((30000 * 8000) / 10000))
+    expect(result.refundType).toBe("mixed")
+  })
+
+  it("all segments at zero refund: refundType is 'none'", async () => {
+    const result = evaluateSegmentedCancellation({
+      daysBeforeDeparture: 60,
+      segments: [
+        { id: "a", rules: nonRefundable(), totalCents: 50000 },
+        { id: "b", rules: nonRefundable(), totalCents: 30000 },
+      ],
+    })
+    expect(result.refundCents).toBe(0)
+    expect(result.refundPercent).toBe(0)
+    expect(result.refundType).toBe("none")
+  })
+
+  it("close-to-departure: flexible rule kicks in at the lower tier", async () => {
+    const result = evaluateSegmentedCancellation({
+      daysBeforeDeparture: 10,
+      segments: [{ id: "a", rules: flexible(), totalCents: 100000 }],
+    })
+    // 10 days out → matches the 7-29 day tier at 50%
+    expect(result.refundCents).toBe(50000)
+    expect(result.refundPercent).toBe(5000)
+  })
+
+  it("preserves per-segment id and label so callers can render breakdowns", async () => {
+    const result = evaluateSegmentedCancellation({
+      daysBeforeDeparture: 60,
+      segments: [
+        { id: "bkit_1", label: "Deluxe room", rules: flexible(), totalCents: 50000 },
+        { id: "bkit_2", label: "Suite", rules: nonRefundable(), totalCents: 30000 },
+      ],
+    })
+    expect(result.segments[0]?.id).toBe("bkit_1")
+    expect(result.segments[0]?.label).toBe("Deluxe room")
+    expect(result.segments[1]?.id).toBe("bkit_2")
+    expect(result.segments[1]?.label).toBe("Suite")
+  })
+
+  it("refundPercent is 0 when totalCents is 0 (defensive against zero-amount segments)", async () => {
+    const result = evaluateSegmentedCancellation({
+      daysBeforeDeparture: 30,
+      segments: [{ id: "a", rules: flexible(), totalCents: 0 }],
+    })
+    expect(result.totalCents).toBe(0)
+    expect(result.refundPercent).toBe(0)
+  })
+})


### PR DESCRIPTION
Closes #310. Picked **option (A)** — fan out + aggregate.

## Use case

Hotel bookings with mid-stay room changes can attach different rate plans per segment, each with its own \`cancellationPolicyId\` (e.g. flexible Deluxe + non-refundable Suite). A customer-initiated cancel needs to compute the partial refund: full from the flexible portion, zero from the non-refundable portion. The pre-existing single-policy \`evaluateCancellationPolicy\` couldn't represent that.

## What ships

- \`CancellationSegment\` type — \`{ id?, label?, rules, totalCents }\` per line item.
- \`SegmentedCancellationInput\` / \`SegmentedCancellationResult\` (aggregate totals + per-segment breakdown + \`refundType: "mixed"\` when segments resolve to different refund types).
- \`evaluateSegmentedCancellation(input)\` — pure function, no I/O.
- \`policiesService.evaluateMultiPolicyCancellation(db, segments, input)\` — DB variant that resolves rules from \`policyId\` per segment (one query per unique policy).

Existing \`evaluateCancellationPolicy\` and \`policiesService.evaluateCancellation\` preserved unchanged.

## Test plan

- [x] 8 unit tests cover empty segments, single fully-refundable segment, mixed flexible + non-refundable (the headline use case), multi-type non-zero refunds → \`"mixed"\`, all zero refunds → \`"none"\`, close-to-departure tier resolution, per-segment id/label preservation, zero-totalCents defensive case.
- [x] \`pnpm -F @voyantjs/legal test\` — 57 passed (49 prior + 8 new).
- [x] \`pnpm typecheck\` clean.