### PR TITLE
feat(agent-runner): publish remote evidence

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -185,6 +185,21 @@ packet under `docs/agent-evidence/active/`, then moves the item to
 branches, expose HTTP, capture browser artifacts, publish evidence, open PRs,
 or clean up the remote workspace.
 
+After a successful remote command, publish the remote evidence packet to GitHub
+or configured R2-compatible object storage:
+
+```bash
+pnpm agent:queue:remote-publish-evidence -- --issue <number> --yes
+pnpm agent:queue:remote-publish-evidence -- --issue <number> --publish-artifacts --yes
+```
+
+Remote-publish-evidence mode reads the relative Evidence path from the remote
+repository directory through the configured adapter, posts or reuses a GitHub
+issue comment, optionally uploads the packet to configured object storage, and
+updates the Project `Evidence` field to the durable URL. It refuses absolute or
+escaping evidence paths and refuses Evidence values that already point at a
+remote URL.
+
 After local start, run a supervised provider-neutral command in the claimed
 workspace:
 
@@ -264,10 +279,12 @@ CI repair packet exists. Ready items with `sandbox:<provider>:<id>` workspaces
 recommend `remote-bootstrap` so dispatch can clone/fetch the repository and
 move the item to `Planning`. Remote workspace items in `Planning`,
 `Changes Requested`, or `CI Repair` recommend `remote-run-command`, but dispatch
-does not execute implementation commands automatically. Later remote workspace
-states still recommend wait states until a remote adapter owns browser evidence,
-PR creation, and cleanup. Malformed reserved `sandbox:` values recommend
-`inspect-workspace`.
+does not execute implementation commands automatically. Remote `Human Review`
+items with local evidence paths recommend `remote-publish-evidence`; after
+evidence is published, they wait for the future remote PR publisher. Later
+remote workspace states still recommend wait states until a remote adapter owns
+browser evidence, PR creation, and cleanup. Malformed reserved `sandbox:`
+values recommend `inspect-workspace`.
 
 Use dispatch to execute one allow-listed tick recommendation:
 
@@ -278,9 +295,10 @@ pnpm agent:queue:dispatch -- --yes
 Dispatch mode re-reads the Project, selects the highest-priority dispatchable
 recommendation, and runs one lifecycle command. It is dry-run by default. Pass
 `--issue <number>` or `--action <name>` to narrow selection. Dispatch can run
-`start`, `remote-bootstrap`, `collect-ci`, `publish-evidence`, `open-pr`,
-`sync-pr`, and `cleanup`; it refuses `run-command`, `remote-run-command`,
-`capture-browser`, `inspect-stale`, blocked work, and wait states so
+`start`, `remote-bootstrap`, `remote-publish-evidence`, `collect-ci`,
+`publish-evidence`, `open-pr`, `sync-pr`, and `cleanup`; it refuses
+`run-command`, `remote-run-command`, `capture-browser`, `inspect-stale`,
+blocked work, and wait states so
 implementation and browser execution remain explicit.
 Successful dispatch attempts append local JSONL audit events to
 `.agent-runs/events.jsonl` by default; pass `--event-log <path>` when a

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1188,8 +1188,12 @@ inside a remote workspace. Ready remote-workspace items can be dispatched
 through that bootstrap path and move to `Planning` after success.
 `agent:queue:remote-run-command` can run an explicit supervised command in that
 remote repository, write a remote transcript and evidence packet, and move the
-Project item to `Human Review` or `Blocked`. Browser evidence, HTTP exposure,
-remote artifact publishing, cleanup, and PR creation remain future slices.
+Project item to `Human Review` or `Blocked`. `agent:queue:remote-publish-evidence`
+can read that remote evidence packet through the configured adapter, post or
+reuse a GitHub evidence comment, optionally publish the packet to configured
+R2-compatible object storage, and update the Project `Evidence` field to the
+durable URL. Browser evidence, HTTP exposure, cleanup, and PR creation remain
+future slices.
 
 Verification:
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "agent:queue:remote-inspect": "node scripts/agent-runner-remote-inspect.mjs",
     "agent:queue:remote-exec": "node scripts/agent-runner-remote-exec.mjs",
     "agent:queue:remote-bootstrap": "node scripts/agent-runner-remote-bootstrap.mjs",
