### PR TITLE
feat(agent-runner): run supervised remote commands

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -169,7 +169,23 @@ After a successful issue-scoped bootstrap, it updates the Project item to
 branch, and refreshes `Last Heartbeat`. Direct `--workspace` validation without
 an issue remains non-Project-mutating.
 
-After start, run a supervised provider-neutral command in the claimed
+After remote bootstrap, run a supervised provider-neutral command in the remote
+repository directory:
+
+```bash
+pnpm agent:queue:remote-run-command -- --issue <number> --command "pnpm verify:fast" --yes
+```
+
+Remote-run-command mode requires a `sandbox:<provider>:<id>` workspace in
+`Planning`, `Running`, `Changes Requested`, or `CI Repair` unless `--force` is
+passed. It moves the item to `Running`, streams stdout/stderr through the
+adapter, writes a remote transcript under `.agent-runs/`, writes an evidence
+packet under `docs/agent-evidence/active/`, then moves the item to
+`Human Review` on exit code `0` or `Blocked` on nonzero exit. It does not push
+branches, expose HTTP, capture browser artifacts, publish evidence, open PRs,
+or clean up the remote workspace.
+
+After local start, run a supervised provider-neutral command in the claimed
 workspace:
 
 ```bash
@@ -246,10 +262,12 @@ machine-readable actions. `Merge Ready` items with linked PRs keep recommending
 `CI Repair` items with failing linked PRs recommend `collect-ci` until a local
 CI repair packet exists. Ready items with `sandbox:<provider>:<id>` workspaces
 recommend `remote-bootstrap` so dispatch can clone/fetch the repository and
-move the item to `Planning`. Later remote workspace states still recommend wait
-states instead of local workspace commands until a remote adapter owns execution
-and cleanup; their recommendation includes a read-only `remote-inspect` command.
-Malformed reserved `sandbox:` values recommend `inspect-workspace`.
+move the item to `Planning`. Remote workspace items in `Planning`,
+`Changes Requested`, or `CI Repair` recommend `remote-run-command`, but dispatch
+does not execute implementation commands automatically. Later remote workspace
+states still recommend wait states until a remote adapter owns browser evidence,
+PR creation, and cleanup. Malformed reserved `sandbox:` values recommend
+`inspect-workspace`.
 
 Use dispatch to execute one allow-listed tick recommendation:
 
@@ -261,9 +279,9 @@ Dispatch mode re-reads the Project, selects the highest-priority dispatchable
 recommendation, and runs one lifecycle command. It is dry-run by default. Pass
 `--issue <number>` or `--action <name>` to narrow selection. Dispatch can run
 `start`, `remote-bootstrap`, `collect-ci`, `publish-evidence`, `open-pr`,
-`sync-pr`, and `cleanup`; it refuses `run-command`, `capture-browser`,
-`inspect-stale`, blocked work, and wait states so implementation and browser
-execution remain explicit.
+`sync-pr`, and `cleanup`; it refuses `run-command`, `remote-run-command`,
+`capture-browser`, `inspect-stale`, blocked work, and wait states so
+implementation and browser execution remain explicit.
 Successful dispatch attempts append local JSONL audit events to
 `.agent-runs/events.jsonl` by default; pass `--event-log <path>` when a
 supervisor needs a different local ledger path.

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1185,8 +1185,11 @@ process management, HTTP exposure, artifact collection, cleanup, evidence
 writing, or PR creation. `agent:queue:remote-bootstrap` can now clone/fetch the
 repository, prefer an existing remote task branch, and check out the task branch
 inside a remote workspace. Ready remote-workspace items can be dispatched
-through that bootstrap path and move to `Planning` after success, but this is
-still repository preparation rather than the full implementation runner.
+through that bootstrap path and move to `Planning` after success.
+`agent:queue:remote-run-command` can run an explicit supervised command in that
+remote repository, write a remote transcript and evidence packet, and move the
+Project item to `Human Review` or `Blocked`. Browser evidence, HTTP exposure,
+remote artifact publishing, cleanup, and PR creation remain future slices.
 
 Verification:
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "agent:queue:remote-inspect": "node scripts/agent-runner-remote-inspect.mjs",
     "agent:queue:remote-exec": "node scripts/agent-runner-remote-exec.mjs",
     "agent:queue:remote-bootstrap": "node scripts/agent-runner-remote-bootstrap.mjs",
+    "agent:queue:remote-run-command": "node scripts/agent-runner-remote-run-command.mjs",
     "agent:queue:prepare": "node scripts/agent-runner-prepare.mjs",
     "agent:queue:start": "node scripts/agent-runner-start.mjs",
     "agent:queue:run-command": "node scripts/agent-runner-run-command.mjs",

--- a/scripts/agent-runner-remote-run-command.mjs
+++ b/scripts/agent-runner-remote-run-command.mjs
@@ -1,0 +1,323 @@
+import { updateProjectItemFields } from "./lib/agent-project-fields.mjs"
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  findProjectIssueItem,
+  loadAllEvaluatedProject,
+  parseArgs,
+  projectScanConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+import {
+  buildCommandEvidencePacket,
+  canRunCommandState,
+  commandRunStates,
+} from "./lib/agent-runner-execution.mjs"
+import {
+  maybePrintHelp,
+  mutationOptions,
+  projectOptions,
+  repositoryOptions,
+} from "./lib/agent-runner-help.mjs"
+import {
+  remoteCommandRunArtifactPlan,
+  remoteCommandRunEnvironment,
+  remoteCommandRunFieldUpdate,
+  remoteLoggedCommandShell,
+  remoteWriteFileShell,
+} from "./lib/agent-runner-remote-execution.mjs"
+import {
+  loadRemoteWorkspaceAdapters,
+  resolveRemoteWorkspaceAdapter,
+} from "./lib/agent-runner-remote-workspace.mjs"
+import {
+  isRemoteWorkspaceDescriptor,
+  parseWorkspaceReference,
+} from "./lib/agent-runner-workspace-contract.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:remote-run-command",
+  summary: "Run a supervised command inside an already bootstrapped remote workspace.",
+  usage:
+    'pnpm agent:queue:remote-run-command -- --issue <number> --command "pnpm verify:fast" --yes',
+  options: [
+    ["--issue <number>", "Issue number whose remote workspace should run the command."],
+    ["--command <shell>", "Shell command to run from the remote repository directory."],
+    [
+      "--workspace <reference>",
+      "Workspace reference override, for example sandbox:sprite:task-579.",
+    ],
+    ["--branch <name>", "Branch reference for evidence. Defaults from the Project field."],
+    ["--remote-dir <path>", "Remote repository directory."],
+    ["--evidence-path <path>", "Evidence path relative to the remote repository directory."],
+    [
+      "--ui-evidence <text>",
+      "Browser artifacts or approved exception for successful UI-labeled work.",
+    ],
+    ["--force", "Allow command execution outside the normal run states."],
+    [
+      "--adapter-config <path>",
+      "Optional remote adapter config module. Defaults to .agents/remote-workspaces.mjs when present.",
+    ],
+    ["--json", "Print machine-readable JSON."],
+    ...repositoryOptions,
+    ...mutationOptions,
+    ...projectOptions,
+  ],
+})
+
+if (!args.issue) {
+  fail("remote-run-command mode requires --issue <number>")
+}
+
+if (!args.command) {
+  fail("remote-run-command mode requires --command <shell>")
+}
+
+if (!args.yes) {
+  fail("remote-run-command requires --yes because it runs a remote command")
+}
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
+const item = findProjectIssueItem(project.items, {
+  issueNumber: args.issue,
+  repository,
+})
+const currentState = item.fields["Agent State"]
+
+if (item.issue.state !== "OPEN") {
+  fail(`issue #${args.issue} cannot run because issue state is ${item.issue.state}`)
+}
+
+if (!canRunCommandState(currentState, { force: Boolean(args.force) })) {
+  fail(
+    `issue #${args.issue} is not in a command-run Agent State: ${
+      currentState ?? "unset"
+    }; expected one of ${Array.from(commandRunStates).join(", ")} or pass --force`,
+  )
+}
+
+const workspaceReference = args.workspace ?? item.fields.Workspace ?? item.dryRunPlan.workspace
+const descriptor = parseWorkspaceReference(workspaceReference, { repoRoot })
+if (!isRemoteWorkspaceDescriptor(descriptor)) {
+  fail(
+    `remote-run-command requires a remote-sandbox workspace; got ${
+      descriptor.kind === "invalid" ? descriptor.reason : descriptor.kind
+    }`,
+  )
+}
+
+const branch = args.branch ?? item.fields.Branch ?? item.dryRunPlan.branch
+const artifactPlan = remoteCommandRunArtifactPlan({
+  descriptor,
+  evidencePath: args.evidencePath,
+  item,
+  remoteDir: args.remoteDir,
+  workspaceReference,
+})
+
+if (!artifactPlan.safeEvidencePath) {
+  fail(
+    `remote-run-command refuses evidence outside the remote workspace: ${artifactPlan.evidenceFile}`,
+  )
+}
+
+const adapters = await loadAdapters({ descriptor, workspaceReference })
+const adapter = resolveAdapter(descriptor, { adapters })
+if (!adapter.capabilities.exec) {
+  failInspection(
+    new Error(`remote workspace provider ${descriptor.provider} cannot exec commands`),
+    {
+      descriptor,
+      workspaceReference,
+    },
+  )
+}
+
+const runningUpdate = {
+  clear: ["Blocked By"],
+  values: {
+    "Agent State": "Running",
+    "Last Heartbeat": today(),
+    Evidence: artifactPlan.logPointer,
+  },
+}
+
+updateProjectItemFields({
+  clear: runningUpdate.clear,
+  item,
+  project,
+  values: runningUpdate.values,
+})
+
+const startedAt = new Date()
+const commandResult = await runRemoteExec({
+  adapter,
+  args: ["-lc", remoteLoggedCommandShell({ command: args.command, logFile: artifactPlan.logFile })],
+  command: "bash",
+  cwd: artifactPlan.workspace,
+  env: remoteCommandRunEnvironment({ artifactPlan, branch, descriptor, item, repository }),
+  httpPost: true,
+})
+const stoppedAt = new Date()
+const exitCode = commandResult.status ?? 1
+const evidencePacket = buildCommandEvidencePacket({
+  artifactPlan: { ...artifactPlan, repoRoot },
+  blockedBy: null,
+  branch,
+  command: args.command,
+  exitCode,
+  item,
+  repository,
+  startedAt,
+  stoppedAt,
+  uiEvidence: args.uiEvidence,
+})
+const evidenceWriteResult = await runRemoteExec({
+  adapter,
+  args: [
+    "-lc",
+    remoteWriteFileShell({
+      content: evidencePacket,
+      file: artifactPlan.evidenceFile,
+    }),
+  ],
+  command: "bash",
+  cwd: artifactPlan.workspace,
+  httpPost: true,
+})
+const finalUpdate = remoteCommandRunFieldUpdate({
+  allowMissingBrowserEvidence: Boolean(args.force),
+  artifactPlan,
+  evidenceWriteStatus: evidenceWriteResult.status ?? 1,
+  exitCode,
+  item,
+  uiEvidence: args.uiEvidence,
+})
+
+if (finalUpdate.blockedBy && evidenceWriteResult.status === 0) {
+  await runRemoteExec({
+    adapter,
+    args: [
+      "-lc",
+      remoteWriteFileShell({
+        content: buildCommandEvidencePacket({
+          artifactPlan: { ...artifactPlan, repoRoot },
+          blockedBy: finalUpdate.blockedBy,
+          branch,
+          command: args.command,
+          exitCode,
+          item,
+          repository,
+          startedAt,
+          stoppedAt,
+          uiEvidence: args.uiEvidence,
+        }),
+        file: artifactPlan.evidenceFile,
+      }),
+    ],
+    command: "bash",
+    cwd: artifactPlan.workspace,
+    httpPost: true,
+  })
+}
+
+updateProjectItemFields({
+  clear: finalUpdate.clear,
+  item,
+  project,
+  values: finalUpdate.values,
+})
+
+if (args.json) {
+  console.log(
+    JSON.stringify(
+      {
+        commandResult,
+        evidenceWriteResult,
+        finalUpdate,
+        issue: item.issue,
+        repository,
+        workspaceReference,
+      },
+      null,
+      2,
+    ),
+  )
+} else {
+  if (commandResult.stdout) console.log(commandResult.stdout)
+  if (commandResult.stderr) console.error(commandResult.stderr)
+  if (evidenceWriteResult.stderr) console.error(evidenceWriteResult.stderr)
+  console.log("agent-runner remote-run-command: command finished and Project fields were updated")
+  console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+  console.log(`repository: ${repository}`)
+  console.log(`workspace: ${workspaceReference}`)
+  console.log(`remote dir: ${artifactPlan.workspace}`)
+  console.log(`log: ${artifactPlan.logFile}`)
+  console.log(`evidence: ${artifactPlan.evidenceFile}`)
+  console.log(`exit code: ${exitCode}`)
+  console.log(`agent state: ${finalUpdate.values["Agent State"]}`)
+}
+
+process.exitCode = finalUpdate.blockedBy ? 1 : exitCode
+
+async function loadAdapters({ descriptor, workspaceReference }) {
+  try {
+    return await loadRemoteWorkspaceAdapters({
+      configPath: args.adapterConfig,
+      repoRoot,
+    })
+  } catch (error) {
+    failInspection(error, { descriptor, workspaceReference })
+  }
+}
+
+function resolveAdapter(descriptor, { adapters }) {
+  try {
+    return resolveRemoteWorkspaceAdapter(descriptor, { adapters })
+  } catch (error) {
+    failInspection(error, { descriptor, workspaceReference })
+  }
+}
+
+async function runRemoteExec({ adapter, ...command }) {
+  try {
+    return await adapter.exec(command)
+  } catch (error) {
+    return {
+      status: 1,
+      stderr: error instanceof Error ? error.message : String(error),
+      stdout: "",
+    }
+  }
+}
+
+function failInspection(error, { descriptor, workspaceReference }) {
+  const message = error instanceof Error ? error.message : String(error)
+  if (args.json) {
+    console.log(
+      JSON.stringify(
+        {
+          error: message,
+          repository,
+          workspace: {
+            descriptor,
+            reference: workspaceReference,
+          },
+        },
+        null,
+        2,
+      ),
+    )
+    process.exit(1)
+  }
+
+  fail(message)
+}
+
+function today() {
+  return new Date().toISOString().slice(0, 10)
+}

