### PR TITLE
feat(agent-control-plane): lease dispatch intents

### DIFF
--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -27,6 +27,7 @@ pnpm -C apps/agent-control-plane dev
 - `GET /api/capabilities`
 - `POST /api/dispatch-plans`
 - `POST /api/dispatch-plans/latest`
+- `POST /api/dispatch-intents/latest`
 - `POST /api/tick-snapshots`
 - `GET /api/tick-snapshots/latest?repository=<owner/name>`
 
@@ -44,6 +45,15 @@ loads the latest stored tick snapshot for that repository, and returns the same
 dispatch plan shape with source metadata. This is the supervisor-friendly path:
 submit snapshots on one cadence, then ask for dispatch plans without reposting
 the full queue payload.
+
+`POST /api/dispatch-intents/latest` accepts
+`{ repository, filters?, options?, lease: { holder, ttlSeconds? } }`, loads the
+latest stored tick snapshot, selects the next dispatchable plan, and persists a
+leased dispatch intent. It still does not execute the command. The lease holder
+is an operator, supervisor, or runner identifier; the TTL defaults to 900
+seconds and must be between 60 and 3600 seconds. If a non-expired intent already
+exists for the same repository, issue, and action, the endpoint returns
+`dispatch_intent_already_active`.
 
 `POST /api/tick-snapshots` accepts the JSON emitted by
 `pnpm agent:queue:tick -- --json`, validates the shape, and returns the accepted
@@ -85,6 +95,17 @@ Use `--json` when a supervisor needs the response shape directly. Use `--issue`,
 `--action`, `--event-log`, and `--update-body` to pass through the same filters
 and command options as `POST /api/dispatch-plans/latest`.
 
+Create a leased dispatch intent from the latest stored snapshot with:
+
+```bash
+AGENT_CONTROL_PLANE_URL=https://agent-control-plane.example.workers.dev \
+AGENT_CONTROL_PLANE_TOKEN=... \
+pnpm agent:queue:lease-dispatch -- --repo voyantjs/voyant --holder supervisor:local
+```
+
+This records the lease and prints the command to run. It does not execute the
+command.
+
 ## Optional R2 Storage
 
 Bind an R2 bucket as `AGENT_TICK_SNAPSHOTS` to keep the latest accepted tick
@@ -101,3 +122,8 @@ snapshot per repository:
 
 Set `AGENT_TICK_SNAPSHOT_KEY_PREFIX` when multiple environments share one
 bucket.
+
+Bind an R2 bucket as `AGENT_DISPATCH_INTENTS` to persist leased dispatch
+intents. Set `AGENT_DISPATCH_INTENT_KEY_PREFIX` when multiple environments
+share one bucket. The same physical R2 bucket can be bound under both names if
+the key prefixes are distinct.

--- a/apps/agent-control-plane/src/app.ts
+++ b/apps/agent-control-plane/src/app.ts
@@ -3,21 +3,33 @@ import { Hono } from "hono"
 import {
   acceptTickSnapshot,
   buildCapabilities,
+  buildDispatchIntentFromStoredPlan,
   buildTickSnapshotRecord,
   dispatchPlanRequestSchema,
+  latestDispatchIntentRequestSchema,
   latestDispatchPlanRequestSchema,
   selectDispatchPlan,
   selectDispatchPlanFromTickSnapshotRecord,
   tickSnapshotRequestSchema,
 } from "./control-plane.js"
+import type { DispatchIntentStore } from "./dispatch-intent-store.js"
 import type { TickSnapshotStore } from "./tick-snapshot-store.js"
 
 interface AppOptions {
   authTokens?: string[]
+  createDispatchIntentId?: () => string
+  dispatchIntentStore?: DispatchIntentStore
+  now?: () => Date
   tickSnapshotStore?: TickSnapshotStore
 }
 
