### PR TITLE
feat(agent-runner): bootstrap remote workspaces

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -153,6 +153,19 @@ pnpm agent:queue:remote-exec -- --workspace sandbox:sprite:<id> --command "pwd" 
 This is an adapter validation tool, not the full implementation runner. It does
 not write evidence, open PRs, collect browser artifacts, or perform cleanup.
 
+Use `remote-bootstrap` to clone or update the repository inside the remote
+workspace before running real commands:
+
+```bash
+pnpm agent:queue:remote-bootstrap -- --workspace sandbox:sprite:<id> --repo voyantjs/voyant --branch feature/123-task --yes
+```
+
+For issue-scoped work, `--issue <number>` derives the branch from the execution
+plan. The command creates a deterministic remote repo directory by default,
+fails if that directory exists but is not a Git repository, fetches origin, and
+checks out the existing task branch or creates it from the selected base ref.
+It does not write evidence or update Project fields.
+
 After start, run a supervised provider-neutral command in the claimed
 workspace:
 

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1182,7 +1182,9 @@ Sprite adapter is available for one-shot command execution once a maintainer
 enables it through adapter config. `agent:queue:remote-exec` can validate that
 path with a guarded command, but remote execution does not yet own long-running
 process management, HTTP exposure, artifact collection, cleanup, evidence
-writing, PR creation, or repository bootstrap.
+writing, or PR creation. `agent:queue:remote-bootstrap` can now clone/fetch the
+repository and check out the task branch inside a remote workspace, but it is
+still a guarded validation step rather than the full implementation runner.
 
 Verification:
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "agent:queue:loop": "node scripts/agent-runner-loop.mjs",
     "agent:queue:remote-inspect": "node scripts/agent-runner-remote-inspect.mjs",
     "agent:queue:remote-exec": "node scripts/agent-runner-remote-exec.mjs",
+    "agent:queue:remote-bootstrap": "node scripts/agent-runner-remote-bootstrap.mjs",
     "agent:queue:prepare": "node scripts/agent-runner-prepare.mjs",
     "agent:queue:start": "node scripts/agent-runner-start.mjs",
     "agent:queue:run-command": "node scripts/agent-runner-run-command.mjs",

--- a/scripts/agent-runner-remote-bootstrap.mjs
+++ b/scripts/agent-runner-remote-bootstrap.mjs
@@ -1,0 +1,176 @@
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  findProjectIssueItem,
+  loadAllEvaluatedProject,
+  parseArgs,
+  projectScanConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+import {
+  maybePrintHelp,
+  mutationOptions,
+  projectOptions,
+  repositoryOptions,
+} from "./lib/agent-runner-help.mjs"
+import { remoteBootstrapPlan } from "./lib/agent-runner-remote-bootstrap.mjs"
+import {
+  loadRemoteWorkspaceAdapters,
+  resolveRemoteWorkspaceAdapter,
+} from "./lib/agent-runner-remote-workspace.mjs"
+import { parseWorkspaceReference } from "./lib/agent-runner-workspace-contract.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:remote-bootstrap",
+  summary: "Clone or update the repository inside a configured remote workspace.",
+  usage: "pnpm agent:queue:remote-bootstrap -- (--issue <number> | --workspace <reference>) --yes",
+  options: [
+    ["--issue <number>", "Issue number whose Project Workspace field should be bootstrapped."],
+    [
+      "--workspace <reference>",
+      "Workspace reference override, for example sandbox:sprite:task-579.",
+    ],
+    ["--branch <name>", "Remote branch name. Defaults to the issue execution plan branch."],
+    ["--base <ref>", "Remote base ref. Defaults to main."],
+    ["--base-ref <ref>", "Alias for --base."],
+    ["--remote-dir <path>", "Remote repository directory."],
+    ["--repo-url <url>", "Repository clone URL. Defaults to https://github.com/<repo>.git."],
+    [
+      "--adapter-config <path>",
+      "Optional remote adapter config module. Defaults to .agents/remote-workspaces.mjs when present.",
+    ],
+    ["--json", "Print machine-readable JSON."],
+    ...mutationOptions,
+    ...repositoryOptions,
+    ...projectOptions,
+  ],
+})
+
+if (!args.issue && !args.workspace) {
+  fail("remote-bootstrap mode requires --issue <number> or --workspace <reference>")
+}
+
+if (!args.yes) {
+  fail("remote-bootstrap requires --yes because it mutates a remote workspace")
+}
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = resolveRepository()
+const item = args.issue ? loadIssueItem({ repository }) : null
+const workspaceReference =
+  args.workspace ?? item.fields.Workspace ?? item.dryRunPlan.workspace ?? undefined
+const descriptor = parseWorkspaceReference(workspaceReference, { repoRoot })
+const plan = resolveBootstrapPlan({ descriptor, item })
+const adapters = await loadAdapters({ descriptor, workspaceReference })
+const adapter = resolveAdapter(descriptor, { adapters })
+
+if (!adapter.capabilities.exec) {
+  failInspection(
+    new Error(`remote workspace provider ${descriptor.provider} cannot exec commands`),
+    {
+      descriptor,
+      workspaceReference,
+    },
+  )
+}
+
+const result = await adapter.exec({
+  args: ["-lc", plan.command],
+  command: "bash",
+  httpPost: true,
+})
+
+if (args.json) {
+  console.log(
+    JSON.stringify(
+      {
+        issue: item?.issue ?? null,
+        plan,
+        repository,
+        result,
+        workspaceReference,
+      },
+      null,
+      2,
+    ),
+  )
+} else {
+  if (result.stdout) console.log(result.stdout)
+  if (result.stderr) console.error(result.stderr)
+  console.error(`remote-bootstrap exited with status ${result.status}`)
+}
+
+process.exitCode = result.status ?? 1
+
+function loadIssueItem({ repository }) {
+  const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
+  return findProjectIssueItem(project.items, {
+    issueNumber: args.issue,
+    repository,
+  })
+}
+
+function resolveRepository() {
+  if (args.repo) return args.repo
+  if (args.repoUrl && !args.issue) return null
+  return currentRepositoryFromOrigin(repoRoot)
+}
+
+function resolveBootstrapPlan({ descriptor, item }) {
+  try {
+    return remoteBootstrapPlan({
+      baseRef: args.base ?? args.baseRef ?? "main",
+      branch: args.branch,
+      descriptor,
+      item,
+      remoteDir: args.remoteDir,
+      repository,
+      repoUrl: args.repoUrl,
+    })
+  } catch (error) {
+    failInspection(error, { descriptor, workspaceReference })
+  }
+}
+
+async function loadAdapters({ descriptor, workspaceReference }) {
+  try {
+    return await loadRemoteWorkspaceAdapters({
+      configPath: args.adapterConfig,
+      repoRoot,
+    })
+  } catch (error) {
+    failInspection(error, { descriptor, workspaceReference })
+  }
+}
+
+function resolveAdapter(descriptor, { adapters }) {
+  try {
+    return resolveRemoteWorkspaceAdapter(descriptor, { adapters })
+  } catch (error) {
+    failInspection(error, { descriptor, workspaceReference })
+  }
+}
+
+function failInspection(error, { descriptor, workspaceReference }) {
+  const message = error instanceof Error ? error.message : String(error)
+  if (args.json) {
+    console.log(
+      JSON.stringify(
+        {
+          error: message,
+          repository,
+          workspace: {
+            descriptor,
+            reference: workspaceReference,
+          },
+        },
+        null,
+        2,
+      ),
+    )
+    process.exit(1)
+  }
+
+  fail(message)
+}

