### PR TITLE
Move toxic PII to crm.people + add structured person_documents

### DIFF
--- a/.changeset/people-pii-and-person-documents.md
+++ b/.changeset/people-pii-and-person-documents.md
@@ -1,0 +1,24 @@
+---
+"@voyantjs/bookings": patch
+"@voyantjs/bookings-react": patch
+"@voyantjs/bookings-ui": patch
+"@voyantjs/crm": patch
+"@voyantjs/crm-react": patch
+"@voyantjs/customer-portal": patch
+"@voyantjs/customer-portal-react": patch
+"@voyantjs/db": patch
+---
+
+Move toxic PII to `crm.people` and add structured `person_documents` (closes #440 and #443).
+
+`user_profiles` is no longer the home for encrypted PII. The four free-text slots (accessibility / dietary / loyalty / insurance) move to `crm.people` so operator-managed humans without auth accounts can carry them, and identity documents graduate to a structured `person_documents` table with type / expiry / issuing authority / attachment + a partial unique index pinning a single primary doc per type per person.
+
+Booking travelers now snapshot dietary, accessibility, and the primary passport from the linked person record at create time (snapshot-on-create, explicit input always wins) via a new `POST /v1/admin/bookings/:id/travelers/with-travel-details` route. Templates wire the snapshot via `createBookingsHonoModule({ resolveTravelSnapshot })` delegating to `crmService.loadPersonTravelSnapshot` — bookings stays free of any direct CRM dependency.
+
+Customer portal exposes plaintext `accessibility/dietary/loyalty/insurance` on `/me` plus full CRUD over `/me/documents`. CRM admin gains server-side encrypt/decrypt endpoints (`travel-snapshot`, `profile-pii`, `*/from-plaintext`) so the operator booking-traveler dialog can pre-fill from profile and push diverging values back without the browser holding KMS material. The dialog itself now ships a "Travel details" section with passport / dietary / accessibility fields, plus "Pre-fill from profile" and "Save to profile" affordances when a CRM person is linked.
+
+Breaking changes (intentionally landed pre-1.0):
+
+- `user_profiles.documentsEncrypted/accessibilityEncrypted/dietaryEncrypted/loyaltyEncrypted/insuranceEncrypted` columns are removed. Migration ships `templates/operator/migrations/0024_people_pii_documents.sql`.
+- `customerPortalProfileSchema.documents` (array) replaced with separate `accessibility/dietary/loyalty/insurance` plaintext string fields. Document CRUD lives at `/v1/public/customer-portal/me/documents`.
+- `bookingsHonoModule` and `crmHonoModule` are still exported but the env-driven default factory `createBookingsHonoModule()` / `createCrmHonoModule()` is the new recommended entry point.

--- a/packages/bookings/src/routes.ts
+++ b/packages/bookings/src/routes.ts
@@ -887,11 +887,26 @@ export const bookingRoutes = new Hono<Env>()
    */
   .patch("/:id/travelers/:travelerId/with-travel-details", async (c) => {
     try {
+      const bookingId = c.req.param("id")
+      const travelerId = c.req.param("travelerId")
+      // Enforce booking↔traveler pairing before delegating to the
+      // service, which writes by traveler id only. Without this guard
+      // a caller could pass /bookings/A/travelers/<traveler-from-B>
+      // and write to B while the audit/PII context is built from A.
+      const traveler = await bookingsService.getTravelerRecordById(
+        c.get("db"),
+        bookingId,
+        travelerId,
+      )
+      if (!traveler) {
+        return c.json({ error: "Traveler not found" }, 404)
+      }
+
       const data = await parseJsonBody(c, updateTravelerWithTravelDetailsSchema)
-      const pii = await createAuditedBookingPiiService(c, c.req.param("id"))
+      const pii = await createAuditedBookingPiiService(c, bookingId)
       const result = await bookingsService.updateTravelerWithTravelDetails(
         c.get("db"),
-        c.req.param("travelerId"),
+        travelerId,
         data,
         { pii, actorId: c.get("userId") },
       )

--- a/packages/crm/src/service/person-documents.ts
+++ b/packages/crm/src/service/person-documents.ts
@@ -160,7 +160,14 @@ export const personDocumentsService = {
         .limit(1)
       if (!existing) return null
 
-      if (data.isPrimary === true) {
+      // Clear prior primary of the *target* type whenever the row
+      // will end up primary after this update — including the case
+      // where `isPrimary` is unchanged but `type` is being switched
+      // and the existing row is already primary. Without this, the
+      // partial unique index `(person_id, type) WHERE is_primary`
+      // rejects type-only edits on a primary doc.
+      const effectiveIsPrimary = data.isPrimary ?? existing.isPrimary
+      if (effectiveIsPrimary) {
         const targetType = data.type ?? existing.type
         await clearPrimaryForType(
           tx as PostgresJsDatabase,

--- a/packages/crm/tests/integration/person-documents.test.ts
+++ b/packages/crm/tests/integration/person-documents.test.ts
@@ -90,6 +90,36 @@ describe.skipIf(!DB_AVAILABLE)("personDocumentsService", () => {
     expect(primaryIds).toEqual([second?.id])
   })
 
+  it("changing the type of a primary doc demotes the existing primary of the new type", async () => {
+    const person = await seedPerson()
+    // Existing primary id_card.
+    const idCard = await personDocumentsService.createPersonDocument(db, person.id, {
+      type: "id_card",
+      isPrimary: true,
+    })
+    // Existing primary passport that we'll re-type to id_card without
+    // touching `isPrimary`. Without the fix this hits the partial
+    // unique index and fails with a DB error.
+    const passport = await personDocumentsService.createPersonDocument(db, person.id, {
+      type: "passport",
+      isPrimary: true,
+    })
+    if (!idCard || !passport) throw new Error("seed failure")
+
+    const updated = await personDocumentsService.updatePersonDocument(db, passport.id, {
+      type: "id_card",
+    })
+    expect(updated?.type).toBe("id_card")
+    expect(updated?.isPrimary).toBe(true)
+
+    const all = await personDocumentsService.listPersonDocuments(db, person.id)
+    const primaryIdCards = all.filter((doc) => doc.type === "id_card" && doc.isPrimary)
+    expect(primaryIdCards.map((doc) => doc.id)).toEqual([passport.id])
+
+    const refreshedOldIdCard = await personDocumentsService.getPersonDocument(db, idCard.id)
+    expect(refreshedOldIdCard?.isPrimary).toBe(false)
+  })
+
   it("setPrimaryPersonDocument promotes one and demotes prior primary", async () => {
     const person = await seedPerson()
     const first = await personDocumentsService.createPersonDocument(db, person.id, {


### PR DESCRIPTION
## Summary

Closes #440 and #443.

- `user_profiles` no longer holds encrypted PII. The four free-text slots (accessibility / dietary / loyalty / insurance) move to `crm.people`, and identity documents graduate to a structured `crm.person_documents` table with type / expiry / issuing authority / attachment + a partial-unique-index pinning a single primary doc per type per person.
- Booking travelers snapshot dietary / accessibility / primary passport from the linked person record on create (snapshot-on-create; explicit input always wins). Templates wire `createBookingsHonoModule({ resolveTravelSnapshot })` → `crmService.loadPersonTravelSnapshot`, so bookings stays free of any direct CRM dep.
- Customer portal exposes plaintext `accessibility/dietary/loyalty/insurance` on `/me` plus full CRUD over `/me/documents`. CRM admin gains `travel-snapshot` / `profile-pii` / `*/from-plaintext` endpoints so the operator booking-traveler dialog can pre-fill from profile and push diverging values back without the browser holding KMS material.
- The operator `TravelerDialog` now ships a "Travel details" section, "Pre-fill from profile" button (when a CRM person is linked), and "Save to profile" affordance (when form values diverge from the linked snapshot).

## Breaking changes (intentional, pre-1.0)

- `user_profiles.documentsEncrypted/accessibilityEncrypted/dietaryEncrypted/loyaltyEncrypted/insuranceEncrypted` columns dropped. Migration: `templates/operator/migrations/0024_people_pii_documents.sql`.
- `customerPortalProfileSchema.documents` (array) replaced with separate plaintext string fields. Document CRUD lives at `/v1/public/customer-portal/me/documents`.
- `bookingsHonoModule` / `crmHonoModule` still exported; the recommended entry points are now `createBookingsHonoModule()` / `createCrmHonoModule()`.

## Pre-merge follow-ups

- **DMC migration baseline is stale.** Only `templates/operator` got the migration. `templates/dmc/migrations/` only has `0000_*` and rebaselining is out of scope here — needs a hand-written equivalent or a fresh baseline before the dmc release ships.
- **Operator drizzle-kit `db:check` fails on `main`** with a pre-existing snapshot collision (`0018`/`0019`). Hand-written migrations apply via `db:migrate`; `db:generate` won't produce clean output until the meta drift is untangled.

## Test plan

- [x] `pnpm typecheck` — 111/111 tasks pass.
- [x] `pnpm test` — 112/112 tasks pass (DB-gated integration tests skip when `TEST_DATABASE_URL` is unset; pure tests still run).
- [x] New tests: customer-portal `/me/documents` CRUD + auto-create-person, CRM `personDocumentsService` (CRUD + primary-uniqueness + `loadPersonTravelSnapshot` decrypt roundtrip), bookings `applyTravelDetailSnapshot` + `createTravelerWithTravelDetails` snapshot wiring (resolver invocation, explicit-input-wins, partial-snapshot fallthrough).
- [ ] Manual smoke against an env with `TEST_DATABASE_URL` set to verify the integration tests pass end-to-end.
- [ ] Apply `0024_people_pii_documents.sql` to a staging DB and exercise the operator booking-traveler dialog (pre-fill + save-back).

## Encryption surface

- `crm.people`: `accessibilityEncrypted` / `dietaryEncrypted` / `loyaltyEncrypted` / `insuranceEncrypted` (plaintext envelope `{ text }`).
- `crm.person_documents`: `numberEncrypted` (plaintext envelope `{ number }`). Structured fields (type / expiry / authority / country / attachment / isPrimary) intentionally NOT encrypted so we can query them.
- `booking_traveler_travel_details`: `identityEncrypted` (bundled passport + nationality + DOB), `dietaryEncrypted`, `accessibilityEncrypted` — per-trip override snapshots; canonical store remains `crm.people` / `crm.person_documents`. Plaintext provenance: `passportPersonDocumentId`.
- Plaintext envelope shapes are exported as `personPiiBlobPlaintextSchema` and `personDocumentNumberPlaintextSchema` from `@voyantjs/crm` so writers (customer-portal) and readers (CRM service + bookings snapshot) can't drift.