+    "agent:queue:remote-publish-evidence": "node scripts/agent-runner-remote-publish-evidence.mjs",
     "agent:queue:remote-run-command": "node scripts/agent-runner-remote-run-command.mjs",
     "agent:queue:prepare": "node scripts/agent-runner-prepare.mjs",
     "agent:queue:start": "node scripts/agent-runner-start.mjs",

--- a/scripts/agent-runner-publish-evidence.mjs
+++ b/scripts/agent-runner-publish-evidence.mjs
@@ -1,4 +1,3 @@
-import { spawnSync } from "node:child_process"
 import { existsSync, readFileSync } from "node:fs"
 import path from "node:path"
 
@@ -17,6 +16,13 @@ import {
   evidencePacketPublicationPlan,
   publishEvidencePacket,
 } from "./lib/agent-runner-artifacts.mjs"
+import {
+  createIssueComment,
+  evidenceCommentBody,
+  evidenceMarker,
+  findExistingEvidenceComment,
+  isRemoteEvidence,
+} from "./lib/agent-runner-evidence-publication.mjs"
 import {
   maybePrintHelp,
   mutationOptions,
@@ -151,86 +157,6 @@ console.log(`repository: ${repository}`)
 console.log(`evidence: ${remoteEvidence?.url ?? commentUrl}`)
 if (remoteEvidence) {
   console.log(`github comment: ${commentUrl}`)
-}
-
-function findExistingEvidenceComment({ issueNumber, marker, repository }) {
-  const result = spawnSync("gh", ["api", `repos/${repository}/issues/${issueNumber}/comments`], {
-    encoding: "utf8",
-    maxBuffer: 1024 * 1024 * 10,
-  })
-
-  if (result.error) {
-    fail(`failed to run gh: ${result.error.message}`)
-  }
-
-  if (result.status !== 0) {
-    const stderr = result.stderr.trim()
-    fail(stderr || `gh api exited with ${result.status}`)
-  }
-
-  let payload
-  try {
-    payload = JSON.parse(result.stdout)
-  } catch (error) {
-    fail(`failed to parse gh JSON output: ${error.message}`)
-  }
-
-  const comment = payload.find((candidate) => candidate.body?.includes(marker))
-  return comment?.html_url
-}
-
-function createIssueComment({ body, issueNumber, repository }) {
-  const result = spawnSync(
-    "gh",
-    [
-      "api",
-      `repos/${repository}/issues/${issueNumber}/comments`,
-      "-X",
-      "POST",
-      "-f",
-      `body=${body}`,
-    ],
-    {
-      encoding: "utf8",
-      maxBuffer: 1024 * 1024 * 10,
-    },
-  )
-
-  if (result.error) {
-    fail(`failed to run gh: ${result.error.message}`)
-  }
-
-  if (result.status !== 0) {
-    const stderr = result.stderr.trim()
-    fail(stderr || `gh api exited with ${result.status}`)
-  }
-
-  let payload
-  try {
-    payload = JSON.parse(result.stdout)
-  } catch (error) {
-    fail(`failed to parse gh JSON output: ${error.message}`)
-  }
-
-  if (!payload.html_url) {
-    fail("GitHub did not return an issue comment URL")
-  }
-
-  return payload.html_url
-}
-
-function evidenceMarker({ evidenceReference, issueNumber, repository }) {
-  const key = Buffer.from(`${repository}#${issueNumber}:${evidenceReference}`).toString("base64url")
-  return `<!-- voyant-agent-evidence:${key} -->`
-}
-
-function evidenceCommentBody({ evidenceBody, marker, remoteEvidenceUrl }) {
-  const remoteLine = remoteEvidenceUrl ? `Published evidence packet: ${remoteEvidenceUrl}\n\n` : ""
-  return `${marker}\n\n${remoteLine}${evidenceBody}`
-}
-
-function isRemoteEvidence(evidence) {
-  return /^https?:\/\//.test(evidence)
 }
 
 function isPathInside(candidatePath, parentPath) {

--- a/scripts/agent-runner-remote-publish-evidence.mjs
+++ b/scripts/agent-runner-remote-publish-evidence.mjs
@@ -1,0 +1,299 @@
+import { updateProjectItemFields } from "./lib/agent-project-fields.mjs"
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  findProjectIssueItem,
+  loadAllEvaluatedProject,
+  parseArgs,
+  projectScanConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+import {
+  artifactPublisherFromEnv,
+  evidencePacketPublicationPlan,
+  publishEvidencePacket,
+} from "./lib/agent-runner-artifacts.mjs"
+import {
+  createIssueComment,
+  evidenceCommentBody,
+  evidenceMarker,
+  findExistingEvidenceComment,
+  isRemoteEvidence,
+} from "./lib/agent-runner-evidence-publication.mjs"
+import {
+  maybePrintHelp,
+  mutationOptions,
+  projectOptions,
+  repositoryOptions,
+} from "./lib/agent-runner-help.mjs"
+import {
+  decodeRemoteBase64File,
+  remoteEvidencePublicationFieldValues,
+  remoteEvidencePublicationPlan,
+  remoteReadFileBase64Shell,
+} from "./lib/agent-runner-remote-evidence.mjs"
+import {
+  loadRemoteWorkspaceAdapters,
+  resolveRemoteWorkspaceAdapter,
+} from "./lib/agent-runner-remote-workspace.mjs"
+import {
+  isRemoteWorkspaceDescriptor,
+  parseWorkspaceReference,
+} from "./lib/agent-runner-workspace-contract.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:remote-publish-evidence",
+  summary: "Read a remote evidence packet, post it to GitHub, and update Project evidence.",
+  usage: "pnpm agent:queue:remote-publish-evidence -- --issue <number> --yes",
+  options: [
+    ["--issue <number>", "Issue number whose remote evidence packet should be published."],
+    ["--evidence-path <path>", "Evidence path relative to the remote repository directory."],
+    [
+      "--workspace <reference>",
+      "Workspace reference override, for example sandbox:sprite:task-579.",
+    ],
+    ["--remote-dir <path>", "Remote repository directory."],
+    ["--publish-artifacts", "Upload the evidence packet to configured R2/S3 object storage."],
+    [
+      "--adapter-config <path>",
+      "Optional remote adapter config module. Defaults to .agents/remote-workspaces.mjs when present.",
+    ],
+    ["--json", "Print machine-readable JSON."],
+    ...repositoryOptions,
+    ...mutationOptions,
+    ...projectOptions,
+  ],
+})
+
+if (!args.issue) {
+  fail("remote-publish-evidence mode requires --issue <number>")
+}
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
+const item = findProjectIssueItem(project.items, {
+  issueNumber: args.issue,
+  repository,
+})
+
+if (item.issue.state !== "OPEN") {
+  fail(`issue #${args.issue} cannot publish evidence because issue state is ${item.issue.state}`)
+}
+
+const workspaceReference = args.workspace ?? item.fields.Workspace ?? item.dryRunPlan.workspace
+const descriptor = parseWorkspaceReference(workspaceReference, { repoRoot })
+if (!isRemoteWorkspaceDescriptor(descriptor)) {
+  fail(
+    `remote-publish-evidence requires a remote-sandbox workspace; got ${
+      descriptor.kind === "invalid" ? descriptor.reason : descriptor.kind
+    }`,
+  )
+}
+
+const evidenceReference = args.evidencePath ?? item.fields.Evidence
+if (!evidenceReference) {
+  fail("remote-publish-evidence mode requires --evidence-path or an existing Evidence field")
+}
+
+if (isRemoteEvidence(evidenceReference)) {
+  fail(`Evidence already points at a remote artifact: ${evidenceReference}`)
+}
+
+const publicationPlan = remoteEvidencePublicationPlan({
+  descriptor,
+  evidencePath: evidenceReference,
+  item,
+  remoteDir: args.remoteDir,
+  workspaceReference,
+})
+
+if (!publicationPlan.safeEvidencePath) {
+  fail(
+    `remote-publish-evidence refuses evidence outside the remote workspace: ${publicationPlan.evidenceFile}`,
+  )
+}
+
+const artifactPublisher = args.publishArtifacts ? artifactPublisherFromEnv() : undefined
+const remoteEvidencePlan = artifactPublisher
+  ? evidencePacketPublicationPlan({
+      publisher: artifactPublisher,
+      reference: publicationPlan.evidencePointer,
+      repository,
+    })
+  : undefined
+
+if (!args.yes) {
+  printPublishPlan({ item, publicationPlan, remoteEvidencePlan, repository })
+  fail("remote-publish-evidence comments on GitHub and updates Project fields; rerun with --yes")
+}
+
+const adapters = await loadAdapters({ descriptor, workspaceReference })
+const adapter = resolveAdapter(descriptor, { adapters })
+if (!adapter.capabilities.exec) {
+  failInspection(
+    new Error(`remote workspace provider ${descriptor.provider} cannot exec commands`),
+    {
+      descriptor,
+      workspaceReference,
+    },
+  )
+}
+
+const readResult = await runRemoteExec({
+  adapter,
+  args: ["-lc", remoteReadFileBase64Shell({ file: publicationPlan.evidenceFile })],
+  command: "bash",
+  cwd: publicationPlan.workspace,
+  httpPost: true,
+})
+
+if (readResult.status !== 0) {
+  failInspection(
+    new Error(readResult.stderr?.trim() || `remote evidence read exited with ${readResult.status}`),
+    { descriptor, workspaceReference },
+  )
+}
+
+let evidenceBody
+try {
+  evidenceBody = decodeRemoteBase64File({
+    file: publicationPlan.evidenceFile,
+    stdout: readResult.stdout,
+  })
+} catch (error) {
+  failInspection(error, { descriptor, workspaceReference })
+}
+
+if (!evidenceBody.trim()) {
+  fail(`remote evidence packet is empty: ${publicationPlan.evidenceFile}`)
+}
+
+const marker = evidenceMarker({
+  evidenceReference: publicationPlan.evidencePointer,
+  issueNumber: item.issue.number,
+  repository,
+})
+const existingCommentUrl = findExistingEvidenceComment({
+  issueNumber: item.issue.number,
+  marker,
+  repository,
+})
+const remoteEvidence =
+  artifactPublisher &&
+  (await publishEvidencePacket({
+    body: evidenceBody,
+    issueNumber: item.issue.number,
+    publisher: artifactPublisher,
+    reference: publicationPlan.evidencePointer,
+    repository,
+  }))
+const commentUrl =
+  existingCommentUrl ??
+  createIssueComment({
+    body: evidenceCommentBody({ evidenceBody, marker, remoteEvidenceUrl: remoteEvidence?.url }),
+    issueNumber: item.issue.number,
+    repository,
+  })
+const evidenceUrl = remoteEvidence?.url ?? commentUrl
+
+updateProjectItemFields({
+  item,
+  project,
+  values: remoteEvidencePublicationFieldValues({ evidenceUrl }),
+})
+
+if (args.json) {
+  console.log(
+    JSON.stringify(
+      {
+        evidence: evidenceUrl,
+        githubComment: commentUrl,
+        issue: item.issue,
+        publishedArtifact: remoteEvidence ?? null,
+        publicationPlan,
+        repository,
+        workspaceReference,
+      },
+      null,
+      2,
+    ),
+  )
+} else {
+  console.log("agent-runner remote-publish-evidence: posted evidence and updated Project fields")
+  console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+  console.log(`repository: ${repository}`)
+  console.log(`workspace: ${workspaceReference}`)
+  console.log(`remote evidence: ${publicationPlan.evidenceFile}`)
+  console.log(`evidence: ${evidenceUrl}`)
+  if (remoteEvidence) {
+    console.log(`github comment: ${commentUrl}`)
+  }
+}
+
+async function loadAdapters({ descriptor, workspaceReference }) {
+  try {
+    return await loadRemoteWorkspaceAdapters({
+      configPath: args.adapterConfig,
+      repoRoot,
+    })
+  } catch (error) {
+    failInspection(error, { descriptor, workspaceReference })
+  }
+}
+
+function resolveAdapter(descriptor, { adapters }) {
+  try {
+    return resolveRemoteWorkspaceAdapter(descriptor, { adapters })
+  } catch (error) {
+    failInspection(error, { descriptor, workspaceReference })
+  }
+}
+
+async function runRemoteExec({ adapter, ...command }) {
+  try {
+    return await adapter.exec(command)
+  } catch (error) {
+    return {
+      status: 1,
+      stderr: error instanceof Error ? error.message : String(error),
+      stdout: "",
+    }
+  }
+}
+
+function failInspection(error, { descriptor, workspaceReference }) {
+  const message = error instanceof Error ? error.message : String(error)
+  if (args.json) {
+    console.log(
+      JSON.stringify(
+        {
+          error: message,
+          repository,
+          workspace: {
+            descriptor,
+            reference: workspaceReference,
+          },
+        },
+        null,
+        2,
+      ),
+    )
+    process.exit(1)
+  }
+
+  fail(message)
+}
+
+function printPublishPlan({ item, publicationPlan, remoteEvidencePlan, repository }) {
+  console.log("agent-runner remote-publish-evidence would update:")
+  console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+  console.log(`repository: ${repository}`)
+  console.log(`workspace: ${publicationPlan.workspaceReference}`)
+  console.log(`remote evidence file: ${publicationPlan.evidenceFile}`)
+  if (remoteEvidencePlan) {
+    console.log(`remote evidence packet: ${remoteEvidencePlan.url}`)
+  }
+  console.log(`Evidence: ${remoteEvidencePlan?.url ?? "<new issue comment URL>"}`)
+}

