### PR TITLE
Add agent runner handoff command

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -112,6 +112,18 @@ Heartbeat mode updates `Last Heartbeat` and can move `Agent State` among
 heartbeats require `--evidence`. When the state is not `Blocked`, heartbeat
 clears `Blocked By`.
 
+When work is ready for maintainer review, write the evidence packet and hand
+off the Project item:
+
+```bash
+pnpm agent:queue:handoff -- --issue <number> --summary "..." --verification "pnpm lint:changed: passed" --yes
+```
+
+Handoff mode writes a markdown evidence packet under the task workspace,
+updates `Evidence` with that path, sets `Agent State = Human Review`, updates
+`Last Heartbeat`, and clears `Blocked By`. It requires `--summary` and
+`--verification` so maintainer review always has a concrete packet.
+
 If a claimed item should return to the executable queue without shipping work,
 release it:
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "agent:queue:prepare": "node scripts/agent-runner-prepare.mjs",
     "agent:queue:claim": "node scripts/agent-runner-claim.mjs",
     "agent:queue:heartbeat": "node scripts/agent-runner-heartbeat.mjs",
+    "agent:queue:handoff": "node scripts/agent-runner-handoff.mjs",
     "agent:queue:release": "node scripts/agent-runner-release.mjs",
     "prepare": "husky",
     "seed:operator": "pnpm -C apps/scripts seed:operator",

