### PR TITLE
feat(agent-control-plane): plan from latest snapshots

### DIFF
--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -26,6 +26,7 @@ pnpm -C apps/agent-control-plane dev
 - `GET /health`
 - `GET /api/capabilities`
 - `POST /api/dispatch-plans`
+- `POST /api/dispatch-plans/latest`
 - `POST /api/tick-snapshots`
 - `GET /api/tick-snapshots/latest?repository=<owner/name>`
 
@@ -37,6 +38,12 @@ runner allow-list: `start`, `remote-bootstrap`, `collect-ci`,
 planned lifecycle command on a supervisor-specific JSONL ledger. Pass
 `options.updateBody = true` to include `--update-body` when the selected plan is
 `sync-pr`; other actions ignore that option.
+
+`POST /api/dispatch-plans/latest` accepts `{ repository, filters?, options? }`,
+loads the latest stored tick snapshot for that repository, and returns the same
+dispatch plan shape with source metadata. This is the supervisor-friendly path:
+submit snapshots on one cadence, then ask for dispatch plans without reposting
+the full queue payload.
 
 `POST /api/tick-snapshots` accepts the JSON emitted by
 `pnpm agent:queue:tick -- --json`, validates the shape, and returns the accepted

--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -73,6 +73,18 @@ AGENT_CONTROL_PLANE_TOKEN=... \
 pnpm agent:queue:submit-tick -- --input .agent-runs/tick.json
 ```
 
+Request the next plan from the latest stored snapshot with:
+
+```bash
+AGENT_CONTROL_PLANE_URL=https://agent-control-plane.example.workers.dev \
+AGENT_CONTROL_PLANE_TOKEN=... \
+pnpm agent:queue:plan-dispatch -- --repo voyantjs/voyant
+```
+
+Use `--json` when a supervisor needs the response shape directly. Use `--issue`,
+`--action`, `--event-log`, and `--update-body` to pass through the same filters
+and command options as `POST /api/dispatch-plans/latest`.
+
 ## Optional R2 Storage
 
 Bind an R2 bucket as `AGENT_TICK_SNAPSHOTS` to keep the latest accepted tick

--- a/apps/agent-control-plane/src/app.ts
+++ b/apps/agent-control-plane/src/app.ts
@@ -5,7 +5,9 @@ import {
   buildCapabilities,
   buildTickSnapshotRecord,
   dispatchPlanRequestSchema,
+  latestDispatchPlanRequestSchema,
   selectDispatchPlan,
+  selectDispatchPlanFromTickSnapshotRecord,
   tickSnapshotRequestSchema,
 } from "./control-plane.js"
 import type { TickSnapshotStore } from "./tick-snapshot-store.js"
@@ -60,6 +62,35 @@ export function createApp({ authTokens = [], tickSnapshotStore }: AppOptions = {
     }
 
     return c.json(selectDispatchPlan(parsed.data))
+  })
+
+  app.post("/api/dispatch-plans/latest", async (c) => {
+    const parsed = latestDispatchPlanRequestSchema.safeParse(await c.req.json().catch(() => null))
+    if (!parsed.success) {
+      return c.json(
+        {
+          error: "invalid_latest_dispatch_plan_request",
+          issues: validationIssues(parsed.error),
+        },
+        400,
+      )
+    }
+
+    if (!tickSnapshotStore) {
+      return c.json({ error: "tick_snapshot_storage_not_configured" }, 503)
+    }
+
+    const record = await tickSnapshotStore.getLatest(parsed.data.repository)
+    if (!record) {
+      return c.json({ error: "tick_snapshot_not_found" }, 404)
+    }
+
+    return c.json(
+      selectDispatchPlanFromTickSnapshotRecord({
+        record,
+        request: parsed.data,
+      }),
+    )
   })
 
   app.post("/api/tick-snapshots", async (c) => {

--- a/apps/agent-control-plane/src/control-plane.ts
+++ b/apps/agent-control-plane/src/control-plane.ts
@@ -43,24 +43,36 @@ const runnerEventSchema = z
   })
   .passthrough()
 
+const dispatchPlanFiltersSchema = z
+  .object({
+    action: z.string().optional(),
+    issueNumber: z.number().int().positive().optional(),
+  })
+  .optional()
+
+const dispatchPlanOptionsSchema = z
+  .object({
+    eventLog: z.string().min(1).optional(),
+    updateBody: z.boolean().optional(),
+  })
+  .optional()
+
 export const dispatchPlanRequestSchema = z.object({
-  filters: z
-    .object({
-      action: z.string().optional(),
-      issueNumber: z.number().int().positive().optional(),
-    })
-    .optional(),
-  options: z
-    .object({
-      eventLog: z.string().min(1).optional(),
-      updateBody: z.boolean().optional(),
-    })
-    .optional(),
+  filters: dispatchPlanFiltersSchema,
+  options: dispatchPlanOptionsSchema,
   recommendations: z.array(queueRecommendationSchema).min(1),
   repository: z.string().min(1),
 })
 
 export type DispatchPlanRequest = z.infer<typeof dispatchPlanRequestSchema>
+
+export const latestDispatchPlanRequestSchema = z.object({
+  filters: dispatchPlanFiltersSchema,
+  options: dispatchPlanOptionsSchema,
+  repository: z.string().min(1),
+})
+
+export type LatestDispatchPlanRequest = z.infer<typeof latestDispatchPlanRequestSchema>
 
 export const tickSnapshotRequestSchema = z.object({
   eventLog: z.object({
@@ -110,6 +122,15 @@ export interface DispatchPlanResult {
   reason: string
 }
 
+export interface StoredDispatchPlanResult extends DispatchPlanResult {
+  source: {
+    acceptedAt: string
+    recommendationCount: number
+    repository: string
+    type: "latest_tick_snapshot"
+  }
+}
+
 export function buildCapabilities({
   tickSnapshotPersistence = "none",
 }: {
@@ -135,6 +156,10 @@ export function buildCapabilities({
         version: 1,
         persistence: tickSnapshotPersistence,
       },
+    },
+    dispatchPlanSources: {
+      inlineRecommendations: true,
+      latestTickSnapshot: tickSnapshotPersistence === "latest",
     },
   }
 }
@@ -220,6 +245,31 @@ export function selectDispatchPlan(request: DispatchPlanRequest): DispatchPlanRe
       requiresMutation: true,
     },
     reason: "matched",
+  }
+}
+
+export function selectDispatchPlanFromTickSnapshotRecord({
+  record,
+  request,
+}: {
+  record: TickSnapshotRecord
+  request: LatestDispatchPlanRequest
+}): StoredDispatchPlanResult {
+  const result = selectDispatchPlan({
+    filters: request.filters,
+    options: request.options,
+    recommendations: record.snapshot.recommendations,
+    repository: request.repository,
+  })
+
+  return {
+    ...result,
+    source: {
+      acceptedAt: record.acceptedAt,
+      recommendationCount: record.summary.recommendationCount,
+      repository: record.snapshot.repository,
+      type: "latest_tick_snapshot",
+    },
   }
 }
 

--- a/apps/agent-control-plane/src/latest-dispatch-plan.test.ts
+++ b/apps/agent-control-plane/src/latest-dispatch-plan.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest"
+
+import { createApp } from "./app.js"
+import { buildTickSnapshotRecord, type TickSnapshotRecord } from "./control-plane.js"
+import type { TickSnapshotStore } from "./tick-snapshot-store.js"
+
+const tickSnapshot = {
+  project: {
+    owner: "voyantjs",
+    number: 1,
+    title: "Voyant Engineering",
+    url: "https://github.com/orgs/voyantjs/projects/1",
+  },
+  repository: "voyantjs/voyant",
+  maxAgeDays: 1,
+  eventLog: {
+    path: "/repo/.agent-runs/events.jsonl",
+    recentEvents: [],
+  },
+  recommendations: [
+    {
+      action: "remote-bootstrap",
+      command: "pnpm agent:queue:remote-bootstrap -- --issue 579 --repo voyantjs/voyant --yes",
+      issue: {
+        number: 579,
+        title: "Test agent project intake workflow",
+        url: "https://github.com/voyantjs/voyant/issues/579",
+        repository: "voyantjs/voyant",
+      },
+      priority: 20,
+      reason: "remote workspace is ready for repository bootstrap",
+      state: "Ready",
+    },
+    {
+      action: "remote-run-command",
+      command:
+        'pnpm agent:queue:remote-run-command -- --issue 580 --repo voyantjs/voyant --command "<implementation-command>" --yes',
+      issue: {
+        number: 580,
+        title: "Run implementation",
+        url: "https://github.com/voyantjs/voyant/issues/580",
+        repository: "voyantjs/voyant",
+      },
+      priority: 30,
+      reason: "implementation execution remains explicit",
+      state: "Planning",
+    },
+  ],
+}
+
+describe("latest dispatch planning", () => {
+  it("plans dispatch from the latest stored tick snapshot", async () => {
+    const app = createApp({
+      authTokens: ["secret"],
+      tickSnapshotStore: inMemoryTickSnapshotStore([
+        buildTickSnapshotRecord(tickSnapshot, {
+          acceptedAt: "2026-05-12T05:00:00.000Z",
+        }),
+      ]),
+    })
+
+    const response = await app.request("/api/dispatch-plans/latest", {
+      method: "POST",
+      headers: { authorization: "Bearer secret", "content-type": "application/json" },
+      body: JSON.stringify({
+        filters: {
+          action: "remote-bootstrap",
+          issueNumber: 579,
+        },
+        options: {
+          eventLog: ".agent-runs/supervisor.jsonl",
+        },
+        repository: "VoyantJS/Voyant",
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      reason: "matched",
+      source: {
+        acceptedAt: "2026-05-12T05:00:00.000Z",
+        recommendationCount: 2,
+        repository: "voyantjs/voyant",
+        type: "latest_tick_snapshot",
+      },
+      plan: {
+        action: "remote-bootstrap",
+        command: [
+          "pnpm",
+          "agent:queue:remote-bootstrap",
+          "--",
+          "--issue",
+          "579",
+          "--repo",
+          "VoyantJS/Voyant",
+          "--yes",
+          "--event-log",
+          ".agent-runs/supervisor.jsonl",
+        ],
+        issue: tickSnapshot.recommendations[0]?.issue,
+        reason: "remote workspace is ready for repository bootstrap",
+        repository: "VoyantJS/Voyant",
+        requiresMutation: true,
+      },
+    })
+  })
+
+  it("returns no plan when the stored snapshot has no matching dispatchable recommendation", async () => {
+    const app = createApp({
+      authTokens: ["secret"],
+      tickSnapshotStore: inMemoryTickSnapshotStore([buildTickSnapshotRecord(tickSnapshot)]),
+    })
+
+    const response = await app.request("/api/dispatch-plans/latest", {
+      method: "POST",
+      headers: { authorization: "Bearer secret", "content-type": "application/json" },
+      body: JSON.stringify({
+        filters: {
+          action: "remote-run-command",
+        },
+        repository: "voyantjs/voyant",
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      reason: "action remote-run-command is not dispatchable",
+      plan: null,
+      source: {
+        repository: "voyantjs/voyant",
+        type: "latest_tick_snapshot",
+      },
+    })
+  })
+
+  it("requires storage, a repository, and a stored snapshot", async () => {
+    const noStore = createApp({ authTokens: ["secret"] })
+    const noStoreResponse = await noStore.request("/api/dispatch-plans/latest", {
+      method: "POST",
+      headers: { authorization: "Bearer secret", "content-type": "application/json" },
+      body: JSON.stringify({ repository: "voyantjs/voyant" }),
+    })
+    expect(noStoreResponse.status).toBe(503)
+    await expect(noStoreResponse.json()).resolves.toEqual({
+      error: "tick_snapshot_storage_not_configured",
+    })
+
+    const app = createApp({
+      authTokens: ["secret"],
+      tickSnapshotStore: inMemoryTickSnapshotStore(),
+    })
+    const invalid = await app.request("/api/dispatch-plans/latest", {
+      method: "POST",
+      headers: { authorization: "Bearer secret", "content-type": "application/json" },
+      body: JSON.stringify({}),
+    })
+    expect(invalid.status).toBe(400)
+    await expect(invalid.json()).resolves.toMatchObject({
+      error: "invalid_latest_dispatch_plan_request",
+    })
+
+    const missingSnapshot = await app.request("/api/dispatch-plans/latest", {
+      method: "POST",
+      headers: { authorization: "Bearer secret", "content-type": "application/json" },
+      body: JSON.stringify({ repository: "voyantjs/voyant" }),
+    })
+    expect(missingSnapshot.status).toBe(404)
+    await expect(missingSnapshot.json()).resolves.toEqual({ error: "tick_snapshot_not_found" })
+  })
+})
+
+function inMemoryTickSnapshotStore(records: TickSnapshotRecord[] = []): TickSnapshotStore {
+  const latest = new Map(
+    records.map((record) => [record.snapshot.repository.toLowerCase(), record]),
+  )
+
+  return {
+    async getLatest(repository) {
+      return latest.get(repository.toLowerCase()) ?? null
+    },
+    async putLatest(record) {
+      latest.set(record.snapshot.repository.toLowerCase(), record)
+      return { key: `latest/${record.snapshot.repository.toLowerCase()}.json` }
+    },
+  }
+}

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -390,6 +390,10 @@ The Cloudflare-ready control-plane app can accept this JSON at
 control-plane Worker has an R2 binding, it also stores the latest accepted
 snapshot per repository for dashboard and supervisor reads. This still does not
 dispatch work.
+After a snapshot is stored, a supervisor can call
+`POST /api/dispatch-plans/latest` with `{ repository, filters?, options? }` to
+plan the next allow-listed lifecycle command from that stored snapshot without
+resubmitting the full tick payload.
 Use `pnpm agent:queue:submit-tick` with `AGENT_CONTROL_PLANE_URL` and
 `AGENT_CONTROL_PLANE_TOKEN` to submit a fresh snapshot. For replayable
 supervisor tests, write `pnpm agent:queue:tick -- --json` to a file and submit

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -398,6 +398,10 @@ Use `pnpm agent:queue:submit-tick` with `AGENT_CONTROL_PLANE_URL` and
 `AGENT_CONTROL_PLANE_TOKEN` to submit a fresh snapshot. For replayable
 supervisor tests, write `pnpm agent:queue:tick -- --json` to a file and submit
 it with `pnpm agent:queue:submit-tick -- --input <path>`.
+Use `pnpm agent:queue:plan-dispatch` with the same control-plane environment to
+request the next read-only dispatch plan from the latest stored snapshot. Pass
+`--json` for supervisors, or `--issue`, `--action`, `--event-log`, and
+`--update-body` to shape the returned lifecycle command.
 `CI Repair` items with failing linked PRs recommend `collect-ci` until a local
 CI repair packet exists. Ready items with `sandbox:<provider>:<id>` workspaces
 recommend `remote-bootstrap` so dispatch can clone/fetch the repository and

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1323,6 +1323,10 @@ Verification:
   snapshot per repository to R2 through the `AGENT_TICK_SNAPSHOTS` binding.
   This gives dashboards and supervisors a durable read model while dispatch
   remains explicit and runner-owned.
+- The control-plane app can also plan dispatch from that latest stored snapshot
+  with `POST /api/dispatch-plans/latest`. This keeps the write path split:
+  runners submit observed queue state, supervisors request safe lifecycle plans,
+  and actual command execution remains outside the Worker.
 
 ## Open Questions
 

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1327,6 +1327,10 @@ Verification:
   with `POST /api/dispatch-plans/latest`. This keeps the write path split:
   runners submit observed queue state, supervisors request safe lifecycle plans,
   and actual command execution remains outside the Worker.
+- The runner can request that read-only plan with
+  `pnpm agent:queue:plan-dispatch`, using the same control-plane URL and token
+  as snapshot submission. It prints the planned lifecycle command or JSON for a
+  supervisor, but does not execute the mutation.
 
 ## Open Questions
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "agent:queue:status": "node scripts/agent-runner-status.mjs",
     "agent:queue:tick": "node scripts/agent-runner-tick.mjs",
     "agent:queue:submit-tick": "node scripts/agent-runner-submit-tick.mjs",
+    "agent:queue:plan-dispatch": "node scripts/agent-runner-plan-dispatch.mjs",
     "agent:queue:dispatch": "node scripts/agent-runner-dispatch.mjs",
     "agent:queue:loop": "node scripts/agent-runner-loop.mjs",
     "agent:queue:remote-inspect": "node scripts/agent-runner-remote-inspect.mjs",

--- a/scripts/agent-runner-plan-dispatch.mjs
+++ b/scripts/agent-runner-plan-dispatch.mjs
@@ -1,0 +1,112 @@
+import { currentRepositoryFromOrigin, fail, parseArgs, runGit } from "./lib/agent-project-queue.mjs"
+import {
+  controlPlaneConfigFromArgs,
+  requestLatestDispatchPlan,
+} from "./lib/agent-runner-control-plane.mjs"
+import { dispatchableActions } from "./lib/agent-runner-dispatch.mjs"
+import { eventLogOptions, maybePrintHelp, repositoryOptions } from "./lib/agent-runner-help.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:plan-dispatch",
+  summary: "Request the next dispatch plan from the control plane's latest stored tick snapshot.",
+  usage: "pnpm agent:queue:plan-dispatch -- [--repo <owner/name>] [--json]",
+  options: [
+    ["--control-plane-url <url>", "Control-plane base URL. Defaults to AGENT_CONTROL_PLANE_URL."],
+    ["AGENT_CONTROL_PLANE_TOKEN", "Bearer token environment variable used for API routes."],
+    ["--issue <number>", "Only plan a recommendation for this issue number."],
+    [
+      "--action <name>",
+      `Only plan this action. Allowed: ${Array.from(dispatchableActions).join(", ")}.`,
+    ],
+    ...eventLogOptions,
+    ["--update-body", "When planning sync-pr, include --update-body in the returned command."],
+    ["--json", "Print machine-readable JSON."],
+    ...repositoryOptions,
+  ],
+})
+
+const repository =
+  args.repo ?? currentRepositoryFromOrigin(runGit(["rev-parse", "--show-toplevel"]))
+
+if (args.action && !dispatchableActions.has(args.action)) {
+  fail(`action ${args.action} is not dispatchable`)
+}
+
+const issueNumber = optionalPositiveInteger(args.issue, "issue")
+const request = {
+  repository,
+  ...(issueNumber || args.action
+    ? {
+        filters: {
+          ...(args.action ? { action: args.action } : {}),
+          ...(issueNumber ? { issueNumber } : {}),
+        },
+      }
+    : {}),
+  ...(args.eventLog || args.updateBody
+    ? {
+        options: {
+          ...(args.eventLog ? { eventLog: args.eventLog } : {}),
+          ...(args.updateBody ? { updateBody: true } : {}),
+        },
+      }
+    : {}),
+}
+const config = readControlPlaneConfig()
+
+try {
+  const result = await requestLatestDispatchPlan({
+    request,
+    token: config.token,
+    url: config.url,
+  })
+
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2))
+  } else {
+    printPlan({ controlPlaneUrl: config.url, result })
+  }
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error))
+}
+
+function printPlan({ controlPlaneUrl, result }) {
+  console.log("agent-runner latest dispatch plan")
+  console.log(`control plane: ${controlPlaneUrl}`)
+  console.log(`repository: ${result.source?.repository ?? repository}`)
+  if (result.source?.acceptedAt) {
+    console.log(`snapshot accepted: ${result.source.acceptedAt}`)
+  }
+  if (Number.isInteger(result.source?.recommendationCount)) {
+    console.log(`snapshot recommendations: ${result.source.recommendationCount}`)
+  }
+
+  if (!result.plan) {
+    console.log(`plan: none (${result.reason})`)
+    return
+  }
+
+  console.log(`issue: #${result.plan.issue.number} ${result.plan.issue.title}`)
+  console.log(`action: ${result.plan.action}`)
+  console.log(`reason: ${result.plan.reason}`)
+  console.log(`command: ${result.plan.command.join(" ")}`)
+}
+
+function readControlPlaneConfig() {
+  try {
+    return controlPlaneConfigFromArgs(args)
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error))
+  }
+}
+
+function optionalPositiveInteger(value, name) {
+  if (value === undefined) return undefined
+
+  const number = Number(value)
+  if (!Number.isInteger(number) || number < 1) {
+    fail(`invalid ${name}: ${value}`)
+  }
+  return number
+}

