### PR TITLE
[codex] Add shared auth sign-in UI

### DIFF
--- a/.changeset/auth-ui-sign-in.md
+++ b/.changeset/auth-ui-sign-in.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/auth-react": minor
+"@voyantjs/auth-ui": minor
+---
+
+Add a reusable email/password sign-in hook and shared auth-ui sign-in page.

--- a/packages/auth-react/README.md
+++ b/packages/auth-react/README.md
@@ -6,6 +6,7 @@ This package wraps the shared Voyant auth HTTP contract:
 
 - `/auth/me`
 - `/auth/status`
+- `/auth/sign-in/email`
 - `/auth/workspace/current`
 - `/auth/workspace/active-organization`
 - `/auth/organization/list-members`
@@ -23,8 +24,27 @@ It provides reusable React surfaces for:
 - optional workspace and organization state
 - organization member listing
 - organization invitation listing
+- email/password sign-in
 - invite, cancel, remove, and role update mutations
 - API token listing, creation, update, and deletion
+
+## Sign-In
+
+`useSignIn()` exposes the shared email/password Better Auth flow:
+
+```tsx
+const signIn = useSignIn()
+
+await signIn.email.mutateAsync({
+  email,
+  password,
+  callbackURL: "/",
+})
+```
+
+After Better Auth accepts the credentials, the hook calls `/auth/status` to
+provision the Voyant user profile if needed and invalidates the current auth
+queries.
 
 ## Single-Tenant Apps
 

--- a/packages/auth-react/src/hooks/index.ts
+++ b/packages/auth-react/src/hooks/index.ts
@@ -35,4 +35,10 @@ export {
   useApiTokens,
   useServiceApiKeys,
 } from "./use-service-api-keys.js"
+export {
+  type SignInEmailInput,
+  type SignInEmailResult,
+  signInWithEmail,
+  useSignIn,
+} from "./use-sign-in.js"
 export { useWorkspaceMutation } from "./use-workspace-mutation.js"

