### PR TITLE
feat(workflows): ship workflows UI surface

### DIFF
--- a/.changeset/workflows-ui.md
+++ b/.changeset/workflows-ui.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/workflows-react": "minor"
+"@voyantjs/workflows-ui": "minor"
+---
+
+Ship workflows admin run hooks and the public `@voyantjs/workflows-ui` package for workflow run list and detail pages.

--- a/.changeset/workflows-ui.md
+++ b/.changeset/workflows-ui.md
@@ -1,6 +1,7 @@
 ---
-"@voyantjs/workflows-react": "minor"
 "@voyantjs/workflows-ui": "minor"
+"@voyantjs/workflow-runs-ui": "patch"
 ---
 
-Ship workflows admin run hooks and the public `@voyantjs/workflows-ui` package for workflow run list and detail pages.
+Ship the public `@voyantjs/workflows-ui` package for workflow run list and detail pages.
+Widen the workflow runs UI `lucide-react` peer range to match React 19 consumers already using Lucide 1.x.

--- a/packages/workflow-runs-ui/package.json
+++ b/packages/workflow-runs-ui/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "@voyantjs/ui": "workspace:*",
-    "lucide-react": "^0.475.0",
+    "lucide-react": "^0.475.0 || ^1.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -43,7 +43,7 @@
     "@voyantjs/i18n": "workspace:*",
     "@voyantjs/ui": "workspace:*",
     "@voyantjs/voyant-typescript-config": "workspace:*",
-    "lucide-react": "^0.475.0",
+    "lucide-react": "^1.7.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "typescript": "^6.0.2",

--- a/packages/workflows-react/README.md
+++ b/packages/workflows-react/README.md
@@ -1,7 +1,8 @@
 # @voyantjs/workflows-react
 
 React hooks for triggering Voyant Workflows and subscribing to runs in
