### PR TITLE
feat(templates): use Voyant Cloud SDK for PDF brochures and video uploads

### DIFF
--- a/.changeset/templates-cloud-sdk-defaults.md
+++ b/.changeset/templates-cloud-sdk-defaults.md
@@ -1,0 +1,17 @@
+---
+"@voyantjs/voyant-cloud": minor
+"@voyantjs/products": patch
+---
+
+Templates now default to Voyant Cloud SDK for browser-rendering (PDF brochures) and video uploads. Both are swappable per-template by editing the helper file.
+
+**`@voyantjs/voyant-cloud`**: bump `@voyantjs/cloud-sdk` peer to `^0.4.0` to access browser/video APIs. Re-export the new types (`BrowserPdfInput`, `BrowserPdfOptions`, `BrowserViewport`, `BrowserGoToOptions`, `BrowserScrapeInput`, `BrowserScreenshotInput`, `BrowserSnapshotResult`, `CreateVideoUploadInput`, `CreateVideoFromUrlInput`, `UpdateVideoInput`, `UploadVideoCaptionInput`, `VideoSummary`, `VideoUploadTicket`, etc.) so consumers only need one import.
+
+**`@voyantjs/products`**: expose `brochureBodyToHtml` from `tasks/` so consumers can compose their own printer. Previously it was internal to `brochure-printers.ts`.
+
+**Templates** (`dmc`, `operator`): two new helpers per template, both intentionally cleanly named so the underlying provider is swappable.
+
+- `src/lib/brochure-printer.ts` — `createProductBrochurePrinter(env)` returns a `ProductBrochurePrinter` that calls `client.browser.pdf({...})`. Replaces the basic pdf-lib path in `workflows.ts → products.generate-pdf`.
+- `src/lib/video-uploads.ts` — `createVideoUploadTicket(env, input)` returns a TUS upload ticket from `client.video.videos.createUpload(...)`. Wired into a new `POST /v1/uploads/video` route. The existing `POST /v1/uploads` keeps handling images/documents through the configured media storage provider (R2 by default).
+
+To switch providers, edit the helper body — e.g., to use direct Cloudflare API for PDFs, drop in `createCloudflareBrowserProductBrochurePrinterFromEnv`. To use a different video host, return your own TUS ticket shape.

--- a/packages/products/src/tasks/brochure-printers.ts
+++ b/packages/products/src/tasks/brochure-printers.ts
@@ -42,7 +42,11 @@ function escapeHtml(value: string) {
     .replaceAll("'", "&#39;")
 }
 
