### PR TITLE
Reject per_booking rules with per-unit prices

### DIFF
--- a/.changeset/per-booking-rule-no-unit-prices.md
+++ b/.changeset/per-booking-rule-no-unit-prices.md
@@ -1,0 +1,17 @@
+---
+"@voyantjs/pricing": patch
+"@voyantjs/i18n": patch
+---
+
+Reject the contradictory combination of `option_price_rules.pricing_mode = "per_booking"` and child per-unit prices, and stop the admin UI from offering the unit-pricing matrix on a per-booking rule (#482).
+
+Before: an `option_price_rule` with `pricingMode = "per_booking"` could carry rows in `option_unit_price_rules`. The storefront totaller in `service-departures.ts` switches on the *unit-level* `pricingMode`, so the rule-level `per_booking` badge was effectively cosmetic — the rule said "single flat amount per booking", the math actually multiplied per-unit prices by quantity. Operators saw "Per Booking" and reasonably expected a flat charge; the system did something different.
+
+After:
+
+- `pricingService.createOptionUnitPriceRule` rejects (400) creating a unit-price row whose parent rule has `pricingMode = "per_booking"`.
+- `pricingService.updateOptionPriceRule` rejects (400) flipping a rule to `pricingMode = "per_booking"` when child unit-price rows already exist.
+- The product-options pricing form in the operator template and apps/dev hides the unit-pricing matrix when the rule is per-booking and shows a helper pointing the user at Per Person / Starting From if they want unit-level prices.
+- New i18n key `priceRules.perBookingFlatHint` (en + ro).
+
+Choosing one mode over the other isn't lossy — operators on rules currently configured as `per_booking` with unit prices were already getting the unit-level math; the badge will now match the math after they switch the rule's mode (typically to `per_person` or `per_unit` at the unit level).

--- a/apps/dev/src/components/voyant/products/product-options-pricing.tsx
+++ b/apps/dev/src/components/voyant/products/product-options-pricing.tsx
@@ -192,6 +192,15 @@ function UnitPriceMatrix({
     return <p className="text-xs italic text-muted-foreground">Add units to configure pricing.</p>
   }
 
+  if (pricingMode === "per_booking") {
+    return (
+      <p className="text-xs italic text-muted-foreground">
+        This rule charges a single flat amount per booking. Switch the pricing mode to Per Person or
+        Starting From to add unit-level prices.
+      </p>
+    )
+  }
+
   // Per-pax tour with no category cross-cut: render a simple unit-only table
   // (Sell column) instead of the unit×category matrix. Accommodation products
   // (or rules with allPricingCategories=false) still get the full matrix.

--- a/packages/i18n/src/admin/products-operator.ts
+++ b/packages/i18n/src/admin/products-operator.ts
@@ -391,6 +391,8 @@ export const operatorAdminProductsMessages = {
           unitCategoryTitle: "Unit x Category Pricing",
           unitPricingTitle: "Unit Pricing",
           addUnitsHint: "Add units to configure pricing.",
+          perBookingFlatHint:
+            "This rule charges a single flat amount per booking. Switch the pricing mode to Per Person or Starting From to add unit-level prices.",
           createCategoriesHint: "Create global pricing categories in Settings first.",
           tableUnit: "Unit",
           tableSell: "Sell",
@@ -856,6 +858,8 @@ export const operatorAdminProductsMessages = {
           unitCategoryTitle: "Preturi pe unitate x categorie",
           unitPricingTitle: "Preturi pe unitate",
           addUnitsHint: "Adauga unitati pentru a configura preturile.",
+          perBookingFlatHint:
+            "Aceasta regula incaseaza o suma unica per rezervare. Schimba modul de pret in Per Persoana sau Starting From pentru a adauga preturi pe unitati.",
           createCategoriesHint: "Creeaza mai intai categoriile globale de pret in Setari.",
           tableUnit: "Unitate",
           tableSell: "Vanzare",

--- a/packages/pricing/src/service-option-rules.ts
+++ b/packages/pricing/src/service-option-rules.ts
@@ -1,3 +1,4 @@
+import { RequestValidationError } from "@voyantjs/hono"
 import { and, asc, desc, eq, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
@@ -7,6 +8,15 @@ import {
   optionUnitPriceRules,
   optionUnitTiers,
 } from "./schema.js"
+
+// A `per_booking` rule produces a single flat amount for the whole booking;
+// per-unit prices implicitly assume a per-unit (or per-person) multiplier.
+// The two are contradictory — see #482.
+const PER_BOOKING_REJECTS_UNIT_PRICES_MESSAGE =
+  "Rules with pricingMode = 'per_booking' cannot carry per-unit prices. " +
+  "Use pricingMode = 'per_person' or 'starting_from' for unit-priced rules, " +
+  "or remove the unit prices to keep this rule a flat per-booking amount."
+
 import type {
   CreateOptionPriceRuleInput,
   CreateOptionStartTimeRuleInput,
@@ -73,6 +83,20 @@ export async function updateOptionPriceRule(
   id: string,
   data: UpdateOptionPriceRuleInput,
 ) {
+  if (data.pricingMode === "per_booking") {
+    const [countRow] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(optionUnitPriceRules)
+      .where(eq(optionUnitPriceRules.optionPriceRuleId, id))
+    const unitPriceCount = countRow?.count ?? 0
+    if (unitPriceCount > 0) {
+      throw new RequestValidationError(PER_BOOKING_REJECTS_UNIT_PRICES_MESSAGE, {
+        ruleId: id,
+        unitPriceCount,
+      })
+    }
+  }
+
   const [row] = await db
     .update(optionPriceRules)
     .set({ ...data, updatedAt: new Date() })
@@ -132,6 +156,17 @@ export async function createOptionUnitPriceRule(
   db: PostgresJsDatabase,
   data: CreateOptionUnitPriceRuleInput,
 ) {
+  const [parent] = await db
+    .select({ pricingMode: optionPriceRules.pricingMode })
+    .from(optionPriceRules)
+    .where(eq(optionPriceRules.id, data.optionPriceRuleId))
+    .limit(1)
+  if (parent?.pricingMode === "per_booking") {
+    throw new RequestValidationError(PER_BOOKING_REJECTS_UNIT_PRICES_MESSAGE, {
+      ruleId: data.optionPriceRuleId,
+    })
+  }
+
   const [row] = await db.insert(optionUnitPriceRules).values(data).returning()
   return row ?? null
 }

--- a/packages/pricing/tests/integration/routes.test.ts
+++ b/packages/pricing/tests/integration/routes.test.ts
@@ -3,6 +3,7 @@ import { newId } from "@voyantjs/db/lib/typeid"
 import { cleanupTestDb, createTestDb } from "@voyantjs/db/test-utils"
 import { optionExtraConfigs, productExtras } from "@voyantjs/extras/schema"
 import { facilities } from "@voyantjs/facilities/schema"
+import { handleApiError } from "@voyantjs/hono"
 import { optionUnits, productOptions, products } from "@voyantjs/products/schema"
 import { Hono } from "hono"
 import { beforeAll, beforeEach, describe, expect, it } from "vitest"
@@ -20,6 +21,7 @@ const app = new Hono()
     await next()
   })
   .route("/", pricingRoutes)
+  .onError((err, c) => handleApiError(err, c))
 
 function req(method: string, path: string, body?: unknown) {
   const init: RequestInit = { method, headers: { "Content-Type": "application/json" } }
@@ -798,6 +800,17 @@ describe.skipIf(!DB_AVAILABLE)("Pricing Routes Integration", () => {
       const json = (await res.json()) as { data: unknown[]; total: number }
       expect(json.total).toBe(1)
     })
+
+    it("PATCH /option-price-rules/:id rejects switching to per_booking when unit prices exist", async () => {
+      const rule = await seedOptionPriceRule({ pricingMode: "per_person" })
+      await seedOptionUnitPriceRule(rule.id)
+      const res = await req("PATCH", `/option-price-rules/${rule.id}`, {
+        pricingMode: "per_booking",
+      })
+      expect(res.status).toBe(400)
+      const json = (await res.json()) as { error: string }
+      expect(json.error).toMatch(/per_booking/)
+    })
   })
 
   // ==================== Option Unit Price Rules ====================
@@ -871,6 +884,20 @@ describe.skipIf(!DB_AVAILABLE)("Pricing Routes Integration", () => {
       expect(res.status).toBe(200)
       const json = (await res.json()) as { data: unknown[]; total: number }
       expect(json.total).toBe(1)
+    })
+
+    it("POST /option-unit-price-rules rejects unit prices under a per_booking parent", async () => {
+      const rule = await seedOptionPriceRule({ pricingMode: "per_booking" })
+      const res = await req("POST", "/option-unit-price-rules", {
+        optionPriceRuleId: rule.id,
+        optionId,
+        unitId,
+        pricingMode: "per_unit",
+        sellAmountCents: 3000,
+      })
+      expect(res.status).toBe(400)
+      const json = (await res.json()) as { error: string }
+      expect(json.error).toMatch(/per_booking/)
     })
   })
 

--- a/templates/operator/src/components/voyant/products/product-options-pricing.tsx
+++ b/templates/operator/src/components/voyant/products/product-options-pricing.tsx
@@ -262,6 +262,12 @@ function UnitPriceMatrix({
     return <p className="text-xs italic text-muted-foreground">{priceRuleMessages.addUnitsHint}</p>
   }
 
+  if (pricingMode === "per_booking") {
+    return (
+      <p className="text-xs italic text-muted-foreground">{priceRuleMessages.perBookingFlatHint}</p>
+    )
+  }
+
   // Per-pax tour with no category cross-cut: render a simple unit-only table
   // (Sell / Cost) instead of the unit×category matrix. Operators on
   // accommodation products (or rules with allPricingCategories=false) still


### PR DESCRIPTION
## Summary

Closes #482. Implements Option A from the issue: a pricing rule whose `pricingMode = "per_booking"` cannot also carry per-unit prices, because the storefront totaller (`packages/storefront/src/service-departures.ts`) switches on the unit-level `pricingMode` and ignores the rule-level mode in that path. The "Per Booking" badge in the admin UI was effectively cosmetic when unit prices were present — operators saw "single flat amount per booking" and got per-unit-multiplied totals.

## Changes

### Service layer (`@voyantjs/pricing`)
- `createOptionUnitPriceRule` rejects creating a unit-price row whose parent rule has `pricingMode = "per_booking"` (`RequestValidationError`, 400).
- `updateOptionPriceRule` rejects flipping a rule's `pricingMode` to `per_booking` when child unit-price rows already exist.
- Existing `optionPriceRule.pricingMode = per_booking` rows with no unit-price children continue to work — the flat-base-amount path is unchanged.

### Admin UI
- The product-options pricing form (operator template + apps/dev playground) hides the unit-pricing matrix when the rule is per-booking and shows a helper pointing the operator at Per Person or Starting From if they want unit-level prices. The `Add cell` affordances and the `Edit cell` buttons are no longer rendered, so the form can't be used to seed the contradictory state.
- New i18n key `priceRules.perBookingFlatHint` in `@voyantjs/i18n` (en + ro).

## Test plan

- [x] 2 new integration tests in `packages/pricing/tests/integration/routes.test.ts`:
  - `POST /option-unit-price-rules rejects unit prices under a per_booking parent` → 400 with message mentioning `per_booking`
  - `PATCH /option-price-rules/:id rejects switching to per_booking when unit prices exist` → 400 with message mentioning `per_booking`
- [x] Test app updated to register `app.onError(handleApiError)` so the new validation throws surface as 400 (matches the framework's `createApp` behaviour).
- [x] `pnpm -F @voyantjs/pricing typecheck` clean.
- [x] `pnpm -F @voyantjs/pricing -F @voyantjs/i18n -F operator -F dev typecheck` clean.
- [x] `TEST_DATABASE_URL=… pnpm -F @voyantjs/pricing exec vitest run --no-file-parallelism` — 105/110. The 5 failures are in `departure-overrides.test.ts` and reproduce on `main` (pre-existing schema drift on `availability_slots.timezone NOT NULL`, unrelated to this PR).
- [ ] Smoke: in operator template, change a rule's pricing mode to "Per Booking" — expect the matrix to disappear and the helper to render. Try to add a unit price via the API on a per-booking rule → expect 400.

## Out of scope

- Pre-existing data audit: any production rows with `option_price_rules.pricing_mode = 'per_booking'` AND children in `option_unit_price_rules` are silently mis-totalling today. The schema change alone doesn't migrate them. Operators should query for these and decide per row whether to switch the rule to `per_person` (preserving the unit prices) or to delete the unit prices (preserving the flat per-booking amount). Worth flagging in release notes.
- Option B from the issue (dropping `per_booking` from `optionPricingModeEnum` entirely) — bigger structural change, defer until a clear case for it appears.