### PR TITLE
feat(allocation-ui): support generic allocation kinds

### DIFF
--- a/.changeset/allocation-ui-generic-surface.md
+++ b/.changeset/allocation-ui-generic-surface.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/allocation-ui": minor
+---
+
+Ship a generic slot allocation surface with resource-kind tabs, vehicle seat maps, kind-aware automation actions, and allocation validation summaries.

--- a/packages/allocation-ui/src/components/slot-allocation-model.ts
+++ b/packages/allocation-ui/src/components/slot-allocation-model.ts
@@ -1,0 +1,204 @@
+import type { AllocationManifestTraveler, AllocationResource } from "@voyantjs/availability-react"
+
+import type { AllocationUiMessages } from "../i18n/index.js"
+
+export const ROOM_KIND = "room"
+export const VEHICLE_KIND = "vehicle"
+export const VEHICLE_SEAT_KIND = "vehicle_seat"
+export const PARENT_ONLY_KINDS = new Set([VEHICLE_KIND])
+
+export type AllocationOccupants = {
+  byResource: Map<string, AllocationManifestTraveler[]>
+  byTravelerId: Map<string, AllocationManifestTraveler>
+  unallocated: AllocationManifestTraveler[]
+}
+
+export type ValidationIssue = {
+  id: string
+  label: string
+}
+
+export function collectOccupants(
+  travelers: AllocationManifestTraveler[],
+  resources: AllocationResource[],
+  kind: string,
+): AllocationOccupants {
+  const resourceIds = new Set(resources.map((resource) => resource.id))
+  const byResource = new Map<string, AllocationManifestTraveler[]>()
+  const byTravelerId = new Map<string, AllocationManifestTraveler>()
+  const unallocated: AllocationManifestTraveler[] = []
+
+  for (const traveler of travelers) {
+    byTravelerId.set(traveler.id, traveler)
+    const resourceId = traveler.allocations[kind]
+    if (!resourceId || !resourceIds.has(resourceId)) {
+      unallocated.push(traveler)
+      continue
+    }
+    const list = byResource.get(resourceId) ?? []
+    list.push(traveler)
+    byResource.set(resourceId, list)
+  }
+
+  return { byResource, byTravelerId, unallocated }
+}
+
+export function buildValidationIssues({
+  travelers,
+  resources,
+  occupants,
+  kind,
+  messages,
+}: {
+  travelers: AllocationManifestTraveler[]
+  resources: AllocationResource[]
+  occupants: AllocationOccupants
+  kind: string
+  messages: AllocationUiMessages
+}) {
+  const issues: ValidationIssue[] = []
+
+  if (occupants.unallocated.length > 0) {
+    issues.push({
+      id: "unallocated",
+      label: `${occupants.unallocated.length} ${messages.validationUnallocated}`,
+    })
+  }
+
+  for (const resource of resources) {
+    const count = occupants.byResource.get(resource.id)?.length ?? 0
+    if (count > resource.capacity) {
+      issues.push({
+        id: `over-capacity:${resource.id}`,
+        label: `${resource.label ?? kindLabel(kind, messages)} ${messages.validationOverCapacity}`,
+      })
+    }
+  }
+
+  for (const splitGroup of splitSharingGroups(travelers, kind)) {
+    issues.push({
+      id: `split:${splitGroup}`,
+      label: `${messages.validationSplitGroup}: ${splitGroup}`,
+    })
+  }
+
+  return issues
+}
+
+export function splitSharingGroups(travelers: AllocationManifestTraveler[], kind: string) {
+  const allocationsByGroup = new Map<string, Set<string>>()
+  for (const traveler of travelers) {
+    const groupId = traveler.sharingGroupId
+    if (!groupId) continue
+    const allocations = allocationsByGroup.get(groupId) ?? new Set<string>()
+    allocations.add(traveler.allocations[kind] ?? "unallocated")
+    allocationsByGroup.set(groupId, allocations)
+  }
+
+  const split: string[] = []
+  for (const [groupId, allocations] of allocationsByGroup) {
+    if (allocations.size > 1) split.push(groupId)
+  }
+  return split
+}
+
+export function groupSeatsByVehicle(seats: AllocationResource[], vehicles: AllocationResource[]) {
+  const vehiclesById = new Map(vehicles.map((vehicle) => [vehicle.id, vehicle]))
+  const grouped = new Map<
+    string,
+    { id: string; label: string; sortOrder: number; seats: AllocationResource[] }
+  >()
+
+  for (const seat of seats) {
+    const parentId = seat.parentId ?? "ungrouped"
+    const parent = parentId === "ungrouped" ? null : vehiclesById.get(parentId)
+    const group =
+      grouped.get(parentId) ??
+      grouped
+        .set(parentId, {
+          id: parentId,
+          label: parent?.label ?? "Vehicle",
+          sortOrder: parent?.sortOrder ?? 0,
+          seats: [],
+        })
+        .get(parentId)
+
+    group?.seats.push(seat)
+  }
+
+  return Array.from(grouped.values())
+    .map((group) => ({
+      ...group,
+      seats: group.seats.sort(compareSeatResources),
+    }))
+    .sort((a, b) => a.sortOrder - b.sortOrder || a.label.localeCompare(b.label))
+}
+
+export function seatRows(seats: AllocationResource[]) {
+  const byRow = new Map<string, AllocationResource[]>()
+  for (const seat of seats) {
+    const rowKey = String(flagNumber(seat.flags.row) ?? 0)
+    const row = byRow.get(rowKey) ?? []
+    row.push(seat)
+    byRow.set(rowKey, row)
+  }
+
+  return Array.from(byRow.entries())
+    .map(([rowKey, rowSeats]) => ({
+      rowKey,
+      seats: rowSeats.sort(compareSeatResources),
+    }))
+    .sort((a, b) => Number(a.rowKey) - Number(b.rowKey) || a.rowKey.localeCompare(b.rowKey))
+}
+
+export function seatName(seat: AllocationResource) {
+  const row = flagNumber(seat.flags.row)
+  const column = flagString(seat.flags.column)
+  if (row && column) return `${row}${column}`
+  return seat.label ?? "Seat"
+}
+
+export function parentKindFor(kind: string) {
+  return kind === VEHICLE_SEAT_KIND ? VEHICLE_KIND : ""
+}
+
+export function defaultCapacityFor(kind: string) {
+  return kind === VEHICLE_SEAT_KIND ? 1 : kind === ROOM_KIND ? 2 : 1
+}
+
+export function kindLabel(kind: string, messages: AllocationUiMessages) {
+  if (kind === ROOM_KIND) return messages.rooms
+  if (kind === VEHICLE_SEAT_KIND) return messages.vehicleSeats
+  if (kind === "cabin") return messages.cabins
+  if (kind === "flight_seat") return messages.flightSeats
+  return titleCaseKind(kind)
+}
+
+export function flagString(value: unknown) {
+  return typeof value === "string" ? value : null
+}
+
+function compareSeatResources(a: AllocationResource, b: AllocationResource) {
+  const aRow = flagNumber(a.flags.row) ?? 0
+  const bRow = flagNumber(b.flags.row) ?? 0
+  const aColumn = flagString(a.flags.column) ?? ""
+  const bColumn = flagString(b.flags.column) ?? ""
+  return aRow - bRow || aColumn.localeCompare(bColumn) || a.sortOrder - b.sortOrder
+}
+
+function titleCaseKind(kind: string) {
+  return kind
+    .split(/[_-]/g)
+    .filter(Boolean)
+    .map((part) => part.slice(0, 1).toUpperCase() + part.slice(1))
+    .join(" ")
+}
+
+function flagNumber(value: unknown) {
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value === "string") {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return null
+}

