### PR TITLE
feat(crm-ui): add commercial context tabs

### DIFF
--- a/.changeset/crm-commercial-context-tabs.md
+++ b/.changeset/crm-commercial-context-tabs.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/crm-ui": minor
+---
+
+Add optional commercial-context tab slots to CRM person and organization detail pages for bookings, invoices, payments, and contracts.

--- a/packages/crm-ui/README.md
+++ b/packages/crm-ui/README.md
@@ -31,6 +31,37 @@ Page components render with `p-6` outer padding by default and are intended to
 mount directly into an app route outlet. Pass `className` to extend or override
 that spacing when a shell owns the page chrome.
 
+### Commercial Context Slots
+
+`PersonDetailPage` and `OrganizationDetailPage` expose optional tab slots for
+commercial context owned by other modules. This keeps `@voyantjs/crm-ui` free of
+cross-package bookings, finance, and legal dependencies while giving consumers a
+standard place to mount those relationships.
+
+```tsx
+<PersonDetailPage
+  id={personId}
+  slots={{
+    bookingsTab: {
+      count: bookings.length,
+      content: <BookingsTable personId={personId} />,
+    },
+    invoicesTab: {
+      count: invoices.length,
+      content: <InvoicesTable personId={personId} />,
+    },
+    paymentsTab: {
+      count: payments.length,
+      content: <PaymentsTable personId={personId} />,
+    },
+    contractsTab: {
+      count: contracts.length,
+      content: <ContractsTable personId={personId} />,
+    },
+  }}
+/>
+```
+
 ## I18n
 
 Components render English by default. To localize them, wrap your UI in

