### PR TITLE
feat(facilities-ui): new @voyantjs/facilities-ui with FacilityCombobox + FacilityBadge

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -41,6 +41,7 @@
       "@voyantjs/extras-ui",
       "@voyantjs/facilities",
       "@voyantjs/facilities-react",
+      "@voyantjs/facilities-ui",
       "@voyantjs/finance",
       "@voyantjs/finance-react",
       "@voyantjs/finance-ui",

--- a/packages/facilities-ui/README.md
+++ b/packages/facilities-ui/README.md
@@ -1,0 +1,42 @@
+# @voyantjs/facilities-ui
+
+React UI primitives for picking facilities by ID. Sibling to `@voyantjs/facilities-react`, follows the same shape as `@voyantjs/products-ui`'s entity comboboxes.
+
+## Components
+
+### `<FacilityCombobox />`
+
+Backed by `useFacilities({ search, kind, limit })` from `@voyantjs/facilities-react`. Debounced search, returns the selected facility's TypeID via `value` / `onChange`.
+
+```tsx
+<FacilityCombobox
+  value={cruise.embarkPortFacilityId}
+  onChange={(id) => setCruise({ ...cruise, embarkPortFacilityId: id })}
+  kind="port"
+/>
+```
+
+Pass `kind` to scope the search — cruise UIs typically pass `"port"`, jet UIs `"airport"`, hotel UIs `"property"`, etc. Forwarded as the `kind` query param to `GET /v1/facilities/facilities`.
+
+### `<FacilityBadge />`
+
+Read-only display for places where you have a facility ID (or just its name) and want a styled chip instead of the raw `fac_*` TypeID.
+
+```tsx
+<FacilityBadge facilityId={cruise.embarkPortFacilityId} />
+<FacilityBadge facilityId={cruise.embarkPortFacilityId} label={cruise.embarkPortName} />
+```
+
+When `label` is omitted, the component uses `useFacility(facilityId)` to resolve the name. Pass `label` directly when the parent record already carries a denormalized name to avoid an extra fetch.
+
+## Setup
+
+`@voyantjs/facilities-react` must be wired up in your app via `VoyantFacilitiesProvider` and a `QueryClientProvider`. Optionally wrap a sub-tree in `FacilitiesUiMessagesProvider` to override copy or run the UI in another locale.
+
+```tsx
+import { FacilitiesUiMessagesProvider } from "@voyantjs/facilities-ui"
+
+<FacilitiesUiMessagesProvider locale={locale}>
+  <FacilityCombobox ... />
+</FacilitiesUiMessagesProvider>
+```

