### PR TITLE
feat(agent-runner): manage remote workspace processes

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -185,6 +185,24 @@ packet under `docs/agent-evidence/active/`, then moves the item to
 branches, expose HTTP, capture browser artifacts, publish evidence, open PRs,
 or clean up the remote workspace.
 
+Use a named remote process when a UI verification flow needs a long-running
+server before browser capture:
+
+```bash
+pnpm agent:queue:remote-start-process -- --issue <number> --name dev-server --command "pnpm dev" --port 3000 --yes
+pnpm agent:queue:remote-capture-browser -- --issue <number> --port 3000 --yes
+pnpm agent:queue:remote-stop-process -- --issue <number> --name dev-server --yes
+```
+
+Remote-start-process mode runs through the adapter's command execution
+capability and stores process metadata, the command, the PID, and logs under
+remote `.agent-runs/remote-processes/<name>/`. It refuses to replace an already
+running process with the same name, waits briefly, then fails with the remote
+log tail if startup exits early. Remote-stop-process mode is idempotent: stale
+or missing PID files are treated as already stopped, while live processes get a
+graceful terminate before a forced kill. These commands do not mutate Project
+state; use them as setup and teardown around browser evidence capture.
+
 For UI work in a remote workspace, expose the running remote dev server and
 capture browser evidence from the local runner:
 

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1199,8 +1199,12 @@ branch through the configured adapter, create or reuse a GitHub PR from the
 local token, and update the Project `PR` field. `agent:queue:remote-capture-browser`
 can call adapter-owned HTTP exposure for a remote port, capture that URL through
 local Playwright, store local ignored browser artifacts, and optionally publish
-the artifact directory to configured R2-compatible storage. Long-running remote
-process management remains a future slice.
+the artifact directory to configured R2-compatible storage.
+`agent:queue:remote-start-process` and `agent:queue:remote-stop-process` can
+manage named long-running processes through adapter command execution, storing
+remote PID, command, log, and metadata files for browser-capture setup and
+teardown. Adapter-native process streaming and richer lifecycle supervision
+remain future slices.
 
 Verification:
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "agent:queue:remote-capture-browser": "node scripts/agent-runner-remote-capture-browser.mjs",
     "agent:queue:remote-open-pr": "node scripts/agent-runner-remote-open-pr.mjs",
     "agent:queue:remote-run-command": "node scripts/agent-runner-remote-run-command.mjs",
+    "agent:queue:remote-start-process": "node scripts/agent-runner-remote-start-process.mjs",
+    "agent:queue:remote-stop-process": "node scripts/agent-runner-remote-stop-process.mjs",
     "agent:queue:prepare": "node scripts/agent-runner-prepare.mjs",
     "agent:queue:start": "node scripts/agent-runner-start.mjs",
     "agent:queue:run-command": "node scripts/agent-runner-run-command.mjs",

