### PR TITLE
[codex] Wire workflow trigger delay

### DIFF
--- a/.changeset/workflows-trigger-delay.md
+++ b/.changeset/workflows-trigger-delay.md
@@ -1,0 +1,7 @@
+---
+"@voyantjs/workflows-orchestrator": patch
+"@voyantjs/workflows-orchestrator-node": patch
+"@voyantjs/workflows-orchestrator-cloudflare": patch
+---
+
+Wire `TriggerOptions.delay` through the workflow orchestrator drivers so delayed runs park on a DATETIME waitpoint and wake through the existing time wheel.

--- a/packages/workflows-orchestrator-cloudflare/src/cloudflare-edge-driver.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/cloudflare-edge-driver.ts
@@ -183,6 +183,10 @@ export function createCloudflareEdgeDriver(opts: CloudflareEdgeDriverOptions): D
         environment: env,
         tags: triggerOpts?.tags,
         idempotencyKey: triggerOpts?.idempotencyKey,
+        delay:
+          triggerOpts?.delay instanceof Date
+            ? { wakeAt: triggerOpts.delay.getTime() }
+            : triggerOpts?.delay,
         triggeredBy: { kind: "api" as const },
       }
       const resp = await forwardToRunDO(

--- a/packages/workflows-orchestrator-cloudflare/src/durable-object.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/durable-object.ts
@@ -87,6 +87,11 @@ export async function handleDurableObjectRequest(
         environment: payload.environment,
         tags: payload.tags,
         runId: payload.runId,
+        idempotencyKey: payload.idempotencyKey,
+        delay:
+          typeof payload.delay === "object" && payload.delay !== null && "wakeAt" in payload.delay
+            ? new Date(payload.delay.wakeAt)
+            : payload.delay,
       },
       { store, handler, now: deps.now },
     )

--- a/packages/workflows-orchestrator-cloudflare/src/types.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/types.ts
@@ -2,6 +2,7 @@
 // a hard dependency on `@cloudflare/workers-types` — matching the
 // shape is enough, and tests can pass plain objects.
 
+import type { Duration } from "@voyantjs/workflows"
 import type { WaitpointInjection } from "@voyantjs/workflows-orchestrator"
 
 /**
@@ -57,6 +58,8 @@ export interface TriggerPayload {
   environment?: "production" | "preview" | "development"
   tags?: string[]
   runId?: string
+  idempotencyKey?: string
+  delay?: Duration | { wakeAt: number }
 }
 
 /** Cancel payload. */

--- a/packages/workflows-orchestrator-node/src/node-standalone-driver.ts
+++ b/packages/workflows-orchestrator-node/src/node-standalone-driver.ts
@@ -243,6 +243,7 @@ export function createNodeStandaloneDriver(opts: NodeStandaloneDriverOptions): D
           environment: env,
           tags: triggerOpts?.tags,
           idempotencyKey: triggerOpts?.idempotencyKey,
+          delay: triggerOpts?.delay,
         },
         { store: runStore, handler, now },
       )

--- a/packages/workflows-orchestrator/src/__tests__/orchestrator.test.ts
+++ b/packages/workflows-orchestrator/src/__tests__/orchestrator.test.ts
@@ -59,6 +59,52 @@ describe("trigger()", () => {
     expect(await store.get(record.id)).toEqual(record)
   })
 
