### PR TITLE
feat(bookings): export framework-agnostic dispatchBookingStatusChange helper

### DIFF
--- a/.changeset/bookings-status-dispatch.md
+++ b/.changeset/bookings-status-dispatch.md
@@ -1,0 +1,20 @@
+---
+"@voyantjs/bookings": minor
+---
+
+Export `dispatchBookingStatusChange` from `@voyantjs/bookings/status-dispatch` (also re-exported from the package barrel).
+
+Framework-agnostic helper that maps `(currentStatus, targetStatus)` → the right verb endpoint (`/confirm`, `/expire`, `/start`, `/complete`, `/cancel`, or `/override-status` for non-adjacent jumps) and the body the server expects. Lets non-React consumers — operator tooling using a generic `api.patch`, server-to-server scripts, third-party storefront builds — reuse the dispatch table that previously lived only inside `bookings-react`'s `useBookingStatusMutation`.
+
+`useBookingStatusMutation` and `useBookingStatusByIdMutation` now delegate to this helper; behaviour is unchanged.
+
+```ts
+import { dispatchBookingStatusChange } from "@voyantjs/bookings/status-dispatch"
+
+const target = dispatchBookingStatusChange(bookingId, "on_hold", "confirmed", "ok by ops")
+await fetch(`${apiBase}${target.path}`, {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(target.body),
+})
+```

--- a/packages/bookings-react/src/hooks/use-booking-status-mutation.ts
+++ b/packages/bookings-react/src/hooks/use-booking-status-mutation.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { dispatchBookingStatusChange } from "@voyantjs/bookings/status-dispatch"
 
 import { fetchWithValidation } from "../client.js"
 import { useVoyantBookingsContext } from "../provider.js"
@@ -19,61 +20,18 @@ export interface UpdateBookingStatusInput {
   note?: string | null
 }
 
