### PR TITLE
feat(agent-runner): add event timeline view

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -352,6 +352,19 @@ staleness threshold. It also tails recent JSONL runner events from
 status distinguishes browser artifact references from generic transcript or
 evidence fields so active runs do not hide missing browser capture.
 
+Use the local event timeline when a maintainer or supervisor needs more than
+the short status tail:
+
+```bash
+pnpm agent:queue:events -- --issue <number>
+```
+
+Events mode reads `.agent-runs/events.jsonl` and prints a filterable timeline.
+Use `--type <event>` to narrow to one event type, `--limit <number>` to control
+the printed event count, `--scan-limit <number>` to scan a larger recent tail
+before filtering, `--event-log <path>` for a different local ledger, and
+`--json` for dashboard or process-manager consumers.
+
 Use the read-only tick view when wiring an always-on supervisor:
 
 ```bash

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1149,9 +1149,11 @@ also refresh a PR description from the current evidence packet with
 explicit so maintainer-edited PR descriptions are not overwritten by routine
 state polling. Dispatch, loop, and core lifecycle mutations write JSONL audit
 events, and status can tail recent events so a maintainer or future dashboard
-can see the last supervised actions without opening raw log files. Dispatch,
-loop, and control-plane planning can pass the same option through to `sync-pr`
-when the runner intentionally wants that refresh.
+can see the last supervised actions without opening raw log files. A filterable
+`pnpm agent:queue:events` timeline supports issue-, repository-, and
+event-type-specific debugging before a full dashboard exists. Dispatch, loop,
+and control-plane planning can pass the same event-log option through to
+`sync-pr` when the runner intentionally wants that refresh.
 
 Verification:
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "verify:full": "pnpm lint && pnpm verify:agent-quality && pnpm verify:ui-components-barrel && pnpm typecheck && pnpm test && pnpm verify:architecture && pnpm build && pnpm verify:package-exports && pnpm verify:publish-tarballs && pnpm i18n:check",
     "agent:queue:doctor": "node scripts/agent-runner-doctor.mjs",
     "agent:queue:dry-run": "node scripts/agent-runner-dry-run.mjs",
+    "agent:queue:events": "node scripts/agent-runner-events.mjs",
     "agent:queue:status": "node scripts/agent-runner-status.mjs",
     "agent:queue:tick": "node scripts/agent-runner-tick.mjs",
     "agent:queue:dispatch": "node scripts/agent-runner-dispatch.mjs",

--- a/scripts/agent-runner-events.mjs
+++ b/scripts/agent-runner-events.mjs
@@ -1,0 +1,108 @@
+import { currentRepositoryFromOrigin, fail, parseArgs, runGit } from "./lib/agent-project-queue.mjs"
+import {
+  eventIssueDetails,
+  filterAgentRunnerEvents,
+  formatAgentRunnerEventSummary,
+  readAgentRunnerEvents,
+  resolveEventLogPath,
+} from "./lib/agent-runner-events.mjs"
+import { eventLogOptions, maybePrintHelp, repositoryOptions } from "./lib/agent-runner-help.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:events",
+  summary: "Print a filtered timeline from the local runner JSONL audit log.",
+  usage: "pnpm agent:queue:events -- [--issue <number>] [--type <event>] [--json]",
+  options: [
+    ["--json", "Print machine-readable JSON."],
+    ["--issue <number>", "Only show events for this issue number."],
+    ["--type <event>", "Only show events with this exact event type."],
+    ["--limit <number>", "Maximum events to print after filtering. Defaults to 20."],
+    ["--scan-limit <number>", "Recent log entries to scan before filtering. Defaults to 500."],
+    ...eventLogOptions,
+    ...repositoryOptions,
+  ],
+})
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
+const limit = numberArg(args.limit, "limit", 20)
+const scanLimit = numberArg(args.scanLimit, "scan-limit", Math.max(500, limit))
+
+let events
+try {
+  events = filterAgentRunnerEvents(readAgentRunnerEvents(eventLogPath, { limit: scanLimit }), {
+    issueNumber: args.issue,
+    repository,
+    type: args.type,
+  }).slice(-limit)
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error))
+}
+
+if (args.json) {
+  console.log(
+    JSON.stringify(
+      {
+        eventLog: {
+          path: eventLogPath,
+          scanLimit,
+        },
+        filters: {
+          issue: args.issue ? Number(args.issue) : null,
+          repository,
+          type: args.type ?? null,
+        },
+        count: events.length,
+        events,
+      },
+      null,
+      2,
+    ),
+  )
+} else {
+  printHumanTimeline()
+}
+
+function printHumanTimeline() {
+  console.log("agent-runner events")
+  console.log(`repository: ${repository}`)
+  console.log(`event log: ${eventLogPath}`)
+  if (args.issue) console.log(`issue: #${args.issue}`)
+  if (args.type) console.log(`type: ${args.type}`)
+  console.log(`events: ${events.length}`)
+  console.log("")
+
+  if (events.length === 0) {
+    console.log("No matching runner events.")
+    return
+  }
+
+  for (const event of events) {
+    console.log(`- ${formatAgentRunnerEventSummary(event)}`)
+    printEventDetail(event)
+  }
+}
+
+function printEventDetail(event) {
+  const issue = eventIssueDetails(event)
+  if (issue?.title) console.log(`  issue: ${issue.title}`)
+  if (event.recommendation?.reason) console.log(`  reason: ${event.recommendation.reason}`)
+  if (Array.isArray(event.command) && event.command.length > 0) {
+    console.log(`  command: ${event.command.join(" ")}`)
+  }
+  if (event.branch) console.log(`  branch: ${event.branch}`)
+  if (event.workspace) console.log(`  workspace: ${event.workspace}`)
+  if (event.pr?.url) console.log(`  pr: ${event.pr.url}`)
+}
+
+function numberArg(value, name, fallback) {
+  if (value === undefined) return fallback
+
+  const number = Number(value)
+  if (!Number.isInteger(number) || number < 1) {
+    fail(`invalid ${name}: ${value}`)
+  }
+  return number
+}