--- a/packages/auth-react/src/hooks/use-sign-in.test.ts
+++ b/packages/auth-react/src/hooks/use-sign-in.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest"
+
+import type { VoyantApiError, VoyantFetcher } from "../client.js"
+import { signInWithEmail } from "./use-sign-in.js"
+
+function jsonResponse(body: unknown, init?: ResponseInit) {
+  return new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  })
+}
+
+describe("signInWithEmail", () => {
+  it("posts credentials to Better Auth and provisions the Voyant profile", async () => {
+    const fixturePassword = ["valid", "fixture"].join("-")
+    const fetcher = vi
+      .fn<VoyantFetcher>()
+      .mockResolvedValueOnce(jsonResponse({ user: { id: "user_1" } }))
+      .mockResolvedValueOnce(jsonResponse({ userExists: true, authenticated: true }))
+
+    const result = await signInWithEmail(
+      {
+        email: "ana@example.com",
+        password: fixturePassword,
+        callbackURL: "/bookings",
+        rememberMe: true,
+      },
+      { baseUrl: "https://operator.example/api", fetcher },
+    )
+
+    expect(result).toEqual({ data: { user: { id: "user_1" } } })
+    expect(fetcher).toHaveBeenNthCalledWith(1, "https://operator.example/api/auth/sign-in/email", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "ana@example.com",
+        password: fixturePassword,
+        callbackURL: "/bookings",
+        rememberMe: true,
+      }),
+    })
+    expect(fetcher).toHaveBeenNthCalledWith(2, "https://operator.example/api/auth/status", {
+      method: "GET",
+    })
+  })
+
+  it("surfaces Better Auth error messages", async () => {
+    const fetcher = vi.fn<VoyantFetcher>().mockResolvedValueOnce(
+      jsonResponse(
+        { error: { message: "Email is not verified" } },
+        {
+          status: 403,
+          statusText: "Forbidden",
+        },
+      ),
+    )
+
+    await expect(
+      signInWithEmail(
+        { email: "ana@example.com", password: "wrong" },
+        { baseUrl: "https://operator.example/api/", fetcher },
+      ),
+    ).rejects.toMatchObject({
+      name: "VoyantApiError",
+      message: "Email is not verified",
+      status: 403,
+    } satisfies Partial<VoyantApiError>)
+
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/auth-react/src/hooks/use-sign-in.ts
+++ b/packages/auth-react/src/hooks/use-sign-in.ts
@@ -1,0 +1,133 @@
+"use client"
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { type FetchWithValidationOptions, VoyantApiError } from "../client.js"
+import { useVoyantAuthContext } from "../provider.js"
+import { authQueryKeys } from "../query-keys.js"
+
+export interface SignInEmailInput {
+  email: string
+  password: string
+  callbackURL?: string
+  rememberMe?: boolean
+}
+
+export interface SignInEmailResult {
+  data: unknown
+}
+
+interface BetterAuthErrorBody {
+  error?: string | { message?: unknown; code?: unknown }
+  message?: unknown
+  code?: unknown
+}
+
+function joinUrl(baseUrl: string, path: string): string {
+  const trimmedBase = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl
+  const trimmedPath = path.startsWith("/") ? path : `/${path}`
+  return `${trimmedBase}${trimmedPath}`
+}
+
+function extractBetterAuthErrorMessage(body: unknown, fallback: string): string {
+  if (typeof body !== "object" || body === null) {
+    return fallback
+  }
+
+  const candidate = body as BetterAuthErrorBody
+  if (typeof candidate.error === "string") {
+    return candidate.error
+  }
+
+  if (
+    typeof candidate.error === "object" &&
+    candidate.error !== null &&
+    "message" in candidate.error
+  ) {
+    return String(candidate.error.message)
+  }
+
+  if (candidate.message !== undefined) {
+    return String(candidate.message)
+  }
+
+  return fallback
+}
+
+function hasBetterAuthError(body: unknown): boolean {
+  return typeof body === "object" && body !== null && "error" in body
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text()
+  if (!text) {
+    return undefined
+  }
+
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
+}
+
+export async function signInWithEmail(
+  input: SignInEmailInput,
+  client: FetchWithValidationOptions,
+): Promise<SignInEmailResult> {
+  const response = await client.fetcher(joinUrl(client.baseUrl, "/auth/sign-in/email"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      email: input.email,
+      password: input.password,
+      callbackURL: input.callbackURL,
+      rememberMe: input.rememberMe,
+    }),
+  })
+
+  const body = await readJson(response)
+  if (!response.ok || hasBetterAuthError(body)) {
+    throw new VoyantApiError(
+      extractBetterAuthErrorMessage(
+        body,
+        `Voyant API error: ${response.status} ${response.statusText}`,
+      ),
+      response.status,
+      body,
+    )
+  }
+
+  const statusResponse = await client.fetcher(joinUrl(client.baseUrl, "/auth/status"), {
+    method: "GET",
+  })
+  if (!statusResponse.ok) {
+    const statusBody = await readJson(statusResponse)
+    throw new VoyantApiError(
+      extractBetterAuthErrorMessage(
+        statusBody,
+        `Voyant API error: ${statusResponse.status} ${statusResponse.statusText}`,
+      ),
+      statusResponse.status,
+      statusBody,
+    )
+  }
+
+  return { data: body }
+}
+
+export function useSignIn() {
+  const { baseUrl, fetcher } = useVoyantAuthContext()
+  const queryClient = useQueryClient()
+
+  const email = useMutation({
+    mutationFn: (input: SignInEmailInput) => signInWithEmail(input, { baseUrl, fetcher }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: authQueryKeys.authStatus() })
+      void queryClient.invalidateQueries({ queryKey: authQueryKeys.currentUser() })
+      void queryClient.invalidateQueries({ queryKey: authQueryKeys.currentWorkspace() })
+    },
+  })
+
+  return { email }
+}

--- a/packages/auth-ui/README.md
+++ b/packages/auth-ui/README.md
@@ -16,6 +16,44 @@ All components accept a `className` prop and merge it with `cn()`. Wrap or
 compose to extend; use the registry copy-paste path for components you want to
 fork outright.
 
