### PR TITLE
[codex] Serialize workflow schedules in manifests

### DIFF
--- a/.changeset/workflows-schedule-manifest.md
+++ b/.changeset/workflows-schedule-manifest.md
@@ -1,0 +1,7 @@
+---
+"@voyantjs/workflows": patch
+"@voyantjs/workflows-orchestrator": patch
+"@voyantjs/workflows-orchestrator-node": patch
+---
+
+Serialize workflow schedule declarations into manifests and expose shared schedule fire-time helpers from the orchestrator package.

--- a/.changeset/workflows-schedule-manifest.md
+++ b/.changeset/workflows-schedule-manifest.md
@@ -1,7 +1,8 @@
 ---
 "@voyantjs/workflows": patch
+"@voyantjs/hono": patch
 "@voyantjs/workflows-orchestrator": patch
 "@voyantjs/workflows-orchestrator-node": patch
 ---
 
-Serialize workflow schedule declarations into manifests and expose shared schedule fire-time helpers from the orchestrator package.
+Serialize workflow schedule declarations into manifests, preserve schedule config when Hono registers runtime manifests, and expose shared schedule fire-time helpers from the orchestrator package.

--- a/packages/hono/src/app.ts
+++ b/packages/hono/src/app.ts
@@ -8,7 +8,11 @@ import {
   type ModuleContainer,
   type WorkflowDescriptor,
 } from "@voyantjs/core"
-import { buildManifest, type EventFilterRuntimeEntry } from "@voyantjs/workflows/events"
+import {
+  type BuildManifestArgs,
+  buildManifest,
+  type EventFilterRuntimeEntry,
+} from "@voyantjs/workflows/events"
 import { Hono } from "hono"
 
 import { requireAuth } from "./middleware/auth.js"
@@ -36,6 +40,13 @@ function resolveSurfaceMountPath(
   }
 
   return `${prefix}/${normalized.replace(/^\/+|\/+$/g, "")}`
