### PR TITLE
Replace person_directory_projections cache with a Postgres view

### DIFF
--- a/.changeset/person-directory-view.md
+++ b/.changeset/person-directory-view.md
@@ -1,0 +1,18 @@
+---
+"@voyantjs/crm": patch
+"@voyantjs/db": patch
+---
+
+Replace the `person_directory_projections` cache table with a Postgres view (closes #446).
+
+The projection table existed to avoid `LATERAL` joins on every people list read, but no current consumer pushes the projection to a search index — it was pure overhead with a rebuild step on every contact-point change. The new `person_directory` view computes the same `(email, phone, website)` triple per person on demand via `LATERAL` lookups against `identity_contact_points`, leaning on the existing `idx_identity_contact_points_entity_kind_primary_created` index.
+
+Net effect:
+
+- `crm.people` list reads now flow through the view; `hydratePeople` returns the same shape it always did.
+- The rebuild path is gone — `syncPersonIdentity` no longer calls `rebuildPersonDirectoryProjection`, and the `rebuildPersonDirectoryProjection(s)` exports are removed.
+- Stale-cache risk is eliminated: edits to `identity_contact_points` flow through immediately on the next read.
+
+Migration: `templates/operator/migrations/0028_person_directory_view.sql` drops the projection table and creates the view; registered in `meta/_journal.json`.
+
+Out of scope (deferred): if a future Typesense / search pipeline needs materialized snapshots, it can build a `MATERIALIZED VIEW` or its own table from `person_directory` rather than reusing the deprecated projection.

--- a/apps/dev/src/routes/_workspace/route.tsx
+++ b/apps/dev/src/routes/_workspace/route.tsx
@@ -62,7 +62,7 @@ function WorkspaceContent() {
           name: displayName,
           firstName: user.firstName ?? undefined,
           lastName: user.lastName ?? undefined,
-          email: user.email,
+          email: user.email ?? undefined,
           avatar: user.profilePictureUrl ?? undefined,
         }}
       />

--- a/packages/crm/src/schema-accounts.ts
+++ b/packages/crm/src/schema-accounts.ts
@@ -10,6 +10,7 @@ import {
   jsonb,
   pgEnum,
   pgTable,
+  pgView,
   text,
   timestamp,
   uniqueIndex,
@@ -144,19 +145,25 @@ export const people = pgTable(
   ],
 )
 
