### PR TITLE
[codex] Wire services into Node self-host workflows

### DIFF
--- a/.changeset/node-selfhost-services.md
+++ b/.changeset/node-selfhost-services.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/workflows-orchestrator-node": patch
+---
+
+Expose a `services` resolver option on the Node self-host server helpers and document the `createApp()` migration path for service-backed package workflows.

--- a/apps/workflows-selfhost-node-server/README.md
+++ b/apps/workflows-selfhost-node-server/README.md
@@ -47,6 +47,15 @@ Supported flags:
 - `--database-url <url>` or `DATABASE_URL`
 - `--cache-bust-entry`
 
+The CLI flags intentionally cover only entry loading, HTTP binding, static
+assets, and storage. Workflows that call `ctx.services.resolve(...)` need a
+host-provided service resolver. For those, either start the server from code
+with `startNodeSelfHostServer({ services })`, or prefer the app-integrated
+Node path with `createApp({ workflows: { driver: () =>
+createNodeStandaloneDriver({ db }) } })`. See
+[`@voyantjs/workflows-orchestrator-node`](../../packages/workflows-orchestrator-node/README.md#service-backed-package-workflows)
+for an example using the promotions catalog reindex workflow.
+
 Operational endpoints:
 
 - `GET /healthz` for liveness

--- a/docs/architecture/workflows-runtime-architecture.md
+++ b/docs/architecture/workflows-runtime-architecture.md
@@ -211,9 +211,13 @@ export function createInMemoryDriver(opts?: InMemoryOpts): DriverFactory
 The user-facing shape:
 
 ```ts
-// Mode 2 default — shorthand
-createApp({ workflows: { db } })
-  // framework wraps as: ({ services }) => createNodeStandaloneDriver({ db, services, ... })
+// Mode 2 — Node standalone driver
+createApp({
+  workflows: {
+    driver: () => createNodeStandaloneDriver({ db }),
+  },
+})
+// createApp() invokes the returned DriverFactory with { services, logger, now? }.
 
 // Mode 1 — explicit factory
 createApp({
@@ -587,13 +591,34 @@ Three coordinated changes:
 
 1. **Extend `StepHandlerDeps`** (`packages/workflows/src/handler/index.ts:38`) with an optional `services?: ModuleContainer`. When set, every step invocation forwards it into `executeWorkflowStep`.
 2. **Extend `CtxBuildArgs`** (`packages/workflows/src/runtime/ctx.ts:127`) with the same `services` field, and surface it on `WorkflowContext` as `services: ModuleContainerView`. The view is read-only — workflows resolve, they don't register.
-3. **Wire from `createApp()`**. The driver factory accepts `services?: ModuleContainer` as a constructor argument:
+3. **Wire from `createApp()`**. `createApp()` invokes the configured driver factory
+   after it has built the module container, passing a read-only service resolver
+   in the factory deps:
 
    ```ts
-   const driver = createNodeStandaloneDriver({ db, services: container })
+   const promotionsWorkflowServices = {
+     module: {
+       name: BULK_REINDEX_SERVICE_KEY,
+       service: bulkReindexProductsService,
+     },
+   }
+
+   const app = createApp({
+     modules: [promotionsHonoModule, promotionsWorkflowServices],
+     workflows: {
+       driver: () => createNodeStandaloneDriver({ db }),
+     },
+   })
    ```
 
-   `createApp()` calls the factory with the container it already builds. No underscore-prefixed methods, no setter API on the driver — the factory takes what it needs at construction time.
+   The Node factory closes over `db`; `createApp()` supplies `{ services }`
+   when it constructs the driver. No underscore-prefixed methods, no setter API
+   on the driver — the factory takes framework services at construction time.
+
+   Existing entry-file self-host deployments that use
+   `startNodeSelfHostServer()` directly can pass the same read-only resolver via
+   `services`; new package workflow integrations should prefer the `createApp()`
+   composition path.
 
 The container reaches the workflow body through the same path the rest of `StepHandlerDeps` does: orchestrator → step handler → executor → ctx → workflow `run`. No new transport.
 
@@ -649,7 +674,11 @@ This is convention, not enforcement. The framework doesn't care which keys you u
 | `now` | `() => number` | Injectable clock. |
 | Module names | Module's `service` value | Whatever each module registered (existing behavior). |
 
-Templates or plugins can register additional keys before `createApp()` returns. This is where catalog services like `indexer` and `productDocBuilder` come from in the operator template.
+Templates or plugins can publish additional keys by registering a host-owned
+module `service` under the key workflows resolve, or by registering into the
+same container during bootstrap when the workflow cannot run before that
+bootstrap completes. This is where catalog services like `indexer` and
+`productDocBuilder` come from in an app template.
 
 ### 11.5 Step-level vs ctx-level access
 
@@ -661,7 +690,7 @@ Concrete patterns the gap blocks today:
 
 - **Modules ship workflow bodies that read shared services.** `bulkReindexProducts` uses `ctx.services.resolve("indexer")` instead of constructing one. Move the workflow between templates → it still works, as long as the host template registers an `indexer`.
 - **Plugins inject services for module workflows.** A `@voyantjs/plugin-typesense` could register `indexer` against a Typesense client; a `@voyantjs/plugin-meilisearch` could register the same key against Meilisearch. Module workflows are unchanged.
-- **Tests inject mocks.** `createInMemoryDriver({ services: testContainer })` for isolated workflow body tests; `createNodeStandaloneDriver({ db: testDb, services: testContainer })` for integration tests.
+- **Tests inject mocks.** `createInMemoryDriver({ services: testContainer })` for isolated workflow body tests; `createNodeStandaloneDriver({ db: testDb })(testFactoryDeps({ services: testContainer }))` for integration tests.
 
 ### 11.7 What it does NOT do
 
@@ -973,7 +1002,7 @@ What `createApp()` does at construction time (synchronous):
 
 1. Resolves modules + plugins (existing pipeline).
 2. Builds the `ModuleContainer` and registers each module's `service` plus the framework-owned defaults (`db` — see lifecycle note below — `eventBus`, `logger`, `now`; see §11.4).
-3. If `workflows: { db }` was passed, synthesizes the default `DriverFactory` `({ services }) => createNodeStandaloneDriver({ db, services })`. If `workflows: { driver }` was passed, takes the supplied factory as-is. Invokes the factory with `{ services: container, logger, db?, now? }` and stores the resulting `WorkflowDriver`.
+3. Invokes `workflows.driver(bindings)` to obtain a `DriverFactory`, then invokes that factory with `{ services: container, logger, now? }` and stores the resulting `WorkflowDriver`. For Node self-host apps this is typically `driver: () => createNodeStandaloneDriver({ db })`; the framework-supplied services arrive through the factory deps, not the `createNodeStandaloneDriver()` options.
 4. Calls `collectWorkflows(modules, plugins)` and `collectEventFilters(modules, plugins)`.
 5. Mounts HTTP routes (existing pipeline).
 6. Sets up the lazy `bootstrapPromise` to fire on first request.

--- a/packages/workflows-orchestrator-node/README.md
+++ b/packages/workflows-orchestrator-node/README.md
@@ -57,6 +57,84 @@ When the parent id comes from an external admin recorder such as
 `seedResults` from that recorder's `WorkflowResumeContext`. Seeded steps are
 replayed from the journal, so their side effects do not run again.
 
+## Service-backed package workflows
+
+Package workflows can resolve host-provided services through
+`ctx.services.resolve(...)`. For example, `@voyantjs/promotions` exports the
+`promotions.reindex-all-products` workflow, which resolves the bulk reindex
+service registered under `BULK_REINDEX_SERVICE_KEY`.
+
+For app-integrated Node runtimes, prefer the `createApp()` workflow runtime.
+`createApp()` builds the module container, passes a read-only service resolver
+to the driver factory, and the Node standalone driver forwards that resolver
+into every workflow step:
+
+```ts
+import { createApp } from "@voyantjs/hono"
+import type { HonoModule } from "@voyantjs/hono/module"
+import { createNodeStandaloneDriver } from "@voyantjs/workflows-orchestrator-node"
+import {
+  BULK_REINDEX_SERVICE_KEY,
+  promotionsHonoModule,
+} from "@voyantjs/promotions"
+
+const promotionsWorkflowServices: HonoModule = {
+  module: {
+    name: BULK_REINDEX_SERVICE_KEY,
+    service: bulkReindexProductsService,
+  },
+}
+
+const app = createApp({
+  db: () => db,
+  modules: [promotionsHonoModule, promotionsWorkflowServices],
+  workflows: {
+    driver: () => createNodeStandaloneDriver({ db }),
+    environment: "production",
+  },
+})
+
+await app.ready()
+```
+
+The key point is that service registration happens in the host app and the
+driver receives the framework's service resolver from `createApp()`; workflow
+code stays package-owned and deployment-agnostic.
+
+If you are still using the standalone self-host HTTP helper directly with an
+entry file, pass the same read-only resolver to `startNodeSelfHostServer()` or
+`createNodeSelfHostDeps()`:
+
+```ts
+import { BULK_REINDEX_SERVICE_KEY } from "@voyantjs/promotions"
+import type { ServiceResolver } from "@voyantjs/workflows/driver"
+import { startNodeSelfHostServer } from "@voyantjs/workflows-orchestrator-node"
+
+const services: ServiceResolver = {
+  resolve<T>(name: string): T {
+    if (name === BULK_REINDEX_SERVICE_KEY) {
+      return bulkReindexProductsService as T
+    }
+    throw new Error(`Service "${name}" is not registered`)
+  },
+  has(name: string): boolean {
+    return name === BULK_REINDEX_SERVICE_KEY
+  },
+}
+
+await startNodeSelfHostServer({
+  entryFile: "./dist/workflows.mjs",
+  databaseUrl: process.env.DATABASE_URL,
+  services,
+})
+```
+
+That direct helper is useful for existing entry-file deployments. New
+service-backed package workflow integrations should usually migrate to
+`createApp({ workflows: { driver: () => createNodeStandaloneDriver({ db }) } })`
+so module services, event filters, manifest registration, and `ctx.services`
+all come from one app composition path.
+
 ## Postgres migrations
 
 The PostgreSQL schema for the Node self-host target lives in

--- a/packages/workflows-orchestrator-node/src/__tests__/dashboard-server.test.ts
+++ b/packages/workflows-orchestrator-node/src/__tests__/dashboard-server.test.ts
@@ -125,6 +125,68 @@ describe("createNodeSelfHostDeps validation", () => {
     }
   })
 
+  it("surfaces configured services to self-host workflow bodies", async () => {
+    const root = await mkdtemp(join(process.cwd(), ".tmp-services-workflow-entry-"))
+    let deps: Awaited<ReturnType<typeof createNodeSelfHostDeps>> | undefined
+    try {
+      const entryFile = join(root, "services-workflows.mjs")
+      const staticDir = join(root, "static")
+      await mkdir(staticDir, { recursive: true })
+      await writeFile(
+        entryFile,
+        [
+          'import { workflow } from "@voyantjs/workflows";',
+          'workflow({ id: "service_probe", async run(_input, ctx) {',
+          '  const catalog = ctx.services.resolve("catalog:indexer");',
+          "  return { serviceName: catalog.name, optional: ctx.services.has('missing') };",
+          "}});",
+        ].join("\n"),
+        "utf8",
+      )
+
+      deps = await createNodeSelfHostDeps({
+        entryFile,
+        staticDir,
+        cacheBustEntry: true,
+        services: {
+          resolve<T>(name: string): T {
+            if (name === "catalog:indexer") return { name: "test-indexer" } as T
+            throw new Error(`missing service ${name}`)
+          },
+          has(name) {
+            return name === "catalog:indexer"
+          },
+        },
+        store: createFsSnapshotRunStore({ rootDir: join(root, "runs") }),
+      })
+
+      const response = await handleRequest(
+        {
+          method: "POST",
+          url: "http://local/api/runs",
+          body: JSON.stringify({ workflowId: "service_probe", input: {} }),
+        },
+        deps,
+      )
+
+      expect(response.status).toBe(200)
+      const triggered = JSON.parse(String(response.body)) as {
+        saved: {
+          status: string
+          result: { output: { serviceName: string; optional: boolean } }
+        }
+      }
+      expect(triggered.saved.status).toBe("completed")
+      expect(triggered.saved.result.output).toEqual({
+        serviceName: "test-indexer",
+        optional: false,
+      })
+    } finally {
+      await deps?.shutdown?.()
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   it("resumes a failed self-host run from its seeded successful steps", async () => {
     const root = await mkdtemp(join(process.cwd(), ".tmp-resume-workflow-entry-"))
     const previousProbe = (globalThis as { __voyantResumeProbeA?: number }).__voyantResumeProbeA

--- a/packages/workflows-orchestrator-node/src/dashboard-server.ts
+++ b/packages/workflows-orchestrator-node/src/dashboard-server.ts
@@ -2,6 +2,7 @@ import { readFile, stat } from "node:fs/promises"
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http"
 import { extname, join, resolve as resolvePath } from "node:path"
 import { URL } from "node:url"
+import type { ServiceResolver } from "@voyantjs/workflows/driver"
 import { handleStepRequest, type StepRunner } from "@voyantjs/workflows/handler"
 import { createInMemoryRateLimiter } from "@voyantjs/workflows/rate-limit"
 import {
@@ -818,6 +819,14 @@ export interface NodeSelfHostServerOptions {
   host?: string
   staticDir?: string
   cacheBustEntry?: boolean
+  /**
+   * Read-only service resolver surfaced to workflow bodies as `ctx.services`.
+   *
+   * Use this when the loaded entry file registers package workflows that
+   * resolve host-provided services, for example
+   * `ctx.services.resolve("promotions:bulk-reindex-products")`.
+   */
+  services?: ServiceResolver
   store?: SnapshotRunStore
   databaseUrl?: string
   wakeupPollIntervalMs?: number
@@ -844,6 +853,7 @@ export async function createNodeSelfHostDeps(
     | "entryFile"
     | "staticDir"
     | "cacheBustEntry"
+    | "services"
     | "store"
     | "databaseUrl"
     | "wakeupPollIntervalMs"
@@ -914,7 +924,7 @@ export async function createNodeSelfHostDeps(
   }
 
   const stepHandler: StepHandler = async (req, stepOpts) =>
-    handleStepRequest(req, { rateLimiter, nodeStepRunner }, stepOpts)
+    handleStepRequest(req, { rateLimiter, nodeStepRunner, services: opts.services }, stepOpts)
   const tenantMeta = {
     tenantId: "tnt_local",
     projectId: "prj_local",


### PR DESCRIPTION
Closes #596

## Summary
- add a `services` resolver option to the Node self-host server helpers and pass it into workflow step execution
- cover entry-file workflows that resolve `ctx.services` with a self-host regression test
- document the app-integrated `createApp()` path and the direct self-host helper path for service-backed package workflows

## Verification
- `pnpm --filter @voyantjs/workflows-orchestrator-node test`
- `pnpm --filter @voyantjs/workflows-orchestrator-node check-types`
- `pnpm --filter @voyantjs/workflows-orchestrator-node build`
- `pnpm lint:changed`
- `git diff --check`
- pre-push `pnpm test`