+  it("parks a delayed trigger on a synthetic DATETIME waitpoint until wakeAt", async () => {
+    let invocations = 0
+    workflow<void, string>({
+      id: "delayed",
+      async run() {
+        invocations++
+        return "done"
+      },
+    })
+    const store = createInMemoryRunStore()
+    const t0 = 1_700_000_000_000
+    let clock = t0
+    const deps = { store, handler, now: () => clock }
+
+    const rec = await trigger(
+      {
+        workflowId: "delayed",
+        workflowVersion: "v1",
+        input: undefined,
+        tenantMeta,
+        delay: "1s",
+      },
+      deps,
+    )
+    expect(rec.status).toBe("waiting")
+    expect(rec.startedAt).toBe(t0 + 1_000)
+    expect(rec.invocationCount).toBe(0)
+    expect(invocations).toBe(0)
+    expect(rec.pendingWaitpoints).toMatchObject([
+      {
+        kind: "DATETIME",
+        meta: { wakeAt: t0 + 1_000, source: "trigger.delay" },
+      },
+    ])
+
+    clock = t0 + 500
+    expect(await resumeDueAlarms({ runId: rec.id }, deps)).toBeNull()
+    expect(invocations).toBe(0)
+
+    clock = t0 + 1_000
+    const saved = await resumeDueAlarms({ runId: rec.id }, deps)
+    expect(saved?.status).toBe("completed")
+    expect(saved?.output).toBe("done")
+    expect(invocations).toBe(1)
+  })
+
   it("persists step results in the run's journal", async () => {
     workflow<number, number>({
       id: "chain",

--- a/packages/workflows-orchestrator/src/driver-inmemory.ts
+++ b/packages/workflows-orchestrator/src/driver-inmemory.ts
@@ -35,7 +35,11 @@ import type { WorkflowManifest } from "@voyantjs/workflows/protocol"
 
 import { routeEvent } from "./event-router.js"
 import { createInMemoryRunStore } from "./in-memory-store.js"
-import { cancel as orchestratorCancel, trigger as orchestratorTrigger } from "./orchestrator.js"
+import {
+  cancel as orchestratorCancel,
+  trigger as orchestratorTrigger,
+  resumeDueAlarms,
+} from "./orchestrator.js"
 import type { RunRecord, StepHandler } from "./types.js"
 
 // ---- Public factory options ----
@@ -128,9 +132,11 @@ export function createInMemoryDriver(opts: InMemoryDriverOptions = {}): DriverFa
           environment: env,
           tags: triggerOpts?.tags,
           idempotencyKey: triggerOpts?.idempotencyKey,
+          delay: triggerOpts?.delay,
         },
         { store, handler, now },
       )
+      scheduleDelayedRun(record)
       return runRecordToRun<TOut>(record)
     }
 
@@ -183,6 +189,7 @@ export function createInMemoryDriver(opts: InMemoryDriverOptions = {}): DriverFa
             },
             { store, handler, now },
           )
+          scheduleDelayedRun(record)
           matches.push({
             filterId: entry.filterId,
             targetWorkflowId: entry.targetWorkflowId,
@@ -216,6 +223,19 @@ export function createInMemoryDriver(opts: InMemoryDriverOptions = {}): DriverFa
 
     async function shutdown(): Promise<void> {
       shuttingDown = true
+    }
+
+    function scheduleDelayedRun(record: RunRecord): void {
+      if (record.status !== "waiting") return
+      const wakeAt = earliestWakeAt(record)
+      if (wakeAt === undefined) return
+      const delayMs = Math.max(0, wakeAt - now())
+      const timer = setTimeout(() => {
+        void resumeDueAlarms({ runId: record.id }, { store, handler, now }).then((resumed) => {
+          if (resumed) scheduleDelayedRun(resumed)
+        })
+      }, delayMs)
+      timer.unref?.()
     }
 
     // ---- WorkflowAdmin (partial; sufficient for compliance tests) ----
@@ -275,6 +295,17 @@ export function createInMemoryDriver(opts: InMemoryDriverOptions = {}): DriverFa
       admin,
     }
   }
+}
+
+function earliestWakeAt(record: RunRecord): number | undefined {
+  let earliest: number | undefined
+  for (const waitpoint of record.pendingWaitpoints) {
+    if (waitpoint.kind !== "DATETIME") continue
+    const wakeAt = typeof waitpoint.meta.wakeAt === "number" ? waitpoint.meta.wakeAt : undefined
+    if (wakeAt === undefined) continue
+    earliest = earliest === undefined ? wakeAt : Math.min(earliest, wakeAt)
+  }
+  return earliest
 }
 
 // ---- Helpers ----

--- a/packages/workflows-orchestrator/src/orchestrator.ts
+++ b/packages/workflows-orchestrator/src/orchestrator.ts
@@ -7,6 +7,8 @@
 // `cancel()` closes out a run without running compensations (they
 // must come from the tenant handler, not the orchestrator).
 
