### PR TITLE
feat(agent-runner): align control plane dispatch

### DIFF
--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -29,7 +29,9 @@ pnpm -C apps/agent-control-plane dev
 
 `POST /api/dispatch-plans` accepts ordered queue recommendations and returns the
 first dispatchable plan that matches the optional filters. It mirrors the local
-runner allow-list: `start`, `collect-ci`, `publish-evidence`, `open-pr`,
-`sync-pr`, and `cleanup`. Pass `options.updateBody = true` to include
-`--update-body` when the selected plan is `sync-pr`; other actions ignore that
-option.
+runner allow-list: `start`, `remote-bootstrap`, `collect-ci`,
+`publish-evidence`, `remote-publish-evidence`, `open-pr`, `remote-open-pr`,
+`sync-pr`, `cleanup`, and `remote-cleanup`. Pass `options.eventLog` to keep the
+planned lifecycle command on a supervisor-specific JSONL ledger. Pass
+`options.updateBody = true` to include `--update-body` when the selected plan is
+`sync-pr`; other actions ignore that option.

--- a/apps/agent-control-plane/src/control-plane.test.ts
+++ b/apps/agent-control-plane/src/control-plane.test.ts
@@ -36,6 +36,10 @@ describe("agent control plane", () => {
         "cleanup",
         "open-pr",
         "publish-evidence",
+        "remote-bootstrap",
+        "remote-cleanup",
+        "remote-open-pr",
+        "remote-publish-evidence",
         "start",
         "sync-pr",
       ],
@@ -134,6 +138,59 @@ describe("agent control plane", () => {
     })
   })
 
