### PR TITLE
fix(smartbill): persist invoice PDF artifacts

### DIFF
--- a/.changeset/smartbill-invoice-pdf-artifacts.md
+++ b/.changeset/smartbill-invoice-pdf-artifacts.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/plugin-smartbill": patch
+---
+
+Persist SmartBill invoice and proforma PDFs as finance invoice renditions and attachments when artifact storage is configured.

--- a/packages/plugins/smartbill/README.md
+++ b/packages/plugins/smartbill/README.md
@@ -29,6 +29,10 @@ const smartbillSync = smartbillPlugin({
   companyVatCode: "RO12345678",
   seriesName: "A",
   // optional: language, art311SpecialRegime, events, mapEvent, logger
+  artifacts: {
+    db: appDb,
+    documentStorage,
+  },
 })
 
 const app = createApp({
@@ -38,10 +42,21 @@ const app = createApp({
 
 `smartbillPlugin(...)` is the packaged distribution helper. At runtime, the
 package behaves primarily as a subscriber-driven SmartBill sync adapter. By
-default it wires up 3 subscribers (`invoice.issued`, `invoice.voided`,
+default it wires up 4 subscribers (`invoice.issued`,
+`invoice.proforma.issued`, `invoice.voided`,
 `invoice.external.sync.requested`) that create, cancel, and check payment
 status on SmartBill. All error handling is fire-and-forget per the EventBus
 contract.
+
+When `artifacts.db` is configured, successful invoice/proforma creation also
+registers the SmartBill external reference through `@voyantjs/finance`. When
+`artifacts.documentStorage` is configured, the plugin downloads the generated
+SmartBill PDF, uploads it to document storage, and records both a ready
+`invoice_renditions` row and a `smartbill_pdf` `invoice_attachments` row. The
+upload path defaults to `invoices/<invoiceId>/smartbill/...`; pass
+`artifacts.documentStorageKeyPrefix` to customize it. Existing
+`smartbill_pdf` attachments are reused so repeat event delivery does not upload
+the same PDF again.
 
 ## Exports
 

--- a/packages/plugins/smartbill/package.json
+++ b/packages/plugins/smartbill/package.json
@@ -21,6 +21,9 @@
   },
   "dependencies": {
     "@voyantjs/core": "workspace:*",
+    "@voyantjs/finance": "workspace:*",
+    "@voyantjs/storage": "workspace:*",
+    "drizzle-orm": "^0.45.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/plugins/smartbill/src/artifacts.ts
+++ b/packages/plugins/smartbill/src/artifacts.ts
@@ -107,7 +107,7 @@ export async function persistSmartbillInvoiceArtifact({
   const seriesName = result.series ?? body.seriesName
   const number = result.number
 
-  await financeService.registerInvoiceExternalRef(db, event.id, {
+  const externalRef = await financeService.registerInvoiceExternalRef(db, event.id, {
     provider: "smartbill",
     externalId: number ?? null,
     externalNumber: number ?? null,
@@ -123,6 +123,7 @@ export async function persistSmartbillInvoiceArtifact({
       documentType,
     },
   })
+  if (!externalRef) return { status: "skipped" as const, reason: "missing_invoice" as const }
 
   const storage = await resolveMaybe(runtime.documentStorage, context)
   if (!storage) return { status: "registered_ref" as const }

--- a/packages/plugins/smartbill/src/artifacts.ts
+++ b/packages/plugins/smartbill/src/artifacts.ts
@@ -1,0 +1,196 @@
+import { financeService } from "@voyantjs/finance"
+import type { StorageProvider } from "@voyantjs/storage"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import type { SmartbillClientApi } from "./client.js"
+import type { SmartbillInvoiceBody, SmartbillInvoiceResponse, VoyantInvoiceEvent } from "./types.js"
+
+export type SmartbillDocumentType = "invoice" | "proforma"
+
+export interface SmartbillArtifactStorageContext {
+  event: VoyantInvoiceEvent
+  documentType: SmartbillDocumentType
+  body: SmartbillInvoiceBody
+  result: SmartbillInvoiceResponse
+}
+
+export type SmartbillDbResolver =
+  | PostgresJsDatabase
+  | ((
+      context: SmartbillArtifactStorageContext,
+    ) => PostgresJsDatabase | null | Promise<PostgresJsDatabase | null>)
+
+export type SmartbillDocumentStorageResolver =
+  | StorageProvider
+  | null
+  | ((
+      context: SmartbillArtifactStorageContext,
+    ) => StorageProvider | null | Promise<StorageProvider | null>)
+
+export type SmartbillStorageKeyPrefixResolver =
+  | string
+  | ((context: SmartbillArtifactStorageContext) => string | Promise<string>)
+
+export interface SmartbillArtifactPersistenceOptions {
+  db?: SmartbillDbResolver
+  documentStorage?: SmartbillDocumentStorageResolver
+  documentStorageKeyPrefix?: SmartbillStorageKeyPrefixResolver
+}
+
+export interface SmartbillArtifactPersistenceRuntime {
+  db?: SmartbillDbResolver
+  documentStorage?: SmartbillDocumentStorageResolver
+  documentStorageKeyPrefix?: SmartbillStorageKeyPrefixResolver
+}
+
+export interface PersistSmartbillInvoiceArtifactInput {
+  runtime: SmartbillArtifactPersistenceRuntime
+  client: SmartbillClientApi
+  event: VoyantInvoiceEvent
+  documentType: SmartbillDocumentType
+  body: SmartbillInvoiceBody
+  result: SmartbillInvoiceResponse
+}
+
+const SMARTBILL_ATTACHMENT_KIND = "smartbill_pdf"
+
+function isResolver<TContext, TValue>(
+  value: TValue | ((context: TContext) => TValue | Promise<TValue>) | undefined | null,
+): value is (context: TContext) => TValue | Promise<TValue> {
+  return typeof value === "function"
+}
+
+async function resolveMaybe<TContext, TValue>(
+  value: TValue | ((context: TContext) => TValue | Promise<TValue>) | undefined,
+  context: TContext,
+) {
+  return isResolver<TContext, TValue>(value) ? await value(context) : value
+}
+
+function sanitizeKeyPart(value: string) {
+  return value.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "document"
+}
+
+async function sha256(bytes: Uint8Array) {
+  const crypto = globalThis.crypto
+  if (!crypto?.subtle) return null
+  const buffer = new ArrayBuffer(bytes.byteLength)
+  new Uint8Array(buffer).set(bytes)
+  const digest = await crypto.subtle.digest("SHA-256", buffer)
+  return `sha256:${Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")}`
+}
+
+function smartbillAttachmentName(
+  documentType: SmartbillDocumentType,
+  seriesName: string,
+  number: string,
+) {
+  return `SmartBill ${documentType} ${seriesName}-${number}.pdf`
+}
+
+export async function persistSmartbillInvoiceArtifact({
+  runtime,
+  client,
+  event,
+  documentType,
+  body,
+  result,
+}: PersistSmartbillInvoiceArtifactInput) {
+  if (!runtime.db) return { status: "skipped" as const, reason: "missing_db" as const }
+
+  const context: SmartbillArtifactStorageContext = { event, documentType, body, result }
+  const db = await resolveMaybe(runtime.db, context)
+  if (!db) return { status: "skipped" as const, reason: "missing_db" as const }
+
+  const seriesName = result.series ?? body.seriesName
+  const number = result.number
+
+  await financeService.registerInvoiceExternalRef(db, event.id, {
+    provider: "smartbill",
+    externalId: number ?? null,
+    externalNumber: number ?? null,
+    externalUrl: result.url ?? null,
+    status: result.errorText ? "error" : "issued",
+    syncedAt: new Date().toISOString(),
+    syncError: result.errorText ?? null,
+    metadata: {
+      companyVatCode: body.companyVatCode,
+      seriesName: body.seriesName,
+      series: seriesName,
+      number: number ?? null,
+      documentType,
+    },
+  })
+
+  const storage = await resolveMaybe(runtime.documentStorage, context)
+  if (!storage) return { status: "registered_ref" as const }
+  if (!number) return { status: "registered_ref" as const, reason: "missing_number" as const }
+
+  const existingAttachments = await financeService.listInvoiceAttachments(db, event.id)
+  const existingSmartbillAttachment = existingAttachments.find(
+    (attachment) => attachment.kind === SMARTBILL_ATTACHMENT_KIND,
+  )
+  if (existingSmartbillAttachment) {
+    return { status: "already_exists" as const, attachment: existingSmartbillAttachment }
+  }
+
+  const pdf =
+    documentType === "proforma"
+      ? await client.viewEstimatePdf(body.companyVatCode, seriesName, number)
+      : await client.viewInvoicePdf(body.companyVatCode, seriesName, number)
+
+  const defaultPrefix = `invoices/${event.id}/smartbill`
+  const keyPrefix = (await resolveMaybe(runtime.documentStorageKeyPrefix, context)) ?? defaultPrefix
+  const key = `${keyPrefix.replace(/\/$/, "")}/${documentType}-${sanitizeKeyPart(seriesName)}-${sanitizeKeyPart(number)}.pdf`
+  const contentType = pdf.contentType || "application/pdf"
+  const checksum = await sha256(pdf.bytes)
+  const uploaded = await storage.upload(pdf.bytes, {
+    key,
+    contentType,
+    metadata: {
+      provider: "smartbill",
+      documentType,
+      invoiceId: event.id,
+      seriesName,
+      number,
+    },
+  })
+
+  const commonMetadata = {
+    provider: "smartbill",
+    documentType,
+    companyVatCode: body.companyVatCode,
+    seriesName,
+    number,
+    storageProvider: storage.name,
+    ...(uploaded.url ? { url: uploaded.url } : {}),
+  }
+
+  const rendition = await financeService.createInvoiceRendition(db, event.id, {
+    format: "pdf",
+    status: "ready",
+    storageKey: uploaded.key,
+    fileSize: pdf.bytes.byteLength,
+    checksum,
+    language: body.language ?? null,
+    generatedAt: new Date().toISOString(),
+    metadata: commonMetadata,
+  })
+
+  const attachment = await financeService.createInvoiceAttachment(db, event.id, {
+    kind: SMARTBILL_ATTACHMENT_KIND,
+    name: smartbillAttachmentName(documentType, seriesName, number),
+    mimeType: contentType,
+    fileSize: pdf.bytes.byteLength,
+    storageKey: uploaded.key,
+    checksum,
+    metadata: {
+      ...commonMetadata,
+      renditionId: rendition?.id ?? null,
+    },
+  })
+
+  return { status: "persisted" as const, rendition, attachment }
+}

--- a/packages/plugins/smartbill/src/index.ts
+++ b/packages/plugins/smartbill/src/index.ts
@@ -1,3 +1,11 @@
+export type {
+  SmartbillArtifactPersistenceOptions,
+  SmartbillArtifactStorageContext,
+  SmartbillDbResolver,
+  SmartbillDocumentStorageResolver,
+  SmartbillDocumentType,
+  SmartbillStorageKeyPrefixResolver,
+} from "./artifacts.js"
 export type { SmartbillClientApi, SmartbillClientOptions } from "./client.js"
 export { createSmartbillClient } from "./client.js"
 export type { SmartbillMappingOptions } from "./mapping.js"

--- a/packages/plugins/smartbill/src/plugin.ts
+++ b/packages/plugins/smartbill/src/plugin.ts
@@ -1,6 +1,11 @@
 import type { Plugin, Subscriber } from "@voyantjs/core"
 import { ZodError } from "zod"
 
+import {
+  persistSmartbillInvoiceArtifact,
+  type SmartbillArtifactPersistenceOptions,
+  type SmartbillDocumentType,
+} from "./artifacts.js"
 import type { SmartbillClientOptions } from "./client.js"
 import type { mapVoyantInvoiceToSmartbill, SmartbillMappingOptions } from "./mapping.js"
 import { createSmartbillSyncRuntime } from "./runtime.js"
@@ -27,18 +32,58 @@ export interface SmartbillPluginOptions extends SmartbillClientOptions, Smartbil
   events?: SmartbillSyncEventNames
   mapEvent?: SmartbillMapFn
   logger?: SmartbillLogger
+  /**
+   * Optional finance artifact persistence. When `db` is supplied, the plugin
+   * registers the SmartBill external ref after creation. When
+   * `documentStorage` is also supplied, it downloads and stores the generated
+   * SmartBill PDF as both an invoice rendition and attachment.
+   */
+  artifacts?: SmartbillArtifactPersistenceOptions
+  /** @deprecated Use `artifacts.db`. */
+  db?: SmartbillArtifactPersistenceOptions["db"]
+  /** @deprecated Use `artifacts.documentStorage`. */
+  documentStorage?: SmartbillArtifactPersistenceOptions["documentStorage"]
+  /** @deprecated Use `artifacts.documentStorageKeyPrefix`. */
+  documentStorageKeyPrefix?: SmartbillArtifactPersistenceOptions["documentStorageKeyPrefix"]
 }
 
 function coerceEvent(data: unknown): VoyantInvoiceEvent | null {
   if (data == null || typeof data !== "object") return null
   const maybe = data as Record<string, unknown>
-  if (typeof maybe.id !== "string") return null
-  return maybe as VoyantInvoiceEvent
+  if (typeof maybe.id === "string") return maybe as VoyantInvoiceEvent
+  if (typeof maybe.invoiceId === "string") {
+    return { ...maybe, id: maybe.invoiceId } as VoyantInvoiceEvent
+  }
+  return null
 }
 
 export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
   const validatedOptions = parseSmartbillPluginOptions(options)
-  const { client, logger, mapEvent, eventNames } = createSmartbillSyncRuntime(validatedOptions)
+  const { client, logger, mapEvent, eventNames, artifacts } =
+    createSmartbillSyncRuntime(validatedOptions)
+
+  async function persistArtifact(
+    event: VoyantInvoiceEvent,
+    documentType: SmartbillDocumentType,
+    body: ReturnType<SmartbillMapFn>,
+    result: Awaited<ReturnType<typeof client.createInvoice>>,
+  ) {
+    try {
+      const persisted = await persistSmartbillInvoiceArtifact({
+        runtime: artifacts,
+        client,
+        event,
+        documentType,
+        body,
+        result,
+      })
+      if (persisted.status === "persisted") {
+        logger.info?.(`[smartbill] ${documentType} PDF persisted for ${event.id}`, persisted)
+      }
+    } catch (err) {
+      logger.error(`[smartbill] artifact persistence failed for ${event.id}`, err)
+    }
+  }
 
   const subscribers: Subscriber[] = [
     {
@@ -53,6 +98,7 @@ export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
             `[smartbill] invoice created: ${result.series}-${result.number} for ${event.id}`,
             result,
           )
+          await persistArtifact(event, "invoice", body, result)
         } catch (err) {
           logger.error(
             `[smartbill] createInvoice on "${eventNames.issued}" failed for ${event.id}`,
@@ -75,6 +121,7 @@ export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
             `[smartbill] proforma created: ${result.series}-${result.number} for ${event.id}`,
             result,
           )
+          await persistArtifact(event, "proforma", body, result)
         } catch (err) {
           logger.error(
             `[smartbill] createProforma on "${eventNames.proformaIssued}" failed for ${event.id}`,

--- a/packages/plugins/smartbill/src/runtime.ts
+++ b/packages/plugins/smartbill/src/runtime.ts
@@ -1,3 +1,4 @@
+import type { SmartbillArtifactPersistenceOptions } from "./artifacts.js"
 import { createSmartbillClient } from "./client.js"
 import { mapVoyantInvoiceToSmartbill, type SmartbillMappingOptions } from "./mapping.js"
 import type { SmartbillLogger, SmartbillMapFn, SmartbillPluginOptions } from "./plugin.js"
@@ -15,6 +16,7 @@ export interface SmartbillSyncRuntime {
   logger: SmartbillLogger
   mapEvent: SmartbillMapFn
   eventNames: ResolvedSmartbillSyncEventNames
+  artifacts: SmartbillArtifactPersistenceOptions
 }
 
 export function createSmartbillSyncRuntime(options: SmartbillPluginOptions): SmartbillSyncRuntime {
@@ -42,5 +44,11 @@ export function createSmartbillSyncRuntime(options: SmartbillPluginOptions): Sma
     logger,
     mapEvent,
     eventNames,
+    artifacts: {
+      db: options.artifacts?.db ?? options.db,
+      documentStorage: options.artifacts?.documentStorage ?? options.documentStorage,
+      documentStorageKeyPrefix:
+        options.artifacts?.documentStorageKeyPrefix ?? options.documentStorageKeyPrefix,
+    },
   }
 }

--- a/packages/plugins/smartbill/src/validation.ts
+++ b/packages/plugins/smartbill/src/validation.ts
@@ -1,5 +1,11 @@
 import { z } from "zod"
 import type {
+  SmartbillArtifactPersistenceOptions,
+  SmartbillDbResolver,
+  SmartbillDocumentStorageResolver,
+  SmartbillStorageKeyPrefixResolver,
+} from "./artifacts.js"
+import type {
   SmartbillLogger,
   SmartbillMapFn,
   SmartbillPluginOptions,
@@ -31,11 +37,55 @@ const optionalMapEvent = z.custom<SmartbillMapFn | undefined>(
   "Expected a mapEvent function",
 )
 
+const optionalDb = z.custom<SmartbillDbResolver | undefined>(
+  (value) =>
+    value === undefined ||
+    typeof value === "function" ||
+    (typeof value === "object" && value !== null),
+  "Expected a database handle or resolver function",
+)
+
+function isStorageProvider(value: unknown) {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { upload?: unknown }).upload === "function" &&
+    typeof (value as { delete?: unknown }).delete === "function" &&
+    typeof (value as { signedUrl?: unknown }).signedUrl === "function" &&
+    typeof (value as { get?: unknown }).get === "function"
+  )
+}
+
+const optionalDocumentStorage = z.custom<SmartbillDocumentStorageResolver | undefined>(
+  (value) =>
+    value === undefined ||
+    value === null ||
+    typeof value === "function" ||
+    isStorageProvider(value),
+  "Expected a storage provider or resolver function",
+)
+
+const optionalDocumentStorageKeyPrefix = z.custom<SmartbillStorageKeyPrefixResolver | undefined>(
+  (value) => value === undefined || typeof value === "string" || typeof value === "function",
+  "Expected a storage key prefix string or resolver function",
+)
+
+const optionalArtifacts = z.custom<SmartbillArtifactPersistenceOptions | undefined>((value) => {
+  if (value === undefined) return true
+  if (typeof value !== "object" || value === null) return false
+  const artifacts = value as SmartbillArtifactPersistenceOptions
+  return (
+    optionalDb.safeParse(artifacts.db).success &&
+    optionalDocumentStorage.safeParse(artifacts.documentStorage).success &&
+    optionalDocumentStorageKeyPrefix.safeParse(artifacts.documentStorageKeyPrefix).success
+  )
+}, "Expected valid SmartBill artifact persistence options")
+
 const optionalEvents = z.custom<SmartbillSyncEventNames | undefined>((value) => {
   if (value === undefined) return true
   if (typeof value !== "object" || value === null) return false
   const events = value as SmartbillSyncEventNames
-  return [events.issued, events.voided, events.syncRequested].every(
+  return [events.issued, events.proformaIssued, events.voided, events.syncRequested].every(
     (entry) => entry === undefined || (typeof entry === "string" && entry.trim().length > 0),
   )
 }, "Expected event names to be non-empty strings")
@@ -53,4 +103,8 @@ export const smartbillPluginOptionsSchema = z.object({
   events: optionalEvents.optional(),
   mapEvent: optionalMapEvent.optional(),
   logger: optionalLogger.optional(),
+  artifacts: optionalArtifacts.optional(),
+  db: optionalDb.optional(),
+  documentStorage: optionalDocumentStorage.optional(),
+  documentStorageKeyPrefix: optionalDocumentStorageKeyPrefix.optional(),
 }) satisfies z.ZodType<SmartbillPluginOptions>

--- a/packages/plugins/smartbill/tests/unit/plugin.test.ts
+++ b/packages/plugins/smartbill/tests/unit/plugin.test.ts
@@ -342,6 +342,46 @@ describe("smartbillPlugin — invoice PDF artifacts", () => {
     expect(financeServiceMock.createInvoiceRendition).not.toHaveBeenCalled()
     expect(financeServiceMock.createInvoiceAttachment).not.toHaveBeenCalled()
   })
+
+  it("does not upload a PDF when the finance invoice is missing", async () => {
+    financeServiceMock.registerInvoiceExternalRef.mockResolvedValueOnce(null)
+    const fetchMock = vi.fn<SmartbillFetch>(async () =>
+      jsonResponse(200, { ...okEnvelope, number: "1", series: "A" }),
+    )
+    const upload = vi.fn()
+    const storage = {
+      name: "test-storage",
+      upload,
+      delete: vi.fn(),
+      signedUrl: vi.fn(),
+      get: vi.fn(),
+    }
+    const plugin = smartbillPlugin({
+      ...baseOptions,
+      fetch: fetchMock,
+      logger: makeLogger(),
+      artifacts: {
+        db: {} as never,
+        documentStorage: storage,
+      },
+    })
+    const handler = subscriberFor(plugin, "invoice.issued").handler
+
+    await handler(
+      eventEnvelope({
+        id: "inv_missing",
+        clientName: "Test SRL",
+        currency: "RON",
+        lineItems: [{ name: "Tour", quantity: 1, unitPrice: 50000 }],
+      }),
+    )
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    expect(upload).not.toHaveBeenCalled()
+    expect(financeServiceMock.listInvoiceAttachments).not.toHaveBeenCalled()
+    expect(financeServiceMock.createInvoiceRendition).not.toHaveBeenCalled()
+    expect(financeServiceMock.createInvoiceAttachment).not.toHaveBeenCalled()
+  })
 })
 
 describe("smartbillPlugin — invoice.voided subscriber", () => {

--- a/packages/plugins/smartbill/tests/unit/plugin.test.ts
+++ b/packages/plugins/smartbill/tests/unit/plugin.test.ts
@@ -1,7 +1,18 @@
 import type { Plugin } from "@voyantjs/core"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { smartbillPlugin } from "../../src/plugin.js"
 import type { SmartbillFetch } from "../../src/types.js"
+
+const financeServiceMock = vi.hoisted(() => ({
+  registerInvoiceExternalRef: vi.fn(),
+  listInvoiceAttachments: vi.fn(),
+  createInvoiceRendition: vi.fn(),
+  createInvoiceAttachment: vi.fn(),
+}))
+
+vi.mock("@voyantjs/finance", () => ({
+  financeService: financeServiceMock,
+}))
 
 function eventEnvelope<T>(data: T) {
   return {
@@ -45,6 +56,21 @@ function textResponse(status: number, text: string) {
   return makeResponse(status, text, false)
 }
 
+function bytesResponse(status: number, bytes: Uint8Array, contentType = "application/pdf") {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => {
+      throw new Error("not json")
+    },
+    text: async () => new TextDecoder().decode(bytes),
+    arrayBuffer: async () => bytes.buffer.slice(0),
+    headers: {
+      get: (name: string) => (name.toLowerCase() === "content-type" ? contentType : null),
+    },
+  }
+}
+
 const okEnvelope = { status: "Ok", message: "", errorText: "" }
 
 const baseOptions = {
@@ -66,6 +92,14 @@ function subscriberFor(plugin: Plugin, event: string) {
   if (!subscriber) throw new Error(`Missing SmartBill subscriber for ${event}`)
   return subscriber
 }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  financeServiceMock.registerInvoiceExternalRef.mockResolvedValue({ id: "iex_1" })
+  financeServiceMock.listInvoiceAttachments.mockResolvedValue([])
+  financeServiceMock.createInvoiceRendition.mockResolvedValue({ id: "invr_1" })
+  financeServiceMock.createInvoiceAttachment.mockResolvedValue({ id: "inva_1" })
+})
 
 describe("smartbillPlugin structure", () => {
   it("returns a Plugin with name and version", () => {
@@ -173,6 +207,140 @@ describe("smartbillPlugin — invoice.issued subscriber", () => {
     const plugin = smartbillPlugin({ ...baseOptions, fetch: fetchMock })
     await subscriberFor(plugin, "invoice.issued").handler(eventEnvelope({ noId: true }))
     expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("accepts finance issued events that carry invoiceId", async () => {
+    const fetchMock = vi.fn<SmartbillFetch>(async () =>
+      jsonResponse(200, { ...okEnvelope, number: "1", series: "A" }),
+    )
+    const plugin = smartbillPlugin({ ...baseOptions, fetch: fetchMock, logger: makeLogger() })
+    const handler = subscriberFor(plugin, "invoice.issued").handler
+
+    await handler(
+      eventEnvelope({
+        invoiceId: "inv_from_finance",
+        clientName: "Test SRL",
+        currency: "RON",
+        lineItems: [{ name: "Tour", quantity: 1, unitPrice: 50000 }],
+      }),
+    )
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+  })
+})
+
+describe("smartbillPlugin — invoice PDF artifacts", () => {
+  it("registers the SmartBill ref and persists the generated invoice PDF when storage is configured", async () => {
+    const pdfBytes = new TextEncoder().encode("%PDF-1.7 smartbill")
+    const fetchMock = vi
+      .fn<SmartbillFetch>()
+      .mockResolvedValueOnce(jsonResponse(200, { ...okEnvelope, number: "1", series: "A" }))
+      .mockResolvedValueOnce(bytesResponse(200, pdfBytes))
+    const upload = vi
+      .fn()
+      .mockResolvedValue({ key: "invoices/inv_123/smartbill/invoice-A-1.pdf", url: "" })
+    const storage = {
+      name: "test-storage",
+      upload,
+      delete: vi.fn(),
+      signedUrl: vi.fn(),
+      get: vi.fn(),
+    }
+    const logger = makeLogger()
+    const plugin = smartbillPlugin({
+      ...baseOptions,
+      fetch: fetchMock,
+      logger,
+      artifacts: {
+        db: {} as never,
+        documentStorage: storage,
+      },
+    })
+    const handler = subscriberFor(plugin, "invoice.issued").handler
+
+    await handler(
+      eventEnvelope({
+        id: "inv_123",
+        clientName: "Test SRL",
+        currency: "RON",
+        lineItems: [{ name: "Tour", quantity: 1, unitPrice: 50000 }],
+      }),
+    )
+
+    expect(financeServiceMock.registerInvoiceExternalRef).toHaveBeenCalledWith(
+      expect.anything(),
+      "inv_123",
+      expect.objectContaining({
+        provider: "smartbill",
+        externalNumber: "1",
+        status: "issued",
+      }),
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(String(fetchMock.mock.calls[1]![0])).toContain("/invoice/pdf")
+    expect(upload).toHaveBeenCalledWith(
+      pdfBytes,
+      expect.objectContaining({ contentType: "application/pdf" }),
+    )
+    expect(financeServiceMock.createInvoiceRendition).toHaveBeenCalledWith(
+      expect.anything(),
+      "inv_123",
+      expect.objectContaining({
+        format: "pdf",
+        status: "ready",
+        storageKey: "invoices/inv_123/smartbill/invoice-A-1.pdf",
+      }),
+    )
+    expect(financeServiceMock.createInvoiceAttachment).toHaveBeenCalledWith(
+      expect.anything(),
+      "inv_123",
+      expect.objectContaining({
+        kind: "smartbill_pdf",
+        name: "SmartBill invoice A-1.pdf",
+        storageKey: "invoices/inv_123/smartbill/invoice-A-1.pdf",
+      }),
+    )
+  })
+
+  it("does not upload again when a SmartBill PDF attachment already exists", async () => {
+    financeServiceMock.listInvoiceAttachments.mockResolvedValueOnce([
+      { id: "inva_existing", kind: "smartbill_pdf" },
+    ])
+    const fetchMock = vi.fn<SmartbillFetch>(async () =>
+      jsonResponse(200, { ...okEnvelope, number: "1", series: "A" }),
+    )
+    const upload = vi.fn()
+    const storage = {
+      name: "test-storage",
+      upload,
+      delete: vi.fn(),
+      signedUrl: vi.fn(),
+      get: vi.fn(),
+    }
+    const plugin = smartbillPlugin({
+      ...baseOptions,
+      fetch: fetchMock,
+      logger: makeLogger(),
+      artifacts: {
+        db: {} as never,
+        documentStorage: storage,
+      },
+    })
+    const handler = subscriberFor(plugin, "invoice.issued").handler
+
+    await handler(
+      eventEnvelope({
+        id: "inv_123",
+        clientName: "Test SRL",
+        currency: "RON",
+        lineItems: [{ name: "Tour", quantity: 1, unitPrice: 50000 }],
+      }),
+    )
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    expect(upload).not.toHaveBeenCalled()
+    expect(financeServiceMock.createInvoiceRendition).not.toHaveBeenCalled()
+    expect(financeServiceMock.createInvoiceAttachment).not.toHaveBeenCalled()
   })
 })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,7 +155,7 @@ importers:
         version: 1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@better-auth/api-key':
         specifier: ^1.5.6
-        version: 1.5.6(1f1bbcdf0f17a0d068016c0095f7b39e)
+        version: 1.5.6(528a90069b32ded3cd69e6bc8dd18c96)
       '@cloudflare/vite-plugin':
         specifier: ^1.31.0
         version: 1.31.0(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260507.1)(wrangler@4.86.0(@cloudflare/workers-types@4.20260426.1))
@@ -404,7 +404,7 @@ importers:
         version: link:../../packages/workflows
       better-auth:
         specifier: ^1.5.6
-        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -959,7 +959,7 @@ importers:
     dependencies:
       '@better-auth/api-key':
         specifier: ^1.5.6
-        version: 1.5.6(1f1bbcdf0f17a0d068016c0095f7b39e)
+        version: 1.5.6(528a90069b32ded3cd69e6bc8dd18c96)
       '@voyantjs/db':
         specifier: workspace:*
         version: link:../db
@@ -968,7 +968,7 @@ importers:
         version: link:../utils
       better-auth:
         specifier: ^1.5.6
-        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
@@ -3825,6 +3825,15 @@ importers:
       '@voyantjs/core':
         specifier: workspace:*
         version: link:../../core
+      '@voyantjs/finance':
+        specifier: workspace:*
+        version: link:../../finance
+      '@voyantjs/storage':
+        specifier: workspace:*
+        version: link:../../storage
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -5226,7 +5235,7 @@ importers:
         version: 1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@better-auth/api-key':
         specifier: ^1.5.6
-        version: 1.5.6(1f1bbcdf0f17a0d068016c0095f7b39e)
+        version: 1.5.6(528a90069b32ded3cd69e6bc8dd18c96)
       '@cloudflare/vite-plugin':
         specifier: ^1.31.0
         version: 1.31.0(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260401.1)(wrangler@4.80.0(@cloudflare/workers-types@4.20260426.1))
@@ -5424,7 +5433,7 @@ importers:
         version: link:../../packages/workflows
       better-auth:
         specifier: ^1.5.6
-        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -5563,7 +5572,7 @@ importers:
         version: 1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@better-auth/api-key':
         specifier: ^1.5.6
-        version: 1.5.6(1f1bbcdf0f17a0d068016c0095f7b39e)
+        version: 1.5.6(528a90069b32ded3cd69e6bc8dd18c96)
       '@cloudflare/vite-plugin':
         specifier: ^1.36.3
         version: 1.36.3(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260507.1)(wrangler@4.90.0(@cloudflare/workers-types@4.20260426.1))
@@ -5854,7 +5863,7 @@ importers:
         version: link:../../packages/workflows-orchestrator-cloudflare
       better-auth:
         specifier: ^1.5.6
-        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -12966,11 +12975,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@better-auth/api-key@1.5.6(1f1bbcdf0f17a0d068016c0095f7b39e)':
+  '@better-auth/api-key@1.5.6(528a90069b32ded3cd69e6bc8dd18c96)':
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
-      better-auth: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
+      better-auth: 1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))
       zod: 4.3.6
 
   '@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)':
@@ -15900,7 +15909,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.14: {}
 
-  better-auth@1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))):
+  better-auth@1.5.6(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0(socks@2.8.7))(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))):
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))


### PR DESCRIPTION
## Summary

- add optional SmartBill artifact persistence for issued invoices and proformas
- register/update SmartBill invoice external refs through finance when a DB resolver is configured
- download generated SmartBill PDFs, upload them to document storage, and create ready `invoice_renditions` plus `smartbill_pdf` `invoice_attachments`
- stop before PDF download/upload when the finance invoice row is missing
- keep artifact writes idempotent by reusing an existing SmartBill PDF attachment
- accept first-party finance issue events that carry `invoiceId`

Closes #622.

## Verification

- `pnpm --filter @voyantjs/plugin-smartbill lint`
- `pnpm --filter @voyantjs/plugin-smartbill typecheck`
- `pnpm --filter @voyantjs/plugin-smartbill test`
- `pnpm --filter @voyantjs/plugin-smartbill build`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm typecheck:affected`
- `pnpm test:affected`
- `pnpm verify:architecture`
- commit hook ran full workspace lint and full workspace typecheck successfully
- latest pre-push hook ran full `pnpm test` successfully

## Notes

- Plain `pnpm verify:fast` hit Node heap OOM in affected app/template typechecks; rerunning affected typecheck with the repo's 8GB heap setting passed.
- `pnpm verify:package-exports` fails on unrelated pre-existing missing build outputs/exports across multiple packages.