### PR TITLE
Fix #468: booking-engine quote driven by option price rules (Phase C)

### DIFF
--- a/.changeset/booking-engine-resolver-hook.md
+++ b/.changeset/booking-engine-resolver-hook.md
@@ -1,0 +1,25 @@
+---
+"@voyantjs/products": minor
+"@voyantjs/pricing": patch
+---
+
+Booking-engine quote driven by option price rules (#468, Phase C).
+
+The owned-arm products handler in `@voyantjs/products` no longer relies solely on the `product.sellAmountCents × pax` placeholder. It now consults a caller-supplied price resolver to drive per-band pricing from `optionPriceRules` + `optionUnitPriceRules`.
+
+**`@voyantjs/products`** (minor)
+
+- New DI hook `loadResolvedOptionPrice` on `OwnedProductsShapeLoaders`. Takes `{ productId, optionId, date, catalogId? }`, returns `{ baseSellAmountCents, unitPrices }` or null. Caller-supplied so `@voyantjs/products` does not import `@voyantjs/pricing` (the dependency direction is `pricing → products`, not the reverse).
+- New DI hook `loadSlotDate` to convert a draft's `departureSlotId` into an ISO date the resolver can match against. Caller-supplied to avoid pulling `@voyantjs/availability` into products.
+- New exported types `ResolvedOptionPrice`, `ResolvedUnitPrice`.
+- `computeQuote` now picks the price using a three-way fall-through:
+  1. **Per-band**: when `unitPrices` matches at least one pax band with positive count, sum `pax[band] × unit.sellAmountCents`. One breakdown line per band.
+  2. **Per-booking**: when no band matches, charge `baseSellAmountCents × paxCount`.
+  3. **Fallback**: `product.sellAmountCents × paxCount` (Phase A behavior preserved for bookings without an option/slot picked).
+- 6 new unit tests covering the matrix above.
+
+**`@voyantjs/pricing`** (patch)
+
+- Re-export `resolveOptionPriceRulesForDate`, `pickRulesForDate`, `loadDeparturePriceOverrides` and supporting types from the package's main entry — they were previously private to internal callers but the booking-engine wiring needs them. No new schema, no migration.
+
+The operator template (`templates/operator/src/api/lib/booking-engine-runtime.ts`) now wires both hooks via the resolver. Per-pax categorization is derived from `optionUnits.minAge`/`maxAge`: `maxAge ≤ 1` → infant, `maxAge ≤ 17` → child, otherwise adult. Operators with senior bands extend per product.

--- a/packages/pricing/src/index.ts
+++ b/packages/pricing/src/index.ts
@@ -77,6 +77,14 @@ export {
   pricingDependencyTypeEnum,
 } from "./schema.js"
 export {
+  loadDeparturePriceOverrides,
+  pickRulesForDate,
+  type ResolverRuleInput,
+  type ResolverScheduleInput,
+  resolveOptionPriceRulesForDate,
+  type UnitPriceOverride,
+} from "./service-rule-resolver.js"
+export {
   addonPricingModeSchema,
   cancellationChargeTypeSchema,
   cancellationPolicyListQuerySchema,

--- a/packages/products/src/booking-engine/handler.ts
+++ b/packages/products/src/booking-engine/handler.ts
@@ -177,6 +177,27 @@ export function buildOwnedProductDraftShape(
 // Handler
 // ─────────────────────────────────────────────────────────────────
 
+/** A per-unit price within a resolved option price rule, returned by
+ *  `loadResolvedOptionPrice`. The handler matches `travelerCategory`
+ *  to the draft's pax-band codes ("adult" / "child" / "infant" /
+ *  "senior") to compute per-band totals. Units that don't map to a
+ *  band — or whose band has zero count — are dropped. */
+export interface ResolvedUnitPrice {
+  unitId: string
+  unitType: "person" | "room" | "vehicle" | "service" | "group" | "other" | string
+  travelerCategory: "adult" | "child" | "infant" | "senior" | null
+  sellAmountCents: number | null
+}
+
+/** Output of `loadResolvedOptionPrice`. The handler prefers
+ *  `unitPrices` (per-band pricing) when present and any unit matches a
+ *  pax band; otherwise falls back to `baseSellAmountCents × paxCount`
+ *  for per-booking rules; otherwise back to `product.sellAmountCents`. */
+export interface ResolvedOptionPrice {
+  baseSellAmountCents: number | null
+  unitPrices: ReadonlyArray<ResolvedUnitPrice>
+}
+
 /** A resolved tax-rate decision — resolved from `tax_classes` ×
  *  `tax_regimes` × buyer country at quote time. */
 export interface ResolvedTaxRate {
@@ -232,6 +253,38 @@ export interface OwnedProductsShapeLoaders {
       buyerType?: "B2C" | "B2B"
     },
   ) => Promise<ResolvedTaxRate | null>
+
+  /**
+   * Resolve the option price rule for a given (product, option, date)
+   * — typically backed by `@voyantjs/pricing`'s
+   * `resolveOptionPriceRulesForDate` plus a join into per-unit prices.
+   * Returns null when no rule applies or the resolver can't run; the
+   * handler then falls back to `product.sellAmountCents × pax`.
+   *
+   * Caller-supplied so `@voyantjs/products` does not import
+   * `@voyantjs/pricing` (the dependency direction is pricing →
+   * products, not the reverse).
+   */
+  loadResolvedOptionPrice?: (
+    ctx: OwnedHandlerContext,
+    args: {
+      productId: string
+      optionId: string
+      /** ISO yyyy-mm-dd in the slot's local timezone. */
+      date: string
+      catalogId?: string
+    },
+  ) => Promise<ResolvedOptionPrice | null>
+
+  /**
+   * Look up the local date of a departure slot (`availability_slots`).
+   * Caller-supplied so the products package does not import
+   * `@voyantjs/availability`. Returns null when the slot is missing.
+   *
+   * Used together with `loadResolvedOptionPrice` to convert a draft's
+   * `departureSlotId` into a date the resolver can match against.
+   */
+  loadSlotDate?: (ctx: OwnedHandlerContext, slotId: string) => Promise<string | null>
 }
 
 /**
@@ -308,9 +361,13 @@ export function createProductsBookingHandler(
       }
 
       const draft = (request.draft ?? {}) as DraftLike
-      // Concurrent enrichment — all three calls are pure reads and
-      // don't depend on each other.
-      const [travelerFields, addonCatalog, taxRate] = await Promise.all([
+      const optionId = draft.configure?.variantId
+      const slotId = draft.configure?.departureSlotId
+
+      // Concurrent enrichment + slot-date lookup. The slot date is
+      // needed before we can call loadResolvedOptionPrice, so it
+      // joins this batch.
+      const [travelerFields, addonCatalog, taxRate, slotDate] = await Promise.all([
         options.loadTravelerFields?.(ctx, request.entityId) ?? Promise.resolve(undefined),
         options.loadAddonCatalog?.(ctx, request.entityId) ?? Promise.resolve(undefined),
         options.loadTaxRate?.(ctx, {
@@ -318,20 +375,39 @@ export function createProductsBookingHandler(
           buyerCountry: draft.billing?.address?.country,
           buyerType: draft.billing?.buyerType,
         }) ?? Promise.resolve(null),
+        slotId && options.loadSlotDate
+          ? options.loadSlotDate(ctx, slotId)
+          : Promise.resolve(draft.configure?.departureDate ?? null),
       ])
+
+      const resolvedPrice =
+        optionId && slotDate && options.loadResolvedOptionPrice
+          ? await options.loadResolvedOptionPrice(ctx, {
+              productId: request.entityId,
+              optionId,
+              date: slotDate,
+            })
+          : null
+
       const paxCount = sumPax(draft.configure?.pax)
       // Per-pax pricing fallback: when no pax is supplied yet, quote a
       // single-occupant baseline so the wizard can render a starter
       // total before the user picks counts.
       const effectivePax = paxCount > 0 ? paxCount : 1
-      const unitCents = product.sellAmountCents ?? 0
-      const grossCents = unitCents * effectivePax
+
+      const priced = priceQuote({
+        product,
+        resolvedPrice,
+        pax: draft.configure?.pax,
+        effectivePax,
+      })
 
       // Tax computation. The base is taxable; addons/accommodation
       // get the same rate in this MVP cut. Per-line override (the
       // `applies_to` axis on tax_classes.lines) lands in a follow-up
       // when the catalog actually carries mixed treatments.
       const taxIsInclusive = taxRate?.priceMode === "inclusive"
+      const grossCents = priced.totalCents
       const taxCents =
         taxRate && taxRate.rate > 0
           ? taxIsInclusive
@@ -341,50 +417,44 @@ export function createProductsBookingHandler(
       const netCents = taxIsInclusive ? grossCents - taxCents : grossCents
       const payableCents = taxIsInclusive ? grossCents : netCents + taxCents
 
-      const pricing =
-        unitCents > 0
-          ? {
-              base_amount: netCents,
-              taxes: taxCents,
-              fees: 0,
-              surcharges: 0,
-              currency: product.sellCurrency,
-              breakdown: {
-                lines: [
-                  {
-                    kind: "base",
-                    label: product.name,
-                    quantity: effectivePax,
-                    unitAmount: unitCents,
-                    totalAmount: grossCents,
-                    taxIncluded: taxIsInclusive,
-                  },
-                ],
-                taxes:
-                  taxRate && taxCents > 0
-                    ? [
-                        {
-                          code: taxRate.code,
-                          label: taxRate.label,
-                          rate: taxRate.rate,
-                          amount: taxCents,
-                          base: netCents,
-                          includedInPrice: taxIsInclusive,
-                          scope: taxIsInclusive ? "included" : "excluded",
-                        },
-                      ]
-                    : [],
-                subtotal: netCents,
-                taxTotal: taxCents,
-                total: payableCents,
-                paxCount: effectivePax,
-              } as Record<string, unknown>,
-            }
-          : undefined
+      const available = grossCents > 0
+      const pricing = available
+        ? {
+            base_amount: netCents,
+            taxes: taxCents,
+            fees: 0,
+            surcharges: 0,
+            currency: product.sellCurrency,
+            breakdown: {
+              lines: priced.lines.map((line) => ({
+                ...line,
+                taxIncluded: taxIsInclusive,
+              })),
+              taxes:
+                taxRate && taxCents > 0
+                  ? [
+                      {
+                        code: taxRate.code,
+                        label: taxRate.label,
+                        rate: taxRate.rate,
+                        amount: taxCents,
+                        base: netCents,
+                        includedInPrice: taxIsInclusive,
+                        scope: taxIsInclusive ? "included" : "excluded",
+                      },
+                    ]
+                  : [],
+              subtotal: netCents,
+              taxTotal: taxCents,
+              total: payableCents,
+              paxCount: effectivePax,
+            } as Record<string, unknown>,
+          }
+        : undefined
 
       return {
-        available: unitCents > 0,
-        invalidReason: unitCents > 0 ? undefined : "no_sell_amount_configured",
+        available,
+        invalidReason: available ? undefined : "no_sell_amount_configured",
         pricing,
         shape: buildOwnedProductDraftShape({
           travelerFields,
@@ -540,6 +610,99 @@ function sumPax(pax: Partial<Record<string, number>> | undefined): number {
     if (typeof v === "number" && Number.isFinite(v) && v > 0) total += v
   }
   return total
+}
+
+interface PricedLine {
+  kind: "base"
+  label: string
+  quantity: number
+  unitAmount: number
+  totalAmount: number
+}
+
+interface PricedQuote {
+  totalCents: number
+  lines: PricedLine[]
+}
+
+/**
+ * Three-way price computation:
+ *
+ * 1. **Per-band** (preferred): when `resolvedPrice.unitPrices` matches
+ *    at least one band with positive count, sum `pax[band] ×
+ *    unit.sellAmountCents` for each matching band. One breakdown line
+ *    per band.
+ *
+ * 2. **Per-booking**: when no per-band match but `baseSellAmountCents`
+ *    is set, charge a single `base × paxCount` line.
+ *
+ * 3. **Fallback**: `product.sellAmountCents × paxCount`. Same shape as
+ *    Phase A behavior, kept for bookings without an option/slot
+ *    configured yet.
+ */
+function priceQuote(input: {
+  product: typeof products.$inferSelect
+  resolvedPrice: ResolvedOptionPrice | null
+  pax: Partial<Record<string, number>> | undefined
+  effectivePax: number
+}): PricedQuote {
+  const { product, resolvedPrice, pax, effectivePax } = input
+
+  if (resolvedPrice && resolvedPrice.unitPrices.length > 0) {
+    const bandLines: PricedLine[] = []
+    let total = 0
+    for (const unit of resolvedPrice.unitPrices) {
+      if (!unit.travelerCategory) continue
+      const count = pax?.[unit.travelerCategory] ?? 0
+      if (count <= 0) continue
+      const sell = unit.sellAmountCents ?? 0
+      if (sell <= 0) continue
+      const lineTotal = sell * count
+      total += lineTotal
+      bandLines.push({
+        kind: "base",
+        label: `${product.name} — ${unit.travelerCategory}`,
+        quantity: count,
+        unitAmount: sell,
+        totalAmount: lineTotal,
+      })
+    }
+    if (bandLines.length > 0) {
+      return { totalCents: total, lines: bandLines }
+    }
+  }
+
+  if (resolvedPrice && resolvedPrice.baseSellAmountCents !== null) {
+    const unitCents = resolvedPrice.baseSellAmountCents
+    const totalCents = unitCents * effectivePax
+    return {
+      totalCents,
+      lines: [
+        {
+          kind: "base",
+          label: product.name,
+          quantity: effectivePax,
+          unitAmount: unitCents,
+          totalAmount: totalCents,
+        },
+      ],
+    }
+  }
+
+  const unitCents = product.sellAmountCents ?? 0
+  const totalCents = unitCents * effectivePax
+  return {
+    totalCents,
+    lines: [
+      {
+        kind: "base",
+        label: product.name,
+        quantity: effectivePax,
+        unitAmount: unitCents,
+        totalAmount: totalCents,
+      },
+    ],
+  }
 }
 
 function extractPersonId(party: Record<string, unknown> | undefined): string | undefined {

--- a/packages/products/tests/unit/booking-engine-quote.test.ts
+++ b/packages/products/tests/unit/booking-engine-quote.test.ts
@@ -1,0 +1,226 @@
+import type { ComputeQuoteRequest, OwnedHandlerContext } from "@voyantjs/catalog/booking-engine"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  createProductsBookingHandler,
+  type ResolvedOptionPrice,
+} from "../../src/booking-engine/handler.js"
+
+const product = {
+  id: "prod_a",
+  name: "Bulgaria Day Trip",
+  status: "active" as const,
+  sellAmountCents: 14500,
+  sellCurrency: "RON",
+}
+
+function makeDb(rows: unknown[]) {
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => rows,
+        }),
+      }),
+    }),
+  } as unknown as OwnedHandlerContext["db"]
+}
+
+function makeCtx(rows: unknown[]): OwnedHandlerContext {
+  return {
+    db: makeDb(rows),
+    adapterContext: {} as never,
+  }
+}
+
+const baseRequest = (draft?: unknown): ComputeQuoteRequest => ({
+  entityModule: "products",
+  entityId: product.id,
+  scope: { locale: "en", audience: "customer", market: "RO" },
+  draft: draft ?? {},
+})
+
+describe("createProductsBookingHandler.computeQuote", () => {
+  it("falls back to product.sellAmountCents × pax when no resolver hooks are wired", async () => {
+    const handler = createProductsBookingHandler({
+      quickCreate: vi.fn(),
+    })
+
+    const result = await handler.computeQuote(
+      makeCtx([product]),
+      baseRequest({ configure: { pax: { adult: 2 } } }),
+    )
+
+    expect(result.available).toBe(true)
+    const breakdown = result.pricing?.breakdown as Record<string, unknown>
+    expect(breakdown?.total).toBe(29000)
+    expect(breakdown?.subtotal).toBe(29000)
+    const lines = breakdown?.lines as Array<{ totalAmount: number; quantity: number }>
+    expect(lines).toHaveLength(1)
+    expect(lines[0]?.totalAmount).toBe(29000)
+    expect(lines[0]?.quantity).toBe(2)
+  })
+
+  it("uses per-band unit prices when the resolver returns matching units", async () => {
+    const loadResolvedOptionPrice = vi.fn(
+      async (): Promise<ResolvedOptionPrice> => ({
+        baseSellAmountCents: 16000,
+        unitPrices: [
+          {
+            unitId: "u_adult",
+            unitType: "person",
+            travelerCategory: "adult",
+            sellAmountCents: 16000,
+          },
+          {
+            unitId: "u_child",
+            unitType: "person",
+            travelerCategory: "child",
+            sellAmountCents: 9500,
+          },
+          {
+            unitId: "u_infant",
+            unitType: "person",
+            travelerCategory: "infant",
+            sellAmountCents: 0,
+          },
+        ],
+      }),
+    )
+    const loadSlotDate = vi.fn(async () => "2026-06-21")
+
+    const handler = createProductsBookingHandler({
+      quickCreate: vi.fn(),
+      loadResolvedOptionPrice,
+      loadSlotDate,
+    })
+
+    const result = await handler.computeQuote(
+      makeCtx([product]),
+      baseRequest({
+        configure: {
+          variantId: "opt_default",
+          departureSlotId: "slot_1",
+          pax: { adult: 2, child: 1, infant: 1 },
+        },
+      }),
+    )
+
+    expect(loadSlotDate).toHaveBeenCalledWith(expect.anything(), "slot_1")
+    expect(loadResolvedOptionPrice).toHaveBeenCalledWith(expect.anything(), {
+      productId: product.id,
+      optionId: "opt_default",
+      date: "2026-06-21",
+    })
+
+    const breakdown = result.pricing?.breakdown as Record<string, unknown>
+    // 2 × 16000 + 1 × 9500 = 41500. Infant (sell=0) drops out.
+    expect(breakdown?.total).toBe(41500)
+    const lines = breakdown?.lines as Array<{ quantity: number; unitAmount: number }>
+    expect(lines).toHaveLength(2)
+    expect(lines.map((l) => `${l.quantity}×${l.unitAmount}`)).toEqual(["2×16000", "1×9500"])
+  })
+
+  it("uses baseSellAmountCents × pax for per-booking rules with no unit prices", async () => {
+    const handler = createProductsBookingHandler({
+      quickCreate: vi.fn(),
+      loadSlotDate: async () => "2026-07-15",
+      loadResolvedOptionPrice: async () => ({
+        baseSellAmountCents: 18000,
+        unitPrices: [],
+      }),
+    })
+
+    const result = await handler.computeQuote(
+      makeCtx([product]),
+      baseRequest({
+        configure: {
+          variantId: "opt_default",
+          departureSlotId: "slot_1",
+          pax: { adult: 3 },
+        },
+      }),
+    )
+
+    const breakdown = result.pricing?.breakdown as Record<string, unknown>
+    expect(breakdown?.total).toBe(54000) // 18000 × 3
+    const lines = breakdown?.lines as Array<{ unitAmount: number; quantity: number }>
+    expect(lines).toHaveLength(1)
+    expect(lines[0]?.unitAmount).toBe(18000)
+    expect(lines[0]?.quantity).toBe(3)
+  })
+
+  it("falls through to product.sellAmountCents when the resolver returns null", async () => {
+    const handler = createProductsBookingHandler({
+      quickCreate: vi.fn(),
+      loadSlotDate: async () => "2026-12-01",
+      loadResolvedOptionPrice: async () => null,
+    })
+
+    const result = await handler.computeQuote(
+      makeCtx([product]),
+      baseRequest({
+        configure: {
+          variantId: "opt_default",
+          departureSlotId: "slot_1",
+          pax: { adult: 1 },
+        },
+      }),
+    )
+
+    const breakdown = result.pricing?.breakdown as Record<string, unknown>
+    expect(breakdown?.total).toBe(14500) // product.sellAmountCents × 1
+  })
+
+  it("skips the resolver when no slot is selected (single-occupant baseline)", async () => {
+    const loadResolvedOptionPrice = vi.fn(async (): Promise<ResolvedOptionPrice | null> => null)
+
+    const handler = createProductsBookingHandler({
+      quickCreate: vi.fn(),
+      loadResolvedOptionPrice,
+      loadSlotDate: async () => "2026-06-21",
+    })
+
+    const result = await handler.computeQuote(
+      makeCtx([product]),
+      baseRequest({ configure: { variantId: "opt_default" } }),
+    )
+
+    expect(loadResolvedOptionPrice).not.toHaveBeenCalled()
+    const breakdown = result.pricing?.breakdown as Record<string, unknown>
+    expect(breakdown?.total).toBe(14500) // single-occupant fallback
+  })
+
+  it("respects an inline draft.configure.departureDate when no loadSlotDate is wired", async () => {
+    const loadResolvedOptionPrice = vi.fn(
+      async (): Promise<ResolvedOptionPrice> => ({
+        baseSellAmountCents: 20000,
+        unitPrices: [],
+      }),
+    )
+
+    const handler = createProductsBookingHandler({
+      quickCreate: vi.fn(),
+      loadResolvedOptionPrice,
+    })
+
+    const result = await handler.computeQuote(
+      makeCtx([product]),
+      baseRequest({
+        configure: {
+          variantId: "opt_default",
+          departureDate: "2026-06-21",
+          pax: { adult: 2 },
+        },
+      }),
+    )
+
+    expect(loadResolvedOptionPrice).toHaveBeenCalledWith(expect.anything(), {
+      productId: product.id,
+      optionId: "opt_default",
+      date: "2026-06-21",
+    })
+    const breakdown = result.pricing?.breakdown as Record<string, unknown>
+    expect(breakdown?.total).toBe(40000)
+  })
+})

