### PR TITLE
feat(agent-runner): audit execution commands

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -363,7 +363,10 @@ Events mode reads `.agent-runs/events.jsonl` and prints a filterable timeline.
 Use `--type <event>` to narrow to one event type, `--limit <number>` to control
 the printed event count, `--scan-limit <number>` to scan a larger recent tail
 before filtering, `--event-log <path>` for a different local ledger, and
-`--json` for dashboard or process-manager consumers.
+`--json` for dashboard or process-manager consumers. The timeline includes
+queue recommendations, lifecycle mutations, supervised command exits, browser
+capture summaries, CI evidence collection, evidence publication, PR sync/open
+events, and cleanup events.
 
 Use the read-only tick view when wiring an always-on supervisor:
 
@@ -436,10 +439,12 @@ Claim mode checks the same execution gate, then updates GitHub Project fields:
 - `Workspace = <planned workspace>`
 - `Last Heartbeat = <today>`
 
-Successful `claim`, `start`, `heartbeat`, `release`, and `complete-pr`
-commands append local JSONL audit events to `.agent-runs/events.jsonl` by
-default; pass `--event-log <path>` when a supervisor needs a different local
-ledger path.
+Successful mutating runner commands append local JSONL audit events to
+`.agent-runs/events.jsonl` by default. This includes `claim`, `start`,
+`heartbeat`, `run-command`, `capture-browser`, `collect-ci`,
+`publish-evidence`, `open-pr`, `sync-pr`, `complete-pr`, `cleanup`, `release`,
+and their remote execution/evidence/PR/cleanup counterparts. Pass
+`--event-log <path>` when a supervisor needs a different local ledger path.
 
 While work is claimed, refresh the item heartbeat or state:
 

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1147,13 +1147,15 @@ failed CI logs into local repair packets, and mark merged PRs done. PR sync can
 also refresh a PR description from the current evidence packet with
 `pnpm agent:queue:sync-pr -- --issue <number> --update-body --yes`; this is
 explicit so maintainer-edited PR descriptions are not overwritten by routine
-state polling. Dispatch, loop, and core lifecycle mutations write JSONL audit
-events, and status can tail recent events so a maintainer or future dashboard
-can see the last supervised actions without opening raw log files. A filterable
-`pnpm agent:queue:events` timeline supports issue-, repository-, and
-event-type-specific debugging before a full dashboard exists. Dispatch, loop,
-and control-plane planning can pass the same event-log option through to
-`sync-pr` when the runner intentionally wants that refresh.
+state polling. Dispatch, loop, lifecycle mutations, supervised command exits,
+browser capture, CI evidence collection, evidence publication, PR sync/open
+commands, and cleanup commands write JSONL audit events. Status can tail recent
+events so a maintainer or future dashboard can see the last supervised actions
+without opening raw log files. A filterable `pnpm agent:queue:events` timeline
+supports issue-, repository-, and event-type-specific debugging before a full
+dashboard exists. Dispatch, loop, and control-plane planning can pass the same
+event-log option through to `sync-pr` when the runner intentionally wants that
+refresh.
 
 Verification:
 
@@ -1197,6 +1199,9 @@ Project item to `Human Review` or `Blocked`. For UI-labeled remote work,
 successful remote commands validate `.agent-runs/remote-browser/.../summary.json`
 artifacts before handoff and keep the item blocked when browser capture found
 blocking console or request issues unless a maintainer accepts the exception.
+Remote execution, browser capture, evidence publication, PR creation, and
+cleanup append the same local JSONL audit events as local runner commands, so a
+supervisor can trace remote work without provider-specific dashboards.
 `agent:queue:remote-publish-evidence`
 can read that remote evidence packet through the configured adapter, post or
 reuse a GitHub evidence comment, optionally publish the packet to configured

