### PR TITLE
feat(agent-runner): add cloud runner shell

### DIFF
--- a/apps/agent-runner/README.md
+++ b/apps/agent-runner/README.md
@@ -1,0 +1,26 @@
+# Voyant Agent Runner
+
+`apps/agent-runner` is the Cloudflare-ready shell for an always-on agent queue
+runner. The first version is intentionally non-executing: it proves the deployed
+Hono surface, bearer-token auth, scheduled handler shape, and control-plane
+configuration without spending agent budget or mutating GitHub Projects.
+
+## Endpoints
+
+- `GET /health` returns public service health.
+- `GET /api/capabilities` returns runner defaults, execution state, and
+  control-plane configuration. Requires `AGENT_RUNNER_TOKENS`.
+- `POST /api/supervisor/ticks` validates a supervisor tick request and returns
+  the equivalent local command plan. It does not execute the command.
+
+## Configuration
+
+- `AGENT_RUNNER_TOKENS`: comma-separated bearer tokens for `/api/*`.
+- `AGENT_RUNNER_ENABLED`: must be `true` before scheduled plans can be accepted.
+- `AGENT_RUNNER_HOLDER`: default lease holder, for example `runner:cloudflare`.
+- `AGENT_RUNNER_REPOSITORY`: default repository, for example `voyantjs/voyant`.
+- `AGENT_CONTROL_PLANE_URL`: deployed control-plane URL.
+- `AGENT_CONTROL_PLANE_TOKEN`: bearer token for the control plane.
+
+Cron triggers should stay disabled until GitHub polling, execution policy,
+budget controls, and provider credentials are wired into a later slice.

--- a/apps/agent-runner/package.json
+++ b/apps/agent-runner/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@voyantjs/agent-runner",
+  "version": "0.0.0",
+  "description": "Cloudflare-ready runner shell for supervised Voyant agent queue work.",
+  "license": "Apache-2.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/worker.ts",
+  "scripts": {
+    "check-types": "tsc --noEmit",
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev",
+    "lint": "biome check .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "hono": "^4.12.10",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260426.1",
+    "@voyantjs/voyant-typescript-config": "workspace:*",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2",
+    "wrangler": "4.86.0"
+  }
+}

--- a/apps/agent-runner/src/app.test.ts
+++ b/apps/agent-runner/src/app.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest"
+
+import { createApp } from "./app.js"
+
+describe("agent runner app", () => {
+  it("serves public health without runner auth", async () => {
+    const response = await createApp().request("/health")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true, service: "agent-runner" })
+  })
+
+  it("requires auth before returning runner capabilities", async () => {
+    const response = await createApp().request("/api/capabilities")
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({ error: "runner_auth_not_configured" })
+  })
+
+  it("reports disabled execution until the runner is explicitly enabled", async () => {
+    const response = await createApp({ authTokens: ["token"] }).request("/api/capabilities", {
+      headers: {
+        authorization: "Bearer token",
+      },
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      execution: {
+        enabled: false,
+        mode: "disabled",
+      },
+      service: "agent-runner",
+    })
+  })
+
+  it("plans supervisor ticks without mutating work", async () => {
+    const app = createApp({
+      authTokens: ["token"],
+      config: {
+        controlPlaneConfigured: true,
+        controlPlaneUrl: "https://control.example.com",
+        enabled: true,
+        holder: "runner:cloudflare",
+        repository: "voyantjs/voyant",
+      },
+      now: () => new Date("2026-05-12T11:00:00.000Z"),
+    })
+
+    const response = await app.request("/api/supervisor/ticks", {
+      body: JSON.stringify({ iterations: 3 }),
+      headers: {
+        authorization: "Bearer token",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      plannedAt: "2026-05-12T11:00:00.000Z",
+      plan: {
+        accepted: true,
+        blockers: [],
+        command: [
+          "pnpm",
+          "agent:queue:control-plane-loop",
+          "--",
+          "--repo",
+          "voyantjs/voyant",
+          "--holder",
+          "runner:cloudflare",
+          "--iterations",
+          "3",
+          "--yes",
+          "--control-plane-url",
+          "https://control.example.com",
+        ],
+        dryRun: true,
+        iterations: 3,
+        source: "api",
+      },
+    })
+  })
+})

