### PR TITLE
[codex] Enforce workflow concurrency policies

### DIFF
--- a/.changeset/workflows-concurrency-policy.md
+++ b/.changeset/workflows-concurrency-policy.md
@@ -1,8 +1,9 @@
 ---
 "@voyantjs/workflows": patch
 "@voyantjs/workflows-orchestrator": patch
+"@voyantjs/workflows-orchestrator-cloudflare": patch
 "@voyantjs/workflows-orchestrator-node": patch
 "@voyantjs/hono": patch
 ---
 
-Serialize workflow concurrency declarations into runtime manifests and enforce in-process workflow concurrency policies for the in-memory and Node orchestrator drivers.
+Serialize workflow concurrency declarations into runtime manifests and enforce workflow concurrency policies for the in-memory, Node, and Cloudflare orchestrator drivers.

--- a/.changeset/workflows-concurrency-policy.md
+++ b/.changeset/workflows-concurrency-policy.md
@@ -1,0 +1,8 @@
+---
+"@voyantjs/workflows": patch
+"@voyantjs/workflows-orchestrator": patch
+"@voyantjs/workflows-orchestrator-node": patch
+"@voyantjs/hono": patch
+---
+
+Serialize workflow concurrency declarations into runtime manifests and enforce in-process workflow concurrency policies for the in-memory and Node orchestrator drivers.

--- a/packages/hono/tests/unit/app-workflows.test.ts
+++ b/packages/hono/tests/unit/app-workflows.test.ts
@@ -160,6 +160,52 @@ describe("createApp workflows wiring", () => {
     ])
   })
 
