### PR TITLE
Capture multi-viewport browser evidence

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -166,8 +166,9 @@ Capture-browser mode writes screenshots, video, console logs, failed-request
 logs, and a summary under `docs/agent-evidence/browser/...` inside the claimed
 workspace. By default it targets the deterministic issue URL in
 `VOYANT_AGENT_DEV_SERVER_URL`; pass `--url` for an already-running app or a
-specific route. The command prints a multi-line value that can be passed as
-`--ui-evidence` to `handoff` or `run-command`.
+specific route. Use `--viewports 1440x900,390x844` to capture desktop and
+mobile evidence in the same artifact packet. The command prints a multi-line
+value that can be passed as `--ui-evidence` to `handoff` or `run-command`.
 
 Use the read-only status view to inspect the current queue and active work:
 

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1106,9 +1106,10 @@ supervised commands through `VOYANT_AGENT_*` environment variables, rejects
 handoff and successful run-command transitions for UI-labeled work that lacks
 browser evidence or an accepted exception, and provides a Playwright capture
 command for screenshot, video, console, failed-request, and summary artifacts.
-Queue status and tick output also surface browser-evidence obligations for
-active UI work; capture recommendations remain explicit and are not dispatched
-automatically.
+The capture command supports multi-viewport evidence packets so responsive UI
+work can include desktop and mobile proof from one run. Queue status and tick
+output also surface browser-evidence obligations for active UI work; capture
+recommendations remain explicit and are not dispatched automatically.
 
 Verification:
 

