### PR TITLE
Require auth for agent control plane API

### DIFF
--- a/.agents/PLANS.md
+++ b/.agents/PLANS.md
@@ -36,6 +36,10 @@ Why this work exists.
 What exists now, with durable references to modules, interfaces, docs, and
 observed behavior.
 
+## Agent Brief
+
+The approved brief copied from the issue body.
+
 ## Desired Behavior
 
 The outcome in user-facing or maintainer-facing terms.

--- a/.agents/WORKFLOW.md
+++ b/.agents/WORKFLOW.md
@@ -12,9 +12,14 @@ Required gate:
 - label: `agent:ready`
 - Project field: `Agent State = Ready`
 - Project field: `Maintainer Approved = Yes`
+- issue body contains a non-empty `Agent Brief` section
 
 Triage agents may classify issues, draft briefs, and recommend next state. They
 must not set the final execution gate.
+
+The `Agent Brief` is the durable task contract. Maintainers may write it
+manually or with the `agent-brief` skill, but it must be present before the
+runner dispatches work.
 
 ## Branches And PRs
 
@@ -78,6 +83,20 @@ without an accepted reason.
   blanket lint disables unless the exception is local, justified, and owned.
 - Prefer deep modules with small interfaces and meaningful behavior behind them.
 - Name files by domain behavior, not implementation trivia.
+
+## Exceptions
+
+When a quality rule cannot be followed, keep the exception close to the work and
+make it reviewable:
+
+- Name the rule being bypassed.
+- Explain why the normal path is blocked.
+- Link the issue, PR, or follow-up that owns removal.
+- Keep the exception as narrow as possible.
+
+Undocumented exceptions should be treated as review findings. Security,
+migration, i18n, and public-package exceptions need maintainer approval before
+handoff.
 
 ## Verification
 

--- a/.agents/skills/agent-brief/SKILL.md
+++ b/.agents/skills/agent-brief/SKILL.md
@@ -20,7 +20,8 @@ the execution agent works from; the issue discussion is supporting context.
    interfaces and behavior over stale file paths.
 3. Draft the brief using the template below.
 4. Flag missing information instead of inventing certainty.
-5. Leave the item for maintainer approval. Do not mark it `Ready`.
+5. Put the final brief under the issue body's `Agent Brief` section.
+6. Leave the item for maintainer approval. Do not mark it `Ready`.
 
 ## Template
 

--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -58,6 +58,24 @@ body:
     validations:
       required: false
   - type: textarea
+    id: agent-brief
+    attributes:
+      label: Agent Brief
+      description: Maintainers or triage agents can fill this before marking the issue agent-ready.
+      placeholder: |
+        Category:
+        Summary:
+        Current behavior:
+        Desired behavior:
+        Key interfaces:
+        Acceptance criteria:
+        Verification lane:
+        Security:
+        Artifacts required:
+        Out of scope:
+    validations:
+      required: false
+  - type: textarea
     id: scope
     attributes:
       label: Scope boundaries

--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -8,6 +8,11 @@ create workspaces, run provider commands, or spend agent budget. Local runner
 scripts remain the execution boundary until authentication, persistence, and
 worker-to-runner transport are designed.
 
