### PR TITLE
Dispatch safe agent queue actions

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -162,6 +162,19 @@ action recommendations such as `start`, `run-command`, `publish-evidence`,
 create worktrees, run commands, publish evidence, or open PRs. Pass `--json`
 when a process manager or future control plane needs machine-readable actions.
 
+Use dispatch to execute one allow-listed tick recommendation:
+
+```bash
+pnpm agent:queue:dispatch -- --yes
+```
+
+Dispatch mode re-reads the Project, selects the highest-priority dispatchable
+recommendation, and runs one lifecycle command. It is dry-run by default. Pass
+`--issue <number>` or `--action <name>` to narrow selection. Dispatch can run
+`start`, `publish-evidence`, `open-pr`, `sync-pr`, and `cleanup`; it refuses
+`run-command`, `inspect-stale`, blocked work, and wait states so implementation
+execution remains explicit.
+
 After a workspace is prepared, claim the item before implementation work starts:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "agent:queue:dry-run": "node scripts/agent-runner-dry-run.mjs",
     "agent:queue:status": "node scripts/agent-runner-status.mjs",
     "agent:queue:tick": "node scripts/agent-runner-tick.mjs",
+    "agent:queue:dispatch": "node scripts/agent-runner-dispatch.mjs",
     "agent:queue:prepare": "node scripts/agent-runner-prepare.mjs",
     "agent:queue:start": "node scripts/agent-runner-start.mjs",
     "agent:queue:run-command": "node scripts/agent-runner-run-command.mjs",

--- a/scripts/agent-runner-dispatch.mjs
+++ b/scripts/agent-runner-dispatch.mjs
@@ -1,0 +1,90 @@
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  filterItemsByRepository,
+  loadAllEvaluatedProject,
+  parseArgs,
+  projectScanConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+import {
+  dispatchableActions,
+  dispatchCommandArgs,
+  runDispatchCommand,
+  selectDispatchRecommendation,
+} from "./lib/agent-runner-dispatch.mjs"
+import {
+  maybePrintHelp,
+  mutationOptions,
+  projectOptions,
+  repositoryOptions,
+} from "./lib/agent-runner-help.mjs"
+import { recommendQueueActions } from "./lib/agent-runner-tick.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:dispatch",
+  summary: "Run one allow-listed queue recommendation from tick.",
+  usage: "pnpm agent:queue:dispatch -- [--issue <number>] [--action start] --yes",
+  options: [
+    ["--issue <number>", "Only dispatch a recommendation for this issue number."],
+    [
+      "--action <name>",
+      `Only dispatch this action. Allowed: ${Array.from(dispatchableActions).join(", ")}.`,
+    ],
+    ["--max-age-days <number>", "Heartbeat staleness threshold. Defaults to 1."],
+    ...repositoryOptions,
+    ...mutationOptions,
+    ...projectOptions,
+  ],
+})
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const maxAgeDays = Number(args.maxAgeDays ?? 1)
+
+if (!Number.isInteger(maxAgeDays) || maxAgeDays < 0) {
+  fail(`invalid max age days: ${String(args.maxAgeDays)}`)
+}
+
+if (args.action && !dispatchableActions.has(args.action)) {
+  fail(`action ${args.action} is not dispatchable`)
+}
+
+const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
+const items = filterItemsByRepository(project.items, repository)
+const recommendations = recommendQueueActions(items, { maxAgeDays, repository })
+let selection
+try {
+  selection = selectDispatchRecommendation(recommendations, {
+    action: args.action,
+    issueNumber: args.issue,
+  })
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error))
+}
+
+const { recommendation, reason } = selection
+
+if (!recommendation) {
+  fail(reason)
+}
+
+const commandArgs = dispatchCommandArgs(recommendation, { repository })
+
+if (!args.yes) {
+  printDispatchPlan({ commandArgs, recommendation, repository })
+  fail("dispatch mode runs one queue mutation; rerun with --yes")
+}
+
+const status = runDispatchCommand(commandArgs)
+process.exitCode = status ?? 1
+
+function printDispatchPlan({ commandArgs, recommendation, repository }) {
+  console.log("agent-runner dispatch would run:")
+  console.log(`issue: #${recommendation.issue.number} ${recommendation.issue.title}`)
+  console.log(`repository: ${repository}`)
+  console.log(`action: ${recommendation.action}`)
+  console.log(`reason: ${recommendation.reason}`)
+  console.log(`command: pnpm ${commandArgs.join(" ")}`)
+}

