### PR TITLE
Require browser evidence for UI handoff

### DIFF
--- a/.agents/WORKFLOW.md
+++ b/.agents/WORKFLOW.md
@@ -59,6 +59,13 @@ Every task ends with an evidence packet:
 - links to PR, CI run, and artifacts
 - explicit handoff state
 
+Issues labeled `ui`, `ui-change`, `frontend`, `browser:evidence`, or
+`needs-browser-evidence` require browser evidence before they can move to
+human review. For `handoff`, pass `--ui-evidence`. For `run-command`, pass
+`--ui-evidence` before a successful run can transition the item to
+`Human Review`. Attach the screenshot paths, console log, failed-request log,
+and video path, or document the maintainer-approved exception.
+
 The runner should reject handoff when evidence is missing or verification failed
 without an accepted reason.
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -141,8 +141,10 @@ ignored transcript under `.agent-runs/`, writes an evidence packet inside the
 workspace, then moves the item to `Human Review` on exit code `0` or `Blocked`
 on nonzero exit. The command receives `VOYANT_AGENT_*` environment variables
 for the issue, branch, workspace, plan path, evidence path, log path, repository,
-and verification lane. It does not push branches, open PRs, or publish evidence
-comments.
+verification lane, and browser artifact location. Successful UI-labeled runs
+must pass `--ui-evidence <text>` or they are blocked instead of moved to
+`Human Review`; nonzero exits are still blocked by the command failure. It does
+not push branches, open PRs, or publish evidence comments.
 
 Use the read-only status view to inspect the current queue and active work:
 
@@ -233,6 +235,18 @@ Handoff mode writes a markdown evidence packet under the task workspace,
 updates `Evidence` with that path, sets `Agent State = Human Review`, updates
 `Last Heartbeat`, and clears `Blocked By`. It requires `--summary` and
 `--verification` so maintainer review always has a concrete packet.
+For issues labeled `ui`, `ui-change`, `frontend`, `browser:evidence`, or
+`needs-browser-evidence`, handoff also requires `--ui-evidence` unless
+`--force` is used with an accepted exception.
+
+Supervised commands receive browser artifact environment variables so UI work
+can keep screenshots, videos, console logs, and failed-request logs in a stable
+per-workspace location:
+
+- `VOYANT_AGENT_DEV_SERVER_PORT`
+- `VOYANT_AGENT_DEV_SERVER_URL`
+- `VOYANT_AGENT_BROWSER_ARTIFACT_DIR`
+- `VOYANT_AGENT_BROWSER_ARTIFACT_REFERENCE`
 
 Publish the evidence packet when it should survive beyond the local workspace:
 

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -15,3 +15,9 @@ ask a maintainer before changing state.
 
 `agent:ready` is special: triage agents must not apply it unless a maintainer
 explicitly instructs them to do so in the current task.
+
+## Evidence Labels
+
+| Role | Label | Meaning |
+| --- | --- | --- |
+| `browser-evidence-required` | `browser:evidence` | UI work must include screenshot, console, request, and video evidence. |

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1090,6 +1090,12 @@ Deliverables:
 - Capture screenshots, console errors, failed requests, and video.
 - Require browser evidence for UI-labeled tasks.
 
+Current status: started. The local runner now allocates deterministic
+per-workspace browser artifact paths and dev-server ports, exposes them to
+supervised commands through `VOYANT_AGENT_*` environment variables, and rejects
+handoff for UI-labeled work that lacks browser evidence or an accepted
+exception.
+
 Verification:
 
 - Run first against `apps/workflows-local-dashboard`, then against a small

--- a/scripts/agent-runner-handoff.mjs
+++ b/scripts/agent-runner-handoff.mjs
@@ -11,6 +11,7 @@ import {
   projectScanConfigFromArgs,
   runGit,
 } from "./lib/agent-project-queue.mjs"
