### PR TITLE
feat(agent-runner): add control plane supervisor loop

### DIFF
--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -135,6 +135,19 @@ This leases the next intent, validates that the leased command is an allowed
 `pnpm agent:queue:*` lifecycle command, executes it locally, then records
 `completed` or `failed` on the dispatch intent.
 
+Run a bounded supervisor loop against the control plane with:
+
+```bash
+AGENT_CONTROL_PLANE_URL=https://agent-control-plane.example.workers.dev \
+AGENT_CONTROL_PLANE_TOKEN=... \
+pnpm agent:queue:control-plane-loop -- --repo voyantjs/voyant --holder supervisor:local --iterations 3 --yes
+```
+
+Each iteration submits a fresh tick snapshot, leases one dispatch intent from
+that stored snapshot, executes the leased command, and records the terminal
+outcome before continuing. The loop stops when no dispatchable intent is
+available, a command fails, or the iteration limit is reached.
+
 ## Optional R2 Storage
 
 Bind an R2 bucket as `AGENT_TICK_SNAPSHOTS` to keep the latest accepted tick

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1346,6 +1346,11 @@ Verification:
   next intent from the control plane, validates that the command is an allowed
   `pnpm agent:queue:*` lifecycle command, executes it without a shell, and then
   records the terminal dispatch intent outcome.
+- A bounded local supervisor loop can use
+  `pnpm agent:queue:control-plane-loop -- --holder <id> --iterations <n> --yes`.
+  Each iteration submits a fresh tick snapshot, leases one intent from that
+  stored snapshot, runs the leased lifecycle command, records the terminal
+  outcome, and stops on idle, failure, or the configured iteration limit.
 
 ## Open Questions
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "agent:queue:lease-dispatch": "node scripts/agent-runner-lease-dispatch.mjs",
     "agent:queue:finish-dispatch": "node scripts/agent-runner-finish-dispatch.mjs",
     "agent:queue:run-dispatch-intent": "node scripts/agent-runner-run-dispatch-intent.mjs",
+    "agent:queue:control-plane-loop": "node scripts/agent-runner-control-plane-loop.mjs",
     "agent:queue:dispatch": "node scripts/agent-runner-dispatch.mjs",
     "agent:queue:loop": "node scripts/agent-runner-loop.mjs",
     "agent:queue:remote-inspect": "node scripts/agent-runner-remote-inspect.mjs",

