### PR TITLE
feat(agent-runner): add remote workspace CLI adapter

### DIFF
--- a/.agents/remote-workspaces.example.mjs
+++ b/.agents/remote-workspaces.example.mjs
@@ -1,0 +1,5 @@
+import { spriteCliRemoteWorkspaceAdapter } from "../scripts/lib/agent-runner-sprite-workspace.mjs"
+
+export const remoteWorkspaceAdapters = {
+  sprite: (workspace) => spriteCliRemoteWorkspaceAdapter(workspace),
+}

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -140,7 +140,18 @@ Remote adapter config is intentionally explicit: pass
 `--adapter-config <path>`, set `VOYANT_AGENT_REMOTE_ADAPTER_CONFIG`, or commit a
 trusted `.agents/remote-workspaces.mjs` config on the runner branch. The module
 should export `remoteWorkspaceAdapters` or a default adapter map keyed by
-provider name.
+provider name. Use `.agents/remote-workspaces.example.mjs` as the local template
+for enabling the CLI-backed Sprite adapter.
+
+When a remote adapter declares command execution, maintainers can run a guarded
+one-shot command without updating Project state:
+
+```bash
+pnpm agent:queue:remote-exec -- --workspace sandbox:sprite:<id> --command "pwd" --yes
+```
+
+This is an adapter validation tool, not the full implementation runner. It does
+not write evidence, open PRs, collect browser artifacts, or perform cleanup.
 
 After start, run a supervised provider-neutral command in the claimed
 workspace:

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1177,7 +1177,12 @@ expose HTTP, collect artifacts, or clean up remote state. Remote adapters can
 now be loaded from an explicit config module via `--adapter-config`,
 `VOYANT_AGENT_REMOTE_ADAPTER_CONFIG`, or trusted
 `.agents/remote-workspaces.mjs`; the runner still treats providers as
-unavailable unless a config supplies that provider.
+unavailable unless a config supplies that provider. A conservative CLI-backed
+Sprite adapter is available for one-shot command execution once a maintainer
+enables it through adapter config. `agent:queue:remote-exec` can validate that
+path with a guarded command, but remote execution does not yet own long-running
+process management, HTTP exposure, artifact collection, cleanup, evidence
+writing, PR creation, or repository bootstrap.
 
 Verification:
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "agent:queue:dispatch": "node scripts/agent-runner-dispatch.mjs",
     "agent:queue:loop": "node scripts/agent-runner-loop.mjs",
     "agent:queue:remote-inspect": "node scripts/agent-runner-remote-inspect.mjs",
+    "agent:queue:remote-exec": "node scripts/agent-runner-remote-exec.mjs",
     "agent:queue:prepare": "node scripts/agent-runner-prepare.mjs",
     "agent:queue:start": "node scripts/agent-runner-start.mjs",
     "agent:queue:run-command": "node scripts/agent-runner-run-command.mjs",

