### PR TITLE
Require occupancyMin on room/vehicle option units

### DIFF
--- a/.changeset/option-unit-occupancy-required.md
+++ b/.changeset/option-unit-occupancy-required.md
@@ -1,0 +1,12 @@
+---
+"@voyantjs/products": patch
+---
+
+Require `occupancyMin` (≥ 1) on `option_units` rows whose `unitType` is `room` or `vehicle`. Storefront pricing math multiplies `room.occupancy * room.quantity` for per-person totals, so leaving occupancy null silently caused the booking engine to under-count capacity-keyed prices (#481).
+
+- `insertOptionUnitSchema` rejects room/vehicle units without a valid `occupancyMin`.
+- `updateOptionUnitSchema` enforces `occupancyMax ≥ occupancyMin` when both are sent in a patch.
+- `productsService.updateUnit` validates the merged record state (existing row + patch) before writing, so a patch that flips `unitType` to `room` or that nulls `occupancyMin` is rejected with a 400 even if the patch itself is sparse.
+- New helper `validateMergedOptionUnit` exported for consumers building their own update flows.
+
+No data-model change. Existing rows that already violate the rule are not migrated automatically; operators should audit `option_units WHERE unit_type IN ('room', 'vehicle') AND occupancy_min IS NULL` and fill in occupancy before deploying.

--- a/packages/products/src/service.ts
+++ b/packages/products/src/service.ts
@@ -1,7 +1,7 @@
+import { RequestValidationError } from "@voyantjs/hono"
 import { and, asc, desc, eq, ilike, inArray, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
-
 import {
   destinations,
   destinationTranslations,
@@ -106,6 +106,7 @@ import type {
   updateProductVisibilitySettingSchema,
   upsertProductBrochureSchema,
 } from "./validation.js"
+import { validateMergedOptionUnit } from "./validation-core.js"
 
 type ProductListQuery = z.infer<typeof productListQuerySchema>
 type CreateProductInput = z.infer<typeof insertProductSchema>
@@ -1637,6 +1638,34 @@ export const productsService = {
   },
 
   async updateUnit(db: PostgresJsDatabase, id: string, data: UpdateOptionUnitInput) {
+    const [existing] = await db
+      .select({
+        unitType: optionUnits.unitType,
+        occupancyMin: optionUnits.occupancyMin,
+        occupancyMax: optionUnits.occupancyMax,
+      })
+      .from(optionUnits)
+      .where(eq(optionUnits.id, id))
+      .limit(1)
+
+    if (!existing) {
+      return null
+    }
+
+    const merged = {
+      unitType: "unitType" in data ? data.unitType : existing.unitType,
+      occupancyMin: "occupancyMin" in data ? data.occupancyMin : existing.occupancyMin,
+      occupancyMax: "occupancyMax" in data ? data.occupancyMax : existing.occupancyMax,
+    }
+
+    const validation = validateMergedOptionUnit(merged)
+    if (!validation.ok) {
+      const first = validation.issues[0]
+      throw new RequestValidationError(first?.message ?? "Invalid option unit", {
+        issues: validation.issues,
+      })
+    }
+
     const [row] = await db
       .update(optionUnits)
       .set({ ...data, updatedAt: new Date() })

--- a/packages/products/src/validation-core.ts
+++ b/packages/products/src/validation-core.ts
@@ -121,8 +121,84 @@ const optionUnitCoreSchema = z.object({
   isHidden: z.boolean().default(false),
   sortOrder: z.number().int().default(0),
 })
-export const insertOptionUnitSchema = optionUnitCoreSchema
-export const updateOptionUnitSchema = optionUnitCoreSchema.partial()
+
+// Room and vehicle units carry capacity that the storefront pricing math
+// multiplies by (e.g. `room.occupancy * room.quantity` for per_person
+// totals in service-departures). Without occupancyMin set, the multiplier
+// silently falls back to 1 and the booking under-charges — see #481.
+const OCCUPANCY_REQUIRED_TYPES = new Set(["room", "vehicle"])
+
+type OccupancyShape = {
+  unitType?: string | null | undefined
+  occupancyMin?: number | null | undefined
+  occupancyMax?: number | null | undefined
+}
+
+type OccupancyIssue = { path: string[]; message: string }
+
+function collectOccupancyIssues(data: OccupancyShape): OccupancyIssue[] {
+  const issues: OccupancyIssue[] = []
+  if (
+    data.unitType &&
+    OCCUPANCY_REQUIRED_TYPES.has(data.unitType) &&
+    (data.occupancyMin == null || data.occupancyMin < 1)
+  ) {
+    issues.push({
+      path: ["occupancyMin"],
+      message: `${data.unitType} units must declare occupancyMin (≥ 1)`,
+    })
+  }
+  if (
+    data.occupancyMin != null &&
+    data.occupancyMax != null &&
+    data.occupancyMax < data.occupancyMin
+  ) {
+    issues.push({
+      path: ["occupancyMax"],
+      message: "occupancyMax must be ≥ occupancyMin",
+    })
+  }
+  return issues
+}
+
+export const insertOptionUnitSchema = optionUnitCoreSchema.superRefine((data, ctx) => {
+  for (const issue of collectOccupancyIssues(data)) {
+    ctx.addIssue({ code: "custom", ...issue })
+  }
+})
+
+// Partial-update schema only enforces what's statically decidable from the
+// patch alone. The "unitType room/vehicle requires occupancyMin" rule needs
+// the merged record state, so it lives in the service layer below
+// (validateMergedOptionUnit).
+export const updateOptionUnitSchema = optionUnitCoreSchema.partial().superRefine((data, ctx) => {
+  if (
+    data.occupancyMin != null &&
+    data.occupancyMax != null &&
+    data.occupancyMax < data.occupancyMin
+  ) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["occupancyMax"],
+      message: "occupancyMax must be ≥ occupancyMin",
+    })
+  }
+})
+
+/**
+ * Validate the merged state of an option unit — the persisted record with a
+ * patch applied. The partial-update schema only sees the patch payload, so
+ * it can't catch e.g. PATCH `{ occupancyMin: null }` clearing occupancy on a
+ * unit whose persisted unitType is already "room". The service layer fetches
+ * the existing row, applies the patch, and runs this against the merged
+ * shape before writing.
+ */
+export function validateMergedOptionUnit(
+  merged: OccupancyShape,
+): { ok: true } | { ok: false; issues: OccupancyIssue[] } {
+  const issues = collectOccupancyIssues(merged)
+  return issues.length === 0 ? { ok: true } : { ok: false, issues }
+}
 export const optionUnitListQuerySchema = z.object({
   optionId: z.string().optional(),
   unitType: optionUnitTypeSchema.optional(),

--- a/packages/products/tests/unit/option-unit-validation.test.ts
+++ b/packages/products/tests/unit/option-unit-validation.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  insertOptionUnitSchema,
+  updateOptionUnitSchema,
+  validateMergedOptionUnit,
+} from "../../src/validation-core.js"
+
+describe("insertOptionUnitSchema — occupancy", () => {
+  it("accepts a person unit without occupancy fields", () => {
+    const result = insertOptionUnitSchema.safeParse({
+      name: "Adult",
+      unitType: "person",
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("accepts a room unit when occupancyMin is set (≥ 1)", () => {
+    const result = insertOptionUnitSchema.safeParse({
+      name: "DBL",
+      unitType: "room",
+      occupancyMin: 2,
+      occupancyMax: 2,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects a room unit with no occupancyMin", () => {
+    const result = insertOptionUnitSchema.safeParse({
+      name: "SGL",
+      unitType: "room",
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.error.issues.find((i) => i.path.join(".") === "occupancyMin")
+      expect(issue).toBeDefined()
+      expect(issue?.message).toMatch(/occupancyMin/)
+    }
+  })
+
+  it("rejects a room unit with occupancyMin = 0", () => {
+    const result = insertOptionUnitSchema.safeParse({
+      name: "SGL",
+      unitType: "room",
+      occupancyMin: 0,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("applies the same constraint to vehicle units", () => {
+    const result = insertOptionUnitSchema.safeParse({
+      name: "Sedan",
+      unitType: "vehicle",
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects occupancyMax < occupancyMin", () => {
+    const result = insertOptionUnitSchema.safeParse({
+      name: "TPL",
+      unitType: "room",
+      occupancyMin: 3,
+      occupancyMax: 2,
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.error.issues.find((i) => i.path.join(".") === "occupancyMax")
+      expect(issue).toBeDefined()
+    }
+  })
+})
+
+describe("updateOptionUnitSchema — occupancy", () => {
+  it("accepts a partial patch that doesn't touch occupancy or unitType", () => {
+    const result = updateOptionUnitSchema.safeParse({ name: "Renamed" })
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects a partial patch where occupancyMax < occupancyMin (both in patch)", () => {
+    const result = updateOptionUnitSchema.safeParse({ occupancyMin: 4, occupancyMax: 2 })
+    expect(result.success).toBe(false)
+  })
+
+  it("does not enforce the room-occupancy rule from the patch alone", () => {
+    // Service layer enforces this against the merged record state. The
+    // partial schema can't tell whether the persisted unit already has
+    // occupancyMin set, so it stays out of the way here.
+    const result = updateOptionUnitSchema.safeParse({ unitType: "room" })
+    expect(result.success).toBe(true)
+  })
+})
+
+describe("validateMergedOptionUnit", () => {
+  it("passes when a room unit has valid occupancy", () => {
+    expect(validateMergedOptionUnit({ unitType: "room", occupancyMin: 2 })).toEqual({ ok: true })
+  })
+
+  it("fails when a room unit's merged state has no occupancyMin", () => {
+    const result = validateMergedOptionUnit({ unitType: "room", occupancyMin: null })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.issues[0]?.path).toEqual(["occupancyMin"])
+    }
+  })
+
+  it("fails when occupancyMax < occupancyMin in merged state", () => {
+    const result = validateMergedOptionUnit({
+      unitType: "room",
+      occupancyMin: 3,
+      occupancyMax: 2,
+    })
+    expect(result.ok).toBe(false)
+  })
+
+  it("ignores occupancy on non-room/vehicle types", () => {
+    expect(validateMergedOptionUnit({ unitType: "person" })).toEqual({ ok: true })
+    expect(validateMergedOptionUnit({ unitType: "service" })).toEqual({ ok: true })
+  })
+})


### PR DESCRIPTION
## Summary

Closes #481. Stops the admin UI from saving a `room`/`vehicle` option unit with no occupancy, which was silently breaking per-person pricing in the storefront.

## Why

`packages/storefront/src/service-departures.ts:684,689` computes per-person totals for room-typed units as `room.occupancy * room.quantity`. The caller sources `room.occupancy` from the unit definition; if `occupancyMin` is null on the unit, the multiplier falls back to 1 and the booking under-charges. There was no error surfaced to the operator at config time — the admin form happily saved a SGL/DBL with the occupancy column blank.

## Changes

- `insertOptionUnitSchema` rejects room/vehicle units without `occupancyMin >= 1`.
- Both insert and partial update enforce `occupancyMax >= occupancyMin` when both are present.
- `productsService.updateUnit` fetches the persisted row, merges the patch, and runs `validateMergedOptionUnit` before writing — catches PATCH `{ unitType: "room" }` against a unit with no occupancy and PATCH `{ occupancyMin: null }` against an existing room unit.
- Failures throw `RequestValidationError` (400) via the standard hono error boundary.
- New helper `validateMergedOptionUnit` exported for downstream UIs that want to validate without a round-trip.

## Test plan

- [x] 13 unit tests cover insert, update partial, and merged-state validation
- [x] `pnpm -F @voyantjs/products typecheck`
- [x] `TEST_DATABASE_URL=… pnpm -F @voyantjs/products exec vitest run --no-file-parallelism` — 135/135 pass (no existing test fixture relied on saving room units without occupancy)
- [x] `pnpm -F @voyantjs/products... typecheck` clean across products dependency graph
- [ ] Smoke: in operator template, try to save a SGL room unit with no occupancy — expect a 400 with field-level message on `occupancyMin`

## Out of scope

- No data migration. Existing rows that already violate the rule (`unit_type IN ('room', 'vehicle') AND occupancy_min IS NULL`) are left alone; the changeset notes that operators should audit and fill these in before deploying. Filing as a separate issue if we want to enforce it on legacy data.
- The same shape probably applies to a few other fields (e.g. `minAge`/`maxAge` ordering, `minQuantity`/`maxQuantity` ordering). Out of scope for #481.