--- a/scripts/lib/agent-runner-remote-bootstrap.mjs
+++ b/scripts/lib/agent-runner-remote-bootstrap.mjs
@@ -1,0 +1,92 @@
+import { isRemoteWorkspaceDescriptor } from "./agent-runner-workspace-contract.mjs"
+
+export function remoteBootstrapPlan({
+  baseRef = "main",
+  branch,
+  descriptor,
+  item,
+  remoteDir,
+  repository,
+  repoUrl,
+} = {}) {
+  if (!isRemoteWorkspaceDescriptor(descriptor)) {
+    throw new Error(
+      `remote bootstrap requires a remote-sandbox reference; got ${descriptor?.kind ?? "unknown"}`,
+    )
+  }
+
+  const selectedBranch = branch ?? item?.dryRunPlan?.branch
+  if (!selectedBranch) {
+    throw new Error("remote bootstrap requires --branch when no issue plan is available")
+  }
+
+  const selectedRepoUrl = repoUrl ?? (repository ? `https://github.com/${repository}.git` : null)
+  if (!selectedRepoUrl) {
+    throw new Error("remote bootstrap requires --repo <owner/name> or --repo-url <url>")
+  }
+
+  const selectedRemoteDir = remoteDir ?? `/home/sprite/voyant-workspaces/${descriptor.id}/repo`
+  assertShellValue("remote directory", selectedRemoteDir)
+  assertShellValue("repository URL", selectedRepoUrl)
+  assertShellValue("branch", selectedBranch)
+  assertShellValue("base ref", baseRef)
+
+  return {
+    baseRef: normalizeRemoteBaseRef(baseRef),
+    branch: selectedBranch,
+    command: remoteBootstrapShell({
+      baseRef: normalizeRemoteBaseRef(baseRef),
+      branch: selectedBranch,
+      remoteDir: selectedRemoteDir,
+      repoUrl: selectedRepoUrl,
+    }),
+    remoteDir: selectedRemoteDir,
+    repository,
+    repoUrl: selectedRepoUrl,
+  }
+}
+
+export function remoteBootstrapShell({ baseRef, branch, remoteDir, repoUrl }) {
+  return `set -euo pipefail
+repo_dir=${shellQuote(remoteDir)}
+repo_url=${shellQuote(repoUrl)}
+branch=${shellQuote(branch)}
+base_ref=${shellQuote(baseRef)}
+
+mkdir -p "$(dirname "$repo_dir")"
+if [ -d "$repo_dir/.git" ]; then
+  cd "$repo_dir"
+  git remote set-url origin "$repo_url"
+elif [ -e "$repo_dir" ]; then
+  echo "remote directory exists but is not a git repository: $repo_dir" >&2
+  exit 1
+else
+  git clone "$repo_url" "$repo_dir"
+  cd "$repo_dir"
+fi
+
+git fetch origin --prune
+if git rev-parse --verify --quiet "refs/heads/$branch" >/dev/null; then
+  git checkout "$branch"
+elif git rev-parse --verify --quiet "refs/remotes/origin/$branch" >/dev/null; then
+  git checkout --track -b "$branch" "origin/$branch"
+else
+  git checkout -b "$branch" "origin/$base_ref"
+fi
+
+git status --short --branch`
+}
+
+export function normalizeRemoteBaseRef(baseRef) {
+  return String(baseRef).replace(/^origin\//, "")
+}
+
+function assertShellValue(name, value) {
+  if (typeof value !== "string" || value.trim().length === 0 || /[\0\r\n]/.test(value)) {
+    throw new Error(`invalid remote bootstrap ${name}: ${String(value)}`)
+  }
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`
+}

--- a/scripts/tests/agent-runner-remote-bootstrap.test.mjs
+++ b/scripts/tests/agent-runner-remote-bootstrap.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import {
+  normalizeRemoteBaseRef,
+  remoteBootstrapPlan,
+} from "../lib/agent-runner-remote-bootstrap.mjs"
+import { parseWorkspaceReference } from "../lib/agent-runner-workspace-contract.mjs"
+import { workItem } from "./agent-fixtures.mjs"
+
+describe("agent runner remote bootstrap helpers", () => {
+  it("builds a conservative remote repository bootstrap command", () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+    const plan = remoteBootstrapPlan({
+      baseRef: "origin/main",
+      descriptor,
+      item: workItem(),
+      repository: "voyantjs/voyant",
+    })
+
+    assert.equal(plan.baseRef, "main")
+    assert.equal(plan.branch, "task/579-test-agent-project-intake-workflow")
+    assert.equal(plan.remoteDir, "/home/sprite/voyant-workspaces/task-579/repo")
+    assert.equal(plan.repoUrl, "https://github.com/voyantjs/voyant.git")
+    assert.match(plan.command, /git clone "\$repo_url" "\$repo_dir"/)
+    assert.match(plan.command, /refs\/remotes\/origin\/\$branch/)
+    assert.match(plan.command, /git checkout --track -b "\$branch" "origin\/\$branch"/)
+    assert.match(plan.command, /git checkout -b "\$branch" "origin\/\$base_ref"/)
+    assert.match(plan.command, /remote directory exists but is not a git repository/)
+  })
+
+  it("uses explicit direct-workspace bootstrap values", () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+    const plan = remoteBootstrapPlan({
+      baseRef: "release/next",
+      branch: "feature/579-remote-workspace",
+      descriptor,
+      remoteDir: "/workspace/voyant",
+      repoUrl: "https://github.com/voyantjs/voyant.git",
+    })
+
+    assert.equal(plan.baseRef, "release/next")
+    assert.equal(plan.branch, "feature/579-remote-workspace")
+    assert.equal(plan.remoteDir, "/workspace/voyant")
+    assert.match(plan.command, /repo_dir='\/workspace\/voyant'/)
+  })
+
+  it("rejects local references and missing branch or repository context", () => {
+    assert.throws(
+      () =>
+        remoteBootstrapPlan({
+          branch: "feature/task",
+          descriptor: parseWorkspaceReference(".agent-worktrees/task", { repoRoot: "/repo" }),
+          repository: "voyantjs/voyant",
+        }),
+      /remote bootstrap requires a remote-sandbox reference/,
+    )
+
+    assert.throws(
+      () =>
+        remoteBootstrapPlan({
+          descriptor: parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" }),
+          repository: "voyantjs/voyant",
+        }),
+      /remote bootstrap requires --branch/,
+    )
+
+    assert.throws(
+      () =>
+        remoteBootstrapPlan({
+          branch: "feature/task",
+          descriptor: parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" }),
+        }),
+      /remote bootstrap requires --repo/,
+    )
+  })
+
+  it("normalizes remote base refs", () => {
+    assert.equal(normalizeRemoteBaseRef("origin/main"), "main")
+    assert.equal(normalizeRemoteBaseRef("release/next"), "release/next")
+  })
+})


### PR DESCRIPTION
## Summary
- add guarded remote-bootstrap command for remote sandbox workspaces
- build a conservative clone/fetch/checkout plan that does not reset existing remote branches
- document the remote bootstrap validation step and cover helper behavior in tests

## Verification
- pnpm agent:queue:test
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- git diff --check
- pnpm agent:queue:remote-bootstrap -- --help
- pnpm agent:queue:remote-bootstrap -- --workspace sandbox:unknown:task-579 --repo voyantjs/voyant --branch feature/579-remote-bootstrap --yes --json
- pre-push hook: pnpm typecheck
- pre-push hook: pnpm test