### PR TITLE
Add default padding to UI pages

### DIFF
--- a/.changeset/ui-page-padding.md
+++ b/.changeset/ui-page-padding.md
@@ -1,0 +1,10 @@
+---
+"@voyantjs/auth-ui": patch
+"@voyantjs/bookings-ui": patch
+"@voyantjs/crm-ui": patch
+"@voyantjs/pricing-ui": patch
+"@voyantjs/products-ui": patch
+"@voyantjs/suppliers-ui": patch
+---
+
+Give shipped page components default outer padding and document the page mounting contract.

--- a/packages/auth-ui/README.md
+++ b/packages/auth-ui/README.md
@@ -1,0 +1,21 @@
+# @voyantjs/auth-ui
+
+Importable React UI components for Voyant auth surfaces. Bundler-consumed
+(Vite, Next.js, webpack, etc.).
+
+## Install
+
+```bash
+pnpm add @voyantjs/auth-ui @voyantjs/auth-react @voyantjs/ui @tanstack/react-query react react-dom
+```
+
+`@voyantjs/ui` provides the design-system primitives. `@voyantjs/auth-react`
+provides the data-layer hooks. Both are required peers.
+
+All components accept a `className` prop and merge it with `cn()`. Wrap or
+compose to extend; use the registry copy-paste path for components you want to
+fork outright.
+
+Page components render with `p-6` outer padding by default and are intended to
+mount directly into an app route outlet. Pass `className` to extend or override
+that spacing when a shell owns the page chrome.

