### PR TITLE
Capture browser evidence for UI work

### DIFF
--- a/.agents/WORKFLOW.md
+++ b/.agents/WORKFLOW.md
@@ -63,8 +63,10 @@ Issues labeled `ui`, `ui-change`, `frontend`, `browser:evidence`, or
 `needs-browser-evidence` require browser evidence before they can move to
 human review. For `handoff`, pass `--ui-evidence`. For `run-command`, pass
 `--ui-evidence` before a successful run can transition the item to
-`Human Review`. Attach the screenshot paths, console log, failed-request log,
-and video path, or document the maintainer-approved exception.
+`Human Review`. Use `pnpm agent:queue:capture-browser -- --issue <number>
+--dev-server-command "pnpm dev" --yes` when the task needs a standard
+screenshot, video, console log, and failed-request log bundle. Attach the
+printed evidence value, or document the maintainer-approved exception.
 
 The runner should reject handoff when evidence is missing or verification failed
 without an accepted reason.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -146,6 +146,20 @@ must pass `--ui-evidence <text>` or they are blocked instead of moved to
 `Human Review`; nonzero exits are still blocked by the command failure. It does
 not push branches, open PRs, or publish evidence comments.
 
+For UI work, capture browser evidence before handoff or before a successful
+`run-command` transition:
+
+```bash
+pnpm agent:queue:capture-browser -- --issue <number> --dev-server-command "pnpm dev" --yes
+```
+
+Capture-browser mode writes screenshots, video, console logs, failed-request
+logs, and a summary under `docs/agent-evidence/browser/...` inside the claimed
+workspace. By default it targets the deterministic issue URL in
+`VOYANT_AGENT_DEV_SERVER_URL`; pass `--url` for an already-running app or a
+specific route. The command prints a multi-line value that can be passed as
+`--ui-evidence` to `handoff` or `run-command`.
+
 Use the read-only status view to inspect the current queue and active work:
 
 ```bash

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1092,9 +1092,10 @@ Deliverables:
 
 Current status: started. The local runner now allocates deterministic
 per-workspace browser artifact paths and dev-server ports, exposes them to
-supervised commands through `VOYANT_AGENT_*` environment variables, and rejects
-handoff for UI-labeled work that lacks browser evidence or an accepted
-exception.
+supervised commands through `VOYANT_AGENT_*` environment variables, rejects
+handoff and successful run-command transitions for UI-labeled work that lacks
+browser evidence or an accepted exception, and provides a Playwright capture
+command for screenshot, video, console, failed-request, and summary artifacts.
 
 Verification:
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "agent:queue:prepare": "node scripts/agent-runner-prepare.mjs",
     "agent:queue:start": "node scripts/agent-runner-start.mjs",
     "agent:queue:run-command": "node scripts/agent-runner-run-command.mjs",
+    "agent:queue:capture-browser": "node scripts/agent-runner-capture-browser.mjs",
     "agent:queue:claim": "node scripts/agent-runner-claim.mjs",
     "agent:queue:heartbeat": "node scripts/agent-runner-heartbeat.mjs",
     "agent:queue:handoff": "node scripts/agent-runner-handoff.mjs",
@@ -81,8 +82,9 @@
     "depcheck": "^1.4.7",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
-    "semver": "^7.7.2",
+    "playwright": "1.59.1",
     "secretlint": "^11.4.1",
+    "semver": "^7.7.2",
     "tsx": "^4.21.0",
     "turbo": "^2.9.3",
     "vitest": "^4.1.2"
@@ -95,6 +97,7 @@
     "onlyBuiltDependencies": [
       "sharp",
       "esbuild",
+      "playwright",
       "unrs-resolver",
       "@tailwindcss/oxide",
       "core-js-pure",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       lint-staged:
         specifier: ^16.4.0
         version: 16.4.0
+      playwright:
+        specifier: 1.59.1
+        version: 1.59.1
       secretlint:
         specifier: ^11.4.1
         version: 11.4.1
@@ -152,10 +155,10 @@ importers:
         version: 1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@better-auth/api-key':
         specifier: ^1.5.6
-        version: 1.5.6(528a90069b32ded3cd69e6bc8dd18c96)
+        version: 1.5.6(1f1bbcdf0f17a0d068016c0095f7b39e)
       '@cloudflare/vite-plugin':
         specifier: ^1.31.0
-        version: 1.31.0(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260426.1)(wrangler@4.86.0(@cloudflare/workers-types@4.20260426.1))
+        version: 1.31.0(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260507.1)(wrangler@4.86.0(@cloudflare/workers-types@4.20260426.1))
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -401,7 +404,7 @@ importers:
         version: link:../../packages/workflows
       better-auth:
         specifier: ^1.5.6
-        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -956,7 +959,7 @@ importers:
     dependencies:
       '@better-auth/api-key':
         specifier: ^1.5.6
-        version: 1.5.6(528a90069b32ded3cd69e6bc8dd18c96)
+        version: 1.5.6(1f1bbcdf0f17a0d068016c0095f7b39e)
       '@voyantjs/db':
         specifier: workspace:*
         version: link:../db
@@ -965,7 +968,7 @@ importers:
         version: link:../utils
       better-auth:
         specifier: ^1.5.6
-        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
@@ -5223,7 +5226,7 @@ importers:
         version: 1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@better-auth/api-key':
         specifier: ^1.5.6
-        version: 1.5.6(528a90069b32ded3cd69e6bc8dd18c96)
+        version: 1.5.6(1f1bbcdf0f17a0d068016c0095f7b39e)
       '@cloudflare/vite-plugin':
         specifier: ^1.31.0
         version: 1.31.0(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260401.1)(wrangler@4.80.0(@cloudflare/workers-types@4.20260426.1))
@@ -5421,7 +5424,7 @@ importers:
         version: link:../../packages/workflows
       better-auth:
         specifier: ^1.5.6
-        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -5560,7 +5563,7 @@ importers:
         version: 1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@better-auth/api-key':
         specifier: ^1.5.6
-        version: 1.5.6(528a90069b32ded3cd69e6bc8dd18c96)
+        version: 1.5.6(1f1bbcdf0f17a0d068016c0095f7b39e)
       '@cloudflare/vite-plugin':
         specifier: ^1.36.3
         version: 1.36.3(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260507.1)(wrangler@4.90.0(@cloudflare/workers-types@4.20260426.1))
@@ -5851,7 +5854,7 @@ importers:
         version: link:../../packages/workflows-orchestrator-cloudflare
       better-auth:
         specifier: ^1.5.6
-        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -11315,8 +11318,18 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   playwright@1.56.1:
     resolution: {integrity: sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -12953,11 +12966,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@better-auth/api-key@1.5.6(528a90069b32ded3cd69e6bc8dd18c96)':
+  '@better-auth/api-key@1.5.6(1f1bbcdf0f17a0d068016c0095f7b39e)':
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
-      better-auth: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
+      better-auth: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
       zod: 4.3.6
 
   '@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)':
@@ -13210,11 +13223,11 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260401.1
 
-  '@cloudflare/unenv-preset@2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260426.1)':
+  '@cloudflare/unenv-preset@2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260507.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260426.1
+      workerd: 1.20260507.1
 
   '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260426.1)':
     dependencies:
@@ -13241,9 +13254,9 @@ snapshots:
       - utf-8-validate
       - workerd
 
-  '@cloudflare/vite-plugin@1.31.0(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260426.1)(wrangler@4.86.0(@cloudflare/workers-types@4.20260426.1))':
+  '@cloudflare/vite-plugin@1.31.0(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260507.1)(wrangler@4.86.0(@cloudflare/workers-types@4.20260426.1))':
     dependencies:
-      '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260426.1)
+      '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260507.1)
       miniflare: 4.20260401.0
       unenv: 2.0.0-rc.24
       vite: 8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)
@@ -15887,7 +15900,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.14: {}
 
-  better-auth@1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))):
+  better-auth@1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))):
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))
@@ -17896,12 +17909,20 @@ snapshots:
   playwright-core@1.56.1:
     optional: true
 
+  playwright-core@1.59.1: {}
+
   playwright@1.56.1:
     dependencies:
       playwright-core: 1.56.1
     optionalDependencies:
       fsevents: 2.3.2
     optional: true
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   please-upgrade-node@3.2.0:
     dependencies:

--- a/scripts/agent-runner-capture-browser.mjs
+++ b/scripts/agent-runner-capture-browser.mjs
@@ -1,0 +1,235 @@
+import { spawn } from "node:child_process"
+import { createWriteStream, existsSync, mkdirSync } from "node:fs"
+import path from "node:path"
+
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  findProjectIssueItem,
+  loadAllEvaluatedProject,
+  parseArgs,
+  projectScanConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+import {
+  browserArtifactPlan,
+  browserCapturePlan,
+  browserEvidenceEnvironment,
+  browserEvidenceText,
+  captureBrowserEvidence,
+  requiresBrowserEvidence,
+} from "./lib/agent-runner-browser-evidence.mjs"
+import {
+  maybePrintHelp,
+  mutationOptions,
+  projectOptions,
+  repositoryOptions,
+} from "./lib/agent-runner-help.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:capture-browser",
+  summary: "Capture browser evidence for a claimed UI task workspace.",
+  usage: 'pnpm agent:queue:capture-browser -- --issue <number> --url "http://127.0.0.1:4879" --yes',
+  options: [
+    ["--issue <number>", "Issue number whose workspace should receive browser artifacts."],
+    ["--url <url>", "URL to capture. Defaults to the issue-scoped local dev server URL."],
+    ["--dev-server-command <shell>", "Optional dev server command to start before capture."],
+    ["--workspace <path>", "Workspace path override."],
+    ["--viewport <size>", "Viewport as <width>x<height>. Defaults to 1440x900."],
+    ["--timeout-ms <number>", "Navigation and dev-server wait timeout. Defaults to 30000."],
+    ["--screenshot-name <name>", "Screenshot file name. Defaults to page.png."],
+    ["--browser-base-port <number>", "Base port for deterministic issue ports. Defaults to 4300."],
+    ...repositoryOptions,
+    ...mutationOptions,
+    ...projectOptions,
+  ],
+})
+
+if (!args.issue) {
+  fail("capture-browser mode requires --issue <number>")
+}
+
+const timeoutMs = numberArg(args.timeoutMs, 30_000, "timeout-ms")
+const browserBasePort = numberArg(args.browserBasePort, 4300, "browser-base-port")
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
+const item = findProjectIssueItem(project.items, {
+  issueNumber: args.issue,
+  repository,
+})
+
+if (item.issue.state !== "OPEN") {
+  fail(
+    `issue #${args.issue} cannot capture browser evidence because issue state is ${item.issue.state}`,
+  )
+}
+
+const workspaceReference = args.workspace ?? item.fields.Workspace ?? item.dryRunPlan.workspace
+const artifactPlan = browserArtifactPlan({
+  basePort: browserBasePort,
+  item,
+  repoRoot,
+  workspaceReference,
+})
+const capturePlan = browserCapturePlan({
+  artifactPlan,
+  screenshotName: args.screenshotName,
+  url: args.url ?? artifactPlan.devServerUrl,
+  viewport: args.viewport,
+})
+
+if (!artifactPlan.safeArtifactPath) {
+  fail(`capture-browser refuses artifacts outside the workspace: ${artifactPlan.artifactDir}`)
+}
+
+if (!existsSync(artifactPlan.workspace)) {
+  fail(`workspace does not exist: ${artifactPlan.workspace}`)
+}
+
+if (!args.yes) {
+  printCapturePlan({ artifactPlan, capturePlan, item, repository })
+  fail("capture-browser mode writes local browser artifacts; rerun with --yes")
+}
+
+const { chromium } = await import("playwright").catch((error) => {
+  fail(`Playwright is not available: ${error.message}`)
+})
+
+mkdirSync(artifactPlan.artifactDir, { recursive: true })
+const server = args.devServerCommand
+  ? startDevServer({
+      artifactPlan,
+      command: args.devServerCommand,
+      env: browserEvidenceEnvironment({ artifactPlan }),
+    })
+  : undefined
+let result
+let captureError
+
+try {
+  if (server) {
+    await waitForUrl(capturePlan.url, { timeoutMs })
+  }
+
+  result = await captureBrowserEvidence({
+    browserLauncher: chromium,
+    capturePlan,
+    timeoutMs,
+  })
+} catch (error) {
+  captureError = error
+} finally {
+  await stopDevServer(server)
+}
+
+if (captureError) {
+  fail(`capture-browser failed: ${captureError.message}`)
+}
+
+console.log("agent-runner capture-browser: wrote browser evidence")
+console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+console.log(`repository: ${repository}`)
+console.log(`workspace: ${artifactPlan.workspace}`)
+console.log(`artifacts: ${artifactPlan.artifactDir}`)
+console.log("")
+console.log("Use this value with --ui-evidence:")
+console.log(browserEvidenceText(result))
+
+if (!requiresBrowserEvidence(item)) {
+  console.log("")
+  console.log("Note: browser evidence is not required by this issue's labels.")
+}
+
+function printCapturePlan({ artifactPlan, capturePlan, item, repository }) {
+  console.log("agent-runner capture-browser would capture:")
+  console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+  console.log(`repository: ${repository}`)
+  console.log(`workspace: ${artifactPlan.workspace}`)
+  console.log(`url: ${capturePlan.url}`)
+  console.log(`viewport: ${capturePlan.viewport.width}x${capturePlan.viewport.height}`)
+  console.log(`artifacts: ${artifactPlan.artifactDir}`)
+  console.log(`screenshot: ${capturePlan.screenshotFile}`)
+  console.log(`console log: ${artifactPlan.consoleLog}`)
+  console.log(`failed-request log: ${artifactPlan.networkLog}`)
+  if (args.devServerCommand) {
+    console.log(`dev server command: ${args.devServerCommand}`)
+  }
+}
+
+function startDevServer({ artifactPlan, command, env }) {
+  const logFile = path.join(artifactPlan.artifactDir, "dev-server.log")
+  const logStream = createWriteStream(logFile, { flags: "a" })
+  logStream.write(`# ${new Date().toISOString()} ${command}\n\n`)
+  let exited = false
+
+  const child = spawn(command, {
+    cwd: artifactPlan.workspace,
+    env: {
+      ...process.env,
+      ...env,
+    },
+    shell: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+
+  child.stdout.pipe(logStream, { end: false })
+  child.stderr.pipe(logStream, { end: false })
+  child.once("exit", () => {
+    exited = true
+  })
+
+  return { child, exited: () => exited, logStream }
+}
+
+async function waitForUrl(url, { timeoutMs }) {
+  const startedAt = Date.now()
+  let lastError
+
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const response = await fetch(url, { redirect: "manual" })
+      if (response.status < 500) return
+      lastError = new Error(`HTTP ${response.status}`)
+    } catch (error) {
+      lastError = error
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 500))
+  }
+
+  fail(`timed out waiting for ${url}: ${lastError?.message ?? "no response"}`)
+}
+
+async function stopDevServer(server) {
+  if (!server) return
+
+  const { child, logStream } = server
+  if (!server.exited() && !child.killed) {
+    child.kill("SIGTERM")
+  }
+
+  if (!server.exited()) {
+    await new Promise((resolve) => {
+      const timeout = setTimeout(resolve, 2_000)
+      child.once("exit", () => {
+        clearTimeout(timeout)
+        resolve()
+      })
+    })
+  }
+
+  await new Promise((resolve) => logStream.end(resolve))
+}
+
+function numberArg(value, fallback, name) {
+  if (value === undefined) return fallback
+
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    fail(`invalid ${name}: ${value}`)
+  }
+
+  return parsed
+}