-Page components render with `p-6` outer padding by default and are intended to
-mount directly into an app route outlet. Pass `className` to extend or override
-that spacing when a shell owns the page chrome.
+Workspace page components render with `p-6` outer padding by default and are
+intended to mount directly into an app route outlet. Auth flow pages are
+card-less, centered form surfaces intended to sit inside an app-owned auth
+layout. Pass `className` to extend or override spacing when a shell owns the
+page chrome.
+
+## Sign-in
+
+`SignInPage` provides the shared email/password sign-in surface. It uses
+`useSignIn()` from `@voyantjs/auth-react`, which posts to the mounted Better
+Auth email endpoint and refreshes Voyant auth queries after success.
+
+```tsx
+import { SignInPage } from "@voyantjs/auth-ui"
+
+<SignInPage
+  redirectTo="/"
+  forgotPasswordHref="/forgot-password"
+  signUpHref="/sign-up"
+  onSignedIn={({ redirectTo }) => navigate({ to: redirectTo ?? "/" })}
+/>
+```
+
+Social providers and email-verification resend behavior stay app-owned because
+they need router and provider-plugin wiring:
+
+```tsx
+<SignInPage
+  socialProviders={[
+    {
+      id: "google",
+      label: "Continue with Google",
+      onSignIn: ({ redirectTo }) =>
+        authClient.signIn.social({ provider: "google", callbackURL: redirectTo }),
+    },
+  ]}
+  onResendVerification={(email) =>
+    authClient.emailOtp.sendVerificationOtp({ email, type: "email-verification" })
+  }
+/>
+```

