### PR TITLE
feat(agent-runner): inspect persisted history

### DIFF
--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -116,6 +116,14 @@ Use `--json` when a supervisor needs the response shape directly. Use `--issue`,
 `--action`, `--event-log`, and `--update-body` to pass through the same filters
 and command options as `POST /api/dispatch-plans/latest`.
 
+Inspect recent stored snapshots with:
+
+```bash
+AGENT_CONTROL_PLANE_URL=https://agent-control-plane.example.workers.dev \
+AGENT_CONTROL_PLANE_TOKEN=... \
+pnpm agent:queue:history -- --source control-plane --repo voyantjs/voyant
+```
+
 Create a leased dispatch intent from the latest stored snapshot with:
 
 ```bash

--- a/apps/agent-runner/README.md
+++ b/apps/agent-runner/README.md
@@ -65,3 +65,11 @@ pnpm agent:queue:deployment-doctor -- --json
 The command reads `AGENT_CONTROL_PLANE_URL`, `AGENT_CONTROL_PLANE_TOKEN`,
 `AGENT_RUNNER_URL`, and `AGENT_RUNNER_TOKEN`, calls both capability endpoints,
 and reports persistence and execution mode without printing token values.
+
+Inspect recent persisted runner ticks with:
+
+```bash
+AGENT_RUNNER_URL=https://agent-runner.example.workers.dev \
+AGENT_RUNNER_TOKEN=... \
+pnpm agent:queue:history -- --source runner --repo voyantjs/voyant
+```

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -421,7 +421,9 @@ values.
 Use the recent history endpoints when an operator needs to inspect more than
 the latest persisted heartbeat: `GET /api/tick-snapshots/recent` on the control
 plane for queue-state snapshots, and `GET /api/supervisor/ticks/recent` on the
-runner for deployed supervisor tick results.
+runner for deployed supervisor tick results. From the repository checkout, use
+`pnpm agent:queue:history -- --source control-plane` for queue snapshots or
+`pnpm agent:queue:history -- --source runner` for deployed runner ticks.
 `CI Repair` items with failing linked PRs recommend `collect-ci` until a local
 CI repair packet exists. Ready items with `sandbox:<provider>:<id>` workspaces
 recommend `remote-bootstrap` so dispatch can clone/fetch the repository and

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1370,6 +1370,9 @@ Verification:
   database. Lease-conflict ticks preserve the active intent returned by the
   control plane so maintainers can see the holder, issue, action, and expiration
   that blocked the run.
+- Operators can inspect persisted control-plane and runner history with
+  `pnpm agent:queue:history`, using `--source control-plane` for queue
+  snapshots or `--source runner` for deployed supervisor ticks.
 - The runner app enforces a local dispatch policy before calling the control
   plane. `AGENT_RUNNER_ALLOWED_ACTIONS` limits which lifecycle actions a
   deployed runner can lease, `AGENT_RUNNER_ACTION` supplies a default action

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "agent:queue:status": "node scripts/agent-runner-status.mjs",
     "agent:queue:tick": "node scripts/agent-runner-tick.mjs",
     "agent:queue:submit-tick": "node scripts/agent-runner-submit-tick.mjs",
+    "agent:queue:history": "node scripts/agent-runner-history.mjs",
     "agent:queue:plan-dispatch": "node scripts/agent-runner-plan-dispatch.mjs",
     "agent:queue:lease-dispatch": "node scripts/agent-runner-lease-dispatch.mjs",
     "agent:queue:active-dispatch": "node scripts/agent-runner-active-dispatch.mjs",

--- a/scripts/agent-runner-history.mjs
+++ b/scripts/agent-runner-history.mjs
@@ -1,0 +1,132 @@
+import { currentRepositoryFromOrigin, fail, parseArgs, runGit } from "./lib/agent-project-queue.mjs"
+import {
+  controlPlaneConfigFromArgs,
+  requestRecentTickSnapshots,
+} from "./lib/agent-runner-control-plane.mjs"
+import {
+  requestRecentRunnerSupervisorTicks,
+  runnerAppConfigFromArgs,
+} from "./lib/agent-runner-deployment-doctor.mjs"
+import { maybePrintHelp, repositoryOptions } from "./lib/agent-runner-help.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:history",
+  summary: "Inspect recent persisted queue snapshots or runner supervisor ticks.",
+  usage: "pnpm agent:queue:history -- [--source control-plane|runner] [--repo <owner/name>]",
+  options: [
+    ["--source <name>", "History source to read. Defaults to control-plane."],
+    [
+      "--limit <n>",
+      "Number of records to read. Defaults to 20 and is clamped by the deployed app.",
+    ],
+    ["--control-plane-url <url>", "Control-plane base URL. Defaults to AGENT_CONTROL_PLANE_URL."],
+    ["AGENT_CONTROL_PLANE_TOKEN", "Bearer token environment variable used for control-plane APIs."],
+    ["--runner-url <url>", "Runner app base URL. Defaults to AGENT_RUNNER_URL."],
+    ["--runner-token <token>", "Runner app bearer token. Defaults to AGENT_RUNNER_TOKEN."],
+    ["--json", "Print machine-readable JSON."],
+    ...repositoryOptions,
+  ],
+})
+
+const source = args.source ?? "control-plane"
+if (!["control-plane", "runner"].includes(source)) {
+  fail(`invalid source: ${source}`)
+}
+
+const repository =
+  args.repo ?? currentRepositoryFromOrigin(runGit(["rev-parse", "--show-toplevel"]))
+const limit = optionalPositiveInteger(args.limit, "limit")
+
+try {
+  const result = source === "runner" ? await readRunnerHistory() : await readControlPlaneHistory()
+
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2))
+  } else {
+    printHistory(result)
+  }
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error))
+}
+
+async function readControlPlaneHistory() {
+  const config = controlPlaneConfigFromArgs(args)
+  const response = await requestRecentTickSnapshots({
+    limit,
+    repository,
+    token: config.token,
+    url: config.url,
+  })
+
+  return {
+    endpoint: config.url,
+    records: response.records ?? [],
+    repository: response.repository ?? repository,
+    source,
+  }
+}
+
+async function readRunnerHistory() {
+  const config = runnerAppConfigFromArgs(args)
+  const response = await requestRecentRunnerSupervisorTicks({
+    limit,
+    repository,
+    token: config.token,
+    url: config.url,
+  })
+
+  return {
+    endpoint: config.url,
+    records: response.records ?? [],
+    repository: response.repository ?? repository,
+    source,
+  }
+}
+
+function printHistory({ endpoint, records, repository, source }) {
+  console.log(`agent-runner history: ${source}`)
+  console.log(`endpoint: ${endpoint}`)
+  console.log(`repository: ${repository}`)
+  console.log(`records: ${records.length}`)
+
+  for (const record of records) {
+    console.log("")
+    if (source === "runner") {
+      printRunnerTick(record)
+    } else {
+      printTickSnapshot(record)
+    }
+  }
+}
+
+function printTickSnapshot(record) {
+  console.log(`accepted: ${record.acceptedAt ?? "unknown"}`)
+  console.log(`recommendations: ${record.summary?.recommendationCount ?? "unknown"}`)
+  console.log(`dispatchable: ${record.summary?.dispatchableRecommendationCount ?? "unknown"}`)
+  if (record.summary?.firstDispatchableIssueNumber) {
+    console.log(
+      `first dispatchable: #${record.summary.firstDispatchableIssueNumber} ${record.summary.firstDispatchableAction}`,
+    )
+  }
+}
+
+function printRunnerTick(record) {
+  console.log(`recorded: ${record.recordedAt ?? "unknown"}`)
+  console.log(`reason: ${record.result?.reason ?? "unknown"}`)
+  console.log(`leased: ${String(record.result?.leased ?? "unknown")}`)
+  const intent = record.result?.intent ?? record.result?.activeIntent
+  if (intent?.id) {
+    console.log(`intent: ${intent.id}`)
+  }
+}
+
+function optionalPositiveInteger(value, name) {
+  if (value === undefined) return undefined
+
+  const number = Number(value)
+  if (!Number.isInteger(number) || number < 1) {
+    fail(`invalid ${name}: ${value}`)
+  }
+  return number
+}

