### PR TITLE
feat(bookings): allow injected resolveKmsProvider for Vault-backed key material

### DIFF
--- a/packages/bookings/src/index.ts
+++ b/packages/bookings/src/index.ts
@@ -1,7 +1,11 @@
 import type { LinkableDefinition, Module } from "@voyantjs/core"
 import type { HonoModule } from "@voyantjs/hono/module"
 
-import { BOOKING_ROUTE_RUNTIME_CONTAINER_KEY, buildBookingRouteRuntime } from "./route-runtime.js"
+import {
+  BOOKING_ROUTE_RUNTIME_CONTAINER_KEY,
+  type BookingRouteRuntimeOptions,
+  buildBookingRouteRuntime,
+} from "./route-runtime.js"
 import { bookingRoutes } from "./routes.js"
 import { publicBookingRoutes } from "./routes-public.js"
 
@@ -64,13 +68,15 @@ export const bookingsModule: Module = {
   linkable: bookingsLinkable,
 }
 
-export function createBookingsHonoModule(): HonoModule {
+export interface BookingsHonoModuleOptions extends BookingRouteRuntimeOptions {}
+
+export function createBookingsHonoModule(options: BookingsHonoModuleOptions = {}): HonoModule {
   const module: Module = {
     ...bookingsModule,
     bootstrap: ({ bindings, container }) => {
       container.register(
         BOOKING_ROUTE_RUNTIME_CONTAINER_KEY,
-        buildBookingRouteRuntime(bindings as Record<string, unknown>),
+        buildBookingRouteRuntime(bindings as Record<string, unknown>, options),
       )
     },
   }
@@ -85,7 +91,11 @@ export function createBookingsHonoModule(): HonoModule {
 
 export const bookingsHonoModule: HonoModule = createBookingsHonoModule()
 
-export type { BookingRouteRuntime } from "./route-runtime.js"
+export type {
+  BookingRouteRuntime,
+  BookingRouteRuntimeOptions,
+  ResolveBookingKmsProvider,
+} from "./route-runtime.js"
 export {
   BOOKING_ROUTE_RUNTIME_CONTAINER_KEY,
   buildBookingRouteRuntime,

--- a/packages/bookings/src/route-runtime.ts
+++ b/packages/bookings/src/route-runtime.ts
@@ -5,7 +5,22 @@ import type { KmsBindings } from "./routes-shared.js"
 export const BOOKING_ROUTE_RUNTIME_CONTAINER_KEY = "runtime.bookings.routes"
 
 export interface BookingRouteRuntime {
-  getKmsProvider(): KmsProvider
+  getKmsProvider(): Promise<KmsProvider>
+}
+
+/**
+ * Hook for apps that source their KMS key material from somewhere other than
+ * env vars / wrangler secrets — e.g. Voyant Cloud Vault. Receives the same
+ * resolved bindings the default env-driven provider would, returns the
+ * provider (sync or async). When omitted, falls back to
+ * `createKmsProviderFromEnv` so existing template wiring keeps working.
+ */
+export type ResolveBookingKmsProvider = (
+  env: Record<string, string | undefined>,
+) => KmsProvider | Promise<KmsProvider>
+
+export interface BookingRouteRuntimeOptions {
+  resolveKmsProvider?: ResolveBookingKmsProvider
 }
 
 function buildRuntimeEnv(bindings: KmsBindings): Record<string, string | undefined> {
@@ -22,11 +37,17 @@ function buildRuntimeEnv(bindings: KmsBindings): Record<string, string | undefin
   }
 }
 
-export function buildBookingRouteRuntime(bindings: KmsBindings): BookingRouteRuntime {
+export function buildBookingRouteRuntime(
+  bindings: KmsBindings,
+  options: BookingRouteRuntimeOptions = {},
+): BookingRouteRuntime {
   const runtimeEnv = buildRuntimeEnv(bindings)
 
   return {
-    getKmsProvider() {
+    async getKmsProvider() {
+      if (options.resolveKmsProvider) {
+        return options.resolveKmsProvider(runtimeEnv)
+      }
       return createKmsProviderFromEnv(runtimeEnv)
     },
   }

--- a/packages/bookings/src/routes.ts
+++ b/packages/bookings/src/routes.ts
@@ -197,11 +197,12 @@ function getRouteRuntime(c: Context<Env>): BookingRouteRuntime {
   }
 }
 
-function createAuditedBookingPiiService(c: Context<Env>, bookingId: string) {
+async function createAuditedBookingPiiService(c: Context<Env>, bookingId: string) {
   const runtime = getRouteRuntime(c)
+  const kms = await runtime.getKmsProvider()
 
   return createBookingPiiService({
-    kms: runtime.getKmsProvider(),
+    kms,
     onAudit: async (event) => {
       await logBookingPiiAccess(c, {
         bookingId,
@@ -749,7 +750,7 @@ export const bookingRoutes = new Hono<Env>()
     }
 
     try {
-      const pii = createAuditedBookingPiiService(c, traveler.bookingId)
+      const pii = await createAuditedBookingPiiService(c, traveler.bookingId)
       const details = await pii.getTravelerTravelDetails(c.get("db"), traveler.id, c.get("userId"))
 
       if (!details) {
@@ -812,7 +813,7 @@ export const bookingRoutes = new Hono<Env>()
     }
 
     try {
-      const pii = createAuditedBookingPiiService(c, traveler.bookingId)
+      const pii = await createAuditedBookingPiiService(c, traveler.bookingId)
       const row = await pii.upsertTravelerTravelDetails(
         c.get("db"),
         traveler.id,
@@ -872,7 +873,7 @@ export const bookingRoutes = new Hono<Env>()
     }
 
     try {
-      const pii = createAuditedBookingPiiService(c, traveler.bookingId)
+      const pii = await createAuditedBookingPiiService(c, traveler.bookingId)
       const row = await pii.deleteTravelerTravelDetails(c.get("db"), traveler.id, c.get("userId"))
 
       if (!row) {

--- a/packages/bookings/tests/unit/module.test.ts
+++ b/packages/bookings/tests/unit/module.test.ts
@@ -1,7 +1,12 @@
 import { createContainer, createEventBus } from "@voyantjs/core"
-import { describe, expect, it } from "vitest"
+import type { KmsProvider } from "@voyantjs/utils"
+import { describe, expect, it, vi } from "vitest"
 
-import { BOOKING_ROUTE_RUNTIME_CONTAINER_KEY, createBookingsHonoModule } from "../../src/index.js"
+import {
+  BOOKING_ROUTE_RUNTIME_CONTAINER_KEY,
+  type BookingRouteRuntime,
+  createBookingsHonoModule,
+} from "../../src/index.js"
 
 describe("createBookingsHonoModule.bootstrap", () => {
   it("registers the shared bookings route runtime once", async () => {
@@ -22,5 +27,32 @@ describe("createBookingsHonoModule.bootstrap", () => {
     }>(BOOKING_ROUTE_RUNTIME_CONTAINER_KEY)
 
     expect(runtime.getKmsProvider).toBeTypeOf("function")
+  })
+
+  it("uses an injected resolveKmsProvider instead of reading env", async () => {
+    const fakeKms: KmsProvider = {
+      // biome-ignore lint/suspicious/noExplicitAny: minimal stub for the test
+      encrypt: vi.fn() as any,
+      // biome-ignore lint/suspicious/noExplicitAny: minimal stub for the test
+      decrypt: vi.fn() as any,
+    }
+    const resolveKmsProvider = vi.fn(async () => fakeKms)
+
+    const module = createBookingsHonoModule({ resolveKmsProvider })
+    const container = createContainer()
+
+    await module.module.bootstrap?.({
+      // Deliberately empty: the resolver must be used in place of any
+      // env-based default.
+      bindings: {},
+      container,
+      eventBus: createEventBus(),
+    })
+
+    const runtime = container.resolve<BookingRouteRuntime>(BOOKING_ROUTE_RUNTIME_CONTAINER_KEY)
+    const resolved = await runtime.getKmsProvider()
+
+    expect(resolveKmsProvider).toHaveBeenCalledTimes(1)
+    expect(resolved).toBe(fakeKms)
   })
 })


### PR DESCRIPTION
## Summary

Closes #342. \`bookingsHonoModule\`'s PII service was hard-wired to \`createKmsProviderFromEnv(c.env)\`, forcing apps to keep \`KMS_*\` env vars populated even when the canonical home for the key is Voyant Cloud Vault (rotation without redeploy, central audit). When env-key and Vault-key drifted, encrypted rows written by one path became unreadable from the other.

## Fix

\`createBookingsHonoModule(options?)\` now accepts an optional \`resolveKmsProvider\` factory:

\`\`\`ts
bookingsHonoModule({
  resolveKmsProvider: async (env) => {
    const cloud = getVoyantCloudClient(env)
    const secret = await cloud.vault.getSecret("booking-pii", "kms-key")
    return new EnvKmsProvider({ key: secret.value })
  },
})
\`\`\`

Default behavior unchanged: callers who don't pass options still get \`createKmsProviderFromEnv\`-driven keys.

## Wiring

- \`route-runtime.ts\` — adds \`BookingRouteRuntimeOptions { resolveKmsProvider? }\` and \`ResolveBookingKmsProvider\` type. \`getKmsProvider()\` now returns \`Promise<KmsProvider>\` (always async) and prefers the injected resolver over \`createKmsProviderFromEnv\`.
- \`index.ts\` — \`createBookingsHonoModule(options?: BookingsHonoModuleOptions)\` threads options into \`buildBookingRouteRuntime\`. \`BookingsHonoModuleOptions\` extends \`BookingRouteRuntimeOptions\` for forward extensibility.
- \`routes.ts\` — \`createAuditedBookingPiiService\` becomes async; the three call sites in PII routes (lines 753, 816, 876) await it.
- \`tests/unit/module.test.ts\` — added test verifying an injected \`resolveKmsProvider\` is used in place of any env-based default.

## Verification

- \`pnpm typecheck\` — 95/95 ✓
- \`pnpm -F @voyantjs/bookings test\` — 214/214 unit tests pass

## Follow-up (not in this PR)

\`@voyantjs/transactions\` has the same shape (\`route-runtime.ts\` with sync \`getKmsProvider\`) and would benefit from the same change. Out of scope here — would warrant a separate issue/PR.

## Test plan

- [ ] CI passes
- [ ] Manual: apps wiring \`resolveKmsProvider\` to \`cloud.vault.getSecret(...)\` can rotate booking-PII keys in Vault without redeploying templates