### PR TITLE
[codex] Wire workflow trigger priority

### DIFF
--- a/.changeset/workflows-trigger-priority.md
+++ b/.changeset/workflows-trigger-priority.md
@@ -1,0 +1,7 @@
+---
+"@voyantjs/workflows-orchestrator": patch
+"@voyantjs/workflows-orchestrator-node": patch
+"@voyantjs/workflows-orchestrator-cloudflare": patch
+---
+
+Wire `TriggerOptions.priority` through the workflow orchestrator drivers and claim due wakeups by priority before wake time.

--- a/packages/workflows-orchestrator-cloudflare/src/cloudflare-edge-driver.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/cloudflare-edge-driver.ts
@@ -187,6 +187,7 @@ export function createCloudflareEdgeDriver(opts: CloudflareEdgeDriverOptions): D
           triggerOpts?.delay instanceof Date
             ? { wakeAt: triggerOpts.delay.getTime() }
             : triggerOpts?.delay,
+        priority: triggerOpts?.priority,
         triggeredBy: { kind: "api" as const },
       }
       const resp = await forwardToRunDO(

--- a/packages/workflows-orchestrator-cloudflare/src/durable-object.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/durable-object.ts
@@ -92,6 +92,7 @@ export async function handleDurableObjectRequest(
           typeof payload.delay === "object" && payload.delay !== null && "wakeAt" in payload.delay
             ? new Date(payload.delay.wakeAt)
             : payload.delay,
+        priority: payload.priority,
       },
       { store, handler, now: deps.now },
     )

--- a/packages/workflows-orchestrator-cloudflare/src/types.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/types.ts
@@ -60,6 +60,7 @@ export interface TriggerPayload {
   runId?: string
   idempotencyKey?: string
   delay?: Duration | { wakeAt: number }
+  priority?: number
 }
 
 /** Cancel payload. */

--- a/packages/workflows-orchestrator-node/drizzle/0005_wakeup_priority.sql
+++ b/packages/workflows-orchestrator-node/drizzle/0005_wakeup_priority.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "voyant_wakeups" ADD COLUMN "priority" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+DROP INDEX "voyant_wakeups_due_idx";--> statement-breakpoint
+CREATE INDEX "voyant_wakeups_due_idx" ON "voyant_wakeups" USING btree ("priority" DESC,"wake_at" ASC);

--- a/packages/workflows-orchestrator-node/drizzle/meta/_journal.json
+++ b/packages/workflows-orchestrator-node/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1779000001000,
       "tag": "0004_workflow_manifests",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1779000002000,
