### PR TITLE
feat(agent-runner): open remote workspace pull requests

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -200,6 +200,21 @@ updates the Project `Evidence` field to the durable URL. It refuses absolute or
 escaping evidence paths and refuses Evidence values that already point at a
 remote URL.
 
+After remote evidence is published, push the remote branch and open or reuse a
+draft PR:
+
+```bash
+pnpm agent:queue:remote-open-pr -- --issue <number> --yes
+pnpm agent:queue:remote-open-pr -- --issue <number> --ready --yes
+```
+
+Remote-open-pr mode requires the same handoff states as local `open-pr` unless
+`--force` is passed. It verifies the remote repository is on the expected
+branch, refuses uncommitted remote changes unless `--allow-dirty` is passed,
+pushes the branch through the configured adapter, creates or reuses the PR from
+the local GitHub token, and updates the Project `PR` field after the PR URL is
+known.
+
 After a remote-backed issue is merged, abandoned, or explicitly force-cleaned,
 dispose the remote workspace through the configured adapter:
 
@@ -293,11 +308,10 @@ move the item to `Planning`. Remote workspace items in `Planning`,
 `Changes Requested`, or `CI Repair` recommend `remote-run-command`, but dispatch
 does not execute implementation commands automatically. Remote `Human Review`
 items with local evidence paths recommend `remote-publish-evidence`; after
-evidence is published, they wait for the future remote PR publisher. Later
-remote workspace states still recommend wait states until a remote adapter owns
-browser evidence and PR creation. Terminal remote items recommend
-`remote-cleanup`. Malformed reserved `sandbox:` values recommend
-`inspect-workspace`.
+evidence is published, they recommend `remote-open-pr`. Later remote workspace
+states still recommend wait states until a remote adapter owns browser
+evidence. Terminal remote items recommend `remote-cleanup`. Malformed reserved
+`sandbox:` values recommend `inspect-workspace`.
 
 Use dispatch to execute one allow-listed tick recommendation:
 
@@ -308,9 +322,9 @@ pnpm agent:queue:dispatch -- --yes
 Dispatch mode re-reads the Project, selects the highest-priority dispatchable
 recommendation, and runs one lifecycle command. It is dry-run by default. Pass
 `--issue <number>` or `--action <name>` to narrow selection. Dispatch can run
-`start`, `remote-bootstrap`, `remote-publish-evidence`, `remote-cleanup`,
-`collect-ci`, `publish-evidence`, `open-pr`, `sync-pr`, and `cleanup`; it
-refuses `run-command`, `remote-run-command`, `capture-browser`,
+`start`, `remote-bootstrap`, `remote-publish-evidence`, `remote-open-pr`,
+`remote-cleanup`, `collect-ci`, `publish-evidence`, `open-pr`, `sync-pr`, and
+`cleanup`; it refuses `run-command`, `remote-run-command`, `capture-browser`,
 `inspect-stale`, blocked work, and wait states so
 implementation and browser execution remain explicit.
 Successful dispatch attempts append local JSONL audit events to

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1194,8 +1194,10 @@ reuse a GitHub evidence comment, optionally publish the packet to configured
 R2-compatible object storage, and update the Project `Evidence` field to the
 durable URL. `agent:queue:remote-cleanup` can call an adapter-owned `dispose`
 operation for terminal remote work and clear the Project `Workspace` field
-after success. Browser evidence, HTTP exposure, and PR creation remain future
-slices.
+after success. `agent:queue:remote-open-pr` can verify and push the remote
+branch through the configured adapter, create or reuse a GitHub PR from the
+local token, and update the Project `PR` field. Browser evidence and HTTP
+exposure remain future slices.
 
 Verification:
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "agent:queue:remote-bootstrap": "node scripts/agent-runner-remote-bootstrap.mjs",
     "agent:queue:remote-publish-evidence": "node scripts/agent-runner-remote-publish-evidence.mjs",
     "agent:queue:remote-cleanup": "node scripts/agent-runner-remote-cleanup.mjs",
