### PR TITLE
feat(agent-control-plane): persist tick snapshots

### DIFF
--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -3,10 +3,10 @@
 Cloudflare-ready Hono Worker for supervised agent queue orchestration.
 
 This app intentionally starts with a dry-run contract. It can answer health,
-capability, and dispatch-planning requests, but it does not mutate GitHub,
-create workspaces, run provider commands, or spend agent budget. Local runner
-scripts remain the execution boundary until authentication, persistence, and
-worker-to-runner transport are designed.
+capability, dispatch-planning, and snapshot-state requests, but it does not
+mutate GitHub, create workspaces, run provider commands, or spend agent budget.
+Local runner scripts remain the execution boundary until authentication,
+persistence, and worker-to-runner transport are designed.
 
 `/health` is public. `/api/*` requires a bearer token from
 `AGENT_CONTROL_PLANE_TOKENS`, a comma-separated secret value configured in the
@@ -27,6 +27,7 @@ pnpm -C apps/agent-control-plane dev
 - `GET /api/capabilities`
 - `POST /api/dispatch-plans`
 - `POST /api/tick-snapshots`
+- `GET /api/tick-snapshots/latest?repository=<owner/name>`
 
 `POST /api/dispatch-plans` accepts ordered queue recommendations and returns the
 first dispatchable plan that matches the optional filters. It mirrors the local
@@ -40,8 +41,13 @@ planned lifecycle command on a supervisor-specific JSONL ledger. Pass
 `POST /api/tick-snapshots` accepts the JSON emitted by
 `pnpm agent:queue:tick -- --json`, validates the shape, and returns the accepted
 snapshot with counts for total recommendations, dispatchable recommendations,
-and recent events. The current contract is intentionally non-persistent; use it
-to prove worker-to-supervisor shape before adding storage or automatic loops.
+and recent events. If the Worker has an `AGENT_TICK_SNAPSHOTS` R2 binding, it
+also stores the latest snapshot for that repository.
+
+`GET /api/tick-snapshots/latest?repository=<owner/name>` reads the latest stored
+snapshot for one repository. It returns
+`tick_snapshot_storage_not_configured` when R2 is not bound, and
+`tick_snapshot_not_found` before the first snapshot is submitted.
 
 Submit the current queue snapshot from the repo runner with:
 
