### PR TITLE
feat(agent-runner): capture remote browser evidence

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -185,6 +185,24 @@ packet under `docs/agent-evidence/active/`, then moves the item to
 branches, expose HTTP, capture browser artifacts, publish evidence, open PRs,
 or clean up the remote workspace.
 
+For UI work in a remote workspace, expose the running remote dev server and
+capture browser evidence from the local runner:
+
+```bash
+pnpm agent:queue:remote-capture-browser -- --issue <number> --port 3000 --yes
+pnpm agent:queue:remote-capture-browser -- --issue <number> --url "https://preview.example.test" --publish-artifacts --yes
+```
+
+Remote-capture-browser mode requires a `sandbox:<provider>:<id>` workspace. With
+`--port`, it calls the adapter's `exposeHttp` operation and captures the
+returned URL with Playwright. With `--url`, it skips adapter exposure and
+captures the supplied URL. Artifacts are written under local `.agent-runs/` so
+remote browser proof does not dirty the task branch; pass `--publish-artifacts`
+to upload screenshots, videos, logs, summaries, and the artifact index to
+configured object storage. Use the printed browser evidence text as
+`--ui-evidence` for the supervised command that writes the final evidence
+packet. Providers that do not declare `exposeHttp` fail closed.
+
 After a successful remote command, publish the remote evidence packet to GitHub
 or configured R2-compatible object storage:
 

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1196,8 +1196,11 @@ durable URL. `agent:queue:remote-cleanup` can call an adapter-owned `dispose`
 operation for terminal remote work and clear the Project `Workspace` field
 after success. `agent:queue:remote-open-pr` can verify and push the remote
 branch through the configured adapter, create or reuse a GitHub PR from the
-local token, and update the Project `PR` field. Browser evidence and HTTP
-exposure remain future slices.
+local token, and update the Project `PR` field. `agent:queue:remote-capture-browser`
+can call adapter-owned HTTP exposure for a remote port, capture that URL through
+local Playwright, store local ignored browser artifacts, and optionally publish
+the artifact directory to configured R2-compatible storage. Long-running remote
+process management remains a future slice.
 
 Verification:
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "agent:queue:remote-bootstrap": "node scripts/agent-runner-remote-bootstrap.mjs",
     "agent:queue:remote-publish-evidence": "node scripts/agent-runner-remote-publish-evidence.mjs",
     "agent:queue:remote-cleanup": "node scripts/agent-runner-remote-cleanup.mjs",
+    "agent:queue:remote-capture-browser": "node scripts/agent-runner-remote-capture-browser.mjs",
     "agent:queue:remote-open-pr": "node scripts/agent-runner-remote-open-pr.mjs",
     "agent:queue:remote-run-command": "node scripts/agent-runner-remote-run-command.mjs",
     "agent:queue:prepare": "node scripts/agent-runner-prepare.mjs",

