### PR TITLE
feat: channel-push v1 gap fixes + operator dashboard UI

### DIFF
--- a/packages/catalog/src/adapter/contract.ts
+++ b/packages/catalog/src/adapter/contract.ts
@@ -544,3 +544,37 @@ export class CapabilityNotSupportedError extends Error {
     this.name = "CapabilityNotSupportedError"
   }
 }
+
+/**
+ * Stable code an adapter throws when an upstream returns 429
+ * (Too Many Requests). The channel-push pipeline catches this,
+ * drains the local rate-limit bucket per `Retry-After`, and stamps the
+ * delivery row with `error_class = "rate_limited"` so the bucket
+ * self-corrects when our outbound estimate drifts from reality.
+ *
+ * Per docs/architecture/channel-push-architecture.md §14.4.
+ */
+export const ADAPTER_RATE_LIMITED = "ADAPTER_RATE_LIMITED" as const
+
+export class AdapterRateLimitedError extends Error {
+  readonly code = ADAPTER_RATE_LIMITED
+  constructor(
+    public readonly adapter_kind: string,
+    /**
+     * Milliseconds to wait before the next attempt, derived from the
+     * upstream's `Retry-After` response header (seconds → ms) or the
+     * adapter's own backoff hint. The processor uses this to drain the
+     * shared rate-limit bucket so concurrent dispatchers also back off.
+     */
+    public readonly retryAfterMs: number,
+    /** Optional context — e.g. which endpoint hit the limit. */
+    public readonly operation?: string,
+    /** Optional upstream payload echoed for diagnostics. */
+    public readonly upstreamPayload?: unknown,
+  ) {
+    super(
+      `adapter "${adapter_kind}" rate-limited${operation ? ` on "${operation}"` : ""} (retry after ${retryAfterMs}ms)`,
+    )
+    this.name = "AdapterRateLimitedError"
+  }
+}

