### PR TITLE
Add agent runner claim and release commands

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -84,3 +84,29 @@ By default, prepare mode only selects Project items for the current checkout's
 `origin` repository. Organization Projects can contain issues from multiple
 repositories with the same issue number. Pass `--repo <owner/name>` only when
 preparing work for a different repository intentionally.
+
+After a workspace is prepared, claim the item before implementation work starts:
+
+```bash
+pnpm agent:queue:claim -- --issue <number> --yes
+```
+
+Claim mode checks the same execution gate, then updates GitHub Project fields:
+
+- `Status = In Progress`
+- `Agent State = Planning`
+- `Branch = <planned branch>`
+- `Workspace = <planned workspace>`
+- `Last Heartbeat = <today>`
+
+If a claimed item should return to the executable queue without shipping work,
+release it:
+
+```bash
+pnpm agent:queue:release -- --issue <number> --reason "Released without implementation" --yes
+```
+
+Release mode updates `Agent State = Ready`, resets `Status = Todo`, updates
+`Last Heartbeat` and `Evidence`, and clears `Branch`, `Workspace`, and
+`Blocked By`. It refuses to release closed issues or items outside the expected
+claimed states unless `--force` is passed.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "verify:full": "pnpm lint && pnpm verify:agent-quality && pnpm typecheck && pnpm test && pnpm verify:architecture && pnpm build && pnpm verify:package-exports && pnpm verify:publish-tarballs && pnpm i18n:check",
     "agent:queue:dry-run": "node scripts/agent-runner-dry-run.mjs",
     "agent:queue:prepare": "node scripts/agent-runner-prepare.mjs",
+    "agent:queue:claim": "node scripts/agent-runner-claim.mjs",
+    "agent:queue:release": "node scripts/agent-runner-release.mjs",
     "prepare": "husky",
     "seed:operator": "pnpm -C apps/scripts seed:operator",
     "regen:routes": "tsx scripts/regen-route-tree.ts",

--- a/scripts/agent-runner-claim.mjs
+++ b/scripts/agent-runner-claim.mjs
@@ -1,0 +1,55 @@
+import { updateProjectItemFields } from "./lib/agent-project-fields.mjs"
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  findSelectedReadyItem,
+  loadEvaluatedProject,
+  parseArgs,
+  projectConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const project = loadEvaluatedProject(projectConfigFromArgs(args))
+const item = findSelectedReadyItem(project.items, {
+  issueNumber: args.issue,
+  repository,
+})
+const values = {
+  Status: "In Progress",
+  "Agent State": "Planning",
+  Branch: item.dryRunPlan.branch,
+  Workspace: item.dryRunPlan.workspace,
+  "Last Heartbeat": today(),
+}
+
+if (!args.yes) {
+  printUpdate("claim", item, values)
+  fail("claim mode updates GitHub Project fields; rerun with --yes to continue")
+}
+
+updateProjectItemFields({ project, item, values })
+
+console.log("agent-runner claim: updated GitHub Project fields")
+console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+console.log(`repository: ${repository}`)
+console.log(`branch: ${item.dryRunPlan.branch}`)
+console.log(`workspace: ${item.dryRunPlan.workspace}`)
+console.log("agent state: Planning")
+console.log("")
+console.log("No agent was run. No branch was pushed.")
+
+function printUpdate(action, selectedItem, fieldValues) {
+  console.log(`agent-runner ${action} would update:`)
+  console.log(`issue: #${selectedItem.issue.number} ${selectedItem.issue.title}`)
+  console.log(`repository: ${repository}`)
+  for (const [fieldName, value] of Object.entries(fieldValues)) {
+    console.log(`${fieldName}: ${value}`)
+  }
+}
+
+function today() {
+  return new Date().toISOString().slice(0, 10)
+}

