### PR TITLE
Define workspace reference contract

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -127,6 +127,11 @@ execution plan, then updates the Project item to `Agent State = Planning`.
 It still does not run an implementation agent, push a branch, open a PR, or
 publish evidence.
 
+The `Workspace` Project field is typed by convention. Local runner commands use
+`.agent-worktrees/<issue-number>-<slug>`. Future remote adapters use
+`sandbox:<provider>:<id>` and must not be interpreted as local filesystem
+paths. Cleanup only removes local worktrees under `.agent-worktrees/`.
+
 After start, run a supervised provider-neutral command in the claimed
 workspace:
 
@@ -141,10 +146,11 @@ ignored transcript under `.agent-runs/`, writes an evidence packet inside the
 workspace, then moves the item to `Human Review` on exit code `0` or `Blocked`
 on nonzero exit. The command receives `VOYANT_AGENT_*` environment variables
 for the issue, branch, workspace, plan path, evidence path, log path, repository,
-verification lane, and browser artifact location. Successful UI-labeled runs
-must pass `--ui-evidence <text>` or they are blocked instead of moved to
-`Human Review`; nonzero exits are still blocked by the command failure. It does
-not push branches, open PRs, or publish evidence comments.
+verification lane, workspace descriptor, and browser artifact location.
+Successful UI-labeled runs must pass `--ui-evidence <text>` or they are blocked
+instead of moved to `Human Review`; nonzero exits are still blocked by the
+command failure. It does not push branches, open PRs, or publish evidence
+comments.
 
 For UI work, capture browser evidence before handoff or before a successful
 `run-command` transition:

--- a/docs/agents/project-fields.md
+++ b/docs/agents/project-fields.md
@@ -12,7 +12,7 @@ Recommended GitHub Project fields for `Voyant Engineering`.
 | `Verification Lane` | Single select | `package`, `verify:fast`, `verify:full`, `custom`. |
 | `Triage Provider` | Single select | Intake model or `manual`. |
 | `Agent Provider` | Single select | `codex`, `claude`, `manual`, `none`. |
-| `Workspace` | Text | Local path or sandbox id. |
+| `Workspace` | Text | Local worktree path or remote sandbox reference. |
 | `Branch` | Text | Work branch. |
 | `PR` | Text | Pull request URL. |
 | `Last Heartbeat` | Date | Staleness detection. |
@@ -35,6 +35,18 @@ Recommended GitHub Project fields for `Voyant Engineering`.
 
 Only maintainers move an item to `Ready`. Merge remains a maintainer decision
 unless a separate maintainer-approved merge automation is introduced.
+
+## Workspace Values
+
+The runner treats `Workspace` as a typed reference, not arbitrary prose:
+
+- Local worktree: `.agent-worktrees/<issue-number>-<slug>`
+- Remote sandbox: `sandbox:<provider>:<id>`
+
+Local commands currently execute only against local worktrees. Remote sandbox
+references are reserved for the Phase 5 adapter contract and must not be
+treated as filesystem paths. Cleanup only removes local worktrees under
+`.agent-worktrees/`.
 
 ## Status Values
 

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -577,7 +577,7 @@ Recommended fields:
 | `Verification Lane` | Single select | `package`, `verify:fast`, `verify:full`, `custom`. |
 | `Triage Provider` | Single select | Cheap intake model or `manual`. |
 | `Agent Provider` | Single select | `codex`, `claude`, `manual`, `none`. |
-| `Workspace` | Text | Local path or sandbox id. |
+| `Workspace` | Text | Local worktree path or remote sandbox reference. |
 | `Branch` | Text | Current work branch. |
 | `PR` | Text | Pull request URL. |
 | `Last Heartbeat` | Date | Staleness detection. |
@@ -802,12 +802,18 @@ behavior. They may solve local RAM pressure and allow work to keep running
 without a developer laptop.
 
 The runner should treat Sprites as one adapter behind the same workspace
