### PR TITLE
Support self-host workflow resume dispatch

### DIFF
--- a/.changeset/selfhost-workflow-resume.md
+++ b/.changeset/selfhost-workflow-resume.md
@@ -1,0 +1,13 @@
+---
+"@voyantjs/workflows-orchestrator-node": minor
+"@voyantjs/workflows-orchestrator": minor
+"@voyantjs/workflow-runs": minor
+---
+
+Add a supported self-host failed-step resume path for workflow-run dispatch.
+
+The Node self-host server now exposes a resume endpoint that can start a new run
+from a stored self-host parent snapshot or from an external admin recorder parent
+id with explicit `workflowId`, `resumeFromStep`, and seeded step results. The
+orchestrator can now trigger runs with a pre-populated journal, and the Node
+self-host package exports a client helper for operator admin integrations.

--- a/packages/workflow-runs/README.md
+++ b/packages/workflow-runs/README.md
@@ -16,23 +16,36 @@ The package is published with the same release-train version as the other instal
 
 ```ts
 import { mountWorkflowRunsAdminRoutes, WorkflowRunnerRegistry } from "@voyantjs/workflow-runs"
+import { createNodeSelfHostWorkflowClient } from "@voyantjs/workflows-orchestrator-node"
 
 const workflowRunnerRegistry = new WorkflowRunnerRegistry()
+const workflowServer = createNodeSelfHostWorkflowClient({
+  baseUrl: process.env.WORKFLOW_SERVER_URL!,
+})
 
 workflowRunnerRegistry.register({
   name: "checkout-finalize",
-  rerun: async ({ run, input }) => {
-    await workflowServer.dispatch("checkout-finalize", {
-      idempotencyKey: run.idempotencyKey ?? run.id,
+  idempotency: "unsafe",
+  description:
+    "Confirms the booking and issues the final invoice. Use Resume to retry from a failed step.",
+  rerun: async (input, ctx) => {
+    const saved = await workflowServer.trigger({
+      workflowId: "checkout-finalize",
       input,
+      tags: [...ctx.tags, "rerun:true"],
     })
+    return { runId: saved.id }
   },
-  resume: async ({ run, input, failedStep }) => {
-    await workflowServer.dispatch("checkout-finalize", {
-      resumeFromStep: failedStep?.stepName ?? null,
-      originalRunId: run.id,
+  resume: async (input, ctx) => {
+    const { saved } = await workflowServer.resume(ctx.parentRunId, {
+      workflowId: "checkout-finalize",
       input,
+      resumeFromStep: ctx.resumeFromStep,
+      seedResults: ctx.seedResults,
+      tags: [...ctx.tags, "resume:true"],
+      triggeredByUserId: ctx.triggeredByUserId,
     })
+    return { runId: saved.id }
   },
 })
 
@@ -41,4 +54,4 @@ mountWorkflowRunsAdminRoutes(hono, {
 })
 ```
 
-For self-hosted workflow services, keep runner registration close to the code that mounts the workflow service. The registry should dispatch to your external workflow server instead of importing worker-only runtime code into the admin API process.
+For self-hosted workflow services, keep runner registration close to the code that mounts the workflow service. The registry should dispatch to your external workflow server instead of importing worker-only runtime code into the admin API process. The resume path sends `ctx.resumeFromStep` plus `ctx.seedResults`; the self-host server starts a new run, pre-populates the journal with the seeded step outputs, and executes from the failed step onward.

--- a/packages/workflows-orchestrator-node/README.md
+++ b/packages/workflows-orchestrator-node/README.md
@@ -13,10 +13,49 @@ This package is the first building block for the Docker/GCE self-host target:
 - lease-based wakeup store + poller primitives for the future multi-process / Postgres-backed adapter
 - persistent wakeup manager for file-backed self-host installs
 - entry loading + HTTP/SSE server helpers for the Node self-host target
+- failed-step resume dispatch for operator dashboards (`POST /api/runs/:id/resume`)
 - package-owned Postgres migration runner for Docker/runtime boot flows
 
 It is intentionally smaller than the future full Node adapter. The first goal is
 to move Node-specific runtime concerns out of the CLI and into a reusable package.
