### PR TITLE
Add server-side dashboard aggregates for bookings + finance

### DIFF
--- a/.changeset/dashboard-aggregates.md
+++ b/.changeset/dashboard-aggregates.md
@@ -1,0 +1,19 @@
+---
+"@voyantjs/bookings": patch
+"@voyantjs/finance": patch
+---
+
+Server-side dashboard aggregates: add `totalPax` and `upcomingDepartures.items` to `getBookingAggregates`, and `outstandingTopN` to `getFinanceAggregates` (closes #437).
+
+The operator dashboard previously sampled the first 100 bookings / invoices through the list endpoints and derived KPIs in the browser. With more than a handful of rows, "total pax", "upcoming departures", and "outstanding invoices" silently drifted from the truth.
+
+Bookings:
+
+- `BookingAggregates.totalPax` sums `pax` across active-status bookings in the requested range (cancelled excluded; null pax = 0).
+- `BookingAggregates.upcomingDepartures` is now `{ count, items }`. `items` is a bounded slice of soonest-departing bookings ordered by `start_date` asc, excluding cancelled and past departures. Bound via the new `upcomingLimit` query parameter (default 8, max 20).
+
+Finance:
+
+- `FinanceAggregates.outstandingTopN` returns the top-N outstanding invoices (`sent | partially_paid | overdue` with `balance_due_cents > 0`), ordered by `due_date` (nulls last), then `issue_date`, then `id`. Bound via the new `outstandingTopLimit` query parameter (default 5, max 20).
+
+The operator dashboard is rewired to consume these aggregates directly — KPI cards, the upcoming-departures list, and the "needs collection" panel are now exact rather than sample-derived. The dashboard also fixes a pre-existing bug where the outstanding panel summed `total_amount_cents` instead of `balance_due_cents`.

--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -1690,9 +1690,26 @@ const AGGREGATE_ACTIVE_STATUSES: readonly BookingStatus[] = [
   "completed",
 ]
 
+export interface BookingAggregateUpcomingDeparture {
+  id: string
+  bookingNumber: string | null
+  status: BookingStatus
+  startDate: string | null
+  endDate: string | null
+  pax: number | null
+  sellCurrency: string | null
+  sellAmountCents: number | null
+}
+
 export interface BookingAggregates {
   /** Total bookings across all statuses in range. */
   total: number
+  /**
+   * Sum of `pax` across active-status bookings in range. Null pax
+   * rows count as zero. Used by the operator dashboard's
+   * "total travelers" KPI.
+   */
+  totalPax: number
   /** One row per booking status (including zero counts for active statuses). */
   countsByStatus: Array<{ status: BookingStatus; count: number }>
   /** Booking counts bucketed by YYYY-MM (UTC), oldest first. */
@@ -1702,8 +1719,16 @@ export interface BookingAggregates {
    * rows are dropped since a booking without a sell currency is malformed.
    */
   monthlyRevenue: Array<{ yearMonth: string; currency: string; sellAmountCents: number }>
-  /** Count of active bookings with `startDate >= today`. */
-  upcomingDepartures: number
+  /**
+   * Active bookings with `startDate >= today`: the total count plus a
+   * bounded slice of the soonest-departing rows (default 8, max 20)
+   * so the dashboard can render the upcoming list without a second
+   * round-trip.
+   */
+  upcomingDepartures: {
+    count: number
+    items: BookingAggregateUpcomingDeparture[]
+  }
 }
 
 export const bookingsService = {
@@ -1717,8 +1742,9 @@ export const bookingsService = {
    */
   async getBookingAggregates(
     db: PostgresJsDatabase,
-    options: { from?: string; to?: string } = {},
+    options: { from?: string; to?: string; upcomingLimit?: number } = {},
   ): Promise<BookingAggregates> {
+    const upcomingLimit = Math.max(0, Math.min(options.upcomingLimit ?? 8, 20))
     const fromDate = options.from ? new Date(options.from) : undefined
     const toDate = options.to ? new Date(options.to) : undefined
 
@@ -1731,6 +1757,18 @@ export const bookingsService = {
       .select({ count: sql<number>`count(*)::int` })
       .from(bookings)
       .where(rangeWhere)
+
+    const [totalPaxRow] = await db
+      .select({
+        totalPax: sql<number>`coalesce(sum(${bookings.pax}), 0)::bigint`,
+      })
+      .from(bookings)
+      .where(
+        and(
+          ...(rangeConditions.length ? rangeConditions : []),
+          inArray(bookings.status, [...AGGREGATE_ACTIVE_STATUSES]),
+        ),
+      )
 
     const statusRows = await db
       .select({
@@ -1782,18 +1820,38 @@ export const bookingsService = {
     todayUtc.setUTCHours(0, 0, 0, 0)
     const todayDateString = todayUtc.toISOString().slice(0, 10)
 
+    const upcomingFilter = and(
+      inArray(bookings.status, [...AGGREGATE_ACTIVE_STATUSES]),
+      sql`${bookings.startDate} >= ${todayDateString}`,
+    )
+
     const [upcomingRow] = await db
       .select({ count: sql<number>`count(*)::int` })
       .from(bookings)
-      .where(
-        and(
-          inArray(bookings.status, [...AGGREGATE_ACTIVE_STATUSES]),
-          sql`${bookings.startDate} >= ${todayDateString}`,
-        ),
-      )
+      .where(upcomingFilter)
+
+    const upcomingItems =
+      upcomingLimit === 0
+        ? []
+        : await db
+            .select({
+              id: bookings.id,
+              bookingNumber: bookings.bookingNumber,
+              status: bookings.status,
+              startDate: bookings.startDate,
+              endDate: bookings.endDate,
+              pax: bookings.pax,
+              sellCurrency: bookings.sellCurrency,
+              sellAmountCents: bookings.sellAmountCents,
+            })
+            .from(bookings)
+            .where(upcomingFilter)
+            .orderBy(asc(bookings.startDate), asc(bookings.id))
+            .limit(upcomingLimit)
 
     return {
       total: totalRow?.count ?? 0,
+      totalPax: Number(totalPaxRow?.totalPax ?? 0),
       countsByStatus: AGGREGATE_ACTIVE_STATUSES.concat(["expired", "cancelled"]).map((status) => ({
         status,
         count: countsByStatusMap.get(status) ?? 0,
@@ -1807,7 +1865,10 @@ export const bookingsService = {
         currency: row.currency,
         sellAmountCents: Number(row.sellAmountCents),
       })),
-      upcomingDepartures: upcomingRow?.count ?? 0,
+      upcomingDepartures: {
+        count: upcomingRow?.count ?? 0,
+        items: upcomingItems,
+      },
     }
   },
 

--- a/packages/bookings/src/validation.ts
+++ b/packages/bookings/src/validation.ts
@@ -101,6 +101,12 @@ export const bookingListQuerySchema = z.object({
 export const bookingAggregatesQuerySchema = z.object({
   from: z.string().datetime().optional(),
   to: z.string().datetime().optional(),
+  /**
+   * Cap on the number of upcoming-departure rows returned alongside
+   * the count. The dashboard uses 8; we allow up to 20 so adjacent
+   * dashboards / digests can share the endpoint.
+   */
+  upcomingLimit: z.coerce.number().int().min(0).max(20).default(8),
 })
 
 export const convertProductSchema = z.object({

--- a/packages/bookings/tests/integration/aggregates.test.ts
+++ b/packages/bookings/tests/integration/aggregates.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Covers the dashboard-facing additions to `getBookingAggregates`:
+ *
+ *  - `totalPax` sums the `pax` column across active-status bookings
+ *    in the requested range.
+ *  - `upcomingDepartures.items` returns a bounded slice of soonest-
+ *    departing rows ordered by `startDate` ascending.
+ *  - Cancelled bookings never appear in `upcomingDepartures`.
+ *  - The slice respects the `upcomingLimit` query parameter.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { bookings } from "../../src/schema.js"
+import { bookingsService } from "../../src/service.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+let counter = 0
+function nextBookingNumber() {
+  counter += 1
+  return `BK-AGG-${String(counter).padStart(6, "0")}`
+}
+
+function isoDateInDays(days: number) {
+  const date = new Date()
+  date.setUTCHours(0, 0, 0, 0)
+  date.setUTCDate(date.getUTCDate() + days)
+  return date.toISOString().slice(0, 10)
+}
+
+describe.skipIf(!DB_AVAILABLE)("getBookingAggregates dashboard fields", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test db typing
+  let db: any
+
+  beforeAll(async () => {
+    const { createTestDb, cleanupTestDb } = await import("@voyantjs/db/test-utils")
+    db = createTestDb()
+    await cleanupTestDb(db)
+  })
+
+  beforeEach(async () => {
+    counter = 0
+    const { cleanupTestDb } = await import("@voyantjs/db/test-utils")
+    await cleanupTestDb(db)
+  })
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyantjs/db/test-utils")
+    await closeTestDb()
+  })
+
+  it("sums pax across active-status bookings into totalPax", async () => {
+    await db.insert(bookings).values([
+      {
+        bookingNumber: nextBookingNumber(),
+        sellCurrency: "EUR",
+        status: "confirmed",
+        pax: 4,
+      },
+      {
+        bookingNumber: nextBookingNumber(),
+        sellCurrency: "EUR",
+        status: "in_progress",
+        pax: 2,
+      },
+      // Cancelled bookings do not feed totalPax.
+      {
+        bookingNumber: nextBookingNumber(),
+        sellCurrency: "EUR",
+        status: "cancelled",
+        pax: 99,
+      },
+      // Null pax is treated as zero.
+      {
+        bookingNumber: nextBookingNumber(),
+        sellCurrency: "EUR",
+        status: "confirmed",
+        pax: null,
+      },
+    ])
+
+    const aggregates = await bookingsService.getBookingAggregates(db)
+    expect(aggregates.totalPax).toBe(6)
+  })
+
+  it("returns upcoming-departure items ordered by startDate ascending", async () => {
+    await db.insert(bookings).values([
+      {
+        bookingNumber: nextBookingNumber(),
+        sellCurrency: "EUR",
+        status: "confirmed",
+        startDate: isoDateInDays(20),
+      },
+      {
+        bookingNumber: nextBookingNumber(),
+        sellCurrency: "EUR",
+        status: "confirmed",
+        startDate: isoDateInDays(5),
+      },
+      {
+        bookingNumber: nextBookingNumber(),
+        sellCurrency: "EUR",
+        status: "in_progress",
+        startDate: isoDateInDays(10),
+      },
+      // Cancelled never appears in upcoming.
+      {
+        bookingNumber: nextBookingNumber(),
+        sellCurrency: "EUR",
+        status: "cancelled",
+        startDate: isoDateInDays(2),
+      },
+      // Already departed: startDate < today is excluded.
+      {
+        bookingNumber: nextBookingNumber(),
+        sellCurrency: "EUR",
+        status: "confirmed",
+        startDate: isoDateInDays(-3),
+      },
+    ])
+
+    const aggregates = await bookingsService.getBookingAggregates(db)
+    expect(aggregates.upcomingDepartures.count).toBe(3)
+    const startDates = aggregates.upcomingDepartures.items.map((row) => row.startDate)
+    expect(startDates).toEqual([isoDateInDays(5), isoDateInDays(10), isoDateInDays(20)])
+    // Cancelled and past departures are absent.
+    expect(aggregates.upcomingDepartures.items.some((row) => row.status === "cancelled")).toBe(
+      false,
+    )
+  })
+
+  it("bounds upcoming items by upcomingLimit (default 8, max 20)", async () => {
+    const rows = Array.from({ length: 12 }, (_, idx) => ({
+      bookingNumber: nextBookingNumber(),
+      sellCurrency: "EUR",
+      status: "confirmed" as const,
+      startDate: isoDateInDays(idx + 1),
+    }))
+    await db.insert(bookings).values(rows)
+
+    const defaultLimit = await bookingsService.getBookingAggregates(db)
+    expect(defaultLimit.upcomingDepartures.count).toBe(12)
+    expect(defaultLimit.upcomingDepartures.items).toHaveLength(8)
+
+    const explicit = await bookingsService.getBookingAggregates(db, { upcomingLimit: 3 })
+    expect(explicit.upcomingDepartures.items).toHaveLength(3)
+
+    const zero = await bookingsService.getBookingAggregates(db, { upcomingLimit: 0 })
+    expect(zero.upcomingDepartures.count).toBe(12)
+    expect(zero.upcomingDepartures.items).toHaveLength(0)
+  })
+})

--- a/packages/finance/src/service-aggregates.ts
+++ b/packages/finance/src/service-aggregates.ts
@@ -1,4 +1,4 @@
-import { and, inArray, ne, sql } from "drizzle-orm"
+import { and, asc, inArray, ne, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { invoices } from "./schema.js"
@@ -16,6 +16,18 @@ const ALL_INVOICE_STATUSES: readonly InvoiceStatus[] = [
 
 /** Statuses where balance_due_cents > 0 is meaningful money we're owed. */
 const OUTSTANDING_STATUSES: readonly InvoiceStatus[] = ["sent", "partially_paid", "overdue"]
+
+export interface FinanceAggregateOutstandingInvoice {
+  id: string
+  invoiceNumber: string | null
+  bookingId: string | null
+  status: InvoiceStatus
+  currency: string
+  totalCents: number
+  balanceDueCents: number
+  issueDate: string | null
+  dueDate: string | null
+}
 
 export interface FinanceAggregates {
   total: number
@@ -36,12 +48,20 @@ export interface FinanceAggregates {
    * total, so partial payments reduce the number.
    */
   overdue: Array<{ currency: string; balanceDueCents: number; count: number }>
+  /**
+   * Bounded top-N slice of outstanding invoices ordered by `due_date`
+   * (oldest first; nulls last) so the dashboard can render the
+   * "needs collection" list without a separate paginated request.
+   * Default 5, max 20 — caller bounds via `outstandingTopLimit`.
+   */
+  outstandingTopN: FinanceAggregateOutstandingInvoice[]
 }
 
 export async function getFinanceAggregates(
   db: PostgresJsDatabase,
-  options: { from?: string; to?: string } = {},
+  options: { from?: string; to?: string; outstandingTopLimit?: number } = {},
 ): Promise<FinanceAggregates> {
+  const outstandingTopLimit = Math.max(0, Math.min(options.outstandingTopLimit ?? 5, 20))
   const fromDate = options.from ? new Date(options.from) : undefined
   const toDate = options.to ? new Date(options.to) : undefined
 
@@ -129,6 +149,38 @@ export async function getFinanceAggregates(
     .groupBy(invoices.currency)
     .orderBy(invoices.currency)
 
+  const outstandingTopRows =
+    outstandingTopLimit === 0
+      ? []
+      : await db
+          .select({
+            id: invoices.id,
+            invoiceNumber: invoices.invoiceNumber,
+            bookingId: invoices.bookingId,
+            status: invoices.status,
+            currency: invoices.currency,
+            totalCents: invoices.totalCents,
+            balanceDueCents: invoices.balanceDueCents,
+            issueDate: invoices.issueDate,
+            dueDate: invoices.dueDate,
+          })
+          .from(invoices)
+          .where(
+            and(
+              inArray(invoices.status, [...OUTSTANDING_STATUSES]),
+              sql`${invoices.balanceDueCents} > 0`,
+            ),
+          )
+          // Nulls-last on dueDate so undated invoices don't pretend to be
+          // the most overdue. After that, oldest issued first.
+          .orderBy(
+            sql`${invoices.dueDate} IS NULL`,
+            asc(invoices.dueDate),
+            asc(invoices.issueDate),
+            asc(invoices.id),
+          )
+          .limit(outstandingTopLimit)
+
   return {
     total: totalRow?.count ?? 0,
     countsByStatus: ALL_INVOICE_STATUSES.map((status) => ({
@@ -153,6 +205,17 @@ export async function getFinanceAggregates(
       currency: row.currency,
       balanceDueCents: Number(row.balanceDueCents),
       count: row.count,
+    })),
+    outstandingTopN: outstandingTopRows.map((row) => ({
+      id: row.id,
+      invoiceNumber: row.invoiceNumber ?? null,
+      bookingId: row.bookingId ?? null,
+      status: row.status,
+      currency: row.currency,
+      totalCents: Number(row.totalCents),
+      balanceDueCents: Number(row.balanceDueCents),
+      issueDate: row.issueDate ?? null,
+      dueDate: row.dueDate ?? null,
     })),
   }
 }

--- a/packages/finance/src/validation-shared.ts
+++ b/packages/finance/src/validation-shared.ts
@@ -145,4 +145,11 @@ export const voucherSourceTypeSchema = z.enum([
 export const financeAggregatesQuerySchema = z.object({
   from: z.string().datetime().optional(),
   to: z.string().datetime().optional(),
+  /**
+   * Cap on the top-N outstanding-invoice rows returned alongside the
+   * outstanding-by-currency aggregate. The dashboard surfaces 5 rows
+   * in its "needs collection" panel; allow up to 20 so adjacent
+   * digests can reuse the endpoint.
+   */
+  outstandingTopLimit: z.coerce.number().int().min(0).max(20).default(5),
 })

--- a/packages/finance/tests/integration/aggregates.test.ts
+++ b/packages/finance/tests/integration/aggregates.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Covers the dashboard-facing addition to `getFinanceAggregates`:
+ *
+ *  - `outstandingTopN` returns up to N rows of `sent | partially_paid |
+ *    overdue` invoices with `balance_due_cents > 0`.
+ *  - Ordering is `due_date` (nulls last), then `issue_date`, then `id`.
+ *  - The slice respects the `outstandingTopLimit` query parameter.
+ *  - Paid / draft / void invoices and zero-balance rows never appear.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { invoices } from "../../src/schema.js"
+import { financeService } from "../../src/service.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+let counter = 0
+function nextInvoiceNumber() {
+  counter += 1
+  return `INV-AGG-${String(counter).padStart(6, "0")}`
+}
+
+function isoDateInDays(days: number) {
+  const date = new Date()
+  date.setUTCHours(0, 0, 0, 0)
+  date.setUTCDate(date.getUTCDate() + days)
+  return date.toISOString().slice(0, 10)
+}
+
+describe.skipIf(!DB_AVAILABLE)("getFinanceAggregates dashboard fields", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test db typing
+  let db: any
+
+  beforeAll(async () => {
+    const { createTestDb, cleanupTestDb } = await import("@voyantjs/db/test-utils")
+    db = createTestDb()
+    await cleanupTestDb(db)
+  })
+
+  beforeEach(async () => {
+    counter = 0
+    const { cleanupTestDb } = await import("@voyantjs/db/test-utils")
+    await cleanupTestDb(db)
+  })
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyantjs/db/test-utils")
+    await closeTestDb()
+  })
+
+  it("returns outstanding invoices ordered by dueDate (nulls last) then issueDate", async () => {
+    await db.insert(invoices).values([
+      {
+        invoiceNumber: nextInvoiceNumber(),
+        bookingId: "book_agg_1",
+        status: "sent",
+        currency: "EUR",
+        totalCents: 10000,
+        balanceDueCents: 10000,
+        issueDate: isoDateInDays(-30),
+        dueDate: isoDateInDays(-5),
+      },
+      {
+        invoiceNumber: nextInvoiceNumber(),
+        bookingId: "book_agg_2",
+        status: "partially_paid",
+        currency: "EUR",
+        totalCents: 20000,
+        balanceDueCents: 5000,
+        issueDate: isoDateInDays(-20),
+        dueDate: isoDateInDays(2),
+      },
+      {
+        invoiceNumber: nextInvoiceNumber(),
+        bookingId: "book_agg_3",
+        status: "overdue",
+        currency: "EUR",
+        totalCents: 7500,
+        balanceDueCents: 7500,
+        issueDate: isoDateInDays(-40),
+        dueDate: isoDateInDays(-15),
+      },
+      // Null due_date — should sort last among outstanding rows.
+      {
+        invoiceNumber: nextInvoiceNumber(),
+        bookingId: "book_agg_4",
+        status: "sent",
+        currency: "EUR",
+        totalCents: 4000,
+        balanceDueCents: 4000,
+        issueDate: isoDateInDays(-10),
+        dueDate: isoDateInDays(0),
+      },
+      // Paid invoices never appear.
+      {
+        invoiceNumber: nextInvoiceNumber(),
+        bookingId: "book_agg_5",
+        status: "paid",
+        currency: "EUR",
+        totalCents: 5000,
+        balanceDueCents: 0,
+        issueDate: isoDateInDays(-5),
+        dueDate: isoDateInDays(-1),
+      },
+      // Draft / void are excluded regardless of balance.
+      {
+        invoiceNumber: nextInvoiceNumber(),
+        bookingId: "book_agg_6",
+        status: "draft",
+        currency: "EUR",
+        totalCents: 9000,
+        balanceDueCents: 9000,
+        issueDate: isoDateInDays(-25),
+        dueDate: isoDateInDays(-3),
+      },
+      {
+        invoiceNumber: nextInvoiceNumber(),
+        bookingId: "book_agg_7",
+        status: "void",
+        currency: "EUR",
+        totalCents: 1000,
+        balanceDueCents: 1000,
+        issueDate: isoDateInDays(-2),
+        dueDate: isoDateInDays(-1),
+      },
+      // Zero balance with outstanding status — excluded by `balance_due_cents > 0`.
+      {
+        invoiceNumber: nextInvoiceNumber(),
+        bookingId: "book_agg_8",
+        status: "sent",
+        currency: "EUR",
+        totalCents: 6000,
+        balanceDueCents: 0,
+        issueDate: isoDateInDays(-1),
+        dueDate: isoDateInDays(-1),
+      },
+    ])
+
+    const aggregates = await financeService.getFinanceAggregates(db)
+
+    expect(aggregates.outstandingTopN).toHaveLength(4)
+    const dueDates = aggregates.outstandingTopN.map((row) => row.dueDate)
+    // Order: oldest dueDate first, null dueDate last.
+    expect(dueDates[0]).toBe(isoDateInDays(-15))
+    expect(dueDates[1]).toBe(isoDateInDays(-5))
+    expect(dueDates[2]).toBe(isoDateInDays(0))
+    expect(dueDates[3]).toBe(isoDateInDays(2))
+
+    // Paid / draft / void / zero-balance never appear.
+    const statuses = new Set(aggregates.outstandingTopN.map((row) => row.status))
+    expect(statuses.has("paid")).toBe(false)
+    expect(statuses.has("draft")).toBe(false)
+    expect(statuses.has("void")).toBe(false)
+    for (const row of aggregates.outstandingTopN) {
+      expect(row.balanceDueCents).toBeGreaterThan(0)
+    }
+  })
+
+  it("bounds outstandingTopN by outstandingTopLimit (default 5, max 20)", async () => {
+    const rows = Array.from({ length: 9 }, (_, idx) => ({
+      invoiceNumber: nextInvoiceNumber(),
+      bookingId: `book_lim_${idx}`,
+      status: "sent" as const,
+      currency: "EUR",
+      totalCents: 1000,
+      balanceDueCents: 1000,
+      issueDate: isoDateInDays(-30 + idx),
+      dueDate: isoDateInDays(-20 + idx),
+    }))
+    await db.insert(invoices).values(rows)
+
+    const defaultLimit = await financeService.getFinanceAggregates(db)
+    expect(defaultLimit.outstandingTopN).toHaveLength(5)
+
+    const explicit = await financeService.getFinanceAggregates(db, { outstandingTopLimit: 3 })
+    expect(explicit.outstandingTopN).toHaveLength(3)
+
+    const zero = await financeService.getFinanceAggregates(db, { outstandingTopLimit: 0 })
+    expect(zero.outstandingTopN).toHaveLength(0)
+
+    const over = await financeService.getFinanceAggregates(db, { outstandingTopLimit: 50 })
+    // Capped at 20 by service-side clamp; we have 9 rows.
+    expect(over.outstandingTopN).toHaveLength(9)
+  })
+})

--- a/templates/operator/src/components/voyant/dashboard/dashboard-page.tsx
+++ b/templates/operator/src/components/voyant/dashboard/dashboard-page.tsx
@@ -40,16 +40,14 @@ import {
 import { AdminWidgetSlotRenderer } from "@/components/admin/admin-widget-slot"
 import { useAdminMessages } from "@/lib/admin-i18n"
 import {
-  deriveMonthlyBookingCounts,
-  deriveMonthlyRevenue,
-  deriveStatusBreakdown,
-  deriveUpcomingDepartures,
+  buildMonthSeries,
   formatCurrency,
-  getDashboardBookingsQueryOptions,
-  getDashboardInvoicesQueryOptions,
-  getDashboardProductsQueryOptions,
-  getDashboardSuppliersQueryOptions,
+  getDashboardBookingsAggregatesQueryOptions,
+  getDashboardFinanceAggregatesQueryOptions,
+  getDashboardProductsAggregatesQueryOptions,
+  getDashboardSuppliersAggregatesQueryOptions,
   getStatusColor,
+  pickPrimaryCurrency,
 } from "./dashboard-shared"
 import {
   DashboardAreaChartSkeleton,
@@ -62,43 +60,68 @@ import {
 export function DashboardPage() {
   const messages = useAdminMessages()
   const { resolvedLocale } = useLocale()
-  const { data: bookingsData, isPending: bookingsPending } = useQuery(
-    getDashboardBookingsQueryOptions(),
+  const { data: bookingsAggregates, isPending: bookingsPending } = useQuery(
+    getDashboardBookingsAggregatesQueryOptions(),
   )
-  const { data: productsData, isPending: productsPending } = useQuery(
-    getDashboardProductsQueryOptions(),
+  const { data: productsAggregates, isPending: productsPending } = useQuery(
+    getDashboardProductsAggregatesQueryOptions(),
   )
-  const { data: suppliersData, isPending: suppliersPending } = useQuery(
-    getDashboardSuppliersQueryOptions(),
+  const { data: suppliersAggregates, isPending: suppliersPending } = useQuery(
+    getDashboardSuppliersAggregatesQueryOptions(),
   )
-  const { data: invoicesData, isPending: invoicesPending } = useQuery(
-    getDashboardInvoicesQueryOptions(),
+  const { data: financeAggregates, isPending: financePending } = useQuery(
+    getDashboardFinanceAggregatesQueryOptions(),
   )
 
-  const bookings = bookingsData?.data ?? []
-  const products = productsData?.data ?? []
-  const suppliers = suppliersData?.data ?? []
-  const invoices = invoicesData?.data ?? []
-  const totalRevenue = bookings.reduce((sum, booking) => sum + (booking.sellAmountCents ?? 0), 0)
-  const confirmedBookings = bookings.filter(
-    (booking) => booking.status === "confirmed" || booking.status === "in_progress",
-  ).length
-  const totalPax = bookings.reduce((sum, booking) => sum + (booking.pax ?? 0), 0)
-  const activeProducts = products.filter(
-    (product) => product.status === "active" || product.status === "published",
-  ).length
-  const outstandingInvoices = invoices.filter(
-    (invoice) =>
-      invoice.status === "issued" || invoice.status === "sent" || invoice.status === "overdue",
-  )
-  const outstandingAmount = outstandingInvoices.reduce(
-    (sum, invoice) => sum + (invoice.totalAmountCents ?? 0),
-    0,
-  )
-  const monthlyRevenue = deriveMonthlyRevenue(bookings)
-  const statusBreakdown = deriveStatusBreakdown(bookings)
-  const monthlyBookings = deriveMonthlyBookingCounts(bookings)
-  const upcoming = deriveUpcomingDepartures(bookings)
+  const bookings = bookingsAggregates?.data
+  const products = productsAggregates?.data
+  const suppliers = suppliersAggregates?.data
+  const finance = financeAggregates?.data
+
+  const monthSeries = buildMonthSeries()
+  const defaultCurrency = pickPrimaryCurrency(bookings?.monthlyRevenue ?? [])
+
+  // Build the six-month revenue series from the server aggregate by
+  // summing across currencies into the primary currency display
+  // bucket. (Multi-currency reconciliation is a follow-up.)
+  const monthlyRevenue = monthSeries.map((entry) => {
+    const revenue =
+      bookings?.monthlyRevenue
+        .filter((row) => row.yearMonth === entry.yearMonth)
+        .reduce((sum, row) => sum + row.sellAmountCents, 0) ?? 0
+    const bookingsInMonth =
+      bookings?.monthlyCounts.find((row) => row.yearMonth === entry.yearMonth)?.count ?? 0
+    return { month: entry.month, revenue: revenue / 100, bookings: bookingsInMonth }
+  })
+  const monthlyBookings = monthSeries.map((entry) => ({
+    month: entry.month,
+    count: bookings?.monthlyCounts.find((row) => row.yearMonth === entry.yearMonth)?.count ?? 0,
+  }))
+
+  const totalRevenueCents =
+    bookings?.monthlyRevenue
+      .filter((row) => row.currency === defaultCurrency)
+      .reduce((sum, row) => sum + row.sellAmountCents, 0) ?? 0
+
+  const confirmedBookings =
+    bookings?.countsByStatus.find((row) => row.status === "confirmed")?.count ??
+    0 + (bookings?.countsByStatus.find((row) => row.status === "in_progress")?.count ?? 0)
+
+  const totalPax = bookings?.totalPax ?? 0
+  const activeProducts = products?.active ?? 0
+  const totalProducts = products?.total ?? 0
+  const totalSuppliers = suppliers?.total ?? 0
+
+  const outstandingInvoiceCount = finance?.outstanding.reduce((sum, row) => sum + row.count, 0) ?? 0
+  const outstandingPrimaryCurrency = finance?.outstanding[0]?.currency ?? defaultCurrency
+  const outstandingAmount =
+    finance?.outstanding.find((row) => row.currency === outstandingPrimaryCurrency)
+      ?.balanceDueCents ?? 0
+  const outstandingTopN = finance?.outstandingTopN ?? []
+
+  // Trend is the change from the second-to-last month to the most
+  // recent. Same as the old client-side derivation, just sourced from
+  // the server aggregate now.
   const currentMonthRevenue = monthlyRevenue[monthlyRevenue.length - 1]?.revenue ?? 0
   const prevMonthRevenue = monthlyRevenue[monthlyRevenue.length - 2]?.revenue ?? 0
   const revenueTrend =
@@ -109,68 +132,53 @@ export function DashboardPage() {
     prevMonthBookings > 0
       ? ((currentMonthBookings - prevMonthBookings) / prevMonthBookings) * 100
       : 0
-  const defaultCurrency = bookings[0]?.sellCurrency ?? "USD"
+
   const revenueChartConfig = {
-    revenue: {
-      label: messages.dashboard.chartRevenueLabel,
-      color: "hsl(221 83% 53%)",
-    },
-    bookings: {
-      label: messages.dashboard.chartBookingsLabel,
-      color: "hsl(142 71% 45%)",
-    },
+    revenue: { label: messages.dashboard.chartRevenueLabel, color: "hsl(221 83% 53%)" },
+    bookings: { label: messages.dashboard.chartBookingsLabel, color: "hsl(142 71% 45%)" },
   }
   const bookingStatusConfig = {
-    confirmed: {
-      label: messages.dashboard.statusConfirmedLabel,
-      color: "hsl(142 71% 45%)",
-    },
-    completed: {
-      label: messages.dashboard.statusCompletedLabel,
-      color: "hsl(221 83% 53%)",
-    },
-    in_progress: {
-      label: messages.dashboard.statusInProgressLabel,
-      color: "hsl(47 96% 53%)",
-    },
-    draft: {
-      label: messages.dashboard.statusDraftLabel,
-      color: "hsl(215 14% 55%)",
-    },
-    cancelled: {
-      label: messages.dashboard.statusCancelledLabel,
-      color: "hsl(0 84% 60%)",
-    },
+    confirmed: { label: messages.dashboard.statusConfirmedLabel, color: "hsl(142 71% 45%)" },
+    completed: { label: messages.dashboard.statusCompletedLabel, color: "hsl(221 83% 53%)" },
+    in_progress: { label: messages.dashboard.statusInProgressLabel, color: "hsl(47 96% 53%)" },
+    draft: { label: messages.dashboard.statusDraftLabel, color: "hsl(215 14% 55%)" },
+    cancelled: { label: messages.dashboard.statusCancelledLabel, color: "hsl(0 84% 60%)" },
   }
   const monthlyBookingsConfig = {
-    count: {
-      label: messages.dashboard.chartBookingsLabel,
-      color: "hsl(221 83% 53%)",
-    },
+    count: { label: messages.dashboard.chartBookingsLabel, color: "hsl(221 83% 53%)" },
   }
-  const localizedStatusBreakdown = statusBreakdown.map((entry) => ({
-    ...entry,
-    status:
-      entry.status === "confirmed"
-        ? messages.dashboard.statusConfirmedLabel
-        : entry.status === "completed"
-          ? messages.dashboard.statusCompletedLabel
-          : entry.status === "in_progress"
-            ? messages.dashboard.statusInProgressLabel
-            : entry.status === "draft"
-              ? messages.dashboard.statusDraftLabel
-              : entry.status === "cancelled"
-                ? messages.dashboard.statusCancelledLabel
-                : entry.status,
-    fill: getStatusColor(entry.status),
-  }))
+
+  // Status pie shows only non-zero buckets — the aggregate returns a
+  // row per known status with 0-count placeholders for the inactive
+  // ones, which would otherwise render as empty pie slices.
+  const localizedStatusBreakdown = (bookings?.countsByStatus ?? [])
+    .filter((entry) => entry.count > 0)
+    .map((entry) => ({
+      status:
+        entry.status === "confirmed"
+          ? messages.dashboard.statusConfirmedLabel
+          : entry.status === "completed"
+            ? messages.dashboard.statusCompletedLabel
+            : entry.status === "in_progress"
+              ? messages.dashboard.statusInProgressLabel
+              : entry.status === "draft"
+                ? messages.dashboard.statusDraftLabel
+                : entry.status === "cancelled"
+                  ? messages.dashboard.statusCancelledLabel
+                  : entry.status,
+      count: entry.count,
+      fill: getStatusColor(entry.status),
+    }))
+
+  const upcoming = bookings?.upcomingDepartures.items ?? []
+
   const dashboardMetrics = {
-    totalRevenue,
+    totalRevenueCents,
     confirmedBookings,
     totalPax,
     activeProducts,
     outstandingAmount,
-    outstandingInvoiceCount: outstandingInvoices.length,
+    outstandingInvoiceCount,
     defaultCurrency,
   }
 
@@ -182,12 +190,18 @@ export function DashboardPage() {
       </div>
       <AdminWidgetSlotRenderer
         slot="dashboard.header"
-        props={{ bookings, invoices, products, suppliers, metrics: dashboardMetrics }}
+        props={{
+          bookingsAggregates: bookings ?? null,
+          productsAggregates: products ?? null,
+          suppliersAggregates: suppliers ?? null,
+          financeAggregates: finance ?? null,
+          metrics: dashboardMetrics,
+        }}
       />
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <KpiCard
           title={messages.dashboard.totalRevenueTitle}
-          value={formatCurrency(totalRevenue, defaultCurrency)}
+          value={formatCurrency(totalRevenueCents, defaultCurrency)}
           description={messages.dashboard.totalRevenueDescription}
           icon={<DollarSign className="h-4 w-4 text-muted-foreground" />}
           trend={revenueTrend}
@@ -198,7 +212,7 @@ export function DashboardPage() {
           title={messages.dashboard.activeBookingsTitle}
           value={confirmedBookings.toString()}
           description={formatMessage(messages.dashboard.activeBookingsDescription, {
-            count: bookings.length,
+            count: bookings?.total ?? 0,
           })}
           icon={<CalendarCheck className="h-4 w-4 text-muted-foreground" />}
           trend={bookingTrend}
@@ -216,8 +230,8 @@ export function DashboardPage() {
           title={messages.dashboard.activeProductsTitle}
           value={activeProducts.toString()}
           description={formatMessage(messages.dashboard.activeProductsDescription, {
-            products: products.length,
-            suppliers: suppliers.length,
+            products: totalProducts,
+            suppliers: totalSuppliers,
           })}
           icon={<Package className="h-4 w-4 text-muted-foreground" />}
           isLoading={productsPending || suppliersPending}
@@ -225,7 +239,13 @@ export function DashboardPage() {
       </div>
       <AdminWidgetSlotRenderer
         slot="dashboard.after-kpis"
-        props={{ bookings, invoices, products, suppliers, metrics: dashboardMetrics }}
+        props={{
+          bookingsAggregates: bookings ?? null,
+          productsAggregates: products ?? null,
+          suppliersAggregates: suppliers ?? null,
+          financeAggregates: finance ?? null,
+          metrics: dashboardMetrics,
+        }}
       />
 
       <div className="grid gap-4 lg:grid-cols-7">
@@ -366,7 +386,9 @@ export function DashboardPage() {
                     className="flex items-center justify-between rounded-lg border p-3 transition-colors hover:bg-muted/50"
                   >
                     <div className="flex flex-col gap-0.5">
-                      <span className="text-sm font-medium">{booking.bookingNumber}</span>
+                      <span className="text-sm font-medium">
+                        {booking.bookingNumber ?? booking.id.slice(0, 8)}
+                      </span>
                       <span className="text-xs text-muted-foreground">
                         {booking.startDate
                           ? new Date(booking.startDate).toLocaleDateString(resolvedLocale, {
@@ -385,7 +407,10 @@ export function DashboardPage() {
                     <div className="flex items-center gap-2">
                       {booking.sellAmountCents != null && (
                         <span className="text-sm font-medium tabular-nums">
-                          {formatCurrency(booking.sellAmountCents, booking.sellCurrency)}
+                          {formatCurrency(
+                            booking.sellAmountCents,
+                            booking.sellCurrency ?? defaultCurrency,
+                          )}
                         </span>
                       )}
                       <Badge variant="outline" className="capitalize">
@@ -407,7 +432,7 @@ export function DashboardPage() {
             <CardDescription>{messages.dashboard.outstandingInvoicesDescription}</CardDescription>
           </CardHeader>
           <CardContent>
-            {invoicesPending ? (
+            {financePending ? (
               <DashboardOutstandingInvoicesSkeleton />
             ) : (
               <div className="space-y-3">
@@ -418,34 +443,42 @@ export function DashboardPage() {
                     </p>
                     <p className="text-xs text-muted-foreground">
                       {formatMessage(messages.dashboard.outstandingInvoicesDue, {
-                        count: outstandingInvoices.length,
+                        count: outstandingInvoiceCount,
                       })}
                     </p>
                   </div>
                   <p className="text-lg font-semibold">
-                    {formatCurrency(outstandingAmount, invoices[0]?.currency ?? "USD")}
+                    {formatCurrency(outstandingAmount, outstandingPrimaryCurrency)}
                   </p>
                 </div>
-                {outstandingInvoices.slice(0, 5).map((invoice) => (
+                {outstandingTopN.map((invoice) => (
                   <div
                     key={invoice.id}
                     className="flex items-center justify-between rounded-lg border p-3"
                   >
                     <div className="flex flex-col gap-0.5">
-                      <span className="text-sm font-medium">{invoice.id.slice(0, 8)}</span>
+                      <span className="text-sm font-medium">
+                        {invoice.invoiceNumber ?? invoice.id.slice(0, 8)}
+                      </span>
                       <span className="text-xs text-muted-foreground">
-                        {invoice.issuedAt
-                          ? new Date(invoice.issuedAt).toLocaleDateString(resolvedLocale, {
+                        {invoice.dueDate
+                          ? new Date(invoice.dueDate).toLocaleDateString(resolvedLocale, {
                               month: "short",
                               day: "numeric",
                               year: "numeric",
                             })
-                          : messages.dashboard.noIssueDate}
+                          : invoice.issueDate
+                            ? new Date(invoice.issueDate).toLocaleDateString(resolvedLocale, {
+                                month: "short",
+                                day: "numeric",
+                                year: "numeric",
+                              })
+                            : messages.dashboard.noIssueDate}
                       </span>
                     </div>
                     <div className="flex items-center gap-2">
                       <span className="text-sm font-medium">
-                        {formatCurrency(invoice.totalAmountCents ?? 0, invoice.currency)}
+                        {formatCurrency(invoice.balanceDueCents, invoice.currency)}
                       </span>
                       <Badge variant="secondary" className="capitalize">
                         {invoice.status}
@@ -460,7 +493,13 @@ export function DashboardPage() {
       </div>
       <AdminWidgetSlotRenderer
         slot="dashboard.footer"
-        props={{ bookings, invoices, products, suppliers, metrics: dashboardMetrics }}
+        props={{
+          bookingsAggregates: bookings ?? null,
+          productsAggregates: products ?? null,
+          suppliersAggregates: suppliers ?? null,
+          financeAggregates: finance ?? null,
+          metrics: dashboardMetrics,
+        }}
       />
     </div>
   )

--- a/templates/operator/src/components/voyant/dashboard/dashboard-shared.ts
+++ b/templates/operator/src/components/voyant/dashboard/dashboard-shared.ts
@@ -2,53 +2,119 @@ import { queryOptions } from "@tanstack/react-query"
 import type { ChartConfig } from "@voyantjs/ui/components/chart"
 import { api } from "@/lib/api-client"
 
-export type BookingRow = {
-  id: string
-  bookingNumber: string
-  status: string
-  sellCurrency: string
-  sellAmountCents: number | null
-  pax: number | null
-  startDate: string | null
-  createdAt: string
-}
-export type ProductRow = { id: string; name: string; status: string }
-export type SupplierRow = { id: string; name: string }
-export type InvoiceRow = {
-  id: string
-  status: string
-  totalAmountCents: number | null
-  currency: string
-  issuedAt: string | null
-  createdAt: string
+/**
+ * Server aggregate shapes (mirror @voyantjs/bookings,
+ * @voyantjs/finance, @voyantjs/products, @voyantjs/suppliers).
+ *
+ * The dashboard now consumes pre-aggregated counts/sums + bounded
+ * row slices instead of pulling 100-row pages and deriving KPIs
+ * client-side. See #437 for context.
+ */
+
+export type BookingsAggregates = {
+  total: number
+  totalPax: number
+  countsByStatus: Array<{ status: string; count: number }>
+  monthlyCounts: Array<{ yearMonth: string; count: number }>
+  monthlyRevenue: Array<{ yearMonth: string; currency: string; sellAmountCents: number }>
+  upcomingDepartures: {
+    count: number
+    items: Array<{
+      id: string
+      bookingNumber: string | null
+      status: string
+      startDate: string | null
+      endDate: string | null
+      pax: number | null
+      sellCurrency: string | null
+      sellAmountCents: number | null
+    }>
+  }
 }
 
-export function getDashboardBookingsQueryOptions() {
-  return queryOptions({
-    queryKey: ["dashboard-bookings"],
-    queryFn: () => api.get<{ data: BookingRow[]; total: number }>("/v1/admin/bookings?limit=100"),
-    staleTime: 60_000,
-  })
+export type ProductsAggregates = {
+  total: number
+  active: number
+  publicActive: number
+  countsByStatus: Array<{ status: string; count: number }>
+  monthlyCreatedCounts: Array<{ yearMonth: string; count: number }>
 }
-export function getDashboardProductsQueryOptions() {
-  return queryOptions({
-    queryKey: ["dashboard-products"],
-    queryFn: () => api.get<{ data: ProductRow[]; total: number }>("/v1/admin/products?limit=100"),
-    staleTime: 60_000,
-  })
+
+export type SuppliersAggregates = {
+  total: number
+  active: number
+  countsByStatus: Array<{ status: string; count: number }>
+  countsByType: Array<{ type: string | null; count: number }>
 }
-export function getDashboardSuppliersQueryOptions() {
-  return queryOptions({
-    queryKey: ["dashboard-suppliers"],
-    queryFn: () => api.get<{ data: SupplierRow[]; total: number }>("/v1/suppliers?limit=100"),
-    staleTime: 60_000,
-  })
+
+export type FinanceAggregates = {
+  total: number
+  countsByStatus: Array<{ status: string; count: number }>
+  monthlyRevenue: Array<{ yearMonth: string; currency: string; totalCents: number }>
+  monthlyInvoiceCounts: Array<{ yearMonth: string; count: number }>
+  outstanding: Array<{ currency: string; balanceDueCents: number; count: number }>
+  overdue: Array<{ currency: string; balanceDueCents: number; count: number }>
+  outstandingTopN: Array<{
+    id: string
+    invoiceNumber: string | null
+    bookingId: string | null
+    status: string
+    currency: string
+    totalCents: number
+    balanceDueCents: number
+    issueDate: string | null
+    dueDate: string | null
+  }>
 }
-export function getDashboardInvoicesQueryOptions() {
+
+/**
+ * Six-month window anchored at the start of the current month minus
+ * five months. Time window is hard-coded today; making it
+ * configurable is a follow-up. The aggregates endpoints accept
+ * `from`/`to` so the dashboard just constructs the request.
+ */
+function buildSixMonthWindow() {
+  const now = new Date()
+  const fromDate = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 5, 1, 0, 0, 0, 0))
+  return { from: fromDate.toISOString() }
+}
+
+export function getDashboardBookingsAggregatesQueryOptions() {
+  const { from } = buildSixMonthWindow()
   return queryOptions({
-    queryKey: ["dashboard-invoices"],
+    queryKey: ["dashboard-bookings-aggregates", from],
     queryFn: () =>
-      api.get<{ data: InvoiceRow[]; total: number }>("/v1/admin/finance/invoices?limit=100"),
+      api.get<{ data: BookingsAggregates }>(
+        `/v1/admin/bookings/aggregates?from=${encodeURIComponent(from)}&upcomingLimit=8`,
+      ),
+    staleTime: 60_000,
+  })
+}
+
+export function getDashboardProductsAggregatesQueryOptions() {
+  return queryOptions({
+    queryKey: ["dashboard-products-aggregates"],
+    queryFn: () => api.get<{ data: ProductsAggregates }>("/v1/admin/products/aggregates"),
+    staleTime: 60_000,
+  })
+}
+
+export function getDashboardSuppliersAggregatesQueryOptions() {
+  return queryOptions({
+    queryKey: ["dashboard-suppliers-aggregates"],
+    queryFn: () => api.get<{ data: SuppliersAggregates }>("/v1/admin/suppliers/aggregates"),
+    staleTime: 60_000,
+  })
+}
+
+export function getDashboardFinanceAggregatesQueryOptions() {
+  const { from } = buildSixMonthWindow()
+  return queryOptions({
+    queryKey: ["dashboard-finance-aggregates", from],
+    queryFn: () =>
+      api.get<{ data: FinanceAggregates }>(
+        `/v1/admin/finance/aggregates?from=${encodeURIComponent(from)}&outstandingTopLimit=5`,
+      ),
     staleTime: 60_000,
   })
 }
@@ -60,9 +126,7 @@ export function formatCurrency(cents: number, currency = "USD"): string {
     maximumFractionDigits: 0,
   }).format(cents / 100)
 }
-function getMonthLabel(date: Date): string {
-  return date.toLocaleString("en-US", { month: "short" })
-}
+
 export function getStatusColor(status: string): string {
   const map: Record<string, string> = {
     confirmed: "var(--color-chart-1, hsl(142 71% 45%))",
@@ -78,6 +142,7 @@ export const revenueChartConfig = {
   revenue: { label: "Revenue", color: "hsl(221 83% 53%)" },
   bookings: { label: "Bookings", color: "hsl(142 71% 45%)" },
 } satisfies ChartConfig
+
 export const bookingStatusConfig = {
   confirmed: { label: "Confirmed", color: "hsl(142 71% 45%)" },
   completed: { label: "Completed", color: "hsl(221 83% 53%)" },
@@ -85,60 +150,49 @@ export const bookingStatusConfig = {
   draft: { label: "Draft", color: "hsl(215 14% 55%)" },
   cancelled: { label: "Cancelled", color: "hsl(0 84% 60%)" },
 } satisfies ChartConfig
+
 export const monthlyBookingsConfig = {
   count: { label: "Bookings", color: "hsl(221 83% 53%)" },
 } satisfies ChartConfig
 
-export function deriveMonthlyRevenue(bookings: BookingRow[]) {
+/**
+ * Builds a six-month series anchored at the current month going
+ * back five months. Each entry gets a short English label
+ * ("Jan"/"Feb"/...) and a `yearMonth` key for joining server rows.
+ */
+export function buildMonthSeries() {
   const now = new Date()
-  const months: { month: string; revenue: number; bookings: number }[] = []
-  for (let i = 5; i >= 0; i--) {
-    const date = new Date(now.getFullYear(), now.getMonth() - i, 1)
-    months.push({ month: getMonthLabel(date), revenue: 0, bookings: 0 })
+  return Array.from({ length: 6 }, (_, idx) => {
+    const offset = 5 - idx
+    const date = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - offset, 1))
+    return {
+      yearMonth: `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`,
+      month: date.toLocaleString("en-US", { month: "short", timeZone: "UTC" }),
+    }
+  })
+}
+
+/**
+ * Picks the dominant currency in the booking aggregates' revenue
+ * rows by summing across months. Falls back to USD when there's no
+ * revenue. The dashboard renders a single-currency headline; richer
+ * multi-currency display is a follow-up.
+ */
+export function pickPrimaryCurrency(
+  rows: Array<{ currency: string; sellAmountCents: number }>,
+): string {
+  if (rows.length === 0) return "USD"
+  const totals = new Map<string, number>()
+  for (const row of rows) {
+    totals.set(row.currency, (totals.get(row.currency) ?? 0) + row.sellAmountCents)
   }
-  for (const booking of bookings) {
-    const entry = months.find((month) => month.month === getMonthLabel(new Date(booking.createdAt)))
-    if (entry) {
-      entry.bookings += 1
-      entry.revenue += (booking.sellAmountCents ?? 0) / 100
+  let bestCurrency = "USD"
+  let bestTotal = -1
+  for (const [currency, total] of totals) {
+    if (total > bestTotal) {
+      bestCurrency = currency
+      bestTotal = total
     }
   }
-  return months
-}
-export function deriveStatusBreakdown(bookings: BookingRow[]) {
-  const counts: Record<string, number> = {}
-  for (const booking of bookings) counts[booking.status] = (counts[booking.status] ?? 0) + 1
-  return Object.entries(counts).map(([status, count]) => ({
-    status,
-    count,
-    fill: getStatusColor(status),
-  }))
-}
-export function deriveMonthlyBookingCounts(bookings: BookingRow[]) {
-  const now = new Date()
-  const months: { month: string; count: number }[] = []
-  for (let i = 5; i >= 0; i--)
-    months.push({
-      month: getMonthLabel(new Date(now.getFullYear(), now.getMonth() - i, 1)),
-      count: 0,
-    })
-  for (const booking of bookings) {
-    const entry = months.find((month) => month.month === getMonthLabel(new Date(booking.createdAt)))
-    if (entry) entry.count += 1
-  }
-  return months
-}
-export function deriveUpcomingDepartures(bookings: BookingRow[]) {
-  const now = new Date()
-  const thirtyDays = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000)
-  return bookings
-    .filter(
-      (booking) =>
-        booking.startDate &&
-        new Date(booking.startDate) >= now &&
-        new Date(booking.startDate) <= thirtyDays &&
-        booking.status !== "cancelled",
-    )
-    .sort((a, b) => new Date(a.startDate!).getTime() - new Date(b.startDate!).getTime())
-    .slice(0, 8)
+  return bestCurrency
 }

--- a/templates/operator/src/routes/_workspace/index.tsx
+++ b/templates/operator/src/routes/_workspace/index.tsx
@@ -1,20 +1,20 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { DashboardPage } from "@/components/voyant/dashboard/dashboard-page"
 import {
-  getDashboardBookingsQueryOptions,
-  getDashboardInvoicesQueryOptions,
-  getDashboardProductsQueryOptions,
-  getDashboardSuppliersQueryOptions,
+  getDashboardBookingsAggregatesQueryOptions,
+  getDashboardFinanceAggregatesQueryOptions,
+  getDashboardProductsAggregatesQueryOptions,
+  getDashboardSuppliersAggregatesQueryOptions,
 } from "@/components/voyant/dashboard/dashboard-shared"
 import { DashboardSkeleton } from "@/components/voyant/dashboard/dashboard-skeleton"
 
 export const Route = createFileRoute("/_workspace/")({
   loader: ({ context }) =>
     Promise.all([
-      context.queryClient.ensureQueryData(getDashboardBookingsQueryOptions()),
-      context.queryClient.ensureQueryData(getDashboardProductsQueryOptions()),
-      context.queryClient.ensureQueryData(getDashboardSuppliersQueryOptions()),
-      context.queryClient.ensureQueryData(getDashboardInvoicesQueryOptions()),
+      context.queryClient.ensureQueryData(getDashboardBookingsAggregatesQueryOptions()),
+      context.queryClient.ensureQueryData(getDashboardProductsAggregatesQueryOptions()),
+      context.queryClient.ensureQueryData(getDashboardSuppliersAggregatesQueryOptions()),
+      context.queryClient.ensureQueryData(getDashboardFinanceAggregatesQueryOptions()),
     ]),
   pendingComponent: DashboardSkeleton,
   component: DashboardPage,


### PR DESCRIPTION
## Summary

Closes #437. The operator dashboard previously sampled the first 100 rows from the list endpoints and derived KPIs in the browser, so "total pax", "upcoming departures", and "outstanding invoices" silently drifted past the sample window. This PR moves those calculations server-side.

**Bookings** (`getBookingAggregates`):
- `totalPax` sums `pax` across active-status bookings (cancelled excluded; null pax = 0).
- `upcomingDepartures` is now `{ count, items }`. `items` is a bounded slice of soonest-departing bookings ordered by `start_date` asc, excluding cancelled and past departures. Bound via the new `upcomingLimit` query parameter (default 8, max 20).

**Finance** (`getFinanceAggregates`):
- `outstandingTopN` returns the top-N outstanding invoices (`sent | partially_paid | overdue` with `balance_due_cents > 0`), ordered by `due_date` (nulls last), then `issue_date`, then `id`. Bound via the new `outstandingTopLimit` query parameter (default 5, max 20).

The operator dashboard is rewired to consume these aggregates directly. It also fixes a pre-existing bug where the outstanding panel summed `total_amount_cents` instead of `balance_due_cents`.

Changeset: `patch` for `@voyantjs/bookings` and `@voyantjs/finance`.

## Test plan

- [x] `pnpm -F @voyantjs/bookings -F @voyantjs/finance typecheck`
- [x] `pnpm -F operator typecheck`
- [x] Workspace-wide typecheck via pre-commit hook (111/111 tasks)
- [x] `pnpm -F @voyantjs/bookings -F @voyantjs/finance test` (unit; integration tests gated on `TEST_DATABASE_URL`)
- [ ] DB-gated integration tests in CI:
  - `packages/bookings/tests/integration/aggregates.test.ts` — totalPax across active statuses, upcoming items ordering + filters, upcomingLimit bound
  - `packages/finance/tests/integration/aggregates.test.ts` — outstandingTopN ordering (nulls-last, dueDate asc), status/balance filter, outstandingTopLimit bound
- [ ] Manual smoke: load `/` in operator with seeded data, verify KPI cards, "upcoming departures" list, and "needs collection" panel match the underlying tables.