--- a/packages/catalog/src/index.ts
+++ b/packages/catalog/src/index.ts
@@ -2,7 +2,9 @@
 
 // Public source-adapter contract.
 export {
+  ADAPTER_RATE_LIMITED,
   type AdapterCapabilities,
+  AdapterRateLimitedError,
   CAPABILITY_NOT_SUPPORTED,
   type CancelRequest,
   type CancelResult,

--- a/packages/distribution/package.json
+++ b/packages/distribution/package.json
@@ -29,6 +29,7 @@
     "@voyantjs/identity": "workspace:*",
     "@voyantjs/products": "workspace:*",
     "@voyantjs/suppliers": "workspace:*",
+    "@voyantjs/workflows": "workspace:*",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.10",
     "zod": "^4.3.6"

--- a/packages/distribution/src/channel-push/admin-routes.ts
+++ b/packages/distribution/src/channel-push/admin-routes.ts
@@ -1,0 +1,200 @@
+/**
+ * Admin API for the channel-push operator dashboard.
+ *
+ * Ships the data layer for "channel sync" views per §9 + §10 (Phase D)
+ * + §14.5 — operators want to see (a) which booking links are stuck,
+ * (b) the delivery log per booking, (c) per-channel throttling, and
+ * (d) a one-click retry button. The React surface lives in templates;
+ * this file is the backing API.
+ *
+ * Routes are mounted under `/v1/admin/distribution/channel-push/*`.
+ *
+ *   GET  /links              — counts + filterable list of channel_booking_links
+ *   POST /retry/:bookingId   — drain pending links for one booking
+ *   GET  /deliveries         — webhook_deliveries scoped by booking/channel
+ *   GET  /throttling         — per-channel rate-limited count in last hour
+ *   POST /reconcile/:flow    — manually trigger a reconciler scanner
+ *
+ * Per docs/architecture/channel-push-architecture.md §9 + §14.5.
+ */
+
+import { type InfraWebhookDelivery, infraWebhookDeliveriesTable } from "@voyantjs/db/schema/infra"
+import { and, desc, eq, gte, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { Hono } from "hono"
+
+import { channelBookingLinks, channels } from "../schema.js"
+import { reconcileAvailability, reconcileBookingLinks, reconcileContent } from "./reconciler.js"
+import { triggerBookingPushForBooking } from "./subscriber.js"
+
+type Env = {
+  Variables: {
+    db: PostgresJsDatabase
+    userId?: string
+  }
+}
+
+export type ChannelPushAdminRoutes = ReturnType<typeof createChannelPushAdminRoutes>
+
+export function createChannelPushAdminRoutes() {
+  const app = new Hono<Env>()
+
+  // ── GET /links ───────────────────────────────────────────────────
+  // Status counts + filterable list of channel_booking_links. The
+  // dashboard's "channel sync" view consumes this for both the summary
+  // tiles ("X pending, Y failed, Z compensated") and the row table.
+  app.get("/links", async (c) => {
+    const db = c.get("db")
+    const status = c.req.query("status")
+    const channelId = c.req.query("channelId")
+    const bookingId = c.req.query("bookingId")
+    const limit = clampLimit(c.req.query("limit"))
+
+    const filters = [
+      status ? eq(channelBookingLinks.pushStatus, status) : sql`true`,
+      channelId ? eq(channelBookingLinks.channelId, channelId) : sql`true`,
+      bookingId ? eq(channelBookingLinks.bookingId, bookingId) : sql`true`,
+    ]
+
+    const rows = await db
+      .select({
+        link: channelBookingLinks,
+        channelName: channels.name,
+        channelKind: channels.kind,
+      })
+      .from(channelBookingLinks)
+      .innerJoin(channels, eq(channelBookingLinks.channelId, channels.id))
+      .where(and(...filters))
+      .orderBy(desc(channelBookingLinks.lastPushAt), desc(channelBookingLinks.createdAt))
+      .limit(limit)
+
+    const counts = await db
+      .select({
+        status: channelBookingLinks.pushStatus,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(channelBookingLinks)
+      .where(and(...filters))
+      .groupBy(channelBookingLinks.pushStatus)
+
+    return c.json({
+      data: rows,
+      counts: Object.fromEntries(counts.map((c) => [c.status, c.count])),
+    })
+  })
+
+  // ── POST /retry/:bookingId ───────────────────────────────────────
+  // Operator-driven retry. Re-resolves push targets, upserts pending
+  // intent rows, and runs processBookingPush inline. Idempotent on
+  // the booking_links unique constraint, so accidental double-clicks
+  // are safe.
+  app.post("/retry/:bookingId", async (c) => {
+    const bookingId = c.req.param("bookingId")
+    try {
+      await triggerBookingPushForBooking(bookingId)
+      return c.json({ data: { ok: true, bookingId } })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return c.json({ error: message }, 500)
+    }
+  })
+
+  // ── GET /deliveries ──────────────────────────────────────────────
+  // Drilldown view: every webhook_deliveries row scoped to a booking,
+  // channel, or both. Used by the "show me what we sent" link in the
+  // dashboard's failure rows.
+  app.get("/deliveries", async (c) => {
+    const db = c.get("db")
+    const bookingId = c.req.query("bookingId")
+    const channelId = c.req.query("channelId")
+    const limit = clampLimit(c.req.query("limit"))
+
+    const filters = [
+      eq(infraWebhookDeliveriesTable.sourceModule, "distribution"),
+      bookingId
+        ? and(
+            eq(infraWebhookDeliveriesTable.sourceEntityModule, "bookings"),
+            eq(infraWebhookDeliveriesTable.sourceEntityId, bookingId),
+          )
+        : sql`true`,
+      channelId ? eq(infraWebhookDeliveriesTable.targetRef, channelId) : sql`true`,
+    ]
+
+    const rows = (await db
+      .select()
+      .from(infraWebhookDeliveriesTable)
+      .where(and(...filters))
+      .orderBy(desc(infraWebhookDeliveriesTable.createdAt))
+      .limit(limit)) as InfraWebhookDelivery[]
+
+    return c.json({ data: rows })
+  })
+
+  // ── GET /throttling ──────────────────────────────────────────────
+  // Per-channel rate-limited count in the last hour. The dashboard
+  // shows a yellow "throttled" badge when any channel has > 0
+  // rate_limited rows in the window. Per §14.5.
+  app.get("/throttling", async (c) => {
+    const db = c.get("db")
+    const sinceMs = Number.parseInt(c.req.query("sinceMs") ?? String(60 * 60 * 1000), 10)
+    const since = new Date(Date.now() - (Number.isFinite(sinceMs) ? sinceMs : 60 * 60 * 1000))
+
+    const rows = await db
+      .select({
+        channelId: infraWebhookDeliveriesTable.targetRef,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(infraWebhookDeliveriesTable)
+      .where(
+        and(
+          eq(infraWebhookDeliveriesTable.sourceModule, "distribution"),
+          eq(infraWebhookDeliveriesTable.errorClass, "rate_limited"),
+          gte(infraWebhookDeliveriesTable.createdAt, since),
+        ),
+      )
+      .groupBy(infraWebhookDeliveriesTable.targetRef)
+
+    return c.json({
+      data: rows.filter((r) => r.channelId != null),
+      sinceMs,
+    })
+  })
+
+  // ── POST /reconcile/:flow ────────────────────────────────────────
+  // Manual reconciler trigger for ops — useful when a channel comes
+  // back up after a long outage and you don't want to wait for the
+  // next scheduled run. `flow` is one of "bookings", "availability",
+  // "content".
+  app.post("/reconcile/:flow", async (c) => {
+    const flow = c.req.param("flow")
+    try {
+      switch (flow) {
+        case "bookings": {
+          const result = await reconcileBookingLinks({})
+          return c.json({ data: result })
+        }
+        case "availability": {
+          const result = await reconcileAvailability({})
+          return c.json({ data: result })
+        }
+        case "content": {
+          const result = await reconcileContent({})
+          return c.json({ data: result })
+        }
+        default:
+          return c.json({ error: `unknown flow "${flow}"` }, 400)
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return c.json({ error: message }, 500)
+    }
+  })
+
+  return app
+}
+
+function clampLimit(raw: string | undefined): number {
+  const parsed = raw ? Number.parseInt(raw, 10) : 50
+  if (!Number.isFinite(parsed) || parsed <= 0) return 50
+  return Math.min(parsed, 500)
+}

--- a/packages/distribution/src/channel-push/availability-push.ts
+++ b/packages/distribution/src/channel-push/availability-push.ts
@@ -13,11 +13,15 @@
  */
 
 import { availabilitySlots } from "@voyantjs/availability/schema"
-import type { PushAvailabilityRequest, SourceAdapterContext } from "@voyantjs/catalog"
+import {
+  AdapterRateLimitedError,
+  type PushAvailabilityRequest,
+  type SourceAdapterContext,
+} from "@voyantjs/catalog"
 import type { AnyDrizzleDb } from "@voyantjs/db"
 import { newId } from "@voyantjs/db/lib/typeid"
 import { and, asc, eq, sql } from "drizzle-orm"
-import { acquireToken, channelScopeKey, type RateLimitConfig } from "../rate-limit.js"
+import { acquireToken, channelScopeKey, drainBucket, type RateLimitConfig } from "../rate-limit.js"
 import {
   channelAvailabilityPushIntents,
   channelInventoryAllotments,
@@ -308,7 +312,18 @@ export async function processAvailabilityPushIntents(
       succeeded += 1
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
-      await envelope.complete({ errorClass: "adapter_error", errorMessage: message })
+      const isRateLimited = err instanceof AdapterRateLimitedError
+      if (isRateLimited) {
+        await drainBucket(
+          db,
+          channelScopeKey(channel.id, intent.sourceConnectionId),
+          err.retryAfterMs,
+        )
+      }
+      await envelope.complete({
+        errorClass: isRateLimited ? "rate_limited" : "adapter_error",
+        errorMessage: message,
+      })
       await stampIntentError(db, intent.id, intent.attempts + 1, message)
       failed += 1
       logger.error?.(`pushAvailability failed for slot ${slot.id} channel ${channel.id}`, {

--- a/packages/distribution/src/channel-push/booking-push.ts
+++ b/packages/distribution/src/channel-push/booking-push.ts
@@ -17,7 +17,11 @@
  */
 
 import { bookingItems, bookings } from "@voyantjs/bookings/schema"
-import type { PushBookingRequest, SourceAdapterContext } from "@voyantjs/catalog"
+import {
+  AdapterRateLimitedError,
+  type PushBookingRequest,
+  type SourceAdapterContext,
+} from "@voyantjs/catalog"
 import type { AnyDrizzleDb } from "@voyantjs/db"
 import { newId } from "@voyantjs/db/lib/typeid"
 import {
@@ -27,7 +31,7 @@ import {
 } from "@voyantjs/distribution/schema"
 import { and, eq, sql } from "drizzle-orm"
 
-import { acquireToken, channelScopeKey, type RateLimitConfig } from "../rate-limit.js"
+import { acquireToken, channelScopeKey, drainBucket, type RateLimitConfig } from "../rate-limit.js"
 import { prepareOutboundEnvelope } from "../webhook-deliveries.js"
 
 import { type ChannelPushDeps, defaultLogger, getChannelPushDepsOrThrow } from "./types.js"
@@ -371,8 +375,16 @@ export async function processBookingPush(
       succeeded += 1
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
+      // 429 from upstream — drain the bucket for the cooldown so
+      // concurrent dispatchers also see "no tokens" until the channel
+      // is ready, and stamp the delivery with the rate-limited class
+      // (per §14.4).
+      const isRateLimited = err instanceof AdapterRateLimitedError
+      if (isRateLimited) {
+        await drainBucket(db, channelScopeKey(channel.id, connectionId), err.retryAfterMs)
+      }
       await envelope.complete({
-        errorClass: "adapter_error",
+        errorClass: isRateLimited ? "rate_limited" : "adapter_error",
         errorMessage: message,
       })
       await markLinkFailed(db, link.id, link.pushAttempts + 1, message)

--- a/packages/distribution/src/channel-push/booking-push.ts
+++ b/packages/distribution/src/channel-push/booking-push.ts
@@ -20,16 +20,18 @@ import { bookingItems, bookings } from "@voyantjs/bookings/schema"
 import {
   AdapterRateLimitedError,
   type PushBookingRequest,
+  type SourceAdapter,
   type SourceAdapterContext,
 } from "@voyantjs/catalog"
 import type { AnyDrizzleDb } from "@voyantjs/db"
 import { newId } from "@voyantjs/db/lib/typeid"
 import {
   channelBookingLinks,
+  channelContracts,
   channelProductMappings,
   channels,
 } from "@voyantjs/distribution/schema"
-import { and, eq, sql } from "drizzle-orm"
+import { and, asc, eq, lte, or, sql } from "drizzle-orm"
 
 import { acquireToken, channelScopeKey, drainBucket, type RateLimitConfig } from "../rate-limit.js"
 import { prepareOutboundEnvelope } from "../webhook-deliveries.js"
@@ -48,15 +50,38 @@ export interface ProcessBookingPushResult {
   attempted: number
   succeeded: number
   failed: number
+  /**
+   * Number of succeeded links that were compensated (rolled back via
+   * `adapter.cancel`) because the contract's `compensation` policy is
+   * `"strict-atomic"` and at least one sibling failed. Always 0 under
+   * the default `"eventually-consistent"` policy.
+   */
+  compensated: number
   /** Per-link outcomes for diagnostics. */
   outcomes: Array<{
     channelId: string
     bookingItemId: string | null
-    status: "ok" | "failed" | "skipped"
+    status: "ok" | "failed" | "skipped" | "compensated"
     upstreamRef?: string
     error?: string
   }>
 }
+
+/**
+ * Compensation modes per `channel_contracts.policy.compensation`.
+ *
+ * - `eventually-consistent` (default): partial successes stay; ops gets
+ *   alerted via `webhook_deliveries` and retries via the reconciler.
+ *   Usually correct for travel inventory — succeeded channels know
+ *   about the booking and will honor it; the failed ones converge.
+ * - `strict-atomic`: on any per-link failure, the engine calls
+ *   `adapter.cancel` for succeeded siblings and marks them
+ *   `push_status = 'compensated'`. Use only when ALL channels MUST
+ *   agree on the booking's existence (rare).
+ *
+ * Per docs/architecture/channel-push-architecture.md §4.2 + §9.
+ */
+export type CompensationPolicy = "strict-atomic" | "eventually-consistent"
 
 /**
  * Build the stable idempotency key the upstream uses to dedupe pushes
@@ -232,7 +257,14 @@ export async function processBookingPush(
   }>
 
   if (links.length === 0) {
-    return { bookingId: input.bookingId, attempted: 0, succeeded: 0, failed: 0, outcomes }
+    return {
+      bookingId: input.bookingId,
+      attempted: 0,
+      succeeded: 0,
+      failed: 0,
+      compensated: 0,
+      outcomes,
+    }
   }
 
   const [booking] = (await db
@@ -243,11 +275,27 @@ export async function processBookingPush(
 
   if (!booking) {
     logger.error?.(`processBookingPush: booking ${input.bookingId} not found`, {})
-    return { bookingId: input.bookingId, attempted: 0, succeeded: 0, failed: 0, outcomes }
+    return {
+      bookingId: input.bookingId,
+      attempted: 0,
+      succeeded: 0,
+      failed: 0,
+      compensated: 0,
+      outcomes,
+    }
   }
 
   let succeeded = 0
   let failed = 0
+  // Track succeeded links so we can compensate them if a sibling fails
+  // and the contract policy demands strict-atomicity. Per §4.2.
+  const successList: Array<{
+    link: typeof channelBookingLinks.$inferSelect
+    channel: typeof channels.$inferSelect
+    adapter: SourceAdapter
+    adapterCtx: SourceAdapterContext
+    upstreamRef: string
+  }> = []
 
   for (const { link, channel } of links) {
     const connectionId = link.sourceConnectionId ?? channel.id
@@ -373,6 +421,7 @@ export async function processBookingPush(
         upstreamRef: result.upstreamRef,
       })
       succeeded += 1
+      successList.push({ link, channel, adapter, adapterCtx, upstreamRef: result.upstreamRef })
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       // 429 from upstream — drain the bucket for the cooldown so
@@ -399,13 +448,146 @@ export async function processBookingPush(
     }
   }
 
+  // Compensation pass: if any link failed and the channel-contract
+  // policy is strict-atomic, roll back succeeded siblings so all
+  // channels see a consistent "no booking" state. Per §4.2.
+  let compensated = 0
+  if (failed > 0 && successList.length > 0) {
+    const policy = await resolveCompensationPolicy(db, links[0]?.channel.id ?? null)
+    if (policy === "strict-atomic") {
+      for (const entry of successList) {
+        const success = await compensateSucceededLink(db, entry, input.bookingId, logger)
+        if (success) {
+          compensated += 1
+          // Update the existing outcome row to compensated.
+          for (const outcome of outcomes) {
+            if (
+              outcome.channelId === entry.channel.id &&
+              outcome.bookingItemId === (entry.link.bookingItemId ?? null) &&
+              outcome.status === "ok"
+            ) {
+              outcome.status = "compensated"
+              break
+            }
+          }
+        }
+      }
+      if (compensated > 0) {
+        logger.warn?.(
+          `processBookingPush: compensated ${compensated} succeeded link(s) under strict-atomic policy`,
+          { bookingId: input.bookingId, compensated, failed },
+        )
+      }
+    }
+  }
+
   return {
     bookingId: input.bookingId,
     attempted: links.length,
     succeeded,
     failed,
+    compensated,
     outcomes,
   }
+}
+
+/**
+ * Read the compensation policy for a channel by walking
+ * `channel_contracts` (most-recent active contract wins). Returns
+ * `eventually-consistent` when no contract exists or no compensation
+ * key is set — that's the doc-default safe behavior for travel
+ * inventory.
+ */
+async function resolveCompensationPolicy(
+  db: AnyDrizzleDb,
+  channelId: string | null,
+): Promise<CompensationPolicy> {
+  if (!channelId) return "eventually-consistent"
+  const today = new Date().toISOString().slice(0, 10)
+  const [contract] = (await db
+    .select({ policy: channelContracts.policy })
+    .from(channelContracts)
+    .where(
+      and(
+        eq(channelContracts.channelId, channelId),
+        eq(channelContracts.status, "active"),
+        or(sql`${channelContracts.endsAt} IS NULL`, lte(channelContracts.startsAt, today)),
+      ),
+    )
+    .orderBy(asc(channelContracts.startsAt))
+    .limit(1)) as Array<{ policy: Record<string, unknown> | null }>
+
+  const raw = contract?.policy?.compensation
+  return raw === "strict-atomic" ? "strict-atomic" : "eventually-consistent"
+}
+
+/**
+ * Roll back a succeeded link by calling `adapter.cancel` for the
+ * upstream reference. Marks the link `compensated` regardless of the
+ * cancel call's outcome — leaving it `ok` would lie to the operator
+ * dashboard. Per §4.2.
+ */
+async function compensateSucceededLink(
+  db: AnyDrizzleDb,
+  entry: {
+    link: typeof channelBookingLinks.$inferSelect
+    channel: typeof channels.$inferSelect
+    adapter: SourceAdapter
+    adapterCtx: SourceAdapterContext
+    upstreamRef: string
+  },
+  bookingId: string,
+  logger: {
+    error?: (message: string, meta?: Record<string, unknown>) => void
+    warn?: (message: string, meta?: Record<string, unknown>) => void
+  },
+): Promise<boolean> {
+  let cancelError: string | null = null
+  if (entry.adapter.cancel) {
+    const envelope = await prepareOutboundEnvelope(db, {
+      sourceModule: "distribution",
+      sourceEvent: "channel.booking.compensate",
+      sourceEntityModule: "bookings",
+      sourceEntityId: bookingId,
+      targetUrl: `adapter:${entry.adapter.kind}`,
+      targetKind: `channel:${entry.adapter.kind}`,
+      targetRef: entry.channel.id,
+      requestMethod: "POST",
+      requestBody: { upstream_ref: entry.upstreamRef, reason: "channel-push-compensation" },
+      attemptNumber: 1,
+      idempotencyKey: `compensate:${entry.link.id}`,
+    })
+    try {
+      const result = await entry.adapter.cancel(entry.adapterCtx, {
+        upstream_ref: entry.upstreamRef,
+        reason: "channel-push-compensation",
+      })
+      await envelope.complete({ responseStatus: 200, responseBody: result })
+    } catch (err) {
+      cancelError = err instanceof Error ? err.message : String(err)
+      await envelope.complete({ errorClass: "adapter_error", errorMessage: cancelError })
+      logger.warn?.(`compensateSucceededLink: cancel failed for ${entry.link.id}`, {
+        error: cancelError,
+      })
+    }
+  } else {
+    cancelError = "adapter does not implement cancel"
+    logger.warn?.(`compensateSucceededLink: ${entry.adapter.kind} has no cancel method`, {
+      linkId: entry.link.id,
+    })
+  }
+
+  const now = new Date()
+  await db
+    .update(channelBookingLinks)
+    .set({
+      pushStatus: "compensated",
+      lastPushAt: now,
+      lastError: cancelError,
+      updatedAt: now,
+    })
+    .where(eq(channelBookingLinks.id, entry.link.id))
+  return true
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/distribution/src/channel-push/content-push.ts
+++ b/packages/distribution/src/channel-push/content-push.ts
@@ -11,12 +11,16 @@
  * Per docs/architecture/channel-push-architecture.md §6 + §12.3.
  */
 
-import type { PushContentRequest, SourceAdapterContext } from "@voyantjs/catalog"
+import {
+  AdapterRateLimitedError,
+  type PushContentRequest,
+  type SourceAdapterContext,
+} from "@voyantjs/catalog"
 import type { AnyDrizzleDb } from "@voyantjs/db"
 import { newId } from "@voyantjs/db/lib/typeid"
 import { products } from "@voyantjs/products/schema"
 import { and, asc, eq, sql } from "drizzle-orm"
-import { acquireToken, channelScopeKey, type RateLimitConfig } from "../rate-limit.js"
+import { acquireToken, channelScopeKey, drainBucket, type RateLimitConfig } from "../rate-limit.js"
 import { channelContentPushIntents, channelProductMappings, channels } from "../schema.js"
 import { prepareOutboundEnvelope } from "../webhook-deliveries.js"
 
@@ -258,7 +262,18 @@ export async function processContentPushIntents(
       succeeded += 1
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
-      await envelope.complete({ errorClass: "adapter_error", errorMessage: message })
+      const isRateLimited = err instanceof AdapterRateLimitedError
+      if (isRateLimited) {
+        await drainBucket(
+          db,
+          channelScopeKey(channel.id, intent.sourceConnectionId),
+          err.retryAfterMs,
+        )
+      }
+      await envelope.complete({
+        errorClass: isRateLimited ? "rate_limited" : "adapter_error",
+        errorMessage: message,
+      })
       await stampIntentError(db, intent.id, intent.attempts + 1, message)
       failed += 1
       logger.error?.(`pushContent failed for product ${intent.productId} channel ${channel.id}`, {

--- a/packages/distribution/src/channel-push/index.ts
+++ b/packages/distribution/src/channel-push/index.ts
@@ -59,3 +59,12 @@ export {
   getChannelPushDepsOrThrow,
   setChannelPushDeps,
 } from "./types.js"
+// Importing this module registers all three durable workflows in the
+// process-local @voyantjs/workflows registry. Hosts that don't run an
+// orchestrator (e.g. the operator template's inline drain) can still
+// import safely — registration is a no-op without a runtime to dispatch.
+export {
+  channelAvailabilityPushWorkflow,
+  channelBookingPushWorkflow,
+  channelContentPushWorkflow,
+} from "./workflows.js"

--- a/packages/distribution/src/channel-push/index.ts
+++ b/packages/distribution/src/channel-push/index.ts
@@ -5,6 +5,10 @@
  */
 
 export {
+  type ChannelPushAdminRoutes,
+  createChannelPushAdminRoutes,
+} from "./admin-routes.js"
+export {
   CHANNEL_AVAILABILITY_PUSH_WORKFLOW_ID,
   type ProcessAvailabilityPushInput,
   type ProcessAvailabilityPushResult,

--- a/packages/distribution/src/channel-push/workflows.ts
+++ b/packages/distribution/src/channel-push/workflows.ts
@@ -1,0 +1,129 @@
+/**
+ * Durable channel-push workflows.
+ *
+ * Wraps the inline-callable processors (`processBookingPush`,
+ * `processAvailabilityPushIntents`, `processContentPushIntents`) in
+ * `@voyantjs/workflows` definitions so retries, sleeps, and resumption
+ * survive worker restarts. Importing this module registers the
+ * workflows in the global registry — Voyant Cloud orchestrator picks
+ * them up automatically.
+ *
+ * The workflow bodies look up `ChannelPushDeps` from the process-local
+ * holder set via `setChannelPushDeps`. Hosts wire deps at bootstrap;
+ * the orchestrator's Node container reads from the same global since
+ * it runs in the same isolate that loaded the user bundle.
+ *
+ * Dev / single-process deployments (e.g. the operator template's
+ * inline drain) don't need to register these — the subscriber calls the
+ * processors directly. Production deployments with the Voyant Cloud
+ * orchestrator wired import this module to opt into durability.
+ *
+ * Per docs/architecture/channel-push-architecture.md §4.2 + §12.
+ */
+
+import { workflow } from "@voyantjs/workflows"
+
+import {
+  CHANNEL_AVAILABILITY_PUSH_WORKFLOW_ID,
+  type ProcessAvailabilityPushInput,
+  type ProcessAvailabilityPushResult,
+  processAvailabilityPushIntents,
+} from "./availability-push.js"
+import {
+  CHANNEL_BOOKING_PUSH_WORKFLOW_ID,
+  type ProcessBookingPushInput,
+  type ProcessBookingPushResult,
+  processBookingPush,
+} from "./booking-push.js"
+import {
+  CHANNEL_CONTENT_PUSH_WORKFLOW_ID,
+  type ProcessContentPushInput,
+  type ProcessContentPushResult,
+  processContentPushIntents,
+} from "./content-push.js"
+
+/**
+ * Per-booking saga workflow with compensation support.
+ *
+ * Concurrency is keyed by `bookingId` so two confirms of the same
+ * booking serialize (which can't actually happen given the booking
+ * state machine, but the perKey lock is cheap insurance). Retries on
+ * exponential backoff up to 5 attempts; the per-link compensation pass
+ * inside `processBookingPush` handles strict-atomic policy when
+ * `channel_contracts.policy.compensation = "strict-atomic"`.
+ *
+ * Per §4.2 + §12.1.
+ */
+export const channelBookingPushWorkflow = workflow<
+  ProcessBookingPushInput,
+  ProcessBookingPushResult
+>({
+  id: CHANNEL_BOOKING_PUSH_WORKFLOW_ID,
+  description: "Drain pending channel_booking_links and push to upstream channels",
+  retry: { backoff: "exponential", max: 5, initial: "5s", maxDelay: "5m" },
+  timeout: "1h",
+  concurrency: {
+    key: (input) => input.bookingId,
+    limit: 1,
+    strategy: "queue",
+  },
+  tags: ["channel-push", "booking"],
+  async run(input, ctx) {
+    return await ctx.step("process-booking-push", () => processBookingPush(input))
+  },
+})
+
+/**
+ * Scheduled batch worker for availability push. Runs every 30 seconds
+ * (tunable per channel via policy in a future iteration); each tick
+ * drains up to 100 pending intents, capped at one concurrent run per
+ * channel. Idempotency is upstream-side via `(slot_id, remaining_pax)`.
+ *
+ * Per §5.3 + §12.2.
+ */
+export const channelAvailabilityPushWorkflow = workflow<
+  ProcessAvailabilityPushInput,
+  ProcessAvailabilityPushResult
+>({
+  id: CHANNEL_AVAILABILITY_PUSH_WORKFLOW_ID,
+  description: "Drain channel_availability_push_intents per channel",
+  schedule: { every: "30s" },
+  retry: { backoff: "exponential", max: 3, initial: "10s" },
+  timeout: "5m",
+  concurrency: {
+    key: (input) => input.channelId ?? "all",
+    limit: 1,
+    strategy: "queue",
+  },
+  tags: ["channel-push", "availability"],
+  async run(input, ctx) {
+    return await ctx.step("process-availability-push", () => processAvailabilityPushIntents(input))
+  },
+})
+
+/**
+ * Scheduled batch worker for content push. Longer cadence (5m) since
+ * content drift is rarely time-critical; idempotency via the upstream's
+ * acknowledged-hash skip in `processContentPushIntents`.
+ *
+ * Per §6 + §12.3.
+ */
+export const channelContentPushWorkflow = workflow<
+  ProcessContentPushInput,
+  ProcessContentPushResult
+>({
+  id: CHANNEL_CONTENT_PUSH_WORKFLOW_ID,
+  description: "Drain channel_content_push_intents per channel",
+  schedule: { every: "5m" },
+  retry: { backoff: "exponential", max: 3, initial: "30s" },
+  timeout: "5m",
+  concurrency: {
+    key: (input) => input.channelId ?? "all",
+    limit: 1,
+    strategy: "queue",
+  },
+  tags: ["channel-push", "content"],
+  async run(input, ctx) {
+    return await ctx.step("process-content-push", () => processContentPushIntents(input))
+  },
+})

--- a/packages/distribution/src/index.ts
+++ b/packages/distribution/src/index.ts
@@ -175,6 +175,8 @@ export {
   type OutboundEnvelopeResultInput,
   type PreparedEnvelope,
   prepareOutboundEnvelope,
+  redactBodyPii,
   redactHeaders,
+  redactStringPii,
 } from "./webhook-deliveries.js"
 export { distributionService }

--- a/packages/distribution/src/webhook-deliveries.ts
+++ b/packages/distribution/src/webhook-deliveries.ts
@@ -44,6 +44,53 @@ const REDACTED_HEADERS = new Set([
 
 const REDACTION_MARKER = "[REDACTED]"
 
+/**
+ * Body-key names that always redact (case-insensitive). Every match is
+ * replaced with `[REDACTED]` regardless of value type. Per §11.3 — PII
+ * redaction is a library guarantee, not caller discipline.
+ */
+const REDACTED_BODY_KEYS = new Set([
+  // Auth
+  "password",
+  "secret",
+  "token",
+  "accesstoken",
+  "refreshtoken",
+  "apikey",
+  "apitoken",
+  "authorization",
+  // Personal identifiers
+  "email",
+  "phone",
+  "phonenumber",
+  "mobile",
+  "ssn",
+  "passport",
+  "passportnumber",
+  "documentnumber",
+  "nationalid",
+  "taxid",
+  "dob",
+  "dateofbirth",
+  "birthdate",
+  // Payment
+  "cardnumber",
+  "pan",
+  "cvv",
+  "cvc",
+  "iban",
+  "bic",
+  "accountnumber",
+  // Booking-traveler shapes
+  "firstname",
+  "lastname",
+  "fullname",
+  "middlename",
+])
+
+const EMAIL_PATTERN = /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/gi
+const PHONE_PATTERN = /\+?\d[\d\s().-]{6,}\d/g
+
 export interface OutboundEnvelopeInput {
   // ── Provenance ────────────────────────────────────────────────────
   sourceModule: string
@@ -194,12 +241,12 @@ function excerptBody(body: unknown, max = DEFAULT_EXCERPT_BYTES): string | null 
   if (body == null) return null
   let text: string
   if (typeof body === "string") {
-    text = body
+    text = redactStringPii(body)
   } else if (body instanceof ArrayBuffer || ArrayBuffer.isView(body)) {
     text = "[binary]"
   } else {
     try {
-      text = JSON.stringify(body)
+      text = JSON.stringify(redactBodyPii(body))
     } catch {
       text = "[unserializable]"
     }
@@ -208,6 +255,42 @@ function excerptBody(body: unknown, max = DEFAULT_EXCERPT_BYTES): string | null 
     return `${text.slice(0, max - 1)}…`
   }
   return text
+}
+
+/**
+ * Recursively redact PII from a JSON-serializable body. Every key whose
+ * lowercased name matches `REDACTED_BODY_KEYS` is replaced with
+ * `[REDACTED]`; remaining string values get email/phone shapes
+ * scrubbed. This protects channel-push booking payloads (which carry
+ * traveler contact info) from leaking into the delivery log per §11.3.
+ *
+ * Exported for callers that want to redact bodies before passing them
+ * to other sinks (logs, error reporters).
+ */
+export function redactBodyPii(value: unknown): unknown {
+  if (value == null) return value
+  if (typeof value === "string") return redactStringPii(value)
+  if (typeof value !== "object") return value
+  if (Array.isArray(value)) return value.map(redactBodyPii)
+  const out: Record<string, unknown> = {}
+  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+    const normalized = key.toLowerCase().replace(/[_-]/g, "")
+    if (REDACTED_BODY_KEYS.has(normalized)) {
+      out[key] = REDACTION_MARKER
+    } else {
+      out[key] = redactBodyPii(raw)
+    }
+  }
+  return out
+}
+
+/**
+ * Scrub email/phone shapes from a free-text string. The patterns are
+ * coarse on purpose — false positives (e.g. a phone-shaped tracking id)
+ * are preferable to leaks.
+ */
+export function redactStringPii(text: string): string {
+  return text.replace(EMAIL_PATTERN, REDACTION_MARKER).replace(PHONE_PATTERN, REDACTION_MARKER)
 }
 
 /**

--- a/packages/distribution/tests/unit/webhook-deliveries.test.ts
+++ b/packages/distribution/tests/unit/webhook-deliveries.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { redactHeaders } from "../../src/webhook-deliveries.js"
+import { redactBodyPii, redactHeaders, redactStringPii } from "../../src/webhook-deliveries.js"
 
 describe("redactHeaders", () => {
   it("returns null for undefined", () => {
@@ -38,5 +38,72 @@ describe("redactHeaders", () => {
 
   it("returns an empty object for empty input (not null)", () => {
     expect(redactHeaders({})).toEqual({})
+  })
+})
+
+describe("redactBodyPii", () => {
+  it("redacts known PII keys regardless of casing or separators", () => {
+    const out = redactBodyPii({
+      bookingId: "book_123",
+      firstName: "Mihai",
+      last_name: "Doe",
+      email: "mihai@example.com",
+      phoneNumber: "+40712345678",
+      cardNumber: "4111111111111111",
+      passport_number: "AB123456",
+    }) as Record<string, unknown>
+    expect(out.bookingId).toBe("book_123")
+    expect(out.firstName).toBe("[REDACTED]")
+    expect(out.last_name).toBe("[REDACTED]")
+    expect(out.email).toBe("[REDACTED]")
+    expect(out.phoneNumber).toBe("[REDACTED]")
+    expect(out.cardNumber).toBe("[REDACTED]")
+    expect(out.passport_number).toBe("[REDACTED]")
+  })
+
+  it("recurses into nested objects and arrays", () => {
+    const out = redactBodyPii({
+      booking: {
+        travelers: [
+          { firstName: "A", lastName: "B", email: "a@b.com" },
+          { firstName: "C", lastName: "D", email: "c@d.com" },
+        ],
+      },
+    }) as { booking: { travelers: Array<Record<string, unknown>> } }
+    expect(out.booking.travelers).toHaveLength(2)
+    expect(out.booking.travelers[0]?.firstName).toBe("[REDACTED]")
+    expect(out.booking.travelers[1]?.email).toBe("[REDACTED]")
+  })
+
+  it("scrubs email and phone shapes from free-text values", () => {
+    const out = redactBodyPii({
+      notes: "Contact me at john@example.com or +1 555 123 4567 please",
+      label: "no PII here",
+    }) as Record<string, string>
+    expect(out.notes).not.toContain("john@example.com")
+    expect(out.notes).not.toContain("+1 555 123 4567")
+    expect(out.notes).toContain("[REDACTED]")
+    expect(out.label).toBe("no PII here")
+  })
+
+  it("passes through primitives untouched", () => {
+    expect(redactBodyPii(42)).toBe(42)
+    expect(redactBodyPii(true)).toBe(true)
+    expect(redactBodyPii(null)).toBe(null)
+    expect(redactBodyPii(undefined)).toBe(undefined)
+  })
+})
+
+describe("redactStringPii", () => {
+  it("redacts emails", () => {
+    expect(redactStringPii("Send to bob+filter@a.co please")).toBe("Send to [REDACTED] please")
+  })
+
+  it("redacts phone-shaped numbers", () => {
+    expect(redactStringPii("Call +40 712 345 678")).toBe("Call [REDACTED]")
+  })
+
+  it("leaves unrelated text alone", () => {
+    expect(redactStringPii("booking #book_abc confirmed")).toBe("booking #book_abc confirmed")
   })
 })

--- a/packages/plugins/catalog-demo/src/adapter.ts
+++ b/packages/plugins/catalog-demo/src/adapter.ts
@@ -8,27 +8,28 @@
  * Mirrors the shape of `@voyantjs/plugin-flights-demo` for `flights`.
  */
 
-import type {
-  AdapterCapabilities,
-  CancelRequest,
-  CancelResult,
-  ConnectionState,
-  DiscoveryCursor,
-  DiscoveryPage,
-  GetContentRequest,
-  GetContentResult,
-  LiveResolveRequest,
-  LiveResolveResult,
-  PushAvailabilityRequest,
-  PushAvailabilityResult,
-  PushBookingRequest,
-  PushBookingResult,
-  PushContentRequest,
-  PushContentResult,
-  ReserveRequest,
-  ReserveResult,
-  SourceAdapter,
-  SourceAdapterContext,
+import {
+  type AdapterCapabilities,
+  AdapterRateLimitedError,
+  type CancelRequest,
+  type CancelResult,
+  type ConnectionState,
+  type DiscoveryCursor,
+  type DiscoveryPage,
+  type GetContentRequest,
+  type GetContentResult,
+  type LiveResolveRequest,
+  type LiveResolveResult,
+  type PushAvailabilityRequest,
+  type PushAvailabilityResult,
+  type PushBookingRequest,
+  type PushBookingResult,
+  type PushContentRequest,
+  type PushContentResult,
+  type ReserveRequest,
+  type ReserveResult,
+  type SourceAdapter,
+  type SourceAdapterContext,
 } from "@voyantjs/catalog"
 
 /** Stable kind identifier emitted as `source.kind` on every projection. */
@@ -97,6 +98,14 @@ export function createDemoCatalogAdapter(options: DemoCatalogAdapterOptions): So
       })
       const text = await response.text()
       const data = text ? (JSON.parse(text) as unknown) : undefined
+      // Surface 429 distinctly so the channel-push pipeline can drain
+      // its rate-limit bucket per the upstream's Retry-After hint.
+      if (response.status === 429) {
+        const retryAfterRaw = response.headers.get("Retry-After")
+        const retryAfterSec = retryAfterRaw ? Number.parseInt(retryAfterRaw, 10) : 60
+        const retryAfterMs = (Number.isFinite(retryAfterSec) ? retryAfterSec : 60) * 1000
+        throw new AdapterRateLimitedError(DEMO_SOURCE_KIND, retryAfterMs, path, data)
+      }
       if (!response.ok) {
         const detail =
           data && typeof data === "object" && "error" in data && typeof data.error === "string"

--- a/packages/products/src/routes.ts
+++ b/packages/products/src/routes.ts
@@ -397,9 +397,10 @@ export const productRoutes = new Hono<Env>()
   })
 
   .post("/:id/features", async (c) => {
+    const productId = c.req.param("id")
     const row = await productsService.createFeature(
       c.get("db"),
-      c.req.param("id"),
+      productId,
       await parseJsonBody(c, insertProductFeatureSchema),
     )
 
@@ -407,6 +408,7 @@ export const productRoutes = new Hono<Env>()
       return c.json({ error: "Product not found" }, 404)
     }
 
+    await emitProductContentChanged(c.get("eventBus"), { id: productId, axis: "feature" })
     return c.json({ data: row }, 201)
   })
 
@@ -421,6 +423,9 @@ export const productRoutes = new Hono<Env>()
       return c.json({ error: "Product feature not found" }, 404)
     }
 
+    if (row.productId) {
+      await emitProductContentChanged(c.get("eventBus"), { id: row.productId, axis: "feature" })
+    }
     return c.json({ data: row })
   })
 
@@ -431,6 +436,9 @@ export const productRoutes = new Hono<Env>()
       return c.json({ error: "Product feature not found" }, 404)
     }
 
+    if ("productId" in row && typeof row.productId === "string") {
+      await emitProductContentChanged(c.get("eventBus"), { id: row.productId, axis: "feature" })
+    }
     return c.json({ success: true }, 200)
   })
 
@@ -449,9 +457,10 @@ export const productRoutes = new Hono<Env>()
   })
 
   .post("/:id/faqs", async (c) => {
+    const productId = c.req.param("id")
     const row = await productsService.createFaq(
       c.get("db"),
-      c.req.param("id"),
+      productId,
       await parseJsonBody(c, insertProductFaqSchema),
     )
 
@@ -459,6 +468,7 @@ export const productRoutes = new Hono<Env>()
       return c.json({ error: "Product not found" }, 404)
     }
 
+    await emitProductContentChanged(c.get("eventBus"), { id: productId, axis: "faq" })
     return c.json({ data: row }, 201)
   })
 
@@ -473,6 +483,9 @@ export const productRoutes = new Hono<Env>()
       return c.json({ error: "Product FAQ not found" }, 404)
     }
 
+    if (row.productId) {
+      await emitProductContentChanged(c.get("eventBus"), { id: row.productId, axis: "faq" })
+    }
     return c.json({ data: row })
   })
 
@@ -481,6 +494,9 @@ export const productRoutes = new Hono<Env>()
 
     if (!row) {
       return c.json({ error: "Product FAQ not found" }, 404)
+    }
+    if ("productId" in row && typeof row.productId === "string") {
+      await emitProductContentChanged(c.get("eventBus"), { id: row.productId, axis: "faq" })
     }
 
     return c.json({ success: true }, 200)
@@ -501,9 +517,10 @@ export const productRoutes = new Hono<Env>()
   })
 
   .post("/:id/locations", async (c) => {
+    const productId = c.req.param("id")
     const row = await productsService.createLocation(
       c.get("db"),
-      c.req.param("id"),
+      productId,
       await parseJsonBody(c, insertProductLocationSchema),
     )
 
@@ -511,6 +528,7 @@ export const productRoutes = new Hono<Env>()
       return c.json({ error: "Product not found" }, 404)
     }
 
+    await emitProductContentChanged(c.get("eventBus"), { id: productId, axis: "location" })
     return c.json({ data: row }, 201)
   })
 
@@ -525,6 +543,9 @@ export const productRoutes = new Hono<Env>()
       return c.json({ error: "Product location not found" }, 404)
     }
 
