### PR TITLE
feat(agent-runner): publish evidence packets to object storage

### DIFF
--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1229,6 +1229,10 @@ Verification:
   same run store and R2 artifacts.
 - Browser capture can publish artifacts directly to R2-compatible object
   storage with `pnpm agent:queue:capture-browser -- --publish-artifacts`.
+  Evidence publishing can use the same object store with
+  `pnpm agent:queue:publish-evidence -- --publish-artifacts`; in that mode the
+  Project `Evidence` field points at the durable remote evidence packet while
+  the GitHub issue comment remains a readable copy.
   Configure it with `VOYANT_AGENT_R2_BUCKET`,
   `VOYANT_AGENT_R2_ACCESS_KEY_ID`, `VOYANT_AGENT_R2_SECRET_ACCESS_KEY`,
   `VOYANT_AGENT_R2_ACCOUNT_ID` or `VOYANT_AGENT_R2_ENDPOINT`, and

--- a/scripts/agent-runner-publish-evidence.mjs
+++ b/scripts/agent-runner-publish-evidence.mjs
@@ -13,6 +13,11 @@ import {
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import {
+  artifactPublisherFromEnv,
+  evidencePacketPublicationPlan,
+  publishEvidencePacket,
+} from "./lib/agent-runner-artifacts.mjs"
+import {
   maybePrintHelp,
   mutationOptions,
   projectOptions,
@@ -28,6 +33,7 @@ maybePrintHelp(args, {
   options: [
     ["--issue <number>", "Issue number whose evidence packet should be published."],
     ["--evidence-path <path>", "Evidence path relative to the task workspace."],
+    ["--publish-artifacts", "Upload the evidence packet to configured R2/S3 object storage."],
     ["--workspace <path>", "Workspace path override."],
     ...repositoryOptions,
     ...mutationOptions,
@@ -68,6 +74,9 @@ if (isRemoteEvidence(evidenceReference)) {
 }
 
 const evidencePath = path.resolve(workspace, evidenceReference)
+if (!isPathInside(evidencePath, workspace)) {
+  fail(`evidence packet is outside the workspace: ${evidenceReference}`)
+}
 if (!existsSync(evidencePath)) {
   fail(`evidence packet does not exist: ${evidencePath}`)
 }
@@ -87,20 +96,42 @@ const existingCommentUrl = findExistingEvidenceComment({
   marker,
   repository,
 })
+const artifactPublisher = args.publishArtifacts ? artifactPublisherFromEnv() : undefined
+const remoteEvidencePlan = artifactPublisher
+  ? evidencePacketPublicationPlan({
+      publisher: artifactPublisher,
+      reference: evidenceReference,
+      repository,
+    })
+  : undefined
 
 if (!args.yes) {
   console.log("agent-runner publish-evidence would update:")
   console.log(`issue: #${item.issue.number} ${item.issue.title}`)
   console.log(`repository: ${repository}`)
   console.log(`evidence file: ${evidencePath}`)
-  console.log(`Evidence: ${existingCommentUrl ?? "<new issue comment URL>"}`)
+  if (remoteEvidencePlan) {
+    console.log(`remote evidence packet: ${remoteEvidencePlan.url}`)
+  }
+  console.log(
+    `Evidence: ${remoteEvidencePlan?.url ?? existingCommentUrl ?? "<new issue comment URL>"}`,
+  )
   fail("publish-evidence mode comments on GitHub and updates Project fields; rerun with --yes")
 }
 
+const remoteEvidence =
+  artifactPublisher &&
+  (await publishEvidencePacket({
+    body: evidenceBody,
+    issueNumber: item.issue.number,
+    publisher: artifactPublisher,
+    reference: evidenceReference,
+    repository,
+  }))
 const commentUrl =
   existingCommentUrl ??
   createIssueComment({
-    body: `${marker}\n\n${evidenceBody}`,
+    body: evidenceCommentBody({ evidenceBody, marker, remoteEvidenceUrl: remoteEvidence?.url }),
     issueNumber: item.issue.number,
     repository,
   })
@@ -109,7 +140,7 @@ updateProjectItemFields({
   project,
   item,
   values: {
-    Evidence: commentUrl,
+    Evidence: remoteEvidence?.url ?? commentUrl,
     "Last Heartbeat": today(),
   },
 })
@@ -117,7 +148,10 @@ updateProjectItemFields({
 console.log("agent-runner publish-evidence: posted issue comment and updated Project fields")
 console.log(`issue: #${item.issue.number} ${item.issue.title}`)
 console.log(`repository: ${repository}`)
-console.log(`evidence: ${commentUrl}`)
+console.log(`evidence: ${remoteEvidence?.url ?? commentUrl}`)
+if (remoteEvidence) {
+  console.log(`github comment: ${commentUrl}`)
+}
 
 function findExistingEvidenceComment({ issueNumber, marker, repository }) {
   const result = spawnSync("gh", ["api", `repos/${repository}/issues/${issueNumber}/comments`], {
@@ -190,8 +224,18 @@ function evidenceMarker({ evidenceReference, issueNumber, repository }) {
   return `<!-- voyant-agent-evidence:${key} -->`
 }
 
+function evidenceCommentBody({ evidenceBody, marker, remoteEvidenceUrl }) {
+  const remoteLine = remoteEvidenceUrl ? `Published evidence packet: ${remoteEvidenceUrl}\n\n` : ""
+  return `${marker}\n\n${remoteLine}${evidenceBody}`
+}
+
 function isRemoteEvidence(evidence) {
   return /^https?:\/\//.test(evidence)
+}
+
+function isPathInside(candidatePath, parentPath) {
+  const relative = path.relative(parentPath, candidatePath)
+  return Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative)
 }
 
 function today() {

--- a/scripts/lib/agent-runner-artifacts.mjs
+++ b/scripts/lib/agent-runner-artifacts.mjs
@@ -126,6 +126,27 @@ export async function publishArtifactDirectory({
   }
 }
 
+export async function publishEvidencePacket({
+  body,
+  issueNumber,
+  publisher,
+  reference,
+  repository,
+}) {
+  const plan = evidencePacketPublicationPlan({ publisher, reference, repository })
+  return publisher.upload({
+    body: Buffer.from(body),
+    contentType: "text/markdown; charset=utf-8",
+    key: plan.key,
+    metadata: {
+      issue: String(issueNumber),
+      reference,
+      repository,
+    },
+    path: path.posix.basename(reference) || "evidence.md",
+  })
+}
+
 export function artifactPublicationPlan({ publisher, reference, repository }) {
   const keyPrefix = objectKeyPrefix({
     prefix: publisher.prefix,
@@ -137,6 +158,19 @@ export function artifactPublicationPlan({ publisher, reference, repository }) {
     indexUrl: publisher.publicUrl(`${keyPrefix}/index.md`),
     keyPrefix,
     manifestUrl: publisher.publicUrl(`${keyPrefix}/manifest.json`),
+  }
+}
+
+export function evidencePacketPublicationPlan({ publisher, reference, repository }) {
+  const key = objectKeyPrefix({
+    prefix: publisher.prefix,
+    reference,
+    repository,
+  })
+
+  return {
+    key,
+    url: publisher.publicUrl(key),
   }
 }
 

--- a/scripts/tests/agent-runner-artifacts.test.mjs
+++ b/scripts/tests/agent-runner-artifacts.test.mjs
@@ -7,6 +7,7 @@ import { describe, it } from "node:test"
 import {
   artifactPublisherFromEnv,
   publishArtifactDirectory,
+  publishEvidencePacket,
 } from "../lib/agent-runner-artifacts.mjs"
 import { browserEvidenceText } from "../lib/agent-runner-browser-evidence.mjs"
 
@@ -81,6 +82,46 @@ describe("agent runner artifact publishing", () => {
     } finally {
       rmSync(tempDir, { force: true, recursive: true })
     }
+  })
+
+  it("uploads an evidence packet to a durable object key", async () => {
+    const requests = []
+    const publisher = artifactPublisherFromEnv(
+      {
+        VOYANT_AGENT_R2_ACCESS_KEY_ID: "access-key",
+        VOYANT_AGENT_R2_ACCOUNT_ID: "account-id",
+        VOYANT_AGENT_R2_BUCKET: "agent-artifacts",
+        VOYANT_AGENT_R2_PUBLIC_BASE_URL: "https://artifacts.example.com",
+        VOYANT_AGENT_R2_SECRET_ACCESS_KEY: "secret-key",
+      },
+      {
+        fetchImpl: async (url, init) => {
+          requests.push({ init, url })
+          return {
+            ok: true,
+            status: 200,
+            text: async () => "",
+          }
+        },
+      },
+    )
+
+    const publication = await publishEvidencePacket({
+      body: "# Evidence\n\nAll checks passed.\n",
+      issueNumber: 579,
+      publisher,
+      reference: "docs/agent-evidence/active/579-test.md",
+      repository: "voyantjs/voyant",
+    })
+
+    assert.equal(
+      publication.url,
+      "https://artifacts.example.com/agent-evidence/voyantjs/voyant/docs/agent-evidence/active/579-test.md",
+    )
+    assert.equal(publication.contentType, "text/markdown; charset=utf-8")
+    assert.equal(requests.length, 1)
+    assert.match(requests[0].url, /agent-artifacts\/agent-evidence\/voyantjs\/voyant/)
+    assert.equal(requests[0].init.headers["x-amz-meta-issue"], "579")
   })
 
   it("includes remote artifact links in browser evidence text", () => {


### PR DESCRIPTION
## Summary
- publish evidence packet markdown to the configured R2/S3 object store from `agent:queue:publish-evidence -- --publish-artifacts`
- set the Project Evidence field to the durable remote packet URL while keeping the GitHub issue comment as a readable copy
- reject evidence paths that resolve outside the workspace and document the durable evidence mode

## Verification
- pnpm agent:queue:test
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- pre-push `pnpm test` hook passed with cached repository tests