### PR TITLE
chore(release): add @voyantjs/catalog-react + catalog-ui to fixed train

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -21,6 +21,8 @@
       "@voyantjs/catalog",
       "@voyantjs/catalog-mcp",
       "@voyantjs/catalog-rag",
+      "@voyantjs/catalog-react",
+      "@voyantjs/catalog-ui",
       "@voyantjs/checkout",
       "@voyantjs/core",
       "@voyantjs/crm",


### PR DESCRIPTION
Adds the two new packages from PR #389 to the changesets fixed train. Subsequent versions auto-bump.

First-publish must still be done manually (CI npm token can't create new package names — same E404 we saw on storage/flights). Once published at any version, CI takes over.

## Test plan
- [x] `pnpm verify:release-train` — 103 publishable packages
- [x] `pnpm typecheck` (turbo, full repo) — all green