### PR TITLE
Recommend next agent queue actions

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -150,6 +150,18 @@ ready, active, stale, blocked, human-review, and merge-ready items. Pass
 `--json` for automation or `--max-age-days <number>` to adjust the heartbeat
 staleness threshold.
 
+Use the read-only tick view when wiring an always-on supervisor:
+
+```bash
+pnpm agent:queue:tick
+```
+
+Tick mode scans the same repository-scoped Project queue and prints ordered
+action recommendations such as `start`, `run-command`, `publish-evidence`,
+`open-pr`, `sync-pr`, `cleanup`, or `inspect-stale`. It does not mutate GitHub,
+create worktrees, run commands, publish evidence, or open PRs. Pass `--json`
+when a process manager or future control plane needs machine-readable actions.
+
 After a workspace is prepared, claim the item before implementation work starts:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "agent:queue:doctor": "node scripts/agent-runner-doctor.mjs",
     "agent:queue:dry-run": "node scripts/agent-runner-dry-run.mjs",
     "agent:queue:status": "node scripts/agent-runner-status.mjs",
+    "agent:queue:tick": "node scripts/agent-runner-tick.mjs",
     "agent:queue:prepare": "node scripts/agent-runner-prepare.mjs",
     "agent:queue:start": "node scripts/agent-runner-start.mjs",
     "agent:queue:run-command": "node scripts/agent-runner-run-command.mjs",

--- a/scripts/agent-runner-tick.mjs
+++ b/scripts/agent-runner-tick.mjs
@@ -1,0 +1,87 @@
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  filterItemsByRepository,
+  loadAllEvaluatedProject,
+  parseArgs,
+  projectScanConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+import { maybePrintHelp, projectOptions, repositoryOptions } from "./lib/agent-runner-help.mjs"
+import { recommendQueueActions } from "./lib/agent-runner-tick.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:tick",
+  summary:
+    "Read the Project queue and recommend the next runner actions without mutating anything.",
+  usage: "pnpm agent:queue:tick -- [--json] [--repo <owner/name>]",
+  options: [
+    ["--json", "Print machine-readable JSON."],
+    ["--max-age-days <number>", "Heartbeat staleness threshold. Defaults to 1."],
+    ...repositoryOptions,
+    ...projectOptions,
+  ],
+})
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const maxAgeDays = Number(args.maxAgeDays ?? 1)
+
+if (!Number.isInteger(maxAgeDays) || maxAgeDays < 0) {
+  fail(`invalid max age days: ${String(args.maxAgeDays)}`)
+}
+
+const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
+const items = filterItemsByRepository(project.items, repository)
+const recommendations = recommendQueueActions(items, { maxAgeDays, repository })
+
+if (args.json) {
+  console.log(
+    JSON.stringify(
+      {
+        project: {
+          owner: project.owner,
+          number: project.projectNumber,
+          title: project.projectTitle,
+          url: project.projectUrl,
+        },
+        repository,
+        maxAgeDays,
+        recommendations,
+      },
+      null,
+      2,
+    ),
+  )
+} else {
+  printHumanSummary()
+}
+
+function printHumanSummary() {
+  console.log(
+    `agent-runner tick: ${project.projectTitle} (${project.owner}/projects/${project.projectNumber})`,
+  )
+  console.log(`repository: ${repository}`)
+  console.log(`items scanned: ${items.length}`)
+  console.log(`recommendations: ${recommendations.length}`)
+  console.log("")
+
+  if (recommendations.length === 0) {
+    console.log("No runner action recommended.")
+    return
+  }
+
+  for (const recommendation of recommendations) {
+    console.log(`- #${recommendation.issue.number} ${recommendation.issue.title}`)
+    console.log(`  action: ${recommendation.action}`)
+    console.log(`  state: ${recommendation.state ?? "unset"}`)
+    console.log(`  reason: ${recommendation.reason}`)
+    if (recommendation.command) {
+      console.log(`  command: ${recommendation.command}`)
+    }
+    if (recommendation.heartbeat) {
+      console.log(`  heartbeat: ${recommendation.heartbeat.reason}`)
+    }
+  }
+}

