### PR TITLE
feat(agent-runner): record lifecycle audit events

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -423,6 +423,11 @@ Claim mode checks the same execution gate, then updates GitHub Project fields:
 - `Workspace = <planned workspace>`
 - `Last Heartbeat = <today>`
 
+Successful `claim`, `start`, `heartbeat`, `release`, and `complete-pr`
+commands append local JSONL audit events to `.agent-runs/events.jsonl` by
+default; pass `--event-log <path>` when a supervisor needs a different local
+ledger path.
+
 While work is claimed, refresh the item heartbeat or state:
 
 ```bash

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1147,11 +1147,11 @@ failed CI logs into local repair packets, and mark merged PRs done. PR sync can
 also refresh a PR description from the current evidence packet with
 `pnpm agent:queue:sync-pr -- --issue <number> --update-body --yes`; this is
 explicit so maintainer-edited PR descriptions are not overwritten by routine
-state polling. Dispatch and loop write JSONL audit events, and status can tail
-recent events so a maintainer or future dashboard can see the last supervised
-actions without opening raw log files. Dispatch, loop, and control-plane
-planning can pass the same option through to `sync-pr` when the runner
-intentionally wants that refresh.
+state polling. Dispatch, loop, and core lifecycle mutations write JSONL audit
+events, and status can tail recent events so a maintainer or future dashboard
+can see the last supervised actions without opening raw log files. Dispatch,
+loop, and control-plane planning can pass the same option through to `sync-pr`
+when the runner intentionally wants that refresh.
 
 Verification:
 

--- a/scripts/agent-runner-claim.mjs
+++ b/scripts/agent-runner-claim.mjs
@@ -9,6 +9,12 @@ import {
 } from "./lib/agent-project-queue.mjs"
 import { claimFieldValues, claimProjectItem, printClaimUpdate } from "./lib/agent-runner-claim.mjs"
 import {
+  issueEventDetails,
+  resolveEventLogPath,
+  tryAppendAgentRunnerEvent,
+} from "./lib/agent-runner-events.mjs"
+import {
+  eventLogOptions,
   maybePrintHelp,
   mutationOptions,
   projectOptions,
@@ -23,6 +29,7 @@ maybePrintHelp(args, {
   options: [
     ["--issue <number>", "Issue number to claim. Required when multiple items are ready."],
     ...repositoryOptions,
+    ...eventLogOptions,
     ...mutationOptions,
     ...projectOptions,
   ],
@@ -30,19 +37,30 @@ maybePrintHelp(args, {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
 const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const item = findSelectedReadyItem(project.items, {
   issueNumber: args.issue,
   repository,
 })
-const values = claimFieldValues(item)
+const claimedAt = new Date()
+const values = claimFieldValues(item, claimedAt)
 
 if (!args.yes) {
   printClaimUpdate({ item, repository, values })
   fail("claim mode updates GitHub Project fields; rerun with --yes to continue")
 }
 
-claimProjectItem({ item, project })
+claimProjectItem({ date: claimedAt, item, project })
+tryAppendAgentRunnerEvent({
+  eventLogPath,
+  event: {
+    type: "claim.completed",
+    fields: values,
+    issue: issueEventDetails(item),
+    repository,
+  },
+})
 
 console.log("agent-runner claim: updated GitHub Project fields")
 console.log(`issue: #${item.issue.number} ${item.issue.title}`)

