### PR TITLE
feat(agent-runner): add supervisor event context

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -380,8 +380,11 @@ action recommendations such as `start`, `run-command`, `capture-browser`,
 `inspect-stale`. It does not mutate GitHub, create worktrees, run commands,
 publish evidence, or
 open PRs. Pass `--json` when a process manager or future control plane needs
-machine-readable actions. `Merge Ready` items with linked PRs keep recommending
-`sync-pr` so the runner can observe maintainer merges and mark the item done.
+machine-readable actions. Tick also tails recent JSONL runner events from
+`.agent-runs/events.jsonl`; pass `--recent-events 0` to hide them or
+`--event-log <path>` to inspect a different local ledger. `Merge Ready` items
+with linked PRs keep recommending `sync-pr` so the runner can observe
+maintainer merges and mark the item done.
 `CI Repair` items with failing linked PRs recommend `collect-ci` until a local
 CI repair packet exists. Ready items with `sandbox:<provider>:<id>` workspaces
 recommend `remote-bootstrap` so dispatch can clone/fetch the repository and
@@ -410,7 +413,8 @@ recommendation, and runs one lifecycle command. It is dry-run by default. Pass
 implementation and browser execution remain explicit.
 Successful dispatch attempts append local JSONL audit events to
 `.agent-runs/events.jsonl` by default; pass `--event-log <path>` when a
-supervisor needs a different local ledger path.
+supervisor needs a different local ledger path. The same path is passed to the
+nested lifecycle command so dispatch and lifecycle events stay in one ledger.
 
 Use loop for a bounded supervisor pass:
 
@@ -423,7 +427,9 @@ recommendation, then sleeps before the next iteration. It is dry-run by default
 and capped at 100 iterations. It uses the same dispatch allow-list, so it cannot
 run implementation commands or override blocked/wait states. Each iteration is
 recorded in the local event log, alongside the nested dispatch command's own
-events, so unattended queue passes have a minimal timeline.
+events, so unattended queue passes have a minimal timeline. Audit writes are
+best-effort and do not block lifecycle work if the local event log cannot be
+written.
 
 After a workspace is prepared, claim the item before implementation work starts:
 

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1155,7 +1155,9 @@ without opening raw log files. A filterable `pnpm agent:queue:events` timeline
 supports issue-, repository-, and event-type-specific debugging before a full
 dashboard exists. Dispatch, loop, and control-plane planning can pass the same
 event-log option through to `sync-pr` when the runner intentionally wants that
-refresh.
+refresh. Tick output now carries a recent audit-event tail as well as ordered
+recommendations, and dispatch keeps nested lifecycle command events in the same
+ledger when a supervisor passes a custom `--event-log`.
 
 Verification:
 