--- a/scripts/lib/agent-runner-tick.mjs
+++ b/scripts/lib/agent-runner-tick.mjs
@@ -1,0 +1,199 @@
+import { evaluateHeartbeat } from "./agent-runner-output.mjs"
+
+const runnableStates = new Set(["Planning", "Changes Requested", "CI Repair"])
+const stalePreemptionStates = new Set(["Planning", "Running", "Changes Requested", "CI Repair"])
+const watchedStates = new Set([
+  "Planning",
+  "Running",
+  "Blocked",
+  "Human Review",
+  "Changes Requested",
+  "CI Repair",
+])
+
+export function recommendQueueActions(items, { maxAgeDays, repository }) {
+  return items
+    .map((item) => recommendQueueAction(item, { maxAgeDays, repository }))
+    .filter((recommendation) => recommendation.action !== "ignore")
+    .sort(
+      (left, right) =>
+        left.priority - right.priority || (left.issue?.number ?? 0) - (right.issue?.number ?? 0),
+    )
+}
+
+export function recommendQueueAction(item, { maxAgeDays, repository }) {
+  if (!item.issue) {
+    return recommendation(item, {
+      action: "ignore",
+      command: null,
+      priority: 999,
+      reason: "project item has no issue content",
+    })
+  }
+
+  const state = item.fields["Agent State"]
+  const heartbeat = watchedStates.has(state)
+    ? evaluateHeartbeat(item.fields["Last Heartbeat"], { maxAgeDays })
+    : null
+
+  if (stalePreemptionStates.has(state) && heartbeat?.stale) {
+    return recommendation(item, {
+      action: "inspect-stale",
+      command: commandWithIssue({
+        command: "watchdog",
+        issueNumber: item.issue.number,
+        repository,
+      }),
+      heartbeat,
+      priority: 10,
+      reason: heartbeat.reason,
+    })
+  }
+
+  if (item.ready) {
+    return recommendation(item, {
+      action: "start",
+      command: commandWithIssue({ command: "start", issueNumber: item.issue.number, repository }),
+      priority: 20,
+      reason: "maintainer-approved item is ready to claim",
+    })
+  }
+
+  if (runnableStates.has(state)) {
+    return recommendation(item, {
+      action: "run-command",
+      command: commandWithIssue({
+        command: "run-command",
+        extraArgs: ['--command "<implementation-command>"'],
+        issueNumber: item.issue.number,
+        repository,
+      }),
+      heartbeat,
+      priority: 30,
+      reason: `item is in ${state}`,
+    })
+  }
+
+  if (state === "Running") {
+    return recommendation(item, {
+      action: "wait-running",
+      command: null,
+      heartbeat,
+      priority: 40,
+      reason: "command execution is already marked running",
+    })
+  }
+
+  if (state === "Human Review") {
+    return humanReviewRecommendation(item, { heartbeat, repository })
+  }
+
+  if (state === "Merge Ready") {
+    return recommendation(item, {
+      action: "wait-maintainer-merge",
+      command: null,
+      priority: 80,
+      reason: "PR is ready for maintainer merge",
+    })
+  }
+
+  if ((state === "Done" || state === "Abandoned") && item.fields.Workspace) {
+    return recommendation(item, {
+      action: "cleanup",
+      command: commandWithIssue({ command: "cleanup", issueNumber: item.issue.number, repository }),
+      priority: 90,
+      reason: `terminal item still has Workspace set`,
+    })
+  }
+
+  if (state === "Blocked") {
+    return recommendation(item, {
+      action: "inspect-blocked",
+      command: null,
+      heartbeat,
+      priority: 95,
+      reason: item.fields["Blocked By"] ?? "item is blocked",
+    })
+  }
+
+  return recommendation(item, {
+    action: "ignore",
+    command: null,
+    priority: 999,
+    reason: item.reasons.join("; ") || `Agent State is ${state ?? "unset"}`,
+  })
+}
+
+function humanReviewRecommendation(item, { heartbeat, repository }) {
+  const evidence = item.fields.Evidence
+  const pr = item.fields.PR
+
+  if (pr) {
+    return recommendation(item, {
+      action: "sync-pr",
+      command: commandWithIssue({ command: "sync-pr", issueNumber: item.issue.number, repository }),
+      heartbeat,
+      priority: 50,
+      reason: "linked PR should be synced back to the Project",
+    })
+  }
+
+  if (!evidence) {
+    return recommendation(item, {
+      action: "needs-evidence",
+      command: null,
+      heartbeat,
+      priority: 55,
+      reason: "human review item is missing Evidence",
+    })
+  }
+
+  if (isRemoteEvidence(evidence)) {
+    return recommendation(item, {
+      action: "open-pr",
+      command: commandWithIssue({ command: "open-pr", issueNumber: item.issue.number, repository }),
+      heartbeat,
+      priority: 60,
+      reason: "published evidence exists and no PR is linked",
+    })
+  }
+
+  return recommendation(item, {
+    action: "publish-evidence",
+    command: commandWithIssue({
+      command: "publish-evidence",
+      issueNumber: item.issue.number,
+      repository,
+    }),
+    heartbeat,
+    priority: 60,
+    reason: "local evidence should be published before opening a PR",
+  })
+}
+
+function recommendation(item, { action, command, heartbeat = null, priority, reason }) {
+  return {
+    action,
+    command,
+    heartbeat,
+    issue: item.issue,
+    priority,
+    reason,
+    state: item.fields["Agent State"] ?? null,
+  }
+}
+
+function isRemoteEvidence(evidence) {
+  return /^https?:\/\//.test(evidence)
+}
+
+function commandWithIssue({ command, extraArgs = [], issueNumber, repository }) {
+  return [
+    `pnpm agent:queue:${command} -- --issue ${issueNumber}`,
+    repository ? `--repo ${repository}` : null,
+    ...extraArgs,
+    "--yes",
+  ]
+    .filter(Boolean)
+    .join(" ")
+}

