### PR TITLE
feat(agent-runner): run leased dispatch intents

### DIFF
--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -123,6 +123,18 @@ AGENT_CONTROL_PLANE_TOKEN=... \
 pnpm agent:queue:finish-dispatch -- --intent intent_579 --holder supervisor:local --status completed
 ```
 
+Run the full local supervisor path for one dispatchable item:
+
+```bash
+AGENT_CONTROL_PLANE_URL=https://agent-control-plane.example.workers.dev \
+AGENT_CONTROL_PLANE_TOKEN=... \
+pnpm agent:queue:run-dispatch-intent -- --repo voyantjs/voyant --holder supervisor:local --yes
+```
+
+This leases the next intent, validates that the leased command is an allowed
+`pnpm agent:queue:*` lifecycle command, executes it locally, then records
+`completed` or `failed` on the dispatch intent.
+
 ## Optional R2 Storage
 
 Bind an R2 bucket as `AGENT_TICK_SNAPSHOTS` to keep the latest accepted tick

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1341,6 +1341,11 @@ Verification:
   `POST /api/dispatch-intents/:id/finish` and records `completed`, `failed`, or
   `released` without waiting for lease TTL expiry. The holder must match the
   holder recorded on the lease.
+- A local supervisor can run one complete leased lifecycle step with
+  `pnpm agent:queue:run-dispatch-intent -- --holder <id> --yes`. It leases the
+  next intent from the control plane, validates that the command is an allowed
+  `pnpm agent:queue:*` lifecycle command, executes it without a shell, and then
+  records the terminal dispatch intent outcome.
 
 ## Open Questions
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "agent:queue:plan-dispatch": "node scripts/agent-runner-plan-dispatch.mjs",
     "agent:queue:lease-dispatch": "node scripts/agent-runner-lease-dispatch.mjs",
     "agent:queue:finish-dispatch": "node scripts/agent-runner-finish-dispatch.mjs",
+    "agent:queue:run-dispatch-intent": "node scripts/agent-runner-run-dispatch-intent.mjs",
     "agent:queue:dispatch": "node scripts/agent-runner-dispatch.mjs",
     "agent:queue:loop": "node scripts/agent-runner-loop.mjs",
     "agent:queue:remote-inspect": "node scripts/agent-runner-remote-inspect.mjs",

--- a/scripts/agent-runner-run-dispatch-intent.mjs
+++ b/scripts/agent-runner-run-dispatch-intent.mjs
@@ -1,0 +1,235 @@
+import { currentRepositoryFromOrigin, fail, parseArgs, runGit } from "./lib/agent-project-queue.mjs"
+import {
+  controlPlaneConfigFromArgs,
+  finishDispatchIntent,
+  requestLatestDispatchIntent,
+} from "./lib/agent-runner-control-plane.mjs"
+import {
+  dispatchableActions,
+  dispatchIntentCommandArgs,
+  runDispatchIntentCommand,
+} from "./lib/agent-runner-dispatch.mjs"
+import {
+  issueEventDetails,
+  resolveEventLogPath,
+  tryAppendAgentRunnerEvent,
+} from "./lib/agent-runner-events.mjs"
+import { eventLogOptions, maybePrintHelp, repositoryOptions } from "./lib/agent-runner-help.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:run-dispatch-intent",
+  summary: "Lease one control-plane dispatch intent, run it, and report the terminal outcome.",
+  usage: "pnpm agent:queue:run-dispatch-intent -- --holder <id> --yes [--repo <owner/name>]",
+  options: [
+    ["--control-plane-url <url>", "Control-plane base URL. Defaults to AGENT_CONTROL_PLANE_URL."],
+    ["AGENT_CONTROL_PLANE_TOKEN", "Bearer token environment variable used for API routes."],
+    ["--holder <id>", "Supervisor or runner identifier recorded on the lease."],
+    ["--ttl-seconds <number>", "Lease TTL in seconds, 60..3600. Defaults to 900."],
+    ["--issue <number>", "Only lease a recommendation for this issue number."],
+    [
+      "--action <name>",
+      `Only lease this action. Allowed: ${Array.from(dispatchableActions).join(", ")}.`,
+    ],
+    ...eventLogOptions,
+    ["--update-body", "When leasing sync-pr, include --update-body in the returned command."],
+    ["--json", "Print machine-readable JSON after finishing the intent."],
+    ["--yes", "Required before the leased command is executed."],
+    ...repositoryOptions,
+  ],
+})
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const holder = requiredString(args.holder, "holder")
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
+
+if (!args.yes) {
+  fail("run-dispatch-intent executes one leased queue mutation; rerun with --yes")
+}
+
+if (args.action && !dispatchableActions.has(args.action)) {
+  fail(`action ${args.action} is not dispatchable`)
+}
+
+const issueNumber = optionalPositiveInteger(args.issue, "issue")
+const ttlSeconds = optionalInteger(args.ttlSeconds, "ttl-seconds", { max: 3600, min: 60 })
+const config = readControlPlaneConfig()
+const request = {
+  repository,
+  lease: {
+    holder,
+    ...(ttlSeconds ? { ttlSeconds } : {}),
+  },
+  ...(issueNumber || args.action
+    ? {
+        filters: {
+          ...(args.action ? { action: args.action } : {}),
+          ...(issueNumber ? { issueNumber } : {}),
+        },
+      }
+    : {}),
+  ...(args.eventLog || args.updateBody
+    ? {
+        options: {
+          ...(args.eventLog ? { eventLog: args.eventLog } : {}),
+          ...(args.updateBody ? { updateBody: true } : {}),
+        },
+      }
+    : {}),
+}
+
+let leaseResult
+try {
+  leaseResult = await requestLatestDispatchIntent({
+    request,
+    token: config.token,
+    url: config.url,
+  })
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error))
+}
+
+if (!leaseResult.intent) {
+  if (args.json) {
+    console.log(JSON.stringify(leaseResult, null, 2))
+  } else {
+    console.log(`dispatch intent: none (${leaseResult.reason})`)
+  }
+  process.exit(0)
+}
+
+const intent = leaseResult.intent
+let commandArgs
+let finishResult
+let status = 1
+let terminalStatus = "failed"
+let terminalReason = "command failed"
+
+try {
+  commandArgs = dispatchIntentCommandArgs(intent)
+  printIntent({ commandArgs, controlPlaneUrl: config.url, intent })
+  tryAppendAgentRunnerEvent({
+    eventLogPath,
+    event: {
+      type: "dispatch-intent.started",
+      command: ["pnpm", ...commandArgs],
+      intent: intentEventDetails(intent),
+      issue: issueEventDetails(intent.plan),
+      repository,
+    },
+  })
+  status = runDispatchIntentCommand(intent) ?? 1
+  terminalStatus = status === 0 ? "completed" : "failed"
+  terminalReason = status === 0 ? "command completed" : `command exited with status ${status}`
+} catch (error) {
+  terminalStatus = "failed"
+  terminalReason = error instanceof Error ? error.message : String(error)
+  console.error(`dispatch intent failed before completion: ${terminalReason}`)
+}
+
+try {
+  finishResult = await finishDispatchIntent({
+    id: intent.id,
+    request: {
+      exitCode: status,
+      holder,
+      reason: terminalReason,
+      status: terminalStatus,
+    },
+    token: config.token,
+    url: config.url,
+  })
+  tryAppendAgentRunnerEvent({
+    eventLogPath,
+    event: {
+      type: "dispatch-intent.finished",
+      intent: intentEventDetails(finishResult.intent),
+      issue: issueEventDetails(intent.plan),
+      repository,
+      status,
+      terminalStatus,
+    },
+  })
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error)
+  tryAppendAgentRunnerEvent({
+    eventLogPath,
+    event: {
+      type: "dispatch-intent.finish_failed",
+      error: message,
+      intent: intentEventDetails(intent),
+      issue: issueEventDetails(intent.plan),
+      repository,
+      status,
+      terminalStatus,
+    },
+  })
+  fail(message)
+}
+
+if (args.json) {
+  console.log(
+    JSON.stringify(
+      {
+        finish: finishResult,
+        lease: leaseResult,
+        status,
+      },
+      null,
+      2,
+    ),
+  )
+} else {
+  console.log(`dispatch intent ${intent.id}: ${terminalStatus}`)
+}
+
+process.exitCode = status
+
+function printIntent({ commandArgs, controlPlaneUrl, intent }) {
+  console.log("agent-runner dispatch intent")
+  console.log(`control plane: ${controlPlaneUrl}`)
+  console.log(`intent: ${intent.id}`)
+  console.log(`holder: ${intent.lease.holder}`)
+  console.log(`issue: #${intent.plan.issue.number} ${intent.plan.issue.title}`)
+  console.log(`action: ${intent.plan.action}`)
+  console.log(`command: pnpm ${commandArgs.join(" ")}`)
+}
+
+function intentEventDetails(intent) {
+  return {
+    action: intent.plan.action,
+    holder: intent.lease.holder,
+    id: intent.id,
+    status: intent.status,
+  }
+}
+
+function readControlPlaneConfig() {
+  try {
+    return controlPlaneConfigFromArgs(args)
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error))
+  }
+}
+
+function requiredString(value, name) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    fail(`missing required --${name}`)
+  }
+  return value.trim()
+}
+
+function optionalPositiveInteger(value, name) {
+  return optionalInteger(value, name, { min: 1 })
+}
+
+function optionalInteger(value, name, { max = Number.POSITIVE_INFINITY, min = 1 } = {}) {
+  if (value === undefined) return undefined
+
+  const number = Number(value)
+  if (!Number.isInteger(number) || number < min || number > max) {
+    fail(`invalid ${name}: ${value}`)
+  }
+  return number
+}

