### PR TITLE
Add agent runner command help

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -59,6 +59,13 @@ or GraphQL when thread-level state or ProjectV2 fields are needed.
 
 ## Runner Dry Run
 
+All runner commands support `--help` and `-h`. When invoked through `pnpm`, pass
+runner flags after `--`:
+
+```bash
+pnpm agent:queue:status -- --help
+```
+
 Before any agent execution is enabled, use the read-only queue runner:
 
 ```bash

--- a/scripts/agent-runner-claim.mjs
+++ b/scripts/agent-runner-claim.mjs
@@ -8,8 +8,26 @@ import {
   projectConfigFromArgs,
   runGit,
 } from "./lib/agent-project-queue.mjs"
+import {
+  maybePrintHelp,
+  mutationOptions,
+  projectOptions,
+  repositoryOptions,
+} from "./lib/agent-runner-help.mjs"
 
 const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:claim",
+  summary: "Mark one approved Project item as claimed before implementation starts.",
+  usage: "pnpm agent:queue:claim -- --issue <number> --yes",
+  options: [
+    ["--issue <number>", "Issue number to claim. Required when multiple items are ready."],
+    ...repositoryOptions,
+    ...mutationOptions,
+    ...projectOptions,
+  ],
+})
+
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
 const project = loadEvaluatedProject(projectConfigFromArgs(args))

--- a/scripts/agent-runner-dry-run.mjs
+++ b/scripts/agent-runner-dry-run.mjs
@@ -3,9 +3,17 @@ import {
   parseArgs,
   projectConfigFromArgs,
 } from "./lib/agent-project-queue.mjs"
+import { maybePrintHelp, projectOptions } from "./lib/agent-runner-help.mjs"
 import { printHumanSummary, projectSummaryJson } from "./lib/agent-runner-output.mjs"
 
 const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:dry-run",
+  summary: "Read the agent Project queue and print executable work without mutating anything.",
+  usage: "pnpm agent:queue:dry-run -- [--json]",
+  options: [["--json", "Print machine-readable JSON."], ...projectOptions],
+})
+
 const project = loadEvaluatedProject(projectConfigFromArgs(args))
 
 if (args.json) {

--- a/scripts/agent-runner-handoff.mjs
+++ b/scripts/agent-runner-handoff.mjs
@@ -11,10 +11,34 @@ import {
   projectConfigFromArgs,
   runGit,
 } from "./lib/agent-project-queue.mjs"
+import {
+  maybePrintHelp,
+  mutationOptions,
+  projectOptions,
+  repositoryOptions,
+} from "./lib/agent-runner-help.mjs"
 
 const handoffStates = new Set(["Planning", "Running", "Changes Requested", "CI Repair"])
 
 const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:handoff",
+  summary: "Write an evidence packet and move claimed work to human review.",
+  usage: 'pnpm agent:queue:handoff -- --issue <number> --summary "..." --verification "..." --yes',
+  options: [
+    ["--issue <number>", "Issue number to hand off."],
+    ["--summary <text>", "Human-readable summary for the evidence packet."],
+    ["--verification <text>", "Verification command and outcome for the evidence packet."],
+    ["--evidence-path <path>", "Evidence path relative to the task workspace."],
+    ["--branch <name>", "Branch reference to record in the evidence packet."],
+    ["--workspace <path>", "Workspace path override."],
+    ["--force", "Allow handoff outside the normal handoff states."],
+    ...repositoryOptions,
+    ...mutationOptions,
+    ...projectOptions,
+  ],
+})
+
 if (!args.issue) {
   fail("handoff mode requires --issue <number>")
 }

--- a/scripts/agent-runner-heartbeat.mjs
+++ b/scripts/agent-runner-heartbeat.mjs
@@ -8,6 +8,12 @@ import {
   projectConfigFromArgs,
   runGit,
 } from "./lib/agent-project-queue.mjs"
+import {
+  maybePrintHelp,
+  mutationOptions,
+  projectOptions,
+  repositoryOptions,
+} from "./lib/agent-runner-help.mjs"
 
 const heartbeatStates = new Set([
   "Planning",
@@ -19,6 +25,23 @@ const heartbeatStates = new Set([
 ])
 
 const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:heartbeat",
+  summary: "Refresh heartbeat metadata and optionally move an active agent item state.",
+  usage: "pnpm agent:queue:heartbeat -- --issue <number> --state Running --yes",
+  options: [
+    ["--issue <number>", "Issue number to update."],
+    ["--state <state>", "Next Agent State. Defaults to the current Project state."],
+    ["--blocked-by <text>", "Required with Blocked unless --reason is provided."],
+    ["--reason <text>", "Reason for a blocked heartbeat or evidence note."],
+    ["--evidence <url-or-path>", "Evidence pointer to write to the Project item."],
+    ["--force", "Allow updates outside the normal heartbeat states."],
+    ...repositoryOptions,
+    ...mutationOptions,
+    ...projectOptions,
+  ],
+})
+
 if (!args.issue) {
   fail("heartbeat mode requires --issue <number>")
 }

--- a/scripts/agent-runner-prepare.mjs
+++ b/scripts/agent-runner-prepare.mjs
@@ -10,8 +10,27 @@ import {
   projectConfigFromArgs,
   runGit,
 } from "./lib/agent-project-queue.mjs"
+import {
+  maybePrintHelp,
+  mutationOptions,
+  projectOptions,
+  repositoryOptions,
+} from "./lib/agent-runner-help.mjs"
 
 const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:prepare",
+  summary: "Create a local worktree and execution plan for one approved Project item.",
+  usage: "pnpm agent:queue:prepare -- --issue <number> --yes",
+  options: [
+    ["--issue <number>", "Issue number to prepare. Required when multiple items are ready."],
+    ["--base <ref>", "Base ref for the new worktree branch. Defaults to origin/main."],
+    ...repositoryOptions,
+    ...mutationOptions,
+    ...projectOptions,
+  ],
+})
+
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
 const project = loadEvaluatedProject(projectConfigFromArgs(args))

--- a/scripts/agent-runner-publish-evidence.mjs
+++ b/scripts/agent-runner-publish-evidence.mjs
@@ -12,8 +12,28 @@ import {
   projectConfigFromArgs,
   runGit,
 } from "./lib/agent-project-queue.mjs"
+import {
+  maybePrintHelp,
+  mutationOptions,
+  projectOptions,
+  repositoryOptions,
+} from "./lib/agent-runner-help.mjs"
 
 const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:publish-evidence",
+  summary: "Post a local evidence packet to GitHub and update the Project evidence field.",
+  usage: "pnpm agent:queue:publish-evidence -- --issue <number> --yes",
+  options: [
+    ["--issue <number>", "Issue number whose evidence packet should be published."],
+    ["--evidence-path <path>", "Evidence path relative to the task workspace."],
+    ["--workspace <path>", "Workspace path override."],
+    ...repositoryOptions,
+    ...mutationOptions,
+    ...projectOptions,
+  ],
+})
+
 if (!args.issue) {
   fail("publish-evidence mode requires --issue <number>")
 }

--- a/scripts/agent-runner-release.mjs
+++ b/scripts/agent-runner-release.mjs
@@ -8,6 +8,12 @@ import {
   projectConfigFromArgs,
   runGit,
 } from "./lib/agent-project-queue.mjs"
+import {
+  maybePrintHelp,
+  mutationOptions,
+  projectOptions,
+  repositoryOptions,
+} from "./lib/agent-runner-help.mjs"
 
 const releasableStates = new Set([
   "Planning",
@@ -19,6 +25,21 @@ const releasableStates = new Set([
 ])
 
 const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:release",
+  summary: "Return claimed work to the ready queue without shipping implementation work.",
+  usage: 'pnpm agent:queue:release -- --issue <number> --reason "..." --yes',
+  options: [
+    ["--issue <number>", "Issue number to release."],
+    ["--reason <text>", "Reason recorded in the Evidence field."],
+    ["--evidence <text>", "Explicit Evidence field value. Defaults from --reason."],
+    ["--force", "Allow release outside the normal claimed states."],
+    ...repositoryOptions,
+    ...mutationOptions,
+    ...projectOptions,
+  ],
+})
+
 if (!args.issue) {
   fail("release mode requires --issue <number>")
 }

--- a/scripts/agent-runner-status.mjs
+++ b/scripts/agent-runner-status.mjs
@@ -7,6 +7,7 @@ import {
   projectConfigFromArgs,
   runGit,
 } from "./lib/agent-project-queue.mjs"
+import { maybePrintHelp, projectOptions, repositoryOptions } from "./lib/agent-runner-help.mjs"
 import { evaluateHeartbeat } from "./lib/agent-runner-output.mjs"
 
 const activeStates = new Set([
@@ -19,6 +20,18 @@ const activeStates = new Set([
 ])
 
 const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:status",
+  summary: "Print a read-only overview of ready, active, stale, blocked, and review work.",
+  usage: "pnpm agent:queue:status -- [--json] [--repo <owner/name>]",
+  options: [
+    ["--json", "Print machine-readable JSON."],
+    ["--max-age-days <number>", "Heartbeat staleness threshold. Defaults to 1."],
+    ...repositoryOptions,
+    ...projectOptions,
+  ],
+})
+
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
 const maxAgeDays = Number(args.maxAgeDays ?? 1)

--- a/scripts/agent-runner-watchdog.mjs
+++ b/scripts/agent-runner-watchdog.mjs
@@ -7,6 +7,7 @@ import {
   projectConfigFromArgs,
   runGit,
 } from "./lib/agent-project-queue.mjs"
+import { maybePrintHelp, projectOptions, repositoryOptions } from "./lib/agent-runner-help.mjs"
 import { evaluateHeartbeat } from "./lib/agent-runner-output.mjs"
 
 const watchedStates = new Set([
@@ -19,6 +20,18 @@ const watchedStates = new Set([
 ])
 
 const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:watchdog",
+  summary: "Find active agent work with missing or stale heartbeats without mutating anything.",
+  usage: "pnpm agent:queue:watchdog -- [--json] [--repo <owner/name>]",
+  options: [
+    ["--json", "Print machine-readable JSON."],
+    ["--max-age-days <number>", "Heartbeat staleness threshold. Defaults to 1."],
+    ...repositoryOptions,
+    ...projectOptions,
+  ],
+})
+
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
 const maxAgeDays = Number(args.maxAgeDays ?? 1)

--- a/scripts/lib/agent-project-queue.mjs
+++ b/scripts/lib/agent-project-queue.mjs
@@ -2,13 +2,17 @@ import { spawnSync } from "node:child_process"
 import path from "node:path"
 
 const knownTypes = new Set(["task", "bug", "refactor", "investigation", "cleanup"])
-const booleanArgs = new Set(["force", "json", "yes"])
+const booleanArgs = new Set(["force", "help", "json", "yes"])
 
 export function parseArgs(argv) {
   const parsed = {}
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index]
     if (arg === "--") continue
+    if (arg === "-h") {
+      parsed.help = true
+      continue
+    }
 
     const booleanKey = arg.startsWith("--") ? arg.slice(2) : undefined
     if (booleanArgs.has(booleanKey)) {

--- a/scripts/lib/agent-runner-help.mjs
+++ b/scripts/lib/agent-runner-help.mjs
@@ -1,0 +1,41 @@
+export const projectOptions = [
+  ["--owner <org>", "GitHub organization that owns the Project. Defaults to voyantjs."],
+  [
+    "--project <number>",
+    "GitHub Project number. Defaults from VOYANT_ENGINEERING_PROJECT_URL or 1.",
+  ],
+  ["--project-number <number>", "Alias for --project."],
+  ["--limit <number>", "Project item page size, 1..100. Defaults to the command's page size."],
+]
+
+export const repositoryOptions = [
+  ["--repo <owner/name>", "Repository scope. Defaults to the current origin remote."],
+]
+
+export const mutationOptions = [
+  ["--yes", "Apply the mutation. Without this, the command prints the planned change."],
+]
+
+export function maybePrintHelp(args, help) {
+  if (!args.help) return
+  printCommandHelp(help)
+  process.exit(0)
+}
+
+function printCommandHelp({ command, summary, usage, options = [] }) {
+  console.log(command)
+  console.log("")
+  console.log(summary)
+  console.log("")
+  console.log("Usage:")
+  console.log(`  ${usage}`)
+
+  if (options.length > 0) {
+    const width = Math.max(...options.map(([flag]) => flag.length))
+    console.log("")
+    console.log("Options:")
+    for (const [flag, description] of options) {
+      console.log(`  ${flag.padEnd(width)}  ${description}`)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add shared `--help` / `-h` handling to the agent runner argument parser
- add reusable command-help formatting for project, repository, and mutation options
- wire help output into dry-run, status, watchdog, prepare, claim, heartbeat, handoff, publish-evidence, and release
- document runner help usage in the issue tracker guide

## Validation
- `node --check scripts/lib/agent-runner-help.mjs && for f in scripts/agent-runner-*.mjs; do node --check "$f" || exit 1; done`
- `for script in dry-run status prepare claim heartbeat handoff publish-evidence watchdog release; do pnpm "agent:queue:${script}" -- --help >/tmp/agent-help-${script}.txt || exit 1; done`
- `pnpm agent:queue:dry-run && pnpm agent:queue:status -- --repo VoyantJS/Voyant && pnpm agent:queue:watchdog -- --repo VoyantJS/Voyant`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm exec secretlint docs/agents/issue-tracker.md scripts/agent-runner-*.mjs scripts/lib/agent-project-queue.mjs scripts/lib/agent-runner-help.mjs`
- `pnpm verify:architecture`

## Notes
- No changeset: internal runner scripts and agent docs only.
- Pushed once after local validation to reduce GitHub Actions usage.