### PR TITLE
Improve browser evidence review index

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -178,6 +178,9 @@ When `handoff` or successful `run-command` receives a local browser artifact
 reference, it reads the artifact `summary.json` and blocks handoff if that
 summary still contains blocking browser issues unless `--allow-browser-issues`
 is used with a maintainer-approved exception.
+Evidence packets expand that local browser summary into a review index with
+repo-relative screenshot, video, console-log, failed-request-log, and summary
+links so PR reviewers do not need to decode raw runner output.
 
 Use the read-only status view to inspect the current queue and active work:
 

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1116,7 +1116,10 @@ Handoff and successful run-command transitions also validate local browser
 artifact summaries before moving UI-labeled work to review, so stale or manually
 pasted bad artifacts do not bypass the capture gate. Queue status and tick
 output also surface browser-evidence obligations for active UI work; capture
-recommendations remain explicit and are not dispatched automatically.
+recommendations remain explicit and are not dispatched automatically. Evidence
+packets now expand local browser summaries into reviewer-facing artifact indexes
+with repo-relative screenshot, video, console-log, failed-request-log, and
+summary links.
 
 Verification:
 

--- a/scripts/agent-runner-handoff.mjs
+++ b/scripts/agent-runner-handoff.mjs
@@ -12,7 +12,10 @@ import {
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import { browserEvidenceMissingReason } from "./lib/agent-runner-browser-evidence.mjs"
-import { browserEvidenceQualityBlockReason } from "./lib/agent-runner-browser-validation.mjs"
+import {
+  browserEvidenceQualityBlockReason,
+  browserEvidenceReviewMarkdown,
+} from "./lib/agent-runner-browser-validation.mjs"
 import {
   maybePrintHelp,
   mutationOptions,
@@ -171,7 +174,7 @@ ${args.verification}
 
 ## UI Evidence
 
-${args.uiEvidence ?? "Not applicable or not provided."}
+${browserEvidenceReviewMarkdown({ uiEvidence: args.uiEvidence, workspace })}
 
 ## Links
 

--- a/scripts/lib/agent-runner-browser-validation.mjs
+++ b/scripts/lib/agent-runner-browser-validation.mjs
@@ -2,7 +2,10 @@ import { existsSync, readFileSync } from "node:fs"
 import path from "node:path"
 
 import { requiresBrowserEvidence } from "./agent-runner-browser-evidence.mjs"
-import { browserIssueBlockReason } from "./agent-runner-browser-issues.mjs"
+import {
+  browserIssueBlockReason,
+  formatBrowserIssueSummary,
+} from "./agent-runner-browser-issues.mjs"
 
 export function browserEvidenceQualityBlockReason({
   allowBrowserIssues = false,
@@ -27,6 +30,25 @@ export function browserEvidenceQualityBlockReason({
   }
 
   return browserIssueBlockReason(summary.browserIssues, { allowBrowserIssues })
+}
+
+export function browserEvidenceReviewMarkdown({ uiEvidence, workspace }) {
+  const trimmedEvidence = uiEvidence?.trim()
+  if (!trimmedEvidence) return "Not applicable or not provided."
+
+  const summaryPlan = browserEvidenceSummaryPlan({ uiEvidence, workspace })
+  if (!summaryPlan?.safePath || !existsSync(summaryPlan.summaryPath)) {
+    return trimmedEvidence
+  }
+
+  const summary = readBrowserEvidenceSummary(summaryPlan.summaryPath)
+  if (!summary.ok) return trimmedEvidence
+
+  return formatBrowserEvidenceSummaryForReview({
+    reference: summaryPlan.reference,
+    summary: summary.value,
+    workspace,
+  })
 }
 
 export function browserEvidenceSummaryPlan({ uiEvidence, workspace }) {
@@ -58,13 +80,76 @@ function readBrowserEvidenceSummary(summaryPath) {
       return { ok: false }
     }
 
-    return { browserIssues: summary.browserIssues, ok: true }
+    return { browserIssues: summary.browserIssues, ok: true, value: summary }
   } catch (error) {
     return {
       ok: false,
       parseError: error.message,
     }
   }
+}
+
+function formatBrowserEvidenceSummaryForReview({ reference, summary, workspace }) {
+  const artifactPointer = summary.artifactPointer ?? path.posix.dirname(reference)
+  const captures = Array.isArray(summary.captures) ? summary.captures : [summary]
+  const captureLines = captures
+    .map((capture) => formatBrowserEvidenceCapture(capture, { workspace }))
+    .filter(Boolean)
+    .join("\n")
+
+  return [
+    `Browser artifacts: ${artifactPointer}`,
+    `Browser issue summary: ${formatBrowserIssueSummary(summary.browserIssues)}`,
+    `Blocking browser issues: ${summary.browserIssues.hasBlockingIssues ? "yes" : "no"}`,
+    "",
+    "Captures:",
+    captureLines || "- Not recorded.",
+    "",
+    "Logs:",
+    `- Summary: ${reference}`,
+    summary.consoleLog
+      ? `- Console log: ${formatArtifactReference(summary.consoleLog, workspace)}`
+      : null,
+    summary.failedRequestLog
+      ? `- Failed-request log: ${formatArtifactReference(summary.failedRequestLog, workspace)}`
+      : null,
+  ]
+    .filter((line) => line !== null)
+    .join("\n")
+}
+
+function formatBrowserEvidenceCapture(capture, { workspace }) {
+  if (!capture) return ""
+
+  const viewport = capture.viewport
+    ? `${capture.viewport.width}x${capture.viewport.height}`
+    : "browser capture"
+  const lines = [`- ${viewport}: ${capture.url ?? "URL not recorded"}`]
+
+  if (capture.screenshot) {
+    const screenshot = formatArtifactReference(capture.screenshot, workspace)
+    lines.push(`  - Screenshot: ![${viewport} screenshot](${screenshot})`)
+  }
+
+  if (capture.video) {
+    const video = formatArtifactReference(capture.video, workspace)
+    lines.push(`  - Video: ${video}`)
+  }
+
+  return lines.join("\n")
+}
+
+function formatArtifactReference(reference, workspace) {
+  if (!reference) return reference
+  if (/^https?:\/\//.test(reference)) return reference
+  if (!path.isAbsolute(reference)) return toPosixPath(reference)
+  if (!workspace || !isPathInside(reference, workspace)) return toPosixPath(reference)
+
+  return toPosixPath(path.relative(workspace, reference))
+}
+
+function toPosixPath(reference) {
+  return reference.split(path.sep).join(path.posix.sep)
 }
 
 function isPathInside(candidatePath, parentPath) {

--- a/scripts/lib/agent-runner-execution.mjs
+++ b/scripts/lib/agent-runner-execution.mjs
@@ -6,7 +6,10 @@ import {
   browserEvidenceMissingReason,
   requiresBrowserEvidence,
 } from "./agent-runner-browser-evidence.mjs"
-import { browserEvidenceQualityBlockReason } from "./agent-runner-browser-validation.mjs"
+import {
+  browserEvidenceQualityBlockReason,
+  browserEvidenceReviewMarkdown,
+} from "./agent-runner-browser-validation.mjs"
 import { ciRepairEvidenceEnvironment, resolveCiRepairEvidencePath } from "./agent-runner-ci.mjs"
 import { localWorkspaceReferencePlan } from "./agent-runner-workspace.mjs"
 import {
@@ -177,7 +180,7 @@ Runner command transcript: ${artifactPlan.logFile}
 
 ## Browser Evidence
 
-${formatBrowserEvidenceRequirement(item, uiEvidence)}
+${formatBrowserEvidenceRequirement({ artifactPlan, item, uiEvidence })}
 
 ## CI Repair Evidence
 
@@ -189,13 +192,16 @@ Review the command transcript and resulting diff before opening or merging a PR.
 `
 }
 
-function formatBrowserEvidenceRequirement(item, uiEvidence) {
+function formatBrowserEvidenceRequirement({ artifactPlan, item, uiEvidence }) {
   if (!requiresBrowserEvidence(item)) {
     return "Not required by issue labels."
   }
 
   if (uiEvidence?.trim()) {
-    return uiEvidence.trim()
+    return browserEvidenceReviewMarkdown({
+      uiEvidence,
+      workspace: artifactPlan.workspace,
+    })
   }
 
   return "Required for UI-labeled work. Attach screenshots, console log, failed-request log, and video or note the maintainer-approved exception."

--- a/scripts/tests/agent-runner-browser-validation.test.mjs
+++ b/scripts/tests/agent-runner-browser-validation.test.mjs
@@ -6,6 +6,7 @@ import { describe, it } from "node:test"
 
 import {
   browserEvidenceQualityBlockReason,
+  browserEvidenceReviewMarkdown,
   browserEvidenceSummaryPlan,
 } from "../lib/agent-runner-browser-validation.mjs"
 import { commandRunBrowserEvidenceBlockReason } from "../lib/agent-runner-execution.mjs"
@@ -182,6 +183,68 @@ describe("agent runner browser evidence validation", () => {
           workspace: tempDir,
         }),
         null,
+      )
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true })
+    }
+  })
+
+  it("formats local browser summaries with reviewable artifact links", () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "voyant-browser-validation-"))
+    try {
+      const artifactPointer = "docs/agent-evidence/browser/579-test/2026-05-10T12-34-56-000Z"
+      const summaryDir = path.join(tempDir, artifactPointer)
+      mkdirSync(summaryDir, { recursive: true })
+      writeFileSync(
+        path.join(summaryDir, "summary.json"),
+        JSON.stringify({
+          artifactPointer,
+          browserIssues: {
+            consoleErrors: 0,
+            consoleWarnings: 1,
+            failedRequests: 0,
+            hasBlockingIssues: false,
+            httpErrors: 0,
+            malformedLogLines: 0,
+            requestFailures: 0,
+          },
+          captures: [
+            {
+              screenshot: path.join(summaryDir, "screenshots/page-1440x900.png"),
+              url: "http://127.0.0.1:4879",
+              video: path.join(summaryDir, "videos/desktop.webm"),
+              viewport: { height: 900, width: 1440 },
+            },
+            {
+              screenshot: path.join(summaryDir, "screenshots/page-390x844.png"),
+              url: "http://127.0.0.1:4879",
+              viewport: { height: 844, width: 390 },
+            },
+          ],
+          consoleLog: path.join(summaryDir, "console.jsonl"),
+          failedRequestLog: path.join(summaryDir, "network.jsonl"),
+        }),
+      )
+
+      const markdown = browserEvidenceReviewMarkdown({
+        uiEvidence: `browser artifacts: ${artifactPointer}`,
+        workspace: tempDir,
+      })
+
+      assert.match(markdown, new RegExp(`Browser artifacts: ${artifactPointer}`))
+      assert.match(markdown, /Browser issue summary: 0 console errors, 1 console warning/)
+      assert.match(markdown, /Blocking browser issues: no/)
+      assert.match(
+        markdown,
+        /Screenshot: !\[1440x900 screenshot\]\(docs\/agent-evidence\/browser\/579-test\/2026-05-10T12-34-56-000Z\/screenshots\/page-1440x900\.png\)/,
+      )
+      assert.match(
+        markdown,
+        /Video: docs\/agent-evidence\/browser\/579-test\/2026-05-10T12-34-56-000Z\/videos\/desktop\.webm/,
+      )
+      assert.match(
+        markdown,
+        /Failed-request log: docs\/agent-evidence\/browser\/579-test\/2026-05-10T12-34-56-000Z\/network\.jsonl/,
       )
     } finally {
       rmSync(tempDir, { force: true, recursive: true })


### PR DESCRIPTION
## Summary
- Expands local browser artifact summaries into reviewer-facing evidence packet indexes.
- Converts captured screenshot, video, console, failed-request, and summary paths to repo-relative references.
- Documents the review index behavior in the agent runner docs.

## Verification
- node --check scripts/lib/agent-runner-browser-validation.mjs
- node --check scripts/lib/agent-runner-execution.mjs
- node --check scripts/agent-runner-handoff.mjs
- node --test scripts/tests/agent-runner-browser-validation.test.mjs scripts/tests/agent-runner-browser-evidence.test.mjs scripts/tests/agent-runner-lifecycle.test.mjs
- pnpm verify:agent-quality:changed
- pnpm lint:changed
- pnpm agent:queue:test
- secretlint on changed docs/scripts plus git diff --check
- commit hook lint/typecheck
- pre-push test suite