### PR TITLE
Fix #510 (mostly): audit Pool lifecycle on templates' non-Hono code paths

### DIFF
--- a/.changeset/templates-pool-lifecycle-audit.md
+++ b/.changeset/templates-pool-lifecycle-audit.md
@@ -1,0 +1,20 @@
+---
+---
+
+Closes #510 (mostly): audit and clean up Pool-lifecycle on the templates' non-Hono code paths after the Neon WebSocket switch in #500.
+
+What changed in both `templates/dmc` and `templates/operator`:
+
+- **Hono route handlers** stop calling `getDbFromEnv(c.env)` — they now read the request-scoped client from `c.get("db")`, which is owned by the `dbFromEnvForApp` factory + Hono db middleware (introduced in #511) and disposed via `executionCtx.waitUntil` after the response.
+- **Helper functions** (`assertSuperAdmin`, `getBetterAuth`) own their own Pool lifecycle now. `assertSuperAdmin` wraps the query in `withDbFromEnv` (open → query → close). `getBetterAuth` returns `{ auth, dispose }`; every caller schedules `dispose()` via `executionCtx.waitUntil` (or awaits inline when no `executionCtx` is reachable, e.g. in `resolveAuthRequest`).
+- **Event-bus subscribers** (catalog-bridge, channel-push, catalog-checkout, booking-schedule, smartbill, dmc/catalog-bridge) wrap their bodies in `withDbFromEnv` so the Pool lives only for the subscriber call.
+- **Scheduled handlers** (`channel-push-scheduled`, `draft-reaper-scheduled`) wrap their tick bodies in `withDbFromEnv`.
+- **Booking-engine handler closures** in `templates/operator/src/api/lib/booking-engine-runtime.ts` (products holds + quickCreate, hospitality + cruises commit bridges) — six closures, each now wraps its query in `withDbFromEnv`.
+- **`mountChannelPushAdminRoutes`** middleware reads `c.var.db` instead of building a new Pool.
+- The Hono sub-app declarations for `auth/handler.ts` (both templates) and the `InvitationsVariables` types now include `db: VoyantDb` so `c.get("db")` is properly typed under those sub-apps' contexts.
+
+What's still leaking (deliberately deferred):
+
+- `app.ts:resolveDb` callbacks passed to `createBookingsHonoModule` and `createLegalHonoModule`. The module-factory contract is `(bindings) => VoyantDb` with no dispose hook; widening it to accept `DisposableDb` is a separate shared-package change. Volume is low (one Pool per booking-confirmed / legal-event subscriber call), so this isn't moving the operational needle today. Both sites have `KNOWN LEAK` comments pointing to the remaining audit. Tracked under #510.
+
+No behavior change for HTTP API contracts. No schema migration. Pure lifecycle / Pool-management cleanup.

--- a/packages/hono/src/middleware/db.ts
+++ b/packages/hono/src/middleware/db.ts
@@ -3,6 +3,16 @@ import type { MiddlewareHandler } from "hono"
 import { type DbFactory, isDisposableDb, type VoyantBindings, type VoyantDb } from "../types.js"
 
 /**
+ * Structural shape of the Cloudflare Workers `ExecutionContext`. Defined
+ * inline so the `@voyantjs/hono` package doesn't need a hard dependency on
+ * `@cloudflare/workers-types` — consumers running on Node, Vercel, or any
+ * other runtime can call this middleware without pulling those globals.
+ */
+interface ExecutionContextLike {
+  waitUntil(promise: Promise<unknown>): void
+}
+
+/**
  * Resolves the per-request db client and stores it on Hono context.
  *
  * If the factory returns a {@link DisposableDb} (e.g. a
@@ -32,7 +42,7 @@ export function db<TBindings extends VoyantBindings>(
         // `executionCtx` is undefined in unit-test contexts where Hono
         // is invoked directly without a Workers runtime — fall back to
         // an inline await so cleanup still runs.
-        const ctx = c.executionCtx as ExecutionContext | undefined
+        const ctx = c.executionCtx as ExecutionContextLike | undefined
         if (ctx && typeof ctx.waitUntil === "function") {
           ctx.waitUntil(result.dispose())
         } else {

--- a/packages/hono/src/middleware/require-permission.ts
+++ b/packages/hono/src/middleware/require-permission.ts
@@ -10,6 +10,12 @@ import {
   type VoyantDb,
   type VoyantVariables,
 } from "../types.js"
+
+/** See db middleware: structural shape avoids a hard `@cloudflare/workers-types` dep. */
+interface ExecutionContextLike {
+  waitUntil(promise: Promise<unknown>): void
+}
+
 import { ForbiddenApiError, UnauthorizedApiError } from "../validation.js"
 
 function hasScope(scopes: string[] | null | undefined, permission: VoyantPermission): boolean {
@@ -90,7 +96,7 @@ export function requirePermission<TBindings extends VoyantBindings>(
       return next()
     } finally {
       if (dispose) {
-        const ctx = c.executionCtx as ExecutionContext | undefined
+        const ctx = c.executionCtx as ExecutionContextLike | undefined
         if (ctx && typeof ctx.waitUntil === "function") {
           ctx.waitUntil(dispose())
         } else {

--- a/templates/dmc/src/api/auth/handler.ts
+++ b/templates/dmc/src/api/auth/handler.ts
@@ -10,13 +10,16 @@
 import { createBetterAuth } from "@voyantjs/auth/server"
 import { tryGetVoyantCloudClient } from "@voyantjs/cloud-sdk"
 import { authUser, userProfilesTable } from "@voyantjs/db/schema/iam"
-import type { VoyantRequestAuthContext } from "@voyantjs/hono"
+import type { VoyantDb, VoyantRequestAuthContext } from "@voyantjs/hono"
 import { eq, sql } from "drizzle-orm"
 import { Hono } from "hono"
 
-import { getDbFromEnv } from "../lib/db"
+import { dbFromEnvForApp } from "../lib/db"
 
-const auth = new Hono<{ Bindings: CloudflareBindings }>()
+// Type ctx so `c.get("db")` resolves to the parent app's middleware-
+// set `VoyantDb` (the per-request Pool the `dbFromEnvForApp` factory
+// installed). Without this, the sub-app sees `unknown` for context vars.
+const auth = new Hono<{ Bindings: CloudflareBindings; Variables: { db: VoyantDb } }>()
 const DEFAULT_APP_URL = "http://localhost:3100"
 
 function normalizeUrl(url: string): string {
@@ -65,12 +68,23 @@ function getAuthBaseUrl(env: CloudflareBindings): string {
  * one request cannot be reused by another ("Cannot perform I/O on behalf of
  * a different request"). So we must NOT cache the auth instance.
  */
-function getBetterAuth(env: CloudflareBindings) {
-  const db = getDbFromEnv(env)
+/**
+ * Builds a per-call Better Auth instance. Returns the auth object plus
+ * a `dispose()` the caller schedules (typically via
+ * `c.executionCtx.waitUntil`) after the auth-using work has settled.
+ * Without `dispose`, the Pool stays open until isolate teardown — at
+ * scale that exhausts Neon's connection budget because every
+ * authenticated request opens a fresh WebSocket.
+ */
+function getBetterAuth(env: CloudflareBindings): {
+  auth: ReturnType<typeof createBetterAuth>
+  dispose: () => Promise<void>
+} {
+  const { db, dispose } = dbFromEnvForApp(env)
   const cloud = tryGetVoyantCloudClient(env as unknown as Record<string, unknown>)
   const emailFrom = env.EMAIL_FROM || "Voyant <noreply@voyantcloud.app>"
 
-  return createBetterAuth({
+  const auth = createBetterAuth({
     // `db` is a `NeonDatabase` (neon-serverless WebSocket); the
     // `CreateBetterAuthOptions.db` type still references the older
     // `getDb` return union (postgres-js + neon-http). Drizzle's
@@ -109,26 +123,34 @@ function getBetterAuth(env: CloudflareBindings) {
       })
     },
   })
+  return { auth, dispose }
 }
 
 export async function resolveAuthRequest(
   request: Request,
   env: CloudflareBindings,
 ): Promise<VoyantRequestAuthContext | null> {
-  const betterAuth = getBetterAuth(env)
-  const session = await betterAuth.api.getSession({ headers: request.headers })
+  const { auth, dispose } = getBetterAuth(env)
+  try {
+    const session = await auth.api.getSession({ headers: request.headers })
 
-  if (!session) {
-    return null
-  }
+    if (!session) {
+      return null
+    }
 
-  return {
-    userId: session.user.id,
-    sessionId: session.session.id,
-    organizationId: null,
-    callerType: "session",
-    actor: "staff",
-    email: session.user.email ?? null,
+    return {
+      userId: session.user.id,
+      sessionId: session.session.id,
+      organizationId: null,
+      callerType: "session",
+      actor: "staff",
+      email: session.user.email ?? null,
+    }
+  } finally {
+    // No `executionCtx` reachable here (called from middleware that
+    // doesn't pass one through). Await inline so the WebSocket closes
+    // before this fn returns.
+    await dispose()
   }
 }
 
@@ -149,13 +171,20 @@ export async function hasAuthPermission(
  * Validates the session cookie directly (no Bearer token needed).
  */
 auth.get("/auth/me", async (c) => {
-  const betterAuth = getBetterAuth(c.env)
-  const session = await betterAuth.api.getSession({ headers: c.req.raw.headers })
+  const { auth: betterAuth, dispose } = getBetterAuth(c.env)
+  let session: Awaited<ReturnType<typeof betterAuth.api.getSession>>
+  try {
+    session = await betterAuth.api.getSession({ headers: c.req.raw.headers })
+  } finally {
+    // Schedule dispose AFTER queries settle. waitUntil keeps the
+    // worker alive while the WebSocket close handshake completes.
+    c.executionCtx.waitUntil(dispose())
+  }
   if (!session) {
     return c.json({ error: "Unauthorized" }, 401)
   }
 
-  const db = getDbFromEnv(c.env)
+  const db = c.get("db")
 
   const [row] = await db
     .select({
@@ -202,14 +231,19 @@ auth.get("/auth/me", async (c) => {
  * but this route serves as an idempotent fallback.
  */
 auth.get("/auth/status", async (c) => {
-  const betterAuth = getBetterAuth(c.env)
-  const session = await betterAuth.api.getSession({ headers: c.req.raw.headers })
+  const { auth: betterAuth, dispose } = getBetterAuth(c.env)
+  let session: Awaited<ReturnType<typeof betterAuth.api.getSession>>
+  try {
+    session = await betterAuth.api.getSession({ headers: c.req.raw.headers })
+  } finally {
+    c.executionCtx.waitUntil(dispose())
+  }
   if (!session) {
     return c.json({ userExists: false, authenticated: false })
   }
 
   const userId = session.user.id
-  const db = getDbFromEnv(c.env)
+  const db = c.get("db")
 
   try {
     const [existingProfile] = await db
@@ -261,7 +295,7 @@ auth.get("/auth/status", async (c) => {
  * Public endpoint — reveals whether any user exists.
  */
 auth.get("/auth/bootstrap-status", async (c) => {
-  const db = getDbFromEnv(c.env)
+  const db = c.get("db")
   const [row] = await db.select({ count: sql<number>`count(*)::int` }).from(authUser)
   return c.json({ hasUsers: (row?.count ?? 0) > 0 })
 })
@@ -271,9 +305,12 @@ auth.get("/auth/bootstrap-status", async (c) => {
  * Sign-up is gated server-side by a `user.create.before` hook in @voyantjs/auth.
  */
 auth.all("/auth/*", async (c) => {
-  const betterAuth = getBetterAuth(c.env)
-  const response = await betterAuth.handler(c.req.raw)
-  return response
+  const { auth: betterAuth, dispose } = getBetterAuth(c.env)
+  try {
+    return await betterAuth.handler(c.req.raw)
+  } finally {
+    c.executionCtx.waitUntil(dispose())
+  }
 })
 
 export default auth

--- a/templates/dmc/src/api/auth/handler.ts
+++ b/templates/dmc/src/api/auth/handler.ts
@@ -62,29 +62,22 @@ function getAuthBaseUrl(env: CloudflareBindings): string {
 }
 
 /**
- * Create a fresh Better Auth instance per request.
+ * Build a Better Auth instance backed by a caller-provided drizzle
+ * client. The caller owns the Pool lifecycle (open before, dispose
+ * after) so the same Pool can serve both the auth lookup and any
+ * subsequent queries the route does — without spinning up a second
+ * connection per request.
  *
- * Cloudflare Workers isolate I/O per request — a DB connection created in
- * one request cannot be reused by another ("Cannot perform I/O on behalf of
- * a different request"). So we must NOT cache the auth instance.
+ * Cloudflare Workers isolate I/O per request — a DB connection created
+ * in one request cannot be reused by another ("Cannot perform I/O on
+ * behalf of a different request"). The auth instance is therefore not
+ * cached either.
  */
-/**
- * Builds a per-call Better Auth instance. Returns the auth object plus
- * a `dispose()` the caller schedules (typically via
- * `c.executionCtx.waitUntil`) after the auth-using work has settled.
- * Without `dispose`, the Pool stays open until isolate teardown — at
- * scale that exhausts Neon's connection budget because every
- * authenticated request opens a fresh WebSocket.
- */
-function getBetterAuth(env: CloudflareBindings): {
-  auth: ReturnType<typeof createBetterAuth>
-  dispose: () => Promise<void>
-} {
-  const { db, dispose } = dbFromEnvForApp(env)
+function buildBetterAuth(env: CloudflareBindings, db: ReturnType<typeof dbFromEnvForApp>["db"]) {
   const cloud = tryGetVoyantCloudClient(env as unknown as Record<string, unknown>)
   const emailFrom = env.EMAIL_FROM || "Voyant <noreply@voyantcloud.app>"
 
-  const auth = createBetterAuth({
+  return createBetterAuth({
     // `db` is a `NeonDatabase` (neon-serverless WebSocket); the
     // `CreateBetterAuthOptions.db` type still references the older
     // `getDb` return union (postgres-js + neon-http). Drizzle's
@@ -123,15 +116,15 @@ function getBetterAuth(env: CloudflareBindings): {
       })
     },
   })
-  return { auth, dispose }
 }
 
 export async function resolveAuthRequest(
   request: Request,
   env: CloudflareBindings,
 ): Promise<VoyantRequestAuthContext | null> {
-  const { auth, dispose } = getBetterAuth(env)
+  const { db, dispose } = dbFromEnvForApp(env)
   try {
+    const auth = buildBetterAuth(env, db)
     const session = await auth.api.getSession({ headers: request.headers })
 
     if (!session) {
@@ -171,57 +164,60 @@ export async function hasAuthPermission(
  * Validates the session cookie directly (no Bearer token needed).
  */
 auth.get("/auth/me", async (c) => {
-  const { auth: betterAuth, dispose } = getBetterAuth(c.env)
-  let session: Awaited<ReturnType<typeof betterAuth.api.getSession>>
+  // The auth sub-app is mounted before the request-scoped `db`
+  // middleware in `createApp` (auth routes are public — no requireAuth
+  // gate), so `c.var.db` is undefined here. Build the per-request Pool
+  // ourselves and use it for both better-auth's session lookup and
+  // the profile query that follows.
+  const { db, dispose } = dbFromEnvForApp(c.env)
   try {
-    session = await betterAuth.api.getSession({ headers: c.req.raw.headers })
+    const betterAuth = buildBetterAuth(c.env, db)
+    const session = await betterAuth.api.getSession({ headers: c.req.raw.headers })
+    if (!session) {
+      return c.json({ error: "Unauthorized" }, 401)
+    }
+
+    const [row] = await db
+      .select({
+        id: authUser.id,
+        email: authUser.email,
+        createdAt: authUser.createdAt,
+        firstName: userProfilesTable.firstName,
+        lastName: userProfilesTable.lastName,
+        locale: userProfilesTable.locale,
+        timezone: userProfilesTable.timezone,
+        uiPrefs: userProfilesTable.uiPrefs,
+        avatarUrl: userProfilesTable.avatarUrl,
+        isSuperAdmin: userProfilesTable.isSuperAdmin,
+        isSupportUser: userProfilesTable.isSupportUser,
+      })
+      .from(authUser)
+      .leftJoin(userProfilesTable, eq(userProfilesTable.id, authUser.id))
+      .where(eq(authUser.id, session.user.id))
+      .limit(1)
+
+    if (!row) {
+      return c.json({ error: "User not found" }, 404)
+    }
+
+    return c.json({
+      id: row.id,
+      email: row.email,
+      firstName: row.firstName ?? null,
+      lastName: row.lastName ?? null,
+      locale: row.locale ?? "en",
+      timezone: row.timezone ?? null,
+      uiPrefs: (row.uiPrefs as Record<string, unknown> | null) ?? null,
+      isSuperAdmin: row.isSuperAdmin ?? false,
+      isSupportUser: row.isSupportUser ?? false,
+      createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
+      profilePictureUrl: row.avatarUrl ?? null,
+    })
   } finally {
     // Schedule dispose AFTER queries settle. waitUntil keeps the
     // worker alive while the WebSocket close handshake completes.
     c.executionCtx.waitUntil(dispose())
   }
-  if (!session) {
-    return c.json({ error: "Unauthorized" }, 401)
-  }
-
-  const db = c.get("db")
-
-  const [row] = await db
-    .select({
-      id: authUser.id,
-      email: authUser.email,
-      createdAt: authUser.createdAt,
-      firstName: userProfilesTable.firstName,
-      lastName: userProfilesTable.lastName,
-      locale: userProfilesTable.locale,
-      timezone: userProfilesTable.timezone,
-      uiPrefs: userProfilesTable.uiPrefs,
-      avatarUrl: userProfilesTable.avatarUrl,
-      isSuperAdmin: userProfilesTable.isSuperAdmin,
-      isSupportUser: userProfilesTable.isSupportUser,
-    })
-    .from(authUser)
-    .leftJoin(userProfilesTable, eq(userProfilesTable.id, authUser.id))
-    .where(eq(authUser.id, session.user.id))
-    .limit(1)
-
-  if (!row) {
-    return c.json({ error: "User not found" }, 404)
-  }
-
-  return c.json({
-    id: row.id,
-    email: row.email,
-    firstName: row.firstName ?? null,
-    lastName: row.lastName ?? null,
-    locale: row.locale ?? "en",
-    timezone: row.timezone ?? null,
-    uiPrefs: (row.uiPrefs as Record<string, unknown> | null) ?? null,
-    isSuperAdmin: row.isSuperAdmin ?? false,
-    isSupportUser: row.isSupportUser ?? false,
-    createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
-    profilePictureUrl: row.avatarUrl ?? null,
-  })
 })
 
 /**
@@ -231,62 +227,63 @@ auth.get("/auth/me", async (c) => {
  * but this route serves as an idempotent fallback.
  */
 auth.get("/auth/status", async (c) => {
-  const { auth: betterAuth, dispose } = getBetterAuth(c.env)
-  let session: Awaited<ReturnType<typeof betterAuth.api.getSession>>
+  // See `/auth/me` above — auth sub-app runs before the request `db`
+  // middleware, so own the Pool here.
+  const { db, dispose } = dbFromEnvForApp(c.env)
   try {
-    session = await betterAuth.api.getSession({ headers: c.req.raw.headers })
-  } finally {
-    c.executionCtx.waitUntil(dispose())
-  }
-  if (!session) {
-    return c.json({ userExists: false, authenticated: false })
-  }
-
-  const userId = session.user.id
-  const db = c.get("db")
-
-  try {
-    const [existingProfile] = await db
-      .select({ id: userProfilesTable.id })
-      .from(userProfilesTable)
-      .where(eq(userProfilesTable.id, userId))
-      .limit(1)
-
-    if (existingProfile) {
-      return c.json({ userExists: true, authenticated: true })
+    const betterAuth = buildBetterAuth(c.env, db)
+    const session = await betterAuth.api.getSession({ headers: c.req.raw.headers })
+    if (!session) {
+      return c.json({ userExists: false, authenticated: false })
     }
 
-    // Profile doesn't exist yet — create from BA user data
-    const [baUser] = await db
-      .select({ name: authUser.name, email: authUser.email, image: authUser.image })
-      .from(authUser)
-      .where(eq(authUser.id, userId))
-      .limit(1)
+    const userId = session.user.id
 
-    if (!baUser?.email) {
+    try {
+      const [existingProfile] = await db
+        .select({ id: userProfilesTable.id })
+        .from(userProfilesTable)
+        .where(eq(userProfilesTable.id, userId))
+        .limit(1)
+
+      if (existingProfile) {
+        return c.json({ userExists: true, authenticated: true })
+      }
+
+      // Profile doesn't exist yet — create from BA user data
+      const [baUser] = await db
+        .select({ name: authUser.name, email: authUser.email, image: authUser.image })
+        .from(authUser)
+        .where(eq(authUser.id, userId))
+        .limit(1)
+
+      if (!baUser?.email) {
+        return c.json(
+          { userExists: false, authenticated: true, reason: `No email found for user ${userId}.` },
+          400,
+        )
+      }
+
+      const nameParts = baUser.name?.split(" ") ?? []
+      const firstName = nameParts[0] ?? null
+      const lastName = nameParts.length > 1 ? nameParts.slice(1).join(" ") : null
+
+      await db
+        .insert(userProfilesTable)
+        .values({ id: userId, firstName, lastName, avatarUrl: baUser.image ?? null })
+        .onConflictDoNothing()
+
+      return c.json({ userExists: true, authenticated: true })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      console.error("[auth/status] Error:", message)
       return c.json(
-        { userExists: false, authenticated: true, reason: `No email found for user ${userId}.` },
-        400,
+        { userExists: false, authenticated: true, reason: `Provisioning error: ${message}` },
+        500,
       )
     }
-
-    const nameParts = baUser.name?.split(" ") ?? []
-    const firstName = nameParts[0] ?? null
-    const lastName = nameParts.length > 1 ? nameParts.slice(1).join(" ") : null
-
-    await db
-      .insert(userProfilesTable)
-      .values({ id: userId, firstName, lastName, avatarUrl: baUser.image ?? null })
-      .onConflictDoNothing()
-
-    return c.json({ userExists: true, authenticated: true })
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    console.error("[auth/status] Error:", message)
-    return c.json(
-      { userExists: false, authenticated: true, reason: `Provisioning error: ${message}` },
-      500,
-    )
+  } finally {
+    c.executionCtx.waitUntil(dispose())
   }
 })
 
@@ -295,9 +292,15 @@ auth.get("/auth/status", async (c) => {
  * Public endpoint — reveals whether any user exists.
  */
 auth.get("/auth/bootstrap-status", async (c) => {
-  const db = c.get("db")
-  const [row] = await db.select({ count: sql<number>`count(*)::int` }).from(authUser)
-  return c.json({ hasUsers: (row?.count ?? 0) > 0 })
+  // See `/auth/me` above — auth sub-app runs before the request `db`
+  // middleware, so own the Pool here.
+  const { db, dispose } = dbFromEnvForApp(c.env)
+  try {
+    const [row] = await db.select({ count: sql<number>`count(*)::int` }).from(authUser)
+    return c.json({ hasUsers: (row?.count ?? 0) > 0 })
+  } finally {
+    c.executionCtx.waitUntil(dispose())
+  }
 })
 
 /**
@@ -305,8 +308,9 @@ auth.get("/auth/bootstrap-status", async (c) => {
  * Sign-up is gated server-side by a `user.create.before` hook in @voyantjs/auth.
  */
 auth.all("/auth/*", async (c) => {
-  const { auth: betterAuth, dispose } = getBetterAuth(c.env)
+  const { db, dispose } = dbFromEnvForApp(c.env)
   try {
+    const betterAuth = buildBetterAuth(c.env, db)
     return await betterAuth.handler(c.req.raw)
   } finally {
     c.executionCtx.waitUntil(dispose())

--- a/templates/dmc/src/api/catalog-bridge.ts
+++ b/templates/dmc/src/api/catalog-bridge.ts
@@ -27,6 +27,7 @@ import {
   createProductDocumentBuilder,
 } from "@voyantjs/products/service-catalog-plane"
 import { and, eq, isNotNull } from "drizzle-orm"
+import type { NeonDatabase } from "drizzle-orm/neon-serverless"
 
 import {
   buildEmbeddingProvider,
@@ -35,7 +36,7 @@ import {
   getFieldPolicyRegistries,
   withEmbedding,
 } from "./lib/catalog-runtime"
-import { getDbFromEnv } from "./lib/db"
+import { withDbFromEnv } from "./lib/db"
 
 interface ProductEventPayload {
   id: string
@@ -59,7 +60,10 @@ export const catalogBridgeBundle: HonoBundle = {
     }
     const sellerOperatorId = env.TENANT_ID ?? "default"
 
-    function buildIndexerContext() {
+    // Compose the indexer service + builder for a given db client. Db
+    // ownership lives at the call site so we can wrap with `withDbFromEnv`
+    // and tear the Pool down before the subscriber returns.
+    function buildIndexerContext(db: NeonDatabase) {
       const embeddings = buildEmbeddingProvider(env)
       const indexer = buildTypesenseIndexer(env, embeddings)
       if (!indexer) return null
@@ -69,7 +73,6 @@ export const catalogBridgeBundle: HonoBundle = {
         slices,
         registries: getFieldPolicyRegistries(),
       })
-      const db = getDbFromEnv(env)
       const builder = withEmbedding(
         createProductDocumentBuilder(db, { sellerOperatorId }),
         embeddings,
@@ -78,59 +81,66 @@ export const catalogBridgeBundle: HonoBundle = {
     }
 
     eventBus.subscribe<ProductEventPayload>("product.created", async ({ data }) => {
-      const ctx = buildIndexerContext()
-      if (!ctx) return
-      await ctx.service.ensureCollections()
-      await ctx.service.reindexEntity("products", data.id, ctx.builder)
+      await withDbFromEnv(env, async (db) => {
+        const ctx = buildIndexerContext(db)
+        if (!ctx) return
+        await ctx.service.ensureCollections()
+        await ctx.service.reindexEntity("products", data.id, ctx.builder)
+      })
     })
 
     eventBus.subscribe<ProductEventPayload>("product.updated", async ({ data }) => {
-      const ctx = buildIndexerContext()
-      if (!ctx) return
-      await ctx.service.reindexEntity("products", data.id, ctx.builder)
+      await withDbFromEnv(env, async (db) => {
+        const ctx = buildIndexerContext(db)
+        if (!ctx) return
+        await ctx.service.reindexEntity("products", data.id, ctx.builder)
+      })
     })
 
     eventBus.subscribe<ProductEventPayload>("product.deleted", async ({ data }) => {
-      const ctx = buildIndexerContext()
-      if (!ctx) return
-      await ctx.service.deleteEntity("products", data.id)
+      await withDbFromEnv(env, async (db) => {
+        const ctx = buildIndexerContext(db)
+        if (!ctx) return
+        await ctx.service.deleteEntity("products", data.id)
+      })
     })
 
     eventBus.subscribe<BookingConfirmedEventPayload>("booking.confirmed", async ({ data }) => {
-      const db = getDbFromEnv(env)
-      // Catalog snapshots use the staff resolver scope — they're an audit
-      // record, not a customer-facing rendering. Booking-time prices /
-      // descriptions stay readable to ops even after audience-scoped
-      // overlays change.
-      const scope = {
-        locale: "en-GB",
-        audience: "staff" as const,
-        market: "default",
-        actor: "staff" as const,
-      }
+      await withDbFromEnv(env, async (db) => {
+        // Catalog snapshots use the staff resolver scope — they're an audit
+        // record, not a customer-facing rendering. Booking-time prices /
+        // descriptions stay readable to ops even after audience-scoped
+        // overlays change.
+        const scope = {
+          locale: "en-GB",
+          audience: "staff" as const,
+          market: "default",
+          actor: "staff" as const,
+        }
 
-      const items = await db
-        .select({ productId: bookingItems.productId })
-        .from(bookingItems)
-        .where(and(eq(bookingItems.bookingId, data.bookingId), isNotNull(bookingItems.productId)))
+        const items = await db
+          .select({ productId: bookingItems.productId })
+          .from(bookingItems)
+          .where(and(eq(bookingItems.bookingId, data.bookingId), isNotNull(bookingItems.productId)))
 
-      const productIds = Array.from(
-        new Set(items.map((i) => i.productId).filter((id): id is string => Boolean(id))),
-      )
-      if (productIds.length === 0) return
+        const productIds = Array.from(
+          new Set(items.map((i) => i.productId).filter((id): id is string => Boolean(id))),
+        )
+        if (productIds.length === 0) return
 
-      const inputs: Array<Omit<CaptureSnapshotInput, "bookingId">> = []
-      for (const productId of productIds) {
-        const input = await buildProductSnapshotInput(db, productId, {
-          sellerOperatorId,
-          scope,
-        })
-        if (input) inputs.push(input)
-      }
+        const inputs: Array<Omit<CaptureSnapshotInput, "bookingId">> = []
+        for (const productId of productIds) {
+          const input = await buildProductSnapshotInput(db, productId, {
+            sellerOperatorId,
+            scope,
+          })
+          if (input) inputs.push(input)
+        }
 
-      if (inputs.length > 0) {
-        await captureSnapshotGraph(db, data.bookingId, inputs)
-      }
+        if (inputs.length > 0) {
+          await captureSnapshotGraph(db, data.bookingId, inputs)
+        }
+      })
     })
   },
 }

--- a/templates/dmc/src/api/invitations.ts
+++ b/templates/dmc/src/api/invitations.ts
@@ -21,17 +21,18 @@ import {
   userInvitationsTable,
   userProfilesTable,
 } from "@voyantjs/db/schema/iam"
+import type { VoyantDb } from "@voyantjs/hono"
 import { hashPassword } from "better-auth/crypto"
 import { and, desc, eq, gt, isNull } from "drizzle-orm"
 import { Hono } from "hono"
 import { z } from "zod"
 
-import { getDbFromEnv } from "./lib/db"
+import { withDbFromEnv } from "./lib/db"
 
 type InvitationsBindings = CloudflareBindings
 type InvitationsVariables = {
   userId?: string
-  db?: unknown
+  db: VoyantDb
 }
 
 const DEFAULT_EXPIRY_HOURS = 72
@@ -75,13 +76,17 @@ function getAppUrl(env: InvitationsBindings): string {
 }
 
 async function assertSuperAdmin(env: InvitationsBindings, userId: string): Promise<boolean> {
-  const db = getDbFromEnv(env)
-  const [row] = await db
-    .select({ isSuperAdmin: userProfilesTable.isSuperAdmin })
-    .from(userProfilesTable)
-    .where(eq(userProfilesTable.id, userId))
-    .limit(1)
-  return !!row?.isSuperAdmin
+  // `withDbFromEnv` owns the per-call Pool — opens, runs the query,
+  // closes in `finally`. Avoids the leak that would happen with a bare
+  // `getDbFromEnv(env)` here (no Hono ctx ⇒ no `c.var.db` to ride on).
+  return withDbFromEnv(env, async (db) => {
+    const [row] = await db
+      .select({ isSuperAdmin: userProfilesTable.isSuperAdmin })
+      .from(userProfilesTable)
+      .where(eq(userProfilesTable.id, userId))
+      .limit(1)
+    return !!row?.isSuperAdmin
+  })
 }
 
 export function createInvitationsRoutes() {
@@ -94,7 +99,7 @@ export function createInvitationsRoutes() {
       return c.json({ error: "Forbidden" }, 403)
     }
 
-    const db = getDbFromEnv(c.env)
+    const db = c.get("db")
     const rows = await db
       .select({
         id: userInvitationsTable.id,
@@ -124,7 +129,7 @@ export function createInvitationsRoutes() {
       return c.json({ error: "Invalid payload", details: parsed.error.issues }, 400)
     }
 
-    const db = getDbFromEnv(c.env)
+    const db = c.get("db")
     const normalizedEmail = parsed.data.email.trim().toLowerCase()
 
     // If this email already has a BA user, block the invite.
@@ -193,7 +198,7 @@ export function createInvitationsRoutes() {
     }
 
     const id = c.req.param("id")
-    const db = getDbFromEnv(c.env)
+    const db = c.get("db")
     await db.delete(userInvitationsTable).where(eq(userInvitationsTable.id, id))
     return c.json({ data: { id } })
   })
@@ -202,7 +207,7 @@ export function createInvitationsRoutes() {
   routes.get("/v1/public/invitations/:token", async (c) => {
     const token = c.req.param("token")
     const tokenHash = await sha256Hex(token)
-    const db = getDbFromEnv(c.env)
+    const db = c.get("db")
 
     const [row] = await db
       .select({
@@ -236,7 +241,7 @@ export function createInvitationsRoutes() {
     }
 
     const tokenHash = await sha256Hex(token)
-    const db = getDbFromEnv(c.env)
+    const db = c.get("db")
     const now = new Date()
 
     const [invite] = await db

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -124,9 +124,14 @@ const notificationsHonoModule = createNotificationsHonoModule({
   // the in-process event bus; errors are logged, not rethrown, so a flaky
   // mailer can't block the confirm request.
   //
-  // `getDbFromEnv` returns either drizzle flavor (postgres-js or
-  // neon-http) depending on env. `resolveDb` accepts the union via
-  // `AnyDrizzleDb`, so no double-cast is needed here.
+  // KNOWN LEAK: `resolveDb` is called per-booking-confirmation by the
+  // module's subscriber and leaks a Neon WebSocket Pool until isolate
+  // teardown (the factory contract is `(bindings) => VoyantDb`, with no
+  // dispose hook). Volume is low (1 per confirmed booking), so this
+  // doesn't move the operational needle today. Fixing it properly
+  // requires widening the module-factory contract in `@voyantjs/bookings`
+  // to accept the `DisposableDb` shape — tracked alongside the rest of
+  // the audit in #510.
   resolveDb: (bindings) => getDbFromEnv(bindings as unknown as CloudflareBindings),
   autoConfirmAndDispatch: {
     enabled: true,
@@ -536,8 +541,9 @@ async function generateContractPdfForBooking(
 }
 
 const legalModule = createLegalHonoModule({
-  // `getDbFromEnv` returns either drizzle flavor; `resolveDb` accepts
-  // the union via `AnyDrizzleDb`, so no double-cast is needed here.
+  // KNOWN LEAK: same shape as the bookings `resolveDb` above — leaks a
+  // Pool per legal-event subscriber call until the module factory's
+  // contract widens to accept `DisposableDb`. Tracked in #510.
   resolveDb: (bindings) => getDbFromEnv(bindings as unknown as CloudflareBindings),
   resolveDocumentDownloadUrl: (bindings, storageKey) =>
     resolveDocumentDownloadUrl(bindings as unknown as CloudflareBindings, storageKey),
@@ -972,7 +978,7 @@ export const app = createApp<CloudflareBindings>({
     // instructions when configured, plus the brand context so the page
     // can render a header. Intentionally minimal — no PII, no secrets.
     hono.get("/v1/public/payment-link-config", async (c) => {
-      const db = getDbFromEnv(c.env) as PostgresJsDatabase
+      const db = c.get("db") as PostgresJsDatabase
       const operatorProfile = await getOperatorSettings(db)
       const bankTransfer = bankTransferDetailsFromOperatorSettings(
         operatorProfile,
@@ -994,7 +1000,7 @@ export const app = createApp<CloudflareBindings>({
     // without checking status first.
     hono.post("/v1/public/payment-link/:sessionId/retry", async (c) => {
       const sessionId = c.req.param("sessionId")
-      const db = getDbFromEnv(c.env)
+      const db = c.get("db")
       const [original] = await db
         .select()
         .from(paymentSessions)
@@ -1039,7 +1045,7 @@ export const app = createApp<CloudflareBindings>({
     hono.get("/v1/public/payment-link/resolve", async (c) => {
       const ref = c.req.query("ref")
       if (!ref) return c.json({ error: "ref query param is required" }, 400)
-      const db = getDbFromEnv(c.env)
+      const db = c.get("db")
       const [session] = await db
         .select({ id: paymentSessions.id })
         .from(paymentSessions)
@@ -1063,7 +1069,7 @@ export const app = createApp<CloudflareBindings>({
     // and returns the new redirect URL.
     hono.post("/v1/public/payment-link/:sessionId/start-card", async (c) => {
       const sessionId = c.req.param("sessionId")
-      const db = getDbFromEnv(c.env)
+      const db = c.get("db")
       // `netopia.startPaymentSession` is typed against postgres-js; cast at
       // the call site since the union with neon-http is structurally
       // compatible for the queries Netopia issues.
@@ -1127,7 +1133,9 @@ export const app = createApp<CloudflareBindings>({
     hono.get("/v1/public/bookings/:bookingId/checkout-status", async (c) => {
       const bookingId = c.req.param("bookingId")
       const ref = c.req.query("session") ?? c.req.query("orderId") ?? c.req.query("ref") ?? null
-      const db = getDbFromEnv(c.env)
+      // Narrow the union to a single drizzle flavor so subsequent `.select`
+      // result types stay specific (avoids `session: any` callback inference).
+      const db = c.get("db") as PostgresJsDatabase
 
       const [booking] = await db
         .select({

--- a/templates/operator/src/api/auth/handler.ts
+++ b/templates/operator/src/api/auth/handler.ts
@@ -67,30 +67,23 @@ function getAuthBaseUrl(env: CloudflareBindings): string {
 }
 
 /**
- * Create a fresh Better Auth instance per request.
+ * Build a Better Auth instance backed by a caller-provided drizzle
+ * client. The caller owns the Pool lifecycle (open before, dispose
+ * after) so the same Pool can serve both the auth lookup and any
+ * subsequent queries the route does — without spinning up a second
+ * connection per request.
  *
- * Cloudflare Workers isolate I/O per request — a DB connection created in
- * one request cannot be reused by another ("Cannot perform I/O on behalf of
- * a different request"). So we must NOT cache the auth instance.
+ * Cloudflare Workers isolate I/O per request — a DB connection created
+ * in one request cannot be reused by another ("Cannot perform I/O on
+ * behalf of a different request"). The auth instance is therefore not
+ * cached either.
  */
-/**
- * Builds a per-call Better Auth instance. Returns the auth object plus
- * a `dispose()` the caller schedules (typically via
- * `c.executionCtx.waitUntil`) after the auth-using work has settled.
- * Without `dispose`, the Pool stays open until isolate teardown — at
- * scale that exhausts Neon's connection budget because every
- * authenticated request opens a fresh WebSocket.
- */
-function getBetterAuth(env: CloudflareBindings): {
-  auth: ReturnType<typeof createBetterAuth>
-  dispose: () => Promise<void>
-} {
-  const { db, dispose } = dbFromEnvForApp(env)
+function buildBetterAuth(env: CloudflareBindings, db: ReturnType<typeof dbFromEnvForApp>["db"]) {
   const cloud = tryGetVoyantCloudClient(env as unknown as Record<string, unknown>)
   const emailFrom = env.EMAIL_FROM || "Voyant <noreply@voyantcloud.app>"
   const emailReplyTo = resolveEmailReplyTo(env)
 
-  const auth = createBetterAuth({
+  return createBetterAuth({
     // `db` is a `NeonDatabase` (neon-serverless WebSocket); the
     // `CreateBetterAuthOptions.db` type still references the older
     // `getDb` return union (postgres-js + neon-http). Drizzle's
@@ -131,15 +124,15 @@ function getBetterAuth(env: CloudflareBindings): {
       })
     },
   })
-  return { auth, dispose }
 }
 
 export async function resolveAuthRequest(
   request: Request,
   env: CloudflareBindings,
 ): Promise<VoyantRequestAuthContext | null> {
-  const { auth, dispose } = getBetterAuth(env)
+  const { db, dispose } = dbFromEnvForApp(env)
   try {
+    const auth = buildBetterAuth(env, db)
     const session = await auth.api.getSession({ headers: request.headers })
 
     if (!session) {
@@ -182,57 +175,60 @@ export async function hasAuthPermission(
  * Validates the session cookie directly (no Bearer token needed).
  */
 auth.get("/auth/me", async (c) => {
-  const { auth: betterAuth, dispose } = getBetterAuth(c.env)
-  let session: Awaited<ReturnType<typeof betterAuth.api.getSession>>
+  // The auth sub-app is mounted before the request-scoped `db`
+  // middleware in `createApp` (auth routes are public — no requireAuth
+  // gate), so `c.var.db` is undefined here. Build the per-request Pool
+  // ourselves and use it for both better-auth's session lookup and
+  // the profile query that follows.
+  const { db, dispose } = dbFromEnvForApp(c.env)
   try {
-    session = await betterAuth.api.getSession({ headers: c.req.raw.headers })
+    const betterAuth = buildBetterAuth(c.env, db)
+    const session = await betterAuth.api.getSession({ headers: c.req.raw.headers })
+    if (!session) {
+      return c.json({ error: "Unauthorized" }, 401)
+    }
+
+    const [row] = await db
+      .select({
+        id: authUser.id,
+        email: authUser.email,
+        createdAt: authUser.createdAt,
+        firstName: userProfilesTable.firstName,
+        lastName: userProfilesTable.lastName,
+        locale: userProfilesTable.locale,
+        timezone: userProfilesTable.timezone,
+        uiPrefs: userProfilesTable.uiPrefs,
+        avatarUrl: userProfilesTable.avatarUrl,
+        isSuperAdmin: userProfilesTable.isSuperAdmin,
+        isSupportUser: userProfilesTable.isSupportUser,
+      })
+      .from(authUser)
+      .leftJoin(userProfilesTable, eq(userProfilesTable.id, authUser.id))
+      .where(eq(authUser.id, session.user.id))
+      .limit(1)
+
+    if (!row) {
+      return c.json({ error: "User not found" }, 404)
+    }
+
+    return c.json({
+      id: row.id,
+      email: row.email,
+      firstName: row.firstName ?? null,
+      lastName: row.lastName ?? null,
+      locale: row.locale ?? "en",
+      timezone: row.timezone ?? null,
+      uiPrefs: (row.uiPrefs as Record<string, unknown> | null) ?? null,
+      isSuperAdmin: row.isSuperAdmin ?? false,
+      isSupportUser: row.isSupportUser ?? false,
+      createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
+      profilePictureUrl: row.avatarUrl ?? null,
+    })
   } finally {
     // Schedule dispose AFTER queries settle. waitUntil keeps the
     // worker alive while the WebSocket close handshake completes.
     c.executionCtx.waitUntil(dispose())
   }
-  if (!session) {
-    return c.json({ error: "Unauthorized" }, 401)
-  }
-
-  const db = c.get("db")
-
-  const [row] = await db
-    .select({
-      id: authUser.id,
-      email: authUser.email,
-      createdAt: authUser.createdAt,
-      firstName: userProfilesTable.firstName,
-      lastName: userProfilesTable.lastName,
-      locale: userProfilesTable.locale,
-      timezone: userProfilesTable.timezone,
-      uiPrefs: userProfilesTable.uiPrefs,
-      avatarUrl: userProfilesTable.avatarUrl,
-      isSuperAdmin: userProfilesTable.isSuperAdmin,
-      isSupportUser: userProfilesTable.isSupportUser,
-    })
-    .from(authUser)
-    .leftJoin(userProfilesTable, eq(userProfilesTable.id, authUser.id))
-    .where(eq(authUser.id, session.user.id))
-    .limit(1)
-
-  if (!row) {
-    return c.json({ error: "User not found" }, 404)
-  }
-
-  return c.json({
-    id: row.id,
-    email: row.email,
-    firstName: row.firstName ?? null,
-    lastName: row.lastName ?? null,
-    locale: row.locale ?? "en",
-    timezone: row.timezone ?? null,
-    uiPrefs: (row.uiPrefs as Record<string, unknown> | null) ?? null,
-    isSuperAdmin: row.isSuperAdmin ?? false,
-    isSupportUser: row.isSupportUser ?? false,
-    createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
-    profilePictureUrl: row.avatarUrl ?? null,
-  })
 })
 
 /**
@@ -242,62 +238,63 @@ auth.get("/auth/me", async (c) => {
  * but this route serves as an idempotent fallback.
  */
 auth.get("/auth/status", async (c) => {
-  const { auth: betterAuth, dispose } = getBetterAuth(c.env)
-  let session: Awaited<ReturnType<typeof betterAuth.api.getSession>>
+  // See `/auth/me` above — auth sub-app runs before the request `db`
+  // middleware, so own the Pool here.
+  const { db, dispose } = dbFromEnvForApp(c.env)
   try {
-    session = await betterAuth.api.getSession({ headers: c.req.raw.headers })
-  } finally {
-    c.executionCtx.waitUntil(dispose())
-  }
-  if (!session) {
-    return c.json({ userExists: false, authenticated: false })
-  }
-
-  const userId = session.user.id
-  const db = c.get("db")
-
-  try {
-    const [existingProfile] = await db
-      .select({ id: userProfilesTable.id })
-      .from(userProfilesTable)
-      .where(eq(userProfilesTable.id, userId))
-      .limit(1)
-
-    if (existingProfile) {
-      return c.json({ userExists: true, authenticated: true })
+    const betterAuth = buildBetterAuth(c.env, db)
+    const session = await betterAuth.api.getSession({ headers: c.req.raw.headers })
+    if (!session) {
+      return c.json({ userExists: false, authenticated: false })
     }
 
-    // Profile doesn't exist yet — create from BA user data
-    const [baUser] = await db
-      .select({ name: authUser.name, email: authUser.email, image: authUser.image })
-      .from(authUser)
-      .where(eq(authUser.id, userId))
-      .limit(1)
+    const userId = session.user.id
 
-    if (!baUser?.email) {
+    try {
+      const [existingProfile] = await db
+        .select({ id: userProfilesTable.id })
+        .from(userProfilesTable)
+        .where(eq(userProfilesTable.id, userId))
+        .limit(1)
+
+      if (existingProfile) {
+        return c.json({ userExists: true, authenticated: true })
+      }
+
+      // Profile doesn't exist yet — create from BA user data
+      const [baUser] = await db
+        .select({ name: authUser.name, email: authUser.email, image: authUser.image })
+        .from(authUser)
+        .where(eq(authUser.id, userId))
+        .limit(1)
+
+      if (!baUser?.email) {
+        return c.json(
+          { userExists: false, authenticated: true, reason: `No email found for user ${userId}.` },
+          400,
+        )
+      }
+
+      const nameParts = baUser.name?.split(" ") ?? []
+      const firstName = nameParts[0] ?? null
+      const lastName = nameParts.length > 1 ? nameParts.slice(1).join(" ") : null
+
+      await db
+        .insert(userProfilesTable)
+        .values({ id: userId, firstName, lastName, avatarUrl: baUser.image ?? null })
+        .onConflictDoNothing()
+
+      return c.json({ userExists: true, authenticated: true })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      console.error("[auth/status] Error:", message)
       return c.json(
-        { userExists: false, authenticated: true, reason: `No email found for user ${userId}.` },
-        400,
+        { userExists: false, authenticated: true, reason: `Provisioning error: ${message}` },
+        500,
       )
     }
-
-    const nameParts = baUser.name?.split(" ") ?? []
-    const firstName = nameParts[0] ?? null
-    const lastName = nameParts.length > 1 ? nameParts.slice(1).join(" ") : null
-
-    await db
-      .insert(userProfilesTable)
-      .values({ id: userId, firstName, lastName, avatarUrl: baUser.image ?? null })
-      .onConflictDoNothing()
-
-    return c.json({ userExists: true, authenticated: true })
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    console.error("[auth/status] Error:", message)
-    return c.json(
-      { userExists: false, authenticated: true, reason: `Provisioning error: ${message}` },
-      500,
-    )
+  } finally {
+    c.executionCtx.waitUntil(dispose())
   }
 })
 
@@ -307,9 +304,15 @@ auth.get("/auth/status", async (c) => {
  * sign-up route loaders to pick the right flow.
  */
 auth.get("/auth/bootstrap-status", async (c) => {
-  const db = c.get("db")
-  const [row] = await db.select({ count: sql<number>`count(*)::int` }).from(authUser)
-  return c.json({ hasUsers: (row?.count ?? 0) > 0 })
+  // See `/auth/me` above — auth sub-app runs before the request `db`
+  // middleware, so own the Pool here.
+  const { db, dispose } = dbFromEnvForApp(c.env)
+  try {
+    const [row] = await db.select({ count: sql<number>`count(*)::int` }).from(authUser)
+    return c.json({ hasUsers: (row?.count ?? 0) > 0 })
+  } finally {
+    c.executionCtx.waitUntil(dispose())
+  }
 })
 
 /**
@@ -320,8 +323,9 @@ auth.get("/auth/bootstrap-status", async (c) => {
  * user exists, the hook throws and BA returns an error to the client.
  */
 auth.all("/auth/*", async (c) => {
-  const { auth: betterAuth, dispose } = getBetterAuth(c.env)
+  const { db, dispose } = dbFromEnvForApp(c.env)
   try {
+    const betterAuth = buildBetterAuth(c.env, db)
     return await betterAuth.handler(c.req.raw)
   } finally {
     c.executionCtx.waitUntil(dispose())

--- a/templates/operator/src/api/auth/handler.ts
+++ b/templates/operator/src/api/auth/handler.ts
@@ -10,14 +10,17 @@
 import { createBetterAuth } from "@voyantjs/auth/server"
 import { tryGetVoyantCloudClient } from "@voyantjs/cloud-sdk"
 import { authUser, userProfilesTable } from "@voyantjs/db/schema/iam"
-import type { VoyantRequestAuthContext } from "@voyantjs/hono"
+import type { VoyantDb, VoyantRequestAuthContext } from "@voyantjs/hono"
 import { eq, sql } from "drizzle-orm"
 import { Hono } from "hono"
 
 import { resolveEmailReplyTo } from "../../lib/notifications"
-import { getDbFromEnv } from "../lib/db"
+import { dbFromEnvForApp } from "../lib/db"
 
-const auth = new Hono<{ Bindings: CloudflareBindings }>()
+// Type ctx so that `c.get("db")` resolves to the parent app's middleware-
+// set `VoyantDb` (the per-request Pool the `dbFromEnvForApp` factory
+// installed). Without this, the sub-app sees `unknown` for context vars.
+const auth = new Hono<{ Bindings: CloudflareBindings; Variables: { db: VoyantDb } }>()
 const DEFAULT_APP_URL = "http://localhost:3300"
 
 function normalizeUrl(url: string): string {
@@ -70,13 +73,24 @@ function getAuthBaseUrl(env: CloudflareBindings): string {
  * one request cannot be reused by another ("Cannot perform I/O on behalf of
  * a different request"). So we must NOT cache the auth instance.
  */
-function getBetterAuth(env: CloudflareBindings) {
-  const db = getDbFromEnv(env)
+/**
+ * Builds a per-call Better Auth instance. Returns the auth object plus
+ * a `dispose()` the caller schedules (typically via
+ * `c.executionCtx.waitUntil`) after the auth-using work has settled.
+ * Without `dispose`, the Pool stays open until isolate teardown — at
+ * scale that exhausts Neon's connection budget because every
+ * authenticated request opens a fresh WebSocket.
+ */
+function getBetterAuth(env: CloudflareBindings): {
+  auth: ReturnType<typeof createBetterAuth>
+  dispose: () => Promise<void>
+} {
+  const { db, dispose } = dbFromEnvForApp(env)
   const cloud = tryGetVoyantCloudClient(env as unknown as Record<string, unknown>)
   const emailFrom = env.EMAIL_FROM || "Voyant <noreply@voyantcloud.app>"
   const emailReplyTo = resolveEmailReplyTo(env)
 
-  return createBetterAuth({
+  const auth = createBetterAuth({
     // `db` is a `NeonDatabase` (neon-serverless WebSocket); the
     // `CreateBetterAuthOptions.db` type still references the older
     // `getDb` return union (postgres-js + neon-http). Drizzle's
@@ -117,26 +131,34 @@ function getBetterAuth(env: CloudflareBindings) {
       })
     },
   })
+  return { auth, dispose }
 }
 
 export async function resolveAuthRequest(
   request: Request,
   env: CloudflareBindings,
 ): Promise<VoyantRequestAuthContext | null> {
-  const betterAuth = getBetterAuth(env)
-  const session = await betterAuth.api.getSession({ headers: request.headers })
+  const { auth, dispose } = getBetterAuth(env)
+  try {
+    const session = await auth.api.getSession({ headers: request.headers })
 
-  if (!session) {
-    return null
-  }
+    if (!session) {
+      return null
+    }
 
-  return {
-    userId: session.user.id,
-    sessionId: session.session.id,
-    organizationId: null,
-    callerType: "session",
-    actor: "staff",
-    email: session.user.email ?? null,
+    return {
+      userId: session.user.id,
+      sessionId: session.session.id,
+      organizationId: null,
+      callerType: "session",
+      actor: "staff",
+      email: session.user.email ?? null,
+    }
+  } finally {
+    // No `executionCtx` reachable here (called from middleware that
+    // doesn't pass one through). Await inline so the WebSocket closes
+    // before this fn returns.
+    await dispose()
   }
 }
 
@@ -160,13 +182,20 @@ export async function hasAuthPermission(
  * Validates the session cookie directly (no Bearer token needed).
  */
 auth.get("/auth/me", async (c) => {
-  const betterAuth = getBetterAuth(c.env)
-  const session = await betterAuth.api.getSession({ headers: c.req.raw.headers })
+  const { auth: betterAuth, dispose } = getBetterAuth(c.env)
+  let session: Awaited<ReturnType<typeof betterAuth.api.getSession>>
+  try {
+    session = await betterAuth.api.getSession({ headers: c.req.raw.headers })
+  } finally {
+    // Schedule dispose AFTER queries settle. waitUntil keeps the
+    // worker alive while the WebSocket close handshake completes.
+    c.executionCtx.waitUntil(dispose())
+  }
   if (!session) {
     return c.json({ error: "Unauthorized" }, 401)
   }
 
-  const db = getDbFromEnv(c.env)
+  const db = c.get("db")
 
   const [row] = await db
     .select({
@@ -213,14 +242,19 @@ auth.get("/auth/me", async (c) => {
  * but this route serves as an idempotent fallback.
  */
 auth.get("/auth/status", async (c) => {
-  const betterAuth = getBetterAuth(c.env)
-  const session = await betterAuth.api.getSession({ headers: c.req.raw.headers })
+  const { auth: betterAuth, dispose } = getBetterAuth(c.env)
+  let session: Awaited<ReturnType<typeof betterAuth.api.getSession>>
+  try {
+    session = await betterAuth.api.getSession({ headers: c.req.raw.headers })
+  } finally {
+    c.executionCtx.waitUntil(dispose())
+  }
   if (!session) {
     return c.json({ userExists: false, authenticated: false })
   }
 
   const userId = session.user.id
-  const db = getDbFromEnv(c.env)
+  const db = c.get("db")
 
   try {
     const [existingProfile] = await db
@@ -273,7 +307,7 @@ auth.get("/auth/status", async (c) => {
  * sign-up route loaders to pick the right flow.
  */
 auth.get("/auth/bootstrap-status", async (c) => {
-  const db = getDbFromEnv(c.env)
+  const db = c.get("db")
   const [row] = await db.select({ count: sql<number>`count(*)::int` }).from(authUser)
   return c.json({ hasUsers: (row?.count ?? 0) > 0 })
 })
@@ -286,9 +320,12 @@ auth.get("/auth/bootstrap-status", async (c) => {
  * user exists, the hook throws and BA returns an error to the client.
  */
 auth.all("/auth/*", async (c) => {
-  const betterAuth = getBetterAuth(c.env)
-  const response = await betterAuth.handler(c.req.raw)
-  return response
+  const { auth: betterAuth, dispose } = getBetterAuth(c.env)
+  try {
+    return await betterAuth.handler(c.req.raw)
+  } finally {
+    c.executionCtx.waitUntil(dispose())
+  }
 })
 
 export default auth

--- a/templates/operator/src/api/catalog-checkout.ts
+++ b/templates/operator/src/api/catalog-checkout.ts
@@ -65,7 +65,7 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context, Hono } from "hono"
 import { z } from "zod"
 
-import { getDbFromEnv } from "./lib/db"
+import { withDbFromEnv } from "./lib/db"
 import { computeBookingItemTaxLine, resolveOperatorSellTaxRate } from "./lib/operator-tax-policy"
 import { getOperatorSettings } from "./settings"
 
@@ -2019,9 +2019,11 @@ export function createCatalogCheckoutBundle(opts: {
       eventBus.subscribe<ContractDocumentGeneratedPayload>(
         "contract.document.generated",
         async ({ data }) => {
-          const db = getDbFromEnv(env) as unknown as PostgresJsDatabase
           try {
-            await persistAcceptanceSignature(db, data.contractId)
+            await withDbFromEnv(env, async (rawDb) => {
+              const db = rawDb as unknown as PostgresJsDatabase
+              await persistAcceptanceSignature(db, data.contractId)
+            })
           } catch (err) {
             console.error("[catalog-checkout] persistAcceptanceSignature failed", err)
           }
@@ -2029,25 +2031,28 @@ export function createCatalogCheckoutBundle(opts: {
       )
       eventBus.subscribe<PaymentCompletedPayload>("payment.completed", async ({ data }) => {
         if (!data.bookingId) return
-        const db = getDbFromEnv(env) as unknown as PostgresJsDatabase
+        const bookingId = data.bookingId
         try {
-          await dispatchCheckoutFinalize({
-            env,
-            db,
-            eventBus,
-            input: {
-              bookingId: data.bookingId,
-              paymentSessionId: data.paymentSessionId,
-              paymentIntent: data.paymentIntent,
-            },
-            trigger: "payment.completed",
-            correlationId: data.paymentSessionId ?? null,
-            tags: [
-              `bookingId:${data.bookingId}`,
-              ...(data.paymentSessionId ? [`paymentSessionId:${data.paymentSessionId}`] : []),
-              ...(data.paymentIntent ? [`paymentIntent:${data.paymentIntent}`] : []),
-            ],
-            generateContractPdf: opts.generateContractPdf,
+          await withDbFromEnv(env, async (rawDb) => {
+            const db = rawDb as unknown as PostgresJsDatabase
+            await dispatchCheckoutFinalize({
+              env,
+              db,
+              eventBus,
+              input: {
+                bookingId,
+                paymentSessionId: data.paymentSessionId,
+                paymentIntent: data.paymentIntent,
+              },
+              trigger: "payment.completed",
+              correlationId: data.paymentSessionId ?? null,
+              tags: [
+                `bookingId:${bookingId}`,
+                ...(data.paymentSessionId ? [`paymentSessionId:${data.paymentSessionId}`] : []),
+                ...(data.paymentIntent ? [`paymentIntent:${data.paymentIntent}`] : []),
+              ],
+              generateContractPdf: opts.generateContractPdf,
+            })
           })
         } catch {
           // dispatchCheckoutFinalize already logged + recorded the
@@ -2063,43 +2068,47 @@ export function createCatalogCheckoutBundle(opts: {
           description:
             "Confirms the booking and issues the final invoice. A fresh rerun re-issues the invoice (collides on existing INV- numbers); use Resume to retry from a failed step.",
           rerun: async (rawInput, ctx) => {
-            const db = getDbFromEnv(env) as unknown as PostgresJsDatabase
             const input = rawInput as CheckoutFinalizeInput | null
             if (!input?.bookingId) {
               throw new Error("checkout-finalize rerun: recorded input has no bookingId")
             }
-            return dispatchCheckoutFinalize({
-              env,
-              db,
-              eventBus,
-              input,
-              trigger: "manual.rerun",
-              correlationId: ctx.correlationId,
-              tags: [...ctx.tags, "rerun:true"],
-              parentRunId: ctx.parentRunId,
-              triggeredByUserId: ctx.triggeredByUserId,
-              generateContractPdf: opts.generateContractPdf,
+            return withDbFromEnv(env, async (rawDb) => {
+              const db = rawDb as unknown as PostgresJsDatabase
+              return dispatchCheckoutFinalize({
+                env,
+                db,
+                eventBus,
+                input,
+                trigger: "manual.rerun",
+                correlationId: ctx.correlationId,
+                tags: [...ctx.tags, "rerun:true"],
+                parentRunId: ctx.parentRunId,
+                triggeredByUserId: ctx.triggeredByUserId,
+                generateContractPdf: opts.generateContractPdf,
+              })
             })
           },
           resume: async (rawInput, ctx) => {
-            const db = getDbFromEnv(env) as unknown as PostgresJsDatabase
             const input = rawInput as CheckoutFinalizeInput | null
             if (!input?.bookingId) {
               throw new Error("checkout-finalize resume: recorded input has no bookingId")
             }
-            return dispatchCheckoutFinalize({
-              env,
-              db,
-              eventBus,
-              input,
-              trigger: "manual.resume",
-              correlationId: ctx.correlationId,
-              tags: [...ctx.tags, "resume:true"],
-              parentRunId: ctx.parentRunId,
-              triggeredByUserId: ctx.triggeredByUserId,
-              resumeFromStep: ctx.resumeFromStep,
-              seedResults: ctx.seedResults,
-              generateContractPdf: opts.generateContractPdf,
+            return withDbFromEnv(env, async (rawDb) => {
+              const db = rawDb as unknown as PostgresJsDatabase
+              return dispatchCheckoutFinalize({
+                env,
+                db,
+                eventBus,
+                input,
+                trigger: "manual.resume",
+                correlationId: ctx.correlationId,
+                tags: [...ctx.tags, "resume:true"],
+                parentRunId: ctx.parentRunId,
+                triggeredByUserId: ctx.triggeredByUserId,
+                resumeFromStep: ctx.resumeFromStep,
+                seedResults: ctx.seedResults,
+                generateContractPdf: opts.generateContractPdf,
+              })
             })
           },
         })

--- a/templates/operator/src/api/channel-push-scheduled.ts
+++ b/templates/operator/src/api/channel-push-scheduled.ts
@@ -21,7 +21,7 @@ import {
 } from "@voyantjs/distribution/channel-push"
 
 import { type BookingEngineEnv, getBookingEngineRegistry } from "./lib/booking-engine-runtime"
-import { getDbFromEnv } from "./lib/db"
+import { withDbFromEnv } from "./lib/db"
 
 const BOOKING_LINK_CRON = "*/15 * * * *"
 const AVAILABILITY_CRON = "0 * * * *"
@@ -31,35 +31,37 @@ export async function runScheduledChannelPushReconciler(
   event: ScheduledController,
   env: CloudflareBindings & BookingEngineEnv,
 ): Promise<void> {
-  const deps = {
-    db: getDbFromEnv(env),
-    registry: getBookingEngineRegistry(env),
-  }
+  // `withDbFromEnv` owns the per-tick Pool — the WebSocket closes when
+  // this scheduled run finishes, instead of leaking until isolate
+  // teardown.
+  await withDbFromEnv(env, async (db) => {
+    const deps = { db, registry: getBookingEngineRegistry(env) }
 
-  try {
-    switch (event.cron) {
-      case BOOKING_LINK_CRON: {
-        const result = await reconcileBookingLinks({}, deps)
-        console.info("[channel-push] reconcileBookingLinks", result)
-        return
+    try {
+      switch (event.cron) {
+        case BOOKING_LINK_CRON: {
+          const result = await reconcileBookingLinks({}, deps)
+          console.info("[channel-push] reconcileBookingLinks", result)
+          return
+        }
+        case AVAILABILITY_CRON: {
+          const result = await reconcileAvailability({}, deps)
+          console.info("[channel-push] reconcileAvailability", result)
+          return
+        }
+        case CONTENT_CRON: {
+          const result = await reconcileContent({}, deps)
+          console.info("[channel-push] reconcileContent", result)
+          return
+        }
+        default:
+          console.warn("[channel-push] unknown cron expression", { cron: event.cron })
       }
-      case AVAILABILITY_CRON: {
-        const result = await reconcileAvailability({}, deps)
-        console.info("[channel-push] reconcileAvailability", result)
-        return
-      }
-      case CONTENT_CRON: {
-        const result = await reconcileContent({}, deps)
-        console.info("[channel-push] reconcileContent", result)
-        return
-      }
-      default:
-        console.warn("[channel-push] unknown cron expression", { cron: event.cron })
+    } catch (err) {
+      console.error("[channel-push] reconciler failed", {
+        cron: event.cron,
+        error: err instanceof Error ? err.message : String(err),
+      })
     }
-  } catch (err) {
-    console.error("[channel-push] reconciler failed", {
-      cron: event.cron,
-      error: err instanceof Error ? err.message : String(err),
-    })
-  }
+  })
 }

--- a/templates/operator/src/api/channel-push.ts
+++ b/templates/operator/src/api/channel-push.ts
@@ -31,11 +31,13 @@ import {
   upsertContentIntent,
   upsertPendingBookingLinks,
 } from "@voyantjs/distribution/channel-push"
+import type { VoyantDb } from "@voyantjs/hono"
 import type { HonoBundle } from "@voyantjs/hono/plugin"
+import type { NeonDatabase } from "drizzle-orm/neon-serverless"
 import type { Hono } from "hono"
 
 import { type BookingEngineEnv, getBookingEngineRegistry } from "./lib/booking-engine-runtime"
-import { getDbFromEnv } from "./lib/db"
+import { withDbFromEnv } from "./lib/db"
 
 interface BookingConfirmedPayload {
   bookingId: string
@@ -64,20 +66,22 @@ export const channelPushBundle: HonoBundle = {
     const env = bindings as CloudflareBindings & BookingEngineEnv
     const registry = getBookingEngineRegistry(env)
 
-    function buildDeps() {
-      return {
-        db: getDbFromEnv(env),
-        registry,
-      }
+    // Build deps from a per-call db client. Each subscriber wraps with
+    // `withDbFromEnv` and feeds the db in here so the Pool is owned for
+    // the duration of the subscriber call.
+    function buildDeps(db: NeonDatabase) {
+      return { db, registry }
     }
 
     eventBus.subscribe<BookingConfirmedPayload>("booking.confirmed", async ({ data }) => {
       try {
-        const deps = buildDeps()
-        const targets = await resolveBookingPushTargets(deps.db, data.bookingId)
-        if (targets.length === 0) return
-        await upsertPendingBookingLinks(deps.db, data.bookingId, targets)
-        await processBookingPush({ bookingId: data.bookingId }, deps)
+        await withDbFromEnv(env, async (db) => {
+          const deps = buildDeps(db)
+          const targets = await resolveBookingPushTargets(deps.db, data.bookingId)
+          if (targets.length === 0) return
+          await upsertPendingBookingLinks(deps.db, data.bookingId, targets)
+          await processBookingPush({ bookingId: data.bookingId }, deps)
+        })
       } catch (err) {
         console.error("[channel-push] booking.confirmed failed", {
           bookingId: data.bookingId,
@@ -90,33 +94,35 @@ export const channelPushBundle: HonoBundle = {
       "availability.slot.changed",
       async ({ data }) => {
         try {
-          const deps = buildDeps()
-          const targets = await resolveAllotmentTargetsForSlot(deps.db, {
-            slotId: data.slotId,
-            productId: data.productId,
-            optionId: data.optionId,
-          })
-          if (targets.length === 0) return
-
-          const startsAt = data.startsAt instanceof Date ? data.startsAt : new Date(data.startsAt)
-          for (const target of targets) {
-            await upsertAvailabilityIntent(deps.db, {
-              channelId: target.channelId,
-              sourceConnectionId: target.sourceConnectionId,
+          await withDbFromEnv(env, async (db) => {
+            const deps = buildDeps(db)
+            const targets = await resolveAllotmentTargetsForSlot(deps.db, {
               slotId: data.slotId,
               productId: data.productId,
               optionId: data.optionId,
-              startsAt,
             })
-          }
+            if (targets.length === 0) return
 
-          // Drain per-channel inline — the inline path keeps latency
-          // bounded for dev / single-isolate deployments. Production
-          // deployments with the workflow runtime wired skip this and
-          // let the scheduled `channel.availability.push` workflow drain.
-          for (const target of targets) {
-            await processAvailabilityPushIntents({ channelId: target.channelId, limit: 50 }, deps)
-          }
+            const startsAt = data.startsAt instanceof Date ? data.startsAt : new Date(data.startsAt)
+            for (const target of targets) {
+              await upsertAvailabilityIntent(deps.db, {
+                channelId: target.channelId,
+                sourceConnectionId: target.sourceConnectionId,
+                slotId: data.slotId,
+                productId: data.productId,
+                optionId: data.optionId,
+                startsAt,
+              })
+            }
+
+            // Drain per-channel inline — the inline path keeps latency
+            // bounded for dev / single-isolate deployments. Production
+            // deployments with the workflow runtime wired skip this and
+            // let the scheduled `channel.availability.push` workflow drain.
+            for (const target of targets) {
+              await processAvailabilityPushIntents({ channelId: target.channelId, limit: 50 }, deps)
+            }
+          })
         } catch (err) {
           console.error("[channel-push] availability.slot.changed failed", {
             slotId: data.slotId,
@@ -130,21 +136,23 @@ export const channelPushBundle: HonoBundle = {
       "product.content.changed",
       async ({ data }) => {
         try {
-          const deps = buildDeps()
-          const targets = await resolveContentPushTargets(deps.db, data.id)
-          if (targets.length === 0) return
+          await withDbFromEnv(env, async (db) => {
+            const deps = buildDeps(db)
+            const targets = await resolveContentPushTargets(deps.db, data.id)
+            if (targets.length === 0) return
 
-          for (const target of targets) {
-            await upsertContentIntent(deps.db, {
-              channelId: target.channelId,
-              sourceConnectionId: target.sourceConnectionId,
-              productId: data.id,
-            })
-          }
+            for (const target of targets) {
+              await upsertContentIntent(deps.db, {
+                channelId: target.channelId,
+                sourceConnectionId: target.sourceConnectionId,
+                productId: data.id,
+              })
+            }
 
-          for (const target of targets) {
-            await processContentPushIntents({ channelId: target.channelId, limit: 50 }, deps)
-          }
+            for (const target of targets) {
+              await processContentPushIntents({ channelId: target.channelId, limit: 50 }, deps)
+            }
+          })
         } catch (err) {
           console.error("[channel-push] product.content.changed failed", {
             productId: data.id,
@@ -168,11 +176,15 @@ export const channelPushBundle: HonoBundle = {
  *
  * Per docs/architecture/channel-push-architecture.md §9 + §14.5.
  */
-export function mountChannelPushAdminRoutes(hono: Hono): void {
+export function mountChannelPushAdminRoutes(hono: Hono<{ Variables: { db: VoyantDb } }>): void {
   hono.use("/v1/admin/distribution/channel-push/*", async (c, next) => {
     const env = c.env as CloudflareBindings & BookingEngineEnv
+    // Use the request-scoped Pool the `dbFromEnvForApp` middleware
+    // installs on `c.var.db`. The disposable middleware closes it
+    // after the response is sent, so we don't have to manage Pool
+    // lifecycle here.
     setChannelPushDeps({
-      db: getDbFromEnv(env),
+      db: c.get("db") as NeonDatabase,
       registry: getBookingEngineRegistry(env),
     })
     await next()

--- a/templates/operator/src/api/draft-reaper-scheduled.ts
+++ b/templates/operator/src/api/draft-reaper-scheduled.ts
@@ -30,7 +30,7 @@ import {
   getBookingEngineRegistry,
   getOwnedBookingHandlerRegistry,
 } from "./lib/booking-engine-runtime"
-import { getDbFromEnv } from "./lib/db"
+import { withDbFromEnv } from "./lib/db"
 
 export const DRAFT_REAPER_CRON = "5 * * * *"
 
@@ -48,61 +48,65 @@ export async function runScheduledDraftReaper(
   _event: ScheduledController,
   env: CloudflareBindings & BookingEngineEnv,
 ): Promise<ReaperResult> {
-  const db = getDbFromEnv(env)
   const registry = getBookingEngineRegistry(env)
   const ownedHandlers = getOwnedBookingHandlerRegistry(env)
 
-  const expired = await findExpiredDrafts(db)
-  let released = 0
-  let releaseErrors = 0
-  let deleted = 0
-  let inGrace = 0
+  // `withDbFromEnv` owns the per-tick Pool — the WebSocket closes when
+  // this scheduled run finishes, instead of leaking until isolate
+  // teardown.
+  return withDbFromEnv(env, async (db) => {
+    const expired = await findExpiredDrafts(db)
+    let released = 0
+    let releaseErrors = 0
+    let deleted = 0
+    let inGrace = 0
 
-  const now = Date.now()
-  for (const draft of expired) {
-    // Per-vertical grace period — defer release for graceMs past
-    // the draft's expiry. Per booking-journey-architecture §12.9.
-    const grace = resolveGraceMs(draft, ownedHandlers, registry)
-    if (grace > 0) {
-      const effectiveExpiry = new Date(draft.expires_at).getTime() + grace
-      if (now < effectiveExpiry) {
-        // Still inside the grace window — leave the draft alone.
-        // The next reaper tick will revisit it.
-        inGrace++
-        continue
+    const now = Date.now()
+    for (const draft of expired) {
+      // Per-vertical grace period — defer release for graceMs past
+      // the draft's expiry. Per booking-journey-architecture §12.9.
+      const grace = resolveGraceMs(draft, ownedHandlers, registry)
+      if (grace > 0) {
+        const effectiveExpiry = new Date(draft.expires_at).getTime() + grace
+        if (now < effectiveExpiry) {
+          // Still inside the grace window — leave the draft alone.
+          // The next reaper tick will revisit it.
+          inGrace++
+          continue
+        }
       }
-    }
 
-    if (draft.hold_expires_at) {
+      if (draft.hold_expires_at) {
+        try {
+          await releaseHold({
+            db,
+            draft,
+            ownedHandlers,
+            registry,
+          })
+          released++
+        } catch (err) {
+          releaseErrors++
+          console.warn("[draft-reaper] failed to release hold", {
+            draftId: draft.id,
+            reason: err instanceof Error ? err.message : String(err),
+          })
+        }
+      }
+
       try {
-        await releaseHold({
-          db,
-          draft,
-          ownedHandlers,
-          registry,
-        })
-        released++
+        await deleteBookingDraft(db, draft.id)
+        deleted++
       } catch (err) {
-        releaseErrors++
-        console.warn("[draft-reaper] failed to release hold", {
+        console.warn("[draft-reaper] failed to delete draft", {
           draftId: draft.id,
           reason: err instanceof Error ? err.message : String(err),
         })
       }
     }
 
-    try {
-      await deleteBookingDraft(db, draft.id)
-      deleted++
-    } catch (err) {
-      console.warn("[draft-reaper] failed to delete draft", {
-        draftId: draft.id,
-        reason: err instanceof Error ? err.message : String(err),
-      })
-    }
-  }
-
-  return { scanned: expired.length, released, releaseErrors, deleted, inGrace }
+    return { scanned: expired.length, released, releaseErrors, deleted, inGrace }
+  })
 }
 
 /**

--- a/templates/operator/src/api/invitations.ts
+++ b/templates/operator/src/api/invitations.ts
@@ -21,18 +21,19 @@ import {
   userInvitationsTable,
   userProfilesTable,
 } from "@voyantjs/db/schema/iam"
+import type { VoyantDb } from "@voyantjs/hono"
 import { hashPassword } from "better-auth/crypto"
 import { and, desc, eq, gt, isNull } from "drizzle-orm"
 import { Hono } from "hono"
 import { z } from "zod"
 
 import { resolveEmailReplyTo } from "../lib/notifications"
-import { getDbFromEnv } from "./lib/db"
+import { withDbFromEnv } from "./lib/db"
 
 type InvitationsBindings = CloudflareBindings
 type InvitationsVariables = {
   userId?: string
-  db?: unknown
+  db: VoyantDb
 }
 
 const DEFAULT_EXPIRY_HOURS = 72
@@ -76,13 +77,17 @@ function getAppUrl(env: InvitationsBindings): string {
 }
 
 async function assertSuperAdmin(env: InvitationsBindings, userId: string): Promise<boolean> {
-  const db = getDbFromEnv(env)
-  const [row] = await db
-    .select({ isSuperAdmin: userProfilesTable.isSuperAdmin })
-    .from(userProfilesTable)
-    .where(eq(userProfilesTable.id, userId))
-    .limit(1)
-  return !!row?.isSuperAdmin
+  // `withDbFromEnv` owns the per-call Pool — opens, runs the query,
+  // closes in `finally`. Avoids the leak that would happen with a bare
+  // `getDbFromEnv(env)` here (no Hono ctx ⇒ no `c.var.db` to ride on).
+  return withDbFromEnv(env, async (db) => {
+    const [row] = await db
+      .select({ isSuperAdmin: userProfilesTable.isSuperAdmin })
+      .from(userProfilesTable)
+      .where(eq(userProfilesTable.id, userId))
+      .limit(1)
+    return !!row?.isSuperAdmin
+  })
 }
 
 export function createInvitationsRoutes() {
@@ -95,7 +100,7 @@ export function createInvitationsRoutes() {
       return c.json({ error: "Forbidden" }, 403)
     }
 
-    const db = getDbFromEnv(c.env)
+    const db = c.get("db")
     const rows = await db
       .select({
         id: userInvitationsTable.id,
@@ -125,7 +130,7 @@ export function createInvitationsRoutes() {
       return c.json({ error: "Invalid payload", details: parsed.error.issues }, 400)
     }
 
-    const db = getDbFromEnv(c.env)
+    const db = c.get("db")
     const normalizedEmail = parsed.data.email.trim().toLowerCase()
 
     // If this email already has a BA user, block the invite.
@@ -196,7 +201,7 @@ export function createInvitationsRoutes() {
     }
 
     const id = c.req.param("id")
-    const db = getDbFromEnv(c.env)
+    const db = c.get("db")
     await db.delete(userInvitationsTable).where(eq(userInvitationsTable.id, id))
     return c.json({ data: { id } })
   })
@@ -205,7 +210,7 @@ export function createInvitationsRoutes() {
   routes.get("/v1/public/invitations/:token", async (c) => {
     const token = c.req.param("token")
     const tokenHash = await sha256Hex(token)
-    const db = getDbFromEnv(c.env)
+    const db = c.get("db")
 
     const [row] = await db
       .select({
@@ -239,7 +244,7 @@ export function createInvitationsRoutes() {
     }
 
     const tokenHash = await sha256Hex(token)
-    const db = getDbFromEnv(c.env)
+    const db = c.get("db")
     const now = new Date()
 
     const [invite] = await db

--- a/templates/operator/src/api/lib/booking-engine-runtime.ts
+++ b/templates/operator/src/api/lib/booking-engine-runtime.ts
@@ -54,7 +54,7 @@ import { and, asc, eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
 
-import { getDbFromEnv } from "./db"
+import { withDbFromEnv } from "./db"
 import { resolveOperatorSellTaxRate } from "./operator-tax-policy"
 
 let _registry: SourceAdapterRegistry | undefined
@@ -93,40 +93,46 @@ export function getOwnedBookingHandlerRegistry(env: BookingEngineEnv): OwnedBook
       createProductsBookingHandler({
         holds: {
           async place(input) {
-            const db = getDbFromEnv(env as Parameters<typeof getDbFromEnv>[0]) as PostgresJsDatabase
-            const result = await placeAvailabilityHold(db, input)
-            if (result.status === "ok") {
-              return {
-                status: "ok",
-                holdToken: result.hold.holdToken,
-                expiresAt: result.hold.expiresAt,
+            return withDbFromEnv(env as Parameters<typeof withDbFromEnv>[0], async (rawDb) => {
+              const db = rawDb as unknown as PostgresJsDatabase
+              const result = await placeAvailabilityHold(db, input)
+              if (result.status === "ok") {
+                return {
+                  status: "ok",
+                  holdToken: result.hold.holdToken,
+                  expiresAt: result.hold.expiresAt,
+                }
               }
-            }
-            if (result.status === "slot_unlimited") {
-              return {
-                status: "ok",
-                holdToken: result.holdToken,
-                expiresAt: result.expiresAt,
+              if (result.status === "slot_unlimited") {
+                return {
+                  status: "ok",
+                  holdToken: result.holdToken,
+                  expiresAt: result.expiresAt,
+                }
               }
-            }
-            if (result.status === "slot_not_found") {
-              return { status: "slot_not_found" }
-            }
-            return {
-              status: "insufficient_capacity",
-              remaining: result.remaining,
-              needed: result.needed,
-            }
+              if (result.status === "slot_not_found") {
+                return { status: "slot_not_found" }
+              }
+              return {
+                status: "insufficient_capacity",
+                remaining: result.remaining,
+                needed: result.needed,
+              }
+            })
           },
           async extend(input) {
-            const db = getDbFromEnv(env as Parameters<typeof getDbFromEnv>[0]) as PostgresJsDatabase
-            const result = await extendAvailabilityHold(db, input)
-            if (result.status === "ok") return { status: "ok", expiresAt: result.expiresAt }
-            return { status: "not_found" }
+            return withDbFromEnv(env as Parameters<typeof withDbFromEnv>[0], async (rawDb) => {
+              const db = rawDb as unknown as PostgresJsDatabase
+              const result = await extendAvailabilityHold(db, input)
+              if (result.status === "ok") return { status: "ok", expiresAt: result.expiresAt }
+              return { status: "not_found" }
+            })
           },
           async release(holdToken) {
-            const db = getDbFromEnv(env as Parameters<typeof getDbFromEnv>[0]) as PostgresJsDatabase
-            await releaseAvailabilityHold(db, holdToken)
+            await withDbFromEnv(env as Parameters<typeof withDbFromEnv>[0], async (rawDb) => {
+              const db = rawDb as unknown as PostgresJsDatabase
+              await releaseAvailabilityHold(db, holdToken)
+            })
           },
         },
         // Bridge into bookingsQuickCreate. The handler builds the
@@ -134,27 +140,25 @@ export function getOwnedBookingHandlerRegistry(env: BookingEngineEnv): OwnedBook
         // env is captured by the closure so the bridge can resolve
         // the per-request DB lazily.
         async quickCreate(input, opts) {
-          // `getDbFromEnv` returns the union AnyDrizzleDb (postgres-js |
-          // neon-http). `quickCreateBooking`'s signature still asks for
-          // postgres-js, so we force-narrow here. After #500 the runtime
-          // is neon-http on Workers; the cast is a TS-suppress, not a
-          // runtime guarantee. If `quickCreateBooking` reaches for
-          // postgres-js-only APIs (real PG transactions, advisory
-          // locks) under the neon-http instance it will surface at
-          // runtime — at which point the right fix is to widen the
-          // service signature to AnyDrizzleDb, not reintroduce
-          // Hyperdrive.
-          const db = getDbFromEnv(env as Parameters<typeof getDbFromEnv>[0]) as PostgresJsDatabase
-          const outcome = await quickCreateBooking(db, input, opts)
-          if (outcome.status === "ok") {
-            await persistQuickCreateTaxLines(db, outcome.result.booking.id, input.taxLines)
-            return {
-              status: "ok",
-              bookingId: outcome.result.booking.id,
-              bookingNumber: outcome.result.booking.bookingNumber,
+          // `withDbFromEnv` owns the per-call Pool — opens, runs the
+          // commit, closes in `finally`. `quickCreateBooking`'s
+          // signature still asks for postgres-js; force-cast here since
+          // the runtime is neon-serverless on Workers and the drizzle
+          // PgDatabase surface is identical across flavors for the
+          // ops we use.
+          return withDbFromEnv(env as Parameters<typeof withDbFromEnv>[0], async (rawDb) => {
+            const db = rawDb as unknown as PostgresJsDatabase
+            const outcome = await quickCreateBooking(db, input, opts)
+            if (outcome.status === "ok") {
+              await persistQuickCreateTaxLines(db, outcome.result.booking.id, input.taxLines)
+              return {
+                status: "ok",
+                bookingId: outcome.result.booking.id,
+                bookingNumber: outcome.result.booking.bookingNumber,
+              }
             }
-          }
-          return { status: outcome.status }
+            return { status: outcome.status }
+          })
         },
         async loadTravelerFields(ctx, productId) {
           // Project booking-requirements rows into the engine's
@@ -322,51 +326,54 @@ export function getOwnedBookingHandlerRegistry(env: BookingEngineEnv): OwnedBook
         },
         async commitBridge(input, opts) {
           // The handler validates `ratePlanId` upstream — defensive
-          // double-check here would be redundant.
-          const db = getDbFromEnv(env as Parameters<typeof getDbFromEnv>[0]) as PostgresJsDatabase
-          try {
-            const outcome = await hospitalityBookingsService.createStayBooking(
-              db,
-              {
-                propertyId: input.propertyId,
-                roomTypeId: input.roomTypeId,
-                ratePlanId: input.ratePlanId,
-                mealPlanId: input.mealPlanId,
-                checkInDate: input.checkInDate,
-                checkOutDate: input.checkOutDate,
-                roomCount: input.roomCount,
-                adults: input.adults,
-                children: input.children,
-                infants: input.infants,
-                dailyRates: input.dailyRates,
-                personId: input.personId,
-                organizationId: input.organizationId,
-                contact: {
-                  firstName: input.contact.firstName,
-                  lastName: input.contact.lastName,
-                  email: input.contact.email,
-                  phone: input.contact.phone,
-                  country: input.contact.country,
+          // double-check here would be redundant. `withDbFromEnv` owns
+          // the per-call Pool.
+          return withDbFromEnv(env as Parameters<typeof withDbFromEnv>[0], async (rawDb) => {
+            const db = rawDb as unknown as PostgresJsDatabase
+            try {
+              const outcome = await hospitalityBookingsService.createStayBooking(
+                db,
+                {
+                  propertyId: input.propertyId,
+                  roomTypeId: input.roomTypeId,
+                  ratePlanId: input.ratePlanId,
+                  mealPlanId: input.mealPlanId,
+                  checkInDate: input.checkInDate,
+                  checkOutDate: input.checkOutDate,
+                  roomCount: input.roomCount,
+                  adults: input.adults,
+                  children: input.children,
+                  infants: input.infants,
+                  dailyRates: input.dailyRates,
+                  personId: input.personId,
+                  organizationId: input.organizationId,
+                  contact: {
+                    firstName: input.contact.firstName,
+                    lastName: input.contact.lastName,
+                    email: input.contact.email,
+                    phone: input.contact.phone,
+                    country: input.contact.country,
+                  },
+                  passengers: input.passengers,
+                  notes: input.notes,
                 },
-                passengers: input.passengers,
-                notes: input.notes,
-              },
-              opts?.userId,
-            )
-            if (outcome.status === "ok") {
+                opts?.userId,
+              )
+              if (outcome.status === "ok") {
+                return {
+                  status: "ok",
+                  bookingId: outcome.result.bookingId,
+                  bookingNumber: outcome.result.bookingNumber,
+                }
+              }
+              return { status: "failed", reason: `hospitality_${outcome.status}` }
+            } catch (err) {
               return {
-                status: "ok",
-                bookingId: outcome.result.bookingId,
-                bookingNumber: outcome.result.bookingNumber,
+                status: "failed",
+                reason: err instanceof Error ? err.message : String(err),
               }
             }
-            return { status: "failed", reason: `hospitality_${outcome.status}` }
-          } catch (err) {
-            return {
-              status: "failed",
-              reason: err instanceof Error ? err.message : String(err),
-            }
-          }
+          })
         },
       }),
     )
@@ -411,79 +418,81 @@ export function getOwnedBookingHandlerRegistry(env: BookingEngineEnv): OwnedBook
           }
         },
         async commitBridge(input, opts) {
-          const db = getDbFromEnv(env as Parameters<typeof getDbFromEnv>[0]) as PostgresJsDatabase
-          try {
-            const result = await cruisesBookingService.createCruiseBooking(
-              db,
-              {
-                sailingId: input.sailingId,
-                cabinCategoryId: input.cabinCategoryId,
-                cabinId: input.cabinId,
-                occupancy: input.occupancy,
-                fareCode: input.fareCode,
-                personId: input.personId,
-                organizationId: input.organizationId,
-                contact: input.contact,
-                passengers: input.passengers,
-                airArrangement: input.airArrangement,
-                notes: input.notes,
-              },
-              opts?.userId,
-            )
-
-            // Cruise installments (per booking-journey-architecture
-            // §7): deposit at book + balance due 90 days before
-            // sail. The handler echoes the pricing total via the
-            // bridge input's pricing context — for now we read it
-            // off the quote stored in cruise_details (the cruise
-            // service already snapshotted it). When the journey
-            // surfaces explicit installment overrides, they flow
-            // through `input.installments` (TBD).
-            const totalCents = priceCentsFromString(result.cruiseDetails.quotedTotalForCabin)
-            if (totalCents > 0) {
-              const depositCents = Math.round(totalCents * 0.25)
-              const balanceCents = totalCents - depositCents
-              const today = new Date()
-              const sailDate = result.cruiseDetails.sailingId
-                ? // TODO: resolve sail date from sailings table when wired
-                  // — until then balance defaults to today + 60d.
-                  null
-                : null
-              const balanceDue = sailDate ?? new Date(today.getTime() + 60 * 24 * 60 * 60 * 1000)
-              const depositDue = today
-              await db.insert(bookingPaymentSchedules).values([
+          return withDbFromEnv(env as Parameters<typeof withDbFromEnv>[0], async (rawDb) => {
+            const db = rawDb as unknown as PostgresJsDatabase
+            try {
+              const result = await cruisesBookingService.createCruiseBooking(
+                db,
                 {
-                  bookingId: result.bookingId,
-                  scheduleType: "deposit",
-                  status: "due",
-                  dueDate: depositDue.toISOString().slice(0, 10),
-                  currency: result.cruiseDetails.quotedCurrency,
-                  amountCents: depositCents,
-                  notes: "Deposit at booking (per cruise journey §7)",
+                  sailingId: input.sailingId,
+                  cabinCategoryId: input.cabinCategoryId,
+                  cabinId: input.cabinId,
+                  occupancy: input.occupancy,
+                  fareCode: input.fareCode,
+                  personId: input.personId,
+                  organizationId: input.organizationId,
+                  contact: input.contact,
+                  passengers: input.passengers,
+                  airArrangement: input.airArrangement,
+                  notes: input.notes,
                 },
-                {
-                  bookingId: result.bookingId,
-                  scheduleType: "balance",
-                  status: "pending",
-                  dueDate: balanceDue.toISOString().slice(0, 10),
-                  currency: result.cruiseDetails.quotedCurrency,
-                  amountCents: balanceCents,
-                  notes: "Balance due before sail",
-                },
-              ])
-            }
+                opts?.userId,
+              )
 
-            return {
-              status: "ok",
-              bookingId: result.bookingId,
-              bookingNumber: result.bookingNumber,
+              // Cruise installments (per booking-journey-architecture
+              // §7): deposit at book + balance due 90 days before
+              // sail. The handler echoes the pricing total via the
+              // bridge input's pricing context — for now we read it
+              // off the quote stored in cruise_details (the cruise
+              // service already snapshotted it). When the journey
+              // surfaces explicit installment overrides, they flow
+              // through `input.installments` (TBD).
+              const totalCents = priceCentsFromString(result.cruiseDetails.quotedTotalForCabin)
+              if (totalCents > 0) {
+                const depositCents = Math.round(totalCents * 0.25)
+                const balanceCents = totalCents - depositCents
+                const today = new Date()
+                const sailDate = result.cruiseDetails.sailingId
+                  ? // TODO: resolve sail date from sailings table when wired
+                    // — until then balance defaults to today + 60d.
+                    null
+                  : null
+                const balanceDue = sailDate ?? new Date(today.getTime() + 60 * 24 * 60 * 60 * 1000)
+                const depositDue = today
+                await db.insert(bookingPaymentSchedules).values([
+                  {
+                    bookingId: result.bookingId,
+                    scheduleType: "deposit",
+                    status: "due",
+                    dueDate: depositDue.toISOString().slice(0, 10),
+                    currency: result.cruiseDetails.quotedCurrency,
+                    amountCents: depositCents,
+                    notes: "Deposit at booking (per cruise journey §7)",
+                  },
+                  {
+                    bookingId: result.bookingId,
+                    scheduleType: "balance",
+                    status: "pending",
+                    dueDate: balanceDue.toISOString().slice(0, 10),
+                    currency: result.cruiseDetails.quotedCurrency,
+                    amountCents: balanceCents,
+                    notes: "Balance due before sail",
+                  },
+                ])
+              }
+
+              return {
+                status: "ok",
+                bookingId: result.bookingId,
+                bookingNumber: result.bookingNumber,
+              }
+            } catch (err) {
+              return {
+                status: "failed",
+                reason: err instanceof Error ? err.message : String(err),
+              }
             }
-          } catch (err) {
-            return {
-              status: "failed",
-              reason: err instanceof Error ? err.message : String(err),
-            }
-          }
+          })
         },
       }),
     )


### PR DESCRIPTION
## Summary

Closes #510 (mostly). After #500/#511 switched the templates' Workers DB layer from Hyperdrive to the Neon serverless WebSocket driver and shipped two helpers (\`getDbFromEnv\` + \`withDbFromEnv\` + \`dbFromEnvForApp\`), several call sites were still calling \`getDbFromEnv(env)\` without lifecycle management — each leaked a Neon WebSocket connection until isolate teardown. This PR audits and converts every one of those sites in both templates.

## Phase breakdown

**Phase 1** — Hono route handlers (28+ sites): switch from \`getDbFromEnv(c.env)\` → \`c.get(\"db\")\` so they ride on the request-scoped Pool the \`dbFromEnvForApp\` middleware installs and disposes via \`executionCtx.waitUntil\` after the response.

**Phase 2** — helper functions:
- \`assertSuperAdmin\` (× 2) wraps the query in \`withDbFromEnv\` (open → query → close).
- \`getBetterAuth\` (× 2) returns \`{ auth, dispose }\`; every caller schedules \`dispose()\` via \`executionCtx.waitUntil\` (or awaits inline when no \`executionCtx\` is reachable, e.g. in \`resolveAuthRequest\` from middleware).
- \`runScheduledDraftReaper\` wraps its tick body in \`withDbFromEnv\`.

**Phase 3** — event-bus subscribers + scheduled handlers (~10 sites): dmc/catalog-bridge subscribers (× 4), operator/channel-push subscribers (× 3), \`channel-push-scheduled\` tick, catalog-checkout subscribers + workflow runners (× 4) — all wrapped in \`withDbFromEnv\`. The \`mountChannelPushAdminRoutes\` middleware reads \`c.var.db\` instead of building a fresh Pool.

**Phase 4** — booking-engine-runtime closures (6 sites): products holds (\`place\`, \`extend\`, \`release\`) + \`quickCreate\`, plus hospitality and cruises \`commitBridge\` — each wraps its query/commit in \`withDbFromEnv\`.

## Sub-app typing fixes that fell out of phase 1

- \`auth/handler.ts\` Hono sub-apps (both templates) and \`InvitationsVariables\` now declare \`db: VoyantDb\` so \`c.get(\"db\")\` is properly typed under those sub-apps' contexts.
- \`mountChannelPushAdminRoutes\` widened its \`hono\` parameter type for the same reason.

## Deliberately deferred

Two \`app.ts:resolveDb\` callbacks passed to \`createBookingsHonoModule\` and \`createLegalHonoModule\` still leak a Pool per subscriber call. The module-factory contract is \`(bindings) => VoyantDb\` with no dispose hook; widening it to accept \`DisposableDb\` is a separate shared-package change. Volume is low (one Pool per booking-confirmed / legal-event subscriber call), so this isn't moving the operational needle today. Both sites have \`KNOWN LEAK\` comments and **#510 stays open** to track the contract widening for the eventual fix — closing this PR drops the easy wins (the other ~30 sites) without blocking on the bigger shared-package change.

## Test plan

- [x] Operator template typecheck (8GB heap) — clean.
- [x] DMC template typecheck (8GB heap) — clean.
- [x] \`pnpm -F @voyantjs/hono test\` — all 52 tests pass.
- [ ] CI for both templates.
- [ ] Manual smoke: hit \`/auth/me\` and \`/v1/admin/invitations\` to exercise both helper-pattern (\`getBetterAuth\` returning \`{ auth, dispose }\`) and route-handler-pattern (\`c.get(\"db\")\`) paths; observe Neon connection count after a burst doesn't accumulate.

No behavior change for HTTP API contracts. No schema migration. Pure lifecycle / Pool-management cleanup.