### PR TITLE
Summarize browser evidence issues

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -167,7 +167,9 @@ logs, and a summary under `docs/agent-evidence/browser/...` inside the claimed
 workspace. By default it targets the deterministic issue URL in
 `VOYANT_AGENT_DEV_SERVER_URL`; pass `--url` for an already-running app or a
 specific route. Use `--viewports 1440x900,390x844` to capture desktop and
-mobile evidence in the same artifact packet. The command prints a multi-line
+mobile evidence in the same artifact packet. The summary classifies console
+errors, console warnings, failed HTTP responses, and failed requests so review
+does not require opening raw JSONL logs first. The command prints a multi-line
 value that can be passed as `--ui-evidence` to `handoff` or `run-command`.
 
 Use the read-only status view to inspect the current queue and active work:

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1107,9 +1107,12 @@ handoff and successful run-command transitions for UI-labeled work that lacks
 browser evidence or an accepted exception, and provides a Playwright capture
 command for screenshot, video, console, failed-request, and summary artifacts.
 The capture command supports multi-viewport evidence packets so responsive UI
-work can include desktop and mobile proof from one run. Queue status and tick
-output also surface browser-evidence obligations for active UI work; capture
-recommendations remain explicit and are not dispatched automatically.
+work can include desktop and mobile proof from one run. Browser summaries
+classify console errors, console warnings, failed HTTP responses, and failed
+requests so reviewers can see quality signals without opening raw logs. Queue
+status and tick output also surface browser-evidence obligations for active UI
+work; capture recommendations remain explicit and are not dispatched
+automatically.
 
 Verification:
 

--- a/scripts/lib/agent-runner-browser-evidence.mjs
+++ b/scripts/lib/agent-runner-browser-evidence.mjs
@@ -1,6 +1,11 @@
 import { mkdirSync, writeFileSync } from "node:fs"
 import path from "node:path"
 
