### PR TITLE
fix(agent-runner): log command blockers

### DIFF
--- a/scripts/agent-runner-run-command.mjs
+++ b/scripts/agent-runner-run-command.mjs
@@ -180,7 +180,7 @@ tryAppendAgentRunnerEvent({
   eventLogPath,
   event: {
     type: "run-command.completed",
-    blockedBy: finalUpdate.blockedBy ?? null,
+    blockedBy: finalUpdate.values["Blocked By"] ?? blockedBy ?? null,
     branch,
     clearedFields: finalUpdate.clear,
     command: args.command,


### PR DESCRIPTION
## Summary

- Fixes local command audit events so failed or blocked runs record the actual blocker text instead of `null`.

## Verification

- `pnpm exec node --test scripts/tests/agent-runner-events.test.mjs`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- Commit hook: full lint and typecheck passed
- Push hook: full test suite passed
