### PR TITLE
Pause remote workspace queue actions

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -191,13 +191,16 @@ pnpm agent:queue:tick
 Tick mode scans the same repository-scoped Project queue and prints ordered
 action recommendations such as `start`, `run-command`, `capture-browser`,
 `collect-ci`, `publish-evidence`, `open-pr`, `sync-pr`, `cleanup`, or
-`inspect-stale`. It
-does not mutate GitHub, create worktrees, run commands, publish evidence, or
+`inspect-stale`. It does not mutate GitHub, create worktrees, run commands,
+publish evidence, or
 open PRs. Pass `--json` when a process manager or future control plane needs
 machine-readable actions. `Merge Ready` items with linked PRs keep recommending
 `sync-pr` so the runner can observe maintainer merges and mark the item done.
 `CI Repair` items with failing linked PRs recommend `collect-ci` until a local
-CI repair packet exists.
+CI repair packet exists. Items with `sandbox:<provider>:<id>` workspaces
+recommend wait states instead of local workspace commands until a remote adapter
+owns execution and cleanup. Malformed reserved `sandbox:` values recommend
+`inspect-workspace`.
 
 Use dispatch to execute one allow-listed tick recommendation:
 

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -808,7 +808,9 @@ references: `.agent-worktrees/<issue-number>-<slug>` for local worktrees, or
 reference before acting on it; a remote sandbox reference must not be resolved
 as a local path. Until a remote adapter owns execution, browser capture,
 handoff, evidence publishing, and PR publishing, those local-only commands must
