### PR TITLE
Scan all project pages in runner commands

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -77,6 +77,13 @@ Project visibility, required Project fields/options, and queue visibility. It
 does not mutate GitHub, create worktrees, or spend agent execution budget. Pass
 `--json` for automation.
 
+Queue readers scan all Project pages by default. `--limit` controls the
+GraphQL page size, not the total number of items scanned.
+
+Pure queue helper coverage lives in `pnpm agent:queue:test`. Keep tests there
+for argument parsing, gate evaluation, repository scoping, and pagination before
+adding live GitHub-dependent cases.
+
 Before any agent execution is enabled, use the read-only queue runner:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "agent:queue:publish-evidence": "node scripts/agent-runner-publish-evidence.mjs",
     "agent:queue:watchdog": "node scripts/agent-runner-watchdog.mjs",
     "agent:queue:release": "node scripts/agent-runner-release.mjs",
+    "agent:queue:test": "node --test scripts/tests/agent-project-queue.test.mjs",
     "prepare": "husky",
     "seed:operator": "pnpm -C apps/scripts seed:operator",
     "regen:routes": "tsx scripts/regen-route-tree.ts",

--- a/scripts/agent-runner-claim.mjs
+++ b/scripts/agent-runner-claim.mjs
@@ -3,9 +3,9 @@ import {
   currentRepositoryFromOrigin,
   fail,
   findSelectedReadyItem,
-  loadEvaluatedProject,
+  loadAllEvaluatedProject,
   parseArgs,
-  projectConfigFromArgs,
+  projectScanConfigFromArgs,
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import {
@@ -30,7 +30,7 @@ maybePrintHelp(args, {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
-const project = loadEvaluatedProject(projectConfigFromArgs(args))
+const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const item = findSelectedReadyItem(project.items, {
   issueNumber: args.issue,
   repository,

--- a/scripts/agent-runner-doctor.mjs
+++ b/scripts/agent-runner-doctor.mjs
@@ -4,7 +4,7 @@ import {
   filterItemsByRepository,
   loadAllEvaluatedProject,
   parseArgs,
-  projectConfigFromArgs,
+  projectScanConfigFromArgs,
 } from "./lib/agent-project-queue.mjs"
 import { maybePrintHelp, projectOptions, repositoryOptions } from "./lib/agent-runner-help.mjs"
 
@@ -131,7 +131,7 @@ process.exitCode = results.every((result) => result.ok) ? 0 : 1
 function loadProject() {
   try {
     return loadAllEvaluatedProject({
-      ...projectConfigFromArgs({ ...args, limit: args.limit ?? 100 }),
+      ...projectScanConfigFromArgs(args),
       onError(message) {
         throw new Error(message)
       },

--- a/scripts/agent-runner-dry-run.mjs
+++ b/scripts/agent-runner-dry-run.mjs
@@ -1,7 +1,7 @@
 import {
-  loadEvaluatedProject,
+  loadAllEvaluatedProject,
   parseArgs,
-  projectConfigFromArgs,
+  projectScanConfigFromArgs,
 } from "./lib/agent-project-queue.mjs"
 import { maybePrintHelp, projectOptions } from "./lib/agent-runner-help.mjs"
 import { printHumanSummary, projectSummaryJson } from "./lib/agent-runner-output.mjs"
@@ -14,7 +14,7 @@ maybePrintHelp(args, {
   options: [["--json", "Print machine-readable JSON."], ...projectOptions],
 })
 
-const project = loadEvaluatedProject(projectConfigFromArgs(args))
+const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 
 if (args.json) {
   console.log(JSON.stringify(projectSummaryJson(project), null, 2))

--- a/scripts/agent-runner-handoff.mjs
+++ b/scripts/agent-runner-handoff.mjs
@@ -6,9 +6,9 @@ import {
   currentRepositoryFromOrigin,
   fail,
   findProjectIssueItem,
-  loadEvaluatedProject,
+  loadAllEvaluatedProject,
   parseArgs,
-  projectConfigFromArgs,
+  projectScanConfigFromArgs,
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import {
@@ -45,7 +45,7 @@ if (!args.issue) {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
-const project = loadEvaluatedProject(projectConfigFromArgs(args))
+const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const item = findProjectIssueItem(project.items, {
   issueNumber: args.issue,
   repository,

--- a/scripts/agent-runner-heartbeat.mjs
+++ b/scripts/agent-runner-heartbeat.mjs
@@ -3,9 +3,9 @@ import {
   currentRepositoryFromOrigin,
   fail,
   findProjectIssueItem,
-  loadEvaluatedProject,
+  loadAllEvaluatedProject,
   parseArgs,
-  projectConfigFromArgs,
+  projectScanConfigFromArgs,
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import {
@@ -48,7 +48,7 @@ if (!args.issue) {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
-const project = loadEvaluatedProject(projectConfigFromArgs(args))
+const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const item = findProjectIssueItem(project.items, {
   issueNumber: args.issue,
   repository,

--- a/scripts/agent-runner-prepare.mjs
+++ b/scripts/agent-runner-prepare.mjs
@@ -5,9 +5,9 @@ import {
   currentRepositoryFromOrigin,
   fail,
   findSelectedReadyItem,
-  loadEvaluatedProject,
+  loadAllEvaluatedProject,
   parseArgs,
-  projectConfigFromArgs,
+  projectScanConfigFromArgs,
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import {
@@ -33,7 +33,7 @@ maybePrintHelp(args, {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
-const project = loadEvaluatedProject(projectConfigFromArgs(args))
+const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const item = findSelectedReadyItem(project.items, {
   issueNumber: args.issue,
   repository,

--- a/scripts/agent-runner-publish-evidence.mjs
+++ b/scripts/agent-runner-publish-evidence.mjs
@@ -7,9 +7,9 @@ import {
   currentRepositoryFromOrigin,
   fail,
   findProjectIssueItem,
-  loadEvaluatedProject,
+  loadAllEvaluatedProject,
   parseArgs,
-  projectConfigFromArgs,
+  projectScanConfigFromArgs,
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import {
@@ -40,7 +40,7 @@ if (!args.issue) {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
-const project = loadEvaluatedProject(projectConfigFromArgs(args))
+const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const item = findProjectIssueItem(project.items, {
   issueNumber: args.issue,
   repository,

--- a/scripts/agent-runner-release.mjs
+++ b/scripts/agent-runner-release.mjs
@@ -3,9 +3,9 @@ import {
   currentRepositoryFromOrigin,
   fail,
   findProjectIssueItem,
-  loadEvaluatedProject,
+  loadAllEvaluatedProject,
   parseArgs,
-  projectConfigFromArgs,
+  projectScanConfigFromArgs,
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import {
@@ -46,7 +46,7 @@ if (!args.issue) {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
-const project = loadEvaluatedProject(projectConfigFromArgs(args))
+const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const item = findProjectIssueItem(project.items, {
   issueNumber: args.issue,
   repository,

--- a/scripts/agent-runner-status.mjs
+++ b/scripts/agent-runner-status.mjs
@@ -4,7 +4,7 @@ import {
   filterItemsByRepository,
   loadAllEvaluatedProject,
   parseArgs,
-  projectConfigFromArgs,
+  projectScanConfigFromArgs,
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import { maybePrintHelp, projectOptions, repositoryOptions } from "./lib/agent-runner-help.mjs"
@@ -40,9 +40,7 @@ if (!Number.isInteger(maxAgeDays) || maxAgeDays < 0) {
   fail(`invalid max age days: ${String(args.maxAgeDays)}`)
 }
 
-const project = loadAllEvaluatedProject(
-  projectConfigFromArgs({ ...args, limit: args.limit ?? 100 }),
-)
+const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const items = filterItemsByRepository(project.items, repository)
 const readyItems = items.filter((item) => item.ready)
 const activeItems = items

--- a/scripts/agent-runner-watchdog.mjs
+++ b/scripts/agent-runner-watchdog.mjs
@@ -4,7 +4,7 @@ import {
   filterItemsByRepository,
   loadAllEvaluatedProject,
   parseArgs,
-  projectConfigFromArgs,
+  projectScanConfigFromArgs,
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import { maybePrintHelp, projectOptions, repositoryOptions } from "./lib/agent-runner-help.mjs"
@@ -40,9 +40,7 @@ if (!Number.isInteger(maxAgeDays) || maxAgeDays < 0) {
   fail(`invalid max age days: ${String(args.maxAgeDays)}`)
 }
 
-const project = loadAllEvaluatedProject(
-  projectConfigFromArgs({ ...args, limit: args.limit ?? 100 }),
-)
+const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const activeItems = filterItemsByRepository(project.items, repository).filter((item) =>
   watchedStates.has(item.fields["Agent State"]),
 )

--- a/scripts/lib/agent-project-queue.mjs
+++ b/scripts/lib/agent-project-queue.mjs
@@ -57,26 +57,29 @@ export function projectConfigFromArgs(args) {
   return { owner, projectNumber, limit }
 }
 
+export function projectScanConfigFromArgs(args) {
+  return projectConfigFromArgs({ ...args, limit: args.limit ?? 100 })
+}
+
 export function projectNumberFromUrl(projectUrl) {
   if (!projectUrl) return undefined
   const match = projectUrl.match(/\/projects\/(\d+)(?:$|[/?#])/)
   return match?.[1]
 }
 
-export function loadEvaluatedProject({ owner, projectNumber, limit, onError = fail }) {
-  const project = readProjectItems({ owner, projectNumber, limit, onError })
-  const items = project.items.map(evaluateItem)
-
-  return evaluatedProject({ items, owner, project, projectNumber })
-}
-
-export function loadAllEvaluatedProject({ owner, projectNumber, limit, onError = fail }) {
+export function loadAllEvaluatedProject({
+  owner,
+  projectNumber,
+  limit,
+  onError = fail,
+  readItems = readProjectItems,
+}) {
   const pageSize = limit ?? 100
   const pages = []
   let after
 
   do {
-    const page = readProjectItems({ after, limit: pageSize, onError, owner, projectNumber })
+    const page = readItems({ after, limit: pageSize, onError, owner, projectNumber })
     pages.push(page)
     after = page.pageInfo.endCursor
     if (page.pageInfo.hasNextPage && !after) {

--- a/scripts/tests/agent-project-queue.test.mjs
+++ b/scripts/tests/agent-project-queue.test.mjs
@@ -1,0 +1,206 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import {
+  evaluateItem,
+  filterItemsByRepository,
+  loadAllEvaluatedProject,
+  parseArgs,
+  projectConfigFromArgs,
+  projectNumberFromUrl,
+  projectScanConfigFromArgs,
+} from "../lib/agent-project-queue.mjs"
+
+describe("agent project queue helpers", () => {
+  it("parses boolean, equals, and separated runner arguments", () => {
+    assert.deepEqual(parseArgs(["--issue", "123", "--json", "--max-age-days=2", "-h"]), {
+      issue: "123",
+      json: true,
+      maxAgeDays: "2",
+      help: true,
+    })
+  })
+
+  it("parses project numbers from GitHub Project URLs", () => {
+    assert.equal(projectNumberFromUrl("https://github.com/orgs/voyantjs/projects/42/views/1"), "42")
+    assert.equal(projectNumberFromUrl("https://github.com/orgs/voyantjs/projects/7"), "7")
+    assert.equal(projectNumberFromUrl("https://github.com/voyantjs/voyant/issues/7"), undefined)
+  })
+
+  it("keeps single page config limits strict while scan config defaults to a full page", () => {
+    assert.deepEqual(projectConfigFromArgs({ owner: "voyantjs", project: "2" }), {
+      owner: "voyantjs",
+      projectNumber: 2,
+      limit: 50,
+    })
+
+    assert.deepEqual(projectScanConfigFromArgs({ owner: "voyantjs", project: "2" }), {
+      owner: "voyantjs",
+      projectNumber: 2,
+      limit: 100,
+    })
+
+    assert.deepEqual(projectScanConfigFromArgs({ owner: "voyantjs", project: "2", limit: "25" }), {
+      owner: "voyantjs",
+      projectNumber: 2,
+      limit: 25,
+    })
+  })
+
+  it("evaluates ready issues and derives execution paths", () => {
+    const evaluated = evaluateItem(
+      projectItem({
+        number: 579,
+        title: "[Bug] Fix agent intake workflow",
+        fields: {
+          "Agent State": "Ready",
+          "Maintainer Approved": "Yes",
+          "Verification Lane": "verify:full",
+          Risk: "Medium",
+          "Security Risk": "Low",
+          "Agent Provider": "manual",
+        },
+      }),
+    )
+
+    assert.equal(evaluated.ready, true)
+    assert.equal(evaluated.issue.number, 579)
+    assert.equal(evaluated.dryRunPlan.branch, "bug/579-fix-agent-intake-workflow")
+    assert.equal(
+      evaluated.dryRunPlan.planPath,
+      "docs/agent-plans/active/579-fix-agent-intake-workflow.md",
+    )
+    assert.equal(evaluated.dryRunPlan.workspace, ".agent-worktrees/579-fix-agent-intake-workflow")
+    assert.equal(evaluated.dryRunPlan.verificationLane, "verify:full")
+  })
+
+  it("records gate reasons for non-executable items", () => {
+    const evaluated = evaluateItem(
+      projectItem({
+        labels: [],
+        state: "CLOSED",
+        fields: {
+          "Agent State": "Running",
+          "Maintainer Approved": "No",
+        },
+      }),
+    )
+
+    assert.equal(evaluated.ready, false)
+    assert.deepEqual(evaluated.reasons, [
+      "issue state is CLOSED",
+      "missing label agent:ready",
+      'Agent State is "Running"',
+      'Maintainer Approved is "No"',
+    ])
+  })
+
+  it("filters evaluated items by repository case-insensitively", () => {
+    const items = [
+      evaluateItem(projectItem({ number: 1, repository: "VoyantJS/Voyant" })),
+      evaluateItem(projectItem({ number: 2, repository: "VoyantJS/Docs" })),
+    ]
+
+    assert.deepEqual(
+      filterItemsByRepository(items, "voyantjs/voyant").map((item) => item.issue.number),
+      [1],
+    )
+  })
+
+  it("loads every project page before evaluating the queue", () => {
+    const calls = []
+    const project = loadAllEvaluatedProject({
+      owner: "voyantjs",
+      projectNumber: 1,
+      limit: 25,
+      readItems: ({ after, limit, owner, projectNumber }) => {
+        calls.push({ after, limit, owner, projectNumber })
+        return after
+          ? projectPage({
+              items: [projectItem({ id: "item-2", number: 2, title: "[Cleanup] Prune queue" })],
+              pageInfo: { endCursor: null, hasNextPage: false },
+            })
+          : projectPage({
+              items: [projectItem({ id: "item-1", number: 1, title: "[Task] Add queue tests" })],
+              pageInfo: { endCursor: "cursor-1", hasNextPage: true },
+            })
+      },
+    })
+
+    assert.deepEqual(calls, [
+      { after: undefined, limit: 25, owner: "voyantjs", projectNumber: 1 },
+      { after: "cursor-1", limit: 25, owner: "voyantjs", projectNumber: 1 },
+    ])
+    assert.equal(project.projectId, "project-1")
+    assert.equal(project.items.length, 2)
+    assert.deepEqual(
+      project.readyItems.map((item) => item.issue.number),
+      [1, 2],
+    )
+  })
+
+  it("fails pagination when GitHub reports another page without a cursor", () => {
+    assert.throws(
+      () =>
+        loadAllEvaluatedProject({
+          owner: "voyantjs",
+          projectNumber: 1,
+          onError: (message) => {
+            throw new Error(message)
+          },
+          readItems: () =>
+            projectPage({
+              pageInfo: { endCursor: null, hasNextPage: true },
+            }),
+        }),
+      /Project item pagination returned no cursor/,
+    )
+  })
+})
+
+function projectPage({ items = [], pageInfo = { endCursor: null, hasNextPage: false } } = {}) {
+  return {
+    id: "project-1",
+    title: "Voyant Engineering",
+    fields: [],
+    items,
+    pageInfo,
+  }
+}
+
+function projectItem({
+  id = "item-1",
+  number = 1,
+  title = "[Task] Implement queue runner",
+  state = "OPEN",
+  repository = "VoyantJS/Voyant",
+  labels = ["agent:ready"],
+  fields = {
+    "Agent State": "Ready",
+    "Maintainer Approved": "Yes",
+  },
+} = {}) {
+  return {
+    id,
+    content: {
+      number,
+      title,
+      url: `https://github.com/${repository}/issues/${number}`,
+      state,
+      repository: {
+        nameWithOwner: repository,
+      },
+      labels: {
+        nodes: labels.map((name) => ({ name })),
+      },
+    },
+    fieldValues: {
+      nodes: Object.entries(fields).map(([name, value]) => ({
+        name: value,
+        field: {
+          name,
+        },
+      })),
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- switch every queue command to scan all GitHub Project pages before selecting work
- keep `--limit` as GraphQL page size, with queue scans defaulting to a full 100-item page
- add pure queue helper tests for argument parsing, Project URL parsing, config defaults, gate evaluation, repository scoping, pagination aggregation, and missing-cursor failure handling
- document the pagination semantics and the new `pnpm agent:queue:test` lane

## Validation
- `pnpm agent:queue:test`
- `for f in scripts/agent-runner-*.mjs scripts/lib/agent-project-queue.mjs scripts/tests/agent-project-queue.test.mjs; do node --check "$f" || exit 1; done`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm exec secretlint docs/agents/issue-tracker.md scripts/agent-runner-*.mjs scripts/lib/agent-project-queue.mjs scripts/tests/agent-project-queue.test.mjs`
- `pnpm verify:architecture`
- help matrix for doctor, dry-run, status, prepare, claim, heartbeat, handoff, publish-evidence, watchdog, release, test
- `pnpm agent:queue:dry-run -- --json`
- `pnpm agent:queue:doctor -- --json`
- `pnpm agent:queue:status -- --repo VoyantJS/Voyant --json`
- `pnpm agent:queue:watchdog -- --repo VoyantJS/Voyant --json`

## Notes
- No changeset: internal runner scripts, tests, and agent docs only.
- Full pre-commit typecheck is currently blocked by unrelated package/module resolution failures in admin/auth-ui/auth-react/availability-ui/catalog-ui/flights-ui/pricing-ui/products-ui/operator.
- Full pre-push tests are currently blocked by an unrelated `@voyantjs/availability-ui` import failure resolving `@voyantjs/i18n`.