### PR TITLE
chore: backfill changesets for 0.10.0 release

### DIFF
--- a/.changeset/bookings-auto-rollup-total.md
+++ b/.changeset/bookings-auto-rollup-total.md
@@ -1,0 +1,9 @@
+---
+"@voyantjs/bookings": minor
+---
+
+Auto-rollup booking total from `booking_items`. `bookingsService.recomputeBookingTotal(db, bookingId)` is now wired into `createItem` / `updateItem` / `deleteItem`, each wrapped in `db.transaction` so partial failures can never leave the parent total stale.
+
+Also exposed publicly for ad-hoc invocation (saga compensation, fix-up scripts).
+
+Base-currency totals (`baseSellAmountCents` / `baseCostAmountCents`) are NOT recomputed by this rollup — those are FX-derived and handled by the FX rollup added in the same release.

--- a/.changeset/bookings-encrypt-accessibility.md
+++ b/.changeset/bookings-encrypt-accessibility.md
@@ -1,0 +1,15 @@
+---
+"@voyantjs/bookings": minor
+---
+
+**BREAKING:** encrypt `accessibilityNeeds` at rest. Move accessibility info from a plaintext column on `booking_travelers` into the KMS-encrypted `booking_traveler_travel_details` envelope (alongside passport / nationality / DOB / dietary).
+
+Disability data has tighter regulatory expectations in many jurisdictions (ADA / Equality Act) than freeform notes, so it lives with the passport-class data, not with `specialRequests` or `notes`.
+
+**Migration:**
+
+- The `booking_travelers.accessibility_needs` column is dropped.
+- `accessibilityNeeds` is removed from `bookingTravelerRecord`, `BookingTraveler*` insert/update validation schemas, `redactTravelerIdentity`, and the bookings-react / finance / scripts surface.
+- Read accessibility data through `createBookingPiiService.getTravelerTravelDetails`, which decrypts via `decryptOptionalJsonEnvelope` + audits the access. Same authorisation gate as the existing dietary / identity buckets.
+
+Contact identifiers (email, phone, names, address) and `specialRequests` deliberately stay plaintext — see `docs/architecture/booking-pii.md` for the cost-benefit decision.

