### PR TITLE
feat(workflows): trigger.on() runtime + DSLs + manifest builder + event router (#514 PR2 of 4)

### DIFF
--- a/packages/workflows-orchestrator-node/src/node-standalone-driver.ts
+++ b/packages/workflows-orchestrator-node/src/node-standalone-driver.ts
@@ -29,6 +29,7 @@ import type {
   DriverFactoryDeps,
   IngestEventArgs,
   IngestEventResponse,
+  IngestMatch,
   WorkflowAdmin,
   WorkflowDriver,
 } from "@voyantjs/workflows/driver"
@@ -38,6 +39,7 @@ import {
   cancel as orchestratorCancel,
   trigger as orchestratorTrigger,
   type RunRecord,
+  routeEvent,
   type StepHandler,
 } from "@voyantjs/workflows-orchestrator"
 import type { drizzle } from "drizzle-orm/node-postgres"
@@ -185,11 +187,72 @@ export function createNodeStandaloneDriver(opts: NodeStandaloneDriverOptions): D
         }
       }
       const eventId = ensureEventId(args.envelope, now)
-      // Filter matching arrives in PR2 (the event-router). Mode 2 returns
-      // the no-matches response when there are no filters or until the
-      // predicate evaluator + input mapper land.
-      void stored
-      return { ok: true, eventId, matches: [] }
+      const manifest = stored.manifest as unknown as WorkflowManifest
+      const routed = routeEvent({
+        manifest,
+        envelope: args.envelope,
+        eventId,
+        idempotencyOverride: args.idempotencyKey,
+      })
+
+      const matches: IngestMatch[] = []
+      let anyTriggered = false
+      let anyFailed = false
+      for (const entry of routed) {
+        if (entry.status === "skipped") {
+          matches.push({
+            filterId: entry.filterId,
+            status: "skipped",
+            reason: entry.reason,
+            details: entry.details,
+          })
+          continue
+        }
+        try {
+          const record = await orchestratorTrigger(
+            {
+              workflowId: entry.targetWorkflowId,
+              workflowVersion: "v1",
+              input: entry.input,
+              tenantMeta,
+              environment: args.environment,
+              idempotencyKey: entry.idempotencyKey,
+              triggeredBy: {
+                kind: "event",
+                eventId,
+                eventType: args.envelope.name,
+                filterId: entry.filterId,
+              },
+            },
+            { store: runStore, handler, now },
+          )
+          matches.push({
+            filterId: entry.filterId,
+            targetWorkflowId: entry.targetWorkflowId,
+            runId: record.id,
+            idempotencyKey: entry.idempotencyKey,
+            status: "queued",
+          })
+          anyTriggered = true
+        } catch (err) {
+          matches.push({
+            filterId: entry.filterId,
+            targetWorkflowId: entry.targetWorkflowId,
+            status: "error",
+            reason: err instanceof Error ? err.message : String(err),
+          })
+          anyFailed = true
+        }
+      }
+
+      if (matches.length > 0 && !anyTriggered && anyFailed) {
+        return {
+          ok: false,
+          reason: "trigger_failed_for_all_matches",
+          message: "every matched filter failed to trigger",
+        }
+      }
+      return { ok: true, eventId, matches }
     }
 
     async function shutdown(): Promise<void> {

--- a/packages/workflows-orchestrator/src/__tests__/event-router.test.ts
+++ b/packages/workflows-orchestrator/src/__tests__/event-router.test.ts
@@ -1,0 +1,178 @@
+import type { WorkflowManifest } from "@voyantjs/workflows/protocol"
+import { describe, expect, test } from "vitest"
+
+import { routeEvent } from "../event-router.js"
+
+function makeManifest(filters: WorkflowManifest["eventFilters"]): WorkflowManifest {
+  return {
+    schemaVersion: 1,
+    projectId: "default",
+    versionId: "v_test",
+    builtAt: 1_700_000_000_000,
+    builderVersion: "test",
+    capabilities: ["events:v1"],
+    workflows: [],
+    eventFilters: filters,
+    bindings: {},
+    environments: { production: {}, preview: {}, development: {} },
+  }
+}
+
+const ENV = {
+  name: "promotion.changed",
+  data: { affected: { kind: "all" }, offerId: "pofr_01" },
+  metadata: { tenantId: "default", eventId: "evt_01" },
+  emittedAt: "2026-05-09T13:22:08.000Z",
+}
+
+describe("routeEvent", () => {
+  test("filters by eventType", () => {
+    const manifest = makeManifest([
+      { id: "ef_a", eventType: "promotion.changed", payloadHash: "h", targetWorkflowId: "wf-a" },
+      { id: "ef_b", eventType: "other.event", payloadHash: "h", targetWorkflowId: "wf-b" },
+    ])
+    const matches = routeEvent({ manifest, envelope: ENV, eventId: "evt_01" })
+    expect(matches).toHaveLength(1)
+    expect(matches[0]).toMatchObject({ filterId: "ef_a", status: "matched" })
+  })
+
+  test("evaluates where predicate", () => {
+    const manifest = makeManifest([
+      {
+        id: "ef_match",
+        eventType: "promotion.changed",
+        where: { eq: [{ path: "data.affected.kind" }, { lit: "all" }] },
+        payloadHash: "h",
+        targetWorkflowId: "wf",
+      },
+      {
+        id: "ef_nomatch",
+        eventType: "promotion.changed",
+        where: { eq: [{ path: "data.affected.kind" }, { lit: "products" }] },
+        payloadHash: "h",
+        targetWorkflowId: "wf",
+      },
+    ])
+    const matches = routeEvent({ manifest, envelope: ENV, eventId: "evt_01" })
+    expect(matches.map((m) => m.filterId)).toEqual(["ef_match"])
+  })
+
+  test("applies input mapper", () => {
+    const manifest = makeManifest([
+      {
+        id: "ef_mapped",
+        eventType: "promotion.changed",
+        input: {
+          object: {
+            sellerOperatorId: { path: "metadata.tenantId" },
+            offerId: { path: "data.offerId" },
+          },
+        },
+        payloadHash: "h",
+        targetWorkflowId: "wf",
+      },
+    ])
+    const matches = routeEvent({ manifest, envelope: ENV, eventId: "evt_01" })
+    expect(matches).toHaveLength(1)
+    const m = matches[0]
+    if (m?.status !== "matched") throw new Error("expected matched")
+    expect(m.input).toEqual({ sellerOperatorId: "default", offerId: "pofr_01" })
+  })
+
+  test("undefined input maps to envelope.data", () => {
+    const manifest = makeManifest([
+      {
+        id: "ef_passthrough",
+        eventType: "promotion.changed",
+        payloadHash: "h",
+        targetWorkflowId: "wf",
+      },
+    ])
+    const matches = routeEvent({ manifest, envelope: ENV, eventId: "evt_01" })
+    const m = matches[0]
+    if (m?.status !== "matched") throw new Error("expected matched")
+    expect(m.input).toEqual(ENV.data)
+  })
+
+  test("derives idempotencyKey from filterId + eventId", () => {
+    const manifest = makeManifest([
+      { id: "ef_x", eventType: "promotion.changed", payloadHash: "h", targetWorkflowId: "wf" },
+    ])
+    const matches = routeEvent({ manifest, envelope: ENV, eventId: "evt_xyz" })
+    const m = matches[0]
+    if (m?.status !== "matched") throw new Error("expected matched")
+    expect(m.idempotencyKey).toBe("ef_x:evt_xyz")
+  })
+
+  test("idempotencyOverride supersedes eventId", () => {
+    const manifest = makeManifest([
+      { id: "ef_x", eventType: "promotion.changed", payloadHash: "h", targetWorkflowId: "wf" },
+    ])
+    const matches = routeEvent({
+      manifest,
+      envelope: ENV,
+      eventId: "evt_xyz",
+      idempotencyOverride: "supplied",
+    })
+    const m = matches[0]
+    if (m?.status !== "matched") throw new Error("expected matched")
+    expect(m.idempotencyKey).toBe("ef_x:supplied")
+  })
+
+  test("multiple filters can match same envelope", () => {
+    const manifest = makeManifest([
+      { id: "ef_a", eventType: "promotion.changed", payloadHash: "h", targetWorkflowId: "wf-a" },
+      { id: "ef_b", eventType: "promotion.changed", payloadHash: "h", targetWorkflowId: "wf-b" },
+    ])
+    const matches = routeEvent({ manifest, envelope: ENV, eventId: "evt_01" })
+    expect(matches.map((m) => m.filterId)).toEqual(["ef_a", "ef_b"])
+  })
+
+  test("isolates predicate eval errors per filter", () => {
+    const manifest = makeManifest([
+      {
+        id: "ef_bad",
+        eventType: "promotion.changed",
+        where: { wat: ["x"] } as never,
+        payloadHash: "h",
+        targetWorkflowId: "wf",
+      },
+      {
+        id: "ef_ok",
+        eventType: "promotion.changed",
+        where: { eq: [{ path: "data.affected.kind" }, { lit: "all" }] },
+        payloadHash: "h",
+        targetWorkflowId: "wf",
+      },
+    ])
+    const matches = routeEvent({ manifest, envelope: ENV, eventId: "evt_01" })
+    const skipped = matches.find((m) => m.filterId === "ef_bad")
+    const matched = matches.find((m) => m.filterId === "ef_ok")
+    expect(skipped?.status).toBe("skipped")
+    expect(matched?.status).toBe("matched")
+  })
+
+  test("isolates input projection errors per filter", () => {
+    const manifest = makeManifest([
+      {
+        id: "ef_bad_input",
+        eventType: "promotion.changed",
+        input: { wat: 1 } as never,
+        payloadHash: "h",
+        targetWorkflowId: "wf",
+      },
+      {
+        id: "ef_ok",
+        eventType: "promotion.changed",
+        payloadHash: "h",
+        targetWorkflowId: "wf",
+      },
+    ])
+    const matches = routeEvent({ manifest, envelope: ENV, eventId: "evt_01" })
+    const skipped = matches.find((m) => m.filterId === "ef_bad_input")
+    expect(skipped?.status).toBe("skipped")
+    if (skipped?.status === "skipped") {
+      expect(skipped.reason).toBe("input_projection_error")
+    }
+  })
+})

--- a/packages/workflows-orchestrator/src/driver-inmemory.ts
+++ b/packages/workflows-orchestrator/src/driver-inmemory.ts
@@ -24,6 +24,7 @@ import {
   type DriverFactoryDeps,
   type IngestEventArgs,
   type IngestEventResponse,
+  type IngestMatch,
   ManifestNotRegisteredError,
   type WorkflowAdmin,
   type WorkflowDriver,
@@ -31,6 +32,7 @@ import {
 import { handleStepRequest, type WorkflowStepRequest } from "@voyantjs/workflows/handler"
 import type { WorkflowManifest } from "@voyantjs/workflows/protocol"
 
+import { routeEvent } from "./event-router.js"
 import { createInMemoryRunStore } from "./in-memory-store.js"
 import { cancel as orchestratorCancel, trigger as orchestratorTrigger } from "./orchestrator.js"
 import type { RunRecord, StepHandler } from "./types.js"
@@ -142,14 +144,73 @@ export function createInMemoryDriver(opts: InMemoryDriverOptions = {}): DriverFa
         }
       }
       const eventId = ensureEventId(args.envelope, now)
-      // Filter matching arrives in PR2 (the event-router).
-      // PR1 ships ingestEvent that validates the manifest is registered and
-      // returns the no-matches response when there are no filters or when the
-      // event router hasn't been wired yet.
-      // Matching against `stored.manifest.eventFilters[]` will replace this
-      // body once the predicate evaluator + input mapper land.
-      void stored
-      return { ok: true, eventId, matches: [] }
+      const routed = routeEvent({
+        manifest: stored.manifest,
+        envelope: args.envelope,
+        eventId,
+        idempotencyOverride: args.idempotencyKey,
+      })
+
+      const matches: IngestMatch[] = []
+      let anyTriggered = false
+      let anyFailed = false
+      for (const entry of routed) {
+        if (entry.status === "skipped") {
+          matches.push({
+            filterId: entry.filterId,
+            status: "skipped",
+            reason: entry.reason,
+            details: entry.details,
+          })
+          continue
+        }
+        try {
+          const record = await orchestratorTrigger(
+            {
+              workflowId: entry.targetWorkflowId,
+              workflowVersion: "v1",
+              input: entry.input,
+              tenantMeta,
+              environment: args.environment,
+              idempotencyKey: entry.idempotencyKey,
+              triggeredBy: {
+                kind: "event",
+                eventId,
+                eventType: args.envelope.name,
+                filterId: entry.filterId,
+              },
+            },
+            { store, handler, now },
+          )
+          matches.push({
+            filterId: entry.filterId,
+            targetWorkflowId: entry.targetWorkflowId,
+            runId: record.id,
+            idempotencyKey: entry.idempotencyKey,
+            status: "queued",
+          })
+          anyTriggered = true
+        } catch (err) {
+          matches.push({
+            filterId: entry.filterId,
+            targetWorkflowId: entry.targetWorkflowId,
+            status: "error",
+            reason: err instanceof Error ? err.message : String(err),
+          })
+          anyFailed = true
+        }
+      }
+
+      // Drivers return ok:true if at least one match queued; ok:false only if
+      // every match errored (per architecture doc §15.5).
+      if (matches.length > 0 && !anyTriggered && anyFailed) {
+        return {
+          ok: false,
+          reason: "trigger_failed_for_all_matches",
+          message: "every matched filter failed to trigger",
+        }
+      }
+      return { ok: true, eventId, matches }
     }
 
     async function shutdown(): Promise<void> {

--- a/packages/workflows-orchestrator/src/event-router.ts
+++ b/packages/workflows-orchestrator/src/event-router.ts
@@ -1,0 +1,120 @@
+// Pure event router — given a manifest and an envelope, decide which
+// filters match and produce the per-match descriptors drivers feed into
+// `trigger()`.
+//
+// Drivers (InMemory, Mode 2 / Postgres, Mode 1 / CF edge) wrap this in
+// their own `ingestEvent` impl: they fetch the manifest from their store,
+// call `routeEvent(...)`, then invoke `trigger()` per match.
+//
+// Architecture: docs/architecture/workflows-runtime-architecture.md §15.
+
+import {
+  evaluatePredicate,
+  type InputMapper,
+  type PredicateEnvelope,
+  type PredicateExpr,
+  projectInput,
+} from "@voyantjs/workflows/events"
+import type { WorkflowManifest } from "@voyantjs/workflows/protocol"
+
+// ---- Public types ----
+
+/**
+ * Outcome of routing a single envelope through every filter in a manifest.
+ * Each match describes exactly enough for a driver to call `trigger()`:
+ *   - `targetWorkflowId` and `input` are the trigger args.
+ *   - `idempotencyKey` derives from `${filterId}:${eventId}` so retries of
+ *     the same envelope produce a stable run regardless of which driver
+ *     applies the trigger.
+ */
+export type RouterMatch =
+  | {
+      filterId: string
+      targetWorkflowId: string
+      input: unknown
+      idempotencyKey: string
+      status: "matched"
+    }
+  | {
+      filterId: string
+      status: "skipped"
+      reason: "where_eval_error" | "input_projection_error"
+      details?: string
+    }
+
+export interface RouteEventArgs {
+  manifest: WorkflowManifest
+  envelope: PredicateEnvelope
+  /**
+   * Stable id for the envelope. Drivers derive this from
+   * `metadata.eventId` (when set) or fall back to a content hash; passing
+   * it in keeps the router pure.
+   */
+  eventId: string
+  /**
+   * Optional caller-supplied idempotency override (per
+   * `IngestEventArgs.idempotencyKey`). When set, the per-match key
+   * becomes `${filterId}:${suppliedKey}` instead of
+   * `${filterId}:${eventId}`.
+   */
+  idempotencyOverride?: string
+}
+
+// ---- Public API ----
+
+/**
+ * Route an envelope through a manifest. Pure: no IO, no side effects.
+ * Returns one entry per filter that targets the envelope's eventType, in
+ * the order they appear in `manifest.eventFilters` (which is itself
+ * id-sorted from `buildManifest`).
+ *
+ * `where` evaluation errors and `input` projection errors are isolated to
+ * the offending filter — other filters still produce matches. Drivers
+ * surface skips as `IngestMatch.status === "skipped"` in the response.
+ */
+export function routeEvent(args: RouteEventArgs): RouterMatch[] {
+  const out: RouterMatch[] = []
+  for (const filter of args.manifest.eventFilters) {
+    if (filter.eventType !== args.envelope.name) continue
+
+    // Predicate gate.
+    if (filter.where !== undefined) {
+      try {
+        const matched = evaluatePredicate(filter.where as PredicateExpr, args.envelope)
+        if (!matched) continue
+      } catch (err) {
+        out.push({
+          filterId: filter.id,
+          status: "skipped",
+          reason: "where_eval_error",
+          details: err instanceof Error ? err.message : String(err),
+        })
+        continue
+      }
+    }
+
+    // Input projection.
+    let input: unknown
+    try {
+      input = projectInput(filter.input as InputMapper, args.envelope)
+    } catch (err) {
+      out.push({
+        filterId: filter.id,
+        status: "skipped",
+        reason: "input_projection_error",
+        details: err instanceof Error ? err.message : String(err),
+      })
+      continue
+    }
+
+    const baseKey = args.idempotencyOverride ?? args.eventId
+    out.push({
+      filterId: filter.id,
+      targetWorkflowId: filter.targetWorkflowId,
+      input,
+      idempotencyKey: `${filter.id}:${baseKey}`,
+      status: "matched",
+    })
+  }
+  return out
+}

--- a/packages/workflows-orchestrator/src/index.ts
+++ b/packages/workflows-orchestrator/src/index.ts
@@ -20,6 +20,11 @@ export {
   type InMemoryDriverOptions,
 } from "./driver-inmemory.js"
 export {
+  type RouteEventArgs,
+  type RouterMatch,
+  routeEvent,
+} from "./event-router.js"
+export {
   createHttpStepHandler,
   type HttpStepHandlerDeps,
   type HttpStepTarget,

--- a/packages/workflows-orchestrator/src/testing/driver-compliance.ts
+++ b/packages/workflows-orchestrator/src/testing/driver-compliance.ts
@@ -251,6 +251,188 @@ export function runDriverComplianceSuite(name: string, makeFactory: () => Driver
           expect(result.eventId).toMatch(/^evt_/)
         }
       })