--- a/scripts/agent-runner-dispatch.mjs
+++ b/scripts/agent-runner-dispatch.mjs
@@ -14,9 +14,9 @@ import {
   selectDispatchRecommendation,
 } from "./lib/agent-runner-dispatch.mjs"
 import {
-  appendAgentRunnerEvent,
   recommendationEventDetails,
   resolveEventLogPath,
+  tryAppendAgentRunnerEvent,
 } from "./lib/agent-runner-events.mjs"
 import {
   eventLogOptions,
@@ -79,6 +79,7 @@ if (!recommendation) {
 }
 
 const commandArgs = dispatchCommandArgs(recommendation, {
+  eventLog: args.eventLog,
   repository,
   updateBody: Boolean(args.updateBody),
 })
@@ -89,7 +90,7 @@ if (!args.yes) {
   fail("dispatch mode runs one queue mutation; rerun with --yes")
 }
 
-appendAgentRunnerEvent({
+tryAppendAgentRunnerEvent({
   eventLogPath,
   event: {
     type: "dispatch.started",
@@ -99,7 +100,7 @@ appendAgentRunnerEvent({
   },
 })
 const status = runDispatchCommand(commandArgs)
-appendAgentRunnerEvent({
+tryAppendAgentRunnerEvent({
   eventLogPath,
   event: {
     type: "dispatch.completed",

--- a/scripts/agent-runner-loop.mjs
+++ b/scripts/agent-runner-loop.mjs
@@ -14,9 +14,9 @@ import {
   selectDispatchRecommendation,
 } from "./lib/agent-runner-dispatch.mjs"
 import {
-  appendAgentRunnerEvent,
   recommendationEventDetails,
   resolveEventLogPath,
+  tryAppendAgentRunnerEvent,
 } from "./lib/agent-runner-events.mjs"
 import {
   eventLogOptions,
@@ -90,7 +90,7 @@ for (let iteration = 1; iteration <= loopOptions.iterations; iteration += 1) {
 
   console.log(`agent-runner loop: dispatch ${iteration}/${loopOptions.iterations}`)
   console.log(`command: pnpm ${commandArgs.join(" ")}`)
-  appendAgentRunnerEvent({
+  tryAppendAgentRunnerEvent({
     eventLogPath,
     event: {
       type: "loop.iteration.started",
@@ -102,7 +102,7 @@ for (let iteration = 1; iteration <= loopOptions.iterations; iteration += 1) {
     },
   })
   const status = runDispatchCommand(commandArgs) ?? 1
-  appendAgentRunnerEvent({
+  tryAppendAgentRunnerEvent({
     eventLogPath,
     event: {
       type: "loop.iteration.completed",

--- a/scripts/agent-runner-tick.mjs
+++ b/scripts/agent-runner-tick.mjs
@@ -7,7 +7,17 @@ import {
   projectScanConfigFromArgs,
   runGit,
 } from "./lib/agent-project-queue.mjs"
-import { maybePrintHelp, projectOptions, repositoryOptions } from "./lib/agent-runner-help.mjs"
+import {
+  formatAgentRunnerEventSummary,
+  readAgentRunnerEvents,
+  resolveEventLogPath,
+} from "./lib/agent-runner-events.mjs"
+import {
+  eventLogOptions,
+  maybePrintHelp,
+  projectOptions,
+  repositoryOptions,
+} from "./lib/agent-runner-help.mjs"
 import { recommendQueueActions } from "./lib/agent-runner-tick.mjs"
 
 const args = parseArgs(process.argv.slice(2))
@@ -19,6 +29,8 @@ maybePrintHelp(args, {
   options: [
     ["--json", "Print machine-readable JSON."],
     ["--max-age-days <number>", "Heartbeat staleness threshold. Defaults to 1."],
+    ["--recent-events <number>", "Number of recent runner events to show. Defaults to 5."],
+    ...eventLogOptions,
     ...repositoryOptions,
     ...projectOptions,
   ],
@@ -27,6 +39,8 @@ maybePrintHelp(args, {
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
 const maxAgeDays = Number(args.maxAgeDays ?? 1)
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
+const recentEventLimit = numberArg(args.recentEvents, "recent-events", 5, { min: 0 })
 
 if (!Number.isInteger(maxAgeDays) || maxAgeDays < 0) {
   fail(`invalid max age days: ${String(args.maxAgeDays)}`)
@@ -35,6 +49,7 @@ if (!Number.isInteger(maxAgeDays) || maxAgeDays < 0) {
 const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
 const items = filterItemsByRepository(project.items, repository)
 const recommendations = recommendQueueActions(items, { maxAgeDays, repository })
+const recentEvents = readRecentEvents()
 
 if (args.json) {
   console.log(
@@ -48,6 +63,10 @@ if (args.json) {
         },
         repository,
         maxAgeDays,
+        eventLog: {
+          path: eventLogPath,
+          recentEvents,
+        },
         recommendations,
       },
       null,
@@ -66,6 +85,7 @@ function printHumanSummary() {
   console.log(`items scanned: ${items.length}`)
   console.log(`recommendations: ${recommendations.length}`)
   console.log("")
+  printRecentEvents()
 
   if (recommendations.length === 0) {
     console.log("No runner action recommended.")
@@ -84,4 +104,40 @@ function printHumanSummary() {
       console.log(`  heartbeat: ${recommendation.heartbeat.reason}`)
     }
   }
+}
+
+function printRecentEvents() {
+  if (recentEventLimit === 0 || recentEvents.length === 0) return
+
+  console.log("Recent runner events:")
+  for (const event of recentEvents) {
+    console.log(`- ${formatAgentRunnerEventSummary(event)}`)
+    if (event.recommendation?.reason) {
+      console.log(`  reason: ${event.recommendation.reason}`)
+    }
+    if (Array.isArray(event.command) && event.command.length > 0) {
+      console.log(`  command: ${event.command.join(" ")}`)
+    } else if (typeof event.command === "string") {
+      console.log(`  command: ${event.command}`)
+    }
+  }
+  console.log("")
+}
+
+function readRecentEvents() {
+  try {
+    return readAgentRunnerEvents(eventLogPath, { limit: recentEventLimit })
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error))
+  }
+}
+
+function numberArg(value, name, fallback, { min = 1 } = {}) {
+  if (value === undefined) return fallback
+
+  const number = Number(value)
+  if (!Number.isInteger(number) || number < min) {
+    fail(`invalid ${name}: ${value}`)
+  }
+  return number
 }


### PR DESCRIPTION
## Summary
- Adds recent runner event context to agent queue tick output for process-manager and dashboard consumers.
- Keeps dispatch and nested lifecycle commands on the same custom event ledger when --event-log is provided.
- Makes dispatch and loop audit writes best-effort so event log write problems do not block lifecycle progress.

## Verification
- node --check scripts/agent-runner-dispatch.mjs scripts/agent-runner-loop.mjs scripts/agent-runner-tick.mjs
- pnpm exec node --test scripts/tests/agent-runner-dispatch.test.mjs scripts/tests/agent-runner-loop.test.mjs scripts/tests/agent-runner-tick.test.mjs scripts/tests/agent-runner-events.test.mjs
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- git diff --check
- pnpm agent:queue:test
- pnpm agent:queue:tick -- --help && pnpm agent:queue:dispatch -- --help && pnpm agent:queue:loop -- --help
- push hook ran pnpm test