### PR TITLE
Validate legal template Liquid syntax

### DIFF
--- a/.changeset/legal-template-liquid-validation.md
+++ b/.changeset/legal-template-liquid-validation.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/legal": patch
+"@voyantjs/utils": patch
+---
+
+Validate Liquid syntax in legal contract template bodies before save or preview so rich-text-split tags return structured template errors instead of render-time failures.

--- a/packages/legal/src/contracts/index.ts
+++ b/packages/legal/src/contracts/index.ts
@@ -51,8 +51,11 @@ export {
 } from "./schema.js"
 export {
   allocateContractNumber,
+  ContractTemplateSyntaxError,
   contractsService,
+  isContractTemplateSyntaxError,
   renderTemplate,
+  validateContractTemplateBody,
   validateTemplateVariables,
 } from "./service.js"
 export type {

--- a/packages/legal/src/contracts/route-template-preview.ts
+++ b/packages/legal/src/contracts/route-template-preview.ts
@@ -1,0 +1,31 @@
+import type { Context } from "hono"
+
+import { contractsService } from "./service.js"
+import { isContractTemplateSyntaxError, type RenderTemplateInput } from "./service-shared.js"
+
+export function contractTemplateSyntaxResponse(c: Context, error: unknown) {
+  if (!isContractTemplateSyntaxError(error)) {
+    throw error
+  }
+
+  return c.json(
+    {
+      error: error.message,
+      issues: error.issues,
+    },
+    400,
+  )
+}
+
+export function renderPreviewResponse(
+  c: Context,
+  input: RenderTemplateInput,
+  extraData: Record<string, unknown> = {},
+) {
+  try {
+    const rendered = contractsService.renderPreview(input)
+    return c.json({ data: { ...extraData, rendered } })
+  } catch (error) {
+    return contractTemplateSyntaxResponse(c, error)
+  }
+}

--- a/packages/legal/src/contracts/routes.ts
+++ b/packages/legal/src/contracts/routes.ts
@@ -10,6 +10,7 @@ import {
   CONTRACTS_ROUTE_RUNTIME_CONTAINER_KEY,
   type ContractsRouteRuntime,
 } from "./route-runtime.js"
+import { renderPreviewResponse } from "./route-template-preview.js"
 import { contractsService } from "./service.js"
 import {
   contractListQuerySchema,
@@ -213,8 +214,7 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
       const template = await contractsService.getTemplateById(c.get("db"), c.req.param("id"))
       if (!template) return c.json({ error: "Template not found" }, 404)
       const body = input.body ?? template.body
-      const rendered = contractsService.renderPreview({ ...input, body })
-      return c.json({ data: { rendered } })
+      return renderPreviewResponse(c, { ...input, body })
     })
     .get("/templates/:id/versions", async (c) => {
       const rows = await contractsService.listTemplateVersions(c.get("db"), c.req.param("id"))
@@ -342,8 +342,7 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
       const input = await parseJsonBody(c, renderTemplateInputSchema)
       const contract = await contractsService.getContractById(c.get("db"), c.req.param("id"))
       if (!contract) return c.json({ error: "Contract not found" }, 404)
-      const rendered = contractsService.renderPreview(input)
-      return c.json({ data: { rendered } })
+      return renderPreviewResponse(c, input)
     })
     .post("/:id/generate-document", async (c) => {
       const runtime = getRuntime(options, c.env, (key) => c.var.container?.resolve(key))
@@ -538,11 +537,10 @@ export function createContractsPublicRoutes() {
         const input = await parseJsonBody(c, publicRenderTemplatePreviewInputSchema)
         const template = await contractsService.getTemplateById(c.get("db"), c.req.param("id"))
         if (!template?.active) return c.json({ error: "Template not found" }, 404)
-        const rendered = contractsService.renderPreview({
+        return renderPreviewResponse(c, {
           variables: input.variables,
           body: template.body,
         })
-        return c.json({ data: { rendered } })
       })
       /**
        * Slug-based variant — storefronts wire products to a contract
@@ -554,12 +552,13 @@ export function createContractsPublicRoutes() {
         const input = await parseJsonBody(c, publicRenderTemplatePreviewInputSchema)
         const template = await contractsService.findTemplateBySlug(c.get("db"), c.req.param("slug"))
         if (!template?.active) return c.json({ error: "Template not found" }, 404)
-        const rendered = contractsService.renderPreview({
-          variables: input.variables,
-          body: template.body,
-        })
-        return c.json({
-          data: {
+        return renderPreviewResponse(
+          c,
+          {
+            variables: input.variables,
+            body: template.body,
+          },
+          {
             template: {
               id: template.id,
               slug: template.slug,
@@ -567,9 +566,8 @@ export function createContractsPublicRoutes() {
               language: template.language,
               scope: template.scope,
             },
-            rendered,
           },
-        })
+        )
       })
       .get("/:id", async (c) => {
         const row = await contractsService.getContractById(c.get("db"), c.req.param("id"))

--- a/packages/legal/src/contracts/service-documents.ts
+++ b/packages/legal/src/contracts/service-documents.ts
@@ -7,7 +7,7 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { contractAttachments, contracts, contractTemplateVersions } from "./schema.js"
 import { contractRecordsService } from "./service-contracts.js"
 import type { CreateContractAttachmentInput } from "./service-shared.js"
-import { renderTemplate } from "./service-shared.js"
+import { isContractTemplateSyntaxError, renderTemplate } from "./service-shared.js"
 import type { GenerateContractDocumentInput } from "./validation.js"
 
 export interface GeneratedContractDocumentArtifact {
@@ -267,7 +267,15 @@ async function ensureRenderedContract(
   }
 
   if (contract.status === "draft" && issueIfDraft) {
-    const issued = await contractRecordsService.issueContract(db, contractId)
+    let issued: Awaited<ReturnType<typeof contractRecordsService.issueContract>>
+    try {
+      issued = await contractRecordsService.issueContract(db, contractId)
+    } catch (error) {
+      if (isContractTemplateSyntaxError(error)) {
+        return { status: "render_unavailable" as const, contract, templateVersion: null }
+      }
+      throw error
+    }
     if (issued.status !== "issued" || !issued.contract) {
       if (issued.status === "not_found") {
         return { status: "not_found" }
@@ -283,7 +291,14 @@ async function ensureRenderedContract(
 
   if ((!renderedBody || !renderedBodyFormat) && templateVersion) {
     const variables = (contract.variables as Record<string, unknown> | null) ?? {}
-    renderedBody = renderTemplate(templateVersion.body, "html", variables)
+    try {
+      renderedBody = renderTemplate(templateVersion.body, "html", variables)
+    } catch (error) {
+      if (isContractTemplateSyntaxError(error)) {
+        return { status: "render_unavailable" as const, contract, templateVersion }
+      }
+      throw error
+    }
     renderedBodyFormat = "html"
 
     const [updated] = await db

--- a/packages/legal/src/contracts/service-shared.ts
+++ b/packages/legal/src/contracts/service-shared.ts
@@ -1,4 +1,8 @@
-import { renderStructuredTemplate } from "@voyantjs/utils/template-renderer"
+import {
+  renderStructuredTemplate,
+  type TemplateSyntaxIssue,
+  validateStructuredTemplateSyntax,
+} from "@voyantjs/utils/template-renderer"
 import { sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
@@ -77,11 +81,39 @@ function resolvePath(obj: unknown, path: string): unknown {
  */
 const CONTRACT_MISSING_VALUE_PLACEHOLDER = "-"
 
+export class ContractTemplateSyntaxError extends Error {
+  readonly issues: TemplateSyntaxIssue[]
+
+  constructor(issues: TemplateSyntaxIssue[]) {
+    super("Contract template contains invalid Liquid syntax")
+    this.name = "ContractTemplateSyntaxError"
+    this.issues = issues
+  }
+}
+
+export function isContractTemplateSyntaxError(
+  error: unknown,
+): error is ContractTemplateSyntaxError {
+  return error instanceof ContractTemplateSyntaxError
+}
+
+export function validateContractTemplateBody(body: string): void {
+  const issues = validateStructuredTemplateSyntax(body, "html")
+  if (issues.length > 0) {
+    throw new ContractTemplateSyntaxError(issues)
+  }
+}
+
 export function renderTemplate(
   body: string,
   bodyFormat: "markdown" | "html" | "lexical_json",
   variables: Record<string, unknown>,
 ): string {
+  const issues = validateStructuredTemplateSyntax(body, bodyFormat)
+  if (issues.length > 0) {
+    throw new ContractTemplateSyntaxError(issues)
+  }
+
   return renderStructuredTemplate(body, bodyFormat, variables, {
     missingValuePlaceholder: CONTRACT_MISSING_VALUE_PLACEHOLDER,
   })

--- a/packages/legal/src/contracts/service-templates.ts
+++ b/packages/legal/src/contracts/service-templates.ts
@@ -10,6 +10,7 @@ import {
   type RenderTemplateInput,
   renderTemplate,
   type UpdateContractTemplateInput,
+  validateContractTemplateBody,
 } from "./service-shared.js"
 
 export const contractTemplatesService = {
@@ -101,6 +102,7 @@ export const contractTemplatesService = {
     return rows[0] ?? null
   },
   async createTemplate(db: PostgresJsDatabase, data: CreateContractTemplateInput) {
+    validateContractTemplateBody(data.body)
     const [row] = await db.insert(contractTemplates).values(data).returning()
     return row ?? null
   },
@@ -120,6 +122,10 @@ export const contractTemplatesService = {
    * out of sync with the versions table.
    */
   async updateTemplate(db: PostgresJsDatabase, id: string, data: UpdateContractTemplateInput) {
+    if (typeof data.body === "string") {
+      validateContractTemplateBody(data.body)
+    }
+
     return db.transaction(async (tx) => {
       // Read the current row first so we can detect whether the body
       // actually changed. Without this we'd version-bump on every
@@ -199,6 +205,8 @@ export const contractTemplatesService = {
     templateId: string,
     data: CreateContractTemplateVersionInput,
   ) {
+    validateContractTemplateBody(data.body)
+
     return db.transaction(async (tx) => {
       const [template] = await tx
         .select({ id: contractTemplates.id })
@@ -233,6 +241,7 @@ export const contractTemplatesService = {
   },
   renderPreview(input: RenderTemplateInput): string {
     const body = input.body ?? ""
+    validateContractTemplateBody(body)
     return renderTemplate(body, "html", input.variables)
   },
 }

--- a/packages/legal/src/contracts/service.ts
+++ b/packages/legal/src/contracts/service.ts
@@ -3,12 +3,22 @@ import { contractDocumentsService } from "./service-documents.js"
 import { contractSeriesService } from "./service-series.js"
 import {
   allocateContractNumber,
+  ContractTemplateSyntaxError,
+  isContractTemplateSyntaxError,
   renderTemplate,
+  validateContractTemplateBody,
   validateTemplateVariables,
 } from "./service-shared.js"
 import { contractTemplatesService } from "./service-templates.js"
 
-export { allocateContractNumber, renderTemplate, validateTemplateVariables }
+export {
+  allocateContractNumber,
+  ContractTemplateSyntaxError,
+  isContractTemplateSyntaxError,
+  renderTemplate,
+  validateContractTemplateBody,
+  validateTemplateVariables,
+}
 
 export const contractsService = {
   ...contractTemplatesService,

--- a/packages/legal/src/contracts/validation.ts
+++ b/packages/legal/src/contracts/validation.ts
@@ -1,3 +1,4 @@
+import { validateStructuredTemplateSyntax } from "@voyantjs/utils/template-renderer"
 import { z } from "zod"
 
 export const contractScopeSchema = z.enum(["customer", "supplier", "partner", "channel", "other"])
@@ -23,6 +24,18 @@ const paginationSchema = z.object({
   offset: z.coerce.number().int().min(0).default(0),
 })
 
+const contractTemplateBodySchema = z
+  .string()
+  .min(1)
+  .superRefine((body, ctx) => {
+    for (const issue of validateStructuredTemplateSyntax(body, "html")) {
+      ctx.addIssue({
+        code: "custom",
+        message: `invalid Liquid syntax: ${issue.message}`,
+      })
+    }
+  })
+
 // ---------- contract templates ----------
 
 const contractTemplateCoreSchema = z.object({
@@ -35,7 +48,7 @@ const contractTemplateCoreSchema = z.object({
   scope: contractScopeSchema,
   language: z.string().min(2).max(10).default("en"),
   description: z.string().max(2000).optional().nullable(),
-  body: z.string().min(1),
+  body: contractTemplateBodySchema,
   variableSchema: z.record(z.string(), z.unknown()).optional().nullable(),
   active: z.boolean().default(true),
 })
@@ -69,7 +82,7 @@ export const contractTemplateDefaultQuerySchema = z.object({
 // ---------- contract template versions ----------
 
 export const insertContractTemplateVersionSchema = z.object({
-  body: z.string().min(1),
+  body: contractTemplateBodySchema,
   variableSchema: z.record(z.string(), z.unknown()).optional().nullable(),
   changelog: z.string().max(2000).optional().nullable(),
   createdBy: z.string().max(255).optional().nullable(),

--- a/packages/legal/tests/unit/render-template.test.ts
+++ b/packages/legal/tests/unit/render-template.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest"
 
-import { renderTemplate, validateTemplateVariables } from "../../src/contracts/service.js"
+import {
+  ContractTemplateSyntaxError,
+  renderTemplate,
+  validateContractTemplateBody,
+  validateTemplateVariables,
+} from "../../src/contracts/service.js"
 
 /**
  * Unit tests for `renderTemplate` and `validateTemplateVariables`.
@@ -260,5 +265,29 @@ describe("validateTemplateVariables", () => {
   it("ignores non-array required field", () => {
     const schema = { required: "not an array" }
     expect(validateTemplateVariables(schema, {})).toEqual([])
+  })
+})
+
+describe("validateContractTemplateBody", () => {
+  it("accepts valid contract Liquid bodies", () => {
+    expect(() =>
+      validateContractTemplateBody(
+        "{% if contract.signed_at %}{{ contract.signed_at | format_date }}{% endif %}",
+      ),
+    ).not.toThrow()
+  })
+
+  it("rejects rich-text-split Liquid output tags before rendering", () => {
+    expect(() =>
+      validateContractTemplateBody('{{ </p><p>contract.signed_at | default: "-" }}'),
+    ).toThrow(ContractTemplateSyntaxError)
+  })
+
+  it("renderTemplate reports malformed Liquid as a template syntax error", () => {
+    expect(() =>
+      renderTemplate('{{ </p><p>contract.signed_at | default: "-" }}', "html", {
+        contract: { signed_at: "2026-05-12" },
+      }),
+    ).toThrow(ContractTemplateSyntaxError)
   })
 })

--- a/packages/legal/tests/unit/service-documents.test.ts
+++ b/packages/legal/tests/unit/service-documents.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ContractTemplateSyntaxError } from "../../src/contracts/service-shared.js"
+
+const contractRecordMocks = vi.hoisted(() => ({
+  getContractById: vi.fn(),
+  issueContract: vi.fn(),
+}))
+
+vi.mock("../../src/contracts/service-contracts.js", () => ({
+  contractRecordsService: {
+    getContractById: contractRecordMocks.getContractById,
+    issueContract: contractRecordMocks.issueContract,
+  },
+}))
+
+import {
+  type ContractDocumentGenerator,
+  contractDocumentsService,
+} from "../../src/contracts/service-documents.js"
+
+describe("contractDocumentsService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("returns render_unavailable when draft auto-issue hits invalid template syntax", async () => {
+    contractRecordMocks.getContractById.mockResolvedValue({
+      id: "cont_draft",
+      status: "draft",
+      templateVersionId: "ctv_bad",
+      renderedBody: null,
+      renderedBodyFormat: "html",
+      variables: {},
+    })
+    contractRecordMocks.issueContract.mockRejectedValue(
+      new ContractTemplateSyntaxError([{ message: "expected variable name" }]),
+    )
+    const generator = vi.fn<ContractDocumentGenerator>()
+
+    const result = await contractDocumentsService.generateContractDocument(
+      {} as never,
+      "cont_draft",
+      {
+        kind: "document",
+        replaceExisting: true,
+        issueIfDraft: true,
+      },
+      { generator },
+    )
+
+    expect(result).toEqual({ status: "render_unavailable" })
+    expect(generator).not.toHaveBeenCalled()
+  })
+})

--- a/packages/utils/src/template-renderer.ts
+++ b/packages/utils/src/template-renderer.ts
@@ -153,6 +153,10 @@ export interface RenderTemplateOptions {
   missingValuePlaceholder?: string
 }
 
+export interface TemplateSyntaxIssue {
+  message: string
+}
+
 function stringifyValue(value: unknown, placeholder?: string): string {
   if (value === null || value === undefined) return placeholder ?? ""
   if (typeof value === "string") {
@@ -166,6 +170,7 @@ const MUSTACHE_RE = /\{\{\s*([^}]+?)\s*\}\}/g
 const LIQUID_CONTROL_RE = /\{%-?[\s\S]*?-?%\}/
 const LIQUID_FILTER_RE = /\{\{[\s\S]*\|[\s\S]*\}\}/
 const LIQUID_OUTPUT_RE = /\{\{\s*([^}]+?)\s*\}\}/g
+const LIQUID_DELIMITER_RE = /\{\{|\{%/
 const HAS_DEFAULT_FILTER_RE = /\|\s*default\s*:/i
 
 /**
@@ -197,6 +202,69 @@ export function renderMustacheTemplate(
 
 function shouldUseLiquid(body: string) {
   return LIQUID_CONTROL_RE.test(body) || LIQUID_FILTER_RE.test(body)
+}
+
+function validateStringTemplateSyntax(body: string): TemplateSyntaxIssue[] {
+  if (!LIQUID_DELIMITER_RE.test(body)) return []
+
+  try {
+    liquid.parse(body)
+    return []
+  } catch (error) {
+    return [{ message: error instanceof Error ? error.message : String(error) }]
+  }
+}
+
+function collectLexicalTextIssues(node: LexicalNode, issues: TemplateSyntaxIssue[]) {
+  if (typeof node.text === "string") {
+    issues.push(...validateStringTemplateSyntax(node.text))
+  }
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      collectLexicalTextIssues(child, issues)
+    }
+  }
+}
+
+/**
+ * Parse-check Liquid syntax without rendering. Rich-text editors can split
+ * Liquid delimiters across HTML blocks; validating the raw body catches those
+ * templates before they are persisted or previewed.
+ */
+export function validateStructuredTemplateSyntax(
+  body: string,
+  bodyFormat: StructuredTemplateBodyFormat,
+): TemplateSyntaxIssue[] {
+  if (bodyFormat !== "lexical_json") {
+    return validateStringTemplateSyntax(body)
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(body)
+    const issues: TemplateSyntaxIssue[] = []
+    if (Array.isArray(parsed)) {
+      for (const entry of parsed) {
+        if (entry && typeof entry === "object") {
+          collectLexicalTextIssues(entry as LexicalNode, issues)
+        }
+      }
+      return issues
+    }
+
+    if (parsed && typeof parsed === "object") {
+      const obj = parsed as { root?: unknown } & Record<string, unknown>
+      if (obj.root && typeof obj.root === "object") {
+        collectLexicalTextIssues(obj.root as LexicalNode, issues)
+        return issues
+      }
+      collectLexicalTextIssues(obj as LexicalNode, issues)
+      return issues
+    }
+
+    return []
+  } catch {
+    return validateStringTemplateSyntax(body)
+  }
 }
 
 export function renderStringTemplate(

--- a/packages/utils/tests/template-renderer.test.ts
+++ b/packages/utils/tests/template-renderer.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest"
 
-import { renderStructuredTemplate } from "../src/template-renderer.js"
+import {
+  renderStructuredTemplate,
+  validateStructuredTemplateSyntax,
+} from "../src/template-renderer.js"
 
 describe("renderStructuredTemplate", () => {
   it("keeps simple mustache interpolation compatibility", () => {
@@ -122,5 +125,39 @@ describe("renderStructuredTemplate", () => {
         renderStructuredTemplate("{{ d | format_date }}", "markdown", { d: "not-a-date" }),
       ).toBe("not-a-date")
     })
+  })
+})
+
+describe("validateStructuredTemplateSyntax", () => {
+  it("accepts valid Liquid and mustache bodies", () => {
+    expect(
+      validateStructuredTemplateSyntax(
+        "{% if travelers.size > 0 %}{{ travelers[0].name }}{% endif %}",
+        "html",
+      ),
+    ).toEqual([])
+  })
+
+  it("rejects rich-text-split Liquid output tags", () => {
+    const issues = validateStructuredTemplateSyntax(
+      '{{ </p><p>contract.signed_at | default: "-" }}',
+      "html",
+    )
+
+    expect(issues).toHaveLength(1)
+    expect(issues[0]?.message).toContain("expected")
+  })
+
+  it("checks Liquid syntax inside lexical text nodes", () => {
+    const body = JSON.stringify({
+      root: {
+        children: [{ type: "text", text: "{% if customer %}Hi" }],
+      },
+    })
+
+    const issues = validateStructuredTemplateSyntax(body, "lexical_json")
+
+    expect(issues).toHaveLength(1)
+    expect(issues[0]?.message).toContain("not closed")
   })
 })


### PR DESCRIPTION
## Summary
- add parse-only Liquid syntax validation for structured template bodies, including Lexical text nodes
- validate legal contract template bodies before create/update/version save and preview render
- return structured 400 template syntax responses for preview routes and avoid document generation crashes for malformed stored templates

Closes #609

## Verification
- `pnpm --filter @voyantjs/utils typecheck`
- `pnpm --filter @voyantjs/utils lint`
- `pnpm --filter @voyantjs/utils test`
- `pnpm --filter @voyantjs/legal typecheck`
- `pnpm --filter @voyantjs/legal lint`
- `pnpm --filter @voyantjs/legal test`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm verify:fast`
- push hook: `pnpm test`