### PR TITLE
Add agent runner doctor command

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -66,6 +66,17 @@ runner flags after `--`:
 pnpm agent:queue:status -- --help
 ```
 
+Before operating the queue, run the read-only doctor:
+
+```bash
+pnpm agent:queue:doctor
+```
+
+Doctor mode checks GitHub CLI authentication, current repository detection,
+Project visibility, required Project fields/options, and queue visibility. It
+does not mutate GitHub, create worktrees, or spend agent execution budget. Pass
+`--json` for automation.
+
 Before any agent execution is enabled, use the read-only queue runner:
 
 ```bash

--- a/docs/agents/project-fields.md
+++ b/docs/agents/project-fields.md
@@ -4,6 +4,7 @@ Recommended GitHub Project fields for `Voyant Engineering`.
 
 | Field | Type | Purpose |
 | --- | --- | --- |
+| `Status` | Single select | GitHub Project workflow state used by the runner. |
 | `Agent State` | Single select | Main state machine. |
 | `Maintainer Approved` | Single select | Required execution gate: `No`, `Yes`. |
 | `Risk` | Single select | `Low`, `Medium`, `High`, `Unknown`. |
@@ -34,6 +35,13 @@ Recommended GitHub Project fields for `Voyant Engineering`.
 
 Only maintainers move an item to `Ready`. Merge remains a maintainer decision
 unless a separate maintainer-approved merge automation is introduced.
+
+## Status Values
+
+Runner commands require these status values:
+
+- `Todo`
+- `In Progress`
 
 ## Maintainer Approved Values
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "verify:agent-quality:changed": "node scripts/check-agent-code-quality.mjs --changed --report-only",
     "verify:fast": "pnpm lint:changed && pnpm verify:agent-quality:changed && pnpm typecheck:affected && pnpm test:affected && pnpm verify:architecture",
     "verify:full": "pnpm lint && pnpm verify:agent-quality && pnpm typecheck && pnpm test && pnpm verify:architecture && pnpm build && pnpm verify:package-exports && pnpm verify:publish-tarballs && pnpm i18n:check",
+    "agent:queue:doctor": "node scripts/agent-runner-doctor.mjs",
     "agent:queue:dry-run": "node scripts/agent-runner-dry-run.mjs",
     "agent:queue:status": "node scripts/agent-runner-status.mjs",
     "agent:queue:prepare": "node scripts/agent-runner-prepare.mjs",

