### PR TITLE
feat(agent-runner): submit tick snapshots

### DIFF
--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -42,3 +42,20 @@ planned lifecycle command on a supervisor-specific JSONL ledger. Pass
 snapshot with counts for total recommendations, dispatchable recommendations,
 and recent events. The current contract is intentionally non-persistent; use it
 to prove worker-to-supervisor shape before adding storage or automatic loops.
+
+Submit the current queue snapshot from the repo runner with:
+
+```bash
+AGENT_CONTROL_PLANE_URL=https://agent-control-plane.example.workers.dev \
+AGENT_CONTROL_PLANE_TOKEN=... \
+pnpm agent:queue:submit-tick
+```
+
+The same command can submit a saved tick JSON file:
+
+```bash
+pnpm agent:queue:tick -- --json > .agent-runs/tick.json
+AGENT_CONTROL_PLANE_URL=https://agent-control-plane.example.workers.dev \
+AGENT_CONTROL_PLANE_TOKEN=... \
+pnpm agent:queue:submit-tick -- --input .agent-runs/tick.json
+```

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -388,6 +388,10 @@ maintainer merges and mark the item done.
 The Cloudflare-ready control-plane app can accept this JSON at
 `POST /api/tick-snapshots` for validation and summary counts, but that endpoint
 is non-persistent and does not dispatch work.
+Use `pnpm agent:queue:submit-tick` with `AGENT_CONTROL_PLANE_URL` and
+`AGENT_CONTROL_PLANE_TOKEN` to submit a fresh snapshot. For replayable
+supervisor tests, write `pnpm agent:queue:tick -- --json` to a file and submit
+it with `pnpm agent:queue:submit-tick -- --input <path>`.
 `CI Repair` items with failing linked PRs recommend `collect-ci` until a local
 CI repair packet exists. Ready items with `sandbox:<provider>:<id>` workspaces
 recommend `remote-bootstrap` so dispatch can clone/fetch the repository and

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1315,6 +1315,10 @@ Verification:
   `VOYANT_AGENT_R2_PUBLIC_BASE_URL`. The public base URL should be a durable
   custom domain or authenticated artifact proxy URL prefix, not a temporary
   signed URL.
+- The runner can submit fresh or saved tick snapshots to the control-plane
+  app with `pnpm agent:queue:submit-tick`, using `AGENT_CONTROL_PLANE_URL` and
+  `AGENT_CONTROL_PLANE_TOKEN`. This keeps the Cloudflare endpoint exercised
+  without adding storage or automatic dispatch yet.
 
 ## Open Questions
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "agent:queue:events": "node scripts/agent-runner-events.mjs",
     "agent:queue:status": "node scripts/agent-runner-status.mjs",
     "agent:queue:tick": "node scripts/agent-runner-tick.mjs",
+    "agent:queue:submit-tick": "node scripts/agent-runner-submit-tick.mjs",
     "agent:queue:dispatch": "node scripts/agent-runner-dispatch.mjs",
     "agent:queue:loop": "node scripts/agent-runner-loop.mjs",
     "agent:queue:remote-inspect": "node scripts/agent-runner-remote-inspect.mjs",

