### PR TITLE
feat(agent-runner): manage remote browser dev servers

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -189,19 +189,30 @@ Use a named remote process when a UI verification flow needs a long-running
 server before browser capture:
 
 ```bash
+pnpm agent:queue:remote-capture-browser -- --issue <number> --dev-server-command "pnpm dev" --port 3000 --yes
+```
+
+With `--dev-server-command`, remote-capture-browser starts a named remote
+process, exposes the requested port, captures browser evidence from the local
+runner, then stops the process even when capture fails. It stores process
+metadata, the command, the PID, process-group marker, and logs under remote
+`.agent-runs/remote-processes/<name>/`. It refuses to replace an already
+running process with the same name, waits briefly, then fails with the remote
+log tail if startup exits early.
+
+For manual debugging, use the standalone process commands around browser
+capture:
+
+```bash
 pnpm agent:queue:remote-start-process -- --issue <number> --name dev-server --command "pnpm dev" --port 3000 --yes
 pnpm agent:queue:remote-capture-browser -- --issue <number> --port 3000 --yes
 pnpm agent:queue:remote-stop-process -- --issue <number> --name dev-server --yes
 ```
 
-Remote-start-process mode runs through the adapter's command execution
-capability and stores process metadata, the command, the PID, and logs under
-remote `.agent-runs/remote-processes/<name>/`. It refuses to replace an already
-running process with the same name, waits briefly, then fails with the remote
-log tail if startup exits early. Remote-stop-process mode is idempotent: stale
-or missing PID files are treated as already stopped, while live processes get a
-graceful terminate before a forced kill. These commands do not mutate Project
-state; use them as setup and teardown around browser evidence capture.
+Remote-stop-process mode is idempotent: stale or missing PID files are treated
+as already stopped, while live processes get a graceful terminate before a
+forced kill. These process commands do not mutate Project state; use them as
+setup and teardown around browser evidence capture.
 
 For UI work in a remote workspace, expose the running remote dev server and
 capture browser evidence from the local runner:
@@ -214,12 +225,15 @@ pnpm agent:queue:remote-capture-browser -- --issue <number> --url "https://previ
 Remote-capture-browser mode requires a `sandbox:<provider>:<id>` workspace. With
 `--port`, it calls the adapter's `exposeHttp` operation and captures the
 returned URL with Playwright. With `--url`, it skips adapter exposure and
-captures the supplied URL. Artifacts are written under local `.agent-runs/` so
-remote browser proof does not dirty the task branch; pass `--publish-artifacts`
-to upload screenshots, videos, logs, summaries, and the artifact index to
+captures the supplied URL. With `--dev-server-command`, it also requires
+adapter command execution so the runner can start and stop the remote server
+for the capture. Artifacts are written under local `.agent-runs/` so remote
+browser proof does not dirty the task branch; pass `--publish-artifacts` to
+upload screenshots, videos, logs, summaries, and the artifact index to
 configured object storage. Use the printed browser evidence text as
 `--ui-evidence` for the supervised command that writes the final evidence
-packet. Providers that do not declare `exposeHttp` fail closed.
+packet. Providers that do not declare the required adapter capabilities fail
+closed.
 
 After a successful remote command, publish the remote evidence packet to GitHub
 or configured R2-compatible object storage:

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1180,12 +1180,12 @@ now be loaded from an explicit config module via `--adapter-config`,
 unavailable unless a config supplies that provider. A conservative CLI-backed
 Sprite adapter is available for one-shot command execution once a maintainer
 enables it through adapter config. `agent:queue:remote-exec` can validate that