+import {
+  browserIssueMarkdown,
+  formatBrowserIssueSummary,
+  summarizeBrowserEvidenceArtifact,
+} from "./agent-runner-browser-issues.mjs"
 import { localWorkspaceReferencePlan } from "./agent-runner-workspace.mjs"
 
 const uiEvidenceLabels = new Set([
@@ -184,6 +189,7 @@ export async function captureBrowserEvidence({ browserLauncher, capturePlan, tim
   })
   const result = {
     ...capture,
+    browserIssues: summarizeBrowserEvidenceArtifact(artifactPlan),
     consoleLog: artifactPlan.consoleLog,
     failedRequestLog: artifactPlan.networkLog,
   }
@@ -229,6 +235,7 @@ export async function captureBrowserEvidenceSet({
 
   const result = {
     artifactPointer: artifactPlan.artifactPointer,
+    browserIssues: summarizeBrowserEvidenceArtifact(artifactPlan),
     captures,
     consoleLog: artifactPlan.consoleLog,
     failedRequestLog: artifactPlan.networkLog,
@@ -299,6 +306,9 @@ export function browserEvidenceText(result) {
       if (capture.video) lines.push(`video: ${capture.video}`)
     }
 
+    if (result.browserIssues) {
+      lines.push(`browser issue summary: ${formatBrowserIssueSummary(result.browserIssues)}`)
+    }
     lines.push(`console log: ${result.consoleLog}`)
     lines.push(`failed-request log: ${result.failedRequestLog}`)
 
@@ -309,9 +319,12 @@ export function browserEvidenceText(result) {
     `browser artifacts: ${result.artifactPointer}`,
     `url: ${result.url}`,
     `screenshot: ${result.screenshot}`,
+    result.browserIssues
+      ? `browser issue summary: ${formatBrowserIssueSummary(result.browserIssues)}`
+      : null,
     `console log: ${result.consoleLog}`,
     `failed-request log: ${result.failedRequestLog}`,
-  ]
+  ].filter(Boolean)
 
   if (result.video) lines.push(`video: ${result.video}`)
 
@@ -344,6 +357,8 @@ ${captureLines}
 
 ## Logs
 
+${browserIssueMarkdown(result.browserIssues)}
+
 - Console log: ${result.consoleLog}
 - Failed-request log: ${result.failedRequestLog}
 `
@@ -356,6 +371,8 @@ Artifacts: ${result.artifactPointer}
 Viewport: ${result.viewport.width}x${result.viewport.height}
 
 ## Files
+
+${browserIssueMarkdown(result.browserIssues)}
 
 - Screenshot: ${result.screenshot}
 - Console log: ${result.consoleLog}

--- a/scripts/lib/agent-runner-browser-issues.mjs
+++ b/scripts/lib/agent-runner-browser-issues.mjs
@@ -1,0 +1,74 @@
+import { readFileSync } from "node:fs"
+
+export function summarizeBrowserEvidenceArtifact(artifactPlan) {
+  return summarizeBrowserEvidenceIssues({
+    consoleLogText: readFileSync(artifactPlan.consoleLog, "utf8"),
+    networkLogText: readFileSync(artifactPlan.networkLog, "utf8"),
+  })
+}
+
+export function summarizeBrowserEvidenceIssues({ consoleLogText = "", networkLogText = "" } = {}) {
+  const consoleEvents = parseJsonLines(consoleLogText)
+  const networkEvents = parseJsonLines(networkLogText)
+  const consoleErrors = consoleEvents.filter((event) =>
+    ["error", "pageerror"].includes(String(event.type)),
+  ).length
+  const consoleWarnings = consoleEvents.filter((event) =>
+    ["warning", "warn"].includes(String(event.type)),
+  ).length
+  const httpErrors = networkEvents.filter((event) => event.type === "http-error").length
+  const requestFailures = networkEvents.filter((event) => event.type === "requestfailed").length
+  const malformedLogLines = [...consoleEvents, ...networkEvents].filter(
+    (event) => event.type === "malformed-jsonl",
+  ).length
+  const failedRequests = httpErrors + requestFailures
+
+  return {
+    consoleErrors,
+    consoleWarnings,
+    failedRequests,
+    hasBlockingIssues: consoleErrors > 0 || failedRequests > 0 || malformedLogLines > 0,
+    httpErrors,
+    malformedLogLines,
+    requestFailures,
+  }
+}
+
+export function formatBrowserIssueSummary(summary) {
+  return [
+    `${summary.consoleErrors} console error${summary.consoleErrors === 1 ? "" : "s"}`,
+    `${summary.consoleWarnings} console warning${summary.consoleWarnings === 1 ? "" : "s"}`,
+    `${summary.failedRequests} failed request${summary.failedRequests === 1 ? "" : "s"}`,
+    summary.malformedLogLines
+      ? `${summary.malformedLogLines} malformed log line${
+          summary.malformedLogLines === 1 ? "" : "s"
+        }`
+      : null,
+  ]
+    .filter(Boolean)
+    .join(", ")
+}
+
+export function browserIssueMarkdown(summary) {
+  if (!summary) return ""
+
+  return `## Browser Issue Summary
+
+- ${formatBrowserIssueSummary(summary)}
+- Blocking issues: ${summary.hasBlockingIssues ? "yes" : "no"}
+`
+}
+
+function parseJsonLines(text) {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        return JSON.parse(line)
+      } catch {
+        return { raw: line, type: "malformed-jsonl" }
+      }
+    })
+}

--- a/scripts/tests/agent-runner-browser-evidence.test.mjs
+++ b/scripts/tests/agent-runner-browser-evidence.test.mjs
@@ -18,6 +18,7 @@ import {
   requiresBrowserEvidence,
   safeScreenshotName,
 } from "../lib/agent-runner-browser-evidence.mjs"
+import { summarizeBrowserEvidenceIssues } from "../lib/agent-runner-browser-issues.mjs"
 import {
   buildCommandEvidencePacket,
   commandRunArtifactPlan,
@@ -218,6 +219,32 @@ describe("agent runner browser evidence helpers", () => {
     )
   })
 
+  it("summarizes browser console and request issues", () => {
+    assert.deepEqual(
+      summarizeBrowserEvidenceIssues({
+        consoleLogText: [
+          JSON.stringify({ text: "loaded", type: "log" }),
+          JSON.stringify({ text: "React hydration failed", type: "error" }),
+          JSON.stringify({ text: "deprecated style", type: "warning" }),
+          "not json",
+        ].join("\n"),
+        networkLogText: [
+          JSON.stringify({ status: 404, type: "http-error" }),
+          JSON.stringify({ failure: "net::ERR_FAILED", type: "requestfailed" }),
+        ].join("\n"),
+      }),
+      {
+        consoleErrors: 1,
+        consoleWarnings: 1,
+        failedRequests: 2,
+        hasBlockingIssues: true,
+        httpErrors: 1,
+        malformedLogLines: 1,
+        requestFailures: 1,
+      },
+    )
+  })
+
   it("plans named browser screenshots for multiple viewports", () => {
     const artifactPlan = browserArtifactPlan({
       item: workItem(),
@@ -266,13 +293,24 @@ describe("agent runner browser evidence helpers", () => {
       assert.equal(result.url, "http://127.0.0.1:4879/dashboard")
       assert.equal(result.consoleLog, artifactPlan.consoleLog)
       assert.equal(result.failedRequestLog, artifactPlan.networkLog)
+      assert.deepEqual(result.browserIssues, {
+        consoleErrors: 0,
+        consoleWarnings: 0,
+        failedRequests: 1,
+        hasBlockingIssues: true,
+        httpErrors: 1,
+        malformedLogLines: 0,
+        requestFailures: 0,
+      })
       assert.equal(existsSync(result.screenshot), true)
       assert.match(readFileSync(artifactPlan.consoleLog, "utf8"), /loaded dashboard/)
       assert.match(readFileSync(artifactPlan.networkLog, "utf8"), /http-error/)
       assert.match(readFileSync(artifactPlan.summaryJson, "utf8"), /390/)
       assert.doesNotMatch(readFileSync(artifactPlan.summaryJson, "utf8"), /"captures"/)
       assert.match(readFileSync(artifactPlan.readme, "utf8"), /Browser Evidence/)
+      assert.match(readFileSync(artifactPlan.readme, "utf8"), /Browser Issue Summary/)
       assert.match(browserEvidenceText(result), /failed-request log:/)
+      assert.match(browserEvidenceText(result), /browser issue summary:/)
     } finally {
       rmSync(tempDir, { force: true, recursive: true })
     }
@@ -302,6 +340,8 @@ describe("agent runner browser evidence helpers", () => {
       })
 
       assert.equal(result.captures.length, 2)
+      assert.equal(result.browserIssues.failedRequests, 2)
+      assert.equal(result.browserIssues.hasBlockingIssues, true)
       assert.equal(path.basename(result.captures[0].screenshot), "page-1440x900.png")
       assert.equal(path.basename(result.captures[1].screenshot), "page-390x844.png")
       assert.equal(existsSync(result.captures[0].screenshot), true)


### PR DESCRIPTION
## Summary
- classify browser evidence console and network logs into a compact issue summary
- include browser issue summaries in evidence JSON, README, and handoff text
- document the new review signals for UI evidence packets

## Validation
- `node --check scripts/lib/agent-runner-browser-evidence.mjs`
- `node --check scripts/lib/agent-runner-browser-issues.mjs`
- `node --test scripts/tests/agent-runner-browser-evidence.test.mjs`
- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm exec secretlint scripts/lib/agent-runner-browser-evidence.mjs scripts/lib/agent-runner-browser-issues.mjs scripts/tests/agent-runner-browser-evidence.test.mjs docs/agents/issue-tracker.md docs/architecture/agentic-engineering-orchestration.md`
- `git diff --check`
- commit hook: full lint + typecheck
- push hook: full test lane
