### PR TITLE
Align auth-ui release train version

### DIFF
--- a/packages/auth-ui/package.json
+++ b/packages/auth-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/auth-ui",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Set the newly added `@voyantjs/auth-ui` package to `0.31.1` so it matches the current shared release train.
- This fixes the release workflow failure in `verify:release-train`, which reported `@voyantjs/auth-ui` alone at `0.31.0` while all other publishable packages were at `0.31.1`.

## Verification
- `pnpm verify:release-train`