### PR TITLE
feat(agent-runner): dispatch remote bootstrap

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -164,7 +164,10 @@ For issue-scoped work, `--issue <number>` derives the branch from the execution
 plan. The command creates a deterministic remote repo directory by default,
 fails if that directory exists but is not a Git repository, fetches origin, and
 checks out the existing task branch or creates it from the selected base ref.
-It does not write evidence or update Project fields.
+After a successful issue-scoped bootstrap, it updates the Project item to
+`Agent State = Planning`, stores the remote `Workspace`, stores the planned
+branch, and refreshes `Last Heartbeat`. Direct `--workspace` validation without
+an issue remains non-Project-mutating.
 
 After start, run a supervised provider-neutral command in the claimed
 workspace:
@@ -241,11 +244,12 @@ open PRs. Pass `--json` when a process manager or future control plane needs
 machine-readable actions. `Merge Ready` items with linked PRs keep recommending
 `sync-pr` so the runner can observe maintainer merges and mark the item done.
 `CI Repair` items with failing linked PRs recommend `collect-ci` until a local
-CI repair packet exists. Items with `sandbox:<provider>:<id>` workspaces
-recommend wait states instead of local workspace commands until a remote adapter
-owns execution and cleanup; their recommendation includes a read-only
-`remote-inspect` command. Malformed reserved `sandbox:` values recommend
-`inspect-workspace`.
+CI repair packet exists. Ready items with `sandbox:<provider>:<id>` workspaces
+recommend `remote-bootstrap` so dispatch can clone/fetch the repository and
+move the item to `Planning`. Later remote workspace states still recommend wait
+states instead of local workspace commands until a remote adapter owns execution
+and cleanup; their recommendation includes a read-only `remote-inspect` command.
+Malformed reserved `sandbox:` values recommend `inspect-workspace`.
 
 Use dispatch to execute one allow-listed tick recommendation:
 
@@ -256,9 +260,10 @@ pnpm agent:queue:dispatch -- --yes
 Dispatch mode re-reads the Project, selects the highest-priority dispatchable
 recommendation, and runs one lifecycle command. It is dry-run by default. Pass
 `--issue <number>` or `--action <name>` to narrow selection. Dispatch can run
-`start`, `collect-ci`, `publish-evidence`, `open-pr`, `sync-pr`, and
-`cleanup`; it refuses `run-command`, `capture-browser`, `inspect-stale`, blocked
-work, and wait states so implementation and browser execution remain explicit.
+`start`, `remote-bootstrap`, `collect-ci`, `publish-evidence`, `open-pr`,
+`sync-pr`, and `cleanup`; it refuses `run-command`, `capture-browser`,
+`inspect-stale`, blocked work, and wait states so implementation and browser
+execution remain explicit.
 Successful dispatch attempts append local JSONL audit events to
 `.agent-runs/events.jsonl` by default; pass `--event-log <path>` when a
 supervisor needs a different local ledger path.

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1183,8 +1183,10 @@ enables it through adapter config. `agent:queue:remote-exec` can validate that
 path with a guarded command, but remote execution does not yet own long-running
 process management, HTTP exposure, artifact collection, cleanup, evidence
 writing, or PR creation. `agent:queue:remote-bootstrap` can now clone/fetch the
-repository and check out the task branch inside a remote workspace, but it is
-still a guarded validation step rather than the full implementation runner.
+repository, prefer an existing remote task branch, and check out the task branch
+inside a remote workspace. Ready remote-workspace items can be dispatched
+through that bootstrap path and move to `Planning` after success, but this is
+still repository preparation rather than the full implementation runner.
 
 Verification:
 