+
+      test("matches a where predicate and triggers a run", async () => {
+        const driver = makeFactory()(testFactoryDeps())
+        const wfId = uniqueId("compliance-ingest-match")
+        const wf = workflow<unknown, void>({
+          id: wfId,
+          async run() {},
+        })
+        const filterId = `ef_${uniqueId("ef")}`
+        const manifest: WorkflowManifest = {
+          ...buildTestManifest(uniqueId("v_match")),
+          eventFilters: [
+            {
+              id: filterId,
+              eventType: "promotion.changed",
+              where: { eq: [{ path: "data.kind" }, { lit: "all" }] },
+              payloadHash: filterId,
+              targetWorkflowId: wfId,
+            },
+          ],
+        }
+        await driver.registerManifest({ environment: "production", manifest })
+
+        const result = await driver.ingestEvent({
+          environment: "production",
+          envelope: {
+            name: "promotion.changed",
+            data: { kind: "all" },
+            metadata: { eventId: `evt_${uniqueId("match")}` },
+            emittedAt: new Date(1_700_000_000_000).toISOString(),
+          },
+        })
+        expect(result.ok).toBe(true)
+        if (!result.ok) return
+        expect(result.matches).toHaveLength(1)
+        const m = result.matches[0]
+        expect(m?.status).toBe("queued")
+        if (m?.status === "queued") {
+          expect(m.filterId).toBe(filterId)
+          expect(m.targetWorkflowId).toBe(wfId)
+          const detail = await driver.admin?.getRun?.(m.runId)
+          expect(detail?.workflowId).toBe(wfId)
+        }
+        void wf
+      })
+
+      test("predicate failure on one filter doesn't block another", async () => {
+        const driver = makeFactory()(testFactoryDeps())
+        const wfId = uniqueId("compliance-ingest-mixed")
+        const wf = workflow<unknown, void>({
+          id: wfId,
+          async run() {},
+        })
+        const goodId = `ef_${uniqueId("ok")}`
+        const manifest: WorkflowManifest = {
+          ...buildTestManifest(uniqueId("v_mixed")),
+          eventFilters: [
+            {
+              id: `ef_${uniqueId("bad")}`,
+              eventType: "evt.x",
+              where: { wat: "huh" } as unknown as never,
+              payloadHash: "h",
+              targetWorkflowId: wfId,
+            },
+            {
+              id: goodId,
+              eventType: "evt.x",
+              where: { eq: [{ path: "data.k" }, { lit: "v" }] },
+              payloadHash: "h",
+              targetWorkflowId: wfId,
+            },
+          ],
+        }
+        await driver.registerManifest({ environment: "production", manifest })
+
+        const result = await driver.ingestEvent({
+          environment: "production",
+          envelope: {
+            name: "evt.x",
+            data: { k: "v" },
+            metadata: { eventId: `evt_${uniqueId("mixed")}` },
+            emittedAt: new Date(1_700_000_000_000).toISOString(),
+          },
+        })
+        expect(result.ok).toBe(true)
+        if (!result.ok) return
+        const skipped = result.matches.find((m) => m.status === "skipped")
+        const queued = result.matches.find((m) => m.status === "queued")
+        expect(skipped?.status).toBe("skipped")
+        if (skipped?.status === "skipped") {
+          expect(skipped.reason).toBe("where_eval_error")
+        }
+        expect(queued?.status).toBe("queued")
+        void wf
+      })
+
+      test("input mapper projects correctly through to the workflow", async () => {
+        const driver = makeFactory()(testFactoryDeps())
+        const wfId = uniqueId("compliance-ingest-input")
+        const wf = workflow<{ kind: string; offer: string }, { kind: string; offer: string }>({
+          id: wfId,
+          async run(input) {
+            return input
+          },
+        })
+        const filterId = `ef_${uniqueId("ef-input")}`
+        const manifest: WorkflowManifest = {
+          ...buildTestManifest(uniqueId("v_input")),
+          eventFilters: [
+            {
+              id: filterId,
+              eventType: "promotion.changed",
+              input: {
+                object: {
+                  kind: { path: "data.affected.kind" },
+                  offer: { path: "data.offerId" },
+                },
+              },
+              payloadHash: filterId,
+              targetWorkflowId: wfId,
+            },
+          ],
+        }
+        await driver.registerManifest({ environment: "production", manifest })
+
+        const result = await driver.ingestEvent({
+          environment: "production",
+          envelope: {
+            name: "promotion.changed",
+            data: { affected: { kind: "all" }, offerId: "pofr_42" },
+            metadata: { eventId: `evt_${uniqueId("input")}` },
+            emittedAt: new Date(1_700_000_000_000).toISOString(),
+          },
+        })
+        expect(result.ok).toBe(true)
+        if (!result.ok) return
+        const m = result.matches[0]
+        if (m?.status !== "queued") throw new Error("expected queued match")
+        const detail = await driver.admin?.getRun?.(m.runId)
+        expect(detail?.output).toEqual({ kind: "all", offer: "pofr_42" })
+        void wf
+      })
+
+      test("metadata.eventId dedupes across retries (same event → same run)", async () => {
+        const driver = makeFactory()(testFactoryDeps())
+        const wfId = uniqueId("compliance-ingest-dedup")
+        const wf = workflow<unknown, void>({
+          id: wfId,
+          async run() {},
+        })
+        const filterId = `ef_${uniqueId("ef-dedup")}`
+        const manifest: WorkflowManifest = {
+          ...buildTestManifest(uniqueId("v_dedup")),
+          eventFilters: [
+            {
+              id: filterId,
+              eventType: "evt.dedup",
+              payloadHash: filterId,
+              targetWorkflowId: wfId,
+            },
+          ],
+        }
+        await driver.registerManifest({ environment: "production", manifest })
+
+        const sharedEventId = `evt_${uniqueId("shared")}`
+        const envelope = {
+          name: "evt.dedup",
+          data: {},
+          metadata: { eventId: sharedEventId },
+          emittedAt: new Date(1_700_000_000_000).toISOString(),
+        }
+        const a = await driver.ingestEvent({ environment: "production", envelope })
+        const b = await driver.ingestEvent({ environment: "production", envelope })
+        if (!a.ok || !b.ok) throw new Error("expected ok=true")
+        const ma = a.matches[0]
+        const mb = b.matches[0]
+        if (ma?.status !== "queued" || mb?.status !== "queued") {
+          throw new Error("expected queued matches")
+        }
+        expect(mb.runId).toBe(ma.runId)
+        void wf
+      })
     })
 
     describe("admin (when implemented)", () => {

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -38,6 +38,10 @@
     "./driver": {
       "types": "./src/driver.ts",
       "import": "./src/driver.ts"
+    },
+    "./events": {
+      "types": "./src/events/index.ts",
+      "import": "./src/events/index.ts"
     }
   },
   "main": "./dist/index.js",
@@ -106,6 +110,10 @@
       "./driver": {
         "types": "./dist/driver.d.ts",
         "import": "./dist/driver.js"
+      },
+      "./events": {
+        "types": "./dist/events/index.d.ts",
+        "import": "./dist/events/index.js"
       }
     },
     "main": "./dist/index.js",