--- a/scripts/agent-runner-capture-browser.mjs
+++ b/scripts/agent-runner-capture-browser.mjs
@@ -29,6 +29,12 @@ import {
 } from "./lib/agent-runner-browser-evidence.mjs"
 import { browserIssueBlockReason } from "./lib/agent-runner-browser-issues.mjs"
 import {
+  issueEventDetails,
+  resolveEventLogPath,
+  tryAppendAgentRunnerEvent,
+} from "./lib/agent-runner-events.mjs"
+import {
+  eventLogOptions,
   maybePrintHelp,
   mutationOptions,
   projectOptions,
@@ -60,6 +66,7 @@ maybePrintHelp(args, {
     ["--publish-artifacts", "Upload captured artifacts to configured R2/S3 object storage."],
     ["--browser-base-port <number>", "Base port for deterministic issue ports. Defaults to 4300."],
     ...repositoryOptions,
+    ...eventLogOptions,
     ...mutationOptions,
     ...projectOptions,
   ],
@@ -77,6 +84,7 @@ if (args.viewport && args.viewports) {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
 const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const item = findProjectIssueItem(project.items, {
   issueNumber: args.issue,
@@ -196,6 +204,21 @@ if (args.publishArtifacts) {
 const issueBlockReason = browserIssueBlockReason(result.browserIssues, {
   allowBrowserIssues: Boolean(args.allowBrowserIssues),
   required: requiresBrowserEvidence(item),
+})
+tryAppendAgentRunnerEvent({
+  eventLogPath,
+  event: {
+    type: "capture-browser.completed",
+    artifacts: result.remoteArtifactIndex ?? artifactPlan.artifactPointer,
+    blockedBy: issueBlockReason ?? null,
+    browserIssueCount: result.browserIssues.length,
+    issue: issueEventDetails(item),
+    repository,
+    required: requiresBrowserEvidence(item),
+    url: capturePlans[0].url,
+    viewports: capturePlans.map((plan) => viewportLabel(plan.viewport)),
+    workspace: artifactPlan.workspace,
+  },
 })
 
 console.log("agent-runner capture-browser: wrote browser evidence")

--- a/scripts/agent-runner-cleanup.mjs
+++ b/scripts/agent-runner-cleanup.mjs
@@ -9,6 +9,12 @@ import {
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import {
+  issueEventDetails,
+  resolveEventLogPath,
+  tryAppendAgentRunnerEvent,
+} from "./lib/agent-runner-events.mjs"
+import {
+  eventLogOptions,
   maybePrintHelp,
   mutationOptions,
   projectOptions,
@@ -31,6 +37,7 @@ maybePrintHelp(args, {
     ["--workspace <path>", "Workspace path override. Defaults from the Project Workspace field."],
     ["--force", "Allow cleanup outside Done or Abandoned Agent State."],
     ...repositoryOptions,
+    ...eventLogOptions,
     ...mutationOptions,
     ...projectOptions,
   ],
@@ -42,6 +49,7 @@ if (!args.issue) {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
 const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const item = findProjectIssueItem(project.items, {
   issueNumber: args.issue,
@@ -77,6 +85,18 @@ if (!args.yes) {
 
 updateProjectItemFields({ project, item, values, clear })
 const removedWorkspace = removeWorkspace({ allowMissing: true, workspace: plan.workspace })
+tryAppendAgentRunnerEvent({
+  eventLogPath,
+  event: {
+    type: "cleanup.completed",
+    clearedFields: clear,
+    fields: values,
+    issue: issueEventDetails(item),
+    removedWorkspace,
+    repository,
+    workspace: plan.workspace,
+  },
+})
 
 console.log(cleanupResultMessage(removedWorkspace))
 console.log(`issue: #${item.issue.number} ${item.issue.title}`)

--- a/scripts/agent-runner-collect-ci.mjs
+++ b/scripts/agent-runner-collect-ci.mjs
@@ -15,6 +15,12 @@ import {
   writeCiRepairEvidencePacket,
 } from "./lib/agent-runner-ci.mjs"
 import {
+  issueEventDetails,
+  resolveEventLogPath,
+  tryAppendAgentRunnerEvent,
+} from "./lib/agent-runner-events.mjs"
+import {
+  eventLogOptions,
   maybePrintHelp,
   mutationOptions,
   projectOptions,
@@ -33,6 +39,7 @@ maybePrintHelp(args, {
     ["--workspace <path>", "Workspace path override for gh context."],
     ["--max-log-bytes <number>", "Maximum failed log bytes per run. Defaults to 120000."],
     ...repositoryOptions,
+    ...eventLogOptions,
     ...mutationOptions,
     ...projectOptions,
   ],
@@ -49,6 +56,7 @@ if (!Number.isInteger(maxLogBytes) || maxLogBytes < 1) {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
 const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const item = findProjectIssueItem(project.items, {
   issueNumber: args.issue,
@@ -89,6 +97,25 @@ const logs = collectFailedCheckLogs({
 })
 writeCiRepairEvidencePacket({ artifactPlan, checks, item, logs, pr, repository })
 updateProjectItemFields({ project, item, values })
+tryAppendAgentRunnerEvent({
+  eventLogPath,
+  event: {
+    type: "collect-ci.completed",
+    checks: checks.map((check) => ({
+      name: check.name,
+      status: check.status,
+      conclusion: check.conclusion,
+    })),
+    evidence: artifactPlan.evidencePointer,
+    fields: values,
+    issue: issueEventDetails(item),
+    pr: {
+      number: pr.number,
+      url: pr.url,
+    },
+    repository,
+  },
+})
 
 console.log("agent-runner collect-ci: wrote CI repair evidence and updated Project fields")
 console.log(`issue: #${item.issue.number} ${item.issue.title}`)

--- a/scripts/agent-runner-events.mjs
+++ b/scripts/agent-runner-events.mjs
@@ -91,9 +91,16 @@ function printEventDetail(event) {
   if (event.recommendation?.reason) console.log(`  reason: ${event.recommendation.reason}`)
   if (Array.isArray(event.command) && event.command.length > 0) {
     console.log(`  command: ${event.command.join(" ")}`)
+  } else if (typeof event.command === "string") {
+    console.log(`  command: ${event.command}`)
   }
   if (event.branch) console.log(`  branch: ${event.branch}`)
   if (event.workspace) console.log(`  workspace: ${event.workspace}`)
+  if (event.remoteDir) console.log(`  remote dir: ${event.remoteDir}`)
+  if (event.evidence) console.log(`  evidence: ${event.evidence}`)
+  if (event.artifacts) console.log(`  artifacts: ${event.artifacts}`)
+  if (event.exitCode !== undefined) console.log(`  exit code: ${event.exitCode}`)
+  if (event.blockedBy) console.log(`  blocked by: ${event.blockedBy}`)
   if (event.pr?.url) console.log(`  pr: ${event.pr.url}`)
 }
 

--- a/scripts/agent-runner-open-pr.mjs
+++ b/scripts/agent-runner-open-pr.mjs
@@ -11,6 +11,12 @@ import {
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import {
+  issueEventDetails,
+  resolveEventLogPath,
+  tryAppendAgentRunnerEvent,
+} from "./lib/agent-runner-events.mjs"
+import {
+  eventLogOptions,
   maybePrintHelp,
   mutationOptions,
   projectOptions,
@@ -44,6 +50,7 @@ maybePrintHelp(args, {
     ["--allow-dirty", "Allow opening a PR from a workspace with uncommitted changes."],
     ["--force", "Allow opening outside the normal handoff states."],
     ...repositoryOptions,
+    ...eventLogOptions,
     ...mutationOptions,
     ...projectOptions,
   ],
@@ -55,6 +62,7 @@ if (!args.issue) {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
 const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const item = findProjectIssueItem(project.items, {
   issueNumber: args.issue,
@@ -127,6 +135,22 @@ updateProjectItemFields({
   project,
   item,
   values: pullRequestFieldValues({ prUrl }),
+})
+tryAppendAgentRunnerEvent({
+  eventLogPath,
+  event: {
+    type: "open-pr.completed",
+    base,
+    branch,
+    draft: !args.ready,
+    issue: issueEventDetails(item),
+    pr: {
+      url: prUrl,
+    },
+    repository,
+    reused: Boolean(existingPrUrl),
+    workspace,
+  },
 })
 
 console.log("agent-runner open-pr: pushed branch, opened or reused PR, and updated Project fields")

--- a/scripts/agent-runner-publish-evidence.mjs
+++ b/scripts/agent-runner-publish-evidence.mjs
@@ -17,6 +17,11 @@ import {
   publishEvidencePacket,
 } from "./lib/agent-runner-artifacts.mjs"
 import {
+  issueEventDetails,
+  resolveEventLogPath,
+  tryAppendAgentRunnerEvent,
+} from "./lib/agent-runner-events.mjs"
+import {
   createIssueComment,
   evidenceCommentBody,
   evidenceMarker,
@@ -24,6 +29,7 @@ import {
   isRemoteEvidence,
 } from "./lib/agent-runner-evidence-publication.mjs"
 import {
+  eventLogOptions,
   maybePrintHelp,
   mutationOptions,
   projectOptions,
@@ -42,6 +48,7 @@ maybePrintHelp(args, {
     ["--publish-artifacts", "Upload the evidence packet to configured R2/S3 object storage."],
     ["--workspace <path>", "Workspace path override."],
     ...repositoryOptions,
+    ...eventLogOptions,
     ...mutationOptions,
     ...projectOptions,
   ],
@@ -53,6 +60,7 @@ if (!args.issue) {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
 const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const item = findProjectIssueItem(project.items, {
   issueNumber: args.issue,
@@ -148,6 +156,19 @@ updateProjectItemFields({
   values: {
     Evidence: remoteEvidence?.url ?? commentUrl,
     "Last Heartbeat": today(),
+  },
+})
+tryAppendAgentRunnerEvent({
+  eventLogPath,
+  event: {
+    type: "publish-evidence.completed",
+    evidence: remoteEvidence?.url ?? commentUrl,
+    githubComment: commentUrl,
+    issue: issueEventDetails(item),
+    publishedArtifact: remoteEvidence ?? null,
+    repository,
+    sourceEvidence: evidenceReference,
+    workspace,
   },
 })
 

--- a/scripts/agent-runner-remote-capture-browser.mjs
+++ b/scripts/agent-runner-remote-capture-browser.mjs
@@ -23,6 +23,12 @@ import {
 } from "./lib/agent-runner-browser-evidence.mjs"
 import { browserIssueBlockReason } from "./lib/agent-runner-browser-issues.mjs"
 import {
+  issueEventDetails,
+  resolveEventLogPath,
+  tryAppendAgentRunnerEvent,
+} from "./lib/agent-runner-events.mjs"
+import {
+  eventLogOptions,
   maybePrintHelp,
   mutationOptions,
   projectOptions,
@@ -86,6 +92,7 @@ maybePrintHelp(args, {
       "Optional remote adapter config module. Defaults to .agents/remote-workspaces.mjs when present.",
     ],
     ...repositoryOptions,
+    ...eventLogOptions,
     ...mutationOptions,
     ...projectOptions,
   ],
@@ -111,6 +118,7 @@ const timeoutMs = numberArg(args.timeoutMs, 30_000, "timeout-ms")
 const port = args.port ? numberArg(args.port, undefined, "port") : undefined
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
 const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const item = findProjectIssueItem(project.items, {
   issueNumber: args.issue,
@@ -294,6 +302,22 @@ if (processStopResult?.status !== 0) {
 const issueBlockReason = browserIssueBlockReason(result.browserIssues, {
   allowBrowserIssues: Boolean(args.allowBrowserIssues),
   required: requiresBrowserEvidence(item),
+})
+tryAppendAgentRunnerEvent({
+  eventLogPath,
+  event: {
+    type: "remote-capture-browser.completed",
+    artifacts: result.remoteArtifactIndex ?? artifactPlan.artifactPointer,
+    blockedBy: issueBlockReason ?? null,
+    browserIssueCount: result.browserIssues.length,
+    issue: issueEventDetails(item),
+    process: processPlan?.processName ?? null,
+    remoteDir: artifactPlan.workspace,
+    repository,
+    required: requiresBrowserEvidence(item),
+    url: captureUrl,
+    workspace: workspaceReference,
+  },
 })
 
 console.log("agent-runner remote-capture-browser: wrote browser evidence")

--- a/scripts/agent-runner-remote-cleanup.mjs
+++ b/scripts/agent-runner-remote-cleanup.mjs
@@ -9,6 +9,12 @@ import {
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import {
+  issueEventDetails,
+  resolveEventLogPath,
+  tryAppendAgentRunnerEvent,
+} from "./lib/agent-runner-events.mjs"
+import {
+  eventLogOptions,
   maybePrintHelp,
   mutationOptions,
   projectOptions,
@@ -42,6 +48,7 @@ maybePrintHelp(args, {
     ],
     ["--json", "Print machine-readable JSON."],
     ...repositoryOptions,
+    ...eventLogOptions,
     ...mutationOptions,
     ...projectOptions,
   ],
@@ -53,6 +60,7 @@ if (!args.issue) {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
 const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const item = findProjectIssueItem(project.items, {
   issueNumber: args.issue,
@@ -106,6 +114,18 @@ try {
 }
 
 updateProjectItemFields({ clear, item, project, values })
+tryAppendAgentRunnerEvent({
+  eventLogPath,
+  event: {
+    type: "remote-cleanup.completed",
+    clearedFields: clear,
+    disposed: result ?? null,
+    fields: values,
+    issue: issueEventDetails(item),
+    repository,
+    workspace: workspaceReference,
+  },
+})
 
 if (args.json) {
   console.log(

--- a/scripts/agent-runner-remote-open-pr.mjs
+++ b/scripts/agent-runner-remote-open-pr.mjs
@@ -9,6 +9,12 @@ import {
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import {
+  issueEventDetails,
+  resolveEventLogPath,
+  tryAppendAgentRunnerEvent,
+} from "./lib/agent-runner-events.mjs"
+import {
+  eventLogOptions,
   maybePrintHelp,
   mutationOptions,
   projectOptions,
@@ -59,6 +65,7 @@ maybePrintHelp(args, {
     ],
     ["--json", "Print machine-readable JSON."],
     ...repositoryOptions,
+    ...eventLogOptions,
     ...mutationOptions,
     ...projectOptions,
   ],
@@ -70,6 +77,7 @@ if (!args.issue) {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
 const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const item = findProjectIssueItem(project.items, {
   issueNumber: args.issue,
@@ -188,6 +196,24 @@ updateProjectItemFields({
   item,
   project,
   values: pullRequestFieldValues({ prUrl }),
+})
+tryAppendAgentRunnerEvent({
+  eventLogPath,
+  event: {
+    type: "remote-open-pr.completed",
+    base,
+    branch: plan.branch,
+    draft: !args.ready,
+    issue: issueEventDetails(item),
+    pr: {
+      url: prUrl,
+    },
+    pushStatus: pushResult.status,
+    remoteDir: plan.workspace,
+    repository,
+    reused: Boolean(existingPrUrl),
+    workspace: workspaceReference,
+  },
 })
 
 if (args.json) {

--- a/scripts/agent-runner-remote-publish-evidence.mjs
+++ b/scripts/agent-runner-remote-publish-evidence.mjs
@@ -14,6 +14,11 @@ import {
   publishEvidencePacket,
 } from "./lib/agent-runner-artifacts.mjs"
 import {
+  issueEventDetails,
+  resolveEventLogPath,
+  tryAppendAgentRunnerEvent,
+} from "./lib/agent-runner-events.mjs"
+import {
   createIssueComment,
   evidenceCommentBody,
   evidenceMarker,
@@ -21,6 +26,7 @@ import {
   isRemoteEvidence,
 } from "./lib/agent-runner-evidence-publication.mjs"
 import {
+  eventLogOptions,
   maybePrintHelp,
   mutationOptions,
   projectOptions,
@@ -61,6 +67,7 @@ maybePrintHelp(args, {
     ],
     ["--json", "Print machine-readable JSON."],
     ...repositoryOptions,
+    ...eventLogOptions,
     ...mutationOptions,
     ...projectOptions,
   ],
@@ -72,6 +79,7 @@ if (!args.issue) {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
 const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const item = findProjectIssueItem(project.items, {
   issueNumber: args.issue,
@@ -202,6 +210,19 @@ updateProjectItemFields({
   item,
   project,
   values: remoteEvidencePublicationFieldValues({ evidenceUrl }),
+})
+tryAppendAgentRunnerEvent({
+  eventLogPath,
+  event: {
+    type: "remote-publish-evidence.completed",
+    evidence: evidenceUrl,
+    githubComment: commentUrl,
+    issue: issueEventDetails(item),
+    publishedArtifact: remoteEvidence ?? null,
+    repository,
+    sourceEvidence: publicationPlan.evidencePointer,
+    workspace: workspaceReference,
+  },
 })
 
 if (args.json) {

--- a/scripts/agent-runner-remote-run-command.mjs
+++ b/scripts/agent-runner-remote-run-command.mjs
@@ -9,11 +9,17 @@ import {
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import {
+  issueEventDetails,
+  resolveEventLogPath,
+  tryAppendAgentRunnerEvent,
+} from "./lib/agent-runner-events.mjs"
+import {
   buildCommandEvidencePacket,
   canRunCommandState,
   commandRunStates,
 } from "./lib/agent-runner-execution.mjs"
 import {
+  eventLogOptions,
   maybePrintHelp,
   mutationOptions,
   projectOptions,
@@ -67,6 +73,7 @@ maybePrintHelp(args, {
     ],
     ["--json", "Print machine-readable JSON."],
     ...repositoryOptions,
+    ...eventLogOptions,
     ...mutationOptions,
     ...projectOptions,
   ],
@@ -86,6 +93,7 @@ if (!args.yes) {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
 const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const item = findProjectIssueItem(project.items, {
   issueNumber: args.issue,
@@ -244,6 +252,25 @@ updateProjectItemFields({
   item,
   project,
   values: finalUpdate.values,
+})
+tryAppendAgentRunnerEvent({
+  eventLogPath,
+  event: {
+    type: "remote-run-command.completed",
+    blockedBy: finalUpdate.blockedBy ?? null,
+    branch,
+    clearedFields: finalUpdate.clear,
+    command: args.command,
+    evidence: artifactPlan.evidencePointer,
+    evidenceWriteStatus: evidenceWriteResult.status ?? 1,
+    exitCode,
+    fields: finalUpdate.values,
+    issue: issueEventDetails(item),
+    log: artifactPlan.logPointer,
+    repository,
+    remoteDir: artifactPlan.workspace,
+    workspace: workspaceReference,
+  },
 })
 
 if (args.json) {

--- a/scripts/agent-runner-run-command.mjs
+++ b/scripts/agent-runner-run-command.mjs
@@ -13,6 +13,11 @@ import {
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import {
+  issueEventDetails,
+  resolveEventLogPath,
+  tryAppendAgentRunnerEvent,
+} from "./lib/agent-runner-events.mjs"
+import {
   buildCommandEvidencePacket,
   canRunCommandState,
   commandRunArtifactPlan,
@@ -22,6 +27,7 @@ import {
   commandRunStates,
 } from "./lib/agent-runner-execution.mjs"
 import {
+  eventLogOptions,
   maybePrintHelp,
   mutationOptions,
   projectOptions,
@@ -49,6 +55,7 @@ maybePrintHelp(args, {
     ],
     ["--force", "Allow command execution outside the normal run states."],
     ...repositoryOptions,
+    ...eventLogOptions,
     ...mutationOptions,
     ...projectOptions,
   ],
@@ -64,6 +71,7 @@ if (!args.command) {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
 const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const item = findProjectIssueItem(project.items, {
   issueNumber: args.issue,
@@ -167,6 +175,23 @@ updateProjectItemFields({
   item,
   values: finalUpdate.values,
   clear: finalUpdate.clear,
+})
+tryAppendAgentRunnerEvent({
+  eventLogPath,
+  event: {
+    type: "run-command.completed",
+    blockedBy: finalUpdate.blockedBy ?? null,
+    branch,
+    clearedFields: finalUpdate.clear,
+    command: args.command,
+    evidence: artifactPlan.evidencePointer,
+    exitCode,
+    fields: finalUpdate.values,
+    issue: issueEventDetails(item),
+    log: artifactPlan.logFile,
+    repository,
+    workspace: artifactPlan.workspace,
+  },
 })
 
 console.log("agent-runner run-command: command finished and Project fields were updated")

--- a/scripts/agent-runner-sync-pr.mjs
+++ b/scripts/agent-runner-sync-pr.mjs
@@ -9,6 +9,12 @@ import {
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import {
+  issueEventDetails,
+  resolveEventLogPath,
+  tryAppendAgentRunnerEvent,
+} from "./lib/agent-runner-events.mjs"
+import {
+  eventLogOptions,
   maybePrintHelp,
   mutationOptions,
   projectOptions,
@@ -37,6 +43,7 @@ maybePrintHelp(args, {
     ["--update-body", "Refresh the PR body from the current evidence packet."],
     ["--force", "Allow syncing closed issues."],
     ...repositoryOptions,
+    ...eventLogOptions,
     ...mutationOptions,
     ...projectOptions,
   ],
@@ -48,6 +55,7 @@ if (!args.issue) {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
 const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const item = findProjectIssueItem(project.items, {
   issueNumber: args.issue,
@@ -91,6 +99,22 @@ if (bodyRefresh) {
   updatePullRequestBody(bodyRefresh)
 }
 updateProjectItemFields({ project, item, values, clear })
+tryAppendAgentRunnerEvent({
+  eventLogPath,
+  event: {
+    type: "sync-pr.completed",
+    bodyRefreshed: Boolean(bodyRefresh),
+    clearedFields: clear,
+    fields: values,
+    issue: issueEventDetails(item),
+    pr: {
+      number: pr.number,
+      url: pr.url,
+    },
+    reason: result.reason,
+    repository,
+  },
+})
 
 console.log("agent-runner sync-pr: updated Project PR review state")
 console.log(`issue: #${item.issue.number} ${item.issue.title}`)


### PR DESCRIPTION
## Summary

- Adds non-fatal JSONL audit events for local execution, browser capture, CI collection, evidence publication, PR sync/open, and cleanup commands.
- Adds the same event logging path to the remote execution/evidence/PR/browser/cleanup commands.
- Expands the event timeline output and docs so supervisors can inspect command exits, evidence, artifacts, PRs, and cleanup from one local ledger.

## Verification

- `pnpm exec node --test scripts/tests/agent-runner-events.test.mjs`
- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- `node --check` on changed runner entry points
- `pnpm agent:queue:events -- --event-log /tmp/voyant-missing-command-events.jsonl --json`
- Help smoke tests for local/remote command and browser capture commands
- Commit hook: full lint and typecheck passed
- Push hook: full test suite passed
