### PR TITLE
Add agent runner watchdog command

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -135,6 +135,16 @@ GitHub issue comment, updates `Evidence` with the comment URL, and refreshes
 `Last Heartbeat`. It refuses remote Evidence URLs so it does not duplicate an
 already-published packet.
 
+Use the watchdog to find claimed work that has stopped reporting heartbeats:
+
+```bash
+pnpm agent:queue:watchdog
+```
+
+Watchdog mode is read-only. It reports items in active agent states with a
+missing or stale `Last Heartbeat`. The default stale threshold is one day; pass
+`--max-age-days <number>` to adjust it.
+
 If a claimed item should return to the executable queue without shipping work,
 release it:
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "agent:queue:heartbeat": "node scripts/agent-runner-heartbeat.mjs",
     "agent:queue:handoff": "node scripts/agent-runner-handoff.mjs",
     "agent:queue:publish-evidence": "node scripts/agent-runner-publish-evidence.mjs",
+    "agent:queue:watchdog": "node scripts/agent-runner-watchdog.mjs",
     "agent:queue:release": "node scripts/agent-runner-release.mjs",
     "prepare": "husky",
     "seed:operator": "pnpm -C apps/scripts seed:operator",

--- a/scripts/agent-runner-watchdog.mjs
+++ b/scripts/agent-runner-watchdog.mjs
@@ -1,0 +1,126 @@
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  loadAllEvaluatedProject,
+  parseArgs,
+  projectConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+
+const watchedStates = new Set([
+  "Planning",
+  "Running",
+  "Blocked",
+  "Human Review",
+  "Changes Requested",
+  "CI Repair",
+])
+
+const args = parseArgs(process.argv.slice(2))
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const maxAgeDays = Number(args.maxAgeDays ?? 1)
+
+if (!Number.isInteger(maxAgeDays) || maxAgeDays < 0) {
+  fail(`invalid max age days: ${String(args.maxAgeDays)}`)
+}
+
+const project = loadAllEvaluatedProject(
+  projectConfigFromArgs({ ...args, limit: args.limit ?? 100 }),
+)
+const activeItems = project.items
+  .filter((item) => item.issue?.repository === repository)
+  .filter((item) => watchedStates.has(item.fields["Agent State"]))
+const staleItems = activeItems
+  .map((item) => ({ ...item, heartbeat: evaluateHeartbeat(item.fields["Last Heartbeat"]) }))
+  .filter((item) => item.heartbeat.stale)
+
+if (args.json) {
+  console.log(
+    JSON.stringify(
+      {
+        project: {
+          owner: project.owner,
+          number: project.projectNumber,
+          title: project.projectTitle,
+          url: project.projectUrl,
+        },
+        repository,
+        maxAgeDays,
+        activeCount: activeItems.length,
+        staleCount: staleItems.length,
+        staleItems: staleItems.map(summaryItem),
+      },
+      null,
+      2,
+    ),
+  )
+} else {
+  printHumanSummary()
+}
+
+function printHumanSummary() {
+  console.log(
+    `agent-runner watchdog: ${project.projectTitle} (${project.owner}/projects/${project.projectNumber})`,
+  )
+  console.log(`repository: ${repository}`)
+  console.log(`active items: ${activeItems.length}`)
+  console.log(`stale items: ${staleItems.length}`)
+  console.log(`max heartbeat age: ${maxAgeDays} day${maxAgeDays === 1 ? "" : "s"}`)
+  console.log("")
+
+  if (staleItems.length === 0) {
+    console.log("No stale agent work found.")
+    return
+  }
+
+  console.log("Stale items:")
+  for (const item of staleItems) {
+    console.log(`- #${item.issue.number} ${item.issue.title}`)
+    console.log(`  state: ${item.fields["Agent State"]}`)
+    console.log(`  heartbeat: ${item.fields["Last Heartbeat"] ?? "unset"}`)
+    console.log(`  reason: ${item.heartbeat.reason}`)
+    console.log(`  url: ${item.issue.url}`)
+  }
+}
+
+function summaryItem(item) {
+  return {
+    issue: item.issue,
+    agentState: item.fields["Agent State"],
+    lastHeartbeat: item.fields["Last Heartbeat"] ?? null,
+    reason: item.heartbeat.reason,
+    branch: item.fields.Branch ?? null,
+    workspace: item.fields.Workspace ?? null,
+    evidence: item.fields.Evidence ?? null,
+  }
+}
+
+function evaluateHeartbeat(value) {
+  if (!value) {
+    return { reason: "Last Heartbeat is unset", stale: true }
+  }
+
+  const parsed = Date.parse(`${value}T00:00:00Z`)
+  if (Number.isNaN(parsed)) {
+    return { reason: `Last Heartbeat is invalid: ${value}`, stale: true }
+  }
+
+  const ageDays = Math.floor((startOfTodayUtc() - parsed) / 86_400_000)
+  if (ageDays > maxAgeDays) {
+    return {
+      reason: `Last Heartbeat is ${ageDays} days old`,
+      stale: true,
+    }
+  }
+
+  return {
+    reason: `Last Heartbeat is ${ageDays} days old`,
+    stale: false,
+  }
+}
+
+function startOfTodayUtc() {
+  const now = new Date()
+  return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+}

