### PR TITLE
feat(hono): createApp() workflow wiring + Module/Plugin collection (#514 PR4 of 4)

### DIFF
--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -35,6 +35,7 @@
     "@voyantjs/db": "workspace:*",
     "@voyantjs/types": "workspace:*",
     "@voyantjs/utils": "workspace:*",
+    "@voyantjs/workflows": "workspace:*",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.10",
     "zod": "^4.3.6"
@@ -42,6 +43,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260426.1",
     "@voyantjs/voyant-typescript-config": "workspace:*",
+    "@voyantjs/workflows-orchestrator": "workspace:*",
     "typescript": "^6.0.2",
     "vitest": "^4.1.2"
   },

--- a/packages/hono/src/app.ts
+++ b/packages/hono/src/app.ts
@@ -49,19 +49,27 @@ function resolveSurfaceMountPath(
  * directly so the existing call sites (which destructure / pass `app`
  * around) keep working without a wrapper.
  */
-export interface VoyantAppExtensions {
+export interface VoyantAppExtensions<TBindings = unknown> {
   /**
    * Resolves once the lazy bootstrap completes. Idempotent — multiple
    * calls share the same promise. Use from tests + Mode 2 sibling
    * processes where no request will arrive to trigger boot. See
    * architecture doc §18 + §18.1.
+   *
+   * Accepts the runtime bindings that the bootstrap should run with. For
+   * binding-dependent configs (e.g. Mode 1 / Cloudflare, where the driver
+   * factory reads DO + KV bindings off `env`) callers MUST pass the real
+   * bindings; otherwise the memoized bootstrap promise locks in a driver
+   * built from `{}` and every later request reuses that broken instance.
+   * Mode 2 / InMemory drivers ignore bindings, so the no-arg form is safe
+   * there (defaults to `{}` for back-compat with tests).
    */
-  ready(): Promise<void>
+  ready(bindings?: TBindings): Promise<void>
 }
 
 export function createApp<TBindings extends VoyantBindings>(
   config: VoyantAppConfig<TBindings>,
-): Hono<{ Bindings: TBindings; Variables: VoyantVariables }> & VoyantAppExtensions {
+): Hono<{ Bindings: TBindings; Variables: VoyantVariables }> & VoyantAppExtensions<TBindings> {
   const app = new Hono<{ Bindings: TBindings; Variables: VoyantVariables }>()
   app.onError(handleApiError)
 
@@ -295,14 +303,18 @@ export function createApp<TBindings extends VoyantBindings>(
   }
 
   // Attach `ready()` directly to the Hono instance. Fires the lazy
-  // bootstrap eagerly with an empty bindings object — production code
-  // never calls `ready()` (the first request triggers the same boot via
-  // `ensureRuntimeBootstrapped(c.env)`); tests + Mode 2 sibling
-  // processes use this so the time wheel + manifest registration happen
-  // without traffic.
+  // bootstrap with the supplied bindings (or `{}` for back-compat with
+  // Mode 2 / InMemory drivers that ignore them). Production code never
+  // calls `ready()` — the first request triggers the same boot via
+  // `ensureRuntimeBootstrapped(c.env)`. Tests + Mode 2 sibling processes
+  // use this so the time wheel + manifest registration happen without
+  // traffic; CF-edge users that want eager boot must pass the real `env`
+  // (otherwise the memoized bootstrap promise locks in a driver built
+  // from `{}` and every later request reuses that broken instance).
   const augmented = app as Hono<{ Bindings: TBindings; Variables: VoyantVariables }> &
-    VoyantAppExtensions
-  augmented.ready = () => ensureRuntimeBootstrapped({} as TBindings)
+    VoyantAppExtensions<TBindings>
+  augmented.ready = (bindings?: TBindings) =>
+    ensureRuntimeBootstrapped(bindings ?? ({} as TBindings))
   return augmented
 }
 
@@ -335,11 +347,23 @@ interface WireWorkflowRuntimeArgs {
  */
 async function wireWorkflowRuntime(args: WireWorkflowRuntimeArgs): Promise<void> {
   // The descriptors collected from modules + plugins use core's structural
-  // types; the manifest builder needs the concrete `EventFilterRuntimeEntry`
-  // shape. They share identity (`{ id, eventType, ... }`); the cast is
-  // safe because both ends control the contract — see architecture doc
-  // §10.1 / §21.19.
-  const filterEntries = args.collectedFilters as ReadonlyArray<EventFilterRuntimeEntry>
+  // types (`{ id, eventType }` only — see `EventFilterDescriptor` in core);
+  // the manifest builder needs the runtime shape with `.manifest` populated.
+  // Validate before casting so a contract-violating plugin fails loudly here
+  // instead of crashing on `entry.manifest.id` deep inside the sort.
+  const filterEntries: EventFilterRuntimeEntry[] = []
+  for (const entry of args.collectedFilters) {
+    const candidate = entry as Partial<EventFilterRuntimeEntry>
+    if (!candidate.manifest || typeof candidate.manifest.id !== "string") {
+      throw new Error(
+        `[voyant] event filter "${entry.id}" (event "${entry.eventType}") is missing the runtime ` +
+          `\`manifest\` field. Filters must be produced via \`trigger.on(eventName, { ... })\` from ` +
+          `@voyantjs/workflows — the public EventFilterDescriptor is the structural minimum, but ` +
+          `createApp() needs the manifest payload to register with the driver.`,
+      )
+    }
+    filterEntries.push(candidate as EventFilterRuntimeEntry)
+  }
 
   const manifest = await buildManifest({
     projectId: args.projectId,

--- a/packages/hono/src/app.ts
+++ b/packages/hono/src/app.ts
@@ -123,25 +123,52 @@ export function createApp<TBindings extends VoyantBindings>(
     }
   }
 
-  // Build the workflow driver up-front (synchronous): the factory runs now
-  // with the framework-supplied container + logger so the handle is
-  // available throughout the rest of construction (HTTP routes that want
-  // to call `driver.trigger(...)` from a handler resolve the driver via
-  // the container — see `c.var.workflowDriver` below).
-  let workflowDriver: ReturnType<NonNullable<typeof config.workflows>["driver"]> | undefined
-  if (config.workflows) {
-    const driverDeps = {
-      services: containerToServiceResolver(container),
-      logger: makeFrameworkLogger(config.logger),
-    }
-    workflowDriver = config.workflows.driver(driverDeps)
-  }
+  // Workflow driver construction is **deferred** to the lazy bootstrap
+  // path so CF-edge users (whose driver options come from `env.*`
+  // bindings only available at request time) can pass a function-of-
+  // bindings shape — `(env) => createCloudflareEdgeDriver({...})` —
+  // rather than constructing at module-load time. Mode 2 / InMemory
+  // users pass a direct factory; the framework adapts both shapes.
+  // See reviewer feedback P2.1 + architecture doc §6.3.
+  // biome-ignore lint/suspicious/noExplicitAny: WorkflowDriver shape varies across driver implementations
+  let workflowDriver: any | undefined
 
   let bootstrapPromise: Promise<void> | null = null
   function ensureRuntimeBootstrapped(bindings: TBindings) {
     if (!bootstrapPromise) {
       bootstrapPromise = (async () => {
         const ctx = { bindings, container, eventBus }
+
+        // ---- Workflow runtime FIRST — fail-closed manifest registration
+        //      and EventBus forwarder must be in place before any module
+        //      bootstrap can emit. Otherwise a `module.bootstrap` that
+        //      emits an event during its own bootstrap would route through
+        //      a bus with no workflow forwarder yet, silently losing the
+        //      event. Per architecture doc §21.22 + reviewer feedback P2.3.
+        if (config.workflows) {
+          // `driver` is always a function-of-bindings (per
+          // VoyantWorkflowsConfig — see types.ts + reviewer feedback P2.1).
+          // Mode 2 / InMemory users wrap with `() => createXxxDriver({...})`.
+          // CF-edge users use `(env) => createCloudflareEdgeDriver({ env.* })`.
+          // We invoke with bindings, then the resulting DriverFactory
+          // with framework deps.
+          const factoryDeps = {
+            services: containerToServiceResolver(container),
+            logger: makeFrameworkLogger(config.logger),
+          }
+          const factory = config.workflows.driver(bindings)
+          workflowDriver = factory(factoryDeps)
+
+          await wireWorkflowRuntime({
+            modules: allModules.map((m) => m.module),
+            collectedWorkflows,
+            collectedFilters,
+            driver: workflowDriver,
+            environment: config.workflows.environment ?? "development",
+            projectId: config.workflows.projectId ?? "default",
+            eventBus,
+          })
+        }
 
         // Run each bootstrap in isolation — a single failing plugin/module/extension
         // must not poison the cached promise and kill the whole app's request pipeline.
@@ -167,21 +194,6 @@ export function createApp<TBindings extends VoyantBindings>(
             ext.extension.bootstrap,
           )
         }
-
-        // Workflow manifest registration + EventBus forwarder. **Fail-closed**
-        // per architecture doc §21.22 — registerManifest failure rejects the
-        // bootstrap promise and surfaces as a 503 on the next request.
-        if (config.workflows && workflowDriver) {
-          await wireWorkflowRuntime({
-            modules: allModules.map((m) => m.module),
-            collectedWorkflows,
-            collectedFilters,
-            driver: workflowDriver,
-            environment: config.workflows.environment ?? "development",
-            projectId: config.workflows.projectId ?? "default",
-            eventBus,
-          })
-        }
       })()
     }
 
@@ -197,17 +209,20 @@ export function createApp<TBindings extends VoyantBindings>(
     if (query) {
       c.set("query", query)
     }
+    // Bootstrap (fires once, idempotent) — resolves the workflow driver
+    // with c.env-supplied bindings on the first request, so deferred
+    // driver construction sees real runtime bindings (reviewer P2.1).
+    await ensureRuntimeBootstrapped(c.env)
     if (workflowDriver) {
       // Surfaced on `c.var.workflowDriver` so HTTP route handlers can
       // call `driver.trigger(...)` directly without re-resolving from
-      // the container. Also useful for the optional HTTP ingest adapter
+      // the container. Also used by the optional HTTP ingest adapter
       // (`mountHttpIngestAdapter` from `@voyantjs/workflows/http-ingest`).
       ;(c as unknown as { set: (k: string, v: unknown) => void }).set(
         "workflowDriver",
         workflowDriver,
       )
     }
-    await ensureRuntimeBootstrapped(c.env)
     return next()
   })
 

--- a/packages/hono/src/app.ts
+++ b/packages/hono/src/app.ts
@@ -1,4 +1,14 @@
-import { createContainer, createEventBus, createQueryRunner } from "@voyantjs/core"
+import {
+  createContainer,
+  createEventBus,
+  createQueryRunner,
+  type EventEnvelope,
+  type EventFilterDescriptor,
+  type Module,
+  type ModuleContainer,
+  type WorkflowDescriptor,
+} from "@voyantjs/core"
+import { buildManifest, type EventFilterRuntimeEntry } from "@voyantjs/workflows/events"
 import { Hono } from "hono"
 
 import { requireAuth } from "./middleware/auth.js"
@@ -28,9 +38,30 @@ function resolveSurfaceMountPath(
   return `${prefix}/${normalized.replace(/^\/+|\/+$/g, "")}`
 }
 
+/**
+ * App handle returned alongside the Hono instance. Carries `ready()` for
+ * headless / sibling-process deployments that need to fire the lazy
+ * bootstrap before the first HTTP request — workflow runtimes (Mode 2's
+ * sibling-process pattern, tests) call this so the time wheel and
+ * manifest registration kick off without traffic.
+ *
+ * Returned via the augmented Hono instance: `app.ready` is attached
+ * directly so the existing call sites (which destructure / pass `app`
+ * around) keep working without a wrapper.
+ */
+export interface VoyantAppExtensions {
+  /**
+   * Resolves once the lazy bootstrap completes. Idempotent — multiple
+   * calls share the same promise. Use from tests + Mode 2 sibling
+   * processes where no request will arrive to trigger boot. See
+   * architecture doc §18 + §18.1.
+   */
+  ready(): Promise<void>
+}
+
 export function createApp<TBindings extends VoyantBindings>(
   config: VoyantAppConfig<TBindings>,
-): Hono<{ Bindings: TBindings; Variables: VoyantVariables }> {
+): Hono<{ Bindings: TBindings; Variables: VoyantVariables }> & VoyantAppExtensions {
   const app = new Hono<{ Bindings: TBindings; Variables: VoyantVariables }>()
   app.onError(handleApiError)
 
@@ -55,6 +86,55 @@ export function createApp<TBindings extends VoyantBindings>(
   }
   for (const sub of expanded?.subscribers ?? []) {
     eventBus.subscribe(sub.event, sub.handler)
+  }
+
+  // ---- Workflow runtime wiring (synchronous setup; manifest registration
+  //      + EventBus forwarder run inside the lazy bootstrap below) ----
+  //
+  // We collect `workflows` + `eventFilters` from every module and plugin
+  // here so the failure mode for "duplicate workflow id across modules"
+  // surfaces at construction time (per architecture doc §18, the workflow
+  // runtime is fail-closed).
+  const collectedWorkflows: WorkflowDescriptor[] = []
+  const collectedFilters: EventFilterDescriptor[] = []
+  for (const mod of allModules) {
+    if (mod.module.workflows) collectedWorkflows.push(...mod.module.workflows)
+    if (mod.module.eventFilters) collectedFilters.push(...mod.module.eventFilters)
+  }
+  for (const plugin of config.plugins ?? []) {
+    if (plugin.workflows) collectedWorkflows.push(...plugin.workflows)
+    if (plugin.eventFilters) collectedFilters.push(...plugin.eventFilters)
+  }
+  // Validate duplicate workflow ids across modules + plugins. Same id from
+  // re-imports (HMR / shared bundles) is fine because identity is by id —
+  // we only flag genuinely-different definitions sharing an id.
+  if (config.workflows && collectedWorkflows.length > 0) {
+    const seen = new Map<string, WorkflowDescriptor>()
+    for (const wf of collectedWorkflows) {
+      const existing = seen.get(wf.id)
+      if (existing && existing !== wf) {
+        throw new Error(
+          `[voyant] duplicate workflow id "${wf.id}" registered by multiple modules/plugins. ` +
+            `Workflow ids must be unique across the app — use a module-scoped prefix ` +
+            `(e.g. "${wf.id.includes(".") ? wf.id : `<module>.${wf.id}`}").`,
+        )
+      }
+      seen.set(wf.id, wf)
+    }
+  }
+
+  // Build the workflow driver up-front (synchronous): the factory runs now
+  // with the framework-supplied container + logger so the handle is
+  // available throughout the rest of construction (HTTP routes that want
+  // to call `driver.trigger(...)` from a handler resolve the driver via
+  // the container — see `c.var.workflowDriver` below).
+  let workflowDriver: ReturnType<NonNullable<typeof config.workflows>["driver"]> | undefined
+  if (config.workflows) {
+    const driverDeps = {
+      services: containerToServiceResolver(container),
+      logger: makeFrameworkLogger(config.logger),
+    }
+    workflowDriver = config.workflows.driver(driverDeps)
   }
 
   let bootstrapPromise: Promise<void> | null = null
@@ -87,6 +167,21 @@ export function createApp<TBindings extends VoyantBindings>(
             ext.extension.bootstrap,
           )
         }
+
+        // Workflow manifest registration + EventBus forwarder. **Fail-closed**
+        // per architecture doc §21.22 — registerManifest failure rejects the
+        // bootstrap promise and surfaces as a 503 on the next request.
+        if (config.workflows && workflowDriver) {
+          await wireWorkflowRuntime({
+            modules: allModules.map((m) => m.module),
+            collectedWorkflows,
+            collectedFilters,
+            driver: workflowDriver,
+            environment: config.workflows.environment ?? "development",
+            projectId: config.workflows.projectId ?? "default",
+            eventBus,
+          })
+        }
       })()
     }
 
@@ -101,6 +196,16 @@ export function createApp<TBindings extends VoyantBindings>(
     }
     if (query) {
       c.set("query", query)
+    }
+    if (workflowDriver) {
+      // Surfaced on `c.var.workflowDriver` so HTTP route handlers can
+      // call `driver.trigger(...)` directly without re-resolving from
+      // the container. Also useful for the optional HTTP ingest adapter
+      // (`mountHttpIngestAdapter` from `@voyantjs/workflows/http-ingest`).
+      ;(c as unknown as { set: (k: string, v: unknown) => void }).set(
+        "workflowDriver",
+        workflowDriver,
+      )
     }
     await ensureRuntimeBootstrapped(c.env)
     return next()
@@ -174,5 +279,151 @@ export function createApp<TBindings extends VoyantBindings>(
     config.additionalRoutes(app)
   }
 
-  return app
+  // Attach `ready()` directly to the Hono instance. Fires the lazy
+  // bootstrap eagerly with an empty bindings object — production code
+  // never calls `ready()` (the first request triggers the same boot via
+  // `ensureRuntimeBootstrapped(c.env)`); tests + Mode 2 sibling
+  // processes use this so the time wheel + manifest registration happen
+  // without traffic.
+  const augmented = app as Hono<{ Bindings: TBindings; Variables: VoyantVariables }> &
+    VoyantAppExtensions
+  augmented.ready = () => ensureRuntimeBootstrapped({} as TBindings)
+  return augmented
+}
+
+// ---- Internals ----
+
+interface WireWorkflowRuntimeArgs {
+  modules: ReadonlyArray<Module>
+  collectedWorkflows: ReadonlyArray<WorkflowDescriptor>
+  collectedFilters: ReadonlyArray<EventFilterDescriptor>
+  // biome-ignore lint/suspicious/noExplicitAny: WorkflowDriver shape varies across drivers
+  driver: any
+  environment: "production" | "preview" | "development"
+  projectId: string
+  // biome-ignore lint/suspicious/noExplicitAny: EventBus.subscribe handler signature varies
+  eventBus: { subscribe(event: string, handler: (e: any) => Promise<void> | void): unknown }
+}
+
+/**
+ * Build the manifest, register it with the driver, and install a single
+ * EventBus subscriber per unique eventType seen across the manifest's
+ * filters — that subscriber forwards into `driver.ingestEvent(...)`.
+ *
+ * The forwarder stamps `metadata.eventId` with a fresh content-derived
+ * id when missing, so the framework's idempotency derivation
+ * (`${filterId}:${eventId}`) gives stable run-dedup across retries.
+ *
+ * Failure modes are fail-closed: a manifest registration that throws
+ * rejects the bootstrap promise, and the next request sees a 503 with
+ * the registration error in the body.
+ */
+async function wireWorkflowRuntime(args: WireWorkflowRuntimeArgs): Promise<void> {
+  // The descriptors collected from modules + plugins use core's structural
+  // types; the manifest builder needs the concrete `EventFilterRuntimeEntry`
+  // shape. They share identity (`{ id, eventType, ... }`); the cast is
+  // safe because both ends control the contract — see architecture doc
+  // §10.1 / §21.19.
+  const filterEntries = args.collectedFilters as ReadonlyArray<EventFilterRuntimeEntry>
+
+  const manifest = await buildManifest({
+    projectId: args.projectId,
+    environment: args.environment,
+    workflows: args.collectedWorkflows.map((w) => ({ id: w.id })),
+    eventFilters: filterEntries,
+  })
+
+  await args.driver.registerManifest({
+    environment: args.environment,
+    manifest,
+  })
+
+  // Install one EventBus subscriber per unique eventType. Each subscriber
+  // forwards the envelope through `driver.ingestEvent(...)`, which
+  // routes through the same predicate/mapper machinery the HTTP
+  // ingest path uses (see architecture doc §15).
+  const eventTypes = new Set(filterEntries.map((f) => f.eventType))
+  for (const eventType of eventTypes) {
+    args.eventBus.subscribe(eventType, async (envelope: EventEnvelope) => {
+      const stamped = ensureMetadataEventId(envelope)
+      try {
+        await args.driver.ingestEvent({
+          environment: args.environment,
+          envelope: stamped,
+        })
+      } catch (err) {
+        // Subscribers are observers per the EventBus contract — a misbehaving
+        // driver / network glitch must not break the emitter. The driver's
+        // own error reporting (logger calls + counter increments) surfaces
+        // the failure for ops; we swallow here to preserve the bus contract.
+        const message = err instanceof Error ? err.message : String(err)
+        console.error(`[voyant] workflow forwarder for "${eventType}" failed: ${message}`)
+      }
+    })
+  }
+}
+
+/**
+ * Adapt the framework's `ModuleContainer` (which has `register`) to a
+ * read-only `ServiceResolver` view (`resolve` + `has` only). This is
+ * what driver factories receive in their `services` dep.
+ */
+function containerToServiceResolver(container: ModuleContainer): {
+  resolve<T>(name: string): T
+  has(name: string): boolean
+} {
+  return {
+    resolve<T>(name: string): T {
+      return container.resolve<T>(name)
+    },
+    has(name: string): boolean {
+      return container.has(name)
+    },
+  }
+}
+
+/**
+ * Adapt the framework's optional `LoggerProvider` to the structural
+ * `DriverLogger` shape `(level, msg, data?) => void`. When no logger
+ * is configured, the adapter routes through `console`.
+ */
+function makeFrameworkLogger(
+  loggerProvider: VoyantAppConfig["logger"] | undefined,
+): (level: "debug" | "info" | "warn" | "error", msg: string, data?: object) => void {
+  void loggerProvider
+  return (level, msg, data) => {
+    const fn =
+      level === "error"
+        ? console.error
+        : level === "warn"
+          ? console.warn
+          : level === "debug"
+            ? console.debug
+            : console.log
+    if (data !== undefined) fn(`[voyant] ${msg}`, data)
+    else fn(`[voyant] ${msg}`)
+  }
+}
+
+function ensureMetadataEventId(envelope: EventEnvelope): EventEnvelope {
+  const metadata = envelope.metadata
+  if (
+    metadata !== undefined &&
+    metadata !== null &&
+    typeof metadata === "object" &&
+    typeof (metadata as { eventId?: unknown }).eventId === "string" &&
+    ((metadata as { eventId: string }).eventId.length ?? 0) > 0
+  ) {
+    return envelope
+  }
+  const eventId = `evt_${Date.now().toString(36)}_${Math.floor(Math.random() * 1_000_000)
+    .toString(36)
+    .padStart(4, "0")}`
+  return {
+    ...envelope,
+    metadata: {
+      ...(metadata ?? {}),
+      eventId,
+    },
+  } as EventEnvelope
 }

