### PR TITLE
fix(workflows): de-flake parallel test by asserting on elapsed time, not completion order

### DIFF
--- a/packages/workflows/src/runtime/__tests__/parallel.test.ts
+++ b/packages/workflows/src/runtime/__tests__/parallel.test.ts
@@ -121,28 +121,34 @@ describe("ctx.parallel", () => {
   })
 
   it("defaults concurrency to total items (no artificial serialization)", async () => {
-    const order: number[] = []
+    // Each item sleeps SLEEP_MS. With no concurrency cap they all run together,
+    // so total elapsed should be ~SLEEP_MS, not 5×SLEEP_MS. Asserting on
+    // elapsed time is robust; asserting on completion order is not — CI
+    // runners' setTimeout resolution can collapse small sleep differences
+    // into the same tick.
+    const SLEEP_MS = 50
+    const ITEMS = [0, 1, 2, 3, 4]
 
     const wf = workflow<void, number[]>({
       id: "parallel.unbounded",
       async run(_, ctx) {
-        return ctx.parallel([0, 1, 2, 3, 4], async (n) => {
-          // Return in reverse-completion order: longer items finish first
-          // would imply real concurrency; with concurrency undefined we
-          // let them all run together.
-          await new Promise((r) => setTimeout(r, (5 - n) * 2))
-          order.push(n)
+        return ctx.parallel(ITEMS, async (n) => {
+          await new Promise((r) => setTimeout(r, SLEEP_MS))
           return n
         })
       },
     })
 
+    const start = Date.now()
     const result = await runWorkflowForTest(wf, undefined)
+    const elapsed = Date.now() - start
 
     expect(result.status).toBe("completed")
     // Results are in input order regardless of completion order.
-    expect(result.output).toEqual([0, 1, 2, 3, 4])
-    // Completion order is reverse because later items sleep less.
-    expect(order).toEqual([4, 3, 2, 1, 0])
+    expect(result.output).toEqual(ITEMS)
+    // Real concurrency: total time is closer to one sleep than to N sleeps.
+    // Generous bound to absorb CI scheduler jitter while still failing if
+    // the implementation accidentally serializes (which would be ~250ms+).
+    expect(elapsed).toBeLessThan(SLEEP_MS * ITEMS.length)
   })
 })


### PR DESCRIPTION
## Summary

The \`ctx.parallel > defaults concurrency to total items\` test failed on main's CI: expected completion order \`[4, 3, 2, 1, 0]\` but got \`[1, 0, 4, 3, 2]\`. Sleep durations were \`(5 - n) * 2\` ms = \`[10, 8, 6, 4, 2]\` — too close to CI runners' \`setTimeout\` resolution (~10-15ms when CPU-bound), so small differences collapse into the same tick and ordering becomes unpredictable.

## Fix

Replace the order assertion with the actual contract under test: with no concurrency cap, all items run together, so total elapsed time is ~one sleep, not N sleeps. Assert \`elapsed < SLEEP_MS * ITEMS.length\` — robust to scheduler jitter while still failing loudly if the implementation accidentally serializes (~250ms vs the 250ms bound).

Bumped sleep durations to 50ms each so the gap between concurrent (~50ms) and serialized (~250ms) is well above any plausible CI jitter.

## Verification

- \`pnpm vitest run src/runtime/__tests__/parallel.test.ts\` — 6/6 ✓ in 84ms
- Pre-commit \`turbo typecheck\` — 95/95 ✓

## Test plan

- [ ] CI passes
- [ ] Test stays green over multiple runs (no flake recurrence)