### PR TITLE
Add agent runner status command

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -85,6 +85,17 @@ By default, prepare mode only selects Project items for the current checkout's
 repositories with the same issue number. Pass `--repo <owner/name>` only when
 preparing work for a different repository intentionally.
 
+Use the read-only status view to inspect the current queue and active work:
+
+```bash
+pnpm agent:queue:status
+```
+
+Status mode scans all Project pages for the current repository and reports
+ready, active, stale, blocked, human-review, and merge-ready items. Pass
+`--json` for automation or `--max-age-days <number>` to adjust the heartbeat
+staleness threshold.
+
 After a workspace is prepared, claim the item before implementation work starts:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "verify:fast": "pnpm lint:changed && pnpm verify:agent-quality:changed && pnpm typecheck:affected && pnpm test:affected && pnpm verify:architecture",
     "verify:full": "pnpm lint && pnpm verify:agent-quality && pnpm typecheck && pnpm test && pnpm verify:architecture && pnpm build && pnpm verify:package-exports && pnpm verify:publish-tarballs && pnpm i18n:check",
     "agent:queue:dry-run": "node scripts/agent-runner-dry-run.mjs",
+    "agent:queue:status": "node scripts/agent-runner-status.mjs",
     "agent:queue:prepare": "node scripts/agent-runner-prepare.mjs",
     "agent:queue:claim": "node scripts/agent-runner-claim.mjs",
     "agent:queue:heartbeat": "node scripts/agent-runner-heartbeat.mjs",

