### PR TITLE
fix(agent-runner): complete closed linked project items

### DIFF
--- a/apps/agent-control-plane/src/control-plane.test.ts
+++ b/apps/agent-control-plane/src/control-plane.test.ts
@@ -92,6 +92,7 @@ describe("agent control plane", () => {
       dryRunOnly: true,
       dispatchableActions: [
         "collect-ci",
+        "complete-pr",
         "cleanup",
         "open-pr",
         "publish-evidence",

--- a/apps/agent-control-plane/src/control-plane.ts
+++ b/apps/agent-control-plane/src/control-plane.ts
@@ -2,6 +2,7 @@ import { z } from "zod"
 
 export const dispatchableActions = [
   "collect-ci",
+  "complete-pr",
   "cleanup",
   "open-pr",
   "publish-evidence",

--- a/scripts/lib/agent-runner-dispatch.mjs
+++ b/scripts/lib/agent-runner-dispatch.mjs
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process"
 
 export const dispatchableActions = new Set([
   "collect-ci",
+  "complete-pr",
   "cleanup",
   "open-pr",
   "publish-evidence",

--- a/scripts/lib/agent-runner-tick.mjs
+++ b/scripts/lib/agent-runner-tick.mjs
@@ -45,6 +45,25 @@ export function recommendQueueAction(item, { maxAgeDays, repository }) {
     ? evaluateHeartbeat(item.fields["Last Heartbeat"], { maxAgeDays })
     : null
 
+  if (
+    item.issue.state === "CLOSED" &&
+    item.fields.PR &&
+    state !== "Done" &&
+    state !== "Abandoned"
+  ) {
+    return recommendation(item, {
+      action: "complete-pr",
+      command: commandWithIssue({
+        command: "complete-pr",
+        issueNumber: item.issue.number,
+        repository,
+      }),
+      heartbeat,
+      priority: 45,
+      reason: "closed issue with linked PR should be completed in the Project",
+    })
+  }
+
   if (stalePreemptionStates.has(state) && heartbeat?.stale) {
     return recommendation(item, {
       action: "inspect-stale",

--- a/scripts/tests/agent-fixtures.mjs
+++ b/scripts/tests/agent-fixtures.mjs
@@ -1,5 +1,6 @@
 export function workItem({
   fields = {},
+  issueState = "OPEN",
   number = 579,
   title = "Test agent project intake workflow",
 } = {}) {
@@ -9,7 +10,7 @@ export function workItem({
       number,
       title,
       url: `https://github.com/voyantjs/voyant/issues/${number}`,
-      state: "OPEN",
+      state: issueState,
       repository: "voyantjs/voyant",
       labels: ["agent:ready"],
       hasAgentBrief: true,

--- a/scripts/tests/agent-runner-dispatch-completion.test.mjs
+++ b/scripts/tests/agent-runner-dispatch-completion.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { dispatchCommandArgs, selectDispatchRecommendation } from "../lib/agent-runner-dispatch.mjs"
+import { recommendQueueAction } from "../lib/agent-runner-tick.mjs"
+import { workItem } from "./agent-fixtures.mjs"
+
+describe("agent runner dispatch completion helpers", () => {
+  it("dispatches closed linked PR completion recommendations", () => {
+    const recommendation = recommendQueueAction(
+      workItem({
+        fields: {
+          "Agent State": "Human Review",
+          PR: "https://github.com/voyantjs/voyant/pull/626",
+        },
+        issueState: "CLOSED",
+      }),
+      { maxAgeDays: 1, repository: "voyantjs/other" },
+    )
+
+    assert.equal(
+      selectDispatchRecommendation([recommendation]).recommendation.action,
+      "complete-pr",
+    )
+    assert.deepEqual(dispatchCommandArgs(recommendation, { repository: "voyantjs/other" }), [
+      "agent:queue:complete-pr",
+      "--",
+      "--issue",
+      "579",
+      "--repo",
+      "voyantjs/other",
+      "--yes",
+    ])
+  })
+})

--- a/scripts/tests/agent-runner-tick.test.mjs
+++ b/scripts/tests/agent-runner-tick.test.mjs
@@ -88,6 +88,32 @@ describe("agent runner tick helpers", () => {
       },
     )
 
+    assert.deepEqual(
+      recommendQueueAction(
+        workItem({
+          fields: {
+            "Agent State": "Human Review",
+            "Last Heartbeat": new Date().toISOString().slice(0, 10),
+            PR: "https://github.com/voyantjs/voyant/pull/626",
+          },
+          issueState: "CLOSED",
+        }),
+        { maxAgeDays: 1, repository: "voyantjs/other" },
+      ),
+      {
+        action: "complete-pr",
+        command: "pnpm agent:queue:complete-pr -- --issue 579 --repo voyantjs/other --yes",
+        heartbeat: {
+          reason: "Last Heartbeat is 0 days old",
+          stale: false,
+        },
+        issue: workItem({ issueState: "CLOSED" }).issue,
+        priority: 45,
+        reason: "closed issue with linked PR should be completed in the Project",
+        state: "Human Review",
+      },
+    )
+
     assert.equal(
       recommendQueueAction(
         workItem({


### PR DESCRIPTION
## Summary

- route closed Project issues with linked PRs to `complete-pr` instead of `sync-pr`
- add `complete-pr` to the runner/control-plane dispatch allow-list
- add regression coverage for the queue recommendation and dispatch path

## Validation

- `pnpm agent:queue:test`
- `pnpm --filter @voyantjs/agent-control-plane test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm agent:queue:tick -- --repo voyantjs/voyant --json`
- `git diff --check`
- pre-commit hook: changed-file formatting, secretlint, agent quality, affected typecheck
- pre-push hook: `pnpm test`