### PR TITLE
feat(agent-runner): inspect remote workspace adapters

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -134,6 +134,8 @@ paths. Cleanup only removes local worktrees under `.agent-worktrees/`.
 Until the remote adapter is implemented, local-only commands such as
 `run-command`, `capture-browser`, `handoff`, `publish-evidence`, and `open-pr`
 reject `sandbox:` workspace references instead of resolving them as paths.
+Use `pnpm agent:queue:remote-inspect -- --issue <number>` to inspect a remote
+workspace reference and confirm whether its provider adapter is configured.
 
 After start, run a supervised provider-neutral command in the claimed
 workspace:
@@ -212,7 +214,8 @@ machine-readable actions. `Merge Ready` items with linked PRs keep recommending
 `CI Repair` items with failing linked PRs recommend `collect-ci` until a local
 CI repair packet exists. Items with `sandbox:<provider>:<id>` workspaces
 recommend wait states instead of local workspace commands until a remote adapter
-owns execution and cleanup. Malformed reserved `sandbox:` values recommend
+owns execution and cleanup; their recommendation includes a read-only
+`remote-inspect` command. Malformed reserved `sandbox:` values recommend
 `inspect-workspace`.
 
 Use dispatch to execute one allow-listed tick recommendation:

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1168,6 +1168,13 @@ Deliverables:
   artifacts.
 - Compare local and remote performance, cost, and reliability.
 
+Current status: started. The runner has a provider-neutral remote workspace
+adapter contract and an unsupported-adapter fallback. Queue recommendations for
+`sandbox:<provider>:<id>` items now point maintainers at
+`pnpm agent:queue:remote-inspect -- --issue <number>` so remote references are
+typed and inspectable before a real sandbox adapter is allowed to execute,
+expose HTTP, collect artifacts, or clean up remote state.
+
 Verification:
 
 - Run the same task locally and in a Sprite.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "agent:queue:tick": "node scripts/agent-runner-tick.mjs",
     "agent:queue:dispatch": "node scripts/agent-runner-dispatch.mjs",
     "agent:queue:loop": "node scripts/agent-runner-loop.mjs",
+    "agent:queue:remote-inspect": "node scripts/agent-runner-remote-inspect.mjs",
     "agent:queue:prepare": "node scripts/agent-runner-prepare.mjs",
     "agent:queue:start": "node scripts/agent-runner-start.mjs",
     "agent:queue:run-command": "node scripts/agent-runner-run-command.mjs",

--- a/scripts/agent-runner-remote-inspect.mjs
+++ b/scripts/agent-runner-remote-inspect.mjs
@@ -1,0 +1,113 @@
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  findProjectIssueItem,
+  loadAllEvaluatedProject,
+  parseArgs,
+  projectScanConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+import { maybePrintHelp, projectOptions, repositoryOptions } from "./lib/agent-runner-help.mjs"
+import { resolveRemoteWorkspaceAdapter } from "./lib/agent-runner-remote-workspace.mjs"
+import { parseWorkspaceReference } from "./lib/agent-runner-workspace-contract.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:remote-inspect",
+  summary: "Inspect a remote sandbox workspace reference without mutating it.",
+  usage: "pnpm agent:queue:remote-inspect -- (--issue <number> | --workspace <reference>)",
+  options: [
+    ["--issue <number>", "Issue number whose Project Workspace field should be inspected."],
+    [
+      "--workspace <reference>",
+      "Workspace reference override, for example sandbox:sprite:task-579.",
+    ],
+    ["--json", "Print machine-readable JSON."],
+    ...repositoryOptions,
+    ...projectOptions,
+  ],
+})
+
+if (!args.issue && !args.workspace) {
+  fail("remote-inspect mode requires --issue <number> or --workspace <reference>")
+}
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = resolveRepository()
+const item = args.issue ? loadIssueItem({ repository }) : null
+const workspaceReference =
+  args.workspace ?? item.fields.Workspace ?? item.dryRunPlan.workspace ?? undefined
+const descriptor = parseWorkspaceReference(workspaceReference, { repoRoot })
+const adapter = resolveAdapter(descriptor)
+const inspection = adapter ? await adapter.inspect() : null
+const result = {
+  issue: item?.issue ?? null,
+  repository,
+  workspace: {
+    descriptor,
+    reference: workspaceReference,
+  },
+  remote: inspection,
+}
+
+if (args.json) {
+  console.log(JSON.stringify(result, null, 2))
+} else {
+  printHumanSummary(result)
+}
+
+function loadIssueItem({ repository }) {
+  const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
+  return findProjectIssueItem(project.items, {
+    issueNumber: args.issue,
+    repository,
+  })
+}
+
+function resolveRepository() {
+  if (args.repo) return args.repo
+  if (!args.issue) return null
+  return currentRepositoryFromOrigin(repoRoot)
+}
+
+function resolveAdapter(descriptor) {
+  try {
+    return resolveRemoteWorkspaceAdapter(descriptor)
+  } catch (error) {
+    if (args.json) {
+      console.log(
+        JSON.stringify(
+          {
+            error: error instanceof Error ? error.message : String(error),
+            repository,
+            workspace: {
+              descriptor,
+              reference: workspaceReference,
+            },
+          },
+          null,
+          2,
+        ),
+      )
+      process.exit(1)
+    }
+
+    fail(error instanceof Error ? error.message : String(error))
+  }
+}
+
+function printHumanSummary({ issue, remote, repository, workspace }) {
+  console.log("agent-runner remote-inspect:")
+  if (issue) {
+    console.log(`issue: #${issue.number} ${issue.title}`)
+  }
+  console.log(`repository: ${repository ?? "not required"}`)
+  console.log(`workspace: ${workspace.reference}`)
+  console.log(`kind: ${workspace.descriptor.kind}`)
+  console.log(`provider: ${workspace.descriptor.provider ?? "none"}`)
+  console.log(`ready: ${remote?.ready ? "yes" : "no"}`)
+  console.log(`reason: ${remote?.reason ?? "none"}`)
+  if (remote?.availableProviders?.length > 0) {
+    console.log(`available providers: ${remote.availableProviders.join(", ")}`)
+  }
+}

