### PR TITLE
Add changeset for API token management

### DIFF
--- a/.changeset/api-token-management.md
+++ b/.changeset/api-token-management.md
@@ -1,0 +1,10 @@
+---
+"@voyantjs/auth": patch
+"@voyantjs/auth-react": patch
+"@voyantjs/auth-ui": patch
+"@voyantjs/hono": patch
+"@voyantjs/i18n": patch
+"@voyantjs/types": patch
+---
+
+Add API token management powered by Better Auth API keys, including reusable React hooks, a shared auth UI package, canonical permission presets, and API-key route permission guards.


### PR DESCRIPTION
## Summary
- Add the missing changeset for the API token management work merged in #594.
- Records patch bumps for the public packages touched by the feature: `@voyantjs/auth`, `@voyantjs/auth-react`, `@voyantjs/auth-ui`, `@voyantjs/hono`, `@voyantjs/i18n`, and `@voyantjs/types`.

## Verification
- `pnpm changeset status --since=FETCH_HEAD`