### PR TITLE
feat(agent-runner): load remote workspace adapter config

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -136,6 +136,11 @@ Until the remote adapter is implemented, local-only commands such as
 reject `sandbox:` workspace references instead of resolving them as paths.
 Use `pnpm agent:queue:remote-inspect -- --issue <number>` to inspect a remote
 workspace reference and confirm whether its provider adapter is configured.
+Remote adapter config is intentionally explicit: pass
+`--adapter-config <path>`, set `VOYANT_AGENT_REMOTE_ADAPTER_CONFIG`, or commit a
+trusted `.agents/remote-workspaces.mjs` config on the runner branch. The module
+should export `remoteWorkspaceAdapters` or a default adapter map keyed by
+provider name.
 
 After start, run a supervised provider-neutral command in the claimed
 workspace:

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1173,7 +1173,11 @@ adapter contract and an unsupported-adapter fallback. Queue recommendations for
 `sandbox:<provider>:<id>` items now point maintainers at
 `pnpm agent:queue:remote-inspect -- --issue <number>` so remote references are
 typed and inspectable before a real sandbox adapter is allowed to execute,
-expose HTTP, collect artifacts, or clean up remote state.
+expose HTTP, collect artifacts, or clean up remote state. Remote adapters can
+now be loaded from an explicit config module via `--adapter-config`,
+`VOYANT_AGENT_REMOTE_ADAPTER_CONFIG`, or trusted
+`.agents/remote-workspaces.mjs`; the runner still treats providers as
+unavailable unless a config supplies that provider.
 
 Verification:
 