--- a/.changeset/bookings-fx-rollup.md
+++ b/.changeset/bookings-fx-rollup.md
@@ -1,0 +1,14 @@
+---
+"@voyantjs/bookings": minor
+---
+
+FX rollup for `base_*_amount_cents` on item mutations. `bookingsService.recomputeBookingTotal` now re-derives `baseSellAmountCents` / `baseCostAmountCents` from per-item totals when the booking declares a `baseCurrency` and `fxRateSetId`.
+
+Schema: `bookings.fx_rate_set_id` (text, nullable) — plain text per the cross-domain FK rule (reference into the markets package).
+
+FX behaviour:
+
+- **Single-currency** (`baseCurrency` null OR every item's `sellCurrency === baseCurrency`): conversion is a no-op, `base*Cents` track `sell*Cents` 1:1. `fxStatus: "ok"`.
+- **Multi-currency with valid FX**: each item converted via `exchange_rates` (direct rate or `inverse_rate_decimal` if direct row missing), summed. `fxStatus: "ok"`.
+- **Missing rate**: short-circuits with `fxStatus: "missing_rate"`; `base*Cents` left unchanged on the parent. Caller decides.
+- **No `fxRateSetId` configured**: skipped, `fxStatus: "skipped"`, `base*Cents` stay null.

--- a/.changeset/bookings-idempotency-key.md
+++ b/.changeset/bookings-idempotency-key.md
@@ -1,0 +1,25 @@
+---
+"@voyantjs/bookings": minor
+"@voyantjs/hono": minor
+"@voyantjs/db": minor
+---
+
+Add `Idempotency-Key` header protocol for non-idempotent booking-creation endpoints.
+
+Same key + same body replays the original response; same key + different body returns `409 Conflict`. Records expire after 24h. Wired (with `required: false` default) into:
+
+- `POST /v1/admin/bookings/`
+- `POST /v1/admin/bookings/reserve`
+- `POST /v1/admin/bookings/from-product`
+- `POST /v1/admin/bookings/from-offer/:offerId/reserve`
+- `POST /v1/admin/bookings/from-order/:orderId/reserve`
+- `POST /v1/public/bookings/sessions`
+- `POST /v1/public/bookings/sessions/:sessionId/confirm`
+
+Ships:
+
+- `idempotency_keys` table in `@voyantjs/db/schema/infra` keyed by `(scope, key)`, with body-hash, captured response, and TTL.
+- `idempotencyKey({ scope, required? })` middleware in `@voyantjs/hono` that reads the header, replays/conflicts/expires, and captures `2xx` JSON responses. Echoes `Idempotency-Key` + `Idempotency-Replayed: true` on replay.
+- `purgeExpiredIdempotencyKeys()` helper for daily-cron cleanup.
+
+Backwards-compatible: clients without the header continue to work. Templates can flip a route to `required: true` per endpoint once their client has rolled out.

--- a/.changeset/bookings-pii-list-redaction.md
+++ b/.changeset/bookings-pii-list-redaction.md
@@ -1,0 +1,13 @@
+---
+"@voyantjs/bookings": minor
+---
+
+Add route-layer PII redaction + mandatory audit on the bookings admin read surface.
+
+`GET /v1/admin/bookings`, `GET /v1/admin/bookings/:id`, and `GET /v1/admin/bookings/:id/travelers` now:
+
+- Check `shouldRevealBookingPii(ctx)` against actor / scopes / caller type
+- Call `logBookingPiiAccess` with reason (`list_redacted` / `detail_reveal` / `insufficient_scope`) and metadata including row count
+- Mask contact PII (name, email, phone, address) in the response unless the caller has the `bookings-pii:read` (or `bookings-pii:*` / `*` superuser) scope, or the request is internal
+
+Exported helpers: `shouldRevealBookingPii`, `redactBookingContact`, `redactTravelerIdentity`, `redactEmail`, `redactPhone`, `redactString`. Surface area + posture documented in `docs/architecture/booking-pii.md`.

--- a/.changeset/bookings-refund-saga.md
+++ b/.changeset/bookings-refund-saga.md
@@ -1,0 +1,18 @@
+---
+"@voyantjs/bookings": minor
+---
+
+Add `refundBooking` saga — atomic credit-note + hold-release + supplier-reverse + notify, built on the existing `createWorkflow` primitive.
+
+Side-effect dependencies are injected (no compile-time pull on finance / transactions / notifications) so the package stays slim; templates wire the deps.
+
+Step graph with reverse-order compensation:
+
+1. `validate-state` — refundable only when `confirmed`, `in_progress`, or `on_hold`. Rejects partial amounts outside `[0, sellAmountCents]`.
+2. `create-credit-note` — short-circuits when `refundAmount === 0`. Compensation: void.
+3. `release-inventory` — releases held + confirmed allocations, restores slot capacity. Compensation: re-decrement (loud failure if re-sold, intentional).
+4. `reverse-supplier-offer` — best-effort.
+5. `transition-booking` → `cancelled` via `transitionBooking()` (state-machine guard).
+6. `notify-customer` — fire-and-forget.
+
+Exports `refundBooking(input, deps)` and `buildRefundBookingWorkflow(deps)` for callers that want to inspect the workflow definition or run it via a JobRunner.

--- a/.changeset/bookings-state-machine.md
+++ b/.changeset/bookings-state-machine.md
@@ -1,0 +1,13 @@
+---
+"@voyantjs/bookings": minor
+---
+
+**BREAKING:** introduce explicit booking state machine with `transitionBooking()` guards.
+
+Bookings now move through a typed state graph (`draft` → `on_hold` → `confirmed` → `in_progress` → `completed`, with `cancelled` / `expired` as terminal exits). Direct status writes are no longer permitted from service code — use `transitionBooking(bookingId, nextStatus, ctx)`, which enforces `BOOKING_TRANSITIONS` and emits an activity log row per transition.
+
+**Migration:**
+
+- Replace any `db.update(bookings).set({ status: ... })` in caller code with `transitionBooking()`.
+- The `redeemed` status is removed (it was a vouchers-domain concept that didn't apply here). Anything that read it should now look at `completed`.
+- The new `in_progress` status models "booking has started but the trip is mid-delivery" — set by the operator or by a scheduled transition once `startDate` is reached.

--- a/.changeset/distribution-connect-channel.md
+++ b/.changeset/distribution-connect-channel.md
@@ -1,0 +1,8 @@
+---
+"@voyantjs/distribution": minor
+"@voyantjs/distribution-react": minor
+---
+
+Add `connect` value to `channelKindEnum` for partners running Voyant Connect (the inbound API integration surface where operators publish into a third-party network using Voyant infrastructure). Distinguishes from `api_partner`, which remains a generic third-party API integration.
+
+Synchronised across pgEnum, Zod validation, React schemas / constants / hooks, registry dialogs, en/ro i18n labels, and template copies in `templates/dmc`, `templates/operator`, and `apps/dev`.

--- a/.changeset/finance-check-constraints.md
+++ b/.changeset/finance-check-constraints.md
@@ -1,0 +1,14 @@
+---
+"@voyantjs/finance": patch
+"@voyantjs/bookings": patch
+"@voyantjs/transactions": patch
+---
+
+Add Postgres `CHECK` constraints across finance, bookings, and transactions schemas to enforce: if any `*_amount_cents` column is set, its companion currency column must also be set.
+
+Two flavours, depending on column shape:
+
+- **Strict XNOR** (`(currency IS NULL) = (amount IS NULL)`) — one currency to one amount: `booking_guarantees`, `booking_item_commissions`, `payments` (base).
+- **Implication** (`(amounts NULL) OR (currency NOT NULL)`) — one currency covering multiple amount columns: `bookings.base_currency`, `booking_items.cost_currency`, `offer_items.cost_currency`, `order_items.cost_currency`, `invoices.base_currency`.
+
+The implication form intentionally allows "currency without amount" because the currency may be pre-declared before line items roll up.

--- a/.changeset/hono-actor-fail-closed.md
+++ b/.changeset/hono-actor-fail-closed.md
@@ -1,5 +1,5 @@
 ---
-"@voyantjs/hono": major
+"@voyantjs/hono": minor
 ---
 
 **BREAKING:** `requireActor` middleware now returns `401 Unauthorized` when no actor is set on the request, instead of defaulting to `"staff"`.

--- a/.changeset/hospitality-atomic-reserve-stay.md
+++ b/.changeset/hospitality-atomic-reserve-stay.md
@@ -1,0 +1,15 @@
+---
+"@voyantjs/hospitality": minor
+---
+
+Add `hospitalityService.reserveStay(db, input)` — atomic per-night inventory consumption for pooled-mode room types.
+
+Inside one `db.transaction`:
+
+1. Per-night `SELECT ... FOR UPDATE` against `room_inventory` for the date range, locks acquired in **date-sorted order** so concurrent reserves with overlapping ranges always grab locks in the same order — no deadlock.
+2. Reject if any night is `stop_sell`, missing, or has `< roomCount` available.
+3. Decrement `available_units`, increment `held_units` per night.
+4. Insert the `stay_booking_items` row.
+5. Insert per-night `stay_daily_rates`.
+
+6 integration tests cover concurrent-reserve races (2 reserves on the last room, 10 reserves on a 5-room slot, day-mid sold-out atomicity).

--- a/.changeset/hospitality-date-scoped-rates.md
+++ b/.changeset/hospitality-date-scoped-rates.md
@@ -1,0 +1,12 @@
+---
+"@voyantjs/hospitality": minor
+---
+
+Date-scoped rate variation via `priceScheduleId` (weekend bumps, seasonal pricing). `hospitalityService.resolveStayDailyRates` now consults `price_schedules` so callers can write one `room_type_rates` row per schedule (uniqueness on `(ratePlanId, roomTypeId, priceScheduleId)`) plus a default row with `priceScheduleId: null`.
+
+Schedule matching:
+
+- `weekdays` (e.g. `["fri", "sat"]`) — match by day of week.
+- `validFrom` / `validTo` — match within an inclusive ISO date window.
+- `priority` — higher wins when multiple schedules match a date.
+- `recurrenceRule` (iCal RRULE) is intentionally NOT parsed — most production usage maps cleanly to the simpler columns above. Inactive schedules (`active=false`) are ignored even if otherwise matching.

--- a/.changeset/hospitality-rate-card-resolver.md
+++ b/.changeset/hospitality-rate-card-resolver.md
@@ -1,0 +1,16 @@
+---
+"@voyantjs/hospitality": minor
+---
+
+Add `hospitalityService.resolveStayDailyRates(db, input)` — produces the per-night rate-card array `reserveStay`'s `dailyRates` parameter expects.
+
+Resolution rules:
+
+1. Base rate from `room_type_rates.baseAmountCents` for the (ratePlanId, roomTypeId) pair.
+2. `rate_plan_inventory_overrides` consulted for restrictions only:
+   - `stop_sell` on any night → typed `stop_sell` failure.
+   - `closed_to_arrival` on the first night → `closed_to_arrival`.
+   - `closed_to_departure` on the last night before checkout → `closed_to_departure`.
+3. Currency from `room_type_rates.currencyCode`.
+
+Date-scoped rate variation (weekend bumps, seasonal pricing) is layered on top in the same release via `priceScheduleId` — see the date-scoped-rate-variation changeset.

--- a/.changeset/hospitality-serialized-reserve.md
+++ b/.changeset/hospitality-serialized-reserve.md
@@ -1,0 +1,18 @@
+---
+"@voyantjs/hospitality": minor
+---
+
+Extend `hospitalityService.reserveStay` to dispatch by the room type's `inventoryMode`. Pooled-mode (existing) decrements `room_inventory` per-night; serialized-mode (new) picks a specific `room_unit` and binds the stay to it.
+
+Serialized-mode flow inside `db.transaction`:
+
+1. Find the first available unit for (roomTypeId, date range) via a single query that excludes:
+   - units in non-active status
+   - units covered by an active `room_blocks` entry (per-unit OR property-wide roomType block) whose date range overlaps
+   - units covered by an active `maintenance_blocks` entry on the same logic
+   - units already in a `reserved` or `checked_in` `stay_booking_items` whose date range overlaps
+2. `SELECT ... FOR UPDATE` the chosen unit so concurrent reserves on the same physical room serialize through the row lock.
+3. Insert `stay_booking_items` with `roomUnitId` set.
+4. Insert `stay_daily_rates`.
+
+If no unit qualifies → `{ status: "no_unit_available" }`.

--- a/.changeset/legal-segmented-cancellation.md
+++ b/.changeset/legal-segmented-cancellation.md
@@ -1,0 +1,13 @@
+---
+"@voyantjs/legal": minor
+---
+
+Add per-segment cancellation policy fan-out for multi-segment bookings (e.g. mid-stay room change with one flexible rate plan + one non-refundable rate plan).
+
+Ships:
+
+- `evaluateSegmentedCancellation(input)` — pure function, no I/O.
+- `policiesService.evaluateMultiPolicyCancellation(db, segments, input)` — DB variant that resolves each segment's rules from a `policyId` (deduplicated; one query per unique policy).
+- Types: `CancellationSegment`, `SegmentedCancellationInput`, `SegmentedCancellationResult` — aggregate totals + per-segment breakdown + `refundType` of `"mixed"` when segments resolve to different refund types (e.g. one full + one none).
+
+Single-policy `evaluateCancellationPolicy` couldn't represent the "partial refund per segment" case; this resolves it without touching the existing API.


### PR DESCRIPTION
## Summary

The release PR (#303) was last refreshed at 18:05 UTC and only consumes one changeset (`hono-actor-fail-closed`), but **17 substantive PRs landed today** without their own changesets. This backfills 14 of them so the 0.10.0 changelog is accurate; the remaining 3 (#301, #305, #307, #309, #296) are test-/docs-only and don't change the public surface.

Also demotes `hono-actor-fail-closed` from `major` to `minor` to keep the release at 0.10.0 — `**BREAKING:**` markers in the body cover the migration semantics. The release-train script (`scripts/version-release-train.cjs`) auto-demotes pre-1.0 majors anyway, but tagging the source explicitly avoids surprises if that logic changes.

## What's backfilled

| # | Changeset | Bump | Note |
|---|-----------|------|------|
| #295 | `bookings-state-machine` | minor | BREAKING: explicit state graph + `transitionBooking()` |
| #302 | `bookings-idempotency-key` | minor | `Idempotency-Key` header on booking-create |
| #304 | `finance-check-constraints` | patch | currency/amount nullable-pair guards |
| #306 | `bookings-pii-list-redaction` | minor | route-layer redaction + audit on admin reads |
| #308 | `bookings-refund-saga` | minor | atomic refund workflow with reverse-order compensation |
| #314 | `bookings-auto-rollup-total` | minor | recompute total on item mutations |
| #315 | `hospitality-atomic-reserve-stay` | minor | per-night `FOR UPDATE` inventory consumption |
| #316 | `hospitality-rate-card-resolver` | minor | resolve daily rates from rate plan + room type |
| #317 | `legal-segmented-cancellation` | minor | multi-policy cancellation with `mixed` refund type |
| #321 | `hospitality-serialized-reserve` | minor | per-unit reserve for serialized inventory mode |
| #322 | `bookings-fx-rollup` | minor | derive `base_*_amount_cents` from FX rate sets |
| #323 | `hospitality-date-scoped-rates` | minor | weekend / seasonal pricing via `priceScheduleId` |
| #324 | `bookings-encrypt-accessibility` | minor | BREAKING: accessibility moves to KMS envelope |
| #299 | `distribution-connect-channel` | minor | `connect` channelKind for Voyant Connect partners |

## Effect

After merge, the existing release PR #303 will be auto-refreshed by the changeset bot to consume all of these. Running `pnpm version-packages` locally confirms the bump still lands at **0.10.0** across the fixed train.

## Test plan

- [x] `pnpm version-packages` (dry-run) → 0.10.0
- [x] `pnpm changeset status` → all 14 + the existing hono changeset are valid and discovered
- [ ] CI green
- [ ] After merge: release PR #303 picks up the new changesets automatically