@@ -59,3 +65,20 @@ AGENT_CONTROL_PLANE_URL=https://agent-control-plane.example.workers.dev \
 AGENT_CONTROL_PLANE_TOKEN=... \
 pnpm agent:queue:submit-tick -- --input .agent-runs/tick.json
 ```
+
+## Optional R2 Storage
+
+Bind an R2 bucket as `AGENT_TICK_SNAPSHOTS` to keep the latest accepted tick
+snapshot per repository:
+
+```jsonc
+"r2_buckets": [
+  {
+    "binding": "AGENT_TICK_SNAPSHOTS",
+    "bucket_name": "voyant-agent-control-plane"
+  }
+]
+```
+
+Set `AGENT_TICK_SNAPSHOT_KEY_PREFIX` when multiple environments share one
+bucket.

--- a/apps/agent-control-plane/src/app.ts
+++ b/apps/agent-control-plane/src/app.ts
@@ -3,16 +3,19 @@ import { Hono } from "hono"
 import {
   acceptTickSnapshot,
   buildCapabilities,
+  buildTickSnapshotRecord,
   dispatchPlanRequestSchema,
   selectDispatchPlan,
   tickSnapshotRequestSchema,
 } from "./control-plane.js"
+import type { TickSnapshotStore } from "./tick-snapshot-store.js"
 
 interface AppOptions {
   authTokens?: string[]
+  tickSnapshotStore?: TickSnapshotStore
 }
 
-export function createApp({ authTokens = [] }: AppOptions = {}): Hono {
+export function createApp({ authTokens = [], tickSnapshotStore }: AppOptions = {}): Hono {
   const app = new Hono()
 
   app.onError((error, c) => {
@@ -36,7 +39,13 @@ export function createApp({ authTokens = [] }: AppOptions = {}): Hono {
     await next()
   })
 
-  app.get("/api/capabilities", (c) => c.json(buildCapabilities()))
+  app.get("/api/capabilities", (c) =>
+    c.json(
+      buildCapabilities({
+        tickSnapshotPersistence: tickSnapshotStore ? "latest" : "none",
+      }),
+    ),
+  )
 
   app.post("/api/dispatch-plans", async (c) => {
     const parsed = dispatchPlanRequestSchema.safeParse(await c.req.json().catch(() => null))
@@ -65,7 +74,37 @@ export function createApp({ authTokens = [] }: AppOptions = {}): Hono {
       )
     }
 
-    return c.json(acceptTickSnapshot(parsed.data))
+    const accepted = acceptTickSnapshot(parsed.data)
+    if (!tickSnapshotStore) {
+      return c.json({
+        ...accepted,
+        storage: { persisted: false, reason: "tick_snapshot_storage_not_configured" },
+      })
+    }
+
+    const write = await tickSnapshotStore.putLatest(buildTickSnapshotRecord(parsed.data))
+    return c.json({
+      ...accepted,
+      storage: { key: write.key, persisted: true },
+    })
+  })
+
+  app.get("/api/tick-snapshots/latest", async (c) => {
+    if (!tickSnapshotStore) {
+      return c.json({ error: "tick_snapshot_storage_not_configured" }, 503)
+    }
+
+    const repository = c.req.query("repository")?.trim()
+    if (!repository) {
+      return c.json({ error: "missing_repository" }, 400)
+    }
+
+    const record = await tickSnapshotStore.getLatest(repository)
+    if (!record) {
+      return c.json({ error: "tick_snapshot_not_found" }, 404)
+    }
+
+    return c.json(record)
   })
 
   return app

--- a/apps/agent-control-plane/src/control-plane.test.ts
+++ b/apps/agent-control-plane/src/control-plane.test.ts
@@ -371,6 +371,7 @@ describe("agent control plane", () => {
     expect(body).toHaveProperty("snapshot.recommendations.0.issue.hasAgentBrief", true)
     expect(body).toHaveProperty("snapshot.recommendations.0.issue.labels", ["agent:ready", "ui"])
     expect(body).toHaveProperty("snapshot.recommendations.0.issue.state", "OPEN")
+    expect(body).toHaveProperty("storage.persisted", false)
   })
 
   it("requires configured bearer auth for API routes", async () => {

--- a/apps/agent-control-plane/src/control-plane.ts
+++ b/apps/agent-control-plane/src/control-plane.ts
@@ -80,6 +80,22 @@ export const tickSnapshotRequestSchema = z.object({
 
 export type TickSnapshotRequest = z.infer<typeof tickSnapshotRequestSchema>
 
+const tickSnapshotSummarySchema = z.object({
+  dispatchableRecommendationCount: z.number().int().nonnegative(),
+  firstDispatchableAction: z.string().nullable(),
+  firstDispatchableIssueNumber: z.number().int().positive().nullable(),
+  recentEventCount: z.number().int().nonnegative(),
+  recommendationCount: z.number().int().nonnegative(),
+})
+
+export const tickSnapshotRecordSchema = z.object({
+  acceptedAt: z.string().min(1),
+  snapshot: tickSnapshotRequestSchema,
+  summary: tickSnapshotSummarySchema,
+})
+
+export type TickSnapshotRecord = z.infer<typeof tickSnapshotRecordSchema>
+
 export interface DispatchPlan {
   action: (typeof dispatchableActions)[number]
   command: string[]
@@ -94,7 +110,11 @@ export interface DispatchPlanResult {
   reason: string
 }
 
-export function buildCapabilities() {
+export function buildCapabilities({
+  tickSnapshotPersistence = "none",
+}: {
+  tickSnapshotPersistence?: "latest" | "none"
+} = {}) {
   return {
     service: "agent-control-plane",
     version: 1,
@@ -113,20 +133,33 @@ export function buildCapabilities() {
     snapshotContracts: {
       tick: {
         version: 1,
-        persistence: "none",
+        persistence: tickSnapshotPersistence,
       },
     },
   }
 }
 
 export function acceptTickSnapshot(snapshot: TickSnapshotRequest) {
+  const record = buildTickSnapshotRecord(snapshot)
+
+  return {
+    accepted: true,
+    snapshot: record.snapshot,
+    summary: record.summary,
+  }
+}
+
+export function buildTickSnapshotRecord(
+  snapshot: TickSnapshotRequest,
+  { acceptedAt = new Date().toISOString() }: { acceptedAt?: string } = {},
+): TickSnapshotRecord {
   const dispatchableRecommendations = snapshot.recommendations.filter((recommendation) =>
     isDispatchableAction(recommendation.action),
   )
   const firstDispatchable = dispatchableRecommendations[0] ?? null
 
   return {
-    accepted: true,
+    acceptedAt,
     snapshot,
     summary: {
       dispatchableRecommendationCount: dispatchableRecommendations.length,

--- a/apps/agent-control-plane/src/tick-snapshot-store.test.ts
+++ b/apps/agent-control-plane/src/tick-snapshot-store.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "vitest"
+
+import { createApp } from "./app.js"
+import { buildTickSnapshotRecord, type TickSnapshotRecord } from "./control-plane.js"
+import {
+  createR2TickSnapshotStore,
+  type TickSnapshotBucket,
+  type TickSnapshotStore,
+} from "./tick-snapshot-store.js"
+
+const tickSnapshot = {
+  project: {
+    owner: "voyantjs",
+    number: 1,
+    title: "Voyant Engineering",
+    url: "https://github.com/orgs/voyantjs/projects/1",
+  },
+  repository: "voyantjs/voyant",
+  maxAgeDays: 1,
+  eventLog: {
+    path: "/repo/.agent-runs/events.jsonl",
+    recentEvents: [
+      {
+        timestamp: "2026-05-12T05:00:00.000Z",
+        type: "dispatch.completed",
+        issue: { number: 579 },
+      },
+    ],
+  },
+  recommendations: [
+    {
+      action: "remote-bootstrap",
+      command: "pnpm agent:queue:remote-bootstrap -- --issue 579 --repo voyantjs/voyant --yes",
+      issue: {
+        number: 579,
+        title: "Test agent project intake workflow",
+        url: "https://github.com/voyantjs/voyant/issues/579",
+        repository: "voyantjs/voyant",
+        agentBrief: "Acceptance criteria and verification lane.",
+        hasAgentBrief: true,
+        labels: ["agent:ready", "ui"],
+        state: "OPEN",
+      },
+      priority: 20,
+      reason: "remote workspace is ready for repository bootstrap",
+      state: "Ready",
+    },
+    {
+      action: "remote-run-command",
+      command:
+        'pnpm agent:queue:remote-run-command -- --issue 580 --repo voyantjs/voyant --command "<implementation-command>" --yes',
+      issue: {
+        number: 580,
+        title: "Run implementation",
+        url: "https://github.com/voyantjs/voyant/issues/580",
+        repository: "voyantjs/voyant",
+      },
+      priority: 30,
+      reason: "implementation execution remains explicit",
+      state: "Planning",
+    },
+  ],
+}
+
+describe("tick snapshot storage", () => {
+  it("builds durable tick snapshot records", () => {
+    expect(
+      buildTickSnapshotRecord(tickSnapshot, {
+        acceptedAt: "2026-05-12T05:00:00.000Z",
+      }),
+    ).toMatchObject({
+      acceptedAt: "2026-05-12T05:00:00.000Z",
+      snapshot: tickSnapshot,
+      summary: {
+        dispatchableRecommendationCount: 1,
+        firstDispatchableAction: "remote-bootstrap",
+        firstDispatchableIssueNumber: 579,
+        recentEventCount: 1,
+        recommendationCount: 2,
+      },
+    })
+  })
+
+  it("persists and reads latest tick snapshots when storage is configured", async () => {
+    const store = inMemoryTickSnapshotStore()
+    const app = createApp({ authTokens: ["secret"], tickSnapshotStore: store })
+    const response = await app.request("/api/tick-snapshots", {
+      method: "POST",
+      headers: { authorization: "Bearer secret", "content-type": "application/json" },
+      body: JSON.stringify(tickSnapshot),
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      accepted: true,
+      storage: {
+        key: "latest/voyantjs/voyant.json",
+        persisted: true,
+      },
+    })
+
+    const latest = await app.request("/api/tick-snapshots/latest?repository=voyantjs%2Fvoyant", {
+      headers: { authorization: "Bearer secret" },
+    })
+    expect(latest.status).toBe(200)
+    await expect(latest.json()).resolves.toMatchObject({
+      snapshot: {
+        repository: "voyantjs/voyant",
+      },
+      summary: {
+        dispatchableRecommendationCount: 1,
+        recommendationCount: 2,
+      },
+    })
+
+    const capabilities = await app.request("/api/capabilities", {
+      headers: { authorization: "Bearer secret" },
+    })
+    await expect(capabilities.json()).resolves.toMatchObject({
+      snapshotContracts: {
+        tick: {
+          persistence: "latest",
+        },
+      },
+    })
+  })
+
+  it("requires repository and configured storage for latest tick snapshots", async () => {
+    const noStore = createApp({ authTokens: ["secret"] })
+    const noStoreResponse = await noStore.request(
+      "/api/tick-snapshots/latest?repository=voyantjs%2Fvoyant",
+      {
+        headers: { authorization: "Bearer secret" },
+      },
+    )
+    expect(noStoreResponse.status).toBe(503)
+    await expect(noStoreResponse.json()).resolves.toEqual({
+      error: "tick_snapshot_storage_not_configured",
+    })
+
+    const app = createApp({
+      authTokens: ["secret"],
+      tickSnapshotStore: inMemoryTickSnapshotStore(),
+    })
+    const missingRepository = await app.request("/api/tick-snapshots/latest", {
+      headers: { authorization: "Bearer secret" },
+    })
+    expect(missingRepository.status).toBe(400)
+    await expect(missingRepository.json()).resolves.toEqual({ error: "missing_repository" })
+
+    const missingSnapshot = await app.request(
+      "/api/tick-snapshots/latest?repository=voyantjs%2Fvoyant",
+      {
+        headers: { authorization: "Bearer secret" },
+      },
+    )
+    expect(missingSnapshot.status).toBe(404)
+    await expect(missingSnapshot.json()).resolves.toEqual({ error: "tick_snapshot_not_found" })
+  })
+
+  it("stores latest tick snapshots in R2-compatible object storage", async () => {
+    const objects = new Map<string, string>()
+    const store = createR2TickSnapshotStore({
+      bucket: {
+        async get(key: string) {
+          const text = objects.get(key)
+          return text
+            ? ({
+                text: async () => text,
+              } as R2ObjectBody)
+            : null
+        },
+        async put(key: string, value: string) {
+          objects.set(key, String(value))
+          return null
+        },
+      } satisfies TickSnapshotBucket,
+      keyPrefix: "/supervisor/",
+    })
+
+    const record = buildTickSnapshotRecord(tickSnapshot, {
+      acceptedAt: "2026-05-12T05:00:00.000Z",
+    })
+
+    await expect(store.putLatest(record)).resolves.toEqual({
+      key: "supervisor/tick-snapshots/latest/voyantjs%2Fvoyant.json",
+    })
+    await expect(store.getLatest("VoyantJS/Voyant")).resolves.toEqual(record)
+  })
+
+  it("stores snapshots without a leading slash when the key prefix is empty", async () => {
+    const objects = new Map<string, string>()
+    const store = createR2TickSnapshotStore({
+      bucket: {
+        async get(_key: string) {
+          return null
+        },
+        async put(key: string, value: string) {
+          objects.set(key, String(value))
+          return null
+        },
+      } satisfies TickSnapshotBucket,
+      keyPrefix: "",
+    })
+
+    await expect(store.putLatest(buildTickSnapshotRecord(tickSnapshot))).resolves.toEqual({
+      key: "tick-snapshots/latest/voyantjs%2Fvoyant.json",
+    })
+  })
+})
+
+function inMemoryTickSnapshotStore(): TickSnapshotStore {
+  const latest = new Map<string, TickSnapshotRecord>()
+
+  return {
+    async getLatest(repository) {
+      return latest.get(repository.toLowerCase()) ?? null
+    },
+    async putLatest(record) {
+      latest.set(record.snapshot.repository.toLowerCase(), record)
+      return { key: `latest/${record.snapshot.repository.toLowerCase()}.json` }
+    },
+  }
+}

--- a/apps/agent-control-plane/src/tick-snapshot-store.ts
+++ b/apps/agent-control-plane/src/tick-snapshot-store.ts
@@ -1,0 +1,59 @@
+import { type TickSnapshotRecord, tickSnapshotRecordSchema } from "./control-plane.js"
+
+export interface TickSnapshotStore {
+  getLatest(repository: string): Promise<TickSnapshotRecord | null>
+  putLatest(record: TickSnapshotRecord): Promise<TickSnapshotStoreWrite>
+}
+
+export interface TickSnapshotStoreWrite {
+  key: string
+}
+
+export interface TickSnapshotBucket {
+  get(key: string): Promise<{ text(): Promise<string> } | null>
+  put(
+    key: string,
+    value: string,
+    options?: { httpMetadata?: { contentType?: string } },
+  ): Promise<unknown>
+}
+
+export function createR2TickSnapshotStore({
+  bucket,
+  keyPrefix = "agent-control-plane",
+}: {
+  bucket: TickSnapshotBucket
+  keyPrefix?: string
+}): TickSnapshotStore {
+  return {
+    async getLatest(repository) {
+      const object = await bucket.get(latestSnapshotKey({ keyPrefix, repository }))
+      if (!object) return null
+
+      const parsed = tickSnapshotRecordSchema.safeParse(JSON.parse(await object.text()))
+      if (!parsed.success) {
+        throw new Error(`stored tick snapshot is invalid for ${repository}`)
+      }
+
+      return parsed.data
+    },
+
+    async putLatest(record) {
+      const key = latestSnapshotKey({ keyPrefix, repository: record.snapshot.repository })
+      await bucket.put(key, JSON.stringify(record), {
+        httpMetadata: {
+          contentType: "application/json",
+        },
+      })
+
+      return { key }
+    },
+  }
+}
+
+function latestSnapshotKey({ keyPrefix, repository }: { keyPrefix: string; repository: string }) {
+  const normalizedPrefix = keyPrefix.replace(/^\/+|\/+$/g, "")
+  const encodedRepository = encodeURIComponent(repository.trim().toLowerCase())
+  const key = `tick-snapshots/latest/${encodedRepository}.json`
+  return normalizedPrefix ? `${normalizedPrefix}/${key}` : key
+}

--- a/apps/agent-control-plane/src/worker.ts
+++ b/apps/agent-control-plane/src/worker.ts
@@ -1,12 +1,23 @@
 import { createApp } from "./app.js"
+import { createR2TickSnapshotStore } from "./tick-snapshot-store.js"
 
 interface Env {
   AGENT_CONTROL_PLANE_TOKENS?: string
+  AGENT_TICK_SNAPSHOT_KEY_PREFIX?: string
+  AGENT_TICK_SNAPSHOTS?: R2Bucket
 }
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
-    const app = createApp({ authTokens: parseTokens(env.AGENT_CONTROL_PLANE_TOKENS) })
+    const app = createApp({
+      authTokens: parseTokens(env.AGENT_CONTROL_PLANE_TOKENS),
+      tickSnapshotStore: env.AGENT_TICK_SNAPSHOTS
+        ? createR2TickSnapshotStore({
+            bucket: env.AGENT_TICK_SNAPSHOTS,
+            keyPrefix: env.AGENT_TICK_SNAPSHOT_KEY_PREFIX,
+          })
+        : undefined,
+    })
     return await app.fetch(request)
   },
 } satisfies ExportedHandler<Env>

--- a/apps/agent-control-plane/wrangler.jsonc
+++ b/apps/agent-control-plane/wrangler.jsonc
@@ -9,6 +9,9 @@
   "compatibility_date": "2025-01-01",
   // Configure AGENT_CONTROL_PLANE_TOKENS as a secret before exposing /api/*:
   // pnpm -C apps/agent-control-plane wrangler secret put AGENT_CONTROL_PLANE_TOKENS
+  // Optional: bind an R2 bucket as AGENT_TICK_SNAPSHOTS to store the latest
+  // accepted tick snapshot per repository. Set AGENT_TICK_SNAPSHOT_KEY_PREFIX
+  // when multiple environments share one bucket.
   "observability": {
     "enabled": true
   }

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -386,8 +386,10 @@ machine-readable actions. Tick also tails recent JSONL runner events from
 with linked PRs keep recommending `sync-pr` so the runner can observe
 maintainer merges and mark the item done.
 The Cloudflare-ready control-plane app can accept this JSON at
-`POST /api/tick-snapshots` for validation and summary counts, but that endpoint
-is non-persistent and does not dispatch work.
+`POST /api/tick-snapshots` for validation and summary counts. When the
+control-plane Worker has an R2 binding, it also stores the latest accepted
+snapshot per repository for dashboard and supervisor reads. This still does not
+dispatch work.
 Use `pnpm agent:queue:submit-tick` with `AGENT_CONTROL_PLANE_URL` and
 `AGENT_CONTROL_PLANE_TOKEN` to submit a fresh snapshot. For replayable
 supervisor tests, write `pnpm agent:queue:tick -- --json` to a file and submit

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1319,6 +1319,10 @@ Verification:
   app with `pnpm agent:queue:submit-tick`, using `AGENT_CONTROL_PLANE_URL` and
   `AGENT_CONTROL_PLANE_TOKEN`. This keeps the Cloudflare endpoint exercised
   without adding storage or automatic dispatch yet.
+- The control-plane app can optionally persist the latest accepted tick
+  snapshot per repository to R2 through the `AGENT_TICK_SNAPSHOTS` binding.
+  This gives dashboards and supervisors a durable read model while dispatch
+  remains explicit and runner-owned.
 
 ## Open Questions
 


### PR DESCRIPTION
## Summary

- add optional latest tick snapshot storage behind a small control-plane storage interface
- wire the Worker to an optional `AGENT_TICK_SNAPSHOTS` R2 binding and expose `GET /api/tick-snapshots/latest?repository=<owner/name>`
- keep POST behavior usable without storage, with explicit storage metadata in the response
- document the R2 binding and update the agent orchestration docs

## Verification

- `pnpm -C apps/agent-control-plane test`
- `pnpm -C apps/agent-control-plane typecheck`
- `pnpm --filter @voyantjs/agent-control-plane lint`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- commit hook: changed-file format/secretlint, agent-quality, affected typecheck
- pre-push hook: `pnpm test`