+    "agent:queue:remote-open-pr": "node scripts/agent-runner-remote-open-pr.mjs",
     "agent:queue:remote-run-command": "node scripts/agent-runner-remote-run-command.mjs",
     "agent:queue:prepare": "node scripts/agent-runner-prepare.mjs",
     "agent:queue:start": "node scripts/agent-runner-start.mjs",

--- a/scripts/agent-runner-remote-open-pr.mjs
+++ b/scripts/agent-runner-remote-open-pr.mjs
@@ -1,0 +1,301 @@
+import { updateProjectItemFields } from "./lib/agent-project-fields.mjs"
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  findProjectIssueItem,
+  loadAllEvaluatedProject,
+  parseArgs,
+  projectScanConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+import {
+  maybePrintHelp,
+  mutationOptions,
+  projectOptions,
+  repositoryOptions,
+} from "./lib/agent-runner-help.mjs"
+import {
+  createPullRequest,
+  evidenceForPullRequest,
+  existingPullRequestUrl,
+  isRemoteReference,
+  openPullRequestStates,
+  pullRequestBody,
+  pullRequestFieldValues,
+  pullRequestTitle,
+} from "./lib/agent-runner-pr.mjs"
+import { remotePullRequestPlan, remotePushBranchShell } from "./lib/agent-runner-remote-pr.mjs"
+import {
+  loadRemoteWorkspaceAdapters,
+  resolveRemoteWorkspaceAdapter,
+} from "./lib/agent-runner-remote-workspace.mjs"
+import {
+  isRemoteWorkspaceDescriptor,
+  parseWorkspaceReference,
+} from "./lib/agent-runner-workspace-contract.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:remote-open-pr",
+  summary:
+    "Push a remote workspace branch, open or reuse a draft PR, and update Project PR metadata.",
+  usage: "pnpm agent:queue:remote-open-pr -- --issue <number> --yes",
+  options: [
+    ["--issue <number>", "Issue number whose remote branch should be published."],
+    ["--base <ref>", "Base branch for the pull request. Defaults to main."],
+    ["--branch <name>", "Branch override. Defaults from the Project Branch field."],
+    [
+      "--workspace <reference>",
+      "Workspace reference override, for example sandbox:sprite:task-579.",
+    ],
+    ["--remote-dir <path>", "Remote repository directory."],
+    ["--evidence <url>", "Evidence URL override. Defaults from the Project Evidence field."],
+    ["--ready", "Open a ready-for-review PR instead of a draft PR."],
+    ["--allow-dirty", "Allow opening a PR from a remote workspace with uncommitted changes."],
+    ["--force", "Allow opening outside the normal handoff states."],
+    [
+      "--adapter-config <path>",
+      "Optional remote adapter config module. Defaults to .agents/remote-workspaces.mjs when present.",
+    ],
+    ["--json", "Print machine-readable JSON."],
+    ...repositoryOptions,
+    ...mutationOptions,
+    ...projectOptions,
+  ],
+})
+
+if (!args.issue) {
+  fail("remote-open-pr mode requires --issue <number>")
+}
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
+const item = findProjectIssueItem(project.items, {
+  issueNumber: args.issue,
+  repository,
+})
+const currentState = item.fields["Agent State"]
+
+if (item.issue.state !== "OPEN") {
+  fail(`issue #${args.issue} cannot open a PR because issue state is ${item.issue.state}`)
+}
+
+if (!args.force && !openPullRequestStates.has(currentState)) {
+  fail(
+    `issue #${args.issue} is not in an open-pr Agent State: ${
+      currentState ?? "unset"
+    }; pass --force to override`,
+  )
+}
+
+const workspaceReference = args.workspace ?? item.fields.Workspace ?? item.dryRunPlan.workspace
+const descriptor = parseWorkspaceReference(workspaceReference, { repoRoot })
+if (!isRemoteWorkspaceDescriptor(descriptor)) {
+  fail(
+    `remote-open-pr requires a remote-sandbox workspace; got ${
+      descriptor.kind === "invalid" ? descriptor.reason : descriptor.kind
+    }`,
+  )
+}
+
+const plan = remotePullRequestPlan({
+  branch: args.branch,
+  descriptor,
+  item,
+  remoteDir: args.remoteDir,
+})
+const evidenceReference = args.evidence ?? item.fields.Evidence
+if (!isRemoteReference(evidenceReference)) {
+  fail("remote-open-pr mode requires a published remote Evidence URL")
+}
+
+const evidence = evidenceForPullRequest({
+  evidenceReference,
+  repoRoot,
+  workspaceReference,
+})
+const title = pullRequestTitle(item)
+const body = pullRequestBody(item, {
+  ...evidence,
+  repository,
+})
+const base = args.base ?? "main"
+const existingPrUrl = item.fields.PR || existingPullRequestUrl({ branch: plan.branch, repository })
+const values = pullRequestFieldValues({
+  prUrl: existingPrUrl ?? "<new pull request URL>",
+})
+
+if (!args.yes) {
+  printOpenPrPlan({
+    base,
+    existingPrUrl,
+    item,
+    plan,
+    repository,
+    title,
+    values,
+    workspaceReference,
+  })
+  fail("remote-open-pr pushes a branch, opens a PR, and updates Project fields; rerun with --yes")
+}
+
+const adapters = await loadAdapters({ descriptor, workspaceReference })
+const adapter = resolveAdapter(descriptor, { adapters })
+if (!adapter.capabilities.exec) {
+  failInspection(
+    new Error(`remote workspace provider ${descriptor.provider} cannot exec commands`),
+    {
+      descriptor,
+      workspaceReference,
+    },
+  )
+}
+
+const pushResult = await runRemoteExec({
+  adapter,
+  args: [
+    "-lc",
+    remotePushBranchShell({
+      allowDirty: Boolean(args.allowDirty),
+      branch: plan.branch,
+    }),
+  ],
+  command: "bash",
+  cwd: plan.workspace,
+  httpPost: true,
+})
+
+if (pushResult.status !== 0) {
+  failInspection(
+    new Error(pushResult.stderr?.trim() || `remote branch push exited with ${pushResult.status}`),
+    { descriptor, workspaceReference },
+  )
+}
+
+const prUrl =
+  existingPrUrl ??
+  createPullRequest({
+    base,
+    body,
+    branch: plan.branch,
+    draft: !args.ready,
+    repository,
+    title,
+  })
+
+updateProjectItemFields({
+  item,
+  project,
+  values: pullRequestFieldValues({ prUrl }),
+})
+
+if (args.json) {
+  console.log(
+    JSON.stringify(
+      {
+        issue: item.issue,
+        pr: prUrl,
+        pushResult,
+        repository,
+        workspace: {
+          descriptor,
+          reference: workspaceReference,
+          remoteDir: plan.workspace,
+        },
+      },
+      null,
+      2,
+    ),
+  )
+} else {
+  if (pushResult.stdout) console.log(pushResult.stdout)
+  if (pushResult.stderr) console.error(pushResult.stderr)
+  console.log(
+    "agent-runner remote-open-pr: pushed branch, opened or reused PR, and updated Project fields",
+  )
+  console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+  console.log(`repository: ${repository}`)
+  console.log(`branch: ${plan.branch}`)
+  console.log(`workspace: ${workspaceReference}`)
+  console.log(`remote dir: ${plan.workspace}`)
+  console.log(`pr: ${prUrl}`)
+}
+
+async function loadAdapters({ descriptor, workspaceReference }) {
+  try {
+    return await loadRemoteWorkspaceAdapters({
+      configPath: args.adapterConfig,
+      repoRoot,
+    })
+  } catch (error) {
+    failInspection(error, { descriptor, workspaceReference })
+  }
+}
+
+function resolveAdapter(descriptor, { adapters }) {
+  try {
+    return resolveRemoteWorkspaceAdapter(descriptor, { adapters })
+  } catch (error) {
+    failInspection(error, { descriptor, workspaceReference })
+  }
+}
+
+async function runRemoteExec({ adapter, ...command }) {
+  try {
+    return await adapter.exec(command)
+  } catch (error) {
+    return {
+      status: 1,
+      stderr: error instanceof Error ? error.message : String(error),
+      stdout: "",
+    }
+  }
+}
+
+function failInspection(error, { descriptor, workspaceReference }) {
+  const message = error instanceof Error ? error.message : String(error)
+  if (args.json) {
+    console.log(
+      JSON.stringify(
+        {
+          error: message,
+          repository,
+          workspace: {
+            descriptor,
+            reference: workspaceReference,
+          },
+        },
+        null,
+        2,
+      ),
+    )
+    process.exit(1)
+  }
+
+  fail(message)
+}
+
+function printOpenPrPlan({
+  base,
+  existingPrUrl,
+  item,
+  plan,
+  repository,
+  title,
+  values,
+  workspaceReference,
+}) {
+  console.log("agent-runner remote-open-pr would update:")
+  console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+  console.log(`repository: ${repository}`)
+  console.log(`base: ${base}`)
+  console.log(`branch: ${plan.branch}`)
+  console.log(`workspace: ${workspaceReference}`)
+  console.log(`remote dir: ${plan.workspace}`)
+  console.log(`title: ${title}`)
+  console.log(`PR: ${existingPrUrl ?? "<new draft pull request URL>"}`)
+  for (const [fieldName, value] of Object.entries(values)) {
+    console.log(`${fieldName}: ${value}`)
+  }
+}

