### PR TITLE
feat(agent-runner): preserve control plane error details

### DIFF
--- a/scripts/lib/agent-runner-control-plane.mjs
+++ b/scripts/lib/agent-runner-control-plane.mjs
@@ -1,3 +1,14 @@
+export class ControlPlaneRequestError extends Error {
+  constructor({ body, endpoint, responseText, status }) {
+    super(formatControlPlaneError({ body, endpoint, responseText, status }))
+    this.name = "ControlPlaneRequestError"
+    this.body = body
+    this.endpoint = endpoint
+    this.responseText = responseText
+    this.status = status
+  }
+}
+
 export function controlPlaneConfigFromArgs(args, env = process.env) {
   const url = args.controlPlaneUrl ?? env.AGENT_CONTROL_PLANE_URL
   const token = env.AGENT_CONTROL_PLANE_TOKEN
@@ -32,8 +43,12 @@ export async function submitTickSnapshot({ fetchImpl = fetch, snapshot, token, u
   const body = parseJsonBody(bodyText)
 
   if (!response.ok) {
-    const detail = body?.error ? `: ${body.error}` : bodyText ? `: ${bodyText}` : ""
-    throw new Error(`control plane rejected tick snapshot with ${response.status}${detail}`)
+    throw new ControlPlaneRequestError({
+      body,
+      endpoint: "tick snapshot",
+      responseText: bodyText,
+      status: response.status,
+    })
   }
 
   return body
@@ -53,8 +68,12 @@ export async function requestLatestDispatchPlan({ fetchImpl = fetch, request, to
   const body = parseJsonBody(bodyText)
 
   if (!response.ok) {
-    const detail = body?.error ? `: ${body.error}` : bodyText ? `: ${bodyText}` : ""
-    throw new Error(`control plane rejected latest dispatch plan with ${response.status}${detail}`)
+    throw new ControlPlaneRequestError({
+      body,
+      endpoint: "latest dispatch plan",
+      responseText: bodyText,
+      status: response.status,
+    })
   }
 
   return body
@@ -74,10 +93,12 @@ export async function requestLatestDispatchIntent({ fetchImpl = fetch, request, 
   const body = parseJsonBody(bodyText)
 
   if (!response.ok) {
-    const detail = body?.error ? `: ${body.error}` : bodyText ? `: ${bodyText}` : ""
-    throw new Error(
-      `control plane rejected latest dispatch intent with ${response.status}${detail}`,
-    )
+    throw new ControlPlaneRequestError({
+      body,
+      endpoint: "latest dispatch intent",
+      responseText: bodyText,
+      status: response.status,
+    })
   }
 
   return body
@@ -103,10 +124,12 @@ export async function requestActiveDispatchIntent({ fetchImpl = fetch, request, 
   const body = parseJsonBody(bodyText)
 
   if (!response.ok) {
-    const detail = body?.error ? `: ${body.error}` : bodyText ? `: ${bodyText}` : ""
-    throw new Error(
-      `control plane rejected active dispatch intent read with ${response.status}${detail}`,
-    )
+    throw new ControlPlaneRequestError({
+      body,
+      endpoint: "active dispatch intent read",
+      responseText: bodyText,
+      status: response.status,
+    })
   }
 
   return body
@@ -129,10 +152,12 @@ export async function finishDispatchIntent({ fetchImpl = fetch, id, request, tok
   const body = parseJsonBody(bodyText)
 
   if (!response.ok) {
-    const detail = body?.error ? `: ${body.error}` : bodyText ? `: ${bodyText}` : ""
-    throw new Error(
-      `control plane rejected dispatch intent finish with ${response.status}${detail}`,
-    )
+    throw new ControlPlaneRequestError({
+      body,
+      endpoint: "dispatch intent finish",
+      responseText: bodyText,
+      status: response.status,
+    })
   }
 
   return body
@@ -150,4 +175,26 @@ function parseJsonBody(bodyText) {
   } catch {
     return null
   }
+}
+
+function formatControlPlaneError({ body, endpoint, responseText, status }) {
+  const detail = body?.error ? `: ${body.error}` : responseText ? `: ${responseText}` : ""
+  return `control plane rejected ${endpoint} with ${status}${detail}${formatActiveIntentDetail(body)}`
+}
+
+function formatActiveIntentDetail(body) {
+  const intent = body?.intent
+  if (!intent || typeof intent !== "object") return ""
+
+  const id = typeof intent.id === "string" ? intent.id : undefined
+  const holder = typeof intent.lease?.holder === "string" ? intent.lease.holder : undefined
+  const expiresAt = typeof intent.lease?.expiresAt === "string" ? intent.lease.expiresAt : undefined
+
+  const parts = [
+    id ? `id=${id}` : undefined,
+    holder ? `holder=${holder}` : undefined,
+    expiresAt ? `expiresAt=${expiresAt}` : undefined,
+  ].filter(Boolean)
+
+  return parts.length > 0 ? ` (${parts.join(", ")})` : ""
 }

--- a/scripts/tests/agent-runner-control-plane.test.mjs
+++ b/scripts/tests/agent-runner-control-plane.test.mjs
@@ -2,8 +2,10 @@ import assert from "node:assert/strict"
 import { describe, it } from "node:test"
 
 import {
+  ControlPlaneRequestError,
   controlPlaneConfigFromArgs,
   finishDispatchIntent,
+  requestActiveDispatchIntent,
   requestLatestDispatchIntent,
   requestLatestDispatchPlan,
   submitTickSnapshot,
@@ -262,9 +264,21 @@ describe("agent runner control plane client", () => {
     await assert.rejects(
       requestLatestDispatchIntent({
         fetchImpl: async () =>
-          new Response(JSON.stringify({ error: "dispatch_intent_already_active" }), {
-            status: 409,
-          }),
+          new Response(
+            JSON.stringify({
+              error: "dispatch_intent_already_active",
+              intent: {
+                id: "intent_579",
+                lease: {
+                  expiresAt: "2026-05-12T12:15:00.000Z",
+                  holder: "supervisor:other",
+                },
+              },
+            }),
+            {
+              status: 409,
+            },
+          ),
         request: {
           lease: { holder: "supervisor:test" },
           repository: "voyantjs/voyant",
@@ -272,7 +286,72 @@ describe("agent runner control plane client", () => {
         token: "tok",
         url: "https://control.example.com",
       }),
-      /409: dispatch_intent_already_active/,
+      (error) => {
+        assert.ok(error instanceof ControlPlaneRequestError)
+        assert.equal(error.status, 409)
+        assert.equal(error.body.intent.id, "intent_579")
+        assert.match(error.message, /409: dispatch_intent_already_active/)
+        assert.match(error.message, /id=intent_579/)
+        assert.match(error.message, /holder=supervisor:other/)
+        assert.match(error.message, /expiresAt=2026-05-12T12:15:00.000Z/)
+        return true
+      },
+    )
+  })
+
+  it("reads active dispatch intents", async () => {
+    const calls = []
+    const response = await requestActiveDispatchIntent({
+      fetchImpl: async (url, init) => {
+        calls.push({ init, url })
+        return new Response(
+          JSON.stringify({
+            intent: {
+              id: "intent_579",
+              lease: {
+                holder: "supervisor:test",
+              },
+              status: "leased",
+            },
+            reason: "active",
+          }),
+          { status: 200 },
+        )
+      },
+      request: {
+        action: "remote-bootstrap",
+        issueNumber: 579,
+        repository: "voyantjs/voyant",
+      },
+      token: "tok",
+      url: "https://control.example.com/",
+    })
+
+    assert.equal(response.intent.id, "intent_579")
+    assert.equal(
+      calls[0].url,
+      "https://control.example.com/api/dispatch-intents/active?action=remote-bootstrap&issueNumber=579&repository=voyantjs%2Fvoyant",
+    )
+    assert.equal(calls[0].init.method, "GET")
+    assert.equal(calls[0].init.headers.authorization, "Bearer tok")
+  })
+
+  it("surfaces rejected active dispatch intent reads", async () => {
+    await assert.rejects(
+      requestActiveDispatchIntent({
+        fetchImpl: async () =>
+          new Response(JSON.stringify({ error: "invalid_active_dispatch_intent_request" }), {
+            status: 400,
+          }),
+        request: {
+          action: "remote-bootstrap",
+          issueNumber: 579,
+          repository: "voyantjs/voyant",
+        },
+        token: "tok",
+        url: "https://control.example.com",
+      }),
+      /400: invalid_active_dispatch_intent_request/,
     )
   })
 


### PR DESCRIPTION
## Summary
- add a typed control-plane request error for script-side API calls
- keep parsed response bodies and raw text on rejected control-plane responses
- include active dispatch lease details in conflict messages and cover active-dispatch reads

## Verification
- node --test scripts/tests/agent-runner-control-plane.test.mjs
- pnpm exec biome check scripts/lib/agent-runner-control-plane.mjs scripts/tests/agent-runner-control-plane.test.mjs
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- pnpm agent:queue:test
- git diff --check
- pre-commit hook
- pre-push hook