--- a/scripts/agent-runner-status.mjs
+++ b/scripts/agent-runner-status.mjs
@@ -11,7 +11,11 @@ import {
   browserEvidenceReferenceKind,
   requiresBrowserEvidence,
 } from "./lib/agent-runner-browser-evidence.mjs"
-import { readAgentRunnerEvents, resolveEventLogPath } from "./lib/agent-runner-events.mjs"
+import {
+  formatAgentRunnerEventSummary,
+  readAgentRunnerEvents,
+  resolveEventLogPath,
+} from "./lib/agent-runner-events.mjs"
 import { maybePrintHelp, projectOptions, repositoryOptions } from "./lib/agent-runner-help.mjs"
 import { evaluateHeartbeat } from "./lib/agent-runner-output.mjs"
 
@@ -164,7 +168,7 @@ function printRecentEvents() {
 
   console.log("Recent runner events:")
   for (const event of recentEvents) {
-    console.log(`- ${formatEventSummary(event)}`)
+    console.log(`- ${formatAgentRunnerEventSummary(event)}`)
     if (event.recommendation?.reason) {
       console.log(`  reason: ${event.recommendation.reason}`)
     }
@@ -173,21 +177,6 @@ function printRecentEvents() {
     }
   }
   console.log("")
-}
-
-function formatEventSummary(event) {
-  const issueNumber = event.recommendation?.issue?.number
-  const action = event.recommendation?.action
-  const status = event.status === undefined ? null : `status ${event.status}`
-  return [
-    event.timestamp ?? "no timestamp",
-    event.type,
-    issueNumber ? `#${issueNumber}` : null,
-    action ?? null,
-    status,
-  ]
-    .filter(Boolean)
-    .join(" ")
 }
 
 function summaryItem(item) {

--- a/scripts/lib/agent-runner-events.mjs
+++ b/scripts/lib/agent-runner-events.mjs
@@ -74,6 +74,54 @@ export function issueEventDetails(item) {
   }
 }
 