--- a/scripts/lib/agent-runner-dispatch.mjs
+++ b/scripts/lib/agent-runner-dispatch.mjs
@@ -6,6 +6,7 @@ export const dispatchableActions = new Set([
   "open-pr",
   "publish-evidence",
   "remote-bootstrap",
+  "remote-publish-evidence",
   "start",
   "sync-pr",
 ])

--- a/scripts/lib/agent-runner-evidence-publication.mjs
+++ b/scripts/lib/agent-runner-evidence-publication.mjs
@@ -1,0 +1,83 @@
+import { spawnSync } from "node:child_process"
+
+import { fail } from "./agent-project-queue.mjs"
+
+export function findExistingEvidenceComment({ issueNumber, marker, repository }) {
+  const result = spawnSync("gh", ["api", `repos/${repository}/issues/${issueNumber}/comments`], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 10,
+  })
+
+  if (result.error) {
+    fail(`failed to run gh: ${result.error.message}`)
+  }
+
+  if (result.status !== 0) {
+    const stderr = result.stderr.trim()
+    fail(stderr || `gh api exited with ${result.status}`)
+  }
+
+  let payload
+  try {
+    payload = JSON.parse(result.stdout)
+  } catch (error) {
+    fail(`failed to parse gh JSON output: ${error.message}`)
+  }
+
+  const comment = payload.find((candidate) => candidate.body?.includes(marker))
+  return comment?.html_url
+}
+
+export function createIssueComment({ body, issueNumber, repository }) {
+  const result = spawnSync(
+    "gh",
+    [
+      "api",
+      `repos/${repository}/issues/${issueNumber}/comments`,
+      "-X",
+      "POST",
+      "-f",
+      `body=${body}`,
+    ],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024 * 10,
+    },
+  )
+
+  if (result.error) {
+    fail(`failed to run gh: ${result.error.message}`)
+  }
+
+  if (result.status !== 0) {
+    const stderr = result.stderr.trim()
+    fail(stderr || `gh api exited with ${result.status}`)
+  }
+
+  let payload
+  try {
+    payload = JSON.parse(result.stdout)
+  } catch (error) {
+    fail(`failed to parse gh JSON output: ${error.message}`)
+  }
+
+  if (!payload.html_url) {
+    fail("GitHub did not return an issue comment URL")
+  }
+
+  return payload.html_url
+}
+
+export function evidenceMarker({ evidenceReference, issueNumber, repository }) {
+  const key = Buffer.from(`${repository}#${issueNumber}:${evidenceReference}`).toString("base64url")
+  return `<!-- voyant-agent-evidence:${key} -->`
+}
+
+export function evidenceCommentBody({ evidenceBody, marker, remoteEvidenceUrl }) {
+  const remoteLine = remoteEvidenceUrl ? `Published evidence packet: ${remoteEvidenceUrl}\n\n` : ""
+  return `${marker}\n\n${remoteLine}${evidenceBody}`
+}
+
+export function isRemoteEvidence(evidence) {
+  return /^https?:\/\//.test(evidence)
+}