--- a/scripts/agent-runner-remote-start-process.mjs
+++ b/scripts/agent-runner-remote-start-process.mjs
@@ -1,0 +1,257 @@
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  findProjectIssueItem,
+  loadAllEvaluatedProject,
+  parseArgs,
+  projectScanConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+import {
+  maybePrintHelp,
+  mutationOptions,
+  projectOptions,
+  repositoryOptions,
+} from "./lib/agent-runner-help.mjs"
+import { remoteWriteFileShell } from "./lib/agent-runner-remote-execution.mjs"
+import {
+  remoteProcessMetadata,
+  remoteProcessPlan,
+  remoteStartProcessShell,
+} from "./lib/agent-runner-remote-process.mjs"
+import {
+  loadRemoteWorkspaceAdapters,
+  resolveRemoteWorkspaceAdapter,
+} from "./lib/agent-runner-remote-workspace.mjs"
+import {
+  isRemoteWorkspaceDescriptor,
+  parseWorkspaceReference,
+} from "./lib/agent-runner-workspace-contract.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:remote-start-process",
+  summary: "Start a named long-running process inside a remote workspace.",
+  usage:
+    'pnpm agent:queue:remote-start-process -- --issue <number> --name dev-server --command "pnpm dev" --port 3000 --yes',
+  options: [
+    ["--issue <number>", "Issue number whose remote workspace owns the process."],
+    ["--command <shell>", "Long-running shell command to start."],
+    ["--name <name>", "Stable process name. Defaults from the issue."],
+    ["--port <number>", "Optional HTTP port the process serves."],
+    [
+      "--workspace <reference>",
+      "Workspace reference override, for example sandbox:sprite:task-579.",
+    ],
+    ["--remote-dir <path>", "Remote repository directory."],
+    ["--verify-after <seconds>", "Seconds to wait before checking the process. Defaults to 2."],
+    [
+      "--adapter-config <path>",
+      "Optional remote adapter config module. Defaults to .agents/remote-workspaces.mjs when present.",
+    ],
+    ["--json", "Print machine-readable JSON."],
+    ...repositoryOptions,
+    ...mutationOptions,
+    ...projectOptions,
+  ],
+})
+
+if (!args.issue) {
+  fail("remote-start-process mode requires --issue <number>")
+}
+
+if (!args.command) {
+  fail("remote-start-process mode requires --command <shell>")
+}
+
+if (!args.yes) {
+  fail("remote-start-process requires --yes because it starts a remote process")
+}
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
+const item = findProjectIssueItem(project.items, {
+  issueNumber: args.issue,
+  repository,
+})
+
+if (item.issue.state !== "OPEN") {
+  fail(`issue #${args.issue} cannot start a process because issue state is ${item.issue.state}`)
+}
+
+const workspaceReference = args.workspace ?? item.fields.Workspace ?? item.dryRunPlan.workspace
+const descriptor = parseWorkspaceReference(workspaceReference, { repoRoot })
+if (!isRemoteWorkspaceDescriptor(descriptor)) {
+  fail(
+    `remote-start-process requires a remote-sandbox workspace; got ${
+      descriptor.kind === "invalid" ? descriptor.reason : descriptor.kind
+    }`,
+  )
+}
+
+const plan = remoteProcessPlan({
+  descriptor,
+  item,
+  name: args.name,
+  port: args.port ? numberArg(args.port, "port") : undefined,
+  remoteDir: args.remoteDir,
+  workspaceReference,
+})
+const adapters = await loadAdapters({ descriptor, workspaceReference })
+const adapter = resolveAdapter(descriptor, { adapters })
+if (!adapter.capabilities.exec) {
+  failInspection(
+    new Error(`remote workspace provider ${descriptor.provider} cannot exec commands`),
+    {
+      descriptor,
+      workspaceReference,
+    },
+  )
+}
+
+const startResult = await runRemoteExec({
+  adapter,
+  args: [
+    "-lc",
+    remoteStartProcessShell({
+      command: args.command,
+      plan,
+      verifyAfterSeconds: numberArg(args.verifyAfter, "verify-after", 2),
+    }),
+  ],
+  command: "bash",
+  cwd: plan.workspace,
+  httpPost: true,
+})
+
+if (startResult.status !== 0) {
+  failInspection(
+    new Error(
+      startResult.stderr?.trim() || `remote process start exited with ${startResult.status}`,
+    ),
+    { descriptor, workspaceReference },
+  )
+}
+
+const metadata = remoteProcessMetadata({
+  command: args.command,
+  item,
+  plan,
+  repository,
+})
+const metadataWrite = await runRemoteExec({
+  adapter,
+  args: [
+    "-lc",
+    remoteWriteFileShell({
+      content: `${JSON.stringify(metadata, null, 2)}\n`,
+      file: plan.metadataFile,
+    }),
+  ],
+  command: "bash",
+  cwd: plan.workspace,
+  httpPost: true,
+})
+
+if (metadataWrite.status !== 0) {
+  failInspection(
+    new Error(
+      metadataWrite.stderr?.trim() ||
+        `remote process metadata write exited with ${metadataWrite.status}`,
+    ),
+    { descriptor, workspaceReference },
+  )
+}
+
+if (args.json) {
+  console.log(
+    JSON.stringify(
+      {
+        issue: item.issue,
+        metadata,
+        metadataWrite,
+        repository,
+        startResult,
+      },
+      null,
+      2,
+    ),
+  )
+} else {
+  if (startResult.stdout) console.log(startResult.stdout)
+  if (startResult.stderr) console.error(startResult.stderr)
+  console.log("agent-runner remote-start-process: process started")
+  console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+  console.log(`repository: ${repository}`)
+  console.log(`workspace: ${workspaceReference}`)
+  console.log(`remote dir: ${plan.workspace}`)
+  console.log(`process: ${plan.processName}`)
+  console.log(`metadata: ${plan.metadataFile}`)
+  console.log(`log: ${plan.logFile}`)
+  if (plan.port) console.log(`port: ${plan.port}`)
+}
+
+async function loadAdapters({ descriptor, workspaceReference }) {
+  try {
+    return await loadRemoteWorkspaceAdapters({
+      configPath: args.adapterConfig,
+      repoRoot,
+    })
+  } catch (error) {
+    failInspection(error, { descriptor, workspaceReference })
+  }
+}
+
+function resolveAdapter(descriptor, { adapters }) {
+  try {
+    return resolveRemoteWorkspaceAdapter(descriptor, { adapters })
+  } catch (error) {
+    failInspection(error, { descriptor, workspaceReference })
+  }
+}
+
+async function runRemoteExec({ adapter, ...command }) {
+  try {
+    return await adapter.exec(command)
+  } catch (error) {
+    return {
+      status: 1,
+      stderr: error instanceof Error ? error.message : String(error),
+      stdout: "",
+    }
+  }
+}
+
+function failInspection(error, { descriptor, workspaceReference }) {
+  const message = error instanceof Error ? error.message : String(error)
+  if (args.json) {
+    console.log(
+      JSON.stringify(
+        {
+          error: message,
+          repository,
+          workspace: {
+            descriptor,
+            reference: workspaceReference,
+          },
+        },
+        null,
+        2,
+      ),
+    )
+    process.exit(1)
+  }
+
+  fail(message)
+}
+
+function numberArg(value, name, fallback) {
+  if (value === undefined) return fallback
+
+  const number = Number(value)
+  if (!Number.isInteger(number) || number < 1) {
+    fail(`invalid ${name}: ${value}`)
+  }
+  return number
+}

