### PR TITLE
Fix operator reindex lint

### DIFF
--- a/templates/operator/scripts/reindex.ts
+++ b/templates/operator/scripts/reindex.ts
@@ -221,7 +221,7 @@ for (const cfg of VERTICAL_CONFIGS) {
 
 interface OrphanProbeDoc {
   id: string
-  ["source.kind"]?: string
+  "source.kind"?: string
 }
 
 async function listOwnedOrphans(


### PR DESCRIPTION
## Summary
- use a literal dotted property key in the operator reindex orphan probe type
- restore full Biome lint compatibility on current main

## Validation
- `pnpm exec biome check templates/operator/scripts/reindex.ts`
- `pnpm exec secretlint templates/operator/scripts/reindex.ts`
- `git diff --check origin/main...HEAD`
- pre-push test suite
