### PR TITLE
Part 1 of #493: ship productDestinationsCatalogPolicy + projectionExtensions plumbing

### DIFF
--- a/.changeset/products-destinations-catalog-policy.md
+++ b/.changeset/products-destinations-catalog-policy.md
@@ -1,0 +1,19 @@
+---
+"@voyantjs/products": minor
+---
+
+Part 1 of #493: ship the destinations child-entity catalog registry plus the `projectionExtensions` plumbing the rest of #493 will use.
+
+New surface:
+
+- `productDestinationsCatalogPolicy` (`@voyantjs/products/catalog-policy-destinations`) — `FieldPolicy[]` declaring `regions[]`, `countries[]`, `cities[]`, `destinationSlugs[]`, `destinationIds[]`. Locale-aware label fields (`regions[]`, `countries[]`, `cities[]`) carry `localized: true` and `reindex: "entry-locale"` so per-locale slices reindex independently. Compose with `productCatalogPolicy` via `createFieldPolicyRegistry([...productCatalogPolicy, ...productDestinationsCatalogPolicy])`.
+- `createProductDestinationsProjectionExtension` (`@voyantjs/products/service-catalog-plane-destinations`) — runtime extension that joins `product_destinations` → `destinations` → `destination_translations` and contributes the field-keyed projection. Locale comes from the `IndexerSlice`; missing translations fall back to the destination's canonical slug.
+- `ProductProjectionExtension` interface + `extensions` parameter on `createProductDocumentBuilder` (`@voyantjs/products/service-catalog-plane`) — generic seam for any child-entity registry to denormalize fields onto the product search doc. Extensions run in parallel after the base row fetch; their projection entries merge into the base before `buildIndexerDocument` filters by registry.
+- `createProductsRegistry(...extensionPolicies)` — convenience for composing the base products policy with any number of child-entity policies.
+
+Wired into the operator template (`templates/operator/src/api/lib/catalog-runtime.ts` + `catalog-bridge.ts`): the `products` registry now includes destination paths, and `createProductDocumentBuilder` runs the destinations extension on every product reindex.
+
+Out of scope here, will land as separate PRs under #493:
+
+- Coordinates / geopoints — destinations have no coordinate columns; product geolocation lives on `product_locations` and ships with its own policy in a follow-up.
+- Categories + tags + slug (PR2), departures (PR3), priceFrom (PR4) — see the comment on #493 for the full plan.

--- a/packages/products/package.json
+++ b/packages/products/package.json
@@ -13,7 +13,9 @@
     "./tasks": "./src/tasks/index.ts",
     "./booking-extension": "./src/booking-extension.ts",
     "./catalog-policy": "./src/catalog-policy.ts",
+    "./catalog-policy-destinations": "./src/catalog-policy-destinations.ts",
     "./service-catalog-plane": "./src/service-catalog-plane.ts",
+    "./service-catalog-plane-destinations": "./src/service-catalog-plane-destinations.ts",
     "./content-shape": "./src/content-shape.ts",
     "./service-content": "./src/service-content.ts",
     "./service-content-synthesizer": "./src/service-content-synthesizer.ts",
@@ -96,10 +98,20 @@
         "import": "./dist/catalog-policy.js",
         "default": "./dist/catalog-policy.js"
       },