--- a/scripts/lib/agent-runner-browser-evidence.mjs
+++ b/scripts/lib/agent-runner-browser-evidence.mjs
@@ -1,3 +1,4 @@
+import { mkdirSync, writeFileSync } from "node:fs"
 import path from "node:path"
 
 const uiEvidenceLabels = new Set([
@@ -38,8 +39,10 @@ export function browserArtifactPlan({
     devServerPort,
     devServerUrl: `http://127.0.0.1:${devServerPort}`,
     networkLog: path.join(artifactDir, "network.jsonl"),
+    readme: path.join(artifactDir, "README.md"),
     screenshotDir: path.join(artifactDir, "screenshots"),
     safeArtifactPath: isPathInside(artifactDir, workspace),
+    summaryJson: path.join(artifactDir, "summary.json"),
     videoDir: path.join(artifactDir, "videos"),
     workspace,
     workspaceReference,
@@ -64,6 +67,200 @@ export function browserEvidenceMissingReason(item, uiEvidence) {
   }
 
   return null
+}
+
+export function browserCapturePlan({
+  artifactPlan,
+  screenshotName = "page.png",
+  url = artifactPlan.devServerUrl,
+  viewport,
+}) {
+  const normalizedViewport = normalizeViewport(viewport)
+  const screenshotFile = path.resolve(
+    artifactPlan.screenshotDir,
+    safeScreenshotName(screenshotName),
+  )
+
+  return {
+    artifactPlan,
+    screenshotFile,
+    url,
+    viewport: normalizedViewport,
+  }
+}
+
+export function safeScreenshotName(screenshotName) {
+  if (!screenshotName || path.basename(screenshotName) !== screenshotName) {
+    throw new Error("screenshot name must be a file name without path separators")
+  }
+
+  return screenshotName
+}
+
+export function normalizeViewport(viewport) {
+  if (!viewport) return { height: 900, width: 1440 }
+
+  if (typeof viewport === "string") {
+    const match = viewport.match(/^(\d+)x(\d+)$/)
+    if (!match) {
+      throw new Error(`invalid viewport: ${viewport}; expected <width>x<height>`)
+    }
+    return viewportSize({ height: Number(match[2]), width: Number(match[1]) })
+  }
+
+  return viewportSize(viewport)
+}
+
+export async function captureBrowserEvidence({ browserLauncher, capturePlan, timeoutMs = 30_000 }) {
+  if (!browserLauncher?.launch) {
+    throw new Error("browser launcher with launch() is required")
+  }
+
+  const { artifactPlan, screenshotFile, url, viewport } = capturePlan
+  mkdirSync(artifactPlan.artifactDir, { recursive: true })
+  mkdirSync(artifactPlan.screenshotDir, { recursive: true })
+  mkdirSync(artifactPlan.videoDir, { recursive: true })
+  writeFileSync(artifactPlan.consoleLog, "", "utf8")
+  writeFileSync(artifactPlan.networkLog, "", "utf8")
+
+  const browser = await browserLauncher.launch({ headless: true })
+  let context
+  let page
+  let videoPath
+
+  try {
+    context = await browser.newContext({
+      recordVideo: {
+        dir: artifactPlan.videoDir,
+        size: viewport,
+      },
+      viewport,
+    })
+    page = await context.newPage()
+    wireBrowserEvidenceEvents({ artifactPlan, page })
+
+    await page.goto(url, { timeout: timeoutMs, waitUntil: "networkidle" })
+    await page.screenshot({ fullPage: true, path: screenshotFile })
+
+    const video = page.video?.()
+    await context.close()
+    context = undefined
+    videoPath = video ? await video.path().catch(() => undefined) : undefined
+  } finally {
+    if (context) await context.close().catch(() => undefined)
+    await browser.close().catch(() => undefined)
+  }
+
+  const result = {
+    artifactPointer: artifactPlan.artifactPointer,
+    consoleLog: artifactPlan.consoleLog,
+    failedRequestLog: artifactPlan.networkLog,
+    screenshot: screenshotFile,
+    url,
+    video: videoPath,
+    viewport,
+  }
+
+  writeFileSync(artifactPlan.summaryJson, `${JSON.stringify(result, null, 2)}\n`, "utf8")
+  writeFileSync(artifactPlan.readme, browserEvidenceMarkdown(result), "utf8")
+
+  return result
+}
+
+export function browserEvidenceText(result) {
+  const lines = [
+    `browser artifacts: ${result.artifactPointer}`,
+    `url: ${result.url}`,
+    `screenshot: ${result.screenshot}`,
+    `console log: ${result.consoleLog}`,
+    `failed-request log: ${result.failedRequestLog}`,
+  ]
+
+  if (result.video) lines.push(`video: ${result.video}`)
+
+  return lines.join("\n")
+}
+
+export function browserEvidenceMarkdown(result) {
+  return `# Browser Evidence
+
+URL: ${result.url}
+Artifacts: ${result.artifactPointer}
+Viewport: ${result.viewport.width}x${result.viewport.height}
+
+## Files
+
+- Screenshot: ${result.screenshot}
+- Console log: ${result.consoleLog}
+- Failed-request log: ${result.failedRequestLog}
+${result.video ? `- Video: ${result.video}\n` : ""}
+`
+}
+
+function wireBrowserEvidenceEvents({ artifactPlan, page }) {
+  page.on("console", (message) => {
+    appendJsonLine(artifactPlan.consoleLog, {
+      location: message.location?.(),
+      text: message.text(),
+      timestamp: new Date().toISOString(),
+      type: message.type(),
+    })
+  })
+
+  page.on("pageerror", (error) => {
+    appendJsonLine(artifactPlan.consoleLog, {
+      message: error.message,
+      name: error.name,
+      stack: error.stack,
+      timestamp: new Date().toISOString(),
+      type: "pageerror",
+    })
+  })
+
+  page.on("requestfailed", (request) => {
+    appendJsonLine(artifactPlan.networkLog, {
+      failure: request.failure?.()?.errorText,
+      method: request.method(),
+      resourceType: request.resourceType(),
+      timestamp: new Date().toISOString(),
+      type: "requestfailed",
+      url: request.url(),
+    })
+  })
+
+  page.on("response", (response) => {
+    if (response.status() < 400) return
+
+    const request = response.request()
+    appendJsonLine(artifactPlan.networkLog, {
+      method: request.method(),
+      resourceType: request.resourceType(),
+      status: response.status(),
+      statusText: response.statusText(),
+      timestamp: new Date().toISOString(),
+      type: "http-error",
+      url: response.url(),
+    })
+  })
+}
+
+function appendJsonLine(filePath, value) {
+  writeFileSync(filePath, `${JSON.stringify(value)}\n`, { encoding: "utf8", flag: "a" })
+}
+
+function viewportSize(viewport) {
+  const width = Number(viewport.width)
+  const height = Number(viewport.height)
+
+  if (!Number.isInteger(width) || width < 320 || width > 7680) {
+    throw new Error(`invalid viewport width: ${String(viewport.width)}`)
+  }
+
+  if (!Number.isInteger(height) || height < 240 || height > 4320) {
+    throw new Error(`invalid viewport height: ${String(viewport.height)}`)
+  }
+
+  return { height, width }
 }
 
 function isPathInside(candidatePath, parentPath) {

--- a/scripts/tests/agent-runner-browser-evidence.test.mjs
+++ b/scripts/tests/agent-runner-browser-evidence.test.mjs
@@ -1,12 +1,18 @@
 import assert from "node:assert/strict"
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import os from "node:os"
 import path from "node:path"
 import { describe, it } from "node:test"
 
 import {
   browserArtifactPlan,
+  browserCapturePlan,
   browserEvidenceEnvironment,
   browserEvidenceMissingReason,
+  browserEvidenceText,
+  captureBrowserEvidence,
   requiresBrowserEvidence,
+  safeScreenshotName,
 } from "../lib/agent-runner-browser-evidence.mjs"
 import {
   buildCommandEvidencePacket,
@@ -57,9 +63,15 @@ describe("agent runner browser evidence helpers", () => {
       networkLog: path.resolve(
         "/repo/.agent-worktrees/579-test-agent-project-intake-workflow/docs/agent-evidence/browser/579-test-agent-project-intake-workflow/2026-05-10T12-34-56-000Z/network.jsonl",
       ),
+      readme: path.resolve(
+        "/repo/.agent-worktrees/579-test-agent-project-intake-workflow/docs/agent-evidence/browser/579-test-agent-project-intake-workflow/2026-05-10T12-34-56-000Z/README.md",
+      ),
       safeArtifactPath: true,
       screenshotDir: path.resolve(
         "/repo/.agent-worktrees/579-test-agent-project-intake-workflow/docs/agent-evidence/browser/579-test-agent-project-intake-workflow/2026-05-10T12-34-56-000Z/screenshots",
+      ),
+      summaryJson: path.resolve(
+        "/repo/.agent-worktrees/579-test-agent-project-intake-workflow/docs/agent-evidence/browser/579-test-agent-project-intake-workflow/2026-05-10T12-34-56-000Z/summary.json",
       ),
       videoDir: path.resolve(
         "/repo/.agent-worktrees/579-test-agent-project-intake-workflow/docs/agent-evidence/browser/579-test-agent-project-intake-workflow/2026-05-10T12-34-56-000Z/videos",
@@ -166,4 +178,154 @@ describe("agent runner browser evidence helpers", () => {
     )
     assert.equal(commandRunBrowserEvidenceBlockReason({ exitCode: 1, item }), null)
   })
+
+  it("keeps screenshot names inside the screenshot artifact directory", () => {
+    assert.equal(safeScreenshotName("after.png"), "after.png")
+    assert.throws(() => safeScreenshotName("../outside.md"), /screenshot name must be a file name/)
+    assert.throws(
+      () =>
+        browserCapturePlan({
+          artifactPlan: browserArtifactPlan({
+            item: workItem(),
+            repoRoot: "/repo",
+            workspaceReference: ".agent-worktrees/task",
+          }),
+          screenshotName: "../outside.md",
+        }),
+      /screenshot name must be a file name/,
+    )
+  })
+
+  it("captures browser evidence through an injected browser launcher", async () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "voyant-browser-evidence-"))
+    try {
+      const item = workItem()
+      const artifactPlan = browserArtifactPlan({
+        date: new Date("2026-05-10T12:34:56.000Z"),
+        item,
+        repoRoot: tempDir,
+        workspaceReference: ".",
+      })
+      const capturePlan = browserCapturePlan({
+        artifactPlan,
+        url: "http://127.0.0.1:4879/dashboard",
+        viewport: "390x844",
+      })
+
+      const result = await captureBrowserEvidence({
+        browserLauncher: new FakeBrowserLauncher(),
+        capturePlan,
+        timeoutMs: 1000,
+      })
+
+      assert.equal(result.viewport.width, 390)
+      assert.equal(result.viewport.height, 844)
+      assert.equal(result.url, "http://127.0.0.1:4879/dashboard")
+      assert.equal(existsSync(result.screenshot), true)
+      assert.match(readFileSync(artifactPlan.consoleLog, "utf8"), /loaded dashboard/)
+      assert.match(readFileSync(artifactPlan.networkLog, "utf8"), /http-error/)
+      assert.match(readFileSync(artifactPlan.summaryJson, "utf8"), /390/)
+      assert.match(readFileSync(artifactPlan.readme, "utf8"), /Browser Evidence/)
+      assert.match(browserEvidenceText(result), /failed-request log:/)
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true })
+    }
+  })
 })
