### PR TITLE
Part 4 of #493: ship productPricingCatalogPolicy with multi-option MIN aggregation

### DIFF
--- a/.changeset/products-pricing-catalog-policy.md
+++ b/.changeset/products-pricing-catalog-policy.md
@@ -1,0 +1,34 @@
+---
+"@voyantjs/products": minor
+"@voyantjs/pricing": minor
+---
+
+Part 4 of #493: ship the pricing child-entity catalog registry — denormalize a `priceFromAmountCents` value across the product's configured default-rule prices so storefront cards can render `from $X` and filter by price range without fanning out to per-option pricing on every render.
+
+New surface (`@voyantjs/products`):
+
+- `productPricingCatalogPolicy` (`@voyantjs/products/catalog-policy-pricing`) — `FieldPolicy[]` declaring `priceFromAmountCents`, `priceFromCurrency`, `hasPricing`. Compose via `createFieldPolicyRegistry([...productCatalogPolicy, ...productPricingCatalogPolicy])`.
+
+New surface (`@voyantjs/pricing`):
+
+- `createProductPricingProjectionExtension` (`@voyantjs/pricing/service-catalog-plane-pricing`) — runtime extension that MINs across `products.sellAmountCents`, the active default `optionPriceRules.baseSellAmountCents`, and the active default `optionUnitPriceRules.sellAmountCents`, filtered to rules whose catalog currency matches the product's `sellCurrency` (or whose catalog currency is null and therefore inherits). `loadProductPricing` is pluggable for testing.
+
+Why a separate `priceFromAmountCents` field (vs. reusing `sellAmountCents` from the base policy): the base policy projects the row-level configured default verbatim. Multi-option products commonly leave `products.sellAmountCents` null and put the real prices on options — the new field MINs across both, giving storefront a value that's always meaningful even for option-driven products.
+
+Why the projection lives in `@voyantjs/pricing` (not products): the data lives there, and `pricing` already depends on `products`. The reverse import would create a circular dep — same architectural decision as PR3's departures projection in `@voyantjs/availability`.
+
+Operator template:
+
+- Composes `productPricingCatalogPolicy` into the products registry alongside destinations, taxonomy, departures.
+- `createProductsDocumentBuilder` runs the pricing extension on every product reindex.
+
+Behavior decisions:
+
+- **Static rules only.** Only `is_default = true AND active = true` rules contribute. Schedule-aware rules (seasonal, promo) and per-departure overrides are excluded. A "true cheapest bookable price right now" projection requires per-slice rule evaluation against a moving "now" date and is deferred.
+- **Currency consistency.** Only rules in catalogs matching the product's currency (or with a null catalog currency, which inherits) are MIN'd together. This prevents emitting a misleading "from $50" when one rule is actually €50.
+- **Document churn.** `now()`-independent — same product reindexed an hour later produces identical fields.
+
+Out of scope (tracked):
+
+- `pricing.changed` event surface. Today, edits to option-price rules don't fire any event, so the catalog bridge can only reindex on `product.updated`. Tracked in #505.
+- Schedule-aware rule resolution + per-departure overrides. Same operational concern as above plus per-slice resolution complexity.

--- a/packages/pricing/package.json
+++ b/packages/pricing/package.json
@@ -9,7 +9,8 @@
     "./validation": "./src/validation.ts",
     "./routes": "./src/routes.ts",
     "./public-routes": "./src/routes-public.ts",
-    "./public-validation": "./src/validation-public.ts"
+    "./public-validation": "./src/validation-public.ts",
+    "./service-catalog-plane-pricing": "./src/service-catalog-plane-pricing.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
@@ -71,6 +72,11 @@
         "types": "./dist/validation-public.d.ts",
         "import": "./dist/validation-public.js",
         "default": "./dist/validation-public.js"
+      },
+      "./service-catalog-plane-pricing": {
+        "types": "./dist/service-catalog-plane-pricing.d.ts",
+        "import": "./dist/service-catalog-plane-pricing.js",
+        "default": "./dist/service-catalog-plane-pricing.js"
       }
     },
     "main": "./dist/index.js",

