### PR TITLE
feat(agent-runner): persist recent tick history

### DIFF
--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -32,6 +32,7 @@ pnpm -C apps/agent-control-plane dev
 - `POST /api/dispatch-intents/:id/finish`
 - `POST /api/tick-snapshots`
 - `GET /api/tick-snapshots/latest?repository=<owner/name>`
+- `GET /api/tick-snapshots/recent?repository=<owner/name>&limit=<n>`
 
 `POST /api/dispatch-plans` accepts ordered queue recommendations and returns the
 first dispatchable plan that matches the optional filters. It mirrors the local
@@ -74,12 +75,17 @@ waiting for TTL expiry.
 `pnpm agent:queue:tick -- --json`, validates the shape, and returns the accepted
 snapshot with counts for total recommendations, dispatchable recommendations,
 and recent events. If the Worker has an `AGENT_TICK_SNAPSHOTS` R2 binding, it
-also stores the latest snapshot for that repository.
+stores both the latest snapshot for that repository and a timestamped history
+record.
 
 `GET /api/tick-snapshots/latest?repository=<owner/name>` reads the latest stored
 snapshot for one repository. It returns
 `tick_snapshot_storage_not_configured` when R2 is not bound, and
 `tick_snapshot_not_found` before the first snapshot is submitted.
+
+`GET /api/tick-snapshots/recent?repository=<owner/name>&limit=<n>` returns
+recent stored snapshots for one repository. `limit` defaults to 20 and is
+clamped to 1..50.
 
 Submit the current queue snapshot from the repo runner with:
 
@@ -179,7 +185,7 @@ available, a command fails, or the iteration limit is reached.
 ## Optional R2 Storage
 
 Bind an R2 bucket as `AGENT_TICK_SNAPSHOTS` to keep the latest accepted tick