--- a/scripts/lib/agent-runner-remote-workspace.mjs
+++ b/scripts/lib/agent-runner-remote-workspace.mjs
@@ -1,0 +1,144 @@
+import { isRemoteWorkspaceDescriptor } from "./agent-runner-workspace-contract.mjs"
+
+export const remoteWorkspaceCapabilityNames = [
+  "inspect",
+  "exec",
+  "spawn",
+  "exposeHttp",
+  "collectArtifacts",
+  "dispose",
+]
+
+export function resolveRemoteWorkspaceAdapter(descriptor, { adapters = {} } = {}) {
+  assertRemoteWorkspaceDescriptor(descriptor)
+
+  const factory = adapters[descriptor.provider]
+  if (!factory) {
+    return unsupportedRemoteWorkspaceAdapter(descriptor, {
+      availableProviders: Object.keys(adapters).sort(),
+    })
+  }
+
+  return validateRemoteWorkspaceAdapter(factory(descriptor), descriptor)
+}
+
+export function unsupportedRemoteWorkspaceAdapter(descriptor, { availableProviders = [] } = {}) {
+  assertRemoteWorkspaceDescriptor(descriptor)
+
+  const reason = `remote workspace provider ${descriptor.provider} is not configured`
+  const unsupported = (operation) => {
+    throw new Error(`${operation} is unavailable: ${reason}`)
+  }
+
+  return {
+    id: descriptor.id,
+    kind: descriptor.kind,
+    provider: descriptor.provider,
+    ready: false,
+    reason,
+    reference: descriptor.reference,
+    capabilities: {
+      inspect: true,
+      exec: false,
+      spawn: false,
+      exposeHttp: false,
+      collectArtifacts: false,
+      dispose: false,
+    },
+    async inspect() {
+      return {
+        availableProviders,
+        capabilities: this.capabilities,
+        id: this.id,
+        kind: this.kind,
+        provider: this.provider,
+        ready: false,
+        reason,
+        reference: this.reference,
+      }
+    },
+    async exec() {
+      unsupported("exec")
+    },
+    async spawn() {
+      unsupported("spawn")
+    },
+    async exposeHttp() {
+      unsupported("exposeHttp")
+    },
+    async collectArtifacts() {
+      unsupported("collectArtifacts")
+    },
+    async dispose() {
+      unsupported("dispose")
+    },
+  }
+}
+
+export function assertRemoteWorkspaceDescriptor(descriptor) {
+  if (descriptor?.kind === "invalid") {
+    throw new Error(`invalid remote workspace reference: ${descriptor.reason}`)
+  }
+
+  if (!isRemoteWorkspaceDescriptor(descriptor)) {
+    throw new Error(
+      `remote workspace adapter requires a remote-sandbox reference; got ${
+        descriptor?.kind ?? "unknown"
+      }`,
+    )
+  }
+}
+
+export function validateRemoteWorkspaceAdapter(adapter, descriptor) {
+  if (!adapter || typeof adapter !== "object") {
+    throw new Error(`remote workspace adapter ${descriptor.provider} did not return an object`)
+  }
+
+  for (const operation of remoteWorkspaceCapabilityNames) {
+    if (operation === "inspect") {
+      assertFunction(adapter, operation, descriptor)
+      continue
+    }
+
+    if (adapter.capabilities?.[operation]) {
+      assertFunction(adapter, operation, descriptor)
+    }
+  }
+
+  return {
+    id: adapter.id ?? descriptor.id,
+    kind: adapter.kind ?? descriptor.kind,
+    provider: adapter.provider ?? descriptor.provider,
+    ready: Boolean(adapter.ready),
+    reason: adapter.reason ?? null,
+    reference: adapter.reference ?? descriptor.reference,
+    capabilities: normalizeCapabilities(adapter.capabilities),
+    inspect: adapter.inspect.bind(adapter),
+    exec: bindOptional(adapter, "exec"),
+    spawn: bindOptional(adapter, "spawn"),
+    exposeHttp: bindOptional(adapter, "exposeHttp"),
+    collectArtifacts: bindOptional(adapter, "collectArtifacts"),
+    dispose: bindOptional(adapter, "dispose"),
+  }
+}
+
+function normalizeCapabilities(capabilities = {}) {
+  return Object.fromEntries(
+    remoteWorkspaceCapabilityNames.map((capability) => [
+      capability,
+      Boolean(capabilities[capability]),
+    ]),
+  )
+}
+
+function assertFunction(adapter, operation, descriptor) {
+  if (typeof adapter[operation] !== "function") {
+    throw new Error(
+      `remote workspace adapter ${descriptor.provider} declares ${operation} but does not implement it`,
+    )
+  }
+}
+
+function bindOptional(adapter, operation) {
+  return typeof adapter[operation] === "function" ? adapter[operation].bind(adapter) : undefined
+}

