### PR TITLE
[codex] Fix rich itinerary day descriptions

### DIFF
--- a/.changeset/rich-itinerary-day-descriptions.md
+++ b/.changeset/rich-itinerary-day-descriptions.md
@@ -1,5 +1,6 @@
 ---
 "@voyantjs/products-ui": patch
+"@voyantjs/products": patch
 "@voyantjs/ui": patch
 ---
 

--- a/.changeset/rich-itinerary-day-descriptions.md
+++ b/.changeset/rich-itinerary-day-descriptions.md
@@ -1,0 +1,8 @@
+---
+"@voyantjs/products-ui": patch
+"@voyantjs/ui": patch
+---
+
+Render product itinerary day descriptions with the shared rich text editor so imported HTML content can be edited without exposing raw markup.
+
+Add link support to the shared rich text editor, including safe URL handling and toolbar actions for adding or removing links.

--- a/packages/products-ui/src/components/product-day-form.tsx
+++ b/packages/products-ui/src/components/product-day-form.tsx
@@ -4,7 +4,7 @@ import { type ProductDayRecord, useProductDayMutation } from "@voyantjs/products
 import { Button } from "@voyantjs/ui/components/button"
 import { Input } from "@voyantjs/ui/components/input"
 import { Label } from "@voyantjs/ui/components/label"
-import { Textarea } from "@voyantjs/ui/components/textarea"
+import { RichTextEditor } from "@voyantjs/ui/components/rich-text-editor"
 import { Loader2 } from "lucide-react"
 import * as React from "react"
 
