### PR TITLE
Polish contract detail page

### DIFF
--- a/.changeset/legal-contract-detail-polish.md
+++ b/.changeset/legal-contract-detail-polish.md
@@ -1,0 +1,7 @@
+---
+"@voyantjs/legal-ui": patch
+"@voyantjs/legal-react": patch
+"@voyantjs/legal": patch
+---
+
+Polish the contract detail page with a clearer header, tabbed document and signature sections, and a file-first attachment dialog.

--- a/packages/legal-react/src/client.ts
+++ b/packages/legal-react/src/client.ts
@@ -41,7 +41,8 @@ export async function fetchWithValidation<TOut>(
 ): Promise<TOut> {
   const url = joinUrl(options.baseUrl, path)
   const headers = new Headers(init?.headers)
-  if (init?.body !== undefined && !headers.has("Content-Type")) {
+  const isFormDataBody = typeof FormData !== "undefined" && init?.body instanceof FormData
+  if (init?.body !== undefined && !isFormDataBody && !headers.has("Content-Type")) {
     headers.set("Content-Type", "application/json")
   }
 

--- a/packages/legal-react/src/hooks/use-contract-attachment-mutation.ts
+++ b/packages/legal-react/src/hooks/use-contract-attachment-mutation.ts
@@ -10,10 +10,23 @@ import type { z } from "zod"
 import { fetchWithValidation } from "../client.js"
 import { useVoyantLegalContext } from "../provider.js"
 import { legalQueryKeys } from "../query-keys.js"
-import { legalContractAttachmentRecordSchema, successEnvelope } from "../schemas.js"
+import { legalContractAttachmentSingleResponse, successEnvelope } from "../schemas.js"
 
 export type CreateLegalContractAttachmentInput = z.input<typeof insertContractAttachmentSchema>
 export type UpdateLegalContractAttachmentInput = z.input<typeof updateContractAttachmentSchema>
+export interface UploadLegalContractAttachmentInput {
+  file: File
+  name?: string
+  kind?: string
+}
+
+function createAttachmentUploadFormData(input: UploadLegalContractAttachmentInput) {
+  const body = new FormData()
+  body.set("file", input.file)
+  if (input.name) body.set("name", input.name)
+  if (input.kind) body.set("kind", input.kind)
+  return body
+}
 
 export function useLegalContractAttachmentMutation() {
   const { baseUrl, fetcher } = useVoyantLegalContext()
@@ -29,11 +42,11 @@ export function useLegalContractAttachmentMutation() {
     }) => {
       const data = await fetchWithValidation(
         `/v1/admin/legal/contracts/${contractId}/attachments`,
-        legalContractAttachmentRecordSchema,
+        legalContractAttachmentSingleResponse,
         { baseUrl, fetcher },
         { method: "POST", body: JSON.stringify(input) },
       )
-      return { contractId, data }
+      return { contractId, data: data.data }
     },
     onSuccess: ({ contractId }) => {
       void queryClient.invalidateQueries({
@@ -54,11 +67,11 @@ export function useLegalContractAttachmentMutation() {
     }) => {
       const data = await fetchWithValidation(
         `/v1/admin/legal/contracts/attachments/${id}`,
-        legalContractAttachmentRecordSchema,
+        legalContractAttachmentSingleResponse,
         { baseUrl, fetcher },
         { method: "PATCH", body: JSON.stringify(input) },
       )
-      return { contractId, data }
+      return { contractId, data: data.data }
     },
     onSuccess: ({ contractId }) => {
       void queryClient.invalidateQueries({
@@ -82,5 +95,53 @@ export function useLegalContractAttachmentMutation() {
     },
   })
 
-  return { create, update, remove }
+  const upload = useMutation({
+    mutationFn: async ({
+      contractId,
+      input,
+    }: {
+      contractId: string
+      input: UploadLegalContractAttachmentInput
+    }) => {
+      const data = await fetchWithValidation(
+        `/v1/admin/legal/contracts/${contractId}/attachments/upload`,
+        legalContractAttachmentSingleResponse,
+        { baseUrl, fetcher },
+        { method: "POST", body: createAttachmentUploadFormData(input) },
+      )
+      return { contractId, data: data.data }
+    },
+    onSuccess: ({ contractId }) => {
+      void queryClient.invalidateQueries({
+        queryKey: legalQueryKeys.contractAttachments(contractId),
+      })
+    },
+  })
+
+  const replaceFile = useMutation({
+    mutationFn: async ({
+      contractId,
+      id,
+      input,
+    }: {
+      contractId: string
+      id: string
+      input: UploadLegalContractAttachmentInput
+    }) => {
+      const data = await fetchWithValidation(
+        `/v1/admin/legal/contracts/attachments/${id}/upload`,
+        legalContractAttachmentSingleResponse,
+        { baseUrl, fetcher },
+        { method: "PATCH", body: createAttachmentUploadFormData(input) },
+      )
+      return { contractId, data: data.data }
+    },
+    onSuccess: ({ contractId }) => {
+      void queryClient.invalidateQueries({
+        queryKey: legalQueryKeys.contractAttachments(contractId),
+      })
+    },
+  })
+
+  return { create, update, remove, upload, replaceFile }
 }

--- a/packages/legal-react/src/schemas.ts
+++ b/packages/legal-react/src/schemas.ts
@@ -82,6 +82,9 @@ export const legalContractAttachmentRecordSchema = insertContractAttachmentSchem
 })
 
 export type LegalContractAttachmentRecord = z.infer<typeof legalContractAttachmentRecordSchema>
+export const legalContractAttachmentSingleResponse = singleEnvelope(
+  legalContractAttachmentRecordSchema,
+)
 
 export const legalContractTemplateRecordSchema = insertContractTemplateSchema.extend({
   id: z.string(),

--- a/packages/legal-ui/src/components/attachment-dialog.tsx
+++ b/packages/legal-ui/src/components/attachment-dialog.tsx
@@ -12,21 +12,32 @@ import {
   DialogTitle,
   Input,
   Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from "@voyantjs/ui/components"
 import { zodResolver } from "@voyantjs/ui/lib/zod-resolver"
-import { Loader2 } from "lucide-react"
-import { useEffect } from "react"
+import { FileText, Loader2, Upload } from "lucide-react"
+import type { ChangeEvent, DragEvent } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useForm } from "react-hook-form"
 import { z } from "zod/v4"
 
 import { useLegalUiMessagesOrDefault } from "../i18n/index.js"
+
+const attachmentKindValues = ["document", "appendix", "scan"] as const
 
 function createAttachmentFormSchema(messages: ReturnType<typeof useLegalUiMessagesOrDefault>) {
   return z.object({
     name: z.string().min(1, messages.attachmentDialog.validation.nameRequired),
     kind: z.string().min(1).optional(),
     mimeType: z.string().optional(),
-    fileSize: z.coerce.number().int().optional(),
+    fileSize: z.preprocess(
+      (value) => (value === "" || value == null ? undefined : value),
+      z.coerce.number().int().optional(),
+    ),
     storageKey: z.string().optional(),
     checksum: z.string().optional(),
   })
@@ -51,15 +62,26 @@ export function AttachmentDialog({
   onSuccess,
 }: AttachmentDialogProps) {
   const isEditing = !!attachment
-  const { create, update } = useLegalContractAttachmentMutation()
+  const { update, upload, replaceFile } = useLegalContractAttachmentMutation()
   const messages = useLegalUiMessagesOrDefault()
   const attachmentFormSchema = createAttachmentFormSchema(messages)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+  const [fileError, setFileError] = useState<string | null>(null)
+  const [isDragging, setIsDragging] = useState(false)
+  const kindItems: Array<{ value: string; label: string }> = attachmentKindValues.map((value) => ({
+    value,
+    label: messages.attachmentDialog.kindLabels[value],
+  }))
+  if (attachment?.kind && !(attachmentKindValues as readonly string[]).includes(attachment.kind)) {
+    kindItems.push({ value: attachment.kind, label: attachment.kind })
+  }
 
   const form = useForm<FormValues, unknown, FormOutput>({
     resolver: zodResolver(attachmentFormSchema),
     defaultValues: {
       name: "",
-      kind: "appendix", // i18n-literal-ok domain default attachment kind
+      kind: "document", // i18n-literal-ok domain attachment kind
       mimeType: "",
       fileSize: undefined,
       storageKey: "",
@@ -77,28 +99,100 @@ export function AttachmentDialog({
         storageKey: attachment.storageKey ?? "",
         checksum: attachment.checksum ?? "",
       })
+      setSelectedFile(null)
+      setFileError(null)
     } else if (open) {
       form.reset()
+      setSelectedFile(null)
+      setFileError(null)
     }
+    setIsDragging(false)
   }, [open, attachment, form])
 
+  const applySelectedFile = (file: File) => {
+    setSelectedFile(file)
+    setFileError(null)
+    setIsDragging(false)
+
+    const currentName = form.getValues("name")
+    if (!currentName || currentName === attachment?.name) {
+      form.setValue("name", file.name, { shouldDirty: true, shouldValidate: true })
+    }
+    form.setValue("mimeType", file.type || "", { shouldDirty: true, shouldValidate: true })
+    form.setValue("fileSize", file.size, { shouldDirty: true, shouldValidate: true })
+  }
+
+  const onFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.currentTarget.files?.[0]
+    if (!file) return
+
+    applySelectedFile(file)
+    event.currentTarget.value = ""
+  }
+
+  const onFileDrop = (event: DragEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    const file = event.dataTransfer.files?.[0]
+    if (file) applySelectedFile(file)
+  }
+
+  const onFileDragOver = (event: DragEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setIsDragging(true)
+  }
+
+  const onFileDragLeave = (event: DragEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setIsDragging(false)
+  }
+
   const onSubmit = async (values: FormOutput) => {
-    const payload = {
-      name: values.name,
-      kind: values.kind || "appendix", // i18n-literal-ok domain default attachment kind
-      mimeType: values.mimeType || undefined,
-      fileSize: values.fileSize || undefined,
-      storageKey: values.storageKey || undefined,
-      checksum: values.checksum || undefined,
+    const uploadInput = selectedFile
+      ? {
+          file: selectedFile,
+          name: values.name,
+          kind: values.kind || "document", // i18n-literal-ok domain attachment kind
+        }
+      : null
+
+    if (uploadInput && isEditing && attachment) {
+      await replaceFile.mutateAsync({ contractId, id: attachment.id, input: uploadInput })
+      onSuccess()
+      return
     }
 
-    if (isEditing && attachment) {
-      await update.mutateAsync({ contractId, id: attachment.id, input: payload })
-    } else {
-      await create.mutateAsync({ contractId, input: payload })
+    if (uploadInput) {
+      await upload.mutateAsync({ contractId, input: uploadInput })
+      onSuccess()
+      return
     }
+
+    if (!isEditing) {
+      setFileError(messages.attachmentDialog.validation.fileRequired)
+      return
+    }
+
+    await update.mutateAsync({
+      contractId,
+      id: attachment.id,
+      input: {
+        name: values.name,
+        kind: values.kind || "document", // i18n-literal-ok domain attachment kind
+        mimeType: values.mimeType || undefined,
+        fileSize: values.fileSize,
+        storageKey: values.storageKey || undefined,
+        checksum: values.checksum || undefined,
+      },
+    })
     onSuccess()
   }
+
+  const isSubmitting =
+    form.formState.isSubmitting || update.isPending || upload.isPending || replaceFile.isPending
+  const submitError = update.error ?? upload.error ?? replaceFile.error ?? null
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -112,66 +206,91 @@ export function AttachmentDialog({
         </DialogHeader>
         <form onSubmit={form.handleSubmit(onSubmit)}>
           <DialogBody className="grid gap-4">
+            <input type="hidden" {...form.register("mimeType")} />
+            <input type="hidden" {...form.register("fileSize")} />
+            <input type="hidden" {...form.register("storageKey")} />
+            <input type="hidden" {...form.register("checksum")} />
+
             <div className="flex flex-col gap-2">
-              <Label>{messages.attachmentDialog.fields.name}</Label>
-              <Input
-                {...form.register("name")}
-                placeholder={messages.attachmentDialog.placeholders.name}
-              />
-              {form.formState.errors.name && (
-                <p className="text-xs text-destructive">{form.formState.errors.name.message}</p>
-              )}
+              <Label>{messages.attachmentDialog.fields.file}</Label>
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                onDrop={onFileDrop}
+                onDragOver={onFileDragOver}
+                onDragLeave={onFileDragLeave}
+                data-dragging={isDragging}
+                className="flex min-h-32 flex-col items-center justify-center gap-2 rounded-md border border-dashed px-4 py-6 text-center transition-colors hover:border-foreground/30 hover:bg-muted/30 data-[dragging=true]:border-primary data-[dragging=true]:bg-primary/5"
+              >
+                {selectedFile ? (
+                  <>
+                    <FileText className="size-6 text-muted-foreground" aria-hidden="true" />
+                    <span className="max-w-full truncate font-medium text-sm">
+                      {selectedFile.name}
+                    </span>
+                    <span className="text-muted-foreground text-xs">
+                      {formatUploadSize(selectedFile.size)}
+                      {selectedFile.type ? ` - ${selectedFile.type}` : ""}
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <Upload className="size-6 text-muted-foreground" aria-hidden="true" />
+                    <span className="text-muted-foreground text-sm">
+                      {messages.attachmentDialog.placeholders.file}
+                    </span>
+                  </>
+                )}
+              </button>
+              <input ref={fileInputRef} type="file" className="hidden" onChange={onFileChange} />
+              {fileError ? <p className="text-xs text-destructive">{fileError}</p> : null}
             </div>
 
             <div className="grid grid-cols-2 gap-4">
+              <div className="flex flex-col gap-2">
+                <Label>{messages.attachmentDialog.fields.name}</Label>
+                <Input
+                  {...form.register("name")}
+                  placeholder={messages.attachmentDialog.placeholders.name}
+                />
+                {form.formState.errors.name && (
+                  <p className="text-xs text-destructive">{form.formState.errors.name.message}</p>
+                )}
+              </div>
+
               <div className="flex flex-col gap-2">
                 <Label>{messages.attachmentDialog.fields.kind}</Label>
-                <Input
-                  {...form.register("kind")}
-                  placeholder={messages.attachmentDialog.placeholders.kind}
-                />
-              </div>
-              <div className="flex flex-col gap-2">
-                <Label>{messages.attachmentDialog.fields.mimeType}</Label>
-                <Input
-                  {...form.register("mimeType")}
-                  placeholder={messages.attachmentDialog.placeholders.mimeType}
-                />
-              </div>
-            </div>
-
-            <div className="grid grid-cols-2 gap-4">
-              <div className="flex flex-col gap-2">
-                <Label>{messages.attachmentDialog.fields.fileSize}</Label>
-                <Input
-                  {...form.register("fileSize")}
-                  type="number"
-                  placeholder={messages.attachmentDialog.placeholders.fileSize}
-                />
-              </div>
-              <div className="flex flex-col gap-2">
-                <Label>{messages.attachmentDialog.fields.checksum}</Label>
-                <Input
-                  {...form.register("checksum")}
-                  placeholder={messages.attachmentDialog.placeholders.checksum}
-                />
+                <Select
+                  items={kindItems}
+                  value={form.watch("kind")}
+                  onValueChange={(value) =>
+                    form.setValue("kind", value ?? undefined, {
+                      shouldDirty: true,
+                      shouldValidate: true,
+                    })
+                  }
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {kindItems.map((item) => (
+                      <SelectItem key={item.value} value={item.value}>
+                        {item.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
             </div>
-
-            <div className="flex flex-col gap-2">
-              <Label>{messages.attachmentDialog.fields.storageKey}</Label>
-              <Input
-                {...form.register("storageKey")}
-                placeholder={messages.attachmentDialog.placeholders.storageKey}
-              />
-            </div>
+            {submitError ? <p className="text-xs text-destructive">{submitError.message}</p> : null}
           </DialogBody>
           <DialogFooter>
             <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
               {messages.common.cancel}
             </Button>
-            <Button type="submit" disabled={form.formState.isSubmitting}>
-              {form.formState.isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               {isEditing ? messages.common.saveChanges : messages.attachmentDialog.actions.create}
             </Button>
           </DialogFooter>
@@ -179,4 +298,10 @@ export function AttachmentDialog({
       </DialogContent>
     </Dialog>
   )
+}
+
+function formatUploadSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }

--- a/packages/legal-ui/src/components/contract-detail-page.tsx
+++ b/packages/legal-ui/src/components/contract-detail-page.tsx
@@ -9,7 +9,7 @@ import {
   useLegalContractMutation,
   useLegalContractSignatures,
 } from "@voyantjs/legal-react"
-import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from "@voyantjs/ui/components"
+import { Badge, Button } from "@voyantjs/ui/components"
 import {
   Table,
   TableBody,
@@ -18,6 +18,7 @@ import {
   TableHeader,
   TableRow,
 } from "@voyantjs/ui/components/table"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@voyantjs/ui/components/tabs"
 import { ArrowLeft, ExternalLink, FileText, Pencil, Plus, Trash2 } from "lucide-react"
 import type { ReactNode } from "react"
 import { useState } from "react"
@@ -44,7 +45,22 @@ export interface ContractDetailPageProps {
   id: string
   onBackToContracts?: () => void
   renderContractDialog?: (props: ContractDetailDialogRenderProps) => ReactNode
+  renderReference?: (props: ContractReferenceRenderProps) => ReactNode
   getAttachmentDownloadHref?: (attachment: LegalContractAttachmentRecord) => string
+}
+
+export type ContractReferenceKind =
+  | "person"
+  | "organization"
+  | "supplier"
+  | "channel"
+  | "booking"
+  | "order"
+
+export interface ContractReferenceRenderProps {
+  kind: ContractReferenceKind
+  id: string
+  contract: LegalContractRecord
 }
 
 export interface ContractDetailDialogRenderProps {
@@ -58,6 +74,7 @@ export function ContractDetailPage({
   id,
   onBackToContracts,
   renderContractDialog,
+  renderReference,
   getAttachmentDownloadHref,
 }: ContractDetailPageProps) {
   const queryClient = useQueryClient()
@@ -107,6 +124,10 @@ export function ContractDetailPage({
 
   const status = contract.status
   const canAddSignature = status === "issued" || status === "sent" || status === "signed"
+  const renderReferenceValue = (kind: ContractReferenceKind, referenceId: string) =>
+    renderReference?.({ kind, id: referenceId, contract }) ?? (
+      <span className="font-mono text-xs">{referenceId}</span>
+    )
 
   return (
     <div className="flex flex-col gap-6 p-6">
@@ -117,22 +138,23 @@ export function ContractDetailPage({
           </Button>
         ) : null}
         <div className="min-w-0 flex-1">
-          <h1 className="text-2xl font-bold tracking-tight">{contract.title}</h1>
-          <div className="mt-1 flex flex-wrap items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="text-2xl font-bold tracking-tight">{f.title}</h1>
+            <Badge variant={statusVariant[status] ?? "secondary"}>
+              {messages.common.contractStatusLabels[status] ?? status}
+            </Badge>
             <Badge variant="outline">
               {messages.common.contractScopeLabels[
                 contract.scope as keyof typeof messages.common.contractScopeLabels
               ] ?? contract.scope}
             </Badge>
-            <Badge variant={statusVariant[status] ?? "secondary"}>
-              {messages.common.contractStatusLabels[status] ?? status}
-            </Badge>
-            {contract.contractNumber ? (
-              <span className="font-mono text-xs text-muted-foreground">
-                {contract.contractNumber}
-              </span>
-            ) : null}
           </div>
+          <p className="mt-1 truncate font-mono text-muted-foreground text-sm">
+            {contract.contractNumber ?? contract.title}
+          </p>
+          {contract.contractNumber ? (
+            <p className="mt-1 truncate text-muted-foreground text-xs">{contract.title}</p>
+          ) : null}
         </div>
         <div className="flex flex-wrap items-center gap-2">
           {status === "draft" ? (
@@ -178,166 +200,191 @@ export function ContractDetailPage({
         </div>
       </div>
 
-      <div className="grid gap-6 md:grid-cols-2">
-        <Card>
-          <CardHeader>
-            <CardTitle>{f.sections.details}</CardTitle>
-          </CardHeader>
-          <CardContent className="grid gap-3 text-sm">
-            <DetailRow label={f.fields.language}>{contract.language}</DetailRow>
-            {contract.templateVersionId ? (
-              <DetailRow label={f.fields.templateVersion}>
-                <span className="font-mono text-xs">{contract.templateVersionId}</span>
-              </DetailRow>
-            ) : null}
-            {contract.seriesId ? (
-              <DetailRow label={f.fields.series}>
-                <span className="font-mono text-xs">{contract.seriesId}</span>
-              </DetailRow>
-            ) : null}
-            {contract.expiresAt ? (
-              <DetailRow label={f.fields.expires}>{i18n.formatDate(contract.expiresAt)}</DetailRow>
-            ) : null}
-            <div className="mt-2 border-t pt-3">
-              <DetailRow label={f.fields.created}>{i18n.formatDate(contract.createdAt)}</DetailRow>
-              <DetailRow label={f.fields.updated}>{i18n.formatDate(contract.updatedAt)}</DetailRow>
+      <Tabs defaultValue="details">
+        <TabsList>
+          <TabsTrigger value="details">{f.sections.details}</TabsTrigger>
+          <TabsTrigger value="parties">{f.sections.parties}</TabsTrigger>
+          <TabsTrigger value="signatures">{f.sections.signatures}</TabsTrigger>
+          <TabsTrigger value="documents">{f.sections.documents}</TabsTrigger>
+        </TabsList>
+        <TabsContent value="details" className="mt-4">
+          <ContractSection title={f.sections.details}>
+            <div className="grid gap-3 text-sm">
+              <DetailRow label={f.fields.language}>{contract.language}</DetailRow>
+              {contract.templateVersionId ? (
+                <DetailRow label={f.fields.templateVersion}>
+                  <span className="font-mono text-xs">{contract.templateVersionId}</span>
+                </DetailRow>
+              ) : null}
+              {contract.seriesId ? (
+                <DetailRow label={f.fields.series}>
+                  <span className="font-mono text-xs">{contract.seriesId}</span>
+                </DetailRow>
+              ) : null}
+              {contract.expiresAt ? (
+                <DetailRow label={f.fields.expires}>
+                  {i18n.formatDate(contract.expiresAt)}
+                </DetailRow>
+              ) : null}
+              <div className="mt-2 border-t pt-3">
+                <DetailRow label={f.fields.created}>
+                  {i18n.formatDate(contract.createdAt)}
+                </DetailRow>
+                <DetailRow label={f.fields.updated}>
+                  {i18n.formatDate(contract.updatedAt)}
+                </DetailRow>
+              </div>
             </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>{f.sections.parties}</CardTitle>
-          </CardHeader>
-          <CardContent className="grid gap-3 text-sm">
-            {contract.personId ? (
-              <DetailRow label={f.fields.person}>
-                <span className="font-mono text-xs">{contract.personId}</span>
-              </DetailRow>
-            ) : null}
-            {contract.organizationId ? (
-              <DetailRow label={f.fields.organization}>
-                <span className="font-mono text-xs">{contract.organizationId}</span>
-              </DetailRow>
-            ) : null}
-            {contract.supplierId ? (
-              <DetailRow label={f.fields.supplier}>
-                <span className="font-mono text-xs">{contract.supplierId}</span>
-              </DetailRow>
-            ) : null}
-            {contract.channelId ? (
-              <DetailRow label={f.fields.channel}>
-                <span className="font-mono text-xs">{contract.channelId}</span>
-              </DetailRow>
-            ) : null}
-            {!contract.personId &&
-            !contract.organizationId &&
-            !contract.supplierId &&
-            !contract.channelId ? (
-              <p className="text-muted-foreground">{f.empty.noParties}</p>
-            ) : null}
-          </CardContent>
-        </Card>
-      </div>
-
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
-          <CardTitle>{f.sections.signatures}</CardTitle>
-          {canAddSignature ? (
-            <Button size="sm" onClick={() => setSignOpen(true)}>
-              <Plus className="mr-2 size-4" aria-hidden="true" />
-              {f.actions.addSignature}
-            </Button>
-          ) : null}
-        </CardHeader>
-        <CardContent>
-          {!signatures || signatures.length === 0 ? (
-            <p className="py-4 text-center text-sm text-muted-foreground">{f.empty.noSignatures}</p>
-          ) : (
-            <div className="rounded border bg-background">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>{f.fields.name}</TableHead>
-                    <TableHead>{f.fields.email}</TableHead>
-                    <TableHead>{f.fields.role}</TableHead>
-                    <TableHead>{f.fields.method}</TableHead>
-                    <TableHead>{f.fields.signedAt}</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {signatures.map((signature) => (
-                    <TableRow key={signature.id}>
-                      <TableCell>{signature.signerName}</TableCell>
-                      <TableCell>
-                        {signature.signerEmail ?? messages.common.noResultsDash}
-                      </TableCell>
-                      <TableCell>{signature.signerRole ?? messages.common.noResultsDash}</TableCell>
-                      <TableCell>{signature.method}</TableCell>
-                      <TableCell>{i18n.formatDateTime(signature.signedAt)}</TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+          </ContractSection>
+        </TabsContent>
+        <TabsContent value="parties" className="mt-4">
+          <ContractSection title={f.sections.parties}>
+            <div className="grid gap-3 text-sm">
+              {contract.personId ? (
+                <DetailRow label={f.fields.person}>
+                  {renderReferenceValue("person", contract.personId)}
+                </DetailRow>
+              ) : null}
+              {contract.organizationId ? (
+                <DetailRow label={f.fields.organization}>
+                  {renderReferenceValue("organization", contract.organizationId)}
+                </DetailRow>
+              ) : null}
+              {contract.supplierId ? (
+                <DetailRow label={f.fields.supplier}>
+                  {renderReferenceValue("supplier", contract.supplierId)}
+                </DetailRow>
+              ) : null}
+              {contract.channelId ? (
+                <DetailRow label={f.fields.channel}>
+                  {renderReferenceValue("channel", contract.channelId)}
+                </DetailRow>
+              ) : null}
+              {contract.bookingId ? (
+                <DetailRow label={f.fields.booking}>
+                  {renderReferenceValue("booking", contract.bookingId)}
+                </DetailRow>
+              ) : null}
+              {contract.orderId ? (
+                <DetailRow label={f.fields.order}>
+                  {renderReferenceValue("order", contract.orderId)}
+                </DetailRow>
+              ) : null}
+              {!contract.personId &&
+              !contract.organizationId &&
+              !contract.supplierId &&
+              !contract.channelId &&
+              !contract.bookingId &&
+              !contract.orderId ? (
+                <p className="text-muted-foreground">{f.empty.noParties}</p>
+              ) : null}
             </div>
-          )}
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
-          <CardTitle>{f.sections.attachments}</CardTitle>
-          <Button
-            size="sm"
-            onClick={() => {
-              setEditingAttachment(undefined)
-              setAttachOpen(true)
-            }}
+          </ContractSection>
+        </TabsContent>
+        <TabsContent value="signatures" className="mt-4">
+          <ContractSection
+            title={f.sections.signatures}
+            action={
+              canAddSignature ? (
+                <Button size="sm" onClick={() => setSignOpen(true)}>
+                  <Plus className="mr-2 size-4" aria-hidden="true" />
+                  {f.actions.addSignature}
+                </Button>
+              ) : null
+            }
           >
-            <Plus className="mr-2 size-4" aria-hidden="true" />
-            {f.actions.addAttachment}
-          </Button>
-        </CardHeader>
-        <CardContent>
-          {!attachments || attachments.length === 0 ? (
-            <p className="py-4 text-center text-sm text-muted-foreground">
-              {f.empty.noAttachments}
-            </p>
-          ) : (
-            <div className="rounded border bg-background">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>{f.fields.name}</TableHead>
-                    <TableHead>{f.fields.kind}</TableHead>
-                    <TableHead>{f.fields.mimeType}</TableHead>
-                    <TableHead>{f.fields.size}</TableHead>
-                    <TableHead className="w-16" />
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {attachments.map((attachment) => (
-                    <AttachmentRow
-                      key={attachment.id}
-                      attachment={attachment}
-                      downloadHref={getAttachmentDownloadHref?.(attachment)}
-                      onEdit={() => {
-                        setEditingAttachment(attachment)
-                        setAttachOpen(true)
-                      }}
-                      onDelete={() => {
-                        if (confirm(f.deleteAttachmentConfirm)) {
-                          removeAttachment.mutate({ contractId: id, id: attachment.id })
-                        }
-                      }}
-                    />
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+            {!signatures || signatures.length === 0 ? (
+              <p className="py-4 text-center text-sm text-muted-foreground">
+                {f.empty.noSignatures}
+              </p>
+            ) : (
+              <div className="rounded border bg-background">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>{f.fields.name}</TableHead>
+                      <TableHead>{f.fields.email}</TableHead>
+                      <TableHead>{f.fields.role}</TableHead>
+                      <TableHead>{f.fields.method}</TableHead>
+                      <TableHead>{f.fields.signedAt}</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {signatures.map((signature) => (
+                      <TableRow key={signature.id}>
+                        <TableCell>{signature.signerName}</TableCell>
+                        <TableCell>
+                          {signature.signerEmail ?? messages.common.noResultsDash}
+                        </TableCell>
+                        <TableCell>
+                          {signature.signerRole ?? messages.common.noResultsDash}
+                        </TableCell>
+                        <TableCell>{signature.method}</TableCell>
+                        <TableCell>{i18n.formatDateTime(signature.signedAt)}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </ContractSection>
+        </TabsContent>
+        <TabsContent value="documents" className="mt-4">
+          <ContractSection
+            title={f.sections.documents}
+            action={
+              <Button
+                size="sm"
+                onClick={() => {
+                  setEditingAttachment(undefined)
+                  setAttachOpen(true)
+                }}
+              >
+                <Plus className="mr-2 size-4" aria-hidden="true" />
+                {f.actions.addDocument}
+              </Button>
+            }
+          >
+            {!attachments || attachments.length === 0 ? (
+              <p className="py-4 text-center text-sm text-muted-foreground">
+                {f.empty.noAttachments}
+              </p>
+            ) : (
+              <div className="rounded border bg-background">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>{f.fields.name}</TableHead>
+                      <TableHead>{f.fields.kind}</TableHead>
+                      <TableHead>{f.fields.mimeType}</TableHead>
+                      <TableHead>{f.fields.size}</TableHead>
+                      <TableHead className="w-16" />
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {attachments.map((attachment) => (
+                      <AttachmentRow
+                        key={attachment.id}
+                        attachment={attachment}
+                        downloadHref={getAttachmentDownloadHref?.(attachment)}
+                        onEdit={() => {
+                          setEditingAttachment(attachment)
+                          setAttachOpen(true)
+                        }}
+                        onDelete={() => {
+                          if (confirm(f.deleteAttachmentConfirm)) {
+                            removeAttachment.mutate({ contractId: id, id: attachment.id })
+                          }
+                        }}
+                      />
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </ContractSection>
+        </TabsContent>
+      </Tabs>
 
       {renderContractDialog?.({
         open: editOpen,
@@ -380,6 +427,26 @@ function DetailRow({ label, children }: { label: string; children: ReactNode }) 
     <div>
       <span className="text-muted-foreground">{label}:</span> <span>{children}</span>
     </div>
+  )
+}
+
+function ContractSection({
+  title,
+  action,
+  children,
+}: {
+  title: string
+  action?: ReactNode
+  children: ReactNode
+}) {
+  return (
+    <section className="rounded-md border bg-background">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b px-4 py-3">
+        <h2 className="font-semibold text-sm">{title}</h2>
+        {action}
+      </div>
+      <div className="p-4">{children}</div>
+    </section>
   )
 }
 

--- a/packages/legal-ui/src/i18n.test.tsx
+++ b/packages/legal-ui/src/i18n.test.tsx
@@ -39,7 +39,7 @@ describe("legal-ui i18n", () => {
 
     expect(html).toContain("Contract")
     expect(html).toContain("Download")
-    expect(html).toContain("Edit Attachment")
+    expect(html).toContain("Edit Document")
     expect(html).toContain("Manual")
   })
 
@@ -52,7 +52,7 @@ describe("legal-ui i18n", () => {
 
     expect(html).toContain("Contract")
     expect(html).toContain("Descarca")
-    expect(html).toContain("Editeaza atasamentul")
+    expect(html).toContain("Editeaza documentul")
     expect(html).toContain("Manual")
   })
 })

--- a/packages/legal-ui/src/i18n/en.ts
+++ b/packages/legal-ui/src/i18n/en.ts
@@ -115,22 +115,25 @@ export const legalUiEn = {
     },
   },
   contractDetailPage: {
+    title: "Contract",
     notFound: "Contract not found",
     backToContracts: "Back to Contracts",
     voidConfirm: "Void this contract?",
     deleteConfirm: 'Delete contract "{title}"?',
-    deleteAttachmentConfirm: "Delete this attachment?",
+    deleteAttachmentConfirm: "Delete this document?",
     actions: {
       issue: "Issue",
       void: "Void",
       addSignature: "Add Signature",
       addAttachment: "Add Attachment",
+      addDocument: "Add Document",
     },
     sections: {
       details: "Contract Details",
       parties: "Parties",
       signatures: "Signatures",
       attachments: "Attachments",
+      documents: "Documents",
     },
     fields: {
       language: "Language",
@@ -143,6 +146,8 @@ export const legalUiEn = {
       organization: "Organization",
       supplier: "Supplier",
       channel: "Channel",
+      booking: "Booking",
+      order: "Order",
       name: "Name",
       email: "Email",
       role: "Role",
@@ -155,7 +160,7 @@ export const legalUiEn = {
     empty: {
       noParties: "No parties assigned.",
       noSignatures: "No signatures yet.",
-      noAttachments: "No attachments yet.",
+      noAttachments: "No documents yet.",
     },
     units: {
       bytes: "B",
@@ -298,19 +303,26 @@ export const legalUiEn = {
   },
   attachmentDialog: {
     titles: {
-      create: "Add Attachment",
-      edit: "Edit Attachment",
+      create: "Add Document",
+      edit: "Edit Document",
     },
     fields: {
+      file: "File",
       name: "Name",
       kind: "Kind",
       mimeType: "MIME Type",
       fileSize: "File Size",
       checksum: "Checksum",
-      storageKey: "Storage Key",
+      storageKey: "Storage Reference",
+    },
+    kindLabels: {
+      document: "Signed document",
+      appendix: "Appendix",
+      scan: "Supporting scan",
     },
     placeholders: {
-      name: "Attachment name",
+      file: "Choose or drop a file",
+      name: "Document name",
       kind: "appendix",
       mimeType: "application/pdf",
       fileSize: "Bytes",
@@ -318,10 +330,11 @@ export const legalUiEn = {
       storageKey: "Optional storage reference",
     },
     actions: {
-      create: "Add Attachment",
+      create: "Add Document",
     },
     validation: {
       nameRequired: "Name is required",
+      fileRequired: "Select a file to upload.",
     },
   },
   policyRuleDialog: {

--- a/packages/legal-ui/src/i18n/messages.ts
+++ b/packages/legal-ui/src/i18n/messages.ts
@@ -127,6 +127,7 @@ export type LegalUiMessages = {
     }
   }
   contractDetailPage: {
+    title: string
     notFound: string
     backToContracts: string
     voidConfirm: string
@@ -137,12 +138,14 @@ export type LegalUiMessages = {
       void: string
       addSignature: string
       addAttachment: string
+      addDocument: string
     }
     sections: {
       details: string
       parties: string
       signatures: string
       attachments: string
+      documents: string
     }
     fields: {
       language: string
@@ -155,6 +158,8 @@ export type LegalUiMessages = {
       organization: string
       supplier: string
       channel: string
+      booking: string
+      order: string
       name: string
       email: string
       role: string
@@ -305,6 +310,7 @@ export type LegalUiMessages = {
       edit: string
     }
     fields: {
+      file: string
       name: string
       kind: string
       mimeType: string
@@ -312,7 +318,13 @@ export type LegalUiMessages = {
       checksum: string
       storageKey: string
     }
+    kindLabels: {
+      document: string
+      appendix: string
+      scan: string
+    }
     placeholders: {
+      file: string
       name: string
       kind: string
       mimeType: string
@@ -325,6 +337,7 @@ export type LegalUiMessages = {
     }
     validation: {
       nameRequired: string
+      fileRequired: string
     }
   }
   policyRuleDialog: {

--- a/packages/legal-ui/src/i18n/ro.ts
+++ b/packages/legal-ui/src/i18n/ro.ts
@@ -115,22 +115,25 @@ export const legalUiRo = {
     },
   },
   contractDetailPage: {
+    title: "Contract",
     notFound: "Contractul nu a fost gasit",
     backToContracts: "Inapoi la contracte",
     voidConfirm: "Anulezi acest contract?",
     deleteConfirm: 'Stergi contractul "{title}"?',
-    deleteAttachmentConfirm: "Stergi acest atasament?",
+    deleteAttachmentConfirm: "Stergi acest document?",
     actions: {
       issue: "Emite",
       void: "Anuleaza",
       addSignature: "Adauga semnatura",
       addAttachment: "Adauga atasament",
+      addDocument: "Adauga document",
     },
     sections: {
       details: "Detalii contract",
       parties: "Parti",
       signatures: "Semnaturi",
       attachments: "Atasamente",
+      documents: "Documente",
     },
     fields: {
       language: "Limba",
@@ -143,6 +146,8 @@ export const legalUiRo = {
       organization: "Organizatie",
       supplier: "Furnizor",
       channel: "Canal",
+      booking: "Rezervare",
+      order: "Comanda",
       name: "Nume",
       email: "Email",
       role: "Rol",
@@ -155,7 +160,7 @@ export const legalUiRo = {
     empty: {
       noParties: "Nu exista parti asociate.",
       noSignatures: "Nu exista inca semnaturi.",
-      noAttachments: "Nu exista inca atasamente.",
+      noAttachments: "Nu exista inca documente.",
     },
     units: {
       bytes: "B",
@@ -298,19 +303,26 @@ export const legalUiRo = {
   },
   attachmentDialog: {
     titles: {
-      create: "Adauga atasament",
-      edit: "Editeaza atasamentul",
+      create: "Adauga document",
+      edit: "Editeaza documentul",
     },
     fields: {
+      file: "Fisier",
       name: "Nume",
       kind: "Tip",
       mimeType: "Tip MIME",
       fileSize: "Dimensiune fisier",
       checksum: "Checksum",
-      storageKey: "Cheie stocare",
+      storageKey: "Referinta stocare",
+    },
+    kindLabels: {
+      document: "Document semnat",
+      appendix: "Anexa",
+      scan: "Scan suport",
     },
     placeholders: {
-      name: "Numele atasamentului",
+      file: "Alege sau plaseaza un fisier",
+      name: "Numele documentului",
       kind: "appendix",
       mimeType: "application/pdf",
       fileSize: "Octeti",
@@ -318,10 +330,11 @@ export const legalUiRo = {
       storageKey: "Referinta optionala de stocare",
     },
     actions: {
-      create: "Adauga atasament",
+      create: "Adauga document",
     },
     validation: {
       nameRequired: "Numele este obligatoriu",
+      fileRequired: "Selecteaza un fisier pentru incarcare.",
     },
   },
   policyRuleDialog: {

--- a/packages/legal-ui/src/index.ts
+++ b/packages/legal-ui/src/index.ts
@@ -8,6 +8,8 @@ export {
   type ContractDetailDialogRenderProps,
   ContractDetailPage,
   type ContractDetailPageProps,
+  type ContractReferenceKind,
+  type ContractReferenceRenderProps,
 } from "./components/contract-detail-page.js"
 export {
   type ContractDialogRenderProps,

--- a/packages/legal/src/contracts/route-runtime.ts
+++ b/packages/legal/src/contracts/route-runtime.ts
@@ -1,9 +1,11 @@
 import type { EventBus } from "@voyantjs/core"
+import type { StorageProvider } from "@voyantjs/storage"
 
 import type { ContractDocumentGenerator, ContractsRouteOptions } from "./routes.js"
 
 export type ContractsRouteRuntime = {
   documentGenerator?: ContractDocumentGenerator
+  documentStorage?: StorageProvider | null
   eventBus?: EventBus
 }
 
@@ -15,6 +17,7 @@ export function buildContractsRouteRuntime(
 ): ContractsRouteRuntime {
   return {
     documentGenerator: options.resolveDocumentGenerator?.(bindings) ?? options.documentGenerator,
+    documentStorage: options.resolveDocumentStorage?.(bindings) ?? options.documentStorage,
     eventBus: options.resolveEventBus?.(bindings) ?? options.eventBus,
   }
 }

--- a/packages/legal/src/contracts/routes.ts
+++ b/packages/legal/src/contracts/routes.ts
@@ -1,6 +1,8 @@
 import type { EventBus, ModuleContainer } from "@voyantjs/core"
 import { parseJsonBody, parseOptionalJsonBody, parseQuery } from "@voyantjs/hono"
+import type { StorageProvider } from "@voyantjs/storage"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import type { Context } from "hono"
 import { Hono } from "hono"
 
 import {
@@ -50,6 +52,8 @@ export interface ContractsRouteOptions {
     bindings: Record<string, unknown>,
     storageKey: string,
   ) => Promise<string | null> | string | null
+  documentStorage?: StorageProvider | null
+  resolveDocumentStorage?: (bindings: Record<string, unknown>) => StorageProvider | null | undefined
   eventBus?: EventBus
   resolveEventBus?: (bindings: Record<string, unknown>) => EventBus | undefined
 }
@@ -84,6 +88,86 @@ function getFallbackDownloadUrl(metadata: unknown) {
   }
 
   return maybeUrl(record.url)
+}
+
+function getMultipartString(value: unknown) {
+  const resolved = Array.isArray(value) ? value[0] : value
+  return typeof resolved === "string" ? resolved : null
+}
+
+function sanitizeStorageFileName(name: string) {
+  const normalized = name
+    .normalize("NFKD")
+    .replace(/[^\w.-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 160)
+  return normalized || "document"
+}
+
+function toHex(buffer: ArrayBuffer) {
+  return Array.from(new Uint8Array(buffer))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+}
+
+async function sha256Checksum(buffer: ArrayBuffer) {
+  const digest = await crypto.subtle.digest("SHA-256", buffer.slice(0))
+  return `sha256:${toHex(digest)}`
+}
+
+async function buildUploadedAttachmentInput({
+  storage,
+  contractId,
+  form,
+  file,
+}: {
+  storage: StorageProvider
+  contractId: string
+  form: Record<string, unknown>
+  file: File
+}) {
+  const originalName = file.name || "document"
+  const name = getMultipartString(form.name)?.trim() || originalName
+  const kind = getMultipartString(form.kind)?.trim() || "document"
+  const mimeType = file.type || "application/octet-stream"
+  const body = await file.arrayBuffer()
+  const checksum = await sha256Checksum(body)
+  const storageName = sanitizeStorageFileName(originalName)
+  const key = `contracts/${contractId}/attachments/${crypto.randomUUID()}-${storageName}`
+  const uploaded = await storage.upload(body, {
+    key,
+    contentType: mimeType,
+    metadata: {
+      checksum,
+      contractId,
+      kind,
+      name,
+      originalName,
+    },
+  })
+
+  return {
+    kind,
+    name,
+    mimeType,
+    fileSize: file.size,
+    storageKey: uploaded.key,
+    checksum,
+    metadata: {
+      originalName,
+      uploadedAt: new Date().toISOString(),
+      ...(uploaded.url ? { url: uploaded.url } : {}),
+    },
+  }
+}
+
+async function parseAttachmentUploadRequest(c: Context<Env>) {
+  const form = (await c.req.parseBody()) as Record<string, unknown>
+  const file = Array.isArray(form.file) ? form.file[0] : form.file
+  if (!(file instanceof File)) {
+    return { error: c.json({ error: "Missing file field in multipart body" }, 400) }
+  }
+  return { form, file }
 }
 
 export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) {
@@ -338,6 +422,29 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
       if (!row) return c.json({ error: "Contract not found" }, 404)
       return c.json({ data: row }, 201)
     })
+    .post("/:id/attachments/upload", async (c) => {
+      const runtime = getRuntime(options, c.env, (key) => c.var.container?.resolve(key))
+      const storage = runtime.documentStorage
+      if (!storage) {
+        return c.json({ error: "Contract document storage is not configured" }, 501)
+      }
+
+      const parsed = await parseAttachmentUploadRequest(c)
+      if ("error" in parsed) return parsed.error
+
+      const row = await contractsService.createAttachment(
+        c.get("db"),
+        c.req.param("id"),
+        await buildUploadedAttachmentInput({
+          storage,
+          contractId: c.req.param("id"),
+          form: parsed.form,
+          file: parsed.file,
+        }),
+      )
+      if (!row) return c.json({ error: "Contract not found" }, 404)
+      return c.json({ data: row }, 201)
+    })
     .patch("/attachments/:attachmentId", async (c) => {
       const row = await contractsService.updateAttachment(
         c.get("db"),
@@ -345,6 +452,46 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
         await parseJsonBody(c, updateContractAttachmentSchema),
       )
       if (!row) return c.json({ error: "Attachment not found" }, 404)
+      return c.json({ data: row })
+    })
+    .patch("/attachments/:attachmentId/upload", async (c) => {
+      const runtime = getRuntime(options, c.env, (key) => c.var.container?.resolve(key))
+      const storage = runtime.documentStorage
+      if (!storage) {
+        return c.json({ error: "Contract document storage is not configured" }, 501)
+      }
+
+      const existing = await contractsService.getAttachmentById(
+        c.get("db"),
+        c.req.param("attachmentId"),
+      )
+      if (!existing) return c.json({ error: "Attachment not found" }, 404)
+
+      const parsed = await parseAttachmentUploadRequest(c)
+      if ("error" in parsed) return parsed.error
+
+      const row = await contractsService.updateAttachment(
+        c.get("db"),
+        c.req.param("attachmentId"),
+        await buildUploadedAttachmentInput({
+          storage,
+          contractId: existing.contractId,
+          form: parsed.form,
+          file: parsed.file,
+        }),
+      )
+      if (!row) return c.json({ error: "Attachment not found" }, 404)
+      if (existing.storageKey && existing.storageKey !== row.storageKey) {
+        try {
+          await storage.delete(existing.storageKey)
+        } catch (error) {
+          console.warn(
+            `[legal] failed to delete replaced contract attachment object ${existing.storageKey}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          )
+        }
+      }
       return c.json({ data: row })
     })
     .get("/attachments/:attachmentId/download", async (c) => {

--- a/templates/dmc/src/api/app.ts
+++ b/templates/dmc/src/api/app.ts
@@ -34,7 +34,12 @@ import { catalogBridgeBundle } from "./catalog-bridge"
 import { mountCatalogContentRoutes } from "./catalog-content"
 import { createInvitationsRoutes } from "./invitations"
 import { dbFromEnvForApp } from "./lib/db"
-import { createMediaStorage, guessMimeType, resolveDocumentDownloadUrl } from "./lib/storage"
+import {
+  createDocumentStorage,
+  createMediaStorage,
+  guessMimeType,
+  resolveDocumentDownloadUrl,
+} from "./lib/storage"
 import { mountCatalogMcpRoutes, mountCatalogSearchRoutes } from "./mcp"
 
 const notificationsHonoModule = createNotificationsHonoModule({
@@ -79,6 +84,8 @@ const financeModule = createFinanceHonoModule({
 const legalModule = createLegalHonoModule({
   resolveDocumentDownloadUrl: (bindings: unknown, storageKey: string) =>
     resolveDocumentDownloadUrl(bindings as unknown as CloudflareBindings, storageKey),
+  resolveDocumentStorage: (bindings) =>
+    createDocumentStorage(bindings as unknown as CloudflareBindings),
 })
 
 const crmHonoModule = createCrmHonoModule()

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -575,6 +575,8 @@ const legalModule = createLegalHonoModule({
   resolveDb: (bindings) => getDbFromEnv(bindings as unknown as CloudflareBindings),
   resolveDocumentDownloadUrl: (bindings, storageKey) =>
     resolveDocumentDownloadUrl(bindings as unknown as CloudflareBindings, storageKey),
+  resolveDocumentStorage: (bindings) =>
+    createDocumentStorage(bindings as unknown as CloudflareBindings),
   resolveDocumentGenerator: (bindings) =>
     resolveContractDocumentGenerator(bindings as unknown as CloudflareBindings) ?? undefined,
   autoGenerateContractOnConfirmed: AUTO_GENERATE_CONTRACT_OPTIONS,


### PR DESCRIPTION
## Summary
- Reworks `ContractDetailPage` into default tabs for details, parties, signatures, and documents while removing the stacked Card chrome.
- Updates the contract header to show `Contract` with status/scope badges and the contract number as the mono subtitle.
- Renames attachment-facing contract UI to Documents and simplifies `AttachmentDialog` into a true drag/drop or click-to-select upload flow.
- Adds legal API multipart upload/replace endpoints backed by configured private document storage, including `storageKey`, MIME type, size, and SHA-256 checksum persistence.
- Adds legal-react upload/replace attachment mutations and a reference-label render hook for host-side party/booking/order labels.
- Adds EN/RO messages, exports the new helper types, updates i18n tests, and adds a changeset.

Closes #658.

## Verification
- `pnpm --filter @voyantjs/legal typecheck`
- `pnpm --filter @voyantjs/legal-react typecheck`
- `pnpm --filter @voyantjs/legal-ui typecheck`
- `pnpm --filter @voyantjs/legal lint`
- `pnpm --filter @voyantjs/legal-react lint`
- `pnpm --filter @voyantjs/legal-ui lint`
- `pnpm --filter @voyantjs/legal test`
- `pnpm --filter @voyantjs/legal-react test`
- `pnpm --filter @voyantjs/legal-ui test`
- `pnpm --filter @voyantjs/legal build`
- `pnpm --filter @voyantjs/legal-react build`
- `pnpm --filter @voyantjs/legal-ui build`
- `pnpm lint:changed`
- `git diff --check`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter dmc typecheck`
- `pnpm --filter operator typecheck`

## Notes
- Plain `pnpm --filter dmc typecheck` hit Node's default heap limit locally. It passed with `NODE_OPTIONS=--max-old-space-size=8192`.
- The local pre-commit broad typecheck hook previously failed outside this change: `@voyantjs/storefront-sdk` and `@voyantjs/allocation-ui` had missing dependency/config errors, while `operator` and `dev` were killed with exit 137.
- The local pre-push broad test hook previously failed outside this change in `@voyantjs/workflows-cloud-adapter` and `@voyantjs/storefront-sdk`. The scoped checks above passed.