--- a/packages/allocation-ui/src/components/slot-allocation-page.tsx
+++ b/packages/allocation-ui/src/components/slot-allocation-page.tsx
@@ -1,51 +1,38 @@
 "use client"
 
 import {
-  type AllocationAuditLogEntry,
   type AllocationManifestTraveler,
-  type AllocationResource,
   useAllocationAutomationMutation,
   useAllocationResourceMutation,
   useAssignTravelerAllocationMutation,
+  useProductResourceTemplates,
   useSlotAllocation,
   useSlotAllocationAuditLog,
 } from "@voyantjs/availability-react"
-import {
-  Badge,
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  cn,
-  Input,
-  Label,
-} from "@voyantjs/ui/components"
-import {
-  Accessibility,
-  ArrowLeft,
-  Bed,
-  Crown,
-  Download,
-  History,
-  Plus,
-  Sparkles,
-  Trash2,
-  Users,
-  UtensilsCrossed,
-  Wand2,
-} from "lucide-react"
-import { type DragEvent, type FormEvent, type ReactNode, useMemo, useState } from "react"
+import { Button, cn, Input, Label, Tabs, TabsList, TabsTrigger } from "@voyantjs/ui/components"
+import { Armchair, ArrowLeft, Bed, Download, Plus, Sparkles, Users, Wand2 } from "lucide-react"
+import { type FormEvent, type ReactNode, useMemo, useState } from "react"
 
 import { useAllocationUiMessagesOrDefault } from "../i18n/index.js"
-
-const ROOM_KIND = "room"
+import {
+  buildValidationIssues,
+  collectOccupants,
+  defaultCapacityFor,
+  kindLabel,
+  PARENT_ONLY_KINDS,
+  parentKindFor,
+  ROOM_KIND,
+  VEHICLE_SEAT_KIND,
+} from "./slot-allocation-model.js"
+import { ResourceColumnsView } from "./slot-allocation-resource-view.js"
+import { VehicleSeatsView } from "./slot-allocation-seat-view.js"
+import { AuditLogCard, ValidationSummary } from "./slot-allocation-shared.js"
 
 export interface SlotAllocationPageProps {
   slotId: string
   className?: string
   onBack?: () => void
-  renderExtraActions?: (context: { slotId: string }) => ReactNode
+  renderExtraActions?: (context: { slotId: string; kind: string }) => ReactNode
   renderTravelerActions?: (traveler: AllocationManifestTraveler) => ReactNode
 }
 
