### PR TITLE
feat(bookings): convenience verb for traveler + encrypted travel-details

### DIFF
--- a/.changeset/bookings-traveler-with-travel-details.md
+++ b/.changeset/bookings-traveler-with-travel-details.md
@@ -1,0 +1,34 @@
+---
+"@voyantjs/bookings": minor
+---
+
+Add `bookingsService.createTravelerWithTravelDetails` and `updateTravelerWithTravelDetails` — convenience verbs that take the same flat payload shape `createTravelerRecord` accepted before 0.10 (with `dateOfBirth` / `nationality` / `passportNumber` / `passportExpiry` / `dietaryRequirements` / `accessibilityNeeds` / `isLeadTraveler` included) and internally fan out to `createTravelerRecord` + `BookingPiiService.upsertTravelerTravelDetails`. The storage split (plaintext columns + encrypted envelope) is preserved at rest — only the call ergonomics collapse.
+
+Migration boundary helper for consumers coming from the pre-0.10 single-call shape: instead of learning the encrypted PII service contract just to keep parity with the dropped `accessibility_needs` column, you can pass one flat object as before.
+
+Also adds `accessibilityNeeds` to `upsertTravelerTravelDetailsSchema` (the underlying PII service has always supported it; the public-facing schema was missing it).
+
+```ts
+import { bookingsService, createBookingPiiService } from "@voyantjs/bookings"
+
+const pii = createBookingPiiService({ kms })
+
+const result = await bookingsService.createTravelerWithTravelDetails(
+  db,
+  bookingId,
+  {
+    participantType: "traveler",
+    firstName: "Ana",
+    lastName: "Traveler",
+    email: "ana@example.com",
+    nationality: "RO",
+    passportNumber: "ABC123",
+    accessibilityNeeds: "wheelchair access",
+    isLeadTraveler: true,
+  },
+  { pii, userId: actorId, actorId },
+)
+// → { traveler, travelDetails }
+```
+
+Operations are sequential, not transactional — a failure in the encrypted-fields write leaves the plaintext row in place (matching the pre-helper two-call protocol).

--- a/packages/bookings/src/index.ts
+++ b/packages/bookings/src/index.ts
@@ -22,7 +22,11 @@ export {
   redactTravelerIdentity,
   shouldRevealBookingPii,
 } from "./pii-redaction.js"