--- a/scripts/agent-runner-remote-capture-browser.mjs
+++ b/scripts/agent-runner-remote-capture-browser.mjs
@@ -1,0 +1,294 @@
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  findProjectIssueItem,
+  loadAllEvaluatedProject,
+  parseArgs,
+  projectScanConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+import {
+  artifactPublicationPlan,
+  artifactPublisherFromEnv,
+  publishArtifactDirectory,
+} from "./lib/agent-runner-artifacts.mjs"
+import {
+  browserCapturePlan,
+  browserCapturePlans,
+  browserEvidenceText,
+  captureBrowserEvidence,
+  captureBrowserEvidenceSet,
+  requiresBrowserEvidence,
+  writeBrowserEvidenceSummary,
+} from "./lib/agent-runner-browser-evidence.mjs"
+import { browserIssueBlockReason } from "./lib/agent-runner-browser-issues.mjs"
+import {
+  maybePrintHelp,
+  mutationOptions,
+  projectOptions,
+  repositoryOptions,
+} from "./lib/agent-runner-help.mjs"
+import {
+  normalizeRemoteHttpExposure,
+  remoteBrowserArtifactPlan,
+} from "./lib/agent-runner-remote-browser.mjs"
+import {
+  loadRemoteWorkspaceAdapters,
+  resolveRemoteWorkspaceAdapter,
+} from "./lib/agent-runner-remote-workspace.mjs"
+import {
+  isRemoteWorkspaceDescriptor,
+  parseWorkspaceReference,
+} from "./lib/agent-runner-workspace-contract.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:remote-capture-browser",
+  summary: "Expose a remote workspace URL and capture local browser evidence for it.",
+  usage: "pnpm agent:queue:remote-capture-browser -- --issue <number> --port 3000 --yes",
+  options: [
+    ["--issue <number>", "Issue number whose remote workspace should receive browser proof."],
+    ["--port <number>", "Remote HTTP port to expose through the adapter."],
+    ["--url <url>", "Already-exposed URL to capture instead of calling exposeHttp."],
+    [
+      "--workspace <reference>",
+      "Workspace reference override, for example sandbox:sprite:task-579.",
+    ],
+    ["--viewport <size>", "Single viewport as <width>x<height>. Defaults to 1440x900."],
+    ["--viewports <sizes>", "Comma-separated viewport list, for example 1440x900,390x844."],
+    [
+      "--allow-browser-issues",
+      "Allow UI evidence with console errors or failed requests after maintainer review.",
+    ],
+    ["--timeout-ms <number>", "Navigation timeout. Defaults to 30000."],
+    ["--screenshot-name <name>", "Screenshot file name. Defaults to page.png."],
+    [
+      "--wait-until <event>",
+      "Playwright navigation wait event: commit, domcontentloaded, load, or networkidle. Defaults to networkidle.",
+    ],
+    ["--publish-artifacts", "Upload captured artifacts to configured R2/S3 object storage."],
+    [
+      "--adapter-config <path>",
+      "Optional remote adapter config module. Defaults to .agents/remote-workspaces.mjs when present.",
+    ],
+    ...repositoryOptions,
+    ...mutationOptions,
+    ...projectOptions,
+  ],
+})
+
+if (!args.issue) {
+  fail("remote-capture-browser mode requires --issue <number>")
+}
+
+if (!args.url && !args.port) {
+  fail("remote-capture-browser mode requires --url or --port <number>")
+}
+
+if (args.viewport && args.viewports) {
+  fail("use either --viewport or --viewports, not both")
+}
+
+const timeoutMs = numberArg(args.timeoutMs, 30_000, "timeout-ms")
+const port = args.port ? numberArg(args.port, undefined, "port") : undefined
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
+const item = findProjectIssueItem(project.items, {
+  issueNumber: args.issue,
+  repository,
+})
+
+if (item.issue.state !== "OPEN") {
+  fail(
+    `issue #${args.issue} cannot capture browser evidence because issue state is ${item.issue.state}`,
+  )
+}
+
+const workspaceReference = args.workspace ?? item.fields.Workspace ?? item.dryRunPlan.workspace
+const descriptor = parseWorkspaceReference(workspaceReference, { repoRoot })
+if (!isRemoteWorkspaceDescriptor(descriptor)) {
+  fail(
+    `remote-capture-browser requires a remote-sandbox workspace; got ${
+      descriptor.kind === "invalid" ? descriptor.reason : descriptor.kind
+    }`,
+  )
+}
+
+const artifactPlan = remoteBrowserArtifactPlan({
+  descriptor,
+  item,
+  repoRoot,
+  workspaceReference,
+})
+
+if (!artifactPlan.safeArtifactPath) {
+  fail(`remote-capture-browser refuses artifacts outside .agent-runs: ${artifactPlan.artifactDir}`)
+}
+
+if (!args.yes) {
+  printCapturePlan({ artifactPlan, item, port, repository, url: args.url })
+  fail("remote-capture-browser exposes HTTP and writes local artifacts; rerun with --yes")
+}
+
+let captureUrl = args.url
+let exposure = null
+if (!captureUrl) {
+  const adapters = await loadAdapters({ descriptor, workspaceReference })
+  const adapter = resolveAdapter(descriptor, { adapters })
+  if (!adapter.capabilities.exposeHttp) {
+    failInspection(
+      new Error(`remote workspace provider ${descriptor.provider} cannot expose HTTP ports`),
+      { descriptor, workspaceReference },
+    )
+  }
+
+  try {
+    exposure = normalizeRemoteHttpExposure({
+      port,
+      result: await adapter.exposeHttp(port),
+    })
+    captureUrl = exposure.url
+  } catch (error) {
+    failInspection(error, { descriptor, workspaceReference })
+  }
+}
+
+const capturePlan = browserCapturePlan({
+  artifactPlan,
+  screenshotName: args.screenshotName,
+  url: captureUrl,
+  viewport: args.viewport,
+  waitUntil: args.waitUntil,
+})
+const capturePlans = args.viewports
+  ? browserCapturePlans({
+      artifactPlan,
+      screenshotName: args.screenshotName,
+      url: captureUrl,
+      viewports: args.viewports,
+      waitUntil: args.waitUntil,
+    })
+  : [capturePlan]
+
+const { chromium } = await import("playwright").catch((error) => {
+  fail(`Playwright is not available: ${error.message}`)
+})
+
+let result
+try {
+  result =
+    capturePlans.length === 1
+      ? await captureBrowserEvidence({
+          browserLauncher: chromium,
+          capturePlan: capturePlans[0],
+          timeoutMs,
+        })
+      : await captureBrowserEvidenceSet({
+          browserLauncher: chromium,
+          capturePlans,
+          timeoutMs,
+        })
+} catch (error) {
+  fail(`remote-capture-browser failed: ${error.message}`)
+}
+
+if (args.publishArtifacts) {
+  try {
+    const publisher = artifactPublisherFromEnv()
+    const publicationPlan = artifactPublicationPlan({
+      publisher,
+      reference: artifactPlan.artifactPointer,
+      repository,
+    })
+    result = {
+      ...result,
+      remoteArtifactIndex: publicationPlan.indexUrl,
+    }
+    writeBrowserEvidenceSummary(artifactPlan, result)
+    await publishArtifactDirectory({
+      directory: artifactPlan.artifactDir,
+      issueNumber: item.issue.number,
+      publisher,
+      reference: artifactPlan.artifactPointer,
+      repository,
+    })
+  } catch (error) {
+    fail(`remote-capture-browser failed to publish artifacts: ${error.message}`)
+  }
+}
+
+const issueBlockReason = browserIssueBlockReason(result.browserIssues, {
+  allowBrowserIssues: Boolean(args.allowBrowserIssues),
+  required: requiresBrowserEvidence(item),
+})
+
+console.log("agent-runner remote-capture-browser: wrote browser evidence")
+console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+console.log(`repository: ${repository}`)
+console.log(`workspace: ${workspaceReference}`)
+if (exposure) console.log(`exposed port: ${exposure.port}`)
+console.log(`url: ${captureUrl}`)
+console.log(`artifacts: ${artifactPlan.artifactDir}`)
+console.log("")
+console.log("Use this value with --ui-evidence:")
+console.log(browserEvidenceText(result))
+
+if (!requiresBrowserEvidence(item)) {
+  console.log("")
+  console.log("Note: browser evidence is not required by this issue's labels.")
+}
+
+if (issueBlockReason) {
+  fail(`${issueBlockReason}; pass --allow-browser-issues only with an accepted exception`)
+}
+
+async function loadAdapters({ descriptor, workspaceReference }) {
+  try {
+    return await loadRemoteWorkspaceAdapters({
+      configPath: args.adapterConfig,
+      repoRoot,
+    })
+  } catch (error) {
+    failInspection(error, { descriptor, workspaceReference })
+  }
+}
+
+function resolveAdapter(descriptor, { adapters }) {
+  try {
+    return resolveRemoteWorkspaceAdapter(descriptor, { adapters })
+  } catch (error) {
+    failInspection(error, { descriptor, workspaceReference })
+  }
+}
+
+function failInspection(error, { descriptor, workspaceReference }) {
+  const message = error instanceof Error ? error.message : String(error)
+  fail(
+    `${message}; workspace=${workspaceReference}; provider=${
+      descriptor.kind === "remote-sandbox" ? descriptor.provider : "unknown"
+    }`,
+  )
+}
+
+function printCapturePlan({ artifactPlan, item, port, repository, url }) {
+  console.log("agent-runner remote-capture-browser would capture:")
+  console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+  console.log(`repository: ${repository}`)
+  console.log(`workspace: ${artifactPlan.workspaceReference}`)
+  console.log(`url: ${url ?? `<expose port ${port}>`}`)
+  console.log(`artifacts: ${artifactPlan.artifactDir}`)
+  if (args.publishArtifacts) {
+    console.log("remote artifacts: configured object storage")
+  }
+}
+
+function numberArg(value, fallback, name) {
+  if (value === undefined) return fallback
+
+  const number = Number(value)
+  if (!Number.isInteger(number) || number < 1) {
+    fail(`invalid ${name}: ${value}`)
+  }
+  return number
+}

