### PR TITLE
feat(agent-control-plane): expose active dispatch intent reads

### DIFF
--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -28,6 +28,7 @@ pnpm -C apps/agent-control-plane dev
 - `POST /api/dispatch-plans`
 - `POST /api/dispatch-plans/latest`
 - `POST /api/dispatch-intents/latest`
+- `GET /api/dispatch-intents/active?repository=<owner/name>&issue=<number>&action=<name>`
 - `POST /api/dispatch-intents/:id/finish`
 - `POST /api/tick-snapshots`
 - `GET /api/tick-snapshots/latest?repository=<owner/name>`
@@ -55,6 +56,12 @@ is an operator, supervisor, or runner identifier; the TTL defaults to 900
 seconds and must be between 60 and 3600 seconds. If a non-expired intent already
 exists for the same repository, issue, and action, the endpoint returns
 `dispatch_intent_already_active`.
+
+`GET /api/dispatch-intents/active` reads the active-pointer record for one
+repository, issue, and lifecycle action. It returns `{ active, intent }`, where
+`active` is false when the stored pointer is expired or terminal. Use this to
+explain lease contention before rerunning or releasing work; it does not mutate
+the lease.
 
 `POST /api/dispatch-intents/:id/finish` accepts
 `{ holder, status, reason?, exitCode? }` where `status` is `completed`,
@@ -113,6 +120,14 @@ pnpm agent:queue:lease-dispatch -- --repo voyantjs/voyant --holder supervisor:lo
 
 This records the lease and prints the command to run. It does not execute the
 command.
+
+Inspect an active lease when a supervisor reports lease contention:
+
+```bash
+AGENT_CONTROL_PLANE_URL=https://agent-control-plane.example.workers.dev \
+AGENT_CONTROL_PLANE_TOKEN=... \
+pnpm agent:queue:active-dispatch -- --repo voyantjs/voyant --issue 579 --action remote-bootstrap
+```
 
 Finish the leased dispatch intent after the runner has handled the printed
 command:

--- a/apps/agent-control-plane/src/active-dispatch-intent.test.ts
+++ b/apps/agent-control-plane/src/active-dispatch-intent.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest"
+
+import { createApp } from "./app.js"
+import {
+  type DispatchIntentRecord,
+  finishDispatchIntent,
+  isDispatchIntentActive,
+} from "./control-plane.js"
+import type { DispatchIntentStore } from "./dispatch-intent-store.js"
+
+const issue = {
+  number: 579,
+  repository: "voyantjs/voyant",
+  title: "Test agent project intake workflow",
+  url: "https://github.com/voyantjs/voyant/issues/579",
+}
+
+describe("active dispatch intent reads", () => {
+  it("returns the active lease for an issue and action without mutating it", async () => {
+    const intentStore = inMemoryDispatchIntentStore()
+    const app = createApp({
+      authTokens: ["secret"],
+      dispatchIntentStore: intentStore,
+      now: () => new Date("2026-05-12T05:30:00.000Z"),
+    })
+    await intentStore.putIntent(leasedIntent({ id: "active_intent" }))
+
+    const response = await app.request(
+      "/api/dispatch-intents/active?repository=VoyantJS/Voyant&issue=579&action=remote-bootstrap",
+      {
+        headers: { authorization: "Bearer secret" },
+      },
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      active: true,
+      intent: {
+        id: "active_intent",
+        lease: {
+          holder: "supervisor:existing",
+        },
+        plan: {
+          action: "remote-bootstrap",
+          issue: {
+            number: 579,
+          },
+        },
+      },
+    })
+  })
+
+  it("reports expired active pointers without treating them as active leases", async () => {
+    const intentStore = inMemoryDispatchIntentStore()
+    const app = createApp({
+      authTokens: ["secret"],
+      dispatchIntentStore: intentStore,
+      now: () => new Date("2026-05-12T05:45:01.000Z"),
+    })
+    await intentStore.putIntent(leasedIntent({ id: "expired_intent" }))
+
+    const response = await app.request(
+      "/api/dispatch-intents/active?repository=voyantjs/voyant&issueNumber=579&action=remote-bootstrap",
+      {
+        headers: { authorization: "Bearer secret" },
+      },
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      active: false,
+      intent: {
+        id: "expired_intent",
+      },
+    })
+  })
+
+  it("validates active lease reads before accessing storage", async () => {
+    const app = createApp({
+      authTokens: ["secret"],
+      dispatchIntentStore: inMemoryDispatchIntentStore(),
+    })
+
+    const invalid = await app.request(
+      "/api/dispatch-intents/active?repository=voyantjs/voyant&issue=579&action=remote-run-command",
+      {
+        headers: { authorization: "Bearer secret" },
+      },
+    )
+    expect(invalid.status).toBe(400)
+    await expect(invalid.json()).resolves.toMatchObject({
+      error: "invalid_active_dispatch_intent_request",
+    })
+
+    const missing = await app.request(
+      "/api/dispatch-intents/active?repository=voyantjs/voyant&issue=579&action=remote-bootstrap",
+      {
+        headers: { authorization: "Bearer secret" },
+      },
+    )
+    expect(missing.status).toBe(404)
+    await expect(missing.json()).resolves.toEqual({ error: "dispatch_intent_not_found" })
+  })
+})
+
+function leasedIntent({ id }: { id: string }): DispatchIntentRecord {
+  return {
+    createdAt: "2026-05-12T05:25:00.000Z",
+    id,
+    lease: {
+      acquiredAt: "2026-05-12T05:25:00.000Z",
+      expiresAt: "2026-05-12T05:35:00.000Z",
+      holder: "supervisor:existing",
+      ttlSeconds: 600,
+    },
+    plan: {
+      action: "remote-bootstrap",
+      command: ["pnpm", "agent:queue:remote-bootstrap"],
+      issue,
+      reason: "existing lease",
+      repository: "voyantjs/voyant",
+      requiresMutation: true,
+    },
+    source: {
+      acceptedAt: "2026-05-12T05:00:00.000Z",
+      recommendationCount: 2,
+      repository: "voyantjs/voyant",
+      type: "latest_tick_snapshot",
+    },
+    status: "leased",
+  }
+}
+
+function inMemoryDispatchIntentStore(): DispatchIntentStore {
+  const active = new Map<string, DispatchIntentRecord>()
+  const byId = new Map<string, DispatchIntentRecord>()
+
+  return {
+    async acquireIntent(record, { now }) {
+      const key = activeIntentKey(record)
+      const existing = active.get(key)
+      if (existing && isDispatchIntentActive(existing, now)) {
+        return { acquired: false, activeIntent: existing }
+      }
+
+      active.set(key, record)
+      byId.set(record.id, record)
+      return { acquired: true, write: { activeKey: key, key: `${record.id}.json` } }
+    },
+    async finishIntent({ id, now, request }) {
+      const intent = byId.get(id)
+      if (!intent) return { finished: false, reason: "not_found" }
+      if (intent.status !== "leased")
+        return { finished: false, intent, reason: "intent_not_active" }
+      if (intent.lease.holder !== request.holder) {
+        return { finished: false, intent, reason: "holder_mismatch" }
+      }
+
+      const finishedIntent = finishDispatchIntent({ intent, now, request })
+      const activeKey = activeIntentKey(intent)
+      byId.set(id, finishedIntent)
+      active.set(activeKey, finishedIntent)
+      return {
+        finished: true,
+        intent: finishedIntent,
+        write: { activeKey, activeUpdated: true, key: `${intent.id}.json` },
+      }
+    },
+    async getActive(reference) {
+      return active.get(activeIntentReferenceKey(reference)) ?? null
+    },
+    async putIntent(record) {
+      const activeKey = activeIntentKey(record)
+      byId.set(record.id, record)
+      active.set(activeKey, record)
+      return { activeKey, key: `${record.id}.json` }
+    },
+  }
+}
+
+function activeIntentKey(record: DispatchIntentRecord) {
+  return activeIntentReferenceKey({
+    action: record.plan.action,
+    issueNumber: record.plan.issue.number,
+    repository: record.plan.repository,
+  })
+}
+
+function activeIntentReferenceKey({
+  action,
+  issueNumber,
+  repository,
+}: {
+  action: string
+  issueNumber: number
+  repository: string
+}) {
+  return `active/${repository.toLowerCase()}/${issueNumber}/${action.toLowerCase()}.json`
+}

