### PR TITLE
Add agent runner evidence publishing

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -124,6 +124,17 @@ updates `Evidence` with that path, sets `Agent State = Human Review`, updates
 `Last Heartbeat`, and clears `Blocked By`. It requires `--summary` and
 `--verification` so maintainer review always has a concrete packet.
 
+Publish the evidence packet when it should survive beyond the local workspace:
+
+```bash
+pnpm agent:queue:publish-evidence -- --issue <number> --yes
+```
+
+Publish mode reads the evidence packet from the task workspace, posts it as a
+GitHub issue comment, updates `Evidence` with the comment URL, and refreshes
+`Last Heartbeat`. It refuses remote Evidence URLs so it does not duplicate an
+already-published packet.
+
 If a claimed item should return to the executable queue without shipping work,
 release it:
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "agent:queue:claim": "node scripts/agent-runner-claim.mjs",
     "agent:queue:heartbeat": "node scripts/agent-runner-heartbeat.mjs",
     "agent:queue:handoff": "node scripts/agent-runner-handoff.mjs",
+    "agent:queue:publish-evidence": "node scripts/agent-runner-publish-evidence.mjs",
     "agent:queue:release": "node scripts/agent-runner-release.mjs",
     "prepare": "husky",
     "seed:operator": "pnpm -C apps/scripts seed:operator",

--- a/scripts/agent-runner-publish-evidence.mjs
+++ b/scripts/agent-runner-publish-evidence.mjs
@@ -1,0 +1,173 @@
+import { spawnSync } from "node:child_process"
+import { existsSync, readFileSync } from "node:fs"
+import path from "node:path"
+
+import { updateProjectItemFields } from "./lib/agent-project-fields.mjs"
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  findProjectIssueItem,
+  loadEvaluatedProject,
+  parseArgs,
+  projectConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+if (!args.issue) {
+  fail("publish-evidence mode requires --issue <number>")
+}
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const project = loadEvaluatedProject(projectConfigFromArgs(args))
+const item = findProjectIssueItem(project.items, {
+  issueNumber: args.issue,
+  repository,
+})
+
+if (item.issue.state !== "OPEN") {
+  fail(`issue #${args.issue} cannot publish evidence because issue state is ${item.issue.state}`)
+}
+
+const workspaceReference = args.workspace ?? item.fields.Workspace ?? item.dryRunPlan.workspace
+const evidenceReference = args.evidencePath ?? item.fields.Evidence
+
+if (!evidenceReference) {
+  fail("publish-evidence mode requires --evidence-path or an existing Evidence field")
+}
+
+if (isRemoteEvidence(evidenceReference)) {
+  fail(`Evidence already points at a remote artifact: ${evidenceReference}`)
+}
+
+const evidencePath = path.resolve(repoRoot, workspaceReference, evidenceReference)
+if (!existsSync(evidencePath)) {
+  fail(`evidence packet does not exist: ${evidencePath}`)
+}
+
+const evidenceBody = readFileSync(evidencePath, "utf8")
+if (!evidenceBody.trim()) {
+  fail(`evidence packet is empty: ${evidencePath}`)
+}
+
+const marker = evidenceMarker({
+  evidenceReference,
+  issueNumber: item.issue.number,
+  repository,
+})
+const existingCommentUrl = findExistingEvidenceComment({
+  issueNumber: item.issue.number,
+  marker,
+  repository,
+})
+
+if (!args.yes) {
+  console.log("agent-runner publish-evidence would update:")
+  console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+  console.log(`repository: ${repository}`)
+  console.log(`evidence file: ${evidencePath}`)
+  console.log(`Evidence: ${existingCommentUrl ?? "<new issue comment URL>"}`)
+  fail("publish-evidence mode comments on GitHub and updates Project fields; rerun with --yes")
+}
+
+const commentUrl =
+  existingCommentUrl ??
+  createIssueComment({
+    body: `${marker}\n\n${evidenceBody}`,
+    issueNumber: item.issue.number,
+    repository,
+  })
+
+updateProjectItemFields({
+  project,
+  item,
+  values: {
+    Evidence: commentUrl,
+    "Last Heartbeat": today(),
+  },
+})
+
+console.log("agent-runner publish-evidence: posted issue comment and updated Project fields")
+console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+console.log(`repository: ${repository}`)
+console.log(`evidence: ${commentUrl}`)
+
+function findExistingEvidenceComment({ issueNumber, marker, repository }) {
+  const result = spawnSync("gh", ["api", `repos/${repository}/issues/${issueNumber}/comments`], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 10,
+  })
+
+  if (result.error) {
+    fail(`failed to run gh: ${result.error.message}`)
+  }
+
+  if (result.status !== 0) {
+    const stderr = result.stderr.trim()
+    fail(stderr || `gh api exited with ${result.status}`)
+  }
+
+  let payload
+  try {
+    payload = JSON.parse(result.stdout)
+  } catch (error) {
+    fail(`failed to parse gh JSON output: ${error.message}`)
+  }
+
+  const comment = payload.find((candidate) => candidate.body?.includes(marker))
+  return comment?.html_url
+}
+
+function createIssueComment({ body, issueNumber, repository }) {
+  const result = spawnSync(
+    "gh",
+    [
+      "api",
+      `repos/${repository}/issues/${issueNumber}/comments`,
+      "-X",
+      "POST",
+      "-f",
+      `body=${body}`,
+    ],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024 * 10,
+    },
+  )
+
+  if (result.error) {
+    fail(`failed to run gh: ${result.error.message}`)
+  }
+
+  if (result.status !== 0) {
+    const stderr = result.stderr.trim()
+    fail(stderr || `gh api exited with ${result.status}`)
+  }
+
+  let payload
+  try {
+    payload = JSON.parse(result.stdout)
+  } catch (error) {
+    fail(`failed to parse gh JSON output: ${error.message}`)
+  }
+
+  if (!payload.html_url) {
+    fail("GitHub did not return an issue comment URL")
+  }
+
+  return payload.html_url
+}
+
+function evidenceMarker({ evidenceReference, issueNumber, repository }) {
+  const key = Buffer.from(`${repository}#${issueNumber}:${evidenceReference}`).toString("base64url")
+  return `<!-- voyant-agent-evidence:${key} -->`
+}
+
+function isRemoteEvidence(evidence) {
+  return /^https?:\/\//.test(evidence)
+}
+
+function today() {
+  return new Date().toISOString().slice(0, 10)
+}


### PR DESCRIPTION
## Summary
- add `agent:queue:publish-evidence` to publish a local evidence packet as a GitHub issue comment
- update the Project `Evidence` field to the durable issue comment URL
- refresh `Last Heartbeat` after publishing evidence
- document evidence publishing in the issue tracker guide

## Safety
- requires an explicit issue number
- refuses closed issues
- refuses already-remote Evidence values so it does not duplicate published packets
- requires the local evidence packet file to exist and be non-empty
- requires `--yes` before creating a GitHub comment or updating Project fields
- does not run agents, push branches, or open PRs

## Validation
- node --check scripts/agent-runner-publish-evidence.mjs
- pnpm agent:queue:publish-evidence (expected failure: missing issue)
- pnpm agent:queue:publish-evidence -- --issue 579 (expected failure: closed smoke-test issue)
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- pnpm verify:architecture
- pnpm exec secretlint scripts/agent-runner-publish-evidence.mjs docs/agents/issue-tracker.md package.json

## Local Verification Note
The broad affected typecheck/test lanes were not rerun for this script-only change because the current workspace still has unrelated UI/operator failures documented on prior runner PRs.