-export type { ConvertProductData } from "./service.js"
+export type {
+  ConvertProductData,
+  CreateTravelerWithTravelDetailsInput,
+  UpdateTravelerWithTravelDetailsInput,
+} from "./service.js"
 export { bookingsService } from "./service.js"
 export {
   type AddBookingGroupMemberInput,
@@ -167,6 +171,7 @@ export {
   confirmBookingSchema,
   convertProductSchema,
   createBookingSchema,
+  createTravelerWithTravelDetailsSchema,
   expireBookingSchema,
   expireStaleBookingsSchema,
   extendBookingHoldSchema,
@@ -205,5 +210,6 @@ export {
   updateBookingSchema,
   updateSupplierStatusSchema,
   updateTravelerSchema,
+  updateTravelerWithTravelDetailsSchema,
   upsertTravelerTravelDetailsSchema,
 } from "./validation.js"

--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -5,6 +5,7 @@ import type { z } from "zod"
 
 import { availabilitySlotsRef } from "./availability-ref.js"
 import { exchangeRatesRef } from "./markets-ref.js"
+import type { BookingPiiService, UpsertBookingTravelerTravelDetailInput } from "./pii.js"
 import {
   bookingItemProductDetailsRef,
   bookingProductDetailsRef,
@@ -51,6 +52,7 @@ import type {
   completeBookingSchema,
   confirmBookingSchema,
   convertProductSchema,
+  createTravelerWithTravelDetailsSchema,
   expireBookingSchema,
   expireStaleBookingsSchema,
   extendBookingHoldSchema,
@@ -72,6 +74,7 @@ import type {
   updateBookingSchema,
   updateTravelerRecordSchema,
   updateTravelerSchema,
+  updateTravelerWithTravelDetailsSchema,
 } from "./validation.js"
 
 type BookingListQuery = z.infer<typeof bookingListQuerySchema>
@@ -91,6 +94,26 @@ type CreateTravelerInput = z.infer<typeof insertTravelerSchema>
 type UpdateTravelerInput = z.infer<typeof updateTravelerSchema>
 type CreateTravelerRecordInput = z.infer<typeof insertTravelerRecordSchema>
 type UpdateTravelerRecordInput = z.infer<typeof updateTravelerRecordSchema>
+export type CreateTravelerWithTravelDetailsInput = z.infer<
+  typeof createTravelerWithTravelDetailsSchema
+>
+export type UpdateTravelerWithTravelDetailsInput = z.infer<
+  typeof updateTravelerWithTravelDetailsSchema
+>
+
+function pickTravelDetailFields(
+  data: CreateTravelerWithTravelDetailsInput | UpdateTravelerWithTravelDetailsInput,
+): UpsertBookingTravelerTravelDetailInput {
+  return {
+    nationality: data.nationality,
+    passportNumber: data.passportNumber,
+    passportExpiry: data.passportExpiry,
+    dateOfBirth: data.dateOfBirth,
+    dietaryRequirements: data.dietaryRequirements,
+    accessibilityNeeds: data.accessibilityNeeds,
+    isLeadTraveler: data.isLeadTraveler,
+  }
+}
 type CreateBookingItemInput = z.infer<typeof insertBookingItemSchema>
 type UpdateBookingItemInput = z.infer<typeof updateBookingItemSchema>
 type CreateBookingItemParticipantInput = z.infer<typeof insertBookingItemParticipantSchema>
@@ -3051,6 +3074,101 @@ export const bookingsService = {
     await ensureParticipantFlags(db, row.bookingId, row.id, data)
 
     return row
+  },
+
+  /**
+   * Create a traveler row and persist the encrypted travel-details envelope in
+   * a single call. Migration boundary helper for consumers coming from the
+   * pre-0.10 `createTravelerRecord({ ..., accessibilityNeeds, ... })` shape:
+   * the storage split (plaintext columns + encrypted bucket) is preserved, but
+   * the call ergonomics collapse back to one flat payload. Plaintext fields go
+   * to `createTravelerRecord`; encrypted fields are forwarded to
+   * `pii.upsertTravelerTravelDetails`. Operations are sequential, not
+   * transactional — a failure in the encrypted-fields write leaves the
+   * plaintext row in place (matching the pre-helper two-call protocol).
+   */
+  async createTravelerWithTravelDetails(
+    db: PostgresJsDatabase,
+    bookingId: string,
+    data: CreateTravelerWithTravelDetailsInput,
+    opts: {
+      pii: BookingPiiService
+      userId?: string
+      actorId?: string | null
+    },
+  ) {
+    const traveler = await this.createTravelerRecord(
+      db,
+      bookingId,
+      {
+        personId: data.personId,
+        participantType: data.participantType,
+        travelerCategory: data.travelerCategory,
+        firstName: data.firstName,
+        lastName: data.lastName,
+        email: data.email,
+        phone: data.phone,
+        preferredLanguage: data.preferredLanguage,
+        specialRequests: data.specialRequests,
+        isPrimary: data.isPrimary,
+        notes: data.notes,
+      },
+      opts.userId,
+    )
+    if (!traveler) {
+      return null
+    }
+
+    const travelDetails = await opts.pii.upsertTravelerTravelDetails(
+      db,
+      traveler.id,
+      pickTravelDetailFields(data),
+      opts.actorId,
+    )
+
+    return { traveler, travelDetails }
+  },
+
+  /**
+   * Update a traveler row and (re-)upsert the encrypted travel-details
+   * envelope in a single call. Same migration-ergonomics motivation as
+   * `createTravelerWithTravelDetails`. Undefined fields are not written;
+   * `null` clears a column / encrypted field.
+   */
+  async updateTravelerWithTravelDetails(
+    db: PostgresJsDatabase,
+    travelerId: string,
+    data: UpdateTravelerWithTravelDetailsInput,
+    opts: {
+      pii: BookingPiiService
+      actorId?: string | null
+    },
+  ) {
+    const traveler = await this.updateTravelerRecord(db, travelerId, {
+      personId: data.personId,
+      participantType: data.participantType,
+      travelerCategory: data.travelerCategory,
+      firstName: data.firstName,
+      lastName: data.lastName,
+      email: data.email,
+      phone: data.phone,
+      preferredLanguage: data.preferredLanguage,
+      specialRequests: data.specialRequests,
+      isPrimary: data.isPrimary,
+      notes: data.notes,
+    })
+    if (!traveler) {
+      return null
+    }
+
+    const travelDetails = await opts.pii.upsertTravelerTravelDetails(
+      db,
+      traveler.id,
+      pickTravelDetailFields(data),
+      opts.actorId,
+    )
+
+    return { traveler, travelDetails }
   },
 
   async deleteTravelerRecord(db: PostgresJsDatabase, travelerId: string) {

--- a/packages/bookings/src/validation.ts
+++ b/packages/bookings/src/validation.ts
@@ -277,8 +277,17 @@ export const upsertTravelerTravelDetailsSchema = z.object({
   passportExpiry: z.string().optional().nullable(),
   dateOfBirth: z.string().optional().nullable(),
   dietaryRequirements: z.string().optional().nullable(),
+  accessibilityNeeds: z.string().optional().nullable(),
   isLeadTraveler: z.boolean().optional().nullable(),
 })
+
+// Flat shape combining plaintext traveler columns + encrypted travel-details
+// fields, matching the pre-0.10 `createTravelerRecord` ergonomics. Migration
+// boundary helper — see `bookingsService.createTravelerWithTravelDetails`.
+export const createTravelerWithTravelDetailsSchema = travelerRecordCoreSchema.extend(
+  upsertTravelerTravelDetailsSchema.shape,
+)
+export const updateTravelerWithTravelDetailsSchema = createTravelerWithTravelDetailsSchema.partial()
 
 // ---------- booking items ----------
 

--- a/packages/bookings/tests/integration/pii.test.ts
+++ b/packages/bookings/tests/integration/pii.test.ts
@@ -27,6 +27,7 @@ describe.skipIf(!DB_AVAILABLE)("Booking PII service", () => {
         traveler_id text PRIMARY KEY NOT NULL REFERENCES booking_travelers(id) ON DELETE cascade,
         identity_encrypted jsonb,
         dietary_encrypted jsonb,
+        accessibility_encrypted jsonb,
         is_lead_traveler boolean DEFAULT false NOT NULL,
         created_at timestamp with time zone DEFAULT now() NOT NULL,
         updated_at timestamp with time zone DEFAULT now() NOT NULL

--- a/packages/bookings/tests/unit/traveler-with-travel-details.test.ts
+++ b/packages/bookings/tests/unit/traveler-with-travel-details.test.ts
@@ -1,0 +1,256 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import type { BookingPiiService, UpsertBookingTravelerTravelDetailInput } from "../../src/pii.js"
+import { bookingsService } from "../../src/service.js"
+
+interface FakePiiCall {
+  travelerId: string
+  input: UpsertBookingTravelerTravelDetailInput
+  actorId: string | null | undefined
+}
+
+function makeFakePii(): { service: BookingPiiService; calls: FakePiiCall[] } {
+  const calls: FakePiiCall[] = []
+  const service: BookingPiiService = {
+    async upsertTravelerTravelDetails(_db, travelerId, input, actorId) {
+      calls.push({ travelerId, input, actorId })
+      return {
+        travelerId,
+        nationality: input.nationality ?? null,
+        passportNumber: input.passportNumber ?? null,
+        passportExpiry: input.passportExpiry ?? null,
+        dateOfBirth: input.dateOfBirth ?? null,
+        dietaryRequirements: input.dietaryRequirements ?? null,
+        accessibilityNeeds: input.accessibilityNeeds ?? null,
+        isLeadTraveler: input.isLeadTraveler ?? false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+    },
+    async getTravelerTravelDetails() {
+      return null
+    },
+    async deleteTravelerTravelDetails(_db, travelerId) {
+      return { travelerId }
+    },
+  }
+  return { service, calls }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("bookingsService.createTravelerWithTravelDetails", () => {
+  it("forwards plaintext fields to createTravelerRecord and encrypted fields to pii.upsertTravelerTravelDetails", async () => {
+    const fakeRow = {
+      id: "bkps_01HZA0000000000000000001",
+      bookingId: "book_x",
+      personId: null,
+      participantType: "traveler",
+      travelerCategory: null,
+      firstName: "Ana",
+      lastName: "Traveler",
+      email: "ana@example.com",
+      phone: "+40700000001",
+      preferredLanguage: null,
+      specialRequests: null,
+      isPrimary: false,
+      notes: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }
+    const createSpy = vi
+      .spyOn(bookingsService, "createTravelerRecord")
+      // biome-ignore lint/suspicious/noExplicitAny: spy return narrowing
+      .mockResolvedValue(fakeRow as any)
+
+    const { service: pii, calls } = makeFakePii()
+    const fakeDb = {} as never
+
+    const result = await bookingsService.createTravelerWithTravelDetails(
+      fakeDb,
+      "book_x",
+      {
+        participantType: "traveler",
+        firstName: "Ana",
+        lastName: "Traveler",
+        email: "ana@example.com",
+        phone: "+40700000001",
+        nationality: "RO",
+        passportNumber: "ABC123",
+        accessibilityNeeds: "wheelchair access",
+        isLeadTraveler: true,
+      },
+      { pii, userId: "u_1", actorId: "u_1" },
+    )
+
+    expect(createSpy).toHaveBeenCalledTimes(1)
+    const createArgs = createSpy.mock.calls[0]
+    expect(createArgs?.[1]).toBe("book_x")
+    // plaintext payload — encrypted keys must NOT leak through
+    expect(createArgs?.[2]).toMatchObject({
+      participantType: "traveler",
+      firstName: "Ana",
+      lastName: "Traveler",
+      email: "ana@example.com",
+      phone: "+40700000001",
+    })
+    expect(createArgs?.[2]).not.toHaveProperty("nationality")
+    expect(createArgs?.[2]).not.toHaveProperty("accessibilityNeeds")
+    expect(createArgs?.[3]).toBe("u_1")
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toEqual({
+      travelerId: fakeRow.id,
+      input: {
+        nationality: "RO",
+        passportNumber: "ABC123",
+        passportExpiry: undefined,
+        dateOfBirth: undefined,
+        dietaryRequirements: undefined,
+        accessibilityNeeds: "wheelchair access",
+        isLeadTraveler: true,
+      },
+      actorId: "u_1",
+    })
+
+    expect(result?.traveler).toEqual(fakeRow)
+    expect(result?.travelDetails?.passportNumber).toBe("ABC123")
+    expect(result?.travelDetails?.accessibilityNeeds).toBe("wheelchair access")
+  })
+
+  it("returns null when createTravelerRecord returns null (booking not found)", async () => {
+    const createSpy = vi.spyOn(bookingsService, "createTravelerRecord").mockResolvedValue(null)
+    const { service: pii, calls } = makeFakePii()
+
+    const result = await bookingsService.createTravelerWithTravelDetails(
+      {} as never,
+      "book_unknown",
+      { participantType: "traveler", firstName: "X", lastName: "Y" },
+      { pii },
+    )
+
+    expect(result).toBeNull()
+    expect(createSpy).toHaveBeenCalled()
+    expect(calls).toHaveLength(0)
+  })
+
+  it("still upserts an empty encrypted envelope when no encrypted fields are supplied", async () => {
+    vi.spyOn(bookingsService, "createTravelerRecord").mockResolvedValue({
+      id: "bkps_only_plain",
+      // biome-ignore lint/suspicious/noExplicitAny: minimal stub row
+    } as any)
+    const { service: pii, calls } = makeFakePii()
+
+    await bookingsService.createTravelerWithTravelDetails(
+      {} as never,
+      "book_x",
+      { participantType: "traveler", firstName: "Bo", lastName: "Traveler" },
+      { pii },
+    )
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.input).toEqual({
+      nationality: undefined,
+      passportNumber: undefined,
+      passportExpiry: undefined,
+      dateOfBirth: undefined,
+      dietaryRequirements: undefined,
+      accessibilityNeeds: undefined,
+      isLeadTraveler: undefined,
+    })
+  })
+})
+
+describe("bookingsService.updateTravelerWithTravelDetails", () => {
+  it("forwards plaintext partial to updateTravelerRecord and encrypted partial to pii.upsertTravelerTravelDetails", async () => {
+    const fakeRow = {
+      id: "bkps_01HZA0000000000000000002",
+      bookingId: "book_x",
+      firstName: "Renamed",
+      lastName: "Traveler",
+      email: "initial@example.com",
+    }
+    const updateSpy = vi
+      .spyOn(bookingsService, "updateTravelerRecord")
+      // biome-ignore lint/suspicious/noExplicitAny: spy return narrowing
+      .mockResolvedValue(fakeRow as any)
+
+    const { service: pii, calls } = makeFakePii()
+
+    const result = await bookingsService.updateTravelerWithTravelDetails(
+      {} as never,
+      "bkps_01HZA0000000000000000002",
+      { firstName: "Renamed", passportNumber: "NEW-12345" },
+      { pii, actorId: "u_42" },
+    )
+
+    expect(updateSpy).toHaveBeenCalledTimes(1)
+    const updateArgs = updateSpy.mock.calls[0]
+    expect(updateArgs?.[1]).toBe("bkps_01HZA0000000000000000002")
+    expect(updateArgs?.[2]).toMatchObject({
+      firstName: "Renamed",
+    })
+    expect(updateArgs?.[2]).not.toHaveProperty("passportNumber")
+    expect(updateArgs?.[2]).not.toHaveProperty("nationality")
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toEqual({
+      travelerId: fakeRow.id,
+      input: {
+        nationality: undefined,
+        passportNumber: "NEW-12345",
+        passportExpiry: undefined,
+        dateOfBirth: undefined,
+        dietaryRequirements: undefined,
+        accessibilityNeeds: undefined,
+        isLeadTraveler: undefined,
+      },
+      actorId: "u_42",
+    })
+
+    expect(result?.traveler).toEqual(fakeRow)
+    expect(result?.travelDetails?.passportNumber).toBe("NEW-12345")
+  })
+
+  it("preserves undefined-vs-null distinction for encrypted fields (undefined → preserve, null → clear)", async () => {
+    vi.spyOn(bookingsService, "updateTravelerRecord").mockResolvedValue({
+      id: "bkps_x",
+      // biome-ignore lint/suspicious/noExplicitAny: minimal stub row
+    } as any)
+    const { service: pii, calls } = makeFakePii()
+
+    await bookingsService.updateTravelerWithTravelDetails(
+      {} as never,
+      "bkps_x",
+      { passportNumber: null }, // explicit clear
+      { pii },
+    )
+
+    expect(calls[0]?.input).toEqual({
+      nationality: undefined, // preserve existing
+      passportNumber: null, // clear
+      passportExpiry: undefined,
+      dateOfBirth: undefined,
+      dietaryRequirements: undefined,
+      accessibilityNeeds: undefined,
+      isLeadTraveler: undefined,
+    })
+  })
+
+  it("returns null when updateTravelerRecord returns null (traveler not found)", async () => {
+    vi.spyOn(bookingsService, "updateTravelerRecord").mockResolvedValue(null)
+    const { service: pii, calls } = makeFakePii()
+
+    const result = await bookingsService.updateTravelerWithTravelDetails(
+      {} as never,
+      "bkps_unknown",
+      { firstName: "Nope" },
+      { pii },
+    )
+
+    expect(result).toBeNull()
+    expect(calls).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `bookingsService.createTravelerWithTravelDetails` and `updateTravelerWithTravelDetails` — convenience verbs that take the same flat payload shape `createTravelerRecord` accepted before 0.10 and internally fan out to `createTravelerRecord` + `BookingPiiService.upsertTravelerTravelDetails`.
- Migration-boundary helper for consumers coming from the pre-0.10 single-call shape: instead of learning the encrypted PII service contract just to keep parity with the dropped `accessibility_needs` column, callers can pass one flat object as before. Storage split (plaintext columns + encrypted envelope) preserved at rest — only the call ergonomics collapse.
- Also fills a gap: `accessibilityNeeds` was missing from `upsertTravelerTravelDetailsSchema` even though the underlying PII service supported it. Added now.
- Operations are sequential, not transactional — a failure in the encrypted-fields write leaves the plaintext row in place (matches the pre-helper two-call protocol explicitly described in the issue).

```ts
import { bookingsService, createBookingPiiService } from "@voyantjs/bookings"

const pii = createBookingPiiService({ kms })

const result = await bookingsService.createTravelerWithTravelDetails(
  db,
  bookingId,
  {
    participantType: "traveler",
    firstName: "Ana",
    lastName: "Traveler",
    email: "ana@example.com",
    nationality: "RO",
    passportNumber: "ABC123",
    accessibilityNeeds: "wheelchair access",
    isLeadTraveler: true,
  },
  { pii, userId: actorId, actorId },
)
// → { traveler, travelDetails }
```

Closes #328.

## Drive-by

`packages/bookings/tests/integration/pii.test.ts` was manually `CREATE TABLE`-ing `booking_traveler_travel_details` without the `accessibility_encrypted` column, even though the schema has carried it since 0.10. Fixed.

## Test plan

- [x] `pnpm -F @voyantjs/bookings test` — 198 passed (full suite), 6 new unit tests in `tests/unit/traveler-with-travel-details.test.ts` covering: plaintext/encrypted field split, encrypted keys not leaking into plaintext path, null booking returns null, empty encrypted envelope is still upserted, undefined-vs-null preserve/clear semantics on update, missing-traveler returns null.
- [x] `pnpm -F @voyantjs/bookings typecheck` clean.
- [x] `pnpm -F @voyantjs/bookings-react typecheck` clean.
- [x] `pnpm -F @voyantjs/bookings lint` clean.
- [x] `pnpm -F @voyantjs/bookings build` clean.