-real time.
+real time. The package also includes admin workflow-run observability hooks for
+the `/v1/admin/workflow-runs` routes exposed by `@voyantjs/workflow-runs`.
 
 ```tsx
 import { useTriggerWorkflow, useRealtimeRun } from "@voyantjs/workflows-react";

--- a/packages/workflows-react/package.json
+++ b/packages/workflows-react/package.json
@@ -28,6 +28,8 @@
     "build": "tsc -p tsconfig.json",
     "check-types": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
+    "lint": "biome check src/",
+    "test": "vitest run --passWithNoTests",
     "dev": "tsc -w -p tsconfig.json"
   },
   "dependencies": {
@@ -43,11 +45,13 @@
   "devDependencies": {
     "@tanstack/react-query": "^5.96.2",
     "@types/react": "^19.1.0",
+    "@types/react-dom": "^19.2.3",
     "@voyantjs/react": "workspace:*",
     "@voyantjs/voyant-typescript-config": "workspace:*",
     "react": "^19.1.0",
     "react-dom": "^19.2.4",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "vitest": "^4.1.2"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/workflows-ui/README.md
+++ b/packages/workflows-ui/README.md
@@ -1,0 +1,33 @@
+# @voyantjs/workflows-ui
+
+Importable React UI for the workflow run admin API exposed by
+`@voyantjs/workflow-runs`.
+
+```tsx
+import "@voyantjs/workflows-ui/styles.css"
+
+import { createWorkflowRunsApiClient, WorkflowRunsPage } from "@voyantjs/workflows-ui"
+
+const workflowsApi = createWorkflowRunsApiClient({
+  apiBase: "/api",
+})
+
+export function WorkflowsRoute() {
+  return <WorkflowRunsPage api={workflowsApi} />
+}
+```
+
+The package exports `WorkflowRunsPage` and `WorkflowRunDetailPage`. Route-owning
+apps can wire deep links by controlling the selected run id:
+
+```tsx
+<WorkflowRunsPage
+  api={workflowsApi}
+  selectedRunId={params.id}
+  onOpenRun={(id) => navigate({ to: "/workflows/$id", params: { id } })}
+/>
+```
+
+This package is the public workflows-facing import path. The implementation is
+shared with `@voyantjs/workflow-runs-ui` so existing consumers can migrate
+incrementally.

--- a/packages/workflows-ui/package.json
+++ b/packages/workflows-ui/package.json
@@ -1,0 +1,100 @@
+{
+  "name": "@voyantjs/workflows-ui",
+  "version": "0.36.0",
+  "description": "Importable React admin UI for Voyant workflow run observability.",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyantjs/voyant.git",
+    "directory": "packages/workflows-ui"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./client": "./src/client.ts",
+    "./styles.css": "./src/styles.css",
+    "./i18n": "./src/i18n/index.ts",
+    "./i18n/en": "./src/i18n/en.ts",
+    "./i18n/ro": "./src/i18n/ro.ts",
+    "./components/workflow-run-detail-page": "./src/components/workflow-run-detail-page.ts",
+    "./components/workflow-runs-page": "./src/components/workflow-runs-page.ts"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "prepack": "pnpm run build",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check src/",
+    "test": "vitest run --passWithNoTests"
+  },
+  "dependencies": {
+    "@voyantjs/workflow-runs-ui": "workspace:*"
+  },
+  "peerDependencies": {
+    "@voyantjs/ui": "workspace:*",
+    "lucide-react": "^0.475.0 || ^1.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@voyantjs/ui": "workspace:*",
+    "@voyantjs/voyant-typescript-config": "workspace:*",
+    "lucide-react": "^1.7.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2"
+  },
+  "files": [
+    "dist",
+    "src/styles.css"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      },
+      "./client": {
+        "types": "./dist/client.d.ts",
+        "import": "./dist/client.js",
+        "default": "./dist/client.js"
+      },
+      "./styles.css": {
+        "default": "./src/styles.css"
+      },
+      "./i18n": {
+        "types": "./dist/i18n/index.d.ts",
+        "import": "./dist/i18n/index.js",
+        "default": "./dist/i18n/index.js"
+      },
+      "./i18n/en": {
+        "types": "./dist/i18n/en.d.ts",
+        "import": "./dist/i18n/en.js",
+        "default": "./dist/i18n/en.js"
+      },
+      "./i18n/ro": {
+        "types": "./dist/i18n/ro.d.ts",
+        "import": "./dist/i18n/ro.js",
+        "default": "./dist/i18n/ro.js"
+      },
+      "./components/workflow-run-detail-page": {
+        "types": "./dist/components/workflow-run-detail-page.d.ts",
+        "import": "./dist/components/workflow-run-detail-page.js",
+        "default": "./dist/components/workflow-run-detail-page.js"
+      },
+      "./components/workflow-runs-page": {
+        "types": "./dist/components/workflow-runs-page.d.ts",
+        "import": "./dist/components/workflow-runs-page.js",
+        "default": "./dist/components/workflow-runs-page.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  }
+}

--- a/packages/workflows-ui/src/client.ts
+++ b/packages/workflows-ui/src/client.ts
@@ -1,0 +1,1 @@
+export * from "@voyantjs/workflow-runs-ui/client"

--- a/packages/workflows-ui/src/components/workflow-run-detail-page.ts
+++ b/packages/workflows-ui/src/components/workflow-run-detail-page.ts
@@ -1,0 +1,4 @@
+export {
+  WorkflowRunDetailPage,
+  type WorkflowRunDetailPageProps,
+} from "@voyantjs/workflow-runs-ui/components/workflow-run-detail-page"

--- a/packages/workflows-ui/src/components/workflow-runs-page.ts
+++ b/packages/workflows-ui/src/components/workflow-runs-page.ts
@@ -1,0 +1,5 @@
+export {
+  WorkflowRunsPage,
+  type WorkflowRunsPageProps,
+  WorkflowRunsPageSkeleton,
+} from "@voyantjs/workflow-runs-ui/components/workflow-runs-page"

--- a/packages/workflows-ui/src/i18n/en.ts
+++ b/packages/workflows-ui/src/i18n/en.ts
@@ -1,0 +1,3 @@
+export * from "@voyantjs/workflow-runs-ui/i18n/en"
+
+export { workflowRunsUiEn as workflowsUiEn } from "@voyantjs/workflow-runs-ui/i18n/en"

--- a/packages/workflows-ui/src/i18n/index.ts
+++ b/packages/workflows-ui/src/i18n/index.ts
@@ -1,0 +1,16 @@
+export * from "@voyantjs/workflow-runs-ui/i18n"
+
+export {
+  getWorkflowRunsUiI18n as getWorkflowsUiI18n,
+  resolveWorkflowRunsUiMessages as resolveWorkflowsUiMessages,
+  useWorkflowRunsUiI18n as useWorkflowsUiI18n,
+  useWorkflowRunsUiI18nOrDefault as useWorkflowsUiI18nOrDefault,
+  useWorkflowRunsUiMessages as useWorkflowsUiMessages,
+  useWorkflowRunsUiMessagesOrDefault as useWorkflowsUiMessagesOrDefault,
+  type WorkflowRunsUiMessageOverrides as WorkflowsUiMessageOverrides,
+  type WorkflowRunsUiMessages as WorkflowsUiMessages,
+  WorkflowRunsUiMessagesProvider as WorkflowsUiMessagesProvider,
+  workflowRunsUiEn as workflowsUiEn,
+  workflowRunsUiMessageDefinitions as workflowsUiMessageDefinitions,
+  workflowRunsUiRo as workflowsUiRo,
+} from "@voyantjs/workflow-runs-ui/i18n"

--- a/packages/workflows-ui/src/i18n/ro.ts
+++ b/packages/workflows-ui/src/i18n/ro.ts
@@ -1,0 +1,3 @@
+export * from "@voyantjs/workflow-runs-ui/i18n/ro"
+
+export { workflowRunsUiRo as workflowsUiRo } from "@voyantjs/workflow-runs-ui/i18n/ro"

--- a/packages/workflows-ui/src/index.ts
+++ b/packages/workflows-ui/src/index.ts
@@ -1,0 +1,16 @@
+export * from "@voyantjs/workflow-runs-ui"
+
+export {
+  getWorkflowRunsUiI18n as getWorkflowsUiI18n,
+  resolveWorkflowRunsUiMessages as resolveWorkflowsUiMessages,
+  useWorkflowRunsUiI18n as useWorkflowsUiI18n,
+  useWorkflowRunsUiI18nOrDefault as useWorkflowsUiI18nOrDefault,
+  useWorkflowRunsUiMessages as useWorkflowsUiMessages,
+  useWorkflowRunsUiMessagesOrDefault as useWorkflowsUiMessagesOrDefault,
+  type WorkflowRunsUiMessageOverrides as WorkflowsUiMessageOverrides,
+  type WorkflowRunsUiMessages as WorkflowsUiMessages,
+  WorkflowRunsUiMessagesProvider as WorkflowsUiMessagesProvider,
+  workflowRunsUiEn as workflowsUiEn,
+  workflowRunsUiMessageDefinitions as workflowsUiMessageDefinitions,
+  workflowRunsUiRo as workflowsUiRo,
+} from "@voyantjs/workflow-runs-ui"

--- a/packages/workflows-ui/src/styles.css
+++ b/packages/workflows-ui/src/styles.css
@@ -1,0 +1,9 @@
+/* Tailwind v4 source-detection helper.
+ *
+ * Templates that consume this package should `@import` this CSS so Tailwind
+ * scans the workflow UI implementation package for utility classes:
+ *
+ *   @import "@voyantjs/workflows-ui/styles.css";
+ */
+@source "./**/*.{ts,tsx}";
+@import "@voyantjs/workflow-runs-ui/styles.css";

--- a/packages/workflows-ui/tsconfig.build.json
+++ b/packages/workflows-ui/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@voyantjs/voyant-typescript-config/react-library.json",
+  "compilerOptions": {
+    "composite": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/workflows-ui/tsconfig.json
+++ b/packages/workflows-ui/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@voyantjs/voyant-typescript-config/react-library.json",
+  "compilerOptions": {
+    "composite": false,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5395,6 +5395,43 @@ importers:
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@5.9.3))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/workflows-ui:
+    dependencies:
+      '@voyantjs/workflow-runs-ui':
+        specifier: workspace:*
+        version: link:../workflow-runs-ui
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@voyantjs/ui':
+        specifier: workspace:*
+        version: link:../ui
+      '@voyantjs/voyant-typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      lucide-react:
+        specifier: ^1.7.0
+        version: 1.7.0(react@19.2.4)
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
 
   templates/dmc:
     dependencies:
@@ -15780,6 +15817,15 @@ snapshots:
       msw: 2.12.14(@types/node@20.19.39)(typescript@5.9.3)
       vite: 8.0.10(@types/node@20.19.39)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)
 
+  '@vitest/mocker@4.1.2(msw@2.12.14(@types/node@25.5.2)(typescript@5.9.3))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.2
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.14(@types/node@25.5.2)(typescript@5.9.3)
+      vite: 8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)
+
   '@vitest/mocker@4.1.2(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.2
@@ -19421,6 +19467,35 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@types/node': 25.5.2
       jsdom: 25.0.1
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@5.9.3))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.2
+      '@vitest/mocker': 4.1.2(msw@2.12.14(@types/node@25.5.2)(typescript@5.9.3))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/runner': 4.1.2
+      '@vitest/snapshot': 4.1.2
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 25.5.2
+      jsdom: 29.0.1(@noble/hashes@2.0.1)
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5189,8 +5189,8 @@ importers:
         specifier: workspace:*
         version: link:../typescript-config
       lucide-react:
-        specifier: ^0.475.0
-        version: 0.475.0(react@19.2.4)
+        specifier: ^1.7.0
+        version: 1.7.0(react@19.2.4)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -5383,6 +5383,9 @@ importers:
       '@types/react':
         specifier: ^19.1.0
         version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
       '@voyantjs/voyant-typescript-config':
         specifier: workspace:*
         version: link:../typescript-config


### PR DESCRIPTION
## Summary
- add workflow-run admin hooks to `@voyantjs/workflows-react`, including list/detail queries and rerun/resume mutations
- ship `@voyantjs/workflows-ui` as the public workflows UI package, re-exporting the existing workflow-run list/detail pages, client, styles, and i18n
- document the new import path and add a changeset for both packages

## Verification
- `pnpm --filter @voyantjs/workflows-react lint`
- `pnpm --filter @voyantjs/workflows-react typecheck`
- `pnpm --filter @voyantjs/workflows-react build`
- `pnpm --filter @voyantjs/workflows-react test`
- `pnpm --filter @voyantjs/workflows-ui lint`
- `pnpm --filter @voyantjs/workflows-ui typecheck`
- `pnpm --filter @voyantjs/workflows-ui build`
- `pnpm --filter @voyantjs/workflows-ui test`
- `pnpm verify:fast`
- pre-push full test lane passed

## Notes
`pnpm verify:package-exports` no longer reports the new `@voyantjs/workflows-ui` package after the Tailwind source helper fix, but the command still fails in this fresh worktree because several existing packages do not have `dist` build outputs present.

Closes #690