### PR TITLE
Fix #492: sync publishConfig.exports for vertical packages

### DIFF
--- a/.changeset/products-publish-exports-sync.md
+++ b/.changeset/products-publish-exports-sync.md
@@ -1,0 +1,19 @@
+---
+"@voyantjs/products": patch
+"@voyantjs/extras": patch
+"@voyantjs/cruises": patch
+"@voyantjs/charters": patch
+"@voyantjs/hospitality": patch
+---
+
+Fix #492: expose all workspace sub-paths in `publishConfig.exports` for vertical packages.
+
+`publishConfig.exports` (used at publish time) had drifted from the workspace `exports` map: catalog plane and content plane sub-paths shipped in `dist/` but were unreachable from the published package. Consumers installing from npm hit `ERR_PACKAGE_PATH_NOT_EXPORTED` / `TS2307` when importing them.
+
+Newly exposed sub-paths:
+
+- `@voyantjs/products`: `./catalog-policy`, `./service-catalog-plane`, `./content-shape`, `./service-content`, `./service-content-synthesizer`, `./routes-content`, `./draft-shape`
+- `@voyantjs/extras`: `./catalog-policy`, `./service-catalog-plane`, `./content-shape`, `./service-content`, `./service-content-synthesizer`, `./draft-shape`
+- `@voyantjs/cruises`: `./catalog-policy`, `./service-catalog-plane`, `./content-shape`, `./service-content-synthesizer`, `./routes-content`, `./draft-shape`
+- `@voyantjs/charters`: `./catalog-policy`, `./service-catalog-plane`, `./content-shape`, `./service-content`, `./service-content-synthesizer`, `./draft-shape`
+- `@voyantjs/hospitality`: `./catalog-policy`, `./service-catalog-plane`, `./content-shape`, `./service-content-synthesizer`, `./draft-shape`

--- a/packages/charters/package.json
+++ b/packages/charters/package.json
@@ -82,6 +82,36 @@
         "types": "./dist/adapters/index.d.ts",
         "import": "./dist/adapters/index.js",
         "default": "./dist/adapters/index.js"
+      },
+      "./catalog-policy": {
+        "types": "./dist/catalog-policy.d.ts",
+        "import": "./dist/catalog-policy.js",
+        "default": "./dist/catalog-policy.js"
+      },
+      "./service-catalog-plane": {
+        "types": "./dist/service-catalog-plane.d.ts",
+        "import": "./dist/service-catalog-plane.js",
+        "default": "./dist/service-catalog-plane.js"
+      },
+      "./content-shape": {
+        "types": "./dist/content-shape.d.ts",
+        "import": "./dist/content-shape.js",
+        "default": "./dist/content-shape.js"
+      },
+      "./service-content": {
+        "types": "./dist/service-content.d.ts",
+        "import": "./dist/service-content.js",
+        "default": "./dist/service-content.js"
+      },
+      "./service-content-synthesizer": {
+        "types": "./dist/service-content-synthesizer.d.ts",
+        "import": "./dist/service-content-synthesizer.js",
+        "default": "./dist/service-content-synthesizer.js"
+      },
+      "./draft-shape": {
+        "types": "./dist/draft-shape.d.ts",
+        "import": "./dist/draft-shape.js",
+        "default": "./dist/draft-shape.js"
       }
     },
     "main": "./dist/index.js",

--- a/packages/cruises/package.json
+++ b/packages/cruises/package.json
@@ -86,15 +86,45 @@
         "import": "./dist/adapters/index.js",
         "default": "./dist/adapters/index.js"
       },
