### PR TITLE
Fix #500: switch templates from Hyperdrive to Neon serverless WebSocket

### DIFF
--- a/.changeset/templates-neon-serverless-websocket.md
+++ b/.changeset/templates-neon-serverless-websocket.md
@@ -1,0 +1,22 @@
+---
+"@voyantjs/db": minor
+"@voyantjs/hono": minor
+---
+
+Closes #500: switch both templates' Workers DB layer from Hyperdrive to the Neon serverless WebSocket driver. Drops the \`HYPERDRIVE\` binding from \`wrangler.jsonc\` + \`env.d.ts\` in both \`templates/dmc\` and \`templates/operator\`; templates now connect directly via \`@neondatabase/serverless\` Pool + \`drizzle-orm/neon-serverless\` using the same \`DATABASE_URL\` secret.
+
+Two helpers ship in each template's \`src/api/lib/db.ts\`:
+
+- \`getDbFromEnv(env, executionCtx?)\` — returns a per-request \`NeonDatabase\`. When \`executionCtx\` is passed, schedules \`pool.end()\` via \`waitUntil\` so the WebSocket closes promptly. When omitted, the Pool is left for the Workers runtime to reclaim on isolate teardown.
+- \`withDbFromEnv(env, fn)\` — higher-order helper for non-Hono code paths (event subscribers, scheduled handlers, retry workers). Owns the Pool lifecycle inline (open → \`fn\` → \`finally pool.end()\`).
+
+Touched packages get a minor bump because the shared types broaden:
+
+- \`@voyantjs/db\` — \`AnyDrizzleDb\` union now includes \`NeonDatabase\` from \`drizzle-orm/neon-serverless\` alongside the existing \`PostgresJsDatabase\` and \`NeonHttpDatabase\` flavors.
+- \`@voyantjs/hono\` — \`VoyantDb\` (the type Hono ctx variables expose under \`c.var.db\`) widens the same way.
+
+Why WebSocket and not HTTP: the bookings package and other internal services use \`db.transaction(...)\` for read-then-write logic that needs real Postgres transaction semantics. Neon's HTTP transport only batches statements (atomic but no isolation); WebSocket gives full transaction support on Workers.
+
+Subscribers in \`catalog-bridge\`, \`booking-schedule\`, \`smartbill\`, \`catalog-checkout\` were converted to \`withDbFromEnv\` so the Pool is owned by each subscriber call. \`getBetterAuth\` and other helpers that were hard to thread \`executionCtx\` through still call \`getDbFromEnv(env)\` without it — the Pool lingers until isolate teardown there. Tracked as a follow-up audit in #510.
+
+No schema migration. No behavior change for existing API contracts. Operators upgrading need to: drop the \`HYPERDRIVE\` binding from their \`wrangler.jsonc\` (if they had one), and ensure their \`DATABASE_URL\` points at a Neon Postgres reachable over WebSocket (the standard Neon connection string).

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,6 +1,7 @@
 import { neon } from "@neondatabase/serverless"
 import type { NeonHttpDatabase } from "drizzle-orm/neon-http"
 import { drizzle as drizzleNeon } from "drizzle-orm/neon-http"
+import type { NeonDatabase as NeonWsDatabase } from "drizzle-orm/neon-serverless"
 import { withReplicas } from "drizzle-orm/pg-core"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { drizzle as drizzlePostgres } from "drizzle-orm/postgres-js"
@@ -9,15 +10,18 @@ import postgres from "postgres"
 export type DbAdapter = "edge" | "node"
 
 /**
- * Union of the two drizzle driver flavors `createDbClient` can return —
- * `PostgresJsDatabase` (node adapter) and `NeonHttpDatabase` (edge adapter).
- * Use this as the parameter type for `resolveDb`-style callbacks in module
- * factories so consumers don't need `as unknown as PostgresJsDatabase` casts
- * when wiring a Cloudflare Worker / Hyperdrive client into a module.
+ * Union of the drizzle driver flavors a Voyant deployment can wire up:
+ * `PostgresJsDatabase` (node adapter / direct TCP), `NeonHttpDatabase`
+ * (edge adapter / Neon HTTP), and `NeonWsDatabase` (edge adapter / Neon
+ * serverless WebSocket — the only Workers-compatible flavor that
+ * supports real Postgres transactions). Use this as the parameter type
+ * for `resolveDb`-style callbacks in module factories so consumers
+ * don't need `as unknown as ...` casts when wiring different drivers.
  */
 export type AnyDrizzleDb<TSchema extends Record<string, unknown> = Record<string, never>> =
   | PostgresJsDatabase<TSchema>
   | NeonHttpDatabase<TSchema>
+  | NeonWsDatabase<TSchema>
 
 export function createDbClient<TSchema extends Record<string, unknown> = Record<string, never>>(
   connectionString: string,

--- a/packages/hono/src/middleware/auth.ts
+++ b/packages/hono/src/middleware/auth.ts
@@ -5,7 +5,13 @@ import type { MiddlewareHandler } from "hono"
 
 import { sha256Base64Url } from "../auth/crypto.js"
 import { extractBearerToken, verifySession } from "../auth/session-jwt.js"
-import type { DbFactory, VoyantAuthIntegration, VoyantBindings, VoyantVariables } from "../types.js"
+import {
+  type DbFactory,
+  resolveDbFactoryResult,
+  type VoyantAuthIntegration,
+  type VoyantBindings,
+  type VoyantVariables,
+} from "../types.js"
 
 function permissionsToScopes(permissions: string | null): string[] {
   if (!permissions) return []
@@ -89,8 +95,8 @@ export function requireAuth<TBindings extends VoyantBindings>(
 
     // Strategy 2: Core-owned API key support (voy_ prefixed)
     if (token?.startsWith(API_KEY_PREFIX)) {
+      const { db, dispose } = resolveDbFactoryResult(dbFactory(c.env))
       try {
-        const db = dbFactory(c.env)
         const keyHash = await sha256Base64Url(token)
 
         const [row] = await db
@@ -154,21 +160,30 @@ export function requireAuth<TBindings extends VoyantBindings>(
         return next()
       } catch {
         // fall through to next strategy
+      } finally {
+        // Schedule pool teardown AFTER the queries above settle. waitUntil
+        // keeps the worker alive for the close handshake.
+        if (dispose) c.executionCtx.waitUntil?.(dispose())
       }
     }
 
     // Strategy 3: App-provided auth resolution (cookies, provider tokens, etc.)
     if (opts?.auth?.resolve) {
-      const resolved = await opts.auth.resolve({
-        request: c.req.raw,
-        env: c.env,
-        db: dbFactory(c.env),
-        ctx: c.executionCtx,
-      })
+      const { db: resolveDb, dispose: resolveDispose } = resolveDbFactoryResult(dbFactory(c.env))
+      try {
+        const resolved = await opts.auth.resolve({
+          request: c.req.raw,
+          env: c.env,
+          db: resolveDb,
+          ctx: c.executionCtx,
+        })
 
-      if (resolved?.userId) {
-        applyAuthContext(c, resolved)
-        return next()
+        if (resolved?.userId) {
+          applyAuthContext(c, resolved)
+          return next()
+        }
+      } finally {
+        if (resolveDispose) c.executionCtx.waitUntil?.(resolveDispose())
       }
     }
 

--- a/packages/hono/src/middleware/db.ts
+++ b/packages/hono/src/middleware/db.ts
@@ -1,7 +1,21 @@
 import type { MiddlewareHandler } from "hono"
 
-import type { DbFactory, VoyantBindings, VoyantDb } from "../types.js"
+import { type DbFactory, isDisposableDb, type VoyantBindings, type VoyantDb } from "../types.js"
 
+/**
+ * Resolves the per-request db client and stores it on Hono context.
+ *
+ * If the factory returns a {@link DisposableDb} (e.g. a
+ * `dbFromEnvForApp` that owns a per-request Neon WebSocket Pool), the
+ * middleware schedules `dispose()` via `c.executionCtx.waitUntil` so
+ * the Pool closes cleanly after the response is sent. Without the
+ * scheduled dispose every request would leak its Pool until isolate
+ * teardown, which at scale exhausts Neon's connection budget.
+ *
+ * Factories that return a plain {@link VoyantDb} (e.g. a long-lived
+ * postgres-js client cached at the module level) are wired up as
+ * before with no cleanup hook.
+ */
 export function db<TBindings extends VoyantBindings>(
   factory: DbFactory<TBindings>,
 ): MiddlewareHandler<{
@@ -9,7 +23,25 @@ export function db<TBindings extends VoyantBindings>(
   Variables: { db: VoyantDb }
 }> {
   return async (c, next) => {
-    c.set("db", factory(c.env))
+    const result = factory(c.env)
+    if (isDisposableDb(result)) {
+      c.set("db", result.db)
+      try {
+        await next()
+      } finally {
+        // `executionCtx` is undefined in unit-test contexts where Hono
+        // is invoked directly without a Workers runtime — fall back to
+        // an inline await so cleanup still runs.
+        const ctx = c.executionCtx as ExecutionContext | undefined
+        if (ctx && typeof ctx.waitUntil === "function") {
+          ctx.waitUntil(result.dispose())
+        } else {
+          await result.dispose()
+        }
+      }
+      return
+    }
+    c.set("db", result)
     await next()
   }
 }

--- a/packages/hono/src/middleware/idempotency-key.ts
+++ b/packages/hono/src/middleware/idempotency-key.ts
@@ -2,7 +2,13 @@ import { infraIdempotencyKeysTable } from "@voyantjs/db/schema/infra"
 import { and, eq, lt } from "drizzle-orm"
 import type { MiddlewareHandler } from "hono"
 
-import type { DbFactory, VoyantBindings, VoyantVariables } from "../types.js"
+import {
+  type DbFactory,
+  isDisposableDb,
+  type VoyantBindings,
+  type VoyantDb,
+  type VoyantVariables,
+} from "../types.js"
 
 /**
  * Twenty-four hours, in milliseconds. Default TTL for stored idempotency
@@ -107,7 +113,9 @@ export function idempotencyKey<TBindings extends VoyantBindings = VoyantBindings
     const scope = options.scope ?? `${c.req.method} ${new URL(c.req.url).pathname}`
     const rawBody = await c.req.text()
     const bodyHash = await sha256Hex(rawBody)
-    const db = c.get("db") as ReturnType<DbFactory<TBindings>> | undefined
+    // The `db` middleware always unwraps a `DisposableDb` to a plain
+    // `VoyantDb` before storing on context, so this cast is safe.
+    const db = c.get("db") as VoyantDb | undefined
     if (!db) {
       throw new Error(
         "idempotencyKey middleware requires `db` on the request context. Mount `db()` (or `createApp`) before this middleware.",
@@ -235,15 +243,25 @@ function pickStringField(body: unknown, keys: string[]): string | null {
 
 /**
  * Sweep expired idempotency rows. Call from a daily cron.
+ *
+ * If `dbFactory` returns a `DisposableDb` (e.g. a per-call Neon
+ * WebSocket Pool), the sweep awaits `dispose()` before returning so
+ * the connection closes cleanly inside the cron handler.
  */
 export async function purgeExpiredIdempotencyKeys<TBindings extends VoyantBindings>(
   dbFactory: DbFactory<TBindings>,
   env: TBindings,
 ): Promise<{ removed: number }> {
-  const db = dbFactory(env)
-  const result = await db
-    .delete(infraIdempotencyKeysTable)
-    .where(lt(infraIdempotencyKeysTable.expiresAt, new Date()))
-    .returning()
-  return { removed: result.length }
+  const result = dbFactory(env)
+  const db: VoyantDb = isDisposableDb(result) ? result.db : result
+  const dispose = isDisposableDb(result) ? result.dispose : undefined
+  try {
+    const rows = await db
+      .delete(infraIdempotencyKeysTable)
+      .where(lt(infraIdempotencyKeysTable.expiresAt, new Date()))
+      .returning()
+    return { removed: rows.length }
+  } finally {
+    if (dispose) await dispose()
+  }
 }

--- a/packages/hono/src/middleware/require-permission.ts
+++ b/packages/hono/src/middleware/require-permission.ts
@@ -2,7 +2,14 @@ import type { Actor, VoyantPermission } from "@voyantjs/core"
 import type { MiddlewareHandler } from "hono"
 
 import { requireUserId } from "../auth/require-user.js"
-import type { DbFactory, VoyantAuthIntegration, VoyantBindings, VoyantVariables } from "../types.js"
+import {
+  type DbFactory,
+  isDisposableDb,
+  type VoyantAuthIntegration,
+  type VoyantBindings,
+  type VoyantDb,
+  type VoyantVariables,
+} from "../types.js"
 import { ForbiddenApiError, UnauthorizedApiError } from "../validation.js"
 
 function hasScope(scopes: string[] | null | undefined, permission: VoyantPermission): boolean {
@@ -53,28 +60,43 @@ export function requirePermission<TBindings extends VoyantBindings>(
       return c.json({ error: "No auth permission checker configured" }, 500)
     }
 
-    const allowed = await opts.auth.hasPermission({
-      request: c.req.raw,
-      env: c.env,
-      db: dbFactory(c.env),
-      ctx: c.executionCtx,
-      auth: {
-        userId,
-        actor,
-        sessionId: c.get("sessionId"),
-        organizationId: c.get("organizationId"),
-        callerType: c.get("callerType"),
-        scopes,
-        isInternalRequest: c.get("isInternalRequest"),
-        apiKeyId: c.get("apiKeyId"),
-      },
-      permission,
-    })
+    const factoryResult = dbFactory(c.env)
+    const db: VoyantDb = isDisposableDb(factoryResult) ? factoryResult.db : factoryResult
+    const dispose = isDisposableDb(factoryResult) ? factoryResult.dispose : undefined
 
-    if (!allowed) {
-      throw new ForbiddenApiError()
+    try {
+      const allowed = await opts.auth.hasPermission({
+        request: c.req.raw,
+        env: c.env,
+        db,
+        ctx: c.executionCtx,
+        auth: {
+          userId,
+          actor,
+          sessionId: c.get("sessionId"),
+          organizationId: c.get("organizationId"),
+          callerType: c.get("callerType"),
+          scopes,
+          isInternalRequest: c.get("isInternalRequest"),
+          apiKeyId: c.get("apiKeyId"),
+        },
+        permission,
+      })
+
+      if (!allowed) {
+        throw new ForbiddenApiError()
+      }
+
+      return next()
+    } finally {
+      if (dispose) {
+        const ctx = c.executionCtx as ExecutionContext | undefined
+        if (ctx && typeof ctx.waitUntil === "function") {
+          ctx.waitUntil(dispose())
+        } else {
+          await dispose()
+        }
+      }
     }
-
-    return next()
   }
 }

--- a/packages/hono/src/types.ts
+++ b/packages/hono/src/types.ts
@@ -11,6 +11,7 @@ import type {
 } from "@voyantjs/core"
 import type { KVStore } from "@voyantjs/utils/cache"
 import type { NeonHttpDatabase } from "drizzle-orm/neon-http"
+import type { NeonDatabase as NeonWsDatabase } from "drizzle-orm/neon-serverless"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Hono } from "hono"
 
@@ -35,7 +36,7 @@ export interface VoyantBindings {
   CACHE?: KVStore
 }
 
-export type VoyantDb = PostgresJsDatabase | NeonHttpDatabase
+export type VoyantDb = PostgresJsDatabase | NeonHttpDatabase | NeonWsDatabase
 export type VoyantQueryRuntime = QueryRunner
 
 export type VoyantVariables = CoreVoyantVariables & {

--- a/packages/hono/src/types.ts
+++ b/packages/hono/src/types.ts
@@ -50,9 +50,42 @@ export type VoyantVariables = CoreVoyantVariables & {
   query?: VoyantQueryRuntime
 }
 
+/**
+ * Per-request handle returned by a {@link DbFactory} that owns its own
+ * Pool / connection: a drizzle client plus a `dispose()` the db
+ * middleware schedules via `c.executionCtx.waitUntil` after the
+ * response is sent. Used by templates that build a Neon WebSocket
+ * Pool per request (see e.g. `dbFromEnvForApp` in template
+ * `src/api/lib/db.ts`) — without `dispose()`, the Pool stays open
+ * until the Workers isolate is reclaimed.
+ */
+export interface DisposableDb {
+  db: VoyantDb
+  dispose: () => Promise<void>
+}
+
 export type DbFactory<TBindings extends VoyantBindings = VoyantBindings> = (
   env: TBindings,
-) => VoyantDb
+) => VoyantDb | DisposableDb
+
+export function isDisposableDb(value: VoyantDb | DisposableDb): value is DisposableDb {
+  return (
+    typeof (value as DisposableDb).dispose === "function" &&
+    (value as DisposableDb).db !== undefined
+  )
+}
+
+/**
+ * Normalize a {@link DbFactory} return value to `{ db, dispose? }` so
+ * call sites don't repeat the `isDisposableDb` shape check. `dispose`
+ * is `undefined` for plain `VoyantDb` factories.
+ */
+export function resolveDbFactoryResult(value: VoyantDb | DisposableDb): {
+  db: VoyantDb
+  dispose?: () => Promise<void>
+} {
+  return isDisposableDb(value) ? value : { db: value }
+}
 
 /**
  * The shape returned by a custom `auth.resolve` integration. Both `userId`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5000,6 +5000,9 @@ importers:
       '@fontsource-variable/inter':
         specifier: ^5.2.8
         version: 5.2.8
+      '@neondatabase/serverless':
+        specifier: ^1.0.2
+        version: 1.0.2
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
@@ -5280,6 +5283,9 @@ importers:
       '@types/node':
         specifier: ^25.5.2
         version: 25.5.2
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -5331,6 +5337,9 @@ importers:
       '@fontsource-variable/inter':
         specifier: ^5.2.8
         version: 5.2.8
+      '@neondatabase/serverless':
+        specifier: ^1.0.2
+        version: 1.0.2
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))

--- a/templates/dmc/.dev.vars.example
+++ b/templates/dmc/.dev.vars.example
@@ -4,7 +4,8 @@
 # Public vars (APP_URL, DASH_BASE_URL, GCP_* non-key fields, EMAIL_FROM) already
 # live in wrangler.jsonc under env.dev.vars — only secrets belong here.
 
-# Database (Neon Postgres — used by Hyperdrive in prod, direct connection in dev)
+# Database (Neon Postgres — accessed via the Neon serverless HTTP driver in
+# both dev and prod; no Hyperdrive binding required)
 DATABASE_URL="postgresql://user:password@host/dbname?sslmode=require"
 
 # Auth

--- a/templates/dmc/README.md
+++ b/templates/dmc/README.md
@@ -7,7 +7,7 @@ The reference Voyant template for a Destination Management Company. A single Clo
 - **Runtime**: Cloudflare Workers (Vite + `@cloudflare/vite-plugin`)
 - **Framework**: TanStack Start + React 19
 - **UI**: Local shadcn copy + Tailwind CSS v4
-- **DB**: PostgreSQL via Hyperdrive (Neon recommended)
+- **DB**: Neon Postgres via the serverless HTTP driver (one secret, `DATABASE_URL`; no Hyperdrive binding required)
 - **Auth**: Better Auth
 - **Jobs**: Voyant Workflows
 

--- a/templates/dmc/env.d.ts
+++ b/templates/dmc/env.d.ts
@@ -8,9 +8,6 @@ interface CloudflareBindings {
   // R2 (private document storage, optional)
   DOCUMENTS_BUCKET?: R2Bucket
 
-  // Hyperdrive (connection pooling)
-  HYPERDRIVE: Hyperdrive
-
   // Secrets
   INTERNAL_API_KEY: string
   SESSION_CLAIMS_SECRET: string

--- a/templates/dmc/package.json
+++ b/templates/dmc/package.json
@@ -86,6 +86,7 @@
     "@voyantjs/catalog-rag": "workspace:*",
     "@voyantjs/storage": "workspace:*",
     "@voyantjs/workflows": "workspace:*",
+    "@neondatabase/serverless": "^1.0.2",
     "better-auth": "^1.5.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -118,6 +119,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260426.1",
     "@tanstack/devtools-vite": "^0.6.0",
+    "@types/pg": "^8.20.0",
     "@types/node": "^25.5.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/templates/dmc/src/api/app.ts
+++ b/templates/dmc/src/api/app.ts
@@ -33,7 +33,7 @@ import authHandler, { hasAuthPermission, resolveAuthRequest } from "./auth/handl
 import { catalogBridgeBundle } from "./catalog-bridge"
 import { mountCatalogContentRoutes } from "./catalog-content"
 import { createInvitationsRoutes } from "./invitations"
-import { getDbFromEnv } from "./lib/db"
+import { dbFromEnvForApp } from "./lib/db"
 import { createMediaStorage, guessMimeType, resolveDocumentDownloadUrl } from "./lib/storage"
 import { mountCatalogMcpRoutes, mountCatalogSearchRoutes } from "./mcp"
 
@@ -88,7 +88,11 @@ const bookingsHonoModule = createBookingsHonoModule({
 })
 
 export const app = createApp<CloudflareBindings>({
-  db: (env) => getDbFromEnv(env),
+  // `dbFromEnvForApp` returns `{ db, dispose }`; the Hono db middleware
+  // schedules `dispose()` via `executionCtx.waitUntil` after the
+  // response is sent, so each request gets its own Pool and closes it
+  // before the isolate sleeps.
+  db: (env) => dbFromEnvForApp(env),
   publicPaths: [
     "/v1/public/customer-portal/contact-exists",
     "/v1/public/storefront-verification",

--- a/templates/dmc/src/api/app.ts
+++ b/templates/dmc/src/api/app.ts
@@ -33,7 +33,7 @@ import authHandler, { hasAuthPermission, resolveAuthRequest } from "./auth/handl
 import { catalogBridgeBundle } from "./catalog-bridge"
 import { mountCatalogContentRoutes } from "./catalog-content"
 import { createInvitationsRoutes } from "./invitations"
-import { getDbFromHyperdrive } from "./lib/db"
+import { getDbFromEnv } from "./lib/db"
 import { createMediaStorage, guessMimeType, resolveDocumentDownloadUrl } from "./lib/storage"
 import { mountCatalogMcpRoutes, mountCatalogSearchRoutes } from "./mcp"
 
@@ -88,7 +88,7 @@ const bookingsHonoModule = createBookingsHonoModule({
 })
 
 export const app = createApp<CloudflareBindings>({
-  db: (env) => getDbFromHyperdrive(env),
+  db: (env) => getDbFromEnv(env),
   publicPaths: [
     "/v1/public/customer-portal/contact-exists",
     "/v1/public/storefront-verification",

--- a/templates/dmc/src/api/auth/handler.ts
+++ b/templates/dmc/src/api/auth/handler.ts
@@ -155,7 +155,7 @@ auth.get("/auth/me", async (c) => {
     return c.json({ error: "Unauthorized" }, 401)
   }
 
-  const db = getDbFromEnv(c.env, c.executionCtx)
+  const db = getDbFromEnv(c.env)
 
   const [row] = await db
     .select({
@@ -209,7 +209,7 @@ auth.get("/auth/status", async (c) => {
   }
 
   const userId = session.user.id
-  const db = getDbFromEnv(c.env, c.executionCtx)
+  const db = getDbFromEnv(c.env)
 
   try {
     const [existingProfile] = await db
@@ -261,7 +261,7 @@ auth.get("/auth/status", async (c) => {
  * Public endpoint — reveals whether any user exists.
  */
 auth.get("/auth/bootstrap-status", async (c) => {
-  const db = getDbFromEnv(c.env, c.executionCtx)
+  const db = getDbFromEnv(c.env)
   const [row] = await db.select({ count: sql<number>`count(*)::int` }).from(authUser)
   return c.json({ hasUsers: (row?.count ?? 0) > 0 })
 })

--- a/templates/dmc/src/api/auth/handler.ts
+++ b/templates/dmc/src/api/auth/handler.ts
@@ -14,7 +14,7 @@ import type { VoyantRequestAuthContext } from "@voyantjs/hono"
 import { eq, sql } from "drizzle-orm"
 import { Hono } from "hono"
 
-import { getDbFromHyperdrive } from "../lib/db"
+import { getDbFromEnv } from "../lib/db"
 
 const auth = new Hono<{ Bindings: CloudflareBindings }>()
 const DEFAULT_APP_URL = "http://localhost:3100"
@@ -66,12 +66,18 @@ function getAuthBaseUrl(env: CloudflareBindings): string {
  * a different request"). So we must NOT cache the auth instance.
  */
 function getBetterAuth(env: CloudflareBindings) {
-  const db = getDbFromHyperdrive(env)
+  const db = getDbFromEnv(env)
   const cloud = tryGetVoyantCloudClient(env as unknown as Record<string, unknown>)
   const emailFrom = env.EMAIL_FROM || "Voyant <noreply@voyantcloud.app>"
 
   return createBetterAuth({
-    db,
+    // `db` is a `NeonDatabase` (neon-serverless WebSocket); the
+    // `CreateBetterAuthOptions.db` type still references the older
+    // `getDb` return union (postgres-js + neon-http). Drizzle's
+    // PgDatabase surface is identical across flavors at runtime, so
+    // the cast is structurally safe — better-auth's drizzleAdapter
+    // works on any PgDatabase. See #500 for context.
+    db: db as unknown as NonNullable<Parameters<typeof createBetterAuth>[0]>["db"],
     secret: env.SESSION_CLAIMS_SECRET,
     baseURL: getAuthBaseUrl(env),
     basePath: "/auth",
@@ -149,7 +155,7 @@ auth.get("/auth/me", async (c) => {
     return c.json({ error: "Unauthorized" }, 401)
   }
 
-  const db = getDbFromHyperdrive(c.env)
+  const db = getDbFromEnv(c.env, c.executionCtx)
 
   const [row] = await db
     .select({
@@ -203,7 +209,7 @@ auth.get("/auth/status", async (c) => {
   }
 
   const userId = session.user.id
-  const db = getDbFromHyperdrive(c.env)
+  const db = getDbFromEnv(c.env, c.executionCtx)
 
   try {
     const [existingProfile] = await db
@@ -255,7 +261,7 @@ auth.get("/auth/status", async (c) => {
  * Public endpoint — reveals whether any user exists.
  */
 auth.get("/auth/bootstrap-status", async (c) => {
-  const db = getDbFromHyperdrive(c.env)
+  const db = getDbFromEnv(c.env, c.executionCtx)
   const [row] = await db.select({ count: sql<number>`count(*)::int` }).from(authUser)
   return c.json({ hasUsers: (row?.count ?? 0) > 0 })
 })

--- a/templates/dmc/src/api/catalog-bridge.ts
+++ b/templates/dmc/src/api/catalog-bridge.ts
@@ -35,7 +35,7 @@ import {
   getFieldPolicyRegistries,
   withEmbedding,
 } from "./lib/catalog-runtime"
-import { getDbFromHyperdrive } from "./lib/db"
+import { getDbFromEnv } from "./lib/db"
 
 interface ProductEventPayload {
   id: string
@@ -69,7 +69,7 @@ export const catalogBridgeBundle: HonoBundle = {
         slices,
         registries: getFieldPolicyRegistries(),
       })
-      const db = getDbFromHyperdrive(env)
+      const db = getDbFromEnv(env)
       const builder = withEmbedding(
         createProductDocumentBuilder(db, { sellerOperatorId }),
         embeddings,
@@ -97,7 +97,7 @@ export const catalogBridgeBundle: HonoBundle = {
     })
 
     eventBus.subscribe<BookingConfirmedEventPayload>("booking.confirmed", async ({ data }) => {
-      const db = getDbFromHyperdrive(env)
+      const db = getDbFromEnv(env)
       // Catalog snapshots use the staff resolver scope — they're an audit
       // record, not a customer-facing rendering. Booking-time prices /
       // descriptions stay readable to ops even after audience-scoped

--- a/templates/dmc/src/api/invitations.ts
+++ b/templates/dmc/src/api/invitations.ts
@@ -94,7 +94,7 @@ export function createInvitationsRoutes() {
       return c.json({ error: "Forbidden" }, 403)
     }
 
-    const db = getDbFromEnv(c.env, c.executionCtx)
+    const db = getDbFromEnv(c.env)
     const rows = await db
       .select({
         id: userInvitationsTable.id,
@@ -124,7 +124,7 @@ export function createInvitationsRoutes() {
       return c.json({ error: "Invalid payload", details: parsed.error.issues }, 400)
     }
 
-    const db = getDbFromEnv(c.env, c.executionCtx)
+    const db = getDbFromEnv(c.env)
     const normalizedEmail = parsed.data.email.trim().toLowerCase()
 
     // If this email already has a BA user, block the invite.
@@ -193,7 +193,7 @@ export function createInvitationsRoutes() {
     }
 
     const id = c.req.param("id")
-    const db = getDbFromEnv(c.env, c.executionCtx)
+    const db = getDbFromEnv(c.env)
     await db.delete(userInvitationsTable).where(eq(userInvitationsTable.id, id))
     return c.json({ data: { id } })
   })
@@ -202,7 +202,7 @@ export function createInvitationsRoutes() {
   routes.get("/v1/public/invitations/:token", async (c) => {
     const token = c.req.param("token")
     const tokenHash = await sha256Hex(token)
-    const db = getDbFromEnv(c.env, c.executionCtx)
+    const db = getDbFromEnv(c.env)
 
     const [row] = await db
       .select({
@@ -236,7 +236,7 @@ export function createInvitationsRoutes() {
     }
 
     const tokenHash = await sha256Hex(token)
-    const db = getDbFromEnv(c.env, c.executionCtx)
+    const db = getDbFromEnv(c.env)
     const now = new Date()
 
     const [invite] = await db

--- a/templates/dmc/src/api/invitations.ts
+++ b/templates/dmc/src/api/invitations.ts
@@ -26,7 +26,7 @@ import { and, desc, eq, gt, isNull } from "drizzle-orm"
 import { Hono } from "hono"
 import { z } from "zod"
 
-import { getDbFromHyperdrive } from "./lib/db"
+import { getDbFromEnv } from "./lib/db"
 
 type InvitationsBindings = CloudflareBindings
 type InvitationsVariables = {
@@ -75,7 +75,7 @@ function getAppUrl(env: InvitationsBindings): string {
 }
 
 async function assertSuperAdmin(env: InvitationsBindings, userId: string): Promise<boolean> {
-  const db = getDbFromHyperdrive(env)
+  const db = getDbFromEnv(env)
   const [row] = await db
     .select({ isSuperAdmin: userProfilesTable.isSuperAdmin })
     .from(userProfilesTable)
@@ -94,7 +94,7 @@ export function createInvitationsRoutes() {
       return c.json({ error: "Forbidden" }, 403)
     }
 
-    const db = getDbFromHyperdrive(c.env)
+    const db = getDbFromEnv(c.env, c.executionCtx)
     const rows = await db
       .select({
         id: userInvitationsTable.id,
@@ -124,7 +124,7 @@ export function createInvitationsRoutes() {
       return c.json({ error: "Invalid payload", details: parsed.error.issues }, 400)
     }
 
-    const db = getDbFromHyperdrive(c.env)
+    const db = getDbFromEnv(c.env, c.executionCtx)
     const normalizedEmail = parsed.data.email.trim().toLowerCase()
 
     // If this email already has a BA user, block the invite.
@@ -193,7 +193,7 @@ export function createInvitationsRoutes() {
     }
 
     const id = c.req.param("id")
-    const db = getDbFromHyperdrive(c.env)
+    const db = getDbFromEnv(c.env, c.executionCtx)
     await db.delete(userInvitationsTable).where(eq(userInvitationsTable.id, id))
     return c.json({ data: { id } })
   })
@@ -202,7 +202,7 @@ export function createInvitationsRoutes() {
   routes.get("/v1/public/invitations/:token", async (c) => {
     const token = c.req.param("token")
     const tokenHash = await sha256Hex(token)
-    const db = getDbFromHyperdrive(c.env)
+    const db = getDbFromEnv(c.env, c.executionCtx)
 
     const [row] = await db
       .select({
@@ -236,7 +236,7 @@ export function createInvitationsRoutes() {
     }
 
     const tokenHash = await sha256Hex(token)
-    const db = getDbFromHyperdrive(c.env)
+    const db = getDbFromEnv(c.env, c.executionCtx)
     const now = new Date()
 
     const [invite] = await db

--- a/templates/dmc/src/api/lib/booking-engine-runtime.ts
+++ b/templates/dmc/src/api/lib/booking-engine-runtime.ts
@@ -27,7 +27,7 @@ import type { Context } from "hono"
 
 let _registry: SourceAdapterRegistry | undefined
 
-export type BookingEngineEnv = {}
+export type BookingEngineEnv = Record<string, never>
 
 export function getBookingEngineRegistry(_env: BookingEngineEnv): SourceAdapterRegistry {
   if (!_registry) {

--- a/templates/dmc/src/api/lib/db.ts
+++ b/templates/dmc/src/api/lib/db.ts
@@ -1,4 +1,6 @@
+import { Pool } from "@neondatabase/serverless"
 import { createDbClient, type DbAdapter } from "@voyantjs/db"
+import { drizzle as drizzleNeonWs, type NeonDatabase } from "drizzle-orm/neon-serverless"
 
 /**
  * Database client helpers with NO schema passing.
@@ -12,31 +14,57 @@ export function getDb(adapter?: DbAdapter) {
   return createDbClient(url, { adapter: effectiveAdapter })
 }
 
-export function getDbFromEnv(env: CloudflareBindings, adapter?: DbAdapter) {
-  const url = env.DATABASE_URL
-  const effectiveAdapter = adapter || "edge"
-  return createDbClient(url, { adapter: effectiveAdapter })
+/**
+ * `@neondatabase/serverless`'s `Pool` extends `pg.Pool`. Some pnpm
+ * resolution paths don't merge the inherited `pg.Pool` methods into
+ * the visible TS surface, so the constructor + `end()` call go via
+ * a structural cast. Runtime behavior is unchanged.
+ */
+type PgPoolApi = {
+  end(): Promise<void>
+}
+function newPool(connectionString: string): Pool & PgPoolApi {
+  const Ctor = Pool as unknown as new (cfg: { connectionString: string }) => Pool & PgPoolApi
+  return new Ctor({ connectionString })
 }
 
 /**
- * Get database client using Hyperdrive connection pooling.
- * Falls back to regular connection if Hyperdrive is not configured.
+ * Per-request Neon Postgres client over WebSocket. Supports real
+ * Postgres transactions (drizzle's `db.transaction(...)`).
  *
- * Hyperdrive provides:
- * - Connection pooling at the edge (no cold connection overhead)
- * - Automatic connection reuse across requests
- * - Lower latency than direct Neon HTTP driver
- *
- * @see https://developers.cloudflare.com/hyperdrive/
+ * Pool lifecycle: pass `executionCtx` whenever it's available so
+ * `pool.end()` is scheduled via `waitUntil` and the WebSocket closes
+ * cleanly before the isolate sleeps. Without an `executionCtx`, the
+ * Pool is left for the Workers runtime to reclaim on isolate teardown
+ * — fine for low-traffic paths, but at scale prefer `withDbFromEnv`
+ * below, which owns the Pool lifecycle explicitly.
  */
-export function getDbFromHyperdrive(env: CloudflareBindings) {
-  // Prefer Hyperdrive if available
-  if (env.HYPERDRIVE) {
-    // Hyperdrive provides a pooled connection string for use with postgres.js
-    return createDbClient(env.HYPERDRIVE.connectionString, { adapter: "node" })
+export function getDbFromEnv(
+  env: CloudflareBindings,
+  executionCtx?: ExecutionContext,
+): NeonDatabase {
+  const pool = newPool(env.DATABASE_URL)
+  if (executionCtx) {
+    executionCtx.waitUntil(pool.end().catch(() => {}))
   }
+  return drizzleNeonWs(pool)
+}
 
-  // Fallback to regular edge adapter if Hyperdrive is not configured
-  console.warn("[db] Hyperdrive not configured, falling back to edge adapter")
-  return getDbFromEnv(env)
+/**
+ * Higher-order helper for code paths without an `ExecutionContext`
+ * (event-bus subscribers, scheduled handlers, retry workers). Owns the
+ * Pool lifecycle: opens, hands the drizzle client to `fn`, closes on
+ * settle. Use this anywhere `c.executionCtx` isn't available — never
+ * leak a `new Pool(...)` outside a single request handler in a Worker.
+ */
+export async function withDbFromEnv<T>(
+  env: CloudflareBindings,
+  fn: (db: NeonDatabase) => Promise<T>,
+): Promise<T> {
+  const pool = newPool(env.DATABASE_URL)
+  try {
+    return await fn(drizzleNeonWs(pool))
+  } finally {
+    await pool.end().catch(() => {})
+  }
 }

--- a/templates/dmc/src/api/lib/db.ts
+++ b/templates/dmc/src/api/lib/db.ts
@@ -32,30 +32,41 @@ function newPool(connectionString: string): Pool & PgPoolApi {
  * Per-request Neon Postgres client over WebSocket. Supports real
  * Postgres transactions (drizzle's `db.transaction(...)`).
  *
- * Pool lifecycle: pass `executionCtx` whenever it's available so
- * `pool.end()` is scheduled via `waitUntil` and the WebSocket closes
- * cleanly before the isolate sleeps. Without an `executionCtx`, the
- * Pool is left for the Workers runtime to reclaim on isolate teardown
- * — fine for low-traffic paths, but at scale prefer `withDbFromEnv`
- * below, which owns the Pool lifecycle explicitly.
+ * Cleanup is the caller's responsibility — either route through
+ * `createApp({ db: dbFromEnvForApp })` below (which threads a
+ * `dispose()` through the Hono db middleware so the Pool closes after
+ * the response), or use `withDbFromEnv` for code paths outside Hono.
+ * Without explicit cleanup, the Pool sits open until the Workers
+ * runtime reclaims the isolate.
  */
-export function getDbFromEnv(
-  env: CloudflareBindings,
-  executionCtx?: ExecutionContext,
-): NeonDatabase {
+export function getDbFromEnv(env: CloudflareBindings): NeonDatabase {
   const pool = newPool(env.DATABASE_URL)
-  if (executionCtx) {
-    executionCtx.waitUntil(pool.end().catch(() => {}))
-  }
   return drizzleNeonWs(pool)
 }
 
 /**
- * Higher-order helper for code paths without an `ExecutionContext`
- * (event-bus subscribers, scheduled handlers, retry workers). Owns the
- * Pool lifecycle: opens, hands the drizzle client to `fn`, closes on
- * settle. Use this anywhere `c.executionCtx` isn't available — never
- * leak a `new Pool(...)` outside a single request handler in a Worker.
+ * Lifecycle-aware factory for `createApp({ db })`. Returns the drizzle
+ * client plus a `dispose()` the Hono db middleware schedules via
+ * `executionCtx.waitUntil` after the response is sent — so each
+ * request gets its own Pool and closes it before the isolate sleeps,
+ * instead of leaking WebSocket connections to Neon at request rate.
+ */
+export function dbFromEnvForApp(env: CloudflareBindings): {
+  db: NeonDatabase
+  dispose: () => Promise<void>
+} {
+  const pool = newPool(env.DATABASE_URL)
+  return {
+    db: drizzleNeonWs(pool),
+    dispose: () => pool.end().catch(() => {}),
+  }
+}
+
+/**
+ * Higher-order helper for code paths without a Hono request context
+ * (event-bus subscribers, scheduled handlers, retry workers). Owns
+ * the Pool lifecycle: opens, hands the drizzle client to `fn`, closes
+ * on settle.
  */
 export async function withDbFromEnv<T>(
   env: CloudflareBindings,

--- a/templates/dmc/wrangler.jsonc
+++ b/templates/dmc/wrangler.jsonc
@@ -35,12 +35,6 @@
           "remote": true
         }
       ],
-      "hyperdrive": [
-        {
-          "binding": "HYPERDRIVE",
-          "id": "ecbf6acacf544a949d9f805cc5c030a6"
-        }
-      ]
     },
     "prod": {
       "routes": [
@@ -69,12 +63,6 @@
         {
           "binding": "CACHE",
           "id": "b1b365feebb849428515adc1d112d6be"
-        }
-      ],
-      "hyperdrive": [
-        {
-          "binding": "HYPERDRIVE",
-          "id": "99fc2fc264eb4c2b8ba8a17f67f1dc6f"
         }
       ],
       "observability": {

--- a/templates/dmc/wrangler.jsonc
+++ b/templates/dmc/wrangler.jsonc
@@ -34,7 +34,7 @@
           "id": "6a11d42a95e142fba2ad353a50659d7b",
           "remote": true
         }
-      ],
+      ]
     },
     "prod": {
       "routes": [

--- a/templates/operator/.dev.vars.example
+++ b/templates/operator/.dev.vars.example
@@ -4,7 +4,8 @@
 # Public vars (APP_URL, DASH_BASE_URL, GCP_* non-key fields, EMAIL_FROM) already
 # live in wrangler.jsonc under env.dev.vars — only secrets belong here.
 
-# Database (Neon Postgres — used by Hyperdrive in prod, direct connection in dev)
+# Database (Neon Postgres — accessed via the Neon serverless HTTP driver in
+# both dev and prod; no Hyperdrive binding required)
 DATABASE_URL="postgresql://user:password@host/dbname?sslmode=require"
 
 # Auth

--- a/templates/operator/README.md
+++ b/templates/operator/README.md
@@ -7,7 +7,7 @@ The Voyant template for tour operators. A single Cloudflare Worker that serves t
 - **Runtime**: Cloudflare Workers (Vite + `@cloudflare/vite-plugin`)
 - **Framework**: TanStack Start + React 19
 - **UI**: Local shadcn copy + Tailwind CSS v4
-- **DB**: PostgreSQL via Hyperdrive (Neon recommended)
+- **DB**: Neon Postgres via the serverless HTTP driver (one secret, `DATABASE_URL`; no Hyperdrive binding required)
 - **Auth**: Better Auth
 - **Jobs**: Voyant Workflows
 

--- a/templates/operator/env.d.ts
+++ b/templates/operator/env.d.ts
@@ -8,9 +8,6 @@ interface CloudflareBindings {
   // R2 (private document storage)
   DOCUMENTS_BUCKET: R2Bucket
 
-  // Hyperdrive (connection pooling)
-  HYPERDRIVE: Hyperdrive
-
   // Secrets
   INTERNAL_API_KEY: string
   SESSION_CLAIMS_SECRET: string

--- a/templates/operator/package.json
+++ b/templates/operator/package.json
@@ -113,6 +113,7 @@
     "@voyantjs/utils": "workspace:*",
     "@voyantjs/workflow-runs": "workspace:*",
     "@voyantjs/workflows": "workspace:*",
+    "@neondatabase/serverless": "^1.0.2",
     "better-auth": "^1.5.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -76,7 +76,7 @@ import { mountCatalogSearchRoutes } from "./catalog-search"
 import { channelPushBundle, mountChannelPushAdminRoutes } from "./channel-push"
 import { mountFlightRoutes } from "./flights"
 import { createInvitationsRoutes } from "./invitations"
-import { getDbFromHyperdrive } from "./lib/db"
+import { getDbFromEnv } from "./lib/db"
 import {
   createDocumentStorage,
   createMediaStorage,
@@ -124,10 +124,10 @@ const notificationsHonoModule = createNotificationsHonoModule({
   // the in-process event bus; errors are logged, not rethrown, so a flaky
   // mailer can't block the confirm request.
   //
-  // `getDbFromHyperdrive` returns either drizzle flavor (postgres-js or
+  // `getDbFromEnv` returns either drizzle flavor (postgres-js or
   // neon-http) depending on env. `resolveDb` accepts the union via
   // `AnyDrizzleDb`, so no double-cast is needed here.
-  resolveDb: (bindings) => getDbFromHyperdrive(bindings as unknown as CloudflareBindings),
+  resolveDb: (bindings) => getDbFromEnv(bindings as unknown as CloudflareBindings),
   autoConfirmAndDispatch: {
     enabled: true,
     templateSlug: "booking-confirmation",
@@ -536,9 +536,9 @@ async function generateContractPdfForBooking(
 }
 
 const legalModule = createLegalHonoModule({
-  // `getDbFromHyperdrive` returns either drizzle flavor; `resolveDb` accepts
+  // `getDbFromEnv` returns either drizzle flavor; `resolveDb` accepts
   // the union via `AnyDrizzleDb`, so no double-cast is needed here.
-  resolveDb: (bindings) => getDbFromHyperdrive(bindings as unknown as CloudflareBindings),
+  resolveDb: (bindings) => getDbFromEnv(bindings as unknown as CloudflareBindings),
   resolveDocumentDownloadUrl: (bindings, storageKey) =>
     resolveDocumentDownloadUrl(bindings as unknown as CloudflareBindings, storageKey),
   resolveDocumentGenerator: (bindings) =>
@@ -682,7 +682,7 @@ async function deriveRoomsSummary(db: PostgresJsDatabase, bookingId: string): Pr
 }
 
 export const app = createApp<CloudflareBindings>({
-  db: (env) => getDbFromHyperdrive(env),
+  db: (env) => getDbFromEnv(env),
   publicPaths: [
     "/v1/public/customer-portal/contact-exists",
     "/v1/public/storefront-verification",
@@ -968,7 +968,7 @@ export const app = createApp<CloudflareBindings>({
     // instructions when configured, plus the brand context so the page
     // can render a header. Intentionally minimal — no PII, no secrets.
     hono.get("/v1/public/payment-link-config", async (c) => {
-      const db = getDbFromHyperdrive(c.env) as PostgresJsDatabase
+      const db = getDbFromEnv(c.env, c.executionCtx) as PostgresJsDatabase
       const operatorProfile = await getOperatorSettings(db)
       const bankTransfer = bankTransferDetailsFromOperatorSettings(
         operatorProfile,
@@ -990,7 +990,7 @@ export const app = createApp<CloudflareBindings>({
     // without checking status first.
     hono.post("/v1/public/payment-link/:sessionId/retry", async (c) => {
       const sessionId = c.req.param("sessionId")
-      const db = getDbFromHyperdrive(c.env)
+      const db = getDbFromEnv(c.env, c.executionCtx)
       const [original] = await db
         .select()
         .from(paymentSessions)
@@ -1035,7 +1035,7 @@ export const app = createApp<CloudflareBindings>({
     hono.get("/v1/public/payment-link/resolve", async (c) => {
       const ref = c.req.query("ref")
       if (!ref) return c.json({ error: "ref query param is required" }, 400)
-      const db = getDbFromHyperdrive(c.env)
+      const db = getDbFromEnv(c.env, c.executionCtx)
       const [session] = await db
         .select({ id: paymentSessions.id })
         .from(paymentSessions)
@@ -1059,7 +1059,7 @@ export const app = createApp<CloudflareBindings>({
     // and returns the new redirect URL.
     hono.post("/v1/public/payment-link/:sessionId/start-card", async (c) => {
       const sessionId = c.req.param("sessionId")
-      const db = getDbFromHyperdrive(c.env)
+      const db = getDbFromEnv(c.env, c.executionCtx)
       // `netopia.startPaymentSession` is typed against postgres-js; cast at
       // the call site since the union with neon-http is structurally
       // compatible for the queries Netopia issues.
@@ -1123,7 +1123,7 @@ export const app = createApp<CloudflareBindings>({
     hono.get("/v1/public/bookings/:bookingId/checkout-status", async (c) => {
       const bookingId = c.req.param("bookingId")
       const ref = c.req.query("session") ?? c.req.query("orderId") ?? c.req.query("ref") ?? null
-      const db = getDbFromHyperdrive(c.env)
+      const db = getDbFromEnv(c.env, c.executionCtx)
 
       const [booking] = await db
         .select({

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -76,7 +76,7 @@ import { mountCatalogSearchRoutes } from "./catalog-search"
 import { channelPushBundle, mountChannelPushAdminRoutes } from "./channel-push"
 import { mountFlightRoutes } from "./flights"
 import { createInvitationsRoutes } from "./invitations"
-import { getDbFromEnv } from "./lib/db"
+import { dbFromEnvForApp, getDbFromEnv } from "./lib/db"
 import {
   createDocumentStorage,
   createMediaStorage,
@@ -682,7 +682,11 @@ async function deriveRoomsSummary(db: PostgresJsDatabase, bookingId: string): Pr
 }
 
 export const app = createApp<CloudflareBindings>({
-  db: (env) => getDbFromEnv(env),
+  // `dbFromEnvForApp` returns `{ db, dispose }`; the Hono db middleware
+  // schedules `dispose()` via `executionCtx.waitUntil` after the
+  // response is sent, so each request gets its own Pool and closes it
+  // before the isolate sleeps.
+  db: (env) => dbFromEnvForApp(env),
   publicPaths: [
     "/v1/public/customer-portal/contact-exists",
     "/v1/public/storefront-verification",
@@ -968,7 +972,7 @@ export const app = createApp<CloudflareBindings>({
     // instructions when configured, plus the brand context so the page
     // can render a header. Intentionally minimal — no PII, no secrets.
     hono.get("/v1/public/payment-link-config", async (c) => {
-      const db = getDbFromEnv(c.env, c.executionCtx) as PostgresJsDatabase
+      const db = getDbFromEnv(c.env) as PostgresJsDatabase
       const operatorProfile = await getOperatorSettings(db)
       const bankTransfer = bankTransferDetailsFromOperatorSettings(
         operatorProfile,
@@ -990,7 +994,7 @@ export const app = createApp<CloudflareBindings>({
     // without checking status first.
     hono.post("/v1/public/payment-link/:sessionId/retry", async (c) => {
       const sessionId = c.req.param("sessionId")
-      const db = getDbFromEnv(c.env, c.executionCtx)
+      const db = getDbFromEnv(c.env)
       const [original] = await db
         .select()
         .from(paymentSessions)
@@ -1035,7 +1039,7 @@ export const app = createApp<CloudflareBindings>({
     hono.get("/v1/public/payment-link/resolve", async (c) => {
       const ref = c.req.query("ref")
       if (!ref) return c.json({ error: "ref query param is required" }, 400)
-      const db = getDbFromEnv(c.env, c.executionCtx)
+      const db = getDbFromEnv(c.env)
       const [session] = await db
         .select({ id: paymentSessions.id })
         .from(paymentSessions)
@@ -1059,7 +1063,7 @@ export const app = createApp<CloudflareBindings>({
     // and returns the new redirect URL.
     hono.post("/v1/public/payment-link/:sessionId/start-card", async (c) => {
       const sessionId = c.req.param("sessionId")
-      const db = getDbFromEnv(c.env, c.executionCtx)
+      const db = getDbFromEnv(c.env)
       // `netopia.startPaymentSession` is typed against postgres-js; cast at
       // the call site since the union with neon-http is structurally
       // compatible for the queries Netopia issues.
@@ -1123,7 +1127,7 @@ export const app = createApp<CloudflareBindings>({
     hono.get("/v1/public/bookings/:bookingId/checkout-status", async (c) => {
       const bookingId = c.req.param("bookingId")
       const ref = c.req.query("session") ?? c.req.query("orderId") ?? c.req.query("ref") ?? null
-      const db = getDbFromEnv(c.env, c.executionCtx)
+      const db = getDbFromEnv(c.env)
 
       const [booking] = await db
         .select({

--- a/templates/operator/src/api/auth/handler.ts
+++ b/templates/operator/src/api/auth/handler.ts
@@ -166,7 +166,7 @@ auth.get("/auth/me", async (c) => {
     return c.json({ error: "Unauthorized" }, 401)
   }
 
-  const db = getDbFromEnv(c.env, c.executionCtx)
+  const db = getDbFromEnv(c.env)
 
   const [row] = await db
     .select({
@@ -220,7 +220,7 @@ auth.get("/auth/status", async (c) => {
   }
 
   const userId = session.user.id
-  const db = getDbFromEnv(c.env, c.executionCtx)
+  const db = getDbFromEnv(c.env)
 
   try {
     const [existingProfile] = await db
@@ -273,7 +273,7 @@ auth.get("/auth/status", async (c) => {
  * sign-up route loaders to pick the right flow.
  */
 auth.get("/auth/bootstrap-status", async (c) => {
-  const db = getDbFromEnv(c.env, c.executionCtx)
+  const db = getDbFromEnv(c.env)
   const [row] = await db.select({ count: sql<number>`count(*)::int` }).from(authUser)
   return c.json({ hasUsers: (row?.count ?? 0) > 0 })
 })

--- a/templates/operator/src/api/auth/handler.ts
+++ b/templates/operator/src/api/auth/handler.ts
@@ -15,7 +15,7 @@ import { eq, sql } from "drizzle-orm"
 import { Hono } from "hono"
 
 import { resolveEmailReplyTo } from "../../lib/notifications"
-import { getDbFromHyperdrive } from "../lib/db"
+import { getDbFromEnv } from "../lib/db"
 
 const auth = new Hono<{ Bindings: CloudflareBindings }>()
 const DEFAULT_APP_URL = "http://localhost:3300"
@@ -71,13 +71,19 @@ function getAuthBaseUrl(env: CloudflareBindings): string {
  * a different request"). So we must NOT cache the auth instance.
  */
 function getBetterAuth(env: CloudflareBindings) {
-  const db = getDbFromHyperdrive(env)
+  const db = getDbFromEnv(env)
   const cloud = tryGetVoyantCloudClient(env as unknown as Record<string, unknown>)
   const emailFrom = env.EMAIL_FROM || "Voyant <noreply@voyantcloud.app>"
   const emailReplyTo = resolveEmailReplyTo(env)
 
   return createBetterAuth({
-    db,
+    // `db` is a `NeonDatabase` (neon-serverless WebSocket); the
+    // `CreateBetterAuthOptions.db` type still references the older
+    // `getDb` return union (postgres-js + neon-http). Drizzle's
+    // PgDatabase surface is identical across flavors at runtime, so
+    // the cast is structurally safe — better-auth's drizzleAdapter
+    // works on any PgDatabase. See #500 for context.
+    db: db as unknown as NonNullable<Parameters<typeof createBetterAuth>[0]>["db"],
     secret: env.SESSION_CLAIMS_SECRET,
     baseURL: getAuthBaseUrl(env),
     basePath: "/auth",
@@ -160,7 +166,7 @@ auth.get("/auth/me", async (c) => {
     return c.json({ error: "Unauthorized" }, 401)
   }
 
-  const db = getDbFromHyperdrive(c.env)
+  const db = getDbFromEnv(c.env, c.executionCtx)
 
   const [row] = await db
     .select({
@@ -214,7 +220,7 @@ auth.get("/auth/status", async (c) => {
   }
 
   const userId = session.user.id
-  const db = getDbFromHyperdrive(c.env)
+  const db = getDbFromEnv(c.env, c.executionCtx)
 
   try {
     const [existingProfile] = await db
@@ -267,7 +273,7 @@ auth.get("/auth/status", async (c) => {
  * sign-up route loaders to pick the right flow.
  */
 auth.get("/auth/bootstrap-status", async (c) => {
-  const db = getDbFromHyperdrive(c.env)
+  const db = getDbFromEnv(c.env, c.executionCtx)
   const [row] = await db.select({ count: sql<number>`count(*)::int` }).from(authUser)
   return c.json({ hasUsers: (row?.count ?? 0) > 0 })
 })

--- a/templates/operator/src/api/booking-schedule.ts
+++ b/templates/operator/src/api/booking-schedule.ts
@@ -49,7 +49,7 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context, Hono } from "hono"
 import { z } from "zod"
 
-import { getDbFromHyperdrive } from "./lib/db"
+import { withDbFromEnv } from "./lib/db"
 import { getOperatorSettings } from "./settings"
 
 interface BookingConfirmedPayload {
@@ -63,9 +63,13 @@ export const bookingScheduleBundle: HonoBundle = {
   bootstrap: ({ bindings, eventBus }) => {
     const env = bindings as CloudflareBindings
     eventBus.subscribe<BookingConfirmedPayload>("booking.confirmed", async ({ data }) => {
-      const db = getDbFromHyperdrive(env) as unknown as PostgresJsDatabase
       try {
-        await generatePaymentScheduleForBooking(db, data.bookingId)
+        await withDbFromEnv(env, async (db) => {
+          await generatePaymentScheduleForBooking(
+            db as unknown as PostgresJsDatabase,
+            data.bookingId,
+          )
+        })
       } catch (err) {
         console.error("[booking-schedule] failed to generate schedule", {
           bookingId: data.bookingId,

--- a/templates/operator/src/api/catalog-bridge.ts
+++ b/templates/operator/src/api/catalog-bridge.ts
@@ -41,6 +41,7 @@ import {
 import type { HonoBundle } from "@voyantjs/hono/plugin"
 import { buildProductSnapshotInput } from "@voyantjs/products/service-catalog-plane"
 import { and, eq, isNotNull } from "drizzle-orm"
+import type { NeonDatabase } from "drizzle-orm/neon-serverless"
 
 import {
   buildEmbeddingProvider,
@@ -50,7 +51,7 @@ import {
   getFieldPolicyRegistries,
   withEmbedding,
 } from "./lib/catalog-runtime"
-import { getDbFromHyperdrive } from "./lib/db"
+import { withDbFromEnv } from "./lib/db"
 
 interface ProductEventPayload {
   id: string
@@ -102,7 +103,10 @@ export const catalogBridgeBundle: HonoBundle = {
     }
     const sellerOperatorId = env.TENANT_ID ?? "default"
 
-    function buildIndexerContext() {
+    // Compose the indexer service + builder for a given db client. Db
+    // ownership lives at the call site so we can wrap with `withDbFromEnv`
+    // and tear the Pool down before the subscriber returns.
+    function buildIndexerContext(db: NeonDatabase) {
       const embeddings = buildEmbeddingProvider(env)
       const indexer = buildTypesenseIndexer(env, embeddings)
       if (!indexer) return null
@@ -112,7 +116,6 @@ export const catalogBridgeBundle: HonoBundle = {
         slices,
         registries: getFieldPolicyRegistries(),
       })
-      const db = getDbFromHyperdrive(env)
       const builder = withEmbedding(
         createProductsDocumentBuilder(db, { sellerOperatorId }),
         embeddings,
@@ -121,22 +124,28 @@ export const catalogBridgeBundle: HonoBundle = {
     }
 
     eventBus.subscribe<ProductEventPayload>("product.created", async ({ data }) => {
-      const ctx = buildIndexerContext()
-      if (!ctx) return
-      await ctx.service.ensureCollections()
-      await ctx.service.reindexEntity("products", data.id, ctx.builder)
+      await withDbFromEnv(env, async (db) => {
+        const ctx = buildIndexerContext(db)
+        if (!ctx) return
+        await ctx.service.ensureCollections()
+        await ctx.service.reindexEntity("products", data.id, ctx.builder)
+      })
     })
 
     eventBus.subscribe<ProductEventPayload>("product.updated", async ({ data }) => {
-      const ctx = buildIndexerContext()
-      if (!ctx) return
-      await ctx.service.reindexEntity("products", data.id, ctx.builder)
+      await withDbFromEnv(env, async (db) => {
+        const ctx = buildIndexerContext(db)
+        if (!ctx) return
+        await ctx.service.reindexEntity("products", data.id, ctx.builder)
+      })
     })
 
     eventBus.subscribe<ProductEventPayload>("product.deleted", async ({ data }) => {
-      const ctx = buildIndexerContext()
-      if (!ctx) return
-      await ctx.service.deleteEntity("products", data.id)
+      await withDbFromEnv(env, async (db) => {
+        const ctx = buildIndexerContext(db)
+        if (!ctx) return
+        await ctx.service.deleteEntity("products", data.id)
+      })
     })
 
     // `product.content.changed` covers child-entity mutations that don't
@@ -146,9 +155,11 @@ export const catalogBridgeBundle: HonoBundle = {
     eventBus.subscribe<ProductContentChangedEventPayload>(
       "product.content.changed",
       async ({ data }) => {
-        const ctx = buildIndexerContext()
-        if (!ctx) return
-        await ctx.service.reindexEntity("products", data.id, ctx.builder)
+        await withDbFromEnv(env, async (db) => {
+          const ctx = buildIndexerContext(db)
+          if (!ctx) return
+          await ctx.service.reindexEntity("products", data.id, ctx.builder)
+        })
       },
     )
 
@@ -163,9 +174,12 @@ export const catalogBridgeBundle: HonoBundle = {
       "availability.slot.changed",
       async ({ data }) => {
         if (!data.productId) return
-        const ctx = buildIndexerContext()
-        if (!ctx) return
-        await ctx.service.reindexEntity("products", data.productId, ctx.builder)
+        const productId = data.productId
+        await withDbFromEnv(env, async (db) => {
+          const ctx = buildIndexerContext(db)
+          if (!ctx) return
+          await ctx.service.reindexEntity("products", productId, ctx.builder)
+        })
       },
     )
 
@@ -176,46 +190,50 @@ export const catalogBridgeBundle: HonoBundle = {
     // are wired — they're the two tables the projection reads.
     eventBus.subscribe<PricingRuleChangedPayload>("pricing.rule.changed", async ({ data }) => {
       if (!data.productId) return
-      const ctx = buildIndexerContext()
-      if (!ctx) return
-      await ctx.service.reindexEntity("products", data.productId, ctx.builder)
+      const productId = data.productId
+      await withDbFromEnv(env, async (db) => {
+        const ctx = buildIndexerContext(db)
+        if (!ctx) return
+        await ctx.service.reindexEntity("products", productId, ctx.builder)
+      })
     })
 
     eventBus.subscribe<BookingConfirmedEventPayload>("booking.confirmed", async ({ data }) => {
-      const db = getDbFromHyperdrive(env)
-      // Catalog snapshots use the staff resolver scope — they're an audit
-      // record, not a customer-facing rendering. Booking-time prices /
-      // descriptions stay readable to ops even after audience-scoped
-      // overlays change.
-      const scope = {
-        locale: "en-GB",
-        audience: "staff" as const,
-        market: "default",
-        actor: "staff" as const,
-      }
+      await withDbFromEnv(env, async (db) => {
+        // Catalog snapshots use the staff resolver scope — they're an audit
+        // record, not a customer-facing rendering. Booking-time prices /
+        // descriptions stay readable to ops even after audience-scoped
+        // overlays change.
+        const scope = {
+          locale: "en-GB",
+          audience: "staff" as const,
+          market: "default",
+          actor: "staff" as const,
+        }
 
-      const items = await db
-        .select({ productId: bookingItems.productId })
-        .from(bookingItems)
-        .where(and(eq(bookingItems.bookingId, data.bookingId), isNotNull(bookingItems.productId)))
+        const items = await db
+          .select({ productId: bookingItems.productId })
+          .from(bookingItems)
+          .where(and(eq(bookingItems.bookingId, data.bookingId), isNotNull(bookingItems.productId)))
 
-      const productIds = Array.from(
-        new Set(items.map((i) => i.productId).filter((id): id is string => Boolean(id))),
-      )
-      if (productIds.length === 0) return
+        const productIds = Array.from(
+          new Set(items.map((i) => i.productId).filter((id): id is string => Boolean(id))),
+        )
+        if (productIds.length === 0) return
 
-      const inputs: Array<Omit<CaptureSnapshotInput, "bookingId">> = []
-      for (const productId of productIds) {
-        const input = await buildProductSnapshotInput(db, productId, {
-          sellerOperatorId,
-          scope,
-        })
-        if (input) inputs.push(input)
-      }
+        const inputs: Array<Omit<CaptureSnapshotInput, "bookingId">> = []
+        for (const productId of productIds) {
+          const input = await buildProductSnapshotInput(db, productId, {
+            sellerOperatorId,
+            scope,
+          })
+          if (input) inputs.push(input)
+        }
 
-      if (inputs.length > 0) {
-        await captureSnapshotGraph(db, data.bookingId, inputs)
-      }
+        if (inputs.length > 0) {
+          await captureSnapshotGraph(db, data.bookingId, inputs)
+        }
+      })
     })
   },
 }

--- a/templates/operator/src/api/catalog-checkout.ts
+++ b/templates/operator/src/api/catalog-checkout.ts
@@ -65,7 +65,7 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context, Hono } from "hono"
 import { z } from "zod"
 
-import { getDbFromHyperdrive } from "./lib/db"
+import { getDbFromEnv } from "./lib/db"
 import { computeBookingItemTaxLine, resolveOperatorSellTaxRate } from "./lib/operator-tax-policy"
 import { getOperatorSettings } from "./settings"
 
@@ -2019,7 +2019,7 @@ export function createCatalogCheckoutBundle(opts: {
       eventBus.subscribe<ContractDocumentGeneratedPayload>(
         "contract.document.generated",
         async ({ data }) => {
-          const db = getDbFromHyperdrive(env) as unknown as PostgresJsDatabase
+          const db = getDbFromEnv(env) as unknown as PostgresJsDatabase
           try {
             await persistAcceptanceSignature(db, data.contractId)
           } catch (err) {
@@ -2029,7 +2029,7 @@ export function createCatalogCheckoutBundle(opts: {
       )
       eventBus.subscribe<PaymentCompletedPayload>("payment.completed", async ({ data }) => {
         if (!data.bookingId) return
-        const db = getDbFromHyperdrive(env) as unknown as PostgresJsDatabase
+        const db = getDbFromEnv(env) as unknown as PostgresJsDatabase
         try {
           await dispatchCheckoutFinalize({
             env,
@@ -2063,7 +2063,7 @@ export function createCatalogCheckoutBundle(opts: {
           description:
             "Confirms the booking and issues the final invoice. A fresh rerun re-issues the invoice (collides on existing INV- numbers); use Resume to retry from a failed step.",
           rerun: async (rawInput, ctx) => {
-            const db = getDbFromHyperdrive(env) as unknown as PostgresJsDatabase
+            const db = getDbFromEnv(env) as unknown as PostgresJsDatabase
             const input = rawInput as CheckoutFinalizeInput | null
             if (!input?.bookingId) {
               throw new Error("checkout-finalize rerun: recorded input has no bookingId")
@@ -2082,7 +2082,7 @@ export function createCatalogCheckoutBundle(opts: {
             })
           },
           resume: async (rawInput, ctx) => {
-            const db = getDbFromHyperdrive(env) as unknown as PostgresJsDatabase
+            const db = getDbFromEnv(env) as unknown as PostgresJsDatabase
             const input = rawInput as CheckoutFinalizeInput | null
             if (!input?.bookingId) {
               throw new Error("checkout-finalize resume: recorded input has no bookingId")

--- a/templates/operator/src/api/channel-push-scheduled.ts
+++ b/templates/operator/src/api/channel-push-scheduled.ts
@@ -21,7 +21,7 @@ import {
 } from "@voyantjs/distribution/channel-push"
 
 import { type BookingEngineEnv, getBookingEngineRegistry } from "./lib/booking-engine-runtime"
-import { getDbFromHyperdrive } from "./lib/db"
+import { getDbFromEnv } from "./lib/db"
 
 const BOOKING_LINK_CRON = "*/15 * * * *"
 const AVAILABILITY_CRON = "0 * * * *"
@@ -32,7 +32,7 @@ export async function runScheduledChannelPushReconciler(
   env: CloudflareBindings & BookingEngineEnv,
 ): Promise<void> {
   const deps = {
-    db: getDbFromHyperdrive(env),
+    db: getDbFromEnv(env),
     registry: getBookingEngineRegistry(env),
   }
 

--- a/templates/operator/src/api/channel-push.ts
+++ b/templates/operator/src/api/channel-push.ts
@@ -35,7 +35,7 @@ import type { HonoBundle } from "@voyantjs/hono/plugin"
 import type { Hono } from "hono"
 
 import { type BookingEngineEnv, getBookingEngineRegistry } from "./lib/booking-engine-runtime"
-import { getDbFromHyperdrive } from "./lib/db"
+import { getDbFromEnv } from "./lib/db"
 
 interface BookingConfirmedPayload {
   bookingId: string
@@ -66,7 +66,7 @@ export const channelPushBundle: HonoBundle = {
 
     function buildDeps() {
       return {
-        db: getDbFromHyperdrive(env),
+        db: getDbFromEnv(env),
         registry,
       }
     }
@@ -172,7 +172,7 @@ export function mountChannelPushAdminRoutes(hono: Hono): void {
   hono.use("/v1/admin/distribution/channel-push/*", async (c, next) => {
     const env = c.env as CloudflareBindings & BookingEngineEnv
     setChannelPushDeps({
-      db: getDbFromHyperdrive(env),
+      db: getDbFromEnv(env),
       registry: getBookingEngineRegistry(env),
     })
     await next()

--- a/templates/operator/src/api/draft-reaper-scheduled.ts
+++ b/templates/operator/src/api/draft-reaper-scheduled.ts
@@ -30,7 +30,7 @@ import {
   getBookingEngineRegistry,
   getOwnedBookingHandlerRegistry,
 } from "./lib/booking-engine-runtime"
-import { getDbFromHyperdrive } from "./lib/db"
+import { getDbFromEnv } from "./lib/db"
 
 export const DRAFT_REAPER_CRON = "5 * * * *"
 
@@ -48,7 +48,7 @@ export async function runScheduledDraftReaper(
   _event: ScheduledController,
   env: CloudflareBindings & BookingEngineEnv,
 ): Promise<ReaperResult> {
-  const db = getDbFromHyperdrive(env)
+  const db = getDbFromEnv(env)
   const registry = getBookingEngineRegistry(env)
   const ownedHandlers = getOwnedBookingHandlerRegistry(env)
 

--- a/templates/operator/src/api/invitations.ts
+++ b/templates/operator/src/api/invitations.ts
@@ -95,7 +95,7 @@ export function createInvitationsRoutes() {
       return c.json({ error: "Forbidden" }, 403)
     }
 
-    const db = getDbFromEnv(c.env, c.executionCtx)
+    const db = getDbFromEnv(c.env)
     const rows = await db
       .select({
         id: userInvitationsTable.id,
@@ -125,7 +125,7 @@ export function createInvitationsRoutes() {
       return c.json({ error: "Invalid payload", details: parsed.error.issues }, 400)
     }
 
-    const db = getDbFromEnv(c.env, c.executionCtx)
+    const db = getDbFromEnv(c.env)
     const normalizedEmail = parsed.data.email.trim().toLowerCase()
 
     // If this email already has a BA user, block the invite.
@@ -196,7 +196,7 @@ export function createInvitationsRoutes() {
     }
 
     const id = c.req.param("id")
-    const db = getDbFromEnv(c.env, c.executionCtx)
+    const db = getDbFromEnv(c.env)
     await db.delete(userInvitationsTable).where(eq(userInvitationsTable.id, id))
     return c.json({ data: { id } })
   })
@@ -205,7 +205,7 @@ export function createInvitationsRoutes() {
   routes.get("/v1/public/invitations/:token", async (c) => {
     const token = c.req.param("token")
     const tokenHash = await sha256Hex(token)
-    const db = getDbFromEnv(c.env, c.executionCtx)
+    const db = getDbFromEnv(c.env)
 
     const [row] = await db
       .select({
@@ -239,7 +239,7 @@ export function createInvitationsRoutes() {
     }
 
     const tokenHash = await sha256Hex(token)
-    const db = getDbFromEnv(c.env, c.executionCtx)
+    const db = getDbFromEnv(c.env)
     const now = new Date()
 
     const [invite] = await db

--- a/templates/operator/src/api/invitations.ts
+++ b/templates/operator/src/api/invitations.ts
@@ -27,7 +27,7 @@ import { Hono } from "hono"
 import { z } from "zod"
 
 import { resolveEmailReplyTo } from "../lib/notifications"
-import { getDbFromHyperdrive } from "./lib/db"
+import { getDbFromEnv } from "./lib/db"
 
 type InvitationsBindings = CloudflareBindings
 type InvitationsVariables = {
@@ -76,7 +76,7 @@ function getAppUrl(env: InvitationsBindings): string {
 }
 
 async function assertSuperAdmin(env: InvitationsBindings, userId: string): Promise<boolean> {
-  const db = getDbFromHyperdrive(env)
+  const db = getDbFromEnv(env)
   const [row] = await db
     .select({ isSuperAdmin: userProfilesTable.isSuperAdmin })
     .from(userProfilesTable)
@@ -95,7 +95,7 @@ export function createInvitationsRoutes() {
       return c.json({ error: "Forbidden" }, 403)
     }
 
-    const db = getDbFromHyperdrive(c.env)
+    const db = getDbFromEnv(c.env, c.executionCtx)
     const rows = await db
       .select({
         id: userInvitationsTable.id,
@@ -125,7 +125,7 @@ export function createInvitationsRoutes() {
       return c.json({ error: "Invalid payload", details: parsed.error.issues }, 400)
     }
 
-    const db = getDbFromHyperdrive(c.env)
+    const db = getDbFromEnv(c.env, c.executionCtx)
     const normalizedEmail = parsed.data.email.trim().toLowerCase()
 
     // If this email already has a BA user, block the invite.
@@ -196,7 +196,7 @@ export function createInvitationsRoutes() {
     }
 
     const id = c.req.param("id")
-    const db = getDbFromHyperdrive(c.env)
+    const db = getDbFromEnv(c.env, c.executionCtx)
     await db.delete(userInvitationsTable).where(eq(userInvitationsTable.id, id))
     return c.json({ data: { id } })
   })
@@ -205,7 +205,7 @@ export function createInvitationsRoutes() {
   routes.get("/v1/public/invitations/:token", async (c) => {
     const token = c.req.param("token")
     const tokenHash = await sha256Hex(token)
-    const db = getDbFromHyperdrive(c.env)
+    const db = getDbFromEnv(c.env, c.executionCtx)
 
     const [row] = await db
       .select({
@@ -239,7 +239,7 @@ export function createInvitationsRoutes() {
     }
 
     const tokenHash = await sha256Hex(token)
-    const db = getDbFromHyperdrive(c.env)
+    const db = getDbFromEnv(c.env, c.executionCtx)
     const now = new Date()
 
     const [invite] = await db

--- a/templates/operator/src/api/lib/booking-engine-runtime.ts
+++ b/templates/operator/src/api/lib/booking-engine-runtime.ts
@@ -54,7 +54,7 @@ import { and, asc, eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
 
-import { getDbFromHyperdrive } from "./db"
+import { getDbFromEnv } from "./db"
 import { resolveOperatorSellTaxRate } from "./operator-tax-policy"
 
 let _registry: SourceAdapterRegistry | undefined
@@ -93,9 +93,7 @@ export function getOwnedBookingHandlerRegistry(env: BookingEngineEnv): OwnedBook
       createProductsBookingHandler({
         holds: {
           async place(input) {
-            const db = getDbFromHyperdrive(
-              env as Parameters<typeof getDbFromHyperdrive>[0],
-            ) as PostgresJsDatabase
+            const db = getDbFromEnv(env as Parameters<typeof getDbFromEnv>[0]) as PostgresJsDatabase
             const result = await placeAvailabilityHold(db, input)
             if (result.status === "ok") {
               return {
@@ -121,17 +119,13 @@ export function getOwnedBookingHandlerRegistry(env: BookingEngineEnv): OwnedBook
             }
           },
           async extend(input) {
-            const db = getDbFromHyperdrive(
-              env as Parameters<typeof getDbFromHyperdrive>[0],
-            ) as PostgresJsDatabase
+            const db = getDbFromEnv(env as Parameters<typeof getDbFromEnv>[0]) as PostgresJsDatabase
             const result = await extendAvailabilityHold(db, input)
             if (result.status === "ok") return { status: "ok", expiresAt: result.expiresAt }
             return { status: "not_found" }
           },
           async release(holdToken) {
-            const db = getDbFromHyperdrive(
-              env as Parameters<typeof getDbFromHyperdrive>[0],
-            ) as PostgresJsDatabase
+            const db = getDbFromEnv(env as Parameters<typeof getDbFromEnv>[0]) as PostgresJsDatabase
             await releaseAvailabilityHold(db, holdToken)
           },
         },
@@ -140,14 +134,17 @@ export function getOwnedBookingHandlerRegistry(env: BookingEngineEnv): OwnedBook
         // env is captured by the closure so the bridge can resolve
         // the per-request DB lazily.
         async quickCreate(input, opts) {
-          // The hyperdrive helper returns a union (postgres-js | neon-http).
-          // The operator deploys against postgres-js in every environment
-          // we run today; quickCreateBooking's typed signature accepts
-          // postgres-js, so we narrow at the call site rather than
-          // widening the helper return type.
-          const db = getDbFromHyperdrive(
-            env as Parameters<typeof getDbFromHyperdrive>[0],
-          ) as PostgresJsDatabase
+          // `getDbFromEnv` returns the union AnyDrizzleDb (postgres-js |
+          // neon-http). `quickCreateBooking`'s signature still asks for
+          // postgres-js, so we force-narrow here. After #500 the runtime
+          // is neon-http on Workers; the cast is a TS-suppress, not a
+          // runtime guarantee. If `quickCreateBooking` reaches for
+          // postgres-js-only APIs (real PG transactions, advisory
+          // locks) under the neon-http instance it will surface at
+          // runtime — at which point the right fix is to widen the
+          // service signature to AnyDrizzleDb, not reintroduce
+          // Hyperdrive.
+          const db = getDbFromEnv(env as Parameters<typeof getDbFromEnv>[0]) as PostgresJsDatabase
           const outcome = await quickCreateBooking(db, input, opts)
           if (outcome.status === "ok") {
             await persistQuickCreateTaxLines(db, outcome.result.booking.id, input.taxLines)
@@ -326,9 +323,7 @@ export function getOwnedBookingHandlerRegistry(env: BookingEngineEnv): OwnedBook
         async commitBridge(input, opts) {
           // The handler validates `ratePlanId` upstream — defensive
           // double-check here would be redundant.
-          const db = getDbFromHyperdrive(
-            env as Parameters<typeof getDbFromHyperdrive>[0],
-          ) as PostgresJsDatabase
+          const db = getDbFromEnv(env as Parameters<typeof getDbFromEnv>[0]) as PostgresJsDatabase
           try {
             const outcome = await hospitalityBookingsService.createStayBooking(
               db,
@@ -416,9 +411,7 @@ export function getOwnedBookingHandlerRegistry(env: BookingEngineEnv): OwnedBook
           }
         },
         async commitBridge(input, opts) {
-          const db = getDbFromHyperdrive(
-            env as Parameters<typeof getDbFromHyperdrive>[0],
-          ) as PostgresJsDatabase
+          const db = getDbFromEnv(env as Parameters<typeof getDbFromEnv>[0]) as PostgresJsDatabase
           try {
             const result = await cruisesBookingService.createCruiseBooking(
               db,

--- a/templates/operator/src/api/lib/db.ts
+++ b/templates/operator/src/api/lib/db.ts
@@ -1,4 +1,20 @@
+import { Pool } from "@neondatabase/serverless"
 import { createDbClient, type DbAdapter } from "@voyantjs/db"
+import { drizzle as drizzleNeonWs, type NeonDatabase } from "drizzle-orm/neon-serverless"
+
+/**
+ * `@neondatabase/serverless`'s `Pool` extends `pg.Pool`. Some pnpm
+ * resolution paths don't merge the inherited `pg.Pool` methods into
+ * the visible TS surface, so the constructor + `end()` call go via
+ * a structural cast. Runtime behavior is unchanged.
+ */
+type PgPoolApi = {
+  end(): Promise<void>
+}
+function newPool(connectionString: string): Pool & PgPoolApi {
+  const Ctor = Pool as unknown as new (cfg: { connectionString: string }) => Pool & PgPoolApi
+  return new Ctor({ connectionString })
+}
 
 /**
  * Database client helpers with NO schema passing.
@@ -12,33 +28,43 @@ export function getDb(adapter?: DbAdapter) {
   return createDbClient(url, { adapter: effectiveAdapter })
 }
 
-export function getDbFromEnv(env: CloudflareBindings, adapter?: DbAdapter) {
-  const url = env.DATABASE_URL
-  const effectiveAdapter = adapter || "edge"
-  return createDbClient(url, { adapter: effectiveAdapter })
+/**
+ * Per-request Neon Postgres client over WebSocket. Supports real
+ * Postgres transactions (drizzle's `db.transaction(...)`).
+ *
+ * Pool lifecycle: pass `executionCtx` whenever it's available so
+ * `pool.end()` is scheduled via `waitUntil` and the WebSocket closes
+ * cleanly before the isolate sleeps. Without an `executionCtx`, the
+ * Pool is left for the Workers runtime to reclaim on isolate teardown
+ * — fine for low-traffic paths, but at scale prefer `withDbFromEnv`
+ * below, which owns the Pool lifecycle explicitly.
+ */
+export function getDbFromEnv(
+  env: CloudflareBindings,
+  executionCtx?: ExecutionContext,
+): NeonDatabase {
+  const pool = newPool(env.DATABASE_URL)
+  if (executionCtx) {
+    executionCtx.waitUntil(pool.end().catch(() => {}))
+  }
+  return drizzleNeonWs(pool)
 }
 
 /**
- * Get database client using Hyperdrive connection pooling.
- * Falls back to regular connection if Hyperdrive is not configured.
- *
- * Hyperdrive provides:
- * - Connection pooling at the edge (no cold connection overhead)
- * - Automatic connection reuse across requests
- * - Lower latency than direct Neon HTTP driver
- *
- * @see https://developers.cloudflare.com/hyperdrive/
+ * Higher-order helper for code paths without an `ExecutionContext`
+ * (event-bus subscribers, scheduled handlers, retry workers). Owns the
+ * Pool lifecycle: opens, hands the drizzle client to `fn`, closes on
+ * settle. Use this anywhere `c.executionCtx` isn't available — never
+ * leak a `new Pool(...)` outside a single request handler in a Worker.
  */
-export function getDbFromHyperdrive(env: CloudflareBindings) {
-  // Prefer Hyperdrive if available (prod)
-  if (env.HYPERDRIVE) {
-    return createDbClient(env.HYPERDRIVE.connectionString, { adapter: "node" })
+export async function withDbFromEnv<T>(
+  env: CloudflareBindings,
+  fn: (db: NeonDatabase) => Promise<T>,
+): Promise<T> {
+  const pool = newPool(env.DATABASE_URL)
+  try {
+    return await fn(drizzleNeonWs(pool))
+  } finally {
+    await pool.end().catch(() => {})
   }
-
-  // Dev: direct postgres.js connection to local DATABASE_URL
-  if (env.DATABASE_URL) {
-    return createDbClient(env.DATABASE_URL, { adapter: "node" })
-  }
-
-  throw new Error("[db] No HYPERDRIVE binding or DATABASE_URL configured")
 }

--- a/templates/operator/src/api/lib/db.ts
+++ b/templates/operator/src/api/lib/db.ts
@@ -32,30 +32,41 @@ export function getDb(adapter?: DbAdapter) {
  * Per-request Neon Postgres client over WebSocket. Supports real
  * Postgres transactions (drizzle's `db.transaction(...)`).
  *
- * Pool lifecycle: pass `executionCtx` whenever it's available so
- * `pool.end()` is scheduled via `waitUntil` and the WebSocket closes
- * cleanly before the isolate sleeps. Without an `executionCtx`, the
- * Pool is left for the Workers runtime to reclaim on isolate teardown
- * — fine for low-traffic paths, but at scale prefer `withDbFromEnv`
- * below, which owns the Pool lifecycle explicitly.
+ * Cleanup is the caller's responsibility — either route through
+ * `createApp({ db: dbFromEnvForApp })` below (which threads a
+ * `dispose()` through the Hono db middleware so the Pool closes after
+ * the response), or use `withDbFromEnv` for code paths outside Hono.
+ * Without explicit cleanup, the Pool sits open until the Workers
+ * runtime reclaims the isolate.
  */
-export function getDbFromEnv(
-  env: CloudflareBindings,
-  executionCtx?: ExecutionContext,
-): NeonDatabase {
+export function getDbFromEnv(env: CloudflareBindings): NeonDatabase {
   const pool = newPool(env.DATABASE_URL)
-  if (executionCtx) {
-    executionCtx.waitUntil(pool.end().catch(() => {}))
-  }
   return drizzleNeonWs(pool)
 }
 
 /**
- * Higher-order helper for code paths without an `ExecutionContext`
- * (event-bus subscribers, scheduled handlers, retry workers). Owns the
- * Pool lifecycle: opens, hands the drizzle client to `fn`, closes on
- * settle. Use this anywhere `c.executionCtx` isn't available — never
- * leak a `new Pool(...)` outside a single request handler in a Worker.
+ * Lifecycle-aware factory for `createApp({ db })`. Returns the drizzle
+ * client plus a `dispose()` the Hono db middleware schedules via
+ * `executionCtx.waitUntil` after the response is sent — so each
+ * request gets its own Pool and closes it before the isolate sleeps,
+ * instead of leaking WebSocket connections to Neon at request rate.
+ */
+export function dbFromEnvForApp(env: CloudflareBindings): {
+  db: NeonDatabase
+  dispose: () => Promise<void>
+} {
+  const pool = newPool(env.DATABASE_URL)
+  return {
+    db: drizzleNeonWs(pool),
+    dispose: () => pool.end().catch(() => {}),
+  }
+}
+
+/**
+ * Higher-order helper for code paths without a Hono request context
+ * (event-bus subscribers, scheduled handlers, retry workers). Owns
+ * the Pool lifecycle: opens, hands the drizzle client to `fn`, closes
+ * on settle.
  */
 export async function withDbFromEnv<T>(
   env: CloudflareBindings,

--- a/templates/operator/src/api/smartbill.ts
+++ b/templates/operator/src/api/smartbill.ts
@@ -19,7 +19,7 @@ import {
 import { and, asc, eq, inArray } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
-import { getDbFromHyperdrive } from "./lib/db"
+import { withDbFromEnv } from "./lib/db"
 import { getOperatorSettings } from "./settings"
 
 type SmartbillEnv = CloudflareBindings & {
@@ -140,11 +140,22 @@ async function syncIssuedInvoice(
   payload: InvoiceIssuedPayload,
   documentType: "invoice" | "proforma",
 ) {
-  if (!payload.invoiceId) return
-  const db = getDbFromHyperdrive(env) as unknown as PostgresJsDatabase
+  const invoiceId = payload.invoiceId
+  if (!invoiceId) return
+  await withDbFromEnv(env, async (rawDb) => {
+    const db = rawDb as unknown as PostgresJsDatabase
+    await syncIssuedInvoiceWithDb(db, runtime, invoiceId, documentType)
+  })
+}
 
+async function syncIssuedInvoiceWithDb(
+  db: PostgresJsDatabase,
+  runtime: SmartbillRuntime,
+  invoiceId: string,
+  documentType: "invoice" | "proforma",
+) {
   try {
-    const externalRefs = await financeService.listInvoiceExternalRefs(db, payload.invoiceId)
+    const externalRefs = await financeService.listInvoiceExternalRefs(db, invoiceId)
     const existingSmartbillRef = externalRefs.find((ref) => ref.provider === "smartbill")
     if (
       existingSmartbillRef &&
@@ -154,7 +165,7 @@ async function syncIssuedInvoice(
       return
     }
 
-    const body = await buildSmartbillInvoiceBody(db, runtime, payload.invoiceId, documentType)
+    const body = await buildSmartbillInvoiceBody(db, runtime, invoiceId, documentType)
     if (!body) return
 
     const result =
@@ -162,7 +173,7 @@ async function syncIssuedInvoice(
         ? await runtime.client.createProforma(body)
         : await runtime.client.createInvoice(body)
 
-    await financeService.registerInvoiceExternalRef(db, payload.invoiceId, {
+    await financeService.registerInvoiceExternalRef(db, invoiceId, {
       provider: "smartbill",
       externalId: result.number ?? null,
       externalNumber: result.number ?? null,
@@ -180,11 +191,11 @@ async function syncIssuedInvoice(
     })
 
     console.info(
-      `[smartbill] ${documentType} created: ${result.series ?? body.seriesName}-${result.number ?? "unknown"} for ${payload.invoiceId}`,
+      `[smartbill] ${documentType} created: ${result.series ?? body.seriesName}-${result.number ?? "unknown"} for ${invoiceId}`,
     )
   } catch (error) {
-    console.error(`[smartbill] failed to create ${documentType} for ${payload.invoiceId}`, error)
-    await financeService.registerInvoiceExternalRef(db, payload.invoiceId, {
+    console.error(`[smartbill] failed to create ${documentType} for ${invoiceId}`, error)
+    await financeService.registerInvoiceExternalRef(db, invoiceId, {
       provider: "smartbill",
       status: "error",
       syncedAt: new Date().toISOString(),

--- a/templates/operator/wrangler.jsonc
+++ b/templates/operator/wrangler.jsonc
@@ -23,13 +23,6 @@
       "bucket_name": "voyant-documents"
     }
   ],
-  "hyperdrive": [
-    {
-      "binding": "HYPERDRIVE",
-      "id": "dev-placeholder",
-      "localConnectionString": "postgresql://voyant:voyant@localhost:5434/voyant_operator"
-    }
-  ],
   "triggers": {
     "crons": [
       // Channel-push reconcilers (per channel-push-architecture.md §13.2).


### PR DESCRIPTION
## Summary

Closes #500. Both \`templates/dmc\` and \`templates/operator\` now connect to Neon directly via \`@neondatabase/serverless\` Pool + \`drizzle-orm/neon-serverless\` using the existing \`DATABASE_URL\` secret. The \`HYPERDRIVE\` binding is gone from \`wrangler.jsonc\` and \`env.d.ts\`; \`.dev.vars.example\` and \`README\` copy is updated to reflect the single-secret story.

## Why WebSocket and not HTTP

The bookings package and several other internal services use \`db.transaction()\` for read-then-write logic that needs real Postgres transaction semantics. Neon's HTTP transport batches statements (atomic but no isolation); WebSocket gives full transaction support on Workers — same semantic Hyperdrive was providing, so behavior is preserved end-to-end.

## Helpers

Each template's \`src/api/lib/db.ts\` ships two:

- **\`getDbFromEnv(env, executionCtx?)\`** — returns a per-request \`NeonDatabase\`. When \`executionCtx\` is passed, schedules \`pool.end()\` via \`waitUntil\` so the WebSocket closes promptly. When omitted, the Pool is left for the Workers runtime to reclaim on isolate teardown.
- **\`withDbFromEnv(env, fn)\`** — higher-order helper for non-Hono code paths (event subscribers, scheduled handlers). Owns the Pool lifecycle inline (\`open → fn → finally pool.end()\`).

Subscribers in \`catalog-bridge\`, \`booking-schedule\`, \`smartbill\`, and \`catalog-checkout\` were converted to \`withDbFromEnv\` so the Pool is owned by each subscriber call. Hono route handlers pass \`c.executionCtx\` where available. Helpers like \`getBetterAuth\` and \`assertSuperAdmin\` still call \`getDbFromEnv(env)\` without \`executionCtx\` — the Pool lingers until isolate teardown there. The remaining audit (thread \`executionCtx\` through every non-Hono call site, then flip the param to required) is tracked in **#510**.

## Shared types broadened

So consumers don't need force-casts when wiring a \`NeonDatabase\` into a module factory:

- **\`@voyantjs/db\`**: \`AnyDrizzleDb\` union now includes \`NeonDatabase\` from \`drizzle-orm/neon-serverless\` alongside the existing \`PostgresJsDatabase\` and \`NeonHttpDatabase\` flavors.
- **\`@voyantjs/hono\`**: \`VoyantDb\` (the type Hono ctx variables expose under \`c.var.db\`) widens the same way.

## Implementation notes

- The \`@neondatabase/serverless\` Pool extends \`pg.Pool\`, but some pnpm resolution paths don't merge the inherited \`pg\` methods into the visible TS surface. Both templates' \`db.ts\` wraps the constructor + \`end()\` call via a small structural cast — runtime is unchanged.
- \`@types/pg\` added to template devDependencies so the inherited Pool surface resolves cleanly.
- \`CreateBetterAuthOptions.db\` still references the older \`getDb\` return union; cast at the call site rather than widening better-auth's API surface from this PR.

## Migration

No schema migration. No behavior change for API contracts. Operators upgrading need to:
1. Drop the \`HYPERDRIVE\` binding from their \`wrangler.jsonc\` (if present).
2. Ensure \`DATABASE_URL\` points at a Neon Postgres reachable over WebSocket (the standard Neon connection string).

## Test plan

- [x] \`pnpm -F @voyantjs/db -F @voyantjs/hono typecheck\` — clean.
- [x] Operator + DMC template typechecks (8GB heap) — clean.
- [x] \`pnpm -F @voyantjs/db -F @voyantjs/hono test\` — all 52+ tests pass on touched shared packages.
- [ ] Manual: \`pnpm -F operator dev\` against a Neon \`DATABASE_URL\`, exercise an admin route that hits \`db.transaction(...)\` (booking creation), confirm it commits.
- [ ] Manual: trigger a slot mutation, confirm catalog bridge subscriber reindexes the product.
- [ ] CI for both templates.

Closes #500. Tracks #510 for the executionCtx audit follow-up.