### PR TITLE
feat(agent-runner): inspect remote processes

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -206,6 +206,7 @@ capture:
 ```bash
 pnpm agent:queue:remote-start-process -- --issue <number> --name dev-server --command "pnpm dev" --port 3000 --yes
 pnpm agent:queue:remote-capture-browser -- --issue <number> --port 3000 --yes
+pnpm agent:queue:remote-process-status -- --issue <number> --name dev-server
 pnpm agent:queue:remote-stop-process -- --issue <number> --name dev-server --yes
 ```
 
@@ -213,6 +214,8 @@ Remote-stop-process mode is idempotent: stale or missing PID files are treated
 as already stopped, while live processes get a graceful terminate before a
 forced kill. These process commands do not mutate Project state; use them as
 setup and teardown around browser evidence capture.
+Remote-process-status is read-only and reports PID liveness, stored metadata,
+and a bounded remote log tail for debugging a running or failed dev server.
 
 For UI work in a remote workspace, expose the running remote dev server and
 capture browser evidence from the local runner:

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1205,8 +1205,10 @@ not require a manually pre-running server.
 `agent:queue:remote-start-process` and `agent:queue:remote-stop-process` can
 manage named long-running processes through adapter command execution, storing
 remote PID, command, log, and metadata files for browser-capture setup and
-teardown. Adapter-native process streaming and richer lifecycle supervision
-remain future slices.
+teardown. `agent:queue:remote-process-status` can inspect those named
+processes without mutating Project state, reporting PID liveness, stored
+metadata, and a bounded remote log tail for debugging. Adapter-native process
+streaming and richer lifecycle supervision remain future slices.
 
 Verification:
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "agent:queue:remote-open-pr": "node scripts/agent-runner-remote-open-pr.mjs",
     "agent:queue:remote-run-command": "node scripts/agent-runner-remote-run-command.mjs",
     "agent:queue:remote-start-process": "node scripts/agent-runner-remote-start-process.mjs",
+    "agent:queue:remote-process-status": "node scripts/agent-runner-remote-process-status.mjs",
     "agent:queue:remote-stop-process": "node scripts/agent-runner-remote-stop-process.mjs",
     "agent:queue:prepare": "node scripts/agent-runner-prepare.mjs",
     "agent:queue:start": "node scripts/agent-runner-start.mjs",

