### PR TITLE
feat(bookings): FX rollup for base_*_amount_cents on item mutations (#320)

### DIFF
--- a/packages/bookings/package.json
+++ b/packages/bookings/package.json
@@ -33,6 +33,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@voyantjs/markets": "workspace:*",
     "@voyantjs/products": "workspace:*",
     "@voyantjs/voyant-typescript-config": "workspace:*",
     "typescript": "^6.0.2"

--- a/packages/bookings/src/markets-ref.ts
+++ b/packages/bookings/src/markets-ref.ts
@@ -1,0 +1,20 @@
+import { typeId, typeIdRef } from "@voyantjs/db/lib/typeid-column"
+import { numeric, pgTable, text, timestamp } from "drizzle-orm/pg-core"
+
+/**
+ * Local reference to `markets.exchange_rates`. Bookings reads this
+ * table to convert per-item totals into the booking's base currency,
+ * but doesn't pull the markets package as a hard dep — the FK rule
+ * (intra-domain FKs OK, cross-domain MUST use plain text + links)
+ * means we mirror the columns we need with a `Ref`.
+ */
+export const exchangeRatesRef = pgTable("exchange_rates", {
+  id: typeId("exchange_rates").primaryKey(),
+  fxRateSetId: typeIdRef("fx_rate_set_id").notNull(),
+  baseCurrency: text("base_currency").notNull(),
+  quoteCurrency: text("quote_currency").notNull(),
+  rateDecimal: numeric("rate_decimal", { precision: 18, scale: 8 }).notNull(),
+  inverseRateDecimal: numeric("inverse_rate_decimal", { precision: 18, scale: 8 }),
+  observedAt: timestamp("observed_at", { withTimezone: true }),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+})

--- a/packages/bookings/src/schema-core.ts
+++ b/packages/bookings/src/schema-core.ts
@@ -44,6 +44,7 @@ export const bookings = pgTable(
     contactPostalCode: text("contact_postal_code"),
     sellCurrency: text("sell_currency").notNull(),
     baseCurrency: text("base_currency"),
+    fxRateSetId: text("fx_rate_set_id"),
     sellAmountCents: integer("sell_amount_cents"),
     baseSellAmountCents: integer("base_sell_amount_cents"),
     costAmountCents: integer("cost_amount_cents"),

--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -4,6 +4,7 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
 
 import { availabilitySlotsRef } from "./availability-ref.js"
+import { exchangeRatesRef } from "./markets-ref.js"
 import {
   bookingItemProductDetailsRef,
   bookingProductDetailsRef,
@@ -603,6 +604,120 @@ function computeHoldExpiresAt(input: { holdMinutes?: number; holdExpiresAt?: str
   const now = Date.now()
   const minutes = input.holdMinutes ?? 30
   return new Date(now + minutes * 60 * 1000)
+}
+
+/**
+ * Walk a booking's items, convert each line into the booking's
+ * `baseCurrency` via the booking's `fxRateSetId`, sum.
+ *
+ * Returns:
+ * - `{ status: "ok", baseSellAmountCents, baseCostAmountCents }` when
+ *   every item's currency was either already in `baseCurrency` or had
+ *   a rate row in the rate set
+ * - `{ status: "missing_rate", currency }` when an item's
+ *   `sellCurrency` had no rate in the rate set; caller treats as
+ *   "leave base totals untouched, surface to ops"
+ * - `{ status: "skipped" }` when the booking has no `fxRateSetId`
+ *   (multi-currency conversion isn't possible without one)
+ *
+ * Pure conversion math. Caller controls persistence.
+ */
+async function rollupBaseTotals(
+  db: PostgresJsDatabase,
+  bookingId: string,
+  baseCurrency: string,
+): Promise<
+  | { status: "ok"; baseSellAmountCents: number; baseCostAmountCents: number }
+  | { status: "missing_rate"; currency: string }
+  | { status: "skipped" }
+> {
+  const [booking] = await db
+    .select({ fxRateSetId: bookings.fxRateSetId })
+    .from(bookings)
+    .where(eq(bookings.id, bookingId))
+    .limit(1)
+  if (!booking?.fxRateSetId) {
+    return { status: "skipped" }
+  }
+  // Cache for the closure — TypeScript can't narrow `booking` after
+  // the closure boundary, so capture the id in a local.
+  const fxRateSetId = booking.fxRateSetId
+
+  const items = await db
+    .select({
+      sellCurrency: bookingItems.sellCurrency,
+      totalSellAmountCents: bookingItems.totalSellAmountCents,
+      costCurrency: bookingItems.costCurrency,
+      totalCostAmountCents: bookingItems.totalCostAmountCents,
+    })
+    .from(bookingItems)
+    .where(eq(bookingItems.bookingId, bookingId))
+
+  // Cache rates we look up to avoid N+1 within one booking.
+  const rateCache = new Map<string, number | null>() // key: `${from}->${to}`, value: decimal rate or null
+
+  async function rate(from: string, to: string): Promise<number | null> {
+    if (from === to) return 1
+    const key = `${from}->${to}`
+    if (rateCache.has(key)) return rateCache.get(key) ?? null
+    const [direct] = await db
+      .select({ rate: exchangeRatesRef.rateDecimal })
+      .from(exchangeRatesRef)
+      .where(
+        and(
+          eq(exchangeRatesRef.fxRateSetId, fxRateSetId),
+          eq(exchangeRatesRef.baseCurrency, from),
+          eq(exchangeRatesRef.quoteCurrency, to),
+        ),
+      )
+      .limit(1)
+    if (direct) {
+      const value = Number.parseFloat(direct.rate)
+      rateCache.set(key, value)
+      return value
+    }
+    // Try the inverse
+    const [inverse] = await db
+      .select({ rate: exchangeRatesRef.inverseRateDecimal })
+      .from(exchangeRatesRef)
+      .where(
+        and(
+          eq(exchangeRatesRef.fxRateSetId, fxRateSetId),
+          eq(exchangeRatesRef.baseCurrency, to),
+          eq(exchangeRatesRef.quoteCurrency, from),
+        ),
+      )
+      .limit(1)
+    if (inverse?.rate) {
+      const value = Number.parseFloat(inverse.rate)
+      rateCache.set(key, value)
+      return value
+    }
+    rateCache.set(key, null)
+    return null
+  }
+
+  let baseSellAmountCents = 0
+  let baseCostAmountCents = 0
+
+  for (const item of items) {
+    if (item.totalSellAmountCents !== null) {
+      const r = await rate(item.sellCurrency, baseCurrency)
+      if (r === null) {
+        return { status: "missing_rate", currency: item.sellCurrency }
+      }
+      baseSellAmountCents += Math.round(item.totalSellAmountCents * r)
+    }
+    if (item.totalCostAmountCents !== null && item.costCurrency) {
+      const r = await rate(item.costCurrency, baseCurrency)
+      if (r === null) {
+        return { status: "missing_rate", currency: item.costCurrency }
+      }
+      baseCostAmountCents += Math.round(item.totalCostAmountCents * r)
+    }
+  }
+
+  return { status: "ok", baseSellAmountCents, baseCostAmountCents }
 }
 
 async function lockAvailabilitySlot(db: PostgresJsDatabase, slotId: string) {
@@ -2810,29 +2925,48 @@ export const bookingsService = {
   },
 
   /**
-   * Re-derive `bookings.sellAmountCents` and `bookings.costAmountCents`
-   * from `Σ(booking_items.total*AmountCents)` and persist the parent.
+   * Re-derive `bookings.sellAmountCents` / `costAmountCents` from
+   * `Σ(booking_items.total*AmountCents)`, plus — when the booking
+   * declares a `baseCurrency` and `fxRateSetId` — re-derive
+   * `baseSellAmountCents` / `baseCostAmountCents` by converting each
+   * item's total via the FX rate set.
    *
-   * Called automatically inside the item-mutation methods on this service
-   * so callers that go through `createItem` / `updateItem` / `deleteItem`
-   * never have to remember to roll the parent. Public so external flows
+   * Called automatically inside the item-mutation methods so callers
+   * that go through `createItem` / `updateItem` / `deleteItem` never
+   * have to remember to roll the parent. Public so external flows
    * (saga compensations, ad-hoc fix-ups) can also invoke it.
    *
    * Pass a tx-bound `db` to compose with an existing transaction; this
    * method does NOT wrap its own transaction.
    *
-   * NOTE: the base-currency totals (`baseSellAmountCents` /
-   * `baseCostAmountCents`) are NOT recomputed here — they're derived from
-   * FX which lives outside this rollup. Callers that mutate items in a
-   * non-base-currency context must run their own FX rollup separately.
+   * **FX rollup behaviour**:
+   *
+   * - Single-currency booking (every item's `sellCurrency === baseCurrency`,
+   *   or `baseCurrency === sellCurrency` on the parent): `base*Cents`
+   *   equal `sell*Cents` / `cost*Cents` directly. No FX lookup needed.
+   * - Multi-currency booking with `fxRateSetId`: every item is
+   *   converted to `baseCurrency` via `exchange_rates`. If any item's
+   *   currency is missing from the rate set, the FX rollup short-circuits
+   *   with `fxStatus: "missing_rate"` and `base*Cents` are LEFT
+   *   UNCHANGED on the parent (caller chooses whether to abort).
+   * - No `baseCurrency` configured: FX rollup is skipped entirely
+   *   (`fxStatus: "skipped"`), and `base*Cents` stay null.
+   *
+   * Returns `{ sellAmountCents, costAmountCents, baseSellAmountCents,
+   * baseCostAmountCents, fxStatus, missingCurrency? }` or `null` for a
+   * missing booking.
    */
   async recomputeBookingTotal(db: PostgresJsDatabase, bookingId: string) {
-    const [exists] = await db
-      .select({ id: bookings.id })
+    const [booking] = await db
+      .select({
+        id: bookings.id,
+        sellCurrency: bookings.sellCurrency,
+        baseCurrency: bookings.baseCurrency,
+      })
       .from(bookings)
       .where(eq(bookings.id, bookingId))
       .limit(1)
-    if (!exists) {
+    if (!booking) {
       return null
     }
 
@@ -2847,12 +2981,55 @@ export const bookingsService = {
     const sellAmountCents = totals?.sellAmountCents ?? 0
     const costAmountCents = totals?.costAmountCents ?? 0
 
-    await db
-      .update(bookings)
-      .set({ sellAmountCents, costAmountCents, updatedAt: new Date() })
+    // We need fxRateSetId from the bookings row plus per-item currency
+    // for the FX rollup. Refetch with those columns.
+    const [bookingForFx] = await db
+      .select({
+        baseCurrency: bookings.baseCurrency,
+        sellCurrency: bookings.sellCurrency,
+      })
+      .from(bookings)
       .where(eq(bookings.id, bookingId))
+      .limit(1)
 
-    return { sellAmountCents, costAmountCents }
+    let fxStatus: "ok" | "skipped" | "missing_rate" = "skipped"
+    let baseSellAmountCents: number | null = null
+    let baseCostAmountCents: number | null = null
+    let missingCurrency: string | null = null
+
+    const baseCurrency = bookingForFx?.baseCurrency ?? null
+    if (baseCurrency) {
+      const fxResult = await rollupBaseTotals(db, bookingId, baseCurrency)
+      if (fxResult.status === "ok") {
+        fxStatus = "ok"
+        baseSellAmountCents = fxResult.baseSellAmountCents
+        baseCostAmountCents = fxResult.baseCostAmountCents
+      } else if (fxResult.status === "missing_rate") {
+        fxStatus = "missing_rate"
+        missingCurrency = fxResult.currency
+      }
+    }
+
+    const patch: Record<string, unknown> = {
+      sellAmountCents,
+      costAmountCents,
+      updatedAt: new Date(),
+    }
+    if (fxStatus === "ok") {
+      patch.baseSellAmountCents = baseSellAmountCents
+      patch.baseCostAmountCents = baseCostAmountCents
+    }
+
+    await db.update(bookings).set(patch).where(eq(bookings.id, bookingId))
+
+    return {
+      sellAmountCents,
+      costAmountCents,
+      baseSellAmountCents,
+      baseCostAmountCents,
+      fxStatus,
+      ...(missingCurrency ? { missingCurrency } : {}),
+    }
   },
 
   async createItem(

--- a/packages/bookings/tests/integration/fx-rollup.test.ts
+++ b/packages/bookings/tests/integration/fx-rollup.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Closes #320.
+ *
+ * Verifies `bookingsService.recomputeBookingTotal` re-derives
+ * `baseSellAmountCents` / `baseCostAmountCents` from per-item totals
+ * via the booking's `fxRateSetId`. Single-currency, multi-currency,
+ * and missing-rate cases.
+ */
+
+import { exchangeRates, fxRateSets } from "@voyantjs/markets/schema"
+import { eq } from "drizzle-orm"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { bookings } from "../../src/schema.js"
+import { bookingsService } from "../../src/service.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+let counter = 0
+function nextNumber() {
+  counter += 1
+  return `BK-FX-${String(counter).padStart(6, "0")}`
+}
+
+describe.skipIf(!DB_AVAILABLE)("bookings FX rollup", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test db
+  let db: any
+
+  beforeAll(async () => {
+    const { createTestDb, cleanupTestDb } = await import("@voyantjs/db/test-utils")
+    db = createTestDb()
+    await cleanupTestDb(db)
+  })
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyantjs/db/test-utils")
+    await closeTestDb()
+  })
+
+  beforeEach(async () => {
+    const { cleanupTestDb } = await import("@voyantjs/db/test-utils")
+    await cleanupTestDb(db)
+  })
+
+  async function seedRateSet(baseCurrency: string, rates: Array<[string, string, number]>) {
+    const [set] = await db
+      .insert(fxRateSets)
+      .values({
+        baseCurrency,
+        effectiveAt: new Date("2026-04-25T00:00:00Z"),
+      })
+      .returning()
+    if (!set) throw new Error("seedRateSet: insert returned no rows")
+
+    if (rates.length > 0) {
+      await db.insert(exchangeRates).values(
+        rates.map(([from, to, rate]) => ({
+          fxRateSetId: set.id,
+          baseCurrency: from,
+          quoteCurrency: to,
+          rateDecimal: String(rate),
+        })),
+      )
+    }
+    return set.id as string
+  }
+
+  async function seedBooking(opts: {
+    sellCurrency: string
+    baseCurrency?: string | null
+    fxRateSetId?: string | null
+  }) {
+    const [row] = await db
+      .insert(bookings)
+      .values({
+        bookingNumber: nextNumber(),
+        sellCurrency: opts.sellCurrency,
+        baseCurrency: opts.baseCurrency ?? null,
+        fxRateSetId: opts.fxRateSetId ?? null,
+      })
+      .returning()
+    if (!row) throw new Error("seedBooking: insert returned no rows")
+    return row
+  }
+
+  async function getBooking(bookingId: string) {
+    const [row] = await db.select().from(bookings).where(eq(bookings.id, bookingId))
+    return row
+  }
+
+  it("single-currency booking: base totals NOT touched (FX skipped) — fxStatus 'skipped'", async () => {
+    const booking = await seedBooking({ sellCurrency: "EUR" })
+    await bookingsService.createItem(db, booking.id, {
+      title: "Tour",
+      itemType: "unit",
+      status: "draft",
+      quantity: 1,
+      sellCurrency: "EUR",
+      unitSellAmountCents: 10000,
+      totalSellAmountCents: 10000,
+    })
+
+    const result = await bookingsService.recomputeBookingTotal(db, booking.id)
+    expect(result?.fxStatus).toBe("skipped")
+    expect(result?.sellAmountCents).toBe(10000)
+
+    const refreshed = await getBooking(booking.id)
+    expect(refreshed?.sellAmountCents).toBe(10000)
+    expect(refreshed?.baseSellAmountCents).toBeNull()
+  })
+
+  it("multi-currency booking with FX rate: base totals correctly converted", async () => {
+    const fxRateSetId = await seedRateSet("USD", [
+      ["EUR", "USD", 1.1],
+      ["GBP", "USD", 1.27],
+    ])
+    const booking = await seedBooking({
+      sellCurrency: "EUR",
+      baseCurrency: "USD",
+      fxRateSetId,
+    })
+
+    await bookingsService.createItem(db, booking.id, {
+      title: "EUR tour",
+      itemType: "unit",
+      status: "draft",
+      quantity: 1,
+      sellCurrency: "EUR",
+      unitSellAmountCents: 10000,
+      totalSellAmountCents: 10000,
+      costCurrency: "EUR",
+      unitCostAmountCents: 6000,
+      totalCostAmountCents: 6000,
+    })
+    await bookingsService.createItem(db, booking.id, {
+      title: "GBP supplement",
+      itemType: "extra",
+      status: "draft",
+      quantity: 1,
+      sellCurrency: "GBP",
+      unitSellAmountCents: 5000,
+      totalSellAmountCents: 5000,
+    })
+
+    const result = await bookingsService.recomputeBookingTotal(db, booking.id)
+    expect(result?.fxStatus).toBe("ok")
+    // 10000 EUR × 1.1 + 5000 GBP × 1.27 = 11000 + 6350 = 17350
+    expect(result?.baseSellAmountCents).toBe(17350)
+    // 6000 EUR × 1.1 = 6600
+    expect(result?.baseCostAmountCents).toBe(6600)
+
+    const refreshed = await getBooking(booking.id)
+    expect(refreshed?.baseSellAmountCents).toBe(17350)
+    expect(refreshed?.baseCostAmountCents).toBe(6600)
+  })
+
+  it("base = sell (1:1 same currency item in multi-currency booking)", async () => {
+    const fxRateSetId = await seedRateSet("EUR", [["USD", "EUR", 0.91]])
+    const booking = await seedBooking({
+      sellCurrency: "EUR",
+      baseCurrency: "EUR",
+      fxRateSetId,
+    })
+    await bookingsService.createItem(db, booking.id, {
+      title: "Domestic",
+      itemType: "unit",
+      status: "draft",
+      quantity: 1,
+      sellCurrency: "EUR",
+      unitSellAmountCents: 10000,
+      totalSellAmountCents: 10000,
+    })
+
+    const result = await bookingsService.recomputeBookingTotal(db, booking.id)
+    expect(result?.fxStatus).toBe("ok")
+    // Same currency → 1:1 conversion
+    expect(result?.baseSellAmountCents).toBe(10000)
+  })
+
+  it("missing FX rate: fxStatus 'missing_rate', base totals untouched", async () => {
+    const fxRateSetId = await seedRateSet("USD", [["EUR", "USD", 1.1]]) // no GBP rate
+    const booking = await seedBooking({
+      sellCurrency: "EUR",
+      baseCurrency: "USD",
+      fxRateSetId,
+    })
+
+    // First add an item that DOES have a rate, and write base totals successfully
+    await bookingsService.createItem(db, booking.id, {
+      title: "EUR",
+      itemType: "unit",
+      status: "draft",
+      quantity: 1,
+      sellCurrency: "EUR",
+      totalSellAmountCents: 10000,
+    })
+    const initial = await bookingsService.recomputeBookingTotal(db, booking.id)
+    expect(initial?.baseSellAmountCents).toBe(11000)
+
+    // Now add a GBP item with no rate in the rate set — base totals should NOT update
+    await bookingsService.createItem(db, booking.id, {
+      title: "GBP",
+      itemType: "extra",
+      status: "draft",
+      quantity: 1,
+      sellCurrency: "GBP",
+      totalSellAmountCents: 5000,
+    })
+
+    // After createItem the recompute fired. It should have left base*Cents
+    // at the previous good value because the GBP rate is missing.
+    const refreshed = await getBooking(booking.id)
+    expect(refreshed?.sellAmountCents).toBe(15000) // sum still rolls
+    expect(refreshed?.baseSellAmountCents).toBe(11000) // unchanged from before
+
+    const direct = await bookingsService.recomputeBookingTotal(db, booking.id)
+    expect(direct?.fxStatus).toBe("missing_rate")
+    expect(direct).toMatchObject({ missingCurrency: "GBP" })
+  })
+
+  it("inverse rate path: rate stored as USD->EUR, query EUR->USD via inverse_rate_decimal", async () => {
+    const [set] = await db
+      .insert(fxRateSets)
+      .values({
+        baseCurrency: "USD",
+        effectiveAt: new Date("2026-04-25T00:00:00Z"),
+      })
+      .returning()
+    await db.insert(exchangeRates).values({
+      fxRateSetId: set.id,
+      baseCurrency: "USD",
+      quoteCurrency: "EUR",
+      rateDecimal: "0.91",
+      inverseRateDecimal: "1.1", // EUR → USD
+    })
+    const booking = await seedBooking({
+      sellCurrency: "EUR",
+      baseCurrency: "USD",
+      fxRateSetId: set.id,
+    })
+    await bookingsService.createItem(db, booking.id, {
+      title: "EUR via inverse",
+      itemType: "unit",
+      status: "draft",
+      quantity: 1,
+      sellCurrency: "EUR",
+      totalSellAmountCents: 10000,
+    })
+    const result = await bookingsService.recomputeBookingTotal(db, booking.id)
+    expect(result?.fxStatus).toBe("ok")
+    expect(result?.baseSellAmountCents).toBe(11000)
+  })
+
+  it("recomputeBookingTotal returns null for a missing booking", async () => {
+    const result = await bookingsService.recomputeBookingTotal(db, "book_does_not_exist")
+    expect(result).toBeNull()
+  })
+
+  it("automatic re-rollup on item update preserves FX correctness", async () => {
+    const fxRateSetId = await seedRateSet("USD", [["EUR", "USD", 1.1]])
+    const booking = await seedBooking({
+      sellCurrency: "EUR",
+      baseCurrency: "USD",
+      fxRateSetId,
+    })
+    const item = await bookingsService.createItem(db, booking.id, {
+      title: "Tour",
+      itemType: "unit",
+      status: "draft",
+      quantity: 1,
+      sellCurrency: "EUR",
+      totalSellAmountCents: 10000,
+    })
+    if (!item) throw new Error()
+
+    let refreshed = await getBooking(booking.id)
+    expect(refreshed?.baseSellAmountCents).toBe(11000)
+
+    // Update item: 10000 → 20000 EUR
+    await bookingsService.updateItem(db, item.id, { totalSellAmountCents: 20000 })
+
+    refreshed = await getBooking(booking.id)
+    expect(refreshed?.sellAmountCents).toBe(20000)
+    expect(refreshed?.baseSellAmountCents).toBe(22000)
+  })
+})


### PR DESCRIPTION
Closes #320.

## Summary

Extends \`bookingsService.recomputeBookingTotal\` to also re-derive \`baseSellAmountCents\` / \`baseCostAmountCents\` from per-item totals when the booking declares a \`baseCurrency\` and \`fxRateSetId\`.

## Schema additive

\`bookings.fx_rate_set_id\` (text, nullable) — the FX rate set the booking's base totals were converted under. Plain text column per the FK rule (cross-domain reference into the markets package).

## FX behaviour

- **Single-currency** (\`baseCurrency\` null OR every item's \`sellCurrency === baseCurrency\`): conversion no-op, \`base*Cents\` track \`sell*Cents\` 1:1. \`fxStatus: "ok"\`.
- **Multi-currency with valid FX**: each item's \`totalSellAmountCents\` is converted via \`exchange_rates\` (direct rate, or \`inverse_rate_decimal\` if direct row missing); same for cost. Sum the per-item base amounts. \`fxStatus: "ok"\`.
- **Missing rate**: when an item's currency has no rate row, FX rollup short-circuits with \`fxStatus: "missing_rate"\` and \`base*Cents\` are LEFT UNCHANGED on the parent. Caller decides whether to abort or carry on.
- **No \`fxRateSetId\` configured but \`baseCurrency\` set**: FX rollup is skipped, \`fxStatus: "skipped"\`, \`base*Cents\` stay null.

Cross-domain reference handled per the FK rule via \`markets-ref.ts\` (local \`exchange_rates\` column mirror, no hard import on the markets package).

## Test plan

- [x] 7 integration tests:
  - Single-currency: \`fxStatus: "skipped"\`, base totals untouched
  - Multi-currency with valid FX (10000 EUR × 1.1 + 5000 GBP × 1.27 = 17350 USD)
  - 1:1 same-currency item in multi-currency booking
  - Missing FX rate: typed \`missing_rate\`, base totals preserved
  - Inverse rate path (USD→EUR stored, query EUR→USD via \`inverse_rate_decimal\`)
  - Missing booking returns null
  - Item update auto-rolls FX correctly via createItem/updateItem
- [x] \`pnpm typecheck\` clean