+
+## Self-host dispatch client
+
+Operator admin processes can use the client helper instead of hand-rolling the
+self-host HTTP contract:
+
+```ts
+import { createNodeSelfHostWorkflowClient } from "@voyantjs/workflows-orchestrator-node";
+
+const workflows = createNodeSelfHostWorkflowClient({
+  baseUrl: process.env.WORKFLOW_SERVER_URL!,
+});
+
+const rerun = await workflows.trigger({
+  workflowId: "checkout-finalize",
+  input,
+  tags: ["rerun:true"],
+});
+
+const resumed = await workflows.resume(parentRunId, {
+  workflowId: "checkout-finalize",
+  input,
+  resumeFromStep: "issue_invoice",
+  seedResults: {
+    validate_booking: { ok: true },
+  },
+  tags: ["resume:true"],
+  triggeredByUserId: userId,
+});
+```
+
+`resume(...)` starts a new run linked to the parent id. When the parent id is a
+self-host snapshot id and `seedResults` is omitted, the server derives seed
+entries from the parent run's successful journaled steps before the failed step.
+When the parent id comes from an external admin recorder such as
+`@voyantjs/workflow-runs`, pass `workflowId`, `resumeFromStep`, and
+`seedResults` from that recorder's `WorkflowResumeContext`. Seeded steps are
+replayed from the journal, so their side effects do not run again.
 
 ## Postgres migrations
 

--- a/packages/workflows-orchestrator-node/src/__tests__/dashboard-server.test.ts
+++ b/packages/workflows-orchestrator-node/src/__tests__/dashboard-server.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 import { createNodeSelfHostDeps, handleRequest } from "../dashboard-server.js"
 import type { SnapshotRunStore } from "../snapshot-run-store.js"
+import { createFsSnapshotRunStore } from "../snapshot-run-store.js"
 
 const emptyStore: SnapshotRunStore = {
   save: async () => {
@@ -120,6 +121,130 @@ describe("createNodeSelfHostDeps validation", () => {
         }),
       ).rejects.toThrow(/registered no workflows/i)
     } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it("resumes a failed self-host run from its seeded successful steps", async () => {
+    const root = await mkdtemp(join(process.cwd(), ".tmp-resume-workflow-entry-"))
+    const previousProbe = (globalThis as { __voyantResumeProbeA?: number }).__voyantResumeProbeA
+    let deps: Awaited<ReturnType<typeof createNodeSelfHostDeps>> | undefined
+    try {
+      ;(globalThis as { __voyantResumeProbeA?: number }).__voyantResumeProbeA = 0
+      const entryFile = join(root, "resume-workflows.mjs")
+      const staticDir = join(root, "static")
+      await mkdir(staticDir, { recursive: true })
+      await writeFile(
+        entryFile,
+        [
+          'import { workflow } from "@voyantjs/workflows";',
+          'workflow({ id: "resume_probe", async run(input, ctx) {',
+          '  const a = await ctx.step("a", () => {',
+          "    globalThis.__voyantResumeProbeA = (globalThis.__voyantResumeProbeA ?? 0) + 1;",
+          "    return input.value;",
+          "  });",
+          '  const b = await ctx.step("b", () => {',
+          '    if (input.fail) throw new Error("boom");',
+          "    return a + 5;",
+          "  });",
+          "  return { total: b };",
+          "}});",
+        ].join("\n"),
+        "utf8",
+      )
+
+      deps = await createNodeSelfHostDeps({
+        entryFile,
+        staticDir,
+        cacheBustEntry: true,
+        store: createFsSnapshotRunStore({ rootDir: join(root, "runs") }),
+      })
+
+      const failedResponse = await handleRequest(
+        {
+          method: "POST",
+          url: "http://local/api/runs",
+          body: JSON.stringify({
+            workflowId: "resume_probe",
+            input: { value: 10, fail: true },
+          }),
+        },
+        deps,
+      )
+      expect(failedResponse.status).toBe(200)
+      const failed = JSON.parse(String(failedResponse.body)) as {
+        saved: { id: string; status: string; result: { steps: Array<{ id: string }> } }
+      }
+      expect(failed.saved.status).toBe("failed")
+      expect(failed.saved.result.steps.map((step) => step.id)).toEqual(["a", "b"])
+      expect((globalThis as { __voyantResumeProbeA?: number }).__voyantResumeProbeA).toBe(1)
+
+      const resumedResponse = await handleRequest(
+        {
+          method: "POST",
+          url: `http://local/api/runs/${failed.saved.id}/resume`,
+          body: JSON.stringify({
+            input: { value: 10, fail: false },
+          }),
+        },
+        deps,
+      )
+      expect(resumedResponse.status).toBe(200)
+      const resumed = JSON.parse(String(resumedResponse.body)) as {
+        saved: {
+          id: string
+          status: string
+          replayOf?: string
+          result: { output: { total: number }; steps: Array<{ id: string }> }
+        }
+        parentRunId: string
+        resumeFromStep: string
+      }
+      expect(resumed.parentRunId).toBe(failed.saved.id)
+      expect(resumed.resumeFromStep).toBe("b")
+      expect(resumed.saved.status).toBe("completed")
+      expect(resumed.saved.replayOf).toBe(failed.saved.id)
+      expect(resumed.saved.result.output).toEqual({ total: 15 })
+      expect(resumed.saved.result.steps.map((step) => step.id)).toEqual(["a", "b"])
+      expect((globalThis as { __voyantResumeProbeA?: number }).__voyantResumeProbeA).toBe(1)
+
+      const externalParentResponse = await handleRequest(
+        {
+          method: "POST",
+          url: "http://local/api/runs/admin_workflow_run_1/resume",
+          body: JSON.stringify({
+            workflowId: "resume_probe",
+            input: { value: 20, fail: false },
+            resumeFromStep: "b",
+            seedResults: { a: 20 },
+          }),
+        },
+        deps,
+      )
+      expect(externalParentResponse.status).toBe(200)
+      const externalParentResume = JSON.parse(String(externalParentResponse.body)) as {
+        saved: {
+          status: string
+          replayOf?: string
+          result: { output: { total: number }; steps: Array<{ id: string }> }
+        }
+        parentRunId: string
+        resumeFromStep: string
+      }
+      expect(externalParentResume.parentRunId).toBe("admin_workflow_run_1")
+      expect(externalParentResume.resumeFromStep).toBe("b")
+      expect(externalParentResume.saved.status).toBe("completed")
+      expect(externalParentResume.saved.replayOf).toBe("admin_workflow_run_1")
+      expect(externalParentResume.saved.result.output).toEqual({ total: 25 })
+      expect(externalParentResume.saved.result.steps.map((step) => step.id)).toEqual(["a", "b"])
+      expect((globalThis as { __voyantResumeProbeA?: number }).__voyantResumeProbeA).toBe(1)
+    } finally {
+      await deps?.shutdown?.()
+      if (previousProbe === undefined) {
+        delete (globalThis as { __voyantResumeProbeA?: number }).__voyantResumeProbeA
+      } else {
+        ;(globalThis as { __voyantResumeProbeA?: number }).__voyantResumeProbeA = previousProbe
+      }
       await rm(root, { recursive: true, force: true })
     }
   })

