### PR TITLE
Fix #465: resolve option price rules by date via priceSchedule + RRULE

### DIFF
--- a/packages/pricing/package.json
+++ b/packages/pricing/package.json
@@ -27,6 +27,7 @@
     "@voyantjs/products": "workspace:*",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.10",
+    "rrule": "^2.8.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/pricing/src/service-public.ts
+++ b/packages/pricing/src/service-public.ts
@@ -9,7 +9,9 @@ import {
   optionUnitPriceRules,
   optionUnitTiers,
   priceCatalogs,
+  priceSchedules,
 } from "./schema.js"
+import { pickRulesForDate, type ResolverScheduleInput } from "./service-rule-resolver.js"
 import type {
   PublicAvailabilitySnapshotQuery,
   PublicProductPricingQuery,
@@ -85,6 +87,93 @@ async function resolvePublicCatalog(
   return catalog ?? null
 }
 
+async function resolveQueryDate(
+  db: PostgresJsDatabase,
+  query: PublicProductPricingQuery,
+): Promise<string | null> {
+  if (query.date) return query.date
+  if (!query.departureId) return null
+
+  const [slot] = await db
+    .select({ dateLocal: availabilitySlots.dateLocal })
+    .from(availabilitySlots)
+    .where(eq(availabilitySlots.id, query.departureId))
+    .limit(1)
+
+  return slot?.dateLocal ?? null
+}
+
+type PricingRuleRow = {
+  id: string
+  optionId: string
+  name: string
+  isDefault: boolean
+  priceScheduleId: string | null
+}
+
+async function narrowRulesByDate<T extends PricingRuleRow>(
+  db: PostgresJsDatabase,
+  rules: T[],
+  isoDate: string,
+): Promise<T[]> {
+  if (rules.length === 0) return rules
+
+  const scheduleIds = Array.from(
+    new Set(rules.map((r) => r.priceScheduleId).filter((id): id is string => id !== null)),
+  )
+
+  const schedules =
+    scheduleIds.length > 0
+      ? await db
+          .select({
+            id: priceSchedules.id,
+            active: priceSchedules.active,
+            priority: priceSchedules.priority,
+            recurrenceRule: priceSchedules.recurrenceRule,
+            validFrom: priceSchedules.validFrom,
+            validTo: priceSchedules.validTo,
+            weekdays: priceSchedules.weekdays,
+            timezone: priceSchedules.timezone,
+          })
+          .from(priceSchedules)
+          .where(inArray(priceSchedules.id, scheduleIds))
+      : []
+
+  const scheduleMap = new Map<string, ResolverScheduleInput>(
+    schedules.map((s) => [
+      s.id,
+      {
+        id: s.id,
+        active: s.active,
+        priority: s.priority,
+        recurrenceRule: s.recurrenceRule,
+        validFrom: s.validFrom,
+        validTo: s.validTo,
+        weekdays: s.weekdays ?? null,
+        timezone: s.timezone,
+      },
+    ]),
+  )
+
+  const rulesByOption = new Map<string, T[]>()
+  for (const r of rules) {
+    const existing = rulesByOption.get(r.optionId) ?? []
+    existing.push(r)
+    rulesByOption.set(r.optionId, existing)
+  }
+
+  const winners: T[] = []
+  for (const [, candidateRules] of rulesByOption) {
+    const picked = pickRulesForDate(candidateRules, scheduleMap, isoDate)
+    const winnerId = picked[0]?.id
+    if (!winnerId) continue
+    const winner = candidateRules.find((r) => r.id === winnerId)
+    if (winner) winners.push(winner)
+  }
+
+  return winners
+}
+
 export const publicPricingService = {
   async getProductPricingSnapshot(
     db: PostgresJsDatabase,
@@ -139,7 +228,9 @@ export const publicPricingService = {
 
     const optionIds = options.map((option) => option.id)
 
-    const [units, rules] = await Promise.all([
+    const resolvedDate = await resolveQueryDate(db, query)
+
+    const [units, allRules] = await Promise.all([
       db
         .select({
           id: optionUnits.id,
@@ -164,6 +255,7 @@ export const publicPricingService = {
           maxPerBooking: optionPriceRules.maxPerBooking,
           isDefault: optionPriceRules.isDefault,
           cancellationPolicyId: optionPriceRules.cancellationPolicyId,
+          priceScheduleId: optionPriceRules.priceScheduleId,
         })
         .from(optionPriceRules)
         .where(
@@ -176,6 +268,8 @@ export const publicPricingService = {
         )
         .orderBy(desc(optionPriceRules.isDefault), asc(optionPriceRules.name)),
     ])
+
+    const rules = resolvedDate ? await narrowRulesByDate(db, allRules, resolvedDate) : allRules
 
     const ruleIds = rules.map((rule) => rule.id)
 

--- a/packages/pricing/src/service-rule-resolver.ts
+++ b/packages/pricing/src/service-rule-resolver.ts
@@ -1,0 +1,236 @@
+import { and, eq, inArray } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { rrulestr } from "rrule"
+
+import { priceSchedules } from "./schema-catalogs.js"
+import { optionPriceRules } from "./schema-option-rules.js"
+
+export interface ResolverRuleInput {
+  id: string
+  name: string
+  isDefault: boolean
+  priceScheduleId: string | null
+}
+
+export interface ResolverScheduleInput {
+  id: string
+  active: boolean
+  priority: number
+  recurrenceRule: string
+  validFrom: string | null
+  validTo: string | null
+  weekdays: string[] | null
+  timezone: string | null
+}
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+const WEEKDAY_CODES = ["SU", "MO", "TU", "WE", "TH", "FR", "SA"] as const
+
+function weekdayCode(isoDate: string): string {
+  const d = new Date(`${isoDate}T00:00:00Z`)
+  return WEEKDAY_CODES[d.getUTCDay()] ?? "MO"
+}
+
+function dateInWindow(isoDate: string, from: string | null, to: string | null): boolean {
+  if (from && isoDate < from) return false
+  if (to && isoDate > to) return false
+  return true
+}
+
+function rruleMatchesDate(ruleString: string, isoDate: string, anchor: string): boolean {
+  const trimmed = ruleString.trim()
+  if (trimmed === "") return true
+
+  const dtstart = `${anchor.replace(/-/g, "")}T000000Z`
+  const hasDtstart = /(?:^|\n)DTSTART[:;]/.test(trimmed)
+  const hasRrule = /(?:^|\n)RRULE[:;]/.test(trimmed)
+  const body = hasRrule ? trimmed : `RRULE:${trimmed}`
+  const fullRule = hasDtstart ? body : `DTSTART:${dtstart}\n${body}`
+
+  let parsed: ReturnType<typeof rrulestr>
+  try {
+    parsed = rrulestr(fullRule)
+  } catch {
+    return false
+  }
+
+  const start = new Date(`${isoDate}T00:00:00Z`)
+  const end = new Date(start.getTime() + 24 * 60 * 60 * 1000)
+  const occurrences = parsed.between(start, end, true)
+  return occurrences.some((occ) => occ.toISOString().slice(0, 10) === isoDate)
+}
+
+function scheduleMatchesDate(s: ResolverScheduleInput, isoDate: string): boolean {
+  if (!s.active) return false
+  if (!dateInWindow(isoDate, s.validFrom, s.validTo)) return false
+
+  if (s.weekdays && s.weekdays.length > 0) {
+    if (!s.weekdays.includes(weekdayCode(isoDate))) return false
+  }
+
+  const anchor = s.validFrom ?? "2000-01-01"
+  if (!rruleMatchesDate(s.recurrenceRule, isoDate, anchor)) return false
+
+  return true
+}
+
+interface Match {
+  rule: ResolverRuleInput
+  priority: number
+  scheduled: boolean
+}
+
+function compareMatches(a: Match, b: Match): number {
+  if (b.priority !== a.priority) return b.priority - a.priority
+  const aDef = a.rule.isDefault ? 1 : 0
+  const bDef = b.rule.isDefault ? 1 : 0
+  if (aDef !== bDef) return bDef - aDef
+  return a.rule.name.localeCompare(b.rule.name)
+}
+
+/**
+ * Pick the option price rule that applies to a given date, given a set of
+ * candidate rules and their schedules.
+ *
+ * - Rules with a matching schedule beat rules without one.
+ * - Among scheduled matches, highest `priority` wins. Ties: `isDefault` first,
+ *   then alphabetic by `name`.
+ * - When no schedule matches, a rule with `isDefault=true` and no schedule acts
+ *   as the fallback. Without one, returns an empty array.
+ */
+export function pickRulesForDate(
+  rules: ResolverRuleInput[],
+  schedules: Map<string, ResolverScheduleInput>,
+  isoDate: string,
+): ResolverRuleInput[] {
+  if (!ISO_DATE_RE.test(isoDate)) {
+    throw new Error(`pickRulesForDate: expected ISO yyyy-mm-dd, got "${isoDate}"`)
+  }
+
+  const matches: Match[] = []
+
+  for (const rule of rules) {
+    if (rule.priceScheduleId === null) {
+      if (rule.isDefault) {
+        matches.push({ rule, priority: Number.NEGATIVE_INFINITY, scheduled: false })
+      }
+      continue
+    }
+    const schedule = schedules.get(rule.priceScheduleId)
+    if (!schedule) continue
+    if (!scheduleMatchesDate(schedule, isoDate)) continue
+    matches.push({ rule, priority: schedule.priority, scheduled: true })
+  }
+
+  if (matches.length === 0) return []
+
+  const scheduled = matches.filter((m) => m.scheduled)
+  if (scheduled.length > 0) {
+    scheduled.sort(compareMatches)
+    const winner = scheduled[0]
+    return winner ? [winner.rule] : []
+  }
+
+  matches.sort(compareMatches)
+  const winner = matches[0]
+  return winner ? [winner.rule] : []
+}
+
+export interface ResolveOptionPriceRulesParams {
+  productId: string
+  optionIds: string[]
+  catalogId: string
+  date: string
+}
+
+/**
+ * DB-backed wrapper around `pickRulesForDate`. Fetches active rules for the
+ * product/option/catalog plus their schedules, then picks the winning rule
+ * per option for the given date.
+ *
+ * Returns a Map keyed by optionId. Options whose rules don't match the date
+ * (and have no default) are absent from the map.
+ */
+export async function resolveOptionPriceRulesForDate(
+  db: PostgresJsDatabase,
+  params: ResolveOptionPriceRulesParams,
+): Promise<Map<string, ResolverRuleInput>> {
+  if (params.optionIds.length === 0) return new Map()
+
+  const rules = await db
+    .select({
+      id: optionPriceRules.id,
+      optionId: optionPriceRules.optionId,
+      name: optionPriceRules.name,
+      isDefault: optionPriceRules.isDefault,
+      priceScheduleId: optionPriceRules.priceScheduleId,
+    })
+    .from(optionPriceRules)
+    .where(
+      and(
+        eq(optionPriceRules.productId, params.productId),
+        inArray(optionPriceRules.optionId, params.optionIds),
+        eq(optionPriceRules.priceCatalogId, params.catalogId),
+        eq(optionPriceRules.active, true),
+      ),
+    )
+
+  const scheduleIds = Array.from(
+    new Set(rules.map((r) => r.priceScheduleId).filter((id): id is string => id !== null)),
+  )
+
+  const schedules =
+    scheduleIds.length > 0
+      ? await db
+          .select({
+            id: priceSchedules.id,
+            active: priceSchedules.active,
+            priority: priceSchedules.priority,
+            recurrenceRule: priceSchedules.recurrenceRule,
+            validFrom: priceSchedules.validFrom,
+            validTo: priceSchedules.validTo,
+            weekdays: priceSchedules.weekdays,
+            timezone: priceSchedules.timezone,
+          })
+          .from(priceSchedules)
+          .where(inArray(priceSchedules.id, scheduleIds))
+      : []
+
+  const scheduleMap = new Map<string, ResolverScheduleInput>(
+    schedules.map((s) => [
+      s.id,
+      {
+        id: s.id,
+        active: s.active,
+        priority: s.priority,
+        recurrenceRule: s.recurrenceRule,
+        validFrom: s.validFrom,
+        validTo: s.validTo,
+        weekdays: s.weekdays ?? null,
+        timezone: s.timezone,
+      },
+    ]),
+  )
+
+  const rulesByOption = new Map<string, ResolverRuleInput[]>()
+  for (const r of rules) {
+    const existing = rulesByOption.get(r.optionId) ?? []
+    existing.push({
+      id: r.id,
+      name: r.name,
+      isDefault: r.isDefault,
+      priceScheduleId: r.priceScheduleId,
+    })
+    rulesByOption.set(r.optionId, existing)
+  }
+
+  const result = new Map<string, ResolverRuleInput>()
+  for (const [optionId, candidateRules] of rulesByOption) {
+    const picked = pickRulesForDate(candidateRules, scheduleMap, params.date)
+    const first = picked[0]
+    if (first) result.set(optionId, first)
+  }
+
+  return result
+}

--- a/packages/pricing/src/validation-public.ts
+++ b/packages/pricing/src/validation-public.ts
@@ -19,6 +19,8 @@ const isoDateSchema = z.string().date()
 export const publicProductPricingQuerySchema = z.object({
   catalogId: z.string().optional(),
   optionId: z.string().optional(),
+  date: isoDateSchema.optional(),
+  departureId: z.string().optional(),
 })
 
 export const publicAvailabilitySnapshotQuerySchema = z.object({

--- a/packages/pricing/tests/rule-resolver.test.ts
+++ b/packages/pricing/tests/rule-resolver.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  pickRulesForDate,
+  type ResolverRuleInput,
+  type ResolverScheduleInput,
+} from "../src/service-rule-resolver.js"
+
+const rule = (id: string, overrides: Partial<ResolverRuleInput> = {}): ResolverRuleInput => ({
+  id,
+  name: id,
+  isDefault: false,
+  priceScheduleId: null,
+  ...overrides,
+})
+
+const schedule = (
+  id: string,
+  overrides: Partial<ResolverScheduleInput> = {},
+): ResolverScheduleInput => ({
+  id,
+  active: true,
+  priority: 0,
+  recurrenceRule: "FREQ=DAILY",
+  validFrom: null,
+  validTo: null,
+  weekdays: null,
+  timezone: null,
+  ...overrides,
+})
+
+const map = (...schedules: ResolverScheduleInput[]) => new Map(schedules.map((s) => [s.id, s]))
+
+describe("pickRulesForDate", () => {
+  it("returns the default rule when only a default exists and no date is constrained", () => {
+    const def = rule("default", { isDefault: true })
+    const result = pickRulesForDate([def], map(), "2026-07-15")
+    expect(result).toEqual([def])
+  })
+
+  it("returns empty when no rule matches and no fallback exists", () => {
+    const seasonal = rule("seasonal", { priceScheduleId: "s1" })
+    const result = pickRulesForDate(
+      [seasonal],
+      map(schedule("s1", { validFrom: "2026-06-01", validTo: "2026-08-31" })),
+      "2026-09-15",
+    )
+    expect(result).toEqual([])
+  })
+
+  it("seasonal rule wins over default when date is in window", () => {
+    const def = rule("default", { isDefault: true })
+    const seasonal = rule("seasonal", { priceScheduleId: "s1" })
+    const result = pickRulesForDate(
+      [def, seasonal],
+      map(schedule("s1", { validFrom: "2026-06-01", validTo: "2026-08-31" })),
+      "2026-07-15",
+    )
+    expect(result).toEqual([seasonal])
+  })
+
+  it("default rule wins when seasonal window doesn't match", () => {
+    const def = rule("default", { isDefault: true })
+    const seasonal = rule("seasonal", { priceScheduleId: "s1" })
+    const result = pickRulesForDate(
+      [def, seasonal],
+      map(schedule("s1", { validFrom: "2026-06-01", validTo: "2026-08-31" })),
+      "2026-12-15",
+    )
+    expect(result).toEqual([def])
+  })
+
+  it("higher-priority schedule wins among overlapping windows", () => {
+    const summer = rule("summer", { priceScheduleId: "s1" })
+    const holiday = rule("holiday", { priceScheduleId: "s2" })
+    const result = pickRulesForDate(
+      [summer, holiday],
+      map(
+        schedule("s1", { priority: 0, validFrom: "2026-06-01", validTo: "2026-08-31" }),
+        schedule("s2", { priority: 100, validFrom: "2026-08-15", validTo: "2026-08-20" }),
+      ),
+      "2026-08-17",
+    )
+    expect(result).toEqual([holiday])
+  })
+
+  it("RRULE BYDAY matches the right weekday", () => {
+    const weekend = rule("weekend", { priceScheduleId: "s1" })
+    const insideWeekend = pickRulesForDate(
+      [weekend],
+      map(
+        schedule("s1", {
+          recurrenceRule: "FREQ=WEEKLY;BYDAY=SA,SU",
+          validFrom: "2026-01-01",
+        }),
+      ),
+      "2026-07-18",
+    )
+    expect(insideWeekend).toEqual([weekend])
+
+    const outsideWeekend = pickRulesForDate(
+      [weekend],
+      map(
+        schedule("s1", {
+          recurrenceRule: "FREQ=WEEKLY;BYDAY=SA,SU",
+          validFrom: "2026-01-01",
+        }),
+      ),
+      "2026-07-15",
+    )
+    expect(outsideWeekend).toEqual([])
+  })
+
+  it("weekdays array filters dates", () => {
+    const weekend = rule("weekend", { priceScheduleId: "s1" })
+    const sched = schedule("s1", {
+      validFrom: "2026-01-01",
+      weekdays: ["SA", "SU"],
+    })
+    expect(pickRulesForDate([weekend], map(sched), "2026-07-18")).toEqual([weekend])
+    expect(pickRulesForDate([weekend], map(sched), "2026-07-15")).toEqual([])
+  })
+
+  it("single-day window (validFrom == validTo) supports per-departure override", () => {
+    const def = rule("default", { isDefault: true })
+    const oneOff = rule("oneOff", { priceScheduleId: "s1" })
+    const sched = schedule("s1", {
+      priority: 50,
+      validFrom: "2026-06-21",
+      validTo: "2026-06-21",
+    })
+    expect(pickRulesForDate([def, oneOff], map(sched), "2026-06-21")).toEqual([oneOff])
+    expect(pickRulesForDate([def, oneOff], map(sched), "2026-06-22")).toEqual([def])
+  })
+
+  it("inactive schedule is treated as no match", () => {
+    const def = rule("default", { isDefault: true })
+    const seasonal = rule("seasonal", { priceScheduleId: "s1" })
+    const result = pickRulesForDate(
+      [def, seasonal],
+      map(
+        schedule("s1", {
+          active: false,
+          validFrom: "2026-06-01",
+          validTo: "2026-08-31",
+        }),
+      ),
+      "2026-07-15",
+    )
+    expect(result).toEqual([def])
+  })
+
+  it("dangling priceScheduleId (schedule missing from map) skips the rule", () => {
+    const def = rule("default", { isDefault: true })
+    const dangling = rule("dangling", { priceScheduleId: "missing" })
+    const result = pickRulesForDate([def, dangling], map(), "2026-07-15")
+    expect(result).toEqual([def])
+  })
+
+  it("rule without schedule and not default is skipped (only default-or-scheduled rules participate)", () => {
+    const orphan = rule("orphan")
+    const result = pickRulesForDate([orphan], map(), "2026-07-15")
+    expect(result).toEqual([])
+  })
+
+  it("ties on priority break by isDefault then name", () => {
+    const a = rule("alpha", { priceScheduleId: "s1" })
+    const b = rule("beta", { priceScheduleId: "s2", isDefault: true })
+    const result = pickRulesForDate(
+      [a, b],
+      map(
+        schedule("s1", { priority: 10, validFrom: "2026-01-01" }),
+        schedule("s2", { priority: 10, validFrom: "2026-01-01" }),
+      ),
+      "2026-07-15",
+    )
+    expect(result).toEqual([b])
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,7 +127,7 @@ importers:
         version: 1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@better-auth/api-key':
         specifier: ^1.5.6
-        version: 1.5.6(528a90069b32ded3cd69e6bc8dd18c96)
+        version: 1.5.6(1f1bbcdf0f17a0d068016c0095f7b39e)
       '@cloudflare/vite-plugin':
         specifier: ^1.31.0
         version: 1.31.0(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260426.1)(wrangler@4.86.0(@cloudflare/workers-types@4.20260426.1))
@@ -376,7 +376,7 @@ importers:
         version: link:../../packages/workflows
       better-auth:
         specifier: ^1.5.6
-        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -925,7 +925,7 @@ importers:
     dependencies:
       '@better-auth/api-key':
         specifier: ^1.5.6
-        version: 1.5.6(528a90069b32ded3cd69e6bc8dd18c96)
+        version: 1.5.6(1f1bbcdf0f17a0d068016c0095f7b39e)
       '@voyantjs/db':
         specifier: workspace:*
         version: link:../db
@@ -934,7 +934,7 @@ importers:
         version: link:../utils
       better-auth:
         specifier: ^1.5.6
-        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
@@ -3719,6 +3719,9 @@ importers:
       hono:
         specifier: ^4.12.10
         version: 4.12.10
+      rrule:
+        specifier: ^2.8.1
+        version: 2.8.1
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -4947,7 +4950,7 @@ importers:
         version: 1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@better-auth/api-key':
         specifier: ^1.5.6
-        version: 1.5.6(528a90069b32ded3cd69e6bc8dd18c96)
+        version: 1.5.6(1f1bbcdf0f17a0d068016c0095f7b39e)
       '@cloudflare/vite-plugin':
         specifier: ^1.31.0
         version: 1.31.0(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260401.1)(wrangler@4.80.0(@cloudflare/workers-types@4.20260426.1))
@@ -5142,7 +5145,7 @@ importers:
         version: link:../../packages/workflows
       better-auth:
         specifier: ^1.5.6
-        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -5278,7 +5281,7 @@ importers:
         version: 1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@better-auth/api-key':
         specifier: ^1.5.6
-        version: 1.5.6(528a90069b32ded3cd69e6bc8dd18c96)
+        version: 1.5.6(1f1bbcdf0f17a0d068016c0095f7b39e)
       '@cloudflare/vite-plugin':
         specifier: ^1.31.0
         version: 1.31.0(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260426.1)(wrangler@4.80.0(@cloudflare/workers-types@4.20260426.1))
@@ -5539,7 +5542,7 @@ importers:
         version: link:../../packages/workflows
       better-auth:
         specifier: ^1.5.6
-        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -11324,6 +11327,9 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
+  rrule@2.8.1:
+    resolution: {integrity: sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==}
+
   rrweb-cssom@0.7.1:
     resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
 
@@ -12578,11 +12584,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@better-auth/api-key@1.5.6(528a90069b32ded3cd69e6bc8dd18c96)':
+  '@better-auth/api-key@1.5.6(1f1bbcdf0f17a0d068016c0095f7b39e)':
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
-      better-auth: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
+      better-auth: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
       zod: 4.3.6
 
   '@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)':
@@ -15489,7 +15495,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.14: {}
 
-  better-auth@1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))):
+  better-auth@1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))):
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))
@@ -17938,6 +17944,10 @@ snapshots:
       path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
+
+  rrule@2.8.1:
+    dependencies:
+      tslib: 2.8.1
 
   rrweb-cssom@0.7.1: {}
 


### PR DESCRIPTION
## Summary
- Adds `service-rule-resolver` to `@voyantjs/pricing` with a pure `pickRulesForDate()` and a DB-backed `resolveOptionPriceRulesForDate()`. Selects the winning rule for a date by evaluating `priceSchedule.recurrenceRule`, `validFrom`/`validTo`, `weekdays`, and `priority`. Rules without a schedule act as a default fallback.
- Wires the resolver into `publicPricingService.getProductPricingSnapshot`. New optional query params: `date` (ISO yyyy-mm-dd) and `departureId` (resolved server-side via `availabilitySlots.dateLocal`). When neither is set, the snapshot still returns every active rule (admin-friendly), preserving the current shape.
- Adds `rrule` (~edge-safe; only `tslib` dep) for RRULE evaluation.

Without this, the schema's seasonal-pricing surface (`priceSchedules` table, `priority`, RRULE) was wired but never evaluated — the snapshot returned every active rule and forced operators into the wrong shape (one rule per departure) to make pricing predictable. Closes #465.

## Out of scope
**Booking-engine integration is deferred to #468 (Phase C).** The handler in `packages/products/src/booking-engine/handler.ts` still uses `product.sellAmountCents × pax` as a placeholder per its own header comment and doesn't read option price rules at all yet, so adding a DI hook now would be decoration. The DI seam lands together with the consumer code that calls it.

## Test plan
- [x] `pnpm -F @voyantjs/pricing typecheck` clean.
- [x] `pnpm -F @voyantjs/pricing test` — 12 new unit tests pass (default-only, seasonal in/out window, priority tie-break, BYDAY, weekdays array, single-day window, inactive schedule, dangling FK, orphan rule).
- [x] `pnpm -F @voyantjs/pricing... typecheck` — full closure (15 packages) clean.
- [x] Pre-commit hook (`pnpm typecheck`) passed.
- [x] Pre-push hook (`pnpm test`) passed.
- [ ] Manual smoke against a seeded DB: hit `/v1/public/products/:id/pricing?date=2026-07-15` with one default rule + one seasonal rule (`validFrom=2026-06-01`, `validTo=2026-08-31`); confirm only the seasonal rule comes back inside the window and only the default outside.

## Follow-ups
- #468 — booking-engine quote integration (Phase C).
- #466 — UI: hide unit×category matrix for per-person rules.
- #467 — first-class per-departure price overrides (depends on this).