-interface DispatchTarget {
-  path: string
-  body: Record<string, unknown>
-}
-
-/**
- * Map (currentStatus, targetStatus) → which verb endpoint to call. Lifecycle
- * arrows that have a named verb on the server go to that verb; everything else
- * (non-adjacent jumps, e.g. cancelled → confirmed for data correction) falls
- * through to /override-status, which requires a reason. We use the operator's
- * note text as the reason — the server rejects empty reasons with a 400.
- */
-function dispatchStatusChange(
-  bookingId: string,
-  current: BookingStatus,
-  target: BookingStatus,
-  note: string | null | undefined,
-): DispatchTarget {
-  const noteBody = note ? { note } : {}
-
-  if (current === "on_hold" && target === "confirmed") {
-    return { path: `/v1/bookings/${bookingId}/confirm`, body: noteBody }
-  }
-  if (current === "on_hold" && target === "expired") {
-    return { path: `/v1/bookings/${bookingId}/expire`, body: noteBody }
-  }
-  if (current === "confirmed" && target === "in_progress") {
-    return { path: `/v1/bookings/${bookingId}/start`, body: noteBody }
-  }
-  if (current === "in_progress" && target === "completed") {
-    return { path: `/v1/bookings/${bookingId}/complete`, body: noteBody }
-  }
-  if (
-    target === "cancelled" &&
-    (current === "draft" ||
-      current === "on_hold" ||
-      current === "confirmed" ||
-      current === "in_progress")
-  ) {
-    return { path: `/v1/bookings/${bookingId}/cancel`, body: noteBody }
-  }
-
-  return {
-    path: `/v1/bookings/${bookingId}/override-status`,
-    body: { status: target, reason: note ?? "", ...(note ? { note } : {}) },
-  }
-}
-
 export function useBookingStatusMutation(bookingId: string) {
   const { baseUrl, fetcher } = useVoyantBookingsContext()
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: async (input: UpdateBookingStatusInput) => {
-      const target = dispatchStatusChange(bookingId, input.currentStatus, input.status, input.note)
+      const target = dispatchBookingStatusChange(
+        bookingId,
+        input.currentStatus,
+        input.status,
+        input.note,
+      )
       const { data } = await fetchWithValidation(
         target.path,
         bookingSingleResponse,
@@ -112,7 +70,7 @@ export function useBookingStatusByIdMutation() {
       status,
       note,
     }: UpdateBookingStatusByIdInput) => {
-      const target = dispatchStatusChange(bookingId, currentStatus, status, note)
+      const target = dispatchBookingStatusChange(bookingId, currentStatus, status, note)
       const { data } = await fetchWithValidation(
         target.path,
         bookingSingleResponse,

--- a/packages/bookings/package.json
+++ b/packages/bookings/package.json
@@ -13,7 +13,8 @@
     "./public-routes": "./src/routes-public.ts",
     "./public-validation": "./src/validation-public.ts",
     "./schema/travel-details": "./src/schema/travel-details.ts",
-    "./extensions/suppliers": "./src/extensions/suppliers.ts"
+    "./extensions/suppliers": "./src/extensions/suppliers.ts",
+    "./status-dispatch": "./src/status-dispatch.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
@@ -83,6 +84,10 @@
       "./extensions/suppliers": {
         "types": "./dist/extensions/suppliers.d.ts",
         "import": "./dist/extensions/suppliers.js"
+      },
+      "./status-dispatch": {
+        "types": "./dist/status-dispatch.d.ts",
+        "import": "./dist/status-dispatch.js"
       }
     },
     "main": "./dist/index.js",

--- a/packages/bookings/src/index.ts
+++ b/packages/bookings/src/index.ts
@@ -35,6 +35,10 @@ export {
 } from "./service-groups.js"
 export type { BookingStatus } from "./state-machine.js"
 export {
+  type BookingStatusDispatchTarget,
+  dispatchBookingStatusChange,
+} from "./status-dispatch.js"
+export {
   type ExpireStaleBookingHoldsInput,
   type ExpireStaleBookingHoldsResult,
   expireStaleBookingHolds,

--- a/packages/bookings/src/status-dispatch.ts
+++ b/packages/bookings/src/status-dispatch.ts
@@ -1,0 +1,65 @@
+import type { BookingStatus } from "./state-machine.js"
+
+export interface BookingStatusDispatchTarget {
+  /**
+   * Path of the verb endpoint to POST to, including `/v1/bookings/:id` prefix.
+   * Always begins with a `/`.
+   */
+  path: string
+  /**
+   * JSON body the server expects for the resolved verb.
+   *
+   * - For named verbs (`/confirm`, `/expire`, `/start`, `/complete`, `/cancel`)
+   *   this is `{ note }` when a note is provided, otherwise an empty object.
+   * - For `/override-status` it is `{ status, reason, note? }` — the server
+   *   rejects empty reasons with a 400, so callers should pass a meaningful
+   *   note when the dispatch falls through to override.
+   */
+  body: Record<string, unknown>
+}
+
+/**
+ * Map (currentStatus, targetStatus) → which verb endpoint to call. Lifecycle
+ * arrows that have a named verb on the server go to that verb; everything else
+ * (non-adjacent jumps, e.g. cancelled → confirmed for data correction) falls
+ * through to /override-status, which requires a reason. The note text is used
+ * as the reason — the server rejects empty reasons with a 400.
+ *
+ * Framework-agnostic: returns the URL + body to send. Callers own the
+ * transport (fetch, axios, the React hook, server-to-server scripts, etc).
+ */
+export function dispatchBookingStatusChange(
+  bookingId: string,
+  current: BookingStatus,
+  target: BookingStatus,
+  note?: string | null,
+): BookingStatusDispatchTarget {
+  const noteBody = note ? { note } : {}
+
+  if (current === "on_hold" && target === "confirmed") {
+    return { path: `/v1/bookings/${bookingId}/confirm`, body: noteBody }
+  }
+  if (current === "on_hold" && target === "expired") {
+    return { path: `/v1/bookings/${bookingId}/expire`, body: noteBody }
+  }
+  if (current === "confirmed" && target === "in_progress") {
+    return { path: `/v1/bookings/${bookingId}/start`, body: noteBody }
+  }
+  if (current === "in_progress" && target === "completed") {
+    return { path: `/v1/bookings/${bookingId}/complete`, body: noteBody }
+  }
+  if (
+    target === "cancelled" &&
+    (current === "draft" ||
+      current === "on_hold" ||
+      current === "confirmed" ||
+      current === "in_progress")
+  ) {
+    return { path: `/v1/bookings/${bookingId}/cancel`, body: noteBody }
+  }
+
+  return {
+    path: `/v1/bookings/${bookingId}/override-status`,
+    body: { status: target, reason: note ?? "", ...(note ? { note } : {}) },
+  }
+}

--- a/packages/bookings/tests/unit/status-dispatch.test.ts
+++ b/packages/bookings/tests/unit/status-dispatch.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest"
+
+import { dispatchBookingStatusChange } from "../../src/status-dispatch.js"
+
+const BOOKING_ID = "book_01HZA0000000000000000000"
+
+describe("dispatchBookingStatusChange — named verbs", () => {
+  it("on_hold → confirmed routes to /confirm", () => {
+    const target = dispatchBookingStatusChange(BOOKING_ID, "on_hold", "confirmed")
+    expect(target.path).toBe(`/v1/bookings/${BOOKING_ID}/confirm`)
+    expect(target.body).toEqual({})
+  })
+
+  it("on_hold → expired routes to /expire", () => {
+    const target = dispatchBookingStatusChange(BOOKING_ID, "on_hold", "expired")
+    expect(target.path).toBe(`/v1/bookings/${BOOKING_ID}/expire`)
+    expect(target.body).toEqual({})
+  })
+
+  it("confirmed → in_progress routes to /start", () => {
+    const target = dispatchBookingStatusChange(BOOKING_ID, "confirmed", "in_progress")
+    expect(target.path).toBe(`/v1/bookings/${BOOKING_ID}/start`)
+    expect(target.body).toEqual({})
+  })
+
+  it("in_progress → completed routes to /complete", () => {
+    const target = dispatchBookingStatusChange(BOOKING_ID, "in_progress", "completed")
+    expect(target.path).toBe(`/v1/bookings/${BOOKING_ID}/complete`)
+    expect(target.body).toEqual({})
+  })
+
+  it.each([
+    "draft",
+    "on_hold",
+    "confirmed",
+    "in_progress",
+  ] as const)("%s → cancelled routes to /cancel", (current) => {
+    const target = dispatchBookingStatusChange(BOOKING_ID, current, "cancelled")
+    expect(target.path).toBe(`/v1/bookings/${BOOKING_ID}/cancel`)
+    expect(target.body).toEqual({})
+  })
+})
+
+describe("dispatchBookingStatusChange — note shaping", () => {
+  it("includes note in body when provided", () => {
+    const target = dispatchBookingStatusChange(BOOKING_ID, "on_hold", "confirmed", "ok by ops")
+    expect(target.body).toEqual({ note: "ok by ops" })
+  })
+
+  it("omits note when null", () => {
+    const target = dispatchBookingStatusChange(BOOKING_ID, "on_hold", "confirmed", null)
+    expect(target.body).toEqual({})
+  })
+
+  it("omits note when empty string (falsy)", () => {
+    const target = dispatchBookingStatusChange(BOOKING_ID, "on_hold", "confirmed", "")
+    expect(target.body).toEqual({})
+  })
+})
+
+describe("dispatchBookingStatusChange — override fallback", () => {
+  it("non-adjacent jump (cancelled → confirmed) falls through to /override-status", () => {
+    const target = dispatchBookingStatusChange(
+      BOOKING_ID,
+      "cancelled",
+      "confirmed",
+      "data correction per ops",
+    )
+    expect(target.path).toBe(`/v1/bookings/${BOOKING_ID}/override-status`)
+    expect(target.body).toEqual({
+      status: "confirmed",
+      reason: "data correction per ops",
+      note: "data correction per ops",
+    })
+  })
+
+  it("override sets reason to empty string when no note (server will reject — surfacing 400)", () => {
+    const target = dispatchBookingStatusChange(BOOKING_ID, "completed", "draft")
+    expect(target.path).toBe(`/v1/bookings/${BOOKING_ID}/override-status`)
+    expect(target.body).toEqual({ status: "draft", reason: "" })
+  })
+
+  it("expired → confirmed falls through to /override-status (no named verb)", () => {
+    const target = dispatchBookingStatusChange(BOOKING_ID, "expired", "confirmed", "ops override")
+    expect(target.path).toBe(`/v1/bookings/${BOOKING_ID}/override-status`)
+    expect(target.body).toEqual({
+      status: "confirmed",
+      reason: "ops override",
+      note: "ops override",
+    })
+  })
+
+  it("draft → confirmed (no named verb for this arrow) routes to override", () => {
+    const target = dispatchBookingStatusChange(BOOKING_ID, "draft", "confirmed", "manual confirm")
+    expect(target.path).toBe(`/v1/bookings/${BOOKING_ID}/override-status`)
+    expect(target.body).toEqual({
+      status: "confirmed",
+      reason: "manual confirm",
+      note: "manual confirm",
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Pulls the `(currentStatus, targetStatus)` → verb endpoint dispatch table out of `bookings-react`'s `useBookingStatusMutation` into a new framework-agnostic module: `@voyantjs/bookings/status-dispatch`.
- Non-React callers (operator scripts hitting the REST API directly, server-to-server clients, third-party storefront builds) can now reuse the helper instead of re-deriving the table from the React hook source.
- `useBookingStatusMutation` and `useBookingStatusByIdMutation` delegate to the new helper. Hook behaviour is unchanged.
- Also re-exported from the package barrel for discoverability.

```ts
import { dispatchBookingStatusChange } from "@voyantjs/bookings/status-dispatch"

const target = dispatchBookingStatusChange(bookingId, "on_hold", "confirmed", "ok by ops")
await fetch(`${apiBase}${target.path}`, {
  method: "POST",
  headers: { "content-type": "application/json" },
  body: JSON.stringify(target.body),
})
```

Closes #329.

## Test plan

- [x] `pnpm -F @voyantjs/bookings test` — 207 passed, 103 skipped (DB-gated integration), incl. 15 new `status-dispatch.test.ts` cases covering all 7 named-verb arrows, note shaping, and `/override-status` fallback for non-adjacent jumps.
- [x] `pnpm -F @voyantjs/bookings typecheck` and `pnpm -F @voyantjs/bookings-react typecheck` clean.
- [x] `pnpm -F @voyantjs/bookings lint` and `pnpm -F @voyantjs/bookings-react lint` clean.
- [x] `pnpm -F @voyantjs/bookings build` emits `dist/status-dispatch.{js,d.ts}` matching the new `publishConfig` sub-path.
- [x] `pnpm -F @voyantjs/bookings-react build` clean (resolves `@voyantjs/bookings/status-dispatch` import).