--- a/packages/pricing/src/service-catalog-plane-pricing.ts
+++ b/packages/pricing/src/service-catalog-plane-pricing.ts
@@ -1,0 +1,259 @@
+/**
+ * Projection extension that aggregates a "price from" amount across the
+ * product's configured default-rule prices and contributes
+ * `priceFromAmountCents`, `priceFromCurrency`, and `hasPricing` to the
+ * product search document.
+ *
+ * Lives in `@voyantjs/pricing` because:
+ *   - The data lives here (`option_price_rules`, `option_unit_price_rules`,
+ *     `price_catalogs`).
+ *   - `pricing` already depends on `products`; importing the
+ *     `ProductProjectionExtension` contract type from products is the
+ *     same direction. The reverse would create a circular dep.
+ *
+ * Wire via `createProductDocumentBuilder({ extensions: [pricingExtension] })`
+ * after composing `productPricingCatalogPolicy` into the registry.
+ *
+ * Scope intentionally narrow:
+ *   - **No schedule-aware rule resolution.** Only `is_default = true`
+ *     rules contribute. Seasonal / promo rules with schedules don't
+ *     surface here — they'd require per-slice resolution against a
+ *     moving "now" date and are deferred to a follow-up.
+ *   - **No per-departure overrides.** Same reason.
+ *   - **Currency consistency.** Only rules whose catalog currency matches
+ *     the product's `sellCurrency` (or whose catalog currency is null
+ *     and therefore inherits the product's) are MIN'd together. This
+ *     prevents emitting a misleading "from $50" when one of the rules
+ *     is actually €50.
+ *
+ * Document churn: this projection is `now()`-independent — it reads
+ * static configured prices, not date-dependent rule windows. Same
+ * product reindexed an hour later produces the same fields.
+ */
+
+import type { AnyDrizzleDb } from "@voyantjs/db"
+import type {
+  IndexerSlice,
+  ProductProjectionExtension,
+} from "@voyantjs/products/service-catalog-plane"
+import { and, eq, isNull, or, sql } from "drizzle-orm"
+
+import { priceCatalogs } from "./schema-catalogs.js"
+import { optionPriceRules, optionUnitPriceRules } from "./schema-option-rules.js"
+
+interface PricingProjectionOptions {
+  /**
+   * Resolve the product's `sellAmountCents` + `sellCurrency` so the
+   * projection can MIN the product-row default into the candidate set
+   * and filter rules by matching currency. Templates inject this — the
+   * default reads the products table via raw SQL, but tests can stub
+   * with a known shape without standing up the products schema.
+   *
+   * Returns `null` for both fields when the product doesn't exist.
+   */
+  loadProductPricing?: (
+    db: AnyDrizzleDb,
+    productId: string,
+  ) => Promise<{ sellAmountCents: number | null; sellCurrency: string | null }>
+}
+
+interface PricingAggregate {
+  priceFromAmountCents: number | null
+  priceFromCurrency: string | null
+  hasPricing: boolean
+}
+
+const EMPTY_AGGREGATE: PricingAggregate = {
+  priceFromAmountCents: null,
+  priceFromCurrency: null,
+  hasPricing: false,
+}
+
+/**
+ * Pure aggregation kernel — given the product-row pricing and the rule
+ * candidate set, produce the projection fields. Exposed via `__test__`
+ * for unit coverage that doesn't need a real DB.
+ *
+ * `productPrice` is the row's `sellAmountCents` (`null` when unset).
+ * `currency` is the row's `sellCurrency` (used as the projected
+ * currency; rule prices fed in here are pre-filtered to match).
+ * `ruleCandidates` is every active default rule's `baseSellAmountCents`
+ * AND every active default rule's per-unit `sellAmountCents`, with
+ * nulls already filtered out.
+ */
+function aggregatePricing(
+  productPrice: number | null,
+  currency: string | null,
+  ruleCandidates: ReadonlyArray<number>,
+): PricingAggregate {
+  const candidates: number[] = []
+  if (productPrice !== null) candidates.push(productPrice)
+  for (const c of ruleCandidates) candidates.push(c)
+
+  if (candidates.length === 0) {
+    return { ...EMPTY_AGGREGATE, priceFromCurrency: currency }
+  }
+
+  // MIN with a sentinel; faster than spread+Math.min for large arrays
+  // and avoids the Math.min stack-arg limit edge case.
+  let min = candidates[0] as number
+  for (const c of candidates) {
+    if (c < min) min = c
+  }
+
+  return {
+    priceFromAmountCents: min,
+    priceFromCurrency: currency,
+    hasPricing: true,
+  }
+}
+
+/**
+ * Construct the pricing projection extension.
+ *
+ * Pass `loadProductPricing` in tests to stub the products-row fetch;
+ * production uses the default raw-SQL implementation.
+ */
+export function createProductPricingProjectionExtension(
+  options: PricingProjectionOptions = {},
+): ProductProjectionExtension {
+  const loadProductPricing = options.loadProductPricing ?? defaultLoadProductPricing
+
+  return {
+    name: "products:pricing",
+    async project(db, productId, _slice: IndexerSlice) {
+      const product = await loadProductPricing(db, productId)
+      const currency = product.sellCurrency
+
+      // Without a product row currency we can't safely filter rules by
+      // matching currency — emit only the (null) row pricing. This case
+      // is rare in practice (every product has sellCurrency set in the
+      // operator UI) but keeps the projection failure-isolated.
+      if (!currency) {
+        const out = aggregatePricing(product.sellAmountCents, null, [])
+        return toProjectionMap(out)
+      }
+
+      const [flatPrices, unitPrices] = await Promise.all([
+        fetchFlatRulePrices(db, productId, currency),
+        fetchUnitRulePrices(db, productId, currency),
+      ])
+
+      const candidates = [...flatPrices, ...unitPrices]
+      const out = aggregatePricing(product.sellAmountCents, currency, candidates)
+      return toProjectionMap(out)
+    },
+  }
+}
+
+/**
+ * Read `optionPriceRules.baseSellAmountCents` for the product's active
+ * default rules whose catalog currency matches the product currency
+ * (or whose catalog has a NULL currency, meaning "inherit product").
+ *
+ * Filtering on the `(productId, active=true, isDefault=true)` subset
+ * keeps the candidate set small even for products with hundreds of
+ * seasonal rules.
+ */
+async function fetchFlatRulePrices(
+  db: AnyDrizzleDb,
+  productId: string,
+  productCurrency: string,
+): Promise<number[]> {
+  const rows = await db
+    .select({ price: optionPriceRules.baseSellAmountCents })
+    .from(optionPriceRules)
+    .innerJoin(priceCatalogs, eq(priceCatalogs.id, optionPriceRules.priceCatalogId))
+    .where(
+      and(
+        eq(optionPriceRules.productId, productId),
+        eq(optionPriceRules.active, true),
+        eq(optionPriceRules.isDefault, true),
+        eq(priceCatalogs.active, true),
+        or(eq(priceCatalogs.currencyCode, productCurrency), isNull(priceCatalogs.currencyCode)),
+      ),
+    )
+
+  const out: number[] = []
+  for (const row of rows) {
+    if (row.price !== null) out.push(row.price)
+  }
+  return out
+}
+
+/**
+ * Read `optionUnitPriceRules.sellAmountCents` for active per-unit tiers
+ * whose parent rule is one of the product's active default rules in a
+ * matching-currency catalog. Used for products priced per occupancy
+ * (e.g. cabins at "single $X / double $Y / triple $Z") where the parent
+ * rule's `baseSellAmountCents` is null and the actual prices live on
+ * the unit tiers.
+ */
+async function fetchUnitRulePrices(
+  db: AnyDrizzleDb,
+  productId: string,
+  productCurrency: string,
+): Promise<number[]> {
+  const rows = await db
+    .select({ price: optionUnitPriceRules.sellAmountCents })
+    .from(optionUnitPriceRules)
+    .innerJoin(optionPriceRules, eq(optionPriceRules.id, optionUnitPriceRules.optionPriceRuleId))
+    .innerJoin(priceCatalogs, eq(priceCatalogs.id, optionPriceRules.priceCatalogId))
+    .where(
+      and(
+        eq(optionPriceRules.productId, productId),
+        eq(optionPriceRules.active, true),
+        eq(optionPriceRules.isDefault, true),
+        eq(optionUnitPriceRules.active, true),
+        eq(priceCatalogs.active, true),
+        or(eq(priceCatalogs.currencyCode, productCurrency), isNull(priceCatalogs.currencyCode)),
+      ),
+    )
+
+  const out: number[] = []
+  for (const row of rows) {
+    if (row.price !== null) out.push(row.price)
+  }
+  return out
+}
+
+/**
+ * Default loader reads the products row via raw SQL so we don't pull
+ * the products schema into this file (would create a circular import
+ * via the typed schema). The columns we read are stable enough that a
+ * rename would break far more than this.
+ */
+async function defaultLoadProductPricing(
+  db: AnyDrizzleDb,
+  productId: string,
+): Promise<{ sellAmountCents: number | null; sellCurrency: string | null }> {
+  // biome-ignore lint/suspicious/noExplicitAny: drizzle's typed sql is overkill for two-column read
+  const dbAny = db as any
+  const result = await dbAny.execute(
+    sql`SELECT sell_amount_cents, sell_currency FROM products WHERE id = ${productId} LIMIT 1`,
+  )
+  // postgres-js returns rows as an array-like; node-postgres returns `{ rows: [...] }`.
+  const rows = Array.isArray(result) ? result : (result?.rows ?? [])
+  const first = rows[0] as
+    | { sell_amount_cents: number | null; sell_currency: string | null }
+    | undefined
+  if (!first) return { sellAmountCents: null, sellCurrency: null }
+  return {
+    sellAmountCents: first.sell_amount_cents,
+    sellCurrency: first.sell_currency,
+  }
+}
+
+function toProjectionMap(a: PricingAggregate): ReadonlyMap<string, unknown> {
+  return new Map<string, unknown>([
+    ["priceFromAmountCents", a.priceFromAmountCents],
+    ["priceFromCurrency", a.priceFromCurrency],
+    ["hasPricing", a.hasPricing],
+  ])
+}
+
+// Internal exports for unit tests — kept off the public surface.
+export const __test__ = {
+  aggregatePricing,
+  EMPTY_AGGREGATE,
+}