--- a/scripts/agent-runner-remote-bootstrap.mjs
+++ b/scripts/agent-runner-remote-bootstrap.mjs
@@ -1,3 +1,4 @@
+import { updateProjectItemFields } from "./lib/agent-project-fields.mjs"
 import {
   currentRepositoryFromOrigin,
   fail,
@@ -13,7 +14,10 @@ import {
   projectOptions,
   repositoryOptions,
 } from "./lib/agent-runner-help.mjs"
-import { remoteBootstrapPlan } from "./lib/agent-runner-remote-bootstrap.mjs"
+import {
+  remoteBootstrapFieldValues,
+  remoteBootstrapPlan,
+} from "./lib/agent-runner-remote-bootstrap.mjs"
 import {
   loadRemoteWorkspaceAdapters,
   resolveRemoteWorkspaceAdapter,
@@ -57,7 +61,8 @@ if (!args.yes) {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = resolveRepository()
-const item = args.issue ? loadIssueItem({ repository }) : null
+const issueContext = args.issue ? loadIssueItem({ repository }) : null
+const item = issueContext?.item ?? null
 const workspaceReference =
   args.workspace ?? item.fields.Workspace ?? item.dryRunPlan.workspace ?? undefined
 const descriptor = parseWorkspaceReference(workspaceReference, { repoRoot })
@@ -80,6 +85,7 @@ const result = await adapter.exec({
   command: "bash",
   httpPost: true,
 })
+const projectUpdated = maybeUpdateProject({ issueContext, plan, result, workspaceReference })
 
 if (args.json) {
   console.log(
@@ -87,6 +93,7 @@ if (args.json) {
       {
         issue: item?.issue ?? null,
         plan,
+        projectUpdated,
         repository,
         result,
         workspaceReference,
@@ -99,16 +106,22 @@ if (args.json) {
   if (result.stdout) console.log(result.stdout)
   if (result.stderr) console.error(result.stderr)
   console.error(`remote-bootstrap exited with status ${result.status}`)
+  if (projectUpdated) {
+    console.error("agent state: Planning")
+    console.error(`workspace: ${workspaceReference}`)
+    console.error(`branch: ${plan.branch}`)
+  }
 }
 
 process.exitCode = result.status ?? 1
 
 function loadIssueItem({ repository }) {
   const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
-  return findProjectIssueItem(project.items, {
+  const item = findProjectIssueItem(project.items, {
     issueNumber: args.issue,
     repository,
   })
+  return { item, project }
 }
 
 function resolveRepository() {
@@ -150,6 +163,21 @@ function resolveAdapter(descriptor, { adapters }) {
   } catch (error) {
     failInspection(error, { descriptor, workspaceReference })
   }
+}
+
+function maybeUpdateProject({ issueContext, plan, result, workspaceReference }) {
+  if (!issueContext || result.status !== 0) return false
+
+  updateProjectItemFields({
+    item: issueContext.item,
+    project: issueContext.project,
+    values: remoteBootstrapFieldValues({
+      branch: plan.branch,
+      workspaceReference,
+    }),
+  })
+
+  return true
 }
 
 function failInspection(error, { descriptor, workspaceReference }) {

--- a/scripts/lib/agent-runner-dispatch.mjs
+++ b/scripts/lib/agent-runner-dispatch.mjs
@@ -5,6 +5,7 @@ export const dispatchableActions = new Set([
   "cleanup",
   "open-pr",
   "publish-evidence",
+  "remote-bootstrap",
   "start",
   "sync-pr",
 ])

--- a/scripts/lib/agent-runner-remote-bootstrap.mjs
+++ b/scripts/lib/agent-runner-remote-bootstrap.mjs
@@ -46,6 +46,16 @@ export function remoteBootstrapPlan({
   }
 }
 
+export function remoteBootstrapFieldValues({ branch, workspaceReference }, date = new Date()) {
+  return {
+    Status: "In Progress",
+    "Agent State": "Planning",
+    Branch: branch,
+    Workspace: workspaceReference,
+    "Last Heartbeat": date.toISOString().slice(0, 10),
+  }
+}
+
 export function remoteBootstrapShell({ baseRef, branch, remoteDir, repoUrl }) {
   return `set -euo pipefail
 repo_dir=${shellQuote(remoteDir)}

--- a/scripts/lib/agent-runner-tick.mjs
+++ b/scripts/lib/agent-runner-tick.mjs
@@ -205,6 +205,20 @@ function remoteWorkspaceRecommendation(item, { heartbeat, repository }) {
   if (state === "Human Review" && item.fields.PR) return null
   if (state === "Merge Ready" && item.fields.PR) return null
 
+  if (item.ready) {
+    return recommendation(item, {
+      action: "remote-bootstrap",
+      command: commandWithIssue({
+        command: "remote-bootstrap",
+        issueNumber: item.issue.number,
+        repository,
+      }),
+      heartbeat,
+      priority: 20,
+      reason: `remote workspace ${descriptor.reference} is ready for repository bootstrap`,
+    })
+  }
+
   if (state === "Done" || state === "Abandoned") {
     return recommendation(item, {
       action: "wait-remote-cleanup",

--- a/scripts/tests/agent-runner-dispatch.test.mjs
+++ b/scripts/tests/agent-runner-dispatch.test.mjs
@@ -80,6 +80,32 @@ describe("agent runner dispatch helpers", () => {
     ])
   })
 
+  it("dispatches ready remote workspace bootstrap recommendations", () => {
+    const recommendation = recommendQueueAction(
+      workItem({
+        fields: {
+          "Agent State": "Ready",
+          Workspace: "sandbox:sprite:task-579",
+        },
+      }),
+      { maxAgeDays: 1, repository: "voyantjs/other" },
+    )
+
+    assert.equal(
+      selectDispatchRecommendation([recommendation]).recommendation.action,
+      "remote-bootstrap",
+    )
+    assert.deepEqual(dispatchCommandArgs(recommendation, { repository: "voyantjs/other" }), [
+      "agent:queue:remote-bootstrap",
+      "--",
+      "--issue",
+      "579",
+      "--repo",
+      "voyantjs/other",
+      "--yes",
+    ])
+  })
+
   it("passes custom event logs to nested dispatch commands", () => {
     const recommendation = recommendQueueAction(workItem(), {
       maxAgeDays: 1,

--- a/scripts/tests/agent-runner-remote-bootstrap.test.mjs
+++ b/scripts/tests/agent-runner-remote-bootstrap.test.mjs
@@ -3,6 +3,7 @@ import { describe, it } from "node:test"
 
 import {
   normalizeRemoteBaseRef,
+  remoteBootstrapFieldValues,
   remoteBootstrapPlan,
 } from "../lib/agent-runner-remote-bootstrap.mjs"
 import { parseWorkspaceReference } from "../lib/agent-runner-workspace-contract.mjs"
@@ -78,5 +79,24 @@ describe("agent runner remote bootstrap helpers", () => {
   it("normalizes remote base refs", () => {
     assert.equal(normalizeRemoteBaseRef("origin/main"), "main")
     assert.equal(normalizeRemoteBaseRef("release/next"), "release/next")
+  })
+
+  it("builds Project field updates after issue-scoped remote bootstrap", () => {
+    assert.deepEqual(
+      remoteBootstrapFieldValues(
+        {
+          branch: "task/579-test-agent-project-intake-workflow",
+          workspaceReference: "sandbox:sprite:task-579",
+        },
+        new Date("2026-05-11T12:00:00.000Z"),
+      ),
+      {
+        Status: "In Progress",
+        "Agent State": "Planning",
+        Branch: "task/579-test-agent-project-intake-workflow",
+        Workspace: "sandbox:sprite:task-579",
+        "Last Heartbeat": "2026-05-11",
+      },
+    )
   })
 })

--- a/scripts/tests/agent-runner-tick.test.mjs
+++ b/scripts/tests/agent-runner-tick.test.mjs
@@ -209,7 +209,7 @@ describe("agent runner tick helpers", () => {
     )
   })
 
-  it("pauses local queue actions for remote workspace references", () => {
+  it("bootstraps ready remote workspace references before pausing local actions", () => {
     assert.deepEqual(
       recommendQueueAction(
         workItem({
@@ -219,8 +219,16 @@ describe("agent runner tick helpers", () => {
           },
         }),
         { maxAgeDays: 1, repository: "voyantjs/other" },
-      ).action,
-      "wait-remote-adapter",
+      ),
+      {
+        action: "remote-bootstrap",
+        command: "pnpm agent:queue:remote-bootstrap -- --issue 579 --repo voyantjs/other --yes",
+        heartbeat: null,
+        issue: workItem().issue,
+        priority: 20,
+        reason: "remote workspace sandbox:sprite:task-579 is ready for repository bootstrap",
+        state: "Ready",
+      },
     )
 
     assert.deepEqual(


### PR DESCRIPTION
## Summary
- recommend remote-bootstrap for ready items assigned to remote workspace references
- allow dispatch to execute remote-bootstrap and advance successful issue-scoped bootstraps to Planning
- document the new remote bootstrap dispatch path and Project field updates

## Verification
- pnpm agent:queue:test
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- git diff --check
- pnpm agent:queue:remote-bootstrap -- --help
- pnpm agent:queue:remote-bootstrap -- --workspace sandbox:unknown:task-579 --repo voyantjs/voyant --branch feature/579-remote-bootstrap --yes --json
- pre-push hook: pnpm typecheck
- pre-push hook: pnpm test