### PR TITLE
Add traveler allocation surface (#695, #696)

### DIFF
--- a/apps/dev/migrations/0023_allocation_resources.sql
+++ b/apps/dev/migrations/0023_allocation_resources.sql
@@ -1,0 +1,36 @@
+ALTER TABLE "booking_traveler_travel_details"
+  ADD COLUMN IF NOT EXISTS "sharing_group_id" text,
+  ADD COLUMN IF NOT EXISTS "room_type_id" text,
+  ADD COLUMN IF NOT EXISTS "bed_preference" text,
+  ADD COLUMN IF NOT EXISTS "allocations" jsonb DEFAULT '{}'::jsonb NOT NULL;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_bptd_sharing_group" ON "booking_traveler_travel_details" USING btree ("sharing_group_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_bptd_room_type" ON "booking_traveler_travel_details" USING btree ("room_type_id");
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "allocation_resources" (
+  "id" text PRIMARY KEY NOT NULL,
+  "slot_id" text NOT NULL,
+  "kind" text NOT NULL,
+  "ref_type" text,
+  "ref_id" text,
+  "label" text,
+  "capacity" integer NOT NULL,
+  "flags" jsonb DEFAULT '{}'::jsonb NOT NULL,
+  "parent_id" text,
+  "sort_order" integer DEFAULT 0 NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "allocation_resources" ADD CONSTRAINT "allocation_resources_slot_id_availability_slots_id_fk" FOREIGN KEY ("slot_id") REFERENCES "public"."availability_slots"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_allocation_resources_slot_kind" ON "allocation_resources" USING btree ("slot_id","kind");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_allocation_resources_parent" ON "allocation_resources" USING btree ("parent_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_allocation_resources_kind_sort" ON "allocation_resources" USING btree ("kind","sort_order","created_at");

--- a/apps/dev/migrations/meta/_journal.json
+++ b/apps/dev/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1778446136397,
       "tag": "0022_invoice_attachments",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1778544000000,
+      "tag": "0023_allocation_resources",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/allocation-ui/package.json
+++ b/packages/allocation-ui/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "@voyantjs/allocation-ui",
+  "version": "0.32.3",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyantjs/voyant.git",
+    "directory": "packages/allocation-ui"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./i18n": "./src/i18n/index.ts",
+    "./styles.css": "./src/styles.css",
+    "./components/*": "./src/components/*.tsx"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "prepack": "pnpm run build",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check src/",
+    "test": "vitest run --passWithNoTests"
+  },
+  "peerDependencies": {
+    "@tanstack/react-query": "^5.90.12",
+    "@voyantjs/availability-react": "workspace:*",
+    "@voyantjs/i18n": "workspace:*",
+    "@voyantjs/ui": "workspace:*",
+    "lucide-react": "^0.475.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@tanstack/react-query": "^5.90.12",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@voyantjs/availability-react": "workspace:*",
+    "@voyantjs/i18n": "workspace:*",
+    "@voyantjs/ui": "workspace:*",
+    "@voyantjs/voyant-typescript-config": "workspace:*",
+    "lucide-react": "^1.7.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2"
+  },
+  "files": [
+    "dist",
+    "src/styles.css"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      },
+      "./i18n": {
+        "types": "./dist/i18n/index.d.ts",
+        "import": "./dist/i18n/index.js",
+        "default": "./dist/i18n/index.js"
+      },
+      "./styles.css": {
+        "default": "./src/styles.css"
+      },
+      "./components/*": {
+        "types": "./dist/components/*.d.ts",
+        "import": "./dist/components/*.js",
+        "default": "./dist/components/*.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  }
+}

--- a/packages/allocation-ui/src/components/slot-allocation-page.tsx
+++ b/packages/allocation-ui/src/components/slot-allocation-page.tsx
@@ -1,0 +1,410 @@
+"use client"
+
+import {
+  type AllocationManifestTraveler,
+  type AllocationResource,
+  useAllocationResourceMutation,
+  useAssignTravelerAllocationMutation,
+  useSlotAllocation,
+} from "@voyantjs/availability-react"
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  cn,
+  Input,
+  Label,
+} from "@voyantjs/ui/components"
+import {
+  Accessibility,
+  ArrowLeft,
+  Bed,
+  Crown,
+  Plus,
+  Trash2,
+  Users,
+  UtensilsCrossed,
+} from "lucide-react"
+import { type DragEvent, type FormEvent, type ReactNode, useMemo, useState } from "react"
+
+import { useAllocationUiMessagesOrDefault } from "../i18n/index.js"
+
+const ROOM_KIND = "room"
+
+export interface SlotAllocationPageProps {
+  slotId: string
+  className?: string
+  onBack?: () => void
+  renderExtraActions?: (context: { slotId: string }) => ReactNode
+  renderTravelerActions?: (traveler: AllocationManifestTraveler) => ReactNode
+}
+
+export function SlotAllocationPage({
+  slotId,
+  className,
+  onBack,
+  renderExtraActions,
+  renderTravelerActions,
+}: SlotAllocationPageProps) {
+  const messages = useAllocationUiMessagesOrDefault()
+  const allocation = useSlotAllocation({ slotId })
+  const resourceMutation = useAllocationResourceMutation(slotId)
+  const assignMutation = useAssignTravelerAllocationMutation(slotId)
+  const [addingRoom, setAddingRoom] = useState(false)
+  const [roomLabel, setRoomLabel] = useState("")
+  const [roomCapacity, setRoomCapacity] = useState(2)
+  const [error, setError] = useState<string | null>(null)
+
+  const data = allocation.data?.data
+  const rooms = useMemo(
+    () => (data?.resources ?? []).filter((resource) => resource.kind === ROOM_KIND),
+    [data?.resources],
+  )
+
+  const travelers = useMemo(() => {
+    const out: AllocationManifestTraveler[] = []
+    for (const booking of data?.bookings ?? []) {
+      if (booking.status === "cancelled") continue
+      out.push(...booking.travelers)
+    }
+    return out
+  }, [data?.bookings])
+
+  const occupants = useMemo(() => {
+    const byRoom = new Map<string, AllocationManifestTraveler[]>()
+    const unallocated: AllocationManifestTraveler[] = []
+    for (const traveler of travelers) {
+      const roomId = traveler.allocations[ROOM_KIND]
+      if (!roomId) {
+        unallocated.push(traveler)
+        continue
+      }
+      const list = byRoom.get(roomId) ?? []
+      list.push(traveler)
+      byRoom.set(roomId, list)
+    }
+    return { byRoom, unallocated }
+  }, [travelers])
+
+  async function assignTraveler(travelerId: string, resourceId: string | null) {
+    setError(null)
+    try {
+      await assignMutation.mutateAsync({ travelerId, kind: ROOM_KIND, resourceId })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : messages.allocationFailed)
+    }
+  }
+
+  async function createRoom(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setError(null)
+    try {
+      await resourceMutation.create.mutateAsync({
+        kind: ROOM_KIND,
+        label: roomLabel.trim() || null,
+        capacity: roomCapacity,
+      })
+      setRoomLabel("")
+      setRoomCapacity(2)
+      setAddingRoom(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : messages.createRoomFailed)
+    }
+  }
+
+  if (allocation.isPending) {
+    return (
+      <div className={cn("p-6 text-sm text-muted-foreground", className)}>{messages.loading}</div>
+    )
+  }
+
+  if (!data || travelers.length === 0) {
+    return (
+      <div className={cn("flex flex-col items-center justify-center gap-3 p-8", className)}>
+        <Users className="size-6 text-muted-foreground" aria-hidden="true" />
+        <p className="text-sm text-muted-foreground">{messages.empty}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-4 p-6", className)}>
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div className="flex items-start gap-3">
+          {onBack ? (
+            <Button variant="ghost" size="icon" onClick={onBack} aria-label={messages.back}>
+              <ArrowLeft data-icon aria-hidden="true" />
+            </Button>
+          ) : null}
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">{messages.pageTitle}</h1>
+            <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+              <span>
+                {data.summary.travelerCount} {messages.travelers}
+              </span>
+              <span>
+                {rooms.length} {messages.rooms.toLowerCase()}
+              </span>
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          {renderExtraActions?.({ slotId })}
+          <Button variant="outline" onClick={() => setAddingRoom((value) => !value)}>
+            <Plus data-icon="inline-start" aria-hidden="true" />
+            {messages.addRoom}
+          </Button>
+        </div>
+      </div>
+
+      {error ? (
+        <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      ) : null}
+
+      {addingRoom ? (
+        <form
+          className="grid gap-3 rounded-md border bg-muted/30 p-3 sm:grid-cols-[1fr_8rem_auto_auto]"
+          onSubmit={createRoom}
+        >
+          <div className="grid gap-1">
+            <Label htmlFor="allocation-room-label">{messages.roomLabel}</Label>
+            <Input
+              id="allocation-room-label"
+              value={roomLabel}
+              onChange={(event) => setRoomLabel(event.target.value)}
+              placeholder="102"
+            />
+          </div>
+          <div className="grid gap-1">
+            <Label htmlFor="allocation-room-capacity">{messages.roomCapacity}</Label>
+            <Input
+              id="allocation-room-capacity"
+              type="number"
+              min={1}
+              value={roomCapacity}
+              onChange={(event) => setRoomCapacity(Number(event.target.value) || 1)}
+            />
+          </div>
+          <Button type="submit" className="self-end" disabled={resourceMutation.create.isPending}>
+            {messages.createRoom}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            className="self-end"
+            onClick={() => setAddingRoom(false)}
+          >
+            {messages.cancel}
+          </Button>
+        </form>
+      ) : null}
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(18rem,22rem)_1fr]">
+        <DropColumn
+          id="unallocated"
+          title={messages.unallocated}
+          description={messages.unallocatedDescription}
+          count={occupants.unallocated.length}
+          capacity={travelers.length}
+          onDropTraveler={(travelerId) => void assignTraveler(travelerId, null)}
+        >
+          {occupants.unallocated.map((traveler) => (
+            <TravelerTile
+              key={traveler.id}
+              traveler={traveler}
+              renderActions={renderTravelerActions}
+            />
+          ))}
+        </DropColumn>
+
+        <div className="grid min-w-0 gap-4 md:grid-cols-2 2xl:grid-cols-3">
+          {rooms.length === 0 ? (
+            <div className="rounded-md border border-dashed p-6 text-sm text-muted-foreground">
+              {messages.noRooms}
+            </div>
+          ) : (
+            rooms.map((room) => {
+              const roomOccupants = occupants.byRoom.get(room.id) ?? []
+              return (
+                <RoomColumn
+                  key={room.id}
+                  room={room}
+                  occupants={roomOccupants}
+                  onDropTraveler={(travelerId) => void assignTraveler(travelerId, room.id)}
+                  onRemoveRoom={() => void resourceMutation.remove.mutateAsync(room.id)}
+                  renderTravelerActions={renderTravelerActions}
+                />
+              )
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function RoomColumn({
+  room,
+  occupants,
+  onDropTraveler,
+  onRemoveRoom,
+  renderTravelerActions,
+}: {
+  room: AllocationResource
+  occupants: AllocationManifestTraveler[]
+  onDropTraveler: (travelerId: string) => void
+  onRemoveRoom: () => void
+  renderTravelerActions?: (traveler: AllocationManifestTraveler) => ReactNode
+}) {
+  const messages = useAllocationUiMessagesOrDefault()
+  const full = occupants.length >= room.capacity
+
+  return (
+    <DropColumn
+      id={`room:${room.id}`}
+      title={room.label ?? messages.rooms}
+      description={`${messages.capacity}: ${occupants.length}/${room.capacity}`}
+      count={occupants.length}
+      capacity={room.capacity}
+      disabled={full}
+      onDropTraveler={onDropTraveler}
+      action={
+        <Button type="button" variant="ghost" size="icon" onClick={onRemoveRoom}>
+          <Trash2 className="size-4" aria-hidden="true" />
+        </Button>
+      }
+    >
+      {full ? (
+        <Badge variant="secondary" className="w-fit">
+          {messages.overCapacity}
+        </Badge>
+      ) : null}
+      {occupants.map((traveler) => (
+        <TravelerTile key={traveler.id} traveler={traveler} renderActions={renderTravelerActions} />
+      ))}
+      {!full ? (
+        <div className="rounded-md border border-dashed p-3 text-xs text-muted-foreground">
+          {messages.dropHere}
+        </div>
+      ) : null}
+    </DropColumn>
+  )
+}
+
+function DropColumn({
+  id,
+  title,
+  description,
+  count,
+  capacity,
+  disabled,
+  action,
+  children,
+  onDropTraveler,
+}: {
+  id: string
+  title: string
+  description: string
+  count: number
+  capacity: number
+  disabled?: boolean
+  action?: ReactNode
+  children: ReactNode
+  onDropTraveler: (travelerId: string) => void
+}) {
+  const [over, setOver] = useState(false)
+
+  function onDrop(event: DragEvent<HTMLDivElement>) {
+    event.preventDefault()
+    setOver(false)
+    if (disabled) return
+    const travelerId = event.dataTransfer.getData("text/plain")
+    if (travelerId) onDropTraveler(travelerId)
+  }
+
+  return (
+    <Card
+      id={id}
+      className={cn(
+        "min-h-40 transition-colors",
+        over && !disabled ? "border-primary bg-primary/5" : null,
+      )}
+      onDragOver={(event) => {
+        event.preventDefault()
+        if (!disabled) setOver(true)
+      }}
+      onDragLeave={() => setOver(false)}
+      onDrop={onDrop}
+    >
+      <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0">
+        <div>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Bed className="size-4" aria-hidden="true" />
+            {title}
+          </CardTitle>
+          <p className="text-xs text-muted-foreground">{description}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Badge variant={count > capacity ? "destructive" : "outline"}>
+            {count}/{capacity}
+          </Badge>
+          {action}
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-2">{children}</CardContent>
+    </Card>
+  )
+}
+
+function TravelerTile({
+  traveler,
+  renderActions,
+}: {
+  traveler: AllocationManifestTraveler
+  renderActions?: (traveler: AllocationManifestTraveler) => ReactNode
+}) {
+  const messages = useAllocationUiMessagesOrDefault()
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: issue #696; the tile can wrap custom action controls, so it cannot be a button.
+    <div
+      draggable
+      role="button"
+      tabIndex={0}
+      onDragStart={(event) => {
+        event.dataTransfer.effectAllowed = "move"
+        event.dataTransfer.setData("text/plain", traveler.id)
+      }}
+      className="group flex cursor-grab items-start justify-between gap-3 rounded-md border bg-background p-3 text-sm shadow-sm active:cursor-grabbing"
+    >
+      <div className="min-w-0">
+        <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+          {traveler.isLeadTraveler ? (
+            <Crown className="size-3.5 text-amber-500" aria-label={messages.lead} />
+          ) : null}
+          <span className="truncate font-medium">{traveler.fullName}</span>
+          {traveler.sharingGroupId ? (
+            <Badge variant="secondary" className="text-[10px]">
+              {messages.sharingGroup}
+            </Badge>
+          ) : null}
+        </div>
+        <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+          <span>{traveler.bookingNumber}</span>
+          {traveler.hasAccessibilityNeeds ? (
+            <Accessibility className="size-3.5" aria-label={messages.accessibility} />
+          ) : null}
+          {traveler.hasDietaryRequirements ? (
+            <UtensilsCrossed className="size-3.5" aria-label={messages.dietary} />
+          ) : null}
+        </div>
+      </div>
+      {renderActions ? <div className="shrink-0">{renderActions(traveler)}</div> : null}
+    </div>
+  )
+}

--- a/packages/allocation-ui/src/i18n/index.ts
+++ b/packages/allocation-ui/src/i18n/index.ts
@@ -1,0 +1,14 @@
+export {
+  type AllocationUiMessageOverrides,
+  type AllocationUiMessages,
+  AllocationUiMessagesProvider,
+  allocationUiEn,
+  allocationUiMessageDefinitions,
+  allocationUiRo,
+  getAllocationUiI18n,
+  resolveAllocationUiMessages,
+  useAllocationUiI18n,
+  useAllocationUiI18nOrDefault,
+  useAllocationUiMessages,
+  useAllocationUiMessagesOrDefault,
+} from "./provider.js"

--- a/packages/allocation-ui/src/i18n/provider.tsx
+++ b/packages/allocation-ui/src/i18n/provider.tsx
@@ -1,0 +1,174 @@
+"use client"
+
+import {
+  createLocaleFormatters,
+  createPackageMessagesContext,
+  type LocaleMessageDefinitions,
+  type LocaleMessageOverrides,
+  type PackageI18nValue,
+  resolvePackageMessages,
+} from "@voyantjs/i18n"
+import type { ReactNode } from "react"
+
+export type AllocationUiMessages = Record<string, unknown> & {
+  pageTitle: string
+  loading: string
+  empty: string
+  back: string
+  addRoom: string
+  roomLabel: string
+  roomCapacity: string
+  createRoom: string
+  cancel: string
+  unallocated: string
+  unallocatedDescription: string
+  rooms: string
+  travelers: string
+  capacity: string
+  lead: string
+  sharingGroup: string
+  accessibility: string
+  dietary: string
+  remove: string
+  overCapacity: string
+  dropHere: string
+  noRooms: string
+  allocationFailed: string
+  createRoomFailed: string
+}
+
+export const allocationUiEn = {
+  pageTitle: "Allocation",
+  loading: "Loading allocation...",
+  empty: "No travelers on this departure yet.",
+  back: "Back",
+  addRoom: "Add room",
+  roomLabel: "Room label",
+  roomCapacity: "Capacity",
+  createRoom: "Create room",
+  cancel: "Cancel",
+  unallocated: "Unallocated",
+  unallocatedDescription: "Travelers not assigned to a room.",
+  rooms: "Rooms",
+  travelers: "travelers",
+  capacity: "Capacity",
+  lead: "Lead",
+  sharingGroup: "Sharing group",
+  accessibility: "Accessibility",
+  dietary: "Dietary",
+  remove: "Remove",
+  overCapacity: "Room is full",
+  dropHere: "Drop traveler here",
+  noRooms: "No rooms have been added for this slot.",
+  allocationFailed: "Could not update allocation.",
+  createRoomFailed: "Could not create room.",
+} satisfies AllocationUiMessages
+
+export const allocationUiRo = {
+  pageTitle: "Alocare",
+  loading: "Se incarca alocarea...",
+  empty: "Nu exista calatori pe aceasta plecare.",
+  back: "Inapoi",
+  addRoom: "Adauga camera",
+  roomLabel: "Eticheta camera",
+  roomCapacity: "Capacitate",
+  createRoom: "Creeaza camera",
+  cancel: "Anuleaza",
+  unallocated: "Nealocati",
+  unallocatedDescription: "Calatori fara camera alocata.",
+  rooms: "Camere",
+  travelers: "calatori",
+  capacity: "Capacitate",
+  lead: "Lead",
+  sharingGroup: "Grup partaj",
+  accessibility: "Accesibilitate",
+  dietary: "Dieta",
+  remove: "Scoate",
+  overCapacity: "Camera este plina",
+  dropHere: "Trage calatorul aici",
+  noRooms: "Nu exista camere adaugate pentru acest slot.",
+  allocationFailed: "Alocarea nu a putut fi actualizata.",
+  createRoomFailed: "Camera nu a putut fi creata.",
+} satisfies AllocationUiMessages
+
+const fallbackLocale = "en"
+
+export const allocationUiMessageDefinitions = {
+  en: allocationUiEn,
+  ro: allocationUiRo,
+} satisfies LocaleMessageDefinitions<AllocationUiMessages>
+
+export type AllocationUiMessageOverrides = LocaleMessageOverrides<AllocationUiMessages>
+
+const allocationUiContext =
+  createPackageMessagesContext<AllocationUiMessages>("AllocationUiMessages")
+
+const defaultAllocationUiI18n: PackageI18nValue<AllocationUiMessages> = {
+  messages: allocationUiEn,
+  ...createLocaleFormatters(fallbackLocale),
+}
+
+export function resolveAllocationUiMessages({
+  locale,
+  overrides,
+}: {
+  locale: string | null | undefined
+  overrides?: AllocationUiMessageOverrides | null
+}) {
+  return resolvePackageMessages({
+    definitions: allocationUiMessageDefinitions,
+    fallbackLocale,
+    locale,
+    overrides,
+  })
+}
+
+export function getAllocationUiI18n({
+  locale,
+  overrides,
+}: {
+  locale?: string | null | undefined
+  overrides?: AllocationUiMessageOverrides | null
+}): PackageI18nValue<AllocationUiMessages> {
+  const resolvedLocale = locale ?? fallbackLocale
+
+  return {
+    messages: resolveAllocationUiMessages({
+      locale: resolvedLocale,
+      overrides,
+    }),
+    ...createLocaleFormatters(resolvedLocale),
+  }
+}
+
+export function AllocationUiMessagesProvider({
+  children,
+  locale,
+  overrides,
+}: {
+  children: ReactNode
+  locale: string | null | undefined
+  overrides?: AllocationUiMessageOverrides | null
+}) {
+  return (
+    <allocationUiContext.ResolvedMessagesProvider
+      definitions={allocationUiMessageDefinitions}
+      fallbackLocale={fallbackLocale}
+      locale={locale}
+      overrides={overrides}
+    >
+      {children}
+    </allocationUiContext.ResolvedMessagesProvider>
+  )
+}
+
+export const useAllocationUiI18n = allocationUiContext.useI18n
+export const useAllocationUiMessages = allocationUiContext.useMessages
+
+export function useAllocationUiI18nOrDefault() {
+  return allocationUiContext.useOptionalI18n() ?? defaultAllocationUiI18n
+}
+
+export function useAllocationUiMessagesOrDefault() {
+  return useAllocationUiI18nOrDefault().messages
+}

--- a/packages/allocation-ui/src/index.ts
+++ b/packages/allocation-ui/src/index.ts
@@ -1,0 +1,18 @@
+export {
+  SlotAllocationPage,
+  type SlotAllocationPageProps,
+} from "./components/slot-allocation-page.js"
+export {
+  type AllocationUiMessageOverrides,
+  type AllocationUiMessages,
+  AllocationUiMessagesProvider,
+  allocationUiEn,
+  allocationUiMessageDefinitions,
+  allocationUiRo,
+  getAllocationUiI18n,
+  resolveAllocationUiMessages,
+  useAllocationUiI18n,
+  useAllocationUiI18nOrDefault,
+  useAllocationUiMessages,
+  useAllocationUiMessagesOrDefault,
+} from "./i18n/index.js"

--- a/packages/allocation-ui/src/styles.css
+++ b/packages/allocation-ui/src/styles.css
@@ -1,0 +1,6 @@
+/* Tailwind v4 source-detection helper.
+ *
+ * Templates that consume this package should `@import` this CSS so Tailwind
+ * scans these component files for utility classes.
+ */
+@source "./components/**/*.{ts,tsx}";

--- a/packages/allocation-ui/tsconfig.build.json
+++ b/packages/allocation-ui/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@voyantjs/voyant-typescript-config/react-library.json",
+  "compilerOptions": {
+    "composite": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/allocation-ui/tsconfig.json
+++ b/packages/allocation-ui/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@voyantjs/voyant-typescript-config/react-library.json",
+  "compilerOptions": {
+    "composite": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/availability-react/src/hooks/index.ts
+++ b/packages/availability-react/src/hooks/index.ts
@@ -9,6 +9,13 @@ export type { UseProductsOptions } from "./use-products.js"
 export { useProducts } from "./use-products.js"
 export type { UseRulesOptions } from "./use-rules.js"
 export { useRules } from "./use-rules.js"
+export {
+  type UseSlotAllocationOptions,
+  useAllocationResourceMutation,
+  useAssignTravelerAllocationMutation,
+  useSlotAllocation,
+  useTravelerSharingGroupMutation,
+} from "./use-slot-allocation.js"
 export type { UseSlotUnitAvailabilityOptions } from "./use-slot-unit-availability.js"
 export { useSlotUnitAvailability } from "./use-slot-unit-availability.js"
 export type { UseSlotsOptions } from "./use-slots.js"

--- a/packages/availability-react/src/hooks/use-slot-allocation.ts
+++ b/packages/availability-react/src/hooks/use-slot-allocation.ts
@@ -1,0 +1,162 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { z } from "zod"
+
+import { fetchWithValidation } from "../client.js"
+import { useVoyantAvailabilityContext } from "../provider.js"
+import { availabilityQueryKeys } from "../query-keys.js"
+import { getSlotAllocationQueryOptions } from "../query-options.js"
+import {
+  allocationResourceSchema,
+  type CreateAllocationResourceInput,
+  singleEnvelope,
+  type UpdateAllocationResourceInput,
+} from "../schemas.js"
+
+const assignTravelerAllocationResponse = singleEnvelope(
+  z.object({
+    travelerId: z.string(),
+    kind: z.string(),
+    resourceId: z.string().nullable(),
+  }),
+)
+
+const updateTravelerSharingGroupResponse = singleEnvelope(
+  z.object({
+    travelerId: z.string(),
+    sharingGroupId: z.string().nullable(),
+  }),
+)
+
+const pairSharingGroupResponse = singleEnvelope(
+  z.object({
+    sharingGroupId: z.string(),
+    travelerIds: z.array(z.string()),
+  }),
+)
+
+export interface UseSlotAllocationOptions {
+  slotId: string | null | undefined
+  enabled?: boolean
+}
+
+export function useSlotAllocation({ slotId, enabled = true }: UseSlotAllocationOptions) {
+  const client = useVoyantAvailabilityContext()
+  return useQuery({
+    ...getSlotAllocationQueryOptions(client, slotId),
+    enabled: enabled && Boolean(slotId),
+  })
+}
+
+export function useAllocationResourceMutation(slotId: string) {
+  const { baseUrl, fetcher } = useVoyantAvailabilityContext()
+  const queryClient = useQueryClient()
+  const invalidate = async () => {
+    await queryClient.invalidateQueries({ queryKey: availabilityQueryKeys.slotAllocation(slotId) })
+  }
+
+  const create = useMutation({
+    mutationFn: async (input: CreateAllocationResourceInput) => {
+      const { data } = await fetchWithValidation(
+        `/v1/admin/availability/slots/${slotId}/allocation/resources`,
+        singleEnvelope(allocationResourceSchema),
+        { baseUrl, fetcher },
+        { method: "POST", body: JSON.stringify(input) },
+      )
+      return data
+    },
+    onSuccess: invalidate,
+  })
+
+  const update = useMutation({
+    mutationFn: async ({
+      resourceId,
+      input,
+    }: {
+      resourceId: string
+      input: UpdateAllocationResourceInput
+    }) => {
+      const { data } = await fetchWithValidation(
+        `/v1/admin/availability/slots/${slotId}/allocation/resources/${resourceId}`,
+        singleEnvelope(allocationResourceSchema),
+        { baseUrl, fetcher },
+        { method: "PATCH", body: JSON.stringify(input) },
+      )
+      return data
+    },
+    onSuccess: invalidate,
+  })
+
+  const remove = useMutation({
+    mutationFn: async (resourceId: string) =>
+      fetchWithValidation(
+        `/v1/admin/availability/slots/${slotId}/allocation/resources/${resourceId}`,
+        singleEnvelope(allocationResourceSchema.pick({ id: true })),
+        { baseUrl, fetcher },
+        { method: "DELETE" },
+      ),
+    onSuccess: invalidate,
+  })
+
+  return { create, update, remove }
+}
+
+export function useAssignTravelerAllocationMutation(slotId: string) {
+  const { baseUrl, fetcher } = useVoyantAvailabilityContext()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (input: { travelerId: string; kind: string; resourceId: string | null }) =>
+      fetchWithValidation(
+        `/v1/admin/availability/slots/${slotId}/allocation/travelers/${input.travelerId}`,
+        assignTravelerAllocationResponse,
+        { baseUrl, fetcher },
+        {
+          method: "PATCH",
+          body: JSON.stringify({ kind: input.kind, resourceId: input.resourceId }),
+        },
+      ),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: availabilityQueryKeys.slotAllocation(slotId),
+      })
+    },
+  })
+}
+
+export function useTravelerSharingGroupMutation(slotId: string) {
+  const { baseUrl, fetcher } = useVoyantAvailabilityContext()
+  const queryClient = useQueryClient()
+  const update = useMutation({
+    mutationFn: (input: { travelerId: string; sharingGroupId: string | null }) =>
+      fetchWithValidation(
+        `/v1/admin/availability/slots/${slotId}/allocation/travelers/${input.travelerId}/sharing-group`,
+        updateTravelerSharingGroupResponse,
+        { baseUrl, fetcher },
+        { method: "PATCH", body: JSON.stringify({ sharingGroupId: input.sharingGroupId }) },
+      ),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: availabilityQueryKeys.slotAllocation(slotId),
+      })
+    },
+  })
+
+  const pair = useMutation({
+    mutationFn: (input: { travelerIds: string[]; sharingGroupId?: string }) =>
+      fetchWithValidation(
+        `/v1/admin/availability/slots/${slotId}/allocation/sharing-groups/pair`,
+        pairSharingGroupResponse,
+        { baseUrl, fetcher },
+        { method: "POST", body: JSON.stringify(input) },
+      ),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: availabilityQueryKeys.slotAllocation(slotId),
+      })
+    },
+  })
+
+  return { update, pair }
+}

