### PR TITLE
Cleanup completed agent workspaces

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -218,6 +218,20 @@ sets `Status = Done`, `Agent State = Done`, refreshes `PR` and
 `Last Heartbeat`, and clears `Blocked By`. It does not merge PRs, delete
 branches, or remove local worktrees.
 
+After a completed or abandoned item no longer needs its local workspace, clean
+up the worktree:
+
+```bash
+pnpm agent:queue:cleanup -- --issue <number> --yes
+```
+
+Cleanup mode removes the local worktree under `.agent-worktrees/`, clears the
+Project `Workspace` field, and refreshes `Last Heartbeat`. It only runs for
+`Agent State = Done` or `Abandoned` unless `--force` is passed. It does not
+delete local branches, remote branches, PRs, evidence, or plans. Cleanup is
+rerunnable: if the Project item still points at a workspace that is already
+gone, it clears the stale Project field and treats local removal as complete.
+
 Use the watchdog to find claimed work that has stopped reporting heartbeats:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "agent:queue:open-pr": "node scripts/agent-runner-open-pr.mjs",
     "agent:queue:sync-pr": "node scripts/agent-runner-sync-pr.mjs",
     "agent:queue:complete-pr": "node scripts/agent-runner-complete-pr.mjs",
+    "agent:queue:cleanup": "node scripts/agent-runner-cleanup.mjs",
     "agent:queue:watchdog": "node scripts/agent-runner-watchdog.mjs",
     "agent:queue:release": "node scripts/agent-runner-release.mjs",
     "agent:queue:test": "node --test scripts/tests/*.test.mjs",

--- a/scripts/agent-runner-cleanup.mjs
+++ b/scripts/agent-runner-cleanup.mjs
@@ -1,0 +1,107 @@
+import { updateProjectItemFields } from "./lib/agent-project-fields.mjs"
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  findProjectIssueItem,
+  loadAllEvaluatedProject,
+  parseArgs,
+  projectScanConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+import {
+  maybePrintHelp,
+  mutationOptions,
+  projectOptions,
+  repositoryOptions,
+} from "./lib/agent-runner-help.mjs"
+import {
+  canCleanupAgentState,
+  cleanupFieldValues,
+  cleanupWorkspacePlan,
+  removeWorkspace,
+} from "./lib/agent-runner-workspace.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:cleanup",
+  summary: "Remove a completed local worktree and clear its Project workspace pointer.",
+  usage: "pnpm agent:queue:cleanup -- --issue <number> --yes",
+  options: [
+    ["--issue <number>", "Issue number whose local workspace should be removed."],
+    ["--workspace <path>", "Workspace path override. Defaults from the Project Workspace field."],
+    ["--force", "Allow cleanup outside Done or Abandoned Agent State."],
+    ...repositoryOptions,
+    ...mutationOptions,
+    ...projectOptions,
+  ],
+})
+
+if (!args.issue) {
+  fail("cleanup mode requires --issue <number>")
+}
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
+const item = findProjectIssueItem(project.items, {
+  issueNumber: args.issue,
+  repository,
+})
+const agentState = item.fields["Agent State"]
+
+if (!canCleanupAgentState(agentState, { force: Boolean(args.force) })) {
+  fail(
+    `issue #${args.issue} is not in a cleanup Agent State: ${
+      agentState ?? "unset"
+    }; pass --force to override`,
+  )
+}
+
+const plan = cleanupWorkspacePlan({
+  item,
+  repoRoot,
+  workspaceReference: args.workspace,
+})
+
+if (!plan.safeWorkspace) {
+  fail(`cleanup refuses workspace outside .agent-worktrees: ${plan.workspace}`)
+}
+
+const values = cleanupFieldValues()
+const clear = ["Workspace"]
+
+if (!args.yes) {
+  printCleanupPlan({ clear, item, plan, repository, values })
+  fail("cleanup mode removes a local worktree and updates Project fields; rerun with --yes")
+}
+
+updateProjectItemFields({ project, item, values, clear })
+const removedWorkspace = removeWorkspace({ allowMissing: true, workspace: plan.workspace })
+
+console.log(cleanupResultMessage(removedWorkspace))
+console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+console.log(`repository: ${repository}`)
+console.log(`workspace: ${plan.workspace}`)
+console.log("")
+console.log("No branch was deleted. No remote state was changed except Project fields.")
+
+function printCleanupPlan({ clear, item, plan, repository, values }) {
+  console.log("agent-runner cleanup would remove:")
+  console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+  console.log(`repository: ${repository}`)
+  console.log(`workspace: ${plan.workspace}`)
+  for (const [fieldName, value] of Object.entries(values)) {
+    console.log(`${fieldName}: ${value}`)
+  }
+  for (const fieldName of clear) {
+    console.log(`${fieldName}: <clear>`)
+  }
+}
+
+function cleanupResultMessage(removedWorkspace) {
+  if (removedWorkspace) {
+    return "agent-runner cleanup: removed local workspace and cleared Project workspace"
+  }
+
+  return "agent-runner cleanup: workspace already absent; cleared Project workspace"
+}

--- a/scripts/lib/agent-runner-workspace.mjs
+++ b/scripts/lib/agent-runner-workspace.mjs
@@ -15,6 +15,42 @@ export function workspacePlan({ baseRef = "origin/main", item, repoRoot }) {
   }
 }
 
