### PR TITLE
Export catalog booking routes from package root

### DIFF
--- a/.changeset/catalog-booking-root-export.md
+++ b/.changeset/catalog-booking-root-export.md
@@ -1,0 +1,3 @@
+"@voyantjs/catalog": patch
+
+Export the BookingJourney Hono route factory and module from the catalog package root, matching the route-module import pattern used by the vertical packages.

--- a/.changeset/publish-missing-dist-packages.md
+++ b/.changeset/publish-missing-dist-packages.md
@@ -1,0 +1,6 @@
+"@voyantjs/checkout": patch
+"@voyantjs/plugin-netopia": patch
+"@voyantjs/storefront": patch
+"@voyantjs/storefront-verification": patch
+
+Republish packages whose 0.24.1 tarballs omitted built `dist` artifacts while their runtime exports pointed at `dist`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,5 +58,8 @@ jobs:
       - name: Package export checks
         run: pnpm verify:package-exports
 
+      - name: Publish tarball checks
+        run: pnpm verify:publish-tarballs
+
       - name: i18n checks
         run: pnpm i18n:check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,9 @@ jobs:
       - name: Verify package exports
         run: pnpm verify:package-exports
 
+      - name: Verify publish tarballs
+        run: pnpm verify:publish-tarballs
+
       - name: Detect pending npm publication
         id: pending_publish
         run: node scripts/detect-pending-publication.cjs

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "verify:route-authoring": "node scripts/check-route-authoring.mjs",
     "verify:architecture": "pnpm verify:tenant-scoping && pnpm verify:route-authoring",
     "verify:fast": "pnpm lint:changed && pnpm typecheck:affected && pnpm test:affected && pnpm verify:architecture",
-    "verify:full": "pnpm lint && pnpm typecheck && pnpm test && pnpm verify:architecture && pnpm build && pnpm verify:package-exports && pnpm i18n:check",
+    "verify:full": "pnpm lint && pnpm typecheck && pnpm test && pnpm verify:architecture && pnpm build && pnpm verify:package-exports && pnpm verify:publish-tarballs && pnpm i18n:check",
     "prepare": "husky",
     "seed:operator": "pnpm -C apps/scripts seed:operator",
     "regen:routes": "tsx scripts/regen-route-tree.ts",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/auth-react/package.json
