### PR TITLE
feat(agent-runner): surface recent runner events in status

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -346,9 +346,11 @@ pnpm agent:queue:status
 Status mode scans all Project pages for the current repository and reports
 ready, active, stale, blocked, human-review, and merge-ready items. Pass
 `--json` for automation or `--max-age-days <number>` to adjust the heartbeat
-staleness threshold. For UI-labeled work, status distinguishes browser artifact
-references from generic transcript or evidence fields so active runs do not
-hide missing browser capture.
+staleness threshold. It also tails recent JSONL runner events from
+`.agent-runs/events.jsonl`; pass `--recent-events 0` to hide them or
+`--event-log <path>` to inspect a different audit log. For UI-labeled work,
+status distinguishes browser artifact references from generic transcript or
+evidence fields so active runs do not hide missing browser capture.
 
 Use the read-only tick view when wiring an always-on supervisor:
 

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1147,8 +1147,11 @@ failed CI logs into local repair packets, and mark merged PRs done. PR sync can
 also refresh a PR description from the current evidence packet with
 `pnpm agent:queue:sync-pr -- --issue <number> --update-body --yes`; this is
 explicit so maintainer-edited PR descriptions are not overwritten by routine
-state polling. Dispatch, loop, and control-plane planning can pass the same
-option through to `sync-pr` when the runner intentionally wants that refresh.
+state polling. Dispatch and loop write JSONL audit events, and status can tail
+recent events so a maintainer or future dashboard can see the last supervised
+actions without opening raw log files. Dispatch, loop, and control-plane
+planning can pass the same option through to `sync-pr` when the runner
+intentionally wants that refresh.
 
 Verification:
 

--- a/scripts/agent-runner-status.mjs
+++ b/scripts/agent-runner-status.mjs
@@ -11,6 +11,7 @@ import {
   browserEvidenceReferenceKind,
   requiresBrowserEvidence,
 } from "./lib/agent-runner-browser-evidence.mjs"
+import { readAgentRunnerEvents, resolveEventLogPath } from "./lib/agent-runner-events.mjs"
 import { maybePrintHelp, projectOptions, repositoryOptions } from "./lib/agent-runner-help.mjs"
 import { evaluateHeartbeat } from "./lib/agent-runner-output.mjs"
 