--- a/apps/agent-control-plane/src/app.ts
+++ b/apps/agent-control-plane/src/app.ts
@@ -2,11 +2,13 @@ import { Hono } from "hono"
 
 import {
   acceptTickSnapshot,
+  activeDispatchIntentRequestSchema,
   buildCapabilities,
   buildDispatchIntentFromStoredPlan,
   buildTickSnapshotRecord,
   dispatchIntentFinishRequestSchema,
   dispatchPlanRequestSchema,
+  isDispatchIntentActive,
   latestDispatchIntentRequestSchema,
   latestDispatchPlanRequestSchema,
   selectDispatchPlan,
@@ -167,6 +169,37 @@ export function createApp({
       },
       201,
     )
+  })
+
+  app.get("/api/dispatch-intents/active", async (c) => {
+    const parsed = activeDispatchIntentRequestSchema.safeParse({
+      action: c.req.query("action"),
+      issueNumber: c.req.query("issueNumber") ?? c.req.query("issue"),
+      repository: c.req.query("repository"),
+    })
+    if (!parsed.success) {
+      return c.json(
+        {
+          error: "invalid_active_dispatch_intent_request",
+          issues: validationIssues(parsed.error),
+        },
+        400,
+      )
+    }
+
+    if (!dispatchIntentStore) {
+      return c.json({ error: "dispatch_intent_storage_not_configured" }, 503)
+    }
+
+    const intent = await dispatchIntentStore.getActive(parsed.data)
+    if (!intent) {
+      return c.json({ error: "dispatch_intent_not_found" }, 404)
+    }
+
+    return c.json({
+      active: isDispatchIntentActive(intent, now()),
+      intent,
+    })
   })
 
   app.post("/api/dispatch-intents/:id/finish", async (c) => {

--- a/apps/agent-control-plane/src/control-plane.ts
+++ b/apps/agent-control-plane/src/control-plane.ts
@@ -100,6 +100,14 @@ export const latestDispatchIntentRequestSchema = z.object({
 
 export type LatestDispatchIntentRequest = z.infer<typeof latestDispatchIntentRequestSchema>
 
+export const activeDispatchIntentRequestSchema = z.object({
+  action: z.enum(dispatchableActions),
+  issueNumber: z.coerce.number().int().positive(),
+  repository: z.string().trim().min(1),
+})
+
+export type ActiveDispatchIntentRequest = z.infer<typeof activeDispatchIntentRequestSchema>
+
 export const tickSnapshotRequestSchema = z.object({
   eventLog: z.object({
     path: z.string().min(1),
@@ -239,6 +247,7 @@ export function buildCapabilities({
     },
     dispatchIntentContracts: {
       latestSnapshotLease: {
+        activeRead: dispatchIntentPersistence === "leased",
         persistence: dispatchIntentPersistence,
         terminalStatuses: dispatchIntentTerminalStatusSchema.options,
         ttlSeconds: {

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -408,6 +408,10 @@ plan, source snapshot, lease holder, and lease expiration so always-on
 supervisors can coordinate explicit command execution without the Worker
 running the command itself. Use `pnpm agent:queue:lease-dispatch -- --holder
 <id>` to create one from a runner or process manager.
+If a supervisor hits lease contention or needs to inspect the current holder, use
+`pnpm agent:queue:active-dispatch -- --issue <number> --action <name>` to read
+the control-plane active pointer without mutating it. The read reports whether
+the stored pointer is still active or only an expired/terminal record.
 `CI Repair` items with failing linked PRs recommend `collect-ci` until a local
 CI repair packet exists. Ready items with `sandbox:<provider>:<id>` workspaces
 recommend `remote-bootstrap` so dispatch can clone/fetch the repository and

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1163,7 +1163,9 @@ include that event-log context when it returns dry-run lifecycle command plans.
 It also accepts non-persistent tick snapshots that match
 `agent:queue:tick -- --json`, so a future dashboard or supervisor can validate
 queue shape and recommendation counts before storage or automatic loops are
-introduced.
+introduced. The control plane also exposes a read-only active dispatch-intent
+lookup so supervisors can explain lease contention or expired active pointers
+without mutating queue state.
 
 Verification:
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "agent:queue:submit-tick": "node scripts/agent-runner-submit-tick.mjs",
     "agent:queue:plan-dispatch": "node scripts/agent-runner-plan-dispatch.mjs",
     "agent:queue:lease-dispatch": "node scripts/agent-runner-lease-dispatch.mjs",
+    "agent:queue:active-dispatch": "node scripts/agent-runner-active-dispatch.mjs",
     "agent:queue:finish-dispatch": "node scripts/agent-runner-finish-dispatch.mjs",
     "agent:queue:run-dispatch-intent": "node scripts/agent-runner-run-dispatch-intent.mjs",
     "agent:queue:control-plane-loop": "node scripts/agent-runner-control-plane-loop.mjs",

--- a/scripts/agent-runner-active-dispatch.mjs
+++ b/scripts/agent-runner-active-dispatch.mjs
@@ -1,0 +1,93 @@
+import { currentRepositoryFromOrigin, fail, parseArgs, runGit } from "./lib/agent-project-queue.mjs"
+import {
+  controlPlaneConfigFromArgs,
+  requestActiveDispatchIntent,
+} from "./lib/agent-runner-control-plane.mjs"
+import { dispatchableActions } from "./lib/agent-runner-dispatch.mjs"
+import { maybePrintHelp, repositoryOptions } from "./lib/agent-runner-help.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:active-dispatch",
+  summary: "Read the active dispatch intent for one repository, issue, and lifecycle action.",
+  usage:
+    "pnpm agent:queue:active-dispatch -- --issue <number> --action <name> [--repo <owner/name>] [--json]",
+  options: [
+    ["--control-plane-url <url>", "Control-plane base URL. Defaults to AGENT_CONTROL_PLANE_URL."],
+    ["AGENT_CONTROL_PLANE_TOKEN", "Bearer token environment variable used for API routes."],
+    ["--issue <number>", "Issue number for the active intent reference."],
+    [
+      "--action <name>",
+      `Dispatch lifecycle action. Allowed: ${Array.from(dispatchableActions).join(", ")}.`,
+    ],
+    ["--json", "Print machine-readable JSON."],
+    ...repositoryOptions,
+  ],
+})
+
+const repository =
+  args.repo ?? currentRepositoryFromOrigin(runGit(["rev-parse", "--show-toplevel"]))
+const issueNumber = requiredPositiveInteger(args.issue, "issue")
+const action = requiredAction(args.action)
+const config = readControlPlaneConfig()
+
+try {
+  const result = await requestActiveDispatchIntent({
+    request: {
+      action,
+      issueNumber,
+      repository,
+    },
+    token: config.token,
+    url: config.url,
+  })
+
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2))
+  } else {
+    printIntent({ controlPlaneUrl: config.url, result })
+  }
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error))
+}
+
+function printIntent({ controlPlaneUrl, result }) {
+  console.log("agent-runner active dispatch intent")
+  console.log(`control plane: ${controlPlaneUrl}`)
+  console.log(`repository: ${result.intent.plan.repository}`)
+  console.log(`issue: #${result.intent.plan.issue.number} ${result.intent.plan.issue.title}`)
+  console.log(`action: ${result.intent.plan.action}`)
+  console.log(`intent: ${result.intent.id}`)
+  console.log(`status: ${result.intent.status}`)
+  console.log(`active: ${result.active ? "yes" : "no"}`)
+  console.log(`holder: ${result.intent.lease.holder}`)
+  console.log(`lease expires: ${result.intent.lease.expiresAt}`)
+}
+
+function readControlPlaneConfig() {
+  try {
+    return controlPlaneConfigFromArgs(args)
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error))
+  }
+}
+
+function requiredAction(value) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    fail("missing required --action")
+  }
+
+  const action = value.trim()
+  if (!dispatchableActions.has(action)) {
+    fail(`action ${action} is not dispatchable`)
+  }
+  return action
+}
+
+function requiredPositiveInteger(value, name) {
+  const number = Number(value)
+  if (!Number.isInteger(number) || number < 1) {
+    fail(`invalid ${name}: ${value ?? ""}`)
+  }
+  return number
+}

--- a/scripts/lib/agent-runner-control-plane.mjs
+++ b/scripts/lib/agent-runner-control-plane.mjs
@@ -83,6 +83,35 @@ export async function requestLatestDispatchIntent({ fetchImpl = fetch, request, 
   return body
 }
 
+export async function requestActiveDispatchIntent({ fetchImpl = fetch, request, token, url }) {
+  const query = new URLSearchParams({
+    action: request.action,
+    issueNumber: String(request.issueNumber),
+    repository: request.repository,
+  })
+  const response = await fetchImpl(
+    `${normalizeControlPlaneUrl(url)}/api/dispatch-intents/active?${query.toString()}`,
+    {
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+      method: "GET",
+    },
+  )
+
+  const bodyText = await response.text()
+  const body = parseJsonBody(bodyText)
+
+  if (!response.ok) {
+    const detail = body?.error ? `: ${body.error}` : bodyText ? `: ${bodyText}` : ""
+    throw new Error(
+      `control plane rejected active dispatch intent read with ${response.status}${detail}`,
+    )
+  }
+
+  return body
+}
+
 export async function finishDispatchIntent({ fetchImpl = fetch, id, request, token, url }) {
   const response = await fetchImpl(
     `${normalizeControlPlaneUrl(url)}/api/dispatch-intents/${encodeURIComponent(id)}/finish`,


### PR DESCRIPTION
## Summary

- add a read-only active dispatch intent endpoint for repository/issue/action lookups
- add `pnpm agent:queue:active-dispatch` for supervisor lease debugging
- document how to inspect active or expired dispatch pointers during contention

## Validation

- `pnpm --filter @voyantjs/agent-control-plane test`
- `pnpm --filter @voyantjs/agent-control-plane typecheck`
- `pnpm --filter @voyantjs/agent-control-plane lint`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm agent:queue:active-dispatch -- --help`
- `git diff --check`
- pre-commit hook: formatting, secretlint, agent quality, repository lint, repository typecheck
- pre-push hook: `pnpm test`