--- a/scripts/lib/agent-runner-remote-browser.mjs
+++ b/scripts/lib/agent-runner-remote-browser.mjs
@@ -1,0 +1,75 @@
+import path from "node:path"
+
+import { isRemoteWorkspaceDescriptor } from "./agent-runner-workspace-contract.mjs"
+
+export function remoteBrowserArtifactPlan({
+  date = new Date(),
+  descriptor,
+  item,
+  repoRoot,
+  workspaceReference,
+}) {
+  if (!isRemoteWorkspaceDescriptor(descriptor)) {
+    throw new Error(
+      `remote browser capture requires a remote-sandbox reference; got ${
+        descriptor?.kind ?? "unknown"
+      }`,
+    )
+  }
+
+  const slug = slugFromTitle(item.issue.title)
+  const timestamp = date.toISOString().replace(/[:.]/g, "-")
+  const artifactPointer = path.posix.join(
+    ".agent-runs",
+    "remote-browser",
+    `${item.issue.number}-${slug}`,
+    timestamp,
+  )
+  const workspace = path.resolve(repoRoot)
+  const artifactDir = path.resolve(workspace, artifactPointer)
+  const artifactRoot = path.resolve(workspace, ".agent-runs")
+
+  return {
+    artifactDir,
+    artifactPointer,
+    consoleLog: path.join(artifactDir, "console.jsonl"),
+    networkLog: path.join(artifactDir, "network.jsonl"),
+    readme: path.join(artifactDir, "README.md"),
+    safeArtifactPath: isPathInside(artifactDir, artifactRoot),
+    screenshotDir: path.join(artifactDir, "screenshots"),
+    summaryJson: path.join(artifactDir, "summary.json"),
+    videoDir: path.join(artifactDir, "videos"),
+    workspace,
+    workspaceReference,
+  }
+}
+
+export function normalizeRemoteHttpExposure({ port, result }) {
+  const url = typeof result === "string" ? result : result?.url
+  if (!url || !/^https?:\/\//.test(url)) {
+    throw new Error(`remote HTTP exposure for port ${port} did not return a URL`)
+  }
+
+  return {
+    ...((result && typeof result === "object" && !Array.isArray(result) && result) || {}),
+    port,
+    url,
+  }
+}
+
+function isPathInside(candidatePath, parentPath) {
+  const relative = path.relative(parentPath, candidatePath)
+  return Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative)
+}
+
+function slugFromTitle(title) {
+  const slug = title
+    .toLowerCase()
+    .replace(/^\[(task|bug|refactor|investigation|cleanup)\]\s*:?\s*/i, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60)
+    .replace(/-+$/g, "")
+
+  return slug || "agent-task"
+}