--- a/scripts/agent-runner-control-plane-loop.mjs
+++ b/scripts/agent-runner-control-plane-loop.mjs
@@ -1,0 +1,176 @@
+import { currentRepositoryFromOrigin, fail, parseArgs, runGit } from "./lib/agent-project-queue.mjs"
+import {
+  controlPlaneConfigFromArgs,
+  finishDispatchIntent,
+  requestLatestDispatchIntent,
+  submitTickSnapshot,
+} from "./lib/agent-runner-control-plane.mjs"
+import {
+  buildLatestDispatchIntentRequest,
+  generateControlPlaneTickSnapshot,
+} from "./lib/agent-runner-control-plane-tick.mjs"
+import { dispatchableActions } from "./lib/agent-runner-dispatch.mjs"
+import { runLeasedDispatchIntent } from "./lib/agent-runner-dispatch-intent-runner.mjs"
+import { resolveEventLogPath, tryAppendAgentRunnerEvent } from "./lib/agent-runner-events.mjs"
+import {
+  eventLogOptions,
+  maybePrintHelp,
+  projectOptions,
+  repositoryOptions,
+} from "./lib/agent-runner-help.mjs"
+import { normalizeLoopOptions, shouldContinueLoop } from "./lib/agent-runner-loop.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:control-plane-loop",
+  summary: "Submit fresh queue snapshots and run leased control-plane dispatch intents.",
+  usage: "pnpm agent:queue:control-plane-loop -- --holder <id> --iterations 3 --yes",
+  options: [
+    ["--control-plane-url <url>", "Control-plane base URL. Defaults to AGENT_CONTROL_PLANE_URL."],
+    ["AGENT_CONTROL_PLANE_TOKEN", "Bearer token environment variable used for API routes."],
+    ["--holder <id>", "Supervisor or runner identifier recorded on each lease."],
+    ["--iterations <number>", "Maximum loop iterations, 1..100. Defaults to 1."],
+    ["--sleep-seconds <number>", "Delay between successful dispatches, 0..3600. Defaults to 60."],
+    ["--ttl-seconds <number>", "Lease TTL in seconds, 60..3600. Defaults to 900."],
+    ["--issue <number>", "Only lease recommendations for this issue number."],
+    [
+      "--action <name>",
+      `Only lease this action. Allowed: ${Array.from(dispatchableActions).join(", ")}.`,
+    ],
+    ["--max-age-days <number>", "Heartbeat staleness threshold. Defaults to 1."],
+    ["--recent-events <number>", "Number of recent runner events to include. Defaults to 5."],
+    ...eventLogOptions,
+    ["--update-body", "When leasing sync-pr, include --update-body in the returned command."],
+    ["--yes", "Required before leased commands are executed."],
+    ...repositoryOptions,
+    ...projectOptions,
+  ],
+})
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const holder = requiredString(args.holder, "holder")
+const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
+const config = readControlPlaneConfig()
+
+if (!args.yes) {
+  fail("control-plane-loop executes leased queue mutations; rerun with --yes")
+}
+
+if (args.action && !dispatchableActions.has(args.action)) {
+  fail(`action ${args.action} is not dispatchable`)
+}
+
+let loopOptions
+try {
+  loopOptions = normalizeLoopOptions({
+    iterations: args.iterations,
+    sleepSeconds: args.sleepSeconds,
+  })
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error))
+}
+
+for (let iteration = 1; iteration <= loopOptions.iterations; iteration += 1) {
+  console.log(`agent-runner control-plane loop: iteration ${iteration}/${loopOptions.iterations}`)
+
+  const snapshot = generateControlPlaneTickSnapshot(args, { repoRoot })
+  const submitted = await submitTickSnapshot({
+    snapshot,
+    token: config.token,
+    url: config.url,
+  }).catch((error) => {
+    fail(error instanceof Error ? error.message : String(error))
+  })
+
+  const leaseResult = await requestLatestDispatchIntent({
+    request: buildLatestDispatchIntentRequest({
+      action: args.action,
+      eventLog: args.eventLog,
+      holder,
+      issue: args.issue,
+      repository,
+      ttlSeconds: args.ttlSeconds,
+      updateBody: args.updateBody,
+    }),
+    token: config.token,
+    url: config.url,
+  }).catch((error) => {
+    fail(error instanceof Error ? error.message : String(error))
+  })
+
+  tryAppendAgentRunnerEvent({
+    eventLogPath,
+    event: {
+      type: "control-plane-loop.iteration.snapshot_submitted",
+      dispatchableRecommendationCount: submitted.summary?.dispatchableRecommendationCount,
+      iteration,
+      iterations: loopOptions.iterations,
+      recommendationCount: submitted.summary?.recommendationCount,
+      repository,
+    },
+  })
+
+  if (!leaseResult.intent) {
+    console.log(`agent-runner control-plane loop: idle (${leaseResult.reason})`)
+    tryAppendAgentRunnerEvent({
+      eventLogPath,
+      event: {
+        type: "control-plane-loop.iteration.idle",
+        iteration,
+        iterations: loopOptions.iterations,
+        reason: leaseResult.reason,
+        repository,
+      },
+    })
+    break
+  }
+
+  let result
+  try {
+    result = await runLeasedDispatchIntent({
+      config,
+      eventLogPath,
+      finishDispatchIntent,
+      holder,
+      intent: leaseResult.intent,
+      repository,
+      requestLatestDispatchIntentResult: leaseResult,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    fail(message)
+  }
+
+  if (
+    !shouldContinueLoop({ iteration, iterations: loopOptions.iterations, status: result.status })
+  ) {
+    process.exitCode = result.status
+    break
+  }
+
+  if (loopOptions.sleepMs > 0) {
+    await sleep(loopOptions.sleepMs)
+  }
+}
+
+function readControlPlaneConfig() {
+  try {
+    return controlPlaneConfigFromArgs(args)
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error))
+  }
+}
+
+function requiredString(value, name) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    fail(`missing required --${name}`)
+  }
+  return value.trim()
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}

