### PR TITLE
feat(agent-runner): lease dispatch intents from runner

### DIFF
--- a/apps/agent-runner/README.md
+++ b/apps/agent-runner/README.md
@@ -1,9 +1,14 @@
 # Voyant Agent Runner
 
 `apps/agent-runner` is the Cloudflare-ready shell for an always-on agent queue
-runner. The first version is intentionally non-executing: it proves the deployed
-Hono surface, bearer-token auth, scheduled handler shape, and control-plane
-configuration without spending agent budget or mutating GitHub Projects.
+runner. It proves the deployed Hono surface, bearer-token auth, scheduled
+handler shape, and control-plane configuration without executing lifecycle
+commands in the Worker.
+
+When explicitly enabled, the runner can perform a lease-only supervisor tick:
+it calls the control plane to acquire one dispatch intent from the latest stored
+queue snapshot. It still does not mutate GitHub directly, create workspaces, run
+provider commands, or spend model budget.
 
 ## Endpoints
 
@@ -11,16 +16,21 @@ configuration without spending agent budget or mutating GitHub Projects.
 - `GET /api/capabilities` returns runner defaults, execution state, and
   control-plane configuration. Requires `AGENT_RUNNER_TOKENS`.
 - `POST /api/supervisor/ticks` validates a supervisor tick request and returns
-  the equivalent local command plan. It does not execute the command.
+  the equivalent local command plan. By default it is a dry run. With
+  `AGENT_RUNNER_ENABLED=true` and `{ "dryRun": false }`, it leases one dispatch
+  intent from `POST /api/dispatch-intents/latest` on the control plane.
 
 ## Configuration
 
 - `AGENT_RUNNER_TOKENS`: comma-separated bearer tokens for `/api/*`.
-- `AGENT_RUNNER_ENABLED`: must be `true` before scheduled plans can be accepted.
+- `AGENT_RUNNER_ENABLED`: must be `true` before scheduled ticks can lease
+  dispatch intents.
 - `AGENT_RUNNER_HOLDER`: default lease holder, for example `runner:cloudflare`.
 - `AGENT_RUNNER_REPOSITORY`: default repository, for example `voyantjs/voyant`.
 - `AGENT_CONTROL_PLANE_URL`: deployed control-plane URL.
 - `AGENT_CONTROL_PLANE_TOKEN`: bearer token for the control plane.
 
-Cron triggers should stay disabled until GitHub polling, execution policy,
-budget controls, and provider credentials are wired into a later slice.
+Cron triggers should stay disabled until queue snapshots and control-plane
+dispatch intent storage are configured. Keep provider execution outside this
+Worker unless a later design adds explicit budget controls, sandbox policy, and
+task-scoped credentials.

