### PR TITLE
Emit booking schedule paid events

### DIFF
--- a/.changeset/finance-schedule-paid-event.md
+++ b/.changeset/finance-schedule-paid-event.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/finance": patch
+---
+
+Emit a first-class booking payment schedule paid event when schedule-backed payment sessions complete, and include target metadata on generic payment completion events.

--- a/docs/architecture/payments-architecture.md
+++ b/docs/architecture/payments-architecture.md
@@ -304,6 +304,16 @@ The payments contract has no concept of "deposit" or "balance" or
 "schedule". It sees individual `PaymentRequest`s. Compose them in the
 vertical's booking service or in finance's payment schedules.
 
+When a session linked to a booking payment schedule is completed,
+`@voyantjs/finance` emits `booking_payment_schedule.paid` after the
+transaction commits. The event includes the booking id, schedule id,
+schedule type, amount, currency, provider, and payment session id. Downstream
+booking lifecycles can subscribe to that event to promote deposit-first
+bookings from `on_hold` to `confirmed` without provider-specific webhook glue.
+The generic `payment.completed` event also carries target metadata
+(`targetType`, `targetId`, schedule id, guarantee id) for subscribers that
+prefer one payment event stream.
+
 ---
 
 ## Package Layout

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -203,8 +203,10 @@ export {
   vouchers,
 } from "./schema.js"
 export type {
+  BookingPaymentSchedulePaidEvent,
   CreateInvoiceFromBookingInput,
   InvoiceFromBookingData,
+  PaymentCompletedEvent,
   UnifiedPaymentRow,
 } from "./service.js"
 export { financeService, renderInvoiceBody } from "./service.js"

--- a/packages/finance/src/service.ts
+++ b/packages/finance/src/service.ts
@@ -1,7 +1,7 @@
 import { bookingItems, bookings } from "@voyantjs/bookings/schema"
 import type { EventBus } from "@voyantjs/core"
 import { renderStructuredTemplate } from "@voyantjs/utils/template-renderer"