-path with a guarded command, but remote execution does not yet own long-running
-process management, HTTP exposure, artifact collection, cleanup, evidence
-writing, or PR creation. `agent:queue:remote-bootstrap` can now clone/fetch the
-repository, prefer an existing remote task branch, and check out the task branch
-inside a remote workspace. Ready remote-workspace items can be dispatched
-through that bootstrap path and move to `Planning` after success.
+path with a guarded command, while higher-level remote commands own bootstrap,
+execution, evidence publication, browser capture, process management, cleanup,
+and PR creation. `agent:queue:remote-bootstrap` can now clone/fetch the
+repository, prefer an existing remote task branch, and check out the task
+branch inside a remote workspace. Ready remote-workspace items can be
+dispatched through that bootstrap path and move to `Planning` after success.
 `agent:queue:remote-run-command` can run an explicit supervised command in that
 remote repository, write a remote transcript and evidence packet, and move the
 Project item to `Human Review` or `Blocked`. `agent:queue:remote-publish-evidence`
@@ -1199,7 +1199,9 @@ branch through the configured adapter, create or reuse a GitHub PR from the
 local token, and update the Project `PR` field. `agent:queue:remote-capture-browser`
 can call adapter-owned HTTP exposure for a remote port, capture that URL through
 local Playwright, store local ignored browser artifacts, and optionally publish
-the artifact directory to configured R2-compatible storage.
+the artifact directory to configured R2-compatible storage. It can also start
+and stop a named remote dev-server command around capture, so UI evidence does
+not require a manually pre-running server.
 `agent:queue:remote-start-process` and `agent:queue:remote-stop-process` can
 manage named long-running processes through adapter command execution, storing
 remote PID, command, log, and metadata files for browser-capture setup and