--- a/scripts/agent-runner-remote-exec.mjs
+++ b/scripts/agent-runner-remote-exec.mjs
@@ -1,0 +1,163 @@
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  findProjectIssueItem,
+  loadAllEvaluatedProject,
+  parseArgs,
+  projectScanConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+import {
+  maybePrintHelp,
+  mutationOptions,
+  projectOptions,
+  repositoryOptions,
+} from "./lib/agent-runner-help.mjs"
+import {
+  loadRemoteWorkspaceAdapters,
+  resolveRemoteWorkspaceAdapter,
+} from "./lib/agent-runner-remote-workspace.mjs"
+import { parseWorkspaceReference } from "./lib/agent-runner-workspace-contract.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:remote-exec",
+  summary: "Run a guarded one-shot command through a configured remote workspace adapter.",
+  usage:
+    "pnpm agent:queue:remote-exec -- (--issue <number> | --workspace <reference>) --command <shell> --yes",
+  options: [
+    ["--issue <number>", "Issue number whose Project Workspace field should be used."],
+    [
+      "--workspace <reference>",
+      "Workspace reference override, for example sandbox:sprite:task-579.",
+    ],
+    ["--command <shell>", "Shell command to execute remotely."],
+    ["--cwd <path>", "Remote working directory for the command."],
+    [
+      "--adapter-config <path>",
+      "Optional remote adapter config module. Defaults to .agents/remote-workspaces.mjs when present.",
+    ],
+    ["--json", "Print machine-readable JSON."],
+    ...mutationOptions,
+    ...repositoryOptions,
+    ...projectOptions,
+  ],
+})
+
+if (!args.issue && !args.workspace) {
+  fail("remote-exec mode requires --issue <number> or --workspace <reference>")
+}
+
+if (!args.command) {
+  fail("remote-exec mode requires --command <shell>")
+}
+
+if (!args.yes) {
+  fail("remote-exec requires --yes because it runs a remote command")
+}
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = resolveRepository()
+const item = args.issue ? loadIssueItem({ repository }) : null
+const workspaceReference =
+  args.workspace ?? item.fields.Workspace ?? item.dryRunPlan.workspace ?? undefined
+const descriptor = parseWorkspaceReference(workspaceReference, { repoRoot })
+const adapters = await loadAdapters({ descriptor, workspaceReference })
+const adapter = resolveAdapter(descriptor, { adapters })
+
+if (!adapter.capabilities.exec) {
+  failInspection(
+    new Error(`remote workspace provider ${descriptor.provider} cannot exec commands`),
+    {
+      descriptor,
+      workspaceReference,
+    },
+  )
+}
+
+const result = await adapter.exec(remoteCommand())
+if (args.json) {
+  console.log(
+    JSON.stringify(
+      {
+        issue: item?.issue ?? null,
+        repository,
+        result,
+        workspaceReference,
+      },
+      null,
+      2,
+    ),
+  )
+} else {
+  if (result.stdout) console.log(result.stdout)
+  if (result.stderr) console.error(result.stderr)
+  console.error(`remote-exec exited with status ${result.status}`)
+}
+
+process.exitCode = result.status ?? 1
+
+function loadIssueItem({ repository }) {
+  const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
+  return findProjectIssueItem(project.items, {
+    issueNumber: args.issue,
+    repository,
+  })
+}
+
+function resolveRepository() {
+  if (args.repo) return args.repo
+  if (!args.issue) return null
+  return currentRepositoryFromOrigin(repoRoot)
+}
+
+async function loadAdapters({ descriptor, workspaceReference }) {
+  try {
+    return await loadRemoteWorkspaceAdapters({
+      configPath: args.adapterConfig,
+      repoRoot,
+    })
+  } catch (error) {
+    failInspection(error, { descriptor, workspaceReference })
+  }
+}
+
+function resolveAdapter(descriptor, { adapters }) {
+  try {
+    return resolveRemoteWorkspaceAdapter(descriptor, { adapters })
+  } catch (error) {
+    failInspection(error, { descriptor, workspaceReference })
+  }
+}
+
+function remoteCommand() {
+  return {
+    args: ["-lc", args.command],
+    command: "bash",
+    cwd: args.cwd,
+    httpPost: true,
+  }
+}
+
+function failInspection(error, { descriptor, workspaceReference }) {
+  const message = error instanceof Error ? error.message : String(error)
+  if (args.json) {
+    console.log(
+      JSON.stringify(
+        {
+          error: message,
+          repository,
+          workspace: {
+            descriptor,
+            reference: workspaceReference,
+          },
+        },
+        null,
+        2,
+      ),
+    )
+    process.exit(1)
+  }
+
+  fail(message)
+}