--- a/scripts/agent-runner-remote-inspect.mjs
+++ b/scripts/agent-runner-remote-inspect.mjs
@@ -8,7 +8,10 @@ import {
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import { maybePrintHelp, projectOptions, repositoryOptions } from "./lib/agent-runner-help.mjs"
-import { resolveRemoteWorkspaceAdapter } from "./lib/agent-runner-remote-workspace.mjs"
+import {
+  loadRemoteWorkspaceAdapters,
+  resolveRemoteWorkspaceAdapter,
+} from "./lib/agent-runner-remote-workspace.mjs"
 import { parseWorkspaceReference } from "./lib/agent-runner-workspace-contract.mjs"
 
 const args = parseArgs(process.argv.slice(2))
@@ -21,6 +24,10 @@ maybePrintHelp(args, {
     [
       "--workspace <reference>",
       "Workspace reference override, for example sandbox:sprite:task-579.",
+    ],
+    [
+      "--adapter-config <path>",
+      "Optional remote adapter config module. Defaults to .agents/remote-workspaces.mjs when present.",
     ],
     ["--json", "Print machine-readable JSON."],
     ...repositoryOptions,
@@ -38,7 +45,8 @@ const item = args.issue ? loadIssueItem({ repository }) : null
 const workspaceReference =
   args.workspace ?? item.fields.Workspace ?? item.dryRunPlan.workspace ?? undefined
 const descriptor = parseWorkspaceReference(workspaceReference, { repoRoot })
-const adapter = resolveAdapter(descriptor)
+const adapters = await loadAdapters({ descriptor, workspaceReference })
+const adapter = resolveAdapter(descriptor, { adapters })
 const inspection = adapter ? await adapter.inspect() : null
 const result = {
   issue: item?.issue ?? null,
@@ -70,30 +78,46 @@ function resolveRepository() {
   return currentRepositoryFromOrigin(repoRoot)
 }
 
-function resolveAdapter(descriptor) {
+async function loadAdapters({ descriptor, workspaceReference }) {
   try {
-    return resolveRemoteWorkspaceAdapter(descriptor)
+    return await loadRemoteWorkspaceAdapters({
+      configPath: args.adapterConfig,
+      repoRoot,
+    })
   } catch (error) {
-    if (args.json) {
-      console.log(
-        JSON.stringify(
-          {
-            error: error instanceof Error ? error.message : String(error),
-            repository,
-            workspace: {
-              descriptor,
-              reference: workspaceReference,
-            },
-          },
-          null,
-          2,
-        ),
-      )
-      process.exit(1)
-    }
-
-    fail(error instanceof Error ? error.message : String(error))
+    failInspection(error, { descriptor, workspaceReference })
   }
+}
+
+function resolveAdapter(descriptor, { adapters }) {
+  try {
+    return resolveRemoteWorkspaceAdapter(descriptor, { adapters })
+  } catch (error) {
+    failInspection(error, { descriptor, workspaceReference })
+  }
+}
+
+function failInspection(error, { descriptor, workspaceReference }) {
+  const message = error instanceof Error ? error.message : String(error)
+  if (args.json) {
+    console.log(
+      JSON.stringify(
+        {
+          error: message,
+          repository,
+          workspace: {
+            descriptor,
+            reference: workspaceReference,
+          },
+        },
+        null,
+        2,
+      ),
+    )
+    process.exit(1)
+  }
+
+  fail(message)
 }
 
 function printHumanSummary({ issue, remote, repository, workspace }) {

--- a/scripts/lib/agent-runner-remote-workspace.mjs
+++ b/scripts/lib/agent-runner-remote-workspace.mjs
@@ -1,3 +1,7 @@
+import { existsSync } from "node:fs"
+import path from "node:path"
+import { pathToFileURL } from "node:url"
+
 import { isRemoteWorkspaceDescriptor } from "./agent-runner-workspace-contract.mjs"
 
 export const remoteWorkspaceCapabilityNames = [
@@ -8,6 +12,8 @@ export const remoteWorkspaceCapabilityNames = [
   "collectArtifacts",
   "dispose",
 ]
+
+const providerNamePattern = /^[a-z][a-z0-9-]{0,31}$/
 
 export function resolveRemoteWorkspaceAdapter(descriptor, { adapters = {} } = {}) {
   assertRemoteWorkspaceDescriptor(descriptor)
@@ -20,6 +26,40 @@ export function resolveRemoteWorkspaceAdapter(descriptor, { adapters = {} } = {}
   }
 
   return validateRemoteWorkspaceAdapter(factory(descriptor), descriptor)
+}
+
+export async function loadRemoteWorkspaceAdapters({
+  configPath,
+  env = process.env,
+  repoRoot,
+} = {}) {
+  const adapterConfigPath = remoteWorkspaceAdapterConfigPath({ configPath, env, repoRoot })
+  if (!adapterConfigPath) return {}
+
+  const moduleExports = await import(pathToFileURL(adapterConfigPath).href)
+  const configuredAdapters = moduleExports.remoteWorkspaceAdapters ?? moduleExports.default
+  const adapters =
+    typeof configuredAdapters === "function"
+      ? await configuredAdapters({ env, repoRoot })
+      : configuredAdapters
+
+  return validateRemoteWorkspaceAdapters(adapters, adapterConfigPath)
+}
+
+export function remoteWorkspaceAdapterConfigPath({ configPath, env = process.env, repoRoot } = {}) {
+  const configuredPath = configPath ?? env.VOYANT_AGENT_REMOTE_ADAPTER_CONFIG
+  if (configuredPath) {
+    const resolvedPath = path.resolve(repoRoot ?? process.cwd(), configuredPath)
+    if (!existsSync(resolvedPath)) {
+      throw new Error(`remote workspace adapter config does not exist: ${resolvedPath}`)
+    }
+    return resolvedPath
+  }
+
+  if (!repoRoot) return null
+
+  const defaultPath = path.join(repoRoot, ".agents", "remote-workspaces.mjs")
+  return existsSync(defaultPath) ? defaultPath : null
 }
 
 export function unsupportedRemoteWorkspaceAdapter(descriptor, { availableProviders = [] } = {}) {
@@ -129,6 +169,26 @@ function normalizeCapabilities(capabilities = {}) {
       Boolean(capabilities[capability]),
     ]),
   )
+}
+
+function validateRemoteWorkspaceAdapters(adapters, adapterConfigPath) {
+  if (!adapters || typeof adapters !== "object" || Array.isArray(adapters)) {
+    throw new Error(
+      `remote workspace adapter config must export an adapter map: ${adapterConfigPath}`,
+    )
+  }
+
+  for (const [provider, factory] of Object.entries(adapters)) {
+    if (!providerNamePattern.test(provider)) {
+      throw new Error(`remote workspace adapter provider is invalid: ${provider}`)
+    }
+
+    if (typeof factory !== "function") {
+      throw new Error(`remote workspace adapter ${provider} must be a factory function`)
+    }
+  }
+
+  return adapters
 }
 
 function assertFunction(adapter, operation, descriptor) {

--- a/scripts/tests/agent-runner-remote-workspace.test.mjs
+++ b/scripts/tests/agent-runner-remote-workspace.test.mjs
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
 import { describe, it } from "node:test"
 
 import {
+  loadRemoteWorkspaceAdapters,
+  remoteWorkspaceAdapterConfigPath,
   resolveRemoteWorkspaceAdapter,
   unsupportedRemoteWorkspaceAdapter,
 } from "../lib/agent-runner-remote-workspace.mjs"
@@ -57,6 +62,82 @@ describe("agent runner remote workspace adapters", () => {
       command: ["pnpm", "test"],
       status: 0,
     })
+  })
+
+  it("loads remote workspace adapters from an explicit config module", async () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), "agent-remote-workspace-"))
+    const configPath = path.join(tempDir, "remote-workspaces.mjs")
+    writeFileSync(
+      configPath,
+      `
+export function remoteWorkspaceAdapters({ env, repoRoot }) {
+  return {
+    sprite: (workspace) => ({
+      ...workspace,
+      capabilities: { inspect: true, exec: true },
+      ready: Boolean(env.TEST_REMOTE_TOKEN),
+      async inspect() {
+        return { ready: this.ready, reference: this.reference, repoRoot }
+      },
+      async exec(command) {
+        return { command, status: 0 }
+      },
+    }),
+  }
+}
+`,
+    )
+
+    try {
+      const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+      const adapters = await loadRemoteWorkspaceAdapters({
+        configPath,
+        env: { TEST_REMOTE_TOKEN: "token" },
+        repoRoot: "/repo",
+      })
+      const adapter = resolveRemoteWorkspaceAdapter(descriptor, { adapters })
+
+      assert.equal(adapter.ready, true)
+      assert.equal(adapter.capabilities.exec, true)
+      assert.deepEqual(await adapter.inspect(), {
+        ready: true,
+        reference: "sandbox:sprite:task-579",
+        repoRoot: "/repo",
+      })
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true })
+    }
+  })
+
+  it("uses a default adapter config only when the repo config exists", () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), "agent-remote-workspace-"))
+
+    try {
+      assert.equal(remoteWorkspaceAdapterConfigPath({ repoRoot: tempDir }), null)
+
+      const configDir = path.join(tempDir, ".agents")
+      const configPath = path.join(configDir, "remote-workspaces.mjs")
+      mkdirSync(configDir)
+      writeFileSync(configPath, "export default {}\n")
+      assert.equal(remoteWorkspaceAdapterConfigPath({ repoRoot: tempDir }), configPath)
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true })
+    }
+  })
+
+  it("rejects malformed adapter config exports", async () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), "agent-remote-workspace-"))
+    const configPath = path.join(tempDir, "remote-workspaces.mjs")
+    writeFileSync(configPath, "export default { Sprite: {} }\n")
+
+    try {
+      await assert.rejects(
+        () => loadRemoteWorkspaceAdapters({ configPath, repoRoot: "/repo" }),
+        /remote workspace adapter provider is invalid: Sprite/,
+      )
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true })
+    }
   })
 
   it("rejects invalid and local workspace references", () => {


### PR DESCRIPTION
## Summary
- add explicit remote workspace adapter config loading for inspectable sandbox providers
- support --adapter-config, VOYANT_AGENT_REMOTE_ADAPTER_CONFIG, and trusted .agents/remote-workspaces.mjs
- document the adapter config contract and cover it in runner tests

## Verification
- pnpm agent:queue:test
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- git diff --check
- pnpm agent:queue:remote-inspect -- --workspace sandbox:sprite:task-579 --json
- pnpm agent:queue:remote-inspect -- --workspace sandbox:sprite:task-579 --adapter-config /tmp/does-not-exist.mjs --json