### PR TITLE
feat(agent-runner): dispose remote workspaces

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -200,6 +200,18 @@ updates the Project `Evidence` field to the durable URL. It refuses absolute or
 escaping evidence paths and refuses Evidence values that already point at a
 remote URL.
 
+After a remote-backed issue is merged, abandoned, or explicitly force-cleaned,
+dispose the remote workspace through the configured adapter:
+
+```bash
+pnpm agent:queue:remote-cleanup -- --issue <number> --yes
+```
+
+Remote-cleanup mode requires `Agent State = Done` or `Abandoned` unless
+`--force` is passed. It calls the adapter's `dispose` operation and clears the
+Project `Workspace` field only after that operation succeeds. Providers that do
+not declare `dispose` fail closed.
+
 After local start, run a supervised provider-neutral command in the claimed
 workspace:
 
@@ -283,8 +295,9 @@ does not execute implementation commands automatically. Remote `Human Review`
 items with local evidence paths recommend `remote-publish-evidence`; after
 evidence is published, they wait for the future remote PR publisher. Later
 remote workspace states still recommend wait states until a remote adapter owns
-browser evidence, PR creation, and cleanup. Malformed reserved `sandbox:`
-values recommend `inspect-workspace`.
+browser evidence and PR creation. Terminal remote items recommend
+`remote-cleanup`. Malformed reserved `sandbox:` values recommend
+`inspect-workspace`.
 
 Use dispatch to execute one allow-listed tick recommendation:
 
@@ -295,10 +308,10 @@ pnpm agent:queue:dispatch -- --yes
 Dispatch mode re-reads the Project, selects the highest-priority dispatchable
 recommendation, and runs one lifecycle command. It is dry-run by default. Pass
 `--issue <number>` or `--action <name>` to narrow selection. Dispatch can run