--- a/scripts/lib/agent-runner-control-plane.mjs
+++ b/scripts/lib/agent-runner-control-plane.mjs
@@ -102,6 +102,42 @@ export async function requestControlPlaneCapabilities({ fetchImpl = fetch, token
   return body
 }
 
+export async function requestRecentTickSnapshots({
+  fetchImpl = fetch,
+  limit,
+  repository,
+  token,
+  url,
+}) {
+  const query = new URLSearchParams({
+    repository,
+    ...(limit ? { limit: String(limit) } : {}),
+  })
+  const response = await fetchImpl(
+    `${normalizeControlPlaneUrl(url)}/api/tick-snapshots/recent?${query.toString()}`,
+    {
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+      method: "GET",
+    },
+  )
+
+  const bodyText = await response.text()
+  const body = parseJsonBody(bodyText)
+
+  if (!response.ok) {
+    throw new ControlPlaneRequestError({
+      body,
+      endpoint: "recent tick snapshots",
+      responseText: bodyText,
+      status: response.status,
+    })
+  }
+
+  return body
+}
+
 export async function requestLatestDispatchIntent({ fetchImpl = fetch, request, token, url }) {
   const response = await fetchImpl(`${normalizeControlPlaneUrl(url)}/api/dispatch-intents/latest`, {
     body: JSON.stringify(request),

--- a/scripts/lib/agent-runner-deployment-doctor.mjs
+++ b/scripts/lib/agent-runner-deployment-doctor.mjs
@@ -1,3 +1,14 @@
+export class RunnerAppRequestError extends Error {
+  constructor({ body, endpoint, responseText, status }) {
+    super(formatRunnerAppError({ body, endpoint, responseText, status }))
+    this.name = "RunnerAppRequestError"
+    this.body = body
+    this.endpoint = endpoint
+    this.responseText = responseText
+    this.status = status
+  }
+}
+
 export function runnerAppConfigFromArgs(args, env = process.env) {
   const url = args.runnerUrl ?? env.AGENT_RUNNER_URL
   const token = args.runnerToken ?? env.AGENT_RUNNER_TOKEN
@@ -17,7 +28,37 @@ export function runnerAppConfigFromArgs(args, env = process.env) {
 }
 
 export async function requestRunnerAppCapabilities({ fetchImpl = fetch, token, url }) {
-  const response = await fetchImpl(`${normalizeRunnerAppUrl(url)}/api/capabilities`, {
+  return requestRunnerAppJson({
+    endpoint: "capabilities",
+    fetchImpl,
+    path: "/api/capabilities",
+    token,
+    url,
+  })
+}
+
+export async function requestRecentRunnerSupervisorTicks({
+  fetchImpl = fetch,
+  limit,
+  repository,
+  token,
+  url,
+}) {
+  const query = new URLSearchParams({
+    repository,
+    ...(limit ? { limit: String(limit) } : {}),
+  })
+  return requestRunnerAppJson({
+    endpoint: "recent supervisor ticks",
+    fetchImpl,
+    path: `/api/supervisor/ticks/recent?${query.toString()}`,
+    token,
+    url,
+  })
+}
+
+async function requestRunnerAppJson({ endpoint, fetchImpl = fetch, path, token, url }) {
+  const response = await fetchImpl(`${normalizeRunnerAppUrl(url)}${path}`, {
     headers: {
       authorization: `Bearer ${token}`,
     },
@@ -28,12 +69,12 @@ export async function requestRunnerAppCapabilities({ fetchImpl = fetch, token, u
   const body = parseJsonBody(bodyText)
 
   if (!response.ok) {
-    const detail = body?.error ? `: ${body.error}` : bodyText ? `: ${bodyText}` : ""
-    const error = new Error(`agent runner rejected capabilities with ${response.status}${detail}`)
-    error.status = response.status
-    error.body = body
-    error.responseText = bodyText
-    throw error
+    throw new RunnerAppRequestError({
+      body,
+      endpoint,
+      responseText: bodyText,
+      status: response.status,
+    })
   }
 
   return body
@@ -74,4 +115,9 @@ function parseJsonBody(bodyText) {
   } catch {
     return null
   }
+}
+
+function formatRunnerAppError({ body, endpoint, responseText, status }) {
+  const detail = body?.error ? `: ${body.error}` : responseText ? `: ${responseText}` : ""
+  return `agent runner rejected ${endpoint} with ${status}${detail}`
 }

--- a/scripts/tests/agent-runner-history.test.mjs
+++ b/scripts/tests/agent-runner-history.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { requestRecentTickSnapshots } from "../lib/agent-runner-control-plane.mjs"
+import { requestRecentRunnerSupervisorTicks } from "../lib/agent-runner-deployment-doctor.mjs"
+
+describe("agent runner history helpers", () => {
+  it("reads recent tick snapshots", async () => {
+    const calls = []
+    const response = await requestRecentTickSnapshots({
+      fetchImpl: async (url, init) => {
+        calls.push({ init, url })
+        return new Response(
+          JSON.stringify({
+            records: [
+              {
+                acceptedAt: "2026-05-12T12:00:00.000Z",
+                snapshot: { repository: "voyantjs/voyant" },
+                summary: { recommendationCount: 2 },
+              },
+            ],
+            repository: "voyantjs/voyant",
+          }),
+          { status: 200 },
+        )
+      },
+      limit: 5,
+      repository: "voyantjs/voyant",
+      token: "tok",
+      url: "https://control.example.com/",
+    })
+
+    assert.equal(response.records.length, 1)
+    assert.equal(
+      calls[0].url,
+      "https://control.example.com/api/tick-snapshots/recent?repository=voyantjs%2Fvoyant&limit=5",
+    )
+    assert.equal(calls[0].init.method, "GET")
+    assert.equal(calls[0].init.headers.authorization, "Bearer tok")
+  })
+
+  it("surfaces rejected recent tick snapshot responses", async () => {
+    await assert.rejects(
+      requestRecentTickSnapshots({
+        fetchImpl: async () =>
+          new Response(JSON.stringify({ error: "tick_snapshot_storage_not_configured" }), {
+            status: 503,
+          }),
+        repository: "voyantjs/voyant",
+        token: "tok",
+        url: "https://control.example.com",
+      }),
+      /503: tick_snapshot_storage_not_configured/,
+    )
+  })
+
+  it("reads recent runner supervisor ticks", async () => {
+    const calls = []
+    const response = await requestRecentRunnerSupervisorTicks({
+      fetchImpl: async (url, init) => {
+        calls.push({ init, url })
+        return new Response(
+          JSON.stringify({
+            records: [
+              {
+                recordedAt: "2026-05-12T12:00:00.000Z",
+                repository: "voyantjs/voyant",
+                result: { leased: false, reason: "dry_run" },
+              },
+            ],
+            repository: "voyantjs/voyant",
+          }),
+          { status: 200 },
+        )
+      },
+      limit: 3,
+      repository: "voyantjs/voyant",
+      token: "tok",
+      url: "https://runner.example.com/",
+    })
+
+    assert.equal(response.records.length, 1)
+    assert.equal(
+      calls[0].url,
+      "https://runner.example.com/api/supervisor/ticks/recent?repository=voyantjs%2Fvoyant&limit=3",
+    )
+    assert.equal(calls[0].init.method, "GET")
+    assert.equal(calls[0].init.headers.authorization, "Bearer tok")
+  })
+
+  it("surfaces rejected recent runner supervisor tick responses", async () => {
+    await assert.rejects(
+      requestRecentRunnerSupervisorTicks({
+        fetchImpl: async () =>
+          new Response(JSON.stringify({ error: "supervisor_tick_storage_not_configured" }), {
+            status: 503,
+          }),
+        repository: "voyantjs/voyant",
+        token: "tok",
+        url: "https://runner.example.com",
+      }),
+      /503: supervisor_tick_storage_not_configured/,
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Add `pnpm agent:queue:history` to inspect persisted control-plane queue snapshots or runner supervisor ticks.
- Add client helpers for recent snapshot/tick endpoints with error handling and focused tests.
- Document the operator command next to the deployed history endpoints.

## Verification
- pnpm agent:queue:test
- pnpm agent:queue:history -- --help
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- git diff --check
- pre-push hook full test lane