--- a/scripts/agent-runner-submit-tick.mjs
+++ b/scripts/agent-runner-submit-tick.mjs
@@ -1,0 +1,133 @@
+import fs from "node:fs"
+
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  filterItemsByRepository,
+  loadAllEvaluatedProject,
+  parseArgs,
+  projectScanConfigFromArgs,
+  runGit,
+} from "./lib/agent-project-queue.mjs"
+import {
+  controlPlaneConfigFromArgs,
+  submitTickSnapshot,
+} from "./lib/agent-runner-control-plane.mjs"
+import { readAgentRunnerEvents, resolveEventLogPath } from "./lib/agent-runner-events.mjs"
+import {
+  eventLogOptions,
+  maybePrintHelp,
+  projectOptions,
+  repositoryOptions,
+} from "./lib/agent-runner-help.mjs"
+import { recommendQueueActions } from "./lib/agent-runner-tick.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:submit-tick",
+  summary: "Submit a queue tick snapshot to the agent control plane without dispatching work.",
+  usage: "pnpm agent:queue:submit-tick -- [--input <path|->] [--control-plane-url <url>]",
+  options: [
+    ["--input <path|->", "Submit an existing tick JSON file, or read JSON from stdin with '-'."],
+    ["--control-plane-url <url>", "Control-plane base URL. Defaults to AGENT_CONTROL_PLANE_URL."],
+    ["AGENT_CONTROL_PLANE_TOKEN", "Bearer token environment variable used for API routes."],
+    [
+      "--max-age-days <number>",
+      "Heartbeat staleness threshold when generating a snapshot. Defaults to 1.",
+    ],
+    ["--recent-events <number>", "Number of recent runner events to include. Defaults to 5."],
+    ...eventLogOptions,
+    ...repositoryOptions,
+    ...projectOptions,
+  ],
+})
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const snapshot = args.input ? readSnapshotInput(args.input) : generateSnapshot()
+const config = readControlPlaneConfig()
+
+try {
+  const result = await submitTickSnapshot({
+    snapshot,
+    token: config.token,
+    url: config.url,
+  })
+
+  console.log("agent-runner submitted tick snapshot")
+  console.log(`control plane: ${config.url}`)
+  console.log(`repository: ${result.snapshot?.repository ?? snapshot.repository}`)
+  console.log(`recommendations: ${result.summary?.recommendationCount ?? "unknown"}`)
+  console.log(`dispatchable: ${result.summary?.dispatchableRecommendationCount ?? "unknown"}`)
+  if (result.summary?.firstDispatchableIssueNumber) {
+    console.log(
+      `first dispatchable: #${result.summary.firstDispatchableIssueNumber} ${result.summary.firstDispatchableAction}`,
+    )
+  }
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error))
+}
+
+function generateSnapshot() {
+  const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+  const maxAgeDays = Number(args.maxAgeDays ?? 1)
+  const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
+  const recentEventLimit = numberArg(args.recentEvents, "recent-events", 5, { min: 0 })
+
+  if (!Number.isInteger(maxAgeDays) || maxAgeDays < 0) {
+    fail(`invalid max age days: ${String(args.maxAgeDays)}`)
+  }
+
+  const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
+  const items = filterItemsByRepository(project.items, repository)
+
+  return {
+    project: {
+      owner: project.owner,
+      number: project.projectNumber,
+      title: project.projectTitle,
+      url: project.projectUrl,
+    },
+    repository,
+    maxAgeDays,
+    eventLog: {
+      path: eventLogPath,
+      recentEvents: readRecentEvents(eventLogPath, recentEventLimit),
+    },
+    recommendations: recommendQueueActions(items, { maxAgeDays, repository }),
+  }
+}
+
+function readSnapshotInput(input) {
+  const text = input === "-" ? fs.readFileSync(0, "utf8") : fs.readFileSync(input, "utf8")
+  try {
+    return JSON.parse(text)
+  } catch (error) {
+    fail(`invalid tick snapshot JSON: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+function readControlPlaneConfig() {
+  try {
+    return controlPlaneConfigFromArgs(args)
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error))
+  }
+}
+
+function readRecentEvents(eventLogPath, limit) {
+  try {
+    return readAgentRunnerEvents(eventLogPath, { limit })
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error))
+  }
+}
+
+function numberArg(value, name, fallback, { min = 1 } = {}) {
+  if (value === undefined) return fallback
+
+  const number = Number(value)
+  if (!Number.isInteger(number) || number < min) {
+    fail(`invalid ${name}: ${value}`)
+  }
+  return number
+}

--- a/scripts/lib/agent-runner-control-plane.mjs
+++ b/scripts/lib/agent-runner-control-plane.mjs
@@ -1,0 +1,54 @@
+export function controlPlaneConfigFromArgs(args, env = process.env) {
+  const url = args.controlPlaneUrl ?? env.AGENT_CONTROL_PLANE_URL
+  const token = env.AGENT_CONTROL_PLANE_TOKEN
+
+  if (!url) {
+    throw new Error(
+      "missing control plane URL; set AGENT_CONTROL_PLANE_URL or pass --control-plane-url",
+    )
+  }
+
+  if (!token) {
+    throw new Error("missing control plane token; set AGENT_CONTROL_PLANE_TOKEN")
+  }
+
+  return {
+    token,
+    url: normalizeControlPlaneUrl(url),
+  }
+}
+
+export async function submitTickSnapshot({ fetchImpl = fetch, snapshot, token, url }) {
+  const response = await fetchImpl(`${normalizeControlPlaneUrl(url)}/api/tick-snapshots`, {
+    body: JSON.stringify(snapshot),
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    method: "POST",
+  })
+
+  const bodyText = await response.text()
+  const body = parseJsonBody(bodyText)
+
+  if (!response.ok) {
+    const detail = body?.error ? `: ${body.error}` : bodyText ? `: ${bodyText}` : ""
+    throw new Error(`control plane rejected tick snapshot with ${response.status}${detail}`)
+  }
+
+  return body
+}
+
+function normalizeControlPlaneUrl(url) {
+  return String(url).replace(/\/+$/, "")
+}
+
+function parseJsonBody(bodyText) {
+  if (!bodyText) return null
+
+  try {
+    return JSON.parse(bodyText)
+  } catch {
+    return null
+  }
+}

--- a/scripts/tests/agent-runner-control-plane.test.mjs
+++ b/scripts/tests/agent-runner-control-plane.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import {
+  controlPlaneConfigFromArgs,
+  submitTickSnapshot,
+} from "../lib/agent-runner-control-plane.mjs"
+
+describe("agent runner control plane client", () => {
+  it("reads URL and token from CLI/env without logging tokens", () => {
+    assert.deepEqual(
+      controlPlaneConfigFromArgs(
+        { controlPlaneUrl: "https://control.example.com/" },
+        { AGENT_CONTROL_PLANE_TOKEN: "tok" },
+      ),
+      {
+        token: "tok",
+        url: "https://control.example.com",
+      },
+    )
+  })
+
+  it("requires a control plane URL and env token", () => {
+    assert.throws(
+      () => controlPlaneConfigFromArgs({}, { AGENT_CONTROL_PLANE_TOKEN: "tok" }),
+      /missing control plane URL/,
+    )
+    assert.throws(
+      () => controlPlaneConfigFromArgs({ controlPlaneUrl: "https://control.example.com" }, {}),
+      /missing control plane token/,
+    )
+  })
+
+  it("posts tick snapshots to the non-mutating snapshot endpoint", async () => {
+    const calls = []
+    const response = await submitTickSnapshot({
+      fetchImpl: async (url, init) => {
+        calls.push({ init, url })
+        return new Response(
+          JSON.stringify({
+            accepted: true,
+            summary: {
+              dispatchableRecommendationCount: 1,
+              recommendationCount: 1,
+            },
+          }),
+          { status: 200 },
+        )
+      },
+      snapshot: { recommendations: [] },
+      token: "tok",
+      url: "https://control.example.com/",
+    })
+
+    assert.deepEqual(response.summary, {
+      dispatchableRecommendationCount: 1,
+      recommendationCount: 1,
+    })
+    assert.equal(calls[0].url, "https://control.example.com/api/tick-snapshots")
+    assert.equal(calls[0].init.method, "POST")
+    assert.equal(calls[0].init.headers.authorization, "Bearer tok")
+    assert.equal(calls[0].init.headers["content-type"], "application/json")
+    assert.equal(calls[0].init.body, JSON.stringify({ recommendations: [] }))
+  })
+
+  it("surfaces rejected snapshot responses", async () => {
+    await assert.rejects(
+      submitTickSnapshot({
+        fetchImpl: async () =>
+          new Response(JSON.stringify({ error: "invalid_tick_snapshot_request" }), {
+            status: 400,
+          }),
+        snapshot: {},
+        token: "tok",
+        url: "https://control.example.com",
+      }),
+      /400: invalid_tick_snapshot_request/,
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- add `pnpm agent:queue:submit-tick` to submit fresh or saved queue tick snapshots to the control-plane Worker
- add a small control-plane client helper for bearer-token configuration, URL normalization, snapshot POSTs, and error handling
- document the supervisor submission flow in the control-plane README, issue-tracker guide, and orchestration architecture doc

## Verification

- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- commit hook: changed-file format/secretlint, agent-quality, affected typecheck
- pre-push hook: `pnpm test`
