### PR TITLE
[codex] Add operator admin page shell

### DIFF
--- a/.changeset/admin-page-shell.md
+++ b/.changeset/admin-page-shell.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/admin": patch
+---
+
+Add an operator admin page shell with breadcrumb, action, sidebar trigger, and padded content slots.

--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -181,6 +181,37 @@ Pass `variant="inset"` or `variant="floating"` and `side="right"` when an app
 needs one of the modern sidebar variants. The sidebar can also be toggled with
 `Cmd+B` on macOS or `Ctrl+B` on Windows and Linux.
 
+Use `OperatorAdminPageShell` when a route needs the standard per-page header:
+sidebar trigger, breadcrumbs, page-level actions, and a padded body. Disable the
+workspace layout's fallback trigger header so the page shell owns the route
+header:
+
+```tsx
+import { OperatorAdminPageShell, OperatorAdminWorkspaceLayout } from "@voyantjs/admin"
+
+function Workspace({ children }) {
+  return (
+    <OperatorAdminWorkspaceLayout currentPath="/bookings" showSidebarTrigger={false}>
+      {children}
+    </OperatorAdminWorkspaceLayout>
+  )
+}
+
+function BookingsRoute() {
+  return (
+    <OperatorAdminPageShell
+      breadcrumbs={<BreadcrumbTrail current="Bookings" />}
+      actions={<NewBookingButton />}
+    >
+      <BookingsPage />
+    </OperatorAdminPageShell>
+  )
+}
+```
+
+Pass `padded={false}` for full-bleed pages such as maps, workflow timelines, or
+canvas-style tools that own their own spacing.
+
 Route-level document titles are derived from `navItems` and `currentPath` by
 default, so `/bookings` renders `Bookings · Voyant` and tracks the active
 locale when the navigation messages change. `AdminPageHead` also keeps

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -12,6 +12,7 @@
     "./components/admin-page-head": "./src/components/admin-page-head.tsx",
     "./components/admin-widget-slot": "./src/components/admin-widget-slot.tsx",
     "./components/operator-admin-bootstrap-gate": "./src/components/operator-admin-bootstrap-gate.tsx",
+    "./components/operator-admin-page-shell": "./src/components/operator-admin-page-shell.tsx",
     "./components/operator-admin-sidebar": "./src/components/operator-admin-sidebar.tsx",
     "./components/team-settings-page": "./src/components/team-settings-page.tsx",
     "./components/operator-admin-user-menu": "./src/components/operator-admin-user-menu.tsx",
@@ -108,6 +109,11 @@
         "types": "./dist/components/operator-admin-bootstrap-gate.d.ts",
         "import": "./dist/components/operator-admin-bootstrap-gate.js",
         "default": "./dist/components/operator-admin-bootstrap-gate.js"
