### PR TITLE
Surface browser evidence queue work

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -169,7 +169,9 @@ pnpm agent:queue:status
 Status mode scans all Project pages for the current repository and reports
 ready, active, stale, blocked, human-review, and merge-ready items. Pass
 `--json` for automation or `--max-age-days <number>` to adjust the heartbeat
-staleness threshold.
+staleness threshold. For UI-labeled work, status distinguishes browser artifact
+references from generic transcript or evidence fields so active runs do not
+hide missing browser capture.
 
 Use the read-only tick view when wiring an always-on supervisor:
 
@@ -178,10 +180,11 @@ pnpm agent:queue:tick
 ```
 
 Tick mode scans the same repository-scoped Project queue and prints ordered
-action recommendations such as `start`, `run-command`, `publish-evidence`,
-`open-pr`, `sync-pr`, `cleanup`, or `inspect-stale`. It does not mutate GitHub,
-create worktrees, run commands, publish evidence, or open PRs. Pass `--json`
-when a process manager or future control plane needs machine-readable actions.
+action recommendations such as `start`, `run-command`, `capture-browser`,
+`publish-evidence`, `open-pr`, `sync-pr`, `cleanup`, or `inspect-stale`. It
+does not mutate GitHub, create worktrees, run commands, publish evidence, or
+open PRs. Pass `--json` when a process manager or future control plane needs
+machine-readable actions.
 
 Use dispatch to execute one allow-listed tick recommendation:
 
@@ -193,10 +196,11 @@ Dispatch mode re-reads the Project, selects the highest-priority dispatchable
 recommendation, and runs one lifecycle command. It is dry-run by default. Pass
 `--issue <number>` or `--action <name>` to narrow selection. Dispatch can run
 `start`, `publish-evidence`, `open-pr`, `sync-pr`, and `cleanup`; it refuses
-`run-command`, `inspect-stale`, blocked work, and wait states so implementation
-execution remains explicit. Successful dispatch attempts append local JSONL
-audit events to `.agent-runs/events.jsonl` by default; pass `--event-log <path>`
-when a supervisor needs a different local ledger path.
+`run-command`, `capture-browser`, `inspect-stale`, blocked work, and wait states
+so implementation and browser execution remain explicit. Successful dispatch
+attempts append local JSONL audit events to `.agent-runs/events.jsonl` by
+default; pass `--event-log <path>` when a supervisor needs a different local
+ledger path.
 
 Use loop for a bounded supervisor pass:
 

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1096,6 +1096,9 @@ supervised commands through `VOYANT_AGENT_*` environment variables, rejects
 handoff and successful run-command transitions for UI-labeled work that lacks
 browser evidence or an accepted exception, and provides a Playwright capture
 command for screenshot, video, console, failed-request, and summary artifacts.
+Queue status and tick output also surface browser-evidence obligations for
+active UI work; capture recommendations remain explicit and are not dispatched
+automatically.
 
 Verification:
 

--- a/scripts/agent-runner-status.mjs
+++ b/scripts/agent-runner-status.mjs
@@ -7,6 +7,10 @@ import {
   projectScanConfigFromArgs,
   runGit,
 } from "./lib/agent-project-queue.mjs"
+import {
+  browserEvidenceReferenceKind,
+  requiresBrowserEvidence,
+} from "./lib/agent-runner-browser-evidence.mjs"
 import { maybePrintHelp, projectOptions, repositoryOptions } from "./lib/agent-runner-help.mjs"
 import { evaluateHeartbeat } from "./lib/agent-runner-output.mjs"
 
@@ -119,9 +123,24 @@ function printSection(title, sectionItems, extraPrinter) {
     console.log(`- #${item.issue.number} ${item.issue.title}`)
     console.log(`  state: ${item.fields["Agent State"] ?? "unset"}`)
     console.log(`  url: ${item.issue.url}`)
+    printBrowserEvidenceStatus(item)
     if (extraPrinter) extraPrinter(item)
   }
   console.log("")
