### PR TITLE
Validate browser evidence handoff

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -174,6 +174,10 @@ fails after writing artifacts when the summary contains console errors, failed
 requests, or malformed log lines; pass `--allow-browser-issues` only when a
 maintainer accepts a documented exception. The command prints a multi-line
 value that can be passed as `--ui-evidence` to `handoff` or `run-command`.
+When `handoff` or successful `run-command` receives a local browser artifact
+reference, it reads the artifact `summary.json` and blocks handoff if that
+summary still contains blocking browser issues unless `--allow-browser-issues`
+is used with a maintainer-approved exception.
 
 Use the read-only status view to inspect the current queue and active work:
 

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1112,9 +1112,11 @@ classify console errors, console warnings, failed HTTP responses, and failed
 requests so reviewers can see quality signals without opening raw logs. For
 UI-labeled work, capture fails after writing artifacts when those summaries
 contain blocking issues unless the runner passes an explicit accepted exception.
-Queue status and tick output also surface browser-evidence obligations for
-active UI work; capture recommendations remain explicit and are not dispatched
-automatically.
+Handoff and successful run-command transitions also validate local browser
+artifact summaries before moving UI-labeled work to review, so stale or manually
+pasted bad artifacts do not bypass the capture gate. Queue status and tick
+output also surface browser-evidence obligations for active UI work; capture
+recommendations remain explicit and are not dispatched automatically.
 
 Verification:
 

