### PR TITLE
Fix #501: wrap cross-package schema refs with z.lazy to avoid bundler init-cycle TDZ

### DIFF
--- a/.changeset/fix-cross-package-schema-init-cycle.md
+++ b/.changeset/fix-cross-package-schema-init-cycle.md
@@ -1,0 +1,23 @@
+---
+"@voyantjs/bookings": patch
+"@voyantjs/crm": patch
+"@voyantjs/transactions": patch
+"@voyantjs/storefront": patch
+---
+
+Fix #501: cross-package schema init cycle that caused chunk-splitting bundlers (Vite 8 / Rolldown) to crash with `Cannot read properties of undefined (reading 'optional')` at module-evaluation time.
+
+Root cause: schema files in 4 packages dereferenced a Zod schema imported from another `@voyantjs/*` package at module top level. When the bundler placed the producer (`kmsEnvelopeSchema` from `@voyantjs/db`, `availabilitySlotStatusSchema` from `@voyantjs/availability`, `extraPricingModeSchema` from `@voyantjs/extras`) into a different chunk than the consumer, ESM live-binding init order didn't guarantee producer-before-consumer evaluation — the consumer hit the producer's TDZ and threw.
+
+Fix: wrap every cross-package top-level schema reference with `z.lazy(() => Schema)` so the schema is dereferenced at first parse rather than at module evaluation. This is the smallest change per the issue's suggested fixes (Option 1) and protects against the same hazard in any future bundler chunking.
+
+Sites updated:
+
+- `@voyantjs/bookings/schema/travel-details` — 3 `kmsEnvelopeSchema` fields (`identityEncrypted`, `dietaryEncrypted`, `accessibilityEncrypted`)
+- `@voyantjs/crm/validation` — 5 `kmsEnvelopeSchema` fields (`accessibilityEncrypted`, `dietaryEncrypted`, `loyaltyEncrypted`, `insuranceEncrypted`, `numberEncrypted` on personDocuments)
+- `@voyantjs/transactions/schema/participant-identity` — 1 `kmsEnvelopeSchema` field (`identityEncrypted`)
+- `@voyantjs/storefront/validation` — `availabilitySlotStatusSchema` + `extraPricingModeSchema` on the storefront departure / extension schemas
+
+Behavior unchanged: `z.lazy(fn).optional().nullable()` parses identically to `Schema.optional().nullable()` for valid and invalid payloads. Regression test in `packages/bookings/tests/unit/travel-details-schema.test.ts` asserts both the happy path (valid envelope round-trips) and the error path (empty `enc` violates the producer's `min(1)` validation) continue to work through the lazy wrap.
+
+No schema migration required, no behavior change for consumers — purely a build-time / module-init shape fix.

--- a/packages/bookings/src/schema/travel-details.ts
+++ b/packages/bookings/src/schema/travel-details.ts
@@ -71,9 +71,24 @@ export const bookingTravelerTravelDetails = pgTable(
 
 const bookingTravelerTravelDetailRecordCoreSchema = z.object({
   travelerId: z.string().min(1),
-  identityEncrypted: kmsEnvelopeSchema.optional().nullable(),
-  dietaryEncrypted: kmsEnvelopeSchema.optional().nullable(),
-  accessibilityEncrypted: kmsEnvelopeSchema.optional().nullable(),
+  // `z.lazy(() => …)` defers schema dereferencing until first use so the
+  // cross-package binding (`kmsEnvelopeSchema` from `@voyantjs/db`) is
+  // resolved at parse time, not at this module's top-level evaluation.
+  // Without `z.lazy`, bundlers that split this file into a separate chunk
+  // from its `@voyantjs/db` producer can hit the producer's TDZ here.
+  // See #501.
+  identityEncrypted: z
+    .lazy(() => kmsEnvelopeSchema)
+    .optional()
+    .nullable(),
+  dietaryEncrypted: z
+    .lazy(() => kmsEnvelopeSchema)
+    .optional()
+    .nullable(),
+  accessibilityEncrypted: z
+    .lazy(() => kmsEnvelopeSchema)
+    .optional()
+    .nullable(),
   passportPersonDocumentId: z.string().nullable().optional(),
   isLeadTraveler: z.boolean().default(false),
 })

--- a/packages/bookings/tests/unit/travel-details-schema.test.ts
+++ b/packages/bookings/tests/unit/travel-details-schema.test.ts
@@ -76,4 +76,40 @@ describe("traveler travel detail schema aliases", () => {
       updatedAt: now,
     })
   })
