### PR TITLE
[codex] Add admin page metadata helpers

### DIFF
--- a/.changeset/admin-page-head.md
+++ b/.changeset/admin-page-head.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/admin": minor
+---
+
+Add locale-aware admin page metadata helpers and derive workspace titles from navigation.

--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -181,6 +181,30 @@ Pass `variant="inset"` or `variant="floating"` and `side="right"` when an app
 needs one of the modern sidebar variants. The sidebar can also be toggled with
 `Cmd+B` on macOS or `Ctrl+B` on Windows and Linux.
 
+Route-level document titles are derived from `navItems` and `currentPath` by
+default, so `/bookings` renders `Bookings · Voyant` and tracks the active
+locale when the navigation messages change. `AdminPageHead` also keeps
+`<html lang>` synchronized with `useLocale().resolvedLocale` and updates the
+description and Open Graph description meta tags when a description is provided.
+Apps can override detail routes that are not represented by navigation items
+with `useAdminPageHead`:
+
+```tsx
+import { useAdminPageHead } from "@voyantjs/admin"
+
+function ProductDetailPage({ product }) {
+  useAdminPageHead({
+    title: product.name,
+    description: product.summary,
+  })
+
+  return <ProductDetailLayout product={product} />
+}
+```
+
+Set `pageHead={false}` on `OperatorAdminWorkspaceLayout` only when an app owns
+all document metadata itself.
+
 The default brand uses the exported `VoyantMark` and `VoyantWordmark` SVG
 components and swaps from wordmark to mark in collapsed icon mode. Apps that
 need a custom lockup can pass `brand={<MyBrand />}` or compose those exported

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -9,6 +9,7 @@
     "./styles.css": "./src/styles.css",
     "./components/admin-nav-group": "./src/components/admin-nav-group.tsx",
     "./components/admin-nav-link": "./src/components/admin-nav-link.tsx",
+    "./components/admin-page-head": "./src/components/admin-page-head.tsx",
     "./components/admin-widget-slot": "./src/components/admin-widget-slot.tsx",
     "./components/operator-admin-bootstrap-gate": "./src/components/operator-admin-bootstrap-gate.tsx",
     "./components/operator-admin-sidebar": "./src/components/operator-admin-sidebar.tsx",
@@ -92,6 +93,11 @@
         "types": "./dist/components/admin-nav-link.d.ts",
         "import": "./dist/components/admin-nav-link.js",
         "default": "./dist/components/admin-nav-link.js"