--- a/scripts/lib/agent-runner-remote-bootstrap.mjs
+++ b/scripts/lib/agent-runner-remote-bootstrap.mjs
@@ -25,7 +25,7 @@ export function remoteBootstrapPlan({
     throw new Error("remote bootstrap requires --repo <owner/name> or --repo-url <url>")
   }
 
-  const selectedRemoteDir = remoteDir ?? `/home/sprite/voyant-workspaces/${descriptor.id}/repo`
+  const selectedRemoteDir = remoteDir ?? defaultRemoteWorkspaceRepoDir(descriptor)
   assertShellValue("remote directory", selectedRemoteDir)
   assertShellValue("repository URL", selectedRepoUrl)
   assertShellValue("branch", selectedBranch)
@@ -54,6 +54,10 @@ export function remoteBootstrapFieldValues({ branch, workspaceReference }, date 
     Workspace: workspaceReference,
     "Last Heartbeat": date.toISOString().slice(0, 10),
   }
+}
+
+export function defaultRemoteWorkspaceRepoDir(descriptor) {
+  return `/home/sprite/voyant-workspaces/${descriptor.id}/repo`
 }
 
 export function remoteBootstrapShell({ baseRef, branch, remoteDir, repoUrl }) {

--- a/scripts/lib/agent-runner-remote-execution.mjs
+++ b/scripts/lib/agent-runner-remote-execution.mjs
@@ -1,0 +1,150 @@
+import path from "node:path"
+
+import { browserEvidenceMissingReason } from "./agent-runner-browser-evidence.mjs"
+import { commandRunFieldUpdate } from "./agent-runner-execution.mjs"
+import { defaultRemoteWorkspaceRepoDir } from "./agent-runner-remote-bootstrap.mjs"
+import { workspaceDescriptorEnvironment } from "./agent-runner-workspace-contract.mjs"
+
+export function remoteCommandRunArtifactPlan({
+  date = new Date(),
+  descriptor,
+  evidencePath,
+  item,
+  remoteDir,
+  workspaceReference,
+}) {
+  const slug = slugFromTitle(item.issue.title)
+  const timestamp = date.toISOString().replace(/[:.]/g, "-")
+  const workspace = remoteDir ?? defaultRemoteWorkspaceRepoDir(descriptor)
+  const evidencePointer =
+    evidencePath ?? path.posix.join("docs/agent-evidence/active", `${item.issue.number}-${slug}.md`)
+  const absoluteEvidencePointer = path.posix.isAbsolute(evidencePointer)
+  const evidenceFile = absoluteEvidencePointer
+    ? evidencePointer
+    : path.posix.join(workspace, evidencePointer)
+  const logPointer = path.posix.join(
+    ".agent-runs",
+    `${item.issue.number}-${slug}`,
+    `${timestamp}.log`,
+  )
+  const logFile = path.posix.join(workspace, logPointer)
+
+  return {
+    evidenceFile,
+    evidencePointer,
+    logFile,
+    logPointer,
+    safeEvidencePath: !absoluteEvidencePointer && isPosixPathInside(evidenceFile, workspace),
+    workspace,
+    workspaceReference,
+  }
+}
+
+export function remoteCommandRunEnvironment({
+  artifactPlan,
+  branch,
+  descriptor,
+  item,
+  repository,
+}) {
+  return {
+    ...workspaceDescriptorEnvironment(descriptor),
+    VOYANT_AGENT_BRANCH: branch,
+    VOYANT_AGENT_EVIDENCE_PATH: artifactPlan.evidenceFile,
+    VOYANT_AGENT_EVIDENCE_REFERENCE: artifactPlan.evidencePointer,
+    VOYANT_AGENT_ISSUE: String(item.issue.number),
+    VOYANT_AGENT_ISSUE_TITLE: item.issue.title,
+    VOYANT_AGENT_ISSUE_URL: item.issue.url,
+    VOYANT_AGENT_LOG_PATH: artifactPlan.logFile,
+    VOYANT_AGENT_LOG_REFERENCE: artifactPlan.logPointer,
+    VOYANT_AGENT_PLAN_PATH: path.posix.join(artifactPlan.workspace, item.dryRunPlan.planPath),
+    VOYANT_AGENT_REPOSITORY: repository,
+    VOYANT_AGENT_VERIFICATION_LANE: item.dryRunPlan.verificationLane,
+    VOYANT_AGENT_WORKSPACE: artifactPlan.workspace,
+  }
+}
+
+export function remoteCommandRunFieldUpdate({
+  allowMissingBrowserEvidence = false,
+  artifactPlan,
+  date = new Date(),
+  evidenceWriteStatus,
+  exitCode,
+  item,
+  uiEvidence,
+}) {
+  const evidenceWriteFailed = evidenceWriteStatus !== 0
+  const browserBlock =
+    allowMissingBrowserEvidence || exitCode !== 0
+      ? null
+      : browserEvidenceMissingReason(item, uiEvidence)
+  const blockedBy = evidenceWriteFailed
+    ? `remote evidence write exited with ${evidenceWriteStatus}`
+    : browserBlock
+
+  return {
+    blockedBy,
+    ...commandRunFieldUpdate({
+      blockedBy,
+      date,
+      evidencePointer: evidenceWriteFailed ? artifactPlan.logPointer : artifactPlan.evidencePointer,
+      exitCode: evidenceWriteFailed ? evidenceWriteStatus : exitCode,
+    }),
+  }
+}
+
+export function remoteLoggedCommandShell({ command, logFile }) {
+  assertShellValue("log file", logFile)
+  assertShellValue("command", command)
+
+  return `set -euo pipefail
+log_file=${shellQuote(logFile)}
+user_command=${shellQuote(command)}
+mkdir -p "$(dirname "$log_file")"
+printf '# %s %s\\n\\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$user_command" >> "$log_file"
+set +e
+bash -lc "$user_command" > >(tee -a "$log_file") 2> >(tee -a "$log_file" >&2)
+status=$?
+set -e
+printf '\\n# exit code: %s\\n' "$status" >> "$log_file"
+exit "$status"`
+}
+
+export function remoteWriteFileShell({ content, file }) {
+  assertShellValue("file", file)
+
+  const encoded = Buffer.from(content, "utf8").toString("base64")
+  return `set -euo pipefail
+file=${shellQuote(file)}
+mkdir -p "$(dirname "$file")"
+base64 -d > "$file" <<'VOYANT_REMOTE_FILE'
+${encoded}
+VOYANT_REMOTE_FILE`
+}
+
+function isPosixPathInside(candidatePath, parentPath) {
+  const relative = path.posix.relative(parentPath, candidatePath)
+  return Boolean(relative) && !relative.startsWith("..") && !path.posix.isAbsolute(relative)
+}
+
+function assertShellValue(name, value) {
+  if (typeof value !== "string" || value.trim().length === 0 || /[\0\r\n]/.test(value)) {
+    throw new Error(`invalid remote command ${name}: ${String(value)}`)
+  }
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`
+}
+
+function slugFromTitle(title) {
+  const slug = title
+    .toLowerCase()
+    .replace(/^\[(task|bug|refactor|investigation|cleanup)\]\s*:?\s*/i, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60)
+    .replace(/-+$/g, "")
+
+  return slug || "agent-task"
+}

--- a/scripts/lib/agent-runner-tick.mjs
+++ b/scripts/lib/agent-runner-tick.mjs
@@ -219,6 +219,35 @@ function remoteWorkspaceRecommendation(item, { heartbeat, repository }) {
     })
   }
 
+  if (state === "CI Repair" && item.fields.PR && !hasCiRepairEvidence(item.fields.Evidence)) {
+    return null
+  }
+
+  if (["Planning", "Changes Requested", "CI Repair"].includes(state)) {
+    return recommendation(item, {
+      action: "remote-run-command",
+      command: commandWithIssue({
+        command: "remote-run-command",
+        extraArgs: ['--command "<implementation-command>"'],
+        issueNumber: item.issue.number,
+        repository,
+      }),
+      heartbeat,
+      priority: 30,
+      reason: `remote workspace ${descriptor.reference} is ready for supervised command execution`,
+    })
+  }
+
+  if (state === "Running") {
+    return recommendation(item, {
+      action: "wait-running",
+      command: null,
+      heartbeat,
+      priority: 40,
+      reason: "remote command execution is already marked running",
+    })
+  }
+
   if (state === "Done" || state === "Abandoned") {
     return recommendation(item, {
       action: "wait-remote-cleanup",

--- a/scripts/tests/agent-runner-remote-execution.test.mjs
+++ b/scripts/tests/agent-runner-remote-execution.test.mjs
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import {
+  remoteCommandRunArtifactPlan,
+  remoteCommandRunEnvironment,
+  remoteCommandRunFieldUpdate,
+  remoteLoggedCommandShell,
+  remoteWriteFileShell,
+} from "../lib/agent-runner-remote-execution.mjs"
+import { parseWorkspaceReference } from "../lib/agent-runner-workspace-contract.mjs"
+import { workItem } from "./agent-fixtures.mjs"
+
+describe("agent runner remote execution helpers", () => {
+  it("plans remote command artifacts inside the remote repository", () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+    const plan = remoteCommandRunArtifactPlan({
+      date: new Date("2026-05-11T12:34:56.000Z"),
+      descriptor,
+      item: workItem(),
+      workspaceReference: descriptor.reference,
+    })
+
+    assert.equal(plan.workspace, "/home/sprite/voyant-workspaces/task-579/repo")
+    assert.equal(
+      plan.evidencePointer,
+      "docs/agent-evidence/active/579-test-agent-project-intake-workflow.md",
+    )
+    assert.equal(
+      plan.evidenceFile,
+      "/home/sprite/voyant-workspaces/task-579/repo/docs/agent-evidence/active/579-test-agent-project-intake-workflow.md",
+    )
+    assert.equal(
+      plan.logPointer,
+      ".agent-runs/579-test-agent-project-intake-workflow/2026-05-11T12-34-56-000Z.log",
+    )
+    assert.equal(plan.safeEvidencePath, true)
+
+    const unsafe = remoteCommandRunArtifactPlan({
+      descriptor,
+      evidencePath: "/tmp/evidence.md",
+      item: workItem(),
+      workspaceReference: descriptor.reference,
+    })
+    assert.equal(unsafe.safeEvidencePath, false)
+  })
+
+  it("builds remote command environment without local workspace assumptions", () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+    const artifactPlan = remoteCommandRunArtifactPlan({
+      descriptor,
+      item: workItem(),
+      remoteDir: "/workspace/voyant",
+      workspaceReference: descriptor.reference,
+    })
+
+    assert.deepEqual(
+      remoteCommandRunEnvironment({
+        artifactPlan,
+        branch: "task/579-test-agent-project-intake-workflow",
+        descriptor,
+        item: workItem(),
+        repository: "voyantjs/voyant",
+      }),
+      {
+        VOYANT_AGENT_BRANCH: "task/579-test-agent-project-intake-workflow",
+        VOYANT_AGENT_EVIDENCE_PATH:
+          "/workspace/voyant/docs/agent-evidence/active/579-test-agent-project-intake-workflow.md",
+        VOYANT_AGENT_EVIDENCE_REFERENCE:
+          "docs/agent-evidence/active/579-test-agent-project-intake-workflow.md",
+        VOYANT_AGENT_ISSUE: "579",
+        VOYANT_AGENT_ISSUE_TITLE: "Test agent project intake workflow",
+        VOYANT_AGENT_ISSUE_URL: "https://github.com/voyantjs/voyant/issues/579",
+        VOYANT_AGENT_LOG_PATH: artifactPlan.logFile,
+        VOYANT_AGENT_LOG_REFERENCE: artifactPlan.logPointer,
+        VOYANT_AGENT_PLAN_PATH:
+          "/workspace/voyant/docs/agent-plans/active/579-test-agent-project-intake-workflow.md",
+        VOYANT_AGENT_REPOSITORY: "voyantjs/voyant",
+        VOYANT_AGENT_VERIFICATION_LANE: "verify:fast",
+        VOYANT_AGENT_WORKSPACE: "/workspace/voyant",
+        VOYANT_AGENT_WORKSPACE_ID: "task-579",
+        VOYANT_AGENT_WORKSPACE_KIND: "remote-sandbox",
+        VOYANT_AGENT_WORKSPACE_PROVIDER: "sprite",
+        VOYANT_AGENT_WORKSPACE_REFERENCE: "sandbox:sprite:task-579",
+      },
+    )
+  })
+
+  it("builds shell wrappers for logged execution and remote evidence writes", () => {
+    assert.match(
+      remoteLoggedCommandShell({
+        command: "pnpm verify:fast",
+        logFile: "/workspace/voyant/.agent-runs/579/run.log",
+      }),
+      /bash -lc "\$user_command"/,
+    )
+    assert.match(
+      remoteWriteFileShell({
+        content: "hello",
+        file: "/workspace/voyant/docs/agent-evidence/active/579.md",
+      }),
+      /aGVsbG8=/,
+    )
+  })
+
+  it("builds Project updates for remote command completion", () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+    const artifactPlan = remoteCommandRunArtifactPlan({
+      descriptor,
+      item: workItem(),
+      workspaceReference: descriptor.reference,
+    })
+
+    assert.deepEqual(
+      remoteCommandRunFieldUpdate({
+        artifactPlan,
+        date: new Date("2026-05-11T12:00:00.000Z"),
+        evidenceWriteStatus: 0,
+        exitCode: 0,
+        item: workItem(),
+      }),
+      {
+        blockedBy: null,
+        clear: ["Blocked By"],
+        values: {
+          "Agent State": "Human Review",
+          "Last Heartbeat": "2026-05-11",
+          Evidence: "docs/agent-evidence/active/579-test-agent-project-intake-workflow.md",
+        },
+      },
+    )
+
+    assert.deepEqual(
+      remoteCommandRunFieldUpdate({
+        artifactPlan,
+        date: new Date("2026-05-11T12:00:00.000Z"),
+        evidenceWriteStatus: 1,
+        exitCode: 0,
+        item: workItem(),
+      }),
+      {
+        blockedBy: "remote evidence write exited with 1",
+        clear: [],
+        values: {
+          "Agent State": "Blocked",
+          "Blocked By": "remote evidence write exited with 1",
+          "Last Heartbeat": "2026-05-11",
+          Evidence: artifactPlan.logPointer,
+        },
+      },
+    )
+  })
+})

--- a/scripts/tests/agent-runner-tick.test.mjs
+++ b/scripts/tests/agent-runner-tick.test.mjs
@@ -88,6 +88,38 @@ describe("agent runner tick helpers", () => {
       },
     )
 
+    assert.equal(
+      recommendQueueAction(
+        workItem({
+          fields: {
+            "Agent State": "CI Repair",
+            "Last Heartbeat": new Date().toISOString().slice(0, 10),
+            PR: "https://github.com/voyantjs/voyant/pull/626",
+            Workspace: "sandbox:sprite:task-579",
+          },
+        }),
+        { maxAgeDays: 1, repository: "voyantjs/other" },
+      ).action,
+      "collect-ci",
+    )
+
+    assert.equal(
+      recommendQueueAction(
+        workItem({
+          fields: {
+            "Agent State": "CI Repair",
+            Evidence:
+              ".agent-runs/579-test-agent-project-intake-workflow/ci-repair-2026-05-10T12-34-56-000Z.md",
+            "Last Heartbeat": new Date().toISOString().slice(0, 10),
+            PR: "https://github.com/voyantjs/voyant/pull/626",
+            Workspace: "sandbox:sprite:task-579",
+          },
+        }),
+        { maxAgeDays: 1, repository: "voyantjs/other" },
+      ).action,
+      "remote-run-command",
+    )
+
     assert.deepEqual(
       recommendQueueAction(
         workItem({
@@ -243,15 +275,17 @@ describe("agent runner tick helpers", () => {
         { maxAgeDays: 1, repository: "voyantjs/other" },
       ),
       {
-        action: "wait-remote-adapter",
-        command: "pnpm agent:queue:remote-inspect -- --issue 579 --repo voyantjs/other",
+        action: "remote-run-command",
+        command:
+          'pnpm agent:queue:remote-run-command -- --issue 579 --repo voyantjs/other --command "<implementation-command>" --yes',
         heartbeat: {
           reason: "Last Heartbeat is 0 days old",
           stale: false,
         },
         issue: workItem().issue,
-        priority: 29,
-        reason: "remote workspace sandbox:sprite:task-579 requires a remote adapter",
+        priority: 30,
+        reason:
+          "remote workspace sandbox:sprite:task-579 is ready for supervised command execution",
         state: "Planning",
       },
     )


### PR DESCRIPTION
## Summary
- add remote-run-command for explicit supervised command execution in bootstrapped remote workspaces
- write remote transcripts and evidence packets, then move Project items to Human Review or Blocked
- teach tick to recommend remote-run-command for remote Planning/Changes Requested/CI Repair states while keeping dispatch from running implementation commands automatically

## Verification
- pnpm agent:queue:test
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- pnpm exec biome check scripts/agent-runner-remote-run-command.mjs scripts/lib/agent-runner-remote-execution.mjs scripts/tests/agent-runner-remote-execution.test.mjs
- git diff --check
- pnpm agent:queue:remote-run-command -- --help
- pre-push hook: pnpm typecheck
- pre-push hook: pnpm test