### PR TITLE
feat(agent-runner): accept tick snapshots

### DIFF
--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -26,6 +26,7 @@ pnpm -C apps/agent-control-plane dev
 - `GET /health`
 - `GET /api/capabilities`
 - `POST /api/dispatch-plans`
+- `POST /api/tick-snapshots`
 
 `POST /api/dispatch-plans` accepts ordered queue recommendations and returns the
 first dispatchable plan that matches the optional filters. It mirrors the local
@@ -35,3 +36,9 @@ runner allow-list: `start`, `remote-bootstrap`, `collect-ci`,
 planned lifecycle command on a supervisor-specific JSONL ledger. Pass
 `options.updateBody = true` to include `--update-body` when the selected plan is
 `sync-pr`; other actions ignore that option.
+
+`POST /api/tick-snapshots` accepts the JSON emitted by
+`pnpm agent:queue:tick -- --json`, validates the shape, and returns the accepted
+snapshot with counts for total recommendations, dispatchable recommendations,
+and recent events. The current contract is intentionally non-persistent; use it
+to prove worker-to-supervisor shape before adding storage or automatic loops.

--- a/apps/agent-control-plane/src/app.ts
+++ b/apps/agent-control-plane/src/app.ts
@@ -1,9 +1,11 @@
 import { Hono } from "hono"
 
 import {
+  acceptTickSnapshot,
   buildCapabilities,
   dispatchPlanRequestSchema,
   selectDispatchPlan,
+  tickSnapshotRequestSchema,
 } from "./control-plane.js"
 
 interface AppOptions {
@@ -42,10 +44,7 @@ export function createApp({ authTokens = [] }: AppOptions = {}): Hono {
       return c.json(
         {
           error: "invalid_dispatch_plan_request",
-          issues: parsed.error.issues.map((issue) => ({
-            path: issue.path.join("."),
-            message: issue.message,
-          })),
+          issues: validationIssues(parsed.error),
         },
         400,
       )
@@ -54,10 +53,32 @@ export function createApp({ authTokens = [] }: AppOptions = {}): Hono {
     return c.json(selectDispatchPlan(parsed.data))
   })
 
+  app.post("/api/tick-snapshots", async (c) => {
+    const parsed = tickSnapshotRequestSchema.safeParse(await c.req.json().catch(() => null))
+    if (!parsed.success) {
+      return c.json(
+        {
+          error: "invalid_tick_snapshot_request",
+          issues: validationIssues(parsed.error),
+        },
+        400,
+      )
+    }
+
+    return c.json(acceptTickSnapshot(parsed.data))
+  })
+
   return app
 }
 
 function bearerToken(header: string | undefined) {
   const match = header?.match(/^Bearer\s+(.+)$/i)
   return match?.[1]?.trim()
+}
+
+function validationIssues(error: { issues: Array<{ path: Array<PropertyKey>; message: string }> }) {
+  return error.issues.map((issue) => ({
+    path: issue.path.join("."),
+    message: issue.message,
+  }))
 }

--- a/apps/agent-control-plane/src/control-plane.test.ts
+++ b/apps/agent-control-plane/src/control-plane.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest"
 
 import { createApp } from "./app.js"
