### PR TITLE
[codex] Wire storefront verification schema

### DIFF
--- a/.changeset/storefront-verification-schema-docs.md
+++ b/.changeset/storefront-verification-schema-docs.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/storefront-verification": patch
+---
+
+Document the Drizzle schema entrypoint required by mounted storefront verification routes and keep template migrations/configs aligned with the challenge table.

--- a/packages/storefront-verification/README.md
+++ b/packages/storefront-verification/README.md
@@ -1,0 +1,85 @@
+# @voyantjs/storefront-verification
+
+Public email and SMS verification challenges for storefront and checkout flows.
+
+The package ships:
+
+- a Hono public route module for `/v1/public/storefront-verification`
+- a service for issuing, sending, and confirming verification challenges
+- provider adapters that reuse `@voyantjs/notifications` providers
+- a Drizzle schema for persisted verification challenge state
+
+## Install
+
+```bash
+pnpm add @voyantjs/storefront-verification
+```
+
+## Usage
+
+```ts
+import { createStorefrontVerificationHonoModule } from "@voyantjs/storefront-verification"
+
+const storefrontVerification = createStorefrontVerificationHonoModule({
+  resolveProviders: (bindings) => [
+    // return NotificationProvider instances for email and/or sms
+  ],
+  email: {
+    subject: "Your verification code",
+  },
+})
+```
+
+Mount the returned module in the same app that exposes the public route:
+
+```ts
+createApp({
+  publicPaths: ["/v1/public/storefront-verification"],
+  modules: [storefrontVerification],
+})
+```
+
+## Database Schema
+
+This module stores challenge rows in `storefront_verification_challenges`.
+Apps that maintain an explicit Drizzle schema array must include the schema
+entrypoint before generating migrations:
+
+```ts
+export default defineConfig({
+  schema: [
+    "../../packages/db/src/schema/index.ts",
+    "../../packages/storefront-verification/src/schema.ts",
+  ],
+})
+```
+
+For package-based tooling, the published package declares:
+
+```json
+{
+  "voyant": {
+    "schema": "./schema",
+    "requiresSchemas": ["@voyantjs/db"]
+  }
+}
+```
+
+The first-party DMC and operator templates include this schema and ship a
+migration for the challenge table. Downstream apps that mount the route module
+should do the same; otherwise the first verification request will fail when the
+service tries to read or write `storefront_verification_challenges`.
+
+## Exports
+
+| Entry | Description |
+| --- | --- |
+| `.` | Hono module factory, service exports, validation exports, schema exports |
+| `./schema` | Drizzle tables, enums, linkable metadata, module definition |
+| `./public-routes` | Public route factory |
+| `./service` | Verification service and provider adapter helpers |
+| `./validation` | Zod request/response schemas |
+
+## License
+
+Apache-2.0

--- a/packages/storefront-verification/tests/unit/module.test.ts
+++ b/packages/storefront-verification/tests/unit/module.test.ts
@@ -1,9 +1,12 @@
+import { readFileSync } from "node:fs"
 import { createContainer, createEventBus } from "@voyantjs/core"
+import { getTableName } from "drizzle-orm"
 import { describe, expect, it, vi } from "vitest"
 
 import {
   createStorefrontVerificationHonoModule,
   STOREFRONT_VERIFICATION_SENDERS_CONTAINER_KEY,
+  storefrontVerificationChallenges,
 } from "../../src/index.js"
 
 describe("createStorefrontVerificationHonoModule.bootstrap", () => {
@@ -50,5 +53,28 @@ describe("createStorefrontVerificationHonoModule.bootstrap", () => {
     expect(resolveProviders).toHaveBeenCalledOnce()
     expect(senders.sendEmailChallenge).toBeTypeOf("function")
     expect(senders.sendSmsChallenge).toBeTypeOf("function")
+  })
+
+  it("publishes the schema entrypoint required by explicit Drizzle schema arrays", () => {
+    const packageJson = JSON.parse(
+      readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+    ) as {
+      exports: Record<string, string>
+      publishConfig: { exports: Record<string, unknown> }
+      voyant: { schema: string; requiresSchemas: string[] }
+    }
+
+    expect(getTableName(storefrontVerificationChallenges)).toBe(
+      "storefront_verification_challenges",
+    )
+    expect(packageJson.exports["./schema"]).toBe("./src/schema.ts")
+    expect(packageJson.publishConfig.exports["./schema"]).toMatchObject({
+      import: "./dist/schema.js",
+      types: "./dist/schema.d.ts",
+    })
+    expect(packageJson.voyant).toEqual({
+      schema: "./schema",
+      requiresSchemas: ["@voyantjs/db"],
+    })
   })
 })