-      "./booking-engine": {
-        "types": "./dist/booking-engine/index.d.ts",
-        "import": "./dist/booking-engine/index.js",
-        "default": "./dist/booking-engine/index.js"
+      "./catalog-policy": {
+        "types": "./dist/catalog-policy.d.ts",
+        "import": "./dist/catalog-policy.js",
+        "default": "./dist/catalog-policy.js"
+      },
+      "./service-catalog-plane": {
+        "types": "./dist/service-catalog-plane.d.ts",
+        "import": "./dist/service-catalog-plane.js",
+        "default": "./dist/service-catalog-plane.js"
+      },
+      "./content-shape": {
+        "types": "./dist/content-shape.d.ts",
+        "import": "./dist/content-shape.js",
+        "default": "./dist/content-shape.js"
       },
       "./service-content": {
         "types": "./dist/service-content.d.ts",
         "import": "./dist/service-content.js",
         "default": "./dist/service-content.js"
+      },
+      "./service-content-synthesizer": {
+        "types": "./dist/service-content-synthesizer.d.ts",
+        "import": "./dist/service-content-synthesizer.js",
+        "default": "./dist/service-content-synthesizer.js"
+      },
+      "./routes-content": {
+        "types": "./dist/routes-content.d.ts",
+        "import": "./dist/routes-content.js",
+        "default": "./dist/routes-content.js"
+      },
+      "./draft-shape": {
+        "types": "./dist/draft-shape.d.ts",
+        "import": "./dist/draft-shape.js",
+        "default": "./dist/draft-shape.js"
+      },
+      "./booking-engine": {
+        "types": "./dist/booking-engine/index.d.ts",
+        "import": "./dist/booking-engine/index.js",
+        "default": "./dist/booking-engine/index.js"
       },
       "./service-pricing": {
         "types": "./dist/service-pricing.d.ts",

--- a/packages/extras/package.json
+++ b/packages/extras/package.json
@@ -63,6 +63,36 @@
         "types": "./dist/routes.d.ts",
         "import": "./dist/routes.js",
         "default": "./dist/routes.js"
+      },
+      "./catalog-policy": {
+        "types": "./dist/catalog-policy.d.ts",
+        "import": "./dist/catalog-policy.js",
+        "default": "./dist/catalog-policy.js"
+      },
+      "./service-catalog-plane": {
+        "types": "./dist/service-catalog-plane.d.ts",
+        "import": "./dist/service-catalog-plane.js",
+        "default": "./dist/service-catalog-plane.js"
+      },
+      "./content-shape": {
+        "types": "./dist/content-shape.d.ts",
+        "import": "./dist/content-shape.js",
+        "default": "./dist/content-shape.js"
+      },
+      "./service-content": {
+        "types": "./dist/service-content.d.ts",
+        "import": "./dist/service-content.js",
+        "default": "./dist/service-content.js"
+      },
+      "./service-content-synthesizer": {
+        "types": "./dist/service-content-synthesizer.d.ts",
+        "import": "./dist/service-content-synthesizer.js",
+        "default": "./dist/service-content-synthesizer.js"
+      },
+      "./draft-shape": {
+        "types": "./dist/draft-shape.d.ts",
+        "import": "./dist/draft-shape.js",
+        "default": "./dist/draft-shape.js"
       }
     },
     "main": "./dist/index.js",

--- a/packages/hospitality/package.json
+++ b/packages/hospitality/package.json
@@ -66,15 +66,40 @@
         "import": "./dist/routes.js",
         "default": "./dist/routes.js"
       },
-      "./booking-engine": {
-        "types": "./dist/booking-engine/index.d.ts",
-        "import": "./dist/booking-engine/index.js",
-        "default": "./dist/booking-engine/index.js"
+      "./catalog-policy": {
+        "types": "./dist/catalog-policy.d.ts",
+        "import": "./dist/catalog-policy.js",
+        "default": "./dist/catalog-policy.js"
+      },
+      "./service-catalog-plane": {
+        "types": "./dist/service-catalog-plane.d.ts",
+        "import": "./dist/service-catalog-plane.js",
+        "default": "./dist/service-catalog-plane.js"
+      },
+      "./content-shape": {
+        "types": "./dist/content-shape.d.ts",
+        "import": "./dist/content-shape.js",
+        "default": "./dist/content-shape.js"
       },
       "./service-content": {
         "types": "./dist/service-content.d.ts",
         "import": "./dist/service-content.js",
         "default": "./dist/service-content.js"
+      },
+      "./service-content-synthesizer": {
+        "types": "./dist/service-content-synthesizer.d.ts",
+        "import": "./dist/service-content-synthesizer.js",
+        "default": "./dist/service-content-synthesizer.js"
+      },
+      "./draft-shape": {
+        "types": "./dist/draft-shape.d.ts",
+        "import": "./dist/draft-shape.js",
+        "default": "./dist/draft-shape.js"
+      },
+      "./booking-engine": {
+        "types": "./dist/booking-engine/index.d.ts",
+        "import": "./dist/booking-engine/index.js",
+        "default": "./dist/booking-engine/index.js"
       }
     },
     "main": "./dist/index.js",