+    if (row.productId) {
+      await emitProductContentChanged(c.get("eventBus"), { id: row.productId, axis: "location" })
+    }
     return c.json({ data: row })
   })
 
@@ -535,6 +556,9 @@ export const productRoutes = new Hono<Env>()
       return c.json({ error: "Product location not found" }, 404)
     }
 
+    if ("productId" in row && typeof row.productId === "string") {
+      await emitProductContentChanged(c.get("eventBus"), { id: row.productId, axis: "location" })
+    }
     return c.json({ success: true }, 200)
   })
 
@@ -634,9 +658,10 @@ export const productRoutes = new Hono<Env>()
   })
 
   .post("/:id/destinations", async (c) => {
+    const productId = c.req.param("id")
     const row = await productsService.assignProductDestination(
       c.get("db"),
-      c.req.param("id"),
+      productId,
       await parseJsonBody(c, insertProductDestinationSchema),
     )
 
@@ -644,13 +669,15 @@ export const productRoutes = new Hono<Env>()
       return c.json({ error: "Product or destination not found" }, 404)
     }
 
+    await emitProductContentChanged(c.get("eventBus"), { id: productId, axis: "destination" })
     return c.json({ data: row }, 201)
   })
 
   .delete("/:id/destinations/:destinationId", async (c) => {
+    const productId = c.req.param("id")
     const row = await productsService.removeProductDestination(
       c.get("db"),
-      c.req.param("id"),
+      productId,
       c.req.param("destinationId"),
     )
 
@@ -658,6 +685,7 @@ export const productRoutes = new Hono<Env>()
       return c.json({ error: "Product destination link not found" }, 404)
     }
 
+    await emitProductContentChanged(c.get("eventBus"), { id: productId, axis: "destination" })
     return c.json({ success: true }, 200)
   })
 
