### PR TITLE
Add agent control plane worker

### DIFF
--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -1,0 +1,28 @@
+# Voyant Agent Control Plane
+
+Cloudflare-ready Hono Worker for supervised agent queue orchestration.
+
+This app intentionally starts with a dry-run contract. It can answer health,
+capability, and dispatch-planning requests, but it does not mutate GitHub,
+create workspaces, run provider commands, or spend agent budget. Local runner
+scripts remain the execution boundary until authentication, persistence, and
+worker-to-runner transport are designed.
+
+## Local Commands
+
+```bash
+pnpm -C apps/agent-control-plane test
+pnpm -C apps/agent-control-plane check-types
+pnpm -C apps/agent-control-plane dev
+```
+
+## Endpoints
+
+- `GET /health`
+- `GET /api/capabilities`
+- `POST /api/dispatch-plans`
+
+`POST /api/dispatch-plans` accepts ordered queue recommendations and returns the
+first dispatchable plan that matches the optional filters. It mirrors the local
+runner allow-list: `start`, `publish-evidence`, `open-pr`, `sync-pr`, and
+`cleanup`.

--- a/apps/agent-control-plane/package.json
+++ b/apps/agent-control-plane/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@voyantjs/agent-control-plane",
+  "version": "0.0.0",
+  "description": "Cloudflare-ready control plane surface for supervised Voyant agent queue work.",
+  "license": "Apache-2.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/worker.ts",
+  "scripts": {
+    "check-types": "tsc --noEmit",
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev",
+    "lint": "biome check .",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "hono": "^4.12.10",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260426.1",
+    "@voyantjs/voyant-typescript-config": "workspace:*",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2",
+    "wrangler": "4.86.0"
+  }
+}

--- a/apps/agent-control-plane/package.json
+++ b/apps/agent-control-plane/package.json
@@ -12,7 +12,8 @@
     "dev": "wrangler dev",
     "lint": "biome check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "hono": "^4.12.10",

--- a/apps/agent-control-plane/src/app.ts
+++ b/apps/agent-control-plane/src/app.ts
@@ -1,0 +1,41 @@
+import { Hono } from "hono"
+
+import {
+  buildCapabilities,
+  dispatchPlanRequestSchema,
+  selectDispatchPlan,
+} from "./control-plane.js"
+
+export function createApp(): Hono {
+  const app = new Hono()
+
+  app.onError((error, c) => {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`[agent-control-plane] ${c.req.method} ${c.req.path}: ${message}`)
+    return c.json({ error: "internal_error" }, 500)
+  })
+
+  app.get("/", (c) => c.json(buildCapabilities()))
+  app.get("/health", (c) => c.json({ ok: true, service: "agent-control-plane" }))
+  app.get("/api/capabilities", (c) => c.json(buildCapabilities()))
+
+  app.post("/api/dispatch-plans", async (c) => {
+    const parsed = dispatchPlanRequestSchema.safeParse(await c.req.json().catch(() => null))
+    if (!parsed.success) {
+      return c.json(
+        {
+          error: "invalid_dispatch_plan_request",
+          issues: parsed.error.issues.map((issue) => ({
+            path: issue.path.join("."),
+            message: issue.message,
+          })),
+        },
+        400,
+      )
+    }
+
+    return c.json(selectDispatchPlan(parsed.data))
+  })
+
+  return app
+}