--- a/scripts/lib/agent-project-queue.mjs
+++ b/scripts/lib/agent-project-queue.mjs
@@ -63,6 +63,29 @@ export function loadEvaluatedProject({ owner, projectNumber, limit }) {
   const project = readProjectItems({ owner, projectNumber, limit })
   const items = project.items.map(evaluateItem)
 
+  return evaluatedProject({ items, owner, project, projectNumber })
+}
+
+export function loadAllEvaluatedProject({ owner, projectNumber, limit }) {
+  const pageSize = limit ?? 100
+  const pages = []
+  let after
+
+  do {
+    const page = readProjectItems({ after, limit: pageSize, owner, projectNumber })
+    pages.push(page)
+    after = page.pageInfo.endCursor
+    if (page.pageInfo.hasNextPage && !after) {
+      fail("Project item pagination returned no cursor")
+    }
+  } while (pages.at(-1).pageInfo.hasNextPage)
+
+  const project = pages[0]
+  const items = pages.flatMap((page) => page.items).map(evaluateItem)
+  return evaluatedProject({ items, owner, project, projectNumber })
+}
+
+function evaluatedProject({ items, owner, project, projectNumber }) {
   return {
     owner,
     projectNumber,
@@ -75,9 +98,9 @@ export function loadEvaluatedProject({ owner, projectNumber, limit }) {
   }
 }
 
-export function readProjectItems({ owner, projectNumber, limit }) {
+export function readProjectItems({ after, owner, projectNumber, limit }) {
   const query = `
-    query($owner: String!, $number: Int!, $limit: Int!) {
+    query($owner: String!, $number: Int!, $limit: Int!, $after: String) {
       organization(login: $owner) {
         projectV2(number: $number) {
           id
@@ -100,7 +123,7 @@ export function readProjectItems({ owner, projectNumber, limit }) {
               }
             }
           }
-          items(first: $limit) {
+          items(first: $limit, after: $after) {
             nodes {
               id
               content {
@@ -162,31 +185,36 @@ export function readProjectItems({ owner, projectNumber, limit }) {
                 }
               }
             }
+            pageInfo {
+              endCursor
+              hasNextPage
+            }
           }
         }
       }
     }
   `
 
-  const result = spawnSync(
-    "gh",
-    [
-      "api",
-      "graphql",
-      "-f",
-      `owner=${owner}`,
-      "-F",
-      `number=${projectNumber}`,
-      "-F",
-      `limit=${limit}`,
-      "-f",
-      `query=${query}`,
-    ],
-    {
-      encoding: "utf8",
-      maxBuffer: 1024 * 1024 * 10,
-    },
-  )
+  const ghArgs = [
+    "api",
+    "graphql",
+    "-f",
+    `owner=${owner}`,
+    "-F",
+    `number=${projectNumber}`,
+    "-F",
+    `limit=${limit}`,
+    "-f",
+    `query=${query}`,
+  ]
+  if (after) {
+    ghArgs.push("-f", `after=${after}`)
+  }
+
+  const result = spawnSync("gh", ghArgs, {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 10,
+  })
 
   if (result.error) {
     fail(`failed to run gh: ${result.error.message}`)
@@ -218,6 +246,7 @@ export function readProjectItems({ owner, projectNumber, limit }) {
     title: project.title,
     fields: normalizeProjectFields(project.fields?.nodes ?? []),
     items: project.items?.nodes ?? [],
+    pageInfo: project.items?.pageInfo ?? { endCursor: null, hasNextPage: false },
   }
 }
 


### PR DESCRIPTION
## Summary
- add `agent:queue:watchdog` for read-only stale heartbeat reporting
- scan active agent states for missing or stale `Last Heartbeat`
- support human and JSON output
- document watchdog usage in the issue tracker guide

## Safety
- read-only: no GitHub mutations, no worktree changes, no agent execution
- defaults to the current checkout repository so org-level Project issue numbers stay scoped
- validates `--max-age-days` before scanning

## Validation
- node --check scripts/agent-runner-watchdog.mjs
- pnpm agent:queue:watchdog
- pnpm agent:queue:watchdog -- --json
- pnpm agent:queue:watchdog -- --max-age-days -1 (expected failure: invalid threshold)
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- pnpm verify:architecture
- pnpm exec secretlint scripts/agent-runner-watchdog.mjs docs/agents/issue-tracker.md package.json

## Local Verification Note
The broad affected typecheck/test lanes were not rerun for this script-only change because the current workspace still has unrelated UI/operator failures documented on prior runner PRs.