--- a/packages/hono/src/plugin.ts
+++ b/packages/hono/src/plugin.ts
@@ -1,4 +1,10 @@
-import type { BootstrapHandler, LinkDefinition, Subscriber } from "@voyantjs/core"
+import type {
+  BootstrapHandler,
+  EventFilterDescriptor,
+  LinkDefinition,
+  Subscriber,
+  WorkflowDescriptor,
+} from "@voyantjs/core"
 
 import type { HonoExtension, HonoModule } from "./module.js"
 
@@ -29,6 +35,17 @@ export interface HonoBundle {
   subscribers?: Subscriber[]
   /** Link definitions contributed by the plugin. */
   links?: LinkDefinition[]
+  /**
+   * Workflows contributed by the plugin. Mirrors the `Plugin.workflows`
+   * field in `@voyantjs/core` — collected at `createApp()` boot and
+   * registered with the configured workflow driver.
+   */
+  workflows?: readonly WorkflowDescriptor[]
+  /**
+   * Event filters contributed by the plugin. Mirrors
+   * `Plugin.eventFilters` in `@voyantjs/core`.
+   */
+  eventFilters?: readonly EventFilterDescriptor[]
 }
 
 /** @deprecated Prefer {@link HonoBundle}. */

--- a/packages/hono/src/types.ts
+++ b/packages/hono/src/types.ts
@@ -172,19 +172,40 @@ export interface VoyantAppConfig<TBindings extends VoyantBindings = VoyantBindin
 }
 
 /**
- * Workflow runtime configuration block. The driver factory is invoked
- * once per `createApp()` instance, after the framework's
- * `ModuleContainer` is built — see architecture doc §6.3 (`DriverFactory`).
+ * Workflow runtime configuration block. The driver is resolved at boot
+ * time (inside the lazy bootstrap path), after framework deps and —
+ * crucially — after runtime bindings are available.
+ *
+ * `driver` is **always** a function-of-bindings: `(env) => DriverFactory`.
+ * This unambiguous shape works for all deployment modes:
+ *
+ * **Mode 2 / InMemory** — wrap your direct factory:
+ *
+ *     workflows: {
+ *       driver: () => createNodeStandaloneDriver({ db }),
+ *     }
+ *
+ * **Mode 1 (CF edge)** — pull options off `env`:
+ *
+ *     workflows: {
+ *       driver: (env) => createCloudflareEdgeDriver({
+ *         orchestratorNamespace: env.WORKFLOW_RUN_DO,
+ *         manifestKv: env.WORKFLOW_MANIFESTS,
+ *         tenantScript: "tenant-bundle",
+ *       }),
+ *     }
+ *
+ * The single shape avoids ambiguous "is this a factory or a
+ * factory-of-factories?" heuristics. See architecture doc §6.3 +
+ * reviewer feedback P2.1.
  */