--- a/packages/auth-ui/src/components/service-api-keys-page.tsx
+++ b/packages/auth-ui/src/components/service-api-keys-page.tsx
@@ -171,7 +171,7 @@ export function ServiceApiKeysPage({
   }
 
   return (
-    <div data-slot="api-tokens-page" className={cn("flex flex-col gap-6", className)}>
+    <div data-slot="api-tokens-page" className={cn("flex flex-col gap-6 p-6", className)}>
       <div>
         <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
         <p className="text-sm text-muted-foreground">{description}</p>

--- a/packages/bookings-ui/README.md
+++ b/packages/bookings-ui/README.md
@@ -12,6 +12,10 @@ pnpm add @voyantjs/bookings-ui @voyantjs/bookings-react @voyantjs/ui @tanstack/r
 
 All components accept a `className` prop and merge it with `cn()`. Wrap or compose to extend; use the registry copy-paste path (`npx shadcn add @voyant/...`) for components you want to fork outright.
 
+Page components render with `p-6` outer padding by default and are intended to
+mount directly into an app route outlet. Pass `className` to extend or override
+that spacing when a shell owns the page chrome.
+
 ## Components
 
 - `BookingsPage`, `BookingDetailPage`

--- a/packages/bookings-ui/src/components/bookings-page.tsx
+++ b/packages/bookings-ui/src/components/bookings-page.tsx
@@ -15,7 +15,7 @@ export function BookingsPage({ pageSize, onBookingOpen, className }: BookingsPag
   const messages = useBookingsUiMessagesOrDefault().bookingsPage
 
   return (
-    <div data-slot="bookings-page" className={cn("flex flex-col gap-6", className)}>
+    <div data-slot="bookings-page" className={cn("flex flex-col gap-6 p-6", className)}>
       <div>
         <h1 className="text-2xl font-bold tracking-tight">{messages.title}</h1>
         <p className="text-sm text-muted-foreground">{messages.description}</p>

--- a/packages/crm-ui/README.md
+++ b/packages/crm-ui/README.md
@@ -27,6 +27,10 @@ function App() {
 
 All components accept a `className` prop and merge it with `cn()`. Wrap or compose to extend; use the registry copy-paste path (`npx shadcn add @voyant/...`) for components you want to fork outright.
 
+Page components render with `p-6` outer padding by default and are intended to
+mount directly into an app route outlet. Pass `className` to extend or override
+that spacing when a shell owns the page chrome.
+
 ## I18n
 
 Components render English by default. To localize them, wrap your UI in

--- a/packages/crm-ui/src/components/organizations-page.tsx
+++ b/packages/crm-ui/src/components/organizations-page.tsx
@@ -19,7 +19,7 @@ export function OrganizationsPage({
   const messages = useCrmUiMessagesOrDefault().organizationsPage
 
   return (
-    <div data-slot="organizations-page" className={cn("flex flex-col gap-6", className)}>
+    <div data-slot="organizations-page" className={cn("flex flex-col gap-6 p-6", className)}>
       <div>
         <h1 className="text-2xl font-bold tracking-tight">{messages.title}</h1>
         <p className="text-sm text-muted-foreground">{messages.description}</p>

--- a/packages/crm-ui/src/components/people-page.tsx
+++ b/packages/crm-ui/src/components/people-page.tsx
@@ -15,7 +15,7 @@ export function PeoplePage({ pageSize, onPersonOpen, className }: PeoplePageProp
   const messages = useCrmUiMessagesOrDefault().peoplePage
 
   return (
-    <div data-slot="people-page" className={cn("flex flex-col gap-6", className)}>
+    <div data-slot="people-page" className={cn("flex flex-col gap-6 p-6", className)}>
       <div>
         <h1 className="text-2xl font-bold tracking-tight">{messages.title}</h1>
         <p className="text-sm text-muted-foreground">{messages.description}</p>

--- a/packages/pricing-ui/README.md
+++ b/packages/pricing-ui/README.md
@@ -18,6 +18,10 @@ pnpm add @voyantjs/pricing-ui @voyantjs/pricing-react @voyantjs/ui @tanstack/rea
 
 All components accept a `className` prop and merge it with `cn()`. Wrap or compose to extend; use the registry copy-paste path (`npx shadcn add @voyant/...`) for components you want to fork outright.
 
+Page components render with `p-6` outer padding by default and are intended to
+mount directly into an app route outlet. Pass `className` to extend or override
+that spacing when a shell owns the page chrome.
+
 ## I18n
 
 Components render English by default. To localize them, wrap your UI in

--- a/packages/pricing-ui/src/components/price-catalogs-page.tsx
+++ b/packages/pricing-ui/src/components/price-catalogs-page.tsx
@@ -103,7 +103,7 @@ export function PriceCatalogsPage({
   const pageCount = Math.max(1, Math.ceil(total / pageSize))
 
   return (
-    <div data-slot="price-catalogs-page" className={cn("flex flex-col gap-6", className)}>
+    <div data-slot="price-catalogs-page" className={cn("flex flex-col gap-6 p-6", className)}>
       <div className="flex items-center justify-between gap-4">
         <div>
           <h2 className="text-lg font-semibold tracking-tight">{pageMessages.title}</h2>

--- a/packages/pricing-ui/src/components/pricing-categories-page.tsx
+++ b/packages/pricing-ui/src/components/pricing-categories-page.tsx
@@ -13,7 +13,7 @@ export function PricingCategoriesPage({ pageSize, className }: PricingCategories
   const messages = usePricingUiMessagesOrDefault().pricingCategoriesPage
 
   return (
-    <div data-slot="pricing-categories-page" className={cn("flex flex-col gap-6", className)}>
+    <div data-slot="pricing-categories-page" className={cn("flex flex-col gap-6 p-6", className)}>
       <div>
         <h2 className="text-lg font-semibold tracking-tight">{messages.title}</h2>
         <p className="text-sm text-muted-foreground">{messages.description}</p>

--- a/packages/products-ui/README.md
+++ b/packages/products-ui/README.md
@@ -13,6 +13,10 @@ pnpm add @voyantjs/products-ui @voyantjs/products-react @voyantjs/ui @tanstack/r
 
 All components accept a `className` prop and merge it with `cn()`. Wrap or compose to extend; use the registry copy-paste path (`npx shadcn add @voyant/...`) for components you want to fork outright.
 
+Page components render with `p-6` outer padding by default and are intended to
+mount directly into an app route outlet. Pass `className` to extend or override
+that spacing when a shell owns the page chrome.
+
 ## Components
 
 - `ProductsPage` publishes the product list composition.

--- a/packages/products-ui/src/components/product-categories-page.tsx
+++ b/packages/products-ui/src/components/product-categories-page.tsx
@@ -13,7 +13,7 @@ export function ProductCategoriesPage({ pageSize, className }: ProductCategories
   const messages = useProductsUiMessagesOrDefault().productCategoriesPage
 
   return (
-    <div data-slot="product-categories-page" className={cn("flex flex-col gap-6", className)}>
+    <div data-slot="product-categories-page" className={cn("flex flex-col gap-6 p-6", className)}>
       <div>
         <h2 className="text-lg font-semibold tracking-tight">{messages.title}</h2>
         <p className="text-sm text-muted-foreground">{messages.description}</p>

--- a/packages/products-ui/src/components/product-detail-page.tsx
+++ b/packages/products-ui/src/components/product-detail-page.tsx
@@ -136,7 +136,7 @@ export function ProductDetailPage({
   }
 
   return (
-    <div data-slot="product-detail-page" className={cn("flex flex-col gap-6", className)}>
+    <div data-slot="product-detail-page" className={cn("flex flex-col gap-6 p-6", className)}>
       <ProductDetailHeader
         product={product}
         onBack={onBack}
@@ -651,7 +651,7 @@ function ProductDetailPageLoading({ className }: { className?: string }) {
   return (
     <div
       data-slot="product-detail-page-loading"
-      className={cn("flex min-h-48 items-center justify-center", className)}
+      className={cn("flex min-h-48 items-center justify-center p-6", className)}
     >
       <div className="flex items-center gap-2 text-sm text-muted-foreground">
         <Loader2 className="size-4 animate-spin" aria-hidden="true" />
@@ -675,7 +675,7 @@ function ProductDetailPageState({
   const messages = useProductsUiMessagesOrDefault()
 
   return (
-    <div data-slot="product-detail-page-state" className={cn("flex flex-col gap-4", className)}>
+    <div data-slot="product-detail-page-state" className={cn("flex flex-col gap-4 p-6", className)}>
       {onBack ? (
         <Button type="button" variant="ghost" className="w-fit" onClick={onBack}>
           <ArrowLeft className="mr-2 size-4" aria-hidden="true" />

--- a/packages/products-ui/src/components/product-tags-page.tsx
+++ b/packages/products-ui/src/components/product-tags-page.tsx
@@ -13,7 +13,7 @@ export function ProductTagsPage({ pageSize, className }: ProductTagsPageProps = 
   const messages = useProductsUiMessagesOrDefault().productTagsPage
 
   return (
-    <div data-slot="product-tags-page" className={cn("flex flex-col gap-6", className)}>
+    <div data-slot="product-tags-page" className={cn("flex flex-col gap-6 p-6", className)}>
       <div>
         <h2 className="text-lg font-semibold tracking-tight">{messages.title}</h2>
         <p className="text-sm text-muted-foreground">{messages.description}</p>

--- a/packages/products-ui/src/components/product-types-page.tsx
+++ b/packages/products-ui/src/components/product-types-page.tsx
@@ -76,7 +76,7 @@ export function ProductTypesPage({
   const pageCount = Math.max(1, Math.ceil(total / pageSize))
 
   return (
-    <div data-slot="product-types-page" className={cn("flex flex-col gap-6", className)}>
+    <div data-slot="product-types-page" className={cn("flex flex-col gap-6 p-6", className)}>
       <div className="flex items-center justify-between gap-4">
         <div>
           <h2 className="text-lg font-semibold tracking-tight">{pageMessages.title}</h2>

--- a/packages/products-ui/src/components/products-page.tsx
+++ b/packages/products-ui/src/components/products-page.tsx
@@ -13,7 +13,7 @@ export function ProductsPage({ pageSize, onProductOpen, className }: ProductsPag
   const productMessages = useProductsUiMessagesOrDefault().productsPage
 
   return (
-    <div data-slot="products-page" className={cn("flex flex-col gap-6", className)}>
+    <div data-slot="products-page" className={cn("flex flex-col gap-6 p-6", className)}>
       <div>
         <h1 className="text-2xl font-bold tracking-tight">{productMessages.title}</h1>
         <p className="text-sm text-muted-foreground">{productMessages.description}</p>

--- a/packages/suppliers-ui/README.md
+++ b/packages/suppliers-ui/README.md
@@ -12,6 +12,10 @@ pnpm add @voyantjs/suppliers-ui @voyantjs/suppliers-react @voyantjs/ui @tanstack
 
 All components accept a `className` prop and merge it with `cn()`. Wrap or compose to extend; use the registry copy-paste path (`npx shadcn add @voyant/...`) for components you want to fork outright.
 
+Page components render with `p-6` outer padding by default and are intended to
+mount directly into an app route outlet. Pass `className` to extend or override
+that spacing when a shell owns the page chrome.
+
 ## I18n
 
 Components render English by default. To localize them, wrap your UI in

--- a/packages/suppliers-ui/src/components/supplier-detail-page.tsx
+++ b/packages/suppliers-ui/src/components/supplier-detail-page.tsx
@@ -23,6 +23,7 @@ import {
   CardTitle,
   Textarea,
 } from "@voyantjs/ui/components"
+import { cn } from "@voyantjs/ui/lib/utils"
 import { ArrowLeft, Loader2, Pencil, Plus, Trash2 } from "lucide-react"
 import * as React from "react"
 import { useSuppliersUiMessagesOrDefault } from "../i18n/index.js"
@@ -37,6 +38,7 @@ export type SupplierDetailPageProps = {
   onBack?: () => void
   onDeleted?: () => void
   confirmAction?: (message: string) => boolean
+  className?: string
   renderCustomerPaymentPolicy?: (args: {
     supplier: Supplier
     updateSupplier: (input: UpdateSupplierInput) => Promise<Supplier>
@@ -50,6 +52,7 @@ export function SupplierDetailPage({
   onBack,
   onDeleted,
   confirmAction = (message) => globalThis.confirm?.(message) ?? true,
+  className,
   renderCustomerPaymentPolicy,
 }: SupplierDetailPageProps) {
   const messages = useSuppliersUiMessagesOrDefault()
@@ -99,17 +102,27 @@ export function SupplierDetailPage({
     setNoteContent("")
   }
 
-  if (supplierQuery.isPending) return <SupplierDetailSkeleton />
+  if (supplierQuery.isPending) return <SupplierDetailSkeleton className={className} />
 
   if (supplierQuery.isError) {
     return (
-      <EmptyState message={detail.loadFailed} onBack={onBack} backLabel={detail.backToSuppliers} />
+      <EmptyState
+        message={detail.loadFailed}
+        onBack={onBack}
+        backLabel={detail.backToSuppliers}
+        className={className}
+      />
     )
   }
 
   if (!supplier) {
     return (
-      <EmptyState message={detail.notFound} onBack={onBack} backLabel={detail.backToSuppliers} />
+      <EmptyState
+        message={detail.notFound}
+        onBack={onBack}
+        backLabel={detail.backToSuppliers}
+        className={className}
+      />
     )
   }
 
@@ -117,7 +130,7 @@ export function SupplierDetailPage({
   const notes = notesQuery.data?.data ?? []
 
   return (
-    <div className="flex flex-col gap-6">
+    <div data-slot="supplier-detail-page" className={cn("flex flex-col gap-6 p-6", className)}>
       <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
         <div className="flex flex-col gap-3">
           {onBack && (
@@ -357,13 +370,20 @@ function EmptyState({
   message,
   onBack,
   backLabel,
+  className,
 }: {
   message: string
   onBack?: () => void
   backLabel: string
+  className?: string
 }) {
   return (
-    <div className="flex min-h-80 flex-col items-center justify-center gap-4 text-center">
+    <div
+      className={cn(
+        "flex min-h-80 flex-col items-center justify-center gap-4 p-6 text-center",
+        className,
+      )}
+    >
       <p className="text-muted-foreground">{message}</p>
       {onBack && (
         <Button type="button" variant="outline" onClick={onBack}>
@@ -375,9 +395,9 @@ function EmptyState({
   )
 }
 
-function SupplierDetailSkeleton() {
+function SupplierDetailSkeleton({ className }: { className?: string }) {
   return (
-    <div className="flex flex-col gap-6">
+    <div className={cn("flex flex-col gap-6 p-6", className)}>
       <div className="h-9 w-72 animate-pulse rounded bg-muted" />
       <div className="grid gap-4 lg:grid-cols-2">
         <div className="h-64 animate-pulse rounded-md bg-muted" />

--- a/packages/suppliers-ui/src/components/suppliers-page.tsx
+++ b/packages/suppliers-ui/src/components/suppliers-page.tsx
@@ -19,6 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@voyantjs/ui/components"
+import { cn } from "@voyantjs/ui/lib/utils"
 import { ArrowDown, ArrowUp, Plus, Search, SlidersHorizontal } from "lucide-react"
 import * as React from "react"
 import { useSuppliersUiMessagesOrDefault } from "../i18n/index.js"
@@ -32,6 +33,7 @@ export type SuppliersPageProps = {
   onSupplierOpen?: (supplier: Supplier) => void
   onSupplierCreated?: (supplier: Supplier) => void
   initialSearch?: string
+  className?: string
 }
 
 export function SuppliersPage({
@@ -39,6 +41,7 @@ export function SuppliersPage({
   onSupplierOpen,
   onSupplierCreated,
   initialSearch = "",
+  className,
 }: SuppliersPageProps = {}) {
   const messages = useSuppliersUiMessagesOrDefault()
   const [search, setSearch] = React.useState(initialSearch)
@@ -87,7 +90,7 @@ export function SuppliersPage({
   }
 
   return (
-    <div className="flex flex-col gap-6">
+    <div data-slot="suppliers-page" className={cn("flex flex-col gap-6 p-6", className)}>
       <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
         <div>
           <h1 className="text-3xl font-semibold tracking-tight">{messages.suppliersPage.title}</h1>

--- a/templates/operator/src/routes/_workspace/bookings/index.tsx
+++ b/templates/operator/src/routes/_workspace/bookings/index.tsx
@@ -18,12 +18,10 @@ function BookingsRoute() {
   const navigate = useNavigate()
 
   return (
-    <div className="p-6">
-      <BookingsPage
-        onBookingOpen={(booking) =>
-          void navigate({ to: "/bookings/$id", params: { id: booking.id } })
-        }
-      />
-    </div>
+    <BookingsPage
+      onBookingOpen={(booking) =>
+        void navigate({ to: "/bookings/$id", params: { id: booking.id } })
+      }
+    />
   )
 }

--- a/templates/operator/src/routes/_workspace/organizations/index.tsx
+++ b/templates/operator/src/routes/_workspace/organizations/index.tsx
@@ -14,12 +14,10 @@ function OrganizationsRoute() {
   const navigate = useNavigate()
 
   return (
-    <div className="p-6">
-      <OrganizationsPage
-        onOrganizationOpen={(organization) =>
-          void navigate({ to: "/organizations/$id", params: { id: organization.id } })
-        }
-      />
-    </div>
+    <OrganizationsPage
+      onOrganizationOpen={(organization) =>
+        void navigate({ to: "/organizations/$id", params: { id: organization.id } })
+      }
+    />
   )
 }

--- a/templates/operator/src/routes/_workspace/people/index.tsx
+++ b/templates/operator/src/routes/_workspace/people/index.tsx
@@ -14,10 +14,8 @@ function PeopleRoute() {
   const navigate = useNavigate()
 
   return (
-    <div className="p-6">
-      <PeoplePage
-        onPersonOpen={(person) => void navigate({ to: "/people/$id", params: { id: person.id } })}
-      />
-    </div>
+    <PeoplePage
+      onPersonOpen={(person) => void navigate({ to: "/people/$id", params: { id: person.id } })}
+    />
   )
 }

--- a/templates/operator/src/routes/_workspace/products/categories.tsx
+++ b/templates/operator/src/routes/_workspace/products/categories.tsx
@@ -16,9 +16,5 @@ export const Route = createFileRoute("/_workspace/products/categories")({
 })
 
 function ProductCategoriesRoute() {
-  return (
-    <div className="p-6">
-      <ProductCategoriesPage />
-    </div>
-  )
+  return <ProductCategoriesPage />
 }

--- a/templates/operator/src/routes/_workspace/products/index.tsx
+++ b/templates/operator/src/routes/_workspace/products/index.tsx
@@ -20,12 +20,10 @@ function ProductsRoute() {
   const navigate = useNavigate()
 
   return (
-    <div className="p-6">
-      <ProductsPage
-        onProductOpen={(product) =>
-          void navigate({ to: "/products/$id", params: { id: product.id } })
-        }
-      />
-    </div>
+    <ProductsPage
+      onProductOpen={(product) =>
+        void navigate({ to: "/products/$id", params: { id: product.id } })
+      }
+    />
   )
 }

--- a/templates/operator/src/routes/_workspace/settings/api-tokens.tsx
+++ b/templates/operator/src/routes/_workspace/settings/api-tokens.tsx
@@ -6,9 +6,5 @@ export const Route = createFileRoute("/_workspace/settings/api-tokens")({
 })
 
 function ApiTokensSettingsPage() {
-  return (
-    <div className="p-6">
-      <ApiTokensPage />
-    </div>
-  )
+  return <ApiTokensPage />
 }

--- a/templates/operator/src/routes/_workspace/settings/price-catalogs.tsx
+++ b/templates/operator/src/routes/_workspace/settings/price-catalogs.tsx
@@ -16,9 +16,5 @@ export const Route = createFileRoute("/_workspace/settings/price-catalogs")({
 })
 
 function PriceCatalogsRoute() {
-  return (
-    <div className="p-6">
-      <PriceCatalogsPage />
-    </div>
-  )
+  return <PriceCatalogsPage />
 }

--- a/templates/operator/src/routes/_workspace/settings/pricing-categories.tsx
+++ b/templates/operator/src/routes/_workspace/settings/pricing-categories.tsx
@@ -16,9 +16,5 @@ export const Route = createFileRoute("/_workspace/settings/pricing-categories")(
 })
 
 function PricingCategoriesRoute() {
-  return (
-    <div className="p-6">
-      <PricingCategoriesPage />
-    </div>
-  )
+  return <PricingCategoriesPage />
 }

--- a/templates/operator/src/routes/_workspace/settings/product-tags.tsx
+++ b/templates/operator/src/routes/_workspace/settings/product-tags.tsx
@@ -16,9 +16,5 @@ export const Route = createFileRoute("/_workspace/settings/product-tags")({
 })
 
 function ProductTagsRoute() {
-  return (
-    <div className="p-6">
-      <ProductTagsPage />
-    </div>
-  )
+  return <ProductTagsPage />
 }

--- a/templates/operator/src/routes/_workspace/settings/product-types.tsx
+++ b/templates/operator/src/routes/_workspace/settings/product-types.tsx
@@ -16,9 +16,5 @@ export const Route = createFileRoute("/_workspace/settings/product-types")({
 })
 
 function ProductTypesRoute() {
-  return (
-    <div className="p-6">
-      <ProductTypesPage />
-    </div>
-  )
+  return <ProductTypesPage />
 }

--- a/templates/operator/src/routes/_workspace/suppliers/$id.tsx
+++ b/templates/operator/src/routes/_workspace/suppliers/$id.tsx
@@ -53,15 +53,13 @@ function SupplierDetailRoute() {
   const { resolvedLocale } = useLocale()
 
   return (
-    <div className="p-6">
-      <SupplierDetailPage
-        id={id}
-        locale={resolvedLocale}
-        onBack={() => void navigate({ to: "/suppliers" })}
-        onDeleted={() => void navigate({ to: "/suppliers" })}
-        renderCustomerPaymentPolicy={(args) => <SupplierPaymentPolicy {...args} />}
-      />
-    </div>
+    <SupplierDetailPage
+      id={id}
+      locale={resolvedLocale}
+      onBack={() => void navigate({ to: "/suppliers" })}
+      onDeleted={() => void navigate({ to: "/suppliers" })}
+      renderCustomerPaymentPolicy={(args) => <SupplierPaymentPolicy {...args} />}
+    />
   )
 }
 

--- a/templates/operator/src/routes/_workspace/suppliers/index.tsx
+++ b/templates/operator/src/routes/_workspace/suppliers/index.tsx
@@ -13,12 +13,10 @@ function SuppliersRoute() {
   const navigate = useNavigate()
 
   return (
-    <div className="p-6">
-      <SuppliersPage
-        onSupplierOpen={(supplier) =>
-          void navigate({ to: "/suppliers/$id", params: { id: supplier.id } })
-        }
-      />
-    </div>
+    <SuppliersPage
+      onSupplierOpen={(supplier) =>
+        void navigate({ to: "/suppliers/$id", params: { id: supplier.id } })
+      }
+    />
   )
 }


### PR DESCRIPTION
## Summary
- add default `p-6` outer padding to the listed page-level UI components
- let suppliers pages accept `className` and use the same `cn(..., className)` pattern as other packages
- document the page mounting contract and add patch changesets for the affected UI packages

Closes #674

## Verification
- `pnpm --filter @voyantjs/auth-ui --filter @voyantjs/bookings-ui --filter @voyantjs/crm-ui --filter @voyantjs/pricing-ui --filter @voyantjs/products-ui --filter @voyantjs/suppliers-ui lint`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyantjs/auth-ui --filter @voyantjs/bookings-ui --filter @voyantjs/crm-ui --filter @voyantjs/pricing-ui --filter @voyantjs/products-ui --filter @voyantjs/suppliers-ui typecheck`
- `pnpm --filter @voyantjs/auth-ui --filter @voyantjs/bookings-ui --filter @voyantjs/crm-ui --filter @voyantjs/pricing-ui --filter @voyantjs/products-ui --filter @voyantjs/suppliers-ui test`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm verify:fast`
- push hook: `pnpm test`