### PR TITLE
Add person_relationships table for kinship + emergency contacts

### DIFF
--- a/.changeset/person-relationships.md
+++ b/.changeset/person-relationships.md
@@ -1,0 +1,19 @@
+---
+"@voyantjs/crm": patch
+"@voyantjs/crm-react": patch
+"@voyantjs/db": patch
+---
+
+Add person-to-person relationships table for kinship, emergency contacts, and travel companions (closes #442).
+
+New `crm.person_relationships` table records directed `fromPerson → toPerson` edges of one of eleven kinds (`spouse`, `partner`, `parent`, `child`, `sibling`, `guardian`, `ward`, `emergency_contact`, `friend`, `travel_companion`, `other`). The optional `inverseKind` lets the service auto-write the symmetric edge in the same transaction (parent↔child, guardian↔ward, etc.) so operator UIs don't have to maintain both sides; the auto-inverse path is idempotent on retry. `(from_person_id, to_person_id, kind)` is uniquely indexed and a CHECK constraint rejects self-edges. Migration: `templates/operator/migrations/0026_person_relationships.sql` (registered in `meta/_journal.json`).
+
+API surface:
+
+- `crmService.listPersonRelationships(db, personId, { direction?: "from" | "to" | "both" })` — defaults to `both` so the typical "Jane's family" view returns the union.
+- `crmService.createPersonRelationship(db, fromPersonId, { toPersonId, kind, inverseKind?, autoInverse? })`
+- `crmService.getPersonRelationship` / `updatePersonRelationship` / `deletePersonRelationship`
+- Admin routes: `GET/POST /v1/admin/crm/people/:id/relationships`, `GET/PATCH/DELETE /v1/admin/crm/person-relationships/:id`.
+- React hooks: `usePersonRelationships(personId, { direction, kind })`, `usePersonRelationshipMutation(personId)` returning `{ create, update, remove }`.
+
+Out of scope (deferred): UI components for the relationship graph; phone-keyed emergency-contact convenience helpers (use `metadata` for now). The data layer is ready for both.

--- a/packages/crm-react/src/hooks/index.ts
+++ b/packages/crm-react/src/hooks/index.ts
@@ -25,6 +25,15 @@ export {
   usePersonMutation,
 } from "./use-person-mutation.js"
 export {
+  type CreatePersonRelationshipInput,
+  type UpdatePersonRelationshipInput,
+  usePersonRelationshipMutation,
+} from "./use-person-relationship-mutation.js"
+export {
+  type UsePersonRelationshipsOptions,
+  usePersonRelationships,
+} from "./use-person-relationships.js"
+export {
   type UsePersonTravelSnapshotOptions,
   usePersonTravelSnapshot,
 } from "./use-person-travel-snapshot.js"

--- a/packages/crm-react/src/hooks/use-person-relationship-mutation.ts
+++ b/packages/crm-react/src/hooks/use-person-relationship-mutation.ts
@@ -1,0 +1,88 @@
+"use client"
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { z } from "zod"
+
+import { fetchWithValidation } from "../client.js"
+import { useVoyantContext } from "../provider.js"
+import { crmQueryKeys } from "../query-keys.js"
+import { type PersonRelationshipKind, personRelationshipSingleResponse } from "../schemas.js"
+
+export interface CreatePersonRelationshipInput {
+  toPersonId: string
+  kind: PersonRelationshipKind
+  /** When set, the route auto-writes the symmetric edge. */
+  inverseKind?: PersonRelationshipKind | null
+  startDate?: string | null
+  endDate?: string | null
+  isPrimary?: boolean
+  notes?: string | null
+  metadata?: Record<string, unknown> | null
+  /** Pass `false` to skip the symmetric edge even if `inverseKind` is set. */
+  autoInverse?: boolean
+}
+
+export interface UpdatePersonRelationshipInput {
+  kind?: PersonRelationshipKind
+  inverseKind?: PersonRelationshipKind | null
+  startDate?: string | null
+  endDate?: string | null
+  isPrimary?: boolean
+  notes?: string | null
+  metadata?: Record<string, unknown> | null
+}
+
+const deleteResponseSchema = z.object({ success: z.boolean() })
+
+export function usePersonRelationshipMutation(personId: string | undefined) {
+  const { baseUrl, fetcher } = useVoyantContext()
+  const queryClient = useQueryClient()
+
+  const invalidate = () => {
+    if (personId) {
+      void queryClient.invalidateQueries({
+        queryKey: [...crmQueryKeys.person(personId), "relationships"],
+      })
+    }
+  }
+
+  const create = useMutation({
+    mutationFn: async (input: CreatePersonRelationshipInput) => {
+      if (!personId) throw new Error("usePersonRelationshipMutation requires a personId")
+      const { data } = await fetchWithValidation(
+        `/v1/crm/people/${personId}/relationships`,
+        personRelationshipSingleResponse,
+        { baseUrl, fetcher },
+        { method: "POST", body: JSON.stringify(input) },
+      )
+      return data
+    },
+    onSuccess: invalidate,
+  })
+
+  const update = useMutation({
+    mutationFn: async ({ id, input }: { id: string; input: UpdatePersonRelationshipInput }) => {
+      const { data } = await fetchWithValidation(
+        `/v1/crm/person-relationships/${id}`,
+        personRelationshipSingleResponse,
+        { baseUrl, fetcher },
+        { method: "PATCH", body: JSON.stringify(input) },
+      )
+      return data
+    },
+    onSuccess: invalidate,
+  })
+
+  const remove = useMutation({
+    mutationFn: async (id: string) =>
+      fetchWithValidation(
+        `/v1/crm/person-relationships/${id}`,
+        deleteResponseSchema,
+        { baseUrl, fetcher },
+        { method: "DELETE" },
+      ),
+    onSuccess: invalidate,
+  })
+
+  return { create, update, remove }
+}

--- a/packages/crm-react/src/hooks/use-person-relationships.ts
+++ b/packages/crm-react/src/hooks/use-person-relationships.ts
@@ -1,0 +1,44 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+
+import { fetchWithValidation } from "../client.js"
+import { useVoyantContext } from "../provider.js"
+import { crmQueryKeys, type PersonRelationshipsListFilters } from "../query-keys.js"
+import { personRelationshipListResponse } from "../schemas.js"
+
+export interface UsePersonRelationshipsOptions extends PersonRelationshipsListFilters {
+  enabled?: boolean
+}
+
+/**
+ * Lists relationships for a person. Default direction `both` returns
+ * the union of incoming and outgoing edges — the typical "Jane's
+ * family" UI shape.
+ */
+export function usePersonRelationships(
+  personId: string | undefined,
+  options: UsePersonRelationshipsOptions = {},
+) {
+  const { baseUrl, fetcher } = useVoyantContext()
+  const { enabled = true, ...filters } = options
+
+  return useQuery({
+    queryKey: crmQueryKeys.personRelationships(personId ?? "", filters),
+    queryFn: async () => {
+      if (!personId) throw new Error("usePersonRelationships requires a personId")
+      const params = new URLSearchParams()
+      if (filters.kind) params.set("kind", filters.kind)
+      if (filters.direction) params.set("direction", filters.direction)
+      if (filters.limit !== undefined) params.set("limit", String(filters.limit))
+      if (filters.offset !== undefined) params.set("offset", String(filters.offset))
+      const qs = params.toString()
+      return fetchWithValidation(
+        `/v1/crm/people/${personId}/relationships${qs ? `?${qs}` : ""}`,
+        personRelationshipListResponse,
+        { baseUrl, fetcher },
+      )
+    },
+    enabled: enabled && Boolean(personId),
+  })
+}

--- a/packages/crm-react/src/index.ts
+++ b/packages/crm-react/src/index.ts
@@ -65,6 +65,15 @@ export {
   usePersonMutation,
 } from "./hooks/use-person-mutation.js"
 export {
+  type CreatePersonRelationshipInput,
+  type UpdatePersonRelationshipInput,
+  usePersonRelationshipMutation,
+} from "./hooks/use-person-relationship-mutation.js"
+export {
+  type UsePersonRelationshipsOptions,
+  usePersonRelationships,
+} from "./hooks/use-person-relationships.js"
+export {
   type UsePersonTravelSnapshotOptions,
   usePersonTravelSnapshot,
 } from "./hooks/use-person-travel-snapshot.js"
@@ -116,6 +125,7 @@ export {
   type OrganizationsListFilters,
   type PeopleListFilters,
   type PersonDocumentsListFilters,
+  type PersonRelationshipsListFilters,
   type PipelinesListFilters,
   type QuotesListFilters,
   type StagesListFilters,
@@ -154,12 +164,16 @@ export {
   type PersonDocumentType,
   type PersonNoteRecord,
   type PersonRecord,
+  type PersonRelationshipKind,
+  type PersonRelationshipRecord,
   type PersonTravelSnapshotRecord,
   type PipelineRecord,
   personDocumentRecordSchema,
   personDocumentTypeSchema,
   personNoteRecordSchema,
   personRecordSchema,
+  personRelationshipKindSchema,
+  personRelationshipRecordSchema,
   personTravelSnapshotSchema,
   pipelineRecordSchema,
   type QuoteLineRecord,

--- a/packages/crm-react/src/query-keys.ts
+++ b/packages/crm-react/src/query-keys.ts
@@ -64,6 +64,13 @@ export interface QuotesListFilters {
   offset?: number | undefined
 }
 
+export interface PersonRelationshipsListFilters {
+  kind?: string | undefined
+  direction?: "from" | "to" | "both" | undefined
+  limit?: number | undefined
+  offset?: number | undefined
+}
+
 export interface PersonDocumentsListFilters {
   type?: string | undefined
   expiringBefore?: string | undefined
@@ -82,6 +89,8 @@ export const crmQueryKeys = {
   personDocument: (id: string) => [...crmQueryKeys.all, "person-documents", "detail", id] as const,
   personTravelSnapshot: (personId: string) =>
     [...crmQueryKeys.person(personId), "travel-snapshot"] as const,
+  personRelationships: (personId: string, filters: PersonRelationshipsListFilters = {}) =>
+    [...crmQueryKeys.person(personId), "relationships", filters] as const,
 
   organizations: () => [...crmQueryKeys.all, "organizations"] as const,
   organizationsList: (filters: OrganizationsListFilters) =>

--- a/packages/crm-react/src/schemas.ts
+++ b/packages/crm-react/src/schemas.ts
@@ -240,6 +240,42 @@ export type PersonDocumentRecord = z.infer<typeof personDocumentRecordSchema>
 export const personDocumentListResponse = listEnvelope(personDocumentRecordSchema)
 export const personDocumentSingleResponse = singleEnvelope(personDocumentRecordSchema)
 
+export const personRelationshipKindSchema = z.enum([
+  "spouse",
+  "partner",
+  "parent",
+  "child",
+  "sibling",
+  "guardian",
+  "ward",
+  "emergency_contact",
+  "friend",
+  "travel_companion",
+  "other",
+])
+
+export type PersonRelationshipKind = z.infer<typeof personRelationshipKindSchema>
+
+export const personRelationshipRecordSchema = z.object({
+  id: z.string(),
+  fromPersonId: z.string(),
+  toPersonId: z.string(),
+  kind: personRelationshipKindSchema,
+  inverseKind: personRelationshipKindSchema.nullable(),
+  startDate: z.string().nullable(),
+  endDate: z.string().nullable(),
+  isPrimary: z.boolean(),
+  notes: z.string().nullable(),
+  metadata: z.record(z.string(), z.unknown()).nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+
+export type PersonRelationshipRecord = z.infer<typeof personRelationshipRecordSchema>
+
+export const personRelationshipListResponse = listEnvelope(personRelationshipRecordSchema)
+export const personRelationshipSingleResponse = singleEnvelope(personRelationshipRecordSchema)
+
 export const personTravelSnapshotSchema = z.object({
   dateOfBirth: z.string().nullable(),
   dietaryRequirements: z.string().nullable(),

--- a/packages/crm/src/index.ts
+++ b/packages/crm/src/index.ts
@@ -91,6 +91,7 @@ export type {
   NewPerson,
   NewPersonDocument,
   NewPersonNote,
+  NewPersonRelationship,
   NewPipeline,
   NewQuote,
   NewQuoteLine,
@@ -105,6 +106,7 @@ export type {
   Person,
   PersonDocument,
   PersonNote,
+  PersonRelationship,
   Pipeline,
   Quote,
   QuoteLine,
@@ -128,6 +130,8 @@ export {
   personDocuments,
   personDocumentTypeEnum,
   personNotes,
+  personRelationshipKindEnum,
+  personRelationships,
   pipelines,
   quoteLines,
   quotes,
@@ -147,6 +151,13 @@ export {
   personDocumentsService,
   personPiiBlobPlaintextSchema,
 } from "./service/person-documents.js"
+export type {
+  CreatePersonRelationshipInput,
+  PersonRelationshipKind,
+  PersonRelationshipListQuery,
+  UpdatePersonRelationshipInput,
+} from "./service/person-relationships.js"
+export { personRelationshipsService } from "./service/person-relationships.js"
 export {
   activityListQuerySchema,
   communicationChannelSchema,
@@ -167,6 +178,7 @@ export {
   insertPersonDocumentFromPlaintextSchema,
   insertPersonDocumentSchema,
   insertPersonNoteSchema,
+  insertPersonRelationshipSchema,
   insertPersonSchema,
   insertPipelineSchema,
   insertQuoteLineSchema,
@@ -178,6 +190,8 @@ export {
   personDocumentListQuerySchema,
   personDocumentTypeSchema,
   personListQuerySchema,
+  personRelationshipKindSchema,
+  personRelationshipListQuerySchema,
   pipelineListQuerySchema,
   quoteListQuerySchema,
   relationTypeSchema,
@@ -190,6 +204,7 @@ export {
   updatePersonDocumentFromPlaintextSchema,
   updatePersonDocumentSchema,
   updatePersonProfilePiiSchema,
+  updatePersonRelationshipSchema,
   updatePersonSchema,
   updatePipelineSchema,
   updateQuoteLineSchema,

--- a/packages/crm/src/routes/index.ts
+++ b/packages/crm/src/routes/index.ts
@@ -6,6 +6,7 @@ import { activityRoutes } from "./activities.js"
 import { customFieldRoutes } from "./custom-fields.js"
 import { opportunityRoutes } from "./opportunities.js"
 import { personDocumentRoutes } from "./person-documents.js"
+import { personRelationshipRoutes } from "./person-relationships.js"
 import { pipelineRoutes } from "./pipelines.js"
 import { quoteRoutes } from "./quotes.js"
 
@@ -19,6 +20,7 @@ type Env = {
 export const crmRoutes = new Hono<Env>()
   .route("/", accountRoutes)
   .route("/", personDocumentRoutes)
+  .route("/", personRelationshipRoutes)
   .route("/", pipelineRoutes)
   .route("/", opportunityRoutes)
   .route("/", quoteRoutes)

--- a/packages/crm/src/routes/person-relationships.ts
+++ b/packages/crm/src/routes/person-relationships.ts
@@ -1,0 +1,55 @@
+import { parseJsonBody, parseQuery } from "@voyantjs/hono"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { Hono } from "hono"
+
+import { crmService } from "../service/index.js"
+import {
+  insertPersonRelationshipSchema,
+  personRelationshipListQuerySchema,
+  updatePersonRelationshipSchema,
+} from "../validation.js"
+
+type Env = {
+  Variables: {
+    db: PostgresJsDatabase
+    userId?: string
+  }
+}
+
+export const personRelationshipRoutes = new Hono<Env>()
+  .get("/people/:id/relationships", async (c) => {
+    const query = parseQuery(c, personRelationshipListQuerySchema)
+    return c.json({
+      data: await crmService.listPersonRelationships(c.get("db"), c.req.param("id"), query),
+    })
+  })
+  .post("/people/:id/relationships", async (c) => {
+    const row = await crmService.createPersonRelationship(
+      c.get("db"),
+      c.req.param("id"),
+      await parseJsonBody(c, insertPersonRelationshipSchema),
+    )
+    if (!row) {
+      return c.json({ error: "Person not found or self-relationship rejected" }, 400)
+    }
+    return c.json({ data: row }, 201)
+  })
+  .get("/person-relationships/:id", async (c) => {
+    const row = await crmService.getPersonRelationship(c.get("db"), c.req.param("id"))
+    if (!row) return c.json({ error: "Relationship not found" }, 404)
+    return c.json({ data: row })
+  })
+  .patch("/person-relationships/:id", async (c) => {
+    const row = await crmService.updatePersonRelationship(
+      c.get("db"),
+      c.req.param("id"),
+      await parseJsonBody(c, updatePersonRelationshipSchema),
+    )
+    if (!row) return c.json({ error: "Relationship not found" }, 404)
+    return c.json({ data: row })
+  })
+  .delete("/person-relationships/:id", async (c) => {
+    const row = await crmService.deletePersonRelationship(c.get("db"), c.req.param("id"))
+    if (!row) return c.json({ error: "Relationship not found" }, 404)
+    return c.json({ success: true })
+  })

--- a/packages/crm/src/schema-accounts.ts
+++ b/packages/crm/src/schema-accounts.ts
@@ -3,6 +3,7 @@ import type { KmsEnvelope } from "@voyantjs/db/schema/iam/kms"
 import { sql } from "drizzle-orm"
 import {
   boolean,
+  check,
   date,
   index,
   integer,
@@ -31,6 +32,28 @@ export const personDocumentTypeEnum = pgEnum("person_document_type", [
   "id_card",
   "driver_license",
   "visa",
+  "other",
+])
+
+/**
+ * Person-to-person relationship kinds. Directed: each row records a
+ * single edge `from → to` of a specific kind. The optional inverse
+ * edge (e.g. parent ↔ child) is kept as a separate row so list
+ * queries against either side return the same shape; the service
+ * layer auto-writes the inverse on insert when an `inverseKind` is
+ * provided.
+ */
+export const personRelationshipKindEnum = pgEnum("person_relationship_kind", [
+  "spouse",
+  "partner",
+  "parent",
+  "child",
+  "sibling",
+  "guardian",
+  "ward",
+  "emergency_contact",
+  "friend",
+  "travel_companion",
   "other",
 ])
 
@@ -201,6 +224,60 @@ export const personDocuments = pgTable(
 
 export type PersonDocument = typeof personDocuments.$inferSelect
 export type NewPersonDocument = typeof personDocuments.$inferInsert
+
+/**
+ * Directed person-to-person edges (kinship, emergency contacts,
+ * travel companions). Each row is a single edge `fromPerson → toPerson`
+ * of one `kind`; the reverse edge — when meaningful — is a separate
+ * row written by the service layer's auto-inverse helper. Self-edges
+ * are rejected via a CHECK constraint; the unique index on
+ * `(from, to, kind)` prevents the same directional edge from being
+ * recorded twice.
+ *
+ * `metadata` is a free-form jsonb bag for module-specific extensions
+ * (e.g. emergency-contact relationship to traveler). Operators that
+ * need richer structure should add their own typed columns.
+ */
+export const personRelationships = pgTable(
+  "person_relationships",
+  {
+    id: typeId("person_relationships"),
+    fromPersonId: typeIdRef("from_person_id")
+      .notNull()
+      .references(() => people.id, { onDelete: "cascade" }),
+    toPersonId: typeIdRef("to_person_id")
+      .notNull()
+      .references(() => people.id, { onDelete: "cascade" }),
+    kind: personRelationshipKindEnum("kind").notNull(),
+    /**
+     * The kind that should label the reverse edge (e.g. parent ↔
+     * child). When set on insert, the service layer writes the
+     * inverse edge in the same transaction unless `autoInverse` is
+     * explicitly disabled.
+     */
+    inverseKind: personRelationshipKindEnum("inverse_kind"),
+    startDate: date("start_date"),
+    endDate: date("end_date"),
+    isPrimary: boolean("is_primary").notNull().default(false),
+    notes: text("notes"),
+    metadata: jsonb("metadata").$type<Record<string, unknown>>(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_person_relationships_from").on(table.fromPersonId),
+    index("idx_person_relationships_to").on(table.toPersonId),
+    uniqueIndex("uidx_person_relationships_pair_kind").on(
+      table.fromPersonId,
+      table.toPersonId,
+      table.kind,
+    ),
+    check("person_relationships_no_self", sql`${table.fromPersonId} <> ${table.toPersonId}`),
+  ],
+)
+
+export type PersonRelationship = typeof personRelationships.$inferSelect
+export type NewPersonRelationship = typeof personRelationships.$inferInsert
 
 /**
  * Saved payment methods on file for a person. Stores processor-issued

--- a/packages/crm/src/service/index.ts
+++ b/packages/crm/src/service/index.ts
@@ -3,6 +3,7 @@ import { activitiesService } from "./activities.js"
 import { customFieldsService } from "./custom-fields.js"
 import { opportunitiesService } from "./opportunities.js"
 import { personDocumentsService } from "./person-documents.js"
+import { personRelationshipsService } from "./person-relationships.js"
 import { pipelinesService } from "./pipelines.js"
 import { quotesService } from "./quotes.js"
 
@@ -14,6 +15,7 @@ export const crmService = {
   ...activitiesService,
   ...customFieldsService,
   ...personDocumentsService,
+  ...personRelationshipsService,
 }
 
 export type {
@@ -28,3 +30,10 @@ export {
   personDocumentsService,
   personPiiBlobPlaintextSchema,
 } from "./person-documents.js"
+export type {
+  CreatePersonRelationshipInput,
+  PersonRelationshipKind,
+  PersonRelationshipListQuery,
+  UpdatePersonRelationshipInput,
+} from "./person-relationships.js"
+export { personRelationshipsService } from "./person-relationships.js"

--- a/packages/crm/src/service/person-relationships.ts
+++ b/packages/crm/src/service/person-relationships.ts
@@ -1,0 +1,159 @@
+import { and, asc, eq, or } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import type { z } from "zod"
+
+import { people, personRelationships } from "../schema.js"
+import type {
+  insertPersonRelationshipSchema,
+  personRelationshipListQuerySchema,
+  updatePersonRelationshipSchema,
+} from "../validation.js"
+
+export type CreatePersonRelationshipInput = z.infer<typeof insertPersonRelationshipSchema>
+export type UpdatePersonRelationshipInput = z.infer<typeof updatePersonRelationshipSchema>
+export type PersonRelationshipListQuery = z.infer<typeof personRelationshipListQuerySchema>
+export type PersonRelationshipKind = CreatePersonRelationshipInput["kind"]
+
+async function personExists(db: PostgresJsDatabase, personId: string) {
+  const [row] = await db
+    .select({ id: people.id })
+    .from(people)
+    .where(eq(people.id, personId))
+    .limit(1)
+  return Boolean(row)
+}
+
+export const personRelationshipsService = {
+  /**
+   * Lists relationships for a person. Default `direction: "both"`
+   * returns the union of outgoing and incoming edges — the typical
+   * "Jane's family" UI shape. Use `from` / `to` for one-sided lists.
+   */
+  listPersonRelationships(
+    db: PostgresJsDatabase,
+    personId: string,
+    query?: PersonRelationshipListQuery,
+  ) {
+    const direction = query?.direction ?? "both"
+    const directionFilter =
+      direction === "from"
+        ? eq(personRelationships.fromPersonId, personId)
+        : direction === "to"
+          ? eq(personRelationships.toPersonId, personId)
+          : or(
+              eq(personRelationships.fromPersonId, personId),
+              eq(personRelationships.toPersonId, personId),
+            )
+
+    const conditions = [directionFilter]
+    if (query?.kind) {
+      conditions.push(eq(personRelationships.kind, query.kind))
+    }
+
+    const limit = query?.limit ?? 50
+    const offset = query?.offset ?? 0
+
+    return db
+      .select()
+      .from(personRelationships)
+      .where(and(...conditions))
+      .orderBy(asc(personRelationships.createdAt))
+      .limit(limit)
+      .offset(offset)
+  },
+
+  async getPersonRelationship(db: PostgresJsDatabase, id: string) {
+    const [row] = await db
+      .select()
+      .from(personRelationships)
+      .where(eq(personRelationships.id, id))
+      .limit(1)
+    return row ?? null
+  },
+
+  /**
+   * Inserts a directed edge `fromPerson → toPerson` of `data.kind`.
+   * When `data.inverseKind` is provided AND `data.autoInverse` is
+   * not explicitly false, also inserts the symmetric
+   * `toPerson → fromPerson` edge with `kind = inverseKind` (and
+   * `inverseKind` swapped back). The pair is written in a single
+   * transaction so a failed inverse rolls the primary back.
+   *
+   * The inverse insert is idempotent — if the symmetric edge
+   * already exists, the `(from, to, kind)` unique index would
+   * normally throw; we suppress that case so retrying a partially
+   * applied operation doesn't fail. Any other DB error still
+   * propagates.
+   */
+  async createPersonRelationship(
+    db: PostgresJsDatabase,
+    fromPersonId: string,
+    data: CreatePersonRelationshipInput,
+  ) {
+    if (fromPersonId === data.toPersonId) return null
+    if (!(await personExists(db, fromPersonId))) return null
+    if (!(await personExists(db, data.toPersonId))) return null
+
+    const { toPersonId, autoInverse: autoInverseInput, inverseKind, ...rest } = data
+    const autoInverse = autoInverseInput !== false
+
+    return db.transaction(async (tx) => {
+      const [primary] = await tx
+        .insert(personRelationships)
+        .values({
+          ...rest,
+          inverseKind: inverseKind ?? null,
+          fromPersonId,
+          toPersonId,
+        })
+        .returning()
+      if (!primary) return null
+
+      if (autoInverse && inverseKind) {
+        await tx
+          .insert(personRelationships)
+          .values({
+            fromPersonId: toPersonId,
+            toPersonId: fromPersonId,
+            kind: inverseKind,
+            inverseKind: rest.kind,
+            startDate: rest.startDate ?? null,
+            endDate: rest.endDate ?? null,
+            isPrimary: rest.isPrimary,
+            notes: rest.notes ?? null,
+            metadata: rest.metadata ?? null,
+          })
+          .onConflictDoNothing({
+            target: [
+              personRelationships.fromPersonId,
+              personRelationships.toPersonId,
+              personRelationships.kind,
+            ],
+          })
+      }
+
+      return primary
+    })
+  },
+
+  async updatePersonRelationship(
+    db: PostgresJsDatabase,
+    id: string,
+    data: UpdatePersonRelationshipInput,
+  ) {
+    const [row] = await db
+      .update(personRelationships)
+      .set({ ...data, updatedAt: new Date() })
+      .where(eq(personRelationships.id, id))
+      .returning()
+    return row ?? null
+  },
+
+  async deletePersonRelationship(db: PostgresJsDatabase, id: string) {
+    const [row] = await db
+      .delete(personRelationships)
+      .where(eq(personRelationships.id, id))
+      .returning({ id: personRelationships.id })
+    return row ?? null
+  },
+}

--- a/packages/crm/src/validation.ts
+++ b/packages/crm/src/validation.ts
@@ -389,6 +389,57 @@ export type PersonDocumentPlaintextInput = z.infer<typeof insertPersonDocumentFr
 export type PersonDocumentPlaintextUpdate = z.infer<typeof updatePersonDocumentFromPlaintextSchema>
 export type UpdatePersonProfilePiiInput = z.infer<typeof updatePersonProfilePiiSchema>
 
+// ---------- person relationships ----------
+
+export const personRelationshipKindSchema = z.enum([
+  "spouse",
+  "partner",
+  "parent",
+  "child",
+  "sibling",
+  "guardian",
+  "ward",
+  "emergency_contact",
+  "friend",
+  "travel_companion",
+  "other",
+])
+
+const personRelationshipCoreSchema = z.object({
+  toPersonId: z.string().min(1),
+  kind: personRelationshipKindSchema,
+  inverseKind: personRelationshipKindSchema.nullable().optional(),
+  startDate: z.string().date().nullable().optional(),
+  endDate: z.string().date().nullable().optional(),
+  isPrimary: z.boolean().default(false),
+  notes: z.string().nullable().optional(),
+  metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+  /**
+   * Set to false to skip writing the symmetric edge when
+   * `inverseKind` is provided. Defaults to `true` so operator UIs
+   * don't have to maintain both sides.
+   */
+  autoInverse: z.boolean().optional(),
+})
+
+export const insertPersonRelationshipSchema = personRelationshipCoreSchema
+export const updatePersonRelationshipSchema = personRelationshipCoreSchema
+  .partial()
+  .omit({ toPersonId: true, autoInverse: true })
+
+export const personRelationshipListQuerySchema = paginationSchema.extend({
+  kind: personRelationshipKindSchema.optional(),
+  /**
+   * `from` returns only outgoing edges, `to` only incoming, `both`
+   * (the default) returns the union — the typical UI shape.
+   */
+  direction: z.enum(["from", "to", "both"]).default("both"),
+})
+
+export type PersonRelationshipInput = z.infer<typeof insertPersonRelationshipSchema>
+export type PersonRelationshipUpdate = z.infer<typeof updatePersonRelationshipSchema>
+export type PersonRelationshipListQueryInput = z.infer<typeof personRelationshipListQuerySchema>
+
 // ---------- notes ----------
 
 export const insertPersonNoteSchema = z.object({

--- a/packages/crm/tests/integration/person-relationships.test.ts
+++ b/packages/crm/tests/integration/person-relationships.test.ts
@@ -1,0 +1,204 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { people } from "../../src/schema.js"
+import { personRelationshipsService } from "../../src/service/person-relationships.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+describe.skipIf(!DB_AVAILABLE)("personRelationshipsService", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test db typing
+  let db: any
+
+  beforeAll(async () => {
+    const { createTestDb, cleanupTestDb } = await import("@voyantjs/db/test-utils")
+    db = createTestDb()
+    await cleanupTestDb(db)
+  })
+
+  beforeEach(async () => {
+    const { cleanupTestDb } = await import("@voyantjs/db/test-utils")
+    await cleanupTestDb(db)
+  })
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyantjs/db/test-utils")
+    await closeTestDb()
+  })
+
+  async function seedPerson(firstName = "Test") {
+    const [row] = await db
+      .insert(people)
+      .values({
+        firstName,
+        lastName: "Person",
+        tags: [],
+        status: "active",
+      })
+      .returning()
+    return row
+  }
+
+  it("creates a directed edge between two people", async () => {
+    const a = await seedPerson("Alice")
+    const b = await seedPerson("Bob")
+    const created = await personRelationshipsService.createPersonRelationship(db, a.id, {
+      toPersonId: b.id,
+      kind: "spouse",
+    })
+    expect(created?.fromPersonId).toBe(a.id)
+    expect(created?.toPersonId).toBe(b.id)
+    expect(created?.kind).toBe("spouse")
+    expect(created?.inverseKind).toBeNull()
+  })
+
+  it("rejects self-relationships", async () => {
+    const a = await seedPerson("Solo")
+    const result = await personRelationshipsService.createPersonRelationship(db, a.id, {
+      toPersonId: a.id,
+      kind: "friend",
+    })
+    expect(result).toBeNull()
+  })
+
+  it("returns null when either person is missing", async () => {
+    const a = await seedPerson("Real")
+    expect(
+      await personRelationshipsService.createPersonRelationship(db, a.id, {
+        toPersonId: "pers_missing",
+        kind: "friend",
+      }),
+    ).toBeNull()
+    expect(
+      await personRelationshipsService.createPersonRelationship(db, "pers_missing", {
+        toPersonId: a.id,
+        kind: "friend",
+      }),
+    ).toBeNull()
+  })
+
+  it("enforces uniqueness on (from, to, kind)", async () => {
+    const a = await seedPerson("Alice")
+    const b = await seedPerson("Bob")
+    await personRelationshipsService.createPersonRelationship(db, a.id, {
+      toPersonId: b.id,
+      kind: "friend",
+    })
+    await expect(
+      personRelationshipsService.createPersonRelationship(db, a.id, {
+        toPersonId: b.id,
+        kind: "friend",
+      }),
+    ).rejects.toThrow()
+    // A different kind on the same pair is fine.
+    const second = await personRelationshipsService.createPersonRelationship(db, a.id, {
+      toPersonId: b.id,
+      kind: "travel_companion",
+    })
+    expect(second?.id).toBeTruthy()
+  })
+
+  it("auto-writes the inverse edge when inverseKind is provided", async () => {
+    const parent = await seedPerson("Parent")
+    const child = await seedPerson("Child")
+    const created = await personRelationshipsService.createPersonRelationship(db, parent.id, {
+      toPersonId: child.id,
+      kind: "parent",
+      inverseKind: "child",
+    })
+    expect(created?.kind).toBe("parent")
+
+    const fromBoth = await personRelationshipsService.listPersonRelationships(db, parent.id)
+    expect(fromBoth).toHaveLength(2)
+    const kinds = fromBoth.map(
+      (row) => `${row.fromPersonId === parent.id ? "out" : "in"}:${row.kind}`,
+    )
+    expect(kinds.sort()).toEqual(["in:child", "out:parent"])
+  })
+
+  it("auto-inverse helper is idempotent on a re-run", async () => {
+    const parent = await seedPerson("Parent")
+    const child = await seedPerson("Child")
+    // Pre-populate the inverse edge directly.
+    await personRelationshipsService.createPersonRelationship(db, child.id, {
+      toPersonId: parent.id,
+      kind: "child",
+    })
+
+    // The auto-inverse path tries to insert (child, parent, child) but
+    // it's already there — the onConflictDoNothing should swallow the
+    // dup and the primary insert should succeed.
+    const created = await personRelationshipsService.createPersonRelationship(db, parent.id, {
+      toPersonId: child.id,
+      kind: "parent",
+      inverseKind: "child",
+    })
+    expect(created?.kind).toBe("parent")
+
+    const all = await personRelationshipsService.listPersonRelationships(db, parent.id)
+    expect(all).toHaveLength(2)
+  })
+
+  it("autoInverse: false skips the symmetric edge", async () => {
+    const parent = await seedPerson("Parent")
+    const child = await seedPerson("Child")
+    await personRelationshipsService.createPersonRelationship(db, parent.id, {
+      toPersonId: child.id,
+      kind: "parent",
+      inverseKind: "child",
+      autoInverse: false,
+    })
+    const all = await personRelationshipsService.listPersonRelationships(db, parent.id)
+    expect(all).toHaveLength(1)
+    expect(all[0]?.kind).toBe("parent")
+  })
+
+  it("listPersonRelationships filters by direction", async () => {
+    const a = await seedPerson("A")
+    const b = await seedPerson("B")
+    const c = await seedPerson("C")
+    await personRelationshipsService.createPersonRelationship(db, a.id, {
+      toPersonId: b.id,
+      kind: "friend",
+    })
+    await personRelationshipsService.createPersonRelationship(db, c.id, {
+      toPersonId: a.id,
+      kind: "sibling",
+    })
+
+    const both = await personRelationshipsService.listPersonRelationships(db, a.id)
+    expect(both).toHaveLength(2)
+
+    const out = await personRelationshipsService.listPersonRelationships(db, a.id, {
+      direction: "from",
+    })
+    expect(out.map((row) => row.toPersonId)).toEqual([b.id])
+
+    const incoming = await personRelationshipsService.listPersonRelationships(db, a.id, {
+      direction: "to",
+    })
+    expect(incoming.map((row) => row.fromPersonId)).toEqual([c.id])
+  })
+
+  it("update + delete operate on a single edge", async () => {
+    const a = await seedPerson("A")
+    const b = await seedPerson("B")
+    const created = await personRelationshipsService.createPersonRelationship(db, a.id, {
+      toPersonId: b.id,
+      kind: "friend",
+    })
+    if (!created) throw new Error("seed failure")
+
+    const updated = await personRelationshipsService.updatePersonRelationship(db, created.id, {
+      notes: "Met at conference",
+      isPrimary: true,
+    })
+    expect(updated?.notes).toBe("Met at conference")
+    expect(updated?.isPrimary).toBe(true)
+
+    const deleted = await personRelationshipsService.deletePersonRelationship(db, created.id)
+    expect(deleted?.id).toBe(created.id)
+
+    const after = await personRelationshipsService.getPersonRelationship(db, created.id)
+    expect(after).toBeNull()
+  })
+})

--- a/packages/db/src/lib/typeid-prefixes.ts
+++ b/packages/db/src/lib/typeid-prefixes.ts
@@ -88,6 +88,7 @@ export const PREFIXES = {
   organizations: "org",
   people: "pers",
   person_documents: "pdoc",
+  person_relationships: "prel",
   pipelines: "pipe",
   stages: "stg",
   opportunities: "opp",

--- a/templates/operator/migrations/0026_person_relationships.sql
+++ b/templates/operator/migrations/0026_person_relationships.sql
@@ -1,0 +1,36 @@
+CREATE TYPE "public"."person_relationship_kind" AS ENUM('spouse', 'partner', 'parent', 'child', 'sibling', 'guardian', 'ward', 'emergency_contact', 'friend', 'travel_companion', 'other');
+--> statement-breakpoint
+CREATE TABLE "person_relationships" (
+  "id" text PRIMARY KEY NOT NULL,
+  "from_person_id" text NOT NULL,
+  "to_person_id" text NOT NULL,
+  "kind" "person_relationship_kind" NOT NULL,
+  "inverse_kind" "person_relationship_kind",
+  "start_date" date,
+  "end_date" date,
+  "is_primary" boolean DEFAULT false NOT NULL,
+  "notes" text,
+  "metadata" jsonb,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "person_relationships_no_self" CHECK ("from_person_id" <> "to_person_id")
+);
+--> statement-breakpoint
+ALTER TABLE "person_relationships"
+  ADD CONSTRAINT "person_relationships_from_person_id_people_id_fk"
+  FOREIGN KEY ("from_person_id") REFERENCES "public"."people"("id")
+  ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "person_relationships"
+  ADD CONSTRAINT "person_relationships_to_person_id_people_id_fk"
+  FOREIGN KEY ("to_person_id") REFERENCES "public"."people"("id")
+  ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "idx_person_relationships_from"
+  ON "person_relationships" USING btree ("from_person_id");
+--> statement-breakpoint
+CREATE INDEX "idx_person_relationships_to"
+  ON "person_relationships" USING btree ("to_person_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_person_relationships_pair_kind"
+  ON "person_relationships" USING btree ("from_person_id", "to_person_id", "kind");

--- a/templates/operator/migrations/meta/_journal.json
+++ b/templates/operator/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1777891700000,
       "tag": "0025_user_email_nullable_phone",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1777891800000,
+      "tag": "0026_person_relationships",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes #442.

New `crm.person_relationships` table records directed `fromPerson → toPerson` edges of one of eleven kinds (`spouse`, `partner`, `parent`, `child`, `sibling`, `guardian`, `ward`, `emergency_contact`, `friend`, `travel_companion`, `other`). Optional `inverseKind` lets the service auto-write the symmetric edge in the same transaction (parent↔child, guardian↔ward) so operator UIs don't have to maintain both sides.

## Schema

- `(from_person_id, to_person_id, kind)` uniquely indexed — duplicate directional edges of the same kind are rejected at the DB layer.
- CHECK constraint `person_relationships_no_self` rejects self-edges.
- Both ends FK `crm.people` with `ON DELETE CASCADE`.
- Migration: `templates/operator/migrations/0026_person_relationships.sql`, registered in `meta/_journal.json`.

## API surface

- `crmService.listPersonRelationships(db, personId, { direction?: "from" | "to" | "both" })` — defaults to `both` so the typical "Jane's family" view returns the union of incoming + outgoing edges.
- `create / get / update / delete` service methods.
- Admin routes:
  - `GET/POST /v1/admin/crm/people/:id/relationships`
  - `GET/PATCH/DELETE /v1/admin/crm/person-relationships/:id`
- React hooks:
  - `usePersonRelationships(personId, { direction, kind })`
  - `usePersonRelationshipMutation(personId)` → `{ create, update, remove }`

## Tests

`packages/crm/tests/integration/person-relationships.test.ts`:

- CRUD basics (create / read / update / delete).
- Self-edge rejected.
- Missing person on either end returns null.
- `(from, to, kind)` uniqueness enforced; same pair with a different `kind` is fine.
- Auto-inverse helper writes both edges; idempotent on retry; `autoInverse: false` opts out.
- `listPersonRelationships` filters correctly by `direction: from | to | both`.

## Out of scope (deferred)

- UI components for the relationship graph.
- Phone-keyed emergency-contact convenience helpers (use `metadata` for now). The data layer is ready for both.

## Test plan

- [x] `pnpm typecheck` — 111/111 tasks pass.
- [x] `pnpm test` — 112/112 tasks pass.
- [ ] Apply `0026_person_relationships.sql` to a staging DB, verify constraints + auto-inverse with real data.