### PR TITLE
ui: publish availability page compositions

### DIFF
--- a/.changeset/availability-page-compositions.md
+++ b/.changeset/availability-page-compositions.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/availability-ui": minor
+---
+
+Publish availability page and rule, slot, and start-time detail page compositions with package-level i18n helpers.

--- a/packages/availability-ui/README.md
+++ b/packages/availability-ui/README.md
@@ -1,24 +1,25 @@
 # @voyantjs/availability-ui
 
-Reusable availability UI primitives for Voyant operator/admin apps.
-
-The initial package surface is intentionally leaf-level so downstream apps can
-replace copied availability UI incrementally while page-level composition stays
-app-owned.
+Reusable availability UI primitives and page compositions for Voyant
+operator/admin apps.
 
 ## Exports
 
 | Entry | Description |
 | --- | --- |
 | `.` | Barrel re-exports |
+| `./i18n` | Availability UI message provider, defaults, and helpers |
 | `./components/*` | Availability UI components |
 | `./utils` | Small formatting helpers |
 
 ## Surface
 
-The package exports reusable pieces that keep app-owned data fetching,
-routing, and mutations injected through props:
+The package exports reusable pieces that keep app-owned routing and the
+availability batch mutations injected through props:
 
+- `AvailabilityPage`
+- `AvailabilityRuleDetailPage`, `AvailabilitySlotDetailPage`,
+  `AvailabilityStartTimeDetailPage`
 - `AvailabilityOverview`
 - `AvailabilitySlotsTab`, `AvailabilityRulesTab`, `AvailabilityStartTimesTab`
 - `AvailabilityCloseoutsTab`, `AvailabilityPickupPointsTab`
@@ -27,9 +28,78 @@ routing, and mutations injected through props:
 - `AvailabilityPageSkeleton`, `AvailabilityBodySkeleton`, detail skeletons
 - `availability*Columns` table column builders
 - `AvailabilitySectionHeader`
+- `AvailabilityUiMessagesProvider` and i18n helpers from `./i18n`
 - `formatLocalizedSelectionLabel`
 
 ## Usage