--- a/packages/workflows/src/events/__tests__/input-mapper.test.ts
+++ b/packages/workflows/src/events/__tests__/input-mapper.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "vitest"
+
+import { type InputMapper, projectInput, validateInputMapper } from "../input-mapper.js"
+import type { PredicateEnvelope } from "../predicate.js"
+
+const ENV: PredicateEnvelope = {
+  name: "promotion.changed",
+  data: {
+    affected: { kind: "all", productIds: ["p1", "p2"] },
+    offerId: "pofr_01",
+    discountPct: 20,
+  },
+  metadata: {
+    tenantId: "default",
+    eventId: "evt_01",
+  },
+  emittedAt: "2026-05-09T13:22:08.000Z",
+}
+
+// ---- projectInput ----
+
+describe("projectInput — pass-through variants", () => {
+  test("undefined → envelope.data", () => {
+    expect(projectInput(undefined, ENV)).toEqual(ENV.data)
+  })
+
+  test("{ passthrough: true } → envelope.data", () => {
+    expect(projectInput({ passthrough: true }, ENV)).toEqual(ENV.data)
+  })
+})
+
+describe("projectInput — { path }", () => {
+  test("scalar path", () => {
+    expect(projectInput({ path: "data.offerId" }, ENV)).toBe("pofr_01")
+  })
+
+  test("nested path", () => {
+    expect(projectInput({ path: "data.affected.kind" }, ENV)).toBe("all")
+  })
+
+  test("array index", () => {
+    expect(projectInput({ path: "data.affected.productIds[0]" }, ENV)).toBe("p1")
+  })
+
+  test("metadata path", () => {
+    expect(projectInput({ path: "metadata.eventId" }, ENV)).toBe("evt_01")
+  })
+
+  test("name root", () => {
+    expect(projectInput({ path: "name" }, ENV)).toBe("promotion.changed")
+  })
+
+  test("missing path → undefined (not throw)", () => {
+    expect(projectInput({ path: "data.missing" }, ENV)).toBeUndefined()
+  })
+
+  test("empty string path throws structurally", () => {
+    expect(() => projectInput({ path: "" }, ENV)).toThrow()
+  })
+})
+
+describe("projectInput — { object }", () => {
+  test("flat object with mixed paths + literals", () => {
+    const out = projectInput(
+      {
+        object: {
+          sellerOperatorId: { path: "metadata.tenantId" },
+          source: { path: "data.affected.kind" },
+          marker: { lit: "promotion.changed" },
+          count: { lit: 42 },
+          isAll: { lit: true },
+        },
+      },
+      ENV,
+    )
+    expect(out).toEqual({
+      sellerOperatorId: "default",
+      source: "all",
+      marker: "promotion.changed",
+      count: 42,
+      isAll: true,
+    })
+  })
+
+  test("nested object via inline mapper", () => {
+    const out = projectInput(
+      {
+        object: {
+          sellerOperatorId: { path: "metadata.tenantId" },
+          reason: {
+            object: {
+              kind: { lit: "promotion.changed" },
+              offerId: { path: "data.offerId" },
+            },
+          },
+        },
+      },
+      ENV,
+    )
+    expect(out).toEqual({
+      sellerOperatorId: "default",
+      reason: { kind: "promotion.changed", offerId: "pofr_01" },
+    })
+  })
+
+  test("missing path inside object → undefined leaf", () => {
+    const out = projectInput({ object: { foo: { path: "data.missing" } } }, ENV) as Record<
+      string,
+      unknown
+    >
+    expect(out.foo).toBeUndefined()
+  })
+
+  test("nested passthrough yields envelope.data inside object", () => {
+    const out = projectInput({ object: { wrapped: { passthrough: true } } }, ENV) as Record<
+      string,
+      unknown
+    >
+    expect(out.wrapped).toEqual(ENV.data)
+  })
+
+  test("empty object yields {}", () => {
+    expect(projectInput({ object: {} }, ENV)).toEqual({})
+  })
+
+  test("nullish lit handled correctly", () => {
+    const out = projectInput(
+      {
+        object: {
+          n: { lit: null },
+          s: { lit: "x" },
+          z: { lit: 0 },
+        },
+      },
+      ENV,
+    )
+    expect(out).toEqual({ n: null, s: "x", z: 0 })
+  })
+})
+
+describe("projectInput — structural errors throw", () => {
+  test("non-object mapper throws", () => {
+    expect(() => projectInput("garbage" as unknown as InputMapper, ENV)).toThrow()
+  })
+
+  test("unknown mapper variant throws", () => {
+    expect(() => projectInput({ wat: "x" } as unknown as InputMapper, ENV)).toThrow()
+  })
+
+  test("{ passthrough: false } throws", () => {
+    expect(() => projectInput({ passthrough: false } as unknown as InputMapper, ENV)).toThrow()
+  })
+})
+
+// ---- validateInputMapper ----
+
+describe("validateInputMapper", () => {
+  test("undefined mapper passes", () => {
+    expect(validateInputMapper(undefined)).toEqual({ ok: true, errors: [] })
+  })
+
+  test("valid passthrough", () => {
+    expect(validateInputMapper({ passthrough: true })).toEqual({ ok: true, errors: [] })
+  })
+
+  test("valid path", () => {
+    expect(validateInputMapper({ path: "data.x" }).ok).toBe(true)
+  })
+
+  test("rejects unknown root in path", () => {
+    const r = validateInputMapper({ path: "payload.x" })
+    expect(r.ok).toBe(false)
+    expect(r.errors[0]).toMatch(/path root "payload"/)
+  })
+
+  test("rejects empty path", () => {
+    expect(validateInputMapper({ path: "" }).ok).toBe(false)
+  })
+
+  test("validates nested object children", () => {
+    const r = validateInputMapper({
+      object: {
+        valid: { path: "data.x" },
+        bad: { path: "rogue.y" },
+        nested: {
+          object: {
+            inner: { path: "alsoBad.z" },
+          },
+        },
+      },
+    })
+    expect(r.ok).toBe(false)
+    expect(r.errors.some((e) => e.includes('path root "rogue"'))).toBe(true)
+    expect(r.errors.some((e) => e.includes('path root "alsoBad"'))).toBe(true)
+  })
+
+  test("rejects invalid lit type", () => {
+    const r = validateInputMapper({
+      object: { ts: { lit: new Date() as unknown as null } },
+    })
+    expect(r.ok).toBe(false)
+    expect(r.errors[0]).toMatch(/lit.*string \| number \| boolean \| null/)
+  })
+
+  test("empty object value rejected", () => {
+    const r = validateInputMapper({} as InputMapper)
+    expect(r.ok).toBe(false)
+    expect(r.errors[0]).toMatch(/passthrough \| path \| object/)
+  })
+})

--- a/packages/workflows/src/events/__tests__/manifest-builder.test.ts
+++ b/packages/workflows/src/events/__tests__/manifest-builder.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, test } from "vitest"
+
+import { __resetRegistry, workflow } from "../../index.js"
+import { trigger } from "../../trigger.js"
+import { buildManifest } from "../manifest-builder.js"
+import { __resetEventFilterRegistry, getEventFilterRegistry } from "../registry.js"
+
+afterEach(() => {
+  __resetRegistry()
+  __resetEventFilterRegistry()
+})
+
+describe("buildManifest", () => {
+  test("empty inputs produce a deterministic manifest", async () => {
+    const a = await buildManifest({
+      environment: "production",
+      workflows: [],
+      eventFilters: [],
+      builtAt: 1_700_000_000_000,
+    })
+    const b = await buildManifest({
+      environment: "production",
+      workflows: [],
+      eventFilters: [],
+      builtAt: 1_700_000_000_000,
+    })
+    expect(a.versionId).toBe(b.versionId)
+    expect(a.versionId).toMatch(/^[0-9a-f]{16}$/)
+    expect(a.workflows).toEqual([])
+    expect(a.eventFilters).toEqual([])
+  })
+
+  test("ordering of workflows and filters is canonical (id-sorted)", async () => {
+    const wfA = workflow({ id: "z-wf", async run() {} })
+    const wfB = workflow({ id: "a-wf", async run() {} })
+    trigger.on("evt.x", { target: wfA })
+    trigger.on("evt.y", { target: wfB })
+
+    const manifest = await buildManifest({
+      environment: "production",
+      workflows: [wfA, wfB],
+      eventFilters: getEventFilterRegistry().list(),
+    })
+
+    const ids = manifest.workflows.map((w) => w.id)
+    expect(ids).toEqual([...ids].sort())
+
+    const filterIds = manifest.eventFilters.map((f) => f.id)
+    expect(filterIds).toEqual([...filterIds].sort())
+  })
+
+  test("identical inputs produce byte-identical manifests (modulo builtAt)", async () => {
+    const wf = workflow({ id: "stable-wf", async run() {} })
+    trigger.on("evt.stable", {
+      target: wf,
+      where: { eq: [{ path: "data.k" }, { lit: "v" }] },
+    })
+
+    const a = await buildManifest({
+      environment: "production",
+      workflows: [wf],
+      eventFilters: getEventFilterRegistry().list(),
+      builtAt: 1_700_000_000_000,
+    })
+    const b = await buildManifest({
+      environment: "production",
+      workflows: [wf],
+      eventFilters: getEventFilterRegistry().list(),
+      builtAt: 1_700_000_000_000,
+    })
+    expect(a.versionId).toBe(b.versionId)
+    // versionId is computed independently of builtAt, so even mismatched
+    // build times should produce the same versionId.
+    const c = await buildManifest({
+      environment: "production",
+      workflows: [wf],
+      eventFilters: getEventFilterRegistry().list(),
+      builtAt: 1_999_999_999_999,
+    })
+    expect(c.versionId).toBe(a.versionId)
+  })
+
+  test("differing eventFilters produce different versionIds", async () => {
+    const wf = workflow({ id: "diff-wf", async run() {} })
+    trigger.on("evt.a", { target: wf })
+    const onlyA = await buildManifest({
+      environment: "production",
+      workflows: [wf],
+      eventFilters: getEventFilterRegistry().list(),
+    })
+
+    trigger.on("evt.b", { target: wf })
+    const aAndB = await buildManifest({
+      environment: "production",
+      workflows: [wf],
+      eventFilters: getEventFilterRegistry().list(),
+    })
+
+    expect(onlyA.versionId).not.toBe(aAndB.versionId)
+  })
+
+  test("filter manifest entries flow through verbatim", async () => {
+    const wf = workflow({ id: "passthrough-wf", async run() {} })
+    trigger.on<{ kind: string }>("promotion.changed", {
+      target: wf,
+      where: { eq: [{ path: "data.kind" }, { lit: "all" }] },
+      input: { passthrough: true },
+    })
+
+    const manifest = await buildManifest({
+      environment: "production",
+      workflows: [wf],
+      eventFilters: getEventFilterRegistry().list(),
+    })
+
+    expect(manifest.eventFilters).toHaveLength(1)
+    expect(manifest.eventFilters[0]).toMatchObject({
+      eventType: "promotion.changed",
+      targetWorkflowId: "passthrough-wf",
+      where: { eq: [{ path: "data.kind" }, { lit: "all" }] },
+      input: { passthrough: true },
+    })
+  })
+})

