### PR TITLE
fix workflow runs package publishing

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -101,6 +101,7 @@
       "@voyantjs/ui",
       "@voyantjs/utils",
       "@voyantjs/storage",
+      "@voyantjs/workflow-runs",
       "@voyantjs/workflows",
       "@voyantjs/workflows-bindings",
       "@voyantjs/workflows-config",

--- a/packages/workflow-runs/README.md
+++ b/packages/workflow-runs/README.md
@@ -1,0 +1,44 @@
+# @voyantjs/workflow-runs
+
+Workflow run recording, admin routes, and rerun/resume dispatch primitives for Voyant operator apps.
+
+## Install
+
+```sh
+pnpm add @voyantjs/workflow-runs
+```
+
+The package is published with the same release-train version as the other installable Voyant packages.
+
+## Mount the admin routes
+
+`mountWorkflowRunsAdminRoutes` adds the workflow-run list, detail, rerun, and resume endpoints under `/v1/admin/workflow-runs`.
+
+```ts
+import { mountWorkflowRunsAdminRoutes, WorkflowRunnerRegistry } from "@voyantjs/workflow-runs"
+
+const workflowRunnerRegistry = new WorkflowRunnerRegistry()
+
+workflowRunnerRegistry.register({
+  name: "checkout-finalize",
+  rerun: async ({ run, input }) => {
+    await workflowServer.dispatch("checkout-finalize", {
+      idempotencyKey: run.idempotencyKey ?? run.id,
+      input,
+    })
+  },
+  resume: async ({ run, input, failedStep }) => {
+    await workflowServer.dispatch("checkout-finalize", {
+      resumeFromStep: failedStep?.stepName ?? null,
+      originalRunId: run.id,
+      input,
+    })
+  },
+})
+
+mountWorkflowRunsAdminRoutes(hono, {
+  runners: workflowRunnerRegistry,
+})
+```
+
+For self-hosted workflow services, keep runner registration close to the code that mounts the workflow service. The registry should dispatch to your external workflow server instead of importing worker-only runtime code into the admin API process.

--- a/packages/workflow-runs/package.json
+++ b/packages/workflow-runs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@voyantjs/workflow-runs",
   "version": "0.21.0",
+  "description": "Workflow run recording, admin routes, and rerun/resume dispatch primitives for Voyant operator apps.",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
@@ -36,6 +37,8 @@
   ],
   "publishConfig": {
     "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
@@ -63,5 +66,10 @@
         "default": "./dist/recorder.js"
       }
     }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyantjs/voyant.git",
+    "directory": "packages/workflow-runs"
   }
 }

--- a/scripts/verify-package-tarballs.mjs
+++ b/scripts/verify-package-tarballs.mjs
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process"
 import fs from "node:fs"
+import os from "node:os"
 import path from "node:path"
 import { promisify } from "node:util"
 