-function brochureBodyToHtml(body: string, bodyFormat: StructuredTemplateBodyFormat, title: string) {
+export function brochureBodyToHtml(
+  body: string,
+  bodyFormat: StructuredTemplateBodyFormat,
+  title: string,
+) {
   const content =
     bodyFormat === "html"
       ? body

--- a/packages/products/src/tasks/index.ts
+++ b/packages/products/src/tasks/index.ts
@@ -1,4 +1,5 @@
 export {
+  brochureBodyToHtml,
   type CloudflareBrowserBrochurePrinterOptions,
   createBasicPdfProductBrochurePrinter,
   createCloudflareBrowserProductBrochurePrinter,

--- a/packages/voyant-cloud/package.json
+++ b/packages/voyant-cloud/package.json
@@ -15,7 +15,7 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
-    "@voyantjs/cloud-sdk": "^0.1.0"
+    "@voyantjs/cloud-sdk": "^0.4.0"
   },
   "devDependencies": {
     "@voyantjs/voyant-typescript-config": "workspace:*",

--- a/packages/voyant-cloud/src/index.ts
+++ b/packages/voyant-cloud/src/index.ts
@@ -5,7 +5,22 @@ import {
 } from "@voyantjs/cloud-sdk"
 
 export type {
+  BrowserCommand,
+  BrowserCommandResult,
+  BrowserGoToOptions,
+  BrowserJsonInput,
+  BrowserPdfInput,
+  BrowserPdfOptions,
+  BrowserRenderInput,
+  BrowserScrapeInput,
+  BrowserScrapeResult,
+  BrowserScreenshotInput,
+  BrowserScreenshotOptions,
+  BrowserSnapshotResult,
+  BrowserViewport,
   CheckVerificationInput,
+  CreateVideoFromUrlInput,
+  CreateVideoUploadInput,
   EmailMessageStatus,
   EmailMessageSummary,
   PhoneNumberCapabilities,
@@ -16,6 +31,8 @@ export type {
   SmsMessageStatus,
   SmsMessageSummary,
   StartVerificationInput,
+  UpdateVideoInput,
+  UploadVideoCaptionInput,
   VaultSecretSummary,
   VaultSecretValue,
   VaultSummary,
@@ -23,6 +40,8 @@ export type {
   VerificationAttemptSummary,
   VerificationChannel,
   VerificationCheckResult,
+  VideoSummary,
+  VideoUploadTicket,
 } from "@voyantjs/cloud-sdk"
 export {
   createVoyantCloudClient,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,7 @@ importers:
         version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260403.1)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(better-auth@1.5.6(147937edba8663fd99b9bdbfb02e61a0))
       '@cloudflare/vite-plugin':
         specifier: ^1.31.0
-        version: 1.31.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260401.1)(wrangler@4.80.0(@cloudflare/workers-types@4.20260403.1))
+        version: 1.31.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260415.1)(wrangler@4.80.0(@cloudflare/workers-types@4.20260403.1))
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -4050,8 +4050,8 @@ importers:
   packages/voyant-cloud:
     dependencies:
       '@voyantjs/cloud-sdk':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.4.0
+        version: 0.4.0
     devDependencies:
       '@voyantjs/voyant-typescript-config':
         specifier: workspace:*
@@ -8249,8 +8249,8 @@ packages:
   '@vitest/utils@4.1.2':
     resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
-  '@voyantjs/cloud-sdk@0.1.0':
-    resolution: {integrity: sha512-r5xCkMgylekCNp4JZ+oY+54Xb/Vzzroup2pDhdDZQNFXbyzyECQ8oBFvfkzcHQt0wJg3GaoNdsM/xhAXjdsDVA==}
+  '@voyantjs/cloud-sdk@0.4.0':
+    resolution: {integrity: sha512-nyeUsoiGDa3V37SrJmH56NoDRiLPQd6sBLi4ltRjwQpd5VJTreOK03l3pBgXPW/LoCeo/O8HDDrh4fAYea0RTw==}
     bundledDependencies:
       - '@voyant-sdk/sdk-core'
 
@@ -12425,19 +12425,6 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260415.1
 
-  '@cloudflare/vite-plugin@1.31.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260401.1)(wrangler@4.80.0(@cloudflare/workers-types@4.20260403.1))':
-    dependencies:
-      '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260401.1)
-      miniflare: 4.20260401.0
-      unenv: 2.0.0-rc.24
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)
-      wrangler: 4.80.0(@cloudflare/workers-types@4.20260403.1)
-      ws: 8.18.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - workerd
-
   '@cloudflare/vite-plugin@1.31.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260415.1)(wrangler@4.80.0(@cloudflare/workers-types@4.20260403.1))':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260415.1)
@@ -15013,7 +15000,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@voyantjs/cloud-sdk@0.1.0': {}
+  '@voyantjs/cloud-sdk@0.4.0': {}
 
   '@vue/compiler-core@3.5.32':
     dependencies:

--- a/templates/dmc/src/api/app.ts
+++ b/templates/dmc/src/api/app.ts
@@ -28,6 +28,7 @@ import { createStorefrontVerificationHonoModule } from "@voyantjs/storefront-ver
 import { suppliersHonoModule } from "@voyantjs/suppliers"
 import { transactionsBookingExtension, transactionsHonoModule } from "@voyantjs/transactions"
 import { resolveNotificationProviders } from "../lib/notifications"
+import { createVideoUploadTicket } from "../lib/video-uploads"
 import authHandler, { hasAuthPermission, resolveAuthRequest } from "./auth/handler"
 import { createInvitationsRoutes } from "./invitations"
 import { getDbFromHyperdrive } from "./lib/db"
@@ -162,6 +163,22 @@ export const app = createApp<CloudflareBindings>({
         mimeType: file.type,
         size: file.size,
       })
+    })
+
+    // POST /v1/uploads/video — request a one-shot upload ticket for video
+    // bytes. The client uploads the video directly to `uploadUrl` (TUS
+    // protocol). See `src/lib/video-uploads.ts` to swap providers.
+    hono.post("/v1/uploads/video", async (c) => {
+      const body = await c.req.json<{
+        maxDurationSeconds: number
+        name?: string | null
+        requireSignedUrls?: boolean
+        allowedOrigins?: string[]
+        thumbnailTimestampPct?: number | null
+        meta?: Record<string, string>
+      }>()
+      const ticket = await createVideoUploadTicket(c.env as Record<string, unknown>, body)
+      return c.json(ticket)
     })
 
     // GET /v1/media/* — serve public media via the configured media storage provider.