-snapshot per repository:
+snapshot plus recent snapshot history per repository:
 
 ```jsonc
 "r2_buckets": [

--- a/apps/agent-control-plane/src/app.ts
+++ b/apps/agent-control-plane/src/app.ts
@@ -303,6 +303,24 @@ export function createApp({
     return c.json(record)
   })
 
+  app.get("/api/tick-snapshots/recent", async (c) => {
+    if (!tickSnapshotStore) {
+      return c.json({ error: "tick_snapshot_storage_not_configured" }, 503)
+    }
+
+    const repository = c.req.query("repository")?.trim()
+    if (!repository) {
+      return c.json({ error: "missing_repository" }, 400)
+    }
+
+    return c.json({
+      records: await tickSnapshotStore.listRecent(repository, {
+        limit: parseLimit(c.req.query("limit")),
+      }),
+      repository,
+    })
+  })
+
   return app
 }
 
@@ -316,4 +334,10 @@ function validationIssues(error: { issues: Array<{ path: Array<PropertyKey>; mes
     path: issue.path.join("."),
     message: issue.message,
   }))
+}
+
+function parseLimit(value: string | undefined) {
+  if (!value) return undefined
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : undefined
 }

--- a/apps/agent-control-plane/src/control-plane.ts
+++ b/apps/agent-control-plane/src/control-plane.ts
@@ -237,6 +237,7 @@ export function buildCapabilities({
     },
     snapshotContracts: {
       tick: {
+        history: tickSnapshotPersistence === "latest",
         version: 1,
         persistence: tickSnapshotPersistence,
       },

--- a/apps/agent-control-plane/src/dispatch-intent-finish.test.ts
+++ b/apps/agent-control-plane/src/dispatch-intent-finish.test.ts
@@ -194,6 +194,10 @@ function inMemoryTickSnapshotStore(records: TickSnapshotRecord[]): TickSnapshotS
     async getLatest(repository) {
       return latest.get(repository.toLowerCase()) ?? null
     },
+    async listRecent(repository) {
+      const record = latest.get(repository.toLowerCase())
+      return record ? [record] : []
+    },
     async putLatest(record) {
       latest.set(record.snapshot.repository.toLowerCase(), record)
       return { key: `latest/${record.snapshot.repository.toLowerCase()}.json` }

--- a/apps/agent-control-plane/src/latest-dispatch-intent.test.ts
+++ b/apps/agent-control-plane/src/latest-dispatch-intent.test.ts
@@ -349,6 +349,10 @@ function inMemoryTickSnapshotStore(records: TickSnapshotRecord[] = []): TickSnap
     async getLatest(repository) {
       return latest.get(repository.toLowerCase()) ?? null
     },
+    async listRecent(repository) {
+      const record = latest.get(repository.toLowerCase())
+      return record ? [record] : []
+    },
     async putLatest(record) {
       latest.set(record.snapshot.repository.toLowerCase(), record)
       return { key: `latest/${record.snapshot.repository.toLowerCase()}.json` }

--- a/apps/agent-control-plane/src/latest-dispatch-plan.test.ts
+++ b/apps/agent-control-plane/src/latest-dispatch-plan.test.ts
@@ -178,6 +178,10 @@ function inMemoryTickSnapshotStore(records: TickSnapshotRecord[] = []): TickSnap
     async getLatest(repository) {
       return latest.get(repository.toLowerCase()) ?? null
     },
+    async listRecent(repository) {
+      const record = latest.get(repository.toLowerCase())
+      return record ? [record] : []
+    },
     async putLatest(record) {
       latest.set(record.snapshot.repository.toLowerCase(), record)
       return { key: `latest/${record.snapshot.repository.toLowerCase()}.json` }

--- a/apps/agent-control-plane/src/tick-snapshot-store.test.ts
+++ b/apps/agent-control-plane/src/tick-snapshot-store.test.ts
@@ -114,6 +114,28 @@ describe("tick snapshot storage", () => {
       },
     })
 
+    const recent = await app.request(
+      "/api/tick-snapshots/recent?repository=voyantjs%2Fvoyant&limit=10",
+      {
+        headers: { authorization: "Bearer secret" },
+      },
+    )
+    expect(recent.status).toBe(200)
+    await expect(recent.json()).resolves.toMatchObject({
+      records: [
+        {
+          snapshot: {
+            repository: "voyantjs/voyant",
+          },
+          summary: {
+            dispatchableRecommendationCount: 1,
+            recommendationCount: 2,
+          },
+        },
+      ],
+      repository: "voyantjs/voyant",
+    })
+
     const capabilities = await app.request("/api/capabilities", {
       headers: { authorization: "Bearer secret" },
     })
@@ -126,7 +148,7 @@ describe("tick snapshot storage", () => {
     })
   })
 
-  it("requires repository and configured storage for latest tick snapshots", async () => {
+  it("requires repository and configured storage for persisted tick snapshots", async () => {
     const noStore = createApp({ authTokens: ["secret"] })
     const noStoreResponse = await noStore.request(
       "/api/tick-snapshots/latest?repository=voyantjs%2Fvoyant",
@@ -148,6 +170,12 @@ describe("tick snapshot storage", () => {
     })
     expect(missingRepository.status).toBe(400)
     await expect(missingRepository.json()).resolves.toEqual({ error: "missing_repository" })
+
+    const missingRecentRepository = await app.request("/api/tick-snapshots/recent", {
+      headers: { authorization: "Bearer secret" },
+    })
+    expect(missingRecentRepository.status).toBe(400)
+    await expect(missingRecentRepository.json()).resolves.toEqual({ error: "missing_repository" })
 
     const missingSnapshot = await app.request(
       "/api/tick-snapshots/latest?repository=voyantjs%2Fvoyant",
@@ -171,6 +199,14 @@ describe("tick snapshot storage", () => {
               } as R2ObjectBody)
             : null
         },
+        async list({ prefix }: { prefix?: string } = {}) {
+          return {
+            objects: Array.from(objects.keys())
+              .filter((key) => !prefix || key.startsWith(prefix))
+              .sort()
+              .map((key) => ({ key })),
+          }
+        },
         async put(key: string, value: string) {
           objects.set(key, String(value))
           return null
@@ -183,10 +219,13 @@ describe("tick snapshot storage", () => {
       acceptedAt: "2026-05-12T05:00:00.000Z",
     })
 
-    await expect(store.putLatest(record)).resolves.toEqual({
+    await expect(store.putLatest(record)).resolves.toMatchObject({
+      historyKey:
+        "supervisor/tick-snapshots/history/voyantjs%2Fvoyant/9005420692740991-2026-05-12T05%3A00%3A00.000Z.json",
       key: "supervisor/tick-snapshots/latest/voyantjs%2Fvoyant.json",
     })
     await expect(store.getLatest("VoyantJS/Voyant")).resolves.toEqual(record)
+    await expect(store.listRecent("VoyantJS/Voyant")).resolves.toEqual([record])
   })
 
   it("stores snapshots without a leading slash when the key prefix is empty", async () => {
@@ -204,7 +243,7 @@ describe("tick snapshot storage", () => {
       keyPrefix: "",
     })
 
-    await expect(store.putLatest(buildTickSnapshotRecord(tickSnapshot))).resolves.toEqual({
+    await expect(store.putLatest(buildTickSnapshotRecord(tickSnapshot))).resolves.toMatchObject({
       key: "tick-snapshots/latest/voyantjs%2Fvoyant.json",
     })
   })
@@ -344,13 +383,20 @@ describe("tick snapshot storage", () => {
 
 function inMemoryTickSnapshotStore(): TickSnapshotStore {
   const latest = new Map<string, TickSnapshotRecord>()
+  const recent: TickSnapshotRecord[] = []
 
   return {
     async getLatest(repository) {
       return latest.get(repository.toLowerCase()) ?? null
     },
+    async listRecent(repository) {
+      return recent.filter(
+        (record) => record.snapshot.repository.toLowerCase() === repository.toLowerCase(),
+      )
+    },
     async putLatest(record) {
       latest.set(record.snapshot.repository.toLowerCase(), record)
+      recent.unshift(record)
       return { key: `latest/${record.snapshot.repository.toLowerCase()}.json` }
     },
   }

--- a/apps/agent-control-plane/src/tick-snapshot-store.ts
+++ b/apps/agent-control-plane/src/tick-snapshot-store.ts
@@ -2,15 +2,22 @@ import { type TickSnapshotRecord, tickSnapshotRecordSchema } from "./control-pla
 
 export interface TickSnapshotStore {
   getLatest(repository: string): Promise<TickSnapshotRecord | null>
+  listRecent(repository: string, options?: { limit?: number }): Promise<TickSnapshotRecord[]>
   putLatest(record: TickSnapshotRecord): Promise<TickSnapshotStoreWrite>
 }
 
 export interface TickSnapshotStoreWrite {
+  historyKey?: string
   key: string
 }
 
 export interface TickSnapshotBucket {
   get(key: string): Promise<{ text(): Promise<string> } | null>
+  list?(options?: { cursor?: string; limit?: number; prefix?: string }): Promise<{
+    cursor?: string
+    objects: Array<{ key: string }>
+    truncated?: boolean
+  }>
   put(
     key: string,
     value: string,
@@ -38,15 +45,50 @@ export function createR2TickSnapshotStore({
       return parsed.data
     },
 
+    async listRecent(repository, options = {}) {
+      if (!bucket.list) {
+        return []
+      }
+
+      const limit = boundedLimit(options.limit)
+      const prefix = historySnapshotPrefix({ keyPrefix, repository })
+      const listed = await bucket.list({
+        limit,
+        prefix,
+      })
+
+      const records: TickSnapshotRecord[] = []
+      for (const object of listed.objects.slice(0, limit)) {
+        const stored = await bucket.get(object.key)
+        if (!stored) continue
+
+        const parsed = tickSnapshotRecordSchema.safeParse(JSON.parse(await stored.text()))
+        if (!parsed.success) {
+          throw new Error(`stored tick snapshot is invalid for ${repository}`)
+        }
+        records.push(parsed.data)
+      }
+
+      return records
+    },
+
     async putLatest(record) {
       const key = latestSnapshotKey({ keyPrefix, repository: record.snapshot.repository })
-      await bucket.put(key, JSON.stringify(record), {
+      const historyKey = historySnapshotKey({
+        acceptedAt: record.acceptedAt,
+        keyPrefix,
+        repository: record.snapshot.repository,
+      })
+      const value = JSON.stringify(record)
+      const options = {
         httpMetadata: {
           contentType: "application/json",
         },
-      })
+      }
+      await bucket.put(key, value, options)
+      await bucket.put(historyKey, value, options)
 
-      return { key }
+      return { historyKey, key }
     },
   }
 }
@@ -56,4 +98,37 @@ function latestSnapshotKey({ keyPrefix, repository }: { keyPrefix: string; repos
   const encodedRepository = encodeURIComponent(repository.trim().toLowerCase())
   const key = `tick-snapshots/latest/${encodedRepository}.json`
   return normalizedPrefix ? `${normalizedPrefix}/${key}` : key
+}
+
+function historySnapshotPrefix({
+  keyPrefix,
+  repository,
+}: {
+  keyPrefix: string
+  repository: string
+}) {
+  const normalizedPrefix = keyPrefix.replace(/^\/+|\/+$/g, "")
+  const encodedRepository = encodeURIComponent(repository.trim().toLowerCase())
+  const key = `tick-snapshots/history/${encodedRepository}/`
+  return normalizedPrefix ? `${normalizedPrefix}/${key}` : key
+}
+
+function historySnapshotKey({
+  acceptedAt,
+  keyPrefix,
+  repository,
+}: {
+  acceptedAt: string
+  keyPrefix: string
+  repository: string
+}) {
+  const timestamp = Date.parse(acceptedAt)
+  const sortable = Number.isFinite(timestamp)
+    ? String(Number.MAX_SAFE_INTEGER - timestamp).padStart(16, "0")
+    : encodeURIComponent(acceptedAt)
+  return `${historySnapshotPrefix({ keyPrefix, repository })}${sortable}-${encodeURIComponent(acceptedAt)}.json`
+}
+
+function boundedLimit(limit = 20) {
+  return Math.min(Math.max(Math.trunc(limit), 1), 50)
 }

--- a/apps/agent-runner/README.md
+++ b/apps/agent-runner/README.md
@@ -27,6 +27,9 @@ provider commands, or spend model budget.
 - `GET /api/supervisor/ticks/latest?repository=<owner/name>` returns the latest
   persisted supervisor tick for a repository. Requires `AGENT_RUNNER_TOKENS`
   and the `AGENT_RUNNER_TICKS` binding.
+- `GET /api/supervisor/ticks/recent?repository=<owner/name>&limit=<n>` returns
+  recent persisted supervisor ticks for a repository. `limit` defaults to 20
+  and is clamped to 1..50.
 
 ## Configuration
 
@@ -41,7 +44,8 @@ provider commands, or spend model budget.
 - `AGENT_RUNNER_MAX_LEASE_TTL_SECONDS`: optional maximum lease TTL. Defaults to
   900 seconds and is clamped to 60..3600 seconds.
 - `AGENT_RUNNER_REPOSITORY`: default repository, for example `voyantjs/voyant`.
-- `AGENT_RUNNER_TICKS`: optional R2 binding for latest supervisor tick status.
+- `AGENT_RUNNER_TICKS`: optional R2 binding for latest supervisor tick status
+  and recent supervisor tick history.
 - `AGENT_RUNNER_TICK_KEY_PREFIX`: optional R2 key prefix for supervisor ticks.
 - `AGENT_CONTROL_PLANE_URL`: deployed control-plane URL.
 - `AGENT_CONTROL_PLANE_TOKEN`: bearer token for the control plane.

--- a/apps/agent-runner/src/app.test.ts
+++ b/apps/agent-runner/src/app.test.ts
@@ -2,12 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import { createApp } from "./app.js"
 import { runnerDispatchActions } from "./runner.js"
-import {
-  createR2SupervisorTickStore,
-  type SupervisorTickBucket,
-  type SupervisorTickRecord,
-  type SupervisorTickStore,
-} from "./supervisor-tick-store.js"
+import type { SupervisorTickRecord, SupervisorTickStore } from "./supervisor-tick-store.js"
 
 describe("agent runner app", () => {
   it("serves public health without runner auth", async () => {
@@ -401,9 +396,33 @@ describe("agent runner app", () => {
         reason: "dry_run",
       },
     })
+
+    const recent = await app.request(
+      "/api/supervisor/ticks/recent?repository=voyantjs%2Fvoyant&limit=5",
+      {
+        headers: {
+          authorization: "Bearer token",
+        },
+      },
+    )
+
+    expect(recent.status).toBe(200)
+    await expect(recent.json()).resolves.toMatchObject({
+      records: [
+        {
+          recordedAt: "2026-05-12T12:00:00.000Z",
+          repository: "voyantjs/voyant",
+          result: {
+            leased: false,
+            reason: "dry_run",
+          },
+        },
+      ],
+      repository: "voyantjs/voyant",
+    })
   })
 
-  it("requires storage and repository before reading latest supervisor ticks", async () => {
+  it("requires storage and repository before reading persisted supervisor ticks", async () => {
     const noStore = createApp({ authTokens: ["token"] })
     const noStoreResponse = await noStore.request(
       "/api/supervisor/ticks/latest?repository=voyantjs%2Fvoyant",
@@ -430,6 +449,14 @@ describe("agent runner app", () => {
     expect(missingRepository.status).toBe(400)
     await expect(missingRepository.json()).resolves.toEqual({ error: "missing_repository" })
 
+    const missingRecentRepository = await app.request("/api/supervisor/ticks/recent", {
+      headers: {
+        authorization: "Bearer token",
+      },
+    })
+    expect(missingRecentRepository.status).toBe(400)
+    await expect(missingRecentRepository.json()).resolves.toEqual({ error: "missing_repository" })
+
     const missingTick = await app.request(
       "/api/supervisor/ticks/latest?repository=voyantjs%2Fvoyant",
       {
@@ -441,47 +468,22 @@ describe("agent runner app", () => {
     expect(missingTick.status).toBe(404)
     await expect(missingTick.json()).resolves.toEqual({ error: "supervisor_tick_not_found" })
   })
-
-  it("stores latest supervisor ticks in R2-compatible object storage", async () => {
-    const objects = new Map<string, string>()
-    const store = createR2SupervisorTickStore({
-      bucket: {
-        async get(key: string) {
-          const text = objects.get(key)
-          return text ? { text: async () => text } : null
-        },
-        async put(key: string, value: string) {
-          objects.set(key, String(value))
-          return null
-        },
-      } satisfies SupervisorTickBucket,
-      keyPrefix: "/runner/",
-    })
-    const record: SupervisorTickRecord = {
-      recordedAt: "2026-05-12T12:00:00.000Z",
-      repository: "voyantjs/voyant",
-      result: {
-        leased: false,
-        reason: "dry_run",
-      },
-    }
-
-    await expect(store.putLatest(record)).resolves.toEqual({
-      key: "runner/supervisor-ticks/latest/voyantjs%2Fvoyant.json",
-    })
-    await expect(store.getLatest("VoyantJS/Voyant")).resolves.toEqual(record)
-  })
 })
 
 function inMemorySupervisorTickStore(): SupervisorTickStore {
   const latest = new Map<string, SupervisorTickRecord>()
+  const recent: SupervisorTickRecord[] = []
 
   return {
     async getLatest(repository) {
       return latest.get(repository.toLowerCase()) ?? null
     },
+    async listRecent(repository) {
+      return recent.filter((record) => record.repository.toLowerCase() === repository.toLowerCase())
+    },
     async putLatest(record) {
       latest.set(record.repository.toLowerCase(), record)
+      recent.unshift(record)
       return { key: `latest/${record.repository.toLowerCase()}.json` }
     },
   }

--- a/apps/agent-runner/src/app.ts
+++ b/apps/agent-runner/src/app.ts
@@ -53,6 +53,7 @@ export function createApp({
     c.json({
       ...buildRunnerCapabilities(config),
       supervisorTicks: {
+        history: Boolean(supervisorTickStore),
         persistence: supervisorTickStore ? "latest" : "none",
       },
     }),
@@ -110,6 +111,24 @@ export function createApp({
     return c.json(record)
   })
 
+  app.get("/api/supervisor/ticks/recent", async (c) => {
+    if (!supervisorTickStore) {
+      return c.json({ error: "supervisor_tick_storage_not_configured" }, 503)
+    }
+
+    const repository = c.req.query("repository")?.trim()
+    if (!repository) {
+      return c.json({ error: "missing_repository" }, 400)
+    }
+
+    return c.json({
+      records: await supervisorTickStore.listRecent(repository, {
+        limit: parseLimit(c.req.query("limit")),
+      }),
+      repository,
+    })
+  })
+
   return app
 }
 
@@ -153,4 +172,10 @@ function validationIssues(error: { issues: Array<{ path: Array<PropertyKey>; mes
     path: issue.path.join("."),
     message: issue.message,
   }))
+}
+
+function parseLimit(value: string | undefined) {
+  if (!value) return undefined
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : undefined
 }

--- a/apps/agent-runner/src/supervisor-tick-store.test.ts
+++ b/apps/agent-runner/src/supervisor-tick-store.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  createR2SupervisorTickStore,
+  type SupervisorTickBucket,
+  type SupervisorTickRecord,
+} from "./supervisor-tick-store.js"
+
+describe("supervisor tick storage", () => {
+  it("stores latest and recent supervisor ticks in R2-compatible object storage", async () => {
+    const objects = new Map<string, string>()
+    const store = createR2SupervisorTickStore({
+      bucket: {
+        async get(key: string) {
+          const text = objects.get(key)
+          return text ? { text: async () => text } : null
+        },
+        async list({ prefix }: { prefix?: string } = {}) {
+          return {
+            objects: Array.from(objects.keys())
+              .filter((key) => !prefix || key.startsWith(prefix))
+              .sort()
+              .map((key) => ({ key })),
+          }
+        },
+        async put(key: string, value: string) {
+          objects.set(key, String(value))
+          return null
+        },
+      } satisfies SupervisorTickBucket,
+      keyPrefix: "/runner/",
+    })
+    const record: SupervisorTickRecord = {
+      recordedAt: "2026-05-12T12:00:00.000Z",
+      repository: "voyantjs/voyant",
+      result: {
+        leased: false,
+        reason: "dry_run",
+      },
+    }
+
+    await expect(store.putLatest(record)).resolves.toMatchObject({
+      historyKey:
+        "runner/supervisor-ticks/history/voyantjs%2Fvoyant/9005420667540991-2026-05-12T12%3A00%3A00.000Z.json",
+      key: "runner/supervisor-ticks/latest/voyantjs%2Fvoyant.json",
+    })
+    await expect(store.getLatest("VoyantJS/Voyant")).resolves.toEqual(record)
+    await expect(store.listRecent("VoyantJS/Voyant")).resolves.toEqual([record])
+  })
+})

--- a/apps/agent-runner/src/supervisor-tick-store.ts
+++ b/apps/agent-runner/src/supervisor-tick-store.ts
@@ -10,15 +10,22 @@ export type SupervisorTickRecord = z.infer<typeof supervisorTickRecordSchema>
 
 export interface SupervisorTickStore {
   getLatest(repository: string): Promise<SupervisorTickRecord | null>
+  listRecent(repository: string, options?: { limit?: number }): Promise<SupervisorTickRecord[]>
   putLatest(record: SupervisorTickRecord): Promise<SupervisorTickStoreWrite>
 }
 
 export interface SupervisorTickStoreWrite {
+  historyKey?: string
   key: string
 }
 
 export interface SupervisorTickBucket {
   get(key: string): Promise<{ text(): Promise<string> } | null>
+  list?(options?: { cursor?: string; limit?: number; prefix?: string }): Promise<{
+    cursor?: string
+    objects: Array<{ key: string }>
+    truncated?: boolean
+  }>
   put(
     key: string,
     value: string,
@@ -62,15 +69,50 @@ export function createR2SupervisorTickStore({
       return parsed.data
     },
 
+    async listRecent(repository, options = {}) {
+      if (!bucket.list) {
+        return []
+      }
+
+      const limit = boundedLimit(options.limit)
+      const prefix = historyTickPrefix({ keyPrefix, repository })
+      const listed = await bucket.list({
+        limit,
+        prefix,
+      })
+
+      const records: SupervisorTickRecord[] = []
+      for (const object of listed.objects.slice(0, limit)) {
+        const stored = await bucket.get(object.key)
+        if (!stored) continue
+
+        const parsed = supervisorTickRecordSchema.safeParse(JSON.parse(await stored.text()))
+        if (!parsed.success) {
+          throw new Error(`stored supervisor tick is invalid for ${repository}`)
+        }
+        records.push(parsed.data)
+      }
+
+      return records
+    },
+
     async putLatest(record) {
       const key = latestTickKey({ keyPrefix, repository: record.repository })
-      await bucket.put(key, JSON.stringify(record), {
+      const historyKey = historyTickKey({
+        keyPrefix,
+        recordedAt: record.recordedAt,
+        repository: record.repository,
+      })
+      const value = JSON.stringify(record)
+      const options = {
         httpMetadata: {
           contentType: "application/json",
         },
-      })
+      }
+      await bucket.put(key, value, options)
+      await bucket.put(historyKey, value, options)
 
-      return { key }
+      return { historyKey, key }
     },
   }
 }
@@ -80,4 +122,31 @@ function latestTickKey({ keyPrefix, repository }: { keyPrefix: string; repositor
   const encodedRepository = encodeURIComponent(repository.trim().toLowerCase())
   const key = `supervisor-ticks/latest/${encodedRepository}.json`
   return normalizedPrefix ? `${normalizedPrefix}/${key}` : key
+}
+
+function historyTickPrefix({ keyPrefix, repository }: { keyPrefix: string; repository: string }) {
+  const normalizedPrefix = keyPrefix.replace(/^\/+|\/+$/g, "")
+  const encodedRepository = encodeURIComponent(repository.trim().toLowerCase())
+  const key = `supervisor-ticks/history/${encodedRepository}/`
+  return normalizedPrefix ? `${normalizedPrefix}/${key}` : key
+}
+
+function historyTickKey({
+  keyPrefix,
+  recordedAt,
+  repository,
+}: {
+  keyPrefix: string
+  recordedAt: string
+  repository: string
+}) {
+  const timestamp = Date.parse(recordedAt)
+  const sortable = Number.isFinite(timestamp)
+    ? String(Number.MAX_SAFE_INTEGER - timestamp).padStart(16, "0")
+    : encodeURIComponent(recordedAt)
+  return `${historyTickPrefix({ keyPrefix, repository })}${sortable}-${encodeURIComponent(recordedAt)}.json`
+}
+
+function boundedLimit(limit = 20) {
+  return Math.min(Math.max(Math.trunc(limit), 1), 50)
 }

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -388,8 +388,8 @@ maintainer merges and mark the item done.
 The Cloudflare-ready control-plane app can accept this JSON at
 `POST /api/tick-snapshots` for validation and summary counts. When the
 control-plane Worker has an R2 binding, it also stores the latest accepted
-snapshot per repository for dashboard and supervisor reads. This still does not
-dispatch work.
+snapshot plus recent snapshot history per repository for dashboard and
+supervisor reads. This still does not dispatch work.
 After a snapshot is stored, a supervisor can call
 `POST /api/dispatch-plans/latest` with `{ repository, filters?, options? }` to
 plan the next allow-listed lifecycle command from that stored snapshot without
@@ -418,6 +418,10 @@ It reads `AGENT_CONTROL_PLANE_URL`, `AGENT_CONTROL_PLANE_TOKEN`,
 `AGENT_RUNNER_URL`, and `AGENT_RUNNER_TOKEN`, calls both `/api/capabilities`
 endpoints, and reports persistence and execution mode without printing token
 values.
+Use the recent history endpoints when an operator needs to inspect more than
+the latest persisted heartbeat: `GET /api/tick-snapshots/recent` on the control
+plane for queue-state snapshots, and `GET /api/supervisor/ticks/recent` on the
+runner for deployed supervisor tick results.
 `CI Repair` items with failing linked PRs recommend `collect-ci` until a local
 CI repair packet exists. Ready items with `sandbox:<provider>:<id>` workspaces
 recommend `remote-bootstrap` so dispatch can clone/fetch the repository and

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1323,6 +1323,7 @@ Verification:
   without adding storage or automatic dispatch yet.
 - The control-plane app can optionally persist the latest accepted tick
   snapshot per repository to R2 through the `AGENT_TICK_SNAPSHOTS` binding.
+  It also writes timestamped recent-history records for operator inspection.
   This gives dashboards and supervisors a durable read model while dispatch
   remains explicit and runner-owned.
 - The control-plane app can also plan dispatch from that latest stored snapshot
@@ -1363,8 +1364,9 @@ Verification:
   task-scoped provider credentials are wired into a later slice.
 - The runner app can persist the latest supervisor tick result per repository
   to R2 through the `AGENT_RUNNER_TICKS` binding and expose it at
-  `GET /api/supervisor/ticks/latest`. This gives Cron-based deployments an
-  inspectable heartbeat and last lease result without introducing a full run
+  `GET /api/supervisor/ticks/latest` and recent records at
+  `GET /api/supervisor/ticks/recent`. This gives Cron-based deployments an
+  inspectable heartbeat and recent lease results without introducing a full run
   database. Lease-conflict ticks preserve the active intent returned by the
   control plane so maintainers can see the holder, issue, action, and expiration
   that blocked the run.


### PR DESCRIPTION
## Summary
- Persist timestamped recent-history records alongside latest control-plane tick snapshots and runner supervisor ticks.
- Add authenticated recent-history endpoints for queue snapshots and deployed runner ticks.
- Document the R2 history behavior and split runner storage coverage out of the large app test file.

## Verification
- pnpm --filter @voyantjs/agent-runner test
- pnpm --filter @voyantjs/agent-runner check-types
- pnpm --filter @voyantjs/agent-control-plane test
- pnpm --filter @voyantjs/agent-control-plane check-types
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- pnpm agent:queue:test
- git diff --check
- pre-push hook full test lane