### PR TITLE
feat(agent-runner): publish browser artifacts to object storage

### DIFF
--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1227,6 +1227,14 @@ Verification:
   GitHub Actions artifacts are temporary CI/debug convenience, not the durable
   archive. A small internal dashboard can be added later as a viewer over the
   same run store and R2 artifacts.
+- Browser capture can publish artifacts directly to R2-compatible object
+  storage with `pnpm agent:queue:capture-browser -- --publish-artifacts`.
+  Configure it with `VOYANT_AGENT_R2_BUCKET`,
+  `VOYANT_AGENT_R2_ACCESS_KEY_ID`, `VOYANT_AGENT_R2_SECRET_ACCESS_KEY`,
+  `VOYANT_AGENT_R2_ACCOUNT_ID` or `VOYANT_AGENT_R2_ENDPOINT`, and
+  `VOYANT_AGENT_R2_PUBLIC_BASE_URL`. The public base URL should be a durable
+  custom domain or authenticated artifact proxy URL prefix, not a temporary
+  signed URL.
 
 ## Open Questions
 

--- a/scripts/agent-runner-capture-browser.mjs
+++ b/scripts/agent-runner-capture-browser.mjs
@@ -12,6 +12,11 @@ import {
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import {
+  artifactPublicationPlan,
+  artifactPublisherFromEnv,
+  publishArtifactDirectory,
+} from "./lib/agent-runner-artifacts.mjs"
+import {
   browserArtifactPlan,
   browserCapturePlan,
   browserCapturePlans,
@@ -20,6 +25,7 @@ import {
   captureBrowserEvidence,
   captureBrowserEvidenceSet,
   requiresBrowserEvidence,
+  writeBrowserEvidenceSummary,
 } from "./lib/agent-runner-browser-evidence.mjs"
 import { browserIssueBlockReason } from "./lib/agent-runner-browser-issues.mjs"
 import {
@@ -51,6 +57,7 @@ maybePrintHelp(args, {
       "--wait-until <event>",
       "Playwright navigation wait event: commit, domcontentloaded, load, or networkidle. Defaults to networkidle.",
     ],
+    ["--publish-artifacts", "Upload captured artifacts to configured R2/S3 object storage."],
     ["--browser-base-port <number>", "Base port for deterministic issue ports. Defaults to 4300."],
     ...repositoryOptions,
     ...mutationOptions,
@@ -161,6 +168,31 @@ if (captureError) {
   fail(`capture-browser failed: ${captureError.message}`)
 }
 
+if (args.publishArtifacts) {
+  try {
+    const publisher = artifactPublisherFromEnv()
+    const publicationPlan = artifactPublicationPlan({
+      publisher,
+      reference: artifactPlan.artifactPointer,
+      repository,
+    })
+    result = {
+      ...result,
+      remoteArtifactIndex: publicationPlan.indexUrl,
+    }
+    writeBrowserEvidenceSummary(artifactPlan, result)
+    await publishArtifactDirectory({
+      directory: artifactPlan.artifactDir,
+      issueNumber: item.issue.number,
+      publisher,
+      reference: artifactPlan.artifactPointer,
+      repository,
+    })
+  } catch (error) {
+    fail(`capture-browser failed to publish artifacts: ${error.message}`)
+  }
+}
+
 const issueBlockReason = browserIssueBlockReason(result.browserIssues, {
   allowBrowserIssues: Boolean(args.allowBrowserIssues),
   required: requiresBrowserEvidence(item),
@@ -193,6 +225,9 @@ function printCapturePlan({ artifactPlan, item, repository }) {
   console.log(`viewports: ${capturePlans.map((plan) => viewportLabel(plan.viewport)).join(", ")}`)
   console.log(`wait until: ${capturePlans[0].waitUntil}`)
   console.log(`artifacts: ${artifactPlan.artifactDir}`)
+  if (args.publishArtifacts) {
+    console.log("remote artifacts: configured object storage")
+  }
   for (const plan of capturePlans) {
     console.log(`screenshot ${viewportLabel(plan.viewport)}: ${plan.screenshotFile}`)
   }

--- a/scripts/lib/agent-project-queue.mjs
+++ b/scripts/lib/agent-project-queue.mjs
@@ -10,6 +10,7 @@ const booleanArgs = new Set([
   "force",
   "help",
   "json",
+  "publish-artifacts",
   "ready",
   "yes",
 ])

--- a/scripts/lib/agent-runner-artifacts.mjs
+++ b/scripts/lib/agent-runner-artifacts.mjs
@@ -1,0 +1,406 @@
+import { readdirSync, readFileSync, statSync } from "node:fs"
+import path from "node:path"
+
+const encoder = new TextEncoder()
+
+export function artifactPublisherFromEnv(env = process.env, options = {}) {
+  const bucket = firstEnv(env, "VOYANT_AGENT_ARTIFACT_BUCKET", "VOYANT_AGENT_R2_BUCKET")
+  const accessKeyId = firstEnv(
+    env,
+    "VOYANT_AGENT_ARTIFACT_ACCESS_KEY_ID",
+    "VOYANT_AGENT_R2_ACCESS_KEY_ID",
+  )
+  const secretAccessKey = firstEnv(
+    env,
+    "VOYANT_AGENT_ARTIFACT_SECRET_ACCESS_KEY",
+    "VOYANT_AGENT_R2_SECRET_ACCESS_KEY",
+  )
+  const endpoint =
+    firstEnv(env, "VOYANT_AGENT_ARTIFACT_ENDPOINT", "VOYANT_AGENT_R2_ENDPOINT") ??
+    r2Endpoint(firstEnv(env, "VOYANT_AGENT_R2_ACCOUNT_ID"))
+  const publicBaseUrl = firstEnv(
+    env,
+    "VOYANT_AGENT_ARTIFACT_PUBLIC_BASE_URL",
+    "VOYANT_AGENT_R2_PUBLIC_BASE_URL",
+  )
+
+  const missing = []
+  if (!bucket) missing.push("VOYANT_AGENT_ARTIFACT_BUCKET or VOYANT_AGENT_R2_BUCKET")
+  if (!accessKeyId) {
+    missing.push("VOYANT_AGENT_ARTIFACT_ACCESS_KEY_ID or VOYANT_AGENT_R2_ACCESS_KEY_ID")
+  }
+  if (!secretAccessKey) {
+    missing.push("VOYANT_AGENT_ARTIFACT_SECRET_ACCESS_KEY or VOYANT_AGENT_R2_SECRET_ACCESS_KEY")
+  }
+  if (!endpoint) {
+    missing.push("VOYANT_AGENT_ARTIFACT_ENDPOINT or VOYANT_AGENT_R2_ACCOUNT_ID")
+  }
+  if (!publicBaseUrl) {
+    missing.push("VOYANT_AGENT_ARTIFACT_PUBLIC_BASE_URL or VOYANT_AGENT_R2_PUBLIC_BASE_URL")
+  }
+  if (missing.length > 0) {
+    throw new Error(`artifact publishing is missing configuration: ${missing.join(", ")}`)
+  }
+
+  return new S3ArtifactPublisher({
+    accessKeyId,
+    bucket,
+    endpoint,
+    fetchImpl: options.fetchImpl,
+    forcePathStyle: boolEnv(env.VOYANT_AGENT_ARTIFACT_FORCE_PATH_STYLE, true),
+    prefix: firstEnv(env, "VOYANT_AGENT_ARTIFACT_PREFIX", "VOYANT_AGENT_R2_PREFIX"),
+    publicBaseUrl,
+    region: firstEnv(env, "VOYANT_AGENT_ARTIFACT_REGION", "VOYANT_AGENT_R2_REGION") ?? "auto",
+    secretAccessKey,
+  })
+}
+
+export async function publishArtifactDirectory({
+  directory,
+  issueNumber,
+  publisher,
+  reference,
+  repository,
+}) {
+  const files = listFiles(directory)
+  const plan = artifactPublicationPlan({ publisher, reference, repository })
+  const keyPrefix = plan.keyPrefix
+  const uploaded = []
+
+  for (const filePath of files) {
+    const relativePath = toPosixPath(path.relative(directory, filePath))
+    const contentType = contentTypeForPath(filePath)
+    const body = readFileSync(filePath)
+    uploaded.push(
+      await publisher.upload({
+        body,
+        contentType,
+        key: `${keyPrefix}/${relativePath}`,
+        metadata: {
+          issue: String(issueNumber),
+          reference,
+          repository,
+        },
+        path: relativePath,
+      }),
+    )
+  }
+
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    issueNumber: Number(issueNumber),
+    keyPrefix,
+    reference,
+    repository,
+    uploaded,
+  }
+  const indexBody = artifactIndexMarkdown(manifest)
+  const index = await publisher.upload({
+    body: Buffer.from(indexBody),
+    contentType: "text/markdown; charset=utf-8",
+    key: `${keyPrefix}/index.md`,
+    metadata: {
+      issue: String(issueNumber),
+      reference,
+      repository,
+    },
+    path: "index.md",
+  })
+  const manifestObject = await publisher.upload({
+    body: Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`),
+    contentType: "application/json; charset=utf-8",
+    key: `${keyPrefix}/manifest.json`,
+    metadata: {
+      issue: String(issueNumber),
+      reference,
+      repository,
+    },
+    path: "manifest.json",
+  })
+
+  return {
+    indexUrl: index.url,
+    keyPrefix,
+    manifestUrl: manifestObject.url,
+    uploaded: [...uploaded, index, manifestObject],
+  }
+}
+
+export function artifactPublicationPlan({ publisher, reference, repository }) {
+  const keyPrefix = objectKeyPrefix({
+    prefix: publisher.prefix,
+    reference,
+    repository,
+  })
+
+  return {
+    indexUrl: publisher.publicUrl(`${keyPrefix}/index.md`),
+    keyPrefix,
+    manifestUrl: publisher.publicUrl(`${keyPrefix}/manifest.json`),
+  }
+}
+
+export class S3ArtifactPublisher {
+  constructor({
+    accessKeyId,
+    bucket,
+    endpoint,
+    fetchImpl = globalThis.fetch,
+    forcePathStyle = true,
+    prefix = "agent-evidence",
+    publicBaseUrl,
+    region,
+    secretAccessKey,
+  }) {
+    if (!fetchImpl) throw new Error("artifact publishing requires fetch")
+    this.accessKeyId = accessKeyId
+    this.bucket = bucket
+    this.endpoint = endpoint.replace(/\/+$/g, "")
+    this.fetchImpl = fetchImpl
+    this.forcePathStyle = forcePathStyle
+    this.prefix = normalizeKeyPart(prefix || "agent-evidence")
+    this.publicBaseUrl = `${publicBaseUrl.replace(/\/+$/g, "")}/`
+    this.region = region
+    this.secretAccessKey = secretAccessKey
+  }
+
+  async upload({ body, contentType, key, metadata = {}, path: artifactPath }) {
+    const url = this.objectUrl(key)
+    const headers = {
+      "content-type": contentType,
+    }
+    for (const [name, value] of Object.entries(metadata)) {
+      headers[`x-amz-meta-${name}`] = value
+    }
+
+    const signed = await signRequest({
+      accessKeyId: this.accessKeyId,
+      body,
+      headers,
+      method: "PUT",
+      region: this.region,
+      secretAccessKey: this.secretAccessKey,
+      url,
+    })
+    const response = await this.fetchImpl(url, {
+      body,
+      headers: signed.headers,
+      method: "PUT",
+    })
+    if (!response.ok) {
+      const text = await response.text().catch(() => "")
+      throw new Error(`artifact upload failed (${response.status}) for ${artifactPath}: ${text}`)
+    }
+
+    return {
+      contentType,
+      key,
+      path: artifactPath,
+      size: body.byteLength,
+      url: `${this.publicBaseUrl}${key}`,
+    }
+  }
+
+  objectUrl(key) {
+    if (this.forcePathStyle) {
+      return `${this.endpoint}/${encodeKey(this.bucket)}/${encodeObjectKey(key)}`
+    }
+    return `${this.endpoint}/${encodeObjectKey(key)}`
+  }
+
+  publicUrl(key) {
+    return `${this.publicBaseUrl}${key}`
+  }
+}
+
+function artifactIndexMarkdown(manifest) {
+  const lines = [
+    "# Agent Evidence Artifacts",
+    "",
+    `Repository: ${manifest.repository}`,
+    `Issue: #${manifest.issueNumber}`,
+    `Reference: ${manifest.reference}`,
+    `Generated: ${manifest.generatedAt}`,
+    "",
+    "## Files",
+    "",
+  ]
+
+  for (const file of manifest.uploaded) {
+    lines.push(`- [${file.path}](${file.url})`)
+  }
+
+  return `${lines.join("\n")}\n`
+}
+
+function listFiles(directory) {
+  const entries = []
+  for (const name of readdirSync(directory)) {
+    const filePath = path.join(directory, name)
+    const stats = statSync(filePath)
+    if (stats.isDirectory()) {
+      entries.push(...listFiles(filePath))
+    } else if (stats.isFile()) {
+      entries.push(filePath)
+    }
+  }
+  return entries.sort()
+}
+
+function objectKeyPrefix({ prefix, reference, repository }) {
+  return [prefix, repository, reference].map(normalizeKeyPart).filter(Boolean).join("/")
+}
+
+function normalizeKeyPart(value) {
+  return String(value ?? "")
+    .split("/")
+    .filter((segment) => segment && segment !== "." && segment !== "..")
+    .join("/")
+}
+
+function contentTypeForPath(filePath) {
+  const extension = path.extname(filePath).toLowerCase()
+  if (extension === ".json") return "application/json; charset=utf-8"
+  if (extension === ".jsonl") return "application/x-ndjson; charset=utf-8"
+  if (extension === ".log" || extension === ".txt") return "text/plain; charset=utf-8"
+  if (extension === ".md") return "text/markdown; charset=utf-8"
+  if (extension === ".png") return "image/png"
+  if (extension === ".webm") return "video/webm"
+  return "application/octet-stream"
+}
+
+function firstEnv(env, ...names) {
+  for (const name of names) {
+    const value = env[name]?.trim()
+    if (value) return value
+  }
+  return undefined
+}
+
+function boolEnv(value, fallback) {
+  if (value === undefined) return fallback
+  return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase())
+}
+
+function r2Endpoint(accountId) {
+  if (!accountId) return undefined
+  return `https://${accountId}.r2.cloudflarestorage.com`
+}
+
+async function signRequest({ accessKeyId, body, headers, method, region, secretAccessKey, url }) {
+  const { amzDate, dateStamp } = datesFromNow()
+  const parsedUrl = new URL(url)
+  const payloadHash = await hexHash(body)
+  const baseHeaders = {
+    ...headers,
+    host: parsedUrl.host,
+    "x-amz-content-sha256": payloadHash,
+    "x-amz-date": amzDate,
+  }
+  const { canonicalHeaders, signedHeaders } = canonicalizeHeaders(baseHeaders)
+  const canonicalRequest = [
+    method.toUpperCase(),
+    canonicalUri(parsedUrl.pathname),
+    canonicalQueryString(parsedUrl),
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join("\n")
+  const scope = `${dateStamp}/${region}/s3/aws4_request`
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    amzDate,
+    scope,
+    await hexHash(encoder.encode(canonicalRequest)),
+  ].join("\n")
+  const signingKey = await deriveSigningKey(secretAccessKey, dateStamp, region)
+  const signature = hex(await hmac(signingKey, stringToSign))
+
+  return {
+    headers: {
+      ...baseHeaders,
+      Authorization:
+        `AWS4-HMAC-SHA256 Credential=${accessKeyId}/${scope}, ` +
+        `SignedHeaders=${signedHeaders}, Signature=${signature}`,
+    },
+  }
+}
+
+function datesFromNow() {
+  const iso = new Date().toISOString().replace(/[:-]|\.\d{3}/g, "")
+  return { amzDate: iso, dateStamp: iso.slice(0, 8) }
+}
+
+function canonicalUri(pathname) {
+  return pathname
+    .split("/")
+    .map((segment) => encodeRfc3986(segment))
+    .join("/")
+}
+
+function canonicalQueryString(url) {
+  const pairs = []
+  for (const [key, value] of url.searchParams.entries()) {
+    pairs.push([encodeRfc3986(key), encodeRfc3986(value)])
+  }
+  pairs.sort((a, b) => (a[0] === b[0] ? a[1].localeCompare(b[1]) : a[0].localeCompare(b[0])))
+  return pairs.map(([key, value]) => `${key}=${value}`).join("&")
+}
+
+function canonicalizeHeaders(headers) {
+  const entries = Object.entries(headers)
+    .map(([key, value]) => [key.toLowerCase(), String(value).trim().replace(/\s+/g, " ")])
+    .sort(([a], [b]) => a.localeCompare(b))
+  return {
+    canonicalHeaders: `${entries.map(([key, value]) => `${key}:${value}`).join("\n")}\n`,
+    signedHeaders: entries.map(([key]) => key).join(";"),
+  }
+}
+
+function encodeRfc3986(value) {
+  return encodeURIComponent(value).replace(
+    /[!'()*]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  )
+}
+
+function encodeKey(value) {
+  return encodeRfc3986(value)
+}
+
+function encodeObjectKey(value) {
+  return value.split("/").map(encodeRfc3986).join("/")
+}
+
+async function hexHash(data) {
+  const bytes = data instanceof Uint8Array ? data : new Uint8Array(data)
+  const digest = await crypto.subtle.digest("SHA-256", bytes)
+  return hex(digest)
+}
+
+async function hmac(key, data) {
+  const bytes = key instanceof Uint8Array ? key : new Uint8Array(key)
+  const cryptoKey = await crypto.subtle.importKey(
+    "raw",
+    bytes,
+    { hash: "SHA-256", name: "HMAC" },
+    false,
+    ["sign"],
+  )
+  return crypto.subtle.sign("HMAC", cryptoKey, encoder.encode(data))
+}
+
+async function deriveSigningKey(secretAccessKey, dateStamp, region) {
+  const dateKey = await hmac(encoder.encode(`AWS4${secretAccessKey}`), dateStamp)
+  const regionKey = await hmac(dateKey, region)
+  const serviceKey = await hmac(regionKey, "s3")
+  return hmac(serviceKey, "aws4_request")
+}
+
+function hex(buffer) {
+  return [...new Uint8Array(buffer)].map((byte) => byte.toString(16).padStart(2, "0")).join("")
+}
+
+function toPosixPath(reference) {
+  return reference.split(path.sep).join(path.posix.sep)
+}

--- a/scripts/lib/agent-runner-browser-evidence.mjs
+++ b/scripts/lib/agent-runner-browser-evidence.mjs
@@ -8,13 +8,9 @@ import {
 } from "./agent-runner-browser-issues.mjs"
 import { localWorkspaceReferencePlan } from "./agent-runner-workspace.mjs"
 
-const uiEvidenceLabels = new Set([
-  "browser:evidence",
-  "frontend",
-  "needs-browser-evidence",
-  "ui",
-  "ui-change",
-])
+const uiEvidenceLabels = new Set(
+  "browser:evidence frontend needs-browser-evidence ui ui-change".split(" "),
+)
 
 export function requiresBrowserEvidence(item) {
   const labels = item.issue?.labels ?? []
@@ -211,8 +207,7 @@ export async function captureBrowserEvidence({ browserLauncher, capturePlan, tim
     failedRequestLog: artifactPlan.networkLog,
   }
 
-  writeFileSync(artifactPlan.summaryJson, `${JSON.stringify(result, null, 2)}\n`, "utf8")
-  writeFileSync(artifactPlan.readme, browserEvidenceMarkdown(result), "utf8")
+  writeBrowserEvidenceSummary(artifactPlan, result)
 
   return result
 }
@@ -258,8 +253,7 @@ export async function captureBrowserEvidenceSet({
     failedRequestLog: artifactPlan.networkLog,
   }
 
-  writeFileSync(artifactPlan.summaryJson, `${JSON.stringify(result, null, 2)}\n`, "utf8")
-  writeFileSync(artifactPlan.readme, browserEvidenceMarkdown(result), "utf8")
+  writeBrowserEvidenceSummary(artifactPlan, result)
 
   return result
 }
@@ -315,6 +309,8 @@ async function captureSingleBrowserEvidence({ browserLauncher, capturePlan, time
 export function browserEvidenceText(result) {
   if (Array.isArray(result.captures)) {
     const lines = [`browser artifacts: ${result.artifactPointer}`]
+    if (result.remoteArtifactIndex)
+      lines.push(`remote artifact index: ${result.remoteArtifactIndex}`)
 
     for (const capture of result.captures) {
       lines.push(
@@ -335,6 +331,7 @@ export function browserEvidenceText(result) {
 
   const lines = [
     `browser artifacts: ${result.artifactPointer}`,
+    result.remoteArtifactIndex ? `remote artifact index: ${result.remoteArtifactIndex}` : null,
     `url: ${result.url}`,
     `screenshot: ${result.screenshot}`,
     result.browserIssues
@@ -347,6 +344,11 @@ export function browserEvidenceText(result) {
   if (result.video) lines.push(`video: ${result.video}`)
 
   return lines.join("\n")
+}
+
+export function writeBrowserEvidenceSummary(artifactPlan, result) {
+  writeFileSync(artifactPlan.summaryJson, `${JSON.stringify(result, null, 2)}\n`, "utf8")
+  writeFileSync(artifactPlan.readme, browserEvidenceMarkdown(result), "utf8")
 }
 
 export function browserEvidenceMarkdown(result) {
@@ -369,6 +371,7 @@ export function browserEvidenceMarkdown(result) {
     return `# Browser Evidence
 
 Artifacts: ${result.artifactPointer}
+${result.remoteArtifactIndex ? `Remote artifact index: ${result.remoteArtifactIndex}\n` : ""}
 
 ## Captures
 
@@ -387,6 +390,7 @@ ${browserIssueMarkdown(result.browserIssues)}
 
 URL: ${result.url}
 Artifacts: ${result.artifactPointer}
+${result.remoteArtifactIndex ? `Remote artifact index: ${result.remoteArtifactIndex}\n` : ""}
 Viewport: ${result.viewport.width}x${result.viewport.height}
 Wait until: ${result.waitUntil}
 

--- a/scripts/lib/agent-runner-browser-validation.mjs
+++ b/scripts/lib/agent-runner-browser-validation.mjs
@@ -99,6 +99,7 @@ function formatBrowserEvidenceSummaryForReview({ reference, summary, workspace }
 
   return [
     `Browser artifacts: ${artifactPointer}`,
+    summary.remoteArtifactIndex ? `Remote artifact index: ${summary.remoteArtifactIndex}` : null,
     `Browser issue summary: ${formatBrowserIssueSummary(summary.browserIssues)}`,
     `Blocking browser issues: ${summary.browserIssues.hasBlockingIssues ? "yes" : "no"}`,
     "",

--- a/scripts/tests/agent-runner-artifacts.test.mjs
+++ b/scripts/tests/agent-runner-artifacts.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { describe, it } from "node:test"
+
+import {
+  artifactPublisherFromEnv,
+  publishArtifactDirectory,
+} from "../lib/agent-runner-artifacts.mjs"
+import { browserEvidenceText } from "../lib/agent-runner-browser-evidence.mjs"
+
+describe("agent runner artifact publishing", () => {
+  it("requires durable R2/S3 configuration before publishing", () => {
+    assert.throws(
+      () => artifactPublisherFromEnv({}),
+      /artifact publishing is missing configuration: .*VOYANT_AGENT_ARTIFACT_BUCKET/,
+    )
+  })
+
+  it("uploads a directory to the configured R2 key prefix", async () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "voyant-agent-artifacts-"))
+    try {
+      mkdirSync(path.join(tempDir, "screenshots"), { recursive: true })
+      mkdirSync(path.join(tempDir, "videos"), { recursive: true })
+      writeFileSync(path.join(tempDir, "README.md"), "# Evidence\n", "utf8")
+      writeFileSync(path.join(tempDir, "summary.json"), "{}\n", "utf8")
+      writeFileSync(path.join(tempDir, "screenshots", "page.png"), "png", "utf8")
+      writeFileSync(path.join(tempDir, "videos", "page.webm"), "webm", "utf8")
+
+      const requests = []
+      const publisher = artifactPublisherFromEnv(
+        {
+          VOYANT_AGENT_R2_ACCESS_KEY_ID: "access-key",
+          VOYANT_AGENT_R2_ACCOUNT_ID: "account-id",
+          VOYANT_AGENT_R2_BUCKET: "agent-artifacts",
+          VOYANT_AGENT_R2_PREFIX: "runs",
+          VOYANT_AGENT_R2_PUBLIC_BASE_URL: "https://artifacts.example.com",
+          VOYANT_AGENT_R2_SECRET_ACCESS_KEY: "secret-key",
+        },
+        {
+          fetchImpl: async (url, init) => {
+            requests.push({ init, url })
+            return {
+              ok: true,
+              status: 200,
+              text: async () => "",
+            }
+          },
+        },
+      )
+
+      const publication = await publishArtifactDirectory({
+        directory: tempDir,
+        issueNumber: 651,
+        publisher,
+        reference: "docs/agent-evidence/browser/651-task/2026-05-11T10-30-11-222Z",
+        repository: "voyantjs/voyant",
+      })
+
+      assert.equal(publication.indexUrl.endsWith("/index.md"), true)
+      assert.equal(publication.manifestUrl.endsWith("/manifest.json"), true)
+      assert.equal(requests.length, 6)
+      assert.match(requests[0].url, /^https:\/\/account-id\.r2\.cloudflarestorage\.com\//)
+      assert.match(
+        requests[0].url,
+        /agent-artifacts\/runs\/voyantjs\/voyant\/docs\/agent-evidence\/browser\/651-task/,
+      )
+      assert.equal(
+        requests.some((request) => request.init.headers.Authorization),
+        true,
+      )
+      assert.equal(
+        requests.some((request) => request.init.headers["content-type"] === "image/png"),
+        true,
+      )
+      assert.equal(
+        publication.uploaded.some((artifact) => artifact.path === "videos/page.webm"),
+        true,
+      )
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true })
+    }
+  })
+
+  it("includes remote artifact links in browser evidence text", () => {
+    assert.match(
+      browserEvidenceText({
+        artifactPointer: "docs/agent-evidence/browser/579-test/2026-05-10T12-34-56-000Z",
+        browserIssues: {
+          consoleErrors: 0,
+          consoleWarnings: 0,
+          failedRequests: 0,
+          hasBlockingIssues: false,
+        },
+        consoleLog: "/workspace/console.jsonl",
+        failedRequestLog: "/workspace/network.jsonl",
+        remoteArtifactIndex: "https://artifacts.example.com/runs/index.md",
+        screenshot: "/workspace/page.png",
+        url: "http://127.0.0.1:4879/dashboard",
+        viewport: { height: 900, width: 1440 },
+      }),
+      /remote artifact index: https:\/\/artifacts\.example\.com\/runs\/index\.md/,
+    )
+  })
+})

--- a/scripts/tests/agent-runner-browser-validation.test.mjs
+++ b/scripts/tests/agent-runner-browser-validation.test.mjs
@@ -223,6 +223,7 @@ describe("agent runner browser evidence validation", () => {
           ],
           consoleLog: path.join(summaryDir, "console.jsonl"),
           failedRequestLog: path.join(summaryDir, "network.jsonl"),
+          remoteArtifactIndex: "https://artifacts.example.com/runs/index.md",
         }),
       )
 
@@ -232,6 +233,10 @@ describe("agent runner browser evidence validation", () => {
       })
 
       assert.match(markdown, new RegExp(`Browser artifacts: ${artifactPointer}`))
+      assert.match(
+        markdown,
+        /Remote artifact index: https:\/\/artifacts\.example\.com\/runs\/index\.md/,
+      )
       assert.match(markdown, /Browser issue summary: 0 console errors, 1 console warning/)
       assert.match(markdown, /Blocking browser issues: no/)
       assert.match(


### PR DESCRIPTION
## Summary
- add an R2/S3-compatible artifact publisher for browser evidence directories
- wire `agent:queue:capture-browser -- --publish-artifacts` to upload artifacts and print a durable remote index link
- document the required R2 environment variables and add focused runner tests

## Verification
- pnpm agent:queue:test
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- pre-push `pnpm test` hook passed with cached repository tests