--- a/scripts/lib/agent-runner-remote-evidence.mjs
+++ b/scripts/lib/agent-runner-remote-evidence.mjs
@@ -1,0 +1,71 @@
+import path from "node:path"
+
+import { defaultRemoteWorkspaceRepoDir } from "./agent-runner-remote-bootstrap.mjs"
+
+export function remoteEvidencePublicationPlan({
+  descriptor,
+  evidencePath,
+  item,
+  remoteDir,
+  workspaceReference,
+}) {
+  const workspace = remoteDir ?? defaultRemoteWorkspaceRepoDir(descriptor)
+  const evidencePointer = evidencePath ?? item.fields.Evidence
+  const absoluteEvidencePointer =
+    typeof evidencePointer === "string" && path.posix.isAbsolute(evidencePointer)
+  const evidenceFile = absoluteEvidencePointer
+    ? evidencePointer
+    : path.posix.join(workspace, evidencePointer ?? "")
+
+  return {
+    evidenceFile,
+    evidencePointer,
+    safeEvidencePath:
+      typeof evidencePointer === "string" &&
+      evidencePointer.trim().length > 0 &&
+      !absoluteEvidencePointer &&
+      isPosixPathInside(evidenceFile, workspace),
+    workspace,
+    workspaceReference,
+  }
+}
+
+export function remoteReadFileBase64Shell({ file }) {
+  assertShellValue("file", file)
+
+  return `set -euo pipefail
+file=${shellQuote(file)}
+test -f "$file"
+base64 "$file" | tr -d '\\n'`
+}
+
+export function decodeRemoteBase64File({ file, stdout }) {
+  const encoded = String(stdout ?? "").replace(/\s+/g, "")
+  if (!encoded) {
+    throw new Error(`remote evidence packet is empty: ${file}`)
+  }
+
+  return Buffer.from(encoded, "base64").toString("utf8")
+}
+
+export function remoteEvidencePublicationFieldValues({ date = new Date(), evidenceUrl }) {
+  return {
+    Evidence: evidenceUrl,
+    "Last Heartbeat": date.toISOString().slice(0, 10),
+  }
+}
+
+function isPosixPathInside(candidatePath, parentPath) {
+  const relative = path.posix.relative(parentPath, candidatePath)
+  return Boolean(relative) && !relative.startsWith("..") && !path.posix.isAbsolute(relative)
+}
+
+function assertShellValue(name, value) {
+  if (typeof value !== "string" || value.trim().length === 0 || /[\0\r\n]/.test(value)) {
+    throw new Error(`invalid remote evidence ${name}: ${String(value)}`)
+  }
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`
+}

--- a/scripts/lib/agent-runner-tick.mjs
+++ b/scripts/lib/agent-runner-tick.mjs
@@ -205,6 +205,35 @@ function remoteWorkspaceRecommendation(item, { heartbeat, repository }) {
   if (state === "Human Review" && item.fields.PR) return null
   if (state === "Merge Ready" && item.fields.PR) return null
 
+  if (state === "Human Review" && item.fields.Evidence) {
+    if (isRemoteEvidence(item.fields.Evidence)) {
+      return recommendation(item, {
+        action: "wait-remote-pr",
+        command: commandWithIssue({
+          command: "remote-inspect",
+          issueNumber: item.issue.number,
+          mutate: false,
+          repository,
+        }),
+        heartbeat,
+        priority: 60,
+        reason: `remote workspace ${descriptor.reference} has published evidence but no remote PR publisher`,
+      })
+    }
+
+    return recommendation(item, {
+      action: "remote-publish-evidence",
+      command: commandWithIssue({
+        command: "remote-publish-evidence",
+        issueNumber: item.issue.number,
+        repository,
+      }),
+      heartbeat,
+      priority: 60,
+      reason: `remote workspace ${descriptor.reference} evidence should be published before PR creation`,
+    })
+  }
+
   if (item.ready) {
     return recommendation(item, {
       action: "remote-bootstrap",

--- a/scripts/tests/agent-runner-dispatch.test.mjs
+++ b/scripts/tests/agent-runner-dispatch.test.mjs
@@ -106,6 +106,33 @@ describe("agent runner dispatch helpers", () => {
     ])
   })
 
+  it("dispatches remote evidence publication recommendations", () => {
+    const recommendation = recommendQueueAction(
+      workItem({
+        fields: {
+          "Agent State": "Human Review",
+          Evidence: "docs/agent-evidence/active/579-test.md",
+          Workspace: "sandbox:sprite:task-579",
+        },
+      }),
+      { maxAgeDays: 1, repository: "voyantjs/other" },
+    )
+
+    assert.equal(
+      selectDispatchRecommendation([recommendation]).recommendation.action,
+      "remote-publish-evidence",
+    )
+    assert.deepEqual(dispatchCommandArgs(recommendation, { repository: "voyantjs/other" }), [
+      "agent:queue:remote-publish-evidence",
+      "--",
+      "--issue",
+      "579",
+      "--repo",
+      "voyantjs/other",
+      "--yes",
+    ])
+  })
+
   it("passes custom event logs to nested dispatch commands", () => {
     const recommendation = recommendQueueAction(workItem(), {
       maxAgeDays: 1,

--- a/scripts/tests/agent-runner-evidence-publication.test.mjs
+++ b/scripts/tests/agent-runner-evidence-publication.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import {
+  evidenceCommentBody,
+  evidenceMarker,
+  isRemoteEvidence,
+} from "../lib/agent-runner-evidence-publication.mjs"
+
+describe("agent runner evidence publication helpers", () => {
+  it("builds stable evidence markers for idempotent GitHub comments", () => {
+    assert.equal(
+      evidenceMarker({
+        evidenceReference: "docs/agent-evidence/active/579-test.md",
+        issueNumber: 579,
+        repository: "voyantjs/voyant",
+      }),
+      "<!-- voyant-agent-evidence:dm95YW50anMvdm95YW50IzU3OTpkb2NzL2FnZW50LWV2aWRlbmNlL2FjdGl2ZS81NzktdGVzdC5tZA -->",
+    )
+  })
+
+  it("prepends durable artifact links when evidence is published remotely", () => {
+    assert.equal(
+      evidenceCommentBody({
+        evidenceBody: "# Evidence\n",
+        marker: "<!-- marker -->",
+        remoteEvidenceUrl: "https://artifacts.example.com/evidence.md",
+      }),
+      "<!-- marker -->\n\nPublished evidence packet: https://artifacts.example.com/evidence.md\n\n# Evidence\n",
+    )
+  })
+
+  it("detects remote evidence URLs", () => {
+    assert.equal(isRemoteEvidence("https://artifacts.example.com/evidence.md"), true)
+    assert.equal(isRemoteEvidence("docs/agent-evidence/active/579-test.md"), false)
+  })
+})

--- a/scripts/tests/agent-runner-remote-evidence.test.mjs
+++ b/scripts/tests/agent-runner-remote-evidence.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import {
+  decodeRemoteBase64File,
+  remoteEvidencePublicationFieldValues,
+  remoteEvidencePublicationPlan,
+  remoteReadFileBase64Shell,
+} from "../lib/agent-runner-remote-evidence.mjs"
+import { workItem } from "./agent-fixtures.mjs"
+
+const descriptor = {
+  id: "task-579",
+  kind: "remote-sandbox",
+  provider: "sprite",
+  reference: "sandbox:sprite:task-579",
+}
+
+describe("agent runner remote evidence helpers", () => {
+  it("plans safe remote evidence paths inside the repository directory", () => {
+    const plan = remoteEvidencePublicationPlan({
+      descriptor,
+      item: workItem({
+        fields: {
+          Evidence: "docs/agent-evidence/active/579-test.md",
+        },
+      }),
+      workspaceReference: "sandbox:sprite:task-579",
+    })
+
+    assert.equal(plan.workspace, "/home/sprite/voyant-workspaces/task-579/repo")
+    assert.equal(
+      plan.evidenceFile,
+      "/home/sprite/voyant-workspaces/task-579/repo/docs/agent-evidence/active/579-test.md",
+    )
+    assert.equal(plan.safeEvidencePath, true)
+  })
+
+  it("rejects absolute or escaping evidence paths", () => {
+    assert.equal(
+      remoteEvidencePublicationPlan({
+        descriptor,
+        evidencePath: "/tmp/evidence.md",
+        item: workItem(),
+        workspaceReference: "sandbox:sprite:task-579",
+      }).safeEvidencePath,
+      false,
+    )
+    assert.equal(
+      remoteEvidencePublicationPlan({
+        descriptor,
+        evidencePath: "../evidence.md",
+        item: workItem(),
+        workspaceReference: "sandbox:sprite:task-579",
+      }).safeEvidencePath,
+      false,
+    )
+  })
+
+  it("builds a remote base64 file read shell and decodes the result", () => {
+    const shell = remoteReadFileBase64Shell({
+      file: "/home/sprite/voyant-workspaces/task-579/repo/docs/evidence.md",
+    })
+
+    assert.match(shell, /test -f "\$file"/)
+    assert.match(shell, /base64 "\$file" \| tr -d '\\n'/)
+    assert.equal(
+      decodeRemoteBase64File({
+        file: "docs/evidence.md",
+        stdout: Buffer.from("# Evidence\n").toString("base64"),
+      }),
+      "# Evidence\n",
+    )
+  })
+
+  it("builds Project field values for published remote evidence", () => {
+    assert.deepEqual(
+      remoteEvidencePublicationFieldValues({
+        date: new Date("2026-05-11T12:00:00Z"),
+        evidenceUrl: "https://artifacts.example.com/evidence.md",
+      }),
+      {
+        Evidence: "https://artifacts.example.com/evidence.md",
+        "Last Heartbeat": "2026-05-11",
+      },
+    )
+  })
+})

--- a/scripts/tests/agent-runner-tick.test.mjs
+++ b/scripts/tests/agent-runner-tick.test.mjs
@@ -301,7 +301,21 @@ describe("agent runner tick helpers", () => {
         }),
         { maxAgeDays: 1, repository: "voyantjs/other" },
       ).action,
-      "wait-remote-adapter",
+      "remote-publish-evidence",
+    )
+
+    assert.deepEqual(
+      recommendQueueAction(
+        workItem({
+          fields: {
+            "Agent State": "Human Review",
+            Evidence: "https://artifacts.example.com/evidence.md",
+            Workspace: "sandbox:sprite:task-579",
+          },
+        }),
+        { maxAgeDays: 1, repository: "voyantjs/other" },
+      ).action,
+      "wait-remote-pr",
     )
 
     assert.deepEqual(


### PR DESCRIPTION
## Summary
- Add a remote evidence publishing command that reads a sandbox evidence packet through the configured adapter, posts or reuses an issue evidence comment, and can publish to R2/S3-backed artifact storage.
- Route remote Human Review items with local evidence paths to remote evidence publication, then hold published remote evidence at a wait state until remote PR publishing exists.
- Share evidence comment helpers between local and remote publishers and document the new remote evidence step.

## Verification
- pnpm exec biome check scripts/agent-runner-publish-evidence.mjs scripts/agent-runner-remote-publish-evidence.mjs scripts/lib/agent-runner-evidence-publication.mjs scripts/lib/agent-runner-remote-evidence.mjs scripts/tests/agent-runner-evidence-publication.test.mjs scripts/tests/agent-runner-remote-evidence.test.mjs scripts/lib/agent-runner-tick.mjs scripts/lib/agent-runner-dispatch.mjs scripts/tests/agent-runner-tick.test.mjs scripts/tests/agent-runner-dispatch.test.mjs package.json
- pnpm agent:queue:test
- pnpm agent:queue:remote-publish-evidence -- --help
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- git diff --cached --check
- commit/push hooks: full lint, typecheck, and test completed successfully