--- a/scripts/tests/agent-runner-remote-browser.test.mjs
+++ b/scripts/tests/agent-runner-remote-browser.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import {
+  normalizeRemoteHttpExposure,
+  remoteBrowserArtifactPlan,
+} from "../lib/agent-runner-remote-browser.mjs"
+import { parseWorkspaceReference } from "../lib/agent-runner-workspace-contract.mjs"
+import { workItem } from "./agent-fixtures.mjs"
+
+describe("agent runner remote browser helpers", () => {
+  it("plans ignored local browser artifacts for a remote workspace", () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+    const plan = remoteBrowserArtifactPlan({
+      date: new Date("2026-05-11T12:34:56.000Z"),
+      descriptor,
+      item: workItem(),
+      repoRoot: "/repo",
+      workspaceReference: descriptor.reference,
+    })
+
+    assert.equal(plan.workspace, "/repo")
+    assert.equal(
+      plan.artifactPointer,
+      ".agent-runs/remote-browser/579-test-agent-project-intake-workflow/2026-05-11T12-34-56-000Z",
+    )
+    assert.equal(
+      plan.summaryJson,
+      "/repo/.agent-runs/remote-browser/579-test-agent-project-intake-workflow/2026-05-11T12-34-56-000Z/summary.json",
+    )
+    assert.equal(plan.safeArtifactPath, true)
+    assert.equal(plan.workspaceReference, "sandbox:sprite:task-579")
+  })
+
+  it("normalizes remote HTTP exposure adapter results", () => {
+    assert.deepEqual(normalizeRemoteHttpExposure({ port: 3000, result: "https://preview.test" }), {
+      port: 3000,
+      url: "https://preview.test",
+    })
+    assert.deepEqual(
+      normalizeRemoteHttpExposure({
+        port: 3000,
+        result: { tunnel: "abc", url: "https://preview.test" },
+      }),
+      {
+        port: 3000,
+        tunnel: "abc",
+        url: "https://preview.test",
+      },
+    )
+    assert.throws(
+      () => normalizeRemoteHttpExposure({ port: 3000, result: { url: "ftp://preview.test" } }),
+      /did not return a URL/,
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Add remote-capture-browser to expose a remote workspace port through the adapter or capture an already exposed URL with local Playwright.
- Store remote browser artifacts under local .agent-runs and optionally publish screenshots, videos, logs, summaries, and artifact indexes to configured object storage.
- Document the remote browser evidence flow and add focused helper coverage for artifact planning and HTTP exposure normalization.

## Verification
- pnpm exec biome check scripts/agent-runner-remote-capture-browser.mjs scripts/lib/agent-runner-remote-browser.mjs scripts/tests/agent-runner-remote-browser.test.mjs docs/agents/issue-tracker.md docs/architecture/agentic-engineering-orchestration.md package.json
- pnpm agent:queue:test
- pnpm agent:queue:remote-capture-browser -- --help
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- git diff --check
- commit/push hooks: full cached lint, typecheck, and test