### PR TITLE
Resolve storefront and availability issue batch

### DIFF
--- a/.changeset/storefront-products-availability.md
+++ b/.changeset/storefront-products-availability.md
@@ -1,0 +1,7 @@
+---
+"@voyantjs/storefront": minor
+"@voyantjs/products-ui": minor
+"@voyantjs/availability-ui": minor
+---
+
+Add request-aware storefront settings and offer resolution, a public product availability summary endpoint, itinerary day extension components for products UI, and an explicit open slots metric for availability overview surfaces.

--- a/apps/dev/src/components/voyant/availability/availability-overview.tsx
+++ b/apps/dev/src/components/voyant/availability/availability-overview.tsx
@@ -24,6 +24,7 @@ import { formatDateTime, productNameById } from "./availability-shared"
 export function AvailabilityOverview({
   products,
   constrainedSlots,
+  openSlotsCount: providedOpenSlotsCount,
   filteredRules,
   filteredPickupPoints,
   productsWithoutActiveRules,
@@ -38,6 +39,7 @@ export function AvailabilityOverview({
 }: {
   products: ProductOption[]
   constrainedSlots: AvailabilitySlotRow[]
+  openSlotsCount?: number
   filteredRules: AvailabilityRuleRow[]
   filteredPickupPoints: AvailabilityPickupPointRow[]
   productsWithoutActiveRules: ProductOption[]
@@ -50,7 +52,8 @@ export function AvailabilityOverview({
   onOpenSlot: (slotId: string) => void
   onOpenProduct: (productId: string) => void
 }) {
-  const openSlotsCount = constrainedSlots.filter((slot) => slot.status === "open").length
+  const openSlotsCount =
+    providedOpenSlotsCount ?? constrainedSlots.filter((slot) => slot.status === "open").length
   const activeRulesCount = filteredRules.filter((rule) => rule.active).length
   const activePickupPointsCount = filteredPickupPoints.filter(
     (pickupPoint) => pickupPoint.active,

--- a/apps/dev/src/components/voyant/availability/availability-page.tsx
+++ b/apps/dev/src/components/voyant/availability/availability-page.tsx
@@ -257,6 +257,7 @@ export function AvailabilityPage() {
           <AvailabilityOverview
             products={products}
             constrainedSlots={constrainedSlots}
+            openSlotsCount={filteredSlots.filter((slot) => slot.status === "open").length}
             filteredRules={filteredRules}
             filteredPickupPoints={filteredPickupPoints}
             productsWithoutActiveRules={productsWithoutActiveRules}

--- a/packages/availability-ui/src/components/availability-overview.tsx
+++ b/packages/availability-ui/src/components/availability-overview.tsx
@@ -49,6 +49,7 @@ export function AvailabilityOverview({
   messages,
   products,
   constrainedSlots,
+  openSlotsCount: providedOpenSlotsCount,
   filteredRules,
   filteredPickupPoints,
   productsWithoutActiveRules,
@@ -64,6 +65,7 @@ export function AvailabilityOverview({
   messages: AvailabilityOverviewMessages
   products: ProductOption[]
   constrainedSlots: AvailabilitySlotRow[]
+  openSlotsCount?: number
   filteredRules: AvailabilityRuleRow[]
   filteredPickupPoints: AvailabilityPickupPointRow[]
   productsWithoutActiveRules: ProductOption[]
@@ -76,7 +78,8 @@ export function AvailabilityOverview({
   onOpenSlot: (slotId: string) => void
   onOpenProduct: (productId: string) => void
 }) {
-  const openSlotsCount = constrainedSlots.filter((slot) => slot.status === "open").length
+  const openSlotsCount =
+    providedOpenSlotsCount ?? constrainedSlots.filter((slot) => slot.status === "open").length
   const activeRulesCount = filteredRules.filter((rule) => rule.active).length
   const activePickupPointsCount = filteredPickupPoints.filter(
     (pickupPoint) => pickupPoint.active,

--- a/packages/products-ui/src/components/product-day-media-tray.tsx
+++ b/packages/products-ui/src/components/product-day-media-tray.tsx
@@ -1,0 +1,228 @@
+"use client"
+
+import {
+  type ProductMediaRecord,
+  useProductMedia,
+  useProductMediaMutation,
+} from "@voyantjs/products-react"
+import { Badge } from "@voyantjs/ui/components/badge"
+import { Button } from "@voyantjs/ui/components/button"
+import { ImageIcon, Loader2, Pencil, Plus, Star, Trash2, Upload } from "lucide-react"
+import * as React from "react"
+
+import { useProductsUiMessagesOrDefault } from "../i18n/provider"
+import { ProductMediaDialog } from "./product-media-dialog"
+import type { ProductMediaUploadHandler } from "./product-media-section"
+
+export interface ProductDayMediaTrayProps {
+  productId: string
+  dayId: string
+  uploadMedia?: ProductMediaUploadHandler
+  uploadAccept?: string
+  emptyState?: React.ReactNode
+}
+
+export function ProductDayMediaTray({
+  productId,
+  dayId,
+  uploadMedia,
+  uploadAccept = "image/*,video/*,application/pdf",
+  emptyState,
+}: ProductDayMediaTrayProps) {
+  const messages = useProductsUiMessagesOrDefault()
+  const [dialogOpen, setDialogOpen] = React.useState(false)
+  const [editingMedia, setEditingMedia] = React.useState<ProductMediaRecord | undefined>()
+  const [isUploading, setIsUploading] = React.useState(false)
+  const [uploadError, setUploadError] = React.useState<string | null>(null)
+  const fileInputRef = React.useRef<HTMLInputElement>(null)
+  const { data, isPending, isError } = useProductMedia(productId, { dayId, limit: 50 })
+  const { create, remove, setCover } = useProductMediaMutation()
+
+  const media = React.useMemo(
+    () =>
+      (data?.data ?? [])
+        .slice()
+        .sort(
+          (left, right) =>
+            Number(right.isCover) - Number(left.isCover) || left.sortOrder - right.sortOrder,
+        ),
+    [data?.data],
+  )
+
+  const handleUpload = async (file: File) => {
+    if (!uploadMedia) return
+
+    setUploadError(null)
+    setIsUploading(true)
+
+    try {
+      const uploaded = await uploadMedia(file, { productId, dayId })
+      const mimeType = uploaded.mimeType?.trim() || file.type || null
+      const mediaType =
+        uploaded.mediaType ??
+        (mimeType?.startsWith("video/")
+          ? "video"
+          : mimeType?.startsWith("image/")
+            ? "image"
+            : "document")
+
+      await create.mutateAsync({
+        productId,
+        dayId,
+        mediaType,
+        name: uploaded.name?.trim() || file.name,
+        url: uploaded.url,
+        storageKey: uploaded.storageKey ?? null,
+        mimeType,
+        fileSize: uploaded.fileSize ?? (file.size || null),
+        altText: uploaded.altText ?? null,
+        sortOrder: uploaded.sortOrder ?? media.length,
+        isCover: uploaded.isCover ?? media.length === 0,
+      })
+    } catch (error) {
+      setUploadError(
+        error instanceof Error ? error.message : messages.productMediaSection.uploadFailed,
+      )
+    } finally {
+      setIsUploading(false)
+    }
+  }
+
+  return (
+    <div data-slot="product-day-media-tray" className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-sm font-medium">{messages.productMediaSection.titles.dayMedia}</div>
+        <div className="flex items-center gap-1">
+          {uploadMedia ? (
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={isUploading}
+                onClick={() => fileInputRef.current?.click()}
+              >
+                {isUploading ? (
+                  <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" />
+                ) : (
+                  <Upload className="mr-2 size-4" aria-hidden="true" />
+                )}
+                {messages.productMediaSection.actions.upload}
+              </Button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept={uploadAccept}
+                className="hidden"
+                onChange={(event) => {
+                  const file = event.target.files?.[0]
+                  if (file) {
+                    void handleUpload(file)
+                    event.target.value = ""
+                  }
+                }}
+              />
+            </>
+          ) : null}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              setEditingMedia(undefined)
+              setDialogOpen(true)
+            }}
+          >
+            <Plus className="mr-2 size-4" aria-hidden="true" />
+            {messages.productMediaSection.actions.addMedia}
+          </Button>
+        </div>
+      </div>
+
+      {uploadError ? <p className="text-sm text-destructive">{uploadError}</p> : null}
+      {isPending ? (
+        <div className="flex min-h-20 items-center justify-center rounded-md border border-dashed">
+          <Loader2 className="size-4 animate-spin text-muted-foreground" />
+        </div>
+      ) : isError ? (
+        <p className="text-sm text-destructive">{messages.productMediaSection.loadingError}</p>
+      ) : media.length === 0 ? (
+        <div className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+          {emptyState ?? messages.productMediaSection.empty}
+        </div>
+      ) : (
+        <div className="flex gap-2 overflow-x-auto pb-1">
+          {media.map((item) => (
+            <div key={item.id} className="w-36 shrink-0 rounded-md border bg-background">
+              {item.mediaType === "image" ? (
+                <img
+                  src={item.url}
+                  alt={item.altText ?? item.name}
+                  className="h-20 w-full rounded-t-md object-cover"
+                />
+              ) : (
+                <div className="flex h-20 w-full items-center justify-center rounded-t-md bg-muted text-muted-foreground">
+                  <ImageIcon className="size-5" aria-hidden="true" />
+                </div>
+              )}
+              <div className="space-y-2 p-2">
+                <div className="truncate text-xs font-medium">{item.name}</div>
+                <div className="flex items-center justify-between gap-1">
+                  {item.isCover ? (
+                    <Badge className="text-[10px]">{messages.productMediaSection.coverBadge}</Badge>
+                  ) : (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={() => setCover.mutate(item.id)}
+                      aria-label={messages.productMediaSection.actions.markCover}
+                    >
+                      <Star className="size-4" aria-hidden="true" />
+                    </Button>
+                  )}
+                  <div className="flex items-center gap-1">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={() => {
+                        setEditingMedia(item)
+                        setDialogOpen(true)
+                      }}
+                      aria-label={messages.productMediaSection.actions.edit}
+                    >
+                      <Pencil className="size-4" aria-hidden="true" />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={() => {
+                        if (confirm(messages.productMediaSection.deleteConfirm)) {
+                          remove.mutate(item.id)
+                        }
+                      }}
+                      aria-label={messages.productMediaSection.actions.delete}
+                    >
+                      <Trash2 className="size-4" aria-hidden="true" />
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <ProductMediaDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        productId={productId}
+        dayId={dayId}
+        media={editingMedia}
+        onSuccess={() => setEditingMedia(undefined)}
+      />
+    </div>
+  )
+}

--- a/packages/products-ui/src/components/product-day-service-form.tsx
+++ b/packages/products-ui/src/components/product-day-service-form.tsx
@@ -1,0 +1,401 @@
+"use client"
+
+import {
+  type ProductDayServiceRecord,
+  useProductDayServiceMutation,
+} from "@voyantjs/products-react"
+import { Button } from "@voyantjs/ui/components/button"
+import { Input } from "@voyantjs/ui/components/input"
+import { Label } from "@voyantjs/ui/components/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@voyantjs/ui/components/select"
+import { Textarea } from "@voyantjs/ui/components/textarea"
+import { Loader2 } from "lucide-react"
+import * as React from "react"
+
+import { useProductsUiMessagesOrDefault } from "../i18n/provider"
+
+type ProductDayServiceType = ProductDayServiceRecord["serviceType"]
+
+type Mode =
+  | { kind: "create"; productId: string; dayId: string; sortOrder?: number }
+  | { kind: "edit"; productId: string; dayId: string; service: ProductDayServiceRecord }
+
+export interface ProductDayServiceSupplierServiceOption {
+  id: string
+  name: string
+  serviceType?: ProductDayServiceType
+  description?: string | null
+  costCurrency?: string
+  costAmountCents?: number | null
+}
+
+export interface ProductDayServiceFormHelpers {
+  setName: (value: string) => void
+  setServiceType: (value: ProductDayServiceType) => void
+  setDescription: (value: string | null) => void
+  setCostCurrency: (value: string) => void
+  setCostAmountCents: (value: number | null) => void
+}
+
+export interface ProductDayServiceSupplierServiceFieldProps {
+  value: string | null
+  disabled: boolean
+  onChange: (
+    supplierServiceId: string | null,
+    option?: ProductDayServiceSupplierServiceOption | null,
+  ) => void
+}
+
+export interface ProductDayServiceFormProps {
+  mode: Mode
+  onSuccess?: (service: ProductDayServiceRecord) => void
+  onCancel?: () => void
+  renderSupplierServiceField?: (
+    props: ProductDayServiceSupplierServiceFieldProps,
+  ) => React.ReactNode
+  onSupplierServiceSelected?: (
+    option: ProductDayServiceSupplierServiceOption,
+    helpers: ProductDayServiceFormHelpers,
+  ) => void
+}
+
+interface FormState {
+  serviceType: ProductDayServiceType
+  name: string
+  description: string
+  countryCode: string
+  supplierServiceId: string
+  costCurrency: string
+  costAmount: string
+  quantity: string
+  sortOrder: string
+  notes: string
+}
+
+function initialState(mode: Mode): FormState {
+  if (mode.kind === "edit") {
+    return {
+      serviceType: mode.service.serviceType,
+      name: mode.service.name,
+      description: mode.service.description ?? "",
+      countryCode: mode.service.countryCode ?? "",
+      supplierServiceId: mode.service.supplierServiceId ?? "",
+      costCurrency: mode.service.costCurrency,
+      costAmount: String(mode.service.costAmountCents / 100),
+      quantity: String(mode.service.quantity),
+      sortOrder: mode.service.sortOrder == null ? "" : String(mode.service.sortOrder),
+      notes: mode.service.notes ?? "",
+    }
+  }
+
+  return {
+    serviceType: "accommodation",
+    name: "",
+    description: "",
+    countryCode: "",
+    supplierServiceId: "",
+    costCurrency: "EUR",
+    costAmount: "0",
+    quantity: "1",
+    sortOrder: mode.sortOrder == null ? "" : String(mode.sortOrder),
+    notes: "",
+  }
+}
+
+export function ProductDayServiceForm({
+  mode,
+  onSuccess,
+  onCancel,
+  renderSupplierServiceField,
+  onSupplierServiceSelected,
+}: ProductDayServiceFormProps) {
+  const messages = useProductsUiMessagesOrDefault()
+  const serviceMessages = messages.productDayServiceForm
+  const [state, setState] = React.useState<FormState>(() => initialState(mode))
+  const [error, setError] = React.useState<string | null>(null)
+  const { create, update } = useProductDayServiceMutation()
+
+  React.useEffect(() => {
+    setState(initialState(mode))
+    setError(null)
+  }, [mode])
+
+  const isSubmitting = create.isPending || update.isPending
+  const serviceTypes: Array<{ value: ProductDayServiceType; label: string }> = [
+    { value: "accommodation", label: serviceMessages.serviceTypes.accommodation },
+    { value: "transfer", label: serviceMessages.serviceTypes.transfer },
+    { value: "experience", label: serviceMessages.serviceTypes.experience },
+    { value: "guide", label: serviceMessages.serviceTypes.guide },
+    { value: "meal", label: serviceMessages.serviceTypes.meal },
+    { value: "other", label: serviceMessages.serviceTypes.other },
+  ]
+
+  const field =
+    <K extends keyof FormState>(key: K) =>
+    (value: FormState[K]) => {
+      setState((previous) => ({ ...previous, [key]: value }))
+    }
+
+  const helpers: ProductDayServiceFormHelpers = {
+    setName: field("name"),
+    setServiceType: field("serviceType"),
+    setDescription: (value) => field("description")(value ?? ""),
+    setCostCurrency: field("costCurrency"),
+    setCostAmountCents: (value) => {
+      field("costAmount")(value == null ? "0" : String(value / 100))
+    },
+  }
+
+  const handleSupplierServiceChange = (
+    supplierServiceId: string | null,
+    option?: ProductDayServiceSupplierServiceOption | null,
+  ) => {
+    field("supplierServiceId")(supplierServiceId ?? "")
+
+    if (!option) return
+
+    if (onSupplierServiceSelected) {
+      onSupplierServiceSelected(option, helpers)
+      return
+    }
+
+    field("name")(option.name)
+    if (option.serviceType) field("serviceType")(option.serviceType)
+    if (option.description != null) field("description")(option.description)
+    if (option.costCurrency) field("costCurrency")(option.costCurrency)
+    if (option.costAmountCents != null) field("costAmount")(String(option.costAmountCents / 100))
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+
+    const costAmount = Number.parseFloat(state.costAmount || "0")
+    const quantity = Number.parseInt(state.quantity || "0", 10)
+    const sortOrder = state.sortOrder.trim() ? Number.parseInt(state.sortOrder, 10) : null
+
+    if (!state.name.trim()) {
+      setError(serviceMessages.validation.nameRequired)
+      return
+    }
+    if (!state.costCurrency.trim() || state.costCurrency.trim().length !== 3) {
+      setError(serviceMessages.validation.currencyRequired)
+      return
+    }
+    if (!Number.isFinite(costAmount) || costAmount < 0) {
+      setError(serviceMessages.validation.costNonNegative)
+      return
+    }
+    if (!Number.isFinite(quantity) || quantity < 1) {
+      setError(serviceMessages.validation.quantityMin)
+      return
+    }
+
+    const payload = {
+      serviceType: state.serviceType,
+      name: state.name.trim(),
+      description: state.description.trim() ? state.description.trim() : null,
+      countryCode: state.countryCode.trim() ? state.countryCode.trim().toUpperCase() : null,
+      supplierServiceId: state.supplierServiceId.trim() ? state.supplierServiceId.trim() : null,
+      costCurrency: state.costCurrency.trim().toUpperCase(),
+      costAmountCents: Math.round(costAmount * 100),
+      quantity,
+      sortOrder: Number.isFinite(sortOrder) ? sortOrder : null,
+      notes: state.notes.trim() ? state.notes.trim() : null,
+    }
+
+    try {
+      const service =
+        mode.kind === "create"
+          ? await create.mutateAsync({
+              productId: mode.productId,
+              dayId: mode.dayId,
+              ...payload,
+            })
+          : await update.mutateAsync({
+              productId: mode.productId,
+              dayId: mode.dayId,
+              serviceId: mode.service.id,
+              input: payload,
+            })
+      onSuccess?.(service.data)
+    } catch (submissionError) {
+      setError(
+        submissionError instanceof Error
+          ? submissionError.message
+          : serviceMessages.validation.saveFailed,
+      )
+    }
+  }
+
+  return (
+    <form
+      data-slot="product-day-service-form"
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-4"
+    >
+      {renderSupplierServiceField ? (
+        renderSupplierServiceField({
+          value: state.supplierServiceId || null,
+          disabled: isSubmitting,
+          onChange: handleSupplierServiceChange,
+        })
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="product-day-service-supplier-service">
+            {serviceMessages.fields.supplierService}
+          </Label>
+          <Input
+            id="product-day-service-supplier-service"
+            value={state.supplierServiceId}
+            onChange={(event) => handleSupplierServiceChange(event.target.value || null)}
+            placeholder={serviceMessages.placeholders.supplierService}
+            disabled={isSubmitting}
+          />
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div className="flex flex-col gap-1.5">
+          <Label>{serviceMessages.fields.serviceType}</Label>
+          <Select
+            value={state.serviceType}
+            onValueChange={(value) => field("serviceType")(value as ProductDayServiceType)}
+            items={serviceTypes}
+            disabled={isSubmitting}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {serviceTypes.map((type) => (
+                <SelectItem key={type.value} value={type.value}>
+                  {type.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="product-day-service-country">{serviceMessages.fields.countryCode}</Label>
+          <Input
+            id="product-day-service-country"
+            value={state.countryCode}
+            maxLength={2}
+            onChange={(event) => field("countryCode")(event.target.value)}
+            placeholder={serviceMessages.placeholders.countryCode}
+            disabled={isSubmitting}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="product-day-service-name">{serviceMessages.fields.name}</Label>
+        <Input
+          id="product-day-service-name"
+          value={state.name}
+          onChange={(event) => field("name")(event.target.value)}
+          placeholder={serviceMessages.placeholders.name}
+          required
+          disabled={isSubmitting}
+        />
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="product-day-service-description">
+          {serviceMessages.fields.description}
+        </Label>
+        <Textarea
+          id="product-day-service-description"
+          value={state.description}
+          onChange={(event) => field("description")(event.target.value)}
+          placeholder={serviceMessages.placeholders.description}
+          disabled={isSubmitting}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="product-day-service-currency">
+            {serviceMessages.fields.costCurrency}
+          </Label>
+          <Input
+            id="product-day-service-currency"
+            value={state.costCurrency}
+            maxLength={3}
+            onChange={(event) => field("costCurrency")(event.target.value)}
+            disabled={isSubmitting}
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="product-day-service-cost">{serviceMessages.fields.costAmount}</Label>
+          <Input
+            id="product-day-service-cost"
+            type="number"
+            min="0"
+            step="0.01"
+            value={state.costAmount}
+            onChange={(event) => field("costAmount")(event.target.value)}
+            disabled={isSubmitting}
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="product-day-service-quantity">{serviceMessages.fields.quantity}</Label>
+          <Input
+            id="product-day-service-quantity"
+            type="number"
+            min="1"
+            value={state.quantity}
+            onChange={(event) => field("quantity")(event.target.value)}
+            disabled={isSubmitting}
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="product-day-service-sort">{serviceMessages.fields.sortOrder}</Label>
+          <Input
+            id="product-day-service-sort"
+            type="number"
+            value={state.sortOrder}
+            onChange={(event) => field("sortOrder")(event.target.value)}
+            disabled={isSubmitting}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="product-day-service-notes">{serviceMessages.fields.notes}</Label>
+        <Textarea
+          id="product-day-service-notes"
+          value={state.notes}
+          onChange={(event) => field("notes")(event.target.value)}
+          placeholder={serviceMessages.placeholders.notes}
+          disabled={isSubmitting}
+        />
+      </div>
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+      <div className="flex items-center justify-end gap-2">
+        {onCancel ? (
+          <Button type="button" variant="ghost" onClick={onCancel} disabled={isSubmitting}>
+            {messages.common.cancel}
+          </Button>
+        ) : null}
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? (
+            <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" />
+          ) : null}
+          {mode.kind === "create"
+            ? serviceMessages.actions.addService
+            : serviceMessages.actions.saveService}
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/packages/products-ui/src/components/product-itinerary-day-row.tsx
+++ b/packages/products-ui/src/components/product-itinerary-day-row.tsx
@@ -1,0 +1,181 @@
+"use client"
+
+import {
+  type ProductDayRecord,
+  type ProductDayServiceRecord,
+  useProductDayServices,
+} from "@voyantjs/products-react"
+import { Badge } from "@voyantjs/ui/components/badge"
+import { Button } from "@voyantjs/ui/components/button"
+import { ChevronDown, ChevronRight, Pencil, Plus, Trash2 } from "lucide-react"
+import type * as React from "react"
+
+import { useProductsUiMessagesOrDefault } from "../i18n/provider"
+
+export interface ProductItineraryDayRowRenderContext {
+  productId: string
+  day: ProductDayRecord
+  expanded: boolean
+}
+
+export interface ProductItineraryDayRowProps {
+  productId: string
+  day: ProductDayRecord
+  expanded: boolean
+  onToggle: () => void
+  onEdit?: () => void
+  onDelete?: () => void
+  onAddService?: () => void
+  onEditService?: (service: ProductDayServiceRecord) => void
+  onDeleteService?: (service: ProductDayServiceRecord) => void
+  renderDayDetails?: (context: ProductItineraryDayRowRenderContext) => React.ReactNode
+  renderServiceActions?: (service: ProductDayServiceRecord) => React.ReactNode
+}
+
+function formatServiceType(
+  serviceType: ProductDayServiceRecord["serviceType"],
+  messages: ReturnType<typeof useProductsUiMessagesOrDefault>["productDayServiceForm"],
+) {
+  return messages.serviceTypes[serviceType]
+}
+
+export function ProductItineraryDayRow({
+  productId,
+  day,
+  expanded,
+  onToggle,
+  onEdit,
+  onDelete,
+  onAddService,
+  onEditService,
+  onDeleteService,
+  renderDayDetails,
+  renderServiceActions,
+}: ProductItineraryDayRowProps) {
+  const messages = useProductsUiMessagesOrDefault()
+  const rowMessages = messages.productItineraryDayRow
+  const servicesQuery = useProductDayServices(productId, day.id, { enabled: expanded })
+  const services = servicesQuery.data?.data ?? []
+
+  return (
+    <div data-slot="product-itinerary-day-row" className="rounded-md border bg-background">
+      <div className="flex items-center gap-3 px-4 py-3">
+        <Button type="button" variant="ghost" size="icon-sm" onClick={onToggle}>
+          {expanded ? (
+            <ChevronDown className="size-4" aria-hidden="true" />
+          ) : (
+            <ChevronRight className="size-4" aria-hidden="true" />
+          )}
+        </Button>
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium">
+            {rowMessages.dayLabel.replace("{dayNumber}", String(day.dayNumber))}
+            {day.title ? `: ${day.title}` : ""}
+          </div>
+          {day.location ? (
+            <div className="truncate text-xs text-muted-foreground">{day.location}</div>
+          ) : null}
+        </div>
+        <div className="flex items-center gap-1">
+          {onAddService ? (
+            <Button type="button" variant="ghost" size="icon-sm" onClick={onAddService}>
+              <Plus className="size-4" aria-hidden="true" />
+            </Button>
+          ) : null}
+          {onEdit ? (
+            <Button type="button" variant="ghost" size="icon-sm" onClick={onEdit}>
+              <Pencil className="size-4" aria-hidden="true" />
+            </Button>
+          ) : null}
+          {onDelete ? (
+            <Button type="button" variant="ghost" size="icon-sm" onClick={onDelete}>
+              <Trash2 className="size-4" aria-hidden="true" />
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      {expanded ? (
+        <div className="border-t">
+          {renderDayDetails ? (
+            <div className="border-b p-4">{renderDayDetails({ productId, day, expanded })}</div>
+          ) : null}
+
+          {servicesQuery.isPending ? (
+            <p className="p-4 text-center text-sm text-muted-foreground">
+              {messages.common.loading}
+            </p>
+          ) : servicesQuery.isError ? (
+            <p className="p-4 text-center text-sm text-destructive">
+              {rowMessages.servicesLoadingError}
+            </p>
+          ) : services.length === 0 ? (
+            <p className="p-4 text-center text-sm text-muted-foreground">
+              {rowMessages.emptyServices}
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b bg-muted/30 text-muted-foreground">
+                    <th className="px-4 py-2 text-left font-medium">{rowMessages.columns.name}</th>
+                    <th className="px-3 py-2 text-left font-medium">{rowMessages.columns.type}</th>
+                    <th className="px-3 py-2 text-left font-medium">{rowMessages.columns.cost}</th>
+                    <th className="px-3 py-2 text-left font-medium">
+                      {rowMessages.columns.quantity}
+                    </th>
+                    <th className="w-24 px-3 py-2" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {services.map((service) => (
+                    <tr key={service.id} className="border-b last:border-b-0">
+                      <td className="px-4 py-2">{service.name}</td>
+                      <td className="px-3 py-2">
+                        <Badge variant="outline">
+                          {formatServiceType(service.serviceType, messages.productDayServiceForm)}
+                        </Badge>
+                      </td>
+                      <td className="px-3 py-2 font-mono text-xs">
+                        {(service.costAmountCents / 100).toFixed(2)} {service.costCurrency}
+                      </td>
+                      <td className="px-3 py-2">{service.quantity}</td>
+                      <td className="px-3 py-2">
+                        {renderServiceActions ? (
+                          renderServiceActions(service)
+                        ) : (
+                          <div className="flex items-center justify-end gap-1">
+                            {onEditService ? (
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon-sm"
+                                onClick={() => onEditService(service)}
+                              >
+                                <Pencil className="size-4" aria-hidden="true" />
+                              </Button>
+                            ) : null}
+                            {onDeleteService ? (
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon-sm"
+                                onClick={() => onDeleteService(service)}
+                              >
+                                <Trash2 className="size-4" aria-hidden="true" />
+                              </Button>
+                            ) : null}
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/products-ui/src/i18n/en.ts
+++ b/packages/products-ui/src/i18n/en.ts
@@ -229,6 +229,57 @@ export const productsUiEn = {
       saveDay: "Save day",
     },
   },
+  productDayServiceForm: {
+    fields: {
+      supplierService: "Supplier service",
+      serviceType: "Service type",
+      countryCode: "Country code",
+      name: "Name",
+      description: "Description",
+      costCurrency: "Currency",
+      costAmount: "Cost",
+      quantity: "Quantity",
+      sortOrder: "Sort order",
+      notes: "Notes",
+    },
+    placeholders: {
+      supplierService: "Optional supplier service id",
+      countryCode: "RO",
+      name: "Hotel stay",
+      description: "Operational service details",
+      notes: "Internal notes",
+    },
+    serviceTypes: {
+      accommodation: "Accommodation",
+      transfer: "Transfer",
+      experience: "Experience",
+      guide: "Guide",
+      meal: "Meal",
+      other: "Other",
+    },
+    validation: {
+      nameRequired: "Service name is required.",
+      currencyRequired: "Currency must be a 3-letter ISO code.",
+      costNonNegative: "Cost must be zero or greater.",
+      quantityMin: "Quantity must be at least 1.",
+      saveFailed: "Failed to save service.",
+    },
+    actions: {
+      addService: "Add service",
+      saveService: "Save service",
+    },
+  },
+  productItineraryDayRow: {
+    dayLabel: "Day {dayNumber}",
+    emptyServices: "No services configured for this day.",
+    servicesLoadingError: "Failed to load day services.",
+    columns: {
+      name: "Name",
+      type: "Type",
+      cost: "Cost",
+      quantity: "Quantity",
+    },
+  },
   productItineraryDialog: {
     titles: {
       create: "New itinerary",

--- a/packages/products-ui/src/i18n/messages.ts
+++ b/packages/products-ui/src/i18n/messages.ts
@@ -227,6 +227,57 @@ export type ProductsUiMessages = {
       saveDay: string
     }
   }
+  productDayServiceForm: {
+    fields: {
+      supplierService: string
+      serviceType: string
+      countryCode: string
+      name: string
+      description: string
+      costCurrency: string
+      costAmount: string
+      quantity: string
+      sortOrder: string
+      notes: string
+    }
+    placeholders: {
+      supplierService: string
+      countryCode: string
+      name: string
+      description: string
+      notes: string
+    }
+    serviceTypes: {
+      accommodation: string
+      transfer: string
+      experience: string
+      guide: string
+      meal: string
+      other: string
+    }
+    validation: {
+      nameRequired: string
+      currencyRequired: string
+      costNonNegative: string
+      quantityMin: string
+      saveFailed: string
+    }
+    actions: {
+      addService: string
+      saveService: string
+    }
+  }
+  productItineraryDayRow: {
+    dayLabel: string
+    emptyServices: string
+    servicesLoadingError: string
+    columns: {
+      name: string
+      type: string
+      cost: string
+      quantity: string
+    }
+  }
   productItineraryDialog: {
     titles: {
       create: string

--- a/packages/products-ui/src/i18n/ro.ts
+++ b/packages/products-ui/src/i18n/ro.ts
@@ -229,6 +229,57 @@ export const productsUiRo = {
       saveDay: "Salveaza ziua",
     },
   },
+  productDayServiceForm: {
+    fields: {
+      supplierService: "Serviciu furnizor",
+      serviceType: "Tip serviciu",
+      countryCode: "Cod tara",
+      name: "Nume",
+      description: "Descriere",
+      costCurrency: "Moneda",
+      costAmount: "Cost",
+      quantity: "Cantitate",
+      sortOrder: "Ordine sortare",
+      notes: "Note",
+    },
+    placeholders: {
+      supplierService: "ID serviciu furnizor optional",
+      countryCode: "RO",
+      name: "Cazare hotel",
+      description: "Detalii operationale ale serviciului",
+      notes: "Note interne",
+    },
+    serviceTypes: {
+      accommodation: "Cazare",
+      transfer: "Transfer",
+      experience: "Experienta",
+      guide: "Ghid",
+      meal: "Masa",
+      other: "Altul",
+    },
+    validation: {
+      nameRequired: "Numele serviciului este obligatoriu.",
+      currencyRequired: "Moneda trebuie sa fie un cod ISO din 3 litere.",
+      costNonNegative: "Costul trebuie sa fie zero sau mai mare.",
+      quantityMin: "Cantitatea trebuie sa fie cel putin 1.",
+      saveFailed: "Salvarea serviciului a esuat.",
+    },
+    actions: {
+      addService: "Adauga serviciu",
+      saveService: "Salveaza serviciul",
+    },
+  },
+  productItineraryDayRow: {
+    dayLabel: "Ziua {dayNumber}",
+    emptyServices: "Nu exista servicii configurate pentru aceasta zi.",
+    servicesLoadingError: "Incarcarea serviciilor zilei a esuat.",
+    columns: {
+      name: "Nume",
+      type: "Tip",
+      cost: "Cost",
+      quantity: "Cantitate",
+    },
+  },
   productItineraryDialog: {
     titles: {
       create: "Itinerar nou",

--- a/packages/products-ui/src/index.ts
+++ b/packages/products-ui/src/index.ts
@@ -16,6 +16,22 @@ export {
 export { ProductDayDialog, type ProductDayDialogProps } from "./components/product-day-dialog"
 export { ProductDayForm, type ProductDayFormProps } from "./components/product-day-form"
 export {
+  ProductDayMediaTray,
+  type ProductDayMediaTrayProps,
+} from "./components/product-day-media-tray"
+export {
+  ProductDayServiceForm,
+  type ProductDayServiceFormHelpers,
+  type ProductDayServiceFormProps,
+  type ProductDayServiceSupplierServiceFieldProps,
+  type ProductDayServiceSupplierServiceOption,
+} from "./components/product-day-service-form"
+export {
+  ProductItineraryDayRow,
+  type ProductItineraryDayRowProps,
+  type ProductItineraryDayRowRenderContext,
+} from "./components/product-itinerary-day-row"
+export {
   ProductItineraryDialog,
   type ProductItineraryDialogProps,
 } from "./components/product-itinerary-dialog"

--- a/packages/storefront/src/index.ts
+++ b/packages/storefront/src/index.ts
@@ -5,7 +5,11 @@ import { createStorefrontPublicRoutes } from "./routes-public.js"
 
 export type { StorefrontPublicRoutes } from "./routes-public.js"
 export { createStorefrontPublicRoutes } from "./routes-public.js"
-export type { StorefrontServiceOptions } from "./service.js"
+export type {
+  StorefrontOfferResolvers,
+  StorefrontRequestContext,
+  StorefrontServiceOptions,
+} from "./service.js"
 export { createStorefrontService, resolveStorefrontSettings } from "./service.js"
 export type {
   StorefrontDepartureListQuery,
@@ -14,6 +18,7 @@ export type {
   StorefrontPaymentMethod,
   StorefrontPaymentMethodCode,
   StorefrontPaymentMethodInput,
+  StorefrontProductAvailabilitySummaryQuery,
   StorefrontPromotionalOffer,
   StorefrontSettings,
   StorefrontSettingsInput,
@@ -32,6 +37,11 @@ export {
   storefrontPaymentMethodCodeSchema,
   storefrontPaymentMethodInputSchema,
   storefrontPaymentMethodSchema,
+  storefrontProductAvailabilitySlotSchema,
+  storefrontProductAvailabilityStateSchema,
+  storefrontProductAvailabilitySummaryQuerySchema,
+  storefrontProductAvailabilitySummaryResponseSchema,
+  storefrontProductAvailabilitySummarySchema,
   storefrontProductExtensionsQuerySchema,
   storefrontProductExtensionsResponseSchema,
   storefrontPromotionalOfferListQuerySchema,

--- a/packages/storefront/src/routes-public.ts
+++ b/packages/storefront/src/routes-public.ts
@@ -1,10 +1,16 @@
 import { parseJsonBody, parseQuery } from "@voyantjs/hono"
+import type { Context } from "hono"
 import { Hono } from "hono"
 
-import { createStorefrontService, type StorefrontServiceOptions } from "./service.js"
+import {
+  createStorefrontService,
+  type StorefrontRequestContext,
+  type StorefrontServiceOptions,
+} from "./service.js"
 import {
   storefrontDepartureListQuerySchema,
   storefrontDeparturePricePreviewInputSchema,
+  storefrontProductAvailabilitySummaryQuerySchema,
   storefrontProductExtensionsQuerySchema,
   storefrontPromotionalOfferListQuerySchema,
 } from "./validation.js"
@@ -18,9 +24,17 @@ type Env = {
 export function createStorefrontPublicRoutes(options?: StorefrontServiceOptions) {
   const storefrontService = createStorefrontService(options)
 
+  function getRequestContext(c: Context<Env>): StorefrontRequestContext {
+    return {
+      db: c.get("db" as never) as StorefrontRequestContext["db"],
+      env: c.env,
+      context: c,
+    } satisfies StorefrontRequestContext
+  }
+
   return new Hono<Env>()
-    .get("/settings", (c) => {
-      return c.json({ data: storefrontService.getSettings() })
+    .get("/settings", async (c) => {
+      return c.json({ data: await storefrontService.resolveSettings(getRequestContext(c)) })
     })
     .get("/departures/:departureId", async (c) => {
       const departure = await storefrontService.getDeparture(
@@ -63,6 +77,15 @@ export function createStorefrontPublicRoutes(options?: StorefrontServiceOptions)
         ),
       })
     })
+    .get("/products/:productId/availability", async (c) => {
+      return c.json({
+        data: await storefrontService.getProductAvailabilitySummary(
+          c.get("db" as never),
+          c.req.param("productId"),
+          await parseQuery(c, storefrontProductAvailabilitySummaryQuerySchema),
+        ),
+      })
+    })
     .get("/products/:productId/departures/:departureId/itinerary", async (c) => {
       const itinerary = await storefrontService.getDepartureItinerary(c.get("db" as never), {
         departureId: c.req.param("departureId"),
@@ -81,6 +104,7 @@ export function createStorefrontPublicRoutes(options?: StorefrontServiceOptions)
           productId: c.req.param("productId"),
           departureId: query.departureId,
           locale: query.locale,
+          context: getRequestContext(c),
         }),
       })
     })
@@ -89,6 +113,7 @@ export function createStorefrontPublicRoutes(options?: StorefrontServiceOptions)
       const offer = await storefrontService.getOfferBySlug({
         slug: c.req.param("slug"),
         locale: query.locale,
+        context: getRequestContext(c),
       })
 
       return offer ? c.json({ data: offer }) : c.json({ error: "Storefront offer not found" }, 404)

--- a/packages/storefront/src/service-departures.ts
+++ b/packages/storefront/src/service-departures.ts
@@ -24,6 +24,7 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type {
   StorefrontDepartureListQuery,
   StorefrontDeparturePricePreviewInput,
+  StorefrontProductAvailabilitySummaryQuery,
 } from "./validation.js"
 
 type SlotRow = {
@@ -298,6 +299,7 @@ async function listSlots(
     dateTo?: string
     limit?: number
     offset?: number
+    includeCancelled?: boolean
   } = {},
 ) {
   const conditions = [
@@ -320,7 +322,7 @@ async function listSlots(
 
   if (filters.status) {
     conditions.push(eq(availabilitySlots.status, filters.status))
-  } else {
+  } else if (!filters.includeCancelled) {
     conditions.push(ne(availabilitySlots.status, "cancelled"))
   }
 
@@ -374,6 +376,7 @@ async function countSlots(
     status?: "open" | "closed" | "sold_out" | "cancelled"
     dateFrom?: string
     dateTo?: string
+    includeCancelled?: boolean
   } = {},
 ) {
   const conditions = [
@@ -396,7 +399,7 @@ async function countSlots(
 
   if (filters.status) {
     conditions.push(eq(availabilitySlots.status, filters.status))
-  } else {
+  } else if (!filters.includeCancelled) {
     conditions.push(ne(availabilitySlots.status, "cancelled"))
   }
 
@@ -911,6 +914,169 @@ export async function listStorefrontProductDepartures(
   return {
     data,
     total,
+    limit: query.limit,
+    offset: query.offset,
+  }
+}
+
+type StorefrontProductAvailabilityState =
+  | "available"
+  | "sold_out"
+  | "closed"
+  | "cancelled"
+  | "on_request"
+  | "past_cutoff"
+  | "too_early"
+  | "unavailable"
+
+function todayLocalDate() {
+  return new Date().toISOString().slice(0, 10)
+}
+
+function buildAvailabilityState(args: {
+  status: "open" | "closed" | "sold_out" | "cancelled" | "on_request"
+  remaining: number | null
+  capacity: number | null
+  pastCutoff: boolean
+  tooEarly: boolean
+}): StorefrontProductAvailabilityState {
+  if (args.status === "cancelled") return "cancelled"
+  if (args.status === "closed") return "closed"
+  if (args.status === "sold_out") return "sold_out"
+  if (args.status === "on_request") return "on_request"
+  if (args.pastCutoff) return "past_cutoff"
+  if (args.tooEarly) return "too_early"
+  if (args.capacity != null && args.remaining === 0) return "sold_out"
+
+  return "available"
+}
+
+function summarizeProductAvailability(
+  departures: Array<{
+    availabilityState: StorefrontProductAvailabilityState
+    status: "open" | "closed" | "sold_out" | "cancelled" | "on_request"
+  }>,
+): StorefrontProductAvailabilityState {
+  if (departures.some((departure) => departure.availabilityState === "available")) {
+    return "available"
+  }
+  if (departures.some((departure) => departure.availabilityState === "on_request")) {
+    return "on_request"
+  }
+  if (departures.some((departure) => departure.availabilityState === "too_early")) {
+    return "too_early"
+  }
+  if (departures.some((departure) => departure.availabilityState === "past_cutoff")) {
+    return "past_cutoff"
+  }
+  if (departures.some((departure) => departure.availabilityState === "sold_out")) {
+    return "sold_out"
+  }
+  if (departures.some((departure) => departure.availabilityState === "closed")) {
+    return "closed"
+  }
+  if (departures.some((departure) => departure.availabilityState === "cancelled")) {
+    return "cancelled"
+  }
+
+  return "unavailable"
+}
+
+export async function getStorefrontProductAvailabilitySummary(
+  db: PostgresJsDatabase,
+  productId: string,
+  query: StorefrontProductAvailabilitySummaryQuery,
+) {
+  const requestedStatus = query.status
+  const persistedStatus = requestedStatus === "on_request" ? "open" : requestedStatus
+  const filters = {
+    productId,
+    optionId: query.optionId,
+    status: persistedStatus,
+    dateFrom: query.dateFrom ?? todayLocalDate(),
+    dateTo: query.dateTo,
+    includeCancelled: true,
+  }
+  const [slots, total] = await Promise.all([
+    listSlots(db, {
+      ...filters,
+      limit: query.limit,
+      offset: query.offset,
+    }),
+    countSlots(db, filters),
+  ])
+  const [meetingPointByProduct, defaultItineraryByProduct] = await Promise.all([
+    listMeetingPointsByProductIds(db, [productId]),
+    listDefaultItineraryIdsByProductIds(db, [productId]),
+  ])
+  const departures = (
+    await Promise.all(
+      slots.map(async (slot) => {
+        const departure = await buildDeparture(
+          db,
+          slot,
+          defaultItineraryByProduct,
+          meetingPointByProduct,
+        )
+        const availabilityState = buildAvailabilityState({
+          status: departure.departureStatus,
+          remaining: departure.remaining,
+          capacity: departure.capacity,
+          pastCutoff: slot.pastCutoff,
+          tooEarly: slot.tooEarly,
+        })
+
+        return {
+          id: departure.id,
+          productId: departure.productId,
+          optionId: departure.optionId,
+          dateLocal: departure.dateLocal,
+          startAt: departure.startAt,
+          endAt: departure.endAt,
+          timezone: departure.timezone,
+          status: departure.departureStatus,
+          availabilityState,
+          capacity: departure.capacity,
+          remaining: departure.remaining,
+          pastCutoff: slot.pastCutoff,
+          tooEarly: slot.tooEarly,
+        }
+      }),
+    )
+  ).filter((departure) => !requestedStatus || departure.status === requestedStatus)
+
+  const counts = departures.reduce(
+    (acc, departure) => {
+      acc.total += 1
+      if (departure.status === "open") acc.open += 1
+      if (departure.status === "closed") acc.closed += 1
+      if (departure.status === "sold_out") acc.soldOut += 1
+      if (departure.status === "cancelled") acc.cancelled += 1
+      if (departure.status === "on_request") acc.onRequest += 1
+      if (departure.availabilityState === "past_cutoff") acc.pastCutoff += 1
+      if (departure.availabilityState === "too_early") acc.tooEarly += 1
+      if (departure.availabilityState === "available") acc.available += 1
+      return acc
+    },
+    {
+      total: 0,
+      open: 0,
+      closed: 0,
+      soldOut: 0,
+      cancelled: 0,
+      onRequest: 0,
+      pastCutoff: 0,
+      tooEarly: 0,
+      available: 0,
+    },
+  )
+
+  return {
+    productId,
+    availabilityState: summarizeProductAvailability(departures),
+    counts,
+    departures,
+    total: requestedStatus === "on_request" ? departures.length : total,
     limit: query.limit,
     offset: query.offset,
   }

--- a/packages/storefront/src/service.ts
+++ b/packages/storefront/src/service.ts
@@ -3,6 +3,7 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import {
   getStorefrontDeparture,
   getStorefrontDepartureItinerary,
+  getStorefrontProductAvailabilitySummary,
   getStorefrontProductExtensions,
   listStorefrontProductDepartures,
   previewStorefrontDeparturePrice,
@@ -15,6 +16,7 @@ import {
   type StorefrontPaymentMethod,
   type StorefrontPaymentMethodCode,
   type StorefrontPaymentMethodInput,
+  type StorefrontProductAvailabilitySummaryQuery,
   type StorefrontPromotionalOffer,
   type StorefrontSettings,
   type StorefrontSettingsInput,
@@ -24,17 +26,39 @@ import {
 
 export interface StorefrontServiceOptions {
   settings?: StorefrontSettingsInput
-  offers?: {
-    listApplicableOffers?: (input: {
+  resolveSettings?: (
+    context: StorefrontRequestContext,
+  ) => Promise<StorefrontSettingsInput> | StorefrontSettingsInput
+  offers?: StorefrontOfferResolvers
+  resolveOffers?: (
+    context: StorefrontRequestContext,
+  ) =>
+    | Promise<StorefrontOfferResolvers | null | undefined>
+    | StorefrontOfferResolvers
+    | null
+    | undefined
+}
+
+export interface StorefrontRequestContext {
+  db?: PostgresJsDatabase
+  env?: unknown
+  context?: unknown
+}
+
+export interface StorefrontOfferResolvers {
+  listApplicableOffers?: (
+    input: {
       productId: string
       departureId?: string
       locale?: string
-    }) => Promise<StorefrontPromotionalOffer[]> | StorefrontPromotionalOffer[]
-    getOfferBySlug?: (input: {
+    } & StorefrontRequestContext,
+  ) => Promise<StorefrontPromotionalOffer[]> | StorefrontPromotionalOffer[]
+  getOfferBySlug?: (
+    input: {
       slug: string
       locale?: string
-    }) => Promise<StorefrontPromotionalOffer | null> | StorefrontPromotionalOffer | null
-  }
+    } & StorefrontRequestContext,
+  ) => Promise<StorefrontPromotionalOffer | null> | StorefrontPromotionalOffer | null
 }
 
 const defaultPaymentLabels: Record<StorefrontPaymentMethodCode, string> = {
@@ -102,10 +126,23 @@ export function resolveStorefrontSettings(input?: StorefrontSettingsInput): Stor
 export function createStorefrontService(options?: StorefrontServiceOptions) {
   const settings = resolveStorefrontSettings(options?.settings)
 
+  async function resolveSettings(context: StorefrontRequestContext = {}) {
+    if (!options?.resolveSettings) {
+      return settings
+    }
+
+    return resolveStorefrontSettings(await options.resolveSettings(context))
+  }
+
+  async function resolveOffers(context: StorefrontRequestContext = {}) {
+    return (await options?.resolveOffers?.(context)) ?? options?.offers
+  }
+
   return {
     getSettings(): StorefrontSettings {
       return settings
     },
+    resolveSettings,
     getDeparture(db: PostgresJsDatabase, departureId: string) {
       return getStorefrontDeparture(db, departureId)
     },
@@ -126,6 +163,13 @@ export function createStorefrontService(options?: StorefrontServiceOptions) {
     getProductExtensions(db: PostgresJsDatabase, productId: string, optionId?: string) {
       return getStorefrontProductExtensions(db, productId, optionId)
     },
+    getProductAvailabilitySummary(
+      db: PostgresJsDatabase,
+      productId: string,
+      query: StorefrontProductAvailabilitySummaryQuery,
+    ) {
+      return getStorefrontProductAvailabilitySummary(db, productId, query)
+    },
     getDepartureItinerary(
       db: PostgresJsDatabase,
       input: { departureId: string; productId: string },
@@ -136,15 +180,25 @@ export function createStorefrontService(options?: StorefrontServiceOptions) {
       productId: string
       departureId?: string
       locale?: string
+      context?: StorefrontRequestContext
     }): Promise<StorefrontPromotionalOffer[]> {
-      const offers = await options?.offers?.listApplicableOffers?.(input)
+      const { context, ...offerInput } = input
+      const offers = await resolveOffers(context)?.then((resolvers) =>
+        resolvers?.listApplicableOffers?.({ ...offerInput, ...(context ?? {}) }),
+      )
       return offers ?? []
     },
     async getOfferBySlug(input: {
       slug: string
       locale?: string
+      context?: StorefrontRequestContext
     }): Promise<StorefrontPromotionalOffer | null> {
-      return (await options?.offers?.getOfferBySlug?.(input)) ?? null
+      const { context, ...offerInput } = input
+      return (
+        (await resolveOffers(context)?.then((resolvers) =>
+          resolvers?.getOfferBySlug?.({ ...offerInput, ...(context ?? {}) }),
+        )) ?? null
+      )
     },
   }
 }

--- a/packages/storefront/src/validation.ts
+++ b/packages/storefront/src/validation.ts
@@ -218,6 +218,67 @@ export const storefrontDepartureListResponseSchema = z.object({
   offset: z.number().int(),
 })
 
+export const storefrontProductAvailabilityStateSchema = z.enum([
+  "available",
+  "sold_out",
+  "closed",
+  "cancelled",
+  "on_request",
+  "past_cutoff",
+  "too_early",
+  "unavailable",
+])
+
+export const storefrontProductAvailabilitySummaryQuerySchema = z.object({
+  optionId: z.string().optional(),
+  status: storefrontDepartureStatusSchema.optional(),
+  dateFrom: z.string().date().optional(),
+  dateTo: z.string().date().optional(),
+  locale: languageTagSchema.optional(),
+  limit: z.coerce.number().int().min(1).max(250).default(100),
+  offset: z.coerce.number().int().min(0).default(0),
+})
+
+export const storefrontProductAvailabilitySlotSchema = z.object({
+  id: z.string(),
+  productId: z.string(),
+  optionId: z.string().nullable(),
+  dateLocal: z.string().nullable(),
+  startAt: z.string().nullable(),
+  endAt: z.string().nullable(),
+  timezone: z.string(),
+  status: storefrontDepartureStatusSchema,
+  availabilityState: storefrontProductAvailabilityStateSchema,
+  capacity: z.number().int().nullable(),
+  remaining: z.number().int().nullable(),
+  pastCutoff: z.boolean(),
+  tooEarly: z.boolean(),
+})
+
+export const storefrontProductAvailabilitySummarySchema = z.object({
+  productId: z.string(),
+  availabilityState: storefrontProductAvailabilityStateSchema,
+  counts: z.object({
+    total: z.number().int(),
+    open: z.number().int(),
+    closed: z.number().int(),
+    soldOut: z.number().int(),
+    cancelled: z.number().int(),
+    onRequest: z.number().int(),
+    pastCutoff: z.number().int(),
+    tooEarly: z.number().int(),
+    available: z.number().int(),
+  }),
+  departures: z.array(storefrontProductAvailabilitySlotSchema),
+  total: z.number().int(),
+  limit: z.number().int(),
+  offset: z.number().int(),
+})
+
+export const storefrontProductAvailabilitySummaryResponseSchema = z.object({
+  data: storefrontProductAvailabilitySummarySchema,
+})
+
 export const storefrontDeparturePricePreviewInputSchema = z.object({
   pax: z
     .object({
@@ -367,6 +428,9 @@ export type StorefrontPaymentMethodCode = z.infer<typeof storefrontPaymentMethod
 export type StorefrontSettingsInput = z.infer<typeof storefrontSettingsInputSchema>
 export type StorefrontSettings = z.infer<typeof storefrontSettingsSchema>
 export type StorefrontDepartureListQuery = z.infer<typeof storefrontDepartureListQuerySchema>
+export type StorefrontProductAvailabilitySummaryQuery = z.infer<
+  typeof storefrontProductAvailabilitySummaryQuerySchema
+>
 export type StorefrontDeparturePricePreviewInput = z.infer<
   typeof storefrontDeparturePricePreviewInputSchema
 >

--- a/packages/storefront/tests/integration/public-routes.test.ts
+++ b/packages/storefront/tests/integration/public-routes.test.ts
@@ -212,6 +212,48 @@ describe.skipIf(!DB_AVAILABLE)("Storefront public routes", () => {
     const detailRes = await app.request(`/departures/${slot.id}`)
     expect(detailRes.status).toBe(200)
     expect((await detailRes.json()).data.id).toBe(slot.id)
+
+    const availabilityRes = await app.request(
+      `/products/${product.id}/availability?dateFrom=2026-08-01`,
+    )
+    expect(availabilityRes.status).toBe(200)
+    expect(await availabilityRes.json()).toEqual({
+      data: {
+        productId: product.id,
+        availabilityState: "available",
+        counts: {
+          total: 1,
+          open: 1,
+          closed: 0,
+          soldOut: 0,
+          cancelled: 0,
+          onRequest: 0,
+          pastCutoff: 0,
+          tooEarly: 0,
+          available: 1,
+        },
+        departures: [
+          {
+            id: slot.id,
+            productId: product.id,
+            optionId: option.id,
+            dateLocal: "2026-08-01",
+            startAt: "2026-08-01T05:30:00.000Z",
+            endAt: "2026-08-01T13:30:00.000Z",
+            timezone: "Europe/Bucharest",
+            status: "open",
+            availabilityState: "available",
+            capacity: 24,
+            remaining: 12,
+            pastCutoff: false,
+            tooEarly: false,
+          },
+        ],
+        total: 1,
+        limit: 100,
+        offset: 0,
+      },
+    })
   })
 
   it("returns a departure price preview with extras", async () => {

--- a/packages/storefront/tests/unit/public-routes.test.ts
+++ b/packages/storefront/tests/unit/public-routes.test.ts
@@ -161,6 +161,39 @@ describe("createStorefrontPublicRoutes", () => {
     })
   })
 
+  it("resolves storefront settings from request context", async () => {
+    const requestDb = { tenant: "tenant_123" }
+    const app = new Hono()
+      .use("*", async (c, next) => {
+        c.set("db" as never, requestDb)
+        await next()
+      })
+      .route(
+        "/",
+        createStorefrontPublicRoutes({
+          resolveSettings({ db, context }) {
+            expect(db).toBe(requestDb)
+            const honoContext = context as { req: { header: (name: string) => string | undefined } }
+
+            return {
+              support: {
+                email: `${honoContext.req.header("x-storefront") ?? "default"}@example.com`,
+              },
+            }
+          },
+        }),
+      )
+
+    const res = await app.request("/settings", {
+      headers: {
+        "x-storefront": "bucharest",
+      },
+    })
+
+    expect(res.status).toBe(200)
+    expect((await res.json()).data.support.email).toBe("bucharest@example.com")
+  })
+
   it("returns applicable promotional offers from the injected resolver", async () => {
     const app = new Hono().route(
       "/",
@@ -262,5 +295,56 @@ describe("createStorefrontPublicRoutes", () => {
 
     expect(res.status).toBe(200)
     expect((await res.json()).data.slug).toBe("early-booking")
+  })
+
+  it("resolves promotional offers from request context", async () => {
+    const requestDb = { tenant: "tenant_123" }
+    const app = new Hono()
+      .use("*", async (c, next) => {
+        c.set("db" as never, requestDb)
+        await next()
+      })
+      .route(
+        "/",
+        createStorefrontPublicRoutes({
+          resolveOffers({ db }) {
+            expect(db).toBe(requestDb)
+
+            return {
+              listApplicableOffers({ productId, db: callbackDb }) {
+                expect(productId).toBe("prod_123")
+                expect(callbackDb).toBe(requestDb)
+
+                return [
+                  {
+                    id: "offer_context",
+                    name: "Context offer",
+                    slug: "context-offer",
+                    description: null,
+                    discountType: "percentage",
+                    discountValue: "10",
+                    currency: null,
+                    applicableProductIds: ["prod_123"],
+                    applicableDepartureIds: [],
+                    validFrom: null,
+                    validTo: null,
+                    minTravelers: null,
+                    imageMobileUrl: null,
+                    imageDesktopUrl: null,
+                    stackable: false,
+                    createdAt: "2026-04-01T00:00:00.000Z",
+                    updatedAt: "2026-04-01T00:00:00.000Z",
+                  },
+                ]
+              },
+            }
+          },
+        }),
+      )
+
+    const res = await app.request("/products/prod_123/offers")
+
+    expect(res.status).toBe(200)
+    expect((await res.json()).data[0].id).toBe("offer_context")
   })
 })

--- a/templates/dmc/src/components/voyant/availability/availability-overview.tsx
+++ b/templates/dmc/src/components/voyant/availability/availability-overview.tsx
@@ -28,6 +28,7 @@ import { useAdminMessages } from "@/lib/admin-i18n"
 export function AvailabilityOverview({
   products,
   constrainedSlots,
+  openSlotsCount: providedOpenSlotsCount,
   filteredRules,
   filteredPickupPoints,
   productsWithoutActiveRules,
@@ -42,6 +43,7 @@ export function AvailabilityOverview({
 }: {
   products: ProductOption[]
   constrainedSlots: AvailabilitySlotRow[]
+  openSlotsCount?: number
   filteredRules: AvailabilityRuleRow[]
   filteredPickupPoints: AvailabilityPickupPointRow[]
   productsWithoutActiveRules: ProductOption[]
@@ -55,7 +57,8 @@ export function AvailabilityOverview({
   onOpenProduct: (productId: string) => void
 }) {
   const messages = useAdminMessages()
-  const openSlotsCount = constrainedSlots.filter((slot) => slot.status === "open").length
+  const openSlotsCount =
+    providedOpenSlotsCount ?? constrainedSlots.filter((slot) => slot.status === "open").length
   const activeRulesCount = filteredRules.filter((rule) => rule.active).length
   const activePickupPointsCount = filteredPickupPoints.filter(
     (pickupPoint) => pickupPoint.active,

--- a/templates/dmc/src/components/voyant/availability/availability-page.tsx
+++ b/templates/dmc/src/components/voyant/availability/availability-page.tsx
@@ -294,6 +294,7 @@ export function AvailabilityPage() {
           <AvailabilityOverview
             products={products}
             constrainedSlots={constrainedSlots}
+            openSlotsCount={filteredSlots.filter((slot) => slot.status === "open").length}
             filteredRules={filteredRules}
             filteredPickupPoints={filteredPickupPoints}
             productsWithoutActiveRules={productsWithoutActiveRules}

--- a/templates/operator/src/components/voyant/availability/availability-page.tsx
+++ b/templates/operator/src/components/voyant/availability/availability-page.tsx
@@ -291,6 +291,7 @@ export function AvailabilityPage() {
             messages={messages.availability}
             products={products}
             constrainedSlots={constrainedSlots}
+            openSlotsCount={filteredSlots.filter((slot) => slot.status === "open").length}
             filteredRules={filteredRules}
             filteredPickupPoints={filteredPickupPoints}
             productsWithoutActiveRules={productsWithoutActiveRules}


### PR DESCRIPTION
## Summary

- Add request-aware storefront settings and offer resolution, including tests for request context forwarding.
- Add a public product availability summary endpoint with query validation and route coverage.
- Split the availability overview open metric from constrained-slot counts for app/template consumers.
- Add products UI itinerary day extension components for media trays, day rows, and supplier-aware service forms.
- Add a changeset for the published package API additions.

## Validation

- Full pre-commit lint/typecheck suite: 111 tasks successful.
- Full pre-push test suite: 112 tasks successful.
- Focused package checks also passed for storefront, products-ui, and availability-ui.

Closes #406.
Closes #407.
Closes #408.
Closes #409.