--- a/packages/pricing/tests/integration/pricing-projection.test.ts
+++ b/packages/pricing/tests/integration/pricing-projection.test.ts
@@ -1,0 +1,249 @@
+import { newId } from "@voyantjs/db/lib/typeid"
+import { cleanupTestDb, createTestDb } from "@voyantjs/db/test-utils"
+import { optionUnits, productOptions, products } from "@voyantjs/products/schema"
+import type { IndexerSlice } from "@voyantjs/products/service-catalog-plane"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { priceCatalogs } from "../../src/schema-catalogs.js"
+import { optionPriceRules, optionUnitPriceRules } from "../../src/schema-option-rules.js"
+import { createProductPricingProjectionExtension } from "../../src/service-catalog-plane-pricing.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+const enSlice: IndexerSlice = {
+  vertical: "products",
+  locale: "en-GB",
+  audience: "customer",
+  market: "default",
+}
+
+describe.skipIf(!DB_AVAILABLE)("createProductPricingProjectionExtension (integration)", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: drizzle test client
+  let db: any
+  let productId: string
+  let optionId: string
+  let unitId: string
+  let usdCatalogId: string
+  let eurCatalogId: string
+
+  beforeAll(() => {
+    db = createTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDb(db)
+
+    productId = newId("products")
+    optionId = newId("product_options")
+    unitId = newId("option_units")
+    usdCatalogId = newId("price_catalogs")
+    eurCatalogId = newId("price_catalogs")
+
+    await db.insert(products).values({
+      id: productId,
+      name: "Multi-Option Tour",
+      sellCurrency: "USD",
+      // No row-level price — exercise the option-rules path.
+      sellAmountCents: null,
+    })
+    await db
+      .insert(productOptions)
+      .values({ id: optionId, productId, name: "Standard", code: "std" })
+    await db.insert(optionUnits).values({ id: unitId, optionId, name: "Adult", code: "adult" })
+    await db.insert(priceCatalogs).values([
+      { id: usdCatalogId, name: "Public USD", code: "public-usd", currencyCode: "USD" },
+      { id: eurCatalogId, name: "Public EUR", code: "public-eur", currencyCode: "EUR" },
+    ])
+  })
+
+  it("emits empty + currency only when no rules and no row price", async () => {
+    const ext = createProductPricingProjectionExtension()
+    const out = await ext.project(db, productId, enSlice)
+    expect(out.get("hasPricing")).toBe(false)
+    expect(out.get("priceFromAmountCents")).toBeNull()
+    expect(out.get("priceFromCurrency")).toBe("USD")
+  })
+
+  it("MINs across active default rules in the matching currency", async () => {
+    await db.insert(optionPriceRules).values([
+      {
+        id: newId("option_price_rules"),
+        productId,
+        optionId,
+        priceCatalogId: usdCatalogId,
+        name: "default",
+        baseSellAmountCents: 15000,
+        isDefault: true,
+        active: true,
+      },
+      {
+        id: newId("option_price_rules"),
+        productId,
+        optionId,
+        priceCatalogId: usdCatalogId,
+        name: "early-bird",
+        baseSellAmountCents: 9900,
+        isDefault: true,
+        active: true,
+      },
+    ])
+
+    const ext = createProductPricingProjectionExtension()
+    const out = await ext.project(db, productId, enSlice)
+    expect(out.get("priceFromAmountCents")).toBe(9900)
+    expect(out.get("priceFromCurrency")).toBe("USD")
+    expect(out.get("hasPricing")).toBe(true)
+  })
+
+  it("excludes rules in non-matching currencies", async () => {
+    // EUR rule with a much lower number — must NOT win the MIN, since
+    // the projection's currency is the product's USD.
+    await db.insert(optionPriceRules).values([
+      {
+        id: newId("option_price_rules"),
+        productId,
+        optionId,
+        priceCatalogId: usdCatalogId,
+        name: "default-usd",
+        baseSellAmountCents: 15000,
+        isDefault: true,
+        active: true,
+      },
+      {
+        id: newId("option_price_rules"),
+        productId,
+        optionId,
+        priceCatalogId: eurCatalogId,
+        name: "default-eur",
+        baseSellAmountCents: 5000,
+        isDefault: true,
+        active: true,
+      },
+    ])
+
+    const ext = createProductPricingProjectionExtension()
+    const out = await ext.project(db, productId, enSlice)
+    expect(out.get("priceFromAmountCents")).toBe(15000)
+  })
+
+  it("includes rules whose catalog has a NULL currency (inherits product currency)", async () => {
+    const inheritCatalogId = newId("price_catalogs")
+    await db.insert(priceCatalogs).values({
+      id: inheritCatalogId,
+      name: "Inherit",
+      code: "inherit",
+      currencyCode: null,
+    })
+    await db.insert(optionPriceRules).values({
+      id: newId("option_price_rules"),
+      productId,
+      optionId,
+      priceCatalogId: inheritCatalogId,
+      name: "default",
+      baseSellAmountCents: 7700,
+      isDefault: true,
+      active: true,
+    })
+
+    const ext = createProductPricingProjectionExtension()
+    const out = await ext.project(db, productId, enSlice)
+    expect(out.get("priceFromAmountCents")).toBe(7700)
+  })
+
+  it("excludes inactive and non-default rules", async () => {
+    await db.insert(optionPriceRules).values([
+      {
+        id: newId("option_price_rules"),
+        productId,
+        optionId,
+        priceCatalogId: usdCatalogId,
+        name: "live-default",
+        baseSellAmountCents: 15000,
+        isDefault: true,
+        active: true,
+      },
+      {
+        id: newId("option_price_rules"),
+        productId,
+        optionId,
+        priceCatalogId: usdCatalogId,
+        name: "promo-not-default",
+        baseSellAmountCents: 4900,
+        isDefault: false,
+        active: true,
+      },
+      {
+        id: newId("option_price_rules"),
+        productId,
+        optionId,
+        priceCatalogId: usdCatalogId,
+        name: "deactivated-default",
+        baseSellAmountCents: 1000,
+        isDefault: true,
+        active: false,
+      },
+    ])
+
+    const ext = createProductPricingProjectionExtension()
+    const out = await ext.project(db, productId, enSlice)
+    expect(out.get("priceFromAmountCents")).toBe(15000)
+  })
+
+  it("includes per-unit price tiers in the MIN", async () => {
+    const ruleId = newId("option_price_rules")
+    await db.insert(optionPriceRules).values({
+      id: ruleId,
+      productId,
+      optionId,
+      priceCatalogId: usdCatalogId,
+      name: "per-unit",
+      // Flat base is null — actual prices live on per-unit rules.
+      baseSellAmountCents: null,
+      isDefault: true,
+      active: true,
+    })
+    await db.insert(optionUnitPriceRules).values([
+      {
+        id: newId("option_unit_price_rules"),
+        optionPriceRuleId: ruleId,
+        optionId,
+        unitId,
+        sellAmountCents: 8500,
+        active: true,
+      },
+      {
+        id: newId("option_unit_price_rules"),
+        optionPriceRuleId: ruleId,
+        optionId,
+        unitId,
+        sellAmountCents: 12000,
+        active: true,
+      },
+    ])
+
+    const ext = createProductPricingProjectionExtension()
+    const out = await ext.project(db, productId, enSlice)
+    expect(out.get("priceFromAmountCents")).toBe(8500)
+  })
+
+  it("MINs the product row sellAmountCents against rules", async () => {
+    // Row default is 5000, rule is 9900 — row wins.
+    const { sql } = await import("drizzle-orm")
+    await db.execute(sql`UPDATE products SET sell_amount_cents = 5000 WHERE id = ${productId}`)
+
+    await db.insert(optionPriceRules).values({
+      id: newId("option_price_rules"),
+      productId,
+      optionId,
+      priceCatalogId: usdCatalogId,
+      name: "default",
+      baseSellAmountCents: 9900,
+      isDefault: true,
+      active: true,
+    })
+
+    const ext = createProductPricingProjectionExtension()
+    const out = await ext.project(db, productId, enSlice)
+    expect(out.get("priceFromAmountCents")).toBe(5000)
+  })
+})