@@ -711,6 +739,9 @@ export const productRoutes = new Hono<Env>()
       return c.json({ error: "Product option not found" }, 404)
     }
 
+    if (row.productId) {
+      await emitProductContentChanged(c.get("eventBus"), { id: row.productId, axis: "option" })
+    }
     return c.json({ data: row })
   })
 
@@ -722,6 +753,9 @@ export const productRoutes = new Hono<Env>()
       return c.json({ error: "Product option not found" }, 404)
     }
 
+    if ("productId" in row && typeof row.productId === "string") {
+      await emitProductContentChanged(c.get("eventBus"), { id: row.productId, axis: "option" })
+    }
     return c.json({ success: true }, 200)
   })
 
@@ -810,9 +844,10 @@ export const productRoutes = new Hono<Env>()
   })
 
   .post("/:id/translations", async (c) => {
+    const productId = c.req.param("id")
     const row = await productsService.createProductTranslation(
       c.get("db"),
-      c.req.param("id"),
+      productId,
       await parseJsonBody(c, insertProductTranslationSchema),
     )
 
@@ -820,6 +855,7 @@ export const productRoutes = new Hono<Env>()
       return c.json({ error: "Product not found" }, 404)
     }
 
+    await emitProductContentChanged(c.get("eventBus"), { id: productId, axis: "translation" })
     return c.json({ data: row }, 201)
   })
 
