### PR TITLE
fix(hono): require actor on VoyantRequestAuthContext, actionable 401

### DIFF
--- a/.changeset/require-actor-on-auth-resolve.md
+++ b/.changeset/require-actor-on-auth-resolve.md
@@ -1,0 +1,37 @@
+---
+"@voyantjs/hono": minor
+---
+
+Make `actor` required on `VoyantRequestAuthContext` and surface a better 401 when it's missing (fixes #381).
+
+`requireActor` is fail-closed — when `c.var.actor` is unset, every protected request 401s. Previously the type kept `actor` optional, the API-key branch hard-coded `"staff"`, the public-paths branch hard-coded `"customer"`, but the custom `auth.resolve` branch had no enforcement, no default, and a 401 message that read like a session bug. Consumers upgrading with a working session resolver saw every `/v1/admin/*` route 401 after a valid sign-in.
+
+**Type-level enforcement (BREAKING for custom resolvers):**
+
+```ts
+// Before
+export type VoyantRequestAuthContext = VoyantAuthContext & {
+  userId: string
+}
+
+// After
+export type VoyantRequestAuthContext = Omit<VoyantAuthContext, "actor"> & {
+  userId: string
+  actor: Actor
+}
+```
+
+Any `auth.resolve` integration whose return type is `VoyantRequestAuthContext` now fails to compile until it includes `actor`. For single-tenant admin apps, return `actor: "staff"`. Customer/partner/supplier sessions should return the corresponding actor so `/v1/public/*` route guards keep working.
+
+`requirePermission` now also throws if `actor` is missing on the request context (it should be set by `requireActor` upstream); this surfaces auth-pipeline misordering rather than fabricating a default.
+
+**Better 401 message:**
+
+```
+Unauthorized: actor not resolved. The auth pipeline did not assign an `actor`
+to this request. If you set `auth.resolve` on `createApp({...})`, the returned
+object must include `actor` (usually `"staff"` for admin sessions). Public
+routes should be listed in `publicPaths`.
+```
+
+**Migration:** add `actor: "staff"` (or the appropriate actor) to whatever your `auth.resolve` returns. The DMC and operator templates and the dev app have all been updated.

--- a/apps/dev/src/api/auth/handler.ts
+++ b/apps/dev/src/api/auth/handler.ts
@@ -127,6 +127,7 @@ export async function resolveAuthRequest(
     sessionId: session.session.id,
     organizationId: null,
     callerType: "session",
+    actor: "staff",
     email: session.user.email ?? null,
   }
 }