--- a/scripts/lib/agent-runner-sprite-workspace.mjs
+++ b/scripts/lib/agent-runner-sprite-workspace.mjs
@@ -1,0 +1,133 @@
+import { spawnSync } from "node:child_process"
+
+export function spriteCliRemoteWorkspaceAdapter(descriptor, options = {}) {
+  const env = options.env ?? process.env
+  const cli = options.cli ?? env.SPRITE_CLI ?? "sprite"
+  const runProcess = options.runProcess ?? spawnSync
+
+  return {
+    id: descriptor.id,
+    kind: descriptor.kind,
+    provider: descriptor.provider,
+    ready: false,
+    reason: "inspect has not run",
+    reference: descriptor.reference,
+    capabilities: {
+      inspect: true,
+      exec: true,
+      spawn: false,
+      exposeHttp: false,
+      collectArtifacts: false,
+      dispose: false,
+    },
+    async inspect() {
+      const cliCheck = runSpriteCommand({
+        cli,
+        env,
+        runProcess,
+        spriteArgs: ["--help"],
+      })
+      const ready = cliCheck.status === 0
+
+      return {
+        capabilities: this.capabilities,
+        cli,
+        id: this.id,
+        kind: this.kind,
+        provider: this.provider,
+        ready,
+        reason: ready ? null : cliCheck.stderr || cliCheck.error || "sprite CLI is unavailable",
+        reference: this.reference,
+      }
+    },
+    async exec(command) {
+      const commandPlan = spriteExecPlan(descriptor, command, { env })
+      const result = runSpriteCommand({
+        cli,
+        env: commandPlan.env,
+        runProcess,
+        spriteArgs: commandPlan.args,
+      })
+
+      return {
+        command: commandPlan.displayCommand,
+        signal: result.signal,
+        status: result.status,
+        stderr: result.stderr,
+        stdout: result.stdout,
+      }
+    },
+  }
+}
+
+export function spriteExecPlan(descriptor, command, { env = process.env } = {}) {
+  const normalizedCommand = normalizeWorkspaceCommand(command)
+  const args = ["exec", "--sprite", descriptor.id]
+  const org = normalizedCommand.org ?? env.SPRITE_ORG
+  if (org) args.push("--org", org)
+  if (normalizedCommand.cwd) args.push("--dir", normalizedCommand.cwd)
+  if (normalizedCommand.env && Object.keys(normalizedCommand.env).length > 0) {
+    args.push("--env", environmentFlag(normalizedCommand.env))
+  }
+  if (normalizedCommand.httpPost) args.push("--http-post")
+  args.push(...normalizedCommand.command)
+
+  return {
+    args,
+    displayCommand: normalizedCommand.command.join(" "),
+    env: { ...env, ...normalizedCommand.env },
+  }
+}
+
+function normalizeWorkspaceCommand(command) {
+  if (typeof command === "string") {
+    return { command: ["bash", "-lc", command], httpPost: true }
+  }
+
+  if (Array.isArray(command)) {
+    return { command, httpPost: true }
+  }
+
+  if (!command || typeof command !== "object") {
+    throw new Error("remote workspace exec requires a command string, array, or object")
+  }
+
+  const binary = command.command ?? command.cmd
+  if (typeof binary !== "string" || binary.trim().length === 0) {
+    throw new Error("remote workspace exec command object requires command")
+  }
+
+  const commandArgs = command.args ?? []
+  if (!Array.isArray(commandArgs) || !commandArgs.every((arg) => typeof arg === "string")) {
+    throw new Error("remote workspace exec command args must be an array of strings")
+  }
+
+  return {
+    command: [binary, ...commandArgs],
+    cwd: command.cwd,
+    env: command.env,
+    httpPost: command.httpPost ?? true,
+    org: command.org,
+  }
+}
+
+function environmentFlag(environment) {
+  return Object.entries(environment)
+    .map(([key, value]) => `${key}=${String(value)}`)
+    .join(",")
+}
+
+function runSpriteCommand({ cli, env, runProcess, spriteArgs }) {
+  const result = runProcess(cli, spriteArgs, {
+    encoding: "utf8",
+    env,
+  })
+
+  return {
+    error: result.error?.message,
+    signal: result.signal ?? null,
+    status: result.status ?? (result.signal || result.error ? 1 : 0),
+    stderr: result.stderr?.trim() ?? "",
+    stdout: result.stdout?.trim() ?? "",
+  }
+}