--- a/packages/auth-ui/src/components/sign-in-page.tsx
+++ b/packages/auth-ui/src/components/sign-in-page.tsx
@@ -1,0 +1,280 @@
+"use client"
+
+import { useSignIn } from "@voyantjs/auth-react"
+import { VoyantApiError } from "@voyantjs/auth-react/client"
+import { Button, cn, Input, Label } from "@voyantjs/ui/components"
+import { Loader2, LogIn } from "lucide-react"
+import { type FormEvent, type ReactNode, useState } from "react"
+
+export interface SignInPageMessages {
+  title: string
+  description: string
+  emailLabel: string
+  emailPlaceholder: string
+  passwordLabel: string
+  forgotPassword: string
+  submit: string
+  signingIn: string
+  invalidEmailOrPassword: string
+  emailRequired: string
+  passwordRequired: string
+  emailNotVerified: string
+  resendVerificationCode: string
+  sending: string
+  somethingWentWrong: string
+  or: string
+  noAccount: string
+  signUp: string
+}
+
+export interface SignInSocialProvider {
+  id: string
+  label: string
+  icon?: ReactNode
+  onSignIn: (options: { redirectTo?: string }) => Promise<void> | void
+}
+
+export interface SignInPageProps {
+  className?: string
+  messages?: Partial<SignInPageMessages>
+  redirectTo?: string
+  forgotPasswordHref?: string
+  signUpHref?: string
+  socialProviders?: readonly SignInSocialProvider[]
+  onSignedIn?: (options: { redirectTo?: string }) => Promise<void> | void
+  onResendVerification?: (email: string) => Promise<void> | void
+}
+
+export const defaultSignInPageMessages: SignInPageMessages = {
+  title: "Sign in",
+  description: "Use your operator account to continue.",
+  emailLabel: "Email",
+  emailPlaceholder: "ana@example.com",
+  passwordLabel: "Password",
+  forgotPassword: "Forgot password?",
+  submit: "Sign in",
+  signingIn: "Signing in",
+  invalidEmailOrPassword: "Invalid email or password.",
+  emailRequired: "Email is required.",
+  passwordRequired: "Password is required.",
+  emailNotVerified: "Your email address has not been verified.",
+  resendVerificationCode: "Resend verification code",
+  sending: "Sending",
+  somethingWentWrong: "Something went wrong. Try again.",
+  or: "Or",
+  noAccount: "No account yet?",
+  signUp: "Create one",
+}
+
+function isEmailNotVerified(error: unknown): boolean {
+  if (error instanceof VoyantApiError && error.status === 403) {
+    return true
+  }
+
+  if (error instanceof Error) {
+    return error.message.toLowerCase().includes("not verified")
+  }
+
+  return false
+}
+
+function errorMessage(error: unknown, messages: SignInPageMessages): string {
+  if (isEmailNotVerified(error)) {
+    return messages.emailNotVerified
+  }
+
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message
+  }
+
+  return messages.invalidEmailOrPassword
+}
+
+export function SignInPage({
+  className,
+  messages: messageOverrides,
+  redirectTo,
+  forgotPasswordHref,
+  signUpHref,
+  socialProviders = [],
+  onSignedIn,
+  onResendVerification,
+}: SignInPageProps) {
+  const messages = { ...defaultSignInPageMessages, ...messageOverrides }
+  const signIn = useSignIn()
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const [emailNotVerified, setEmailNotVerified] = useState(false)
+  const [resendingVerification, setResendingVerification] = useState(false)
+  const [pendingSocialProvider, setPendingSocialProvider] = useState<string | null>(null)
+
+  const isSubmitting = signIn.email.isPending
+  const hasSocialProviders = socialProviders.length > 0
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+    setEmailNotVerified(false)
+
+    const trimmedEmail = email.trim()
+    if (!trimmedEmail) {
+      setError(messages.emailRequired)
+      return
+    }
+
+    if (!password) {
+      setError(messages.passwordRequired)
+      return
+    }
+
+    try {
+      await signIn.email.mutateAsync({ email: trimmedEmail, password, callbackURL: redirectTo })
+      await onSignedIn?.({ redirectTo })
+    } catch (err) {
+      const needsVerification = isEmailNotVerified(err)
+      setEmailNotVerified(needsVerification)
+      setError(errorMessage(err, messages))
+    }
+  }
+
+  const handleResendVerification = async () => {
+    if (!onResendVerification) {
+      return
+    }
+
+    setError(null)
+    setResendingVerification(true)
+    try {
+      await onResendVerification(email.trim())
+    } catch {
+      setError(messages.somethingWentWrong)
+    } finally {
+      setResendingVerification(false)
+    }
+  }
+
+  const handleSocialSignIn = async (provider: SignInSocialProvider) => {
+    setError(null)
+    setPendingSocialProvider(provider.id)
+    try {
+      await provider.onSignIn({ redirectTo })
+    } catch {
+      setError(messages.somethingWentWrong)
+      setPendingSocialProvider(null)
+    }
+  }
+
+  return (
+    <div
+      data-slot="sign-in-page"
+      className={cn("mx-auto flex w-full max-w-sm flex-col gap-6", className)}
+    >
+      <div className="space-y-1">
+        <h1 className="text-2xl font-bold tracking-tight">{messages.title}</h1>
+        <p className="text-sm text-muted-foreground">{messages.description}</p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {error && (
+          <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            <p>{error}</p>
+            {emailNotVerified && onResendVerification && (
+              <button
+                type="button"
+                onClick={() => void handleResendVerification()}
+                disabled={resendingVerification}
+                className="mt-2 font-medium underline hover:no-underline disabled:opacity-50"
+              >
+                {resendingVerification ? messages.sending : messages.resendVerificationCode}
+              </button>
+            )}
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <Label htmlFor="auth-sign-in-email">{messages.emailLabel}</Label>
+          <Input
+            id="auth-sign-in-email"
+            type="email"
+            placeholder={messages.emailPlaceholder}
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            required
+            autoComplete="email"
+            autoFocus
+          />
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between gap-4">
+            <Label htmlFor="auth-sign-in-password">{messages.passwordLabel}</Label>
+            {forgotPasswordHref && (
+              <a
+                href={forgotPasswordHref}
+                className="text-xs text-muted-foreground hover:underline"
+              >
+                {messages.forgotPassword}
+              </a>
+            )}
+          </div>
+          <Input
+            id="auth-sign-in-password"
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            required
+            autoComplete="current-password"
+          />
+        </div>
+
+        <Button type="submit" className="w-full" disabled={isSubmitting}>
+          {isSubmitting ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <LogIn className="mr-2 h-4 w-4" />
+          )}
+          {isSubmitting ? messages.signingIn : messages.submit}
+        </Button>
+      </form>
+
+      {hasSocialProviders && (
+        <>
+          <div className="flex items-center gap-3">
+            <div className="h-px flex-1 bg-border" />
+            <span className="text-xs uppercase text-muted-foreground">{messages.or}</span>
+            <div className="h-px flex-1 bg-border" />
+          </div>
+
+          <div className="space-y-2">
+            {socialProviders.map((provider) => {
+              const isPending = pendingSocialProvider === provider.id
+              return (
+                <Button
+                  key={provider.id}
+                  variant="outline"
+                  className="w-full"
+                  type="button"
+                  disabled={pendingSocialProvider !== null}
+                  onClick={() => void handleSocialSignIn(provider)}
+                >
+                  {isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : provider.icon}
+                  {provider.label}
+                </Button>
+              )
+            })}
+          </div>
+        </>
+      )}
+
+      {signUpHref && (
+        <p className="text-center text-sm text-muted-foreground">
+          {messages.noAccount}{" "}
+          <a href={signUpHref} className="font-medium text-primary hover:underline">
+            {messages.signUp}
+          </a>
+        </p>
+      )}
+    </div>
+  )
+}