--- a/scripts/lib/agent-runner-dispatch.mjs
+++ b/scripts/lib/agent-runner-dispatch.mjs
@@ -1,0 +1,70 @@
+import { spawnSync } from "node:child_process"
+
+export const dispatchableActions = new Set([
+  "cleanup",
+  "open-pr",
+  "publish-evidence",
+  "start",
+  "sync-pr",
+])
+
+export function selectDispatchRecommendation(recommendations, { action, issueNumber } = {}) {
+  const normalizedIssueNumber = normalizeIssueNumber(issueNumber)
+  const matches = recommendations.filter((recommendation) => {
+    if (action && recommendation.action !== action) return false
+    if (
+      normalizedIssueNumber !== undefined &&
+      recommendation.issue?.number !== normalizedIssueNumber
+    ) {
+      return false
+    }
+    return dispatchableActions.has(recommendation.action)
+  })
+
+  if (matches.length === 0) {
+    return {
+      recommendation: null,
+      reason: "no dispatchable recommendation matched",
+    }
+  }
+
+  return {
+    recommendation: matches[0],
+    reason:
+      matches.length > 1 ? "selected highest-priority dispatchable recommendation" : "matched",
+  }
+}
+
+export function dispatchCommandArgs(recommendation, { repository }) {
+  if (!dispatchableActions.has(recommendation.action)) {
+    throw new Error(`action ${recommendation.action} is not dispatchable`)
+  }
+
+  return [
+    `agent:queue:${recommendation.action}`,
+    "--",
+    "--issue",
+    String(recommendation.issue.number),
+    "--repo",
+    repository,
+    "--yes",
+  ]
+}
+
+export function runDispatchCommand(commandArgs) {
+  return spawnSync("pnpm", commandArgs, {
+    encoding: "utf8",
+    stdio: "inherit",
+  }).status
+}
+
+function normalizeIssueNumber(issueNumber) {
+  if (issueNumber === undefined) return undefined
+
+  const normalized = Number(issueNumber)
+  if (!Number.isInteger(normalized) || normalized < 1) {
+    throw new Error(`invalid issue number: ${String(issueNumber)}`)
+  }
+
+  return normalized
+}