--- a/packages/pricing/tests/pricing-projection.test.ts
+++ b/packages/pricing/tests/pricing-projection.test.ts
@@ -1,0 +1,149 @@
+import type { AnyDrizzleDb } from "@voyantjs/db"
+import type { IndexerSlice } from "@voyantjs/products/service-catalog-plane"
+import { describe, expect, it } from "vitest"
+
+import {
+  __test__,
+  createProductPricingProjectionExtension,
+} from "../src/service-catalog-plane-pricing.js"
+
+const { aggregatePricing, EMPTY_AGGREGATE } = __test__
+
+const customerSlice: IndexerSlice = {
+  vertical: "products",
+  locale: "en-GB",
+  audience: "customer",
+  market: "default",
+}
+
+describe("aggregatePricing (kernel)", () => {
+  it("returns empty aggregate when product has null price and no rules", () => {
+    expect(aggregatePricing(null, "USD", [])).toEqual({
+      ...EMPTY_AGGREGATE,
+      priceFromCurrency: "USD",
+    })
+  })
+
+  it("returns the product price when there are no rule candidates", () => {
+    const out = aggregatePricing(15000, "USD", [])
+    expect(out.priceFromAmountCents).toBe(15000)
+    expect(out.priceFromCurrency).toBe("USD")
+    expect(out.hasPricing).toBe(true)
+  })
+
+  it("returns MIN of rule candidates when product price is null", () => {
+    const out = aggregatePricing(null, "USD", [9900, 14900, 19900])
+    expect(out.priceFromAmountCents).toBe(9900)
+    expect(out.hasPricing).toBe(true)
+  })
+
+  it("MINs the product price into the candidate set", () => {
+    // Product has a default of 5000; one rule is cheaper at 4900.
+    const out = aggregatePricing(5000, "USD", [4900, 9900])
+    expect(out.priceFromAmountCents).toBe(4900)
+  })
+
+  it("product price wins when it's cheaper than every rule", () => {
+    const out = aggregatePricing(1000, "USD", [4900, 9900])
+    expect(out.priceFromAmountCents).toBe(1000)
+  })
+
+  it("handles a mix of unit-rule and flat-rule candidates", () => {
+    // Per-unit prices feed in alongside flat rule prices — no special
+    // handling needed in the kernel; both are just ints to MIN over.
+    const out = aggregatePricing(
+      null,
+      "EUR",
+      [/* flat */ 12000, /* unit single */ 8500, /* unit double */ 14000],
+    )
+    expect(out.priceFromAmountCents).toBe(8500)
+  })
+
+  it("hasPricing=false when nothing is priced (currency still surfaced)", () => {
+    const out = aggregatePricing(null, "USD", [])
+    expect(out.hasPricing).toBe(false)
+    expect(out.priceFromAmountCents).toBeNull()
+    // Keep the currency so storefront can format empty states with the
+    // operator's default symbol.
+    expect(out.priceFromCurrency).toBe("USD")
+  })
+
+  it("preserves currency=null when product currency is missing", () => {
+    const out = aggregatePricing(null, null, [])
+    expect(out.priceFromCurrency).toBeNull()
+    expect(out.hasPricing).toBe(false)
+  })
+})
+
+describe("createProductPricingProjectionExtension", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: drizzle stub
+  function dbWithRules(flatPrices: Array<number | null>, unitPrices: Array<number | null>): any {
+    const nextRows = flatPrices
+    let calls = 0
+    return {
+      select() {
+        const which = calls++
+        return {
+          from() {
+            return {
+              innerJoin() {
+                return {
+                  innerJoin() {
+                    return {
+                      where: async () =>
+                        (which === 0 ? flatPrices : unitPrices).map((p) => ({ price: p })),
+                    }
+                  },
+                  where: async () => nextRows.map((p) => ({ price: p })),
+                }
+              },
+            }
+          },
+        }
+      },
+    }
+  }
+
+  it("short-circuits to row-only pricing when product has no currency", async () => {
+    const ext = createProductPricingProjectionExtension({
+      loadProductPricing: async () => ({ sellAmountCents: 9900, sellCurrency: null }),
+    })
+    // biome-ignore lint/suspicious/noExplicitAny: db unused on this path
+    const out = await ext.project({} as any, "prod_x", customerSlice)
+    expect(out.get("priceFromAmountCents")).toBe(9900)
+    expect(out.get("priceFromCurrency")).toBeNull()
+    expect(out.get("hasPricing")).toBe(true)
+  })
+
+  it("returns empty + null currency when product is missing entirely", async () => {
+    const ext = createProductPricingProjectionExtension({
+      loadProductPricing: async () => ({ sellAmountCents: null, sellCurrency: null }),
+    })
+    // biome-ignore lint/suspicious/noExplicitAny: db unused on this path
+    const out = await ext.project({} as any, "prod_missing", customerSlice)
+    expect(out.get("hasPricing")).toBe(false)
+    expect(out.get("priceFromAmountCents")).toBeNull()
+  })
+
+  it("MINs across product price + flat rule prices + unit-rule prices", async () => {
+    const db = dbWithRules([15000, 12000], [8000])
+    const ext = createProductPricingProjectionExtension({
+      loadProductPricing: async () => ({ sellAmountCents: 20000, sellCurrency: "USD" }),
+    })
+    const out = await ext.project(db as AnyDrizzleDb, "prod_multi", customerSlice)
+    expect(out.get("priceFromAmountCents")).toBe(8000)
+    expect(out.get("priceFromCurrency")).toBe("USD")
+    expect(out.get("hasPricing")).toBe(true)
+  })
+
+  it("ignores null rule prices in the candidate set", async () => {
+    // Rule rows that come back with `null` baseSellAmountCents (e.g.
+    // per-unit-priced rules with no flat base) must not collapse to 0.
+    const db = dbWithRules([null, 18000], [null])
+    const ext = createProductPricingProjectionExtension({
+      loadProductPricing: async () => ({ sellAmountCents: null, sellCurrency: "USD" }),
+    })
+    const out = await ext.project(db as AnyDrizzleDb, "prod_nulls", customerSlice)
+    expect(out.get("priceFromAmountCents")).toBe(18000)
+  })
+})

