### PR TITLE
feat(agent-control-plane): finish dispatch intents

### DIFF
--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -28,6 +28,7 @@ pnpm -C apps/agent-control-plane dev
 - `POST /api/dispatch-plans`
 - `POST /api/dispatch-plans/latest`
 - `POST /api/dispatch-intents/latest`
+- `POST /api/dispatch-intents/:id/finish`
 - `POST /api/tick-snapshots`
 - `GET /api/tick-snapshots/latest?repository=<owner/name>`
 
@@ -54,6 +55,13 @@ is an operator, supervisor, or runner identifier; the TTL defaults to 900
 seconds and must be between 60 and 3600 seconds. If a non-expired intent already
 exists for the same repository, issue, and action, the endpoint returns
 `dispatch_intent_already_active`.
+
+`POST /api/dispatch-intents/:id/finish` accepts
+`{ holder, status, reason?, exitCode? }` where `status` is `completed`,
+`failed`, or `released`. The holder must match the lease holder. Finishing an
+intent writes a terminal record and updates the active pointer when it still
+points at that lease, allowing the next supervisor lease to proceed without
+waiting for TTL expiry.
 
 `POST /api/tick-snapshots` accepts the JSON emitted by
 `pnpm agent:queue:tick -- --json`, validates the shape, and returns the accepted
@@ -105,6 +113,15 @@ pnpm agent:queue:lease-dispatch -- --repo voyantjs/voyant --holder supervisor:lo
 
 This records the lease and prints the command to run. It does not execute the
 command.
+
+Finish the leased dispatch intent after the runner has handled the printed
+command:
+
+```bash
+AGENT_CONTROL_PLANE_URL=https://agent-control-plane.example.workers.dev \
+AGENT_CONTROL_PLANE_TOKEN=... \
+pnpm agent:queue:finish-dispatch -- --intent intent_579 --holder supervisor:local --status completed
+```
 
 ## Optional R2 Storage
 