@@ -834,6 +870,12 @@ export const productRoutes = new Hono<Env>()
       return c.json({ error: "Product translation not found" }, 404)
     }
 
+    if (row.productId) {
+      await emitProductContentChanged(c.get("eventBus"), {
+        id: row.productId,
+        axis: "translation",
+      })
+    }
     return c.json({ data: row })
   })
 
@@ -847,6 +889,12 @@ export const productRoutes = new Hono<Env>()
       return c.json({ error: "Product translation not found" }, 404)
     }
 
+    if ("productId" in row && typeof row.productId === "string") {
+      await emitProductContentChanged(c.get("eventBus"), {
+        id: row.productId,
+        axis: "translation",
+      })
+    }
     return c.json({ success: true }, 200)
   })
 
@@ -1457,9 +1505,10 @@ export const productRoutes = new Hono<Env>()
 
   // DELETE /:id/days/:dayId/services/:serviceId — Delete service
   .delete("/:id/days/:dayId/services/:serviceId", async (c) => {
+    const productId = c.req.param("id")
     const row = await productsService.deleteDayService(
       c.get("db"),
-      c.req.param("id"),
+      productId,
       c.req.param("serviceId"),
     )
 
@@ -1467,6 +1516,7 @@ export const productRoutes = new Hono<Env>()
       return c.json({ error: "Service not found" }, 404)
     }
 
+    await emitProductContentChanged(c.get("eventBus"), { id: productId, axis: "day" })
     return c.json({ success: true }, 200)
   })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2024,6 +2024,9 @@ importers:
       '@voyantjs/suppliers':
         specifier: workspace:*
         version: link:../suppliers
