### PR TITLE
Expose catalog BookingJourney route module

### DIFF
--- a/.changeset/quiet-catalog-routes.md
+++ b/.changeset/quiet-catalog-routes.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/catalog": patch
+---
+
+Expose a reusable BookingJourney Hono route module for the catalog booking engine.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Architecture checks
         run: pnpm verify:architecture
 
+      - name: Build
+        run: pnpm build
+
       - name: Package export checks
         run: pnpm verify:package-exports
 

--- a/docs/architecture/catalog-booking-route-module-plan.md
+++ b/docs/architecture/catalog-booking-route-module-plan.md
@@ -1,0 +1,260 @@
+# Catalog Booking Route Module Plan
+
+Status: proposed for [issue #418](https://github.com/voyantjs/voyant/issues/418)
+
+## Problem
+
+`@voyantjs/catalog` publishes the booking engine services and
+`@voyantjs/catalog-react/booking-engine` publishes hooks that call the booking
+journey HTTP contract. Package consumers still need to recreate the Hono route
+layer that those hooks expect before `@voyantjs/bookings-ui/journey` can be a
+safe installable package swap.
+
+The operator template currently has a working implementation in
+`templates/operator/src/api/catalog-booking.ts`, but it mixes three concerns:
+
+- the reusable BookingJourney route contract
+- operator-specific helpers such as slots, order administration, and booking
+  snapshot enrichment
+- deployment-specific runtime wiring for registries, tax policy, auth, and
+  checkout handoff
+
+Issue #418 should extract the reusable contract without pulling template-only
+dependencies into `@voyantjs/catalog`.
+
+## Goals
+
+- Export a `createCatalogBookingHonoModule()` or equivalent route factory from
+  `@voyantjs/catalog/booking-engine`.
+- Cover the route family used by `@voyantjs/catalog-react/booking-engine`:
+  - `POST /v1/{admin,public}/catalog/quote`
+  - `PUT /v1/{admin,public}/catalog/drafts/:id`
+  - `GET /v1/{admin,public}/catalog/drafts/:id`
+  - `DELETE /v1/{admin,public}/catalog/drafts/:id`
+  - `POST /v1/{admin,public}/catalog/holds/place`
+  - `POST /v1/{admin,public}/catalog/holds/release`
+  - `POST /v1/{admin,public}/catalog/book`
+- Accept runtime injections for source adapters, owned handlers, content
+  enrichment, snapshot capture, actor identity, adapter context, and optional
+  post-commit hooks.
+- Use shared route parsing and error conventions from `@voyantjs/hono`.
+- Keep admin and public surfaces explicit so package consumers know which
+  public paths must be allowed by their app auth policy.
+- Migrate the operator template to consume the shared module for the reusable
+  route family while keeping template-only routes local.
+
+## Non-Goals
+
+- Do not move `/slots` into `@voyantjs/catalog` in the first slice. Slot lookup
+  depends on availability, products, product content, suppliers, and
+  template-specific source-content behavior.
+- Do not move admin order routes into the first reusable module:
+  - `GET /v1/admin/catalog/orders`
+  - `GET /v1/admin/catalog/orders/:id`
+  - `POST /v1/admin/catalog/orders/:id/cancel`
+- Do not move `GET /v1/admin/bookings/:id/catalog-snapshot` into the first
+  reusable module. It enriches snapshots with operator-facing labels and owned
+  product details.
+- Do not add in-package tenant scoping to `packages/*`. The app-level Hono
+  auth and deployment boundary continue to own tenant and actor policy.
+
+## Proposed Package Surface
+
+Add a route module file in the booking engine package:
+
+```ts
+// @voyantjs/catalog/booking-engine
+export function createCatalogBookingRoutes(
+  options: CatalogBookingRoutesOptions,
+): Hono
+
+export function createCatalogBookingHonoModule(
+  options: CatalogBookingRoutesOptions,
+): HonoModule
+```
+
+The Hono module should use `module.name = "catalog"` with both `adminRoutes`
+and `publicRoutes` mounted at the catalog module path by `@voyantjs/hono`:
+
+- admin routes become `/v1/admin/catalog/*`
+- public routes become `/v1/public/catalog/*`
+
+If the package needs a lower-level escape hatch, also export a route factory
+that returns relative routes (`/quote`, `/drafts/:id`, `/holds/place`,
+`/holds/release`, `/book`) so templates can compose the surface manually.
+
+## Runtime Options
+
+The route factory should accept callbacks rather than importing template
+runtime modules:
+
+```ts
+interface CatalogBookingRoutesOptions {
+  resolveDb(c: Context): AnyDrizzleDb
+  resolveSourceRegistry(c: Context): SourceAdapterRegistry
+  resolveOwnedHandlers?(c: Context): OwnedBookingHandlerRegistry | undefined
+
+  resolveActorId?(c: Context): string | null
+  resolveCorrelationId?(c: Context): string
+  resolveAdapterContext?(input: CatalogBookingAdapterContextInput): SourceAdapterContext
+  resolveEntityProvenance?(input: CatalogBookingProvenanceInput): Promise<CatalogBookingProvenance>
+
+  contentEnricher?: QuoteContentEnricher
+  onContentEnricherError?: QuoteEntityDeps["onEnricherError"]
+  captureSnapshotContent?: SnapshotContentCapturer
+
+  resolveHoldTtlMs?(input: CatalogBookingHoldTtlInput): Promise<number>
+  onDraftConsumedError?(event: CatalogBookingDraftConsumedError): void
+  onCommitted?(event: CatalogBookingCommittedEvent): Promise<void> | void
+  transformQuoteResult?(event: CatalogBookingQuoteTransformInput): Promise<QuoteEntityResult>
+  transformBookResult?(event: CatalogBookingBookTransformInput): Promise<BookEntityResult>
+}
+```
+
+Defaults should be conservative:
+
+- `resolveActorId` reads `userId` from Hono context when present and otherwise
+  returns `null`.
+- `resolveCorrelationId` uses `x-request-id`, then `crypto.randomUUID()`.
+- `resolveEntityProvenance` uses `readSourcedEntry(...)` and falls back to
+  `OWNED_SOURCE_KIND`.
+- `resolveHoldTtlMs` returns 30 minutes unless the template overrides it.
+- `resolveAdapterContext` uses the resolved connection id or source kind plus
+  the correlation id.
+
+## Request Validation
+
+All JSON routes should use `parseJsonBody(...)` from `@voyantjs/hono`; query
+routes in later slices should use `parseQuery(...)`.
+
+Add local route schemas near the route module. They should validate only the
+HTTP contract and keep engine validation inside the engine services:
+
+- quote body: entity pointer, optional source pointer, scope, parameters,
+  draft, and TTL
+- draft upsert body: entity pointer for creation, source pointer, draft
+  payload, current step, current quote id, and TTL
+- hold place body: entity pointer, draft id, optional TTL, and parameters
+- hold release body: entity module and hold token
+- book body: quote id or draft id, optional booking id, party, payment intent,
+  parameters, and idempotency key
+
+For the draft-first book flow, `POST /book` should keep the current behavior:
+when `draftId` is supplied without `quoteId`, load the draft, require
+`current_quote_id`, and pass the draft payload into engine parameters.
+
+## Error Mapping
+
+The package route module should normalize engine errors to HTTP responses:
+
+- `NO_ADAPTER_REGISTERED` and `NO_HANDLER_REGISTERED`: 503
+- `QUOTE_NOT_FOUND`: 404
+- `QUOTE_EXPIRED` and `QUOTE_MISMATCH`: 409
+- `RESERVE_FAILED`: 502
+- missing draft: 404
+- draft without current quote: 409
+- unsupported hold primitive: 503 for place, 204 no-op for release
+
+Use the shared Hono validation error shape for invalid JSON and invalid
+payloads. Keep existing booking-engine error payload fields where clients may
+already depend on them: `error`, `code`, and optional `context`.
+
+## Operator Template Migration
+
+After the package module exists, update
+`templates/operator/src/api/catalog-booking.ts` to:
+
+- import the package route factory
+- mount the shared route family for both admin and public catalog surfaces
+- pass operator runtime callbacks:
+  - `getBookingEngineRegistryFromContext`
+  - `getOwnedBookingHandlerRegistryFromContext`
+  - operator-specific hold TTL resolver
+  - operator tax quote transform
+  - actor id from `userId`
+- keep these routes local:
+  - `/v1/{admin,public}/catalog/slots`
+  - `/v1/admin/catalog/orders*`
+  - `/v1/admin/bookings/:id/catalog-snapshot`
+
+This keeps the package extraction small and gives the template an immediate
+consumer test.
+
+## Implementation Slices
+
+1. Add route factory and module exports.
+   - Create `packages/catalog/src/booking-engine/routes.ts`.
+   - Export the route types and factories from
+     `packages/catalog/src/booking-engine/index.ts`.
+   - Add a package export only if consumers need
+     `@voyantjs/catalog/booking-engine/routes`; otherwise keep the root
+     booking-engine export as the public surface.
+
+2. Add route unit tests.
+   - Verify every expected path is present on both admin and public surfaces.
+   - Verify invalid JSON and invalid payloads return shared validation errors.
+   - Verify quote delegates to `quoteEntity` dependencies with resolved
+     provenance and adapter context.
+   - Verify draft CRUD uses the draft service and preserves create-vs-update
+     behavior.
+   - Verify draft-first book resolves `current_quote_id`, marks the draft
+     consumed, and logs rather than fails when the consume update races.
+   - Verify hold place/release behavior for missing handlers and happy paths.
+
+3. Migrate the operator template.
+   - Replace duplicated shared route handlers with the package route factory.
+   - Keep operator-specific slots, orders, snapshot enrichment, and tax helpers
+     in the template.
+   - Confirm existing storefront and operator journey wrappers still call the
+     same URLs.
+
+4. Document consumer setup.
+   - Update `@voyantjs/catalog` or `@voyantjs/catalog-react` docs with the
+     minimum server setup.
+   - Document required public auth bypass path:
+     `/v1/public/catalog`.
+   - Document the registry and owned-handler injections a template must supply.
+
+5. Publish as a patch release.
+   - Add a changeset for `@voyantjs/catalog`.
+   - Include `@voyantjs/catalog-react` docs only if its README changes.
+
+## Verification Plan
+
+Run the smallest checks that cover the blast radius:
+
+- `pnpm --filter @voyantjs/catalog test`
+- `pnpm --filter @voyantjs/catalog typecheck`
+- `pnpm -C templates/operator typecheck`
+- `pnpm lint:changed`
+- `pnpm verify:package-exports` when adding or changing package exports
+
+If the operator migration touches route mounting or public auth allowlists, run
+the relevant storefront booking journey smoke test manually against the operator
+template.
+
+## Open Questions
+
+- Should the public route factory mount only the BookingJourney contract, or
+  should it expose a hook for app-owned public child routes under
+  `/v1/public/catalog`?
+- Should checkout handoff be a route hook on `POST /book`, or should checkout
+  remain a separate app route under `/catalog/checkout/start`?
+- Should route responses preserve the current operator template's loose
+  response shapes exactly, or should they be parsed through
+  `quoteResponseV1` and `bookResponseV1` before returning?
+- Should `captureSnapshotContent` be wired in the first implementation slice,
+  or deferred until a template uses it from the route layer?
+
+## Acceptance Criteria
+
+- A consumer can install `@voyantjs/catalog`,
+  `@voyantjs/catalog-react`, and `@voyantjs/bookings-ui` without copying the
+  operator template's booking route handlers.
+- The package exposes a documented route module or factory for both
+  `/v1/admin/catalog/*` and `/v1/public/catalog/*`.
+- The route module supports the exact HTTP calls made by the current React
+  hooks.
+- The operator template consumes the shared route module for the reusable route
+  family.
+- Template-only catalog routes stay out of `@voyantjs/catalog`.

--- a/docs/architecture/catalog-booking-route-module-plan.md
+++ b/docs/architecture/catalog-booking-route-module-plan.md
@@ -1,6 +1,12 @@
 # Catalog Booking Route Module Plan
 
-Status: proposed for [issue #418](https://github.com/voyantjs/voyant/issues/418)
+Status: first implementation slice in progress for
+[issue #418](https://github.com/voyantjs/voyant/issues/418)
+
+Implementation note: the initial route module keeps the reusable quote, draft,
+hold, and book contract in `@voyantjs/catalog/booking-engine`; operator-specific
+slots, order management, checkout start, and snapshot enrichment remain in the
+operator template.
 
 ## Problem
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "verify:route-authoring": "node scripts/check-route-authoring.mjs",
     "verify:architecture": "pnpm verify:tenant-scoping && pnpm verify:route-authoring",
     "verify:fast": "pnpm lint:changed && pnpm typecheck:affected && pnpm test:affected && pnpm verify:architecture",
-    "verify:full": "pnpm lint && pnpm typecheck && pnpm test && pnpm verify:architecture && pnpm verify:package-exports && pnpm i18n:check",
+    "verify:full": "pnpm lint && pnpm typecheck && pnpm test && pnpm verify:architecture && pnpm build && pnpm verify:package-exports && pnpm i18n:check",
     "prepare": "husky",
     "seed:operator": "pnpm -C apps/scripts seed:operator",
     "regen:routes": "tsx scripts/regen-route-tree.ts",

--- a/packages/catalog/README.md
+++ b/packages/catalog/README.md
@@ -25,6 +25,7 @@ pnpm add @voyantjs/catalog
 - **`./drift/events`** — drift event types for upstream change detection.
 - **`./events/taxonomy`** — catalog event names + visibility-filtered payload builders, emitted via `@voyantjs/core/events` and consumed by the existing webhook pipeline.
 - **`./adapter/contract`** — public source-adapter contract. Voyant Connect, third-party providers, operator-built adapters all implement this.
+- **`./booking-engine`** — quote/book services plus the Hono route module that backs `@voyantjs/catalog-react/booking-engine` and `@voyantjs/bookings-ui/journey`.
 
 ## Architectural rules
 
@@ -62,3 +63,31 @@ export const productCatalogPolicy = defineFieldPolicy([
 ```
 
 See `docs/architecture/catalog-architecture.md` for the full contract and worked examples.
+
+## BookingJourney HTTP routes
+
+`@voyantjs/catalog/booking-engine` exports `createCatalogBookingHonoModule(...)`
+and `createCatalogBookingRoutes(...)` for the BookingJourney server contract.
+The module mounts the shared quote, draft, hold, and book endpoints on both
+catalog API surfaces:
+
+- `/v1/admin/catalog/*`
+- `/v1/public/catalog/*`
+
+Templates provide the runtime dependencies instead of the package importing
+deployment code:
+
+```typescript
+import { createCatalogBookingHonoModule } from "@voyantjs/catalog/booking-engine"
+
+export const catalogBookingModule = createCatalogBookingHonoModule({
+  resolveDb: (c) => c.get("db"),
+  resolveSourceRegistry: (c) => getBookingEngineRegistryFromContext(c),
+  resolveOwnedHandlers: (c) => getOwnedBookingHandlerRegistryFromContext(c),
+})
+```
+
+Apps that protect public routes by default must allow
+`/v1/public/catalog`. Template-specific routes such as slots, admin order
+management, checkout start, and booking snapshot enrichment stay in the
+template.

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -171,7 +171,9 @@
   "dependencies": {
     "@voyantjs/core": "workspace:*",
     "@voyantjs/db": "workspace:*",
+    "@voyantjs/hono": "workspace:*",
     "drizzle-orm": "^0.45.2",
+    "hono": "^4.12.10",
     "zod": "^4.1.4"
   },
   "devDependencies": {

--- a/packages/catalog/src/booking-engine/index.ts
+++ b/packages/catalog/src/booking-engine/index.ts
@@ -169,6 +169,25 @@ export {
   type SourceAdapterRegistry,
 } from "./registry.js"
 export {
+  type CatalogBookingAdapterContextInput,
+  type CatalogBookingBookBody,
+  type CatalogBookingBookTransformInput,
+  type CatalogBookingCommittedEvent,
+  type CatalogBookingContentScopeInput,
+  type CatalogBookingDraftBody,
+  type CatalogBookingDraftConsumedError,
+  type CatalogBookingHoldPlaceBody,
+  type CatalogBookingHoldReleaseBody,
+  type CatalogBookingHoldTtlInput,
+  type CatalogBookingProvenance,
+  type CatalogBookingProvenanceInput,
+  type CatalogBookingQuoteBody,
+  type CatalogBookingQuoteTransformInput,
+  type CatalogBookingRoutesOptions,
+  createCatalogBookingHonoModule,
+  createCatalogBookingRoutes,
+} from "./routes.js"
+export {
   catalogQuotesTable,
   type InsertCatalogQuote,
   type SelectCatalogQuote,

--- a/packages/catalog/src/booking-engine/routes.test.ts
+++ b/packages/catalog/src/booking-engine/routes.test.ts
@@ -1,0 +1,345 @@
+import { handleApiError } from "@voyantjs/hono"
+import { Hono } from "hono"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { PricingBasis } from "../snapshot/schema.js"
+
+import { bookEntity } from "./book.js"
+import {
+  createBookingDraft,
+  deleteBookingDraft,
+  getBookingDraft,
+  markDraftConsumed,
+  updateBookingDraft,
+} from "./drafts-service.js"
+import { createOwnedBookingHandlerRegistry, type OwnedBookingHandler } from "./owned-handler.js"
+import { quoteEntity } from "./quote.js"
+import { createSourceAdapterRegistry } from "./registry.js"
+import {
+  type CatalogBookingRoutesOptions,
+  createCatalogBookingHonoModule,
+  createCatalogBookingRoutes,
+} from "./routes.js"
+
+vi.mock("./quote.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./quote.js")>()
+  return { ...actual, quoteEntity: vi.fn() }
+})
+
+vi.mock("./book.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./book.js")>()
+  return { ...actual, bookEntity: vi.fn() }
+})
+
+vi.mock("./drafts-service.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./drafts-service.js")>()
+  return {
+    ...actual,
+    createBookingDraft: vi.fn(),
+    deleteBookingDraft: vi.fn(),
+    getBookingDraft: vi.fn(),
+    markDraftConsumed: vi.fn(),
+    updateBookingDraft: vi.fn(),
+  }
+})
+
+const db = { kind: "db" } as never
+const registry = createSourceAdapterRegistry()
+
+function createTestApp(overrides: Partial<CatalogBookingRoutesOptions> = {}) {
+  const ownedHandlers = createOwnedBookingHandlerRegistry()
+  const app = new Hono()
+  app.onError(handleApiError)
+  app.route(
+    "/v1/public/catalog",
+    createCatalogBookingRoutes({
+      resolveDb: () => db,
+      resolveSourceRegistry: () => registry,
+      resolveOwnedHandlers: () => ownedHandlers,
+      ...overrides,
+    }),
+  )
+  return { app, ownedHandlers }
+}
+
+const pricing: PricingBasis = {
+  base_amount: 10000,
+  taxes: 1900,
+  fees: 250,
+  surcharges: 0,
+  currency: "EUR",
+}
+
+describe("createCatalogBookingRoutes", () => {
+  beforeEach(() => {
+    vi.mocked(bookEntity).mockReset()
+    vi.mocked(createBookingDraft).mockReset()
+    vi.mocked(deleteBookingDraft).mockReset()
+    vi.mocked(getBookingDraft).mockReset()
+    vi.mocked(markDraftConsumed).mockReset()
+    vi.mocked(quoteEntity).mockReset()
+    vi.mocked(updateBookingDraft).mockReset()
+  })
+
+  it("exposes both admin and public routes through the Hono module wrapper", () => {
+    const module = createCatalogBookingHonoModule({
+      resolveDb: () => db,
+      resolveSourceRegistry: () => registry,
+    })
+
+    expect(module.module.name).toBe("catalog")
+    expect(module.adminRoutes).toBeTruthy()
+    expect(module.publicRoutes).toBeTruthy()
+  })
+
+  it("uses shared JSON validation errors for invalid bodies", async () => {
+    const { app } = createTestApp()
+
+    const response = await app.request("/v1/public/catalog/quote", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    })
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid JSON body",
+      code: "invalid_request",
+    })
+  })
+
+  it("quotes through injected provenance, registries, and adapter context", async () => {
+    vi.mocked(quoteEntity).mockResolvedValue({
+      quoteId: "quote_1",
+      quotedAt: new Date("2026-05-05T10:00:00.000Z"),
+      expiresAt: new Date("2026-05-05T10:10:00.000Z"),
+      available: true,
+      pricing,
+      upstreamPayload: { ok: true },
+    })
+    const resolveEntityProvenance = vi.fn(async () => ({
+      sourceKind: "demo",
+      sourceConnectionId: "conn_demo",
+      sourceRef: "upstream_1",
+    }))
+    const resolveAdapterContext = vi.fn(({ sourceConnectionId, correlationId }) => ({
+      connection_id: sourceConnectionId ?? "fallback",
+      correlation_id: correlationId,
+      credentials: { token: "secret" },
+    }))
+    const { app, ownedHandlers } = createTestApp({
+      resolveCorrelationId: () => "req_1",
+      resolveEntityProvenance,
+      resolveAdapterContext,
+    })
+
+    const response = await app.request("/v1/public/catalog/quote", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        entityModule: "products",
+        entityId: "prod_1",
+        draft: { configure: { departureSlotId: "slot_1", pax: { adult: 2 } } },
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      quoteId: "quote_1",
+      quotedAt: "2026-05-05T10:00:00.000Z",
+      pricing: {
+        currency: "EUR",
+        subtotal: 10250,
+        taxTotal: 1900,
+        total: 12150,
+      },
+    })
+    expect(resolveEntityProvenance).toHaveBeenCalledWith(
+      expect.objectContaining({ db, entityModule: "products", entityId: "prod_1" }),
+    )
+    expect(quoteEntity).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ registry, ownedHandlers }),
+      expect.objectContaining({
+        entityModule: "products",
+        entityId: "prod_1",
+        sourceKind: "demo",
+        sourceConnectionId: "conn_demo",
+        sourceRef: "upstream_1",
+        scope: {
+          locale: "en-GB",
+          audience: "customer",
+          market: "default",
+          currency: undefined,
+        },
+        parameters: expect.objectContaining({
+          draft: expect.any(Object),
+          departureSlotId: "slot_1",
+          departure_id: "slot_1",
+          slotId: "slot_1",
+          paxCount: 2,
+        }),
+        adapterContext: {
+          connection_id: "conn_demo",
+          correlation_id: "req_1",
+          credentials: { token: "secret" },
+        },
+      }),
+    )
+  })
+
+  it("creates drafts with actor identity and explicit source provenance", async () => {
+    vi.mocked(getBookingDraft).mockResolvedValue(null)
+    vi.mocked(createBookingDraft).mockResolvedValue({
+      id: "draft_1",
+      entity_module: "products",
+      entity_id: "prod_1",
+      source_kind: "owned",
+      source_connection_id: null,
+      source_ref: null,
+      draft_payload: { entity: { id: "prod_1" } },
+      current_step: "configure",
+      current_quote_id: null,
+      hold_expires_at: null,
+      consumed_booking_id: null,
+      consumed_at: null,
+      created_by: "user_1",
+      expires_at: new Date("2026-05-06T10:00:00.000Z"),
+      created_at: new Date("2026-05-05T10:00:00.000Z"),
+      updated_at: new Date("2026-05-05T10:00:00.000Z"),
+    } as never)
+    const { app } = createTestApp({ resolveActorId: () => "user_1" })
+
+    const response = await app.request("/v1/public/catalog/drafts/draft_1", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        entityModule: "products",
+        entityId: "prod_1",
+        sourceKind: "owned",
+        draftPayload: { entity: { id: "prod_1" } },
+        currentStep: "configure",
+      }),
+    })
+
+    expect(response.status).toBe(201)
+    expect(createBookingDraft).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({
+        id: "draft_1",
+        entityModule: "products",
+        entityId: "prod_1",
+        sourceKind: "owned",
+        createdBy: "user_1",
+      }),
+    )
+  })
+
+  it("books draft-first, forwards draft parameters, and reports draft consume races", async () => {
+    vi.mocked(getBookingDraft).mockResolvedValue({
+      id: "draft_1",
+      current_quote_id: "quote_1",
+      draft_payload: { configure: { departureSlotId: "slot_1", pax: { adult: 2 } } },
+    } as never)
+    vi.mocked(bookEntity).mockResolvedValue({
+      bookingId: "booking_1",
+      orderRef: "order_1",
+      status: "held",
+      snapshotId: "snap_1",
+      pricing,
+    })
+    const consumeError = new Error("race")
+    vi.mocked(markDraftConsumed).mockRejectedValue(consumeError)
+    const onDraftConsumedError = vi.fn()
+    const onCommitted = vi.fn()
+    const { app } = createTestApp({
+      resolveCorrelationId: () => "req_2",
+      onDraftConsumedError,
+      onCommitted,
+    })
+
+    const response = await app.request("/v1/public/catalog/book", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ draftId: "draft_1", idempotencyKey: "idem_12345678" }),
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      bookingId: "booking_1",
+      pricing: { total: 12150 },
+    })
+    expect(bookEntity).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ registry }),
+      expect.objectContaining({
+        quoteId: "quote_1",
+        idempotencyKey: "idem_12345678",
+        parameters: expect.objectContaining({
+          draft: expect.any(Object),
+          departureSlotId: "slot_1",
+          departure_id: "slot_1",
+          slotId: "slot_1",
+          paxCount: 2,
+        }),
+        adapterContext: { connection_id: "engine", correlation_id: "req_2" },
+      }),
+    )
+    expect(onDraftConsumedError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        draftId: "draft_1",
+        bookingId: "booking_1",
+        error: consumeError,
+      }),
+    )
+    expect(onCommitted).toHaveBeenCalledWith(
+      expect.objectContaining({ result: expect.objectContaining({ bookingId: "booking_1" }) }),
+    )
+  })
+
+  it("places and releases holds through the owned handler registry", async () => {
+    const placeHold = vi.fn(async () => ({
+      holdToken: "hold_1",
+      expiresAt: new Date("2026-05-05T10:30:00.000Z"),
+    }))
+    const releaseHold = vi.fn(async () => undefined)
+    const handler: OwnedBookingHandler = {
+      entityModule: "products",
+      computeQuote: async () => ({ available: true }),
+      commit: async () => ({ status: "held", orderRef: "order_1" }),
+      placeHold,
+      releaseHold,
+    }
+    const { app, ownedHandlers } = createTestApp({
+      resolveCorrelationId: () => "req_3",
+      resolveHoldTtlMs: async () => 15 * 60 * 1000,
+    })
+    ownedHandlers.register(handler)
+
+    const placeResponse = await app.request("/v1/public/catalog/holds/place", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ entityModule: "products", entityId: "prod_1", draftId: "draft_1" }),
+    })
+    expect(placeResponse.status).toBe(200)
+    await expect(placeResponse.json()).resolves.toEqual({
+      holdToken: "hold_1",
+      expiresAt: "2026-05-05T10:30:00.000Z",
+    })
+    expect(placeHold).toHaveBeenCalledWith(
+      { db, adapterContext: { connection_id: "engine", correlation_id: "req_3" } },
+      expect.objectContaining({ ttlMs: 15 * 60 * 1000 }),
+    )
+
+    const releaseResponse = await app.request("/v1/public/catalog/holds/release", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ entityModule: "products", holdToken: "hold_1" }),
+    })
+    expect(releaseResponse.status).toBe(204)
+    expect(releaseHold).toHaveBeenCalledWith(
+      { db, adapterContext: { connection_id: "engine", correlation_id: "req_3" } },
+      "hold_1",
+    )
+  })
+})

--- a/packages/catalog/src/booking-engine/routes.ts
+++ b/packages/catalog/src/booking-engine/routes.ts
@@ -1,0 +1,697 @@
+import type { AnyDrizzleDb } from "@voyantjs/db"
+import { handleApiError, parseJsonBody, RequestValidationError } from "@voyantjs/hono"
+import type { HonoModule } from "@voyantjs/hono/module"
+import type { Context } from "hono"
+import { Hono } from "hono"
+import { z } from "zod"
+
+import type { SourceAdapterContext } from "../adapter/contract.js"
+import { readSourcedEntry } from "../services/sourced-entry-service.js"
+import type { PricingBasis } from "../snapshot/schema.js"
+
+import { type BookEntityResult, bookEntity } from "./book.js"
+import {
+  type BookResponseV1,
+  bookResponseV1,
+  type PricingBreakdownV1,
+  type QuoteResponseV1,
+  quoteResponseV1,
+} from "./contracts.js"
+import {
+  createBookingDraft,
+  DEFAULT_DRAFT_TTL_MS,
+  deleteBookingDraft,
+  getBookingDraft,
+  markDraftConsumed,
+  updateBookingDraft,
+} from "./drafts-service.js"
+import {
+  BookingEngineError,
+  NO_ADAPTER_REGISTERED,
+  NO_HANDLER_REGISTERED,
+  ORDER_ALREADY_CANCELLED,
+  ORDER_NOT_FOUND,
+  QUOTE_EXPIRED,
+  QUOTE_MISMATCH,
+  QUOTE_NOT_FOUND,
+  RESERVE_FAILED,
+} from "./errors.js"
+import { OWNED_SOURCE_KIND, type OwnedBookingHandlerRegistry } from "./owned-handler.js"
+import { type QuoteEntityDeps, type QuoteEntityResult, quoteEntity } from "./quote.js"
+import type { SourceAdapterRegistry } from "./registry.js"
+import type { SnapshotContentCapturer } from "./snapshot-content.js"
+
+const DEFAULT_HOLD_TTL_MS = 30 * 60 * 1000
+
+const recordSchema = z.record(z.string(), z.unknown())
+
+const quoteScopeSchema = z
+  .object({
+    locale: z.string().min(1).optional(),
+    audience: z.enum(["staff", "customer", "partner", "supplier"]).optional(),
+    market: z.string().min(1).optional(),
+    currency: z.string().min(1).optional(),
+  })
+  .optional()
+
+const quoteBodySchema = z.object({
+  entityModule: z.string().min(1),
+  entityId: z.string().min(1),
+  sourceKind: z.string().min(1).optional(),
+  sourceProvider: z.string().min(1).optional(),
+  sourceConnectionId: z.string().min(1).optional(),
+  sourceRef: z.string().min(1).optional(),
+  scope: quoteScopeSchema,
+  parameters: recordSchema.optional(),
+  draft: recordSchema.optional(),
+  ttlMs: z.number().int().positive().optional(),
+})
+
+const bookBodySchema = z
+  .object({
+    quoteId: z.string().min(1).optional(),
+    bookingId: z.string().min(1).optional(),
+    party: recordSchema.optional(),
+    paymentIntent: z
+      .union([
+        z.object({ type: z.literal("hold") }),
+        z.object({ type: z.literal("card"), tokenizedCard: z.string().min(1) }),
+        z.object({ type: z.literal("ticket_on_credit"), agencyAccount: z.string().min(1) }),
+      ])
+      .optional(),
+    parameters: recordSchema.optional(),
+    draftId: z.string().min(1).optional(),
+    idempotencyKey: z.string().min(8).max(128).optional(),
+  })
+  .refine((body) => body.quoteId || body.draftId, {
+    message: "either quoteId or draftId is required",
+  })
+
+const draftBodySchema = z.object({
+  entityModule: z.string().min(1).optional(),
+  entityId: z.string().min(1).optional(),
+  sourceKind: z.string().min(1).optional(),
+  sourceConnectionId: z.string().min(1).optional(),
+  sourceRef: z.string().min(1).optional(),
+  draftPayload: recordSchema,
+  currentStep: z.string().min(1).optional(),
+  currentQuoteId: z.string().min(1).optional(),
+  ttlMs: z.number().int().positive().optional(),
+})
+
+const holdPlaceBodySchema = z.object({
+  entityModule: z.string().min(1),
+  entityId: z.string().min(1),
+  draftId: z.string().min(1),
+  ttlMs: z.number().int().positive().optional(),
+  parameters: recordSchema.optional(),
+})
+
+const holdReleaseBodySchema = z.object({
+  entityModule: z.string().min(1),
+  holdToken: z.string().min(1),
+})
+
+export type CatalogBookingQuoteBody = z.infer<typeof quoteBodySchema>
+export type CatalogBookingBookBody = z.infer<typeof bookBodySchema>
+export type CatalogBookingDraftBody = z.infer<typeof draftBodySchema>
+export type CatalogBookingHoldPlaceBody = z.infer<typeof holdPlaceBodySchema>
+export type CatalogBookingHoldReleaseBody = z.infer<typeof holdReleaseBodySchema>
+
+export interface CatalogBookingProvenance {
+  sourceKind: string
+  sourceProvider?: string
+  sourceConnectionId?: string
+  sourceRef?: string
+}
+
+export interface CatalogBookingProvenanceInput {
+  c: Context
+  db: AnyDrizzleDb
+  entityModule: string
+  entityId: string
+}
+
+export interface CatalogBookingAdapterContextInput {
+  c: Context
+  db: AnyDrizzleDb
+  operation: "quote" | "book" | "hold"
+  entityModule?: string
+  entityId?: string
+  sourceKind: string
+  sourceConnectionId?: string
+  correlationId: string
+}
+
+export interface CatalogBookingHoldTtlInput {
+  c: Context
+  db: AnyDrizzleDb
+  entityModule: string
+  entityId: string
+}
+
+export interface CatalogBookingContentScopeInput {
+  c: Context
+  db: AnyDrizzleDb
+  body: CatalogBookingBookBody
+  draftPayload?: Record<string, unknown>
+}
+
+export interface CatalogBookingQuoteTransformInput {
+  c: Context
+  db: AnyDrizzleDb
+  request: CatalogBookingQuoteBody
+  provenance: CatalogBookingProvenance
+  result: QuoteEntityResult
+}
+
+export interface CatalogBookingBookTransformInput {
+  c: Context
+  db: AnyDrizzleDb
+  request: CatalogBookingBookBody
+  result: BookEntityResult
+}
+
+export interface CatalogBookingDraftConsumedError {
+  c: Context
+  db: AnyDrizzleDb
+  draftId: string
+  bookingId: string
+  error: unknown
+}
+
+export interface CatalogBookingCommittedEvent {
+  c: Context
+  db: AnyDrizzleDb
+  request: CatalogBookingBookBody
+  result: BookEntityResult
+}
+
+export interface CatalogBookingRoutesOptions {
+  resolveDb(c: Context): AnyDrizzleDb
+  resolveSourceRegistry(c: Context): SourceAdapterRegistry
+  resolveOwnedHandlers?(c: Context): OwnedBookingHandlerRegistry | undefined
+  resolveActorId?(c: Context): string | null
+  resolveCorrelationId?(c: Context): string
+  resolveAdapterContext?(input: CatalogBookingAdapterContextInput): SourceAdapterContext
+  resolveEntityProvenance?(input: CatalogBookingProvenanceInput): Promise<CatalogBookingProvenance>
+  resolveHoldTtlMs?(input: CatalogBookingHoldTtlInput): Promise<number>
+  resolveContentScope?(input: CatalogBookingContentScopeInput):
+    | {
+        locale: string
+        market?: string
+        currency?: string
+      }
+    | undefined
+  contentEnricher?: QuoteEntityDeps["contentEnricher"]
+  onContentEnricherError?: QuoteEntityDeps["onEnricherError"]
+  captureSnapshotContent?: SnapshotContentCapturer
+  transformQuoteResult?(input: CatalogBookingQuoteTransformInput): Promise<QuoteEntityResult>
+  transformBookResult?(input: CatalogBookingBookTransformInput): Promise<BookEntityResult>
+  onDraftConsumedError?(event: CatalogBookingDraftConsumedError): void
+  onCommitted?(event: CatalogBookingCommittedEvent): Promise<void> | void
+}
+
+export function createCatalogBookingRoutes(options: CatalogBookingRoutesOptions): Hono {
+  return new Hono()
+    .post("/quote", async (c) => handleQuote(c, options))
+    .post("/book", async (c) => handleBook(c, options))
+    .put("/drafts/:id", async (c) => handleDraftPut(c, options))
+    .get("/drafts/:id", async (c) => handleDraftGet(c, options))
+    .delete("/drafts/:id", async (c) => handleDraftDelete(c, options))
+    .post("/holds/place", async (c) => handleHoldPlace(c, options))
+    .post("/holds/release", async (c) => handleHoldRelease(c, options))
+}
+
+export function createCatalogBookingHonoModule(options: CatalogBookingRoutesOptions): HonoModule {
+  return {
+    module: { name: "catalog" },
+    adminRoutes: createCatalogBookingRoutes(options),
+    publicRoutes: createCatalogBookingRoutes(options),
+  }
+}
+
+async function handleQuote(c: Context, options: CatalogBookingRoutesOptions): Promise<Response> {
+  const body = await parseJsonBody(c, quoteBodySchema)
+  const db = options.resolveDb(c)
+  const provenance = body.sourceKind
+    ? {
+        sourceKind: body.sourceKind,
+        sourceProvider: body.sourceProvider,
+        sourceConnectionId: body.sourceConnectionId,
+        sourceRef: body.sourceRef,
+      }
+    : await resolveEntityProvenance(c, options, db, body.entityModule, body.entityId)
+  const correlationId = resolveCorrelationId(c, options)
+  const adapterContext = resolveAdapterContext(c, options, {
+    db,
+    operation: "quote",
+    entityModule: body.entityModule,
+    entityId: body.entityId,
+    sourceKind: provenance.sourceKind,
+    sourceConnectionId: provenance.sourceConnectionId,
+    correlationId,
+  })
+
+  try {
+    const result = await quoteEntity(
+      db,
+      {
+        registry: options.resolveSourceRegistry(c),
+        ownedHandlers: options.resolveOwnedHandlers?.(c),
+        contentEnricher: options.contentEnricher,
+        onEnricherError: options.onContentEnricherError,
+      },
+      {
+        entityModule: body.entityModule,
+        entityId: body.entityId,
+        sourceKind: provenance.sourceKind,
+        sourceProvider: provenance.sourceProvider,
+        sourceConnectionId: provenance.sourceConnectionId,
+        sourceRef: provenance.sourceRef,
+        scope: {
+          locale: body.scope?.locale ?? "en-GB",
+          audience: body.scope?.audience ?? defaultAudienceForPath(c),
+          market: body.scope?.market ?? "default",
+          currency: body.scope?.currency,
+        },
+        parameters: engineParametersFromDraft(body.parameters, body.draft),
+        ttlMs: body.ttlMs,
+        adapterContext,
+      },
+    )
+    const transformed =
+      (await options.transformQuoteResult?.({ c, db, request: body, provenance, result })) ?? result
+    return c.json(serializeQuoteResult(transformed))
+  } catch (err) {
+    return bookingEngineErrorResponse(c, err)
+  }
+}
+
+async function handleBook(c: Context, options: CatalogBookingRoutesOptions): Promise<Response> {
+  const body = await parseJsonBody(c, bookBodySchema)
+  const db = options.resolveDb(c)
+  const correlationId = resolveCorrelationId(c, options)
+
+  let quoteId = body.quoteId
+  let draftPayload: Record<string, unknown> | undefined
+  if (!quoteId && body.draftId) {
+    const draft = await getBookingDraft(db, body.draftId)
+    if (!draft) {
+      return c.json({ error: "draft not found" }, 404)
+    }
+    if (!draft.current_quote_id) {
+      return c.json({ error: "draft has no current quote - call /quote first" }, 409)
+    }
+    quoteId = draft.current_quote_id
+    draftPayload = draft.draft_payload
+  }
+  if (!quoteId) {
+    return c.json({ error: "quoteId could not be resolved" }, 400)
+  }
+
+  try {
+    const adapterContext = resolveAdapterContext(c, options, {
+      db,
+      operation: "book",
+      sourceKind: "engine",
+      correlationId,
+    })
+    const result = await bookEntity(
+      db,
+      {
+        registry: options.resolveSourceRegistry(c),
+        ownedHandlers: options.resolveOwnedHandlers?.(c),
+        captureSnapshotContent: options.captureSnapshotContent,
+      },
+      {
+        quoteId,
+        bookingId: body.bookingId,
+        party: body.party,
+        paymentIntent: body.paymentIntent,
+        parameters: engineParametersFromDraft(
+          body.parameters,
+          draftPayload ?? body.parameters?.draft,
+        ),
+        idempotencyKey: body.idempotencyKey,
+        adapterContext,
+        contentScope: options.resolveContentScope?.({ c, db, body, draftPayload }),
+      },
+    )
+
+    if (body.draftId) {
+      try {
+        await markDraftConsumed(db, body.draftId, result.bookingId)
+      } catch (error) {
+        options.onDraftConsumedError?.({
+          c,
+          db,
+          draftId: body.draftId,
+          bookingId: result.bookingId,
+          error,
+        })
+      }
+    }
+
+    await options.onCommitted?.({ c, db, request: body, result })
+    const transformed =
+      (await options.transformBookResult?.({ c, db, request: body, result })) ?? result
+    return c.json(serializeBookResult(transformed))
+  } catch (err) {
+    return bookingEngineErrorResponse(c, err)
+  }
+}
+
+async function handleDraftPut(c: Context, options: CatalogBookingRoutesOptions): Promise<Response> {
+  const id = c.req.param("id")
+  if (!id) throw new RequestValidationError("id is required")
+
+  const body = await parseJsonBody(c, draftBodySchema)
+  const db = options.resolveDb(c)
+  const existing = await getBookingDraft(db, id)
+  if (existing) {
+    const updated = await updateBookingDraft(db, id, {
+      draftPayload: body.draftPayload,
+      currentStep: body.currentStep,
+      currentQuoteId: body.currentQuoteId,
+      refreshTtlMs: body.ttlMs ?? DEFAULT_DRAFT_TTL_MS,
+    })
+    return c.json(updated)
+  }
+
+  if (!body.entityModule || !body.entityId) {
+    throw new RequestValidationError("entityModule and entityId are required when creating a draft")
+  }
+
+  const provenance = body.sourceKind
+    ? {
+        sourceKind: body.sourceKind,
+        sourceConnectionId: body.sourceConnectionId,
+        sourceRef: body.sourceRef,
+      }
+    : await resolveEntityProvenance(c, options, db, body.entityModule, body.entityId)
+
+  const created = await createBookingDraft(db, {
+    id,
+    entityModule: body.entityModule,
+    entityId: body.entityId,
+    sourceKind: provenance.sourceKind,
+    sourceConnectionId: provenance.sourceConnectionId,
+    sourceRef: provenance.sourceRef,
+    draftPayload: body.draftPayload,
+    currentStep: body.currentStep,
+    currentQuoteId: body.currentQuoteId,
+    createdBy: resolveActorId(c, options),
+    ttlMs: body.ttlMs,
+  })
+  return c.json(created, 201)
+}
+
+async function handleDraftGet(c: Context, options: CatalogBookingRoutesOptions): Promise<Response> {
+  const id = c.req.param("id")
+  if (!id) throw new RequestValidationError("id is required")
+  const row = await getBookingDraft(options.resolveDb(c), id)
+  if (!row) return c.json({ error: "draft not found" }, 404)
+  return c.json(row)
+}
+
+async function handleDraftDelete(
+  c: Context,
+  options: CatalogBookingRoutesOptions,
+): Promise<Response> {
+  const id = c.req.param("id")
+  if (!id) throw new RequestValidationError("id is required")
+  await deleteBookingDraft(options.resolveDb(c), id)
+  return c.body(null, 204)
+}
+
+async function handleHoldPlace(
+  c: Context,
+  options: CatalogBookingRoutesOptions,
+): Promise<Response> {
+  const body = await parseJsonBody(c, holdPlaceBodySchema)
+  const ownedHandlers = options.resolveOwnedHandlers?.(c)
+  const handler = ownedHandlers?.resolve(body.entityModule)
+  if (!handler?.placeHold) {
+    return c.json({ error: "no hold primitive registered for this vertical" }, 503)
+  }
+
+  const db = options.resolveDb(c)
+  const correlationId = resolveCorrelationId(c, options)
+  const ttlMs =
+    body.ttlMs ??
+    (await (options.resolveHoldTtlMs?.({
+      c,
+      db,
+      entityModule: body.entityModule,
+      entityId: body.entityId,
+    }) ?? DEFAULT_HOLD_TTL_MS))
+  const adapterContext = resolveAdapterContext(c, options, {
+    db,
+    operation: "hold",
+    entityModule: body.entityModule,
+    entityId: body.entityId,
+    sourceKind: "engine",
+    correlationId,
+  })
+
+  try {
+    const result = await handler.placeHold(
+      { db, adapterContext },
+      {
+        entityModule: body.entityModule,
+        entityId: body.entityId,
+        draftId: body.draftId,
+        ttlMs,
+        parameters: body.parameters,
+      },
+    )
+    return c.json({ holdToken: result.holdToken, expiresAt: result.expiresAt.toISOString() })
+  } catch (err) {
+    return bookingEngineErrorResponse(c, err)
+  }
+}
+
+async function handleHoldRelease(
+  c: Context,
+  options: CatalogBookingRoutesOptions,
+): Promise<Response> {
+  const body = await parseJsonBody(c, holdReleaseBodySchema)
+  const ownedHandlers = options.resolveOwnedHandlers?.(c)
+  const handler = ownedHandlers?.resolve(body.entityModule)
+  if (!handler?.releaseHold) {
+    return c.body(null, 204)
+  }
+
+  const db = options.resolveDb(c)
+  const correlationId = resolveCorrelationId(c, options)
+  const adapterContext = resolveAdapterContext(c, options, {
+    db,
+    operation: "hold",
+    entityModule: body.entityModule,
+    sourceKind: "engine",
+    correlationId,
+  })
+
+  try {
+    await handler.releaseHold({ db, adapterContext }, body.holdToken)
+    return c.body(null, 204)
+  } catch (err) {
+    return bookingEngineErrorResponse(c, err)
+  }
+}
+
+async function resolveEntityProvenance(
+  c: Context,
+  options: CatalogBookingRoutesOptions,
+  db: AnyDrizzleDb,
+  entityModule: string,
+  entityId: string,
+): Promise<CatalogBookingProvenance> {
+  if (options.resolveEntityProvenance) {
+    return options.resolveEntityProvenance({ c, db, entityModule, entityId })
+  }
+
+  const row = await readSourcedEntry(db, entityModule, entityId)
+  if (!row) return { sourceKind: OWNED_SOURCE_KIND }
+  return {
+    sourceKind: row.source_kind,
+    sourceProvider: row.source_provider ?? undefined,
+    sourceConnectionId: row.source_connection_id ?? undefined,
+    sourceRef: row.source_ref ?? undefined,
+  }
+}
+
+function resolveActorId(c: Context, options: CatalogBookingRoutesOptions): string | null {
+  if (options.resolveActorId) return options.resolveActorId(c)
+  const userId = (c.var as { userId?: string }).userId
+  return typeof userId === "string" ? userId : null
+}
+
+function resolveCorrelationId(c: Context, options: CatalogBookingRoutesOptions): string {
+  return options.resolveCorrelationId?.(c) ?? c.req.header("x-request-id") ?? cryptoRandom()
+}
+
+function resolveAdapterContext(
+  c: Context,
+  options: CatalogBookingRoutesOptions,
+  input: Omit<CatalogBookingAdapterContextInput, "c">,
+): SourceAdapterContext {
+  return (
+    options.resolveAdapterContext?.({ c, ...input }) ?? {
+      connection_id: input.sourceConnectionId ?? input.sourceKind,
+      correlation_id: input.correlationId,
+    }
+  )
+}
+
+function defaultAudienceForPath(c: Context): "staff" | "customer" {
+  return c.req.path.startsWith("/v1/public/") ? "customer" : "staff"
+}
+
+function engineParametersFromDraft(
+  parameters: Record<string, unknown> | undefined,
+  draftPayload: unknown,
+): Record<string, unknown> {
+  const draft = asRecord(draftPayload)
+  const configure = asRecord(draft?.configure)
+  const departureSlotId = stringValue(configure?.departureSlotId)
+  const paxCount = sumDraftPax(configure?.pax)
+  const next: Record<string, unknown> = {
+    ...(parameters ?? {}),
+    ...(draft ? { draft } : {}),
+  }
+
+  if (departureSlotId) {
+    if (next.departureSlotId == null) next.departureSlotId = departureSlotId
+    if (next.departure_id == null) next.departure_id = departureSlotId
+    if (next.slotId == null) next.slotId = departureSlotId
+  }
+  if (paxCount > 0 && next.paxCount == null) {
+    next.paxCount = paxCount
+  }
+
+  return next
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null
+}
+
+function sumDraftPax(value: unknown): number {
+  const pax = asRecord(value)
+  if (!pax) return 0
+  let total = 0
+  for (const count of Object.values(pax)) {
+    if (typeof count === "number" && Number.isFinite(count) && count > 0) {
+      total += count
+    }
+  }
+  return total
+}
+
+function bookingEngineErrorResponse(c: Context, err: unknown): Response {
+  if (err instanceof BookingEngineError) {
+    const status = statusForCode(err.code)
+    return c.json({ error: err.message, code: err.code, context: err.context }, status as never)
+  }
+  return handleApiError(err, c)
+}
+
+function statusForCode(code: string): number {
+  switch (code) {
+    case NO_ADAPTER_REGISTERED:
+    case NO_HANDLER_REGISTERED:
+      return 503
+    case QUOTE_NOT_FOUND:
+    case ORDER_NOT_FOUND:
+      return 404
+    case QUOTE_EXPIRED:
+    case QUOTE_MISMATCH:
+    case ORDER_ALREADY_CANCELLED:
+      return 409
+    case RESERVE_FAILED:
+      return 502
+    default:
+      return 500
+  }
+}
+
+function cryptoRandom(): string {
+  if (typeof globalThis.crypto !== "undefined" && globalThis.crypto.randomUUID) {
+    return globalThis.crypto.randomUUID()
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+function serializeQuoteResult(result: QuoteEntityResult): QuoteResponseV1 {
+  return quoteResponseV1.parse({
+    ...result,
+    quotedAt: result.quotedAt.toISOString(),
+    expiresAt: result.expiresAt.toISOString(),
+    pricing: toPricingBreakdownV1(result.pricing),
+  })
+}
+
+function serializeBookResult(result: BookEntityResult): BookResponseV1 {
+  return bookResponseV1.parse({
+    ...result,
+    pricing: toPricingBreakdownV1(result.pricing),
+  })
+}
+
+function toPricingBreakdownV1(basis: PricingBasis | undefined): PricingBreakdownV1 | undefined {
+  if (!basis) return undefined
+  if (basis.breakdown) {
+    const breakdown = basis.breakdown as PricingBreakdownV1
+    if (breakdown.currency && Array.isArray(breakdown.lines) && Array.isArray(breakdown.taxes)) {
+      return breakdown
+    }
+  }
+  const lines: PricingBreakdownV1["lines"] = [
+    {
+      kind: "base",
+      label: "Base",
+      quantity: 1,
+      unitAmount: basis.base_amount,
+      totalAmount: basis.base_amount,
+    },
+  ]
+  if (basis.fees > 0) {
+    lines.push({ kind: "fee", label: "Fees", unitAmount: basis.fees, totalAmount: basis.fees })
+  }
+  if (basis.surcharges > 0) {
+    lines.push({
+      kind: "supplement",
+      label: "Surcharges",
+      unitAmount: basis.surcharges,
+      totalAmount: basis.surcharges,
+    })
+  }
+  const subtotal = basis.base_amount + basis.fees + basis.surcharges
+  return {
+    currency: basis.currency,
+    lines,
+    taxes:
+      basis.taxes > 0
+        ? [
+            {
+              code: "tax",
+              label: "Tax",
+              rate: 0,
+              amount: basis.taxes,
+              base: basis.base_amount,
+            },
+          ]
+        : [],
+    subtotal,
+    taxTotal: basis.taxes,
+    total: subtotal + basis.taxes,
+  }
+}

--- a/packages/ui/registry/products/i18n/en.ts
+++ b/packages/ui/registry/products/i18n/en.ts
@@ -1,4 +1,4 @@
-import { productsUiEn } from "@voyantjs/products-ui/i18n/en"
+import { productsUiEn } from "../../../../products-ui/src/i18n/en"
 
 import type { RegistryProductsMessages } from "./messages"
 

--- a/packages/ui/registry/products/i18n/ro.ts
+++ b/packages/ui/registry/products/i18n/ro.ts
@@ -1,4 +1,4 @@
-import { productsUiRo } from "@voyantjs/products-ui/i18n/ro"
+import { productsUiRo } from "../../../../products-ui/src/i18n/ro"
 
 import type { RegistryProductsMessages } from "./messages"
 

--- a/packages/workflows-errors/package.json
+++ b/packages/workflows-errors/package.json
@@ -11,8 +11,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
     }
   },
   "main": "./dist/index.js",
@@ -34,6 +34,14 @@
     "typescript": "^5.9.2"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
   }
 }

--- a/packages/workflows-orchestrator-cloudflare/package.json
+++ b/packages/workflows-orchestrator-cloudflare/package.json
@@ -12,8 +12,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
     }
   },
   "main": "./dist/index.js",
@@ -47,6 +47,14 @@
     "wrangler": "^4.86.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
   }
 }

--- a/packages/workflows-orchestrator/package.json
+++ b/packages/workflows-orchestrator/package.json
@@ -12,8 +12,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
     }
   },
   "main": "./dist/index.js",
@@ -42,6 +42,14 @@
     "vitest": "^3.2.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
   }
 }

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -12,28 +12,28 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
     },
     "./testing": {
-      "types": "./dist/testing/index.d.ts",
-      "import": "./dist/testing/index.js"
+      "types": "./src/testing/index.ts",
+      "import": "./src/testing/index.ts"
     },
     "./protocol": {
-      "types": "./dist/protocol/index.d.ts",
-      "import": "./dist/protocol/index.js"
+      "types": "./src/protocol/index.ts",
+      "import": "./src/protocol/index.ts"
     },
     "./handler": {
-      "types": "./dist/handler/index.d.ts",
-      "import": "./dist/handler/index.js"
+      "types": "./src/handler/index.ts",
+      "import": "./src/handler/index.ts"
     },
     "./auth": {
-      "types": "./dist/auth/index.d.ts",
-      "import": "./dist/auth/index.js"
+      "types": "./src/auth/index.ts",
+      "import": "./src/auth/index.ts"
     },
     "./rate-limit": {
-      "types": "./dist/rate-limit/index.d.ts",
-      "import": "./dist/rate-limit/index.js"
+      "types": "./src/rate-limit/index.ts",
+      "import": "./src/rate-limit/index.ts"
     }
   },
   "main": "./dist/index.js",
@@ -73,6 +73,34 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./testing": {
+        "types": "./dist/testing/index.d.ts",
+        "import": "./dist/testing/index.js"
+      },
+      "./protocol": {
+        "types": "./dist/protocol/index.d.ts",
+        "import": "./dist/protocol/index.js"
+      },
+      "./handler": {
+        "types": "./dist/handler/index.d.ts",
+        "import": "./dist/handler/index.js"
+      },
+      "./auth": {
+        "types": "./dist/auth/index.d.ts",
+        "import": "./dist/auth/index.js"
+      },
+      "./rate-limit": {
+        "types": "./dist/rate-limit/index.d.ts",
+        "import": "./dist/rate-limit/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1353,9 +1353,15 @@ importers:
       '@voyantjs/db':
         specifier: workspace:*
         version: link:../db
+      '@voyantjs/hono':
+        specifier: workspace:*
+        version: link:../hono
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
+      hono:
+        specifier: ^4.12.10
+        version: 4.12.10
       zod:
         specifier: ^4.1.4
         version: 4.3.6

--- a/scripts/check-package-i18n-parity.mjs
+++ b/scripts/check-package-i18n-parity.mjs
@@ -43,11 +43,57 @@ async function collectPackageI18nEntries() {
   return entries.sort()
 }
 
+function isPlainObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function findLocaleExport(moduleExports, source) {
+  for (const value of Object.values(moduleExports)) {
+    if (isPlainObject(value)) {
+      return value
+    }
+  }
+
+  throw new Error(`No locale message object export found in ${source}`)
+}
+
+async function collectLocaleFileDefinitions(entryFile) {
+  const entryDir = path.dirname(entryFile)
+  const localeFiles = (await readdir(entryDir))
+    .filter((fileName) => /^[a-z]{2}(?:-[A-Z]{2})?\.ts$/.test(fileName))
+    .sort()
+
+  if (localeFiles.length === 0) {
+    return null
+  }
+
+  const definitions = {}
+
+  for (const localeFile of localeFiles) {
+    const locale = path.basename(localeFile, ".ts")
+    const filePath = path.join(entryDir, localeFile)
+    const moduleExports = await import(pathToFileURL(filePath).href)
+    definitions[locale] = findLocaleExport(moduleExports, path.relative(rootDir, filePath))
+  }
+
+  return {
+    definitions,
+    source: `${path.relative(rootDir, entryFile)}:localeFiles`,
+  }
+}
+
 async function main() {
   const entryFiles = await collectPackageI18nEntries()
   const definitions = []
 
   for (const entryFile of entryFiles) {
+    const localeFileDefinitions = await collectLocaleFileDefinitions(entryFile)
+
+    if (localeFileDefinitions) {
+      definitions.push(localeFileDefinitions)
+      continue
+    }
+
     const moduleExports = await import(pathToFileURL(entryFile).href)
     definitions.push(
       ...collectLocaleDefinitionExports(path.relative(rootDir, entryFile), moduleExports),

--- a/templates/operator/src/api/catalog-booking.ts
+++ b/templates/operator/src/api/catalog-booking.ts
@@ -30,17 +30,11 @@
 import { availabilitySlots } from "@voyantjs/availability/schema"
 import {
   BookingEngineError,
-  type BookingPaymentIntent,
-  bookEntity,
   cancelEntity,
   catalogQuotesTable,
-  createBookingDraft,
-  DEFAULT_DRAFT_TTL_MS,
-  deleteBookingDraft,
-  getBookingDraft,
+  createCatalogBookingRoutes,
   getOrderById,
   listOrders,
-  markDraftConsumed,
   NO_ADAPTER_REGISTERED,
   NO_HANDLER_REGISTERED,
   ORDER_ALREADY_CANCELLED,
@@ -49,9 +43,8 @@ import {
   QUOTE_EXPIRED,
   QUOTE_MISMATCH,
   QUOTE_NOT_FOUND,
-  quoteEntity,
+  type QuoteEntityResult,
   RESERVE_FAILED,
-  updateBookingDraft,
 } from "@voyantjs/catalog/booking-engine"
 import { readSourcedEntry } from "@voyantjs/catalog/services/sourced-entry"
 import type { AnyDrizzleDb } from "@voyantjs/db"
@@ -74,63 +67,6 @@ function getDb(c: Context): AnyDrizzleDb {
   return (c.var as { db: AnyDrizzleDb }).db
 }
 
-/**
- * Resolve provenance for an `(entity_module, entity_id)` pair.
- * Sourced rows live in `catalog_sourced_entries` and carry their
- * upstream pointer; everything else is owned. Customer-facing
- * surfaces shouldn't have to know which is which — they pass the
- * entity, the engine resolves the kind.
- */
-async function resolveEntityProvenance(
-  db: AnyDrizzleDb,
-  entityModule: string,
-  entityId: string,
-): Promise<{
-  sourceKind: string
-  sourceProvider?: string
-  sourceConnectionId?: string
-  sourceRef?: string
-}> {
-  const row = await readSourcedEntry(db, entityModule, entityId)
-  if (!row) {
-    return { sourceKind: OWNED_SOURCE_KIND }
-  }
-  return {
-    sourceKind: row.source_kind,
-    sourceProvider: row.source_provider ?? undefined,
-    sourceConnectionId: row.source_connection_id ?? undefined,
-    sourceRef: row.source_ref ?? undefined,
-  }
-}
-
-interface QuoteBody {
-  entityModule?: string
-  entityId?: string
-  sourceKind?: string
-  sourceProvider?: string
-  sourceConnectionId?: string
-  sourceRef?: string
-  scope?: { locale?: string; audience?: string; market?: string; currency?: string }
-  parameters?: Record<string, unknown>
-  /** Optional draft state — when present, the engine reads pax / addons /
-   *  accommodation / billing country off this for live re-quoting. */
-  draft?: Record<string, unknown>
-  ttlMs?: number
-}
-
-interface BookBody {
-  quoteId?: string
-  bookingId?: string
-  party?: Record<string, unknown>
-  paymentIntent?: BookingPaymentIntent
-  parameters?: Record<string, unknown>
-  /** Optional draft id — when present, the engine resolves the most
-   *  recent quote and full draft payload from `booking_drafts`. */
-  draftId?: string
-  /** Idempotency key — same key in 24h returns the existing booking. */
-  idempotencyKey?: string
-}
-
 interface CancelBody {
   bookingId?: string
   entityModule?: string
@@ -138,41 +74,29 @@ interface CancelBody {
   reason?: string
 }
 
-interface DraftBody {
-  entityModule?: string
-  entityId?: string
-  sourceKind?: string
-  sourceConnectionId?: string
-  sourceRef?: string
-  draftPayload?: Record<string, unknown>
-  currentStep?: string
-  currentQuoteId?: string
-  ttlMs?: number
-}
-
-interface HoldPlaceBody {
-  entityModule?: string
-  entityId?: string
-  draftId?: string
-  ttlMs?: number
-  parameters?: Record<string, unknown>
-}
-
-interface HoldReleaseBody {
-  entityModule?: string
-  holdToken?: string
-}
-
 export function mountCatalogBookingRoutes(hono: Hono): void {
-  // /quote — both surfaces
   for (const prefix of ["/v1/admin/catalog", "/v1/public/catalog"]) {
-    hono.post(`${prefix}/quote`, handleQuote)
-    hono.post(`${prefix}/book`, handleBook)
-    hono.put(`${prefix}/drafts/:id`, handleDraftPut)
-    hono.get(`${prefix}/drafts/:id`, handleDraftGet)
-    hono.delete(`${prefix}/drafts/:id`, handleDraftDelete)
-    hono.post(`${prefix}/holds/place`, handleHoldPlace)
-    hono.post(`${prefix}/holds/release`, handleHoldRelease)
+    hono.route(
+      prefix,
+      createCatalogBookingRoutes({
+        resolveDb: getDb,
+        resolveSourceRegistry: getBookingEngineRegistryFromContext,
+        resolveOwnedHandlers: getOwnedBookingHandlerRegistryFromContext,
+        resolveHoldTtlMs: ({ db, entityModule, entityId }) =>
+          resolveHoldTtlMs(db, entityModule, entityId),
+        transformQuoteResult: ({ db, result, request, provenance }) =>
+          applyOperatorTaxToQuoteResult(
+            db,
+            result,
+            request.entityModule,
+            request.entityId,
+            provenance.sourceKind,
+          ),
+        onDraftConsumedError: ({ error }) => {
+          console.warn("[catalog-booking] markDraftConsumed failed:", error)
+        },
+      }),
+    )
     // List available departures / slots for a product. Drives the
     // storefront's departure-select on the product detail page —
     // customers pick from real available options, not a free-form
@@ -196,150 +120,6 @@ export function mountCatalogBookingRoutes(hono: Hono): void {
 // ─────────────────────────────────────────────────────────────────
 // Handlers
 // ─────────────────────────────────────────────────────────────────
-
-async function handleQuote(c: Context): Promise<Response> {
-  let body: QuoteBody
-  try {
-    body = await c.req.json<QuoteBody>()
-  } catch {
-    body = {}
-  }
-
-  if (!body.entityModule || !body.entityId) {
-    return c.json({ error: "entityModule and entityId are required" }, 400)
-  }
-
-  const db = getDb(c)
-  const registry = getBookingEngineRegistryFromContext(c)
-  const ownedHandlers = getOwnedBookingHandlerRegistryFromContext(c)
-  const correlationId = c.req.header("x-request-id") ?? cryptoRandom()
-
-  // Resolve source provenance from the catalog plane when the
-  // caller hasn't supplied it. Customer-facing surfaces don't (and
-  // shouldn't) carry source kind in URLs — it's an operator
-  // concern. Operator surfaces still pass it explicitly.
-  const provenance = body.sourceKind
-    ? {
-        sourceKind: body.sourceKind,
-        sourceProvider: body.sourceProvider,
-        sourceConnectionId: body.sourceConnectionId,
-        sourceRef: body.sourceRef,
-      }
-    : await resolveEntityProvenance(db, body.entityModule, body.entityId)
-
-  try {
-    const result = await quoteEntity(
-      db,
-      { registry, ownedHandlers },
-      {
-        entityModule: body.entityModule,
-        entityId: body.entityId,
-        sourceKind: provenance.sourceKind,
-        sourceProvider: provenance.sourceProvider,
-        sourceConnectionId: provenance.sourceConnectionId,
-        sourceRef: provenance.sourceRef,
-        scope: {
-          locale: body.scope?.locale ?? "en-GB",
-          audience: body.scope?.audience ?? defaultAudienceForPath(c),
-          market: body.scope?.market ?? "default",
-          currency: body.scope?.currency,
-        },
-        // Both `parameters` and the optional draft are forwarded; the
-        // engine routes the draft into the owned handler / sourced
-        // adapter when present.
-        parameters: engineParametersFromDraft(body.parameters, body.draft),
-        ttlMs: body.ttlMs,
-        adapterContext: {
-          connection_id: provenance.sourceConnectionId ?? provenance.sourceKind,
-          correlation_id: correlationId,
-        },
-      },
-    )
-    const resultWithTax = await applyOperatorTaxToQuoteResult(
-      db,
-      result,
-      body.entityModule,
-      body.entityId,
-      provenance.sourceKind,
-    )
-    return c.json({ ...resultWithTax, pricing: toPricingBreakdownV1(resultWithTax.pricing) })
-  } catch (err) {
-    return errorResponse(c, err)
-  }
-}
-
-async function handleBook(c: Context): Promise<Response> {
-  let body: BookBody
-  try {
-    body = await c.req.json<BookBody>()
-  } catch {
-    body = {}
-  }
-
-  if (!body.quoteId && !body.draftId) {
-    return c.json({ error: "either quoteId or draftId is required" }, 400)
-  }
-
-  const db = getDb(c)
-  const registry = getBookingEngineRegistryFromContext(c)
-  const ownedHandlers = getOwnedBookingHandlerRegistryFromContext(c)
-  const correlationId = c.req.header("x-request-id") ?? cryptoRandom()
-
-  // When the caller passes a draftId without a quoteId, resolve the
-  // current quote off the draft. Phase B's draft-first flow.
-  let quoteId = body.quoteId
-  let draftPayload: Record<string, unknown> | undefined
-  if (!quoteId && body.draftId) {
-    const draft = await getBookingDraft(db, body.draftId)
-    if (!draft) return c.json({ error: "draft not found" }, 404)
-    if (!draft.current_quote_id) {
-      return c.json({ error: "draft has no current quote — call /quote first" }, 409)
-    }
-    quoteId = draft.current_quote_id
-    draftPayload = draft.draft_payload
-  }
-  if (!quoteId) return c.json({ error: "quoteId could not be resolved" }, 400)
-
-  try {
-    const result = await bookEntity(
-      db,
-      { registry, ownedHandlers },
-      {
-        quoteId,
-        bookingId: body.bookingId,
-        party: body.party,
-        paymentIntent: body.paymentIntent,
-        parameters: engineParametersFromDraft(
-          body.parameters,
-          draftPayload ?? body.parameters?.draft,
-        ),
-        idempotencyKey: body.idempotencyKey,
-        adapterContext: { connection_id: "engine", correlation_id: correlationId },
-      },
-    )
-
-    // Link the draft → booking so downstream materialization (lazy
-    // booking row creation in /checkout/start, or the rerun runner)
-    // can find the customer-entered travelers + billing contact via
-    // `consumed_booking_id`. Without this the booking ends up with
-    // empty traveler / contact / dates fields even though the draft
-    // captured them. See booking-journey-architecture §5.7.
-    if (body.draftId) {
-      try {
-        await markDraftConsumed(db, body.draftId, result.bookingId)
-      } catch (err) {
-        // Don't fail the booking if the draft consume update races
-        // with another request — the booking is the source of truth
-        // post-commit, the draft link is for cosmetic / audit purposes.
-        console.warn("[catalog-booking] markDraftConsumed failed:", err)
-      }
-    }
-
-    return c.json({ ...result, pricing: toPricingBreakdownV1(result.pricing) })
-  } catch (err) {
-    return errorResponse(c, err)
-  }
-}
 
 async function handleCancel(c: Context): Promise<Response> {
   let body: CancelBody
@@ -531,216 +311,9 @@ async function resolveHoldTtlMs(
   return (positiveMinutes(supplier?.reservationTimeoutMinutes) ?? 30) * 60 * 1000
 }
 
-async function handleHoldPlace(c: Context): Promise<Response> {
-  let body: HoldPlaceBody
-  try {
-    body = await c.req.json<HoldPlaceBody>()
-  } catch {
-    body = {}
-  }
-
-  if (!body.entityModule || !body.entityId || !body.draftId) {
-    return c.json({ error: "entityModule, entityId, and draftId are required" }, 400)
-  }
-
-  const ownedHandlers = getOwnedBookingHandlerRegistryFromContext(c)
-  const handler = ownedHandlers.resolve(body.entityModule)
-  if (!handler?.placeHold) {
-    return c.json({ error: "no hold primitive registered for this vertical" }, 503)
-  }
-
-  const db = getDb(c)
-  const ttlMs = body.ttlMs ?? (await resolveHoldTtlMs(db, body.entityModule, body.entityId))
-  const correlationId = c.req.header("x-request-id") ?? cryptoRandom()
-  try {
-    const result = await handler.placeHold(
-      { db, adapterContext: { connection_id: "engine", correlation_id: correlationId } },
-      {
-        entityModule: body.entityModule,
-        entityId: body.entityId,
-        draftId: body.draftId,
-        ttlMs,
-        parameters: body.parameters,
-      },
-    )
-    return c.json({ holdToken: result.holdToken, expiresAt: result.expiresAt.toISOString() })
-  } catch (err) {
-    return errorResponse(c, err)
-  }
-}
-
-async function handleHoldRelease(c: Context): Promise<Response> {
-  let body: HoldReleaseBody
-  try {
-    body = await c.req.json<HoldReleaseBody>()
-  } catch {
-    body = {}
-  }
-
-  if (!body.entityModule || !body.holdToken) {
-    return c.json({ error: "entityModule and holdToken are required" }, 400)
-  }
-
-  const ownedHandlers = getOwnedBookingHandlerRegistryFromContext(c)
-  const handler = ownedHandlers.resolve(body.entityModule)
-  if (!handler?.releaseHold) {
-    return c.body(null, 204) // graceful no-op
-  }
-
-  const db = getDb(c)
-  const correlationId = c.req.header("x-request-id") ?? cryptoRandom()
-  try {
-    await handler.releaseHold(
-      { db, adapterContext: { connection_id: "engine", correlation_id: correlationId } },
-      body.holdToken,
-    )
-    return c.body(null, 204)
-  } catch (err) {
-    return errorResponse(c, err)
-  }
-}
-
-async function handleDraftPut(c: Context): Promise<Response> {
-  const id = c.req.param("id")
-  if (!id) return c.json({ error: "id is required" }, 400)
-
-  let body: DraftBody
-  try {
-    body = await c.req.json<DraftBody>()
-  } catch {
-    body = {}
-  }
-
-  if (!body.draftPayload) {
-    return c.json({ error: "draftPayload is required" }, 400)
-  }
-
-  const db = getDb(c)
-
-  // Upsert: if a draft exists, patch; else create with the supplied id.
-  const existing = await getBookingDraft(db, id)
-  if (existing) {
-    const updated = await updateBookingDraft(db, id, {
-      draftPayload: body.draftPayload,
-      currentStep: body.currentStep,
-      currentQuoteId: body.currentQuoteId,
-      refreshTtlMs: body.ttlMs ?? DEFAULT_DRAFT_TTL_MS,
-    })
-    return c.json(updated)
-  }
-
-  if (!body.entityModule || !body.entityId) {
-    return c.json({ error: "entityModule and entityId are required when creating a draft" }, 400)
-  }
-
-  // Customer-facing surfaces don't carry sourceKind in URLs / drafts —
-  // the engine resolves provenance from (entityModule, entityId) via
-  // the catalog plane's sourced-entry lookup (same as /quote and
-  // /book). Operator surfaces still send it explicitly when known.
-  const provenance = body.sourceKind
-    ? {
-        sourceKind: body.sourceKind,
-        sourceConnectionId: body.sourceConnectionId,
-        sourceRef: body.sourceRef,
-      }
-    : await resolveEntityProvenance(db, body.entityModule, body.entityId)
-
-  const created = await createBookingDraft(db, {
-    id,
-    entityModule: body.entityModule,
-    entityId: body.entityId,
-    sourceKind: provenance.sourceKind,
-    sourceConnectionId: provenance.sourceConnectionId,
-    sourceRef: provenance.sourceRef,
-    draftPayload: body.draftPayload,
-    currentStep: body.currentStep,
-    currentQuoteId: body.currentQuoteId,
-    createdBy: extractActorId(c),
-    ttlMs: body.ttlMs,
-  })
-  return c.json(created, 201)
-}
-
-async function handleDraftGet(c: Context): Promise<Response> {
-  const id = c.req.param("id")
-  if (!id) return c.json({ error: "id is required" }, 400)
-  const db = getDb(c)
-  const row = await getBookingDraft(db, id)
-  if (!row) return c.json({ error: "draft not found" }, 404)
-  return c.json(row)
-}
-
-async function handleDraftDelete(c: Context): Promise<Response> {
-  const id = c.req.param("id")
-  if (!id) return c.json({ error: "id is required" }, 400)
-  const db = getDb(c)
-  await deleteBookingDraft(db, id)
-  return c.body(null, 204)
-}
-
 // ─────────────────────────────────────────────────────────────────
 // Helpers
 // ─────────────────────────────────────────────────────────────────
-
-function defaultAudienceForPath(c: Context): string {
-  return c.req.path.startsWith("/v1/public/") ? "customer" : "staff"
-}
-
-function extractActorId(c: Context): string | null {
-  const userId = (c.var as { userId?: string }).userId
-  return typeof userId === "string" ? userId : null
-}
-
-function engineParametersFromDraft(
-  parameters: Record<string, unknown> | undefined,
-  draftPayload: unknown,
-): Record<string, unknown> {
-  const draft = asRecord(draftPayload)
-  const configure = asRecord(draft?.configure)
-  const departureSlotId = stringValue(configure?.departureSlotId)
-  const paxCount = sumDraftPax(configure?.pax)
-  const next: Record<string, unknown> = {
-    ...(parameters ?? {}),
-    ...(draft ? { draft } : {}),
-  }
-
-  if (departureSlotId) {
-    // The journey's canonical field is `configure.departureSlotId`.
-    // Older/source adapters, including the demo adapter, still read
-    // `departure_id`; owned hold bridges read `slotId`. Send all
-    // aliases so quote and reserve operate on the same selected slot.
-    if (next.departureSlotId == null) next.departureSlotId = departureSlotId
-    if (next.departure_id == null) next.departure_id = departureSlotId
-    if (next.slotId == null) next.slotId = departureSlotId
-  }
-  if (paxCount > 0 && next.paxCount == null) {
-    next.paxCount = paxCount
-  }
-
-  return next
-}
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined
-}
-
-function stringValue(value: unknown): string | null {
-  return typeof value === "string" && value.length > 0 ? value : null
-}
-
-function sumDraftPax(value: unknown): number {
-  const pax = asRecord(value)
-  if (!pax) return 0
-  let total = 0
-  for (const count of Object.values(pax)) {
-    if (typeof count === "number" && Number.isFinite(count) && count > 0) {
-      total += count
-    }
-  }
-  return total
-}
 
 function errorResponse(c: Context, err: unknown): Response {
   if (err instanceof BookingEngineError) {
@@ -777,22 +350,13 @@ function cryptoRandom(): string {
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
 }
 
-interface PricingBasisShape {
-  base_amount: number
-  taxes: number
-  fees: number
-  surcharges: number
-  currency: string
-  breakdown?: Record<string, unknown>
-}
-
 async function applyOperatorTaxToQuoteResult(
   db: AnyDrizzleDb,
-  result: Awaited<ReturnType<typeof quoteEntity>>,
+  result: QuoteEntityResult,
   entityModule: string,
   entityId: string,
   sourceKind: string,
-): Promise<Awaited<ReturnType<typeof quoteEntity>>> {
+): Promise<QuoteEntityResult> {
   if (!result.available || !result.pricing || sourceKind === OWNED_SOURCE_KIND) return result
   if (result.pricing.taxes > 0) return result
 
@@ -854,84 +418,6 @@ async function applyOperatorTaxToQuoteResult(
     .where(eq(catalogQuotesTable.id, result.quoteId))
 
   return { ...result, pricing: adjustedPricing }
-}
-
-/**
- * Map the engine's `PricingBasis` (base/taxes/fees/surcharges totals)
- * onto the wire shape `pricingBreakdownV1` (lines + tax rows + totals)
- * that V1 clients expect. The basis is what adapters report; the
- * breakdown is what the storefront renders. A line-aware breakdown
- * may eventually flow through the engine and override this projection.
- */
-function toPricingBreakdownV1(basis: PricingBasisShape | undefined):
-  | {
-      currency: string
-      lines: Array<{
-        kind: "base" | "addon" | "accommodation" | "supplement" | "discount" | "fee"
-        label: string
-        quantity?: number
-        unitAmount: number
-        totalAmount: number
-      }>
-      taxes: Array<{ code: string; label: string; rate: number; amount: number; base: number }>
-      subtotal: number
-      taxTotal: number
-      total: number
-    }
-  | undefined {
-  if (!basis) return undefined
-  if (basis.breakdown) {
-    const breakdown = basis.breakdown as ReturnType<typeof toPricingBreakdownV1>
-    if (breakdown?.currency && Array.isArray(breakdown.lines) && Array.isArray(breakdown.taxes)) {
-      return breakdown
-    }
-  }
-  const lines: Array<{
-    kind: "base" | "fee" | "supplement"
-    label: string
-    quantity?: number
-    unitAmount: number
-    totalAmount: number
-  }> = [
-    {
-      kind: "base",
-      label: "Base",
-      quantity: 1,
-      unitAmount: basis.base_amount,
-      totalAmount: basis.base_amount,
-    },
-  ]
-  if (basis.fees > 0) {
-    lines.push({ kind: "fee", label: "Fees", unitAmount: basis.fees, totalAmount: basis.fees })
-  }
-  if (basis.surcharges > 0) {
-    lines.push({
-      kind: "supplement",
-      label: "Surcharges",
-      unitAmount: basis.surcharges,
-      totalAmount: basis.surcharges,
-    })
-  }
-  const subtotal = basis.base_amount + basis.fees + basis.surcharges
-  return {
-    currency: basis.currency,
-    lines,
-    taxes:
-      basis.taxes > 0
-        ? [
-            {
-              code: "tax",
-              label: "Tax",
-              rate: 0,
-              amount: basis.taxes,
-              base: basis.base_amount,
-            },
-          ]
-        : [],
-    subtotal,
-    taxTotal: basis.taxes,
-    total: subtotal + basis.taxes,
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary
Implements the first #418 slice by exporting a reusable BookingJourney Hono route module from `@voyantjs/catalog/booking-engine`.

## Changes
- Adds `createCatalogBookingRoutes` and `createCatalogBookingHonoModule` for quote, draft CRUD, hold place/release, and book flows.
- Adds injected runtime hooks for database access, source registry, owned handlers, provenance, adapter context, content enrichment, snapshot capture, hold TTL, quote/book transforms, draft-consume handling, and commit notifications.
- Serializes quote/book responses to the V1 contracts used by `@voyantjs/catalog-react/booking-engine`.
- Migrates the operator template to consume the shared core routes while keeping slots, admin orders, checkout, and snapshot enrichment local.
- Documents consumer setup and adds a catalog changeset.

Refs #418.

## Validation
- `pnpm --filter @voyantjs/catalog lint`
- `pnpm --filter @voyantjs/catalog typecheck`
- `pnpm --filter @voyantjs/catalog test`
- `pnpm -C templates/operator typecheck`
- `pnpm lint:changed`
- `pnpm verify:package-exports`
- commit hook: full repo lint/typecheck
- pre-push hook: full repo test lane