### PR TITLE
[codex] Fix release train allocation UI version

### DIFF
--- a/packages/allocation-ui/package.json
+++ b/packages/allocation-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/allocation-ui",
-  "version": "0.32.3",
+  "version": "0.33.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Align `@voyantjs/allocation-ui` with the shared release train version.

## Root Cause

The package was introduced at `0.32.3` after the rest of the publishable packages had been advanced to `0.33.1`, causing `pnpm verify:release-train` to fail on `main`.

## Validation

- `NODE_PATH=/Users/mihai/builds/internal/voyant-all/voyant/node_modules pnpm verify:release-train`