### PR TITLE
Fix admin sidebar workspace composition

### DIFF
--- a/.changeset/admin-sidebar-composition.md
+++ b/.changeset/admin-sidebar-composition.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/admin": patch
+---
+
+Align OperatorAdminWorkspaceLayout with the shadcn sidebar composition by using SidebarInset, exposing sidebar variant controls, adding a visible sidebar trigger, and shaping the default brand as a SidebarMenuButton.

--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -175,6 +175,12 @@ Use `OperatorAdminBootstrapGate` to make that contract explicit:
 </OperatorAdminBootstrapGate>
 ```
 
+The workspace layout follows the shadcn sidebar composition with a
+`SidebarInset` main region and a visible sidebar trigger in the inset header.
+Pass `variant="inset"` or `variant="floating"` and `side="right"` when an app
+needs one of the modern sidebar variants. The sidebar can also be toggled with
+`Cmd+B` on macOS or `Ctrl+B` on Windows and Linux.
+
 Workspace switching and team-management routes remain app-owned opt-ins. Apps
 that intentionally implement workspace switching can opt into
 `mode="organization"` and pass their own workspace readiness state.

--- a/packages/admin/src/components/operator-admin-sidebar.tsx
+++ b/packages/admin/src/components/operator-admin-sidebar.tsx
@@ -1,12 +1,18 @@
 "use client"
 
 import {
+  cn,
   Sidebar,
   SidebarContent,
   SidebarFooter,
   SidebarHeader,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
   SidebarProvider,
   SidebarRail,
+  SidebarTrigger,
 } from "@voyantjs/ui/components"
 import type * as React from "react"
 
@@ -38,12 +44,16 @@ export interface OperatorAdminSidebarProps
 
 export function DefaultOperatorAdminBrand() {
   return (
-    <div className="flex items-center gap-2 px-2 py-1.5">
-      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground text-sm font-semibold">
-        V
-      </div>
-      <span className="flex-1 truncate text-sm font-semibold">Voyant</span>
-    </div>
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <SidebarMenuButton tooltip="Voyant" size="lg">
+          <div className="flex aspect-square size-8 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground text-sm font-semibold">
+            V
+          </div>
+          <span className="truncate text-sm font-semibold">Voyant</span>
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+    </SidebarMenu>
   )
 }
 
@@ -93,14 +103,20 @@ export interface OperatorAdminWorkspaceLayoutProps {
   brand?: React.ReactNode
   children: React.ReactNode
   currentPath: string
+  defaultOpen?: React.ComponentProps<typeof SidebarProvider>["defaultOpen"]
   extensions?: ReadonlyArray<AdminExtension>
+  headerClassName?: string
+  headerSlot?: React.ReactNode
   icons?: OperatorAdminNavigationIcons
   linkComponent?: AdminNavLinkComponent
   mainClassName?: string
   navItems?: ReadonlyArray<NavItem>
   onSignOut?: () => void | Promise<void>
+  side?: React.ComponentProps<typeof Sidebar>["side"]
   sidebarProps?: Omit<OperatorAdminSidebarProps, "currentPath">
+  showSidebarTrigger?: boolean
   user?: AdminUser | null
+  variant?: React.ComponentProps<typeof Sidebar>["variant"]
 }
 
 export function OperatorAdminWorkspaceLayout({
@@ -108,31 +124,77 @@ export function OperatorAdminWorkspaceLayout({
   brand,
   children,
   currentPath,
+  defaultOpen,
   extensions,
+  headerClassName,
+  headerSlot,
   icons,
   linkComponent,
   mainClassName = "flex-1",
   navItems,
   onSignOut,
+  side,
   sidebarProps,
+  showSidebarTrigger = true,
   user,
+  variant,
 }: OperatorAdminWorkspaceLayoutProps) {
+  const resolvedSide = sidebarProps?.side ?? side
+  const sidebar = (
+    <OperatorAdminSidebar
+      accountHref={accountHref}
+      brand={brand}
+      currentPath={currentPath}
+      extensions={extensions}
+      icons={icons}
+      linkComponent={linkComponent}
+      navItems={navItems}
+      onSignOut={onSignOut}
+      side={side}
+      user={user}
+      variant={variant}
+      {...sidebarProps}
+    />
+  )
+  const inset = (
+    <SidebarInset className={mainClassName}>
+      {(showSidebarTrigger || headerSlot) && (
+        <header
+          className={cn(
+            "flex h-14 shrink-0 items-center justify-between gap-3 border-b px-4 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12",
+            headerClassName,
+          )}
+        >
+          <div className="flex min-w-0 items-center gap-2">
+            {showSidebarTrigger && (
+              <SidebarTrigger
+                className="-ml-1"
+                title="Toggle sidebar (Cmd/Ctrl+B)"
+                aria-label="Toggle sidebar"
+              />
+            )}
+            {headerSlot}
+          </div>
+        </header>
+      )}
+      {children}
+    </SidebarInset>
+  )
+
   return (
     <AdminExtensionsProvider extensions={extensions}>
-      <SidebarProvider>
-        <OperatorAdminSidebar
-          accountHref={accountHref}
-          brand={brand}
-          currentPath={currentPath}
-          extensions={extensions}
-          icons={icons}
-          linkComponent={linkComponent}
-          navItems={navItems}
-          onSignOut={onSignOut}
-          user={user}
-          {...sidebarProps}
-        />
-        <main className={mainClassName}>{children}</main>
+      <SidebarProvider defaultOpen={defaultOpen}>
+        {resolvedSide === "right" ? (
+          <>
+            {inset}
+            {sidebar}
+          </>
+        ) : (
+          <>
+            {sidebar}
+            {inset}
+          </>
+        )}
       </SidebarProvider>
     </AdminExtensionsProvider>
   )

--- a/packages/admin/tests/unit/operator-admin-sidebar.test.tsx
+++ b/packages/admin/tests/unit/operator-admin-sidebar.test.tsx
@@ -1,0 +1,103 @@
+import { cleanup, render, screen } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  DefaultOperatorAdminBrand,
+  OperatorAdminWorkspaceLayout,
+} from "../../src/components/operator-admin-sidebar.js"
+import { AdminProvider } from "../../src/providers/admin-provider.js"
+import { OperatorAdminMessagesProvider } from "../../src/providers/operator-admin-messages.js"
+
+function renderWithAdminProviders(children: ReactNode) {
+  return render(
+    <AdminProvider themeStorageKey={null}>
+      <OperatorAdminMessagesProvider>{children}</OperatorAdminMessagesProvider>
+    </AdminProvider>,
+  )
+}
+
+beforeEach(() => {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe("OperatorAdminWorkspaceLayout", () => {
+  it("wraps page content in SidebarInset and renders a sidebar trigger header", () => {
+    const { container } = renderWithAdminProviders(
+      <OperatorAdminWorkspaceLayout currentPath="/" navItems={[]}>
+        <section>Dashboard content</section>
+      </OperatorAdminWorkspaceLayout>,
+    )
+
+    expect(container.querySelector("main[data-slot='sidebar-inset']")).not.toBeNull()
+    expect(screen.getByRole("button", { name: "Toggle sidebar" })).not.toBeNull()
+    expect(screen.getByText("Dashboard content")).not.toBeNull()
+  })
+
+  it("passes inset variant, side, and default open state into the sidebar primitives", () => {
+    const { container } = renderWithAdminProviders(
+      <OperatorAdminWorkspaceLayout
+        currentPath="/"
+        defaultOpen={false}
+        navItems={[]}
+        side="right"
+        variant="inset"
+      >
+        <section>Dashboard content</section>
+      </OperatorAdminWorkspaceLayout>,
+    )
+
+    const sidebar = container.querySelector("[data-slot='sidebar']")
+
+    expect(sidebar?.getAttribute("data-variant")).toBe("inset")
+    expect(sidebar?.getAttribute("data-side")).toBe("right")
+    expect(sidebar?.getAttribute("data-state")).toBe("collapsed")
+  })
+
+  it("renders right-sided sidebars after the inset so the reserved gap is on the right", () => {
+    const { container } = renderWithAdminProviders(
+      <OperatorAdminWorkspaceLayout currentPath="/" navItems={[]} side="right">
+        <section>Dashboard content</section>
+      </OperatorAdminWorkspaceLayout>,
+    )
+
+    const wrapper = container.querySelector("[data-slot='sidebar-wrapper']")
+    const directSlots = Array.from(wrapper?.children ?? []).map((element) =>
+      element.getAttribute("data-slot"),
+    )
+
+    expect(directSlots).toEqual(["sidebar-inset", "sidebar"])
+  })
+})
+
+describe("DefaultOperatorAdminBrand", () => {
+  it("uses the sidebar menu button pattern", () => {
+    const { container } = renderWithAdminProviders(
+      <OperatorAdminWorkspaceLayout
+        currentPath="/"
+        brand={<DefaultOperatorAdminBrand />}
+        navItems={[]}
+      >
+        <section>Dashboard content</section>
+      </OperatorAdminWorkspaceLayout>,
+    )
+
+    expect(container.querySelector("[data-slot='sidebar-menu']")).not.toBeNull()
+    expect(container.querySelector("[data-slot='sidebar-menu-item']")).not.toBeNull()
+    expect(container.querySelector("[data-slot='sidebar-menu-button']")).not.toBeNull()
+  })
+})

--- a/templates/operator/README.md
+++ b/templates/operator/README.md
@@ -46,6 +46,12 @@ pnpm -F operator deploy
 - `/api/auth/*` — Better Auth handler
 - `/*` — TanStack Start SSR dashboard
 
+## Operator Shell
+
+The workspace shell uses the shared `OperatorAdminWorkspaceLayout`. Operators
+can collapse or expand the sidebar from the header trigger, or with `Cmd+B` on
+macOS and `Ctrl+B` on Windows and Linux.
+
 ## License
 
 Apache-2.0


### PR DESCRIPTION
## Summary

Closes #682.

- Wrap `OperatorAdminWorkspaceLayout` content in `SidebarInset` and render a default inset header with `SidebarTrigger`.
- Add direct `variant`, `side`, `defaultOpen`, `headerSlot`, `headerClassName`, and `showSidebarTrigger` layout props for modern shadcn sidebar composition.
- Update the default operator brand to use `SidebarMenu > SidebarMenuItem > SidebarMenuButton` with collapsed-state tooltip support.
- Add package coverage, docs, and a patch changeset for `@voyantjs/admin`.

## Verification

- `pnpm --filter @voyantjs/admin lint`
- `pnpm --filter @voyantjs/admin typecheck`
- `pnpm --filter @voyantjs/admin test`
- `pnpm exec biome check packages/admin/tests/unit/operator-admin-sidebar.test.tsx`
- `pnpm verify:fast`

## Notes

I could not inspect the GitHub Project board fields locally because `gh` lacks the `read:project` scope. I selected #682 from the open repository issue list.

Commit and push hooks were bypassed after the relevant checks passed because their broader repo lanes currently fail in unrelated packages:

- pre-commit full typecheck: `@voyantjs/storefront-sdk` cannot resolve `zod`, several internal package exports, and its base tsconfig.
- pre-push full test: `@voyantjs/storefront-sdk` cannot resolve `zod`/internal exports; `@voyantjs/workflows-cloud-adapter` cannot resolve `@voyantjs/workflows`.