-`start`, `remote-bootstrap`, `remote-publish-evidence`, `collect-ci`,
-`publish-evidence`, `open-pr`, `sync-pr`, and `cleanup`; it refuses
-`run-command`, `remote-run-command`, `capture-browser`, `inspect-stale`,
-blocked work, and wait states so
+`start`, `remote-bootstrap`, `remote-publish-evidence`, `remote-cleanup`,
+`collect-ci`, `publish-evidence`, `open-pr`, `sync-pr`, and `cleanup`; it
+refuses `run-command`, `remote-run-command`, `capture-browser`,
+`inspect-stale`, blocked work, and wait states so
 implementation and browser execution remain explicit.
 Successful dispatch attempts append local JSONL audit events to
 `.agent-runs/events.jsonl` by default; pass `--event-log <path>` when a

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1192,8 +1192,10 @@ Project item to `Human Review` or `Blocked`. `agent:queue:remote-publish-evidenc
 can read that remote evidence packet through the configured adapter, post or
 reuse a GitHub evidence comment, optionally publish the packet to configured
 R2-compatible object storage, and update the Project `Evidence` field to the
-durable URL. Browser evidence, HTTP exposure, cleanup, and PR creation remain
-future slices.
+durable URL. `agent:queue:remote-cleanup` can call an adapter-owned `dispose`
+operation for terminal remote work and clear the Project `Workspace` field
+after success. Browser evidence, HTTP exposure, and PR creation remain future
+slices.
 
 Verification:
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "agent:queue:remote-exec": "node scripts/agent-runner-remote-exec.mjs",
     "agent:queue:remote-bootstrap": "node scripts/agent-runner-remote-bootstrap.mjs",
     "agent:queue:remote-publish-evidence": "node scripts/agent-runner-remote-publish-evidence.mjs",
+    "agent:queue:remote-cleanup": "node scripts/agent-runner-remote-cleanup.mjs",
     "agent:queue:remote-run-command": "node scripts/agent-runner-remote-run-command.mjs",
     "agent:queue:prepare": "node scripts/agent-runner-prepare.mjs",
     "agent:queue:start": "node scripts/agent-runner-start.mjs",

--- a/scripts/agent-runner-remote-cleanup.mjs
+++ b/scripts/agent-runner-remote-cleanup.mjs
@@ -1,0 +1,189 @@
+import { updateProjectItemFields } from "./lib/agent-project-fields.mjs"
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  findProjectIssueItem,
+  loadAllEvaluatedProject,
+  parseArgs,
+  projectScanConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+import {
+  maybePrintHelp,
+  mutationOptions,
+  projectOptions,
+  repositoryOptions,
+} from "./lib/agent-runner-help.mjs"
+import {
+  loadRemoteWorkspaceAdapters,
+  resolveRemoteWorkspaceAdapter,
+} from "./lib/agent-runner-remote-workspace.mjs"
+import { canCleanupAgentState, cleanupFieldValues } from "./lib/agent-runner-workspace.mjs"
+import {
+  isRemoteWorkspaceDescriptor,
+  parseWorkspaceReference,
+} from "./lib/agent-runner-workspace-contract.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:remote-cleanup",
+  summary: "Dispose a completed remote workspace and clear its Project workspace pointer.",
+  usage: "pnpm agent:queue:remote-cleanup -- --issue <number> --yes",
+  options: [
+    ["--issue <number>", "Issue number whose remote workspace should be disposed."],
+    [
+      "--workspace <reference>",
+      "Workspace reference override, for example sandbox:sprite:task-579.",
+    ],
+    ["--force", "Allow cleanup outside Done or Abandoned Agent State."],
+    [
+      "--adapter-config <path>",
+      "Optional remote adapter config module. Defaults to .agents/remote-workspaces.mjs when present.",
+    ],
+    ["--json", "Print machine-readable JSON."],
+    ...repositoryOptions,
+    ...mutationOptions,
+    ...projectOptions,
+  ],
+})
+
+if (!args.issue) {
+  fail("remote-cleanup mode requires --issue <number>")
+}
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
+const item = findProjectIssueItem(project.items, {
+  issueNumber: args.issue,
+  repository,
+})
+const agentState = item.fields["Agent State"]
+
+if (!canCleanupAgentState(agentState, { force: Boolean(args.force) })) {
+  fail(
+    `issue #${args.issue} is not in a cleanup Agent State: ${
+      agentState ?? "unset"
+    }; pass --force to override`,
+  )
+}
+
+const workspaceReference = args.workspace ?? item.fields.Workspace ?? item.dryRunPlan.workspace
+const descriptor = parseWorkspaceReference(workspaceReference, { repoRoot })
+if (!isRemoteWorkspaceDescriptor(descriptor)) {
+  fail(
+    `remote-cleanup requires a remote-sandbox workspace; got ${
+      descriptor.kind === "invalid" ? descriptor.reason : descriptor.kind
+    }`,
+  )
+}
+
+const values = cleanupFieldValues()
+const clear = ["Workspace"]
+
+if (!args.yes) {
+  printCleanupPlan({ clear, descriptor, item, repository, values, workspaceReference })
+  fail("remote-cleanup disposes a remote workspace and updates Project fields; rerun with --yes")
+}
+
+const adapters = await loadAdapters({ descriptor, workspaceReference })
+const adapter = resolveAdapter(descriptor, { adapters })
+if (!adapter.capabilities.dispose) {
+  failInspection(
+    new Error(`remote workspace provider ${descriptor.provider} cannot dispose workspaces`),
+    {
+      descriptor,
+      workspaceReference,
+    },
+  )
+}
+
+let result
+try {
+  result = await adapter.dispose({ keepForReview: false })
+} catch (error) {
+  failInspection(error, { descriptor, workspaceReference })
+}
+
+updateProjectItemFields({ clear, item, project, values })
+
+if (args.json) {
+  console.log(
+    JSON.stringify(
+      {
+        disposed: result ?? null,
+        issue: item.issue,
+        repository,
+        workspace: {
+          descriptor,
+          reference: workspaceReference,
+        },
+      },
+      null,
+      2,
+    ),
+  )
+} else {
+  console.log(
+    "agent-runner remote-cleanup: disposed remote workspace and cleared Project workspace",
+  )
+  console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+  console.log(`repository: ${repository}`)
+  console.log(`workspace: ${workspaceReference}`)
+}
+
+async function loadAdapters({ descriptor, workspaceReference }) {
+  try {
+    return await loadRemoteWorkspaceAdapters({
+      configPath: args.adapterConfig,
+      repoRoot,
+    })
+  } catch (error) {
+    failInspection(error, { descriptor, workspaceReference })
+  }
+}
+
+function resolveAdapter(descriptor, { adapters }) {
+  try {
+    return resolveRemoteWorkspaceAdapter(descriptor, { adapters })
+  } catch (error) {
+    failInspection(error, { descriptor, workspaceReference })
+  }
+}
+
+function failInspection(error, { descriptor, workspaceReference }) {
+  const message = error instanceof Error ? error.message : String(error)
+  if (args.json) {
+    console.log(
+      JSON.stringify(
+        {
+          error: message,
+          repository,
+          workspace: {
+            descriptor,
+            reference: workspaceReference,
+          },
+        },
+        null,
+        2,
+      ),
+    )
+    process.exit(1)
+  }
+
+  fail(message)
+}
+
+function printCleanupPlan({ clear, descriptor, item, repository, values, workspaceReference }) {
+  console.log("agent-runner remote-cleanup would dispose:")
+  console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+  console.log(`repository: ${repository}`)
+  console.log(`workspace: ${workspaceReference}`)
+  console.log(`provider: ${descriptor.provider}`)
+  for (const [fieldName, value] of Object.entries(values)) {
+    console.log(`${fieldName}: ${value}`)
+  }
+  for (const fieldName of clear) {
+    console.log(`${fieldName}: <clear>`)
+  }
+}

--- a/scripts/lib/agent-runner-dispatch.mjs
+++ b/scripts/lib/agent-runner-dispatch.mjs
@@ -6,6 +6,7 @@ export const dispatchableActions = new Set([
   "open-pr",
   "publish-evidence",
   "remote-bootstrap",
+  "remote-cleanup",
   "remote-publish-evidence",
   "start",
   "sync-pr",

--- a/scripts/lib/agent-runner-tick.mjs
+++ b/scripts/lib/agent-runner-tick.mjs
@@ -279,11 +279,10 @@ function remoteWorkspaceRecommendation(item, { heartbeat, repository }) {
 
   if (state === "Done" || state === "Abandoned") {
     return recommendation(item, {
-      action: "wait-remote-cleanup",
+      action: "remote-cleanup",
       command: commandWithIssue({
-        command: "remote-inspect",
+        command: "remote-cleanup",
         issueNumber: item.issue.number,
-        mutate: false,
         repository,
       }),
       heartbeat,

--- a/scripts/tests/agent-runner-dispatch.test.mjs
+++ b/scripts/tests/agent-runner-dispatch.test.mjs
@@ -133,6 +133,32 @@ describe("agent runner dispatch helpers", () => {
     ])
   })
 
+  it("dispatches remote cleanup recommendations", () => {
+    const recommendation = recommendQueueAction(
+      workItem({
+        fields: {
+          "Agent State": "Done",
+          Workspace: "sandbox:sprite:task-579",
+        },
+      }),
+      { maxAgeDays: 1, repository: "voyantjs/other" },
+    )
+
+    assert.equal(
+      selectDispatchRecommendation([recommendation]).recommendation.action,
+      "remote-cleanup",
+    )
+    assert.deepEqual(dispatchCommandArgs(recommendation, { repository: "voyantjs/other" }), [
+      "agent:queue:remote-cleanup",
+      "--",
+      "--issue",
+      "579",
+      "--repo",
+      "voyantjs/other",
+      "--yes",
+    ])
+  })
+
   it("passes custom event logs to nested dispatch commands", () => {
     const recommendation = recommendQueueAction(workItem(), {
       maxAgeDays: 1,

--- a/scripts/tests/agent-runner-tick.test.mjs
+++ b/scripts/tests/agent-runner-tick.test.mjs
@@ -344,8 +344,8 @@ describe("agent runner tick helpers", () => {
         { maxAgeDays: 1, repository: "voyantjs/other" },
       ),
       {
-        action: "wait-remote-cleanup",
-        command: "pnpm agent:queue:remote-inspect -- --issue 579 --repo voyantjs/other",
+        action: "remote-cleanup",
+        command: "pnpm agent:queue:remote-cleanup -- --issue 579 --repo voyantjs/other --yes",
         heartbeat: null,
         issue: workItem().issue,
         priority: 90,


### PR DESCRIPTION
## Summary
- Add remote-cleanup to dispose terminal sandbox workspaces through adapters that explicitly support dispose.
- Route terminal remote Project items to remote-cleanup and allow dispatch to execute that lifecycle step.
- Document remote cleanup behavior and the fail-closed provider capability requirement.

## Verification
- pnpm exec biome check scripts/agent-runner-remote-cleanup.mjs scripts/lib/agent-runner-dispatch.mjs scripts/lib/agent-runner-tick.mjs scripts/tests/agent-runner-dispatch.test.mjs scripts/tests/agent-runner-tick.test.mjs package.json
- pnpm agent:queue:test
- pnpm agent:queue:remote-cleanup -- --help
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- git diff --check
- commit/push hooks: full lint, typecheck, and test completed successfully