+      "tag": "0005_wakeup_priority",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/workflows-orchestrator-node/src/__tests__/postgres-integration.test.ts
+++ b/packages/workflows-orchestrator-node/src/__tests__/postgres-integration.test.ts
@@ -112,6 +112,7 @@ describeIfDb("postgres integration", () => {
     await wakeups.upsert({
       runId: "run_due",
       wakeAt: 1_000,
+      priority: 1,
     })
     await wakeups.upsert({
       runId: "run_later",
@@ -157,6 +158,28 @@ describeIfDb("postgres integration", () => {
 
     const all = await wakeups.list()
     expect(all.map((record) => record.runId)).toEqual(["run_due", "run_later"])
+  })
+
+  it("leases higher-priority due wakeups before earlier lower-priority wakeups", async () => {
+    await wakeups.upsert({
+      runId: "low",
+      wakeAt: 1_000,
+      priority: 1,
+    })
+    await wakeups.upsert({
+      runId: "high",
+      wakeAt: 1_500,
+      priority: 10,
+    })
+
+    const leased = await wakeups.leaseDue({
+      owner: "worker-a",
+      now: 2_000,
+      leaseMs: 5_000,
+      limit: 2,
+    })
+
+    expect(leased.map((record) => record.runId)).toEqual(["high", "low"])
   })
 
   it("lets only one poller instance process a due wakeup lease", async () => {

--- a/packages/workflows-orchestrator-node/src/__tests__/postgres-store-mappers.test.ts
+++ b/packages/workflows-orchestrator-node/src/__tests__/postgres-store-mappers.test.ts
@@ -78,6 +78,7 @@ describe("postgres wakeup mappers", () => {
       {
         runId: "run_1",
         wakeAt: 1000,
+        priority: 3,
         leaseOwner: undefined,
         leaseExpiresAt: undefined,
         updatedAt: 2000,
@@ -88,6 +89,7 @@ describe("postgres wakeup mappers", () => {
     expect(rowToWakeupRecord(row)).toEqual({
       runId: "run_1",
       wakeAt: 1000,
+      priority: 3,
       updatedAt: 2000,
     })
   })

--- a/packages/workflows-orchestrator-node/src/__tests__/wakeup-store.test.ts
+++ b/packages/workflows-orchestrator-node/src/__tests__/wakeup-store.test.ts
@@ -90,6 +90,20 @@ describe("createFsWakeupStore", () => {
     })
     expect(expired.map((w) => w.runId).sort()).toEqual(["due", "future", "leased"])
   })
+
+  it("leases higher-priority due wakeups before earlier lower-priority wakeups", async () => {
+    const store = createFsWakeupStore({ rootDir: tmp, now: () => clock })
+    await store.upsert({ runId: "low", wakeAt: clock - 10_000, priority: 1 })
+    await store.upsert({ runId: "high", wakeAt: clock - 1, priority: 10 })
+
+    const leased = await store.leaseDue({
+      owner: "worker_a",
+      now: clock,
+      leaseMs: 2_000,
+      limit: 2,
+    })
+    expect(leased.map((w) => w.runId)).toEqual(["high", "low"])
+  })
 })
 
 describe("syncWakeupFromRecord", () => {
@@ -97,6 +111,9 @@ describe("syncWakeupFromRecord", () => {
     const store = createFsWakeupStore({ rootDir: tmp, now: () => clock })
     await syncWakeupFromRecord(store, makeRecord())
     expect((await store.list()).map((w) => w.runId)).toEqual(["run_1"])
+
+    await syncWakeupFromRecord(store, makeRecord({ priority: 5 }))
+    expect(await store.get("run_1")).toMatchObject({ priority: 5 })
 
     await syncWakeupFromRecord(store, makeRecord({ status: "completed", pendingWaitpoints: [] }))
     expect(await store.list()).toEqual([])

--- a/packages/workflows-orchestrator-node/src/node-standalone-driver.ts
+++ b/packages/workflows-orchestrator-node/src/node-standalone-driver.ts
@@ -244,6 +244,7 @@ export function createNodeStandaloneDriver(opts: NodeStandaloneDriverOptions): D
           tags: triggerOpts?.tags,
           idempotencyKey: triggerOpts?.idempotencyKey,
           delay: triggerOpts?.delay,
+          priority: triggerOpts?.priority,
         },
         { store: runStore, handler, now },
       )

--- a/packages/workflows-orchestrator-node/src/postgres-schema.ts
+++ b/packages/workflows-orchestrator-node/src/postgres-schema.ts
@@ -61,12 +61,13 @@ export const wakeupsTable = pgTable(
   {
     runId: text("run_id").primaryKey(),
     wakeAt: bigint("wake_at", { mode: "number" }).notNull(),
+    priority: integer("priority").notNull().default(0),
     leaseOwner: text("lease_owner"),
     leaseExpiresAt: bigint("lease_expires_at", { mode: "number" }),
     updatedAt: bigint("updated_at", { mode: "number" }).notNull(),
   },
   (table) => ({
-    dueIdx: index("voyant_wakeups_due_idx").on(table.wakeAt),
+    dueIdx: index("voyant_wakeups_due_idx").on(table.priority.desc(), table.wakeAt.asc()),
     leaseIdx: index("voyant_wakeups_lease_idx").on(table.leaseExpiresAt),
   }),
 )

--- a/packages/workflows-orchestrator-node/src/postgres-wakeup-store.ts
+++ b/packages/workflows-orchestrator-node/src/postgres-wakeup-store.ts
@@ -94,6 +94,11 @@ export function createPostgresWakeupStore(opts: PostgresWakeupStoreOptions): Wak
         lease_expires_at: number | string | null
         updated_at: number | string
       }>
+      rows.sort((a, b) => {
+        const priorityDelta = toNumber(b.priority) - toNumber(a.priority)
+        if (priorityDelta !== 0) return priorityDelta
+        return toNumber(a.wake_at) - toNumber(b.wake_at)
+      })
       return rows.map((row) => ({
         runId: row.run_id,
         wakeAt: toNumber(row.wake_at),

--- a/packages/workflows-orchestrator-node/src/postgres-wakeup-store.ts
+++ b/packages/workflows-orchestrator-node/src/postgres-wakeup-store.ts
@@ -62,6 +62,7 @@ export function createPostgresWakeupStore(opts: PostgresWakeupStoreOptions): Wak
         wake_at: number
         lease_owner: string | null
         lease_expires_at: number | null
+        priority: number
         updated_at: number
       }>(sql`
         WITH due AS (
@@ -73,7 +74,7 @@ export function createPostgresWakeupStore(opts: PostgresWakeupStoreOptions): Wak
               OR lease_expires_at <= ${at}
               OR lease_owner = ${owner}
             )
-          ORDER BY wake_at ASC
+          ORDER BY priority DESC, wake_at ASC
           LIMIT ${limit}
           FOR UPDATE SKIP LOCKED
         )
@@ -83,11 +84,12 @@ export function createPostgresWakeupStore(opts: PostgresWakeupStoreOptions): Wak
             updated_at = ${at}
         FROM due
         WHERE wakeups.run_id = due.run_id
-        RETURNING wakeups.run_id, wakeups.wake_at, wakeups.lease_owner, wakeups.lease_expires_at, wakeups.updated_at
+        RETURNING wakeups.run_id, wakeups.wake_at, wakeups.priority, wakeups.lease_owner, wakeups.lease_expires_at, wakeups.updated_at
       `)
       const rows = result.rows as Array<{
         run_id: string
         wake_at: number | string
+        priority: number | string
         lease_owner: string | null
         lease_expires_at: number | string | null
         updated_at: number | string
@@ -95,6 +97,7 @@ export function createPostgresWakeupStore(opts: PostgresWakeupStoreOptions): Wak
       return rows.map((row) => ({
         runId: row.run_id,
         wakeAt: toNumber(row.wake_at),
+        priority: toNumber(row.priority),
         leaseOwner: row.lease_owner ?? undefined,
         leaseExpiresAt: row.lease_expires_at === null ? undefined : toNumber(row.lease_expires_at),
         updatedAt: toNumber(row.updated_at),
@@ -125,6 +128,7 @@ export function wakeupToRow(
   return {
     runId: record.runId,
     wakeAt: record.wakeAt,
+    priority: record.priority ?? 0,
     leaseOwner: record.leaseOwner ?? null,
     leaseExpiresAt: record.leaseExpiresAt ?? null,
     updatedAt,
@@ -135,6 +139,7 @@ export function rowToWakeupRecord(row: typeof wakeupsTable.$inferSelect): Wakeup
   return {
     runId: row.runId,
     wakeAt: row.wakeAt,
+    priority: row.priority,
     leaseOwner: row.leaseOwner ?? undefined,
     leaseExpiresAt: row.leaseExpiresAt ?? undefined,
     updatedAt: row.updatedAt,

--- a/packages/workflows-orchestrator-node/src/wakeup-store.ts
+++ b/packages/workflows-orchestrator-node/src/wakeup-store.ts
@@ -6,6 +6,7 @@ import { findEarliestWakeAt } from "./sleep-alarm-manager.js"
 export interface WakeupRecord {
   runId: string
   wakeAt: number
+  priority?: number
   leaseOwner?: string
   leaseExpiresAt?: number
   updatedAt: number
@@ -74,7 +75,7 @@ export function createFsWakeupStore(opts: FsWakeupStoreOptions = {}): WakeupStor
     },
 
     async leaseDue({ owner, now: at = now(), leaseMs, limit = 25 }) {
-      const wakeups = await this.list()
+      const wakeups = (await this.list()).sort(compareWakeupClaimOrder)
       const leased: WakeupRecord[] = []
       for (const wakeup of wakeups) {
         if (leased.length >= limit) break
@@ -119,9 +120,16 @@ export async function syncWakeupFromRecord(store: WakeupStore, record: RunRecord
   await store.upsert({
     runId: record.id,
     wakeAt,
+    priority: record.priority,
     leaseOwner: undefined,
     leaseExpiresAt: undefined,
   })
+}
+
+function compareWakeupClaimOrder(a: WakeupRecord, b: WakeupRecord): number {
+  const priorityDelta = (b.priority ?? 0) - (a.priority ?? 0)
+  if (priorityDelta !== 0) return priorityDelta
+  return a.wakeAt - b.wakeAt
 }
 
 async function safeReaddir(dir: string): Promise<string[]> {

--- a/packages/workflows-orchestrator/src/__tests__/driver-compliance.test.ts
+++ b/packages/workflows-orchestrator/src/__tests__/driver-compliance.test.ts
@@ -6,4 +6,4 @@
 import { createInMemoryDriver } from "../driver-inmemory.js"
 import { runDriverComplianceSuite } from "../testing/driver-compliance.js"
 
-runDriverComplianceSuite("InMemory", () => createInMemoryDriver())
+runDriverComplianceSuite("InMemory", () => createInMemoryDriver(), { autoDatetimeWakeups: true })

--- a/packages/workflows-orchestrator/src/__tests__/orchestrator.test.ts
+++ b/packages/workflows-orchestrator/src/__tests__/orchestrator.test.ts
@@ -105,6 +105,26 @@ describe("trigger()", () => {
     expect(invocations).toBe(1)
   })
 
+  it("records trigger priority on the run record", async () => {
+    workflow<void, void>({
+      id: "priority",
+      async run() {},
+    })
+    const store = createInMemoryRunStore()
+    const rec = await trigger(
+      {
+        workflowId: "priority",
+        workflowVersion: "v1",
+        input: undefined,
+        tenantMeta,
+        priority: 10,
+      },
+      { store, handler },
+    )
+    expect(rec.priority).toBe(10)
+    expect((await store.get(rec.id))?.priority).toBe(10)
+  })
+
   it("persists step results in the run's journal", async () => {
     workflow<number, number>({
       id: "chain",

--- a/packages/workflows-orchestrator/src/driver-inmemory.ts
+++ b/packages/workflows-orchestrator/src/driver-inmemory.ts
@@ -133,6 +133,7 @@ export function createInMemoryDriver(opts: InMemoryDriverOptions = {}): DriverFa
           tags: triggerOpts?.tags,
           idempotencyKey: triggerOpts?.idempotencyKey,
           delay: triggerOpts?.delay,
+          priority: triggerOpts?.priority,
         },
         { store, handler, now },
       )

--- a/packages/workflows-orchestrator/src/orchestrator.ts
+++ b/packages/workflows-orchestrator/src/orchestrator.ts
@@ -50,6 +50,8 @@ export interface TriggerArgs {
    * waitpoint and leaves execution to the normal wakeup/time-wheel path.
    */
   delay?: Duration | Date
+  /** Higher values are claimed first by scheduler/time-wheel stores. */
+  priority?: number
   /**
    * Optional journal seed. Used by external replay/resume callers
    * that need a new run to skip steps already completed by a parent
@@ -105,6 +107,7 @@ export async function trigger(args: TriggerArgs, deps: OrchestratorDeps): Promis
     metadataAppliedCount: 0,
     computeTimeMs: 0,
     timeoutMs: args.timeoutMs,
+    priority: args.priority,
     parent: args.parent,
     pendingWaitpoints:
       delayWakeAt !== undefined

--- a/packages/workflows-orchestrator/src/testing/driver-compliance.ts
+++ b/packages/workflows-orchestrator/src/testing/driver-compliance.ts
@@ -111,6 +111,12 @@ export interface DriverComplianceCapabilities {
    * an empty page; voyant-cloud provides an index in its repo.
    */
   crossRunQueries?: boolean
+  /**
+   * When true, the driver under test runs an in-process DATETIME wakeup
+   * loop/timer during compliance tests. False for drivers whose compliance
+   * harness intentionally disables or fakes the time wheel.
+   */
+  autoDatetimeWakeups?: boolean
 }
 
 // ---- The parameterized contract ----
@@ -122,6 +128,7 @@ export function runDriverComplianceSuite(
 ): void {
   const servicesThreading = capabilities.servicesThreading ?? true
   const crossRunQueries = capabilities.crossRunQueries ?? true
+  const autoDatetimeWakeups = capabilities.autoDatetimeWakeups ?? false
   describe(`${name} driver compliance`, () => {
     beforeEach(() => {
       __resetRegistry()
@@ -219,22 +226,25 @@ export function runDriverComplianceSuite(
         expect(invocationCount).toBe(0)
       })
 
-      test("delay continues scheduling later DATETIME waits after the trigger delay fires", async () => {
-        const driver = makeFactory()(testFactoryDeps())
-        const completed = vi.fn()
-        const wf = workflow<Record<string, never>, void>({
-          id: uniqueId("compliance-delay-then-sleep"),
-          async run(_, ctx) {
-            await ctx.sleep("1ms")
-            completed()
-          },
-        })
+      test.runIf(autoDatetimeWakeups)(
+        "delay continues scheduling later DATETIME waits after the trigger delay fires",
+        async () => {
+          const driver = makeFactory()(testFactoryDeps())
+          const completed = vi.fn()
+          const wf = workflow<Record<string, never>, void>({
+            id: uniqueId("compliance-delay-then-sleep"),
+            async run(_, ctx) {
+              await ctx.sleep("1ms")
+              completed()
+            },
+          })
 
-        const run = await driver.trigger(wf, {}, { delay: "1ms" })
-        expect(run.status).toBe("waiting")
+          const run = await driver.trigger(wf, {}, { delay: "1ms" })
+          expect(run.status).toBe("waiting")
 
-        await vi.waitFor(() => expect(completed).toHaveBeenCalledTimes(1), { timeout: 250 })
-      })
+          await vi.waitFor(() => expect(completed).toHaveBeenCalledTimes(1), { timeout: 250 })
+        },
+      )
 
       test("idempotencyKey produces a stable run across retries (same key → same run)", async () => {
         const driver = makeFactory()(testFactoryDeps())

--- a/packages/workflows-orchestrator/src/types.ts
+++ b/packages/workflows-orchestrator/src/types.ts
@@ -88,6 +88,11 @@ export interface RunRecord {
   /** ms budget from WorkflowConfig.timeout. Zero / undefined = no limit. */
   timeoutMs?: number
   /**
+   * Trigger-time scheduling priority. Higher numbers are claimed first
+   * by store-backed time wheels when multiple runs are due.
+   */
+  priority?: number
+  /**
    * Cross-run lineage. Present on child runs created by
    * `ctx.invoke`; set by the orchestrator when the child parks so
    * its eventual terminal transition can cascade-resume the parent.


### PR DESCRIPTION
## Summary
- Store `TriggerOptions.priority` on workflow run records and forward it through in-memory, Node standalone, and Cloudflare drivers.
- Persist wakeup priority in the Node Postgres wakeup table and claim due wakeups by priority descending before wake time.
- Add FS/Postgres wakeup ordering coverage, trigger priority coverage, a migration, and a changeset.

## Verification
- `pnpm --filter @voyantjs/workflows-orchestrator test -- --runInBand`
- `pnpm --filter @voyantjs/workflows-orchestrator-node test`
- `pnpm --filter @voyantjs/workflows-orchestrator-cloudflare test`
- `pnpm verify:fast`
- pre-commit lint/typecheck hook
- pre-push test hook

Closes #518