--- a/scripts/tests/agent-runner-sprite-workspace.test.mjs
+++ b/scripts/tests/agent-runner-sprite-workspace.test.mjs
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import {
+  spriteCliRemoteWorkspaceAdapter,
+  spriteExecPlan,
+} from "../lib/agent-runner-sprite-workspace.mjs"
+import { parseWorkspaceReference } from "../lib/agent-runner-workspace-contract.mjs"
+
+describe("agent runner sprite workspace adapter", () => {
+  it("plans non-interactive CLI exec commands", () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+
+    assert.deepEqual(
+      spriteExecPlan(
+        descriptor,
+        {
+          args: ["verify:fast"],
+          command: "pnpm",
+          cwd: "/workspace/voyant",
+          env: { CI: "1" },
+        },
+        { env: { SPRITE_ORG: "voyant" } },
+      ),
+      {
+        args: [
+          "exec",
+          "--sprite",
+          "task-579",
+          "--org",
+          "voyant",
+          "--dir",
+          "/workspace/voyant",
+          "--env",
+          "CI=1",
+          "--http-post",
+          "pnpm",
+          "verify:fast",
+        ],
+        displayCommand: "pnpm verify:fast",
+        env: { CI: "1", SPRITE_ORG: "voyant" },
+      },
+    )
+  })
+
+  it("wraps shell command strings for remote execution", () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+
+    assert.deepEqual(spriteExecPlan(descriptor, "pnpm test", { env: {} }), {
+      args: ["exec", "--sprite", "task-579", "--http-post", "bash", "-lc", "pnpm test"],
+      displayCommand: "bash -lc pnpm test",
+      env: {},
+    })
+  })
+
+  it("executes through an injected CLI process", async () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+    const calls = []
+    const adapter = spriteCliRemoteWorkspaceAdapter(descriptor, {
+      cli: "sprite",
+      env: { SPRITE_ORG: "voyant" },
+      runProcess(command, args, options) {
+        calls.push({ args, command, env: options.env })
+        return { status: 0, stderr: "", stdout: "ok" }
+      },
+    })
+
+    assert.deepEqual(await adapter.exec({ args: ["test"], command: "pnpm" }), {
+      command: "pnpm test",
+      signal: null,
+      status: 0,
+      stderr: "",
+      stdout: "ok",
+    })
+    assert.deepEqual(calls, [
+      {
+        args: ["exec", "--sprite", "task-579", "--org", "voyant", "--http-post", "pnpm", "test"],
+        command: "sprite",
+        env: { SPRITE_ORG: "voyant" },
+      },
+    ])
+  })
+
+  it("treats signaled CLI execution as failed", async () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+    const adapter = spriteCliRemoteWorkspaceAdapter(descriptor, {
+      runProcess() {
+        return { signal: "SIGTERM", status: null, stderr: "terminated", stdout: "" }
+      },
+    })
+
+    assert.deepEqual(await adapter.exec("pnpm test"), {
+      command: "bash -lc pnpm test",
+      signal: "SIGTERM",
+      status: 1,
+      stderr: "terminated",
+      stdout: "",
+    })
+  })
+
+  it("reports unavailable CLI during inspect", async () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+    const adapter = spriteCliRemoteWorkspaceAdapter(descriptor, {
+      runProcess() {
+        return { error: new Error("not found"), status: null, stderr: "", stdout: "" }
+      },
+    })
+
+    assert.deepEqual(await adapter.inspect(), {
+      capabilities: {
+        inspect: true,
+        exec: true,
+        spawn: false,
+        exposeHttp: false,
+        collectArtifacts: false,
+        dispose: false,
+      },
+      cli: "sprite",
+      id: "task-579",
+      kind: "remote-sandbox",
+      provider: "sprite",
+      ready: false,
+      reason: "not found",
+      reference: "sandbox:sprite:task-579",
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add an opt-in CLI-backed remote workspace adapter for one-shot command execution
- add a guarded remote-exec validation command for configured remote workspaces
- add an example adapter config plus tests and docs for the Phase 5 path

## Verification
- pnpm agent:queue:test
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- git diff --check
- pnpm agent:queue:remote-exec -- --help
- pnpm agent:queue:remote-exec -- --workspace sandbox:unknown:task-579 --command pwd --yes --json
- pnpm agent:queue:remote-inspect -- --workspace sandbox:sprite:task-579 --adapter-config .agents/remote-workspaces.example.mjs --json