### PR TITLE
Make auth.user.email nullable + add phone_number columns

### DIFF
--- a/.changeset/auth-user-email-nullable.md
+++ b/.changeset/auth-user-email-nullable.md
@@ -1,0 +1,20 @@
+---
+"@voyantjs/auth": patch
+"@voyantjs/auth-react": patch
+"@voyantjs/customer-portal": patch
+"@voyantjs/db": patch
+---
+
+Make `auth.user.email` nullable and add `phone_number` columns so phone-only signups (Better Auth phone-OTP plugin) no longer need a synthetic `<phone>@phone.protravel.ro` placeholder (closes #441).
+
+Schema: drops the email-only `UNIQUE` on `auth.user.email`, alters the column to nullable, adds `phone_number` (text, nullable) + `phone_number_verified` (boolean, default false), creates partial unique indexes (`user_email_unique WHERE email IS NOT NULL`, `user_phone_unique WHERE phone_number IS NOT NULL`), and a check constraint `user_email_or_phone CHECK (email IS NOT NULL OR phone_number IS NOT NULL)` so a row must carry at least one identifier. Migration ships `templates/operator/migrations/0025_user_email_nullable_phone.sql`.
+
+Consumer cleanup:
+
+- `@voyantjs/auth`'s `CurrentUser` type and `getCurrentUser` / `ensureCurrentUserProfile` now treat email as nullable; phone-only signups fall through provisioning instead of being rejected.
+- `@voyantjs/auth-react`'s `currentUserSchema` and `organizationMemberUserSchema` accept null email; `currentUserSchema` also exposes the new `phoneNumber` field.
+- `@voyantjs/customer-portal`'s profile read/write paths handle null `authUser.email`: `getAccessibleBookingIds` and `hasBookingAccess` skip the email-match branch for phone-only users (linked-person matching still works), and `bootstrap` skips email-keyed candidate lookup. Existing email-based flows are unchanged.
+
+Out of scope for this PR (deferred):
+
+- Wiring the Better Auth phone-OTP plugin in `@voyantjs/auth/src/server.ts` (needs SMS provider + signup route work). The schema is now ready for it; the plugin wiring lands in a follow-up.

--- a/packages/auth-react/src/schemas.ts
+++ b/packages/auth-react/src/schemas.ts
@@ -2,7 +2,10 @@ import { z } from "zod"
 
 export const currentUserSchema = z.object({
   id: z.string(),
-  email: z.string(),
+  // Either email or phoneNumber is set on phone-only signups; null when
+  // the user authenticates via the other channel only.
+  email: z.string().nullable(),
+  phoneNumber: z.string().nullable().optional(),
   firstName: z.string().nullable(),
   lastName: z.string().nullable(),
   isSuperAdmin: z.boolean(),
@@ -40,7 +43,7 @@ export type CurrentWorkspace = z.infer<typeof currentWorkspaceSchema>
 
 const organizationMemberUserSchema = z.object({
   id: z.string(),
-  email: z.string(),
+  email: z.string().nullable(),
   name: z.string().nullable().optional(),
   image: z.string().nullable().optional(),
 })

--- a/packages/auth/src/workspace.ts
+++ b/packages/auth/src/workspace.ts
@@ -6,7 +6,8 @@ type WorkspaceDb = ReturnType<typeof getDb>
 
 export type CurrentUser = {
   id: string
-  email: string
+  email: string | null
+  phoneNumber?: string | null
   firstName: string | null
   lastName: string | null
   isSuperAdmin: boolean
@@ -29,6 +30,7 @@ export async function getCurrentUser(
     .select({
       id: authUser.id,
       email: authUser.email,
+      phoneNumber: authUser.phoneNumber,
       createdAt: authUser.createdAt,
       firstName: userProfilesTable.firstName,
       lastName: userProfilesTable.lastName,
@@ -48,6 +50,7 @@ export async function getCurrentUser(
   return {
     id: row.id,
     email: row.email,
+    phoneNumber: row.phoneNumber ?? null,
     firstName: row.firstName ?? null,
     lastName: row.lastName ?? null,
     isSuperAdmin: row.isSuperAdmin ?? false,
@@ -73,16 +76,23 @@ export async function ensureCurrentUserProfile(
     }
 
     const [user] = await db
-      .select({ name: authUser.name, email: authUser.email, image: authUser.image })
+      .select({
+        name: authUser.name,
+        email: authUser.email,
+        phoneNumber: authUser.phoneNumber,
+        image: authUser.image,
+      })
       .from(authUser)
       .where(eq(authUser.id, userId))
       .limit(1)
 
-    if (!user?.email) {
+    // Phone-only signups have `email` null but `phoneNumber` set; the
+    // schema check constraint guarantees at least one of the two.
+    if (!user?.email && !user?.phoneNumber) {
       return {
         userExists: false,
         authenticated: true,
-        reason: `No email found for user ${userId}.`,
+        reason: `No email or phone number found for user ${userId}.`,
       }
     }
 

--- a/packages/customer-portal/src/service-public.ts
+++ b/packages/customer-portal/src/service-public.ts
@@ -1128,10 +1128,10 @@ async function upsertCustomerBillingAddress(
 
 async function getAccessibleBookingIds(
   db: PostgresJsDatabase,
-  params: { userId: string; email: string },
+  params: { userId: string; email: string | null },
 ) {
   const linkedPersonId = await resolveLinkedCustomerRecordId(db, params.userId)
-  const email = params.email.trim().toLowerCase()
+  const email = params.email?.trim().toLowerCase() ?? null
 
   const [directBookingRows, participantPersonRows, participantEmailRows] = await Promise.all([
     linkedPersonId
@@ -1146,10 +1146,13 @@ async function getAccessibleBookingIds(
           .from(bookingTravelers)
           .where(eq(bookingTravelers.personId, linkedPersonId))
       : Promise.resolve([]),
-    db
-      .select({ bookingId: bookingTravelers.bookingId })
-      .from(bookingTravelers)
-      .where(sql`lower(${bookingTravelers.email}) = ${email}`),
+    // Phone-only users have no email to match on — fall back to linked-person matching only.
+    email
+      ? db
+          .select({ bookingId: bookingTravelers.bookingId })
+          .from(bookingTravelers)
+          .where(sql`lower(${bookingTravelers.email}) = ${email}`)
+      : Promise.resolve([]),
   ])
 
   return Array.from(
@@ -1165,13 +1168,22 @@ async function hasBookingAccess(params: {
   db: PostgresJsDatabase
   bookingId: string
   userId: string
-  authEmail: string
+  // Phone-only users have no email; the email-match branch is skipped
+  // and access falls through to the linked-person path.
+  authEmail: string | null
   linkedPersonId: string | null
 }) {
-  const ownershipConditions = [sql`lower(${bookingTravelers.email}) = ${params.authEmail}`]
+  const ownershipConditions = []
+  if (params.authEmail) {
+    ownershipConditions.push(sql`lower(${bookingTravelers.email}) = ${params.authEmail}`)
+  }
 
   if (params.linkedPersonId) {
     ownershipConditions.push(eq(bookingTravelers.personId, params.linkedPersonId))
+  }
+
+  if (ownershipConditions.length === 0) {
+    return false
   }
 
   const [participantMatch, bookingMatch] = await Promise.all([
@@ -1773,7 +1785,10 @@ export const publicCustomerPortalService = {
       }
     }
 
-    const normalizedEmail = normalizeEmail(authProfile.email)
+    // Phone-only signups have no email; email-keyed candidate
+    // matching simply finds zero candidates and the path falls
+    // through to creating a fresh `crm.people` row when allowed.
+    const normalizedEmail = authProfile.email ? normalizeEmail(authProfile.email) : null
     const nextFirstName =
       input.firstName ?? authProfile.firstName ?? authProfile.name.split(" ")[0] ?? "Customer"
     const nextLastName =
@@ -1858,7 +1873,9 @@ export const publicCustomerPortalService = {
       }
     }
 
-    const customerCandidates = await listCustomerRecordCandidatesByEmail(db, normalizedEmail)
+    const customerCandidates = normalizedEmail
+      ? await listCustomerRecordCandidatesByEmail(db, normalizedEmail)
+      : []
     const selectableCandidates = customerCandidates.filter(
       (candidate) => !candidate.claimedByAnotherUser,
     )
@@ -2282,7 +2299,7 @@ export const publicCustomerPortalService = {
       resolveLinkedCustomerRecordId(db, userId),
       getCustomerRecord(db, userId),
     ])
-    const authEmail = authProfile.email.trim().toLowerCase()
+    const authEmail = authProfile.email?.trim().toLowerCase() ?? null
     const canAccess = await hasBookingAccess({
       db,
       bookingId,
@@ -2323,7 +2340,7 @@ export const publicCustomerPortalService = {
       db,
       bookingId,
       userId,
-      authEmail: authProfile.email.trim().toLowerCase(),
+      authEmail: authProfile.email?.trim().toLowerCase() ?? null,
       linkedPersonId,
     })
 

--- a/packages/customer-portal/src/validation-public.ts
+++ b/packages/customer-portal/src/validation-public.ts
@@ -192,7 +192,10 @@ export const customerPortalBootstrapCandidateSchema = customerPortalRecordSchema
 
 export const customerPortalProfileSchema = z.object({
   userId: z.string(),
-  email: z.string().email(),
+  // null for phone-only signups; check constraint on auth.user
+  // guarantees email or phoneNumber is set, not both required.
+  email: z.string().email().nullable(),
+  phoneNumber: z.string().nullable().optional(),
   emailVerified: z.boolean(),
   firstName: z.string().nullable(),
   middleName: z.string().nullable(),

--- a/packages/db/src/schema/iam/auth.ts
+++ b/packages/db/src/schema/iam/auth.ts
@@ -9,20 +9,41 @@
  * camelCase JS property names — the Drizzle adapter handles the mapping.
  */
 
-import { boolean, index, pgTable, text, timestamp } from "drizzle-orm/pg-core"
+import { sql } from "drizzle-orm"
+import { boolean, check, index, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core"
 
 // ---------------------------------------------------------------------------
 // user
+//
+// Either `email` or `phoneNumber` must be set — phone-only signups (Better
+// Auth phone-OTP plugin) skip email entirely. Both columns are individually
+// unique among non-null rows via partial unique indexes; the check
+// constraint guards against rows with neither identifier.
 // ---------------------------------------------------------------------------
-export const authUser = pgTable("user", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  email: text("email").notNull().unique(),
-  emailVerified: boolean("email_verified").notNull(),
-  image: text("image"),
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
-  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
-})
+export const authUser = pgTable(
+  "user",
+  {
+    id: text("id").primaryKey(),
+    name: text("name").notNull(),
+    email: text("email"),
+    emailVerified: boolean("email_verified").notNull(),
+    phoneNumber: text("phone_number"),
+    phoneNumberVerified: boolean("phone_number_verified").notNull().default(false),
+    image: text("image"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
+  },
+  (table) => [
+    uniqueIndex("user_email_unique").on(table.email).where(sql`${table.email} IS NOT NULL`),
+    uniqueIndex("user_phone_unique")
+      .on(table.phoneNumber)
+      .where(sql`${table.phoneNumber} IS NOT NULL`),
+    check(
+      "user_email_or_phone",
+      sql`${table.email} IS NOT NULL OR ${table.phoneNumber} IS NOT NULL`,
+    ),
+  ],
+)
 
 export type SelectAuthUser = typeof authUser.$inferSelect
 export type InsertAuthUser = typeof authUser.$inferInsert

--- a/packages/db/tests/integration/auth-user-identifier.test.ts
+++ b/packages/db/tests/integration/auth-user-identifier.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Verifies the auth.user identifier rules introduced in #441:
+ *
+ *  - `email` is nullable (phone-only signups have no email).
+ *  - `phone_number` is the second identifier and is independently
+ *    unique among non-null rows.
+ *  - The `user_email_or_phone` check constraint rejects rows where
+ *    both identifiers are null.
+ *  - The partial unique indexes allow many phone-only or many
+ *    email-only users to coexist while still rejecting duplicates of
+ *    each non-null identifier.
+ *
+ * Skipped without `TEST_DATABASE_URL`. The test runs raw SQL because
+ * the goal is to assert PG-level constraint behaviour, not Drizzle's
+ * insert ergonomics.
+ */
+import { sql } from "drizzle-orm"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { createTestDb } from "../../src/test-utils.js"
+
+const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
+let DB_AVAILABLE = false
+
+if (TEST_DATABASE_URL) {
+  try {
+    const probe = createTestDb()
+    await probe.execute(/* sql */ `SELECT 1`)
+    DB_AVAILABLE = true
+  } catch {
+    DB_AVAILABLE = false
+  }
+}
+
+describe.skipIf(!DB_AVAILABLE)("auth.user email-or-phone constraints", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test db typing
+  let db: any
+
+  beforeAll(async () => {
+    db = createTestDb()
+  })
+
+  beforeEach(async () => {
+    // The `user` table is shared across many tests; clean only the
+    // rows we insert here to stay polite.
+    await db.execute(sql`DELETE FROM "user" WHERE "id" LIKE 'authuser_test_%'`)
+  })
+
+  afterAll(async () => {
+    await db.execute(sql`DELETE FROM "user" WHERE "id" LIKE 'authuser_test_%'`)
+  })
+
+  async function insertUser(values: {
+    id: string
+    email?: string | null
+    phoneNumber?: string | null
+    name?: string
+  }) {
+    return db.execute(sql`
+      INSERT INTO "user" ("id", "name", "email", "email_verified", "phone_number", "phone_number_verified", "created_at", "updated_at")
+      VALUES (
+        ${values.id},
+        ${values.name ?? "Test User"},
+        ${values.email ?? null},
+        ${false},
+        ${values.phoneNumber ?? null},
+        ${false},
+        now(),
+        now()
+      )
+    `)
+  }
+
+  it("accepts a phone-only user (email NULL)", async () => {
+    await expect(
+      insertUser({ id: "authuser_test_phone1", phoneNumber: "+40700000001" }),
+    ).resolves.not.toThrow()
+  })
+
+  it("accepts an email-only user (phone NULL)", async () => {
+    await expect(
+      insertUser({ id: "authuser_test_email1", email: "test441-1@example.com" }),
+    ).resolves.not.toThrow()
+  })
+
+  it("rejects a row with both email and phone NULL", async () => {
+    await expect(insertUser({ id: "authuser_test_neither" })).rejects.toThrow(/user_email_or_phone/)
+  })
+
+  it("enforces email uniqueness only among non-null emails", async () => {
+    await insertUser({ id: "authuser_test_email2", email: "test441-dup@example.com" })
+    await expect(
+      insertUser({ id: "authuser_test_email3", email: "test441-dup@example.com" }),
+    ).rejects.toThrow(/user_email_unique/)
+    // A phone-only row alongside an email-only row is fine.
+    await expect(
+      insertUser({ id: "authuser_test_phone2", phoneNumber: "+40700000002" }),
+    ).resolves.not.toThrow()
+  })
+
+  it("enforces phone uniqueness only among non-null phones", async () => {
+    await insertUser({ id: "authuser_test_phone3", phoneNumber: "+40700000003" })
+    await expect(
+      insertUser({ id: "authuser_test_phone4", phoneNumber: "+40700000003" }),
+    ).rejects.toThrow(/user_phone_unique/)
+  })
+
+  it("allows the same row to set both email and phone", async () => {
+    await expect(
+      insertUser({
+        id: "authuser_test_both",
+        email: "test441-both@example.com",
+        phoneNumber: "+40700000099",
+      }),
+    ).resolves.not.toThrow()
+  })
+})

--- a/templates/operator/migrations/0025_user_email_nullable_phone.sql
+++ b/templates/operator/migrations/0025_user_email_nullable_phone.sql
@@ -1,0 +1,18 @@
+ALTER TABLE "user" DROP CONSTRAINT "user_email_unique";
+--> statement-breakpoint
+ALTER TABLE "user" ALTER COLUMN "email" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "phone_number" text;
+--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "phone_number_verified" boolean DEFAULT false NOT NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "user_email_unique"
+  ON "user" USING btree ("email")
+  WHERE "email" IS NOT NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "user_phone_unique"
+  ON "user" USING btree ("phone_number")
+  WHERE "phone_number" IS NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "user" ADD CONSTRAINT "user_email_or_phone"
+  CHECK ("email" IS NOT NULL OR "phone_number" IS NOT NULL);

--- a/templates/operator/migrations/meta/_journal.json
+++ b/templates/operator/migrations/meta/_journal.json
@@ -169,6 +169,20 @@
       "when": 1777891500000,
       "tag": "0023_product_day_service_country",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1777891600000,
+      "tag": "0024_people_pii_documents",
+      "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1777891700000,
+      "tag": "0025_user_email_nullable_phone",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes #441.

`auth.user.email` was `notNull().unique()`, which forced phone-only signups to invent synthetic `<phone>@phone.protravel.ro` placeholders. Those placeholders leak into password-reset bounces, audit logs, and CRM contact rows. This PR fixes the data layer so phone-only users can exist as first-class rows.

## Schema

- `auth.user.email` becomes nullable; old email-only `UNIQUE` replaced with partial `user_email_unique WHERE email IS NOT NULL`.
- New columns: `phone_number` (text, nullable) and `phone_number_verified` (boolean, default false) — matching Better Auth's phone-OTP plugin shape.
- New partial `user_phone_unique WHERE phone_number IS NOT NULL`.
- New check constraint `user_email_or_phone CHECK (email IS NOT NULL OR phone_number IS NOT NULL)` so every row carries at least one identifier.
- Migration: `templates/operator/migrations/0025_user_email_nullable_phone.sql`.

## Consumer cleanup

- `@voyantjs/auth`'s `CurrentUser` type, `getCurrentUser`, and `ensureCurrentUserProfile` accept null email — phone-only users no longer fail provisioning.
- `@voyantjs/auth-react`'s `currentUserSchema` and `organizationMemberUserSchema` accept null email; `currentUserSchema` exposes the new `phoneNumber` field. `organizationInvitationSchema.email` stays required (org invitations are email-keyed in Better Auth's plugin).
- `@voyantjs/customer-portal`'s `getAccessibleBookingIds` and `hasBookingAccess` skip the email-match branch for phone-only users (linked-person matching still works); `bootstrap` skips email-keyed candidate lookup. Email-based flows are unchanged.

## Out of scope (deferred)

- Wiring the Better Auth phone-OTP plugin in `packages/auth/src/server.ts`. Needs an SMS provider + signup route work + UI; lands in a follow-up.
- Phone-keyed organization invitations (Better Auth invitations are email-only today).

## Pre-merge follow-ups

- **DMC migration baseline still stale.** Same as the previous PR — `templates/dmc/migrations/` only has `0000_*` and needs a hand-written `0025` equivalent or rebaselining before dmc releases.

## Test plan

- [x] `pnpm typecheck` — 111/111 tasks pass.
- [x] `pnpm test` — 112/112 tasks pass.
- [x] New `packages/db/tests/integration/auth-user-identifier.test.ts`: phone-only insert succeeds, email-only insert succeeds, both-null rejected with `user_email_or_phone`, partial unique indexes reject duplicates of each non-null identifier independently. DB-gated; runs when `TEST_DATABASE_URL` is set.
- [ ] Apply `0025_user_email_nullable_phone.sql` to a staging DB and verify the constraints behave as expected with real Better Auth signups (email-only path) before phone-OTP wiring lands.