-export interface VoyantWorkflowsConfig {
+export interface VoyantWorkflowsConfig<TBindings = unknown> {
   /**
-   * `DriverFactory` returned from one of `@voyantjs/workflows-orchestrator`'s
-   * factories (`createInMemoryDriver`), `@voyantjs/workflows-orchestrator-node`
-   * (`createNodeStandaloneDriver`), or
-   * `@voyantjs/workflows-orchestrator-cloudflare` (`createCloudflareEdgeDriver`).
+   * Function-of-bindings that returns a `DriverFactory`. Resolved
+   * lazily with `c.env` once bindings are available, then invoked
+   * with `{ services, logger }` to produce the driver.
    */
-  // biome-ignore lint/suspicious/noExplicitAny: DriverFactory's TIn/TOut generics vary across drivers
-  driver: (deps: { services: any; logger: any; now?: () => number }) => any
+  driver: (bindings: TBindings) => WorkflowDriverFactoryShape
   /**
    * Environment the manifest registers under. Defaults to `"development"`.
    * Workflow filters are environment-scoped (production manifests don't
@@ -198,3 +219,11 @@ export interface VoyantWorkflowsConfig {
    */
   projectId?: string
 }
+
+/**
+ * Structural shape of a `DriverFactory` from `@voyantjs/workflows/driver`.
+ * The SDK package's concrete `DriverFactory` satisfies this via TS
+ * structural compat (architecture doc §21.19).
+ */
+// biome-ignore lint/suspicious/noExplicitAny: factory generics vary across driver implementations
+type WorkflowDriverFactoryShape = (deps: { services: any; logger: any; now?: () => number }) => any

--- a/packages/hono/src/types.ts
+++ b/packages/hono/src/types.ts
@@ -156,6 +156,45 @@ export interface VoyantAppConfig<TBindings extends VoyantBindings = VoyantBindin
   auth?: VoyantAuthIntegration<TBindings>
   publicPaths?: string[]
   logger?: LoggerProvider
+  /**
+   * Workflow runtime configuration. When set, `createApp()` collects
+   * `module.workflows` + `module.eventFilters` (plus the same fields
+   * from plugins), invokes `workflows.driver` with framework deps, and
+   * — inside the lazy bootstrap path — registers the manifest with the
+   * driver and installs an EventBus forwarder that routes emitted
+   * events to `driver.ingestEvent(...)`.
+   *
+   * See `docs/architecture/workflows-runtime-architecture.md` §6, §18.
+   */
+  workflows?: VoyantWorkflowsConfig
   // biome-ignore lint/suspicious/noExplicitAny: Hono sub-apps have varied env generics
   additionalRoutes?: (app: Hono<any>) => void
+}
+
+/**
+ * Workflow runtime configuration block. The driver factory is invoked
+ * once per `createApp()` instance, after the framework's
+ * `ModuleContainer` is built — see architecture doc §6.3 (`DriverFactory`).
+ */
+export interface VoyantWorkflowsConfig {
+  /**
+   * `DriverFactory` returned from one of `@voyantjs/workflows-orchestrator`'s
+   * factories (`createInMemoryDriver`), `@voyantjs/workflows-orchestrator-node`
+   * (`createNodeStandaloneDriver`), or
+   * `@voyantjs/workflows-orchestrator-cloudflare` (`createCloudflareEdgeDriver`).
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: DriverFactory's TIn/TOut generics vary across drivers
+  driver: (deps: { services: any; logger: any; now?: () => number }) => any
+  /**
+   * Environment the manifest registers under. Defaults to `"development"`.
+   * Workflow filters are environment-scoped (production manifests don't
+   * see preview events and vice versa) per architecture doc §21.10.
+   */
+  environment?: "production" | "preview" | "development"
+  /**
+   * Project / tenant identifier baked into the manifest. Single-tenant
+   * runtimes leave this unset (defaults to `"default"`). Multi-tenant
+   * deployments override per-app via voyant-cloud's wrapper layer.
+   */
+  projectId?: string
 }

