### PR TITLE
feat(agent-runner): validate remote browser evidence

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -184,6 +184,11 @@ packet under `docs/agent-evidence/active/`, then moves the item to
 `Human Review` on exit code `0` or `Blocked` on nonzero exit. It does not push
 branches, expose HTTP, capture browser artifacts, publish evidence, open PRs,
 or clean up the remote workspace.
+For UI-labeled work, pass `--ui-evidence` with the browser evidence text from
+`remote-capture-browser`. Successful remote commands validate local
+`.agent-runs/remote-browser/.../summary.json` artifacts before moving to review;
+blocking console or request issues keep the Project item in `Blocked` unless a
+maintainer explicitly passes `--allow-browser-issues`.
 
 Use a named remote process when a UI verification flow needs a long-running
 server before browser capture:
@@ -367,9 +372,9 @@ move the item to `Planning`. Remote workspace items in `Planning`,
 does not execute implementation commands automatically. Remote `Human Review`
 items with local evidence paths recommend `remote-publish-evidence`; after
 evidence is published, they recommend `remote-open-pr`. Later remote workspace
-states still recommend wait states until a remote adapter owns browser
-evidence. Terminal remote items recommend `remote-cleanup`. Malformed reserved
-`sandbox:` values recommend `inspect-workspace`.
+states still recommend explicit wait or manual evidence steps. Terminal remote
+items recommend `remote-cleanup`. Malformed reserved `sandbox:` values recommend
+`inspect-workspace`.
 
 Use dispatch to execute one allow-listed tick recommendation:
 

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1188,7 +1188,11 @@ branch inside a remote workspace. Ready remote-workspace items can be
 dispatched through that bootstrap path and move to `Planning` after success.
 `agent:queue:remote-run-command` can run an explicit supervised command in that
 remote repository, write a remote transcript and evidence packet, and move the
-Project item to `Human Review` or `Blocked`. `agent:queue:remote-publish-evidence`
+Project item to `Human Review` or `Blocked`. For UI-labeled remote work,
+successful remote commands validate `.agent-runs/remote-browser/.../summary.json`
+artifacts before handoff and keep the item blocked when browser capture found
+blocking console or request issues unless a maintainer accepts the exception.
+`agent:queue:remote-publish-evidence`
 can read that remote evidence packet through the configured adapter, post or
 reuse a GitHub evidence comment, optionally publish the packet to configured
 R2-compatible object storage, and update the Project `Evidence` field to the