--- a/scripts/lib/agent-runner-tick.mjs
+++ b/scripts/lib/agent-runner-tick.mjs
@@ -55,7 +55,7 @@ export function recommendQueueAction(item, { maxAgeDays, repository }) {
     })
   }
 
-  const workspaceRecommendation = remoteWorkspaceRecommendation(item, { heartbeat })
+  const workspaceRecommendation = remoteWorkspaceRecommendation(item, { heartbeat, repository })
   if (workspaceRecommendation) {
     return workspaceRecommendation
   }
@@ -183,7 +183,7 @@ export function recommendQueueAction(item, { maxAgeDays, repository }) {
   })
 }
 
-function remoteWorkspaceRecommendation(item, { heartbeat }) {
+function remoteWorkspaceRecommendation(item, { heartbeat, repository }) {
   const workspace = item.fields.Workspace
   if (!workspace) return null
 
@@ -208,7 +208,12 @@ function remoteWorkspaceRecommendation(item, { heartbeat }) {
   if (state === "Done" || state === "Abandoned") {
     return recommendation(item, {
       action: "wait-remote-cleanup",
-      command: null,
+      command: commandWithIssue({
+        command: "remote-inspect",
+        issueNumber: item.issue.number,
+        mutate: false,
+        repository,
+      }),
       heartbeat,
       priority: 90,
       reason: `remote workspace ${descriptor.reference} needs remote adapter cleanup`,
@@ -223,7 +228,12 @@ function remoteWorkspaceRecommendation(item, { heartbeat }) {
   ) {
     return recommendation(item, {
       action: "wait-remote-adapter",
-      command: null,
+      command: commandWithIssue({
+        command: "remote-inspect",
+        issueNumber: item.issue.number,
+        mutate: false,
+        repository,
+      }),
       heartbeat,
       priority: 29,
       reason: `remote workspace ${descriptor.reference} requires a remote adapter`,
@@ -333,12 +343,12 @@ function isRemoteEvidence(evidence) {
   return /^https?:\/\//.test(evidence)
 }
 
-function commandWithIssue({ command, extraArgs = [], issueNumber, repository }) {
+function commandWithIssue({ command, extraArgs = [], issueNumber, mutate = true, repository }) {
   return [
     `pnpm agent:queue:${command} -- --issue ${issueNumber}`,
     repository ? `--repo ${repository}` : null,
     ...extraArgs,
-    "--yes",
+    mutate ? "--yes" : null,
   ]
     .filter(Boolean)
     .join(" ")

--- a/scripts/tests/agent-runner-remote-workspace.test.mjs
+++ b/scripts/tests/agent-runner-remote-workspace.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import {
+  resolveRemoteWorkspaceAdapter,
+  unsupportedRemoteWorkspaceAdapter,
+} from "../lib/agent-runner-remote-workspace.mjs"
+import { parseWorkspaceReference } from "../lib/agent-runner-workspace-contract.mjs"
+
+describe("agent runner remote workspace adapters", () => {
+  it("reports unsupported remote providers without enabling execution", async () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+    const unsupported = unsupportedRemoteWorkspaceAdapter(descriptor)
+
+    assert.deepEqual(await unsupported.inspect(), {
+      availableProviders: [],
+      capabilities: {
+        inspect: true,
+        exec: false,
+        spawn: false,
+        exposeHttp: false,
+        collectArtifacts: false,
+        dispose: false,
+      },
+      id: "task-579",
+      kind: "remote-sandbox",
+      provider: "sprite",
+      ready: false,
+      reason: "remote workspace provider sprite is not configured",
+      reference: "sandbox:sprite:task-579",
+    })
+    await assert.rejects(() => unsupported.exec(), /exec is unavailable/)
+  })
+
+  it("normalizes registered remote workspace adapters", async () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+    const registered = resolveRemoteWorkspaceAdapter(descriptor, {
+      adapters: {
+        sprite: (workspace) => ({
+          ...workspace,
+          capabilities: { inspect: true, exec: true },
+          ready: true,
+          async inspect() {
+            return { ready: true, reference: workspace.reference }
+          },
+          async exec(command) {
+            return { command, status: 0 }
+          },
+        }),
+      },
+    })
+
+    assert.equal(registered.ready, true)
+    assert.equal(registered.capabilities.exec, true)
+    assert.equal(registered.capabilities.spawn, false)
+    assert.deepEqual(await registered.exec(["pnpm", "test"]), {
+      command: ["pnpm", "test"],
+      status: 0,
+    })
+  })
+
+  it("rejects invalid and local workspace references", () => {
+    assert.throws(
+      () =>
+        resolveRemoteWorkspaceAdapter(
+          parseWorkspaceReference("sandbox:Sprite:task-579", { repoRoot: "/repo" }),
+        ),
+      /invalid remote workspace reference: remote sandbox reference is malformed/,
+    )
+
+    assert.throws(
+      () =>
+        resolveRemoteWorkspaceAdapter(
+          parseWorkspaceReference(".agent-worktrees/task-579", { repoRoot: "/repo" }),
+        ),
+      /remote workspace adapter requires a remote-sandbox reference; got local-worktree/,
+    )
+  })
+})

--- a/scripts/tests/agent-runner-tick.test.mjs
+++ b/scripts/tests/agent-runner-tick.test.mjs
@@ -236,7 +236,7 @@ describe("agent runner tick helpers", () => {
       ),
       {
         action: "wait-remote-adapter",
-        command: null,
+        command: "pnpm agent:queue:remote-inspect -- --issue 579 --repo voyantjs/other",
         heartbeat: {
           reason: "Last Heartbeat is 0 days old",
           stale: false,
@@ -289,7 +289,7 @@ describe("agent runner tick helpers", () => {
       ),
       {
         action: "wait-remote-cleanup",
-        command: null,
+        command: "pnpm agent:queue:remote-inspect -- --issue 579 --repo voyantjs/other",
         heartbeat: null,
         issue: workItem().issue,
         priority: 90,


### PR DESCRIPTION
## Summary
- add a provider-neutral remote workspace adapter contract with an unsupported-provider fallback
- add `agent:queue:remote-inspect` for read-only inspection of `sandbox:<provider>:<id>` workspace references
- update queue recommendations and docs so remote workspace items point at diagnostic inspection instead of local lifecycle commands

## Verification
- pnpm agent:queue:test
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- pnpm agent:queue:remote-inspect -- --help
- pnpm agent:queue:remote-inspect -- --workspace sandbox:sprite:task-579 --json
- git diff --check
- pre-push `pnpm test` hook passed with cached repository tests