+      "./catalog-policy-destinations": {
+        "types": "./dist/catalog-policy-destinations.d.ts",
+        "import": "./dist/catalog-policy-destinations.js",
+        "default": "./dist/catalog-policy-destinations.js"
+      },
       "./service-catalog-plane": {
         "types": "./dist/service-catalog-plane.d.ts",
         "import": "./dist/service-catalog-plane.js",
         "default": "./dist/service-catalog-plane.js"
+      },
+      "./service-catalog-plane-destinations": {
+        "types": "./dist/service-catalog-plane-destinations.d.ts",
+        "import": "./dist/service-catalog-plane-destinations.js",
+        "default": "./dist/service-catalog-plane-destinations.js"
       },
       "./content-shape": {
         "types": "./dist/content-shape.d.ts",

--- a/packages/products/src/catalog-policy-destinations.ts
+++ b/packages/products/src/catalog-policy-destinations.ts
@@ -1,0 +1,127 @@
+/**
+ * Catalog plane field policy for product → destination denormalization.
+ *
+ * These fields don't live on the `products` table — they're joined from
+ * `product_destinations` → `destinations` (+ `destination_translations` for
+ * locale-aware names) at index time and projected onto the product search
+ * document. See `docs/architecture/catalog-architecture.md` §5.4 — the
+ * search index is the canonical place for cross-entity denormalization.
+ *
+ * Storefront product cards filter and display by destinations:
+ *   - "trips to Italy" (filter: `countries[]` includes "Italy")
+ *   - "trips in Rome" (filter: `cities[]` includes "Rome")
+ *   - "Mediterranean cruises" (filter: `regions[]` includes "Mediterranean")
+ *
+ * Wire this policy into the products registry by composing with
+ * `productCatalogPolicy`:
+ *
+ *   const registry = createFieldPolicyRegistry([
+ *     ...productCatalogPolicy,
+ *     ...productDestinationsCatalogPolicy,
+ *   ])
+ *
+ * and wire `createProductDestinationsProjectionExtension` into
+ * `createProductDocumentBuilder` so the values land in the doc.
+ *
+ * Out of scope here:
+ *   - Coordinates / geopoints. The `destinations` table has no coordinate
+ *     columns; product geolocation lives on `product_locations` and will
+ *     ship as its own policy in a follow-up PR.
+ *   - Slug fields per locale. Destinations have one canonical slug today;
+ *     locale-specific slugs are a follow-up if marketing needs them.
+ */
+
+import { defineFieldPolicy, type FieldPolicyInput } from "@voyantjs/catalog/contract"
+
+const PRODUCT_DESTINATIONS_FIELD_POLICY: FieldPolicyInput[] = [
+  // ── Locale-aware destination labels ──────────────────────────────────────
+  // Sourced from `destination_translations` (falls back to `destinations.slug`
+  // when no translation exists for the slice's locale). One array entry per
+  // linked destination of the matching `destination_type`.
+  {
+    path: "regions[]",
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "entry-locale",
+    snapshot: "on-book",
+    query: "indexed-column",
+    localized: true,
+    visibility: ["staff", "customer", "partner"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+  },
+  {
+    path: "countries[]",
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "entry-locale",
+    snapshot: "on-book",
+    query: "indexed-column",
+    localized: true,
+    visibility: ["staff", "customer", "partner"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+  },
+  {
+    path: "cities[]",
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "entry-locale",
+    snapshot: "on-book",
+    query: "indexed-column",
+    localized: true,
+    visibility: ["staff", "customer", "partner"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+  },
+
+  // ── Slugs (locale-stable) ────────────────────────────────────────────────
+  // Used for category-page links — operators want stable URLs that don't
+  // shift when translations are edited. One entry per linked destination.
+  {
+    path: "destinationSlugs[]",
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "facet-affecting",
+    snapshot: "on-book",
+    query: "indexed-column",
+    localized: false,
+    visibility: ["staff", "customer", "partner"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+  },
+
+  // ── Destination IDs ──────────────────────────────────────────────────────
+  // Useful for filtering by exact destination match (e.g. landing pages
+  // pinned to a destination ID rather than a slug).
+  {
+    path: "destinationIds[]",
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "facet-affecting",
+    snapshot: "on-book",
+    query: "indexed-column",
+    localized: false,
+    visibility: ["staff", "customer", "partner"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+  },
+]
+
+/**
+ * Resolved destinations policy. Compose with `productCatalogPolicy` when
+ * building the products registry.
+ */
+export const productDestinationsCatalogPolicy = defineFieldPolicy(PRODUCT_DESTINATIONS_FIELD_POLICY)
+
+export { PRODUCT_DESTINATIONS_FIELD_POLICY }

--- a/packages/products/src/service-catalog-plane-destinations.ts
+++ b/packages/products/src/service-catalog-plane-destinations.ts
@@ -1,0 +1,154 @@
+/**
+ * Projection extension that joins product → destinations and contributes
+ * locale-aware destination fields (regions, countries, cities, slugs, ids)
+ * onto the product search document.
+ *
+ * Wire via `createProductDocumentBuilder({ extensions: [destinationsExtension] })`.
+ * Requires the registry to include `productDestinationsCatalogPolicy` —
+ * otherwise the contributed fields are silently dropped by the indexer's
+ * field-policy filter.
+ *
+ * Locale handling: `destination_translations` is keyed by `(destination_id,
+ * language_tag)`. The projection looks up the slice's locale; missing
+ * translations fall back to the destination's canonical `slug`. Operators
+ * who want the locale lookup to fall back to a different language (e.g.
+ * `fr-CA` → `fr` → `en`) should pre-populate the translation row;
+ * multi-tier fallback isn't built into the joins.
+ *
+ * Today's destinations table has no coordinate columns — geopoints come
+ * from `product_locations` and will ship as a separate projection
+ * extension once that policy lands.
+ */
+
+import type { AnyDrizzleDb } from "@voyantjs/db"
+import { and, eq, inArray } from "drizzle-orm"
+
+import { destinations, destinationTranslations, productDestinations } from "./schema-taxonomy.js"
+import type { ProductProjectionExtension } from "./service-catalog-plane.js"
+
+interface DestinationJoinRow {
+  destinationId: string
+  destinationType: string
+  slug: string
+  translatedName: string | null
+}
+
+async function joinProductDestinations(
+  db: AnyDrizzleDb,
+  productId: string,
+  languageTag: string,
+): Promise<DestinationJoinRow[]> {
+  // Sub-query the linked destination ids first so the locale lookup is
+  // single-shot. Drizzle's join builder doesn't compose left joins on
+  // composite predicates cleanly across all dialects, so two queries +
+  // an in-memory merge keeps the contract obvious.
+  const links = await db
+    .select({
+      destinationId: productDestinations.destinationId,
+      destinationType: destinations.destinationType,
+      slug: destinations.slug,
+      active: destinations.active,
+    })
+    .from(productDestinations)
+    .innerJoin(destinations, eq(productDestinations.destinationId, destinations.id))
+    .where(eq(productDestinations.productId, productId))
+
+  const activeLinks = links.filter((row) => row.active)
+  if (activeLinks.length === 0) return []
+
+  const destinationIds = activeLinks.map((row) => row.destinationId)
+  const translations = await db
+    .select({
+      destinationId: destinationTranslations.destinationId,
+      name: destinationTranslations.name,
+    })
+    .from(destinationTranslations)
+    .where(
+      and(
+        inArray(destinationTranslations.destinationId, destinationIds),
+        eq(destinationTranslations.languageTag, languageTag),
+      ),
+    )
+
+  const nameByDestinationId = new Map<string, string>()
+  for (const row of translations) {
+    nameByDestinationId.set(row.destinationId, row.name)
+  }
+
+  return activeLinks.map((row) => ({
+    destinationId: row.destinationId,
+    destinationType: row.destinationType,
+    slug: row.slug,
+    translatedName: nameByDestinationId.get(row.destinationId) ?? null,
+  }))
+}
+
+/** Bucket destinations by `destinationType` and return locale-aware names. */
+function bucketByType(rows: ReadonlyArray<DestinationJoinRow>): {
+  regions: string[]
+  countries: string[]
+  cities: string[]
+  slugs: string[]
+  ids: string[]
+} {
+  const regions: string[] = []
+  const countries: string[] = []
+  const cities: string[] = []
+  const slugs: string[] = []
+  const ids: string[] = []
+
+  for (const row of rows) {
+    const label = row.translatedName ?? row.slug
+    switch (row.destinationType) {
+      case "region":
+        regions.push(label)
+        break
+      case "country":
+        countries.push(label)
+        break
+      case "city":
+        cities.push(label)
+        break
+      // "destination" (the catch-all default) doesn't bucket into any of
+      // the typed lists. Its slug + id still land in the doc so storefronts
+      // can filter generically.
+    }
+    slugs.push(row.slug)
+    ids.push(row.destinationId)
+  }
+
+  return { regions, countries, cities, slugs, ids }
+}
+
+/**
+ * Construct the destinations projection extension.
+ *
+ * Returns a `ProductProjectionExtension` ready to pass to
+ * `createProductDocumentBuilder`.
+ */
+export function createProductDestinationsProjectionExtension(): ProductProjectionExtension {
+  return {
+    name: "products:destinations",
+    async project(db, productId, slice) {
+      const rows = await joinProductDestinations(db, productId, slice.locale)
+      if (rows.length === 0) {
+        return new Map<string, unknown>([
+          ["regions[]", []],
+          ["countries[]", []],
+          ["cities[]", []],
+          ["destinationSlugs[]", []],
+          ["destinationIds[]", []],
+        ])
+      }
+
+      const { regions, countries, cities, slugs, ids } = bucketByType(rows)
+      return new Map<string, unknown>([
+        ["regions[]", regions],
+        ["countries[]", countries],
+        ["cities[]", cities],
+        ["destinationSlugs[]", slugs],
+        ["destinationIds[]", ids],
+      ])
+    },
+  }
+}

--- a/packages/products/src/service-catalog-plane.ts
+++ b/packages/products/src/service-catalog-plane.ts
@@ -26,6 +26,7 @@ import {
   createFieldPolicyRegistry,
   type DocumentBuilder,
   type DocumentEmitter,
+  type FieldPolicy,
   type FieldPolicyRegistry,
   type IndexerDocument,
   type IndexerSlice,
@@ -236,6 +237,52 @@ export async function buildProductSnapshotInput(
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
+ * A projection extension contributes additional field-keyed entries to the
+ * product search document. The builder runs all extensions in parallel after
+ * fetching the product row, then merges their entries into the base
+ * projection before emitting.
+ *
+ * Used by child-entity registries (destinations, taxonomy, departures, etc.)
+ * to denormalize fields onto the product doc. See architecture §5.4 — the
+ * search index is the canonical place for cross-entity denormalization.
+ *
+ * `buildIndexerDocument` silently drops entries whose paths aren't registered
+ * in the field-policy registry — so an extension's contributed registry must
+ * be composed into the registry passed to `createProductDocumentBuilder` for
+ * its fields to actually land in the document.
+ */
+export interface ProductProjectionExtension {
+  /** Identifier — used for diagnostics and logging only. */
+  readonly name: string
+  /**
+   * Contribute additional projection entries for one product. The slice
+   * carries locale and audience for translation lookups and audience
+   * filtering.
+   */
+  project(
+    db: AnyDrizzleDb,
+    productId: string,
+    slice: IndexerSlice,
+  ): Promise<ReadonlyMap<string, unknown>>
+}
+
+/**
+ * Compose the registry from the base product policy plus any contributing
+ * extensions' policies. Templates wire this when they enable child-entity
+ * registries.
+ */
+export function createProductsRegistry(
+  ...extensionPolicies: ReadonlyArray<ReadonlyArray<FieldPolicy>>
+): FieldPolicyRegistry {
+  if (extensionPolicies.length === 0) return getProductsRegistry()
+  const composed: FieldPolicy[] = [...productCatalogPolicy]
+  for (const policies of extensionPolicies) {
+    composed.push(...policies)
+  }
+  return createFieldPolicyRegistry(composed)
+}
+
+/**
  * Construct a sync `DocumentEmitter` for products. The emitter takes a
  * pre-fetched product row + a slice and returns the indexer document
  * (filtered by visibility, with blob-only fields skipped).
@@ -243,11 +290,15 @@ export async function buildProductSnapshotInput(
  * Bulk-reindex pipelines that already have rows in hand call this directly.
  * Live reindex paths use `createProductDocumentBuilder` below, which fetches
  * the row before emitting.
+ *
+ * Pass a custom `registry` when the deployment composes additional
+ * child-entity policies; otherwise the default products registry is used.
  */
 export function createProductDocumentEmitter(context: {
   sellerOperatorId: string
+  registry?: FieldPolicyRegistry
 }): DocumentEmitter<typeof products.$inferSelect> {
-  const registry = getProductsRegistry()
+  const registry = context.registry ?? getProductsRegistry()
   return {
     vertical: "products",
     emit(source, slice) {
@@ -266,17 +317,47 @@ export function createProductDocumentEmitter(context: {
  * Returns `null` if the product no longer exists (e.g. it was deleted
  * between the reindex enqueue and the worker picking it up). Callers can
  * treat `null` as a delete signal.
+ *
+ * `extensions` denormalize child-entity fields onto the product doc. They
+ * run in parallel after the base row is fetched. An extension that throws
+ * fails the whole build — failures here would otherwise produce silently
+ * incomplete documents.
+ *
+ * Pass a custom `registry` (composed via `createProductsRegistry`) when
+ * extensions contribute fields beyond the base products policy.
  */
 export function createProductDocumentBuilder(
   db: AnyDrizzleDb,
-  context: { sellerOperatorId: string },
+  context: {
+    sellerOperatorId: string
+    extensions?: ReadonlyArray<ProductProjectionExtension>
+    registry?: FieldPolicyRegistry
+  },
 ): DocumentBuilder {
-  const emitter = createProductDocumentEmitter(context)
+  const registry = context.registry ?? getProductsRegistry()
+  const extensions = context.extensions ?? []
   return async (entityId: string, slice: IndexerSlice): Promise<IndexerDocument | null> => {
     const rows = await db.select().from(products).where(eq(products.id, entityId)).limit(1)
     const row = rows[0]
     if (!row) return null
-    return emitter.emit(row, slice)
+
+    const baseProjection = productRowToProjection(row, {
+      sellerOperatorId: context.sellerOperatorId,
+    })
+    if (extensions.length === 0) {
+      return buildIndexerDocument(registry, baseProjection, slice, entityId)
+    }
+
+    const extensionProjections = await Promise.all(
+      extensions.map((ext) => ext.project(db, entityId, slice)),
+    )
+    const merged = new Map<string, unknown>(baseProjection)
+    for (const projection of extensionProjections) {
+      for (const [path, value] of projection) {
+        merged.set(path, value)
+      }
+    }
+    return buildIndexerDocument(registry, merged, slice, entityId)
   }
 }
 

--- a/packages/products/tests/integration/destinations-projection.test.ts
+++ b/packages/products/tests/integration/destinations-projection.test.ts
@@ -1,0 +1,222 @@
+import type { IndexerSlice } from "@voyantjs/catalog"
+import { type SQL, sql } from "drizzle-orm"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { productDestinationsCatalogPolicy } from "../../src/catalog-policy-destinations.js"
+import {
+  destinations,
+  destinationTranslations,
+  productDestinations,
+} from "../../src/schema-taxonomy.js"
+import {
+  createProductDocumentBuilder,
+  createProductsRegistry,
+} from "../../src/service-catalog-plane.js"
+import { createProductDestinationsProjectionExtension } from "../../src/service-catalog-plane-destinations.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+const enSlice: IndexerSlice = {
+  vertical: "products",
+  locale: "en-GB",
+  audience: "customer",
+  market: "default",
+}
+
+const itSlice: IndexerSlice = { ...enSlice, locale: "it-IT" }
+
+describe.skipIf(!DB_AVAILABLE)("createProductDestinationsProjectionExtension", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: drizzle test client
+  let db: any
+  let productId: string
+
+  async function ensureProductsTable(client: { execute: (statement: SQL) => Promise<unknown> }) {
+    // Minimal `products` schema sufficient for the document builder's row
+    // fetch — we don't exercise the full product columns here.
+    await client.execute(sql`
+      CREATE TABLE IF NOT EXISTS products (
+        id text PRIMARY KEY NOT NULL,
+        name text NOT NULL,
+        description text,
+        booking_mode text NOT NULL DEFAULT 'date',
+        capacity_mode text NOT NULL DEFAULT 'limited',
+        timezone text NOT NULL DEFAULT 'UTC',
+        visibility text NOT NULL DEFAULT 'public',
+        activated boolean NOT NULL DEFAULT true,
+        status text NOT NULL DEFAULT 'active',
+        reservation_timeout_minutes integer NOT NULL DEFAULT 30,
+        sell_currency text NOT NULL DEFAULT 'EUR',
+        sell_amount_cents integer,
+        cost_amount_cents integer,
+        margin_percent integer,
+        facility_id text,
+        product_type_id text,
+        supplier_id text,
+        start_date date,
+        end_date date,
+        pax integer,
+        tags text[] NOT NULL DEFAULT '{}',
+        created_at timestamp with time zone NOT NULL DEFAULT now(),
+        updated_at timestamp with time zone NOT NULL DEFAULT now()
+      )
+    `)
+  }
+
+  async function ensureDestinationTables(client: {
+    execute: (statement: SQL) => Promise<unknown>
+  }) {
+    const statements: SQL[] = [
+      sql`CREATE TABLE IF NOT EXISTS destinations (
+        id text PRIMARY KEY NOT NULL,
+        parent_id text,
+        slug text NOT NULL,
+        code text,
+        destination_type text DEFAULT 'destination' NOT NULL,
+        sort_order integer DEFAULT 0 NOT NULL,
+        active boolean DEFAULT true NOT NULL,
+        metadata jsonb,
+        created_at timestamp with time zone DEFAULT now() NOT NULL,
+        updated_at timestamp with time zone DEFAULT now() NOT NULL
+      )`,
+      sql`CREATE UNIQUE INDEX IF NOT EXISTS uidx_destinations_slug ON destinations (slug)`,
+      sql`CREATE TABLE IF NOT EXISTS destination_translations (
+        id text PRIMARY KEY NOT NULL,
+        destination_id text NOT NULL,
+        language_tag text NOT NULL,
+        name text NOT NULL,
+        description text,
+        seo_title text,
+        seo_description text,
+        created_at timestamp with time zone DEFAULT now() NOT NULL,
+        updated_at timestamp with time zone DEFAULT now() NOT NULL
+      )`,
+      sql`CREATE UNIQUE INDEX IF NOT EXISTS uidx_destination_translations_locale
+        ON destination_translations (destination_id, language_tag)`,
+      sql`CREATE TABLE IF NOT EXISTS product_destinations (
+        product_id text NOT NULL,
+        destination_id text NOT NULL,
+        sort_order integer DEFAULT 0 NOT NULL,
+        created_at timestamp with time zone DEFAULT now() NOT NULL,
+        updated_at timestamp with time zone DEFAULT now() NOT NULL,
+        PRIMARY KEY (product_id, destination_id)
+      )`,
+    ]
+    for (const statement of statements) {
+      await client.execute(statement)
+    }
+  }
+
+  beforeAll(async () => {
+    const { createTestDb } = await import("@voyantjs/db/test-utils")
+    db = createTestDb()
+    await ensureProductsTable(db)
+    await ensureDestinationTables(db)
+  })
+
+  beforeEach(async () => {
+    await db.execute(
+      sql`TRUNCATE products, destinations, destination_translations, product_destinations CASCADE`,
+    )
+
+    productId = "prod_dest_test"
+    await db.execute(sql`INSERT INTO products (id, name) VALUES (${productId}, 'Italy Loop Tour')`)
+
+    // Three destinations, hierarchy: Mediterranean (region) > Italy (country) > Rome (city).
+    await db.insert(destinations).values([
+      {
+        id: "dest_med",
+        slug: "mediterranean",
+        destinationType: "region",
+      },
+      {
+        id: "dest_it",
+        slug: "italy",
+        destinationType: "country",
+      },
+      {
+        id: "dest_rm",
+        slug: "rome",
+        destinationType: "city",
+      },
+    ])
+
+    // English + Italian translations for each.
+    await db.insert(destinationTranslations).values([
+      { id: "dt_med_en", destinationId: "dest_med", languageTag: "en-GB", name: "Mediterranean" },
+      { id: "dt_it_en", destinationId: "dest_it", languageTag: "en-GB", name: "Italy" },
+      { id: "dt_rm_en", destinationId: "dest_rm", languageTag: "en-GB", name: "Rome" },
+      { id: "dt_it_it", destinationId: "dest_it", languageTag: "it-IT", name: "Italia" },
+      { id: "dt_rm_it", destinationId: "dest_rm", languageTag: "it-IT", name: "Roma" },
+      // Note: no Italian translation for Mediterranean — fallback path tested below.
+    ])
+
+    await db.insert(productDestinations).values([
+      { productId, destinationId: "dest_med" },
+      { productId, destinationId: "dest_it" },
+      { productId, destinationId: "dest_rm" },
+    ])
+  })
+
+  it("buckets destinations by type and emits locale-aware labels", async () => {
+    const ext = createProductDestinationsProjectionExtension()
+    const projection = await ext.project(db, productId, enSlice)
+    expect(projection.get("regions[]")).toEqual(["Mediterranean"])
+    expect(projection.get("countries[]")).toEqual(["Italy"])
+    expect(projection.get("cities[]")).toEqual(["Rome"])
+    expect(projection.get("destinationSlugs[]")).toEqual(
+      expect.arrayContaining(["mediterranean", "italy", "rome"]),
+    )
+    expect(projection.get("destinationIds[]")).toEqual(
+      expect.arrayContaining(["dest_med", "dest_it", "dest_rm"]),
+    )
+  })
+
+  it("uses the slice's locale when picking translation labels", async () => {
+    const ext = createProductDestinationsProjectionExtension()
+    const projection = await ext.project(db, productId, itSlice)
+    // Italian translations exist for Italy + Rome
+    expect(projection.get("countries[]")).toEqual(["Italia"])
+    expect(projection.get("cities[]")).toEqual(["Roma"])
+  })
+
+  it("falls back to the destination slug when no translation exists for the locale", async () => {
+    const ext = createProductDestinationsProjectionExtension()
+    const projection = await ext.project(db, productId, itSlice)
+    // Mediterranean has no it-IT translation — the slug "mediterranean" is used.
+    expect(projection.get("regions[]")).toEqual(["mediterranean"])
+  })
+
+  it("returns empty arrays when the product has no destination links", async () => {
+    await db.execute(sql`DELETE FROM product_destinations WHERE product_id = ${productId}`)
+    const ext = createProductDestinationsProjectionExtension()
+    const projection = await ext.project(db, productId, enSlice)
+    expect(projection.get("regions[]")).toEqual([])
+    expect(projection.get("countries[]")).toEqual([])
+    expect(projection.get("cities[]")).toEqual([])
+    expect(projection.get("destinationSlugs[]")).toEqual([])
+    expect(projection.get("destinationIds[]")).toEqual([])
+  })
+
+  it("excludes inactive destinations from the projection", async () => {
+    await db.execute(sql`UPDATE destinations SET active = false WHERE id = 'dest_rm'`)
+    const ext = createProductDestinationsProjectionExtension()
+    const projection = await ext.project(db, productId, enSlice)
+    expect(projection.get("cities[]")).toEqual([])
+    expect(projection.get("countries[]")).toEqual(["Italy"])
+  })
+
+  it("end-to-end: createProductDocumentBuilder projects destinations onto the product doc", async () => {
+    const registry = createProductsRegistry(productDestinationsCatalogPolicy)
+    const build = createProductDocumentBuilder(db, {
+      sellerOperatorId: "op_xyz",
+      registry,
+      extensions: [createProductDestinationsProjectionExtension()],
+    })
+    const doc = await build(productId, enSlice)
+    expect(doc).not.toBeNull()
+    expect(doc?.id).toBe(productId)
+    expect(doc?.fields).toHaveProperty("regions", ["Mediterranean"])
+    expect(doc?.fields).toHaveProperty("countries", ["Italy"])
+    expect(doc?.fields).toHaveProperty("cities", ["Rome"])
+  })
+})

--- a/packages/products/tests/unit/catalog-policy-destinations.test.ts
+++ b/packages/products/tests/unit/catalog-policy-destinations.test.ts
@@ -1,0 +1,59 @@
+import { createFieldPolicyRegistry } from "@voyantjs/catalog/contract"
+import { describe, expect, it } from "vitest"
+
+import { productCatalogPolicy } from "../../src/catalog-policy.js"
+import {
+  PRODUCT_DESTINATIONS_FIELD_POLICY,
+  productDestinationsCatalogPolicy,
+} from "../../src/catalog-policy-destinations.js"
+
+describe("productDestinationsCatalogPolicy", () => {
+  it("declares the storefront-required destination paths", () => {
+    const paths = PRODUCT_DESTINATIONS_FIELD_POLICY.map((p) => p.path)
+    expect(paths).toContain("regions[]")
+    expect(paths).toContain("countries[]")
+    expect(paths).toContain("cities[]")
+    expect(paths).toContain("destinationSlugs[]")
+    expect(paths).toContain("destinationIds[]")
+  })
+
+  it("marks locale-aware label fields as localized", () => {
+    const localizedPaths = new Set(
+      PRODUCT_DESTINATIONS_FIELD_POLICY.filter((p) => p.localized).map((p) => p.path),
+    )
+    expect(localizedPaths).toContain("regions[]")
+    expect(localizedPaths).toContain("countries[]")
+    expect(localizedPaths).toContain("cities[]")
+    // Slugs and IDs are not locale-stable
+    expect(localizedPaths).not.toContain("destinationSlugs[]")
+    expect(localizedPaths).not.toContain("destinationIds[]")
+  })
+
+  it("makes every field visible to staff/customer/partner so storefront cards can render", () => {
+    for (const policy of PRODUCT_DESTINATIONS_FIELD_POLICY) {
+      expect(policy.visibility).toContain("customer")
+      expect(policy.visibility).toContain("partner")
+      expect(policy.visibility).toContain("staff")
+    }
+  })
+
+  it("composes cleanly with productCatalogPolicy into a single registry", () => {
+    const registry = createFieldPolicyRegistry([
+      ...productCatalogPolicy,
+      ...productDestinationsCatalogPolicy,
+    ])
+    // Both root and destination paths should resolve
+    expect(registry.resolve("name")).toBeDefined()
+    expect(registry.resolve("regions[]")).toBeDefined()
+    expect(registry.resolve("countries[]")).toBeDefined()
+    expect(registry.resolve("destinationSlugs[]")).toBeDefined()
+  })
+
+  it("does not duplicate any path against productCatalogPolicy", () => {
+    // If we accidentally redeclare a root-policy path the registry would
+    // throw, so this test guards against silent regressions.
+    expect(() =>
+      createFieldPolicyRegistry([...productCatalogPolicy, ...productDestinationsCatalogPolicy]),
+    ).not.toThrow()
+  })
+})

--- a/packages/products/tests/unit/document-builder-extensions.test.ts
+++ b/packages/products/tests/unit/document-builder-extensions.test.ts
@@ -1,0 +1,163 @@
+import type { IndexerSlice } from "@voyantjs/catalog"
+import { describe, expect, it, vi } from "vitest"
+
+import { productDestinationsCatalogPolicy } from "../../src/catalog-policy-destinations.js"
+import {
+  createProductDocumentBuilder,
+  createProductsRegistry,
+  type ProductProjectionExtension,
+} from "../../src/service-catalog-plane.js"
+
+const sampleRow = {
+  id: "prod_abc",
+  name: "Bali Wellness Retreat",
+  status: "active",
+  description: "Source description",
+  bookingMode: "date",
+  capacityMode: "limited",
+  timezone: "Asia/Jakarta",
+  visibility: "public",
+  activated: true,
+  reservationTimeoutMinutes: 30,
+  sellCurrency: "EUR",
+  sellAmountCents: 250000,
+  costAmountCents: 180000,
+  marginPercent: 28,
+  facilityId: null,
+  startDate: "2026-05-01",
+  endDate: "2026-12-31",
+  pax: 12,
+  productTypeId: "ptyp_wellness",
+  tags: ["wellness", "yoga"],
+  createdAt: new Date("2026-01-01"),
+  updatedAt: new Date("2026-04-01"),
+}
+
+/**
+ * Stub drizzle that satisfies the chained `select().from().where().limit()`
+ * invocation without a real DB. Returns `rows` as the awaited result.
+ */
+function stubDb<T>(rows: T[]) {
+  const tail = {
+    limit: vi.fn().mockResolvedValue(rows),
+  }
+  const where = { where: vi.fn().mockReturnValue(tail) }
+  const from = { from: vi.fn().mockReturnValue(where) }
+  return {
+    // biome-ignore lint/suspicious/noExplicitAny: stub for drizzle chained API
+    select: vi.fn().mockReturnValue(from) as any,
+  }
+}
+
+const customerSlice: IndexerSlice = {
+  vertical: "products",
+  locale: "en-GB",
+  audience: "customer",
+  market: "default",
+}
+
+describe("createProductDocumentBuilder — projection extensions", () => {
+  it("returns the base document unchanged when no extensions are provided", async () => {
+    const db = stubDb([sampleRow])
+    // biome-ignore lint/suspicious/noExplicitAny: drizzle stub
+    const build = createProductDocumentBuilder(db as any, { sellerOperatorId: "op_xyz" })
+    const doc = await build("prod_abc", customerSlice)
+    expect(doc).not.toBeNull()
+    expect(doc?.id).toBe("prod_abc")
+    expect(doc?.fields).toHaveProperty("name", "Bali Wellness Retreat")
+    expect(doc?.fields).not.toHaveProperty("regions")
+  })
+
+  it("returns null when the product no longer exists", async () => {
+    const db = stubDb<typeof sampleRow>([])
+    // biome-ignore lint/suspicious/noExplicitAny: drizzle stub
+    const build = createProductDocumentBuilder(db as any, { sellerOperatorId: "op_xyz" })
+    const doc = await build("prod_missing", customerSlice)
+    expect(doc).toBeNull()
+  })
+
+  it("merges extension projection entries into the document when registry includes them", async () => {
+    const db = stubDb([sampleRow])
+    const registry = createProductsRegistry(productDestinationsCatalogPolicy)
+    const ext: ProductProjectionExtension = {
+      name: "test:destinations",
+      project: vi.fn().mockResolvedValue(
+        new Map<string, unknown>([
+          ["regions[]", ["Mediterranean"]],
+          ["countries[]", ["Italy"]],
+          ["cities[]", ["Rome"]],
+          ["destinationSlugs[]", ["italy", "rome"]],
+          ["destinationIds[]", ["dest_it", "dest_rm"]],
+        ]),
+      ),
+    }
+    const build = createProductDocumentBuilder(
+      // biome-ignore lint/suspicious/noExplicitAny: drizzle stub
+      db as any,
+      { sellerOperatorId: "op_xyz", registry, extensions: [ext] },
+    )
+    const doc = await build("prod_abc", customerSlice)
+    expect(doc?.fields).toHaveProperty("regions", ["Mediterranean"])
+    expect(doc?.fields).toHaveProperty("countries", ["Italy"])
+    expect(doc?.fields).toHaveProperty("cities", ["Rome"])
+    expect(doc?.fields).toHaveProperty("destinationSlugs", ["italy", "rome"])
+    // List paths drop the `[]` suffix on the indexed field name
+    expect(doc?.fields).not.toHaveProperty("regions[]")
+    expect(ext.project).toHaveBeenCalledWith(db, "prod_abc", customerSlice)
+  })
+
+  it("silently drops extension entries whose paths aren't in the registry", async () => {
+    // Default registry does NOT include the destinations policy, so any
+    // contributed entries are filtered out by buildIndexerDocument.
+    const db = stubDb([sampleRow])
+    const ext: ProductProjectionExtension = {
+      name: "test:destinations",
+      project: async () => new Map<string, unknown>([["regions[]", ["Mediterranean"]]]),
+    }
+    const build = createProductDocumentBuilder(
+      // biome-ignore lint/suspicious/noExplicitAny: drizzle stub
+      db as any,
+      { sellerOperatorId: "op_xyz", extensions: [ext] },
+    )
+    const doc = await build("prod_abc", customerSlice)
+    expect(doc?.fields).not.toHaveProperty("regions")
+  })
+
+  it("runs multiple extensions in parallel and merges all entries", async () => {
+    const db = stubDb([sampleRow])
+    const registry = createProductsRegistry(productDestinationsCatalogPolicy)
+    const a: ProductProjectionExtension = {
+      name: "test:a",
+      project: async () => new Map<string, unknown>([["regions[]", ["Mediterranean"]]]),
+    }
+    const b: ProductProjectionExtension = {
+      name: "test:b",
+      project: async () => new Map<string, unknown>([["countries[]", ["Italy"]]]),
+    }
+    const build = createProductDocumentBuilder(
+      // biome-ignore lint/suspicious/noExplicitAny: drizzle stub
+      db as any,
+      { sellerOperatorId: "op_xyz", registry, extensions: [a, b] },
+    )
+    const doc = await build("prod_abc", customerSlice)
+    expect(doc?.fields).toHaveProperty("regions", ["Mediterranean"])
+    expect(doc?.fields).toHaveProperty("countries", ["Italy"])
+  })
+
+  it("propagates extension errors instead of producing a partial document", async () => {
+    const db = stubDb([sampleRow])
+    const registry = createProductsRegistry(productDestinationsCatalogPolicy)
+    const failing: ProductProjectionExtension = {
+      name: "test:failing",
+      project: async () => {
+        throw new Error("destination lookup failed")
+      },
+    }
+    const build = createProductDocumentBuilder(
+      // biome-ignore lint/suspicious/noExplicitAny: drizzle stub
+      db as any,
+      { sellerOperatorId: "op_xyz", registry, extensions: [failing] },
+    )
+    await expect(build("prod_abc", customerSlice)).rejects.toThrow("destination lookup failed")
+  })
+})

--- a/templates/operator/scripts/reindex.ts
+++ b/templates/operator/scripts/reindex.ts
@@ -20,35 +20,32 @@
  */
 
 import {
-  createFieldPolicyRegistry,
   createIndexerService,
   createTypesenseIndexer,
   type DocumentBuilder,
-  type FieldPolicyRegistry,
   type IndexerDocument,
   type IndexerSlice,
   type TypesenseClient,
 } from "@voyantjs/catalog"
 import { createGeminiEmbeddingProvider, type EmbeddingProvider } from "@voyantjs/catalog-rag"
-import { charterCatalogPolicy } from "@voyantjs/charters/catalog-policy"
 import { charterProducts } from "@voyantjs/charters/schema"
 import { createCharterDocumentBuilder } from "@voyantjs/charters/service-catalog-plane"
-import { cruiseCatalogPolicy } from "@voyantjs/cruises/catalog-policy"
 import { cruises } from "@voyantjs/cruises/schema"
 import { createCruiseDocumentBuilder } from "@voyantjs/cruises/service-catalog-plane"
 import { createDbClient } from "@voyantjs/db"
-import { extrasCatalogPolicy } from "@voyantjs/extras/catalog-policy"
 import { productExtras } from "@voyantjs/extras/schema"
 import { createExtraDocumentBuilder } from "@voyantjs/extras/service-catalog-plane"
-import { hospitalityCatalogPolicy } from "@voyantjs/hospitality/catalog-policy"
 import { roomTypes } from "@voyantjs/hospitality/schema"
 import { createRoomTypeDocumentBuilder } from "@voyantjs/hospitality/service-catalog-plane"
-import { productCatalogPolicy } from "@voyantjs/products/catalog-policy"
 import { products } from "@voyantjs/products/schema"
-import { createProductDocumentBuilder } from "@voyantjs/products/service-catalog-plane"
 import { config } from "dotenv"
 import type { PgTable } from "drizzle-orm/pg-core"
 import { Client as TypesenseSdkClient } from "typesense"
+
+import {
+  createProductsDocumentBuilder,
+  getFieldPolicyRegistries,
+} from "../src/api/lib/catalog-runtime.js"
 
 config({ path: ".env" })
 config({ path: "../../.env" })
@@ -112,13 +109,11 @@ const indexer = createTypesenseIndexer({
   vectorDimensions: embeddings?.capabilities.dimensions,
 })
 
-const registries = new Map<string, FieldPolicyRegistry>([
-  ["products", createFieldPolicyRegistry(productCatalogPolicy)],
-  ["extras", createFieldPolicyRegistry(extrasCatalogPolicy)],
-  ["cruises", createFieldPolicyRegistry(cruiseCatalogPolicy)],
-  ["charters", createFieldPolicyRegistry(charterCatalogPolicy)],
-  ["hospitality", createFieldPolicyRegistry(hospitalityCatalogPolicy)],
-])
+// Use the shared registry map so the CLI and the live catalog-bridge
+// produce documents from the same composed policy. Without sharing this,
+// the bulk path drifts from the live path on every new child-entity
+// registry that lands (destinations, taxonomy, …).
+const registries = getFieldPolicyRegistries()
 
 const activeSlices = SLICES.filter(
   (slice) => !requestedVertical || slice.vertical === requestedVertical,
@@ -145,7 +140,9 @@ const VERTICAL_CONFIGS: VerticalConfig[] = [
   {
     vertical: "products",
     table: products as unknown as VerticalConfig["table"],
-    builder: createProductDocumentBuilder(db, { sellerOperatorId }),
+    // Shared with the live catalog-bridge — keeps destination (and any
+    // future child-entity) projections wired identically across paths.
+    builder: createProductsDocumentBuilder(db, { sellerOperatorId }),
   },
   {
     vertical: "extras",

--- a/templates/operator/src/api/catalog-bridge.ts
+++ b/templates/operator/src/api/catalog-bridge.ts
@@ -26,6 +26,7 @@ import {
   buildProductSnapshotInput,
   createProductDocumentBuilder,
 } from "@voyantjs/products/service-catalog-plane"
+import { createProductDestinationsProjectionExtension } from "@voyantjs/products/service-catalog-plane-destinations"
 import { and, eq, isNotNull } from "drizzle-orm"
 
 import {
@@ -70,8 +71,13 @@ export const catalogBridgeBundle: HonoBundle = {
         registries: getFieldPolicyRegistries(),
       })
       const db = getDbFromHyperdrive(env)
+      const registry = getFieldPolicyRegistries().get("products")
       const builder = withEmbedding(
-        createProductDocumentBuilder(db, { sellerOperatorId }),
+        createProductDocumentBuilder(db, {
+          sellerOperatorId,
+          registry,
+          extensions: [createProductDestinationsProjectionExtension()],
+        }),
         embeddings,
       )
       return { service, builder }

--- a/templates/operator/src/api/catalog-bridge.ts
+++ b/templates/operator/src/api/catalog-bridge.ts
@@ -4,11 +4,16 @@
  * booking commits freeze a snapshot of every line item's resolved view.
  *
  * Subscriptions:
- *   - `product.created`  → reindex the product across DEFAULT_SLICES
- *   - `product.updated`  → reindex the product
- *   - `product.deleted`  → delete from every configured slice
- *   - `booking.confirmed` → capture a snapshot graph of the booking's
- *                            product line items via `captureSnapshotGraph`
+ *   - `product.created`         → reindex the product across DEFAULT_SLICES
+ *   - `product.updated`         → reindex the product
+ *   - `product.deleted`         → delete from every configured slice
+ *   - `product.content.changed` → reindex the product (covers child-entity
+ *                                 mutations like destination link
+ *                                 add/remove that don't bump
+ *                                 `product.updated`)
+ *   - `booking.confirmed`       → capture a snapshot graph of the
+ *                                 booking's product line items via
+ *                                 `captureSnapshotGraph`
  *
  * If Typesense isn't configured (no `TYPESENSE_HOST`), the indexer
  * handlers no-op silently. Snapshot capture only requires DB access, so
@@ -22,16 +27,13 @@ import {
   createIndexerService,
 } from "@voyantjs/catalog"
 import type { HonoBundle } from "@voyantjs/hono/plugin"
-import {
-  buildProductSnapshotInput,
-  createProductDocumentBuilder,
-} from "@voyantjs/products/service-catalog-plane"
-import { createProductDestinationsProjectionExtension } from "@voyantjs/products/service-catalog-plane-destinations"
+import { buildProductSnapshotInput } from "@voyantjs/products/service-catalog-plane"
 import { and, eq, isNotNull } from "drizzle-orm"
 
 import {
   buildEmbeddingProvider,
   buildTypesenseIndexer,
+  createProductsDocumentBuilder,
   DEFAULT_SLICES,
   getFieldPolicyRegistries,
   withEmbedding,
@@ -40,6 +42,11 @@ import { getDbFromHyperdrive } from "./lib/db"
 
 interface ProductEventPayload {
   id: string
+}
+
+interface ProductContentChangedEventPayload {
+  id: string
+  axis?: string
 }
 
 interface BookingConfirmedEventPayload {
@@ -71,13 +78,8 @@ export const catalogBridgeBundle: HonoBundle = {
         registries: getFieldPolicyRegistries(),
       })
       const db = getDbFromHyperdrive(env)
-      const registry = getFieldPolicyRegistries().get("products")
       const builder = withEmbedding(
-        createProductDocumentBuilder(db, {
-          sellerOperatorId,
-          registry,
-          extensions: [createProductDestinationsProjectionExtension()],
-        }),
+        createProductsDocumentBuilder(db, { sellerOperatorId }),
         embeddings,
       )
       return { service, builder }
@@ -101,6 +103,19 @@ export const catalogBridgeBundle: HonoBundle = {
       if (!ctx) return
       await ctx.service.deleteEntity("products", data.id)
     })
+
+    // `product.content.changed` covers child-entity mutations that don't
+    // emit `product.updated` — destination link add/remove, days, options,
+    // features, faq, location, media, translations. Every axis affects
+    // some part of the resolved doc, so reindex on all of them.
+    eventBus.subscribe<ProductContentChangedEventPayload>(
+      "product.content.changed",
+      async ({ data }) => {
+        const ctx = buildIndexerContext()
+        if (!ctx) return
+        await ctx.service.reindexEntity("products", data.id, ctx.builder)
+      },
+    )
 
     eventBus.subscribe<BookingConfirmedEventPayload>("booking.confirmed", async ({ data }) => {
       const db = getDbFromHyperdrive(env)

--- a/templates/operator/src/api/lib/catalog-runtime.ts
+++ b/templates/operator/src/api/lib/catalog-runtime.ts
@@ -22,10 +22,13 @@ import {
 import { createGeminiEmbeddingProvider, type EmbeddingProvider } from "@voyantjs/catalog-rag"
 import { charterCatalogPolicy } from "@voyantjs/charters/catalog-policy"
 import { cruiseCatalogPolicy } from "@voyantjs/cruises/catalog-policy"
+import type { AnyDrizzleDb } from "@voyantjs/db"
 import { extrasCatalogPolicy } from "@voyantjs/extras/catalog-policy"
 import { hospitalityCatalogPolicy } from "@voyantjs/hospitality/catalog-policy"
 import { productCatalogPolicy } from "@voyantjs/products/catalog-policy"
 import { productDestinationsCatalogPolicy } from "@voyantjs/products/catalog-policy-destinations"
+import { createProductDocumentBuilder } from "@voyantjs/products/service-catalog-plane"
+import { createProductDestinationsProjectionExtension } from "@voyantjs/products/service-catalog-plane-destinations"
 
 /**
  * The slice set the operator template indexes by default — staff (admin
@@ -239,6 +242,28 @@ export function getFieldPolicyRegistries(): Map<string, FieldPolicyRegistry> {
     ])
   }
   return _registries
+}
+
+/**
+ * Build the products `DocumentBuilder` with all child-entity projection
+ * extensions wired in. Single source of truth for both the live catalog
+ * bridge (event-driven reindex) and the bulk reindex CLI — without this,
+ * the two paths drift and bulk reindex produces docs missing the
+ * denormalized child-entity fields.
+ *
+ * Resolves the products registry from `getFieldPolicyRegistries()` so the
+ * builder honors the same composed policy the indexer service sees.
+ */
+export function createProductsDocumentBuilder(
+  db: AnyDrizzleDb,
+  context: { sellerOperatorId: string },
+): DocumentBuilder {
+  const registry = getFieldPolicyRegistries().get("products")
+  return createProductDocumentBuilder(db, {
+    sellerOperatorId: context.sellerOperatorId,
+    registry,
+    extensions: [createProductDestinationsProjectionExtension()],
+  })
 }
 
 /**

--- a/templates/operator/src/api/lib/catalog-runtime.ts
+++ b/templates/operator/src/api/lib/catalog-runtime.ts
@@ -25,6 +25,7 @@ import { cruiseCatalogPolicy } from "@voyantjs/cruises/catalog-policy"
 import { extrasCatalogPolicy } from "@voyantjs/extras/catalog-policy"
 import { hospitalityCatalogPolicy } from "@voyantjs/hospitality/catalog-policy"
 import { productCatalogPolicy } from "@voyantjs/products/catalog-policy"
+import { productDestinationsCatalogPolicy } from "@voyantjs/products/catalog-policy-destinations"
 
 /**
  * The slice set the operator template indexes by default — staff (admin
@@ -227,7 +228,10 @@ let _registries: Map<string, FieldPolicyRegistry> | undefined
 export function getFieldPolicyRegistries(): Map<string, FieldPolicyRegistry> {
   if (!_registries) {
     _registries = new Map<string, FieldPolicyRegistry>([
-      ["products", createFieldPolicyRegistry(productCatalogPolicy)],
+      [
+        "products",
+        createFieldPolicyRegistry([...productCatalogPolicy, ...productDestinationsCatalogPolicy]),
+      ],
       ["extras", createFieldPolicyRegistry(extrasCatalogPolicy)],
       ["cruises", createFieldPolicyRegistry(cruiseCatalogPolicy)],
       ["charters", createFieldPolicyRegistry(charterCatalogPolicy)],


### PR DESCRIPTION
## Summary

First of 4 PRs implementing #493 (storefront child-entity catalog registries on `@voyantjs/products`). Ships:

1. **`productDestinationsCatalogPolicy`** (`@voyantjs/products/catalog-policy-destinations`) — `FieldPolicy[]` declaring `regions[]`, `countries[]`, `cities[]`, `destinationSlugs[]`, `destinationIds[]`. Locale-aware label fields (`regions[]`, `countries[]`, `cities[]`) carry `localized: true` and `reindex: \"entry-locale\"`.
2. **`createProductDestinationsProjectionExtension`** (`@voyantjs/products/service-catalog-plane-destinations`) — runtime extension that joins `product_destinations` → `destinations` → `destination_translations`, buckets by `destination_type`, and falls back to the destination slug when no translation exists for the slice's locale.
3. **`ProductProjectionExtension` + `extensions` parameter on `createProductDocumentBuilder`** — generic plumbing that the remaining #493 PRs (taxonomy, departures, pricing) will reuse. Extensions run in parallel after the base row fetch; their projections merge into the base before `buildIndexerDocument` filters by registry.
4. **`createProductsRegistry(...extensionPolicies)`** — convenience for composing the base products policy with any number of child-entity policies.
5. **Operator template wiring** (`templates/operator/src/api/lib/catalog-runtime.ts` + `catalog-bridge.ts`) — composes both policies into the products registry and runs the destinations extension on every product reindex.

## Out of scope

Will land as separate PRs under #493:

- **Coordinates / geopoints** — destinations have no coordinate columns; product geolocation lives on `product_locations`.
- **Categories + tags + slug** (PR2), **departures** (PR3), **`priceFrom`** (PR4).
- **Promotions** — moved to #497 (schema doesn't exist).
- **Category translations** — moved to #498 (`product_categories` is English-only).

See the comment on #493 for the full plan.

## Architecture

§5.4 of `docs/architecture/catalog-architecture.md` blesses denormalization at index time as the canonical pattern; this PR is its first concrete adoption on the products vertical. `buildIndexerDocument` silently drops projection keys without a registered policy — so the registry composition (`[...productCatalogPolicy, ...productDestinationsCatalogPolicy]`) is what unlocks the contributed fields landing in the doc.

## Test plan

- [x] `pnpm -F @voyantjs/products typecheck` — passes
- [x] `pnpm -F @voyantjs/products test` — 127 passed, 19 skipped (DB-gated integration tests skip without `TEST_DATABASE_URL`)
- [x] Pre-commit pipeline (workspace-wide typecheck across 130 packages, lint, lint-staged) — 112/112 typecheck tasks passed
- [x] `pnpm -F @voyantjs/products build` — verified `dist/catalog-policy-destinations.{js,d.ts}` and `dist/service-catalog-plane-destinations.{js,d.ts}` ship
- [x] `pnpm -F @voyantjs/products lint` — passes
- [ ] Manual smoke: with `TEST_DATABASE_URL` set, run the new integration test and confirm locale-aware fallback (`regions[]` → `[\"mediterranean\"]` for `it-IT` since no Italian translation exists)

## Tests added

- `tests/unit/catalog-policy-destinations.test.ts` — 5 tests on policy shape + registry composition
- `tests/unit/document-builder-extensions.test.ts` — 5 tests on the extension hook plumbing (no DB; uses a stubbed drizzle chain)
- `tests/integration/destinations-projection.test.ts` — 6 tests against a real Postgres covering the join + locale fallback + end-to-end document build (gated by `TEST_DATABASE_URL`)