+
+class FakeBrowserLauncher {
+  async launch(options) {
+    this.options = options
+    return new FakeBrowser()
+  }
+}
+
+class FakeBrowser {
+  async newContext(options) {
+    this.context = new FakeContext(options)
+    return this.context
+  }
+
+  async close() {
+    this.closed = true
+  }
+}
+
+class FakeContext {
+  constructor(options) {
+    this.options = options
+  }
+
+  async newPage() {
+    return new FakePage(this.options)
+  }
+
+  async close() {
+    this.closed = true
+  }
+}
+
+class FakePage {
+  #handlers = new Map()
+
+  constructor(options) {
+    this.options = options
+  }
+
+  on(eventName, handler) {
+    const handlers = this.#handlers.get(eventName) ?? []
+    handlers.push(handler)
+    this.#handlers.set(eventName, handlers)
+  }
+
+  async goto(url, options) {
+    this.gotoOptions = { options, url }
+    this.#emit("console", {
+      location: () => ({ columnNumber: 1, lineNumber: 1, url }),
+      text: () => "loaded dashboard",
+      type: () => "log",
+    })
+    this.#emit("response", new FakeResponse(`${url}/missing.css`))
+  }
+
+  async screenshot(options) {
+    writeFileSync(options.path, "fake screenshot", "utf8")
+  }
+
+  video() {
+    return {
+      path: async () => path.join(this.options.recordVideo.dir, "capture.webm"),
+    }
+  }
+
+  #emit(eventName, value) {
+    for (const handler of this.#handlers.get(eventName) ?? []) {
+      handler(value)
+    }
+  }
+}
+
+class FakeResponse {
+  constructor(url) {
+    this.responseUrl = url
+  }
+
+  request() {
+    return {
+      method: () => "GET",
+      resourceType: () => "stylesheet",
+    }
+  }
+
+  status() {
+    return 404
+  }
+
+  statusText() {
+    return "Not Found"
+  }
+
+  url() {
+    return this.responseUrl
+  }
+}


