### PR TITLE
Part 2 of #493: ship productTaxonomyCatalogPolicy with ancestor denormalization

### DIFF
--- a/.changeset/products-taxonomy-catalog-policy.md
+++ b/.changeset/products-taxonomy-catalog-policy.md
@@ -1,0 +1,20 @@
+---
+"@voyantjs/products": minor
+---
+
+Part 2 of #493: ship the taxonomy child-entity catalog registry — denormalize product categories (with full ancestor walk) and structured tags onto the product search document.
+
+New surface:
+
+- `productTaxonomyCatalogPolicy` (`@voyantjs/products/catalog-policy-taxonomy`) — `FieldPolicy[]` declaring `categories[]`, `categoryIds[]`, `categorySlugs[]`, `primaryCategoryId`, `primaryCategoryName`, `primaryCategorySlug`, `tagLabels[]`, `tagIds[]`. Compose with `productCatalogPolicy` via `createFieldPolicyRegistry([...productCatalogPolicy, ...productTaxonomyCatalogPolicy])`.
+- `createProductTaxonomyProjectionExtension` (`@voyantjs/products/service-catalog-plane-taxonomy`) — runtime extension that joins `product_category_products` → `product_categories` (walking the parent chain so a leaf-only link surfaces every active ancestor) and `product_tag_products` → `product_tags`. Inactive categories/ancestors are excluded so an operator-paused parent stops surfacing children under the parent filter. Primary category = the lowest-`sortOrder` direct link, ties broken by name.
+- New `category` and `tag` axis values on `ProductContentChangedEvent`, emitted from the four product → category and product → tag link-mutation routes in `routes.ts`. Without these, the catalog bridge would not reindex on link changes and the new fields would silently go stale.
+
+Hierarchy denormalization is the load-bearing part of this PR: Typesense can't recurse, so a product linked to "Hiking" (parent: "Adventure") needs both labels in `categories[]` for an "Adventure" filter to match a single equality. The extension walks the chain iteratively (bounded by tree depth, cycle-protected) instead of relying on a recursive CTE — keeps the join inside Drizzle and the unit-test surface a pure function.
+
+Wired into the operator template (`templates/operator/src/api/lib/catalog-runtime.ts`): the `products` registry now includes taxonomy paths, and `createProductsDocumentBuilder` runs both the destinations and taxonomy extensions on every product reindex (live + bulk paths share the same builder per the PR #499 fix).
+
+Out of scope here, tracked as follow-ups:
+
+- Locale-aware category/tag names. `product_categories.name` and `product_tags.name` are single columns today (no `category_translations`/`tag_translations` tables). All fields ship `localized: false` until a schema migration with backfill lands. Tracked in #502.
+- `priceFrom` (PR4) and departures aggregations (PR3) per the #493 plan.

--- a/packages/products/package.json
+++ b/packages/products/package.json
@@ -14,8 +14,10 @@
     "./booking-extension": "./src/booking-extension.ts",
     "./catalog-policy": "./src/catalog-policy.ts",
     "./catalog-policy-destinations": "./src/catalog-policy-destinations.ts",
+    "./catalog-policy-taxonomy": "./src/catalog-policy-taxonomy.ts",
     "./service-catalog-plane": "./src/service-catalog-plane.ts",
     "./service-catalog-plane-destinations": "./src/service-catalog-plane-destinations.ts",
+    "./service-catalog-plane-taxonomy": "./src/service-catalog-plane-taxonomy.ts",
     "./content-shape": "./src/content-shape.ts",
     "./service-content": "./src/service-content.ts",
     "./service-content-synthesizer": "./src/service-content-synthesizer.ts",
@@ -103,6 +105,11 @@
         "import": "./dist/catalog-policy-destinations.js",
         "default": "./dist/catalog-policy-destinations.js"
       },
