### PR TITLE
fix(bookings-react): derive CreateBookingItemInput from server schema

### DIFF
--- a/packages/bookings-react/src/hooks/use-booking-item-mutation.ts
+++ b/packages/bookings-react/src/hooks/use-booking-item-mutation.ts
@@ -1,31 +1,23 @@
 "use client"
 
 import { useMutation, useQueryClient } from "@tanstack/react-query"
+import type {
+  insertBookingItemSchema,
+  updateBookingItemSchema,
+} from "@voyantjs/bookings/validation"
+import type { z } from "zod"
 
 import { fetchWithValidation } from "../client.js"
 import { useVoyantBookingsContext } from "../provider.js"
 import { bookingsQueryKeys } from "../query-keys.js"
 import { bookingItemsResponse, bookingSingleResponse, successEnvelope } from "../schemas.js"
 
-export interface CreateBookingItemInput {
-  title: string
-  itemType?: string
-  status?: string
-  quantity?: number
-  sellCurrency: string
-  unitSellAmountCents?: number | null
-  totalSellAmountCents?: number | null
-  costCurrency?: string | null
-  unitCostAmountCents?: number | null
-  totalCostAmountCents?: number | null
-  serviceDate?: string | null
-  startsAt?: string | null
-  endsAt?: string | null
-  description?: string | null
-  notes?: string | null
-}
-
-export type UpdateBookingItemInput = Partial<CreateBookingItemInput>
+// Derived from the server schema so this can't drift out of sync. `z.input`
+// (not `z.infer`/`z.output`) gives the pre-parse type, where fields with
+// `.default(...)` are optional — the right shape for a client-side create
+// payload.
+export type CreateBookingItemInput = z.input<typeof insertBookingItemSchema>
+export type UpdateBookingItemInput = z.input<typeof updateBookingItemSchema>
 
 export function useBookingItemMutation(bookingId: string) {
   const { baseUrl, fetcher } = useVoyantBookingsContext()


### PR DESCRIPTION
## Summary

Closes #356. The hand-rolled \`CreateBookingItemInput\` in \`use-booking-item-mutation.ts\` had drifted from the server's \`bookingItemCoreSchema\`, missing **7 fields**: \`productId\`, \`optionId\`, \`optionUnitId\`, \`pricingCategoryId\` (the four mentioned in the issue), plus \`sourceSnapshotId\`, \`sourceOfferId\`, \`metadata\` (also missing).

## Fix

Replaced the hand-rolled interface with the issue's preferred fix #1 — derive from the schema:

\`\`\`ts
export type CreateBookingItemInput = z.input<typeof insertBookingItemSchema>
export type UpdateBookingItemInput = z.input<typeof updateBookingItemSchema>
\`\`\`

Notes:
- Single source of truth — won't drift again.
- Uses \`z.input\` (not \`z.infer\`/\`z.output\`) so fields with \`.default(...)\` stay optional, which is the right shape for a client-side create payload.
- \`@voyantjs/bookings/validation\` was already imported elsewhere in bookings-react, and \`@voyantjs/bookings\` is already a peer + dev dep — no package.json changes needed.

## Verification

- \`pnpm typecheck\` — 95/95 ✓
- No tests for this hook today; no external consumers reference \`CreateBookingItemInput\` / \`UpdateBookingItemInput\` (only the hook file itself and its barrel re-export).

## Test plan

- [ ] CI passes
- [ ] Manual smoke: \`useBookingItemMutation().create.mutateAsync({ productId: \"...\" })\` typechecks without a cast in a consumer project