--- a/scripts/agent-runner-run-dispatch-intent.mjs
+++ b/scripts/agent-runner-run-dispatch-intent.mjs
@@ -4,16 +4,10 @@ import {
   finishDispatchIntent,
   requestLatestDispatchIntent,
 } from "./lib/agent-runner-control-plane.mjs"
-import {
-  dispatchableActions,
-  dispatchIntentCommandArgs,
-  runDispatchIntentCommand,
-} from "./lib/agent-runner-dispatch.mjs"
-import {
-  issueEventDetails,
-  resolveEventLogPath,
-  tryAppendAgentRunnerEvent,
-} from "./lib/agent-runner-events.mjs"
+import { buildLatestDispatchIntentRequest } from "./lib/agent-runner-control-plane-tick.mjs"
+import { dispatchableActions } from "./lib/agent-runner-dispatch.mjs"
+import { runLeasedDispatchIntent } from "./lib/agent-runner-dispatch-intent-runner.mjs"
+import { resolveEventLogPath } from "./lib/agent-runner-events.mjs"
 import { eventLogOptions, maybePrintHelp, repositoryOptions } from "./lib/agent-runner-help.mjs"
 
 const args = parseArgs(process.argv.slice(2))
@@ -55,29 +49,15 @@ if (args.action && !dispatchableActions.has(args.action)) {
 const issueNumber = optionalPositiveInteger(args.issue, "issue")
 const ttlSeconds = optionalInteger(args.ttlSeconds, "ttl-seconds", { max: 3600, min: 60 })
 const config = readControlPlaneConfig()
-const request = {
+const request = buildLatestDispatchIntentRequest({
+  action: args.action,
+  eventLog: args.eventLog,
+  holder,
+  issue: issueNumber,
   repository,
-  lease: {
-    holder,
-    ...(ttlSeconds ? { ttlSeconds } : {}),
-  },
-  ...(issueNumber || args.action
-    ? {
-        filters: {
-          ...(args.action ? { action: args.action } : {}),
-          ...(issueNumber ? { issueNumber } : {}),
-        },
-      }
-    : {}),
-  ...(args.eventLog || args.updateBody
-    ? {
-        options: {
-          ...(args.eventLog ? { eventLog: args.eventLog } : {}),
-          ...(args.updateBody ? { updateBody: true } : {}),
-        },
-      }
-    : {}),
-}
+  ttlSeconds,
+  updateBody: args.updateBody,
+})
 
 let leaseResult
 try {
@@ -100,71 +80,25 @@ if (!leaseResult.intent) {
 }
 
 const intent = leaseResult.intent
-let commandArgs
 let finishResult
 let status = 1
 let terminalStatus = "failed"
-let terminalReason = "command failed"
 
 try {
-  commandArgs = dispatchIntentCommandArgs(intent)
-  printIntent({ commandArgs, controlPlaneUrl: config.url, intent })
-  tryAppendAgentRunnerEvent({
+  const result = await runLeasedDispatchIntent({
+    config,
     eventLogPath,
-    event: {
-      type: "dispatch-intent.started",
-      command: ["pnpm", ...commandArgs],
-      intent: intentEventDetails(intent),
-      issue: issueEventDetails(intent.plan),
-      repository,
-    },
+    finishDispatchIntent,
+    holder,
+    intent,
+    repository,
+    requestLatestDispatchIntentResult: leaseResult,
   })
-  status = runDispatchIntentCommand(intent) ?? 1
-  terminalStatus = status === 0 ? "completed" : "failed"
-  terminalReason = status === 0 ? "command completed" : `command exited with status ${status}`
-} catch (error) {
-  terminalStatus = "failed"
-  terminalReason = error instanceof Error ? error.message : String(error)
-  console.error(`dispatch intent failed before completion: ${terminalReason}`)
-}
-
-try {
-  finishResult = await finishDispatchIntent({
-    id: intent.id,
-    request: {
-      exitCode: status,
-      holder,
-      reason: terminalReason,
-      status: terminalStatus,
-    },
-    token: config.token,
-    url: config.url,
-  })
-  tryAppendAgentRunnerEvent({
-    eventLogPath,
-    event: {
-      type: "dispatch-intent.finished",
-      intent: intentEventDetails(finishResult.intent),
-      issue: issueEventDetails(intent.plan),
-      repository,
-      status,
-      terminalStatus,
-    },
-  })
+  finishResult = result.finish
+  status = result.status
+  terminalStatus = result.terminalStatus
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error)
-  tryAppendAgentRunnerEvent({
-    eventLogPath,
-    event: {
-      type: "dispatch-intent.finish_failed",
-      error: message,
-      intent: intentEventDetails(intent),
-      issue: issueEventDetails(intent.plan),
-      repository,
-      status,
-      terminalStatus,
-    },
-  })
   fail(message)
 }
 
@@ -185,25 +119,6 @@ if (args.json) {
 }
 
 process.exitCode = status
-
-function printIntent({ commandArgs, controlPlaneUrl, intent }) {
-  console.log("agent-runner dispatch intent")
-  console.log(`control plane: ${controlPlaneUrl}`)
-  console.log(`intent: ${intent.id}`)
-  console.log(`holder: ${intent.lease.holder}`)
-  console.log(`issue: #${intent.plan.issue.number} ${intent.plan.issue.title}`)
-  console.log(`action: ${intent.plan.action}`)
-  console.log(`command: pnpm ${commandArgs.join(" ")}`)
-}
-
-function intentEventDetails(intent) {
-  return {
-    action: intent.plan.action,
-    holder: intent.lease.holder,
-    id: intent.id,
-    status: intent.status,
-  }
-}
 
 function readControlPlaneConfig() {
   try {

--- a/scripts/agent-runner-submit-tick.mjs
+++ b/scripts/agent-runner-submit-tick.mjs
@@ -1,26 +1,18 @@
-import fs from "node:fs"
-
-import {
-  currentRepositoryFromOrigin,
-  fail,
-  filterItemsByRepository,
-  loadAllEvaluatedProject,
-  parseArgs,
-  projectScanConfigFromArgs,
-  runGit,
-} from "./lib/agent-project-queue.mjs"
+import { fail, parseArgs, runGit } from "./lib/agent-project-queue.mjs"
 import {
   controlPlaneConfigFromArgs,
   submitTickSnapshot,
 } from "./lib/agent-runner-control-plane.mjs"
-import { readAgentRunnerEvents, resolveEventLogPath } from "./lib/agent-runner-events.mjs"
+import {
+  generateControlPlaneTickSnapshot,
+  readControlPlaneTickSnapshotInput,
+} from "./lib/agent-runner-control-plane-tick.mjs"
 import {
   eventLogOptions,
   maybePrintHelp,
   projectOptions,
   repositoryOptions,
 } from "./lib/agent-runner-help.mjs"
-import { recommendQueueActions } from "./lib/agent-runner-tick.mjs"
 
 const args = parseArgs(process.argv.slice(2))
 maybePrintHelp(args, {
@@ -43,7 +35,9 @@ maybePrintHelp(args, {
 })
 
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
-const snapshot = args.input ? readSnapshotInput(args.input) : generateSnapshot()
+const snapshot = args.input
+  ? readControlPlaneTickSnapshotInput(args.input)
+  : generateControlPlaneTickSnapshot(args, { repoRoot })
 const config = readControlPlaneConfig()
 
 try {
@@ -67,67 +61,10 @@ try {
   fail(error instanceof Error ? error.message : String(error))
 }
 
-function generateSnapshot() {
-  const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
-  const maxAgeDays = Number(args.maxAgeDays ?? 1)
-  const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
-  const recentEventLimit = numberArg(args.recentEvents, "recent-events", 5, { min: 0 })
-
-  if (!Number.isInteger(maxAgeDays) || maxAgeDays < 0) {
-    fail(`invalid max age days: ${String(args.maxAgeDays)}`)
-  }
-
-  const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
-  const items = filterItemsByRepository(project.items, repository)
-
-  return {
-    project: {
-      owner: project.owner,
-      number: project.projectNumber,
-      title: project.projectTitle,
-      url: project.projectUrl,
-    },
-    repository,
-    maxAgeDays,
-    eventLog: {
-      path: eventLogPath,
-      recentEvents: readRecentEvents(eventLogPath, recentEventLimit),
-    },
-    recommendations: recommendQueueActions(items, { maxAgeDays, repository }),
-  }
-}
-
-function readSnapshotInput(input) {
-  const text = input === "-" ? fs.readFileSync(0, "utf8") : fs.readFileSync(input, "utf8")
-  try {
-    return JSON.parse(text)
-  } catch (error) {
-    fail(`invalid tick snapshot JSON: ${error instanceof Error ? error.message : String(error)}`)
-  }
-}
-
 function readControlPlaneConfig() {
   try {
     return controlPlaneConfigFromArgs(args)
   } catch (error) {
     fail(error instanceof Error ? error.message : String(error))
   }
-}
-
-function readRecentEvents(eventLogPath, limit) {
-  try {
-    return readAgentRunnerEvents(eventLogPath, { limit })
-  } catch (error) {
-    fail(error instanceof Error ? error.message : String(error))
-  }
-}
-
-function numberArg(value, name, fallback, { min = 1 } = {}) {
-  if (value === undefined) return fallback
-
-  const number = Number(value)
-  if (!Number.isInteger(number) || number < min) {
-    fail(`invalid ${name}: ${value}`)
-  }
-  return number
 }

--- a/scripts/lib/agent-runner-control-plane-tick.mjs
+++ b/scripts/lib/agent-runner-control-plane-tick.mjs
@@ -1,0 +1,119 @@
+import fs from "node:fs"
+
+import {
+  currentRepositoryFromOrigin,
+  fail,
+  filterItemsByRepository,
+  loadAllEvaluatedProject,
+  projectScanConfigFromArgs,
+} from "./agent-project-queue.mjs"
+import { readAgentRunnerEvents, resolveEventLogPath } from "./agent-runner-events.mjs"
+import { recommendQueueActions } from "./agent-runner-tick.mjs"
+
+export function generateControlPlaneTickSnapshot(args, { repoRoot }) {
+  const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+  const maxAgeDays = Number(args.maxAgeDays ?? 1)
+  const eventLogPath = resolveEventLogPath(args.eventLog, { repoRoot })
+  const recentEventLimit = numberArg(args.recentEvents, "recent-events", 5, { min: 0 })
+
+  if (!Number.isInteger(maxAgeDays) || maxAgeDays < 0) {
+    fail(`invalid max age days: ${String(args.maxAgeDays)}`)
+  }
+
+  const project = loadAllEvaluatedProject(projectScanConfigFromArgs(args))
+  const items = filterItemsByRepository(project.items, repository)
+
+  return {
+    project: {
+      owner: project.owner,
+      number: project.projectNumber,
+      title: project.projectTitle,
+      url: project.projectUrl,
+    },
+    repository,
+    maxAgeDays,
+    eventLog: {
+      path: eventLogPath,
+      recentEvents: readRecentEvents(eventLogPath, recentEventLimit),
+    },
+    recommendations: recommendQueueActions(items, { maxAgeDays, repository }),
+  }
+}
+
+export function readControlPlaneTickSnapshotInput(input) {
+  const text = input === "-" ? fs.readFileSync(0, "utf8") : fs.readFileSync(input, "utf8")
+  try {
+    return JSON.parse(text)
+  } catch (error) {
+    fail(`invalid tick snapshot JSON: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+export function buildLatestDispatchIntentRequest({
+  action,
+  eventLog,
+  holder,
+  issue,
+  repository,
+  ttlSeconds,
+  updateBody,
+}) {
+  const issueNumber = optionalPositiveInteger(issue, "issue")
+  const leaseTtlSeconds = optionalInteger(ttlSeconds, "ttl-seconds", { max: 3600, min: 60 })
+
+  return {
+    repository,
+    lease: {
+      holder,
+      ...(leaseTtlSeconds ? { ttlSeconds: leaseTtlSeconds } : {}),
+    },
+    ...(issueNumber || action
+      ? {
+          filters: {
+            ...(action ? { action } : {}),
+            ...(issueNumber ? { issueNumber } : {}),
+          },
+        }
+      : {}),
+    ...(eventLog || updateBody
+      ? {
+          options: {
+            ...(eventLog ? { eventLog } : {}),
+            ...(updateBody ? { updateBody: true } : {}),
+          },
+        }
+      : {}),
+  }
+}
+
+function readRecentEvents(eventLogPath, limit) {
+  try {
+    return readAgentRunnerEvents(eventLogPath, { limit })
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error))
+  }
+}
+
+function optionalPositiveInteger(value, name) {
+  return optionalInteger(value, name, { min: 1 })
+}
+
+function optionalInteger(value, name, { max = Number.POSITIVE_INFINITY, min = 1 } = {}) {
+  if (value === undefined) return undefined
+
+  const number = Number(value)
+  if (!Number.isInteger(number) || number < min || number > max) {
+    fail(`invalid ${name}: ${value}`)
+  }
+  return number
+}
+
+function numberArg(value, name, fallback, { min = 1 } = {}) {
+  if (value === undefined) return fallback
+
+  const number = Number(value)
+  if (!Number.isInteger(number) || number < min) {
+    fail(`invalid ${name}: ${value}`)
+  }
+  return number
+}

--- a/scripts/lib/agent-runner-dispatch-intent-runner.mjs
+++ b/scripts/lib/agent-runner-dispatch-intent-runner.mjs
@@ -1,0 +1,125 @@
+import { dispatchIntentCommandArgs, runDispatchIntentCommand } from "./agent-runner-dispatch.mjs"
+import { issueEventDetails, tryAppendAgentRunnerEvent } from "./agent-runner-events.mjs"
+
+export async function runLeasedDispatchIntent({
+  config,
+  eventLogPath,
+  finishDispatchIntent,
+  holder,
+  intent,
+  log = console.log,
+  repository,
+  requestLatestDispatchIntentResult,
+  runDispatchIntentCommandImpl = runDispatchIntentCommand,
+}) {
+  let commandArgs
+  let status = 1
+  let terminalStatus = "failed"
+  let terminalReason = "command failed"
+
+  try {
+    commandArgs = dispatchIntentCommandArgs(intent)
+    printIntent({ commandArgs, controlPlaneUrl: config.url, intent, log })
+    tryAppendAgentRunnerEvent({
+      eventLogPath,
+      event: {
+        type: "dispatch-intent.started",
+        command: ["pnpm", ...commandArgs],
+        intent: intentEventDetails(intent),
+        issue: issueEventDetails(intent.plan),
+        repository,
+      },
+    })
+    status = runDispatchIntentCommandImpl(intent) ?? 1
+    terminalStatus = status === 0 ? "completed" : "failed"
+    terminalReason = status === 0 ? "command completed" : `command exited with status ${status}`
+  } catch (error) {
+    terminalStatus = "failed"
+    terminalReason = error instanceof Error ? error.message : String(error)
+    console.error(`dispatch intent failed before completion: ${terminalReason}`)
+  }
+
+  let finishResult
+  try {
+    finishResult = await finishDispatchIntent({
+      id: intent.id,
+      request: {
+        exitCode: status,
+        holder,
+        reason: terminalReason,
+        status: terminalStatus,
+      },
+      token: config.token,
+      url: config.url,
+    })
+  } catch (error) {
+    appendDispatchIntentFinishFailureEvent({
+      error: error instanceof Error ? error.message : String(error),
+      eventLogPath,
+      intent,
+      repository,
+      status,
+      terminalStatus,
+    })
+    throw error
+  }
+  tryAppendAgentRunnerEvent({
+    eventLogPath,
+    event: {
+      type: "dispatch-intent.finished",
+      intent: intentEventDetails(finishResult.intent),
+      issue: issueEventDetails(intent.plan),
+      repository,
+      status,
+      terminalStatus,
+    },
+  })
+
+  return {
+    finish: finishResult,
+    lease: requestLatestDispatchIntentResult,
+    status,
+    terminalStatus,
+  }
+}
+
+function appendDispatchIntentFinishFailureEvent({
+  error,
+  eventLogPath,
+  intent,
+  repository,
+  status,
+  terminalStatus,
+}) {
+  tryAppendAgentRunnerEvent({
+    eventLogPath,
+    event: {
+      type: "dispatch-intent.finish_failed",
+      error,
+      intent: intentEventDetails(intent),
+      issue: issueEventDetails(intent.plan),
+      repository,
+      status,
+      terminalStatus,
+    },
+  })
+}
+
+function printIntent({ commandArgs, controlPlaneUrl, intent, log }) {
+  log("agent-runner dispatch intent")
+  log(`control plane: ${controlPlaneUrl}`)
+  log(`intent: ${intent.id}`)
+  log(`holder: ${intent.lease.holder}`)
+  log(`issue: #${intent.plan.issue.number} ${intent.plan.issue.title}`)
+  log(`action: ${intent.plan.action}`)
+  log(`command: pnpm ${commandArgs.join(" ")}`)
+}
+
+function intentEventDetails(intent) {
+  return {
+    action: intent.plan.action,
+    holder: intent.lease.holder,
+    id: intent.id,
+    status: intent.status,
+  }
+}

--- a/scripts/tests/agent-runner-control-plane-supervisor.test.mjs
+++ b/scripts/tests/agent-runner-control-plane-supervisor.test.mjs
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict"
+import { mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { describe, it } from "node:test"
+
+import { buildLatestDispatchIntentRequest } from "../lib/agent-runner-control-plane-tick.mjs"
+import { runLeasedDispatchIntent } from "../lib/agent-runner-dispatch-intent-runner.mjs"
+
+describe("agent runner control plane supervisor helpers", () => {
+  it("builds latest dispatch intent requests with filters, lease, and command options", () => {
+    assert.deepEqual(
+      buildLatestDispatchIntentRequest({
+        action: "sync-pr",
+        eventLog: ".agent-runs/supervisor.jsonl",
+        holder: "supervisor:local",
+        issue: "579",
+        repository: "voyantjs/voyant",
+        ttlSeconds: "600",
+        updateBody: true,
+      }),
+      {
+        filters: {
+          action: "sync-pr",
+          issueNumber: 579,
+        },
+        lease: {
+          holder: "supervisor:local",
+          ttlSeconds: 600,
+        },
+        options: {
+          eventLog: ".agent-runs/supervisor.jsonl",
+          updateBody: true,
+        },
+        repository: "voyantjs/voyant",
+      },
+    )
+  })
+
+  it("runs leased dispatch intents and finishes them with terminal status", async () => {
+    const tmp = mkdtempSync(path.join(tmpdir(), "agent-control-plane-supervisor-"))
+    const eventLogPath = path.join(tmp, "events.jsonl")
+    const finishCalls = []
+
+    try {
+      const result = await runLeasedDispatchIntent({
+        config: {
+          token: "tok",
+          url: "https://control.example.com",
+        },
+        eventLogPath,
+        finishDispatchIntent: async (call) => {
+          finishCalls.push(call)
+          return {
+            intent: {
+              ...dispatchIntent(),
+              resolution: {
+                finishedAt: "2026-05-12T12:05:00.000Z",
+                holder: "supervisor:local",
+              },
+              status: "completed",
+            },
+          }
+        },
+        holder: "supervisor:local",
+        intent: dispatchIntent(),
+        log: () => {},
+        repository: "voyantjs/voyant",
+        requestLatestDispatchIntentResult: {
+          intent: dispatchIntent(),
+          reason: "leased",
+        },
+        runDispatchIntentCommandImpl: () => 0,
+      })
+
+      assert.equal(result.status, 0)
+      assert.equal(result.terminalStatus, "completed")
+      assert.deepEqual(finishCalls, [
+        {
+          id: "intent_579",
+          request: {
+            exitCode: 0,
+            holder: "supervisor:local",
+            reason: "command completed",
+            status: "completed",
+          },
+          token: "tok",
+          url: "https://control.example.com",
+        },
+      ])
+
+      const events = readFileSync(eventLogPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line))
+      assert.deepEqual(
+        events.map((event) => event.type),
+        ["dispatch-intent.started", "dispatch-intent.finished"],
+      )
+    } finally {
+      rmSync(tmp, { force: true, recursive: true })
+    }
+  })
+
+  it("records the computed command status when finishing an intent fails", async () => {
+    const tmp = mkdtempSync(path.join(tmpdir(), "agent-control-plane-supervisor-"))
+    const eventLogPath = path.join(tmp, "events.jsonl")
+
+    try {
+      await assert.rejects(
+        runLeasedDispatchIntent({
+          config: {
+            token: "tok",
+            url: "https://control.example.com",
+          },
+          eventLogPath,
+          finishDispatchIntent: async () => {
+            throw new Error("control plane unavailable")
+          },
+          holder: "supervisor:local",
+          intent: dispatchIntent(),
+          log: () => {},
+          repository: "voyantjs/voyant",
+          requestLatestDispatchIntentResult: {
+            intent: dispatchIntent(),
+            reason: "leased",
+          },
+          runDispatchIntentCommandImpl: () => 0,
+        }),
+        /control plane unavailable/,
+      )
+
+      const events = readFileSync(eventLogPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line))
+      assert.deepEqual(
+        events.map((event) => event.type),
+        ["dispatch-intent.started", "dispatch-intent.finish_failed"],
+      )
+      assert.equal(events[1].status, 0)
+      assert.equal(events[1].terminalStatus, "completed")
+      assert.equal(events[1].error, "control plane unavailable")
+    } finally {
+      rmSync(tmp, { force: true, recursive: true })
+    }
+  })
+})
+
+function dispatchIntent() {
+  return {
+    id: "intent_579",
+    lease: {
+      holder: "supervisor:local",
+    },
+    plan: {
+      action: "start",
+      command: [
+        "pnpm",
+        "agent:queue:start",
+        "--",
+        "--issue",
+        "579",
+        "--repo",
+        "voyantjs/voyant",
+        "--yes",
+      ],
+      issue: {
+        number: 579,
+        repository: "voyantjs/voyant",
+        title: "Test issue",
+        url: "https://github.com/voyantjs/voyant/issues/579",
+      },
+      reason: "ready",
+      repository: "voyantjs/voyant",
+      requiresMutation: true,
+    },
+    status: "leased",
+  }
+}


### PR DESCRIPTION
## Summary

- add `pnpm agent:queue:control-plane-loop` for bounded control-plane supervisor runs
- share tick snapshot and latest dispatch intent request helpers across submit/run/loop commands
- share leased dispatch intent execution and finish-event handling between one-shot and loop commands

## Validation

- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm agent:queue:control-plane-loop -- --help`
- `pnpm agent:queue:run-dispatch-intent -- --help`
- `git diff --check`
- commit hook: changed-file formatting, secretlint, agent quality, affected typecheck
- pre-push hook: `pnpm test`