@@ -62,16 +49,17 @@ export function SlotAllocationPage({
   const resourceMutation = useAllocationResourceMutation(slotId)
   const assignMutation = useAssignTravelerAllocationMutation(slotId)
   const automationMutation = useAllocationAutomationMutation(slotId)
-  const [addingRoom, setAddingRoom] = useState(false)
-  const [roomLabel, setRoomLabel] = useState("")
-  const [roomCapacity, setRoomCapacity] = useState(2)
+  const [selectedKind, setSelectedKind] = useState(ROOM_KIND)
+  const [addingResource, setAddingResource] = useState(false)
+  const [resourceLabel, setResourceLabel] = useState("")
+  const [resourceCapacity, setResourceCapacity] = useState(2)
   const [error, setError] = useState<string | null>(null)
 
   const data = allocation.data?.data
-  const rooms = useMemo(
-    () => (data?.resources ?? []).filter((resource) => resource.kind === ROOM_KIND),
-    [data?.resources],
-  )
+  const templates = useProductResourceTemplates({
+    productId: data?.slot.productId,
+    enabled: Boolean(data?.slot.productId),
+  })
 
   const travelers = useMemo(() => {
     const out: AllocationManifestTraveler[] = []
@@ -82,21 +70,41 @@ export function SlotAllocationPage({
     return out
   }, [data?.bookings])
 
-  const occupants = useMemo(() => {
-    const byRoom = new Map<string, AllocationManifestTraveler[]>()
-    const unallocated: AllocationManifestTraveler[] = []
-    for (const traveler of travelers) {
-      const roomId = traveler.allocations[ROOM_KIND]
-      if (!roomId) {
-        unallocated.push(traveler)
-        continue
-      }
-      const list = byRoom.get(roomId) ?? []
-      list.push(traveler)
-      byRoom.set(roomId, list)
+  const allocationKinds = useMemo(() => {
+    const kinds: string[] = []
+    const addKind = (kind: string | null | undefined) => {
+      if (!kind || PARENT_ONLY_KINDS.has(kind) || kinds.includes(kind)) return
+      kinds.push(kind)
     }
-    return { byRoom, unallocated }
-  }, [travelers])
+
+    addKind(ROOM_KIND)
+    for (const resource of data?.resources ?? []) addKind(resource.kind)
+    for (const option of templates.data?.data ?? []) {
+      for (const template of option.templates) addKind(template.kind)
+    }
+
+    return kinds
+  }, [data?.resources, templates.data?.data])
+
+  const activeKind = allocationKinds.includes(selectedKind)
+    ? selectedKind
+    : (allocationKinds[0] ?? ROOM_KIND)
+  const resources = useMemo(
+    () => (data?.resources ?? []).filter((resource) => resource.kind === activeKind),
+    [data?.resources, activeKind],
+  )
+  const parentResources = useMemo(
+    () => (data?.resources ?? []).filter((resource) => resource.kind === parentKindFor(activeKind)),
+    [data?.resources, activeKind],
+  )
+  const occupants = useMemo(
+    () => collectOccupants(travelers, resources, activeKind),
+    [travelers, resources, activeKind],
+  )
+  const validationIssues = useMemo(
+    () => buildValidationIssues({ travelers, resources, occupants, kind: activeKind, messages }),
+    [travelers, resources, occupants, activeKind, messages],
+  )
 
   function downloadExport(kind: "passengers" | "rooming-list") {
     globalThis.location.assign(
@@ -107,42 +115,67 @@ export function SlotAllocationPage({
   async function assignTraveler(travelerId: string, resourceId: string | null) {
     setError(null)
     try {
-      await assignMutation.mutateAsync({ travelerId, kind: ROOM_KIND, resourceId })
+      await assignMutation.mutateAsync({ travelerId, kind: activeKind, resourceId })
     } catch (err) {
       setError(err instanceof Error ? err.message : messages.allocationFailed)
     }
   }
 
-  async function createRoom(event: FormEvent<HTMLFormElement>) {
+  async function swapOrAssignSeat(travelerId: string, resourceId: string) {
+    const traveler = occupants.byTravelerId.get(travelerId)
+    if (!traveler) return
+
+    const currentResourceId = traveler.allocations[activeKind] ?? null
+    if (currentResourceId === resourceId) return
+
+    setError(null)
+    try {
+      const targetOccupant = (occupants.byResource.get(resourceId) ?? []).find(
+        (occupant) => occupant.id !== travelerId,
+      )
+      if (targetOccupant) {
+        await assignMutation.mutateAsync({
+          travelerId: targetOccupant.id,
+          kind: activeKind,
+          resourceId: currentResourceId,
+        })
+      }
+      await assignMutation.mutateAsync({ travelerId, kind: activeKind, resourceId })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : messages.allocationFailed)
+    }
+  }
+
+  async function createResource(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     setError(null)
     try {
       await resourceMutation.create.mutateAsync({
-        kind: ROOM_KIND,
-        label: roomLabel.trim() || null,
-        capacity: roomCapacity,
+        kind: activeKind,
+        label: resourceLabel.trim() || null,
+        capacity: resourceCapacity,
       })
-      setRoomLabel("")
-      setRoomCapacity(2)
-      setAddingRoom(false)
+      setResourceLabel("")
+      setResourceCapacity(defaultCapacityFor(activeKind))
+      setAddingResource(false)
     } catch (err) {
-      setError(err instanceof Error ? err.message : messages.createRoomFailed)
+      setError(err instanceof Error ? err.message : messages.createResourceFailed)
     }
   }
 
-  async function generateRooms() {
+  async function generateResources() {
     setError(null)
     try {
-      await automationMutation.autoMaterialize.mutateAsync({ kind: ROOM_KIND })
+      await automationMutation.autoMaterialize.mutateAsync({ kind: activeKind })
     } catch (err) {
-      setError(err instanceof Error ? err.message : messages.generateRoomsFailed)
+      setError(err instanceof Error ? err.message : messages.generateResourcesFailed)
     }
   }
 
   async function autoAllocate() {
     setError(null)
     try {
-      await automationMutation.autoAllocate.mutateAsync({ kind: ROOM_KIND })
+      await automationMutation.autoAllocate.mutateAsync({ kind: activeKind })
     } catch (err) {
       setError(err instanceof Error ? err.message : messages.autoAllocateFailed)
     }
@@ -163,6 +196,9 @@ export function SlotAllocationPage({
     )
   }
 
+  const isSeatMap = activeKind === VEHICLE_SEAT_KIND
+  const canManuallyAddResource = !isSeatMap
+
   return (
     <div className={cn("flex flex-col gap-4 p-6", className)}>
       <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
@@ -173,19 +209,19 @@ export function SlotAllocationPage({
             </Button>
           ) : null}
           <div>
-            <h1 className="text-2xl font-semibold tracking-tight">{messages.pageTitle}</h1>
+            <h1 className="text-2xl font-semibold">{messages.pageTitle}</h1>
             <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
               <span>
                 {data.summary.travelerCount} {messages.travelers}
               </span>
               <span>
-                {rooms.length} {messages.rooms.toLowerCase()}
+                {resources.length} {kindLabel(activeKind, messages).toLowerCase()}
               </span>
             </div>
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-2">
-          {renderExtraActions?.({ slotId })}
+          {renderExtraActions?.({ slotId, kind: activeKind })}
           <Button variant="outline" onClick={() => downloadExport("passengers")}>
             <Download data-icon="inline-start" aria-hidden="true" />
             {messages.exportPassengers}
@@ -194,16 +230,16 @@ export function SlotAllocationPage({
             <Download data-icon="inline-start" aria-hidden="true" />
             {messages.exportRooming}
           </Button>
-          {rooms.length === 0 ? (
+          {resources.length === 0 ? (
             <Button
               variant="outline"
-              onClick={() => void generateRooms()}
+              onClick={() => void generateResources()}
               disabled={automationMutation.autoMaterialize.isPending}
             >
               <Sparkles data-icon="inline-start" aria-hidden="true" />
               {automationMutation.autoMaterialize.isPending
-                ? messages.generatingRooms
-                : messages.generateRooms}
+                ? messages.generatingResources
+                : messages.generateResources}
             </Button>
           ) : (
             <Button
@@ -217,12 +253,35 @@ export function SlotAllocationPage({
                 : messages.autoAllocate}
             </Button>
           )}
-          <Button variant="outline" onClick={() => setAddingRoom((value) => !value)}>
-            <Plus data-icon="inline-start" aria-hidden="true" />
-            {messages.addRoom}
-          </Button>
+          {canManuallyAddResource ? (
+            <Button
+              variant="outline"
+              onClick={() => {
+                setResourceCapacity(defaultCapacityFor(activeKind))
+                setAddingResource((value) => !value)
+              }}
+            >
+              <Plus data-icon="inline-start" aria-hidden="true" />
+              {messages.addResource}
+            </Button>
+          ) : null}
         </div>
       </div>
+
+      <Tabs value={activeKind} onValueChange={setSelectedKind}>
+        <TabsList className="flex h-auto w-fit flex-wrap justify-start">
+          {allocationKinds.map((kind) => (
+            <TabsTrigger key={kind} value={kind} className="gap-2">
+              {kind === VEHICLE_SEAT_KIND ? (
+                <Armchair className="size-4" aria-hidden="true" />
+              ) : (
+                <Bed className="size-4" aria-hidden="true" />
+              )}
+              {kindLabel(kind, messages)}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
 
       {error ? (
         <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
@@ -230,320 +289,74 @@ export function SlotAllocationPage({
         </div>
       ) : null}
 
-      {addingRoom ? (
+      {addingResource && canManuallyAddResource ? (
         <form
           className="grid gap-3 rounded-md border bg-muted/30 p-3 sm:grid-cols-[1fr_8rem_auto_auto]"
-          onSubmit={createRoom}
+          onSubmit={createResource}
         >
           <div className="grid gap-1">
-            <Label htmlFor="allocation-room-label">{messages.roomLabel}</Label>
+            <Label htmlFor="allocation-resource-label">{messages.resourceLabel}</Label>
             <Input
-              id="allocation-room-label"
-              value={roomLabel}
-              onChange={(event) => setRoomLabel(event.target.value)}
-              placeholder="102"
+              id="allocation-resource-label"
+              value={resourceLabel}
+              onChange={(event) => setResourceLabel(event.target.value)}
+              placeholder={activeKind === ROOM_KIND ? "102" : kindLabel(activeKind, messages)}
             />
           </div>
           <div className="grid gap-1">
-            <Label htmlFor="allocation-room-capacity">{messages.roomCapacity}</Label>
+            <Label htmlFor="allocation-resource-capacity">{messages.resourceCapacity}</Label>
             <Input
-              id="allocation-room-capacity"
+              id="allocation-resource-capacity"
               type="number"
               min={1}
-              value={roomCapacity}
-              onChange={(event) => setRoomCapacity(Number(event.target.value) || 1)}
+              value={resourceCapacity}
+              onChange={(event) => setResourceCapacity(Number(event.target.value) || 1)}
             />
           </div>
           <Button type="submit" className="self-end" disabled={resourceMutation.create.isPending}>
-            {messages.createRoom}
+            {messages.createResource}
           </Button>
           <Button
             type="button"
             variant="ghost"
             className="self-end"
-            onClick={() => setAddingRoom(false)}
+            onClick={() => setAddingResource(false)}
           >
             {messages.cancel}
           </Button>
         </form>
       ) : null}
 
-      <div className="grid gap-4 xl:grid-cols-[minmax(18rem,22rem)_1fr]">
-        <DropColumn
-          id="unallocated"
-          title={messages.unallocated}
-          description={messages.unallocatedDescription}
-          count={occupants.unallocated.length}
-          capacity={travelers.length}
-          onDropTraveler={(travelerId) => void assignTraveler(travelerId, null)}
-        >
-          {occupants.unallocated.map((traveler) => (
-            <TravelerTile
-              key={traveler.id}
-              traveler={traveler}
-              sharingGroupLabel={
-                traveler.sharingGroupId ? data.sharingGroupLabels[traveler.sharingGroupId] : null
-              }
-              renderActions={renderTravelerActions}
-            />
-          ))}
-        </DropColumn>
+      <ValidationSummary
+        issues={validationIssues}
+        resources={resources}
+        unallocatedCount={occupants.unallocated.length}
+      />
 
-        <div className="grid min-w-0 gap-4 md:grid-cols-2 2xl:grid-cols-3">
-          {rooms.length === 0 ? (
-            <div className="rounded-md border border-dashed p-6 text-sm text-muted-foreground">
-              {messages.noRooms}
-            </div>
-          ) : (
-            rooms.map((room) => {
-              const roomOccupants = occupants.byRoom.get(room.id) ?? []
-              return (
-                <RoomColumn
-                  key={room.id}
-                  room={room}
-                  occupants={roomOccupants}
-                  onDropTraveler={(travelerId) => void assignTraveler(travelerId, room.id)}
-                  onRemoveRoom={() => void resourceMutation.remove.mutateAsync(room.id)}
-                  sharingGroupLabels={data.sharingGroupLabels}
-                  renderTravelerActions={renderTravelerActions}
-                />
-              )
-            })
-          )}
-        </div>
-      </div>
+      {isSeatMap ? (
+        <VehicleSeatsView
+          seats={resources}
+          vehicles={parentResources}
+          occupants={occupants}
+          sharingGroupLabels={data.sharingGroupLabels}
+          onDropTraveler={(travelerId, resourceId) => void swapOrAssignSeat(travelerId, resourceId)}
+          onUnassignTraveler={(travelerId) => void assignTraveler(travelerId, null)}
+          renderTravelerActions={renderTravelerActions}
+        />
+      ) : (
+        <ResourceColumnsView
+          kind={activeKind}
+          resources={resources}
+          travelers={travelers}
+          occupants={occupants}
+          sharingGroupLabels={data.sharingGroupLabels}
+          onDropTraveler={(travelerId, resourceId) => void assignTraveler(travelerId, resourceId)}
+          onRemoveResource={(resourceId) => void resourceMutation.remove.mutateAsync(resourceId)}
+          renderTravelerActions={renderTravelerActions}
+        />
+      )}
+
       <AuditLogCard entries={auditLog.data?.data ?? []} />
     </div>
   )
-}
-
-function RoomColumn({
-  room,
-  occupants,
-  onDropTraveler,
-  onRemoveRoom,
-  sharingGroupLabels,
-  renderTravelerActions,
-}: {
-  room: AllocationResource
-  occupants: AllocationManifestTraveler[]
-  onDropTraveler: (travelerId: string) => void
-  onRemoveRoom: () => void
-  sharingGroupLabels: Record<string, string>
-  renderTravelerActions?: (traveler: AllocationManifestTraveler) => ReactNode
-}) {
-  const messages = useAllocationUiMessagesOrDefault()
-  const full = occupants.length >= room.capacity
-
-  return (
-    <DropColumn
-      id={`room:${room.id}`}
-      title={room.label ?? messages.rooms}
-      description={`${messages.capacity}: ${occupants.length}/${room.capacity}`}
-      count={occupants.length}
-      capacity={room.capacity}
-      disabled={full}
-      onDropTraveler={onDropTraveler}
-      action={
-        <Button type="button" variant="ghost" size="icon" onClick={onRemoveRoom}>
-          <Trash2 className="size-4" aria-hidden="true" />
-        </Button>
-      }
-    >
-      {full ? (
-        <Badge variant="secondary" className="w-fit">
-          {messages.overCapacity}
-        </Badge>
-      ) : null}
-      {occupants.map((traveler) => (
-        <TravelerTile
-          key={traveler.id}
-          traveler={traveler}
-          sharingGroupLabel={
-            traveler.sharingGroupId ? sharingGroupLabels[traveler.sharingGroupId] : null
-          }
-          renderActions={renderTravelerActions}
-        />
-      ))}
-      {!full ? (
-        <div className="rounded-md border border-dashed p-3 text-xs text-muted-foreground">
-          {messages.dropHere}
-        </div>
-      ) : null}
-    </DropColumn>
-  )
-}
-
-function DropColumn({
-  id,
-  title,
-  description,
-  count,
-  capacity,
-  disabled,
-  action,
-  children,
-  onDropTraveler,
-}: {
-  id: string
-  title: string
-  description: string
-  count: number
-  capacity: number
-  disabled?: boolean
-  action?: ReactNode
-  children: ReactNode
-  onDropTraveler: (travelerId: string) => void
-}) {
-  const [over, setOver] = useState(false)
-
-  function onDrop(event: DragEvent<HTMLDivElement>) {
-    event.preventDefault()
-    setOver(false)
-    if (disabled) return
-    const travelerId = event.dataTransfer.getData("text/plain")
-    if (travelerId) onDropTraveler(travelerId)
-  }
-
-  return (
-    <Card
-      id={id}
-      className={cn(
-        "min-h-40 transition-colors",
-        over && !disabled ? "border-primary bg-primary/5" : null,
-      )}
-      onDragOver={(event) => {
-        event.preventDefault()
-        if (!disabled) setOver(true)
-      }}
-      onDragLeave={() => setOver(false)}
-      onDrop={onDrop}
-    >
-      <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0">
-        <div>
-          <CardTitle className="flex items-center gap-2 text-base">
-            <Bed className="size-4" aria-hidden="true" />
-            {title}
-          </CardTitle>
-          <p className="text-xs text-muted-foreground">{description}</p>
-        </div>
-        <div className="flex items-center gap-2">
-          <Badge variant={count > capacity ? "destructive" : "outline"}>
-            {count}/{capacity}
-          </Badge>
-          {action}
-        </div>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-2">{children}</CardContent>
-    </Card>
-  )
-}
-
-function TravelerTile({
-  traveler,
-  sharingGroupLabel,
-  renderActions,
-}: {
-  traveler: AllocationManifestTraveler
-  sharingGroupLabel?: string | null
-  renderActions?: (traveler: AllocationManifestTraveler) => ReactNode
-}) {
-  const messages = useAllocationUiMessagesOrDefault()
-
-  return (
-    // biome-ignore lint/a11y/useSemanticElements: issue #696; the tile can wrap custom action controls, so it cannot be a button.
-    <div
-      draggable
-      role="button"
-      tabIndex={0}
-      onDragStart={(event) => {
-        event.dataTransfer.effectAllowed = "move"
-        event.dataTransfer.setData("text/plain", traveler.id)
-      }}
-      className="group flex cursor-grab items-start justify-between gap-3 rounded-md border bg-background p-3 text-sm shadow-sm active:cursor-grabbing"
-    >
-      <div className="min-w-0">
-        <div className="flex min-w-0 flex-wrap items-center gap-1.5">
-          {traveler.isLeadTraveler ? (
-            <Crown className="size-3.5 text-amber-500" aria-label={messages.lead} />
-          ) : null}
-          <span className="truncate font-medium">{traveler.fullName}</span>
-          {traveler.sharingGroupId ? (
-            <Badge variant="secondary" className="text-[10px]">
-              {sharingGroupLabel ?? messages.sharingGroup}
-            </Badge>
-          ) : null}
-        </div>
-        <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
-          <span>{traveler.bookingNumber}</span>
-          {traveler.hasAccessibilityNeeds ? (
-            <Accessibility className="size-3.5" aria-label={messages.accessibility} />
-          ) : null}
-          {traveler.hasDietaryRequirements ? (
-            <UtensilsCrossed className="size-3.5" aria-label={messages.dietary} />
-          ) : null}
-        </div>
-      </div>
-      {renderActions ? <div className="shrink-0">{renderActions(traveler)}</div> : null}
-    </div>
-  )
-}
-
-function AuditLogCard({ entries }: { entries: AllocationAuditLogEntry[] }) {
-  const messages = useAllocationUiMessagesOrDefault()
-  if (entries.length === 0) return null
-
-  return (
-    <Card>
-      <CardHeader className="flex flex-row items-center gap-2 space-y-0 py-3">
-        <History className="size-4 text-muted-foreground" aria-hidden="true" />
-        <div>
-          <CardTitle className="text-base">{messages.auditLog}</CardTitle>
-          <p className="text-xs text-muted-foreground">{messages.auditLogDescription}</p>
-        </div>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-2">
-        {entries.slice(0, 8).map((entry) => (
-          <div key={entry.id} className="flex flex-wrap items-center gap-2 text-xs">
-            <span className="text-muted-foreground">
-              {new Date(entry.createdAt).toLocaleString()}
-            </span>
-            <Badge variant="outline">{actionLabel(entry.action, messages)}</Badge>
-            <span className="min-w-0 flex-1 truncate text-muted-foreground">
-              {entryDetail(entry)}
-            </span>
-          </div>
-        ))}
-      </CardContent>
-    </Card>
-  )
-}
-
-function actionLabel(
-  action: string,
-  messages: ReturnType<typeof useAllocationUiMessagesOrDefault>,
-) {
-  return messages.auditActions[action] ?? action
-}
-
-function entryDetail(entry: AllocationAuditLogEntry) {
-  const after = entry.after ?? {}
-  if (entry.action === "auto-allocate") {
-    return `${after.kind ?? ""}: ${after.assigned ?? 0} assigned, ${after.skipped ?? 0} skipped`
-  }
-  if (entry.action === "resources.materialize") {
-    return `${after.kind ?? ""}: ${after.created ?? 0} created`
-  }
-  if (entry.action.startsWith("resource.")) {
-    return [after.kind, after.label, after.capacity ? `capacity ${after.capacity}` : null]
-      .filter(Boolean)
-      .join(" · ")
-  }
-  if (entry.action.startsWith("traveler.")) {
-    return [after.kind, after.resourceId, after.sharingGroupId].filter(Boolean).join(" · ")
-  }
-  if (entry.action.startsWith("sharing-group.")) {
-    return [after.sharingGroupId, after.label].filter(Boolean).join(" · ")
-  }
-  return JSON.stringify(after)
 }

--- a/packages/allocation-ui/src/components/slot-allocation-resource-view.tsx
+++ b/packages/allocation-ui/src/components/slot-allocation-resource-view.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import type { AllocationManifestTraveler, AllocationResource } from "@voyantjs/availability-react"
+import { Badge, Button } from "@voyantjs/ui/components"
+import { Armchair, Bed, Trash2, Users } from "lucide-react"
+import type { ReactNode } from "react"
+
+import { useAllocationUiMessagesOrDefault } from "../i18n/index.js"
+import { type AllocationOccupants, kindLabel, VEHICLE_SEAT_KIND } from "./slot-allocation-model.js"
+import { DropColumn, ResourceFlagBadges, TravelerTile } from "./slot-allocation-shared.js"
+
+export function ResourceColumnsView({
+  kind,
+  resources,
+  travelers,
+  occupants,
+  sharingGroupLabels,
+  onDropTraveler,
+  onRemoveResource,
+  renderTravelerActions,
+}: {
+  kind: string
+  resources: AllocationResource[]
+  travelers: AllocationManifestTraveler[]
+  occupants: AllocationOccupants
+  sharingGroupLabels: Record<string, string>
+  onDropTraveler: (travelerId: string, resourceId: string | null) => void
+  onRemoveResource: (resourceId: string) => void
+  renderTravelerActions?: (traveler: AllocationManifestTraveler) => ReactNode
+}) {
+  const messages = useAllocationUiMessagesOrDefault()
+
+  return (
+    <div className="grid gap-4 xl:grid-cols-[minmax(18rem,22rem)_1fr]">
+      <DropColumn
+        id="unallocated"
+        icon={<Users className="size-4" aria-hidden="true" />}
+        title={messages.unallocated}
+        description={messages.unallocatedDescription}
+        count={occupants.unallocated.length}
+        capacity={travelers.length}
+        onDropTraveler={(travelerId) => onDropTraveler(travelerId, null)}
+      >
+        {occupants.unallocated.map((traveler) => (
+          <TravelerTile
+            key={traveler.id}
+            traveler={traveler}
+            sharingGroupLabel={
+              traveler.sharingGroupId ? sharingGroupLabels[traveler.sharingGroupId] : null
+            }
+            renderActions={renderTravelerActions}
+          />
+        ))}
+      </DropColumn>
+
+      <div className="grid min-w-0 gap-4 md:grid-cols-2 2xl:grid-cols-3">
+        {resources.length === 0 ? (
+          <div className="rounded-md border border-dashed p-6 text-sm text-muted-foreground">
+            {messages.noResources}
+          </div>
+        ) : (
+          resources.map((resource) => (
+            <AllocationResourceColumn
+              key={resource.id}
+              kind={kind}
+              resource={resource}
+              occupants={occupants.byResource.get(resource.id) ?? []}
+              sharingGroupLabels={sharingGroupLabels}
+              onDropTraveler={(travelerId) => onDropTraveler(travelerId, resource.id)}
+              onRemoveResource={() => onRemoveResource(resource.id)}
+              renderTravelerActions={renderTravelerActions}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  )
+}
+
+function AllocationResourceColumn({
+  kind,
+  resource,
+  occupants,
+  onDropTraveler,
+  onRemoveResource,
+  sharingGroupLabels,
+  renderTravelerActions,
+}: {
+  kind: string
+  resource: AllocationResource
+  occupants: AllocationManifestTraveler[]
+  onDropTraveler: (travelerId: string) => void
+  onRemoveResource: () => void
+  sharingGroupLabels: Record<string, string>
+  renderTravelerActions?: (traveler: AllocationManifestTraveler) => ReactNode
+}) {
+  const messages = useAllocationUiMessagesOrDefault()
+  const full = occupants.length >= resource.capacity
+
+  return (
+    <DropColumn
+      id={`allocation-resource:${resource.id}`}
+      icon={
+        kind === VEHICLE_SEAT_KIND ? <Armchair className="size-4" /> : <Bed className="size-4" />
+      }
+      title={resource.label ?? kindLabel(kind, messages)}
+      description={`${messages.capacity}: ${occupants.length}/${resource.capacity}`}
+      count={occupants.length}
+      capacity={resource.capacity}
+      disabled={full}
+      onDropTraveler={onDropTraveler}
+      action={
+        <Button type="button" variant="ghost" size="icon" onClick={onRemoveResource}>
+          <Trash2 className="size-4" aria-hidden="true" />
+        </Button>
+      }
+    >
+      <ResourceFlagBadges resource={resource} />
+      {full ? (
+        <Badge variant="secondary" className="w-fit">
+          {messages.overCapacity}
+        </Badge>
+      ) : null}
+      {occupants.map((traveler) => (
+        <TravelerTile
+          key={traveler.id}
+          traveler={traveler}
+          sharingGroupLabel={
+            traveler.sharingGroupId ? sharingGroupLabels[traveler.sharingGroupId] : null
+          }
+          renderActions={renderTravelerActions}
+        />
+      ))}
+      {!full ? (
+        <div className="rounded-md border border-dashed p-3 text-xs text-muted-foreground">
+          {messages.dropHere}
+        </div>
+      ) : null}
+    </DropColumn>
+  )
+}

--- a/packages/allocation-ui/src/components/slot-allocation-seat-view.tsx
+++ b/packages/allocation-ui/src/components/slot-allocation-seat-view.tsx
@@ -1,0 +1,188 @@
+"use client"
+
+import type { AllocationManifestTraveler, AllocationResource } from "@voyantjs/availability-react"
+import { Badge, Card, CardContent, CardHeader, CardTitle, cn } from "@voyantjs/ui/components"
+import { Armchair, Crown, Users } from "lucide-react"
+import { type DragEvent, type ReactNode, useState } from "react"
+
+import { useAllocationUiMessagesOrDefault } from "../i18n/index.js"
+import {
+  type AllocationOccupants,
+  groupSeatsByVehicle,
+  seatName,
+  seatRows,
+} from "./slot-allocation-model.js"
+import { DropColumn, SeatPositionBadge, TravelerTile } from "./slot-allocation-shared.js"
+
+export function VehicleSeatsView({
+  seats,
+  vehicles,
+  occupants,
+  sharingGroupLabels,
+  onDropTraveler,
+  onUnassignTraveler,
+  renderTravelerActions,
+}: {
+  seats: AllocationResource[]
+  vehicles: AllocationResource[]
+  occupants: AllocationOccupants
+  sharingGroupLabels: Record<string, string>
+  onDropTraveler: (travelerId: string, resourceId: string) => void
+  onUnassignTraveler: (travelerId: string) => void
+  renderTravelerActions?: (traveler: AllocationManifestTraveler) => ReactNode
+}) {
+  const messages = useAllocationUiMessagesOrDefault()
+  const groups = groupSeatsByVehicle(seats, vehicles)
+
+  return (
+    <div className="grid gap-4 xl:grid-cols-[minmax(18rem,22rem)_1fr]">
+      <DropColumn
+        id="unallocated"
+        icon={<Users className="size-4" aria-hidden="true" />}
+        title={messages.unallocated}
+        description={messages.unallocatedDescription}
+        count={occupants.unallocated.length}
+        capacity={occupants.byTravelerId.size}
+        onDropTraveler={onUnassignTraveler}
+      >
+        {occupants.unallocated.map((traveler) => (
+          <TravelerTile
+            key={traveler.id}
+            traveler={traveler}
+            sharingGroupLabel={
+              traveler.sharingGroupId ? sharingGroupLabels[traveler.sharingGroupId] : null
+            }
+            renderActions={renderTravelerActions}
+          />
+        ))}
+      </DropColumn>
+
+      <div className="grid min-w-0 gap-4">
+        {seats.length === 0 ? (
+          <div className="rounded-md border border-dashed p-6 text-sm text-muted-foreground">
+            {messages.noSeats}
+          </div>
+        ) : (
+          groups.map((group) => (
+            <Card key={group.id}>
+              <CardHeader className="pb-3">
+                <CardTitle className="flex flex-wrap items-center gap-2 text-base">
+                  <Armchair className="size-4" aria-hidden="true" />
+                  <span>{group.label}</span>
+                  <Badge variant="outline">
+                    {
+                      group.seats.filter(
+                        (seat) => (occupants.byResource.get(seat.id) ?? []).length > 0,
+                      ).length
+                    }
+                    /{group.seats.length}
+                  </Badge>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="grid gap-2">
+                  {seatRows(group.seats).map((row) => (
+                    <div
+                      key={row.rowKey}
+                      className="grid items-stretch gap-2"
+                      style={{
+                        gridTemplateColumns: `repeat(${row.seats.length}, minmax(4.25rem, 1fr))`,
+                      }}
+                    >
+                      {row.seats.map((seat) => {
+                        const seatOccupants = occupants.byResource.get(seat.id) ?? []
+                        return (
+                          <VehicleSeatCell
+                            key={seat.id}
+                            seat={seat}
+                            occupant={seatOccupants[0] ?? null}
+                            overflow={seatOccupants.length > 1}
+                            sharingGroupLabel={
+                              seatOccupants[0]?.sharingGroupId
+                                ? sharingGroupLabels[seatOccupants[0].sharingGroupId]
+                                : null
+                            }
+                            onDropTraveler={(travelerId) => onDropTraveler(travelerId, seat.id)}
+                          />
+                        )
+                      })}
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}
+
+function VehicleSeatCell({
+  seat,
+  occupant,
+  overflow,
+  sharingGroupLabel,
+  onDropTraveler,
+}: {
+  seat: AllocationResource
+  occupant: AllocationManifestTraveler | null
+  overflow: boolean
+  sharingGroupLabel?: string | null
+  onDropTraveler: (travelerId: string) => void
+}) {
+  const messages = useAllocationUiMessagesOrDefault()
+  const [over, setOver] = useState(false)
+
+  function onDrop(event: DragEvent<HTMLDivElement>) {
+    event.preventDefault()
+    setOver(false)
+    const travelerId = event.dataTransfer.getData("text/plain")
+    if (travelerId) onDropTraveler(travelerId)
+  }
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: issue #696; this cell is a drag-and-drop target, not a button or table cell.
+    <div
+      id={`seat:${seat.id}`}
+      className={cn(
+        "min-h-24 rounded-md border bg-background p-2 text-left text-xs transition-colors",
+        over ? "border-primary bg-primary/5" : null,
+        overflow ? "border-destructive bg-destructive/5" : null,
+      )}
+      onDragOver={(event) => {
+        event.preventDefault()
+        setOver(true)
+      }}
+      onDragLeave={() => setOver(false)}
+      onDrop={onDrop}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <span className="font-medium">{seat.label ?? seatName(seat)}</span>
+        <SeatPositionBadge seat={seat} />
+      </div>
+      {occupant ? (
+        <div className="mt-2 min-w-0">
+          <div className="flex items-center gap-1">
+            {occupant.isLeadTraveler ? (
+              <Crown className="size-3 text-amber-500" aria-label={messages.lead} />
+            ) : null}
+            <span className="truncate font-medium">{occupant.fullName}</span>
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-1 text-muted-foreground">
+            <span>{occupant.bookingNumber}</span>
+            {sharingGroupLabel ? (
+              <Badge variant="secondary" className="max-w-full truncate text-[10px]">
+                {sharingGroupLabel}
+              </Badge>
+            ) : null}
+          </div>
+        </div>
+      ) : (
+        <div className="mt-3 rounded border border-dashed p-2 text-muted-foreground">
+          {messages.dropHere}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/allocation-ui/src/components/slot-allocation-shared.tsx
+++ b/packages/allocation-ui/src/components/slot-allocation-shared.tsx
@@ -1,0 +1,267 @@
+"use client"
+
+import type {
+  AllocationAuditLogEntry,
+  AllocationManifestTraveler,
+  AllocationResource,
+} from "@voyantjs/availability-react"
+import { Badge, Card, CardContent, CardHeader, CardTitle, cn } from "@voyantjs/ui/components"
+import { Accessibility, CircleAlert, Crown, History, UtensilsCrossed } from "lucide-react"
+import { type DragEvent, type ReactNode, useState } from "react"
+
+import { useAllocationUiMessagesOrDefault } from "../i18n/index.js"
+import { flagString, type ValidationIssue } from "./slot-allocation-model.js"
+
+export function DropColumn({
+  id,
+  icon,
+  title,
+  description,
+  count,
+  capacity,
+  disabled,
+  action,
+  children,
+  onDropTraveler,
+}: {
+  id: string
+  icon: ReactNode
+  title: string
+  description: string
+  count: number
+  capacity: number
+  disabled?: boolean
+  action?: ReactNode
+  children: ReactNode
+  onDropTraveler: (travelerId: string) => void
+}) {
+  const [over, setOver] = useState(false)
+
+  function onDrop(event: DragEvent<HTMLDivElement>) {
+    event.preventDefault()
+    setOver(false)
+    if (disabled) return
+    const travelerId = event.dataTransfer.getData("text/plain")
+    if (travelerId) onDropTraveler(travelerId)
+  }
+
+  return (
+    <Card
+      id={id}
+      className={cn(
+        "min-h-40 transition-colors",
+        over && !disabled ? "border-primary bg-primary/5" : null,
+      )}
+      onDragOver={(event) => {
+        event.preventDefault()
+        if (!disabled) setOver(true)
+      }}
+      onDragLeave={() => setOver(false)}
+      onDrop={onDrop}
+    >
+      <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0">
+        <div>
+          <CardTitle className="flex items-center gap-2 text-base">
+            {icon}
+            {title}
+          </CardTitle>
+          <p className="text-xs text-muted-foreground">{description}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Badge variant={count > capacity ? "destructive" : "outline"}>
+            {count}/{capacity}
+          </Badge>
+          {action}
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-2">{children}</CardContent>
+    </Card>
+  )
+}
+
+export function TravelerTile({
+  traveler,
+  sharingGroupLabel,
+  renderActions,
+}: {
+  traveler: AllocationManifestTraveler
+  sharingGroupLabel?: string | null
+  renderActions?: (traveler: AllocationManifestTraveler) => ReactNode
+}) {
+  const messages = useAllocationUiMessagesOrDefault()
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: issue #696; the tile can wrap custom action controls, so it cannot be a button.
+    <div
+      draggable
+      role="button"
+      tabIndex={0}
+      onDragStart={(event) => {
+        event.dataTransfer.effectAllowed = "move"
+        event.dataTransfer.setData("text/plain", traveler.id)
+      }}
+      className="group flex cursor-grab items-start justify-between gap-3 rounded-md border bg-background p-3 text-sm shadow-sm active:cursor-grabbing"
+    >
+      <div className="min-w-0">
+        <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+          {traveler.isLeadTraveler ? (
+            <Crown className="size-3.5 text-amber-500" aria-label={messages.lead} />
+          ) : null}
+          <span className="truncate font-medium">{traveler.fullName}</span>
+          {traveler.sharingGroupId ? (
+            <Badge variant="secondary" className="max-w-full truncate text-[10px]">
+              {sharingGroupLabel ?? messages.sharingGroup}
+            </Badge>
+          ) : null}
+        </div>
+        <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+          <span>{traveler.bookingNumber}</span>
+          {traveler.roomTypeId ? <span>{traveler.roomTypeId}</span> : null}
+          {traveler.bedPreference ? <span>{traveler.bedPreference}</span> : null}
+          {traveler.hasAccessibilityNeeds ? (
+            <Accessibility className="size-3.5" aria-label={messages.accessibility} />
+          ) : null}
+          {traveler.hasDietaryRequirements ? (
+            <UtensilsCrossed className="size-3.5" aria-label={messages.dietary} />
+          ) : null}
+        </div>
+      </div>
+      {renderActions ? <div className="shrink-0">{renderActions(traveler)}</div> : null}
+    </div>
+  )
+}
+
+export function ValidationSummary({
+  issues,
+  resources,
+  unallocatedCount,
+}: {
+  issues: ValidationIssue[]
+  resources: AllocationResource[]
+  unallocatedCount: number
+}) {
+  const messages = useAllocationUiMessagesOrDefault()
+
+  if (issues.length === 0) {
+    return (
+      <div className="flex flex-wrap items-center gap-2 rounded-md border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+        <Badge variant="outline">{messages.validationClear}</Badge>
+        <span>
+          {resources.length} {messages.resources.toLowerCase()} · {unallocatedCount}{" "}
+          {messages.unallocated.toLowerCase()}
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-md border border-amber-300/60 bg-amber-50 px-3 py-2 text-sm text-amber-950 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-100">
+      <div className="flex items-center gap-2 font-medium">
+        <CircleAlert className="size-4" aria-hidden="true" />
+        {messages.validationTitle}
+      </div>
+      <div className="mt-2 flex flex-wrap gap-2">
+        {issues.map((issue) => (
+          <Badge key={issue.id} variant="outline" className="border-amber-300 bg-background/70">
+            {issue.label}
+          </Badge>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function ResourceFlagBadges({ resource }: { resource: AllocationResource }) {
+  const messages = useAllocationUiMessagesOrDefault()
+  const flags = resource.flags
+  const badges: string[] = []
+
+  if (flags.accessibilityNeeded === true) badges.push(messages.accessibility)
+  if (flags.smokingAllowed === true) badges.push(messages.smokingAllowed)
+  if (typeof flags.note === "string" && flags.note.trim()) badges.push(flags.note.trim())
+
+  if (badges.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {badges.map((badge) => (
+        <Badge key={badge} variant="outline" className="max-w-full truncate text-[10px]">
+          {badge}
+        </Badge>
+      ))}
+    </div>
+  )
+}
+
+export function SeatPositionBadge({ seat }: { seat: AllocationResource }) {
+  const messages = useAllocationUiMessagesOrDefault()
+  const position = flagString(seat.flags.position)
+  if (!position) return null
+
+  const label =
+    position === "window"
+      ? messages.windowSeat
+      : position === "aisle"
+        ? messages.aisleSeat
+        : position === "middle"
+          ? messages.middleSeat
+          : position
+
+  return (
+    <Badge variant="outline" className="text-[10px]">
+      {label}
+    </Badge>
+  )
+}
+
+export function AuditLogCard({ entries }: { entries: AllocationAuditLogEntry[] }) {
+  const messages = useAllocationUiMessagesOrDefault()
+  if (entries.length === 0) return null
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center gap-2 space-y-0 py-3">
+        <History className="size-4 text-muted-foreground" aria-hidden="true" />
+        <div>
+          <CardTitle className="text-base">{messages.auditLog}</CardTitle>
+          <p className="text-xs text-muted-foreground">{messages.auditLogDescription}</p>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-2">
+        {entries.slice(0, 8).map((entry) => (
+          <div key={entry.id} className="flex flex-wrap items-center gap-2 text-xs">
+            <span className="text-muted-foreground">
+              {new Date(entry.createdAt).toLocaleString()}
+            </span>
+            <Badge variant="outline">{messages.auditActions[entry.action] ?? entry.action}</Badge>
+            <span className="min-w-0 flex-1 truncate text-muted-foreground">
+              {entryDetail(entry)}
+            </span>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  )
+}
+
+function entryDetail(entry: AllocationAuditLogEntry) {
+  const after = entry.after ?? {}
+  if (entry.action === "auto-allocate") {
+    return `${after.kind ?? ""}: ${after.assigned ?? 0} assigned, ${after.skipped ?? 0} skipped`
+  }
+  if (entry.action === "resources.materialize") {
+    return `${after.kind ?? ""}: ${after.created ?? 0} created`
+  }
+  if (entry.action.startsWith("resource.")) {
+    return [after.kind, after.label, after.capacity ? `capacity ${after.capacity}` : null]
+      .filter(Boolean)
+      .join(" · ")
+  }
+  if (entry.action.startsWith("traveler.")) {
+    return [after.kind, after.resourceId, after.sharingGroupId].filter(Boolean).join(" · ")
+  }
+  if (entry.action.startsWith("sharing-group.")) {
+    return [after.sharingGroupId, after.label].filter(Boolean).join(" · ")
+  }
+  return JSON.stringify(after)
+}

--- a/packages/allocation-ui/src/i18n/provider.tsx
+++ b/packages/allocation-ui/src/i18n/provider.tsx
@@ -16,8 +16,11 @@ export type AllocationUiMessages = Record<string, unknown> & {
   empty: string
   back: string
   addRoom: string
+  addResource: string
   generateRooms: string
   generatingRooms: string
+  generateResources: string
+  generatingResources: string
   autoAllocate: string
   autoAllocating: string
   exportPassengers: string
@@ -28,23 +31,43 @@ export type AllocationUiMessages = Record<string, unknown> & {
   roomLabel: string
   roomCapacity: string
   createRoom: string
+  resourceLabel: string
+  resourceCapacity: string
+  createResource: string
   cancel: string
   unallocated: string
   unallocatedDescription: string
   rooms: string
+  resources: string
+  vehicleSeats: string
+  cabins: string
+  flightSeats: string
   travelers: string
   capacity: string
   lead: string
   sharingGroup: string
   accessibility: string
   dietary: string
+  smokingAllowed: string
   remove: string
   overCapacity: string
   dropHere: string
   noRooms: string
+  noResources: string
+  noSeats: string
+  windowSeat: string
+  aisleSeat: string
+  middleSeat: string
+  validationTitle: string
+  validationClear: string
+  validationUnallocated: string
+  validationOverCapacity: string
+  validationSplitGroup: string
   allocationFailed: string
   createRoomFailed: string
+  createResourceFailed: string
   generateRoomsFailed: string
+  generateResourcesFailed: string
   autoAllocateFailed: string
 }
 
@@ -54,8 +77,11 @@ export const allocationUiEn = {
   empty: "No travelers on this departure yet.",
   back: "Back",
   addRoom: "Add room",
+  addResource: "Add resource",
   generateRooms: "Generate rooms",
   generatingRooms: "Generating...",
+  generateResources: "Generate resources",
+  generatingResources: "Generating...",
   autoAllocate: "Auto-allocate",
   autoAllocating: "Allocating...",
   exportPassengers: "Passengers",
@@ -78,23 +104,43 @@ export const allocationUiEn = {
   roomLabel: "Room label",
   roomCapacity: "Capacity",
   createRoom: "Create room",
+  resourceLabel: "Resource label",
+  resourceCapacity: "Capacity",
+  createResource: "Create resource",
   cancel: "Cancel",
   unallocated: "Unallocated",
-  unallocatedDescription: "Travelers not assigned to a room.",
+  unallocatedDescription: "Travelers not assigned to this resource kind.",
   rooms: "Rooms",
+  resources: "Resources",
+  vehicleSeats: "Vehicle seats",
+  cabins: "Cabins",
+  flightSeats: "Flight seats",
   travelers: "travelers",
   capacity: "Capacity",
   lead: "Lead",
   sharingGroup: "Sharing group",
   accessibility: "Accessibility",
   dietary: "Dietary",
+  smokingAllowed: "Smoking",
   remove: "Remove",
-  overCapacity: "Room is full",
+  overCapacity: "Resource is full",
   dropHere: "Drop traveler here",
   noRooms: "No rooms have been added for this slot.",
+  noResources: "No resources have been added for this slot.",
+  noSeats: "No vehicle seats have been generated for this slot.",
+  windowSeat: "Window",
+  aisleSeat: "Aisle",
+  middleSeat: "Middle",
+  validationTitle: "Allocation needs attention",
+  validationClear: "No validation issues",
+  validationUnallocated: "unallocated",
+  validationOverCapacity: "is over capacity",
+  validationSplitGroup: "Split sharing group",
   allocationFailed: "Could not update allocation.",
   createRoomFailed: "Could not create room.",
+  createResourceFailed: "Could not create resource.",
   generateRoomsFailed: "Could not generate rooms.",
+  generateResourcesFailed: "Could not generate resources.",
   autoAllocateFailed: "Could not auto-allocate travelers.",
 } satisfies AllocationUiMessages
 
@@ -104,8 +150,11 @@ export const allocationUiRo = {
   empty: "Nu exista calatori pe aceasta plecare.",
   back: "Inapoi",
   addRoom: "Adauga camera",
+  addResource: "Adauga resursa",
   generateRooms: "Genereaza camere",
   generatingRooms: "Se genereaza...",
+  generateResources: "Genereaza resurse",
+  generatingResources: "Se genereaza...",
   autoAllocate: "Auto-aloca",
   autoAllocating: "Se aloca...",
   exportPassengers: "Pasageri",
@@ -128,23 +177,43 @@ export const allocationUiRo = {
   roomLabel: "Eticheta camera",
   roomCapacity: "Capacitate",
   createRoom: "Creeaza camera",
+  resourceLabel: "Eticheta resursa",
+  resourceCapacity: "Capacitate",
+  createResource: "Creeaza resursa",
   cancel: "Anuleaza",
   unallocated: "Nealocati",
-  unallocatedDescription: "Calatori fara camera alocata.",
+  unallocatedDescription: "Calatori fara acest tip de resursa alocat.",
   rooms: "Camere",
+  resources: "Resurse",
+  vehicleSeats: "Locuri vehicul",
+  cabins: "Cabine",
+  flightSeats: "Locuri zbor",
   travelers: "calatori",
   capacity: "Capacitate",
   lead: "Lead",
   sharingGroup: "Grup partaj",
   accessibility: "Accesibilitate",
   dietary: "Dieta",
+  smokingAllowed: "Fumat",
   remove: "Scoate",
-  overCapacity: "Camera este plina",
+  overCapacity: "Resursa este plina",
   dropHere: "Trage calatorul aici",
   noRooms: "Nu exista camere adaugate pentru acest slot.",
+  noResources: "Nu exista resurse adaugate pentru acest slot.",
+  noSeats: "Nu exista locuri generate pentru acest slot.",
+  windowSeat: "Geam",
+  aisleSeat: "Culoar",
+  middleSeat: "Mijloc",
+  validationTitle: "Alocarea necesita atentie",
+  validationClear: "Fara probleme de validare",
+  validationUnallocated: "nealocati",
+  validationOverCapacity: "depaseste capacitatea",
+  validationSplitGroup: "Grup partaj impartit",
   allocationFailed: "Alocarea nu a putut fi actualizata.",
   createRoomFailed: "Camera nu a putut fi creata.",
+  createResourceFailed: "Resursa nu a putut fi creata.",
   generateRoomsFailed: "Camerele nu au putut fi generate.",
+  generateResourcesFailed: "Resursele nu au putut fi generate.",
   autoAllocateFailed: "Calatorii nu au putut fi auto-alocati.",
 } satisfies AllocationUiMessages
 


### PR DESCRIPTION
## Summary
- make SlotAllocationPage kind-aware using manifest resources and product option resource templates
- add generic resource columns plus a vehicle seat map with occupied-seat swap behavior
- add allocation validation summary and i18n strings for generic resources, vehicle seats, and seat positions
- split allocation UI internals into focused model/view files and add a changeset

## Verification
- pnpm --filter @voyantjs/allocation-ui lint
- pnpm --filter @voyantjs/allocation-ui typecheck
- pnpm --filter @voyantjs/allocation-ui build
- pnpm --filter @voyantjs/allocation-ui test
- pnpm verify:fast
- pre-push full test lane passed from cache

Closes #696