### PR TITLE
Sync PR review state in agent runner

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -195,6 +195,18 @@ branch, refuses dirty workspaces by default, pushes the branch, opens or reuses
 a draft PR, updates the Project `PR` field, and refreshes `Last Heartbeat`.
 It does not merge the PR or mark work merge-ready.
 
+After a PR exists, sync its review/check status back into the Project:
+
+```bash
+pnpm agent:queue:sync-pr -- --issue <number> --yes
+```
+
+Sync-PR mode reads the linked PR and its check rollup. Failing checks move the
+item to `Agent State = CI Repair`, requested changes move it to
+`Changes Requested`, pending checks or draft PRs keep it in `Human Review`, and
+passing non-draft PRs move it to `Merge Ready`. It updates `PR`,
+`Last Heartbeat`, and `Blocked By`; it does not merge the PR.
+
 Use the watchdog to find claimed work that has stopped reporting heartbeats:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "agent:queue:handoff": "node scripts/agent-runner-handoff.mjs",
     "agent:queue:publish-evidence": "node scripts/agent-runner-publish-evidence.mjs",
     "agent:queue:open-pr": "node scripts/agent-runner-open-pr.mjs",
+    "agent:queue:sync-pr": "node scripts/agent-runner-sync-pr.mjs",
     "agent:queue:watchdog": "node scripts/agent-runner-watchdog.mjs",
     "agent:queue:release": "node scripts/agent-runner-release.mjs",
     "agent:queue:test": "node --test scripts/tests/*.test.mjs",

--- a/scripts/agent-runner-sync-pr.mjs
+++ b/scripts/agent-runner-sync-pr.mjs
@@ -1,0 +1,101 @@
+import { updateProjectItemFields } from "./lib/agent-project-fields.mjs"
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  findProjectIssueItem,
+  loadAllEvaluatedProject,
+  parseArgs,
+  projectScanConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+import {
+  maybePrintHelp,
+  mutationOptions,
+  projectOptions,
+  repositoryOptions,
+} from "./lib/agent-runner-help.mjs"
+import {
+  evaluatePullRequestGate,
+  pullRequestNumberFromUrl,
+  pullRequestSyncFieldValues,
+  readPullRequestStatus,
+} from "./lib/agent-runner-pr.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:sync-pr",
+  summary: "Read a linked PR/check status and update the Project item review state.",
+  usage: "pnpm agent:queue:sync-pr -- --issue <number> --yes",
+  options: [
+    ["--issue <number>", "Issue number whose linked PR should be synced."],
+    ["--pr <url-or-number>", "PR URL or number override. Defaults from the Project PR field."],
+    ["--workspace <path>", "Workspace path override for gh context."],
+    ["--force", "Allow syncing closed issues."],
+    ...repositoryOptions,
+    ...mutationOptions,
+    ...projectOptions,
+  ],
+})
+
+if (!args.issue) {
+  fail("sync-pr mode requires --issue <number>")
+}
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
+const item = findProjectIssueItem(project.items, {
+  issueNumber: args.issue,
+  repository,
+})
+
+if (item.issue.state !== "OPEN" && !args.force) {
+  fail(`issue #${args.issue} cannot sync PR because issue state is ${item.issue.state}`)
+}
+
+const prReference = normalizePrReference(args.pr ?? item.fields.PR)
+if (!prReference) {
+  fail("sync-pr mode requires --pr or an existing Project PR field")
+}
+
+const workspace = args.workspace ?? repoRoot
+const pr = readPullRequestStatus({ prReference, repository, workspace })
+const result = evaluatePullRequestGate(pr)
+const values = pullRequestSyncFieldValues({ pr, result })
+const clear = result.blockedBy ? [] : ["Blocked By"]
+if (result.blockedBy) {
+  values["Blocked By"] = result.blockedBy
+}
+
+if (!args.yes) {
+  printSyncPlan({ item, pr, repository, result, values, clear })
+  fail("sync-pr mode updates GitHub Project fields; rerun with --yes")
+}
+
+updateProjectItemFields({ project, item, values, clear })
+
+console.log("agent-runner sync-pr: updated Project PR review state")
+console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+console.log(`repository: ${repository}`)
+console.log(`pr: ${pr.url}`)
+console.log(`agent state: ${result.agentState}`)
+console.log(`reason: ${result.reason}`)
+
+function normalizePrReference(value) {
+  if (!value) return undefined
+  return String(pullRequestNumberFromUrl(value) ?? value)
+}
+
+function printSyncPlan({ clear, item, pr, repository, result, values }) {
+  console.log("agent-runner sync-pr would update:")
+  console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+  console.log(`repository: ${repository}`)
+  console.log(`pr: ${pr.url}`)
+  console.log(`reason: ${result.reason}`)
+  for (const [fieldName, value] of Object.entries(values)) {
+    console.log(`${fieldName}: ${value}`)
+  }
+  for (const fieldName of clear) {
+    console.log(`${fieldName}: <clear>`)
+  }
+}