--- a/packages/workflows/src/events/__tests__/payload-hash.test.ts
+++ b/packages/workflows/src/events/__tests__/payload-hash.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "vitest"
+
+import { canonicalize, canonicalJson, sha256, shortHash } from "../payload-hash.js"
+
+describe("canonicalize", () => {
+  test("primitives passthrough", () => {
+    expect(canonicalize(1)).toBe(1)
+    expect(canonicalize("x")).toBe("x")
+    expect(canonicalize(true)).toBe(true)
+    expect(canonicalize(null)).toBeNull()
+  })
+
+  test("undefined becomes null", () => {
+    expect(canonicalize(undefined)).toBeNull()
+  })
+
+  test("alphabetizes object keys recursively", () => {
+    const result = canonicalize({
+      z: 1,
+      a: 2,
+      nested: { y: 1, x: 2 },
+    })
+    expect(JSON.stringify(result)).toBe('{"a":2,"nested":{"x":2,"y":1},"z":1}')
+  })
+
+  test("arrays preserve order", () => {
+    expect(canonicalize([3, 1, 2])).toEqual([3, 1, 2])
+  })
+
+  test("nested arrays + objects", () => {
+    const result = canonicalize({
+      list: [
+        { b: 1, a: 2 },
+        { d: 3, c: 4 },
+      ],
+    })
+    expect(JSON.stringify(result)).toBe('{"list":[{"a":2,"b":1},{"c":4,"d":3}]}')
+  })
+})
+
+describe("canonicalJson", () => {
+  test("two structurally equal values produce identical strings", () => {
+    const a = { z: 1, a: 2, nested: { y: 1, x: 2 } }
+    const b = { a: 2, nested: { x: 2, y: 1 }, z: 1 }
+    expect(canonicalJson(a)).toBe(canonicalJson(b))
+  })
+
+  test("differing values produce different strings", () => {
+    expect(canonicalJson({ x: 1 })).not.toBe(canonicalJson({ x: 2 }))
+  })
+})
+
+describe("sha256", () => {
+  test("returns 64-char lowercase hex", async () => {
+    const digest = await sha256({ x: 1 })
+    expect(digest).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  test("two structurally equal values hash identically", async () => {
+    const a = { z: 1, a: 2 }
+    const b = { a: 2, z: 1 }
+    expect(await sha256(a)).toBe(await sha256(b))
+  })
+
+  test("differing values hash differently", async () => {
+    expect(await sha256({ x: 1 })).not.toBe(await sha256({ x: 2 }))
+  })
+
+  test("known value", async () => {
+    // sha256(canonicalJson({a:1,b:2})) == sha256('{"a":1,"b":2}')
+    // Reproducible across runtimes.
+    const digest = await sha256({ a: 1, b: 2 })
+    expect(digest).toMatch(/^[0-9a-f]{64}$/)
+    expect(digest).toBe(await sha256({ b: 2, a: 1 }))
+  })
+})
+
+describe("shortHash", () => {
+  test("returns 16-char lowercase hex", async () => {
+    const id = await shortHash({ x: 1 })
+    expect(id).toMatch(/^[0-9a-f]{16}$/)
+  })
+
+  test("matches first 16 chars of full sha256", async () => {
+    const value = { x: 1, y: { a: 1 } }
+    const full = await sha256(value)
+    const short = await shortHash(value)
+    expect(short).toBe(full.slice(0, 16))
+  })
+})

--- a/packages/workflows/src/events/__tests__/predicate.test.ts
+++ b/packages/workflows/src/events/__tests__/predicate.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, test } from "vitest"
+
+import {
+  evaluatePredicate,
+  type PredicateEnvelope,
+  type PredicateExpr,
+  resolvePath,
+  validatePredicate,
+} from "../predicate.js"
+
+const ENV: PredicateEnvelope = {
+  name: "promotion.changed",
+  data: {
+    affected: { kind: "all", productIds: ["p1", "p2"] },
+    offerId: "pofr_01",
+    discountPct: 20,
+    enabled: true,
+  },
+  metadata: {
+    tenantId: "default",
+    eventId: "evt_01",
+  },
+  emittedAt: "2026-05-09T13:22:08.000Z",
+}
+
+// ---- resolvePath ----
+
+describe("resolvePath", () => {
+  test.each([
+    ["name", "promotion.changed"],
+    ["emittedAt", "2026-05-09T13:22:08.000Z"],
+    ["data.affected.kind", "all"],
+    ["data.affected.productIds[0]", "p1"],
+    ["data.affected.productIds[1]", "p2"],
+    ["data.offerId", "pofr_01"],
+    ["data.discountPct", 20],
+    ["data.enabled", true],
+    ["metadata.tenantId", "default"],
+    ["metadata.eventId", "evt_01"],
+  ])("%s -> %j", (path, expected) => {
+    expect(resolvePath(path, ENV)).toEqual(expected)
+  })
+
+  test.each([
+    "data.missing",
+    "data.affected.missing",
+    "data.affected.productIds[5]",
+    "metadata.missing",
+    "unknownRoot",
+    "unknownRoot.x",
+    "",
+  ])("%s -> undefined", (path) => {
+    expect(resolvePath(path, ENV)).toBeUndefined()
+  })
+
+  test("malformed bracket yields []", () => {
+    expect(resolvePath("data.items[", ENV)).toBeUndefined()
+  })
+})
+
+// ---- evaluatePredicate ----
+
+describe("evaluatePredicate — eq / neq", () => {
+  test("eq path-vs-lit", () => {
+    expect(evaluatePredicate({ eq: [{ path: "data.affected.kind" }, { lit: "all" }] }, ENV)).toBe(
+      true,
+    )
+  })
+
+  test("eq mismatch", () => {
+    expect(
+      evaluatePredicate({ eq: [{ path: "data.affected.kind" }, { lit: "products" }] }, ENV),
+    ).toBe(false)
+  })
+
+  test("eq path-vs-path", () => {
+    expect(
+      evaluatePredicate(
+        { eq: [{ path: "metadata.tenantId" }, { path: "metadata.tenantId" }] },
+        ENV,
+      ),
+    ).toBe(true)
+  })
+
+  test("eq with missing path always false", () => {
+    expect(evaluatePredicate({ eq: [{ path: "data.missing" }, { lit: null }] }, ENV)).toBe(false)
+  })
+
+  test("eq number/string mismatch is false", () => {
+    expect(evaluatePredicate({ eq: [{ path: "data.discountPct" }, { lit: "20" }] }, ENV)).toBe(
+      false,
+    )
+  })
+
+  test("eq null-vs-null is true", () => {
+    expect(evaluatePredicate({ eq: [{ lit: null }, { lit: null }] }, ENV)).toBe(true)
+  })
+
+  test("neq inverts", () => {
+    expect(evaluatePredicate({ neq: [{ path: "data.affected.kind" }, { lit: "all" }] }, ENV)).toBe(
+      false,
+    )
+    expect(
+      evaluatePredicate({ neq: [{ path: "data.affected.kind" }, { lit: "products" }] }, ENV),
+    ).toBe(true)
+  })
+})
+
+describe("evaluatePredicate — in", () => {
+  test("membership match", () => {
+    expect(
+      evaluatePredicate(
+        { in: [{ path: "data.affected.kind" }, [{ lit: "products" }, { lit: "all" }]] },
+        ENV,
+      ),
+    ).toBe(true)
+  })
+
+  test("membership miss", () => {
+    expect(
+      evaluatePredicate(
+        { in: [{ path: "data.affected.kind" }, [{ lit: "x" }, { lit: "y" }]] },
+        ENV,
+      ),
+    ).toBe(false)
+  })
+
+  test("missing lhs path → false", () => {
+    expect(evaluatePredicate({ in: [{ path: "data.missing" }, [{ lit: "all" }]] }, ENV)).toBe(false)
+  })
+
+  test("empty rhs → false", () => {
+    expect(evaluatePredicate({ in: [{ path: "data.affected.kind" }, []] }, ENV)).toBe(false)
+  })
+})
+
+describe("evaluatePredicate — gt / gte / lt / lte", () => {
+  test("number gt true", () => {
+    expect(evaluatePredicate({ gt: [{ path: "data.discountPct" }, { lit: 10 }] }, ENV)).toBe(true)
+  })
+  test("number gt false (eq)", () => {
+    expect(evaluatePredicate({ gt: [{ path: "data.discountPct" }, { lit: 20 }] }, ENV)).toBe(false)
+  })
+  test("number gte at boundary", () => {
+    expect(evaluatePredicate({ gte: [{ path: "data.discountPct" }, { lit: 20 }] }, ENV)).toBe(true)
+  })
+  test("number lt true", () => {
+    expect(evaluatePredicate({ lt: [{ path: "data.discountPct" }, { lit: 30 }] }, ENV)).toBe(true)
+  })
+  test("number lte at boundary", () => {
+    expect(evaluatePredicate({ lte: [{ path: "data.discountPct" }, { lit: 20 }] }, ENV)).toBe(true)
+  })
+
+  test("string lex compare", () => {
+    expect(evaluatePredicate({ gt: [{ lit: "b" }, { lit: "a" }] }, ENV)).toBe(true)
+    expect(evaluatePredicate({ lt: [{ lit: "a" }, { lit: "b" }] }, ENV)).toBe(true)
+  })
+
+  test("type mismatch returns false (not throw)", () => {
+    expect(evaluatePredicate({ gt: [{ path: "data.discountPct" }, { lit: "10" }] }, ENV)).toBe(
+      false,
+    )
+  })
+
+  test("missing path returns false", () => {
+    expect(evaluatePredicate({ gt: [{ path: "data.missing" }, { lit: 0 }] }, ENV)).toBe(false)
+  })
+})
+
+describe("evaluatePredicate — exists / not / and / or", () => {
+  test("exists true", () => {
+    expect(evaluatePredicate({ exists: { path: "metadata.eventId" } }, ENV)).toBe(true)
+  })
+  test("exists false on missing", () => {
+    expect(evaluatePredicate({ exists: { path: "metadata.missing" } }, ENV)).toBe(false)
+  })
+
+  test("not inverts", () => {
+    expect(
+      evaluatePredicate({ not: { eq: [{ path: "data.affected.kind" }, { lit: "all" }] } }, ENV),
+    ).toBe(false)
+  })
+
+  test("and short-circuits semantics", () => {
+    expect(
+      evaluatePredicate(
+        {
+          and: [
+            { eq: [{ path: "name" }, { lit: "promotion.changed" }] },
+            { eq: [{ path: "data.affected.kind" }, { lit: "all" }] },
+          ],
+        },
+        ENV,
+      ),
+    ).toBe(true)
+    expect(
+      evaluatePredicate(
+        {
+          and: [
+            { eq: [{ path: "name" }, { lit: "promotion.changed" }] },
+            { eq: [{ path: "data.affected.kind" }, { lit: "products" }] },
+          ],
+        },
+        ENV,
+      ),
+    ).toBe(false)
+  })
+
+  test("or matches any", () => {
+    expect(
+      evaluatePredicate(
+        {
+          or: [
+            { eq: [{ path: "data.affected.kind" }, { lit: "x" }] },
+            { eq: [{ path: "data.affected.kind" }, { lit: "all" }] },
+          ],
+        },
+        ENV,
+      ),
+    ).toBe(true)
+  })
+
+  test("empty and is true (vacuously)", () => {
+    expect(evaluatePredicate({ and: [] }, ENV)).toBe(true)
+  })
+
+  test("empty or is false (vacuously)", () => {
+    expect(evaluatePredicate({ or: [] }, ENV)).toBe(false)
+  })
+})
+
+// ---- validatePredicate ----
+
+describe("validatePredicate", () => {
+  test("valid predicate passes", () => {
+    const result = validatePredicate({
+      and: [
+        { eq: [{ path: "data.affected.kind" }, { lit: "all" }] },
+        { exists: { path: "metadata.eventId" } },
+      ],
+    })
+    expect(result.ok).toBe(true)
+    expect(result.errors).toEqual([])
+  })
+
+  test("rejects unknown root", () => {
+    const result = validatePredicate({
+      eq: [{ path: "payload.something" }, { lit: "x" }],
+    } as PredicateExpr)
+    expect(result.ok).toBe(false)
+    expect(result.errors[0]).toMatch(/path root "payload"/)
+  })
+
+  test("rejects unknown operator", () => {
+    const result = validatePredicate({ wat: ["x"] } as unknown as PredicateExpr)
+    expect(result.ok).toBe(false)
+    expect(result.errors[0]).toMatch(/unknown predicate operator/)
+  })
+
+  test("rejects mixed-type ordered comparison literals", () => {
+    const result = validatePredicate({
+      gt: [{ lit: 10 }, { lit: "10" }],
+    })
+    expect(result.ok).toBe(false)
+    expect(result.errors[0]).toMatch(/ordered comparison sides must agree on type/)
+  })
+
+  test("rejects malformed object (multiple operator keys)", () => {
+    const result = validatePredicate({
+      eq: [{ lit: 1 }, { lit: 1 }],
+      neq: [{ lit: 1 }, { lit: 2 }],
+    } as unknown as PredicateExpr)
+    expect(result.ok).toBe(false)
+    expect(result.errors[0]).toMatch(/exactly one operator key/)
+  })
+
+  test("rejects empty path", () => {
+    const result = validatePredicate({
+      exists: { path: "" },
+    })
+    expect(result.ok).toBe(false)
+    expect(result.errors[0]).toMatch(/non-empty/)
+  })
+
+  test("rejects malformed side (neither path nor lit)", () => {
+    const result = validatePredicate({
+      eq: [{} as never, { lit: "x" }],
+    })
+    expect(result.ok).toBe(false)
+    expect(result.errors[0]).toMatch(/must specify "path" or "lit"/)
+  })
+
+  test("validates nested predicates", () => {
+    const result = validatePredicate({
+      and: [
+        { eq: [{ path: "data.kind" }, { lit: "x" }] },
+        { not: { eq: [{ path: "rogueRoot" }, { lit: "y" }] } as PredicateExpr },
+      ],
+    })
+    expect(result.ok).toBe(false)
+    expect(result.errors.some((e) => e.includes('path root "rogueRoot"'))).toBe(true)
+  })
+})

--- a/packages/workflows/src/events/__tests__/trigger-on.test.ts
+++ b/packages/workflows/src/events/__tests__/trigger-on.test.ts
@@ -1,0 +1,182 @@
+// trigger.on() runtime collector — exercises the SDK-facing API end-to-end:
+// declare a workflow, call trigger.on(), inspect the registry.
+
+import { afterEach, describe, expect, test } from "vitest"
+
+import { __resetRegistry, workflow } from "../../index.js"
+import { trigger } from "../../trigger.js"
+import { EventFilterCompileError } from "../compile.js"
+import { __resetEventFilterRegistry, getEventFilterRegistry } from "../registry.js"
+
+afterEach(() => {
+  __resetRegistry()
+  __resetEventFilterRegistry()
+})
+
+describe("trigger.on", () => {
+  test("registers a filter and returns a handle", () => {
+    const wf = workflow<{ x: number }, void>({
+      id: "test-target",
+      async run() {},
+    })
+
+    const handle = trigger.on<{ kind: string }>("promotion.changed", {
+      target: wf,
+      where: { eq: [{ path: "data.kind" }, { lit: "all" }] },
+    })
+
+    expect(handle.event).toBe("promotion.changed")
+    expect(handle.id).toMatch(/^ef_[0-9a-f]{16}$/)
+
+    const entries = getEventFilterRegistry().list()
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.id).toBe(handle.id)
+    expect(entries[0]?.eventType).toBe("promotion.changed")
+    expect(entries[0]?.targetWorkflowId).toBe("test-target")
+  })
+
+  test("identical declarations produce identical ids (stable across re-imports)", () => {
+    const wf = workflow<{ x: number }, void>({
+      id: "test-stable",
+      async run() {},
+    })
+
+    const a = trigger.on("evt.x", {
+      target: wf,
+      where: { eq: [{ path: "data.k" }, { lit: "v" }] },
+    })
+    const b = trigger.on("evt.x", {
+      target: wf,
+      where: { eq: [{ path: "data.k" }, { lit: "v" }] },
+    })
+
+    expect(a.id).toBe(b.id)
+    // Re-registering the same id is idempotent.
+    expect(getEventFilterRegistry().list()).toHaveLength(1)
+  })
+
+  test("differing where clauses produce different ids", () => {
+    const wf = workflow<{ x: number }, void>({
+      id: "test-diff",
+      async run() {},
+    })
+
+    const a = trigger.on("evt.x", {
+      target: wf,
+      where: { eq: [{ path: "data.k" }, { lit: "v1" }] },
+    })
+    const b = trigger.on("evt.x", {
+      target: wf,
+      where: { eq: [{ path: "data.k" }, { lit: "v2" }] },
+    })
+
+    expect(a.id).not.toBe(b.id)
+    expect(getEventFilterRegistry().list()).toHaveLength(2)
+  })
+
+  test("filter without where or input is allowed (always-fire)", () => {
+    const wf = workflow<{ x: number }, void>({
+      id: "test-bare",
+      async run() {},
+    })
+
+    const handle = trigger.on("evt.x", { target: wf })
+    expect(handle.event).toBe("evt.x")
+    const entry = getEventFilterRegistry()
+      .list()
+      .find((e) => e.id === handle.id)
+    expect(entry?.manifest.where).toBeUndefined()
+    expect(entry?.manifest.input).toBeUndefined()
+  })
+
+  test("rejects empty event name", () => {
+    const wf = workflow<{ x: number }, void>({
+      id: "test-empty-event",
+      async run() {},
+    })
+    expect(() => trigger.on("", { target: wf })).toThrow(EventFilterCompileError)
+  })
+
+  test("rejects target without id", () => {
+    expect(() => trigger.on("evt.x", { target: {} as never })).toThrow(EventFilterCompileError)
+  })
+
+  test("rejects legacy match callback explicitly", () => {
+    const wf = workflow<{ x: number }, void>({
+      id: "test-legacy-match",
+      async run() {},
+    })
+    expect(() =>
+      trigger.on("evt.x", {
+        target: wf,
+        match: () => true,
+      } as never),
+    ).toThrow(/match.*callback is no longer supported/)
+  })
+
+  test("rejects malformed where clause at registration", () => {
+    const wf = workflow<{ x: number }, void>({
+      id: "test-bad-where",
+      async run() {},
+    })
+    let err: unknown
+    try {
+      trigger.on("evt.x", {
+        target: wf,
+        where: { eq: [{ path: "rogue.x" }, { lit: "v" }] },
+      })
+    } catch (e) {
+      err = e
+    }
+    expect(err).toBeInstanceOf(EventFilterCompileError)
+    expect((err as EventFilterCompileError).errors[0]).toMatch(/path root "rogue"/)
+  })
+
+  test("rejects malformed input mapper at registration", () => {
+    const wf = workflow<{ x: number }, void>({
+      id: "test-bad-input",
+      async run() {},
+    })
+    expect(() =>
+      trigger.on("evt.x", {
+        target: wf,
+        input: { object: { x: { path: "rogue.y" } } },
+      }),
+    ).toThrow(EventFilterCompileError)
+  })
+
+  test("manifest entry mirrors the declaration shape", () => {
+    const wf = workflow<{ x: number }, void>({
+      id: "test-manifest-shape",
+      async run() {},
+    })
+
+    const handle = trigger.on("evt.x", {
+      target: wf,
+      where: { eq: [{ path: "data.k" }, { lit: "v" }] },
+      input: {
+        object: {
+          k: { path: "data.k" },
+          marker: { lit: "evt.x" },
+        },
+      },
+    })
+
+    const entry = getEventFilterRegistry()
+      .list()
+      .find((e) => e.id === handle.id)
+    expect(entry?.manifest).toMatchObject({
+      id: handle.id,
+      eventType: "evt.x",
+      targetWorkflowId: "test-manifest-shape",
+      where: { eq: [{ path: "data.k" }, { lit: "v" }] },
+      input: {
+        object: {
+          k: { path: "data.k" },
+          marker: { lit: "evt.x" },
+        },
+      },
+    })
+    expect(entry?.manifest.payloadHash).toMatch(/^[0-9a-f]{16}$/)
+  })
+})

