### PR TITLE
feat(agent-runner): enforce dispatch lease policy

### DIFF
--- a/apps/agent-runner/README.md
+++ b/apps/agent-runner/README.md
@@ -30,7 +30,13 @@ provider commands, or spend model budget.
 - `AGENT_RUNNER_TOKENS`: comma-separated bearer tokens for `/api/*`.
 - `AGENT_RUNNER_ENABLED`: must be `true` before scheduled ticks can lease
   dispatch intents.
+- `AGENT_RUNNER_ALLOWED_ACTIONS`: optional comma-separated lifecycle action
+  allow-list. Defaults to all runner-supported lifecycle actions.
+- `AGENT_RUNNER_ACTION`: optional default lifecycle action filter, useful when
+  `AGENT_RUNNER_ALLOWED_ACTIONS` restricts Cron to one action such as `sync-pr`.
 - `AGENT_RUNNER_HOLDER`: default lease holder, for example `runner:cloudflare`.
+- `AGENT_RUNNER_MAX_LEASE_TTL_SECONDS`: optional maximum lease TTL. Defaults to
+  900 seconds and is clamped to 60..3600 seconds.
 - `AGENT_RUNNER_REPOSITORY`: default repository, for example `voyantjs/voyant`.
 - `AGENT_RUNNER_TICKS`: optional R2 binding for latest supervisor tick status.
 - `AGENT_RUNNER_TICK_KEY_PREFIX`: optional R2 key prefix for supervisor ticks.