--- a/scripts/lib/agent-runner-dispatch.mjs
+++ b/scripts/lib/agent-runner-dispatch.mjs
@@ -73,6 +73,52 @@ export function runDispatchCommand(commandArgs) {
   }).status
 }
 
+export function dispatchIntentCommandArgs(intent) {
+  const command = intent?.plan?.command
+  if (!Array.isArray(command) || command.length < 2) {
+    throw new Error("dispatch intent command is missing")
+  }
+
+  const [binary, script, ...rest] = command
+  if (binary !== "pnpm") {
+    throw new Error(`dispatch intent command must use pnpm, got ${String(binary)}`)
+  }
+  if (typeof script !== "string" || !script.startsWith("agent:queue:")) {
+    throw new Error("dispatch intent command must target an agent queue script")
+  }
+
+  const action = script.slice("agent:queue:".length)
+  if (action !== intent.plan.action) {
+    throw new Error(`dispatch intent command action ${action} does not match ${intent.plan.action}`)
+  }
+  if (!dispatchableActions.has(action)) {
+    throw new Error(`action ${action} is not dispatchable`)
+  }
+  if (rest[0] !== "--") {
+    throw new Error("dispatch intent command must include the pnpm argument separator")
+  }
+  const issueNumber = optionValue(rest, "--issue")
+  if (issueNumber !== String(intent.plan.issue.number)) {
+    throw new Error("dispatch intent command issue does not match the leased plan")
+  }
+  const repository = optionValue(rest, "--repo")
+  if (!repositoriesMatch(repository, intent.plan.repository)) {
+    throw new Error("dispatch intent command repository does not match the leased plan")
+  }
+  if (!rest.includes("--yes")) {
+    throw new Error("dispatch intent command must include --yes")
+  }
+
+  return [script, ...rest]
+}
+
+export function runDispatchIntentCommand(intent, { spawn = spawnSync } = {}) {
+  return spawn("pnpm", dispatchIntentCommandArgs(intent), {
+    encoding: "utf8",
+    stdio: "inherit",
+  }).status
+}
+
 function normalizeIssueNumber(issueNumber) {
   if (issueNumber === undefined) return undefined
 
@@ -82,4 +128,17 @@ function normalizeIssueNumber(issueNumber) {
   }
 
   return normalized
+}
+
+function optionValue(args, name) {
+  const index = args.indexOf(name)
+  return index === -1 ? undefined : args[index + 1]
+}
+
+function repositoriesMatch(left, right) {
+  return (
+    typeof left === "string" &&
+    typeof right === "string" &&
+    left.trim().toLowerCase() === right.trim().toLowerCase()
+  )
 }