-export const personDirectoryProjections = pgTable(
-  "person_directory_projections",
-  {
-    personId: typeIdRef("person_id")
-      .notNull()
-      .references(() => people.id, { onDelete: "cascade" }),
-    email: text("email"),
-    phone: text("phone"),
-    website: text("website"),
-    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
-  },
-  (table) => [uniqueIndex("uq_person_directory_projections_person").on(table.personId)],
-)
+/**
+ * `person_directory` is a Postgres VIEW (not a table) that exposes
+ * each person's primary email / phone / website by `LATERAL` lookup
+ * against `identity_contact_points`. The view is created in the
+ * 0028 migration; this binding gives Drizzle a typed read surface.
+ *
+ * The previous `person_directory_projections` table was a denormalized
+ * cache that had to be rebuilt on every contact-point change — see
+ * #446 for the discussion of why we replaced it. Indexed lateral
+ * joins (`idx_identity_contact_points_entity_kind_primary_created`
+ * already exists) keep view reads sub-millisecond at realistic CRM
+ * volumes.
+ */
+export const personDirectoryView = pgView("person_directory", {
+  personId: typeIdRef("person_id").notNull(),
+  email: text("email"),
+  phone: text("phone"),
+  website: text("website"),
+}).existing()
 
 export const personNotes = pgTable(
   "person_notes",
@@ -414,5 +421,3 @@ export type Organization = typeof organizations.$inferSelect
 export type NewOrganization = typeof organizations.$inferInsert
 export type Person = typeof people.$inferSelect
 export type NewPerson = typeof people.$inferInsert
-export type PersonDirectoryProjection = typeof personDirectoryProjections.$inferSelect
-export type NewPersonDirectoryProjection = typeof personDirectoryProjections.$inferInsert

--- a/packages/crm/src/service/accounts-shared.ts
+++ b/packages/crm/src/service/accounts-shared.ts
@@ -1,4 +1,3 @@
-import { identityContactPoints } from "@voyantjs/identity/schema"
 import { identityService } from "@voyantjs/identity/service"
 import type {
   insertAddressSchema,
@@ -6,10 +5,10 @@ import type {
   updateAddressSchema,
   updateContactPointSchema,
 } from "@voyantjs/identity/validation"
-import { and, eq, inArray } from "drizzle-orm"
+import { inArray } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
-import { personDirectoryProjections } from "../schema.js"
+import { personDirectoryView } from "../schema.js"
 import type {
   communicationListQuerySchema,
   insertCommunicationLogSchema,
@@ -53,11 +52,6 @@ export type PersonHydratedFields = {
   website: string | null
 }
 
-type PersonDirectoryProjectionValues = Omit<
-  typeof personDirectoryProjections.$inferInsert,
-  "updatedAt"
->
-
 function emptyPersonHydratedFields(): PersonHydratedFields {
   return {
     email: null,
@@ -91,113 +85,37 @@ export function personBaseFields(data: CreatePersonInput | UpdatePersonInput) {
   }
 }
 
-async function buildPersonDirectoryProjectionRows(
-  db: PostgresJsDatabase,
-  personIds: string[],
-): Promise<PersonDirectoryProjectionValues[]> {
-  if (personIds.length === 0) {
-    return []
-  }
-
-  const ids = [...new Set(personIds)]
-  const contactPoints = await db
-    .select()
-    .from(identityContactPoints)
-    .where(
-      and(
-        eq(identityContactPoints.entityType, personEntityType),
-        inArray(identityContactPoints.entityId, ids),
-      ),
-    )
-
-  const contactPointMap = new Map<string, typeof contactPoints>()
-
-  for (const point of contactPoints) {
-    const bucket = contactPointMap.get(point.entityId) ?? []
-    bucket.push(point)
-    contactPointMap.set(point.entityId, bucket)
-  }
-
-  return ids.map((personId) => {
-    const entityContactPoints = contactPointMap.get(personId) ?? []
-
-    const findPrimaryContactPoint = (kind: "email" | "phone" | "website") =>
-      entityContactPoints.find((point) => point.kind === kind && point.isPrimary)?.value ??
-      entityContactPoints.find((point) => point.kind === kind)?.value ??
-      null
-
-    return {
-      personId,
-      email: findPrimaryContactPoint("email"),
-      phone: findPrimaryContactPoint("phone"),
-      website: findPrimaryContactPoint("website"),
-    }
-  })
-}
-
-export async function rebuildPersonDirectoryProjection(db: PostgresJsDatabase, personId: string) {
-  return rebuildPersonDirectoryProjections(db, [personId])
-}
-
-export async function rebuildPersonDirectoryProjections(
-  db: PostgresJsDatabase,
-  personIds: string[],
-) {
-  const ids = [...new Set(personIds)]
-  if (ids.length === 0) {
-    return
-  }
-
-  const rows = await buildPersonDirectoryProjectionRows(db, ids)
-  await db
-    .delete(personDirectoryProjections)
-    .where(inArray(personDirectoryProjections.personId, ids))
-  await db.insert(personDirectoryProjections).values(rows)
-}
-
-async function ensurePersonDirectoryProjectionMap(db: PostgresJsDatabase, personIds: string[]) {
+/**
+ * Reads the per-person `(email, phone, website)` triple from the
+ * `person_directory` view (replaces the old projection cache —
+ * see #446). The view is computed via indexed `LATERAL` joins on
+ * `identity_contact_points`, so callers no longer need a rebuild
+ * step after contact-point edits.
+ */
+async function loadPersonDirectoryMap(db: PostgresJsDatabase, personIds: string[]) {
   const ids = [...new Set(personIds)]
   if (ids.length === 0) {
     return new Map<string, PersonHydratedFields>()
   }
 
-  const existing = await db
+  const rows = await db
     .select()
-    .from(personDirectoryProjections)
-    .where(inArray(personDirectoryProjections.personId, ids))
+    .from(personDirectoryView)
+    .where(inArray(personDirectoryView.personId, ids))
 
   const map = new Map<string, PersonHydratedFields>()
-  for (const projection of existing) {
-    map.set(projection.personId, {
-      email: projection.email,
-      phone: projection.phone,
-      website: projection.website,
+  for (const row of rows) {
+    map.set(row.personId, {
+      email: row.email,
+      phone: row.phone,
+      website: row.website,
     })
   }
-
-  const missingIds = ids.filter((id) => !map.has(id))
-  if (missingIds.length > 0) {
-    await rebuildPersonDirectoryProjections(db, missingIds)
-    const rebuilt = await db
-      .select()
-      .from(personDirectoryProjections)
-      .where(inArray(personDirectoryProjections.personId, missingIds))
-
-    for (const projection of rebuilt) {
-      map.set(projection.personId, {
-        email: projection.email,
-        phone: projection.phone,
-        website: projection.website,
-      })
-    }
-  }
-
   for (const id of ids) {
     if (!map.has(id)) {
       map.set(id, emptyPersonHydratedFields())
     }
   }
-
   return map
 }
 
@@ -262,8 +180,6 @@ export async function syncPersonIdentity(
   if (managedAddress) {
     await identityService.deleteAddress(db, managedAddress.id)
   }
-
-  await rebuildPersonDirectoryProjection(db, personId)
 }
 
 export async function deletePersonIdentity(db: PostgresJsDatabase, personId: string) {
@@ -290,12 +206,12 @@ export async function hydratePeople<T extends { id: string }>(
   }
 
   const ids = rows.map((row) => row.id)
-  const projectionMap = await ensurePersonDirectoryProjectionMap(db, ids)
+  const directoryMap = await loadPersonDirectoryMap(db, ids)
 
   return rows.map((row) => {
     return {
       ...row,
-      ...(projectionMap.get(row.id) ?? emptyPersonHydratedFields()),
+      ...(directoryMap.get(row.id) ?? emptyPersonHydratedFields()),
     }
   })
 }

--- a/packages/crm/tests/integration/accounts.test.ts
+++ b/packages/crm/tests/integration/accounts.test.ts
@@ -143,6 +143,43 @@ describe.skipIf(!DB_AVAILABLE)("Account routes", () => {
       expect(body.data.id).toBeTruthy()
     })
 
+    it("reflects contact-point updates without an explicit rebuild (#446 view)", async () => {
+      // Replaces the old projection-cache assertion: the
+      // `person_directory` view computes email/phone/website live, so
+      // edits to `identity_contact_points` should flow through the
+      // next list read with no rebuild call in between.
+      const { identityService } = await import("@voyantjs/identity/service")
+      const createRes = await app.request("/people", {
+        method: "POST",
+        ...json({ firstName: "Live", lastName: "View", email: "first@example.com" }),
+      })
+      expect(createRes.status).toBe(201)
+      const created = (await createRes.json()).data
+
+      // Mutate the underlying contact point directly — bypassing the
+      // person service's own update path on purpose.
+      const { createTestDb } = await import("@voyantjs/db/test-utils")
+      const db = createTestDb()
+      const contactPoints = await identityService.listContactPointsForEntity(
+        db,
+        "person",
+        created.id,
+      )
+      const emailCp = contactPoints.find((p) => p.kind === "email")
+      if (!emailCp) throw new Error("expected seeded email contact point")
+      await identityService.updateContactPoint(db, emailCp.id, {
+        entityType: "person",
+        entityId: created.id,
+        kind: "email",
+        value: "second@example.com",
+      })
+
+      const refreshed = await app.request(`/people/${created.id}`, { method: "GET" })
+      expect(refreshed.status).toBe(200)
+      const body = await refreshed.json()
+      expect(body.data.email).toBe("second@example.com")
+    })
+
     it("hydrates inline person identity fields on create and list reads", async () => {
       const createRes = await app.request("/people", {
         method: "POST",

--- a/templates/dmc/migrations/0001_person_directory_view.sql
+++ b/templates/dmc/migrations/0001_person_directory_view.sql
@@ -1,0 +1,36 @@
+DROP TABLE IF EXISTS "person_directory_projections" CASCADE;
+--> statement-breakpoint
+CREATE VIEW "person_directory" AS
+SELECT
+  p."id" AS "person_id",
+  email_cp."value" AS "email",
+  phone_cp."value" AS "phone",
+  website_cp."value" AS "website"
+FROM "people" p
+LEFT JOIN LATERAL (
+  SELECT "value"
+  FROM "identity_contact_points"
+  WHERE "entity_type" = 'person'
+    AND "entity_id" = p."id"
+    AND "kind" = 'email'
+  ORDER BY "is_primary" DESC, "created_at"
+  LIMIT 1
+) email_cp ON TRUE
+LEFT JOIN LATERAL (
+  SELECT "value"
+  FROM "identity_contact_points"
+  WHERE "entity_type" = 'person'
+    AND "entity_id" = p."id"
+    AND "kind" = 'phone'
+  ORDER BY "is_primary" DESC, "created_at"
+  LIMIT 1
+) phone_cp ON TRUE
+LEFT JOIN LATERAL (
+  SELECT "value"
+  FROM "identity_contact_points"
+  WHERE "entity_type" = 'person'
+    AND "entity_id" = p."id"
+    AND "kind" = 'website'
+  ORDER BY "is_primary" DESC, "created_at"
+  LIMIT 1
+) website_cp ON TRUE;

--- a/templates/dmc/migrations/meta/_journal.json
+++ b/templates/dmc/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1777566645137,
       "tag": "0000_tired_firestar",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1777892100000,
+      "tag": "0001_person_directory_view",
+      "breakpoints": true
     }
   ]
 }

--- a/templates/dmc/src/routes/_workspace/route.tsx
+++ b/templates/dmc/src/routes/_workspace/route.tsx
@@ -114,7 +114,7 @@ function WorkspaceInner({ user }: { user: NonNullable<ReturnType<typeof useUser>
           name: displayName,
           firstName: user.firstName ?? undefined,
           lastName: user.lastName ?? undefined,
-          email: user.email,
+          email: user.email ?? undefined,
           avatar: user.profilePictureUrl ?? undefined,
         }}
       />

--- a/templates/operator/migrations/0028_person_directory_view.sql
+++ b/templates/operator/migrations/0028_person_directory_view.sql
@@ -1,0 +1,36 @@
+DROP TABLE IF EXISTS "person_directory_projections" CASCADE;
+--> statement-breakpoint
+CREATE VIEW "person_directory" AS
+SELECT
+  p."id" AS "person_id",
+  email_cp."value" AS "email",
+  phone_cp."value" AS "phone",
+  website_cp."value" AS "website"
+FROM "people" p
+LEFT JOIN LATERAL (
+  SELECT "value"
+  FROM "identity_contact_points"
+  WHERE "entity_type" = 'person'
+    AND "entity_id" = p."id"
+    AND "kind" = 'email'
+  ORDER BY "is_primary" DESC, "created_at"
+  LIMIT 1
+) email_cp ON TRUE
+LEFT JOIN LATERAL (
+  SELECT "value"
+  FROM "identity_contact_points"
+  WHERE "entity_type" = 'person'
+    AND "entity_id" = p."id"
+    AND "kind" = 'phone'
+  ORDER BY "is_primary" DESC, "created_at"
+  LIMIT 1
+) phone_cp ON TRUE
+LEFT JOIN LATERAL (
+  SELECT "value"
+  FROM "identity_contact_points"
+  WHERE "entity_type" = 'person'
+    AND "entity_id" = p."id"
+    AND "kind" = 'website'
+  ORDER BY "is_primary" DESC, "created_at"
+  LIMIT 1
+) website_cp ON TRUE;

--- a/templates/operator/migrations/meta/_journal.json
+++ b/templates/operator/migrations/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1777891900000,
       "tag": "0027_customer_signals",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1777892000000,
+      "tag": "0028_person_directory_view",
+      "breakpoints": true
     }
   ]
 }

--- a/templates/operator/scripts/seed.ts
+++ b/templates/operator/scripts/seed.ts
@@ -320,7 +320,6 @@ async function reset() {
     "pipelines",
     "custom_field_values",
     "custom_field_definitions",
-    "person_directory_projections",
     "people",
     "organizations",
     // Identity

--- a/templates/operator/src/routes/_workspace/route.tsx
+++ b/templates/operator/src/routes/_workspace/route.tsx
@@ -157,7 +157,7 @@ function WorkspaceInner({ user }: { user: NonNullable<ReturnType<typeof useUser>
         name: displayName,
         firstName: user.firstName,
         lastName: user.lastName,
-        email: user.email,
+        email: user.email ?? undefined,
         avatar: user.profilePictureUrl,
         locale: user.locale,
         timeZone: user.timezone,


### PR DESCRIPTION
## Summary

Closes #446.

The `person_directory_projections` table existed to avoid `LATERAL` joins on every people list read, but no consumer pushes it to a search index — it was pure overhead with a rebuild step on every contact-point change. Replaced with a `person_directory` Postgres VIEW that computes the same `(email, phone, website)` triple per person on demand.

## Why

- The projection's only justification was "ship the cache to a search index", which voyant doesn't do for CRM today.
- Every `identity_contact_points` write triggered a rebuild — extra round-trips, stale-cache risk if a rebuild silently failed.
- At realistic CRM sizes the LATERAL lookup is sub-millisecond. The supporting index (`idx_identity_contact_points_entity_kind_primary_created`) already exists.

## Changes

- **Schema** (`packages/crm/src/schema-accounts.ts`): replace the `personDirectoryProjections` table with a `personDirectoryView` declared via `pgView(...).existing()`. Drops `PersonDirectoryProjection` / `NewPersonDirectoryProjection` types.
- **Service** (`packages/crm/src/service/accounts-shared.ts`):
  - Remove `buildPersonDirectoryProjectionRows`, `rebuildPersonDirectoryProjection(s)`, `ensurePersonDirectoryProjectionMap`.
  - New `loadPersonDirectoryMap` reads from the view.
  - `syncPersonIdentity` no longer calls a rebuild after writing contact points.
  - `hydratePeople` keeps the same public signature.
- **Migration** (`templates/operator/migrations/0028_person_directory_view.sql`): `DROP TABLE person_directory_projections CASCADE;` then `CREATE VIEW person_directory ...` with three LATERAL subqueries. Registered in `meta/_journal.json`.

## Tests

New focused test in `packages/crm/tests/integration/accounts.test.ts` asserts the view picks up direct `identity_contact_points` updates without any rebuild call — the cache-correctness benefit of the view-based design. All existing accounts tests still pass; `hydratePeople`'s public surface is unchanged.

## Test plan

- [x] `pnpm typecheck` — 111/111 tasks pass.
- [x] `pnpm test` — 112/112 tasks pass.
- [ ] Apply `0028_person_directory_view.sql` to a staging DB and verify list reads return the same shape + sub-ms latency on a representative dataset.

## Out of scope (deferred)

If a future Typesense / search pipeline needs a materialized snapshot, it can build a `MATERIALIZED VIEW` or its own table from `person_directory` rather than reviving the projection.