--- a/packages/workflows/src/events/compile.ts
+++ b/packages/workflows/src/events/compile.ts
@@ -1,0 +1,270 @@
+// Compile an `EventFilterDeclaration` (authored in user code) into an
+// `EventFilterRuntimeEntry`. Validates the predicate + mapper at
+// registration time so authoring errors fail fast; computes the
+// content-derived `id` / `payloadHash` so the manifest is deterministic.
+//
+// Called from `trigger.on(...)` in `../trigger.js`.
+
+import type { EventFilterManifestEntry } from "../protocol/index.js"
+import type { EventFilterDeclaration } from "../trigger.js"
+import { type InputMapper, validateInputMapper } from "./input-mapper.js"
+import { canonicalJson, sha256 } from "./payload-hash.js"
+import { type PredicateExpr, validatePredicate } from "./predicate.js"
+import { type EventFilterRuntimeEntry, getEventFilterRegistry } from "./registry.js"
+
+export class EventFilterCompileError extends Error {
+  readonly errors: string[]
+
+  constructor(message: string, errors: string[] = []) {
+    super(message)
+    this.name = "EventFilterCompileError"
+    this.errors = errors
+  }
+}
+
+/**
+ * Compile an authored declaration into a runtime entry. Throws
+ * `EventFilterCompileError` on shape errors so authoring problems fail
+ * at module-load time.
+ */
+export async function compileEventFilter<T>(
+  eventType: string,
+  declaration: EventFilterDeclaration<T>,
+): Promise<EventFilterRuntimeEntry> {
+  if (typeof eventType !== "string" || eventType.length === 0) {
+    throw new EventFilterCompileError(
+      `trigger.on(eventType, ...): eventType must be a non-empty string`,
+    )
+  }
+  if (typeof declaration !== "object" || declaration === null) {
+    throw new EventFilterCompileError(
+      `trigger.on("${eventType}", ...): declaration must be an object`,
+    )
+  }
+  if (!declaration.target || typeof declaration.target !== "object") {
+    throw new EventFilterCompileError(
+      `trigger.on("${eventType}", ...): "target" must be a workflow definition (got ${typeof declaration.target})`,
+    )
+  }
+  const targetWorkflowId =
+    typeof (declaration.target as { id?: unknown }).id === "string"
+      ? (declaration.target as { id: string }).id
+      : ""
+  if (targetWorkflowId.length === 0) {
+    throw new EventFilterCompileError(
+      `trigger.on("${eventType}", ...): "target.id" must be a non-empty string`,
+    )
+  }
+
+  // Validate `where` if supplied.
+  const where = (declaration as { where?: PredicateExpr }).where
+  if (where !== undefined) {
+    const result = validatePredicate(where)
+    if (!result.ok) {
+      throw new EventFilterCompileError(
+        `trigger.on("${eventType}", target=${targetWorkflowId}): invalid where clause`,
+        result.errors,
+      )
+    }
+  }
+
+  // Validate `input` if supplied.
+  const input = (declaration as { input?: InputMapper }).input
+  if (input !== undefined) {
+    const result = validateInputMapper(input)
+    if (!result.ok) {
+      throw new EventFilterCompileError(
+        `trigger.on("${eventType}", target=${targetWorkflowId}): invalid input mapper`,
+        result.errors,
+      )
+    }
+  }
+
+  // Reject the legacy `match` callback explicitly so authoring errors are obvious.
+  if (typeof (declaration as { match?: unknown }).match === "function") {
+    throw new EventFilterCompileError(
+      `trigger.on("${eventType}"): the "match" callback is no longer supported. ` +
+        `Use the structured "where" predicate instead. See architecture doc §12.`,
+    )
+  }
+
+  // Canonical content-derived id. Stable across re-deploys because the
+  // canonicalized JSON of the declaration is identical for byte-equivalent
+  // sources.
+  const canonicalDeclaration = {
+    eventType,
+    where: where ?? null,
+    input: input ?? null,
+    targetWorkflowId,
+  }
+  const fullHash = await sha256(canonicalDeclaration)
+  const payloadHash = fullHash
+  // Filter id seeds from the same hash but stays human-friendly in logs.
+  const id = `ef_${fullHash.slice(0, 16)}`
+
+  const manifest: EventFilterManifestEntry = {
+    id,
+    eventType,
+    payloadHash,
+    targetWorkflowId,
+    ...(where !== undefined ? { where } : {}),
+    ...(input !== undefined ? { input } : {}),
+  }
+
+  const entry: EventFilterRuntimeEntry = {
+    id,
+    eventType,
+    manifest,
+    declaration: declaration as EventFilterDeclaration<unknown>,
+    targetWorkflowId,
+  }
+  return entry
+}
+
+/**
+ * Compile + register in one step. The synchronous wrapper for `trigger.on()`
+ * that user code calls — kicks off compile asynchronously, registers when
+ * the entry is ready, and returns a handle the user can ignore. Validation
+ * errors become unhandled-rejection warnings in dev (caught by vitest etc.)
+ * and surface at boot via `manifestBuilder.buildManifest()` which awaits
+ * registry settlement.
+ *
+ * For the synchronous-handle return we use a placeholder id; the real id
+ * lands when the compile resolves. Since `trigger.on()` is the user-facing
+ * API and most users don't inspect the returned handle (they just want the
+ * filter registered), this is fine. If a future caller needs the real id
+ * synchronously, see {@link compileEventFilterSync} below.
+ */
+export function compileAndRegister<T>(
+  eventType: string,
+  declaration: EventFilterDeclaration<T>,
+): { id: string; readonly event: string } {
+  // Run validation + compile synchronously where possible. The async
+  // boundary is the SHA-256 digest from Web Crypto; we bridge via a
+  // synchronous canonical-JSON hash so trigger.on() can stay sync.
+  const entry = compileEventFilterSync(eventType, declaration)
+  getEventFilterRegistry().add(entry)
+  return { id: entry.id, event: entry.eventType }
+}
+
+/**
+ * Synchronous compile — uses a deterministic but non-cryptographic hash
+ * over the canonical JSON. Suitable for the registry id (we just need
+ * stable + collision-resistant-enough across realistic registration
+ * counts). The crypto-grade `sha256(...)` is used at *manifest build*
+ * time when async is fine.
+ */
+export function compileEventFilterSync<T>(
+  eventType: string,
+  declaration: EventFilterDeclaration<T>,
+): EventFilterRuntimeEntry {
+  if (typeof eventType !== "string" || eventType.length === 0) {
+    throw new EventFilterCompileError(
+      `trigger.on(eventType, ...): eventType must be a non-empty string`,
+    )
+  }
+  if (typeof declaration !== "object" || declaration === null) {
+    throw new EventFilterCompileError(
+      `trigger.on("${eventType}", ...): declaration must be an object`,
+    )
+  }
+  if (!declaration.target || typeof declaration.target !== "object") {
+    throw new EventFilterCompileError(
+      `trigger.on("${eventType}", ...): "target" must be a workflow definition (got ${typeof declaration.target})`,
+    )
+  }
+  const targetWorkflowId =
+    typeof (declaration.target as { id?: unknown }).id === "string"
+      ? (declaration.target as { id: string }).id
+      : ""
+  if (targetWorkflowId.length === 0) {
+    throw new EventFilterCompileError(
+      `trigger.on("${eventType}", ...): "target.id" must be a non-empty string`,
+    )
+  }
+
+  const where = (declaration as { where?: PredicateExpr }).where
+  if (where !== undefined) {
+    const result = validatePredicate(where)
+    if (!result.ok) {
+      throw new EventFilterCompileError(
+        `trigger.on("${eventType}", target=${targetWorkflowId}): invalid where clause`,
+        result.errors,
+      )
+    }
+  }
+
+  const input = (declaration as { input?: InputMapper }).input
+  if (input !== undefined) {
+    const result = validateInputMapper(input)
+    if (!result.ok) {
+      throw new EventFilterCompileError(
+        `trigger.on("${eventType}", target=${targetWorkflowId}): invalid input mapper`,
+        result.errors,
+      )
+    }
+  }
+
+  if (typeof (declaration as { match?: unknown }).match === "function") {
+    throw new EventFilterCompileError(
+      `trigger.on("${eventType}"): the "match" callback is no longer supported. ` +
+        `Use the structured "where" predicate instead. See architecture doc §12.`,
+    )
+  }
+
+  const canonicalDeclaration = {
+    eventType,
+    where: where ?? null,
+    input: input ?? null,
+    targetWorkflowId,
+  }
+  const json = canonicalJson(canonicalDeclaration)
+  const shortId = nonCryptoHash16(json)
+  const id = `ef_${shortId}`
+
+  const manifest: EventFilterManifestEntry = {
+    id,
+    eventType,
+    // payloadHash on the manifest is stable (same canonical JSON) but
+    // upgraded to the crypto-grade sha256 at manifest-build time. Until
+    // then it carries the same short hash so consumers that read it pre-
+    // build (e.g. dashboards in dev mode) still see something sensible.
+    payloadHash: shortId,
+    targetWorkflowId,
+    ...(where !== undefined ? { where } : {}),
+    ...(input !== undefined ? { input } : {}),
+  }
+
+  return {
+    id,
+    eventType,
+    manifest,
+    declaration: declaration as EventFilterDeclaration<unknown>,
+    targetWorkflowId,
+  }
+}
+
+/**
+ * Deterministic 16-hex-char hash for synchronous registration. Uses FNV-1a
+ * 64-bit folded into hex — collision-resistant enough at the cardinality of
+ * "filters per project" (low thousands at most). The cryptographic SHA-256
+ * is the source of truth for manifest-level identity; this is just enough
+ * to be a stable id for the in-process registry.
+ */
+function nonCryptoHash16(text: string): string {
+  // FNV-1a 64-bit, computed as two 32-bit halves to avoid bigint overhead
+  // in tight loops. Output: 16 hex chars (concatenation of the two halves).
+  let h1 = 0xcbf29ce4
+  let h2 = 0x84222325
+  for (let i = 0; i < text.length; i++) {
+    const c = text.charCodeAt(i)
+    h1 = (h1 ^ c) >>> 0
+    h2 = (h2 ^ c) >>> 0
+    // Multiply by 0x100000001b3 split into the two halves.
+    const lo = h2 * 0x01b3
+    const hi = h1 * 0x01b3 + Math.floor(lo / 0x100000000)
+    h2 = (lo & 0xffffffff) >>> 0
+    h1 = hi >>> 0
+  }
+  return h1.toString(16).padStart(8, "0") + h2.toString(16).padStart(8, "0")
+}

