### PR TITLE
feat(agent-runner): persist supervisor tick status

### DIFF
--- a/apps/agent-runner/README.md
+++ b/apps/agent-runner/README.md
@@ -18,7 +18,12 @@ provider commands, or spend model budget.
 - `POST /api/supervisor/ticks` validates a supervisor tick request and returns
   the equivalent local command plan. By default it is a dry run. With
   `AGENT_RUNNER_ENABLED=true` and `{ "dryRun": false }`, it leases one dispatch
-  intent from `POST /api/dispatch-intents/latest` on the control plane.
+  intent from `POST /api/dispatch-intents/latest` on the control plane. When
+  `AGENT_RUNNER_TICKS` is bound, the result is persisted as the latest
+  supervisor tick for the repository.
+- `GET /api/supervisor/ticks/latest?repository=<owner/name>` returns the latest
+  persisted supervisor tick for a repository. Requires `AGENT_RUNNER_TOKENS`
+  and the `AGENT_RUNNER_TICKS` binding.
 
 ## Configuration
 
@@ -27,6 +32,8 @@ provider commands, or spend model budget.
   dispatch intents.
 - `AGENT_RUNNER_HOLDER`: default lease holder, for example `runner:cloudflare`.
 - `AGENT_RUNNER_REPOSITORY`: default repository, for example `voyantjs/voyant`.
+- `AGENT_RUNNER_TICKS`: optional R2 binding for latest supervisor tick status.
+- `AGENT_RUNNER_TICK_KEY_PREFIX`: optional R2 key prefix for supervisor ticks.
 - `AGENT_CONTROL_PLANE_URL`: deployed control-plane URL.
 - `AGENT_CONTROL_PLANE_TOKEN`: bearer token for the control plane.
 

--- a/apps/agent-runner/src/app.test.ts
+++ b/apps/agent-runner/src/app.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest"
 
 import { createApp } from "./app.js"
+import {
+  createR2SupervisorTickStore,
+  type SupervisorTickBucket,
+  type SupervisorTickRecord,
+  type SupervisorTickStore,
+} from "./supervisor-tick-store.js"
 
 describe("agent runner app", () => {
   it("serves public health without runner auth", async () => {
@@ -86,6 +92,10 @@ describe("agent runner app", () => {
         },
         reason: "dry_run",
       },
+      storage: {
+        persisted: false,
+        reason: "supervisor_tick_storage_not_configured",
+      },
     })
   })
 
@@ -123,6 +133,7 @@ describe("agent runner app", () => {
         )
       },
       now: () => new Date("2026-05-12T11:00:00.000Z"),