--- a/templates/operator/src/api/lib/booking-engine-runtime.ts
+++ b/templates/operator/src/api/lib/booking-engine-runtime.ts
@@ -18,6 +18,7 @@
  * lifetime.
  */
 
+import { availabilitySlots } from "@voyantjs/availability/schema"
 import {
   extendAvailabilityHold,
   placeAvailabilityHold,
@@ -41,8 +42,15 @@ import { hospitalityBookingsService } from "@voyantjs/hospitality"
 import { createHospitalityBookingHandler } from "@voyantjs/hospitality/booking-engine"
 import { getHospitalityContent } from "@voyantjs/hospitality/service-content"
 import { createDemoCatalogAdapter } from "@voyantjs/plugin-catalog-demo"
+import {
+  optionPriceRules,
+  optionUnitPriceRules,
+  priceCatalogs,
+  resolveOptionPriceRulesForDate,
+} from "@voyantjs/pricing"
 import { createProductsBookingHandler } from "@voyantjs/products/booking-engine"
-import { asc, eq } from "drizzle-orm"
+import { optionUnits } from "@voyantjs/products/schema"
+import { and, asc, eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
 
@@ -198,6 +206,98 @@ export function getOwnedBookingHandlerRegistry(env: BookingEngineEnv): OwnedBook
           void args.buyerType
           const db = ctx.db as unknown as PostgresJsDatabase
           return resolveOperatorSellTaxRate(db, { productId: args.productId })
+        },
+        async loadSlotDate(ctx, slotId) {
+          const db = ctx.db as unknown as PostgresJsDatabase
+          const [slot] = await db
+            .select({ dateLocal: availabilitySlots.dateLocal })
+            .from(availabilitySlots)
+            .where(eq(availabilitySlots.id, slotId))
+            .limit(1)
+          return slot?.dateLocal ?? null
+        },
+        async loadResolvedOptionPrice(ctx, args) {
+          const db = ctx.db as unknown as PostgresJsDatabase
+
+          // Resolve catalog id: explicit (rare) > default public.
+          let catalogId = args.catalogId
+          if (!catalogId) {
+            const [cat] = await db
+              .select({ id: priceCatalogs.id })
+              .from(priceCatalogs)
+              .where(
+                and(
+                  eq(priceCatalogs.catalogType, "public"),
+                  eq(priceCatalogs.active, true),
+                  eq(priceCatalogs.isDefault, true),
+                ),
+              )
+              .limit(1)
+            if (!cat) return null
+            catalogId = cat.id
+          }
+
+          const ruleByOption = await resolveOptionPriceRulesForDate(db, {
+            productId: args.productId,
+            optionIds: [args.optionId],
+            catalogId,
+            date: args.date,
+          })
+          const rule = ruleByOption.get(args.optionId)
+          if (!rule) return null
+
+          const [ruleRow, unitPriceRows, unitRows] = await Promise.all([
+            db
+              .select({ baseSellAmountCents: optionPriceRules.baseSellAmountCents })
+              .from(optionPriceRules)
+              .where(eq(optionPriceRules.id, rule.id))
+              .limit(1),
+            db
+              .select({
+                unitId: optionUnitPriceRules.unitId,
+                sellAmountCents: optionUnitPriceRules.sellAmountCents,
+                pricingCategoryId: optionUnitPriceRules.pricingCategoryId,
+              })
+              .from(optionUnitPriceRules)
+              .where(
+                and(
+                  eq(optionUnitPriceRules.optionPriceRuleId, rule.id),
+                  eq(optionUnitPriceRules.active, true),
+                ),
+              ),
+            db
+              .select({
+                id: optionUnits.id,
+                unitType: optionUnits.unitType,
+                minAge: optionUnits.minAge,
+                maxAge: optionUnits.maxAge,
+              })
+              .from(optionUnits)
+              .where(and(eq(optionUnits.optionId, args.optionId), eq(optionUnits.isHidden, false))),
+          ])
+          const unitsById = new Map(unitRows.map((u) => [u.id, u]))
+          const unitPrices = unitPriceRows.flatMap((up) => {
+            const unit = unitsById.get(up.unitId)
+            if (!unit) return []
+            // Per-category rows (`pricingCategoryId` set) belong to the
+            // unit×category matrix used for accommodation products. The
+            // booking engine prices per-band today, so we only consume
+            // rows where the unit alone determines the price.
+            if (up.pricingCategoryId !== null) return []
+            return [
+              {
+                unitId: up.unitId,
+                unitType: unit.unitType,
+                travelerCategory: deriveTravelerCategory(unit),
+                sellAmountCents: up.sellAmountCents,
+              },
+            ]
+          })
+
+          return {
+            baseSellAmountCents: ruleRow[0]?.baseSellAmountCents ?? null,
+            unitPrices,
+          }
         },
       }),
     )