--- a/templates/dmc/src/lib/brochure-printer.ts
+++ b/templates/dmc/src/lib/brochure-printer.ts
@@ -1,0 +1,31 @@
+import { brochureBodyToHtml, type ProductBrochurePrinter } from "@voyantjs/products/tasks"
+import { getVoyantCloudClient, type VoyantCloudEnv } from "@voyantjs/voyant-cloud"
+
+/**
+ * Default brochure printer for this template.
+ *
+ * Renders the product brochure HTML to PDF via Voyant Cloud's browser-rendering
+ * API. To switch providers, replace the body of this function — `@voyantjs/products/tasks`
+ * exports alternatives like `createCloudflareBrowserProductBrochurePrinter`
+ * (direct Cloudflare API) and `createBasicPdfProductBrochurePrinter` (pdf-lib).
+ */
+export function createProductBrochurePrinter(env: VoyantCloudEnv): ProductBrochurePrinter {
+  const client = getVoyantCloudClient(env)
+
+  return async ({ template, context }) => {
+    const body = await client.browser.pdf({
+      html: brochureBodyToHtml(template.body, template.bodyFormat, template.title),
+    })
+
+    return {
+      body,
+      mimeType: "application/pdf",
+      fileSize: body.byteLength,
+      metadata: {
+        renderer: "voyant-cloud-browser",
+        productId: context.product.id,
+        bodyFormat: template.bodyFormat,
+      },
+    }
+  }
+}

--- a/templates/dmc/src/lib/video-uploads.ts
+++ b/templates/dmc/src/lib/video-uploads.ts
@@ -1,0 +1,22 @@
+import {
+  type CreateVideoUploadInput,
+  getVoyantCloudClient,
+  type VideoUploadTicket,
+  type VoyantCloudEnv,
+} from "@voyantjs/voyant-cloud"
+
+/**
+ * Default video upload handler for this template.
+ *
+ * Returns a one-shot TUS upload ticket that the client uploads the video bytes
+ * to directly. To switch providers (e.g., upload through your own Cloudflare
+ * Stream account or any TUS-compatible host), replace the body of this function
+ * with one that constructs the equivalent ticket.
+ */
+export function createVideoUploadTicket(
+  env: VoyantCloudEnv,
+  input: CreateVideoUploadInput,
+): Promise<VideoUploadTicket> {
+  const client = getVoyantCloudClient(env)
+  return client.video.videos.createUpload(input)
+}

--- a/templates/dmc/src/workflows.ts
+++ b/templates/dmc/src/workflows.ts
@@ -5,10 +5,15 @@ import {
   deliverQueuedNotificationReminder,
   sendDueNotificationReminders,
 } from "@voyantjs/notifications/tasks"
-import { generateProductPdf } from "@voyantjs/products/tasks"
+import {
+  createDefaultProductBrochureTemplate,
+  loadProductBrochureTemplateContext,
+  renderProductBrochureTemplate,
+} from "@voyantjs/products/tasks"
 import { workflow } from "@voyantjs/workflows"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
+import { createProductBrochurePrinter } from "./lib/brochure-printer.js"
 import { getNotificationTaskRuntime } from "./lib/notifications.js"
 
 function getDb() {
@@ -19,11 +24,18 @@ workflow<{ productId: string }, { base64: string; filename: string; sizeBytes: n
   id: "products.generate-pdf",
   defaultRuntime: "node",
   async run(input) {
-    const result = await generateProductPdf(getDb(), input.productId)
+    const db = getDb()
+    const printer = createProductBrochurePrinter(process.env)
+    const context = await loadProductBrochureTemplateContext(db, input.productId)
+    const rendered = await renderProductBrochureTemplate(
+      createDefaultProductBrochureTemplate(),
+      context,
+    )
+    const printed = await printer({ template: rendered, context })
     return {
-      base64: Buffer.from(result.pdfBytes).toString("base64"),
-      filename: result.filename,
-      sizeBytes: result.sizeBytes,
+      base64: Buffer.from(printed.body).toString("base64"),
+      filename: rendered.filename,
+      sizeBytes: printed.fileSize ?? printed.body.byteLength,
     }
   },
 })

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -25,6 +25,7 @@ import { createStorefrontVerificationHonoModule } from "@voyantjs/storefront-ver
 import { suppliersHonoModule } from "@voyantjs/suppliers"
 import { transactionsBookingExtension, transactionsHonoModule } from "@voyantjs/transactions"
 import { resolveNotificationProviders } from "../lib/notifications"
