### PR TITLE
Split CI verify into parallel checks and build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,21 @@ concurrency:
 permissions:
   contents: read
 
+# Two jobs run in parallel. `checks` covers everything that only needs source
+# (lint/typecheck/test/architecture/i18n); `build` covers everything that
+# needs fresh dist (turbo build → package exports → publish tarballs). They
+# share the same setup; both rely on the pnpm + turbo remote caches to make
+# the duplicated install/build effectively free on warm caches.
+#
+# NOTE: branch protection rules need to require both `CI / checks` and
+# `CI / build` (the previous single `verify` job no longer exists).
+
 jobs:
-  verify:
+  checks:
+    name: checks
     runs-on: ubuntu-latest
     env:
       HUSKY: 0
-      # Turbo remote cache. Configure in GitHub Settings -> Secrets and variables
-      # -> Actions; without them turbo falls back to the local runner cache.
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
@@ -52,6 +60,30 @@ jobs:
       - name: Architecture checks
         run: pnpm verify:architecture
 
+      - name: i18n checks
+        run: pnpm i18n:check
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    env:
+      HUSKY: 0
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
       - name: Build
         run: pnpm build
 
@@ -65,6 +97,3 @@ jobs:
         env:
           VOYANT_PACK_REUSE_DIST: "1"
         run: pnpm verify:publish-tarballs
-
-      - name: i18n checks
-        run: pnpm i18n:check

--- a/scripts/verify-package-tarballs.mjs
+++ b/scripts/verify-package-tarballs.mjs
@@ -317,9 +317,7 @@ async function verifyPackage(packageDir) {
   try {
     ;[packInfo] = getPackJson(stdout)
     extracted = await extractTarball(packInfo.filename)
-    packedManifest = JSON.parse(
-      fs.readFileSync(path.join(extracted.root, "package.json"), "utf8"),
-    )
+    packedManifest = JSON.parse(fs.readFileSync(path.join(extracted.root, "package.json"), "utf8"))
     extensionlessRelativeSpecifiers = collectPackedExtensionlessRelativeSpecifiers(
       extracted.root,
       packInfo,


### PR DESCRIPTION
## Summary

Restructure the `verify` job in `.github/workflows/ci.yml` into two jobs that run concurrently:

* **checks**: lint, typecheck, test, architecture, i18n
* **build**: turbo build, package-export checks, publish-tarball checks

Both share setup-node + pnpm install. Turbo + pnpm remote caches make the duplicated install/build close to free on warm runs. Wall time becomes `max(checks, build)` instead of the previous `sum(checks, build)`.

## Heads up — branch protection

Splitting `verify` renames the required check. If branch protection currently requires `CI / verify`, update it to require both:

* `CI / checks`
* `CI / build`

Otherwise this PR will read as "missing required status" once merged.

## Scope changes since first push

The earlier version of this branch also bundled Phase 1 (REUSE_DIST gate) and Phase 2 (skip prepack tsc + bulk-extract) for `verify:publish-tarballs`. Those landed separately in #439 and are already on main. A `turbo.json` typecheck-input override was also dropped after Codex flagged that excluding `package.json` would silently mask changes to `scripts.typecheck`, `type`, `exports`, etc. — turbo can't hash JSON sub-fields, so there's no surgical way to exclude only `version`. Accepting the typecheck cascade on `chore: release packages` runs is the correct trade-off.

## Test plan

- [ ] CI on this PR shows two parallel jobs (`checks` + `build`); both go green
- [ ] Total wall time is `max(checks, build)`, not the prior sum
- [ ] After merge, branch protection updated to require both new checks