### PR TITLE
Fix release changeset frontmatter

### DIFF
--- a/.changeset/catalog-booking-root-export.md
+++ b/.changeset/catalog-booking-root-export.md
@@ -1,3 +1,5 @@
+---
 "@voyantjs/catalog": patch
+---
 
 Export the BookingJourney Hono route factory and module from the catalog package root, matching the route-module import pattern used by the vertical packages.

--- a/.changeset/publish-missing-dist-packages.md
+++ b/.changeset/publish-missing-dist-packages.md
@@ -1,6 +1,8 @@
+---
 "@voyantjs/checkout": patch
 "@voyantjs/plugin-netopia": patch
 "@voyantjs/storefront": patch
 "@voyantjs/storefront-verification": patch
+---
 
 Republish packages whose 0.24.1 tarballs omitted built `dist` artifacts while their runtime exports pointed at `dist`.


### PR DESCRIPTION
Fixes the changeset frontmatter delimiters so the release workflow can parse the pending catalog and tarball republish changesets.