--- a/scripts/agent-runner-remote-capture-browser.mjs
+++ b/scripts/agent-runner-remote-capture-browser.mjs
@@ -31,7 +31,15 @@ import {
 import {
   normalizeRemoteHttpExposure,
   remoteBrowserArtifactPlan,
+  waitForRemoteHttpReady,
 } from "./lib/agent-runner-remote-browser.mjs"
+import { remoteWriteFileShell } from "./lib/agent-runner-remote-execution.mjs"
+import {
+  remoteProcessMetadata,
+  remoteProcessPlan,
+  remoteStartProcessShell,
+  remoteStopProcessShell,
+} from "./lib/agent-runner-remote-process.mjs"
 import {
   loadRemoteWorkspaceAdapters,
   resolveRemoteWorkspaceAdapter,
@@ -45,11 +53,17 @@ const args = parseArgs(process.argv.slice(2))
 maybePrintHelp(args, {
   command: "agent:queue:remote-capture-browser",
   summary: "Expose a remote workspace URL and capture local browser evidence for it.",
-  usage: "pnpm agent:queue:remote-capture-browser -- --issue <number> --port 3000 --yes",
+  usage:
+    'pnpm agent:queue:remote-capture-browser -- --issue <number> --dev-server-command "pnpm dev" --port 3000 --yes',
   options: [
     ["--issue <number>", "Issue number whose remote workspace should receive browser proof."],
     ["--port <number>", "Remote HTTP port to expose through the adapter."],
     ["--url <url>", "Already-exposed URL to capture instead of calling exposeHttp."],
+    [
+      "--dev-server-command <shell>",
+      "Optional remote command to start before capture and stop afterward.",
+    ],
+    ["--process-name <name>", "Stable remote process name. Defaults from the issue."],
     [
       "--workspace <reference>",
       "Workspace reference override, for example sandbox:sprite:task-579.",
@@ -83,6 +97,10 @@ if (!args.issue) {
 
 if (!args.url && !args.port) {
   fail("remote-capture-browser mode requires --url or --port <number>")
+}
+
+if (args.devServerCommand && !args.port) {
+  fail("remote-capture-browser mode requires --port when --dev-server-command is provided")
 }
 
 if (args.viewport && args.viewports) {
@@ -127,56 +145,90 @@ if (!artifactPlan.safeArtifactPath) {
 }
 
 if (!args.yes) {
-  printCapturePlan({ artifactPlan, item, port, repository, url: args.url })
+  printCapturePlan({
+    artifactPlan,
+    devServerCommand: args.devServerCommand,
+    item,
+    port,
+    processName: args.processName,
+    repository,
+    url: args.url,
+  })
   fail("remote-capture-browser exposes HTTP and writes local artifacts; rerun with --yes")
 }
 
 let captureUrl = args.url
 let exposure = null
+const needsAdapter = Boolean(args.devServerCommand) || !captureUrl
+const adapters = needsAdapter ? await loadAdapters({ descriptor, workspaceReference }) : null
+const adapter = adapters ? resolveAdapter(descriptor, { adapters }) : null
+
+if (args.devServerCommand && !adapter.capabilities.exec) {
+  failInspection(
+    new Error(`remote workspace provider ${descriptor.provider} cannot exec commands`),
+    { descriptor, workspaceReference },
+  )
+}
+
 if (!captureUrl) {
-  const adapters = await loadAdapters({ descriptor, workspaceReference })
-  const adapter = resolveAdapter(descriptor, { adapters })
   if (!adapter.capabilities.exposeHttp) {
     failInspection(
       new Error(`remote workspace provider ${descriptor.provider} cannot expose HTTP ports`),
       { descriptor, workspaceReference },
     )
   }
+}
 
-  try {
+const processPlan = args.devServerCommand
+  ? remoteProcessPlan({
+      descriptor,
+      item,
+      name: args.processName,
+      port,
+      workspaceReference,
+    })
+  : null
+
+let processStopResult = null
+let result
+let runError = null
+
+try {
+  if (processPlan) {
+    await startRemoteDevServer({ adapter, item, plan: processPlan, repository })
+  }
+
+  if (!captureUrl) {
     exposure = normalizeRemoteHttpExposure({
       port,
       result: await adapter.exposeHttp(port),
     })
     captureUrl = exposure.url
-  } catch (error) {
-    failInspection(error, { descriptor, workspaceReference })
   }
-}
 
-const capturePlan = browserCapturePlan({
-  artifactPlan,
-  screenshotName: args.screenshotName,
-  url: captureUrl,
-  viewport: args.viewport,
-  waitUntil: args.waitUntil,
-})
-const capturePlans = args.viewports
-  ? browserCapturePlans({
-      artifactPlan,
-      screenshotName: args.screenshotName,
-      url: captureUrl,
-      viewports: args.viewports,
-      waitUntil: args.waitUntil,
-    })
-  : [capturePlan]
+  if (processPlan) {
+    await waitForRemoteHttpReady(captureUrl, { timeoutMs })
+  }
 
-const { chromium } = await import("playwright").catch((error) => {
-  fail(`Playwright is not available: ${error.message}`)
-})
+  const capturePlan = browserCapturePlan({
+    artifactPlan,
+    screenshotName: args.screenshotName,
+    url: captureUrl,
+    viewport: args.viewport,
+    waitUntil: args.waitUntil,
+  })
+  const capturePlans = args.viewports
+    ? browserCapturePlans({
+        artifactPlan,
+        screenshotName: args.screenshotName,
+        url: captureUrl,
+        viewports: args.viewports,
+        waitUntil: args.waitUntil,
+      })
+    : [capturePlan]
 
-let result
-try {
+  const { chromium } = await import("playwright")
+
   result =
     capturePlans.length === 1
       ? await captureBrowserEvidence({
@@ -189,12 +241,8 @@ try {
           capturePlans,
           timeoutMs,
         })
-} catch (error) {
-  fail(`remote-capture-browser failed: ${error.message}`)
-}
 
-if (args.publishArtifacts) {
-  try {
+  if (args.publishArtifacts) {
     const publisher = artifactPublisherFromEnv()
     const publicationPlan = artifactPublicationPlan({
       publisher,
@@ -213,9 +261,34 @@ if (args.publishArtifacts) {
       reference: artifactPlan.artifactPointer,
       repository,
     })
-  } catch (error) {
-    fail(`remote-capture-browser failed to publish artifacts: ${error.message}`)
   }
+} catch (error) {
+  runError = error
+} finally {
+  if (processPlan) {
+    processStopResult = await stopRemoteDevServer({ adapter, plan: processPlan })
+  }
+}
+
+if (runError) {
+  const message = runError instanceof Error ? runError.message : String(runError)
+  const stopMessage =
+    processStopResult?.status && processStopResult.status !== 0
+      ? `; remote dev server stop also exited with ${
+          processStopResult.status
+        }: ${processStopResult.stderr?.trim()}`
+      : ""
+  fail(`remote-capture-browser failed: ${message}${stopMessage}`)
+}
+
+if (processStopResult?.status !== 0) {
+  failInspection(
+    new Error(
+      processStopResult.stderr?.trim() ||
+        `remote dev server stop exited with ${processStopResult.status}`,
+    ),
+    { descriptor, workspaceReference },
+  )
 }
 
 const issueBlockReason = browserIssueBlockReason(result.browserIssues, {
@@ -230,6 +303,10 @@ console.log(`workspace: ${workspaceReference}`)
 if (exposure) console.log(`exposed port: ${exposure.port}`)
 console.log(`url: ${captureUrl}`)
 console.log(`artifacts: ${artifactPlan.artifactDir}`)
+if (processPlan) {
+  console.log(`remote process: ${processPlan.processName}`)
+  console.log(`remote process log: ${processPlan.logFile}`)
+}
 console.log("")
 console.log("Use this value with --ui-evidence:")
 console.log(browserEvidenceText(result))
@@ -254,6 +331,95 @@ async function loadAdapters({ descriptor, workspaceReference }) {
   }
 }
 
+async function startRemoteDevServer({ adapter, item, plan, repository }) {
+  const startResult = await runRemoteExec({
+    adapter,
+    args: [
+      "-lc",
+      remoteStartProcessShell({
+        command: args.devServerCommand,
+        plan,
+      }),
+    ],
+    command: "bash",
+    cwd: plan.workspace,
+    httpPost: true,
+  })
+
+  if (startResult.status !== 0) {
+    failInspection(
+      new Error(
+        startResult.stderr?.trim() || `remote dev server exited with ${startResult.status}`,
+      ),
+      { descriptor, workspaceReference },
+    )
+  }
+
+  const metadata = remoteProcessMetadata({
+    command: args.devServerCommand,
+    item,
+    plan,
+    repository,
+  })
+  const metadataWrite = await runRemoteExec({
+    adapter,
+    args: [
+      "-lc",
+      remoteWriteFileShell({
+        content: `${JSON.stringify(metadata, null, 2)}\n`,
+        file: plan.metadataFile,
+      }),
+    ],
+    command: "bash",
+    cwd: plan.workspace,
+    httpPost: true,
+  })
+
+  if (metadataWrite.status !== 0) {
+    const stopResult = await stopRemoteDevServer({ adapter, plan })
+    const stopMessage =
+      stopResult.status === 0
+        ? ""
+        : `; stop also exited with ${stopResult.status}: ${stopResult.stderr?.trim()}`
+    failInspection(
+      new Error(
+        `${
+          metadataWrite.stderr?.trim() ||
+          `remote dev server metadata write exited with ${metadataWrite.status}`
+        }${stopMessage}`,
+      ),
+      { descriptor, workspaceReference },
+    )
+  }
+}
+
+async function stopRemoteDevServer({ adapter, plan }) {
+  return runRemoteExec({
+    adapter,
+    args: [
+      "-lc",
+      remoteStopProcessShell({
+        plan,
+      }),
+    ],
+    command: "bash",
+    cwd: plan.workspace,
+    httpPost: true,
+  })
+}
+
+async function runRemoteExec({ adapter, ...command }) {
+  try {
+    return await adapter.exec(command)
+  } catch (error) {
+    return {
+      status: 1,
+      stderr: error instanceof Error ? error.message : String(error),
+      stdout: "",
+    }
+  }
+}
+
 function resolveAdapter(descriptor, { adapters }) {
   try {
     return resolveRemoteWorkspaceAdapter(descriptor, { adapters })
@@ -271,13 +437,25 @@ function failInspection(error, { descriptor, workspaceReference }) {
   )
 }
 
-function printCapturePlan({ artifactPlan, item, port, repository, url }) {
+function printCapturePlan({
+  artifactPlan,
+  devServerCommand,
+  item,
+  port,
+  processName,
+  repository,
+  url,
+}) {
   console.log("agent-runner remote-capture-browser would capture:")
   console.log(`issue: #${item.issue.number} ${item.issue.title}`)
   console.log(`repository: ${repository}`)
   console.log(`workspace: ${artifactPlan.workspaceReference}`)
   console.log(`url: ${url ?? `<expose port ${port}>`}`)
   console.log(`artifacts: ${artifactPlan.artifactDir}`)
+  if (devServerCommand) {
+    console.log(`remote dev server command: ${devServerCommand}`)
+    console.log(`remote process: ${processName ?? "<issue default>"}`)
+  }
   if (args.publishArtifacts) {
     console.log("remote artifacts: configured object storage")
   }

--- a/scripts/lib/agent-runner-remote-browser.mjs
+++ b/scripts/lib/agent-runner-remote-browser.mjs
@@ -57,6 +57,28 @@ export function normalizeRemoteHttpExposure({ port, result }) {
   }
 }
 
+export async function waitForRemoteHttpReady(
+  url,
+  { fetchImpl = fetch, intervalMs = 500, timeoutMs },
+) {
+  const startedAt = Date.now()
+  let lastError
+
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const response = await fetchImpl(url, { redirect: "manual" })
+      if (response.status < 500) return
+      lastError = new Error(`HTTP ${response.status}`)
+    } catch (error) {
+      lastError = error
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+
+  throw new Error(`timed out waiting for ${url}: ${lastError?.message ?? "no response"}`)
+}
+
 function isPathInside(candidatePath, parentPath) {
   const relative = path.relative(parentPath, candidatePath)
   return Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative)

--- a/scripts/tests/agent-runner-remote-browser.test.mjs
+++ b/scripts/tests/agent-runner-remote-browser.test.mjs
@@ -4,6 +4,7 @@ import { describe, it } from "node:test"
 import {
   normalizeRemoteHttpExposure,
   remoteBrowserArtifactPlan,
+  waitForRemoteHttpReady,
 } from "../lib/agent-runner-remote-browser.mjs"
 import { parseWorkspaceReference } from "../lib/agent-runner-workspace-contract.mjs"
 import { workItem } from "./agent-fixtures.mjs"
@@ -51,6 +52,34 @@ describe("agent runner remote browser helpers", () => {
     assert.throws(
       () => normalizeRemoteHttpExposure({ port: 3000, result: { url: "ftp://preview.test" } }),
       /did not return a URL/,
+    )
+  })
+
+  it("waits until the exposed remote HTTP URL is ready", async () => {
+    let attempts = 0
+
+    await waitForRemoteHttpReady("https://preview.test", {
+      fetchImpl: async () => {
+        attempts += 1
+        return { status: attempts === 1 ? 503 : 200 }
+      },
+      intervalMs: 1,
+      timeoutMs: 100,
+    })
+
+    assert.equal(attempts, 2)
+  })
+
+  it("fails when the exposed remote HTTP URL never becomes ready", async () => {
+    await assert.rejects(
+      waitForRemoteHttpReady("https://preview.test", {
+        fetchImpl: async () => {
+          throw new Error("connection refused")
+        },
+        intervalMs: 1,
+        timeoutMs: 5,
+      }),
+      /timed out waiting for https:\/\/preview\.test: connection refused/,
     )
   })
 })


### PR DESCRIPTION
## Summary
- allow `remote-capture-browser` to start a remote dev-server command before capture and stop it afterward
- reuse remote process metadata/log/PID handling for browser evidence flows
- update the orchestration docs with the one-command remote UI evidence path

## Verification
- `pnpm exec biome check --write scripts/agent-runner-remote-capture-browser.mjs`
- `pnpm agent:queue:test`
- `pnpm agent:queue:remote-capture-browser -- --help`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- pre-commit hook: secretlint, agent-quality, affected typecheck
- pre-push hook: package tests