### PR TITLE
fix(workflows): trigger.on() returns EventFilterRuntimeEntry

### DIFF
--- a/packages/hono/tests/unit/app-workflows.test.ts
+++ b/packages/hono/tests/unit/app-workflows.test.ts
@@ -13,11 +13,7 @@ import {
   type WorkflowDescriptor,
 } from "@voyantjs/core"
 import { __resetRegistry, trigger, workflow } from "@voyantjs/workflows"
-import {
-  __resetEventFilterRegistry,
-  type EventFilterRuntimeEntry,
-  getEventFilterRegistry,
-} from "@voyantjs/workflows/events"
+import { __resetEventFilterRegistry } from "@voyantjs/workflows/events"
 import { createInMemoryDriver } from "@voyantjs/workflows-orchestrator"
 import { afterEach, describe, expect, test } from "vitest"
 
@@ -41,23 +37,19 @@ function buildPromotionsLikeModule(): HonoModule {
     },
   })
 
-  // Filter: matches when payload.kind === "all".
-  trigger.on("test.event", {
+  // Filter: matches when payload.kind === "all". `trigger.on()` returns
+  // the EventFilterRuntimeEntry directly so it drops straight into
+  // Module.eventFilters — no registry lookup needed.
+  const onPromoChanged = trigger.on("test.event", {
     target: bulkReindex,
     where: { eq: [{ path: "data.kind" }, { lit: "all" }] },
     input: { object: { kind: { path: "data.kind" } } },
   })
 
-  // Pull the single registered runtime entry; in real modules the entry
-  // is the value `trigger.on()` returns. The ./events registry is the
-  // canonical source so a module's eventFilters[] can carry it.
-  const filters = getEventFilterRegistry().list() as readonly (EventFilterRuntimeEntry &
-    EventFilterDescriptor)[]
-
   const moduleSpec: Module = {
     name: "promotions-test",
     workflows: [bulkReindex satisfies WorkflowDescriptor],
-    eventFilters: filters,
+    eventFilters: [onPromoChanged],
   }
   return { module: moduleSpec }
 }
@@ -284,16 +276,14 @@ describe("createApp workflows wiring", () => {
         return input
       },
     })
