### PR TITLE
Fix #479: pricing-react priceCatalogRecord.currencyCode nullable

### DIFF
--- a/.changeset/pricing-react-currency-nullable.md
+++ b/.changeset/pricing-react-currency-nullable.md
@@ -1,0 +1,8 @@
+---
+"@voyantjs/pricing-react": patch
+"@voyantjs/ui": patch
+---
+
+Fix #479: `priceCatalogRecordSchema.currencyCode` is now `z.string().nullable()`, matching the DB column, the server-side core schema, and the `#462` "NULL means follow `product.sellCurrency`" semantics. Operators using a single default public catalog with `currency_code = NULL` no longer hit `Voyant API response failed validation` on the catalog-settings page or the departure-pricing-override dialog.
+
+`PriceCatalogRecord["currencyCode"]` is now `string | null`. Registry components in `@voyantjs/ui` (`price-catalogs-page`, `price-catalog-dialog`) render the NULL case as `—` and load it as `""` into the form. Direct consumers of `record.currencyCode` should add a similar fallback.

--- a/apps/dev/src/components/voyant/pricing/price-catalog-dialog.tsx
+++ b/apps/dev/src/components/voyant/pricing/price-catalog-dialog.tsx
@@ -97,7 +97,7 @@ export function PriceCatalogDialog({
       form.reset({
         code: catalog.code,
         name: catalog.name,
-        currencyCode: catalog.currencyCode,
+        currencyCode: catalog.currencyCode ?? "",
         catalogType: catalog.catalogType,
         isDefault: catalog.isDefault,
         active: catalog.active,

--- a/apps/dev/src/components/voyant/pricing/price-catalogs-page.tsx
+++ b/apps/dev/src/components/voyant/pricing/price-catalogs-page.tsx
@@ -52,7 +52,9 @@ export function PriceCatalogsPage() {
       {
         accessorKey: "currencyCode",
         header: "Currency",
-        cell: ({ row }) => <span className="font-mono text-xs">{row.original.currencyCode}</span>,
+        cell: ({ row }) => (
+          <span className="font-mono text-xs">{row.original.currencyCode ?? "—"}</span>
+        ),
       },
       {
         accessorKey: "isDefault",

--- a/packages/pricing-react/src/schemas.ts
+++ b/packages/pricing-react/src/schemas.ts
@@ -64,7 +64,7 @@ export const priceCatalogRecordSchema = z.object({
   id: z.string(),
   code: z.string(),
   name: z.string(),
-  currencyCode: z.string(),
+  currencyCode: z.string().nullable(),
   catalogType: z.enum(["public", "contract", "net", "gross", "promo", "internal", "other"]),
   isDefault: z.boolean(),
   active: z.boolean(),

--- a/packages/ui/registry/pricing/price-catalog-dialog.tsx
+++ b/packages/ui/registry/pricing/price-catalog-dialog.tsx
@@ -102,7 +102,7 @@ export function PriceCatalogDialog({
       form.reset({
         code: catalog.code,
         name: catalog.name,
-        currencyCode: catalog.currencyCode,
+        currencyCode: catalog.currencyCode ?? "",
         catalogType: catalog.catalogType,
         isDefault: catalog.isDefault,
         active: catalog.active,

--- a/packages/ui/registry/pricing/price-catalogs-page.tsx
+++ b/packages/ui/registry/pricing/price-catalogs-page.tsx
@@ -58,7 +58,9 @@ export function PriceCatalogsPage() {
       {
         accessorKey: "currencyCode",
         header: pageMessages.columns.currency,
-        cell: ({ row }) => <span className="font-mono text-xs">{row.original.currencyCode}</span>,
+        cell: ({ row }) => (
+          <span className="font-mono text-xs">{row.original.currencyCode ?? "—"}</span>
+        ),
       },
       {
         accessorKey: "isDefault",

--- a/templates/operator/src/components/voyant/settings/price-catalogs-page.tsx
+++ b/templates/operator/src/components/voyant/settings/price-catalogs-page.tsx
@@ -131,7 +131,7 @@ export function PriceCatalogsPage() {
                     <span className="text-sm font-medium">{catalog.name}</span>
                     <span className="font-mono text-xs text-muted-foreground">{catalog.code}</span>
                     <Badge variant="outline" className="text-xs">
-                      {catalog.currencyCode}
+                      {catalog.currencyCode ?? "—"}
                     </Badge>
                     <Badge variant="outline" className="text-xs capitalize">
                       {catalogTypeLabels[catalog.catalogType] ?? catalog.catalogType}


### PR DESCRIPTION
## Summary
- `priceCatalogRecordSchema.currencyCode` widened to `z.string().nullable()` in `@voyantjs/pricing-react`, aligning the client-side response schema with the DB column, the server-side core schema, and the #462 "NULL means follow `product.sellCurrency`" semantics.
- Registry components (`@voyantjs/ui/registry/pricing`), the `apps/dev` playground, and the operator template now render the NULL case as `—` and load it as `""` into the catalog form. Operator submit code already mapped `"" ↔ null`, so no behavior change there.
- Patch changesets for `@voyantjs/pricing-react` and `@voyantjs/ui`.

## Behavior change
`PriceCatalogRecord["currencyCode"]` is now `string | null`. Direct consumers reading `record.currencyCode` for display should add a `?? "—"` (or similar) fallback. All in-repo consumers are covered by this PR.

## Test plan
- [x] `pnpm -F @voyantjs/pricing-react -F @voyantjs/ui -F dev -F operator typecheck` — clean
- [x] Pre-commit + pre-push hooks (full-workspace typecheck + tests) passed locally
- [ ] Reviewer: insert a `price_catalogs` row with `currency_code = NULL, is_default = true, catalog_type = 'public'` and confirm the operator settings page + departure-pricing-override dialog load without the `Voyant API response failed validation` error reported in #479

Closes #479