--- a/scripts/agent-runner-remote-stop-process.mjs
+++ b/scripts/agent-runner-remote-stop-process.mjs
@@ -1,0 +1,202 @@
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  findProjectIssueItem,
+  loadAllEvaluatedProject,
+  parseArgs,
+  projectScanConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+import {
+  maybePrintHelp,
+  mutationOptions,
+  projectOptions,
+  repositoryOptions,
+} from "./lib/agent-runner-help.mjs"
+import { remoteProcessPlan, remoteStopProcessShell } from "./lib/agent-runner-remote-process.mjs"
+import {
+  loadRemoteWorkspaceAdapters,
+  resolveRemoteWorkspaceAdapter,
+} from "./lib/agent-runner-remote-workspace.mjs"
+import {
+  isRemoteWorkspaceDescriptor,
+  parseWorkspaceReference,
+} from "./lib/agent-runner-workspace-contract.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:remote-stop-process",
+  summary: "Stop a named long-running process inside a remote workspace.",
+  usage: "pnpm agent:queue:remote-stop-process -- --issue <number> --name dev-server --yes",
+  options: [
+    ["--issue <number>", "Issue number whose remote workspace owns the process."],
+    ["--name <name>", "Stable process name. Defaults from the issue."],
+    [
+      "--workspace <reference>",
+      "Workspace reference override, for example sandbox:sprite:task-579.",
+    ],
+    ["--remote-dir <path>", "Remote repository directory."],
+    ["--grace-seconds <seconds>", "Seconds to wait before SIGKILL. Defaults to 10."],
+    [
+      "--adapter-config <path>",
+      "Optional remote adapter config module. Defaults to .agents/remote-workspaces.mjs when present.",
+    ],
+    ["--json", "Print machine-readable JSON."],
+    ...repositoryOptions,
+    ...mutationOptions,
+    ...projectOptions,
+  ],
+})
+
+if (!args.issue) {
+  fail("remote-stop-process mode requires --issue <number>")
+}
+
+if (!args.yes) {
+  fail("remote-stop-process requires --yes because it stops a remote process")
+}
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
+const item = findProjectIssueItem(project.items, {
+  issueNumber: args.issue,
+  repository,
+})
+const workspaceReference = args.workspace ?? item.fields.Workspace ?? item.dryRunPlan.workspace
+const descriptor = parseWorkspaceReference(workspaceReference, { repoRoot })
+if (!isRemoteWorkspaceDescriptor(descriptor)) {
+  fail(
+    `remote-stop-process requires a remote-sandbox workspace; got ${
+      descriptor.kind === "invalid" ? descriptor.reason : descriptor.kind
+    }`,
+  )
+}
+
+const plan = remoteProcessPlan({
+  descriptor,
+  item,
+  name: args.name,
+  remoteDir: args.remoteDir,
+  workspaceReference,
+})
+const adapters = await loadAdapters({ descriptor, workspaceReference })
+const adapter = resolveAdapter(descriptor, { adapters })
+if (!adapter.capabilities.exec) {
+  failInspection(
+    new Error(`remote workspace provider ${descriptor.provider} cannot exec commands`),
+    {
+      descriptor,
+      workspaceReference,
+    },
+  )
+}
+
+const stopResult = await runRemoteExec({
+  adapter,
+  args: [
+    "-lc",
+    remoteStopProcessShell({
+      graceSeconds: numberArg(args.graceSeconds, "grace-seconds", 10),
+      plan,
+    }),
+  ],
+  command: "bash",
+  cwd: plan.workspace,
+  httpPost: true,
+})
+
+if (stopResult.status !== 0) {
+  failInspection(
+    new Error(stopResult.stderr?.trim() || `remote process stop exited with ${stopResult.status}`),
+    { descriptor, workspaceReference },
+  )
+}
+
+if (args.json) {
+  console.log(
+    JSON.stringify(
+      {
+        issue: item.issue,
+        plan,
+        repository,
+        stopResult,
+      },
+      null,
+      2,
+    ),
+  )
+} else {
+  if (stopResult.stdout) console.log(stopResult.stdout)
+  if (stopResult.stderr) console.error(stopResult.stderr)
+  console.log("agent-runner remote-stop-process: process stopped or already absent")
+  console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+  console.log(`repository: ${repository}`)
+  console.log(`workspace: ${workspaceReference}`)
+  console.log(`remote dir: ${plan.workspace}`)
+  console.log(`process: ${plan.processName}`)
+}
+
+async function loadAdapters({ descriptor, workspaceReference }) {
+  try {
+    return await loadRemoteWorkspaceAdapters({
+      configPath: args.adapterConfig,
+      repoRoot,
+    })
+  } catch (error) {
+    failInspection(error, { descriptor, workspaceReference })
+  }
+}
+
+function resolveAdapter(descriptor, { adapters }) {
+  try {
+    return resolveRemoteWorkspaceAdapter(descriptor, { adapters })
+  } catch (error) {
+    failInspection(error, { descriptor, workspaceReference })
+  }
+}
+
+async function runRemoteExec({ adapter, ...command }) {
+  try {
+    return await adapter.exec(command)
+  } catch (error) {
+    return {
+      status: 1,
+      stderr: error instanceof Error ? error.message : String(error),
+      stdout: "",
+    }
+  }
+}
+
+function failInspection(error, { descriptor, workspaceReference }) {
+  const message = error instanceof Error ? error.message : String(error)
+  if (args.json) {
+    console.log(
+      JSON.stringify(
+        {
+          error: message,
+          repository,
+          workspace: {
+            descriptor,
+            reference: workspaceReference,
+          },
+        },
+        null,
+        2,
+      ),
+    )
+    process.exit(1)
+  }
+
+  fail(message)
+}
+
+function numberArg(value, name, fallback) {
+  if (value === undefined) return fallback
+
+  const number = Number(value)
+  if (!Number.isInteger(number) || number < 1) {
+    fail(`invalid ${name}: ${value}`)
+  }
+  return number
+}