--- a/packages/workflows-orchestrator-node/src/dashboard-server.ts
+++ b/packages/workflows-orchestrator-node/src/dashboard-server.ts
@@ -19,6 +19,7 @@ import { createPersistentWakeupManager } from "./persistent-wakeup-manager.js"
 import { createPostgresConnection } from "./postgres.js"
 import { createPostgresSnapshotRunStore } from "./postgres-snapshot-run-store.js"
 import { createPostgresWakeupStore } from "./postgres-wakeup-store.js"
+import { buildResumeJournal, buildSeededResumeJournal } from "./resume-run.js"
 import { recordToSnapshot, snapshotToRecord } from "./run-record-snapshot.js"
 import { createScheduler, type SchedulerHandle, type ScheduleSource } from "./scheduler.js"
 import {
@@ -42,7 +43,23 @@ export interface ServeDeps {
   triggerRun?: (args: {
     workflowId: string
     input: unknown
+    runId?: string
+    tags?: string[]
+    triggeredByUserId?: string | null
   }) => Promise<{ ok: true; saved: StoredRun } | { ok: false; message: string; exitCode: number }>
+  resumeRun?: (args: {
+    parentRunId: string
+    workflowId?: string
+    input?: unknown
+    resumeFromStep?: string
+    seedResults?: Record<string, unknown>
+    runId?: string
+    tags?: string[]
+    triggeredByUserId?: string | null
+  }) => Promise<
+    | { ok: true; saved: StoredRun; parentRunId: string; resumeFromStep: string }
+    | { ok: false; message: string; exitCode: number }
+  >
   listWorkflows?: () => { id: string; description?: string }[]
   injectWaitpoint?: (args: {
     runId: string
@@ -100,6 +117,7 @@ export interface RequestHandlerDeps {
   readStatic?: (path: string) => Promise<Uint8Array | null>
   hasStaticDashboard?: boolean
   triggerRun?: ServeDeps["triggerRun"]
+  resumeRun?: ServeDeps["resumeRun"]
   listWorkflows?: ServeDeps["listWorkflows"]
   injectWaitpoint?: ServeDeps["injectWaitpoint"]
   listSchedules?: ServeDeps["listSchedules"]
@@ -169,6 +187,35 @@ export async function handleRequest(
       return json(200, { saved: result.saved })
     }
 
+    const resumeMatch = url.pathname.match(/^\/api\/runs\/([^/]+)\/resume$/)
+    if (resumeMatch) {
+      if (!deps.resumeRun) {
+        return json(501, {
+          error: "resume_not_supported",
+          message:
+            "This self-host server was started without a workflow entry. " +
+            "Restart with `--file <path>` to enable failed-step resume.",
+        })
+      }
+      const parsed = parseResumeRequestBody(req.body)
+      if (!parsed.ok) {
+        return json(parsed.status, { error: parsed.error, message: parsed.message })
+      }
+      const parentRunId = decodeURIComponent(resumeMatch[1]!)
+      const result = await deps.resumeRun({ parentRunId, ...parsed.body })
+      if (!result.ok) {
+        return json(result.exitCode === 2 ? 400 : 404, {
+          error: "resume_failed",
+          message: result.message,
+        })
+      }
+      return json(200, {
+        saved: result.saved,
+        parentRunId: result.parentRunId,
+        resumeFromStep: result.resumeFromStep,
+      })
+    }
+
     const eventsMatch = url.pathname.match(/^\/api\/runs\/([^/]+)\/events$/)
     const signalsMatch = url.pathname.match(/^\/api\/runs\/([^/]+)\/signals$/)
     const tokenMatch = url.pathname.match(/^\/api\/runs\/([^/]+)\/tokens\/([^/]+)$/)
@@ -228,7 +275,13 @@ export async function handleRequest(
             "Restart with `--file <path>` to enable triggering.",
         })
       }
-      let parsed: { workflowId?: unknown; input?: unknown }
+      let parsed: {
+        workflowId?: unknown
+        input?: unknown
+        runId?: unknown
+        tags?: unknown
+        triggeredByUserId?: unknown
+      }
       try {
         parsed = req.body ? JSON.parse(req.body) : {}
       } catch (err) {
@@ -243,7 +296,35 @@ export async function handleRequest(
           message: "`workflowId` (string) is required",
         })
       }
-      const result = await deps.triggerRun({ workflowId: parsed.workflowId, input: parsed.input })
+      if (parsed.runId !== undefined && typeof parsed.runId !== "string") {
+        return json(400, {
+          error: "invalid_body",
+          message: "`runId` must be a string when provided",
+        })
+      }
+      if (parsed.tags !== undefined && !isStringArray(parsed.tags)) {
+        return json(400, {
+          error: "invalid_body",
+          message: "`tags` must be an array of strings when provided",
+        })
+      }
+      if (
+        parsed.triggeredByUserId !== undefined &&
+        parsed.triggeredByUserId !== null &&
+        typeof parsed.triggeredByUserId !== "string"
+      ) {
+        return json(400, {
+          error: "invalid_body",
+          message: "`triggeredByUserId` must be a string or null when provided",
+        })
+      }
+      const result = await deps.triggerRun({
+        workflowId: parsed.workflowId,
+        input: parsed.input,
+        runId: parsed.runId,
+        tags: parsed.tags,
+        triggeredByUserId: parsed.triggeredByUserId,
+      })
       if (!result.ok) {
         return json(result.exitCode === 2 ? 400 : 404, {
           error: "trigger_failed",
@@ -375,6 +456,105 @@ export async function handleRequest(
   return json(404, { error: "route_not_found", path: url.pathname })
 }
 
+function parseResumeRequestBody(body: string | undefined):
+  | {
+      ok: true
+      body: {
+        input?: unknown
+        workflowId?: string
+        resumeFromStep?: string
+        seedResults?: Record<string, unknown>
+        runId?: string
+        tags?: string[]
+        triggeredByUserId?: string | null
+      }
+    }
+  | { ok: false; status: number; error: string; message: string } {
+  let parsed: Record<string, unknown>
+  try {
+    parsed = body ? (JSON.parse(body) as Record<string, unknown>) : {}
+  } catch (err) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_json",
+      message: err instanceof Error ? err.message : String(err),
+    }
+  }
+  if (!isPlainObject(parsed)) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_body",
+      message: "request body must be an object",
+    }
+  }
+  if (parsed.resumeFromStep !== undefined && typeof parsed.resumeFromStep !== "string") {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_body",
+      message: "`resumeFromStep` must be a string when provided",
+    }
+  }
+  if (parsed.workflowId !== undefined && typeof parsed.workflowId !== "string") {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_body",
+      message: "`workflowId` must be a string when provided",
+    }
+  }
+  if (parsed.runId !== undefined && typeof parsed.runId !== "string") {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_body",
+      message: "`runId` must be a string when provided",
+    }
+  }
+  if (
+    parsed.triggeredByUserId !== undefined &&
+    parsed.triggeredByUserId !== null &&
+    typeof parsed.triggeredByUserId !== "string"
+  ) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_body",
+      message: "`triggeredByUserId` must be a string or null when provided",
+    }
+  }
+  if (parsed.tags !== undefined && !isStringArray(parsed.tags)) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_body",
+      message: "`tags` must be an array of strings when provided",
+    }
+  }
+  if (parsed.seedResults !== undefined && !isPlainObject(parsed.seedResults)) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_body",
+      message: "`seedResults` must be an object when provided",
+    }
+  }
+  return {
+    ok: true,
+    body: {
+      input: parsed.input,
+      workflowId: parsed.workflowId as string | undefined,
+      resumeFromStep: parsed.resumeFromStep,
+      seedResults: parsed.seedResults as Record<string, unknown> | undefined,
+      runId: parsed.runId,
+      tags: parsed.tags as string[] | undefined,
+      triggeredByUserId: parsed.triggeredByUserId as string | null | undefined,
+    },
+  }
+}
+
 export function createStaticReader(rootDir: string): (path: string) => Promise<Uint8Array | null> {
   const root = resolvePath(rootDir)
   return async (path: string) => {
@@ -453,6 +633,7 @@ export async function startServer(
           readStatic,
           hasStaticDashboard,
           triggerRun: deps.triggerRun,
+          resumeRun: deps.resumeRun,
           listWorkflows: deps.listWorkflows,
           injectWaitpoint: deps.injectWaitpoint,
           listSchedules: deps.listSchedules,
@@ -862,7 +1043,13 @@ export async function createNodeSelfHostDeps(
     return { ok: true, saved }
   }
 
-  const triggerRun: ServeDeps["triggerRun"] = async ({ workflowId, input }) => {
+  const triggerRun: ServeDeps["triggerRun"] = async ({
+    workflowId,
+    input,
+    runId,
+    tags,
+    triggeredByUserId,
+  }) => {
     const workflow = wfMod.__listRegisteredWorkflows().find((entry) => entry.id === workflowId)
     if (!workflow) {
       return {
@@ -871,23 +1058,28 @@ export async function createNodeSelfHostDeps(
         exitCode: 2,
       }
     }
-    const runId = generateLocalRunId()
+    const nextRunId = runId ?? generateLocalRunId()
     const memStore = createInMemoryRunStore()
     let record: RunRecord
     try {
       record = await trigger(
         {
-          runId,
+          runId: nextRunId,
           workflowId,
           workflowVersion: "local",
           input,
           tenantMeta,
+          tags,
+          triggeredBy:
+            triggeredByUserId === undefined || triggeredByUserId === null
+              ? { kind: "api" }
+              : { kind: "api", actor: triggeredByUserId },
           timeoutMs: durationToMs(workflow.config.timeout),
         },
         {
           store: memStore,
           handler: stepHandler,
-          onStreamChunk: (chunk) => chunkBus.publish({ runId, chunk }),
+          onStreamChunk: (chunk) => chunkBus.publish({ runId: nextRunId, chunk }),
         },
       )
     } catch (err) {
@@ -905,6 +1097,124 @@ export async function createNodeSelfHostDeps(
     const saved = await store.update(stored)
     await wakeupManager.syncStoredRun(saved)
     return { ok: true, saved }
+  }
+
+  const resumeRun: ServeDeps["resumeRun"] = async ({
+    parentRunId,
+    workflowId: requestedWorkflowId,
+    input,
+    resumeFromStep,
+    seedResults,
+    runId,
+    tags,
+    triggeredByUserId,
+  }) => {
+    const existing = await store.get(parentRunId)
+    let parent: RunRecord | undefined
+    if (existing) {
+      try {
+        parent = snapshotToRecord(existing)
+      } catch (err) {
+        return {
+          ok: false,
+          message: err instanceof Error ? err.message : String(err),
+          exitCode: 1,
+        }
+      }
+    } else if (!requestedWorkflowId) {
+      return {
+        ok: false,
+        message:
+          `parent run "${parentRunId}" not found; pass workflowId, resumeFromStep, ` +
+          "and seedResults to resume from an external workflow-runs parent",
+        exitCode: 1,
+      }
+    }
+
+    const workflowId = parent?.workflowId ?? requestedWorkflowId!
+    const workflow = wfMod.__listRegisteredWorkflows().find((entry) => entry.id === workflowId)
+    if (!workflow) {
+      return {
+        ok: false,
+        message: `workflow "${workflowId}" is not registered in ${entryAbs}.`,
+        exitCode: 2,
+      }
+    }
+
+    let resumeSeed: ReturnType<typeof buildResumeJournal>
+    try {
+      resumeSeed = parent
+        ? buildResumeJournal({
+            parent,
+            resumeFromStep,
+            seedResults,
+          })
+        : buildSeededResumeJournal({
+            parentRunId,
+            resumeFromStep: requireExternalResumeFromStep(resumeFromStep),
+            seedResults: requireExternalSeedResults(seedResults),
+          })
+    } catch (err) {
+      return {
+        ok: false,
+        message: err instanceof Error ? err.message : String(err),
+        exitCode: 2,
+      }
+    }
+
+    const memStore = createInMemoryRunStore()
+    const nextRunId = runId ?? generateLocalRunId()
+    let record: RunRecord
+    try {
+      record = await trigger(
+        {
+          runId: nextRunId,
+          workflowId,
+          workflowVersion: parent?.workflowVersion ?? "local",
+          input: input === undefined ? parent?.input : input,
+          tenantMeta: parent?.tenantMeta ?? tenantMeta,
+          environment: parent?.environment,
+          triggeredBy:
+            triggeredByUserId === undefined || triggeredByUserId === null
+              ? { kind: "api" }
+              : { kind: "api", actor: triggeredByUserId },
+          tags: mergeTags(parent?.tags, [
+            "resume:true",
+            `parentRunId:${parent?.id ?? parentRunId}`,
+            ...(tags ?? []),
+          ]),
+          timeoutMs: durationToMs(workflow.config.timeout),
+          initialJournal: resumeSeed.journal,
+        },
+        {
+          store: memStore,
+          handler: stepHandler,
+          onStreamChunk: (chunk) => chunkBus.publish({ runId: nextRunId, chunk }),
+        },
+      )
+    } catch (err) {
+      return {
+        ok: false,
+        message: err instanceof Error ? err.message : String(err),
+        exitCode: 1,
+      }
+    }
+
+    if (!store.update) {
+      return { ok: false, message: "snapshot run store does not support update", exitCode: 1 }
+    }
+    const stored = recordToSnapshot(record, {
+      entryFile: entryAbs,
+      replayOf: parent?.id ?? parentRunId,
+    })
+    const saved = await store.update(stored)
+    await wakeupManager.syncStoredRun(saved)
+    return {
+      ok: true,
+      saved,
+      parentRunId: parent?.id ?? parentRunId,
+      resumeFromStep: resumeSeed.resumeFromStep,
+    }
   }
 
   const injectWaitpoint: ServeDeps["injectWaitpoint"] = async ({ runId, injection }) => {
@@ -993,6 +1303,7 @@ export async function createNodeSelfHostDeps(
     },
     staticDir,
     triggerRun,
+    resumeRun,
     listWorkflows,
     injectWaitpoint,
     scheduler,
@@ -1024,6 +1335,42 @@ async function assertReadableDirectory(path: string, label: string): Promise<voi
   if (!info.isDirectory()) {
     throw new Error(`voyant workflows selfhost: ${label} must be a directory (got "${path}")`)
   }
+}
+
+function mergeTags(...groups: ReadonlyArray<ReadonlyArray<string> | undefined>): string[] {
+  const tags = new Set<string>()
+  for (const group of groups) {
+    for (const tag of group ?? []) tags.add(tag)
+  }
+  return Array.from(tags)
+}
+
+function requireExternalResumeFromStep(resumeFromStep: string | undefined): string {
+  if (!resumeFromStep) {
+    throw new Error(
+      "resumeFromStep is required when the parent run is not stored by this self-host server",
+    )
+  }
+  return resumeFromStep
+}
+
+function requireExternalSeedResults(
+  seedResults: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (!seedResults) {
+    throw new Error(
+      "seedResults is required when the parent run is not stored by this self-host server",
+    )
+  }
+  return seedResults
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string")
 }
 
 function json(status: number, body: unknown): HandlerResponse {

--- a/packages/workflows-orchestrator-node/src/index.ts
+++ b/packages/workflows-orchestrator-node/src/index.ts
@@ -66,6 +66,13 @@ export {
   wakeupToRow,
 } from "./postgres-wakeup-store.js"
 export {
+  type BuildResumeJournalInput,
+  type BuildResumeJournalResult,
+  type BuildSeededResumeJournalInput,
+  buildResumeJournal,
+  buildSeededResumeJournal,
+} from "./resume-run.js"
+export {
   type RunRecordSnapshot,
   type RunRecordSnapshotBase,
   recordToSnapshot,
@@ -82,6 +89,14 @@ export {
   type ScheduleSource,
   toMs,
 } from "./scheduler.js"
+export {
+  createNodeSelfHostWorkflowClient,
+  type NodeSelfHostWorkflowClient,
+  type NodeSelfHostWorkflowClientOptions,
+  type SelfHostResumeRunInput,
+  type SelfHostResumeRunResult,
+  type SelfHostTriggerRunInput,
+} from "./selfhost-client.js"
 export {
   createSleepAlarmManager,
   findEarliestWakeAt,

--- a/packages/workflows-orchestrator-node/src/resume-run.ts
+++ b/packages/workflows-orchestrator-node/src/resume-run.ts
@@ -1,0 +1,96 @@
+import {
+  emptyJournal,
+  type JournalSlice,
+  type RunRecord,
+  type StepJournalEntry,
+} from "@voyantjs/workflows-orchestrator"
+
+export interface BuildResumeJournalInput {
+  parent: RunRecord
+  resumeFromStep?: string
+  seedResults?: Record<string, unknown>
+  now?: () => number
+}
+
+export interface BuildResumeJournalResult {
+  resumeFromStep: string
+  journal: JournalSlice
+}
+
+export interface BuildSeededResumeJournalInput {
+  parentRunId: string
+  resumeFromStep: string
+  seedResults: Record<string, unknown>
+  metadataState?: Record<string, unknown>
+  now?: () => number
+}
+
+export function buildResumeJournal(input: BuildResumeJournalInput): BuildResumeJournalResult {
+  const resumeFromStep = input.resumeFromStep ?? findFirstFailedStep(input.parent)
+  if (!resumeFromStep) {
+    throw new Error(
+      `run "${input.parent.id}" has no failed step; pass resumeFromStep explicitly to resume it`,
+    )
+  }
+
+  const journal = emptyJournal()
+  journal.metadataState = structuredClone(input.parent.journal.metadataState) as Record<
+    string,
+    unknown
+  >
+
+  if (input.seedResults) {
+    return buildSeededResumeJournal({
+      parentRunId: input.parent.id,
+      resumeFromStep,
+      seedResults: input.seedResults,
+      metadataState: journal.metadataState,
+      now: input.now,
+    })
+  }
+
+  for (const [stepId, entry] of Object.entries(input.parent.journal.stepResults)) {
+    if (stepId === resumeFromStep) break
+    if (entry.status !== "ok") {
+      throw new Error(
+        `step "${stepId}" completed before "${resumeFromStep}" but is not successful; cannot seed resume journal`,
+      )
+    }
+    journal.stepResults[stepId] = structuredClone(entry) as StepJournalEntry
+  }
+
+  return { resumeFromStep, journal }
+}
+
+export function buildSeededResumeJournal(
+  input: BuildSeededResumeJournalInput,
+): BuildResumeJournalResult {
+  const journal = emptyJournal()
+  journal.metadataState = input.metadataState
+    ? (structuredClone(input.metadataState) as Record<string, unknown>)
+    : {}
+  const now = input.now ?? (() => Date.now())
+  let at = now()
+  for (const [stepId, output] of Object.entries(input.seedResults)) {
+    journal.stepResults[stepId] = seededStepEntry(output, at)
+    at += 1
+  }
+  return { resumeFromStep: input.resumeFromStep, journal }
+}
+
+function findFirstFailedStep(parent: RunRecord): string | undefined {
+  for (const [stepId, entry] of Object.entries(parent.journal.stepResults)) {
+    if (entry.status === "err") return stepId
+  }
+  return undefined
+}
+
+function seededStepEntry(output: unknown, at: number): StepJournalEntry {
+  return {
+    attempt: 1,
+    status: "ok",
+    output,
+    startedAt: at,
+    finishedAt: at,
+  }
+}

--- a/packages/workflows-orchestrator-node/src/selfhost-client.ts
+++ b/packages/workflows-orchestrator-node/src/selfhost-client.ts
@@ -1,0 +1,77 @@
+import type { StoredRun } from "./snapshot-run-store.js"
+
+export interface NodeSelfHostWorkflowClientOptions {
+  baseUrl: string
+  fetch?: typeof fetch
+}
+
+export interface SelfHostTriggerRunInput {
+  workflowId: string
+  input?: unknown
+  runId?: string
+  tags?: string[]
+  triggeredByUserId?: string | null
+}
+
+export interface SelfHostResumeRunInput {
+  workflowId?: string
+  input?: unknown
+  resumeFromStep?: string
+  seedResults?: Record<string, unknown>
+  runId?: string
+  tags?: string[]
+  triggeredByUserId?: string | null
+}
+
+export interface SelfHostResumeRunResult {
+  saved: StoredRun
+  parentRunId: string
+  resumeFromStep: string
+}
+
+export interface NodeSelfHostWorkflowClient {
+  trigger(input: SelfHostTriggerRunInput): Promise<StoredRun>
+  resume(parentRunId: string, input?: SelfHostResumeRunInput): Promise<SelfHostResumeRunResult>
+}
+
+export function createNodeSelfHostWorkflowClient(
+  opts: NodeSelfHostWorkflowClientOptions,
+): NodeSelfHostWorkflowClient {
+  const fetchImpl = opts.fetch ?? fetch
+  const baseUrl = opts.baseUrl.replace(/\/+$/, "")
+  return {
+    async trigger(input) {
+      const payload = await postJson<{ saved: StoredRun }>(fetchImpl, `${baseUrl}/api/runs`, input)
+      return payload.saved
+    },
+    async resume(parentRunId, input = {}) {
+      return postJson<SelfHostResumeRunResult>(
+        fetchImpl,
+        `${baseUrl}/api/runs/${encodeURIComponent(parentRunId)}/resume`,
+        input,
+      )
+    },
+  }
+}
+
+async function postJson<T>(fetchImpl: typeof fetch, url: string, body: unknown): Promise<T> {
+  const response = await fetchImpl(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  })
+  const text = await response.text()
+  const parsed = text ? JSON.parse(text) : null
+  if (!response.ok) {
+    const message =
+      isObject(parsed) && typeof parsed.message === "string"
+        ? parsed.message
+        : `self-host workflow request failed with HTTP ${response.status}`
+    throw new Error(message)
+  }
+  return parsed as T
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}

--- a/packages/workflows-orchestrator/src/orchestrator.ts
+++ b/packages/workflows-orchestrator/src/orchestrator.ts
@@ -11,6 +11,7 @@ import { registerRunAbort, signalRunAbort, unregisterRunAbort } from "./abort-re
 import { applyWaitpointInjection, type DriveOptions, driveUntilPaused } from "./drive.js"
 import { emptyJournal } from "./journal-helpers.js"
 import type {
+  JournalSlice,
   RunRecord,
   RunRecordStore,
   RunTrigger,
@@ -29,6 +30,12 @@ export interface TriggerArgs {
   runNumber?: number
   /** Optional id to use; defaults to `run_` + crypto random. */
   runId?: string
+  /**
+   * Optional journal seed. Used by external replay/resume callers
+   * that need a new run to skip steps already completed by a parent
+   * run.
+   */
+  initialJournal?: JournalSlice
   /**
    * Compute-time budget in ms, typically from `WorkflowConfig.timeout`.
    * Parked time on waitpoints does not count against this. When the
@@ -69,7 +76,7 @@ export async function trigger(args: TriggerArgs, deps: OrchestratorDeps): Promis
     workflowVersion: args.workflowVersion,
     status: "running",
     input: args.input,
-    journal: emptyJournal(),
+    journal: args.initialJournal ? cloneJournal(args.initialJournal) : emptyJournal(),
     invocationCount: 0,
     metadataAppliedCount: 0,
     computeTimeMs: 0,
@@ -109,6 +116,10 @@ export async function trigger(args: TriggerArgs, deps: OrchestratorDeps): Promis
     }
   }
   return deps.store.save(record)
+}
+
+function cloneJournal(journal: JournalSlice): JournalSlice {
+  return structuredClone(journal) as JournalSlice
 }
 
 /**

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -232,7 +232,10 @@ const checkoutHonoModule = createCheckoutHonoModule({
  * runners on bootstrap (see `createCatalogCheckoutBundle`) so the
  * `/v1/admin/workflow-runs/:id/{rerun,resume}` endpoints can dispatch
  * a workflow by name. The dashboard's "Rerun" / "Resume" buttons are
- * powered by this registry.
+ * powered by this registry. Self-hosted workflow services should
+ * register runners that call `createNodeSelfHostWorkflowClient(...)`
+ * and forward resume calls with `ctx.resumeFromStep` and
+ * `ctx.seedResults`.
  */
 const workflowRunnerRegistry = new WorkflowRunnerRegistry()
 


### PR DESCRIPTION
## Summary
- add a Node self-host failed-step resume endpoint and dispatch dependency
- allow orchestrator triggers to start with a seeded journal so completed steps replay without re-running side effects
- export a Node self-host client helper and document the workflow-runs/operator integration pattern
- add a minor Changesets entry for the fixed release train

Closes #429.

## Validation
- pnpm --filter @voyantjs/workflows-orchestrator-node test
- pnpm --filter @voyantjs/workflows-orchestrator-node check-types
- pnpm --filter @voyantjs/workflows-orchestrator-node build
- pnpm --filter @voyantjs/workflows-orchestrator build
- pnpm verify:fast
- pnpm verify:release-train
- pre-commit lint/typecheck hook
- pre-push test hook