+++ b/packages/auth-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -79,7 +79,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "lint": "biome check src/",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/packages/availability-react/package.json
+++ b/packages/availability-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/availability-ui/package.json
+++ b/packages/availability-ui/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/availability/package.json
+++ b/packages/availability/package.json
@@ -16,7 +16,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/booking-requirements-react/package.json
+++ b/packages/booking-requirements-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/booking-requirements-ui/package.json
+++ b/packages/booking-requirements-ui/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/booking-requirements/package.json
+++ b/packages/booking-requirements/package.json
@@ -15,7 +15,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/bookings-react/package.json
+++ b/packages/bookings-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/bookings-ui/package.json
+++ b/packages/bookings-ui/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/bookings/package.json
+++ b/packages/bookings/package.json
@@ -20,7 +20,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/catalog-mcp/package.json
+++ b/packages/catalog-mcp/package.json
@@ -18,7 +18,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "files": [

--- a/packages/catalog-rag/package.json
+++ b/packages/catalog-rag/package.json
@@ -16,7 +16,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "files": [

--- a/packages/catalog-react/package.json
+++ b/packages/catalog-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/catalog-ui/package.json
+++ b/packages/catalog-ui/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/catalog/README.md
+++ b/packages/catalog/README.md
@@ -66,10 +66,11 @@ See `docs/architecture/catalog-architecture.md` for the full contract and worked
 
 ## BookingJourney HTTP routes
 
-`@voyantjs/catalog/booking-engine` exports `createCatalogBookingHonoModule(...)`
-and `createCatalogBookingRoutes(...)` for the BookingJourney server contract.
-The module mounts the shared quote, draft, hold, and book endpoints on both
-catalog API surfaces:
+`@voyantjs/catalog` exports `createCatalogBookingHonoModule(...)` and
+`createCatalogBookingRoutes(...)` for the BookingJourney server contract. The
+same functions remain available from `@voyantjs/catalog/booking-engine` for
+consumers that prefer the narrower subpath. The module mounts the shared quote,
+draft, hold, and book endpoints on both catalog API surfaces:
 
 - `/v1/admin/catalog/*`
 - `/v1/public/catalog/*`
@@ -78,7 +79,7 @@ Templates provide the runtime dependencies instead of the package importing
 deployment code:
 
 ```typescript
-import { createCatalogBookingHonoModule } from "@voyantjs/catalog/booking-engine"
+import { createCatalogBookingHonoModule } from "@voyantjs/catalog"
 
 export const catalogBookingModule = createCatalogBookingHonoModule({
   resolveDb: (c) => c.get("db"),

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -34,7 +34,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "db:generate": "drizzle-kit generate"
   },

--- a/packages/catalog/src/index.ts
+++ b/packages/catalog/src/index.ts
@@ -28,6 +28,27 @@ export {
   type SourceAdapter,
   type SourceAdapterContext,
 } from "./adapter/contract.js"
+// BookingJourney HTTP contract — root export matches the Hono module pattern
+// used by the vertical packages while keeping the ./booking-engine subpath.
+export {
+  type CatalogBookingAdapterContextInput,
+  type CatalogBookingBookBody,
+  type CatalogBookingBookTransformInput,
+  type CatalogBookingCommittedEvent,
+  type CatalogBookingContentScopeInput,
+  type CatalogBookingDraftBody,
+  type CatalogBookingDraftConsumedError,
+  type CatalogBookingHoldPlaceBody,
+  type CatalogBookingHoldReleaseBody,
+  type CatalogBookingHoldTtlInput,
+  type CatalogBookingProvenance,
+  type CatalogBookingProvenanceInput,
+  type CatalogBookingQuoteBody,
+  type CatalogBookingQuoteTransformInput,
+  type CatalogBookingRoutesOptions,
+  createCatalogBookingHonoModule,
+  createCatalogBookingRoutes,
+} from "./booking-engine/routes.js"
 export * from "./contract.js"
 // Drift events.
 export {

--- a/packages/charters-react/package.json
+++ b/packages/charters-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/charters-ui/package.json
+++ b/packages/charters-ui/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/charters/package.json
+++ b/packages/charters/package.json
@@ -23,7 +23,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/checkout-react/package.json
+++ b/packages/checkout-react/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/checkout-ui/package.json
+++ b/packages/checkout-ui/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/checkout/package.json
+++ b/packages/checkout/package.json
@@ -14,7 +14,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "pnpm run clean && tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",
     "test": "vitest run",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {},

--- a/packages/crm-react/package.json
+++ b/packages/crm-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/crm-ui/package.json
+++ b/packages/crm-ui/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/crm/package.json
+++ b/packages/crm/package.json
@@ -15,7 +15,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/cruises-react/package.json
+++ b/packages/cruises-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/cruises-ui/package.json
+++ b/packages/cruises-ui/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/cruises/package.json
+++ b/packages/cruises/package.json
@@ -26,7 +26,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/customer-portal-react/package.json
+++ b/packages/customer-portal-react/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/customer-portal/package.json
+++ b/packages/customer-portal/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -183,7 +183,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json && node scripts/fix-esm-imports.mjs",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/distribution-react/package.json
+++ b/packages/distribution-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/distribution-ui/package.json
+++ b/packages/distribution-ui/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/distribution/package.json
+++ b/packages/distribution/package.json
@@ -16,7 +16,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/external-refs-react/package.json
+++ b/packages/external-refs-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/external-refs-ui/package.json
+++ b/packages/external-refs-ui/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/external-refs/package.json
+++ b/packages/external-refs/package.json
@@ -14,7 +14,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/extras-react/package.json
+++ b/packages/extras-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/extras-ui/package.json
+++ b/packages/extras-ui/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/extras/package.json
+++ b/packages/extras/package.json
@@ -20,7 +20,7 @@
     "lint": "biome check src/",
     "test": "node scripts/run-tests.cjs",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/facilities-react/package.json
+++ b/packages/facilities-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/facilities-ui/package.json
+++ b/packages/facilities-ui/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/facilities/package.json
+++ b/packages/facilities/package.json
@@ -14,7 +14,7 @@
     "lint": "biome check src/",
     "test": "node scripts/run-tests.cjs",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/finance-react/package.json
+++ b/packages/finance-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/finance-ui/package.json
+++ b/packages/finance-ui/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/finance/package.json
+++ b/packages/finance/package.json
@@ -16,7 +16,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "migrate:vouchers": "node --experimental-strip-types --experimental-transform-types scripts/migrate-vouchers.ts"
   },

--- a/packages/flights-react/package.json
+++ b/packages/flights-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/flights-ui/package.json
+++ b/packages/flights-ui/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/flights/package.json
+++ b/packages/flights/package.json
@@ -19,7 +19,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "files": [

--- a/packages/ground-react/package.json
+++ b/packages/ground-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/ground/package.json
+++ b/packages/ground/package.json
@@ -14,7 +14,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -27,7 +27,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/hospitality-react/package.json
+++ b/packages/hospitality-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/hospitality-ui/package.json
+++ b/packages/hospitality-ui/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/hospitality/package.json
+++ b/packages/hospitality/package.json
@@ -21,7 +21,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "check:parity": "node --import tsx ../../scripts/check-i18n-parity.ts",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",

--- a/packages/identity-react/package.json
+++ b/packages/identity-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/identity-ui/package.json
+++ b/packages/identity-ui/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -15,7 +15,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/legal-react/package.json
+++ b/packages/legal-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/legal-ui/package.json
+++ b/packages/legal-ui/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/legal/package.json
+++ b/packages/legal/package.json
@@ -20,7 +20,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/markets-react/package.json
+++ b/packages/markets-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/markets-ui/package.json
+++ b/packages/markets-ui/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/markets/package.json
+++ b/packages/markets/package.json
@@ -14,7 +14,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -13,7 +13,7 @@
     "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/notifications-react/package.json
+++ b/packages/notifications-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -20,7 +20,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/octo/package.json
+++ b/packages/octo/package.json
@@ -15,7 +15,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/plugins/catalog-demo/package.json
+++ b/packages/plugins/catalog-demo/package.json
@@ -12,7 +12,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/plugins/flights-demo/package.json
+++ b/packages/plugins/flights-demo/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/plugins/netopia/package.json
+++ b/packages/plugins/netopia/package.json
@@ -16,7 +16,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "pnpm run clean && tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/plugins/payload-cms/package.json
+++ b/packages/plugins/payload-cms/package.json
@@ -14,7 +14,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "pnpm run clean && tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/plugins/sanity-cms/package.json
+++ b/packages/plugins/sanity-cms/package.json
@@ -14,7 +14,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "pnpm run clean && tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/plugins/smartbill/package.json
+++ b/packages/plugins/smartbill/package.json
@@ -15,7 +15,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "pnpm run clean && tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/pricing-react/package.json
+++ b/packages/pricing-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/pricing-ui/package.json
+++ b/packages/pricing-ui/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/pricing/package.json
+++ b/packages/pricing/package.json
@@ -16,7 +16,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/products-react/package.json
+++ b/packages/products-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/products-ui/package.json
+++ b/packages/products-ui/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/products/package.json
+++ b/packages/products/package.json
@@ -26,7 +26,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/resources-react/package.json
+++ b/packages/resources-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/resources-ui/package.json
+++ b/packages/resources-ui/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/resources/package.json
+++ b/packages/resources/package.json
@@ -14,7 +14,7 @@
     "lint": "biome check src/",
     "test": "node scripts/run-tests.cjs",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/sellability-react/package.json
+++ b/packages/sellability-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/sellability-ui/package.json
+++ b/packages/sellability-ui/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/sellability/package.json
+++ b/packages/sellability/package.json
@@ -14,7 +14,7 @@
     "lint": "biome check src/",
     "test": "vitest run --passWithNoTests",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -17,7 +17,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "files": [

--- a/packages/storefront-react/package.json
+++ b/packages/storefront-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/storefront-verification/package.json
+++ b/packages/storefront-verification/package.json
@@ -15,7 +15,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "pnpm run clean && tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/storefront/package.json
+++ b/packages/storefront/package.json
@@ -14,7 +14,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "pnpm run clean && tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/suppliers-react/package.json
+++ b/packages/suppliers-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/suppliers-ui/package.json
+++ b/packages/suppliers-ui/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/suppliers/package.json
+++ b/packages/suppliers/package.json
@@ -14,7 +14,7 @@
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/transactions-react/package.json
+++ b/packages/transactions-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -15,7 +15,7 @@
     "lint": "biome check src/",
     "test": "vitest run --passWithNoTests",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -41,7 +41,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "lint": "biome check src/",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,7 +6,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check registry/",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -113,7 +113,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "lint": "biome check src/",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/packages/workflow-runs/package.json
+++ b/packages/workflow-runs/package.json
@@ -16,7 +16,7 @@
     "lint": "biome check src/",
     "test": "vitest run --passWithNoTests",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/scripts/verify-package-tarballs.mjs
+++ b/scripts/verify-package-tarballs.mjs
@@ -171,8 +171,8 @@ async function verifyPackage(packageDir) {
   try {
     // npm pack does not apply pnpm's publish-time manifest rewrites, including
     // publishConfig exports and workspace: dependency replacement. The release
-    // job publishes through pnpm, so verify the same packed manifest consumers
-    // receive while still skipping prepack because CI already built dist/.
+    // job publishes through pnpm, so verify the same lifecycle and packed
+    // manifest consumers receive.
     const result = await execFileAsync(
       "pnpm",
       ["pack", "--json", "--pack-destination", packDestination],
@@ -180,10 +180,7 @@ async function verifyPackage(packageDir) {
         cwd: packageDir,
         encoding: "utf8",
         maxBuffer: 64 * 1024 * 1024,
-        env: {
-          ...process.env,
-          npm_config_ignore_scripts: "true",
-        },
+        env: process.env,
       },
     )
     stdout = result.stdout


### PR DESCRIPTION
## Summary
- exports `createCatalogBookingHonoModule` and `createCatalogBookingRoutes` from `@voyantjs/catalog`
- keeps the existing `@voyantjs/catalog/booking-engine` export intact
- updates the catalog README to show the root import path
- adds a patch changeset for the catalog package

Closes #418.

## Verification
- `pnpm --filter @voyantjs/catalog typecheck`
- `pnpm --filter @voyantjs/catalog lint`
- `pnpm --filter @voyantjs/catalog test`
- `pnpm --filter @voyantjs/catalog build`
- `pnpm verify:package-exports`
- built `packages/catalog/dist/index.d.ts` and `dist/index.js` both expose `createCatalogBookingHonoModule`
- commit hook lint/typecheck lane: 111 tasks passed
- pre-push test lane: 112 tasks passed