+import type { Duration } from "@voyantjs/workflows"
+
 import { registerRunAbort, signalRunAbort, unregisterRunAbort } from "./abort-registry.js"
 import { applyWaitpointInjection, type DriveOptions, driveUntilPaused } from "./drive.js"
 import { emptyJournal } from "./journal-helpers.js"
@@ -43,6 +45,12 @@ export interface TriggerArgs {
    */
   idempotencyKey?: string
   /**
+   * Optional trigger-time delay. When set to a future instant, the
+   * orchestrator persists the run in `waiting` on a synthetic DATETIME
+   * waitpoint and leaves execution to the normal wakeup/time-wheel path.
+   */
+  delay?: Duration | Date
+  /**
    * Optional journal seed. Used by external replay/resume callers
    * that need a new run to skip steps already completed by a parent
    * run.
@@ -72,6 +80,7 @@ export interface OrchestratorDeps extends DriveOptions {
 
 export async function trigger(args: TriggerArgs, deps: OrchestratorDeps): Promise<RunRecord> {
   const now = deps.now ?? (() => Date.now())
+  const createdAt = now()
   // Idempotency: caller-supplied `runId` wins (explicit). Otherwise, when
   // `idempotencyKey` is supplied, derive a deterministic runId from
   // `(workflowId, idempotencyKey)`. We then route through `store.tryInsert`
@@ -84,11 +93,12 @@ export async function trigger(args: TriggerArgs, deps: OrchestratorDeps): Promis
     idempotencyKey !== undefined ? `idem-${args.workflowId}-${idempotencyKey}` : undefined
   const id = explicitRunId ?? derivedRunId ?? deps.idGenerator?.() ?? defaultRunId(now)
   const isIdempotent = explicitRunId !== undefined || derivedRunId !== undefined
+  const delayWakeAt = resolveDelayWakeAt(args.delay, createdAt)
   const record: RunRecord = {
     id,
     workflowId: args.workflowId,
     workflowVersion: args.workflowVersion,
-    status: "running",
+    status: delayWakeAt !== undefined ? "waiting" : "running",
     input: args.input,
     journal: args.initialJournal ? cloneJournal(args.initialJournal) : emptyJournal(),
     invocationCount: 0,
@@ -96,9 +106,22 @@ export async function trigger(args: TriggerArgs, deps: OrchestratorDeps): Promis
     computeTimeMs: 0,
     timeoutMs: args.timeoutMs,
     parent: args.parent,
-    pendingWaitpoints: [],
+    pendingWaitpoints:
+      delayWakeAt !== undefined
+        ? [
+            {
+              clientWaitpointId: triggerDelayWaitpointId(id),
+              kind: "DATETIME",
+              meta: {
+                wakeAt: delayWakeAt,
+                durationMs: Math.max(0, delayWakeAt - createdAt),
+                source: "trigger.delay",
+              },
+            },
+          ]
+        : [],
     streams: {},
-    startedAt: now(),
+    startedAt: delayWakeAt ?? createdAt,
     triggeredBy: args.triggeredBy ?? { kind: "api" },
     tags: args.tags ?? [],
     environment: args.environment ?? "development",
@@ -119,6 +142,9 @@ export async function trigger(args: TriggerArgs, deps: OrchestratorDeps): Promis
     // Persist up-front so concurrent `cancel(runId)` calls can find the
     // run before any invocation has completed.
     await deps.store.save(record)
+  }
+  if (delayWakeAt !== undefined) {
+    return record
   }
   const abortCtrl = registerRunAbort(id)
   try {
@@ -142,6 +168,39 @@ export async function trigger(args: TriggerArgs, deps: OrchestratorDeps): Promis
     }
   }
   return deps.store.save(record)
+}
+
+function resolveDelayWakeAt(delay: Duration | Date | undefined, now: number): number | undefined {
+  if (delay === undefined) return undefined
+  const wakeAt = delay instanceof Date ? delay.getTime() : now + durationToMs(delay)
+  return wakeAt > now ? wakeAt : undefined
+}
+
+function durationToMs(duration: Duration): number {
+  if (typeof duration === "number") return duration
+  const m = /^(\d+)(ms|s|m|h|d|w)$/.exec(duration)
+  if (!m) throw new Error(`invalid duration: ${String(duration)}`)
+  const n = Number(m[1])
+  switch (m[2]) {
+    case "ms":
+      return n
+    case "s":
+      return n * 1_000
+    case "m":
+      return n * 60_000
+    case "h":
+      return n * 3_600_000
+    case "d":
+      return n * 86_400_000
+    case "w":
+      return n * 604_800_000
+    default:
+      throw new Error(`invalid duration unit: ${m[2]}`)
+  }
+}
+
+function triggerDelayWaitpointId(runId: string): string {
+  return `trigger-delay:${runId}`
 }
 
 function cloneJournal(journal: JournalSlice): JournalSlice {

--- a/packages/workflows-orchestrator/src/testing/driver-compliance.ts
+++ b/packages/workflows-orchestrator/src/testing/driver-compliance.ts
@@ -21,7 +21,7 @@
 import { __resetRegistry, workflow } from "@voyantjs/workflows"
 import type { DriverFactory, DriverFactoryDeps, ServiceResolver } from "@voyantjs/workflows/driver"
 import type { WorkflowManifest } from "@voyantjs/workflows/protocol"
-import { beforeEach, describe, expect, test } from "vitest"
+import { beforeEach, describe, expect, test, vi } from "vitest"
 
 /**
  * Tiny in-memory ServiceResolver builder for compliance tests. Lets a test
@@ -202,6 +202,38 @@ export function runDriverComplianceSuite(
 
         const run = await driver.trigger(wf, {}, { environment: "preview" })
         expect(run.status).toBe("completed")
+      })
+
+      test("delay parks the run instead of invoking the workflow immediately", async () => {
+        const driver = makeFactory()(testFactoryDeps())
+        let invocationCount = 0
+        const wf = workflow<Record<string, never>, void>({
+          id: uniqueId("compliance-delay"),
+          async run() {
+            invocationCount++
+          },
+        })
+
+        const run = await driver.trigger(wf, {}, { delay: "1s" })
+        expect(run.status).toBe("waiting")
+        expect(invocationCount).toBe(0)
+      })
+
+      test("delay continues scheduling later DATETIME waits after the trigger delay fires", async () => {
+        const driver = makeFactory()(testFactoryDeps())
+        const completed = vi.fn()
+        const wf = workflow<Record<string, never>, void>({
+          id: uniqueId("compliance-delay-then-sleep"),
+          async run(_, ctx) {
+            await ctx.sleep("1ms")
+            completed()
+          },
+        })
+
+        const run = await driver.trigger(wf, {}, { delay: "1ms" })
+        expect(run.status).toBe("waiting")
+
+        await vi.waitFor(() => expect(completed).toHaveBeenCalledTimes(1), { timeout: 250 })
       })
 
       test("idempotencyKey produces a stable run across retries (same key → same run)", async () => {


### PR DESCRIPTION
## Summary

Wires `TriggerOptions.delay` through the workflow runtime so delayed triggers are no longer declared-only.

- Adds `delay` to orchestrator trigger args and parks future-delayed runs on a synthetic `DATETIME` waitpoint.
- Forwards `delay` through the in-memory, Node, and Cloudflare drivers.
- Schedules delayed in-memory runs through the existing `resumeDueAlarms` path.
- Adds core regression coverage and shared driver compliance coverage.
- Adds a patch changeset for the touched workflow orchestrator packages.

## Why

`TriggerOptions.delay` was present in the SDK type surface but ignored by the runtime. A delayed trigger now creates a waiting run and resumes through the same time-wheel/DATETIME wakeup machinery used by sleeps.

## Validation

- `pnpm --filter @voyantjs/workflows-orchestrator test -- --runInBand`
- `pnpm --filter @voyantjs/workflows-orchestrator-node test`
- `pnpm --filter @voyantjs/workflows-orchestrator-cloudflare test`
- `pnpm verify:fast`
- Pre-commit hook: full lint + typecheck
- Pre-push hook: full test lane