--- a/scripts/lib/agent-runner-pr.mjs
+++ b/scripts/lib/agent-runner-pr.mjs
@@ -4,6 +4,14 @@ import path from "node:path"
 import { fail, runCommand, runGit } from "./agent-project-queue.mjs"
 
 export const openPullRequestStates = new Set(["Human Review", "CI Repair", "Changes Requested"])
+const successfulCheckConclusions = new Set(["SUCCESS", "SKIPPED", "NEUTRAL"])
+const failedCheckConclusions = new Set([
+  "ACTION_REQUIRED",
+  "CANCELLED",
+  "FAILURE",
+  "STARTUP_FAILURE",
+  "TIMED_OUT",
+])
 
 export function pullRequestFieldValues({ date = new Date(), prUrl }) {
   return {
@@ -100,6 +108,139 @@ export function pullRequestCreateArgs({ base, body, branch, draft = true, title 
 
 export function isRemoteReference(reference) {
   return /^https?:\/\//.test(reference)
+}
+
+export function pullRequestNumberFromUrl(prUrl) {
+  const match = prUrl?.match(/\/pull\/(\d+)(?:$|[/?#])/)
+  return match ? Number(match[1]) : undefined
+}
+
+export function readPullRequestStatus({ prReference, repository, workspace }) {
+  const payload = runCommand(
+    "gh",
+    [
+      "pr",
+      "view",
+      prReference,
+      "--repo",
+      repository,
+      "--json",
+      "isDraft,mergeStateStatus,number,reviewDecision,state,statusCheckRollup,title,url",
+    ],
+    { cwd: workspace },
+  )
+  return JSON.parse(payload)
+}
+
+export function evaluatePullRequestGate(pr) {
+  const checks = summarizeChecks(pr.statusCheckRollup ?? [])
+
+  if (pr.state !== "OPEN") {
+    return {
+      agentState: "Human Review",
+      blockedBy: `PR is ${pr.state}`,
+      mergeReady: false,
+      reason: `PR is ${pr.state}`,
+    }
+  }
+
+  if (pr.reviewDecision === "CHANGES_REQUESTED") {
+    return {
+      agentState: "Changes Requested",
+      blockedBy: "PR changes requested",
+      mergeReady: false,
+      reason: "review changes requested",
+    }
+  }
+
+  if (checks.failed.length > 0) {
+    return {
+      agentState: "CI Repair",
+      blockedBy: `Failing checks: ${checks.failed.join(", ")}`,
+      mergeReady: false,
+      reason: "checks failing",
+    }
+  }
+
+  if (checks.pending.length > 0) {
+    return {
+      agentState: "Human Review",
+      blockedBy: `Pending checks: ${checks.pending.join(", ")}`,
+      mergeReady: false,
+      reason: "checks pending",
+    }
+  }
+
+  if (pr.reviewDecision && pr.reviewDecision !== "APPROVED") {
+    return {
+      agentState: "Human Review",
+      blockedBy: `PR review decision: ${pr.reviewDecision}`,
+      mergeReady: false,
+      reason: "review required",
+    }
+  }
+
+  if (pr.isDraft) {
+    return {
+      agentState: "Human Review",
+      blockedBy: "PR is draft",
+      mergeReady: false,
+      reason: "draft PR",
+    }
+  }
+
+  return {
+    agentState: "Merge Ready",
+    blockedBy: null,
+    mergeReady: true,
+    reason: "PR is ready for maintainer merge",
+  }
+}
+
+export function pullRequestSyncFieldValues({ date = new Date(), pr, result }) {
+  return {
+    "Agent State": result.agentState,
+    PR: pr.url,
+    "Last Heartbeat": date.toISOString().slice(0, 10),
+  }
+}
+
+export function summarizeChecks(checks) {
+  const summary = {
+    failed: [],
+    pending: [],
+    successful: [],
+  }
+
+  for (const check of checks) {
+    const name = check.name ?? check.workflowName ?? "unnamed check"
+    const status = check.status ?? ""
+    const conclusion = check.conclusion ?? ""
+
+    if (status && status !== "COMPLETED") {
+      summary.pending.push(name)
+      continue
+    }
+
+    if (!conclusion) {
+      summary.pending.push(name)
+      continue
+    }
+
+    if (failedCheckConclusions.has(conclusion)) {
+      summary.failed.push(name)
+      continue
+    }
+
+    if (successfulCheckConclusions.has(conclusion)) {
+      summary.successful.push(name)
+      continue
+    }
+
+    summary.failed.push(name)
+  }
+
+  return summary
 }
 
 function formatEvidence(evidenceReference, evidenceBody) {

--- a/scripts/tests/agent-runner-lifecycle.test.mjs
+++ b/scripts/tests/agent-runner-lifecycle.test.mjs
@@ -4,11 +4,15 @@ import { describe, it } from "node:test"
 
 import { claimFieldValues } from "../lib/agent-runner-claim.mjs"
 import {
+  evaluatePullRequestGate,
   isRemoteReference,
   pullRequestBody,
   pullRequestCreateArgs,
   pullRequestFieldValues,
+  pullRequestNumberFromUrl,
+  pullRequestSyncFieldValues,
   pullRequestTitle,
+  summarizeChecks,
 } from "../lib/agent-runner-pr.mjs"
 import { buildExecutionPlan, workspacePlan } from "../lib/agent-runner-workspace.mjs"
 
@@ -125,6 +129,137 @@ describe("agent runner lifecycle helpers", () => {
       "--draft",
     ])
     assert.equal(args.includes("voyantjs:task/579-test-agent-project-intake-workflow"), false)
+  })
+
+  it("parses PR numbers from GitHub pull request URLs", () => {
+    assert.equal(pullRequestNumberFromUrl("https://github.com/voyantjs/voyant/pull/603"), 603)
+    assert.equal(
+      pullRequestNumberFromUrl("https://github.com/voyantjs/voyant/issues/603"),
+      undefined,
+    )
+  })
+
+  it("summarizes PR checks into successful, pending, and failed buckets", () => {
+    assert.deepEqual(
+      summarizeChecks([
+        { name: "build", status: "COMPLETED", conclusion: "SUCCESS" },
+        { name: "checks", status: "IN_PROGRESS", conclusion: "" },
+        { name: "test", status: "COMPLETED", conclusion: "FAILURE" },
+      ]),
+      {
+        failed: ["test"],
+        pending: ["checks"],
+        successful: ["build"],
+      },
+    )
+  })
+
+  it("moves failing PR checks to CI repair", () => {
+    assert.deepEqual(
+      evaluatePullRequestGate({
+        state: "OPEN",
+        isDraft: false,
+        reviewDecision: "",
+        statusCheckRollup: [{ name: "checks", status: "COMPLETED", conclusion: "FAILURE" }],
+      }),
+      {
+        agentState: "CI Repair",
+        blockedBy: "Failing checks: checks",
+        mergeReady: false,
+        reason: "checks failing",
+      },
+    )
+  })
+
+  it("moves requested changes to changes requested before check state", () => {
+    assert.deepEqual(
+      evaluatePullRequestGate({
+        state: "OPEN",
+        isDraft: false,
+        reviewDecision: "CHANGES_REQUESTED",
+        statusCheckRollup: [{ name: "checks", status: "COMPLETED", conclusion: "SUCCESS" }],
+      }),
+      {
+        agentState: "Changes Requested",
+        blockedBy: "PR changes requested",
+        mergeReady: false,
+        reason: "review changes requested",
+      },
+    )
+  })
+
+  it("keeps draft or pending-check PRs in human review", () => {
+    assert.equal(
+      evaluatePullRequestGate({
+        state: "OPEN",
+        isDraft: true,
+        reviewDecision: "",
+        statusCheckRollup: [{ name: "checks", status: "COMPLETED", conclusion: "SUCCESS" }],
+      }).agentState,
+      "Human Review",
+    )
+
+    assert.deepEqual(
+      evaluatePullRequestGate({
+        state: "OPEN",
+        isDraft: false,
+        reviewDecision: "",
+        statusCheckRollup: [{ name: "checks", status: "QUEUED", conclusion: "" }],
+      }),
+      {
+        agentState: "Human Review",
+        blockedBy: "Pending checks: checks",
+        mergeReady: false,
+        reason: "checks pending",
+      },
+    )
+  })
+
+  it("keeps review-required PRs in human review even with passing checks", () => {
+    assert.deepEqual(
+      evaluatePullRequestGate({
+        state: "OPEN",
+        isDraft: false,
+        reviewDecision: "REVIEW_REQUIRED",
+        statusCheckRollup: [{ name: "checks", status: "COMPLETED", conclusion: "SUCCESS" }],
+      }),
+      {
+        agentState: "Human Review",
+        blockedBy: "PR review decision: REVIEW_REQUIRED",
+        mergeReady: false,
+        reason: "review required",
+      },
+    )
+  })
+
+  it("moves passing non-draft PRs to merge ready", () => {
+    const pr = {
+      url: "https://github.com/voyantjs/voyant/pull/603",
+      state: "OPEN",
+      isDraft: false,
+      reviewDecision: "",
+      statusCheckRollup: [{ name: "checks", status: "COMPLETED", conclusion: "SUCCESS" }],
+    }
+    const result = evaluatePullRequestGate(pr)
+
+    assert.deepEqual(result, {
+      agentState: "Merge Ready",
+      blockedBy: null,
+      mergeReady: true,
+      reason: "PR is ready for maintainer merge",
+    })
+    assert.deepEqual(
+      pullRequestSyncFieldValues({
+        date: new Date("2026-05-10T12:34:56.000Z"),
+        pr,
+        result,
+      }),
+      {
+        "Agent State": "Merge Ready",
+        PR: "https://github.com/voyantjs/voyant/pull/603",
+        "Last Heartbeat": "2026-05-10",
+      },
+    )
   })
 })
 


### PR DESCRIPTION
## Summary
- add `pnpm agent:queue:sync-pr` to read a linked PR/check rollup and update Project review state
- classify failing checks as `CI Repair`, requested changes as `Changes Requested`, pending/draft PRs as `Human Review`, and passing non-draft PRs as `Merge Ready`
- update PR, heartbeat, and blocked-by Project fields from the sync result without merging
- add pure tests for PR URL parsing, check summaries, PR state classification, and sync field values
- document the PR sync step in the runner workflow

## Validation
- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm exec secretlint docs/agents/issue-tracker.md scripts/agent-runner-*.mjs scripts/lib/agent-*.mjs scripts/tests/*.test.mjs`
- `pnpm verify:architecture`
- help matrix for doctor, dry-run, status, prepare, start, claim, heartbeat, handoff, publish-evidence, open-pr, sync-pr, watchdog, release, test
- `pnpm agent:queue:dry-run -- --json`
- `pnpm agent:queue:doctor -- --json`
- `pnpm agent:queue:sync-pr -- --issue 579 --pr 603` exits with the expected closed issue failure before mutation

## Notes
- No changeset: internal runner scripts, tests, and agent docs only.
- Commit/push hooks were bypassed because the broad repo typecheck/test hooks are still blocked by unrelated package resolution failures observed on previous runner PRs.