--- a/scripts/agent-runner-remote-process-status.mjs
+++ b/scripts/agent-runner-remote-process-status.mjs
@@ -1,0 +1,210 @@
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  findProjectIssueItem,
+  loadAllEvaluatedProject,
+  parseArgs,
+  projectScanConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+import { maybePrintHelp, projectOptions, repositoryOptions } from "./lib/agent-runner-help.mjs"
+import { remoteProcessPlan, remoteProcessStatusShell } from "./lib/agent-runner-remote-process.mjs"
+import {
+  loadRemoteWorkspaceAdapters,
+  resolveRemoteWorkspaceAdapter,
+} from "./lib/agent-runner-remote-workspace.mjs"
+import {
+  isRemoteWorkspaceDescriptor,
+  parseWorkspaceReference,
+} from "./lib/agent-runner-workspace-contract.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:remote-process-status",
+  summary: "Inspect a named long-running process inside a remote workspace.",
+  usage:
+    "pnpm agent:queue:remote-process-status -- (--issue <number> | --workspace <reference> --name <name>)",
+  options: [
+    ["--issue <number>", "Issue number whose remote workspace owns the process."],
+    ["--name <name>", "Stable process name. Defaults from the issue."],
+    [
+      "--workspace <reference>",
+      "Workspace reference override, for example sandbox:sprite:task-579.",
+    ],
+    ["--remote-dir <path>", "Remote repository directory."],
+    ["--tail-lines <number>", "Number of process log lines to print. Defaults to 80."],
+    [
+      "--adapter-config <path>",
+      "Optional remote adapter config module. Defaults to .agents/remote-workspaces.mjs when present.",
+    ],
+    ["--json", "Print machine-readable JSON."],
+    ...repositoryOptions,
+    ...projectOptions,
+  ],
+})
+
+if (!args.issue && !args.workspace) {
+  fail("remote-process-status mode requires --issue <number> or --workspace <reference>")
+}
+
+if (!args.issue && !args.name) {
+  fail("remote-process-status mode requires --name when --workspace is used without --issue")
+}
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = resolveRepository()
+const item = args.issue ? loadIssueItem({ repository }) : null
+const workspaceReference =
+  args.workspace ?? item?.fields.Workspace ?? item?.dryRunPlan.workspace ?? undefined
+const descriptor = parseWorkspaceReference(workspaceReference, { repoRoot })
+if (!isRemoteWorkspaceDescriptor(descriptor)) {
+  fail(
+    `remote-process-status requires a remote-sandbox workspace; got ${
+      descriptor.kind === "invalid" ? descriptor.reason : descriptor.kind
+    }`,
+  )
+}
+
+const plan = remoteProcessPlan({
+  descriptor,
+  item,
+  name: args.name,
+  remoteDir: args.remoteDir,
+  workspaceReference,
+})
+const adapters = await loadAdapters({ descriptor, workspaceReference })
+const adapter = resolveAdapter(descriptor, { adapters })
+if (!adapter.capabilities.exec) {
+  failInspection(
+    new Error(`remote workspace provider ${descriptor.provider} cannot exec commands`),
+    {
+      descriptor,
+      workspaceReference,
+    },
+  )
+}
+
+const statusResult = await runRemoteExec({
+  adapter,
+  args: [
+    "-lc",
+    remoteProcessStatusShell({
+      plan,
+      tailLines: numberArg(args.tailLines, "tail-lines", 80),
+    }),
+  ],
+  command: "bash",
+  cwd: plan.workspace,
+  httpPost: true,
+})
+
+if (statusResult.status !== 0) {
+  failInspection(
+    new Error(
+      statusResult.stderr?.trim() || `remote process status exited with ${statusResult.status}`,
+    ),
+    { descriptor, workspaceReference },
+  )
+}
+
+if (args.json) {
+  console.log(
+    JSON.stringify(
+      {
+        issue: item?.issue ?? null,
+        plan,
+        repository,
+        statusResult,
+      },
+      null,
+      2,
+    ),
+  )
+} else {
+  if (statusResult.stdout) console.log(statusResult.stdout)
+  if (statusResult.stderr) console.error(statusResult.stderr)
+  console.log("agent-runner remote-process-status: process inspected")
+  if (item) console.log(`issue: #${item.issue.number} ${item.issue.title}`)
+  console.log(`repository: ${repository ?? "not required"}`)
+  console.log(`workspace: ${workspaceReference}`)
+  console.log(`remote dir: ${plan.workspace}`)
+  console.log(`process: ${plan.processName}`)
+}
+
+function loadIssueItem({ repository }) {
+  const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
+  return findProjectIssueItem(project.items, {
+    issueNumber: args.issue,
+    repository,
+  })
+}
+
+function resolveRepository() {
+  if (args.repo) return args.repo
+  if (!args.issue) return null
+  return currentRepositoryFromOrigin(repoRoot)
+}
+
+async function loadAdapters({ descriptor, workspaceReference }) {
+  try {
+    return await loadRemoteWorkspaceAdapters({
+      configPath: args.adapterConfig,
+      repoRoot,
+    })
+  } catch (error) {
+    failInspection(error, { descriptor, workspaceReference })
+  }
+}
+
+function resolveAdapter(descriptor, { adapters }) {
+  try {
+    return resolveRemoteWorkspaceAdapter(descriptor, { adapters })
+  } catch (error) {
+    failInspection(error, { descriptor, workspaceReference })
+  }
+}
+
+async function runRemoteExec({ adapter, ...command }) {
+  try {
+    return await adapter.exec(command)
+  } catch (error) {
+    return {
+      status: 1,
+      stderr: error instanceof Error ? error.message : String(error),
+      stdout: "",
+    }
+  }
+}
+
+function failInspection(error, { descriptor, workspaceReference }) {
+  const message = error instanceof Error ? error.message : String(error)
+  if (args.json) {
+    console.log(
+      JSON.stringify(
+        {
+          error: message,
+          repository,
+          workspace: {
+            descriptor,
+            reference: workspaceReference,
+          },
+        },
+        null,
+        2,
+      ),
+    )
+    process.exit(1)
+  }
+
+  fail(message)
+}
+
+function numberArg(value, name, fallback) {
+  if (value === undefined) return fallback
+
+  const number = Number(value)
+  if (!Number.isInteger(number) || number < 1) {
+    fail(`invalid ${name}: ${value}`)
+  }
+  return number
+}

