### PR TITLE
Fix PromotionsPage list UX

### DIFF
--- a/.changeset/promotions-list-page-filters.md
+++ b/.changeset/promotions-list-page-filters.md
@@ -1,0 +1,7 @@
+---
+"@voyantjs/promotions": minor
+"@voyantjs/promotions-react": minor
+"@voyantjs/promotions-ui": minor
+---
+
+Add server-backed promotions list search, filters, pagination, and row-navigation hooks to the operator PromotionsPage.

--- a/packages/promotions-react/src/index.ts
+++ b/packages/promotions-react/src/index.ts
@@ -8,7 +8,10 @@ import {
   useQueryClient,
 } from "@tanstack/react-query"
 import {
+  type PromotionalOfferApplicationMode,
+  type PromotionalOfferListStatus,
   type PromotionalOfferScope,
+  type PromotionalOfferScopeKind,
   promotionalOfferScopeSchema,
 } from "@voyantjs/promotions/validation"
 import {
@@ -35,7 +38,10 @@ export {
 // ---------- Schemas ----------
 
 export {
+  type PromotionalOfferApplicationMode,
+  type PromotionalOfferListStatus,
   type PromotionalOfferScope,
+  type PromotionalOfferScopeKind,
   promotionalOfferScopeSchema,
 } from "@voyantjs/promotions/validation"
 
@@ -76,6 +82,12 @@ const singleResponseSchema = z.object({ data: promotionalOfferRecordSchema })
 export interface PromotionsListQuery {
   active?: boolean
   code?: string
+  search?: string
+  applicationMode?: PromotionalOfferApplicationMode
+  status?: PromotionalOfferListStatus
+  scopeKind?: PromotionalOfferScopeKind
+  validFrom?: string
+  validUntil?: string
   limit?: number
   offset?: number
 }
@@ -89,6 +101,12 @@ function buildSearch(query: PromotionsListQuery): string {
   const params = new URLSearchParams()
   if (query.active !== undefined) params.set("active", String(query.active))
   if (query.code) params.set("code", query.code)
+  if (query.search) params.set("search", query.search)
+  if (query.applicationMode) params.set("applicationMode", query.applicationMode)
+  if (query.status) params.set("status", query.status)
+  if (query.scopeKind) params.set("scopeKind", query.scopeKind)
+  if (query.validFrom) params.set("validFrom", query.validFrom)
+  if (query.validUntil) params.set("validUntil", query.validUntil)
   if (query.limit !== undefined) params.set("limit", String(query.limit))
   if (query.offset !== undefined) params.set("offset", String(query.offset))
   const s = params.toString()

--- a/packages/promotions-ui/src/index.ts
+++ b/packages/promotions-ui/src/index.ts
@@ -1,2 +1,7 @@
 export { PromotionDialog, type PromotionDialogProps } from "./promotion-dialog.js"
-export { loadPromotionsPage, PromotionsPage } from "./promotions-page.js"
+export {
+  loadPromotionsPage,
+  type PromotionDialogRenderProps,
+  PromotionsPage,
+  type PromotionsPageProps,
+} from "./promotions-page.js"

--- a/packages/promotions-ui/src/promotions-page.tsx
+++ b/packages/promotions-ui/src/promotions-page.tsx
@@ -3,50 +3,139 @@
 /**
  * Operator-facing promotions list page.
  *
- * Lists every promotional offer with its scope, discount, validity, and
- * status. Edit-on-click opens the create/edit dialog (PromotionDialog).
- *
- * v1 limitations: no separate detail page, no redemption-history view —
- * the list + form covers the operator-essential capability. Detail +
- * redemption views can ship as follow-up commits.
+ * Lists every promotional offer with server-backed search, filters, pagination,
+ * and optional row navigation for apps that expose a dedicated detail route.
  */
 
 import type { QueryClient } from "@tanstack/react-query"
 import {
   createPromotionsClientOptions,
   getPromotionsListQueryOptions,
+  type PromotionalOfferApplicationMode,
+  type PromotionalOfferListStatus,
   type PromotionalOfferRecord,
   type PromotionalOfferScope,
+  type PromotionalOfferScopeKind,
   type PromotionsClientOptions,
+  type PromotionsListQuery,
   usePromotionsList,
 } from "@voyantjs/promotions-react"
-import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from "@voyantjs/ui/components"
-import { Plus } from "lucide-react"
-import { useMemo, useState } from "react"
+import {
+  Badge,
+  Button,
+  DateRangePicker,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@voyantjs/ui/components"
+import { cn } from "@voyantjs/ui/lib/utils"
+import { Plus, Search, X } from "lucide-react"
+import type { ReactNode } from "react"
+import { useState } from "react"
 
 import { PromotionDialog } from "./promotion-dialog.js"
+
+const DEFAULT_PAGE_SIZE = 25
+const ALL = "__all__"
+const TABLE_COLUMN_COUNT = 7
+
+const scopeKinds: PromotionalOfferScopeKind[] = [
+  "global",
+  "products",
+  "categories",
+  "destinations",
+  "markets",
+  "audiences",
+]
+
+const applicationModes: PromotionalOfferApplicationMode[] = ["auto", "code"]
+const statusFilters: PromotionalOfferListStatus[] = ["active", "scheduled", "expired", "archived"]
+
+type DateRangeValue = {
+  from: string | null
+  to: string | null
+}
+
+export interface PromotionDialogRenderProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  offer?: PromotionalOfferRecord
+  onSuccess: () => void
+}
+
+export interface PromotionsPageProps {
+  className?: string
+  pageSize?: number
+  onOpenPromotion?: (promotionId: string, promotion: PromotionalOfferRecord) => void
+  renderPromotionDialog?: (props: PromotionDialogRenderProps) => ReactNode
+}
 
 export function loadPromotionsPage(
   queryClient: QueryClient,
   client?: Partial<PromotionsClientOptions>,
+  query: PromotionsListQuery = {},
 ) {
   return queryClient.ensureQueryData(
-    getPromotionsListQueryOptions({ limit: 50, offset: 0 }, createPromotionsClientOptions(client)),
+    getPromotionsListQueryOptions(
+      { limit: DEFAULT_PAGE_SIZE, offset: 0, ...query },
+      createPromotionsClientOptions(client),
+    ),
   )
 }
 
-export function PromotionsPage() {
-  const { data, isPending, error } = usePromotionsList({ limit: 50, offset: 0 })
+export function PromotionsPage({
+  className,
+  pageSize = DEFAULT_PAGE_SIZE,
+  onOpenPromotion,
+  renderPromotionDialog,
+}: PromotionsPageProps = {}) {
+  const [search, setSearch] = useState("")
+  const [applicationMode, setApplicationMode] = useState<string>(ALL)
+  const [status, setStatus] = useState<string>(ALL)
+  const [scopeKind, setScopeKind] = useState<string>(ALL)
+  const [validityRange, setValidityRange] = useState<DateRangeValue | null>(null)
+  const [pageIndex, setPageIndex] = useState(0)
   const [dialogOpen, setDialogOpen] = useState(false)
   const [editingOffer, setEditingOffer] = useState<PromotionalOfferRecord | undefined>()
 
-  const offers = data?.data ?? []
+  const query: PromotionsListQuery = {
+    search: search || undefined,
+    applicationMode:
+      applicationMode === ALL ? undefined : (applicationMode as PromotionalOfferApplicationMode),
+    status: status === ALL ? undefined : (status as PromotionalOfferListStatus),
+    scopeKind: scopeKind === ALL ? undefined : (scopeKind as PromotionalOfferScopeKind),
+    validFrom: validityRange?.from ?? undefined,
+    validUntil: validityRange?.to ?? undefined,
+    limit: pageSize,
+    offset: pageIndex * pageSize,
+  }
 
-  const summary = useMemo(() => {
-    const active = offers.filter((o) => o.active).length
-    const codeGated = offers.filter((o) => o.code != null).length
-    return { total: offers.length, active, codeGated }
-  }, [offers])
+  const { data, isPending, isFetching, isError, error, refetch } = usePromotionsList(query)
+
+  const offers = data?.data ?? []
+  const total = data?.total ?? 0
+  const page = pageIndex + 1
+  const pageCount = Math.max(1, Math.ceil(total / pageSize))
+  const showSkeleton = isPending || (isFetching && offers.length === 0)
+  const hasActiveFilters =
+    search !== "" ||
+    applicationMode !== ALL ||
+    status !== ALL ||
+    scopeKind !== ALL ||
+    Boolean(validityRange?.from || validityRange?.to)
+
+  const resetPage = () => setPageIndex(0)
 
   function openCreate() {
     setEditingOffer(undefined)
@@ -58,9 +147,41 @@ export function PromotionsPage() {
     setDialogOpen(true)
   }
 
+  function openOffer(offer: PromotionalOfferRecord) {
+    if (onOpenPromotion) {
+      onOpenPromotion(offer.id, offer)
+      return
+    }
+    openEdit(offer)
+  }
+
+  function clearFilters() {
+    setSearch("")
+    setApplicationMode(ALL)
+    setStatus(ALL)
+    setScopeKind(ALL)
+    setValidityRange(null)
+    resetPage()
+  }
+
+  const dialog = renderPromotionDialog ? (
+    renderPromotionDialog({
+      open: dialogOpen,
+      onOpenChange: setDialogOpen,
+      offer: editingOffer,
+      onSuccess: () => {
+        setDialogOpen(false)
+        resetPage()
+        void refetch()
+      },
+    })
+  ) : (
+    <PromotionDialog open={dialogOpen} onOpenChange={setDialogOpen} offer={editingOffer} />
+  )
+
   return (
-    <div className="space-y-4 p-6">
-      <div className="flex items-center justify-between">
+    <div className={cn("flex flex-col gap-6 p-6", className)}>
+      <div className="flex items-center justify-between gap-4">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Promotions</h1>
           <p className="text-sm text-muted-foreground">
@@ -68,91 +189,268 @@ export function PromotionsPage() {
           </p>
         </div>
         <Button onClick={openCreate}>
-          <Plus className="mr-2 size-4" />
+          <Plus className="mr-2 size-4" aria-hidden="true" />
           New promotion
         </Button>
       </div>
 
-      <div className="grid grid-cols-3 gap-3">
-        <SummaryCard label="Total" value={summary.total} />
-        <SummaryCard label="Active" value={summary.active} />
-        <SummaryCard label="Code-gated" value={summary.codeGated} />
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative min-w-[14rem] max-w-sm flex-1">
+          <Label htmlFor="promotions-search" className="sr-only">
+            Search promotions
+          </Label>
+          <Search
+            className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <Input
+            id="promotions-search"
+            placeholder="Search name, slug, description, or code"
+            value={search}
+            onChange={(event) => {
+              setSearch(event.target.value)
+              resetPage()
+            }}
+            className="pl-9"
+          />
+        </div>
+
+        <Select
+          value={applicationMode}
+          onValueChange={(value) => {
+            setApplicationMode(value ?? ALL)
+            resetPage()
+          }}
+        >
+          <SelectTrigger className="w-[10.5rem]">
+            <SelectValue placeholder="Mode" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>All modes</SelectItem>
+            {applicationModes.map((mode) => (
+              <SelectItem key={mode} value={mode}>
+                {applicationModeLabel(mode)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={status}
+          onValueChange={(value) => {
+            setStatus(value ?? ALL)
+            resetPage()
+          }}
+        >
+          <SelectTrigger className="w-[10.5rem]">
+            <SelectValue placeholder="Status" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>All statuses</SelectItem>
+            {statusFilters.map((value) => (
+              <SelectItem key={value} value={value}>
+                {statusLabel(value)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={scopeKind}
+          onValueChange={(value) => {
+            setScopeKind(value ?? ALL)
+            resetPage()
+          }}
+        >
+          <SelectTrigger className="w-[11rem]">
+            <SelectValue placeholder="Scope" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>All scopes</SelectItem>
+            {scopeKinds.map((value) => (
+              <SelectItem key={value} value={value}>
+                {scopeKindLabel(value)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <DateRangePicker
+          value={validityRange}
+          onChange={(value) => {
+            setValidityRange(value)
+            resetPage()
+          }}
+          placeholder="Validity range"
+          className="w-[15rem]"
+        />
+
+        {hasActiveFilters ? (
+          <Button variant="ghost" onClick={clearFilters}>
+            <X className="mr-2 size-4" aria-hidden="true" />
+            Clear
+          </Button>
+        ) : null}
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>All offers</CardTitle>
-        </CardHeader>
-        <CardContent>
-          {error ? (
-            <p className="text-sm text-destructive">
-              Failed to load: {error instanceof Error ? error.message : String(error)}
-            </p>
-          ) : isPending ? (
-            <p className="text-sm text-muted-foreground">Loading…</p>
-          ) : offers.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              No promotions yet. Create your first offer to get started.
-            </p>
-          ) : (
-            <table className="w-full text-sm">
-              <thead className="text-left text-xs uppercase text-muted-foreground">
-                <tr>
-                  <th className="py-2 pr-4">Name</th>
-                  <th className="py-2 pr-4">Scope</th>
-                  <th className="py-2 pr-4">Discount</th>
-                  <th className="py-2 pr-4">Validity</th>
-                  <th className="py-2 pr-4">Code</th>
-                  <th className="py-2 pr-4">Status</th>
-                </tr>
-              </thead>
-              <tbody>
-                {offers.map((offer) => (
-                  <tr
-                    key={offer.id}
-                    className="cursor-pointer border-t hover:bg-muted/40"
-                    onClick={() => openEdit(offer)}
-                  >
-                    <td className="py-2 pr-4 font-medium">{offer.name}</td>
-                    <td className="py-2 pr-4 text-muted-foreground">
-                      {summarizeScope(offer.scope)}
-                    </td>
-                    <td className="py-2 pr-4">{summarizeDiscount(offer)}</td>
-                    <td className="py-2 pr-4 text-muted-foreground">
-                      {summarizeValidity(offer.validFrom, offer.validUntil)}
-                    </td>
-                    <td className="py-2 pr-4 font-mono text-xs">{offer.code ?? "—"}</td>
-                    <td className="py-2 pr-4">
-                      <Badge variant={offer.active ? "default" : "outline"}>
-                        {offer.active ? "active" : "archived"}
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Mode</TableHead>
+              <TableHead>Scope</TableHead>
+              <TableHead>Discount</TableHead>
+              <TableHead>Validity</TableHead>
+              <TableHead>Code</TableHead>
+              <TableHead>Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {showSkeleton ? (
+              <PromotionRowSkeleton rows={6} />
+            ) : isError ? (
+              <TableRow>
+                <TableCell
+                  colSpan={TABLE_COLUMN_COUNT}
+                  className="h-24 text-center text-sm text-destructive"
+                >
+                  Failed to load: {error instanceof Error ? error.message : String(error)}
+                </TableCell>
+              </TableRow>
+            ) : offers.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={TABLE_COLUMN_COUNT}
+                  className="h-24 text-center text-sm text-muted-foreground"
+                >
+                  No promotions match the current filters.
+                </TableCell>
+              </TableRow>
+            ) : (
+              offers.map((offer) => (
+                <TableRow
+                  key={offer.id}
+                  className="cursor-pointer"
+                  onClick={() => openOffer(offer)}
+                >
+                  <TableCell>
+                    <div className="font-medium">{offer.name}</div>
+                    <div className="font-mono text-xs text-muted-foreground">{offer.slug}</div>
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={offer.code == null ? "secondary" : "outline"}>
+                      {offer.code == null ? "Auto" : "Code"}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {summarizeScope(offer.scope)}
+                  </TableCell>
+                  <TableCell>{summarizeDiscount(offer)}</TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {summarizeValidity(offer.validFrom, offer.validUntil)}
+                  </TableCell>
+                  <TableCell className="font-mono text-xs">{offer.code ?? "-"}</TableCell>
+                  <TableCell>
+                    <div className="flex flex-wrap gap-2">
+                      <Badge variant={statusBadgeVariant(getOfferStatus(offer))}>
+                        {statusLabel(getOfferStatus(offer))}
                       </Badge>
-                      {offer.stackable ? (
-                        <Badge variant="secondary" className="ml-2">
-                          stackable
-                        </Badge>
-                      ) : null}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
-        </CardContent>
-      </Card>
+                      {offer.stackable ? <Badge variant="secondary">Stackable</Badge> : null}
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
 
-      <PromotionDialog open={dialogOpen} onOpenChange={setDialogOpen} offer={editingOffer} />
+      <PaginationBar
+        shown={offers.length}
+        total={total}
+        page={page}
+        pageCount={pageCount}
+        onPrevious={() => setPageIndex((prev) => Math.max(0, prev - 1))}
+        onNext={() => setPageIndex((prev) => prev + 1)}
+        canGoBack={pageIndex > 0}
+        canGoForward={(pageIndex + 1) * pageSize < total}
+      />
+
+      {dialog}
     </div>
   )
 }
 
-function SummaryCard({ label, value }: { label: string; value: number }) {
+function PaginationBar({
+  shown,
+  total,
+  page,
+  pageCount,
+  onPrevious,
+  onNext,
+  canGoBack,
+  canGoForward,
+}: {
+  shown: number
+  total: number
+  page: number
+  pageCount: number
+  onPrevious: () => void
+  onNext: () => void
+  canGoBack: boolean
+  canGoForward: boolean
+}) {
   return (
-    <Card>
-      <CardContent className="flex flex-col gap-1 py-4">
-        <span className="text-xs uppercase text-muted-foreground">{label}</span>
-        <span className="text-2xl font-semibold">{value}</span>
-      </CardContent>
-    </Card>
+    <div className="flex items-center justify-between text-sm text-muted-foreground">
+      <span>
+        Showing {shown} of {total}
+      </span>
+      <div className="flex items-center gap-2">
+        <Button variant="outline" size="sm" disabled={!canGoBack} onClick={onPrevious}>
+          Previous
+        </Button>
+        <span>
+          Page {page} of {pageCount}
+        </span>
+        <Button variant="outline" size="sm" disabled={!canGoForward} onClick={onNext}>
+          Next
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function PromotionRowSkeleton({ rows }: { rows: number }) {
+  return (
+    <>
+      {Array.from({ length: rows }).map((_, index) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders are stable
+        <TableRow key={`promotion-skeleton-${index}`}>
+          <TableCell>
+            <Skeleton className="h-4 w-40" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-5 w-16 rounded-full" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-4 w-28" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-4 w-20" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-4 w-32" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-4 w-20" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-5 w-20 rounded-full" />
+          </TableCell>
+        </TableRow>
+      ))}
+    </>
   )
 }
 
@@ -187,5 +485,62 @@ function summarizeValidity(from: string | null, until: string | null): string {
   const fmt = (iso: string) => iso.slice(0, 10)
   if (from == null) return `Until ${fmt(until ?? "")}`
   if (until == null) return `From ${fmt(from)}`
-  return `${fmt(from)} → ${fmt(until)}`
+  return `${fmt(from)} - ${fmt(until)}`
+}
+
+function getOfferStatus(offer: PromotionalOfferRecord): PromotionalOfferListStatus {
+  if (!offer.active) return "archived"
+  const now = Date.now()
+  if (offer.validFrom != null && new Date(offer.validFrom).getTime() > now) return "scheduled"
+  if (offer.validUntil != null && new Date(offer.validUntil).getTime() < now) return "expired"
+  return "active"
+}
+
+function statusBadgeVariant(
+  status: PromotionalOfferListStatus,
+): "default" | "secondary" | "outline" | "destructive" {
+  switch (status) {
+    case "active":
+      return "default"
+    case "scheduled":
+      return "secondary"
+    case "expired":
+      return "destructive"
+    case "archived":
+      return "outline"
+  }
+}
+
+function applicationModeLabel(mode: PromotionalOfferApplicationMode): string {
+  return mode === "auto" ? "Auto-applied" : "Code-redeemed"
+}
+
+function statusLabel(status: PromotionalOfferListStatus): string {
+  switch (status) {
+    case "active":
+      return "Active"
+    case "scheduled":
+      return "Scheduled"
+    case "expired":
+      return "Expired"
+    case "archived":
+      return "Archived"
+  }
+}
+
+function scopeKindLabel(scopeKind: PromotionalOfferScopeKind): string {
+  switch (scopeKind) {
+    case "global":
+      return "Global"
+    case "products":
+      return "Products"
+    case "categories":
+      return "Categories"
+    case "destinations":
+      return "Destinations"
+    case "markets":
+      return "Markets"
+    case "audiences":
+      return "Audiences"
+  }
 }

--- a/packages/promotions/src/service.ts
+++ b/packages/promotions/src/service.ts
@@ -17,7 +17,20 @@
 
 import type { EventBus } from "@voyantjs/core"
 import { productCategoryProducts, productDestinations } from "@voyantjs/products/schema"
-import { and, count, desc, eq, inArray, sql } from "drizzle-orm"
+import {
+  and,
+  count,
+  desc,
+  eq,
+  gte,
+  ilike,
+  inArray,
+  isNotNull,
+  isNull,
+  lte,
+  or,
+  sql,
+} from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import {
@@ -205,6 +218,56 @@ async function listOffers(db: PostgresJsDatabase, query: PromotionalOfferListQue
   const where = []
   if (query.active !== undefined) where.push(eq(promotionalOffers.active, query.active))
   if (query.code !== undefined) where.push(eq(promotionalOffers.code, query.code.toLowerCase()))
+  if (query.search !== undefined) {
+    const term = `%${query.search}%`
+    where.push(
+      or(
+        ilike(promotionalOffers.name, term),
+        ilike(promotionalOffers.slug, term),
+        ilike(promotionalOffers.description, term),
+        ilike(promotionalOffers.code, term),
+      ),
+    )
+  }
+  if (query.applicationMode === "auto") where.push(isNull(promotionalOffers.code))
+  if (query.applicationMode === "code") where.push(isNotNull(promotionalOffers.code))
+  if (query.scopeKind !== undefined) {
+    where.push(sql`${promotionalOffers.scope}->>'kind' = ${query.scopeKind}`)
+  }
+  if (query.status !== undefined) {
+    const now = new Date()
+    if (query.status === "archived") {
+      where.push(eq(promotionalOffers.active, false))
+    } else if (query.status === "scheduled") {
+      where.push(and(eq(promotionalOffers.active, true), gte(promotionalOffers.validFrom, now)))
+    } else if (query.status === "expired") {
+      where.push(and(eq(promotionalOffers.active, true), lte(promotionalOffers.validUntil, now)))
+    } else {
+      where.push(
+        and(
+          eq(promotionalOffers.active, true),
+          or(isNull(promotionalOffers.validFrom), lte(promotionalOffers.validFrom, now)),
+          or(isNull(promotionalOffers.validUntil), gte(promotionalOffers.validUntil, now)),
+        ),
+      )
+    }
+  }
+  if (query.validFrom !== undefined) {
+    where.push(
+      or(
+        isNull(promotionalOffers.validUntil),
+        gte(promotionalOffers.validUntil, startOfDay(query.validFrom)),
+      ),
+    )
+  }
+  if (query.validUntil !== undefined) {
+    where.push(
+      or(
+        isNull(promotionalOffers.validFrom),
+        lte(promotionalOffers.validFrom, endOfDay(query.validUntil)),
+      ),
+    )
+  }
 
   const filter = where.length > 0 ? and(...where) : undefined
   const limit = query.limit ?? 50
@@ -225,6 +288,14 @@ async function listOffers(db: PostgresJsDatabase, query: PromotionalOfferListQue
     .offset(offset)
 
   return { data, total, limit, offset }
+}
+
+function startOfDay(isoDate: string): Date {
+  return new Date(`${isoDate}T00:00:00.000Z`)
+}
+
+function endOfDay(isoDate: string): Date {
+  return new Date(`${isoDate}T23:59:59.999Z`)
 }
 
 async function getOfferById(db: PostgresJsDatabase, id: string): Promise<PromotionalOffer | null> {

--- a/packages/promotions/src/validation.ts
+++ b/packages/promotions/src/validation.ts
@@ -161,6 +161,14 @@ export const promotionalOfferListQuerySchema = z.object({
     .transform((v) => v === "true")
     .optional(),
   code: z.string().min(1).max(80).optional(),
+  search: z.string().trim().min(1).max(200).optional(),
+  applicationMode: z.enum(["auto", "code"]).optional(),
+  status: z.enum(["active", "scheduled", "expired", "archived"]).optional(),
+  scopeKind: z
+    .enum(["global", "products", "categories", "destinations", "markets", "audiences"])
+    .optional(),
+  validFrom: z.string().date().optional(),
+  validUntil: z.string().date().optional(),
   limit: z.coerce.number().int().positive().max(200).optional().default(50),
   offset: z.coerce.number().int().nonnegative().optional().default(0),
 })
@@ -170,3 +178,7 @@ export type InsertPromotionalOffer = z.infer<typeof insertPromotionalOfferSchema
 export type UpdatePromotionalOfferInput = z.input<typeof updatePromotionalOfferSchema>
 export type UpdatePromotionalOffer = z.infer<typeof updatePromotionalOfferSchema>
 export type PromotionalOfferListQuery = z.infer<typeof promotionalOfferListQuerySchema>
+export type PromotionalOfferApplicationMode = NonNullable<
+  PromotionalOfferListQuery["applicationMode"]
+>
+export type PromotionalOfferListStatus = NonNullable<PromotionalOfferListQuery["status"]>

--- a/packages/promotions/tests/integration/service.test.ts
+++ b/packages/promotions/tests/integration/service.test.ts
@@ -23,9 +23,7 @@ import type { InsertPromotionalOfferInput, PromotionalOfferScope } from "../../s
 const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
 const DB_AVAILABLE = !!TEST_DATABASE_URL
 
-const db: PostgresJsDatabase = DB_AVAILABLE
-  ? createTestDb()
-  : (null as unknown as PostgresJsDatabase)
+let db: PostgresJsDatabase
 
 interface RecordedEvent {
   topic: string
@@ -66,6 +64,7 @@ describe.skipIf(!DB_AVAILABLE)("promotionsService", () => {
   let destinationId: string
 
   beforeAll(() => {
+    db = createTestDb()
     productAId = newId("products")
     productBId = newId("products")
     productCId = newId("products")
@@ -360,6 +359,67 @@ describe.skipIf(!DB_AVAILABLE)("promotionsService", () => {
       })
       expect(result.total).toBe(1)
       expect(result.data[0]?.code).toBe("findme")
+    })
+
+    it("filters by search, application mode, and scope kind", async () => {
+      await promotionsService.createOffer(
+        db,
+        baseOffer({
+          name: "Spring product offer",
+          slug: "spring-product",
+          code: "SPRING",
+          scope: { kind: "products", productIds: [productAId] },
+        }),
+      )
+      await promotionsService.createOffer(
+        db,
+        baseOffer({
+          name: "Spring auto offer",
+          slug: "spring-auto",
+          scope: { kind: "global" },
+        }),
+      )
+
+      const result = await promotionsService.listOffers(db, {
+        search: "spring",
+        applicationMode: "code",
+        scopeKind: "products",
+        limit: 50,
+        offset: 0,
+      })
+
+      expect(result.total).toBe(1)
+      expect(result.data[0]?.slug).toBe("spring-product")
+    })
+
+    it("filters by derived status and validity overlap", async () => {
+      const dayMs = 24 * 60 * 60 * 1000
+      const past = new Date(Date.now() - dayMs)
+      const future = new Date(Date.now() + dayMs)
+      const furtherFuture = new Date(Date.now() + dayMs * 10)
+      await promotionsService.createOffer(db, baseOffer({ slug: "current" }))
+      await promotionsService.createOffer(
+        db,
+        baseOffer({ slug: "scheduled", validFrom: future, validUntil: furtherFuture }),
+      )
+      await promotionsService.createOffer(db, baseOffer({ slug: "expired", validUntil: past }))
+
+      const scheduled = await promotionsService.listOffers(db, {
+        status: "scheduled",
+        limit: 50,
+        offset: 0,
+      })
+      expect(scheduled.total).toBe(1)
+      expect(scheduled.data[0]?.slug).toBe("scheduled")
+
+      const overlapping = await promotionsService.listOffers(db, {
+        validFrom: future.toISOString().slice(0, 10),
+        validUntil: furtherFuture.toISOString().slice(0, 10),
+        limit: 50,
+        offset: 0,
+      })
+      expect(overlapping.data.map((offer) => offer.slug)).toContain("scheduled")
+      expect(overlapping.data.map((offer) => offer.slug)).not.toContain("expired")
     })
   })
 

--- a/packages/promotions/tests/unit/validation.test.ts
+++ b/packages/promotions/tests/unit/validation.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   insertPromotionalOfferSchema,
   promotionalOfferConditionsSchema,
+  promotionalOfferListQuerySchema,
   promotionalOfferScopeSchema,
   updatePromotionalOfferSchema,
 } from "../../src/validation.js"
@@ -263,5 +264,31 @@ describe("updatePromotionalOfferSchema", () => {
         discountAmountCents: 100,
       }),
     ).toThrow(/percentage offers/i)
+  })
+})
+
+describe("promotionalOfferListQuerySchema", () => {
+  it("accepts operator list filters", () => {
+    expect(
+      promotionalOfferListQuerySchema.parse({
+        search: "spring",
+        applicationMode: "code",
+        status: "scheduled",
+        scopeKind: "products",
+        validFrom: "2026-05-01",
+        validUntil: "2026-05-31",
+        limit: "25",
+        offset: "50",
+      }),
+    ).toEqual({
+      search: "spring",
+      applicationMode: "code",
+      status: "scheduled",
+      scopeKind: "products",
+      validFrom: "2026-05-01",
+      validUntil: "2026-05-31",
+      limit: 25,
+      offset: 50,
+    })
   })
 })


### PR DESCRIPTION
## Summary

Closes #654.

- Reworks `@voyantjs/promotions-ui` `PromotionsPage` into the standard operator list shape: header, toolbar, bare bordered table, pagination, and optional row navigation via `onOpenPromotion`.
- Adds server-backed promotions list filters for search, application mode, status, scope kind, and validity range, exposed through `@voyantjs/promotions-react` query options.
- Adds a changeset and targeted validation/service coverage for the new list query filters.

## Verification

- `pnpm --filter @voyantjs/promotions typecheck`
- `pnpm --filter @voyantjs/promotions-react typecheck`
- `pnpm --filter @voyantjs/promotions-ui typecheck`
- `pnpm --filter @voyantjs/promotions lint`
- `pnpm --filter @voyantjs/promotions-react lint`
- `pnpm --filter @voyantjs/promotions-ui lint`
- `pnpm --filter @voyantjs/promotions test`
- `pnpm --filter @voyantjs/promotions-ui test`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm verify:fast`

Note: the first plain `pnpm verify:fast` attempt hit a Node heap OOM in `apps/dev` typecheck; rerunning the same lane with an 8GB heap passed.