-export function createApp({ authTokens = [], tickSnapshotStore }: AppOptions = {}): Hono {
+export function createApp({
+  authTokens = [],
+  createDispatchIntentId = () => crypto.randomUUID(),
+  dispatchIntentStore,
+  now = () => new Date(),
+  tickSnapshotStore,
+}: AppOptions = {}): Hono {
   const app = new Hono()
 
   app.onError((error, c) => {
@@ -44,6 +56,7 @@ export function createApp({ authTokens = [], tickSnapshotStore }: AppOptions = {
   app.get("/api/capabilities", (c) =>
     c.json(
       buildCapabilities({
+        dispatchIntentPersistence: dispatchIntentStore ? "leased" : "none",
         tickSnapshotPersistence: tickSnapshotStore ? "latest" : "none",
       }),
     ),
@@ -90,6 +103,68 @@ export function createApp({ authTokens = [], tickSnapshotStore }: AppOptions = {
         record,
         request: parsed.data,
       }),
+    )
+  })
+
+  app.post("/api/dispatch-intents/latest", async (c) => {
+    const parsed = latestDispatchIntentRequestSchema.safeParse(await c.req.json().catch(() => null))
+    if (!parsed.success) {
+      return c.json(
+        {
+          error: "invalid_latest_dispatch_intent_request",
+          issues: validationIssues(parsed.error),
+        },
+        400,
+      )
+    }
+
+    if (!tickSnapshotStore) {
+      return c.json({ error: "tick_snapshot_storage_not_configured" }, 503)
+    }
+
+    if (!dispatchIntentStore) {
+      return c.json({ error: "dispatch_intent_storage_not_configured" }, 503)
+    }
+
+    const snapshot = await tickSnapshotStore.getLatest(parsed.data.repository)
+    if (!snapshot) {
+      return c.json({ error: "tick_snapshot_not_found" }, 404)
+    }
+
+    const planResult = selectDispatchPlanFromTickSnapshotRecord({
+      record: snapshot,
+      request: parsed.data,
+    })
+    const requestedAt = now()
+    const intentResult = buildDispatchIntentFromStoredPlan({
+      id: createDispatchIntentId(),
+      now: requestedAt,
+      request: parsed.data,
+      result: planResult,
+    })
+    if (!intentResult.intent) {
+      return c.json(intentResult)
+    }
+
+    const acquire = await dispatchIntentStore.acquireIntent(intentResult.intent, {
+      now: requestedAt,
+    })
+    if (!acquire.acquired) {
+      return c.json(
+        {
+          error: "dispatch_intent_already_active",
+          intent: acquire.activeIntent,
+        },
+        409,
+      )
+    }
+
+    return c.json(
+      {
+        ...intentResult,
+        storage: { activeKey: acquire.write.activeKey, key: acquire.write.key, persisted: true },
+      },
+      201,
     )
   })
 

--- a/apps/agent-control-plane/src/control-plane.ts
+++ b/apps/agent-control-plane/src/control-plane.ts
@@ -74,6 +74,20 @@ export const latestDispatchPlanRequestSchema = z.object({
 
 export type LatestDispatchPlanRequest = z.infer<typeof latestDispatchPlanRequestSchema>
 
+const dispatchIntentLeaseRequestSchema = z.object({
+  holder: z.string().min(1),
+  ttlSeconds: z.number().int().min(60).max(3600).optional(),
+})
+
+export const latestDispatchIntentRequestSchema = z.object({
+  filters: dispatchPlanFiltersSchema,
+  lease: dispatchIntentLeaseRequestSchema,
+  options: dispatchPlanOptionsSchema,
+  repository: z.string().min(1),
+})
+
+export type LatestDispatchIntentRequest = z.infer<typeof latestDispatchIntentRequestSchema>
+
 export const tickSnapshotRequestSchema = z.object({
   eventLog: z.object({
     path: z.string().min(1),
@@ -108,6 +122,40 @@ export const tickSnapshotRecordSchema = z.object({
 
 export type TickSnapshotRecord = z.infer<typeof tickSnapshotRecordSchema>
 
+const dispatchPlanIssueSchema = issueSchema
+
+const dispatchPlanSchema = z.object({
+  action: z.enum(dispatchableActions),
+  command: z.array(z.string()),
+  issue: dispatchPlanIssueSchema,
+  reason: z.string().min(1),
+  repository: z.string().min(1),
+  requiresMutation: z.literal(true),
+})
+
+const dispatchIntentSourceSchema = z.object({
+  acceptedAt: z.string().min(1),
+  recommendationCount: z.number().int().nonnegative(),
+  repository: z.string().min(1),
+  type: z.literal("latest_tick_snapshot"),
+})
+
+export const dispatchIntentRecordSchema = z.object({
+  createdAt: z.string().min(1),
+  id: z.string().min(1),
+  lease: z.object({
+    acquiredAt: z.string().min(1),
+    expiresAt: z.string().min(1),
+    holder: z.string().min(1),
+    ttlSeconds: z.number().int().min(60).max(3600),
+  }),
+  plan: dispatchPlanSchema,
+  source: dispatchIntentSourceSchema,
+  status: z.literal("leased"),
+})
+
+export type DispatchIntentRecord = z.infer<typeof dispatchIntentRecordSchema>
+
 export interface DispatchPlan {
   action: (typeof dispatchableActions)[number]
   command: string[]
@@ -131,9 +179,17 @@ export interface StoredDispatchPlanResult extends DispatchPlanResult {
   }
 }
 
+export interface DispatchIntentResult {
+  intent: DispatchIntentRecord | null
+  reason: string
+  source: StoredDispatchPlanResult["source"]
+}
+
 export function buildCapabilities({
+  dispatchIntentPersistence = "none",
   tickSnapshotPersistence = "none",
 }: {
+  dispatchIntentPersistence?: "leased" | "none"
   tickSnapshotPersistence?: "latest" | "none"
 } = {}) {
   return {
@@ -160,6 +216,16 @@ export function buildCapabilities({
     dispatchPlanSources: {
       inlineRecommendations: true,
       latestTickSnapshot: tickSnapshotPersistence === "latest",
+    },
+    dispatchIntentContracts: {
+      latestSnapshotLease: {
+        persistence: dispatchIntentPersistence,
+        ttlSeconds: {
+          default: 900,
+          min: 60,
+          max: 3600,
+        },
+      },
     },
   }
 }
@@ -271,6 +337,52 @@ export function selectDispatchPlanFromTickSnapshotRecord({
       type: "latest_tick_snapshot",
     },
   }
+}
+
+export function buildDispatchIntentFromStoredPlan({
+  id,
+  now = new Date(),
+  request,
+  result,
+}: {
+  id: string
+  now?: Date
+  request: LatestDispatchIntentRequest
+  result: StoredDispatchPlanResult
+}): DispatchIntentResult {
+  if (!result.plan) {
+    return {
+      intent: null,
+      reason: result.reason,
+      source: result.source,
+    }
+  }
+
+  const createdAt = now.toISOString()
+  const ttlSeconds = request.lease.ttlSeconds ?? 900
+  const expiresAt = new Date(now.getTime() + ttlSeconds * 1000).toISOString()
+
+  return {
+    intent: {
+      createdAt,
+      id,
+      lease: {
+        acquiredAt: createdAt,
+        expiresAt,
+        holder: request.lease.holder,
+        ttlSeconds,
+      },
+      plan: result.plan,
+      source: result.source,
+      status: "leased",
+    },
+    reason: "leased",
+    source: result.source,
+  }
+}
+
+export function isDispatchIntentActive(intent: DispatchIntentRecord, now = new Date()) {
+  return intent.status === "leased" && Date.parse(intent.lease.expiresAt) > now.getTime()
 }
 
 function dispatchCommand({

--- a/apps/agent-control-plane/src/dispatch-intent-store.ts
+++ b/apps/agent-control-plane/src/dispatch-intent-store.ts
@@ -1,0 +1,164 @@
+import {
+  type DispatchIntentRecord,
+  dispatchIntentRecordSchema,
+  isDispatchIntentActive,
+} from "./control-plane.js"
+
+export interface DispatchIntentStore {
+  acquireIntent(
+    record: DispatchIntentRecord,
+    options: { now: Date },
+  ): Promise<DispatchIntentAcquireResult>
+  getActive(reference: DispatchIntentReference): Promise<DispatchIntentRecord | null>
+  putIntent(record: DispatchIntentRecord): Promise<DispatchIntentStoreWrite>
+}
+
+export interface DispatchIntentReference {
+  action: string
+  issueNumber: number
+  repository: string
+}
+
+export interface DispatchIntentStoreWrite {
+  activeKey: string
+  key: string
+}
+
+export type DispatchIntentAcquireResult =
+  | { acquired: true; write: DispatchIntentStoreWrite }
+  | { acquired: false; activeIntent: DispatchIntentRecord }
+
+export interface DispatchIntentBucket {
+  get(key: string): Promise<{ etag?: string; text(): Promise<string> } | null>
+  put(
+    key: string,
+    value: string,
+    options?: {
+      httpMetadata?: { contentType?: string }
+      onlyIf?: { etagDoesNotMatch?: string; etagMatches?: string }
+    },
+  ): Promise<unknown | null>
+}
+
+export function createR2DispatchIntentStore({
+  bucket,
+  keyPrefix = "agent-control-plane",
+}: {
+  bucket: DispatchIntentBucket
+  keyPrefix?: string
+}): DispatchIntentStore {
+  return {
+    async acquireIntent(record, { now }) {
+      const reference = recordReference(record)
+      const activeKey = activeIntentKey({ keyPrefix, reference })
+      const existingObject = await bucket.get(activeKey)
+      if (existingObject) {
+        const activeIntent = parseStoredIntent({
+          repository: reference.repository,
+          text: await existingObject.text(),
+        })
+        if (isDispatchIntentActive(activeIntent, now)) {
+          return { acquired: false, activeIntent }
+        }
+      }
+
+      const value = JSON.stringify(record)
+      const options = {
+        httpMetadata: {
+          contentType: "application/json",
+        },
+        onlyIf: existingObject?.etag
+          ? { etagMatches: existingObject.etag }
+          : { etagDoesNotMatch: "*" },
+      }
+      const activeWrite = await bucket.put(activeKey, value, options)
+      if (!activeWrite) {
+        const activeIntent = await this.getActive(reference)
+        if (activeIntent) {
+          return { acquired: false, activeIntent }
+        }
+        throw new Error(`dispatch intent lease contention for ${reference.repository}`)
+      }
+
+      const key = intentKey({ id: record.id, keyPrefix })
+      await bucket.put(key, value, {
+        httpMetadata: {
+          contentType: "application/json",
+        },
+      })
+
+      return {
+        acquired: true,
+        write: { activeKey, key },
+      }
+    },
+
+    async getActive(reference) {
+      const object = await bucket.get(activeIntentKey({ keyPrefix, reference }))
+      if (!object) return null
+
+      return parseStoredIntent({
+        repository: reference.repository,
+        text: await object.text(),
+      })
+    },
+
+    async putIntent(record) {
+      const reference = recordReference(record)
+      const key = intentKey({ id: record.id, keyPrefix })
+      const activeKey = activeIntentKey({ keyPrefix, reference })
+      const value = JSON.stringify(record)
+      const options = {
+        httpMetadata: {
+          contentType: "application/json",
+        },
+      }
+
+      await bucket.put(key, value, options)
+      await bucket.put(activeKey, value, options)
+
+      return { activeKey, key }
+    },
+  }
+}
+
+function intentKey({ id, keyPrefix }: { id: string; keyPrefix: string }) {
+  const normalizedPrefix = normalizePrefix(keyPrefix)
+  const key = `dispatch-intents/by-id/${encodeURIComponent(id)}.json`
+  return normalizedPrefix ? `${normalizedPrefix}/${key}` : key
+}
+
+function parseStoredIntent({ repository, text }: { repository: string; text: string }) {
+  const parsed = dispatchIntentRecordSchema.safeParse(JSON.parse(text))
+  if (!parsed.success) {
+    throw new Error(`stored dispatch intent is invalid for ${repository}`)
+  }
+
+  return parsed.data
+}
+
+function recordReference(record: DispatchIntentRecord) {
+  return {
+    action: record.plan.action,
+    issueNumber: record.plan.issue.number,
+    repository: record.plan.repository,
+  }
+}
+
+function activeIntentKey({
+  keyPrefix,
+  reference,
+}: {
+  keyPrefix: string
+  reference: DispatchIntentReference
+}) {
+  const normalizedPrefix = normalizePrefix(keyPrefix)
+  const encodedRepository = encodeURIComponent(reference.repository.trim().toLowerCase())
+  const encodedAction = encodeURIComponent(reference.action.trim().toLowerCase())
+  const key = `dispatch-intents/active/${encodedRepository}/${reference.issueNumber}/${encodedAction}.json`
+  return normalizedPrefix ? `${normalizedPrefix}/${key}` : key
+}
+
+function normalizePrefix(keyPrefix: string) {
+  return keyPrefix.replace(/^\/+|\/+$/g, "")
+}

--- a/apps/agent-control-plane/src/latest-dispatch-intent.test.ts
+++ b/apps/agent-control-plane/src/latest-dispatch-intent.test.ts
@@ -1,0 +1,415 @@
+import { describe, expect, it } from "vitest"
+
+import { createApp } from "./app.js"
+import {
+  buildTickSnapshotRecord,
+  type DispatchIntentRecord,
+  type TickSnapshotRecord,
+} from "./control-plane.js"
+import type { DispatchIntentStore } from "./dispatch-intent-store.js"
+import type { TickSnapshotStore } from "./tick-snapshot-store.js"
+
+const tickSnapshot = {
+  project: {
+    owner: "voyantjs",
+    number: 1,
+    title: "Voyant Engineering",
+    url: "https://github.com/orgs/voyantjs/projects/1",
+  },
+  repository: "voyantjs/voyant",
+  maxAgeDays: 1,
+  eventLog: {
+    path: "/repo/.agent-runs/events.jsonl",
+    recentEvents: [],
+  },
+  recommendations: [
+    {
+      action: "remote-bootstrap",
+      command: "pnpm agent:queue:remote-bootstrap -- --issue 579 --repo voyantjs/voyant --yes",
+      issue: {
+        number: 579,
+        title: "Test agent project intake workflow",
+        url: "https://github.com/voyantjs/voyant/issues/579",
+        repository: "voyantjs/voyant",
+      },
+      priority: 20,
+      reason: "remote workspace is ready for repository bootstrap",
+      state: "Ready",
+    },
+    {
+      action: "remote-run-command",
+      command:
+        'pnpm agent:queue:remote-run-command -- --issue 580 --repo voyantjs/voyant --command "<implementation-command>" --yes',
+      issue: {
+        number: 580,
+        title: "Run implementation",
+        url: "https://github.com/voyantjs/voyant/issues/580",
+        repository: "voyantjs/voyant",
+      },
+      priority: 30,
+      reason: "implementation execution remains explicit",
+      state: "Planning",
+    },
+  ],
+}
+
+describe("latest dispatch intents", () => {
+  it("leases a dispatch intent from the latest stored tick snapshot", async () => {
+    const intentStore = inMemoryDispatchIntentStore()
+    const app = createApp({
+      authTokens: ["secret"],
+      createDispatchIntentId: () => "intent_579",
+      dispatchIntentStore: intentStore,
+      now: () => new Date("2026-05-12T05:30:00.000Z"),
+      tickSnapshotStore: inMemoryTickSnapshotStore([
+        buildTickSnapshotRecord(tickSnapshot, {
+          acceptedAt: "2026-05-12T05:00:00.000Z",
+        }),
+      ]),
+    })
+
+    const response = await app.request("/api/dispatch-intents/latest", {
+      method: "POST",
+      headers: { authorization: "Bearer secret", "content-type": "application/json" },
+      body: JSON.stringify({
+        filters: {
+          action: "remote-bootstrap",
+          issueNumber: 579,
+        },
+        lease: {
+          holder: "supervisor:test",
+          ttlSeconds: 600,
+        },
+        options: {
+          eventLog: ".agent-runs/supervisor.jsonl",
+        },
+        repository: "VoyantJS/Voyant",
+      }),
+    })
+
+    expect(response.status).toBe(201)
+    await expect(response.json()).resolves.toEqual({
+      reason: "leased",
+      source: {
+        acceptedAt: "2026-05-12T05:00:00.000Z",
+        recommendationCount: 2,
+        repository: "voyantjs/voyant",
+        type: "latest_tick_snapshot",
+      },
+      storage: {
+        activeKey: "active/voyantjs/voyant/579/remote-bootstrap.json",
+        key: "intent_579.json",
+        persisted: true,
+      },
+      intent: {
+        createdAt: "2026-05-12T05:30:00.000Z",
+        id: "intent_579",
+        lease: {
+          acquiredAt: "2026-05-12T05:30:00.000Z",
+          expiresAt: "2026-05-12T05:40:00.000Z",
+          holder: "supervisor:test",
+          ttlSeconds: 600,
+        },
+        plan: {
+          action: "remote-bootstrap",
+          command: [
+            "pnpm",
+            "agent:queue:remote-bootstrap",
+            "--",
+            "--issue",
+            "579",
+            "--repo",
+            "VoyantJS/Voyant",
+            "--yes",
+            "--event-log",
+            ".agent-runs/supervisor.jsonl",
+          ],
+          issue: tickSnapshot.recommendations[0]?.issue,
+          reason: "remote workspace is ready for repository bootstrap",
+          repository: "VoyantJS/Voyant",
+          requiresMutation: true,
+        },
+        source: {
+          acceptedAt: "2026-05-12T05:00:00.000Z",
+          recommendationCount: 2,
+          repository: "voyantjs/voyant",
+          type: "latest_tick_snapshot",
+        },
+        status: "leased",
+      },
+    })
+  })
+
+  it("does not create an intent when no dispatchable plan matches", async () => {
+    const app = createApp({
+      authTokens: ["secret"],
+      createDispatchIntentId: () => "unused",
+      dispatchIntentStore: inMemoryDispatchIntentStore(),
+      tickSnapshotStore: inMemoryTickSnapshotStore([buildTickSnapshotRecord(tickSnapshot)]),
+    })
+
+    const response = await app.request("/api/dispatch-intents/latest", {
+      method: "POST",
+      headers: { authorization: "Bearer secret", "content-type": "application/json" },
+      body: JSON.stringify({
+        filters: {
+          action: "remote-run-command",
+        },
+        lease: {
+          holder: "supervisor:test",
+        },
+        repository: "voyantjs/voyant",
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      intent: null,
+      reason: "action remote-run-command is not dispatchable",
+      source: {
+        repository: "voyantjs/voyant",
+        type: "latest_tick_snapshot",
+      },
+    })
+  })
+
+  it("rejects an active lease for the same issue and action", async () => {
+    const intentStore = inMemoryDispatchIntentStore()
+    const app = createApp({
+      authTokens: ["secret"],
+      createDispatchIntentId: () => "new_intent",
+      dispatchIntentStore: intentStore,
+      now: () => new Date("2026-05-12T05:30:00.000Z"),
+      tickSnapshotStore: inMemoryTickSnapshotStore([buildTickSnapshotRecord(tickSnapshot)]),
+    })
+    await intentStore.putIntent({
+      createdAt: "2026-05-12T05:25:00.000Z",
+      id: "active_intent",
+      lease: {
+        acquiredAt: "2026-05-12T05:25:00.000Z",
+        expiresAt: "2026-05-12T05:35:00.000Z",
+        holder: "supervisor:existing",
+        ttlSeconds: 600,
+      },
+      plan: {
+        action: "remote-bootstrap",
+        command: ["pnpm", "agent:queue:remote-bootstrap"],
+        issue: tickSnapshot.recommendations[0]!.issue,
+        reason: "existing lease",
+        repository: "voyantjs/voyant",
+        requiresMutation: true,
+      },
+      source: {
+        acceptedAt: "2026-05-12T05:00:00.000Z",
+        recommendationCount: 2,
+        repository: "voyantjs/voyant",
+        type: "latest_tick_snapshot",
+      },
+      status: "leased",
+    })
+
+    const response = await app.request("/api/dispatch-intents/latest", {
+      method: "POST",
+      headers: { authorization: "Bearer secret", "content-type": "application/json" },
+      body: JSON.stringify({
+        lease: {
+          holder: "supervisor:test",
+        },
+        repository: "voyantjs/voyant",
+      }),
+    })
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toMatchObject({
+      error: "dispatch_intent_already_active",
+      intent: {
+        id: "active_intent",
+      },
+    })
+  })
+
+  it("allows a new lease when the previous active intent is expired", async () => {
+    const intentStore = inMemoryDispatchIntentStore()
+    const app = createApp({
+      authTokens: ["secret"],
+      createDispatchIntentId: () => "replacement_intent",
+      dispatchIntentStore: intentStore,
+      now: () => new Date("2026-05-12T05:45:01.000Z"),
+      tickSnapshotStore: inMemoryTickSnapshotStore([buildTickSnapshotRecord(tickSnapshot)]),
+    })
+    await intentStore.putIntent({
+      createdAt: "2026-05-12T05:25:00.000Z",
+      id: "expired_intent",
+      lease: {
+        acquiredAt: "2026-05-12T05:25:00.000Z",
+        expiresAt: "2026-05-12T05:35:00.000Z",
+        holder: "supervisor:existing",
+        ttlSeconds: 600,
+      },
+      plan: {
+        action: "remote-bootstrap",
+        command: ["pnpm", "agent:queue:remote-bootstrap"],
+        issue: tickSnapshot.recommendations[0]!.issue,
+        reason: "expired lease",
+        repository: "voyantjs/voyant",
+        requiresMutation: true,
+      },
+      source: {
+        acceptedAt: "2026-05-12T05:00:00.000Z",
+        recommendationCount: 2,
+        repository: "voyantjs/voyant",
+        type: "latest_tick_snapshot",
+      },
+      status: "leased",
+    })
+
+    const response = await app.request("/api/dispatch-intents/latest", {
+      method: "POST",
+      headers: { authorization: "Bearer secret", "content-type": "application/json" },
+      body: JSON.stringify({
+        lease: {
+          holder: "supervisor:test",
+        },
+        repository: "voyantjs/voyant",
+      }),
+    })
+
+    expect(response.status).toBe(201)
+    await expect(response.json()).resolves.toMatchObject({
+      intent: {
+        id: "replacement_intent",
+        lease: {
+          holder: "supervisor:test",
+        },
+      },
+      reason: "leased",
+    })
+  })
+
+  it("requires storage, a lease holder, and a stored snapshot", async () => {
+    const noIntentStore = createApp({
+      authTokens: ["secret"],
+      tickSnapshotStore: inMemoryTickSnapshotStore([buildTickSnapshotRecord(tickSnapshot)]),
+    })
+    const noIntentStoreResponse = await noIntentStore.request("/api/dispatch-intents/latest", {
+      method: "POST",
+      headers: { authorization: "Bearer secret", "content-type": "application/json" },
+      body: JSON.stringify({
+        lease: {
+          holder: "supervisor:test",
+        },
+        repository: "voyantjs/voyant",
+      }),
+    })
+    expect(noIntentStoreResponse.status).toBe(503)
+    await expect(noIntentStoreResponse.json()).resolves.toEqual({
+      error: "dispatch_intent_storage_not_configured",
+    })
+
+    const app = createApp({
+      authTokens: ["secret"],
+      dispatchIntentStore: inMemoryDispatchIntentStore(),
+      tickSnapshotStore: inMemoryTickSnapshotStore(),
+    })
+    const invalid = await app.request("/api/dispatch-intents/latest", {
+      method: "POST",
+      headers: { authorization: "Bearer secret", "content-type": "application/json" },
+      body: JSON.stringify({
+        repository: "voyantjs/voyant",
+      }),
+    })
+    expect(invalid.status).toBe(400)
+    await expect(invalid.json()).resolves.toMatchObject({
+      error: "invalid_latest_dispatch_intent_request",
+    })
+
+    const missingSnapshot = await app.request("/api/dispatch-intents/latest", {
+      method: "POST",
+      headers: { authorization: "Bearer secret", "content-type": "application/json" },
+      body: JSON.stringify({
+        lease: {
+          holder: "supervisor:test",
+        },
+        repository: "voyantjs/voyant",
+      }),
+    })
+    expect(missingSnapshot.status).toBe(404)
+    await expect(missingSnapshot.json()).resolves.toEqual({ error: "tick_snapshot_not_found" })
+  })
+})
+
+function inMemoryTickSnapshotStore(records: TickSnapshotRecord[] = []): TickSnapshotStore {
+  const latest = new Map(
+    records.map((record) => [record.snapshot.repository.toLowerCase(), record]),
+  )
+
+  return {
+    async getLatest(repository) {
+      return latest.get(repository.toLowerCase()) ?? null
+    },
+    async putLatest(record) {
+      latest.set(record.snapshot.repository.toLowerCase(), record)
+      return { key: `latest/${record.snapshot.repository.toLowerCase()}.json` }
+    },
+  }
+}
+
+function inMemoryDispatchIntentStore(): DispatchIntentStore {
+  const active = new Map<string, DispatchIntentRecord>()
+
+  return {
+    async acquireIntent(record, { now }) {
+      const key = activeIntentKey({
+        action: record.plan.action,
+        issueNumber: record.plan.issue.number,
+        repository: record.plan.repository,
+      })
+      const existing = active.get(key)
+      if (existing && Date.parse(existing.lease.expiresAt) > now.getTime()) {
+        return { acquired: false, activeIntent: existing }
+      }
+
+      active.set(key, record)
+      return {
+        acquired: true,
+        write: {
+          activeKey: key,
+          key: `${record.id}.json`,
+        },
+      }
+    },
+    async getActive(reference) {
+      return active.get(activeIntentKey(reference)) ?? null
+    },
+    async putIntent(record) {
+      active.set(
+        activeIntentKey({
+          action: record.plan.action,
+          issueNumber: record.plan.issue.number,
+          repository: record.plan.repository,
+        }),
+        record,
+      )
+      return {
+        activeKey: activeIntentKey({
+          action: record.plan.action,
+          issueNumber: record.plan.issue.number,
+          repository: record.plan.repository,
+        }),
+        key: `${record.id}.json`,
+      }
+    },
+  }
+}
+
+function activeIntentKey({
+  action,
+  issueNumber,
+  repository,
+}: {
+  action: string
+  issueNumber: number
+  repository: string
+}) {
+  return `active/${repository.toLowerCase()}/${issueNumber}/${action.toLowerCase()}.json`
+}

--- a/apps/agent-control-plane/src/tick-snapshot-store.test.ts
+++ b/apps/agent-control-plane/src/tick-snapshot-store.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import { createApp } from "./app.js"
 import { buildTickSnapshotRecord, type TickSnapshotRecord } from "./control-plane.js"
+import { createR2DispatchIntentStore, type DispatchIntentBucket } from "./dispatch-intent-store.js"
 import {
   createR2TickSnapshotStore,
   type TickSnapshotBucket,
@@ -205,6 +206,92 @@ describe("tick snapshot storage", () => {
 
     await expect(store.putLatest(buildTickSnapshotRecord(tickSnapshot))).resolves.toEqual({
       key: "tick-snapshots/latest/voyantjs%2Fvoyant.json",
+    })
+  })
+
+  it("stores active dispatch intents in R2-compatible object storage", async () => {
+    const objects = new Map<string, { etag: string; value: string }>()
+    const store = createR2DispatchIntentStore({
+      bucket: {
+        async get(key: string) {
+          const object = objects.get(key)
+          return object
+            ? ({
+                etag: object.etag,
+                text: async () => object.value,
+              } satisfies Awaited<ReturnType<DispatchIntentBucket["get"]>>)
+            : null
+        },
+        async put(key: string, value: string, options) {
+          const object = objects.get(key)
+          if (options?.onlyIf?.etagDoesNotMatch === "*" && object) {
+            return null
+          }
+          if (options?.onlyIf?.etagMatches && object?.etag !== options.onlyIf.etagMatches) {
+            return null
+          }
+
+          objects.set(key, { etag: `${key}:${String(value).length}`, value: String(value) })
+          return {}
+        },
+      } satisfies DispatchIntentBucket,
+      keyPrefix: "/supervisor/",
+    })
+    const intent = {
+      createdAt: "2026-05-12T05:30:00.000Z",
+      id: "intent_579",
+      lease: {
+        acquiredAt: "2026-05-12T05:30:00.000Z",
+        expiresAt: "2026-05-12T05:45:00.000Z",
+        holder: "supervisor:test",
+        ttlSeconds: 900,
+      },
+      plan: {
+        action: "remote-bootstrap" as const,
+        command: ["pnpm", "agent:queue:remote-bootstrap"],
+        issue: tickSnapshot.recommendations[0]!.issue,
+        reason: "remote workspace is ready for repository bootstrap",
+        repository: "voyantjs/voyant",
+        requiresMutation: true as const,
+      },
+      source: {
+        acceptedAt: "2026-05-12T05:00:00.000Z",
+        recommendationCount: 2,
+        repository: "voyantjs/voyant",
+        type: "latest_tick_snapshot" as const,
+      },
+      status: "leased" as const,
+    }
+
+    await expect(store.putIntent(intent)).resolves.toEqual({
+      activeKey: "supervisor/dispatch-intents/active/voyantjs%2Fvoyant/579/remote-bootstrap.json",
+      key: "supervisor/dispatch-intents/by-id/intent_579.json",
+    })
+    await expect(
+      store.getActive({
+        action: "remote-bootstrap",
+        issueNumber: 579,
+        repository: "VoyantJS/Voyant",
+      }),
+    ).resolves.toEqual(intent)
+
+    await expect(
+      store.acquireIntent(
+        {
+          ...intent,
+          id: "intent_580",
+          lease: {
+            ...intent.lease,
+            expiresAt: "2026-05-12T05:50:00.000Z",
+          },
+        },
+        { now: new Date("2026-05-12T05:40:00.000Z") },
+      ),
+    ).resolves.toMatchObject({
+      acquired: false,
+      activeIntent: {
+        id: "intent_579",
+      },
     })
   })
 })

--- a/apps/agent-control-plane/src/worker.ts
+++ b/apps/agent-control-plane/src/worker.ts
@@ -1,8 +1,11 @@
 import { createApp } from "./app.js"
+import { createR2DispatchIntentStore } from "./dispatch-intent-store.js"
 import { createR2TickSnapshotStore } from "./tick-snapshot-store.js"
 
 interface Env {
   AGENT_CONTROL_PLANE_TOKENS?: string
+  AGENT_DISPATCH_INTENT_KEY_PREFIX?: string
+  AGENT_DISPATCH_INTENTS?: R2Bucket
   AGENT_TICK_SNAPSHOT_KEY_PREFIX?: string
   AGENT_TICK_SNAPSHOTS?: R2Bucket
 }
@@ -11,6 +14,12 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const app = createApp({
       authTokens: parseTokens(env.AGENT_CONTROL_PLANE_TOKENS),
+      dispatchIntentStore: env.AGENT_DISPATCH_INTENTS
+        ? createR2DispatchIntentStore({
+            bucket: env.AGENT_DISPATCH_INTENTS,
+            keyPrefix: env.AGENT_DISPATCH_INTENT_KEY_PREFIX,
+          })
+        : undefined,
       tickSnapshotStore: env.AGENT_TICK_SNAPSHOTS
         ? createR2TickSnapshotStore({
             bucket: env.AGENT_TICK_SNAPSHOTS,

--- a/apps/agent-control-plane/wrangler.jsonc
+++ b/apps/agent-control-plane/wrangler.jsonc
@@ -12,6 +12,9 @@
   // Optional: bind an R2 bucket as AGENT_TICK_SNAPSHOTS to store the latest
   // accepted tick snapshot per repository. Set AGENT_TICK_SNAPSHOT_KEY_PREFIX
   // when multiple environments share one bucket.
+  // Optional: bind an R2 bucket as AGENT_DISPATCH_INTENTS to store leased
+  // dispatch intents. Set AGENT_DISPATCH_INTENT_KEY_PREFIX when multiple
+  // environments share one bucket.
   "observability": {
     "enabled": true
   }

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -402,6 +402,12 @@ Use `pnpm agent:queue:plan-dispatch` with the same control-plane environment to
 request the next read-only dispatch plan from the latest stored snapshot. Pass
 `--json` for supervisors, or `--issue`, `--action`, `--event-log`, and
 `--update-body` to shape the returned lifecycle command.
+The control-plane app can also persist leased dispatch intents with
+`POST /api/dispatch-intents/latest`. A dispatch intent records the selected
+plan, source snapshot, lease holder, and lease expiration so always-on
+supervisors can coordinate explicit command execution without the Worker
+running the command itself. Use `pnpm agent:queue:lease-dispatch -- --holder
+<id>` to create one from a runner or process manager.
 `CI Repair` items with failing linked PRs recommend `collect-ci` until a local
 CI repair packet exists. Ready items with `sandbox:<provider>:<id>` workspaces
 recommend `remote-bootstrap` so dispatch can clone/fetch the repository and

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1331,6 +1331,11 @@ Verification:
   `pnpm agent:queue:plan-dispatch`, using the same control-plane URL and token
   as snapshot submission. It prints the planned lifecycle command or JSON for a
   supervisor, but does not execute the mutation.
+- The control-plane app can persist leased dispatch intents with
+  `POST /api/dispatch-intents/latest` when an `AGENT_DISPATCH_INTENTS` R2
+  binding is configured. This gives always-on supervisors a durable coordination
+  record for the selected lifecycle command, lease holder, and expiration while
+  command execution remains runner-owned.
 
 ## Open Questions
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "agent:queue:tick": "node scripts/agent-runner-tick.mjs",
     "agent:queue:submit-tick": "node scripts/agent-runner-submit-tick.mjs",
     "agent:queue:plan-dispatch": "node scripts/agent-runner-plan-dispatch.mjs",
+    "agent:queue:lease-dispatch": "node scripts/agent-runner-lease-dispatch.mjs",
     "agent:queue:dispatch": "node scripts/agent-runner-dispatch.mjs",
     "agent:queue:loop": "node scripts/agent-runner-loop.mjs",
     "agent:queue:remote-inspect": "node scripts/agent-runner-remote-inspect.mjs",

--- a/scripts/agent-runner-lease-dispatch.mjs
+++ b/scripts/agent-runner-lease-dispatch.mjs
@@ -1,0 +1,131 @@
+import { currentRepositoryFromOrigin, fail, parseArgs, runGit } from "./lib/agent-project-queue.mjs"
+import {
+  controlPlaneConfigFromArgs,
+  requestLatestDispatchIntent,
+} from "./lib/agent-runner-control-plane.mjs"
+import { dispatchableActions } from "./lib/agent-runner-dispatch.mjs"
+import { eventLogOptions, maybePrintHelp, repositoryOptions } from "./lib/agent-runner-help.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:lease-dispatch",
+  summary: "Lease the next dispatch intent from the control plane's latest stored tick snapshot.",
+  usage: "pnpm agent:queue:lease-dispatch -- --holder <id> [--repo <owner/name>] [--json]",
+  options: [
+    ["--control-plane-url <url>", "Control-plane base URL. Defaults to AGENT_CONTROL_PLANE_URL."],
+    ["AGENT_CONTROL_PLANE_TOKEN", "Bearer token environment variable used for API routes."],
+    ["--holder <id>", "Supervisor or runner identifier recorded on the lease."],
+    ["--ttl-seconds <number>", "Lease TTL in seconds, 60..3600. Defaults to 900."],
+    ["--issue <number>", "Only lease a recommendation for this issue number."],
+    [
+      "--action <name>",
+      `Only lease this action. Allowed: ${Array.from(dispatchableActions).join(", ")}.`,
+    ],
+    ...eventLogOptions,
+    ["--update-body", "When leasing sync-pr, include --update-body in the returned command."],
+    ["--json", "Print machine-readable JSON."],
+    ...repositoryOptions,
+  ],
+})
+
+const repository =
+  args.repo ?? currentRepositoryFromOrigin(runGit(["rev-parse", "--show-toplevel"]))
+const holder = requiredString(args.holder, "holder")
+
+if (args.action && !dispatchableActions.has(args.action)) {
+  fail(`action ${args.action} is not dispatchable`)
+}
+
+const issueNumber = optionalPositiveInteger(args.issue, "issue")
+const ttlSeconds = optionalInteger(args.ttlSeconds, "ttl-seconds", { max: 3600, min: 60 })
+const request = {
+  repository,
+  lease: {
+    holder,
+    ...(ttlSeconds ? { ttlSeconds } : {}),
+  },
+  ...(issueNumber || args.action
+    ? {
+        filters: {
+          ...(args.action ? { action: args.action } : {}),
+          ...(issueNumber ? { issueNumber } : {}),
+        },
+      }
+    : {}),
+  ...(args.eventLog || args.updateBody
+    ? {
+        options: {
+          ...(args.eventLog ? { eventLog: args.eventLog } : {}),
+          ...(args.updateBody ? { updateBody: true } : {}),
+        },
+      }
+    : {}),
+}
+const config = readControlPlaneConfig()
+
+try {
+  const result = await requestLatestDispatchIntent({
+    request,
+    token: config.token,
+    url: config.url,
+  })
+
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2))
+  } else {
+    printIntent({ controlPlaneUrl: config.url, result })
+  }
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error))
+}
+
+function printIntent({ controlPlaneUrl, result }) {
+  console.log("agent-runner latest dispatch intent")
+  console.log(`control plane: ${controlPlaneUrl}`)
+  console.log(`repository: ${result.source?.repository ?? repository}`)
+  if (result.source?.acceptedAt) {
+    console.log(`snapshot accepted: ${result.source.acceptedAt}`)
+  }
+
+  if (!result.intent) {
+    console.log(`intent: none (${result.reason})`)
+    return
+  }
+
+  console.log(`intent: ${result.intent.id}`)
+  console.log(`holder: ${result.intent.lease.holder}`)
+  console.log(`lease expires: ${result.intent.lease.expiresAt}`)
+  console.log(`issue: #${result.intent.plan.issue.number} ${result.intent.plan.issue.title}`)
+  console.log(`action: ${result.intent.plan.action}`)
+  console.log(`reason: ${result.intent.plan.reason}`)
+  console.log(`command: ${result.intent.plan.command.join(" ")}`)
+}
+
+function readControlPlaneConfig() {
+  try {
+    return controlPlaneConfigFromArgs(args)
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error))
+  }
+}
+
+function requiredString(value, name) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    fail(`missing required --${name}`)
+  }
+  return value.trim()
+}
+
+function optionalPositiveInteger(value, name) {
+  return optionalInteger(value, name, { min: 1 })
+}
+
+function optionalInteger(value, name, { max = Number.POSITIVE_INFINITY, min = 1 } = {}) {
+  if (value === undefined) return undefined
+
+  const number = Number(value)
+  if (!Number.isInteger(number) || number < min || number > max) {
+    fail(`invalid ${name}: ${value}`)
+  }
+  return number
+}

--- a/scripts/lib/agent-runner-control-plane.mjs
+++ b/scripts/lib/agent-runner-control-plane.mjs
@@ -60,6 +60,29 @@ export async function requestLatestDispatchPlan({ fetchImpl = fetch, request, to
   return body
 }
 
+export async function requestLatestDispatchIntent({ fetchImpl = fetch, request, token, url }) {
+  const response = await fetchImpl(`${normalizeControlPlaneUrl(url)}/api/dispatch-intents/latest`, {
+    body: JSON.stringify(request),
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    method: "POST",
+  })
+
+  const bodyText = await response.text()
+  const body = parseJsonBody(bodyText)
+
+  if (!response.ok) {
+    const detail = body?.error ? `: ${body.error}` : bodyText ? `: ${bodyText}` : ""
+    throw new Error(
+      `control plane rejected latest dispatch intent with ${response.status}${detail}`,
+    )
+  }
+
+  return body
+}
+
 function normalizeControlPlaneUrl(url) {
   return String(url).replace(/\/+$/, "")
 }

--- a/scripts/tests/agent-runner-control-plane.test.mjs
+++ b/scripts/tests/agent-runner-control-plane.test.mjs
@@ -3,6 +3,7 @@ import { describe, it } from "node:test"
 
 import {
   controlPlaneConfigFromArgs,
+  requestLatestDispatchIntent,
   requestLatestDispatchPlan,
   submitTickSnapshot,
 } from "../lib/agent-runner-control-plane.mjs"
@@ -166,6 +167,111 @@ describe("agent runner control plane client", () => {
         url: "https://control.example.com",
       }),
       /404: latest_tick_snapshot_not_found/,
+    )
+  })
+
+  it("requests latest dispatch intents from stored snapshots", async () => {
+    const calls = []
+    const response = await requestLatestDispatchIntent({
+      fetchImpl: async (url, init) => {
+        calls.push({ init, url })
+        return new Response(
+          JSON.stringify({
+            intent: {
+              createdAt: "2026-05-12T12:00:00.000Z",
+              id: "intent_579",
+              lease: {
+                acquiredAt: "2026-05-12T12:00:00.000Z",
+                expiresAt: "2026-05-12T12:15:00.000Z",
+                holder: "supervisor:test",
+                ttlSeconds: 900,
+              },
+              plan: {
+                action: "remote-bootstrap",
+                command: [
+                  "pnpm",
+                  "agent:queue:remote-bootstrap",
+                  "--",
+                  "--issue",
+                  "579",
+                  "--repo",
+                  "voyantjs/voyant",
+                  "--yes",
+                ],
+                issue: {
+                  number: 579,
+                  repository: "voyantjs/voyant",
+                  title: "Test issue",
+                  url: "https://github.com/voyantjs/voyant/issues/579",
+                },
+                reason: "ready",
+                repository: "voyantjs/voyant",
+                requiresMutation: true,
+              },
+              source: {
+                acceptedAt: "2026-05-12T11:59:00.000Z",
+                recommendationCount: 1,
+                repository: "voyantjs/voyant",
+                type: "latest_tick_snapshot",
+              },
+              status: "leased",
+            },
+            reason: "leased",
+          }),
+          { status: 201 },
+        )
+      },
+      request: {
+        filters: {
+          action: "remote-bootstrap",
+          issueNumber: 579,
+        },
+        lease: {
+          holder: "supervisor:test",
+          ttlSeconds: 900,
+        },
+        repository: "voyantjs/voyant",
+      },
+      token: "tok",
+      url: "https://control.example.com/",
+    })
+
+    assert.equal(response.intent.id, "intent_579")
+    assert.equal(calls[0].url, "https://control.example.com/api/dispatch-intents/latest")
+    assert.equal(calls[0].init.method, "POST")
+    assert.equal(calls[0].init.headers.authorization, "Bearer tok")
+    assert.equal(calls[0].init.headers["content-type"], "application/json")
+    assert.equal(
+      calls[0].init.body,
+      JSON.stringify({
+        filters: {
+          action: "remote-bootstrap",
+          issueNumber: 579,
+        },
+        lease: {
+          holder: "supervisor:test",
+          ttlSeconds: 900,
+        },
+        repository: "voyantjs/voyant",
+      }),
+    )
+  })
+
+  it("surfaces rejected latest dispatch intent responses", async () => {
+    await assert.rejects(
+      requestLatestDispatchIntent({
+        fetchImpl: async () =>
+          new Response(JSON.stringify({ error: "dispatch_intent_already_active" }), {
+            status: 409,
+          }),
+        request: {
+          lease: { holder: "supervisor:test" },
+          repository: "voyantjs/voyant",
+        },
+        token: "tok",
+        url: "https://control.example.com",
+      }),
+      /409: dispatch_intent_already_active/,
     )
   })
 })


### PR DESCRIPTION
## Summary

- add `POST /api/dispatch-intents/latest` to lease a dispatch intent from the latest stored tick snapshot
- persist active dispatch intents through an R2-compatible store with per-repository/issue/action lease keys
- expose dispatch intent capabilities and Worker bindings for `AGENT_DISPATCH_INTENTS`
- add `pnpm agent:queue:lease-dispatch` for supervisors to create a lease and print the command without executing it
- document the leased-intent flow and storage configuration

## Verification

- `pnpm -C apps/agent-control-plane test`
- `pnpm -C apps/agent-control-plane typecheck`
- `pnpm --filter @voyantjs/agent-control-plane lint`
- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- commit hook: changed-file format/secretlint, agent-quality, affected typecheck
- pre-push hook: `pnpm test`