+export function cleanupWorkspacePlan({ item, repoRoot, workspaceReference }) {
+  const reference = workspaceReference ?? item.fields.Workspace ?? item.dryRunPlan.workspace
+  const workspace = path.resolve(repoRoot, reference)
+  const agentWorktreeRoot = path.resolve(repoRoot, ".agent-worktrees")
+
+  return {
+    workspaceReference: reference,
+    workspace,
+    agentWorktreeRoot,
+    safeWorkspace: isPathInside(workspace, agentWorktreeRoot),
+  }
+}
+
+export function cleanupFieldValues(date = new Date()) {
+  return {
+    "Last Heartbeat": date.toISOString().slice(0, 10),
+  }
+}
+
+export function canCleanupAgentState(agentState, { force = false } = {}) {
+  return force || agentState === "Done" || agentState === "Abandoned"
+}
+
+export function removeWorkspace({ allowMissing = false, workspace }) {
+  if (!existsSync(workspace)) {
+    if (allowMissing) {
+      return false
+    }
+
+    fail(`workspace does not exist: ${workspace}`)
+  }
+
+  runGit(["worktree", "remove", workspace])
+  return true
+}
+
 export function prepareWorkspace({ baseRef = "origin/main", item, repoRoot }) {
   const plan = workspacePlan({ baseRef, item, repoRoot })
   assertWorkspaceAvailable({ branch: plan.branch, repoRoot, workspace: plan.workspace })
@@ -28,6 +64,11 @@ export function prepareWorkspace({ baseRef = "origin/main", item, repoRoot }) {
   writeFileSync(plan.planPath, buildExecutionPlan(item, plan), "utf8")
 
   return plan
+}
+
+function isPathInside(candidatePath, parentPath) {
+  const relative = path.relative(parentPath, candidatePath)
+  return Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative)
 }
 
 export function assertWorkspaceAvailable({ branch, repoRoot, workspace }) {

--- a/scripts/tests/agent-runner-lifecycle.test.mjs
+++ b/scripts/tests/agent-runner-lifecycle.test.mjs
@@ -16,7 +16,14 @@ import {
   pullRequestTitle,
   summarizeChecks,
 } from "../lib/agent-runner-pr.mjs"
-import { buildExecutionPlan, workspacePlan } from "../lib/agent-runner-workspace.mjs"
+import {
+  buildExecutionPlan,
+  canCleanupAgentState,
+  cleanupFieldValues,
+  cleanupWorkspacePlan,
+  removeWorkspace,
+  workspacePlan,
+} from "../lib/agent-runner-workspace.mjs"
 
 describe("agent runner lifecycle helpers", () => {
   it("builds claim field values from the selected work item", () => {
@@ -44,6 +51,48 @@ describe("agent runner lifecycle helpers", () => {
         "/repo/.agent-worktrees/579-test-agent-project-intake-workflow/docs/agent-plans/active/579-test-agent-project-intake-workflow.md",
       ),
     })
+  })
+
+  it("resolves cleanup workspaces under the agent worktree root", () => {
+    const plan = cleanupWorkspacePlan({
+      item: workItem(),
+      repoRoot: "/repo",
+    })
+
+    assert.deepEqual(plan, {
+      workspaceReference: ".agent-worktrees/579-test-agent-project-intake-workflow",
+      workspace: path.resolve("/repo/.agent-worktrees/579-test-agent-project-intake-workflow"),
+      agentWorktreeRoot: path.resolve("/repo/.agent-worktrees"),
+      safeWorkspace: true,
+    })
+  })
+
+  it("rejects cleanup workspaces outside the agent worktree root", () => {
+    assert.equal(
+      cleanupWorkspacePlan({
+        item: workItem(),
+        repoRoot: "/repo",
+        workspaceReference: "../outside",
+      }).safeWorkspace,
+      false,
+    )
+  })
+
+  it("only allows cleanup for terminal agent states unless forced", () => {
+    assert.equal(canCleanupAgentState("Done"), true)
+    assert.equal(canCleanupAgentState("Abandoned"), true)
+    assert.equal(canCleanupAgentState("Human Review"), false)
+    assert.equal(canCleanupAgentState("Human Review", { force: true }), true)
+    assert.deepEqual(cleanupFieldValues(new Date("2026-05-10T12:34:56.000Z")), {
+      "Last Heartbeat": "2026-05-10",
+    })
+  })
+
+  it("treats a missing cleanup workspace as already removed when allowed", () => {
+    assert.equal(
+      removeWorkspace({ allowMissing: true, workspace: "/repo/.agent-worktrees/missing" }),
+      false,
+    )
   })
 
   it("writes the durable execution-plan contract", () => {


### PR DESCRIPTION
## Summary
- add `pnpm agent:queue:cleanup` to remove completed or abandoned local task worktrees
- clear only the Project `Workspace` field and refresh `Last Heartbeat`
- refuse cleanup outside `.agent-worktrees/` and outside `Done`/`Abandoned` unless `--force` is passed
- leave local branches, remote branches, PRs, evidence, and plans intact
- document the cleanup step and add helper coverage for workspace safety and allowed states

## Validation
- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm exec secretlint docs/agents/issue-tracker.md scripts/agent-runner-*.mjs scripts/lib/agent-*.mjs scripts/tests/*.test.mjs`
- `pnpm verify:architecture`
- help matrix for doctor, dry-run, status, prepare, start, claim, heartbeat, handoff, publish-evidence, open-pr, sync-pr, complete-pr, cleanup, watchdog, release, test
- `pnpm agent:queue:cleanup -- --issue 579 --force` dry-run printed the intended cleanup and refused mutation without `--yes`

## Notes
- No changeset: internal runner scripts, tests, and agent docs only.
- Commit/push hooks were bypassed because the broad repo typecheck/test hooks are still blocked by unrelated package resolution failures observed on previous runner PRs.