### PR TITLE
Fix #505: emit pricing.rule.changed so the catalog bridge reindexes on rule mutations

### DIFF
--- a/.changeset/pricing-rule-event-emission.md
+++ b/.changeset/pricing-rule-event-emission.md
@@ -1,0 +1,17 @@
+---
+"@voyantjs/pricing": minor
+---
+
+Closes #505: introduce a `pricing.rule.changed` event surface so the catalog bridge reindexes products when option-price rules are mutated.
+
+PR4 of #493 (#506) shipped `productPricingCatalogPolicy` denormalizing `priceFromAmountCents` from `optionPriceRules` + `optionUnitPriceRules`. Until now, those tables had no event emission at all — operators editing a rule in isolation would leave the projected `priceFromAmountCents` stale until the next unrelated `product.updated`. Same operational gap PR3 closed for availability slots, but this one was scoped out of PR4 because the pricing module had no event surface to extend.
+
+Changes:
+
+- New `packages/pricing/src/events.ts` defining `PRICING_RULE_CHANGED_EVENT` (`"pricing.rule.changed"`) and `PricingRuleChangedEvent` (carries `productId` + `ruleId` + `kind` + `source`). `kind` is `"option-rule" | "option-unit-rule"` — the two tables PR4's projection actually reads. Other pricing tables (`option_start_time_rules`, `option_unit_tiers`, `departure_price_overrides`, pickup-price-rules, etc.) intentionally don't emit yet — extending them is its own design conversation, and emitting events no subscriber consumes is dead surface.
+- `service-option-rules.ts`: the six relevant mutation functions (`createOptionPriceRule`, `updateOptionPriceRule`, `deleteOptionPriceRule`, `createOptionUnitPriceRule`, `updateOptionUnitPriceRule`, `deleteOptionUnitPriceRule`) accept an optional `RuleMutationRuntime { eventBus?, source? }` and emit after a successful commit. Existing callers that don't pass a runtime stay silent (back-compat).
+- `deleteOptionPriceRule` snapshots `productId` before deletion. `optionUnitPriceRules` mutations resolve `productId` by joining through their parent `optionPriceRule` — unit rules don't carry `productId` directly.
+- `routes-rules.ts`: each of the six routes threads `c.get("eventBus")` to the service. `routes-shared.ts` `Env` type extended with `eventBus?: EventBus`.
+- Operator template's `catalog-bridge.ts` subscribes to `pricing.rule.changed` and reindexes the affected product, mirroring the `availability.slot.changed` subscription added in PR3.
+
+Pre-existing gap NOT addressed here: the batch-update / batch-delete slot endpoints have the same hole (the shared batch helpers in `routes-shared.ts` don't thread the event bus through). Pricing has no batch endpoints today, so this PR doesn't add the same plumbing — when batch endpoints land or when availability's batch helpers are fixed, that fix can extend to pricing.

--- a/packages/pricing/src/events.ts
+++ b/packages/pricing/src/events.ts
@@ -1,0 +1,56 @@
+/**
+ * Pricing domain events.
+ *
+ * Emitted (after commit) by paths that mutate pricing rules feeding the
+ * catalog-plane `priceFromAmountCents` projection (PR4 of #493). The
+ * catalog bridge subscribes to these and reindexes the affected
+ * product so the denormalized "from $X" stays in sync without a full
+ * reindex run.
+ *
+ * Subscriber contract: treat the payload as a *trigger*, not the source
+ * of truth. Re-read the row(s) before acting on them — concurrent edits
+ * may have superseded the snapshot in this payload.
+ *
+ * Per docs/architecture/channel-push-architecture.md §5.1 (same shape as
+ * `availability.slot.changed`).
+ *
+ * Today's surface covers `option_price_rules` + `option_unit_price_rules`
+ * — the two tables that feed PR4's MIN aggregation. Other pricing
+ * tables (`option_start_time_rules`, `option_unit_tiers`,
+ * `departure_price_overrides`, `pickup_price_rules`, `cancellation_*`)
+ * intentionally do NOT emit yet: extending the catalog projection to
+ * read them is its own design conversation and emitting an event no
+ * subscriber consumes is dead surface area. When a future projection
+ * grows to read one of those tables, extend `kind` and add emission to
+ * the corresponding service function.
+ */
+
+/** Stable string identifier for the event. */
+export const PRICING_RULE_CHANGED_EVENT = "pricing.rule.changed" as const
+
+/** Origin of the change. Diagnostic only — subscribers don't behave
+ *  differently on this field, but it's preserved end-to-end so logs
+ *  and dashboards can attribute drift to a cause. */
+export type PricingRuleChangeSource = "created" | "updated" | "deleted"
+
+/**
+ * Which pricing-rule table the mutation touched. Lets a subscriber
+ * filter without re-reading the row (e.g. a future projection that
+ * only cares about `option-rule` mutations can skip per-unit deltas).
+ */
+export type PricingRuleKind = "option-rule" | "option-unit-rule"
+
+export interface PricingRuleChangedEvent {
+  /**
+   * The product whose pricing surface changed. Subscribers reindex
+   * this product. Always set — every relevant rule belongs to a
+   * product (option-unit rules join through their parent option-rule
+   * to find the product).
+   */
+  productId: string
+  /** The mutated row's id, for diagnostics. */
+  ruleId: string
+  /** Which table was touched. */
+  kind: PricingRuleKind
+  source: PricingRuleChangeSource
+}

--- a/packages/pricing/src/routes-rules.ts
+++ b/packages/pricing/src/routes-rules.ts
@@ -44,6 +44,7 @@ export const pricingRuleRoutes = new Hono<Env>()
         data: await pricingService.createOptionPriceRule(
           c.get("db"),
           await parseJsonBody(c, insertOptionPriceRuleSchema),
+          { eventBus: c.get("eventBus") },
         ),
       },
       201,