--- a/scripts/agent-runner-handoff.mjs
+++ b/scripts/agent-runner-handoff.mjs
@@ -1,0 +1,177 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs"
+import path from "node:path"
+
+import { updateProjectItemFields } from "./lib/agent-project-fields.mjs"
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  findProjectIssueItem,
+  loadEvaluatedProject,
+  parseArgs,
+  projectConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+
+const handoffStates = new Set(["Planning", "Running", "Changes Requested", "CI Repair"])
+
+const args = parseArgs(process.argv.slice(2))
+if (!args.issue) {
+  fail("handoff mode requires --issue <number>")
+}
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const project = loadEvaluatedProject(projectConfigFromArgs(args))
+const item = findProjectIssueItem(project.items, {
+  issueNumber: args.issue,
+  repository,
+})
+const currentState = item.fields["Agent State"]
+
+if (item.issue.state !== "OPEN") {
+  fail(`issue #${args.issue} cannot be handed off because issue state is ${item.issue.state}`)
+}
+
+if (!args.force && !handoffStates.has(currentState)) {
+  fail(
+    `issue #${args.issue} is not in a handoff Agent State: ${
+      currentState ?? "unset"
+    }; pass --force to override`,
+  )
+}
+
+if (!args.summary) {
+  fail("handoff mode requires --summary <text>")
+}
+
+if (!args.verification) {
+  fail("handoff mode requires --verification <command-and-outcome>")
+}
+
+const workspaceReference = args.workspace ?? item.fields.Workspace ?? item.dryRunPlan.workspace
+const branchReference = item.fields.Branch ?? item.dryRunPlan.branch
+const workspace = path.resolve(repoRoot, workspaceReference)
+if (!existsSync(workspace)) {
+  fail(`workspace does not exist: ${workspace}`)
+}
+
+const evidencePointer =
+  args.evidencePath ??
+  path.posix.join(
+    "docs/agent-evidence/active",
+    `${item.issue.number}-${slugFromTitle(item.issue.title)}.md`,
+  )
+const evidencePath = path.resolve(workspace, evidencePointer)
+const values = {
+  "Agent State": "Human Review",
+  "Last Heartbeat": today(),
+  Evidence: evidencePointer,
+}
+const clear = ["Blocked By"]
+
+if (!args.yes) {
+  printUpdate(item, values, clear, evidencePath)
+  fail("handoff mode writes an evidence packet and updates GitHub Project fields; rerun with --yes")
+}
+
+mkdirSync(path.dirname(evidencePath), { recursive: true })
+writeFileSync(
+  evidencePath,
+  buildEvidencePacket(item, { branch: branchReference, evidencePointer, repository, workspace }),
+  "utf8",
+)
+updateProjectItemFields({ project, item, values, clear })
+
+console.log("agent-runner handoff: wrote evidence packet and updated GitHub Project fields")
+console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+console.log(`repository: ${repository}`)
+console.log(`evidence: ${evidencePath}`)
+console.log("agent state: Human Review")
+console.log("")
+console.log("No agent was run. No branch was pushed.")
+
+function buildEvidencePacket(selectedItem, { branch, evidencePointer, repository, workspace }) {
+  return `# Evidence Packet: ${selectedItem.issue.title}
+
+Issue: ${selectedItem.issue.url}
+Repository: ${repository}
+Branch: ${branch}
+Workspace: ${workspace}
+Evidence: ${evidencePointer}
+Handoff state: Human Review
+Generated: ${new Date().toISOString()}
+
+## Summary
+
+${args.summary}
+
+## Files Touched
+
+${formatList(args.files)}
+
+## Verification
+
+${args.verification}
+
+## UI Evidence
+
+${args.uiEvidence ?? "Not applicable or not provided."}
+
+## Links
+
+- PR: ${args.pr ?? "Not provided."}
+- CI: ${args.ci ?? "Not provided."}
+- Logs: ${args.logs ?? "Not provided."}
+
+## Residual Risks
+
+${args.risks ?? "No known residual risks provided."}
+
+## Security Considerations
+
+${args.security ?? "No security-sensitive changes reported."}
+
+## Notes
+
+${args.notes ?? "No additional notes."}
+`
+}
+
+function printUpdate(selectedItem, fieldValues, clearFields, evidencePath) {
+  console.log("agent-runner handoff would update:")
+  console.log(`issue: #${selectedItem.issue.number} ${selectedItem.issue.title}`)
+  console.log(`repository: ${repository}`)
+  console.log(`evidence file: ${evidencePath}`)
+  for (const [fieldName, value] of Object.entries(fieldValues)) {
+    console.log(`${fieldName}: ${value}`)
+  }
+  for (const fieldName of clearFields) {
+    console.log(`${fieldName}: <clear>`)
+  }
+}
+
+function formatList(value) {
+  if (!value) return "- Not provided."
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => `- ${entry}`)
+    .join("\n")
+}
+
+function slugFromTitle(title) {
+  const slug = title
+    .toLowerCase()
+    .replace(/^\[(task|bug|refactor|investigation|cleanup)\]\s*:?\s*/i, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60)
+    .replace(/-+$/g, "")
+
+  return slug || "agent-task"
+}
+
+function today() {
+  return new Date().toISOString().slice(0, 10)
+}


### PR DESCRIPTION
## Summary
- add `agent:queue:handoff` for producing a markdown evidence packet in the task workspace
- move handed-off items to `Agent State = Human Review` and update `Evidence` with the packet path
- require summary and verification text before handoff so maintainer review has concrete evidence
- document the handoff command in the issue tracker guide

## Safety
- requires an explicit issue number
- refuses closed issues
- refuses unexpected current Agent State values unless `--force` is passed
- requires `--summary` and `--verification`
- requires the prepared workspace to exist before writing evidence
- updates GitHub Project metadata only; it does not run agents, push branches, open PRs, or change source files beyond the evidence packet in the task workspace

## Validation
- node --check scripts/agent-runner-handoff.mjs
- pnpm agent:queue:handoff (expected failure: missing issue)
- pnpm agent:queue:handoff -- --issue 579 --summary "Smoke handoff" --verification "not run" (expected failure: closed smoke-test issue)
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- pnpm verify:architecture
- pnpm exec secretlint scripts/agent-runner-handoff.mjs docs/agents/issue-tracker.md package.json

## Local Verification Note
The broad affected typecheck/test lanes were not rerun for this script-only change because the current workspace still has unrelated UI/operator failures documented on prior runner PRs.