-import { and, asc, desc, eq, gte, ilike, lte, or, sql } from "drizzle-orm"
+import { and, asc, desc, eq, gte, ilike, lte, ne, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
 import {
@@ -378,6 +378,66 @@ export interface FinanceServiceRuntime {
   eventBus?: EventBus
 }
 
+export interface BookingPaymentSchedulePaidEvent {
+  bookingId: string
+  bookingPaymentScheduleId: string
+  paymentSessionId: string
+  paymentId: string | null
+  scheduleType: (typeof bookingPaymentSchedules.$inferSelect)["scheduleType"]
+  amountCents: number
+  currency: string
+  provider: string | null
+}
+
+export interface PaymentCompletedEvent {
+  paymentSessionId: string
+  targetType: (typeof paymentSessions.$inferSelect)["targetType"]
+  targetId: string | null
+  bookingId: string | null
+  orderId: string | null
+  invoiceId: string | null
+  bookingPaymentScheduleId: string | null
+  bookingGuaranteeId: string | null
+  amountCents: number
+  currency: string
+  provider: string | null
+}
+
+export function buildBookingPaymentSchedulePaidEvent(
+  schedule: typeof bookingPaymentSchedules.$inferSelect,
+  session: typeof paymentSessions.$inferSelect,
+  paymentId: string | null,
+): BookingPaymentSchedulePaidEvent {
+  return {
+    bookingId: schedule.bookingId,
+    bookingPaymentScheduleId: schedule.id,
+    paymentSessionId: session.id,
+    paymentId,
+    scheduleType: schedule.scheduleType,
+    amountCents: schedule.amountCents,
+    currency: schedule.currency,
+    provider: session.provider,
+  }
+}
+
+export function buildPaymentCompletedEvent(
+  session: typeof paymentSessions.$inferSelect,
+): PaymentCompletedEvent {
+  return {
+    paymentSessionId: session.id,
+    targetType: session.targetType,
+    targetId: session.targetId,
+    bookingId: session.bookingId,
+    orderId: session.orderId,
+    invoiceId: session.invoiceId,
+    bookingPaymentScheduleId: session.bookingPaymentScheduleId,
+    bookingGuaranteeId: session.bookingGuaranteeId,
+    amountCents: session.amountCents,
+    currency: session.currency,
+    provider: session.provider,
+  }
+}
+
 interface RawUnifiedPaymentRow {
   kind: "customer" | "supplier"
   id: string
@@ -733,6 +793,7 @@ export const financeService = {
       // a consistent post-update view. Stays null when this call doesn't
       // result in a new payment being applied to an invoice.
       let settlementForEmit: InvoiceSettledEvent | null = null
+      let bookingSchedulePaidForEmit: BookingPaymentSchedulePaidEvent | null = null
 
       if (!authorizationId) {
         const [authorization] = await tx
@@ -869,10 +930,24 @@ export const financeService = {
       }
 
       if (data.status === "paid" && session.bookingPaymentScheduleId) {
-        await tx
+        const [paidSchedule] = await tx
           .update(bookingPaymentSchedules)
           .set({ status: "paid", updatedAt: new Date() })
-          .where(eq(bookingPaymentSchedules.id, session.bookingPaymentScheduleId))
+          .where(
+            and(
+              eq(bookingPaymentSchedules.id, session.bookingPaymentScheduleId),
+              ne(bookingPaymentSchedules.status, "paid"),
+            ),
+          )
+          .returning()
+
+        if (paidSchedule) {
+          bookingSchedulePaidForEmit = buildBookingPaymentSchedulePaidEvent(
+            paidSchedule,
+            session,
+            paymentId,
+          )
+        }
       }
 
       if (session.bookingGuaranteeId && authorizationId) {
@@ -914,11 +989,22 @@ export const financeService = {
         .where(eq(paymentSessions.id, id))
         .returning()
 
-      return { updated: updated ?? null, settlement: settlementForEmit }
+      return {
+        updated: updated ?? null,
+        settlement: settlementForEmit,
+        bookingSchedulePaid: bookingSchedulePaidForEmit,
+      }
     })
 
     if (txResult.settlement) {
       await runtime.eventBus?.emit("invoice.settled", txResult.settlement, {
+        category: "domain",
+        source: "service",
+      })
+    }
+
+    if (txResult.bookingSchedulePaid) {
+      await runtime.eventBus?.emit("booking_payment_schedule.paid", txResult.bookingSchedulePaid, {
         category: "domain",
         source: "service",
       })
@@ -934,19 +1020,10 @@ export const financeService = {
       txResult.updated &&
       (session.bookingId || session.orderId || session.invoiceId)
     ) {
-      await runtime.eventBus?.emit(
-        "payment.completed",
-        {
-          paymentSessionId: id,
-          bookingId: session.bookingId,
-          orderId: session.orderId,
-          invoiceId: session.invoiceId,
-          amountCents: session.amountCents,
-          currency: session.currency,
-          provider: session.provider,
-        },
-        { category: "domain", source: "service" },
-      )
+      await runtime.eventBus?.emit("payment.completed", buildPaymentCompletedEvent(session), {
+        category: "domain",
+        source: "service",
+      })
     }
 
     return txResult.updated

--- a/packages/finance/tests/integration/routes.test.ts
+++ b/packages/finance/tests/integration/routes.test.ts
@@ -103,6 +103,8 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
   let app: Hono
   let db: ReturnType<typeof import("@voyantjs/db/test-utils").createTestDb>
   const settlementEvents: Array<Record<string, unknown>> = []
+  const paymentCompletedEvents: Array<Record<string, unknown>> = []
+  const schedulePaidEvents: Array<Record<string, unknown>> = []
 
   beforeAll(async () => {
     process.env.TEST_DATABASE_URL = getIsolatedFinanceTestDbUrl(process.env.TEST_DATABASE_URL)
@@ -245,6 +247,12 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
     eventBus.subscribe("invoice.settled", (event) => {
       settlementEvents.push(event as Record<string, unknown>)
     })
+    eventBus.subscribe("payment.completed", (event) => {
+      paymentCompletedEvents.push(event as Record<string, unknown>)
+    })
+    eventBus.subscribe("booking_payment_schedule.paid", (event) => {
+      schedulePaidEvents.push(event as Record<string, unknown>)
+    })
     const financeRouteRuntime = {
       eventBus,
       invoiceSettlementPollers: {},
@@ -273,6 +281,8 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
   beforeEach(async () => {
     await cleanupFinanceTestData(db)
     settlementEvents.length = 0
+    paymentCompletedEvents.length = 0
+    schedulePaidEvents.length = 0
   })
 
   afterAll(async () => {
@@ -639,6 +649,36 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
         .from(bookingPaymentSchedules)
         .where(eq(bookingPaymentSchedules.id, schedule.id))
       expect(storedSchedule?.status).toBe("paid")
+      expect(schedulePaidEvents).toHaveLength(1)
+      expect(schedulePaidEvents[0]).toMatchObject({
+        bookingId: booking.id,
+        bookingPaymentScheduleId: schedule.id,
+        paymentSessionId: session.id,
+        paymentId: null,
+        scheduleType: schedule.scheduleType,
+        amountCents: schedule.amountCents,
+        currency: schedule.currency,
+        provider: "netopia",
+      })
+      expect(paymentCompletedEvents).toHaveLength(1)
+      expect(paymentCompletedEvents[0]).toMatchObject({
+        paymentSessionId: session.id,
+        targetType: "booking_payment_schedule",
+        targetId: schedule.id,
+        bookingId: booking.id,
+        bookingPaymentScheduleId: schedule.id,
+        bookingGuaranteeId: null,
+        amountCents: 25000,
+        currency: "USD",
+        provider: "netopia",
+      })
+
+      const retryRes = await app.request(`/payment-sessions/${session.id}/complete`, {
+        method: "POST",
+        ...json({ status: "paid", paymentMethod: "credit_card" }),
+      })
+      expect(retryRes.status).toBe(200)
+      expect(schedulePaidEvents).toHaveLength(1)
     })
 
     it("fails and lists payment sessions by status", async () => {

--- a/packages/finance/tests/unit/payment-session-events.test.ts
+++ b/packages/finance/tests/unit/payment-session-events.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildBookingPaymentSchedulePaidEvent,
+  buildPaymentCompletedEvent,
+} from "../../src/service.js"
+
+describe("payment session events", () => {
+  it("builds schedule-paid events with booking lifecycle context", () => {
+    const session = {
+      id: "psess_123",
+      provider: "netopia",
+      targetType: "booking_payment_schedule",
+      targetId: "bps_123",
+      bookingId: "book_123",
+      orderId: null,
+      invoiceId: null,
+      bookingPaymentScheduleId: "bps_123",
+      bookingGuaranteeId: null,
+      amountCents: 25000,
+      currency: "USD",
+    }
+    const schedule = {
+      id: "bps_123",
+      bookingId: "book_123",
+      scheduleType: "deposit",
+      amountCents: 25000,
+      currency: "USD",
+    }
+
+    expect(
+      buildBookingPaymentSchedulePaidEvent(schedule as never, session as never, "pay_123"),
+    ).toEqual({
+      bookingId: "book_123",
+      bookingPaymentScheduleId: "bps_123",
+      paymentSessionId: "psess_123",
+      paymentId: "pay_123",
+      scheduleType: "deposit",
+      amountCents: 25000,
+      currency: "USD",
+      provider: "netopia",
+    })
+  })
+
+  it("includes target metadata on generic payment completion events", () => {
+    expect(
+      buildPaymentCompletedEvent({
+        id: "psess_123",
+        targetType: "booking_payment_schedule",
+        targetId: "bps_123",
+        bookingId: "book_123",
+        orderId: null,
+        invoiceId: null,
+        bookingPaymentScheduleId: "bps_123",
+        bookingGuaranteeId: null,
+        amountCents: 25000,
+        currency: "USD",
+        provider: "netopia",
+      } as never),
+    ).toMatchObject({
+      paymentSessionId: "psess_123",
+      targetType: "booking_payment_schedule",
+      targetId: "bps_123",
+      bookingId: "book_123",
+      bookingPaymentScheduleId: "bps_123",
+      bookingGuaranteeId: null,
+      amountCents: 25000,
+      currency: "USD",
+      provider: "netopia",
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- emit `booking_payment_schedule.paid` after schedule-backed payment sessions complete and the transaction commits
- enrich `payment.completed` with target metadata including schedule and guarantee ids
- document the finance event contract and add event payload coverage

Closes #618

## Verification
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/finance lint`
- `pnpm --filter @voyantjs/finance test -- tests/unit/payment-session-events.test.ts tests/integration/routes.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm verify:fast`
- push hook: `pnpm test`