--- a/packages/products/package.json
+++ b/packages/products/package.json
@@ -16,6 +16,7 @@
     "./catalog-policy-destinations": "./src/catalog-policy-destinations.ts",
     "./catalog-policy-taxonomy": "./src/catalog-policy-taxonomy.ts",
     "./catalog-policy-departures": "./src/catalog-policy-departures.ts",
+    "./catalog-policy-pricing": "./src/catalog-policy-pricing.ts",
     "./service-catalog-plane": "./src/service-catalog-plane.ts",
     "./service-catalog-plane-destinations": "./src/service-catalog-plane-destinations.ts",
     "./service-catalog-plane-taxonomy": "./src/service-catalog-plane-taxonomy.ts",
@@ -115,6 +116,11 @@
         "types": "./dist/catalog-policy-departures.d.ts",
         "import": "./dist/catalog-policy-departures.js",
         "default": "./dist/catalog-policy-departures.js"
+      },
+      "./catalog-policy-pricing": {
+        "types": "./dist/catalog-policy-pricing.d.ts",
+        "import": "./dist/catalog-policy-pricing.js",
+        "default": "./dist/catalog-policy-pricing.js"
       },
       "./service-catalog-plane": {
         "types": "./dist/service-catalog-plane.d.ts",

--- a/packages/products/src/catalog-policy-pricing.ts
+++ b/packages/products/src/catalog-policy-pricing.ts
@@ -1,0 +1,113 @@
+/**
+ * Catalog plane field policy for product → pricing denormalization.
+ *
+ * Aggregates a "price from" value across the product's configured
+ * default-rule prices so storefront cards can render `from $X` without
+ * fanning out to per-option pricing on every render. See
+ * `docs/architecture/catalog-architecture.md` §5.4.
+ *
+ * Storefront product cards filter and display by:
+ *   - "trips under $1000" (filter: `priceFromAmountCents` <= 100000)
+ *   - badge "from $X" (display: `priceFromAmountCents` + `priceFromCurrency`)
+ *   - sort by price ascending (`priceFromAmountCents` asc)
+ *
+ * Wire this policy into the products registry by composing with
+ * `productCatalogPolicy`:
+ *
+ *   const registry = createFieldPolicyRegistry([
+ *     ...productCatalogPolicy,
+ *     ...productPricingCatalogPolicy,
+ *   ])
+ *
+ * and wire `createProductPricingProjectionExtension` (from
+ * `@voyantjs/pricing/service-catalog-plane-pricing`) into
+ * `createProductDocumentBuilder` so the values land in the doc.
+ *
+ * Why a separate field instead of reusing the existing `sellAmountCents`
+ * from `productCatalogPolicy`: that path projects the product-row
+ * configured default verbatim. Multi-option products often leave
+ * `products.sellAmountCents` null and put the real prices on options —
+ * this projection MINs across both, giving storefront a value that's
+ * always meaningful even for the option-driven case.
+ *
+ * Out of scope here (deferred):
+ *   - Schedule-aware rule resolution. The kernel reads `isDefault=true`
+ *     rule prices only — it does NOT walk seasonal schedules, per-
+ *     departure overrides, or per-unit occupancy tiers. A "true cheapest
+ *     bookable price right now" projection requires per-slice rule
+ *     evaluation with a moving "now" date and is a follow-up.
+ *   - Per-audience / per-market currency conversion. The currency we
+ *     emit is `products.sellCurrency`; multi-catalog operators using
+ *     mixed currencies for the same product will see prices clipped
+ *     to the rules matching that currency.
+ *   - `pricing.changed` event surface. Today, edits to option-price
+ *     rules don't fire any event, so the bridge can only reindex on
+ *     `product.updated`. Tracked separately.
+ */
+
+import { defineFieldPolicy, type FieldPolicyInput } from "@voyantjs/catalog/contract"
+
+const PRODUCT_PRICING_FIELD_POLICY: FieldPolicyInput[] = [
+  // ── Aggregated "price from" amount ───────────────────────────────────────
+  // MIN across `products.sellAmountCents` and the active default
+  // `optionPriceRules.baseSellAmountCents` (plus option-unit-rule MINs for
+  // per-unit-priced options). `null` when no source has a non-null amount.
+  {
+    path: "priceFromAmountCents",
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "facet-affecting",
+    snapshot: "on-book",
+    query: "indexed-column",
+    localized: false,
+    visibility: ["staff", "customer", "partner"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+  },
+  // ── Currency for the projected amount ────────────────────────────────────
+  // `products.sellCurrency`. Stays consistent across all rule sources for
+  // the projected product because we filter rule rows to ones matching
+  // this currency before MIN'ing.
+  {
+    path: "priceFromCurrency",
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "facet-affecting",
+    snapshot: "on-book",
+    query: "indexed-column",
+    localized: false,
+    visibility: ["staff", "customer", "partner"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+  },
+  // ── Existence flag ───────────────────────────────────────────────────────
+  // `false` when neither the product row nor any active default rule has a
+  // configured price. Storefront filters use this for "show only priced
+  // products" and to suppress an empty `from` badge.
+  {
+    path: "hasPricing",
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "facet-affecting",
+    snapshot: "on-book",
+    query: "indexed-column",
+    localized: false,
+    visibility: ["staff", "customer", "partner"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+  },
+]
+
+/**
+ * Resolved pricing policy. Compose with `productCatalogPolicy` when
+ * building the products registry.
+ */
+export const productPricingCatalogPolicy = defineFieldPolicy(PRODUCT_PRICING_FIELD_POLICY)
+
+export { PRODUCT_PRICING_FIELD_POLICY }

--- a/packages/products/tests/unit/catalog-policy-pricing.test.ts
+++ b/packages/products/tests/unit/catalog-policy-pricing.test.ts
@@ -1,0 +1,67 @@
+import { createFieldPolicyRegistry } from "@voyantjs/catalog/contract"
+import { describe, expect, it } from "vitest"
+
+import { productCatalogPolicy } from "../../src/catalog-policy.js"
+import { productDeparturesCatalogPolicy } from "../../src/catalog-policy-departures.js"
+import { productDestinationsCatalogPolicy } from "../../src/catalog-policy-destinations.js"
+import {
+  PRODUCT_PRICING_FIELD_POLICY,
+  productPricingCatalogPolicy,
+} from "../../src/catalog-policy-pricing.js"
+import { productTaxonomyCatalogPolicy } from "../../src/catalog-policy-taxonomy.js"
+
+describe("productPricingCatalogPolicy", () => {
+  it("declares the storefront-required price-from paths", () => {
+    const paths = PRODUCT_PRICING_FIELD_POLICY.map((p) => p.path)
+    expect(paths).toContain("priceFromAmountCents")
+    expect(paths).toContain("priceFromCurrency")
+    expect(paths).toContain("hasPricing")
+  })
+
+  it("does not collide with the base policy's existing sellAmountCents/sellCurrency paths", () => {
+    // The base policy already projects sellAmountCents + sellCurrency
+    // verbatim from the products row. Pricing policy uses different
+    // names so the two coexist (priceFrom is the multi-option MIN
+    // aggregate, sellAmount is the row default).
+    const pricingPaths = new Set(PRODUCT_PRICING_FIELD_POLICY.map((p) => p.path))
+    expect(pricingPaths.has("sellAmountCents")).toBe(false)
+    expect(pricingPaths.has("sellCurrency")).toBe(false)
+  })
+
+  it("makes every field visible to staff/customer/partner so storefront cards can render", () => {
+    for (const policy of PRODUCT_PRICING_FIELD_POLICY) {
+      expect(policy.visibility).toContain("customer")
+      expect(policy.visibility).toContain("partner")
+      expect(policy.visibility).toContain("staff")
+    }
+  })
+
+  it("composes cleanly with all other product child-entity policies", () => {
+    const registry = createFieldPolicyRegistry([
+      ...productCatalogPolicy,
+      ...productDestinationsCatalogPolicy,
+      ...productTaxonomyCatalogPolicy,
+      ...productDeparturesCatalogPolicy,
+      ...productPricingCatalogPolicy,
+    ])
+    expect(registry.resolve("name")).toBeDefined()
+    expect(registry.resolve("regions[]")).toBeDefined()
+    expect(registry.resolve("categories[]")).toBeDefined()
+    expect(registry.resolve("nextDepartureAt")).toBeDefined()
+    expect(registry.resolve("priceFromAmountCents")).toBeDefined()
+    expect(registry.resolve("priceFromCurrency")).toBeDefined()
+    expect(registry.resolve("hasPricing")).toBeDefined()
+  })
+
+  it("does not duplicate any path against base or sibling child-entity policies", () => {
+    expect(() =>
+      createFieldPolicyRegistry([
+        ...productCatalogPolicy,
+        ...productDestinationsCatalogPolicy,
+        ...productTaxonomyCatalogPolicy,
+        ...productDeparturesCatalogPolicy,
+        ...productPricingCatalogPolicy,
+      ]),
+    ).not.toThrow()
+  })
+})

--- a/templates/operator/src/api/lib/catalog-runtime.ts
+++ b/templates/operator/src/api/lib/catalog-runtime.ts
@@ -26,9 +26,11 @@ import { cruiseCatalogPolicy } from "@voyantjs/cruises/catalog-policy"
 import type { AnyDrizzleDb } from "@voyantjs/db"
 import { extrasCatalogPolicy } from "@voyantjs/extras/catalog-policy"
 import { hospitalityCatalogPolicy } from "@voyantjs/hospitality/catalog-policy"
+import { createProductPricingProjectionExtension } from "@voyantjs/pricing/service-catalog-plane-pricing"
 import { productCatalogPolicy } from "@voyantjs/products/catalog-policy"
 import { productDeparturesCatalogPolicy } from "@voyantjs/products/catalog-policy-departures"
 import { productDestinationsCatalogPolicy } from "@voyantjs/products/catalog-policy-destinations"
+import { productPricingCatalogPolicy } from "@voyantjs/products/catalog-policy-pricing"
 import { productTaxonomyCatalogPolicy } from "@voyantjs/products/catalog-policy-taxonomy"
 import { createProductDocumentBuilder } from "@voyantjs/products/service-catalog-plane"
 import { createProductDestinationsProjectionExtension } from "@voyantjs/products/service-catalog-plane-destinations"
@@ -242,6 +244,7 @@ export function getFieldPolicyRegistries(): Map<string, FieldPolicyRegistry> {
           ...productDestinationsCatalogPolicy,
           ...productTaxonomyCatalogPolicy,
           ...productDeparturesCatalogPolicy,
+          ...productPricingCatalogPolicy,
         ]),
       ],
       ["extras", createFieldPolicyRegistry(extrasCatalogPolicy)],
@@ -275,6 +278,7 @@ export function createProductsDocumentBuilder(
       createProductDestinationsProjectionExtension(),
       createProductTaxonomyProjectionExtension(),
       createProductDeparturesProjectionExtension(),
+      createProductPricingProjectionExtension(),
     ],
   })
 }