-import { buildCapabilities, selectDispatchPlan } from "./control-plane.js"
+import {
+  acceptTickSnapshot,
+  buildCapabilities,
+  selectDispatchPlan,
+  tickSnapshotRequestSchema,
+} from "./control-plane.js"
 
 const recommendations = [
   {
@@ -26,6 +31,60 @@ const recommendations = [
   },
 ]
 
+const tickSnapshot = {
+  project: {
+    owner: "voyantjs",
+    number: 1,
+    title: "Voyant Engineering",
+    url: "https://github.com/orgs/voyantjs/projects/1",
+  },
+  repository: "voyantjs/voyant",
+  maxAgeDays: 1,
+  eventLog: {
+    path: "/repo/.agent-runs/events.jsonl",
+    recentEvents: [
+      {
+        timestamp: "2026-05-12T05:00:00.000Z",
+        type: "dispatch.completed",
+        issue: { number: 579 },
+      },
+    ],
+  },
+  recommendations: [
+    {
+      action: "remote-bootstrap",
+      command: "pnpm agent:queue:remote-bootstrap -- --issue 579 --repo voyantjs/voyant --yes",
+      issue: {
+        number: 579,
+        title: "Test agent project intake workflow",
+        url: "https://github.com/voyantjs/voyant/issues/579",
+        repository: "voyantjs/voyant",
+        agentBrief: "Acceptance criteria and verification lane.",
+        hasAgentBrief: true,
+        labels: ["agent:ready", "ui"],
+        state: "OPEN",
+      },
+      priority: 20,
+      reason: "remote workspace is ready for repository bootstrap",
+      state: "Ready",
+    },
+    {
+      action: "remote-run-command",
+      command:
+        'pnpm agent:queue:remote-run-command -- --issue 580 --repo voyantjs/voyant --command "<implementation-command>" --yes',
+      issue: {
+        number: 580,
+        title: "Run implementation",
+        url: "https://github.com/voyantjs/voyant/issues/580",
+        repository: "voyantjs/voyant",
+      },
+      priority: 30,
+      reason: "implementation execution remains explicit",
+      state: "Planning",
+    },
+  ],
+}
+
 describe("agent control plane", () => {
   it("reports dry-run capabilities", () => {
     expect(buildCapabilities()).toMatchObject({
@@ -43,6 +102,35 @@ describe("agent control plane", () => {
         "start",
         "sync-pr",
       ],
+      snapshotContracts: {
+        tick: {
+          persistence: "none",
+          version: 1,
+        },
+      },
+    })
+  })
+
+  it("accepts and summarizes tick snapshots without dispatching work", () => {
+    expect(acceptTickSnapshot(tickSnapshot)).toEqual({
+      accepted: true,
+      snapshot: tickSnapshot,
+      summary: {
+        dispatchableRecommendationCount: 1,
+        firstDispatchableAction: "remote-bootstrap",
+        firstDispatchableIssueNumber: 579,
+        recentEventCount: 1,
+        recommendationCount: 2,
+      },
+    })
+  })
+
+  it("preserves extra issue metadata when validating tick snapshots", () => {
+    expect(tickSnapshotRequestSchema.parse(tickSnapshot).recommendations[0]?.issue).toMatchObject({
+      agentBrief: "Acceptance criteria and verification lane.",
+      hasAgentBrief: true,
+      labels: ["agent:ready", "ui"],
+      state: "OPEN",
     })
   })
 
@@ -261,6 +349,30 @@ describe("agent control plane", () => {
     })
   })
 
+  it("accepts tick snapshots through Hono", async () => {
+    const app = createApp({ authTokens: ["secret"] })
+    const response = await app.request("/api/tick-snapshots", {
+      method: "POST",
+      headers: { authorization: "Bearer secret", "content-type": "application/json" },
+      body: JSON.stringify(tickSnapshot),
+    })
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toMatchObject({
+      accepted: true,
+      summary: {
+        dispatchableRecommendationCount: 1,
+        firstDispatchableAction: "remote-bootstrap",
+        recentEventCount: 1,
+        recommendationCount: 2,
+      },
+    })
+    expect(body).toHaveProperty("snapshot.recommendations.0.issue.hasAgentBrief", true)
+    expect(body).toHaveProperty("snapshot.recommendations.0.issue.labels", ["agent:ready", "ui"])
+    expect(body).toHaveProperty("snapshot.recommendations.0.issue.state", "OPEN")
+  })
+
   it("requires configured bearer auth for API routes", async () => {
     const missingConfig = createApp()
     const root = await missingConfig.request("/")
@@ -288,15 +400,26 @@ describe("agent control plane", () => {
 
   it("returns validation errors for malformed planning requests", async () => {
     const app = createApp({ authTokens: ["secret"] })
-    const response = await app.request("/api/dispatch-plans", {
+    const planResponse = await app.request("/api/dispatch-plans", {
       method: "POST",
       headers: { authorization: "Bearer secret", "content-type": "application/json" },
       body: JSON.stringify({ recommendations: [] }),
     })
 
-    expect(response.status).toBe(400)
-    await expect(response.json()).resolves.toMatchObject({
+    expect(planResponse.status).toBe(400)
+    await expect(planResponse.json()).resolves.toMatchObject({
       error: "invalid_dispatch_plan_request",
+    })
+
+    const snapshotResponse = await app.request("/api/tick-snapshots", {
+      method: "POST",
+      headers: { authorization: "Bearer secret", "content-type": "application/json" },
+      body: JSON.stringify({ recommendations: [] }),
+    })
+
+    expect(snapshotResponse.status).toBe(400)
+    await expect(snapshotResponse.json()).resolves.toMatchObject({
+      error: "invalid_tick_snapshot_request",
     })
   })
 })

--- a/apps/agent-control-plane/src/control-plane.ts
+++ b/apps/agent-control-plane/src/control-plane.ts
@@ -15,6 +15,34 @@ export const dispatchableActions = [
 
 const dispatchableActionSet = new Set<string>(dispatchableActions)
 
+const issueSchema = z
+  .object({
+    number: z.number().int().positive(),
+    title: z.string().min(1),
+    url: z.string().url(),
+    repository: z.string().min(1),
+  })
+  .passthrough()
+
+const queueRecommendationSchema = z
+  .object({
+    action: z.string(),
+    command: z.string().nullable().optional(),
+    heartbeat: z.record(z.string(), z.unknown()).nullable().optional(),
+    issue: issueSchema,
+    priority: z.number().finite().optional(),
+    reason: z.string().min(1),
+    state: z.string().nullable().optional(),
+  })
+  .passthrough()
+
+const runnerEventSchema = z
+  .object({
+    timestamp: z.string().min(1).optional(),
+    type: z.string().min(1).optional(),
+  })
+  .passthrough()
+
 export const dispatchPlanRequestSchema = z.object({
   filters: z
     .object({
@@ -28,24 +56,29 @@ export const dispatchPlanRequestSchema = z.object({
       updateBody: z.boolean().optional(),
     })
     .optional(),
-  recommendations: z
-    .array(
-      z.object({
-        action: z.string(),
-        reason: z.string().min(1),
-        issue: z.object({
-          number: z.number().int().positive(),
-          title: z.string().min(1),
-          url: z.string().url(),
-          repository: z.string().min(1),
-        }),
-      }),
-    )
-    .min(1),
+  recommendations: z.array(queueRecommendationSchema).min(1),
   repository: z.string().min(1),
 })
 
 export type DispatchPlanRequest = z.infer<typeof dispatchPlanRequestSchema>
+
+export const tickSnapshotRequestSchema = z.object({
+  eventLog: z.object({
+    path: z.string().min(1),
+    recentEvents: z.array(runnerEventSchema),
+  }),
+  maxAgeDays: z.number().int().nonnegative(),
+  project: z.object({
+    number: z.number().int().positive(),
+    owner: z.string().min(1),
+    title: z.string().min(1),
+    url: z.string().url(),
+  }),
+  recommendations: z.array(queueRecommendationSchema),
+  repository: z.string().min(1),
+})
+
+export type TickSnapshotRequest = z.infer<typeof tickSnapshotRequestSchema>
 
 export interface DispatchPlan {
   action: (typeof dispatchableActions)[number]
@@ -76,6 +109,31 @@ export function buildCapabilities() {
         min: 0,
         max: 3600,
       },
+    },
+    snapshotContracts: {
+      tick: {
+        version: 1,
+        persistence: "none",
+      },
+    },
+  }
+}
+
+export function acceptTickSnapshot(snapshot: TickSnapshotRequest) {
+  const dispatchableRecommendations = snapshot.recommendations.filter((recommendation) =>
+    isDispatchableAction(recommendation.action),
+  )
+  const firstDispatchable = dispatchableRecommendations[0] ?? null
+
+  return {
+    accepted: true,
+    snapshot,
+    summary: {
+      dispatchableRecommendationCount: dispatchableRecommendations.length,
+      firstDispatchableAction: firstDispatchable?.action ?? null,
+      firstDispatchableIssueNumber: firstDispatchable?.issue.number ?? null,
+      recentEventCount: snapshot.eventLog.recentEvents.length,
+      recommendationCount: snapshot.recommendations.length,
     },
   }
 }

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -385,6 +385,9 @@ machine-readable actions. Tick also tails recent JSONL runner events from
 `--event-log <path>` to inspect a different local ledger. `Merge Ready` items
 with linked PRs keep recommending `sync-pr` so the runner can observe
 maintainer merges and mark the item done.
+The Cloudflare-ready control-plane app can accept this JSON at
+`POST /api/tick-snapshots` for validation and summary counts, but that endpoint
+is non-persistent and does not dispatch work.
 `CI Repair` items with failing linked PRs recommend `collect-ci` until a local
 CI repair packet exists. Ready items with `sandbox:<provider>:<id>` workspaces
 recommend `remote-bootstrap` so dispatch can clone/fetch the repository and

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1160,6 +1160,10 @@ recommendations, and dispatch keeps nested lifecycle command events in the same
 ledger when a supervisor passes a custom `--event-log`. The Cloudflare-ready
 control-plane app mirrors the safe local and remote dispatch allow-list and can
 include that event-log context when it returns dry-run lifecycle command plans.
+It also accepts non-persistent tick snapshots that match
+`agent:queue:tick -- --json`, so a future dashboard or supervisor can validate
+queue shape and recommendation counts before storage or automatic loops are
+introduced.
 
 Verification:
 


### PR DESCRIPTION
## Summary
- add a typed `/api/tick-snapshots` control-plane endpoint for `agent:queue:tick -- --json` output
- return non-persistent recommendation/event summary counts for supervisor and dashboard consumers
- document the snapshot contract in the control-plane README and agent orchestration docs

## Verification
- `pnpm -C apps/agent-control-plane test`
- `pnpm -C apps/agent-control-plane typecheck`
- `pnpm --filter @voyantjs/agent-control-plane lint`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- push hook full `pnpm test`