### PR TITLE
feat(hospitality): serialized-mode stay reserve (#319)

### DIFF
--- a/packages/hospitality/src/service.ts
+++ b/packages/hospitality/src/service.ts
@@ -223,11 +223,13 @@ export interface ReserveStayInput {
 }
 
 export type ReserveStayResult =
-  | { status: "ok"; stayBookingItemId: string; nightCount: number }
+  | { status: "ok"; stayBookingItemId: string; nightCount: number; roomUnitId?: string | null }
   | { status: "insufficient_capacity"; date: string; available: number; needed: number }
   | { status: "stop_sell"; date: string }
   | { status: "inventory_missing"; date: string }
   | { status: "rate_count_mismatch"; expected: number; received: number }
+  | { status: "no_unit_available" }
+  | { status: "room_type_not_found" }
 
 /**
  * Per-night rate row produced by {@link resolveStayDailyRates}. Shape
@@ -369,28 +371,31 @@ export const hospitalityService = {
   },
 
   /**
-   * Atomically reserve a stay against the property's pooled inventory.
+   * Atomically reserve a stay. Dispatches based on the room type's
+   * `inventoryMode`:
    *
-   * Steps inside one `db.transaction`:
-   * 1. Compute the per-night date range
-   * 2. For each night, lock the `room_inventory` row for
-   *    `(roomTypeId, date)` with `SELECT ... FOR UPDATE`
-   * 3. Reject if any night has `stopSell = true`, missing inventory, or
-   *    `availableUnits < roomCount`
-   * 4. Decrement `availableUnits`, increment `heldUnits` per night
-   * 5. Insert the `stay_booking_items` row
-   * 6. Insert the `stay_daily_rates` rows
+   * - **pooled** (default): the property tracks "rooms-of-type-X
+   *   available for date Y" in `room_inventory`. Multiple physical
+   *   rooms are interchangeable; the desk picks one at check-in.
+   *   Reserve decrements `available_units` per night via per-night
+   *   `SELECT ... FOR UPDATE` row locks.
+   * - **serialized**: each `room_unit` is a specific physical room
+   *   ("an instance"); the booking is bound to that unit at reserve
+   *   time. Reserve picks the first available unit (sortOrder +
+   *   room_number deterministic), `SELECT ... FOR UPDATE`s the
+   *   chosen row, and persists the `roomUnitId` on
+   *   `stay_booking_items`. Skips units covered by `room_blocks` /
+   *   `maintenance_blocks` or already in an overlapping
+   *   reserved/checked-in stay.
+   * - **virtual**: not yet supported by `reserveStay`. Falls through
+   *   to pooled-mode logic, which will fail with
+   *   `inventory_missing` if no `room_inventory` row exists.
    *
-   * Concurrency: two callers reserving the last available room of a type
-   * for an overlapping date range serialize through the per-night
-   * `room_inventory` row lock; the loser receives
-   * `{ status: "insufficient_capacity" }` and never mutates inventory.
-   *
-   * **Scope:** pooled-mode room types only. Instance-mode (one
-   * `room_unit` per actual physical room, with check-in assignment) is
-   * out of scope here — instance reservation needs to also lock the
-   * specific room_unit and check `room_blocks` / maintenance overlap.
-   * Tracked separately.
+   * Concurrency: pooled-mode reserves serialize through per-night
+   * `room_inventory` locks; serialized-mode reserves serialize through
+   * per-unit `room_units` locks. Both produce typed
+   * `insufficient_capacity` / `no_unit_available` failures without
+   * mutating state.
    */
   async reserveStay(db: PostgresJsDatabase, input: ReserveStayInput): Promise<ReserveStayResult> {
     const nights = eachNight(input.checkInDate, input.checkOutDate)
@@ -403,6 +408,20 @@ export const hospitalityService = {
         expected: nights.length,
         received: input.dailyRates.length,
       }
+    }
+
+    // Look up the room type to dispatch by inventory mode.
+    const [roomType] = await db
+      .select({ id: roomTypes.id, inventoryMode: roomTypes.inventoryMode })
+      .from(roomTypes)
+      .where(eq(roomTypes.id, input.roomTypeId))
+      .limit(1)
+    if (!roomType) {
+      return { status: "room_type_not_found" }
+    }
+
+    if (roomType.inventoryMode === "serialized") {
+      return this._reserveStaySerialized(db, input, nights)
     }
 
     const roomCount = input.roomCount ?? 1
@@ -498,6 +517,126 @@ export const hospitalityService = {
       )
 
       return { status: "ok" as const, stayBookingItemId: stayRow.id, nightCount: nights.length }
+    })
+  },
+
+  /**
+   * Internal: serialized-mode (per-physical-room) reserve.
+   * Pooled-mode is in `reserveStay`.
+   *
+   * Picks the first available `room_unit` of the requested type by:
+   * - Excluding units in non-active status
+   * - Excluding units covered by an active `room_blocks` entry whose
+   *   range overlaps the requested stay (per-unit OR property-wide
+   *   roomType block)
+   * - Excluding units covered by an active `maintenance_blocks` entry
+   *   on the same logic
+   * - Excluding units already occupied by a reserved or checked-in
+   *   `stay_booking_items` whose date range overlaps
+   *
+   * The chosen unit is `SELECT ... FOR UPDATE`d so concurrent reserves
+   * on the same physical room serialize. The loser sees the unit
+   * already locked + occupied (after the first commits) and falls
+   * through to the next candidate, or `no_unit_available` if none
+   * remain.
+   */
+  async _reserveStaySerialized(
+    db: PostgresJsDatabase,
+    input: ReserveStayInput,
+    nights: string[],
+  ): Promise<ReserveStayResult> {
+    return db.transaction(async (tx) => {
+      // Find + lock the first available unit. The query mirrors the
+      // logic enumerated in the docstring above. We use FOR UPDATE so
+      // concurrent reserves serialize on the chosen unit.
+      const candidates = await tx.execute(sql`
+        SELECT u.id
+        FROM ${roomUnits} u
+        WHERE u.room_type_id = ${input.roomTypeId}
+          AND u.status = 'active'
+          AND NOT EXISTS (
+            SELECT 1 FROM ${roomBlocks} b
+            WHERE (
+                b.room_unit_id = u.id
+                OR (b.room_type_id = u.room_type_id AND b.room_unit_id IS NULL)
+              )
+              AND b.status IN ('held', 'confirmed')
+              AND b.starts_on < ${input.checkOutDate}
+              AND b.ends_on > ${input.checkInDate}
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM ${maintenanceBlocks} m
+            WHERE (
+                m.room_unit_id = u.id
+                OR (m.room_type_id = u.room_type_id AND m.room_unit_id IS NULL)
+              )
+              AND m.status IN ('open', 'in_progress')
+              AND m.starts_on < ${input.checkOutDate}
+              AND m.ends_on > ${input.checkInDate}
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM ${stayBookingItems} s
+            WHERE s.room_unit_id = u.id
+              AND s.status IN ('reserved', 'checked_in')
+              AND s.check_in_date < ${input.checkOutDate}
+              AND s.check_out_date > ${input.checkInDate}
+          )
+        ORDER BY u.code NULLS LAST, u.room_number NULLS LAST, u.id
+        LIMIT 1
+        FOR UPDATE
+      `)
+      const candidate = (candidates as unknown as Array<{ id: string }>)[0]
+      if (!candidate) {
+        return { status: "no_unit_available" as const }
+      }
+
+      const [stayRow] = await tx
+        .insert(stayBookingItems)
+        .values({
+          bookingItemId: input.bookingItemId,
+          propertyId: input.propertyId,
+          roomTypeId: input.roomTypeId,
+          roomUnitId: candidate.id,
+          ratePlanId: input.ratePlanId,
+          mealPlanId: input.mealPlanId ?? null,
+          checkInDate: input.checkInDate,
+          checkOutDate: input.checkOutDate,
+          nightCount: nights.length,
+          roomCount: input.roomCount ?? 1,
+          adults: input.adults ?? 1,
+          children: input.children ?? 0,
+          infants: input.infants ?? 0,
+          status: "reserved",
+        })
+        .returning()
+
+      if (!stayRow) {
+        throw new Error("_reserveStayInstance: stay_booking_items insert returned no rows")
+      }
+
+      await tx.insert(stayDailyRates).values(
+        nights.map((date, idx) => {
+          const rate = input.dailyRates[idx]!
+          return {
+            stayBookingItemId: stayRow.id,
+            date,
+            sellCurrency: rate.sellCurrency,
+            sellAmountCents: rate.sellAmountCents ?? null,
+            costCurrency: rate.costCurrency ?? null,
+            costAmountCents: rate.costAmountCents ?? null,
+            taxAmountCents: rate.taxAmountCents ?? null,
+            feeAmountCents: rate.feeAmountCents ?? null,
+            commissionAmountCents: rate.commissionAmountCents ?? null,
+          }
+        }),
+      )
+
+      return {
+        status: "ok" as const,
+        stayBookingItemId: stayRow.id,
+        nightCount: nights.length,
+        roomUnitId: candidate.id,
+      }
     })
   },
 