--- a/scripts/agent-runner-doctor.mjs
+++ b/scripts/agent-runner-doctor.mjs
@@ -1,0 +1,251 @@
+import { spawnSync } from "node:child_process"
+
+import {
+  filterItemsByRepository,
+  loadAllEvaluatedProject,
+  parseArgs,
+  projectConfigFromArgs,
+} from "./lib/agent-project-queue.mjs"
+import { maybePrintHelp, projectOptions, repositoryOptions } from "./lib/agent-runner-help.mjs"
+
+const requiredFields = [
+  {
+    name: "Status",
+    type: "SINGLE_SELECT",
+    options: ["Todo", "In Progress"],
+  },
+  {
+    name: "Agent State",
+    type: "SINGLE_SELECT",
+    options: [
+      "Triage",
+      "Ready",
+      "Planning",
+      "Running",
+      "Blocked",
+      "Human Review",
+      "Changes Requested",
+      "CI Repair",
+      "Merge Ready",
+      "Done",
+      "Abandoned",
+    ],
+  },
+  {
+    name: "Maintainer Approved",
+    type: "SINGLE_SELECT",
+    options: ["No", "Yes"],
+  },
+  {
+    name: "Risk",
+    type: "SINGLE_SELECT",
+    options: ["Low", "Medium", "High", "Unknown"],
+  },
+  {
+    name: "Security Risk",
+    type: "SINGLE_SELECT",
+    options: ["None", "Sensitive", "Needs security review"],
+  },
+  {
+    name: "Verification Lane",
+    type: "SINGLE_SELECT",
+    options: ["package", "verify:fast", "verify:full", "custom"],
+  },
+  {
+    name: "Triage Provider",
+    type: "SINGLE_SELECT",
+    options: ["manual"],
+  },
+  {
+    name: "Agent Provider",
+    type: "SINGLE_SELECT",
+    options: ["codex", "claude", "manual", "none"],
+  },
+  { name: "Workspace", type: "TEXT" },
+  { name: "Branch", type: "TEXT" },
+  { name: "PR", type: "TEXT" },
+  { name: "Last Heartbeat", type: "DATE" },
+  { name: "Blocked By", type: "TEXT" },
+  { name: "Evidence", type: "TEXT" },
+]
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:doctor",
+  summary: "Check local runner prerequisites, Project visibility, and required Project fields.",
+  usage: "pnpm agent:queue:doctor -- [--json] [--repo <owner/name>]",
+  options: [["--json", "Print machine-readable JSON."], ...repositoryOptions, ...projectOptions],
+})
+
+const results = []
+const ghStatus = runCommand("gh", ["auth", "status"])
+recordCommand({
+  name: "gh auth",
+  ok: ghStatus.status === 0,
+  detail: ghStatus.status === 0 ? "GitHub CLI is authenticated." : commandOutput(ghStatus),
+})
+
+const repo = args.repo ?? currentRepository()
+if (repo) {
+  record({ name: "repository", ok: true, detail: `Using repository scope ${repo}.` })
+} else {
+  record({
+    name: "repository",
+    ok: false,
+    detail: "Could not determine repository from origin remote; pass --repo <owner/name>.",
+  })
+}
+
+let project
+if (ghStatus.status === 0) {
+  project = loadProject()
+}
+
+if (project) {
+  record({
+    name: "project visibility",
+    ok: true,
+    detail: `Loaded ${project.projectTitle} (${project.owner}/projects/${project.projectNumber}).`,
+  })
+  checkRequiredFields(project)
+  checkQueue(project, repo)
+}
+
+if (args.json) {
+  console.log(
+    JSON.stringify(
+      {
+        ok: results.every((result) => result.ok),
+        results,
+      },
+      null,
+      2,
+    ),
+  )
+} else {
+  printHumanSummary()
+}
+
+process.exitCode = results.every((result) => result.ok) ? 0 : 1
+
+function loadProject() {
+  try {
+    return loadAllEvaluatedProject({
+      ...projectConfigFromArgs({ ...args, limit: args.limit ?? 100 }),
+      onError(message) {
+        throw new Error(message)
+      },
+    })
+  } catch (error) {
+    record({
+      name: "project visibility",
+      ok: false,
+      detail: error instanceof Error ? error.message : String(error),
+    })
+    return undefined
+  }
+}
+
+function checkRequiredFields(project) {
+  for (const expectedField of requiredFields) {
+    const field = project.fieldDefinitions.find(
+      (candidate) => candidate.name === expectedField.name,
+    )
+    if (!field) {
+      record({
+        name: `Project field ${expectedField.name}`,
+        ok: false,
+        detail: "Missing required Project field.",
+      })
+      continue
+    }
+
+    if (field.dataType !== expectedField.type) {
+      record({
+        name: `Project field ${expectedField.name}`,
+        ok: false,
+        detail: `Expected ${expectedField.type}, found ${field.dataType}.`,
+      })
+      continue
+    }
+
+    const missingOptions = (expectedField.options ?? []).filter(
+      (option) => !field.options.some((candidate) => candidate.name === option),
+    )
+    if (missingOptions.length > 0) {
+      record({
+        name: `Project field ${expectedField.name}`,
+        ok: false,
+        detail: `Missing option(s): ${missingOptions.join(", ")}.`,
+      })
+      continue
+    }
+
+    record({
+      name: `Project field ${expectedField.name}`,
+      ok: true,
+      detail: "Configured.",
+    })
+  }
+}
+
+function checkQueue(project, repo) {
+  const scopedItems = repo ? filterItemsByRepository(project.items, repo) : project.items
+  const readyItems = scopedItems.filter((item) => item.ready)
+  record({
+    name: "queue visibility",
+    ok: true,
+    detail: `Scanned ${scopedItems.length} item(s); ${readyItems.length} executable item(s).`,
+  })
+}
+
+function currentRepository() {
+  const remote = runCommand("git", ["remote", "get-url", "origin"])
+  if (remote.status !== 0) return undefined
+  return repositoryFromGitHubRemote(remote.stdout.trim())
+}
+
+function repositoryFromGitHubRemote(remoteUrl) {
+  const normalized = remoteUrl.trim().replace(/\.git$/, "")
+  return normalized.match(/github\.com[:/]([^/]+\/[^/]+)$/)?.[1]
+}
+
+function recordCommand({ name, ok, detail }) {
+  record({
+    detail: detail || "Command produced no output.",
+    name,
+    ok,
+  })
+}
+
+function record(result) {
+  results.push(result)
+}
+
+function printHumanSummary() {
+  const ok = results.every((result) => result.ok)
+  console.log(`agent-runner doctor: ${ok ? "OK" : "FAILED"}`)
+  console.log("")
+  for (const result of results) {
+    console.log(`${result.ok ? "OK" : "FAIL"} ${result.name}`)
+    console.log(`  ${result.detail}`)
+  }
+}
+
+function runCommand(command, commandArgs) {
+  const result = spawnSync(command, commandArgs, {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 10,
+  })
+  return {
+    error: result.error,
+    status: result.status ?? 1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  }
+}
+
+function commandOutput(result) {
+  if (result.error) return result.error.message
+  return result.stderr.trim() || result.stdout.trim() || `command exited with ${result.status}`
+}