@@ -482,6 +582,34 @@ function priceCentsFromString(s: string): number {
   const fracPadded = `${frac}00`.slice(0, 2)
   const cents = Number(whole) * 100 + Number(fracPadded)
   return negative ? -cents : cents
+}
+
+/**
+ * Map an `optionUnits` row to one of the booking-engine's pax-band
+ * codes. Operators don't tag units with explicit categories; the
+ * mapping is derived from age windows. Heuristic:
+ *
+ *   - non-person units → null (rooms / vehicles / services don't
+ *     participate in per-pax pricing)
+ *   - `maxAge ≤ 1` → `infant`
+ *   - `maxAge ≤ 17` → `child` (covers operators who tag teens as
+ *     "Child 6-12" or similar — the booking engine still treats them
+ *     as the child band)
+ *   - otherwise → `adult`
+ *
+ * `senior` requires an explicit pax band, which the default
+ * `DEFAULT_PAX_BANDS` does not include — operators that need it
+ * extend the bands per product.
+ */
+function deriveTravelerCategory(unit: {
+  unitType: string
+  minAge: number | null
+  maxAge: number | null
+}): "adult" | "child" | "infant" | "senior" | null {
+  if (unit.unitType !== "person") return null
+  if (unit.maxAge !== null && unit.maxAge <= 1) return "infant"
+  if (unit.maxAge !== null && unit.maxAge <= 17) return "child"
+  return "adult"
 }
 
 function humanizeFieldKey(key: string): string {


### PR DESCRIPTION
## Summary
- The owned-arm products handler in `@voyantjs/products` no longer relies solely on the `product.sellAmountCents × pax` placeholder. It now consults a caller-supplied price resolver to drive per-band pricing from `optionPriceRules` + `optionUnitPriceRules` — closing the loop opened by #465.
- New DI hooks `loadResolvedOptionPrice` and `loadSlotDate` on `OwnedProductsShapeLoaders`. Caller-supplied so `@voyantjs/products` doesn't import `@voyantjs/pricing` (the dependency direction is `pricing → products`, not the reverse).
- Three-way fall-through: per-band → per-booking → Phase A `product.sellAmountCents`. Tax math unchanged.
- The operator template wires both hooks through `@voyantjs/pricing`'s resolver. Per-pax categorization is derived from `optionUnits.minAge`/`maxAge`.

Closes #468.

## What's in the PR

**`@voyantjs/products`** (minor)
- New types `ResolvedOptionPrice`, `ResolvedUnitPrice`.
- `OwnedProductsShapeLoaders.loadResolvedOptionPrice`: takes `{ productId, optionId, date, catalogId? }`, returns `{ baseSellAmountCents, unitPrices }` or null.
- `OwnedProductsShapeLoaders.loadSlotDate`: converts `departureSlotId` → ISO date.
- `computeQuote` reads `variantId`/`departureSlotId` off the draft, resolves the date, calls the hook, then prices via:
  1. **Per-band**: when `unitPrices` matches at least one pax band with positive count, sum `pax[band] × unit.sellAmountCents`. One breakdown line per band.
  2. **Per-booking**: when no band matches but `baseSellAmountCents` is set, charge `baseSellAmountCents × paxCount`.
  3. **Fallback**: `product.sellAmountCents × paxCount` (Phase A behavior preserved).

**`@voyantjs/pricing`** (patch)
- Re-export `resolveOptionPriceRulesForDate`, `pickRulesForDate`, `loadDeparturePriceOverrides` and supporting types from the package's main entry — they were previously private to internal callers but the booking-engine wiring needs them. No new schema, no migration.

**Operator template**
- `templates/operator/src/api/lib/booking-engine-runtime.ts` wires both hooks. `loadResolvedOptionPrice` resolves the default public catalog, calls the resolver, then joins per-unit prices.
- Per-category rows (`pricingCategoryId` set) are skipped — they belong to the unit×category matrix used for accommodation products, not per-band tour pricing. The Bulgaria-style use case (per-pax day trip) lights up cleanly.
- Traveler-category derivation: `maxAge ≤ 1` → infant, `maxAge ≤ 17` → child, otherwise adult. Senior bands require operators to extend `DEFAULT_PAX_BANDS` per product (out of scope here).

## Test plan
- [x] `pnpm -F @voyantjs/products... typecheck` clean (full closure).
- [x] `pnpm -F @voyantjs/products test` — 6 new unit tests cover the matrix; 103 tests total.
- [x] `pnpm -F operator typecheck` + lint clean.
- [x] Pre-commit hook (full-workspace `pnpm typecheck`) passed (5m 29s).
- [x] Pre-push hook (`pnpm test`) passed.
- [ ] Manual smoke against a seeded DB: open a product with a per-person rule + Adult / Child / Infant units, place a draft with `variantId` + `departureSlotId` + pax map, hit the quote endpoint, verify total = sum of per-unit × per-band.
- [ ] Verify accommodation products (`pricingCategoryId` set on unit-price rows) still fall through to Phase A behavior — they should because per-category rows are skipped.

## Out of scope
- Per-occupancy room pricing (the unit×category matrix). Day-trip per-pax case is the priority for Phase C.
- `optionUnitTiers` (quantity-based discounts). Handler ignores them today.
- Surcharges / addons in the quote total. Already deferred per Phase A comments.

## Follow-ups
- Senior-band support — requires per-product `paxBands` override and a senior unit at the schema level.