--- a/apps/agent-control-plane/src/app.ts
+++ b/apps/agent-control-plane/src/app.ts
@@ -5,6 +5,7 @@ import {
   buildCapabilities,
   buildDispatchIntentFromStoredPlan,
   buildTickSnapshotRecord,
+  dispatchIntentFinishRequestSchema,
   dispatchPlanRequestSchema,
   latestDispatchIntentRequestSchema,
   latestDispatchPlanRequestSchema,
@@ -166,6 +167,62 @@ export function createApp({
       },
       201,
     )
+  })
+
+  app.post("/api/dispatch-intents/:id/finish", async (c) => {
+    const id = c.req.param("id")?.trim()
+    if (!id) {
+      return c.json({ error: "missing_dispatch_intent_id" }, 400)
+    }
+
+    const parsed = dispatchIntentFinishRequestSchema.safeParse(await c.req.json().catch(() => null))
+    if (!parsed.success) {
+      return c.json(
+        {
+          error: "invalid_dispatch_intent_finish_request",
+          issues: validationIssues(parsed.error),
+        },
+        400,
+      )
+    }
+
+    if (!dispatchIntentStore) {
+      return c.json({ error: "dispatch_intent_storage_not_configured" }, 503)
+    }
+
+    const result = await dispatchIntentStore.finishIntent({
+      id,
+      now: now(),
+      request: parsed.data,
+    })
+    if (!result.finished) {
+      if (result.reason === "not_found") {
+        return c.json({ error: "dispatch_intent_not_found" }, 404)
+      }
+
+      return c.json(
+        {
+          error:
+            result.reason === "holder_mismatch"
+              ? "dispatch_intent_holder_mismatch"
+              : result.reason === "finish_contention"
+                ? "dispatch_intent_finish_contention"
+                : "dispatch_intent_not_active",
+          ...(result.intent ? { intent: result.intent } : {}),
+        },
+        409,
+      )
+    }
+
+    return c.json({
+      intent: result.intent,
+      storage: {
+        activeKey: result.write.activeKey,
+        activeUpdated: result.write.activeUpdated,
+        key: result.write.key,
+        persisted: true,
+      },
+    })
   })
 
   app.post("/api/tick-snapshots", async (c) => {

--- a/apps/agent-control-plane/src/control-plane.ts
+++ b/apps/agent-control-plane/src/control-plane.ts
@@ -79,6 +79,17 @@ const dispatchIntentLeaseRequestSchema = z.object({
   ttlSeconds: z.number().int().min(60).max(3600).optional(),
 })
 
+const dispatchIntentTerminalStatusSchema = z.enum(["completed", "failed", "released"])
+
+export const dispatchIntentFinishRequestSchema = z.object({
+  exitCode: z.number().int().optional(),
+  holder: z.string().min(1),
+  reason: z.string().min(1).optional(),
+  status: dispatchIntentTerminalStatusSchema,
+})
+
+export type DispatchIntentFinishRequest = z.infer<typeof dispatchIntentFinishRequestSchema>
+
 export const latestDispatchIntentRequestSchema = z.object({
   filters: dispatchPlanFiltersSchema,
   lease: dispatchIntentLeaseRequestSchema,
@@ -150,8 +161,16 @@ export const dispatchIntentRecordSchema = z.object({
     ttlSeconds: z.number().int().min(60).max(3600),
   }),
   plan: dispatchPlanSchema,
+  resolution: z
+    .object({
+      finishedAt: z.string().min(1),
+      holder: z.string().min(1),
+      exitCode: z.number().int().optional(),
+      reason: z.string().min(1).optional(),
+    })
+    .optional(),
   source: dispatchIntentSourceSchema,
-  status: z.literal("leased"),
+  status: z.union([z.literal("leased"), dispatchIntentTerminalStatusSchema]),
 })
 
 export type DispatchIntentRecord = z.infer<typeof dispatchIntentRecordSchema>
@@ -220,6 +239,7 @@ export function buildCapabilities({
     dispatchIntentContracts: {
       latestSnapshotLease: {
         persistence: dispatchIntentPersistence,
+        terminalStatuses: dispatchIntentTerminalStatusSchema.options,
         ttlSeconds: {
           default: 900,
           min: 60,
@@ -383,6 +403,27 @@ export function buildDispatchIntentFromStoredPlan({
 
 export function isDispatchIntentActive(intent: DispatchIntentRecord, now = new Date()) {
   return intent.status === "leased" && Date.parse(intent.lease.expiresAt) > now.getTime()
+}
+
+export function finishDispatchIntent({
+  intent,
+  now = new Date(),
+  request,
+}: {
+  intent: DispatchIntentRecord
+  now?: Date
+  request: DispatchIntentFinishRequest
+}): DispatchIntentRecord {
+  return {
+    ...intent,
+    resolution: {
+      finishedAt: now.toISOString(),
+      holder: request.holder,
+      ...(request.exitCode === undefined ? {} : { exitCode: request.exitCode }),
+      ...(request.reason ? { reason: request.reason } : {}),
+    },
+    status: request.status,
+  }
 }
 
 function dispatchCommand({

--- a/apps/agent-control-plane/src/dispatch-intent-finish.test.ts
+++ b/apps/agent-control-plane/src/dispatch-intent-finish.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from "vitest"
+
+import { createApp } from "./app.js"
+import {
+  buildTickSnapshotRecord,
+  type DispatchIntentRecord,
+  finishDispatchIntent,
+  isDispatchIntentActive,
+  type TickSnapshotRecord,
+} from "./control-plane.js"
+import type { DispatchIntentStore } from "./dispatch-intent-store.js"
+import type { TickSnapshotStore } from "./tick-snapshot-store.js"
+
+const issue = {
+  number: 579,
+  repository: "voyantjs/voyant",
+  title: "Test agent project intake workflow",
+  url: "https://github.com/voyantjs/voyant/issues/579",
+}
+
+const tickSnapshot = {
+  eventLog: {
+    path: "/repo/.agent-runs/events.jsonl",
+    recentEvents: [],
+  },
+  maxAgeDays: 1,
+  project: {
+    number: 1,
+    owner: "voyantjs",
+    title: "Voyant Engineering",
+    url: "https://github.com/orgs/voyantjs/projects/1",
+  },
+  recommendations: [
+    {
+      action: "remote-bootstrap",
+      command: "pnpm agent:queue:remote-bootstrap -- --issue 579 --repo voyantjs/voyant --yes",
+      issue,
+      priority: 20,
+      reason: "remote workspace is ready for repository bootstrap",
+      state: "Ready",
+    },
+  ],
+  repository: "voyantjs/voyant",
+}
+
+describe("dispatch intent finish lifecycle", () => {
+  it("finishes a leased dispatch intent and allows the next lease immediately", async () => {
+    const intentStore = inMemoryDispatchIntentStore()
+    const app = createApp({
+      authTokens: ["secret"],
+      createDispatchIntentId: () => "replacement_intent",
+      dispatchIntentStore: intentStore,
+      now: () => new Date("2026-05-12T05:32:00.000Z"),
+      tickSnapshotStore: inMemoryTickSnapshotStore([buildTickSnapshotRecord(tickSnapshot)]),
+    })
+    await intentStore.putIntent(leasedIntent())
+
+    const finished = await app.request("/api/dispatch-intents/intent_579/finish", {
+      body: JSON.stringify({
+        holder: "supervisor:test",
+        reason: "command finished",
+        status: "completed",
+      }),
+      headers: { authorization: "Bearer secret", "content-type": "application/json" },
+      method: "POST",
+    })
+
+    expect(finished.status).toBe(200)
+    await expect(finished.json()).resolves.toMatchObject({
+      intent: {
+        id: "intent_579",
+        resolution: {
+          finishedAt: "2026-05-12T05:32:00.000Z",
+          holder: "supervisor:test",
+          reason: "command finished",
+        },
+        status: "completed",
+      },
+      storage: {
+        activeUpdated: true,
+        persisted: true,
+      },
+    })
+
+    const response = await app.request("/api/dispatch-intents/latest", {
+      body: JSON.stringify({
+        lease: {
+          holder: "supervisor:next",
+        },
+        repository: "voyantjs/voyant",
+      }),
+      headers: { authorization: "Bearer secret", "content-type": "application/json" },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(201)
+    await expect(response.json()).resolves.toMatchObject({
+      intent: {
+        id: "replacement_intent",
+        lease: {
+          holder: "supervisor:next",
+        },
+      },
+    })
+  })
+
+  it("rejects finishing intents for the wrong holder or missing storage", async () => {
+    const intentStore = inMemoryDispatchIntentStore()
+    const app = createApp({
+      authTokens: ["secret"],
+      dispatchIntentStore: intentStore,
+      now: () => new Date("2026-05-12T05:32:00.000Z"),
+      tickSnapshotStore: inMemoryTickSnapshotStore([buildTickSnapshotRecord(tickSnapshot)]),
+    })
+    await intentStore.putIntent(leasedIntent())
+
+    const holderMismatch = await app.request("/api/dispatch-intents/intent_579/finish", {
+      body: JSON.stringify({
+        holder: "supervisor:other",
+        status: "released",
+      }),
+      headers: { authorization: "Bearer secret", "content-type": "application/json" },
+      method: "POST",
+    })
+    expect(holderMismatch.status).toBe(409)
+    await expect(holderMismatch.json()).resolves.toMatchObject({
+      error: "dispatch_intent_holder_mismatch",
+      intent: {
+        id: "intent_579",
+      },
+    })
+
+    const notFound = await app.request("/api/dispatch-intents/missing/finish", {
+      body: JSON.stringify({
+        holder: "supervisor:test",
+        status: "released",
+      }),
+      headers: { authorization: "Bearer secret", "content-type": "application/json" },
+      method: "POST",
+    })
+    expect(notFound.status).toBe(404)
+    await expect(notFound.json()).resolves.toEqual({ error: "dispatch_intent_not_found" })
+
+    const noIntentStore = createApp({ authTokens: ["secret"] })
+    const noStore = await noIntentStore.request("/api/dispatch-intents/intent_579/finish", {
+      body: JSON.stringify({
+        holder: "supervisor:test",
+        status: "released",
+      }),
+      headers: { authorization: "Bearer secret", "content-type": "application/json" },
+      method: "POST",
+    })
+    expect(noStore.status).toBe(503)
+    await expect(noStore.json()).resolves.toEqual({
+      error: "dispatch_intent_storage_not_configured",
+    })
+  })
+})
+
+function leasedIntent(): DispatchIntentRecord {
+  return {
+    createdAt: "2026-05-12T05:30:00.000Z",
+    id: "intent_579",
+    lease: {
+      acquiredAt: "2026-05-12T05:30:00.000Z",
+      expiresAt: "2026-05-12T05:45:00.000Z",
+      holder: "supervisor:test",
+      ttlSeconds: 900,
+    },
+    plan: {
+      action: "remote-bootstrap",
+      command: ["pnpm", "agent:queue:remote-bootstrap"],
+      issue,
+      reason: "leased command",
+      repository: "voyantjs/voyant",
+      requiresMutation: true,
+    },
+    source: {
+      acceptedAt: "2026-05-12T05:00:00.000Z",
+      recommendationCount: 1,
+      repository: "voyantjs/voyant",
+      type: "latest_tick_snapshot",
+    },
+    status: "leased",
+  }
+}
+
+function inMemoryTickSnapshotStore(records: TickSnapshotRecord[]): TickSnapshotStore {
+  const latest = new Map(
+    records.map((record) => [record.snapshot.repository.toLowerCase(), record]),
+  )
+
+  return {
+    async getLatest(repository) {
+      return latest.get(repository.toLowerCase()) ?? null
+    },
+    async putLatest(record) {
+      latest.set(record.snapshot.repository.toLowerCase(), record)
+      return { key: `latest/${record.snapshot.repository.toLowerCase()}.json` }
+    },
+  }
+}
+
+function inMemoryDispatchIntentStore(): DispatchIntentStore {
+  const active = new Map<string, DispatchIntentRecord>()
+  const byId = new Map<string, DispatchIntentRecord>()
+
+  return {
+    async acquireIntent(record, { now }) {
+      const key = activeIntentKey(record)
+      const existing = active.get(key)
+      if (existing && isDispatchIntentActive(existing, now)) {
+        return { acquired: false, activeIntent: existing }
+      }
+
+      active.set(key, record)
+      byId.set(record.id, record)
+      return { acquired: true, write: { activeKey: key, key: `${record.id}.json` } }
+    },
+    async finishIntent({ id, now, request }) {
+      const intent = byId.get(id)
+      if (!intent) return { finished: false, reason: "not_found" }
+      if (intent.status !== "leased")
+        return { finished: false, intent, reason: "intent_not_active" }
+      if (intent.lease.holder !== request.holder) {
+        return { finished: false, intent, reason: "holder_mismatch" }
+      }
+
+      const finishedIntent = finishDispatchIntent({ intent, now, request })
+      const activeKey = activeIntentKey(intent)
+      byId.set(id, finishedIntent)
+      active.set(activeKey, finishedIntent)
+      return {
+        finished: true,
+        intent: finishedIntent,
+        write: { activeKey, activeUpdated: true, key: `${intent.id}.json` },
+      }
+    },
+    async getActive(reference) {
+      return active.get(activeIntentReferenceKey(reference)) ?? null
+    },
+    async putIntent(record) {
+      const activeKey = activeIntentKey(record)
+      byId.set(record.id, record)
+      active.set(activeKey, record)
+      return { activeKey, key: `${record.id}.json` }
+    },
+  }
+}
+
+function activeIntentKey(record: DispatchIntentRecord) {
+  return activeIntentReferenceKey({
+    action: record.plan.action,
+    issueNumber: record.plan.issue.number,
+    repository: record.plan.repository,
+  })
+}
+
+function activeIntentReferenceKey({
+  action,
+  issueNumber,
+  repository,
+}: {
+  action: string
+  issueNumber: number
+  repository: string
+}) {
+  return `active/${repository.toLowerCase()}/${issueNumber}/${action.toLowerCase()}.json`
+}

--- a/apps/agent-control-plane/src/dispatch-intent-store.ts
+++ b/apps/agent-control-plane/src/dispatch-intent-store.ts
@@ -1,6 +1,8 @@
 import {
+  type DispatchIntentFinishRequest,
   type DispatchIntentRecord,
   dispatchIntentRecordSchema,
+  finishDispatchIntent,
   isDispatchIntentActive,
 } from "./control-plane.js"
 
@@ -9,6 +11,11 @@ export interface DispatchIntentStore {
     record: DispatchIntentRecord,
     options: { now: Date },
   ): Promise<DispatchIntentAcquireResult>
+  finishIntent(options: {
+    id: string
+    now: Date
+    request: DispatchIntentFinishRequest
+  }): Promise<DispatchIntentFinishResult>
   getActive(reference: DispatchIntentReference): Promise<DispatchIntentRecord | null>
   putIntent(record: DispatchIntentRecord): Promise<DispatchIntentStoreWrite>
 }
@@ -27,6 +34,18 @@ export interface DispatchIntentStoreWrite {
 export type DispatchIntentAcquireResult =
   | { acquired: true; write: DispatchIntentStoreWrite }
   | { acquired: false; activeIntent: DispatchIntentRecord }
+
+export type DispatchIntentFinishResult =
+  | {
+      finished: true
+      intent: DispatchIntentRecord
+      write: DispatchIntentStoreWrite & { activeUpdated: boolean }
+    }
+  | {
+      finished: false
+      intent?: DispatchIntentRecord
+      reason: "finish_contention" | "holder_mismatch" | "intent_not_active" | "not_found"
+    }
 
 export interface DispatchIntentBucket {
   get(key: string): Promise<{ etag?: string; text(): Promise<string> } | null>
@@ -54,7 +73,7 @@ export function createR2DispatchIntentStore({
       const existingObject = await bucket.get(activeKey)
       if (existingObject) {
         const activeIntent = parseStoredIntent({
-          repository: reference.repository,
+          context: reference.repository,
           text: await existingObject.text(),
         })
         if (isDispatchIntentActive(activeIntent, now)) {
@@ -93,12 +112,99 @@ export function createR2DispatchIntentStore({
       }
     },
 
+    async finishIntent({ id, now, request }) {
+      const key = intentKey({ id, keyPrefix })
+      const object = await bucket.get(key)
+      if (!object) {
+        return { finished: false, reason: "not_found" }
+      }
+
+      const intent = parseStoredIntent({
+        context: id,
+        text: await object.text(),
+      })
+      if (intent.status !== "leased") {
+        return { finished: false, intent, reason: "intent_not_active" }
+      }
+      if (intent.lease.holder !== request.holder) {
+        return { finished: false, intent, reason: "holder_mismatch" }
+      }
+
+      const finishedIntent = finishDispatchIntent({ intent, now, request })
+      const value = JSON.stringify(finishedIntent)
+      const writeOptions = {
+        httpMetadata: {
+          contentType: "application/json",
+        },
+        ...(object.etag ? { onlyIf: { etagMatches: object.etag } } : {}),
+      }
+      const byIdWrite = await bucket.put(key, value, writeOptions)
+      if (!byIdWrite) {
+        const currentObject = await bucket.get(key)
+        if (!currentObject) {
+          return { finished: false, reason: "not_found" }
+        }
+
+        const currentIntent = parseStoredIntent({
+          context: id,
+          text: await currentObject.text(),
+        })
+        return { finished: false, intent: currentIntent, reason: "finish_contention" }
+      }
+
+      const reference = recordReference(intent)
+      const activeKey = activeIntentKey({ keyPrefix, reference })
+      const activeObject = await bucket.get(activeKey)
+      let activeUpdated = false
+      if (activeObject) {
+        const activeIntent = parseStoredIntent({
+          context: `${reference.repository}#${reference.issueNumber}`,
+          text: await activeObject.text(),
+        })
+        if (activeIntent.id === intent.id) {
+          const activeWrite = await bucket.put(activeKey, value, {
+            httpMetadata: {
+              contentType: "application/json",
+            },
+            ...(activeObject.etag ? { onlyIf: { etagMatches: activeObject.etag } } : {}),
+          })
+          activeUpdated = Boolean(activeWrite)
+          if (!activeUpdated) {
+            const refreshedActiveObject = await bucket.get(activeKey)
+            if (refreshedActiveObject) {
+              const refreshedActiveIntent = parseStoredIntent({
+                context: `${reference.repository}#${reference.issueNumber}`,
+                text: await refreshedActiveObject.text(),
+              })
+              if (refreshedActiveIntent.id === intent.id) {
+                const retryWrite = await bucket.put(activeKey, value, {
+                  httpMetadata: {
+                    contentType: "application/json",
+                  },
+                  ...(refreshedActiveObject.etag
+                    ? { onlyIf: { etagMatches: refreshedActiveObject.etag } }
+                    : {}),
+                })
+                activeUpdated = Boolean(retryWrite)
+              }
+            }
+          }
+        }
+      }
+
+      return {
+        finished: true,
+        intent: finishedIntent,
+        write: { activeKey, activeUpdated, key },
+      }
+    },
+
     async getActive(reference) {
       const object = await bucket.get(activeIntentKey({ keyPrefix, reference }))
       if (!object) return null
 
       return parseStoredIntent({
-        repository: reference.repository,
+        context: reference.repository,
         text: await object.text(),
       })
     },
@@ -128,10 +234,10 @@ function intentKey({ id, keyPrefix }: { id: string; keyPrefix: string }) {
   return normalizedPrefix ? `${normalizedPrefix}/${key}` : key
 }
 
-function parseStoredIntent({ repository, text }: { repository: string; text: string }) {
+function parseStoredIntent({ context, text }: { context: string; text: string }) {
   const parsed = dispatchIntentRecordSchema.safeParse(JSON.parse(text))
   if (!parsed.success) {
-    throw new Error(`stored dispatch intent is invalid for ${repository}`)
+    throw new Error(`stored dispatch intent is invalid for ${context}`)
   }
 
   return parsed.data

--- a/apps/agent-control-plane/src/latest-dispatch-intent.test.ts
+++ b/apps/agent-control-plane/src/latest-dispatch-intent.test.ts
@@ -4,6 +4,8 @@ import { createApp } from "./app.js"
 import {
   buildTickSnapshotRecord,
   type DispatchIntentRecord,
+  finishDispatchIntent,
+  isDispatchIntentActive,
   type TickSnapshotRecord,
 } from "./control-plane.js"
 import type { DispatchIntentStore } from "./dispatch-intent-store.js"
@@ -356,6 +358,7 @@ function inMemoryTickSnapshotStore(records: TickSnapshotRecord[] = []): TickSnap
 
 function inMemoryDispatchIntentStore(): DispatchIntentStore {
   const active = new Map<string, DispatchIntentRecord>()
+  const byId = new Map<string, DispatchIntentRecord>()
 
   return {
     async acquireIntent(record, { now }) {
@@ -365,11 +368,12 @@ function inMemoryDispatchIntentStore(): DispatchIntentStore {
         repository: record.plan.repository,
       })
       const existing = active.get(key)
-      if (existing && Date.parse(existing.lease.expiresAt) > now.getTime()) {
+      if (existing && isDispatchIntentActive(existing, now)) {
         return { acquired: false, activeIntent: existing }
       }
 
       active.set(key, record)
+      byId.set(record.id, record)
       return {
         acquired: true,
         write: {
@@ -378,10 +382,45 @@ function inMemoryDispatchIntentStore(): DispatchIntentStore {
         },
       }
     },
+    async finishIntent({ id, now, request }) {
+      const intent = byId.get(id)
+      if (!intent) {
+        return { finished: false, reason: "not_found" }
+      }
+      if (intent.status !== "leased") {
+        return { finished: false, intent, reason: "intent_not_active" }
+      }
+      if (intent.lease.holder !== request.holder) {
+        return { finished: false, intent, reason: "holder_mismatch" }
+      }
+
+      const finishedIntent = finishDispatchIntent({ intent, now, request })
+      const activeKey = activeIntentKey({
+        action: intent.plan.action,
+        issueNumber: intent.plan.issue.number,
+        repository: intent.plan.repository,
+      })
+      byId.set(id, finishedIntent)
+      const activeUpdated = active.get(activeKey)?.id === id
+      if (activeUpdated) {
+        active.set(activeKey, finishedIntent)
+      }
+
+      return {
+        finished: true,
+        intent: finishedIntent,
+        write: {
+          activeKey,
+          activeUpdated,
+          key: `${intent.id}.json`,
+        },
+      }
+    },
     async getActive(reference) {
       return active.get(activeIntentKey(reference)) ?? null
     },
     async putIntent(record) {
+      byId.set(record.id, record)
       active.set(
         activeIntentKey({
           action: record.plan.action,

--- a/apps/agent-control-plane/src/tick-snapshot-store.test.ts
+++ b/apps/agent-control-plane/src/tick-snapshot-store.test.ts
@@ -293,6 +293,52 @@ describe("tick snapshot storage", () => {
         id: "intent_579",
       },
     })
+
+    await expect(
+      store.finishIntent({
+        id: "intent_579",
+        now: new Date("2026-05-12T05:41:00.000Z"),
+        request: {
+          holder: "supervisor:test",
+          reason: "command completed",
+          status: "completed",
+        },
+      }),
+    ).resolves.toMatchObject({
+      finished: true,
+      intent: {
+        id: "intent_579",
+        resolution: {
+          finishedAt: "2026-05-12T05:41:00.000Z",
+          holder: "supervisor:test",
+          reason: "command completed",
+        },
+        status: "completed",
+      },
+      write: {
+        activeUpdated: true,
+      },
+    })
+
+    await expect(
+      store.acquireIntent(
+        {
+          ...intent,
+          id: "intent_580",
+          lease: {
+            ...intent.lease,
+            holder: "supervisor:next",
+          },
+        },
+        { now: new Date("2026-05-12T05:42:00.000Z") },
+      ),
+    ).resolves.toMatchObject({
+      acquired: true,
+      write: {
+        activeKey: "supervisor/dispatch-intents/active/voyantjs%2Fvoyant/579/remote-bootstrap.json",
+        key: "supervisor/dispatch-intents/by-id/intent_580.json",
+      },
+    })
   })
 })
 

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1336,6 +1336,11 @@ Verification:
   binding is configured. This gives always-on supervisors a durable coordination
   record for the selected lifecycle command, lease holder, and expiration while
   command execution remains runner-owned.
+- Runners can finish those leased dispatch intents with
+  `pnpm agent:queue:finish-dispatch`, which calls
+  `POST /api/dispatch-intents/:id/finish` and records `completed`, `failed`, or
+  `released` without waiting for lease TTL expiry. The holder must match the
+  holder recorded on the lease.
 
 ## Open Questions
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "agent:queue:submit-tick": "node scripts/agent-runner-submit-tick.mjs",
     "agent:queue:plan-dispatch": "node scripts/agent-runner-plan-dispatch.mjs",
     "agent:queue:lease-dispatch": "node scripts/agent-runner-lease-dispatch.mjs",
+    "agent:queue:finish-dispatch": "node scripts/agent-runner-finish-dispatch.mjs",
     "agent:queue:dispatch": "node scripts/agent-runner-dispatch.mjs",
     "agent:queue:loop": "node scripts/agent-runner-loop.mjs",
     "agent:queue:remote-inspect": "node scripts/agent-runner-remote-inspect.mjs",

--- a/scripts/agent-runner-finish-dispatch.mjs
+++ b/scripts/agent-runner-finish-dispatch.mjs
@@ -1,0 +1,99 @@
+import { fail, parseArgs } from "./lib/agent-project-queue.mjs"
+import {
+  controlPlaneConfigFromArgs,
+  finishDispatchIntent,
+} from "./lib/agent-runner-control-plane.mjs"
+import { maybePrintHelp } from "./lib/agent-runner-help.mjs"
+
+const terminalStatuses = new Set(["completed", "failed", "released"])
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:finish-dispatch",
+  summary: "Mark a leased dispatch intent as completed, failed, or released.",
+  usage:
+    "pnpm agent:queue:finish-dispatch -- --intent <id> --holder <id> --status <completed|failed|released>",
+  options: [
+    ["--control-plane-url <url>", "Control-plane base URL. Defaults to AGENT_CONTROL_PLANE_URL."],
+    ["AGENT_CONTROL_PLANE_TOKEN", "Bearer token environment variable used for API routes."],
+    ["--intent <id>", "Dispatch intent id returned by agent:queue:lease-dispatch."],
+    ["--holder <id>", "Lease holder recorded on the dispatch intent."],
+    ["--status <name>", "Terminal status: completed, failed, or released."],
+    ["--reason <text>", "Optional completion note for audit context."],
+    ["--exit-code <number>", "Optional process exit code for completed or failed commands."],
+    ["--json", "Print machine-readable JSON."],
+  ],
+})
+
+const id = requiredString(args.intent, "intent")
+const holder = requiredString(args.holder, "holder")
+const status = requiredString(args.status, "status")
+if (!terminalStatuses.has(status)) {
+  fail(`invalid status: ${status}`)
+}
+
+const exitCode = optionalInteger(args.exitCode, "exit-code")
+const request = {
+  holder,
+  status,
+  ...(args.reason ? { reason: String(args.reason).trim() } : {}),
+  ...(exitCode === undefined ? {} : { exitCode }),
+}
+const config = readControlPlaneConfig()
+
+try {
+  const result = await finishDispatchIntent({
+    id,
+    request,
+    token: config.token,
+    url: config.url,
+  })
+
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2))
+  } else {
+    printResult({ controlPlaneUrl: config.url, result })
+  }
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error))
+}
+
+function printResult({ controlPlaneUrl, result }) {
+  console.log("agent-runner dispatch intent finish")
+  console.log(`control plane: ${controlPlaneUrl}`)
+  console.log(`intent: ${result.intent.id}`)
+  console.log(`status: ${result.intent.status}`)
+  console.log(`holder: ${result.intent.resolution?.holder ?? result.intent.lease.holder}`)
+  if (result.intent.resolution?.finishedAt) {
+    console.log(`finished: ${result.intent.resolution.finishedAt}`)
+  }
+  if (result.intent.resolution?.reason) {
+    console.log(`reason: ${result.intent.resolution.reason}`)
+  }
+  console.log(`active updated: ${result.storage.activeUpdated ? "yes" : "no"}`)
+}
+
+function readControlPlaneConfig() {
+  try {
+    return controlPlaneConfigFromArgs(args)
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error))
+  }
+}
+
+function requiredString(value, name) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    fail(`missing required --${name}`)
+  }
+  return value.trim()
+}
+
+function optionalInteger(value, name) {
+  if (value === undefined) return undefined
+
+  const number = Number(value)
+  if (!Number.isInteger(number)) {
+    fail(`invalid ${name}: ${value}`)
+  }
+  return number
+}

--- a/scripts/lib/agent-runner-control-plane.mjs
+++ b/scripts/lib/agent-runner-control-plane.mjs
@@ -83,6 +83,32 @@ export async function requestLatestDispatchIntent({ fetchImpl = fetch, request, 
   return body
 }
 
+export async function finishDispatchIntent({ fetchImpl = fetch, id, request, token, url }) {
+  const response = await fetchImpl(
+    `${normalizeControlPlaneUrl(url)}/api/dispatch-intents/${encodeURIComponent(id)}/finish`,
+    {
+      body: JSON.stringify(request),
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      method: "POST",
+    },
+  )
+
+  const bodyText = await response.text()
+  const body = parseJsonBody(bodyText)
+
+  if (!response.ok) {
+    const detail = body?.error ? `: ${body.error}` : bodyText ? `: ${bodyText}` : ""
+    throw new Error(
+      `control plane rejected dispatch intent finish with ${response.status}${detail}`,
+    )
+  }
+
+  return body
+}
+
 function normalizeControlPlaneUrl(url) {
   return String(url).replace(/\/+$/, "")
 }

--- a/scripts/tests/agent-runner-control-plane.test.mjs
+++ b/scripts/tests/agent-runner-control-plane.test.mjs
@@ -3,6 +3,7 @@ import { describe, it } from "node:test"
 
 import {
   controlPlaneConfigFromArgs,
+  finishDispatchIntent,
   requestLatestDispatchIntent,
   requestLatestDispatchPlan,
   submitTickSnapshot,
@@ -272,6 +273,77 @@ describe("agent runner control plane client", () => {
         url: "https://control.example.com",
       }),
       /409: dispatch_intent_already_active/,
+    )
+  })
+
+  it("finishes dispatch intents", async () => {
+    const calls = []
+    const response = await finishDispatchIntent({
+      fetchImpl: async (url, init) => {
+        calls.push({ init, url })
+        return new Response(
+          JSON.stringify({
+            intent: {
+              id: "intent_579",
+              lease: {
+                holder: "supervisor:test",
+              },
+              resolution: {
+                finishedAt: "2026-05-12T12:05:00.000Z",
+                holder: "supervisor:test",
+                reason: "done",
+              },
+              status: "completed",
+            },
+            storage: {
+              activeUpdated: true,
+              persisted: true,
+            },
+          }),
+          { status: 200 },
+        )
+      },
+      id: "intent_579",
+      request: {
+        holder: "supervisor:test",
+        reason: "done",
+        status: "completed",
+      },
+      token: "tok",
+      url: "https://control.example.com/",
+    })
+
+    assert.equal(response.intent.status, "completed")
+    assert.equal(calls[0].url, "https://control.example.com/api/dispatch-intents/intent_579/finish")
+    assert.equal(calls[0].init.method, "POST")
+    assert.equal(calls[0].init.headers.authorization, "Bearer tok")
+    assert.equal(calls[0].init.headers["content-type"], "application/json")
+    assert.equal(
+      calls[0].init.body,
+      JSON.stringify({
+        holder: "supervisor:test",
+        reason: "done",
+        status: "completed",
+      }),
+    )
+  })
+
+  it("surfaces rejected dispatch intent finish responses", async () => {
+    await assert.rejects(
+      finishDispatchIntent({
+        fetchImpl: async () =>
+          new Response(JSON.stringify({ error: "dispatch_intent_holder_mismatch" }), {
+            status: 409,
+          }),
+        id: "intent_579",
+        request: {
+          holder: "supervisor:other",
+          status: "released",
+        },
+        token: "tok",
+        url: "https://control.example.com",
+      }),
+      /409: dispatch_intent_holder_mismatch/,
     )
   })
 })


### PR DESCRIPTION
## Summary

- add a dispatch intent finish contract with `completed`, `failed`, and `released` terminal states
- persist terminal intent records through the R2-backed store and update the active pointer when it still belongs to the finished lease
- add `pnpm agent:queue:finish-dispatch` plus runner client coverage and documentation

## Validation

- `pnpm -C apps/agent-control-plane test`
- `pnpm -C apps/agent-control-plane typecheck`
- `pnpm --filter @voyantjs/agent-control-plane lint`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm agent:queue:test`
- `git diff --check`
- commit hook: changed-file formatting, secretlint, agent quality, affected typecheck
- pre-push hook: `pnpm test`