--- a/scripts/agent-runner-handoff.mjs
+++ b/scripts/agent-runner-handoff.mjs
@@ -12,6 +12,7 @@ import {
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import { browserEvidenceMissingReason } from "./lib/agent-runner-browser-evidence.mjs"
+import { browserEvidenceQualityBlockReason } from "./lib/agent-runner-browser-validation.mjs"
 import {
   maybePrintHelp,
   mutationOptions,
@@ -34,6 +35,10 @@ maybePrintHelp(args, {
     [
       "--ui-evidence <text>",
       "Required browser artifacts or approved exception for UI-labeled work.",
+    ],
+    [
+      "--allow-browser-issues",
+      "Allow UI evidence with browser quality issues after maintainer review.",
     ],
     ["--evidence-path <path>", "Evidence path relative to the task workspace."],
     ["--branch <name>", "Branch reference to record in the evidence packet."],
@@ -92,6 +97,18 @@ const { workspace } = localWorkspaceReferencePlan({
 })
 if (!existsSync(workspace)) {
   fail(`workspace does not exist: ${workspace}`)
+}
+
+const browserEvidenceQualityReason = browserEvidenceQualityBlockReason({
+  allowBrowserIssues: Boolean(args.allowBrowserIssues),
+  item,
+  uiEvidence: args.uiEvidence,
+  workspace,
+})
+if (browserEvidenceQualityReason) {
+  fail(
+    `${browserEvidenceQualityReason}; pass --allow-browser-issues only with an accepted exception`,
+  )
 }
 
 const evidencePointer =

--- a/scripts/agent-runner-run-command.mjs
+++ b/scripts/agent-runner-run-command.mjs
@@ -43,6 +43,10 @@ maybePrintHelp(args, {
       "--ui-evidence <text>",
       "Required browser artifacts or approved exception for successful UI-labeled work.",
     ],
+    [
+      "--allow-browser-issues",
+      "Allow UI evidence with browser quality issues after maintainer review.",
+    ],
     ["--force", "Allow command execution outside the normal run states."],
     ...repositoryOptions,
     ...mutationOptions,
@@ -127,10 +131,12 @@ const exitCode = await runLoggedCommand({
 })
 const stoppedAt = new Date()
 const blockedBy = commandRunBrowserEvidenceBlockReason({
+  allowBrowserIssues: Boolean(args.allowBrowserIssues),
   exitCode,
   force: Boolean(args.force),
   item,
   uiEvidence: args.uiEvidence,
+  workspace: artifactPlan.workspace,
 })
 const finalUpdate = commandRunFieldUpdate({
   blockedBy,

--- a/scripts/lib/agent-runner-browser-validation.mjs
+++ b/scripts/lib/agent-runner-browser-validation.mjs
@@ -1,0 +1,73 @@
+import { existsSync, readFileSync } from "node:fs"
+import path from "node:path"
+
+import { requiresBrowserEvidence } from "./agent-runner-browser-evidence.mjs"
+import { browserIssueBlockReason } from "./agent-runner-browser-issues.mjs"
+
+export function browserEvidenceQualityBlockReason({
+  allowBrowserIssues = false,
+  item,
+  uiEvidence,
+  workspace,
+}) {
+  if (!requiresBrowserEvidence(item)) return null
+
+  const summaryPlan = browserEvidenceSummaryPlan({ uiEvidence, workspace })
+  if (!summaryPlan) return null
+  if (!summaryPlan.safePath) {
+    return `browser evidence summary is outside the workspace: ${summaryPlan.reference}`
+  }
+  if (!existsSync(summaryPlan.summaryPath)) {
+    return `browser evidence summary was not found: ${summaryPlan.reference}`
+  }
+
+  const summary = readBrowserEvidenceSummary(summaryPlan.summaryPath)
+  if (!summary.ok) {
+    return `browser evidence summary is malformed: ${summaryPlan.reference}`
+  }
+
+  return browserIssueBlockReason(summary.browserIssues, { allowBrowserIssues })
+}
+
+export function browserEvidenceSummaryPlan({ uiEvidence, workspace }) {
+  const reference = browserEvidenceReferenceFromText(uiEvidence)
+  if (!reference) return null
+  if (!workspace) return null
+
+  const summaryReference = reference.endsWith("/summary.json")
+    ? reference
+    : path.posix.join(reference, "summary.json")
+  const summaryPath = path.resolve(workspace, summaryReference)
+
+  return {
+    reference: summaryReference,
+    safePath: isPathInside(summaryPath, workspace),
+    summaryPath,
+  }
+}
+
+function browserEvidenceReferenceFromText(uiEvidence) {
+  const match = uiEvidence?.match(/docs\/agent-evidence\/browser\/[^\s)]+/)
+  return match?.[0]?.replace(/[),.;]+$/g, "") ?? null
+}
+
+function readBrowserEvidenceSummary(summaryPath) {
+  try {
+    const summary = JSON.parse(readFileSync(summaryPath, "utf8"))
+    if (!summary?.browserIssues || typeof summary.browserIssues.hasBlockingIssues !== "boolean") {
+      return { ok: false }
+    }
+
+    return { browserIssues: summary.browserIssues, ok: true }
+  } catch (error) {
+    return {
+      ok: false,
+      parseError: error.message,
+    }
+  }
+}
+
+function isPathInside(candidatePath, parentPath) {
+  const relative = path.relative(parentPath, candidatePath)
+  return Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative)
+}

--- a/scripts/lib/agent-runner-execution.mjs
+++ b/scripts/lib/agent-runner-execution.mjs
@@ -6,6 +6,7 @@ import {
   browserEvidenceMissingReason,
   requiresBrowserEvidence,
 } from "./agent-runner-browser-evidence.mjs"
+import { browserEvidenceQualityBlockReason } from "./agent-runner-browser-validation.mjs"
 import { ciRepairEvidenceEnvironment, resolveCiRepairEvidencePath } from "./agent-runner-ci.mjs"
 import { localWorkspaceReferencePlan } from "./agent-runner-workspace.mjs"
 import {
@@ -87,17 +88,29 @@ export function commandRunEnvironment({ artifactPlan, branch, item, repository }
 }
 
 export function commandRunBrowserEvidenceBlockReason({
+  allowBrowserIssues = false,
   exitCode,
   force = false,
   item,
   uiEvidence,
+  workspace,
 }) {
   if (exitCode !== 0 || force) return null
 
   const missingReason = browserEvidenceMissingReason(item, uiEvidence)
-  if (!missingReason) return null
+  if (missingReason) {
+    return `${missingReason}; pass --ui-evidence or --force with an accepted exception`
+  }
 
-  return `${missingReason}; pass --ui-evidence or --force with an accepted exception`
+  const qualityReason = browserEvidenceQualityBlockReason({
+    allowBrowserIssues,
+    item,
+    uiEvidence,
+    workspace,
+  })
+  if (!qualityReason) return null
+
+  return `${qualityReason}; pass --allow-browser-issues only with an accepted exception`
 }
 
 export function commandRunFieldUpdate({ blockedBy, date = new Date(), evidencePointer, exitCode }) {

--- a/scripts/tests/agent-runner-browser-validation.test.mjs
+++ b/scripts/tests/agent-runner-browser-validation.test.mjs
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { describe, it } from "node:test"
+
+import {
+  browserEvidenceQualityBlockReason,
+  browserEvidenceSummaryPlan,
+} from "../lib/agent-runner-browser-validation.mjs"
+import { commandRunBrowserEvidenceBlockReason } from "../lib/agent-runner-execution.mjs"
+import { workItem } from "./agent-fixtures.mjs"
+
+describe("agent runner browser evidence validation", () => {
+  it("resolves local browser evidence summary references inside a workspace", () => {
+    assert.deepEqual(
+      browserEvidenceSummaryPlan({
+        uiEvidence:
+          "browser artifacts: docs/agent-evidence/browser/579-test/2026-05-10T12-34-56-000Z",
+        workspace: "/repo/.agent-worktrees/task",
+      }),
+      {
+        reference: "docs/agent-evidence/browser/579-test/2026-05-10T12-34-56-000Z/summary.json",
+        safePath: true,
+        summaryPath: path.resolve(
+          "/repo/.agent-worktrees/task/docs/agent-evidence/browser/579-test/2026-05-10T12-34-56-000Z/summary.json",
+        ),
+      },
+    )
+    assert.equal(
+      browserEvidenceSummaryPlan({
+        uiEvidence: "accepted exception: static copy only",
+        workspace: "/repo/.agent-worktrees/task",
+      }),
+      null,
+    )
+  })
+
+  it("blocks local browser evidence summaries with captured blocking issues", () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "voyant-browser-validation-"))
+    try {
+      const summaryDir = path.join(
+        tempDir,
+        "docs/agent-evidence/browser/579-test/2026-05-10T12-34-56-000Z",
+      )
+      mkdirSync(summaryDir, { recursive: true })
+      writeFileSync(
+        path.join(summaryDir, "summary.json"),
+        JSON.stringify({
+          browserIssues: {
+            consoleErrors: 1,
+            consoleWarnings: 0,
+            failedRequests: 1,
+            hasBlockingIssues: true,
+            httpErrors: 1,
+            malformedLogLines: 0,
+            requestFailures: 0,
+          },
+        }),
+      )
+
+      const item = workItem()
+      item.issue.labels = ["ui"]
+      const uiEvidence =
+        "browser artifacts: docs/agent-evidence/browser/579-test/2026-05-10T12-34-56-000Z"
+
+      assert.equal(
+        browserEvidenceQualityBlockReason({ item, uiEvidence, workspace: tempDir }),
+        "browser evidence has blocking issues: 1 console error, 0 console warnings, 1 failed request",
+      )
+      assert.equal(
+        browserEvidenceQualityBlockReason({
+          allowBrowserIssues: true,
+          item,
+          uiEvidence,
+          workspace: tempDir,
+        }),
+        null,
+      )
+      assert.equal(
+        commandRunBrowserEvidenceBlockReason({
+          exitCode: 0,
+          item,
+          uiEvidence,
+          workspace: tempDir,
+        }),
+        "browser evidence has blocking issues: 1 console error, 0 console warnings, 1 failed request; pass --allow-browser-issues only with an accepted exception",
+      )
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true })
+    }
+  })
+
+  it("blocks missing, unsafe, or malformed browser summary references", () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "voyant-browser-validation-"))
+    try {
+      const item = workItem()
+      item.issue.labels = ["ui"]
+
+      assert.equal(
+        browserEvidenceQualityBlockReason({
+          allowBrowserIssues: true,
+          item,
+          uiEvidence:
+            "browser artifacts: docs/agent-evidence/browser/579-test/2026-05-10T12-34-56-000Z",
+          workspace: tempDir,
+        }),
+        "browser evidence summary was not found: docs/agent-evidence/browser/579-test/2026-05-10T12-34-56-000Z/summary.json",
+      )
+
+      assert.equal(
+        browserEvidenceQualityBlockReason({
+          allowBrowserIssues: true,
+          item,
+          uiEvidence: "browser artifacts: docs/agent-evidence/browser/../../../../outside",
+          workspace: tempDir,
+        }),
+        "browser evidence summary is outside the workspace: ../outside/summary.json",
+      )
+
+      const summaryDir = path.join(
+        tempDir,
+        "docs/agent-evidence/browser/579-test/2026-05-10T12-34-56-000Z",
+      )
+      mkdirSync(summaryDir, { recursive: true })
+      writeFileSync(path.join(summaryDir, "summary.json"), "{")
+
+      assert.equal(
+        browserEvidenceQualityBlockReason({
+          allowBrowserIssues: true,
+          item,
+          uiEvidence:
+            "browser artifacts: docs/agent-evidence/browser/579-test/2026-05-10T12-34-56-000Z",
+          workspace: tempDir,
+        }),
+        "browser evidence summary is malformed: docs/agent-evidence/browser/579-test/2026-05-10T12-34-56-000Z/summary.json",
+      )
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true })
+    }
+  })
+
+  it("does not block clean summaries or non-UI work", () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "voyant-browser-validation-"))
+    try {
+      const summaryDir = path.join(
+        tempDir,
+        "docs/agent-evidence/browser/579-test/2026-05-10T12-34-56-000Z",
+      )
+      mkdirSync(summaryDir, { recursive: true })
+      writeFileSync(
+        path.join(summaryDir, "summary.json"),
+        JSON.stringify({
+          browserIssues: {
+            consoleErrors: 0,
+            consoleWarnings: 0,
+            failedRequests: 0,
+            hasBlockingIssues: false,
+            httpErrors: 0,
+            malformedLogLines: 0,
+            requestFailures: 0,
+          },
+        }),
+      )
+
+      const uiItem = workItem()
+      uiItem.issue.labels = ["ui"]
+      assert.equal(
+        browserEvidenceQualityBlockReason({
+          item: uiItem,
+          uiEvidence:
+            "browser artifacts: docs/agent-evidence/browser/579-test/2026-05-10T12-34-56-000Z",
+          workspace: tempDir,
+        }),
+        null,
+      )
+      assert.equal(
+        browserEvidenceQualityBlockReason({
+          item: workItem({ fields: {} }),
+          uiEvidence:
+            "browser artifacts: docs/agent-evidence/browser/579-test/2026-05-10T12-34-56-000Z",
+          workspace: tempDir,
+        }),
+        null,
+      )
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- validate local browser artifact `summary.json` references during handoff and successful command runs
- block UI review transitions when browser evidence is missing, unsafe, malformed, or still contains blocking browser issues
- document the handoff validation path and the narrow `--allow-browser-issues` exception

## Validation
- `node --check scripts/lib/agent-runner-browser-validation.mjs`
- `node --check scripts/lib/agent-runner-execution.mjs`
- `node --check scripts/agent-runner-handoff.mjs`
- `node --check scripts/agent-runner-run-command.mjs`
- `node --test scripts/tests/agent-runner-browser-validation.test.mjs scripts/tests/agent-runner-browser-evidence.test.mjs scripts/tests/agent-runner-lifecycle.test.mjs`
- `pnpm agent:queue:test`
- `pnpm verify:agent-quality:changed`
- `pnpm lint:changed`
- `pnpm exec secretlint scripts/agent-runner-handoff.mjs scripts/agent-runner-run-command.mjs scripts/lib/agent-runner-browser-validation.mjs scripts/lib/agent-runner-execution.mjs scripts/tests/agent-runner-browser-validation.test.mjs docs/agents/issue-tracker.md docs/architecture/agentic-engineering-orchestration.md`
- `git diff --check`
- commit hook: lint + typecheck
- pre-push test suite