--- a/apps/agent-runner/src/app.test.ts
+++ b/apps/agent-runner/src/app.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { createApp } from "./app.js"
+import { runnerDispatchActions } from "./runner.js"
 import {
   createR2SupervisorTickStore,
   type SupervisorTickBucket,
@@ -88,6 +89,12 @@ describe("agent runner app", () => {
           dryRun: true,
           iterations: 3,
           mode: "lease-only",
+          policy: {
+            allowedActions: Array.from(runnerDispatchActions).sort(),
+            defaultAction: null,
+            maxLeaseTtlSeconds: 900,
+            requiresActionFilter: false,
+          },
           source: "api",
         },
         reason: "dry_run",
@@ -189,6 +196,169 @@ describe("agent runner app", () => {
       },
     ])
     expect(calls[0]?.headers.get("authorization")).toBe("Bearer control-token")
+  })
+
+  it("applies runner action and lease TTL policy before calling the control plane", async () => {
+    const calls: string[] = []
+    const app = createApp({
+      authTokens: ["token"],
+      config: {
+        allowedActions: ["sync-pr"],
+        controlPlaneConfigured: true,
+        controlPlaneToken: "control-token",
+        controlPlaneUrl: "https://control.example.com/",
+        enabled: true,
+        holder: "runner:cloudflare",
+        maxLeaseTtlSeconds: 120,
+        repository: "voyantjs/voyant",
+      },
+      fetchImpl: async (url) => {
+        calls.push(String(url))
+        return new Response(JSON.stringify({ reason: "leased" }), { status: 201 })
+      },
+      now: () => new Date("2026-05-12T11:00:00.000Z"),
+    })
+
+    const missingAction = await app.request("/api/supervisor/ticks", {
+      body: JSON.stringify({ dryRun: false }),
+      headers: {
+        authorization: "Bearer token",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+    expect(missingAction.status).toBe(200)
+    await expect(missingAction.json()).resolves.toMatchObject({
+      result: {
+        leased: false,
+        plan: {
+          accepted: false,
+          blockers: ["runner policy requires an action filter"],
+        },
+        reason: "blocked",
+      },
+    })
+
+    const blocked = await app.request("/api/supervisor/ticks", {
+      body: JSON.stringify({ action: "cleanup", dryRun: false, ttlSeconds: 300 }),
+      headers: {
+        authorization: "Bearer token",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+    expect(blocked.status).toBe(200)
+    await expect(blocked.json()).resolves.toMatchObject({
+      result: {
+        leased: false,
+        plan: {
+          accepted: false,
+          blockers: [
+            "action cleanup is not allowed by runner policy",
+            "lease TTL 300s exceeds runner policy maximum 120s",
+          ],
+        },
+        reason: "blocked",
+      },
+    })
+    expect(calls).toEqual([])
+  })
+
+  it("treats typoed full-length action allow-lists as restricted", async () => {
+    const allowedActions = [
+      ...runnerDispatchActions.filter((action) => action !== "cleanup"),
+      "clean-up",
+    ]
+    expect(new Set(allowedActions).size).toBe(runnerDispatchActions.length)
+
+    const app = createApp({
+      authTokens: ["token"],
+      config: {
+        allowedActions,
+        controlPlaneConfigured: true,
+        controlPlaneToken: "control-token",
+        controlPlaneUrl: "https://control.example.com/",
+        enabled: true,
+        holder: "runner:cloudflare",
+        repository: "voyantjs/voyant",
+      },
+    })
+
+    const response = await app.request("/api/supervisor/ticks", {
+      body: JSON.stringify({ dryRun: false }),
+      headers: {
+        authorization: "Bearer token",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      result: {
+        leased: false,
+        plan: {
+          accepted: false,
+          policy: {
+            requiresActionFilter: true,
+          },
+          blockers: ["runner policy requires an action filter"],
+        },
+        reason: "blocked",
+      },
+    })
+  })
+
+  it("uses the configured default action when scheduled ticks are action-restricted", async () => {
+    const calls: Array<{ body: unknown; url: string }> = []
+    const app = createApp({
+      authTokens: ["token"],
+      config: {
+        allowedActions: ["sync-pr"],
+        controlPlaneConfigured: true,
+        controlPlaneToken: "control-token",
+        controlPlaneUrl: "https://control.example.com/",
+        defaultAction: "sync-pr",
+        enabled: true,
+        holder: "runner:cloudflare",
+        repository: "voyantjs/voyant",
+      },
+      fetchImpl: async (url, init) => {
+        calls.push({ body: JSON.parse(String(init?.body)), url: String(url) })
+        return new Response(JSON.stringify({ reason: "idle" }), { status: 200 })
+      },
+    })
+
+    const response = await app.request("/api/supervisor/ticks", {
+      body: JSON.stringify({ dryRun: false }),
+      headers: {
+        authorization: "Bearer token",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      result: {
+        leased: false,
+        reason: "idle",
+      },
+    })
+    expect(calls).toEqual([
+      {
+        body: {
+          filters: {
+            action: "sync-pr",
+          },
+          lease: {
+            holder: "runner:cloudflare",
+          },
+          repository: "voyantjs/voyant",
+        },
+        url: "https://control.example.com/api/dispatch-intents/latest",
+      },
+    ])
   })
 
   it("reads the latest persisted supervisor tick", async () => {

--- a/apps/agent-runner/src/runner.ts
+++ b/apps/agent-runner/src/runner.ts
@@ -1,5 +1,21 @@
 import { z } from "zod"
 
+export const runnerDispatchActions = [
+  "collect-ci",
+  "complete-pr",
+  "cleanup",
+  "open-pr",
+  "publish-evidence",
+  "remote-bootstrap",
+  "remote-cleanup",
+  "remote-open-pr",
+  "remote-publish-evidence",
+  "start",
+  "sync-pr",
+] as const
+
+const runnerDispatchActionSet = new Set<string>(runnerDispatchActions)
+
 export const supervisorTickRequestSchema = z
   .object({
     action: z.string().trim().min(1).optional(),
@@ -18,11 +34,14 @@ export const supervisorTickRequestSchema = z
 export type SupervisorTickRequest = z.infer<typeof supervisorTickRequestSchema>
 
 export interface RunnerConfig {
+  allowedActions?: string[]
   controlPlaneConfigured: boolean
   controlPlaneToken?: string
   controlPlaneUrl?: string
+  defaultAction?: string
   enabled: boolean
   holder?: string
+  maxLeaseTtlSeconds?: number
   repository?: string
 }
 
@@ -42,9 +61,11 @@ export function buildRunnerCapabilities(config: RunnerConfig) {
       url: config.controlPlaneUrl ?? null,
     },
     defaults: {
+      action: config.defaultAction ?? null,
       holder: config.holder ?? null,
       repository: config.repository ?? null,
     },
+    policy: buildRunnerPolicy(config),
     scheduler: {
       cronCompatible: true,
       mode: "lease-only",
@@ -65,12 +86,16 @@ export function planSupervisorTick({
   const holder = request.holder ?? config.holder
   const repository = request.repository ?? config.repository
   const iterations = request.iterations ?? 1
+  const policy = buildRunnerPolicy(config)
+  const action = request.action ?? config.defaultAction
 
   const blockers = [
     config.enabled ? null : "runner execution is disabled",
     config.controlPlaneConfigured ? null : "control plane is not configured",
     holder ? null : "holder is not configured",
     repository ? null : "repository is not configured",
+    actionPolicyBlocker({ action, policy }),
+    ttlPolicyBlocker({ policy, ttlSeconds: request.ttlSeconds }),
   ].filter((blocker): blocker is string => Boolean(blocker))
 
   return {
@@ -85,6 +110,7 @@ export function planSupervisorTick({
     dryRun: request.dryRun ?? true,
     iterations,
     mode: "lease-only",
+    policy,
     source,
   }
 }
@@ -167,6 +193,7 @@ function buildDispatchIntentRequest({
 }) {
   const holder = request.holder ?? config.holder
   const repository = request.repository ?? config.repository
+  const action = request.action ?? config.defaultAction
 
   return {
     repository,
@@ -174,10 +201,10 @@ function buildDispatchIntentRequest({
       holder,
       ...(request.ttlSeconds ? { ttlSeconds: request.ttlSeconds } : {}),
     },
-    ...(request.action || request.issue
+    ...(action || request.issue
       ? {
           filters: {
-            ...(request.action ? { action: request.action } : {}),
+            ...(action ? { action } : {}),
             ...(request.issue ? { issueNumber: request.issue } : {}),
           },
         }
@@ -191,6 +218,68 @@ function buildDispatchIntentRequest({
         }
       : {}),
   }
+}
+
+function buildRunnerPolicy(config: RunnerConfig) {
+  const allowedActions = normalizeAllowedActions(config.allowedActions)
+  const maxLeaseTtlSeconds = normalizeMaxLeaseTtlSeconds(config.maxLeaseTtlSeconds)
+  const restrictsActions = runnerDispatchActions.some((action) => !allowedActions.includes(action))
+
+  return {
+    allowedActions,
+    defaultAction: config.defaultAction ?? null,
+    maxLeaseTtlSeconds,
+    requiresActionFilter: restrictsActions,
+  }
+}
+
+function normalizeAllowedActions(allowedActions: string[] | undefined) {
+  const normalized = (allowedActions?.length ? allowedActions : Array.from(runnerDispatchActions))
+    .map((action) => action.trim())
+    .filter((action) => action.length > 0)
+
+  return Array.from(new Set(normalized)).sort()
+}
+
+function normalizeMaxLeaseTtlSeconds(value: number | undefined) {
+  if (!value) return 900
+  return Math.min(Math.max(value, 60), 3600)
+}
+
+function actionPolicyBlocker({
+  action,
+  policy,
+}: {
+  action?: string
+  policy: ReturnType<typeof buildRunnerPolicy>
+}) {
+  if (action && !runnerDispatchActionSet.has(action)) {
+    return `action ${action} is not dispatchable`
+  }
+
+  if (action && !policy.allowedActions.includes(action)) {
+    return `action ${action} is not allowed by runner policy`
+  }
+
+  if (!action && policy.requiresActionFilter) {
+    return "runner policy requires an action filter"
+  }
+
+  return null
+}
+
+function ttlPolicyBlocker({
+  policy,
+  ttlSeconds,
+}: {
+  policy: ReturnType<typeof buildRunnerPolicy>
+  ttlSeconds?: number
+}) {
+  if (ttlSeconds && ttlSeconds > policy.maxLeaseTtlSeconds) {
+    return `lease TTL ${ttlSeconds}s exceeds runner policy maximum ${policy.maxLeaseTtlSeconds}s`
+  }
+
+  return null
 }
 
 function buildLocalEquivalentCommand({

--- a/apps/agent-runner/src/worker.ts
+++ b/apps/agent-runner/src/worker.ts
@@ -5,8 +5,11 @@ import { createR2SupervisorTickStore } from "./supervisor-tick-store.js"
 interface Env {
   AGENT_CONTROL_PLANE_TOKEN?: string
   AGENT_CONTROL_PLANE_URL?: string
+  AGENT_RUNNER_ACTION?: string
+  AGENT_RUNNER_ALLOWED_ACTIONS?: string
   AGENT_RUNNER_ENABLED?: string
   AGENT_RUNNER_HOLDER?: string
+  AGENT_RUNNER_MAX_LEASE_TTL_SECONDS?: string
   AGENT_RUNNER_REPOSITORY?: string
   AGENT_RUNNER_TICK_KEY_PREFIX?: string
   AGENT_RUNNER_TICKS?: R2Bucket
@@ -45,11 +48,14 @@ export default {
 
 function runnerConfigFromEnv(env: Env) {
   return {
+    allowedActions: parseList(env.AGENT_RUNNER_ALLOWED_ACTIONS),
     controlPlaneConfigured: Boolean(env.AGENT_CONTROL_PLANE_URL && env.AGENT_CONTROL_PLANE_TOKEN),
     controlPlaneToken: env.AGENT_CONTROL_PLANE_TOKEN,
     controlPlaneUrl: env.AGENT_CONTROL_PLANE_URL,
+    defaultAction: env.AGENT_RUNNER_ACTION,
     enabled: env.AGENT_RUNNER_ENABLED === "true",
     holder: env.AGENT_RUNNER_HOLDER,
+    maxLeaseTtlSeconds: parsePositiveInteger(env.AGENT_RUNNER_MAX_LEASE_TTL_SECONDS),
     repository: env.AGENT_RUNNER_REPOSITORY,
   }
 }
@@ -64,8 +70,19 @@ function supervisorTickStoreFromEnv(env: Env) {
 }
 
 function parseTokens(value: string | undefined) {
+  return parseList(value)
+}
+
+function parseList(value: string | undefined) {
   return (value ?? "")
     .split(",")
-    .map((token) => token.trim())
-    .filter((token) => token.length > 0)
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+}
+
+function parsePositiveInteger(value: string | undefined) {
+  if (!value) return undefined
+
+  const number = Number(value)
+  return Number.isInteger(number) && number > 0 ? number : undefined
 }

--- a/apps/agent-runner/wrangler.jsonc
+++ b/apps/agent-runner/wrangler.jsonc
@@ -12,6 +12,8 @@
   // Configure AGENT_CONTROL_PLANE_TOKEN separately when the runner is allowed to
   // call the control plane. Cron triggers should stay disabled until execution
   // policy, queue budget, and provider credentials are configured.
+  // Optional: set AGENT_RUNNER_ALLOWED_ACTIONS and AGENT_RUNNER_ACTION to keep
+  // scheduled ticks constrained to one approved lifecycle action.
   // Optional: bind an R2 bucket as AGENT_RUNNER_TICKS to store the latest
   // supervisor tick status per repository. Set AGENT_RUNNER_TICK_KEY_PREFIX
   // when multiple environments share one bucket.

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1364,6 +1364,13 @@ Verification:
   `GET /api/supervisor/ticks/latest`. This gives Cron-based deployments an
   inspectable heartbeat and last lease result without introducing a full run
   database.
+- The runner app enforces a local dispatch policy before calling the control
+  plane. `AGENT_RUNNER_ALLOWED_ACTIONS` limits which lifecycle actions a
+  deployed runner can lease, `AGENT_RUNNER_ACTION` supplies a default action
+  filter for Cron, and `AGENT_RUNNER_MAX_LEASE_TTL_SECONDS` caps lease TTLs.
+  If the action allow-list is narrower than the full lifecycle set, the runner
+  refuses unfiltered ticks so the control plane cannot choose a different
+  queued action.
 
 ## Open Questions
 


### PR DESCRIPTION
## Summary

- add runner-side lifecycle action allow-list and lease TTL policy
- block restricted runner ticks unless an action filter or configured default action is present
- pass configured default action through to control-plane dispatch intent requests
- document Cloudflare runner policy env vars for safe Cron deployment

## Validation

- `pnpm --filter @voyantjs/agent-runner test`
- `pnpm --filter @voyantjs/agent-runner typecheck`
- `pnpm --filter @voyantjs/agent-runner lint`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- pre-commit hook: formatting, secretlint, agent quality, repository lint, repository typecheck
- pre-push hook: `pnpm test`