--- a/packages/workflows/src/events/index.ts
+++ b/packages/workflows/src/events/index.ts
@@ -1,0 +1,41 @@
+// `@voyantjs/workflows/events` — the events runtime: structured `where`
+// predicate + `input` mapper, event-filter registry, manifest builder.
+//
+// Authoritative architecture: docs/architecture/workflows-runtime-architecture.md
+// §12 (trigger.on runtime), §13 (DSLs), §14 (manifest lifecycle).
+
+export {
+  compileAndRegister,
+  compileEventFilterSync,
+  EventFilterCompileError,
+} from "./compile.js"
+export type { InputMapper } from "./input-mapper.js"
+export {
+  type InputMapperValidationResult,
+  projectInput,
+  validateInputMapper,
+} from "./input-mapper.js"
+export {
+  type BuildManifestArgs,
+  buildManifest,
+} from "./manifest-builder.js"
+export {
+  canonicalize,
+  canonicalJson,
+  sha256,
+  shortHash,
+} from "./payload-hash.js"
+export {
+  evaluatePredicate,
+  type PathOrLit,
+  type PredicateEnvelope,
+  type PredicateExpr,
+  type PredicateValidationResult,
+  resolvePath,
+  validatePredicate,
+} from "./predicate.js"
+export {
+  __resetEventFilterRegistry,
+  type EventFilterRuntimeEntry,
+  getEventFilterRegistry,
+} from "./registry.js"

--- a/packages/workflows/src/events/input-mapper.ts
+++ b/packages/workflows/src/events/input-mapper.ts
@@ -1,0 +1,201 @@
+// Input mapper DSL — projects a workflow input from an event envelope.
+//
+// Each `EventFilterDeclaration` carries an optional `input: InputMapper`. At
+// ingest time, after the predicate matches, the mapper builds the actual
+// input value passed to `driver.trigger(target, input, ...)`. Same path
+// roots as the predicate evaluator (`data`, `metadata`, `name`, `emittedAt`).
+//
+// Variants:
+//   * `undefined`              → pass through `envelope.data`
+//   * `{ passthrough: true }`  → explicit pass-through of `envelope.data`
+//   * `{ path: string }`       → workflow input = the resolved path value
+//   * `{ object: {...} }`      → build an object by projecting each key;
+//                                 each value is itself an InputMapper or a
+//                                 `PathOrLit` for terminal projections
+//
+// Architecture: docs/architecture/workflows-runtime-architecture.md §13.2.
+
+import { type PathOrLit, type PredicateEnvelope, resolvePath } from "./predicate.js"
+
+// ---- Public types ----
+
+export type InputMapper =
+  | undefined
+  | { passthrough: true }
+  | { path: string }
+  | { object: Record<string, InputMapper | PathOrLit> }
+
+// ---- Public API ----
+
+/**
+ * Project a workflow input from an event envelope. Mirrors the predicate
+ * evaluator's no-throw contract — missing paths produce `undefined` in the
+ * output, registration-time linting catches structural errors.
+ *
+ * Throws `InputMapperError` only on unexpected shape errors (the mapper
+ * itself was constructed wrong). Drivers catch and surface this as
+ * `IngestMatch.status === "skipped"` with reason `"input_projection_error"`.
+ */
+export function projectInput(mapper: InputMapper, envelope: PredicateEnvelope): unknown {
+  if (mapper === undefined) return envelope.data
+  if (typeof mapper !== "object" || mapper === null) {
+    throw new InputMapperError(
+      `input mapper must be undefined, {passthrough}, {path}, or {object}, got ${typeof mapper}`,
+    )
+  }
+  if ("passthrough" in mapper) {
+    if (mapper.passthrough !== true) {
+      throw new InputMapperError(`{ passthrough } must be true`)
+    }
+    return envelope.data
+  }
+  if ("path" in mapper) {
+    if (typeof mapper.path !== "string" || mapper.path.length === 0) {
+      throw new InputMapperError(`{ path } must be a non-empty string`)
+    }
+    return resolvePath(mapper.path, envelope)
+  }
+  if ("object" in mapper) {
+    if (typeof mapper.object !== "object" || mapper.object === null) {
+      throw new InputMapperError(`{ object } must map keys to InputMapper | PathOrLit`)
+    }
+    const out: Record<string, unknown> = {}
+    for (const [key, child] of Object.entries(mapper.object)) {
+      out[key] = projectChild(child, envelope)
+    }
+    return out
+  }
+  throw new InputMapperError(
+    `input mapper must contain one of passthrough | path | object, got keys: ${Object.keys(mapper).join(", ")}`,
+  )
+}
+
+// ---- Static linter ----
+
+export interface InputMapperValidationResult {
+  ok: boolean
+  errors: string[]
+}
+
+export function validateInputMapper(mapper: InputMapper): InputMapperValidationResult {
+  const errors: string[] = []
+  walkValidate(mapper, errors, [])
+  return { ok: errors.length === 0, errors }
+}
+
+// ---- Internals ----
+
+class InputMapperError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "InputMapperError"
+  }
+}
+
+/**
+ * Resolve one entry inside `{ object: { ... } }`. The value is either a
+ * nested mapper (recurse) or a `PathOrLit` (terminal projection).
+ */
+function projectChild(child: InputMapper | PathOrLit, envelope: PredicateEnvelope): unknown {
+  if (child === undefined) return envelope.data
+  if (typeof child !== "object" || child === null) {
+    throw new InputMapperError(`nested mapper entry must be an object, got ${typeof child}`)
+  }
+  // Distinguish PathOrLit (`{ path }` or `{ lit }`) from nested mapper.
+  if ("lit" in child) {
+    return (child as { lit: unknown }).lit
+  }
+  // `{ path: "..." }` is shared between PathOrLit and InputMapper — resolve directly.
+  if ("path" in child) {
+    if (typeof child.path !== "string" || child.path.length === 0) {
+      throw new InputMapperError(`nested { path } must be a non-empty string`)
+    }
+    return resolvePath(child.path, envelope)
+  }
+  // Otherwise: a nested InputMapper (passthrough / object).
+  return projectInput(child as InputMapper, envelope)
+}
+
+function walkValidate(mapper: InputMapper, errors: string[], path: string[]): void {
+  if (mapper === undefined) return
+  if (typeof mapper !== "object" || mapper === null) {
+    errors.push(
+      `${pathLabel(path)}: input mapper must be undefined or an object, got ${typeof mapper}`,
+    )
+    return
+  }
+  const keys = Object.keys(mapper)
+  if (keys.length === 0) {
+    errors.push(`${pathLabel(path)}: input mapper must specify passthrough | path | object`)
+    return
+  }
+  if ("passthrough" in mapper) {
+    if (mapper.passthrough !== true) {
+      errors.push(`${pathLabel(path)}: { passthrough } must be true`)
+    }
+    return
+  }
+  if ("path" in mapper) {
+    if (typeof mapper.path !== "string" || mapper.path.length === 0) {
+      errors.push(`${pathLabel(path)}: { path } must be a non-empty string`)
+      return
+    }
+    validatePathRoot(mapper.path, errors, path)
+    return
+  }
+  if ("object" in mapper) {
+    if (typeof mapper.object !== "object" || mapper.object === null) {
+      errors.push(`${pathLabel(path)}: { object } must map keys to InputMapper | PathOrLit`)
+      return
+    }
+    for (const [k, child] of Object.entries(mapper.object)) {
+      validateChild(child, errors, [...path, k])
+    }
+    return
+  }
+  errors.push(`${pathLabel(path)}: unknown mapper variant — keys: ${keys.join(", ")}`)
+}
+
+function validateChild(child: InputMapper | PathOrLit, errors: string[], path: string[]): void {
+  if (child === undefined) return
+  if (typeof child !== "object" || child === null) {
+    errors.push(`${pathLabel(path)}: nested entry must be an object`)
+    return
+  }
+  if ("lit" in child) {
+    const t = typeof (child as { lit: unknown }).lit
+    if (
+      t !== "string" &&
+      t !== "number" &&
+      t !== "boolean" &&
+      (child as { lit: unknown }).lit !== null
+    ) {
+      errors.push(`${pathLabel(path)}: { lit } must be string | number | boolean | null`)
+    }
+    return
+  }
+  if ("path" in child) {
+    if (typeof child.path !== "string" || child.path.length === 0) {
+      errors.push(`${pathLabel(path)}: { path } must be a non-empty string`)
+      return
+    }
+    validatePathRoot(child.path, errors, path)
+    return
+  }
+  walkValidate(child as InputMapper, errors, path)
+}
+
+function validatePathRoot(path: string, errors: string[], errorPath: string[]): void {
+  // Match the predicate path roots exactly so the two DSLs stay aligned.
+  const firstSegment = path.split(".")[0] ?? ""
+  const root = firstSegment.split("[")[0] ?? ""
+  if (root !== "data" && root !== "metadata" && root !== "name" && root !== "emittedAt") {
+    errors.push(
+      `${pathLabel(errorPath)}: path root "${root}" is not one of data | metadata | name | emittedAt`,
+    )
+  }
+}
+
+function pathLabel(path: string[]): string {
+  return path.length === 0 ? "(root)" : path.join(".")
+}

--- a/packages/workflows/src/events/manifest-builder.ts
+++ b/packages/workflows/src/events/manifest-builder.ts
@@ -1,0 +1,97 @@
+// Build a `WorkflowManifest` from collected workflow + event-filter entries.
+//
+// Called once at `createApp()` boot (PR4). The resulting manifest is
+// content-addressed: byte-identical inputs produce byte-identical
+// `versionId`s, so concurrent registration calls don't race meaningfully —
+// the second caller sees the same versionId the first did.
+//
+// Architecture: docs/architecture/workflows-runtime-architecture.md §14.1.
+
+import type {
+  EventFilterManifestEntry,
+  WorkflowManifest,
+  WorkflowManifestEntry,
+} from "../protocol/index.js"
+import { canonicalJson, shortHash } from "./payload-hash.js"
+import type { EventFilterRuntimeEntry } from "./registry.js"
+
+export interface BuildManifestArgs {
+  /** Project / tenant identifier. Single-tenant runtimes pass `"default"`. */
+  projectId?: string
+  /** Deployment environment. */
+  environment: "production" | "preview" | "development"
+  /** Workflow definitions collected from modules + plugins. */
+  workflows: ReadonlyArray<{
+    id: string
+    config?: { defaultRuntime?: "edge" | "node"; retry?: unknown; timeout?: unknown }
+  }>
+  /** Event-filter entries from `getEventFilterRegistry()`. */
+  eventFilters: ReadonlyArray<EventFilterRuntimeEntry>
+  /** Wall-clock build time, ms-since-epoch. Defaults to `Date.now()`. */
+  builtAt?: number
+  /** Source-code version of the manifest builder. */
+  builderVersion?: string
+}
+
+/**
+ * Build a deterministic `WorkflowManifest`. Same inputs always produce
+ * byte-identical output, including `versionId`.
+ *
+ * Does NOT write the manifest anywhere — that's the driver's
+ * `registerManifest(...)` responsibility. This function is pure.
+ */
+export async function buildManifest(args: BuildManifestArgs): Promise<WorkflowManifest> {
+  const builtAt = args.builtAt ?? Date.now()
+  const builderVersion = args.builderVersion ?? "@voyantjs/workflows@manifest-builder/v1"
+  const projectId = args.projectId ?? "default"
+
+  const workflows: WorkflowManifestEntry[] = args.workflows
+    .map((wf) => ({
+      id: wf.id,
+      version: "v1",
+      steps: [],
+      schedules: [],
+      defaultRuntime: wf.config?.defaultRuntime ?? "edge",
+      hasCompensation: false,
+      sourceLocation: { file: "<runtime>", line: 0 },
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id))
+
+  // Sort filters by id so the canonical form is order-independent.
+  const eventFilters: EventFilterManifestEntry[] = args.eventFilters
+    .map((entry) => entry.manifest)
+    .sort((a, b) => a.id.localeCompare(b.id))
+
+  const draft: Omit<WorkflowManifest, "versionId"> & { versionId?: string } = {
+    schemaVersion: 1,
+    projectId,
+    builtAt,
+    builderVersion,
+    capabilities: ["events:v1"],
+    workflows,
+    eventFilters,
+    bindings: {},
+    environments: { production: {}, preview: {}, development: {} },
+  }
+
+  // versionId is the cryptographic short hash of the canonical manifest
+  // body (excluding builtAt + versionId itself, which are non-load-bearing
+  // for content identity).
+  const identityBody = {
+    schemaVersion: draft.schemaVersion,
+    projectId: draft.projectId,
+    builderVersion: draft.builderVersion,
+    capabilities: draft.capabilities,
+    workflows: draft.workflows,
+    eventFilters: draft.eventFilters,
+    bindings: draft.bindings,
+    environments: draft.environments,
+  }
+  const versionId = await shortHash(identityBody)
+  void canonicalJson // referenced via shortHash; keep the import surface stable
+
+  return {
+    ...(draft as Omit<WorkflowManifest, "versionId">),
+    versionId,
+  }
+}

--- a/packages/workflows/src/events/payload-hash.ts
+++ b/packages/workflows/src/events/payload-hash.ts
@@ -1,0 +1,86 @@
+// Canonical JSON + SHA-256 helpers used to derive `payloadHash` ids for
+// `EventFilterRuntimeEntry` and `WorkflowManifest.versionId`.
+//
+// Canonicalization recursively alphabetizes object keys before
+// JSON.stringify. SHA-256 uses Web Crypto (`globalThis.crypto.subtle`),
+// available on Node ≥ 19, all modern browsers, and Cloudflare Workers.
+// Async because Web Crypto's digest is async — callers `await` once
+// at registration time.
+//
+// Architecture: docs/architecture/workflows-runtime-architecture.md §13.3.
+
+/**
+ * Recursively alphabetize object keys, leaving arrays and primitives intact.
+ * `undefined` is converted to `null` so canonical JSON shape is stable
+ * (JSON.stringify drops `undefined` from objects).
+ */
+export function canonicalize(value: unknown): unknown {
+  if (value === undefined) return null
+  if (value === null || typeof value !== "object") return value
+  if (Array.isArray(value)) {
+    return value.map(canonicalize)
+  }
+  const sorted: Record<string, unknown> = {}
+  const keys = Object.keys(value as Record<string, unknown>).sort()
+  for (const k of keys) {
+    sorted[k] = canonicalize((value as Record<string, unknown>)[k])
+  }
+  return sorted
+}
+
+/**
+ * Stable canonical JSON string for `value`. Two values that are deeply
+ * equal modulo key order produce identical strings; two values that
+ * differ in any way produce different strings. Used as the input to
+ * `sha256(...)` for content-derived ids.
+ */
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value))
+}
+
+/**
+ * SHA-256 hex digest of an arbitrary value (canonicalized first). Async
+ * — callers await once during manifest build.
+ *
+ * @returns lowercase hex string, 64 chars long.
+ */
+export async function sha256(value: unknown): Promise<string> {
+  const text = canonicalJson(value)
+  const bytes = new TextEncoder().encode(text)
+  const digest = await getCrypto().subtle.digest("SHA-256", bytes)
+  return bytesToHex(new Uint8Array(digest))
+}
+
+/**
+ * Short content-derived id, used as `EventFilterManifestEntry.payloadHash`
+ * and `WorkflowManifest.versionId`. 16 hex chars (~64 bits) — collision
+ * space is fine for human-friendly ids in dashboards/logs; the canonical
+ * full hash is `sha256(...)` if you need it.
+ */
+export async function shortHash(value: unknown): Promise<string> {
+  const full = await sha256(value)
+  return full.slice(0, 16)
+}
+
+// ---- Internal ----
+
+function getCrypto(): Crypto {
+  // `globalThis.crypto` is available on Node 19+, Workers, browsers.
+  // Any environment older than that needs a polyfill at the consumer level.
+  const c = (globalThis as { crypto?: Crypto }).crypto
+  if (!c?.subtle) {
+    throw new Error(
+      "@voyantjs/workflows/events: globalThis.crypto.subtle is required for payload-hash. " +
+        "Polyfill via webcrypto on legacy runtimes.",
+    )
+  }
+  return c
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let out = ""
+  for (let i = 0; i < bytes.length; i++) {
+    out += (bytes[i] ?? 0).toString(16).padStart(2, "0")
+  }
+  return out
+}