--- a/apps/agent-runner/src/app.ts
+++ b/apps/agent-runner/src/app.ts
@@ -1,0 +1,84 @@
+import { Hono } from "hono"
+
+import {
+  buildRunnerCapabilities,
+  planSupervisorTick,
+  type RunnerConfig,
+  supervisorTickRequestSchema,
+} from "./runner.js"
+
+interface AppOptions {
+  authTokens?: string[]
+  config?: RunnerConfig
+  now?: () => Date
+}
+
+export function createApp({
+  authTokens = [],
+  config = {
+    controlPlaneConfigured: false,
+    enabled: false,
+  },
+  now = () => new Date(),
+}: AppOptions = {}): Hono {
+  const app = new Hono()
+
+  app.onError((error, c) => {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`[agent-runner] ${c.req.method} ${c.req.path}: ${message}`)
+    return c.json({ error: "internal_error" }, 500)
+  })
+
+  app.get("/health", (c) => c.json({ ok: true, service: "agent-runner" }))
+
+  app.use("/api/*", async (c, next) => {
+    if (authTokens.length === 0) {
+      return c.json({ error: "runner_auth_not_configured" }, 503)
+    }
+
+    const token = bearerToken(c.req.header("authorization"))
+    if (!token || !authTokens.includes(token)) {
+      return c.json({ error: "unauthorized" }, 401)
+    }
+
+    await next()
+  })
+
+  app.get("/api/capabilities", (c) => c.json(buildRunnerCapabilities(config)))
+
+  app.post("/api/supervisor/ticks", async (c) => {
+    const parsed = supervisorTickRequestSchema.safeParse(await c.req.json().catch(() => ({})))
+    if (!parsed.success) {
+      return c.json(
+        {
+          error: "invalid_supervisor_tick_request",
+          issues: validationIssues(parsed.error),
+        },
+        400,
+      )
+    }
+
+    return c.json({
+      plannedAt: now().toISOString(),
+      plan: planSupervisorTick({
+        config,
+        request: parsed.data,
+        source: "api",
+      }),
+    })
+  })
+
+  return app
+}
+
+function bearerToken(header: string | undefined) {
+  const match = header?.match(/^Bearer\s+(.+)$/i)
+  return match?.[1]?.trim()
+}
+
+function validationIssues(error: { issues: Array<{ path: Array<PropertyKey>; message: string }> }) {
+  return error.issues.map((issue) => ({
+    path: issue.path.join("."),
+    message: issue.message,
+  }))
+}

--- a/apps/agent-runner/src/runner.ts
+++ b/apps/agent-runner/src/runner.ts
@@ -1,0 +1,106 @@
+import { z } from "zod"
+
+export const supervisorTickRequestSchema = z
+  .object({
+    dryRun: z.boolean().optional(),
+    holder: z.string().trim().min(1).optional(),
+    iterations: z.number().int().positive().max(100).optional(),
+    repository: z.string().trim().min(1).optional(),
+    reason: z.string().trim().min(1).optional(),
+  })
+  .strict()
+
+export type SupervisorTickRequest = z.infer<typeof supervisorTickRequestSchema>
+
+export interface RunnerConfig {
+  controlPlaneConfigured: boolean
+  controlPlaneUrl?: string
+  enabled: boolean
+  holder?: string
+  repository?: string
+}
+
+export function buildRunnerCapabilities(config: RunnerConfig) {
+  return {
+    service: "agent-runner",
+    execution: {
+      enabled: config.enabled,
+      mode: config.enabled ? "supervisor" : "disabled",
+      reason: config.enabled
+        ? "runner execution is enabled by environment"
+        : "runner execution is disabled until credentials, queue budget, and policy are configured",
+    },
+    controlPlane: {
+      configured: config.controlPlaneConfigured,
+      url: config.controlPlaneUrl ?? null,
+    },
+    defaults: {
+      holder: config.holder ?? null,
+      repository: config.repository ?? null,
+    },
+    scheduler: {
+      cronCompatible: true,
+      mutatesByDefault: false,
+    },
+  }
+}
+
+export function planSupervisorTick({
+  config,
+  request = {},
+  source,
+}: {
+  config: RunnerConfig
+  request?: SupervisorTickRequest
+  source: "api" | "scheduled"
+}) {
+  const holder = request.holder ?? config.holder
+  const repository = request.repository ?? config.repository
+  const iterations = request.iterations ?? 1
+
+  const blockers = [
+    config.enabled ? null : "runner execution is disabled",
+    config.controlPlaneConfigured ? null : "control plane is not configured",
+    holder ? null : "holder is not configured",
+    repository ? null : "repository is not configured",
+  ].filter((blocker): blocker is string => Boolean(blocker))
+
+  return {
+    accepted: blockers.length === 0,
+    blockers,
+    command: buildLocalEquivalentCommand({
+      controlPlaneUrl: config.controlPlaneUrl,
+      holder,
+      iterations,
+      repository,
+    }),
+    dryRun: request.dryRun ?? true,
+    iterations,
+    source,
+  }
+}
+
+function buildLocalEquivalentCommand({
+  controlPlaneUrl,
+  holder,
+  iterations,
+  repository,
+}: {
+  controlPlaneUrl?: string
+  holder?: string
+  iterations: number
+  repository?: string
+}) {
+  const command = ["pnpm", "agent:queue:control-plane-loop", "--"]
+  if (repository) {
+    command.push("--repo", repository)
+  }
+  if (holder) {
+    command.push("--holder", holder)
+  }
+  command.push("--iterations", String(iterations), "--yes")
+  if (controlPlaneUrl) {
+    command.push("--control-plane-url", controlPlaneUrl)
+  }
+  return command
+}