+import { createVideoUploadTicket } from "../lib/video-uploads"
 import authHandler, { hasAuthPermission, resolveAuthRequest } from "./auth/handler"
 import { createInvitationsRoutes } from "./invitations"
 import { getDbFromHyperdrive } from "./lib/db"
@@ -209,6 +210,22 @@ export const app = createApp<CloudflareBindings>({
         mimeType: file.type,
         size: file.size,
       })
+    })
+
+    // POST /v1/uploads/video — request a one-shot upload ticket for video
+    // bytes. The client uploads the video directly to `uploadUrl` (TUS
+    // protocol). See `src/lib/video-uploads.ts` to swap providers.
+    hono.post("/v1/uploads/video", async (c) => {
+      const body = await c.req.json<{
+        maxDurationSeconds: number
+        name?: string | null
+        requireSignedUrls?: boolean
+        allowedOrigins?: string[]
+        thumbnailTimestampPct?: number | null
+        meta?: Record<string, string>
+      }>()
+      const ticket = await createVideoUploadTicket(c.env as Record<string, unknown>, body)
+      return c.json(ticket)
     })
 
     // GET /v1/media/* — serve public media via the configured media storage provider.

--- a/templates/operator/src/lib/brochure-printer.ts
+++ b/templates/operator/src/lib/brochure-printer.ts
@@ -1,0 +1,31 @@
+import { brochureBodyToHtml, type ProductBrochurePrinter } from "@voyantjs/products/tasks"
+import { getVoyantCloudClient, type VoyantCloudEnv } from "@voyantjs/voyant-cloud"
+
+/**
+ * Default brochure printer for this template.
+ *
+ * Renders the product brochure HTML to PDF via Voyant Cloud's browser-rendering
+ * API. To switch providers, replace the body of this function — `@voyantjs/products/tasks`
+ * exports alternatives like `createCloudflareBrowserProductBrochurePrinter`
+ * (direct Cloudflare API) and `createBasicPdfProductBrochurePrinter` (pdf-lib).
+ */
+export function createProductBrochurePrinter(env: VoyantCloudEnv): ProductBrochurePrinter {
+  const client = getVoyantCloudClient(env)
+
+  return async ({ template, context }) => {
+    const body = await client.browser.pdf({
+      html: brochureBodyToHtml(template.body, template.bodyFormat, template.title),
+    })
+
+    return {
+      body,
+      mimeType: "application/pdf",
+      fileSize: body.byteLength,
+      metadata: {
+        renderer: "voyant-cloud-browser",
+        productId: context.product.id,
+        bodyFormat: template.bodyFormat,
+      },
+    }
+  }
+}

--- a/templates/operator/src/lib/video-uploads.ts
+++ b/templates/operator/src/lib/video-uploads.ts
@@ -1,0 +1,22 @@
+import {
+  type CreateVideoUploadInput,
+  getVoyantCloudClient,
+  type VideoUploadTicket,
+  type VoyantCloudEnv,
+} from "@voyantjs/voyant-cloud"
+
+/**
+ * Default video upload handler for this template.
+ *
+ * Returns a one-shot TUS upload ticket that the client uploads the video bytes
+ * to directly. To switch providers (e.g., upload through your own Cloudflare
+ * Stream account or any TUS-compatible host), replace the body of this function
+ * with one that constructs the equivalent ticket.
+ */
+export function createVideoUploadTicket(
+  env: VoyantCloudEnv,
+  input: CreateVideoUploadInput,
+): Promise<VideoUploadTicket> {
+  const client = getVoyantCloudClient(env)
+  return client.video.videos.createUpload(input)
+}

--- a/templates/operator/src/workflows.ts
+++ b/templates/operator/src/workflows.ts
@@ -4,10 +4,15 @@ import {
   deliverQueuedNotificationReminder,
   sendDueNotificationReminders,
 } from "@voyantjs/notifications/tasks"
-import { generateProductPdf } from "@voyantjs/products/tasks"
+import {
+  createDefaultProductBrochureTemplate,
+  loadProductBrochureTemplateContext,
+  renderProductBrochureTemplate,
+} from "@voyantjs/products/tasks"
 import { workflow } from "@voyantjs/workflows"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