--- a/scripts/agent-runner-complete-pr.mjs
+++ b/scripts/agent-runner-complete-pr.mjs
@@ -9,6 +9,12 @@ import {
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import {
+  issueEventDetails,
+  resolveEventLogPath,
+  tryAppendAgentRunnerEvent,
+} from "./lib/agent-runner-events.mjs"
+import {
+  eventLogOptions,
   maybePrintHelp,
   mutationOptions,
   projectOptions,
@@ -31,6 +37,7 @@ maybePrintHelp(args, {
     ["--pr <url-or-number>", "PR URL or number override. Defaults from the Project PR field."],
     ["--workspace <path>", "Workspace path override for gh context."],
     ...repositoryOptions,
+    ...eventLogOptions,
     ...mutationOptions,
     ...projectOptions,
   ],
@@ -42,6 +49,7 @@ if (!args.issue) {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
 const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const item = findProjectIssueItem(project.items, {
   issueNumber: args.issue,
@@ -68,6 +76,20 @@ if (!args.yes) {
 }
 
 updateProjectItemFields({ project, item, values, clear })
+tryAppendAgentRunnerEvent({
+  eventLogPath,
+  event: {
+    type: "complete-pr.completed",
+    clearedFields: clear,
+    fields: values,
+    issue: issueEventDetails(item),
+    pr: {
+      number: pr.number,
+      url: pr.url,
+    },
+    repository,
+  },
+})
 
 console.log("agent-runner complete-pr: marked Project item done")
 console.log(`issue: #${item.issue.number} ${item.issue.title}`)

--- a/scripts/agent-runner-dispatch.mjs
+++ b/scripts/agent-runner-dispatch.mjs
@@ -19,6 +19,7 @@ import {
   resolveEventLogPath,
 } from "./lib/agent-runner-events.mjs"
 import {
+  eventLogOptions,
   maybePrintHelp,
   mutationOptions,
   projectOptions,
@@ -38,7 +39,7 @@ maybePrintHelp(args, {
       `Only dispatch this action. Allowed: ${Array.from(dispatchableActions).join(", ")}.`,
     ],
     ["--max-age-days <number>", "Heartbeat staleness threshold. Defaults to 1."],
-    ["--event-log <path>", "JSONL audit log path. Defaults to .agent-runs/events.jsonl."],
+    ...eventLogOptions,
     ["--update-body", "When dispatching sync-pr, refresh the PR body from evidence."],
     ...repositoryOptions,
     ...mutationOptions,

--- a/scripts/agent-runner-heartbeat.mjs
+++ b/scripts/agent-runner-heartbeat.mjs
@@ -9,6 +9,12 @@ import {
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import {
+  issueEventDetails,
+  resolveEventLogPath,
+  tryAppendAgentRunnerEvent,
+} from "./lib/agent-runner-events.mjs"
+import {
+  eventLogOptions,
   maybePrintHelp,
   mutationOptions,
   projectOptions,
@@ -37,6 +43,7 @@ maybePrintHelp(args, {
     ["--evidence <url-or-path>", "Evidence pointer to write to the Project item."],
     ["--force", "Allow updates outside the normal heartbeat states."],
     ...repositoryOptions,
+    ...eventLogOptions,
     ...mutationOptions,
     ...projectOptions,
   ],
@@ -48,6 +55,7 @@ if (!args.issue) {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
 const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const item = findProjectIssueItem(project.items, {
   issueNumber: args.issue,
@@ -96,6 +104,17 @@ if (!args.yes) {
 }
 
 updateProjectItemFields({ project, item, values, clear })
+tryAppendAgentRunnerEvent({
+  eventLogPath,
+  event: {
+    type: "heartbeat.completed",
+    clearedFields: clear,
+    fields: values,
+    issue: issueEventDetails(item),
+    previousAgentState: currentState ?? null,
+    repository,
+  },
+})
 
 console.log("agent-runner heartbeat: updated GitHub Project fields")
 console.log(`issue: #${item.issue.number} ${item.issue.title}`)

--- a/scripts/agent-runner-loop.mjs
+++ b/scripts/agent-runner-loop.mjs
@@ -19,6 +19,7 @@ import {
   resolveEventLogPath,
 } from "./lib/agent-runner-events.mjs"
 import {
+  eventLogOptions,
   maybePrintHelp,
   mutationOptions,
   projectOptions,
@@ -41,7 +42,7 @@ maybePrintHelp(args, {
       `Only dispatch this action. Allowed: ${Array.from(dispatchableActions).join(", ")}.`,
     ],
     ["--max-age-days <number>", "Heartbeat staleness threshold. Defaults to 1."],
-    ["--event-log <path>", "JSONL audit log path. Defaults to .agent-runs/events.jsonl."],
+    ...eventLogOptions,
     ["--update-body", "When dispatching sync-pr, refresh the PR body from evidence."],
     ...repositoryOptions,
     ...mutationOptions,

--- a/scripts/agent-runner-release.mjs
+++ b/scripts/agent-runner-release.mjs
@@ -9,6 +9,12 @@ import {
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import {
+  issueEventDetails,
+  resolveEventLogPath,
+  tryAppendAgentRunnerEvent,
+} from "./lib/agent-runner-events.mjs"
+import {
+  eventLogOptions,
   maybePrintHelp,
   mutationOptions,
   projectOptions,
@@ -35,6 +41,7 @@ maybePrintHelp(args, {
     ["--evidence <text>", "Explicit Evidence field value. Defaults from --reason."],
     ["--force", "Allow release outside the normal claimed states."],
     ...repositoryOptions,
+    ...eventLogOptions,
     ...mutationOptions,
     ...projectOptions,
   ],
@@ -46,6 +53,7 @@ if (!args.issue) {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
 const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const item = findProjectIssueItem(project.items, {
   issueNumber: args.issue,
@@ -79,6 +87,17 @@ if (!args.yes) {
 }
 
 updateProjectItemFields({ project, item, values, clear })
+tryAppendAgentRunnerEvent({
+  eventLogPath,
+  event: {
+    type: "release.completed",
+    clearedFields: clear,
+    fields: values,
+    issue: issueEventDetails(item),
+    previousAgentState: currentState ?? null,
+    repository,
+  },
+})
 
 console.log("agent-runner release: updated GitHub Project fields")
 console.log(`issue: #${item.issue.number} ${item.issue.title}`)

--- a/scripts/agent-runner-start.mjs
+++ b/scripts/agent-runner-start.mjs
@@ -9,6 +9,12 @@ import {
 } from "./lib/agent-project-queue.mjs"
 import { claimFieldValues, claimProjectItem, printClaimUpdate } from "./lib/agent-runner-claim.mjs"
 import {
+  issueEventDetails,
+  resolveEventLogPath,
+  tryAppendAgentRunnerEvent,
+} from "./lib/agent-runner-events.mjs"
+import {
+  eventLogOptions,
   maybePrintHelp,
   mutationOptions,
   projectOptions,
@@ -29,6 +35,7 @@ maybePrintHelp(args, {
     ["--issue <number>", "Issue number to start. Required when multiple items are ready."],
     ["--base <ref>", "Base ref for the new worktree branch. Defaults to origin/main."],
     ...repositoryOptions,
+    ...eventLogOptions,
     ...mutationOptions,
     ...projectOptions,
   ],
@@ -36,6 +43,7 @@ maybePrintHelp(args, {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
 const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const item = findSelectedReadyItem(project.items, {
   issueNumber: args.issue,
@@ -43,7 +51,8 @@ const item = findSelectedReadyItem(project.items, {
 })
 const baseRef = args.base ?? "origin/main"
 const plan = workspacePlan({ baseRef, item, repoRoot })
-const values = claimFieldValues(item)
+const claimedAt = new Date()
+const values = claimFieldValues(item, claimedAt)
 
 if (!args.yes) {
   printWorkspacePlan({ item, plan, repository })
@@ -53,7 +62,20 @@ if (!args.yes) {
 }
 
 prepareWorkspace({ baseRef, item, repoRoot })
-claimProjectItem({ item, project })
+claimProjectItem({ date: claimedAt, item, project })
+tryAppendAgentRunnerEvent({
+  eventLogPath,
+  event: {
+    type: "start.completed",
+    baseRef,
+    branch: plan.branch,
+    fields: values,
+    issue: issueEventDetails(item),
+    planPath: plan.planPath,
+    repository,
+    workspace: plan.workspace,
+  },
+})
 
 console.log("agent-runner start: created local workspace and claimed Project item")
 console.log(`issue: #${item.issue.number} ${item.issue.title}`)

--- a/scripts/lib/agent-runner-events.mjs
+++ b/scripts/lib/agent-runner-events.mjs
@@ -24,6 +24,20 @@ export function appendAgentRunnerEvent({ event, eventLogPath, now = new Date() }
   return entry
 }
 
+export function tryAppendAgentRunnerEvent({
+  event,
+  eventLogPath,
+  now = new Date(),
+  warn = console.warn,
+}) {
+  try {
+    return appendAgentRunnerEvent({ event, eventLogPath, now })
+  } catch (error) {
+    warn(`agent-runner event log warning: ${error.message}`)
+    return null
+  }
+}
+
 export function readAgentRunnerEvents(
   eventLogPath,
   { limit = 20, maxBytes = defaultEventLogTailBytes } = {},
@@ -46,12 +60,17 @@ export function recommendationEventDetails(recommendation) {
   return {
     action: recommendation.action,
     reason: recommendation.reason,
-    issue: {
-      number: recommendation.issue.number,
-      title: recommendation.issue.title,
-      url: recommendation.issue.url,
-      repository: recommendation.issue.repository,
-    },
+    issue: issueEventDetails(recommendation),
+  }
+}
+
+export function issueEventDetails(item) {
+  const issue = item.issue ?? item
+  return {
+    number: issue.number,
+    title: issue.title,
+    url: issue.url,
+    repository: issue.repository,
   }
 }
 

--- a/scripts/lib/agent-runner-help.mjs
+++ b/scripts/lib/agent-runner-help.mjs
@@ -16,6 +16,10 @@ export const mutationOptions = [
   ["--yes", "Apply the mutation. Without this, the command prints the planned change."],
 ]
 
+export const eventLogOptions = [
+  ["--event-log <path>", "JSONL audit log path. Defaults to .agent-runs/events.jsonl."],
+]
+
 export function maybePrintHelp(args, help) {
   if (!args.help) return
   printCommandHelp(help)

--- a/scripts/tests/agent-runner-events.test.mjs
+++ b/scripts/tests/agent-runner-events.test.mjs
@@ -7,9 +7,11 @@ import { describe, it } from "node:test"
 import {
   appendAgentRunnerEvent,
   defaultEventLogPath,
+  issueEventDetails,
   readAgentRunnerEvents,
   recommendationEventDetails,
   resolveEventLogPath,
+  tryAppendAgentRunnerEvent,
 } from "../lib/agent-runner-events.mjs"
 import { recommendQueueAction } from "../lib/agent-runner-tick.mjs"
 import { workItem } from "./agent-fixtures.mjs"
@@ -45,6 +47,27 @@ describe("agent runner event helpers", () => {
       repository: "voyantjs/voyant",
     })
     assert.equal(`${JSON.stringify(entry)}\n`, readFileSync(eventLogPath, "utf8"))
+  })
+
+  it("can treat event log write failures as non-fatal", () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), "agent-runner-events-"))
+    const eventLogParent = path.join(tempDir, "event-parent")
+    const eventLogPath = path.join(eventLogParent, "events.jsonl")
+    const warnings = []
+
+    writeFileSync(eventLogParent, "not a directory", "utf8")
+
+    const entry = tryAppendAgentRunnerEvent({
+      eventLogPath,
+      event: {
+        type: "claim.completed",
+        repository: "voyantjs/voyant",
+      },
+      warn: (message) => warnings.push(message),
+    })
+
+    assert.equal(entry, null)
+    assert.match(warnings[0], /agent-runner event log warning:/)
   })
 
   it("reads a bounded tail of JSONL runner events", () => {
@@ -104,6 +127,18 @@ describe("agent runner event helpers", () => {
         repository: "voyantjs/voyant",
       },
     })
+  })
+
+  it("extracts stable issue details for command events", () => {
+    const item = workItem({ number: 579 })
+
+    assert.deepEqual(issueEventDetails(item), {
+      number: 579,
+      title: "Test agent project intake workflow",
+      url: "https://github.com/voyantjs/voyant/issues/579",
+      repository: "voyantjs/voyant",
+    })
+    assert.deepEqual(issueEventDetails(item.issue), issueEventDetails(item))
   })
 
   it("rejects events without a type", () => {


### PR DESCRIPTION
## Summary
- add shared `--event-log` help options for runner audit-log writers
- record completed audit events for `claim`, `start`, `heartbeat`, `release`, and `complete-pr`
- add stable issue metadata helpers and document lifecycle audit events

## Verification
- `pnpm exec node --test scripts/tests/agent-runner-events.test.mjs scripts/tests/agent-runner-dispatch.test.mjs scripts/tests/agent-runner-lifecycle.test.mjs`
- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