--- a/templates/dmc/drizzle.config.ts
+++ b/templates/dmc/drizzle.config.ts
@@ -35,6 +35,9 @@ export default defineConfig({
     "../../packages/finance/src/schema.ts",
     "../../packages/legal/src/schema.ts",
     "../../packages/catalog/src/schema.ts",
+    // Mounted at /v1/public/storefront-verification; keep this schema
+    // alongside the route module so challenge requests do not fail at runtime.
+    "../../packages/storefront-verification/src/schema.ts",
   ],
   out: "./migrations",
   dialect: "postgresql",

--- a/templates/dmc/migrations/0004_storefront_verification_challenges.sql
+++ b/templates/dmc/migrations/0004_storefront_verification_challenges.sql
@@ -1,0 +1,39 @@
+DO $$ BEGIN
+ CREATE TYPE "public"."storefront_verification_channel" AS ENUM('email', 'sms');
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."storefront_verification_status" AS ENUM('pending', 'verified', 'expired', 'failed', 'cancelled');
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "storefront_verification_challenges" (
+  "id" text PRIMARY KEY NOT NULL,
+  "channel" "storefront_verification_channel" NOT NULL,
+  "destination" text NOT NULL,
+  "purpose" text DEFAULT 'contact_confirmation' NOT NULL,
+  "code_hash" text NOT NULL,
+  "status" "storefront_verification_status" DEFAULT 'pending' NOT NULL,
+  "attempt_count" integer DEFAULT 0 NOT NULL,
+  "max_attempts" integer DEFAULT 5 NOT NULL,
+  "expires_at" timestamp with time zone NOT NULL,
+  "last_sent_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "verified_at" timestamp with time zone,
+  "failed_at" timestamp with time zone,
+  "metadata" jsonb,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_storefront_verification_channel" ON "storefront_verification_challenges" USING btree ("channel");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_storefront_verification_destination" ON "storefront_verification_challenges" USING btree ("destination");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_storefront_verification_purpose" ON "storefront_verification_challenges" USING btree ("purpose");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_storefront_verification_status" ON "storefront_verification_challenges" USING btree ("status");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_storefront_verification_lookup" ON "storefront_verification_challenges" USING btree ("channel","destination","purpose","updated_at","created_at");

--- a/templates/dmc/migrations/meta/_journal.json
+++ b/templates/dmc/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1778544000000,
       "tag": "0003_allocation_resources",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1778582674000,
+      "tag": "0004_storefront_verification_challenges",
+      "breakpoints": true
     }
   ]
 }

--- a/templates/operator/drizzle.config.ts
+++ b/templates/operator/drizzle.config.ts
@@ -43,6 +43,9 @@ export default defineConfig({
     "../../packages/flights/src/reference/local-postgres.ts",
     "../../packages/catalog/src/schema.ts",
     "../../packages/workflow-runs/src/schema.ts",
+    // Mounted at /v1/public/storefront-verification; keep this schema
+    // alongside the route module so challenge requests do not fail at runtime.
+    "../../packages/storefront-verification/src/schema.ts",
     // Operator-template-local tables (agency profile + default
     // customer payment policy). Lives in-template since the shape
     // is deployment-flavored.

--- a/templates/operator/migrations/0011_storefront_verification_challenges.sql
+++ b/templates/operator/migrations/0011_storefront_verification_challenges.sql
@@ -1,0 +1,39 @@
+DO $$ BEGIN
+ CREATE TYPE "public"."storefront_verification_channel" AS ENUM('email', 'sms');
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."storefront_verification_status" AS ENUM('pending', 'verified', 'expired', 'failed', 'cancelled');
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "storefront_verification_challenges" (
+  "id" text PRIMARY KEY NOT NULL,
+  "channel" "storefront_verification_channel" NOT NULL,
+  "destination" text NOT NULL,
+  "purpose" text DEFAULT 'contact_confirmation' NOT NULL,
+  "code_hash" text NOT NULL,
+  "status" "storefront_verification_status" DEFAULT 'pending' NOT NULL,
+  "attempt_count" integer DEFAULT 0 NOT NULL,
+  "max_attempts" integer DEFAULT 5 NOT NULL,
+  "expires_at" timestamp with time zone NOT NULL,
+  "last_sent_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "verified_at" timestamp with time zone,
+  "failed_at" timestamp with time zone,
+  "metadata" jsonb,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_storefront_verification_channel" ON "storefront_verification_challenges" USING btree ("channel");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_storefront_verification_destination" ON "storefront_verification_challenges" USING btree ("destination");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_storefront_verification_purpose" ON "storefront_verification_challenges" USING btree ("purpose");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_storefront_verification_status" ON "storefront_verification_challenges" USING btree ("status");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_storefront_verification_lookup" ON "storefront_verification_challenges" USING btree ("channel","destination","purpose","updated_at","created_at");

--- a/templates/operator/migrations/meta/_journal.json
+++ b/templates/operator/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1778544000000,
       "tag": "0010_allocation_resources",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1778582674000,
+      "tag": "0011_storefront_verification_challenges",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Closes #616

## Summary
- add storefront verification schema entries to the DMC and operator Drizzle configs
- ship idempotent template migrations for `storefront_verification_challenges` and its enums/indexes
- document the package schema entrypoint and explicit-schema-array requirement
- add a unit test covering the package schema export and `voyant` schema metadata

## Verification
- pnpm --filter @voyantjs/storefront-verification test
- pnpm --filter @voyantjs/storefront-verification typecheck
- pnpm --filter @voyantjs/storefront-verification lint
- pnpm --filter @voyantjs/storefront-verification build
- pnpm --filter dmc typecheck
- pnpm --filter operator typecheck
- pnpm lint:changed
- git diff --check
- pre-push pnpm test