--- a/scripts/lib/agent-runner-dispatch.mjs
+++ b/scripts/lib/agent-runner-dispatch.mjs
@@ -7,6 +7,7 @@ export const dispatchableActions = new Set([
   "publish-evidence",
   "remote-bootstrap",
   "remote-cleanup",
+  "remote-open-pr",
   "remote-publish-evidence",
   "start",
   "sync-pr",

--- a/scripts/lib/agent-runner-pr.mjs
+++ b/scripts/lib/agent-runner-pr.mjs
@@ -89,24 +89,40 @@ export function pushBranch({ branch, workspace }) {
   runGit(["push", "-u", "origin", branch], { cwd: workspace })
 }
 
-export function existingPullRequestUrl({ branch, workspace }) {
-  const result = runCommand("gh", ["pr", "view", branch, "--json", "url", "--jq", ".url"], {
+export function existingPullRequestUrl({ branch, repository, workspace }) {
+  const args = ["pr", "view", branch, "--json", "url", "--jq", ".url"]
+  if (repository) {
+    args.push("--repo", repository)
+  }
+
+  const result = runCommand("gh", args, {
     cwd: workspace,
     allowFailure: true,
   })
   return result || undefined
 }
 
-export function createPullRequest({ base, body, branch, draft = true, title, workspace }) {
-  return runCommand("gh", pullRequestCreateArgs({ base, body, branch, draft, title }), {
+export function createPullRequest({
+  base,
+  body,
+  branch,
+  draft = true,
+  repository,
+  title,
+  workspace,
+}) {
+  return runCommand("gh", pullRequestCreateArgs({ base, body, branch, draft, repository, title }), {
     cwd: workspace,
   })
 }
 
-export function pullRequestCreateArgs({ base, body, branch, draft = true, title }) {
+export function pullRequestCreateArgs({ base, body, branch, draft = true, repository, title }) {
   const args = ["pr", "create", "--base", base, "--head", branch, "--title", title, "--body", body]
   if (draft) {
     args.push("--draft")
+  }
+  if (repository) {
+    args.push("--repo", repository)
   }
 
   return args

--- a/scripts/lib/agent-runner-remote-pr.mjs
+++ b/scripts/lib/agent-runner-remote-pr.mjs
@@ -1,0 +1,55 @@
+import { defaultRemoteWorkspaceRepoDir } from "./agent-runner-remote-bootstrap.mjs"
+import { isRemoteWorkspaceDescriptor } from "./agent-runner-workspace-contract.mjs"
+
+export function remotePullRequestPlan({ branch, descriptor, item, remoteDir } = {}) {
+  if (!isRemoteWorkspaceDescriptor(descriptor)) {
+    throw new Error(
+      `remote open-pr requires a remote-sandbox reference; got ${descriptor?.kind ?? "unknown"}`,
+    )
+  }
+
+  const selectedBranch = branch ?? item?.fields?.Branch ?? item?.dryRunPlan?.branch
+  if (!selectedBranch) {
+    throw new Error("remote open-pr requires --branch when no issue plan is available")
+  }
+
+  const workspace = remoteDir ?? defaultRemoteWorkspaceRepoDir(descriptor)
+  assertShellValue("remote directory", workspace)
+  assertShellValue("branch", selectedBranch)
+
+  return {
+    branch: selectedBranch,
+    workspace,
+  }
+}
+
+export function remotePushBranchShell({ allowDirty = false, branch }) {
+  assertShellValue("branch", branch)
+
+  return `set -euo pipefail
+branch=${shellQuote(branch)}
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$current_branch" != "$branch" ]; then
+  echo "remote workspace branch is $current_branch; expected $branch" >&2
+  exit 1
+fi
+
+status="$(git status --porcelain)"
+if [ -n "$status" ] && [ ${allowDirty ? "0" : "1"} -eq 1 ]; then
+  echo "remote workspace has uncommitted changes; commit them or pass --allow-dirty" >&2
+  echo "$status" >&2
+  exit 1
+fi
+
+git push -u origin "$branch"`
+}
+
+function assertShellValue(name, value) {
+  if (typeof value !== "string" || value.trim().length === 0 || /[\0\r\n]/.test(value)) {
+    throw new Error(`invalid remote open-pr ${name}: ${String(value)}`)
+  }
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`
+}

--- a/scripts/lib/agent-runner-tick.mjs
+++ b/scripts/lib/agent-runner-tick.mjs
@@ -208,16 +208,15 @@ function remoteWorkspaceRecommendation(item, { heartbeat, repository }) {
   if (state === "Human Review" && item.fields.Evidence) {
     if (isRemoteEvidence(item.fields.Evidence)) {
       return recommendation(item, {
-        action: "wait-remote-pr",
+        action: "remote-open-pr",
         command: commandWithIssue({
-          command: "remote-inspect",
+          command: "remote-open-pr",
           issueNumber: item.issue.number,
-          mutate: false,
           repository,
         }),
         heartbeat,
         priority: 60,
-        reason: `remote workspace ${descriptor.reference} has published evidence but no remote PR publisher`,
+        reason: `remote workspace ${descriptor.reference} has published evidence and needs a PR`,
       })
     }
 

--- a/scripts/tests/agent-runner-dispatch.test.mjs
+++ b/scripts/tests/agent-runner-dispatch.test.mjs
@@ -159,6 +159,33 @@ describe("agent runner dispatch helpers", () => {
     ])
   })
 
+  it("dispatches remote PR publication recommendations", () => {
+    const recommendation = recommendQueueAction(
+      workItem({
+        fields: {
+          "Agent State": "Human Review",
+          Evidence: "https://artifacts.example.com/evidence.md",
+          Workspace: "sandbox:sprite:task-579",
+        },
+      }),
+      { maxAgeDays: 1, repository: "voyantjs/other" },
+    )
+
+    assert.equal(
+      selectDispatchRecommendation([recommendation]).recommendation.action,
+      "remote-open-pr",
+    )
+    assert.deepEqual(dispatchCommandArgs(recommendation, { repository: "voyantjs/other" }), [
+      "agent:queue:remote-open-pr",
+      "--",
+      "--issue",
+      "579",
+      "--repo",
+      "voyantjs/other",
+      "--yes",
+    ])
+  })
+
   it("passes custom event logs to nested dispatch commands", () => {
     const recommendation = recommendQueueAction(workItem(), {
       maxAgeDays: 1,

--- a/scripts/tests/agent-runner-pr.test.mjs
+++ b/scripts/tests/agent-runner-pr.test.mjs
@@ -88,6 +88,32 @@ describe("agent runner PR helpers", () => {
     assert.equal(args.includes("voyantjs:task/579-test-agent-project-intake-workflow"), false)
   })
 
+  it("opens remote workspace PRs through repository-scoped gh commands", () => {
+    const args = pullRequestCreateArgs({
+      base: "main",
+      body: "PR body",
+      branch: "task/579-test-agent-project-intake-workflow",
+      draft: false,
+      repository: "voyantjs/voyant",
+      title: "Test agent project intake workflow",
+    })
+
+    assert.deepEqual(args, [
+      "pr",
+      "create",
+      "--base",
+      "main",
+      "--head",
+      "task/579-test-agent-project-intake-workflow",
+      "--title",
+      "Test agent project intake workflow",
+      "--body",
+      "PR body",
+      "--repo",
+      "voyantjs/voyant",
+    ])
+  })
+
   it("builds PR body update arguments", () => {
     assert.deepEqual(
       pullRequestEditBodyArgs({

--- a/scripts/tests/agent-runner-remote-pr.test.mjs
+++ b/scripts/tests/agent-runner-remote-pr.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { remotePullRequestPlan, remotePushBranchShell } from "../lib/agent-runner-remote-pr.mjs"
+import { parseWorkspaceReference } from "../lib/agent-runner-workspace-contract.mjs"
+import { workItem } from "./agent-fixtures.mjs"
+
+describe("agent runner remote PR helpers", () => {
+  it("plans remote PR publication from the bootstrapped repository directory", () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+    const plan = remotePullRequestPlan({
+      descriptor,
+      item: workItem({
+        fields: {
+          Branch: "task/579-test-agent-project-intake-workflow",
+        },
+      }),
+    })
+
+    assert.deepEqual(plan, {
+      branch: "task/579-test-agent-project-intake-workflow",
+      workspace: "/home/sprite/voyant-workspaces/task-579/repo",
+    })
+  })
+
+  it("builds a guarded remote branch push shell", () => {
+    const shell = remotePushBranchShell({
+      branch: "task/579-test-agent-project-intake-workflow",
+    })
+
+    assert.match(shell, /git rev-parse --abbrev-ref HEAD/)
+    assert.match(shell, /remote workspace has uncommitted changes/)
+    assert.match(shell, /git push -u origin "\$branch"/)
+  })
+
+  it("can allow dirty remote workspaces when explicitly requested", () => {
+    const shell = remotePushBranchShell({
+      allowDirty: true,
+      branch: "task/579-test-agent-project-intake-workflow",
+    })
+
+    assert.match(shell, /\[ 0 -eq 1 \]/)
+  })
+})

--- a/scripts/tests/agent-runner-tick.test.mjs
+++ b/scripts/tests/agent-runner-tick.test.mjs
@@ -315,7 +315,7 @@ describe("agent runner tick helpers", () => {
         }),
         { maxAgeDays: 1, repository: "voyantjs/other" },
       ).action,
-      "wait-remote-pr",
+      "remote-open-pr",
     )
 
     assert.deepEqual(


### PR DESCRIPTION
## Summary
- Add remote-open-pr to push a bootstrapped remote workspace branch through the configured adapter and create or reuse a GitHub PR from the local token.
- Route remote Human Review items with published evidence to remote-open-pr and allow dispatch to run that lifecycle step.
- Document the remote PR handoff flow and add focused helper, dispatch, tick, and PR argument coverage.

## Verification
- pnpm exec biome check scripts/agent-runner-remote-open-pr.mjs scripts/lib/agent-runner-pr.mjs scripts/lib/agent-runner-remote-pr.mjs scripts/lib/agent-runner-dispatch.mjs scripts/lib/agent-runner-tick.mjs scripts/tests/agent-runner-pr.test.mjs scripts/tests/agent-runner-remote-pr.test.mjs scripts/tests/agent-runner-dispatch.test.mjs scripts/tests/agent-runner-tick.test.mjs docs/agents/issue-tracker.md docs/architecture/agentic-engineering-orchestration.md package.json
- pnpm agent:queue:test
- pnpm agent:queue:remote-open-pr -- --help
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- git diff --check
- commit/push hooks: full cached lint, typecheck, and test