--- a/packages/hospitality/tests/integration/serialized-stay-reserve.test.ts
+++ b/packages/hospitality/tests/integration/serialized-stay-reserve.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Closes #319.
+ *
+ * Verifies serialized-mode (per-physical-room) stay reserve picks an
+ * available `room_unit`, locks it, and excludes units covered by
+ * `room_blocks` / `maintenance_blocks` or already in an overlapping
+ * reserved stay.
+ */
+
+import { bookingItems, bookings } from "@voyantjs/bookings/schema"
+import { facilities, properties } from "@voyantjs/facilities/schema"
+import { eq } from "drizzle-orm"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+import {
+  maintenanceBlocks,
+  ratePlanRoomTypes,
+  ratePlans,
+  roomBlocks,
+  roomTypes,
+  roomUnits,
+} from "../../src/schema.js"
+import { stayBookingItems } from "../../src/schema-bookings.js"
+import { hospitalityService } from "../../src/service.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+let counter = 0
+function id(prefix: string) {
+  counter += 1
+  return `${prefix}_ser${counter}`
+}
+
+describe.skipIf(!DB_AVAILABLE)("hospitality.reserveStay — serialized mode", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test db
+  let db: any
+  let propertyId: string
+  let roomTypeId: string
+  let ratePlanId: string
+
+  beforeAll(async () => {
+    const { createTestDb, cleanupTestDb } = await import("@voyantjs/db/test-utils")
+    db = createTestDb()
+    await cleanupTestDb(db)
+  })
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyantjs/db/test-utils")
+    await closeTestDb()
+  })
+
+  beforeEach(async () => {
+    const { cleanupTestDb } = await import("@voyantjs/db/test-utils")
+    await cleanupTestDb(db)
+
+    const facilityId = id("fac")
+    await db
+      .insert(facilities)
+      .values({ id: facilityId, name: "Serialized Hotel", type: "property" })
+    propertyId = id("prop")
+    await db.insert(properties).values({ id: propertyId, facilityId, propertyType: "hotel" })
+    roomTypeId = id("hrmt")
+    await db.insert(roomTypes).values({
+      id: roomTypeId,
+      propertyId,
+      code: "STD",
+      name: "Standard",
+      inventoryMode: "serialized",
+    })
+    ratePlanId = id("hrpl")
+    await db.insert(ratePlans).values({
+      id: ratePlanId,
+      propertyId,
+      code: "BAR",
+      name: "Best Available Rate",
+      currencyCode: "EUR",
+    })
+    await db.insert(ratePlanRoomTypes).values({ id: id("hrrt"), ratePlanId, roomTypeId })
+  })
+
+  async function seedRoomUnit(code: string, status: "active" | "out_of_order" = "active") {
+    const unitId = id("hrun")
+    await db.insert(roomUnits).values({
+      id: unitId,
+      propertyId,
+      roomTypeId,
+      code,
+      roomNumber: code,
+      status,
+    })
+    return unitId
+  }
+
+  async function seedBooking() {
+    const [booking] = await db
+      .insert(bookings)
+      .values({
+        bookingNumber: `BK-SER-${counter}`,
+        sellCurrency: "EUR",
+      })
+      .returning()
+    const [item] = await db
+      .insert(bookingItems)
+      .values({
+        bookingId: booking.id,
+        title: "Stay placeholder",
+        itemType: "accommodation",
+        sellCurrency: "EUR",
+      })
+      .returning()
+    return { bookingId: booking.id as string, bookingItemId: item.id as string }
+  }
+
+  function reservePayload(bookingItemId: string, checkInDate: string, checkOutDate: string) {
+    const nightCount = Math.round(
+      (new Date(`${checkOutDate}T00:00:00Z`).getTime() -
+        new Date(`${checkInDate}T00:00:00Z`).getTime()) /
+        (24 * 60 * 60 * 1000),
+    )
+    return {
+      bookingItemId,
+      propertyId,
+      roomTypeId,
+      ratePlanId,
+      checkInDate,
+      checkOutDate,
+      adults: 2,
+      dailyRates: Array.from({ length: nightCount }, () => ({
+        sellCurrency: "EUR" as const,
+        sellAmountCents: 12000,
+      })),
+    }
+  }
+
+  it("picks an active unit and persists roomUnitId on the stay row", async () => {
+    const unitId = await seedRoomUnit("101")
+    const a = await seedBooking()
+
+    const result = await hospitalityService.reserveStay(
+      db,
+      reservePayload(a.bookingItemId, "2026-09-10", "2026-09-12"),
+    )
+    expect(result.status).toBe("ok")
+    if (result.status !== "ok") throw new Error()
+    expect(result.roomUnitId).toBe(unitId)
+
+    const [stay] = await db
+      .select()
+      .from(stayBookingItems)
+      .where(eq(stayBookingItems.id, result.stayBookingItemId))
+    expect(stay?.roomUnitId).toBe(unitId)
+  })
+
+  it("two concurrent reserves with one available unit — exactly one succeeds", async () => {
+    await seedRoomUnit("101")
+    const a = await seedBooking()
+    const b = await seedBooking()
+
+    const [resultA, resultB] = await Promise.all([
+      hospitalityService.reserveStay(
+        db,
+        reservePayload(a.bookingItemId, "2026-09-10", "2026-09-12"),
+      ),
+      hospitalityService.reserveStay(
+        db,
+        reservePayload(b.bookingItemId, "2026-09-10", "2026-09-12"),
+      ),
+    ])
+
+    const ok = [resultA, resultB].filter((r) => r.status === "ok")
+    const conflicts = [resultA, resultB].filter((r) => r.status === "no_unit_available")
+    expect(ok).toHaveLength(1)
+    expect(conflicts).toHaveLength(1)
+
+    const stays = await db.select().from(stayBookingItems)
+    expect(stays).toHaveLength(1)
+  })
+
+  it("with two units, two concurrent reserves both succeed on different units", async () => {
+    const unitA = await seedRoomUnit("101")
+    const unitB = await seedRoomUnit("102")
+    const bookingA = await seedBooking()
+    const bookingB = await seedBooking()
+
+    const [resultA, resultB] = await Promise.all([
+      hospitalityService.reserveStay(
+        db,
+        reservePayload(bookingA.bookingItemId, "2026-09-10", "2026-09-12"),
+      ),
+      hospitalityService.reserveStay(
+        db,
+        reservePayload(bookingB.bookingItemId, "2026-09-10", "2026-09-12"),
+      ),
+    ])
+    expect(resultA.status).toBe("ok")
+    expect(resultB.status).toBe("ok")
+
+    const assigned = new Set<string | undefined | null>()
+    if (resultA.status === "ok") assigned.add(resultA.roomUnitId)
+    if (resultB.status === "ok") assigned.add(resultB.roomUnitId)
+    expect(assigned.size).toBe(2)
+    expect(assigned.has(unitA)).toBe(true)
+    expect(assigned.has(unitB)).toBe(true)
+  })
+
+  it("skips units in out_of_order status", async () => {
+    await seedRoomUnit("101", "out_of_order")
+    const a = await seedBooking()
+
+    const result = await hospitalityService.reserveStay(
+      db,
+      reservePayload(a.bookingItemId, "2026-09-10", "2026-09-12"),
+    )
+    expect(result.status).toBe("no_unit_available")
+  })
+
+  it("skips units covered by a per-unit room_block whose range overlaps", async () => {
+    const unitId = await seedRoomUnit("101")
+    await db.insert(roomBlocks).values({
+      id: id("hrbl"),
+      propertyId,
+      roomUnitId: unitId,
+      startsOn: "2026-09-09",
+      endsOn: "2026-09-15",
+      status: "confirmed",
+    })
+    const a = await seedBooking()
+
+    const result = await hospitalityService.reserveStay(
+      db,
+      reservePayload(a.bookingItemId, "2026-09-10", "2026-09-12"),
+    )
+    expect(result.status).toBe("no_unit_available")
+  })
+
+  it("skips units covered by a property-wide roomType room_block", async () => {
+    await seedRoomUnit("101")
+    await db.insert(roomBlocks).values({
+      id: id("hrbl"),
+      propertyId,
+      roomTypeId,
+      // No roomUnitId → applies to all units of this room type
+      startsOn: "2026-09-09",
+      endsOn: "2026-09-15",
+      status: "held",
+    })
+    const a = await seedBooking()
+
+    const result = await hospitalityService.reserveStay(
+      db,
+      reservePayload(a.bookingItemId, "2026-09-10", "2026-09-12"),
+    )
+    expect(result.status).toBe("no_unit_available")
+  })
+
+  it("does NOT skip units whose room_block has been released", async () => {
+    const unitId = await seedRoomUnit("101")
+    await db.insert(roomBlocks).values({
+      id: id("hrbl"),
+      propertyId,
+      roomUnitId: unitId,
+      startsOn: "2026-09-09",
+      endsOn: "2026-09-15",
+      status: "released",
+    })
+    const a = await seedBooking()
+
+    const result = await hospitalityService.reserveStay(
+      db,
+      reservePayload(a.bookingItemId, "2026-09-10", "2026-09-12"),
+    )
+    expect(result.status).toBe("ok")
+  })
+
+  it("skips units in maintenance_blocks (open or in_progress)", async () => {
+    const unitId = await seedRoomUnit("101")
+    await db.insert(maintenanceBlocks).values({
+      id: id("hmbl"),
+      propertyId,
+      roomUnitId: unitId,
+      startsOn: "2026-09-10",
+      endsOn: "2026-09-13",
+      status: "in_progress",
+    })
+    const a = await seedBooking()
+
+    const result = await hospitalityService.reserveStay(
+      db,
+      reservePayload(a.bookingItemId, "2026-09-10", "2026-09-12"),
+    )
+    expect(result.status).toBe("no_unit_available")
+  })
+
+  it("skips units already in an overlapping reserved stay", async () => {
+    const unitId = await seedRoomUnit("101")
+    const first = await seedBooking()
+    const ok = await hospitalityService.reserveStay(
+      db,
+      reservePayload(first.bookingItemId, "2026-09-08", "2026-09-12"),
+    )
+    expect(ok.status).toBe("ok")
+    if (ok.status === "ok") {
+      expect(ok.roomUnitId).toBe(unitId)
+    }
+
+    const second = await seedBooking()
+    const result = await hospitalityService.reserveStay(
+      db,
+      reservePayload(second.bookingItemId, "2026-09-10", "2026-09-14"),
+    )
+    expect(result.status).toBe("no_unit_available")
+  })
+
+  it("does NOT skip units whose existing stay was cancelled", async () => {
+    const unitId = await seedRoomUnit("101")
+    const first = await seedBooking()
+    const result1 = await hospitalityService.reserveStay(
+      db,
+      reservePayload(first.bookingItemId, "2026-09-08", "2026-09-12"),
+    )
+    if (result1.status !== "ok") throw new Error()
+    await db
+      .update(stayBookingItems)
+      .set({ status: "cancelled", updatedAt: new Date() })
+      .where(eq(stayBookingItems.id, result1.stayBookingItemId))
+
+    const second = await seedBooking()
+    const result2 = await hospitalityService.reserveStay(
+      db,
+      reservePayload(second.bookingItemId, "2026-09-10", "2026-09-14"),
+    )
+    expect(result2.status).toBe("ok")
+    if (result2.status === "ok") {
+      expect(result2.roomUnitId).toBe(unitId)
+    }
+  })
+
+  it("returns room_type_not_found when the roomTypeId doesn't exist", async () => {
+    const a = await seedBooking()
+    const result = await hospitalityService.reserveStay(db, {
+      bookingItemId: a.bookingItemId,
+      propertyId,
+      roomTypeId: "hrmt_does_not_exist",
+      ratePlanId,
+      checkInDate: "2026-09-10",
+      checkOutDate: "2026-09-12",
+      adults: 1,
+      dailyRates: [
+        { sellCurrency: "EUR", sellAmountCents: 12000 },
+        { sellCurrency: "EUR", sellAmountCents: 12000 },
+      ],
+    })
+    expect(result.status).toBe("room_type_not_found")
+  })
+})


