### PR TITLE
feat(agent-runner): add deployment diagnostics

### DIFF
--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -129,6 +129,19 @@ AGENT_CONTROL_PLANE_TOKEN=... \
 pnpm agent:queue:active-dispatch -- --repo voyantjs/voyant --issue 579 --action remote-bootstrap
 ```
 
+Validate deployed control-plane and runner capabilities before enabling Cron:
+
+```bash
+AGENT_CONTROL_PLANE_URL=https://agent-control-plane.example.workers.dev \
+AGENT_CONTROL_PLANE_TOKEN=... \
+AGENT_RUNNER_URL=https://agent-runner.example.workers.dev \
+AGENT_RUNNER_TOKEN=... \
+pnpm agent:queue:deployment-doctor -- --json
+```
+
+The doctor calls both `/api/capabilities` endpoints and reports persistence and
+execution mode without printing token values.
+
 Finish the leased dispatch intent after the runner has handled the printed
 command:
 

--- a/apps/agent-runner/README.md
+++ b/apps/agent-runner/README.md
@@ -50,3 +50,14 @@ Cron triggers should stay disabled until queue snapshots and control-plane
 dispatch intent storage are configured. Keep provider execution outside this
 Worker unless a later design adds explicit budget controls, sandbox policy, and
 task-scoped credentials.
+
+Before enabling Cron, validate the deployed control plane and runner app from
+the repository checkout:
+
+```bash
+pnpm agent:queue:deployment-doctor -- --json
+```
+
+The command reads `AGENT_CONTROL_PLANE_URL`, `AGENT_CONTROL_PLANE_TOKEN`,
+`AGENT_RUNNER_URL`, and `AGENT_RUNNER_TOKEN`, calls both capability endpoints,
+and reports persistence and execution mode without printing token values.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -412,6 +412,12 @@ If a supervisor hits lease contention or needs to inspect the current holder, us
 `pnpm agent:queue:active-dispatch -- --issue <number> --action <name>` to read
 the control-plane active pointer without mutating it. The read reports whether
 the stored pointer is still active or only an expired/terminal record.
+Before enabling a deployed control plane or scheduled runner, run
+`pnpm agent:queue:deployment-doctor -- --json` from the repository checkout.
+It reads `AGENT_CONTROL_PLANE_URL`, `AGENT_CONTROL_PLANE_TOKEN`,
+`AGENT_RUNNER_URL`, and `AGENT_RUNNER_TOKEN`, calls both `/api/capabilities`
+endpoints, and reports persistence and execution mode without printing token
+values.
 `CI Repair` items with failing linked PRs recommend `collect-ci` until a local
 CI repair packet exists. Ready items with `sandbox:<provider>:<id>` workspaces
 recommend `remote-bootstrap` so dispatch can clone/fetch the repository and

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1375,6 +1375,10 @@ Verification:
   If the action allow-list is narrower than the full lifecycle set, the runner
   refuses unfiltered ticks so the control plane cannot choose a different
   queued action.
+- Deployed control-plane and runner setup should be checked with
+  `pnpm agent:queue:deployment-doctor` before enabling Cron. The command calls
+  both capability endpoints, verifies auth reaches the deployed apps, and
+  reports persistence and execution mode without printing bearer tokens.
 
 ## Open Questions
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "verify:fast": "pnpm lint:changed && pnpm verify:agent-quality:changed && pnpm verify:ui-components-barrel && pnpm verify:native-date-inputs && pnpm verify:raw-minor-unit-labels && pnpm typecheck:affected && pnpm test:affected && pnpm verify:architecture",
     "verify:full": "pnpm lint && pnpm verify:agent-quality && pnpm verify:ui-components-barrel && pnpm verify:native-date-inputs && pnpm verify:raw-minor-unit-labels && pnpm typecheck && pnpm test && pnpm verify:architecture && pnpm build && pnpm verify:package-exports && pnpm verify:publish-tarballs && pnpm i18n:check",
     "agent:queue:doctor": "node scripts/agent-runner-doctor.mjs",
+    "agent:queue:deployment-doctor": "node scripts/agent-runner-deployment-doctor.mjs",
     "agent:queue:dry-run": "node scripts/agent-runner-dry-run.mjs",
     "agent:queue:events": "node scripts/agent-runner-events.mjs",
     "agent:queue:status": "node scripts/agent-runner-status.mjs",

--- a/scripts/agent-runner-deployment-doctor.mjs
+++ b/scripts/agent-runner-deployment-doctor.mjs
@@ -1,0 +1,121 @@
+import { parseArgs } from "./lib/agent-project-queue.mjs"
+import {
+  controlPlaneConfigFromArgs,
+  requestControlPlaneCapabilities,
+} from "./lib/agent-runner-control-plane.mjs"
+import {
+  requestRunnerAppCapabilities,
+  runnerAppConfigFromArgs,
+  summarizeControlPlaneCapabilities,
+  summarizeRunnerAppCapabilities,
+} from "./lib/agent-runner-deployment-doctor.mjs"
+import { maybePrintHelp } from "./lib/agent-runner-help.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:deployment-doctor",
+  summary: "Check deployed control-plane and runner app capability endpoints.",
+  usage: "pnpm agent:queue:deployment-doctor -- [--json]",
+  options: [
+    ["--control-plane-url <url>", "Control-plane base URL. Defaults to AGENT_CONTROL_PLANE_URL."],
+    ["AGENT_CONTROL_PLANE_TOKEN", "Bearer token environment variable used for control-plane APIs."],
+    ["--runner-url <url>", "Runner app base URL. Defaults to AGENT_RUNNER_URL."],
+    ["--runner-token <token>", "Runner app bearer token. Defaults to AGENT_RUNNER_TOKEN."],
+    ["--json", "Print machine-readable JSON."],
+  ],
+})
+
+const checks = []
+
+await checkControlPlane()
+await checkRunnerApp()
+
+const ok = checks.every((check) => check.ok)
+if (args.json) {
+  console.log(JSON.stringify({ checks, ok }, null, 2))
+} else {
+  printHumanSummary({ checks, ok })
+}
+
+process.exitCode = ok ? 0 : 1
+
+async function checkControlPlane() {
+  let config
+  try {
+    config = controlPlaneConfigFromArgs(args)
+  } catch (error) {
+    record({
+      detail: error instanceof Error ? error.message : String(error),
+      name: "control plane configuration",
+      ok: false,
+    })
+    return
+  }
+
+  record({
+    detail: `Using ${config.url}; token configured.`,
+    name: "control plane configuration",
+    ok: true,
+  })
+
+  try {
+    const capabilities = await requestControlPlaneCapabilities(config)
+    record({
+      name: "control plane capabilities",
+      ...summarizeControlPlaneCapabilities(capabilities),
+    })
+  } catch (error) {
+    record({
+      detail: error instanceof Error ? error.message : String(error),
+      name: "control plane capabilities",
+      ok: false,
+    })
+  }
+}
+
+async function checkRunnerApp() {
+  let config
+  try {
+    config = runnerAppConfigFromArgs(args)
+  } catch (error) {
+    record({
+      detail: error instanceof Error ? error.message : String(error),
+      name: "runner app configuration",
+      ok: false,
+    })
+    return
+  }
+
+  record({
+    detail: `Using ${config.url}; token configured.`,
+    name: "runner app configuration",
+    ok: true,
+  })
+
+  try {
+    const capabilities = await requestRunnerAppCapabilities(config)
+    record({
+      name: "runner app capabilities",
+      ...summarizeRunnerAppCapabilities(capabilities),
+    })
+  } catch (error) {
+    record({
+      detail: error instanceof Error ? error.message : String(error),
+      name: "runner app capabilities",
+      ok: false,
+    })
+  }
+}
+
+function record(check) {
+  checks.push(check)
+}
+
+function printHumanSummary({ checks, ok }) {
+  console.log(`agent-runner deployment doctor: ${ok ? "OK" : "FAILED"}`)
+  console.log("")
+  for (const check of checks) {
+    console.log(`${check.ok ? "OK" : "FAIL"} ${check.name}`)
+    console.log(`  ${check.detail}`)
+  }
+}

--- a/scripts/lib/agent-runner-control-plane.mjs
+++ b/scripts/lib/agent-runner-control-plane.mjs
@@ -79,6 +79,29 @@ export async function requestLatestDispatchPlan({ fetchImpl = fetch, request, to
   return body
 }
 
+export async function requestControlPlaneCapabilities({ fetchImpl = fetch, token, url }) {
+  const response = await fetchImpl(`${normalizeControlPlaneUrl(url)}/api/capabilities`, {
+    headers: {
+      authorization: `Bearer ${token}`,
+    },
+    method: "GET",
+  })
+
+  const bodyText = await response.text()
+  const body = parseJsonBody(bodyText)
+
+  if (!response.ok) {
+    throw new ControlPlaneRequestError({
+      body,
+      endpoint: "capabilities",
+      responseText: bodyText,
+      status: response.status,
+    })
+  }
+
+  return body
+}
+
 export async function requestLatestDispatchIntent({ fetchImpl = fetch, request, token, url }) {
   const response = await fetchImpl(`${normalizeControlPlaneUrl(url)}/api/dispatch-intents/latest`, {
     body: JSON.stringify(request),

--- a/scripts/lib/agent-runner-deployment-doctor.mjs
+++ b/scripts/lib/agent-runner-deployment-doctor.mjs
@@ -1,0 +1,77 @@
+export function runnerAppConfigFromArgs(args, env = process.env) {
+  const url = args.runnerUrl ?? env.AGENT_RUNNER_URL
+  const token = args.runnerToken ?? env.AGENT_RUNNER_TOKEN
+
+  if (!url) {
+    throw new Error("missing runner URL; set AGENT_RUNNER_URL or pass --runner-url")
+  }
+
+  if (!token) {
+    throw new Error("missing runner token; set AGENT_RUNNER_TOKEN or pass --runner-token")
+  }
+
+  return {
+    token,
+    url: normalizeRunnerAppUrl(url),
+  }
+}
+
+export async function requestRunnerAppCapabilities({ fetchImpl = fetch, token, url }) {
+  const response = await fetchImpl(`${normalizeRunnerAppUrl(url)}/api/capabilities`, {
+    headers: {
+      authorization: `Bearer ${token}`,
+    },
+    method: "GET",
+  })
+
+  const bodyText = await response.text()
+  const body = parseJsonBody(bodyText)
+
+  if (!response.ok) {
+    const detail = body?.error ? `: ${body.error}` : bodyText ? `: ${bodyText}` : ""
+    const error = new Error(`agent runner rejected capabilities with ${response.status}${detail}`)
+    error.status = response.status
+    error.body = body
+    error.responseText = bodyText
+    throw error
+  }
+
+  return body
+}
+
+export function summarizeControlPlaneCapabilities(capabilities) {
+  const tickPersistence = capabilities?.snapshotContracts?.tick?.persistence ?? "unknown"
+  const intentPersistence =
+    capabilities?.dispatchIntentContracts?.latestSnapshotLease?.persistence ?? "unknown"
+  const activeRead = capabilities?.dispatchIntentContracts?.latestSnapshotLease?.activeRead
+
+  return {
+    ok:
+      capabilities?.service === "agent-control-plane" &&
+      tickPersistence === "latest" &&
+      intentPersistence === "leased" &&
+      activeRead === true,
+    detail: `tick snapshots: ${tickPersistence}; dispatch intents: ${intentPersistence}; active read: ${String(activeRead ?? "unknown")}`,
+  }
+}
+
+export function summarizeRunnerAppCapabilities(capabilities) {
+  return {
+    ok: Boolean(capabilities?.execution),
+    detail: `execution: ${capabilities?.execution?.mode ?? "unknown"}; enabled: ${String(capabilities?.execution?.enabled ?? "unknown")}; tick persistence: ${capabilities?.supervisorTicks?.persistence ?? "unknown"}`,
+  }
+}
+
+function normalizeRunnerAppUrl(url) {
+  return String(url).replace(/\/+$/, "")
+}
+
+function parseJsonBody(bodyText) {
+  if (!bodyText) return null
+
+  try {
+    return JSON.parse(bodyText)
+  } catch {
+    return null
+  }
+}

--- a/scripts/tests/agent-runner-control-plane.test.mjs
+++ b/scripts/tests/agent-runner-control-plane.test.mjs
@@ -6,6 +6,7 @@ import {
   controlPlaneConfigFromArgs,
   finishDispatchIntent,
   requestActiveDispatchIntent,
+  requestControlPlaneCapabilities,
   requestLatestDispatchIntent,
   requestLatestDispatchPlan,
   submitTickSnapshot,
@@ -170,6 +171,53 @@ describe("agent runner control plane client", () => {
         url: "https://control.example.com",
       }),
       /404: latest_tick_snapshot_not_found/,
+    )
+  })
+
+  it("reads control plane capabilities", async () => {
+    const calls = []
+    const response = await requestControlPlaneCapabilities({
+      fetchImpl: async (url, init) => {
+        calls.push({ init, url })
+        return new Response(
+          JSON.stringify({
+            dispatchIntentContracts: {
+              latestSnapshotLease: {
+                activeRead: true,
+                persistence: "leased",
+              },
+            },
+            service: "agent-control-plane",
+            snapshotContracts: {
+              tick: {
+                persistence: "latest",
+              },
+            },
+          }),
+          { status: 200 },
+        )
+      },
+      token: "tok",
+      url: "https://control.example.com/",
+    })
+
+    assert.equal(response.service, "agent-control-plane")
+    assert.equal(calls[0].url, "https://control.example.com/api/capabilities")
+    assert.equal(calls[0].init.method, "GET")
+    assert.equal(calls[0].init.headers.authorization, "Bearer tok")
+  })
+
+  it("surfaces rejected control plane capability responses", async () => {
+    await assert.rejects(
+      requestControlPlaneCapabilities({
+        fetchImpl: async () =>
+          new Response(JSON.stringify({ error: "unauthorized" }), {
+            status: 401,
+          }),
+        token: "tok",
+        url: "https://control.example.com",
+      }),
+      /401: unauthorized/,
     )
   })
 

--- a/scripts/tests/agent-runner-deployment-doctor.test.mjs
+++ b/scripts/tests/agent-runner-deployment-doctor.test.mjs
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import {
+  requestRunnerAppCapabilities,
+  runnerAppConfigFromArgs,
+  summarizeControlPlaneCapabilities,
+  summarizeRunnerAppCapabilities,
+} from "../lib/agent-runner-deployment-doctor.mjs"
+
+describe("agent runner deployment doctor helpers", () => {
+  it("reads runner app URL and token from CLI/env without logging tokens", () => {
+    assert.deepEqual(
+      runnerAppConfigFromArgs(
+        { runnerUrl: "https://runner.example.com/" },
+        { AGENT_RUNNER_TOKEN: "tok" },
+      ),
+      {
+        token: "tok",
+        url: "https://runner.example.com",
+      },
+    )
+  })
+
+  it("requires runner app URL and token", () => {
+    assert.throws(
+      () => runnerAppConfigFromArgs({}, { AGENT_RUNNER_TOKEN: "tok" }),
+      /missing runner URL/,
+    )
+    assert.throws(
+      () => runnerAppConfigFromArgs({ runnerUrl: "https://runner.example.com" }, {}),
+      /missing runner token/,
+    )
+  })
+
+  it("reads runner app capabilities", async () => {
+    const calls = []
+    const response = await requestRunnerAppCapabilities({
+      fetchImpl: async (url, init) => {
+        calls.push({ init, url })
+        return new Response(
+          JSON.stringify({
+            execution: {
+              enabled: true,
+              mode: "lease-only",
+            },
+            service: "agent-runner",
+            supervisorTicks: {
+              persistence: "latest",
+            },
+          }),
+          { status: 200 },
+        )
+      },
+      token: "tok",
+      url: "https://runner.example.com/",
+    })
+
+    assert.equal(response.service, "agent-runner")
+    assert.equal(calls[0].url, "https://runner.example.com/api/capabilities")
+    assert.equal(calls[0].init.method, "GET")
+    assert.equal(calls[0].init.headers.authorization, "Bearer tok")
+  })
+
+  it("surfaces rejected runner app capability responses", async () => {
+    await assert.rejects(
+      requestRunnerAppCapabilities({
+        fetchImpl: async () =>
+          new Response(JSON.stringify({ error: "unauthorized" }), {
+            status: 401,
+          }),
+        token: "tok",
+        url: "https://runner.example.com",
+      }),
+      /401: unauthorized/,
+    )
+  })
+
+  it("summarizes deployed capabilities without including secrets", () => {
+    assert.deepEqual(
+      summarizeControlPlaneCapabilities({
+        dispatchIntentContracts: {
+          latestSnapshotLease: {
+            activeRead: true,
+            persistence: "leased",
+          },
+        },
+        service: "agent-control-plane",
+        snapshotContracts: {
+          tick: {
+            persistence: "latest",
+          },
+        },
+      }),
+      {
+        detail: "tick snapshots: latest; dispatch intents: leased; active read: true",
+        ok: true,
+      },
+    )
+
+    assert.deepEqual(
+      summarizeRunnerAppCapabilities({
+        execution: {
+          enabled: false,
+          mode: "disabled",
+        },
+        supervisorTicks: {
+          persistence: "latest",
+        },
+      }),
+      {
+        detail: "execution: disabled; enabled: false; tick persistence: latest",
+        ok: true,
+      },
+    )
+  })
+
+  it("fails control plane summaries until required stores are configured", () => {
+    assert.deepEqual(
+      summarizeControlPlaneCapabilities({
+        dispatchIntentContracts: {
+          latestSnapshotLease: {
+            activeRead: false,
+            persistence: "none",
+          },
+        },
+        service: "agent-control-plane",
+        snapshotContracts: {
+          tick: {
+            persistence: "none",
+          },
+        },
+      }),
+      {
+        detail: "tick snapshots: none; dispatch intents: none; active read: false",
+        ok: false,
+      },
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add a deployment doctor for deployed control-plane and runner capability checks
- add script-side capability clients and coverage for deployed capability reads
- document the pre-Cron diagnostics flow for the control plane, runner app, issue tracker, and orchestration plan

## Verification
- node --test scripts/tests/agent-runner-control-plane.test.mjs scripts/tests/agent-runner-deployment-doctor.test.mjs
- pnpm agent:queue:test
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- git diff --check origin/main...HEAD
- pre-commit hook
- pre-push hook