--- a/scripts/lib/agent-runner-remote-process.mjs
+++ b/scripts/lib/agent-runner-remote-process.mjs
@@ -1,0 +1,203 @@
+import path from "node:path"
+
+import { defaultRemoteWorkspaceRepoDir } from "./agent-runner-remote-bootstrap.mjs"
+import { isRemoteWorkspaceDescriptor } from "./agent-runner-workspace-contract.mjs"
+
+export function remoteProcessPlan({
+  descriptor,
+  item,
+  name,
+  port,
+  remoteDir,
+  workspaceReference,
+} = {}) {
+  if (!isRemoteWorkspaceDescriptor(descriptor)) {
+    throw new Error(
+      `remote process requires a remote-sandbox reference; got ${descriptor?.kind ?? "unknown"}`,
+    )
+  }
+
+  const processName = safeProcessName(
+    name ??
+      `${item?.issue?.number ?? "task"}-${slugFromTitle(item?.issue?.title ?? "remote-process")}`,
+  )
+  const processPort = port === undefined ? undefined : Number(port)
+  if (processPort !== undefined) {
+    assertPositiveInteger("port", processPort)
+  }
+
+  const workspace = remoteDir ?? defaultRemoteWorkspaceRepoDir(descriptor)
+  assertShellValue("remote directory", workspace)
+
+  const processDir = path.posix.join(workspace, ".agent-runs", "remote-processes", processName)
+  const metadataFile = path.posix.join(processDir, "process.json")
+
+  return {
+    commandFile: path.posix.join(processDir, "command.sh"),
+    logFile: path.posix.join(processDir, "process.log"),
+    metadataFile,
+    metadataPointer: path.posix.relative(workspace, metadataFile),
+    processGroupFile: path.posix.join(processDir, "process.pgid"),
+    pidFile: path.posix.join(processDir, "process.pid"),
+    port: processPort,
+    processDir,
+    processName,
+    workspace,
+    workspaceReference,
+  }
+}
+
+export function remoteStartProcessShell({ command, plan, verifyAfterSeconds = 2 }) {
+  assertShellValue("command", command)
+  assertPositiveInteger("verifyAfterSeconds", verifyAfterSeconds)
+
+  return `set -euo pipefail
+process_dir=${shellQuote(plan.processDir)}
+pid_file=${shellQuote(plan.pidFile)}
+process_group_file=${shellQuote(plan.processGroupFile)}
+log_file=${shellQuote(plan.logFile)}
+command_file=${shellQuote(plan.commandFile)}
+encoded_command=${shellQuote(Buffer.from(command, "utf8").toString("base64"))}
+verify_after=${shellQuote(String(verifyAfterSeconds))}
+
+mkdir -p "$process_dir"
+if [ -f "$pid_file" ] && kill -0 "$(cat "$pid_file")" 2>/dev/null; then
+  echo "remote process already running: $(cat "$pid_file")" >&2
+  exit 1
+fi
+rm -f "$pid_file" "$process_group_file"
+
+printf '%s' "$encoded_command" | base64 -d > "$command_file"
+chmod +x "$command_file"
+: > "$log_file"
+if command -v setsid >/dev/null 2>&1; then
+  nohup setsid bash "$command_file" >> "$log_file" 2>&1 < /dev/null &
+  printf '1\\n' > "$process_group_file"
+else
+  nohup bash "$command_file" >> "$log_file" 2>&1 < /dev/null &
+  printf '0\\n' > "$process_group_file"
+fi
+pid=$!
+printf '%s\\n' "$pid" > "$pid_file"
+sleep "$verify_after"
+
+if ! kill -0 "$pid" 2>/dev/null; then
+  rm -f "$pid_file" "$process_group_file"
+  echo "remote process exited during startup: $pid" >&2
+  tail -n 80 "$log_file" >&2 || true
+  exit 1
+fi
+
+echo "remote process started: $pid"
+echo "pid file: $pid_file"
+echo "log file: $log_file"`
+}
+
+export function remoteStopProcessShell({ graceSeconds = 10, plan }) {
+  assertPositiveInteger("graceSeconds", graceSeconds)
+
+  return `set -euo pipefail
+pid_file=${shellQuote(plan.pidFile)}
+process_group_file=${shellQuote(plan.processGroupFile)}
+log_file=${shellQuote(plan.logFile)}
+grace_seconds=${shellQuote(String(graceSeconds))}
+
+if [ ! -f "$pid_file" ]; then
+  echo "remote process is not running: missing pid file"
+  exit 0
+fi
+
+pid="$(cat "$pid_file")"
+if ! kill -0 "$pid" 2>/dev/null; then
+  rm -f "$pid_file" "$process_group_file"
+  echo "remote process is not running: stale pid $pid"
+  exit 0
+fi
+
+target="$pid"
+if [ -f "$process_group_file" ] && [ "$(cat "$process_group_file")" = "1" ]; then
+  target="-$pid"
+fi
+
+kill -- "$target" 2>/dev/null || kill "$pid" 2>/dev/null || true
+deadline=$((SECONDS + grace_seconds))
+while kill -0 "$pid" 2>/dev/null && [ "$SECONDS" -lt "$deadline" ]; do
+  sleep 1
+done
+
+if kill -0 "$pid" 2>/dev/null; then
+  kill -KILL -- "$target" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true
+fi
+
+rm -f "$pid_file" "$process_group_file"
+echo "remote process stopped: $pid"
+if [ -f "$log_file" ]; then
+  echo "log file: $log_file"
+fi`
+}
+
+export function remoteProcessMetadata({ command, date = new Date(), item, plan, repository }) {
+  return {
+    command,
+    createdAt: date.toISOString(),
+    issue: item?.issue
+      ? {
+          number: item.issue.number,
+          title: item.issue.title,
+          url: item.issue.url,
+        }
+      : null,
+    logFile: plan.logFile,
+    metadataFile: plan.metadataFile,
+    pidFile: plan.pidFile,
+    processGroupFile: plan.processGroupFile,
+    port: plan.port ?? null,
+    processName: plan.processName,
+    repository,
+    workspace: plan.workspace,
+    workspaceReference: plan.workspaceReference,
+  }
+}
+
+function safeProcessName(value) {
+  const normalized = String(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80)
+    .replace(/-+$/g, "")
+
+  if (!normalized) {
+    throw new Error("remote process name is empty")
+  }
+
+  return normalized
+}
+
+function slugFromTitle(title) {
+  const slug = title
+    .toLowerCase()
+    .replace(/^\[(task|bug|refactor|investigation|cleanup)\]\s*:?\s*/i, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 50)
+    .replace(/-+$/g, "")
+
+  return slug || "remote-process"
+}
+
+function assertPositiveInteger(name, value) {
+  if (!Number.isInteger(Number(value)) || Number(value) < 1) {
+    throw new Error(`invalid remote process ${name}: ${String(value)}`)
+  }
+}
+
+function assertShellValue(name, value) {
+  if (typeof value !== "string" || value.trim().length === 0 || /[\0\r\n]/.test(value)) {
+    throw new Error(`invalid remote process ${name}: ${String(value)}`)
+  }
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`
+}

--- a/scripts/tests/agent-runner-remote-process.test.mjs
+++ b/scripts/tests/agent-runner-remote-process.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import {
+  remoteProcessMetadata,
+  remoteProcessPlan,
+  remoteStartProcessShell,
+  remoteStopProcessShell,
+} from "../lib/agent-runner-remote-process.mjs"
+import { parseWorkspaceReference } from "../lib/agent-runner-workspace-contract.mjs"
+import { workItem } from "./agent-fixtures.mjs"
+
+describe("agent runner remote process helpers", () => {
+  it("plans named process files inside the remote repository", () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+    const plan = remoteProcessPlan({
+      descriptor,
+      item: workItem(),
+      port: 3000,
+      workspaceReference: descriptor.reference,
+    })
+
+    assert.equal(plan.workspace, "/home/sprite/voyant-workspaces/task-579/repo")
+    assert.equal(plan.processName, "579-test-agent-project-intake-workflow")
+    assert.equal(
+      plan.metadataPointer,
+      ".agent-runs/remote-processes/579-test-agent-project-intake-workflow/process.json",
+    )
+    assert.equal(
+      plan.pidFile,
+      "/home/sprite/voyant-workspaces/task-579/repo/.agent-runs/remote-processes/579-test-agent-project-intake-workflow/process.pid",
+    )
+    assert.equal(
+      plan.processGroupFile,
+      "/home/sprite/voyant-workspaces/task-579/repo/.agent-runs/remote-processes/579-test-agent-project-intake-workflow/process.pgid",
+    )
+    assert.equal(plan.port, 3000)
+  })
+
+  it("builds a remote start shell with duplicate detection and startup verification", () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+    const plan = remoteProcessPlan({
+      descriptor,
+      item: workItem(),
+      name: "dev server",
+      workspaceReference: descriptor.reference,
+    })
+    const shell = remoteStartProcessShell({
+      command: "pnpm dev",
+      plan,
+      verifyAfterSeconds: 3,
+    })
+
+    assert.match(shell, /remote process already running/)
+    assert.match(shell, /cG5wbSBkZXY=/)
+    assert.match(shell, /command -v setsid/)
+    assert.match(shell, /nohup setsid bash "\$command_file"/)
+    assert.match(shell, /kill -0 "\$pid"/)
+    assert.match(shell, /tail -n 80 "\$log_file"/)
+    assert.match(shell, /verify_after='3'/)
+  })
+
+  it("builds an idempotent remote stop shell", () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+    const plan = remoteProcessPlan({
+      descriptor,
+      item: workItem(),
+      name: "dev-server",
+      workspaceReference: descriptor.reference,
+    })
+    const shell = remoteStopProcessShell({ graceSeconds: 7, plan })
+
+    assert.match(shell, /missing pid file/)
+    assert.match(shell, /stale pid/)
+    assert.match(shell, /target="-\$pid"/)
+    assert.match(shell, /kill -- "\$target"/)
+    assert.match(shell, /kill -KILL -- "\$target"/)
+    assert.match(shell, /grace_seconds='7'/)
+  })
+
+  it("serializes process metadata for evidence and follow-up commands", () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+    const plan = remoteProcessPlan({
+      descriptor,
+      item: workItem(),
+      name: "dev-server",
+      port: 3000,
+      workspaceReference: descriptor.reference,
+    })
+
+    assert.deepEqual(
+      remoteProcessMetadata({
+        command: "pnpm dev",
+        date: new Date("2026-05-12T10:30:00.000Z"),
+        item: workItem(),
+        plan,
+        repository: "voyantjs/voyant",
+      }),
+      {
+        command: "pnpm dev",
+        createdAt: "2026-05-12T10:30:00.000Z",
+        issue: {
+          number: 579,
+          title: "Test agent project intake workflow",
+          url: "https://github.com/voyantjs/voyant/issues/579",
+        },
+        logFile:
+          "/home/sprite/voyant-workspaces/task-579/repo/.agent-runs/remote-processes/dev-server/process.log",
+        metadataFile:
+          "/home/sprite/voyant-workspaces/task-579/repo/.agent-runs/remote-processes/dev-server/process.json",
+        pidFile:
+          "/home/sprite/voyant-workspaces/task-579/repo/.agent-runs/remote-processes/dev-server/process.pid",
+        port: 3000,
+        processGroupFile:
+          "/home/sprite/voyant-workspaces/task-579/repo/.agent-runs/remote-processes/dev-server/process.pgid",
+        processName: "dev-server",
+        repository: "voyantjs/voyant",
+        workspace: "/home/sprite/voyant-workspaces/task-579/repo",
+        workspaceReference: "sandbox:sprite:task-579",
+      },
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add remote start/stop process commands for named long-running services in remote workspaces
- store remote command, PID, process group, log, and metadata files under `.agent-runs/remote-processes/<name>/`
- document the remote UI evidence flow around start, browser capture, and stop

## Verification
- `pnpm agent:queue:test`
- `pnpm agent:queue:remote-start-process -- --help`
- `pnpm agent:queue:remote-stop-process -- --help`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- pre-commit hook: formatting, secretlint, agent-quality, affected typecheck
- pre-push hook: package tests (cached)