+  test("registers workflow concurrency config in the runtime manifest", async () => {
+    const queued = workflow<{ tenantId: string }, { ok: true }>({
+      id: "test-queued-workflow",
+      concurrency: {
+        key: "tenant",
+        limit: 1,
+        strategy: "queue",
+      },
+      async run() {
+        return { ok: true }
+      },
+    })
+    const moduleSpec: Module = {
+      name: "concurrency-workflows",
+      workflows: [queued satisfies WorkflowDescriptor],
+    }
+    const factory = createInMemoryDriver()
+    let driverHandle: ReturnType<typeof factory> | undefined
+
+    const app = createApp({
+      db: () => null as never,
+      modules: [{ module: moduleSpec }],
+      workflows: {
+        driver: () => (deps) => {
+          driverHandle = factory(deps)
+          return driverHandle
+        },
+        environment: "production",
+      },
+    })
+
+    await app.ready()
+
+    const manifest = await driverHandle?.getManifest({ environment: "production" })
+    expect(manifest?.workflows).toEqual([
+      expect.objectContaining({
+        id: "test-queued-workflow",
+        concurrency: {
+          key: "tenant",
+          limit: 1,
+          strategy: "queue",
+        },
+      }),
+    ])
+  })
+
   test("non-matching events do not trigger runs", async () => {
     const module = buildPromotionsLikeModule()
     const eventBus = createEventBus()

--- a/packages/workflows-orchestrator-cloudflare/src/__tests__/cloudflare-edge-driver.test.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/__tests__/cloudflare-edge-driver.test.ts
@@ -17,6 +17,8 @@ import { describe, expect, it } from "vitest"
 
 import { createCloudflareEdgeDriver } from "../cloudflare-edge-driver.js"
 import {
+  type ConcurrencyCoordinator,
+  createConcurrencyCoordinator,
   createDurableObjectRunStore,
   createInlineDispatcher,
   type DurableObjectNamespaceLike,
@@ -87,6 +89,14 @@ function inProcessRunDONamespace(): DurableObjectNamespaceLike<string> {
       const stableStorage = storage
       return {
         async fetch(req: Request): Promise<Response> {
+          const path = new URL(req.url).pathname
+          if (path !== "/trigger") {
+            return handleDurableObjectRequest(req, {
+              storage: stableStorage,
+              dispatcher,
+            })
+          }
+
           const prev = queues.get(id) ?? Promise.resolve()
           let release!: () => void
           const next = new Promise<void>((resolve) => {
@@ -108,6 +118,35 @@ function inProcessRunDONamespace(): DurableObjectNamespaceLike<string> {
   }
 }
 
+function inProcessConcurrencyDONamespace(
+  runDO: DurableObjectNamespaceLike<string>,
+): DurableObjectNamespaceLike<string> {
+  const storages = new Map<string, DurableObjectStorageLike>()
+  const coordinators = new Map<string, ConcurrencyCoordinator>()
+  return {
+    idFromName(name) {
+      return name
+    },
+    get(id: string) {
+      let storage = storages.get(id)
+      if (!storage) {
+        storage = makeStorage()
+        storages.set(id, storage)
+      }
+      let coordinator = coordinators.get(id)
+      if (!coordinator) {
+        coordinator = createConcurrencyCoordinator({ storage, runDO })
+        coordinators.set(id, coordinator)
+      }
+      return {
+        fetch(req: Request): Promise<Response> {
+          return coordinator.fetch(req)
+        },
+      }
+    },
+  }
+}
+
 // Run the parameterized compliance suite. Each call to the factory builds
 // a fresh driver wired against fresh fakes — same pattern Mode 2 uses.
 //
@@ -118,15 +157,18 @@ function inProcessRunDONamespace(): DurableObjectNamespaceLike<string> {
 // its own `createApp()` boundary. See architecture doc §8.
 runDriverComplianceSuite(
   "CloudflareEdge",
-  () =>
-    createCloudflareEdgeDriver({
-      orchestratorNamespace: inProcessRunDONamespace(),
+  () => {
+    const runDO = inProcessRunDONamespace()
+    return createCloudflareEdgeDriver({
+      orchestratorNamespace: runDO,
+      concurrencyNamespace: inProcessConcurrencyDONamespace(runDO),
       manifestKv: createInMemoryKv(),
-    }),
+    })
+  },
   // servicesThreading: orchestrator and step handlers can run in
   //                    separate Worker isolates depending on dispatcher.
   // crossRunQueries:   self-host Mode 1 has no native query layer per §8.3.
-  { servicesThreading: false, crossRunQueries: false, workflowConcurrency: false },
+  { servicesThreading: false, crossRunQueries: false },
 )
 
 // ---- Smoke: end-to-end driver path with no tenantScript ----

--- a/packages/workflows-orchestrator-cloudflare/src/__tests__/cloudflare-edge-driver.test.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/__tests__/cloudflare-edge-driver.test.ts
@@ -126,7 +126,7 @@ runDriverComplianceSuite(
   // servicesThreading: orchestrator and step handlers can run in
   //                    separate Worker isolates depending on dispatcher.
   // crossRunQueries:   self-host Mode 1 has no native query layer per §8.3.
-  { servicesThreading: false, crossRunQueries: false },
+  { servicesThreading: false, crossRunQueries: false, workflowConcurrency: false },
 )
 
 // ---- Smoke: end-to-end driver path with no tenantScript ----

--- a/packages/workflows-orchestrator-cloudflare/src/__tests__/cloudflare-edge-driver.test.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/__tests__/cloudflare-edge-driver.test.ts
@@ -23,6 +23,7 @@ import {
   createInlineDispatcher,
   type DurableObjectNamespaceLike,
   type DurableObjectStorageLike,
+  handleDurableObjectAlarm,
   handleDurableObjectRequest,
 } from "../index.js"
 import { createInMemoryKv } from "../manifest-kv-store.js"
@@ -67,7 +68,9 @@ function makeStorage(): DurableObjectStorageLike {
   }
 }
 
-function inProcessRunDONamespace(): DurableObjectNamespaceLike<string> {
+function inProcessRunDONamespace(
+  getConcurrencyDO?: () => DurableObjectNamespaceLike<string> | undefined,
+): DurableObjectNamespaceLike<string> {
   const storages = new Map<string, DurableObjectStorageLike>()
   // Per-id request queue — mirrors the production CF guarantee that a
   // Durable Object instance processes requests one at a time. Without
@@ -94,6 +97,7 @@ function inProcessRunDONamespace(): DurableObjectNamespaceLike<string> {
             return handleDurableObjectRequest(req, {
               storage: stableStorage,
               dispatcher,
+              concurrencyDO: getConcurrencyDO?.(),
             })
           }
 
@@ -108,12 +112,59 @@ function inProcessRunDONamespace(): DurableObjectNamespaceLike<string> {
             return await handleDurableObjectRequest(req, {
               storage: stableStorage,
               dispatcher,
+              concurrencyDO: getConcurrencyDO?.(),
             })
           } finally {
             release()
           }
         },
       }
+    },
+  }
+}
+
+function alarmableRunDONamespace(
+  getConcurrencyDO?: () => DurableObjectNamespaceLike<string> | undefined,
+): {
+  namespace: DurableObjectNamespaceLike<string>
+  alarm(runId: string): Promise<void>
+} {
+  const storages = new Map<string, DurableObjectStorageLike>()
+  const dispatcher = createInlineDispatcher(async (req) => handleStepRequest(req))
+
+  function storageFor(id: string): DurableObjectStorageLike {
+    let storage = storages.get(id)
+    if (!storage) {
+      storage = makeStorage()
+      storages.set(id, storage)
+    }
+    return storage
+  }
+
+  return {
+    namespace: {
+      idFromName(name) {
+        return name
+      },
+      get(id: string) {
+        const storage = storageFor(id)
+        return {
+          fetch(req: Request): Promise<Response> {
+            return handleDurableObjectRequest(req, {
+              storage,
+              dispatcher,
+              concurrencyDO: getConcurrencyDO?.(),
+            })
+          },
+        }
+      },
+    },
+    alarm(runId: string) {
+      return handleDurableObjectAlarm({
+        storage: storageFor(runId),
+        dispatcher,
+        concurrencyDO: getConcurrencyDO?.(),
+      })
     },
   }
 }
@@ -158,10 +209,12 @@ function inProcessConcurrencyDONamespace(
 runDriverComplianceSuite(
   "CloudflareEdge",
   () => {
-    const runDO = inProcessRunDONamespace()
+    let concurrencyDO: DurableObjectNamespaceLike<string> | undefined
+    const runDO = inProcessRunDONamespace(() => concurrencyDO)
+    concurrencyDO = inProcessConcurrencyDONamespace(runDO)
     return createCloudflareEdgeDriver({
       orchestratorNamespace: runDO,
-      concurrencyNamespace: inProcessConcurrencyDONamespace(runDO),
+      concurrencyNamespace: concurrencyDO,
       manifestKv: createInMemoryKv(),
     })
   },
@@ -197,5 +250,40 @@ describe("self-host inline-dispatcher path", () => {
     expect(run.status).toBe("completed")
     const detail = await driver.admin?.getRun?.(run.id)
     expect(detail?.output).toEqual({ doubled: 42 })
+  })
+
+  it("releases a concurrency slot when an alarm completes a delayed run", async () => {
+    let concurrencyDO: DurableObjectNamespaceLike<string> | undefined
+    const runDO = alarmableRunDONamespace(() => concurrencyDO)
+    concurrencyDO = inProcessConcurrencyDONamespace(runDO.namespace)
+    const driver = createCloudflareEdgeDriver({
+      orchestratorNamespace: runDO.namespace,
+      concurrencyNamespace: concurrencyDO,
+      manifestKv: createInMemoryKv(),
+    })(testFactoryDeps())
+
+    const wf = workflow<{ value: number }, number>({
+      id: "cloudflare-concurrency-alarm-release",
+      concurrency: {
+        key: "shared",
+        limit: 1,
+        strategy: "cancel-newest",
+      },
+      async run(input) {
+        return input.value
+      },
+    })
+
+    const delayed = await driver.trigger(wf, { value: 1 }, { delay: "1ms" })
+    expect(delayed.status).toBe("waiting")
+
+    await new Promise((resolve) => setTimeout(resolve, 5))
+    await runDO.alarm(delayed.id)
+
+    const afterAlarm = await driver.admin?.getRun?.(delayed.id)
+    expect(afterAlarm?.status).toBe("completed")
+
+    const next = await driver.trigger(wf, { value: 2 })
+    expect(next.status).toBe("completed")
   })
 })

--- a/packages/workflows-orchestrator-cloudflare/src/cloudflare-edge-driver.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/cloudflare-edge-driver.ts
@@ -24,6 +24,7 @@ import type {
   RunDetail,
   RunSummary,
   TriggerOptions,
+  WorkflowDefinition,
 } from "@voyantjs/workflows"
 import type {
   DriverFactory,
@@ -36,13 +37,19 @@ import type {
 } from "@voyantjs/workflows/driver"
 import { deriveStableEventId } from "@voyantjs/workflows/events"
 import type { WorkflowManifest } from "@voyantjs/workflows/protocol"
-import { routeEvent } from "@voyantjs/workflows-orchestrator"
+import {
+  type RuntimeConcurrencyPolicy,
+  resolveConcurrencyKey,
+  routeEvent,
+  WorkflowConcurrencyRejectedError,
+} from "@voyantjs/workflows-orchestrator"
 
 import {
   type CfManifestStore,
   createKvManifestStore,
   type KvNamespaceLike,
 } from "./manifest-kv-store.js"
+import type { TriggerPayload } from "./types.js"
 import type { DurableObjectNamespaceLike } from "./worker.js"
 
 // ---- Public factory options ----
@@ -50,6 +57,8 @@ import type { DurableObjectNamespaceLike } from "./worker.js"
 export interface CloudflareEdgeDriverOptions {
   /** Durable Object namespace holding one DO per run. */
   orchestratorNamespace: DurableObjectNamespaceLike
+  /** Optional Durable Object namespace coordinating workflow concurrency across runs. */
+  concurrencyNamespace?: DurableObjectNamespaceLike
   /** KV namespace storing serialized manifests. */
   manifestKv: KvNamespaceLike
   /**
@@ -129,6 +138,99 @@ export function createCloudflareEdgeDriver(opts: CloudflareEdgeDriverOptions): D
       return stub.fetch(request)
     }
 
+    async function forwardToConcurrencyDO(
+      environment: EnvironmentName,
+      concurrencyKey: string,
+      request: Request,
+    ): Promise<Response> {
+      if (!opts.concurrencyNamespace) {
+        throw new Error("CloudflareEdgeDriver: concurrency namespace is not configured")
+      }
+      const id = opts.concurrencyNamespace.idFromName(
+        `workflow-concurrency:${environment}:${concurrencyKey}`,
+      )
+      const stub = opts.concurrencyNamespace.get(id)
+      return stub.fetch(request)
+    }
+
+    function findManifestPolicy(
+      manifest: WorkflowManifest | null,
+      workflowId: string,
+    ): RuntimeConcurrencyPolicy | undefined {
+      return manifest?.workflows.find((entry) => entry.id === workflowId)?.concurrency
+    }
+
+    async function resolveConcurrencyPolicy(
+      workflow: { config?: { concurrency?: unknown } } | string,
+      workflowId: string,
+      environment: EnvironmentName,
+      manifest?: WorkflowManifest | null,
+    ): Promise<RuntimeConcurrencyPolicy | undefined> {
+      if (typeof workflow !== "string" && workflow.config?.concurrency) {
+        return workflow.config.concurrency as RuntimeConcurrencyPolicy
+      }
+      return findManifestPolicy(manifest ?? (await getManifest({ environment })), workflowId)
+    }
+
+    async function forwardTrigger(
+      payload: TriggerPayload & { runId: string; environment: EnvironmentName },
+      policy?: RuntimeConcurrencyPolicy,
+    ): Promise<Response> {
+      if (!policy || !opts.concurrencyNamespace) {
+        return forwardToRunDO(
+          payload.runId,
+          new Request("https://do-internal/trigger", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(payload),
+          }),
+        )
+      }
+
+      const concurrencyKey = resolveConcurrencyKey(payload.workflowId, payload.input, policy)
+      const resp = await forwardToConcurrencyDO(
+        payload.environment,
+        concurrencyKey,
+        new Request("https://do-internal/trigger", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            concurrency: {
+              key: concurrencyKey,
+              limit: policy.limit,
+              strategy: policy.strategy,
+            },
+            trigger: payload,
+          }),
+        }),
+      )
+      if (resp.status === 409) {
+        const body = await safeJson<{ concurrencyKey?: string }>(resp)
+        throw new WorkflowConcurrencyRejectedError(body?.concurrencyKey ?? concurrencyKey)
+      }
+      return resp
+    }
+
+    async function releaseConcurrencySlot(detail: RunDetail | null): Promise<void> {
+      if (!detail || !opts.concurrencyNamespace) return
+      const policy = await resolveConcurrencyPolicy(
+        detail.workflowId,
+        detail.workflowId,
+        detail.environment,
+      )
+      if (!policy) return
+      const concurrencyKey = resolveConcurrencyKey(detail.workflowId, detail.input, policy)
+      await forwardToConcurrencyDO(
+        detail.environment,
+        concurrencyKey,
+        new Request("https://do-internal/release", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ runId: detail.id }),
+        }),
+      ).catch(() => undefined)
+    }
+
     function genRunId(seed?: string): string {
       if (seed !== undefined) return seed
       if (opts.idGenerator) return opts.idGenerator()
@@ -162,7 +264,7 @@ export function createCloudflareEdgeDriver(opts: CloudflareEdgeDriverOptions): D
     }
 
     async function trigger<TIn, TOut>(
-      workflow: { id: string } | string,
+      workflow: WorkflowDefinition<TIn, TOut> | string,
       input: TIn,
       triggerOpts?: TriggerOptions,
     ): Promise<Run<TOut>> {
@@ -190,13 +292,10 @@ export function createCloudflareEdgeDriver(opts: CloudflareEdgeDriverOptions): D
         priority: triggerOpts?.priority,
         triggeredBy: { kind: "api" as const },
       }
-      const resp = await forwardToRunDO(
-        runId,
-        new Request("https://do-internal/trigger", {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify(payload),
-        }),
+      const policy = await resolveConcurrencyPolicy(workflow, workflowId, env)
+      const resp = await forwardTrigger(
+        payload as TriggerPayload & { runId: string; environment: EnvironmentName },
+        policy,
       )
       if (!resp.ok) {
         const body = await safeText(resp)
@@ -273,13 +372,15 @@ export function createCloudflareEdgeDriver(opts: CloudflareEdgeDriverOptions): D
           },
         }
         try {
-          const resp = await forwardToRunDO(
-            runId,
-            new Request("https://do-internal/trigger", {
-              method: "POST",
-              headers: { "content-type": "application/json" },
-              body: JSON.stringify(payload),
-            }),
+          const policy = await resolveConcurrencyPolicy(
+            entry.targetWorkflowId,
+            entry.targetWorkflowId,
+            args.environment,
+            manifest,
+          )
+          const resp = await forwardTrigger(
+            payload as TriggerPayload & { runId: string; environment: EnvironmentName },
+            policy,
           )
           if (resp.ok) {
             matches.push({
@@ -334,55 +435,60 @@ export function createCloudflareEdgeDriver(opts: CloudflareEdgeDriverOptions): D
     //      streamRun are explicitly unsupported per architecture
     //      doc §8.3) ----
 
+    async function getRunDetail(runId: string): Promise<RunDetail | null> {
+      try {
+        const resp = await forwardToRunDO(
+          runId,
+          new Request("https://do-internal/get", { method: "GET" }),
+        )
+        if (resp.status === 404) return null
+        if (!resp.ok) return null
+        const rec = (await resp.json()) as {
+          id: string
+          workflowId: string
+          workflowVersion: string
+          status: RunSummary["status"]
+          startedAt: number
+          completedAt?: number
+          tags: string[]
+          environment: EnvironmentName
+          input: unknown
+          output?: unknown
+          error?: unknown
+        }
+        return {
+          id: rec.id,
+          workflowId: rec.workflowId,
+          status: rec.status,
+          startedAt: rec.startedAt,
+          completedAt: rec.completedAt,
+          tags: [...rec.tags],
+          environment: rec.environment,
+          version: rec.workflowVersion,
+          input: rec.input,
+          output: rec.output,
+          error: rec.error,
+          durationMs:
+            rec.completedAt !== undefined
+              ? Math.max(0, rec.completedAt - rec.startedAt)
+              : undefined,
+        }
+      } catch {
+        return null
+      }
+    }
+
     const admin: Partial<WorkflowAdmin> = {
       async getRun(runId: string): Promise<RunDetail | null> {
-        try {
-          const resp = await forwardToRunDO(
-            runId,
-            new Request("https://do-internal/get", { method: "GET" }),
-          )
-          if (resp.status === 404) return null
-          if (!resp.ok) return null
-          const rec = (await resp.json()) as {
-            id: string
-            workflowId: string
-            workflowVersion: string
-            status: RunSummary["status"]
-            startedAt: number
-            completedAt?: number
-            tags: string[]
-            environment: EnvironmentName
-            input: unknown
-            output?: unknown
-            error?: unknown
-          }
-          return {
-            id: rec.id,
-            workflowId: rec.workflowId,
-            status: rec.status,
-            startedAt: rec.startedAt,
-            completedAt: rec.completedAt,
-            tags: [...rec.tags],
-            environment: rec.environment,
-            version: rec.workflowVersion,
-            input: rec.input,
-            output: rec.output,
-            error: rec.error,
-            durationMs:
-              rec.completedAt !== undefined
-                ? Math.max(0, rec.completedAt - rec.startedAt)
-                : undefined,
-          }
-        } catch {
-          return null
-        }
+        return getRunDetail(runId)
       },
 
       async cancelRun(runId: string, cancelOpts?: { reason?: string; compensate?: boolean }) {
         // Per architecture doc §21.21, cancel does NOT run compensations
         // by default; the `compensate` flag is accepted but no-op in v1.
         void cancelOpts?.compensate
-        await forwardToRunDO(
+        const detail = opts.concurrencyNamespace ? await getRunDetail(runId) : null
+        const resp = await forwardToRunDO(
           runId,
           new Request("https://do-internal/cancel", {
             method: "POST",
@@ -390,6 +496,7 @@ export function createCloudflareEdgeDriver(opts: CloudflareEdgeDriverOptions): D
             body: JSON.stringify({ reason: cancelOpts?.reason }),
           }),
         )
+        if (resp.ok) await releaseConcurrencySlot(detail)
       },
 
       async listRuns(_listOpts?: ListRunsOptions) {
@@ -436,5 +543,13 @@ async function safeText(resp: Response): Promise<string> {
     return await resp.text()
   } catch {
     return ""
+  }
+}
+
+async function safeJson<T>(resp: Response): Promise<T | undefined> {
+  try {
+    return (await resp.json()) as T
+  } catch {
+    return undefined
   }
 }

--- a/packages/workflows-orchestrator-cloudflare/src/concurrency-coordinator.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/concurrency-coordinator.ts
@@ -118,9 +118,10 @@ export function createConcurrencyCoordinator<Id>(
     let next: Waiter | undefined
     await withStateLock(async () => {
       const state = await loadState()
+      const wasActive = state.active.includes(runId)
       state.active = state.active.filter((holder) => holder !== runId)
-      next = waiters.shift()
-      if (next) {
+      next = wasActive ? waiters.shift() : undefined
+      if (wasActive && next) {
         state.active.push(next.runId)
       }
       await saveState(state)
@@ -149,12 +150,14 @@ export function createConcurrencyCoordinator<Id>(
 
         let resp: Response | undefined
         try {
-          resp = await forwardToRunDO(
-            deps.runDO,
-            payload.trigger.runId,
-            "/trigger",
-            payload.trigger,
-          )
+          resp = await forwardToRunDO(deps.runDO, payload.trigger.runId, "/trigger", {
+            ...payload.trigger,
+            concurrencyLease: {
+              environment: payload.trigger.environment ?? "development",
+              key: payload.concurrency.key,
+              runId: payload.trigger.runId,
+            },
+          })
           if (resp.ok) {
             const record = (await resp.clone().json()) as RunRecord
             if (isTerminal(record.status)) {

--- a/packages/workflows-orchestrator-cloudflare/src/concurrency-coordinator.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/concurrency-coordinator.ts
@@ -1,0 +1,234 @@
+import {
+  type RunRecord,
+  type RuntimeConcurrencyPolicy,
+  WorkflowConcurrencyRejectedError,
+} from "@voyantjs/workflows-orchestrator"
+
+import type { DurableObjectStorageLike, TriggerPayload } from "./types.js"
+import type { DurableObjectNamespaceLike } from "./worker.js"
+
+export interface ConcurrencyCoordinatorDeps<Id = unknown> {
+  storage: DurableObjectStorageLike
+  runDO: DurableObjectNamespaceLike<Id>
+}
+
+export interface ConcurrencyCoordinator {
+  fetch(req: Request): Promise<Response>
+}
+
+interface CoordinatorState {
+  active: string[]
+}
+
+interface ConcurrencyTriggerPayload {
+  concurrency: {
+    key: string
+    limit?: number
+    strategy?: RuntimeConcurrencyPolicy["strategy"]
+  }
+  trigger: TriggerPayload & { runId: string }
+}
+
+interface ReleasePayload {
+  runId: string
+}
+
+interface Waiter {
+  runId: string
+  resolve(): void
+}
+
+const STATE_KEY = "state"
+
+export function createConcurrencyCoordinator<Id>(
+  deps: ConcurrencyCoordinatorDeps<Id>,
+): ConcurrencyCoordinator {
+  const waiters: Waiter[] = []
+  let stateLock: Promise<void> = Promise.resolve()
+
+  async function withStateLock<T>(fn: () => Promise<T>): Promise<T> {
+    const previous = stateLock
+    let release!: () => void
+    stateLock = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    await previous
+    try {
+      return await fn()
+    } finally {
+      release()
+    }
+  }
+
+  async function loadState(): Promise<CoordinatorState> {
+    return (await deps.storage.get<CoordinatorState>(STATE_KEY)) ?? { active: [] }
+  }
+
+  async function saveState(state: CoordinatorState): Promise<void> {
+    await deps.storage.put(STATE_KEY, { active: [...state.active] })
+  }
+
+  async function acquire(payload: ConcurrencyTriggerPayload): Promise<void> {
+    const runId = payload.trigger.runId
+    let holdersToCancel: string[] | undefined
+    let waitForSlot: Promise<void> | undefined
+
+    await withStateLock(async () => {
+      const state = await loadState()
+      if (state.active.includes(runId)) return
+
+      const limit = normalizeLimit(payload.concurrency.limit)
+      if (state.active.length < limit) {
+        state.active.push(runId)
+        await saveState(state)
+        return
+      }
+
+      const strategy = payload.concurrency.strategy ?? "queue"
+      if (strategy === "cancel-newest") {
+        throw new WorkflowConcurrencyRejectedError(payload.concurrency.key)
+      }
+
+      if (strategy === "cancel-in-progress") {
+        holdersToCancel = [...state.active]
+        state.active = [runId]
+        await saveState(state)
+        return
+      }
+
+      waitForSlot = new Promise<void>((resolve) => {
+        waiters.push({ runId, resolve })
+      })
+    })
+
+    if (holdersToCancel) {
+      await Promise.all(
+        holdersToCancel.map((holder) =>
+          forwardToRunDO(deps.runDO, holder, "/cancel", {
+            reason: "cancelled by workflow concurrency policy",
+          }).catch(() => undefined),
+        ),
+      )
+    }
+
+    await waitForSlot
+  }
+
+  async function release(runId: string): Promise<void> {
+    let next: Waiter | undefined
+    await withStateLock(async () => {
+      const state = await loadState()
+      state.active = state.active.filter((holder) => holder !== runId)
+      next = waiters.shift()
+      if (next) {
+        state.active.push(next.runId)
+      }
+      await saveState(state)
+    })
+    next?.resolve()
+  }
+
+  return {
+    async fetch(req) {
+      const url = new URL(req.url)
+
+      if (req.method === "POST" && url.pathname === "/trigger") {
+        const payload = (await req.json()) as ConcurrencyTriggerPayload
+        try {
+          await acquire(payload)
+        } catch (err) {
+          if (err instanceof WorkflowConcurrencyRejectedError) {
+            return json(409, {
+              error: err.code,
+              message: err.message,
+              concurrencyKey: err.concurrencyKey,
+            })
+          }
+          throw err
+        }
+
+        let resp: Response | undefined
+        try {
+          resp = await forwardToRunDO(
+            deps.runDO,
+            payload.trigger.runId,
+            "/trigger",
+            payload.trigger,
+          )
+          if (resp.ok) {
+            const record = (await resp.clone().json()) as RunRecord
+            if (isTerminal(record.status)) {
+              await release(record.id)
+            }
+          } else {
+            await release(payload.trigger.runId)
+          }
+          return resp
+        } catch (err) {
+          await release(payload.trigger.runId)
+          throw err
+        }
+      }
+
+      if (req.method === "POST" && url.pathname === "/release") {
+        const payload = (await req.json()) as ReleasePayload
+        await release(payload.runId)
+        return json(200, { ok: true })
+      }
+
+      if (req.method === "GET" && url.pathname === "/state") {
+        return json(200, await loadState())
+      }
+
+      return json(404, { error: "route_not_found", path: url.pathname })
+    },
+  }
+}
+
+export async function handleConcurrencyCoordinatorRequest<Id>(
+  req: Request,
+  deps: ConcurrencyCoordinatorDeps<Id> & { coordinator?: ConcurrencyCoordinator },
+): Promise<Response> {
+  const coordinator = deps.coordinator ?? createConcurrencyCoordinator(deps)
+  return coordinator.fetch(req)
+}
+
+async function forwardToRunDO<Id>(
+  runDO: DurableObjectNamespaceLike<Id>,
+  runId: string,
+  path: "/trigger" | "/cancel",
+  body: unknown,
+): Promise<Response> {
+  const id = runDO.idFromName(runId)
+  const stub = runDO.get(id)
+  return stub.fetch(
+    new Request(`https://do-internal${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  )
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  if (limit === undefined) return 1
+  if (!Number.isFinite(limit)) return 1
+  return Math.max(1, Math.floor(limit))
+}
+
+function isTerminal(status: RunRecord["status"]): boolean {
+  return (
+    status === "completed" ||
+    status === "failed" ||
+    status === "cancelled" ||
+    status === "compensated" ||
+    status === "compensation_failed"
+  )
+}
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  })
+}

--- a/packages/workflows-orchestrator-cloudflare/src/durable-object.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/durable-object.ts
@@ -32,10 +32,12 @@ import type { StepDispatcher } from "./dispatchers.js"
 import { createDurableObjectRunStore } from "./do-store.js"
 import type {
   CancelPayload,
+  ConcurrencyLease,
   DurableObjectStorageLike,
   ResumePayload,
   TriggerPayload,
 } from "./types.js"
+import type { DurableObjectNamespaceLike } from "./worker.js"
 
 export interface DurableObjectDeps {
   storage: DurableObjectStorageLike
@@ -52,8 +54,11 @@ export interface DurableObjectDeps {
    *  - `createHttpDispatcher`           — arbitrary HTTP endpoint
    */
   dispatcher: StepDispatcher
+  concurrencyDO?: DurableObjectNamespaceLike
   now?: () => number
 }
+
+const CONCURRENCY_LEASE_KEY = "concurrencyLease"
 
 function resolve(
   deps: DurableObjectDeps,
@@ -74,6 +79,9 @@ export async function handleDurableObjectRequest(
 
   if (req.method === "POST" && url.pathname === "/trigger") {
     const payload = (await req.json()) as TriggerPayload
+    if (payload.concurrencyLease) {
+      await deps.storage.put(CONCURRENCY_LEASE_KEY, payload.concurrencyLease)
+    }
     const handler = resolve(deps, {
       tenantMeta: payload.tenantMeta,
       workflowId: payload.workflowId,
@@ -115,6 +123,7 @@ export async function handleDurableObjectRequest(
       return json(status, { error: out.status, message: out.message })
     }
     await reconcileAlarm(out.record, store, deps)
+    await releaseConcurrencyLeaseIfTerminal(out.record, deps)
     return json(200, out.record)
   }
 
@@ -132,6 +141,7 @@ export async function handleDurableObjectRequest(
       return json(status, { error: out.status, message: out.message })
     }
     await reconcileAlarm(out.record, store, deps)
+    await releaseConcurrencyLeaseIfTerminal(out.record, deps)
     return json(200, out.record)
   }
 
@@ -190,6 +200,7 @@ export async function handleDurableObjectAlarm(deps: DurableObjectDeps): Promise
   await driveUntilPaused(record, { handler, now: deps.now })
   await store.save(record)
   await reconcileAlarm(record, store, deps)
+  await releaseConcurrencyLeaseIfTerminal(record, deps)
 }
 
 /**
@@ -238,6 +249,38 @@ async function getStoredRunId(
 ): Promise<string | undefined> {
   const all = await store.list()
   return all[0]?.id
+}
+
+async function releaseConcurrencyLeaseIfTerminal(
+  record: RunRecord,
+  deps: DurableObjectDeps,
+): Promise<void> {
+  if (!deps.concurrencyDO || !isTerminal(record.status)) return
+  const lease = await deps.storage.get<ConcurrencyLease>(CONCURRENCY_LEASE_KEY)
+  if (!lease) return
+
+  const id = deps.concurrencyDO.idFromName(`workflow-concurrency:${lease.environment}:${lease.key}`)
+  const stub = deps.concurrencyDO.get(id)
+  await stub
+    .fetch(
+      new Request("https://do-internal/release", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ runId: lease.runId }),
+      }),
+    )
+    .catch(() => undefined)
+  await deps.storage.delete(CONCURRENCY_LEASE_KEY)
+}
+
+function isTerminal(status: RunRecord["status"]): boolean {
+  return (
+    status === "completed" ||
+    status === "failed" ||
+    status === "cancelled" ||
+    status === "compensated" ||
+    status === "compensation_failed"
+  )
 }
 
 function json(status: number, body: unknown): Response {

--- a/packages/workflows-orchestrator-cloudflare/src/durable-object.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/durable-object.ts
@@ -88,6 +88,7 @@ export async function handleDurableObjectRequest(
         tags: payload.tags,
         runId: payload.runId,
         idempotencyKey: payload.idempotencyKey,
+        triggeredBy: payload.triggeredBy,
         delay:
           typeof payload.delay === "object" && payload.delay !== null && "wakeAt" in payload.delay
             ? new Date(payload.delay.wakeAt)

--- a/packages/workflows-orchestrator-cloudflare/src/index.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/index.ts
@@ -43,6 +43,12 @@ export {
   createCloudflareEdgeDriver,
 } from "./cloudflare-edge-driver.js"
 export {
+  type ConcurrencyCoordinator,
+  type ConcurrencyCoordinatorDeps,
+  createConcurrencyCoordinator,
+  handleConcurrencyCoordinatorRequest,
+} from "./concurrency-coordinator.js"
+export {
   createHttpDispatcher,
   createInlineDispatcher,
   createServiceBindingDispatcher,

--- a/packages/workflows-orchestrator-cloudflare/src/types.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/types.ts
@@ -2,7 +2,7 @@
 // a hard dependency on `@cloudflare/workers-types` — matching the
 // shape is enough, and tests can pass plain objects.
 
-import type { Duration, RunTrigger } from "@voyantjs/workflows"
+import type { Duration, EnvironmentName, RunTrigger } from "@voyantjs/workflows"
 import type { WaitpointInjection } from "@voyantjs/workflows-orchestrator"
 
 /**
@@ -62,6 +62,13 @@ export interface TriggerPayload {
   delay?: Duration | { wakeAt: number }
   priority?: number
   triggeredBy?: RunTrigger
+  concurrencyLease?: ConcurrencyLease
+}
+
+export interface ConcurrencyLease {
+  environment: EnvironmentName
+  key: string
+  runId: string
 }
 
 /** Cancel payload. */

--- a/packages/workflows-orchestrator-cloudflare/src/types.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/types.ts
@@ -2,7 +2,7 @@
 // a hard dependency on `@cloudflare/workers-types` — matching the
 // shape is enough, and tests can pass plain objects.
 
-import type { Duration } from "@voyantjs/workflows"
+import type { Duration, RunTrigger } from "@voyantjs/workflows"
 import type { WaitpointInjection } from "@voyantjs/workflows-orchestrator"
 
 /**
@@ -61,6 +61,7 @@ export interface TriggerPayload {
   idempotencyKey?: string
   delay?: Duration | { wakeAt: number }
   priority?: number
+  triggeredBy?: RunTrigger
 }
 
 /** Cancel payload. */

--- a/packages/workflows-orchestrator-node/src/node-standalone-driver.ts
+++ b/packages/workflows-orchestrator-node/src/node-standalone-driver.ts
@@ -37,14 +37,17 @@ import { deriveStableEventId } from "@voyantjs/workflows/events"
 import { handleStepRequest, type WorkflowStepRequest } from "@voyantjs/workflows/handler"
 import type { WorkflowManifest } from "@voyantjs/workflows/protocol"
 import {
+  createInProcessConcurrencyCoordinator,
   createScheduler,
   manifestScheduleSources,
   cancel as orchestratorCancel,
   trigger as orchestratorTrigger,
   type RunRecord,
+  type RuntimeConcurrencyPolicy,
   routeEvent,
   type SchedulerHandle,
   type StepHandler,
+  type TriggerArgs,
 } from "@voyantjs/workflows-orchestrator"
 import type { drizzle } from "drizzle-orm/node-postgres"
 
@@ -198,6 +201,14 @@ export function createNodeStandaloneDriver(opts: NodeStandaloneDriverOptions): D
 
     const scheduleRunners = new Map<string, SchedulerHandle>()
     let shuttingDown = false
+    const concurrency = createInProcessConcurrencyCoordinator({
+      async cancelRun(runId, reason) {
+        const out = await orchestratorCancel({ runId, reason }, { store: runStore, handler, now })
+        if (out.ok && isTerminal(out.record.status)) {
+          concurrency.releaseRun(out.record)
+        }
+      },
+    })
 
     // ---- WorkflowDriver implementation ----
 
@@ -245,8 +256,9 @@ export function createNodeStandaloneDriver(opts: NodeStandaloneDriverOptions): D
       assertNotShutdown(shuttingDown)
       const workflowId = typeof workflow === "string" ? workflow : workflow.id
       const env = triggerOpts?.environment ?? defaultEnv
+      const policy = await resolveConcurrencyPolicy(workflow, workflowId, env, getManifest)
 
-      const record = await orchestratorTrigger(
+      const record = await triggerRecord(
         {
           workflowId,
           workflowVersion: triggerOpts?.lockToVersion ?? "v1",
@@ -258,7 +270,7 @@ export function createNodeStandaloneDriver(opts: NodeStandaloneDriverOptions): D
           delay: triggerOpts?.delay,
           priority: triggerOpts?.priority,
         },
-        { store: runStore, handler, now },
+        policy,
       )
       // Sync wakeup row so the time-wheel can resume DATETIME-parked runs.
       // No-op if the run completed inline (status !== "waiting").
@@ -299,7 +311,7 @@ export function createNodeStandaloneDriver(opts: NodeStandaloneDriverOptions): D
           continue
         }
         try {
-          const record = await orchestratorTrigger(
+          const record = await triggerRecord(
             {
               workflowId: entry.targetWorkflowId,
               workflowVersion: "v1",
@@ -314,7 +326,12 @@ export function createNodeStandaloneDriver(opts: NodeStandaloneDriverOptions): D
                 filterId: entry.filterId,
               },
             },
-            { store: runStore, handler, now },
+            await resolveConcurrencyPolicy(
+              entry.targetWorkflowId,
+              entry.targetWorkflowId,
+              args.environment,
+              getManifest,
+            ),
           )
           await syncWakeupFromRecord(wakeupStore, record)
           matches.push({
@@ -377,7 +394,7 @@ export function createNodeStandaloneDriver(opts: NodeStandaloneDriverOptions): D
         tickMs: opts.schedulePollIntervalMs,
         onFire: async ({ workflowId, input, scheduleId, fireAt }) => {
           assertNotShutdown(shuttingDown)
-          const record = await orchestratorTrigger(
+          const record = await triggerRecord(
             {
               workflowId,
               workflowVersion: "v1",
@@ -387,7 +404,7 @@ export function createNodeStandaloneDriver(opts: NodeStandaloneDriverOptions): D
               idempotencyKey: `${scheduleId}:${fireAt}`,
               triggeredBy: { kind: "schedule", scheduleId },
             },
-            { store: runStore, handler, now },
+            await resolveConcurrencyPolicy(workflowId, workflowId, environment, getManifest),
           )
           await syncWakeupFromRecord(wakeupStore, record)
         },
@@ -396,6 +413,27 @@ export function createNodeStandaloneDriver(opts: NodeStandaloneDriverOptions): D
       if (runner.sourceCount() === 0) return
       runner.start()
       scheduleRunners.set(environment, runner)
+    }
+
+    async function triggerRecord(
+      args: TriggerArgs,
+      policy: RuntimeConcurrencyPolicy | undefined,
+    ): Promise<RunRecord> {
+      return concurrency.run(
+        {
+          workflowId: args.workflowId,
+          input: args.input,
+          policy,
+        },
+        (hooks) =>
+          orchestratorTrigger(
+            {
+              ...args,
+              onRunRecordCreated: hooks.onRunRecordCreated,
+            },
+            { store: runStore, handler, now },
+          ),
+      )
     }
 
     // ---- WorkflowAdmin (full; Mode 2 has Postgres-native query support) ----
@@ -443,10 +481,13 @@ export function createNodeStandaloneDriver(opts: NodeStandaloneDriverOptions): D
         // default (architecture doc §21.21). The `compensate` flag is
         // accepted but no-ops in v1.
         void cancelOpts?.compensate
-        await orchestratorCancel(
+        const out = await orchestratorCancel(
           { runId, reason: cancelOpts?.reason },
           { store: runStore, handler, now },
         )
+        if (out.ok && isTerminal(out.record.status)) {
+          concurrency.releaseRun(out.record)
+        }
       },
 
       streamRun(runId: string): AsyncIterable<never> {
@@ -483,6 +524,29 @@ function assertNotShutdown(shuttingDown: boolean): void {
   if (shuttingDown) {
     throw new Error("NodeStandaloneDriver: shutdown() has been called; new operations are refused.")
   }
+}
+
+async function resolveConcurrencyPolicy(
+  workflow: { id: string; config?: { concurrency?: RuntimeConcurrencyPolicy } } | string,
+  workflowId: string,
+  environment: "production" | "preview" | "development",
+  getManifest: (args: { environment: string }) => Promise<WorkflowManifest | null>,
+): Promise<RuntimeConcurrencyPolicy | undefined> {
+  if (typeof workflow !== "string" && workflow.config?.concurrency) {
+    return workflow.config.concurrency
+  }
+  const manifest = await getManifest({ environment })
+  return manifest?.workflows.find((entry) => entry.id === workflowId)?.concurrency
+}
+
+function isTerminal(status: RunRecord["status"]): boolean {
+  return (
+    status === "completed" ||
+    status === "failed" ||
+    status === "cancelled" ||
+    status === "compensated" ||
+    status === "compensation_failed"
+  )
 }
 
 function randomToken(): string {

--- a/packages/workflows-orchestrator-node/src/node-standalone-driver.ts
+++ b/packages/workflows-orchestrator-node/src/node-standalone-driver.ts
@@ -424,6 +424,7 @@ export function createNodeStandaloneDriver(opts: NodeStandaloneDriverOptions): D
           workflowId: args.workflowId,
           input: args.input,
           policy,
+          holderId: concurrencyHolderId(args),
         },
         (hooks) =>
           orchestratorTrigger(
@@ -547,6 +548,12 @@ function isTerminal(status: RunRecord["status"]): boolean {
     status === "compensated" ||
     status === "compensation_failed"
   )
+}
+
+function concurrencyHolderId(args: TriggerArgs): string | undefined {
+  if (args.runId !== undefined) return args.runId
+  if (args.idempotencyKey !== undefined) return `idem-${args.workflowId}-${args.idempotencyKey}`
+  return undefined
 }
 
 function randomToken(): string {

--- a/packages/workflows-orchestrator/src/__tests__/driver-inmemory-concurrency.test.ts
+++ b/packages/workflows-orchestrator/src/__tests__/driver-inmemory-concurrency.test.ts
@@ -1,0 +1,164 @@
+import { __resetRegistry, workflow } from "@voyantjs/workflows"
+import { afterEach, describe, expect, test, vi } from "vitest"
+
+import { WorkflowConcurrencyRejectedError } from "../concurrency.js"
+import { createInMemoryDriver } from "../driver-inmemory.js"
+import { testFactoryDeps } from "../testing/driver-compliance.js"
+
+afterEach(() => {
+  __resetRegistry()
+})
+
+describe("InMemory driver workflow concurrency", () => {
+  test("queues triggers with the same concurrency key until the active run completes", async () => {
+    const driver = createInMemoryDriver()(testFactoryDeps())
+    const firstGate = deferred<void>()
+    const started: string[] = []
+
+    const wf = workflow<{ id: string }, string>({
+      id: "concurrency.queue",
+      concurrency: {
+        key: (input) => input.id,
+        limit: 1,
+        strategy: "queue",
+      },
+      async run(input) {
+        started.push(input.id)
+        if (input.id === "same") {
+          await firstGate.promise
+        }
+        return input.id
+      },
+    })
+
+    const first = driver.trigger(wf, { id: "same" })
+    await vi.waitFor(() => expect(started).toEqual(["same"]))
+
+    const second = driver.trigger(wf, { id: "same" })
+    await Promise.resolve()
+    expect(started).toEqual(["same"])
+
+    firstGate.resolve()
+    await first
+    await second
+
+    expect(started).toEqual(["same", "same"])
+  })
+
+  test("allows up to limit active triggers before queueing", async () => {
+    const driver = createInMemoryDriver()(testFactoryDeps())
+    const gate = deferred<void>()
+    const started: number[] = []
+
+    const wf = workflow<{ n: number }, number>({
+      id: "concurrency.limit",
+      concurrency: {
+        key: "shared",
+        limit: 2,
+        strategy: "queue",
+      },
+      async run(input) {
+        started.push(input.n)
+        await gate.promise
+        return input.n
+      },
+    })
+
+    const first = driver.trigger(wf, { n: 1 })
+    const second = driver.trigger(wf, { n: 2 })
+    await vi.waitFor(() => expect(started).toEqual([1, 2]))
+
+    const third = driver.trigger(wf, { n: 3 })
+    await Promise.resolve()
+    expect(started).toEqual([1, 2])
+
+    gate.resolve()
+    await Promise.all([first, second, third])
+    expect(started).toEqual([1, 2, 3])
+  })
+
+  test("rejects the newest trigger when cancel-newest is at capacity", async () => {
+    const driver = createInMemoryDriver()(testFactoryDeps())
+    const gate = deferred<void>()
+
+    const wf = workflow<{ n: number }, number>({
+      id: "concurrency.cancel-newest",
+      concurrency: {
+        key: "shared",
+        limit: 1,
+        strategy: "cancel-newest",
+      },
+      async run(input) {
+        await gate.promise
+        return input.n
+      },
+    })
+
+    const first = driver.trigger(wf, { n: 1 })
+    await expect(driver.trigger(wf, { n: 2 })).rejects.toBeInstanceOf(
+      WorkflowConcurrencyRejectedError,
+    )
+
+    gate.resolve()
+    const run = await first
+    expect(run.status).toBe("completed")
+  })
+
+  test("cancels the in-progress run before starting a replacement", async () => {
+    const driver = createInMemoryDriver()(testFactoryDeps())
+    const started: number[] = []
+    let firstAborted = false
+
+    const wf = workflow<{ n: number }, number>({
+      id: "concurrency.cancel-in-progress",
+      concurrency: {
+        key: "shared",
+        limit: 1,
+        strategy: "cancel-in-progress",
+      },
+      async run(input, ctx) {
+        started.push(input.n)
+        if (input.n === 1) {
+          await ctx.step("block-until-cancelled", async (stepCtx) => {
+            await new Promise<void>((resolve) => {
+              stepCtx.signal.addEventListener(
+                "abort",
+                () => {
+                  firstAborted = true
+                  resolve()
+                },
+                { once: true },
+              )
+            })
+          })
+        }
+        return input.n
+      },
+    })
+
+    const first = driver.trigger(wf, { n: 1 })
+    await vi.waitFor(() => expect(started).toEqual([1]))
+
+    const second = await driver.trigger(wf, { n: 2 })
+    expect(second.status).toBe("completed")
+    expect(started).toEqual([1, 2])
+    expect(firstAborted).toBe(true)
+
+    const firstRun = await first
+    expect(firstRun.status).toBe("cancelled")
+  })
+})
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve(value: T): void
+  reject(error: unknown): void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}

--- a/packages/workflows-orchestrator/src/__tests__/driver-inmemory-concurrency.test.ts
+++ b/packages/workflows-orchestrator/src/__tests__/driver-inmemory-concurrency.test.ts
@@ -104,6 +104,38 @@ describe("InMemory driver workflow concurrency", () => {
     expect(run.status).toBe("completed")
   })
 
+  test("idempotent retries bypass concurrency rejection while the original run is active", async () => {
+    const driver = createInMemoryDriver()(testFactoryDeps())
+    const gate = deferred<void>()
+    let invocationCount = 0
+
+    const wf = workflow<{ n: number }, number>({
+      id: "concurrency.idempotent-retry",
+      concurrency: {
+        key: "shared",
+        limit: 1,
+        strategy: "cancel-newest",
+      },
+      async run(input) {
+        invocationCount++
+        await gate.promise
+        return input.n
+      },
+    })
+
+    const first = driver.trigger(wf, { n: 1 }, { idempotencyKey: "retry-key" })
+    await vi.waitFor(() => expect(invocationCount).toBe(1))
+    const retry = await driver.trigger(wf, { n: 999 }, { idempotencyKey: "retry-key" })
+
+    expect(retry.id).toBe("idem-concurrency.idempotent-retry-retry-key")
+    expect(invocationCount).toBe(1)
+
+    gate.resolve()
+    const firstRun = await first
+    expect(retry.id).toBe(firstRun.id)
+    expect(invocationCount).toBe(1)
+  })
+
   test("cancels the in-progress run before starting a replacement", async () => {
     const driver = createInMemoryDriver()(testFactoryDeps())
     const started: number[] = []

--- a/packages/workflows-orchestrator/src/concurrency.ts
+++ b/packages/workflows-orchestrator/src/concurrency.ts
@@ -1,0 +1,213 @@
+import type { ConcurrencyPolicy } from "@voyantjs/workflows"
+
+import type { RunRecord } from "./types.js"
+
+export type RuntimeConcurrencyPolicy =
+  | ConcurrencyPolicy<unknown>
+  | {
+      key?: string
+      limit?: number
+      strategy?: "queue" | "cancel-in-progress" | "cancel-newest" | "round-robin"
+    }
+
+export interface ConcurrencyRunHooks {
+  onRunRecordCreated(record: RunRecord): void
+}
+
+export class WorkflowConcurrencyRejectedError extends Error {
+  readonly code = "WORKFLOW_CONCURRENCY_REJECTED"
+
+  constructor(readonly concurrencyKey: string) {
+    super(`workflow concurrency limit reached for key "${concurrencyKey}"`)
+    this.name = "WorkflowConcurrencyRejectedError"
+  }
+}
+
+export interface InProcessConcurrencyCoordinator {
+  run(
+    args: {
+      workflowId: string
+      input: unknown
+      policy?: RuntimeConcurrencyPolicy
+    },
+    operation: (hooks: ConcurrencyRunHooks) => Promise<RunRecord>,
+  ): Promise<RunRecord>
+  releaseRun(recordOrRunId: RunRecord | string): void
+}
+
+interface Group {
+  active: Set<string>
+  waiters: Waiter[]
+}
+
+interface Slot {
+  key: string
+  holderId: string
+}
+
+interface Waiter {
+  holderId: string
+  resolve(slot: Slot): void
+}
+
+interface CreateInProcessConcurrencyCoordinatorOptions {
+  cancelRun?: (runId: string, reason: string) => Promise<unknown>
+}
+
+const TOKEN_PREFIX = "concurrency-slot:"
+
+export function createInProcessConcurrencyCoordinator(
+  opts: CreateInProcessConcurrencyCoordinatorOptions = {},
+): InProcessConcurrencyCoordinator {
+  const groups = new Map<string, Group>()
+  const runKeys = new Map<string, string>()
+  let nextToken = 0
+
+  function getGroup(key: string): Group {
+    let group = groups.get(key)
+    if (!group) {
+      group = { active: new Set(), waiters: [] }
+      groups.set(key, group)
+    }
+    return group
+  }
+
+  function createToken(): string {
+    nextToken += 1
+    return `${TOKEN_PREFIX}${nextToken}`
+  }
+
+  async function acquire(
+    key: string,
+    limit: number,
+    strategy: NonNullable<RuntimeConcurrencyPolicy["strategy"]>,
+  ): Promise<Slot> {
+    const group = getGroup(key)
+    if (group.active.size < limit) {
+      const holderId = createToken()
+      group.active.add(holderId)
+      return { key, holderId }
+    }
+
+    if (strategy === "cancel-newest") {
+      throw new WorkflowConcurrencyRejectedError(key)
+    }
+
+    if (strategy === "cancel-in-progress") {
+      const holders = [...group.active]
+      for (const holder of holders) {
+        group.active.delete(holder)
+        runKeys.delete(holder)
+        if (!holder.startsWith(TOKEN_PREFIX)) {
+          await opts.cancelRun?.(holder, "cancelled by workflow concurrency policy")
+        }
+      }
+      const holderId = createToken()
+      group.active.add(holderId)
+      return { key, holderId }
+    }
+
+    const holderId = createToken()
+    return new Promise((resolve) => {
+      group.waiters.push({
+        holderId,
+        resolve(slot) {
+          resolve(slot)
+        },
+      })
+    })
+  }
+
+  function assignRunId(slot: Slot, record: RunRecord): Slot {
+    const group = getGroup(slot.key)
+    if (group.active.delete(slot.holderId)) {
+      group.active.add(record.id)
+    }
+    runKeys.set(record.id, slot.key)
+    return { key: slot.key, holderId: record.id }
+  }
+
+  function releaseSlot(slot: Slot): void {
+    const group = groups.get(slot.key)
+    if (!group) return
+    group.active.delete(slot.holderId)
+    runKeys.delete(slot.holderId)
+    drain(slot.key, group)
+    if (group.active.size === 0 && group.waiters.length === 0) {
+      groups.delete(slot.key)
+    }
+  }
+
+  function drain(key: string, group: Group): void {
+    while (group.waiters.length > 0) {
+      const waiter = group.waiters.shift()
+      if (!waiter) return
+      group.active.add(waiter.holderId)
+      waiter.resolve({ key, holderId: waiter.holderId })
+      if (group.active.size > 0) return
+    }
+  }
+
+  return {
+    async run(args, operation) {
+      const policy = args.policy
+      if (!policy) {
+        return operation({ onRunRecordCreated() {} })
+      }
+
+      const key = resolveConcurrencyKey(args.workflowId, args.input, policy)
+      const limit = normalizeLimit(policy.limit)
+      const strategy = policy.strategy ?? "queue"
+      let slot = await acquire(key, limit, strategy)
+      let record: RunRecord | undefined
+
+      try {
+        record = await operation({
+          onRunRecordCreated(created) {
+            slot = assignRunId(slot, created)
+          },
+        })
+        if (!runKeys.has(record.id)) {
+          slot = assignRunId(slot, record)
+        }
+        return record
+      } finally {
+        if (!record || isTerminal(record.status)) {
+          releaseSlot(record ? { key: slot.key, holderId: record.id } : slot)
+        }
+      }
+    },
+
+    releaseRun(recordOrRunId) {
+      const runId = typeof recordOrRunId === "string" ? recordOrRunId : recordOrRunId.id
+      const key = runKeys.get(runId)
+      if (!key) return
+      releaseSlot({ key, holderId: runId })
+    },
+  }
+}
+
+export function resolveConcurrencyKey(
+  workflowId: string,
+  input: unknown,
+  policy: RuntimeConcurrencyPolicy,
+): string {
+  const rawKey = typeof policy.key === "function" ? policy.key(input) : policy.key
+  return `${workflowId}:${rawKey ?? "default"}`
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  if (limit === undefined) return 1
+  if (!Number.isFinite(limit)) return 1
+  return Math.max(1, Math.floor(limit))
+}
+
+function isTerminal(status: RunRecord["status"]): boolean {
+  return (
+    status === "completed" ||
+    status === "failed" ||
+    status === "cancelled" ||
+    status === "compensated" ||
+    status === "compensation_failed"
+  )
+}

--- a/packages/workflows-orchestrator/src/concurrency.ts
+++ b/packages/workflows-orchestrator/src/concurrency.ts
@@ -29,6 +29,7 @@ export interface InProcessConcurrencyCoordinator {
       workflowId: string
       input: unknown
       policy?: RuntimeConcurrencyPolicy
+      holderId?: string
     },
     operation: (hooks: ConcurrencyRunHooks) => Promise<RunRecord>,
   ): Promise<RunRecord>
@@ -81,10 +82,15 @@ export function createInProcessConcurrencyCoordinator(
     key: string,
     limit: number,
     strategy: NonNullable<RuntimeConcurrencyPolicy["strategy"]>,
+    preferredHolderId?: string,
   ): Promise<Slot> {
     const group = getGroup(key)
+    if (preferredHolderId && group.active.has(preferredHolderId)) {
+      return { key, holderId: preferredHolderId }
+    }
+
+    const holderId = preferredHolderId ?? createToken()
     if (group.active.size < limit) {
-      const holderId = createToken()
       group.active.add(holderId)
       return { key, holderId }
     }
@@ -102,12 +108,10 @@ export function createInProcessConcurrencyCoordinator(
           await opts.cancelRun?.(holder, "cancelled by workflow concurrency policy")
         }
       }
-      const holderId = createToken()
       group.active.add(holderId)
       return { key, holderId }
     }
 
-    const holderId = createToken()
     return new Promise((resolve) => {
       group.waiters.push({
         holderId,
@@ -158,7 +162,7 @@ export function createInProcessConcurrencyCoordinator(
       const key = resolveConcurrencyKey(args.workflowId, args.input, policy)
       const limit = normalizeLimit(policy.limit)
       const strategy = policy.strategy ?? "queue"
-      let slot = await acquire(key, limit, strategy)
+      let slot = await acquire(key, limit, strategy, args.holderId)
       let record: RunRecord | undefined
 
       try {

--- a/packages/workflows-orchestrator/src/driver-inmemory.ts
+++ b/packages/workflows-orchestrator/src/driver-inmemory.ts
@@ -33,12 +33,17 @@ import { deriveStableEventId } from "@voyantjs/workflows/events"
 import { handleStepRequest, type WorkflowStepRequest } from "@voyantjs/workflows/handler"
 import type { WorkflowManifest } from "@voyantjs/workflows/protocol"
 
+import {
+  createInProcessConcurrencyCoordinator,
+  type RuntimeConcurrencyPolicy,
+} from "./concurrency.js"
 import { routeEvent } from "./event-router.js"
 import { createInMemoryRunStore } from "./in-memory-store.js"
 import {
   cancel as orchestratorCancel,
   trigger as orchestratorTrigger,
   resumeDueAlarms,
+  type TriggerArgs,
 } from "./orchestrator.js"
 import { createScheduler, manifestScheduleSources, type SchedulerHandle } from "./schedule.js"
 import type { RunRecord, StepHandler } from "./types.js"
@@ -94,6 +99,14 @@ export function createInMemoryDriver(opts: InMemoryDriverOptions = {}): DriverFa
         handleStepRequest(req, { services: deps.services }, stepOpts))
 
     let shuttingDown = false
+    const concurrency = createInProcessConcurrencyCoordinator({
+      async cancelRun(runId, reason) {
+        const out = await orchestratorCancel({ runId, reason }, { store, handler, now })
+        if (out.ok && isTerminal(out.record.status)) {
+          concurrency.releaseRun(out.record)
+        }
+      },
+    })
 
     // ---- WorkflowDriver implementation ----
 
@@ -124,13 +137,14 @@ export function createInMemoryDriver(opts: InMemoryDriverOptions = {}): DriverFa
       assertNotShutdown(shuttingDown)
       const workflowId = typeof workflow === "string" ? workflow : workflow.id
       const env = triggerOpts?.environment ?? defaultEnv
+      const policy = resolveConcurrencyPolicy(workflow, workflowId, env, manifests)
 
       // The orchestrator core handles idempotencyKey natively (deterministic
       // runId derivation from `(workflowId, idempotencyKey)`); the driver just
       // forwards the field. Persistent stores like `voyant_snapshot_runs`
       // additionally read `RunRecord.idempotencyKey` to populate their own
       // dedup column.
-      const record = await orchestratorTrigger(
+      const record = await triggerRecord(
         {
           workflowId,
           workflowVersion: triggerOpts?.lockToVersion ?? "v1",
@@ -142,7 +156,7 @@ export function createInMemoryDriver(opts: InMemoryDriverOptions = {}): DriverFa
           delay: triggerOpts?.delay,
           priority: triggerOpts?.priority,
         },
-        { store, handler, now },
+        policy,
       )
       scheduleDelayedRun(record)
       return runRecordToRun<TOut>(record)
@@ -180,7 +194,7 @@ export function createInMemoryDriver(opts: InMemoryDriverOptions = {}): DriverFa
           continue
         }
         try {
-          const record = await orchestratorTrigger(
+          const record = await triggerRecord(
             {
               workflowId: entry.targetWorkflowId,
               workflowVersion: "v1",
@@ -195,7 +209,12 @@ export function createInMemoryDriver(opts: InMemoryDriverOptions = {}): DriverFa
                 filterId: entry.filterId,
               },
             },
-            { store, handler, now },
+            resolveConcurrencyPolicy(
+              entry.targetWorkflowId,
+              entry.targetWorkflowId,
+              args.environment,
+              manifests,
+            ),
           )
           scheduleDelayedRun(record)
           matches.push({
@@ -253,7 +272,7 @@ export function createInMemoryDriver(opts: InMemoryDriverOptions = {}): DriverFa
         tickMs: opts.schedulePollIntervalMs,
         onFire: async ({ workflowId, input, scheduleId, fireAt }) => {
           assertNotShutdown(shuttingDown)
-          const record = await orchestratorTrigger(
+          const record = await triggerRecord(
             {
               workflowId,
               workflowVersion: "v1",
@@ -263,7 +282,7 @@ export function createInMemoryDriver(opts: InMemoryDriverOptions = {}): DriverFa
               idempotencyKey: `${scheduleId}:${fireAt}`,
               triggeredBy: { kind: "schedule", scheduleId },
             },
-            { store, handler, now },
+            resolveConcurrencyPolicy(workflowId, workflowId, environment, manifests),
           )
           scheduleDelayedRun(record)
         },
@@ -281,10 +300,35 @@ export function createInMemoryDriver(opts: InMemoryDriverOptions = {}): DriverFa
       const delayMs = Math.max(0, wakeAt - now())
       const timer = setTimeout(() => {
         void resumeDueAlarms({ runId: record.id }, { store, handler, now }).then((resumed) => {
-          if (resumed) scheduleDelayedRun(resumed)
+          if (!resumed) return
+          if (isTerminal(resumed.status)) {
+            concurrency.releaseRun(resumed)
+          }
+          scheduleDelayedRun(resumed)
         })
       }, delayMs)
       timer.unref?.()
+    }
+
+    async function triggerRecord(
+      args: TriggerArgs,
+      policy: RuntimeConcurrencyPolicy | undefined,
+    ): Promise<RunRecord> {
+      return concurrency.run(
+        {
+          workflowId: args.workflowId,
+          input: args.input,
+          policy,
+        },
+        (hooks) =>
+          orchestratorTrigger(
+            {
+              ...args,
+              onRunRecordCreated: hooks.onRunRecordCreated,
+            },
+            { store, handler, now },
+          ),
+      )
     }
 
     // ---- WorkflowAdmin (partial; sufficient for compliance tests) ----
@@ -326,7 +370,13 @@ export function createInMemoryDriver(opts: InMemoryDriverOptions = {}): DriverFa
         // is accepted but no-ops in v1; honoring it would require an engine
         // behavior change tracked separately.
         void cancelOpts?.compensate
-        await orchestratorCancel({ runId, reason: cancelOpts?.reason }, { store, handler, now })
+        const out = await orchestratorCancel(
+          { runId, reason: cancelOpts?.reason },
+          { store, handler, now },
+        )
+        if (out.ok && isTerminal(out.record.status)) {
+          concurrency.releaseRun(out.record)
+        }
       },
 
       // streamRun is not implemented for InMemory in PR1. Dashboards that
@@ -363,6 +413,29 @@ function assertNotShutdown(shuttingDown: boolean): void {
   if (shuttingDown) {
     throw new Error("InMemoryDriver: shutdown() has been called; new operations are refused.")
   }
+}
+
+function resolveConcurrencyPolicy(
+  workflow: { id: string; config?: { concurrency?: RuntimeConcurrencyPolicy } } | string,
+  workflowId: string,
+  environment: EnvironmentName,
+  manifests: Map<EnvironmentName, { manifest: WorkflowManifest; versionId: string }>,
+): RuntimeConcurrencyPolicy | undefined {
+  if (typeof workflow !== "string" && workflow.config?.concurrency) {
+    return workflow.config.concurrency
+  }
+  const manifest = manifests.get(environment)?.manifest
+  return manifest?.workflows.find((entry) => entry.id === workflowId)?.concurrency
+}
+
+function isTerminal(status: RunRecord["status"]): boolean {
+  return (
+    status === "completed" ||
+    status === "failed" ||
+    status === "cancelled" ||
+    status === "compensated" ||
+    status === "compensation_failed"
+  )
 }
 
 async function ensureEventId(envelope: {

--- a/packages/workflows-orchestrator/src/driver-inmemory.ts
+++ b/packages/workflows-orchestrator/src/driver-inmemory.ts
@@ -319,6 +319,7 @@ export function createInMemoryDriver(opts: InMemoryDriverOptions = {}): DriverFa
           workflowId: args.workflowId,
           input: args.input,
           policy,
+          holderId: concurrencyHolderId(args),
         },
         (hooks) =>
           orchestratorTrigger(
@@ -394,6 +395,12 @@ export function createInMemoryDriver(opts: InMemoryDriverOptions = {}): DriverFa
       admin,
     }
   }
+}
+
+function concurrencyHolderId(args: TriggerArgs): string | undefined {
+  if (args.runId !== undefined) return args.runId
+  if (args.idempotencyKey !== undefined) return `idem-${args.workflowId}-${args.idempotencyKey}`
+  return undefined
 }
 
 function earliestWakeAt(record: RunRecord): number | undefined {

--- a/packages/workflows-orchestrator/src/index.ts
+++ b/packages/workflows-orchestrator/src/index.ts
@@ -14,6 +14,13 @@ export {
   signalRunAbort,
   unregisterRunAbort,
 } from "./abort-registry.js"
+export {
+  type ConcurrencyRunHooks,
+  createInProcessConcurrencyCoordinator,
+  type InProcessConcurrencyCoordinator,
+  type RuntimeConcurrencyPolicy,
+  WorkflowConcurrencyRejectedError,
+} from "./concurrency.js"
 export { applyWaitpointInjection, type DriveOptions, driveUntilPaused } from "./drive.js"
 export {
   createInMemoryDriver,

--- a/packages/workflows-orchestrator/src/index.ts
+++ b/packages/workflows-orchestrator/src/index.ts
@@ -19,6 +19,7 @@ export {
   createInProcessConcurrencyCoordinator,
   type InProcessConcurrencyCoordinator,
   type RuntimeConcurrencyPolicy,
+  resolveConcurrencyKey,
   WorkflowConcurrencyRejectedError,
 } from "./concurrency.js"
 export { applyWaitpointInjection, type DriveOptions, driveUntilPaused } from "./drive.js"

--- a/packages/workflows-orchestrator/src/orchestrator.ts
+++ b/packages/workflows-orchestrator/src/orchestrator.ts
@@ -71,6 +71,11 @@ export interface TriggerArgs {
    * the child's terminal status cascade-resumes the parent.
    */
   parent?: { runId: string; waitpointId: string }
+  /**
+   * Internal lifecycle hook used by driver-level coordinators that need
+   * the persisted run id before the first invocation starts.
+   */
+  onRunRecordCreated?: (record: RunRecord) => void
 }
 
 export interface OrchestratorDeps extends DriveOptions {
@@ -141,10 +146,12 @@ export async function trigger(args: TriggerArgs, deps: OrchestratorDeps): Promis
       // re-driving — drive() is what actually fires side effects.
       return result.record
     }
+    args.onRunRecordCreated?.(record)
   } else {
     // Persist up-front so concurrent `cancel(runId)` calls can find the
     // run before any invocation has completed.
     await deps.store.save(record)
+    args.onRunRecordCreated?.(record)
   }
   if (delayWakeAt !== undefined) {
     return record

--- a/packages/workflows-orchestrator/src/testing/driver-compliance.ts
+++ b/packages/workflows-orchestrator/src/testing/driver-compliance.ts
@@ -23,6 +23,8 @@ import type { DriverFactory, DriverFactoryDeps, ServiceResolver } from "@voyantj
 import type { WorkflowManifest } from "@voyantjs/workflows/protocol"
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
+import { WorkflowConcurrencyRejectedError } from "../concurrency.js"
+
 /**
  * Tiny in-memory ServiceResolver builder for compliance tests. Lets a test
  * register named services then assert workflow bodies can resolve them via
@@ -117,6 +119,12 @@ export interface DriverComplianceCapabilities {
    * harness intentionally disables or fakes the time wheel.
    */
   autoDatetimeWakeups?: boolean
+  /**
+   * When true, workflow-level `WorkflowConfig.concurrency` is enforced
+   * for in-process workflow definitions. False for Mode 1 / Cloudflare
+   * until it grows a cross-run coordination DO.
+   */
+  workflowConcurrency?: boolean
 }
 
 // ---- The parameterized contract ----
@@ -129,6 +137,7 @@ export function runDriverComplianceSuite(
   const servicesThreading = capabilities.servicesThreading ?? true
   const crossRunQueries = capabilities.crossRunQueries ?? true
   const autoDatetimeWakeups = capabilities.autoDatetimeWakeups ?? false
+  const workflowConcurrency = capabilities.workflowConcurrency ?? true
   describe(`${name} driver compliance`, () => {
     beforeEach(() => {
       __resetRegistry()
@@ -290,6 +299,66 @@ export function runDriverComplianceSuite(
         // callers return the existing record without re-driving.)
         expect(invocationCount).toBeLessThanOrEqual(1)
       })
+
+      test.skipIf(!workflowConcurrency)(
+        "concurrency queue strategy serializes triggers with the same key",
+        async () => {
+          const driver = makeFactory()(testFactoryDeps())
+          const gate = deferred<void>()
+          const started: string[] = []
+          const wf = workflow<{ key: string }, string>({
+            id: uniqueId("compliance-concurrency-queue"),
+            concurrency: {
+              key: (input) => input.key,
+              limit: 1,
+              strategy: "queue",
+            },
+            async run(input) {
+              started.push(input.key)
+              if (started.length === 1) await gate.promise
+              return input.key
+            },
+          })
+
+          const first = driver.trigger(wf, { key: "same" })
+          await vi.waitFor(() => expect(started).toEqual(["same"]))
+          const second = driver.trigger(wf, { key: "same" })
+          await Promise.resolve()
+          expect(started).toEqual(["same"])
+
+          gate.resolve()
+          await Promise.all([first, second])
+          expect(started).toEqual(["same", "same"])
+        },
+      )
+
+      test.skipIf(!workflowConcurrency)(
+        "concurrency cancel-newest strategy rejects overflow triggers",
+        async () => {
+          const driver = makeFactory()(testFactoryDeps())
+          const gate = deferred<void>()
+          const wf = workflow<{ n: number }, number>({
+            id: uniqueId("compliance-concurrency-cancel-newest"),
+            concurrency: {
+              key: "shared",
+              limit: 1,
+              strategy: "cancel-newest",
+            },
+            async run(input) {
+              await gate.promise
+              return input.n
+            },
+          })
+
+          const first = driver.trigger(wf, { n: 1 })
+          await expect(driver.trigger(wf, { n: 2 })).rejects.toBeInstanceOf(
+            WorkflowConcurrencyRejectedError,
+          )
+
+          gate.resolve()
+          await expect(first).resolves.toMatchObject({ status: "completed" })
+        },
+      )
     })
 
     describe("ingestEvent", () => {
@@ -691,4 +760,18 @@ export function runDriverComplianceSuite(
       })
     })
   })
+}
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve(value: T): void
+  reject(error: unknown): void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
 }

--- a/packages/workflows/src/events/manifest-builder.ts
+++ b/packages/workflows/src/events/manifest-builder.ts
@@ -9,11 +9,12 @@
 
 import type {
   EventFilterManifestEntry,
+  ManifestConcurrencyPolicy,
   ManifestSchedule,
   WorkflowManifest,
   WorkflowManifestEntry,
 } from "../protocol/index.js"
-import type { ScheduleDeclaration } from "../workflow.js"
+import type { ConcurrencyPolicy, ScheduleDeclaration } from "../workflow.js"
 import { canonicalJson, shortHash } from "./payload-hash.js"
 import type { EventFilterRuntimeEntry } from "./registry.js"
 
@@ -27,6 +28,7 @@ export interface BuildManifestArgs {
     id: string
     config?: {
       defaultRuntime?: "edge" | "node"
+      concurrency?: ConcurrencyPolicy<unknown>
       retry?: unknown
       timeout?: unknown
       schedule?: ScheduleDeclaration | ScheduleDeclaration[]
@@ -57,6 +59,7 @@ export async function buildManifest(args: BuildManifestArgs): Promise<WorkflowMa
       id: wf.id,
       version: "v1",
       steps: [],
+      concurrency: serializeConcurrency(wf.config?.concurrency),
       schedules: serializeSchedules(wf.config?.schedule),
       defaultRuntime: wf.config?.defaultRuntime ?? "edge",
       hasCompensation: false,
@@ -101,6 +104,17 @@ export async function buildManifest(args: BuildManifestArgs): Promise<WorkflowMa
     ...(draft as Omit<WorkflowManifest, "versionId">),
     versionId,
   }
+}
+
+function serializeConcurrency(
+  concurrency: ConcurrencyPolicy<unknown> | undefined,
+): ManifestConcurrencyPolicy | undefined {
+  if (!concurrency) return undefined
+  const out: ManifestConcurrencyPolicy = {}
+  if (typeof concurrency.key === "string") out.key = concurrency.key
+  if (concurrency.limit !== undefined) out.limit = concurrency.limit
+  if (concurrency.strategy !== undefined) out.strategy = concurrency.strategy
+  return out
 }
 
 function serializeSchedules(

--- a/packages/workflows/src/protocol/index.ts
+++ b/packages/workflows/src/protocol/index.ts
@@ -59,11 +59,18 @@ export interface WorkflowManifestEntry {
   version: string
   inputSchema?: unknown
   outputSchema?: unknown
+  concurrency?: ManifestConcurrencyPolicy
   steps: ManifestStep[]
   schedules: ManifestSchedule[]
   defaultRuntime: "edge" | "node"
   hasCompensation: boolean
   sourceLocation: { file: string; line: number }
+}
+
+export interface ManifestConcurrencyPolicy {
+  key?: string
+  limit?: number
+  strategy?: "queue" | "cancel-in-progress" | "cancel-newest" | "round-robin"
 }
 
 export interface ManifestStep {


### PR DESCRIPTION
## Summary

- serialize `WorkflowConfig.concurrency` into workflow manifests so runtime drivers can see declared policies
- add a shared in-process concurrency coordinator for workflow triggers
- enforce `queue`, `cancel-newest`, `cancel-in-progress`, and `limit` in the InMemory and Node standalone drivers
- add driver compliance coverage plus InMemory regression tests and a changeset

## Notes

This covers the in-process driver shape used by InMemory and Node standalone. Cloudflare edge compliance is explicitly opted out for workflow concurrency until that driver has a cross-run coordination Durable Object instead of one DO per run.

Related to #516.

## Verification

- `pnpm --filter @voyantjs/workflows build`
- `pnpm --filter @voyantjs/workflows-orchestrator test -- src/__tests__/driver-compliance.test.ts src/__tests__/driver-inmemory-concurrency.test.ts`
- `pnpm --filter @voyantjs/workflows-orchestrator build`
- `pnpm --filter @voyantjs/workflows-orchestrator-node build`
- `pnpm --filter @voyantjs/workflows-orchestrator-cloudflare test -- src/__tests__/cloudflare-edge-driver.test.ts`
- `pnpm --filter @voyantjs/hono test -- tests/unit/app-workflows.test.ts`
- `pnpm verify:fast`
- pre-push `pnpm test` passed: 116 successful, 116 total