### PR DESCRIPTION
## Summary
- add `agent:queue:capture-browser` for UI evidence capture in claimed workspaces
- start an optional dev server, wait for the target URL, and capture screenshot/video/console/failed-request artifacts
- write browser artifact summaries and print a `--ui-evidence` value for handoff or supervised command completion
- add Playwright as the root browser harness dependency
- update the agent workflow docs and Phase 3 status

## Validation
- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm verify:architecture`
- `pnpm exec biome check scripts/lib/agent-runner-browser-evidence.mjs scripts/agent-runner-capture-browser.mjs scripts/tests/agent-runner-browser-evidence.test.mjs package.json docs/agents/issue-tracker.md .agents/WORKFLOW.md docs/architecture/agentic-engineering-orchestration.md`
- `pnpm exec secretlint .agents/WORKFLOW.md docs/agents/issue-tracker.md docs/architecture/agentic-engineering-orchestration.md package.json pnpm-lock.yaml scripts/agent-runner-capture-browser.mjs scripts/lib/agent-runner-browser-evidence.mjs scripts/tests/agent-runner-browser-evidence.test.mjs`
- `node --check scripts/lib/agent-runner-browser-evidence.mjs && node --check scripts/agent-runner-capture-browser.mjs && node --check scripts/tests/agent-runner-browser-evidence.test.mjs`
- `pnpm agent:queue:capture-browser -- --help`
- real Playwright smoke against a data URL using `captureBrowserEvidence(...)`
- pre-push `pnpm test`