@@ -58,11 +59,14 @@ export const pricingRuleRoutes = new Hono<Env>()
       c.get("db"),
       c.req.param("id"),
       await parseJsonBody(c, updateOptionPriceRuleSchema),
+      { eventBus: c.get("eventBus") },
     )
     return row ? c.json({ data: row }) : notFound(c, "Option price rule not found")
   })
   .delete("/option-price-rules/:id", async (c) => {
-    const row = await pricingService.deleteOptionPriceRule(c.get("db"), c.req.param("id"))
+    const row = await pricingService.deleteOptionPriceRule(c.get("db"), c.req.param("id"), {
+      eventBus: c.get("eventBus"),
+    })
     return row ? c.json({ success: true }) : notFound(c, "Option price rule not found")
   })
   .get("/option-unit-price-rules", async (c) =>
@@ -79,6 +83,7 @@ export const pricingRuleRoutes = new Hono<Env>()
         data: await pricingService.createOptionUnitPriceRule(
           c.get("db"),
           await parseJsonBody(c, insertOptionUnitPriceRuleSchema),
+          { eventBus: c.get("eventBus") },
         ),
       },
       201,
@@ -93,11 +98,14 @@ export const pricingRuleRoutes = new Hono<Env>()
       c.get("db"),
       c.req.param("id"),
       await parseJsonBody(c, updateOptionUnitPriceRuleSchema),
+      { eventBus: c.get("eventBus") },
     )
     return row ? c.json({ data: row }) : notFound(c, "Option unit price rule not found")
   })
   .delete("/option-unit-price-rules/:id", async (c) => {
-    const row = await pricingService.deleteOptionUnitPriceRule(c.get("db"), c.req.param("id"))
+    const row = await pricingService.deleteOptionUnitPriceRule(c.get("db"), c.req.param("id"), {
+      eventBus: c.get("eventBus"),
+    })
     return row ? c.json({ success: true }) : notFound(c, "Option unit price rule not found")
   })
   .get("/option-start-time-rules", async (c) =>

--- a/packages/pricing/src/routes-shared.ts
+++ b/packages/pricing/src/routes-shared.ts
@@ -1,3 +1,4 @@
+import type { EventBus } from "@voyantjs/core"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
 
@@ -5,6 +6,7 @@ export type Env = {
   Variables: {
     db: PostgresJsDatabase
     userId?: string
+    eventBus?: EventBus
   }
 }
 

--- a/packages/pricing/src/service-option-rules.ts
+++ b/packages/pricing/src/service-option-rules.ts
@@ -136,18 +136,37 @@ export async function updateOptionPriceRule(
     }
   }
 
+  // Snapshot the pre-update productId so reassignment (rule moves
+  // between products) reindexes the *previous* product too. Without
+  // this, the projection on the old product keeps a stale MIN that
+  // includes a rule it no longer owns.
+  const [pre] = await db
+    .select({ productId: optionPriceRules.productId })
+    .from(optionPriceRules)
+    .where(eq(optionPriceRules.id, id))
+    .limit(1)
+
   const [row] = await db
     .update(optionPriceRules)
     .set({ ...data, updatedAt: new Date() })
     .where(eq(optionPriceRules.id, id))
     .returning()
   if (!row) return null
+
   await emitRuleChanged(runtime.eventBus, {
     productId: row.productId,
     ruleId: row.id,
     kind: "option-rule",
     source: runtime.source ?? "updated",
   })