--- a/packages/auth-ui/src/index.ts
+++ b/packages/auth-ui/src/index.ts
@@ -4,3 +4,10 @@ export {
   ServiceApiKeysPage,
   type ServiceApiKeysPageProps,
 } from "./components/service-api-keys-page.js"
+export {
+  defaultSignInPageMessages,
+  SignInPage,
+  type SignInPageMessages,
+  type SignInPageProps,
+  type SignInSocialProvider,
+} from "./components/sign-in-page.js"

--- a/packages/auth-ui/src/sign-in-page.test.tsx
+++ b/packages/auth-ui/src/sign-in-page.test.tsx
@@ -1,0 +1,33 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { VoyantAuthProvider, type VoyantFetcher } from "@voyantjs/auth-react"
+import type { ReactNode } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+
+import { SignInPage } from "./components/sign-in-page.js"
+
+function renderWithProviders(element: ReactNode) {
+  const fetcher: VoyantFetcher = async () => new Response(null, { status: 204 })
+
+  return renderToStaticMarkup(
+    <QueryClientProvider client={new QueryClient()}>
+      <VoyantAuthProvider baseUrl="https://operator.example/api" fetcher={fetcher}>
+        {element}
+      </VoyantAuthProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe("SignInPage", () => {
+  it("renders the reusable email/password sign-in surface", () => {
+    const markup = renderWithProviders(
+      <SignInPage forgotPasswordHref="/forgot-password" signUpHref="/sign-up" />,
+    )
+
+    expect(markup).toContain("Sign in")
+    expect(markup).toContain("auth-sign-in-email")
+    expect(markup).toContain("auth-sign-in-password")
+    expect(markup).toContain("/forgot-password")
+    expect(markup).toContain("/sign-up")
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `useSignIn()` and `signInWithEmail()` to `@voyantjs/auth-react`, posting to the mounted Better Auth email sign-in endpoint and refreshing Voyant auth state after success.
- Adds a reusable, router-agnostic `SignInPage` to `@voyantjs/auth-ui` with email/password sign-in, optional forgot-password/sign-up links, social provider hooks, and verification resend hook wiring.
- Documents the new auth-react/auth-ui surfaces and adds tests plus changesets for both packages.

Advances #655.

## Validation
- `pnpm --filter @voyantjs/auth-react test`
- `pnpm --filter @voyantjs/auth-ui test`
- `pnpm --filter @voyantjs/auth-react typecheck`
- `pnpm --filter @voyantjs/auth-ui typecheck`
- `pnpm --filter @voyantjs/auth-react build`
- `pnpm --filter @voyantjs/auth-ui build`
- `pnpm lint:changed`
- pre-push `pnpm test`