### PR TITLE
feat(hospitality): date-scoped rate variation via priceScheduleId (#318)

### DIFF
--- a/packages/hospitality/package.json
+++ b/packages/hospitality/package.json
@@ -28,6 +28,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@voyantjs/pricing": "workspace:*",
     "@voyantjs/voyant-typescript-config": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/packages/hospitality/src/pricing-ref.ts
+++ b/packages/hospitality/src/pricing-ref.ts
@@ -1,0 +1,26 @@
+import { typeId, typeIdRef } from "@voyantjs/db/lib/typeid-column"
+import { boolean, date, integer, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core"
+
+/**
+ * Local reference to `pricing.price_schedules`. Hospitality reads this
+ * table to resolve per-date rate variations on
+ * `hospitalityService.resolveStayDailyRates`, but doesn't pull
+ * `@voyantjs/pricing` as a hard dep — the FK rule (intra-domain FKs
+ * OK, cross-domain MUST be plain text) means we mirror only the
+ * columns we read.
+ */
+export const priceSchedulesRef = pgTable("price_schedules", {
+  id: typeId("price_schedules").primaryKey(),
+  priceCatalogId: typeIdRef("price_catalog_id").notNull(),
+  code: text("code"),
+  name: text("name").notNull(),
+  recurrenceRule: text("recurrence_rule").notNull(),
+  timezone: text("timezone"),
+  validFrom: date("valid_from"),
+  validTo: date("valid_to"),
+  weekdays: jsonb("weekdays").$type<string[]>(),
+  priority: integer("priority").notNull(),
+  active: boolean("active").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
+})

--- a/packages/hospitality/src/service.ts
+++ b/packages/hospitality/src/service.ts
@@ -1,6 +1,8 @@
-import { and, asc, desc, eq, gte, ilike, lte, or, sql } from "drizzle-orm"
+import { and, asc, desc, eq, gte, ilike, inArray, lte, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
+
+import { priceSchedulesRef } from "./pricing-ref.js"
 
 import {
   housekeepingTasks,
@@ -169,6 +171,79 @@ function toDateOrNull(value: string | null | undefined) {
   return value ? new Date(value) : null
 }
 
+const WEEKDAY_CODES = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"] as const
+
+/**
+ * Returns true when the given ISO date matches the schedule's
+ * weekdays + validFrom/validTo window.
+ *
+ * Schedule matching is intentionally simple: the
+ * `recurrenceRule` (an iCal RRULE string) is NOT parsed. Production
+ * uses set the `weekdays` JSON array (e.g. `["fri", "sat"]`) and
+ * `validFrom` / `validTo` for the date window. Anything beyond
+ * that — exception dates, monthly recurrences — needs RRULE parsing
+ * which is a follow-up.
+ */
+function scheduleMatchesDate(
+  schedule: {
+    validFrom: string | null
+    validTo: string | null
+    weekdays: string[] | null
+  },
+  isoDate: string,
+): boolean {
+  if (schedule.validFrom && isoDate < schedule.validFrom) return false
+  if (schedule.validTo && isoDate > schedule.validTo) return false
+  if (schedule.weekdays && schedule.weekdays.length > 0) {
+    const dayCode = WEEKDAY_CODES[new Date(`${isoDate}T00:00:00Z`).getUTCDay()]!
+    const normalized = schedule.weekdays.map((d) => d.toLowerCase().slice(0, 3))
+    if (!normalized.includes(dayCode)) return false
+  }
+  return true
+}
+
+/**
+ * Pick the winning rate row for a given date from a set of candidate
+ * rate rows. Rules with a higher-priority matching schedule beat
+ * lower-priority ones; if no schedule matches, the default
+ * (null-schedule) rule is returned.
+ */
+function pickRateForDate<
+  TRate extends {
+    priceScheduleId: string | null
+    currencyCode: string
+    baseAmountCents: number | null
+    extraAdultAmountCents: number | null
+    extraChildAmountCents: number | null
+    extraInfantAmountCents: number | null
+  },
+  TSchedule extends {
+    validFrom: string | null
+    validTo: string | null
+    weekdays: string[] | null
+    priority: number
+  },
+>(
+  date: string,
+  rateRows: TRate[],
+  schedulesById: Map<string, TSchedule>,
+  defaultRate: TRate,
+): TRate {
+  let winner = defaultRate
+  let winnerPriority = Number.NEGATIVE_INFINITY
+  for (const row of rateRows) {
+    if (!row.priceScheduleId) continue
+    const schedule = schedulesById.get(row.priceScheduleId)
+    if (!schedule) continue
+    if (!scheduleMatchesDate(schedule, date)) continue
+    if (schedule.priority > winnerPriority) {
+      winner = row
+      winnerPriority = schedule.priority
+    }
+  }
+  return winner
+}
+
 /**
  * Iterate the dates from `start` (inclusive) to `end` (exclusive) as
  * ISO YYYY-MM-DD strings. Hotel "nights" — checking out on the
@@ -301,7 +376,12 @@ export const hospitalityService = {
       return { status: "ok", rates: [] }
     }
 
-    const [rate] = await db
+    // Pull every active rate row for the (ratePlanId, roomTypeId) pair.
+    // Multiple rows are allowed when each carries a different
+    // priceScheduleId (uidx_room_type_rates_plan_room_schedule); the
+    // null-schedule row is the default that applies when no schedule
+    // matches a given night.
+    const rateRows = await db
       .select()
       .from(roomTypeRates)
       .where(
@@ -311,15 +391,32 @@ export const hospitalityService = {
           eq(roomTypeRates.active, true),
         ),
       )
-      .limit(1)
 
-    if (!rate) {
+    if (rateRows.length === 0) {
       return {
         status: "rate_not_found",
         ratePlanId: input.ratePlanId,
         roomTypeId: input.roomTypeId,
       }
     }
+
+    const defaultRate = rateRows.find((r) => r.priceScheduleId === null) ?? rateRows[0]!
+
+    // Load schedules referenced by any non-default rate row. Cross-domain
+    // read via the local pricing-ref column mirror.
+    const scheduleIds = rateRows
+      .map((r) => r.priceScheduleId)
+      .filter((id): id is string => Boolean(id))
+    const schedules =
+      scheduleIds.length === 0
+        ? []
+        : await db
+            .select()
+            .from(priceSchedulesRef)
+            .where(
+              and(inArray(priceSchedulesRef.id, scheduleIds), eq(priceSchedulesRef.active, true)),
+            )
+    const schedulesById = new Map(schedules.map((s) => [s.id, s]))
 
     const overrides = await db
       .select()
@@ -350,24 +447,27 @@ export const hospitalityService = {
       return { status: "closed_to_arrival", date: firstNight }
     }
     // Closed-to-departure on the last night before checkout → reject.
-    // The "last night" is the night before endDate; eachNight() returned
-    // the inclusive list, so it's the array's tail.
     const lastNight = nights[nights.length - 1]!
     if (overridesByDate.get(lastNight)?.closedToDeparture) {
       return { status: "closed_to_departure", date: lastNight }
     }
 
-    return {
-      status: "ok",
-      rates: nights.map((date) => ({
+    // For each night, pick the rate row whose linked schedule matches.
+    // Higher priority wins; if no schedule matches, fall back to the
+    // default (null-schedule) row.
+    const rates = nights.map((date) => {
+      const winner = pickRateForDate(date, rateRows, schedulesById, defaultRate)
+      return {
         date,
-        sellCurrency: rate.currencyCode,
-        sellAmountCents: rate.baseAmountCents,
-        extraAdultAmountCents: rate.extraAdultAmountCents,
-        extraChildAmountCents: rate.extraChildAmountCents,
-        extraInfantAmountCents: rate.extraInfantAmountCents,
-      })),
-    }
+        sellCurrency: winner.currencyCode,
+        sellAmountCents: winner.baseAmountCents,
+        extraAdultAmountCents: winner.extraAdultAmountCents,
+        extraChildAmountCents: winner.extraChildAmountCents,
+        extraInfantAmountCents: winner.extraInfantAmountCents,
+      }
+    })
+
+    return { status: "ok", rates }
   },
 
   /**

--- a/packages/hospitality/tests/integration/rate-resolver-schedules.test.ts
+++ b/packages/hospitality/tests/integration/rate-resolver-schedules.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Closes #318.
+ *
+ * Verifies `resolveStayDailyRates` consults `room_type_rates` rows
+ * linked via `priceScheduleId` and applies per-date variation —
+ * weekend bumps, seasonal windows, priority resolution.
+ *
+ * The recurrence is matched by `weekdays` + `validFrom`/`validTo`
+ * columns on `price_schedules`. Full iCal RRULE parsing is NOT
+ * implemented; that's a follow-up if more complex patterns become
+ * needed.
+ */
+
+import { facilities, properties } from "@voyantjs/facilities/schema"
+import { priceCatalogs, priceSchedules } from "@voyantjs/pricing"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { ratePlans, roomTypeRates, roomTypes } from "../../src/schema.js"
+import { hospitalityService } from "../../src/service.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+let counter = 0
+function id(prefix: string) {
+  counter += 1
+  return `${prefix}_psched${counter}`
+}
+
+describe.skipIf(!DB_AVAILABLE)(
+  "hospitality.resolveStayDailyRates — date-scoped rate variation",
+  () => {
+    // biome-ignore lint/suspicious/noExplicitAny: test db
+    let db: any
+    let propertyId: string
+    let roomTypeId: string
+    let ratePlanId: string
+    let priceCatalogId: string
+
+    beforeAll(async () => {
+      const { createTestDb, cleanupTestDb } = await import("@voyantjs/db/test-utils")
+      db = createTestDb()
+      await cleanupTestDb(db)
+    })
+
+    afterAll(async () => {
+      const { closeTestDb } = await import("@voyantjs/db/test-utils")
+      await closeTestDb()
+    })
+
+    beforeEach(async () => {
+      const { cleanupTestDb } = await import("@voyantjs/db/test-utils")
+      await cleanupTestDb(db)
+
+      const facilityId = id("fac")
+      await db
+        .insert(facilities)
+        .values({ id: facilityId, name: "Schedule Hotel", type: "property" })
+      propertyId = id("prop")
+      await db.insert(properties).values({ id: propertyId, facilityId, propertyType: "hotel" })
+      roomTypeId = id("hrmt")
+      await db
+        .insert(roomTypes)
+        .values({ id: roomTypeId, propertyId, code: "STD", name: "Standard" })
+      ratePlanId = id("hrpl")
+      await db.insert(ratePlans).values({
+        id: ratePlanId,
+        propertyId,
+        code: "BAR",
+        name: "Best Available Rate",
+        currencyCode: "EUR",
+      })
+      priceCatalogId = id("prca")
+      await db.insert(priceCatalogs).values({
+        id: priceCatalogId,
+        code: `cat-${counter}`,
+        name: "Default catalog",
+      })
+    })
+
+    async function seedDefaultRate(amount: number) {
+      await db.insert(roomTypeRates).values({
+        id: id("hrtr"),
+        ratePlanId,
+        roomTypeId,
+        currencyCode: "EUR",
+        baseAmountCents: amount,
+        // No priceScheduleId → default rate
+      })
+    }
+
+    async function seedSchedule(opts: {
+      weekdays?: string[]
+      validFrom?: string
+      validTo?: string
+      priority?: number
+      name?: string
+    }) {
+      const scheduleId = id("prsc")
+      await db.insert(priceSchedules).values({
+        id: scheduleId,
+        priceCatalogId,
+        code: scheduleId,
+        name: opts.name ?? "Schedule",
+        recurrenceRule: "FREQ=DAILY", // unused — we match via weekdays/validFrom/validTo
+        weekdays: opts.weekdays ?? null,
+        validFrom: opts.validFrom ?? null,
+        validTo: opts.validTo ?? null,
+        priority: opts.priority ?? 0,
+      })
+      return scheduleId
+    }
+
+    async function seedScheduledRate(scheduleId: string, amount: number) {
+      await db.insert(roomTypeRates).values({
+        id: id("hrtr"),
+        ratePlanId,
+        roomTypeId,
+        priceScheduleId: scheduleId,
+        currencyCode: "EUR",
+        baseAmountCents: amount,
+      })
+    }
+
+    it("flat default rate (no schedules) — backwards-compatible behaviour", async () => {
+      await seedDefaultRate(15000)
+      const result = await hospitalityService.resolveStayDailyRates(db, {
+        ratePlanId,
+        roomTypeId,
+        startDate: "2026-09-10",
+        endDate: "2026-09-13",
+      })
+      expect(result.status).toBe("ok")
+      if (result.status !== "ok") throw new Error()
+      expect(result.rates).toHaveLength(3)
+      for (const r of result.rates) {
+        expect(r.sellAmountCents).toBe(15000)
+      }
+    })
+
+    it("weekend bump: Fri/Sat use the schedule rate, weekdays use the default", async () => {
+      await seedDefaultRate(15000)
+      const weekendId = await seedSchedule({
+        weekdays: ["fri", "sat"],
+        priority: 10,
+        name: "Weekend",
+      })
+      await seedScheduledRate(weekendId, 25000)
+
+      // 2026-09-10 is Thursday → 15000
+      // 2026-09-11 is Friday → 25000
+      // 2026-09-12 is Saturday → 25000
+      // 2026-09-13 is Sunday → 15000 (back to default; Sunday isn't in the schedule)
+      const result = await hospitalityService.resolveStayDailyRates(db, {
+        ratePlanId,
+        roomTypeId,
+        startDate: "2026-09-10",
+        endDate: "2026-09-14",
+      })
+      expect(result.status).toBe("ok")
+      if (result.status !== "ok") throw new Error()
+      const map = new Map(result.rates.map((r) => [r.date, r.sellAmountCents]))
+      expect(map.get("2026-09-10")).toBe(15000)
+      expect(map.get("2026-09-11")).toBe(25000)
+      expect(map.get("2026-09-12")).toBe(25000)
+      expect(map.get("2026-09-13")).toBe(15000)
+    })
+
+    it("seasonal window: validFrom/validTo on the schedule scopes the rate", async () => {
+      await seedDefaultRate(10000)
+      const seasonId = await seedSchedule({
+        validFrom: "2026-12-20",
+        validTo: "2027-01-05",
+        priority: 5,
+        name: "High Season",
+      })
+      await seedScheduledRate(seasonId, 20000)
+
+      // Mid-Dec date → high season rate
+      // Mid-Jan date → default rate
+      const result = await hospitalityService.resolveStayDailyRates(db, {
+        ratePlanId,
+        roomTypeId,
+        startDate: "2026-12-19",
+        endDate: "2027-01-08",
+      })
+      expect(result.status).toBe("ok")
+      if (result.status !== "ok") throw new Error()
+      const map = new Map(result.rates.map((r) => [r.date, r.sellAmountCents]))
+      expect(map.get("2026-12-19")).toBe(10000) // before the window
+      expect(map.get("2026-12-20")).toBe(20000) // first day in window
+      expect(map.get("2027-01-05")).toBe(20000) // last day in window
+      expect(map.get("2027-01-06")).toBe(10000) // after the window
+    })
+
+    it("priority resolution: higher-priority schedule wins when multiple match", async () => {
+      await seedDefaultRate(10000)
+      // Lower priority weekend bump
+      const weekendId = await seedSchedule({
+        weekdays: ["fri", "sat"],
+        priority: 5,
+        name: "Weekend",
+      })
+      await seedScheduledRate(weekendId, 15000)
+      // Higher priority Christmas premium covering the same Friday
+      const xmasId = await seedSchedule({
+        validFrom: "2026-12-23",
+        validTo: "2026-12-26",
+        priority: 100,
+        name: "Christmas",
+      })
+      await seedScheduledRate(xmasId, 30000)
+
+      // 2026-12-25 is Friday → matches both Weekend AND Christmas; Christmas wins on priority
+      const result = await hospitalityService.resolveStayDailyRates(db, {
+        ratePlanId,
+        roomTypeId,
+        startDate: "2026-12-25",
+        endDate: "2026-12-26",
+      })
+      expect(result.status).toBe("ok")
+      if (result.status !== "ok") throw new Error()
+      expect(result.rates[0]?.sellAmountCents).toBe(30000)
+    })
+
+    it("inactive schedule is ignored", async () => {
+      await seedDefaultRate(10000)
+      const weekendId = id("prsc")
+      await db.insert(priceSchedules).values({
+        id: weekendId,
+        priceCatalogId,
+        code: weekendId,
+        name: "Inactive weekend",
+        recurrenceRule: "FREQ=DAILY",
+        weekdays: ["fri", "sat"],
+        priority: 10,
+        active: false,
+      })
+      await seedScheduledRate(weekendId, 25000)
+
+      // 2026-09-11 is Friday — but the schedule is inactive, so default applies
+      const result = await hospitalityService.resolveStayDailyRates(db, {
+        ratePlanId,
+        roomTypeId,
+        startDate: "2026-09-11",
+        endDate: "2026-09-12",
+      })
+      expect(result.status).toBe("ok")
+      if (result.status !== "ok") throw new Error()
+      expect(result.rates[0]?.sellAmountCents).toBe(10000)
+    })
+
+    it("rate_not_found when no rate rows exist at all", async () => {
+      const result = await hospitalityService.resolveStayDailyRates(db, {
+        ratePlanId,
+        roomTypeId,
+        startDate: "2026-09-10",
+        endDate: "2026-09-13",
+      })
+      expect(result.status).toBe("rate_not_found")
+    })
+  },
+)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -951,6 +951,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@voyantjs/markets':
+        specifier: workspace:*
+        version: link:../markets
       '@voyantjs/products':
         specifier: workspace:*
         version: link:../products
@@ -1759,6 +1762,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@voyantjs/pricing':
+        specifier: workspace:*
+        version: link:../pricing
       '@voyantjs/voyant-typescript-config':
         specifier: workspace:*
         version: link:../typescript-config


### PR DESCRIPTION
Closes #318.

## Summary

Extends \`hospitalityService.resolveStayDailyRates\` to consult \`price_schedules\` so weekend bumps and seasonal pricing land. The caller writes one \`room_type_rates\` row per schedule (uniqueness on \`(ratePlanId, roomTypeId, priceScheduleId)\`) plus a default row with \`priceScheduleId: null\`; the resolver picks the highest-priority matching schedule per date and falls back to the default row when no schedule matches.

## Schedule matching

\`recurrenceRule\` (iCal RRULE) is intentionally NOT parsed — that's expensive and most production usage maps cleanly to the simpler \`weekdays\` + \`validFrom\` + \`validTo\` columns:

- \`weekdays\` (e.g. \`["fri", "sat"]\`) — day-of-week match
- \`validFrom\` / \`validTo\` — inclusive ISO date window
- \`priority\` — higher wins when multiple schedules match a date

Inactive schedules (\`active = false\`) are ignored even if they match.

If RRULE-style exceptions or monthly recurrences become a need later, add an RRULE evaluator and call it from \`scheduleMatchesDate\` — the rate-row-per-schedule model already supports it.

## Cross-domain pattern

Cross-domain reference into pricing handled per the FK rule via \`pricing-ref.ts\` (local \`price_schedules\` column mirror, no hard runtime import — \`@voyantjs/pricing\` is dev-only for tests).

## Test plan

- [x] 6 new integration tests:
  - Backwards-compat: flat default rate returns identical per-night rows
  - Weekend bump (Fri/Sat schedule with higher rate)
  - Seasonal window via \`validFrom\`/\`validTo\`
  - Priority resolution when multiple schedules match
  - Inactive schedule is ignored
  - \`rate_not_found\` when no rate rows exist
- [x] \`pnpm typecheck\` clean. Existing rate-resolver tests in \`rate-resolver.test.ts\` continue to pass.