### PR TITLE
Enforce local workspace command references

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -131,6 +131,9 @@ The `Workspace` Project field is typed by convention. Local runner commands use
 `.agent-worktrees/<issue-number>-<slug>`. Future remote adapters use
 `sandbox:<provider>:<id>` and must not be interpreted as local filesystem
 paths. Cleanup only removes local worktrees under `.agent-worktrees/`.
+Until the remote adapter is implemented, local-only commands such as
+`run-command`, `capture-browser`, `handoff`, `publish-evidence`, and `open-pr`
+reject `sandbox:` workspace references instead of resolving them as paths.
 
 After start, run a supervised provider-neutral command in the claimed
 workspace:

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -806,7 +806,9 @@ interface. The GitHub Project `Workspace` field should use one of two typed
 references: `.agent-worktrees/<issue-number>-<slug>` for local worktrees, or
 `sandbox:<provider>:<id>` for remote sandboxes. Runner code must parse the
 reference before acting on it; a remote sandbox reference must not be resolved
-as a local path.
+as a local path. Until a remote adapter owns execution, browser capture,
+handoff, evidence publishing, and PR publishing, those local-only commands must
+reject `sandbox:` workspace references explicitly.
 
 ```ts
 interface AgentWorkspace {

--- a/scripts/agent-runner-handoff.mjs
+++ b/scripts/agent-runner-handoff.mjs
@@ -18,6 +18,7 @@ import {
   projectOptions,
   repositoryOptions,
 } from "./lib/agent-runner-help.mjs"
+import { localWorkspaceReferencePlan } from "./lib/agent-runner-workspace.mjs"
 
 const handoffStates = new Set(["Planning", "Running", "Changes Requested", "CI Repair"])
 
@@ -84,7 +85,11 @@ if (missingBrowserEvidence && !args.force) {
 
 const workspaceReference = args.workspace ?? item.fields.Workspace ?? item.dryRunPlan.workspace
 const branchReference = item.fields.Branch ?? item.dryRunPlan.branch
-const workspace = path.resolve(repoRoot, workspaceReference)
+const { workspace } = localWorkspaceReferencePlan({
+  commandName: "handoff mode",
+  repoRoot,
+  workspaceReference,
+})
 if (!existsSync(workspace)) {
   fail(`workspace does not exist: ${workspace}`)
 }

--- a/scripts/agent-runner-open-pr.mjs
+++ b/scripts/agent-runner-open-pr.mjs
@@ -1,5 +1,4 @@
 import { existsSync } from "node:fs"
-import path from "node:path"
 
 import { updateProjectItemFields } from "./lib/agent-project-fields.mjs"
 import {
@@ -28,6 +27,7 @@ import {
   pullRequestTitle,
   pushBranch,
 } from "./lib/agent-runner-pr.mjs"
+import { localWorkspaceReferencePlan } from "./lib/agent-runner-workspace.mjs"
 
 const args = parseArgs(process.argv.slice(2))
 maybePrintHelp(args, {
@@ -76,7 +76,11 @@ if (!args.force && !openPullRequestStates.has(currentState)) {
 
 const branch = args.branch ?? item.fields.Branch ?? item.dryRunPlan.branch
 const workspaceReference = args.workspace ?? item.fields.Workspace ?? item.dryRunPlan.workspace
-const workspace = path.resolve(repoRoot, workspaceReference)
+const { workspace } = localWorkspaceReferencePlan({
+  commandName: "open-pr mode",
+  repoRoot,
+  workspaceReference,
+})
 if (!existsSync(workspace)) {
   fail(`workspace does not exist: ${workspace}`)
 }

--- a/scripts/agent-runner-publish-evidence.mjs
+++ b/scripts/agent-runner-publish-evidence.mjs
@@ -18,6 +18,7 @@ import {
   projectOptions,
   repositoryOptions,
 } from "./lib/agent-runner-help.mjs"
+import { localWorkspaceReferencePlan } from "./lib/agent-runner-workspace.mjs"
 
 const args = parseArgs(process.argv.slice(2))
 maybePrintHelp(args, {
@@ -52,6 +53,11 @@ if (item.issue.state !== "OPEN") {
 
 const workspaceReference = args.workspace ?? item.fields.Workspace ?? item.dryRunPlan.workspace
 const evidenceReference = args.evidencePath ?? item.fields.Evidence
+const { workspace } = localWorkspaceReferencePlan({
+  commandName: "publish-evidence mode",
+  repoRoot,
+  workspaceReference,
+})
 
 if (!evidenceReference) {
   fail("publish-evidence mode requires --evidence-path or an existing Evidence field")
@@ -61,7 +67,7 @@ if (isRemoteEvidence(evidenceReference)) {
   fail(`Evidence already points at a remote artifact: ${evidenceReference}`)
 }
 
-const evidencePath = path.resolve(repoRoot, workspaceReference, evidenceReference)
+const evidencePath = path.resolve(workspace, evidenceReference)
 if (!existsSync(evidencePath)) {
   fail(`evidence packet does not exist: ${evidencePath}`)
 }

--- a/scripts/lib/agent-runner-browser-evidence.mjs
+++ b/scripts/lib/agent-runner-browser-evidence.mjs
@@ -1,6 +1,8 @@
 import { mkdirSync, writeFileSync } from "node:fs"
 import path from "node:path"
 
+import { localWorkspaceReferencePlan } from "./agent-runner-workspace.mjs"
+
 const uiEvidenceLabels = new Set([
   "browser:evidence",
   "frontend",
@@ -23,7 +25,12 @@ export function browserArtifactPlan({
 }) {
   const slug = slugFromTitle(item.issue.title)
   const timestamp = date.toISOString().replace(/[:.]/g, "-")
-  const workspace = path.resolve(repoRoot, workspaceReference)
+  const localWorkspace = localWorkspaceReferencePlan({
+    commandName: "capture-browser mode",
+    repoRoot,
+    workspaceReference,
+  })
+  const workspace = localWorkspace.workspace
   const artifactPointer = path.posix.join(
     "docs/agent-evidence/browser",
     `${item.issue.number}-${slug}`,
@@ -45,7 +52,7 @@ export function browserArtifactPlan({
     summaryJson: path.join(artifactDir, "summary.json"),
     videoDir: path.join(artifactDir, "videos"),
     workspace,
-    workspaceReference,
+    workspaceReference: localWorkspace.workspaceReference,
   }
 }
 

--- a/scripts/lib/agent-runner-execution.mjs
+++ b/scripts/lib/agent-runner-execution.mjs
@@ -7,6 +7,7 @@ import {
   requiresBrowserEvidence,
 } from "./agent-runner-browser-evidence.mjs"
 import { ciRepairEvidenceEnvironment, resolveCiRepairEvidencePath } from "./agent-runner-ci.mjs"
+import { localWorkspaceReferencePlan } from "./agent-runner-workspace.mjs"
 import {
   parseWorkspaceReference,
   workspaceDescriptorEnvironment,
@@ -27,7 +28,12 @@ export function commandRunArtifactPlan({
 }) {
   const slug = slugFromTitle(item.issue.title)
   const timestamp = date.toISOString().replace(/[:.]/g, "-")
-  const workspace = path.resolve(repoRoot, workspaceReference)
+  const localWorkspace = localWorkspaceReferencePlan({
+    commandName: "run-command mode",
+    repoRoot,
+    workspaceReference,
+  })
+  const workspace = localWorkspace.workspace
   const evidencePointer =
     evidencePath ?? path.posix.join("docs/agent-evidence/active", `${item.issue.number}-${slug}.md`)
   const evidenceFile = path.resolve(workspace, evidencePointer)
@@ -45,7 +51,7 @@ export function commandRunArtifactPlan({
     repoRoot,
     safeEvidencePath: isPathInside(evidenceFile, workspace),
     workspace,
-    workspaceReference,
+    workspaceReference: localWorkspace.workspaceReference,
   }
 }
 

--- a/scripts/lib/agent-runner-pr.mjs
+++ b/scripts/lib/agent-runner-pr.mjs
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs"
 import path from "node:path"
 
 import { fail, runCommand, runGit } from "./agent-project-queue.mjs"
+import { localWorkspaceReferencePlan } from "./agent-runner-workspace.mjs"
 
 export const openPullRequestStates = new Set(["Human Review", "CI Repair", "Changes Requested"])
 const successfulCheckConclusions = new Set(["SUCCESS", "SKIPPED", "NEUTRAL"])
@@ -51,7 +52,12 @@ export function evidenceForPullRequest({ evidenceReference, repoRoot, workspaceR
     }
   }
 
-  const evidencePath = path.resolve(repoRoot, workspaceReference, evidenceReference)
+  const { workspace } = localWorkspaceReferencePlan({
+    commandName: "open-pr mode",
+    repoRoot,
+    workspaceReference,
+  })
+  const evidencePath = path.resolve(workspace, evidenceReference)
   if (!existsSync(evidencePath)) {
     fail(`evidence packet does not exist: ${evidencePath}`)
   }

--- a/scripts/lib/agent-runner-workspace-contract.mjs
+++ b/scripts/lib/agent-runner-workspace-contract.mjs
@@ -21,6 +21,10 @@ export function parseWorkspaceReference(reference, { repoRoot }) {
     }
   }
 
+  if (normalizedReference.startsWith("sandbox:")) {
+    return invalidWorkspace(normalizedReference, "remote sandbox reference is malformed")
+  }
+
   const workspace = path.resolve(repoRoot, normalizedReference)
   const localRoot = path.resolve(repoRoot, ".agent-worktrees")
 

--- a/scripts/lib/agent-runner-workspace.mjs
+++ b/scripts/lib/agent-runner-workspace.mjs
@@ -32,6 +32,31 @@ export function cleanupWorkspacePlan({ item, repoRoot, workspaceReference }) {
   }
 }
 
+export function localWorkspaceReferencePlan({
+  commandName = "agent-runner",
+  onError = fail,
+  repoRoot,
+  workspaceReference,
+}) {
+  const descriptor = parseWorkspaceReference(workspaceReference, { repoRoot })
+
+  if (!isLocalWorkspaceDescriptor(descriptor)) {
+    const detail =
+      descriptor.kind === "invalid"
+        ? descriptor.reason
+        : `${descriptor.kind} reference ${descriptor.reference}`
+    const message = `${commandName} requires a local workspace; got ${detail}`
+    onError(message)
+    throw new Error(message)
+  }
+
+  return {
+    workspace: descriptor.workspace,
+    workspaceDescriptor: descriptor,
+    workspaceReference: descriptor.reference,
+  }
+}
+
 export function cleanupFieldValues(date = new Date()) {
   return {
     "Last Heartbeat": date.toISOString().slice(0, 10),

--- a/scripts/tests/agent-runner-lifecycle.test.mjs
+++ b/scripts/tests/agent-runner-lifecycle.test.mjs
@@ -15,6 +15,7 @@ import {
   canCleanupAgentState,
   cleanupFieldValues,
   cleanupWorkspacePlan,
+  localWorkspaceReferencePlan,
   removeWorkspace,
   workspacePlan,
 } from "../lib/agent-runner-workspace.mjs"
@@ -103,6 +104,55 @@ describe("agent runner lifecycle helpers", () => {
     })
   })
 
+  it("rejects remote sandbox references for local-only workspace commands", () => {
+    assert.deepEqual(
+      localWorkspaceReferencePlan({
+        commandName: "run-command mode",
+        repoRoot: "/repo",
+        workspaceReference: ".agent-worktrees/579-test-agent-project-intake-workflow",
+      }),
+      {
+        workspace: path.resolve("/repo/.agent-worktrees/579-test-agent-project-intake-workflow"),
+        workspaceDescriptor: {
+          agentWorktreeRoot: path.resolve("/repo/.agent-worktrees"),
+          id: "579-test-agent-project-intake-workflow",
+          kind: "local-worktree",
+          provider: null,
+          reference: ".agent-worktrees/579-test-agent-project-intake-workflow",
+          safeLocalWorkspace: true,
+          workspace: path.resolve("/repo/.agent-worktrees/579-test-agent-project-intake-workflow"),
+        },
+        workspaceReference: ".agent-worktrees/579-test-agent-project-intake-workflow",
+      },
+    )
+
+    assert.throws(
+      () =>
+        localWorkspaceReferencePlan({
+          commandName: "run-command mode",
+          onError: (message) => {
+            throw new Error(message)
+          },
+          repoRoot: "/repo",
+          workspaceReference: "sandbox:sprite:task-579",
+        }),
+      /run-command mode requires a local workspace; got remote-sandbox reference sandbox:sprite:task-579/,
+    )
+
+    assert.throws(
+      () =>
+        localWorkspaceReferencePlan({
+          commandName: "run-command mode",
+          onError: (message) => {
+            throw new Error(message)
+          },
+          repoRoot: "/repo",
+          workspaceReference: "sandbox:sprite:task/579",
+        }),
+      /run-command mode requires a local workspace; got remote sandbox reference is malformed/,
+    )
+  })
+
   it("parses local and remote workspace references", () => {
     assert.deepEqual(
       parseWorkspaceReference(".agent-worktrees/579-test-agent-project-intake-workflow", {
@@ -124,6 +174,14 @@ describe("agent runner lifecycle helpers", () => {
       kind: "remote-sandbox",
       provider: "sprite",
       reference: "sandbox:sprite:task-579",
+    })
+
+    assert.deepEqual(parseWorkspaceReference("sandbox:Sprite:task-579", { repoRoot: "/repo" }), {
+      id: null,
+      kind: "invalid",
+      provider: null,
+      reason: "remote sandbox reference is malformed",
+      reference: "sandbox:Sprite:task-579",
     })
 
     assert.deepEqual(


### PR DESCRIPTION
## Summary

- add a shared local workspace resolver for local-only runner commands
- make run-command, browser capture, handoff, evidence publishing, and PR publishing reject `sandbox:` references instead of treating them as paths
- document that remote workspace references remain reserved until a remote adapter owns those commands

## Validation

- `node --check` on changed runner scripts/libs
- `node --test scripts/tests/agent-runner-lifecycle.test.mjs scripts/tests/agent-runner-browser-evidence.test.mjs scripts/tests/agent-runner-pr.test.mjs`
- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm exec secretlint ...`
- `git diff --check`
- commit hook: full lint + typecheck
- push hook: full test lane
