### PR TITLE
feat(agent-runner): surface active lease conflicts

### DIFF
--- a/apps/agent-runner/README.md
+++ b/apps/agent-runner/README.md
@@ -21,6 +21,9 @@ provider commands, or spend model budget.
   intent from `POST /api/dispatch-intents/latest` on the control plane. When
   `AGENT_RUNNER_TICKS` is bound, the result is persisted as the latest
   supervisor tick for the repository.
+  If the control plane rejects the lease because an active intent already
+  exists, the tick result includes that active intent so operators can inspect
+  the holder and expiration from the persisted supervisor status.
 - `GET /api/supervisor/ticks/latest?repository=<owner/name>` returns the latest
   persisted supervisor tick for a repository. Requires `AGENT_RUNNER_TOKENS`
   and the `AGENT_RUNNER_TICKS` binding.

--- a/apps/agent-runner/src/runner.ts
+++ b/apps/agent-runner/src/runner.ts
@@ -164,6 +164,7 @@ export async function runSupervisorTick({
   if (!response.ok) {
     return {
       controlPlane: {
+        ...(body?.intent ? { activeIntent: body.intent } : {}),
         error: body?.error ?? bodyText,
         status: response.status,
       },

--- a/apps/agent-runner/src/supervisor-tick-conflict.test.ts
+++ b/apps/agent-runner/src/supervisor-tick-conflict.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest"
+
+import { createApp } from "./app.js"
+
+describe("agent runner supervisor tick conflicts", () => {
+  it("surfaces active control-plane lease details when a tick conflicts", async () => {
+    const app = createApp({
+      authTokens: ["token"],
+      config: {
+        controlPlaneConfigured: true,
+        controlPlaneToken: "control-token",
+        controlPlaneUrl: "https://control.example.com/",
+        enabled: true,
+        holder: "runner:cloudflare",
+        repository: "voyantjs/voyant",
+      },
+      fetchImpl: async () =>
+        new Response(
+          JSON.stringify({
+            error: "dispatch_intent_already_active",
+            intent: {
+              id: "intent_active",
+              lease: {
+                expiresAt: "2026-05-12T12:10:00.000Z",
+                holder: "runner:other",
+              },
+              plan: {
+                action: "sync-pr",
+                issue: {
+                  number: 579,
+                  title: "Test agent project intake workflow",
+                },
+              },
+              status: "leased",
+            },
+          }),
+          { status: 409 },
+        ),
+    })
+
+    const response = await app.request("/api/supervisor/ticks", {
+      body: JSON.stringify({
+        action: "sync-pr",
+        dryRun: false,
+      }),
+      headers: {
+        authorization: "Bearer token",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      result: {
+        controlPlane: {
+          activeIntent: {
+            id: "intent_active",
+            lease: {
+              expiresAt: "2026-05-12T12:10:00.000Z",
+              holder: "runner:other",
+            },
+            plan: {
+              action: "sync-pr",
+              issue: {
+                number: 579,
+              },
+            },
+          },
+          error: "dispatch_intent_already_active",
+          status: 409,
+        },
+        leased: false,
+        reason: "control_plane_rejected",
+      },
+    })
+  })
+})

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1365,7 +1365,9 @@ Verification:
   to R2 through the `AGENT_RUNNER_TICKS` binding and expose it at
   `GET /api/supervisor/ticks/latest`. This gives Cron-based deployments an
   inspectable heartbeat and last lease result without introducing a full run
-  database.
+  database. Lease-conflict ticks preserve the active intent returned by the
+  control plane so maintainers can see the holder, issue, action, and expiration
+  that blocked the run.
 - The runner app enforces a local dispatch policy before calling the control
   plane. `AGENT_RUNNER_ALLOWED_ACTIONS` limits which lifecycle actions a
   deployed runner can lease, `AGENT_RUNNER_ACTION` supplies a default action


### PR DESCRIPTION
## Summary

- preserve active dispatch intent details when the control plane rejects a runner tick for lease contention
- add focused runner coverage for conflicted supervisor ticks
- document that persisted runner tick status includes the blocking lease holder and expiration

## Validation

- `pnpm --filter @voyantjs/agent-runner test`
- `pnpm --filter @voyantjs/agent-runner typecheck`
- `pnpm --filter @voyantjs/agent-runner lint`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- pre-commit hook: formatting, secretlint, agent quality, repository lint, repository typecheck
- pre-push hook: `pnpm test`