--- a/scripts/lib/agent-project-queue.mjs
+++ b/scripts/lib/agent-project-queue.mjs
@@ -63,24 +63,24 @@ export function projectNumberFromUrl(projectUrl) {
   return match?.[1]
 }
 
-export function loadEvaluatedProject({ owner, projectNumber, limit }) {
-  const project = readProjectItems({ owner, projectNumber, limit })
+export function loadEvaluatedProject({ owner, projectNumber, limit, onError = fail }) {
+  const project = readProjectItems({ owner, projectNumber, limit, onError })
   const items = project.items.map(evaluateItem)
 
   return evaluatedProject({ items, owner, project, projectNumber })
 }
 
-export function loadAllEvaluatedProject({ owner, projectNumber, limit }) {
+export function loadAllEvaluatedProject({ owner, projectNumber, limit, onError = fail }) {
   const pageSize = limit ?? 100
   const pages = []
   let after
 
   do {
-    const page = readProjectItems({ after, limit: pageSize, owner, projectNumber })
+    const page = readProjectItems({ after, limit: pageSize, onError, owner, projectNumber })
     pages.push(page)
     after = page.pageInfo.endCursor
     if (page.pageInfo.hasNextPage && !after) {
-      fail("Project item pagination returned no cursor")
+      onError("Project item pagination returned no cursor")
     }
   } while (pages.at(-1).pageInfo.hasNextPage)
 
@@ -102,7 +102,7 @@ function evaluatedProject({ items, owner, project, projectNumber }) {
   }
 }
 
-export function readProjectItems({ after, owner, projectNumber, limit }) {
+export function readProjectItems({ after, owner, projectNumber, limit, onError = fail }) {
   const query = `
     query($owner: String!, $number: Int!, $limit: Int!, $after: String) {
       organization(login: $owner) {
@@ -221,28 +221,28 @@ export function readProjectItems({ after, owner, projectNumber, limit }) {
   })
 
   if (result.error) {
-    fail(`failed to run gh: ${result.error.message}`)
+    onError(`failed to run gh: ${result.error.message}`)
   }
 
   if (result.status !== 0) {
     const stderr = result.stderr.trim()
-    fail(stderr || `gh api graphql exited with ${result.status}`)
+    onError(stderr || `gh api graphql exited with ${result.status}`)
   }
 
   let payload
   try {
     payload = JSON.parse(result.stdout)
   } catch (error) {
-    fail(`failed to parse gh JSON output: ${error.message}`)
+    onError(`failed to parse gh JSON output: ${error.message}`)
   }
 
   if (payload.errors?.length) {
-    fail(payload.errors.map((error) => error.message).join("; "))
+    onError(payload.errors.map((error) => error.message).join("; "))
   }
 
   const project = payload.data?.organization?.projectV2
   if (!project) {
-    fail(`project ${owner}/${projectNumber} was not found or is not visible to gh`)
+    onError(`project ${owner}/${projectNumber} was not found or is not visible to gh`)
   }
 
   return {


### PR DESCRIPTION
## Summary
- add a read-only `agent:queue:doctor` command for runner setup diagnostics
- check GitHub CLI auth, repository scope, Project visibility, required Project fields/options, and queue visibility
- return structured JSON for automation, including Project visibility failures
- document doctor usage and the Project `Status` field values the runner needs

## Validation
- `for script in doctor dry-run status prepare claim heartbeat handoff publish-evidence watchdog release; do pnpm "agent:queue:${script}" -- --help >/tmp/agent-help-${script}.txt || exit 1; done`
- `pnpm agent:queue:doctor`
- `pnpm agent:queue:doctor -- --json`
- `pnpm agent:queue:doctor -- --project 999999 --json` exits nonzero with structured Project visibility diagnostics
- `pnpm agent:queue:doctor -- --repo VoyantJS/Voyant`
- `pnpm agent:queue:status -- --repo VoyantJS/Voyant`
- `pnpm agent:queue:watchdog -- --repo VoyantJS/Voyant`
- `for f in scripts/agent-runner-*.mjs scripts/lib/agent-project-queue.mjs scripts/lib/agent-runner-help.mjs; do node --check "$f" || exit 1; done`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm exec secretlint docs/agents/issue-tracker.md docs/agents/project-fields.md package.json scripts/agent-runner-doctor.mjs scripts/lib/agent-project-queue.mjs`
- `pnpm verify:architecture`

## Notes
- No changeset: internal runner scripts and agent docs only.
- Pushed once after local validation to reduce GitHub Actions usage.