--- a/packages/products/package.json
+++ b/packages/products/package.json
@@ -91,6 +91,41 @@
         "import": "./dist/booking-extension.js",
         "default": "./dist/booking-extension.js"
       },
+      "./catalog-policy": {
+        "types": "./dist/catalog-policy.d.ts",
+        "import": "./dist/catalog-policy.js",
+        "default": "./dist/catalog-policy.js"
+      },
+      "./service-catalog-plane": {
+        "types": "./dist/service-catalog-plane.d.ts",
+        "import": "./dist/service-catalog-plane.js",
+        "default": "./dist/service-catalog-plane.js"
+      },
+      "./content-shape": {
+        "types": "./dist/content-shape.d.ts",
+        "import": "./dist/content-shape.js",
+        "default": "./dist/content-shape.js"
+      },
+      "./service-content": {
+        "types": "./dist/service-content.d.ts",
+        "import": "./dist/service-content.js",
+        "default": "./dist/service-content.js"
+      },
+      "./service-content-synthesizer": {
+        "types": "./dist/service-content-synthesizer.d.ts",
+        "import": "./dist/service-content-synthesizer.js",
+        "default": "./dist/service-content-synthesizer.js"
+      },
+      "./routes-content": {
+        "types": "./dist/routes-content.d.ts",
+        "import": "./dist/routes-content.js",
+        "default": "./dist/routes-content.js"
+      },
+      "./draft-shape": {
+        "types": "./dist/draft-shape.d.ts",
+        "import": "./dist/draft-shape.js",
+        "default": "./dist/draft-shape.js"
+      },
       "./booking-engine": {
         "types": "./dist/booking-engine/index.d.ts",
         "import": "./dist/booking-engine/index.js",


### PR DESCRIPTION
## Summary

Closes #492.

`publishConfig.exports` (used at publish time, since the workspace `exports` map points at `src/*.ts`) had drifted from the workspace `exports` map across all 5 vertical packages. Sub-paths shipped in `dist/` but were unreachable from the published package — npm consumers got `ERR_PACKAGE_PATH_NOT_EXPORTED` / TS2307 when importing them.

The issue called out 2 missing sub-paths in `@voyantjs/products`. While auditing per the issue's suggestion, I found the same gap in `@voyantjs/{extras,cruises,charters,hospitality}`.

## Changes

Added missing `publishConfig.exports` entries:

- `@voyantjs/products` — `./catalog-policy`, `./service-catalog-plane`, `./content-shape`, `./service-content`, `./service-content-synthesizer`, `./routes-content`, `./draft-shape`
- `@voyantjs/extras` — `./catalog-policy`, `./service-catalog-plane`, `./content-shape`, `./service-content`, `./service-content-synthesizer`, `./draft-shape`
- `@voyantjs/cruises` — `./catalog-policy`, `./service-catalog-plane`, `./content-shape`, `./service-content-synthesizer`, `./routes-content`, `./draft-shape`
- `@voyantjs/charters` — `./catalog-policy`, `./service-catalog-plane`, `./content-shape`, `./service-content`, `./service-content-synthesizer`, `./draft-shape`
- `@voyantjs/hospitality` — `./catalog-policy`, `./service-catalog-plane`, `./content-shape`, `./service-content-synthesizer`, `./draft-shape`

Each entry only added if the source file exists in `packages/<pkg>/src/` (so the dist artifact will exist after `prepack` build).

Changeset: patch bump for all 5 packages.

## Test plan

- [x] `pnpm -F @voyantjs/{products,extras,cruises,charters,hospitality} typecheck` — all pass
- [x] `pnpm -F @voyantjs/products build` — verified `dist/` contains all 7 newly exported files (`.js` + `.d.ts`)
- [x] Repro script confirms each new `publishConfig.exports` entry resolves to a real built artifact
- [ ] After publish: install `@voyantjs/products` from npm in a scratch project and confirm `import {} from "@voyantjs/products/catalog-policy"` resolves