--- a/scripts/lib/agent-runner-control-plane.mjs
+++ b/scripts/lib/agent-runner-control-plane.mjs
@@ -39,6 +39,27 @@ export async function submitTickSnapshot({ fetchImpl = fetch, snapshot, token, u
   return body
 }
 
+export async function requestLatestDispatchPlan({ fetchImpl = fetch, request, token, url }) {
+  const response = await fetchImpl(`${normalizeControlPlaneUrl(url)}/api/dispatch-plans/latest`, {
+    body: JSON.stringify(request),
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    method: "POST",
+  })
+
+  const bodyText = await response.text()
+  const body = parseJsonBody(bodyText)
+
+  if (!response.ok) {
+    const detail = body?.error ? `: ${body.error}` : bodyText ? `: ${bodyText}` : ""
+    throw new Error(`control plane rejected latest dispatch plan with ${response.status}${detail}`)
+  }
+
+  return body
+}
+
 function normalizeControlPlaneUrl(url) {
   return String(url).replace(/\/+$/, "")
 }

--- a/scripts/tests/agent-runner-control-plane.test.mjs
+++ b/scripts/tests/agent-runner-control-plane.test.mjs
@@ -3,6 +3,7 @@ import { describe, it } from "node:test"
 
 import {
   controlPlaneConfigFromArgs,
+  requestLatestDispatchPlan,
   submitTickSnapshot,
 } from "../lib/agent-runner-control-plane.mjs"
 
@@ -75,6 +76,96 @@ describe("agent runner control plane client", () => {
         url: "https://control.example.com",
       }),
       /400: invalid_tick_snapshot_request/,
+    )
+  })
+
+  it("requests latest dispatch plans from stored snapshots", async () => {
+    const calls = []
+    const response = await requestLatestDispatchPlan({
+      fetchImpl: async (url, init) => {
+        calls.push({ init, url })
+        return new Response(
+          JSON.stringify({
+            plan: {
+              action: "remote-bootstrap",
+              command: [
+                "pnpm",
+                "agent:queue:remote-bootstrap",
+                "--",
+                "--issue",
+                "579",
+                "--repo",
+                "voyantjs/voyant",
+                "--yes",
+              ],
+              issue: {
+                number: 579,
+                repository: "voyantjs/voyant",
+                title: "Test issue",
+                url: "https://github.com/voyantjs/voyant/issues/579",
+              },
+              reason: "ready",
+              repository: "voyantjs/voyant",
+              requiresMutation: true,
+            },
+            reason: "matched",
+            source: {
+              acceptedAt: "2026-05-12T12:00:00.000Z",
+              recommendationCount: 1,
+              repository: "voyantjs/voyant",
+              type: "latest_tick_snapshot",
+            },
+          }),
+          { status: 200 },
+        )
+      },
+      request: {
+        filters: {
+          action: "remote-bootstrap",
+          issueNumber: 579,
+        },
+        options: {
+          eventLog: ".agent-runs/events.jsonl",
+        },
+        repository: "voyantjs/voyant",
+      },
+      token: "tok",
+      url: "https://control.example.com/",
+    })
+
+    assert.equal(response.plan.action, "remote-bootstrap")
+    assert.equal(response.source.type, "latest_tick_snapshot")
+    assert.equal(calls[0].url, "https://control.example.com/api/dispatch-plans/latest")
+    assert.equal(calls[0].init.method, "POST")
+    assert.equal(calls[0].init.headers.authorization, "Bearer tok")
+    assert.equal(calls[0].init.headers["content-type"], "application/json")
+    assert.equal(
+      calls[0].init.body,
+      JSON.stringify({
+        filters: {
+          action: "remote-bootstrap",
+          issueNumber: 579,
+        },
+        options: {
+          eventLog: ".agent-runs/events.jsonl",
+        },
+        repository: "voyantjs/voyant",
+      }),
+    )
+  })
+
+  it("surfaces rejected latest dispatch plan responses", async () => {
+    await assert.rejects(
+      requestLatestDispatchPlan({
+        fetchImpl: async () =>
+          new Response(JSON.stringify({ error: "latest_tick_snapshot_not_found" }), {
+            status: 404,
+          }),
+        request: { repository: "voyantjs/voyant" },
+        token: "tok",
+        url: "https://control.example.com",
+      }),
+      /404: latest_tick_snapshot_not_found/,
     )
   })
 })


### PR DESCRIPTION
## Summary

- add `POST /api/dispatch-plans/latest` so supervisors can plan from the latest stored tick snapshot
- reuse dispatch filters/options across inline and latest-snapshot planning
- include latest snapshot source metadata in stored dispatch-plan responses
- add `pnpm agent:queue:plan-dispatch` to request the latest stored dispatch plan without executing mutations
- document the supervisor-friendly snapshot submit/read/plan flow

## Verification

- `pnpm agent:queue:test`
- `pnpm -C apps/agent-control-plane test`
- `pnpm -C apps/agent-control-plane typecheck`
- `pnpm --filter @voyantjs/agent-control-plane lint`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- commit hook: changed-file format/secretlint, agent-quality, affected typecheck
- pre-push hook: `pnpm test`