### PR TITLE
[codex] Expose traveler sharing groups

### DIFF
--- a/.changeset/sharing-group-traveler-helpers.md
+++ b/.changeset/sharing-group-traveler-helpers.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/bookings": minor
+"@voyantjs/bookings-react": minor
+---
+
+Expose slot-scoped traveler sharing groups through bookings routes and React hooks, and wire traveler allocation metadata through travel-details validation.

--- a/packages/bookings-react/src/hooks/index.ts
+++ b/packages/bookings-react/src/hooks/index.ts
@@ -91,6 +91,12 @@ export {
 } from "./use-public-booking-session-state.js"
 export { type UseRevealTravelerOptions, useRevealTraveler } from "./use-reveal-traveler.js"
 export {
+  type UseBookingsBySharingGroupOptions,
+  type UseSharingGroupsForSlotOptions,
+  useBookingsBySharingGroup,
+  useSharingGroupsForSlot,
+} from "./use-sharing-groups.js"
+export {
   type CreateSupplierStatusInput,
   type UpdateSupplierStatusInput,
   useSupplierStatusMutation,

--- a/packages/bookings-react/src/hooks/use-sharing-groups.ts
+++ b/packages/bookings-react/src/hooks/use-sharing-groups.ts
@@ -1,0 +1,44 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+
+import { useVoyantBookingsContext } from "../provider.js"
+import {
+  getBookingsBySharingGroupQueryOptions,
+  getSharingGroupsForSlotQueryOptions,
+} from "../query-options.js"
+
+export interface UseSharingGroupsForSlotOptions {
+  enabled?: boolean
+}
+
+export function useSharingGroupsForSlot(
+  slotId: string | null | undefined,
+  options: UseSharingGroupsForSlotOptions = {},
+) {
+  const { baseUrl, fetcher } = useVoyantBookingsContext()
+  const { enabled = true } = options
+
+  return useQuery({
+    ...getSharingGroupsForSlotQueryOptions({ baseUrl, fetcher }, slotId),
+    enabled: enabled && Boolean(slotId),
+  })
+}
+
+export interface UseBookingsBySharingGroupOptions {
+  enabled?: boolean
+}
+
+export function useBookingsBySharingGroup(
+  slotId: string | null | undefined,
+  groupId: string | null | undefined,
+  options: UseBookingsBySharingGroupOptions = {},
+) {
+  const { baseUrl, fetcher } = useVoyantBookingsContext()
+  const { enabled = true } = options
+
+  return useQuery({
+    ...getBookingsBySharingGroupQueryOptions({ baseUrl, fetcher }, slotId, groupId),
+    enabled: enabled && Boolean(slotId) && Boolean(groupId),
+  })
+}

--- a/packages/bookings-react/src/hooks/use-traveler-with-travel-details-mutation.ts
+++ b/packages/bookings-react/src/hooks/use-traveler-with-travel-details-mutation.ts
@@ -38,6 +38,10 @@ export interface CreateTravelerWithTravelDetailsInput {
   dietaryRequirements?: string | null
   accessibilityNeeds?: string | null
   isLeadTraveler?: boolean | null
+  sharingGroupId?: string | null
+  roomTypeId?: string | null
+  bedPreference?: "single" | "twin" | "double" | "no-preference" | null
+  allocations?: Record<string, string>
 }
 
 export type UpdateTravelerWithTravelDetailsInput = Partial<CreateTravelerWithTravelDetailsInput>

--- a/packages/bookings-react/src/index.ts
+++ b/packages/bookings-react/src/index.ts
@@ -26,11 +26,13 @@ export {
   getBookingItemTravelersQueryOptions,
   getBookingNotesQueryOptions,
   getBookingQueryOptions,
+  getBookingsBySharingGroupQueryOptions,
   getBookingsQueryOptions,
   getBookingTravelerDocumentsQueryOptions,
   getPricingPreviewQueryOptions,
   getPublicBookingSessionQueryOptions,
   getPublicBookingSessionStateQueryOptions,
+  getSharingGroupsForSlotQueryOptions,
   getSupplierStatusesQueryOptions,
   getTravelersQueryOptions,
 } from "./query-options.js"

--- a/packages/bookings-react/src/query-keys.ts
+++ b/packages/bookings-react/src/query-keys.ts
@@ -56,6 +56,10 @@ export const bookingsQueryKeys = {
   itemParticipants: (bookingId: string, itemId: string) =>
     [...bookingsQueryKeys.items(bookingId), itemId, "participants"] as const,
   travelers: (bookingId: string) => [...bookingsQueryKeys.booking(bookingId), "travelers"] as const,
+  sharingGroupsForSlot: (slotId: string) =>
+    [...bookingsQueryKeys.all, "sharing-groups", "slot", slotId] as const,
+  travelersBySharingGroup: (slotId: string, groupId: string) =>
+    [...bookingsQueryKeys.sharingGroupsForSlot(slotId), groupId, "travelers"] as const,
   passengers: (bookingId: string) =>
     [...bookingsQueryKeys.booking(bookingId), "passengers"] as const,
   documents: (bookingId: string) => [...bookingsQueryKeys.booking(bookingId), "documents"] as const,

--- a/packages/bookings-react/src/query-options.ts
+++ b/packages/bookings-react/src/query-options.ts
@@ -28,7 +28,9 @@ import {
   bookingSingleResponse,
   bookingSupplierStatusesResponse,
   bookingTravelerDocumentsResponse,
+  bookingTravelerSharingGroupsResponse,
   bookingTravelerSingleResponse,
+  bookingTravelersBySharingGroupResponse,
   bookingTravelersResponse,
   pricingPreviewResponse,
   publicBookingSessionResponse,
@@ -138,6 +140,39 @@ export function getTravelersQueryOptions(
     queryKey: bookingsQueryKeys.travelers(bookingId ?? ""),
     queryFn: () =>
       fetchWithValidation(`/v1/bookings/${bookingId}/travelers`, bookingTravelersResponse, client),
+  })
+}
+
+export function getSharingGroupsForSlotQueryOptions(
+  client: FetchWithValidationOptions,
+  slotId: string | null | undefined,
+) {
+  return queryOptions({
+    queryKey: bookingsQueryKeys.sharingGroupsForSlot(slotId ?? ""),
+    queryFn: () =>
+      fetchWithValidation(
+        `/v1/bookings/sharing-groups?slotId=${encodeURIComponent(slotId ?? "")}`,
+        bookingTravelerSharingGroupsResponse,
+        client,
+      ),
+  })
+}
+
+export function getBookingsBySharingGroupQueryOptions(
+  client: FetchWithValidationOptions,
+  slotId: string | null | undefined,
+  groupId: string | null | undefined,
+) {
+  return queryOptions({
+    queryKey: bookingsQueryKeys.travelersBySharingGroup(slotId ?? "", groupId ?? ""),
+    queryFn: () =>
+      fetchWithValidation(
+        `/v1/bookings/sharing-groups/${encodeURIComponent(
+          groupId ?? "",
+        )}/travelers?slotId=${encodeURIComponent(slotId ?? "")}`,
+        bookingTravelersBySharingGroupResponse,
+        client,
+      ),
   })
 }
 

--- a/packages/bookings-react/src/schemas.ts
+++ b/packages/bookings-react/src/schemas.ts
@@ -127,6 +127,10 @@ export const bookingTravelerTravelDetailsSchema = z.object({
   dietaryRequirements: z.string().nullable(),
   accessibilityNeeds: z.string().nullable(),
   isLeadTraveler: z.boolean(),
+  sharingGroupId: z.string().nullable(),
+  roomTypeId: z.string().nullable(),
+  bedPreference: z.enum(["single", "twin", "double", "no-preference"]).nullable(),
+  allocations: z.record(z.string(), z.string()),
   createdAt: z.string(),
   updatedAt: z.string(),
 })
@@ -138,6 +142,31 @@ export const bookingTravelerRevealRecordSchema = bookingTravelerRecordSchema.ext
 export type BookingTravelerRecord = z.infer<typeof bookingTravelerRecordSchema>
 export type BookingTravelerTravelDetailsRecord = z.infer<typeof bookingTravelerTravelDetailsSchema>
 export type BookingTravelerRevealRecord = z.infer<typeof bookingTravelerRevealRecordSchema>
+
+export const bookingTravelerSharingGroupSummarySchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  occupancy: z.number().int(),
+  roomTypeId: z.string().nullable(),
+  bookingIds: z.array(z.string()),
+})
+
+export const bookingTravelerSharingGroupMemberSchema = bookingTravelerRecordSchema.extend({
+  bookingNumber: z.string(),
+  personId: z.string().nullable(),
+  isLeadTraveler: z.boolean(),
+  sharingGroupId: z.string(),
+  roomTypeId: z.string().nullable(),
+  bedPreference: z.string().nullable(),
+  allocations: z.record(z.string(), z.string()),
+})
+
+export type BookingTravelerSharingGroupSummary = z.infer<
+  typeof bookingTravelerSharingGroupSummarySchema
+>
+export type BookingTravelerSharingGroupMember = z.infer<
+  typeof bookingTravelerSharingGroupMemberSchema
+>
 
 export const bookingSupplierStatusRecordSchema = z.object({
   id: z.string(),
@@ -330,6 +359,12 @@ export const bookingGroupForBookingResponse = z.object({
 export type BookingGroupForBookingRecord = z.infer<typeof bookingGroupForBookingSchema>
 export const bookingTravelersResponse = arrayEnvelope(bookingTravelerRecordSchema)
 export const bookingTravelerSingleResponse = singleEnvelope(bookingTravelerRevealRecordSchema)
+export const bookingTravelerSharingGroupsResponse = arrayEnvelope(
+  bookingTravelerSharingGroupSummarySchema,
+)
+export const bookingTravelersBySharingGroupResponse = arrayEnvelope(
+  bookingTravelerSharingGroupMemberSchema,
+)
 export const bookingPassengersResponse = bookingTravelersResponse
 export const bookingItemParticipantsResponse = bookingItemTravelersResponse
 export const bookingSupplierStatusesResponse = arrayEnvelope(bookingSupplierStatusRecordSchema)

--- a/packages/bookings/src/index.ts
+++ b/packages/bookings/src/index.ts
@@ -27,6 +27,8 @@ export {
   shouldRevealBookingPii,
 } from "./pii-redaction.js"
 export type {
+  BookingTravelerSharingGroupMember,
+  BookingTravelerSharingGroupSummary,
   ConvertProductData,
   CreateTravelerWithTravelDetailsInput,
   UpdateTravelerWithTravelDetailsInput,
@@ -227,6 +229,7 @@ export {
   recordBookingRedemptionSchema,
   reserveBookingFromTransactionSchema,
   reserveBookingSchema,
+  sharingGroupsForSlotQuerySchema,
   startBookingSchema,
   updateBookingAllocationSchema,
   updateBookingFulfillmentSchema,

--- a/packages/bookings/src/routes.ts
+++ b/packages/bookings/src/routes.ts
@@ -53,6 +53,7 @@ import {
   recordBookingRedemptionSchema,
   reserveBookingFromTransactionSchema,
   reserveBookingSchema,
+  sharingGroupsForSlotQuerySchema,
   startBookingSchema,
   updateBookingFulfillmentSchema,
   updateBookingItemSchema,
@@ -285,6 +286,34 @@ export const bookingRoutes = new Hono<Env>()
     }
 
     return c.json({ data: overview })
+  })
+
+  .get("/sharing-groups", async (c) => {
+    const query = parseQuery(c, sharingGroupsForSlotQuerySchema)
+    const data = await bookingsService.listSharingGroupsForSlot(c.get("db"), query.slotId)
+    return c.json({ data })
+  })
+
+  .get("/sharing-groups/:groupId/travelers", async (c) => {
+    const query = parseQuery(c, sharingGroupsForSlotQuerySchema)
+    const data = await bookingsService.listTravelersBySharingGroup(
+      c.get("db"),
+      query.slotId,
+      c.req.param("groupId"),
+    )
+    const reveal = shouldRevealBookingPii({
+      actor: c.get("actor"),
+      scopes: c.get("scopes"),
+      callerType: c.get("callerType"),
+      isInternalRequest: c.get("isInternalRequest"),
+    })
+    await logBookingPiiAccess(c, {
+      action: "read",
+      outcome: "allowed",
+      reason: reveal ? "sharing_group_travelers_reveal" : "sharing_group_travelers_redacted",
+      metadata: { rowCount: data.length, reveal },
+    })
+    return c.json({ data: reveal ? data : data.map((row) => redactTravelerIdentity(row)) })
   })
 
   // 2. GET /:id — Get single booking

--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -1,5 +1,19 @@
 import type { EventBus } from "@voyantjs/core"
-import { and, asc, desc, eq, exists, gte, ilike, inArray, lte, ne, or, sql } from "drizzle-orm"
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  exists,
+  gte,
+  ilike,
+  inArray,
+  isNotNull,
+  lte,
+  ne,
+  or,
+  sql,
+} from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
 
@@ -23,6 +37,7 @@ import {
   productTicketSettingsRef,
   suppliersRef,
 } from "./products-ref.js"
+import { bookingTravelerTravelDetails } from "./schema/travel-details.js"
 import {
   bookingActivityLog,
   bookingAllocations,
@@ -121,6 +136,10 @@ function pickTravelDetailFields(
     dietaryRequirements: data.dietaryRequirements,
     accessibilityNeeds: data.accessibilityNeeds,
     isLeadTraveler: data.isLeadTraveler,
+    sharingGroupId: data.sharingGroupId,
+    roomTypeId: data.roomTypeId,
+    bedPreference: data.bedPreference,
+    allocations: data.allocations,
   }
 }
 type CreateBookingItemInput = z.infer<typeof insertBookingItemSchema>
@@ -299,7 +318,47 @@ export interface BookingStatusOverriddenEvent {
   actorId: string | null
 }
 
+export interface BookingTravelerSharingGroupMember {
+  id: string
+  bookingId: string
+  bookingNumber: string
+  participantType: string
+  travelerCategory: string | null
+  personId: string | null
+  firstName: string
+  lastName: string
+  email: string | null
+  phone: string | null
+  preferredLanguage: string | null
+  specialRequests: string | null
+  isPrimary: boolean
+  notes: string | null
+  isLeadTraveler: boolean
+  sharingGroupId: string
+  roomTypeId: string | null
+  bedPreference: string | null
+  allocations: Record<string, string>
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface BookingTravelerSharingGroupSummary {
+  id: string
+  label: string
+  occupancy: number
+  roomTypeId: string | null
+  bookingIds: string[]
+}
+
 const travelerParticipantTypes = ["traveler", "occupant"] as const
+const sharingGroupBookingStatuses = [
+  "draft",
+  "on_hold",
+  "confirmed",
+  "in_progress",
+  "completed",
+] as const
+const sharingGroupAllocationStatuses = ["held", "confirmed", "fulfilled"] as const
 
 class BookingServiceError extends Error {
   constructor(
@@ -341,6 +400,16 @@ function toTravelerResponse(participant: typeof bookingTravelers.$inferSelect) {
     createdAt: participant.createdAt,
     updatedAt: participant.updatedAt,
   }
+}
+
+function normalizeTravelerAllocationMap(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {}
+
+  const out: Record<string, string> = {}
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw === "string") out[key] = raw
+  }
+  return out
 }
 
 async function ensureParticipantFlags(
@@ -3796,6 +3865,121 @@ export const bookingsService = {
       )
       .orderBy(asc(bookingTravelers.createdAt))
       .then((rows) => rows.map(toTravelerResponse))
+  },
+
+  async listSharingGroupsForSlot(
+    db: PostgresJsDatabase,
+    slotId: string,
+  ): Promise<BookingTravelerSharingGroupSummary[]> {
+    const rows = await db
+      .select({
+        id: bookingTravelerTravelDetails.sharingGroupId,
+        occupancy: sql<number>`count(distinct ${bookingTravelers.id})::int`,
+        roomTypeId: sql<string | null>`
+          case
+            when count(distinct ${bookingTravelerTravelDetails.roomTypeId})
+              filter (where ${bookingTravelerTravelDetails.roomTypeId} is not null) = 1
+            then min(${bookingTravelerTravelDetails.roomTypeId})
+            else null
+          end
+        `,
+        bookingIds: sql<string[]>`
+          array_agg(distinct ${bookingTravelers.bookingId} order by ${bookingTravelers.bookingId})
+        `,
+      })
+      .from(bookingTravelerTravelDetails)
+      .innerJoin(bookingTravelers, eq(bookingTravelers.id, bookingTravelerTravelDetails.travelerId))
+      .innerJoin(bookings, eq(bookings.id, bookingTravelers.bookingId))
+      .innerJoin(bookingAllocations, eq(bookingAllocations.bookingId, bookings.id))
+      .where(
+        and(
+          eq(bookingAllocations.availabilitySlotId, slotId),
+          isNotNull(bookingTravelerTravelDetails.sharingGroupId),
+          ne(bookingTravelerTravelDetails.sharingGroupId, ""),
+          inArray(bookings.status, sharingGroupBookingStatuses),
+          inArray(bookingAllocations.status, sharingGroupAllocationStatuses),
+          or(...travelerParticipantTypes.map((type) => eq(bookingTravelers.participantType, type))),
+        ),
+      )
+      .groupBy(bookingTravelerTravelDetails.sharingGroupId)
+      .orderBy(asc(bookingTravelerTravelDetails.sharingGroupId))
+
+    return rows.flatMap((row) => {
+      if (!row.id) return []
+      return [
+        {
+          id: row.id,
+          label: row.id,
+          occupancy: row.occupancy,
+          roomTypeId: row.roomTypeId,
+          bookingIds: row.bookingIds,
+        },
+      ]
+    })
+  },
+
+  async listTravelersBySharingGroup(
+    db: PostgresJsDatabase,
+    slotId: string,
+    sharingGroupId: string,
+  ): Promise<BookingTravelerSharingGroupMember[]> {
+    const rows = await db
+      .selectDistinct({
+        id: bookingTravelers.id,
+        bookingId: bookingTravelers.bookingId,
+        bookingNumber: bookings.bookingNumber,
+        participantType: bookingTravelers.participantType,
+        travelerCategory: bookingTravelers.travelerCategory,
+        personId: bookingTravelers.personId,
+        firstName: bookingTravelers.firstName,
+        lastName: bookingTravelers.lastName,
+        email: bookingTravelers.email,
+        phone: bookingTravelers.phone,
+        preferredLanguage: bookingTravelers.preferredLanguage,
+        specialRequests: bookingTravelers.specialRequests,
+        isPrimary: bookingTravelers.isPrimary,
+        notes: bookingTravelers.notes,
+        isLeadTraveler: bookingTravelerTravelDetails.isLeadTraveler,
+        sharingGroupId: bookingTravelerTravelDetails.sharingGroupId,
+        roomTypeId: bookingTravelerTravelDetails.roomTypeId,
+        bedPreference: bookingTravelerTravelDetails.bedPreference,
+        allocations: bookingTravelerTravelDetails.allocations,
+        createdAt: bookingTravelers.createdAt,
+        updatedAt: bookingTravelers.updatedAt,
+      })
+      .from(bookingTravelers)
+      .innerJoin(
+        bookingTravelerTravelDetails,
+        eq(bookingTravelerTravelDetails.travelerId, bookingTravelers.id),
+      )
+      .innerJoin(bookings, eq(bookings.id, bookingTravelers.bookingId))
+      .innerJoin(bookingAllocations, eq(bookingAllocations.bookingId, bookings.id))
+      .where(
+        and(
+          eq(bookingAllocations.availabilitySlotId, slotId),
+          eq(bookingTravelerTravelDetails.sharingGroupId, sharingGroupId),
+          inArray(bookings.status, sharingGroupBookingStatuses),
+          inArray(bookingAllocations.status, sharingGroupAllocationStatuses),
+          or(...travelerParticipantTypes.map((type) => eq(bookingTravelers.participantType, type))),
+        ),
+      )
+      .orderBy(
+        asc(bookings.bookingNumber),
+        desc(bookingTravelers.isPrimary),
+        asc(bookingTravelers.createdAt),
+      )
+
+    return rows.flatMap((row) => {
+      if (!row.sharingGroupId) return []
+      return [
+        {
+          ...row,
+          isLeadTraveler: row.isLeadTraveler,
+          sharingGroupId: row.sharingGroupId,
+          allocations: normalizeTravelerAllocationMap(row.allocations),
+        },
+      ]
+    })
   },
 
   async createTraveler(

--- a/packages/bookings/src/validation.ts
+++ b/packages/bookings/src/validation.ts
@@ -1,6 +1,10 @@
 import { z } from "zod"
 
 import {
+  bookingTravelerBedPreferenceSchema,
+  travelerAllocationMapSchema,
+} from "./schema/travel-details.js"
+import {
   bookingAllocationStatusSchema,
   bookingAllocationTypeSchema,
   bookingDocumentTypeSchema,
@@ -125,6 +129,10 @@ export const bookingAggregatesQuerySchema = z.object({
    * dashboards / digests can share the endpoint.
    */
   upcomingLimit: z.coerce.number().int().min(0).max(20).default(8),
+})
+
+export const sharingGroupsForSlotQuerySchema = z.object({
+  slotId: z.string().min(1),
 })
 
 export const convertProductSchema = z.object({
@@ -330,6 +338,10 @@ export const upsertTravelerTravelDetailsSchema = z.object({
   dietaryRequirements: z.string().optional().nullable(),
   accessibilityNeeds: z.string().optional().nullable(),
   isLeadTraveler: z.boolean().optional().nullable(),
+  sharingGroupId: z.string().max(255).optional().nullable(),
+  roomTypeId: z.string().max(255).optional().nullable(),
+  bedPreference: bookingTravelerBedPreferenceSchema.optional().nullable(),
+  allocations: travelerAllocationMapSchema.optional(),
 })
 
 // Flat shape combining plaintext traveler columns + encrypted travel-details

--- a/packages/bookings/tests/integration/routes.test.ts
+++ b/packages/bookings/tests/integration/routes.test.ts
@@ -1451,6 +1451,10 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
             passportNumber: "X1234567",
             dietaryRequirements: "vegetarian",
             isLeadTraveler: true,
+            sharingGroupId: "share_route_1",
+            roomTypeId: "rt_double",
+            bedPreference: "twin",
+            allocations: { room: "room_102" },
           }),
         },
       )
@@ -1478,6 +1482,86 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
       expect(body.data.nationality).toBe("RO")
       expect(body.data.dietaryRequirements).toBe("vegetarian")
       expect(body.data.isLeadTraveler).toBe(true)
+      expect(body.data.sharingGroupId).toBe("share_route_1")
+      expect(body.data.roomTypeId).toBe("rt_double")
+      expect(body.data.bedPreference).toBe("twin")
+      expect(body.data.allocations).toEqual({ room: "room_102" })
+    })
+
+    it("lists slot sharing groups and their travelers", async () => {
+      const slot = await seedSlot()
+      const booking = await seedBooking({ status: "confirmed" })
+      const [item] = await db
+        .insert(bookingItems)
+        .values({
+          bookingId: booking.id,
+          title: "Double sharing",
+          itemType: "accommodation",
+          status: "confirmed",
+          quantity: 1,
+          sellCurrency: "USD",
+        })
+        .returning()
+
+      await db.insert(bookingAllocations).values({
+        bookingId: booking.id,
+        bookingItemId: item!.id,
+        availabilitySlotId: slot.id,
+        quantity: 1,
+        status: "confirmed",
+      })
+
+      const travelerPayloads = [
+        { firstName: "Ana", lastName: "One", isLeadTraveler: true },
+        { firstName: "Bogdan", lastName: "Two", isLeadTraveler: false },
+      ]
+
+      for (const travelerPayload of travelerPayloads) {
+        const createRes = await app.request(`/${booking.id}/travelers`, {
+          method: "POST",
+          ...json({
+            firstName: travelerPayload.firstName,
+            lastName: travelerPayload.lastName,
+          }),
+        })
+        const { data: traveler } = await createRes.json()
+        await app.request(`/${booking.id}/travelers/${traveler.id}/travel-details`, {
+          method: "PATCH",
+          ...json({
+            isLeadTraveler: travelerPayload.isLeadTraveler,
+            sharingGroupId: "share_slot_1",
+            roomTypeId: "rt_double",
+            bedPreference: "double",
+          }),
+        })
+      }
+
+      const groupsRes = await app.request(`/sharing-groups?slotId=${slot.id}`)
+      expect(groupsRes.status).toBe(200)
+      const groupsBody = await groupsRes.json()
+      expect(groupsBody.data).toEqual([
+        {
+          id: "share_slot_1",
+          label: "share_slot_1",
+          occupancy: 2,
+          roomTypeId: "rt_double",
+          bookingIds: [booking.id],
+        },
+      ])
+
+      const travelersRes = await app.request(
+        `/sharing-groups/share_slot_1/travelers?slotId=${slot.id}`,
+      )
+      expect(travelersRes.status).toBe(200)
+      const travelersBody = await travelersRes.json()
+      expect(travelersBody.data).toHaveLength(2)
+      expect(travelersBody.data[0]).toMatchObject({
+        bookingId: booking.id,
+        bookingNumber: booking.bookingNumber,
+        sharingGroupId: "share_slot_1",
+        roomTypeId: "rt_double",
+        bedPreference: "double",
+      })
     })
 
     it("preserves unspecified travel detail fields on partial update", async () => {

--- a/packages/bookings/tests/unit/validation-participants-items.test.ts
+++ b/packages/bookings/tests/unit/validation-participants-items.test.ts
@@ -153,6 +153,10 @@ describe("Traveler travel detail schema alias", () => {
       nationality: "RO",
       dateOfBirth: "1990-02-03",
       isLeadTraveler: true,
+      sharingGroupId: "share_1",
+      roomTypeId: "rt_double",
+      bedPreference: "twin",
+      allocations: { room: "resource_room_102" },
     })
 
     expect(result).toEqual({
@@ -162,6 +166,10 @@ describe("Traveler travel detail schema alias", () => {
       dateOfBirth: "1990-02-03",
       dietaryRequirements: undefined,
       isLeadTraveler: true,
+      sharingGroupId: "share_1",
+      roomTypeId: "rt_double",
+      bedPreference: "twin",
+      allocations: { room: "resource_room_102" },
     })
   })
 })


### PR DESCRIPTION
## Summary

- Wires traveler allocation metadata (`sharingGroupId`, `roomTypeId`, `bedPreference`, `allocations`) through bookings travel-details validation and the combined traveler create/update path.
- Adds slot-scoped bookings routes for sharing-group summaries and travelers in a sharing group.
- Exposes `useSharingGroupsForSlot` and `useBookingsBySharingGroup` from `@voyantjs/bookings-react`, with response schemas and query keys.
- Adds route coverage for sharing-group listing and a changeset for the package surfaces.

Closes #695.

## Tests

- `pnpm --filter @voyantjs/bookings lint`
- `pnpm --filter @voyantjs/bookings-react lint`
- `pnpm --filter @voyantjs/bookings typecheck`
- `pnpm --filter @voyantjs/bookings-react typecheck`
- `pnpm --filter @voyantjs/bookings build`
- `pnpm --filter @voyantjs/bookings-react build`
- `pnpm --filter @voyantjs/bookings test -- tests/unit/validation-participants-items.test.ts tests/unit/travel-details-schema.test.ts`
- `pnpm --filter @voyantjs/bookings test -- tests/integration/routes.test.ts`
- `pnpm --filter @voyantjs/bookings-react test`
- `pnpm lint:changed`
- commit hook: full `pnpm lint`
- commit hook: full `pnpm typecheck`
- pre-push hook: full `pnpm test`