--- a/apps/agent-control-plane/src/control-plane.test.ts
+++ b/apps/agent-control-plane/src/control-plane.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest"
+
+import { createApp } from "./app.js"
+import { buildCapabilities, selectDispatchPlan } from "./control-plane.js"
+
+const recommendations = [
+  {
+    action: "run-command",
+    reason: "implementation execution remains explicit",
+    issue: {
+      number: 581,
+      title: "Run implementation command",
+      url: "https://github.com/voyantjs/voyant/issues/581",
+      repository: "voyantjs/voyant",
+    },
+  },
+  {
+    action: "start",
+    reason: "maintainer-approved item is ready to claim",
+    issue: {
+      number: 579,
+      title: "Test agent project intake workflow",
+      url: "https://github.com/voyantjs/voyant/issues/579",
+      repository: "voyantjs/voyant",
+    },
+  },
+]
+
+describe("agent control plane", () => {
+  it("reports dry-run capabilities", () => {
+    expect(buildCapabilities()).toMatchObject({
+      service: "agent-control-plane",
+      dryRunOnly: true,
+      dispatchableActions: ["cleanup", "open-pr", "publish-evidence", "start", "sync-pr"],
+    })
+  })
+
+  it("selects the first matching dispatchable plan", () => {
+    expect(
+      selectDispatchPlan({
+        recommendations,
+        repository: "voyantjs/voyant",
+      }),
+    ).toEqual({
+      reason: "matched",
+      plan: {
+        action: "start",
+        command: [
+          "pnpm",
+          "agent:queue:start",
+          "--",
+          "--issue",
+          "579",
+          "--repo",
+          "voyantjs/voyant",
+          "--yes",
+        ],
+        issue: recommendations[1]?.issue,
+        reason: "maintainer-approved item is ready to claim",
+        repository: "voyantjs/voyant",
+        requiresMutation: true,
+      },
+    })
+  })
+
+  it("applies issue, action, and repository filters", () => {
+    expect(
+      selectDispatchPlan({
+        filters: { action: "start", issueNumber: 579 },
+        recommendations,
+        repository: "VoyantJS/Voyant",
+      }).plan?.issue.number,
+    ).toBe(579)
+
+    expect(
+      selectDispatchPlan({
+        filters: { action: "cleanup" },
+        recommendations,
+        repository: "voyantjs/voyant",
+      }),
+    ).toEqual({
+      plan: null,
+      reason: "no dispatchable recommendation matched",
+    })
+
+    expect(
+      selectDispatchPlan({
+        filters: { action: "run-command" },
+        recommendations,
+        repository: "voyantjs/voyant",
+      }),
+    ).toEqual({
+      plan: null,
+      reason: "action run-command is not dispatchable",
+    })
+  })
+
+  it("serves health and dispatch planning through Hono", async () => {
+    const app = createApp()
+
+    const health = await app.request("/health")
+    expect(health.status).toBe(200)
+    await expect(health.json()).resolves.toEqual({
+      ok: true,
+      service: "agent-control-plane",
+    })
+
+    const plan = await app.request("/api/dispatch-plans", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        recommendations,
+        repository: "voyantjs/voyant",
+      }),
+    })
+
+    expect(plan.status).toBe(200)
+    await expect(plan.json()).resolves.toMatchObject({
+      reason: "matched",
+      plan: {
+        action: "start",
+        issue: { number: 579 },
+      },
+    })
+  })
+
+  it("returns validation errors for malformed planning requests", async () => {
+    const app = createApp()
+    const response = await app.request("/api/dispatch-plans", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ recommendations: [] }),
+    })
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      error: "invalid_dispatch_plan_request",
+    })
+  })
+})