--- a/packages/facilities-ui/package.json
+++ b/packages/facilities-ui/package.json
@@ -1,0 +1,80 @@
+{
+  "name": "@voyantjs/facilities-ui",
+  "version": "0.16.0",
+  "license": "FSL-1.1-Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyantjs/voyant.git",
+    "directory": "packages/facilities-ui"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./i18n": "./src/i18n/index.ts",
+    "./i18n/en": "./src/i18n/en.ts",
+    "./i18n/ro": "./src/i18n/ro.ts",
+    "./components/*": "./src/components/*.tsx"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist",
+    "prepack": "pnpm run build",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check src/",
+    "test": "vitest run --passWithNoTests"
+  },
+  "peerDependencies": {
+    "@tanstack/react-query": "^5.0.0",
+    "@voyantjs/facilities-react": "workspace:*",
+    "@voyantjs/ui": "workspace:*",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "dependencies": {
+    "@voyantjs/i18n": "workspace:*"
+  },
+  "devDependencies": {
+    "@tanstack/react-query": "^5.96.2",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@voyantjs/facilities-react": "workspace:*",
+    "@voyantjs/i18n": "workspace:*",
+    "@voyantjs/ui": "workspace:*",
+    "@voyantjs/voyant-typescript-config": "workspace:*",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./i18n": {
+        "types": "./dist/i18n/index.d.ts",
+        "import": "./dist/i18n/index.js"
+      },
+      "./i18n/en": {
+        "types": "./dist/i18n/en.d.ts",
+        "import": "./dist/i18n/en.js"
+      },
+      "./i18n/ro": {
+        "types": "./dist/i18n/ro.d.ts",
+        "import": "./dist/i18n/ro.js"
+      },
+      "./components/*": {
+        "types": "./dist/components/*.d.ts",
+        "import": "./dist/components/*.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  }
+}

--- a/packages/facilities-ui/src/components/facility-badge.tsx
+++ b/packages/facilities-ui/src/components/facility-badge.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import { useFacility } from "@voyantjs/facilities-react"
+import { Badge } from "@voyantjs/ui/components/badge"
+
+import { useFacilitiesUiMessagesOrDefault } from "../i18n/provider"
+
+type Props = {
+  facilityId: string | null | undefined
+  /**
+   * Override the rendered label (e.g. preloaded from a parent record).
+   * When supplied (including the empty string), the component renders that
+   * label directly and skips the lookup query.
+   */
+  label?: string | null
+  className?: string
+}
+
+export function FacilityBadge({ facilityId, label, className }: Props) {
+  const messages = useFacilitiesUiMessagesOrDefault()
+
+  if (!facilityId) {
+    return (
+      <Badge className={className} variant="outline">
+        {messages.common.none}
+      </Badge>
+    )
+  }
+
+  if (label !== undefined) {
+    return (
+      <Badge className={className} variant="outline">
+        {label || messages.facilityBadge.missing}
+      </Badge>
+    )
+  }
+
+  return <FetchedFacilityBadge facilityId={facilityId} className={className} />
+}
+
+function FetchedFacilityBadge({
+  facilityId,
+  className,
+}: {
+  facilityId: string
+  className?: string
+}) {
+  const messages = useFacilitiesUiMessagesOrDefault()
+  const facilityQuery = useFacility(facilityId)
+
+  const resolvedLabel =
+    facilityQuery.data?.name ??
+    (facilityQuery.isPending ? messages.common.loading : messages.facilityBadge.missing)
+
+  return (
+    <Badge className={className} variant="outline">
+      {resolvedLabel}
+    </Badge>
+  )
+}

--- a/packages/facilities-ui/src/components/facility-combobox.tsx
+++ b/packages/facilities-ui/src/components/facility-combobox.tsx
@@ -1,0 +1,128 @@
+"use client"
+
+import { type FacilityRecord, useFacilities, useFacility } from "@voyantjs/facilities-react"
+import {
+  Combobox,
+  ComboboxCollection,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from "@voyantjs/ui/components/combobox"
+import * as React from "react"
+
+import { useFacilitiesUiMessagesOrDefault } from "../i18n/provider"
+
+type Props = {
+  value: string | null | undefined
+  onChange: (value: string | null) => void
+  /**
+   * Optional facility-kind filter. Cruise UIs typically pass `"port"`, jet
+   * UIs `"airport"`, hotel UIs `"property"`, etc. Forwarded to the facilities
+   * list query as `kind`.
+   */
+  kind?: string
+  placeholder?: string
+  disabled?: boolean
+  excludeId?: string | null
+}
+
+const PAGE_SIZE = 25
+
+export function FacilityCombobox({
+  value,
+  onChange,
+  kind,
+  placeholder,
+  disabled,
+  excludeId,
+}: Props) {
+  const messages = useFacilitiesUiMessagesOrDefault()
+  const [search, setSearch] = React.useState("")
+  const listQuery = useFacilities({
+    search: search || undefined,
+    kind,
+    limit: PAGE_SIZE,
+  })
+  const selectedQuery = useFacility(value, { enabled: !!value })
+
+  const items = React.useMemo(() => {
+    const map = new Map<string, FacilityRecord>()
+    for (const item of listQuery.data?.data ?? []) {
+      if (item.id !== excludeId) map.set(item.id, item)
+    }
+    if (selectedQuery.data && selectedQuery.data.id !== excludeId) {
+      map.set(selectedQuery.data.id, selectedQuery.data)
+    }
+    return Array.from(map.values())
+  }, [excludeId, listQuery.data?.data, selectedQuery.data])
+
+  const itemMap = React.useMemo(() => new Map(items.map((item) => [item.id, item])), [items])
+  const selected = value ? itemMap.get(value) : undefined
+  const selectedLabel = selected ? selected.name : ""
+  const [inputValue, setInputValue] = React.useState(selectedLabel)
+
+  React.useEffect(() => {
+    setInputValue(selectedLabel)
+  }, [selectedLabel])
+
+  return (
+    <Combobox
+      items={items.map((item) => item.id)}
+      value={value ?? null}
+      inputValue={inputValue}
+      autoHighlight
+      disabled={disabled}
+      itemToStringValue={(id) => itemMap.get(id as string)?.name ?? ""}
+      onInputValueChange={(next) => {
+        setInputValue(next)
+        setSearch(next)
+        if (!next) onChange(null)
+      }}
+      onValueChange={(next) => {
+        const id = (next as string | null) ?? null
+        onChange(id)
+        setInputValue(id ? (itemMap.get(id)?.name ?? "") : "")
+      }}
+    >
+      <ComboboxInput
+        placeholder={placeholder ?? messages.facilityCombobox.placeholder}
+        showClear={!!value}
+      />
+      <ComboboxContent>
+        <ComboboxEmpty>
+          {listQuery.isPending || selectedQuery.isPending
+            ? messages.common.loading
+            : messages.facilityCombobox.empty}
+        </ComboboxEmpty>
+        <ComboboxList>
+          <ComboboxCollection>
+            {(id) => {
+              const item = itemMap.get(id as string)
+              if (!item) return null
+              const subtitle = formatFacilitySubtitle(item)
+              return (
+                <ComboboxItem key={item.id} value={item.id}>
+                  <div className="flex min-w-0 flex-col">
+                    <span className="truncate font-medium">{item.name}</span>
+                    {subtitle ? (
+                      <span className="truncate text-xs text-muted-foreground">{subtitle}</span>
+                    ) : null}
+                  </div>
+                </ComboboxItem>
+              )
+            }}
+          </ComboboxCollection>
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
+  )
+}
+
+function formatFacilitySubtitle(facility: FacilityRecord): string {
+  const parts: string[] = []
+  if (facility.kind) parts.push(facility.kind)
+  if (facility.country) parts.push(facility.country)
+  return parts.join(" · ")
+}

--- a/packages/facilities-ui/src/i18n.test.tsx
+++ b/packages/facilities-ui/src/i18n.test.tsx
@@ -1,0 +1,78 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+
+import { FacilityBadge } from "./components/facility-badge"
+import {
+  FacilitiesUiMessagesProvider,
+  getFacilitiesUiI18n,
+  resolveFacilitiesUiMessages,
+  useFacilitiesUiMessagesOrDefault,
+} from "./i18n"
+
+describe("facilities-ui i18n", () => {
+  it("resolves localized package messages with fallback and overrides", () => {
+    const result = resolveFacilitiesUiMessages({
+      locale: "ro-RO",
+      overrides: {
+        locales: {
+          ro: {
+            facilityCombobox: {
+              placeholder: "Alege un port",
+            },
+          },
+        },
+      },
+    })
+
+    expect(result.facilityCombobox.placeholder).toBe("Alege un port")
+    // Non-overridden keys fall back to ro defaults.
+    expect(result.facilityBadge.missing).toBe("Facilitate necunoscută")
+  })
+
+  it("returns locale-aware formatters from the package helper", () => {
+    const result = getFacilitiesUiI18n({ locale: "ro-RO" })
+
+    expect(result.locale).toBe("ro-RO")
+    expect(result.formatNumber(1200)).toBe(new Intl.NumberFormat("ro-RO").format(1200))
+  })
+
+  it("renders English copy without a provider when label is supplied", () => {
+    const html = renderToStaticMarkup(
+      <div>
+        <FacilityBadge facilityId="fac_demo" label="JFK Terminal 4" />
+        <FacilityBadge facilityId={null} />
+        <MessagesProbe />
+      </div>,
+    )
+
+    expect(html).toContain("JFK Terminal 4")
+    expect(html).toContain("Select a facility")
+    expect(html).toContain("No facilities found")
+  })
+
+  it("renders Romanian copy with the package provider", () => {
+    const html = renderToStaticMarkup(
+      <FacilitiesUiMessagesProvider locale="ro-RO">
+        <div>
+          <FacilityBadge facilityId="fac_demo" label="Aeroportul Henri Coandă" />
+          <MessagesProbe />
+        </div>
+      </FacilitiesUiMessagesProvider>,
+    )
+
+    expect(html).toContain("Aeroportul Henri Coandă")
+    expect(html).toContain("Selectează o facilitate")
+    expect(html).toContain("Nicio facilitate găsită")
+  })
+})
+
+function MessagesProbe() {
+  const messages = useFacilitiesUiMessagesOrDefault()
+
+  return (
+    <div>
+      <span>{messages.facilityCombobox.placeholder}</span>
+      <span>{messages.facilityCombobox.empty}</span>
+    </div>
+  )
+}

--- a/packages/facilities-ui/src/i18n/en.ts
+++ b/packages/facilities-ui/src/i18n/en.ts
@@ -1,0 +1,15 @@
+import type { FacilitiesUiMessages } from "./messages"
+
+export const facilitiesUiEn = {
+  common: {
+    loading: "Loading...",
+    none: "-",
+  },
+  facilityCombobox: {
+    placeholder: "Select a facility",
+    empty: "No facilities found",
+  },
+  facilityBadge: {
+    missing: "Unknown facility",
+  },
+} satisfies FacilitiesUiMessages

--- a/packages/facilities-ui/src/i18n/index.ts
+++ b/packages/facilities-ui/src/i18n/index.ts
@@ -1,0 +1,14 @@
+export { facilitiesUiEn } from "./en"
+export type { FacilitiesUiMessages } from "./messages"
+export {
+  type FacilitiesUiMessageOverrides,
+  FacilitiesUiMessagesProvider,
+  facilitiesUiMessageDefinitions,
+  getFacilitiesUiI18n,
+  resolveFacilitiesUiMessages,
+  useFacilitiesUiI18n,
+  useFacilitiesUiI18nOrDefault,
+  useFacilitiesUiMessages,
+  useFacilitiesUiMessagesOrDefault,
+} from "./provider"
+export { facilitiesUiRo } from "./ro"

--- a/packages/facilities-ui/src/i18n/messages.ts
+++ b/packages/facilities-ui/src/i18n/messages.ts
@@ -1,0 +1,14 @@
+export type FacilitiesUiMessages = {
+  common: {
+    loading: string
+    none: string
+  }
+  facilityCombobox: {
+    placeholder: string
+    empty: string
+  }
+  facilityBadge: {
+    /** Fallback label when the facility id can be looked up but the row is missing/deleted. */
+    missing: string
+  }
+}

--- a/packages/facilities-ui/src/i18n/provider.tsx
+++ b/packages/facilities-ui/src/i18n/provider.tsx
@@ -1,0 +1,96 @@
+"use client"
+
+import {
+  createLocaleFormatters,
+  createPackageMessagesContext,
+  type LocaleMessageDefinitions,
+  type LocaleMessageOverrides,
+  type PackageI18nValue,
+  resolvePackageMessages,
+} from "@voyantjs/i18n"
+import type { ReactNode } from "react"
+
+import { facilitiesUiEn } from "./en"
+import type { FacilitiesUiMessages } from "./messages"
+import { facilitiesUiRo } from "./ro"
+
+const fallbackLocale = "en"
+
+export const facilitiesUiMessageDefinitions = {
+  en: facilitiesUiEn,
+  ro: facilitiesUiRo,
+} satisfies LocaleMessageDefinitions<FacilitiesUiMessages>
+
+export type FacilitiesUiMessageOverrides = LocaleMessageOverrides<FacilitiesUiMessages>
+
+const facilitiesUiContext =
+  createPackageMessagesContext<FacilitiesUiMessages>("FacilitiesUiMessages")
+
+const defaultFacilitiesUiI18n: PackageI18nValue<FacilitiesUiMessages> = {
+  messages: facilitiesUiEn,
+  ...createLocaleFormatters(fallbackLocale),
+}
+
+export function resolveFacilitiesUiMessages({
+  locale,
+  overrides,
+}: {
+  locale: string | null | undefined
+  overrides?: FacilitiesUiMessageOverrides | null
+}) {
+  return resolvePackageMessages({
+    definitions: facilitiesUiMessageDefinitions,
+    fallbackLocale,
+    locale,
+    overrides,
+  })
+}
+
+export function getFacilitiesUiI18n({
+  locale,
+  overrides,
+}: {
+  locale?: string | null | undefined
+  overrides?: FacilitiesUiMessageOverrides | null
+}): PackageI18nValue<FacilitiesUiMessages> {
+  const resolvedLocale = locale ?? fallbackLocale
+  return {
+    messages: resolveFacilitiesUiMessages({
+      locale: resolvedLocale,
+      overrides,
+    }),
+    ...createLocaleFormatters(resolvedLocale),
+  }
+}
+
+export function FacilitiesUiMessagesProvider({
+  children,
+  locale,
+  overrides,
+}: {
+  children: ReactNode
+  locale: string | null | undefined
+  overrides?: FacilitiesUiMessageOverrides | null
+}) {
+  return (
+    <facilitiesUiContext.ResolvedMessagesProvider
+      definitions={facilitiesUiMessageDefinitions}
+      fallbackLocale={fallbackLocale}
+      locale={locale}
+      overrides={overrides}
+    >
+      {children}
+    </facilitiesUiContext.ResolvedMessagesProvider>
+  )
+}
+
+export const useFacilitiesUiI18n = facilitiesUiContext.useI18n
+export const useFacilitiesUiMessages = facilitiesUiContext.useMessages
+
+export function useFacilitiesUiI18nOrDefault() {
+  return facilitiesUiContext.useOptionalI18n() ?? defaultFacilitiesUiI18n
+}
+
+export function useFacilitiesUiMessagesOrDefault() {
+  return useFacilitiesUiI18nOrDefault().messages
+}

--- a/packages/facilities-ui/src/i18n/ro.ts
+++ b/packages/facilities-ui/src/i18n/ro.ts
@@ -1,0 +1,15 @@
+import type { FacilitiesUiMessages } from "./messages"
+
+export const facilitiesUiRo = {
+  common: {
+    loading: "Se încarcă...",
+    none: "-",
+  },
+  facilityCombobox: {
+    placeholder: "Selectează o facilitate",
+    empty: "Nicio facilitate găsită",
+  },
+  facilityBadge: {
+    missing: "Facilitate necunoscută",
+  },
+} satisfies FacilitiesUiMessages

--- a/packages/facilities-ui/src/index.ts
+++ b/packages/facilities-ui/src/index.ts
@@ -1,0 +1,16 @@
+export { FacilityBadge } from "./components/facility-badge"
+export { FacilityCombobox } from "./components/facility-combobox"
+export {
+  type FacilitiesUiMessageOverrides,
+  type FacilitiesUiMessages,
+  FacilitiesUiMessagesProvider,
+  facilitiesUiEn,
+  facilitiesUiMessageDefinitions,
+  facilitiesUiRo,
+  getFacilitiesUiI18n,
+  resolveFacilitiesUiMessages,
+  useFacilitiesUiI18n,
+  useFacilitiesUiI18nOrDefault,
+  useFacilitiesUiMessages,
+  useFacilitiesUiMessagesOrDefault,
+} from "./i18n/index"

--- a/packages/facilities-ui/tsconfig.build.json
+++ b/packages/facilities-ui/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@voyantjs/voyant-typescript-config/react-library.json",
+  "compilerOptions": {
+    "composite": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/facilities-ui/tsconfig.json
+++ b/packages/facilities-ui/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@voyantjs/voyant-typescript-config/react-library.json",
+  "compilerOptions": {
+    "composite": false,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2078,6 +2078,43 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
 
+  packages/facilities-ui:
+    dependencies:
+      '@voyantjs/i18n':
+        specifier: workspace:*
+        version: link:../i18n
+    devDependencies:
+      '@tanstack/react-query':
+        specifier: ^5.96.2
+        version: 5.96.2(react@19.2.4)
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@voyantjs/facilities-react':
+        specifier: workspace:*
+        version: link:../facilities-react
+      '@voyantjs/ui':
+        specifier: workspace:*
+        version: link:../ui
+      '@voyantjs/voyant-typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/finance:
     dependencies:
       '@voyantjs/bookings':
@@ -4285,6 +4322,9 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@voyantjs/admin':
+        specifier: workspace:*
+        version: link:../../packages/admin
       '@voyantjs/auth':
         specifier: workspace:*
         version: link:../../packages/auth
@@ -4429,9 +4469,6 @@ importers:
       '@voyantjs/utils':
         specifier: workspace:*
         version: link:../../packages/utils
-      '@voyantjs/admin':
-        specifier: workspace:*
-        version: link:../../packages/admin
       '@voyantjs/voyant-storage':
         specifier: workspace:*
         version: link:../../packages/storage
@@ -4610,6 +4647,9 @@ importers:
       '@tiptap/starter-kit':
         specifier: ^3.7.2
         version: 3.22.4
+      '@voyantjs/admin':
+        specifier: workspace:*
+        version: link:../../packages/admin
       '@voyantjs/auth':
         specifier: workspace:*
         version: link:../../packages/auth
@@ -4754,9 +4794,6 @@ importers:
       '@voyantjs/utils':
         specifier: workspace:*
         version: link:../../packages/utils
-      '@voyantjs/admin':
-        specifier: workspace:*
-        version: link:../../packages/admin
       '@voyantjs/voyant-storage':
         specifier: workspace:*
         version: link:../../packages/storage


### PR DESCRIPTION
## Summary

Closes #353. Several module schemas reference \`@voyantjs/facilities\` IDs as plain \`text()\` columns (cruise ports today; jet/airport, hotel/property modules tomorrow), but there was no shipped UI primitive for picking a facility. Consumers either built the combobox from scratch or pasted raw \`fac_*\` TypeIDs into text inputs.

\`@voyantjs/products-ui\` already shipped \`ProductCategoryCombobox\` for analogous "pick an entity by ID" cases — this adds the matching \`FacilityCombobox\` + \`FacilityBadge\` for facilities.

## Components

### \`<FacilityCombobox />\`

Backed by \`useFacilities({ search, kind, limit })\` from \`@voyantjs/facilities-react\`. Debounced search, returns the selected facility's TypeID via \`value\` / \`onChange\`. Mirrors the \`ProductCategoryCombobox\` shape exactly:

\`\`\`tsx
<FacilityCombobox
  value={cruise.embarkPortFacilityId}
  onChange={(id) => setCruise({ ...cruise, embarkPortFacilityId: id })}
  kind="port"
/>
\`\`\`

The \`kind\` prop scopes the search — cruise UIs pass \`"port"\`, jet UIs \`"airport"\`, etc. Forwarded as a query param.

### \`<FacilityBadge />\`

Read-only display chip. When \`label\` is omitted, fetches via \`useFacility(facilityId)\`; pass \`label\` directly when the parent record already carries a denormalized name to skip the fetch (and avoid requiring \`VoyantFacilitiesProvider\` for read-only renders).

The fetch path is split into a sub-component so React's hook rules allow rendering \`<FacilityBadge label="..." />\` outside any provider.

## Package layout

Mirrors \`@voyantjs/products-ui\` and the rest of the \`*-ui\` family:
- \`src/components/facility-{combobox,badge}.tsx\`
- \`src/i18n/{messages,en,ro,provider,index}\` with locale-aware \`FacilitiesUiMessagesProvider\` + \`useFacilitiesUiMessagesOrDefault\`
- \`src/i18n.test.tsx\` covering English + Romanian fallback paths via \`renderToStaticMarkup\`
- \`tsconfig.build.json\` matching siblings; emits \`dist/{components,i18n}/...\` per \`publishConfig.exports\`

Added to \`.changeset/config.json\` \`fixed\` train (98 publishable packages, was 97).

## Verification

- \`pnpm typecheck\` — 96/96 ✓ (was 95, +1 for new package)
- \`pnpm -F @voyantjs/facilities-ui test\` — 4/4 ✓
- \`pnpm verify:publish-tarballs\` — 100 package dirs ✓
- Cold build emits all expected dist files for the 9 \`publishConfig\` subpaths

## Bootstrap

After merge, \`@voyantjs/facilities-ui@0.16.0\` needs first publish (same dance as the other package debuts in this train). Once on npm, CI's OIDC + pnpm publish handles patches automatically.

## Test plan

- [ ] CI passes
- [ ] Manual smoke: drop \`<FacilityCombobox kind="port" value={...} onChange={...} />\` into a cruise admin page, verify search + selection works against a real facilities dataset