+  if (pre && pre.productId !== row.productId) {
+    await emitRuleChanged(runtime.eventBus, {
+      productId: pre.productId,
+      ruleId: row.id,
+      kind: "option-rule",
+      source: runtime.source ?? "updated",
+    })
+  }
   return row
 }
 
@@ -275,6 +294,13 @@ export async function updateOptionUnitPriceRule(
   data: UpdateOptionUnitPriceRuleInput,
   runtime: RuleMutationRuntime = {},
 ) {
+  // Snapshot the pre-update parent's productId. If the update reassigns
+  // `optionPriceRuleId` to a parent rule under a different product, the
+  // *previous* product also loses this unit-rule from its MIN
+  // candidate set and needs reindexing. Without this snapshot the old
+  // product's `priceFromAmountCents` stays stale.
+  const prevProductId = await getProductIdForUnitRule(db, id)
+
   const [row] = await db
     .update(optionUnitPriceRules)
     .set({ ...data, updatedAt: new Date() })
@@ -282,10 +308,18 @@ export async function updateOptionUnitPriceRule(
     .returning()
   if (!row) return null
 
-  const productId = await getProductIdForUnitRule(db, row.id)
-  if (productId) {
+  const nextProductId = await getProductIdForUnitRule(db, row.id)
+  if (nextProductId) {
     await emitRuleChanged(runtime.eventBus, {
-      productId,
+      productId: nextProductId,
+      ruleId: row.id,
+      kind: "option-unit-rule",
+      source: runtime.source ?? "updated",
+    })
+  }
+  if (prevProductId && prevProductId !== nextProductId) {
+    await emitRuleChanged(runtime.eventBus, {
+      productId: prevProductId,
       ruleId: row.id,
       kind: "option-unit-rule",
       source: runtime.source ?? "updated",

--- a/packages/pricing/src/service-option-rules.ts
+++ b/packages/pricing/src/service-option-rules.ts
@@ -1,13 +1,43 @@
+import type { EventBus } from "@voyantjs/core"
 import { RequestValidationError } from "@voyantjs/hono"
 import { and, asc, desc, eq, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
+import {
+  PRICING_RULE_CHANGED_EVENT,
+  type PricingRuleChangedEvent,
+  type PricingRuleChangeSource,
+} from "./events.js"
 import {
   optionPriceRules,
   optionStartTimeRules,
   optionUnitPriceRules,
   optionUnitTiers,
 } from "./schema.js"
+
+/**
+ * Optional runtime context for pricing-rule mutations. When `eventBus`
+ * is wired the service emits `pricing.rule.changed` after a successful
+ * mutation so the catalog bridge can reindex the affected product.
+ *
+ * Keeping it optional preserves back-compat with existing callers that
+ * don't care about the catalog plane (e.g. data-import scripts).
+ */
+export interface RuleMutationRuntime {
+  eventBus?: EventBus
+  source?: PricingRuleChangeSource
+}
+
+async function emitRuleChanged(
+  eventBus: EventBus | undefined,
+  payload: PricingRuleChangedEvent,
+): Promise<void> {
+  if (!eventBus) return
+  await eventBus.emit(PRICING_RULE_CHANGED_EVENT, payload, {
+    category: "domain",
+    source: "service",
+  })
+}
 
 // A `per_booking` rule produces a single flat amount for the whole booking;
 // per-unit prices implicitly assume a per-unit (or per-person) multiplier.
@@ -73,15 +103,24 @@ export async function getOptionPriceRuleById(db: PostgresJsDatabase, id: string)
 export async function createOptionPriceRule(
   db: PostgresJsDatabase,
   data: CreateOptionPriceRuleInput,
+  runtime: RuleMutationRuntime = {},
 ) {
   const [row] = await db.insert(optionPriceRules).values(data).returning()
-  return row ?? null
+  if (!row) return null
+  await emitRuleChanged(runtime.eventBus, {
+    productId: row.productId,
+    ruleId: row.id,
+    kind: "option-rule",
+    source: runtime.source ?? "created",
+  })
+  return row
 }
 
 export async function updateOptionPriceRule(
   db: PostgresJsDatabase,
   id: string,
   data: UpdateOptionPriceRuleInput,
+  runtime: RuleMutationRuntime = {},
 ) {
   if (data.pricingMode === "per_booking") {
     const [countRow] = await db
@@ -102,15 +141,44 @@ export async function updateOptionPriceRule(
     .set({ ...data, updatedAt: new Date() })
     .where(eq(optionPriceRules.id, id))
     .returning()
-  return row ?? null
+  if (!row) return null
+  await emitRuleChanged(runtime.eventBus, {
+    productId: row.productId,
+    ruleId: row.id,
+    kind: "option-rule",
+    source: runtime.source ?? "updated",
+  })
+  return row
 }
 
-export async function deleteOptionPriceRule(db: PostgresJsDatabase, id: string) {
+export async function deleteOptionPriceRule(
+  db: PostgresJsDatabase,
+  id: string,
+  runtime: RuleMutationRuntime = {},
+) {
+  // Snapshot before deletion so the event payload carries productId —
+  // can't read it back from the deleted row.
+  const [snapshot] = await db
+    .select({ productId: optionPriceRules.productId })
+    .from(optionPriceRules)
+    .where(eq(optionPriceRules.id, id))
+    .limit(1)
+
   const [row] = await db
     .delete(optionPriceRules)
     .where(eq(optionPriceRules.id, id))
     .returning({ id: optionPriceRules.id })
-  return row ?? null
+  if (!row) return null
+
+  if (snapshot) {
+    await emitRuleChanged(runtime.eventBus, {
+      productId: snapshot.productId,
+      ruleId: row.id,
+      kind: "option-rule",
+      source: runtime.source ?? "deleted",
+    })
+  }
+  return row
 }
 
 export async function listOptionUnitPriceRules(
@@ -152,12 +220,33 @@ export async function getOptionUnitPriceRuleById(db: PostgresJsDatabase, id: str
   return row ?? null
 }
 
+/**
+ * Look up the productId on an option-unit-rule's parent rule. Used by
+ * the mutation paths to populate the `pricing.rule.changed` payload —
+ * unit rules don't carry productId directly, so we walk through their
+ * parent every time. One small extra query per mutation; pricing
+ * mutations aren't on a hot path so the cost is negligible.
+ */
+async function getProductIdForUnitRule(
+  db: PostgresJsDatabase,
+  unitRuleId: string,
+): Promise<string | null> {
+  const [row] = await db
+    .select({ productId: optionPriceRules.productId })
+    .from(optionUnitPriceRules)
+    .innerJoin(optionPriceRules, eq(optionPriceRules.id, optionUnitPriceRules.optionPriceRuleId))
+    .where(eq(optionUnitPriceRules.id, unitRuleId))
+    .limit(1)
+  return row?.productId ?? null
+}
+
 export async function createOptionUnitPriceRule(
   db: PostgresJsDatabase,
   data: CreateOptionUnitPriceRuleInput,
+  runtime: RuleMutationRuntime = {},
 ) {
   const [parent] = await db
-    .select({ pricingMode: optionPriceRules.pricingMode })
+    .select({ pricingMode: optionPriceRules.pricingMode, productId: optionPriceRules.productId })
     .from(optionPriceRules)
     .where(eq(optionPriceRules.id, data.optionPriceRuleId))
     .limit(1)
@@ -168,28 +257,66 @@ export async function createOptionUnitPriceRule(
   }
 
   const [row] = await db.insert(optionUnitPriceRules).values(data).returning()
-  return row ?? null
+  if (!row) return null
+  if (parent) {
+    await emitRuleChanged(runtime.eventBus, {
+      productId: parent.productId,
+      ruleId: row.id,
+      kind: "option-unit-rule",
+      source: runtime.source ?? "created",
+    })
+  }
+  return row
 }
 
 export async function updateOptionUnitPriceRule(
   db: PostgresJsDatabase,
   id: string,
   data: UpdateOptionUnitPriceRuleInput,
+  runtime: RuleMutationRuntime = {},
 ) {
   const [row] = await db
     .update(optionUnitPriceRules)
     .set({ ...data, updatedAt: new Date() })
     .where(eq(optionUnitPriceRules.id, id))
     .returning()
-  return row ?? null
+  if (!row) return null
+
+  const productId = await getProductIdForUnitRule(db, row.id)
+  if (productId) {
+    await emitRuleChanged(runtime.eventBus, {
+      productId,
+      ruleId: row.id,
+      kind: "option-unit-rule",
+      source: runtime.source ?? "updated",
+    })
+  }
+  return row
 }
 
-export async function deleteOptionUnitPriceRule(db: PostgresJsDatabase, id: string) {
+export async function deleteOptionUnitPriceRule(
+  db: PostgresJsDatabase,
+  id: string,
+  runtime: RuleMutationRuntime = {},
+) {
+  // Snapshot productId before deletion — the row is gone after.
+  const productId = await getProductIdForUnitRule(db, id)
+
   const [row] = await db
     .delete(optionUnitPriceRules)
     .where(eq(optionUnitPriceRules.id, id))
     .returning({ id: optionUnitPriceRules.id })
-  return row ?? null
+  if (!row) return null
+
+  if (productId) {
+    await emitRuleChanged(runtime.eventBus, {
+      productId,
+      ruleId: row.id,
+      kind: "option-unit-rule",
+      source: runtime.source ?? "deleted",
+    })
+  }
+  return row
 }
 
 export async function listOptionStartTimeRules(

--- a/packages/pricing/tests/integration/rule-events.test.ts
+++ b/packages/pricing/tests/integration/rule-events.test.ts
@@ -108,6 +108,46 @@ describe.skipIf(!DB_AVAILABLE)("pricing rule events", () => {
       expect(events[0]?.productId).toBe(productId)
     })
 
+    it("updateOptionPriceRule reassigning productId emits for BOTH old and new product", async () => {
+      // Operator moves a rule between products (rare, but the update
+      // schema allows it). Both products' projections must reindex —
+      // old product loses the rule from its MIN, new product gains it.
+      const otherProductId = newId("products")
+      const otherOptionId = newId("product_options")
+      await db.insert(products).values({
+        id: otherProductId,
+        name: "Receiving Product",
+        sellCurrency: "USD",
+        bookingMode: "date",
+      })
+      await db
+        .insert(productOptions)
+        .values({ id: otherOptionId, productId: otherProductId, name: "Std", code: "std" })
+
+      const ruleId = newId("option_price_rules")
+      await db.insert(optionPriceRules).values({
+        id: ruleId,
+        productId,
+        optionId,
+        priceCatalogId: catalogId,
+        name: "moving-rule",
+        baseSellAmountCents: 9900,
+        isDefault: true,
+        active: true,
+      })
+
+      const { bus, events } = recordingBus()
+      await updateOptionPriceRule(
+        db,
+        ruleId,
+        { productId: otherProductId, optionId: otherOptionId },
+        { eventBus: bus },
+      )
+      expect(events).toHaveLength(2)
+      const productIds = events.map((e) => e.productId).sort()
+      expect(productIds).toEqual([otherProductId, productId].sort())
+    })
+
     it("deleteOptionPriceRule emits with source='deleted' (snapshots productId before delete)", async () => {
       const ruleId = newId("option_price_rules")
       await db.insert(optionPriceRules).values({
@@ -195,6 +235,63 @@ describe.skipIf(!DB_AVAILABLE)("pricing rule events", () => {
       expect(events[0]?.kind).toBe("option-unit-rule")
       expect(events[0]?.source).toBe("updated")
       expect(events[0]?.productId).toBe(productId)
+    })
+
+    it("updateOptionUnitPriceRule reassigning to a parent on a different product emits for BOTH products", async () => {
+      // Move a unit-rule from parentRuleId (under productId) to a new
+      // parent under a different product. Both products' MINs change.
+      const otherProductId = newId("products")
+      const otherOptionId = newId("product_options")
+      const otherUnitId = newId("option_units")
+      const otherParentRuleId = newId("option_price_rules")
+      await db.insert(products).values({
+        id: otherProductId,
+        name: "Receiving Product",
+        sellCurrency: "USD",
+        bookingMode: "date",
+      })
+      await db
+        .insert(productOptions)
+        .values({ id: otherOptionId, productId: otherProductId, name: "Std", code: "std" })
+      await db
+        .insert(optionUnits)
+        .values({ id: otherUnitId, optionId: otherOptionId, name: "Adult", code: "adult" })
+      await db.insert(optionPriceRules).values({
+        id: otherParentRuleId,
+        productId: otherProductId,
+        optionId: otherOptionId,
+        priceCatalogId: catalogId,
+        name: "other-parent",
+        baseSellAmountCents: null,
+        pricingMode: "per_person",
+        isDefault: true,
+        active: true,
+      })
+
+      const unitRuleId = newId("option_unit_price_rules")
+      await db.insert(optionUnitPriceRules).values({
+        id: unitRuleId,
+        optionPriceRuleId: parentRuleId,
+        optionId,
+        unitId,
+        sellAmountCents: 8500,
+        active: true,
+      })
+
+      const { bus, events } = recordingBus()
+      await updateOptionUnitPriceRule(
+        db,
+        unitRuleId,
+        {
+          optionPriceRuleId: otherParentRuleId,
+          optionId: otherOptionId,
+          unitId: otherUnitId,
+        },
+        { eventBus: bus },
+      )
+      expect(events).toHaveLength(2)
+      const productIds = events.map((e) => e.productId).sort()
+      expect(productIds).toEqual([otherProductId, productId].sort())
     })
 
     it("deleteOptionUnitPriceRule snapshots productId before deletion", async () => {

--- a/packages/pricing/tests/integration/rule-events.test.ts
+++ b/packages/pricing/tests/integration/rule-events.test.ts
@@ -1,0 +1,236 @@
+import { createEventBus } from "@voyantjs/core"
+import { newId } from "@voyantjs/db/lib/typeid"
+import { cleanupTestDb, createTestDb } from "@voyantjs/db/test-utils"
+import { optionUnits, productOptions, products } from "@voyantjs/products/schema"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { PRICING_RULE_CHANGED_EVENT, type PricingRuleChangedEvent } from "../../src/events.js"
+import { priceCatalogs } from "../../src/schema-catalogs.js"
+import { optionPriceRules, optionUnitPriceRules } from "../../src/schema-option-rules.js"
+import {
+  createOptionPriceRule,
+  createOptionUnitPriceRule,
+  deleteOptionPriceRule,
+  deleteOptionUnitPriceRule,
+  updateOptionPriceRule,
+  updateOptionUnitPriceRule,
+} from "../../src/service-option-rules.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+describe.skipIf(!DB_AVAILABLE)("pricing rule events", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: drizzle test client
+  let db: any
+  let productId: string
+  let optionId: string
+  let unitId: string
+  let catalogId: string
+
+  beforeAll(() => {
+    db = createTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDb(db)
+    productId = newId("products")
+    optionId = newId("product_options")
+    unitId = newId("option_units")
+    catalogId = newId("price_catalogs")
+
+    await db.insert(products).values({
+      id: productId,
+      name: "Pricing Event Test Product",
+      sellCurrency: "USD",
+      bookingMode: "date",
+    })
+    await db
+      .insert(productOptions)
+      .values({ id: optionId, productId, name: "Standard", code: "std" })
+    await db.insert(optionUnits).values({ id: unitId, optionId, name: "Adult", code: "adult" })
+    await db.insert(priceCatalogs).values({
+      id: catalogId,
+      name: "Public USD",
+      code: "public-usd",
+      currencyCode: "USD",
+    })
+  })
+
+  function recordingBus() {
+    const bus = createEventBus()
+    const events: PricingRuleChangedEvent[] = []
+    bus.subscribe<PricingRuleChangedEvent>(PRICING_RULE_CHANGED_EVENT, ({ data }) => {
+      events.push(data)
+    })
+    return { bus, events }
+  }
+
+  describe("option-rule mutations", () => {
+    it("createOptionPriceRule emits with source='created' and the productId", async () => {
+      const { bus, events } = recordingBus()
+      const created = await createOptionPriceRule(
+        db,
+        {
+          productId,
+          optionId,
+          priceCatalogId: catalogId,
+          name: "default",
+          baseSellAmountCents: 9900,
+          isDefault: true,
+          active: true,
+        },
+        { eventBus: bus },
+      )
+      expect(created).toBeDefined()
+      expect(events).toHaveLength(1)
+      expect(events[0]?.source).toBe("created")
+      expect(events[0]?.kind).toBe("option-rule")
+      expect(events[0]?.productId).toBe(productId)
+      expect(events[0]?.ruleId).toBe(created?.id)
+    })
+
+    it("updateOptionPriceRule emits with source='updated'", async () => {
+      const ruleId = newId("option_price_rules")
+      await db.insert(optionPriceRules).values({
+        id: ruleId,
+        productId,
+        optionId,
+        priceCatalogId: catalogId,
+        name: "default",
+        baseSellAmountCents: 9900,
+        isDefault: true,
+        active: true,
+      })
+
+      const { bus, events } = recordingBus()
+      await updateOptionPriceRule(db, ruleId, { baseSellAmountCents: 8800 }, { eventBus: bus })
+      expect(events).toHaveLength(1)
+      expect(events[0]?.source).toBe("updated")
+      expect(events[0]?.productId).toBe(productId)
+    })
+
+    it("deleteOptionPriceRule emits with source='deleted' (snapshots productId before delete)", async () => {
+      const ruleId = newId("option_price_rules")
+      await db.insert(optionPriceRules).values({
+        id: ruleId,
+        productId,
+        optionId,
+        priceCatalogId: catalogId,
+        name: "default",
+        baseSellAmountCents: 9900,
+        isDefault: true,
+        active: true,
+      })
+
+      const { bus, events } = recordingBus()
+      const deleted = await deleteOptionPriceRule(db, ruleId, { eventBus: bus })
+      expect(deleted).toBeDefined()
+      expect(events).toHaveLength(1)
+      expect(events[0]?.source).toBe("deleted")
+      expect(events[0]?.productId).toBe(productId)
+    })
+
+    it("deleteOptionPriceRule is a no-op (no event) when the rule doesn't exist", async () => {
+      const { bus, events } = recordingBus()
+      const result = await deleteOptionPriceRule(db, "option_price_rules_nonexistent", {
+        eventBus: bus,
+      })
+      expect(result).toBeNull()
+      expect(events).toHaveLength(0)
+    })
+  })
+
+  describe("option-unit-rule mutations (productId resolved via parent rule)", () => {
+    let parentRuleId: string
+
+    beforeEach(async () => {
+      parentRuleId = newId("option_price_rules")
+      await db.insert(optionPriceRules).values({
+        id: parentRuleId,
+        productId,
+        optionId,
+        priceCatalogId: catalogId,
+        name: "per-unit-parent",
+        // Per-unit pricing — flat base is null.
+        baseSellAmountCents: null,
+        pricingMode: "per_person",
+        isDefault: true,
+        active: true,
+      })
+    })
+
+    it("createOptionUnitPriceRule emits 'option-unit-rule' kind with parent's productId", async () => {
+      const { bus, events } = recordingBus()
+      const created = await createOptionUnitPriceRule(
+        db,
+        {
+          optionPriceRuleId: parentRuleId,
+          optionId,
+          unitId,
+          sellAmountCents: 8500,
+          active: true,
+        },
+        { eventBus: bus },
+      )
+      expect(created).toBeDefined()
+      expect(events).toHaveLength(1)
+      expect(events[0]?.kind).toBe("option-unit-rule")
+      expect(events[0]?.source).toBe("created")
+      expect(events[0]?.productId).toBe(productId)
+    })
+
+    it("updateOptionUnitPriceRule emits with the resolved productId", async () => {
+      const unitRuleId = newId("option_unit_price_rules")
+      await db.insert(optionUnitPriceRules).values({
+        id: unitRuleId,
+        optionPriceRuleId: parentRuleId,
+        optionId,
+        unitId,
+        sellAmountCents: 8500,
+        active: true,
+      })
+
+      const { bus, events } = recordingBus()
+      await updateOptionUnitPriceRule(db, unitRuleId, { sellAmountCents: 7700 }, { eventBus: bus })
+      expect(events).toHaveLength(1)
+      expect(events[0]?.kind).toBe("option-unit-rule")
+      expect(events[0]?.source).toBe("updated")
+      expect(events[0]?.productId).toBe(productId)
+    })
+
+    it("deleteOptionUnitPriceRule snapshots productId before deletion", async () => {
+      const unitRuleId = newId("option_unit_price_rules")
+      await db.insert(optionUnitPriceRules).values({
+        id: unitRuleId,
+        optionPriceRuleId: parentRuleId,
+        optionId,
+        unitId,
+        sellAmountCents: 8500,
+        active: true,
+      })
+
+      const { bus, events } = recordingBus()
+      const deleted = await deleteOptionUnitPriceRule(db, unitRuleId, { eventBus: bus })
+      expect(deleted).toBeDefined()
+      expect(events).toHaveLength(1)
+      expect(events[0]?.kind).toBe("option-unit-rule")
+      expect(events[0]?.source).toBe("deleted")
+      expect(events[0]?.productId).toBe(productId)
+    })
+  })
+
+  it("mutations called without an eventBus stay silent (back-compat)", async () => {
+    // No runtime arg → no event. Existing callers that don't care about
+    // the catalog plane keep working unchanged.
+    const created = await createOptionPriceRule(db, {
+      productId,
+      optionId,
+      priceCatalogId: catalogId,
+      name: "no-bus",
+      baseSellAmountCents: 5000,
+      isDefault: true,
+      active: true,
+    })
+    expect(created).toBeDefined()
+    // Nothing to assert other than: this didn't throw.
+  })
+})

--- a/templates/operator/src/api/catalog-bridge.ts
+++ b/templates/operator/src/api/catalog-bridge.ts
@@ -18,6 +18,11 @@
  *                                   with availability concerns and keeps
  *                                   the products package free of an
  *                                   availability dep.
+ *   - `pricing.rule.changed`      → reindex the affected product so the
+ *                                   `priceFromAmountCents` aggregation
+ *                                   reflects the rule edit. Same
+ *                                   cross-package pattern as
+ *                                   `availability.slot.changed`.
  *   - `booking.confirmed`         → capture a snapshot graph of the
  *                                   booking's product line items via
  *                                   `captureSnapshotGraph`
@@ -72,6 +77,17 @@ interface AvailabilitySlotChangedPayload {
   slotId: string
   productId: string
   optionId: string | null
+}
+
+/**
+ * Mirrors `PricingRuleChangedEvent` from `@voyantjs/pricing`. Inlined
+ * for the same reason as `AvailabilitySlotChangedPayload` above.
+ */
+interface PricingRuleChangedPayload {
+  productId: string
+  ruleId: string
+  kind: "option-rule" | "option-unit-rule"
+  source: "created" | "updated" | "deleted"
 }
 
 export const catalogBridgeBundle: HonoBundle = {
@@ -152,6 +168,18 @@ export const catalogBridgeBundle: HonoBundle = {
         await ctx.service.reindexEntity("products", data.productId, ctx.builder)
       },
     )
+
+    // Pricing-rule create/update/delete reindexes the affected product so
+    // `priceFromAmountCents` (the MIN-across-options aggregate from PR4)
+    // reflects rule edits without waiting for an unrelated
+    // `product.updated`. Both `option-rule` and `option-unit-rule` kinds
+    // are wired — they're the two tables the projection reads.
+    eventBus.subscribe<PricingRuleChangedPayload>("pricing.rule.changed", async ({ data }) => {
+      if (!data.productId) return
+      const ctx = buildIndexerContext()
+      if (!ctx) return
+      await ctx.service.reindexEntity("products", data.productId, ctx.builder)
+    })
 
     eventBus.subscribe<BookingConfirmedEventPayload>("booking.confirmed", async ({ data }) => {
       const db = getDbFromHyperdrive(env)


### PR DESCRIPTION
## Summary

Closes the operational gap left by PR4 of #493 (#506): until now, `@voyantjs/pricing` had no event surface, so operator edits to option-price rules left the catalog plane's `priceFromAmountCents` projection stale until the next unrelated `product.updated`. Same shape PR3 closed for availability slot mutations — scoped out of PR4 because pricing had nothing to extend.

- New `packages/pricing/src/events.ts` defining `PRICING_RULE_CHANGED_EVENT` (`"pricing.rule.changed"`) and `PricingRuleChangedEvent { productId, ruleId, kind, source }`. `kind` is `"option-rule" | "option-unit-rule"` — exactly the two tables PR4's projection reads.
- The 6 mutation functions in `service-option-rules.ts` accept an optional `RuleMutationRuntime { eventBus?, source? }` and emit after a successful commit. `deleteOptionPriceRule` snapshots `productId` first; `optionUnitPriceRules` mutations resolve `productId` by joining through their parent rule (unit rules don't carry it directly).
- The 6 corresponding routes in `routes-rules.ts` thread `c.get("eventBus")`. `routes-shared.ts` `Env` adds `eventBus?: EventBus` to match the existing shape across other route files.
- Operator template's `catalog-bridge.ts` subscribes to `pricing.rule.changed` and reindexes the affected product. Same shape as the `availability.slot.changed` subscription PR3 added.

## Why only `option-rule` + `option-unit-rule` (and not e.g. `option-start-time-rule`, `option-unit-tier`, `departure-price-override`, `pickup-price-rule`, etc.)

Because they're the only two tables PR4's projection currently reads. Emitting events no subscriber consumes is dead surface area — when a future projection grows to read one of those tables, that follow-up PR can extend the `kind` enum and add emission to the corresponding service function. Sticking to a tight scope keeps this PR reviewable.

## Pre-existing gap NOT addressed

The batch-update / batch-delete endpoints in `@voyantjs/availability` still don't thread the event bus through their shared helpers (`handleBatchUpdate` / `handleBatchDelete`). Pricing has no batch endpoints today, so this PR doesn't extend the same plumbing — when batch endpoints land or when availability's batch helpers get fixed, that fix can extend to pricing.

## Back-compat

Mutation functions called without a runtime arg stay silent (no event, no behavior change). Existing data-import scripts and other non-event-bus callers keep working.

## Test plan

- [x] `pnpm -F @voyantjs/pricing typecheck` — clean.
- [x] Operator template typecheck — clean.
- [x] `pnpm -F @voyantjs/pricing test` — 24 pass / 113 skip (8 new integration tests in `rule-events.test.ts` skip without `TEST_DATABASE_URL`).
- [ ] CI runs the integration tests against `TEST_DATABASE_URL` (all 6 emission paths + back-compat + non-existent-id no-op).
- [ ] Manual: with operator template running, `POST /v1/admin/pricing/option-price-rules` for an existing product, verify the corresponding product is reindexed in Typesense (check `priceFromAmountCents` reflects the new rule).

Closes #505. Refs #493 (PR4 follow-up) and #506.