+import { browserEvidenceMissingReason } from "./lib/agent-runner-browser-evidence.mjs"
 import {
   maybePrintHelp,
   mutationOptions,
@@ -29,6 +30,10 @@ maybePrintHelp(args, {
     ["--issue <number>", "Issue number to hand off."],
     ["--summary <text>", "Human-readable summary for the evidence packet."],
     ["--verification <text>", "Verification command and outcome for the evidence packet."],
+    [
+      "--ui-evidence <text>",
+      "Required browser artifacts or approved exception for UI-labeled work.",
+    ],
     ["--evidence-path <path>", "Evidence path relative to the task workspace."],
     ["--branch <name>", "Branch reference to record in the evidence packet."],
     ["--workspace <path>", "Workspace path override."],
@@ -70,6 +75,11 @@ if (!args.summary) {
 
 if (!args.verification) {
   fail("handoff mode requires --verification <command-and-outcome>")
+}
+
+const missingBrowserEvidence = browserEvidenceMissingReason(item, args.uiEvidence)
+if (missingBrowserEvidence && !args.force) {
+  fail(`${missingBrowserEvidence}; pass --ui-evidence or --force with an accepted exception`)
 }
 
 const workspaceReference = args.workspace ?? item.fields.Workspace ?? item.dryRunPlan.workspace

--- a/scripts/agent-runner-run-command.mjs
+++ b/scripts/agent-runner-run-command.mjs
@@ -16,6 +16,7 @@ import {
   buildCommandEvidencePacket,
   canRunCommandState,
   commandRunArtifactPlan,
+  commandRunBrowserEvidenceBlockReason,
   commandRunEnvironment,
   commandRunFieldUpdate,
   commandRunStates,
@@ -38,6 +39,10 @@ maybePrintHelp(args, {
     ["--workspace <path>", "Workspace path override."],
     ["--branch <name>", "Branch reference for evidence. Defaults from the Project field."],
     ["--evidence-path <path>", "Evidence path relative to the task workspace."],
+    [
+      "--ui-evidence <text>",
+      "Required browser artifacts or approved exception for successful UI-labeled work.",
+    ],
     ["--force", "Allow command execution outside the normal run states."],
     ...repositoryOptions,
     ...mutationOptions,
@@ -121,7 +126,14 @@ const exitCode = await runLoggedCommand({
   repository,
 })
 const stoppedAt = new Date()
+const blockedBy = commandRunBrowserEvidenceBlockReason({
+  exitCode,
+  force: Boolean(args.force),
+  item,
+  uiEvidence: args.uiEvidence,
+})
 const finalUpdate = commandRunFieldUpdate({
+  blockedBy,
   evidencePointer: artifactPlan.evidencePointer,
   exitCode,
 })
@@ -138,6 +150,8 @@ writeFileSync(
     repository,
     startedAt,
     stoppedAt,
+    blockedBy,
+    uiEvidence: args.uiEvidence,
   }),
   "utf8",
 )
@@ -156,8 +170,9 @@ console.log(`workspace: ${artifactPlan.workspace}`)
 console.log(`log: ${artifactPlan.logFile}`)
 console.log(`evidence: ${artifactPlan.evidenceFile}`)
 console.log(`exit code: ${exitCode}`)
+console.log(`agent state: ${finalUpdate.values["Agent State"]}`)
 
-process.exitCode = exitCode
+process.exitCode = blockedBy ? 1 : exitCode
 
 function printRunPlan({ artifactPlan, branch, item, repository, runningUpdate }) {
   console.log("agent-runner run-command would execute:")

--- a/scripts/lib/agent-runner-browser-evidence.mjs
+++ b/scripts/lib/agent-runner-browser-evidence.mjs
@@ -1,0 +1,84 @@
+import path from "node:path"
+
+const uiEvidenceLabels = new Set([
+  "browser:evidence",
+  "frontend",
+  "needs-browser-evidence",
+  "ui",
+  "ui-change",
+])
+
+export function requiresBrowserEvidence(item) {
+  const labels = item.issue?.labels ?? []
+  return labels.some((label) => uiEvidenceLabels.has(label.toLowerCase()))
+}
+
+export function browserArtifactPlan({
+  basePort = 4300,
+  date = new Date(),
+  item,
+  repoRoot,
+  workspaceReference,
+}) {
+  const slug = slugFromTitle(item.issue.title)
+  const timestamp = date.toISOString().replace(/[:.]/g, "-")
+  const workspace = path.resolve(repoRoot, workspaceReference)
+  const artifactPointer = path.posix.join(
+    "docs/agent-evidence/browser",
+    `${item.issue.number}-${slug}`,
+    timestamp,
+  )
+  const artifactDir = path.resolve(workspace, artifactPointer)
+  const devServerPort = basePort + (Number(item.issue.number) % 1000)
+
+  return {
+    artifactDir,
+    artifactPointer,
+    consoleLog: path.join(artifactDir, "console.jsonl"),
+    devServerPort,
+    devServerUrl: `http://127.0.0.1:${devServerPort}`,
+    networkLog: path.join(artifactDir, "network.jsonl"),
+    screenshotDir: path.join(artifactDir, "screenshots"),
+    safeArtifactPath: isPathInside(artifactDir, workspace),
+    videoDir: path.join(artifactDir, "videos"),
+    workspace,
+    workspaceReference,
+  }
+}
+
+export function browserEvidenceEnvironment({ artifactPlan }) {
+  return {
+    VOYANT_AGENT_BROWSER_ARTIFACT_DIR: artifactPlan.artifactDir,
+    VOYANT_AGENT_BROWSER_ARTIFACT_REFERENCE: artifactPlan.artifactPointer,
+    VOYANT_AGENT_DEV_SERVER_PORT: String(artifactPlan.devServerPort),
+    VOYANT_AGENT_DEV_SERVER_URL: artifactPlan.devServerUrl,
+  }
+}
+
+export function browserEvidenceMissingReason(item, uiEvidence) {
+  if (!requiresBrowserEvidence(item)) return null
+
+  const normalized = uiEvidence?.trim().toLowerCase()
+  if (!normalized || ["n/a", "na", "none", "not applicable", "not provided"].includes(normalized)) {
+    return "browser evidence is required for UI-labeled work"
+  }
+
+  return null
+}
+
+function isPathInside(candidatePath, parentPath) {
+  const relative = path.relative(parentPath, candidatePath)
+  return Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative)
+}
+
+function slugFromTitle(title) {
+  const slug = title
+    .toLowerCase()
+    .replace(/^\[(task|bug|refactor|investigation|cleanup)\]\s*:?\s*/i, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60)
+    .replace(/-+$/g, "")
+
+  return slug || "agent-task"
+}

--- a/scripts/lib/agent-runner-execution.mjs
+++ b/scripts/lib/agent-runner-execution.mjs
@@ -1,5 +1,12 @@
 import path from "node:path"
 
+import {
+  browserArtifactPlan,
+  browserEvidenceEnvironment,
+  browserEvidenceMissingReason,
+  requiresBrowserEvidence,
+} from "./agent-runner-browser-evidence.mjs"
+
 export const commandRunStates = new Set(["Planning", "Running", "Changes Requested", "CI Repair"])
 
 export function canRunCommandState(agentState, { force = false } = {}) {
@@ -30,6 +37,7 @@ export function commandRunArtifactPlan({
     evidenceFile,
     evidencePointer,
     logFile,
+    repoRoot,
     safeEvidencePath: isPathInside(evidenceFile, workspace),
     workspace,
     workspaceReference,
@@ -37,7 +45,14 @@ export function commandRunArtifactPlan({
 }
 
 export function commandRunEnvironment({ artifactPlan, branch, item, repository }) {
+  const browserPlan = browserArtifactPlan({
+    item,
+    repoRoot: artifactPlan.repoRoot,
+    workspaceReference: artifactPlan.workspaceReference,
+  })
+
   return {
+    ...browserEvidenceEnvironment({ artifactPlan: browserPlan }),
     VOYANT_AGENT_BRANCH: branch,
     VOYANT_AGENT_EVIDENCE_PATH: artifactPlan.evidenceFile,
     VOYANT_AGENT_EVIDENCE_REFERENCE: artifactPlan.evidencePointer,
@@ -52,19 +67,34 @@ export function commandRunEnvironment({ artifactPlan, branch, item, repository }
   }
 }
 
-export function commandRunFieldUpdate({ date = new Date(), evidencePointer, exitCode }) {
+export function commandRunBrowserEvidenceBlockReason({
+  exitCode,
+  force = false,
+  item,
+  uiEvidence,
+}) {
+  if (exitCode !== 0 || force) return null
+
+  const missingReason = browserEvidenceMissingReason(item, uiEvidence)
+  if (!missingReason) return null
+
+  return `${missingReason}; pass --ui-evidence or --force with an accepted exception`
+}
+
+export function commandRunFieldUpdate({ blockedBy, date = new Date(), evidencePointer, exitCode }) {
+  const blocked = exitCode !== 0 || Boolean(blockedBy)
   const values = {
-    "Agent State": exitCode === 0 ? "Human Review" : "Blocked",
+    "Agent State": blocked ? "Blocked" : "Human Review",
     "Last Heartbeat": date.toISOString().slice(0, 10),
     Evidence: evidencePointer,
   }
 
-  if (exitCode !== 0) {
-    values["Blocked By"] = `run-command exited with ${exitCode}`
+  if (blocked) {
+    values["Blocked By"] = blockedBy ?? `run-command exited with ${exitCode}`
   }
 
   return {
-    clear: exitCode === 0 ? ["Blocked By"] : [],
+    clear: blocked ? [] : ["Blocked By"],
     values,
   }
 }
@@ -78,8 +108,10 @@ export function buildCommandEvidencePacket({
   repository,
   startedAt,
   stoppedAt,
+  blockedBy,
+  uiEvidence,
 }) {
-  const state = exitCode === 0 ? "Human Review" : "Blocked"
+  const state = exitCode === 0 && !blockedBy ? "Human Review" : "Blocked"
 
   return `# Evidence Packet: ${item.issue.title}
 
@@ -94,6 +126,7 @@ Generated: ${stoppedAt.toISOString()}
 ## Summary
 
 Supervised command completed with exit code ${exitCode}.
+${blockedBy ? `\nRun-command handoff blocked: ${blockedBy}.\n` : ""}
 
 ## Command
 
@@ -110,10 +143,26 @@ ${command}
 
 Runner command transcript: ${artifactPlan.logFile}
 
+## Browser Evidence
+
+${formatBrowserEvidenceRequirement(item, uiEvidence)}
+
 ## Residual Risks
 
 Review the command transcript and resulting diff before opening or merging a PR.
 `
+}
+
+function formatBrowserEvidenceRequirement(item, uiEvidence) {
+  if (!requiresBrowserEvidence(item)) {
+    return "Not required by issue labels."
+  }
+
+  if (uiEvidence?.trim()) {
+    return uiEvidence.trim()
+  }
+
+  return "Required for UI-labeled work. Attach screenshots, console log, failed-request log, and video or note the maintainer-approved exception."
 }
 
 function isPathInside(candidatePath, parentPath) {

--- a/scripts/tests/agent-runner-browser-evidence.test.mjs
+++ b/scripts/tests/agent-runner-browser-evidence.test.mjs
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict"
+import path from "node:path"
+import { describe, it } from "node:test"
+
+import {
+  browserArtifactPlan,
+  browserEvidenceEnvironment,
+  browserEvidenceMissingReason,
+  requiresBrowserEvidence,
+} from "../lib/agent-runner-browser-evidence.mjs"
+import {
+  buildCommandEvidencePacket,
+  commandRunArtifactPlan,
+  commandRunBrowserEvidenceBlockReason,
+  commandRunEnvironment,
+  commandRunFieldUpdate,
+} from "../lib/agent-runner-execution.mjs"
+import { workItem } from "./agent-fixtures.mjs"
+
+describe("agent runner browser evidence helpers", () => {
+  it("detects UI-labeled work that needs browser evidence", () => {
+    const item = workItem()
+    item.issue.labels = ["agent:ready", "ui-change"]
+
+    assert.equal(requiresBrowserEvidence(item), true)
+    assert.equal(
+      browserEvidenceMissingReason(item, undefined),
+      "browser evidence is required for UI-labeled work",
+    )
+    assert.equal(
+      browserEvidenceMissingReason(item, "screenshots: docs/agent-evidence/browser/579"),
+      null,
+    )
+    assert.equal(requiresBrowserEvidence(workItem()), false)
+  })
+
+  it("allocates deterministic per-workspace browser artifact paths", () => {
+    const item = workItem()
+    const plan = browserArtifactPlan({
+      date: new Date("2026-05-10T12:34:56.000Z"),
+      item,
+      repoRoot: "/repo",
+      workspaceReference: item.dryRunPlan.workspace,
+    })
+
+    assert.deepEqual(plan, {
+      artifactDir: path.resolve(
+        "/repo/.agent-worktrees/579-test-agent-project-intake-workflow/docs/agent-evidence/browser/579-test-agent-project-intake-workflow/2026-05-10T12-34-56-000Z",
+      ),
+      artifactPointer:
+        "docs/agent-evidence/browser/579-test-agent-project-intake-workflow/2026-05-10T12-34-56-000Z",
+      consoleLog: path.resolve(
+        "/repo/.agent-worktrees/579-test-agent-project-intake-workflow/docs/agent-evidence/browser/579-test-agent-project-intake-workflow/2026-05-10T12-34-56-000Z/console.jsonl",
+      ),
+      devServerPort: 4879,
+      devServerUrl: "http://127.0.0.1:4879",
+      networkLog: path.resolve(
+        "/repo/.agent-worktrees/579-test-agent-project-intake-workflow/docs/agent-evidence/browser/579-test-agent-project-intake-workflow/2026-05-10T12-34-56-000Z/network.jsonl",
+      ),
+      safeArtifactPath: true,
+      screenshotDir: path.resolve(
+        "/repo/.agent-worktrees/579-test-agent-project-intake-workflow/docs/agent-evidence/browser/579-test-agent-project-intake-workflow/2026-05-10T12-34-56-000Z/screenshots",
+      ),
+      videoDir: path.resolve(
+        "/repo/.agent-worktrees/579-test-agent-project-intake-workflow/docs/agent-evidence/browser/579-test-agent-project-intake-workflow/2026-05-10T12-34-56-000Z/videos",
+      ),
+      workspace: path.resolve("/repo/.agent-worktrees/579-test-agent-project-intake-workflow"),
+      workspaceReference: ".agent-worktrees/579-test-agent-project-intake-workflow",
+    })
+  })
+
+  it("passes browser artifact context to supervised commands", () => {
+    const item = workItem()
+    item.issue.labels = ["agent:ready", "ui"]
+    const artifactPlan = commandRunArtifactPlan({
+      item,
+      repoRoot: "/repo",
+      workspaceReference: item.dryRunPlan.workspace,
+    })
+    const env = commandRunEnvironment({
+      artifactPlan,
+      branch: item.dryRunPlan.branch,
+      item,
+      repository: "voyantjs/voyant",
+    })
+
+    assert.equal(env.VOYANT_AGENT_DEV_SERVER_PORT, "4879")
+    assert.equal(env.VOYANT_AGENT_DEV_SERVER_URL, "http://127.0.0.1:4879")
+    assert.match(
+      env.VOYANT_AGENT_BROWSER_ARTIFACT_REFERENCE,
+      /^docs\/agent-evidence\/browser\/579-/,
+    )
+    assert.deepEqual(
+      browserEvidenceEnvironment({
+        artifactPlan: browserArtifactPlan({
+          item,
+          repoRoot: "/repo",
+          workspaceReference: item.dryRunPlan.workspace,
+        }),
+      }).VOYANT_AGENT_DEV_SERVER_URL,
+      "http://127.0.0.1:4879",
+    )
+  })
+
+  it("marks browser evidence as required in command evidence for UI work", () => {
+    const item = workItem()
+    item.issue.labels = ["agent:ready", "frontend"]
+    const artifactPlan = commandRunArtifactPlan({
+      item,
+      repoRoot: "/repo",
+      workspaceReference: item.dryRunPlan.workspace,
+    })
+    const evidence = buildCommandEvidencePacket({
+      artifactPlan,
+      branch: item.dryRunPlan.branch,
+      command: "pnpm verify:fast",
+      exitCode: 0,
+      item,
+      repository: "voyantjs/voyant",
+      startedAt: new Date("2026-05-10T12:34:56.000Z"),
+      stoppedAt: new Date("2026-05-10T12:35:56.000Z"),
+    })
+
+    assert.match(evidence, /## Browser Evidence/)
+    assert.match(evidence, /Required for UI-labeled work/)
+  })
+
+  it("blocks successful command handoff for UI work without browser evidence", () => {
+    const item = workItem()
+    item.issue.labels = ["agent:ready", "ui-change"]
+    const blockedBy = commandRunBrowserEvidenceBlockReason({
+      exitCode: 0,
+      item,
+      uiEvidence: undefined,
+    })
+
+    assert.equal(
+      blockedBy,
+      "browser evidence is required for UI-labeled work; pass --ui-evidence or --force with an accepted exception",
+    )
+    assert.deepEqual(
+      commandRunFieldUpdate({
+        blockedBy,
+        date: new Date("2026-05-10T12:34:56.000Z"),
+        evidencePointer: "docs/agent-evidence/active/579-test.md",
+        exitCode: 0,
+      }),
+      {
+        clear: [],
+        values: {
+          "Agent State": "Blocked",
+          "Last Heartbeat": "2026-05-10",
+          Evidence: "docs/agent-evidence/active/579-test.md",
+          "Blocked By": blockedBy,
+        },
+      },
+    )
+
+    assert.equal(
+      commandRunBrowserEvidenceBlockReason({
+        exitCode: 0,
+        item,
+        uiEvidence: "screenshots: docs/agent-evidence/browser/579",
+      }),
+      null,
+    )
+    assert.equal(commandRunBrowserEvidenceBlockReason({ exitCode: 1, item }), null)
+  })
+})

--- a/scripts/tests/agent-runner-lifecycle.test.mjs
+++ b/scripts/tests/agent-runner-lifecycle.test.mjs
@@ -111,7 +111,6 @@ describe("agent runner lifecycle helpers", () => {
       repoRoot: "/repo",
       workspaceReference: item.dryRunPlan.workspace,
     })
-
     assert.deepEqual(plan, {
       evidenceFile: path.resolve(
         "/repo/.agent-worktrees/579-test-agent-project-intake-workflow/docs/agent-evidence/active/579-test-agent-project-intake-workflow.md",
@@ -120,6 +119,7 @@ describe("agent runner lifecycle helpers", () => {
       logFile: path.resolve(
         "/repo/.agent-runs/579-test-agent-project-intake-workflow/2026-05-10T12-34-56-000Z.log",
       ),
+      repoRoot: "/repo",
       safeEvidencePath: true,
       workspace: path.resolve("/repo/.agent-worktrees/579-test-agent-project-intake-workflow"),
       workspaceReference: ".agent-worktrees/579-test-agent-project-intake-workflow",


### PR DESCRIPTION
## Summary
- add browser evidence detection for UI-labeled agent work
- allocate deterministic per-workspace browser artifact paths and dev-server ports
- expose browser artifact context to supervised runner commands
- require `--ui-evidence` at handoff for UI-labeled items unless forced with an accepted exception
- document the Phase 3 browser evidence contract and labels

## Validation
- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm verify:architecture`
- `pnpm exec biome check scripts/lib/agent-runner-browser-evidence.mjs scripts/lib/agent-runner-execution.mjs scripts/agent-runner-handoff.mjs scripts/tests/agent-runner-browser-evidence.test.mjs scripts/tests/agent-runner-lifecycle.test.mjs`
- `pnpm exec secretlint scripts/lib/agent-runner-browser-evidence.mjs scripts/lib/agent-runner-execution.mjs scripts/agent-runner-handoff.mjs scripts/tests/agent-runner-browser-evidence.test.mjs scripts/tests/agent-runner-lifecycle.test.mjs .agents/WORKFLOW.md docs/agents/issue-tracker.md docs/agents/triage-labels.md docs/architecture/agentic-engineering-orchestration.md`
- `node --check scripts/lib/agent-runner-browser-evidence.mjs scripts/lib/agent-runner-execution.mjs scripts/agent-runner-handoff.mjs scripts/tests/agent-runner-browser-evidence.test.mjs scripts/tests/agent-runner-lifecycle.test.mjs`
- pre-push `pnpm test`
