### PR TITLE
feat(agent-runner): recommend remote browser evidence

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -238,6 +238,11 @@ configured object storage. Use the printed browser evidence text as
 packet. Providers that do not declare the required adapter capabilities fail
 closed.
 
+Queue tick recommends this remote browser command for UI-labeled remote work
+that is in review or repair without browser proof. It intentionally leaves
+`<dev-server-command>` and `<port>` as maintainer-filled placeholders, so
+dispatch does not run it unattended.
+
 After a successful remote command, publish the remote evidence packet to GitHub
 or configured R2-compatible object storage:
 

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1201,7 +1201,10 @@ can call adapter-owned HTTP exposure for a remote port, capture that URL through
 local Playwright, store local ignored browser artifacts, and optionally publish
 the artifact directory to configured R2-compatible storage. It can also start
 and stop a named remote dev-server command around capture, so UI evidence does
-not require a manually pre-running server.
+not require a manually pre-running server. Queue recommendations now surface
+that remote browser capture command for UI-labeled remote work that lacks
+browser proof, while leaving the dev-server command and port as explicit
+maintainer-filled placeholders.
 `agent:queue:remote-start-process` and `agent:queue:remote-stop-process` can
 manage named long-running processes through adapter command execution, storing
 remote PID, command, log, and metadata files for browser-capture setup and

--- a/scripts/lib/agent-runner-tick.mjs
+++ b/scripts/lib/agent-runner-tick.mjs
@@ -202,6 +202,13 @@ function remoteWorkspaceRecommendation(item, { heartbeat, repository }) {
 
   if (!isRemoteWorkspaceDescriptor(descriptor)) return null
 
+  const remoteBrowserRecommendation = remoteBrowserEvidenceRecommendation(item, {
+    descriptor,
+    heartbeat,
+    repository,
+  })
+  if (remoteBrowserRecommendation) return remoteBrowserRecommendation
+
   if (state === "Human Review" && item.fields.PR) return null
   if (state === "Merge Ready" && item.fields.PR) return null
 
@@ -311,6 +318,30 @@ function remoteWorkspaceRecommendation(item, { heartbeat, repository }) {
   }
 
   return null
+}
+
+function remoteBrowserEvidenceRecommendation(item, { descriptor, heartbeat, repository }) {
+  const state = item.fields["Agent State"]
+  if (
+    !requiresBrowserEvidence(item) ||
+    browserEvidenceCovered(item.fields.Evidence) ||
+    !["Changes Requested", "CI Repair", "Human Review"].includes(state)
+  ) {
+    return null
+  }
+
+  return recommendation(item, {
+    action: "remote-capture-browser",
+    command: commandWithIssue({
+      command: "remote-capture-browser",
+      extraArgs: ['--dev-server-command "<dev-server-command>"', "--port <port>"],
+      issueNumber: item.issue.number,
+      repository,
+    }),
+    heartbeat,
+    priority: state === "Human Review" ? 54 : 35,
+    reason: `UI-labeled remote work in ${descriptor.reference} needs browser evidence before handoff`,
+  })
 }
 
 function humanReviewRecommendation(item, { heartbeat, repository }) {

--- a/scripts/tests/agent-runner-dispatch.test.mjs
+++ b/scripts/tests/agent-runner-dispatch.test.mjs
@@ -289,6 +289,28 @@ describe("agent runner dispatch helpers", () => {
         reason: "no dispatchable recommendation matched",
       },
     )
+
+    const remoteUiItem = workItem({
+      fields: {
+        "Agent State": "Human Review",
+        "Last Heartbeat": new Date().toISOString().slice(0, 10),
+        Workspace: "sandbox:sprite:task-579",
+      },
+    })
+    remoteUiItem.issue.labels = ["agent:ready", "ui-change"]
+
+    assert.deepEqual(
+      selectDispatchRecommendation([
+        recommendQueueAction(remoteUiItem, {
+          maxAgeDays: 1,
+          repository: "voyantjs/other",
+        }),
+      ]),
+      {
+        recommendation: null,
+        reason: "no dispatchable recommendation matched",
+      },
+    )
   })
 
   it("rejects invalid issue filters before selecting a recommendation", () => {

--- a/scripts/tests/agent-runner-tick.test.mjs
+++ b/scripts/tests/agent-runner-tick.test.mjs
@@ -241,6 +241,62 @@ describe("agent runner tick helpers", () => {
     )
   })
 
+  it("recommends remote browser capture for remote UI work before handoff", () => {
+    const item = workItem({
+      fields: {
+        "Agent State": "Human Review",
+        "Last Heartbeat": new Date().toISOString().slice(0, 10),
+        Workspace: "sandbox:sprite:task-579",
+      },
+    })
+    item.issue.labels = ["agent:ready", "ui-change"]
+
+    const recommendation = recommendQueueAction(item, {
+      maxAgeDays: 1,
+      repository: "voyantjs/other",
+    })
+    assert.equal(recommendation.action, "remote-capture-browser")
+    assert.equal(
+      recommendation.command,
+      'pnpm agent:queue:remote-capture-browser -- --issue 579 --repo voyantjs/other --dev-server-command "<dev-server-command>" --port <port> --yes',
+    )
+    assert.equal(recommendation.heartbeat.stale, false)
+    assert.equal(recommendation.priority, 54)
+    assert.equal(
+      recommendation.reason,
+      "UI-labeled remote work in sandbox:sprite:task-579 needs browser evidence before handoff",
+    )
+
+    const prLinkedItem = workItem({
+      fields: {
+        "Agent State": "Human Review",
+        "Last Heartbeat": new Date().toISOString().slice(0, 10),
+        PR: "https://github.com/voyantjs/voyant/pull/626",
+        Workspace: "sandbox:sprite:task-579",
+      },
+    })
+    prLinkedItem.issue.labels = ["agent:ready", "ui-change"]
+
+    assert.equal(
+      recommendQueueAction(prLinkedItem, { maxAgeDays: 1, repository: "voyantjs/other" }).action,
+      "remote-capture-browser",
+    )
+
+    const coveredItem = workItem({
+      fields: {
+        "Agent State": "Human Review",
+        Evidence: "docs/agent-evidence/active/579-test.md",
+        Workspace: "sandbox:sprite:task-579",
+      },
+    })
+    coveredItem.issue.labels = ["agent:ready", "ui-change"]
+
+    assert.equal(
+      recommendQueueAction(coveredItem, { maxAgeDays: 1, repository: "voyantjs/other" }).action,
+      "remote-publish-evidence",
+    )
+  })
+
   it("bootstraps ready remote workspace references before pausing local actions", () => {
     assert.deepEqual(
       recommendQueueAction(


### PR DESCRIPTION
## Summary

- recommend `remote-capture-browser` for UI-labeled remote workspace items that lack browser evidence
- keep the recommendation manual-only by leaving the dev-server command and port as explicit placeholders
- document the queue tick behavior in the remote browser evidence flow

## Verification

- `pnpm exec node --test scripts/tests/agent-runner-tick.test.mjs scripts/tests/agent-runner-dispatch.test.mjs`
- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- pre-commit hook: secretlint, agent quality, affected typecheck
- pre-push hook: package tests