### PR DESCRIPTION
## Summary

- New `productPricingCatalogPolicy` (`@voyantjs/products/catalog-policy-pricing`) declaring `priceFromAmountCents`, `priceFromCurrency`, `hasPricing`.
- New `createProductPricingProjectionExtension` (`@voyantjs/pricing/service-catalog-plane-pricing`) that MINs across `products.sellAmountCents`, active default `optionPriceRules.baseSellAmountCents`, and active default `optionUnitPriceRules.sellAmountCents`, currency-filtered to the product's `sellCurrency`.
- Operator template composes the new policy + extension alongside destinations, taxonomy, departures.

## Why a separate `priceFromAmountCents` field

The base policy already projects `sellAmountCents` + `sellCurrency` from the product row verbatim (`catalog-policy.ts:358-390`). The reason that's not enough: multi-option products commonly leave `products.sellAmountCents` null and put the real prices on options (`optionPriceRules.baseSellAmountCents` per option). The new field MINs across both — the storefront card shows `from $X` even for option-driven products where the row default is unset.

## Architecture decisions

- **Projection lives in `@voyantjs/pricing`, not products.** Pricing already deps on products; importing the `ProductProjectionExtension` contract type from products is the same direction. The reverse (products querying pricing tables) would create a circular dep — same call PR3's departures projection made for `@voyantjs/availability`.
- **Static rules only.** Only `is_default = true AND active = true` rules contribute. Schedule-aware rules and per-departure overrides are excluded — they require per-slice resolution against a moving "now" date and would churn docs every reindex tick. Deferred.
- **Currency consistency.** Only rules whose catalog currency matches the product's `sellCurrency` (or whose catalog currency is null and inherits) are MIN'd. Without this filter we'd risk emitting `from $50` when one rule is actually €50.
- **Document churn-free.** `now()`-independent — same product reindexed an hour later produces identical fields.