+
+  // Regression for #501: the cross-package `kmsEnvelopeSchema` reference
+  // was wrapped with `z.lazy(() => …)` to defer dereferencing until parse
+  // time so chunk-splitting bundlers (Vite/Rolldown) don't trip on a TDZ
+  // for the producer chunk. The wrap is only meaningful if the inner
+  // schema is actually invoked when an envelope payload is supplied —
+  // optional()/nullable() short-circuit on null/undefined and would mask
+  // a broken lazy.
+  describe("envelope payload still parses through the z.lazy wrap (#501)", () => {
+    it("accepts a well-formed kms envelope on every encrypted field", () => {
+      const env = { enc: "ciphertext-bytes" }
+      const result = bookingTravelerTravelDetailInsertSchema.parse({
+        travelerId: "bkpt_abc",
+        identityEncrypted: env,
+        dietaryEncrypted: env,
+        accessibilityEncrypted: env,
+        isLeadTraveler: false,
+      })
+      expect(result.identityEncrypted).toEqual(env)
+      expect(result.dietaryEncrypted).toEqual(env)
+      expect(result.accessibilityEncrypted).toEqual(env)
+    })
+
+    it("rejects a malformed envelope (wrong shape) on the encrypted fields", () => {
+      // The lazy wrap must still enforce the producer's validation —
+      // an empty `enc` violates the producer's `min(1)` and should fail
+      // exactly as it would with a direct (non-lazy) reference.
+      expect(() =>
+        bookingTravelerTravelDetailInsertSchema.parse({
+          travelerId: "bkpt_abc",
+          identityEncrypted: { enc: "" },
+          isLeadTraveler: false,
+        }),
+      ).toThrow()
+    })
+  })
 })