+      "./catalog-policy-taxonomy": {
+        "types": "./dist/catalog-policy-taxonomy.d.ts",
+        "import": "./dist/catalog-policy-taxonomy.js",
+        "default": "./dist/catalog-policy-taxonomy.js"
+      },
       "./service-catalog-plane": {
         "types": "./dist/service-catalog-plane.d.ts",
         "import": "./dist/service-catalog-plane.js",
@@ -112,6 +119,11 @@
         "types": "./dist/service-catalog-plane-destinations.d.ts",
         "import": "./dist/service-catalog-plane-destinations.js",
         "default": "./dist/service-catalog-plane-destinations.js"
+      },
+      "./service-catalog-plane-taxonomy": {
+        "types": "./dist/service-catalog-plane-taxonomy.d.ts",
+        "import": "./dist/service-catalog-plane-taxonomy.js",
+        "default": "./dist/service-catalog-plane-taxonomy.js"
       },
       "./content-shape": {
         "types": "./dist/content-shape.d.ts",

--- a/packages/products/src/catalog-policy-taxonomy.ts
+++ b/packages/products/src/catalog-policy-taxonomy.ts
@@ -1,0 +1,189 @@
+/**
+ * Catalog plane field policy for product → taxonomy denormalization
+ * (categories + tags).
+ *
+ * These fields don't live on the `products` table — they're joined from
+ * `product_category_products` → `product_categories` (with parent walk for
+ * hierarchy denormalization) and `product_tag_products` → `product_tags` at
+ * index time and projected onto the product search document. See
+ * `docs/architecture/catalog-architecture.md` §5.4 — the search index is the
+ * canonical place for cross-entity denormalization.
+ *
+ * Storefront product cards filter and display by taxonomy:
+ *   - "Adventure tours" (filter: `categories[]` includes "Adventure")
+ *   - A product tagged "Hiking" (parent "Adventure") MUST also surface under
+ *     the "Adventure" filter — Typesense can't recurse, so the projection
+ *     denormalizes the full ancestor chain into `categories[]` /
+ *     `categoryIds[]`.
+ *   - "Family-friendly" (filter: `tags[]` includes "Family-friendly")
+ *
+ * Wire this policy into the products registry by composing with
+ * `productCatalogPolicy`:
+ *
+ *   const registry = createFieldPolicyRegistry([
+ *     ...productCatalogPolicy,
+ *     ...productTaxonomyCatalogPolicy,
+ *   ])
+ *
+ * and wire `createProductTaxonomyProjectionExtension` into
+ * `createProductDocumentBuilder` so the values land in the doc.
+ *
+ * Out of scope here:
+ *   - Locale-aware names. `product_categories.name` and `product_tags.name`
+ *     are single columns today (no `category_translations` / `tag_translations`
+ *     tables). Adding locale support needs a schema migration with backfill
+ *     and is tracked as a follow-up. Until then, these fields ship
+ *     `localized: false` and the same name lands on every locale slice.
+ *   - Tag hierarchy. Tags are flat by design.
+ */
+
+import { defineFieldPolicy, type FieldPolicyInput } from "@voyantjs/catalog/contract"
+
+const PRODUCT_TAXONOMY_FIELD_POLICY: FieldPolicyInput[] = [
+  // ── Category labels (denormalized with ancestors) ────────────────────────
+  // One entry per category in the linked-category-plus-ancestors set, deduped.
+  // A product linked to "Hiking" (parent: "Adventure") emits both
+  // ["Hiking", "Adventure"] so any-level filter matches a single equality.
+  {
+    path: "categories[]",
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "facet-affecting",
+    snapshot: "on-book",
+    query: "indexed-column",
+    localized: false,
+    visibility: ["staff", "customer", "partner"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+  },
+
+  // ── Category IDs (denormalized with ancestors) ───────────────────────────
+  // Same denormalization as `categories[]` but for ID-based filters
+  // (landing pages pinned to a category id rather than a label).
+  {
+    path: "categoryIds[]",
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "facet-affecting",
+    snapshot: "on-book",
+    query: "indexed-column",
+    localized: false,
+    visibility: ["staff", "customer", "partner"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+  },
+
+  // ── Category slugs (locale-stable, denormalized with ancestors) ──────────
+  // Storefront category-page links want stable URLs that don't shift when
+  // labels are edited. `product_categories.slug` exists today.
+  {
+    path: "categorySlugs[]",
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "facet-affecting",
+    snapshot: "on-book",
+    query: "indexed-column",
+    localized: false,
+    visibility: ["staff", "customer", "partner"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+  },
+
+  // ── Primary category (single, for badge display) ─────────────────────────
+  // Picked as the directly-linked category with the lowest sortOrder on
+  // `product_category_products` (the operator-controlled per-product
+  // ordering); ties broken by category name. Ancestors are NOT considered
+  // for primary — operators pin a leaf via the link table. Null when the
+  // product has no category links.
+  {
+    path: "primaryCategoryId",
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "facet-affecting",
+    snapshot: "on-book",
+    query: "indexed-column",
+    localized: false,
+    visibility: ["staff", "customer", "partner"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+  },
+  {
+    path: "primaryCategoryName",
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "facet-affecting",
+    snapshot: "on-book",
+    query: "indexed-column",
+    localized: false,
+    visibility: ["staff", "customer", "partner"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+  },
+  {
+    path: "primaryCategorySlug",
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "facet-affecting",
+    snapshot: "on-book",
+    query: "indexed-column",
+    localized: false,
+    visibility: ["staff", "customer", "partner"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+  },
+
+  // ── Tag labels ───────────────────────────────────────────────────────────
+  // `products.tags` (a free-form `text[]` column) already projects to
+  // `tags[]` from the base product policy. The structured `product_tags`
+  // table is a separate, normalized taxonomy — its labels land here under
+  // `tagLabels[]` to avoid colliding with the legacy column. One entry per
+  // linked tag.
+  {
+    path: "tagLabels[]",
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "facet-affecting",
+    snapshot: "on-book",
+    query: "indexed-column",
+    localized: false,
+    visibility: ["staff", "customer", "partner"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+  },
+  {
+    path: "tagIds[]",
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "facet-affecting",
+    snapshot: "on-book",
+    query: "indexed-column",
+    localized: false,
+    visibility: ["staff", "customer", "partner"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+  },
+]
+
+/**
+ * Resolved taxonomy policy. Compose with `productCatalogPolicy` when
+ * building the products registry.
+ */
+export const productTaxonomyCatalogPolicy = defineFieldPolicy(PRODUCT_TAXONOMY_FIELD_POLICY)
+
+export { PRODUCT_TAXONOMY_FIELD_POLICY }

--- a/packages/products/src/events.ts
+++ b/packages/products/src/events.ts
@@ -31,6 +31,8 @@ export interface ProductContentChangedEvent {
     | "faq"
     | "location"
     | "destination"
+    | "category"
+    | "tag"
     | "translation"
 }
 

--- a/packages/products/src/routes.ts
+++ b/packages/products/src/routes.ts
@@ -1591,6 +1591,7 @@ export const productRoutes = new Hono<Env>()
   })
 
   .post("/:id/categories", async (c) => {
+    const productId = c.req.param("id")
     const { categoryId, sortOrder } = await parseJsonBody(
       c,
       z.object({
@@ -1600,25 +1601,28 @@ export const productRoutes = new Hono<Env>()
     )
     const row = await productsService.addProductToCategory(
       c.get("db"),
-      c.req.param("id"),
+      productId,
       categoryId,
       sortOrder,
     )
     if (!row) {
       return c.json({ error: "Already assigned or not found" }, 409)
     }
+    await emitProductContentChanged(c.get("eventBus"), { id: productId, axis: "category" })
     return c.json({ success: true }, 201)
   })
 
   .delete("/:id/categories/:categoryId", async (c) => {
+    const productId = c.req.param("id")
     const row = await productsService.removeProductFromCategory(
       c.get("db"),
-      c.req.param("id"),
+      productId,
       c.req.param("categoryId"),
     )
     if (!row) {
       return c.json({ error: "Association not found" }, 404)
     }
+    await emitProductContentChanged(c.get("eventBus"), { id: productId, axis: "category" })
     return c.json({ success: true }, 200)
   })
 
@@ -1633,28 +1637,28 @@ export const productRoutes = new Hono<Env>()
   })
 
   .post("/:id/tags", async (c) => {
+    const productId = c.req.param("id")
     const { tagId } = await parseJsonBody(
       c,
       z.object({
         tagId: z.string(),
       }),
     )
-    const row = await productsService.addProductTag(c.get("db"), c.req.param("id"), tagId)
+    const row = await productsService.addProductTag(c.get("db"), productId, tagId)
     if (!row) {
       return c.json({ error: "Already assigned or not found" }, 409)
     }
+    await emitProductContentChanged(c.get("eventBus"), { id: productId, axis: "tag" })
     return c.json({ success: true }, 201)
   })
 
   .delete("/:id/tags/:tagId", async (c) => {
-    const row = await productsService.removeProductTag(
-      c.get("db"),
-      c.req.param("id"),
-      c.req.param("tagId"),
-    )
+    const productId = c.req.param("id")
+    const row = await productsService.removeProductTag(c.get("db"), productId, c.req.param("tagId"))
     if (!row) {
       return c.json({ error: "Association not found" }, 404)
     }
+    await emitProductContentChanged(c.get("eventBus"), { id: productId, axis: "tag" })
     return c.json({ success: true }, 200)
   })
 

--- a/packages/products/src/service-catalog-plane-taxonomy.ts
+++ b/packages/products/src/service-catalog-plane-taxonomy.ts
@@ -1,0 +1,246 @@
+/**
+ * Projection extension that joins product → categories (with ancestor walk)
+ * and product → tags, contributing taxonomy fields onto the product search
+ * document.
+ *
+ * Wire via `createProductDocumentBuilder({ extensions: [taxonomyExtension] })`.
+ * Requires the registry to include `productTaxonomyCatalogPolicy` —
+ * otherwise the contributed fields are silently dropped by the indexer's
+ * field-policy filter.
+ *
+ * Hierarchy denormalization: Typesense can't recurse, so a product linked
+ * to "Hiking" (parent: "Adventure") needs both labels in `categories[]` for
+ * the "Adventure" filter to match. The projection walks the parent chain
+ * iteratively, filtering inactive ancestors (so an operator-paused parent
+ * stops surfacing its still-active children under the parent filter).
+ *
+ * Today's schema has no translation tables for categories/tags (single
+ * `name` columns). The same name lands on every locale slice. Locale support
+ * is a follow-up that needs a schema migration with backfill.
+ */
+
+import type { AnyDrizzleDb } from "@voyantjs/db"
+import { and, eq, inArray } from "drizzle-orm"
+
+import {
+  productCategories,
+  productCategoryProducts,
+  productTagProducts,
+  productTags,
+} from "./schema-taxonomy.js"
+import type { ProductProjectionExtension } from "./service-catalog-plane.js"
+
+interface CategoryRow {
+  id: string
+  parentId: string | null
+  name: string
+  slug: string
+  active: boolean
+}
+
+interface DirectCategoryLink {
+  categoryId: string
+  sortOrder: number
+}
+
+/**
+ * Resolve linked category ids for a product, ordered by the operator-set
+ * `sortOrder` on `product_category_products` (lowest first). Direct links
+ * only — ancestors are walked separately.
+ */
+async function fetchDirectCategoryLinks(
+  db: AnyDrizzleDb,
+  productId: string,
+): Promise<DirectCategoryLink[]> {
+  return db
+    .select({
+      categoryId: productCategoryProducts.categoryId,
+      sortOrder: productCategoryProducts.sortOrder,
+    })
+    .from(productCategoryProducts)
+    .where(eq(productCategoryProducts.productId, productId))
+}
+
+/**
+ * Walk up the parent chain from a set of seed category ids, filtering
+ * inactive rows. Returns every active row reachable from the seeds.
+ *
+ * Iterative breadth-first to bound depth and avoid Drizzle recursive-CTE
+ * complexity. Real-world category trees are O(depth ≤ 5), so this issues
+ * at most a handful of `inArray` lookups regardless of breadth.
+ *
+ * Cycle-protected via a visited set — a misconfigured parent loop won't
+ * spin the indexer.
+ */
+async function walkActiveCategoryChain(
+  db: AnyDrizzleDb,
+  seedIds: ReadonlyArray<string>,
+): Promise<Map<string, CategoryRow>> {
+  const resolved = new Map<string, CategoryRow>()
+  const visited = new Set<string>()
+  let frontier = Array.from(new Set(seedIds))
+
+  while (frontier.length > 0) {
+    for (const id of frontier) visited.add(id)
+
+    const rows = await db
+      .select({
+        id: productCategories.id,
+        parentId: productCategories.parentId,
+        name: productCategories.name,
+        slug: productCategories.slug,
+        active: productCategories.active,
+      })
+      .from(productCategories)
+      .where(and(inArray(productCategories.id, frontier), eq(productCategories.active, true)))
+
+    const nextFrontier: string[] = []
+    for (const row of rows) {
+      resolved.set(row.id, row)
+      if (row.parentId && !visited.has(row.parentId) && !resolved.has(row.parentId)) {
+        nextFrontier.push(row.parentId)
+      }
+    }
+    frontier = Array.from(new Set(nextFrontier))
+  }
+
+  return resolved
+}
+
+interface TagRow {
+  id: string
+  name: string
+}
+
+async function fetchProductTags(db: AnyDrizzleDb, productId: string): Promise<TagRow[]> {
+  return db
+    .select({ id: productTags.id, name: productTags.name })
+    .from(productTagProducts)
+    .innerJoin(productTags, eq(productTagProducts.tagId, productTags.id))
+    .where(eq(productTagProducts.productId, productId))
+}
+
+interface TaxonomyProjection {
+  categoryIds: string[]
+  categoryNames: string[]
+  categorySlugs: string[]
+  primaryCategoryId: string | null
+  primaryCategoryName: string | null
+  primaryCategorySlug: string | null
+  tagIds: string[]
+  tagLabels: string[]
+}
+
+function buildTaxonomyProjection(
+  directLinks: ReadonlyArray<DirectCategoryLink>,
+  resolvedCategories: ReadonlyMap<string, CategoryRow>,
+  tags: ReadonlyArray<TagRow>,
+): TaxonomyProjection {
+  // Primary = first direct link (by sortOrder asc, then category name asc)
+  // that resolved as active. If every direct link is inactive, primary is
+  // null even when ancestors are active — the badge represents what the
+  // operator pinned.
+  const sortedDirect = [...directLinks].sort((a, b) => {
+    if (a.sortOrder !== b.sortOrder) return a.sortOrder - b.sortOrder
+    const nameA = resolvedCategories.get(a.categoryId)?.name ?? ""
+    const nameB = resolvedCategories.get(b.categoryId)?.name ?? ""
+    return nameA.localeCompare(nameB)
+  })
+
+  let primary: CategoryRow | null = null
+  for (const link of sortedDirect) {
+    const row = resolvedCategories.get(link.categoryId)
+    if (row) {
+      primary = row
+      break
+    }
+  }
+
+  // Categories[] = direct links + ancestors, deduped, ordered by direct-link
+  // sortOrder first then ancestor walk order. Stable enough that storefronts
+  // can rely on `categories[0]` being a representative label.
+  const seenIds = new Set<string>()
+  const categoryIds: string[] = []
+  const categoryNames: string[] = []
+  const categorySlugs: string[] = []
+
+  function emit(row: CategoryRow): void {
+    if (seenIds.has(row.id)) return
+    seenIds.add(row.id)
+    categoryIds.push(row.id)
+    categoryNames.push(row.name)
+    categorySlugs.push(row.slug)
+  }
+
+  // Pass 1: direct links first, in operator-controlled order.
+  for (const link of sortedDirect) {
+    const row = resolvedCategories.get(link.categoryId)
+    if (row) emit(row)
+  }
+
+  // Pass 2: ancestors of direct links, walking up via parentId.
+  for (const link of sortedDirect) {
+    let cursor = resolvedCategories.get(link.categoryId)?.parentId ?? null
+    const guard = new Set<string>() // local guard against malformed loops
+    while (cursor && !guard.has(cursor)) {
+      guard.add(cursor)
+      const parentRow = resolvedCategories.get(cursor)
+      if (!parentRow) break
+      emit(parentRow)
+      cursor = parentRow.parentId
+    }
+  }
+
+  return {
+    categoryIds,
+    categoryNames,
+    categorySlugs,
+    primaryCategoryId: primary?.id ?? null,
+    primaryCategoryName: primary?.name ?? null,
+    primaryCategorySlug: primary?.slug ?? null,
+    tagIds: tags.map((t) => t.id),
+    tagLabels: tags.map((t) => t.name),
+  }
+}
+
+/**
+ * Construct the taxonomy projection extension.
+ *
+ * Returns a `ProductProjectionExtension` ready to pass to
+ * `createProductDocumentBuilder`.
+ */
+export function createProductTaxonomyProjectionExtension(): ProductProjectionExtension {
+  return {
+    name: "products:taxonomy",
+    async project(db, productId, _slice) {
+      const [directLinks, tags] = await Promise.all([
+        fetchDirectCategoryLinks(db, productId),
+        fetchProductTags(db, productId),
+      ])
+
+      const seedIds = directLinks.map((l) => l.categoryId)
+      const resolvedCategories =
+        seedIds.length > 0
+          ? await walkActiveCategoryChain(db, seedIds)
+          : new Map<string, CategoryRow>()
+
+      const projection = buildTaxonomyProjection(directLinks, resolvedCategories, tags)
+
+      return new Map<string, unknown>([
+        ["categories[]", projection.categoryNames],
+        ["categoryIds[]", projection.categoryIds],
+        ["categorySlugs[]", projection.categorySlugs],
+        ["primaryCategoryId", projection.primaryCategoryId],
+        ["primaryCategoryName", projection.primaryCategoryName],
+        ["primaryCategorySlug", projection.primaryCategorySlug],
+        ["tagLabels[]", projection.tagLabels],
+        ["tagIds[]", projection.tagIds],
+      ])
+    },
+  }
+}
+
+// Internal exports for unit tests — kept separate from the public surface.
+export const __test__ = {
+  buildTaxonomyProjection,
+}

--- a/packages/products/tests/integration/taxonomy-projection.test.ts
+++ b/packages/products/tests/integration/taxonomy-projection.test.ts
@@ -1,0 +1,241 @@
+import type { IndexerSlice } from "@voyantjs/catalog"
+import { type SQL, sql } from "drizzle-orm"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { productTaxonomyCatalogPolicy } from "../../src/catalog-policy-taxonomy.js"
+import {
+  productCategories,
+  productCategoryProducts,
+  productTagProducts,
+  productTags,
+} from "../../src/schema-taxonomy.js"
+import {
+  createProductDocumentBuilder,
+  createProductsRegistry,
+} from "../../src/service-catalog-plane.js"
+import { createProductTaxonomyProjectionExtension } from "../../src/service-catalog-plane-taxonomy.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+const enSlice: IndexerSlice = {
+  vertical: "products",
+  locale: "en-GB",
+  audience: "customer",
+  market: "default",
+}
+
+describe.skipIf(!DB_AVAILABLE)("createProductTaxonomyProjectionExtension", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: drizzle test client
+  let db: any
+  let productId: string
+
+  async function ensureProductsTable(client: { execute: (statement: SQL) => Promise<unknown> }) {
+    await client.execute(sql`
+      CREATE TABLE IF NOT EXISTS products (
+        id text PRIMARY KEY NOT NULL,
+        name text NOT NULL,
+        description text,
+        booking_mode text NOT NULL DEFAULT 'date',
+        capacity_mode text NOT NULL DEFAULT 'limited',
+        timezone text NOT NULL DEFAULT 'UTC',
+        visibility text NOT NULL DEFAULT 'public',
+        activated boolean NOT NULL DEFAULT true,
+        status text NOT NULL DEFAULT 'active',
+        reservation_timeout_minutes integer NOT NULL DEFAULT 30,
+        sell_currency text NOT NULL DEFAULT 'EUR',
+        sell_amount_cents integer,
+        cost_amount_cents integer,
+        margin_percent integer,
+        facility_id text,
+        product_type_id text,
+        supplier_id text,
+        start_date date,
+        end_date date,
+        pax integer,
+        tags text[] NOT NULL DEFAULT '{}',
+        created_at timestamp with time zone NOT NULL DEFAULT now(),
+        updated_at timestamp with time zone NOT NULL DEFAULT now()
+      )
+    `)
+  }
+
+  async function ensureTaxonomyTables(client: { execute: (statement: SQL) => Promise<unknown> }) {
+    const statements: SQL[] = [
+      sql`CREATE TABLE IF NOT EXISTS product_categories (
+        id text PRIMARY KEY NOT NULL,
+        parent_id text,
+        name text NOT NULL,
+        slug text NOT NULL,
+        description text,
+        sort_order integer DEFAULT 0 NOT NULL,
+        active boolean DEFAULT true NOT NULL,
+        customer_payment_policy jsonb,
+        metadata jsonb,
+        created_at timestamp with time zone DEFAULT now() NOT NULL,
+        updated_at timestamp with time zone DEFAULT now() NOT NULL
+      )`,
+      sql`CREATE UNIQUE INDEX IF NOT EXISTS uidx_product_categories_slug ON product_categories (slug)`,
+      sql`CREATE TABLE IF NOT EXISTS product_tags (
+        id text PRIMARY KEY NOT NULL,
+        name text NOT NULL,
+        created_at timestamp with time zone DEFAULT now() NOT NULL,
+        updated_at timestamp with time zone DEFAULT now() NOT NULL
+      )`,
+      sql`CREATE UNIQUE INDEX IF NOT EXISTS uidx_product_tags_name ON product_tags (name)`,
+      sql`CREATE TABLE IF NOT EXISTS product_category_products (
+        product_id text NOT NULL,
+        category_id text NOT NULL,
+        sort_order integer DEFAULT 0 NOT NULL,
+        created_at timestamp with time zone DEFAULT now() NOT NULL,
+        updated_at timestamp with time zone DEFAULT now() NOT NULL,
+        PRIMARY KEY (product_id, category_id)
+      )`,
+      sql`CREATE TABLE IF NOT EXISTS product_tag_products (
+        product_id text NOT NULL,
+        tag_id text NOT NULL,
+        created_at timestamp with time zone DEFAULT now() NOT NULL,
+        PRIMARY KEY (product_id, tag_id)
+      )`,
+    ]
+    for (const statement of statements) {
+      await client.execute(statement)
+    }
+  }
+
+  beforeAll(async () => {
+    const { createTestDb } = await import("@voyantjs/db/test-utils")
+    db = createTestDb()
+    await ensureProductsTable(db)
+    await ensureTaxonomyTables(db)
+  })
+
+  beforeEach(async () => {
+    await db.execute(
+      sql`TRUNCATE products, product_categories, product_tags, product_category_products, product_tag_products CASCADE`,
+    )
+
+    productId = "prod_taxo_test"
+    await db.execute(
+      sql`INSERT INTO products (id, name) VALUES (${productId}, 'Mountain Hiking Tour')`,
+    )
+
+    // Tree: Adventure (root) > Hiking > Mountain Hiking
+    // Plus a sibling subtree: Adventure > Climbing
+    await db.insert(productCategories).values([
+      { id: "cat_adv", parentId: null, name: "Adventure", slug: "adventure" },
+      { id: "cat_hik", parentId: "cat_adv", name: "Hiking", slug: "hiking" },
+      { id: "cat_mtn", parentId: "cat_hik", name: "Mountain Hiking", slug: "mountain-hiking" },
+      { id: "cat_clm", parentId: "cat_adv", name: "Climbing", slug: "climbing" },
+    ])
+
+    await db.insert(productTags).values([
+      { id: "tag_fam", name: "Family-friendly" },
+      { id: "tag_eco", name: "Eco" },
+    ])
+  })
+
+  it("returns empty arrays / nulls when product has no taxonomy links", async () => {
+    const ext = createProductTaxonomyProjectionExtension()
+    const projection = await ext.project(db, productId, enSlice)
+    expect(projection.get("categories[]")).toEqual([])
+    expect(projection.get("categoryIds[]")).toEqual([])
+    expect(projection.get("categorySlugs[]")).toEqual([])
+    expect(projection.get("primaryCategoryId")).toBeNull()
+    expect(projection.get("primaryCategoryName")).toBeNull()
+    expect(projection.get("primaryCategorySlug")).toBeNull()
+    expect(projection.get("tagLabels[]")).toEqual([])
+    expect(projection.get("tagIds[]")).toEqual([])
+  })
+
+  it("denormalizes the full ancestor chain from a leaf-only link", async () => {
+    // Operator pinned Mountain Hiking as the only category — the projection
+    // must surface Hiking and Adventure too so an "Adventure" filter hits.
+    await db
+      .insert(productCategoryProducts)
+      .values([{ productId, categoryId: "cat_mtn", sortOrder: 0 }])
+
+    const ext = createProductTaxonomyProjectionExtension()
+    const projection = await ext.project(db, productId, enSlice)
+
+    expect(projection.get("categories[]")).toEqual(["Mountain Hiking", "Hiking", "Adventure"])
+    expect(projection.get("categoryIds[]")).toEqual(["cat_mtn", "cat_hik", "cat_adv"])
+    expect(projection.get("categorySlugs[]")).toEqual(["mountain-hiking", "hiking", "adventure"])
+    expect(projection.get("primaryCategoryId")).toBe("cat_mtn")
+    expect(projection.get("primaryCategoryName")).toBe("Mountain Hiking")
+  })
+
+  it("dedupes shared ancestors across multiple direct links", async () => {
+    await db.insert(productCategoryProducts).values([
+      { productId, categoryId: "cat_hik", sortOrder: 1 },
+      { productId, categoryId: "cat_clm", sortOrder: 2 },
+    ])
+
+    const ext = createProductTaxonomyProjectionExtension()
+    const projection = await ext.project(db, productId, enSlice)
+
+    const ids = projection.get("categoryIds[]") as string[]
+    // Adventure (the shared parent) appears exactly once.
+    expect(ids.filter((id) => id === "cat_adv").length).toBe(1)
+    expect(ids).toEqual(expect.arrayContaining(["cat_hik", "cat_clm", "cat_adv"]))
+  })
+
+  it("primary picks the lowest sortOrder direct link", async () => {
+    await db.insert(productCategoryProducts).values([
+      { productId, categoryId: "cat_clm", sortOrder: 5 },
+      { productId, categoryId: "cat_hik", sortOrder: 1 },
+    ])
+
+    const ext = createProductTaxonomyProjectionExtension()
+    const projection = await ext.project(db, productId, enSlice)
+    expect(projection.get("primaryCategoryId")).toBe("cat_hik")
+    expect(projection.get("primaryCategoryName")).toBe("Hiking")
+  })
+
+  it("excludes inactive direct categories and stops the chain at inactive ancestors", async () => {
+    // Pause the parent "Adventure" — children stay active.
+    await db.execute(sql`UPDATE product_categories SET active = false WHERE id = 'cat_adv'`)
+    await db
+      .insert(productCategoryProducts)
+      .values([{ productId, categoryId: "cat_hik", sortOrder: 0 }])
+
+    const ext = createProductTaxonomyProjectionExtension()
+    const projection = await ext.project(db, productId, enSlice)
+    // "Adventure" is paused → not denormalized into the projection.
+    expect(projection.get("categories[]")).toEqual(["Hiking"])
+    expect(projection.get("categoryIds[]")).toEqual(["cat_hik"])
+  })
+
+  it("emits structured tag labels and ids without colliding with the legacy tags column", async () => {
+    await db.insert(productTagProducts).values([
+      { productId, tagId: "tag_fam" },
+      { productId, tagId: "tag_eco" },
+    ])
+
+    const ext = createProductTaxonomyProjectionExtension()
+    const projection = await ext.project(db, productId, enSlice)
+    expect(projection.get("tagLabels[]")).toEqual(
+      expect.arrayContaining(["Family-friendly", "Eco"]),
+    )
+    expect(projection.get("tagIds[]")).toEqual(expect.arrayContaining(["tag_fam", "tag_eco"]))
+  })
+
+  it("end-to-end: createProductDocumentBuilder projects taxonomy onto the product doc", async () => {
+    await db
+      .insert(productCategoryProducts)
+      .values([{ productId, categoryId: "cat_mtn", sortOrder: 0 }])
+    await db.insert(productTagProducts).values([{ productId, tagId: "tag_fam" }])
+
+    const registry = createProductsRegistry(productTaxonomyCatalogPolicy)
+    const build = createProductDocumentBuilder(db, {
+      sellerOperatorId: "op_xyz",
+      registry,
+      extensions: [createProductTaxonomyProjectionExtension()],
+    })
+    const doc = await build(productId, enSlice)
+    expect(doc).not.toBeNull()
+    expect(doc?.id).toBe(productId)
+    expect(doc?.fields).toHaveProperty("categories", ["Mountain Hiking", "Hiking", "Adventure"])
+    expect(doc?.fields).toHaveProperty("primaryCategoryName", "Mountain Hiking")
+    expect(doc?.fields).toHaveProperty("tagLabels", ["Family-friendly"])
+  })
+})

--- a/packages/products/tests/unit/catalog-policy-taxonomy.test.ts
+++ b/packages/products/tests/unit/catalog-policy-taxonomy.test.ts
@@ -1,0 +1,71 @@
+import { createFieldPolicyRegistry } from "@voyantjs/catalog/contract"
+import { describe, expect, it } from "vitest"
+
+import { productCatalogPolicy } from "../../src/catalog-policy.js"
+import { productDestinationsCatalogPolicy } from "../../src/catalog-policy-destinations.js"
+import {
+  PRODUCT_TAXONOMY_FIELD_POLICY,
+  productTaxonomyCatalogPolicy,
+} from "../../src/catalog-policy-taxonomy.js"
+
+describe("productTaxonomyCatalogPolicy", () => {
+  it("declares the storefront-required taxonomy paths", () => {
+    const paths = PRODUCT_TAXONOMY_FIELD_POLICY.map((p) => p.path)
+    expect(paths).toContain("categories[]")
+    expect(paths).toContain("categoryIds[]")
+    expect(paths).toContain("categorySlugs[]")
+    expect(paths).toContain("primaryCategoryId")
+    expect(paths).toContain("primaryCategoryName")
+    expect(paths).toContain("primaryCategorySlug")
+    expect(paths).toContain("tagLabels[]")
+    expect(paths).toContain("tagIds[]")
+  })
+
+  it("does not declare any locale-keyed fields (today's schema is single-name)", () => {
+    // Localization is deferred — the schema has no category/tag translation
+    // tables yet. Asserting `localized: false` everywhere guards against an
+    // accidental flip that would silently emit the same name on every locale
+    // slice while telling the indexer it's locale-keyed.
+    for (const policy of PRODUCT_TAXONOMY_FIELD_POLICY) {
+      expect(policy.localized).toBe(false)
+    }
+  })
+
+  it("does not collide with the base catalog-policy `tags[]` path", () => {
+    // The base policy already projects `products.tags` (free-form text[]).
+    // Structured taxonomy lands on `tagLabels[]` to avoid colliding.
+    const taxonomyPaths = new Set(PRODUCT_TAXONOMY_FIELD_POLICY.map((p) => p.path))
+    expect(taxonomyPaths.has("tags[]")).toBe(false)
+  })
+
+  it("makes every field visible to staff/customer/partner so storefront cards can render", () => {
+    for (const policy of PRODUCT_TAXONOMY_FIELD_POLICY) {
+      expect(policy.visibility).toContain("customer")
+      expect(policy.visibility).toContain("partner")
+      expect(policy.visibility).toContain("staff")
+    }
+  })
+
+  it("composes cleanly with productCatalogPolicy + productDestinationsCatalogPolicy", () => {
+    const registry = createFieldPolicyRegistry([
+      ...productCatalogPolicy,
+      ...productDestinationsCatalogPolicy,
+      ...productTaxonomyCatalogPolicy,
+    ])
+    expect(registry.resolve("name")).toBeDefined()
+    expect(registry.resolve("regions[]")).toBeDefined()
+    expect(registry.resolve("categories[]")).toBeDefined()
+    expect(registry.resolve("primaryCategoryId")).toBeDefined()
+    expect(registry.resolve("tagLabels[]")).toBeDefined()
+  })
+
+  it("does not duplicate any path against the base or destinations policies", () => {
+    expect(() =>
+      createFieldPolicyRegistry([
+        ...productCatalogPolicy,
+        ...productDestinationsCatalogPolicy,
+        ...productTaxonomyCatalogPolicy,
+      ]),
+    ).not.toThrow()
+  })
+})

--- a/packages/products/tests/unit/taxonomy-projection.test.ts
+++ b/packages/products/tests/unit/taxonomy-projection.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest"
+
+import { __test__ } from "../../src/service-catalog-plane-taxonomy.js"
+
+const { buildTaxonomyProjection } = __test__
+
+interface CategoryRow {
+  id: string
+  parentId: string | null
+  name: string
+  slug: string
+  active: boolean
+}
+
+function cat(
+  id: string,
+  name: string,
+  parentId: string | null = null,
+  slug = name.toLowerCase().replace(/\s+/g, "-"),
+  active = true,
+): CategoryRow {
+  return { id, name, slug, parentId, active }
+}
+
+describe("buildTaxonomyProjection", () => {
+  it("emits empty projection when no links and no tags", () => {
+    const out = buildTaxonomyProjection([], new Map(), [])
+    expect(out.categoryIds).toEqual([])
+    expect(out.categoryNames).toEqual([])
+    expect(out.categorySlugs).toEqual([])
+    expect(out.primaryCategoryId).toBeNull()
+    expect(out.primaryCategoryName).toBeNull()
+    expect(out.primaryCategorySlug).toBeNull()
+    expect(out.tagIds).toEqual([])
+    expect(out.tagLabels).toEqual([])
+  })
+
+  it("emits direct link with no ancestors when category has no parent", () => {
+    const resolved = new Map([["cat_a", cat("cat_a", "Adventure")]])
+    const out = buildTaxonomyProjection([{ categoryId: "cat_a", sortOrder: 0 }], resolved, [])
+    expect(out.categoryNames).toEqual(["Adventure"])
+    expect(out.categoryIds).toEqual(["cat_a"])
+    expect(out.categorySlugs).toEqual(["adventure"])
+    expect(out.primaryCategoryName).toBe("Adventure")
+  })
+
+  it("walks parent chain so child links surface ancestor labels (Adventure filter use case)", () => {
+    // Tree: Adventure > Hiking > Mountain Hiking
+    const resolved = new Map([
+      ["cat_adv", cat("cat_adv", "Adventure")],
+      ["cat_hik", cat("cat_hik", "Hiking", "cat_adv")],
+      ["cat_mtn", cat("cat_mtn", "Mountain Hiking", "cat_hik")],
+    ])
+    const out = buildTaxonomyProjection([{ categoryId: "cat_mtn", sortOrder: 0 }], resolved, [])
+    // Direct-link first, then ancestors walking up.
+    expect(out.categoryNames).toEqual(["Mountain Hiking", "Hiking", "Adventure"])
+    expect(out.categoryIds).toEqual(["cat_mtn", "cat_hik", "cat_adv"])
+  })
+
+  it("dedupes when multiple direct links share the same ancestor", () => {
+    // Two leaves under the same parent — Adventure must appear once.
+    const resolved = new Map([
+      ["cat_adv", cat("cat_adv", "Adventure")],
+      ["cat_hik", cat("cat_hik", "Hiking", "cat_adv")],
+      ["cat_clm", cat("cat_clm", "Climbing", "cat_adv")],
+    ])
+    const out = buildTaxonomyProjection(
+      [
+        { categoryId: "cat_hik", sortOrder: 1 },
+        { categoryId: "cat_clm", sortOrder: 2 },
+      ],
+      resolved,
+      [],
+    )
+    expect(out.categoryNames).toEqual(["Hiking", "Climbing", "Adventure"])
+    expect(new Set(out.categoryIds).size).toBe(out.categoryIds.length)
+  })
+
+  it("stops the chain at an inactive ancestor (resolved map omits it)", () => {
+    // Ancestor walk reads from the resolved map. The fetcher filters
+    // inactive rows out, so a paused parent is absent from the map and the
+    // chain truncates there.
+    const resolved = new Map([
+      // cat_adv is intentionally omitted (operator paused it).
+      ["cat_hik", cat("cat_hik", "Hiking", "cat_adv")],
+    ])
+    const out = buildTaxonomyProjection([{ categoryId: "cat_hik", sortOrder: 0 }], resolved, [])
+    expect(out.categoryNames).toEqual(["Hiking"])
+    expect(out.categoryIds).toEqual(["cat_hik"])
+  })
+
+  it("primary = lowest sortOrder direct link, regardless of category-row name order", () => {
+    const resolved = new Map([
+      ["cat_z", cat("cat_z", "Zebra")],
+      ["cat_a", cat("cat_a", "Apple")],
+    ])
+    const out = buildTaxonomyProjection(
+      [
+        { categoryId: "cat_z", sortOrder: 0 }, // pinned first
+        { categoryId: "cat_a", sortOrder: 1 },
+      ],
+      resolved,
+      [],
+    )
+    expect(out.primaryCategoryId).toBe("cat_z")
+    expect(out.primaryCategoryName).toBe("Zebra")
+  })
+
+  it("breaks sortOrder ties by category name asc", () => {
+    const resolved = new Map([
+      ["cat_z", cat("cat_z", "Zebra")],
+      ["cat_a", cat("cat_a", "Apple")],
+    ])
+    const out = buildTaxonomyProjection(
+      [
+        { categoryId: "cat_z", sortOrder: 0 },
+        { categoryId: "cat_a", sortOrder: 0 },
+      ],
+      resolved,
+      [],
+    )
+    expect(out.primaryCategoryId).toBe("cat_a")
+  })
+
+  it("primary is null when every direct link resolved as inactive (missing from map)", () => {
+    // Direct link exists in the join but the category is paused — inactive
+    // row was filtered upstream, so the resolved map doesn't include it.
+    const resolved = new Map<string, CategoryRow>()
+    const out = buildTaxonomyProjection([{ categoryId: "cat_paused", sortOrder: 0 }], resolved, [])
+    expect(out.primaryCategoryId).toBeNull()
+    expect(out.primaryCategoryName).toBeNull()
+  })
+
+  it("emits tag labels and ids preserving fetch order", () => {
+    const out = buildTaxonomyProjection([], new Map(), [
+      { id: "tag_1", name: "Family-friendly" },
+      { id: "tag_2", name: "Eco" },
+    ])
+    expect(out.tagLabels).toEqual(["Family-friendly", "Eco"])
+    expect(out.tagIds).toEqual(["tag_1", "tag_2"])
+  })
+
+  it("survives a parent loop (cat_a → cat_b → cat_a) without infinite walking", () => {
+    // Misconfigured data: a loop in parentId. Per-walk guard catches it.
+    const resolved = new Map([
+      ["cat_a", cat("cat_a", "A", "cat_b")],
+      ["cat_b", cat("cat_b", "B", "cat_a")],
+    ])
+    const out = buildTaxonomyProjection([{ categoryId: "cat_a", sortOrder: 0 }], resolved, [])
+    // Both walked once, then guard stops the cycle.
+    expect(out.categoryIds.sort()).toEqual(["cat_a", "cat_b"])
+  })
+})

--- a/templates/operator/src/api/lib/catalog-runtime.ts
+++ b/templates/operator/src/api/lib/catalog-runtime.ts
@@ -27,8 +27,10 @@ import { extrasCatalogPolicy } from "@voyantjs/extras/catalog-policy"
 import { hospitalityCatalogPolicy } from "@voyantjs/hospitality/catalog-policy"
 import { productCatalogPolicy } from "@voyantjs/products/catalog-policy"
 import { productDestinationsCatalogPolicy } from "@voyantjs/products/catalog-policy-destinations"
+import { productTaxonomyCatalogPolicy } from "@voyantjs/products/catalog-policy-taxonomy"
 import { createProductDocumentBuilder } from "@voyantjs/products/service-catalog-plane"
 import { createProductDestinationsProjectionExtension } from "@voyantjs/products/service-catalog-plane-destinations"
+import { createProductTaxonomyProjectionExtension } from "@voyantjs/products/service-catalog-plane-taxonomy"
 
 /**
  * The slice set the operator template indexes by default — staff (admin
@@ -233,7 +235,11 @@ export function getFieldPolicyRegistries(): Map<string, FieldPolicyRegistry> {
     _registries = new Map<string, FieldPolicyRegistry>([
       [
         "products",
-        createFieldPolicyRegistry([...productCatalogPolicy, ...productDestinationsCatalogPolicy]),
+        createFieldPolicyRegistry([
+          ...productCatalogPolicy,
+          ...productDestinationsCatalogPolicy,
+          ...productTaxonomyCatalogPolicy,
+        ]),
       ],
       ["extras", createFieldPolicyRegistry(extrasCatalogPolicy)],
       ["cruises", createFieldPolicyRegistry(cruiseCatalogPolicy)],
@@ -262,7 +268,10 @@ export function createProductsDocumentBuilder(
   return createProductDocumentBuilder(db, {
     sellerOperatorId: context.sellerOperatorId,
     registry,
-    extensions: [createProductDestinationsProjectionExtension()],
+    extensions: [
+      createProductDestinationsProjectionExtension(),
+      createProductTaxonomyProjectionExtension(),
+    ],
   })
 }
 


### PR DESCRIPTION
## Summary

- New `productTaxonomyCatalogPolicy` (`@voyantjs/products/catalog-policy-taxonomy`) declaring `categories[]`, `categoryIds[]`, `categorySlugs[]`, `primaryCategoryId/Name/Slug`, `tagLabels[]`, `tagIds[]`.
- New `createProductTaxonomyProjectionExtension` (`@voyantjs/products/service-catalog-plane-taxonomy`) that joins `product_category_products` → `product_categories` (walking the active-ancestor chain) and `product_tag_products` → `product_tags`, contributing those fields to the product search document.
- New `category` and `tag` axes on `ProductContentChangedEvent`, emitted from the four product → category/tag link-mutation routes so the catalog bridge reindexes on link changes (closes the same silent-staleness hole PR #499 P1 patched for destinations).
- Operator template wires the new policy + extension alongside destinations; live and bulk reindex paths share `createProductsDocumentBuilder` per the PR #499 fix.

## Why ancestor denormalization

Typesense can't recurse, so a product linked to "Hiking" (parent: "Adventure") needs both labels in `categories[]` for an "Adventure" filter to match a single equality. The extension walks the chain iteratively (bounded by tree depth, cycle-protected) instead of relying on a recursive CTE — keeps the join inside Drizzle and the unit-test surface a pure function. Inactive categories/ancestors are excluded so an operator-paused parent stops surfacing children under the parent filter.

## Out of scope

- Locale-aware category/tag names — `product_categories.name` and `product_tags.name` are single columns today; all fields ship `localized: false`. Tracked in #502.
- `priceFrom` (PR4) and departures aggregations (PR3) per the #493 plan.

## Test plan

- [x] `pnpm -F @voyantjs/products typecheck` — clean.
- [x] `pnpm -F @voyantjs/products test tests/unit/catalog-policy-taxonomy.test.ts tests/unit/taxonomy-projection.test.ts` — 16/16 unit tests pass.
- [x] Operator template typecheck — clean.
- [ ] Integration test (`tests/integration/taxonomy-projection.test.ts`) runs in CI against `TEST_DATABASE_URL`. Skipped locally.
- [ ] Manual: `pnpm -F operator dev`, link a product to a leaf category, verify `categories[]` in the resulting Typesense doc includes the full ancestor chain.

Refs #493. Follow-up: #502 (translations).