### PR TITLE
Harden public checkout session capabilities

### DIFF
--- a/.changeset/public-checkout-capabilities.md
+++ b/.changeset/public-checkout-capabilities.md
@@ -1,0 +1,7 @@
+---
+"@voyantjs/hono": minor
+"@voyantjs/bookings": minor
+"@voyantjs/finance": minor
+---
+
+Harden public checkout sessions with scoped signed capabilities. Public booking-session creation now returns a short-lived checkout capability and sets an HttpOnly SameSite cookie; PII-bearing session reads, session mutations, repricing/finalization, and public finance payment bootstrap/read routes require that booking-scoped capability. Public mutable checkout/payment routes also accept the shared `Idempotency-Key` retry middleware where it was missing.

--- a/docs/architecture/storefront-architecture.md
+++ b/docs/architecture/storefront-architecture.md
@@ -117,9 +117,45 @@ Rule:
 Storefront/public behavior should make locale/market/channel context explicit
 when it affects the contract.
 
+### 7. Mutable checkout sessions use scoped capabilities
+
+Public catalog, availability, and pricing reads can stay anonymously readable
+when the operator chooses to expose them. Booking/session checkout surfaces are
+different: once a public flow creates a booking session, the booking id is only
+an identifier and must not be treated as the bearer secret.
+
+The public checkout/session model is:
+
+- `POST /v1/public/bookings/sessions` creates the booking session and returns a
+  short-lived `checkoutCapability` object. The route also sets an HttpOnly
+  SameSite cookie named `voyant_checkout_session` for same-site storefronts.
+- PII-bearing session reads and all public session mutations require the
+  capability, either via the cookie or the
+  `X-Voyant-Checkout-Capability` header.
+- The capability is scoped to one booking session, a narrow action set
+  (`session:read`, `session:update`, `session:reprice`, `session:finalize`,
+  `payment:read`, `payment:start`), and a short lifetime. Configure the signing
+  secret with `VOYANT_CHECKOUT_CAPABILITY_SECRET`; if unset, runtime falls back
+  to the auth/session secret.
+- Public finance booking payment options, payment-session reads, and
+  payment-session creation require the same booking-scoped capability.
+- Public payment-session creation derives currency and amount from the selected
+  booking schedule, guarantee, or invoice. Public clients can choose the server
+  target, provider, payer metadata, and return/cancel URLs; they cannot author
+  arbitrary payable amounts on these routes.
+- Public mutable session/payment routes accept `Idempotency-Key` so clients can
+  safely retry creation, step updates, repricing, finalization, expiry, and
+  payment bootstrap.
+
+Rule:
+
+Use the checkout capability for public booking-session secrets. Do not rely on
+booking ids, payment-session ids, invoice ids, or URLs as bearer secrets for
+customer checkout state.
+
 ## Frontend Layering
 
-### 7. Keep the frontend split clear
+### 8. Keep the frontend split clear
 
 Voyant already has distinct frontend layers that should remain separate:
 
@@ -135,7 +171,7 @@ Rule:
 Keep public contracts, runtime hooks, UI blocks, and final storefront apps as
 distinct layers.
 
-### 8. Preserve the source-installed UI strategy
+### 9. Preserve the source-installed UI strategy
 
 Voyant should keep the registry/source-installed block approach for storefront
 UI.
@@ -154,7 +190,7 @@ replaced with a more opaque frontend system.
 
 ## Template Ownership
 
-### 9. Storefront apps should remain template-owned
+### 10. Storefront apps should remain template-owned
 
 The final storefront application should remain app/template-owned.
 
@@ -173,7 +209,7 @@ Rule:
 The final storefront UX is template-owned even when the shared public contract
 is framework-owned.
 
-### 10. Shared public contracts should reduce app-local compatibility code
+### 11. Shared public contracts should reduce app-local compatibility code
 
 When a shared public/storefront contract exists upstream, downstream apps should
 not need local wrappers just to consume it.
@@ -199,8 +235,12 @@ When adding or reviewing a storefront/public capability:
 3. Keep `storefront` as the package/runtime term, not a nested HTTP namespace.
 4. Shape the public payload around customer-facing needs, not admin CRUD.
 5. Make market/locale/channel context explicit when it affects the contract.
-6. Keep the final storefront shell template-owned.
-7. Preserve the source-installed UI strategy for editable presentation.
+6. Require a scoped checkout capability for PII-bearing session reads,
+   customer-entered state updates, repricing mutations, finalization, and
+   payment bootstrap.
+7. Keep payment amounts server-derived from booking/payment targets.
+8. Keep the final storefront shell template-owned.
+9. Preserve the source-installed UI strategy for editable presentation.
 
 ## Non-Goals
 

--- a/packages/bookings/package.json
+++ b/packages/bookings/package.json
@@ -12,6 +12,7 @@
     "./routes": "./src/routes.ts",
     "./public-routes": "./src/routes-public.ts",
     "./public-validation": "./src/validation-public.ts",
+    "./checkout-capability": "./src/checkout-capability.ts",
     "./extensions/suppliers": "./src/extensions/suppliers.ts",
     "./status-dispatch": "./src/status-dispatch.ts"
   },
@@ -82,6 +83,11 @@
         "types": "./dist/validation-public.d.ts",
         "import": "./dist/validation-public.js",
         "default": "./dist/validation-public.js"
+      },
+      "./checkout-capability": {
+        "types": "./dist/checkout-capability.d.ts",
+        "import": "./dist/checkout-capability.js",
+        "default": "./dist/checkout-capability.js"
       },
       "./extensions/suppliers": {
         "types": "./dist/extensions/suppliers.d.ts",

--- a/packages/bookings/src/checkout-capability.ts
+++ b/packages/bookings/src/checkout-capability.ts
@@ -1,0 +1,91 @@
+import {
+  createPublicCapabilityToken,
+  extractPublicCapabilityToken,
+  serializePublicCapabilityCookie,
+  UnauthorizedApiError,
+  verifyPublicCapabilityToken,
+} from "@voyantjs/hono"
+import type { Context } from "hono"
+
+export const CHECKOUT_CAPABILITY_COOKIE = "voyant_checkout_session"
+export const CHECKOUT_CAPABILITY_HEADER = "X-Voyant-Checkout-Capability"
+export const CHECKOUT_CAPABILITY_SCOPE = "booking-checkout-session"
+
+export const checkoutCapabilityActions = [
+  "session:read",
+  "session:update",
+  "session:reprice",
+  "session:finalize",
+  "payment:read",
+  "payment:start",
+] as const
+
+export type CheckoutCapabilityAction = (typeof checkoutCapabilityActions)[number]
+
+const DEFAULT_TTL_SECONDS = 30 * 60
+const MAX_TTL_SECONDS = 2 * 60 * 60
+
+export function resolveCheckoutCapabilitySecret(env: Record<string, string | undefined>) {
+  return (
+    env.VOYANT_CHECKOUT_CAPABILITY_SECRET ??
+    env.CHECKOUT_CAPABILITY_SECRET ??
+    env.SESSION_CLAIMS_SECRET ??
+    env.BETTER_AUTH_SECRET ??
+    ""
+  )
+}
+
+export function resolveCheckoutCapabilityTtlSeconds(env: Record<string, string | undefined>) {
+  const raw = env.VOYANT_CHECKOUT_CAPABILITY_TTL_SECONDS ?? env.CHECKOUT_CAPABILITY_TTL_SECONDS
+  const parsed = raw ? Number(raw) : DEFAULT_TTL_SECONDS
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_TTL_SECONDS
+  }
+
+  return Math.min(Math.floor(parsed), MAX_TTL_SECONDS)
+}
+
+export async function issueCheckoutCapability(
+  bookingId: string,
+  env: Record<string, string | undefined>,
+) {
+  return createPublicCapabilityToken({
+    secret: resolveCheckoutCapabilitySecret(env),
+    scope: CHECKOUT_CAPABILITY_SCOPE,
+    subjectId: bookingId,
+    actions: [...checkoutCapabilityActions],
+    ttlSeconds: resolveCheckoutCapabilityTtlSeconds(env),
+  })
+}
+
+export async function requireCheckoutCapability(
+  c: Context,
+  bookingId: string,
+  action: CheckoutCapabilityAction,
+  env: Record<string, string | undefined>,
+) {
+  const token = extractPublicCapabilityToken(c, {
+    headerName: CHECKOUT_CAPABILITY_HEADER,
+    cookieName: CHECKOUT_CAPABILITY_COOKIE,
+  })
+
+  if (!token) {
+    throw new UnauthorizedApiError("Missing checkout session capability")
+  }
+
+  return verifyPublicCapabilityToken(token, {
+    secret: resolveCheckoutCapabilitySecret(env),
+    scope: CHECKOUT_CAPABILITY_SCOPE,
+    subjectId: bookingId,
+    action,
+  })
+}
+
+export function checkoutCapabilityCookie(token: string, expiresAt: Date) {
+  return serializePublicCapabilityCookie({
+    name: CHECKOUT_CAPABILITY_COOKIE,
+    token,
+    expiresAt,
+    path: "/v1/public",
+  })
+}