--- a/apps/agent-control-plane/src/control-plane.ts
+++ b/apps/agent-control-plane/src/control-plane.ts
@@ -1,0 +1,133 @@
+import { z } from "zod"
+
+export const dispatchableActions = [
+  "cleanup",
+  "open-pr",
+  "publish-evidence",
+  "start",
+  "sync-pr",
+] as const
+
+const dispatchableActionSet = new Set<string>(dispatchableActions)
+
+export const dispatchPlanRequestSchema = z.object({
+  filters: z
+    .object({
+      action: z.string().optional(),
+      issueNumber: z.number().int().positive().optional(),
+    })
+    .optional(),
+  recommendations: z
+    .array(
+      z.object({
+        action: z.string(),
+        reason: z.string().min(1),
+        issue: z.object({
+          number: z.number().int().positive(),
+          title: z.string().min(1),
+          url: z.string().url(),
+          repository: z.string().min(1),
+        }),
+      }),
+    )
+    .min(1),
+  repository: z.string().min(1),
+})
+
+export type DispatchPlanRequest = z.infer<typeof dispatchPlanRequestSchema>
+
+export interface DispatchPlan {
+  action: (typeof dispatchableActions)[number]
+  command: string[]
+  issue: DispatchPlanRequest["recommendations"][number]["issue"]
+  reason: string
+  repository: string
+  requiresMutation: true
+}
+
+export interface DispatchPlanResult {
+  plan: DispatchPlan | null
+  reason: string
+}
+
+export function buildCapabilities() {
+  return {
+    service: "agent-control-plane",
+    version: 1,
+    dispatchableActions,
+    dryRunOnly: true,
+    limits: {
+      loopIterations: {
+        min: 1,
+        max: 100,
+      },
+      loopSleepSeconds: {
+        min: 0,
+        max: 3600,
+      },
+    },
+  }
+}
+
+export function selectDispatchPlan(request: DispatchPlanRequest): DispatchPlanResult {
+  const actionFilter = request.filters?.action
+  if (actionFilter && !dispatchableActionSet.has(actionFilter)) {
+    return {
+      plan: null,
+      reason: `action ${actionFilter} is not dispatchable`,
+    }
+  }
+
+  const recommendation = request.recommendations.find((candidate) => {
+    if (!isDispatchableAction(candidate.action)) return false
+    if (actionFilter && candidate.action !== actionFilter) return false
+    if (request.filters?.issueNumber && candidate.issue.number !== request.filters.issueNumber) {
+      return false
+    }
+    if (!repositoriesMatch(candidate.issue.repository, request.repository)) return false
+    return true
+  })
+
+  if (!recommendation) {
+    return {
+      plan: null,
+      reason: "no dispatchable recommendation matched",
+    }
+  }
+  const action = recommendation.action
+  if (!isDispatchableAction(action)) {
+    return {
+      plan: null,
+      reason: `action ${action} is not dispatchable`,
+    }
+  }
+
+  return {
+    plan: {
+      action,
+      command: [
+        "pnpm",
+        `agent:queue:${action}`,
+        "--",
+        "--issue",
+        String(recommendation.issue.number),
+        "--repo",
+        request.repository,
+        "--yes",
+      ],
+      issue: recommendation.issue,
+      reason: recommendation.reason,
+      repository: request.repository,
+      requiresMutation: true,
+    },
+    reason: "matched",
+  }
+}
+
+function isDispatchableAction(action: string): action is DispatchPlan["action"] {
+  return dispatchableActionSet.has(action)
+}
+
+function repositoriesMatch(left: string, right: string) {
+  return left.trim().toLowerCase() === right.trim().toLowerCase()
+}

--- a/apps/agent-control-plane/src/worker.ts
+++ b/apps/agent-control-plane/src/worker.ts
@@ -1,0 +1,9 @@
+import { createApp } from "./app.js"
+
+const app = createApp()
+
+export default {
+  async fetch(request: Request): Promise<Response> {
+    return await app.fetch(request)
+  },
+} satisfies ExportedHandler

--- a/apps/agent-control-plane/tsconfig.json
+++ b/apps/agent-control-plane/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@voyantjs/voyant-typescript-config/workers.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "moduleResolution": "Bundler",
+    "module": "ESNext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/apps/agent-control-plane/vitest.config.ts
+++ b/apps/agent-control-plane/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+    globals: false,
+  },
+})

--- a/apps/agent-control-plane/wrangler.jsonc
+++ b/apps/agent-control-plane/wrangler.jsonc
@@ -1,0 +1,13 @@
+{
+  // Reference Cloudflare Worker for the agent queue control plane.
+  // The first deployment exposes dry-run planning only; mutation and
+  // provider execution remain owned by the local runner scripts until the
+  // control-plane contract stabilizes.
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "voyant-agent-control-plane",
+  "main": "src/worker.ts",
+  "compatibility_date": "2025-01-01",
+  "observability": {
+    "enabled": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,31 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
 
+  apps/agent-control-plane:
+    dependencies:
+      hono:
+        specifier: ^4.12.10
+        version: 4.12.10
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260426.1
+        version: 4.20260426.1
+      '@voyantjs/voyant-typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
+      wrangler:
+        specifier: 4.86.0
+        version: 4.86.0(@cloudflare/workers-types@4.20260426.1)
+
   apps/catalog-demo-api:
     dependencies:
       '@hono/node-server':


### PR DESCRIPTION
## Summary

- add a private Cloudflare-ready Hono Worker for the agent queue control plane
- expose health, capabilities, and dry-run dispatch-plan endpoints
- validate dispatch-plan payloads with Zod and keep mutation execution outside the Worker
- add focused tests for allow-list selection, filters, endpoint wiring, and malformed payloads

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @voyantjs/agent-control-plane typecheck`
- `pnpm --filter @voyantjs/agent-control-plane test`
- `pnpm --filter @voyantjs/agent-control-plane lint`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm verify:architecture`
- `pnpm exec secretlint apps/agent-control-plane package.json pnpm-lock.yaml`
- `pnpm test:affected`