### PR TITLE
feat(agent-runner): pass PR refresh through dispatch plans

### DIFF
--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -30,4 +30,6 @@ pnpm -C apps/agent-control-plane dev
 `POST /api/dispatch-plans` accepts ordered queue recommendations and returns the
 first dispatchable plan that matches the optional filters. It mirrors the local
 runner allow-list: `start`, `collect-ci`, `publish-evidence`, `open-pr`,
-`sync-pr`, and `cleanup`.
+`sync-pr`, and `cleanup`. Pass `options.updateBody = true` to include
+`--update-body` when the selected plan is `sync-pr`; other actions ignore that
+option.

--- a/apps/agent-control-plane/src/control-plane.test.ts
+++ b/apps/agent-control-plane/src/control-plane.test.ts
@@ -134,6 +134,45 @@ describe("agent control plane", () => {
     })
   })
 
+  it("adds PR body refresh only for sync plans", () => {
+    const syncRecommendation = {
+      action: "sync-pr",
+      reason: "linked PR should be synced back to the Project",
+      issue: {
+        number: 627,
+        title: "Sync review state",
+        url: "https://github.com/voyantjs/voyant/issues/627",
+        repository: "voyantjs/voyant",
+      },
+    }
+
+    expect(
+      selectDispatchPlan({
+        options: { updateBody: true },
+        recommendations: [syncRecommendation],
+        repository: "voyantjs/voyant",
+      }).plan?.command,
+    ).toEqual([
+      "pnpm",
+      "agent:queue:sync-pr",
+      "--",
+      "--issue",
+      "627",
+      "--repo",
+      "voyantjs/voyant",
+      "--yes",
+      "--update-body",
+    ])
+
+    expect(
+      selectDispatchPlan({
+        options: { updateBody: true },
+        recommendations: [recommendations[1]!],
+        repository: "voyantjs/voyant",
+      }).plan?.command,
+    ).not.toContain("--update-body")
+  })
+
   it("serves health and dispatch planning through Hono", async () => {
     const app = createApp({ authTokens: ["secret"] })
 

--- a/apps/agent-control-plane/src/control-plane.ts
+++ b/apps/agent-control-plane/src/control-plane.ts
@@ -18,6 +18,11 @@ export const dispatchPlanRequestSchema = z.object({
       issueNumber: z.number().int().positive().optional(),
     })
     .optional(),
+  options: z
+    .object({
+      updateBody: z.boolean().optional(),
+    })
+    .optional(),
   recommendations: z
     .array(
       z.object({
@@ -106,16 +111,12 @@ export function selectDispatchPlan(request: DispatchPlanRequest): DispatchPlanRe
   return {
     plan: {
       action,
-      command: [
-        "pnpm",
-        `agent:queue:${action}`,
-        "--",
-        "--issue",
-        String(recommendation.issue.number),
-        "--repo",
-        request.repository,
-        "--yes",
-      ],
+      command: dispatchCommand({
+        action,
+        issueNumber: recommendation.issue.number,
+        repository: request.repository,
+        updateBody: request.options?.updateBody,
+      }),
       issue: recommendation.issue,
       reason: recommendation.reason,
       repository: request.repository,
@@ -123,6 +124,35 @@ export function selectDispatchPlan(request: DispatchPlanRequest): DispatchPlanRe
     },
     reason: "matched",
   }
+}
+
+function dispatchCommand({
+  action,
+  issueNumber,
+  repository,
+  updateBody,
+}: {
+  action: DispatchPlan["action"]
+  issueNumber: number
+  repository: string
+  updateBody?: boolean
+}) {
+  const command = [
+    "pnpm",
+    `agent:queue:${action}`,
+    "--",
+    "--issue",
+    String(issueNumber),
+    "--repo",
+    repository,
+    "--yes",
+  ]
+
+  if (updateBody && action === "sync-pr") {
+    command.push("--update-body")
+  }
+
+  return command
 }
 
 function isDispatchableAction(action: string): action is DispatchPlan["action"] {

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1147,7 +1147,8 @@ failed CI logs into local repair packets, and mark merged PRs done. PR sync can
 also refresh a PR description from the current evidence packet with
 `pnpm agent:queue:sync-pr -- --issue <number> --update-body --yes`; this is
 explicit so maintainer-edited PR descriptions are not overwritten by routine
-state polling.
+state polling. Dispatch, loop, and control-plane planning can pass the same
+option through to `sync-pr` when the runner intentionally wants that refresh.
 
 Verification:
 

--- a/scripts/agent-runner-dispatch.mjs
+++ b/scripts/agent-runner-dispatch.mjs
@@ -39,6 +39,7 @@ maybePrintHelp(args, {
     ],
     ["--max-age-days <number>", "Heartbeat staleness threshold. Defaults to 1."],
     ["--event-log <path>", "JSONL audit log path. Defaults to .agent-runs/events.jsonl."],
+    ["--update-body", "When dispatching sync-pr, refresh the PR body from evidence."],
     ...repositoryOptions,
     ...mutationOptions,
     ...projectOptions,
@@ -76,7 +77,10 @@ if (!recommendation) {
   fail(reason)
 }
 
-const commandArgs = dispatchCommandArgs(recommendation, { repository })
+const commandArgs = dispatchCommandArgs(recommendation, {
+  repository,
+  updateBody: Boolean(args.updateBody),
+})
 const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
 
 if (!args.yes) {

--- a/scripts/agent-runner-loop.mjs
+++ b/scripts/agent-runner-loop.mjs
@@ -42,6 +42,7 @@ maybePrintHelp(args, {
     ],
     ["--max-age-days <number>", "Heartbeat staleness threshold. Defaults to 1."],
     ["--event-log <path>", "JSONL audit log path. Defaults to .agent-runs/events.jsonl."],
+    ["--update-body", "When dispatching sync-pr, refresh the PR body from evidence."],
     ...repositoryOptions,
     ...mutationOptions,
     ...projectOptions,
@@ -75,7 +76,11 @@ for (let iteration = 1; iteration <= loopOptions.iterations; iteration += 1) {
   const recommendation = selectLoopRecommendation()
   if (!recommendation) break
 
-  const commandArgs = dispatchCommandArgs(recommendation, { eventLog: args.eventLog, repository })
+  const commandArgs = dispatchCommandArgs(recommendation, {
+    eventLog: args.eventLog,
+    repository,
+    updateBody: Boolean(args.updateBody),
+  })
 
   if (!args.yes) {
     printLoopPlan({ commandArgs, iteration, recommendation })

--- a/scripts/lib/agent-runner-dispatch.mjs
+++ b/scripts/lib/agent-runner-dispatch.mjs
@@ -36,7 +36,7 @@ export function selectDispatchRecommendation(recommendations, { action, issueNum
   }
 }
 
-export function dispatchCommandArgs(recommendation, { eventLog, repository }) {
+export function dispatchCommandArgs(recommendation, { eventLog, repository, updateBody } = {}) {
   if (!dispatchableActions.has(recommendation.action)) {
     throw new Error(`action ${recommendation.action} is not dispatchable`)
   }
@@ -53,6 +53,10 @@ export function dispatchCommandArgs(recommendation, { eventLog, repository }) {
 
   if (eventLog) {
     commandArgs.push("--event-log", eventLog)
+  }
+
+  if (updateBody && recommendation.action === "sync-pr") {
+    commandArgs.push("--update-body")
   }
 
   return commandArgs

--- a/scripts/tests/agent-runner-dispatch.test.mjs
+++ b/scripts/tests/agent-runner-dispatch.test.mjs
@@ -105,6 +105,48 @@ describe("agent runner dispatch helpers", () => {
     )
   })
 
+  it("passes PR body refresh only to sync recommendations", () => {
+    const syncRecommendation = recommendQueueAction(
+      workItem({
+        fields: {
+          "Agent State": "Human Review",
+          PR: "https://github.com/voyantjs/voyant/pull/626",
+        },
+      }),
+      { maxAgeDays: 1, repository: "voyantjs/other" },
+    )
+
+    assert.deepEqual(
+      dispatchCommandArgs(syncRecommendation, {
+        repository: "voyantjs/other",
+        updateBody: true,
+      }),
+      [
+        "agent:queue:sync-pr",
+        "--",
+        "--issue",
+        "579",
+        "--repo",
+        "voyantjs/other",
+        "--yes",
+        "--update-body",
+      ],
+    )
+
+    const startRecommendation = recommendQueueAction(workItem(), {
+      maxAgeDays: 1,
+      repository: "voyantjs/other",
+    })
+
+    assert.equal(
+      dispatchCommandArgs(startRecommendation, {
+        repository: "voyantjs/other",
+        updateBody: true,
+      }).includes("--update-body"),
+      false,
+    )
+  })
+
   it("does not dispatch implementation or wait actions", () => {
     const running = recommendQueueAction(
       workItem({


### PR DESCRIPTION
## Summary
- allow `agent:queue:dispatch` and `agent:queue:loop` to pass `--update-body` through when the selected action is `sync-pr`
- expose the same opt-in PR body refresh option in the Cloudflare-ready control-plane dispatch plan API
- document the dispatch/control-plane behavior so routine sync still avoids overwriting maintainer-edited PR descriptions

## Verification
- pnpm agent:queue:test
- pnpm -C apps/agent-control-plane test
- pnpm -C apps/agent-control-plane check-types
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- git diff --check
- pnpm agent:queue:dispatch -- --help
- pnpm agent:queue:loop -- --help
- pre-push `pnpm test` hook passed with cached repository tests