### PR TITLE
Make SmartBill mock emit live-compatible response envelopes

### DIFF
--- a/.changeset/smartbill-live-envelopes.md
+++ b/.changeset/smartbill-live-envelopes.md
@@ -1,0 +1,22 @@
+---
+"@voyantjs/plugin-smartbill": patch
+---
+
+Make `@voyantjs/plugin-smartbill/mock` return live-compatible SmartBill response envelopes by default, so a third-party SmartBill SDK can now point at the local mock as a sandbox (closes #436).
+
+Mock changes:
+
+- `GET /tax`, `GET /series`, `POST /invoice`, `POST /estimate`, `PUT /invoice/cancel|restore|reverse`, `DELETE /invoice`, `GET /invoice/paymentstatus`, `GET /estimate/invoices` now wrap their bodies in the live envelope shape (`status: "Ok" | "Error"`, `message`, `errorText`, plus payload fields). Errors emit `{ status: "Error", errorText, message }`.
+- `GET /series` returns the live single-letter `type` codes (`"f"` for invoice / factură, `"p"` for proforma).
+- `GET /invoice/paymentstatus` returns the live `paid: boolean` plus `invoiceTotalAmount` and a `payments` list (currently one entry per payment supplied at create time).
+- `GET /estimate/invoices` returns `areInvoicesCreated`, `series`, and `number` of the latest converted invoice.
+- `GET /invoice/pdf` and `GET /estimate/pdf` now return raw PDF bytes with `Content-Type: application/pdf`. The synthetic mock URL stays available via the `X-Mock-Pdf-Url` response header.
+
+Client changes (in-tree `createSmartbillClient`, breaking shape but private to this package — no other workspace package consumes the old shape):
+
+- `viewPdf` now returns `{ bytes: Uint8Array; contentType: string }`. Added `viewInvoicePdf` (same behaviour) and a new `viewEstimatePdf` for proforma PDFs. `viewPdf` is kept as an alias for `viewInvoicePdf`.
+- `getPaymentStatus` now returns the live envelope (`paid: boolean`, `invoiceTotalAmount`, `paidAmount`, `unpaidAmount`, `payments`, `status`, `message`, `errorText`). Callers should read `paid` instead of comparing `status === "paid"`. The settlement poller has been updated accordingly.
+- New methods: `restoreInvoice`, `listTaxes`, `listSeries`, `listEstimateInvoices`.
+- The client now treats any envelope with `status === "Error"` or a non-empty `errorText` as a thrown error, matching live SmartBill behaviour.
+
+`SmartbillFetch` is extended with `arrayBuffer()` and an optional `headers.get(name)` accessor — purely additive on top of the existing `fetch`-shape. New exported types: `SmartbillEnvelope`, `SmartbillTaxesResponse`, `SmartbillSeriesResponse`, `SmartbillEstimateInvoicesResponse`, `SmartbillPaymentEntry`.

--- a/packages/plugins/smartbill/src/client.ts
+++ b/packages/plugins/smartbill/src/client.ts
@@ -1,9 +1,13 @@
 import type {
+  SmartbillEnvelope,
+  SmartbillEstimateInvoicesResponse,
   SmartbillFetch,
   SmartbillInvoiceBody,
   SmartbillInvoiceResponse,
   SmartbillPdfResponse,
+  SmartbillSeriesResponse,
   SmartbillStatusResponse,
+  SmartbillTaxesResponse,
 } from "./types.js"
 
 /**
@@ -23,36 +27,67 @@ export interface SmartbillClientOptions {
 }
 
 export interface SmartbillClientApi {
-  /** Create an invoice. Returns the series + number + URL. */
+  /** Create an invoice. Returns the live envelope: series + number + URL + status/message. */
   createInvoice(body: SmartbillInvoiceBody): Promise<SmartbillInvoiceResponse>
   /** Create a proforma invoice. */
   createProforma(body: SmartbillInvoiceBody): Promise<SmartbillInvoiceResponse>
-  /** Cancel an invoice by series + number. */
+  /** Cancel an invoice by series + number. Returns the live envelope. */
   cancelInvoice(
     companyVatCode: string,
     seriesName: string,
     number: string,
-  ): Promise<{ errorText?: string }>
+  ): Promise<SmartbillEnvelope>
+  /** Restore a previously cancelled invoice. */
+  restoreInvoice(
+    companyVatCode: string,
+    seriesName: string,
+    number: string,
+  ): Promise<SmartbillEnvelope>
   /** Delete an invoice by series + number. */
   deleteInvoice(
     companyVatCode: string,
     seriesName: string,
     number: string,
-  ): Promise<{ errorText?: string }>
-  /** Reverse an invoice by series + number. */
+  ): Promise<SmartbillEnvelope>
+  /** Reverse an invoice — issues a credit-note style reversal invoice. */
   reverseInvoice(
     companyVatCode: string,
     seriesName: string,
     number: string,
   ): Promise<SmartbillInvoiceResponse>
-  /** Get PDF URL for an invoice. */
+  /** Download invoice PDF bytes. */
+  viewInvoicePdf(
+    companyVatCode: string,
+    seriesName: string,
+    number: string,
+  ): Promise<SmartbillPdfResponse>
+  /**
+   * Alias for {@link viewInvoicePdf}. Kept for backward compatibility with
+   * earlier client versions that only exposed an invoice PDF method.
+   */
   viewPdf(companyVatCode: string, seriesName: string, number: string): Promise<SmartbillPdfResponse>
+  /** Download proforma PDF bytes. */
+  viewEstimatePdf(
+    companyVatCode: string,
+    seriesName: string,
+    number: string,
+  ): Promise<SmartbillPdfResponse>
   /** Get payment status for an invoice. */
   getPaymentStatus(
     companyVatCode: string,
     seriesName: string,
     number: string,
   ): Promise<SmartbillStatusResponse>
+  /** List taxes configured on the SmartBill account. */
+  listTaxes(): Promise<SmartbillTaxesResponse>
+  /** List document series configured on the SmartBill account. */
+  listSeries(): Promise<SmartbillSeriesResponse>
+  /** List invoices created from a proforma (conversion lookup). */
+  listEstimateInvoices(
+    companyVatCode: string,
+    seriesName: string,
+    number: string,
+  ): Promise<SmartbillEstimateInvoicesResponse>
 }
 
 export function createSmartbillClient(options: SmartbillClientOptions): SmartbillClientApi {
@@ -71,11 +106,12 @@ export function createSmartbillClient(options: SmartbillClientOptions): Smartbil
     }
   }
 