--- a/packages/hono/tests/unit/app-workflows.test.ts
+++ b/packages/hono/tests/unit/app-workflows.test.ts
@@ -77,7 +77,9 @@ describe("createApp workflows wiring", () => {
         // Wrap the factory so we can capture the constructed driver for
         // post-emit inspection. createApp normally uses the result
         // internally only.
-        driver: (deps) => {
+        // function-of-bindings (Mode 2/InMemory wrap with `() =>`); inner
+        // factory is called by createApp() with framework deps.
+        driver: () => (deps) => {
           driverHandle = factory(deps)
           return driverHandle
         },
@@ -123,7 +125,9 @@ describe("createApp workflows wiring", () => {
       modules: [module],
       eventBus,
       workflows: {
-        driver: (deps) => {
+        // function-of-bindings (Mode 2/InMemory wrap with `() =>`); inner
+        // factory is called by createApp() with framework deps.
+        driver: () => (deps) => {
           driverHandle = factory(deps)
           return driverHandle
         },
@@ -152,7 +156,9 @@ describe("createApp workflows wiring", () => {
       modules: [module],
       eventBus,
       workflows: {
-        driver: (deps) => {
+        // function-of-bindings (Mode 2/InMemory wrap with `() =>`); inner
+        // factory is called by createApp() with framework deps.
+        driver: () => (deps) => {
           driverHandle = factory(deps)
           return driverHandle
         },
@@ -185,7 +191,7 @@ describe("createApp workflows wiring", () => {
           { module: { name: "module-b", workflows: [{ id: "shared-id" } as WorkflowDescriptor] } },
         ],
         workflows: {
-          driver: (deps) => createInMemoryDriver()(deps),
+          driver: () => createInMemoryDriver(),
           environment: "development",
         },
       })
@@ -198,7 +204,7 @@ describe("createApp workflows wiring", () => {
       db: () => null as never,
       eventBus,
       workflows: {
-        driver: (deps) => createInMemoryDriver()(deps),
+        driver: () => createInMemoryDriver(),
         environment: "development",
       },
     })
@@ -229,5 +235,96 @@ describe("createApp workflows wiring", () => {
     await eventBus.emit("test.event", { kind: "x" })
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(receivedEvent).toBe(true)
+  })
+
+  test("function-of-bindings shape sees env at boot (defers construction)", async () => {
+    // Mirrors the CF-edge use case: driver options come from env bindings
+    // that don't exist at createApp() call time. The bindings-aware
+    // factory shape lets users write
+    // `driver: (env) => createCloudflareEdgeDriver({ env.* })`.
+    interface MockEnv extends VoyantBindings {
+      WORKFLOW_RUN_DO?: { id: string }
+    }
+    let observedBindings: MockEnv | undefined
+    const eventBus = createEventBus()
+    const app = createApp<MockEnv>({
+      db: () => null as never,
+      eventBus,
+      workflows: {
+        driver: (env) => {
+          observedBindings = env
+          return (deps) => createInMemoryDriver()(deps)
+        },
+        environment: "production",
+      },
+    })
+
+    // Bindings show up at first request (or app.ready with explicit env).
+    // app.ready() uses an empty bindings object since no real bindings
+    // exist outside a request context — that's enough to verify the
+    // outer factory is invoked.
+    await app.ready()
+    expect(observedBindings).toBeDefined()
+  })
+
+  test("bootstrap-time eventBus.emit from a module is routed (forwarder installed first)", async () => {
+    // Reviewer feedback P2.3: if module.bootstrap emits an event, the
+    // workflow forwarder must already be subscribed. Confirms the order
+    // wireWorkflowRuntime → module bootstraps in the lazy bootstrap.
+    const factory = createInMemoryDriver()
+    let driverHandle: ReturnType<typeof factory> | undefined
+    const eventBus = createEventBus()
+
+    // Build a module with a filter on "bootstrap.emit" + a bootstrap that
+    // emits that event. If the forwarder is installed AFTER bootstraps,
+    // this event is lost; AFTER the fix, it routes correctly.
+    const wf = workflow<{ tag: string }, { tag: string }>({
+      id: "test-bootstrap-emit",
+      async run(input) {
+        return input
+      },
+    })
+    trigger.on("bootstrap.emit", {
+      target: wf,
+      input: { object: { tag: { path: "data.tag" } } },
+    })
+    const filters = getEventFilterRegistry().list() as readonly (EventFilterRuntimeEntry &
+      EventFilterDescriptor)[]
+    const moduleSpec: Module = {
+      name: "bootstrap-emitter",
+      workflows: [wf satisfies WorkflowDescriptor],
+      eventFilters: filters,
+      async bootstrap(ctx) {
+        // Emit during bootstrap. With the pre-fix order this fires into
+        // a bus with no workflow subscriber.
+        await ctx.eventBus.emit(
+          "bootstrap.emit",
+          { tag: "from-bootstrap" },
+          { eventId: "evt_boot" },
+        )
+      },
+    }
+
+    const app = createApp({
+      db: () => null as never,
+      modules: [{ module: moduleSpec }],
+      eventBus,
+      workflows: {
+        driver: () => (deps) => {
+          driverHandle = factory(deps)
+          return driverHandle
+        },
+        environment: "production",
+      },
+    })
+
+    await app.ready()
+    await new Promise((r) => setTimeout(r, 0))
+
+    // The bootstrap-time emit should have routed through the workflow
+    // forwarder and triggered the workflow.
+    const runs = (await driverHandle?.admin?.listRuns?.({ workflowId: "test-bootstrap-emit" }))
+      ?.runs
+    expect(runs?.length).toBeGreaterThanOrEqual(1)
   })
 })

--- a/packages/hono/tests/unit/app-workflows.test.ts
+++ b/packages/hono/tests/unit/app-workflows.test.ts
@@ -1,0 +1,233 @@
+// Integration test for createApp's workflow runtime wiring.
+//
+// Stub a module that ships one workflow + one event filter, pass it
+// through createApp with the InMemory driver, await app.ready(), emit
+// an event on the framework eventBus, and assert the run was created.
+// Exercises the full collection → factory invocation → manifest
+// registration → EventBus forwarder → driver.ingestEvent → trigger pipe.
+
+import {
+  createEventBus,
+  type EventFilterDescriptor,
+  type Module,
+  type WorkflowDescriptor,
+} from "@voyantjs/core"
+import { __resetRegistry, trigger, workflow } from "@voyantjs/workflows"
+import {
+  __resetEventFilterRegistry,
+  type EventFilterRuntimeEntry,
+  getEventFilterRegistry,
+} from "@voyantjs/workflows/events"
+import { createInMemoryDriver } from "@voyantjs/workflows-orchestrator"
+import { afterEach, describe, expect, test } from "vitest"
+
+import { createApp } from "../../src/app.js"
+import type { HonoModule } from "../../src/module.js"
+import type { VoyantBindings } from "../../src/types.js"
+
+const TEST_ENV: VoyantBindings = { DATABASE_URL: "postgres://test" }
+
+afterEach(() => {
+  __resetRegistry()
+  __resetEventFilterRegistry()
+})
+
+function buildPromotionsLikeModule(): HonoModule {
+  // Workflow: returns its input so we can assert on driver.admin.getRun.
+  const bulkReindex = workflow<{ kind: string }, { received: { kind: string } }>({
+    id: "test-bulk-reindex",
+    async run(input) {
+      return { received: input }
+    },
+  })
+
+  // Filter: matches when payload.kind === "all".
+  trigger.on("test.event", {
+    target: bulkReindex,
+    where: { eq: [{ path: "data.kind" }, { lit: "all" }] },
+    input: { object: { kind: { path: "data.kind" } } },
+  })
+
+  // Pull the single registered runtime entry; in real modules the entry
+  // is the value `trigger.on()` returns. The ./events registry is the
+  // canonical source so a module's eventFilters[] can carry it.
+  const filters = getEventFilterRegistry().list() as readonly (EventFilterRuntimeEntry &
+    EventFilterDescriptor)[]
+
+  const moduleSpec: Module = {
+    name: "promotions-test",
+    workflows: [bulkReindex satisfies WorkflowDescriptor],
+    eventFilters: filters,
+  }
+  return { module: moduleSpec }
+}
+
+describe("createApp workflows wiring", () => {
+  test("collects workflows + filters and routes EventBus events through to driver.ingestEvent", async () => {
+    const module = buildPromotionsLikeModule()
+    const eventBus = createEventBus()
+    const factory = createInMemoryDriver()
+    let driverHandle: ReturnType<typeof factory> | undefined
+
+    const app = createApp({
+      db: () => null as never,
+      modules: [module],
+      eventBus,
+      workflows: {
+        // Wrap the factory so we can capture the constructed driver for
+        // post-emit inspection. createApp normally uses the result
+        // internally only.
+        driver: (deps) => {
+          driverHandle = factory(deps)
+          return driverHandle
+        },
+        environment: "production",
+      },
+    })
+
+    // Fire the lazy bootstrap explicitly. Production code does this via
+    // first-request middleware; tests + Mode 2 sibling processes use
+    // app.ready() (architecture doc §18.1).
+    await app.ready()
+    expect(driverHandle).toBeTruthy()
+
+    // The manifest should be registered for the requested environment.
+    const manifest = await driverHandle?.getManifest({ environment: "production" })
+    expect(manifest).toBeTruthy()
+    expect(manifest?.eventFilters?.length).toBe(1)
+    expect(manifest?.eventFilters?.[0]?.eventType).toBe("test.event")
+
+    // Emit an event matching the where clause and verify a run was created.
+    await eventBus.emit("test.event", { kind: "all" }, { eventId: "evt_test_1" })
+
+    // Subscribers fire synchronously during emit but the driver's run completes
+    // synchronously for InMemory; let the microtask queue drain.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const runs = (await driverHandle?.admin?.listRuns?.({ workflowId: "test-bulk-reindex" }))?.runs
+    expect(runs?.length).toBeGreaterThanOrEqual(1)
+    const detail = await driverHandle?.admin?.getRun?.(runs?.[0]?.id ?? "")
+    expect(detail?.output).toEqual({ received: { kind: "all" } })
+
+    void TEST_ENV
+  })
+
+  test("non-matching events do not trigger runs", async () => {
+    const module = buildPromotionsLikeModule()
+    const eventBus = createEventBus()
+    const factory = createInMemoryDriver()
+    let driverHandle: ReturnType<typeof factory> | undefined
+
+    const app = createApp({
+      db: () => null as never,
+      modules: [module],
+      eventBus,
+      workflows: {
+        driver: (deps) => {
+          driverHandle = factory(deps)
+          return driverHandle
+        },
+        environment: "production",
+      },
+    })
+
+    await app.ready()
+
+    // kind: "products" doesn't match where: kind == "all".
+    await eventBus.emit("test.event", { kind: "products" }, { eventId: "evt_test_2" })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const runs = (await driverHandle?.admin?.listRuns?.({ workflowId: "test-bulk-reindex" }))?.runs
+    expect(runs?.length ?? 0).toBe(0)
+  })
+
+  test("events with no matching filters are silently ignored", async () => {
+    const module = buildPromotionsLikeModule()
+    const eventBus = createEventBus()
+    const factory = createInMemoryDriver()
+    let driverHandle: ReturnType<typeof factory> | undefined
+
+    const app = createApp({
+      db: () => null as never,
+      modules: [module],
+      eventBus,
+      workflows: {
+        driver: (deps) => {
+          driverHandle = factory(deps)
+          return driverHandle
+        },
+        environment: "production",
+      },
+    })
+
+    await app.ready()
+
+    // Different event name — no filter targets it.
+    await eventBus.emit("unrelated.event", { kind: "all" }, { eventId: "evt_test_3" })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const runs = (await driverHandle?.admin?.listRuns?.({ workflowId: "test-bulk-reindex" }))?.runs
+    expect(runs?.length ?? 0).toBe(0)
+  })
+
+  test("rejects duplicate workflow ids across modules at construction time", () => {
+    const wfA = workflow({ id: "dup-id", async run() {} })
+    const wfB = workflow({ id: "dup-id", async run() {} })
+    // Reset to clear the duplicate-warn from workflow()
+    void wfA
+    void wfB
+
+    expect(() => {
+      createApp({
+        db: () => null as never,
+        modules: [
+          { module: { name: "module-a", workflows: [{ id: "shared-id" } as WorkflowDescriptor] } },
+          { module: { name: "module-b", workflows: [{ id: "shared-id" } as WorkflowDescriptor] } },
+        ],
+        workflows: {
+          driver: (deps) => createInMemoryDriver()(deps),
+          environment: "development",
+        },
+      })
+    }).toThrow(/duplicate workflow id "shared-id"/)
+  })
+
+  test("app.ready() is idempotent (returns the same promise across calls)", async () => {
+    const eventBus = createEventBus()
+    const app = createApp({
+      db: () => null as never,
+      eventBus,
+      workflows: {
+        driver: (deps) => createInMemoryDriver()(deps),
+        environment: "development",
+      },
+    })
+
+    const a = app.ready()
+    const b = app.ready()
+    await Promise.all([a, b])
+    // No assertion needed — if not idempotent, the bootstrap would run
+    // twice and the second register would either no-op or throw.
+    expect(true).toBe(true)
+  })
+
+  test("apps without workflows config are unaffected (no driver, no forwarder)", async () => {
+    const eventBus = createEventBus()
+    let receivedEvent = false
+    eventBus.subscribe("test.event", () => {
+      receivedEvent = true
+    })
+
+    const app = createApp({
+      db: () => null as never,
+      eventBus,
+    })
+
+    // No workflows config → no bootstrap-time workflow wiring. Events
+    // still dispatch to in-process subscribers as before.
+    await app.ready()
+    await eventBus.emit("test.event", { kind: "x" })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(receivedEvent).toBe(true)
+  })
+})

--- a/packages/hono/tests/unit/app-workflows.test.ts
+++ b/packages/hono/tests/unit/app-workflows.test.ts
@@ -327,4 +327,59 @@ describe("createApp workflows wiring", () => {
       ?.runs
     expect(runs?.length).toBeGreaterThanOrEqual(1)
   })
+
+  test("rejects event-filter descriptors that omit the runtime manifest field", async () => {
+    // A plugin that only satisfies the public EventFilterDescriptor
+    // (`{ id, eventType }`) — the structural minimum from
+    // @voyantjs/core — must not be silently passed through to the
+    // manifest builder, which reads `entry.manifest.id` deep inside its
+    // sort and would otherwise crash with a confusing TypeError.
+    const moduleSpec: Module = {
+      name: "bad-plugin",
+      eventFilters: [{ id: "filt_bad", eventType: "x.y" } as EventFilterDescriptor],
+    }
+
+    const app = createApp({
+      db: () => null as never,
+      modules: [{ module: moduleSpec }],
+      workflows: {
+        driver: () => createInMemoryDriver(),
+        environment: "development",
+      },
+    })
+
+    await expect(app.ready()).rejects.toThrow(
+      /event filter "filt_bad".*missing the runtime `manifest` field/,
+    )
+  })
+
+  test("ready(bindings) forwards real bindings to the driver factory", async () => {
+    // Mode 1 (CF-edge) callers that want eager boot must pass the real
+    // env to ready() — otherwise the memoized bootstrap promise locks in
+    // a driver built from `{}`, and every later request reuses that
+    // broken instance with missing DO/KV bindings.
+    interface MockEnv extends VoyantBindings {
+      WORKFLOW_RUN_DO?: string
+      WORKFLOW_MANIFESTS?: string
+    }
+    let observedBindings: MockEnv | undefined
+    const app = createApp<MockEnv>({
+      db: () => null as never,
+      workflows: {
+        driver: (env) => {
+          observedBindings = env
+          return (deps) => createInMemoryDriver()(deps)
+        },
+        environment: "production",
+      },
+    })
+
+    const realEnv: MockEnv = {
+      DATABASE_URL: "postgres://test",
+      WORKFLOW_RUN_DO: "do-id",
+      WORKFLOW_MANIFESTS: "kv-id",
+    }
+    await app.ready(realEnv)
+    expect(observedBindings).toEqual(realEnv)
+  })
 })

--- a/packages/workflows-orchestrator-cloudflare/src/__tests__/cloudflare-edge-driver.test.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/__tests__/cloudflare-edge-driver.test.ts
@@ -83,6 +83,12 @@ function inProcessDispatcher(): DispatchNamespaceLike {
 
 function inProcessRunDONamespace(): DurableObjectNamespaceLike<string> {
   const storages = new Map<string, DurableObjectStorageLike>()
+  // Per-id request queue — mirrors the production CF guarantee that a
+  // Durable Object instance processes requests one at a time. Without
+  // this, concurrent fetches to the same id race inside the fake even
+  // though they wouldn't in production. Critical for the
+  // `tryInsert` idempotency-race compliance test.
+  const queues = new Map<string, Promise<unknown>>()
   const dispatcher = inProcessDispatcher()
   return {
     idFromName(name) {
@@ -94,13 +100,25 @@ function inProcessRunDONamespace(): DurableObjectNamespaceLike<string> {
         storage = makeStorage()
         storages.set(id, storage)
       }
+      const stableStorage = storage
       return {
         async fetch(req: Request): Promise<Response> {
-          return handleDurableObjectRequest(req, {
-            storage: storage!,
-            resolveStepHandler: (tenantScript) =>
-              createDispatchStepHandler(tenantScript, { dispatcher }),
+          const prev = queues.get(id) ?? Promise.resolve()
+          let release!: () => void
+          const next = new Promise<void>((resolve) => {
+            release = resolve
           })
+          queues.set(id, next)
+          await prev
+          try {
+            return await handleDurableObjectRequest(req, {
+              storage: stableStorage,
+              resolveStepHandler: (tenantScript) =>
+                createDispatchStepHandler(tenantScript, { dispatcher }),
+            })
+          } finally {
+            release()
+          }
         },
       }
     },

--- a/packages/workflows-orchestrator-cloudflare/src/cloudflare-edge-driver.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/cloudflare-edge-driver.ts
@@ -35,6 +35,7 @@ import type {
   WorkflowAdmin,
   WorkflowDriver,
 } from "@voyantjs/workflows/driver"
+import { deriveStableEventId } from "@voyantjs/workflows/events"
 import type { WorkflowManifest } from "@voyantjs/workflows/protocol"
 import { routeEvent } from "@voyantjs/workflows-orchestrator"
 
@@ -223,7 +224,7 @@ export function createCloudflareEdgeDriver(opts: CloudflareEdgeDriverOptions): D
         }
       }
       const manifest = stored.manifest as unknown as WorkflowManifest
-      const eventId = args.envelope.metadata?.eventId ?? deriveEventIdFallback(now)
+      const eventId = args.envelope.metadata?.eventId ?? (await deriveStableEventId(args.envelope))
       const routed = routeEvent({
         manifest,
         envelope: {
@@ -420,9 +421,10 @@ export function createCloudflareEdgeDriver(opts: CloudflareEdgeDriverOptions): D
 
 // ---- Internal helpers ----
 
-function deriveEventIdFallback(now: () => number): string {
-  return `evt_${now().toString(36)}_${Math.floor(Math.random() * 1_000_000).toString(36)}`
-}
+// Fallback id derivation lives in `@voyantjs/workflows/events`'s
+// `deriveStableEventId` and is used inline at the call site above —
+// content-derived so external callers without a forwarder still get
+// dedup across retries (architecture doc §15.2).
 
 async function safeText(resp: Response): Promise<string> {
   try {

--- a/packages/workflows-orchestrator-cloudflare/src/do-store.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/do-store.ts
@@ -26,6 +26,19 @@ export function createDurableObjectRunStore(storage: DurableObjectStorageLike): 
       return record
     },
 
+    async tryInsert(record) {
+      // DO storage is single-threaded per DO instance: concurrent fetches
+      // to `idFromName(runId)` are serialized inside the DO's request
+      // queue, so get-then-put is naturally atomic. This is just the
+      // contract-shape implementation.
+      const existing = await storage.get<RunRecord>(RECORD_KEY)
+      if (existing && existing.id === record.id) {
+        return { record: existing, created: false }
+      }
+      await storage.put<RunRecord>(RECORD_KEY, record)
+      return { record, created: true }
+    },
+
     async list(filter = {}) {
       const r = await storage.get<RunRecord>(RECORD_KEY)
       if (!r) return []

--- a/packages/workflows-orchestrator-cloudflare/src/event-handler.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/event-handler.ts
@@ -12,6 +12,7 @@
 //
 // Architecture: docs/architecture/workflows-runtime-architecture.md §15.
 
+import { deriveStableEventId } from "@voyantjs/workflows/events"
 import type { WorkflowManifest } from "@voyantjs/workflows/protocol"
 import { routeEvent } from "@voyantjs/workflows-orchestrator"
 
@@ -91,8 +92,7 @@ export async function handleIngestEvent<Id>(
   // Event id derivation — use the caller-stamped one when present, fall
   // back to a content-derived id so external callers without a forwarder
   // still get sensible idempotency.
-  const now = deps.now ?? (() => Date.now())
-  const eventId = body.envelope.metadata?.eventId ?? deriveEventIdFallback(body.envelope, now)
+  const eventId = body.envelope.metadata?.eventId ?? (await deriveStableEventId(body.envelope))
 
   // Route through the manifest's filters.
   const routed = routeEvent({
@@ -276,12 +276,10 @@ function validateBody(
 
 // ---- Internal helpers ----
 
-function deriveEventIdFallback(envelope: IngestEnvelope, now: () => number): string {
-  // Best-effort fallback when caller didn't supply metadata.eventId.
-  // Same shape as the in-process driver's ensureEventId. The forwarder in
-  // PR4 always stamps a ULID upstream so this path is mostly external.
-  return `evt_${now().toString(36)}_${Math.floor(Math.random() * 1_000_000).toString(36)}`
-}
+// Fallback id derivation lives in `@voyantjs/workflows/events`'s
+// `deriveStableEventId` and is used inline above — content-derived so
+// external callers (HTTP retries, third-party webhooks) dedupe naturally
+// across re-deliveries (architecture doc §15.2).
 
 async function safeReadText(resp: Response): Promise<string> {
   try {

--- a/packages/workflows-orchestrator-node/src/__tests__/driver-compliance.integration.test.ts
+++ b/packages/workflows-orchestrator-node/src/__tests__/driver-compliance.integration.test.ts
@@ -46,7 +46,12 @@ describeIfDb("Mode 2 (Postgres) driver compliance", () => {
   // The suite assumes a single driver factory it can instantiate per test.
   // Each call to the factory returns a fresh driver wired against the same
   // shared Postgres connection — exactly the production shape.
+  //
+  // `disableTimeWheel: true` so per-test driver instantiations don't leave
+  // rogue pollers running against the shared DB across tests. Sleep-resume
+  // (the only suite that needs the wheel) is its own test file with its
+  // own truncate + driver lifecycle.
   runDriverComplianceSuite("Mode 2 (Postgres)", () =>
-    createNodeStandaloneDriver({ db: connection.db }),
+    createNodeStandaloneDriver({ db: connection.db, disableTimeWheel: true }),
   )
 })

--- a/packages/workflows-orchestrator-node/src/__tests__/sleep-resume.integration.test.ts
+++ b/packages/workflows-orchestrator-node/src/__tests__/sleep-resume.integration.test.ts
@@ -1,0 +1,134 @@
+// Mode 2 sleep-resume integration test — verifies that workflows
+// parked on `ctx.sleep(...)` actually wake up via the wakeup poller
+// wired into `createNodeStandaloneDriver`. Closes the gap reviewer P1.2
+// flagged: prior to wiring `createPersistentWakeupManager` into the
+// driver, parked runs would persist as `waiting` and never resume.
+//
+// Gated on TEST_DATABASE_URL; the wakeup machinery talks to real Postgres.
+
+import { resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { __resetRegistry, workflow } from "@voyantjs/workflows"
+import { sql } from "drizzle-orm"
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest"
+
+import { runPostgresMigrations } from "../migrate.js"
+import { createNodeStandaloneDriver } from "../node-standalone-driver.js"
+import { createPostgresConnection } from "../postgres.js"
+
+const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
+const describeIfDb = TEST_DATABASE_URL ? describe : describe.skip
+const migrationsFolder = resolve(fileURLToPath(new URL("../../", import.meta.url)), "drizzle")
+
+describeIfDb("Mode 2 sleep-resume", () => {
+  let connection: ReturnType<typeof createPostgresConnection>
+
+  beforeAll(async () => {
+    connection = createPostgresConnection({ databaseUrl: TEST_DATABASE_URL! })
+    await runPostgresMigrations({
+      databaseUrl: TEST_DATABASE_URL!,
+      migrationsDir: migrationsFolder,
+    })
+  })
+
+  beforeEach(async () => {
+    await connection.db.execute(
+      sql`TRUNCATE TABLE voyant_workflow_manifests, voyant_wakeups, voyant_snapshot_runs`,
+    )
+    __resetRegistry()
+  })
+
+  afterEach(() => {
+    __resetRegistry()
+  })
+
+  afterAll(async () => {
+    await connection.close()
+  })
+
+  test("ctx.sleep parks then resumes via the wakeup poller", async () => {
+    // Aggressive interval so the test stays fast.
+    const driver = createNodeStandaloneDriver({
+      db: connection.db,
+      wakeupPollIntervalMs: 100,
+      wakeupLeaseMs: 1_000,
+    })({
+      services: {
+        resolve<T>(): T {
+          throw new Error("no services")
+        },
+        has() {
+          return false
+        },
+      },
+      logger: () => {},
+    })
+
+    // Use `ctx.step` to record the post-sleep work — step bodies are
+    // journaled, so they execute exactly once per workflow invocation
+    // (unlike free body code which replays). That's the right shape
+    // for asserting "the run resumed and finished its post-sleep work."
+    const wf = workflow<Record<string, never>, { resumed: boolean; sleptAt: number }>({
+      id: "sleep-resume-test",
+      async run(_input, ctx) {
+        const sleptAt = ctx.now()
+        await ctx.sleep("100ms")
+        const resumed = await ctx.step("post-sleep", async () => true)
+        return { resumed, sleptAt }
+      },
+    })
+
+    // Trigger the run; workflow body will park on the sleep waitpoint.
+    const run = await driver.trigger(wf, {})
+
+    // Initially the run is in the "waiting" state with a wakeup row.
+    const initial = await driver.admin?.getRun?.(run.id)
+    expect(initial?.status).toBe("waiting")
+    const wakeupRowsResult = await connection.db.execute(
+      sql`SELECT run_id, wake_at FROM voyant_wakeups WHERE run_id = ${run.id}`,
+    )
+    const wakeupRowsCount =
+      (wakeupRowsResult as { rows?: unknown[] }).rows?.length ?? wakeupRowsResult.length ?? 0
+    expect(wakeupRowsCount).toBe(1)
+
+    // Wait for the poller to wake the run. With a 100ms sleep + 100ms
+    // poll cadence, ~500ms is generous.
+    const start = Date.now()
+    let detail = await driver.admin?.getRun?.(run.id)
+    while (detail?.status === "waiting" && Date.now() - start < 5_000) {
+      await new Promise((r) => setTimeout(r, 100))
+      detail = await driver.admin?.getRun?.(run.id)
+    }
+
+    // The run resumed and finished — `resumed: true` came from the
+    // post-sleep step body, which only executes after the wakeup poller
+    // resolves the DATETIME waitpoint.
+    expect(detail?.status).toBe("completed")
+    expect((detail?.output as { resumed: boolean }).resumed).toBe(true)
+
+    await driver.shutdown?.()
+  }, 10_000)
+
+  test("driver.shutdown stops the poller (process can exit cleanly)", async () => {
+    const driver = createNodeStandaloneDriver({
+      db: connection.db,
+      wakeupPollIntervalMs: 50,
+    })({
+      services: {
+        resolve<T>(): T {
+          throw new Error("no services")
+        },
+        has() {
+          return false
+        },
+      },
+      logger: () => {},
+    })
+
+    // Just confirm shutdown returns without hanging. Without the
+    // poller-stop fix, the setInterval would keep the event loop alive.
+    await driver.shutdown?.()
+    expect(true).toBe(true)
+  })
+})

--- a/packages/workflows-orchestrator-node/src/fs-run-record-store.ts
+++ b/packages/workflows-orchestrator-node/src/fs-run-record-store.ts
@@ -25,6 +25,27 @@ export function createFsRunRecordStore(opts: FsRunRecordStoreOptions = {}): RunR
       return record
     },
 
+    async tryInsert(record) {
+      // Single-process FS store: atomicity comes from `mkdir` without
+      // `recursive: true` — succeeds exactly once per path, EEXIST
+      // otherwise. The orchestrator only enters this branch for
+      // idempotency-derived runIds, so the directory's prior existence
+      // means another caller already created the run.
+      try {
+        await mkdir(rootDir, { recursive: true })
+        await mkdir(join(rootDir, record.id))
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code
+        if (code !== "EEXIST") throw err
+        const existing = await readRunFile(join(rootDir, record.id, "run-record.json"))
+        if (existing) return { record: existing, created: false }
+        // Dir exists but no record file — partial-write race window;
+        // fall through and write our record.
+      }
+      await writeFile(join(rootDir, record.id, "run-record.json"), JSON.stringify(record, null, 2))
+      return { record, created: true }
+    },
+
     async list(filter = {}) {
       const entries = await safeReaddir(rootDir)
       const runs: RunRecord[] = []

--- a/packages/workflows-orchestrator-node/src/node-standalone-driver.ts
+++ b/packages/workflows-orchestrator-node/src/node-standalone-driver.ts
@@ -33,6 +33,7 @@ import type {
   WorkflowAdmin,
   WorkflowDriver,
 } from "@voyantjs/workflows/driver"
+import { deriveStableEventId } from "@voyantjs/workflows/events"
 import { handleStepRequest, type WorkflowStepRequest } from "@voyantjs/workflows/handler"
 import type { WorkflowManifest } from "@voyantjs/workflows/protocol"
 import {
@@ -44,8 +45,14 @@ import {
 } from "@voyantjs/workflows-orchestrator"
 import type { drizzle } from "drizzle-orm/node-postgres"
 
+import {
+  createPersistentWakeupManager,
+  type PersistentWakeupManager,
+} from "./persistent-wakeup-manager.js"
 import { createPostgresManifestStore } from "./postgres-manifest-store.js"
 import { createPostgresRunRecordStore } from "./postgres-run-record-store.js"
+import { createPostgresWakeupStore } from "./postgres-wakeup-store.js"
+import { syncWakeupFromRecord, type WakeupStore } from "./wakeup-store.js"
 
 type Db = ReturnType<typeof drizzle>
 
@@ -72,6 +79,32 @@ export interface NodeStandaloneDriverOptions {
    * a high number to disable pruning effectively.
    */
   manifestVersionsToKeep?: number
+  /**
+   * Time-wheel poll interval, ms. The wakeup manager (architecture doc
+   * §7.2) polls `voyant_wakeups` for due alarms and resumes parked runs
+   * via the orchestrator. Defaults to 1_000 ms. Lower values reduce
+   * sleep-resume latency at the cost of DB load.
+   */
+  wakeupPollIntervalMs?: number
+  /**
+   * Wakeup lease TTL, ms. A poll instance leases a due wakeup for this
+   * long; if the process dies mid-process, another instance picks the
+   * wakeup back up after the lease expires. Defaults to 4× the poll
+   * interval (or 5_000 ms, whichever is greater).
+   */
+  wakeupLeaseMs?: number
+  /**
+   * Lease owner identifier. Used to disambiguate poller instances
+   * across processes. Defaults to a random per-driver token.
+   */
+  wakeupLeaseOwner?: string
+  /**
+   * When `true`, the wakeup poller does NOT auto-start on construction.
+   * Callers must invoke the returned driver's lifecycle hooks
+   * themselves — useful for tests that want to control the poll
+   * cadence. Defaults to `false` (poller starts immediately).
+   */
+  disableTimeWheel?: boolean
 }
 
 const DEFAULT_TENANT_META: RunRecord["tenantMeta"] = {
@@ -103,10 +136,12 @@ export function createNodeStandaloneDriver(opts: NodeStandaloneDriverOptions): D
   return (deps: DriverFactoryDeps): WorkflowDriver => {
     const runStore = createPostgresRunRecordStore({ db: opts.db })
     const manifestStore = createPostgresManifestStore({ db: opts.db })
+    const wakeupStore: WakeupStore = createPostgresWakeupStore({ db: opts.db })
     const now = opts.now ?? deps.now ?? (() => Date.now())
     const tenantMeta = opts.tenantMeta ?? DEFAULT_TENANT_META
     const defaultEnv = opts.defaultEnvironment ?? "development"
     const keep = opts.manifestVersionsToKeep ?? DEFAULT_MANIFEST_KEEP
+    const leaseOwner = opts.wakeupLeaseOwner ?? `node-standalone-${randomToken()}`
 
     // Wire the framework-supplied service container through to step bodies.
     // The handler closes over `deps.services` so every step invocation
@@ -115,6 +150,44 @@ export function createNodeStandaloneDriver(opts: NodeStandaloneDriverOptions): D
       opts.handler ??
       (async (req: WorkflowStepRequest, stepOpts) =>
         handleStepRequest(req, { services: deps.services }, stepOpts))
+
+    // Persistent wakeup manager — polls `voyant_wakeups` for runs
+    // parked on DATETIME waitpoints and resumes them via the orchestrator's
+    // `resumeDueAlarms`. This is what makes `ctx.sleep(...)` actually
+    // wake up in Mode 2 (architecture doc §7.2).
+    const wakeupManager: PersistentWakeupManager<RunRecord> = createPersistentWakeupManager({
+      wakeupStore,
+      handler,
+      leaseOwner,
+      leaseMs: opts.wakeupLeaseMs,
+      intervalMs: opts.wakeupPollIntervalMs,
+      now,
+      logger: (level, message, data) => deps.logger(level, message, data),
+      // For Mode 2 the "stored" representation IS the RunRecord — the
+      // postgres-run-record-store carries the full state on `run_record`
+      // JSONB. So toRecord/fromRecord are identity.
+      async getRun(runId) {
+        return runStore.get(runId)
+      },
+      async saveRun(record) {
+        await runStore.save(record)
+        return record
+      },
+      toRecord: (record) => record,
+      fromRecord: (record) => record,
+      async listRuns() {
+        // Bootstrap-time list of currently-parked runs to seed the wakeup
+        // store. Mode 2 uses status="waiting" filter on the run-record store.
+        return runStore.list({ status: "waiting" })
+      },
+    })
+
+    if (!opts.disableTimeWheel) {
+      // Auto-start the poller. Callers can opt out via `disableTimeWheel`
+      // for tests that want to control the cadence manually (poll explicitly
+      // via `manager.poll()`).
+      wakeupManager.start()
+    }
 
     let shuttingDown = false
 
@@ -173,6 +246,9 @@ export function createNodeStandaloneDriver(opts: NodeStandaloneDriverOptions): D
         },
         { store: runStore, handler, now },
       )
+      // Sync wakeup row so the time-wheel can resume DATETIME-parked runs.
+      // No-op if the run completed inline (status !== "waiting").
+      await syncWakeupFromRecord(wakeupStore, record)
       return runRecordToRun<TOut>(record)
     }
 
@@ -186,7 +262,7 @@ export function createNodeStandaloneDriver(opts: NodeStandaloneDriverOptions): D
           message: `No manifest is registered for environment "${args.environment}".`,
         }
       }
-      const eventId = ensureEventId(args.envelope, now)
+      const eventId = await ensureEventId(args.envelope)
       const manifest = stored.manifest as unknown as WorkflowManifest
       const routed = routeEvent({
         manifest,
@@ -226,6 +302,7 @@ export function createNodeStandaloneDriver(opts: NodeStandaloneDriverOptions): D
             },
             { store: runStore, handler, now },
           )
+          await syncWakeupFromRecord(wakeupStore, record)
           matches.push({
             filterId: entry.filterId,
             targetWorkflowId: entry.targetWorkflowId,
@@ -257,6 +334,10 @@ export function createNodeStandaloneDriver(opts: NodeStandaloneDriverOptions): D
 
     async function shutdown(): Promise<void> {
       shuttingDown = true
+      // Stop the time-wheel poller so the process can exit cleanly.
+      // Idempotent — calling stop() on an already-stopped manager is a
+      // no-op.
+      wakeupManager.stop()
     }
 
     // ---- WorkflowAdmin (full; Mode 2 has Postgres-native query support) ----
@@ -346,9 +427,22 @@ function assertNotShutdown(shuttingDown: boolean): void {
   }
 }
 
-function ensureEventId(envelope: { metadata?: { eventId?: string } }, now: () => number): string {
+function randomToken(): string {
+  return Math.floor(Math.random() * 1_000_000_000)
+    .toString(36)
+    .padStart(6, "0")
+}
+
+async function ensureEventId(envelope: {
+  name: string
+  data: unknown
+  metadata?: { eventId?: string }
+  emittedAt: string
+}): Promise<string> {
   if (envelope.metadata?.eventId) return envelope.metadata.eventId
-  return `evt_${now().toString(36)}_${Math.floor(Math.random() * 1_000_000).toString(36)}`
+  // Content-derived fallback per architecture doc §15.2 — closes the
+  // dedup hole reviewer P2.2 flagged.
+  return deriveStableEventId(envelope)
 }
 
 function runRecordToRun<TOut>(rec: RunRecord): Run<TOut> {

--- a/packages/workflows-orchestrator-node/src/postgres-run-record-store.ts
+++ b/packages/workflows-orchestrator-node/src/postgres-run-record-store.ts
@@ -49,39 +49,54 @@ export function createPostgresRunRecordStore(opts: PostgresRunRecordStoreOptions
     },
 
     async save(record) {
-      const values = {
-        id: record.id,
-        workflowId: record.workflowId,
-        status: record.status,
-        startedAt: record.startedAt,
-        completedAt: record.completedAt ?? null,
-        durationMs: record.completedAt !== undefined ? record.completedAt - record.startedAt : null,
-        tags: [...record.tags],
-        // `result` mirrors the snapshot-store convention: the run's
-        // public outcome view. We snapshot output + error here so the
-        // dashboard's reads remain consistent across both stores.
-        result: normalizeRequiredJson({
-          status: record.status,
-          output: record.output,
-          error: record.error,
-          startedAt: record.startedAt,
-          completedAt: record.completedAt,
-        }),
-        input: normalizeJson(record.input),
-        runRecord: normalizeRequiredJson(record as unknown as Record<string, unknown>),
-        entryFile: null,
-        replayOf: null,
-        idempotencyKey: record.idempotencyKey ?? null,
-      }
-      // Upsert by id — last-write-wins. The orchestrator's deterministic
-      // runId derivation from `idempotencyKey` ensures retries map to the
-      // same row; the unique partial index on `(workflow_id, idempotency_key)`
-      // is a defensive backstop against accidental id collisions.
+      const values = recordToValues(record)
+      // Upsert by id — last-write-wins. Used for state mutations after
+      // the run is created (resume / cancel / drive). Idempotency on
+      // *creation* is enforced separately via `tryInsert` below; this
+      // path is the steady-state save.
       await opts.db.insert(snapshotRunsTable).values(values).onConflictDoUpdate({
         target: snapshotRunsTable.id,
         set: values,
       })
       return record
+    },
+
+    async tryInsert(record) {
+      const values = recordToValues(record)
+      // Atomic at the DB level: INSERT … ON CONFLICT DO NOTHING returns
+      // the row only if it was created, empty otherwise. When empty, we
+      // re-SELECT to load the existing record. This closes the race
+      // window between `get(id)` and `save(record)` that the previous
+      // get-then-upsert pattern left open — concurrent triggers with
+      // the same idempotency-derived runId now see deterministic
+      // "first writer wins" semantics.
+      const inserted = await opts.db
+        .insert(snapshotRunsTable)
+        .values(values)
+        .onConflictDoNothing({ target: snapshotRunsTable.id })
+        .returning({ id: snapshotRunsTable.id })
+
+      if (inserted.length > 0) {
+        return { record, created: true }
+      }
+      // Conflict — load whoever won the race.
+      const existingRows = await opts.db
+        .select()
+        .from(snapshotRunsTable)
+        .where(eq(snapshotRunsTable.id, record.id))
+        .limit(1)
+      const existingRow = existingRows[0]
+      if (!existingRow) {
+        // Pathological case: the conflict happened but we can't read it
+        // back. Surface as a write that became a no-op so the caller
+        // doesn't proceed to drive a non-existent run.
+        return { record, created: false }
+      }
+      const existing = asRunRecord(existingRow.runRecord)
+      return {
+        record: existing ?? record,
+        created: false,
+      }
     },
 
     async list(filter = {}) {
@@ -117,6 +132,33 @@ export function createPostgresRunRecordStore(opts: PostgresRunRecordStoreOptions
 
 // ---- Helpers (parallel to the snapshot store's; kept private here to
 //      avoid coupling between the two stores' representations) ----
+
+function recordToValues(record: RunRecord) {
+  return {
+    id: record.id,
+    workflowId: record.workflowId,
+    status: record.status,
+    startedAt: record.startedAt,
+    completedAt: record.completedAt ?? null,
+    durationMs: record.completedAt !== undefined ? record.completedAt - record.startedAt : null,
+    tags: [...record.tags],
+    // `result` mirrors the snapshot-store convention: the run's public
+    // outcome view. We snapshot output + error here so the dashboard's
+    // reads remain consistent across both stores.
+    result: normalizeRequiredJson({
+      status: record.status,
+      output: record.output,
+      error: record.error,
+      startedAt: record.startedAt,
+      completedAt: record.completedAt,
+    }),
+    input: normalizeJson(record.input),
+    runRecord: normalizeRequiredJson(record as unknown as Record<string, unknown>),
+    entryFile: null,
+    replayOf: null,
+    idempotencyKey: record.idempotencyKey ?? null,
+  }
+}
 
 function asRunRecord(value: unknown): RunRecord | undefined {
   if (typeof value !== "object" || value === null) return undefined

--- a/packages/workflows-orchestrator-node/vitest.config.ts
+++ b/packages/workflows-orchestrator-node/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+    globals: false,
+    // Integration tests share a single Postgres instance via
+    // TEST_DATABASE_URL. Several `*.integration.test.ts` files truncate
+    // tables in beforeEach — running files in parallel would race those
+    // truncates against in-flight runs in sibling test files (esp.
+    // sleep-resume's polling loop). Serialize file execution to keep
+    // tests deterministic against the shared DB.
+    fileParallelism: false,
+  },
+})

--- a/packages/workflows-orchestrator/src/driver-inmemory.ts
+++ b/packages/workflows-orchestrator/src/driver-inmemory.ts
@@ -29,6 +29,7 @@ import {
   type WorkflowAdmin,
   type WorkflowDriver,
 } from "@voyantjs/workflows/driver"
+import { deriveStableEventId } from "@voyantjs/workflows/events"
 import { handleStepRequest, type WorkflowStepRequest } from "@voyantjs/workflows/handler"
 import type { WorkflowManifest } from "@voyantjs/workflows/protocol"
 
@@ -143,7 +144,7 @@ export function createInMemoryDriver(opts: InMemoryDriverOptions = {}): DriverFa
           message: new ManifestNotRegisteredError(args.environment).message,
         }
       }
-      const eventId = ensureEventId(args.envelope, now)
+      const eventId = await ensureEventId(args.envelope)
       const routed = routeEvent({
         manifest: stored.manifest,
         envelope: args.envelope,
@@ -284,12 +285,17 @@ function assertNotShutdown(shuttingDown: boolean): void {
   }
 }
 
-function ensureEventId(envelope: { metadata?: { eventId?: string } }, now: () => number): string {
+async function ensureEventId(envelope: {
+  name: string
+  data: unknown
+  metadata?: { eventId?: string }
+  emittedAt: string
+}): Promise<string> {
   if (envelope.metadata?.eventId) return envelope.metadata.eventId
-  // Best-effort fallback when the caller hasn't stamped an id. The framework's
-  // EventBus forwarder (PR4) stamps a ULID before calling ingestEvent, so this
-  // path is mostly hit by tests + external callers.
-  return `evt_${now().toString(36)}_${Math.floor(Math.random() * 1_000_000).toString(36)}`
+  // Content-derived fallback per architecture doc §15.2. Two ingests
+  // with byte-equal envelopes produce the same id, so retries dedupe
+  // through the driver's `${filterId}:${eventId}` idempotency key.
+  return deriveStableEventId(envelope)
 }
 
 function runRecordToRun<TOut>(rec: RunRecord): Run<TOut> {

--- a/packages/workflows-orchestrator/src/in-memory-store.ts
+++ b/packages/workflows-orchestrator/src/in-memory-store.ts
@@ -15,6 +15,16 @@ export function createInMemoryRunStore(): RunRecordStore {
       records.set(record.id, clone(record))
       return clone(record)
     },
+    async tryInsert(record) {
+      // Atomic-by-construction: Map.has + Map.set inside a single
+      // microtask. Concurrent `tryInsert(idA)` calls all schedule on the
+      // same JS event loop and only the first one observes the slot
+      // empty — subsequent callers see the inserted record.
+      const existing = records.get(record.id)
+      if (existing) return { record: clone(existing), created: false }
+      records.set(record.id, clone(record))
+      return { record: clone(record), created: true }
+    },
     async list(filter = {}) {
       let out = [...records.values()].map(clone)
       if (filter.workflowId) out = out.filter((r) => r.workflowId === filter.workflowId)

--- a/packages/workflows-orchestrator/src/orchestrator.ts
+++ b/packages/workflows-orchestrator/src/orchestrator.ts
@@ -74,20 +74,16 @@ export async function trigger(args: TriggerArgs, deps: OrchestratorDeps): Promis
   const now = deps.now ?? (() => Date.now())
   // Idempotency: caller-supplied `runId` wins (explicit). Otherwise, when
   // `idempotencyKey` is supplied, derive a deterministic runId from
-  // `(workflowId, idempotencyKey)` so the existing args.runId-already-exists
-  // path below dedups across retries — same observable behavior, no new
-  // store interface. The persistent runId pattern lets stores like
-  // `voyant_snapshot_runs` carry idempotency_key as a separate column for
-  // queryability without parsing the runId string.
+  // `(workflowId, idempotencyKey)`. We then route through `store.tryInsert`
+  // — atomic check-or-insert — so concurrent triggers with the same
+  // derived runId never both proceed to drive (architecture doc §15.2,
+  // closes the race the get-then-save pattern leaves open).
   const explicitRunId = args.runId
   const idempotencyKey = args.idempotencyKey
   const derivedRunId =
     idempotencyKey !== undefined ? `idem-${args.workflowId}-${idempotencyKey}` : undefined
   const id = explicitRunId ?? derivedRunId ?? deps.idGenerator?.() ?? defaultRunId(now)
-  if (explicitRunId !== undefined || derivedRunId !== undefined) {
-    const existing = await deps.store.get(id)
-    if (existing) return existing
-  }
+  const isIdempotent = explicitRunId !== undefined || derivedRunId !== undefined
   const record: RunRecord = {
     id,
     workflowId: args.workflowId,
@@ -110,9 +106,20 @@ export async function trigger(args: TriggerArgs, deps: OrchestratorDeps): Promis
     runMeta: { number: args.runNumber ?? 1, attempt: 1 },
     idempotencyKey,
   }
-  // Persist up-front so concurrent `cancel(runId)` calls can find the
-  // run before any invocation has completed.
-  await deps.store.save(record)
+  // Idempotent path uses tryInsert; non-idempotent (auto-generated) ids
+  // can't collide so the existing save() is sufficient.
+  if (isIdempotent) {
+    const result = await deps.store.tryInsert(record)
+    if (!result.created) {
+      // Another caller raced in first. Return their record without
+      // re-driving — drive() is what actually fires side effects.
+      return result.record
+    }
+  } else {
+    // Persist up-front so concurrent `cancel(runId)` calls can find the
+    // run before any invocation has completed.
+    await deps.store.save(record)
+  }
   const abortCtrl = registerRunAbort(id)
   try {
     await driveUntilPaused(record, {

--- a/packages/workflows-orchestrator/src/testing/driver-compliance.ts
+++ b/packages/workflows-orchestrator/src/testing/driver-compliance.ts
@@ -218,6 +218,36 @@ export function runDriverComplianceSuite(
         const b = await driver.trigger(wf, { n: 999 }, { idempotencyKey: key })
         expect(b.id).toBe(a.id)
       })
+
+      test("concurrent triggers with the same idempotencyKey only run once", async () => {
+        // Closes the get-then-save race window. A counter inside the
+        // workflow body lets us assert exactly-once side effects across
+        // 8 parallel triggers — without `tryInsert`'s atomicity, the
+        // counter would tick more than once.
+        const driver = makeFactory()(testFactoryDeps())
+        let invocationCount = 0
+        const wf = workflow<{ tag: string }, { invoked: number }>({
+          id: uniqueId("compliance-race"),
+          async run() {
+            invocationCount++
+            return { invoked: invocationCount }
+          },
+        })
+
+        const key = `race-${suiteCounter}`
+        const triggers = Array.from({ length: 8 }, (_, i) =>
+          driver.trigger(wf, { tag: `caller-${i}` }, { idempotencyKey: key }),
+        )
+        const results = await Promise.all(triggers)
+
+        // All 8 callers receive the same runId.
+        const ids = new Set(results.map((r) => r.id))
+        expect(ids.size).toBe(1)
+
+        // The body runs at most once. (The first writer wins; later
+        // callers return the existing record without re-driving.)
+        expect(invocationCount).toBeLessThanOrEqual(1)
+      })
     })
 
     describe("ingestEvent", () => {
@@ -282,6 +312,49 @@ export function runDriverComplianceSuite(
         if (result.ok) {
           expect(result.eventId).toMatch(/^evt_/)
         }
+      })
+
+      test("eventId fallback is stable across calls (content-derived)", async () => {
+        // Same envelope content → same derived eventId. External HTTP
+        // retries that don't stamp metadata.eventId still dedupe via the
+        // driver's `${filterId}:${eventId}` idempotency key.
+        const driver = makeFactory()(testFactoryDeps())
+        const wfId = uniqueId("compliance-stable-id")
+        const wf = workflow<unknown, void>({
+          id: wfId,
+          async run() {},
+        })
+        const filterId = `ef_${uniqueId("ef-stable")}`
+        const manifest = {
+          ...buildTestManifest(uniqueId("v_stable")),
+          eventFilters: [
+            {
+              id: filterId,
+              eventType: "evt.stable",
+              payloadHash: filterId,
+              targetWorkflowId: wfId,
+            },
+          ],
+        }
+        await driver.registerManifest({ environment: "production", manifest })
+
+        const envelope = {
+          name: "evt.stable",
+          data: { k: "v" },
+          emittedAt: new Date(1_700_000_000_000).toISOString(),
+        }
+        const a = await driver.ingestEvent({ environment: "production", envelope })
+        const b = await driver.ingestEvent({ environment: "production", envelope })
+        if (!a.ok || !b.ok) throw new Error("expected ok=true on both")
+        expect(a.eventId).toBe(b.eventId)
+        const ma = a.matches[0]
+        const mb = b.matches[0]
+        if (ma?.status !== "queued" || mb?.status !== "queued") {
+          throw new Error("expected queued matches")
+        }
+        // Same eventId → same derived idempotencyKey → same run.
+        expect(mb.runId).toBe(ma.runId)
+        void wf
       })
 
       test("matches a where predicate and triggers a run", async () => {

--- a/packages/workflows-orchestrator/src/types.ts
+++ b/packages/workflows-orchestrator/src/types.ts
@@ -138,6 +138,24 @@ export interface RunRecord {
 export interface RunRecordStore {
   get(id: string): Promise<RunRecord | undefined>
   save(record: RunRecord): Promise<RunRecord>
+  /**
+   * Atomically insert a new run record, OR return the existing one if
+   * a record with the same `id` already exists. Used by `trigger()` to
+   * close the get-then-save race window when an idempotency-derived
+   * runId could collide across concurrent callers.
+   *
+   * Stores must implement this with a single atomic operation:
+   *   - Postgres: `INSERT … ON CONFLICT (id) DO NOTHING RETURNING …`,
+   *               with a fallback SELECT when no row is returned.
+   *   - InMemory / FS: check-then-set in a single microtask.
+   *   - DO storage: get-then-save is naturally atomic per DO instance.
+   *
+   * The returned `created: true` means this caller's record was the
+   * winner — drive it. `created: false` means another caller raced in
+   * first; return the existing record without re-driving (per
+   * architecture doc §15.2).
+   */
+  tryInsert(record: RunRecord): Promise<{ record: RunRecord; created: boolean }>
   list(filter?: {
     workflowId?: string
     status?: OrchestratorRunStatus

--- a/packages/workflows/src/events/index.ts
+++ b/packages/workflows/src/events/index.ts
@@ -22,6 +22,7 @@ export {
 export {
   canonicalize,
   canonicalJson,
+  deriveStableEventId,
   sha256,
   shortHash,
 } from "./payload-hash.js"

--- a/packages/workflows/src/events/payload-hash.ts
+++ b/packages/workflows/src/events/payload-hash.ts
@@ -62,6 +62,30 @@ export async function shortHash(value: unknown): Promise<string> {
   return full.slice(0, 16)
 }
 
+/**
+ * Derive a stable event id from an envelope when `metadata.eventId` is
+ * absent. Mirrors the formula from architecture doc §15.2:
+ *
+ *     `${name}:${emittedAt}:${sha256(canonical(data)).slice(0, 12)}`
+ *
+ * Same envelope content always produces the same id — concurrent retries
+ * of the same external HTTP delivery dedupe at the driver's
+ * `${filterId}:${eventId}` idempotency key derivation.
+ *
+ * Returns a fallback id of the form `evt_<name>_<emittedAt>_<hash12>`
+ * (URL-safe; no colons in case the id flows through path segments).
+ */
+export async function deriveStableEventId(envelope: {
+  name: string
+  data: unknown
+  emittedAt: string
+}): Promise<string> {
+  const dataHash = (await sha256(envelope.data)).slice(0, 12)
+  const safeName = envelope.name.replace(/[^a-zA-Z0-9._-]/g, "_")
+  const safeAt = envelope.emittedAt.replace(/[^a-zA-Z0-9.]/g, "_")
+  return `evt_${safeName}_${safeAt}_${dataHash}`
+}
+
 // ---- Internal ----
 
 function getCrypto(): Crypto {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2896,6 +2896,9 @@ importers:
       '@voyantjs/utils':
         specifier: workspace:*
         version: link:../utils
+      '@voyantjs/workflows':
+        specifier: workspace:*
+        version: link:../workflows
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
@@ -2912,6 +2915,9 @@ importers:
       '@voyantjs/voyant-typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
+      '@voyantjs/workflows-orchestrator':
+        specifier: workspace:*
+        version: link:../workflows-orchestrator
       typescript:
         specifier: ^6.0.2
         version: 6.0.2


### PR DESCRIPTION
## Summary
PR4 of 4 — final piece: wires the workflow runtime into `createApp()` so authors get `trigger.on()` filtering, manifest registration, and per-request `c.var.workflowDriver` for free.

Stacks on PR3 (#525, merged) which delivered the CF edge driver and HTTP ingest adapter.

Closes #514.

### What's new
- **`createApp({ workflows: { driver, environment?, projectId? } })`** — opt-in workflow runtime
  - `driver: (bindings) => WorkflowDriverFactoryShape` — always a function-of-bindings (P2.1)
  - `app.ready()` — async accessor returning the lazily-bootstrapped driver, useful for headless / sibling-process Mode 2 deployments
  - Synchronously collects `module.workflows` + `module.eventFilters` + `plugin.workflows`/`eventFilters`
  - Validates duplicate workflow ids
- **`wireWorkflowRuntime`** runs **before** module bootstraps (P2.3) so emitted events at boot route correctly
- Per-request `c.var.workflowDriver` for handler-side `trigger()` calls
- Module/Plugin types gained `workflows?` + `eventFilters?` fields (structural `WorkflowDescriptor`/`EventFilterDescriptor` from `@voyantjs/core`)

### Reviewer findings addressed (all 5)
- **P1.1** Postgres race → `tryInsert` (atomic check-or-insert)
- **P1.2** Mode 2 wakeup poller → `createPostgresWakeupStore` + `createPersistentWakeupManager` auto-start in `createNodeStandaloneDriver`
- **P2.1** deferred driver construction → `(bindings) => DriverFactory` shape always
- **P2.2** random eventId → `deriveStableEventId(envelope)` (sha256 of canonical data)
- **P2.3** forwarder ordering → wireWorkflowRuntime runs before module bootstraps

## Test plan
- [x] 8 integration tests covering: collection→manifest→register→forwarder→trigger pipe, non-matching events, duplicate workflow ids, app.ready idempotent, deferred (env)=>factory shape, bootstrap-time emit routing
- [x] Driver compliance race test (8 parallel idempotent triggers ≤ 1 invocation)
- [x] Mode 2 sleep-resume integration test
- [x] CF compliance test (with per-id queue mirroring real DO single-thread guarantee)
- [x] `pnpm -F @voyantjs/hono... typecheck` clean