-interface:
+interface. The GitHub Project `Workspace` field should use one of two typed
+references: `.agent-worktrees/<issue-number>-<slug>` for local worktrees, or
+`sandbox:<provider>:<id>` for remote sandboxes. Runner code must parse the
+reference before acting on it; a remote sandbox reference must not be resolved
+as a local path.
 
 ```ts
 interface AgentWorkspace {
   id: string
-  kind: "local-worktree" | "sprite"
+  kind: "local-worktree" | "remote-sandbox"
+  provider?: string
+  reference: string
   cwd: string
   branch: string
   exec(command: WorkspaceCommand): Promise<WorkspaceCommandResult>
@@ -1129,6 +1135,8 @@ Verification:
 
 Deliverables:
 
+- Define and enforce the workspace reference contract shared by local worktrees
+  and remote sandboxes.
 - Add the first remote sandbox adapter behind the same workspace interface,
   likely `SpriteWorkspace` unless another provider proves better during the
   pilot.

--- a/scripts/lib/agent-runner-execution.mjs
+++ b/scripts/lib/agent-runner-execution.mjs
@@ -7,6 +7,10 @@ import {
   requiresBrowserEvidence,
 } from "./agent-runner-browser-evidence.mjs"
 import { ciRepairEvidenceEnvironment, resolveCiRepairEvidencePath } from "./agent-runner-ci.mjs"
+import {
+  parseWorkspaceReference,
+  workspaceDescriptorEnvironment,
+} from "./agent-runner-workspace-contract.mjs"
 
 export const commandRunStates = new Set(["Planning", "Running", "Changes Requested", "CI Repair"])
 
@@ -51,6 +55,9 @@ export function commandRunEnvironment({ artifactPlan, branch, item, repository }
     repoRoot: artifactPlan.repoRoot,
     workspaceReference: artifactPlan.workspaceReference,
   })
+  const workspaceDescriptor = parseWorkspaceReference(artifactPlan.workspaceReference, {
+    repoRoot: artifactPlan.repoRoot,
+  })
 
   return {
     ...browserEvidenceEnvironment({ artifactPlan: browserPlan }),
@@ -58,6 +65,7 @@ export function commandRunEnvironment({ artifactPlan, branch, item, repository }
       evidenceReference: item.fields.Evidence,
       repoRoot: artifactPlan.repoRoot,
     }),
+    ...workspaceDescriptorEnvironment(workspaceDescriptor),
     VOYANT_AGENT_BRANCH: branch,
     VOYANT_AGENT_EVIDENCE_PATH: artifactPlan.evidenceFile,
     VOYANT_AGENT_EVIDENCE_REFERENCE: artifactPlan.evidencePointer,

--- a/scripts/lib/agent-runner-workspace-contract.mjs
+++ b/scripts/lib/agent-runner-workspace-contract.mjs
@@ -1,0 +1,71 @@
+import path from "node:path"
+
+export const localWorkspaceKind = "local-worktree"
+export const remoteWorkspaceKind = "remote-sandbox"
+
+const remoteWorkspacePattern = /^sandbox:([a-z][a-z0-9-]{0,31}):([A-Za-z0-9][A-Za-z0-9._-]{0,127})$/
+
+export function parseWorkspaceReference(reference, { repoRoot }) {
+  if (typeof reference !== "string" || reference.trim().length === 0) {
+    return invalidWorkspace(reference, "workspace reference is empty")
+  }
+
+  const normalizedReference = reference.trim()
+  const remoteMatch = normalizedReference.match(remoteWorkspacePattern)
+  if (remoteMatch) {
+    return {
+      id: remoteMatch[2],
+      kind: remoteWorkspaceKind,
+      provider: remoteMatch[1],
+      reference: normalizedReference,
+    }
+  }
+
+  const workspace = path.resolve(repoRoot, normalizedReference)
+  const localRoot = path.resolve(repoRoot, ".agent-worktrees")
+
+  return {
+    agentWorktreeRoot: localRoot,
+    id: path.basename(workspace),
+    kind: localWorkspaceKind,
+    provider: null,
+    reference: normalizedReference,
+    safeLocalWorkspace: isPathInside(workspace, localRoot),
+    workspace,
+  }
+}
+
+export function workspaceDescriptorEnvironment(descriptor) {
+  const environment = {
+    VOYANT_AGENT_WORKSPACE_ID: descriptor.id ?? "",
+    VOYANT_AGENT_WORKSPACE_KIND: descriptor.kind,
+    VOYANT_AGENT_WORKSPACE_PROVIDER:
+      descriptor.kind === remoteWorkspaceKind ? descriptor.provider : "",
+    VOYANT_AGENT_WORKSPACE_REFERENCE: descriptor.reference ?? "",
+  }
+
+  return environment
+}
+
+export function isLocalWorkspaceDescriptor(descriptor) {
+  return descriptor.kind === localWorkspaceKind
+}
+
+export function isRemoteWorkspaceDescriptor(descriptor) {
+  return descriptor.kind === remoteWorkspaceKind
+}
+
+function invalidWorkspace(reference, reason) {
+  return {
+    id: null,
+    kind: "invalid",
+    provider: null,
+    reason,
+    reference,
+  }
+}
+
+function isPathInside(candidatePath, parentPath) {
+  const relative = path.relative(parentPath, candidatePath)
+  return Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative)
+}

--- a/scripts/lib/agent-runner-workspace.mjs
+++ b/scripts/lib/agent-runner-workspace.mjs
@@ -2,6 +2,10 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs"
 import path from "node:path"
 
 import { fail, runGit } from "./agent-project-queue.mjs"
+import {
+  isLocalWorkspaceDescriptor,
+  parseWorkspaceReference,
+} from "./agent-runner-workspace-contract.mjs"
 
 export function workspacePlan({ baseRef = "origin/main", item, repoRoot }) {
   const workspace = path.resolve(repoRoot, item.dryRunPlan.workspace)
@@ -17,14 +21,14 @@ export function workspacePlan({ baseRef = "origin/main", item, repoRoot }) {
 
 export function cleanupWorkspacePlan({ item, repoRoot, workspaceReference }) {
   const reference = workspaceReference ?? item.fields.Workspace ?? item.dryRunPlan.workspace
-  const workspace = path.resolve(repoRoot, reference)
-  const agentWorktreeRoot = path.resolve(repoRoot, ".agent-worktrees")
+  const descriptor = parseWorkspaceReference(reference, { repoRoot })
 
   return {
     workspaceReference: reference,
-    workspace,
-    agentWorktreeRoot,
-    safeWorkspace: isPathInside(workspace, agentWorktreeRoot),
+    workspace: descriptor.workspace ?? null,
+    agentWorktreeRoot: descriptor.agentWorktreeRoot ?? path.resolve(repoRoot, ".agent-worktrees"),
+    safeWorkspace: isLocalWorkspaceDescriptor(descriptor) && descriptor.safeLocalWorkspace,
+    workspaceDescriptor: descriptor,
   }
 }
 
@@ -64,11 +68,6 @@ export function prepareWorkspace({ baseRef = "origin/main", item, repoRoot }) {
   writeFileSync(plan.planPath, buildExecutionPlan(item, plan), "utf8")
 
   return plan
-}
-
-function isPathInside(candidatePath, parentPath) {
-  const relative = path.relative(parentPath, candidatePath)
-  return Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative)
 }
 
 export function assertWorkspaceAvailable({ branch, repoRoot, workspace }) {

--- a/scripts/tests/agent-runner-lifecycle.test.mjs
+++ b/scripts/tests/agent-runner-lifecycle.test.mjs
@@ -18,6 +18,10 @@ import {
   removeWorkspace,
   workspacePlan,
 } from "../lib/agent-runner-workspace.mjs"
+import {
+  parseWorkspaceReference,
+  workspaceDescriptorEnvironment,
+} from "../lib/agent-runner-workspace-contract.mjs"
 import { workItem } from "./agent-fixtures.mjs"
 
 describe("agent runner lifecycle helpers", () => {
@@ -59,6 +63,15 @@ describe("agent runner lifecycle helpers", () => {
       workspace: path.resolve("/repo/.agent-worktrees/579-test-agent-project-intake-workflow"),
       agentWorktreeRoot: path.resolve("/repo/.agent-worktrees"),
       safeWorkspace: true,
+      workspaceDescriptor: {
+        agentWorktreeRoot: path.resolve("/repo/.agent-worktrees"),
+        id: "579-test-agent-project-intake-workflow",
+        kind: "local-worktree",
+        provider: null,
+        reference: ".agent-worktrees/579-test-agent-project-intake-workflow",
+        safeLocalWorkspace: true,
+        workspace: path.resolve("/repo/.agent-worktrees/579-test-agent-project-intake-workflow"),
+      },
     })
   })
 
@@ -70,6 +83,68 @@ describe("agent runner lifecycle helpers", () => {
         workspaceReference: "../outside",
       }).safeWorkspace,
       false,
+    )
+  })
+
+  it("does not treat remote sandbox references as local cleanup paths", () => {
+    const plan = cleanupWorkspacePlan({
+      item: workItem(),
+      repoRoot: "/repo",
+      workspaceReference: "sandbox:sprite:task-579",
+    })
+
+    assert.equal(plan.workspace, null)
+    assert.equal(plan.safeWorkspace, false)
+    assert.deepEqual(plan.workspaceDescriptor, {
+      id: "task-579",
+      kind: "remote-sandbox",
+      provider: "sprite",
+      reference: "sandbox:sprite:task-579",
+    })
+  })
+
+  it("parses local and remote workspace references", () => {
+    assert.deepEqual(
+      parseWorkspaceReference(".agent-worktrees/579-test-agent-project-intake-workflow", {
+        repoRoot: "/repo",
+      }),
+      {
+        agentWorktreeRoot: path.resolve("/repo/.agent-worktrees"),
+        id: "579-test-agent-project-intake-workflow",
+        kind: "local-worktree",
+        provider: null,
+        reference: ".agent-worktrees/579-test-agent-project-intake-workflow",
+        safeLocalWorkspace: true,
+        workspace: path.resolve("/repo/.agent-worktrees/579-test-agent-project-intake-workflow"),
+      },
+    )
+
+    assert.deepEqual(parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" }), {
+      id: "task-579",
+      kind: "remote-sandbox",
+      provider: "sprite",
+      reference: "sandbox:sprite:task-579",
+    })
+
+    assert.deepEqual(
+      workspaceDescriptorEnvironment(
+        parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" }),
+      ),
+      {
+        VOYANT_AGENT_WORKSPACE_ID: "task-579",
+        VOYANT_AGENT_WORKSPACE_KIND: "remote-sandbox",
+        VOYANT_AGENT_WORKSPACE_PROVIDER: "sprite",
+        VOYANT_AGENT_WORKSPACE_REFERENCE: "sandbox:sprite:task-579",
+      },
+    )
+
+    assert.equal(
+      workspaceDescriptorEnvironment(
+        parseWorkspaceReference(".agent-worktrees/579-test-agent-project-intake-workflow", {
+          repoRoot: "/repo",
+        }),
+      ).VOYANT_AGENT_WORKSPACE_PROVIDER,
+      "",
     )
   })
 
@@ -178,6 +253,13 @@ describe("agent runner lifecycle helpers", () => {
     assert.equal(env.VOYANT_AGENT_BRANCH, "task/579-test-agent-project-intake-workflow")
     assert.equal(env.VOYANT_AGENT_REPOSITORY, "voyantjs/voyant")
     assert.equal(env.VOYANT_AGENT_VERIFICATION_LANE, "verify:fast")
+    assert.equal(env.VOYANT_AGENT_WORKSPACE_ID, "579-test-agent-project-intake-workflow")
+    assert.equal(env.VOYANT_AGENT_WORKSPACE_KIND, "local-worktree")
+    assert.equal(env.VOYANT_AGENT_WORKSPACE_PROVIDER, "")
+    assert.equal(
+      env.VOYANT_AGENT_WORKSPACE_REFERENCE,
+      ".agent-worktrees/579-test-agent-project-intake-workflow",
+    )
     assert.equal(env.VOYANT_AGENT_CI_REPAIR_EVIDENCE_PATH, undefined)
   })
 


### PR DESCRIPTION
## Summary

- add a typed workspace reference parser for local worktrees and future remote sandboxes
- expose workspace kind/id/reference through supervised command environment variables
- document `Workspace` values as `.agent-worktrees/...` or `sandbox:<provider>:<id>`

## Validation

- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm exec secretlint scripts/lib/agent-runner-workspace-contract.mjs scripts/lib/agent-runner-workspace.mjs scripts/lib/agent-runner-execution.mjs scripts/tests/agent-runner-lifecycle.test.mjs docs/agents/project-fields.md docs/agents/issue-tracker.md docs/architecture/agentic-engineering-orchestration.md`
- `git diff --check`
- commit hook: full lint + typecheck
- push hook: full test lane