+      },
+      "./components/operator-admin-page-shell": {
+        "types": "./dist/components/operator-admin-page-shell.d.ts",
+        "import": "./dist/components/operator-admin-page-shell.js",
+        "default": "./dist/components/operator-admin-page-shell.js"
       },
       "./components/operator-admin-sidebar": {
         "types": "./dist/components/operator-admin-sidebar.d.ts",

--- a/packages/admin/src/components/operator-admin-page-shell.tsx
+++ b/packages/admin/src/components/operator-admin-page-shell.tsx
@@ -1,0 +1,73 @@
+"use client"
+
+import { cn, Separator, SidebarTrigger } from "@voyantjs/ui/components"
+import type * as React from "react"
+
+export interface OperatorAdminPageShellProps {
+  actions?: React.ReactNode
+  breadcrumbs?: React.ReactNode
+  children: React.ReactNode
+  className?: string
+  contentClassName?: string
+  headerClassName?: string
+  padded?: boolean
+  showSidebarTrigger?: boolean
+}
+
+export function OperatorAdminPageShell({
+  actions,
+  breadcrumbs,
+  children,
+  className,
+  contentClassName,
+  headerClassName,
+  padded = true,
+  showSidebarTrigger = true,
+}: OperatorAdminPageShellProps) {
+  return (
+    <div
+      data-slot="operator-admin-page-shell"
+      className={cn("flex min-h-0 flex-1 flex-col", className)}
+    >
+      <header
+        data-slot="operator-admin-page-shell-header"
+        className={cn(
+          "sticky top-0 z-10 flex h-16 shrink-0 items-center justify-between gap-2 border-b border-border bg-background/95 px-4 backdrop-blur transition-[width,height] ease-linear supports-[backdrop-filter]:bg-background/80 group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12",
+          headerClassName,
+        )}
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          {showSidebarTrigger ? (
+            <SidebarTrigger
+              className="-ml-1"
+              title="Toggle sidebar (Cmd/Ctrl+B)"
+              aria-label="Toggle sidebar"
+            />
+          ) : null}
+          {breadcrumbs ? (
+            <>
+              {showSidebarTrigger ? (
+                <Separator orientation="vertical" className="mr-2 h-4" />
+              ) : null}
+              <div className="min-w-0 flex-1">{breadcrumbs}</div>
+            </>
+          ) : null}
+        </div>
+        {actions ? (
+          <div
+            className="flex shrink-0 items-center gap-2"
+            data-slot="operator-admin-page-shell-actions"
+          >
+            {actions}
+          </div>
+        ) : null}
+      </header>
+      <div
+        data-slot="operator-admin-page-shell-content"
+        className={cn(padded && "px-4 py-6 md:px-6", contentClassName)}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -47,6 +47,10 @@ export {
   type OperatorAdminBootstrapRenderState,
 } from "./components/operator-admin-bootstrap-gate.js"
 export {
+  OperatorAdminPageShell,
+  type OperatorAdminPageShellProps,
+} from "./components/operator-admin-page-shell.js"
+export {
   DefaultOperatorAdminBrand,
   type DefaultOperatorAdminBrandProps,
   OperatorAdminSidebar,

--- a/packages/admin/tests/unit/operator-admin-page-shell.test.tsx
+++ b/packages/admin/tests/unit/operator-admin-page-shell.test.tsx
@@ -1,0 +1,86 @@
+import { cleanup, render, screen } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { OperatorAdminPageShell } from "../../src/components/operator-admin-page-shell.js"
+import { OperatorAdminWorkspaceLayout } from "../../src/components/operator-admin-sidebar.js"
+import { AdminProvider } from "../../src/providers/admin-provider.js"
+import { OperatorAdminMessagesProvider } from "../../src/providers/operator-admin-messages.js"
+
+function renderWithAdminProviders(children: ReactNode) {
+  return render(
+    <AdminProvider themeStorageKey={null}>
+      <OperatorAdminMessagesProvider>{children}</OperatorAdminMessagesProvider>
+    </AdminProvider>,
+  )
+}
+
+beforeEach(() => {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe("OperatorAdminPageShell", () => {
+  it("renders a sticky page header with breadcrumbs, actions, and padded content", () => {
+    const { container } = renderWithAdminProviders(
+      <OperatorAdminWorkspaceLayout
+        currentPath="/bookings"
+        navItems={[]}
+        showSidebarTrigger={false}
+      >
+        <OperatorAdminPageShell
+          breadcrumbs={<nav aria-label="Breadcrumb">Bookings</nav>}
+          actions={<button type="button">New booking</button>}
+        >
+          <section>Bookings table</section>
+        </OperatorAdminPageShell>
+      </OperatorAdminWorkspaceLayout>,
+    )
+
+    expect(container.querySelectorAll("main[data-slot='sidebar-inset']")).toHaveLength(1)
+    expect(container.querySelector("[data-slot='operator-admin-page-shell']")).not.toBeNull()
+    expect(
+      container.querySelector("[data-slot='operator-admin-page-shell-header']")?.classList,
+    ).toContain("sticky")
+    expect(screen.getByRole("button", { name: "Toggle sidebar" })).not.toBeNull()
+    expect(screen.getByRole("navigation", { name: "Breadcrumb" }).textContent).toBe("Bookings")
+    expect(screen.getByRole("button", { name: "New booking" })).not.toBeNull()
+    expect(
+      container.querySelector("[data-slot='operator-admin-page-shell-content']")?.classList,
+    ).toContain("px-4")
+    expect(screen.getByText("Bookings table")).not.toBeNull()
+  })
+
+  it("can render full-bleed content without duplicating the sidebar trigger", () => {
+    const { container } = renderWithAdminProviders(
+      <OperatorAdminWorkspaceLayout
+        currentPath="/operations"
+        navItems={[]}
+        showSidebarTrigger={false}
+      >
+        <OperatorAdminPageShell padded={false} showSidebarTrigger={false}>
+          <section>Live operations map</section>
+        </OperatorAdminPageShell>
+      </OperatorAdminWorkspaceLayout>,
+    )
+
+    expect(screen.queryByRole("button", { name: "Toggle sidebar" })).toBeNull()
+    expect(
+      container.querySelector("[data-slot='operator-admin-page-shell-content']")?.classList,
+    ).not.toContain("px-4")
+    expect(screen.getByText("Live operations map")).not.toBeNull()
+  })
+})

--- a/templates/operator/README.md
+++ b/templates/operator/README.md
@@ -52,6 +52,12 @@ The workspace shell uses the shared `OperatorAdminWorkspaceLayout`. Operators
 can collapse or expand the sidebar from the header trigger, or with `Cmd+B` on
 macOS and `Ctrl+B` on Windows and Linux.
 
+Use `OperatorAdminPageShell` from `@voyantjs/admin` for route-level chrome:
+breadcrumbs, page actions, and the padded page body. When a route adopts the
+page shell, pass `showSidebarTrigger={false}` to `OperatorAdminWorkspaceLayout`
+so the shell owns the only visible route header. Pass `padded={false}` to the
+page shell for full-bleed operator tools that own their own spacing.
+
 Route-level browser titles are auto-derived from the shared navigation items
 and active locale. Override detail pages that need entity-specific metadata
 with `useAdminPageHead({ title, description })` from `@voyantjs/admin`. The


### PR DESCRIPTION
## Summary

Closes #685.

Adds a reusable `OperatorAdminPageShell` to `@voyantjs/admin` for route-level operator chrome. The shell provides a sticky header with the sidebar trigger, breadcrumbs slot, actions slot, and a padded body by default, with escape hatches for full-bleed pages and routes that need to hide the trigger.

## Changes

- Add `OperatorAdminPageShell` and `OperatorAdminPageShellProps`.
- Export the page shell from the admin barrel and package subpath.
- Add unit coverage for standard padded usage and full-bleed/no-trigger usage.
- Document the shell in `packages/admin/README.md` and `templates/operator/README.md`.
- Add a patch changeset for `@voyantjs/admin`.

## Validation

- `pnpm --filter @voyantjs/admin lint`
- `pnpm --filter @voyantjs/admin typecheck`
- `pnpm --filter @voyantjs/admin test`
- `pnpm --filter @voyantjs/admin build`
- `git diff --check`
- post-rebase: `pnpm --filter @voyantjs/admin lint`
- post-rebase: `pnpm --filter @voyantjs/admin typecheck`
- post-rebase: `pnpm --filter @voyantjs/admin test`
- post-rebase: `git diff --check origin/main...HEAD`
- pre-commit repo typecheck
- pre-push repo test lane

Note: `pnpm verify:package-exports` was attempted in the fresh worktree, but it requires dist outputs for many unrelated packages and failed on missing build artifacts before reaching this change.