@@ -144,11 +144,11 @@ export function ProductDayForm({ mode, onSuccess, onCancel }: ProductDayFormProp
         <Label htmlFor="product-day-description">
           {messages.productDayForm.fields.description}
         </Label>
-        <Textarea
-          id="product-day-description"
+        <RichTextEditor
           value={state.description}
-          onChange={(event) => field("description")(event.target.value)}
+          onChange={field("description")}
           placeholder={messages.productDayForm.placeholders.description}
+          editorClassName="max-h-[320px] overflow-y-auto"
         />
       </div>
 

--- a/packages/products/src/tasks/generate-pdf.ts
+++ b/packages/products/src/tasks/generate-pdf.ts
@@ -3,6 +3,7 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { PDFDocument, rgb, StandardFonts } from "pdf-lib"
 
 import { productDayServices, productDays, productItineraries, products } from "../schema.js"
+import { plainTextForPdf } from "./pdf-text.js"
 
 export type GenerateProductPdfResult = {
   pdfBytes: Uint8Array
@@ -94,7 +95,7 @@ export async function generateProductPdf(
 
   if (product.description) {
     y -= 8
-    drawText(product.description, { size: 10 })
+    drawText(plainTextForPdf(product.description), { size: 10 })
   }
 
   y -= 16
@@ -111,7 +112,7 @@ export async function generateProductPdf(
       drawText(`Location: ${day.location}`, { size: 9 })
     }
     if (day.description) {
-      drawText(day.description, { size: 9 })
+      drawText(plainTextForPdf(day.description), { size: 9 })
     }
 
     // Services

--- a/packages/products/src/tasks/pdf-text.ts
+++ b/packages/products/src/tasks/pdf-text.ts
@@ -1,0 +1,50 @@
+const NAMED_HTML_ENTITIES: Record<string, string> = {
+  amp: "&",
+  apos: "'",
+  gt: ">",
+  lt: "<",
+  nbsp: " ",
+  quot: '"',
+}
+
+function decodeHtmlEntities(value: string) {
+  return value.replace(/&(#\d+|#x[\da-f]+|[a-z][\da-z]+);/gi, (match, entity: string) => {
+    if (entity.startsWith("#x")) {
+      const codePoint = Number.parseInt(entity.slice(2), 16)
+      return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : match
+    }
+
+    if (entity.startsWith("#")) {
+      const codePoint = Number.parseInt(entity.slice(1), 10)
+      return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : match
+    }
+
+    return NAMED_HTML_ENTITIES[entity.toLowerCase()] ?? match
+  })
+}
+
+export function plainTextForPdf(value: string) {
+  const trimmed = value.trim()
+
+  if (!trimmed) {
+    return ""
+  }
+
+  const textWithoutTags = /<[a-z][\s\S]*>/i.test(trimmed)
+    ? trimmed
+        .replace(/<\s*br\s*\/?>/gi, "\n")
+        .replace(/<\s*li\b[^>]*>/gi, " * ")
+        .replace(
+          /<\s*\/\s*(address|article|aside|blockquote|div|footer|h[1-6]|header|li|main|ol|p|section|table|tbody|td|tfoot|th|thead|tr|ul)\s*>/gi,
+          "\n",
+        )
+        .replace(/<[^>]*>/g, "")
+    : trimmed
+
+  return decodeHtmlEntities(textWithoutTags)
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .map((line) => line.replace(/[ \t\f\v]+/g, " ").trim())
+    .filter(Boolean)
+    .join(" ")
+}

--- a/packages/products/tests/unit/generate-pdf.test.ts
+++ b/packages/products/tests/unit/generate-pdf.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+
+import { plainTextForPdf } from "../../src/tasks/pdf-text.js"
+
+describe("plainTextForPdf", () => {
+  it("strips rich text editor markup before PDF rendering", () => {
+    expect(
+      plainTextForPdf(
+        '<p>Arrive &amp; check in</p><ul><li><a href="https://example.com">Hotel</a></li><li>Walk</li></ul>',
+      ),
+    ).toBe("Arrive & check in * Hotel * Walk")
+  })
+
+  it("preserves non-HTML plain text", () => {
+    expect(plainTextForPdf("Keep 2 < 3 and 5 > 4")).toBe("Keep 2 < 3 and 5 > 4")
+  })
+})

--- a/packages/ui/src/components/rich-text-editor.tsx
+++ b/packages/ui/src/components/rich-text-editor.tsx
@@ -7,12 +7,14 @@ import {
   Heading2,
   Heading3,
   Italic,
+  Link,
   List,
   ListOrdered,
   Quote,
   Redo,
   Strikethrough,
   Undo,
+  Unlink,
 } from "lucide-react"
 import { useEffect } from "react"
 import { cn } from "../lib/utils.js"
@@ -42,6 +44,66 @@ const EMPTY_CONTENT = "<p></p>"
 
 function normalizeEditorContent(value: string) {
   return value.trim() ? value : EMPTY_CONTENT
+}
+
+function isAllowedLinkUri(uri: string) {
+  const value = uri.trim()
+
+  if (!value) {
+    return false
+  }
+
+  if (
+    value.startsWith("/") ||
+    value.startsWith("#") ||
+    value.startsWith("./") ||
+    value.startsWith("../")
+  ) {
+    return true
+  }
+
+  try {
+    const parsed = new URL(value)
+    return ["http:", "https:", "mailto:", "tel:"].includes(parsed.protocol)
+  } catch {
+    return false
+  }
+}
+
+function isRelativeLinkUri(uri: string) {
+  const value = uri.trim()
+
+  return (
+    value.startsWith("/") ||
+    value.startsWith("#") ||
+    value.startsWith("./") ||
+    value.startsWith("../")
+  )
+}
+
+function hasLinkProtocol(uri: string) {
+  return /^[a-z][a-z0-9+.-]*:/i.test(uri.trim())
+}
+
+function normalizeLinkHref(href: string) {
+  const value = href.trim()
+
+  if (!value) {
+    return null
+  }
+
+  if (
+    value.startsWith("/") ||
+    value.startsWith("#") ||
+    value.startsWith("./") ||
+    value.startsWith("../") ||
+    hasLinkProtocol(value)
+  ) {
+    return isAllowedLinkUri(value) ? value : null
+  }
+
+  const withProtocol = `https://${value}`
+  return isAllowedLinkUri(withProtocol) ? withProtocol : null
 }
 
 function ToolbarButton({
@@ -81,6 +143,28 @@ export function RichTextEditor({
     StarterKit.configure({
       heading: {
         levels: [2, 3],
+      },
+      link: {
+        autolink: true,
+        defaultProtocol: "https",
+        linkOnPaste: true,
+        openOnClick: false,
+        protocols: ["mailto", "tel"],
+        HTMLAttributes: {
+          rel: "noopener noreferrer",
+          target: "_blank",
+        },
+        isAllowedUri: (url, { defaultValidate }) => {
+          if (isRelativeLinkUri(url)) {
+            return true
+          }
+
+          if (hasLinkProtocol(url)) {
+            return isAllowedLinkUri(url) && defaultValidate(url)
+          }
+
+          return defaultValidate(url) && isAllowedLinkUri(`https://${url.trim()}`)
+        },
       },
     }),
     Placeholder.configure({
@@ -139,6 +223,32 @@ export function RichTextEditor({
       onEditorReady(null)
     }
   }, [editor, onEditorReady])
+
+  const setLink = () => {
+    if (!editor) {
+      return
+    }
+
+    const previousHref = editor.getAttributes("link").href
+    const href = window.prompt("Link URL", typeof previousHref === "string" ? previousHref : "")
+
+    if (href === null) {
+      return
+    }
+
+    if (href.trim() === "") {
+      editor.chain().focus().extendMarkRange("link").unsetLink().run()
+      return
+    }
+
+    const normalizedHref = normalizeLinkHref(href)
+
+    if (!normalizedHref) {
+      return
+    }
+
+    editor.chain().focus().extendMarkRange("link").setLink({ href: normalizedHref }).run()
+  }
 
   return (
     <div className={cn("rounded-md border border-input bg-transparent", className)}>
@@ -206,6 +316,21 @@ export function RichTextEditor({
           onClick={() => editor?.chain().focus().toggleBlockquote().run()}
         >
           <Quote className="h-4 w-4" />
+        </ToolbarButton>
+        <ToolbarButton
+          label="Link"
+          active={editor?.isActive("link")}
+          disabled={!editor || disabled}
+          onClick={setLink}
+        >
+          <Link className="h-4 w-4" />
+        </ToolbarButton>
+        <ToolbarButton
+          label="Remove link"
+          disabled={!editor?.isActive("link")}
+          onClick={() => editor?.chain().focus().extendMarkRange("link").unsetLink().run()}
+        >
+          <Unlink className="h-4 w-4" />
         </ToolbarButton>
         <div className="ml-auto flex items-center gap-2">
           <ToolbarButton


### PR DESCRIPTION
## Summary

Fixes #564.

Product itinerary day descriptions now use the shared rich text editor instead of a plain textarea, so imported HTML/rich-text content is edited as authored content instead of raw markup.

The shared rich text editor also now supports links: existing anchors are preserved by the TipTap StarterKit link extension, pasted URLs can be linked, and the toolbar includes add/remove link actions with protocol filtering for http, https, mailto, tel, and relative links.

PDF generation now strips rich-text markup before drawing product and itinerary day descriptions, so saved editor HTML does not appear as raw markup in generated PDFs.

## Changes

- Replaced the product itinerary day description textarea with `RichTextEditor`.
- Added safe link configuration and link/unlink toolbar buttons to `@voyantjs/ui`'s shared editor.
- Added PDF plain-text normalization for rich-text product/day descriptions.
- Added a patch changeset for `@voyantjs/products`, `@voyantjs/products-ui`, and `@voyantjs/ui`.

## Validation

- `pnpm install`
- `pnpm exec biome check --write .changeset/rich-itinerary-day-descriptions.md packages/products/src/tasks/pdf-text.ts packages/products/src/tasks/generate-pdf.ts packages/products/tests/unit/generate-pdf.test.ts packages/products-ui/src/components/product-day-form.tsx packages/ui/src/components/rich-text-editor.tsx`
- `pnpm --dir packages/products exec vitest run tests/unit/generate-pdf.test.ts`
- `pnpm --filter @voyantjs/products typecheck`
- `pnpm --filter @voyantjs/ui typecheck`
- `pnpm --filter @voyantjs/products-ui typecheck`