--- a/scripts/lib/agent-runner-remote-process.mjs
+++ b/scripts/lib/agent-runner-remote-process.mjs
@@ -136,6 +136,64 @@ if [ -f "$log_file" ]; then
 fi`
 }
 
+export function remoteProcessStatusShell({ plan, tailLines = 80 }) {
+  assertPositiveInteger("tailLines", tailLines)
+
+  return `set -euo pipefail
+pid_file=${shellQuote(plan.pidFile)}
+process_group_file=${shellQuote(plan.processGroupFile)}
+metadata_file=${shellQuote(plan.metadataFile)}
+log_file=${shellQuote(plan.logFile)}
+tail_lines=${shellQuote(String(tailLines))}
+
+status="stopped"
+reason="missing-pid-file"
+pid=""
+process_group="unknown"
+
+if [ -f "$pid_file" ]; then
+  pid="$(cat "$pid_file")"
+  if kill -0 "$pid" 2>/dev/null; then
+    status="running"
+    reason="pid-live"
+  else
+    status="stopped"
+    reason="stale-pid"
+  fi
+fi
+
+if [ -f "$process_group_file" ]; then
+  if [ "$(cat "$process_group_file")" = "1" ]; then
+    process_group="yes"
+  else
+    process_group="no"
+  fi
+fi
+
+echo "status: $status"
+echo "reason: $reason"
+echo "pid: \${pid:-none}"
+echo "process group: $process_group"
+echo "pid file: $pid_file"
+echo "metadata file: $metadata_file"
+echo "log file: $log_file"
+
+if [ -f "$metadata_file" ]; then
+  echo ""
+  echo "--- metadata ---"
+  cat "$metadata_file"
+fi
+
+if [ -f "$log_file" ]; then
+  echo ""
+  echo "--- log tail ($tail_lines) ---"
+  tail -n "$tail_lines" "$log_file" || true
+else
+  echo ""
+  echo "log: missing"
+fi`
+}
+
 export function remoteProcessMetadata({ command, date = new Date(), item, plan, repository }) {
   return {
     command,

--- a/scripts/tests/agent-runner-remote-process.test.mjs
+++ b/scripts/tests/agent-runner-remote-process.test.mjs
@@ -4,6 +4,7 @@ import { describe, it } from "node:test"
 import {
   remoteProcessMetadata,
   remoteProcessPlan,
+  remoteProcessStatusShell,
   remoteStartProcessShell,
   remoteStopProcessShell,
 } from "../lib/agent-runner-remote-process.mjs"
@@ -76,6 +77,25 @@ describe("agent runner remote process helpers", () => {
     assert.match(shell, /kill -- "\$target"/)
     assert.match(shell, /kill -KILL -- "\$target"/)
     assert.match(shell, /grace_seconds='7'/)
+  })
+
+  it("builds a remote status shell with metadata and bounded log tail", () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+    const plan = remoteProcessPlan({
+      descriptor,
+      item: workItem(),
+      name: "dev-server",
+      workspaceReference: descriptor.reference,
+    })
+    const shell = remoteProcessStatusShell({ plan, tailLines: 25 })
+
+    assert.match(shell, /status="running"/)
+    assert.match(shell, /reason="stale-pid"/)
+    assert.match(shell, /metadata file:/)
+    assert.match(shell, /--- metadata ---/)
+    assert.match(shell, /--- log tail \(\$tail_lines\) ---/)
+    assert.match(shell, /tail -n "\$tail_lines" "\$log_file"/)
+    assert.match(shell, /tail_lines='25'/)
   })
 
   it("serializes process metadata for evidence and follow-up commands", () => {


### PR DESCRIPTION
## Summary

- add a read-only `agent:queue:remote-process-status` command for named remote workspace processes
- report PID liveness, metadata location, process-group marker, and a bounded remote log tail
- document the status command in the remote browser/process debugging flow

## Verification

- `pnpm exec node --test scripts/tests/agent-runner-remote-process.test.mjs`
- `pnpm agent:queue:remote-process-status -- --help`
- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- pre-commit hook: secretlint, agent quality, affected typecheck
- pre-push hook: package tests
