### PR TITLE
docs: consolidated per-minor migration pages (0.10, 0.11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Voyant is a source-available framework for travel companies. It provides starter apps and domain modules for CRM, products, availability, bookings, finance, distribution, resources, legal, and related travel workflows.
 
-#### [CLI](./packages/cli/README.md) | [DMC Template](./templates/dmc/README.md) | [Operator Template](./templates/operator/README.md) | [Packages](./packages) | [Examples](./examples)
+#### [CLI](./packages/cli/README.md) | [DMC Template](./templates/dmc/README.md) | [Operator Template](./templates/operator/README.md) | [Packages](./packages) | [Examples](./examples) | [Migrations](./docs/migrations/README.md)
 
 ## Get started
 
@@ -143,7 +143,8 @@ Voyant keeps a strict boundary:
 - Transport adapters stay thin and call shared domain services rather than owning business logic
 
 Architecture decisions live in [`docs/adr/`](./docs/adr/); domain
-conventions live in [`docs/architecture/`](./docs/architecture/).
+conventions live in [`docs/architecture/`](./docs/architecture/);
+per-minor migration notes live in [`docs/migrations/`](./docs/migrations/README.md).
 
 ## Security model
 

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -1,0 +1,29 @@
+# Migrations
+
+Per-minor consolidated migration notes for Voyant. Each page collects every breaking change in a release train into one read — removed exports across all packages, schema column changes, HTTP route changes, hook signature changes, activity-log enum changes, and the caller-code rewrites needed to land on the new minor.
+
+The full history (including patch-level changes and dependency updates) lives in the per-package `CHANGELOG.md` files; these pages exist because changeset entries land in *every* package's CHANGELOG that depends on the changed one, so the actual breaking signal is otherwise buried under dozens of `Updated dependencies [...]` lines per package.
+
+## Available
+
+- [Migrating to 0.11](./migrating-to-0.11.md) — privatize Booking state machine; replace `PATCH /:id/status` with named verbs; `useBookingStatusMutation` requires `currentStatus`; activity-type enum gains three values.
+- [Migrating to 0.10](./migrating-to-0.10.md) — encrypt `accessibility_needs` at rest; explicit Booking state machine + `transitionBooking` guards; drop `redeemed` status; add `bookings.fx_rate_set_id`; `requireActor` fail-closed; `Idempotency-Key` middleware on booking-creation endpoints; mandatory PII redaction + audit on admin booking reads.
+
+## Long-jumping
+
+If you skipped releases (e.g. `0.9 → 0.11`), apply the pages in order — each one assumes the previous minor is in place. Schema migrations stack: run `drizzle-kit push` once at the end is fine, but service-call rewrites in 0.11 (e.g. dropping `transitionBooking` imports) only make sense if you've already applied 0.10's migration of `db.update(bookings).set({ status })` patterns to the state machine.
+
+## Authoring (for maintainers)
+
+When cutting a minor with breaking changes, add a `migrating-to-0.X.md` page **alongside** the changeset, not after the release. Each breaking changeset should also link the consolidated page in its own description so consumers landing on the per-package CHANGELOG can find it.
+
+The page should cover, in this order:
+
+1. **TL;DR** — the 5-bullet executive summary.
+2. **Schema changes** — added / dropped columns, new enum values, CHECK constraints; with `drizzle-kit push` notes.
+3. **Removed exports** — old symbol → new symbol, including renames that are *not* backward-aliased.
+4. **HTTP route changes** — removed routes, replacement verbs.
+5. **Hook signature changes** — old signature → new signature.
+6. **Caller-code migrations** — `before` / `after` rewrites for the most common upgrade paths.
+7. **New capabilities** (optional, non-breaking) — worth flagging because consumers may want to opt in during the upgrade.
+8. **Per-package CHANGELOG links** — the bottom-of-page exit ramp into the full detail.

--- a/docs/migrations/migrating-to-0.10.md
+++ b/docs/migrations/migrating-to-0.10.md
@@ -1,0 +1,155 @@
+# Migrating to 0.10
+
+Consolidated breaking-change notes for the `0.10.0` release train. All entries here also live in the per-package `CHANGELOG.md` files (look for changeset `29a581a` and `b7f0501`); this page exists so you can find them all in one read instead of walking 30+ changelogs.
+
+> Long-jumping releases? See the [migrations index](./README.md) for the full list and apply each page in order.
+
+---
+
+## TL;DR
+
+- Run `drizzle-kit push` after upgrading — the booking activity-type enum and a few schema changes need to land at the database level.
+- Anonymous traffic on `/v1/admin/*` now returns `401` instead of `200` — `requireActor` is fail-closed.
+- `booking_travelers.accessibility_needs` is dropped — read/write through the encrypted PII service instead.
+- The `redeemed` booking status is gone. Read `completed` instead.
+- Direct `db.update(bookings).set({ status })` is no longer permitted from caller code — use `transitionBooking()`.
+- Booking-creation endpoints accept an optional `Idempotency-Key` header.
+
+---
+
+## Schema changes
+
+### Dropped
+
+| Column | Why | Replacement |
+|---|---|---|
+| `booking_travelers.accessibility_needs` | Disability data has tighter regulatory expectations (ADA / Equality Act) than freeform notes; moved into the KMS-encrypted bucket alongside passport / DOB / dietary. | Encrypted column `booking_traveler_travel_details.accessibility_encrypted`. Read via `createBookingPiiService.getTravelerTravelDetails`; write via `upsertTravelerTravelDetails`. |
+
+### Added
+
+| Column | Notes |
+|---|---|
+| `bookings.fx_rate_set_id` | Plain text, nullable. Soft FK into the `markets` package per the cross-domain FK rule. Drives the new FX rollup on `base_*_amount_cents`. |
+
+### CHECK constraints (additive, may reject existing bad data)
+
+Postgres `CHECK` constraints now enforce that if any `*_amount_cents` column is set, its companion currency column must also be set. Two flavours:
+
+- **Strict XNOR** (`(currency IS NULL) = (amount IS NULL)`): one currency to one amount — `booking_guarantees`, `booking_item_commissions`, `payments` (base).
+- **Implication** (`(amounts NULL) OR (currency NOT NULL)`): one currency covering multiple amount columns — `bookings.base_currency`, `booking_items.cost_currency`, `offer_items.cost_currency`, `order_items.cost_currency`, `invoices.base_currency`. The implication form intentionally allows "currency without amount" because the currency may be pre-declared before line items roll up.
+
+If the migration fails, the offending rows have an amount without a currency — fix or null the amount before retrying.
+
+### Activity-log enum (no breaking change in 0.10, see 0.11 for the values added then)
+
+No activity-type changes in 0.10.
+
+---
+
+## Removed exports
+
+### `@voyantjs/bookings`
+
+| Removed | Replacement |
+|---|---|
+| `accessibilityNeeds` field on `BookingTraveler*` insert / update validation schemas (`insertTravelerSchema`, `updateTravelerSchema`, `insertTravelerRecordSchema`, `updateTravelerRecordSchema`) and on `redactTravelerIdentity()` output | Use `createBookingPiiService.upsertTravelerTravelDetails({ accessibilityNeeds })`. As of [`@voyantjs/bookings@0.13`](./migrating-to-0.13.md), the `bookingsService.createTravelerWithTravelDetails` convenience verb takes the same flat payload as the old `createTravelerRecord`. |
+| `redeemed` value in `BookingStatus` | Read `completed` instead. The redemption concept moved to the vouchers domain. |
+
+---
+
+## HTTP route changes
+
+### Added
+
+- `POST /v1/admin/bookings/`, `POST /v1/admin/bookings/reserve`, `POST /v1/admin/bookings/from-product`, `POST /v1/admin/bookings/from-offer/:offerId/reserve`, `POST /v1/admin/bookings/from-order/:orderId/reserve`, `POST /v1/public/bookings/sessions`, and `POST /v1/public/bookings/sessions/:sessionId/confirm` accept an optional `Idempotency-Key` header. Same key + same body replays the original response; same key + different body returns `409 Conflict`. Records expire after 24h.
+
+  No client change required (header defaults to `required: false`). Templates can flip a route to `required: true` per endpoint once their client has rolled out.
+
+### Behaviour change — fail-closed `requireActor`
+
+`requireActor` middleware now returns `401 Unauthorized` when no actor is set on the request, instead of defaulting to `"staff"`.
+
+- Earlier versions silently granted operator privileges to anonymous traffic if `requireAuth` was missing, misordered, or a route mounted before auth. The fail-open default has been replaced with fail-closed.
+- `requireAuth` now sets `actor: "staff"` explicitly on the core-owned API key path (`voy_` prefix) — server-to-server integrations behave the same.
+- Custom `auth.resolve` integrations that previously relied on the implicit `"staff"` fallback must now return an explicit `actor` from `resolve()`.
+- Anonymous requests on `/v1/admin/*` now return `401` instead of `200`. Anonymous requests on `/v1/public/*` continue to receive `actor: "customer"` via the `publicPaths` bypass when applicable, and `401` otherwise.
+- The differentiation between `401` (no actor) and `403` (actor not in the allowed list) is now reliable — earlier the no-actor path returned `403` for some surfaces and `200` for others.
+
+### Behaviour change — admin booking reads gain mandatory PII redaction + audit
+
+`GET /v1/admin/bookings`, `GET /v1/admin/bookings/:id`, and `GET /v1/admin/bookings/:id/travelers` now mask contact PII (name, email, phone, address) in the response unless the caller has the `bookings-pii:read` (or `bookings-pii:*` / `*` superuser) scope, or the request is internal. Every call also writes a `booking_pii_access_log` row with reason (`list_redacted` / `detail_reveal` / `insufficient_scope`) and metadata including row count.
+
+If your operator UI relies on contact data being present in list responses, grant the operator user the `bookings-pii:read` scope or upgrade to detail reveal.
+
+---
+
+## Caller-code migrations
+
+### State machine — direct status writes are no longer permitted
+
+Bookings now move through a typed state graph:
+
+```
+draft → on_hold → confirmed → in_progress → completed
+                                    ↓
+                              cancelled / expired (terminal exits)
+```
+
+Replace any `db.update(bookings).set({ status: ... })` in caller code with `transitionBooking(bookingId, nextStatus, ctx)`, which enforces `BOOKING_TRANSITIONS` and emits an activity log row per transition.
+
+> **Note**: as of `@voyantjs/bookings@0.11`, `transitionBooking` itself is no longer exported — the lifecycle laws live behind named verb routes / service methods. See [migrating-to-0.11.md](./migrating-to-0.11.md). If you're long-jumping from `0.9` to `0.11+`, you can skip the `transitionBooking()` step and go straight to the verb endpoints.
+
+### Encrypted accessibility data — read/write contract change
+
+```ts
+// Before — 0.9.x
+await bookingsService.createTravelerRecord(db, bookingId, {
+  // ...plaintext fields
+  accessibilityNeeds: "wheelchair access",
+})
+
+// After — 0.10.x (two-call protocol)
+const traveler = await bookingsService.createTravelerRecord(db, bookingId, {
+  // ...plaintext fields only
+})
+const pii = createBookingPiiService({ kms })
+await pii.upsertTravelerTravelDetails(db, traveler.id, {
+  accessibilityNeeds: "wheelchair access",
+})
+
+// After — 0.13+ (single-call convenience verb)
+const result = await bookingsService.createTravelerWithTravelDetails(
+  db,
+  bookingId,
+  { /* ...plaintext + accessibilityNeeds + other encrypted fields */ },
+  { pii },
+)
+```
+
+Reads of accessibility data go through `createBookingPiiService.getTravelerTravelDetails`, which decrypts via `decryptOptionalJsonEnvelope` + audits the access. Same authorisation gate as the existing dietary / identity buckets.
+
+Contact identifiers (email, phone, names, address) and `specialRequests` deliberately stay plaintext — see `docs/architecture/booking-pii.md` for the cost-benefit decision.
+
+### `redeemed` status removed
+
+Anything that filtered on `BookingStatus === "redeemed"` should now look at `"completed"`. The redemption event itself still exists in `booking_redemption_events` — the change was just to the lifecycle terminal value.
+
+---
+
+## New capabilities (non-breaking, but worth knowing)
+
+- **`bookingsService.recomputeBookingTotal(db, bookingId)`** — auto-rolls up the parent total from `booking_items` on `createItem` / `updateItem` / `deleteItem`, each wrapped in `db.transaction`. Also exposed publicly for ad-hoc invocation (saga compensation, fix-up scripts). Base-currency totals are NOT recomputed by this rollup — that's the FX rollup, see below.
+- **FX rollup for `base_*_amount_cents`** — re-derives `baseSellAmountCents` / `baseCostAmountCents` from per-item totals when the booking declares a `baseCurrency` and `fxRateSetId`. Handles single-currency (no-op), multi-currency with valid FX, missing rate (short-circuits with `fxStatus: "missing_rate"`), and skipped (no `fxRateSetId`).
+- **`refundBooking` saga** — atomic credit-note + hold-release + supplier-reverse + notify, built on the existing `createWorkflow` primitive. Side-effect dependencies are injected (no compile-time pull on finance / transactions / notifications) so the package stays slim; templates wire the deps. Exports `refundBooking(input, deps)` and `buildRefundBookingWorkflow(deps)`.
+- **`idempotencyKey({ scope, required? })` middleware** in `@voyantjs/hono` — see Added routes above. Pair with `purgeExpiredIdempotencyKeys()` for daily-cron cleanup.
+
+---
+
+## Per-package CHANGELOGs
+
+For full detail, including patch-level changes and dependency updates not listed here:
+
+- [`@voyantjs/bookings@0.10.0`](../../packages/bookings/CHANGELOG.md)
+- [`@voyantjs/hono@0.10.0`](../../packages/hono/CHANGELOG.md)
+- [`@voyantjs/db@0.10.0`](../../packages/db/CHANGELOG.md)
+- [`@voyantjs/core@0.10.0`](../../packages/core/CHANGELOG.md)

--- a/docs/migrations/migrating-to-0.10.md
+++ b/docs/migrations/migrating-to-0.10.md
@@ -40,10 +40,6 @@ Postgres `CHECK` constraints now enforce that if any `*_amount_cents` column is 
 
 If the migration fails, the offending rows have an amount without a currency — fix or null the amount before retrying.
 
-### Activity-log enum (no breaking change in 0.10, see 0.11 for the values added then)
-
-No activity-type changes in 0.10.
-
 ---
 
 ## Removed exports
@@ -52,7 +48,7 @@ No activity-type changes in 0.10.
 
 | Removed | Replacement |
 |---|---|
-| `accessibilityNeeds` field on `BookingTraveler*` insert / update validation schemas (`insertTravelerSchema`, `updateTravelerSchema`, `insertTravelerRecordSchema`, `updateTravelerRecordSchema`) and on `redactTravelerIdentity()` output | Use `createBookingPiiService.upsertTravelerTravelDetails({ accessibilityNeeds })`. As of [`@voyantjs/bookings@0.13`](./migrating-to-0.13.md), the `bookingsService.createTravelerWithTravelDetails` convenience verb takes the same flat payload as the old `createTravelerRecord`. |
+| `accessibilityNeeds` field on `BookingTraveler*` insert / update validation schemas (`insertTravelerSchema`, `updateTravelerSchema`, `insertTravelerRecordSchema`, `updateTravelerRecordSchema`) and on `redactTravelerIdentity()` output | Use `createBookingPiiService.upsertTravelerTravelDetails({ accessibilityNeeds })`. A later release adds a `bookingsService.createTravelerWithTravelDetails` convenience verb that takes the same flat payload as the old `createTravelerRecord` — see the matching migration page when it ships. |
 | `redeemed` value in `BookingStatus` | Read `completed` instead. The redemption concept moved to the vouchers domain. |
 
 ---
@@ -117,7 +113,7 @@ await pii.upsertTravelerTravelDetails(db, traveler.id, {
   accessibilityNeeds: "wheelchair access",
 })
 
-// After — 0.13+ (single-call convenience verb)
+// After — single-call convenience verb (added in a later release)
 const result = await bookingsService.createTravelerWithTravelDetails(
   db,
   bookingId,

--- a/docs/migrations/migrating-to-0.11.md
+++ b/docs/migrations/migrating-to-0.11.md
@@ -1,0 +1,154 @@
+# Migrating to 0.11
+
+Consolidated breaking-change notes for the `0.11.0` release train. All entries here also live in the per-package `CHANGELOG.md` files (look for changeset `fe905b0`); this page exists so you can find them all in one read instead of walking 30+ changelogs.
+
+> Long-jumping releases? See the [migrations index](./README.md) for the full list and apply each page in order. If you're coming from `0.9.x`, also apply [migrating-to-0.10.md](./migrating-to-0.10.md) first.
+
+---
+
+## TL;DR
+
+- The Booking state machine is now private. `BOOKING_TRANSITIONS`, `canTransitionBooking`, `transitionBooking`, `BookingStatusPatch`, `BookingTransitionError` are removed from `@voyantjs/bookings`.
+- `PATCH /v1/bookings/:id/status` is **removed**. Use the named verb routes instead: `/start`, `/complete`, `/override-status`, plus the existing `/confirm`, `/cancel`, `/expire`.
+- `bookingsService.updateBookingStatus(...)` is **removed**; use `.startBooking(...)` / `.completeBooking(...)` / `.overrideBookingStatus(...)` (or the existing `.confirmBooking` / `.cancelBooking` / `.expireBooking`).
+- React: `useBookingStatusMutation` and `useBookingStatusByIdMutation` now require `currentStatus` in their input.
+- Run `drizzle-kit push` to add `booking_started`, `booking_completed`, `status_overridden` to the activity-type enum.
+
+---
+
+## Schema changes
+
+### Activity-type enum gains three values
+
+| Value | Emitted by |
+|---|---|
+| `booking_started` | `POST /:id/start`, `bookingsService.startBooking` |
+| `booking_completed` | `POST /:id/complete`, `bookingsService.completeBooking` |
+| `status_overridden` | `POST /:id/override-status`, `bookingsService.overrideBookingStatus` |
+
+Run `drizzle-kit push` to sync. Activity-log readers that switch on `activity_type` should add cases for these three values.
+
+---
+
+## Removed exports
+
+### `@voyantjs/bookings`
+
+| Removed | Replacement |
+|---|---|
+| `BOOKING_TRANSITIONS` | None public. The transition graph is now an implementation detail; cross the seam via the named verbs below. |
+| `canTransitionBooking(from, to)` | None public. If you need pre-flight validation, attempt the verb and handle the error. |
+| `transitionBooking(from, to)` | Call the matching service verb: `startBooking` / `completeBooking` / `confirmBooking` / `cancelBooking` / `expireBooking` / `overrideBookingStatus`. |
+| `BookingTransitionError` | Service verbs return / throw their own errors; catch generically or by error code. |
+| `BookingStatusPatch` | Internal type, no replacement. |
+| `bookingsService.updateBookingStatus(...)` | One of `startBooking` / `completeBooking` / `confirmBooking` / `cancelBooking` / `expireBooking` / `overrideBookingStatus`. |
+| `updateBookingStatusSchema` | One of `startBookingSchema` / `completeBookingSchema` / `confirmBookingSchema` / `cancelBookingSchema` / `expireBookingSchema` / `overrideBookingStatusSchema`. |
+
+`BookingStatus` (the union type) **stays exported** — it's data, not a lifecycle helper.
+
+---
+
+## HTTP route changes
+
+### Removed
+
+| Route | Replacement |
+|---|---|
+| `PATCH /v1/bookings/:id/status` | Use the named verb endpoint matching the `(currentStatus, targetStatus)` arrow. See dispatch table below. |
+
+### Added
+
+| Route | Arrow | Notes |
+|---|---|---|
+| `POST /v1/bookings/:id/start` | `confirmed → in_progress` | Emits `booking.started`. Body: `{ note? }`. |
+| `POST /v1/bookings/:id/complete` | `in_progress → completed` | Emits `booking.completed`. Cascades confirmed allocations + items to `fulfilled`. Body: `{ note? }`. |
+| `POST /v1/bookings/:id/override-status` | (any) → (any) | Admin override. Bypasses the transition graph. Updates the Booking row only; does **not** cascade. Requires non-empty `reason`. Emits `booking.status_overridden` as a privileged audit signal distinct from the normal lifecycle events. Body: `{ status, reason, note? }`. |
+
+`POST /:id/confirm`, `/:id/cancel`, `/:id/expire`, `/:id/extend-hold` are unchanged.
+
+### Dispatch table for non-React callers
+
+If you were calling `PATCH /v1/bookings/:id/status` directly (operator scripts, server-to-server, third-party storefront builds), the mapping from `(current, target)` to verb is:
+
+| current | target | endpoint | body |
+|---|---|---|---|
+| `on_hold` | `confirmed` | `/confirm` | `{ note? }` |
+| `on_hold` | `expired` | `/expire` | `{ note? }` |
+| `confirmed` | `in_progress` | `/start` | `{ note? }` |
+| `in_progress` | `completed` | `/complete` | `{ note? }` |
+| `draft` / `on_hold` / `confirmed` / `in_progress` | `cancelled` | `/cancel` | `{ note? }` |
+| (anything else) | (anything) | `/override-status` | `{ status, reason, note? }` (reason required, server returns 400 on empty) |
+
+This table is also the body of the framework-agnostic `dispatchBookingStatusChange` helper exported from `@voyantjs/bookings/status-dispatch` — see [PR #334](https://github.com/voyantjs/voyant/pull/334).
+
+```ts
+import { dispatchBookingStatusChange } from "@voyantjs/bookings/status-dispatch"
+
+const target = dispatchBookingStatusChange(bookingId, currentStatus, targetStatus, note)
+await fetch(`${apiBase}${target.path}`, {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(target.body),
+})
+```
+
+---
+
+## Hook signature changes
+
+### `@voyantjs/bookings-react`
+
+`useBookingStatusMutation` and `useBookingStatusByIdMutation` now require `currentStatus` in their input. The hook dispatches client-side to the right verb endpoint; non-adjacent jumps fall through to `/override-status`, using the operator's note as the reason.
+
+```ts
+// Before — 0.10.x
+const mutation = useBookingStatusMutation(bookingId)
+mutation.mutate({ status: "confirmed", note })
+
+// After — 0.11.x
+const mutation = useBookingStatusMutation(bookingId)
+mutation.mutate({ currentStatus, status: "confirmed", note })
+```
+
+The `<StatusChangeDialog>` UX is unchanged — pass the booking's current status from props.
+
+---
+
+## Caller-code migrations
+
+### Service-call rewrites
+
+```ts
+// Before — 0.10.x
+import { transitionBooking } from "@voyantjs/bookings"
+const patch = transitionBooking(currentStatus, "confirmed")
+await db.update(bookings).set(patch).where(eq(bookings.id, bookingId))
+
+// After — 0.11.x
+await bookingsService.confirmBooking(db, bookingId, { note }, { actor: { userId } })
+```
+
+| Before | After |
+|---|---|
+| `bookingsService.updateBookingStatus(db, id, { status: "confirmed", note })` | `bookingsService.confirmBooking(db, id, { note }, { actor })` |
+| `bookingsService.updateBookingStatus(db, id, { status: "cancelled", note })` | `bookingsService.cancelBooking(db, id, { note }, { actor })` |
+| `bookingsService.updateBookingStatus(db, id, { status: "expired", note })` | `bookingsService.expireBooking(db, id, { note }, { actor })` |
+| `bookingsService.updateBookingStatus(db, id, { status: "in_progress", note })` | `bookingsService.startBooking(db, id, { note }, { actor })` |
+| `bookingsService.updateBookingStatus(db, id, { status: "completed", note })` | `bookingsService.completeBooking(db, id, { note }, { actor })` |
+| `bookingsService.updateBookingStatus(db, id, { status, note })` (data correction / non-adjacent jump) | `bookingsService.overrideBookingStatus(db, id, { status, reason: note }, { actor })` (reason required) |
+
+### Activity-log enum readers
+
+If your app reads `booking_activity_log.activity_type`, add cases for `booking_started`, `booking_completed`, `status_overridden`.
+
+---
+
+## Per-package CHANGELOGs
+
+For full detail, including patch-level changes and dependency updates not listed here:
+
+- [`@voyantjs/bookings@0.11.0`](../../packages/bookings/CHANGELOG.md)
+- [`@voyantjs/bookings-react@0.11.0`](../../packages/bookings-react/CHANGELOG.md)
+- [`@voyantjs/hono@0.11.0`](../../packages/hono/CHANGELOG.md)
+- [`@voyantjs/db@0.11.0`](../../packages/db/CHANGELOG.md)
+- [`@voyantjs/core@0.11.0`](../../packages/core/CHANGELOG.md)


### PR DESCRIPTION
## Summary

Adds `docs/migrations/` with one consolidated page per minor release. Each page collects every breaking change in a release train into one read — removed exports across all packages, schema column changes, HTTP route changes, hook signature changes, activity-log enum changes, and the caller-code rewrites needed to land on the new minor.

The motivation (verbatim from the issue): changeset entries land in *every* package's CHANGELOG that depends on the changed one, so the actual breaking signal is otherwise buried under dozens of `Updated dependencies [...]` lines per package. To find the breaking changes for a release train today, a consumer has to walk every package's CHANGELOG and dedupe the same changeset hash showing up in 30+ files. This page set fixes that.

### Files

- `docs/migrations/README.md` — index + an authoring checklist for maintainers, so the per-minor page becomes the standard shape for future breaking releases.
- `docs/migrations/migrating-to-0.10.md` — encrypt `accessibility_needs` at rest; explicit Booking state machine + `transitionBooking` guards; drop `redeemed` status; add `bookings.fx_rate_set_id`; `requireActor` fail-closed; `Idempotency-Key` middleware on booking-creation endpoints; mandatory PII redaction + audit on admin booking reads.
- `docs/migrations/migrating-to-0.11.md` — privatize Booking state machine; replace `PATCH /:id/status` with named verbs (`/start`, `/complete`, `/override-status`, plus the existing `/confirm`, `/cancel`, `/expire`); `useBookingStatusMutation` requires `currentStatus`; activity-type enum gains three values.
- `README.md` — link from the top-of-file table-of-contents and from the existing "Architecture" section.

Closes #330.

## Test plan

- [x] All cross-references between the two pages and the index resolve.
- [x] Cross-references into per-package `CHANGELOG.md` files resolve (relative paths from `docs/migrations/`).
- [x] State-machine privatization claim verified against current `packages/bookings/src/index.ts` (only `BookingStatus` is exported; runtime helpers are gone).
- [x] Verb-route claims verified against current `packages/bookings/src/routes.ts` (`/start`, `/complete`, `/override-status`, `/confirm`, `/cancel`, `/expire` all present; no `PATCH /:id/status`).
- [x] Hook signature claim verified against current `packages/bookings-react/src/hooks/use-booking-status-mutation.ts` (`UpdateBookingStatusInput` has `currentStatus: BookingStatus` as a required field).
- [x] No source code changes; nothing to typecheck or test beyond markdown rendering.