--- a/packages/crm/src/validation.ts
+++ b/packages/crm/src/validation.ts
@@ -122,11 +122,13 @@ export const personCoreSchema = z.object({
   tags: z.array(z.string()).default([]),
   birthday: z.string().date().nullable().optional(),
   notes: z.string().nullable().optional(),
-  // Encrypted PII slots (canonical store; documents live in person_documents)
-  accessibilityEncrypted: kmsEnvelopeSchema.optional(),
-  dietaryEncrypted: kmsEnvelopeSchema.optional(),
-  loyaltyEncrypted: kmsEnvelopeSchema.optional(),
-  insuranceEncrypted: kmsEnvelopeSchema.optional(),
+  // Encrypted PII slots (canonical store; documents live in person_documents).
+  // `z.lazy(() => …)` defers cross-package schema dereferencing until
+  // first parse — see #501 for the bundler chunk-init hazard otherwise.
+  accessibilityEncrypted: z.lazy(() => kmsEnvelopeSchema).optional(),
+  dietaryEncrypted: z.lazy(() => kmsEnvelopeSchema).optional(),
+  loyaltyEncrypted: z.lazy(() => kmsEnvelopeSchema).optional(),
+  insuranceEncrypted: z.lazy(() => kmsEnvelopeSchema).optional(),
   // Inline identity fields — synced to identity module on create/update
   email: z.string().email().nullable().optional(),
   phone: z.string().nullable().optional(),
@@ -353,7 +355,8 @@ export const personDocumentTypeSchema = z.enum([
 
 export const personDocumentCoreSchema = z.object({
   type: personDocumentTypeSchema,
-  numberEncrypted: kmsEnvelopeSchema.optional(),
+  // `z.lazy` for cross-package init-cycle protection — see #501.
+  numberEncrypted: z.lazy(() => kmsEnvelopeSchema).optional(),
   issuingAuthority: z.string().nullable().optional(),
   issuingCountry: z.string().nullable().optional(),
   issueDate: z.string().date().nullable().optional(),

--- a/packages/storefront/src/validation.ts
+++ b/packages/storefront/src/validation.ts
@@ -204,7 +204,8 @@ export const storefrontDepartureSchema = z.object({
 
 export const storefrontDepartureListQuerySchema = z.object({
   optionId: z.string().optional(),
-  status: availabilitySlotStatusSchema.optional(),
+  // `z.lazy(() => …)` for cross-package init-cycle protection — see #501.
+  status: z.lazy(() => availabilitySlotStatusSchema).optional(),
   dateFrom: z.string().date().optional(),
   dateTo: z.string().date().optional(),
   limit: z.coerce.number().int().min(1).max(250).default(100),
@@ -351,7 +352,8 @@ export const storefrontProductExtensionSchema = z.object({
   thumb: z.string().nullable(),
   pricePerPerson: z.number().nullable(),
   currencyCode: z.string(),
-  pricingMode: extraPricingModeSchema,
+  // `z.lazy(() => …)` for cross-package init-cycle protection — see #501.
+  pricingMode: z.lazy(() => extraPricingModeSchema),
   defaultQuantity: z.number().int().nullable(),
   minQuantity: z.number().int().nullable(),
   maxQuantity: z.number().int().nullable(),

--- a/packages/transactions/src/schema/participant-identity.ts
+++ b/packages/transactions/src/schema/participant-identity.ts
@@ -16,7 +16,13 @@ export const decryptedTransactionTravelerIdentitySchema = z.object({
 })
 
 export const transactionTravelerIdentityEnvelopeSchema = z.object({
-  identityEncrypted: kmsEnvelopeSchema.optional().nullable(),
+  // `z.lazy(() => …)` defers cross-package schema dereferencing until
+  // first parse — see #501 for why bundlers that split this file from
+  // its `@voyantjs/db` producer crash without it.
+  identityEncrypted: z
+    .lazy(() => kmsEnvelopeSchema)
+    .optional()
+    .nullable(),
 })
 
 export const transactionParticipantIdentitySchema = transactionTravelerIdentitySchema


### PR DESCRIPTION
## Summary

Closes #501. Chunk-splitting bundlers (Vite 8 / Rolldown, possibly Vite 7 / Rollup) crash with `Cannot read properties of undefined (reading 'optional')` at module-evaluation time when a schema file dereferences a Zod schema imported from a different `@voyantjs/*` package at module top level. The producer ends up in a separate chunk from the consumer; ESM live-binding init order doesn't guarantee producer-before-consumer evaluation, so the consumer hits the producer's TDZ.

Per the issue's recommended Option 1: wrap each cross-package top-level reference with `z.lazy(() => Schema)`. The schema is now dereferenced at first parse instead of at module evaluation, so chunk ordering can't matter. Smallest possible change and protects against the same hazard in any future bundler chunking.

## Sites updated (sweep beyond the named site)

The issue named only `packages/bookings/schema/travel-details.ts` but explicitly asked for a sweep of "any other `@voyantjs/*/schema/*.js` that does top-level evaluation of an imported schema from a different `@voyantjs/*` package". Found three more files with the identical pattern:

- `@voyantjs/bookings/schema/travel-details` — 3 `kmsEnvelopeSchema` fields (`identityEncrypted`, `dietaryEncrypted`, `accessibilityEncrypted`) — the original repro
- `@voyantjs/crm/validation` — 5 `kmsEnvelopeSchema` fields (`accessibilityEncrypted`, `dietaryEncrypted`, `loyaltyEncrypted`, `insuranceEncrypted` on `personCoreSchema`; `numberEncrypted` on `personDocumentCoreSchema`)
- `@voyantjs/transactions/schema/participant-identity` — 1 `kmsEnvelopeSchema` field
- `@voyantjs/storefront/validation` — `availabilitySlotStatusSchema` + `extraPricingModeSchema` (different producers, same TDZ hazard)

## Behavior

`z.lazy(() => Schema).optional().nullable()` parses identically to `Schema.optional().nullable()` for both valid and invalid payloads. Two new regression tests in `packages/bookings/tests/unit/travel-details-schema.test.ts` assert the happy path (envelope round-trip) and the error path (empty `enc` violates the producer's `min(1)`) continue to flow through the lazy wrap. The existing `optional()`/`nullable()` short-circuits on null/undefined would have masked any inner-schema breakage; these new tests close that gap.

## Test plan

- [x] `pnpm -F @voyantjs/bookings -F @voyantjs/crm -F @voyantjs/transactions -F @voyantjs/storefront test` — 367 pass / 210 skip across the 4 affected packages.
- [x] `pnpm -F @voyantjs/bookings -F @voyantjs/crm -F @voyantjs/transactions -F @voyantjs/storefront typecheck` — clean.
- [x] New regression tests cover both happy and error paths through the lazy wrap.
- [ ] Reporter verification: drop the consumer-side `manualChunks` workaround from the affected app's `vite.config.ts`, rebuild, confirm the page mounts and the `schema-*.js` chunk no longer references an undefined producer at module-eval time.

No schema migration, no consumer behavior change. Patch bump for all four affected packages.