+}
+
+type ManifestWorkflowDescriptor = BuildManifestArgs["workflows"][number]
+
+function toManifestWorkflowDescriptor(wf: WorkflowDescriptor): ManifestWorkflowDescriptor {
+  const candidate = wf as WorkflowDescriptor & Partial<Pick<ManifestWorkflowDescriptor, "config">>
+  return candidate.config ? { id: wf.id, config: candidate.config } : { id: wf.id }
 }
 
 /**
@@ -368,7 +379,7 @@ async function wireWorkflowRuntime(args: WireWorkflowRuntimeArgs): Promise<void>
   const manifest = await buildManifest({
     projectId: args.projectId,
     environment: args.environment,
-    workflows: args.collectedWorkflows.map((w) => ({ id: w.id })),
+    workflows: args.collectedWorkflows.map(toManifestWorkflowDescriptor),
     eventFilters: filterEntries,
   })
 

--- a/packages/hono/tests/unit/app-workflows.test.ts
+++ b/packages/hono/tests/unit/app-workflows.test.ts
@@ -106,6 +106,60 @@ describe("createApp workflows wiring", () => {
     void TEST_ENV
   })
 
+  test("registers scheduled workflow config in the runtime manifest", async () => {
+    const scheduled = workflow<{ source: string }, { ok: true }>({
+      id: "test-scheduled-report",
+      schedule: {
+        every: "5m",
+        timezone: "UTC",
+        input: { source: "schedule" },
+        overlap: "skip",
+        environments: ["production"],
+        name: "every-five-minutes",
+      },
+      async run() {
+        return { ok: true }
+      },
+    })
+    const moduleSpec: Module = {
+      name: "scheduled-workflows",
+      workflows: [scheduled satisfies WorkflowDescriptor],
+    }
+    const factory = createInMemoryDriver()
+    let driverHandle: ReturnType<typeof factory> | undefined
+
+    const app = createApp({
+      db: () => null as never,
+      modules: [{ module: moduleSpec }],
+      workflows: {
+        driver: () => (deps) => {
+          driverHandle = factory(deps)
+          return driverHandle
+        },
+        environment: "production",
+      },
+    })
+
+    await app.ready()
+
+    const manifest = await driverHandle?.getManifest({ environment: "production" })
+    expect(manifest?.workflows).toEqual([
+      expect.objectContaining({
+        id: "test-scheduled-report",
+        schedules: [
+          {
+            every: "5m",
+            timezone: "UTC",
+            input: { source: "schedule" },
+            overlap: "skip",
+            environments: ["production"],
+            name: "every-five-minutes",
+          },
+        ],
+      }),
+    ])
+  })
+
   test("non-matching events do not trigger runs", async () => {
     const module = buildPromotionsLikeModule()
     const eventBus = createEventBus()

--- a/packages/workflows-orchestrator-node/src/scheduler.ts
+++ b/packages/workflows-orchestrator-node/src/scheduler.ts
@@ -1,4 +1,7 @@
-import type { Duration, EnvironmentName, ScheduleDeclaration } from "@voyantjs/workflows"
+import type { EnvironmentName, ScheduleDeclaration } from "@voyantjs/workflows"
+import { computeNextFire } from "@voyantjs/workflows-orchestrator"
+
+export { computeNextFire, nextCronFire, parseCron, toMs } from "@voyantjs/workflows-orchestrator"
 
 export interface ScheduleSource {
   workflowId: string
@@ -142,109 +145,4 @@ async function resolveInput(
     return await (input as () => unknown | Promise<unknown>)()
   }
   return input
-}
-
-export function computeNextFire(decl: ScheduleDeclaration, fromMs: number): number {
-  if ("cron" in decl) return nextCronFire(parseCron(decl.cron), fromMs)
-  if ("every" in decl) return fromMs + toMs(decl.every)
-  if ("at" in decl) {
-    const at = typeof decl.at === "string" ? Date.parse(decl.at) : decl.at.getTime()
-    if (!Number.isFinite(at)) throw new Error(`invalid "at" value: ${String(decl.at)}`)
-    return at < fromMs ? Number.POSITIVE_INFINITY : at
-  }
-  throw new Error(`schedule declaration missing one of cron/every/at`)
-}
-
-export interface CronSpec {
-  minute: number[]
-  hour: number[]
-  day: number[]
-  month: number[]
-  dow: number[]
-}
-
-export function parseCron(expr: string): CronSpec {
-  const parts = expr.trim().split(/\s+/)
-  if (parts.length !== 5) {
-    throw new Error(`invalid cron "${expr}" — expected 5 fields (minute hour day month dow)`)
-  }
-  return {
-    minute: parseField(parts[0]!, 0, 59, "minute"),
-    hour: parseField(parts[1]!, 0, 23, "hour"),
-    day: parseField(parts[2]!, 1, 31, "day"),
-    month: parseField(parts[3]!, 1, 12, "month"),
-    dow: parseField(parts[4]!, 0, 6, "dow"),
-  }
-}
-
-function parseField(f: string, min: number, max: number, label: string): number[] {
-  const out = new Set<number>()
-  for (const part of f.split(",")) {
-    const stepMatch = /^(.+)\/(\d+)$/.exec(part)
-    const body = stepMatch ? stepMatch[1]! : part
-    const step = stepMatch ? Number(stepMatch[2]) : 1
-    if (!(step >= 1)) throw new Error(`cron ${label} step must be >=1 in "${f}"`)
-    let lo: number
-    let hi: number
-    if (body === "*") {
-      lo = min
-      hi = max
-    } else if (body.includes("-")) {
-      const [a, b] = body.split("-")
-      lo = Number(a)
-      hi = Number(b)
-    } else {
-      lo = Number(body)
-      hi = lo
-    }
-    if (!Number.isFinite(lo) || !Number.isFinite(hi) || lo < min || hi > max || lo > hi) {
-      throw new Error(`cron ${label} out of range [${min}..${max}] in "${f}"`)
-    }
-    for (let i = lo; i <= hi; i += step) out.add(i)
-  }
-  return [...out].sort((a, b) => a - b)
-}
-
-export function nextCronFire(spec: CronSpec, fromMs: number): number {
-  const date = new Date(fromMs)
-  date.setUTCSeconds(0, 0)
-  date.setUTCMinutes(date.getUTCMinutes() + 1)
-
-  const maxIterations = 60 * 24 * 366 * 5
-  for (let i = 0; i < maxIterations; i++) {
-    if (
-      spec.minute.includes(date.getUTCMinutes()) &&
-      spec.hour.includes(date.getUTCHours()) &&
-      spec.day.includes(date.getUTCDate()) &&
-      spec.month.includes(date.getUTCMonth() + 1) &&
-      spec.dow.includes(date.getUTCDay())
-    ) {
-      return date.getTime()
-    }
-    date.setUTCMinutes(date.getUTCMinutes() + 1)
-  }
-  throw new Error("cron search exceeded 5 years without finding a match")
-}
-
-export function toMs(duration: Duration): number {
-  if (typeof duration === "number") return duration
-  const m = /^(\d+)(ms|s|m|h|d|w)$/.exec(duration)
-  if (!m) throw new Error(`invalid duration "${duration}"`)
-  const n = Number(m[1])
-  switch (m[2]) {
-    case "ms":
-      return n
-    case "s":
-      return n * 1_000
-    case "m":
-      return n * 60_000
-    case "h":
-      return n * 3_600_000
-    case "d":
-      return n * 86_400_000
-    case "w":
-      return n * 604_800_000
-    default:
-      throw new Error(`invalid duration "${duration}"`)
-  }
 }

--- a/packages/workflows-orchestrator-node/src/scheduler.ts
+++ b/packages/workflows-orchestrator-node/src/scheduler.ts
@@ -1,7 +1,13 @@
 import type { EnvironmentName, ScheduleDeclaration } from "@voyantjs/workflows"
 import { computeNextFire } from "@voyantjs/workflows-orchestrator"
 
-export { computeNextFire, nextCronFire, parseCron, toMs } from "@voyantjs/workflows-orchestrator"
+export {
+  type CronSpec,
+  computeNextFire,
+  nextCronFire,
+  parseCron,
+  toMs,
+} from "@voyantjs/workflows-orchestrator"
 
 export interface ScheduleSource {
   workflowId: string

--- a/packages/workflows-orchestrator/src/__tests__/schedule.test.ts
+++ b/packages/workflows-orchestrator/src/__tests__/schedule.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest"
+import { computeNextFire, nextCronFire, parseCron, toMs } from "../schedule.js"
+
+describe("toMs", () => {
+  it("passes numbers through", () => {
+    expect(toMs(500)).toBe(500)
+  })
+
+  it("parses common units", () => {
+    expect(toMs("250ms")).toBe(250)
+    expect(toMs("5s")).toBe(5_000)
+    expect(toMs("2m")).toBe(120_000)
+    expect(toMs("1h")).toBe(3_600_000)
+    expect(toMs("1d")).toBe(86_400_000)
+    expect(toMs("1w")).toBe(604_800_000)
+  })
+
+  it("rejects junk", () => {
+    expect(() => toMs("bad" as "1s")).toThrow(/invalid duration/)
+  })
+})
+
+describe("parseCron", () => {
+  it("accepts a 5-field literal expression", () => {
+    const spec = parseCron("30 8 1 1 0")
+    expect(spec.minute).toEqual([30])
+    expect(spec.hour).toEqual([8])
+    expect(spec.day).toEqual([1])
+    expect(spec.month).toEqual([1])
+    expect(spec.dow).toEqual([0])
+  })
+
+  it("expands wildcards and ranges", () => {
+    expect(parseCron("*/15 * * * *").minute).toEqual([0, 15, 30, 45])
+    expect(parseCron("0 9-11,14 * * 1-5").hour).toEqual([9, 10, 11, 14])
+  })
+
+  it("rejects invalid field counts and ranges", () => {
+    expect(() => parseCron("* * *")).toThrow(/5 fields/)
+    expect(() => parseCron("60 * * * *")).toThrow(/minute/)
+    expect(() => parseCron("* 24 * * *")).toThrow(/hour/)
+  })
+})
+
+describe("nextCronFire", () => {
+  it("finds the next matching minute", () => {
+    const spec = parseCron("*/5 * * * *")
+    const from = Date.UTC(2026, 3, 17, 10, 2, 13)
+    const next = nextCronFire(spec, from)
+    expect(new Date(next).toISOString()).toBe("2026-04-17T10:05:00.000Z")
+  })
+
+  it("advances to the next day when the current slot already passed", () => {
+    const spec = parseCron("0 9 * * *")
+    const from = Date.UTC(2026, 3, 17, 10, 0)
+    const next = nextCronFire(spec, from)
+    expect(new Date(next).toISOString()).toBe("2026-04-18T09:00:00.000Z")
+  })
+})
+
+describe("computeNextFire", () => {
+  it("handles every declarations", () => {
+    const from = 1_700_000_000_000
+    expect(computeNextFire({ every: "5s" }, from)).toBe(from + 5_000)
+  })
+
+  it("returns Infinity for a past one-shot schedule", () => {
+    const from = Date.UTC(2026, 3, 17)
+    const past = new Date(Date.UTC(2020, 0, 1)).toISOString()
+    expect(computeNextFire({ at: past }, from)).toBe(Number.POSITIVE_INFINITY)
+  })
+})