--- a/packages/availability-react/src/index.ts
+++ b/packages/availability-react/src/index.ts
@@ -19,6 +19,7 @@ export {
   getProductQueryOptions,
   getProductsQueryOptions,
   getRulesQueryOptions,
+  getSlotAllocationQueryOptions,
   getSlotAssignmentsQueryOptions,
   getSlotBookingsQueryOptions,
   getSlotCloseoutsQueryOptions,

--- a/packages/availability-react/src/query-keys.ts
+++ b/packages/availability-react/src/query-keys.ts
@@ -78,5 +78,7 @@ export const availabilityQueryKeys = {
     [...availabilityQueryKeys.slots(), "resources", "list", filters] as const,
   slotBookingsList: (filters: PaginationFilters) =>
     [...availabilityQueryKeys.slots(), "bookings", "list", filters] as const,
+  slotAllocation: (slotId: string) =>
+    [...availabilityQueryKeys.slots(), "allocation", slotId] as const,
   product: (id: string) => [...availabilityQueryKeys.products(), "detail", id] as const,
 } as const

--- a/packages/availability-react/src/query-options.ts
+++ b/packages/availability-react/src/query-options.ts
@@ -23,6 +23,7 @@ import {
   productListResponse,
   productSingleResponse,
   resourceSummaryListResponse,
+  slotAllocationManifestResponse,
   slotUnitAvailabilityListResponse,
 } from "./schemas.js"
 
@@ -186,6 +187,23 @@ export function getSlotUnitAvailabilityQueryOptions(
       return fetchWithValidation(
         `/v1/availability/slots/${slotId}/unit-availability`,
         slotUnitAvailabilityListResponse,
+        client,
+      )
+    },
+  })
+}
+
+export function getSlotAllocationQueryOptions(
+  client: FetchWithValidationOptions,
+  slotId: string | null | undefined,
+) {
+  return queryOptions({
+    queryKey: availabilityQueryKeys.slotAllocation(slotId ?? ""),
+    queryFn: async () => {
+      if (!slotId) throw new Error("getSlotAllocationQueryOptions requires a slotId")
+      return fetchWithValidation(
+        `/v1/admin/availability/slots/${slotId}/allocation`,
+        slotAllocationManifestResponse,
         client,
       )
     },

--- a/packages/availability-react/src/schemas.ts
+++ b/packages/availability-react/src/schemas.ts
@@ -1,7 +1,9 @@
 import {
+  insertAllocationResourceSchema,
   insertAvailabilityRuleSchema,
   insertAvailabilitySlotSchema,
   insertAvailabilityStartTimeSchema,
+  updateAllocationResourceSchema,
   updateAvailabilityRuleSchema,
   updateAvailabilitySlotSchema,
   updateAvailabilityStartTimeSchema,
@@ -186,6 +188,82 @@ export const availabilitySlotAssignmentListResponse = paginatedEnvelope(
 export const bookingSummaryListResponse = paginatedEnvelope(bookingSummarySchema)
 export const resourceSummaryListResponse = paginatedEnvelope(resourceSummarySchema)
 
+export const allocationResourceSchema = z.object({
+  id: z.string(),
+  slotId: z.string(),
+  kind: z.string(),
+  refType: z.string().nullable(),
+  refId: z.string().nullable(),
+  label: z.string().nullable(),
+  capacity: z.number().int(),
+  flags: z.record(z.string(), z.unknown()),
+  parentId: z.string().nullable(),
+  sortOrder: z.number().int(),
+  createdAt: z.string().or(z.date()),
+  updatedAt: z.string().or(z.date()),
+})
+
+export type AllocationResource = z.infer<typeof allocationResourceSchema>
+
+export const allocationManifestTravelerSchema = z.object({
+  id: z.string(),
+  bookingId: z.string(),
+  bookingNumber: z.string(),
+  bookingStatus: z.string(),
+  firstName: z.string(),
+  lastName: z.string(),
+  fullName: z.string(),
+  email: z.string().nullable(),
+  phone: z.string().nullable(),
+  isLeadTraveler: z.boolean(),
+  isPrimary: z.boolean(),
+  sharingGroupId: z.string().nullable(),
+  roomTypeId: z.string().nullable(),
+  bedPreference: z.string().nullable(),
+  allocations: z.record(z.string(), z.string()),
+  travelerCategory: z.string().nullable(),
+  participantType: z.string(),
+  hasAccessibilityNeeds: z.boolean(),
+  hasDietaryRequirements: z.boolean(),
+})
+
+export type AllocationManifestTraveler = z.infer<typeof allocationManifestTravelerSchema>
+
+export const allocationManifestBookingSchema = z.object({
+  id: z.string(),
+  bookingNumber: z.string(),
+  status: z.string(),
+  contactFirstName: z.string().nullable(),
+  contactLastName: z.string().nullable(),
+  contactEmail: z.string().nullable(),
+  contactPhone: z.string().nullable(),
+  sellCurrency: z.string().nullable(),
+  pax: z.number().int().nullable(),
+  travelers: z.array(allocationManifestTravelerSchema),
+})
+
+export type AllocationManifestBooking = z.infer<typeof allocationManifestBookingSchema>
+
+export const slotAllocationManifestSchema = z.object({
+  slot: z.object({
+    id: z.string(),
+    productId: z.string().nullable(),
+    startsAt: z.string().nullable(),
+    endsAt: z.string().nullable(),
+  }),
+  bookings: z.array(allocationManifestBookingSchema),
+  resources: z.array(allocationResourceSchema),
+  summary: z.object({
+    bookingCount: z.number().int(),
+    travelerCount: z.number().int(),
+    leadTravelerCount: z.number().int(),
+    bookingsByStatus: z.record(z.string(), z.number().int()),
+  }),
+})
+
+export type SlotAllocationManifest = z.infer<typeof slotAllocationManifestSchema>
+export const slotAllocationManifestResponse = singleEnvelope(slotAllocationManifestSchema)
+
 export const slotUnitAvailabilityRecordSchema = z.object({
   optionUnitId: z.string(),
   unitName: z.string(),
@@ -200,14 +278,18 @@ export const slotUnitAvailabilityListResponse = z.object({
 })
 
 export {
+  insertAllocationResourceSchema,
   insertAvailabilityRuleSchema,
   insertAvailabilitySlotSchema,
   insertAvailabilityStartTimeSchema,
+  updateAllocationResourceSchema,
   updateAvailabilityRuleSchema,
   updateAvailabilitySlotSchema,
   updateAvailabilityStartTimeSchema,
 }
 
+export type CreateAllocationResourceInput = z.input<typeof insertAllocationResourceSchema>
+export type UpdateAllocationResourceInput = z.input<typeof updateAllocationResourceSchema>
 export type CreateAvailabilityRuleInput = z.input<typeof insertAvailabilityRuleSchema>
 export type UpdateAvailabilityRuleInput = z.input<typeof updateAvailabilityRuleSchema>
 export type CreateAvailabilityStartTimeInput = z.input<typeof insertAvailabilityStartTimeSchema>

--- a/packages/availability/src/bookings-ref.ts
+++ b/packages/availability/src/bookings-ref.ts
@@ -1,4 +1,4 @@
-import { integer, jsonb, pgTable, text } from "drizzle-orm/pg-core"
+import { boolean, integer, jsonb, pgTable, text } from "drizzle-orm/pg-core"
 
 /**
  * Minimal references to bookings tables so availability service methods can
@@ -8,7 +8,14 @@ import { integer, jsonb, pgTable, text } from "drizzle-orm/pg-core"
  */
 export const bookingsRef = pgTable("bookings", {
   id: text("id").primaryKey(),
+  bookingNumber: text("booking_number").notNull(),
   status: text("status").notNull(),
+  contactFirstName: text("contact_first_name"),
+  contactLastName: text("contact_last_name"),
+  contactEmail: text("contact_email"),
+  contactPhone: text("contact_phone"),
+  sellCurrency: text("sell_currency"),
+  pax: integer("pax"),
 })
 
 export const bookingItemsRef = pgTable("booking_items", {
@@ -19,4 +26,40 @@ export const bookingItemsRef = pgTable("booking_items", {
   optionUnitId: text("option_unit_id"),
   quantity: integer("quantity").notNull().default(1),
   metadata: jsonb("metadata").$type<Record<string, unknown> | null>(),
+})
+
+export const bookingAllocationsRef = pgTable("booking_allocations", {
+  id: text("id").primaryKey(),
+  bookingId: text("booking_id").notNull(),
+  bookingItemId: text("booking_item_id").notNull(),
+  productId: text("product_id"),
+  optionId: text("option_id"),
+  optionUnitId: text("option_unit_id"),
+  availabilitySlotId: text("availability_slot_id"),
+  quantity: integer("quantity").notNull().default(1),
+  status: text("status").notNull(),
+})
+
+export const bookingTravelersRef = pgTable("booking_travelers", {
+  id: text("id").primaryKey(),
+  bookingId: text("booking_id").notNull(),
+  personId: text("person_id"),
+  participantType: text("participant_type").notNull(),
+  travelerCategory: text("traveler_category"),
+  firstName: text("first_name").notNull(),
+  lastName: text("last_name").notNull(),
+  email: text("email"),
+  phone: text("phone"),
+  isPrimary: boolean("is_primary").notNull(),
+})
+
+export const bookingTravelerTravelDetailsRef = pgTable("booking_traveler_travel_details", {
+  travelerId: text("traveler_id").primaryKey(),
+  dietaryEncrypted: jsonb("dietary_encrypted"),
+  accessibilityEncrypted: jsonb("accessibility_encrypted"),
+  isLeadTraveler: boolean("is_lead_traveler").notNull(),
+  sharingGroupId: text("sharing_group_id"),
+  roomTypeId: text("room_type_id"),
+  bedPreference: text("bed_preference"),
+  allocations: jsonb("allocations").$type<Record<string, string>>().notNull(),
 })

--- a/packages/availability/src/index.ts
+++ b/packages/availability/src/index.ts
@@ -1,10 +1,10 @@
 import type { Module } from "@voyantjs/core"
 import type { HonoModule } from "@voyantjs/hono/module"
 
-import { availabilityRoutes } from "./routes.js"
+import { availabilityAdminRoutes, availabilityRoutes } from "./routes.js"
 import { availabilityService } from "./service.js"
 
-export type { AvailabilityRoutes } from "./routes.js"
+export type { AvailabilityAdminRoutes, AvailabilityRoutes } from "./routes.js"
 
 export const availabilityModule: Module = {
   name: "availability",
@@ -13,6 +13,7 @@ export const availabilityModule: Module = {
 export const availabilityHonoModule: HonoModule = {
   module: availabilityModule,
   routes: availabilityRoutes,
+  adminRoutes: availabilityAdminRoutes,
 }
 
 export {
@@ -26,6 +27,7 @@ export {
   generateAvailabilitySlots,
 } from "./generate-slots.js"
 export type {
+  AllocationResource,
   AvailabilityCloseout,
   AvailabilityPickupPoint,
   AvailabilityRule,
@@ -34,6 +36,7 @@ export type {
   AvailabilityStartTime,
   CustomPickupArea,
   LocationPickupTime,
+  NewAllocationResource,
   NewAvailabilityCloseout,
   NewAvailabilityPickupPoint,
   NewAvailabilityRule,
@@ -50,6 +53,7 @@ export type {
   ProductMeetingConfig,
 } from "./schema.js"
 export {
+  allocationResources,
   availabilityCloseouts,
   availabilityPickupPoints,
   availabilityRules,
@@ -63,6 +67,7 @@ export {
   productMeetingConfigs,
 } from "./schema.js"
 export {
+  assignTravelerAllocationSchema,
   availabilityCloseoutListQuerySchema,
   availabilityPickupPointListQuerySchema,
   availabilityRuleListQuerySchema,
@@ -70,6 +75,7 @@ export {
   availabilitySlotPickupListQuerySchema,
   availabilityStartTimeListQuerySchema,
   customPickupAreaListQuerySchema,
+  insertAllocationResourceSchema,
   insertAvailabilityCloseoutSchema,
   insertAvailabilityPickupPointSchema,
   insertAvailabilityRuleSchema,
@@ -82,9 +88,11 @@ export {
   insertPickupLocationSchema,
   insertProductMeetingConfigSchema,
   locationPickupTimeListQuerySchema,
+  pairSharingGroupSchema,
   pickupGroupListQuerySchema,
   pickupLocationListQuerySchema,
   productMeetingConfigListQuerySchema,
+  updateAllocationResourceSchema,
   updateAvailabilityCloseoutSchema,
   updateAvailabilityPickupPointSchema,
   updateAvailabilityRuleSchema,
@@ -96,5 +104,6 @@ export {
   updatePickupGroupSchema,
   updatePickupLocationSchema,
   updateProductMeetingConfigSchema,
+  updateTravelerSharingGroupSchema,
 } from "./validation.js"
 export { availabilityService }

--- a/packages/availability/src/routes-allocation.ts
+++ b/packages/availability/src/routes-allocation.ts
@@ -1,0 +1,110 @@
+import { parseJsonBody } from "@voyantjs/hono"
+import type { Context } from "hono"
+import { Hono } from "hono"
+
+import type { Env } from "./routes-shared.js"
+import {
+  AllocationServiceError,
+  assignTravelerAllocation,
+  createAllocationResource,
+  deleteAllocationResource,
+  getSlotAllocationManifest,
+  pairSharingGroup,
+  updateAllocationResource,
+  updateTravelerSharingGroup,
+} from "./service-allocation.js"
+import {
+  assignTravelerAllocationSchema,
+  insertAllocationResourceSchema,
+  pairSharingGroupSchema,
+  updateAllocationResourceSchema,
+  updateTravelerSharingGroupSchema,
+} from "./validation.js"
+
+export const availabilityAllocationRoutes = new Hono<Env>()
+  .get("/slots/:id/allocation", async (c) => {
+    const manifest = await getSlotAllocationManifest(c.get("db"), c.req.param("id"))
+    return manifest
+      ? c.json({ data: manifest })
+      : c.json({ error: "Availability slot not found" }, 404)
+  })
+  .post("/slots/:id/allocation/resources", async (c) => {
+    const row = await createAllocationResource(
+      c.get("db"),
+      c.req.param("id"),
+      await parseJsonBody(c, insertAllocationResourceSchema),
+    )
+    return row ? c.json({ data: row }, 201) : c.json({ error: "Availability slot not found" }, 404)
+  })
+  .patch("/slots/:id/allocation/resources/:resourceId", async (c) => {
+    try {
+      const row = await updateAllocationResource(
+        c.get("db"),
+        c.req.param("id"),
+        c.req.param("resourceId"),
+        await parseJsonBody(c, updateAllocationResourceSchema),
+      )
+      return row ? c.json({ data: row }) : c.json({ error: "Allocation resource not found" }, 404)
+    } catch (error) {
+      return handleAllocationRouteError(c, error)
+    }
+  })
+  .delete("/slots/:id/allocation/resources/:resourceId", async (c) => {
+    const row = await deleteAllocationResource(
+      c.get("db"),
+      c.req.param("id"),
+      c.req.param("resourceId"),
+    )
+    return row ? c.json({ data: row }) : c.json({ error: "Allocation resource not found" }, 404)
+  })
+  .patch("/slots/:id/allocation/travelers/:travelerId", async (c) => {
+    try {
+      const result = await assignTravelerAllocation(
+        c.get("db"),
+        c.req.param("id"),
+        c.req.param("travelerId"),
+        await parseJsonBody(c, assignTravelerAllocationSchema),
+      )
+      return c.json({ data: result })
+    } catch (error) {
+      return handleAllocationRouteError(c, error)
+    }
+  })
+  .patch("/slots/:id/allocation/travelers/:travelerId/sharing-group", async (c) => {
+    try {
+      const result = await updateTravelerSharingGroup(
+        c.get("db"),
+        c.req.param("id"),
+        c.req.param("travelerId"),
+        await parseJsonBody(c, updateTravelerSharingGroupSchema),
+      )
+      return c.json({ data: result })
+    } catch (error) {
+      return handleAllocationRouteError(c, error)
+    }
+  })
+  .post("/slots/:id/allocation/sharing-groups/pair", async (c) => {
+    try {
+      const result = await pairSharingGroup(
+        c.get("db"),
+        c.req.param("id"),
+        await parseJsonBody(c, pairSharingGroupSchema),
+      )
+      return c.json({ data: result }, 201)
+    } catch (error) {
+      return handleAllocationRouteError(c, error)
+    }
+  })
+
+function handleAllocationRouteError(c: Context<Env>, error: unknown): Response {
+  if (error instanceof AllocationServiceError) {
+    return c.json(
+      {
+        error: error.message,
+        ...(error.detail ? { detail: error.detail } : {}),
+      },
+      error.status as 400 | 404 | 409,
+    )
+  }
+  throw error
+}

--- a/packages/availability/src/routes.ts
+++ b/packages/availability/src/routes.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono"
 
+import { availabilityAllocationRoutes } from "./routes-allocation.js"
 import { availabilityCoreRoutes } from "./routes-core.js"
 import { availabilityPickupRoutes } from "./routes-pickups.js"
 import type { Env } from "./routes-shared.js"
@@ -8,4 +9,8 @@ export const availabilityRoutes = new Hono<Env>()
 availabilityRoutes.route("/", availabilityCoreRoutes)
 availabilityRoutes.route("/", availabilityPickupRoutes)
 
+export const availabilityAdminRoutes = new Hono<Env>()
+availabilityAdminRoutes.route("/", availabilityAllocationRoutes)
+
 export type AvailabilityRoutes = typeof availabilityRoutes
+export type AvailabilityAdminRoutes = typeof availabilityAdminRoutes

--- a/packages/availability/src/schema.ts
+++ b/packages/availability/src/schema.ts
@@ -5,6 +5,7 @@ import {
   date,
   index,
   integer,
+  jsonb,
   pgEnum,
   pgTable,
   text,
@@ -157,6 +158,31 @@ export const availabilityCloseouts = pgTable(
     index("idx_availability_closeouts_product_created").on(table.productId, table.createdAt),
     index("idx_availability_closeouts_slot_created").on(table.slotId, table.createdAt),
     index("idx_availability_closeouts_date_created").on(table.dateLocal, table.createdAt),
+  ],
+)
+
+export const allocationResources = pgTable(
+  "allocation_resources",
+  {
+    id: typeId("allocation_resources"),
+    slotId: typeIdRef("slot_id")
+      .notNull()
+      .references(() => availabilitySlots.id, { onDelete: "cascade" }),
+    kind: text("kind").notNull(),
+    refType: text("ref_type"),
+    refId: text("ref_id"),
+    label: text("label"),
+    capacity: integer("capacity").notNull(),
+    flags: jsonb("flags").$type<Record<string, unknown>>().notNull().default({}),
+    parentId: text("parent_id"),
+    sortOrder: integer("sort_order").notNull().default(0),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_allocation_resources_slot_kind").on(table.slotId, table.kind),
+    index("idx_allocation_resources_parent").on(table.parentId),
+    index("idx_allocation_resources_kind_sort").on(table.kind, table.sortOrder, table.createdAt),
   ],
 )
 
@@ -369,6 +395,8 @@ export type AvailabilitySlot = typeof availabilitySlots.$inferSelect
 export type NewAvailabilitySlot = typeof availabilitySlots.$inferInsert
 export type AvailabilityCloseout = typeof availabilityCloseouts.$inferSelect
 export type NewAvailabilityCloseout = typeof availabilityCloseouts.$inferInsert
+export type AllocationResource = typeof allocationResources.$inferSelect
+export type NewAllocationResource = typeof allocationResources.$inferInsert
 export type AvailabilityPickupPoint = typeof availabilityPickupPoints.$inferSelect
 export type NewAvailabilityPickupPoint = typeof availabilityPickupPoints.$inferInsert
 export type AvailabilitySlotPickup = typeof availabilitySlotPickups.$inferSelect
@@ -405,11 +433,19 @@ export const availabilitySlotsRelations = relations(availabilitySlots, ({ one, m
   pickups: many(availabilitySlotPickups),
   closeouts: many(availabilityCloseouts),
   locationPickupTimes: many(locationPickupTimes),
+  allocationResources: many(allocationResources),
 }))
 
 export const availabilityCloseoutsRelations = relations(availabilityCloseouts, ({ one }) => ({
   slot: one(availabilitySlots, {
     fields: [availabilityCloseouts.slotId],
+    references: [availabilitySlots.id],
+  }),
+}))
+
+export const allocationResourcesRelations = relations(allocationResources, ({ one }) => ({
+  slot: one(availabilitySlots, {
+    fields: [allocationResources.slotId],
     references: [availabilitySlots.id],
   }),
 }))

--- a/packages/availability/src/service-allocation.ts
+++ b/packages/availability/src/service-allocation.ts
@@ -1,0 +1,558 @@
+import { and, asc, eq, type SQL, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import type { z } from "zod"
+import { allocationResources, availabilitySlots } from "./schema.js"
+import type {
+  assignTravelerAllocationSchema,
+  insertAllocationResourceSchema,
+  pairSharingGroupSchema,
+  updateAllocationResourceSchema,
+  updateTravelerSharingGroupSchema,
+} from "./validation.js"
+
+export type CreateAllocationResourceInput = z.infer<typeof insertAllocationResourceSchema>
+export type UpdateAllocationResourceInput = z.infer<typeof updateAllocationResourceSchema>
+export type AssignTravelerAllocationInput = z.infer<typeof assignTravelerAllocationSchema>
+export type UpdateTravelerSharingGroupInput = z.infer<typeof updateTravelerSharingGroupSchema>
+export type PairSharingGroupInput = z.infer<typeof pairSharingGroupSchema>
+
+export class AllocationServiceError extends Error {
+  readonly status: number
+  readonly detail?: unknown
+
+  constructor(message: string, status: number, detail?: unknown) {
+    super(message)
+    this.name = "AllocationServiceError"
+    this.status = status
+    this.detail = detail
+  }
+}
+
+export interface AllocationManifestTraveler {
+  id: string
+  bookingId: string
+  bookingNumber: string
+  bookingStatus: string
+  firstName: string
+  lastName: string
+  fullName: string
+  email: string | null
+  phone: string | null
+  isLeadTraveler: boolean
+  isPrimary: boolean
+  sharingGroupId: string | null
+  roomTypeId: string | null
+  bedPreference: string | null
+  allocations: Record<string, string>
+  travelerCategory: string | null
+  participantType: string
+  hasAccessibilityNeeds: boolean
+  hasDietaryRequirements: boolean
+}
+
+export interface AllocationManifestBooking {
+  id: string
+  bookingNumber: string
+  status: string
+  contactFirstName: string | null
+  contactLastName: string | null
+  contactEmail: string | null
+  contactPhone: string | null
+  sellCurrency: string | null
+  pax: number | null
+  travelers: AllocationManifestTraveler[]
+}
+
+export interface SlotAllocationManifest {
+  slot: {
+    id: string
+    productId: string | null
+    startsAt: string | null
+    endsAt: string | null
+  }
+  bookings: AllocationManifestBooking[]
+  resources: Array<typeof allocationResources.$inferSelect>
+  summary: {
+    bookingCount: number
+    travelerCount: number
+    leadTravelerCount: number
+    bookingsByStatus: Record<string, number>
+  }
+}
+
+export async function getSlotAllocationManifest(
+  db: PostgresJsDatabase,
+  slotId: string,
+): Promise<SlotAllocationManifest | null> {
+  const [slot] = await db
+    .select({
+      id: availabilitySlots.id,
+      productId: availabilitySlots.productId,
+      startsAt: availabilitySlots.startsAt,
+      endsAt: availabilitySlots.endsAt,
+    })
+    .from(availabilitySlots)
+    .where(eq(availabilitySlots.id, slotId))
+    .limit(1)
+
+  if (!slot) return null
+
+  const resources = await listAllocationResources(db, slotId)
+  const bookingRows = await loadSlotBookingRows(db, slotId)
+  if (bookingRows.length === 0) {
+    return {
+      slot: serializeSlot(slot),
+      bookings: [],
+      resources,
+      summary: {
+        bookingCount: 0,
+        travelerCount: 0,
+        leadTravelerCount: 0,
+        bookingsByStatus: {},
+      },
+    }
+  }
+
+  const bookingIds = bookingRows.map((row) => row.id)
+  const travelerRows = await loadSlotTravelerRows(db, bookingIds)
+  const bookingById = new Map(bookingRows.map((row) => [row.id, row]))
+  const travelersByBooking = new Map<string, AllocationManifestTraveler[]>()
+
+  for (const row of travelerRows) {
+    const booking = bookingById.get(row.booking_id)
+    const traveler: AllocationManifestTraveler = {
+      id: row.id,
+      bookingId: row.booking_id,
+      bookingNumber: booking?.booking_number ?? "",
+      bookingStatus: booking?.status ?? "unknown",
+      firstName: row.first_name,
+      lastName: row.last_name,
+      fullName: [row.first_name, row.last_name].filter(Boolean).join(" "),
+      email: row.email,
+      phone: row.phone,
+      isLeadTraveler: row.is_lead_traveler ?? false,
+      isPrimary: row.is_primary,
+      sharingGroupId: row.sharing_group_id,
+      roomTypeId: row.room_type_id,
+      bedPreference: row.bed_preference,
+      allocations: normalizeAllocationMap(row.allocations),
+      travelerCategory: row.traveler_category,
+      participantType: row.participant_type,
+      hasAccessibilityNeeds: row.has_accessibility_needs,
+      hasDietaryRequirements: row.has_dietary_requirements,
+    }
+    const list = travelersByBooking.get(row.booking_id) ?? []
+    list.push(traveler)
+    travelersByBooking.set(row.booking_id, list)
+  }
+
+  const bookings = bookingRows.map(
+    (row): AllocationManifestBooking => ({
+      id: row.id,
+      bookingNumber: row.booking_number,
+      status: row.status,
+      contactFirstName: row.contact_first_name,
+      contactLastName: row.contact_last_name,
+      contactEmail: row.contact_email,
+      contactPhone: row.contact_phone,
+      sellCurrency: row.sell_currency,
+      pax: row.pax,
+      travelers: travelersByBooking.get(row.id) ?? [],
+    }),
+  )
+
+  return {
+    slot: serializeSlot(slot),
+    bookings,
+    resources,
+    summary: bookings.reduce(
+      (acc, booking) => {
+        acc.bookingCount += 1
+        acc.travelerCount += booking.travelers.length
+        acc.leadTravelerCount += booking.travelers.filter(
+          (traveler) => traveler.isLeadTraveler,
+        ).length
+        acc.bookingsByStatus[booking.status] = (acc.bookingsByStatus[booking.status] ?? 0) + 1
+        return acc
+      },
+      {
+        bookingCount: 0,
+        travelerCount: 0,
+        leadTravelerCount: 0,
+        bookingsByStatus: {} as Record<string, number>,
+      },
+    ),
+  }
+}
+
+export async function listAllocationResources(db: PostgresJsDatabase, slotId: string) {
+  return db
+    .select()
+    .from(allocationResources)
+    .where(eq(allocationResources.slotId, slotId))
+    .orderBy(
+      asc(allocationResources.kind),
+      asc(allocationResources.sortOrder),
+      asc(allocationResources.createdAt),
+    )
+}
+
+export async function createAllocationResource(
+  db: PostgresJsDatabase,
+  slotId: string,
+  input: CreateAllocationResourceInput,
+) {
+  const [slot] = await db
+    .select({ id: availabilitySlots.id })
+    .from(availabilitySlots)
+    .where(eq(availabilitySlots.id, slotId))
+    .limit(1)
+  if (!slot) return null
+
+  const [row] = await db
+    .insert(allocationResources)
+    .values({
+      slotId,
+      kind: input.kind,
+      refType: input.refType ?? null,
+      refId: input.refId ?? null,
+      label: input.label ?? null,
+      capacity: input.capacity,
+      flags: input.flags ?? {},
+      parentId: input.parentId ?? null,
+      sortOrder: input.sortOrder ?? 0,
+    })
+    .returning()
+  return row ?? null
+}
+
+export async function updateAllocationResource(
+  db: PostgresJsDatabase,
+  slotId: string,
+  resourceId: string,
+  input: UpdateAllocationResourceInput,
+) {
+  const [existing] = await db
+    .select({
+      id: allocationResources.id,
+      kind: allocationResources.kind,
+    })
+    .from(allocationResources)
+    .where(and(eq(allocationResources.id, resourceId), eq(allocationResources.slotId, slotId)))
+    .limit(1)
+  if (!existing) return null
+
+  if (input.capacity !== undefined) {
+    const current = await countResourceOccupants(db, existing.kind, resourceId)
+    if (current > input.capacity) {
+      throw new AllocationServiceError("Resource over capacity", 409, {
+        capacity: input.capacity,
+        current,
+      })
+    }
+  }
+
+  const patch = {
+    ...input,
+    updatedAt: new Date(),
+  }
+
+  const [row] = await db
+    .update(allocationResources)
+    .set(patch)
+    .where(and(eq(allocationResources.id, resourceId), eq(allocationResources.slotId, slotId)))
+    .returning()
+  return row ?? null
+}
+
+export async function deleteAllocationResource(
+  db: PostgresJsDatabase,
+  slotId: string,
+  resourceId: string,
+) {
+  const [row] = await db
+    .delete(allocationResources)
+    .where(and(eq(allocationResources.id, resourceId), eq(allocationResources.slotId, slotId)))
+    .returning({ id: allocationResources.id })
+  if (row) await clearTravelerAllocationsForResource(db, resourceId)
+  return row ?? null
+}
+
+export async function assignTravelerAllocation(
+  db: PostgresJsDatabase,
+  slotId: string,
+  travelerId: string,
+  input: AssignTravelerAllocationInput,
+) {
+  await assertTravelerBelongsToSlot(db, slotId, travelerId)
+
+  if (input.resourceId) {
+    const [resource] = await db
+      .select({
+        id: allocationResources.id,
+        kind: allocationResources.kind,
+        capacity: allocationResources.capacity,
+      })
+      .from(allocationResources)
+      .where(
+        and(
+          eq(allocationResources.id, input.resourceId),
+          eq(allocationResources.slotId, slotId),
+          eq(allocationResources.kind, input.kind),
+        ),
+      )
+      .limit(1)
+
+    if (!resource) {
+      throw new AllocationServiceError("Resource not found for this slot/kind", 404)
+    }
+
+    const current = await countResourceOccupants(db, input.kind, input.resourceId, travelerId)
+    if (current + 1 > resource.capacity) {
+      throw new AllocationServiceError("Resource over capacity", 409, {
+        capacity: resource.capacity,
+        current,
+      })
+    }
+  }
+
+  await ensureTravelerTravelDetailsRow(db, travelerId)
+
+  if (input.resourceId) {
+    await db.execute(sql`
+      UPDATE booking_traveler_travel_details
+      SET allocations = COALESCE(allocations, '{}'::jsonb) || jsonb_build_object(${input.kind}::text, ${input.resourceId}::text),
+          updated_at = now()
+      WHERE traveler_id = ${travelerId}
+    `)
+  } else {
+    await db.execute(sql`
+      UPDATE booking_traveler_travel_details
+      SET allocations = COALESCE(allocations, '{}'::jsonb) - ${input.kind}::text,
+          updated_at = now()
+      WHERE traveler_id = ${travelerId}
+    `)
+  }
+
+  return { travelerId, kind: input.kind, resourceId: input.resourceId }
+}
+
+export async function updateTravelerSharingGroup(
+  db: PostgresJsDatabase,
+  slotId: string,
+  travelerId: string,
+  input: UpdateTravelerSharingGroupInput,
+) {
+  await assertTravelerBelongsToSlot(db, slotId, travelerId)
+  await db.execute(sql`
+    INSERT INTO booking_traveler_travel_details (traveler_id, sharing_group_id)
+    VALUES (${travelerId}, ${input.sharingGroupId})
+    ON CONFLICT (traveler_id) DO UPDATE SET
+      sharing_group_id = ${input.sharingGroupId},
+      updated_at = now()
+  `)
+
+  return { travelerId, sharingGroupId: input.sharingGroupId }
+}
+
+export async function pairSharingGroup(
+  db: PostgresJsDatabase,
+  slotId: string,
+  input: PairSharingGroupInput,
+) {
+  for (const travelerId of input.travelerIds) {
+    await assertTravelerBelongsToSlot(db, slotId, travelerId)
+  }
+
+  const sharingGroupId = input.sharingGroupId ?? globalThis.crypto.randomUUID()
+  await db.execute(sql`
+    INSERT INTO booking_traveler_travel_details (traveler_id, sharing_group_id)
+    SELECT id, ${sharingGroupId}
+    FROM unnest(${input.travelerIds}::text[]) AS u(id)
+    ON CONFLICT (traveler_id) DO UPDATE SET
+      sharing_group_id = EXCLUDED.sharing_group_id,
+      updated_at = now()
+  `)
+
+  return { sharingGroupId, travelerIds: input.travelerIds }
+}
+
+async function ensureTravelerTravelDetailsRow(db: PostgresJsDatabase, travelerId: string) {
+  await db.execute(sql`
+    INSERT INTO booking_traveler_travel_details (traveler_id)
+    VALUES (${travelerId})
+    ON CONFLICT (traveler_id) DO NOTHING
+  `)
+}
+
+async function assertTravelerBelongsToSlot(
+  db: PostgresJsDatabase,
+  slotId: string,
+  travelerId: string,
+) {
+  const rows = await executeRows<{ exists: number }>(
+    db,
+    sql`
+    SELECT 1 AS exists
+    FROM booking_travelers bt
+    JOIN booking_allocations ba ON ba.booking_id = bt.booking_id
+    WHERE bt.id = ${travelerId}
+      AND ba.availability_slot_id = ${slotId}
+    LIMIT 1
+  `,
+  )
+
+  if (rows.length === 0) {
+    throw new AllocationServiceError("Traveler not found for this slot", 404)
+  }
+}
+
+async function countResourceOccupants(
+  db: PostgresJsDatabase,
+  kind: string,
+  resourceId: string,
+  excludeTravelerId?: string,
+) {
+  const rows = await executeRows<{ count: number }>(
+    db,
+    sql`
+    SELECT COUNT(*)::int AS count
+    FROM booking_traveler_travel_details
+    WHERE allocations ->> ${kind} = ${resourceId}
+      AND (${excludeTravelerId ?? null}::text IS NULL OR traveler_id <> ${excludeTravelerId ?? null})
+  `,
+  )
+
+  return rows[0]?.count ?? 0
+}
+
+async function clearTravelerAllocationsForResource(db: PostgresJsDatabase, resourceId: string) {
+  await db.execute(sql`
+    UPDATE booking_traveler_travel_details btd
+    SET allocations = COALESCE((
+      SELECT jsonb_object_agg(key, value)
+      FROM jsonb_each(COALESCE(btd.allocations, '{}'::jsonb))
+      WHERE value <> to_jsonb(${resourceId}::text)
+    ), '{}'::jsonb),
+    updated_at = now()
+    WHERE EXISTS (
+      SELECT 1
+      FROM jsonb_each(COALESCE(btd.allocations, '{}'::jsonb))
+      WHERE value = to_jsonb(${resourceId}::text)
+    )
+  `)
+}
+
+async function executeRows<T>(db: PostgresJsDatabase, query: SQL): Promise<T[]> {
+  const rows = await db.execute(query)
+  return Array.isArray(rows) ? (rows as T[]) : []
+}
+
+function serializeSlot(slot: {
+  id: string
+  productId: string | null
+  startsAt: Date
+  endsAt: Date | null
+}) {
+  return {
+    id: slot.id,
+    productId: slot.productId ?? null,
+    startsAt: slot.startsAt ? slot.startsAt.toISOString() : null,
+    endsAt: slot.endsAt ? slot.endsAt.toISOString() : null,
+  }
+}
+
+interface BookingRow {
+  id: string
+  booking_number: string
+  status: string
+  contact_first_name: string | null
+  contact_last_name: string | null
+  contact_email: string | null
+  contact_phone: string | null
+  sell_currency: string | null
+  pax: number | null
+}
+
+interface TravelerRow {
+  id: string
+  booking_id: string
+  first_name: string
+  last_name: string
+  email: string | null
+  phone: string | null
+  is_primary: boolean
+  participant_type: string
+  traveler_category: string | null
+  is_lead_traveler: boolean | null
+  sharing_group_id: string | null
+  room_type_id: string | null
+  bed_preference: string | null
+  allocations: unknown
+  has_accessibility_needs: boolean
+  has_dietary_requirements: boolean
+}
+
+async function loadSlotBookingRows(db: PostgresJsDatabase, slotId: string): Promise<BookingRow[]> {
+  return executeRows<BookingRow>(
+    db,
+    sql`
+    SELECT DISTINCT
+      b.id,
+      b.booking_number,
+      b.status,
+      b.contact_first_name,
+      b.contact_last_name,
+      b.contact_email,
+      b.contact_phone,
+      b.sell_currency,
+      b.pax
+    FROM bookings b
+    JOIN booking_allocations ba ON ba.booking_id = b.id
+    WHERE ba.availability_slot_id = ${slotId}
+    ORDER BY b.booking_number
+  `,
+  )
+}
+
+async function loadSlotTravelerRows(
+  db: PostgresJsDatabase,
+  bookingIds: string[],
+): Promise<TravelerRow[]> {
+  return executeRows<TravelerRow>(
+    db,
+    sql`
+    SELECT
+      bt.id,
+      bt.booking_id,
+      bt.first_name,
+      bt.last_name,
+      bt.email,
+      bt.phone,
+      bt.is_primary,
+      bt.participant_type,
+      bt.traveler_category,
+      COALESCE(btd.is_lead_traveler, false) AS is_lead_traveler,
+      btd.sharing_group_id,
+      btd.room_type_id,
+      btd.bed_preference,
+      COALESCE(btd.allocations, '{}'::jsonb) AS allocations,
+      (btd.accessibility_encrypted IS NOT NULL) AS has_accessibility_needs,
+      (btd.dietary_encrypted IS NOT NULL) AS has_dietary_requirements
+    FROM booking_travelers bt
+    LEFT JOIN booking_traveler_travel_details btd ON btd.traveler_id = bt.id
+    WHERE bt.booking_id = ANY(${bookingIds}::text[])
+    ORDER BY bt.booking_id, bt.is_primary DESC, bt.created_at
+  `,
+  )
+}
+
+function normalizeAllocationMap(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {}
+
+  const out: Record<string, string> = {}
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw === "string") out[key] = raw
+  }
+  return out
+}

--- a/packages/availability/src/service-allocation.ts
+++ b/packages/availability/src/service-allocation.ts
@@ -16,6 +16,10 @@ export type AssignTravelerAllocationInput = z.infer<typeof assignTravelerAllocat
 export type UpdateTravelerSharingGroupInput = z.infer<typeof updateTravelerSharingGroupSchema>
 export type PairSharingGroupInput = z.infer<typeof pairSharingGroupSchema>
 
+interface SqlExecutor {
+  execute(query: SQL): Promise<unknown>
+}
+
 export class AllocationServiceError extends Error {
   readonly status: number
   readonly detail?: unknown
@@ -243,7 +247,7 @@ export async function updateAllocationResource(
   if (!existing) return null
 
   if (input.capacity !== undefined) {
-    const current = await countResourceOccupants(db, existing.kind, resourceId)
+    const current = await countResourceOccupants(db, slotId, existing.kind, resourceId)
     if (current > input.capacity) {
       throw new AllocationServiceError("Resource over capacity", 409, {
         capacity: input.capacity,
@@ -284,55 +288,63 @@ export async function assignTravelerAllocation(
   travelerId: string,
   input: AssignTravelerAllocationInput,
 ) {
-  await assertTravelerBelongsToSlot(db, slotId, travelerId)
+  await db.transaction(async (tx) => {
+    await assertTravelerBelongsToSlot(tx, slotId, travelerId)
 
-  if (input.resourceId) {
-    const [resource] = await db
-      .select({
-        id: allocationResources.id,
-        kind: allocationResources.kind,
-        capacity: allocationResources.capacity,
-      })
-      .from(allocationResources)
-      .where(
-        and(
-          eq(allocationResources.id, input.resourceId),
-          eq(allocationResources.slotId, slotId),
-          eq(allocationResources.kind, input.kind),
-        ),
+    if (input.resourceId) {
+      const [resource] = await executeRows<{
+        id: string
+        kind: string
+        capacity: number
+      }>(
+        tx,
+        sql`
+          SELECT id, kind, capacity
+          FROM allocation_resources
+          WHERE id = ${input.resourceId}
+            AND slot_id = ${slotId}
+            AND kind = ${input.kind}
+          FOR UPDATE
+        `,
       )
-      .limit(1)
 
-    if (!resource) {
-      throw new AllocationServiceError("Resource not found for this slot/kind", 404)
+      if (!resource) {
+        throw new AllocationServiceError("Resource not found for this slot/kind", 404)
+      }
+
+      const current = await countResourceOccupants(
+        tx,
+        slotId,
+        input.kind,
+        input.resourceId,
+        travelerId,
+      )
+      if (current + 1 > resource.capacity) {
+        throw new AllocationServiceError("Resource over capacity", 409, {
+          capacity: resource.capacity,
+          current,
+        })
+      }
     }
 
-    const current = await countResourceOccupants(db, input.kind, input.resourceId, travelerId)
-    if (current + 1 > resource.capacity) {
-      throw new AllocationServiceError("Resource over capacity", 409, {
-        capacity: resource.capacity,
-        current,
-      })
+    await ensureTravelerTravelDetailsRow(tx, travelerId)
+
+    if (input.resourceId) {
+      await tx.execute(sql`
+        UPDATE booking_traveler_travel_details
+        SET allocations = COALESCE(allocations, '{}'::jsonb) || jsonb_build_object(${input.kind}::text, ${input.resourceId}::text),
+            updated_at = now()
+        WHERE traveler_id = ${travelerId}
+      `)
+    } else {
+      await tx.execute(sql`
+        UPDATE booking_traveler_travel_details
+        SET allocations = COALESCE(allocations, '{}'::jsonb) - ${input.kind}::text,
+            updated_at = now()
+        WHERE traveler_id = ${travelerId}
+      `)
     }
-  }
-
-  await ensureTravelerTravelDetailsRow(db, travelerId)
-
-  if (input.resourceId) {
-    await db.execute(sql`
-      UPDATE booking_traveler_travel_details
-      SET allocations = COALESCE(allocations, '{}'::jsonb) || jsonb_build_object(${input.kind}::text, ${input.resourceId}::text),
-          updated_at = now()
-      WHERE traveler_id = ${travelerId}
-    `)
-  } else {
-    await db.execute(sql`
-      UPDATE booking_traveler_travel_details
-      SET allocations = COALESCE(allocations, '{}'::jsonb) - ${input.kind}::text,
-          updated_at = now()
-      WHERE traveler_id = ${travelerId}
-    `)
-  }
+  })
 
   return { travelerId, kind: input.kind, resourceId: input.resourceId }
 }
@@ -377,7 +389,7 @@ export async function pairSharingGroup(
   return { sharingGroupId, travelerIds: input.travelerIds }
 }
 
-async function ensureTravelerTravelDetailsRow(db: PostgresJsDatabase, travelerId: string) {
+async function ensureTravelerTravelDetailsRow(db: SqlExecutor, travelerId: string) {
   await db.execute(sql`
     INSERT INTO booking_traveler_travel_details (traveler_id)
     VALUES (${travelerId})
@@ -385,19 +397,18 @@ async function ensureTravelerTravelDetailsRow(db: PostgresJsDatabase, travelerId
   `)
 }
 
-async function assertTravelerBelongsToSlot(
-  db: PostgresJsDatabase,
-  slotId: string,
-  travelerId: string,
-) {
+async function assertTravelerBelongsToSlot(db: SqlExecutor, slotId: string, travelerId: string) {
   const rows = await executeRows<{ exists: number }>(
     db,
     sql`
     SELECT 1 AS exists
     FROM booking_travelers bt
     JOIN booking_allocations ba ON ba.booking_id = bt.booking_id
+    JOIN bookings b ON b.id = bt.booking_id
     WHERE bt.id = ${travelerId}
       AND ba.availability_slot_id = ${slotId}
+      AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
+      AND ba.status IN ('held', 'confirmed', 'fulfilled')
     LIMIT 1
   `,
   )
@@ -408,7 +419,8 @@ async function assertTravelerBelongsToSlot(
 }
 
 async function countResourceOccupants(
-  db: PostgresJsDatabase,
+  db: SqlExecutor,
+  slotId: string,
   kind: string,
   resourceId: string,
   excludeTravelerId?: string,
@@ -416,10 +428,16 @@ async function countResourceOccupants(
   const rows = await executeRows<{ count: number }>(
     db,
     sql`
-    SELECT COUNT(*)::int AS count
-    FROM booking_traveler_travel_details
-    WHERE allocations ->> ${kind} = ${resourceId}
-      AND (${excludeTravelerId ?? null}::text IS NULL OR traveler_id <> ${excludeTravelerId ?? null})
+    SELECT COUNT(DISTINCT btd.traveler_id)::int AS count
+    FROM booking_traveler_travel_details btd
+    JOIN booking_travelers bt ON bt.id = btd.traveler_id
+    JOIN booking_allocations ba ON ba.booking_id = bt.booking_id
+    JOIN bookings b ON b.id = bt.booking_id
+    WHERE btd.allocations ->> ${kind} = ${resourceId}
+      AND ba.availability_slot_id = ${slotId}
+      AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
+      AND ba.status IN ('held', 'confirmed', 'fulfilled')
+      AND (${excludeTravelerId ?? null}::text IS NULL OR btd.traveler_id <> ${excludeTravelerId ?? null})
   `,
   )
 
@@ -443,7 +461,7 @@ async function clearTravelerAllocationsForResource(db: PostgresJsDatabase, resou
   `)
 }
 
-async function executeRows<T>(db: PostgresJsDatabase, query: SQL): Promise<T[]> {
+async function executeRows<T>(db: SqlExecutor, query: SQL): Promise<T[]> {
   const rows = await db.execute(query)
   return Array.isArray(rows) ? (rows as T[]) : []
 }
@@ -510,6 +528,8 @@ async function loadSlotBookingRows(db: PostgresJsDatabase, slotId: string): Prom
     FROM bookings b
     JOIN booking_allocations ba ON ba.booking_id = b.id
     WHERE ba.availability_slot_id = ${slotId}
+      AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
+      AND ba.status IN ('held', 'confirmed', 'fulfilled')
     ORDER BY b.booking_number
   `,
   )

--- a/packages/availability/src/service.ts
+++ b/packages/availability/src/service.ts
@@ -1,5 +1,15 @@
 import { getAvailabilityAggregates } from "./service-aggregates.js"
 import {
+  assignTravelerAllocation,
+  createAllocationResource,
+  deleteAllocationResource,
+  getSlotAllocationManifest,
+  listAllocationResources,
+  pairSharingGroup,
+  updateAllocationResource,
+  updateTravelerSharingGroup,
+} from "./service-allocation.js"
+import {
   createCloseout,
   createRule,
   createSlot,
@@ -61,6 +71,14 @@ import {
 import { getSlotUnitAvailability } from "./service-unit-availability.js"
 
 export const availabilityService = {
+  getSlotAllocationManifest,
+  listAllocationResources,
+  createAllocationResource,
+  updateAllocationResource,
+  deleteAllocationResource,
+  assignTravelerAllocation,
+  updateTravelerSharingGroup,
+  pairSharingGroup,
   getSlotUnitAvailability,
   getAvailabilityAggregates,
   listRules,

--- a/packages/availability/src/validation.ts
+++ b/packages/availability/src/validation.ts
@@ -10,6 +10,9 @@ export const availabilitySlotStatusSchema = z.enum(["open", "closed", "sold_out"
 export const meetingModeSchema = z.enum(["meeting_only", "pickup_only", "meet_or_pickup"])
 export const pickupGroupKindSchema = z.enum(["pickup", "dropoff", "meeting"])
 export const pickupTimingModeSchema = z.enum(["fixed_time", "offset_from_start"])
+export const allocationResourceKindSchema = z.string().trim().min(1).max(80)
+export const allocationResourceFlagsSchema = z.record(z.string(), z.unknown())
+export const travelerAllocationMapSchema = z.record(z.string(), z.string())
 
 const isoDateSchema = z.string().date()
 const isoDateTimeSchema = z.string().datetime()
@@ -114,6 +117,40 @@ export const availabilityCloseoutListQuerySchema = paginationSchema.extend({
   productId: z.string().optional(),
   slotId: z.string().optional(),
   dateLocal: isoDateSchema.optional(),
+})
+
+export const allocationResourceCoreSchema = z.object({
+  kind: allocationResourceKindSchema,
+  refType: z.string().nullable().optional(),
+  refId: z.string().nullable().optional(),
+  label: z.string().nullable().optional(),
+  capacity: z.number().int().min(1),
+  flags: allocationResourceFlagsSchema.default({}),
+  parentId: z.string().nullable().optional(),
+  sortOrder: z.number().int().default(0),
+})
+
+export const insertAllocationResourceSchema = allocationResourceCoreSchema
+export const updateAllocationResourceSchema = allocationResourceCoreSchema
+  .omit({ kind: true })
+  .strict()
+  .partial()
+  .refine((value) => Object.keys(value).length > 0, {
+    message: "Patch payload is required",
+  })
+
+export const assignTravelerAllocationSchema = z.object({
+  kind: allocationResourceKindSchema,
+  resourceId: z.string().nullable(),
+})
+
+export const updateTravelerSharingGroupSchema = z.object({
+  sharingGroupId: z.string().trim().min(1).nullable(),
+})
+
+export const pairSharingGroupSchema = z.object({
+  travelerIds: z.array(z.string().min(1)).min(2).max(20),
+  sharingGroupId: z.string().trim().min(1).optional(),
 })
 
 export const availabilityPickupPointCoreSchema = z.object({

--- a/packages/availability/tests/unit/validation.test.ts
+++ b/packages/availability/tests/unit/validation.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  allocationResourceKindSchema,
+  assignTravelerAllocationSchema,
   availabilityRuleListQuerySchema,
   availabilitySlotStatusSchema,
   customPickupAreaListQuerySchema,
+  insertAllocationResourceSchema,
   insertAvailabilityCloseoutSchema,
   insertAvailabilityPickupPointSchema,
   insertAvailabilityRuleSchema,
@@ -16,8 +19,11 @@ import {
   insertPickupLocationSchema,
   insertProductMeetingConfigSchema,
   meetingModeSchema,
+  pairSharingGroupSchema,
   pickupGroupKindSchema,
   pickupTimingModeSchema,
+  updateAllocationResourceSchema,
+  updateTravelerSharingGroupSchema,
 } from "../../src/validation.js"
 
 describe("Enum schemas", () => {
@@ -47,6 +53,73 @@ describe("Enum schemas", () => {
     for (const m of ["fixed_time", "offset_from_start"]) {
       expect(pickupTimingModeSchema.parse(m)).toBe(m)
     }
+  })
+
+  it("accepts valid allocation resource kinds", () => {
+    for (const kind of ["room", "vehicle", "guide", "equipment", "custom"]) {
+      expect(allocationResourceKindSchema.parse(kind)).toBe(kind)
+    }
+  })
+})
+
+describe("Allocation schema", () => {
+  it("accepts an allocation resource with defaults", () => {
+    const result = insertAllocationResourceSchema.parse({
+      slotId: "slot_abc",
+      kind: "room",
+      label: "Room 101",
+      capacity: 2,
+    })
+
+    expect(result.kind).toBe("room")
+    expect(result.capacity).toBe(2)
+    expect(result.sortOrder).toBe(0)
+    expect(result.flags).toEqual({})
+  })
+
+  it("rejects non-positive capacity", () => {
+    expect(() =>
+      insertAllocationResourceSchema.parse({
+        slotId: "slot_abc",
+        kind: "room",
+        label: "Invalid room",
+        capacity: 0,
+      }),
+    ).toThrow()
+  })
+
+  it("does not allow changing a resource kind through patch input", () => {
+    expect(() =>
+      updateAllocationResourceSchema.parse({
+        kind: "vehicle",
+      }),
+    ).toThrow()
+  })
+
+  it("accepts traveler allocation assignment and clearing", () => {
+    expect(
+      assignTravelerAllocationSchema.parse({
+        kind: "room",
+        resourceId: "resource_abc",
+      }),
+    ).toEqual({ kind: "room", resourceId: "resource_abc" })
+
+    expect(assignTravelerAllocationSchema.parse({ kind: "room", resourceId: null })).toEqual({
+      kind: "room",
+      resourceId: null,
+    })
+  })
+
+  it("accepts sharing-group updates and pairing requests", () => {
+    expect(updateTravelerSharingGroupSchema.parse({ sharingGroupId: "share_abc" })).toEqual({
+      sharingGroupId: "share_abc",
+    })
+
+    expect(
+      pairSharingGroupSchema.parse({
+        travelerIds: ["traveler_a", "traveler_b"],
+      }),
+    ).toEqual({ travelerIds: ["traveler_a", "traveler_b"] })
   })
 })
 

--- a/packages/bookings/src/index.ts
+++ b/packages/bookings/src/index.ts
@@ -111,13 +111,16 @@ export type { BookingRoutes } from "./routes.js"
 export type { PublicBookingRoutes } from "./routes-public.js"
 export { publicBookingRoutes } from "./routes-public.js"
 export type {
+  BookingTravelerBedPreference,
   BookingTravelerDietary,
   BookingTravelerIdentity,
   BookingTravelerTravelDetail,
   DecryptedBookingTravelerTravelDetail,
   NewBookingTravelerTravelDetail,
+  TravelerAllocationMap,
 } from "./schema/travel-details.js"
 export {
+  bookingTravelerBedPreferenceSchema,
   bookingTravelerDietarySchema,
   bookingTravelerIdentitySchema,
   bookingTravelerTravelDetailInsertSchema,
@@ -125,6 +128,7 @@ export {
   bookingTravelerTravelDetails,
   bookingTravelerTravelDetailUpdateSchema,
   decryptedBookingTravelerTravelDetailSchema,
+  travelerAllocationMapSchema,
 } from "./schema/travel-details.js"
 export type {
   Booking,

--- a/packages/bookings/src/pii.ts
+++ b/packages/bookings/src/pii.ts
@@ -3,11 +3,13 @@ import { decryptOptionalJsonEnvelope, encryptOptionalJsonEnvelope } from "@voyan
 import { eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import {
+  type BookingTravelerBedPreference,
   bookingTravelerAccessibilitySchema,
   bookingTravelerDietarySchema,
   bookingTravelerIdentitySchema,
   bookingTravelerTravelDetails,
   type DecryptedBookingTravelerTravelDetail,
+  type TravelerAllocationMap,
 } from "./schema/travel-details.js"
 import { bookingTravelers } from "./schema.js"
 
@@ -23,6 +25,10 @@ export interface UpsertBookingTravelerTravelDetailInput {
   dietaryRequirements?: string | null
   accessibilityNeeds?: string | null
   isLeadTraveler?: boolean | null
+  sharingGroupId?: string | null
+  roomTypeId?: string | null
+  bedPreference?: BookingTravelerBedPreference | null
+  allocations?: TravelerAllocationMap
 }
 
 /**
@@ -195,6 +201,10 @@ async function loadExistingTravelDetails(
     dietaryRequirements: dietary?.dietaryRequirements ?? null,
     accessibilityNeeds: accessibility?.accessibilityNeeds ?? null,
     isLeadTraveler: row.isLeadTraveler,
+    sharingGroupId: row.sharingGroupId ?? null,
+    roomTypeId: row.roomTypeId ?? null,
+    bedPreference: row.bedPreference ?? null,
+    allocations: row.allocations ?? {},
   }
 }
 
@@ -239,6 +249,15 @@ function mergeTravelDetailInput(
       input.isLeadTraveler === undefined
         ? (existing?.isLeadTraveler ?? false)
         : input.isLeadTraveler,
+    sharingGroupId:
+      input.sharingGroupId === undefined
+        ? (existing?.sharingGroupId ?? null)
+        : input.sharingGroupId,
+    roomTypeId: input.roomTypeId === undefined ? (existing?.roomTypeId ?? null) : input.roomTypeId,
+    bedPreference:
+      input.bedPreference === undefined ? (existing?.bedPreference ?? null) : input.bedPreference,
+    allocations:
+      input.allocations === undefined ? (existing?.allocations ?? {}) : input.allocations,
   }
 }
 
@@ -294,6 +313,10 @@ export function createBookingPiiService(options: BookingPiiServiceOptions): Book
         dietaryRequirements: dietary?.dietaryRequirements ?? null,
         accessibilityNeeds: accessibility?.accessibilityNeeds ?? null,
         isLeadTraveler: row.isLeadTraveler,
+        sharingGroupId: row.sharingGroupId ?? null,
+        roomTypeId: row.roomTypeId ?? null,
+        bedPreference: row.bedPreference ?? null,
+        allocations: row.allocations ?? {},
         createdAt: row.createdAt,
         updatedAt: row.updatedAt,
       }
@@ -344,6 +367,10 @@ export function createBookingPiiService(options: BookingPiiServiceOptions): Book
           accessibilityEncrypted,
           passportPersonDocumentId: mergedInput.passportPersonDocumentId ?? null,
           isLeadTraveler: mergedInput.isLeadTraveler ?? false,
+          sharingGroupId: mergedInput.sharingGroupId ?? null,
+          roomTypeId: mergedInput.roomTypeId ?? null,
+          bedPreference: mergedInput.bedPreference ?? null,
+          allocations: mergedInput.allocations ?? {},
           updatedAt: now,
         })
         .onConflictDoUpdate({
@@ -354,6 +381,10 @@ export function createBookingPiiService(options: BookingPiiServiceOptions): Book
             accessibilityEncrypted,
             passportPersonDocumentId: mergedInput.passportPersonDocumentId ?? null,
             isLeadTraveler: mergedInput.isLeadTraveler ?? false,
+            sharingGroupId: mergedInput.sharingGroupId ?? null,
+            roomTypeId: mergedInput.roomTypeId ?? null,
+            bedPreference: mergedInput.bedPreference ?? null,
+            allocations: mergedInput.allocations ?? {},
             updatedAt: now,
           },
         })

--- a/packages/bookings/src/schema/travel-details.ts
+++ b/packages/bookings/src/schema/travel-details.ts
@@ -1,4 +1,5 @@
 import { type KmsEnvelope, kmsEnvelopeSchema } from "@voyantjs/db/schema/iam"
+import { sql } from "drizzle-orm"
 import { boolean, index, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core"
 import { z } from "zod"
 
@@ -27,6 +28,15 @@ export const bookingTravelerAccessibilitySchema = z.object({
   accessibilityNeeds: z.string().optional().nullable(),
 })
 
+export const bookingTravelerBedPreferenceSchema = z.enum([
+  "single",
+  "twin",
+  "double",
+  "no-preference",
+])
+
+export const travelerAllocationMapSchema = z.record(z.string(), z.string())
+
 const decryptedBookingTravelerTravelDetailRecordSchema = z.object({
   travelerId: z.string(),
   nationality: z.string().nullable(),
@@ -39,6 +49,10 @@ const decryptedBookingTravelerTravelDetailRecordSchema = z.object({
   dietaryRequirements: z.string().nullable(),
   accessibilityNeeds: z.string().nullable(),
   isLeadTraveler: z.boolean(),
+  sharingGroupId: z.string().nullable(),
+  roomTypeId: z.string().nullable(),
+  bedPreference: bookingTravelerBedPreferenceSchema.nullable(),
+  allocations: travelerAllocationMapSchema,
   createdAt: z.date(),
   updatedAt: z.date(),
 })
@@ -63,10 +77,35 @@ export const bookingTravelerTravelDetails = pgTable(
      */
     passportPersonDocumentId: text("passport_person_document_id"),
     isLeadTraveler: boolean("is_lead_traveler").notNull().default(false),
+    /**
+     * Groups travelers across different bookings who share one resource
+     * while paying independently. Travelers on the same booking are grouped
+     * implicitly by `bookingId`.
+     */
+    sharingGroupId: text("sharing_group_id"),
+    /**
+     * Plain cross-package reference to a room type/catalog unit. No FK:
+     * hospitality/product catalogs are optional packages.
+     */
+    roomTypeId: text("room_type_id"),
+    bedPreference:
+      text("bed_preference").$type<z.infer<typeof bookingTravelerBedPreferenceSchema>>(),
+    /**
+     * Generic per-resource-kind allocation map, e.g.
+     * `{ room: "resource-id", vehicle_seat: "resource-id" }`.
+     */
+    allocations: jsonb("allocations")
+      .$type<Record<string, string>>()
+      .notNull()
+      .default(sql`'{}'::jsonb`),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (t) => [index("idx_bptd_lead_traveler").on(t.isLeadTraveler)],
+  (t) => [
+    index("idx_bptd_lead_traveler").on(t.isLeadTraveler),
+    index("idx_bptd_sharing_group").on(t.sharingGroupId),
+    index("idx_bptd_room_type").on(t.roomTypeId),
+  ],
 )
 
 const bookingTravelerTravelDetailRecordCoreSchema = z.object({
@@ -91,6 +130,10 @@ const bookingTravelerTravelDetailRecordCoreSchema = z.object({
     .nullable(),
   passportPersonDocumentId: z.string().nullable().optional(),
   isLeadTraveler: z.boolean().default(false),
+  sharingGroupId: z.string().nullable().optional(),
+  roomTypeId: z.string().nullable().optional(),
+  bedPreference: bookingTravelerBedPreferenceSchema.nullable().optional(),
+  allocations: travelerAllocationMapSchema.default({}),
 })
 
 export const bookingTravelerTravelDetailInsertSchema = bookingTravelerTravelDetailRecordCoreSchema
@@ -112,6 +155,8 @@ export const bookingTravelerTravelDetailSelectSchema =
 export type BookingTravelerIdentity = z.infer<typeof bookingTravelerIdentitySchema>
 export type BookingTravelerDietary = z.infer<typeof bookingTravelerDietarySchema>
 export type BookingTravelerAccessibility = z.infer<typeof bookingTravelerAccessibilitySchema>
+export type BookingTravelerBedPreference = z.infer<typeof bookingTravelerBedPreferenceSchema>
+export type TravelerAllocationMap = z.infer<typeof travelerAllocationMapSchema>
 export type BookingTravelerTravelDetail = z.infer<typeof bookingTravelerTravelDetailSelectSchema>
 export type NewBookingTravelerTravelDetail = z.infer<typeof bookingTravelerTravelDetailInsertSchema>
 export type DecryptedBookingTravelerTravelDetail = z.infer<

--- a/packages/bookings/tests/integration/pii.test.ts
+++ b/packages/bookings/tests/integration/pii.test.ts
@@ -13,7 +13,7 @@ function nextBookingNumber() {
 }
 
 describe.skipIf(!DB_AVAILABLE)("Booking PII service", () => {
-  // biome-ignore lint/suspicious/noExplicitAny: test db typing
+  // biome-ignore lint/suspicious/noExplicitAny: issue #695; test db helpers return a broad Drizzle client type.
   let db: any
 
   beforeAll(async () => {
@@ -30,12 +30,19 @@ describe.skipIf(!DB_AVAILABLE)("Booking PII service", () => {
         accessibility_encrypted jsonb,
         passport_person_document_id text,
         is_lead_traveler boolean DEFAULT false NOT NULL,
+        sharing_group_id text,
+        room_type_id text,
+        bed_preference text,
+        allocations jsonb DEFAULT '{}'::jsonb NOT NULL,
         created_at timestamp with time zone DEFAULT now() NOT NULL,
         updated_at timestamp with time zone DEFAULT now() NOT NULL
       )
     `)
     await db.execute(
       sql`CREATE INDEX idx_bttd_lead_traveler ON booking_traveler_travel_details (is_lead_traveler)`,
+    )
+    await db.execute(
+      sql`CREATE INDEX idx_bttd_sharing_group ON booking_traveler_travel_details (sharing_group_id)`,
     )
   })
 

--- a/packages/bookings/tests/integration/traveler-snapshot.test.ts
+++ b/packages/bookings/tests/integration/traveler-snapshot.test.ts
@@ -52,7 +52,7 @@ describe("applyTravelDetailSnapshot (pure)", () => {
 })
 
 describe.skipIf(!DB_AVAILABLE)("createTravelerWithTravelDetails snapshot wiring", () => {
-  // biome-ignore lint/suspicious/noExplicitAny: test db typing
+  // biome-ignore lint/suspicious/noExplicitAny: issue #695; test db helpers return a broad Drizzle client type.
   let db: any
 
   beforeAll(async () => {
@@ -68,12 +68,19 @@ describe.skipIf(!DB_AVAILABLE)("createTravelerWithTravelDetails snapshot wiring"
         accessibility_encrypted jsonb,
         passport_person_document_id text,
         is_lead_traveler boolean DEFAULT false NOT NULL,
+        sharing_group_id text,
+        room_type_id text,
+        bed_preference text,
+        allocations jsonb DEFAULT '{}'::jsonb NOT NULL,
         created_at timestamp with time zone DEFAULT now() NOT NULL,
         updated_at timestamp with time zone DEFAULT now() NOT NULL
       )
     `)
     await db.execute(
       sql`CREATE INDEX idx_bttd_lead_traveler ON booking_traveler_travel_details (is_lead_traveler)`,
+    )
+    await db.execute(
+      sql`CREATE INDEX idx_bttd_sharing_group ON booking_traveler_travel_details (sharing_group_id)`,
     )
   })
 

--- a/packages/bookings/tests/unit/travel-details-schema.test.ts
+++ b/packages/bookings/tests/unit/travel-details-schema.test.ts
@@ -17,7 +17,9 @@ describe("traveler travel detail schema aliases", () => {
       travelerId: "bkpt_abc",
       identityEncrypted: undefined,
       dietaryEncrypted: undefined,
+      accessibilityEncrypted: undefined,
       isLeadTraveler: true,
+      allocations: {},
     })
   })
 
@@ -27,7 +29,12 @@ describe("traveler travel detail schema aliases", () => {
       travelerId: "bkpt_abc",
       identityEncrypted: null,
       dietaryEncrypted: null,
+      accessibilityEncrypted: null,
       isLeadTraveler: false,
+      sharingGroupId: "share_1",
+      roomTypeId: "rt_double",
+      bedPreference: "twin",
+      allocations: { room: "alloc_1" },
       createdAt: now,
       updatedAt: now,
     })
@@ -36,7 +43,12 @@ describe("traveler travel detail schema aliases", () => {
       travelerId: "bkpt_abc",
       identityEncrypted: null,
       dietaryEncrypted: null,
+      accessibilityEncrypted: null,
       isLeadTraveler: false,
+      sharingGroupId: "share_1",
+      roomTypeId: "rt_double",
+      bedPreference: "twin",
+      allocations: { room: "alloc_1" },
       createdAt: now,
       updatedAt: now,
     })
@@ -56,6 +68,10 @@ describe("traveler travel detail schema aliases", () => {
       dietaryRequirements: null,
       accessibilityNeeds: null,
       isLeadTraveler: false,
+      sharingGroupId: "share_1",
+      roomTypeId: "rt_double",
+      bedPreference: "twin",
+      allocations: { room: "alloc_1" },
       createdAt: now,
       updatedAt: now,
     })
@@ -72,8 +88,33 @@ describe("traveler travel detail schema aliases", () => {
       dietaryRequirements: null,
       accessibilityNeeds: null,
       isLeadTraveler: false,
+      sharingGroupId: "share_1",
+      roomTypeId: "rt_double",
+      bedPreference: "twin",
+      allocations: { room: "alloc_1" },
       createdAt: now,
       updatedAt: now,
+    })
+  })
+
+  it("parses sharing, room type, bed preference, and generic allocations", () => {
+    const result = bookingTravelerTravelDetailInsertSchema.parse({
+      travelerId: "bkpt_abc",
+      sharingGroupId: "share_1",
+      roomTypeId: "rt_double",
+      bedPreference: "double",
+      allocations: {
+        room: "resource_room_102",
+        vehicle_seat: "resource_seat_3a",
+      },
+    })
+
+    expect(result.sharingGroupId).toBe("share_1")
+    expect(result.roomTypeId).toBe("rt_double")
+    expect(result.bedPreference).toBe("double")
+    expect(result.allocations).toEqual({
+      room: "resource_room_102",
+      vehicle_seat: "resource_seat_3a",
     })
   })
 

--- a/packages/db/src/lib/typeid-prefixes.ts
+++ b/packages/db/src/lib/typeid-prefixes.ts
@@ -82,6 +82,7 @@ export const PREFIXES = {
   availability_start_times: "avst",
   availability_slots: "avsl",
   availability_closeouts: "avcl",
+  allocation_resources: "alrs",
   availability_pickup_points: "avpp",
   availability_slot_pickups: "avsp",
   product_meeting_configs: "pmcf",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -955,6 +955,45 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@25.0.1)(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/allocation-ui:
+    devDependencies:
+      '@tanstack/react-query':
+        specifier: ^5.90.12
+        version: 5.96.2(react@19.2.4)
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@voyantjs/availability-react':
+        specifier: workspace:*
+        version: link:../availability-react
+      '@voyantjs/i18n':
+        specifier: workspace:*
+        version: link:../i18n
+      '@voyantjs/ui':
+        specifier: workspace:*
+        version: link:../ui
+      '@voyantjs/voyant-typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      lucide-react:
+        specifier: ^1.7.0
+        version: 1.7.0(react@19.2.4)
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/auth:
     dependencies:
       '@better-auth/api-key':

--- a/templates/dmc/migrations/0003_allocation_resources.sql
+++ b/templates/dmc/migrations/0003_allocation_resources.sql
@@ -1,0 +1,36 @@
+ALTER TABLE "booking_traveler_travel_details"
+  ADD COLUMN IF NOT EXISTS "sharing_group_id" text,
+  ADD COLUMN IF NOT EXISTS "room_type_id" text,
+  ADD COLUMN IF NOT EXISTS "bed_preference" text,
+  ADD COLUMN IF NOT EXISTS "allocations" jsonb DEFAULT '{}'::jsonb NOT NULL;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_bptd_sharing_group" ON "booking_traveler_travel_details" USING btree ("sharing_group_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_bptd_room_type" ON "booking_traveler_travel_details" USING btree ("room_type_id");
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "allocation_resources" (
+  "id" text PRIMARY KEY NOT NULL,
+  "slot_id" text NOT NULL,
+  "kind" text NOT NULL,
+  "ref_type" text,
+  "ref_id" text,
+  "label" text,
+  "capacity" integer NOT NULL,
+  "flags" jsonb DEFAULT '{}'::jsonb NOT NULL,
+  "parent_id" text,
+  "sort_order" integer DEFAULT 0 NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "allocation_resources" ADD CONSTRAINT "allocation_resources_slot_id_availability_slots_id_fk" FOREIGN KEY ("slot_id") REFERENCES "public"."availability_slots"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_allocation_resources_slot_kind" ON "allocation_resources" USING btree ("slot_id","kind");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_allocation_resources_parent" ON "allocation_resources" USING btree ("parent_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_allocation_resources_kind_sort" ON "allocation_resources" USING btree ("kind","sort_order","created_at");

--- a/templates/dmc/migrations/meta/_journal.json
+++ b/templates/dmc/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1778446136397,
       "tag": "0002_invoice_attachments",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1778544000000,
+      "tag": "0003_allocation_resources",
+      "breakpoints": true
     }
   ]
 }

--- a/templates/operator/migrations/0010_allocation_resources.sql
+++ b/templates/operator/migrations/0010_allocation_resources.sql
@@ -1,0 +1,36 @@
+ALTER TABLE "booking_traveler_travel_details"
+  ADD COLUMN IF NOT EXISTS "sharing_group_id" text,
+  ADD COLUMN IF NOT EXISTS "room_type_id" text,
+  ADD COLUMN IF NOT EXISTS "bed_preference" text,
+  ADD COLUMN IF NOT EXISTS "allocations" jsonb DEFAULT '{}'::jsonb NOT NULL;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_bptd_sharing_group" ON "booking_traveler_travel_details" USING btree ("sharing_group_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_bptd_room_type" ON "booking_traveler_travel_details" USING btree ("room_type_id");
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "allocation_resources" (
+  "id" text PRIMARY KEY NOT NULL,
+  "slot_id" text NOT NULL,
+  "kind" text NOT NULL,
+  "ref_type" text,
+  "ref_id" text,
+  "label" text,
+  "capacity" integer NOT NULL,
+  "flags" jsonb DEFAULT '{}'::jsonb NOT NULL,
+  "parent_id" text,
+  "sort_order" integer DEFAULT 0 NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "allocation_resources" ADD CONSTRAINT "allocation_resources_slot_id_availability_slots_id_fk" FOREIGN KEY ("slot_id") REFERENCES "public"."availability_slots"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_allocation_resources_slot_kind" ON "allocation_resources" USING btree ("slot_id","kind");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_allocation_resources_parent" ON "allocation_resources" USING btree ("parent_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_allocation_resources_kind_sort" ON "allocation_resources" USING btree ("kind","sort_order","created_at");

--- a/templates/operator/migrations/meta/_journal.json
+++ b/templates/operator/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1778446136397,
       "tag": "0009_invoice_attachments",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1778544000000,
+      "tag": "0010_allocation_resources",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add booking traveler travel-detail storage for sharing groups, room type, bed preference, and generic allocation maps
- add allocation resources, admin allocation routes, service capacity checks, and migrations for dev/operator/dmc
- add availability-react allocation schemas/hooks and a new allocation-ui room assignment surface

## Verification
- pnpm verify:fast
- pre-push hook ran pnpm test successfully
- commit hook ran agent-quality report, full lint, and full repository typecheck

Implements #695 and #696.