### PR TITLE
[codex] Add promotions React and UI packages

### DIFF
--- a/.changeset/promotions-react-ui-packages.md
+++ b/.changeset/promotions-react-ui-packages.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/promotions-react": minor
+"@voyantjs/promotions-ui": minor
+---
+
+Add package-owned React hooks and UI components for operator promotions.

--- a/packages/promotions-react/package.json
+++ b/packages/promotions-react/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@voyantjs/promotions-react",
+  "version": "0.29.0",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyantjs/voyant.git",
+    "directory": "packages/promotions-react"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "prepack": "pnpm run build",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check src/",
+    "test": "vitest run --passWithNoTests"
+  },
+  "peerDependencies": {
+    "@tanstack/react-query": "^5.0.0",
+    "@voyantjs/promotions": "workspace:*",
+    "@voyantjs/react": "workspace:*",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@tanstack/react-query": "^5.96.2",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@voyantjs/promotions": "workspace:*",
+    "@voyantjs/react": "workspace:*",
+    "@voyantjs/voyant-typescript-config": "workspace:*",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2",
+    "zod": "^4.3.6"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  }
+}

--- a/packages/promotions-react/src/index.ts
+++ b/packages/promotions-react/src/index.ts
@@ -1,11 +1,4 @@
-/**
- * Template-local promotions client + React Query options.
- *
- * Mirrors the legal-react pattern (fetch + Zod + queryOptions factory)
- * but lives in-template for v1 — promotion ops are operator-internal so
- * we don't need a published react companion package yet. If a second
- * template needs this, extract to `@voyantjs/promotions-react`.
- */
+"use client"
 
 import {
   type QueryClient,
@@ -14,24 +7,37 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query"
+import {
+  type PromotionalOfferScope,
+  promotionalOfferScopeSchema,
+} from "@voyantjs/promotions/validation"
+import {
+  defaultFetcher,
+  useVoyantReactContext,
+  type VoyantFetcher,
+  type VoyantReactContextValue,
+  VoyantReactProvider,
+  type VoyantReactProviderProps,
+} from "@voyantjs/react"
 import { z } from "zod"
 
-import { getApiUrl } from "@/lib/env"
+// ---------- Provider ----------
 
-// ---------- Schemas (subset of @voyantjs/promotions/validation) ----------
+export {
+  defaultFetcher,
+  useVoyantReactContext as useVoyantPromotionsContext,
+  type VoyantFetcher,
+  type VoyantReactContextValue as VoyantPromotionsContextValue,
+  VoyantReactProvider as VoyantPromotionsProvider,
+  type VoyantReactProviderProps as VoyantPromotionsProviderProps,
+}
 
-const audienceSchema = z.enum(["staff", "customer", "partner", "supplier"])
+// ---------- Schemas ----------
 
-export const promotionalOfferScopeSchema = z.discriminatedUnion("kind", [
-  z.object({ kind: z.literal("global") }),
-  z.object({ kind: z.literal("products"), productIds: z.array(z.string().min(1)).min(1) }),
-  z.object({ kind: z.literal("categories"), categoryIds: z.array(z.string().min(1)).min(1) }),
-  z.object({ kind: z.literal("destinations"), destinationIds: z.array(z.string().min(1)).min(1) }),
-  z.object({ kind: z.literal("markets"), marketIds: z.array(z.string().min(1)).min(1) }),
-  z.object({ kind: z.literal("audiences"), audiences: z.array(audienceSchema).min(1) }),
-])
-
-export type PromotionalOfferScope = z.infer<typeof promotionalOfferScopeSchema>
+export {
+  type PromotionalOfferScope,
+  promotionalOfferScopeSchema,
+} from "@voyantjs/promotions/validation"
 
 const promotionalOfferRecordSchema = z.object({
   id: z.string(),
@@ -67,14 +73,19 @@ const singleResponseSchema = z.object({ data: promotionalOfferRecordSchema })
 
 // ---------- Fetch helpers ----------
 
-interface ListQuery {
+export interface PromotionsListQuery {
   active?: boolean
   code?: string
   limit?: number
   offset?: number
 }
 
-function buildSearch(query: ListQuery): string {
+export interface PromotionsClientOptions {
+  baseUrl: string
+  fetcher: VoyantFetcher
+}
+
+function buildSearch(query: PromotionsListQuery): string {
   const params = new URLSearchParams()
   if (query.active !== undefined) params.set("active", String(query.active))
   if (query.code) params.set("code", query.code)
@@ -84,29 +95,63 @@ function buildSearch(query: ListQuery): string {
   return s ? `?${s}` : ""
 }
 
-async function fetchJson<T>(path: string, init: RequestInit, schema: z.ZodType<T>): Promise<T> {
-  const res = await fetch(`${getApiUrl()}${path}`, {
-    credentials: "include",
-    headers: { "Content-Type": "application/json", ...(init.headers ?? {}) },
-    ...init,
-  })
-  const text = await res.text()
-  const body = text ? safeJson(text) : undefined
-  if (!res.ok) {
+export async function fetchPromotionsJson<T>(
+  path: string,
+  init: RequestInit,
+  schema: z.ZodType<T>,
+  client: PromotionsClientOptions,
+): Promise<T> {
+  const headers = new Headers(init.headers)
+  if (init.body !== undefined && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json")
+  }
+
+  const response = await client.fetcher(joinUrl(client.baseUrl, path), { ...init, headers })
+  const body = await safeJson(response)
+  if (!response.ok) {
     const message =
       typeof body === "object" && body && "error" in body
         ? String((body as { error: unknown }).error)
-        : `Promotions API error: ${res.status} ${res.statusText}`
-    throw new PromotionsApiError(message, res.status, body)
+        : `Promotions API error: ${response.status} ${response.statusText}`
+    throw new PromotionsApiError(message, response.status, body)
   }
   return schema.parse(body)
 }
 
-function safeJson(text: string): unknown {
+async function safeJson(response: Response): Promise<unknown> {
+  const text = await response.text()
+  if (!text) return undefined
+
   try {
     return JSON.parse(text)
   } catch {
     return text
+  }
+}
+
+function joinUrl(baseUrl: string, path: string): string {
+  const resolvedBaseUrl = resolveBaseUrl(baseUrl)
+  const trimmedBase = resolvedBaseUrl.endsWith("/") ? resolvedBaseUrl.slice(0, -1) : resolvedBaseUrl
+  const trimmedPath = path.startsWith("/") ? path : `/${path}`
+  return `${trimmedBase}${trimmedPath}`
+}
+
+function resolveBaseUrl(baseUrl: string): string {
+  if (baseUrl.trim()) return baseUrl
+
+  if (typeof window !== "undefined") {
+    return `${window.location.origin}/api`
+  }
+
+  return "http://localhost:3300/api"
+}
+
+export function createPromotionsClientOptions(
+  client?: Partial<PromotionsClientOptions>,
+): PromotionsClientOptions {
+  return {
+    baseUrl: client?.baseUrl ?? "",
+    fetcher: client?.fetcher ?? defaultFetcher,
   }
 }
 
@@ -123,32 +168,47 @@ export class PromotionsApiError extends Error {
 
 // ---------- Query keys + options ----------
 
-const promotionsKeys = {
+export const promotionsKeys = {
   all: ["promotions"] as const,
-  list: (query: ListQuery) => ["promotions", "list", query] as const,
+  list: (query: PromotionsListQuery) => ["promotions", "list", query] as const,
   detail: (id: string) => ["promotions", "detail", id] as const,
 }
 
-export function getPromotionsListQueryOptions(query: ListQuery = {}) {
+export function getPromotionsListQueryOptions(
+  query: PromotionsListQuery = {},
+  client: PromotionsClientOptions = createPromotionsClientOptions(),
+) {
   return queryOptions({
     queryKey: promotionsKeys.list(query),
     queryFn: () =>
-      fetchJson(`/v1/admin/promotions${buildSearch(query)}`, { method: "GET" }, listResponseSchema),
-  })
-}
-
-export function getPromotionByIdQueryOptions(id: string) {
-  return queryOptions({
-    queryKey: promotionsKeys.detail(id),
-    queryFn: () =>
-      fetchJson(`/v1/admin/promotions/${id}`, { method: "GET" }, singleResponseSchema).then(
-        (r) => r.data,
+      fetchPromotionsJson(
+        `/v1/admin/promotions${buildSearch(query)}`,
+        { method: "GET" },
+        listResponseSchema,
+        client,
       ),
   })
 }
 
-export function usePromotionsList(query: ListQuery = {}) {
-  return useQuery(getPromotionsListQueryOptions(query))
+export function getPromotionByIdQueryOptions(
+  id: string,
+  client: PromotionsClientOptions = createPromotionsClientOptions(),
+) {
+  return queryOptions({
+    queryKey: promotionsKeys.detail(id),
+    queryFn: () =>
+      fetchPromotionsJson(
+        `/v1/admin/promotions/${id}`,
+        { method: "GET" },
+        singleResponseSchema,
+        client,
+      ).then((r) => r.data),
+  })
+}
+
+export function usePromotionsList(query: PromotionsListQuery = {}) {
+  const client = useVoyantReactContext()
+  return useQuery(getPromotionsListQueryOptions(query, client))
 }
 
 // ---------- Mutations ----------
@@ -178,12 +238,14 @@ function invalidatePromotions(qc: QueryClient): Promise<void> {
 
 export function useCreatePromotion() {
   const qc = useQueryClient()
+  const client = useVoyantReactContext()
   return useMutation({
     mutationFn: (input: PromotionInsertInput) =>
-      fetchJson(
+      fetchPromotionsJson(
         "/v1/admin/promotions",
         { method: "POST", body: JSON.stringify(input) },
         singleResponseSchema,
+        client,
       ).then((r) => r.data),
     onSuccess: () => invalidatePromotions(qc),
   })
@@ -191,12 +253,14 @@ export function useCreatePromotion() {
 
 export function useUpdatePromotion() {
   const qc = useQueryClient()
+  const client = useVoyantReactContext()
   return useMutation({
     mutationFn: ({ id, patch }: { id: string; patch: PromotionUpdateInput }) =>
-      fetchJson(
+      fetchPromotionsJson(
         `/v1/admin/promotions/${id}`,
         { method: "PATCH", body: JSON.stringify(patch) },
         singleResponseSchema,
+        client,
       ).then((r) => r.data),
     onSuccess: () => invalidatePromotions(qc),
   })
@@ -204,12 +268,14 @@ export function useUpdatePromotion() {
 
 export function useArchivePromotion() {
   const qc = useQueryClient()
+  const client = useVoyantReactContext()
   return useMutation({
     mutationFn: (id: string) =>
-      fetchJson(
+      fetchPromotionsJson(
         `/v1/admin/promotions/${id}/archive`,
         { method: "POST" },
         singleResponseSchema,
+        client,
       ).then((r) => r.data),
     onSuccess: () => invalidatePromotions(qc),
   })
@@ -217,12 +283,14 @@ export function useArchivePromotion() {
 
 export function useDeletePromotion() {
   const qc = useQueryClient()
+  const client = useVoyantReactContext()
   return useMutation({
     mutationFn: (id: string) =>
-      fetchJson(
+      fetchPromotionsJson(
         `/v1/admin/promotions/${id}`,
         { method: "DELETE" },
         z.object({ data: z.object({ id: z.string() }) }),
+        client,
       ).then((r) => r.data),
     onSuccess: () => invalidatePromotions(qc),
   })

--- a/packages/promotions-react/tsconfig.json
+++ b/packages/promotions-react/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@voyantjs/voyant-typescript-config/react-library.json",
+  "compilerOptions": {
+    "composite": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/promotions-ui/package.json
+++ b/packages/promotions-ui/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@voyantjs/promotions-ui",
+  "version": "0.29.0",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyantjs/voyant.git",
+    "directory": "packages/promotions-ui"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./components/*": "./src/*.tsx"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "prepack": "pnpm run build",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check src/",
+    "test": "vitest run --passWithNoTests"
+  },
+  "peerDependencies": {
+    "@tanstack/react-query": "^5.0.0",
+    "@voyantjs/promotions-react": "workspace:*",
+    "@voyantjs/ui": "workspace:*",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@tanstack/react-query": "^5.96.2",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@voyantjs/promotions-react": "workspace:*",
+    "@voyantjs/ui": "workspace:*",
+    "@voyantjs/voyant-typescript-config": "workspace:*",
+    "lucide-react": "^0.475.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2",
+    "zod": "^4.3.6"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      },
+      "./components/*": {
+        "types": "./dist/*.d.ts",
+        "import": "./dist/*.js",
+        "default": "./dist/*.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  }
+}

--- a/packages/promotions-ui/src/index.ts
+++ b/packages/promotions-ui/src/index.ts
@@ -1,0 +1,2 @@
+export { PromotionDialog, type PromotionDialogProps } from "./promotion-dialog.js"
+export { loadPromotionsPage, PromotionsPage } from "./promotions-page.js"

--- a/packages/promotions-ui/src/promotion-dialog.tsx
+++ b/packages/promotions-ui/src/promotion-dialog.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 /**
  * Create / edit dialog for a promotional offer.
  *
@@ -8,7 +10,14 @@
  * search components per scope kind.
  */
 
-import { useEffect, useState } from "react"
+import {
+  type PromotionalOfferRecord,
+  type PromotionalOfferScope,
+  type PromotionInsertInput,
+  promotionalOfferScopeSchema,
+  useCreatePromotion,
+  useUpdatePromotion,
+} from "@voyantjs/promotions-react"
 import {
   Button,
   Dialog,
@@ -26,18 +35,10 @@ import {
   SelectValue,
   Switch,
   Textarea,
-} from "@/components/ui"
+} from "@voyantjs/ui/components"
+import { useEffect, useState } from "react"
 
-import {
-  type PromotionalOfferRecord,
-  type PromotionalOfferScope,
-  type PromotionInsertInput,
-  promotionalOfferScopeSchema,
-  useCreatePromotion,
-  useUpdatePromotion,
-} from "./promotions-client"
-
-interface PromotionDialogProps {
+export interface PromotionDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   /** When provided, the dialog opens in edit mode. */

--- a/packages/promotions-ui/src/promotions-page.tsx
+++ b/packages/promotions-ui/src/promotions-page.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 /**
  * Operator-facing promotions list page.
  *
@@ -10,21 +12,27 @@
  */
 
 import type { QueryClient } from "@tanstack/react-query"
-import { Plus } from "lucide-react"
-import { useMemo, useState } from "react"
-
-import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from "@/components/ui"
-
-import { PromotionDialog } from "./promotion-dialog"
 import {
+  createPromotionsClientOptions,
   getPromotionsListQueryOptions,
   type PromotionalOfferRecord,
   type PromotionalOfferScope,
+  type PromotionsClientOptions,
   usePromotionsList,
-} from "./promotions-client"
+} from "@voyantjs/promotions-react"
+import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from "@voyantjs/ui/components"
+import { Plus } from "lucide-react"
+import { useMemo, useState } from "react"
 
-export function loadPromotionsPage(queryClient: QueryClient) {
-  return queryClient.ensureQueryData(getPromotionsListQueryOptions({ limit: 50, offset: 0 }))
+import { PromotionDialog } from "./promotion-dialog.js"
+
+export function loadPromotionsPage(
+  queryClient: QueryClient,
+  client?: Partial<PromotionsClientOptions>,
+) {
+  return queryClient.ensureQueryData(
+    getPromotionsListQueryOptions({ limit: 50, offset: 0 }, createPromotionsClientOptions(client)),
+  )
 }
 
 export function PromotionsPage() {

--- a/packages/promotions-ui/tsconfig.build.json
+++ b/packages/promotions-ui/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@voyantjs/voyant-typescript-config/react-library.json",
+  "compilerOptions": {
+    "composite": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/promotions-ui/tsconfig.json
+++ b/packages/promotions-ui/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@voyantjs/voyant-typescript-config/react-library.json",
+  "compilerOptions": {
+    "composite": false,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4055,6 +4055,81 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
 
+  packages/promotions-react:
+    devDependencies:
+      '@tanstack/react-query':
+        specifier: ^5.96.2
+        version: 5.96.2(react@19.2.4)
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@voyantjs/promotions':
+        specifier: workspace:*
+        version: link:../promotions
+      '@voyantjs/react':
+        specifier: workspace:*
+        version: link:../react
+      '@voyantjs/voyant-typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+
+  packages/promotions-ui:
+    devDependencies:
+      '@tanstack/react-query':
+        specifier: ^5.96.2
+        version: 5.96.2(react@19.2.4)
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@voyantjs/promotions-react':
+        specifier: workspace:*
+        version: link:../promotions-react
+      '@voyantjs/ui':
+        specifier: workspace:*
+        version: link:../ui
+      '@voyantjs/voyant-typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      lucide-react:
+        specifier: ^0.475.0
+        version: 0.475.0(react@19.2.4)
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+
   packages/react:
     devDependencies:
       '@types/react':
@@ -5599,6 +5674,12 @@ importers:
       '@voyantjs/promotions':
         specifier: workspace:*
         version: link:../../packages/promotions
+      '@voyantjs/promotions-react':
+        specifier: workspace:*
+        version: link:../../packages/promotions-react
+      '@voyantjs/promotions-ui':
+        specifier: workspace:*
+        version: link:../../packages/promotions-ui
       '@voyantjs/react':
         specifier: workspace:*
         version: link:../../packages/react

--- a/templates/operator/package.json
+++ b/templates/operator/package.json
@@ -97,6 +97,8 @@
     "@voyantjs/products-react": "workspace:*",
     "@voyantjs/products-ui": "workspace:*",
     "@voyantjs/promotions": "workspace:*",
+    "@voyantjs/promotions-react": "workspace:*",
+    "@voyantjs/promotions-ui": "workspace:*",
     "@voyantjs/react": "workspace:*",
     "@voyantjs/resources": "workspace:*",
     "@voyantjs/resources-react": "workspace:*",

--- a/templates/operator/src/lib/admin-extensions.tsx
+++ b/templates/operator/src/lib/admin-extensions.tsx
@@ -23,8 +23,8 @@ import { Tag } from "lucide-react"
 
 /**
  * Promotions extension — registers the sidebar nav entry pointing to
- * `/promotions`. Routes + components live template-local in
- * `src/components/voyant/promotions/` (pattern mirrors `legal`).
+ * `/promotions`. The route composes package-owned React/UI surfaces from
+ * `@voyantjs/promotions-react` and `@voyantjs/promotions-ui`.
  *
  * Per docs/architecture/promotions-architecture.md PR5.
  */

--- a/templates/operator/src/routes/_workspace/promotions/index.tsx
+++ b/templates/operator/src/routes/_workspace/promotions/index.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router"
-import { loadPromotionsPage, PromotionsPage } from "@/components/voyant/promotions/promotions-page"
+import { loadPromotionsPage, PromotionsPage } from "@voyantjs/promotions-ui"
+import { getApiUrl } from "@/lib/env"
 
 export const Route = createFileRoute("/_workspace/promotions/")({
-  loader: ({ context }) => loadPromotionsPage(context.queryClient),
+  loader: ({ context }) => loadPromotionsPage(context.queryClient, { baseUrl: getApiUrl() }),
   component: PromotionsPage,
 })

--- a/templates/operator/src/routes/_workspace/promotions/index.tsx
+++ b/templates/operator/src/routes/_workspace/promotions/index.tsx
@@ -1,8 +1,17 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { VoyantPromotionsProvider } from "@voyantjs/promotions-react"
 import { loadPromotionsPage, PromotionsPage } from "@voyantjs/promotions-ui"
 import { getApiUrl } from "@/lib/env"
 
 export const Route = createFileRoute("/_workspace/promotions/")({
   loader: ({ context }) => loadPromotionsPage(context.queryClient, { baseUrl: getApiUrl() }),
-  component: PromotionsPage,
+  component: PromotionsRoute,
 })
+
+function PromotionsRoute() {
+  return (
+    <VoyantPromotionsProvider baseUrl={getApiUrl()}>
+      <PromotionsPage />
+    </VoyantPromotionsProvider>
+  )
+}


### PR DESCRIPTION
## Summary

- Add `@voyantjs/promotions-react` with the promotions API client, React Query hooks, query options, and provider aliases.
- Add `@voyantjs/promotions-ui` with package-owned operator promotions page/dialog components.
- Rewire the operator promotions route to consume the new packages and remove the template-local promotions client/UI files.
- Add a changeset so the new packages join the next release train.

## Validation

- `pnpm -F @voyantjs/promotions-react lint`
- `pnpm -F @voyantjs/promotions-react typecheck`
- `pnpm -F @voyantjs/promotions-react build`
- `pnpm -F @voyantjs/promotions-ui lint`
- `pnpm -F @voyantjs/promotions-ui typecheck`
- `pnpm -F @voyantjs/promotions-ui build`
- `pnpm verify:release-train`
- `pnpm verify:package-exports`
- commit hook full lint + Turbo typecheck
- pre-push full test lane