-reject `sandbox:` workspace references explicitly.
+reject `sandbox:` workspace references explicitly. Queue recommendation code
+must also pause remote-workspace items with adapter wait states instead of
+dispatching local lifecycle commands.
 
 ```ts
 interface AgentWorkspace {

--- a/scripts/lib/agent-runner-tick.mjs
+++ b/scripts/lib/agent-runner-tick.mjs
@@ -4,6 +4,10 @@ import {
 } from "./agent-runner-browser-evidence.mjs"
 import { hasCiRepairEvidence } from "./agent-runner-ci.mjs"
 import { evaluateHeartbeat } from "./agent-runner-output.mjs"
+import {
+  isRemoteWorkspaceDescriptor,
+  parseWorkspaceReference,
+} from "./agent-runner-workspace-contract.mjs"
 
 const runnableStates = new Set(["Planning", "Changes Requested", "CI Repair"])
 const stalePreemptionStates = new Set(["Planning", "Running", "Changes Requested", "CI Repair"])
@@ -49,6 +53,11 @@ export function recommendQueueAction(item, { maxAgeDays, repository }) {
       priority: 10,
       reason: heartbeat.reason,
     })
+  }
+
+  const workspaceRecommendation = remoteWorkspaceRecommendation(item, { heartbeat })
+  if (workspaceRecommendation) {
+    return workspaceRecommendation
   }
 
   if (item.ready) {
@@ -172,6 +181,56 @@ export function recommendQueueAction(item, { maxAgeDays, repository }) {
     priority: 999,
     reason: item.reasons.join("; ") || `Agent State is ${state ?? "unset"}`,
   })
+}
+
+function remoteWorkspaceRecommendation(item, { heartbeat }) {
+  const workspace = item.fields.Workspace
+  if (!workspace) return null
+
+  const descriptor = parseWorkspaceReference(workspace, { repoRoot: "/" })
+  const state = item.fields["Agent State"]
+
+  if (descriptor.kind === "invalid") {
+    return recommendation(item, {
+      action: "inspect-workspace",
+      command: null,
+      heartbeat,
+      priority: 25,
+      reason: `invalid Workspace: ${descriptor.reason}`,
+    })
+  }
+
+  if (!isRemoteWorkspaceDescriptor(descriptor)) return null
+
+  if (state === "Human Review" && item.fields.PR) return null
+  if (state === "Merge Ready" && item.fields.PR) return null
+
+  if (state === "Done" || state === "Abandoned") {
+    return recommendation(item, {
+      action: "wait-remote-cleanup",
+      command: null,
+      heartbeat,
+      priority: 90,
+      reason: `remote workspace ${descriptor.reference} needs remote adapter cleanup`,
+    })
+  }
+
+  if (
+    ["Ready", "Planning", "Running", "Changes Requested", "CI Repair", "Human Review"].includes(
+      state,
+    ) ||
+    item.ready
+  ) {
+    return recommendation(item, {
+      action: "wait-remote-adapter",
+      command: null,
+      heartbeat,
+      priority: 29,
+      reason: `remote workspace ${descriptor.reference} requires a remote adapter`,
+    })
+  }
+
+  return null
 }
 
 function humanReviewRecommendation(item, { heartbeat, repository }) {

--- a/scripts/tests/agent-runner-tick.test.mjs
+++ b/scripts/tests/agent-runner-tick.test.mjs
@@ -208,4 +208,121 @@ describe("agent runner tick helpers", () => {
       "run-command",
     )
   })
+
+  it("pauses local queue actions for remote workspace references", () => {
+    assert.deepEqual(
+      recommendQueueAction(
+        workItem({
+          fields: {
+            "Agent State": "Ready",
+            Workspace: "sandbox:sprite:task-579",
+          },
+        }),
+        { maxAgeDays: 1, repository: "voyantjs/other" },
+      ).action,
+      "wait-remote-adapter",
+    )
+
+    assert.deepEqual(
+      recommendQueueAction(
+        workItem({
+          fields: {
+            "Agent State": "Planning",
+            "Last Heartbeat": new Date().toISOString().slice(0, 10),
+            Workspace: "sandbox:sprite:task-579",
+          },
+        }),
+        { maxAgeDays: 1, repository: "voyantjs/other" },
+      ),
+      {
+        action: "wait-remote-adapter",
+        command: null,
+        heartbeat: {
+          reason: "Last Heartbeat is 0 days old",
+          stale: false,
+        },
+        issue: workItem().issue,
+        priority: 29,
+        reason: "remote workspace sandbox:sprite:task-579 requires a remote adapter",
+        state: "Planning",
+      },
+    )
+
+    assert.deepEqual(
+      recommendQueueAction(
+        workItem({
+          fields: {
+            "Agent State": "Human Review",
+            Evidence: "docs/agent-evidence/active/579-test.md",
+            Workspace: "sandbox:sprite:task-579",
+          },
+        }),
+        { maxAgeDays: 1, repository: "voyantjs/other" },
+      ).action,
+      "wait-remote-adapter",
+    )
+
+    assert.deepEqual(
+      recommendQueueAction(
+        workItem({
+          fields: {
+            "Agent State": "Human Review",
+            Evidence: "docs/agent-evidence/active/579-test.md",
+            PR: "https://github.com/voyantjs/voyant/pull/626",
+            Workspace: "sandbox:sprite:task-579",
+          },
+        }),
+        { maxAgeDays: 1, repository: "voyantjs/other" },
+      ).action,
+      "sync-pr",
+    )
+
+    assert.deepEqual(
+      recommendQueueAction(
+        workItem({
+          fields: {
+            "Agent State": "Done",
+            Workspace: "sandbox:sprite:task-579",
+          },
+        }),
+        { maxAgeDays: 1, repository: "voyantjs/other" },
+      ),
+      {
+        action: "wait-remote-cleanup",
+        command: null,
+        heartbeat: null,
+        issue: workItem().issue,
+        priority: 90,
+        reason: "remote workspace sandbox:sprite:task-579 needs remote adapter cleanup",
+        state: "Done",
+      },
+    )
+  })
+
+  it("surfaces malformed sandbox workspace references before local actions", () => {
+    assert.deepEqual(
+      recommendQueueAction(
+        workItem({
+          fields: {
+            "Agent State": "Planning",
+            "Last Heartbeat": new Date().toISOString().slice(0, 10),
+            Workspace: "sandbox:Sprite:task-579",
+          },
+        }),
+        { maxAgeDays: 1, repository: "voyantjs/other" },
+      ),
+      {
+        action: "inspect-workspace",
+        command: null,
+        heartbeat: {
+          reason: "Last Heartbeat is 0 days old",
+          stale: false,
+        },
+        issue: workItem().issue,
+        priority: 25,
+        reason: "invalid Workspace: remote sandbox reference is malformed",
+        state: "Planning",
+      },
+    )
+  })
 })


### PR DESCRIPTION
## Summary
- pause local queue recommendations for remote workspace references until a remote adapter owns execution
- surface malformed reserved `sandbox:` workspace values as `inspect-workspace` recommendations
- document queue behavior for remote workspace references

## Validation
- `node --check scripts/lib/agent-runner-tick.mjs`
- `node --test scripts/tests/agent-runner-tick.test.mjs`
- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm exec secretlint scripts/lib/agent-runner-tick.mjs scripts/tests/agent-runner-tick.test.mjs docs/agents/issue-tracker.md docs/architecture/agentic-engineering-orchestration.md`
- `git diff --check`
- commit hook: full lint + typecheck
- push hook: full test lane