--- a/packages/hono/src/middleware/require-actor.ts
+++ b/packages/hono/src/middleware/require-actor.ts
@@ -44,7 +44,15 @@ export function requireActor<TBindings extends VoyantBindings = VoyantBindings>(
 
     const actor = c.get("actor") as Actor | undefined
     if (!actor) {
-      return c.json({ error: "Unauthorized: actor not resolved" }, 401)
+      return c.json(
+        {
+          error:
+            "Unauthorized: actor not resolved. The auth pipeline did not assign an `actor` to this request. " +
+            "If you set `auth.resolve` on `createApp({...})`, the returned object must include `actor` " +
+            '(usually `"staff"` for admin sessions). Public routes should be listed in `publicPaths`.',
+        },
+        401,
+      )
     }
     if (!allowSet.has(actor)) {
       return c.json({ error: "Forbidden: actor not permitted on this surface" }, 403)

--- a/packages/hono/src/middleware/require-permission.ts
+++ b/packages/hono/src/middleware/require-permission.ts
@@ -1,9 +1,9 @@
-import type { VoyantPermission } from "@voyantjs/core"
+import type { Actor, VoyantPermission } from "@voyantjs/core"
 import type { MiddlewareHandler } from "hono"
 
 import { requireUserId } from "../auth/require-user.js"
 import type { DbFactory, VoyantAuthIntegration, VoyantBindings, VoyantVariables } from "../types.js"
-import { ForbiddenApiError } from "../validation.js"
+import { ForbiddenApiError, UnauthorizedApiError } from "../validation.js"
 
 function hasScope(scopes: string[] | null | undefined, permission: VoyantPermission): boolean {
   if (!scopes || scopes.length === 0) return false
@@ -41,6 +41,13 @@ export function requirePermission<TBindings extends VoyantBindings>(
     }
 
     const userId = requireUserId(c)
+    const actor = c.get("actor") as Actor | undefined
+    if (!actor) {
+      // Should be unreachable in well-wired apps: `requireActor` runs before
+      // `requirePermission`. Throw rather than fabricate a default so callers
+      // see the upstream wiring bug instead of a silent privilege grant.
+      throw new UnauthorizedApiError()
+    }
 
     if (!opts?.auth?.hasPermission) {
       return c.json({ error: "No auth permission checker configured" }, 500)
@@ -53,6 +60,7 @@ export function requirePermission<TBindings extends VoyantBindings>(
       ctx: c.executionCtx,
       auth: {
         userId,
+        actor,
         sessionId: c.get("sessionId"),
         organizationId: c.get("organizationId"),
         callerType: c.get("callerType"),

--- a/packages/hono/src/types.ts
+++ b/packages/hono/src/types.ts
@@ -1,4 +1,5 @@
 import type {
+  Actor,
   VoyantVariables as CoreVoyantVariables,
   EventBus,
   LinkService,
@@ -52,8 +53,15 @@ export type DbFactory<TBindings extends VoyantBindings = VoyantBindings> = (
   env: TBindings,
 ) => VoyantDb
 
-export type VoyantRequestAuthContext = VoyantAuthContext & {
+/**
+ * The shape returned by a custom `auth.resolve` integration. Both `userId`
+ * and `actor` are required: `requireActor` is fail-closed, so a resolver
+ * that omits `actor` would 401 every protected request. Make the omission a
+ * compile-time error instead of a runtime mystery.
+ */
+export type VoyantRequestAuthContext = Omit<VoyantAuthContext, "actor"> & {
   userId: string
+  actor: Actor
 }
 
 export interface LogEntry {
@@ -88,6 +96,15 @@ export interface VoyantAuthIntegration<TBindings extends VoyantBindings = Voyant
       ctx?: VoyantExecutionContext,
     ) => Response | Promise<Response>
   }
+  /**
+   * Resolve the request to an auth context, or return `null` for anonymous.
+   *
+   * The returned object MUST include `actor` — `requireActor` is fail-closed,
+   * so omitting it 401s every protected route. For single-tenant admin apps
+   * where every authenticated session is staff, return `actor: "staff"`.
+   * Customer/partner/supplier sessions should return the corresponding actor
+   * so `/v1/public/*` route guards work.
+   */
   resolve?: (
     args: VoyantAuthResolveArgs<TBindings>,
   ) => Promise<VoyantRequestAuthContext | null> | VoyantRequestAuthContext | null

--- a/packages/hono/tests/unit/require-actor.test.ts
+++ b/packages/hono/tests/unit/require-actor.test.ts
@@ -55,6 +55,21 @@ describe("requireActor", () => {
     expect(body.error).toMatch(/Unauthorized/)
   })
 
+  it("401 message points custom-resolver consumers at the missing `actor` field", async () => {
+    // Lock in the actionable wording — the previous "actor not resolved" error
+    // surfaced as a session bug; the message must call out `auth.resolve` and
+    // the `actor` field so the migration path is obvious. See issue #381.
+    const app = makeApp(() => {})
+    app.use("*", requireActor("staff"))
+    app.get("/", (c) => c.json({ ok: true }))
+
+    const res = await app.request("/")
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toContain("auth.resolve")
+    expect(body.error).toContain("actor")
+    expect(body.error).toContain("staff")
+  })
+
   it("returns 401 when no actor is set on a public-only surface", async () => {
     const app = makeApp(() => {
       // do not set actor

--- a/packages/hono/tests/unit/require-permission.test.ts
+++ b/packages/hono/tests/unit/require-permission.test.ts
@@ -48,6 +48,7 @@ describe("requirePermission", () => {
     app.use("*", requestId)
     app.use("*", async (c, next) => {
       c.set("userId", "user_123")
+      c.set("actor", "staff")
       await next()
     })
     app.use(
@@ -72,6 +73,40 @@ describe("requirePermission", () => {
       code: "forbidden",
     })
     expect(hasPermission).toHaveBeenCalledTimes(1)
+  })
+
+  it("returns 401 when userId is set but actor is not (upstream wiring bug)", async () => {
+    // `requirePermission` runs after `requireActor`. If actor is missing here,
+    // it means the auth pipeline silently let an unresolved request through —
+    // throw rather than fabricate a default that would mask the bug. See #381.
+    vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const hasPermission = vi.fn().mockResolvedValue(true)
+
+    const app = new Hono()
+    app.onError(handleApiError)
+    app.use("*", requestId)
+    app.use("*", async (c, next) => {
+      c.set("userId", "user_123")
+      // intentionally no `actor`
+      await next()
+    })
+    app.use(
+      "*",
+      requirePermission(() => ({}) as never, "crm", "write", {
+        auth: { hasPermission },
+      }),
+    )
+    app.get("/secure", (c) => c.json({ ok: true }))
+
+    const response = await app.fetch(
+      new Request("http://example.com/secure"),
+      {},
+      mockExecutionCtx(),
+    )
+
+    expect(response.status).toBe(401)
+    expect(hasPermission).not.toHaveBeenCalled()
   })
 })
 

--- a/templates/dmc/src/api/auth/handler.ts
+++ b/templates/dmc/src/api/auth/handler.ts
@@ -111,6 +111,7 @@ export async function resolveAuthRequest(
     sessionId: session.session.id,
     organizationId: null,
     callerType: "session",
+    actor: "staff",
     email: session.user.email ?? null,
   }
 }

--- a/templates/operator/src/api/auth/handler.ts
+++ b/templates/operator/src/api/auth/handler.ts
@@ -115,6 +115,7 @@ export async function resolveAuthRequest(
     sessionId: session.session.id,
     organizationId: null,
     callerType: "session",
+    actor: "staff",
     email: session.user.email ?? null,
   }
 }


### PR DESCRIPTION
Closes #381.

## Summary

`requireActor` was made fail-closed in a recent release, but the migration path for custom `auth.resolve` consumers was not enforced anywhere. The API-key branch hard-codes `actor: "staff"` and the public-paths branch hard-codes `actor: "customer"`, but the custom-resolver branch had no default and the type kept `actor?: Actor` optional — so a working session-based admin app 401s on every \`/v1/admin/*\` route after upgrade, with an error that reads like a session bug rather than a middleware contract change.

This PR takes the type-tightening + better-error route from the issue (suggestions 1, 3, 4). Skipped suggestion 2 (default unset session callers under \`/v1/admin/*\` to \`"staff"\`) — it would silently elevate any session caller to staff on the admin surface, exactly the property the fail-closed change deliberately removed; Voyant supports customer/partner/supplier session callers so \`session ⇒ staff\` isn't a safe default.

## Changes

- `VoyantRequestAuthContext` now requires \`actor: Actor\`. Any \`auth.resolve\` returning that type fails to compile until \`actor\` is set — the omission becomes a compile-time error at the resolver's return statement instead of a runtime mystery on the first protected request.
- 401 message in \`require-actor\` rewritten to point at the cause: mentions \`auth.resolve\`, the missing \`actor\` field, the typical \`"staff"\` value for admin sessions, and \`publicPaths\` for anonymous routes.
- \`requirePermission\` throws 401 when \`actor\` is missing on the request context (should be unreachable behind \`requireActor\`, but fabricating a default would mask upstream wiring bugs).
- DMC/operator templates and the dev app's \`resolveAuthRequest\` updated to set \`actor: "staff"\` on session callers (single-tenant admin shape).
- JSDoc on \`VoyantAuthIntegration.resolve\` calls out the contract.

## Migration

Add \`actor: "staff"\` (or the appropriate actor) to whatever your \`auth.resolve\` returns. TypeScript will flag the missing field at upgrade time.

## Test plan

- [x] \`pnpm typecheck\` — 96/96 tasks pass
- [x] \`pnpm test\` — 97/97 tasks pass; new tests:
  - \`requireActor\` 401 message contains \`auth.resolve\`, \`actor\`, \`staff\`
  - \`requirePermission\` returns 401 when userId is set but actor is not
- [x] DMC + operator template typecheck pass after adding \`actor: "staff"\`