### PR DESCRIPTION
Closes #319.

## Summary

Extends \`hospitalityService.reserveStay\` to dispatch by \`inventoryMode\`. Pooled-mode (existing) decrements \`room_inventory\` per-night; serialized-mode (new) picks a specific \`room_unit\` and binds the stay to it.

(Note: the schema's enum value is \`"serialized"\`, not \`"instance"\` as the issue title used. The semantics are the same — one \`room_unit\` row per physical room.)

## Serialized-mode flow

Inside \`db.transaction\`:

1. Find the first available unit for (roomTypeId, date range) via one query that excludes:
   - units in non-active status
   - units covered by an active \`room_blocks\` entry whose date range overlaps (per-unit OR property-wide roomType block)
   - units covered by an active \`maintenance_blocks\` entry on the same logic
   - units already in a \`reserved\` or \`checked_in\` \`stay_booking_items\` whose date range overlaps
2. \`SELECT ... FOR UPDATE\` the chosen unit
3. Insert \`stay_booking_items\` with \`roomUnitId\` set
4. Insert \`stay_daily_rates\`

If no unit qualifies → \`{ status: "no_unit_available" }\`.

## Result type changes

\`ReserveStayResult\` extended with:
- \`{ status: "no_unit_available" }\` — serialized-mode all-blocked
- \`{ status: "room_type_not_found" }\` — defensive

\`{ status: "ok", ... }\` now carries an optional \`roomUnitId\` — populated for serialized-mode, undefined for pooled.

## Test plan

- [x] 10 integration tests covering: unit picked + persisted, concurrent reserves with 1 unit and 2 units, out_of_order skipped, per-unit and property-wide \`room_blocks\` skipped, released blocks ignored, maintenance blocks skipped, overlapping reserved stay skipped, cancelled stay reusable, room_type_not_found.
- [x] \`pnpm typecheck\` clean.