-  async function request(
+  async function request<T extends SmartbillEnvelope>(
+    operation: string,
     method: string,
     path: string,
     body?: unknown,
-  ): Promise<{ ok: boolean; status: number; json: unknown; text: string }> {
+  ): Promise<T> {
     if (!fetchImpl) {
       throw new Error("SmartBill client requires a fetch implementation")
     }
@@ -86,59 +122,88 @@ export function createSmartbillClient(options: SmartbillClientOptions): Smartbil
     if (body !== undefined) init.body = JSON.stringify(body)
     const response = await fetchImpl(`${apiUrl}${path}`, init)
     let text = ""
-    let json: unknown = null
+    let parsed: unknown = null
     try {
       text = await response.text()
-      json = text ? JSON.parse(text) : null
+      parsed = text ? JSON.parse(text) : null
     } catch {
-      // leave json as null, surface text
+      // leave parsed as null, surface text
     }
-    return { ok: response.ok, status: response.status, json, text }
+    if (!response.ok) {
+      throw new Error(`SmartBill ${operation} failed (${response.status}): ${text}`)
+    }
+    const envelope = (parsed ?? {}) as T
+    if (envelope.status === "Error" || envelope.errorText) {
+      throw new Error(
+        `SmartBill ${operation} failed: ${envelope.errorText ?? envelope.message ?? "Error"}`,
+      )
+    }
+    return envelope
+  }
+
+  async function fetchPdf(operation: string, path: string): Promise<SmartbillPdfResponse> {
+    if (!fetchImpl) {
+      throw new Error("SmartBill client requires a fetch implementation")
+    }
+    const response = await fetchImpl(`${apiUrl}${path}`, {
+      method: "GET",
+      headers: { ...headers(), Accept: "application/pdf" },
+    })
+    if (!response.ok) {
+      const text = await response.text().catch(() => "")
+      throw new Error(`SmartBill ${operation} failed (${response.status}): ${text}`)
+    }
+    const buffer = await response.arrayBuffer()
+    const contentType = response.headers?.get("content-type") ?? "application/pdf"
+    return { bytes: new Uint8Array(buffer), contentType }
+  }
+
+  function pdfQuery(companyVatCode: string, seriesName: string, number: string) {
+    return `cif=${encodeURIComponent(companyVatCode)}&seriesname=${encodeURIComponent(seriesName)}&number=${encodeURIComponent(number)}`
   }
 
   async function createInvoice(body: SmartbillInvoiceBody): Promise<SmartbillInvoiceResponse> {
-    const res = await request("POST", "/invoice", body)
-    if (!res.ok) {
-      throw new Error(`SmartBill createInvoice failed (${res.status}): ${res.text}`)
-    }
-    return (res.json ?? {}) as SmartbillInvoiceResponse
+    return request<SmartbillInvoiceResponse>("createInvoice", "POST", "/invoice", body)
   }
 
   async function createProforma(body: SmartbillInvoiceBody): Promise<SmartbillInvoiceResponse> {
-    const res = await request("POST", "/estimate", body)
-    if (!res.ok) {
-      throw new Error(`SmartBill createProforma failed (${res.status}): ${res.text}`)
-    }
-    return (res.json ?? {}) as SmartbillInvoiceResponse
+    return request<SmartbillInvoiceResponse>("createProforma", "POST", "/estimate", body)
   }
 
   async function cancelInvoice(
     companyVatCode: string,
     seriesName: string,
     number: string,
-  ): Promise<{ errorText?: string }> {
-    const res = await request("PUT", "/invoice/cancel", {
+  ): Promise<SmartbillEnvelope> {
+    return request<SmartbillEnvelope>("cancelInvoice", "PUT", "/invoice/cancel", {
       companyVatCode,
       seriesName,
       number,
     })
-    if (!res.ok) {
-      throw new Error(`SmartBill cancelInvoice failed (${res.status}): ${res.text}`)
-    }
-    return (res.json ?? {}) as { errorText?: string }
+  }
+
+  async function restoreInvoice(
+    companyVatCode: string,
+    seriesName: string,
+    number: string,
+  ): Promise<SmartbillEnvelope> {
+    return request<SmartbillEnvelope>("restoreInvoice", "PUT", "/invoice/restore", {
+      companyVatCode,
+      seriesName,
+      number,
+    })
   }
 
   async function deleteInvoice(
     companyVatCode: string,
     seriesName: string,
     number: string,
-  ): Promise<{ errorText?: string }> {
-    const query = `cif=${encodeURIComponent(companyVatCode)}&seriesname=${encodeURIComponent(seriesName)}&number=${encodeURIComponent(number)}`
-    const res = await request("DELETE", `/invoice?${query}`)
-    if (!res.ok) {
-      throw new Error(`SmartBill deleteInvoice failed (${res.status}): ${res.text}`)
-    }
-    return (res.json ?? {}) as { errorText?: string }
+  ): Promise<SmartbillEnvelope> {
+    return request<SmartbillEnvelope>(
+      "deleteInvoice",
+      "DELETE",
+      `/invoice?${pdfQuery(companyVatCode, seriesName, number)}`,
+    )
   }
 
   async function reverseInvoice(
@@ -146,28 +211,33 @@ export function createSmartbillClient(options: SmartbillClientOptions): Smartbil
     seriesName: string,
     number: string,
   ): Promise<SmartbillInvoiceResponse> {
-    const res = await request("PUT", "/invoice/reverse", {
+    return request<SmartbillInvoiceResponse>("reverseInvoice", "PUT", "/invoice/reverse", {
       companyVatCode,
       seriesName,
       number,
     })
-    if (!res.ok) {
-      throw new Error(`SmartBill reverseInvoice failed (${res.status}): ${res.text}`)
-    }
-    return (res.json ?? {}) as SmartbillInvoiceResponse
   }
 
-  async function viewPdf(
+  async function viewInvoicePdf(
     companyVatCode: string,
     seriesName: string,
     number: string,
   ): Promise<SmartbillPdfResponse> {
-    const query = `cif=${encodeURIComponent(companyVatCode)}&seriesname=${encodeURIComponent(seriesName)}&number=${encodeURIComponent(number)}`
-    const res = await request("GET", `/invoice/pdf?${query}`)
-    if (!res.ok) {
-      throw new Error(`SmartBill viewPdf failed (${res.status}): ${res.text}`)
-    }
-    return (res.json ?? {}) as SmartbillPdfResponse
+    return fetchPdf(
+      "viewInvoicePdf",
+      `/invoice/pdf?${pdfQuery(companyVatCode, seriesName, number)}`,
+    )
+  }
+
+  async function viewEstimatePdf(
+    companyVatCode: string,
+    seriesName: string,
+    number: string,
+  ): Promise<SmartbillPdfResponse> {
+    return fetchPdf(
+      "viewEstimatePdf",
+      `/estimate/pdf?${pdfQuery(companyVatCode, seriesName, number)}`,
+    )
   }
 
   async function getPaymentStatus(
@@ -175,21 +245,46 @@ export function createSmartbillClient(options: SmartbillClientOptions): Smartbil
     seriesName: string,
     number: string,
   ): Promise<SmartbillStatusResponse> {
-    const query = `cif=${encodeURIComponent(companyVatCode)}&seriesname=${encodeURIComponent(seriesName)}&number=${encodeURIComponent(number)}`
-    const res = await request("GET", `/invoice/paymentstatus?${query}`)
-    if (!res.ok) {
-      throw new Error(`SmartBill getPaymentStatus failed (${res.status}): ${res.text}`)
-    }
-    return (res.json ?? {}) as SmartbillStatusResponse
+    return request<SmartbillStatusResponse>(
+      "getPaymentStatus",
+      "GET",
+      `/invoice/paymentstatus?${pdfQuery(companyVatCode, seriesName, number)}`,
+    )
+  }
+
+  async function listTaxes(): Promise<SmartbillTaxesResponse> {
+    return request<SmartbillTaxesResponse>("listTaxes", "GET", "/tax")
+  }
+
+  async function listSeries(): Promise<SmartbillSeriesResponse> {
+    return request<SmartbillSeriesResponse>("listSeries", "GET", "/series")
+  }
+
+  async function listEstimateInvoices(
+    companyVatCode: string,
+    seriesName: string,
+    number: string,
+  ): Promise<SmartbillEstimateInvoicesResponse> {
+    return request<SmartbillEstimateInvoicesResponse>(
+      "listEstimateInvoices",
+      "GET",
+      `/estimate/invoices?${pdfQuery(companyVatCode, seriesName, number)}`,
+    )
   }
 
   return {
     createInvoice,
     createProforma,
     cancelInvoice,
+    restoreInvoice,
     deleteInvoice,
     reverseInvoice,
-    viewPdf,
+    viewInvoicePdf,
+    viewPdf: viewInvoicePdf,
+    viewEstimatePdf,
     getPaymentStatus,
+    listTaxes,
+    listSeries,
+    listEstimateInvoices,
   }
 }

--- a/packages/plugins/smartbill/src/index.ts
+++ b/packages/plugins/smartbill/src/index.ts
@@ -36,11 +36,16 @@ export type {
 export { createSmartbillInvoiceSettlementPoller } from "./settlement.js"
 export type {
   SmartbillClient,
+  SmartbillEnvelope,
+  SmartbillEstimateInvoicesResponse,
   SmartbillFetch,
   SmartbillInvoiceBody,
   SmartbillInvoiceResponse,
+  SmartbillPaymentEntry,
   SmartbillPdfResponse,
   SmartbillProduct,
+  SmartbillSeriesResponse,
   SmartbillStatusResponse,
+  SmartbillTaxesResponse,
   VoyantInvoiceEvent,
 } from "./types.js"

--- a/packages/plugins/smartbill/src/mock.ts
+++ b/packages/plugins/smartbill/src/mock.ts
@@ -1,4 +1,13 @@
-import type { SmartbillFetch, SmartbillInvoiceBody, SmartbillInvoiceResponse } from "./types.js"
+import type {
+  SmartbillEstimateInvoicesResponse,
+  SmartbillFetch,
+  SmartbillInvoiceBody,
+  SmartbillInvoiceResponse,
+  SmartbillPaymentEntry,
+  SmartbillSeriesResponse,
+  SmartbillStatusResponse,
+  SmartbillTaxesResponse,
+} from "./types.js"
 
 export type SmartbillMockDocumentKind = "invoice" | "estimate"
 
@@ -31,6 +40,7 @@ export interface SmartbillMockDocument {
   url: string
   total: number
   paidAmount: number
+  payments: SmartbillPaymentEntry[]
   createdAt: string
   convertedInvoices: SmartbillInvoiceResponse[]
 }
@@ -60,7 +70,12 @@ export interface SmartbillMockRequest {
 export interface SmartbillMockResponse {
   status: number
   headers: Record<string, string>
-  body: string
+  /**
+   * Serialised body. JSON endpoints emit a UTF-8 string; PDF endpoints
+   * emit raw bytes. The HTTP listener writes both as-is; the in-process
+   * `fetch` adapter exposes them through the matching Response method.
+   */
+  body: string | Uint8Array
 }
 
 export interface SmartbillMockServer {
@@ -94,7 +109,7 @@ interface SmartbillNodeRequest extends AsyncIterable<Uint8Array | string> {
 interface SmartbillNodeResponse {
   setHeader: (key: string, value: string) => void
   statusCode: number
-  end: (body: string) => void
+  end: (body: string | Uint8Array) => void
 }
 
 interface SmartbillNodeServer {
@@ -174,7 +189,7 @@ export function createSmartbillMockServer(
         `Converted from proforma ${args.seriesName}-${args.number}`,
       ),
     })
-    const response = toDocumentResponse(invoice)
+    const response = toCreateResponse(invoice)
     estimate.convertedInvoices.push(response)
     documents.set(
       documentKey(estimate.kind, estimate.companyVatCode, estimate.seriesName, estimate.number),
@@ -189,44 +204,36 @@ export function createSmartbillMockServer(
     const path = normalizeSmartbillPath(url.pathname)
 
     try {
-      if (method === "GET" && path === "/tax") return json(200, taxes)
-      if (method === "GET" && path === "/series") return json(200, listSeries())
+      if (method === "GET" && path === "/tax") return json(200, taxesEnvelope(taxes))
+      if (method === "GET" && path === "/series") return json(200, seriesEnvelope(listSeries()))
 
       if (method === "POST" && path === "/invoice") {
-        return json(200, toDocumentResponse(createDocument("invoice", parseBody(request.body))))
+        return json(200, toCreateResponse(createDocument("invoice", parseBody(request.body))))
       }
 
       if (method === "POST" && path === "/estimate") {
-        return json(200, toDocumentResponse(createDocument("estimate", parseBody(request.body))))
+        return json(200, toCreateResponse(createDocument("estimate", parseBody(request.body))))
       }
 
       if (method === "GET" && path === "/invoice/pdf") {
-        return json(200, { url: findByQuery("invoice", url).url })
+        return pdf(findByQuery("invoice", url))
       }
 
       if (method === "GET" && path === "/estimate/pdf") {
-        return json(200, { url: findByQuery("estimate", url).url })
+        return pdf(findByQuery("estimate", url))
       }
 
       if (method === "GET" && path === "/estimate/invoices") {
-        return json(200, { invoices: findByQuery("estimate", url).convertedInvoices })
+        return json(200, estimateInvoicesEnvelope(findByQuery("estimate", url)))
       }
 
       if (method === "GET" && path === "/invoice/paymentstatus") {
-        const invoice = findByQuery("invoice", url)
-        return json(200, {
-          status:
-            invoice.status === "cancelled" || invoice.status === "deleted"
-              ? invoice.status
-              : paymentStatus(invoice),
-          paidAmount: invoice.paidAmount,
-          unpaidAmount: Math.max(0, invoice.total - invoice.paidAmount),
-        })
+        return json(200, paymentStatusEnvelope(findByQuery("invoice", url)))
       }
 
       if (method === "PUT" && path === "/invoice/cancel") {
-        updateInvoiceStatus(parseBody(request.body), "cancelled")
-        return json(200, {})
+        const invoice = updateInvoiceStatus(parseBody(request.body), "cancelled")
+        return json(200, ackEnvelope(`Invoice ${invoice.seriesName}-${invoice.number} cancelled`))
       }
 
       if (method === "PUT" && path === "/invoice/reverse") {
@@ -242,24 +249,25 @@ export function createSmartbillMockServer(
             `Reversal for ${invoice.seriesName}-${invoice.number}`,
           ),
         })
-        return json(200, toDocumentResponse(reversal))
+        return json(200, toCreateResponse(reversal))
       }
 
       if (method === "PUT" && path === "/invoice/restore") {
-        updateInvoiceStatus(parseBody(request.body), "restored")
-        return json(200, {})
+        const invoice = updateInvoiceStatus(parseBody(request.body), "restored")
+        return json(200, ackEnvelope(`Invoice ${invoice.seriesName}-${invoice.number} restored`))
       }
 
       if (method === "DELETE" && path === "/invoice") {
-        updateByQuery(url, "deleted")
-        return json(200, {})
+        const invoice = updateByQuery(url, "deleted")
+        return json(200, ackEnvelope(`Invoice ${invoice.seriesName}-${invoice.number} deleted`))
       }
 
-      return json(404, { errorText: `SmartBill mock endpoint not found: ${method} ${path}` })
+      return json(404, errorEnvelope(`SmartBill mock endpoint not found: ${method} ${path}`))
     } catch (error) {
-      return json(error instanceof SmartbillMockError ? error.status : 500, {
-        errorText: error instanceof Error ? error.message : "SmartBill mock failed",
-      })
+      return json(
+        error instanceof SmartbillMockError ? error.status : 500,
+        errorEnvelope(error instanceof Error ? error.message : "SmartBill mock failed"),
+      )
     }
   }
 
@@ -269,11 +277,29 @@ export function createSmartbillMockServer(
       url: input,
       body: init.body,
     })
+    const isBinary = response.body instanceof Uint8Array
+    const bytes = isBinary
+      ? (response.body as Uint8Array)
+      : new TextEncoder().encode(response.body as string)
+    const text = isBinary
+      ? new TextDecoder().decode(response.body as Uint8Array)
+      : (response.body as string)
     return {
       ok: response.status >= 200 && response.status < 300,
       status: response.status,
-      json: async () => JSON.parse(response.body),
-      text: async () => response.body,
+      json: async () => {
+        if (isBinary) throw new Error("SmartBill mock response is not JSON")
+        return JSON.parse(text)
+      },
+      text: async () => text,
+      arrayBuffer: async () => {
+        const copy = new ArrayBuffer(bytes.byteLength)
+        new Uint8Array(copy).set(bytes)
+        return copy
+      },
+      headers: {
+        get: (name) => response.headers[name.toLowerCase()] ?? null,
+      },
     }
   }
 
@@ -327,6 +353,17 @@ export function createSmartbillMockServer(
     const number = nextNumber(kind, seriesName)
     const companyVatCode = body.companyVatCode
     const total = totalAmount(body, taxes)
+    const paid = paidAmount(body, total)
+    const payments: SmartbillPaymentEntry[] = body.payment
+      ? [
+          {
+            type: body.payment.type,
+            value: paid,
+            paidDate: now().toISOString().slice(0, 10),
+            isCash: body.payment.isCash,
+          },
+        ]
+      : []
     const document: SmartbillMockDocument = {
       kind,
       companyVatCode,
@@ -339,7 +376,8 @@ export function createSmartbillMockServer(
       },
       url: `smartbill-mock://test-document/${kind}/${encodeURIComponent(companyVatCode)}/${encodeURIComponent(seriesName)}/${number}.pdf`,
       total,
-      paidAmount: paidAmount(body, total),
+      paidAmount: paid,
+      payments,
       createdAt: now().toISOString(),
       convertedInvoices: [],
     }
@@ -408,6 +446,21 @@ export function createSmartbillMockServer(
       documentKey("invoice", invoice.companyVatCode, invoice.seriesName, invoice.number),
       invoice,
     )
+    return invoice
+  }
+
+  function pdf(document: SmartbillMockDocument): SmartbillMockResponse {
+    const label = `${document.kind === "estimate" ? "Proforma" : "Invoice"} ${document.seriesName}-${document.number} (TEST)`
+    return {
+      status: 200,
+      headers: {
+        "access-control-allow-origin": "*",
+        "content-type": "application/pdf",
+        "content-disposition": `inline; filename="${document.seriesName}-${document.number}.pdf"`,
+        "x-mock-pdf-url": document.url,
+      },
+      body: createPlaceholderPdf(label),
+    }
   }
 
   reset()
@@ -500,17 +553,80 @@ function paidAmount(body: SmartbillInvoiceBody, total: number) {
   return roundMoney(Math.min(total, body.payment?.value ?? 0))
 }
 
-function paymentStatus(document: SmartbillMockDocument) {
-  if (document.paidAmount >= document.total && document.total > 0) return "paid"
-  if (document.paidAmount > 0) return "partially_paid"
-  return "unpaid"
-}
-
-function toDocumentResponse(document: SmartbillMockDocument): SmartbillInvoiceResponse {
+function toCreateResponse(document: SmartbillMockDocument): SmartbillInvoiceResponse {
   return {
+    status: "Ok",
+    message: "",
+    errorText: "",
     series: document.seriesName,
     number: document.number,
     url: document.url,
+  }
+}
+
+function ackEnvelope(message: string): SmartbillInvoiceResponse {
+  return { status: "Ok", message, errorText: "" }
+}
+
+function errorEnvelope(message: string): SmartbillInvoiceResponse {
+  return { status: "Error", message: "", errorText: message }
+}
+
+function taxesEnvelope(taxes: SmartbillMockTax[]): SmartbillTaxesResponse {
+  return {
+    status: "Ok",
+    message: "",
+    errorText: "",
+    taxes: taxes.map(({ name, percentage }) => ({ name, percentage })),
+  }
+}
+
+function seriesEnvelope(series: SmartbillMockSeries[]): SmartbillSeriesResponse {
+  return {
+    status: "Ok",
+    message: "",
+    errorText: "",
+    list: series.map((item) => ({
+      name: item.name,
+      nextNumber: item.nextNumber,
+      type: item.type === "invoice" ? "f" : "p",
+    })),
+  }
+}
+
+function paymentStatusEnvelope(document: SmartbillMockDocument): SmartbillStatusResponse {
+  const unpaid = Math.max(0, roundMoney(document.total - document.paidAmount))
+  return {
+    status: "Ok",
+    message: paymentStatusMessage(document),
+    errorText: "",
+    paid: document.total > 0 && document.paidAmount >= document.total,
+    invoiceTotalAmount: document.total,
+    paidAmount: document.paidAmount,
+    unpaidAmount: unpaid,
+    payments: document.payments.map((entry) => ({ ...entry })),
+  }
+}
+
+function paymentStatusMessage(document: SmartbillMockDocument): string {
+  if (document.status === "cancelled") return "Invoice cancelled"
+  if (document.status === "deleted") return "Invoice deleted"
+  if (document.status === "reversed") return "Invoice reversed"
+  return ""
+}
+
+function estimateInvoicesEnvelope(
+  estimate: SmartbillMockDocument,
+): SmartbillEstimateInvoicesResponse {
+  const last = estimate.convertedInvoices[estimate.convertedInvoices.length - 1]
+  return {
+    status: "Ok",
+    message: "",
+    errorText: "",
+    series: last?.series ?? "",
+    number: last?.number ?? "",
+    areInvoicesCreated: estimate.convertedInvoices.length > 0,
+    invoices: estimate.convertedInvoices.map((invoice) => ({ ...invoice })),
   }
 }
 
@@ -535,6 +651,7 @@ function cloneDocument(document: SmartbillMockDocument): SmartbillMockDocument {
   return {
     ...document,
     body: structuredClone(document.body),
+    payments: document.payments.map((entry) => ({ ...entry })),
     convertedInvoices: document.convertedInvoices.map((invoice) => ({ ...invoice })),
   }
 }
@@ -557,4 +674,49 @@ function concat(chunks: Uint8Array[]) {
 async function importNodeHttp(): Promise<SmartbillNodeHttp> {
   const specifier = "node:http"
   return import(specifier) as Promise<SmartbillNodeHttp>
+}
+
+/**
+ * Builds a small but well-formed single-page PDF that satisfies SDKs
+ * expecting `application/pdf` bytes. The label is rendered on the page
+ * so the file is recognisable when opened by hand.
+ */
+function createPlaceholderPdf(label: string): Uint8Array {
+  const escapedLabel = label.replace(/[()\\]/g, (m) => `\\${m}`)
+  const stream = `BT /F1 18 Tf 72 720 Td (${escapedLabel}) Tj ET`
+  const objects = [
+    "<< /Type /Catalog /Pages 2 0 R >>",
+    "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>",
+    `<< /Length ${stream.length} >>\nstream\n${stream}\nendstream`,
+    "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+  ]
+  const encoder = new TextEncoder()
+  const parts: Uint8Array[] = []
+  parts.push(encoder.encode("%PDF-1.4\n%"))
+  // Binary marker: any four bytes >=128 satisfy PDF readers' "this file is binary" probe.
+  parts.push(new Uint8Array([0xe2, 0xe3, 0xcf, 0xd3, 0x0a]))
+  let length = parts.reduce((sum, p) => sum + p.byteLength, 0)
+  const offsets: number[] = []
+  for (let i = 0; i < objects.length; i++) {
+    offsets.push(length)
+    const chunk = encoder.encode(`${i + 1} 0 obj\n${objects[i]}\nendobj\n`)
+    parts.push(chunk)
+    length += chunk.byteLength
+  }
+  const xrefStart = length
+  let xref = `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`
+  for (const off of offsets) {
+    xref += `${String(off).padStart(10, "0")} 00000 n \n`
+  }
+  xref += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefStart}\n%%EOF\n`
+  parts.push(encoder.encode(xref))
+  const total = parts.reduce((sum, p) => sum + p.byteLength, 0)
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const part of parts) {
+    out.set(part, offset)
+    offset += part.byteLength
+  }
+  return out
 }

--- a/packages/plugins/smartbill/src/plugin.ts
+++ b/packages/plugins/smartbill/src/plugin.ts
@@ -138,8 +138,13 @@ export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
             seriesName,
             number,
           )
+          const paymentLabel = status.paid
+            ? "paid"
+            : (status.paidAmount ?? 0) > 0
+              ? "partially_paid"
+              : "unpaid"
           logger.info?.(
-            `[smartbill] payment status for ${seriesName}-${number}: ${status.status}`,
+            `[smartbill] payment status for ${seriesName}-${number}: ${paymentLabel}`,
             status,
           )
         } catch (err) {

--- a/packages/plugins/smartbill/src/settlement.ts
+++ b/packages/plugins/smartbill/src/settlement.ts
@@ -114,18 +114,19 @@ export function createSmartbillInvoiceSettlementPoller(
     }
 
     const status = await client.getPaymentStatus(companyVatCode, seriesName, number)
+    const paid = status.paid === true
 
     return {
       externalId: externalRef.externalId ?? null,
       externalNumber: number,
-      status: status.status ?? null,
+      status: paid ? "paid" : "unpaid",
       paidAmountCents: toCents(status.paidAmount),
       unpaidAmountCents: toCents(status.unpaidAmount),
       settledAt:
-        status.status === "paid" && typeof status.paidAmount === "number" && status.paidAmount > 0
+        paid && typeof status.paidAmount === "number" && status.paidAmount > 0
           ? new Date().toISOString()
           : null,
-      syncError: status.errorText ?? null,
+      syncError: status.errorText ? status.errorText : null,
       metadata: {
         ...(metadata ?? {}),
         companyVatCode,

--- a/packages/plugins/smartbill/src/types.ts
+++ b/packages/plugins/smartbill/src/types.ts
@@ -72,37 +72,92 @@ export interface SmartbillInvoiceBody {
 }
 
 /**
- * SmartBill API response for invoice creation.
+ * Live-API response envelope shared by most SmartBill endpoints.
+ *
+ * The live API returns `status: "Ok"` on success and `status: "Error"` (or
+ * an HTTP non-2xx) on failure. `errorText` carries the machine-readable
+ * cause; `message` is a human-readable note.
  */
-export interface SmartbillInvoiceResponse {
+export interface SmartbillEnvelope {
+  /** "Ok" on success, "Error" on failure. */
+  status?: string
+  message?: string
+  errorText?: string
+}
+
+/**
+ * SmartBill API response for invoice / estimate creation.
+ */
+export interface SmartbillInvoiceResponse extends SmartbillEnvelope {
   number?: string
   series?: string
   url?: string
-  errorText?: string
 }
 
 /**
- * SmartBill API response for PDF download.
+ * SmartBill API response for the PDF endpoints. Live SmartBill responds
+ * with raw PDF bytes and `Content-Type: application/pdf`.
  */
 export interface SmartbillPdfResponse {
-  url?: string
-  errorText?: string
+  /** Raw PDF bytes returned by SmartBill. */
+  bytes: Uint8Array
+  /** Content-Type header from the response. */
+  contentType: string
 }
 
 /**
- * SmartBill API response for invoice status.
+ * SmartBill API response for `GET /invoice/paymentstatus`.
+ *
+ * Live shape: the envelope's `status` is `"Ok"` / `"Error"`, while payment
+ * state is carried by `paid: boolean` plus the amount fields. `payments`
+ * is the per-receipt list. The mock and the live API both populate these.
  */
-export interface SmartbillStatusResponse {
-  status?: string
+export interface SmartbillStatusResponse extends SmartbillEnvelope {
+  /** True when the invoice has been fully paid. */
+  paid?: boolean
+  invoiceTotalAmount?: number
   paidAmount?: number
   unpaidAmount?: number
-  errorText?: string
+  payments?: SmartbillPaymentEntry[]
+}
+
+export interface SmartbillPaymentEntry {
+  type?: string
+  value?: number
+  paidDate?: string
+  [key: string]: unknown
 }
 
 /**
- * Minimal `fetch` shape the SmartBill client depends on. Works with the global
- * `fetch` in Node 18+ / Cloudflare Workers / browsers, and is trivially
- * stubbable in tests.
+ * Response shape for `GET /tax`.
+ */
+export interface SmartbillTaxesResponse extends SmartbillEnvelope {
+  taxes?: Array<{ name: string; percentage: number }>
+}
+
+/**
+ * Response shape for `GET /series`. `type` is `"f"` (factură / invoice) or
+ * `"p"` (proformă).
+ */
+export interface SmartbillSeriesResponse extends SmartbillEnvelope {
+  list?: Array<{ name: string; nextNumber: number; type: "f" | "p" }>
+}
+
+/**
+ * Response shape for `GET /estimate/invoices` (proforma → invoice
+ * conversion lookup).
+ */
+export interface SmartbillEstimateInvoicesResponse extends SmartbillEnvelope {
+  series?: string
+  number?: string
+  areInvoicesCreated?: boolean
+  invoices?: SmartbillInvoiceResponse[]
+}
+
+/**
+ * Minimal `fetch` shape the SmartBill client depends on. Mirrors the
+ * subset of the global `fetch` Response that the client uses, so the
+ * global `fetch` and the mock server both fit.
  */
 export type SmartbillFetch = (
   input: string,
@@ -116,4 +171,6 @@ export type SmartbillFetch = (
   status: number
   json: () => Promise<unknown>
   text: () => Promise<string>
+  arrayBuffer: () => Promise<ArrayBuffer>
+  headers?: { get(name: string): string | null }
 }>

--- a/packages/plugins/smartbill/tests/unit/client.test.ts
+++ b/packages/plugins/smartbill/tests/unit/client.test.ts
@@ -5,22 +5,47 @@ import type { SmartbillFetch } from "../../src/types.js"
 
 function jsonResponse(status: number, body: unknown) {
   const text = JSON.stringify(body)
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => JSON.parse(text),
-    text: async () => text,
-  }
+  return makeResponse(status, text, "application/json; charset=utf-8")
 }
 
 function textResponse(status: number, text: string) {
+  return makeResponse(status, text, "text/plain")
+}
+
+function pdfResponse(status: number, bytes: Uint8Array, contentType = "application/pdf") {
   return {
     ok: status >= 200 && status < 300,
     status,
     json: async () => {
       throw new Error("not json")
     },
+    text: async () => new TextDecoder().decode(bytes),
+    arrayBuffer: async () => {
+      const copy = new ArrayBuffer(bytes.byteLength)
+      new Uint8Array(copy).set(bytes)
+      return copy
+    },
+    headers: {
+      get: (name: string) => (name.toLowerCase() === "content-type" ? contentType : null),
+    },
+  }
+}
+
+function makeResponse(status: number, text: string, contentType: string) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => JSON.parse(text),
     text: async () => text,
+    arrayBuffer: async () => {
+      const bytes = new TextEncoder().encode(text)
+      const copy = new ArrayBuffer(bytes.byteLength)
+      new Uint8Array(copy).set(bytes)
+      return copy
+    },
+    headers: {
+      get: (name: string) => (name.toLowerCase() === "content-type" ? contentType : null),
+    },
   }
 }
 
@@ -29,10 +54,12 @@ const baseOptions = {
   apiToken: "test-token",
 }
 
+const okEnvelope = { status: "Ok", message: "", errorText: "" }
+
 describe("createSmartbillClient.createInvoice", () => {
-  it("sends POST to /invoice with basic auth", async () => {
+  it("sends POST to /invoice with basic auth and returns the live envelope", async () => {
     const fetchMock = vi.fn<SmartbillFetch>(async () =>
-      jsonResponse(200, { number: "1", series: "A" }),
+      jsonResponse(200, { ...okEnvelope, number: "1", series: "A", url: "https://x/y.pdf" }),
     )
     const client = createSmartbillClient({ ...baseOptions, fetch: fetchMock })
     const result = await client.createInvoice({
@@ -51,7 +78,12 @@ describe("createSmartbillClient.createInvoice", () => {
         },
       ],
     })
-    expect(result).toEqual({ number: "1", series: "A" })
+    expect(result).toEqual({
+      ...okEnvelope,
+      number: "1",
+      series: "A",
+      url: "https://x/y.pdf",
+    })
     const [url, init] = fetchMock.mock.calls[0]!
     expect(url).toBe("https://ws.smartbill.ro/SBORO/api/invoice")
     expect(init.method).toBe("POST")
@@ -75,12 +107,28 @@ describe("createSmartbillClient.createInvoice", () => {
       }),
     ).rejects.toThrow(/SmartBill createInvoice failed \(400\)/)
   })
+
+  it("throws when the live envelope reports an error", async () => {
+    const fetchMock = vi.fn<SmartbillFetch>(async () =>
+      jsonResponse(200, { status: "Error", message: "", errorText: "Series not found" }),
+    )
+    const client = createSmartbillClient({ ...baseOptions, fetch: fetchMock })
+    await expect(
+      client.createInvoice({
+        companyVatCode: "RO123",
+        client: { name: "X" },
+        seriesName: "MISSING",
+        currency: "RON",
+        products: [],
+      }),
+    ).rejects.toThrow(/SmartBill createInvoice failed: Series not found/)
+  })
 })
 
 describe("createSmartbillClient.createProforma", () => {
   it("sends POST to /estimate", async () => {
     const fetchMock = vi.fn<SmartbillFetch>(async () =>
-      jsonResponse(200, { number: "P1", series: "P" }),
+      jsonResponse(200, { ...okEnvelope, number: "P1", series: "P" }),
     )
     const client = createSmartbillClient({ ...baseOptions, fetch: fetchMock })
     await client.createProforma({
@@ -97,9 +145,10 @@ describe("createSmartbillClient.createProforma", () => {
 
 describe("createSmartbillClient.cancelInvoice", () => {
   it("sends PUT to /invoice/cancel", async () => {
-    const fetchMock = vi.fn<SmartbillFetch>(async () => jsonResponse(200, {}))
+    const fetchMock = vi.fn<SmartbillFetch>(async () => jsonResponse(200, okEnvelope))
     const client = createSmartbillClient({ ...baseOptions, fetch: fetchMock })
-    await client.cancelInvoice("RO123", "A", "42")
+    const result = await client.cancelInvoice("RO123", "A", "42")
+    expect(result.status).toBe("Ok")
     const [url, init] = fetchMock.mock.calls[0]!
     expect(url).toBe("https://ws.smartbill.ro/SBORO/api/invoice/cancel")
     expect(init.method).toBe("PUT")
@@ -116,9 +165,20 @@ describe("createSmartbillClient.cancelInvoice", () => {
   })
 })
 
+describe("createSmartbillClient.restoreInvoice", () => {
+  it("sends PUT to /invoice/restore", async () => {
+    const fetchMock = vi.fn<SmartbillFetch>(async () => jsonResponse(200, okEnvelope))
+    const client = createSmartbillClient({ ...baseOptions, fetch: fetchMock })
+    await client.restoreInvoice("RO123", "A", "7")
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe("https://ws.smartbill.ro/SBORO/api/invoice/restore")
+    expect(init.method).toBe("PUT")
+  })
+})
+
 describe("createSmartbillClient.deleteInvoice", () => {
   it("sends DELETE to /invoice with query params", async () => {
-    const fetchMock = vi.fn<SmartbillFetch>(async () => jsonResponse(200, {}))
+    const fetchMock = vi.fn<SmartbillFetch>(async () => jsonResponse(200, okEnvelope))
     const client = createSmartbillClient({ ...baseOptions, fetch: fetchMock })
     await client.deleteInvoice("RO123", "A", "42")
     const [url, init] = fetchMock.mock.calls[0]!
@@ -130,47 +190,137 @@ describe("createSmartbillClient.deleteInvoice", () => {
 describe("createSmartbillClient.reverseInvoice", () => {
   it("sends PUT to /invoice/reverse", async () => {
     const fetchMock = vi.fn<SmartbillFetch>(async () =>
-      jsonResponse(200, { number: "S1", series: "S" }),
+      jsonResponse(200, { ...okEnvelope, number: "S1", series: "S" }),
     )
     const client = createSmartbillClient({ ...baseOptions, fetch: fetchMock })
     const result = await client.reverseInvoice("RO123", "A", "42")
-    expect(result).toEqual({ number: "S1", series: "S" })
+    expect(result).toMatchObject({ number: "S1", series: "S", status: "Ok" })
     const [url, init] = fetchMock.mock.calls[0]!
     expect(url).toBe("https://ws.smartbill.ro/SBORO/api/invoice/reverse")
     expect(init.method).toBe("PUT")
   })
 })
 
-describe("createSmartbillClient.viewPdf", () => {
-  it("sends GET to /invoice/pdf with query params", async () => {
-    const fetchMock = vi.fn<SmartbillFetch>(async () =>
-      jsonResponse(200, { url: "https://smartbill.ro/pdf/123" }),
-    )
+describe("createSmartbillClient PDF endpoints", () => {
+  const pdfBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34])
+
+  it("returns PDF bytes from /invoice/pdf", async () => {
+    const fetchMock = vi.fn<SmartbillFetch>(async () => pdfResponse(200, pdfBytes))
     const client = createSmartbillClient({ ...baseOptions, fetch: fetchMock })
-    const result = await client.viewPdf("RO123", "A", "42")
-    expect(result.url).toBe("https://smartbill.ro/pdf/123")
+    const result = await client.viewInvoicePdf("RO123", "A", "42")
+    expect(result.contentType).toBe("application/pdf")
+    expect(result.bytes).toBeInstanceOf(Uint8Array)
+    expect(Array.from(result.bytes)).toEqual(Array.from(pdfBytes))
     const [url, init] = fetchMock.mock.calls[0]!
     expect(url).toContain("/invoice/pdf?cif=RO123&seriesname=A&number=42")
     expect(init.method).toBe("GET")
+    expect(init.headers.Accept).toBe("application/pdf")
+  })
+
+  it("returns PDF bytes from /estimate/pdf", async () => {
+    const fetchMock = vi.fn<SmartbillFetch>(async () => pdfResponse(200, pdfBytes))
+    const client = createSmartbillClient({ ...baseOptions, fetch: fetchMock })
+    const result = await client.viewEstimatePdf("RO123", "P", "5")
+    expect(result.contentType).toBe("application/pdf")
+    const [url] = fetchMock.mock.calls[0]!
+    expect(url).toContain("/estimate/pdf?cif=RO123&seriesname=P&number=5")
+  })
+
+  it("falls back to application/pdf when no content-type header is exposed", async () => {
+    const fetchMock = vi.fn<SmartbillFetch>(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => null,
+      text: async () => "",
+      arrayBuffer: async () => {
+        const copy = new ArrayBuffer(pdfBytes.byteLength)
+        new Uint8Array(copy).set(pdfBytes)
+        return copy
+      },
+    }))
+    const client = createSmartbillClient({ ...baseOptions, fetch: fetchMock })
+    const result = await client.viewInvoicePdf("RO123", "A", "1")
+    expect(result.contentType).toBe("application/pdf")
+  })
+
+  it("throws on non-2xx PDF response", async () => {
+    const fetchMock = vi.fn<SmartbillFetch>(async () => textResponse(404, "not found"))
+    const client = createSmartbillClient({ ...baseOptions, fetch: fetchMock })
+    await expect(client.viewInvoicePdf("RO123", "A", "missing")).rejects.toThrow(
+      /SmartBill viewInvoicePdf failed \(404\)/,
+    )
   })
 })
 
 describe("createSmartbillClient.getPaymentStatus", () => {
-  it("sends GET to /invoice/paymentstatus", async () => {
+  it("returns the live paymentstatus envelope including paid bool and payments list", async () => {
     const fetchMock = vi.fn<SmartbillFetch>(async () =>
-      jsonResponse(200, { status: "paid", paidAmount: 100, unpaidAmount: 0 }),
+      jsonResponse(200, {
+        ...okEnvelope,
+        paid: true,
+        invoiceTotalAmount: 100,
+        paidAmount: 100,
+        unpaidAmount: 0,
+        payments: [{ type: "Card", value: 100, paidDate: "2026-05-07" }],
+      }),
     )
     const client = createSmartbillClient({ ...baseOptions, fetch: fetchMock })
     const result = await client.getPaymentStatus("RO123", "A", "42")
-    expect(result).toEqual({ status: "paid", paidAmount: 100, unpaidAmount: 0 })
+    expect(result.paid).toBe(true)
+    expect(result.paidAmount).toBe(100)
+    expect(result.unpaidAmount).toBe(0)
+    expect(result.payments).toEqual([{ type: "Card", value: 100, paidDate: "2026-05-07" }])
     const [url] = fetchMock.mock.calls[0]!
     expect(url).toContain("/invoice/paymentstatus?cif=RO123&seriesname=A&number=42")
   })
 })
 
+describe("createSmartbillClient list endpoints", () => {
+  it("listTaxes returns the live tax envelope", async () => {
+    const fetchMock = vi.fn<SmartbillFetch>(async () =>
+      jsonResponse(200, { ...okEnvelope, taxes: [{ name: "Normala", percentage: 19 }] }),
+    )
+    const client = createSmartbillClient({ ...baseOptions, fetch: fetchMock })
+    const result = await client.listTaxes()
+    expect(result.taxes).toEqual([{ name: "Normala", percentage: 19 }])
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://ws.smartbill.ro/SBORO/api/tax")
+  })
+
+  it("listSeries returns the live series envelope with single-letter type codes", async () => {
+    const fetchMock = vi.fn<SmartbillFetch>(async () =>
+      jsonResponse(200, {
+        ...okEnvelope,
+        list: [
+          { name: "FCT", nextNumber: 5, type: "f" },
+          { name: "PRF", nextNumber: 2, type: "p" },
+        ],
+      }),
+    )
+    const client = createSmartbillClient({ ...baseOptions, fetch: fetchMock })
+    const result = await client.listSeries()
+    expect(result.list?.map((entry) => entry.type)).toEqual(["f", "p"])
+  })
+
+  it("listEstimateInvoices includes areInvoicesCreated and converted invoice list", async () => {
+    const fetchMock = vi.fn<SmartbillFetch>(async () =>
+      jsonResponse(200, {
+        ...okEnvelope,
+        series: "A",
+        number: "1",
+        areInvoicesCreated: true,
+        invoices: [{ ...okEnvelope, series: "A", number: "1" }],
+      }),
+    )
+    const client = createSmartbillClient({ ...baseOptions, fetch: fetchMock })
+    const result = await client.listEstimateInvoices("RO123", "P", "1")
+    expect(result.areInvoicesCreated).toBe(true)
+    expect(result.invoices).toHaveLength(1)
+  })
+})
+
 describe("createSmartbillClient — custom apiUrl", () => {
   it("respects custom API base URL", async () => {
-    const fetchMock = vi.fn<SmartbillFetch>(async () => jsonResponse(200, {}))
+    const fetchMock = vi.fn<SmartbillFetch>(async () => jsonResponse(200, okEnvelope))
     const client = createSmartbillClient({
       ...baseOptions,
       apiUrl: "https://custom.example.com/api/",
@@ -184,7 +334,7 @@ describe("createSmartbillClient — custom apiUrl", () => {
 
 describe("createSmartbillClient — basic auth encoding", () => {
   it("encodes username:token as base64", async () => {
-    const fetchMock = vi.fn<SmartbillFetch>(async () => jsonResponse(200, {}))
+    const fetchMock = vi.fn<SmartbillFetch>(async () => jsonResponse(200, okEnvelope))
     const client = createSmartbillClient({
       username: "test@test.com",
       apiToken: "secret123",

--- a/packages/plugins/smartbill/tests/unit/mock.test.ts
+++ b/packages/plugins/smartbill/tests/unit/mock.test.ts
@@ -39,23 +39,89 @@ describe("createSmartbillMockServer", () => {
       ...invoiceBody,
       payment: { type: "Card", value: 200, isCash: false },
     })
-    expect(created).toEqual({
+    expect(created).toMatchObject({
+      status: "Ok",
       series: "SB",
       number: "1",
       url: "smartbill-mock://test-document/invoice/RO123/SB/1.pdf",
     })
 
-    const pdf = await client.viewPdf("RO123", "SB", "1")
-    expect(pdf.url).toContain("test-document/invoice/RO123/SB/1.pdf")
+    const pdf = await client.viewInvoicePdf("RO123", "SB", "1")
+    expect(pdf.contentType).toBe("application/pdf")
+    // PDFs start with the magic %PDF- header.
+    expect(new TextDecoder().decode(pdf.bytes.slice(0, 5))).toBe("%PDF-")
 
     const status = await client.getPaymentStatus("RO123", "SB", "1")
-    expect(status).toEqual({ status: "paid", paidAmount: 200, unpaidAmount: 0 })
+    expect(status).toMatchObject({
+      status: "Ok",
+      paid: true,
+      invoiceTotalAmount: 200,
+      paidAmount: 200,
+      unpaidAmount: 0,
+    })
+    expect(status.payments).toHaveLength(1)
+    expect(status.payments?.[0]).toMatchObject({ type: "Card", value: 200 })
 
-    await client.cancelInvoice("RO123", "SB", "1")
+    const cancelled = await client.cancelInvoice("RO123", "SB", "1")
+    expect(cancelled.status).toBe("Ok")
     expect(mock.getDocument("invoice", "RO123", "SB", "1")?.status).toBe("cancelled")
   })
 
-  it("tracks proforma conversion for /estimate/invoices polling", async () => {
+  it("returns the live envelope shape for /tax", async () => {
+    const mock = createSmartbillMockServer()
+    const response = await mock.handleRequest({
+      method: "GET",
+      url: "http://smartbill.local/SBORO/api/tax",
+    })
+    expect(response.headers["content-type"]).toMatch(/application\/json/)
+    const body = JSON.parse(response.body as string)
+    expect(body.status).toBe("Ok")
+    expect(body.taxes).toEqual(
+      expect.arrayContaining([
+        { name: "Normala", percentage: 19 },
+        { name: "Redusa", percentage: 9 },
+      ]),
+    )
+  })
+
+  it("returns the live envelope shape for /series with single-letter type codes", async () => {
+    const mock = createSmartbillMockServer()
+    const response = await mock.handleRequest({
+      method: "GET",
+      url: "http://smartbill.local/SBORO/api/series",
+    })
+    const body = JSON.parse(response.body as string)
+    expect(body.status).toBe("Ok")
+    expect(body.list).toEqual(
+      expect.arrayContaining([
+        { name: "SB-TEST", nextNumber: 1, type: "f" },
+        { name: "PF-TEST", nextNumber: 1, type: "p" },
+      ]),
+    )
+  })
+
+  it("returns PDF bytes with application/pdf and a debug URL header", async () => {
+    const mock = createSmartbillMockServer()
+    await mock.handleRequest({
+      method: "POST",
+      url: "http://smartbill.local/SBORO/api/invoice",
+      body: JSON.stringify(invoiceBody),
+    })
+
+    const pdf = await mock.handleRequest({
+      method: "GET",
+      url: "http://smartbill.local/SBORO/api/invoice/pdf?cif=RO123&seriesname=SB&number=1",
+    })
+    expect(pdf.headers["content-type"]).toBe("application/pdf")
+    expect(pdf.headers["x-mock-pdf-url"]).toContain("test-document/invoice/RO123/SB/1.pdf")
+    expect(pdf.body).toBeInstanceOf(Uint8Array)
+    const bytes = pdf.body as Uint8Array
+    // %PDF- header and %%EOF trailer mark a well-formed file.
+    expect(new TextDecoder().decode(bytes.slice(0, 5))).toBe("%PDF-")
+    expect(new TextDecoder().decode(bytes.slice(-6)).trim()).toBe("%%EOF")
+  })
+
+  it("tracks proforma conversion via /estimate/invoices with areInvoicesCreated", async () => {
     const mock = createSmartbillMockServer()
     const client = createSmartbillClient({
       ...baseOptions,
@@ -64,11 +130,9 @@ describe("createSmartbillMockServer", () => {
     })
 
     const estimate = await client.createProforma({ ...invoiceBody, seriesName: "PF" })
-    const before = await mock.handleRequest({
-      method: "GET",
-      url: "http://smartbill.local/estimate/invoices?cif=RO123&seriesname=PF&number=1",
-    })
-    expect(JSON.parse(before.body)).toEqual({ invoices: [] })
+    const before = await client.listEstimateInvoices("RO123", "PF", estimate.number ?? "")
+    expect(before.areInvoicesCreated).toBe(false)
+    expect(before.invoices).toEqual([])
 
     const invoice = mock.convertEstimateToInvoice({
       companyVatCode: "RO123",
@@ -77,11 +141,14 @@ describe("createSmartbillMockServer", () => {
       invoiceSeriesName: "SB",
     })
 
-    const after = await mock.handleRequest({
-      method: "GET",
-      url: "http://smartbill.local/estimate/invoices?cif=RO123&seriesname=PF&number=1",
+    const after = await client.listEstimateInvoices("RO123", "PF", estimate.number ?? "")
+    expect(after.areInvoicesCreated).toBe(true)
+    expect(after.invoices?.[0]).toMatchObject({
+      series: invoice.series,
+      number: invoice.number,
     })
-    expect(JSON.parse(after.body)).toEqual({ invoices: [invoice] })
+    expect(after.series).toBe(invoice.series)
+    expect(after.number).toBe(invoice.number)
   })
 
   it("includes VAT in payment status totals for tax-exclusive products", async () => {
@@ -108,8 +175,10 @@ describe("createSmartbillMockServer", () => {
       payment: { type: "Card", value: 100, isCash: false },
     })
 
-    await expect(client.getPaymentStatus("RO123", "SB", "1")).resolves.toEqual({
-      status: "partially_paid",
+    const status = await client.getPaymentStatus("RO123", "SB", "1")
+    expect(status).toMatchObject({
+      paid: false,
+      invoiceTotalAmount: 119,
       paidAmount: 100,
       unpaidAmount: 19,
     })
@@ -140,10 +209,25 @@ describe("createSmartbillMockServer", () => {
       payment: { type: "Card", value: 100, isCash: false },
     })
 
-    await expect(client.getPaymentStatus("RO123", "SB", "1")).resolves.toEqual({
-      status: "partially_paid",
+    const status = await client.getPaymentStatus("RO123", "SB", "1")
+    expect(status).toMatchObject({
+      paid: false,
+      invoiceTotalAmount: 121,
       paidAmount: 100,
       unpaidAmount: 21,
+    })
+  })
+
+  it("returns an error envelope when an invoice is not found", async () => {
+    const mock = createSmartbillMockServer()
+    const response = await mock.handleRequest({
+      method: "GET",
+      url: "http://smartbill.local/SBORO/api/invoice/paymentstatus?cif=RO123&seriesname=SB&number=999",
+    })
+    expect(response.status).toBe(404)
+    expect(JSON.parse(response.body as string)).toMatchObject({
+      status: "Error",
+      errorText: expect.stringContaining("not found"),
     })
   })
 
@@ -156,7 +240,11 @@ describe("createSmartbillMockServer", () => {
     })
 
     expect(response.status).toBe(200)
-    expect(JSON.parse(response.body)).toMatchObject({ series: "SB", number: "1" })
+    expect(JSON.parse(response.body as string)).toMatchObject({
+      status: "Ok",
+      series: "SB",
+      number: "1",
+    })
     expect(mock.getDocument("invoice", "RO123", "SB", "1")?.body.mentions).toContain(
       "TEST DOCUMENT",
     )

--- a/packages/plugins/smartbill/tests/unit/plugin.test.ts
+++ b/packages/plugins/smartbill/tests/unit/plugin.test.ts
@@ -11,26 +11,41 @@ function eventEnvelope<T>(data: T) {
   }
 }
 
-function jsonResponse(status: number, body: unknown) {
-  const text = JSON.stringify(body)
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => JSON.parse(text),
-    text: async () => text,
-  }
-}
-
-function textResponse(status: number, text: string) {
+function makeResponse(status: number, text: string, isJson: boolean) {
   return {
     ok: status >= 200 && status < 300,
     status,
     json: async () => {
-      throw new Error("not json")
+      if (!isJson) throw new Error("not json")
+      return JSON.parse(text)
     },
     text: async () => text,
+    arrayBuffer: async () => {
+      const bytes = new TextEncoder().encode(text)
+      const copy = new ArrayBuffer(bytes.byteLength)
+      new Uint8Array(copy).set(bytes)
+      return copy
+    },
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-type"
+          ? isJson
+            ? "application/json; charset=utf-8"
+            : "text/plain"
+          : null,
+    },
   }
 }
+
+function jsonResponse(status: number, body: unknown) {
+  return makeResponse(status, JSON.stringify(body), true)
+}
+
+function textResponse(status: number, text: string) {
+  return makeResponse(status, text, false)
+}
+
+const okEnvelope = { status: "Ok", message: "", errorText: "" }
 
 const baseOptions = {
   username: "user@test.com",
@@ -106,7 +121,7 @@ describe("smartbillPlugin structure", () => {
 describe("smartbillPlugin — invoice.issued subscriber", () => {
   it("calls createInvoice with mapped body", async () => {
     const fetchMock = vi.fn<SmartbillFetch>(async () =>
-      jsonResponse(200, { number: "1", series: "A" }),
+      jsonResponse(200, { ...okEnvelope, number: "1", series: "A" }),
     )
     const logger = makeLogger()
     const plugin = smartbillPlugin({ ...baseOptions, fetch: fetchMock, logger })
@@ -163,7 +178,7 @@ describe("smartbillPlugin — invoice.issued subscriber", () => {
 
 describe("smartbillPlugin — invoice.voided subscriber", () => {
   it("calls cancelInvoice with external number", async () => {
-    const fetchMock = vi.fn<SmartbillFetch>(async () => jsonResponse(200, {}))
+    const fetchMock = vi.fn<SmartbillFetch>(async () => jsonResponse(200, okEnvelope))
     const logger = makeLogger()
     const plugin = smartbillPlugin({ ...baseOptions, fetch: fetchMock, logger })
     const handler = subscriberFor(plugin, "invoice.voided").handler
@@ -187,7 +202,7 @@ describe("smartbillPlugin — invoice.voided subscriber", () => {
   })
 
   it("falls back to invoiceNumber when externalNumber missing", async () => {
-    const fetchMock = vi.fn<SmartbillFetch>(async () => jsonResponse(200, {}))
+    const fetchMock = vi.fn<SmartbillFetch>(async () => jsonResponse(200, okEnvelope))
     const logger = makeLogger()
     const plugin = smartbillPlugin({ ...baseOptions, fetch: fetchMock, logger })
     const handler = subscriberFor(plugin, "invoice.voided").handler
@@ -228,7 +243,13 @@ describe("smartbillPlugin — invoice.voided subscriber", () => {
 describe("smartbillPlugin — invoice.external.sync.requested subscriber", () => {
   it("calls getPaymentStatus and logs result", async () => {
     const fetchMock = vi.fn<SmartbillFetch>(async () =>
-      jsonResponse(200, { status: "paid", paidAmount: 100 }),
+      jsonResponse(200, {
+        ...okEnvelope,
+        paid: true,
+        invoiceTotalAmount: 100,
+        paidAmount: 100,
+        unpaidAmount: 0,
+      }),
     )
     const logger = makeLogger()
     const plugin = smartbillPlugin({ ...baseOptions, fetch: fetchMock, logger })
@@ -272,7 +293,7 @@ describe("smartbillPlugin — invoice.external.sync.requested subscriber", () =>
 describe("smartbillPlugin — custom mapEvent", () => {
   it("uses custom mapper when provided", async () => {
     const fetchMock = vi.fn<SmartbillFetch>(async () =>
-      jsonResponse(200, { number: "1", series: "A" }),
+      jsonResponse(200, { ...okEnvelope, number: "1", series: "A" }),
     )
     const logger = makeLogger()
     const customMapper = vi.fn().mockReturnValue({

--- a/packages/plugins/smartbill/tests/unit/settlement.test.ts
+++ b/packages/plugins/smartbill/tests/unit/settlement.test.ts
@@ -10,13 +10,31 @@ function jsonResponse(status: number, body: unknown) {
     status,
     json: async () => JSON.parse(text),
     text: async () => text,
+    arrayBuffer: async () => {
+      const bytes = new TextEncoder().encode(text)
+      const copy = new ArrayBuffer(bytes.byteLength)
+      new Uint8Array(copy).set(bytes)
+      return copy
+    },
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-type" ? "application/json; charset=utf-8" : null,
+    },
   }
 }
+
+const okEnvelope = { status: "Ok", message: "", errorText: "" }
 
 describe("createSmartbillInvoiceSettlementPoller", () => {
   it("queries SmartBill and normalizes paid amounts to cents", async () => {
     const fetchMock = vi.fn<SmartbillFetch>(async () =>
-      jsonResponse(200, { status: "paid", paidAmount: 123.45, unpaidAmount: 0 }),
+      jsonResponse(200, {
+        ...okEnvelope,
+        paid: true,
+        invoiceTotalAmount: 123.45,
+        paidAmount: 123.45,
+        unpaidAmount: 0,
+      }),
     )
 
     const poller = createSmartbillInvoiceSettlementPoller({
@@ -50,13 +68,20 @@ describe("createSmartbillInvoiceSettlementPoller", () => {
         seriesName: "SB",
       },
     })
+    expect(result.settledAt).toBeTruthy()
     const [url] = fetchMock.mock.calls[0]!
     expect(url).toContain("/invoice/paymentstatus?cif=RO12345678&seriesname=SB&number=1001")
   })
 
   it("falls back to external-ref metadata and returns sync errors for missing config", async () => {
     const fetchMock = vi.fn<SmartbillFetch>(async () =>
-      jsonResponse(200, { status: "open", paidAmount: 0, unpaidAmount: 10 }),
+      jsonResponse(200, {
+        ...okEnvelope,
+        paid: false,
+        invoiceTotalAmount: 10,
+        paidAmount: 0,
+        unpaidAmount: 10,
+      }),
     )
 
     const poller = createSmartbillInvoiceSettlementPoller({
@@ -82,10 +107,12 @@ describe("createSmartbillInvoiceSettlementPoller", () => {
 
     expect(success).toMatchObject({
       externalNumber: "77",
+      status: "unpaid",
       paidAmountCents: 0,
       unpaidAmountCents: 1000,
       syncError: null,
     })
+    expect(success.settledAt).toBeNull()
 
     const missingConfig = await poller({
       db: null as never,


### PR DESCRIPTION
## Summary

Closes #436. The mock previously returned a custom JSON shape — a third-party SmartBill SDK pointed at it would break on every endpoint. This PR rewrites the mock to mirror the live SmartBill API so it can be used as a drop-in local sandbox.

**Mock (HTTP path):**
- `GET /tax`, `/series`, `POST /invoice`, `/estimate`, `PUT /invoice/cancel|restore|reverse`, `DELETE /invoice`, `GET /invoice/paymentstatus`, `/estimate/invoices` all wrap their bodies in the live envelope shape (`status`, `message`, `errorText`). Errors emit `{ status: "Error", errorText, message }`.
- `/series` uses the live single-letter `type` codes (`"f"` / `"p"`).
- `/invoice/paymentstatus` exposes `paid: boolean`, `invoiceTotalAmount`, and a `payments` list seeded from the create-time payment.
- `/estimate/invoices` exposes `areInvoicesCreated`, `series`, `number` of the latest converted invoice.
- `/invoice/pdf` and `/estimate/pdf` return raw PDF bytes with `Content-Type: application/pdf`. The synthetic mock URL stays available via the `X-Mock-Pdf-Url` response header. The PDF body is a small but well-formed single-page document.

**Client + settlement adapt to the new envelopes:**
- The request helper throws on `status === "Error"` or non-empty `errorText`, matching live SmartBill behaviour.
- `viewPdf` returns `{ bytes, contentType }`; new `viewInvoicePdf` / `viewEstimatePdf`. `viewPdf` retained as an alias.
- New methods: `restoreInvoice`, `listTaxes`, `listSeries`, `listEstimateInvoices`.
- The settlement poller reads `paid: boolean` instead of comparing the envelope status string and emits a normalized `"paid"` / `"unpaid"`.

`SmartbillFetch` is extended with `arrayBuffer()` and an optional `headers.get()` accessor — purely additive on top of the existing fetch-shape. No other workspace package consumes the old shape (verified by repo-wide grep).

Patch-level changeset for `@voyantjs/plugin-smartbill`.

## Test plan

- [x] `pnpm -F @voyantjs/plugin-smartbill typecheck`
- [x] Workspace-wide typecheck via pre-commit hook (111/111 tasks)
- [x] `pnpm -F @voyantjs/plugin-smartbill test` → **67 tests pass** (was 49)
- [x] `pnpm -F @voyantjs/finance -F @voyantjs/identity-ui -F @voyantjs/products test` (re-run after pre-push hook hit a SIGTERM under load; all pass independently)
- [ ] Manual smoke: point a third-party SmartBill SDK at `mock.listen()` — invoice create / paymentstatus / pdf bytes round-trip end-to-end.