--- a/apps/agent-runner/src/worker.ts
+++ b/apps/agent-runner/src/worker.ts
@@ -1,0 +1,49 @@
+import { createApp } from "./app.js"
+import { planSupervisorTick } from "./runner.js"
+
+interface Env {
+  AGENT_CONTROL_PLANE_TOKEN?: string
+  AGENT_CONTROL_PLANE_URL?: string
+  AGENT_RUNNER_ENABLED?: string
+  AGENT_RUNNER_HOLDER?: string
+  AGENT_RUNNER_REPOSITORY?: string
+  AGENT_RUNNER_TOKENS?: string
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const app = createApp({
+      authTokens: parseTokens(env.AGENT_RUNNER_TOKENS),
+      config: runnerConfigFromEnv(env),
+    })
+    return await app.fetch(request)
+  },
+
+  async scheduled(_event: ScheduledController, env: Env): Promise<void> {
+    const plan = planSupervisorTick({
+      config: runnerConfigFromEnv(env),
+      request: {
+        reason: "cloudflare-cron",
+      },
+      source: "scheduled",
+    })
+    console.log(JSON.stringify({ service: "agent-runner", supervisorTick: plan }))
+  },
+} satisfies ExportedHandler<Env>
+
+function runnerConfigFromEnv(env: Env) {
+  return {
+    controlPlaneConfigured: Boolean(env.AGENT_CONTROL_PLANE_URL && env.AGENT_CONTROL_PLANE_TOKEN),
+    controlPlaneUrl: env.AGENT_CONTROL_PLANE_URL,
+    enabled: env.AGENT_RUNNER_ENABLED === "true",
+    holder: env.AGENT_RUNNER_HOLDER,
+    repository: env.AGENT_RUNNER_REPOSITORY,
+  }
+}
+
+function parseTokens(value: string | undefined) {
+  return (value ?? "")
+    .split(",")
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0)
+}

--- a/apps/agent-runner/tsconfig.json
+++ b/apps/agent-runner/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@voyantjs/voyant-typescript-config/workers.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "moduleResolution": "Bundler",
+    "module": "ESNext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/apps/agent-runner/vitest.config.ts
+++ b/apps/agent-runner/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+    globals: false,
+  },
+})

--- a/apps/agent-runner/wrangler.jsonc
+++ b/apps/agent-runner/wrangler.jsonc
@@ -1,0 +1,18 @@
+{
+  // Reference Cloudflare Worker for the agent queue runner shell.
+  // This first deployment is intentionally non-executing: it exposes the
+  // deployable surface, auth, scheduled handler, and control-plane wiring before
+  // any remote GitHub or provider mutation is enabled.
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "voyant-agent-runner",
+  "main": "src/worker.ts",
+  "compatibility_date": "2025-01-01",
+  // Configure AGENT_RUNNER_TOKENS as a secret before exposing /api/*:
+  // pnpm -C apps/agent-runner wrangler secret put AGENT_RUNNER_TOKENS
+  // Configure AGENT_CONTROL_PLANE_TOKEN separately when the runner is allowed to
+  // call the control plane. Cron triggers should stay disabled until execution
+  // policy, queue budget, and provider credentials are configured.
+  "observability": {
+    "enabled": true
+  }
+}

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1351,6 +1351,11 @@ Verification:
   Each iteration submits a fresh tick snapshot, leases one intent from that
   stored snapshot, runs the leased lifecycle command, records the terminal
   outcome, and stops on idle, failure, or the configured iteration limit.
+- A Cloudflare-ready runner shell exists in `apps/agent-runner`. It exposes
+  health, capabilities, a scheduled handler, and a guarded supervisor tick
+  planning endpoint. The shell is deliberately non-executing until GitHub
+  polling, budget controls, provider credentials, and execution policy are wired
+  into a later slice.
 
 ## Open Questions
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,31 @@ importers:
         specifier: 4.86.0
         version: 4.86.0(@cloudflare/workers-types@4.20260426.1)
 
+  apps/agent-runner:
+    dependencies:
+      hono:
+        specifier: ^4.12.10
+        version: 4.12.10
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260426.1
+        version: 4.20260426.1
+      '@voyantjs/voyant-typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
+      wrangler:
+        specifier: 4.86.0
+        version: 4.86.0(@cloudflare/workers-types@4.20260426.1)
+
   apps/catalog-demo-api:
     dependencies:
       '@hono/node-server':


### PR DESCRIPTION
## Summary

- add `apps/agent-runner` as a Cloudflare/Hono runner shell
- expose health, authenticated capabilities, and guarded supervisor tick planning endpoints
- wire a scheduled handler that logs a non-mutating supervisor tick plan
- document runner env vars and mark execution disabled until policy, budget, GitHub polling, and credentials are wired

## Validation

- `pnpm --filter @voyantjs/agent-runner test`
- `pnpm --filter @voyantjs/agent-runner typecheck`
- `pnpm --filter @voyantjs/agent-runner lint`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- pre-commit hook: formatting, secretlint, agent quality, repository lint, repository typecheck
- pre-push hook: `pnpm test`