--- a/packages/workflows/src/events/predicate.ts
+++ b/packages/workflows/src/events/predicate.ts
@@ -1,0 +1,390 @@
+// Predicate DSL — the structured `where` filter on EventFilterDeclaration.
+//
+// Closed grammar of 12 operators, evaluated against the standard
+// EventEnvelope shape (`data`, `metadata`, `name`, `emittedAt`). No `eval`,
+// no Function constructor, no callback-via-network — everything is data.
+//
+// Authoring shape (from a module's source):
+//
+//     trigger.on("promotion.changed", {
+//       target: bulkReindexProducts,
+//       where: { eq: [{ path: "data.affected.kind" }, { lit: "all" }] },
+//       input: { ... },
+//     })
+//
+// Architecture: docs/architecture/workflows-runtime-architecture.md §13.1.
+
+// ---- Path / literal references ----
+
+/** Either a path into the envelope or an inline literal value. */
+export type PathOrLit = { path: string } | { lit: string | number | boolean | null }
+
+// ---- The grammar ----
+
+export type PredicateExpr =
+  | { eq: [PathOrLit, PathOrLit] }
+  | { neq: [PathOrLit, PathOrLit] }
+  | { in: [PathOrLit, PathOrLit[]] }
+  | { gt: [PathOrLit, PathOrLit] }
+  | { gte: [PathOrLit, PathOrLit] }
+  | { lt: [PathOrLit, PathOrLit] }
+  | { lte: [PathOrLit, PathOrLit] }
+  | { exists: PathOrLit }
+  | { not: PredicateExpr }
+  | { and: PredicateExpr[] }
+  | { or: PredicateExpr[] }
+
+// ---- Envelope view (what paths address into) ----
+
+/**
+ * Minimal structural envelope the evaluator reads. Matches the standard
+ * `EventEnvelope` from `@voyantjs/core`. Declared structurally here so the
+ * SDK package stays a leaf.
+ */
+export interface PredicateEnvelope<TData = unknown> {
+  name: string
+  data: TData
+  metadata?: Record<string, unknown> | undefined
+  emittedAt: string
+}
+
+// ---- Public API ----
+
+/**
+ * Evaluate a predicate against an event envelope. Returns `true` / `false`.
+ * Path resolution against missing keys yields `undefined`, which makes
+ * comparison ops `false` (not throw). The evaluator never throws on data
+ * mismatches — registration-time linting catches structural errors via
+ * {@link validatePredicate}.
+ *
+ * Throws `PredicateEvalError` only on unexpected shape errors (the predicate
+ * itself was constructed wrong, e.g. malformed operator). Drivers catch
+ * this and surface it as `IngestMatch.status === "skipped"` with reason
+ * `"where_eval_error"`.
+ */
+export function evaluatePredicate(expr: PredicateExpr, envelope: PredicateEnvelope): boolean {
+  if ("eq" in expr) {
+    return strictEquals(resolveSide(expr.eq[0], envelope), resolveSide(expr.eq[1], envelope))
+  }
+  if ("neq" in expr) {
+    return !strictEquals(resolveSide(expr.neq[0], envelope), resolveSide(expr.neq[1], envelope))
+  }
+  if ("in" in expr) {
+    const lhs = resolveSide(expr.in[0], envelope)
+    const rhs = expr.in[1].map((item) => resolveSide(item, envelope))
+    return rhs.some((candidate) => strictEquals(lhs, candidate))
+  }
+  if ("gt" in expr) return compareTwo(expr.gt, envelope, ">")
+  if ("gte" in expr) return compareTwo(expr.gte, envelope, ">=")
+  if ("lt" in expr) return compareTwo(expr.lt, envelope, "<")
+  if ("lte" in expr) return compareTwo(expr.lte, envelope, "<=")
+  if ("exists" in expr) {
+    return resolveSide(expr.exists, envelope) !== undefined
+  }
+  if ("not" in expr) return !evaluatePredicate(expr.not, envelope)
+  if ("and" in expr) {
+    if (!Array.isArray(expr.and)) {
+      throw new PredicateEvalError("`and` clause must be an array of predicates")
+    }
+    return expr.and.every((sub) => evaluatePredicate(sub, envelope))
+  }
+  if ("or" in expr) {
+    if (!Array.isArray(expr.or)) {
+      throw new PredicateEvalError("`or` clause must be an array of predicates")
+    }
+    return expr.or.some((sub) => evaluatePredicate(sub, envelope))
+  }
+  throw new PredicateEvalError(`unknown predicate operator: ${stringify(expr)}`)
+}
+
+/**
+ * Resolve a path string against an envelope. Public so consumers (input
+ * mapper, manifest builder) can share the same path semantics without
+ * re-implementing them.
+ *
+ * Path syntax: dot-separated; `[N]` for array index; missing intermediate
+ * keys produce `undefined`. Roots: `data`, `metadata`, `name`, `emittedAt`.
+ *
+ * Returns `undefined` on any shape mismatch — that's how runtime evaluation
+ * stays no-throw.
+ */
+export function resolvePath(path: string, envelope: PredicateEnvelope): unknown {
+  const segments = parsePath(path)
+  if (segments.length === 0) return undefined
+  const [root, ...rest] = segments
+  let value: unknown
+  switch (root) {
+    case "name":
+      value = envelope.name
+      break
+    case "emittedAt":
+      value = envelope.emittedAt
+      break
+    case "data":
+      value = envelope.data
+      break
+    case "metadata":
+      value = envelope.metadata
+      break
+    default:
+      // Unknown roots evaluate to undefined at runtime. Registration-time
+      // linter surfaces this as a structural error so callers see it earlier.
+      return undefined
+  }
+  for (const segment of rest) {
+    if (value === undefined || value === null) return undefined
+    if (typeof segment === "number") {
+      if (!Array.isArray(value)) return undefined
+      value = value[segment]
+    } else {
+      if (typeof value !== "object") return undefined
+      value = (value as Record<string, unknown>)[segment]
+    }
+  }
+  return value
+}
+
+// ---- Static linter (registration-time) ----
+
+export interface PredicateValidationResult {
+  ok: boolean
+  errors: string[]
+}
+
+/**
+ * Static structural check on a `PredicateExpr`. Catches path roots that
+ * aren't `data`/`metadata`/`name`/`emittedAt`, type mismatches on
+ * comparison operators (number vs string lhs/rhs), and malformed grammars.
+ * Surfaced at `trigger.on()` registration so authoring errors fail fast.
+ */
+export function validatePredicate(expr: PredicateExpr): PredicateValidationResult {
+  const errors: string[] = []
+  walk(expr, errors, [])
+  return { ok: errors.length === 0, errors }
+}
+
+function walk(expr: PredicateExpr, errors: string[], path: string[]): void {
+  if (typeof expr !== "object" || expr === null) {
+    errors.push(`${pathLabel(path)}: predicate must be an object, got ${typeof expr}`)
+    return
+  }
+  const keys = Object.keys(expr)
+  if (keys.length !== 1) {
+    errors.push(
+      `${pathLabel(path)}: a predicate object must have exactly one operator key, got ${keys.length} (${keys.join(", ")})`,
+    )
+    return
+  }
+  const op = keys[0] as keyof PredicateExpr
+  switch (op) {
+    case "eq":
+    case "neq":
+    case "gt":
+    case "gte":
+    case "lt":
+    case "lte": {
+      const raw = (expr as Record<string, unknown>)[op]
+      if (!Array.isArray(raw) || raw.length !== 2) {
+        errors.push(`${pathLabel([...path, op])}: expected [lhs, rhs] tuple`)
+        return
+      }
+      const sides = raw as [PathOrLit, PathOrLit]
+      validateSide(sides[0], errors, [...path, op, "0"])
+      validateSide(sides[1], errors, [...path, op, "1"])
+      // Type-sanity for ordered comparisons: both literals must be the same numeric/string flavor.
+      if (op !== "eq" && op !== "neq") {
+        const lhsLit = sideLitType(sides[0])
+        const rhsLit = sideLitType(sides[1])
+        if (
+          lhsLit !== "unknown" &&
+          rhsLit !== "unknown" &&
+          lhsLit !== rhsLit &&
+          (lhsLit === "number" || lhsLit === "string")
+        ) {
+          errors.push(
+            `${pathLabel([...path, op])}: ordered comparison sides must agree on type (got ${lhsLit} vs ${rhsLit})`,
+          )
+        }
+      }
+      return
+    }
+    case "in": {
+      const tuple = (expr as { in: [PathOrLit, PathOrLit[]] }).in
+      if (!Array.isArray(tuple) || tuple.length !== 2) {
+        errors.push(`${pathLabel([...path, "in"])}: expected [lhs, rhs[]] tuple`)
+        return
+      }
+      validateSide(tuple[0], errors, [...path, "in", "0"])
+      if (!Array.isArray(tuple[1])) {
+        errors.push(`${pathLabel([...path, "in", "1"])}: rhs must be an array of paths/literals`)
+        return
+      }
+      for (let i = 0; i < tuple[1].length; i++) {
+        const s = tuple[1][i] as PathOrLit
+        validateSide(s, errors, [...path, "in", "1", String(i)])
+      }
+      return
+    }
+    case "exists":
+      validateSide((expr as { exists: PathOrLit }).exists, errors, [...path, "exists"])
+      return
+    case "not":
+      walk((expr as { not: PredicateExpr }).not, errors, [...path, "not"])
+      return
+    case "and":
+    case "or": {
+      const raw = (expr as Record<string, unknown>)[op]
+      if (!Array.isArray(raw)) {
+        errors.push(`${pathLabel([...path, op])}: ${op} must be an array of predicates`)
+        return
+      }
+      const arr = raw as PredicateExpr[]
+      for (let i = 0; i < arr.length; i++) {
+        const sub = arr[i] as PredicateExpr
+        walk(sub, errors, [...path, op, String(i)])
+      }
+      return
+    }
+    default:
+      errors.push(`${pathLabel(path)}: unknown predicate operator "${String(op)}"`)
+  }
+}
+
+function validateSide(side: PathOrLit, errors: string[], path: string[]): void {
+  if (typeof side !== "object" || side === null) {
+    errors.push(`${pathLabel(path)}: expected { path } or { lit }, got ${typeof side}`)
+    return
+  }
+  if ("path" in side) {
+    if (typeof side.path !== "string" || side.path.length === 0) {
+      errors.push(`${pathLabel(path)}: "path" must be a non-empty string`)
+      return
+    }
+    const root = parsePath(side.path)[0]
+    if (root !== "data" && root !== "metadata" && root !== "name" && root !== "emittedAt") {
+      errors.push(
+        `${pathLabel(path)}: path root "${String(root)}" is not one of data | metadata | name | emittedAt`,
+      )
+    }
+    return
+  }
+  if ("lit" in side) {
+    const t = typeof side.lit
+    if (t !== "string" && t !== "number" && t !== "boolean" && side.lit !== null) {
+      errors.push(`${pathLabel(path)}: lit must be string | number | boolean | null`)
+    }
+    return
+  }
+  errors.push(`${pathLabel(path)}: must specify "path" or "lit"`)
+}
+
+// ---- Internal helpers ----
+
+class PredicateEvalError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "PredicateEvalError"
+  }
+}
+
+function resolveSide(side: PathOrLit, envelope: PredicateEnvelope): unknown {
+  if ("lit" in side) return side.lit
+  if ("path" in side) return resolvePath(side.path, envelope)
+  return undefined
+}
+
+function strictEquals(a: unknown, b: unknown): boolean {
+  if (a === undefined || b === undefined) return false
+  if (a === null && b === null) return true
+  if (a === null || b === null) return false
+  if (typeof a !== typeof b) return false
+  if (typeof a === "object") {
+    // Strict equality only for primitives + null. Object equality is not
+    // supported in v1; users who need it project specific paths to compare.
+    return false
+  }
+  return a === b
+}
+
+function compareTwo(
+  sides: [PathOrLit, PathOrLit],
+  envelope: PredicateEnvelope,
+  op: ">" | ">=" | "<" | "<=",
+): boolean {
+  const lhs = resolveSide(sides[0], envelope)
+  const rhs = resolveSide(sides[1], envelope)
+  if (lhs === undefined || rhs === undefined) return false
+  if (typeof lhs !== typeof rhs) return false
+  if (typeof lhs !== "number" && typeof lhs !== "string") return false
+  switch (op) {
+    case ">":
+      return (lhs as number | string) > (rhs as number | string)
+    case ">=":
+      return (lhs as number | string) >= (rhs as number | string)
+    case "<":
+      return (lhs as number | string) < (rhs as number | string)
+    case "<=":
+      return (lhs as number | string) <= (rhs as number | string)
+  }
+}
+
+function sideLitType(side: PathOrLit): "number" | "string" | "boolean" | "null" | "unknown" {
+  if ("lit" in side) {
+    if (side.lit === null) return "null"
+    const t = typeof side.lit
+    if (t === "number" || t === "string" || t === "boolean") return t
+  }
+  return "unknown"
+}
+
+/**
+ * Parse a dot-and-bracket path into segments. `data.items[0].id` becomes
+ * `["data", "items", 0, "id"]`. Numeric segments inside `[N]` are returned
+ * as numbers; everything else as strings. Malformed input yields `[]`.
+ */
+function parsePath(path: string): Array<string | number> {
+  if (typeof path !== "string" || path.length === 0) return []
+  const segments: Array<string | number> = []
+  let i = 0
+  let buf = ""
+  const flushBuf = (): void => {
+    if (buf.length > 0) {
+      segments.push(buf)
+      buf = ""
+    }
+  }
+  while (i < path.length) {
+    const c = path[i]
+    if (c === ".") {
+      flushBuf()
+      i++
+      continue
+    }
+    if (c === "[") {
+      flushBuf()
+      const end = path.indexOf("]", i)
+      if (end === -1) return []
+      const idx = Number(path.slice(i + 1, end))
+      if (!Number.isInteger(idx) || idx < 0) return []
+      segments.push(idx)
+      i = end + 1
+      continue
+    }
+    buf += c
+    i++
+  }
+  flushBuf()
+  return segments
+}
+
+function pathLabel(path: string[]): string {
+  return path.length === 0 ? "(root)" : path.join(".")
+}
+
+function stringify(value: unknown): string {
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}