--- a/scripts/agent-runner-capture-browser.mjs
+++ b/scripts/agent-runner-capture-browser.mjs
@@ -14,9 +14,11 @@ import {
 import {
   browserArtifactPlan,
   browserCapturePlan,
+  browserCapturePlans,
   browserEvidenceEnvironment,
   browserEvidenceText,
   captureBrowserEvidence,
+  captureBrowserEvidenceSet,
   requiresBrowserEvidence,
 } from "./lib/agent-runner-browser-evidence.mjs"
 import {
@@ -36,7 +38,8 @@ maybePrintHelp(args, {
     ["--url <url>", "URL to capture. Defaults to the issue-scoped local dev server URL."],
     ["--dev-server-command <shell>", "Optional dev server command to start before capture."],
     ["--workspace <path>", "Workspace path override."],
-    ["--viewport <size>", "Viewport as <width>x<height>. Defaults to 1440x900."],
+    ["--viewport <size>", "Single viewport as <width>x<height>. Defaults to 1440x900."],
+    ["--viewports <sizes>", "Comma-separated viewport list, for example 1440x900,390x844."],
     ["--timeout-ms <number>", "Navigation and dev-server wait timeout. Defaults to 30000."],
     ["--screenshot-name <name>", "Screenshot file name. Defaults to page.png."],
     ["--browser-base-port <number>", "Base port for deterministic issue ports. Defaults to 4300."],
@@ -52,6 +55,10 @@ if (!args.issue) {
 
 const timeoutMs = numberArg(args.timeoutMs, 30_000, "timeout-ms")
 const browserBasePort = numberArg(args.browserBasePort, 4300, "browser-base-port")
+if (args.viewport && args.viewports) {
+  fail("use either --viewport or --viewports, not both")
+}
+
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
 const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
@@ -79,6 +86,14 @@ const capturePlan = browserCapturePlan({
   url: args.url ?? artifactPlan.devServerUrl,
   viewport: args.viewport,
 })
+const capturePlans = args.viewports
+  ? browserCapturePlans({
+      artifactPlan,
+      screenshotName: args.screenshotName,
+      url: args.url ?? artifactPlan.devServerUrl,
+      viewports: args.viewports,
+    })
+  : [capturePlan]
 
 if (!artifactPlan.safeArtifactPath) {
   fail(`capture-browser refuses artifacts outside the workspace: ${artifactPlan.artifactDir}`)
@@ -89,7 +104,7 @@ if (!existsSync(artifactPlan.workspace)) {
 }
 
 if (!args.yes) {
-  printCapturePlan({ artifactPlan, capturePlan, item, repository })
+  printCapturePlan({ artifactPlan, item, repository })
   fail("capture-browser mode writes local browser artifacts; rerun with --yes")
 }
 
@@ -110,14 +125,21 @@ let captureError
 
 try {
   if (server) {
-    await waitForUrl(capturePlan.url, { timeoutMs })
+    await waitForUrl(capturePlans[0].url, { timeoutMs })
   }
 
-  result = await captureBrowserEvidence({
-    browserLauncher: chromium,
-    capturePlan,
-    timeoutMs,
-  })
+  result =
+    capturePlans.length === 1
+      ? await captureBrowserEvidence({
+          browserLauncher: chromium,
+          capturePlan: capturePlans[0],
+          timeoutMs,
+        })
+      : await captureBrowserEvidenceSet({
+          browserLauncher: chromium,
+          capturePlans,
+          timeoutMs,
+        })
 } catch (error) {
   captureError = error
 } finally {
@@ -142,20 +164,26 @@ if (!requiresBrowserEvidence(item)) {
   console.log("Note: browser evidence is not required by this issue's labels.")
 }
 
-function printCapturePlan({ artifactPlan, capturePlan, item, repository }) {
+function printCapturePlan({ artifactPlan, item, repository }) {
   console.log("agent-runner capture-browser would capture:")
   console.log(`issue: #${item.issue.number} ${item.issue.title}`)
   console.log(`repository: ${repository}`)
   console.log(`workspace: ${artifactPlan.workspace}`)
-  console.log(`url: ${capturePlan.url}`)
-  console.log(`viewport: ${capturePlan.viewport.width}x${capturePlan.viewport.height}`)
+  console.log(`url: ${capturePlans[0].url}`)
+  console.log(`viewports: ${capturePlans.map((plan) => viewportLabel(plan.viewport)).join(", ")}`)
   console.log(`artifacts: ${artifactPlan.artifactDir}`)
-  console.log(`screenshot: ${capturePlan.screenshotFile}`)
+  for (const plan of capturePlans) {
+    console.log(`screenshot ${viewportLabel(plan.viewport)}: ${plan.screenshotFile}`)
+  }
   console.log(`console log: ${artifactPlan.consoleLog}`)
   console.log(`failed-request log: ${artifactPlan.networkLog}`)
   if (args.devServerCommand) {
     console.log(`dev server command: ${args.devServerCommand}`)
   }
+}
+
+function viewportLabel(viewport) {
+  return `${viewport.width}x${viewport.height}`
 }
 
 function startDevServer({ artifactPlan, command, env }) {

--- a/scripts/lib/agent-runner-browser-evidence.mjs
+++ b/scripts/lib/agent-runner-browser-evidence.mjs
@@ -111,12 +111,48 @@ export function browserCapturePlan({
   }
 }
 
+export function browserCapturePlans({
+  artifactPlan,
+  screenshotName = "page.png",
+  url = artifactPlan.devServerUrl,
+  viewports,
+}) {
+  const normalizedViewports = normalizeViewportList(viewports)
+  const multipleViewports = normalizedViewports.length > 1
+
+  return normalizedViewports.map((viewport) =>
+    browserCapturePlan({
+      artifactPlan,
+      screenshotName: screenshotNameForViewport(screenshotName, viewport, multipleViewports),
+      url,
+      viewport,
+    }),
+  )
+}
+
 export function safeScreenshotName(screenshotName) {
   if (!screenshotName || path.basename(screenshotName) !== screenshotName) {
     throw new Error("screenshot name must be a file name without path separators")
   }
 
   return screenshotName
+}
+
+export function normalizeViewportList(viewports) {
+  if (!viewports) return [normalizeViewport()]
+
+  const viewportValues = Array.isArray(viewports)
+    ? viewports
+    : String(viewports)
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean)
+
+  if (viewportValues.length === 0) {
+    throw new Error("at least one viewport is required")
+  }
+
+  return viewportValues.map((viewport) => normalizeViewport(viewport))
 }
 
 export function normalizeViewport(viewport) {
@@ -138,13 +174,82 @@ export async function captureBrowserEvidence({ browserLauncher, capturePlan, tim
     throw new Error("browser launcher with launch() is required")
   }
 
-  const { artifactPlan, screenshotFile, url, viewport } = capturePlan
+  const artifactPlan = capturePlan.artifactPlan
+  prepareBrowserEvidenceArtifacts(artifactPlan)
+
+  const capture = await captureSingleBrowserEvidence({
+    browserLauncher,
+    capturePlan,
+    timeoutMs,
+  })
+  const result = {
+    ...capture,
+    consoleLog: artifactPlan.consoleLog,
+    failedRequestLog: artifactPlan.networkLog,
+  }
+
+  writeFileSync(artifactPlan.summaryJson, `${JSON.stringify(result, null, 2)}\n`, "utf8")
+  writeFileSync(artifactPlan.readme, browserEvidenceMarkdown(result), "utf8")
+
+  return result
+}
+
+export async function captureBrowserEvidenceSet({
+  browserLauncher,
+  capturePlans,
+  timeoutMs = 30_000,
+}) {
+  if (!browserLauncher?.launch) {
+    throw new Error("browser launcher with launch() is required")
+  }
+
+  if (!Array.isArray(capturePlans) || capturePlans.length === 0) {
+    throw new Error("at least one browser capture plan is required")
+  }
+
+  const artifactPlan = capturePlans[0].artifactPlan
+  for (const capturePlan of capturePlans) {
+    if (capturePlan.artifactPlan !== artifactPlan) {
+      throw new Error("browser capture plans must share an artifact plan")
+    }
+  }
+
+  prepareBrowserEvidenceArtifacts(artifactPlan)
+
+  const captures = []
+  for (const capturePlan of capturePlans) {
+    captures.push(
+      await captureSingleBrowserEvidence({
+        browserLauncher,
+        capturePlan,
+        timeoutMs,
+      }),
+    )
+  }
+
+  const result = {
+    artifactPointer: artifactPlan.artifactPointer,
+    captures,
+    consoleLog: artifactPlan.consoleLog,
+    failedRequestLog: artifactPlan.networkLog,
+  }
+
+  writeFileSync(artifactPlan.summaryJson, `${JSON.stringify(result, null, 2)}\n`, "utf8")
+  writeFileSync(artifactPlan.readme, browserEvidenceMarkdown(result), "utf8")
+
+  return result
+}
+
+function prepareBrowserEvidenceArtifacts(artifactPlan) {
   mkdirSync(artifactPlan.artifactDir, { recursive: true })
   mkdirSync(artifactPlan.screenshotDir, { recursive: true })
   mkdirSync(artifactPlan.videoDir, { recursive: true })
   writeFileSync(artifactPlan.consoleLog, "", "utf8")
   writeFileSync(artifactPlan.networkLog, "", "utf8")
+}
 
+async function captureSingleBrowserEvidence({ browserLauncher, capturePlan, timeoutMs }) {
+  const { artifactPlan, screenshotFile, url, viewport } = capturePlan
   const browser = await browserLauncher.launch({ headless: true })
   let context
   let page
@@ -173,23 +278,33 @@ export async function captureBrowserEvidence({ browserLauncher, capturePlan, tim
     await browser.close().catch(() => undefined)
   }
 
-  const result = {
+  return {
     artifactPointer: artifactPlan.artifactPointer,
-    consoleLog: artifactPlan.consoleLog,
-    failedRequestLog: artifactPlan.networkLog,
     screenshot: screenshotFile,
     url,
     video: videoPath,
     viewport,
   }
-
-  writeFileSync(artifactPlan.summaryJson, `${JSON.stringify(result, null, 2)}\n`, "utf8")
-  writeFileSync(artifactPlan.readme, browserEvidenceMarkdown(result), "utf8")
-
-  return result
 }
 
 export function browserEvidenceText(result) {
+  if (Array.isArray(result.captures)) {
+    const lines = [`browser artifacts: ${result.artifactPointer}`]
+
+    for (const capture of result.captures) {
+      lines.push(
+        `capture ${capture.viewport.width}x${capture.viewport.height}: ${capture.url}`,
+        `screenshot: ${capture.screenshot}`,
+      )
+      if (capture.video) lines.push(`video: ${capture.video}`)
+    }
+
+    lines.push(`console log: ${result.consoleLog}`)
+    lines.push(`failed-request log: ${result.failedRequestLog}`)
+
+    return lines.join("\n")
+  }
+
   const lines = [
     `browser artifacts: ${result.artifactPointer}`,
     `url: ${result.url}`,
@@ -204,6 +319,36 @@ export function browserEvidenceText(result) {
 }
 
 export function browserEvidenceMarkdown(result) {
+  if (Array.isArray(result.captures)) {
+    const captureLines = result.captures
+      .map((capture) =>
+        [
+          `### ${capture.viewport.width}x${capture.viewport.height}`,
+          "",
+          `URL: ${capture.url}`,
+          `Screenshot: ${capture.screenshot}`,
+          capture.video ? `Video: ${capture.video}` : null,
+        ]
+          .filter(Boolean)
+          .join("\n"),
+      )
+      .join("\n\n")
+
+    return `# Browser Evidence
+
+Artifacts: ${result.artifactPointer}
+
+## Captures
+
+${captureLines}
+
+## Logs
+
+- Console log: ${result.consoleLog}
+- Failed-request log: ${result.failedRequestLog}
+`
+  }
+
   return `# Browser Evidence
 
 URL: ${result.url}
@@ -217,6 +362,15 @@ Viewport: ${result.viewport.width}x${result.viewport.height}
 - Failed-request log: ${result.failedRequestLog}
 ${result.video ? `- Video: ${result.video}\n` : ""}
 `
+}
+
+function screenshotNameForViewport(screenshotName, viewport, multipleViewports) {
+  const safeName = safeScreenshotName(screenshotName)
+  if (!multipleViewports) return safeName
+
+  const extension = path.extname(safeName) || ".png"
+  const stem = path.basename(safeName, path.extname(safeName))
+  return `${stem}-${viewport.width}x${viewport.height}${extension}`
 }
 
 function wireBrowserEvidenceEvents({ artifactPlan, page }) {

--- a/scripts/tests/agent-runner-browser-evidence.test.mjs
+++ b/scripts/tests/agent-runner-browser-evidence.test.mjs
@@ -7,11 +7,14 @@ import { describe, it } from "node:test"
 import {
   browserArtifactPlan,
   browserCapturePlan,
+  browserCapturePlans,
   browserEvidenceEnvironment,
   browserEvidenceMissingReason,
   browserEvidenceReferenceKind,
   browserEvidenceText,
   captureBrowserEvidence,
+  captureBrowserEvidenceSet,
+  normalizeViewportList,
   requiresBrowserEvidence,
   safeScreenshotName,
 } from "../lib/agent-runner-browser-evidence.mjs"
@@ -215,6 +218,27 @@ describe("agent runner browser evidence helpers", () => {
     )
   })
 
+  it("plans named browser screenshots for multiple viewports", () => {
+    const artifactPlan = browserArtifactPlan({
+      item: workItem(),
+      repoRoot: "/repo",
+      workspaceReference: ".agent-worktrees/task",
+    })
+    const plans = browserCapturePlans({
+      artifactPlan,
+      screenshotName: "after.png",
+      viewports: "1440x900,390x844",
+    })
+
+    assert.deepEqual(normalizeViewportList("1440x900,390x844"), [
+      { height: 900, width: 1440 },
+      { height: 844, width: 390 },
+    ])
+    assert.equal(path.basename(plans[0].screenshotFile), "after-1440x900.png")
+    assert.equal(path.basename(plans[1].screenshotFile), "after-390x844.png")
+    assert.throws(() => normalizeViewportList(","), /at least one viewport is required/)
+  })
+
   it("captures browser evidence through an injected browser launcher", async () => {
     const tempDir = mkdtempSync(path.join(os.tmpdir(), "voyant-browser-evidence-"))
     try {
@@ -240,12 +264,51 @@ describe("agent runner browser evidence helpers", () => {
       assert.equal(result.viewport.width, 390)
       assert.equal(result.viewport.height, 844)
       assert.equal(result.url, "http://127.0.0.1:4879/dashboard")
+      assert.equal(result.consoleLog, artifactPlan.consoleLog)
+      assert.equal(result.failedRequestLog, artifactPlan.networkLog)
       assert.equal(existsSync(result.screenshot), true)
       assert.match(readFileSync(artifactPlan.consoleLog, "utf8"), /loaded dashboard/)
       assert.match(readFileSync(artifactPlan.networkLog, "utf8"), /http-error/)
       assert.match(readFileSync(artifactPlan.summaryJson, "utf8"), /390/)
+      assert.doesNotMatch(readFileSync(artifactPlan.summaryJson, "utf8"), /"captures"/)
       assert.match(readFileSync(artifactPlan.readme, "utf8"), /Browser Evidence/)
       assert.match(browserEvidenceText(result), /failed-request log:/)
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true })
+    }
+  })
+
+  it("captures a combined browser evidence packet for multiple viewports", async () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "voyant-browser-evidence-"))
+    try {
+      const item = workItem()
+      const artifactPlan = browserArtifactPlan({
+        date: new Date("2026-05-10T12:34:56.000Z"),
+        item,
+        repoRoot: tempDir,
+        workspaceReference: ".",
+      })
+      const capturePlans = browserCapturePlans({
+        artifactPlan,
+        screenshotName: "page.png",
+        url: "http://127.0.0.1:4879/dashboard",
+        viewports: "1440x900,390x844",
+      })
+
+      const result = await captureBrowserEvidenceSet({
+        browserLauncher: new FakeBrowserLauncher(),
+        capturePlans,
+        timeoutMs: 1000,
+      })
+
+      assert.equal(result.captures.length, 2)
+      assert.equal(path.basename(result.captures[0].screenshot), "page-1440x900.png")
+      assert.equal(path.basename(result.captures[1].screenshot), "page-390x844.png")
+      assert.equal(existsSync(result.captures[0].screenshot), true)
+      assert.equal(existsSync(result.captures[1].screenshot), true)
+      assert.match(readFileSync(artifactPlan.summaryJson, "utf8"), /"captures"/)
+      assert.match(readFileSync(artifactPlan.readme, "utf8"), /1440x900/)
+      assert.match(browserEvidenceText(result), /capture 390x844/)
     } finally {
       rmSync(tempDir, { force: true, recursive: true })
     }


### PR DESCRIPTION
## Summary
- add multi-viewport browser evidence plans for desktop/mobile capture in one artifact packet
- keep single-viewport capture output backward-compatible while adding combined summaries for multi-viewport runs
- document `--viewports 1440x900,390x844` as the UI evidence path for responsive work

## Validation
- `node --check scripts/lib/agent-runner-browser-evidence.mjs && node --check scripts/agent-runner-capture-browser.mjs`
- `node --test scripts/tests/agent-runner-browser-evidence.test.mjs`
- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm exec secretlint scripts/lib/agent-runner-browser-evidence.mjs scripts/tests/agent-runner-browser-evidence.test.mjs scripts/agent-runner-capture-browser.mjs docs/agents/issue-tracker.md docs/architecture/agentic-engineering-orchestration.md`
- `git diff --check`
- commit hook: full lint + typecheck
- push hook: full test lane