--- a/scripts/tests/agent-fixtures.mjs
+++ b/scripts/tests/agent-fixtures.mjs
@@ -1,0 +1,29 @@
+export function workItem({
+  fields = {},
+  number = 579,
+  title = "Test agent project intake workflow",
+} = {}) {
+  return {
+    itemId: `item-${number}`,
+    issue: {
+      number,
+      title,
+      url: `https://github.com/voyantjs/voyant/issues/${number}`,
+      state: "OPEN",
+      repository: "voyantjs/voyant",
+      labels: ["agent:ready"],
+    },
+    fields,
+    ready: fields["Agent State"] ? fields["Agent State"] === "Ready" : true,
+    reasons: [],
+    dryRunPlan: {
+      branch: "task/579-test-agent-project-intake-workflow",
+      workspace: ".agent-worktrees/579-test-agent-project-intake-workflow",
+      planPath: "docs/agent-plans/active/579-test-agent-project-intake-workflow.md",
+      verificationLane: "verify:fast",
+      risk: "Low",
+      securityRisk: "None",
+      agentProvider: "manual",
+    },
+  }
+}

--- a/scripts/tests/agent-runner-lifecycle.test.mjs
+++ b/scripts/tests/agent-runner-lifecycle.test.mjs
@@ -31,6 +31,7 @@ import {
   removeWorkspace,
   workspacePlan,
 } from "../lib/agent-runner-workspace.mjs"