--- a/packages/crm-ui/src/components/organization-detail-page.tsx
+++ b/packages/crm-ui/src/components/organization-detail-page.tsx
@@ -10,7 +10,7 @@ import {
 } from "@voyantjs/crm-react"
 import { Button, cn } from "@voyantjs/ui/components"
 import { Loader2 } from "lucide-react"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 import { useCrmUiMessagesOrDefault } from "../i18n/index.js"
 import {
@@ -42,6 +42,18 @@ export function OrganizationDetailPage({
   const [activeTab, setActiveTab] = useState<OrganizationDetailTab>("overview")
   const orgQuery = useOrganization(id)
   const { remove, update } = useOrganizationMutation()
+
+  useEffect(() => {
+    const activeCommercialTabIsAvailable =
+      (activeTab === "bookings" && Boolean(slots?.bookingsTab)) ||
+      (activeTab === "invoices" && Boolean(slots?.invoicesTab)) ||
+      (activeTab === "payments" && Boolean(slots?.paymentsTab)) ||
+      (activeTab === "contracts" && Boolean(slots?.contractsTab))
+
+    if (isOrganizationCommercialTab(activeTab) && !activeCommercialTabIsAvailable) {
+      setActiveTab("overview")
+    }
+  }, [activeTab, slots?.bookingsTab, slots?.invoicesTab, slots?.paymentsTab, slots?.contractsTab])
 
   const updateField = async (patch: UpdateOrganizationInput) => {
     await update.mutateAsync({ id, input: patch })
@@ -135,4 +147,10 @@ export function OrganizationDetailPage({
       </div>
     </div>
   )
+}
+
+function isOrganizationCommercialTab(
+  tab: OrganizationDetailTab,
+): tab is "bookings" | "invoices" | "payments" | "contracts" {
+  return tab === "bookings" || tab === "invoices" || tab === "payments" || tab === "contracts"
 }

--- a/packages/crm-ui/src/components/organization-detail-page.tsx
+++ b/packages/crm-ui/src/components/organization-detail-page.tsx
@@ -14,6 +14,7 @@ import { useState } from "react"
 
 import { useCrmUiMessagesOrDefault } from "../i18n/index.js"
 import {
+  type OrganizationDetailPageSlots,
   type OrganizationDetailTab,
   OrganizationMain,
   OrganizationSidebar,
@@ -26,6 +27,7 @@ export interface OrganizationDetailPageProps {
   onBack?: () => void
   onDeleted?: () => void
   onPersonOpen?: (personId: string) => void
+  slots?: OrganizationDetailPageSlots
 }
 
 export function OrganizationDetailPage({
@@ -34,6 +36,7 @@ export function OrganizationDetailPage({
   onBack,
   onDeleted,
   onPersonOpen,
+  slots,
 }: OrganizationDetailPageProps) {
   const messages = useCrmUiMessagesOrDefault()
   const [activeTab, setActiveTab] = useState<OrganizationDetailTab>("overview")
@@ -107,9 +110,12 @@ export function OrganizationDetailPage({
           onBack?.()
         }}
       />
+      {slots?.afterTopBar}
 
       <div className="grid flex-1 grid-cols-12 gap-4 p-4 lg:p-6">
-        <OrganizationSidebar org={org} websiteHref={websiteHref} onUpdateField={updateField} />
+        <OrganizationSidebar org={org} websiteHref={websiteHref} onUpdateField={updateField}>
+          {slots?.sidebarEnd}
+        </OrganizationSidebar>
         <OrganizationMain
           activeTab={activeTab}
           setActiveTab={setActiveTab}
@@ -124,6 +130,7 @@ export function OrganizationDetailPage({
           primaryCurrency={primaryCurrency}
           onOpenPerson={(personId) => onPersonOpen?.(personId)}
           onUpdateField={updateField}
+          slots={slots}
         />
       </div>
     </div>

--- a/packages/crm-ui/src/components/organization-detail-sections.tsx
+++ b/packages/crm-ui/src/components/organization-detail-sections.tsx
@@ -34,6 +34,7 @@ import {
   TrendingUp,
   Users,
 } from "lucide-react"
+import type { ReactNode } from "react"
 
 import { useCrmUiI18nOrDefault, useCrmUiMessagesOrDefault } from "../i18n/index.js"
 import { formatCrmDate, formatCrmMoney, formatCrmRelative } from "./crm-format.js"
@@ -44,7 +45,15 @@ import { InlineNumberField } from "./inline-number-field.js"
 import { InlineSelectField } from "./inline-select-field.js"
 import { TagsEditor } from "./tags-editor.js"
 
-export type OrganizationDetailTab = "overview" | "people" | "opportunities" | "activities"
+export type OrganizationDetailTab =
+  | "overview"
+  | "people"
+  | "opportunities"
+  | "activities"
+  | "bookings"
+  | "invoices"
+  | "payments"
+  | "contracts"
 
 export type OrganizationData = Pick<
   OrganizationRecord,
@@ -84,6 +93,25 @@ export type OrganizationActivity = Pick<
   ActivityRecord,
   "createdAt" | "description" | "dueAt" | "id" | "status" | "subject" | "type" | "updatedAt"
 >
+
+export interface OrganizationCommercialContextTabSlot {
+  label?: string
+  count?: number
+  content: ReactNode
+}
+
+export interface OrganizationDetailPageSlots {
+  afterTopBar?: ReactNode
+  sidebarEnd?: ReactNode
+  overviewEnd?: ReactNode
+  peopleEnd?: ReactNode
+  opportunitiesEnd?: ReactNode
+  activitiesEnd?: ReactNode
+  bookingsTab?: OrganizationCommercialContextTabSlot
+  invoicesTab?: OrganizationCommercialContextTabSlot
+  paymentsTab?: OrganizationCommercialContextTabSlot
+  contractsTab?: OrganizationCommercialContextTabSlot
+}
 
 export interface OrganizationTopBarProps {
   orgName: string
@@ -132,9 +160,15 @@ export interface OrganizationSidebarProps {
   org: OrganizationData
   websiteHref?: string
   onUpdateField: (patch: UpdateOrganizationInput) => Promise<void>
+  children?: ReactNode
 }
 
-export function OrganizationSidebar({ org, websiteHref, onUpdateField }: OrganizationSidebarProps) {
+export function OrganizationSidebar({
+  org,
+  websiteHref,
+  onUpdateField,
+  children,
+}: OrganizationSidebarProps) {
   const messages = useCrmUiMessagesOrDefault()
   const relationOptions = [
     { value: "client", label: messages.common.relationTypeLabels.client },
@@ -271,6 +305,8 @@ export function OrganizationSidebar({ org, websiteHref, onUpdateField }: Organiz
           <TagsEditor tags={org.tags} onChange={(tags) => onUpdateField({ tags })} />
         </CardContent>
       </Card>
+
+      {children}
     </aside>
   )
 }
@@ -289,6 +325,7 @@ export interface OrganizationMainProps {
   primaryCurrency: string | null
   onOpenPerson: (id: string) => void
   onUpdateField: (patch: UpdateOrganizationInput) => Promise<void>
+  slots?: OrganizationDetailPageSlots
 }
 
 export function OrganizationMain({
@@ -305,6 +342,7 @@ export function OrganizationMain({
   primaryCurrency,
   onOpenPerson,
   onUpdateField,
+  slots,
 }: OrganizationMainProps) {
   const i18n = useCrmUiI18nOrDefault()
   const messages = useCrmUiMessagesOrDefault()
@@ -356,7 +394,7 @@ export function OrganizationMain({
           onValueChange={(value) => setActiveTab(value as OrganizationDetailTab)}
         >
           <CardHeader className="pb-0">
-            <TabsList>
+            <TabsList className="h-auto flex-wrap justify-start">
               <TabsTrigger value="overview">
                 {messages.organizationDetail.tabs.overview}
               </TabsTrigger>
@@ -369,6 +407,26 @@ export function OrganizationMain({
               <TabsTrigger value="activities">
                 {messages.organizationDetail.tabs.activities} ({activities.length})
               </TabsTrigger>
+              {slots?.bookingsTab ? (
+                <TabsTrigger value="bookings">
+                  {formatTabLabel(messages.organizationDetail.tabs.bookings, slots.bookingsTab)}
+                </TabsTrigger>
+              ) : null}
+              {slots?.invoicesTab ? (
+                <TabsTrigger value="invoices">
+                  {formatTabLabel(messages.organizationDetail.tabs.invoices, slots.invoicesTab)}
+                </TabsTrigger>
+              ) : null}
+              {slots?.paymentsTab ? (
+                <TabsTrigger value="payments">
+                  {formatTabLabel(messages.organizationDetail.tabs.payments, slots.paymentsTab)}
+                </TabsTrigger>
+              ) : null}
+              {slots?.contractsTab ? (
+                <TabsTrigger value="contracts">
+                  {formatTabLabel(messages.organizationDetail.tabs.contracts, slots.contractsTab)}
+                </TabsTrigger>
+              ) : null}
             </TabsList>
           </CardHeader>
           <CardContent className="pt-4">
@@ -402,6 +460,7 @@ export function OrganizationMain({
                 value={org.notes}
                 onSave={(next) => onUpdateField({ notes: next })}
               />
+              {slots?.overviewEnd}
             </TabsContent>
 
             <TabsContent value="people" className="m-0">
@@ -450,6 +509,7 @@ export function OrganizationMain({
                   })}
                 </ul>
               )}
+              {slots?.peopleEnd}
             </TabsContent>
 
             <TabsContent value="opportunities" className="m-0">
@@ -495,6 +555,7 @@ export function OrganizationMain({
                   })}
                 </ul>
               )}
+              {slots?.opportunitiesEnd}
             </TabsContent>
 
             <TabsContent value="activities" className="m-0">
@@ -535,7 +596,28 @@ export function OrganizationMain({
                   ))}
                 </ul>
               )}
+              {slots?.activitiesEnd}
             </TabsContent>
+            {slots?.bookingsTab ? (
+              <TabsContent value="bookings" className="m-0">
+                {slots.bookingsTab.content}
+              </TabsContent>
+            ) : null}
+            {slots?.invoicesTab ? (
+              <TabsContent value="invoices" className="m-0">
+                {slots.invoicesTab.content}
+              </TabsContent>
+            ) : null}
+            {slots?.paymentsTab ? (
+              <TabsContent value="payments" className="m-0">
+                {slots.paymentsTab.content}
+              </TabsContent>
+            ) : null}
+            {slots?.contractsTab ? (
+              <TabsContent value="contracts" className="m-0">
+                {slots.contractsTab.content}
+              </TabsContent>
+            ) : null}
           </CardContent>
         </Tabs>
       </Card>
@@ -546,6 +628,14 @@ export function OrganizationMain({
       </div>
     </main>
   )
+}
+
+function formatTabLabel(
+  defaultLabel: string,
+  slot: OrganizationCommercialContextTabSlot,
+): ReactNode {
+  const label = slot.label ?? defaultLabel
+  return typeof slot.count === "number" ? `${label} (${slot.count})` : label
 }
 
 export function initialsFrom(name: string): string {

--- a/packages/crm-ui/src/components/person-detail-page.tsx
+++ b/packages/crm-ui/src/components/person-detail-page.tsx
@@ -53,7 +53,7 @@ import {
   User,
   Users,
 } from "lucide-react"
-import { type ReactNode, useMemo, useState } from "react"
+import { type ReactNode, useEffect, useMemo, useState } from "react"
 
 import { useCrmUiI18nOrDefault, useCrmUiMessagesOrDefault } from "../i18n/index.js"
 import { formatCrmDate, formatCrmMoney, formatCrmRelative } from "./crm-format.js"
@@ -188,6 +188,18 @@ export function PersonDetailPage({
   const personQuery = usePerson(id)
   const { remove, update } = usePersonMutation()
   const person = personQuery.data
+
+  useEffect(() => {
+    const activeCommercialTabIsAvailable =
+      (activeTab === "bookings" && Boolean(slots?.bookingsTab)) ||
+      (activeTab === "invoices" && Boolean(slots?.invoicesTab)) ||
+      (activeTab === "payments" && Boolean(slots?.paymentsTab)) ||
+      (activeTab === "contracts" && Boolean(slots?.contractsTab))
+
+    if (isPersonCommercialTab(activeTab) && !activeCommercialTabIsAvailable) {
+      setActiveTab("overview")
+    }
+  }, [activeTab, slots?.bookingsTab, slots?.invoicesTab, slots?.paymentsTab, slots?.contractsTab])
 
   const organizationQuery = useOrganization(person?.organizationId ?? undefined, {
     enabled: Boolean(person?.organizationId),
@@ -720,6 +732,12 @@ export function PersonMain({
 function formatTabLabel(defaultLabel: string, slot: PersonCommercialContextTabSlot): ReactNode {
   const label = slot.label ?? defaultLabel
   return typeof slot.count === "number" ? `${label} (${slot.count})` : label
+}
+
+function isPersonCommercialTab(
+  tab: PersonDetailTab,
+): tab is "bookings" | "invoices" | "payments" | "contracts" {
+  return tab === "bookings" || tab === "invoices" || tab === "payments" || tab === "contracts"
 }
 
 export interface MetricCardProps {

--- a/packages/crm-ui/src/components/person-detail-page.tsx
+++ b/packages/crm-ui/src/components/person-detail-page.tsx
@@ -70,6 +70,10 @@ export type PersonDetailTab =
   | "activities"
   | "relationships"
   | "documents"
+  | "bookings"
+  | "invoices"
+  | "payments"
+  | "contracts"
 
 export type PersonData = Pick<
   PersonRecord,
@@ -141,6 +145,12 @@ export type PersonDocument = Pick<
 
 export type PersonTravelSnapshot = PersonTravelSnapshotRecord
 
+export interface PersonCommercialContextTabSlot {
+  label?: string
+  count?: number
+  content: ReactNode
+}
+
 export interface PersonDetailPageSlots {
   afterTopBar?: ReactNode
   sidebarEnd?: ReactNode
@@ -149,6 +159,10 @@ export interface PersonDetailPageSlots {
   activitiesEnd?: ReactNode
   relationshipsEnd?: ReactNode
   documentsEnd?: ReactNode
+  bookingsTab?: PersonCommercialContextTabSlot
+  invoicesTab?: PersonCommercialContextTabSlot
+  paymentsTab?: PersonCommercialContextTabSlot
+  contractsTab?: PersonCommercialContextTabSlot
 }
 
 export interface PersonDetailPageProps {
@@ -594,7 +608,7 @@ export function PersonMain({
       <Card>
         <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as PersonDetailTab)}>
           <CardHeader className="pb-0">
-            <TabsList>
+            <TabsList className="h-auto flex-wrap justify-start">
               <TabsTrigger value="overview">{messages.personDetail.tabs.overview}</TabsTrigger>
               <TabsTrigger value="opportunities">
                 {messages.personDetail.tabs.opportunities} ({opportunities.length})
@@ -608,6 +622,26 @@ export function PersonMain({
               <TabsTrigger value="documents">
                 {messages.personDetail.tabs.documents} ({documents.length})
               </TabsTrigger>
+              {slots?.bookingsTab ? (
+                <TabsTrigger value="bookings">
+                  {formatTabLabel(messages.personDetail.tabs.bookings, slots.bookingsTab)}
+                </TabsTrigger>
+              ) : null}
+              {slots?.invoicesTab ? (
+                <TabsTrigger value="invoices">
+                  {formatTabLabel(messages.personDetail.tabs.invoices, slots.invoicesTab)}
+                </TabsTrigger>
+              ) : null}
+              {slots?.paymentsTab ? (
+                <TabsTrigger value="payments">
+                  {formatTabLabel(messages.personDetail.tabs.payments, slots.paymentsTab)}
+                </TabsTrigger>
+              ) : null}
+              {slots?.contractsTab ? (
+                <TabsTrigger value="contracts">
+                  {formatTabLabel(messages.personDetail.tabs.contracts, slots.contractsTab)}
+                </TabsTrigger>
+              ) : null}
             </TabsList>
           </CardHeader>
           <CardContent className="pt-4">
@@ -651,6 +685,26 @@ export function PersonMain({
               />
               {slots?.documentsEnd}
             </TabsContent>
+            {slots?.bookingsTab ? (
+              <TabsContent value="bookings" className="m-0">
+                {slots.bookingsTab.content}
+              </TabsContent>
+            ) : null}
+            {slots?.invoicesTab ? (
+              <TabsContent value="invoices" className="m-0">
+                {slots.invoicesTab.content}
+              </TabsContent>
+            ) : null}
+            {slots?.paymentsTab ? (
+              <TabsContent value="payments" className="m-0">
+                {slots.paymentsTab.content}
+              </TabsContent>
+            ) : null}
+            {slots?.contractsTab ? (
+              <TabsContent value="contracts" className="m-0">
+                {slots.contractsTab.content}
+              </TabsContent>
+            ) : null}
           </CardContent>
         </Tabs>
       </Card>
@@ -661,6 +715,11 @@ export function PersonMain({
       </div>
     </main>
   )
+}
+
+function formatTabLabel(defaultLabel: string, slot: PersonCommercialContextTabSlot): ReactNode {
+  const label = slot.label ?? defaultLabel
+  return typeof slot.count === "number" ? `${label} (${slot.count})` : label
 }
 
 export interface MetricCardProps {

--- a/packages/crm-ui/src/i18n/en.ts
+++ b/packages/crm-ui/src/i18n/en.ts
@@ -277,6 +277,10 @@ export const crmUiEn = {
       people: "People",
       opportunities: "Opportunities",
       activities: "Activities",
+      bookings: "Bookings",
+      invoices: "Invoices",
+      payments: "Payments",
+      contracts: "Contracts",
     },
     sections: {
       created: "Created",
@@ -335,6 +339,10 @@ export const crmUiEn = {
       activities: "Activities",
       relationships: "Relationships",
       documents: "Documents",
+      bookings: "Bookings",
+      invoices: "Invoices",
+      payments: "Payments",
+      contracts: "Contracts",
     },
     sections: {
       created: "Created",

--- a/packages/crm-ui/src/i18n/messages.ts
+++ b/packages/crm-ui/src/i18n/messages.ts
@@ -259,6 +259,10 @@ export type CrmUiMessages = {
       people: string
       opportunities: string
       activities: string
+      bookings: string
+      invoices: string
+      payments: string
+      contracts: string
     }
     sections: {
       created: string
@@ -316,6 +320,10 @@ export type CrmUiMessages = {
       activities: string
       relationships: string
       documents: string
+      bookings: string
+      invoices: string
+      payments: string
+      contracts: string
     }
     sections: {
       created: string

--- a/packages/crm-ui/src/i18n/ro.ts
+++ b/packages/crm-ui/src/i18n/ro.ts
@@ -277,6 +277,10 @@ export const crmUiRo = {
       people: "Persoane",
       opportunities: "Oportunitati",
       activities: "Activitati",
+      bookings: "Rezervari",
+      invoices: "Facturi",
+      payments: "Plati",
+      contracts: "Contracte",
     },
     sections: {
       created: "Creat",
@@ -335,6 +339,10 @@ export const crmUiRo = {
       activities: "Activitati",
       relationships: "Relatii",
       documents: "Documente",
+      bookings: "Rezervari",
+      invoices: "Facturi",
+      payments: "Plati",
+      contracts: "Contracte",
     },
     sections: {
       created: "Creat",

--- a/packages/crm-ui/src/index.ts
+++ b/packages/crm-ui/src/index.ts
@@ -24,7 +24,9 @@ export {
 export {
   initialsFrom,
   type OrganizationActivity,
+  type OrganizationCommercialContextTabSlot,
   type OrganizationData,
+  type OrganizationDetailPageSlots,
   type OrganizationDetailTab,
   OrganizationMain,
   type OrganizationMainProps,
@@ -72,6 +74,7 @@ export {
   PersonActivitiesPanel,
   type PersonActivitiesPanelProps,
   type PersonActivity,
+  type PersonCommercialContextTabSlot,
   type PersonData,
   PersonDetailPage,
   type PersonDetailPageProps,


### PR DESCRIPTION
## Summary
- add optional Bookings, Invoices, Payments, and Contracts tab slots to `PersonDetailPage`
- add the same commercial-context slot surface to `OrganizationDetailPage`, including sidebar/top-bar/existing-tab extension points
- add localized default labels, public type exports, README usage docs, and a changeset

## Why
CRM detail pages need a standard place to surface commercial relationships without making `@voyantjs/crm-ui` depend directly on bookings, finance, or legal packages.

## Verification
- pnpm --filter @voyantjs/crm-ui lint
- pnpm --filter @voyantjs/crm-ui typecheck
- pnpm --filter @voyantjs/crm-ui build
- pnpm --filter @voyantjs/crm-ui test
- pnpm verify:fast
- pre-push full cached test lane passed

## Notes
`pnpm verify:fast` passed. The report-only agent-quality check flags the pre-existing file sizes of `person-detail-page.tsx` and `organization-detail-sections.tsx` because this PR touches them; splitting those mature detail pages is intentionally left out of this focused API change.

Closes #659