--- a/packages/workflows-orchestrator/src/index.ts
+++ b/packages/workflows-orchestrator/src/index.ts
@@ -42,4 +42,11 @@ export {
   type TriggerArgs,
   trigger,
 } from "./orchestrator.js"
+export {
+  type CronSpec,
+  computeNextFire,
+  nextCronFire,
+  parseCron,
+  toMs,
+} from "./schedule.js"
 export * from "./types.js"

--- a/packages/workflows-orchestrator/src/schedule.ts
+++ b/packages/workflows-orchestrator/src/schedule.ts
@@ -1,0 +1,106 @@
+import type { Duration, ScheduleDeclaration } from "@voyantjs/workflows"
+
+export function computeNextFire(decl: ScheduleDeclaration, fromMs: number): number {
+  if ("cron" in decl) return nextCronFire(parseCron(decl.cron), fromMs)
+  if ("every" in decl) return fromMs + toMs(decl.every)
+  if ("at" in decl) {
+    const at = typeof decl.at === "string" ? Date.parse(decl.at) : decl.at.getTime()
+    if (!Number.isFinite(at)) throw new Error(`invalid "at" value: ${String(decl.at)}`)
+    return at < fromMs ? Number.POSITIVE_INFINITY : at
+  }
+  throw new Error(`schedule declaration missing one of cron/every/at`)
+}
+
+export interface CronSpec {
+  minute: number[]
+  hour: number[]
+  day: number[]
+  month: number[]
+  dow: number[]
+}
+
+export function parseCron(expr: string): CronSpec {
+  const parts = expr.trim().split(/\s+/)
+  if (parts.length !== 5) {
+    throw new Error(`invalid cron "${expr}" - expected 5 fields (minute hour day month dow)`)
+  }
+  return {
+    minute: parseField(parts[0]!, 0, 59, "minute"),
+    hour: parseField(parts[1]!, 0, 23, "hour"),
+    day: parseField(parts[2]!, 1, 31, "day"),
+    month: parseField(parts[3]!, 1, 12, "month"),
+    dow: parseField(parts[4]!, 0, 6, "dow"),
+  }
+}
+
+function parseField(f: string, min: number, max: number, label: string): number[] {
+  const out = new Set<number>()
+  for (const part of f.split(",")) {
+    const stepMatch = /^(.+)\/(\d+)$/.exec(part)
+    const body = stepMatch ? stepMatch[1]! : part
+    const step = stepMatch ? Number(stepMatch[2]) : 1
+    if (!(step >= 1)) throw new Error(`cron ${label} step must be >=1 in "${f}"`)
+    let lo: number
+    let hi: number
+    if (body === "*") {
+      lo = min
+      hi = max
+    } else if (body.includes("-")) {
+      const [a, b] = body.split("-")
+      lo = Number(a)
+      hi = Number(b)
+    } else {
+      lo = Number(body)
+      hi = lo
+    }
+    if (!Number.isFinite(lo) || !Number.isFinite(hi) || lo < min || hi > max || lo > hi) {
+      throw new Error(`cron ${label} out of range [${min}..${max}] in "${f}"`)
+    }
+    for (let i = lo; i <= hi; i += step) out.add(i)
+  }
+  return [...out].sort((a, b) => a - b)
+}
+
+export function nextCronFire(spec: CronSpec, fromMs: number): number {
+  const date = new Date(fromMs)
+  date.setUTCSeconds(0, 0)
+  date.setUTCMinutes(date.getUTCMinutes() + 1)
+
+  const maxIterations = 60 * 24 * 366 * 5
+  for (let i = 0; i < maxIterations; i++) {
+    if (
+      spec.minute.includes(date.getUTCMinutes()) &&
+      spec.hour.includes(date.getUTCHours()) &&
+      spec.day.includes(date.getUTCDate()) &&
+      spec.month.includes(date.getUTCMonth() + 1) &&
+      spec.dow.includes(date.getUTCDay())
+    ) {
+      return date.getTime()
+    }
+    date.setUTCMinutes(date.getUTCMinutes() + 1)
+  }
+  throw new Error("cron search exceeded 5 years without finding a match")
+}
+
+export function toMs(duration: Duration): number {
+  if (typeof duration === "number") return duration
+  const m = /^(\d+)(ms|s|m|h|d|w)$/.exec(duration)
+  if (!m) throw new Error(`invalid duration "${duration}"`)
+  const n = Number(m[1])
+  switch (m[2]) {
+    case "ms":
+      return n
+    case "s":
+      return n * 1_000
+    case "m":
+      return n * 60_000
+    case "h":
+      return n * 3_600_000
+    case "d":
+      return n * 86_400_000
+    case "w":
+      return n * 604_800_000
+    default:
+      throw new Error(`invalid duration "${duration}"`)
+  }
+}

