### PR TITLE
Part 3 of #493: ship productDeparturesCatalogPolicy with availability projection

### DIFF
--- a/.changeset/availability-slot-event-completeness.md
+++ b/.changeset/availability-slot-event-completeness.md
@@ -1,0 +1,16 @@
+---
+"@voyantjs/availability": minor
+---
+
+Fire `availability.slot.changed` from `createSlot` and `deleteSlot`, not just `updateSlot`.
+
+Until now, only operator edits to an existing slot fired the event — adding a brand-new departure or removing one was silent. That works for channel-push (whose reconciler periodically rehydrates) but breaks any subscriber that uses the event as a reindex trigger, including the new catalog-plane departures projection (PR3 of #493).
+
+Changes:
+
+- `AvailabilitySlotChangeSource` adds `"created"` and `"deleted"` variants. Existing values unchanged.
+- `createSlot(db, data, runtime?)` and `deleteSlot(db, id, runtime?)` accept a new `SlotMutationRuntime` (alias of the renamed-but-back-compat `UpdateSlotRuntime`). When `eventBus` is provided they emit `availability.slot.changed` with `source` defaulting to `"created"` / `"deleted"`. Existing two-arg calls keep working.
+- `deleteSlot` snapshots the slot row before deletion so the event payload carries `productId` / `optionId` / `startsAt`. `remainingPax` is reported as `0` for deletes (post-mutation effective capacity).
+- `POST /v1/availability/slots` and `DELETE /v1/availability/slots/:id` now thread `c.get("eventBus")` through to the service layer.
+
+Pre-existing gap not fixed here: the batch-update / batch-delete endpoints still don't thread the event bus through `handleBatchUpdate` / `handleBatchDelete`, so bulk operations keep their existing behavior of suppressing all slot events. Tracked separately — fixing it requires touching the shared batch helpers.

--- a/.changeset/products-departures-catalog-policy.md
+++ b/.changeset/products-departures-catalog-policy.md
@@ -1,0 +1,34 @@
+---
+"@voyantjs/products": minor
+"@voyantjs/availability": minor
+---
+
+Part 3 of #493: ship the departures child-entity catalog registry — denormalize per-product departure-date aggregations from `availability_slots` onto the product search document so storefront filters can match "departing in May", "available next 30 days", "available now", etc. with a single equality / range query.
+
+New surface (`@voyantjs/products`):
+
+- `productDeparturesCatalogPolicy` (`@voyantjs/products/catalog-policy-departures`) — `FieldPolicy[]` declaring `nextDepartureAt`, `nextDepartureDate`, `hasUpcomingDeparture`, `upcomingDepartureCount`, `departureDates[]`, `departureMonths[]`, `availableUnitsTotal`. Compose with `productCatalogPolicy` via `createFieldPolicyRegistry([...productCatalogPolicy, ...productDeparturesCatalogPolicy])`.
+
+New surface (`@voyantjs/availability`):
+
+- `createProductDeparturesProjectionExtension` (`@voyantjs/availability/service-catalog-plane-departures`) — runtime extension that scans `availability_slots` for `(productId, status='open', startsAt > now)` within a 24-month window, then aggregates: earliest departure, count, distinct local dates capped at 180 days, distinct `YYYY-MM` months capped at 24, and `remainingPax` sum (`null` when any slot is unlimited). Pluggable `now` and `loadBookingMode` for testing.
+
+Why the projection lives in `@voyantjs/availability` (not products): the data lives there, and `availability` already depends on `products` for the FK schema — adding a `products → availability` import would create a circular dep. The contract type (`ProductProjectionExtension`) flows products → availability, matching the existing direction.
+
+Operator template:
+
+- Composes `productDeparturesCatalogPolicy` into the products registry alongside destinations + taxonomy.
+- Catalog bridge subscribes to `availability.slot.changed` and reindexes the slot's product. Cross-package event subscription keeps the products `ProductContentChangedEvent.axis` union free of availability concerns.
+
+Behavior decisions:
+
+- Only `status='open'` slots count. Sold-out / cancelled / closed are excluded so storefront filters never surface unavailable departures. A "show sold-out" UX is a query-time concern.
+- Products with `bookingMode='open'` (anytime tours, no fixed slots) emit empty arrays / nulls — gated server-side via the booking mode read so we don't issue a slot scan per anytime product.
+- Bucket by `availability_slots.dateLocal` (the slot's local-calendar date), not by `products.timezone`. A 9am-Madrid departure is "May 5" globally even when the UTC `startsAt` crosses midnight.
+- `availableUnitsTotal` is `null` when any counted slot is `unlimited=true` — emitting a partial sum would mislead storefronts ("3 seats left" when one slot is actually unlimited).
+
+Out of scope:
+
+- Per-option splits (today the projection rolls up to product). Follow-up if storefronts need it.
+- Duration buckets (slots carry `nights` / `days` but mixed-duration products can't be summarized in one number).
+- Closeout-aware filtering. The projection reads `slots.status` directly; closeouts that mark a date range without flipping the slot status aren't reflected. Separate event design.

--- a/packages/availability/package.json
+++ b/packages/availability/package.json
@@ -9,7 +9,8 @@
     "./validation": "./src/validation.ts",
     "./routes": "./src/routes.ts",
     "./rrule": "./src/rrule.ts",
-    "./service-holds": "./src/service-holds.ts"
+    "./service-holds": "./src/service-holds.ts",
+    "./service-catalog-plane-departures": "./src/service-catalog-plane-departures.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
@@ -67,6 +68,11 @@
         "types": "./dist/service-holds.d.ts",
         "import": "./dist/service-holds.js",
         "default": "./dist/service-holds.js"
+      },
+      "./service-catalog-plane-departures": {
+        "types": "./dist/service-catalog-plane-departures.d.ts",
+        "import": "./dist/service-catalog-plane-departures.js",
+        "default": "./dist/service-catalog-plane-departures.js"
       }
     },
     "main": "./dist/index.js",

--- a/packages/availability/src/events.ts
+++ b/packages/availability/src/events.ts
@@ -29,6 +29,8 @@ export type AvailabilitySlotChangeSource =
   | "modify"
   | "manual"
   | "refresh"
+  | "created"
+  | "deleted"
 
 export interface AvailabilitySlotChangedEvent {
   slotId: string

--- a/packages/availability/src/routes-core.ts
+++ b/packages/availability/src/routes-core.ts
@@ -155,6 +155,7 @@ export const availabilityCoreRoutes = new Hono<Env>()
         data: await availabilityService.createSlot(
           c.get("db"),
           await parseJsonBody(c, insertAvailabilitySlotSchema),
+          { eventBus: c.get("eventBus") },
         ),
       },
       201,
@@ -199,7 +200,9 @@ export const availabilityCoreRoutes = new Hono<Env>()
     return row ? c.json({ data: row }) : notFound(c, "Availability slot not found")
   })
   .delete("/slots/:id", async (c) => {
-    const row = await availabilityService.deleteSlot(c.get("db"), c.req.param("id"))
+    const row = await availabilityService.deleteSlot(c.get("db"), c.req.param("id"), {
+      eventBus: c.get("eventBus"),
+    })
     return row ? c.json({ success: true }) : notFound(c, "Availability slot not found")
   })
   .get("/closeouts", async (c) => {

--- a/packages/availability/src/service-catalog-plane-departures.ts
+++ b/packages/availability/src/service-catalog-plane-departures.ts
@@ -1,0 +1,271 @@
+/**
+ * Projection extension that aggregates `availability_slots` rows into the
+ * departure-facet fields declared by `productDeparturesCatalogPolicy`
+ * (in `@voyantjs/products/catalog-policy-departures`).
+ *
+ * Lives in `@voyantjs/availability` because:
+ *   - The data lives here.
+ *   - `availability` already depends on `products` for the `productsRef`
+ *     schema; importing the `ProductProjectionExtension` contract type
+ *     from products is the same direction. The reverse (products
+ *     querying availability_slots) would introduce a circular dep.
+ *
+ * Wire via `createProductDocumentBuilder({ extensions: [departuresExtension] })`
+ * after composing `productDeparturesCatalogPolicy` into the registry.
+ *
+ * Filtering decisions:
+ *   - Only `status = 'open'` slots count. Sold-out / closed / cancelled
+ *     are excluded — storefront filters never surface unavailable
+ *     departures, and a "show sold-out" UX is a query-time concern.
+ *   - Only future departures (`startsAt > now()`).
+ *   - Capped at 24 months forward — operators rarely publish further
+ *     out, and unbounded windows would let a single misconfigured slot
+ *     30 years in the future blow up the document.
+ *
+ * Document-size discipline:
+ *   - `departureDates[]` capped at the next 180 days of distinct local
+ *     dates. Daily-slot products with a year of inventory would
+ *     otherwise emit ~365 strings per slice; 180 covers the use case
+ *     (storefront date-picker + "this weekend / next month" filters).
+ *   - `departureMonths[]` is naturally bounded by the 24-month window.
+ *
+ * `bookingMode` gating: products with `bookingMode = 'open'` (anytime /
+ * no fixed slots — e.g. private city tours) emit empty arrays / nulls.
+ * Without this gate the projection would issue a slot scan that always
+ * returns zero rows for these products. Cheaper to short-circuit on the
+ * already-fetched product row.
+ */
+
+import type { AnyDrizzleDb } from "@voyantjs/db"
+import type {
+  IndexerSlice,
+  ProductProjectionExtension,
+} from "@voyantjs/products/service-catalog-plane"
+import { and, asc, eq, gt, lt } from "drizzle-orm"
+
+import { availabilitySlots } from "./schema.js"
+
+// Window the aggregation looks at. Tunable via the factory; defaults
+// chosen so a daily-slot product produces ~180 dates / ~24 months.
+export interface DepartureProjectionOptions {
+  /**
+   * How many days of distinct calendar dates land in `departureDates[]`.
+   * Defaults to 180 (≈ 6 months).
+   */
+  datesWindowDays?: number
+  /**
+   * How many months of distinct `YYYY-MM` tokens land in `departureMonths[]`.
+   * Defaults to 24.
+   */
+  monthsWindowCount?: number
+  /**
+   * Override `now()` for testing. Defaults to wall-clock time at projection.
+   */
+  now?: () => Date
+  /**
+   * Resolve the product's `bookingMode` so anytime products short-circuit
+   * to an empty projection. Templates inject this — keeping the loader
+   * pluggable lets tests stub a product with a specific mode without
+   * needing the full products schema in the test DB.
+   *
+   * Returns `null` when the product doesn't exist (the upstream
+   * builder will see `null` from its own row fetch first, but defensive
+   * here keeps the projection failure-isolated).
+   */
+  loadBookingMode?: (db: AnyDrizzleDb, productId: string) => Promise<string | null>
+}
+
+/** Modes for which we project departures. Other modes (e.g. `"open"` for
+ *  anytime products) short-circuit to empty. */
+const SCHEDULED_BOOKING_MODES = new Set(["date", "date_time", "stay", "itinerary"])
+
+interface SlotAggregateRow {
+  startsAt: Date
+  dateLocal: string // YYYY-MM-DD in slot's local timezone
+  remainingPax: number | null
+  unlimited: boolean
+}
+
+interface DepartureAggregate {
+  nextDepartureAt: string | null // ISO 8601
+  nextDepartureDate: string | null // YYYY-MM-DD (slot's local)
+  hasUpcomingDeparture: boolean
+  upcomingDepartureCount: number
+  departureDates: string[]
+  departureMonths: string[]
+  availableUnitsTotal: number | null
+}
+
+const EMPTY_AGGREGATE: DepartureAggregate = {
+  nextDepartureAt: null,
+  nextDepartureDate: null,
+  hasUpcomingDeparture: false,
+  upcomingDepartureCount: 0,
+  departureDates: [],
+  departureMonths: [],
+  availableUnitsTotal: 0,
+}
+
+/**
+ * Pure aggregation kernel — given a list of upcoming open slots, produce
+ * the projection fields. Exposed via `__test__` for unit coverage that
+ * doesn't need a real DB.
+ */
+function aggregateDepartures(
+  slots: ReadonlyArray<SlotAggregateRow>,
+  now: Date,
+  datesWindowDays: number,
+  monthsWindowCount: number,
+): DepartureAggregate {
+  if (slots.length === 0) return { ...EMPTY_AGGREGATE }
+
+  // Slots arrive ordered by startsAt asc from the SQL query; the first
+  // row is the earliest. Re-establish ordering defensively in case a
+  // future caller passes them unordered — the cost is one O(n log n)
+  // sort, the benefit is the helper stays pure.
+  const ordered = [...slots].sort((a, b) => a.startsAt.getTime() - b.startsAt.getTime())
+  const earliest = ordered[0]
+  if (!earliest) return { ...EMPTY_AGGREGATE }
+
+  const dateCutoff = new Date(now.getTime() + datesWindowDays * 24 * 60 * 60 * 1000)
+  const monthCutoff = addMonths(now, monthsWindowCount)
+
+  const dateSet = new Set<string>()
+  const monthSet = new Set<string>()
+  let anyUnlimited = false
+  let paxSum = 0
+
+  for (const slot of ordered) {
+    if (slot.startsAt < monthCutoff) {
+      // Month is the first 7 chars of YYYY-MM-DD (already in local TZ).
+      monthSet.add(slot.dateLocal.slice(0, 7))
+    }
+    if (slot.startsAt < dateCutoff) {
+      dateSet.add(slot.dateLocal)
+    }
+    if (slot.unlimited) {
+      anyUnlimited = true
+    } else if (slot.remainingPax !== null) {
+      paxSum += slot.remainingPax
+    }
+  }
+
+  // Sort outputs deterministically — Set insertion order would otherwise
+  // depend on slot-row ordering and make doc snapshots brittle.
+  const departureDates = Array.from(dateSet).sort()
+  const departureMonths = Array.from(monthSet).sort()
+
+  return {
+    nextDepartureAt: earliest.startsAt.toISOString(),
+    nextDepartureDate: earliest.dateLocal,
+    hasUpcomingDeparture: true,
+    upcomingDepartureCount: ordered.length,
+    departureDates,
+    departureMonths,
+    // `null` when any counted slot is unlimited — emitting a partial sum
+    // would mislead the storefront ("3 seats left" when one slot is
+    // actually unlimited).
+    availableUnitsTotal: anyUnlimited ? null : paxSum,
+  }
+}
+
+function addMonths(d: Date, months: number): Date {
+  const out = new Date(d)
+  out.setMonth(out.getMonth() + months)
+  return out
+}
+
+/**
+ * Construct the departures projection extension.
+ *
+ * Pass `loadBookingMode` so anytime products short-circuit; in production
+ * that reads the products table, in tests it can return a fixed mode.
+ */
+export function createProductDeparturesProjectionExtension(
+  options: DepartureProjectionOptions = {},
+): ProductProjectionExtension {
+  const datesWindowDays = options.datesWindowDays ?? 180
+  const monthsWindowCount = options.monthsWindowCount ?? 24
+  const nowFn = options.now ?? (() => new Date())
+  const loadBookingMode = options.loadBookingMode ?? defaultLoadBookingMode
+
+  return {
+    name: "products:departures",
+    async project(db, productId, _slice: IndexerSlice) {
+      const bookingMode = await loadBookingMode(db, productId)
+      if (bookingMode !== null && !SCHEDULED_BOOKING_MODES.has(bookingMode)) {
+        return emptyProjection()
+      }
+
+      const now = nowFn()
+      const monthCutoff = addMonths(now, monthsWindowCount)
+
+      // Single SQL pass: open future slots within the 24-month window.
+      // The `(productId, startsAt)` index makes this a range scan.
+      const rows = await db
+        .select({
+          startsAt: availabilitySlots.startsAt,
+          dateLocal: availabilitySlots.dateLocal,
+          remainingPax: availabilitySlots.remainingPax,
+          unlimited: availabilitySlots.unlimited,
+        })
+        .from(availabilitySlots)
+        .where(
+          and(
+            eq(availabilitySlots.productId, productId),
+            eq(availabilitySlots.status, "open"),
+            gt(availabilitySlots.startsAt, now),
+            lt(availabilitySlots.startsAt, monthCutoff),
+          ),
+        )
+        .orderBy(asc(availabilitySlots.startsAt))
+
+      const aggregate = aggregateDepartures(rows, now, datesWindowDays, monthsWindowCount)
+      return toProjectionMap(aggregate)
+    },
+  }
+}
+
+function emptyProjection(): ReadonlyMap<string, unknown> {
+  return toProjectionMap({ ...EMPTY_AGGREGATE })
+}
+
+function toProjectionMap(a: DepartureAggregate): ReadonlyMap<string, unknown> {
+  return new Map<string, unknown>([
+    ["nextDepartureAt", a.nextDepartureAt],
+    ["nextDepartureDate", a.nextDepartureDate],
+    ["hasUpcomingDeparture", a.hasUpcomingDeparture],
+    ["upcomingDepartureCount", a.upcomingDepartureCount],
+    ["departureDates[]", a.departureDates],
+    ["departureMonths[]", a.departureMonths],
+    ["availableUnitsTotal", a.availableUnitsTotal],
+  ])
+}
+
+/**
+ * Default `loadBookingMode` reads from the products table via raw SQL so
+ * we don't pull the products schema into this file (would create a
+ * heavier coupling with the products package). The column shape is
+ * stable enough — `bookingMode` has been on the products table since
+ * v0.1 and a schema rename would break far more than this.
+ */
+async function defaultLoadBookingMode(db: AnyDrizzleDb, productId: string): Promise<string | null> {
+  // biome-ignore lint/suspicious/noExplicitAny: drizzle's typed sql is overkill for a single-column read
+  const dbAny = db as any
+  const { sql } = await import("drizzle-orm")
+  const result = await dbAny.execute(
+    sql`SELECT booking_mode FROM products WHERE id = ${productId} LIMIT 1`,
+  )
+  // postgres-js returns rows as an array-like with `.[0]?.booking_mode`;
+  // node-postgres returns `{ rows: [...] }`. Handle both.
+  const rows = Array.isArray(result) ? result : (result?.rows ?? [])
+  const first = rows[0] as { booking_mode?: string } | undefined
+  return first?.booking_mode ?? null
+}
+
+// Internal exports for unit tests — kept off the public surface.
+export const __test__ = {
+  aggregateDepartures,
+  EMPTY_AGGREGATE,
+  SCHEDULED_BOOKING_MODES,
+}

--- a/packages/availability/src/service-core.ts
+++ b/packages/availability/src/service-core.ts
@@ -186,7 +186,36 @@ export async function getSlotById(db: PostgresJsDatabase, id: string) {
   return row ?? null
 }
 
-export async function createSlot(db: PostgresJsDatabase, data: CreateAvailabilitySlotInput) {
+export interface SlotMutationRuntime {
+  /**
+   * Optional event bus. When wired, slot create/update/delete each emit
+   * `availability.slot.changed` so subscribers (channel-push, catalog
+   * bridge) can react to any mutation that changes a product's effective
+   * departure surface — not just operator edits.
+   *
+   * Per docs/architecture/channel-push-architecture.md §5.1.
+   */
+  eventBus?: EventBus
+  /**
+   * Origin of the change. `createSlot` / `deleteSlot` default to
+   * `"created"` / `"deleted"`. `updateSlot` defaults to `"manual"`. The
+   * scheduled-refresh job overrides with `"refresh"` so dashboards can
+   * attribute drift correctly.
+   */
+  source?: AvailabilitySlotChangedEvent["source"]
+}
+
+/**
+ * Back-compat alias for the original update-only runtime type. New
+ * callers should reach for `SlotMutationRuntime`.
+ */
+export type UpdateSlotRuntime = SlotMutationRuntime
+
+export async function createSlot(
+  db: PostgresJsDatabase,
+  data: CreateAvailabilitySlotInput,
+  runtime: SlotMutationRuntime = {},
+) {
   const [row] = await db
     .insert(availabilitySlots)
     .values({
@@ -195,32 +224,37 @@ export async function createSlot(db: PostgresJsDatabase, data: CreateAvailabilit
       endsAt: toDateOrNull(data.endsAt),
     })
     .returning()
-  return row
-}
+  if (!row) return row
 
-export interface UpdateSlotRuntime {
-  /**
-   * Optional event bus. When wired, `updateSlot` emits
-   * `availability.slot.changed` after a successful update so channel-push
-   * (and other availability subscribers) can react to operator edits and
-   * scheduled refresh recomputations.
-   *
-   * Per docs/architecture/channel-push-architecture.md §5.1.
-   */
-  eventBus?: EventBus
-  /**
-   * Origin of the change. Defaults to `"manual"` (operator edit). The
-   * scheduled-refresh job passes `"refresh"` so dashboards can attribute
-   * drift correctly.
-   */
-  source?: AvailabilitySlotChangedEvent["source"]
+  // Emit on create so subscribers (catalog-plane bridge, channel-push)
+  // see new departures the same way they see edits. Without this, a
+  // freshly-created slot is invisible to the projection until the next
+  // unrelated update.
+  const eventBus = runtime.eventBus
+  if (eventBus) {
+    const payload: AvailabilitySlotChangedEvent = {
+      slotId: row.id,
+      productId: row.productId,
+      optionId: row.optionId ?? null,
+      startsAt: row.startsAt,
+      remainingPax: row.unlimited ? null : (row.remainingPax ?? null),
+      unlimited: row.unlimited,
+      source: runtime.source ?? "created",
+    }
+    await eventBus.emit(AVAILABILITY_SLOT_CHANGED_EVENT, payload, {
+      category: "domain",
+      source: "service",
+    })
+  }
+
+  return row
 }
 
 export async function updateSlot(
   db: PostgresJsDatabase,
   id: string,
   data: UpdateAvailabilitySlotInput,
-  runtime: UpdateSlotRuntime = {},
+  runtime: SlotMutationRuntime = {},
 ) {
   const patch = {
     ...data,
@@ -260,12 +294,45 @@ export async function updateSlot(
   return row
 }
 
-export async function deleteSlot(db: PostgresJsDatabase, id: string) {
+export async function deleteSlot(
+  db: PostgresJsDatabase,
+  id: string,
+  runtime: SlotMutationRuntime = {},
+) {
+  // Snapshot the row before deletion so we can build a complete event
+  // payload — once the row is gone we can't reconstruct productId etc.
+  const [snapshot] = await db
+    .select()
+    .from(availabilitySlots)
+    .where(eq(availabilitySlots.id, id))
+    .limit(1)
+
   const [row] = await db
     .delete(availabilitySlots)
     .where(eq(availabilitySlots.id, id))
     .returning({ id: availabilitySlots.id })
-  return row ?? null
+  if (!row) return null
+
+  const eventBus = runtime.eventBus
+  if (eventBus && snapshot) {
+    const payload: AvailabilitySlotChangedEvent = {
+      slotId: snapshot.id,
+      productId: snapshot.productId,
+      optionId: snapshot.optionId ?? null,
+      startsAt: snapshot.startsAt,
+      // Deleted slot contributes zero capacity. `remainingPax` reflects
+      // the post-mutation state per the contract; for a delete that's 0.
+      remainingPax: 0,
+      unlimited: false,
+      source: runtime.source ?? "deleted",
+    }
+    await eventBus.emit(AVAILABILITY_SLOT_CHANGED_EVENT, payload, {
+      category: "domain",
+      source: "service",
+    })
+  }
+
+  return row
 }
 
 export async function listCloseouts(db: PostgresJsDatabase, query: AvailabilityCloseoutListQuery) {

--- a/packages/availability/tests/integration/departures-projection.test.ts
+++ b/packages/availability/tests/integration/departures-projection.test.ts
@@ -1,0 +1,253 @@
+import { newId } from "@voyantjs/db/lib/typeid"
+import { cleanupTestDb, createTestDb } from "@voyantjs/db/test-utils"
+import { products } from "@voyantjs/products/schema"
+import type { IndexerSlice } from "@voyantjs/products/service-catalog-plane"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { availabilitySlots } from "../../src/schema.js"
+import { createProductDeparturesProjectionExtension } from "../../src/service-catalog-plane-departures.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+const enSlice: IndexerSlice = {
+  vertical: "products",
+  locale: "en-GB",
+  audience: "customer",
+  market: "default",
+}
+
+// Pin "now" so test fixtures don't drift with wall-clock.
+const NOW = new Date("2026-05-08T12:00:00Z")
+
+describe.skipIf(!DB_AVAILABLE)("createProductDeparturesProjectionExtension (integration)", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: drizzle test client
+  let db: any
+  let productId: string
+
+  beforeAll(() => {
+    db = createTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDb(db)
+    productId = newId("products")
+    await db.insert(products).values({
+      id: productId,
+      name: "Bali Wellness Retreat",
+      sellCurrency: "USD",
+      bookingMode: "date",
+    })
+  })
+
+  it("returns empty fields when there are no slots", async () => {
+    const ext = createProductDeparturesProjectionExtension({ now: () => NOW })
+    const out = await ext.project(db, productId, enSlice)
+    expect(out.get("hasUpcomingDeparture")).toBe(false)
+    expect(out.get("upcomingDepartureCount")).toBe(0)
+    expect(out.get("departureDates[]")).toEqual([])
+    expect(out.get("departureMonths[]")).toEqual([])
+    expect(out.get("availableUnitsTotal")).toBe(0)
+    expect(out.get("nextDepartureAt")).toBeNull()
+    expect(out.get("nextDepartureDate")).toBeNull()
+  })
+
+  it("aggregates open future slots, picks earliest as next", async () => {
+    await db.insert(availabilitySlots).values([
+      {
+        id: newId("availability_slots"),
+        productId,
+        dateLocal: "2026-05-10",
+        startsAt: new Date("2026-05-10T08:00:00Z"),
+        timezone: "UTC",
+        status: "open",
+        unlimited: false,
+        remainingPax: 4,
+      },
+      {
+        id: newId("availability_slots"),
+        productId,
+        dateLocal: "2026-06-01",
+        startsAt: new Date("2026-06-01T08:00:00Z"),
+        timezone: "UTC",
+        status: "open",
+        unlimited: false,
+        remainingPax: 8,
+      },
+    ])
+
+    const ext = createProductDeparturesProjectionExtension({ now: () => NOW })
+    const out = await ext.project(db, productId, enSlice)
+    expect(out.get("hasUpcomingDeparture")).toBe(true)
+    expect(out.get("upcomingDepartureCount")).toBe(2)
+    expect(out.get("nextDepartureDate")).toBe("2026-05-10")
+    expect(out.get("departureDates[]")).toEqual(["2026-05-10", "2026-06-01"])
+    expect(out.get("departureMonths[]")).toEqual(["2026-05", "2026-06"])
+    expect(out.get("availableUnitsTotal")).toBe(12)
+  })
+
+  it("excludes sold_out / cancelled / closed slots from every field", async () => {
+    await db.insert(availabilitySlots).values([
+      {
+        id: newId("availability_slots"),
+        productId,
+        dateLocal: "2026-05-10",
+        startsAt: new Date("2026-05-10T08:00:00Z"),
+        timezone: "UTC",
+        status: "sold_out",
+        unlimited: false,
+        remainingPax: 0,
+      },
+      {
+        id: newId("availability_slots"),
+        productId,
+        dateLocal: "2026-05-11",
+        startsAt: new Date("2026-05-11T08:00:00Z"),
+        timezone: "UTC",
+        status: "cancelled",
+        unlimited: false,
+        remainingPax: 0,
+      },
+      {
+        id: newId("availability_slots"),
+        productId,
+        dateLocal: "2026-05-12",
+        startsAt: new Date("2026-05-12T08:00:00Z"),
+        timezone: "UTC",
+        status: "open",
+        unlimited: false,
+        remainingPax: 5,
+      },
+    ])
+
+    const ext = createProductDeparturesProjectionExtension({ now: () => NOW })
+    const out = await ext.project(db, productId, enSlice)
+    // Only the open slot survives the filter.
+    expect(out.get("upcomingDepartureCount")).toBe(1)
+    expect(out.get("departureDates[]")).toEqual(["2026-05-12"])
+    expect(out.get("availableUnitsTotal")).toBe(5)
+  })
+
+  it("excludes past slots", async () => {
+    await db.insert(availabilitySlots).values([
+      {
+        id: newId("availability_slots"),
+        productId,
+        dateLocal: "2026-04-01", // before NOW
+        startsAt: new Date("2026-04-01T08:00:00Z"),
+        timezone: "UTC",
+        status: "open",
+        unlimited: false,
+        remainingPax: 5,
+      },
+      {
+        id: newId("availability_slots"),
+        productId,
+        dateLocal: "2026-06-01",
+        startsAt: new Date("2026-06-01T08:00:00Z"),
+        timezone: "UTC",
+        status: "open",
+        unlimited: false,
+        remainingPax: 5,
+      },
+    ])
+
+    const ext = createProductDeparturesProjectionExtension({ now: () => NOW })
+    const out = await ext.project(db, productId, enSlice)
+    expect(out.get("upcomingDepartureCount")).toBe(1)
+    expect(out.get("departureDates[]")).toEqual(["2026-06-01"])
+  })
+
+  it("emits availableUnitsTotal=null when any slot is unlimited", async () => {
+    await db.insert(availabilitySlots).values([
+      {
+        id: newId("availability_slots"),
+        productId,
+        dateLocal: "2026-05-10",
+        startsAt: new Date("2026-05-10T08:00:00Z"),
+        timezone: "UTC",
+        status: "open",
+        unlimited: false,
+        remainingPax: 4,
+      },
+      {
+        id: newId("availability_slots"),
+        productId,
+        dateLocal: "2026-05-11",
+        startsAt: new Date("2026-05-11T08:00:00Z"),
+        timezone: "UTC",
+        status: "open",
+        unlimited: true,
+        remainingPax: null,
+      },
+    ])
+
+    const ext = createProductDeparturesProjectionExtension({ now: () => NOW })
+    const out = await ext.project(db, productId, enSlice)
+    expect(out.get("availableUnitsTotal")).toBeNull()
+    expect(out.get("upcomingDepartureCount")).toBe(2)
+  })
+
+  it("short-circuits empty for products with bookingMode='open'", async () => {
+    // Re-create the product with bookingMode='open'.
+    await db.delete(products)
+    await db.insert(products).values({
+      id: productId,
+      name: "Anytime City Tour",
+      sellCurrency: "USD",
+      bookingMode: "open",
+    })
+    // Create a slot anyway — projection should ignore it.
+    await db.insert(availabilitySlots).values({
+      id: newId("availability_slots"),
+      productId,
+      dateLocal: "2026-05-10",
+      startsAt: new Date("2026-05-10T08:00:00Z"),
+      timezone: "UTC",
+      status: "open",
+      unlimited: false,
+      remainingPax: 5,
+    })
+
+    const ext = createProductDeparturesProjectionExtension({ now: () => NOW })
+    const out = await ext.project(db, productId, enSlice)
+    expect(out.get("hasUpcomingDeparture")).toBe(false)
+    expect(out.get("upcomingDepartureCount")).toBe(0)
+    expect(out.get("departureDates[]")).toEqual([])
+  })
+
+  it("clips departure dates to the configured window", async () => {
+    // Three slots: within 30d, just past 30d, far future.
+    await db.insert(availabilitySlots).values([
+      {
+        id: newId("availability_slots"),
+        productId,
+        dateLocal: "2026-05-15",
+        startsAt: new Date("2026-05-15T08:00:00Z"),
+        timezone: "UTC",
+        status: "open",
+        unlimited: false,
+        remainingPax: 1,
+      },
+      {
+        id: newId("availability_slots"),
+        productId,
+        dateLocal: "2026-08-15",
+        startsAt: new Date("2026-08-15T08:00:00Z"),
+        timezone: "UTC",
+        status: "open",
+        unlimited: false,
+        remainingPax: 1,
+      },
+    ])
+
+    const ext = createProductDeparturesProjectionExtension({
+      now: () => NOW,
+      datesWindowDays: 30,
+      monthsWindowCount: 24,
+    })
+    const out = await ext.project(db, productId, enSlice)
+    expect(out.get("departureDates[]")).toEqual(["2026-05-15"])
+    // Months window keeps both.
+    expect(out.get("departureMonths[]")).toEqual(["2026-05", "2026-08"])
+  })
+})

--- a/packages/availability/tests/integration/slot-events.test.ts
+++ b/packages/availability/tests/integration/slot-events.test.ts
@@ -1,0 +1,116 @@
+import { createEventBus } from "@voyantjs/core"
+import { newId } from "@voyantjs/db/lib/typeid"
+import { cleanupTestDb, createTestDb } from "@voyantjs/db/test-utils"
+import { products } from "@voyantjs/products/schema"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import {
+  AVAILABILITY_SLOT_CHANGED_EVENT,
+  type AvailabilitySlotChangedEvent,
+} from "../../src/events.js"
+import { availabilitySlots } from "../../src/schema.js"
+import { createSlot, deleteSlot, updateSlot } from "../../src/service-core.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+describe.skipIf(!DB_AVAILABLE)("availability slot events", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: drizzle test client
+  let db: any
+  let productId: string
+
+  beforeAll(() => {
+    db = createTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDb(db)
+    productId = newId("products")
+    await db.insert(products).values({
+      id: productId,
+      name: "Slot Event Test Product",
+      sellCurrency: "USD",
+      bookingMode: "date",
+    })
+  })
+
+  function recordingBus() {
+    const bus = createEventBus()
+    const events: Array<{ event: string; data: AvailabilitySlotChangedEvent }> = []
+    bus.subscribe<AvailabilitySlotChangedEvent>(AVAILABILITY_SLOT_CHANGED_EVENT, ({ data }) => {
+      events.push({ event: AVAILABILITY_SLOT_CHANGED_EVENT, data })
+    })
+    return { bus, events }
+  }
+
+  it("createSlot emits availability.slot.changed with source='created'", async () => {
+    const { bus, events } = recordingBus()
+    const created = await createSlot(
+      db,
+      {
+        productId,
+        dateLocal: "2026-06-01",
+        startsAt: "2026-06-01T08:00:00Z",
+        timezone: "UTC",
+        status: "open",
+        unlimited: false,
+        remainingPax: 5,
+      },
+      { eventBus: bus },
+    )
+    expect(created).toBeDefined()
+    expect(events).toHaveLength(1)
+    expect(events[0]?.data.source).toBe("created")
+    expect(events[0]?.data.productId).toBe(productId)
+    expect(events[0]?.data.remainingPax).toBe(5)
+  })
+
+  it("deleteSlot emits availability.slot.changed with source='deleted'", async () => {
+    // Seed a slot directly so we can isolate the delete event.
+    const slotId = newId("availability_slots")
+    await db.insert(availabilitySlots).values({
+      id: slotId,
+      productId,
+      dateLocal: "2026-06-01",
+      startsAt: new Date("2026-06-01T08:00:00Z"),
+      timezone: "UTC",
+      status: "open",
+      unlimited: false,
+      remainingPax: 5,
+    })
+
+    const { bus, events } = recordingBus()
+    const deleted = await deleteSlot(db, slotId, { eventBus: bus })
+    expect(deleted).toBeDefined()
+    expect(events).toHaveLength(1)
+    expect(events[0]?.data.source).toBe("deleted")
+    expect(events[0]?.data.productId).toBe(productId)
+    // Deleted slot reports zero remaining capacity per the contract.
+    expect(events[0]?.data.remainingPax).toBe(0)
+  })
+
+  it("deleteSlot is a no-op (no event) when the slot doesn't exist", async () => {
+    const { bus, events } = recordingBus()
+    const result = await deleteSlot(db, "availability_slots_nonexistent", { eventBus: bus })
+    expect(result).toBeNull()
+    expect(events).toHaveLength(0)
+  })
+
+  it("updateSlot still emits with default source='manual' (back-compat)", async () => {
+    const slotId = newId("availability_slots")
+    await db.insert(availabilitySlots).values({
+      id: slotId,
+      productId,
+      dateLocal: "2026-06-01",
+      startsAt: new Date("2026-06-01T08:00:00Z"),
+      timezone: "UTC",
+      status: "open",
+      unlimited: false,
+      remainingPax: 5,
+    })
+
+    const { bus, events } = recordingBus()
+    await updateSlot(db, slotId, { remainingPax: 3 }, { eventBus: bus })
+    expect(events).toHaveLength(1)
+    expect(events[0]?.data.source).toBe("manual")
+  })
+})

--- a/packages/availability/tests/unit/departures-projection.test.ts
+++ b/packages/availability/tests/unit/departures-projection.test.ts
@@ -1,0 +1,210 @@
+import type { AnyDrizzleDb } from "@voyantjs/db"
+import type { IndexerSlice } from "@voyantjs/products/service-catalog-plane"
+import { describe, expect, it } from "vitest"
+
+import {
+  __test__,
+  createProductDeparturesProjectionExtension,
+} from "../../src/service-catalog-plane-departures.js"
+
+const { aggregateDepartures, EMPTY_AGGREGATE, SCHEDULED_BOOKING_MODES } = __test__
+
+interface Slot {
+  startsAt: Date
+  dateLocal: string
+  remainingPax: number | null
+  unlimited: boolean
+}
+
+function slot(
+  isoStarts: string,
+  dateLocal: string,
+  remainingPax: number | null = 5,
+  unlimited = false,
+): Slot {
+  return { startsAt: new Date(isoStarts), dateLocal, remainingPax, unlimited }
+}
+
+const NOW = new Date("2026-05-08T12:00:00Z")
+
+const customerSlice: IndexerSlice = {
+  vertical: "products",
+  locale: "en-GB",
+  audience: "customer",
+  market: "default",
+}
+
+describe("aggregateDepartures (kernel)", () => {
+  it("returns the empty aggregate when no slots", () => {
+    expect(aggregateDepartures([], NOW, 180, 24)).toEqual(EMPTY_AGGREGATE)
+  })
+
+  it("picks earliest slot as next, counts all, dedupes dates and months", () => {
+    const slots: Slot[] = [
+      slot("2026-05-09T10:00:00Z", "2026-05-09", 4),
+      slot("2026-05-09T18:00:00Z", "2026-05-09", 6), // same local date, second time slot
+      slot("2026-06-15T08:00:00Z", "2026-06-15", 8),
+    ]
+    const out = aggregateDepartures(slots, NOW, 180, 24)
+    expect(out.nextDepartureAt).toBe("2026-05-09T10:00:00.000Z")
+    expect(out.nextDepartureDate).toBe("2026-05-09")
+    expect(out.hasUpcomingDeparture).toBe(true)
+    expect(out.upcomingDepartureCount).toBe(3)
+    // Two distinct dates after dedup, sorted ascending.
+    expect(out.departureDates).toEqual(["2026-05-09", "2026-06-15"])
+    expect(out.departureMonths).toEqual(["2026-05", "2026-06"])
+    expect(out.availableUnitsTotal).toBe(18)
+  })
+
+  it("emits availableUnitsTotal=null when ANY slot is unlimited", () => {
+    const slots: Slot[] = [
+      slot("2026-05-09T10:00:00Z", "2026-05-09", 4),
+      slot("2026-05-10T10:00:00Z", "2026-05-10", null, true), // unlimited
+    ]
+    const out = aggregateDepartures(slots, NOW, 180, 24)
+    expect(out.availableUnitsTotal).toBeNull()
+    // But count + dates still reflect both.
+    expect(out.upcomingDepartureCount).toBe(2)
+    expect(out.departureDates).toEqual(["2026-05-09", "2026-05-10"])
+  })
+
+  it("clips departureDates to the configured window", () => {
+    const slots: Slot[] = [
+      slot("2026-05-15T10:00:00Z", "2026-05-15"), // within 30 days
+      slot("2026-08-15T10:00:00Z", "2026-08-15"), // outside 30 days
+    ]
+    const out = aggregateDepartures(slots, NOW, /* days */ 30, /* months */ 24)
+    expect(out.departureDates).toEqual(["2026-05-15"])
+    // Months window stays at 24 — both still appear.
+    expect(out.departureMonths).toEqual(["2026-05", "2026-08"])
+    // Count is unaffected by the window — it's the underlying scan size.
+    expect(out.upcomingDepartureCount).toBe(2)
+  })
+
+  it("clips departureMonths to the configured window", () => {
+    const slots: Slot[] = [
+      slot("2026-05-15T10:00:00Z", "2026-05-15"),
+      slot("2027-08-15T10:00:00Z", "2027-08-15"), // 15 months out
+      slot("2028-08-15T10:00:00Z", "2028-08-15"), // 27 months out — past 24mo cap
+    ]
+    const out = aggregateDepartures(slots, NOW, 180, 24)
+    expect(out.departureMonths).toEqual(["2026-05", "2027-08"])
+  })
+
+  it("uses slot.dateLocal verbatim — does not attempt timezone conversion of startsAt", () => {
+    // 9am Madrid local on May 5 — startsAt is the equivalent UTC
+    // (May 5 07:00Z), but the slot row says May 5 in its TZ. Storefronts
+    // bucket by the slot's local calendar so a Hawaii user still sees
+    // "May 5 in Madrid" and not "May 4 UTC".
+    const madridSlot = slot("2026-05-05T07:00:00Z", "2026-05-05", 12)
+    const out = aggregateDepartures([madridSlot], NOW, 180, 24)
+    expect(out.nextDepartureDate).toBe("2026-05-05")
+    expect(out.departureDates).toEqual(["2026-05-05"])
+    expect(out.departureMonths).toEqual(["2026-05"])
+  })
+
+  it("orders defensively even when caller passes slots out of order", () => {
+    const out = aggregateDepartures(
+      [slot("2026-09-01T10:00:00Z", "2026-09-01"), slot("2026-05-09T10:00:00Z", "2026-05-09")],
+      NOW,
+      180,
+      24,
+    )
+    expect(out.nextDepartureAt).toBe("2026-05-09T10:00:00.000Z")
+  })
+
+  it("scheduled-mode set covers the modes operators use for fixed cohorts", () => {
+    expect(SCHEDULED_BOOKING_MODES.has("date")).toBe(true)
+    expect(SCHEDULED_BOOKING_MODES.has("date_time")).toBe(true)
+    expect(SCHEDULED_BOOKING_MODES.has("stay")).toBe(true)
+    expect(SCHEDULED_BOOKING_MODES.has("itinerary")).toBe(true)
+    // "open" = anytime (no fixed slots) — must NOT be scheduled.
+    expect(SCHEDULED_BOOKING_MODES.has("open")).toBe(false)
+  })
+})
+
+describe("createProductDeparturesProjectionExtension", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: drizzle stub
+  const dbStub: any = {}
+
+  it("short-circuits to empty for products with bookingMode='open'", async () => {
+    const ext = createProductDeparturesProjectionExtension({
+      now: () => NOW,
+      loadBookingMode: async () => "open",
+    })
+    const out = await ext.project(dbStub as AnyDrizzleDb, "prod_anytime", customerSlice)
+    expect(out.get("nextDepartureAt")).toBeNull()
+    expect(out.get("hasUpcomingDeparture")).toBe(false)
+    expect(out.get("upcomingDepartureCount")).toBe(0)
+    expect(out.get("departureDates[]")).toEqual([])
+    expect(out.get("departureMonths[]")).toEqual([])
+    expect(out.get("availableUnitsTotal")).toBe(0)
+  })
+
+  it("short-circuits empty for any other non-scheduled mode (transfer, other, ...)", async () => {
+    const ext = createProductDeparturesProjectionExtension({
+      now: () => NOW,
+      loadBookingMode: async () => "transfer",
+    })
+    const out = await ext.project(dbStub as AnyDrizzleDb, "prod_transfer", customerSlice)
+    expect(out.get("hasUpcomingDeparture")).toBe(false)
+  })
+
+  it("emits empty when bookingMode is null (product missing — defensive)", async () => {
+    const ext = createProductDeparturesProjectionExtension({
+      now: () => NOW,
+      loadBookingMode: async () => null,
+    })
+    // Stub a DB that returns no slots so the path runs without errors.
+    // biome-ignore lint/suspicious/noExplicitAny: chained drizzle stub
+    const localDb: any = {
+      select() {
+        return {
+          from() {
+            return {
+              where() {
+                return { orderBy: async () => [] }
+              },
+            }
+          },
+        }
+      },
+    }
+    const out = await ext.project(localDb, "prod_missing", customerSlice)
+    // null bookingMode is treated as "scheduled" (defensive), so the
+    // query runs and the empty result still produces the empty aggregate.
+    expect(out.get("upcomingDepartureCount")).toBe(0)
+  })
+
+  it("returns aggregated fields for a scheduled product", async () => {
+    // biome-ignore lint/suspicious/noExplicitAny: chained drizzle stub
+    const dbWithSlots: any = {
+      select() {
+        return {
+          from() {
+            return {
+              where() {
+                return {
+                  orderBy: async () => [
+                    slot("2026-05-09T10:00:00Z", "2026-05-09", 5),
+                    slot("2026-06-01T10:00:00Z", "2026-06-01", 8),
+                  ],
+                }
+              },
+            }
+          },
+        }
+      },
+    }
+    const ext = createProductDeparturesProjectionExtension({
+      now: () => NOW,
+      loadBookingMode: async () => "date",
+    })
+    const out = await ext.project(dbWithSlots, "prod_scheduled", customerSlice)
+    expect(out.get("hasUpcomingDeparture")).toBe(true)
+    expect(out.get("upcomingDepartureCount")).toBe(2)
+    expect(out.get("nextDepartureDate")).toBe("2026-05-09")
+    expect(out.get("availableUnitsTotal")).toBe(13)
+    expect(out.get("departureMonths[]")).toEqual(["2026-05", "2026-06"])
+  })
+})

--- a/packages/products/package.json
+++ b/packages/products/package.json
@@ -15,6 +15,7 @@
     "./catalog-policy": "./src/catalog-policy.ts",
     "./catalog-policy-destinations": "./src/catalog-policy-destinations.ts",
     "./catalog-policy-taxonomy": "./src/catalog-policy-taxonomy.ts",
+    "./catalog-policy-departures": "./src/catalog-policy-departures.ts",
     "./service-catalog-plane": "./src/service-catalog-plane.ts",
     "./service-catalog-plane-destinations": "./src/service-catalog-plane-destinations.ts",
     "./service-catalog-plane-taxonomy": "./src/service-catalog-plane-taxonomy.ts",
@@ -109,6 +110,11 @@
         "types": "./dist/catalog-policy-taxonomy.d.ts",
         "import": "./dist/catalog-policy-taxonomy.js",
         "default": "./dist/catalog-policy-taxonomy.js"
+      },
+      "./catalog-policy-departures": {
+        "types": "./dist/catalog-policy-departures.d.ts",
+        "import": "./dist/catalog-policy-departures.js",
+        "default": "./dist/catalog-policy-departures.js"
       },
       "./service-catalog-plane": {
         "types": "./dist/service-catalog-plane.d.ts",

--- a/packages/products/src/catalog-policy-departures.ts
+++ b/packages/products/src/catalog-policy-departures.ts
@@ -1,0 +1,176 @@
+/**
+ * Catalog plane field policy for product → departures denormalization.
+ *
+ * These fields don't live on the `products` table — they're aggregated
+ * from `availability_slots` (filtered to `status = 'open'` and future
+ * `startsAt`) at index time and projected onto the product search
+ * document. See `docs/architecture/catalog-architecture.md` §5.4.
+ *
+ * Storefront product cards filter and display by departure surface:
+ *   - "departing in May" (filter: `departureMonths[]` includes "2026-05")
+ *   - "available this weekend" (filter: `departureDates[]` overlap)
+ *   - "available now" (filter: `hasUpcomingDeparture:true`)
+ *   - sort by next departure (`nextDepartureAt` asc)
+ *   - show capacity badge (`availableUnitsTotal`)
+ *
+ * Wire this policy into the products registry by composing with
+ * `productCatalogPolicy`:
+ *
+ *   const registry = createFieldPolicyRegistry([
+ *     ...productCatalogPolicy,
+ *     ...productDeparturesCatalogPolicy,
+ *   ])
+ *
+ * and wire `createProductDeparturesProjectionExtension` into
+ * `createProductDocumentBuilder` so the values land in the doc.
+ *
+ * Reindex semantics: every aggregation depends on `now()` — the same
+ * product reindexed an hour later will produce slightly different
+ * documents because the future window slides. Operators rely on the
+ * channel-push reconciler + scheduled refresh to keep these fields warm
+ * without storming the indexer on each tick. Per architecture §5.4,
+ * `reindex: "facet-affecting"` is the right tier — these fields drive
+ * facets but aren't on the merchandisable hot path.
+ *
+ * Out of scope here:
+ *   - Sold-out / cancelled / closed slots. The projection only counts
+ *     `status = 'open'` so storefront filters never surface unavailable
+ *     departures. A "show sold-out" toggle is a query-time concern.
+ *   - Per-option splits. Today's projection rolls up to the product;
+ *     per-option faceting is a follow-up if storefronts need it.
+ *   - Duration buckets (nights/days). Slots carry these but products
+ *     with mixed-duration slots can't be summarized in one number.
+ */
+
+import { defineFieldPolicy, type FieldPolicyInput } from "@voyantjs/catalog/contract"
+
+const PRODUCT_DEPARTURES_FIELD_POLICY: FieldPolicyInput[] = [
+  // ── Earliest open future departure ──────────────────────────────────────
+  // `nextDepartureAt` is the timestamptz for sort order (catalog sort by
+  // soonest available). `nextDepartureDate` is the same departure expressed
+  // as the slot's local calendar date — what the storefront card renders.
+  {
+    path: "nextDepartureAt",
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "facet-affecting",
+    snapshot: "on-book",
+    query: "indexed-column",
+    localized: false,
+    visibility: ["staff", "customer", "partner"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+  },
+  {
+    path: "nextDepartureDate",
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "facet-affecting",
+    snapshot: "on-book",
+    query: "indexed-column",
+    localized: false,
+    visibility: ["staff", "customer", "partner"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+  },
+
+  // ── Existence + count facets ─────────────────────────────────────────────
+  // `hasUpcomingDeparture` is the cheap "available now" filter. The count
+  // lets storefront sort by "lots of options available" without exposing
+  // the date list to the query layer.
+  {
+    path: "hasUpcomingDeparture",
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "facet-affecting",
+    snapshot: "on-book",
+    query: "indexed-column",
+    localized: false,
+    visibility: ["staff", "customer", "partner"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+  },
+  {
+    path: "upcomingDepartureCount",
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "facet-affecting",
+    snapshot: "on-book",
+    query: "indexed-column",
+    localized: false,
+    visibility: ["staff", "customer", "partner"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+  },
+
+  // ── Calendar-bucket facets ──────────────────────────────────────────────
+  // `departureDates[]` powers fine-grained "this weekend" / "next week"
+  // filters; capped at 180 days of distinct calendar dates so document
+  // size stays bounded for daily-slot products. `departureMonths[]` is
+  // the longer-tail facet — 24 months of "YYYY-MM" tokens covers an
+  // operator's typical forward-published inventory horizon.
+  {
+    path: "departureDates[]",
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "facet-affecting",
+    snapshot: "on-book",
+    query: "indexed-column",
+    localized: false,
+    visibility: ["staff", "customer", "partner"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+  },
+  {
+    path: "departureMonths[]",
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "facet-affecting",
+    snapshot: "on-book",
+    query: "indexed-column",
+    localized: false,
+    visibility: ["staff", "customer", "partner"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+  },
+
+  // ── Capacity ────────────────────────────────────────────────────────────
+  // Sum of `remaining_pax` across upcoming open slots. `null` when ANY
+  // counted slot is unlimited — unbounded capacity can't be summarized in
+  // a number, and emitting a partial sum would mislead the storefront
+  // ("3 seats left" when one slot is actually unlimited).
+  {
+    path: "availableUnitsTotal",
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "facet-affecting",
+    snapshot: "on-book",
+    query: "indexed-column",
+    localized: false,
+    visibility: ["staff", "customer", "partner"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+  },
+]
+
+/**
+ * Resolved departures policy. Compose with `productCatalogPolicy` when
+ * building the products registry.
+ */
+export const productDeparturesCatalogPolicy = defineFieldPolicy(PRODUCT_DEPARTURES_FIELD_POLICY)
+
+export { PRODUCT_DEPARTURES_FIELD_POLICY }

--- a/packages/products/tests/unit/catalog-policy-departures.test.ts
+++ b/packages/products/tests/unit/catalog-policy-departures.test.ts
@@ -1,0 +1,63 @@
+import { createFieldPolicyRegistry } from "@voyantjs/catalog/contract"
+import { describe, expect, it } from "vitest"
+
+import { productCatalogPolicy } from "../../src/catalog-policy.js"
+import {
+  PRODUCT_DEPARTURES_FIELD_POLICY,
+  productDeparturesCatalogPolicy,
+} from "../../src/catalog-policy-departures.js"
+import { productDestinationsCatalogPolicy } from "../../src/catalog-policy-destinations.js"
+import { productTaxonomyCatalogPolicy } from "../../src/catalog-policy-taxonomy.js"
+
+describe("productDeparturesCatalogPolicy", () => {
+  it("declares the storefront-required departure paths", () => {
+    const paths = PRODUCT_DEPARTURES_FIELD_POLICY.map((p) => p.path)
+    expect(paths).toContain("nextDepartureAt")
+    expect(paths).toContain("nextDepartureDate")
+    expect(paths).toContain("hasUpcomingDeparture")
+    expect(paths).toContain("upcomingDepartureCount")
+    expect(paths).toContain("departureDates[]")
+    expect(paths).toContain("departureMonths[]")
+    expect(paths).toContain("availableUnitsTotal")
+  })
+
+  it("does not declare any locale-keyed fields (departures are TZ-keyed, not locale-keyed)", () => {
+    for (const policy of PRODUCT_DEPARTURES_FIELD_POLICY) {
+      expect(policy.localized).toBe(false)
+    }
+  })
+
+  it("makes every field visible to staff/customer/partner so storefront cards can render", () => {
+    for (const policy of PRODUCT_DEPARTURES_FIELD_POLICY) {
+      expect(policy.visibility).toContain("customer")
+      expect(policy.visibility).toContain("partner")
+      expect(policy.visibility).toContain("staff")
+    }
+  })
+
+  it("composes cleanly with all other product child-entity policies", () => {
+    const registry = createFieldPolicyRegistry([
+      ...productCatalogPolicy,
+      ...productDestinationsCatalogPolicy,
+      ...productTaxonomyCatalogPolicy,
+      ...productDeparturesCatalogPolicy,
+    ])
+    expect(registry.resolve("name")).toBeDefined()
+    expect(registry.resolve("regions[]")).toBeDefined()
+    expect(registry.resolve("categories[]")).toBeDefined()
+    expect(registry.resolve("nextDepartureAt")).toBeDefined()
+    expect(registry.resolve("departureMonths[]")).toBeDefined()
+    expect(registry.resolve("availableUnitsTotal")).toBeDefined()
+  })
+
+  it("does not duplicate any path against the base or sibling child-entity policies", () => {
+    expect(() =>
+      createFieldPolicyRegistry([
+        ...productCatalogPolicy,
+        ...productDestinationsCatalogPolicy,
+        ...productTaxonomyCatalogPolicy,
+        ...productDeparturesCatalogPolicy,
+      ]),
+    ).not.toThrow()
+  })
+})

--- a/templates/operator/src/api/catalog-bridge.ts
+++ b/templates/operator/src/api/catalog-bridge.ts
@@ -4,16 +4,23 @@
  * booking commits freeze a snapshot of every line item's resolved view.
  *
  * Subscriptions:
- *   - `product.created`         → reindex the product across DEFAULT_SLICES
- *   - `product.updated`         → reindex the product
- *   - `product.deleted`         → delete from every configured slice
- *   - `product.content.changed` → reindex the product (covers child-entity
- *                                 mutations like destination link
- *                                 add/remove that don't bump
- *                                 `product.updated`)
- *   - `booking.confirmed`       → capture a snapshot graph of the
- *                                 booking's product line items via
- *                                 `captureSnapshotGraph`
+ *   - `product.created`           → reindex the product across DEFAULT_SLICES
+ *   - `product.updated`           → reindex the product
+ *   - `product.deleted`           → delete from every configured slice
+ *   - `product.content.changed`   → reindex the product (covers child-entity
+ *                                   mutations like destination/category/tag
+ *                                   link add/remove that don't bump
+ *                                   `product.updated`)
+ *   - `availability.slot.changed` → reindex the slot's product so the
+ *                                   departure-date facets stay fresh.
+ *                                   Cross-package event: avoids polluting
+ *                                   `ProductContentChangedEvent.axis`
+ *                                   with availability concerns and keeps
+ *                                   the products package free of an
+ *                                   availability dep.
+ *   - `booking.confirmed`         → capture a snapshot graph of the
+ *                                   booking's product line items via
+ *                                   `captureSnapshotGraph`
  *
  * If Typesense isn't configured (no `TYPESENSE_HOST`), the indexer
  * handlers no-op silently. Snapshot capture only requires DB access, so
@@ -53,6 +60,18 @@ interface BookingConfirmedEventPayload {
   bookingId: string
   bookingNumber: string
   actorId: string | null
+}
+
+/**
+ * Mirrors `AvailabilitySlotChangedEvent` from `@voyantjs/availability`.
+ * Inlined here so the bridge doesn't need to import the availability
+ * events module just for the type — the contract is stable enough that
+ * a structural shape suffices and changes show up in review.
+ */
+interface AvailabilitySlotChangedPayload {
+  slotId: string
+  productId: string
+  optionId: string | null
 }
 
 export const catalogBridgeBundle: HonoBundle = {
@@ -114,6 +133,23 @@ export const catalogBridgeBundle: HonoBundle = {
         const ctx = buildIndexerContext()
         if (!ctx) return
         await ctx.service.reindexEntity("products", data.id, ctx.builder)
+      },
+    )
+
+    // Slot create/update/delete in the availability module reindexes the
+    // owning product so departure-date facets (`nextDepartureAt`,
+    // `departureDates[]`, `departureMonths[]`, `availableUnitsTotal`)
+    // stay fresh. The product itself doesn't change — but the projection
+    // extension reads slots, so the document does. Filter early on
+    // missing `productId` so a malformed payload can't blow up the
+    // subscriber.
+    eventBus.subscribe<AvailabilitySlotChangedPayload>(
+      "availability.slot.changed",
+      async ({ data }) => {
+        if (!data.productId) return
+        const ctx = buildIndexerContext()
+        if (!ctx) return
+        await ctx.service.reindexEntity("products", data.productId, ctx.builder)
       },
     )
 

--- a/templates/operator/src/api/lib/catalog-runtime.ts
+++ b/templates/operator/src/api/lib/catalog-runtime.ts
@@ -6,6 +6,7 @@
  * background catalog-bridge subscribers stay aligned.
  */
 
+import { createProductDeparturesProjectionExtension } from "@voyantjs/availability/service-catalog-plane-departures"
 import {
   createFieldPolicyRegistry,
   createTypesenseIndexer,
@@ -26,6 +27,7 @@ import type { AnyDrizzleDb } from "@voyantjs/db"
 import { extrasCatalogPolicy } from "@voyantjs/extras/catalog-policy"
 import { hospitalityCatalogPolicy } from "@voyantjs/hospitality/catalog-policy"
 import { productCatalogPolicy } from "@voyantjs/products/catalog-policy"
+import { productDeparturesCatalogPolicy } from "@voyantjs/products/catalog-policy-departures"
 import { productDestinationsCatalogPolicy } from "@voyantjs/products/catalog-policy-destinations"
 import { productTaxonomyCatalogPolicy } from "@voyantjs/products/catalog-policy-taxonomy"
 import { createProductDocumentBuilder } from "@voyantjs/products/service-catalog-plane"
@@ -239,6 +241,7 @@ export function getFieldPolicyRegistries(): Map<string, FieldPolicyRegistry> {
           ...productCatalogPolicy,
           ...productDestinationsCatalogPolicy,
           ...productTaxonomyCatalogPolicy,
+          ...productDeparturesCatalogPolicy,
         ]),
       ],
       ["extras", createFieldPolicyRegistry(extrasCatalogPolicy)],
@@ -271,6 +274,7 @@ export function createProductsDocumentBuilder(
     extensions: [
       createProductDestinationsProjectionExtension(),
       createProductTaxonomyProjectionExtension(),
+      createProductDeparturesProjectionExtension(),
     ],
   })
 }


### PR DESCRIPTION
## Summary

- New `productDeparturesCatalogPolicy` (`@voyantjs/products/catalog-policy-departures`) declaring `nextDepartureAt`, `nextDepartureDate`, `hasUpcomingDeparture`, `upcomingDepartureCount`, `departureDates[]`, `departureMonths[]`, `availableUnitsTotal`.
- New `createProductDeparturesProjectionExtension` (`@voyantjs/availability/service-catalog-plane-departures`) that scans `availability_slots` for `(productId, status='open', startsAt > now)` within a 24-month window and aggregates the fields.
- Catalog bridge subscribes to `availability.slot.changed` so any slot mutation reindexes the owning product.
- Closes a related event-emission gap: `createSlot` and `deleteSlot` in `@voyantjs/availability` now emit `availability.slot.changed` (only `updateSlot` did before). Source enum extended with `"created" | "deleted"`. Routes thread `c.get("eventBus")` through to the service. Without this, fresh / removed departures were invisible to the projection until the next unrelated slot edit — same silent-staleness pattern PR #499 P1 patched for destinations.

## Architecture decisions

- **Projection lives in `@voyantjs/availability`, not products.** Availability already deps on products for the FK schema; importing the `ProductProjectionExtension` contract type from products is the same direction. The reverse (products querying `availability_slots`) would create a circular dep.
- **Cross-package event subscription** (`availability.slot.changed` → product reindex) instead of polluting `ProductContentChangedEvent.axis` with availability concerns.
- **Only `status='open'` slots count** so storefront filters never surface unavailable departures. A "show sold-out" UX is a query-time concern.
- **Products with `bookingMode='open'`** (anytime tours, no fixed slots) short-circuit to empty arrays / nulls — gated server-side via the booking-mode read, no spurious slot scans.
- **Bucket by `availability_slots.dateLocal`**, not `products.timezone`. A 9am-Madrid departure is "May 5" globally even when the UTC `startsAt` crosses midnight.
- **`availableUnitsTotal` is `null`** when any counted slot is `unlimited=true` — emitting a partial sum would mislead the storefront.
- **Window caps:** 180 days for `departureDates[]` (covers date-picker / "this weekend / next month" filters; bounded so daily-slot products don't blow doc size); 24 months for `departureMonths[]` (matches operator forward-publishing horizon).

## Pre-existing gap NOT addressed here

The batch-update / batch-delete slot endpoints don't thread the event bus through `handleBatchUpdate` / `handleBatchDelete`, so bulk slot operations remain silent. This is pre-existing behavior (already broken for `updateSlot` before this PR) and fixing it requires touching the shared batch helpers. Tracked for a follow-up PR.

## Out of scope

- Per-option splits (today the projection rolls up to product). Follow-up if storefronts need it.
- Duration buckets (slots carry `nights` / `days` but mixed-duration products can't be summarized in one number).
- Closeout-aware filtering (closeouts that mark a date range without flipping slot status aren't reflected — separate event design).

## Test plan

- [x] `pnpm -F @voyantjs/availability typecheck` — clean.
- [x] `pnpm -F @voyantjs/products typecheck` — clean.
- [x] Operator template typecheck — clean.
- [x] `pnpm -F @voyantjs/availability test` — 57 pass / 43 skip (12 new unit tests + 14 new integration tests skip without `TEST_DATABASE_URL`).
- [x] `pnpm -F @voyantjs/products test` — 148 pass / 32 skip (5 new unit tests).
- [ ] CI runs the integration tests against `TEST_DATABASE_URL` (kernel + projection + slot-event emission).
- [ ] Manual: with operator template running, create / delete / edit a slot via `POST/PATCH/DELETE /v1/availability/slots`, verify `nextDepartureAt`, `departureDates[]`, `availableUnitsTotal` update in the resulting Typesense doc.

Refs #493. Closes the bridge gap that would otherwise have surfaced as a PR-review blocker like the one on PR #499.