+}
+
+function printBrowserEvidenceStatus(item) {
+  if (!requiresBrowserEvidence(item)) return
+
+  const referenceKind = browserEvidenceReferenceKind(item.fields.Evidence)
+  console.log(`  browser evidence: required; ${browserEvidenceStatusText(referenceKind)}`)
+}
+
+function browserEvidenceStatusText(referenceKind) {
+  if (referenceKind === "browser-artifacts") return "browser artifact reference is present"
+  if (referenceKind === "evidence-packet") return "inspect evidence packet for browser artifacts"
+  if (referenceKind === "generic") return "Evidence field is not a browser artifact"
+  return "Evidence field is empty"
 }
 
 function printHeartbeat(item) {
@@ -130,6 +149,9 @@ function printHeartbeat(item) {
 }
 
 function summaryItem(item) {
+  const browserEvidenceRequired = requiresBrowserEvidence(item)
+  const browserEvidenceKind = browserEvidenceReferenceKind(item.fields.Evidence)
+
   return {
     issue: item.issue,
     agentState: item.fields["Agent State"] ?? null,
@@ -140,5 +162,10 @@ function summaryItem(item) {
     workspace: item.fields.Workspace ?? null,
     pr: item.fields.PR ?? null,
     evidence: item.fields.Evidence ?? null,
+    browserEvidence: {
+      required: browserEvidenceRequired,
+      referenceKind: browserEvidenceKind,
+      browserArtifactReferencePresent: browserEvidenceKind === "browser-artifacts",
+    },
   }
 }

--- a/scripts/lib/agent-runner-browser-evidence.mjs
+++ b/scripts/lib/agent-runner-browser-evidence.mjs
@@ -69,6 +69,21 @@ export function browserEvidenceMissingReason(item, uiEvidence) {
   return null
 }
 
+export function browserEvidenceReferenceKind(evidence) {
+  const normalized = evidence?.trim()
+  if (!normalized) return "missing"
+
+  if (/docs\/agent-evidence\/browser\//.test(normalized)) {
+    return "browser-artifacts"
+  }
+
+  if (/^https?:\/\//.test(normalized) || /docs\/agent-evidence\/active\//.test(normalized)) {
+    return "evidence-packet"
+  }
+
+  return "generic"
+}
+
 export function browserCapturePlan({
   artifactPlan,
   screenshotName = "page.png",

--- a/scripts/lib/agent-runner-tick.mjs
+++ b/scripts/lib/agent-runner-tick.mjs
@@ -1,3 +1,7 @@
+import {
+  browserEvidenceReferenceKind,
+  requiresBrowserEvidence,
+} from "./agent-runner-browser-evidence.mjs"
 import { evaluateHeartbeat } from "./agent-runner-output.mjs"
 
 const runnableStates = new Set(["Planning", "Changes Requested", "CI Repair"])
@@ -53,6 +57,11 @@ export function recommendQueueAction(item, { maxAgeDays, repository }) {
       priority: 20,
       reason: "maintainer-approved item is ready to claim",
     })
+  }
+
+  const browserRecommendation = browserEvidenceRecommendation(item, { heartbeat, repository })
+  if (browserRecommendation) {
+    return browserRecommendation
   }
 
   if (runnableStates.has(state)) {
@@ -124,6 +133,11 @@ function humanReviewRecommendation(item, { heartbeat, repository }) {
   const evidence = item.fields.Evidence
   const pr = item.fields.PR
 
+  if (!evidence) {
+    const browserRecommendation = browserEvidenceRecommendation(item, { heartbeat, repository })
+    if (browserRecommendation) return browserRecommendation
+  }
+
   if (pr) {
     return recommendation(item, {
       action: "sync-pr",
@@ -165,6 +179,38 @@ function humanReviewRecommendation(item, { heartbeat, repository }) {
     priority: 60,
     reason: "local evidence should be published before opening a PR",
   })
+}
+
+function browserEvidenceRecommendation(item, { heartbeat, repository }) {
+  const state = item.fields["Agent State"]
+  if (
+    !requiresBrowserEvidence(item) ||
+    browserEvidenceCovered(item.fields.Evidence) ||
+    !item.fields.Workspace
+  ) {
+    return null
+  }
+
+  if (!["Changes Requested", "CI Repair", "Human Review", "Running"].includes(state)) {
+    return null
+  }
+
+  return recommendation(item, {
+    action: "capture-browser",
+    command: commandWithIssue({
+      command: "capture-browser",
+      extraArgs: ['--dev-server-command "<dev-server-command>"'],
+      issueNumber: item.issue.number,
+      repository,
+    }),
+    heartbeat,
+    priority: state === "Human Review" ? 54 : 35,
+    reason: "UI-labeled work needs browser evidence before handoff",
+  })
+}
+
+function browserEvidenceCovered(evidence) {
+  return ["browser-artifacts", "evidence-packet"].includes(browserEvidenceReferenceKind(evidence))
 }
 
 function recommendation(item, { action, command, heartbeat = null, priority, reason }) {

--- a/scripts/tests/agent-runner-browser-evidence.test.mjs
+++ b/scripts/tests/agent-runner-browser-evidence.test.mjs
@@ -9,6 +9,7 @@ import {
   browserCapturePlan,
   browserEvidenceEnvironment,
   browserEvidenceMissingReason,
+  browserEvidenceReferenceKind,
   browserEvidenceText,
   captureBrowserEvidence,
   requiresBrowserEvidence,
@@ -38,6 +39,24 @@ describe("agent runner browser evidence helpers", () => {
       null,
     )
     assert.equal(requiresBrowserEvidence(workItem()), false)
+  })
+
+  it("classifies browser evidence references separately from generic evidence", () => {
+    assert.equal(browserEvidenceReferenceKind(undefined), "missing")
+    assert.equal(
+      browserEvidenceReferenceKind(
+        "browser artifacts: docs/agent-evidence/browser/579-test/2026-05-10T12-34-56-000Z",
+      ),
+      "browser-artifacts",
+    )
+    assert.equal(
+      browserEvidenceReferenceKind("docs/agent-evidence/active/579-test.md"),
+      "evidence-packet",
+    )
+    assert.equal(
+      browserEvidenceReferenceKind(".agent-runs/579-test/2026-05-10T12-34-56-000Z.log"),
+      "generic",
+    )
   })
 
   it("allocates deterministic per-workspace browser artifact paths", () => {

--- a/scripts/tests/agent-runner-dispatch.test.mjs
+++ b/scripts/tests/agent-runner-dispatch.test.mjs
@@ -96,6 +96,28 @@ describe("agent runner dispatch helpers", () => {
       recommendation: null,
       reason: "no dispatchable recommendation matched",
     })
+
+    const uiItem = workItem({
+      fields: {
+        "Agent State": "Changes Requested",
+        "Last Heartbeat": new Date().toISOString().slice(0, 10),
+        Workspace: ".agent-worktrees/579-test-agent-project-intake-workflow",
+      },
+    })
+    uiItem.issue.labels = ["agent:ready", "ui-change"]
+
+    assert.deepEqual(
+      selectDispatchRecommendation([
+        recommendQueueAction(uiItem, {
+          maxAgeDays: 1,
+          repository: "voyantjs/other",
+        }),
+      ]),
+      {
+        recommendation: null,
+        reason: "no dispatchable recommendation matched",
+      },
+    )
   })
 
   it("rejects invalid issue filters before selecting a recommendation", () => {

--- a/scripts/tests/agent-runner-tick.test.mjs
+++ b/scripts/tests/agent-runner-tick.test.mjs
@@ -80,4 +80,58 @@ describe("agent runner tick helpers", () => {
       "pnpm agent:queue:cleanup -- --issue 579 --repo voyantjs/other --yes",
     )
   })
+
+  it("recommends browser capture for active UI work before handoff", () => {
+    const item = workItem({
+      fields: {
+        "Agent State": "Changes Requested",
+        "Last Heartbeat": new Date().toISOString().slice(0, 10),
+        Workspace: ".agent-worktrees/579-test-agent-project-intake-workflow",
+      },
+    })
+    item.issue.labels = ["agent:ready", "ui-change"]
+
+    const recommendation = recommendQueueAction(item, {
+      maxAgeDays: 1,
+      repository: "voyantjs/other",
+    })
+    assert.equal(recommendation.action, "capture-browser")
+    assert.equal(
+      recommendation.command,
+      'pnpm agent:queue:capture-browser -- --issue 579 --repo voyantjs/other --dev-server-command "<dev-server-command>" --yes',
+    )
+    assert.equal(recommendation.heartbeat.stale, false)
+    assert.equal(recommendation.priority, 35)
+    assert.equal(recommendation.reason, "UI-labeled work needs browser evidence before handoff")
+
+    const transcriptItem = workItem({
+      fields: {
+        "Agent State": "Running",
+        Evidence: ".agent-runs/579-test/2026-05-10T12-34-56-000Z.log",
+        "Last Heartbeat": new Date().toISOString().slice(0, 10),
+        Workspace: ".agent-worktrees/579-test-agent-project-intake-workflow",
+      },
+    })
+    transcriptItem.issue.labels = ["agent:ready", "ui-change"]
+
+    assert.equal(
+      recommendQueueAction(transcriptItem, { maxAgeDays: 1, repository: "voyantjs/other" }).action,
+      "capture-browser",
+    )
+
+    const capturedItem = workItem({
+      fields: {
+        "Agent State": "Changes Requested",
+        Evidence: "docs/agent-evidence/active/579-test.md",
+        "Last Heartbeat": new Date().toISOString().slice(0, 10),
+        Workspace: ".agent-worktrees/579-test-agent-project-intake-workflow",
+      },
+    })
+    capturedItem.issue.labels = ["agent:ready", "ui-change"]
+
+    assert.equal(
+      recommendQueueAction(capturedItem, { maxAgeDays: 1, repository: "voyantjs/other" }).action,
+      "run-command",
+    )
+  })
 })


### PR DESCRIPTION
## Summary
- add a non-dispatchable `capture-browser` recommendation for active UI-labeled queue items with a workspace and no evidence
- show browser-evidence requirements in the queue status JSON and human output
- document that dispatch keeps browser capture explicit

## Verification
- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `node --check scripts/lib/agent-runner-tick.mjs`
- `node --check scripts/agent-runner-status.mjs`
- `node --check scripts/tests/agent-runner-tick.test.mjs`
- `node --check scripts/tests/agent-runner-dispatch.test.mjs`
- `pnpm exec secretlint docs/agents/issue-tracker.md docs/architecture/agentic-engineering-orchestration.md scripts/agent-runner-status.mjs scripts/lib/agent-runner-tick.mjs scripts/tests/agent-runner-dispatch.test.mjs scripts/tests/agent-runner-tick.test.mjs`
- `pnpm test`