## Pre-existing gap NOT addressed here

`@voyantjs/pricing` has no event surface today (no `events.ts`, no `eventBus` callsites). The catalog bridge can therefore only reindex on `product.updated`, not on direct rule mutations. Operators editing an option-price rule in isolation will see a staleness window until the next product-row update. Same operational gap pattern PR #499 review caught for destinations and PR3 closed for availability slots — but pricing has 8+ mutation routes that would need wiring, large enough to deserve its own PR. Tracked in #505.

## Out of scope (other follow-ups)

- Schedule-aware rule resolution at index time ("true cheapest bookable price right now"). Per-slice resolution + moving-now design conversation.
- Per-departure override aggregation. Same complexity bucket.
- Per-audience / per-market currency conversion (FX rates).

## Test plan

- [x] `pnpm -F @voyantjs/pricing typecheck` — clean.
- [x] `pnpm -F @voyantjs/products typecheck` — clean.
- [x] Operator template typecheck — clean.
- [x] `pnpm -F @voyantjs/pricing test` — 24 pass / 105 skip (12 new unit tests + 7 new integration tests skip without `TEST_DATABASE_URL`).
- [x] `pnpm -F @voyantjs/products test` — 153 pass / 32 skip (5 new policy unit tests).
- [ ] CI runs the integration tests against `TEST_DATABASE_URL` (kernel + extension + multi-option fixtures including currency filtering and per-unit tier coverage).
- [ ] Manual: with operator template running, create a multi-option product with prices via `POST /v1/admin/pricing/option-price-rules`, run `pnpm reindex products`, verify `priceFromAmountCents` in the resulting Typesense doc matches the cheapest active default rule.

Refs #493 (closes the 4-PR plan). Tracks #505 for the pricing event-emission follow-up.