### PR TITLE
Fall back to product.sellCurrency in public pricing snapshot

### DIFF
--- a/.changeset/pricing-currency-fallback.md
+++ b/.changeset/pricing-currency-fallback.md
@@ -1,0 +1,11 @@
+---
+"@voyantjs/pricing": patch
+"@voyantjs/catalog-ui": patch
+"@voyantjs/bookings-ui": patch
+---
+
+Fall back to `product.sellCurrency` when `price_catalogs.currencyCode` is null in the public pricing snapshot, and stop silently labelling currency-less amounts as EUR.
+
+- `@voyantjs/pricing`: `getProductPricingSnapshot` now resolves the snapshot's `catalog.currencyCode` from the catalog when set, otherwise from the product's `sellCurrency`. Catalogs with a non-null `currencyCode` behave exactly as before; catalogs with `currency_code = NULL` follow each product's native currency, so multi-currency operators can use a single retail catalog instead of one catalog per currency.
+- `@voyantjs/catalog-ui`: `formatPriceCents` in the catalog detail sheet now renders plain digits (no currency symbol) when no currency is supplied, instead of mis-labelling amounts as EUR.
+- `@voyantjs/bookings-ui`: `formatMoney` in the booking payments summary handles a missing currency the same way.

--- a/packages/bookings-ui/src/components/booking-payments-summary.tsx
+++ b/packages/bookings-ui/src/components/booking-payments-summary.tsx
@@ -81,7 +81,7 @@ export function BookingPaymentsSummary({
   const totalCompleted = payments
     .filter((p) => p.status === "completed")
     .reduce((sum, p) => sum + p.amountCents, 0)
-  const currency = payments[0]?.currency ?? "EUR"
+  const currency = payments[0]?.currency ?? null
 
   return (
     <Card data-slot="booking-payments-summary">
@@ -183,7 +183,13 @@ export function BookingPaymentsSummary({
   )
 }
 
-function formatMoney(cents: number, currency: string): string {
+function formatMoney(cents: number, currency: string | null | undefined): string {
+  if (!currency) {
+    return new Intl.NumberFormat(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(cents / 100)
+  }
   try {
     return new Intl.NumberFormat(undefined, { style: "currency", currency }).format(cents / 100)
   } catch {

--- a/packages/catalog-ui/src/components/catalog-detail-sheet.tsx
+++ b/packages/catalog-ui/src/components/catalog-detail-sheet.tsx
@@ -670,9 +670,12 @@ function formatDeparture(iso: string): string {
 }
 
 function formatPriceCents(cents: number, currency?: string | null): string {
+  if (!currency) {
+    return new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(cents / 100)
+  }
   return new Intl.NumberFormat(undefined, {
     style: "currency",
-    currency: currency ?? "EUR",
+    currency,
     maximumFractionDigits: 0,
   }).format(cents / 100)
 }

--- a/packages/pricing/src/schema-catalogs.ts
+++ b/packages/pricing/src/schema-catalogs.ts
@@ -19,6 +19,7 @@ export const priceCatalogs = pgTable(
     id: typeId("price_catalogs"),
     code: text("code").notNull(),
     name: text("name").notNull(),
+    // NULL = follow product.sellCurrency at snapshot time (multi-currency catalog)
     currencyCode: text("currency_code"),
     catalogType: priceCatalogTypeEnum("catalog_type").notNull().default("public"),
     isDefault: boolean("is_default").notNull().default(false),

--- a/packages/pricing/src/service-public.ts
+++ b/packages/pricing/src/service-public.ts
@@ -29,6 +29,7 @@ async function ensurePublicProduct(db: PostgresJsDatabase, productId: string) {
       id: products.id,
       bookingMode: products.bookingMode,
       capacityMode: products.capacityMode,
+      sellCurrency: products.sellCurrency,
     })
     .from(products)
     .where(
@@ -130,7 +131,7 @@ export const publicPricingService = {
         productId,
         catalog: {
           ...catalog,
-          currencyCode: catalog.currencyCode ?? null,
+          currencyCode: catalog.currencyCode ?? product.sellCurrency,
         },
         options: [],
       }
@@ -304,7 +305,7 @@ export const publicPricingService = {
       productId,
       catalog: {
         ...catalog,
-        currencyCode: catalog.currencyCode ?? null,
+        currencyCode: catalog.currencyCode ?? product.sellCurrency,
       },
       options: options.map((option) => ({
         id: option.id,

--- a/packages/pricing/tests/integration/public-routes.test.ts
+++ b/packages/pricing/tests/integration/public-routes.test.ts
@@ -134,6 +134,7 @@ describe.skipIf(!DB_AVAILABLE)("Public pricing routes", () => {
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(body.data.catalog.code).toBe("PUBLIC-EUR")
+    expect(body.data.catalog.currencyCode).toBe("EUR")
     expect(body.data.options).toHaveLength(1)
     expect(body.data.options[0]?.pricingRules[0]?.baseSellAmountCents).toBe(2500)
     expect(body.data.options[0]?.pricingRules[0]?.unitPrices[0]?.unitName).toBe("Adult")
@@ -143,6 +144,58 @@ describe.skipIf(!DB_AVAILABLE)("Public pricing routes", () => {
     expect(body.data.options[0]?.pricingRules[0]?.startTimeAdjustments[0]?.startTimeLocal).toBe(
       "09:00",
     )
+  })
+
+  it("falls back to product.sellCurrency when catalog.currencyCode is null", async () => {
+    const [product] = await db
+      .insert(products)
+      .values({
+        name: "Bucharest City Tour",
+        status: "active",
+        activated: true,
+        visibility: "public",
+        sellCurrency: "RON",
+      })
+      .returning()
+
+    const [option] = await db
+      .insert(productOptions)
+      .values({
+        productId: product.id,
+        name: "Standard",
+        status: "active",
+        isDefault: true,
+      })
+      .returning()
+
+    const [catalog] = await db
+      .insert(priceCatalogs)
+      .values({
+        code: "PUBLIC-MULTI",
+        name: "Public Retail",
+        currencyCode: null,
+        catalogType: "public",
+        isDefault: true,
+        active: true,
+      })
+      .returning()
+
+    await db.insert(optionPriceRules).values({
+      productId: product.id,
+      optionId: option.id,
+      priceCatalogId: catalog.id,
+      name: "Default",
+      pricingMode: "per_person",
+      baseSellAmountCents: 18900,
+      isDefault: true,
+      active: true,
+    })
+
+    const res = await app.request(`/products/${product.id}/pricing`, { method: "GET" })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data.catalog.currencyCode).toBe("RON")
   })
 
   it("returns a public availability snapshot", async () => {

--- a/templates/operator/src/components/admin/widgets/dashboard-outstanding-invoices-widget.tsx
+++ b/templates/operator/src/components/admin/widgets/dashboard-outstanding-invoices-widget.tsx
@@ -11,7 +11,13 @@ type DashboardOutstandingInvoicesWidgetProps = {
   }
 }
 
-function formatCurrency(amountInMinor: number, currency: string): string {
+function formatCurrency(amountInMinor: number, currency: string | null | undefined): string {
+  if (!currency) {
+    return new Intl.NumberFormat("en-US", {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(amountInMinor / 100)
+  }
   return new Intl.NumberFormat("en-US", {
     style: "currency",
     currency,
@@ -23,7 +29,7 @@ export function DashboardOutstandingInvoicesWidget({
 }: DashboardOutstandingInvoicesWidgetProps) {
   const outstandingInvoiceCount = metrics?.outstandingInvoiceCount ?? 0
   const outstandingAmount = metrics?.outstandingAmount ?? 0
-  const defaultCurrency = metrics?.defaultCurrency ?? "EUR"
+  const defaultCurrency = metrics?.defaultCurrency ?? null
 
   return (
     <Card>

--- a/templates/operator/src/components/voyant/products/product-payment-policy-section.tsx
+++ b/templates/operator/src/components/voyant/products/product-payment-policy-section.tsx
@@ -63,11 +63,11 @@ export function ProductPaymentPolicySection({
           value={draft}
           onChange={setDraft}
           inheritable={true}
-          currency={product.sellCurrency ?? "EUR"}
+          currency={product.sellCurrency}
           disabled={update.isPending}
         />
         <div className="flex flex-col gap-3">
-          <PaymentPolicyPreview policy={draft} currency={product.sellCurrency ?? "EUR"} />
+          <PaymentPolicyPreview policy={draft} currency={product.sellCurrency} />
           <div className="flex justify-end">
             <Button
               size="sm"

--- a/templates/operator/src/components/voyant/suppliers/supplier-detail-page.tsx
+++ b/templates/operator/src/components/voyant/suppliers/supplier-detail-page.tsx
@@ -253,46 +253,54 @@ export function SupplierDetailPage({ id }: { id: string }) {
           </CardDescription>
         </CardHeader>
         <CardContent className="grid gap-6 lg:grid-cols-[2fr_1fr]">
-          <PaymentPolicyForm
-            value={policyDraft}
-            onChange={setPolicyDraft}
-            inheritable={true}
-            currency={supplier.defaultCurrency ?? "EUR"}
-            disabled={supplierMutation.update.isPending}
-          />
-          <div className="flex flex-col gap-3">
-            <PaymentPolicyPreview
-              policy={policyDraft}
-              currency={supplier.defaultCurrency ?? "EUR"}
-            />
-            <div className="flex justify-end">
-              <Button
-                size="sm"
+          {supplier.defaultCurrency ? (
+            <>
+              <PaymentPolicyForm
+                value={policyDraft}
+                onChange={setPolicyDraft}
+                inheritable={true}
+                currency={supplier.defaultCurrency}
                 disabled={supplierMutation.update.isPending}
-                onClick={() => {
-                  supplierMutation.update.mutate(
-                    {
-                      id,
-                      input: {
-                        customerPaymentPolicy:
-                          (policyDraft as SupplierCustomerPaymentPolicy | null) ?? null,
-                      },
-                    },
-                    {
-                      onSuccess: () => toast.success("Customer payment policy saved"),
-                      onError: (err) =>
-                        toast.error(err instanceof Error ? err.message : "Failed to save policy"),
-                    },
-                  )
-                }}
-              >
-                {supplierMutation.update.isPending ? (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                ) : null}
-                Save policy
-              </Button>
-            </div>
-          </div>
+              />
+              <div className="flex flex-col gap-3">
+                <PaymentPolicyPreview policy={policyDraft} currency={supplier.defaultCurrency} />
+                <div className="flex justify-end">
+                  <Button
+                    size="sm"
+                    disabled={supplierMutation.update.isPending}
+                    onClick={() => {
+                      supplierMutation.update.mutate(
+                        {
+                          id,
+                          input: {
+                            customerPaymentPolicy:
+                              (policyDraft as SupplierCustomerPaymentPolicy | null) ?? null,
+                          },
+                        },
+                        {
+                          onSuccess: () => toast.success("Customer payment policy saved"),
+                          onError: (err) =>
+                            toast.error(
+                              err instanceof Error ? err.message : "Failed to save policy",
+                            ),
+                        },
+                      )
+                    }}
+                  >
+                    {supplierMutation.update.isPending ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : null}
+                    Save policy
+                  </Button>
+                </div>
+              </div>
+            </>
+          ) : (
+            <p className="text-muted-foreground text-sm lg:col-span-2">
+              Set the supplier's default currency above before defining a payment policy — amounts
+              must be denominated in a known currency.
+            </p>
+          )}
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Summary

Fixes #462. The public pricing snapshot resolved its display currency only from `price_catalogs.currency_code`, forcing operators in multi-currency markets (CEE in particular) to maintain one catalog per currency even though `products.sell_currency` is `NOT NULL` and is already the source of truth in the booking + checkout paths.

When `price_catalogs.currency_code` is `NULL`, the snapshot now falls back to `product.sell_currency`. Catalogs with a non-null `currency_code` behave exactly as before; operators can collapse N currency-specific catalogs into one retail catalog with `currency_code = NULL`, where each product's display currency follows its own `sell_currency`. No schema change — the column is already nullable.

## Changes

- **`@voyantjs/pricing`** — `getProductPricingSnapshot` selects `products.sell_currency` and falls back to it when the catalog's currency is null. Comment on `price_catalogs.currency_code` documents the NULL semantics.
- **`@voyantjs/catalog-ui`** — `formatPriceCents` renders plain digits (no currency symbol) when no currency is supplied, instead of mis-labelling amounts as EUR.
- **`@voyantjs/bookings-ui`** — same treatment in `formatMoney` for the booking payments summary.
- **operator template** — the dashboard outstanding-invoices widget renders plain digits when no currency is supplied; the supplier payment-policy editor hides with a "set the supplier's default currency first" guard instead of rendering EUR-formatted amounts; the product payment-policy section drops a dead `?? "EUR"` (the column is `NOT NULL`).

## Out of scope

- Service-layer transactional `?? "EUR"` fallbacks in `@voyantjs/storefront`, `@voyantjs/hospitality`, and the operator catalog-checkout — these decide actual transaction currency and warrant a separate review.
- `@voyantjs/finance-ui` `PaymentPolicyForm` / `PaymentPolicyPreview` internal `currency = "EUR"` defaults — touching the public component signature is its own decision; current callers now pass concrete currencies.
- Form-default `?? "EUR"` sites tagged `i18n-literal-ok` (legal-ui, finance-ui, markets-ui, ui registry, apps/dev transactions) — intentional UX defaults for empty form fields.

## Test plan

- [x] `pnpm -F @voyantjs/pricing... typecheck`
- [x] `pnpm -F @voyantjs/bookings-ui -F @voyantjs/catalog-ui -F operator typecheck`
- [x] `pnpm -F @voyantjs/pricing exec vitest run --no-file-parallelism` — 91/91 pass, including a new `falls back to product.sellCurrency when catalog.currencyCode is null` integration test plus a tightened catalog-wins assertion on the existing happy-path test
- [ ] Smoke check: a product with `sellCurrency: "RON"` against a catalog with `currency_code = NULL` renders prices in RON (verified via the new integration test)
- [ ] Smoke check: a supplier with `defaultCurrency = NULL` shows the "set the supplier's default currency above" guard in the payment-policy editor instead of EUR-labelled amounts