--- a/scripts/agent-runner-prepare.mjs
+++ b/scripts/agent-runner-prepare.mjs
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs"
 import path from "node:path"
 
 import {
+  currentRepositoryFromOrigin,
   fail,
   findSelectedReadyItem,
   loadEvaluatedProject,
@@ -12,7 +13,7 @@ import {
 
 const args = parseArgs(process.argv.slice(2))
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
-const repository = args.repo ?? currentRepository(repoRoot)
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
 const project = loadEvaluatedProject(projectConfigFromArgs(args))
 const item = findSelectedReadyItem(project.items, {
   issueNumber: args.issue,
@@ -53,20 +54,6 @@ console.log(`workspace: ${workspace}`)
 console.log(`plan: ${planPath}`)
 console.log("")
 console.log("No agent was run. No GitHub state was changed.")
-
-function currentRepository(repoRoot) {
-  const remoteUrl = runGit(["remote", "get-url", "origin"], { cwd: repoRoot })
-  const repository = repositoryFromGitHubRemote(remoteUrl)
-  if (!repository) {
-    fail("could not determine repository from origin remote; pass --repo <owner/name>")
-  }
-  return repository
-}
-
-function repositoryFromGitHubRemote(remoteUrl) {
-  const normalized = remoteUrl.trim().replace(/\.git$/, "")
-  return normalized.match(/github\.com[:/]([^/]+\/[^/]+)$/)?.[1]
-}
 
 function branchExists(branch, repoRoot) {
   const result = runGit(["branch", "--list", branch], { cwd: repoRoot })

--- a/scripts/agent-runner-release.mjs
+++ b/scripts/agent-runner-release.mjs
@@ -1,0 +1,83 @@
+import { updateProjectItemFields } from "./lib/agent-project-fields.mjs"
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  findProjectIssueItem,
+  loadEvaluatedProject,
+  parseArgs,
+  projectConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+
+const releasableStates = new Set([
+  "Planning",
+  "Running",
+  "Blocked",
+  "Human Review",
+  "Changes Requested",
+  "CI Repair",
+])
+
+const args = parseArgs(process.argv.slice(2))
+if (!args.issue) {
+  fail("release mode requires --issue <number>")
+}
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const project = loadEvaluatedProject(projectConfigFromArgs(args))
+const item = findProjectIssueItem(project.items, {
+  issueNumber: args.issue,
+  repository,
+})
+const currentState = item.fields["Agent State"]
+
+if (item.issue.state !== "OPEN") {
+  fail(`issue #${args.issue} is not releasable because issue state is ${item.issue.state}`)
+}
+
+if (!args.force && !releasableStates.has(currentState)) {
+  fail(
+    `issue #${args.issue} is not in a releasable Agent State: ${
+      currentState ?? "unset"
+    }; pass --force to override`,
+  )
+}
+
+const values = {
+  Status: "Todo",
+  "Agent State": "Ready",
+  "Last Heartbeat": today(),
+  Evidence: args.evidence ?? args.reason ?? `Released local claim at ${new Date().toISOString()}`,
+}
+const clear = ["Branch", "Workspace", "Blocked By"]
+
+if (!args.yes) {
+  printUpdate(item, values, clear)
+  fail("release mode updates GitHub Project fields; rerun with --yes to continue")
+}
+
+updateProjectItemFields({ project, item, values, clear })
+
+console.log("agent-runner release: updated GitHub Project fields")
+console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+console.log(`repository: ${repository}`)
+console.log("agent state: Ready")
+console.log("")
+console.log("No agent was run. No branch was pushed.")
+
+function printUpdate(selectedItem, fieldValues, clearFields) {
+  console.log("agent-runner release would update:")
+  console.log(`issue: #${selectedItem.issue.number} ${selectedItem.issue.title}`)
+  console.log(`repository: ${repository}`)
+  for (const [fieldName, value] of Object.entries(fieldValues)) {
+    console.log(`${fieldName}: ${value}`)
+  }
+  for (const fieldName of clearFields) {
+    console.log(`${fieldName}: <clear>`)
+  }
+}
+
+function today() {
+  return new Date().toISOString().slice(0, 10)
+}

--- a/scripts/lib/agent-project-fields.mjs
+++ b/scripts/lib/agent-project-fields.mjs
@@ -1,0 +1,135 @@
+import { spawnSync } from "node:child_process"
+
+import { fail } from "./agent-project-queue.mjs"
+
+export function updateProjectItemFields({ project, item, values, clear = [] }) {
+  const projectId = project.projectId
+  if (!projectId) {
+    fail("project id was not loaded")
+  }
+
+  const updates = Object.entries(values).map(([fieldName, value]) => {
+    const field = findField(project, fieldName)
+    return {
+      field,
+      value: projectValue(field, value),
+    }
+  })
+  const clears = clear.map((fieldName) => findField(project, fieldName))
+
+  for (const update of updates) {
+    updateProjectItemField({ projectId, itemId: item.itemId, ...update })
+  }
+
+  for (const field of clears) {
+    clearProjectItemField({
+      projectId,
+      itemId: item.itemId,
+      field,
+    })
+  }
+}
+
+function updateProjectItemField({ projectId, itemId, field, value }) {
+  const mutation = `
+    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: ProjectV2FieldValue!) {
+      updateProjectV2ItemFieldValue(input: {
+        projectId: $projectId
+        itemId: $itemId
+        fieldId: $fieldId
+        value: $value
+      }) {
+        projectV2Item {
+          id
+        }
+      }
+    }
+  `
+
+  runGhGraphql(mutation, {
+    projectId,
+    itemId,
+    fieldId: field.id,
+    value,
+  })
+}
+
+function clearProjectItemField({ projectId, itemId, field }) {
+  const mutation = `
+    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!) {
+      clearProjectV2ItemFieldValue(input: {
+        projectId: $projectId
+        itemId: $itemId
+        fieldId: $fieldId
+      }) {
+        projectV2Item {
+          id
+        }
+      }
+    }
+  `
+
+  runGhGraphql(mutation, {
+    projectId,
+    itemId,
+    fieldId: field.id,
+  })
+}
+
+function projectValue(field, value) {
+  if (field.dataType === "SINGLE_SELECT") {
+    const option = field.options.find((candidate) => candidate.name === value)
+    if (!option) {
+      fail(`option "${value}" was not found for Project field "${field.name}"`)
+    }
+    return { singleSelectOptionId: option.id }
+  }
+
+  if (field.dataType === "DATE") {
+    return { date: value }
+  }
+
+  if (field.dataType === "TEXT") {
+    return { text: value }
+  }
+
+  fail(`Project field "${field.name}" has unsupported data type ${field.dataType}`)
+}
+
+function findField(project, fieldName) {
+  const field = project.fieldDefinitions?.find((candidate) => candidate.name === fieldName)
+  if (!field) {
+    fail(`Project field "${fieldName}" was not found`)
+  }
+  return field
+}
+
+function runGhGraphql(query, variables) {
+  const result = spawnSync("gh", ["api", "graphql", "--input", "-"], {
+    encoding: "utf8",
+    input: JSON.stringify({ query, variables }),
+    maxBuffer: 1024 * 1024 * 10,
+  })
+
+  if (result.error) {
+    fail(`failed to run gh: ${result.error.message}`)
+  }
+
+  if (result.status !== 0) {
+    const stderr = result.stderr.trim()
+    fail(stderr || `gh api graphql exited with ${result.status}`)
+  }
+
+  let payload
+  try {
+    payload = JSON.parse(result.stdout)
+  } catch (error) {
+    fail(`failed to parse gh JSON output: ${error.message}`)
+  }
+
+  if (payload.errors?.length) {
+    fail(payload.errors.map((error) => error.message).join("; "))
+  }
+
+  return payload.data
+}

--- a/scripts/lib/agent-project-queue.mjs
+++ b/scripts/lib/agent-project-queue.mjs
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process"
 import path from "node:path"
 
 const knownTypes = new Set(["task", "bug", "refactor", "investigation", "cleanup"])
+const booleanArgs = new Set(["force", "json", "yes"])
 
 export function parseArgs(argv) {
   const parsed = {}
@@ -9,8 +10,9 @@ export function parseArgs(argv) {
     const arg = argv[index]
     if (arg === "--") continue
 
-    if (arg === "--json" || arg === "--yes") {
-      parsed[arg.slice(2)] = true
+    const booleanKey = arg.startsWith("--") ? arg.slice(2) : undefined
+    if (booleanArgs.has(booleanKey)) {
+      parsed[booleanKey] = true
       continue
     }
 
@@ -64,8 +66,10 @@ export function loadEvaluatedProject({ owner, projectNumber, limit }) {
   return {
     owner,
     projectNumber,
+    projectId: project.id,
     projectTitle: project.title,
     projectUrl: `https://github.com/orgs/${owner}/projects/${projectNumber}`,
+    fieldDefinitions: project.fields,
     items,
     readyItems: items.filter((item) => item.ready),
   }
@@ -76,7 +80,26 @@ export function readProjectItems({ owner, projectNumber, limit }) {
     query($owner: String!, $number: Int!, $limit: Int!) {
       organization(login: $owner) {
         projectV2(number: $number) {
+          id
           title
+          fields(first: 50) {
+            nodes {
+              ... on ProjectV2FieldCommon {
+                id
+                name
+                dataType
+              }
+              ... on ProjectV2SingleSelectField {
+                id
+                name
+                dataType
+                options {
+                  id
+                  name
+                }
+              }
+            }
+          }
           items(first: $limit) {
             nodes {
               id
@@ -191,7 +214,9 @@ export function readProjectItems({ owner, projectNumber, limit }) {
   }
 
   return {
+    id: project.id,
     title: project.title,
+    fields: normalizeProjectFields(project.fields?.nodes ?? []),
     items: project.items?.nodes ?? [],
   }
 }
@@ -251,30 +276,15 @@ export function evaluateItem(item) {
 }
 
 export function findSelectedReadyItem(items, { issueNumber, repository } = {}) {
-  const scopedItems = repository
-    ? items.filter((item) => repositoriesMatch(item.issue?.repository, repository))
-    : items
-
   if (issueNumber) {
-    const normalizedIssueNumber = Number(issueNumber)
-    if (!Number.isInteger(normalizedIssueNumber) || normalizedIssueNumber < 1) {
-      fail(`invalid issue number: ${String(issueNumber)}`)
-    }
-
-    const selected = scopedItems.find((item) => item.issue?.number === normalizedIssueNumber)
-    if (!selected) {
-      fail(
-        repository
-          ? `issue #${issueNumber} was not found for repository ${repository}`
-          : `issue #${issueNumber} was not found in the project item list`,
-      )
-    }
+    const selected = findProjectIssueItem(items, { issueNumber, repository })
     if (!selected.ready) {
       fail(`issue #${issueNumber} is not executable: ${selected.reasons.join("; ")}`)
     }
     return selected
   }
 
+  const scopedItems = filterItemsByRepository(items, repository)
   const readyItems = scopedItems.filter((item) => item.ready)
   if (readyItems.length === 0) {
     fail(
@@ -287,6 +297,25 @@ export function findSelectedReadyItem(items, { issueNumber, repository } = {}) {
     fail(`multiple executable items found; pass --issue <number>`)
   }
   return readyItems[0]
+}
+
+export function findProjectIssueItem(items, { issueNumber, repository } = {}) {
+  const normalizedIssueNumber = Number(issueNumber)
+  if (!Number.isInteger(normalizedIssueNumber) || normalizedIssueNumber < 1) {
+    fail(`invalid issue number: ${String(issueNumber)}`)
+  }
+
+  const selected = filterItemsByRepository(items, repository).find(
+    (item) => item.issue?.number === normalizedIssueNumber,
+  )
+  if (!selected) {
+    fail(
+      repository
+        ? `issue #${issueNumber} was not found for repository ${repository}`
+        : `issue #${issueNumber} was not found in the project item list`,
+    )
+  }
+  return selected
 }
 
 export function projectSummaryJson(project) {
@@ -356,9 +385,29 @@ export function runGit(gitArgs, options = {}) {
   return result.stdout.trim()
 }
 
+export function currentRepositoryFromOrigin(repoRoot) {
+  const remoteUrl = runGit(["remote", "get-url", "origin"], { cwd: repoRoot })
+  const repository = repositoryFromGitHubRemote(remoteUrl)
+  if (!repository) {
+    fail("could not determine repository from origin remote; pass --repo <owner/name>")
+  }
+  return repository
+}
+
 export function fail(message) {
   console.error(`agent-runner: ${message}`)
   process.exit(1)
+}
+
+function normalizeProjectFields(fields) {
+  return fields
+    .filter((field) => field.id && field.name)
+    .map((field) => ({
+      id: field.id,
+      name: field.name,
+      dataType: field.dataType,
+      options: field.options ?? [],
+    }))
 }
 
 function fieldMap(fieldValues) {
@@ -405,6 +454,17 @@ function repositoriesMatch(left, right) {
   return normalizeRepository(left) === normalizeRepository(right)
 }
 
+function filterItemsByRepository(items, repository) {
+  return repository
+    ? items.filter((item) => repositoriesMatch(item.issue?.repository, repository))
+    : items
+}
+
 function normalizeRepository(repository) {
   return repository?.trim().toLowerCase()
+}
+
+function repositoryFromGitHubRemote(remoteUrl) {
+  const normalized = remoteUrl.trim().replace(/\.git$/, "")
+  return normalized.match(/github\.com[:/]([^/]+\/[^/]+)$/)?.[1]
 }


### PR DESCRIPTION
## Summary
- add Project field mutation support for the local runner
- add claim mode to reserve an executable item by setting Status, Agent State, Branch, Workspace, and Last Heartbeat
- add release mode to return a claimed item to Ready, record Evidence, and clear local ownership fields
- document claim/release usage in the issue tracker guide

## Safety
- claim uses the same execution gate as dry-run and prepare
- release requires an explicit issue number and refuses closed issues
- release refuses unexpected Agent State values unless --force is passed
- neither command runs an implementation agent, pushes a branch, opens a PR, or touches code outside Project metadata

## Validation
- node --check scripts/lib/agent-project-queue.mjs
- node --check scripts/lib/agent-project-fields.mjs
- node --check scripts/agent-runner-prepare.mjs
- node --check scripts/agent-runner-claim.mjs
- node --check scripts/agent-runner-release.mjs
- pnpm agent:queue:dry-run
- pnpm agent:queue:dry-run -- --json
- pnpm agent:queue:claim (expected failure: no executable items)
- pnpm agent:queue:claim -- --issue 579 (expected failure: closed/unapproved smoke-test issue)
- pnpm agent:queue:release (expected failure: missing issue)
- pnpm agent:queue:release -- --issue 579 --reason "Release smoke test" (expected failure: closed issue)
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- pnpm verify:architecture
- pnpm exec secretlint scripts/lib/agent-project-queue.mjs scripts/lib/agent-project-fields.mjs scripts/agent-runner-prepare.mjs scripts/agent-runner-claim.mjs scripts/agent-runner-release.mjs docs/agents/issue-tracker.md package.json

## Local Verification Note
The broad affected typecheck/test lanes were not rerun for this script-only change because the current workspace still has unrelated UI/operator failures documented on the previous runner PR.