+      '@voyantjs/workflows':
+        specifier: workspace:*
+        version: link:../workflows
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -48,7 +48,7 @@ import { mountCatalogBookingRoutes } from "./catalog-booking"
 import { catalogBridgeBundle } from "./catalog-bridge"
 import { mountCatalogContentRoutes } from "./catalog-content"
 import { mountCatalogSearchRoutes } from "./catalog-search"
-import { channelPushBundle } from "./channel-push"
+import { channelPushBundle, mountChannelPushAdminRoutes } from "./channel-push"
 import { mountFlightRoutes } from "./flights"
 import { createInvitationsRoutes } from "./invitations"
 import { getDbFromHyperdrive } from "./lib/db"
@@ -460,6 +460,7 @@ export const app = createApp<CloudflareBindings>({
     mountCatalogSearchRoutes(hono)
     mountCatalogBookingRoutes(hono)
     mountCatalogContentRoutes(hono)
+    mountChannelPushAdminRoutes(hono)
     mountFlightRoutes(hono)
   },
 })

--- a/templates/operator/src/api/channel-push.ts
+++ b/templates/operator/src/api/channel-push.ts
@@ -19,17 +19,20 @@
  */
 
 import {
+  createChannelPushAdminRoutes,
   processAvailabilityPushIntents,
   processBookingPush,
   processContentPushIntents,
   resolveAllotmentTargetsForSlot,
   resolveBookingPushTargets,
   resolveContentPushTargets,
+  setChannelPushDeps,
   upsertAvailabilityIntent,
   upsertContentIntent,
   upsertPendingBookingLinks,
 } from "@voyantjs/distribution/channel-push"
 import type { HonoBundle } from "@voyantjs/hono/plugin"
+import type { Hono } from "hono"
 
 import { type BookingEngineEnv, getBookingEngineRegistry } from "./lib/booking-engine-runtime"
 import { getDbFromHyperdrive } from "./lib/db"
@@ -151,4 +154,28 @@ export const channelPushBundle: HonoBundle = {
       },
     )
   },
+}
+
+/**
+ * Mount the channel-push admin API at
+ * `/v1/admin/distribution/channel-push/*`. The operator dashboard's
+ * "channel sync" view consumes these endpoints.
+ *
+ * Wires `setChannelPushDeps` per-request — the admin routes
+ * (`triggerBookingPushForBooking` and the reconciler triggers) read
+ * deps via `getChannelPushDepsOrThrow`, so this hop makes Workers'
+ * per-request DB binding play nicely with the global holder.
+ *
+ * Per docs/architecture/channel-push-architecture.md §9 + §14.5.
+ */
+export function mountChannelPushAdminRoutes(hono: Hono): void {
+  hono.use("/v1/admin/distribution/channel-push/*", async (c, next) => {
+    const env = c.env as CloudflareBindings & BookingEngineEnv
+    setChannelPushDeps({
+      db: getDbFromHyperdrive(env),
+      registry: getBookingEngineRegistry(env),
+    })
+    await next()
+  })
+  hono.route("/v1/admin/distribution/channel-push", createChannelPushAdminRoutes())
 }

--- a/templates/operator/src/components/navigation/app-sidebar.tsx
+++ b/templates/operator/src/components/navigation/app-sidebar.tsx
@@ -17,6 +17,7 @@ import {
   Mail,
   Package,
   Plane,
+  Radio,
   Scale,
   Settings,
   Users,
@@ -181,6 +182,12 @@ export function AppSidebar({ user, ...props }: AppSidebarProps) {
           url: "/legal/number-series",
         },
       ],