+import { createProductBrochurePrinter } from "./lib/brochure-printer.js"
 import { getNotificationTaskRuntime } from "./lib/notifications.js"
 
 function getDb() {
@@ -18,11 +23,18 @@ workflow<{ productId: string }, { base64: string; filename: string; sizeBytes: n
   id: "products.generate-pdf",
   defaultRuntime: "node",
   async run(input) {
-    const result = await generateProductPdf(getDb(), input.productId)
+    const db = getDb()
+    const printer = createProductBrochurePrinter(process.env)
+    const context = await loadProductBrochureTemplateContext(db, input.productId)
+    const rendered = await renderProductBrochureTemplate(
+      createDefaultProductBrochureTemplate(),
+      context,
+    )
+    const printed = await printer({ template: rendered, context })
     return {
-      base64: Buffer.from(result.pdfBytes).toString("base64"),
-      filename: result.filename,
-      sizeBytes: result.sizeBytes,
+      base64: Buffer.from(printed.body).toString("base64"),
+      filename: rendered.filename,
+      sizeBytes: printed.fileSize ?? printed.body.byteLength,
     }
   },
 })


### PR DESCRIPTION
## Summary

Templates default to Voyant Cloud SDK for the two pieces it makes most sense to default-on:
- HTML→PDF rendering (Cloud Browser Rendering)
- Video uploads (Cloud Stream)

Both are configurable per-template by editing the helper file. Function names are intentionally generic — `createProductBrochurePrinter`, `createVideoUploadTicket` — so consumers swap the implementation by replacing the function body, not by switching to a different import path.

## Changes

**`@voyantjs/voyant-cloud`** (`packages/voyant-cloud`)
- Bumped `@voyantjs/cloud-sdk` from `^0.1.0` to `^0.4.0` to access browser/video APIs.
- Re-exports `BrowserPdfInput`, `BrowserPdfOptions`, `BrowserViewport`, `BrowserGoToOptions`, `BrowserScrapeInput`, `BrowserScreenshotInput`, `BrowserSnapshotResult`, `CreateVideoUploadInput`, `CreateVideoFromUrlInput`, `UpdateVideoInput`, `UploadVideoCaptionInput`, `VideoSummary`, `VideoUploadTicket`, etc. — templates need only one import.

**`@voyantjs/products`** (`packages/products`)
- Exposes `brochureBodyToHtml` from `./tasks` (was internal). Lets template-side printers render the same HTML the package's built-in printers do.
- The package itself is **not** Voyant-Cloud-aware. Existing `createCloudflareBrowserProductBrochurePrinter*` and `createBasicPdfProductBrochurePrinter` stay; no Cloud-SDK printer added inside the package.

**Templates** (`templates/dmc`, `templates/operator`)
- New `src/lib/brochure-printer.ts` — `createProductBrochurePrinter(env): ProductBrochurePrinter` calls `client.browser.pdf(...)` internally.
- New `src/lib/video-uploads.ts` — `createVideoUploadTicket(env, input): Promise<VideoUploadTicket>` calls `client.video.videos.createUpload(...)`.
- `workflows.ts` → `products.generate-pdf` workflow swaps from the basic pdf-lib path to the cloud printer pipeline (`loadProductBrochureTemplateContext` + `renderProductBrochureTemplate` + the new printer).
- `api/app.ts` adds `POST /v1/uploads/video` returning a TUS upload ticket. The existing `POST /v1/uploads` keeps handling images/documents through the configured media storage provider (R2 by default).

## How to swap providers

In a consumer's copy of the template:

```ts
// templates/<n>/src/lib/brochure-printer.ts — switch to direct Cloudflare API:
import { createCloudflareBrowserProductBrochurePrinterFromEnv } from "@voyantjs/products/tasks"
export const createProductBrochurePrinter = createCloudflareBrowserProductBrochurePrinterFromEnv
```

```ts
// templates/<n>/src/lib/video-uploads.ts — return a custom TUS ticket:
export async function createVideoUploadTicket(env, input) {
  // your provider here
  return { video: { ... }, uploadUrl, uploadExpiresAt: null }
}
```

## Test plan

- [ ] CI typecheck stays green (verified locally: 170/170)
- [ ] Trigger the `products.generate-pdf` workflow against a product, confirm the rendered PDF arrives via Cloud Browser Rendering
- [ ] `POST /v1/uploads/video` returns a TUS ticket; client-side TUS upload completes; video is queryable via `client.video.videos.get(id)`
- [ ] `POST /v1/uploads` still works for images/documents via R2

## Notes

- The PR depends on Voyant Cloud being configured (`VOYANT_CLOUD_API_KEY`). Templates already require it for notifications; brochure/video usage adds no new env vars.
- `pnpm-lock.yaml` updates because `@voyantjs/cloud-sdk` resolves to `0.4.0` instead of `0.1.0`.