--- a/packages/bookings/src/routes-public.ts
+++ b/packages/bookings/src/routes-public.ts
@@ -1,5 +1,5 @@
 import { idempotencyKey, parseJsonBody, parseQuery, UnauthorizedApiError } from "@voyantjs/hono"
-import type { Context } from "hono"
+import type { Context, MiddlewareHandler } from "hono"
 import { Hono } from "hono"
 
 import {
@@ -70,6 +70,13 @@ async function requireSessionCapability(c: Context, action: CheckoutCapabilityAc
   await requireCheckoutCapability(c, sessionId, action, getRuntimeEnv(c))
 }
 
+function sessionCapability(action: CheckoutCapabilityAction): MiddlewareHandler<Env> {
+  return async (c, next) => {
+    await requireSessionCapability(c, action)
+    await next()
+  }
+}
+
 export const publicBookingRoutes = new Hono<Env>()
   .post("/sessions", idempotencyKey({ scope: "POST /v1/public/bookings/sessions" }), async (c) => {
     const result = await publicBookingsService.createSession(
@@ -111,10 +118,9 @@ export const publicBookingRoutes = new Hono<Env>()
   })
   .patch(
     "/sessions/:sessionId",
-    idempotencyKey({ scope: "PATCH /v1/public/bookings/sessions" }),
+    sessionCapability("session:update"),
+    idempotencyKey(),
     async (c) => {
-      await requireSessionCapability(c, "session:update")
-
       const result = await publicBookingsService.updateSession(
         c.get("db"),
         c.req.param("sessionId"),
@@ -142,10 +148,9 @@ export const publicBookingRoutes = new Hono<Env>()
   })
   .put(
     "/sessions/:sessionId/state",
-    idempotencyKey({ scope: "PUT /v1/public/bookings/sessions/state" }),
+    sessionCapability("session:update"),
+    idempotencyKey(),
     async (c) => {
-      await requireSessionCapability(c, "session:update")
-
       const result = await publicBookingsService.updateSessionState(
         c.get("db"),
         c.req.param("sessionId"),
@@ -161,10 +166,9 @@ export const publicBookingRoutes = new Hono<Env>()
   )
   .post(
     "/sessions/:sessionId/reprice",
-    idempotencyKey({ scope: "POST /v1/public/bookings/sessions/reprice" }),
+    sessionCapability("session:reprice"),
+    idempotencyKey(),
     async (c) => {
-      await requireSessionCapability(c, "session:reprice")
-
       const result = await publicBookingsService.repriceSession(
         c.get("db"),
         c.req.param("sessionId"),
@@ -193,10 +197,9 @@ export const publicBookingRoutes = new Hono<Env>()
   )
   .post(
     "/sessions/:sessionId/confirm",
-    idempotencyKey({ scope: "POST /v1/public/bookings/sessions/confirm" }),
+    sessionCapability("session:finalize"),
+    idempotencyKey(),
     async (c) => {
-      await requireSessionCapability(c, "session:finalize")
-
       const result = await publicBookingsService.confirmSession(
         c.get("db"),
         c.req.param("sessionId"),
@@ -217,10 +220,9 @@ export const publicBookingRoutes = new Hono<Env>()
   )
   .post(
     "/sessions/:sessionId/expire",
-    idempotencyKey({ scope: "POST /v1/public/bookings/sessions/expire" }),
+    sessionCapability("session:finalize"),
+    idempotencyKey(),
     async (c) => {
-      await requireSessionCapability(c, "session:finalize")
-
       const result = await publicBookingsService.expireSession(
         c.get("db"),
         c.req.param("sessionId"),

--- a/packages/bookings/src/routes-public.ts
+++ b/packages/bookings/src/routes-public.ts
@@ -1,7 +1,15 @@
-import { idempotencyKey, parseJsonBody, parseQuery } from "@voyantjs/hono"
+import { idempotencyKey, parseJsonBody, parseQuery, UnauthorizedApiError } from "@voyantjs/hono"
+import type { Context } from "hono"
 import { Hono } from "hono"
 
-import { type Env, notFound } from "./routes-shared.js"
+import {
+  type CheckoutCapabilityAction,
+  checkoutCapabilityActions,
+  checkoutCapabilityCookie,
+  issueCheckoutCapability,
+  requireCheckoutCapability,
+} from "./checkout-capability.js"
+import { type Env, getRuntimeEnv, notFound } from "./routes-shared.js"
 import { publicBookingsService } from "./service-public.js"
 import {
   publicBookingOverviewLookupQuerySchema,
@@ -39,6 +47,29 @@ function sessionConflictError(status: string) {
   }
 }
 
+function attachCheckoutCapability<T extends { sessionId: string }>(
+  session: T,
+  issued: Awaited<ReturnType<typeof issueCheckoutCapability>>,
+) {
+  return {
+    ...session,
+    checkoutCapability: {
+      token: issued.token,
+      expiresAt: issued.expiresAt.toISOString(),
+      actions: [...checkoutCapabilityActions],
+    },
+  }
+}
+
+async function requireSessionCapability(c: Context, action: CheckoutCapabilityAction) {
+  const sessionId = c.req.param("sessionId")
+  if (!sessionId) {
+    throw new UnauthorizedApiError("Missing checkout session id")
+  }
+
+  await requireCheckoutCapability(c, sessionId, action, getRuntimeEnv(c))
+}
+
 export const publicBookingRoutes = new Hono<Env>()
   .post("/sessions", idempotencyKey({ scope: "POST /v1/public/bookings/sessions" }), async (c) => {
     const result = await publicBookingsService.createSession(
@@ -55,9 +86,22 @@ export const publicBookingRoutes = new Hono<Env>()
       return c.json({ error: sessionConflictError(result.status) }, 409)
     }
 
-    return c.json({ data: result.session }, 201)
+    const capability = await issueCheckoutCapability(
+      (result.session as { sessionId: string }).sessionId,
+      getRuntimeEnv(c),
+    )
+    c.header("Set-Cookie", checkoutCapabilityCookie(capability.token, capability.expiresAt), {
+      append: true,
+    })
+
+    return c.json(
+      { data: attachCheckoutCapability(result.session as { sessionId: string }, capability) },
+      201,
+    )
   })
   .get("/sessions/:sessionId", async (c) => {
+    await requireSessionCapability(c, "session:read")
+
     const session = await publicBookingsService.getSessionById(
       c.get("db"),
       c.req.param("sessionId"),
@@ -65,72 +109,94 @@ export const publicBookingRoutes = new Hono<Env>()
 
     return session ? c.json({ data: session }) : notFound(c, "Booking session not found")
   })
-  .patch("/sessions/:sessionId", async (c) => {
-    const result = await publicBookingsService.updateSession(
-      c.get("db"),
-      c.req.param("sessionId"),
-      await parseJsonBody(c, publicUpdateBookingSessionSchema),
-      c.get("userId"),
-    )
+  .patch(
+    "/sessions/:sessionId",
+    idempotencyKey({ scope: "PATCH /v1/public/bookings/sessions" }),
+    async (c) => {
+      await requireSessionCapability(c, "session:update")
 
-    if (result.status === "not_found") {
-      return notFound(c, "Booking session not found")
-    }
+      const result = await publicBookingsService.updateSession(
+        c.get("db"),
+        c.req.param("sessionId"),
+        await parseJsonBody(c, publicUpdateBookingSessionSchema),
+        c.get("userId"),
+      )
 
-    if (!hasSessionResult(result)) {
-      return c.json({ error: sessionConflictError(result.status) }, 409)
-    }
+      if (result.status === "not_found") {
+        return notFound(c, "Booking session not found")
+      }
 
-    return c.json({ data: result.session })
-  })
+      if (!hasSessionResult(result)) {
+        return c.json({ error: sessionConflictError(result.status) }, 409)
+      }
+
+      return c.json({ data: result.session })
+    },
+  )
   .get("/sessions/:sessionId/state", async (c) => {
+    await requireSessionCapability(c, "session:read")
+
     const state = await publicBookingsService.getSessionState(c.get("db"), c.req.param("sessionId"))
 
     return state ? c.json({ data: state }) : notFound(c, "Booking session not found")
   })
-  .put("/sessions/:sessionId/state", async (c) => {
-    const result = await publicBookingsService.updateSessionState(
-      c.get("db"),
-      c.req.param("sessionId"),
-      await parseJsonBody(c, publicUpsertBookingSessionStateSchema),
-    )
+  .put(
+    "/sessions/:sessionId/state",
+    idempotencyKey({ scope: "PUT /v1/public/bookings/sessions/state" }),
+    async (c) => {
+      await requireSessionCapability(c, "session:update")
 
-    if (result.status === "not_found") {
-      return notFound(c, "Booking session not found")
-    }
+      const result = await publicBookingsService.updateSessionState(
+        c.get("db"),
+        c.req.param("sessionId"),
+        await parseJsonBody(c, publicUpsertBookingSessionStateSchema),
+      )
 
-    return c.json({ data: result.state })
-  })
-  .post("/sessions/:sessionId/reprice", async (c) => {
-    const result = await publicBookingsService.repriceSession(
-      c.get("db"),
-      c.req.param("sessionId"),
-      await parseJsonBody(c, publicRepriceBookingSessionSchema),
-    )
+      if (result.status === "not_found") {
+        return notFound(c, "Booking session not found")
+      }
 
-    if (result.status === "not_found") {
-      return notFound(c, "Booking session not found")
-    }
+      return c.json({ data: result.state })
+    },
+  )
+  .post(
+    "/sessions/:sessionId/reprice",
+    idempotencyKey({ scope: "POST /v1/public/bookings/sessions/reprice" }),
+    async (c) => {
+      await requireSessionCapability(c, "session:reprice")
 
-    if (result.status === "invalid_selection") {
-      return c.json({ error: "Booking session contains an invalid item selection" }, 400)
-    }
+      const result = await publicBookingsService.repriceSession(
+        c.get("db"),
+        c.req.param("sessionId"),
+        await parseJsonBody(c, publicRepriceBookingSessionSchema),
+      )
 
-    if (result.status !== "ok") {
-      return c.json({ error: sessionConflictError(result.status) }, 409)
-    }
+      if (result.status === "not_found") {
+        return notFound(c, "Booking session not found")
+      }
 
-    return c.json({
-      data: {
-        pricing: result.pricing,
-        session: result.session,
-      },
-    })
-  })
+      if (result.status === "invalid_selection") {
+        return c.json({ error: "Booking session contains an invalid item selection" }, 400)
+      }
+
+      if (result.status !== "ok") {
+        return c.json({ error: sessionConflictError(result.status) }, 409)
+      }
+
+      return c.json({
+        data: {
+          pricing: result.pricing,
+          session: result.session,
+        },
+      })
+    },
+  )
   .post(
     "/sessions/:sessionId/confirm",
     idempotencyKey({ scope: "POST /v1/public/bookings/sessions/confirm" }),
     async (c) => {
+      await requireSessionCapability(c, "session:finalize")
+
       const result = await publicBookingsService.confirmSession(
         c.get("db"),
         c.req.param("sessionId"),
@@ -149,24 +215,30 @@ export const publicBookingRoutes = new Hono<Env>()
       return c.json({ data: result.session })
     },
   )
-  .post("/sessions/:sessionId/expire", async (c) => {
-    const result = await publicBookingsService.expireSession(
-      c.get("db"),
-      c.req.param("sessionId"),
-      await parseJsonBody(c, publicBookingSessionMutationSchema),
-      c.get("userId"),
-    )
+  .post(
+    "/sessions/:sessionId/expire",
+    idempotencyKey({ scope: "POST /v1/public/bookings/sessions/expire" }),
+    async (c) => {
+      await requireSessionCapability(c, "session:finalize")
 
-    if (result.status === "not_found") {
-      return notFound(c, "Booking session not found")
-    }
+      const result = await publicBookingsService.expireSession(
+        c.get("db"),
+        c.req.param("sessionId"),
+        await parseJsonBody(c, publicBookingSessionMutationSchema),
+        c.get("userId"),
+      )
 
-    if (!hasSessionResult(result)) {
-      return c.json({ error: sessionConflictError(result.status) }, 409)
-    }
+      if (result.status === "not_found") {
+        return notFound(c, "Booking session not found")
+      }
 
-    return c.json({ data: result.session })
-  })
+      if (!hasSessionResult(result)) {
+        return c.json({ error: sessionConflictError(result.status) }, 409)
+      }
+
+      return c.json({ data: result.session })
+    },
+  )
   .get("/overview", async (c) => {
     const overview = await publicBookingsService.getOverview(
       c.get("db"),

--- a/packages/bookings/src/routes-shared.ts
+++ b/packages/bookings/src/routes-shared.ts
@@ -47,7 +47,7 @@ export type Env = {
   }
 }
 
-export function getRuntimeEnv(c: Context<Env>) {
+export function getRuntimeEnv(c: Context) {
   const processEnv =
     (
       globalThis as typeof globalThis & {

--- a/packages/bookings/src/validation-public.ts
+++ b/packages/bookings/src/validation-public.ts
@@ -215,6 +215,21 @@ export const publicBookingSessionChecklistSchema = z.object({
   readyForConfirmation: z.boolean(),
 })
 
+export const publicCheckoutCapabilitySchema = z.object({
+  token: z.string().min(1),
+  expiresAt: z.string(),
+  actions: z.array(
+    z.enum([
+      "session:read",
+      "session:update",
+      "session:reprice",
+      "session:finalize",
+      "payment:read",
+      "payment:start",
+    ]),
+  ),
+})
+
 export const publicBookingSessionSchema = z.object({
   sessionId: z.string(),
   bookingNumber: z.string(),
@@ -236,6 +251,7 @@ export const publicBookingSessionSchema = z.object({
   allocations: z.array(publicBookingSessionAllocationSchema),
   checklist: publicBookingSessionChecklistSchema,
   state: publicBookingSessionStateSchema.nullable(),
+  checkoutCapability: publicCheckoutCapabilitySchema.optional(),
 })
 
 export const publicBookingSessionRepriceItemSchema = z.object({
@@ -316,6 +332,7 @@ export const publicBookingOverviewSchema = z.object({
 export type PublicCreateBookingSessionInput = z.infer<typeof publicCreateBookingSessionSchema>
 export type PublicUpdateBookingSessionInput = z.infer<typeof publicUpdateBookingSessionSchema>
 export type PublicBookingSessionMutationInput = z.infer<typeof publicBookingSessionMutationSchema>
+export type PublicCheckoutCapability = z.infer<typeof publicCheckoutCapabilitySchema>
 export type PublicBookingSessionState = z.infer<typeof publicBookingSessionStateSchema>
 export type PublicUpsertBookingSessionStateInput = z.infer<
   typeof publicUpsertBookingSessionStateSchema

--- a/packages/bookings/tests/integration/public-routes.test.ts
+++ b/packages/bookings/tests/integration/public-routes.test.ts
@@ -1,3 +1,4 @@
+import { handleApiError } from "@voyantjs/hono"
 import { optionUnits, productOptions, products } from "@voyantjs/products/schema"
 import { eq } from "drizzle-orm"
 import { Hono } from "hono"
@@ -14,6 +15,7 @@ import { bookingDocuments, bookingFulfillments, bookings } from "../../src/schem
 
 const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
 const DB_AVAILABLE = !!TEST_DATABASE_URL
+const ORIGINAL_CHECKOUT_CAPABILITY_SECRET = process.env.VOYANT_CHECKOUT_CAPABILITY_SECRET
 
 const json = (body: Record<string, unknown>) => ({
   headers: { "Content-Type": "application/json" },
@@ -25,10 +27,12 @@ describe.skipIf(!DB_AVAILABLE)("Public booking routes", () => {
   let db: ReturnType<typeof import("@voyantjs/db/test-utils").createTestDb>
 
   beforeAll(async () => {
+    process.env.VOYANT_CHECKOUT_CAPABILITY_SECRET = "public-booking-route-test-secret-32"
     const { createTestDb } = await import("@voyantjs/db/test-utils")
 
     db = createTestDb()
     app = new Hono()
+      .onError(handleApiError)
       .use("*", async (c, next) => {
         c.set("db" as never, db)
         c.set("userId" as never, "public-test-user")
@@ -44,8 +48,13 @@ describe.skipIf(!DB_AVAILABLE)("Public booking routes", () => {
 
   afterAll(async () => {
     const { closeTestDb } = await import("@voyantjs/db/test-utils")
+    process.env.VOYANT_CHECKOUT_CAPABILITY_SECRET = ORIGINAL_CHECKOUT_CAPABILITY_SECRET
     await closeTestDb()
   })
+
+  function capabilityHeaders(session: { checkoutCapability: { token: string } }): HeadersInit {
+    return { "X-Voyant-Checkout-Capability": session.checkoutCapability.token }
+  }
 
   async function seedSlot(overrides: Record<string, unknown> = {}) {
     const [slot] = await db
@@ -175,6 +184,7 @@ describe.skipIf(!DB_AVAILABLE)("Public booking routes", () => {
     expect(res.status).toBe(201)
     const body = await res.json()
     expect(body.data.status).toBe("on_hold")
+    expect(body.data.checkoutCapability.actions).toContain("session:update")
     expect(body.data.bookingNumber).toMatch(/^BK-\d{4}-\d{6}$/)
     expect(body.data.travelers).toHaveLength(1)
     expect(body.data.allocations).toHaveLength(1)
@@ -218,7 +228,8 @@ describe.skipIf(!DB_AVAILABLE)("Public booking routes", () => {
 
     const res = await app.request(`/sessions/${session.sessionId}`, {
       method: "PATCH",
-      ...json({
+      headers: { ...json({}).headers, ...capabilityHeaders(session) },
+      body: JSON.stringify({
         communicationLanguage: "ro",
         travelers: [
           {
@@ -276,6 +287,7 @@ describe.skipIf(!DB_AVAILABLE)("Public booking routes", () => {
     const confirmRes = await app.request(`/sessions/${session.sessionId}/confirm`, {
       method: "POST",
       ...json({}),
+      headers: { ...json({}).headers, ...capabilityHeaders(session) },
     })
 
     expect(confirmRes.status).toBe(200)
@@ -337,7 +349,8 @@ describe.skipIf(!DB_AVAILABLE)("Public booking routes", () => {
 
     const stateRes = await app.request(`/sessions/${session.sessionId}/state`, {
       method: "PUT",
-      ...json({
+      headers: { ...json({}).headers, ...capabilityHeaders(session) },
+      body: JSON.stringify({
         currentStep: "rooms",
         completedSteps: ["travelers"],
         payload: {
@@ -351,7 +364,10 @@ describe.skipIf(!DB_AVAILABLE)("Public booking routes", () => {
     expect(stateBody.data.currentStep).toBe("rooms")
     expect(stateBody.data.version).toBe(1)
 
-    const sessionRes = await app.request(`/sessions/${session.sessionId}`, { method: "GET" })
+    const sessionRes = await app.request(`/sessions/${session.sessionId}`, {
+      method: "GET",
+      headers: capabilityHeaders(session),
+    })
     expect(sessionRes.status).toBe(200)
     const sessionBody = await sessionRes.json()
     expect(sessionBody.data.state.currentStep).toBe("rooms")
@@ -382,7 +398,8 @@ describe.skipIf(!DB_AVAILABLE)("Public booking routes", () => {
 
     const stateRes = await app.request(`/sessions/${session.sessionId}/state`, {
       method: "PUT",
-      ...json({
+      headers: { ...json({}).headers, ...capabilityHeaders(session) },
+      body: JSON.stringify({
         currentStep: "billing",
         completedSteps: ["travelers"],
         payload: {
@@ -466,7 +483,8 @@ describe.skipIf(!DB_AVAILABLE)("Public booking routes", () => {
 
     const repriceRes = await app.request(`/sessions/${session.sessionId}/reprice`, {
       method: "POST",
-      ...json({
+      headers: { ...json({}).headers, ...capabilityHeaders(session) },
+      body: JSON.stringify({
         applyToSession: true,
         selections: [
           {
@@ -484,5 +502,29 @@ describe.skipIf(!DB_AVAILABLE)("Public booking routes", () => {
     expect(body.data.pricing.items[0]?.totalSellAmountCents).toBe(50000)
     expect(body.data.session.items[0]?.optionUnitId).toBe(pricing.unit.id)
     expect(body.data.session.sellAmountCents).toBe(50000)
+  })
+
+  it("rejects PII-bearing session reads without a checkout capability", async () => {
+    const slot = await seedSlot()
+
+    const createRes = await app.request("/sessions", {
+      method: "POST",
+      ...json({
+        sellCurrency: "EUR",
+        items: [
+          {
+            title: "Capability check",
+            availabilitySlotId: slot.id,
+            quantity: 1,
+            totalSellAmountCents: 12000,
+          },
+        ],
+      }),
+    })
+
+    const session = (await createRes.json()).data
+    const res = await app.request(`/sessions/${session.sessionId}`, { method: "GET" })
+
+    expect(res.status).toBe(401)
   })
 })

--- a/packages/bookings/tests/unit/validation-public-booking-session.test.ts
+++ b/packages/bookings/tests/unit/validation-public-booking-session.test.ts
@@ -4,11 +4,22 @@ import {
   publicBookingOverviewSchema,
   publicBookingSessionSchema,
   publicBookingSessionTravelerInputSchema,
+  publicCheckoutCapabilitySchema,
   publicCreateBookingSessionSchema,
   publicUpdateBookingSessionSchema,
 } from "../../src/validation-public.js"
 
 describe("public booking session traveler schema", () => {
+  it("parses checkout session capability response metadata", () => {
+    const result = publicCheckoutCapabilitySchema.parse({
+      token: "capability-token",
+      expiresAt: "2026-05-11T12:00:00.000Z",
+      actions: ["session:read", "session:update", "payment:start"],
+    })
+
+    expect(result.actions).toContain("payment:start")
+  })
+
   it("uses traveler input as the primary public schema", () => {
     const result = publicBookingSessionTravelerInputSchema.parse({
       firstName: "Ana",

--- a/packages/finance/src/routes-public.ts
+++ b/packages/finance/src/routes-public.ts
@@ -1,7 +1,12 @@
-import { parseJsonBody, parseQuery } from "@voyantjs/hono"
+import {
+  type CheckoutCapabilityAction,
+  requireCheckoutCapability,
+} from "@voyantjs/bookings/checkout-capability"
+import { idempotencyKey, parseJsonBody, parseQuery } from "@voyantjs/hono"
+import type { Context } from "hono"
 import { Hono } from "hono"
 
-import { type Env, notFound } from "./routes-shared.js"
+import { type Env, getRuntimeEnv, notFound } from "./routes-shared.js"
 import { publicFinanceService } from "./service-public.js"
 import {
   publicFinanceDocumentLookupQuerySchema,
@@ -25,16 +30,26 @@ function paymentConflictError(error: unknown) {
   return "Unable to start payment session"
 }
 
+async function requireBookingCheckoutCapability(
+  c: Context,
+  bookingId: string,
+  action: CheckoutCapabilityAction,
+) {
+  await requireCheckoutCapability(c, bookingId, action, getRuntimeEnv(c))
+}
+
 export function createPublicFinanceRoutes(options: PublicFinanceRouteOptions = {}) {
   const resolveDocumentDownloadUrl = (bindings: unknown, storageKey: string) =>
     options.resolveDocumentDownloadUrl?.(bindings, storageKey) ?? null
 
   return new Hono<Env>()
     .post("/vouchers/validate", async (c) => {
-      const result = await publicFinanceService.validateVoucher(
-        c.get("db"),
-        await parseJsonBody(c, publicValidateVoucherSchema),
-      )
+      const input = await parseJsonBody(c, publicValidateVoucherSchema)
+      if (input.bookingId) {
+        await requireBookingCheckoutCapability(c, input.bookingId, "payment:read")
+      }
+
+      const result = await publicFinanceService.validateVoucher(c.get("db"), input)
 
       return c.json({ data: result })
     })
@@ -47,9 +62,15 @@ export function createPublicFinanceRoutes(options: PublicFinanceRouteOptions = {
         },
       )
 
+      if (document?.bookingId) {
+        await requireBookingCheckoutCapability(c, document.bookingId, "payment:read")
+      }
+
       return document ? c.json({ data: document }) : notFound(c, "Finance document not found")
     })
     .get("/bookings/:bookingId/documents", async (c) => {
+      await requireBookingCheckoutCapability(c, c.req.param("bookingId"), "payment:read")
+
       const documents = await publicFinanceService.getBookingDocuments(
         c.get("db"),
         c.req.param("bookingId"),
@@ -61,6 +82,8 @@ export function createPublicFinanceRoutes(options: PublicFinanceRouteOptions = {
       return documents ? c.json({ data: documents }) : notFound(c, "Booking documents not found")
     })
     .get("/bookings/:bookingId/payments", async (c) => {
+      await requireBookingCheckoutCapability(c, c.req.param("bookingId"), "payment:read")
+
       const payments = await publicFinanceService.getBookingPayments(
         c.get("db"),
         c.req.param("bookingId"),
@@ -69,6 +92,8 @@ export function createPublicFinanceRoutes(options: PublicFinanceRouteOptions = {
       return payments ? c.json({ data: payments }) : notFound(c, "Booking payments not found")
     })
     .get("/bookings/:bookingId/payment-options", async (c) => {
+      await requireBookingCheckoutCapability(c, c.req.param("bookingId"), "payment:read")
+
       const paymentOptions = await publicFinanceService.getBookingPaymentOptions(
         c.get("db"),
         c.req.param("bookingId"),
@@ -85,51 +110,84 @@ export function createPublicFinanceRoutes(options: PublicFinanceRouteOptions = {
         c.req.param("sessionId"),
       )
 
+      if (session?.bookingId) {
+        await requireBookingCheckoutCapability(c, session.bookingId, "payment:read")
+      }
+
       return session ? c.json({ data: session }) : notFound(c, "Payment session not found")
     })
-    .post("/bookings/:bookingId/payment-schedules/:scheduleId/payment-session", async (c) => {
-      try {
-        const session = await publicFinanceService.startBookingSchedulePaymentSession(
-          c.get("db"),
-          c.req.param("bookingId"),
-          c.req.param("scheduleId"),
-          await parseJsonBody(c, publicStartPaymentSessionSchema),
-        )
+    .post(
+      "/bookings/:bookingId/payment-schedules/:scheduleId/payment-session",
+      idempotencyKey({
+        scope: "POST /v1/public/finance/bookings/payment-schedules/payment-session",
+      }),
+      async (c) => {
+        await requireBookingCheckoutCapability(c, c.req.param("bookingId"), "payment:start")
 
-        return session
-          ? c.json({ data: session }, 201)
-          : notFound(c, "Booking payment schedule not found")
-      } catch (error) {
-        return c.json({ error: paymentConflictError(error) }, 409)
-      }
-    })
-    .post("/bookings/:bookingId/guarantees/:guaranteeId/payment-session", async (c) => {
-      try {
-        const session = await publicFinanceService.startBookingGuaranteePaymentSession(
-          c.get("db"),
-          c.req.param("bookingId"),
-          c.req.param("guaranteeId"),
-          await parseJsonBody(c, publicStartPaymentSessionSchema),
-        )
+        try {
+          const session = await publicFinanceService.startBookingSchedulePaymentSession(
+            c.get("db"),
+            c.req.param("bookingId"),
+            c.req.param("scheduleId"),
+            await parseJsonBody(c, publicStartPaymentSessionSchema),
+          )
 
-        return session ? c.json({ data: session }, 201) : notFound(c, "Booking guarantee not found")
-      } catch (error) {
-        return c.json({ error: paymentConflictError(error) }, 409)
-      }
-    })
-    .post("/invoices/:invoiceId/payment-session", async (c) => {
-      try {
-        const session = await publicFinanceService.startInvoicePaymentSession(
-          c.get("db"),
-          c.req.param("invoiceId"),
-          await parseJsonBody(c, publicStartPaymentSessionSchema),
-        )
+          return session
+            ? c.json({ data: session }, 201)
+            : notFound(c, "Booking payment schedule not found")
+        } catch (error) {
+          return c.json({ error: paymentConflictError(error) }, 409)
+        }
+      },
+    )
+    .post(
+      "/bookings/:bookingId/guarantees/:guaranteeId/payment-session",
+      idempotencyKey({ scope: "POST /v1/public/finance/bookings/guarantees/payment-session" }),
+      async (c) => {
+        await requireBookingCheckoutCapability(c, c.req.param("bookingId"), "payment:start")
 
-        return session ? c.json({ data: session }, 201) : notFound(c, "Invoice not found")
-      } catch (error) {
-        return c.json({ error: paymentConflictError(error) }, 409)
-      }
-    })
+        try {
+          const session = await publicFinanceService.startBookingGuaranteePaymentSession(
+            c.get("db"),
+            c.req.param("bookingId"),
+            c.req.param("guaranteeId"),
+            await parseJsonBody(c, publicStartPaymentSessionSchema),
+          )
+
+          return session
+            ? c.json({ data: session }, 201)
+            : notFound(c, "Booking guarantee not found")
+        } catch (error) {
+          return c.json({ error: paymentConflictError(error) }, 409)
+        }
+      },
+    )
+    .post(
+      "/invoices/:invoiceId/payment-session",
+      idempotencyKey({ scope: "POST /v1/public/finance/invoices/payment-session" }),
+      async (c) => {
+        try {
+          const bookingId = await publicFinanceService.getInvoiceBookingId(
+            c.get("db"),
+            c.req.param("invoiceId"),
+          )
+          if (!bookingId) {
+            return notFound(c, "Invoice not found")
+          }
+          await requireBookingCheckoutCapability(c, bookingId, "payment:start")
+
+          const session = await publicFinanceService.startInvoicePaymentSession(
+            c.get("db"),
+            c.req.param("invoiceId"),
+            await parseJsonBody(c, publicStartPaymentSessionSchema),
+          )
+
+          return session ? c.json({ data: session }, 201) : notFound(c, "Invoice not found")
+        } catch (error) {
+          return c.json({ error: paymentConflictError(error) }, 409)
+        }
+      },
+    )
 }
 
 export const publicFinanceRoutes = createPublicFinanceRoutes()

--- a/packages/finance/src/routes-public.ts
+++ b/packages/finance/src/routes-public.ts
@@ -2,8 +2,8 @@ import {
   type CheckoutCapabilityAction,
   requireCheckoutCapability,
 } from "@voyantjs/bookings/checkout-capability"
-import { idempotencyKey, parseJsonBody, parseQuery } from "@voyantjs/hono"
-import type { Context } from "hono"
+import { idempotencyKey, parseJsonBody, parseQuery, UnauthorizedApiError } from "@voyantjs/hono"
+import type { Context, MiddlewareHandler } from "hono"
 import { Hono } from "hono"
 
 import { type Env, getRuntimeEnv, notFound } from "./routes-shared.js"
@@ -36,6 +36,35 @@ async function requireBookingCheckoutCapability(
   action: CheckoutCapabilityAction,
 ) {
   await requireCheckoutCapability(c, bookingId, action, getRuntimeEnv(c))
+}
+
+function bookingCheckoutCapability(action: CheckoutCapabilityAction): MiddlewareHandler<Env> {
+  return async (c, next) => {
+    const bookingId = c.req.param("bookingId")
+    if (!bookingId) {
+      throw new UnauthorizedApiError("Missing checkout booking id")
+    }
+
+    await requireBookingCheckoutCapability(c, bookingId, action)
+    await next()
+  }
+}
+
+function invoiceCheckoutCapability(action: CheckoutCapabilityAction): MiddlewareHandler<Env> {
+  return async (c, next) => {
+    const invoiceId = c.req.param("invoiceId")
+    if (!invoiceId) {
+      throw new UnauthorizedApiError("Missing checkout invoice id")
+    }
+
+    const bookingId = await publicFinanceService.getInvoiceBookingId(c.get("db"), invoiceId)
+    if (!bookingId) {
+      return notFound(c, "Invoice not found")
+    }
+
+    await requireBookingCheckoutCapability(c, bookingId, action)
+    await next()
+  }
 }
 
 export function createPublicFinanceRoutes(options: PublicFinanceRouteOptions = {}) {
@@ -118,12 +147,9 @@ export function createPublicFinanceRoutes(options: PublicFinanceRouteOptions = {
     })
     .post(
       "/bookings/:bookingId/payment-schedules/:scheduleId/payment-session",
-      idempotencyKey({
-        scope: "POST /v1/public/finance/bookings/payment-schedules/payment-session",
-      }),
+      bookingCheckoutCapability("payment:start"),
+      idempotencyKey(),
       async (c) => {
-        await requireBookingCheckoutCapability(c, c.req.param("bookingId"), "payment:start")
-
         try {
           const session = await publicFinanceService.startBookingSchedulePaymentSession(
             c.get("db"),
@@ -142,10 +168,9 @@ export function createPublicFinanceRoutes(options: PublicFinanceRouteOptions = {
     )
     .post(
       "/bookings/:bookingId/guarantees/:guaranteeId/payment-session",
-      idempotencyKey({ scope: "POST /v1/public/finance/bookings/guarantees/payment-session" }),
+      bookingCheckoutCapability("payment:start"),
+      idempotencyKey(),
       async (c) => {
-        await requireBookingCheckoutCapability(c, c.req.param("bookingId"), "payment:start")
-
         try {
           const session = await publicFinanceService.startBookingGuaranteePaymentSession(
             c.get("db"),
@@ -164,18 +189,10 @@ export function createPublicFinanceRoutes(options: PublicFinanceRouteOptions = {
     )
     .post(
       "/invoices/:invoiceId/payment-session",
-      idempotencyKey({ scope: "POST /v1/public/finance/invoices/payment-session" }),
+      invoiceCheckoutCapability("payment:start"),
+      idempotencyKey(),
       async (c) => {
         try {
-          const bookingId = await publicFinanceService.getInvoiceBookingId(
-            c.get("db"),
-            c.req.param("invoiceId"),
-          )
-          if (!bookingId) {
-            return notFound(c, "Invoice not found")
-          }
-          await requireBookingCheckoutCapability(c, bookingId, "payment:start")
-
           const session = await publicFinanceService.startInvoicePaymentSession(
             c.get("db"),
             c.req.param("invoiceId"),

--- a/packages/finance/src/routes-shared.ts
+++ b/packages/finance/src/routes-shared.ts
@@ -3,10 +3,32 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
 
 export type Env = {
+  Bindings: Partial<{
+    VOYANT_CHECKOUT_CAPABILITY_SECRET: string
+    CHECKOUT_CAPABILITY_SECRET: string
+    VOYANT_CHECKOUT_CAPABILITY_TTL_SECONDS: string
+    CHECKOUT_CAPABILITY_TTL_SECONDS: string
+    SESSION_CLAIMS_SECRET: string
+    BETTER_AUTH_SECRET: string
+  }>
   Variables: {
     db: PostgresJsDatabase
     userId?: string
     container?: ModuleContainer
+  }
+}
+
+export function getRuntimeEnv(c: Context) {
+  const processEnv =
+    (
+      globalThis as typeof globalThis & {
+        process?: { env?: Record<string, string | undefined> }
+      }
+    ).process?.env ?? {}
+
+  return {
+    ...processEnv,
+    ...(c.env ?? {}),
   }
 }
 

--- a/packages/finance/src/service-public.ts
+++ b/packages/finance/src/service-public.ts
@@ -430,6 +430,16 @@ export const publicFinanceService = {
     return session ? toPublicPaymentSession(session) : null
   },
 
+  async getInvoiceBookingId(db: PostgresJsDatabase, invoiceId: string) {
+    const [invoice] = await db
+      .select({ bookingId: invoices.bookingId })
+      .from(invoices)
+      .where(eq(invoices.id, invoiceId))
+      .limit(1)
+
+    return invoice?.bookingId ?? null
+  },
+
   async startBookingSchedulePaymentSession(
     db: PostgresJsDatabase,
     bookingId: string,

--- a/packages/finance/tests/integration/public-routes.test.ts
+++ b/packages/finance/tests/integration/public-routes.test.ts
@@ -1,4 +1,6 @@
+import { issueCheckoutCapability } from "@voyantjs/bookings/checkout-capability"
 import { bookings } from "@voyantjs/bookings/schema"
+import { handleApiError } from "@voyantjs/hono"
 import { eq, sql } from "drizzle-orm"
 import { Hono } from "hono"
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
@@ -16,6 +18,7 @@ import {
 
 const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
 const ORIGINAL_TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
+const ORIGINAL_CHECKOUT_CAPABILITY_SECRET = process.env.VOYANT_CHECKOUT_CAPABILITY_SECRET
 
 const json = (body: Record<string, unknown>) => ({
   headers: { "Content-Type": "application/json" },
@@ -102,12 +105,14 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
 
   beforeAll(async () => {
     process.env.TEST_DATABASE_URL = getIsolatedFinanceTestDbUrl(process.env.TEST_DATABASE_URL)
+    process.env.VOYANT_CHECKOUT_CAPABILITY_SECRET = "public-finance-route-test-secret-32"
     const { createTestDb } = await import("@voyantjs/db/test-utils")
 
     db = createTestDb()
     await cleanupFinanceTestData(db)
 
     app = new Hono()
+    app.onError(handleApiError)
     app.use("*", async (c, next) => {
       c.set("db" as never, db)
       c.set("userId" as never, "public-finance-test-user")
@@ -123,8 +128,17 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
   afterAll(async () => {
     const { closeTestDb } = await import("@voyantjs/db/test-utils")
     process.env.TEST_DATABASE_URL = ORIGINAL_TEST_DATABASE_URL
+    process.env.VOYANT_CHECKOUT_CAPABILITY_SECRET = ORIGINAL_CHECKOUT_CAPABILITY_SECRET
     await closeTestDb()
   })
+
+  async function capabilityHeaders(bookingId: string): Promise<HeadersInit> {
+    const capability = await issueCheckoutCapability(bookingId, {
+      VOYANT_CHECKOUT_CAPABILITY_SECRET: process.env.VOYANT_CHECKOUT_CAPABILITY_SECRET,
+    })
+
+    return { "X-Voyant-Checkout-Capability": capability.token }
+  }
 
   async function seedBooking(overrides: Partial<typeof bookings.$inferInsert> = {}) {
     const [row] = await db
@@ -224,7 +238,9 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
       },
     ])
 
-    const res = await app.request(`/bookings/${booking.id}/payment-options`)
+    const res = await app.request(`/bookings/${booking.id}/payment-options`, {
+      headers: await capabilityHeaders(booking.id),
+    })
 
     expect(res.status).toBe(200)
     const body = await res.json()
@@ -267,7 +283,9 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
       },
     ])
 
-    const res = await app.request(`/bookings/${booking.id}/documents`)
+    const res = await app.request(`/bookings/${booking.id}/documents`, {
+      headers: await capabilityHeaders(booking.id),
+    })
 
     expect(res.status).toBe(200)
     const body = await res.json()
@@ -325,7 +343,12 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
       referenceNumber: "PAY-REF-1001",
     })
 
-    const paymentReferenceRes = await app.request("/documents/by-reference?reference=PAY-REF-1001")
+    const paymentReferenceRes = await app.request(
+      "/documents/by-reference?reference=PAY-REF-1001",
+      {
+        headers: await capabilityHeaders(booking.id),
+      },
+    )
 
     expect(paymentReferenceRes.status).toBe(200)
     expect((await paymentReferenceRes.json()).data).toMatchObject({
@@ -337,7 +360,9 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
       downloadUrl: "https://example.com/proforma-by-reference.pdf",
     })
 
-    const invoiceReferenceRes = await app.request("/documents/by-reference?reference=PF-REF-1001")
+    const invoiceReferenceRes = await app.request("/documents/by-reference?reference=PF-REF-1001", {
+      headers: await capabilityHeaders(booking.id),
+    })
 
     expect(invoiceReferenceRes.status).toBe(200)
     expect((await invoiceReferenceRes.json()).data).toMatchObject({
@@ -377,7 +402,9 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
       },
     ])
 
-    const res = await app.request(`/bookings/${booking.id}/payments`)
+    const res = await app.request(`/bookings/${booking.id}/payments`, {
+      headers: await capabilityHeaders(booking.id),
+    })
 
     expect(res.status).toBe(200)
     const body = await res.json()
@@ -422,7 +449,8 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
       `/bookings/${booking.id}/payment-schedules/${schedule.id}/payment-session`,
       {
         method: "POST",
-        ...json({
+        headers: { ...json({}).headers, ...(await capabilityHeaders(booking.id)) },
+        body: JSON.stringify({
           provider: "netopia",
           payerEmail: "traveler@example.com",
           payerName: "Ana Popescu",
@@ -440,7 +468,9 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
     expect(created.amountCents).toBe(18000)
     expect(created.payerEmail).toBe("traveler@example.com")
 
-    const getRes = await app.request(`/payment-sessions/${created.id}`)
+    const getRes = await app.request(`/payment-sessions/${created.id}`, {
+      headers: await capabilityHeaders(booking.id),
+    })
     expect(getRes.status).toBe(200)
     const stored = (await getRes.json()).data
     expect(stored.id).toBe(created.id)
@@ -463,7 +493,8 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
 
     const res = await app.request(`/invoices/${invoice.id}/payment-session`, {
       method: "POST",
-      ...json({
+      headers: { ...json({}).headers, ...(await capabilityHeaders(booking.id)) },
+      body: JSON.stringify({
         provider: "netopia",
         payerEmail: "traveler@example.com",
         returnUrl: "https://example.com/return",
@@ -503,7 +534,8 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
 
     const res = await app.request("/vouchers/validate", {
       method: "POST",
-      ...json({
+      headers: { ...json({}).headers, ...(await capabilityHeaders(booking.id)) },
+      body: JSON.stringify({
         code: "spring-2026",
         bookingId: booking.id,
         currency: "EUR",
@@ -549,6 +581,13 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
     expect(body.data.reason).toBe("insufficient_balance")
   })
 
+  it("rejects booking-scoped public payment reads without a checkout capability", async () => {
+    const booking = await seedBooking()
+    const res = await app.request(`/bookings/${booking.id}/payment-options`)
+
+    expect(res.status).toBe(401)
+  })
+
   it("rejects a voucher when booking scope does not match", async () => {
     const booking = await seedBooking()
     const otherBooking = await seedBooking()
@@ -570,7 +609,8 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
 
     const res = await app.request("/vouchers/validate", {
       method: "POST",
-      ...json({
+      headers: { ...json({}).headers, ...(await capabilityHeaders(otherBooking.id)) },
+      body: JSON.stringify({
         code: "SCOPED-1",
         bookingId: otherBooking.id,
       }),

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -43,6 +43,18 @@ export {
   expandHonoPlugins,
 } from "./plugin.js"
 export type {
+  CreatePublicCapabilityOptions,
+  PublicCapabilityCookieOptions,
+  PublicCapabilityPayload,
+  VerifyPublicCapabilityOptions,
+} from "./public-capability.js"
+export {
+  createPublicCapabilityToken,
+  extractPublicCapabilityToken,
+  serializePublicCapabilityCookie,
+  verifyPublicCapabilityToken,
+} from "./public-capability.js"
+export type {
   DbFactory,
   LogEntry,
   LoggerProvider,

--- a/packages/hono/src/public-capability.ts
+++ b/packages/hono/src/public-capability.ts
@@ -1,0 +1,221 @@
+import type { Context } from "hono"
+
+import { ForbiddenApiError, UnauthorizedApiError } from "./validation.js"
+
+export interface PublicCapabilityPayload {
+  v: 1
+  scope: string
+  subjectId: string
+  actions: string[]
+  iat: number
+  exp: number
+  jti?: string
+}
+
+export interface CreatePublicCapabilityOptions {
+  secret: string
+  scope: string
+  subjectId: string
+  actions: string[]
+  ttlSeconds: number
+  now?: Date
+  jti?: string
+}
+
+export interface VerifyPublicCapabilityOptions {
+  secret: string
+  scope: string
+  subjectId: string
+  action: string
+  now?: Date
+}
+
+export interface PublicCapabilityCookieOptions {
+  name: string
+  token: string
+  expiresAt: Date
+  secure?: boolean
+  sameSite?: "Strict" | "Lax" | "None"
+  path?: string
+}
+
+const TOKEN_TYPE = "voyant-public-capability+jwt"
+const DEFAULT_CAPABILITY_HEADER = "X-Voyant-Checkout-Capability"
+
+function getWebCrypto(): Crypto {
+  if (globalThis.crypto?.subtle) {
+    return globalThis.crypto
+  }
+
+  throw new Error("No crypto implementation available")
+}
+
+function encodeBase64Url(input: string | Uint8Array) {
+  const bytes = typeof input === "string" ? new TextEncoder().encode(input) : input
+  let binary = ""
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+}
+
+function decodeBase64Url(input: string) {
+  const base64 = input.replace(/-/g, "+").replace(/_/g, "/")
+  const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=")
+  return atob(padded)
+}
+
+function constantTimeEqual(left: string, right: string) {
+  if (left.length !== right.length) return false
+
+  let result = 0
+  for (let index = 0; index < left.length; index += 1) {
+    result |= left.charCodeAt(index) ^ right.charCodeAt(index)
+  }
+  return result === 0
+}
+
+async function signMessage(message: string, secret: string) {
+  const crypto = getWebCrypto()
+  const encoder = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  )
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(message))
+  return encodeBase64Url(new Uint8Array(signature))
+}
+
+function validateSecret(secret: string) {
+  if (secret.length < 32) {
+    throw new Error("Public capability secret must be at least 32 characters")
+  }
+}
+
+export async function createPublicCapabilityToken(
+  options: CreatePublicCapabilityOptions,
+): Promise<{ token: string; payload: PublicCapabilityPayload; expiresAt: Date }> {
+  validateSecret(options.secret)
+
+  const issuedAt = Math.floor((options.now ?? new Date()).getTime() / 1000)
+  const expiresAtSeconds = issuedAt + options.ttlSeconds
+  const payload: PublicCapabilityPayload = {
+    v: 1,
+    scope: options.scope,
+    subjectId: options.subjectId,
+    actions: Array.from(new Set(options.actions)).sort(),
+    iat: issuedAt,
+    exp: expiresAtSeconds,
+    ...(options.jti ? { jti: options.jti } : {}),
+  }
+  const header = { alg: "HS256", typ: TOKEN_TYPE }
+  const headerB64 = encodeBase64Url(JSON.stringify(header))
+  const payloadB64 = encodeBase64Url(JSON.stringify(payload))
+  const message = `${headerB64}.${payloadB64}`
+  const signature = await signMessage(message, options.secret)
+
+  return {
+    token: `${message}.${signature}`,
+    payload,
+    expiresAt: new Date(expiresAtSeconds * 1000),
+  }
+}
+
+export async function verifyPublicCapabilityToken(
+  token: string,
+  options: VerifyPublicCapabilityOptions,
+): Promise<PublicCapabilityPayload> {
+  validateSecret(options.secret)
+
+  const [headerB64, payloadB64, signature] = token.split(".")
+  if (!headerB64 || !payloadB64 || !signature) {
+    throw new UnauthorizedApiError("Invalid checkout session capability")
+  }
+
+  const message = `${headerB64}.${payloadB64}`
+  const expectedSignature = await signMessage(message, options.secret)
+  if (!constantTimeEqual(signature, expectedSignature)) {
+    throw new UnauthorizedApiError("Invalid checkout session capability")
+  }
+
+  let header: { typ?: unknown }
+  let payload: PublicCapabilityPayload
+  try {
+    header = JSON.parse(decodeBase64Url(headerB64)) as { typ?: unknown }
+    payload = JSON.parse(decodeBase64Url(payloadB64)) as PublicCapabilityPayload
+  } catch {
+    throw new UnauthorizedApiError("Invalid checkout session capability")
+  }
+
+  if (header.typ !== TOKEN_TYPE || payload.v !== 1) {
+    throw new UnauthorizedApiError("Invalid checkout session capability")
+  }
+
+  const now = Math.floor((options.now ?? new Date()).getTime() / 1000)
+  if (payload.exp < now) {
+    throw new UnauthorizedApiError("Expired checkout session capability")
+  }
+
+  if (payload.scope !== options.scope || payload.subjectId !== options.subjectId) {
+    throw new ForbiddenApiError("Checkout session capability is not scoped to this resource")
+  }
+
+  if (!payload.actions.includes(options.action)) {
+    throw new ForbiddenApiError("Checkout session capability cannot perform this action")
+  }
+
+  return payload
+}
+
+export function extractPublicCapabilityToken(
+  c: Context,
+  options: { headerName?: string; cookieName?: string } = {},
+) {
+  const headerName = options.headerName ?? DEFAULT_CAPABILITY_HEADER
+  const headerToken = c.req.header(headerName)
+  if (headerToken) {
+    return headerToken
+  }
+
+  const cookieName = options.cookieName
+  if (!cookieName) {
+    return null
+  }
+
+  const cookieHeader = c.req.header("Cookie")
+  if (!cookieHeader) {
+    return null
+  }
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValueParts] = part.trim().split("=")
+    if (rawName === cookieName) {
+      return decodeURIComponent(rawValueParts.join("="))
+    }
+  }
+
+  return null
+}
+
+export function serializePublicCapabilityCookie(options: PublicCapabilityCookieOptions) {
+  const secure = options.secure ?? true
+  const sameSite = options.sameSite ?? "Lax"
+  const path = options.path ?? "/"
+  const parts = [
+    `${options.name}=${encodeURIComponent(options.token)}`,
+    "HttpOnly",
+    `SameSite=${sameSite}`,
+    `Path=${path}`,
+    `Expires=${options.expiresAt.toUTCString()}`,
+  ]
+
+  if (secure) {
+    parts.push("Secure")
+  }
+
+  return parts.join("; ")
+}

--- a/packages/hono/tests/unit/public-capability.test.ts
+++ b/packages/hono/tests/unit/public-capability.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  createPublicCapabilityToken,
+  verifyPublicCapabilityToken,
+} from "../../src/public-capability.js"
+import { ForbiddenApiError, UnauthorizedApiError } from "../../src/validation.js"
+
+const SECRET = "checkout-capability-test-secret-32chars"
+
+describe("public capability tokens", () => {
+  it("verifies a scoped action for the intended subject", async () => {
+    const issued = await createPublicCapabilityToken({
+      secret: SECRET,
+      scope: "booking-checkout-session",
+      subjectId: "book_123",
+      actions: ["session:read", "session:update"],
+      ttlSeconds: 60,
+      now: new Date("2026-05-11T00:00:00.000Z"),
+    })
+
+    await expect(
+      verifyPublicCapabilityToken(issued.token, {
+        secret: SECRET,
+        scope: "booking-checkout-session",
+        subjectId: "book_123",
+        action: "session:update",
+        now: new Date("2026-05-11T00:00:30.000Z"),
+      }),
+    ).resolves.toMatchObject({
+      scope: "booking-checkout-session",
+      subjectId: "book_123",
+    })
+  })
+
+  it("rejects a token presented for another subject", async () => {
+    const issued = await createPublicCapabilityToken({
+      secret: SECRET,
+      scope: "booking-checkout-session",
+      subjectId: "book_123",
+      actions: ["session:read"],
+      ttlSeconds: 60,
+      now: new Date("2026-05-11T00:00:00.000Z"),
+    })
+
+    await expect(
+      verifyPublicCapabilityToken(issued.token, {
+        secret: SECRET,
+        scope: "booking-checkout-session",
+        subjectId: "book_456",
+        action: "session:read",
+        now: new Date("2026-05-11T00:00:30.000Z"),
+      }),
+    ).rejects.toBeInstanceOf(ForbiddenApiError)
+  })
+
+  it("rejects actions outside the token grant", async () => {
+    const issued = await createPublicCapabilityToken({
+      secret: SECRET,
+      scope: "booking-checkout-session",
+      subjectId: "book_123",
+      actions: ["session:read"],
+      ttlSeconds: 60,
+      now: new Date("2026-05-11T00:00:00.000Z"),
+    })
+
+    await expect(
+      verifyPublicCapabilityToken(issued.token, {
+        secret: SECRET,
+        scope: "booking-checkout-session",
+        subjectId: "book_123",
+        action: "session:update",
+        now: new Date("2026-05-11T00:00:30.000Z"),
+      }),
+    ).rejects.toBeInstanceOf(ForbiddenApiError)
+  })
+
+  it("rejects expired tokens", async () => {
+    const issued = await createPublicCapabilityToken({
+      secret: SECRET,
+      scope: "booking-checkout-session",
+      subjectId: "book_123",
+      actions: ["session:read"],
+      ttlSeconds: 60,
+      now: new Date("2026-05-11T00:00:00.000Z"),
+    })
+
+    await expect(
+      verifyPublicCapabilityToken(issued.token, {
+        secret: SECRET,
+        scope: "booking-checkout-session",
+        subjectId: "book_123",
+        action: "session:read",
+        now: new Date("2026-05-11T00:02:00.000Z"),
+      }),
+    ).rejects.toBeInstanceOf(UnauthorizedApiError)
+  })
+})


### PR DESCRIPTION
## Summary

- Add a shared signed public capability primitive in `@voyantjs/hono`.
- Issue booking-scoped checkout capabilities when public booking sessions are created.
- Require the capability for PII-bearing booking session reads, public session mutations, repricing/finalization, and public finance checkout/payment routes.
- Add idempotency middleware coverage for public mutable checkout/payment routes.
- Document the public checkout capability model and add a changeset.

Closes #636.

## Verification

- `pnpm --filter @voyantjs/hono typecheck`
- `pnpm --filter @voyantjs/bookings typecheck`
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/hono lint`
- `pnpm --filter @voyantjs/bookings lint`
- `pnpm --filter @voyantjs/finance lint`
- `pnpm --filter @voyantjs/hono test`
- `pnpm --filter @voyantjs/bookings test`
- `pnpm --filter @voyantjs/finance test`
- `git diff --check`
- pre-push `pnpm test` lane passed

Note: `pnpm verify:package-exports` was attempted and still fails on existing repository-wide build/export issues unrelated to this branch.