--- a/packages/workflows/src/events/__tests__/manifest-builder.test.ts
+++ b/packages/workflows/src/events/__tests__/manifest-builder.test.ts
@@ -99,6 +99,73 @@ describe("buildManifest", () => {
     expect(onlyA.versionId).not.toBe(aAndB.versionId)
   })
 
+  test("schedule declarations flow into workflow manifest entries", async () => {
+    const wf = workflow({
+      id: "scheduled-wf",
+      schedule: [
+        {
+          cron: "0 * * * *",
+          timezone: "UTC",
+          environments: ["production"],
+          input: { kind: "hourly" },
+          overlap: "skip",
+          name: "hourly",
+        },
+        {
+          at: new Date(Date.UTC(2026, 0, 1, 12, 0, 0)),
+          enabled: false,
+          name: "new-year",
+        },
+      ],
+      async run() {},
+    })
+
+    const manifest = await buildManifest({
+      environment: "production",
+      workflows: [wf],
+      eventFilters: [],
+    })
+
+    expect(manifest.workflows[0]?.schedules).toEqual([
+      {
+        cron: "0 * * * *",
+        timezone: "UTC",
+        environments: ["production"],
+        input: { kind: "hourly" },
+        overlap: "skip",
+        name: "hourly",
+      },
+      {
+        at: "2026-01-01T12:00:00.000Z",
+        enabled: false,
+        name: "new-year",
+      },
+    ])
+  })
+
+  test("schedule changes participate in manifest identity", async () => {
+    const withoutSchedule = workflow({ id: "identity-wf", async run() {} })
+    const a = await buildManifest({
+      environment: "production",
+      workflows: [withoutSchedule],
+      eventFilters: [],
+    })
+
+    __resetRegistry()
+    const withSchedule = workflow({
+      id: "identity-wf",
+      schedule: { every: "5m" },
+      async run() {},
+    })
+    const b = await buildManifest({
+      environment: "production",
+      workflows: [withSchedule],
+      eventFilters: [],
+    })
+
+    expect(a.versionId).not.toBe(b.versionId)
+  })
+
   test("filter manifest entries flow through verbatim", async () => {
     const wf = workflow({ id: "passthrough-wf", async run() {} })
     trigger.on<{ kind: string }>("promotion.changed", {

--- a/packages/workflows/src/events/manifest-builder.ts
+++ b/packages/workflows/src/events/manifest-builder.ts
@@ -9,9 +9,11 @@
 
 import type {
   EventFilterManifestEntry,
+  ManifestSchedule,
   WorkflowManifest,
   WorkflowManifestEntry,
 } from "../protocol/index.js"
+import type { ScheduleDeclaration } from "../workflow.js"
 import { canonicalJson, shortHash } from "./payload-hash.js"
 import type { EventFilterRuntimeEntry } from "./registry.js"
 
@@ -23,7 +25,12 @@ export interface BuildManifestArgs {
   /** Workflow definitions collected from modules + plugins. */
   workflows: ReadonlyArray<{
     id: string
-    config?: { defaultRuntime?: "edge" | "node"; retry?: unknown; timeout?: unknown }
+    config?: {
+      defaultRuntime?: "edge" | "node"
+      retry?: unknown
+      timeout?: unknown
+      schedule?: ScheduleDeclaration | ScheduleDeclaration[]
+    }
   }>
   /** Event-filter entries from `getEventFilterRegistry()`. */
   eventFilters: ReadonlyArray<EventFilterRuntimeEntry>
@@ -50,7 +57,7 @@ export async function buildManifest(args: BuildManifestArgs): Promise<WorkflowMa
       id: wf.id,
       version: "v1",
       steps: [],
-      schedules: [],
+      schedules: serializeSchedules(wf.config?.schedule),
       defaultRuntime: wf.config?.defaultRuntime ?? "edge",
       hasCompensation: false,
       sourceLocation: { file: "<runtime>", line: 0 },
@@ -94,4 +101,29 @@ export async function buildManifest(args: BuildManifestArgs): Promise<WorkflowMa
     ...(draft as Omit<WorkflowManifest, "versionId">),
     versionId,
   }
+}
+
+function serializeSchedules(
+  schedule: ScheduleDeclaration | ScheduleDeclaration[] | undefined,
+): ManifestSchedule[] {
+  if (!schedule) return []
+  const schedules = Array.isArray(schedule) ? schedule : [schedule]
+  return schedules.map(serializeSchedule)
+}
+
+function serializeSchedule(schedule: ScheduleDeclaration): ManifestSchedule {
+  const out: ManifestSchedule = {}
+  if ("cron" in schedule) out.cron = schedule.cron
+  if ("every" in schedule) out.every = schedule.every
+  if ("at" in schedule) {
+    out.at = schedule.at instanceof Date ? schedule.at.toISOString() : schedule.at
+  }
+  if (schedule.timezone !== undefined) out.timezone = schedule.timezone
+  if (schedule.input !== undefined && typeof schedule.input !== "function")
+    out.input = schedule.input
+  if (schedule.enabled !== undefined) out.enabled = schedule.enabled
+  if (schedule.overlap !== undefined) out.overlap = schedule.overlap
+  if (schedule.environments !== undefined) out.environments = schedule.environments
+  if (schedule.name !== undefined) out.name = schedule.name
+  return out
 }

--- a/packages/workflows/src/protocol/index.ts
+++ b/packages/workflows/src/protocol/index.ts
@@ -75,9 +75,12 @@ export interface ManifestStep {
 
 export interface ManifestSchedule {
   cron?: string
-  every?: string
+  every?: string | number
   at?: string
   timezone?: string
+  input?: unknown
+  enabled?: boolean
+  overlap?: "skip" | "queue" | "allow"
   environments?: ("production" | "preview" | "development")[]
   name?: string
 }


### PR DESCRIPTION
## Summary
- Serialize `WorkflowConfig.schedule` declarations into workflow manifest entries instead of always emitting `schedules: []`.
- Include schedule metadata needed by schedulers: `cron` / `every` / `at`, timezone, environments, literal input, enabled, overlap, and name.
- Move cron/duration next-fire helpers into `@voyantjs/workflows-orchestrator` and keep the Node scheduler re-exporting them for compatibility.

## Verification
- `pnpm --filter @voyantjs/workflows test -- src/events/__tests__/manifest-builder.test.ts`
- `pnpm --filter @voyantjs/workflows-orchestrator test -- src/__tests__/schedule.test.ts`
- `pnpm --filter @voyantjs/workflows-orchestrator-node test -- src/__tests__/scheduler.test.ts`
- `pnpm verify:fast`
- pre-commit lint/typecheck hook
- pre-push test hook

Refs #517