--- a/packages/workflows/src/events/registry.ts
+++ b/packages/workflows/src/events/registry.ts
@@ -1,0 +1,88 @@
+// Process-local registry for event-filter runtime entries.
+//
+// `trigger.on(eventName, filter)` adds an entry here at module-load time.
+// `createApp()` (PR4) walks `getEventFilterRegistry().list()` to build a
+// manifest, hand it to the configured driver, and install the EventBus
+// forwarder.
+//
+// Backed by `globalThis` so bundles that inline their own copy of
+// `@voyantjs/workflows` still share the registry with the loader's copy
+// — same pattern `getWorkflow()` uses for the workflow registry.
+//
+// Architecture: docs/architecture/workflows-runtime-architecture.md §12.
+
+import type { EventFilterManifestEntry } from "../protocol/index.js"
+import type { EventFilterDeclaration } from "../trigger.js"
+
+const REGISTRY_KEY = "__voyantEventFilterRegistry" as const
+
+/**
+ * Internal/runtime form of a registered event filter. Carries:
+ *   - The serializable manifest entry (sent to drivers, persisted in
+ *     manifest stores, evaluated by the event router).
+ *   - A debug-only structural copy of the original declaration. Not
+ *     serialized; used by the dashboard / dev mode for human-readable
+ *     filter inspection.
+ *
+ * Concrete `WorkflowDefinition` from `workflow.ts` satisfies the structural
+ * `target` shape via TypeScript compat.
+ */
+export interface EventFilterRuntimeEntry {
+  readonly id: string
+  readonly eventType: string
+  readonly manifest: EventFilterManifestEntry
+  /** Debug-only — non-serializable. */
+  readonly declaration: EventFilterDeclaration<unknown>
+  /** Workflow id this filter targets, for quick lookup. */
+  readonly targetWorkflowId: string
+}
+
+interface EventFilterRegistry {
+  add(entry: EventFilterRuntimeEntry): void
+  list(): EventFilterRuntimeEntry[]
+  /** Reset to empty. Test-only — production code never calls this. */
+  reset(): void
+}
+
+const globalRef = globalThis as unknown as Record<
+  typeof REGISTRY_KEY,
+  Map<string, EventFilterRuntimeEntry> | undefined
+>
+
+const REGISTRY: Map<string, EventFilterRuntimeEntry> =
+  globalRef[REGISTRY_KEY] ?? new Map<string, EventFilterRuntimeEntry>()
+globalRef[REGISTRY_KEY] = REGISTRY
+
+const registry: EventFilterRegistry = {
+  add(entry) {
+    if (REGISTRY.has(entry.id)) {
+      // Same id implies same canonicalized declaration. HMR re-imports
+      // and re-evaluations of the same module file land here; replace
+      // (overwrite is harmless since the entry is content-addressed).
+      // For genuine duplicates from different declarations, the canonical
+      // hash would differ, so different ids would result.
+      REGISTRY.set(entry.id, entry)
+      return
+    }
+    REGISTRY.set(entry.id, entry)
+  },
+  list() {
+    return [...REGISTRY.values()]
+  },
+  reset() {
+    REGISTRY.clear()
+  },
+}
+
+/** Process-local event-filter registry. Singleton per realm. */
+export function getEventFilterRegistry(): EventFilterRegistry {
+  return registry
+}
+
+/**
+ * Internal: clear every registered filter. Used by tests that import the
+ * SDK and need a clean slate between cases. Not part of the public API.
+ */
+export function __resetEventFilterRegistry(): void {
+  registry.reset()
+}

--- a/packages/workflows/src/protocol/index.ts
+++ b/packages/workflows/src/protocol/index.ts
@@ -83,11 +83,26 @@ export interface ManifestSchedule {
 }
 
 export interface EventFilterManifestEntry {
+  /** Stable id derived from `payloadHash` of the canonicalized declaration. */
   id: string
+  /** Event name the filter targets — matches `EventEnvelope.name`. */
   eventType: string
-  scope?: string
-  matchExpression?: string
+  /**
+   * Optional structured `where` predicate. When absent, every event of the
+   * matching `eventType` fires the target workflow. Concrete shape lives in
+   * `@voyantjs/workflows/events` (`PredicateExpr`); the protocol declares
+   * it as an opaque object so old orchestrators that don't understand the
+   * shape don't have to evaluate it.
+   */
+  where?: unknown
+  /**
+   * Optional input mapper. When absent, the workflow input = `envelope.data`.
+   * Concrete shape lives in `@voyantjs/workflows/events` (`InputMapper`).
+   */
+  input?: unknown
+  /** Content-derived hash of the canonicalized declaration. */
   payloadHash: string
+  /** Workflow id this filter triggers. */
   targetWorkflowId: string
 }
 

--- a/packages/workflows/src/trigger.ts
+++ b/packages/workflows/src/trigger.ts
@@ -2,7 +2,7 @@
 // Authoritative contract in docs/sdk-surface.md §6.
 
 import type { Duration, EnvironmentName, RunStatus } from "./types.js"
-import type { EnvironmentContext, WorkflowHandle } from "./workflow.js"
+import type { WorkflowHandle } from "./workflow.js"
 
 // ---- workflows.* ----
 
@@ -112,16 +112,32 @@ export const workflows: WorkflowsClient = new Proxy({} as WorkflowsClient, {
 
 // ---- trigger.on ----
 
+import { compileAndRegister } from "./events/compile.js"
+import type { InputMapper } from "./events/input-mapper.js"
+import type { PredicateExpr } from "./events/predicate.js"
+
 export interface EventFilterHandle {
   readonly id: string
   readonly event: string
 }
 
+/**
+ * Declarative binding from an event name to a target workflow. Authors call
+ * `trigger.on(eventName, declaration)` at module-load time; the framework
+ * collects the entries via the process-local registry (see
+ * `./events/registry.js`) and ships them in the manifest.
+ *
+ * `where` and `input` are structured DSLs (no callbacks) so the runtime
+ * can evaluate them anywhere — in-process for self-host, server-side for
+ * managed deployments. The previous `match` callback is no longer
+ * supported; registration throws if it's set.
+ */
 export interface EventFilterDeclaration<T> {
   target: WorkflowHandle<T, unknown>
-  match?: (payload: T, ctx: { environment: EnvironmentContext; project: { id: string } }) => boolean
-  scope?: string
-  input?: (payload: T) => unknown
+  /** Structured predicate; see `@voyantjs/workflows/events` `PredicateExpr`. */
+  where?: PredicateExpr
+  /** Structured input projection; see `@voyantjs/workflows/events` `InputMapper`. */
+  input?: InputMapper
 }
 
 export interface TriggerApi {
@@ -129,11 +145,7 @@ export interface TriggerApi {
 }
 
 export const trigger: TriggerApi = {
-  on<T>(_event: string, _filter: EventFilterDeclaration<T>): EventFilterHandle {
-    throw new Error(
-      "@voyantjs/workflows: trigger.on() must be collected by `voyant workflows build` and " +
-        "registered with the orchestrator at deploy time; it has no runtime behavior when " +
-        "called directly. See docs/sdk-surface.md §6.2.",
-    )
+  on<T>(event: string, filter: EventFilterDeclaration<T>): EventFilterHandle {
+    return compileAndRegister(event, filter)
   },
 }


### PR DESCRIPTION
## Summary
PR2 of 4 in the #514 stack — adds the `trigger.on()` runtime: structured `where`/`input` DSLs, manifest builder with stable content-derived ids, process-local event-filter registry, and a pure event router that maps incoming envelopes to queued workflow triggers.

Builds on PR1 (#520, merged) which delivered the `WorkflowDriver` abstraction + InMemory + Mode 2 (Postgres) drivers.

### What's new
- **`@voyantjs/workflows/events`** — new sub-entry exposing:
  - `PredicateExpr` (12-operator structural DSL) + `validatePredicate` + `evaluatePredicate`
  - `InputMapper` (path/literal/object projection) + `validateInputMapper` + `projectInput`
  - `canonicalize`/`canonicalJson`/`sha256`/`shortHash` for content-derived ids
  - `compileEventFilterSync` + process-local `getEventFilterRegistry`
  - `buildManifest` (per-env, includes `payloadHash` per filter + global `versionId`)
  - `deriveStableEventId(envelope)` — `evt_<safeName>_<safeAt>_<sha256(canonical(data)).slice(0,12)>`
- **`trigger.on(eventName, { target, where?, input? })`** — replaces the throwing proxy; calls `compileAndRegister`
- **`@voyantjs/workflows-orchestrator/event-router`** — `routeEvent({ manifest, envelope, eventId, idempotencyOverride })` → `RouterMatch[]` (queued/skipped)

### Reviewer findings addressed (P1.1 / P2.2)
- **P1.1 — Postgres race**: trigger() now uses `tryInsert()` (atomic check-or-insert) on the idempotent path. RunRecordStore gained `tryInsert(record): Promise<{ record, created }>`. New compliance test fires 8 parallel triggers with the same idempotency key and asserts ≤ 1 invocation.
- **P2.2 — random eventId**: switched to `deriveStableEventId(envelope)` so the same envelope always gets the same id (no double-trigger on retry).

### Migrations
- `0003_idempotency_key.sql` — adds `idempotency_key` column + unique partial index on `voyant_snapshot_runs`
- `0004_workflow_manifests.sql` — new `voyant_workflow_manifests` table (env-scoped)

## Test plan
- [x] `pnpm -F @voyantjs/workflows... typecheck` — clean
- [x] `pnpm -F @voyantjs/workflows... test` — all green
- [x] Driver compliance suite (parameterized over capability flags) passes for InMemory + CF in-process fake + Mode 2 (Postgres)
- [x] Race compliance test (8 parallel idempotent triggers ≤ 1 invocation) passes
- [x] Stable-eventId test passes