+`/health` is public. `/api/*` requires a bearer token from
+`AGENT_CONTROL_PLANE_TOKENS`, a comma-separated secret value configured in the
+deployment environment. If no token is configured, API routes fail closed with
+`control_plane_auth_not_configured`.
+
 ## Local Commands
 
 ```bash

--- a/apps/agent-control-plane/src/app.ts
+++ b/apps/agent-control-plane/src/app.ts
@@ -6,7 +6,11 @@ import {
   selectDispatchPlan,
 } from "./control-plane.js"
 
-export function createApp(): Hono {
+interface AppOptions {
+  authTokens?: string[]
+}
+
+export function createApp({ authTokens = [] }: AppOptions = {}): Hono {
   const app = new Hono()
 
   app.onError((error, c) => {
@@ -17,6 +21,20 @@ export function createApp(): Hono {
 
   app.get("/", (c) => c.json(buildCapabilities()))
   app.get("/health", (c) => c.json({ ok: true, service: "agent-control-plane" }))
+
+  app.use("/api/*", async (c, next) => {
+    if (authTokens.length === 0) {
+      return c.json({ error: "control_plane_auth_not_configured" }, 503)
+    }
+
+    const token = bearerToken(c.req.header("authorization"))
+    if (!token || !authTokens.includes(token)) {
+      return c.json({ error: "unauthorized" }, 401)
+    }
+
+    await next()
+  })
+
   app.get("/api/capabilities", (c) => c.json(buildCapabilities()))
 
   app.post("/api/dispatch-plans", async (c) => {
@@ -38,4 +56,9 @@ export function createApp(): Hono {
   })
 
   return app
+}
+
+function bearerToken(header: string | undefined) {
+  const match = header?.match(/^Bearer\s+(.+)$/i)
+  return match?.[1]?.trim()
 }

--- a/apps/agent-control-plane/src/app.ts
+++ b/apps/agent-control-plane/src/app.ts
@@ -19,7 +19,6 @@ export function createApp({ authTokens = [] }: AppOptions = {}): Hono {
     return c.json({ error: "internal_error" }, 500)
   })
 
-  app.get("/", (c) => c.json(buildCapabilities()))
   app.get("/health", (c) => c.json({ ok: true, service: "agent-control-plane" }))
 
   app.use("/api/*", async (c, next) => {

--- a/apps/agent-control-plane/src/control-plane.test.ts
+++ b/apps/agent-control-plane/src/control-plane.test.ts
@@ -126,6 +126,9 @@ describe("agent control plane", () => {
 
   it("requires configured bearer auth for API routes", async () => {
     const missingConfig = createApp()
+    const root = await missingConfig.request("/")
+    expect(root.status).toBe(404)
+
     const notConfigured = await missingConfig.request("/api/capabilities")
     expect(notConfigured.status).toBe(503)
     await expect(notConfigured.json()).resolves.toEqual({

--- a/apps/agent-control-plane/src/control-plane.test.ts
+++ b/apps/agent-control-plane/src/control-plane.test.ts
@@ -96,7 +96,7 @@ describe("agent control plane", () => {
   })
 
   it("serves health and dispatch planning through Hono", async () => {
-    const app = createApp()
+    const app = createApp({ authTokens: ["secret"] })
 
     const health = await app.request("/health")
     expect(health.status).toBe(200)
@@ -107,7 +107,7 @@ describe("agent control plane", () => {
 
     const plan = await app.request("/api/dispatch-plans", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: { authorization: "Bearer secret", "content-type": "application/json" },
       body: JSON.stringify({
         recommendations,
         repository: "voyantjs/voyant",
@@ -124,11 +124,33 @@ describe("agent control plane", () => {
     })
   })
 
+  it("requires configured bearer auth for API routes", async () => {
+    const missingConfig = createApp()
+    const notConfigured = await missingConfig.request("/api/capabilities")
+    expect(notConfigured.status).toBe(503)
+    await expect(notConfigured.json()).resolves.toEqual({
+      error: "control_plane_auth_not_configured",
+    })
+
+    const app = createApp({ authTokens: ["secret"] })
+    const unauthorized = await app.request("/api/capabilities")
+    expect(unauthorized.status).toBe(401)
+    await expect(unauthorized.json()).resolves.toEqual({ error: "unauthorized" })
+
+    const authorized = await app.request("/api/capabilities", {
+      headers: { authorization: "Bearer secret" },
+    })
+    expect(authorized.status).toBe(200)
+    await expect(authorized.json()).resolves.toMatchObject({
+      service: "agent-control-plane",
+    })
+  })
+
   it("returns validation errors for malformed planning requests", async () => {
-    const app = createApp()
+    const app = createApp({ authTokens: ["secret"] })
     const response = await app.request("/api/dispatch-plans", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: { authorization: "Bearer secret", "content-type": "application/json" },
       body: JSON.stringify({ recommendations: [] }),
     })
 

--- a/apps/agent-control-plane/src/worker.ts
+++ b/apps/agent-control-plane/src/worker.ts
@@ -1,9 +1,19 @@
 import { createApp } from "./app.js"
 
-const app = createApp()
+interface Env {
+  AGENT_CONTROL_PLANE_TOKENS?: string
+}
 
 export default {
-  async fetch(request: Request): Promise<Response> {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const app = createApp({ authTokens: parseTokens(env.AGENT_CONTROL_PLANE_TOKENS) })
     return await app.fetch(request)
   },
-} satisfies ExportedHandler
+} satisfies ExportedHandler<Env>
+
+function parseTokens(value: string | undefined) {
+  return (value ?? "")
+    .split(",")
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0)
+}

--- a/apps/agent-control-plane/wrangler.jsonc
+++ b/apps/agent-control-plane/wrangler.jsonc
@@ -7,6 +7,8 @@
   "name": "voyant-agent-control-plane",
   "main": "src/worker.ts",
   "compatibility_date": "2025-01-01",
+  // Configure AGENT_CONTROL_PLANE_TOKENS as a secret before exposing /api/*:
+  // pnpm -C apps/agent-control-plane wrangler secret put AGENT_CONTROL_PLANE_TOKENS
   "observability": {
     "enabled": true
   }

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -16,6 +16,7 @@ Voyant Engineering
   - label `agent:ready` is present
   - Project field `Agent State = Ready`
   - Project field `Maintainer Approved = Yes`
+  - the issue body contains a non-empty `Agent Brief` section
 - Triage agents may draft recommendations and briefs, but must not set the
   final execution gate.
 
@@ -38,8 +39,8 @@ GitHub's default `GITHUB_TOKEN` is repository-scoped and is not enough for
 organization Projects v2 automation.
 
 The intake workflow only adds eligible issues to the Project. Maintainers still
-set `Agent State = Ready` and `Maintainer Approved = Yes` in the Project before
-the runner may execute work.
+set `Agent State = Ready` and `Maintainer Approved = Yes` in the Project, and
+ensure the issue body has an `Agent Brief`, before the runner may execute work.
 
 ## GitHub CLI
 
@@ -79,6 +80,10 @@ does not mutate GitHub, create worktrees, or spend agent execution budget. Pass
 
 Queue readers scan all Project pages by default. `--limit` controls the
 GraphQL page size, not the total number of items scanned.
+
+The runner treats a missing or empty `Agent Brief` issue-body section as a hard
+execution gate failure. Draft briefs may start in comments, but the approved
+brief must be copied into the issue body before `Agent State = Ready`.
 
 Pure queue helper coverage lives in `pnpm agent:queue:test`. Keep tests there
 for argument parsing, gate evaluation, repository scoping, and pagination before

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -984,6 +984,10 @@ Use the existing package strategy: reusable runner primitives belong in
 
 ## Implementation Plan
 
+Status: Phases 0-2 have a working local pilot. The remaining orchestration
+work should focus on Phase 3 browser and UI evidence, then Phase 4 PR shepherd
+and CI repair.
+
 ### Phase 0: Record And Enforce The Operating Contract
 
 Deliverables:
@@ -1015,6 +1019,11 @@ Deliverables:
 - Document the exception process for oversized files, TypeScript suppressions,
   generated files, and adapter/test seams.
 
+Current status: complete for the local pilot. The operating docs, security
+rules, execution-plan template, brief skill, issue-tracker docs, quality lane,
+and pre-commit feedback path exist. The quality checker remains reporting-only
+until the baseline exception list is mature enough to make it blocking.
+
 Verification:
 
 - `pnpm lint:changed`
@@ -1034,6 +1043,11 @@ Deliverables:
 - Document the exact Project fields and labels in `docs/agents/` so skills and
   runner code share the same vocabulary.
 
+Current status: complete for the local pilot. The `Voyant Engineering` Project,
+fields, intake workflow, issue form, and docs are in place. Execution remains
+maintainer-gated by label, Project fields, and the issue-body `Agent Brief`
+section.
+
 Verification:
 
 - Create one test issue.
@@ -1047,12 +1061,19 @@ Deliverables:
 - Build a script or small app that polls ready Project items.
 - Require an agent brief before dispatch.
 - Create a worktree and branch per item.
-- Start a Codex or Claude task in that worktree.
+- Run a supervised provider-neutral implementation command in that worktree.
 - Record logs and heartbeats.
 - Run a declared verification command.
 - Post a Project comment with the evidence packet.
 - Include agent code-quality checks in the evidence packet, even if they are
   still reporting-only.
+
+Current status: complete for the local pilot. The runner can inspect the queue,
+claim work, prepare a worktree and branch, write the approved brief into the
+execution plan, run an explicit command with `VOYANT_AGENT_*` context, record
+local logs and evidence, publish evidence, open draft PRs, sync PR state, clean
+up worktrees, and recover from restarts from Project fields plus local event
+logs.
 
 Verification:
 

--- a/scripts/lib/agent-brief-parser.mjs
+++ b/scripts/lib/agent-brief-parser.mjs
@@ -1,0 +1,28 @@
+export function hasAgentBrief(body) {
+  return Boolean(extractAgentBrief(body))
+}
+
+export function extractAgentBrief(body) {
+  if (!body) return false
+
+  const lines = body.split(/\r?\n/)
+  const headingIndex = lines.findIndex((line) => /^#{2,6}\s+Agent Brief\s*$/i.test(line.trim()))
+  if (headingIndex === -1) return false
+
+  const sectionLines = []
+  for (const line of lines.slice(headingIndex + 1)) {
+    if (/^#{1,6}\s+\S/.test(line.trim())) break
+    sectionLines.push(line)
+  }
+
+  const content = sectionLines
+    .join("\n")
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .trim()
+
+  if (["no response", "_no response_", "tbd", "todo"].includes(content.toLowerCase())) {
+    return false
+  }
+
+  return content || false
+}

--- a/scripts/lib/agent-project-queue.mjs
+++ b/scripts/lib/agent-project-queue.mjs
@@ -1,6 +1,8 @@
 import { spawnSync } from "node:child_process"
 import path from "node:path"
 
+import { extractAgentBrief, hasAgentBrief } from "./agent-brief-parser.mjs"
+
 const knownTypes = new Set(["task", "bug", "refactor", "investigation", "cleanup"])
 const booleanArgs = new Set(["allow-dirty", "force", "help", "json", "ready", "yes"])
 
@@ -144,6 +146,7 @@ export function readProjectItems({ after, owner, projectNumber, limit, onError =
                 ... on Issue {
                   number
                   title
+                  body
                   url
                   state
                   repository {
@@ -158,6 +161,7 @@ export function readProjectItems({ after, owner, projectNumber, limit, onError =
                 ... on PullRequest {
                   number
                   title
+                  body
                   url
                   state
                   repository {
@@ -284,6 +288,7 @@ export function evaluateItem(item) {
   if (!content) reasons.push("project item has no issue or pull request content")
   if (content?.state !== "OPEN") reasons.push(`issue state is ${content?.state ?? "unknown"}`)
   if (!labels.includes("agent:ready")) reasons.push("missing label agent:ready")
+  if (!hasAgentBrief(content?.body)) reasons.push("missing Agent Brief section")
   if (fields["Agent State"] !== "Ready") {
     reasons.push(`Agent State is ${quoteField(fields["Agent State"])}`)
   }
@@ -303,6 +308,8 @@ export function evaluateItem(item) {
           state: content.state,
           repository: content.repository?.nameWithOwner,
           labels,
+          agentBrief: extractAgentBrief(content.body),
+          hasAgentBrief: hasAgentBrief(content.body),
         }
       : null,
     fields,

--- a/scripts/lib/agent-runner-workspace.mjs
+++ b/scripts/lib/agent-runner-workspace.mjs
@@ -106,6 +106,10 @@ export function buildExecutionPlan(item, { baseRef, workspace }) {
   const issue = item.issue
   const plan = item.dryRunPlan
 
+  if (!issue.agentBrief) {
+    fail("execution plan requires an approved Agent Brief")
+  }
+
   return `# ${issue.title}
 
 Issue: ${issue.url}