+      },
+      "./components/admin-page-head": {
+        "types": "./dist/components/admin-page-head.d.ts",
+        "import": "./dist/components/admin-page-head.js",
+        "default": "./dist/components/admin-page-head.js"
       },
       "./components/admin-widget-slot": {
         "types": "./dist/components/admin-widget-slot.d.ts",

--- a/packages/admin/src/components/admin-page-head.tsx
+++ b/packages/admin/src/components/admin-page-head.tsx
@@ -50,6 +50,10 @@ function upsertMeta(selector: string, attributes: Record<string, string>, conten
   element.content = content
 }
 
+function removeMeta(selector: string) {
+  document.head.querySelector<HTMLMetaElement>(selector)?.remove()
+}
+
 function useApplyAdminPageHead({
   brand,
   description,
@@ -80,7 +84,13 @@ function useApplyAdminPageHead({
   }, [brand, enabled, title])
 
   useEffect(() => {
-    if (!enabled || typeof document === "undefined" || description == null) {
+    if (!enabled || typeof document === "undefined") {
+      return
+    }
+
+    if (description == null) {
+      removeMeta('meta[name="description"]')
+      removeMeta('meta[property="og:description"]')
       return
     }
 

--- a/packages/admin/src/components/admin-page-head.tsx
+++ b/packages/admin/src/components/admin-page-head.tsx
@@ -1,0 +1,168 @@
+"use client"
+
+import type * as React from "react"
+import { createContext, useContext, useEffect, useId, useMemo, useState } from "react"
+
+import { DEFAULT_ADMIN_LOCALE, useLocale } from "../providers/locale.js"
+
+export interface AdminPageHeadOptions {
+  brand?: string | null
+  description?: string | null
+  title?: string | null
+}
+
+export interface AdminPageHeadProps extends AdminPageHeadOptions {
+  children?: React.ReactNode
+}
+
+export interface AdminPageHeadProviderProps {
+  baseHead?: AdminPageHeadOptions | null
+  children: React.ReactNode
+}
+
+interface AdminPageHeadContextValue {
+  setPageHeadOverride: (id: string, head: AdminPageHeadOptions | null) => void
+}
+
+const AdminPageHeadContext = createContext<AdminPageHeadContextValue | null>(null)
+
+function formatAdminDocumentTitle({
+  brand,
+  title,
+}: Pick<AdminPageHeadOptions, "brand" | "title">): string {
+  const resolvedBrand = brand?.trim() || "Voyant"
+  const resolvedTitle = title?.trim()
+
+  return resolvedTitle ? `${resolvedTitle} · ${resolvedBrand}` : resolvedBrand
+}
+
+function upsertMeta(selector: string, attributes: Record<string, string>, content: string) {
+  let element = document.head.querySelector<HTMLMetaElement>(selector)
+
+  if (!element) {
+    element = document.createElement("meta")
+    for (const [name, value] of Object.entries(attributes)) {
+      element.setAttribute(name, value)
+    }
+    document.head.appendChild(element)
+  }
+
+  element.content = content
+}
+
+function useApplyAdminPageHead({
+  brand,
+  description,
+  enabled = true,
+  title,
+}: AdminPageHeadOptions & { enabled?: boolean }) {
+  const { resolvedLocale } = useLocale()
+
+  useEffect(() => {
+    if (!enabled || typeof document === "undefined") {
+      return
+    }
+
+    const lang = resolvedLocale || DEFAULT_ADMIN_LOCALE
+    if (document.documentElement.lang !== lang) {
+      document.documentElement.lang = lang
+    }
+  }, [enabled, resolvedLocale])
+
+  useEffect(() => {
+    if (!enabled || typeof document === "undefined") {
+      return
+    }
+
+    const documentTitle = formatAdminDocumentTitle({ brand, title })
+    document.title = documentTitle
+    upsertMeta('meta[property="og:title"]', { property: "og:title" }, documentTitle)
+  }, [brand, enabled, title])
+
+  useEffect(() => {
+    if (!enabled || typeof document === "undefined" || description == null) {
+      return
+    }
+
+    upsertMeta('meta[name="description"]', { name: "description" }, description)
+    upsertMeta('meta[property="og:description"]', { property: "og:description" }, description)
+  }, [description, enabled])
+}
+
+function mergeAdminPageHead(
+  baseHead: AdminPageHeadOptions | null | undefined,
+  override: AdminPageHeadOptions | null | undefined,
+): AdminPageHeadOptions {
+  return {
+    brand: override?.brand ?? baseHead?.brand ?? "Voyant",
+    description: override?.description ?? baseHead?.description ?? null,
+    title: override?.title ?? baseHead?.title ?? null,
+  }
+}
+
+export function AdminPageHead({ children, ...head }: AdminPageHeadProps) {
+  useApplyAdminPageHead(head)
+
+  return <>{children ?? null}</>
+}
+
+export function AdminPageHeadProvider({ baseHead, children }: AdminPageHeadProviderProps) {
+  const [overrides, setOverrides] = useState<ReadonlyMap<string, AdminPageHeadOptions>>(
+    () => new Map(),
+  )
+  const latestOverride = Array.from(overrides.values()).at(-1)
+  const resolvedHead = mergeAdminPageHead(baseHead, latestOverride)
+  const context = useMemo<AdminPageHeadContextValue>(
+    () => ({
+      setPageHeadOverride(id, head) {
+        setOverrides((currentOverrides) => {
+          const nextOverrides = new Map(currentOverrides)
+
+          if (head) {
+            nextOverrides.set(id, head)
+          } else {
+            nextOverrides.delete(id)
+          }
+
+          return nextOverrides
+        })
+      },
+    }),
+    [],
+  )
+
+  return (
+    <AdminPageHeadContext.Provider value={context}>
+      <AdminPageHead {...resolvedHead} />
+      {children}
+    </AdminPageHeadContext.Provider>
+  )
+}
+
+export function useAdminPageHead(head: AdminPageHeadOptions) {
+  const context = useContext(AdminPageHeadContext)
+  const id = useId()
+  const stableHead = useMemo(
+    () => ({
+      brand: head.brand,
+      description: head.description,
+      title: head.title,
+    }),
+    [head.brand, head.description, head.title],
+  )
+
+  useEffect(() => {
+    if (!context) {
+      return
+    }
+
+    context.setPageHeadOverride(id, stableHead)
+
+    return () => context.setPageHeadOverride(id, null)
+  }, [context, id, stableHead])
+
+  useApplyAdminPageHead({
+    ...stableHead,
+    enabled: context == null,
+  })
+}

--- a/packages/admin/src/components/operator-admin-sidebar.tsx
+++ b/packages/admin/src/components/operator-admin-sidebar.tsx
@@ -24,9 +24,10 @@ import {
 } from "../navigation/operator-navigation.js"
 import { AdminExtensionsProvider } from "../providers/admin-extensions.js"
 import { useOperatorAdminMessages } from "../providers/operator-admin-messages.js"
-import type { AdminUser, NavItem } from "../types.js"
+import type { AdminUser, NavItem, NavSubItem } from "../types.js"
 import { AdminNavGroup } from "./admin-nav-group.js"
 import { type AdminNavLinkComponent, DefaultAdminNavLink } from "./admin-nav-link.js"
+import { type AdminPageHeadOptions, AdminPageHeadProvider } from "./admin-page-head.js"
 import { VoyantMark } from "./brand/voyant-mark.js"
 import { VoyantWordmark } from "./brand/voyant-wordmark.js"
 import { OperatorAdminUserMenu } from "./operator-admin-user-menu.js"
@@ -129,11 +130,56 @@ export interface OperatorAdminWorkspaceLayoutProps {
   mainClassName?: string
   navItems?: ReadonlyArray<NavItem>
   onSignOut?: () => void | Promise<void>
+  pageHead?: (AdminPageHeadOptions & { titleOverride?: string | null }) | false
   side?: React.ComponentProps<typeof Sidebar>["side"]
   sidebarProps?: Omit<OperatorAdminSidebarProps, "currentPath">
   showSidebarTrigger?: boolean
   user?: AdminUser | null
   variant?: React.ComponentProps<typeof Sidebar>["variant"]
+}
+
+function normalizePath(path: string): string {
+  const withoutHash = path.split("#")[0] ?? ""
+  const withoutSearch = withoutHash.split("?")[0] ?? ""
+  const normalized = withoutSearch.replace(/\/+$/, "")
+
+  return normalized || "/"
+}
+
+function navUrlMatchesPath(navUrl: string, currentPath: string): boolean {
+  const normalizedUrl = normalizePath(navUrl)
+  const normalizedPath = normalizePath(currentPath)
+
+  if (normalizedUrl === "/") {
+    return normalizedPath === "/"
+  }
+
+  return normalizedPath === normalizedUrl || normalizedPath.startsWith(`${normalizedUrl}/`)
+}
+
+export function resolveAdminPageTitle(
+  currentPath: string,
+  navItems: ReadonlyArray<NavItem>,
+): string | null {
+  let matchedTitle: string | null = null
+  let matchedUrlLength = -1
+  const visitItem = (item: NavItem | NavSubItem) => {
+    if (navUrlMatchesPath(item.url, currentPath)) {
+      const urlLength = normalizePath(item.url).length
+      if (urlLength >= matchedUrlLength) {
+        matchedTitle = item.title
+        matchedUrlLength = urlLength
+      }
+    }
+
+    if ("items" in item) {
+      item.items?.forEach(visitItem)
+    }
+  }
+
+  navItems.forEach(visitItem)
+
+  return matchedTitle
 }
 
 export function OperatorAdminWorkspaceLayout({
@@ -150,27 +196,59 @@ export function OperatorAdminWorkspaceLayout({
   mainClassName = "flex-1",
   navItems,
   onSignOut,
+  pageHead,
   side,
   sidebarProps,
   showSidebarTrigger = true,
   user,
   variant,
 }: OperatorAdminWorkspaceLayoutProps) {
-  const resolvedSide = sidebarProps?.side ?? side
+  const messages = useOperatorAdminMessages()
+  const {
+    extensions: sidebarExtensions,
+    navItems: sidebarNavItems,
+    side: sidebarSide,
+    ...restSidebarProps
+  } = sidebarProps ?? {}
+  const baseItems =
+    sidebarNavItems ?? navItems ?? createOperatorAdminNavigation({ icons, messages: messages.nav })
+  const resolvedItems = resolveAdminNavigation({
+    baseItems,
+    extensions: sidebarExtensions ?? extensions,
+  })
+  const resolvedSide = sidebarSide ?? side
+  let pageTitle: string | null = null
+  if (pageHead !== false) {
+    if (pageHead?.titleOverride !== undefined) {
+      pageTitle = pageHead.titleOverride
+    } else if (pageHead?.title !== undefined) {
+      pageTitle = pageHead.title
+    } else {
+      pageTitle = resolveAdminPageTitle(currentPath, resolvedItems)
+    }
+  }
+  const pageHeadBase =
+    pageHead === false
+      ? null
+      : {
+          brand: pageHead?.brand ?? "Voyant",
+          description: pageHead?.description ?? null,
+          title: pageTitle,
+        }
   const sidebar = (
     <OperatorAdminSidebar
       accountHref={accountHref}
       brand={brand}
       currentPath={currentPath}
-      extensions={extensions}
+      extensions={undefined}
       icons={icons}
       linkComponent={linkComponent}
-      navItems={navItems}
+      navItems={resolvedItems}
       onSignOut={onSignOut}
-      side={side}
+      side={resolvedSide}
       user={user}
       variant={variant}
-      {...sidebarProps}
+      {...restSidebarProps}
     />
   )
   const inset = (
@@ -197,20 +275,26 @@ export function OperatorAdminWorkspaceLayout({
       {children}
     </SidebarInset>
   )
+  const workspace =
+    resolvedSide === "right" ? (
+      <>
+        {inset}
+        {sidebar}
+      </>
+    ) : (
+      <>
+        {sidebar}
+        {inset}
+      </>
+    )
 
   return (
     <AdminExtensionsProvider extensions={extensions}>
       <SidebarProvider defaultOpen={defaultOpen}>
-        {resolvedSide === "right" ? (
-          <>
-            {inset}
-            {sidebar}
-          </>
+        {pageHead === false ? (
+          workspace
         ) : (
-          <>
-            {sidebar}
-            {inset}
-          </>
+          <AdminPageHeadProvider baseHead={pageHeadBase}>{workspace}</AdminPageHeadProvider>
         )}
       </SidebarProvider>
     </AdminExtensionsProvider>

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -27,6 +27,14 @@ export {
   DefaultAdminNavLink,
 } from "./components/admin-nav-link.js"
 export {
+  AdminPageHead,
+  type AdminPageHeadOptions,
+  type AdminPageHeadProps,
+  AdminPageHeadProvider,
+  type AdminPageHeadProviderProps,
+  useAdminPageHead,
+} from "./components/admin-page-head.js"
+export {
   AdminWidgetSlotRenderer,
   type AdminWidgetSlotRendererProps,
 } from "./components/admin-widget-slot.js"
@@ -45,6 +53,7 @@ export {
   type OperatorAdminSidebarProps,
   OperatorAdminWorkspaceLayout,
   type OperatorAdminWorkspaceLayoutProps,
+  resolveAdminPageTitle,
 } from "./components/operator-admin-sidebar.js"
 export {
   OperatorAdminUserMenu,

--- a/packages/admin/tests/unit/admin-page-head.test.tsx
+++ b/packages/admin/tests/unit/admin-page-head.test.tsx
@@ -1,0 +1,84 @@
+import { cleanup, render, waitFor } from "@testing-library/react"
+import { type ReactNode, useState } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  AdminPageHead,
+  AdminPageHeadProvider,
+  useAdminPageHead,
+} from "../../src/components/admin-page-head.js"
+import { AdminProvider } from "../../src/providers/admin-provider.js"
+
+function renderWithAdminProvider(children: ReactNode) {
+  return render(<AdminProvider themeStorageKey={null}>{children}</AdminProvider>)
+}
+
+beforeEach(() => {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+  document.documentElement.lang = ""
+  document.title = ""
+  document.head.querySelector('meta[name="description"]')?.remove()
+  document.head.querySelector('meta[property="og:title"]')?.remove()
+  document.head.querySelector('meta[property="og:description"]')?.remove()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe("AdminPageHead", () => {
+  it("updates document title, html lang, description, and Open Graph tags", async () => {
+    renderWithAdminProvider(
+      <AdminPageHead brand="Acme" description="Operator booking queue" title="Bookings" />,
+    )
+
+    await waitFor(() => expect(document.title).toBe("Bookings · Acme"))
+    expect(document.documentElement.lang).toBe("en")
+    expect(document.head.querySelector('meta[name="description"]')?.getAttribute("content")).toBe(
+      "Operator booking queue",
+    )
+    expect(document.head.querySelector('meta[property="og:title"]')?.getAttribute("content")).toBe(
+      "Bookings · Acme",
+    )
+    expect(
+      document.head.querySelector('meta[property="og:description"]')?.getAttribute("content"),
+    ).toBe("Operator booking queue")
+  })
+
+  it("lets nested route hooks override provider defaults and restores them on unmount", async () => {
+    function DetailHead() {
+      useAdminPageHead({ description: "Detailed product view", title: "Danube Cruise" })
+
+      return null
+    }
+
+    function Harness() {
+      const [showDetail, setShowDetail] = useState(true)
+
+      return (
+        <AdminPageHeadProvider baseHead={{ brand: "Acme", title: "Products" }}>
+          <button type="button" onClick={() => setShowDetail(false)}>
+            Close detail
+          </button>
+          {showDetail && <DetailHead />}
+        </AdminPageHeadProvider>
+      )
+    }
+
+    const { getByRole } = renderWithAdminProvider(<Harness />)
+
+    await waitFor(() => expect(document.title).toBe("Danube Cruise · Acme"))
+    getByRole("button", { name: "Close detail" }).click()
+    await waitFor(() => expect(document.title).toBe("Products · Acme"))
+  })
+})

--- a/packages/admin/tests/unit/admin-page-head.test.tsx
+++ b/packages/admin/tests/unit/admin-page-head.test.tsx
@@ -78,7 +78,12 @@ describe("AdminPageHead", () => {
     const { getByRole } = renderWithAdminProvider(<Harness />)
 
     await waitFor(() => expect(document.title).toBe("Danube Cruise · Acme"))
+    expect(document.head.querySelector('meta[name="description"]')?.getAttribute("content")).toBe(
+      "Detailed product view",
+    )
     getByRole("button", { name: "Close detail" }).click()
     await waitFor(() => expect(document.title).toBe("Products · Acme"))
+    expect(document.head.querySelector('meta[name="description"]')).toBeNull()
+    expect(document.head.querySelector('meta[property="og:description"]')).toBeNull()
   })
 })

--- a/packages/admin/tests/unit/operator-admin-sidebar.test.tsx
+++ b/packages/admin/tests/unit/operator-admin-sidebar.test.tsx
@@ -1,10 +1,11 @@
-import { cleanup, render, screen } from "@testing-library/react"
+import { cleanup, render, screen, waitFor } from "@testing-library/react"
 import type { ReactNode } from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
   DefaultOperatorAdminBrand,
   OperatorAdminWorkspaceLayout,
+  resolveAdminPageTitle,
 } from "../../src/components/operator-admin-sidebar.js"
 import { AdminProvider } from "../../src/providers/admin-provider.js"
 import { OperatorAdminMessagesProvider } from "../../src/providers/operator-admin-messages.js"
@@ -18,6 +19,7 @@ function renderWithAdminProviders(children: ReactNode) {
 }
 
 beforeEach(() => {
+  document.title = ""
   window.matchMedia = vi.fn().mockImplementation((query: string) => ({
     matches: false,
     media: query,
@@ -81,6 +83,65 @@ describe("OperatorAdminWorkspaceLayout", () => {
     )
 
     expect(directSlots).toEqual(["sidebar-inset", "sidebar"])
+  })
+
+  it("derives document titles from the matching navigation item", async () => {
+    renderWithAdminProviders(
+      <OperatorAdminWorkspaceLayout
+        currentPath="/finance/invoices/123"
+        navItems={[
+          {
+            id: "finance",
+            title: "Finance",
+            url: "/finance/invoices",
+            items: [
+              { id: "invoices", title: "Invoices", url: "/finance/invoices" },
+              { id: "payments", title: "Payments", url: "/finance/payments" },
+            ],
+          },
+          { id: "settings", title: "Settings", url: "/settings" },
+        ]}
+      >
+        <section>Invoice detail</section>
+      </OperatorAdminWorkspaceLayout>,
+    )
+
+    await waitFor(() => expect(document.title).toBe("Invoices · Voyant"))
+  })
+
+  it("allows workspace consumers to disable automatic page metadata", async () => {
+    document.title = "Consumer owned"
+
+    renderWithAdminProviders(
+      <OperatorAdminWorkspaceLayout
+        currentPath="/settings"
+        navItems={[{ id: "settings", title: "Settings", url: "/settings" }]}
+        pageHead={false}
+      >
+        <section>Settings</section>
+      </OperatorAdminWorkspaceLayout>,
+    )
+
+    await waitFor(() => expect(document.title).toBe("Consumer owned"))
+  })
+})
+
+describe("resolveAdminPageTitle", () => {
+  it("uses the longest route-prefix match and keeps the root route exact", () => {
+    expect(
+      resolveAdminPageTitle("/finance/payments/pm_123", [
+        { id: "dashboard", title: "Dashboard", url: "/" },
+        {
+          id: "finance",
+          title: "Finance",
+          url: "/finance/invoices",
+          items: [
+            { id: "invoices", title: "Invoices", url: "/finance/invoices" },
+            { id: "payments", title: "Payments", url: "/finance/payments" },
+          ],
+        },
+      ]),
+    ).toBe("Payments")
   })
 })
 

--- a/templates/operator/README.md
+++ b/templates/operator/README.md
@@ -52,6 +52,12 @@ The workspace shell uses the shared `OperatorAdminWorkspaceLayout`. Operators
 can collapse or expand the sidebar from the header trigger, or with `Cmd+B` on
 macOS and `Ctrl+B` on Windows and Linux.
 
+Route-level browser titles are auto-derived from the shared navigation items
+and active locale. Override detail pages that need entity-specific metadata
+with `useAdminPageHead({ title, description })` from `@voyantjs/admin`. The
+root document also sets `robots: noindex,nofollow`; keep operator deployments
+out of search indexes.
+
 ## Charts
 
 The dashboard uses `recharts` through `@voyantjs/ui` and `@voyantjs/admin`.

--- a/templates/operator/src/routes/__root.tsx
+++ b/templates/operator/src/routes/__root.tsx
@@ -28,6 +28,11 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
     meta: [
       { charSet: "utf-8" },
       { name: "viewport", content: "width=device-width, initial-scale=1" },
+      { name: "robots", content: "noindex,nofollow" },
+      { name: "description", content: "Voyant operator workspace" },
+      { name: "theme-color", content: "#ffffff" },
+      { property: "og:title", content: "Voyant" },
+      { property: "og:type", content: "website" },
       { title: "Voyant" },
     ],
     links: [


### PR DESCRIPTION
Closes #681

## Summary
- add `AdminPageHead`, `AdminPageHeadProvider`, and `useAdminPageHead` for locale-aware document metadata
- derive `OperatorAdminWorkspaceLayout` page titles from the resolved nav tree and support per-page overrides / opt-out
- add operator template root metadata defaults, including `robots: noindex,nofollow`, and document the integration

## Verification
- `pnpm --filter @voyantjs/admin typecheck`
- `pnpm --filter @voyantjs/admin lint`
- `pnpm --filter @voyantjs/admin test`
- `pnpm --filter @voyantjs/admin build`
- `pnpm --filter operator lint`
- `pnpm --filter operator typecheck`
- `pnpm lint:changed`
- pre-push `pnpm test` (121 successful)

Note: `pnpm verify:package-exports` is blocked in this fresh worktree by unrelated packages with missing `dist` output.