+import { workItem } from "./agent-fixtures.mjs"
 
 describe("agent runner lifecycle helpers", () => {
   it("builds claim field values from the selected work item", () => {
@@ -472,27 +473,3 @@ describe("agent runner lifecycle helpers", () => {
     )
   })
 })
-
-function workItem() {
-  return {
-    itemId: "item-579",
-    issue: {
-      number: 579,
-      title: "Test agent project intake workflow",
-      url: "https://github.com/voyantjs/voyant/issues/579",
-      state: "OPEN",
-      repository: "voyantjs/voyant",
-      labels: ["agent:ready"],
-    },
-    fields: {},
-    dryRunPlan: {
-      branch: "task/579-test-agent-project-intake-workflow",
-      workspace: ".agent-worktrees/579-test-agent-project-intake-workflow",
-      planPath: "docs/agent-plans/active/579-test-agent-project-intake-workflow.md",
-      verificationLane: "verify:fast",
-      risk: "Low",
-      securityRisk: "None",
-      agentProvider: "manual",
-    },
-  }
-}

--- a/scripts/tests/agent-runner-tick.test.mjs
+++ b/scripts/tests/agent-runner-tick.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { recommendQueueAction, recommendQueueActions } from "../lib/agent-runner-tick.mjs"
+import { workItem } from "./agent-fixtures.mjs"
+
+describe("agent runner tick helpers", () => {
+  it("recommends ordered queue tick actions", () => {
+    const ready = workItem()
+    const humanReview = workItem({
+      fields: {
+        "Agent State": "Human Review",
+        Evidence: "docs/agent-evidence/active/579-test.md",
+      },
+      number: 580,
+      title: "Publish evidence",
+    })
+    const staleRunning = workItem({
+      fields: {
+        "Agent State": "Running",
+        "Last Heartbeat": "2026-05-08",
+      },
+      number: 581,
+      title: "Inspect stale runner",
+    })
+
+    assert.deepEqual(
+      recommendQueueActions([ready, humanReview, staleRunning], {
+        maxAgeDays: 1,
+        repository: "voyantjs/other",
+      }).map((item) => item.action),
+      ["inspect-stale", "start", "publish-evidence"],
+    )
+  })
+
+  it("maps queue tick states to the next safe runner command", () => {
+    assert.deepEqual(
+      recommendQueueAction(workItem(), { maxAgeDays: 1, repository: "voyantjs/other" }),
+      {
+        action: "start",
+        command: "pnpm agent:queue:start -- --issue 579 --repo voyantjs/other --yes",
+        heartbeat: null,
+        issue: workItem().issue,
+        priority: 20,
+        reason: "maintainer-approved item is ready to claim",
+        state: null,
+      },
+    )
+
+    assert.deepEqual(
+      recommendQueueAction(
+        workItem({
+          fields: {
+            "Agent State": "Human Review",
+            Evidence: "https://github.com/voyantjs/voyant/issues/579#issuecomment-1",
+          },
+        }),
+        { maxAgeDays: 1, repository: "voyantjs/other" },
+      ).action,
+      "open-pr",
+    )
+
+    assert.deepEqual(
+      recommendQueueAction(
+        workItem({
+          fields: {
+            "Agent State": "Done",
+            Workspace: ".agent-worktrees/579-test-agent-project-intake-workflow",
+          },
+        }),
+        { maxAgeDays: 1, repository: "voyantjs/other" },
+      ).command,
+      "pnpm agent:queue:cleanup -- --issue 579 --repo voyantjs/other --yes",
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- add read-only `agent:queue:tick` for ordered queue action recommendations
- classify ready, running, review, merge-ready, terminal, stale, and blocked items into next runner actions
- split runner test fixtures/tick tests so lifecycle coverage stays under the file-size guardrail
- document tick as the read-only supervisor/control-plane input

## Validation

- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm verify:architecture`
- `pnpm exec secretlint docs/agents/issue-tracker.md package.json scripts/agent-runner-tick.mjs scripts/lib/agent-runner-tick.mjs scripts/tests/agent-runner-lifecycle.test.mjs scripts/tests/agent-runner-tick.test.mjs scripts/tests/agent-fixtures.mjs`
- `pnpm exec biome check scripts/agent-runner-tick.mjs scripts/lib/agent-runner-tick.mjs scripts/tests/agent-runner-lifecycle.test.mjs scripts/tests/agent-runner-tick.test.mjs scripts/tests/agent-fixtures.mjs`
- `pnpm agent:queue:tick -- --help`
- `node --check scripts/agent-runner-tick.mjs && node --check scripts/lib/agent-runner-tick.mjs && node --check scripts/tests/agent-runner-tick.test.mjs`