+export function eventIssueDetails(event) {
+  return event.issue ?? event.recommendation?.issue ?? null
+}
+
+export function filterAgentRunnerEvents(events, { issueNumber, repository, type } = {}) {
+  const normalizedIssueNumber = normalizeIssueNumberFilter(issueNumber)
+  return events.filter((event) => {
+    if (type && event.type !== type) return false
+    if (repository && eventRepository(event) !== repository) return false
+    if (
+      normalizedIssueNumber !== undefined &&
+      eventIssueDetails(event)?.number !== normalizedIssueNumber
+    ) {
+      return false
+    }
+    return true
+  })
+}
+
+export function formatAgentRunnerEventSummary(event) {
+  const issue = eventIssueDetails(event)
+  const action = event.recommendation?.action
+  const status = event.status === undefined ? null : `status ${event.status}`
+  return [
+    event.timestamp ?? "no timestamp",
+    event.type,
+    issue?.number ? `#${issue.number}` : null,
+    action ?? null,
+    status,
+  ]
+    .filter(Boolean)
+    .join(" ")
+}
+
+function eventRepository(event) {
+  return event.repository ?? eventIssueDetails(event)?.repository
+}
+
+function normalizeIssueNumberFilter(issueNumber) {
+  if (issueNumber === undefined) return undefined
+
+  const normalized = Number(issueNumber)
+  if (!Number.isInteger(normalized) || normalized < 1) {
+    throw new Error(`invalid issue number: ${String(issueNumber)}`)
+  }
+  return normalized
+}
+
 function normalizeEvent(event, { now }) {
   if (!event?.type) {
     throw new Error("agent runner event requires a type")

--- a/scripts/tests/agent-runner-events.test.mjs
+++ b/scripts/tests/agent-runner-events.test.mjs
@@ -7,6 +7,9 @@ import { describe, it } from "node:test"
 import {
   appendAgentRunnerEvent,
   defaultEventLogPath,
+  eventIssueDetails,
+  filterAgentRunnerEvents,
+  formatAgentRunnerEventSummary,
   issueEventDetails,
   readAgentRunnerEvents,
   recommendationEventDetails,
@@ -139,6 +142,62 @@ describe("agent runner event helpers", () => {
       repository: "voyantjs/voyant",
     })
     assert.deepEqual(issueEventDetails(item.issue), issueEventDetails(item))
+  })
+
+  it("formats and filters timeline events by issue, repository, and type", () => {
+    const events = [
+      {
+        timestamp: "2026-05-10T12:00:00.000Z",
+        type: "dispatch.started",
+        repository: "voyantjs/voyant",
+        recommendation: {
+          action: "start",
+          issue: {
+            number: 579,
+            title: "Test agent project intake workflow",
+            url: "https://github.com/voyantjs/voyant/issues/579",
+            repository: "voyantjs/voyant",
+          },
+        },
+      },
+      {
+        timestamp: "2026-05-10T12:01:00.000Z",
+        type: "claim.completed",
+        repository: "voyantjs/voyant",
+        issue: {
+          number: 580,
+          title: "Other task",
+          url: "https://github.com/voyantjs/voyant/issues/580",
+          repository: "voyantjs/voyant",
+        },
+      },
+      {
+        timestamp: "2026-05-10T12:02:00.000Z",
+        type: "claim.completed",
+        repository: "voyantjs/other",
+        issue: {
+          number: 579,
+          title: "Other repo task",
+          url: "https://github.com/voyantjs/other/issues/579",
+          repository: "voyantjs/other",
+        },
+      },
+    ]
+
+    assert.deepEqual(eventIssueDetails(events[0]), events[0].recommendation.issue)
+    assert.deepEqual(eventIssueDetails(events[1]), events[1].issue)
+    assert.equal(
+      formatAgentRunnerEventSummary(events[0]),
+      "2026-05-10T12:00:00.000Z dispatch.started #579 start",
+    )
+    assert.deepEqual(
+      filterAgentRunnerEvents(events, {
+        issueNumber: 579,
+        repository: "voyantjs/voyant",
+        type: "dispatch.started",
+      }),
+      [events[0]],
+    )
   })
 
   it("rejects events without a type", () => {


### PR DESCRIPTION
## Summary
- add `agent:queue:events` for filtered local audit-log timelines
- share event issue extraction and formatting between status and timeline views
- document the event timeline as the bridge from local logs to future dashboard views

## Verification
- `pnpm exec node --test scripts/tests/agent-runner-events.test.mjs`
- `pnpm agent:queue:events -- --help`
- `pnpm agent:queue:events -- --event-log /tmp/voyant-missing-events.jsonl --json`
- `pnpm agent:queue:events -- --limit 3`
- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- commit hook: full package lint/typecheck
- push hook: full package tests