--- a/scripts/agent-runner-status.mjs
+++ b/scripts/agent-runner-status.mjs
@@ -1,0 +1,133 @@
+import {
+  currentRepositoryFromOrigin,
+  evaluateHeartbeat,
+  fail,
+  filterItemsByRepository,
+  loadAllEvaluatedProject,
+  parseArgs,
+  projectConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+
+const activeStates = new Set([
+  "Planning",
+  "Running",
+  "Blocked",
+  "Human Review",
+  "Changes Requested",
+  "CI Repair",
+])
+
+const args = parseArgs(process.argv.slice(2))
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const maxAgeDays = Number(args.maxAgeDays ?? 1)
+
+if (!Number.isInteger(maxAgeDays) || maxAgeDays < 0) {
+  fail(`invalid max age days: ${String(args.maxAgeDays)}`)
+}
+
+const project = loadAllEvaluatedProject(
+  projectConfigFromArgs({ ...args, limit: args.limit ?? 100 }),
+)
+const items = filterItemsByRepository(project.items, repository)
+const readyItems = items.filter((item) => item.ready)
+const activeItems = items
+  .filter((item) => activeStates.has(item.fields["Agent State"]))
+  .map((item) => ({
+    ...item,
+    heartbeat: evaluateHeartbeat(item.fields["Last Heartbeat"], { maxAgeDays }),
+  }))
+const staleItems = activeItems.filter((item) => item.heartbeat.stale)
+const blockedItems = items.filter((item) => item.fields["Agent State"] === "Blocked")
+const reviewItems = items.filter((item) => item.fields["Agent State"] === "Human Review")
+const mergeReadyItems = items.filter((item) => item.fields["Agent State"] === "Merge Ready")
+
+if (args.json) {
+  console.log(
+    JSON.stringify(
+      {
+        project: {
+          owner: project.owner,
+          number: project.projectNumber,
+          title: project.projectTitle,
+          url: project.projectUrl,
+        },
+        repository,
+        maxAgeDays,
+        counts: {
+          scanned: items.length,
+          ready: readyItems.length,
+          active: activeItems.length,
+          stale: staleItems.length,
+          blocked: blockedItems.length,
+          humanReview: reviewItems.length,
+          mergeReady: mergeReadyItems.length,
+        },
+        readyItems: readyItems.map(summaryItem),
+        activeItems: activeItems.map(summaryItem),
+        staleItems: staleItems.map(summaryItem),
+        blockedItems: blockedItems.map(summaryItem),
+        humanReviewItems: reviewItems.map(summaryItem),
+        mergeReadyItems: mergeReadyItems.map(summaryItem),
+      },
+      null,
+      2,
+    ),
+  )
+} else {
+  printHumanSummary()
+}
+
+function printHumanSummary() {
+  console.log(
+    `agent-runner status: ${project.projectTitle} (${project.owner}/projects/${project.projectNumber})`,
+  )
+  console.log(`repository: ${repository}`)
+  console.log(`items scanned: ${items.length}`)
+  console.log(`ready items: ${readyItems.length}`)
+  console.log(`active items: ${activeItems.length}`)
+  console.log(`stale active items: ${staleItems.length}`)
+  console.log(`blocked items: ${blockedItems.length}`)
+  console.log(`human review items: ${reviewItems.length}`)
+  console.log(`merge ready items: ${mergeReadyItems.length}`)
+  console.log("")
+
+  printSection("Ready items", readyItems)
+  printSection("Stale active items", staleItems, printHeartbeat)
+  printSection("Blocked items", blockedItems)
+  printSection("Human review items", reviewItems)
+  printSection("Merge ready items", mergeReadyItems)
+}
+
+function printSection(title, sectionItems, extraPrinter) {
+  if (sectionItems.length === 0) return
+
+  console.log(`${title}:`)
+  for (const item of sectionItems) {
+    console.log(`- #${item.issue.number} ${item.issue.title}`)
+    console.log(`  state: ${item.fields["Agent State"] ?? "unset"}`)
+    console.log(`  url: ${item.issue.url}`)
+    if (extraPrinter) extraPrinter(item)
+  }
+  console.log("")
+}
+
+function printHeartbeat(item) {
+  console.log(`  heartbeat: ${item.fields["Last Heartbeat"] ?? "unset"}`)
+  console.log(`  reason: ${item.heartbeat.reason}`)
+}
+
+function summaryItem(item) {
+  return {
+    issue: item.issue,
+    agentState: item.fields["Agent State"] ?? null,
+    maintainerApproved: item.fields["Maintainer Approved"] ?? null,
+    lastHeartbeat: item.fields["Last Heartbeat"] ?? null,
+    heartbeat: item.heartbeat ?? null,
+    branch: item.fields.Branch ?? null,
+    workspace: item.fields.Workspace ?? null,
+    pr: item.fields.PR ?? null,
+    evidence: item.fields.Evidence ?? null,
+  }
+}

--- a/scripts/agent-runner-watchdog.mjs
+++ b/scripts/agent-runner-watchdog.mjs
@@ -1,6 +1,8 @@
 import {
   currentRepositoryFromOrigin,
+  evaluateHeartbeat,
   fail,
+  filterItemsByRepository,
   loadAllEvaluatedProject,
   parseArgs,
   projectConfigFromArgs,
@@ -28,11 +30,14 @@ if (!Number.isInteger(maxAgeDays) || maxAgeDays < 0) {
 const project = loadAllEvaluatedProject(
   projectConfigFromArgs({ ...args, limit: args.limit ?? 100 }),
 )
-const activeItems = project.items
-  .filter((item) => item.issue?.repository === repository)
-  .filter((item) => watchedStates.has(item.fields["Agent State"]))
+const activeItems = filterItemsByRepository(project.items, repository).filter((item) =>
+  watchedStates.has(item.fields["Agent State"]),
+)
 const staleItems = activeItems
-  .map((item) => ({ ...item, heartbeat: evaluateHeartbeat(item.fields["Last Heartbeat"]) }))
+  .map((item) => ({
+    ...item,
+    heartbeat: evaluateHeartbeat(item.fields["Last Heartbeat"], { maxAgeDays }),
+  }))
   .filter((item) => item.heartbeat.stale)
 
 if (args.json) {
@@ -94,33 +99,4 @@ function summaryItem(item) {
     workspace: item.fields.Workspace ?? null,
     evidence: item.fields.Evidence ?? null,
   }
-}
-
-function evaluateHeartbeat(value) {
-  if (!value) {
-    return { reason: "Last Heartbeat is unset", stale: true }
-  }
-
-  const parsed = Date.parse(`${value}T00:00:00Z`)
-  if (Number.isNaN(parsed)) {
-    return { reason: `Last Heartbeat is invalid: ${value}`, stale: true }
-  }
-
-  const ageDays = Math.floor((startOfTodayUtc() - parsed) / 86_400_000)
-  if (ageDays > maxAgeDays) {
-    return {
-      reason: `Last Heartbeat is ${ageDays} days old`,
-      stale: true,
-    }
-  }
-
-  return {
-    reason: `Last Heartbeat is ${ageDays} days old`,
-    stale: false,
-  }
-}
-
-function startOfTodayUtc() {
-  const now = new Date()
-  return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
 }

--- a/scripts/lib/agent-project-queue.mjs
+++ b/scripts/lib/agent-project-queue.mjs
@@ -361,6 +361,27 @@ export function projectSummaryJson(project) {
   }
 }
 
+export function evaluateHeartbeat(value, { maxAgeDays }) {
+  if (!Number.isInteger(maxAgeDays) || maxAgeDays < 0) {
+    fail(`invalid max age days: ${String(maxAgeDays)}`)
+  }
+
+  if (!value) {
+    return { reason: "Last Heartbeat is unset", stale: true }
+  }
+
+  const parsed = Date.parse(`${value}T00:00:00Z`)
+  if (Number.isNaN(parsed)) {
+    return { reason: `Last Heartbeat is invalid: ${value}`, stale: true }
+  }
+
+  const ageDays = Math.floor((startOfTodayUtc() - parsed) / 86_400_000)
+  return {
+    reason: `Last Heartbeat is ${ageDays} days old`,
+    stale: ageDays > maxAgeDays,
+  }
+}
+
 export function printHumanSummary(project) {
   console.log(
     `agent-runner dry run: ${project.projectTitle} (${project.owner}/projects/${project.projectNumber})`,
@@ -479,11 +500,16 @@ function quoteField(value) {
   return value ? `"${value}"` : "unset"
 }
 
+function startOfTodayUtc() {
+  const now = new Date()
+  return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+}
+
 function repositoriesMatch(left, right) {
   return normalizeRepository(left) === normalizeRepository(right)
 }
 
-function filterItemsByRepository(items, repository) {
+export function filterItemsByRepository(items, repository) {
   return repository
     ? items.filter((item) => repositoriesMatch(item.issue?.repository, repository))
     : items


### PR DESCRIPTION
## Summary
- add a read-only `agent:queue:status` command for queue and active-work overview
- report ready, active, stale, blocked, human-review, and merge-ready items for the current repository
- share heartbeat staleness evaluation between status and watchdog
- document status usage in the issue tracker guide

## Validation
- `node --check scripts/lib/agent-project-queue.mjs && node --check scripts/agent-runner-status.mjs && node --check scripts/agent-runner-watchdog.mjs`
- `pnpm agent:queue:status`
- `pnpm agent:queue:status -- --json`
- `pnpm agent:queue:status -- --max-age-days -1` exits with the expected validation error
- `pnpm agent:queue:watchdog`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed` (report-only warning: `scripts/lib/agent-project-queue.mjs` is 526 lines)
- `pnpm exec secretlint scripts/agent-runner-status.mjs scripts/agent-runner-watchdog.mjs scripts/lib/agent-project-queue.mjs docs/agents/issue-tracker.md package.json`
- `pnpm verify:architecture`

## Notes
- No changeset: this only changes internal runner scripts and docs.
- The local pre-commit full typecheck still fails on existing unrelated package UI/admin dependency/type issues.
- The local pre-push full test hook still fails on `@voyantjs/availability-ui#test`, outside this runner change.