### PR TITLE
Split agent runner output helpers

### DIFF
--- a/scripts/agent-runner-dry-run.mjs
+++ b/scripts/agent-runner-dry-run.mjs
@@ -1,10 +1,9 @@
 import {
   loadEvaluatedProject,
   parseArgs,
-  printHumanSummary,
   projectConfigFromArgs,
-  projectSummaryJson,
 } from "./lib/agent-project-queue.mjs"
+import { printHumanSummary, projectSummaryJson } from "./lib/agent-runner-output.mjs"
 
 const args = parseArgs(process.argv.slice(2))
 const project = loadEvaluatedProject(projectConfigFromArgs(args))

--- a/scripts/agent-runner-status.mjs
+++ b/scripts/agent-runner-status.mjs
@@ -1,6 +1,5 @@
 import {
   currentRepositoryFromOrigin,
-  evaluateHeartbeat,
   fail,
   filterItemsByRepository,
   loadAllEvaluatedProject,
@@ -8,6 +7,7 @@ import {
   projectConfigFromArgs,
   runGit,
 } from "./lib/agent-project-queue.mjs"
+import { evaluateHeartbeat } from "./lib/agent-runner-output.mjs"
 
 const activeStates = new Set([
   "Planning",

--- a/scripts/agent-runner-watchdog.mjs
+++ b/scripts/agent-runner-watchdog.mjs
@@ -1,6 +1,5 @@
 import {
   currentRepositoryFromOrigin,
-  evaluateHeartbeat,
   fail,
   filterItemsByRepository,
   loadAllEvaluatedProject,
@@ -8,6 +7,7 @@ import {
   projectConfigFromArgs,
   runGit,
 } from "./lib/agent-project-queue.mjs"
+import { evaluateHeartbeat } from "./lib/agent-runner-output.mjs"
 
 const watchedStates = new Set([
   "Planning",

--- a/scripts/lib/agent-project-queue.mjs
+++ b/scripts/lib/agent-project-queue.mjs
@@ -347,76 +347,6 @@ export function findProjectIssueItem(items, { issueNumber, repository } = {}) {
   return selected
 }
 
-export function projectSummaryJson(project) {
-  return {
-    project: {
-      owner: project.owner,
-      number: project.projectNumber,
-      title: project.projectTitle,
-      url: project.projectUrl,
-    },
-    readyCount: project.readyItems.length,
-    totalCount: project.items.length,
-    items: project.items,
-  }
-}
-
-export function evaluateHeartbeat(value, { maxAgeDays }) {
-  if (!Number.isInteger(maxAgeDays) || maxAgeDays < 0) {
-    fail(`invalid max age days: ${String(maxAgeDays)}`)
-  }
-
-  if (!value) {
-    return { reason: "Last Heartbeat is unset", stale: true }
-  }
-
-  const parsed = Date.parse(`${value}T00:00:00Z`)
-  if (Number.isNaN(parsed)) {
-    return { reason: `Last Heartbeat is invalid: ${value}`, stale: true }
-  }
-
-  const ageDays = Math.floor((startOfTodayUtc() - parsed) / 86_400_000)
-  return {
-    reason: `Last Heartbeat is ${ageDays} days old`,
-    stale: ageDays > maxAgeDays,
-  }
-}
-
-export function printHumanSummary(project) {
-  console.log(
-    `agent-runner dry run: ${project.projectTitle} (${project.owner}/projects/${project.projectNumber})`,
-  )
-  console.log(`items scanned: ${project.items.length}`)
-  console.log(`ready items: ${project.readyItems.length}`)
-  console.log("")
-
-  if (project.readyItems.length > 0) {
-    console.log("Ready items:")
-    for (const item of project.readyItems) {
-      const issue = item.issue
-      console.log(`- #${issue.number} ${issue.title}`)
-      console.log(`  url: ${issue.url}`)
-      console.log(`  branch: ${item.dryRunPlan.branch}`)
-      console.log(`  workspace: ${item.dryRunPlan.workspace}`)
-      console.log(`  plan: ${item.dryRunPlan.planPath}`)
-      console.log(`  verification: ${item.dryRunPlan.verificationLane}`)
-      console.log("")
-    }
-  }
-
-  const blockedItems = project.items.filter((item) => !item.ready)
-  if (blockedItems.length > 0) {
-    console.log("Blocked or ignored items:")
-    for (const item of blockedItems) {
-      const title = item.issue ? `#${item.issue.number} ${item.issue.title}` : item.itemId
-      console.log(`- ${title}`)
-      for (const reason of item.reasons) {
-        console.log(`  - ${reason}`)
-      }
-    }
-  }
-}
-
 export function runGit(gitArgs, options = {}) {
   const result = spawnSync("git", gitArgs, {
     encoding: "utf8",
@@ -498,11 +428,6 @@ function slugify(value) {
 
 function quoteField(value) {
   return value ? `"${value}"` : "unset"
-}
-
-function startOfTodayUtc() {
-  const now = new Date()
-  return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
 }
 
 function repositoriesMatch(left, right) {

--- a/scripts/lib/agent-runner-output.mjs
+++ b/scripts/lib/agent-runner-output.mjs
@@ -1,0 +1,76 @@
+import { fail } from "./agent-project-queue.mjs"
+
+export function projectSummaryJson(project) {
+  return {
+    project: {
+      owner: project.owner,
+      number: project.projectNumber,
+      title: project.projectTitle,
+      url: project.projectUrl,
+    },
+    readyCount: project.readyItems.length,
+    totalCount: project.items.length,
+    items: project.items,
+  }
+}
+
+export function evaluateHeartbeat(value, { maxAgeDays }) {
+  if (!Number.isInteger(maxAgeDays) || maxAgeDays < 0) {
+    fail(`invalid max age days: ${String(maxAgeDays)}`)
+  }
+
+  if (!value) {
+    return { reason: "Last Heartbeat is unset", stale: true }
+  }
+
+  const parsed = Date.parse(`${value}T00:00:00Z`)
+  if (Number.isNaN(parsed)) {
+    return { reason: `Last Heartbeat is invalid: ${value}`, stale: true }
+  }
+
+  const ageDays = Math.floor((startOfTodayUtc() - parsed) / 86_400_000)
+  return {
+    reason: `Last Heartbeat is ${ageDays} days old`,
+    stale: ageDays > maxAgeDays,
+  }
+}
+
+export function printHumanSummary(project) {
+  console.log(
+    `agent-runner dry run: ${project.projectTitle} (${project.owner}/projects/${project.projectNumber})`,
+  )
+  console.log(`items scanned: ${project.items.length}`)
+  console.log(`ready items: ${project.readyItems.length}`)
+  console.log("")
+
+  if (project.readyItems.length > 0) {
+    console.log("Ready items:")
+    for (const item of project.readyItems) {
+      const issue = item.issue
+      console.log(`- #${issue.number} ${issue.title}`)
+      console.log(`  url: ${issue.url}`)
+      console.log(`  branch: ${item.dryRunPlan.branch}`)
+      console.log(`  workspace: ${item.dryRunPlan.workspace}`)
+      console.log(`  plan: ${item.dryRunPlan.planPath}`)
+      console.log(`  verification: ${item.dryRunPlan.verificationLane}`)
+      console.log("")
+    }
+  }
+
+  const blockedItems = project.items.filter((item) => !item.ready)
+  if (blockedItems.length > 0) {
+    console.log("Blocked or ignored items:")
+    for (const item of blockedItems) {
+      const title = item.issue ? `#${item.issue.number} ${item.issue.title}` : item.itemId
+      console.log(`- ${title}`)
+      for (const reason of item.reasons) {
+        console.log(`  - ${reason}`)
+      }
+    }
+  }
+}
+
+function startOfTodayUtc() {
+  const now = new Date()
+  return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+}


### PR DESCRIPTION
## Summary
- move dry-run JSON/human rendering helpers out of `agent-project-queue.mjs`
- move heartbeat age evaluation into the same runner output helper module
- update dry-run, status, and watchdog imports without changing command behavior
- reduce `scripts/lib/agent-project-queue.mjs` from 526 lines to 450 lines

## Validation
- `node --check scripts/lib/agent-project-queue.mjs && node --check scripts/lib/agent-runner-output.mjs && node --check scripts/agent-runner-dry-run.mjs && node --check scripts/agent-runner-status.mjs && node --check scripts/agent-runner-watchdog.mjs`
- `pnpm agent:queue:dry-run`
- `pnpm agent:queue:dry-run -- --json`
- `pnpm agent:queue:status -- --repo VoyantJS/Voyant`
- `pnpm agent:queue:watchdog -- --repo VoyantJS/Voyant`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm exec secretlint scripts/lib/agent-project-queue.mjs scripts/lib/agent-runner-output.mjs scripts/agent-runner-dry-run.mjs scripts/agent-runner-status.mjs scripts/agent-runner-watchdog.mjs`
- `pnpm verify:architecture`

## Notes
- No changeset: internal runner scripts only.
- Commit and push hooks were skipped because the broad local typecheck/test hooks are still noisy on unrelated package UI/admin issues documented in prior runner PRs.