@@ -125,6 +129,10 @@ Prepare an implementation workspace for the maintainer-approved issue.
 - Risk: ${plan.risk}
 - Security risk: ${plan.securityRisk}
 - Verification lane: ${plan.verificationLane}
+
+## Agent Brief
+
+${issue.agentBrief}
 
 ## Desired Behavior
 

--- a/scripts/tests/agent-fixtures.mjs
+++ b/scripts/tests/agent-fixtures.mjs
@@ -12,6 +12,8 @@ export function workItem({
       state: "OPEN",
       repository: "voyantjs/voyant",
       labels: ["agent:ready"],
+      hasAgentBrief: true,
+      agentBrief: "Current behavior, desired behavior, acceptance criteria, and verification lane.",
     },
     fields,
     ready: fields["Agent State"] ? fields["Agent State"] === "Ready" : true,

--- a/scripts/tests/agent-project-queue.test.mjs
+++ b/scripts/tests/agent-project-queue.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict"
 import { describe, it } from "node:test"
 
+import { extractAgentBrief, hasAgentBrief } from "../lib/agent-brief-parser.mjs"
 import {
   evaluateItem,
   filterItemsByRepository,
@@ -78,6 +79,10 @@ describe("agent project queue helpers", () => {
 
     assert.equal(evaluated.ready, true)
     assert.equal(evaluated.issue.number, 579)
+    assert.equal(
+      evaluated.issue.agentBrief,
+      "Current behavior, desired behavior, acceptance criteria, and verification lane.",
+    )
     assert.equal(evaluated.dryRunPlan.branch, "bug/579-fix-agent-intake-workflow")
     assert.equal(
       evaluated.dryRunPlan.planPath,
@@ -106,6 +111,28 @@ describe("agent project queue helpers", () => {
       'Agent State is "Running"',
       'Maintainer Approved is "No"',
     ])
+  })
+
+  it("requires a durable Agent Brief before an item is executable", () => {
+    const evaluated = evaluateItem(
+      projectItem({
+        body: "### Agent Brief\n_No response_\n\n### Additional notes\nLater.",
+      }),
+    )
+
+    assert.equal(evaluated.ready, false)
+    assert.deepEqual(evaluated.reasons, ["missing Agent Brief section"])
+  })
+
+  it("detects non-empty Agent Brief sections", () => {
+    const body = "## Agent Brief\nCurrent behavior, desired behavior, acceptance criteria."
+    assert.equal(hasAgentBrief(body), true)
+    assert.equal(
+      extractAgentBrief(`${body}\n\n## Notes\nLater`),
+      "Current behavior, desired behavior, acceptance criteria.",
+    )
+    assert.equal(hasAgentBrief("### Agent Brief\nTBD\n\n### Notes\nLater"), false)
+    assert.equal(hasAgentBrief("## Notes\nNo brief yet"), false)
   })
 
   it("filters evaluated items by repository case-insensitively", () => {
@@ -184,6 +211,7 @@ function projectPage({ items = [], pageInfo = { endCursor: null, hasNextPage: fa
 function projectItem({
   id = "item-1",
   number = 1,
+  body = "## Agent Brief\nCurrent behavior, desired behavior, acceptance criteria, and verification lane.",
   title = "[Task] Implement queue runner",
   state = "OPEN",
   repository = "VoyantJS/Voyant",
@@ -197,6 +225,7 @@ function projectItem({
     id,
     content: {
       number,
+      body,
       title,
       url: `https://github.com/${repository}/issues/${number}`,
       state,

--- a/scripts/tests/agent-runner-lifecycle.test.mjs
+++ b/scripts/tests/agent-runner-lifecycle.test.mjs
@@ -230,8 +230,32 @@ describe("agent runner lifecycle helpers", () => {
     assert.match(plan, /- Project item: item-579/)
     assert.match(plan, /- Repository: voyantjs\/voyant/)
     assert.match(plan, /- Verification lane: verify:fast/)
+    assert.match(
+      plan,
+      /## Agent Brief\n\nCurrent behavior, desired behavior, acceptance criteria, and verification lane\./,
+    )
     assert.match(plan, /## Milestones/)
     assert.match(plan, /## Risks And Rollback/)
+  })
+
+  it("refuses execution plans without an approved Agent Brief", () => {
+    const item = workItem()
+    const original = { error: console.error, exit: process.exit }
+    delete item.issue.agentBrief
+
+    try {
+      console.error = () => {}
+      process.exit = (code) => {
+        throw new Error(`process exit ${code}`)
+      }
+      assert.throws(
+        () => buildExecutionPlan(item, { baseRef: "origin/main", workspace: "/repo/worktree" }),
+        /process exit 1/,
+      )
+    } finally {
+      console.error = original.error
+      process.exit = original.exit
+    }
   })
 
   it("builds PR metadata from issue and evidence context", () => {


### PR DESCRIPTION
## Summary

- require bearer auth for `apps/agent-control-plane` `/api/*` routes while keeping `/health` public for deployment probes
- fail closed when `AGENT_CONTROL_PLANE_TOKENS` is not configured and document the Cloudflare secret setup
- make `Agent Brief` a mechanical execution gate for ready Project items
- copy the approved brief into generated execution plans and refuse plan creation when it is missing
- mark Phases 0-2 complete for the local pilot in the orchestration plan docs, including the exception process and provider-neutral runner command path

## Validation

- `pnpm --filter @voyantjs/agent-control-plane typecheck`
- `pnpm --filter @voyantjs/agent-control-plane test`
- `pnpm --filter @voyantjs/agent-control-plane lint`
- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm verify:architecture`
- `pnpm test:affected`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm typecheck:affected`
- `pnpm exec secretlint ...changed files...`

Note: `pnpm verify:fast` hit a local heap OOM in `templates/operator` typecheck with the default Node heap. The affected typecheck passed when rerun with `NODE_OPTIONS=--max-old-space-size=8192`; the remaining fast-lane pieces passed separately.