--- a/scripts/agent-runner-remote-run-command.mjs
+++ b/scripts/agent-runner-remote-run-command.mjs
@@ -21,6 +21,7 @@ import {
 } from "./lib/agent-runner-help.mjs"
 import {
   remoteCommandRunArtifactPlan,
+  remoteCommandRunBrowserEvidenceBlockReason,
   remoteCommandRunEnvironment,
   remoteCommandRunFieldUpdate,
   remoteLoggedCommandShell,
@@ -54,6 +55,10 @@ maybePrintHelp(args, {
     [
       "--ui-evidence <text>",
       "Browser artifacts or approved exception for successful UI-labeled work.",
+    ],
+    [
+      "--allow-browser-issues",
+      "Allow UI evidence with browser quality issues after maintainer review.",
     ],
     ["--force", "Allow command execution outside the normal run states."],
     [
@@ -164,9 +169,17 @@ const commandResult = await runRemoteExec({
 })
 const stoppedAt = new Date()
 const exitCode = commandResult.status ?? 1
+const browserBlockReason = remoteCommandRunBrowserEvidenceBlockReason({
+  allowBrowserIssues: Boolean(args.allowBrowserIssues),
+  exitCode,
+  force: Boolean(args.force),
+  item,
+  repoRoot,
+  uiEvidence: args.uiEvidence,
+})
 const evidencePacket = buildCommandEvidencePacket({
-  artifactPlan: { ...artifactPlan, repoRoot },
-  blockedBy: null,
+  artifactPlan: { ...artifactPlan, browserEvidenceWorkspace: repoRoot, repoRoot },
+  blockedBy: browserBlockReason,
   branch,
   command: args.command,
   exitCode,
@@ -192,6 +205,7 @@ const evidenceWriteResult = await runRemoteExec({
 const finalUpdate = remoteCommandRunFieldUpdate({
   allowMissingBrowserEvidence: Boolean(args.force),
   artifactPlan,
+  browserBlockReason,
   evidenceWriteStatus: evidenceWriteResult.status ?? 1,
   exitCode,
   item,
@@ -205,7 +219,7 @@ if (finalUpdate.blockedBy && evidenceWriteResult.status === 0) {
       "-lc",
       remoteWriteFileShell({
         content: buildCommandEvidencePacket({
-          artifactPlan: { ...artifactPlan, repoRoot },
+          artifactPlan: { ...artifactPlan, browserEvidenceWorkspace: repoRoot, repoRoot },
           blockedBy: finalUpdate.blockedBy,
           branch,
           command: args.command,

--- a/scripts/lib/agent-runner-browser-validation.mjs
+++ b/scripts/lib/agent-runner-browser-validation.mjs
@@ -69,7 +69,9 @@ export function browserEvidenceSummaryPlan({ uiEvidence, workspace }) {
 }
 
 function browserEvidenceReferenceFromText(uiEvidence) {
-  const match = uiEvidence?.match(/docs\/agent-evidence\/browser\/[^\s)]+/)
+  const match = uiEvidence?.match(
+    /(?:docs\/agent-evidence\/browser|\.agent-runs\/remote-browser)\/[^\s)]+/,
+  )
   return match?.[0]?.replace(/[),.;]+$/g, "") ?? null
 }
 

--- a/scripts/lib/agent-runner-execution.mjs
+++ b/scripts/lib/agent-runner-execution.mjs
@@ -200,7 +200,7 @@ function formatBrowserEvidenceRequirement({ artifactPlan, item, uiEvidence }) {
   if (uiEvidence?.trim()) {
     return browserEvidenceReviewMarkdown({
       uiEvidence,
-      workspace: artifactPlan.workspace,
+      workspace: artifactPlan.browserEvidenceWorkspace ?? artifactPlan.workspace,
     })
   }
 

--- a/scripts/lib/agent-runner-remote-execution.mjs
+++ b/scripts/lib/agent-runner-remote-execution.mjs
@@ -1,7 +1,10 @@
 import path from "node:path"
 
 import { browserEvidenceMissingReason } from "./agent-runner-browser-evidence.mjs"
-import { commandRunFieldUpdate } from "./agent-runner-execution.mjs"
+import {
+  commandRunBrowserEvidenceBlockReason,
+  commandRunFieldUpdate,
+} from "./agent-runner-execution.mjs"
 import { defaultRemoteWorkspaceRepoDir } from "./agent-runner-remote-bootstrap.mjs"
 import { workspaceDescriptorEnvironment } from "./agent-runner-workspace-contract.mjs"
 
@@ -64,18 +67,20 @@ export function remoteCommandRunEnvironment({
   }
 }
 
-export function remoteCommandRunFieldUpdate({
-  allowMissingBrowserEvidence = false,
-  artifactPlan,
-  date = new Date(),
-  evidenceWriteStatus,
-  exitCode,
-  item,
-  uiEvidence,
-}) {
+export function remoteCommandRunFieldUpdate(options) {
+  const {
+    allowMissingBrowserEvidence = false,
+    artifactPlan,
+    date = new Date(),
+    evidenceWriteStatus,
+    exitCode,
+    item,
+    uiEvidence,
+  } = options
   const evidenceWriteFailed = evidenceWriteStatus !== 0
-  const browserBlock =
-    allowMissingBrowserEvidence || exitCode !== 0
+  const browserBlock = Object.hasOwn(options, "browserBlockReason")
+    ? options.browserBlockReason
+    : allowMissingBrowserEvidence || exitCode !== 0
       ? null
       : browserEvidenceMissingReason(item, uiEvidence)
   const blockedBy = evidenceWriteFailed
@@ -91,6 +96,24 @@ export function remoteCommandRunFieldUpdate({
       exitCode: evidenceWriteFailed ? evidenceWriteStatus : exitCode,
     }),
   }
+}
+
+export function remoteCommandRunBrowserEvidenceBlockReason({
+  allowBrowserIssues = false,
+  exitCode,
+  force = false,
+  item,
+  repoRoot,
+  uiEvidence,
+}) {
+  return commandRunBrowserEvidenceBlockReason({
+    allowBrowserIssues,
+    exitCode,
+    force: force && !uiEvidence?.trim(),
+    item,
+    uiEvidence,
+    workspace: repoRoot,
+  })
 }
 
 export function remoteLoggedCommandShell({ command, logFile }) {

--- a/scripts/tests/agent-runner-browser-validation.test.mjs
+++ b/scripts/tests/agent-runner-browser-validation.test.mjs
@@ -35,6 +35,21 @@ describe("agent runner browser evidence validation", () => {
       }),
       null,
     )
+
+    assert.deepEqual(
+      browserEvidenceSummaryPlan({
+        uiEvidence:
+          "browser artifacts: .agent-runs/remote-browser/579-test/2026-05-10T12-34-56-000Z",
+        workspace: "/repo",
+      }),
+      {
+        reference: ".agent-runs/remote-browser/579-test/2026-05-10T12-34-56-000Z/summary.json",
+        safePath: true,
+        summaryPath: path.resolve(
+          "/repo/.agent-runs/remote-browser/579-test/2026-05-10T12-34-56-000Z/summary.json",
+        ),
+      },
+    )
   })
 
   it("blocks local browser evidence summaries with captured blocking issues", () => {
@@ -86,6 +101,48 @@ describe("agent runner browser evidence validation", () => {
           workspace: tempDir,
         }),
         "browser evidence has blocking issues: 1 console error, 0 console warnings, 1 failed request; pass --allow-browser-issues only with an accepted exception",
+      )
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true })
+    }
+  })
+
+  it("blocks remote browser evidence summaries with captured blocking issues", () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "voyant-remote-browser-validation-"))
+    try {
+      const summaryDir = path.join(
+        tempDir,
+        ".agent-runs/remote-browser/579-test/2026-05-10T12-34-56-000Z",
+      )
+      mkdirSync(summaryDir, { recursive: true })
+      writeFileSync(
+        path.join(summaryDir, "summary.json"),
+        JSON.stringify({
+          browserIssues: {
+            consoleErrors: 0,
+            consoleWarnings: 0,
+            failedRequests: 1,
+            hasBlockingIssues: true,
+            httpErrors: 1,
+            malformedLogLines: 0,
+            requestFailures: 0,
+          },
+        }),
+      )
+
+      const item = workItem()
+      item.issue.labels = ["ui"]
+      const uiEvidence =
+        "browser artifacts: .agent-runs/remote-browser/579-test/2026-05-10T12-34-56-000Z"
+
+      assert.equal(
+        commandRunBrowserEvidenceBlockReason({
+          exitCode: 0,
+          item,
+          uiEvidence,
+          workspace: tempDir,
+        }),
+        "browser evidence has blocking issues: 0 console errors, 0 console warnings, 1 failed request; pass --allow-browser-issues only with an accepted exception",
       )
     } finally {
       rmSync(tempDir, { force: true, recursive: true })

--- a/scripts/tests/agent-runner-remote-execution.test.mjs
+++ b/scripts/tests/agent-runner-remote-execution.test.mjs
@@ -1,8 +1,12 @@
 import assert from "node:assert/strict"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import os from "node:os"
+import path from "node:path"
 import { describe, it } from "node:test"
 
 import {
   remoteCommandRunArtifactPlan,
+  remoteCommandRunBrowserEvidenceBlockReason,
   remoteCommandRunEnvironment,
   remoteCommandRunFieldUpdate,
   remoteLoggedCommandShell,
@@ -134,6 +138,30 @@ describe("agent runner remote execution helpers", () => {
       remoteCommandRunFieldUpdate({
         artifactPlan,
         date: new Date("2026-05-11T12:00:00.000Z"),
+        browserBlockReason:
+          "browser evidence has blocking issues: 0 console errors, 0 console warnings, 1 failed request; pass --allow-browser-issues only with an accepted exception",
+        evidenceWriteStatus: 0,
+        exitCode: 0,
+        item: workItem(),
+      }),
+      {
+        blockedBy:
+          "browser evidence has blocking issues: 0 console errors, 0 console warnings, 1 failed request; pass --allow-browser-issues only with an accepted exception",
+        clear: [],
+        values: {
+          "Agent State": "Blocked",
+          "Blocked By":
+            "browser evidence has blocking issues: 0 console errors, 0 console warnings, 1 failed request; pass --allow-browser-issues only with an accepted exception",
+          "Last Heartbeat": "2026-05-11",
+          Evidence: "docs/agent-evidence/active/579-test-agent-project-intake-workflow.md",
+        },
+      },
+    )
+
+    assert.deepEqual(
+      remoteCommandRunFieldUpdate({
+        artifactPlan,
+        date: new Date("2026-05-11T12:00:00.000Z"),
         evidenceWriteStatus: 1,
         exitCode: 0,
         item: workItem(),
@@ -149,5 +177,56 @@ describe("agent runner remote execution helpers", () => {
         },
       },
     )
+  })
+
+  it("preserves remote browser issue checks when command execution is forced", () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "voyant-remote-command-browser-"))
+    try {
+      const summaryDir = path.join(
+        tempDir,
+        ".agent-runs/remote-browser/579-test/2026-05-10T12-34-56-000Z",
+      )
+      mkdirSync(summaryDir, { recursive: true })
+      writeFileSync(
+        path.join(summaryDir, "summary.json"),
+        JSON.stringify({
+          browserIssues: {
+            consoleErrors: 1,
+            consoleWarnings: 0,
+            failedRequests: 0,
+            hasBlockingIssues: true,
+            httpErrors: 0,
+            malformedLogLines: 0,
+            requestFailures: 0,
+          },
+        }),
+      )
+
+      const item = workItem()
+      item.issue.labels = ["ui"]
+
+      assert.equal(
+        remoteCommandRunBrowserEvidenceBlockReason({
+          exitCode: 0,
+          force: true,
+          item,
+          repoRoot: tempDir,
+          uiEvidence:
+            "browser artifacts: .agent-runs/remote-browser/579-test/2026-05-10T12-34-56-000Z",
+        }),
+        "browser evidence has blocking issues: 1 console error, 0 console warnings, 0 failed requests; pass --allow-browser-issues only with an accepted exception",
+      )
+      assert.equal(
+        remoteCommandRunBrowserEvidenceBlockReason({
+          exitCode: 0,
+          force: true,
+          item,
+          repoRoot: tempDir,
+        }),
+        null,
+      )
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true })
+    }
   })
 })


### PR DESCRIPTION
## Summary

- validate `.agent-runs/remote-browser/...` summaries during remote command handoff
- block UI-labeled remote work when browser evidence contains blocking console or request issues, unless explicitly allowed
- document remote browser evidence validation and the reviewed exception flag

## Verification

- `pnpm exec node --test scripts/tests/agent-runner-browser-validation.test.mjs scripts/tests/agent-runner-remote-execution.test.mjs`
- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- pre-commit hook: secretlint, agent quality, affected typecheck
- pre-push hook: package tests