--- a/scripts/lib/agent-runner-tick.mjs
+++ b/scripts/lib/agent-runner-tick.mjs
@@ -39,11 +39,7 @@ export function recommendQueueAction(item, { maxAgeDays, repository }) {
   if (stalePreemptionStates.has(state) && heartbeat?.stale) {
     return recommendation(item, {
       action: "inspect-stale",
-      command: commandWithIssue({
-        command: "watchdog",
-        issueNumber: item.issue.number,
-        repository,
-      }),
+      command: commandWithRepo({ command: "watchdog", repository }),
       heartbeat,
       priority: 10,
       reason: heartbeat.reason,
@@ -194,6 +190,12 @@ function commandWithIssue({ command, extraArgs = [], issueNumber, repository }) 
     ...extraArgs,
     "--yes",
   ]
+    .filter(Boolean)
+    .join(" ")
+}
+
+function commandWithRepo({ command, repository }) {
+  return [`pnpm agent:queue:${command}`, repository ? `-- --repo ${repository}` : null]
     .filter(Boolean)
     .join(" ")
 }

--- a/scripts/tests/agent-runner-dispatch.test.mjs
+++ b/scripts/tests/agent-runner-dispatch.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { dispatchCommandArgs, selectDispatchRecommendation } from "../lib/agent-runner-dispatch.mjs"
+import { recommendQueueAction } from "../lib/agent-runner-tick.mjs"
+import { workItem } from "./agent-fixtures.mjs"
+
+describe("agent runner dispatch helpers", () => {
+  it("selects the highest-priority dispatchable recommendation", () => {
+    const recommendations = [
+      recommendQueueAction(
+        workItem({
+          fields: {
+            "Agent State": "Running",
+          },
+          number: 581,
+        }),
+        { maxAgeDays: 1, repository: "voyantjs/other" },
+      ),
+      recommendQueueAction(workItem({ number: 579 }), {
+        maxAgeDays: 1,
+        repository: "voyantjs/other",
+      }),
+      recommendQueueAction(
+        workItem({
+          fields: {
+            "Agent State": "Human Review",
+            Evidence: "docs/agent-evidence/active/580-test.md",
+          },
+          number: 580,
+        }),
+        { maxAgeDays: 1, repository: "voyantjs/other" },
+      ),
+    ]
+
+    assert.equal(selectDispatchRecommendation(recommendations).recommendation.action, "start")
+    assert.equal(
+      selectDispatchRecommendation(recommendations, { issueNumber: 580 }).recommendation.action,
+      "publish-evidence",
+    )
+  })
+
+  it("builds pnpm command args with repository scope", () => {
+    const recommendation = recommendQueueAction(workItem(), {
+      maxAgeDays: 1,
+      repository: "voyantjs/other",
+    })
+
+    assert.deepEqual(dispatchCommandArgs(recommendation, { repository: "voyantjs/other" }), [
+      "agent:queue:start",
+      "--",
+      "--issue",
+      "579",
+      "--repo",
+      "voyantjs/other",
+      "--yes",
+    ])
+  })
+
+  it("does not dispatch implementation or wait actions", () => {
+    const running = recommendQueueAction(
+      workItem({
+        fields: {
+          "Agent State": "Running",
+        },
+      }),
+      { maxAgeDays: 1, repository: "voyantjs/other" },
+    )
+
+    assert.deepEqual(selectDispatchRecommendation([running]), {
+      recommendation: null,
+      reason: "no dispatchable recommendation matched",
+    })
+  })
+
+  it("rejects invalid issue filters before selecting a recommendation", () => {
+    const recommendations = [
+      recommendQueueAction(workItem(), {
+        maxAgeDays: 1,
+        repository: "voyantjs/other",
+      }),
+    ]
+
+    assert.throws(
+      () => selectDispatchRecommendation(recommendations, { issueNumber: "abc" }),
+      /invalid issue number: abc/,
+    )
+    assert.throws(
+      () => selectDispatchRecommendation(recommendations, { issueNumber: "0" }),
+      /invalid issue number: 0/,
+    )
+  })
+})

--- a/scripts/tests/agent-runner-tick.test.mjs
+++ b/scripts/tests/agent-runner-tick.test.mjs
@@ -31,6 +31,13 @@ describe("agent runner tick helpers", () => {
       }).map((item) => item.action),
       ["inspect-stale", "start", "publish-evidence"],
     )
+    assert.equal(
+      recommendQueueActions([staleRunning], {
+        maxAgeDays: 1,
+        repository: "voyantjs/other",
+      })[0].command,
+      "pnpm agent:queue:watchdog -- --repo voyantjs/other",
+    )
   })
 
   it("maps queue tick states to the next safe runner command", () => {


### PR DESCRIPTION
## Summary

- add `agent:queue:dispatch` to execute one allow-listed tick recommendation
- keep dispatch dry-run by default and support `--issue` / `--action` filters
- refuse implementation/wait/blocked recommendations so `run-command` remains explicit
- preserve repository scope when dispatching and fix stale watchdog recommendations to avoid unsupported `--issue`/`--yes` flags

## Validation

- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm verify:architecture`
- `pnpm exec secretlint docs/agents/issue-tracker.md package.json scripts/agent-runner-dispatch.mjs scripts/lib/agent-runner-dispatch.mjs scripts/lib/agent-runner-tick.mjs scripts/tests/agent-runner-dispatch.test.mjs scripts/tests/agent-runner-tick.test.mjs`
- `pnpm exec biome check scripts/agent-runner-dispatch.mjs scripts/lib/agent-runner-dispatch.mjs scripts/lib/agent-runner-tick.mjs scripts/tests/agent-runner-dispatch.test.mjs scripts/tests/agent-runner-tick.test.mjs`
- `pnpm agent:queue:dispatch -- --help`
- `node --check scripts/agent-runner-dispatch.mjs && node --check scripts/lib/agent-runner-dispatch.mjs && node --check scripts/lib/agent-runner-tick.mjs`