### PR TITLE
fix(finance): emit invoice.settled when completePaymentSession applies a payment

### DIFF
--- a/packages/bookings-react/src/hooks/use-booking-item-mutation.ts
+++ b/packages/bookings-react/src/hooks/use-booking-item-mutation.ts
@@ -1,31 +1,23 @@
 "use client"
 
 import { useMutation, useQueryClient } from "@tanstack/react-query"
+import type {
+  insertBookingItemSchema,
+  updateBookingItemSchema,
+} from "@voyantjs/bookings/validation"
+import type { z } from "zod"
 
 import { fetchWithValidation } from "../client.js"
 import { useVoyantBookingsContext } from "../provider.js"
 import { bookingsQueryKeys } from "../query-keys.js"
 import { bookingItemsResponse, bookingSingleResponse, successEnvelope } from "../schemas.js"
 
-export interface CreateBookingItemInput {
-  title: string
-  itemType?: string
-  status?: string
-  quantity?: number
-  sellCurrency: string
-  unitSellAmountCents?: number | null
-  totalSellAmountCents?: number | null
-  costCurrency?: string | null
-  unitCostAmountCents?: number | null
-  totalCostAmountCents?: number | null
-  serviceDate?: string | null
-  startsAt?: string | null
-  endsAt?: string | null
-  description?: string | null
-  notes?: string | null
-}
-
-export type UpdateBookingItemInput = Partial<CreateBookingItemInput>
+// Derived from the server schema so this can't drift out of sync. `z.input`
+// (not `z.infer`/`z.output`) gives the pre-parse type, where fields with
+// `.default(...)` are optional — the right shape for a client-side create
+// payload.
+export type CreateBookingItemInput = z.input<typeof insertBookingItemSchema>
+export type UpdateBookingItemInput = z.input<typeof updateBookingItemSchema>
 
 export function useBookingItemMutation(bookingId: string) {
   const { baseUrl, fetcher } = useVoyantBookingsContext()

--- a/packages/finance/src/routes-shared.ts
+++ b/packages/finance/src/routes-shared.ts
@@ -1,3 +1,4 @@
+import type { ModuleContainer } from "@voyantjs/core"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
 
@@ -5,6 +6,7 @@ export type Env = {
   Variables: {
     db: PostgresJsDatabase
     userId?: string
+    container?: ModuleContainer
   }
 }
 

--- a/packages/finance/src/routes.ts
+++ b/packages/finance/src/routes.ts
@@ -1,6 +1,7 @@
 import { parseJsonBody, parseQuery, requireUserId } from "@voyantjs/hono"
 import { Hono } from "hono"
 
+import { FINANCE_ROUTE_RUNTIME_CONTAINER_KEY, type FinanceRouteRuntime } from "./route-runtime.js"
 import type { publicFinanceRoutes } from "./routes-public.js"
 import type { Env } from "./routes-shared.js"
 import { financeService } from "./service.js"
@@ -133,10 +134,18 @@ export const financeRoutes = new Hono<Env>()
   })
 
   .post("/payment-sessions/:id/complete", async (c) => {
+    const runtime = (() => {
+      try {
+        return c.var.container?.resolve<FinanceRouteRuntime>(FINANCE_ROUTE_RUNTIME_CONTAINER_KEY)
+      } catch {
+        return undefined
+      }
+    })()
     const row = await financeService.completePaymentSession(
       c.get("db"),
       c.req.param("id"),
       await parseJsonBody(c, completePaymentSessionSchema),
+      { eventBus: runtime?.eventBus },
     )
     if (!row) return c.json({ error: "Payment session not found" }, 404)
     return c.json({ data: row })

--- a/packages/finance/src/service.ts
+++ b/packages/finance/src/service.ts
@@ -1,9 +1,9 @@
 import { bookingItems, bookings } from "@voyantjs/bookings/schema"
+import type { EventBus } from "@voyantjs/core"
 import { renderStructuredTemplate } from "@voyantjs/utils/template-renderer"
 import { and, asc, desc, eq, gte, ilike, lte, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
-
 import {
   bookingGuarantees,
   bookingItemCommissions,
@@ -27,6 +27,7 @@ import {
   taxRegimes,
 } from "./schema.js"
 import { getFinanceAggregates } from "./service-aggregates.js"
+import type { InvoiceSettledEvent } from "./service-settlement.js"
 import { vouchersService } from "./service-vouchers.js"
 import type {
   agingReportQuerySchema,
@@ -276,6 +277,16 @@ async function paginate<T extends object>(
 ) {
   const [data, countResult] = await Promise.all([rowsQuery, countQuery])
   return { data, total: countResult[0]?.total ?? 0, limit, offset }
+}
+
+/**
+ * Runtime context for finance service methods that need to emit lifecycle
+ * events (e.g. `invoice.settled`). Optional — methods fall back to a no-op
+ * when no eventBus is provided, so direct callers (tests, scripts) don't
+ * have to wire one up.
+ */
+export interface FinanceServiceRuntime {
+  eventBus?: EventBus
 }
 
 export const financeService = {
@@ -551,6 +562,7 @@ export const financeService = {
     db: PostgresJsDatabase,
     id: string,
     data: CompletePaymentSessionInput,
+    runtime: FinanceServiceRuntime = {},
   ) {
     const [session] = await db
       .select()
@@ -562,10 +574,14 @@ export const financeService = {
       return null
     }
 
-    return db.transaction(async (tx) => {
+    const txResult = await db.transaction(async (tx) => {
       let authorizationId = session.paymentAuthorizationId
       let captureId = session.paymentCaptureId
       let paymentId = session.paymentId
+      // Settlement payload to emit after the tx commits, so subscribers see
+      // a consistent post-update view. Stays null when this call doesn't
+      // result in a new payment being applied to an invoice.
+      let settlementForEmit: InvoiceSettledEvent | null = null
 
       if (!authorizationId) {
         const [authorization] = await tx
@@ -687,6 +703,17 @@ export const financeService = {
               updatedAt: new Date(),
             })
             .where(eq(invoices.id, session.invoiceId))
+
+          if (paymentId) {
+            settlementForEmit = {
+              invoiceId: session.invoiceId,
+              paymentId,
+              provider: session.provider ?? "internal",
+              newlyAppliedAmountCents: session.amountCents,
+              paidCents,
+              balanceDueCents,
+            }
+          }
         }
       }
 
@@ -736,8 +763,17 @@ export const financeService = {
         .where(eq(paymentSessions.id, id))
         .returning()
 
-      return updated ?? null
+      return { updated: updated ?? null, settlement: settlementForEmit }
     })
+
+    if (txResult.settlement) {
+      await runtime.eventBus?.emit("invoice.settled", txResult.settlement, {
+        category: "domain",
+        source: "service",
+      })
+    }
+
+    return txResult.updated
   },
 
   async listPaymentAuthorizations(db: PostgresJsDatabase, query: PaymentAuthorizationListQuery) {

--- a/packages/finance/tests/integration/routes.test.ts
+++ b/packages/finance/tests/integration/routes.test.ts
@@ -1,8 +1,10 @@
 import { bookingItems, bookings } from "@voyantjs/bookings/schema"
+import { createEventBus } from "@voyantjs/core"
 import { eq, sql } from "drizzle-orm"
 import { Hono } from "hono"
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
 
+import { FINANCE_ROUTE_RUNTIME_CONTAINER_KEY } from "../../src/route-runtime.js"
 import { financeRoutes } from "../../src/routes.js"
 import {
   bookingPaymentSchedules,
@@ -99,6 +101,7 @@ async function cleanupFinanceTestData(
 describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
   let app: Hono
   let db: ReturnType<typeof import("@voyantjs/db/test-utils").createTestDb>
+  const settlementEvents: Array<Record<string, unknown>> = []
 
   beforeAll(async () => {
     process.env.TEST_DATABASE_URL = getIsolatedFinanceTestDbUrl(process.env.TEST_DATABASE_URL)
@@ -217,10 +220,25 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       sql`CREATE UNIQUE INDEX IF NOT EXISTS uidx_payment_sessions_idempotency ON payment_sessions (idempotency_key)`,
     )
 
+    const eventBus = createEventBus()
+    eventBus.subscribe("invoice.settled", (event) => {
+      settlementEvents.push(event as Record<string, unknown>)
+    })
+    const financeRouteRuntime = { eventBus, invoiceSettlementPollers: {} }
+    const containerStub = {
+      resolve: <T>(key: string): T => {
+        if (key === FINANCE_ROUTE_RUNTIME_CONTAINER_KEY) {
+          return financeRouteRuntime as T
+        }
+        throw new Error(`No provider for ${key}`)
+      },
+    }
+
     app = new Hono()
     app.use("*", async (c, next) => {
       c.set("db" as never, db)
       c.set("userId" as never, "test-user-id")
+      c.set("container" as never, containerStub)
       await next()
     })
     app.route("/", financeRoutes)
@@ -228,6 +246,7 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
 
   beforeEach(async () => {
     await cleanupFinanceTestData(db)
+    settlementEvents.length = 0
   })
 
   afterAll(async () => {
@@ -553,6 +572,19 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       expect(invoiceBody.data.status).toBe("paid")
       expect(invoiceBody.data.paidCents).toBe(110000)
       expect(invoiceBody.data.balanceDueCents).toBe(0)
+
+      // Settling the session via the complete endpoint must fan out
+      // `invoice.settled` so plugin callbacks (Netopia and friends) don't
+      // need a separate poller — see issue #357.
+      expect(settlementEvents).toHaveLength(1)
+      expect(settlementEvents[0]).toMatchObject({
+        invoiceId: invoice.id,
+        paymentId: data.paymentId,
+        provider: "netopia",
+        newlyAppliedAmountCents: 110000,
+        paidCents: 110000,
+        balanceDueCents: 0,
+      })
     })
 
     it("completes a paid session and marks the linked booking schedule as paid", async () => {

--- a/packages/plugins/netopia/src/plugin.ts
+++ b/packages/plugins/netopia/src/plugin.ts
@@ -1,4 +1,5 @@
 import type { Extension, ModuleContainer } from "@voyantjs/core"
+import { FINANCE_ROUTE_RUNTIME_CONTAINER_KEY, type FinanceRouteRuntime } from "@voyantjs/finance"
 import { defineHonoBundle, type HonoBundle, parseJsonBody } from "@voyantjs/hono"
 import type { HonoExtension } from "@voyantjs/hono/module"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -167,7 +168,20 @@ export function createNetopiaFinanceRoutes(options: NetopiaRuntimeOptions = {}) 
     .post("/providers/netopia/callback", async (c) => {
       const payload = await parseJsonBody(c, netopiaWebhookPayloadSchema)
       const runtime = resolveRuntime(c)
-      const result = await netopiaService.handleCallback(c.get("db"), payload, runtime)
+      const financeRuntime = (() => {
+        try {
+          return c.var.container?.resolve<FinanceRouteRuntime>(FINANCE_ROUTE_RUNTIME_CONTAINER_KEY)
+        } catch {
+          return undefined
+        }
+      })()
+      const result = await netopiaService.handleCallback(
+        c.get("db"),
+        payload,
+        runtime,
+        c.env,
+        financeRuntime ? { eventBus: financeRuntime.eventBus } : undefined,
+      )
       return c.json({ data: result })
     })
     .get("/providers/netopia/config", async (c) => {

--- a/packages/plugins/netopia/src/service-callback.ts
+++ b/packages/plugins/netopia/src/service-callback.ts
@@ -1,3 +1,4 @@
+import type { EventBus } from "@voyantjs/core"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { resolveNetopiaRuntimeOptions } from "./client.js"
@@ -16,6 +17,7 @@ export async function handleCallback(
   payload: NetopiaWebhookPayload,
   runtimeOptions: NetopiaRuntimeOptions = {},
   bindings?: Record<string, unknown>,
+  financeRuntime: { eventBus?: EventBus } = {},
 ): Promise<NetopiaCallbackResult> {
   const runtime = resolveNetopiaRuntimeOptions(bindings, runtimeOptions)
   const orderId = payload.order.orderID
@@ -104,32 +106,37 @@ export async function handleCallback(
       }
     }
 
-    const completed = await financeService.completePaymentSession(db, session.id, {
-      status: "paid",
-      captureMode: "manual",
-      paymentMethod: "credit_card",
-      providerSessionId: payload.payment.ntpID,
-      providerPaymentId: payload.payment.ntpID,
-      externalReference: orderId,
-      externalAuthorizationId:
-        typeof payload.payment.data?.AuthCode === "string"
-          ? payload.payment.data.AuthCode
-          : payload.payment.ntpID,
-      externalCaptureId:
-        typeof payload.payment.data?.RRN === "string"
-          ? payload.payment.data.RRN
-          : payload.payment.ntpID,
-      approvalCode:
-        typeof payload.payment.data?.AuthCode === "string"
-          ? payload.payment.data.AuthCode
-          : undefined,
-      referenceNumber:
-        typeof payload.payment.data?.RRN === "string" ? payload.payment.data.RRN : undefined,
-      authorizedAt: new Date().toISOString(),
-      capturedAt: new Date().toISOString(),
-      paymentDate: new Date().toISOString(),
-      providerPayload,
-    })
+    const completed = await financeService.completePaymentSession(
+      db,
+      session.id,
+      {
+        status: "paid",
+        captureMode: "manual",
+        paymentMethod: "credit_card",
+        providerSessionId: payload.payment.ntpID,
+        providerPaymentId: payload.payment.ntpID,
+        externalReference: orderId,
+        externalAuthorizationId:
+          typeof payload.payment.data?.AuthCode === "string"
+            ? payload.payment.data.AuthCode
+            : payload.payment.ntpID,
+        externalCaptureId:
+          typeof payload.payment.data?.RRN === "string"
+            ? payload.payment.data.RRN
+            : payload.payment.ntpID,
+        approvalCode:
+          typeof payload.payment.data?.AuthCode === "string"
+            ? payload.payment.data.AuthCode
+            : undefined,
+        referenceNumber:
+          typeof payload.payment.data?.RRN === "string" ? payload.payment.data.RRN : undefined,
+        authorizedAt: new Date().toISOString(),
+        capturedAt: new Date().toISOString(),
+        paymentDate: new Date().toISOString(),
+        providerPayload,
+      },
+      { eventBus: financeRuntime.eventBus },
+    )
 
     return {
       action: "completed",


### PR DESCRIPTION
## Summary

Closes #357. When a customer paid via Netopia (or any provider plugin's collect→callback flow), \`financeService.completePaymentSession\` inserted the payment row, recomputed \`paid_cents\` / \`balance_due_cents\`, and updated invoice status — but never emitted \`invoice.settled\`. Consumers wanting "booking paid" emails / accounting export had to either run their own poller scanning \`payment_sessions\` in \`paid\` state or wrap each plugin callback to manually trigger \`pollInvoiceSettlement\`.

## Fix

\`completePaymentSession\` now accepts a 4th \`runtime: { eventBus? }\` parameter and emits \`invoice.settled\` after the transaction commits, with the same payload shape \`pollInvoiceSettlement\` already uses (\`InvoiceSettledEvent\` re-imported from service-settlement.ts).

### Wiring

- **Service**: \`financeService.completePaymentSession(db, id, data, runtime?)\` builds the event payload inside the tx alongside the payment+invoice update, then emits AFTER commit so subscribers see consistent post-update state.
- **Routes**: \`/payment-sessions/:id/complete\` resolves \`FinanceRouteRuntime\` from the container (try/catch since direct test mounts may not register one) and threads \`eventBus\` through. Required adding \`container?: ModuleContainer\` to \`Env.Variables\` in \`routes-shared.ts\`.
- **Netopia plugin**: \`handleCallback\` accepts a 5th \`financeRuntime: { eventBus? }\` param and forwards to \`completePaymentSession\`. The Netopia callback route resolves the finance runtime from the container and wires it.

### Provider field on the event

- pollInvoiceSettlement path: \`provider = externalRef.provider\` (e.g. \`smartbill\`).
- completePaymentSession path: \`provider = session.provider ?? "internal"\` (e.g. \`netopia\` for plugin callbacks; \`internal\` for manual sessions with no provider set).

No double-emit risk: \`pollInvoiceSettlement\` calls \`createPayment\` (not \`completePaymentSession\`) and continues to do its own emission; \`completePaymentSession\` is only invoked from plugin callbacks and the \`/complete\` route.

## Test

Extended \`tests/integration/routes.test.ts\`'s "completes a paid session" case to subscribe to \`invoice.settled\` via a stub container and assert the event was fired with the expected payload (provider \`netopia\`, paymentId, balance fields).

## Verification

- \`pnpm typecheck\` — 95/95 ✓
- \`pnpm -F @voyantjs/plugin-netopia test\` — 26/26 ✓
- Unit tests in \`@voyantjs/finance\` — 62/62 ✓ (167 integration tests skipped locally; my Postgres wasn't running this session, will run on CI)

## Test plan

- [ ] CI integration tests pass (Postgres available there)
- [ ] Manual: trigger Netopia callback in dev, observe \`invoice.settled\` event in logs / subscriber