+
+`AvailabilityPage` owns the common operator availability shell, data hooks,
+filters, overview metrics, table tabs, calendar tab, and rule/slot/start-time
+dialogs. Route navigation and batch mutations stay app-specific:
+
+```tsx
+import { AvailabilityPage } from "@voyantjs/availability-ui"
+
+<AvailabilityPage
+  onSlotOpen={(id) => navigate({ to: "/availability/$id", params: { id } })}
+  onRuleOpen={(id) => navigate({ to: "/availability/rules/$id", params: { id } })}
+  onStartTimeOpen={(id) =>
+    navigate({ to: "/availability/start-times/$id", params: { id } })
+  }
+  onProductOpen={(id) => navigate({ to: "/products/$id", params: { id } })}
+  onBulkUpdate={handleAvailabilityBulkUpdate}
+  onBulkDelete={handleAvailabilityBulkDelete}
+/>
+```
+
+Closeout and pickup-point mutations are not owned by `availability-react` yet.
+Pass `onCloseoutSubmit` and `onPickupPointSubmit` to use the package dialogs, or
+use the `slots.dialogs` escape hatch to render app-owned dialogs.
+
+Detail pages expose query/loader helpers that accept the app's API client:
+
+```tsx
+import {
+  AvailabilitySlotDetailPage,
+  loadAvailabilitySlotDetailPage,
+} from "@voyantjs/availability-ui"
+import { defaultFetcher } from "@voyantjs/availability-react"
+
+const client = { baseUrl: getApiUrl(), fetcher: defaultFetcher }
+
+export const Route = createFileRoute("/_workspace/availability/$id")({
+  loader: ({ context, params }) =>
+    loadAvailabilitySlotDetailPage(context.queryClient, client, params.id),
+  component: () => {
+    const { id } = Route.useParams()
+    return (
+      <AvailabilitySlotDetailPage
+        id={id}
+        onBack={() => navigate({ to: "/availability" })}
+        onOpenProduct={(productId) =>
+          navigate({ to: "/products/$id", params: { id: productId } })
+        }
+        onOpenStartTime={(startTimeId) =>
+          navigate({ to: "/availability/start-times/$id", params: { id: startTimeId } })
+        }
+      />
+    )
+  },
+})
+```
+
+Wrap consumers in `AvailabilityUiMessagesProvider` for package-level copy and
+locale-aware formatting. Without a provider the package falls back to English.
+
+```tsx
+import { AvailabilityUiMessagesProvider } from "@voyantjs/availability-ui/i18n"
+
+<AvailabilityUiMessagesProvider locale={resolvedLocale}>
+  <AvailabilityPage onBulkUpdate={handleBulkUpdate} onBulkDelete={handleBulkDelete} />
+</AvailabilityUiMessagesProvider>
+```
+
+Leaf components remain available for custom page shells:
 
 ```tsx
 import { AvailabilitySectionHeader } from "@voyantjs/availability-ui"

--- a/packages/availability-ui/package.json
+++ b/packages/availability-ui/package.json
@@ -28,7 +28,6 @@
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-query": "^5.90.12",
     "@voyantjs/availability-react": "workspace:*",
-    "@voyantjs/i18n": "workspace:*",
     "@voyantjs/ui": "workspace:*",
     "lucide-react": "^0.475.0",
     "react": "^19.0.0",
@@ -52,6 +51,9 @@
     "typescript": "^6.0.2",
     "vitest": "^4.1.2",
     "zod": "^4.3.6"
+  },
+  "dependencies": {
+    "@voyantjs/i18n": "workspace:*"
   },
   "files": [
     "dist",

--- a/packages/availability-ui/package.json
+++ b/packages/availability-ui/package.json
@@ -11,6 +11,7 @@
   "sideEffects": false,
   "exports": {
     ".": "./src/index.ts",
+    "./i18n": "./src/i18n/index.ts",
     "./styles.css": "./src/styles.css",
     "./components/*": "./src/components/*.tsx",
     "./utils": "./src/utils.ts"
@@ -25,7 +26,9 @@
   },
   "peerDependencies": {
     "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-query": "^5.90.12",
     "@voyantjs/availability-react": "workspace:*",
+    "@voyantjs/i18n": "workspace:*",
     "@voyantjs/ui": "workspace:*",
     "lucide-react": "^0.475.0",
     "react": "^19.0.0",
@@ -35,9 +38,11 @@
   },
   "devDependencies": {
     "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-query": "^5.90.12",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@voyantjs/availability-react": "workspace:*",
+    "@voyantjs/i18n": "workspace:*",
     "@voyantjs/ui": "workspace:*",
     "@voyantjs/voyant-typescript-config": "workspace:*",
     "lucide-react": "^1.7.0",
@@ -59,6 +64,11 @@
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js",
         "default": "./dist/index.js"
+      },
+      "./i18n": {
+        "types": "./dist/i18n/index.d.ts",
+        "import": "./dist/i18n/index.js",
+        "default": "./dist/i18n/index.js"
       },
       "./styles.css": {
         "default": "./src/styles.css"

--- a/packages/availability-ui/src/components/availability-page.tsx
+++ b/packages/availability-ui/src/components/availability-page.tsx
@@ -1,0 +1,797 @@
+"use client"
+
+import { useQueryClient } from "@tanstack/react-query"
+import type { RowSelectionState } from "@tanstack/react-table"
+import {
+  type AvailabilityCloseoutRow,
+  type AvailabilityPickupPointRow,
+  type AvailabilityRuleRow,
+  type AvailabilitySlotRow,
+  type AvailabilityStartTimeRow,
+  availabilityQueryKeys,
+  type CreateAvailabilityRuleInput,
+  type CreateAvailabilitySlotInput,
+  type CreateAvailabilityStartTimeInput,
+  type ProductOption,
+  type UpdateAvailabilityRuleInput,
+  type UpdateAvailabilitySlotInput,
+  type UpdateAvailabilityStartTimeInput,
+  useAvailabilityRuleMutation,
+  useAvailabilitySlotMutation,
+  useAvailabilityStartTimeMutation,
+  useCloseouts,
+  usePickupPoints,
+  useProducts,
+  useRules,
+  useSlots,
+  useStartTimes,
+} from "@voyantjs/availability-react"
+import { Button, cn, Label } from "@voyantjs/ui/components"
+import { AsyncCombobox } from "@voyantjs/ui/components/async-combobox"
+import {
+  CalendarProvider,
+  CalendarView,
+  type IEvent,
+  type TCalendarView,
+} from "@voyantjs/ui/components/big-calendar"
+import { DateRangePicker, type DateRangeValue } from "@voyantjs/ui/components/date-picker"
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@voyantjs/ui/components/select"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@voyantjs/ui/components/tabs"
+import type { ReactNode } from "react"
+import { useState } from "react"
+
+import { useAvailabilityUiMessagesOrDefault } from "../i18n/index.js"
+import {
+  AvailabilityCloseoutDialog,
+  type AvailabilityCloseoutSubmitPayload,
+  AvailabilityPickupPointDialog,
+  type AvailabilityPickupPointSubmitPayload,
+  AvailabilityRuleDialog,
+  type AvailabilityRuleSubmitPayload,
+  AvailabilitySlotDialog,
+  type AvailabilitySlotSubmitPayload,
+  AvailabilityStartTimeDialog,
+  type AvailabilityStartTimeSubmitPayload,
+} from "./availability-dialogs.js"
+import { AvailabilityOverview } from "./availability-overview.js"
+import { AvailabilityBodySkeleton } from "./availability-skeletons.js"
+import {
+  type AvailabilityBulkDeleteFn,
+  type AvailabilityBulkUpdateFn,
+  AvailabilityCloseoutsTab,
+  AvailabilityPickupPointsTab,
+  AvailabilityRulesTab,
+  AvailabilitySlotsTab,
+  AvailabilityStartTimesTab,
+} from "./availability-tabs.js"
+
+export type AvailabilityPageTab =
+  | "slots"
+  | "rules"
+  | "start-times"
+  | "closeouts"
+  | "pickup-points"
+  | "calendar"
+
+export type AvailabilityPageActiveFilter = "all" | "active" | "inactive"
+export type AvailabilityPageSlotStatusFilter = "all" | AvailabilitySlotRow["status"]
+
+export type AvailabilityPageBulkUpdateHandler = AvailabilityBulkUpdateFn
+export type AvailabilityPageBulkDeleteHandler = AvailabilityBulkDeleteFn
+
+type DialogSubmitContext = { isEditing: boolean; id?: string }
+
+export type AvailabilityPageRuleSubmitHandler = (
+  payload: AvailabilityRuleSubmitPayload,
+  context: DialogSubmitContext,
+) => Promise<void>
+
+export type AvailabilityPageStartTimeSubmitHandler = (
+  payload: AvailabilityStartTimeSubmitPayload,
+  context: DialogSubmitContext,
+) => Promise<void>
+
+export type AvailabilityPageSlotSubmitHandler = (
+  payload: AvailabilitySlotSubmitPayload,
+  context: DialogSubmitContext,
+) => Promise<void>
+
+export type AvailabilityPageCloseoutSubmitHandler = (
+  payload: AvailabilityCloseoutSubmitPayload,
+  context: DialogSubmitContext,
+) => Promise<void>
+
+export type AvailabilityPagePickupPointSubmitHandler = (
+  payload: AvailabilityPickupPointSubmitPayload,
+  context: DialogSubmitContext,
+) => Promise<void>
+
+export interface AvailabilityPageSlots {
+  headerEnd?: ReactNode
+  beforeOverview?: ReactNode
+  afterOverview?: ReactNode
+  beforeTabs?: ReactNode
+  afterTabs?: ReactNode
+  dialogs?: ReactNode
+}
+
+export interface AvailabilityPageProps {
+  className?: string
+  defaultTab?: AvailabilityPageTab
+  bulkActionTarget?: string | null
+  onBulkUpdate: AvailabilityPageBulkUpdateHandler
+  onBulkDelete: AvailabilityPageBulkDeleteHandler
+  onSlotOpen?: (slotId: string) => void
+  onRuleOpen?: (ruleId: string) => void
+  onStartTimeOpen?: (startTimeId: string) => void
+  onProductOpen?: (productId: string) => void
+  onCloseoutCreate?: () => void
+  onCloseoutEdit?: (closeout: AvailabilityCloseoutRow) => void
+  onPickupPointCreate?: () => void
+  onPickupPointEdit?: (pickupPoint: AvailabilityPickupPointRow) => void
+  onRuleSubmit?: AvailabilityPageRuleSubmitHandler
+  onStartTimeSubmit?: AvailabilityPageStartTimeSubmitHandler
+  onSlotSubmit?: AvailabilityPageSlotSubmitHandler
+  onCloseoutSubmit?: AvailabilityPageCloseoutSubmitHandler
+  onPickupPointSubmit?: AvailabilityPagePickupPointSubmitHandler
+  slots?: AvailabilityPageSlots
+}
+
+const noop = () => undefined
+const noopId = (_id: string) => undefined
+const noopCloseout = (_row: AvailabilityCloseoutRow) => undefined
+const noopPickupPoint = (_row: AvailabilityPickupPointRow) => undefined
+
+export function AvailabilityPage({
+  className,
+  defaultTab = "slots",
+  bulkActionTarget = null,
+  onBulkUpdate,
+  onBulkDelete,
+  onSlotOpen = noopId,
+  onRuleOpen = noopId,
+  onStartTimeOpen = noopId,
+  onProductOpen = noopId,
+  onCloseoutCreate = noop,
+  onCloseoutEdit = noopCloseout,
+  onPickupPointCreate = noop,
+  onPickupPointEdit = noopPickupPoint,
+  onRuleSubmit,
+  onStartTimeSubmit,
+  onSlotSubmit,
+  onCloseoutSubmit,
+  onPickupPointSubmit,
+  slots: pageSlots,
+}: AvailabilityPageProps) {
+  const messages = useAvailabilityUiMessagesOrDefault()
+  const page = messages.page
+  const queryClient = useQueryClient()
+  const ruleMutation = useAvailabilityRuleMutation()
+  const startTimeMutation = useAvailabilityStartTimeMutation()
+  const slotMutation = useAvailabilitySlotMutation()
+  const [productFilter, setProductFilter] = useState("all")
+  const [productSearch, setProductSearch] = useState("")
+  const [slotStatusFilter, setSlotStatusFilter] = useState<AvailabilityPageSlotStatusFilter>("all")
+  const [slotDateRange, setSlotDateRange] = useState<DateRangeValue | null>(null)
+  const [ruleActiveFilter, setRuleActiveFilter] = useState<AvailabilityPageActiveFilter>("all")
+  const [startTimeActiveFilter, setStartTimeActiveFilter] =
+    useState<AvailabilityPageActiveFilter>("all")
+  const [closeoutDateRange, setCloseoutDateRange] = useState<DateRangeValue | null>(null)
+  const [pickupPointActiveFilter, setPickupPointActiveFilter] =
+    useState<AvailabilityPageActiveFilter>("all")
+  const [activeTab, setActiveTab] = useState<AvailabilityPageTab>(defaultTab)
+  const [calendarView, setCalendarView] = useState<TCalendarView>("month")
+  const [ruleSelection, setRuleSelection] = useState<RowSelectionState>({})
+  const [startTimeSelection, setStartTimeSelection] = useState<RowSelectionState>({})
+  const [slotSelection, setSlotSelection] = useState<RowSelectionState>({})
+  const [closeoutSelection, setCloseoutSelection] = useState<RowSelectionState>({})
+  const [pickupPointSelection, setPickupPointSelection] = useState<RowSelectionState>({})
+  const [ruleDialogOpen, setRuleDialogOpen] = useState(false)
+  const [startTimeDialogOpen, setStartTimeDialogOpen] = useState(false)
+  const [slotDialogOpen, setSlotDialogOpen] = useState(false)
+  const [closeoutDialogOpen, setCloseoutDialogOpen] = useState(false)
+  const [pickupPointDialogOpen, setPickupPointDialogOpen] = useState(false)
+  const [editingRule, setEditingRule] = useState<AvailabilityRuleRow | undefined>()
+  const [editingStartTime, setEditingStartTime] = useState<AvailabilityStartTimeRow | undefined>()
+  const [editingSlot, setEditingSlot] = useState<AvailabilitySlotRow | undefined>()
+  const [editingCloseout, setEditingCloseout] = useState<AvailabilityCloseoutRow | undefined>()
+  const [editingPickupPoint, setEditingPickupPoint] = useState<
+    AvailabilityPickupPointRow | undefined
+  >()
+
+  const productsQuery = useProducts({ search: productSearch || undefined, limit: 25, offset: 0 })
+  const rulesQuery = useRules({ limit: 25, offset: 0 })
+  const startTimesQuery = useStartTimes({ limit: 25, offset: 0 })
+  const slotsQuery = useSlots({ limit: 25, offset: 0 })
+  const closeoutsQuery = useCloseouts({ limit: 25, offset: 0 })
+  const pickupPointsQuery = usePickupPoints({ limit: 25, offset: 0 })
+
+  const products = productsQuery.data?.data ?? []
+  const rules = rulesQuery.data?.data ?? []
+  const startTimes = startTimesQuery.data?.data ?? []
+  const availabilitySlots = slotsQuery.data?.data ?? []
+  const closeouts = closeoutsQuery.data?.data ?? []
+  const pickupPoints = pickupPointsQuery.data?.data ?? []
+
+  const matchesProduct = (productId: string) =>
+    productFilter === "all" || productId === productFilter
+  const matchesActive = (active: boolean, filter: AvailabilityPageActiveFilter) =>
+    filter === "all" || (filter === "active" ? active : !active)
+  const matchesDateRange = (date: string, range: DateRangeValue | null) =>
+    (!range?.from || date >= range.from) && (!range?.to || date <= range.to)
+
+  const filteredRules = rules.filter(
+    (rule) => matchesProduct(rule.productId) && matchesActive(rule.active, ruleActiveFilter),
+  )
+  const filteredStartTimes = startTimes.filter(
+    (startTime) =>
+      matchesProduct(startTime.productId) && matchesActive(startTime.active, startTimeActiveFilter),
+  )
+  const productFilteredSlots = availabilitySlots.filter((slot) => matchesProduct(slot.productId))
+  const filteredSlots = productFilteredSlots.filter(
+    (slot) =>
+      (slotStatusFilter === "all" || slot.status === slotStatusFilter) &&
+      matchesDateRange(slot.dateLocal, slotDateRange),
+  )
+  const filteredCloseouts = closeouts.filter(
+    (closeout) =>
+      matchesProduct(closeout.productId) && matchesDateRange(closeout.dateLocal, closeoutDateRange),
+  )
+  const filteredPickupPoints = pickupPoints.filter(
+    (pickupPoint) =>
+      matchesProduct(pickupPoint.productId) &&
+      matchesActive(pickupPoint.active, pickupPointActiveFilter),
+  )
+  const filteredProducts = products.filter(
+    (product) => productFilter === "all" || product.id === productFilter,
+  )
+  const constrainedSlots = [...filteredSlots]
+    .filter((slot) => slot.status === "sold_out" || slot.status === "closed")
+    .sort((left, right) => left.startsAt.localeCompare(right.startsAt))
+  const nowIso = new Date().toISOString()
+  const productsWithoutUpcomingDepartures = filteredProducts.filter(
+    (product) =>
+      !productFilteredSlots.some(
+        (slot) =>
+          slot.productId === product.id && slot.status === "open" && slot.startsAt >= nowIso,
+      ),
+  )
+  const hasFilters = productFilter !== "all"
+  const selectedProduct = products.find((product) => product.id === productFilter) ?? null
+
+  const slotStatusToColor: Record<AvailabilitySlotRow["status"], IEvent["color"]> = {
+    open: "green",
+    closed: "gray",
+    sold_out: "red",
+    cancelled: "yellow",
+  }
+  const calendarEvents: IEvent[] = filteredSlots.map((slot) => {
+    const productName = products.find((product) => product.id === slot.productId)?.name
+    return {
+      id: slot.id,
+      startDate: slot.startsAt,
+      endDate: slot.endsAt ?? slot.startsAt,
+      title: productName ?? slot.productName ?? messages.tabs.slots.title,
+      description: slot.notes ?? "",
+      color: slotStatusToColor[slot.status],
+    }
+  })
+
+  const queries = [
+    productsQuery,
+    rulesQuery,
+    startTimesQuery,
+    slotsQuery,
+    closeoutsQuery,
+    pickupPointsQuery,
+  ]
+  const isLoading = queries.some((query) => query.isPending)
+  const isError = queries.some((query) => query.isError)
+
+  const refreshAll = async () => {
+    await queryClient.invalidateQueries({ queryKey: availabilityQueryKeys.all })
+  }
+
+  const handleRuleSubmit: AvailabilityPageRuleSubmitHandler =
+    onRuleSubmit ??
+    (async (payload, context) => {
+      if (context.isEditing) {
+        await ruleMutation.update.mutateAsync({
+          id: requireEditingId(context),
+          input: payload as UpdateAvailabilityRuleInput,
+        })
+        return
+      }
+
+      await ruleMutation.create.mutateAsync(payload as CreateAvailabilityRuleInput)
+    })
+
+  const handleStartTimeSubmit: AvailabilityPageStartTimeSubmitHandler =
+    onStartTimeSubmit ??
+    (async (payload, context) => {
+      if (context.isEditing) {
+        await startTimeMutation.update.mutateAsync({
+          id: requireEditingId(context),
+          input: payload as UpdateAvailabilityStartTimeInput,
+        })
+        return
+      }
+
+      await startTimeMutation.create.mutateAsync(payload as CreateAvailabilityStartTimeInput)
+    })
+
+  const handleSlotSubmit: AvailabilityPageSlotSubmitHandler =
+    onSlotSubmit ??
+    (async (payload, context) => {
+      if (context.isEditing) {
+        await slotMutation.update.mutateAsync({
+          id: requireEditingId(context),
+          input: payload as UpdateAvailabilitySlotInput,
+        })
+        return
+      }
+
+      await slotMutation.create.mutateAsync(payload as CreateAvailabilitySlotInput)
+    })
+
+  const closeRuleDialog = () => {
+    setRuleDialogOpen(false)
+    setEditingRule(undefined)
+  }
+  const closeStartTimeDialog = () => {
+    setStartTimeDialogOpen(false)
+    setEditingStartTime(undefined)
+  }
+  const closeSlotDialog = () => {
+    setSlotDialogOpen(false)
+    setEditingSlot(undefined)
+  }
+  const closeCloseoutDialog = () => {
+    setCloseoutDialogOpen(false)
+    setEditingCloseout(undefined)
+  }
+  const closePickupPointDialog = () => {
+    setPickupPointDialogOpen(false)
+    setEditingPickupPoint(undefined)
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-6 p-6", className)}>
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">{messages.title}</h1>
+          <p className="text-sm text-muted-foreground">{messages.description}</p>
+        </div>
+        <div className="flex w-full flex-col gap-3 md:w-72">
+          <AsyncCombobox<ProductOption>
+            value={productFilter === "all" ? null : productFilter}
+            onChange={(value) => setProductFilter(value ?? "all")}
+            items={products}
+            selectedItem={selectedProduct}
+            getKey={(product) => product.id}
+            getLabel={(product) => product.name}
+            onSearchChange={setProductSearch}
+            placeholder={messages.allProducts}
+            emptyText={productsQuery.isFetching ? page.loading : page.filters.productSearchEmpty}
+            triggerClassName="w-full"
+          />
+          {pageSlots?.headerEnd}
+        </div>
+      </div>
+
+      {isLoading ? (
+        <AvailabilityBodySkeleton />
+      ) : isError ? (
+        <div className="rounded-md border p-6 text-sm text-muted-foreground">{page.loadFailed}</div>
+      ) : (
+        <>
+          {pageSlots?.beforeOverview}
+          <AvailabilityOverview
+            messages={messages}
+            products={products}
+            constrainedSlots={constrainedSlots}
+            openSlotsCount={filteredSlots.filter((slot) => slot.status === "open").length}
+            filteredRules={filteredRules}
+            filteredPickupPoints={filteredPickupPoints}
+            productsWithoutUpcomingDepartures={productsWithoutUpcomingDepartures}
+            search=""
+            setSearch={() => {}}
+            productFilter={productFilter}
+            setProductFilter={setProductFilter}
+            hasFilters={hasFilters}
+            onClearFilters={() => setProductFilter("all")}
+            onOpenSlot={onSlotOpen}
+            onOpenProduct={onProductOpen}
+            onJumpToSlots={() => setActiveTab("slots")}
+            showFilters={false}
+          />
+          {pageSlots?.afterOverview}
+          {pageSlots?.beforeTabs}
+
+          <Tabs
+            value={activeTab}
+            onValueChange={(value) => setActiveTab((value ?? "slots") as AvailabilityPageTab)}
+          >
+            <TabsList className="flex w-full justify-start overflow-x-auto">
+              <TabsTrigger value="slots">{messages.tabSlots}</TabsTrigger>
+              <TabsTrigger value="rules">{messages.tabRules}</TabsTrigger>
+              <TabsTrigger value="start-times">{messages.tabStartTimes}</TabsTrigger>
+              <TabsTrigger value="closeouts">{messages.tabCloseouts}</TabsTrigger>
+              <TabsTrigger value="pickup-points">{messages.tabPickupPoints}</TabsTrigger>
+              <TabsTrigger value="calendar">{page.calendarTab}</TabsTrigger>
+            </TabsList>
+
+            <AvailabilitySlotsTab
+              messages={messages}
+              products={products}
+              filteredSlots={filteredSlots}
+              slotSelection={slotSelection}
+              setSlotSelection={setSlotSelection}
+              bulkActionTarget={bulkActionTarget}
+              handleBulkUpdate={onBulkUpdate}
+              handleBulkDelete={onBulkDelete}
+              onCreate={() => {
+                setEditingSlot(undefined)
+                setSlotDialogOpen(true)
+              }}
+              onOpenRoute={onSlotOpen}
+              onEdit={(row) => {
+                setEditingSlot(row)
+                setSlotDialogOpen(true)
+              }}
+              toolbar={
+                <SlotsToolbar
+                  value={slotStatusFilter}
+                  onValueChange={setSlotStatusFilter}
+                  dateRange={slotDateRange}
+                  onDateRangeChange={setSlotDateRange}
+                />
+              }
+            />
+            <AvailabilityRulesTab
+              messages={messages}
+              products={products}
+              filteredRules={filteredRules}
+              ruleSelection={ruleSelection}
+              setRuleSelection={setRuleSelection}
+              bulkActionTarget={bulkActionTarget}
+              handleBulkUpdate={onBulkUpdate}
+              handleBulkDelete={onBulkDelete}
+              onCreate={() => {
+                setEditingRule(undefined)
+                setRuleDialogOpen(true)
+              }}
+              onOpenRoute={onRuleOpen}
+              onEdit={(row) => {
+                setEditingRule(row)
+                setRuleDialogOpen(true)
+              }}
+              toolbar={
+                <ActiveToolbar value={ruleActiveFilter} onValueChange={setRuleActiveFilter} />
+              }
+            />
+            <AvailabilityStartTimesTab
+              messages={messages}
+              products={products}
+              filteredStartTimes={filteredStartTimes}
+              startTimeSelection={startTimeSelection}
+              setStartTimeSelection={setStartTimeSelection}
+              bulkActionTarget={bulkActionTarget}
+              handleBulkUpdate={onBulkUpdate}
+              handleBulkDelete={onBulkDelete}
+              onCreate={() => {
+                setEditingStartTime(undefined)
+                setStartTimeDialogOpen(true)
+              }}
+              onOpenRoute={onStartTimeOpen}
+              onEdit={(row) => {
+                setEditingStartTime(row)
+                setStartTimeDialogOpen(true)
+              }}
+              toolbar={
+                <ActiveToolbar
+                  value={startTimeActiveFilter}
+                  onValueChange={setStartTimeActiveFilter}
+                />
+              }
+            />
+            <AvailabilityCloseoutsTab
+              messages={messages}
+              products={products}
+              filteredCloseouts={filteredCloseouts}
+              closeoutSelection={closeoutSelection}
+              setCloseoutSelection={setCloseoutSelection}
+              bulkActionTarget={bulkActionTarget}
+              handleBulkDelete={onBulkDelete}
+              onCreate={
+                onCloseoutSubmit
+                  ? () => {
+                      setEditingCloseout(undefined)
+                      setCloseoutDialogOpen(true)
+                    }
+                  : onCloseoutCreate
+              }
+              onEdit={(row) => {
+                if (onCloseoutSubmit) {
+                  setEditingCloseout(row)
+                  setCloseoutDialogOpen(true)
+                  return
+                }
+
+                onCloseoutEdit(row)
+              }}
+              toolbar={
+                <DateRangeToolbar value={closeoutDateRange} onValueChange={setCloseoutDateRange} />
+              }
+            />
+            <AvailabilityPickupPointsTab
+              messages={messages}
+              products={products}
+              filteredPickupPoints={filteredPickupPoints}
+              pickupPointSelection={pickupPointSelection}
+              setPickupPointSelection={setPickupPointSelection}
+              bulkActionTarget={bulkActionTarget}
+              handleBulkUpdate={onBulkUpdate}
+              handleBulkDelete={onBulkDelete}
+              onCreate={
+                onPickupPointSubmit
+                  ? () => {
+                      setEditingPickupPoint(undefined)
+                      setPickupPointDialogOpen(true)
+                    }
+                  : onPickupPointCreate
+              }
+              onEdit={(row) => {
+                if (onPickupPointSubmit) {
+                  setEditingPickupPoint(row)
+                  setPickupPointDialogOpen(true)
+                  return
+                }
+
+                onPickupPointEdit(row)
+              }}
+              toolbar={
+                <ActiveToolbar
+                  value={pickupPointActiveFilter}
+                  onValueChange={setPickupPointActiveFilter}
+                />
+              }
+            />
+            <TabsContent value="calendar" className="flex flex-col gap-4">
+              <CalendarProvider
+                events={calendarEvents}
+                onEventClick={(event) => onSlotOpen(event.id)}
+              >
+                <CalendarView
+                  view={calendarView}
+                  onViewChange={setCalendarView}
+                  onDayClick={() => setCalendarView("day")}
+                />
+              </CalendarProvider>
+            </TabsContent>
+          </Tabs>
+          {pageSlots?.afterTabs}
+        </>
+      )}
+
+      <AvailabilityRuleDialog
+        messages={messages}
+        open={ruleDialogOpen}
+        onOpenChange={setRuleDialogOpen}
+        rule={editingRule}
+        products={products}
+        onSubmit={handleRuleSubmit}
+        onSuccess={() => {
+          closeRuleDialog()
+          void refreshAll()
+        }}
+      />
+      <AvailabilityStartTimeDialog
+        messages={messages}
+        open={startTimeDialogOpen}
+        onOpenChange={setStartTimeDialogOpen}
+        startTime={editingStartTime}
+        products={products}
+        onSubmit={handleStartTimeSubmit}
+        onSuccess={() => {
+          closeStartTimeDialog()
+          void refreshAll()
+        }}
+      />
+      <AvailabilitySlotDialog
+        messages={messages}
+        open={slotDialogOpen}
+        onOpenChange={setSlotDialogOpen}
+        slot={editingSlot}
+        products={products}
+        rules={rules}
+        startTimes={startTimes}
+        onSubmit={handleSlotSubmit}
+        onSuccess={() => {
+          closeSlotDialog()
+          void refreshAll()
+        }}
+      />
+      {onCloseoutSubmit ? (
+        <AvailabilityCloseoutDialog
+          messages={messages}
+          open={closeoutDialogOpen}
+          onOpenChange={setCloseoutDialogOpen}
+          closeout={editingCloseout}
+          products={products}
+          slots={availabilitySlots}
+          onSubmit={onCloseoutSubmit}
+          onSuccess={() => {
+            closeCloseoutDialog()
+            void refreshAll()
+          }}
+        />
+      ) : null}
+      {onPickupPointSubmit ? (
+        <AvailabilityPickupPointDialog
+          messages={messages}
+          open={pickupPointDialogOpen}
+          onOpenChange={setPickupPointDialogOpen}
+          pickupPoint={editingPickupPoint}
+          products={products}
+          onSubmit={onPickupPointSubmit}
+          onSuccess={() => {
+            closePickupPointDialog()
+            void refreshAll()
+          }}
+        />
+      ) : null}
+      {pageSlots?.dialogs}
+    </div>
+  )
+}
+
+function requireEditingId(context: DialogSubmitContext) {
+  if (!context.id) throw new Error("AvailabilityPage edit submit requires an id.")
+  return context.id
+}
+
+function SlotsToolbar({
+  value,
+  onValueChange,
+  dateRange,
+  onDateRangeChange,
+}: {
+  value: AvailabilityPageSlotStatusFilter
+  onValueChange: (value: AvailabilityPageSlotStatusFilter) => void
+  dateRange: DateRangeValue | null
+  onDateRangeChange: (value: DateRangeValue | null) => void
+}) {
+  const messages = useAvailabilityUiMessagesOrDefault()
+  const page = messages.page
+  const hasFilters = value !== "all" || Boolean(dateRange?.from) || Boolean(dateRange?.to)
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="availability-slot-status" className="text-xs">
+          {page.filters.statusLabel}
+        </Label>
+        <Select
+          value={value}
+          onValueChange={(nextValue) =>
+            onValueChange((nextValue ?? "all") as AvailabilityPageSlotStatusFilter)
+          }
+        >
+          <SelectTrigger id="availability-slot-status" className="w-full sm:w-44">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              <SelectItem value="all">{page.filters.allStatuses}</SelectItem>
+              <SelectItem value="open">{messages.statusOpen}</SelectItem>
+              <SelectItem value="closed">{messages.statusClosed}</SelectItem>
+              <SelectItem value="sold_out">{messages.statusSoldOut}</SelectItem>
+              <SelectItem value="cancelled">{messages.statusCancelled}</SelectItem>
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <Label className="text-xs">{page.filters.dateRangeLabel}</Label>
+        <DateRangePicker
+          value={dateRange}
+          onChange={onDateRangeChange}
+          className="w-full sm:w-72"
+          placeholder={page.filters.anyDate}
+        />
+      </div>
+      {hasFilters ? (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            onValueChange("all")
+            onDateRangeChange(null)
+          }}
+        >
+          {page.filters.reset}
+        </Button>
+      ) : null}
+    </div>
+  )
+}
+
+function DateRangeToolbar({
+  value,
+  onValueChange,
+}: {
+  value: DateRangeValue | null
+  onValueChange: (value: DateRangeValue | null) => void
+}) {
+  const page = useAvailabilityUiMessagesOrDefault().page
+  const hasFilters = Boolean(value?.from) || Boolean(value?.to)
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
+      <div className="flex flex-col gap-1.5">
+        <Label className="text-xs">{page.filters.dateRangeLabel}</Label>
+        <DateRangePicker
+          value={value}
+          onChange={onValueChange}
+          className="w-full sm:w-72"
+          placeholder={page.filters.anyDate}
+        />
+      </div>
+      {hasFilters ? (
+        <Button variant="outline" size="sm" onClick={() => onValueChange(null)}>
+          {page.filters.reset}
+        </Button>
+      ) : null}
+    </div>
+  )
+}
+
+function ActiveToolbar({
+  value,
+  onValueChange,
+}: {
+  value: AvailabilityPageActiveFilter
+  onValueChange: (value: AvailabilityPageActiveFilter) => void
+}) {
+  const page = useAvailabilityUiMessagesOrDefault().page
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="availability-active-filter" className="text-xs">
+          {page.filters.stateLabel}
+        </Label>
+        <Select
+          value={value}
+          onValueChange={(nextValue) =>
+            onValueChange((nextValue ?? "all") as AvailabilityPageActiveFilter)
+          }
+        >
+          <SelectTrigger id="availability-active-filter" className="w-full sm:w-44">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              <SelectItem value="all">{page.filters.allStates}</SelectItem>
+              <SelectItem value="active">{page.filters.active}</SelectItem>
+              <SelectItem value="inactive">{page.filters.inactive}</SelectItem>
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </div>
+      {value !== "all" ? (
+        <Button variant="outline" size="sm" onClick={() => onValueChange("all")}>
+          {page.filters.reset}
+        </Button>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/availability-ui/src/components/availability-rule-detail-page.tsx
+++ b/packages/availability-ui/src/components/availability-rule-detail-page.tsx
@@ -1,0 +1,283 @@
+"use client"
+
+import type { QueryClient } from "@tanstack/react-query"
+import { queryOptions, useQuery } from "@tanstack/react-query"
+import {
+  type AvailabilityRuleRow,
+  type AvailabilitySlotRow,
+  availabilityQueryKeys,
+  availabilityRuleSingleResponse,
+  fetchWithValidation,
+  formatDateTime,
+  getProductQueryOptions,
+  getSlotsQueryOptions,
+  useAvailabilityRuleMutation,
+  useVoyantAvailabilityContext,
+  type VoyantAvailabilityContextValue,
+} from "@voyantjs/availability-react"
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  cn,
+} from "@voyantjs/ui/components"
+import { ArrowLeft, CalendarDays, Package, Trash2 } from "lucide-react"
+
+import { useAvailabilityUiMessagesOrDefault } from "../i18n/index.js"
+import { getSlotStatusLabel } from "./availability-columns.js"
+import { AvailabilityRuleDetailSkeleton } from "./availability-skeletons.js"
+
+export interface AvailabilityRuleDetailPageProps {
+  id: string
+  className?: string
+  onBack?: () => void
+  onDeleted?: () => void
+  onOpenProduct?: (productId: string) => void
+  onOpenSlot?: (slotId: string) => void
+  confirmAction?: (message: string) => boolean
+}
+
+export function getAvailabilityRuleDetailQueryOptions(
+  client: VoyantAvailabilityContextValue,
+  id: string | null | undefined,
+) {
+  return queryOptions({
+    queryKey: availabilityQueryKeys.ruleDetail(id ?? ""),
+    queryFn: async () => {
+      if (!id) throw new Error("getAvailabilityRuleDetailQueryOptions requires an id")
+      return fetchWithValidation(
+        `/v1/availability/rules/${id}`,
+        availabilityRuleSingleResponse,
+        client,
+      )
+    },
+  })
+}
+
+export function getAvailabilityRuleSlotsQueryOptions(
+  client: VoyantAvailabilityContextValue,
+  id: string | null | undefined,
+) {
+  return getSlotsQueryOptions(client, { availabilityRuleId: id ?? undefined, limit: 25, offset: 0 })
+}
+
+export async function loadAvailabilityRuleDetailPage(
+  queryClient: QueryClient,
+  client: VoyantAvailabilityContextValue,
+  id: string,
+) {
+  const ruleData = await queryClient.ensureQueryData(
+    getAvailabilityRuleDetailQueryOptions(client, id),
+  )
+
+  return Promise.all([
+    Promise.resolve(ruleData),
+    queryClient.ensureQueryData(getAvailabilityRuleSlotsQueryOptions(client, id)),
+    queryClient.ensureQueryData(getProductQueryOptions(client, ruleData.data.productId)),
+  ])
+}
+
+export function AvailabilityRuleDetailPage({
+  id,
+  className,
+  onBack,
+  onDeleted,
+  onOpenProduct,
+  onOpenSlot,
+  confirmAction = (message) => globalThis.confirm?.(message) ?? true,
+}: AvailabilityRuleDetailPageProps) {
+  const client = useVoyantAvailabilityContext()
+  const messages = useAvailabilityUiMessagesOrDefault()
+  const detailMessages = messages.details
+  const noValue = detailMessages.noValue
+  const ruleMutation = useAvailabilityRuleMutation()
+  const { data: ruleData, isPending } = useQuery(getAvailabilityRuleDetailQueryOptions(client, id))
+  const rule = ruleData?.data
+  const productQuery = useQuery({
+    ...getProductQueryOptions(client, rule?.productId ?? ""),
+    enabled: Boolean(rule?.productId),
+  })
+  const slotsQuery = useQuery(getAvailabilityRuleSlotsQueryOptions(client, id))
+
+  if (isPending) {
+    return <AvailabilityRuleDetailSkeleton />
+  }
+
+  if (!rule) {
+    return (
+      <DetailEmptyState
+        message={detailMessages.rule.notFound}
+        backLabel={detailMessages.backToAvailability}
+        onBack={onBack}
+      />
+    )
+  }
+
+  async function deleteRule(currentRule: AvailabilityRuleRow) {
+    if (!confirmAction(detailMessages.rule.deleteConfirm)) return
+    await ruleMutation.remove.mutateAsync(currentRule.id)
+    if (onDeleted) onDeleted()
+    else onBack?.()
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-6 p-6", className)}>
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="flex items-start gap-4">
+          {onBack ? (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onBack}
+              aria-label={detailMessages.backToAvailability}
+            >
+              <ArrowLeft data-icon aria-hidden="true" />
+            </Button>
+          ) : null}
+          <div className="flex-1">
+            <h1 className="text-2xl font-bold tracking-tight">{detailMessages.rule.pageTitle}</h1>
+            <div className="mt-1 flex flex-wrap items-center gap-2">
+              <Badge variant={rule.active ? "default" : "secondary"}>
+                {rule.active ? messages.statusActive : messages.statusInactive}
+              </Badge>
+              <Badge variant="outline">{rule.timezone}</Badge>
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          {onOpenProduct ? (
+            <Button variant="outline" onClick={() => onOpenProduct(rule.productId)}>
+              <Package data-icon="inline-start" aria-hidden="true" />
+              {detailMessages.openProduct}
+            </Button>
+          ) : null}
+          <Button
+            variant="destructive"
+            onClick={() => void deleteRule(rule)}
+            disabled={ruleMutation.remove.isPending}
+          >
+            <Trash2 data-icon="inline-start" aria-hidden="true" />
+            {detailMessages.delete}
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>{detailMessages.rule.detailsTitle}</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3 text-sm">
+            <DetailLine label={messages.productLabel}>
+              {productQuery.data?.data.name ?? rule.productId}
+            </DetailLine>
+            <div>
+              <span className="text-muted-foreground">{messages.recurrenceLabel}:</span>
+              <pre className="mt-1 overflow-x-auto rounded-md bg-muted p-3 font-mono text-xs">
+                {rule.recurrenceRule}
+              </pre>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>{detailMessages.rule.capacityPolicyTitle}</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3 text-sm">
+            <DetailLine label={messages.maxPaxLabel}>{rule.maxCapacity}</DetailLine>
+            <DetailLine label={detailMessages.rule.maxPickupCapacityLabel}>
+              {rule.maxPickupCapacity ?? noValue}
+            </DetailLine>
+            <DetailLine label={detailMessages.rule.minTotalPaxLabel}>
+              {rule.minTotalPax ?? noValue}
+            </DetailLine>
+            <DetailLine label={detailMessages.rule.cutoffMinutesLabel}>
+              {rule.cutoffMinutes ?? noValue}
+            </DetailLine>
+            <DetailLine label={detailMessages.rule.earlyBookingLimitLabel}>
+              {rule.earlyBookingLimitMinutes ?? noValue}
+            </DetailLine>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center gap-2">
+          <CalendarDays className="size-4" aria-hidden="true" />
+          <CardTitle>{detailMessages.rule.generatedSlotsTitle}</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3 text-sm">
+          {(slotsQuery.data?.data.length ?? 0) === 0 ? (
+            <p className="text-muted-foreground">{detailMessages.rule.generatedSlotsEmpty}</p>
+          ) : (
+            slotsQuery.data?.data.map((slot) => (
+              <SlotButton key={slot.id} slot={slot} onOpenSlot={onOpenSlot} />
+            ))
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function SlotButton({
+  slot,
+  onOpenSlot,
+}: {
+  slot: AvailabilitySlotRow
+  onOpenSlot?: (slotId: string) => void
+}) {
+  const messages = useAvailabilityUiMessagesOrDefault()
+  const noValue = messages.details.noValue
+
+  return (
+    <button
+      type="button"
+      className="block w-full rounded-md border p-3 text-left hover:bg-muted/40"
+      onClick={() => onOpenSlot?.(slot.id)}
+    >
+      <div className="flex items-center gap-2">
+        <Badge variant="outline">{getSlotStatusLabel(slot.status, messages)}</Badge>
+        <span>
+          {slot.dateLocal} · {formatDateTime(slot.startsAt)}
+        </span>
+      </div>
+      <div className="mt-2 text-muted-foreground">
+        {messages.remainingPaxLabel}: {slot.remainingPax ?? noValue}
+      </div>
+    </button>
+  )
+}
+
+function DetailLine({ label, children }: { label: string; children: import("react").ReactNode }) {
+  return (
+    <div>
+      <span className="text-muted-foreground">{label}:</span> <span>{children}</span>
+    </div>
+  )
+}
+
+function DetailEmptyState({
+  message,
+  backLabel,
+  onBack,
+}: {
+  message: string
+  backLabel: string
+  onBack?: () => void
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-12">
+      <p className="text-muted-foreground">{message}</p>
+      {onBack ? (
+        <Button variant="outline" onClick={onBack}>
+          {backLabel}
+        </Button>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/availability-ui/src/components/availability-slot-detail-page.tsx
+++ b/packages/availability-ui/src/components/availability-slot-detail-page.tsx
@@ -1,0 +1,430 @@
+"use client"
+
+import type { QueryClient } from "@tanstack/react-query"
+import { useQuery } from "@tanstack/react-query"
+import {
+  type AvailabilitySlotRow,
+  formatDateTime,
+  getPickupPointsQueryOptions,
+  getProductQueryOptions,
+  getSlotAssignmentsQueryOptions,
+  getSlotBookingsQueryOptions,
+  getSlotCloseoutsQueryOptions,
+  getSlotPickupsQueryOptions,
+  getSlotQueryOptions,
+  getSlotResourcesQueryOptions,
+  slotStatusVariant,
+  useAvailabilitySlotMutation,
+  useVoyantAvailabilityContext,
+  type VoyantAvailabilityContextValue,
+} from "@voyantjs/availability-react"
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  cn,
+} from "@voyantjs/ui/components"
+import { ArrowLeft, CalendarDays, Package, Trash2, Truck, Wrench } from "lucide-react"
+import type { ReactNode } from "react"
+
+import { useAvailabilityUiI18nOrDefault } from "../i18n/index.js"
+import { getSlotStatusLabel } from "./availability-columns.js"
+import { AvailabilitySlotDetailSkeleton } from "./availability-skeletons.js"
+
+export interface AvailabilitySlotDetailPageProps {
+  id: string
+  className?: string
+  onBack?: () => void
+  onDeleted?: () => void
+  onOpenProduct?: (productId: string) => void
+  onOpenStartTime?: (startTimeId: string) => void
+  confirmAction?: (message: string) => boolean
+}
+
+export function getAvailabilitySlotDetailQueryOptions(
+  client: VoyantAvailabilityContextValue,
+  id: string | null | undefined,
+) {
+  return getSlotQueryOptions(client, id)
+}
+
+export function getAvailabilitySlotProductQueryOptions(
+  client: VoyantAvailabilityContextValue,
+  productId: string | null | undefined,
+) {
+  return getProductQueryOptions(client, productId)
+}
+
+export function getAvailabilitySlotPickupsQueryOptions(
+  client: VoyantAvailabilityContextValue,
+  id: string | null | undefined,
+) {
+  return getSlotPickupsQueryOptions(client, id, { limit: 25, offset: 0 })
+}
+
+export function getAvailabilitySlotPickupPointsQueryOptions(
+  client: VoyantAvailabilityContextValue,
+  productId: string | null | undefined,
+) {
+  return getPickupPointsQueryOptions(client, {
+    productId: productId ?? undefined,
+    limit: 25,
+    offset: 0,
+  })
+}
+
+export function getAvailabilitySlotCloseoutsQueryOptions(
+  client: VoyantAvailabilityContextValue,
+  id: string | null | undefined,
+) {
+  return getSlotCloseoutsQueryOptions(client, id, { limit: 25, offset: 0 })
+}
+
+export function getAvailabilitySlotAssignmentsQueryOptions(
+  client: VoyantAvailabilityContextValue,
+  id: string | null | undefined,
+) {
+  return getSlotAssignmentsQueryOptions(client, id, { limit: 25, offset: 0 })
+}
+
+export function getAvailabilitySlotResourcesQueryOptions(client: VoyantAvailabilityContextValue) {
+  return getSlotResourcesQueryOptions(client, { limit: 25, offset: 0 })
+}
+
+export function getAvailabilitySlotBookingsQueryOptions(client: VoyantAvailabilityContextValue) {
+  return getSlotBookingsQueryOptions(client, { limit: 25, offset: 0 })
+}
+
+export async function loadAvailabilitySlotDetailPage(
+  queryClient: QueryClient,
+  client: VoyantAvailabilityContextValue,
+  id: string,
+) {
+  const slotData = await queryClient.ensureQueryData(
+    getAvailabilitySlotDetailQueryOptions(client, id),
+  )
+
+  return Promise.all([
+    Promise.resolve(slotData),
+    queryClient.ensureQueryData(getAvailabilitySlotPickupsQueryOptions(client, id)),
+    queryClient.ensureQueryData(getAvailabilitySlotCloseoutsQueryOptions(client, id)),
+    queryClient.ensureQueryData(getAvailabilitySlotAssignmentsQueryOptions(client, id)),
+    queryClient.ensureQueryData(getAvailabilitySlotResourcesQueryOptions(client)),
+    queryClient.ensureQueryData(getAvailabilitySlotBookingsQueryOptions(client)),
+    queryClient.ensureQueryData(
+      getAvailabilitySlotProductQueryOptions(client, slotData.data.productId),
+    ),
+    queryClient.ensureQueryData(
+      getAvailabilitySlotPickupPointsQueryOptions(client, slotData.data.productId),
+    ),
+  ])
+}
+
+export function AvailabilitySlotDetailPage({
+  id,
+  className,
+  onBack,
+  onDeleted,
+  onOpenProduct,
+  onOpenStartTime,
+  confirmAction = (message) => globalThis.confirm?.(message) ?? true,
+}: AvailabilitySlotDetailPageProps) {
+  const client = useVoyantAvailabilityContext()
+  const i18n = useAvailabilityUiI18nOrDefault()
+  const messages = i18n.messages
+  const detailMessages = messages.details
+  const noValue = detailMessages.noValue
+  const slotMutation = useAvailabilitySlotMutation()
+  const { data: slotData, isPending } = useQuery(getAvailabilitySlotDetailQueryOptions(client, id))
+  const slot = slotData?.data
+  const productQuery = useQuery({
+    ...getAvailabilitySlotProductQueryOptions(client, slot?.productId ?? ""),
+    enabled: Boolean(slot?.productId),
+  })
+  const slotPickupsQuery = useQuery(getAvailabilitySlotPickupsQueryOptions(client, id))
+  const pickupPointsQuery = useQuery({
+    ...getAvailabilitySlotPickupPointsQueryOptions(client, slot?.productId ?? ""),
+    enabled: Boolean(slot?.productId),
+  })
+  const closeoutsQuery = useQuery(getAvailabilitySlotCloseoutsQueryOptions(client, id))
+  const assignmentsQuery = useQuery(getAvailabilitySlotAssignmentsQueryOptions(client, id))
+  const resourcesQuery = useQuery(getAvailabilitySlotResourcesQueryOptions(client))
+  const bookingsQuery = useQuery(getAvailabilitySlotBookingsQueryOptions(client))
+
+  if (isPending) {
+    return <AvailabilitySlotDetailSkeleton />
+  }
+
+  if (!slot) {
+    return (
+      <DetailEmptyState
+        message={detailMessages.slot.notFound}
+        backLabel={detailMessages.backToAvailability}
+        onBack={onBack}
+      />
+    )
+  }
+
+  const pickupPointById = new Map(
+    (pickupPointsQuery.data?.data ?? []).map((item) => [item.id, item]),
+  )
+  const resourceById = new Map((resourcesQuery.data?.data ?? []).map((item) => [item.id, item]))
+  const bookingById = new Map((bookingsQuery.data?.data ?? []).map((item) => [item.id, item]))
+
+  async function deleteSlot(currentSlot: AvailabilitySlotRow) {
+    if (!confirmAction(detailMessages.slot.deleteConfirm)) return
+    await slotMutation.remove.mutateAsync(currentSlot.id)
+    if (onDeleted) onDeleted()
+    else onBack?.()
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-6 p-6", className)}>
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="flex items-start gap-4">
+          {onBack ? (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onBack}
+              aria-label={detailMessages.backToAvailability}
+            >
+              <ArrowLeft data-icon aria-hidden="true" />
+            </Button>
+          ) : null}
+          <div className="flex-1">
+            <h1 className="text-2xl font-bold tracking-tight">
+              {slot.dateLocal} · {formatDateTime(slot.startsAt)}
+            </h1>
+            <div className="mt-1 flex flex-wrap items-center gap-2">
+              <Badge variant={slotStatusVariant[slot.status]}>
+                {getSlotStatusLabel(slot.status, messages)}
+              </Badge>
+              <Badge variant="outline">{slot.timezone}</Badge>
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          {slot.productId && onOpenProduct ? (
+            <Button variant="outline" onClick={() => onOpenProduct(slot.productId)}>
+              <Package data-icon="inline-start" aria-hidden="true" />
+              {detailMessages.openProduct}
+            </Button>
+          ) : null}
+          <Button
+            variant="destructive"
+            onClick={() => void deleteSlot(slot)}
+            disabled={slotMutation.remove.isPending}
+          >
+            <Trash2 data-icon="inline-start" aria-hidden="true" />
+            {detailMessages.delete}
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>{detailMessages.slot.detailsTitle}</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3 text-sm">
+            <DetailLine label={messages.productLabel}>
+              {productQuery.data?.data.name ?? slot.productId}
+            </DetailLine>
+            <DetailLine label={detailMessages.slot.ruleLabel}>
+              {slot.availabilityRuleId ?? noValue}
+            </DetailLine>
+            <DetailLine label={detailMessages.slot.startTimeIdLabel}>
+              {slot.startTimeId && onOpenStartTime ? (
+                <Button
+                  variant="link"
+                  className="h-auto p-0"
+                  onClick={() => onOpenStartTime(slot.startTimeId ?? "")}
+                >
+                  {slot.startTimeId}
+                </Button>
+              ) : (
+                (slot.startTimeId ?? noValue)
+              )}
+            </DetailLine>
+            <DetailLine label={detailMessages.slot.endsAtLabel}>
+              {formatDateTime(slot.endsAt)}
+            </DetailLine>
+            <DetailLine label={detailMessages.slot.unlimitedLabel}>
+              {slot.unlimited ? detailMessages.yes : detailMessages.no}
+            </DetailLine>
+            <DetailLine label={detailMessages.slot.pastCutoffLabel}>
+              {slot.pastCutoff ? detailMessages.yes : detailMessages.no}
+            </DetailLine>
+            <DetailLine label={detailMessages.slot.tooEarlyLabel}>
+              {slot.tooEarly ? detailMessages.yes : detailMessages.no}
+            </DetailLine>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>{detailMessages.slot.capacityStateTitle}</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3 text-sm">
+            <DetailLine label={detailMessages.slot.initialPaxLabel}>
+              {slot.initialPax ?? noValue}
+            </DetailLine>
+            <DetailLine label={messages.remainingPaxLabel}>
+              {slot.remainingPax ?? noValue}
+            </DetailLine>
+            <DetailLine label={detailMessages.slot.initialPickupsLabel}>
+              {slot.initialPickups ?? noValue}
+            </DetailLine>
+            <DetailLine label={detailMessages.slot.remainingPickupsLabel}>
+              {slot.remainingPickups ?? noValue}
+            </DetailLine>
+            <DetailLine label={detailMessages.slot.remainingResourcesLabel}>
+              {slot.remainingResources ?? noValue}
+            </DetailLine>
+            <DetailLine label={detailMessages.createdLabel}>
+              {i18n.formatDateTime(slot.createdAt)}
+            </DetailLine>
+            <DetailLine label={detailMessages.updatedLabel}>
+              {i18n.formatDateTime(slot.updatedAt)}
+            </DetailLine>
+          </CardContent>
+        </Card>
+      </div>
+
+      {slot.notes ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>{detailMessages.notesTitle}</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm whitespace-pre-wrap">{slot.notes}</CardContent>
+        </Card>
+      ) : null}
+
+      <Card>
+        <CardHeader className="flex flex-row items-center gap-2">
+          <Truck className="size-4" aria-hidden="true" />
+          <CardTitle>{detailMessages.slot.pickupCapacityTitle}</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3 text-sm">
+          {(slotPickupsQuery.data?.data.length ?? 0) === 0 ? (
+            <p className="text-muted-foreground">{detailMessages.slot.pickupCapacityEmpty}</p>
+          ) : (
+            slotPickupsQuery.data?.data.map((pickup) => {
+              const point = pickupPointById.get(pickup.pickupPointId)
+
+              return (
+                <div key={pickup.id} className="rounded-md border p-3">
+                  <div className="font-medium">{point?.name ?? pickup.pickupPointId}</div>
+                  <div className="text-muted-foreground">
+                    {point?.locationText ?? detailMessages.slot.noLocationText}
+                  </div>
+                  <div className="mt-2">
+                    {detailMessages.slot.initialLabel}: {pickup.initialCapacity ?? noValue} ·{" "}
+                    {detailMessages.slot.remainingLabel}: {pickup.remainingCapacity ?? noValue}
+                  </div>
+                </div>
+              )
+            })
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center gap-2">
+          <Wrench className="size-4" aria-hidden="true" />
+          <CardTitle>{detailMessages.slot.resourceAssignmentsTitle}</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3 text-sm">
+          {(assignmentsQuery.data?.data.length ?? 0) === 0 ? (
+            <p className="text-muted-foreground">{detailMessages.slot.resourceAssignmentsEmpty}</p>
+          ) : (
+            assignmentsQuery.data?.data.map((assignment) => (
+              <div key={assignment.id} className="rounded-md border p-3">
+                <div className="flex items-center gap-2">
+                  <Badge variant="outline" className="capitalize">
+                    {assignment.status}
+                  </Badge>
+                  <span>
+                    {resourceById.get(assignment.resourceId ?? "")?.name ??
+                      assignment.resourceId ??
+                      detailMessages.slot.unassignedResource}
+                  </span>
+                </div>
+                <div className="mt-2 text-muted-foreground">
+                  {detailMessages.slot.bookingLabel}:{" "}
+                  {bookingById.get(assignment.bookingId ?? "")?.bookingNumber ??
+                    assignment.bookingId ??
+                    noValue}
+                </div>
+                <div className="text-muted-foreground">
+                  {detailMessages.slot.poolLabel}: {assignment.poolId ?? noValue} ·{" "}
+                  {detailMessages.slot.releasedLabel}: {formatDateTime(assignment.releasedAt)}
+                </div>
+                {assignment.notes ? (
+                  <div className="mt-2 whitespace-pre-wrap">{assignment.notes}</div>
+                ) : null}
+              </div>
+            ))
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center gap-2">
+          <CalendarDays className="size-4" aria-hidden="true" />
+          <CardTitle>{detailMessages.slot.relatedCloseoutsTitle}</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3 text-sm">
+          {(closeoutsQuery.data?.data.length ?? 0) === 0 ? (
+            <p className="text-muted-foreground">{detailMessages.slot.relatedCloseoutsEmpty}</p>
+          ) : (
+            closeoutsQuery.data?.data.map((closeout) => (
+              <div key={closeout.id} className="rounded-md border p-3">
+                <div className="font-medium">{closeout.dateLocal}</div>
+                <div className="text-muted-foreground">
+                  {detailMessages.slot.createdByLabel}: {closeout.createdBy ?? noValue}
+                </div>
+                {closeout.reason ? (
+                  <div className="mt-2 whitespace-pre-wrap">{closeout.reason}</div>
+                ) : null}
+              </div>
+            ))
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function DetailLine({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div>
+      <span className="text-muted-foreground">{label}:</span> <span>{children}</span>
+    </div>
+  )
+}
+
+function DetailEmptyState({
+  message,
+  backLabel,
+  onBack,
+}: {
+  message: string
+  backLabel: string
+  onBack?: () => void
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-12">
+      <p className="text-muted-foreground">{message}</p>
+      {onBack ? (
+        <Button variant="outline" onClick={onBack}>
+          {backLabel}
+        </Button>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/availability-ui/src/components/availability-start-time-detail-page.tsx
+++ b/packages/availability-ui/src/components/availability-start-time-detail-page.tsx
@@ -1,0 +1,292 @@
+"use client"
+
+import type { QueryClient } from "@tanstack/react-query"
+import { queryOptions, useQuery } from "@tanstack/react-query"
+import {
+  type AvailabilitySlotRow,
+  type AvailabilityStartTimeRow,
+  availabilityQueryKeys,
+  availabilityStartTimeRecordSchema,
+  fetchWithValidation,
+  formatDateTime,
+  getProductQueryOptions,
+  getSlotsQueryOptions,
+  singleEnvelope,
+  useAvailabilityStartTimeMutation,
+  useVoyantAvailabilityContext,
+  type VoyantAvailabilityContextValue,
+} from "@voyantjs/availability-react"
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  cn,
+} from "@voyantjs/ui/components"
+import { ArrowLeft, Clock3, Package, Trash2 } from "lucide-react"
+import type { ReactNode } from "react"
+import { z } from "zod"
+
+import { useAvailabilityUiI18nOrDefault } from "../i18n/index.js"
+import { getSlotStatusLabel } from "./availability-columns.js"
+import { AvailabilityStartTimeDetailSkeleton } from "./availability-skeletons.js"
+
+const availabilityStartTimeDetailResponse = singleEnvelope(
+  availabilityStartTimeRecordSchema.extend({
+    createdAt: z.string().optional(),
+    updatedAt: z.string().optional(),
+  }),
+)
+
+export interface AvailabilityStartTimeDetailPageProps {
+  id: string
+  className?: string
+  onBack?: () => void
+  onDeleted?: () => void
+  onOpenProduct?: (productId: string) => void
+  onOpenSlot?: (slotId: string) => void
+  confirmAction?: (message: string) => boolean
+}
+
+export function getAvailabilityStartTimeDetailQueryOptions(
+  client: VoyantAvailabilityContextValue,
+  id: string | null | undefined,
+) {
+  return queryOptions({
+    queryKey: availabilityQueryKeys.startTimeDetail(id ?? ""),
+    queryFn: async () => {
+      if (!id) throw new Error("getAvailabilityStartTimeDetailQueryOptions requires an id")
+      return fetchWithValidation(
+        `/v1/availability/start-times/${id}`,
+        availabilityStartTimeDetailResponse,
+        client,
+      )
+    },
+  })
+}
+
+export function getAvailabilityStartTimeSlotsQueryOptions(
+  client: VoyantAvailabilityContextValue,
+  id: string | null | undefined,
+) {
+  return getSlotsQueryOptions(client, { startTimeId: id ?? undefined, limit: 25, offset: 0 })
+}
+
+export async function loadAvailabilityStartTimeDetailPage(
+  queryClient: QueryClient,
+  client: VoyantAvailabilityContextValue,
+  id: string,
+) {
+  const startTimeData = await queryClient.ensureQueryData(
+    getAvailabilityStartTimeDetailQueryOptions(client, id),
+  )
+
+  return Promise.all([
+    Promise.resolve(startTimeData),
+    queryClient.ensureQueryData(getAvailabilityStartTimeSlotsQueryOptions(client, id)),
+    queryClient.ensureQueryData(getProductQueryOptions(client, startTimeData.data.productId)),
+  ])
+}
+
+export function AvailabilityStartTimeDetailPage({
+  id,
+  className,
+  onBack,
+  onDeleted,
+  onOpenProduct,
+  onOpenSlot,
+  confirmAction = (message) => globalThis.confirm?.(message) ?? true,
+}: AvailabilityStartTimeDetailPageProps) {
+  const client = useVoyantAvailabilityContext()
+  const i18n = useAvailabilityUiI18nOrDefault()
+  const messages = i18n.messages
+  const detailMessages = messages.details
+  const noValue = detailMessages.noValue
+  const startTimeMutation = useAvailabilityStartTimeMutation()
+  const { data: startTimeData, isPending } = useQuery(
+    getAvailabilityStartTimeDetailQueryOptions(client, id),
+  )
+  const startTime = startTimeData?.data
+  const productQuery = useQuery({
+    ...getProductQueryOptions(client, startTime?.productId ?? ""),
+    enabled: Boolean(startTime?.productId),
+  })
+  const slotsQuery = useQuery(getAvailabilityStartTimeSlotsQueryOptions(client, id))
+
+  if (isPending) {
+    return <AvailabilityStartTimeDetailSkeleton />
+  }
+
+  if (!startTime) {
+    return (
+      <DetailEmptyState
+        message={detailMessages.startTime.notFound}
+        backLabel={detailMessages.backToAvailability}
+        onBack={onBack}
+      />
+    )
+  }
+
+  async function deleteStartTime(currentStartTime: AvailabilityStartTimeRow) {
+    if (!confirmAction(detailMessages.startTime.deleteConfirm)) return
+    await startTimeMutation.remove.mutateAsync(currentStartTime.id)
+    if (onDeleted) onDeleted()
+    else onBack?.()
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-6 p-6", className)}>
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="flex items-start gap-4">
+          {onBack ? (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onBack}
+              aria-label={detailMessages.backToAvailability}
+            >
+              <ArrowLeft data-icon aria-hidden="true" />
+            </Button>
+          ) : null}
+          <div className="flex-1">
+            <h1 className="text-2xl font-bold tracking-tight">
+              {startTime.label ?? detailMessages.startTime.fallbackTitle}
+            </h1>
+            <div className="mt-1 flex flex-wrap items-center gap-2">
+              <Badge variant="outline">{startTime.startTimeLocal}</Badge>
+              <Badge variant={startTime.active ? "default" : "secondary"}>
+                {startTime.active ? messages.statusActive : messages.statusInactive}
+              </Badge>
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          {onOpenProduct ? (
+            <Button variant="outline" onClick={() => onOpenProduct(startTime.productId)}>
+              <Package data-icon="inline-start" aria-hidden="true" />
+              {detailMessages.openProduct}
+            </Button>
+          ) : null}
+          <Button
+            variant="destructive"
+            onClick={() => void deleteStartTime(startTime)}
+            disabled={startTimeMutation.remove.isPending}
+          >
+            <Trash2 data-icon="inline-start" aria-hidden="true" />
+            {detailMessages.delete}
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>{detailMessages.startTime.detailsTitle}</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3 text-sm">
+            <DetailLine label={messages.productLabel}>
+              {productQuery.data?.data.name ?? startTime.productId}
+            </DetailLine>
+            <DetailLine label={messages.labelLabel}>{startTime.label ?? noValue}</DetailLine>
+            <DetailLine label={messages.durationLabel}>
+              {startTime.durationMinutes == null ? noValue : `${startTime.durationMinutes} min`}
+            </DetailLine>
+            <DetailLine label={detailMessages.startTime.sortOrderLabel}>
+              {startTime.sortOrder}
+            </DetailLine>
+            <DetailLine label={detailMessages.createdLabel}>
+              {formatOptionalDateTime(startTime.createdAt, noValue, i18n.formatDateTime)}
+            </DetailLine>
+            <DetailLine label={detailMessages.updatedLabel}>
+              {formatOptionalDateTime(startTime.updatedAt, noValue, i18n.formatDateTime)}
+            </DetailLine>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center gap-2">
+            <Clock3 className="size-4" aria-hidden="true" />
+            <CardTitle>{detailMessages.startTime.generatedSlotsTitle}</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3 text-sm">
+            {(slotsQuery.data?.data.length ?? 0) === 0 ? (
+              <p className="text-muted-foreground">
+                {detailMessages.startTime.generatedSlotsEmpty}
+              </p>
+            ) : (
+              slotsQuery.data?.data.map((slot) => (
+                <SlotButton key={slot.id} slot={slot} onOpenSlot={onOpenSlot} />
+              ))
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+function SlotButton({
+  slot,
+  onOpenSlot,
+}: {
+  slot: AvailabilitySlotRow
+  onOpenSlot?: (slotId: string) => void
+}) {
+  const messages = useAvailabilityUiI18nOrDefault().messages
+  const noValue = messages.details.noValue
+
+  return (
+    <button
+      type="button"
+      className="block w-full rounded-md border p-3 text-left hover:bg-muted/40"
+      onClick={() => onOpenSlot?.(slot.id)}
+    >
+      <div className="font-medium">
+        {slot.dateLocal} · {formatDateTime(slot.startsAt)}
+      </div>
+      <div className="text-muted-foreground">
+        {messages.statusLabel}: {getSlotStatusLabel(slot.status, messages)} ·{" "}
+        {messages.remainingPaxLabel}: {slot.remainingPax ?? noValue}
+      </div>
+    </button>
+  )
+}
+
+function formatOptionalDateTime(
+  value: string | undefined,
+  fallback: string,
+  formatter: (value: string | number | Date) => string,
+) {
+  return value ? formatter(value) : fallback
+}
+
+function DetailLine({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div>
+      <span className="text-muted-foreground">{label}:</span> <span>{children}</span>
+    </div>
+  )
+}
+
+function DetailEmptyState({
+  message,
+  backLabel,
+  onBack,
+}: {
+  message: string
+  backLabel: string
+  onBack?: () => void
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-12">
+      <p className="text-muted-foreground">{message}</p>
+      {onBack ? (
+        <Button variant="outline" onClick={onBack}>
+          {backLabel}
+        </Button>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/availability-ui/src/i18n.test.tsx
+++ b/packages/availability-ui/src/i18n.test.tsx
@@ -1,0 +1,71 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+
+import {
+  AvailabilityUiMessagesProvider,
+  getAvailabilityUiI18n,
+  resolveAvailabilityUiMessages,
+  useAvailabilityUiMessagesOrDefault,
+} from "./i18n/index.js"
+
+describe("availability-ui i18n", () => {
+  it("resolves localized package messages with fallback and overrides", () => {
+    const result = resolveAvailabilityUiMessages({
+      locale: "ro-RO",
+      overrides: {
+        locales: {
+          ro: {
+            page: {
+              filters: {
+                productSearchEmpty: "Niciun rezultat.",
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(result.page.filters.productSearchEmpty).toBe("Niciun rezultat.")
+    expect(result.title).toBe("Disponibilitate")
+    expect(result.tabSlots).toBe("Sloturi")
+  })
+
+  it("returns locale-aware formatters from the package helper", () => {
+    const result = getAvailabilityUiI18n({ locale: "ro-RO" })
+
+    expect(result.locale).toBe("ro-RO")
+    expect(result.formatNumber(1200)).toBe(new Intl.NumberFormat("ro-RO").format(1200))
+  })
+
+  it("renders English copy without a provider", () => {
+    const html = renderToStaticMarkup(<AvailabilityMessageProbe />)
+
+    expect(html).toContain("Availability")
+    expect(html).toContain("Calendar")
+    expect(html).toContain("All statuses")
+  })
+
+  it("renders Romanian copy with the package provider", () => {
+    const html = renderToStaticMarkup(
+      <AvailabilityUiMessagesProvider locale="ro-RO">
+        <AvailabilityMessageProbe />
+      </AvailabilityUiMessagesProvider>,
+    )
+
+    expect(html).toContain("Disponibilitate")
+    expect(html).toContain("Calendar")
+    expect(html).toContain("Toate statusurile")
+  })
+})
+
+function AvailabilityMessageProbe() {
+  const messages = useAvailabilityUiMessagesOrDefault()
+
+  return (
+    <div>
+      <span>{messages.title}</span>
+      <span>{messages.page.calendarTab}</span>
+      <span>{messages.page.filters.allStatuses}</span>
+    </div>
+  )
+}

--- a/packages/availability-ui/src/i18n/index.ts
+++ b/packages/availability-ui/src/i18n/index.ts
@@ -1,0 +1,14 @@
+export {
+  type AvailabilityUiMessageOverrides,
+  type AvailabilityUiMessages,
+  AvailabilityUiMessagesProvider,
+  availabilityUiEn,
+  availabilityUiMessageDefinitions,
+  availabilityUiRo,
+  getAvailabilityUiI18n,
+  resolveAvailabilityUiMessages,
+  useAvailabilityUiI18n,
+  useAvailabilityUiI18nOrDefault,
+  useAvailabilityUiMessages,
+  useAvailabilityUiMessagesOrDefault,
+} from "./provider.js"

--- a/packages/availability-ui/src/i18n/provider.tsx
+++ b/packages/availability-ui/src/i18n/provider.tsx
@@ -1,0 +1,166 @@
+"use client"
+
+import {
+  adminAvailabilityMessages,
+  createLocaleFormatters,
+  createPackageMessagesContext,
+  type LocaleMessageDefinitions,
+  type LocaleMessageOverrides,
+  type PackageI18nValue,
+  resolvePackageMessages,
+} from "@voyantjs/i18n"
+import type { ReactNode } from "react"
+
+type BaseAvailabilityMessages = (typeof adminAvailabilityMessages.en)["availability"]
+
+export type AvailabilityUiMessages = BaseAvailabilityMessages & {
+  page: {
+    loading: string
+    loadFailed: string
+    calendarTab: string
+    filters: {
+      statusLabel: string
+      stateLabel: string
+      dateRangeLabel: string
+      anyDate: string
+      allStatuses: string
+      allStates: string
+      active: string
+      inactive: string
+      reset: string
+      productSearchEmpty: string
+    }
+  }
+}
+
+const availabilityUiExtraEn = {
+  page: {
+    loading: "Loading availability...",
+    loadFailed: "Availability data could not be loaded.",
+    calendarTab: "Calendar",
+    filters: {
+      statusLabel: "Status",
+      stateLabel: "State",
+      dateRangeLabel: "Date range",
+      anyDate: "Any date",
+      allStatuses: "All statuses",
+      allStates: "All",
+      active: "Active",
+      inactive: "Inactive",
+      reset: "Reset",
+      productSearchEmpty: "No products match that search.",
+    },
+  },
+} satisfies Pick<AvailabilityUiMessages, "page">
+
+const availabilityUiExtraRo = {
+  page: {
+    loading: "Se incarca disponibilitatea...",
+    loadFailed: "Datele de disponibilitate nu au putut fi incarcate.",
+    calendarTab: "Calendar",
+    filters: {
+      statusLabel: "Status",
+      stateLabel: "Stare",
+      dateRangeLabel: "Interval de date",
+      anyDate: "Orice data",
+      allStatuses: "Toate statusurile",
+      allStates: "Toate",
+      active: "Active",
+      inactive: "Inactive",
+      reset: "Reseteaza",
+      productSearchEmpty: "Niciun produs nu se potriveste cautarii.",
+    },
+  },
+} satisfies Pick<AvailabilityUiMessages, "page">
+
+export const availabilityUiEn = {
+  ...adminAvailabilityMessages.en.availability,
+  ...availabilityUiExtraEn,
+} satisfies AvailabilityUiMessages
+
+export const availabilityUiRo = {
+  ...adminAvailabilityMessages.ro.availability,
+  ...availabilityUiExtraRo,
+} satisfies AvailabilityUiMessages
+
+const fallbackLocale = "en"
+
+export const availabilityUiMessageDefinitions = {
+  en: availabilityUiEn,
+  ro: availabilityUiRo,
+} satisfies LocaleMessageDefinitions<AvailabilityUiMessages>
+
+export type AvailabilityUiMessageOverrides = LocaleMessageOverrides<AvailabilityUiMessages>
+
+const availabilityUiContext =
+  createPackageMessagesContext<AvailabilityUiMessages>("AvailabilityUiMessages")
+
+const defaultAvailabilityUiI18n: PackageI18nValue<AvailabilityUiMessages> = {
+  messages: availabilityUiEn,
+  ...createLocaleFormatters(fallbackLocale),
+}
+
+export function resolveAvailabilityUiMessages({
+  locale,
+  overrides,
+}: {
+  locale: string | null | undefined
+  overrides?: AvailabilityUiMessageOverrides | null
+}) {
+  return resolvePackageMessages({
+    definitions: availabilityUiMessageDefinitions,
+    fallbackLocale,
+    locale,
+    overrides,
+  })
+}
+
+export function getAvailabilityUiI18n({
+  locale,
+  overrides,
+}: {
+  locale?: string | null | undefined
+  overrides?: AvailabilityUiMessageOverrides | null
+}): PackageI18nValue<AvailabilityUiMessages> {
+  const resolvedLocale = locale ?? fallbackLocale
+
+  return {
+    messages: resolveAvailabilityUiMessages({
+      locale: resolvedLocale,
+      overrides,
+    }),
+    ...createLocaleFormatters(resolvedLocale),
+  }
+}
+
+export function AvailabilityUiMessagesProvider({
+  children,
+  locale,
+  overrides,
+}: {
+  children: ReactNode
+  locale: string | null | undefined
+  overrides?: AvailabilityUiMessageOverrides | null
+}) {
+  return (
+    <availabilityUiContext.ResolvedMessagesProvider
+      definitions={availabilityUiMessageDefinitions}
+      fallbackLocale={fallbackLocale}
+      locale={locale}
+      overrides={overrides}
+    >
+      {children}
+    </availabilityUiContext.ResolvedMessagesProvider>
+  )
+}
+
+export const useAvailabilityUiI18n = availabilityUiContext.useI18n
+export const useAvailabilityUiMessages = availabilityUiContext.useMessages
+
+export function useAvailabilityUiI18nOrDefault() {
+  return availabilityUiContext.useOptionalI18n() ?? defaultAvailabilityUiI18n
+}
+
+export function useAvailabilityUiMessagesOrDefault() {
+  return useAvailabilityUiI18nOrDefault().messages
+}

--- a/packages/availability-ui/src/index.ts
+++ b/packages/availability-ui/src/index.ts
@@ -25,6 +25,28 @@ export {
   type AvailabilityOverviewMessages,
 } from "./components/availability-overview.js"
 export {
+  AvailabilityPage,
+  type AvailabilityPageActiveFilter,
+  type AvailabilityPageBulkDeleteHandler,
+  type AvailabilityPageBulkUpdateHandler,
+  type AvailabilityPageCloseoutSubmitHandler,
+  type AvailabilityPagePickupPointSubmitHandler,
+  type AvailabilityPageProps,
+  type AvailabilityPageRuleSubmitHandler,
+  type AvailabilityPageSlotStatusFilter,
+  type AvailabilityPageSlotSubmitHandler,
+  type AvailabilityPageSlots,
+  type AvailabilityPageStartTimeSubmitHandler,
+  type AvailabilityPageTab,
+} from "./components/availability-page.js"
+export {
+  AvailabilityRuleDetailPage,
+  type AvailabilityRuleDetailPageProps,
+  getAvailabilityRuleDetailQueryOptions,
+  getAvailabilityRuleSlotsQueryOptions,
+  loadAvailabilityRuleDetailPage,
+} from "./components/availability-rule-detail-page.js"
+export {
   AvailabilitySectionHeader,
   type AvailabilitySectionHeaderProps,
 } from "./components/availability-section-header.js"
@@ -36,6 +58,26 @@ export {
   AvailabilityStartTimeDetailSkeleton,
 } from "./components/availability-skeletons.js"
 export {
+  AvailabilitySlotDetailPage,
+  type AvailabilitySlotDetailPageProps,
+  getAvailabilitySlotAssignmentsQueryOptions,
+  getAvailabilitySlotBookingsQueryOptions,
+  getAvailabilitySlotCloseoutsQueryOptions,
+  getAvailabilitySlotDetailQueryOptions,
+  getAvailabilitySlotPickupPointsQueryOptions,
+  getAvailabilitySlotPickupsQueryOptions,
+  getAvailabilitySlotProductQueryOptions,
+  getAvailabilitySlotResourcesQueryOptions,
+  loadAvailabilitySlotDetailPage,
+} from "./components/availability-slot-detail-page.js"
+export {
+  AvailabilityStartTimeDetailPage,
+  type AvailabilityStartTimeDetailPageProps,
+  getAvailabilityStartTimeDetailQueryOptions,
+  getAvailabilityStartTimeSlotsQueryOptions,
+  loadAvailabilityStartTimeDetailPage,
+} from "./components/availability-start-time-detail-page.js"
+export {
   type AvailabilityBulkDeleteFn,
   type AvailabilityBulkUpdateFn,
   AvailabilityCloseoutsTab,
@@ -45,4 +87,18 @@ export {
   AvailabilityStartTimesTab,
   type AvailabilityTabMessages,
 } from "./components/availability-tabs.js"
+export {
+  type AvailabilityUiMessageOverrides,
+  type AvailabilityUiMessages,
+  AvailabilityUiMessagesProvider,
+  availabilityUiEn,
+  availabilityUiMessageDefinitions,
+  availabilityUiRo,
+  getAvailabilityUiI18n,
+  resolveAvailabilityUiMessages,
+  useAvailabilityUiI18n,
+  useAvailabilityUiI18nOrDefault,
+  useAvailabilityUiMessages,
+  useAvailabilityUiMessagesOrDefault,
+} from "./i18n/index.js"
 export { formatLocalizedSelectionLabel } from "./utils.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1056,6 +1056,9 @@ importers:
 
   packages/availability-ui:
     devDependencies:
+      '@tanstack/react-query':
+        specifier: ^5.90.12
+        version: 5.96.2(react@19.2.4)
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1068,6 +1071,9 @@ importers:
       '@voyantjs/availability-react':
         specifier: workspace:*
         version: link:../availability-react
+      '@voyantjs/i18n':
+        specifier: workspace:*
+        version: link:../i18n
       '@voyantjs/ui':
         specifier: workspace:*
         version: link:../ui

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1055,6 +1055,10 @@ importers:
         version: 4.3.6
 
   packages/availability-ui:
+    dependencies:
+      '@voyantjs/i18n':
+        specifier: workspace:*
+        version: link:../i18n
     devDependencies:
       '@tanstack/react-query':
         specifier: ^5.90.12
@@ -1071,9 +1075,6 @@ importers:
       '@voyantjs/availability-react':
         specifier: workspace:*
         version: link:../availability-react
-      '@voyantjs/i18n':
-        specifier: workspace:*
-        version: link:../i18n
       '@voyantjs/ui':
         specifier: workspace:*
         version: link:../ui


### PR DESCRIPTION
## Summary
- Publish package-owned availability page composition with injected route and batch mutation handlers
- Add rule, slot, and start-time detail page compositions plus loader/query helpers
- Add availability-ui i18n provider, README docs, and changeset

## Verification
- pnpm --filter @voyantjs/availability-ui lint
- pnpm --filter @voyantjs/availability-ui typecheck
- pnpm --filter @voyantjs/availability-ui test
- pnpm --filter @voyantjs/availability-ui build
- NODE_OPTIONS=--max-old-space-size=8192 pnpm verify:fast

Closes #555
Parent #487