### PR TITLE
Add agent runner heartbeat command

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -99,6 +99,19 @@ Claim mode checks the same execution gate, then updates GitHub Project fields:
 - `Workspace = <planned workspace>`
 - `Last Heartbeat = <today>`
 
+While work is claimed, refresh the item heartbeat or state:
+
+```bash
+pnpm agent:queue:heartbeat -- --issue <number> --state Running --yes
+```
+
+Heartbeat mode updates `Last Heartbeat` and can move `Agent State` among
+`Planning`, `Running`, `Blocked`, `Human Review`, `Changes Requested`, and
+`CI Repair`. Blocked heartbeats require `--blocked-by` or `--reason`. Passing
+`--evidence <url-or-path>` updates the `Evidence` field. `Human Review`
+heartbeats require `--evidence`. When the state is not `Blocked`, heartbeat
+clears `Blocked By`.
+
 If a claimed item should return to the executable queue without shipping work,
 release it:
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "agent:queue:dry-run": "node scripts/agent-runner-dry-run.mjs",
     "agent:queue:prepare": "node scripts/agent-runner-prepare.mjs",
     "agent:queue:claim": "node scripts/agent-runner-claim.mjs",
+    "agent:queue:heartbeat": "node scripts/agent-runner-heartbeat.mjs",
     "agent:queue:release": "node scripts/agent-runner-release.mjs",
     "prepare": "husky",
     "seed:operator": "pnpm -C apps/scripts seed:operator",

--- a/scripts/agent-runner-heartbeat.mjs
+++ b/scripts/agent-runner-heartbeat.mjs
@@ -1,0 +1,98 @@
+import { updateProjectItemFields } from "./lib/agent-project-fields.mjs"
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  findProjectIssueItem,
+  loadEvaluatedProject,
+  parseArgs,
+  projectConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+
+const heartbeatStates = new Set([
+  "Planning",
+  "Running",
+  "Blocked",
+  "Human Review",
+  "Changes Requested",
+  "CI Repair",
+])
+
+const args = parseArgs(process.argv.slice(2))
+if (!args.issue) {
+  fail("heartbeat mode requires --issue <number>")
+}
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const project = loadEvaluatedProject(projectConfigFromArgs(args))
+const item = findProjectIssueItem(project.items, {
+  issueNumber: args.issue,
+  repository,
+})
+const currentState = item.fields["Agent State"]
+const nextState = args.state ?? currentState
+
+if (item.issue.state !== "OPEN") {
+  fail(`issue #${args.issue} cannot heartbeat because issue state is ${item.issue.state}`)
+}
+
+if (!nextState || !heartbeatStates.has(nextState)) {
+  fail(`Agent State must be one of: ${Array.from(heartbeatStates).join(", ")}`)
+}
+
+if (!args.force && !heartbeatStates.has(currentState)) {
+  fail(
+    `issue #${args.issue} is not in a heartbeat Agent State: ${
+      currentState ?? "unset"
+    }; pass --force to override`,
+  )
+}
+
+if (nextState === "Blocked" && !(args.blockedBy ?? args.reason)) {
+  fail("blocked heartbeats require --blocked-by or --reason")
+}
+
+if (nextState === "Human Review" && !args.evidence) {
+  fail("human review heartbeats require --evidence <url-or-path>")
+}
+
+const values = {
+  "Agent State": nextState,
+  "Last Heartbeat": today(),
+}
+
+if (args.evidence) values.Evidence = args.evidence
+if (args.blockedBy ?? args.reason) values["Blocked By"] = args.blockedBy ?? args.reason
+
+const clear = nextState === "Blocked" ? [] : ["Blocked By"]
+
+if (!args.yes) {
+  printUpdate(item, values, clear)
+  fail("heartbeat mode updates GitHub Project fields; rerun with --yes to continue")
+}
+
+updateProjectItemFields({ project, item, values, clear })
+
+console.log("agent-runner heartbeat: updated GitHub Project fields")
+console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+console.log(`repository: ${repository}`)
+console.log(`agent state: ${nextState}`)
+console.log("")
+console.log("No agent was run. No branch was pushed.")
+
+function printUpdate(selectedItem, fieldValues, clearFields) {
+  console.log("agent-runner heartbeat would update:")
+  console.log(`issue: #${selectedItem.issue.number} ${selectedItem.issue.title}`)
+  console.log(`repository: ${repository}`)
+  for (const [fieldName, value] of Object.entries(fieldValues)) {
+    console.log(`${fieldName}: ${value}`)
+  }
+  for (const fieldName of clearFields) {
+    console.log(`${fieldName}: <clear>`)
+  }
+}
+
+function today() {
+  return new Date().toISOString().slice(0, 10)
+}


### PR DESCRIPTION
## Summary
- add `agent:queue:heartbeat` for updating claimed item liveness and state
- allow claimed items to move among Planning, Running, Blocked, Human Review, Changes Requested, and CI Repair
- support Evidence updates and Blocked By handling from the heartbeat command
- document heartbeat usage in the issue tracker guide

## Safety
- requires an explicit issue number
- refuses closed issues
- refuses unexpected current Agent State values unless --force is passed
- blocked heartbeats require --blocked-by or --reason
- updates GitHub Project metadata only; it does not run agents, push branches, open PRs, or change code

## Validation
- node --check scripts/agent-runner-heartbeat.mjs
- pnpm agent:queue:heartbeat (expected failure: missing issue)
- pnpm agent:queue:heartbeat -- --issue 579 --state Running (expected failure: closed smoke-test issue)
- pnpm agent:queue:heartbeat -- --issue 579 --state Blocked (expected failure: closed smoke-test issue)
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- pnpm verify:architecture
- pnpm exec secretlint scripts/agent-runner-heartbeat.mjs docs/agents/issue-tracker.md package.json

## Local Verification Note
The broad affected typecheck/test lanes were not rerun for this script-only change because the current workspace still has unrelated UI/operator failures documented on prior runner PRs.