### PR TITLE
Add bounded agent queue loop

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -175,6 +175,17 @@ recommendation, and runs one lifecycle command. It is dry-run by default. Pass
 `run-command`, `inspect-stale`, blocked work, and wait states so implementation
 execution remains explicit.
 
+Use loop for a bounded supervisor pass:
+
+```bash
+pnpm agent:queue:loop -- --iterations 3 --yes
+```
+
+Loop mode repeatedly re-reads the Project, dispatches one allow-listed
+recommendation, then sleeps before the next iteration. It is dry-run by default
+and capped at 100 iterations. It uses the same dispatch allow-list, so it cannot
+run implementation commands or override blocked/wait states.
+
 After a workspace is prepared, claim the item before implementation work starts:
 
 ```bash

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -173,7 +173,9 @@ recommendation, and runs one lifecycle command. It is dry-run by default. Pass
 `--issue <number>` or `--action <name>` to narrow selection. Dispatch can run
 `start`, `publish-evidence`, `open-pr`, `sync-pr`, and `cleanup`; it refuses
 `run-command`, `inspect-stale`, blocked work, and wait states so implementation
-execution remains explicit.
+execution remains explicit. Successful dispatch attempts append local JSONL
+audit events to `.agent-runs/events.jsonl` by default; pass `--event-log <path>`
+when a supervisor needs a different local ledger path.
 
 Use loop for a bounded supervisor pass:
 
@@ -184,7 +186,9 @@ pnpm agent:queue:loop -- --iterations 3 --yes
 Loop mode repeatedly re-reads the Project, dispatches one allow-listed
 recommendation, then sleeps before the next iteration. It is dry-run by default
 and capped at 100 iterations. It uses the same dispatch allow-list, so it cannot
-run implementation commands or override blocked/wait states.
+run implementation commands or override blocked/wait states. Each iteration is
+recorded in the local event log, alongside the nested dispatch command's own
+events, so unattended queue passes have a minimal timeline.
 
 After a workspace is prepared, claim the item before implementation work starts:
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "agent:queue:status": "node scripts/agent-runner-status.mjs",
     "agent:queue:tick": "node scripts/agent-runner-tick.mjs",
     "agent:queue:dispatch": "node scripts/agent-runner-dispatch.mjs",
+    "agent:queue:loop": "node scripts/agent-runner-loop.mjs",
     "agent:queue:prepare": "node scripts/agent-runner-prepare.mjs",
     "agent:queue:start": "node scripts/agent-runner-start.mjs",
     "agent:queue:run-command": "node scripts/agent-runner-run-command.mjs",

--- a/scripts/agent-runner-dispatch.mjs
+++ b/scripts/agent-runner-dispatch.mjs
@@ -14,6 +14,11 @@ import {
   selectDispatchRecommendation,
 } from "./lib/agent-runner-dispatch.mjs"
 import {
+  appendAgentRunnerEvent,
+  recommendationEventDetails,
+  resolveEventLogPath,
+} from "./lib/agent-runner-events.mjs"
+import {
   maybePrintHelp,
   mutationOptions,
   projectOptions,
@@ -33,6 +38,7 @@ maybePrintHelp(args, {
       `Only dispatch this action. Allowed: ${Array.from(dispatchableActions).join(", ")}.`,
     ],
     ["--max-age-days <number>", "Heartbeat staleness threshold. Defaults to 1."],
+    ["--event-log <path>", "JSONL audit log path. Defaults to .agent-runs/events.jsonl."],
     ...repositoryOptions,
     ...mutationOptions,
     ...projectOptions,
@@ -71,20 +77,40 @@ if (!recommendation) {
 }
 
 const commandArgs = dispatchCommandArgs(recommendation, { repository })
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
 
 if (!args.yes) {
-  printDispatchPlan({ commandArgs, recommendation, repository })
+  printDispatchPlan({ commandArgs, eventLogPath, recommendation, repository })
   fail("dispatch mode runs one queue mutation; rerun with --yes")
 }
 
+appendAgentRunnerEvent({
+  eventLogPath,
+  event: {
+    type: "dispatch.started",
+    command: ["pnpm", ...commandArgs],
+    repository,
+    recommendation: recommendationEventDetails(recommendation),
+  },
+})
 const status = runDispatchCommand(commandArgs)
+appendAgentRunnerEvent({
+  eventLogPath,
+  event: {
+    type: "dispatch.completed",
+    repository,
+    status: status ?? 1,
+    recommendation: recommendationEventDetails(recommendation),
+  },
+})
 process.exitCode = status ?? 1
 
-function printDispatchPlan({ commandArgs, recommendation, repository }) {
+function printDispatchPlan({ commandArgs, eventLogPath, recommendation, repository }) {
   console.log("agent-runner dispatch would run:")
   console.log(`issue: #${recommendation.issue.number} ${recommendation.issue.title}`)
   console.log(`repository: ${repository}`)
   console.log(`action: ${recommendation.action}`)
   console.log(`reason: ${recommendation.reason}`)
   console.log(`command: pnpm ${commandArgs.join(" ")}`)
