### PR TITLE
chore(products): export destinations / productDestinations / destinationTranslations from barrel

### DIFF
--- a/packages/products/src/index.ts
+++ b/packages/products/src/index.ts
@@ -94,6 +94,8 @@ export type {
   ProductVisibilitySetting,
 } from "./schema.js"
 export {
+  destinations,
+  destinationTranslations,
   optionUnits,
   optionUnitTranslations,
   productActivationSettings,
@@ -103,6 +105,7 @@ export {
   productDayServices,
   productDays,
   productDeliveryFormats,
+  productDestinations,
   productFaqs,
   productFeatures,
   productItineraries,


### PR DESCRIPTION
## Summary

Closes #351. The taxonomy tables (\`destinations\`, \`destinationTranslations\`, \`productDestinations\`) live in \`packages/products/src/schema-taxonomy.ts\` and are re-exported from \`schema.ts\` via \`export * from \"./schema-taxonomy\"\`, but the package's public \`index.ts\` barrel forgot them.

\`productCategories\`/\`productCategoryProducts\` were already exported; the destination trio just needs to ride along.

## Fix

One-line addition to the existing export block in \`packages/products/src/index.ts\`. No schema changes, no migration.

## Verification

- \`pnpm typecheck\` — 95/95 ✓
- \`import { destinations, productDestinations } from \"@voyantjs/products\"\` now resolves at the public surface, matching the pattern of \`productCategories\`/\`productCategoryProducts\`.

## Test plan

- [ ] CI passes
- [ ] Consumers building country-tag derivation / destination-walk queries can import from the package root without deep paths or raw SQL