+  it("plans allow-listed remote lifecycle actions", () => {
+    const remoteRecommendation = {
+      action: "remote-publish-evidence",
+      reason: "remote workspace evidence should be published before PR creation",
+      issue: {
+        number: 628,
+        title: "Publish remote evidence",
+        url: "https://github.com/voyantjs/voyant/issues/628",
+        repository: "voyantjs/voyant",
+      },
+    }
+
+    expect(
+      selectDispatchPlan({
+        recommendations: [remoteRecommendation],
+        repository: "voyantjs/voyant",
+      }).plan,
+    ).toMatchObject({
+      action: "remote-publish-evidence",
+      command: [
+        "pnpm",
+        "agent:queue:remote-publish-evidence",
+        "--",
+        "--issue",
+        "628",
+        "--repo",
+        "voyantjs/voyant",
+        "--yes",
+      ],
+    })
+  })
+
+  it("adds event log context to planned lifecycle commands", () => {
+    expect(
+      selectDispatchPlan({
+        options: { eventLog: ".agent-runs/supervisor.jsonl" },
+        recommendations: [recommendations[1]!],
+        repository: "voyantjs/voyant",
+      }).plan?.command,
+    ).toEqual([
+      "pnpm",
+      "agent:queue:start",
+      "--",
+      "--issue",
+      "579",
+      "--repo",
+      "voyantjs/voyant",
+      "--yes",
+      "--event-log",
+      ".agent-runs/supervisor.jsonl",
+    ])
+  })
+
   it("adds PR body refresh only for sync plans", () => {
     const syncRecommendation = {
       action: "sync-pr",
@@ -148,7 +205,7 @@ describe("agent control plane", () => {
 
     expect(
       selectDispatchPlan({
-        options: { updateBody: true },
+        options: { eventLog: ".agent-runs/supervisor.jsonl", updateBody: true },
         recommendations: [syncRecommendation],
         repository: "voyantjs/voyant",
       }).plan?.command,
@@ -161,6 +218,8 @@ describe("agent control plane", () => {
       "--repo",
       "voyantjs/voyant",
       "--yes",
+      "--event-log",
+      ".agent-runs/supervisor.jsonl",
       "--update-body",
     ])
 

--- a/apps/agent-control-plane/src/control-plane.ts
+++ b/apps/agent-control-plane/src/control-plane.ts
@@ -5,6 +5,10 @@ export const dispatchableActions = [
   "cleanup",
   "open-pr",
   "publish-evidence",
+  "remote-bootstrap",
+  "remote-cleanup",
+  "remote-open-pr",
+  "remote-publish-evidence",
   "start",
   "sync-pr",
 ] as const
@@ -20,6 +24,7 @@ export const dispatchPlanRequestSchema = z.object({
     .optional(),
   options: z
     .object({
+      eventLog: z.string().min(1).optional(),
       updateBody: z.boolean().optional(),
     })
     .optional(),
@@ -113,6 +118,7 @@ export function selectDispatchPlan(request: DispatchPlanRequest): DispatchPlanRe
       action,
       command: dispatchCommand({
         action,
+        eventLog: request.options?.eventLog,
         issueNumber: recommendation.issue.number,
         repository: request.repository,
         updateBody: request.options?.updateBody,
@@ -128,11 +134,13 @@ export function selectDispatchPlan(request: DispatchPlanRequest): DispatchPlanRe
 
 function dispatchCommand({
   action,
+  eventLog,
   issueNumber,
   repository,
   updateBody,
 }: {
   action: DispatchPlan["action"]
+  eventLog?: string
   issueNumber: number
   repository: string
   updateBody?: boolean
@@ -147,6 +155,10 @@ function dispatchCommand({
     repository,
     "--yes",
   ]
+
+  if (eventLog) {
+    command.push("--event-log", eventLog)
+  }
 
   if (updateBody && action === "sync-pr") {
     command.push("--update-body")

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1157,7 +1157,9 @@ dashboard exists. Dispatch, loop, and control-plane planning can pass the same
 event-log option through to `sync-pr` when the runner intentionally wants that
 refresh. Tick output now carries a recent audit-event tail as well as ordered
 recommendations, and dispatch keeps nested lifecycle command events in the same
-ledger when a supervisor passes a custom `--event-log`.
+ledger when a supervisor passes a custom `--event-log`. The Cloudflare-ready
+control-plane app mirrors the safe local and remote dispatch allow-list and can
+include that event-log context when it returns dry-run lifecycle command plans.
 
 Verification:
 

--- a/scripts/agent-runner-remote-bootstrap.mjs
+++ b/scripts/agent-runner-remote-bootstrap.mjs
@@ -9,6 +9,12 @@ import {
   runGit,
 } from "./lib/agent-project-queue.mjs"
 import {
+  issueEventDetails,
+  resolveEventLogPath,
+  tryAppendAgentRunnerEvent,
+} from "./lib/agent-runner-events.mjs"
+import {
+  eventLogOptions,
   maybePrintHelp,
   mutationOptions,
   projectOptions,
@@ -45,6 +51,7 @@ maybePrintHelp(args, {
       "Optional remote adapter config module. Defaults to .agents/remote-workspaces.mjs when present.",
     ],
     ["--json", "Print machine-readable JSON."],
+    ...eventLogOptions,
     ...mutationOptions,
     ...repositoryOptions,
     ...projectOptions,
@@ -61,6 +68,7 @@ if (!args.yes) {
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = resolveRepository()
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
 const issueContext = args.issue ? loadIssueItem({ repository }) : null
 const item = issueContext?.item ?? null
 const workspaceReference =
@@ -86,6 +94,20 @@ const result = await adapter.exec({
   httpPost: true,
 })
 const projectUpdated = maybeUpdateProject({ issueContext, plan, result, workspaceReference })
+tryAppendAgentRunnerEvent({
+  eventLogPath,
+  event: {
+    type: "remote-bootstrap.completed",
+    branch: plan.branch,
+    issue: item ? issueEventDetails(item) : null,
+    projectUpdated,
+    repository,
+    result: {
+      status: result.status ?? null,
+    },
+    workspace: workspaceReference,
+  },
+})
 
 if (args.json) {
   console.log(


### PR DESCRIPTION
## Summary
- Updates the control-plane dispatch planner to include the current safe remote lifecycle actions.
- Adds options.eventLog so planned lifecycle commands can stay on a supervisor-specific audit ledger.
- Updates control-plane docs and orchestration status notes to match the current contract.

## Verification
- pnpm -C apps/agent-control-plane test
- pnpm -C apps/agent-control-plane typecheck
- pnpm --filter @voyantjs/agent-control-plane lint
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- git diff --check
- push hook ran pnpm test