+  console.log(`event log: ${eventLogPath}`)
 }

--- a/scripts/agent-runner-loop.mjs
+++ b/scripts/agent-runner-loop.mjs
@@ -14,6 +14,11 @@ import {
   selectDispatchRecommendation,
 } from "./lib/agent-runner-dispatch.mjs"
 import {
+  appendAgentRunnerEvent,
+  recommendationEventDetails,
+  resolveEventLogPath,
+} from "./lib/agent-runner-events.mjs"
+import {
   maybePrintHelp,
   mutationOptions,
   projectOptions,
@@ -36,6 +41,7 @@ maybePrintHelp(args, {
       `Only dispatch this action. Allowed: ${Array.from(dispatchableActions).join(", ")}.`,
     ],
     ["--max-age-days <number>", "Heartbeat staleness threshold. Defaults to 1."],
+    ["--event-log <path>", "JSONL audit log path. Defaults to .agent-runs/events.jsonl."],
     ...repositoryOptions,
     ...mutationOptions,
     ...projectOptions,
@@ -45,6 +51,7 @@ maybePrintHelp(args, {
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
 const maxAgeDays = Number(args.maxAgeDays ?? 1)
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
 
 if (!Number.isInteger(maxAgeDays) || maxAgeDays < 0) {
   fail(`invalid max age days: ${String(args.maxAgeDays)}`)
@@ -68,7 +75,7 @@ for (let iteration = 1; iteration <= loopOptions.iterations; iteration += 1) {
   const recommendation = selectLoopRecommendation()
   if (!recommendation) break
 
-  const commandArgs = dispatchCommandArgs(recommendation, { repository })
+  const commandArgs = dispatchCommandArgs(recommendation, { eventLog: args.eventLog, repository })
 
   if (!args.yes) {
     printLoopPlan({ commandArgs, iteration, recommendation })
@@ -77,7 +84,29 @@ for (let iteration = 1; iteration <= loopOptions.iterations; iteration += 1) {
 
   console.log(`agent-runner loop: dispatch ${iteration}/${loopOptions.iterations}`)
   console.log(`command: pnpm ${commandArgs.join(" ")}`)
+  appendAgentRunnerEvent({
+    eventLogPath,
+    event: {
+      type: "loop.iteration.started",
+      command: ["pnpm", ...commandArgs],
+      iteration,
+      iterations: loopOptions.iterations,
+      repository,
+      recommendation: recommendationEventDetails(recommendation),
+    },
+  })
   const status = runDispatchCommand(commandArgs) ?? 1
+  appendAgentRunnerEvent({
+    eventLogPath,
+    event: {
+      type: "loop.iteration.completed",
+      iteration,
+      iterations: loopOptions.iterations,
+      repository,
+      status,
+      recommendation: recommendationEventDetails(recommendation),
+    },
+  })
   if (!shouldContinueLoop({ iteration, iterations: loopOptions.iterations, status })) {
     process.exitCode = status
     break
@@ -119,6 +148,7 @@ function printLoopPlan({ commandArgs, iteration, recommendation }) {
   console.log(`action: ${recommendation.action}`)
   console.log(`reason: ${recommendation.reason}`)
   console.log(`command: pnpm ${commandArgs.join(" ")}`)
+  console.log(`event log: ${eventLogPath}`)
 }
 
 function sleep(ms) {

--- a/scripts/agent-runner-loop.mjs
+++ b/scripts/agent-runner-loop.mjs
@@ -1,0 +1,128 @@
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  filterItemsByRepository,
+  loadAllEvaluatedProject,
+  parseArgs,
+  projectScanConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+import {
+  dispatchableActions,
+  dispatchCommandArgs,
+  runDispatchCommand,
+  selectDispatchRecommendation,
+} from "./lib/agent-runner-dispatch.mjs"
+import {
+  maybePrintHelp,
+  mutationOptions,
+  projectOptions,
+  repositoryOptions,
+} from "./lib/agent-runner-help.mjs"
+import { normalizeLoopOptions, shouldContinueLoop } from "./lib/agent-runner-loop.mjs"
+import { recommendQueueActions } from "./lib/agent-runner-tick.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:loop",
+  summary: "Run a bounded loop of allow-listed queue dispatches.",
+  usage: "pnpm agent:queue:loop -- --iterations 3 --yes",
+  options: [
+    ["--iterations <number>", "Maximum dispatch iterations, 1..100. Defaults to 1."],
+    ["--sleep-seconds <number>", "Delay between successful dispatches, 0..3600. Defaults to 60."],
+    ["--issue <number>", "Only dispatch recommendations for this issue number."],
+    [
+      "--action <name>",
+      `Only dispatch this action. Allowed: ${Array.from(dispatchableActions).join(", ")}.`,
+    ],
+    ["--max-age-days <number>", "Heartbeat staleness threshold. Defaults to 1."],
+    ...repositoryOptions,
+    ...mutationOptions,
+    ...projectOptions,
+  ],
+})
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const maxAgeDays = Number(args.maxAgeDays ?? 1)
+
+if (!Number.isInteger(maxAgeDays) || maxAgeDays < 0) {
+  fail(`invalid max age days: ${String(args.maxAgeDays)}`)
+}
+
+if (args.action && !dispatchableActions.has(args.action)) {
+  fail(`action ${args.action} is not dispatchable`)
+}
+
+let loopOptions
+try {
+  loopOptions = normalizeLoopOptions({
+    iterations: args.iterations,
+    sleepSeconds: args.sleepSeconds,
+  })
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error))
+}
+
+for (let iteration = 1; iteration <= loopOptions.iterations; iteration += 1) {
+  const recommendation = selectLoopRecommendation()
+  if (!recommendation) break
+
+  const commandArgs = dispatchCommandArgs(recommendation, { repository })
+
+  if (!args.yes) {
+    printLoopPlan({ commandArgs, iteration, recommendation })
+    fail("loop mode runs queue mutations; rerun with --yes")
+  }
+
+  console.log(`agent-runner loop: dispatch ${iteration}/${loopOptions.iterations}`)
+  console.log(`command: pnpm ${commandArgs.join(" ")}`)
+  const status = runDispatchCommand(commandArgs) ?? 1
+  if (!shouldContinueLoop({ iteration, iterations: loopOptions.iterations, status })) {
+    process.exitCode = status
+    break
+  }
+
+  if (loopOptions.sleepMs > 0) {
+    await sleep(loopOptions.sleepMs)
+  }
+}
+
+function selectLoopRecommendation() {
+  const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
+  const items = filterItemsByRepository(project.items, repository)
+  const recommendations = recommendQueueActions(items, { maxAgeDays, repository })
+  let selection
+
+  try {
+    selection = selectDispatchRecommendation(recommendations, {
+      action: args.action,
+      issueNumber: args.issue,
+    })
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error))
+  }
+
+  if (!selection.recommendation) {
+    console.log(`agent-runner loop: ${selection.reason}`)
+    return null
+  }
+
+  return selection.recommendation
+}
+
+function printLoopPlan({ commandArgs, iteration, recommendation }) {
+  console.log("agent-runner loop would run:")
+  console.log(`iteration: ${iteration}/${loopOptions.iterations}`)
+  console.log(`issue: #${recommendation.issue.number} ${recommendation.issue.title}`)
+  console.log(`repository: ${repository}`)
+  console.log(`action: ${recommendation.action}`)
+  console.log(`reason: ${recommendation.reason}`)
+  console.log(`command: pnpm ${commandArgs.join(" ")}`)
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}

--- a/scripts/lib/agent-runner-dispatch.mjs
+++ b/scripts/lib/agent-runner-dispatch.mjs
@@ -35,12 +35,12 @@ export function selectDispatchRecommendation(recommendations, { action, issueNum
   }
 }
 
-export function dispatchCommandArgs(recommendation, { repository }) {
+export function dispatchCommandArgs(recommendation, { eventLog, repository }) {
   if (!dispatchableActions.has(recommendation.action)) {
     throw new Error(`action ${recommendation.action} is not dispatchable`)
   }
 
-  return [
+  const commandArgs = [
     `agent:queue:${recommendation.action}`,
     "--",
     "--issue",
@@ -49,6 +49,12 @@ export function dispatchCommandArgs(recommendation, { repository }) {
     repository,
     "--yes",
   ]
+
+  if (eventLog) {
+    commandArgs.push("--event-log", eventLog)
+  }
+
+  return commandArgs
 }
 
 export function runDispatchCommand(commandArgs) {

--- a/scripts/lib/agent-runner-events.mjs
+++ b/scripts/lib/agent-runner-events.mjs
@@ -1,0 +1,40 @@
+import { appendFileSync, mkdirSync } from "node:fs"
+import path from "node:path"
+
+export const defaultEventLogPath = ".agent-runs/events.jsonl"
+
+export function resolveEventLogPath(value, { repoRoot = process.cwd() } = {}) {
+  const eventLogPath = value ?? defaultEventLogPath
+  return path.isAbsolute(eventLogPath) ? eventLogPath : path.join(repoRoot, eventLogPath)
+}
+
+export function appendAgentRunnerEvent({ event, eventLogPath, now = new Date() }) {
+  const entry = normalizeEvent(event, { now })
+  mkdirSync(path.dirname(eventLogPath), { recursive: true })
+  appendFileSync(eventLogPath, `${JSON.stringify(entry)}\n`, "utf8")
+  return entry
+}
+
+export function recommendationEventDetails(recommendation) {
+  return {
+    action: recommendation.action,
+    reason: recommendation.reason,
+    issue: {
+      number: recommendation.issue.number,
+      title: recommendation.issue.title,
+      url: recommendation.issue.url,
+      repository: recommendation.issue.repository,
+    },
+  }
+}
+
+function normalizeEvent(event, { now }) {
+  if (!event?.type) {
+    throw new Error("agent runner event requires a type")
+  }
+
+  return {
+    timestamp: now.toISOString(),
+    ...event,
+  }
+}

--- a/scripts/lib/agent-runner-loop.mjs
+++ b/scripts/lib/agent-runner-loop.mjs
@@ -1,0 +1,23 @@
+export function normalizeLoopOptions({ iterations = "1", sleepSeconds = "60" } = {}) {
+  return {
+    iterations: positiveIntegerOption("iterations", iterations, { max: 100 }),
+    sleepMs:
+      positiveIntegerOption("sleep seconds", sleepSeconds, { allowZero: true, max: 3600 }) * 1000,
+  }
+}
+
+export function shouldContinueLoop({ iteration, iterations, status }) {
+  return status === 0 && iteration < iterations
+}
+
+function positiveIntegerOption(name, value, { allowZero = false, max } = {}) {
+  const normalized = Number(value)
+  const minimum = allowZero ? 0 : 1
+
+  if (!Number.isInteger(normalized) || normalized < minimum || (max && normalized > max)) {
+    const range = max ? `${minimum}..${max}` : `>= ${minimum}`
+    throw new Error(`invalid ${name}: ${String(value)}; expected ${range}`)
+  }
+
+  return normalized
+}

--- a/scripts/tests/agent-runner-dispatch.test.mjs
+++ b/scripts/tests/agent-runner-dispatch.test.mjs
@@ -57,6 +57,31 @@ describe("agent runner dispatch helpers", () => {
     ])
   })
 
+  it("passes custom event logs to nested dispatch commands", () => {
+    const recommendation = recommendQueueAction(workItem(), {
+      maxAgeDays: 1,
+      repository: "voyantjs/other",
+    })
+
+    assert.deepEqual(
+      dispatchCommandArgs(recommendation, {
+        eventLog: ".agent-runs/supervisor.jsonl",
+        repository: "voyantjs/other",
+      }),
+      [
+        "agent:queue:start",
+        "--",
+        "--issue",
+        "579",
+        "--repo",
+        "voyantjs/other",
+        "--yes",
+        "--event-log",
+        ".agent-runs/supervisor.jsonl",
+      ],
+    )
+  })
+
   it("does not dispatch implementation or wait actions", () => {
     const running = recommendQueueAction(
       workItem({

--- a/scripts/tests/agent-runner-events.test.mjs
+++ b/scripts/tests/agent-runner-events.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict"
+import { mkdtempSync, readFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { describe, it } from "node:test"
+
+import {
+  appendAgentRunnerEvent,
+  defaultEventLogPath,
+  recommendationEventDetails,
+  resolveEventLogPath,
+} from "../lib/agent-runner-events.mjs"
+import { recommendQueueAction } from "../lib/agent-runner-tick.mjs"
+import { workItem } from "./agent-fixtures.mjs"
+
+describe("agent runner event helpers", () => {
+  it("resolves the default event log under the repository root", () => {
+    assert.equal(
+      resolveEventLogPath(undefined, { repoRoot: "/repo" }),
+      path.join("/repo", defaultEventLogPath),
+    )
+    assert.equal(
+      resolveEventLogPath("/tmp/events.jsonl", { repoRoot: "/repo" }),
+      "/tmp/events.jsonl",
+    )
+  })
+
+  it("appends JSONL events with timestamps", () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), "agent-runner-events-"))
+    const eventLogPath = path.join(tempDir, "nested", "events.jsonl")
+
+    const entry = appendAgentRunnerEvent({
+      eventLogPath,
+      event: {
+        type: "dispatch.started",
+        repository: "voyantjs/voyant",
+      },
+      now: new Date("2026-05-10T12:00:00.000Z"),
+    })
+
+    assert.deepEqual(entry, {
+      timestamp: "2026-05-10T12:00:00.000Z",
+      type: "dispatch.started",
+      repository: "voyantjs/voyant",
+    })
+    assert.equal(`${JSON.stringify(entry)}\n`, readFileSync(eventLogPath, "utf8"))
+  })
+
+  it("extracts stable recommendation details for logs", () => {
+    const recommendation = recommendQueueAction(workItem({ number: 579 }), {
+      maxAgeDays: 1,
+      repository: "voyantjs/voyant",
+    })
+
+    assert.deepEqual(recommendationEventDetails(recommendation), {
+      action: "start",
+      reason: "maintainer-approved item is ready to claim",
+      issue: {
+        number: 579,
+        title: "Test agent project intake workflow",
+        url: "https://github.com/voyantjs/voyant/issues/579",
+        repository: "voyantjs/voyant",
+      },
+    })
+  })
+
+  it("rejects events without a type", () => {
+    assert.throws(
+      () =>
+        appendAgentRunnerEvent({
+          eventLogPath: path.join(tmpdir(), "unused-events.jsonl"),
+          event: {},
+        }),
+      /agent runner event requires a type/,
+    )
+  })
+})

--- a/scripts/tests/agent-runner-loop.test.mjs
+++ b/scripts/tests/agent-runner-loop.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { normalizeLoopOptions, shouldContinueLoop } from "../lib/agent-runner-loop.mjs"
+
+describe("agent runner loop helpers", () => {
+  it("normalizes bounded loop options", () => {
+    assert.deepEqual(normalizeLoopOptions({ iterations: "3", sleepSeconds: "0" }), {
+      iterations: 3,
+      sleepMs: 0,
+    })
+    assert.deepEqual(normalizeLoopOptions(), {
+      iterations: 1,
+      sleepMs: 60_000,
+    })
+  })
+
+  it("rejects unbounded or invalid loop options", () => {
+    assert.throws(
+      () => normalizeLoopOptions({ iterations: "0" }),
+      /invalid iterations: 0; expected 1..100/,
+    )
+    assert.throws(
+      () => normalizeLoopOptions({ iterations: "101" }),
+      /invalid iterations: 101; expected 1..100/,
+    )
+    assert.throws(
+      () => normalizeLoopOptions({ sleepSeconds: "-1" }),
+      /invalid sleep seconds: -1; expected 0..3600/,
+    )
+  })
+
+  it("continues only after successful non-final iterations", () => {
+    assert.equal(shouldContinueLoop({ iteration: 1, iterations: 3, status: 0 }), true)
+    assert.equal(shouldContinueLoop({ iteration: 3, iterations: 3, status: 0 }), false)
+    assert.equal(shouldContinueLoop({ iteration: 1, iterations: 3, status: 1 }), false)
+  })
+})


### PR DESCRIPTION
## Summary

- add `agent:queue:loop` for bounded repeated safe dispatches
- cap loop iterations and sleep interval to keep supervisor runs explicit
- keep dry-run default and reuse the dispatch allow-list so implementation execution remains manual
- append local JSONL audit events for dispatch and loop attempts
- document the loop path and event ledger for future always-on supervisors

## Validation

- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm verify:architecture`
- `pnpm exec secretlint docs/agents/issue-tracker.md scripts/agent-runner-dispatch.mjs scripts/agent-runner-loop.mjs scripts/lib/agent-runner-dispatch.mjs scripts/lib/agent-runner-events.mjs scripts/tests/agent-runner-dispatch.test.mjs scripts/tests/agent-runner-events.test.mjs`
- `pnpm exec biome check scripts/agent-runner-dispatch.mjs scripts/agent-runner-loop.mjs scripts/lib/agent-runner-dispatch.mjs scripts/lib/agent-runner-events.mjs scripts/tests/agent-runner-dispatch.test.mjs scripts/tests/agent-runner-events.test.mjs`
- `pnpm agent:queue:dispatch -- --help && pnpm agent:queue:loop -- --help`
- `node --check scripts/agent-runner-dispatch.mjs && node --check scripts/agent-runner-loop.mjs && node --check scripts/lib/agent-runner-dispatch.mjs && node --check scripts/lib/agent-runner-events.mjs && node --check scripts/tests/agent-runner-dispatch.test.mjs && node --check scripts/tests/agent-runner-events.test.mjs && git diff --check`