@@ -82,10 +83,52 @@ function collectExportTargets(value, targets) {
 function getPackJson(stdout) {
   const trimmed = stdout.trim()
   const arrayStart = trimmed.indexOf("[")
-  if (arrayStart === -1) {
+  const objectStart = trimmed.indexOf("{")
+  const jsonStart =
+    arrayStart === -1
+      ? objectStart
+      : objectStart === -1
+        ? arrayStart
+        : Math.min(arrayStart, objectStart)
+
+  if (jsonStart === -1) {
     throw new Error("npm pack did not return JSON output")
   }
-  return JSON.parse(trimmed.slice(arrayStart))
+
+  const parsed = JSON.parse(trimmed.slice(jsonStart))
+  return Array.isArray(parsed) ? parsed : [parsed]
+}
+
+async function readPackedManifest(tarballPath) {
+  const result = await execFileAsync("tar", ["-xOf", tarballPath, "package/package.json"], {
+    encoding: "utf8",
+    maxBuffer: 8 * 1024 * 1024,
+  })
+
+  return JSON.parse(result.stdout)
+}
+
+function collectWorkspaceProtocolDependencies(pkg) {
+  const problems = []
+  const dependencyFields = [
+    "dependencies",
+    "peerDependencies",
+    "optionalDependencies",
+    "devDependencies",
+  ]
+
+  for (const field of dependencyFields) {
+    const dependencies = pkg[field]
+    if (!dependencies || typeof dependencies !== "object") continue
+
+    for (const [name, version] of Object.entries(dependencies)) {
+      if (typeof version === "string" && version.startsWith("workspace:")) {
+        problems.push(`${field}.${name}=${version}`)
+      }
+    }
+  }
+
+  return problems
 }
 
 function getPublishedTargets(pkg) {
@@ -119,44 +162,55 @@ async function verifyPackage(packageDir) {
 
   if (pkg.private) return null
 
-  const expectedTargets = getPublishedTargets(pkg)
-  if (expectedTargets.length === 0) return null
   const sourceFiles = new Set(listPackageFiles(packageDir))
+  const packDestination = fs.mkdtempSync(path.join(os.tmpdir(), "voyant-pack-"))
 
   let stdout
+  let packInfo
+  let packedManifest
   try {
-    // --ignore-scripts skips prepack (= `pnpm run build` in every package). The
-    // Build packages CI step already populated `dist/` for every workspace
-    // package, so npm pack just needs to enumerate files, not rebuild them.
+    // npm pack does not apply pnpm's publish-time manifest rewrites, including
+    // publishConfig exports and workspace: dependency replacement. The release
+    // job publishes through pnpm, so verify the same packed manifest consumers
+    // receive while still skipping prepack because CI already built dist/.
     const result = await execFileAsync(
-      "npm",
-      ["--cache", "/tmp/npm-cache", "pack", "--dry-run", "--json", "--ignore-scripts"],
+      "pnpm",
+      ["pack", "--json", "--pack-destination", packDestination],
       {
         cwd: packageDir,
         encoding: "utf8",
         maxBuffer: 64 * 1024 * 1024,
+        env: {
+          ...process.env,
+          npm_config_ignore_scripts: "true",
+        },
       },
     )
     stdout = result.stdout
   } catch (error) {
+    fs.rmSync(packDestination, { recursive: true, force: true })
     return {
       name: pkg.name,
       packageDir,
-      problems: [`npm pack failed: ${error.stderr?.toString().trim() || error.message}`],
+      problems: [`pnpm pack failed: ${error.stderr?.toString().trim() || error.message}`],
     }
   }
 
-  let packInfo
   try {
     ;[packInfo] = getPackJson(stdout)
+    packedManifest = await readPackedManifest(packInfo.filename)
   } catch (error) {
+    fs.rmSync(packDestination, { recursive: true, force: true })
     return {
       name: pkg.name,
       packageDir,
-      problems: [`could not parse npm pack output: ${error.message}`],
+      problems: [`could not parse pnpm pack output: ${error.message}`],
     }
+  } finally {
+    fs.rmSync(packDestination, { recursive: true, force: true })
   }
 
+  const expectedTargets = getPublishedTargets(packedManifest)
   const tarballFiles = new Set(packInfo.files.map((file) => file.path))
   const missingTargets = expectedTargets.filter(
     (target) =>
@@ -172,6 +226,14 @@ async function verifyPackage(packageDir) {
   const problems = []
   if (missingTargets.length > 0) {
     problems.push(`missing published targets: ${missingTargets.join(", ")}`)
+  }
+  const workspaceProtocolDependencies = collectWorkspaceProtocolDependencies(packedManifest)
+  if (workspaceProtocolDependencies.length > 0) {
+    problems.push(
+      `packed manifest contains workspace protocol dependencies: ${workspaceProtocolDependencies.join(
+        ", ",
+      )}`,
+    )
   }
   if (suspiciousFiles.length > 0) {
     problems.push(`unexpected packaged build paths: ${suspiciousFiles.join(", ")}`)


### PR DESCRIPTION
## Summary

Fixes #400 by wiring `@voyantjs/workflow-runs` into the publishable Voyant release train and documenting the downstream mounting pattern.

## What changed

- Adds `@voyantjs/workflow-runs` to the Changesets fixed release train so it participates in coordinated package publishing.
- Adds package metadata, published `main`/`types`, and repository metadata for the workflow-runs package.
- Adds a README with install, admin route mounting, and self-hosted runner registration examples.
- Updates publish tarball verification to inspect the actual `pnpm pack` manifest and fail on unresolved `workspace:*` dependencies.

## Validation

- `pnpm verify:release-train`
- `pnpm -C packages/workflow-runs build`
- `pnpm verify:publish-tarballs`
- `pnpm -C packages/workflow-runs test`
- pre-commit lint/typecheck hook
- pre-push test hook

## Release note

The repository release workflow publishes packages on pushes to `main`, so merging this PR is the release trigger for making `@voyantjs/workflow-runs` installable from npm.