### PR TITLE
Fix release train for new publishable packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -91,6 +91,7 @@
       "@voyantjs/sellability-ui",
       "@voyantjs/storefront",
       "@voyantjs/storefront-react",
+      "@voyantjs/storefront-sdk",
       "@voyantjs/storefront-verification",
       "@voyantjs/suppliers",
       "@voyantjs/suppliers-react",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,8 @@ jobs:
 
       # `--concurrency=4` caps peak parallelism so a cold-cache cascade rebuild
       # can't OOM the runner (kernel SIGKILLs the heaviest tsc — exit 137).
-      - name: Build packages
-        run: pnpm turbo build --filter='./packages/**' --continue --concurrency=4
+      - name: Build publishable workspaces
+        run: pnpm turbo build --filter='./packages/**' --filter='./apps/workflows-node-step-container' --continue --concurrency=4
 
       - name: Build registry artifacts
         run: pnpm registry:build
@@ -108,8 +108,8 @@ jobs:
 
       # `--concurrency=4` caps peak parallelism so a cold-cache cascade rebuild
       # can't OOM the runner (kernel SIGKILLs the heaviest tsc — exit 137).
-      - name: Build packages
-        run: pnpm turbo build --filter='./packages/**' --continue --concurrency=4
+      - name: Build publishable workspaces
+        run: pnpm turbo build --filter='./packages/**' --filter='./apps/workflows-node-step-container' --continue --concurrency=4
 
       - name: Build registry artifacts
         run: pnpm registry:build

--- a/apps/workflows-node-step-container/package.json
+++ b/apps/workflows-node-step-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/workflows-node-step-container",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "description": "Reference Node container image for executing `runtime: \"node\"` steps. Deployed alongside the orchestrator as a Cloudflare Container.",
   "license": "Apache-2.0",
   "repository": {

--- a/apps/workflows-node-step-container/package.json
+++ b/apps/workflows-node-step-container/package.json
@@ -32,6 +32,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "check-types": "tsc --noEmit",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "prepack": "pnpm run clean && pnpm run build",
     "start": "node dist/server.js"
   },
   "dependencies": {

--- a/packages/storefront-sdk/package.json
+++ b/packages/storefront-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/storefront-sdk",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/workflows-cloud-adapter/package.json
+++ b/packages/workflows-cloud-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/workflows-cloud-adapter",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "description": "Tenant Worker adapter for Voyant Cloud Workflows deployments. Wires WorkflowRunDO, inline local dispatch, and platform step-runner bindings from env.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary
- align the new publishable workflow packages with the current `0.31.4` release train
- add `@voyantjs/storefront-sdk` to the fixed release train so `verify:release-train` treats it with the rest of the publishable packages

## Failure
The latest main Release workflow failed at `Verify release train` in run `25657936070`. The checker reported `@voyantjs/storefront-sdk`, `@voyantjs/workflows-cloud-adapter`, and `@voyantjs/workflows-node-step-container` on `0.31.3` while the shared train is `0.31.4`.

## Verification
- `pnpm verify:release-train`
- `pnpm lint:changed`

Note: the broad pre-commit typecheck lane currently fails on unrelated issues: SmartBill missing module declarations, storefront-sdk missing local `tsc`, and operator killed with exit 137. This PR is scoped to the release-train failure.