+      supervisorTickStore: inMemorySupervisorTickStore(),
     })
 
     const response = await app.request("/api/supervisor/ticks", {
@@ -152,6 +163,10 @@ describe("agent runner app", () => {
         leased: true,
         reason: "leased",
       },
+      storage: {
+        key: "latest/voyantjs/voyant.json",
+        persisted: true,
+      },
     })
     expect(calls).toEqual([
       {
@@ -175,4 +190,129 @@ describe("agent runner app", () => {
     ])
     expect(calls[0]?.headers.get("authorization")).toBe("Bearer control-token")
   })
+
+  it("reads the latest persisted supervisor tick", async () => {
+    const supervisorTickStore = inMemorySupervisorTickStore()
+    const app = createApp({
+      authTokens: ["token"],
+      config: {
+        controlPlaneConfigured: true,
+        controlPlaneUrl: "https://control.example.com",
+        enabled: true,
+        holder: "runner:cloudflare",
+        repository: "voyantjs/voyant",
+      },
+      now: () => new Date("2026-05-12T12:00:00.000Z"),
+      supervisorTickStore,
+    })
+
+    const tick = await app.request("/api/supervisor/ticks", {
+      body: JSON.stringify({ dryRun: true }),
+      headers: {
+        authorization: "Bearer token",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+    expect(tick.status).toBe(200)
+
+    const latest = await app.request("/api/supervisor/ticks/latest?repository=voyantjs%2Fvoyant", {
+      headers: {
+        authorization: "Bearer token",
+      },
+    })
+
+    expect(latest.status).toBe(200)
+    await expect(latest.json()).resolves.toMatchObject({
+      recordedAt: "2026-05-12T12:00:00.000Z",
+      repository: "voyantjs/voyant",
+      result: {
+        leased: false,
+        reason: "dry_run",
+      },
+    })
+  })
+
+  it("requires storage and repository before reading latest supervisor ticks", async () => {
+    const noStore = createApp({ authTokens: ["token"] })
+    const noStoreResponse = await noStore.request(
+      "/api/supervisor/ticks/latest?repository=voyantjs%2Fvoyant",
+      {
+        headers: {
+          authorization: "Bearer token",
+        },
+      },
+    )
+    expect(noStoreResponse.status).toBe(503)
+    await expect(noStoreResponse.json()).resolves.toEqual({
+      error: "supervisor_tick_storage_not_configured",
+    })
+
+    const app = createApp({
+      authTokens: ["token"],
+      supervisorTickStore: inMemorySupervisorTickStore(),
+    })
+    const missingRepository = await app.request("/api/supervisor/ticks/latest", {
+      headers: {
+        authorization: "Bearer token",
+      },
+    })
+    expect(missingRepository.status).toBe(400)
+    await expect(missingRepository.json()).resolves.toEqual({ error: "missing_repository" })
+
+    const missingTick = await app.request(
+      "/api/supervisor/ticks/latest?repository=voyantjs%2Fvoyant",
+      {
+        headers: {
+          authorization: "Bearer token",
+        },
+      },
+    )
+    expect(missingTick.status).toBe(404)
+    await expect(missingTick.json()).resolves.toEqual({ error: "supervisor_tick_not_found" })
+  })
+
+  it("stores latest supervisor ticks in R2-compatible object storage", async () => {
+    const objects = new Map<string, string>()
+    const store = createR2SupervisorTickStore({
+      bucket: {
+        async get(key: string) {
+          const text = objects.get(key)
+          return text ? { text: async () => text } : null
+        },
+        async put(key: string, value: string) {
+          objects.set(key, String(value))
+          return null
+        },
+      } satisfies SupervisorTickBucket,
+      keyPrefix: "/runner/",
+    })
+    const record: SupervisorTickRecord = {
+      recordedAt: "2026-05-12T12:00:00.000Z",
+      repository: "voyantjs/voyant",
+      result: {
+        leased: false,
+        reason: "dry_run",
+      },
+    }
+
+    await expect(store.putLatest(record)).resolves.toEqual({
+      key: "runner/supervisor-ticks/latest/voyantjs%2Fvoyant.json",
+    })
+    await expect(store.getLatest("VoyantJS/Voyant")).resolves.toEqual(record)
+  })
 })
+
+function inMemorySupervisorTickStore(): SupervisorTickStore {
+  const latest = new Map<string, SupervisorTickRecord>()
+
+  return {
+    async getLatest(repository) {
+      return latest.get(repository.toLowerCase()) ?? null
+    },
+    async putLatest(record) {
+      latest.set(record.repository.toLowerCase(), record)
+      return { key: `latest/${record.repository.toLowerCase()}.json` }
+    },
+  }
+}

--- a/apps/agent-runner/src/app.ts
+++ b/apps/agent-runner/src/app.ts
@@ -6,12 +6,14 @@ import {
   runSupervisorTick,
   supervisorTickRequestSchema,
 } from "./runner.js"
+import { createSupervisorTickRecord, type SupervisorTickStore } from "./supervisor-tick-store.js"
 
 interface AppOptions {
   authTokens?: string[]
   config?: RunnerConfig
   fetchImpl?: typeof fetch
   now?: () => Date
+  supervisorTickStore?: SupervisorTickStore
 }
 
 export function createApp({
@@ -22,6 +24,7 @@ export function createApp({
   },
   fetchImpl = fetch,
   now = () => new Date(),
+  supervisorTickStore,
 }: AppOptions = {}): Hono {
   const app = new Hono()
 
@@ -46,7 +49,14 @@ export function createApp({
     await next()
   })
 
-  app.get("/api/capabilities", (c) => c.json(buildRunnerCapabilities(config)))
+  app.get("/api/capabilities", (c) =>
+    c.json({
+      ...buildRunnerCapabilities(config),
+      supervisorTicks: {
+        persistence: supervisorTickStore ? "latest" : "none",
+      },
+    }),
+  )
 
   app.post("/api/supervisor/ticks", async (c) => {
     const parsed = supervisorTickRequestSchema.safeParse(await c.req.json().catch(() => ({})))
@@ -60,18 +70,77 @@ export function createApp({
       )
     }
 
+    const recordedAt = now()
+    const result = await runSupervisorTick({
+      config,
+      fetchImpl,
+      request: parsed.data,
+      source: "api",
+    })
+    const repository = parsed.data.repository ?? config.repository
+    const storage = await persistSupervisorTick({
+      recordedAt,
+      repository,
+      result,
+      supervisorTickStore,
+    })
+
     return c.json({
-      plannedAt: now().toISOString(),
-      result: await runSupervisorTick({
-        config,
-        fetchImpl,
-        request: parsed.data,
-        source: "api",
-      }),
+      plannedAt: recordedAt.toISOString(),
+      result,
+      storage,
     })
   })
 
+  app.get("/api/supervisor/ticks/latest", async (c) => {
+    if (!supervisorTickStore) {
+      return c.json({ error: "supervisor_tick_storage_not_configured" }, 503)
+    }
+
+    const repository = c.req.query("repository")?.trim()
+    if (!repository) {
+      return c.json({ error: "missing_repository" }, 400)
+    }
+
+    const record = await supervisorTickStore.getLatest(repository)
+    if (!record) {
+      return c.json({ error: "supervisor_tick_not_found" }, 404)
+    }
+
+    return c.json(record)
+  })
+
   return app
+}
+
+export async function persistSupervisorTick({
+  recordedAt,
+  repository,
+  result,
+  supervisorTickStore,
+}: {
+  recordedAt: Date
+  repository?: string
+  result: unknown
+  supervisorTickStore?: SupervisorTickStore
+}) {
+  if (!supervisorTickStore) {
+    return { persisted: false, reason: "supervisor_tick_storage_not_configured" }
+  }
+
+  if (!repository) {
+    return { persisted: false, reason: "missing_repository" }
+  }
+
+  const write = await supervisorTickStore.putLatest(
+    createSupervisorTickRecord({
+      recordedAt,
+      repository,
+      result,
+    }),
+  )
+
+  return { key: write.key, persisted: true }
 }
 
 function bearerToken(header: string | undefined) {

--- a/apps/agent-runner/src/supervisor-tick-store.ts
+++ b/apps/agent-runner/src/supervisor-tick-store.ts
@@ -1,0 +1,83 @@
+import { z } from "zod"
+
+export const supervisorTickRecordSchema = z.object({
+  recordedAt: z.string().datetime(),
+  repository: z.string().trim().min(1),
+  result: z.unknown(),
+})
+
+export type SupervisorTickRecord = z.infer<typeof supervisorTickRecordSchema>
+
+export interface SupervisorTickStore {
+  getLatest(repository: string): Promise<SupervisorTickRecord | null>
+  putLatest(record: SupervisorTickRecord): Promise<SupervisorTickStoreWrite>
+}
+
+export interface SupervisorTickStoreWrite {
+  key: string
+}
+
+export interface SupervisorTickBucket {
+  get(key: string): Promise<{ text(): Promise<string> } | null>
+  put(
+    key: string,
+    value: string,
+    options?: { httpMetadata?: { contentType?: string } },
+  ): Promise<unknown>
+}
+
+export function createSupervisorTickRecord({
+  recordedAt = new Date(),
+  repository,
+  result,
+}: {
+  recordedAt?: Date
+  repository: string
+  result: unknown
+}): SupervisorTickRecord {
+  return {
+    recordedAt: recordedAt.toISOString(),
+    repository,
+    result,
+  }
+}
+
+export function createR2SupervisorTickStore({
+  bucket,
+  keyPrefix = "agent-runner",
+}: {
+  bucket: SupervisorTickBucket
+  keyPrefix?: string
+}): SupervisorTickStore {
+  return {
+    async getLatest(repository) {
+      const object = await bucket.get(latestTickKey({ keyPrefix, repository }))
+      if (!object) return null
+
+      const parsed = supervisorTickRecordSchema.safeParse(JSON.parse(await object.text()))
+      if (!parsed.success) {
+        throw new Error(`stored supervisor tick is invalid for ${repository}`)
+      }
+
+      return parsed.data
+    },
+
+    async putLatest(record) {
+      const key = latestTickKey({ keyPrefix, repository: record.repository })
+      await bucket.put(key, JSON.stringify(record), {
+        httpMetadata: {
+          contentType: "application/json",
+        },
+      })
+
+      return { key }
+    },
+  }
+}
+
+function latestTickKey({ keyPrefix, repository }: { keyPrefix: string; repository: string }) {
+  const normalizedPrefix = keyPrefix.replace(/^\/+|\/+$/g, "")
+  const encodedRepository = encodeURIComponent(repository.trim().toLowerCase())
+  const key = `supervisor-ticks/latest/${encodedRepository}.json`
+  return normalizedPrefix ? `${normalizedPrefix}/${key}` : key
+}

--- a/apps/agent-runner/src/worker.ts
+++ b/apps/agent-runner/src/worker.ts
@@ -1,5 +1,6 @@
-import { createApp } from "./app.js"
+import { createApp, persistSupervisorTick } from "./app.js"
 import { runSupervisorTick } from "./runner.js"
+import { createR2SupervisorTickStore } from "./supervisor-tick-store.js"
 
 interface Env {
   AGENT_CONTROL_PLANE_TOKEN?: string
@@ -7,6 +8,8 @@ interface Env {
   AGENT_RUNNER_ENABLED?: string
   AGENT_RUNNER_HOLDER?: string
   AGENT_RUNNER_REPOSITORY?: string
+  AGENT_RUNNER_TICK_KEY_PREFIX?: string
+  AGENT_RUNNER_TICKS?: R2Bucket
   AGENT_RUNNER_TOKENS?: string
 }
 
@@ -15,11 +18,13 @@ export default {
     const app = createApp({
       authTokens: parseTokens(env.AGENT_RUNNER_TOKENS),
       config: runnerConfigFromEnv(env),
+      supervisorTickStore: supervisorTickStoreFromEnv(env),
     })
     return await app.fetch(request)
   },
 
   async scheduled(_event: ScheduledController, env: Env): Promise<void> {
+    const recordedAt = new Date()
     const result = await runSupervisorTick({
       config: runnerConfigFromEnv(env),
       request: {
@@ -28,7 +33,13 @@ export default {
       },
       source: "scheduled",
     })
-    console.log(JSON.stringify({ service: "agent-runner", supervisorTick: result }))
+    const storage = await persistSupervisorTick({
+      recordedAt,
+      repository: env.AGENT_RUNNER_REPOSITORY,
+      result,
+      supervisorTickStore: supervisorTickStoreFromEnv(env),
+    })
+    console.log(JSON.stringify({ service: "agent-runner", supervisorTick: result, storage }))
   },
 } satisfies ExportedHandler<Env>
 
@@ -41,6 +52,15 @@ function runnerConfigFromEnv(env: Env) {
     holder: env.AGENT_RUNNER_HOLDER,
     repository: env.AGENT_RUNNER_REPOSITORY,
   }
+}
+
+function supervisorTickStoreFromEnv(env: Env) {
+  return env.AGENT_RUNNER_TICKS
+    ? createR2SupervisorTickStore({
+        bucket: env.AGENT_RUNNER_TICKS,
+        keyPrefix: env.AGENT_RUNNER_TICK_KEY_PREFIX,
+      })
+    : undefined
 }
 
 function parseTokens(value: string | undefined) {

--- a/apps/agent-runner/wrangler.jsonc
+++ b/apps/agent-runner/wrangler.jsonc
@@ -12,6 +12,9 @@
   // Configure AGENT_CONTROL_PLANE_TOKEN separately when the runner is allowed to
   // call the control plane. Cron triggers should stay disabled until execution
   // policy, queue budget, and provider credentials are configured.
+  // Optional: bind an R2 bucket as AGENT_RUNNER_TICKS to store the latest
+  // supervisor tick status per repository. Set AGENT_RUNNER_TICK_KEY_PREFIX
+  // when multiple environments share one bucket.
   "observability": {
     "enabled": true
   }

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1359,6 +1359,11 @@ Verification:
   create workspaces, or spend model budget. Command execution remains owned by
   trusted runner processes until budget controls, sandbox policy, and
   task-scoped provider credentials are wired into a later slice.
+- The runner app can persist the latest supervisor tick result per repository
+  to R2 through the `AGENT_RUNNER_TICKS` binding and expose it at
+  `GET /api/supervisor/ticks/latest`. This gives Cron-based deployments an
+  inspectable heartbeat and last lease result without introducing a full run
+  database.
 
 ## Open Questions
 


### PR DESCRIPTION
## Summary

- add optional R2-backed storage for the latest supervisor tick per repository
- expose an authenticated latest supervisor tick endpoint for deployed runner heartbeat/status checks
- persist API and scheduled tick results when storage is configured
- document the runner tick status binding and deployment boundary

## Validation

- `pnpm --filter @voyantjs/agent-runner test`
- `pnpm --filter @voyantjs/agent-runner typecheck`
- `pnpm --filter @voyantjs/agent-runner lint`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- pre-commit hook: formatting, secretlint, agent quality, repository lint, repository typecheck
- pre-push hook: `pnpm test`