@@ -31,6 +32,8 @@ maybePrintHelp(args, {
   options: [
     ["--json", "Print machine-readable JSON."],
     ["--max-age-days <number>", "Heartbeat staleness threshold. Defaults to 1."],
+    ["--event-log <path>", "JSONL audit log path. Defaults to .agent-runs/events.jsonl."],
+    ["--recent-events <number>", "Number of recent runner events to show. Defaults to 5."],
     ...repositoryOptions,
     ...projectOptions,
   ],
@@ -39,6 +42,8 @@ maybePrintHelp(args, {
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
 const maxAgeDays = Number(args.maxAgeDays ?? 1)
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
+const recentEventLimit = numberArg(args.recentEvents, "recent-events", 5, { min: 0 })
 
 if (!Number.isInteger(maxAgeDays) || maxAgeDays < 0) {
   fail(`invalid max age days: ${String(args.maxAgeDays)}`)
@@ -57,6 +62,7 @@ const staleItems = activeItems.filter((item) => item.heartbeat.stale)
 const blockedItems = items.filter((item) => item.fields["Agent State"] === "Blocked")
 const reviewItems = items.filter((item) => item.fields["Agent State"] === "Human Review")
 const mergeReadyItems = items.filter((item) => item.fields["Agent State"] === "Merge Ready")
+const recentEvents = readRecentEvents()
 
 if (args.json) {
   console.log(
@@ -70,6 +76,10 @@ if (args.json) {
         },
         repository,
         maxAgeDays,
+        eventLog: {
+          path: eventLogPath,
+          recentEvents,
+        },
         counts: {
           scanned: items.length,
           ready: readyItems.length,
@@ -113,6 +123,7 @@ function printHumanSummary() {
   printSection("Blocked items", blockedItems)
   printSection("Human review items", reviewItems)
   printSection("Merge ready items", mergeReadyItems)
+  printRecentEvents()
 }
 
 function printSection(title, sectionItems, extraPrinter) {
@@ -148,6 +159,37 @@ function printHeartbeat(item) {
   console.log(`  reason: ${item.heartbeat.reason}`)
 }
 
+function printRecentEvents() {
+  if (recentEventLimit === 0 || recentEvents.length === 0) return
+
+  console.log("Recent runner events:")
+  for (const event of recentEvents) {
+    console.log(`- ${formatEventSummary(event)}`)
+    if (event.recommendation?.reason) {
+      console.log(`  reason: ${event.recommendation.reason}`)
+    }
+    if (Array.isArray(event.command) && event.command.length > 0) {
+      console.log(`  command: ${event.command.join(" ")}`)
+    }
+  }
+  console.log("")
+}
+
+function formatEventSummary(event) {
+  const issueNumber = event.recommendation?.issue?.number
+  const action = event.recommendation?.action
+  const status = event.status === undefined ? null : `status ${event.status}`
+  return [
+    event.timestamp ?? "no timestamp",
+    event.type,
+    issueNumber ? `#${issueNumber}` : null,
+    action ?? null,
+    status,
+  ]
+    .filter(Boolean)
+    .join(" ")
+}
+
 function summaryItem(item) {
   const browserEvidenceRequired = requiresBrowserEvidence(item)
   const browserEvidenceKind = browserEvidenceReferenceKind(item.fields.Evidence)
@@ -168,4 +210,22 @@ function summaryItem(item) {
       browserArtifactReferencePresent: browserEvidenceKind === "browser-artifacts",
     },
   }
+}
+
+function readRecentEvents() {
+  try {
+    return readAgentRunnerEvents(eventLogPath, { limit: recentEventLimit })
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error))
+  }
+}
+
+function numberArg(value, name, fallback, { min = 1 } = {}) {
+  if (value === undefined) return fallback
+
+  const number = Number(value)
+  if (!Number.isInteger(number) || number < min) {
+    fail(`invalid ${name}: ${value}`)
+  }
+  return number
 }

--- a/scripts/lib/agent-runner-events.mjs
+++ b/scripts/lib/agent-runner-events.mjs
@@ -1,7 +1,16 @@
-import { appendFileSync, mkdirSync } from "node:fs"
+import {
+  appendFileSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  statSync,
+} from "node:fs"
 import path from "node:path"
 
 export const defaultEventLogPath = ".agent-runs/events.jsonl"
+const defaultEventLogTailBytes = 256 * 1024
 
 export function resolveEventLogPath(value, { repoRoot = process.cwd() } = {}) {
   const eventLogPath = value ?? defaultEventLogPath
@@ -13,6 +22,24 @@ export function appendAgentRunnerEvent({ event, eventLogPath, now = new Date() }
   mkdirSync(path.dirname(eventLogPath), { recursive: true })
   appendFileSync(eventLogPath, `${JSON.stringify(entry)}\n`, "utf8")
   return entry
+}
+
+export function readAgentRunnerEvents(
+  eventLogPath,
+  { limit = 20, maxBytes = defaultEventLogTailBytes } = {},
+) {
+  const normalizedLimit = normalizeEventLimit(limit)
+  if (!existsSync(eventLogPath) || normalizedLimit === 0) return []
+
+  const tail = readEventLogTail(eventLogPath, { maxBytes })
+  const lines = tail.text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+
+  if (tail.truncated) lines.shift()
+
+  return lines.slice(-normalizedLimit).map((line) => parseEventLine(line))
 }
 
 export function recommendationEventDetails(recommendation) {
@@ -37,4 +64,54 @@ function normalizeEvent(event, { now }) {
     timestamp: now.toISOString(),
     ...event,
   }
+}
+
+function normalizeEventLimit(limit) {
+  const normalized = Number(limit)
+  if (!Number.isInteger(normalized) || normalized < 0) {
+    throw new Error(`agent runner event limit must be a non-negative integer: ${String(limit)}`)
+  }
+  return normalized
+}
+
+function readEventLogTail(eventLogPath, { maxBytes }) {
+  const normalizedMaxBytes = normalizeTailBytes(maxBytes)
+  const stats = statSync(eventLogPath)
+  if (stats.size === 0 || normalizedMaxBytes === 0) {
+    return { text: "", truncated: stats.size > 0 }
+  }
+
+  const byteLength = Math.min(stats.size, normalizedMaxBytes)
+  const start = stats.size - byteLength
+  const buffer = Buffer.alloc(byteLength)
+  const fd = openSync(eventLogPath, "r")
+
+  try {
+    readSync(fd, buffer, 0, byteLength, start)
+  } finally {
+    closeSync(fd)
+  }
+
+  return {
+    text: buffer.toString("utf8"),
+    truncated: start > 0,
+  }
+}
+
+function normalizeTailBytes(maxBytes) {
+  const normalized = Number(maxBytes)
+  if (!Number.isInteger(normalized) || normalized < 0) {
+    throw new Error(
+      `agent runner event tail bytes must be a non-negative integer: ${String(maxBytes)}`,
+    )
+  }
+  return normalized
+}
+
+function parseEventLine(line) {
+  const event = JSON.parse(line)
+  if (!event?.type) {
+    throw new Error("agent runner event log line is missing type")
+  }
+  return event
 }

--- a/scripts/tests/agent-runner-events.test.mjs
+++ b/scripts/tests/agent-runner-events.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { mkdtempSync, readFileSync } from "node:fs"
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import path from "node:path"
 import { describe, it } from "node:test"
@@ -7,6 +7,7 @@ import { describe, it } from "node:test"
 import {
   appendAgentRunnerEvent,
   defaultEventLogPath,
+  readAgentRunnerEvents,
   recommendationEventDetails,
   resolveEventLogPath,
 } from "../lib/agent-runner-events.mjs"
@@ -46,6 +47,47 @@ describe("agent runner event helpers", () => {
     assert.equal(`${JSON.stringify(entry)}\n`, readFileSync(eventLogPath, "utf8"))
   })
 
+  it("reads a bounded tail of JSONL runner events", () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), "agent-runner-events-"))
+    const eventLogPath = path.join(tempDir, "events.jsonl")
+
+    writeFileSync(
+      eventLogPath,
+      [
+        JSON.stringify({ timestamp: "2026-05-10T12:00:00.000Z", type: "one" }),
+        "",
+        JSON.stringify({ timestamp: "2026-05-10T12:01:00.000Z", type: "two" }),
+        JSON.stringify({ timestamp: "2026-05-10T12:02:00.000Z", type: "three" }),
+      ].join("\n"),
+      "utf8",
+    )
+
+    assert.deepEqual(readAgentRunnerEvents(eventLogPath, { limit: 2 }), [
+      { timestamp: "2026-05-10T12:01:00.000Z", type: "two" },
+      { timestamp: "2026-05-10T12:02:00.000Z", type: "three" },
+    ])
+    assert.deepEqual(readAgentRunnerEvents(eventLogPath, { limit: 0 }), [])
+    assert.deepEqual(readAgentRunnerEvents(path.join(tempDir, "missing.jsonl")), [])
+  })
+
+  it("does not parse historical event lines outside the bounded tail", () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), "agent-runner-events-"))
+    const eventLogPath = path.join(tempDir, "events.jsonl")
+    const historicalLine = `${JSON.stringify({ timestamp: "2026-05-10T12:00:00.000Z" })}${"x".repeat(200)}`
+    const recentEvents = [
+      { timestamp: "2026-05-10T12:01:00.000Z", type: "two" },
+      { timestamp: "2026-05-10T12:02:00.000Z", type: "three" },
+    ]
+
+    writeFileSync(
+      eventLogPath,
+      [historicalLine, ...recentEvents.map((event) => JSON.stringify(event))].join("\n"),
+      "utf8",
+    )
+
+    assert.deepEqual(readAgentRunnerEvents(eventLogPath, { limit: 2, maxBytes: 150 }), recentEvents)
+  })
+
   it("extracts stable recommendation details for logs", () => {
     const recommendation = recommendQueueAction(workItem({ number: 579 }), {
       maxAgeDays: 1,
@@ -72,6 +114,21 @@ describe("agent runner event helpers", () => {
           event: {},
         }),
       /agent runner event requires a type/,
+    )
+  })
+
+  it("rejects invalid event read limits and missing event types", () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), "agent-runner-events-"))
+    const eventLogPath = path.join(tempDir, "events.jsonl")
+    writeFileSync(eventLogPath, `${JSON.stringify({ timestamp: "2026-05-10T12:00:00.000Z" })}\n`)
+
+    assert.throws(
+      () => readAgentRunnerEvents(eventLogPath, { limit: "x" }),
+      /agent runner event limit must be a non-negative integer: x/,
+    )
+    assert.throws(
+      () => readAgentRunnerEvents(eventLogPath),
+      /agent runner event log line is missing type/,
     )
   })
 })


### PR DESCRIPTION
## Summary
- add a bounded JSONL event-log reader for runner audit events
- show recent runner events in `agent:queue:status` human and JSON output
- document the status/event-log behavior in the runner docs and orchestration plan

## Verification
- `pnpm exec node --test scripts/tests/agent-runner-events.test.mjs scripts/tests/agent-runner-dispatch.test.mjs`
- `pnpm agent:queue:test`
- `pnpm agent:queue:status -- --help`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