--- a/apps/agent-runner/src/app.test.ts
+++ b/apps/agent-runner/src/app.test.ts
@@ -39,6 +39,7 @@ describe("agent runner app", () => {
       authTokens: ["token"],
       config: {
         controlPlaneConfigured: true,
+        controlPlaneToken: "control-token",
         controlPlaneUrl: "https://control.example.com",
         enabled: true,
         holder: "runner:cloudflare",
@@ -59,27 +60,119 @@ describe("agent runner app", () => {
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({
       plannedAt: "2026-05-12T11:00:00.000Z",
-      plan: {
-        accepted: true,
-        blockers: [],
-        command: [
-          "pnpm",
-          "agent:queue:control-plane-loop",
-          "--",
-          "--repo",
-          "voyantjs/voyant",
-          "--holder",
-          "runner:cloudflare",
-          "--iterations",
-          "3",
-          "--yes",
-          "--control-plane-url",
-          "https://control.example.com",
-        ],
-        dryRun: true,
-        iterations: 3,
-        source: "api",
+      result: {
+        leased: false,
+        plan: {
+          accepted: true,
+          blockers: [],
+          command: [
+            "pnpm",
+            "agent:queue:control-plane-loop",
+            "--",
+            "--repo",
+            "voyantjs/voyant",
+            "--holder",
+            "runner:cloudflare",
+            "--iterations",
+            "3",
+            "--yes",
+            "--control-plane-url",
+            "https://control.example.com",
+          ],
+          dryRun: true,
+          iterations: 3,
+          mode: "lease-only",
+          source: "api",
+        },
+        reason: "dry_run",
       },
     })
+  })
+
+  it("leases one dispatch intent from the control plane when explicitly enabled", async () => {
+    const calls: Array<{ body: unknown; headers: Headers; method: string; url: string }> = []
+    const app = createApp({
+      authTokens: ["token"],
+      config: {
+        controlPlaneConfigured: true,
+        controlPlaneToken: "control-token",
+        controlPlaneUrl: "https://control.example.com/",
+        enabled: true,
+        holder: "runner:cloudflare",
+        repository: "voyantjs/voyant",
+      },
+      fetchImpl: async (url, init) => {
+        calls.push({
+          body: JSON.parse(String(init?.body)),
+          headers: new Headers(init?.headers),
+          method: init?.method ?? "GET",
+          url: String(url),
+        })
+        return new Response(
+          JSON.stringify({
+            intent: {
+              id: "intent_579",
+              plan: {
+                action: "sync-pr",
+              },
+              status: "leased",
+            },
+            reason: "leased",
+          }),
+          { status: 201 },
+        )
+      },
+      now: () => new Date("2026-05-12T11:00:00.000Z"),
+    })
+
+    const response = await app.request("/api/supervisor/ticks", {
+      body: JSON.stringify({
+        action: "sync-pr",
+        dryRun: false,
+        eventLog: ".agent-runs/cloudflare.jsonl",
+        ttlSeconds: 120,
+      }),
+      headers: {
+        authorization: "Bearer token",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      result: {
+        controlPlane: {
+          status: 201,
+        },
+        intent: {
+          id: "intent_579",
+          status: "leased",
+        },
+        leased: true,
+        reason: "leased",
+      },
+    })
+    expect(calls).toEqual([
+      {
+        body: {
+          filters: {
+            action: "sync-pr",
+          },
+          lease: {
+            holder: "runner:cloudflare",
+            ttlSeconds: 120,
+          },
+          options: {
+            eventLog: ".agent-runs/cloudflare.jsonl",
+          },
+          repository: "voyantjs/voyant",
+        },
+        headers: expect.any(Headers),
+        method: "POST",
+        url: "https://control.example.com/api/dispatch-intents/latest",
+      },
+    ])
+    expect(calls[0]?.headers.get("authorization")).toBe("Bearer control-token")
   })
 })

--- a/apps/agent-runner/src/app.ts
+++ b/apps/agent-runner/src/app.ts
@@ -2,14 +2,15 @@ import { Hono } from "hono"
 
 import {
   buildRunnerCapabilities,
-  planSupervisorTick,
   type RunnerConfig,
+  runSupervisorTick,
   supervisorTickRequestSchema,
 } from "./runner.js"
 
 interface AppOptions {
   authTokens?: string[]
   config?: RunnerConfig
+  fetchImpl?: typeof fetch
   now?: () => Date
 }
 
@@ -19,6 +20,7 @@ export function createApp({
     controlPlaneConfigured: false,
     enabled: false,
   },
+  fetchImpl = fetch,
   now = () => new Date(),
 }: AppOptions = {}): Hono {
   const app = new Hono()
@@ -60,8 +62,9 @@ export function createApp({
 
     return c.json({
       plannedAt: now().toISOString(),
-      plan: planSupervisorTick({
+      result: await runSupervisorTick({
         config,
+        fetchImpl,
         request: parsed.data,
         source: "api",
       }),

--- a/apps/agent-runner/src/runner.ts
+++ b/apps/agent-runner/src/runner.ts
@@ -2,11 +2,16 @@ import { z } from "zod"
 
 export const supervisorTickRequestSchema = z
   .object({
+    action: z.string().trim().min(1).optional(),
     dryRun: z.boolean().optional(),
+    eventLog: z.string().trim().min(1).optional(),
     holder: z.string().trim().min(1).optional(),
+    issue: z.number().int().positive().optional(),
     iterations: z.number().int().positive().max(100).optional(),
     repository: z.string().trim().min(1).optional(),
     reason: z.string().trim().min(1).optional(),
+    ttlSeconds: z.number().int().min(60).max(3600).optional(),
+    updateBody: z.boolean().optional(),
   })
   .strict()
 
@@ -14,6 +19,7 @@ export type SupervisorTickRequest = z.infer<typeof supervisorTickRequestSchema>
 
 export interface RunnerConfig {
   controlPlaneConfigured: boolean
+  controlPlaneToken?: string
   controlPlaneUrl?: string
   enabled: boolean
   holder?: string
@@ -25,13 +31,14 @@ export function buildRunnerCapabilities(config: RunnerConfig) {
     service: "agent-runner",
     execution: {
       enabled: config.enabled,
-      mode: config.enabled ? "supervisor" : "disabled",
+      mode: config.enabled ? "lease-only" : "disabled",
       reason: config.enabled
-        ? "runner execution is enabled by environment"
+        ? "runner can lease dispatch intents; command execution remains external"
         : "runner execution is disabled until credentials, queue budget, and policy are configured",
     },
     controlPlane: {
       configured: config.controlPlaneConfigured,
+      tokenConfigured: Boolean(config.controlPlaneToken),
       url: config.controlPlaneUrl ?? null,
     },
     defaults: {
@@ -40,6 +47,7 @@ export function buildRunnerCapabilities(config: RunnerConfig) {
     },
     scheduler: {
       cronCompatible: true,
+      mode: "lease-only",
       mutatesByDefault: false,
     },
   }
@@ -76,7 +84,112 @@ export function planSupervisorTick({
     }),
     dryRun: request.dryRun ?? true,
     iterations,
+    mode: "lease-only",
     source,
+  }
+}
+
+export async function runSupervisorTick({
+  config,
+  fetchImpl = fetch,
+  request = {},
+  source,
+}: {
+  config: RunnerConfig
+  fetchImpl?: typeof fetch
+  request?: SupervisorTickRequest
+  source: "api" | "scheduled"
+}) {
+  const plan = planSupervisorTick({ config, request, source })
+  if (!plan.accepted || plan.dryRun) {
+    return {
+      leased: false,
+      plan,
+      reason: plan.accepted ? "dry_run" : "blocked",
+    }
+  }
+
+  if (!config.controlPlaneToken || !config.controlPlaneUrl) {
+    return {
+      leased: false,
+      plan: {
+        ...plan,
+        accepted: false,
+        blockers: [...plan.blockers, "control plane credentials are incomplete"],
+      },
+      reason: "blocked",
+    }
+  }
+
+  const response = await fetchImpl(
+    `${normalizeControlPlaneUrl(config.controlPlaneUrl)}/api/dispatch-intents/latest`,
+    {
+      body: JSON.stringify(buildDispatchIntentRequest({ config, request })),
+      headers: {
+        authorization: `Bearer ${config.controlPlaneToken}`,
+        "content-type": "application/json",
+      },
+      method: "POST",
+    },
+  )
+  const bodyText = await response.text()
+  const body = parseJsonBody(bodyText)
+
+  if (!response.ok) {
+    return {
+      controlPlane: {
+        error: body?.error ?? bodyText,
+        status: response.status,
+      },
+      leased: false,
+      plan,
+      reason: "control_plane_rejected",
+    }
+  }
+
+  return {
+    controlPlane: {
+      status: response.status,
+    },
+    intent: body?.intent ?? null,
+    leased: Boolean(body?.intent),
+    plan,
+    reason: body?.reason ?? (body?.intent ? "leased" : "no_intent"),
+  }
+}
+
+function buildDispatchIntentRequest({
+  config,
+  request,
+}: {
+  config: RunnerConfig
+  request: SupervisorTickRequest
+}) {
+  const holder = request.holder ?? config.holder
+  const repository = request.repository ?? config.repository
+
+  return {
+    repository,
+    lease: {
+      holder,
+      ...(request.ttlSeconds ? { ttlSeconds: request.ttlSeconds } : {}),
+    },
+    ...(request.action || request.issue
+      ? {
+          filters: {
+            ...(request.action ? { action: request.action } : {}),
+            ...(request.issue ? { issueNumber: request.issue } : {}),
+          },
+        }
+      : {}),
+    ...(request.eventLog || request.updateBody
+      ? {
+          options: {
+            ...(request.eventLog ? { eventLog: request.eventLog } : {}),
+            ...(request.updateBody ? { updateBody: true } : {}),
+          },
+        }
+      : {}),
   }
 }
 
@@ -103,4 +216,18 @@ function buildLocalEquivalentCommand({
     command.push("--control-plane-url", controlPlaneUrl)
   }
   return command
+}
+
+function normalizeControlPlaneUrl(url: string) {
+  return url.replace(/\/+$/, "")
+}
+
+function parseJsonBody(bodyText: string) {
+  if (!bodyText) return null
+
+  try {
+    return JSON.parse(bodyText)
+  } catch {
+    return null
+  }
 }

--- a/apps/agent-runner/src/worker.ts
+++ b/apps/agent-runner/src/worker.ts
@@ -1,5 +1,5 @@
 import { createApp } from "./app.js"
-import { planSupervisorTick } from "./runner.js"
+import { runSupervisorTick } from "./runner.js"
 
 interface Env {
   AGENT_CONTROL_PLANE_TOKEN?: string
@@ -20,20 +20,22 @@ export default {
   },
 
   async scheduled(_event: ScheduledController, env: Env): Promise<void> {
-    const plan = planSupervisorTick({
+    const result = await runSupervisorTick({
       config: runnerConfigFromEnv(env),
       request: {
+        dryRun: env.AGENT_RUNNER_ENABLED !== "true",
         reason: "cloudflare-cron",
       },
       source: "scheduled",
     })
-    console.log(JSON.stringify({ service: "agent-runner", supervisorTick: plan }))
+    console.log(JSON.stringify({ service: "agent-runner", supervisorTick: result }))
   },
 } satisfies ExportedHandler<Env>
 
 function runnerConfigFromEnv(env: Env) {
   return {
     controlPlaneConfigured: Boolean(env.AGENT_CONTROL_PLANE_URL && env.AGENT_CONTROL_PLANE_TOKEN),
+    controlPlaneToken: env.AGENT_CONTROL_PLANE_TOKEN,
     controlPlaneUrl: env.AGENT_CONTROL_PLANE_URL,
     enabled: env.AGENT_RUNNER_ENABLED === "true",
     holder: env.AGENT_RUNNER_HOLDER,

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1353,9 +1353,12 @@ Verification:
   outcome, and stops on idle, failure, or the configured iteration limit.
 - A Cloudflare-ready runner shell exists in `apps/agent-runner`. It exposes
   health, capabilities, a scheduled handler, and a guarded supervisor tick
-  planning endpoint. The shell is deliberately non-executing until GitHub
-  polling, budget controls, provider credentials, and execution policy are wired
-  into a later slice.
+  endpoint. By default it is dry-run only. When explicitly enabled, it can lease
+  one dispatch intent from the control-plane app's latest stored queue snapshot,
+  but it still does not execute lifecycle commands, mutate GitHub directly,
+  create workspaces, or spend model budget. Command execution remains owned by
+  trusted runner processes until budget controls, sandbox policy, and
+  task-scoped provider credentials are wired into a later slice.
 
 ## Open Questions
 


### PR DESCRIPTION
## Summary

- add a lease-only supervisor tick path to the Cloudflare runner app
- allow authenticated non-dry-run ticks to acquire one dispatch intent from the control plane
- keep lifecycle command execution outside the Worker and document the boundary

## Validation

- `pnpm --filter @voyantjs/agent-runner test`
- `pnpm --filter @voyantjs/agent-runner typecheck`
- `pnpm --filter @voyantjs/agent-runner lint`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- pre-commit hook: formatting, secretlint, agent quality, repository lint, repository typecheck
- pre-push hook: `pnpm test`