-    trigger.on("bootstrap.emit", {
+    const onBootstrapEmit = trigger.on("bootstrap.emit", {
       target: wf,
       input: { object: { tag: { path: "data.tag" } } },
     })
-    const filters = getEventFilterRegistry().list() as readonly (EventFilterRuntimeEntry &
-      EventFilterDescriptor)[]
     const moduleSpec: Module = {
       name: "bootstrap-emitter",
       workflows: [wf satisfies WorkflowDescriptor],
-      eventFilters: filters,
+      eventFilters: [onBootstrapEmit],
       async bootstrap(ctx) {
         // Emit during bootstrap. With the pre-fix order this fires into
         // a bus with no workflow subscriber.

--- a/packages/workflows/src/events/__tests__/trigger-on.test.ts
+++ b/packages/workflows/src/events/__tests__/trigger-on.test.ts
@@ -14,25 +14,29 @@ afterEach(() => {
 })
 
 describe("trigger.on", () => {
-  test("registers a filter and returns a handle", () => {
+  test("registers a filter and returns the runtime entry", () => {
     const wf = workflow<{ x: number }, void>({
       id: "test-target",
       async run() {},
     })
 
-    const handle = trigger.on<{ kind: string }>("promotion.changed", {
+    const entry = trigger.on<{ kind: string }>("promotion.changed", {
       target: wf,
       where: { eq: [{ path: "data.kind" }, { lit: "all" }] },
     })
 
-    expect(handle.event).toBe("promotion.changed")
-    expect(handle.id).toMatch(/^ef_[0-9a-f]{16}$/)
+    // The returned entry is the same EventFilterRuntimeEntry that lands
+    // in the registry — directly droppable into Module.eventFilters
+    // without a registry lookup.
+    expect(entry.eventType).toBe("promotion.changed")
+    expect(entry.id).toMatch(/^ef_[0-9a-f]{16}$/)
+    expect(entry.targetWorkflowId).toBe("test-target")
+    expect(entry.manifest.eventType).toBe("promotion.changed")
+    expect(entry.manifest.id).toBe(entry.id)
 
     const entries = getEventFilterRegistry().list()
     expect(entries).toHaveLength(1)
-    expect(entries[0]?.id).toBe(handle.id)
-    expect(entries[0]?.eventType).toBe("promotion.changed")
-    expect(entries[0]?.targetWorkflowId).toBe("test-target")
+    expect(entries[0]).toBe(entry)
   })
 
   test("identical declarations produce identical ids (stable across re-imports)", () => {
@@ -80,13 +84,10 @@ describe("trigger.on", () => {
       async run() {},
     })
 
-    const handle = trigger.on("evt.x", { target: wf })
-    expect(handle.event).toBe("evt.x")
-    const entry = getEventFilterRegistry()
-      .list()
-      .find((e) => e.id === handle.id)
-    expect(entry?.manifest.where).toBeUndefined()
-    expect(entry?.manifest.input).toBeUndefined()
+    const entry = trigger.on("evt.x", { target: wf })
+    expect(entry.eventType).toBe("evt.x")
+    expect(entry.manifest.where).toBeUndefined()
+    expect(entry.manifest.input).toBeUndefined()
   })
 
   test("rejects empty event name", () => {
@@ -151,7 +152,7 @@ describe("trigger.on", () => {
       async run() {},
     })
 
-    const handle = trigger.on("evt.x", {
+    const entry = trigger.on("evt.x", {
       target: wf,
       where: { eq: [{ path: "data.k" }, { lit: "v" }] },
       input: {
@@ -162,11 +163,8 @@ describe("trigger.on", () => {
       },
     })
 
-    const entry = getEventFilterRegistry()
-      .list()
-      .find((e) => e.id === handle.id)
-    expect(entry?.manifest).toMatchObject({
-      id: handle.id,
+    expect(entry.manifest).toMatchObject({
+      id: entry.id,
       eventType: "evt.x",
       targetWorkflowId: "test-manifest-shape",
       where: { eq: [{ path: "data.k" }, { lit: "v" }] },

--- a/packages/workflows/src/events/compile.ts
+++ b/packages/workflows/src/events/compile.ts
@@ -123,28 +123,26 @@ export async function compileEventFilter<T>(
 
 /**
  * Compile + register in one step. The synchronous wrapper for `trigger.on()`
- * that user code calls — kicks off compile asynchronously, registers when
- * the entry is ready, and returns a handle the user can ignore. Validation
- * errors become unhandled-rejection warnings in dev (caught by vitest etc.)
- * and surface at boot via `manifestBuilder.buildManifest()` which awaits
- * registry settlement.
+ * that user code calls — validates the declaration, computes the
+ * content-derived id, registers the entry, and returns it.
  *
- * For the synchronous-handle return we use a placeholder id; the real id
- * lands when the compile resolves. Since `trigger.on()` is the user-facing
- * API and most users don't inspect the returned handle (they just want the
- * filter registered), this is fine. If a future caller needs the real id
- * synchronously, see {@link compileEventFilterSync} below.
+ * Returning the full {@link EventFilterRuntimeEntry} is what makes the
+ * authoring shape from the architecture doc work directly — modules can
+ * write `eventFilters: [trigger.on(...)]` without a registry round-trip:
+ * the entry already structurally satisfies `EventFilterDescriptor`
+ * (matching `id` + `eventType` fields) and carries the `manifest` payload
+ * `createApp()`'s wireWorkflowRuntime needs to register with the driver.
  */
 export function compileAndRegister<T>(
   eventType: string,
   declaration: EventFilterDeclaration<T>,
-): { id: string; readonly event: string } {
+): EventFilterRuntimeEntry {
   // Run validation + compile synchronously where possible. The async
   // boundary is the SHA-256 digest from Web Crypto; we bridge via a
   // synchronous canonical-JSON hash so trigger.on() can stay sync.
   const entry = compileEventFilterSync(eventType, declaration)
   getEventFilterRegistry().add(entry)
-  return { id: entry.id, event: entry.eventType }
+  return entry
 }
 
 /**

--- a/packages/workflows/src/trigger.ts
+++ b/packages/workflows/src/trigger.ts
@@ -115,11 +115,7 @@ export const workflows: WorkflowsClient = new Proxy({} as WorkflowsClient, {
 import { compileAndRegister } from "./events/compile.js"
 import type { InputMapper } from "./events/input-mapper.js"
 import type { PredicateExpr } from "./events/predicate.js"
-
-export interface EventFilterHandle {
-  readonly id: string
-  readonly event: string
-}
+import type { EventFilterRuntimeEntry } from "./events/registry.js"
 
 /**
  * Declarative binding from an event name to a target workflow. Authors call
@@ -141,11 +137,19 @@ export interface EventFilterDeclaration<T> {
 }
 
 export interface TriggerApi {
-  on<T = unknown>(event: string, filter: EventFilterDeclaration<T>): EventFilterHandle
+  /**
+   * Register an event filter targeting `event`. Returns the
+   * {@link EventFilterRuntimeEntry} so authors can drop it directly into
+   * `Module.eventFilters` / `Plugin.eventFilters` — the entry structurally
+   * satisfies core's `EventFilterDescriptor` (matching `id` + `eventType`)
+   * and carries the manifest payload `createApp()` needs to register with
+   * the driver.
+   */
+  on<T = unknown>(event: string, filter: EventFilterDeclaration<T>): EventFilterRuntimeEntry
 }
 
 export const trigger: TriggerApi = {
-  on<T>(event: string, filter: EventFilterDeclaration<T>): EventFilterHandle {
+  on<T>(event: string, filter: EventFilterDeclaration<T>): EventFilterRuntimeEntry {
     return compileAndRegister(event, filter)
   },
 }


### PR DESCRIPTION
## Summary

`trigger.on()` previously returned `EventFilterHandle = { id, event }`, which didn't structurally satisfy core's `EventFilterDescriptor = { id, eventType }` (field name mismatch) and didn't carry the `manifest` payload that `createApp()`'s `wireWorkflowRuntime` needs (the validator added in 5433d538b on PR #526 explicitly requires `.manifest`).

That made the architecture-doc authoring shape

\`\`\`ts
const onPromoChanged = trigger.on(\"promotion.changed\", { ... })

export const promotionsModule: Module = {
  workflows: [bulkReindex],
  eventFilters: [onPromoChanged], // ← didn't typecheck, didn't pass validator
}
\`\`\`

unusable. Authors had to walk the registry (\`getEventFilterRegistry().list()\`) by id to recover the runtime entry — a workaround a downstream agent flagged while migrating the promotions module.

## Fix

Return the full \`EventFilterRuntimeEntry\` from \`trigger.on()\`. The entry:
- has matching \`id\` + \`eventType\` so it satisfies `EventFilterDescriptor` exactly
- carries \`manifest\` so the validator passes
- carries \`targetWorkflowId\` + \`declaration\` for debug / dashboard use
- is the same object stored in the process-local registry, so identity comparisons work

Drops the unused \`EventFilterHandle\` interface. No other consumers reference it.

## Test plan
- [x] \`packages/workflows\` — 254/254 tests pass
- [x] \`packages/hono\` — 10/10 \`app-workflows.test.ts\` tests pass
- [x] \`pnpm -F dmc typecheck\` clean
- [x] \`pnpm -F operator typecheck\` clean
- [x] Updated \`packages/hono/tests/unit/app-workflows.test.ts\` to remove the registry-lookup workaround in two places — unit tests now demonstrate the clean authoring shape directly