--- a/scripts/tests/agent-runner-dispatch.test.mjs
+++ b/scripts/tests/agent-runner-dispatch.test.mjs
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict"
 import { describe, it } from "node:test"
 
-import { dispatchCommandArgs, selectDispatchRecommendation } from "../lib/agent-runner-dispatch.mjs"
+import {
+  dispatchCommandArgs,
+  dispatchIntentCommandArgs,
+  runDispatchIntentCommand,
+  selectDispatchRecommendation,
+} from "../lib/agent-runner-dispatch.mjs"
 import { recommendQueueAction } from "../lib/agent-runner-tick.mjs"
 import { workItem } from "./agent-fixtures.mjs"
 
@@ -330,4 +335,153 @@ describe("agent runner dispatch helpers", () => {
       /invalid issue number: 0/,
     )
   })
+
+  it("validates and runs leased dispatch intent commands without a shell", () => {
+    const intent = dispatchIntent()
+    assert.deepEqual(dispatchIntentCommandArgs(intent), [
+      "agent:queue:start",
+      "--",
+      "--issue",
+      "579",
+      "--repo",
+      "voyantjs/voyant",
+      "--yes",
+    ])
+
+    const calls = []
+    const status = runDispatchIntentCommand(intent, {
+      spawn: (binary, args, options) => {
+        calls.push({ args, binary, options })
+        return { status: 0 }
+      },
+    })
+
+    assert.equal(status, 0)
+    assert.deepEqual(calls, [
+      {
+        args: dispatchIntentCommandArgs(intent),
+        binary: "pnpm",
+        options: {
+          encoding: "utf8",
+          stdio: "inherit",
+        },
+      },
+    ])
+  })
+
+  it("rejects leased dispatch intent commands outside the runner allow-list", () => {
+    assert.throws(
+      () =>
+        dispatchIntentCommandArgs(
+          dispatchIntent({
+            command: ["node", "-e", "process.exit(0)"],
+          }),
+        ),
+      /must use pnpm/,
+    )
+    assert.throws(
+      () =>
+        dispatchIntentCommandArgs(
+          dispatchIntent({
+            action: "start",
+            command: ["pnpm", "agent:queue:cleanup", "--", "--issue", "579", "--yes"],
+          }),
+        ),
+      /does not match start/,
+    )
+    assert.throws(
+      () =>
+        dispatchIntentCommandArgs(
+          dispatchIntent({
+            command: ["pnpm", "agent:queue:run-command", "--", "--issue", "579", "--yes"],
+          }),
+        ),
+      /does not match start/,
+    )
+    assert.throws(
+      () =>
+        dispatchIntentCommandArgs(
+          dispatchIntent({
+            command: [
+              "pnpm",
+              "agent:queue:start",
+              "--",
+              "--issue",
+              "579",
+              "--repo",
+              "voyantjs/voyant",
+            ],
+          }),
+        ),
+      /must include --yes/,
+    )
+    assert.throws(
+      () =>
+        dispatchIntentCommandArgs(
+          dispatchIntent({
+            command: [
+              "pnpm",
+              "agent:queue:start",
+              "--",
+              "--issue",
+              "580",
+              "--repo",
+              "voyantjs/voyant",
+              "--yes",
+            ],
+          }),
+        ),
+      /issue does not match/,
+    )
+    assert.throws(
+      () =>
+        dispatchIntentCommandArgs(
+          dispatchIntent({
+            command: [
+              "pnpm",
+              "agent:queue:start",
+              "--",
+              "--issue",
+              "579",
+              "--repo",
+              "voyantjs/other",
+              "--yes",
+            ],
+          }),
+        ),
+      /repository does not match/,
+    )
+  })
 })
+
+function dispatchIntent({ action = "start", command } = {}) {
+  return {
+    id: "intent_579",
+    lease: {
+      holder: "supervisor:test",
+    },
+    plan: {
+      action,
+      command: command ?? [
+        "pnpm",
+        "agent:queue:start",
+        "--",
+        "--issue",
+        "579",
+        "--repo",
+        "voyantjs/voyant",
+        "--yes",
+      ],
+      issue: {
+        number: 579,
+        repository: "voyantjs/voyant",
+        title: "Test issue",
+        url: "https://github.com/voyantjs/voyant/issues/579",
+      },
+      reason: "ready",
+      repository: "voyantjs/voyant",
+      requiresMutation: true,
+    },
+    status: "leased",
+  }
+}


### PR DESCRIPTION
## Summary

- add `pnpm agent:queue:run-dispatch-intent` to lease, execute, and finish one dispatch intent
- validate leased command shape before execution, including action, issue, repository, and `--yes`
- document the one-step local supervisor path

## Validation

- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm agent:queue:run-dispatch-intent -- --help`
- `git diff --check`
- commit hook: changed-file formatting, secretlint, agent quality, affected typecheck
- pre-push hook: `pnpm test`