+    },
+    {
+      id: "channel-sync",
+      title: "Channel sync",
+      url: "/channel-sync",
+      icon: Radio,
     },
     {
       id: "settings",

--- a/templates/operator/src/components/voyant/channel-sync/channel-sync-page.tsx
+++ b/templates/operator/src/components/voyant/channel-sync/channel-sync-page.tsx
@@ -1,0 +1,560 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Sheet,
+  SheetBody,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@voyantjs/ui/components"
+import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@voyantjs/ui/components/empty"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@voyantjs/ui/components/table"
+import { AlertTriangle, Loader2, RefreshCw, RotateCw } from "lucide-react"
+import { useState } from "react"
+
+import { getApiUrl } from "@/lib/env"
+
+// ── Types matching the admin API at distribution/src/channel-push/admin-routes.ts
+
+interface ChannelBookingLinkRow {
+  link: {
+    id: string
+    channelId: string
+    bookingId: string
+    bookingItemId: string | null
+    sourceKind: string | null
+    sourceConnectionId: string | null
+    pushStatus: string
+    pushAttempts: number
+    lastPushAt: string | null
+    lastError: string | null
+    externalBookingId: string | null
+    externalReference: string | null
+    externalStatus: string | null
+    createdAt: string
+  }
+  channelName: string
+  channelKind: string
+}
+
+interface LinksResponse {
+  data: ChannelBookingLinkRow[]
+  counts: Record<string, number>
+}
+
+interface DeliveryRow {
+  id: string
+  sourceModule: string
+  sourceEvent: string
+  sourceEntityId: string | null
+  targetUrl: string
+  targetKind: string | null
+  targetRef: string | null
+  requestMethod: string
+  responseStatus: number | null
+  responseBodyExcerpt: string | null
+  attemptNumber: number
+  status: string
+  errorClass: string | null
+  errorMessage: string | null
+  durationMs: number | null
+  createdAt: string
+}
+
+interface DeliveriesResponse {
+  data: DeliveryRow[]
+}
+
+interface ThrottlingRow {
+  channelId: string | null
+  count: number
+}
+
+interface ThrottlingResponse {
+  data: ThrottlingRow[]
+  sinceMs: number
+}
+
+interface ReconcilerResult {
+  scanned: number
+  triggered: number
+}
+
+// ── Fetch helpers
+
+async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${getApiUrl()}${path}`, {
+    credentials: "include",
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...init?.headers,
+    },
+  })
+  const text = await res.text()
+  const body = text
+    ? (JSON.parse(text) as { data?: T; error?: string })
+    : ({} as { error?: string })
+  if (!res.ok) {
+    throw new Error(body.error ?? `Request failed: ${res.status}`)
+  }
+  return body as T
+}
+
+const STATUS_VARIANTS: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
+  pending: "secondary",
+  ok: "default",
+  failed: "destructive",
+  compensated: "outline",
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  pending: "Pending",
+  ok: "OK",
+  failed: "Failed",
+  compensated: "Compensated",
+}
+
+// ── Page
+
+export function ChannelSyncPage() {
+  const [statusFilter, setStatusFilter] = useState<string>("all")
+  const [bookingFilter, setBookingFilter] = useState("")
+  const [channelFilter, setChannelFilter] = useState("")
+  const [drilldownBookingId, setDrilldownBookingId] = useState<string | null>(null)
+
+  const queryClient = useQueryClient()
+
+  const linksQuery = useQuery<LinksResponse>({
+    queryKey: ["channel-push-links", statusFilter, bookingFilter, channelFilter],
+    queryFn: () => {
+      const params = new URLSearchParams({ limit: "100" })
+      if (statusFilter !== "all") params.set("status", statusFilter)
+      if (bookingFilter.trim()) params.set("bookingId", bookingFilter.trim())
+      if (channelFilter.trim()) params.set("channelId", channelFilter.trim())
+      return fetchJson<LinksResponse>(`/v1/admin/distribution/channel-push/links?${params}`)
+    },
+    refetchInterval: 30_000,
+  })
+
+  const throttlingQuery = useQuery<ThrottlingResponse>({
+    queryKey: ["channel-push-throttling"],
+    queryFn: () => fetchJson<ThrottlingResponse>("/v1/admin/distribution/channel-push/throttling"),
+    refetchInterval: 60_000,
+  })
+
+  const retryMutation = useMutation({
+    mutationFn: (bookingId: string) =>
+      fetchJson<{ ok: boolean; bookingId: string }>(
+        `/v1/admin/distribution/channel-push/retry/${bookingId}`,
+        { method: "POST" },
+      ),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["channel-push-links"] })
+    },
+  })
+
+  const reconcileMutation = useMutation({
+    mutationFn: (flow: "bookings" | "availability" | "content") =>
+      fetchJson<ReconcilerResult>(`/v1/admin/distribution/channel-push/reconcile/${flow}`, {
+        method: "POST",
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["channel-push-links"] })
+    },
+  })
+
+  const counts = linksQuery.data?.counts ?? {}
+  const rows = linksQuery.data?.data ?? []
+  const throttledChannels = throttlingQuery.data?.data ?? []
+  const isThrottled = throttledChannels.length > 0
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold tracking-tight">Channel sync</h2>
+          <p className="text-sm text-muted-foreground">
+            Monitor outbound pushes to syndication channels. Bookings flow first; availability and
+            content pushes happen in the background.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={reconcileMutation.isPending}
+            onClick={() => reconcileMutation.mutate("bookings")}
+          >
+            <RotateCw className="mr-1.5 h-3.5 w-3.5" />
+            Reconcile bookings
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={reconcileMutation.isPending}
+            onClick={() => reconcileMutation.mutate("availability")}
+          >
+            <RotateCw className="mr-1.5 h-3.5 w-3.5" />
+            Availability
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={reconcileMutation.isPending}
+            onClick={() => reconcileMutation.mutate("content")}
+          >
+            <RotateCw className="mr-1.5 h-3.5 w-3.5" />
+            Content
+          </Button>
+        </div>
+      </div>
+
+      {/* Status tiles */}
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        <StatusTile label="Pending" value={counts.pending ?? 0} tone="secondary" />
+        <StatusTile label="OK" value={counts.ok ?? 0} tone="default" />
+        <StatusTile label="Failed" value={counts.failed ?? 0} tone="destructive" />
+        <StatusTile label="Compensated" value={counts.compensated ?? 0} tone="outline" />
+      </div>
+
+      {isThrottled ? (
+        <div className="flex items-center gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200">
+          <AlertTriangle className="h-4 w-4" />
+          <span className="font-medium">Throttled.</span>
+          <span>
+            {throttledChannels.reduce((sum, c) => sum + c.count, 0)} rate-limited deliveries in the
+            last hour across {throttledChannels.length} channel
+            {throttledChannels.length === 1 ? "" : "s"}. Lower the per-channel RPS in settings if
+            this persists.
+          </span>
+        </div>
+      ) : null}
+
+      {/* Filters */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm">Filter</CardTitle>
+          <CardDescription>
+            Narrow the list to a specific status, channel, or booking.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-3 md:grid-cols-3">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="cs-status" className="text-xs">
+                Status
+              </Label>
+              <Select
+                value={statusFilter}
+                onValueChange={(value) => setStatusFilter(value ?? "all")}
+              >
+                <SelectTrigger id="cs-status">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All statuses</SelectItem>
+                  <SelectItem value="pending">Pending</SelectItem>
+                  <SelectItem value="ok">OK</SelectItem>
+                  <SelectItem value="failed">Failed</SelectItem>
+                  <SelectItem value="compensated">Compensated</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="cs-booking" className="text-xs">
+                Booking ID
+              </Label>
+              <Input
+                id="cs-booking"
+                value={bookingFilter}
+                onChange={(e) => setBookingFilter(e.target.value)}
+                placeholder="book_…"
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="cs-channel" className="text-xs">
+                Channel ID
+              </Label>
+              <Input
+                id="cs-channel"
+                value={channelFilter}
+                onChange={(e) => setChannelFilter(e.target.value)}
+                placeholder="chan_…"
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Links table */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between pb-3">
+          <div>
+            <CardTitle className="text-sm">Booking links</CardTitle>
+            <CardDescription>Per-channel push state for recent bookings.</CardDescription>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => void linksQuery.refetch()}
+            disabled={linksQuery.isFetching}
+          >
+            <RefreshCw
+              className={`mr-1.5 h-3.5 w-3.5 ${linksQuery.isFetching ? "animate-spin" : ""}`}
+            />
+            Refresh
+          </Button>
+        </CardHeader>
+        <CardContent className="p-0">
+          {linksQuery.isPending ? (
+            <div className="flex items-center justify-center p-12">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : rows.length === 0 ? (
+            <Empty className="border-0">
+              <EmptyHeader>
+                <EmptyTitle>No links found</EmptyTitle>
+                <EmptyDescription>
+                  Channel-push booking links show up here as bookings confirm. Adjust the filters or
+                  wait for a booking to land.
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Booking</TableHead>
+                  <TableHead>Channel</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Attempts</TableHead>
+                  <TableHead>Last push</TableHead>
+                  <TableHead>External ref</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((row) => (
+                  <TableRow key={row.link.id}>
+                    <TableCell className="font-mono text-xs">
+                      <div>{row.link.bookingId}</div>
+                      {row.link.bookingItemId ? (
+                        <div className="text-muted-foreground">item: {row.link.bookingItemId}</div>
+                      ) : null}
+                    </TableCell>
+                    <TableCell>
+                      <div>{row.channelName}</div>
+                      <div className="text-xs text-muted-foreground capitalize">
+                        {row.channelKind.replace("_", " ")}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={STATUS_VARIANTS[row.link.pushStatus] ?? "outline"}>
+                        {STATUS_LABELS[row.link.pushStatus] ?? row.link.pushStatus}
+                      </Badge>
+                      {row.link.lastError ? (
+                        <div
+                          className="mt-1 max-w-xs truncate text-xs text-destructive"
+                          title={row.link.lastError}
+                        >
+                          {row.link.lastError}
+                        </div>
+                      ) : null}
+                    </TableCell>
+                    <TableCell className="tabular-nums">{row.link.pushAttempts}</TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      {row.link.lastPushAt ? formatRelative(row.link.lastPushAt) : "—"}
+                    </TableCell>
+                    <TableCell className="font-mono text-xs">
+                      {row.link.externalBookingId ?? row.link.externalReference ?? "—"}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex justify-end gap-1">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setDrilldownBookingId(row.link.bookingId)}
+                        >
+                          Deliveries
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          disabled={
+                            retryMutation.isPending &&
+                            retryMutation.variables === row.link.bookingId
+                          }
+                          onClick={() => retryMutation.mutate(row.link.bookingId)}
+                        >
+                          {retryMutation.isPending &&
+                          retryMutation.variables === row.link.bookingId ? (
+                            <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                          ) : null}
+                          Retry
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <DeliveriesDrawer
+        bookingId={drilldownBookingId}
+        onClose={() => setDrilldownBookingId(null)}
+      />
+    </div>
+  )
+}
+
+function StatusTile({
+  label,
+  value,
+  tone,
+}: {
+  label: string
+  value: number
+  tone: "default" | "secondary" | "destructive" | "outline"
+}) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardDescription>{label}</CardDescription>
+        <CardTitle className="text-2xl tabular-nums">{value}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Badge variant={tone} className="text-xs">
+          {label}
+        </Badge>
+      </CardContent>
+    </Card>
+  )
+}
+
+function DeliveriesDrawer({
+  bookingId,
+  onClose,
+}: {
+  bookingId: string | null
+  onClose: () => void
+}) {
+  const isOpen = bookingId !== null
+  const query = useQuery<DeliveriesResponse>({
+    enabled: isOpen,
+    queryKey: ["channel-push-deliveries", bookingId],
+    queryFn: () => {
+      const params = new URLSearchParams({ bookingId: bookingId ?? "", limit: "200" })
+      return fetchJson<DeliveriesResponse>(
+        `/v1/admin/distribution/channel-push/deliveries?${params}`,
+      )
+    },
+  })
+
+  const rows = query.data?.data ?? []
+
+  return (
+    <Sheet open={isOpen} onOpenChange={(open) => (open ? null : onClose())}>
+      <SheetContent side="right" size="xl">
+        <SheetHeader>
+          <SheetTitle>Delivery log — {bookingId ?? ""}</SheetTitle>
+        </SheetHeader>
+        <SheetBody className="flex flex-col gap-3">
+          {query.isPending ? (
+            <div className="flex items-center justify-center p-12">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : rows.length === 0 ? (
+            <Empty>
+              <EmptyHeader>
+                <EmptyTitle>No deliveries yet</EmptyTitle>
+                <EmptyDescription>
+                  Channel-push attempts log here once they dispatch.
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          ) : (
+            rows.map((row) => (
+              <Card key={row.id} className="text-xs">
+                <CardHeader className="pb-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2">
+                      <Badge variant={row.status === "succeeded" ? "default" : "destructive"}>
+                        {row.status}
+                      </Badge>
+                      <span className="font-mono">{row.sourceEvent}</span>
+                      <span className="text-muted-foreground">attempt #{row.attemptNumber}</span>
+                    </div>
+                    <span className="text-muted-foreground">
+                      {row.durationMs != null ? `${row.durationMs}ms` : ""}
+                    </span>
+                  </div>
+                  <CardDescription className="font-mono">
+                    {row.requestMethod} {row.targetUrl}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-2">
+                  <div className="flex flex-wrap gap-2">
+                    {row.responseStatus != null ? (
+                      <Badge variant="outline">HTTP {row.responseStatus}</Badge>
+                    ) : null}
+                    {row.errorClass ? <Badge variant="destructive">{row.errorClass}</Badge> : null}
+                    <span className="text-muted-foreground">{formatRelative(row.createdAt)}</span>
+                  </div>
+                  {row.errorMessage ? (
+                    <pre className="overflow-x-auto whitespace-pre-wrap rounded bg-destructive/10 p-2 text-destructive">
+                      {row.errorMessage}
+                    </pre>
+                  ) : null}
+                  {row.responseBodyExcerpt ? (
+                    <pre className="overflow-x-auto rounded bg-muted p-2">
+                      {row.responseBodyExcerpt}
+                    </pre>
+                  ) : null}
+                </CardContent>
+              </Card>
+            ))
+          )}
+        </SheetBody>
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+function formatRelative(iso: string): string {
+  const date = new Date(iso)
+  const diffMs = Date.now() - date.getTime()
+  const sec = Math.round(diffMs / 1000)
+  if (sec < 60) return `${sec}s ago`
+  const min = Math.round(sec / 60)
+  if (min < 60) return `${min}m ago`
+  const hours = Math.round(min / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.round(hours / 24)
+  return `${days}d ago`
+}

--- a/templates/operator/src/routeTree.gen.ts
+++ b/templates/operator/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as authRouteRouteImport } from './routes/(auth)/route'
 import { Route as WorkspaceIndexRouteImport } from './routes/_workspace/index'
 import { Route as PaySessionIdRouteImport } from './routes/pay_.$sessionId'
 import { Route as WorkspaceFlightsRouteImport } from './routes/_workspace/flights'
+import { Route as WorkspaceChannelSyncRouteImport } from './routes/_workspace/channel-sync'
 import { Route as WorkspaceCatalogRouteImport } from './routes/_workspace/catalog'
 import { Route as WorkspaceAccountRouteImport } from './routes/_workspace/account'
 import { Route as authVerifyEmailRouteImport } from './routes/(auth)/verify-email'
@@ -101,6 +102,11 @@ const PaySessionIdRoute = PaySessionIdRouteImport.update({
 const WorkspaceFlightsRoute = WorkspaceFlightsRouteImport.update({
   id: '/flights',
   path: '/flights',
+  getParentRoute: () => WorkspaceRouteRoute,
+} as any)
+const WorkspaceChannelSyncRoute = WorkspaceChannelSyncRouteImport.update({
+  id: '/channel-sync',
+  path: '/channel-sync',
   getParentRoute: () => WorkspaceRouteRoute,
 } as any)
 const WorkspaceCatalogRoute = WorkspaceCatalogRouteImport.update({
@@ -445,6 +451,7 @@ export interface FileRoutesByFullPath {
   '/verify-email': typeof authVerifyEmailRoute
   '/account': typeof WorkspaceAccountRoute
   '/catalog': typeof WorkspaceCatalogRoute
+  '/channel-sync': typeof WorkspaceChannelSyncRoute
   '/flights': typeof WorkspaceFlightsRoute
   '/pay/$sessionId': typeof PaySessionIdRoute
   '/availability/$id': typeof WorkspaceAvailabilityIdRoute
@@ -508,6 +515,7 @@ export interface FileRoutesByTo {
   '/verify-email': typeof authVerifyEmailRoute
   '/account': typeof WorkspaceAccountRoute
   '/catalog': typeof WorkspaceCatalogRoute
+  '/channel-sync': typeof WorkspaceChannelSyncRoute
   '/flights': typeof WorkspaceFlightsRoute
   '/pay/$sessionId': typeof PaySessionIdRoute
   '/': typeof WorkspaceIndexRoute
@@ -576,6 +584,7 @@ export interface FileRoutesById {
   '/(auth)/verify-email': typeof authVerifyEmailRoute
   '/_workspace/account': typeof WorkspaceAccountRoute
   '/_workspace/catalog': typeof WorkspaceCatalogRoute
+  '/_workspace/channel-sync': typeof WorkspaceChannelSyncRoute
   '/_workspace/flights': typeof WorkspaceFlightsRoute
   '/pay_/$sessionId': typeof PaySessionIdRoute
   '/_workspace/': typeof WorkspaceIndexRoute
@@ -644,6 +653,7 @@ export interface FileRouteTypes {
     | '/verify-email'
     | '/account'
     | '/catalog'
+    | '/channel-sync'
     | '/flights'
     | '/pay/$sessionId'
     | '/availability/$id'
@@ -707,6 +717,7 @@ export interface FileRouteTypes {
     | '/verify-email'
     | '/account'
     | '/catalog'
+    | '/channel-sync'
     | '/flights'
     | '/pay/$sessionId'
     | '/'
@@ -774,6 +785,7 @@ export interface FileRouteTypes {
     | '/(auth)/verify-email'
     | '/_workspace/account'
     | '/_workspace/catalog'
+    | '/_workspace/channel-sync'
     | '/_workspace/flights'
     | '/pay_/$sessionId'
     | '/_workspace/'
@@ -876,6 +888,13 @@ declare module '@tanstack/react-router' {
       path: '/flights'
       fullPath: '/flights'
       preLoaderRoute: typeof WorkspaceFlightsRouteImport
+      parentRoute: typeof WorkspaceRouteRoute
+    }
+    '/_workspace/channel-sync': {
+      id: '/_workspace/channel-sync'
+      path: '/channel-sync'
+      fullPath: '/channel-sync'
+      preLoaderRoute: typeof WorkspaceChannelSyncRouteImport
       parentRoute: typeof WorkspaceRouteRoute
     }
     '/_workspace/catalog': {
@@ -1351,6 +1370,7 @@ interface WorkspaceRouteRouteChildren {
   WorkspaceSettingsRouteRoute: typeof WorkspaceSettingsRouteRouteWithChildren
   WorkspaceAccountRoute: typeof WorkspaceAccountRoute
   WorkspaceCatalogRoute: typeof WorkspaceCatalogRoute
+  WorkspaceChannelSyncRoute: typeof WorkspaceChannelSyncRoute
   WorkspaceFlightsRoute: typeof WorkspaceFlightsRoute
   WorkspaceIndexRoute: typeof WorkspaceIndexRoute
   WorkspaceAvailabilityIdRoute: typeof WorkspaceAvailabilityIdRoute
@@ -1400,6 +1420,7 @@ const WorkspaceRouteRouteChildren: WorkspaceRouteRouteChildren = {
   WorkspaceSettingsRouteRoute: WorkspaceSettingsRouteRouteWithChildren,
   WorkspaceAccountRoute: WorkspaceAccountRoute,
   WorkspaceCatalogRoute: WorkspaceCatalogRoute,
+  WorkspaceChannelSyncRoute: WorkspaceChannelSyncRoute,
   WorkspaceFlightsRoute: WorkspaceFlightsRoute,
   WorkspaceIndexRoute: WorkspaceIndexRoute,
   WorkspaceAvailabilityIdRoute: WorkspaceAvailabilityIdRoute,

--- a/templates/operator/src/routes/_workspace/channel-sync.tsx
+++ b/templates/operator/src/routes/_workspace/channel-sync.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { ChannelSyncPage } from "@/components/voyant/channel-sync/channel-sync-page"
+
+export const Route = createFileRoute("/_workspace/channel-sync")({
+  component: ChannelSyncPage,
+})


### PR DESCRIPTION
## Summary

Follow-up to #396 (squash-merged as `ac3d21994`). That PR shipped Phases A-G of the channel-push architecture; this PR closes the six v1 gaps I'd flagged in the post-merge audit and ships the operator dashboard UI.

### Gaps closed

1. **429 handling (§14.4)** — `AdapterRateLimitedError` in the catalog adapter contract; processors detect it and call `drainBucket` per `Retry-After` so concurrent dispatchers also see "no tokens" until the channel recovers. Demo adapter throws it on actual 429 responses.
2. **PII body redaction (§11.3)** — `redactBodyPii` recursively scrubs known-PII keys (firstName, email, phone, passport, card*, iban, …) from request/response bodies before they hit `webhook_deliveries` excerpts; remaining string values pass through `redactStringPii` to scrub email + phone shapes from free text. Hashes still run on the unredacted body.
3. **Compensation policy (§4.2)** — `processBookingPush` reads `channel_contracts.policy.compensation` (`"strict-atomic"` or `"eventually-consistent"`, default eventually-consistent). On partial failure under strict-atomic, calls `adapter.cancel` for succeeded siblings and marks them `push_status="compensated"`. Compensation calls go through `prepareOutboundEnvelope` so the rollback chain is traceable.
4. **Durable workflows (§4.2 + §12)** — `channelBookingPushWorkflow` / `channelAvailabilityPushWorkflow` / `channelContentPushWorkflow` registered via `@voyantjs/workflows`. Booking workflow: per-`bookingId` concurrency, exponential retry up to 5, 1h timeout. Availability: `schedule { every: 30s }`. Content: `schedule { every: 5m }`. Single-process (operator template Workers isolate) keeps inline drain unchanged.
5. **Content event coverage (§6 + §10 Phase B)** — `product.content.changed` now also fires from features, faqs, locations, destinations-on-product, options PATCH/DELETE, day-services DELETE, and product translations. The reconciler still backstops the deeply-nested entities.
6. **Admin API for channel-sync dashboard (§9, §14.5)** — `/v1/admin/distribution/channel-push/{links, retry/:bookingId, deliveries, throttling, reconcile/:flow}`. Mounted in the operator template under the existing admin guard.

### Operator dashboard UI

New page at `/_workspace/channel-sync` with:
- Status tiles (Pending / OK / Failed / Compensated), refetched every 30s
- Throttling banner (yellow) when any channel has rate-limited deliveries in the last hour, with copy steering ops to lower per-channel RPS
- Filter bar (status, booking-id, channel-id) driving the `/links` query
- Manual reconcile buttons (bookings / availability / content) for ops triggers
- Booking-links table with channel name + kind, status badge with last-error tooltip, attempts, last-push relative time, external reference
- Per-row Deliveries drawer showing `webhook_deliveries` per booking with response excerpts, error-class badges, and timing
- Sidebar entry "Channel sync" (Radio icon) above Settings

5 commits, +1700 / -200. 109/109 turbo tasks pass.

## Test plan

- [ ] Local: `pnpm typecheck` passes (109/109 already verified)
- [ ] Local: `pnpm test` passes (distribution + plugin-catalog-demo + products)
- [ ] Demo end-to-end: with `CATALOG_DEMO_API_URL` set + a `channel_product_mapping` configured, confirm a booking, see a row appear at `/channel-sync`, click Retry, watch the count flip Pending → OK
- [ ] Trigger a 429 from the demo upstream, verify the bucket drains and the throttling banner appears
- [ ] Test compensation: set `channel_contracts.policy = '{"compensation":"strict-atomic"}'` for a channel, simulate one failure with multiple syndicated channels, verify succeeded links flip to `compensated`
- [ ] Reconciler manual triggers from the page work for all three flows
- [ ] PII smoke: confirm a booking with traveler contact info, then `SELECT request_body_excerpt FROM webhook_deliveries WHERE source_event = 'channel.booking.push'` — verify no email/phone/name values appear