### PR TITLE
ci: don't cancel in-flight push runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,18 @@ on:
       - main
       - develop
 
+# Cancel in-flight runs only for PR pushes (`pull_request` events). Pushes to
+# main/develop always run to completion: each merged commit is a state we may
+# need to bisect or reproduce later, and the changesets-bot's "chore: release
+# packages" auto-merge pattern lands a follow-up commit within seconds — under
+# the previous `cancel-in-progress: true` rule that follow-up reliably
+# cancelled the bot commit's CI before it could finish, leaving a red X on
+# main with no useful signal. Splitting the group by event keeps PR-side
+# cancellation (still useful — when you push to a PR, the previous run is
+# obsolete) while letting push-side runs complete.
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Splits the CI concurrency group by `event_name` and only opts `pull_request` events into `cancel-in-progress`. Push events to `main`/`develop` now always run to completion.
- Fixes the recurring red-X-on-main problem after merges, especially around the changesets-bot's "chore: release packages" auto-merge cadence.

## Why

The previous rule was a single concurrency group `ci-${{ github.ref }}` with `cancel-in-progress: true`. That worked for PR pushes (push to a PR → cancel old run, fine) but broke push-to-main runs whenever commits landed back-to-back.

Recent main shows the pattern clearly:

| Commit | Type | CI |
|---|---|---|
| `93c9c6f` chore: release #471 | bot | **cancelled** |
| `dc46e37a` Fix #467 | merge | success |
| `3b3c8bd` chore: release #474 | bot | **cancelled** |
| `b72948d` Fix #468 | merge | success |
| `c0b3f82` chore: release #476 | bot | **cancelled** |
| `4d952f9` Fix #473 | merge | **cancelled** |

Every "chore: release packages" auto-merge gets cancelled — the changesets-bot lands a release commit, then the next merge follows seconds later, the new push triggers a CI run that takes the slot from the bot commit's still-in-progress run, and main shows a red X with no useful signal. The most recent merge (`4d952f9`) was even cancelled by what looks like a post-merge PR-synchronize event in the same group.

## What changes

```yaml
# Before
concurrency:
  group: ci-${{ github.ref }}
  cancel-in-progress: true

# After
concurrency:
  group: ci-${{ github.event_name }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

- PR runs still cancel each other (the useful case).
- Push runs to main/develop never get cancelled.
- Push and pull_request events live in disjoint groups, so they can't collide either.

## Test plan
- [x] Pre-commit hook (full-workspace `pnpm typecheck`) passed.
- [x] Pre-push hook (`pnpm test`) passed.
- [ ] After merge: confirm the next "chore: release packages" auto-merge from the changesets-bot lands with a green CI on main.