### PR TITLE
feat(modules): widen resolveDb to AnyDrizzleDb + normalize bindings typing

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,10 +1,23 @@
 import { neon } from "@neondatabase/serverless"
+import type { NeonHttpDatabase } from "drizzle-orm/neon-http"
 import { drizzle as drizzleNeon } from "drizzle-orm/neon-http"
 import { withReplicas } from "drizzle-orm/pg-core"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { drizzle as drizzlePostgres } from "drizzle-orm/postgres-js"
 import postgres from "postgres"
 
 export type DbAdapter = "edge" | "node"
+
+/**
+ * Union of the two drizzle driver flavors `createDbClient` can return —
+ * `PostgresJsDatabase` (node adapter) and `NeonHttpDatabase` (edge adapter).
+ * Use this as the parameter type for `resolveDb`-style callbacks in module
+ * factories so consumers don't need `as unknown as PostgresJsDatabase` casts
+ * when wiring a Cloudflare Worker / Hyperdrive client into a module.
+ */
+export type AnyDrizzleDb<TSchema extends Record<string, unknown> = Record<string, never>> =
+  | PostgresJsDatabase<TSchema>
+  | NeonHttpDatabase<TSchema>
 
 export function createDbClient<TSchema extends Record<string, unknown> = Record<string, never>>(
   connectionString: string,

--- a/packages/legal/src/contracts/routes.ts
+++ b/packages/legal/src/contracts/routes.ts
@@ -43,13 +43,15 @@ export type ContractDocumentGenerator = Parameters<
 
 export interface ContractsRouteOptions {
   documentGenerator?: ContractDocumentGenerator
-  resolveDocumentGenerator?: (bindings: unknown) => ContractDocumentGenerator | undefined
+  resolveDocumentGenerator?: (
+    bindings: Record<string, unknown>,
+  ) => ContractDocumentGenerator | undefined
   resolveDocumentDownloadUrl?: (
-    bindings: unknown,
+    bindings: Record<string, unknown>,
     storageKey: string,
   ) => Promise<string | null> | string | null
   eventBus?: EventBus
-  resolveEventBus?: (bindings: unknown) => EventBus | undefined
+  resolveEventBus?: (bindings: Record<string, unknown>) => EventBus | undefined
 }
 
 function getRuntime(

--- a/packages/legal/src/index.ts
+++ b/packages/legal/src/index.ts
@@ -1,4 +1,5 @@
 import type { Module } from "@voyantjs/core"
+import type { AnyDrizzleDb } from "@voyantjs/db"
 import type { HonoModule } from "@voyantjs/hono/module"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
@@ -33,9 +34,12 @@ export interface CreateLegalHonoModuleOptions extends ContractsRouteOptions {
   /**
    * Required when `autoGenerateContractOnConfirmed.enabled` is true. The
    * `booking.confirmed` subscriber fires outside request scope, so it
-   * needs its own db handle from runtime bindings.
+   * needs its own db handle from runtime bindings. Returns `AnyDrizzleDb`
+   * (the `PostgresJsDatabase | NeonHttpDatabase` union from
+   * `@voyantjs/db`) so consumers don't need to cast through `unknown` when
+   * wiring a Hyperdrive/Neon client.
    */
-  resolveDb?: (bindings: Record<string, unknown>) => PostgresJsDatabase
+  resolveDb?: (bindings: Record<string, unknown>) => AnyDrizzleDb
   /**
    * Opt-in auto-generate on `booking.confirmed`. When enabled + a
    * `templateSlug` is supplied + a `documentGenerator` is resolvable, every
@@ -89,7 +93,10 @@ export function createLegalHonoModule(options: CreateLegalHonoModuleOptions = {}
             data: { bookingId: string; bookingNumber: string; actorId: string | null }
           }) => {
             try {
-              const db = resolveDb(bindings as Record<string, unknown>)
+              // The resolver may return either drizzle flavor; the queries
+              // autoGenerateContractForBooking runs are compatible with both
+              // at runtime, so we narrow at this internal boundary.
+              const db = resolveDb(bindings as Record<string, unknown>) as PostgresJsDatabase
               const result = await autoGenerateContractForBooking(db, event.data, auto, {
                 generator,
                 eventBus,

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -1,4 +1,5 @@
 import type { Module } from "@voyantjs/core"
+import type { AnyDrizzleDb } from "@voyantjs/db"
 import type { HonoModule } from "@voyantjs/hono/module"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
@@ -151,9 +152,12 @@ export interface CreateNotificationsHonoModuleOptions extends NotificationsRoute
   /**
    * Resolves a database from runtime bindings. Required for
    * `autoConfirmAndDispatch` — the `booking.confirmed` subscriber fires
-   * outside a request scope and needs its own db handle.
+   * outside a request scope and needs its own db handle. Returns
+   * `AnyDrizzleDb` (the union of `PostgresJsDatabase | NeonHttpDatabase`)
+   * so consumers don't have to cast through `unknown` when wiring a
+   * Hyperdrive/Neon client.
    */
-  resolveDb?: (bindings: Record<string, unknown>) => PostgresJsDatabase
+  resolveDb?: (bindings: Record<string, unknown>) => AnyDrizzleDb
   autoConfirmAndDispatch?: NotificationsAutoConfirmAndDispatchOptions
 }
 
@@ -187,7 +191,10 @@ export function createNotificationsHonoModule(
             data: { bookingId: string; bookingNumber: string; actorId: string | null }
           }) => {
             try {
-              const db = resolveDb(bindings as Record<string, unknown>)
+              // The resolver may return either drizzle flavor; the queries
+              // bookingDocumentNotificationsService runs are compatible with
+              // both at runtime, so we narrow at this internal boundary.
+              const db = resolveDb(bindings as Record<string, unknown>) as PostgresJsDatabase
               await bookingDocumentNotificationsService.confirmAndDispatchBooking(
                 db,
                 dispatcher,

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -60,14 +60,10 @@ const notificationsHonoModule = createNotificationsHonoModule({
   // the in-process event bus; errors are logged, not rethrown, so a flaky
   // mailer can't block the confirm request.
   //
-  // `getDbFromHyperdrive` returns a union of PostgresJsDatabase and
-  // NeonHttpDatabase depending on env (hyperdrive vs plain DATABASE_URL).
-  // The notifications service only calls drizzle operations that both
-  // flavors support, so we narrow through `unknown`.
-  resolveDb: (bindings) =>
-    getDbFromHyperdrive(
-      bindings as unknown as CloudflareBindings,
-    ) as unknown as import("drizzle-orm/postgres-js").PostgresJsDatabase,
+  // `getDbFromHyperdrive` returns either drizzle flavor (postgres-js or
+  // neon-http) depending on env. `resolveDb` accepts the union via
+  // `AnyDrizzleDb`, so no double-cast is needed here.
+  resolveDb: (bindings) => getDbFromHyperdrive(bindings as unknown as CloudflareBindings),
   autoConfirmAndDispatch: {
     enabled: true,
     templateSlug: "booking-confirmation",
@@ -93,21 +89,17 @@ const financeModule = createFinanceHonoModule({
     resolveDocumentDownloadUrl(bindings as unknown as CloudflareBindings, storageKey),
 })
 const legalModule = createLegalHonoModule({
-  // Same union-narrowing trick notifications uses — see the comment on
-  // notificationsHonoModule's resolveDb. Contract operations are all
-  // compatible across the hyperdrive/neon-http drizzle flavors.
-  resolveDb: (bindings) =>
-    getDbFromHyperdrive(
-      bindings as unknown as CloudflareBindings,
-    ) as unknown as import("drizzle-orm/postgres-js").PostgresJsDatabase,
-  resolveDocumentDownloadUrl: (bindings: unknown, storageKey: string) =>
+  // `getDbFromHyperdrive` returns either drizzle flavor; `resolveDb` accepts
+  // the union via `AnyDrizzleDb`, so no double-cast is needed here.
+  resolveDb: (bindings) => getDbFromHyperdrive(bindings as unknown as CloudflareBindings),
+  resolveDocumentDownloadUrl: (bindings, storageKey) =>
     resolveDocumentDownloadUrl(bindings as unknown as CloudflareBindings, storageKey),
   // Wire a PDF document generator against the private DOCUMENTS_BUCKET so
   // auto-generated contracts + manual regeneration land in R2. Returning
   // `undefined` when no bucket is configured keeps the module wired but
   // inert — the generate-document endpoint falls back to a 501.
   resolveDocumentGenerator: (bindings) => {
-    const storage = createDocumentStorage(bindings as CloudflareBindings)
+    const storage = createDocumentStorage(bindings as unknown as CloudflareBindings)
     if (!storage) return undefined
     return createPdfContractDocumentGenerator({ storage })
   },


### PR DESCRIPTION
## Summary

Partially closes #349. Tackles the two concrete pain points the issue flagged with "apology" comments + double casts in the operator template:

### 1. \`resolveDb\` accepts the drizzle driver union, not just \`PostgresJsDatabase\`

\`getDbFromHyperdrive\` returns either \`PostgresJsDatabase\` or \`NeonHttpDatabase\` depending on whether Hyperdrive is bound. The factory option used to require \`PostgresJsDatabase\`, forcing templates to cast through \`unknown\`:

\`\`\`ts
resolveDb: (bindings) =>
  getDbFromHyperdrive(bindings as unknown as CloudflareBindings)
    as unknown as PostgresJsDatabase,
\`\`\`

New shared type alias \`AnyDrizzleDb = PostgresJsDatabase | NeonHttpDatabase\` exported from \`@voyantjs/db\`. \`resolveDb\` in \`createNotificationsHonoModule\` and \`createLegalHonoModule\` now returns \`AnyDrizzleDb\`. Internal call sites cast back to \`PostgresJsDatabase\` once at the boundary so downstream services keep their existing signatures.

### 2. \`bindings: unknown\` vs \`bindings: Record<string, unknown>\` inconsistency

\`packages/legal/src/contracts/routes.ts\` had three resolver callbacks typed \`(bindings: unknown) => ...\`. Normalized to \`(bindings: Record<string, unknown>) => ...\` to match every other resolver in the workspace.

## Operator template cleanup

- Dropped \`as unknown as PostgresJsDatabase\` from both \`resolveDb\` call sites (notifications + legal). Comment about drizzle flavor unions shrunk to one line.
- One call site (\`resolveDocumentGenerator\`) gained an \`unknown\` step — the option moved from \`unknown\` to \`Record<string, unknown>\`, so casting to \`CloudflareBindings\` needs an explicit \`unknown\` step. Net wash.

## Deferred from #349

The issue also asks for factories to be **generic in \`TBindings\`** (\`createNotificationsHonoModule<CloudflareBindings>(...)\`). I attempted this and reverted:

- Cloudflare's auto-generated \`CloudflareBindings\` lacks an index signature, so it doesn't satisfy \`extends Record<string, unknown>\`.
- Loosening to \`extends object\` typechecks the public surface but immediately breaks every consumer that defines a helper like \`resolveNotificationProviders(env: Record<string, unknown>)\` — that helper would need to be generic too, propagating across ~30 helper functions in \`templates/.../lib/\`.

Worth a follow-up, but materially bigger than this issue's apparent scope. Closing the type-inconsistency + resolveDb halves now; can pick up generics in a separate PR if the bigger ripple is appetited.

## Verification

- \`pnpm typecheck\` — 95/95 ✓
- \`pnpm -F @voyantjs/notifications -F @voyantjs/legal test\` — 57+48 unit tests ✓

## Test plan

- [ ] CI passes
- [ ] Manual: operator template builds against latest packages without re-introducing the apology casts