### PR TITLE
feat(ui): add auth and checkout i18n providers

### DIFF
--- a/.changeset/auth-checkout-ui-i18n.md
+++ b/.changeset/auth-checkout-ui-i18n.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/auth-ui": "minor"
+"@voyantjs/checkout-ui": "minor"
+---
+
+Add provider-backed English and Romanian i18n surfaces for auth and checkout UI components.

--- a/packages/auth-ui/package.json
+++ b/packages/auth-ui/package.json
@@ -12,6 +12,9 @@
   "exports": {
     ".": "./src/index.ts",
     "./styles.css": "./src/styles.css",
+    "./i18n": "./src/i18n/index.ts",
+    "./i18n/en": "./src/i18n/en.ts",
+    "./i18n/ro": "./src/i18n/ro.ts",
     "./components/*": "./src/components/*.tsx"
   },
   "scripts": {
@@ -25,6 +28,7 @@
   "peerDependencies": {
     "@tanstack/react-query": "^5.0.0",
     "@voyantjs/auth-react": "workspace:*",
+    "@voyantjs/i18n": "workspace:*",
     "@voyantjs/types": "workspace:*",
     "@voyantjs/ui": "workspace:*",
     "lucide-react": "^0.475.0 || ^1.0.0",
@@ -36,6 +40,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@voyantjs/auth-react": "workspace:*",
+    "@voyantjs/i18n": "workspace:*",
     "@voyantjs/types": "workspace:*",
     "@voyantjs/ui": "workspace:*",
     "@voyantjs/voyant-typescript-config": "workspace:*",
@@ -59,6 +64,21 @@
       },
       "./styles.css": {
         "default": "./src/styles.css"
+      },
+      "./i18n": {
+        "types": "./dist/i18n/index.d.ts",
+        "import": "./dist/i18n/index.js",
+        "default": "./dist/i18n/index.js"
+      },
+      "./i18n/en": {
+        "types": "./dist/i18n/en.d.ts",
+        "import": "./dist/i18n/en.js",
+        "default": "./dist/i18n/en.js"
+      },
+      "./i18n/ro": {
+        "types": "./dist/i18n/ro.d.ts",
+        "import": "./dist/i18n/ro.js",
+        "default": "./dist/i18n/ro.js"
       },
       "./components/*": {
         "types": "./dist/components/*.d.ts",

--- a/packages/auth-ui/src/components/service-api-keys-page.tsx
+++ b/packages/auth-ui/src/components/service-api-keys-page.tsx
@@ -6,6 +6,7 @@ import {
   useApiTokenMutation,
   useApiTokens,
 } from "@voyantjs/auth-react"
+import { formatMessage } from "@voyantjs/i18n"
 import {
   API_KEY_PERMISSION_GROUPS,
   API_KEY_PERMISSION_PRESETS,
@@ -40,13 +41,7 @@ import {
 } from "lucide-react"
 import { type FormEvent, useMemo, useState } from "react"
 
-const expirationOptions = [
-  { label: "No expiration", days: null },
-  { label: "7 days", days: 7 },
-  { label: "30 days", days: 30 },
-  { label: "90 days", days: 90 },
-  { label: "1 year", days: 365 },
-] as const
+import { useAuthUiMessagesOrDefault } from "../i18n/provider.js"
 
 export interface ServiceApiKeysPageProps {
   className?: string
@@ -61,8 +56,8 @@ function expiresInSeconds(days: number | null): number | null {
   return days === null ? null : days * 24 * 60 * 60
 }
 
-function formatDate(value: string | null | undefined): string {
-  if (!value) return "Never"
+function formatDate(value: string | null | undefined, fallback: string): string {
+  if (!value) return fallback
   const date = new Date(value)
   if (Number.isNaN(date.getTime())) return value
   return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(
@@ -70,8 +65,8 @@ function formatDate(value: string | null | undefined): string {
   )
 }
 
-function permissionLabel(permission: string): string {
-  if (permission === "*") return "Full access"
+function permissionLabel(permission: string, fullAccessLabel: string): string {
+  if (permission === "*") return fullAccessLabel
   const [resource, action] = permission.split(":")
   return `${resource ?? permission}:${action ?? ""}`
 }
@@ -114,9 +109,19 @@ function useClipboard() {
 export function ServiceApiKeysPage({
   className,
   pageSize = 25,
-  title = "API tokens",
-  description = "Create permissioned API tokens for automation, integrations, and third-party systems.",
+  title,
+  description,
 }: ServiceApiKeysPageProps) {
+  const messages = useAuthUiMessagesOrDefault().serviceApiKeysPage
+  const pageTitle = title ?? messages.title
+  const pageDescription = description ?? messages.description
+  const expirationOptions = [
+    { label: messages.create.expirationOptions.never, days: null },
+    { label: messages.create.expirationOptions.sevenDays, days: 7 },
+    { label: messages.create.expirationOptions.thirtyDays, days: 30 },
+    { label: messages.create.expirationOptions.ninetyDays, days: 90 },
+    { label: messages.create.expirationOptions.oneYear, days: 365 },
+  ] as const
   const keys = useApiTokens({ limit: pageSize, sortBy: "createdAt", sortDirection: "desc" })
   const mutations = useApiTokenMutation()
   const clipboard = useClipboard()
@@ -148,12 +153,12 @@ export function ServiceApiKeysPage({
     setCreatedKey(null)
 
     if (!name.trim()) {
-      setError("Token name is required.")
+      setError(messages.create.errors.nameRequired)
       return
     }
 
     if (permissionsToStrings(selectedPermissions).length === 0) {
-      setError("Select at least one permission.")
+      setError(messages.create.errors.permissionRequired)
       return
     }
 
@@ -166,15 +171,15 @@ export function ServiceApiKeysPage({
       setCreatedKey(result)
       setName("")
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Could not create API token.")
+      setError(err instanceof Error ? err.message : messages.create.errors.createFailed)
     }
   }
 
   return (
     <div data-slot="api-tokens-page" className={cn("flex flex-col gap-6 p-6", className)}>
       <div>
-        <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
-        <p className="text-sm text-muted-foreground">{description}</p>
+        <h1 className="text-2xl font-bold tracking-tight">{pageTitle}</h1>
+        <p className="text-sm text-muted-foreground">{pageDescription}</p>
       </div>
 
       {createdKey && (
@@ -182,9 +187,9 @@ export function ServiceApiKeysPage({
           <CardHeader>
             <CardTitle className="flex items-center gap-2 text-base">
               <KeyRound className="h-4 w-4" />
-              New token
+              {messages.createdToken.title}
             </CardTitle>
-            <CardDescription>This token is shown once. Store it before leaving.</CardDescription>
+            <CardDescription>{messages.createdToken.description}</CardDescription>
           </CardHeader>
           <CardContent className="flex flex-col gap-3 sm:flex-row">
             <Input value={createdKey.key} readOnly className="font-mono text-xs" />
@@ -198,7 +203,7 @@ export function ServiceApiKeysPage({
               ) : (
                 <Copy className="mr-2 h-4 w-4" />
               )}
-              Copy
+              {messages.createdToken.copy}
             </Button>
           </CardContent>
         </Card>
@@ -206,7 +211,7 @@ export function ServiceApiKeysPage({
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Create token</CardTitle>
+          <CardTitle className="text-base">{messages.create.title}</CardTitle>
           <CardDescription>{selectedDescription}</CardDescription>
         </CardHeader>
         <CardContent>
@@ -219,16 +224,16 @@ export function ServiceApiKeysPage({
 
             <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_180px]">
               <div className="space-y-2">
-                <Label htmlFor="api-token-name">Name</Label>
+                <Label htmlFor="api-token-name">{messages.create.name}</Label>
                 <Input
                   id="api-token-name"
                   value={name}
                   onChange={(event) => setName(event.target.value)}
-                  placeholder="CMS sync, webhook relay, nightly automation"
+                  placeholder={messages.create.namePlaceholder}
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="api-token-expiration">Expiration</Label>
+                <Label htmlFor="api-token-expiration">{messages.create.expiration}</Label>
                 <select
                   id="api-token-expiration"
                   value={expirationDays ?? "never"}
@@ -314,7 +319,7 @@ export function ServiceApiKeysPage({
                 ) : (
                   <Plus className="mr-2 h-4 w-4" />
                 )}
-                Create token
+                {messages.create.submit}
               </Button>
             </div>
           </form>
@@ -322,10 +327,10 @@ export function ServiceApiKeysPage({
       </Card>
 
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold">Existing tokens</h2>
+        <h2 className="text-lg font-semibold">{messages.list.title}</h2>
         <Button type="button" variant="outline" size="sm" onClick={() => void keys.refetch()}>
           <RefreshCw className="mr-2 h-4 w-4" />
-          Refresh
+          {messages.list.refresh}
         </Button>
       </div>
 
@@ -333,7 +338,7 @@ export function ServiceApiKeysPage({
         <Card>
           <CardContent className="flex items-center gap-2 py-6 text-sm text-muted-foreground">
             <Loader2 className="h-4 w-4 animate-spin" />
-            Loading tokens
+            {messages.list.loading}
           </CardContent>
         </Card>
       ) : keys.data?.apiKeys.length ? (
@@ -345,7 +350,7 @@ export function ServiceApiKeysPage({
       ) : (
         <Card>
           <CardContent className="py-6 text-sm text-muted-foreground">
-            No API tokens have been created yet.
+            {messages.list.empty}
           </CardContent>
         </Card>
       )}
@@ -356,6 +361,7 @@ export function ServiceApiKeysPage({
 export const ApiTokensPage = ServiceApiKeysPage
 
 function ServiceApiKeyRow({ apiKey }: { apiKey: ApiToken }) {
+  const messages = useAuthUiMessagesOrDefault().serviceApiKeysPage
   const mutations = useApiTokenMutation()
   const enabled = apiKey.enabled !== false
 
@@ -364,9 +370,9 @@ function ServiceApiKeyRow({ apiKey }: { apiKey: ApiToken }) {
       <CardContent className="flex flex-col gap-4 py-4 lg:flex-row lg:items-center lg:justify-between">
         <div className="min-w-0 space-y-2">
           <div className="flex flex-wrap items-center gap-2">
-            <h3 className="font-medium">{apiKey.name || "Untitled token"}</h3>
+            <h3 className="font-medium">{apiKey.name || messages.list.untitled}</h3>
             <Badge variant={enabled ? "default" : "secondary"}>
-              {enabled ? "Enabled" : "Disabled"}
+              {enabled ? messages.list.enabled : messages.list.disabled}
             </Badge>
             {apiKey.start && <Badge variant="outline">{apiKey.start}</Badge>}
           </div>
@@ -374,16 +380,19 @@ function ServiceApiKeyRow({ apiKey }: { apiKey: ApiToken }) {
             {apiKey.permissionList.length ? (
               apiKey.permissionList.map((permission) => (
                 <Badge key={permission} variant="outline" className="font-mono text-[11px]">
-                  {permissionLabel(permission)}
+                  {permissionLabel(permission, messages.permissions.fullAccess)}
                 </Badge>
               ))
             ) : (
-              <span className="text-xs text-muted-foreground">No permissions</span>
+              <span className="text-xs text-muted-foreground">{messages.list.noPermissions}</span>
             )}
           </div>
           <p className="text-xs text-muted-foreground">
-            Created {formatDate(apiKey.createdAt)} · Expires {formatDate(apiKey.expiresAt)} · Last
-            used {formatDate(apiKey.lastRequest)}
+            {formatMessage(messages.list.metadata, {
+              created: formatDate(apiKey.createdAt, messages.date.never),
+              expires: formatDate(apiKey.expiresAt, messages.date.never),
+              lastUsed: formatDate(apiKey.lastRequest, messages.date.never),
+            })}
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
@@ -397,7 +406,7 @@ function ServiceApiKeyRow({ apiKey }: { apiKey: ApiToken }) {
             }
           >
             {enabled ? <PowerOff className="mr-2 h-4 w-4" /> : <Power className="mr-2 h-4 w-4" />}
-            {enabled ? "Disable" : "Enable"}
+            {enabled ? messages.list.disable : messages.list.enable}
           </Button>
           <Button
             type="button"
@@ -407,7 +416,7 @@ function ServiceApiKeyRow({ apiKey }: { apiKey: ApiToken }) {
             onClick={() => void mutations.remove.mutateAsync({ keyId: apiKey.id })}
           >
             <Trash2 className="mr-2 h-4 w-4" />
-            Delete
+            {messages.list.delete}
           </Button>
         </div>
       </CardContent>

--- a/packages/auth-ui/src/components/service-api-keys-page.tsx
+++ b/packages/auth-ui/src/components/service-api-keys-page.tsx
@@ -41,7 +41,7 @@ import {
 } from "lucide-react"
 import { type FormEvent, useMemo, useState } from "react"
 
-import { useAuthUiMessagesOrDefault } from "../i18n/provider.js"
+import { useAuthUiI18nOrDefault, useAuthUiMessagesOrDefault } from "../i18n/provider.js"
 
 export interface ServiceApiKeysPageProps {
   className?: string
@@ -56,13 +56,13 @@ function expiresInSeconds(days: number | null): number | null {
   return days === null ? null : days * 24 * 60 * 60
 }
 
-function formatDate(value: string | null | undefined, fallback: string): string {
+function formatDate(
+  value: string | null | undefined,
+  fallback: string,
+  formatDateTime: (value: string) => string,
+): string {
   if (!value) return fallback
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return value
-  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(
-    date,
-  )
+  return formatDateTime(value)
 }
 
 function permissionLabel(permission: string, fullAccessLabel: string): string {
@@ -361,7 +361,8 @@ export function ServiceApiKeysPage({
 export const ApiTokensPage = ServiceApiKeysPage
 
 function ServiceApiKeyRow({ apiKey }: { apiKey: ApiToken }) {
-  const messages = useAuthUiMessagesOrDefault().serviceApiKeysPage
+  const i18n = useAuthUiI18nOrDefault()
+  const messages = i18n.messages.serviceApiKeysPage
   const mutations = useApiTokenMutation()
   const enabled = apiKey.enabled !== false
 
@@ -389,9 +390,9 @@ function ServiceApiKeyRow({ apiKey }: { apiKey: ApiToken }) {
           </div>
           <p className="text-xs text-muted-foreground">
             {formatMessage(messages.list.metadata, {
-              created: formatDate(apiKey.createdAt, messages.date.never),
-              expires: formatDate(apiKey.expiresAt, messages.date.never),
-              lastUsed: formatDate(apiKey.lastRequest, messages.date.never),
+              created: formatDate(apiKey.createdAt, messages.date.never, i18n.formatDateTime),
+              expires: formatDate(apiKey.expiresAt, messages.date.never, i18n.formatDateTime),
+              lastUsed: formatDate(apiKey.lastRequest, messages.date.never, i18n.formatDateTime),
             })}
           </p>
         </div>

--- a/packages/auth-ui/src/i18n.test.tsx
+++ b/packages/auth-ui/src/i18n.test.tsx
@@ -1,0 +1,56 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+
+import {
+  AuthUiMessagesProvider,
+  getAuthUiI18n,
+  resolveAuthUiMessages,
+  useAuthUiMessagesOrDefault,
+} from "./i18n/index.js"
+
+describe("auth-ui i18n", () => {
+  it("resolves romanian messages with fallback", () => {
+    const messages = getAuthUiI18n({ locale: "ro-RO" }).messages
+
+    expect(messages.serviceApiKeysPage.title).toBe("Tokenuri API")
+    expect(messages.serviceApiKeysPage.create.submit).toBe("Creeaza token")
+  })
+
+  it("applies overrides", () => {
+    const messages = resolveAuthUiMessages({
+      locale: "ro",
+      overrides: {
+        locales: {
+          ro: {
+            serviceApiKeysPage: {
+              list: {
+                refresh: "Actualizeaza",
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(messages.serviceApiKeysPage.list.refresh).toBe("Actualizeaza")
+  })
+
+  it("falls back to english outside a provider", () => {
+    expect(renderToStaticMarkup(<MessageProbe />)).toContain("API tokens")
+  })
+
+  it("provides romanian messages through the provider", () => {
+    const html = renderToStaticMarkup(
+      <AuthUiMessagesProvider locale="ro-RO">
+        <MessageProbe />
+      </AuthUiMessagesProvider>,
+    )
+
+    expect(html).toContain("Tokenuri API")
+  })
+})
+
+function MessageProbe() {
+  const messages = useAuthUiMessagesOrDefault()
+  return <span>{messages.serviceApiKeysPage.title}</span>
+}

--- a/packages/auth-ui/src/i18n.test.tsx
+++ b/packages/auth-ui/src/i18n.test.tsx
@@ -5,6 +5,7 @@ import {
   AuthUiMessagesProvider,
   getAuthUiI18n,
   resolveAuthUiMessages,
+  useAuthUiI18nOrDefault,
   useAuthUiMessagesOrDefault,
 } from "./i18n/index.js"
 
@@ -48,9 +49,30 @@ describe("auth-ui i18n", () => {
 
     expect(html).toContain("Tokenuri API")
   })
+
+  it("provides locale-aware date formatters through the provider", () => {
+    const value = "2026-05-12T13:45:00.000Z"
+    const expected = new Intl.DateTimeFormat("ro-RO", {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(new Date(value))
+
+    const html = renderToStaticMarkup(
+      <AuthUiMessagesProvider locale="ro-RO">
+        <FormatterProbe value={value} />
+      </AuthUiMessagesProvider>,
+    )
+
+    expect(html).toContain(expected)
+  })
 })
 
 function MessageProbe() {
   const messages = useAuthUiMessagesOrDefault()
   return <span>{messages.serviceApiKeysPage.title}</span>
+}
+
+function FormatterProbe({ value }: { value: string }) {
+  const i18n = useAuthUiI18nOrDefault()
+  return <span>{i18n.formatDateTime(value)}</span>
 }

--- a/packages/auth-ui/src/i18n/en.ts
+++ b/packages/auth-ui/src/i18n/en.ts
@@ -1,0 +1,53 @@
+import type { AuthUiMessages } from "./messages.js"
+
+export const authUiEn: AuthUiMessages = {
+  serviceApiKeysPage: {
+    title: "API tokens",
+    description:
+      "Create permissioned API tokens for automation, integrations, and third-party systems.",
+    createdToken: {
+      title: "New token",
+      description: "This token is shown once. Store it before leaving.",
+      copy: "Copy",
+    },
+    create: {
+      title: "Create token",
+      name: "Name",
+      namePlaceholder: "CMS sync, webhook relay, nightly automation",
+      expiration: "Expiration",
+      submit: "Create token",
+      errors: {
+        nameRequired: "Token name is required.",
+        permissionRequired: "Select at least one permission.",
+        createFailed: "Could not create API token.",
+      },
+      expirationOptions: {
+        never: "No expiration",
+        sevenDays: "7 days",
+        thirtyDays: "30 days",
+        ninetyDays: "90 days",
+        oneYear: "1 year",
+      },
+    },
+    list: {
+      title: "Existing tokens",
+      refresh: "Refresh",
+      loading: "Loading tokens",
+      empty: "No API tokens have been created yet.",
+      untitled: "Untitled token",
+      enabled: "Enabled",
+      disabled: "Disabled",
+      noPermissions: "No permissions",
+      metadata: "Created {created} · Expires {expires} · Last used {lastUsed}",
+      disable: "Disable",
+      enable: "Enable",
+      delete: "Delete",
+    },
+    permissions: {
+      fullAccess: "Full access",
+    },
+    date: {
+      never: "Never",
+    },
+  },
+}

--- a/packages/auth-ui/src/i18n/index.ts
+++ b/packages/auth-ui/src/i18n/index.ts
@@ -1,0 +1,14 @@
+export { authUiEn } from "./en.js"
+export type { AuthUiMessages } from "./messages.js"
+export {
+  type AuthUiMessageOverrides,
+  AuthUiMessagesProvider,
+  authUiMessageDefinitions,
+  getAuthUiI18n,
+  resolveAuthUiMessages,
+  useAuthUiI18n,
+  useAuthUiI18nOrDefault,
+  useAuthUiMessages,
+  useAuthUiMessagesOrDefault,
+} from "./provider.js"
+export { authUiRo } from "./ro.js"

--- a/packages/auth-ui/src/i18n/messages.ts
+++ b/packages/auth-ui/src/i18n/messages.ts
@@ -1,0 +1,50 @@
+export type AuthUiMessages = {
+  serviceApiKeysPage: {
+    title: string
+    description: string
+    createdToken: {
+      title: string
+      description: string
+      copy: string
+    }
+    create: {
+      title: string
+      name: string
+      namePlaceholder: string
+      expiration: string
+      submit: string
+      errors: {
+        nameRequired: string
+        permissionRequired: string
+        createFailed: string
+      }
+      expirationOptions: {
+        never: string
+        sevenDays: string
+        thirtyDays: string
+        ninetyDays: string
+        oneYear: string
+      }
+    }
+    list: {
+      title: string
+      refresh: string
+      loading: string
+      empty: string
+      untitled: string
+      enabled: string
+      disabled: string
+      noPermissions: string
+      metadata: string
+      disable: string
+      enable: string
+      delete: string
+    }
+    permissions: {
+      fullAccess: string
+    }
+    date: {
+      never: string
+    }
+  }
+}

--- a/packages/auth-ui/src/i18n/provider.tsx
+++ b/packages/auth-ui/src/i18n/provider.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import {
+  createLocaleFormatters,
+  createPackageMessagesContext,
+  type LocaleMessageDefinitions,
+  type LocaleMessageOverrides,
+  type PackageI18nValue,
+  resolvePackageMessages,
+} from "@voyantjs/i18n"
+import type { ReactNode } from "react"
+
+import { authUiEn } from "./en.js"
+import type { AuthUiMessages } from "./messages.js"
+import { authUiRo } from "./ro.js"
+
+const fallbackLocale = "en"
+
+export const authUiMessageDefinitions = {
+  en: authUiEn,
+  ro: authUiRo,
+} satisfies LocaleMessageDefinitions<AuthUiMessages>
+
+export type AuthUiMessageOverrides = LocaleMessageOverrides<AuthUiMessages>
+
+const authUiContext = createPackageMessagesContext<AuthUiMessages>("AuthUiMessages")
+
+const defaultAuthUiI18n: PackageI18nValue<AuthUiMessages> = {
+  messages: authUiEn,
+  ...createLocaleFormatters(fallbackLocale),
+}
+
+export function resolveAuthUiMessages({
+  locale,
+  overrides,
+}: {
+  locale: string | null | undefined
+  overrides?: AuthUiMessageOverrides | null
+}) {
+  return resolvePackageMessages({
+    definitions: authUiMessageDefinitions,
+    fallbackLocale,
+    locale,
+    overrides,
+  })
+}
+
+export function getAuthUiI18n({
+  locale,
+  overrides,
+}: {
+  locale?: string | null | undefined
+  overrides?: AuthUiMessageOverrides | null
+}): PackageI18nValue<AuthUiMessages> {
+  const resolvedLocale = locale ?? fallbackLocale
+  return {
+    messages: resolveAuthUiMessages({ locale: resolvedLocale, overrides }),
+    ...createLocaleFormatters(resolvedLocale),
+  }
+}
+
+export function AuthUiMessagesProvider({
+  children,
+  locale,
+  overrides,
+}: {
+  children: ReactNode
+  locale: string | null | undefined
+  overrides?: AuthUiMessageOverrides | null
+}) {
+  return (
+    <authUiContext.ResolvedMessagesProvider
+      definitions={authUiMessageDefinitions}
+      fallbackLocale={fallbackLocale}
+      locale={locale}
+      overrides={overrides}
+    >
+      {children}
+    </authUiContext.ResolvedMessagesProvider>
+  )
+}
+
+export const useAuthUiI18n = authUiContext.useI18n
+export const useAuthUiMessages = authUiContext.useMessages
+
+export function useAuthUiI18nOrDefault() {
+  return authUiContext.useOptionalI18n() ?? defaultAuthUiI18n
+}
+
+export function useAuthUiMessagesOrDefault() {
+  return useAuthUiI18nOrDefault().messages
+}

--- a/packages/auth-ui/src/i18n/ro.ts
+++ b/packages/auth-ui/src/i18n/ro.ts
@@ -1,0 +1,53 @@
+import type { AuthUiMessages } from "./messages.js"
+
+export const authUiRo: AuthUiMessages = {
+  serviceApiKeysPage: {
+    title: "Tokenuri API",
+    description:
+      "Creeaza tokenuri API cu permisiuni pentru automatizari, integrari si sisteme terte.",
+    createdToken: {
+      title: "Token nou",
+      description: "Acest token este afisat o singura data. Salveaza-l inainte sa pleci.",
+      copy: "Copiaza",
+    },
+    create: {
+      title: "Creeaza token",
+      name: "Nume",
+      namePlaceholder: "Sincronizare CMS, webhook relay, automatizare nocturna",
+      expiration: "Expirare",
+      submit: "Creeaza token",
+      errors: {
+        nameRequired: "Numele tokenului este obligatoriu.",
+        permissionRequired: "Selecteaza cel putin o permisiune.",
+        createFailed: "Tokenul API nu a putut fi creat.",
+      },
+      expirationOptions: {
+        never: "Fara expirare",
+        sevenDays: "7 zile",
+        thirtyDays: "30 de zile",
+        ninetyDays: "90 de zile",
+        oneYear: "1 an",
+      },
+    },
+    list: {
+      title: "Tokenuri existente",
+      refresh: "Reincarca",
+      loading: "Se incarca tokenurile",
+      empty: "Nu a fost creat inca niciun token API.",
+      untitled: "Token fara nume",
+      enabled: "Activ",
+      disabled: "Inactiv",
+      noPermissions: "Fara permisiuni",
+      metadata: "Creat {created} · Expira {expires} · Ultima utilizare {lastUsed}",
+      disable: "Dezactiveaza",
+      enable: "Activeaza",
+      delete: "Sterge",
+    },
+    permissions: {
+      fullAccess: "Acces complet",
+    },
+    date: {
+      never: "Niciodata",
+    },
+  },
+}

--- a/packages/auth-ui/src/index.ts
+++ b/packages/auth-ui/src/index.ts
@@ -11,3 +11,15 @@ export {
   type SignInPageProps,
   type SignInSocialProvider,
 } from "./components/sign-in-page.js"
+export type { AuthUiMessages } from "./i18n/index.js"
+export {
+  type AuthUiMessageOverrides,
+  AuthUiMessagesProvider,
+  authUiMessageDefinitions,
+  getAuthUiI18n,
+  resolveAuthUiMessages,
+  useAuthUiI18n,
+  useAuthUiI18nOrDefault,
+  useAuthUiMessages,
+  useAuthUiMessagesOrDefault,
+} from "./i18n/index.js"

--- a/packages/checkout-ui/package.json
+++ b/packages/checkout-ui/package.json
@@ -12,6 +12,9 @@
   "exports": {
     ".": "./src/index.ts",
     "./styles.css": "./src/styles.css",
+    "./i18n": "./src/i18n/index.ts",
+    "./i18n/en": "./src/i18n/en.ts",
+    "./i18n/ro": "./src/i18n/ro.ts",
     "./components/*": "./src/components/*.tsx"
   },
   "scripts": {
@@ -27,6 +30,7 @@
     "@voyantjs/checkout-react": "workspace:*",
     "@voyantjs/finance": "workspace:*",
     "@voyantjs/finance-react": "workspace:*",
+    "@voyantjs/i18n": "workspace:*",
     "@voyantjs/ui": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "react": "^19.0.0",
@@ -41,6 +45,7 @@
     "@voyantjs/checkout-react": "workspace:*",
     "@voyantjs/finance": "workspace:*",
     "@voyantjs/finance-react": "workspace:*",
+    "@voyantjs/i18n": "workspace:*",
     "@voyantjs/ui": "workspace:*",
     "@voyantjs/voyant-typescript-config": "workspace:*",
     "lucide-react": "^0.475.0",
@@ -64,6 +69,21 @@
       },
       "./styles.css": {
         "default": "./src/styles.css"
+      },
+      "./i18n": {
+        "types": "./dist/i18n/index.d.ts",
+        "import": "./dist/i18n/index.js",
+        "default": "./dist/i18n/index.js"
+      },
+      "./i18n/en": {
+        "types": "./dist/i18n/en.d.ts",
+        "import": "./dist/i18n/en.js",
+        "default": "./dist/i18n/en.js"
+      },
+      "./i18n/ro": {
+        "types": "./dist/i18n/ro.d.ts",
+        "import": "./dist/i18n/ro.js",
+        "default": "./dist/i18n/ro.js"
       },
       "./components/*": {
         "types": "./dist/components/*.d.ts",

--- a/packages/checkout-ui/src/components/collect-payment-dialog.tsx
+++ b/packages/checkout-ui/src/components/collect-payment-dialog.tsx
@@ -2,6 +2,7 @@
 
 import type { InitiatedCheckoutCollectionRecord } from "@voyantjs/checkout"
 import { type PaymentChoice, useCollectPayment } from "@voyantjs/checkout-react"
+import { formatMessage } from "@voyantjs/i18n"
 import { Button } from "@voyantjs/ui/components/button"
 import {
   Dialog,
@@ -17,6 +18,7 @@ import { CheckCircle2, Copy, ExternalLink, Loader2 } from "lucide-react"
 import { useMemo, useState } from "react"
 import { toast } from "sonner"
 
+import { useCheckoutUiMessagesOrDefault } from "../i18n/provider.js"
 import { PaymentStep } from "./payment-step.js"
 
 /**
@@ -89,6 +91,7 @@ export function CollectPaymentDialog({
   cancelUrl,
   cardProvider,
 }: CollectPaymentDialogProps) {
+  const messages = useCheckoutUiMessagesOrDefault().collectPaymentDialog
   const [amountCents, setAmountCents] = useState<number>(defaultAmountCents ?? 0)
   const [choice, setChoice] = useState<PaymentChoice | null>(null)
   const [result, setResult] = useState<InitiatedCheckoutCollectionRecord | null>(null)
@@ -116,17 +119,17 @@ export function CollectPaymentDialog({
 
   async function submit() {
     if (!choice || choice.type !== "hold") {
-      toast.error("Pick 'Hold — generate payment link' to produce a shareable link.")
+      toast.error(messages.validation.pickHold)
       return
     }
     if (amountCents <= 0) {
-      toast.error("Enter an amount above zero.")
+      toast.error(messages.validation.amountAboveZero)
       return
     }
     try {
       const data = await collect.mutateAsync({ choice, amountCents })
       setResult(data)
-      toast.success("Payment link ready — copy or share it with the customer.")
+      toast.success(messages.validation.linkReady)
     } catch (err) {
       toast.error((err as Error).message)
     }
@@ -142,11 +145,8 @@ export function CollectPaymentDialog({
     >
       <DialogContent className="max-w-xl">
         <DialogHeader>
-          <DialogTitle>Generate payment link</DialogTitle>
-          <DialogDescription>
-            Hold the booking and produce a payment link the customer can open to pay by card or bank
-            transfer. Share it however you prefer (email, chat, etc.).
-          </DialogDescription>
+          <DialogTitle>{messages.title}</DialogTitle>
+          <DialogDescription>{messages.description}</DialogDescription>
         </DialogHeader>
 
         {result ? (
@@ -154,7 +154,9 @@ export function CollectPaymentDialog({
         ) : (
           <div className="flex flex-col gap-5">
             <div className="flex flex-col gap-2">
-              <Label htmlFor="collect-amount">Amount ({defaultCurrency})</Label>
+              <Label htmlFor="collect-amount">
+                {formatMessage(messages.amountLabel, { currency: defaultCurrency })}
+              </Label>
               <Input
                 id="collect-amount"
                 type="number"
@@ -167,9 +169,7 @@ export function CollectPaymentDialog({
                   setAmountCents(Number.isFinite(raw) ? Math.round(raw * 100) : 0)
                 }}
               />
-              <p className="text-muted-foreground text-xs">
-                Defaults to the booking's sell amount. Override for a deposit or partial collection.
-              </p>
+              <p className="text-muted-foreground text-xs">{messages.amountHelp}</p>
             </div>
 
             <PaymentStep value={choice} onChange={setChoice} capabilities={CAPABILITIES} />
@@ -178,7 +178,7 @@ export function CollectPaymentDialog({
 
         <DialogFooter>
           {result ? (
-            <Button onClick={() => onOpenChange(false)}>Done</Button>
+            <Button onClick={() => onOpenChange(false)}>{messages.done}</Button>
           ) : (
             <>
               <Button
@@ -186,11 +186,11 @@ export function CollectPaymentDialog({
                 onClick={() => onOpenChange(false)}
                 disabled={collect.isPending}
               >
-                Cancel
+                {messages.cancel}
               </Button>
               <Button onClick={submit} disabled={collect.isPending || choice?.type !== "hold"}>
                 {collect.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                Generate link
+                {messages.generateLink}
               </Button>
             </>
           )}
@@ -201,6 +201,7 @@ export function CollectPaymentDialog({
 }
 
 function ResultPanel({ result }: { result: InitiatedCheckoutCollectionRecord }) {
+  const messages = useCheckoutUiMessagesOrDefault().collectPaymentDialog
   const sessionId = result.paymentSession?.id ?? null
   const landingUrl =
     sessionId && typeof window !== "undefined" ? `${window.location.origin}/pay/${sessionId}` : null
@@ -208,8 +209,9 @@ function ResultPanel({ result }: { result: InitiatedCheckoutCollectionRecord }) 
   if (!landingUrl) {
     return (
       <div className="rounded-xl border border-amber-500/40 bg-amber-500/5 p-5 text-sm">
-        The session was created but no link could be built. Session id:{" "}
-        <span className="font-mono">{sessionId ?? "—"}</span>.
+        {formatMessage(messages.result.noLink, {
+          sessionId: sessionId ?? messages.result.noSession,
+        })}
       </div>
     )
   }
@@ -218,16 +220,14 @@ function ResultPanel({ result }: { result: InitiatedCheckoutCollectionRecord }) 
     <div className="flex flex-col gap-4 rounded-xl border bg-card p-5">
       <div className="flex items-center gap-2 text-emerald-700">
         <CheckCircle2 className="h-5 w-5" />
-        <span className="font-medium">Payment link ready</span>
+        <span className="font-medium">{messages.result.ready}</span>
       </div>
-      <p className="text-muted-foreground text-sm">
-        Share this link with the customer. They'll choose card or bank transfer on the page.
-      </p>
+      <p className="text-muted-foreground text-sm">{messages.result.body}</p>
       <div className="flex items-center gap-2 rounded-md border bg-muted/30 p-3 font-mono text-xs">
         <span className="flex-1 break-all">{landingUrl}</span>
         <button
           type="button"
-          aria-label="Copy link"
+          aria-label={messages.result.copyLink}
           className="text-muted-foreground hover:text-foreground"
           onClick={() => {
             navigator.clipboard?.writeText(landingUrl).catch(() => undefined)
@@ -239,7 +239,7 @@ function ResultPanel({ result }: { result: InitiatedCheckoutCollectionRecord }) 
           href={landingUrl}
           target="_blank"
           rel="noreferrer"
-          aria-label="Open link"
+          aria-label={messages.result.openLink}
           className="text-muted-foreground hover:text-foreground"
         >
           <ExternalLink className="h-3.5 w-3.5" />

--- a/packages/checkout-ui/src/components/payment-link-landing-page.tsx
+++ b/packages/checkout-ui/src/components/payment-link-landing-page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import type { PublicPaymentSession } from "@voyantjs/finance/public-validation"
+import { formatMessage } from "@voyantjs/i18n"
 import { Button } from "@voyantjs/ui/components/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@voyantjs/ui/components/tabs"
 import { cn } from "@voyantjs/ui/lib/utils"
@@ -14,6 +15,9 @@ import {
   Loader2,
 } from "lucide-react"
 import { type ReactNode, useState } from "react"
+
+import type { CheckoutUiMessages } from "../i18n/messages.js"
+import { useCheckoutUiMessagesOrDefault } from "../i18n/provider.js"
 
 interface StartCardResponse {
   data?: { redirectUrl: string | null }
@@ -109,9 +113,12 @@ export function PaymentLinkLandingPage({
 // ─────────────────────────────────────────────────────────────────────────────
 
 function Header({ session, description }: { session: PublicPaymentSession; description?: string }) {
+  const messages = useCheckoutUiMessagesOrDefault().paymentLinkLandingPage
   return (
     <header className="flex flex-col gap-2 border-b pb-4">
-      <h1 className="font-semibold text-2xl">{description ?? defaultDescription(session)}</h1>
+      <h1 className="font-semibold text-2xl">
+        {description ?? defaultDescription(session, messages)}
+      </h1>
       {session.notes && <p className="text-muted-foreground text-sm">{session.notes}</p>}
       <div className="flex items-baseline gap-3">
         <span className="font-semibold text-3xl tabular-nums">
@@ -119,7 +126,7 @@ function Header({ session, description }: { session: PublicPaymentSession; descr
         </span>
         {session.expiresAt && session.status !== "paid" && (
           <span className="text-muted-foreground text-sm">
-            Expires {formatDateTime(session.expiresAt)}
+            {formatMessage(messages.expires, { date: formatDateTime(session.expiresAt) })}
           </span>
         )}
       </div>
@@ -138,6 +145,7 @@ function Body({
   onPayByCard?: () => void
   onRetry?: () => Promise<void> | void
 }) {
+  const messages = useCheckoutUiMessagesOrDefault().paymentLinkLandingPage
   // Terminal states — short-circuit body to a status panel.
   if (session.status === "paid") return <TerminalState status="paid" reason={null} />
   if (session.status === "failed") {
@@ -162,11 +170,8 @@ function Body({
   if (!cardAvailable && !bankAvailable) {
     return (
       <div className="rounded-xl border border-amber-500/40 bg-amber-500/5 p-5 text-sm">
-        <p className="font-medium">No payment method available</p>
-        <p className="mt-2 text-muted-foreground">
-          This payment link doesn't have any payment methods configured. Please contact your travel
-          agent.
-        </p>
+        <p className="font-medium">{messages.noMethods.title}</p>
+        <p className="mt-2 text-muted-foreground">{messages.noMethods.body}</p>
       </div>
     )
   }
@@ -185,11 +190,11 @@ function Body({
       <TabsList className="grid w-full grid-cols-2">
         <TabsTrigger value="card">
           <CreditCard className="mr-2 h-4 w-4" />
-          Pay by card
+          {messages.cardTab}
         </TabsTrigger>
         <TabsTrigger value="bank">
           <Building2 className="mr-2 h-4 w-4" />
-          Bank transfer
+          {messages.bankTab}
         </TabsTrigger>
       </TabsList>
       <TabsContent value="card" className="mt-4">
@@ -211,6 +216,7 @@ function CardPanel({
   session: PublicPaymentSession
   onPayByCard?: () => void
 }) {
+  const messages = useCheckoutUiMessagesOrDefault().paymentLinkLandingPage
   const [starting, setStarting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -235,7 +241,7 @@ function CardPanel({
       })
       const body = (await res.json()) as StartCardResponse
       if (!res.ok || !body.data?.redirectUrl) {
-        throw new Error(body.error ?? "Card payment couldn't be prepared.")
+        throw new Error(body.error ?? messages.card.startFailed)
       }
       window.location.href = body.data.redirectUrl
     } catch (err) {
@@ -246,17 +252,17 @@ function CardPanel({
 
   return (
     <div className="rounded-xl border bg-card p-5 shadow-sm">
-      <p className="mb-4 text-muted-foreground text-sm">
-        You'll be redirected to the secure payment page hosted by the card processor.
-      </p>
+      <p className="mb-4 text-muted-foreground text-sm">{messages.card.description}</p>
       <Button className="w-full" disabled={starting} onClick={handleClick}>
         {starting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-        Pay {formatMoneyCents(session.amountCents, session.currency)}
+        {formatMessage(messages.card.payAmount, {
+          amount: formatMoneyCents(session.amountCents, session.currency),
+        })}
         {!starting && <ExternalLink className="ml-2 h-4 w-4" />}
       </Button>
       {error && (
         <p className="mt-3 text-destructive text-xs">
-          {error} If the issue persists, please pay by bank transfer or contact your travel agent.
+          {formatMessage(messages.card.errorAdvice, { message: error })}
         </p>
       )}
     </div>
@@ -270,26 +276,28 @@ function BankTransferPanel({
   session: PublicPaymentSession
   instructions: BankTransferInstructions
 }) {
+  const messages = useCheckoutUiMessagesOrDefault().paymentLinkLandingPage
   const reference =
     instructions.reference ?? session.externalReference ?? session.clientReference ?? session.id
   return (
     <div className="rounded-xl border bg-card p-5 shadow-sm">
       <p className="mb-4 text-muted-foreground text-sm">
-        Wire {formatMoneyCents(session.amountCents, session.currency)} to the account below. Your
-        booking is confirmed once payment is received (typically 1–3 business days).
+        {formatMessage(messages.bank.instructions, {
+          amount: formatMoneyCents(session.amountCents, session.currency),
+        })}
       </p>
       <dl className="grid grid-cols-1 gap-2 text-sm">
-        <Row label="Beneficiary">{instructions.beneficiaryName}</Row>
-        <Row label="IBAN" copyValue={instructions.iban}>
+        <Row label={messages.bank.beneficiary}>{instructions.beneficiaryName}</Row>
+        <Row label={messages.bank.iban} copyValue={instructions.iban}>
           <span className="font-mono">{instructions.iban}</span>
         </Row>
         {instructions.bic && (
-          <Row label="BIC / SWIFT" copyValue={instructions.bic}>
+          <Row label={messages.bank.bicSwift} copyValue={instructions.bic}>
             <span className="font-mono">{instructions.bic}</span>
           </Row>
         )}
-        {instructions.bankName && <Row label="Bank">{instructions.bankName}</Row>}
-        <Row label="Reference" copyValue={reference}>
+        {instructions.bankName && <Row label={messages.bank.bank}>{instructions.bankName}</Row>}
+        <Row label={messages.bank.reference} copyValue={reference}>
           <span className="font-mono">{reference}</span>
         </Row>
       </dl>
@@ -321,11 +329,12 @@ function Row({
 }
 
 function CopyButton({ value }: { value: string }) {
+  const messages = useCheckoutUiMessagesOrDefault().paymentLinkLandingPage
   const [copied, setCopied] = useState(false)
   return (
     <button
       type="button"
-      aria-label={copied ? "Copied" : `Copy ${value}`}
+      aria-label={copied ? messages.copy.copied : formatMessage(messages.copy.copyValue, { value })}
       className="text-muted-foreground transition-colors hover:text-foreground"
       onClick={async () => {
         try {
@@ -356,32 +365,33 @@ function TerminalState({
   reason: string | null
   onRetry?: () => Promise<void> | void
 }) {
+  const messages = useCheckoutUiMessagesOrDefault().paymentLinkLandingPage
   const [retrying, setRetrying] = useState(false)
   const [retryError, setRetryError] = useState<string | null>(null)
 
   const cfg = {
     paid: {
       icon: <CheckCircle2 className="h-10 w-10 text-emerald-600" />,
-      title: "Payment received",
-      body: "Thanks — your booking is confirmed. You'll receive a confirmation email shortly.",
+      title: messages.terminal.paid.title,
+      body: messages.terminal.paid.body,
       tone: "border-emerald-500/40 bg-emerald-500/5",
     },
     failed: {
       icon: <CircleAlert className="h-10 w-10 text-destructive" />,
-      title: "Payment failed",
-      body: reason ?? "The payment couldn't be processed. Please try again or contact support.",
+      title: messages.terminal.failed.title,
+      body: reason ?? messages.terminal.failed.body,
       tone: "border-destructive/40 bg-destructive/5",
     },
     expired: {
       icon: <CircleAlert className="h-10 w-10 text-amber-600" />,
-      title: "Payment link expired",
-      body: "This payment link has expired. Please request a new one from your travel agent.",
+      title: messages.terminal.expired.title,
+      body: messages.terminal.expired.body,
       tone: "border-amber-500/40 bg-amber-500/5",
     },
     cancelled: {
       icon: <CircleAlert className="h-10 w-10 text-muted-foreground" />,
-      title: "Payment cancelled",
-      body: "This payment was cancelled. Please contact your travel agent if this is unexpected.",
+      title: messages.terminal.cancelled.title,
+      body: messages.terminal.cancelled.body,
       tone: "border-border bg-muted/20",
     },
   }[status]
@@ -410,7 +420,7 @@ function TerminalState({
             }}
           >
             {retrying && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            Try again
+            {messages.terminal.tryAgain}
           </Button>
           {retryError && <p className="text-destructive text-xs">{retryError}</p>}
         </>
@@ -420,34 +430,21 @@ function TerminalState({
 }
 
 function ProcessingState() {
+  const messages = useCheckoutUiMessagesOrDefault().paymentLinkLandingPage
   return (
     <div className="flex flex-col items-center gap-3 rounded-xl border bg-card p-8 text-center">
       <Loader2 className="h-10 w-10 animate-spin text-muted-foreground" />
-      <h2 className="font-semibold text-lg">Processing payment…</h2>
-      <p className="max-w-md text-muted-foreground text-sm">
-        We're confirming the payment with the processor. This usually takes a few seconds.
-      </p>
+      <h2 className="font-semibold text-lg">{messages.processing.title}</h2>
+      <p className="max-w-md text-muted-foreground text-sm">{messages.processing.body}</p>
     </div>
   )
 }
 
-function defaultDescription(session: PublicPaymentSession): string {
-  switch (session.targetType) {
-    case "booking":
-      return "Booking payment"
-    case "booking_payment_schedule":
-      return "Booking deposit"
-    case "booking_guarantee":
-      return "Booking guarantee"
-    case "invoice":
-      return "Invoice payment"
-    case "order":
-      return "Order payment"
-    case "flight_order":
-      return "Flight payment"
-    default:
-      return "Payment"
-  }
+function defaultDescription(
+  session: PublicPaymentSession,
+  messages: CheckoutUiMessages["paymentLinkLandingPage"],
+): string {
+  return messages.descriptions[session.targetType] ?? messages.descriptions.default
 }
 
 function formatMoneyCents(cents: number, currency: string): string {

--- a/packages/checkout-ui/src/components/payment-link-landing-page.tsx
+++ b/packages/checkout-ui/src/components/payment-link-landing-page.tsx
@@ -17,7 +17,7 @@ import {
 import { type ReactNode, useState } from "react"
 
 import type { CheckoutUiMessages } from "../i18n/messages.js"
-import { useCheckoutUiMessagesOrDefault } from "../i18n/provider.js"
+import { useCheckoutUiI18nOrDefault, useCheckoutUiMessagesOrDefault } from "../i18n/provider.js"
 
 interface StartCardResponse {
   data?: { redirectUrl: string | null }
@@ -113,7 +113,8 @@ export function PaymentLinkLandingPage({
 // ─────────────────────────────────────────────────────────────────────────────
 
 function Header({ session, description }: { session: PublicPaymentSession; description?: string }) {
-  const messages = useCheckoutUiMessagesOrDefault().paymentLinkLandingPage
+  const i18n = useCheckoutUiI18nOrDefault()
+  const messages = i18n.messages.paymentLinkLandingPage
   return (
     <header className="flex flex-col gap-2 border-b pb-4">
       <h1 className="font-semibold text-2xl">
@@ -122,11 +123,18 @@ function Header({ session, description }: { session: PublicPaymentSession; descr
       {session.notes && <p className="text-muted-foreground text-sm">{session.notes}</p>}
       <div className="flex items-baseline gap-3">
         <span className="font-semibold text-3xl tabular-nums">
-          {formatMoneyCents(session.amountCents, session.currency)}
+          {i18n.formatCurrency(session.amountCents / 100, session.currency)}
         </span>
         {session.expiresAt && session.status !== "paid" && (
           <span className="text-muted-foreground text-sm">
-            {formatMessage(messages.expires, { date: formatDateTime(session.expiresAt) })}
+            {formatMessage(messages.expires, {
+              date: i18n.formatDateTime(session.expiresAt, {
+                day: "numeric",
+                month: "short",
+                hour: "2-digit",
+                minute: "2-digit",
+              }),
+            })}
           </span>
         )}
       </div>
@@ -216,7 +224,8 @@ function CardPanel({
   session: PublicPaymentSession
   onPayByCard?: () => void
 }) {
-  const messages = useCheckoutUiMessagesOrDefault().paymentLinkLandingPage
+  const i18n = useCheckoutUiI18nOrDefault()
+  const messages = i18n.messages.paymentLinkLandingPage
   const [starting, setStarting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -256,7 +265,7 @@ function CardPanel({
       <Button className="w-full" disabled={starting} onClick={handleClick}>
         {starting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
         {formatMessage(messages.card.payAmount, {
-          amount: formatMoneyCents(session.amountCents, session.currency),
+          amount: i18n.formatCurrency(session.amountCents / 100, session.currency),
         })}
         {!starting && <ExternalLink className="ml-2 h-4 w-4" />}
       </Button>
@@ -276,14 +285,15 @@ function BankTransferPanel({
   session: PublicPaymentSession
   instructions: BankTransferInstructions
 }) {
-  const messages = useCheckoutUiMessagesOrDefault().paymentLinkLandingPage
+  const i18n = useCheckoutUiI18nOrDefault()
+  const messages = i18n.messages.paymentLinkLandingPage
   const reference =
     instructions.reference ?? session.externalReference ?? session.clientReference ?? session.id
   return (
     <div className="rounded-xl border bg-card p-5 shadow-sm">
       <p className="mb-4 text-muted-foreground text-sm">
         {formatMessage(messages.bank.instructions, {
-          amount: formatMoneyCents(session.amountCents, session.currency),
+          amount: i18n.formatCurrency(session.amountCents / 100, session.currency),
         })}
       </p>
       <dl className="grid grid-cols-1 gap-2 text-sm">
@@ -445,25 +455,4 @@ function defaultDescription(
   messages: CheckoutUiMessages["paymentLinkLandingPage"],
 ): string {
   return messages.descriptions[session.targetType] ?? messages.descriptions.default
-}
-
-function formatMoneyCents(cents: number, currency: string): string {
-  const amount = cents / 100
-  if (!Number.isFinite(amount)) return `${cents} ${currency}`
-  return new Intl.NumberFormat(undefined, {
-    style: "currency",
-    currency,
-    maximumFractionDigits: 2,
-  }).format(amount)
-}
-
-function formatDateTime(iso: string): string {
-  const d = new Date(iso)
-  if (Number.isNaN(d.getTime())) return iso
-  return new Intl.DateTimeFormat(undefined, {
-    day: "numeric",
-    month: "short",
-    hour: "2-digit",
-    minute: "2-digit",
-  }).format(d)
 }

--- a/packages/checkout-ui/src/components/payment-step.tsx
+++ b/packages/checkout-ui/src/components/payment-step.tsx
@@ -6,12 +6,15 @@ import type {
   PaymentStepCapabilities,
   SavedPaymentAccount,
 } from "@voyantjs/checkout-react"
+import { formatMessage } from "@voyantjs/i18n"
 import { Input } from "@voyantjs/ui/components/input"
 import { Label } from "@voyantjs/ui/components/label"
 import { RadioGroup, RadioGroupItem } from "@voyantjs/ui/components/radio-group"
 import { cn } from "@voyantjs/ui/lib/utils"
 import { Banknote, CreditCard, Wallet } from "lucide-react"
 import { type ReactNode, useState } from "react"
+
+import { useCheckoutUiMessagesOrDefault } from "../i18n/provider.js"
 
 /**
  * UI-side extension of the `PaymentStepExtraOption` from checkout-react —
@@ -66,13 +69,12 @@ export function PaymentStep({
   extraOptions,
   hideHoldOption,
 }: PaymentStepProps) {
+  const messages = useCheckoutUiMessagesOrDefault().paymentStep
   return (
     <div className="flex flex-col gap-5">
       <div>
-        <h2 className="font-semibold text-base">Payment</h2>
-        <p className="text-muted-foreground text-sm">
-          Pick a saved method or use a different payment option.
-        </p>
+        <h2 className="font-semibold text-base">{messages.title}</h2>
+        <p className="text-muted-foreground text-sm">{messages.description}</p>
       </div>
 
       {capabilities.chargeSavedCard && (
@@ -108,19 +110,22 @@ function SavedMethodsSection({
   selectedId: string | null
   onSelect: (method: SavedPaymentAccount) => void
 }) {
+  const messages = useCheckoutUiMessagesOrDefault().paymentStep.savedMethods
   return (
     <section className="rounded-xl border bg-card p-5 shadow-sm">
       <header className="mb-3 flex items-center justify-between">
-        <h3 className="font-medium text-sm">Saved payment methods</h3>
+        <h3 className="font-medium text-sm">{messages.title}</h3>
         {methods.length > 0 && (
-          <span className="text-muted-foreground text-xs">{methods.length} on file</span>
+          <span className="text-muted-foreground text-xs">
+            {formatMessage(messages.countOnFile, { count: methods.length })}
+          </span>
         )}
       </header>
       {loading ? (
         <div className="h-16 animate-pulse rounded-md bg-muted/40" />
       ) : methods.length === 0 ? (
         <div className="rounded-md border border-dashed p-4 text-center text-muted-foreground text-xs">
-          No saved methods on file for this contact.
+          {messages.empty}
         </div>
       ) : (
         <ul className="flex flex-col gap-2">
@@ -150,17 +155,22 @@ function SavedMethodsSection({
                       )}
                       {m.isDefault && (
                         <span className="ml-2 rounded-full bg-primary/10 px-1.5 py-0.5 font-medium text-[9px] text-primary uppercase tracking-wider">
-                          Default
+                          {messages.defaultBadge}
                         </span>
                       )}
                     </span>
                     {m.expiryMonth && m.expiryYear && (
                       <span className="text-muted-foreground text-xs">
-                        Expires {String(m.expiryMonth).padStart(2, "0")}/{m.expiryYear}
+                        {formatMessage(messages.expires, {
+                          month: String(m.expiryMonth).padStart(2, "0"),
+                          year: m.expiryYear,
+                        })}
                       </span>
                     )}
                   </div>
-                  {selected && <span className="font-medium text-primary text-xs">Selected</span>}
+                  {selected && (
+                    <span className="font-medium text-primary text-xs">{messages.selected}</span>
+                  )}
                 </button>
               </li>
             )
@@ -186,6 +196,7 @@ function AltMethodsSection({
   extraOptions: ReadonlyArray<PaymentStepExtraOption>
   hideHoldOption?: boolean
 }) {
+  const messages = useCheckoutUiMessagesOrDefault().paymentStep.otherOptions
   const [newCardName, setNewCardName] = useState("")
   const [newCardNumber, setNewCardNumber] = useState("")
   const [newCardExp, setNewCardExp] = useState("")
@@ -217,7 +228,7 @@ function AltMethodsSection({
   return (
     <section className="rounded-xl border bg-card p-5 shadow-sm">
       <header className="mb-3 flex items-center justify-between">
-        <h3 className="font-medium text-sm">Other payment options</h3>
+        <h3 className="font-medium text-sm">{messages.title}</h3>
       </header>
       <RadioGroup
         value={activeId ?? "__none"}
@@ -233,13 +244,13 @@ function AltMethodsSection({
           <AltRow
             id="new_card"
             icon={<CreditCard className="h-4 w-4 text-muted-foreground" />}
-            title="New credit / debit card"
-            body="Charge a one-off card now."
+            title={messages.newCard.title}
+            body={messages.newCard.body}
             active={activeId === "new_card"}
           >
             {activeId === "new_card" && (
               <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-3">
-                <Field label="Cardholder name">
+                <Field label={messages.newCard.cardholderName}>
                   <Input
                     value={newCardName}
                     onChange={(e) => {
@@ -250,10 +261,10 @@ function AltMethodsSection({
                     }}
                   />
                 </Field>
-                <Field label="Card number">
+                <Field label={messages.newCard.cardNumber}>
                   <Input
                     inputMode="numeric"
-                    placeholder="•••• •••• •••• ••••"
+                    placeholder={messages.newCard.cardNumberPlaceholder}
                     value={newCardNumber}
                     onChange={(e) => {
                       setNewCardNumber(e.target.value)
@@ -263,7 +274,7 @@ function AltMethodsSection({
                     }}
                   />
                 </Field>
-                <Field label="MM/YY">
+                <Field label={messages.newCard.expiry}>
                   <Input
                     value={newCardExp}
                     onChange={(e) => {
@@ -272,7 +283,7 @@ function AltMethodsSection({
                         onChange({ ...value, expiry: e.target.value })
                       }
                     }}
-                    placeholder="08/29"
+                    placeholder={messages.newCard.expiryPlaceholder}
                   />
                 </Field>
               </div>
@@ -295,8 +306,8 @@ function AltMethodsSection({
           <AltRow
             id="hold"
             icon={<Wallet className="h-4 w-4 text-muted-foreground" />}
-            title="Hold — generate payment link"
-            body="Lock the order and generate a payment link the customer can open to pay by card or bank transfer. Share it however you prefer."
+            title={messages.hold.title}
+            body={messages.hold.body}
             active={activeId === "hold"}
           />
         )}
@@ -305,8 +316,7 @@ function AltMethodsSection({
       {showNewCard && (
         <p className="mt-4 flex items-start gap-1.5 text-[11px] text-muted-foreground">
           <Banknote className="mt-0.5 h-3 w-3" />
-          Card numbers entered here are tokenized in production via the processor's hosted form —
-          never sent through this UI.
+          {messages.cardSecurityNote}
         </p>
       )}
     </section>
@@ -359,9 +369,10 @@ function Field({ label, children }: { label: string; children: ReactNode }) {
 }
 
 function BrandTile({ brand }: { brand: string | null }) {
+  const messages = useCheckoutUiMessagesOrDefault().paymentStep.otherOptions
   return (
     <span className="flex h-9 w-12 shrink-0 items-center justify-center rounded-md border bg-muted/30 font-mono text-[10px] uppercase tracking-wider">
-      {(brand ?? "card").slice(0, 4)}
+      {(brand ?? messages.brandFallback).slice(0, 4)}
     </span>
   )
 }

--- a/packages/checkout-ui/src/i18n.test.tsx
+++ b/packages/checkout-ui/src/i18n.test.tsx
@@ -5,6 +5,7 @@ import {
   CheckoutUiMessagesProvider,
   getCheckoutUiI18n,
   resolveCheckoutUiMessages,
+  useCheckoutUiI18nOrDefault,
   useCheckoutUiMessagesOrDefault,
 } from "./i18n/index.js"
 
@@ -46,9 +47,29 @@ describe("checkout-ui i18n", () => {
 
     expect(html).toContain("Plata")
   })
+
+  it("provides locale-aware currency formatters through the provider", () => {
+    const expected = new Intl.NumberFormat("ro-RO", {
+      currency: "RON",
+      style: "currency",
+    }).format(123.45)
+
+    const html = renderToStaticMarkup(
+      <CheckoutUiMessagesProvider locale="ro-RO">
+        <FormatterProbe />
+      </CheckoutUiMessagesProvider>,
+    )
+
+    expect(html).toContain(expected)
+  })
 })
 
 function MessageProbe() {
   const messages = useCheckoutUiMessagesOrDefault()
   return <span>{messages.paymentStep.title}</span>
+}
+
+function FormatterProbe() {
+  const i18n = useCheckoutUiI18nOrDefault()
+  return <span>{i18n.formatCurrency(123.45, "RON")}</span>
 }

--- a/packages/checkout-ui/src/i18n.test.tsx
+++ b/packages/checkout-ui/src/i18n.test.tsx
@@ -1,0 +1,54 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+
+import {
+  CheckoutUiMessagesProvider,
+  getCheckoutUiI18n,
+  resolveCheckoutUiMessages,
+  useCheckoutUiMessagesOrDefault,
+} from "./i18n/index.js"
+
+describe("checkout-ui i18n", () => {
+  it("resolves romanian messages with fallback", () => {
+    const messages = getCheckoutUiI18n({ locale: "ro-RO" }).messages
+
+    expect(messages.paymentStep.title).toBe("Plata")
+    expect(messages.collectPaymentDialog.generateLink).toBe("Genereaza link")
+  })
+
+  it("applies overrides", () => {
+    const messages = resolveCheckoutUiMessages({
+      locale: "ro",
+      overrides: {
+        locales: {
+          ro: {
+            paymentLinkLandingPage: {
+              cardTab: "Card",
+            },
+          },
+        },
+      },
+    })
+
+    expect(messages.paymentLinkLandingPage.cardTab).toBe("Card")
+  })
+
+  it("falls back to english outside a provider", () => {
+    expect(renderToStaticMarkup(<MessageProbe />)).toContain("Payment")
+  })
+
+  it("provides romanian messages through the provider", () => {
+    const html = renderToStaticMarkup(
+      <CheckoutUiMessagesProvider locale="ro-RO">
+        <MessageProbe />
+      </CheckoutUiMessagesProvider>,
+    )
+
+    expect(html).toContain("Plata")
+  })
+})
+
+function MessageProbe() {
+  const messages = useCheckoutUiMessagesOrDefault()
+  return <span>{messages.paymentStep.title}</span>
+}

--- a/packages/checkout-ui/src/i18n/en.ts
+++ b/packages/checkout-ui/src/i18n/en.ts
@@ -1,0 +1,121 @@
+import type { CheckoutUiMessages } from "./messages.js"
+
+export const checkoutUiEn: CheckoutUiMessages = {
+  paymentLinkLandingPage: {
+    cardTab: "Pay by card",
+    bankTab: "Bank transfer",
+    expires: "Expires {date}",
+    noMethods: {
+      title: "No payment method available",
+      body: "This payment link doesn't have any payment methods configured. Please contact your travel agent.",
+    },
+    card: {
+      description: "You'll be redirected to the secure payment page hosted by the card processor.",
+      payAmount: "Pay {amount}",
+      startFailed: "Card payment couldn't be prepared.",
+      errorAdvice:
+        "{message} If the issue persists, please pay by bank transfer or contact your travel agent.",
+    },
+    bank: {
+      instructions:
+        "Wire {amount} to the account below. Your booking is confirmed once payment is received (typically 1-3 business days).",
+      beneficiary: "Beneficiary",
+      iban: "IBAN",
+      bicSwift: "BIC / SWIFT",
+      bank: "Bank",
+      reference: "Reference",
+    },
+    copy: {
+      copied: "Copied",
+      copyValue: "Copy {value}",
+    },
+    terminal: {
+      paid: {
+        title: "Payment received",
+        body: "Thanks - your booking is confirmed. You'll receive a confirmation email shortly.",
+      },
+      failed: {
+        title: "Payment failed",
+        body: "The payment couldn't be processed. Please try again or contact support.",
+      },
+      expired: {
+        title: "Payment link expired",
+        body: "This payment link has expired. Please request a new one from your travel agent.",
+      },
+      cancelled: {
+        title: "Payment cancelled",
+        body: "This payment was cancelled. Please contact your travel agent if this is unexpected.",
+      },
+      tryAgain: "Try again",
+    },
+    processing: {
+      title: "Processing payment...",
+      body: "We're confirming the payment with the processor. This usually takes a few seconds.",
+    },
+    descriptions: {
+      booking: "Booking payment",
+      booking_payment_schedule: "Booking deposit",
+      booking_guarantee: "Booking guarantee",
+      invoice: "Invoice payment",
+      order: "Order payment",
+      flight_order: "Flight payment",
+      other: "Payment",
+      default: "Payment",
+    },
+  },
+  paymentStep: {
+    title: "Payment",
+    description: "Pick a saved method or use a different payment option.",
+    savedMethods: {
+      title: "Saved payment methods",
+      countOnFile: "{count} on file",
+      empty: "No saved methods on file for this contact.",
+      defaultBadge: "Default",
+      expires: "Expires {month}/{year}",
+      selected: "Selected",
+    },
+    otherOptions: {
+      title: "Other payment options",
+      newCard: {
+        title: "New credit / debit card",
+        body: "Charge a one-off card now.",
+        cardholderName: "Cardholder name",
+        cardNumber: "Card number",
+        expiry: "MM/YY",
+        cardNumberPlaceholder: ".... .... .... ....",
+        expiryPlaceholder: "08/29",
+      },
+      hold: {
+        title: "Hold - generate payment link",
+        body: "Lock the order and generate a payment link the customer can open to pay by card or bank transfer. Share it however you prefer.",
+      },
+      cardSecurityNote:
+        "Card numbers entered here are tokenized in production via the processor's hosted form - never sent through this UI.",
+      brandFallback: "card",
+    },
+  },
+  collectPaymentDialog: {
+    title: "Generate payment link",
+    description:
+      "Hold the booking and produce a payment link the customer can open to pay by card or bank transfer. Share it however you prefer (email, chat, etc.).",
+    amountLabel: "Amount ({currency})",
+    amountHelp:
+      "Defaults to the booking's sell amount. Override for a deposit or partial collection.",
+    cancel: "Cancel",
+    done: "Done",
+    generateLink: "Generate link",
+    validation: {
+      pickHold: "Pick 'Hold - generate payment link' to produce a shareable link.",
+      amountAboveZero: "Enter an amount above zero.",
+      linkReady: "Payment link ready - copy or share it with the customer.",
+    },
+    result: {
+      noLink: "The session was created but no link could be built. Session id: {sessionId}.",
+      noSession: "-",
+      ready: "Payment link ready",
+      body: "Share this link with the customer. They'll choose card or bank transfer on the page.",
+      copyLink: "Copy link",
+      openLink: "Open link",
+    },
+  },
+}

--- a/packages/checkout-ui/src/i18n/index.ts
+++ b/packages/checkout-ui/src/i18n/index.ts
@@ -1,0 +1,14 @@
+export { checkoutUiEn } from "./en.js"
+export type { CheckoutPaymentTargetType, CheckoutUiMessages } from "./messages.js"
+export {
+  type CheckoutUiMessageOverrides,
+  CheckoutUiMessagesProvider,
+  checkoutUiMessageDefinitions,
+  getCheckoutUiI18n,
+  resolveCheckoutUiMessages,
+  useCheckoutUiI18n,
+  useCheckoutUiI18nOrDefault,
+  useCheckoutUiMessages,
+  useCheckoutUiMessagesOrDefault,
+} from "./provider.js"
+export { checkoutUiRo } from "./ro.js"

--- a/packages/checkout-ui/src/i18n/messages.ts
+++ b/packages/checkout-ui/src/i18n/messages.ts
@@ -1,0 +1,109 @@
+import type { PublicPaymentSession } from "@voyantjs/finance/public-validation"
+
+export type CheckoutPaymentTargetType = PublicPaymentSession["targetType"]
+
+export type CheckoutUiMessages = {
+  paymentLinkLandingPage: {
+    cardTab: string
+    bankTab: string
+    expires: string
+    noMethods: {
+      title: string
+      body: string
+    }
+    card: {
+      description: string
+      payAmount: string
+      startFailed: string
+      errorAdvice: string
+    }
+    bank: {
+      instructions: string
+      beneficiary: string
+      iban: string
+      bicSwift: string
+      bank: string
+      reference: string
+    }
+    copy: {
+      copied: string
+      copyValue: string
+    }
+    terminal: {
+      paid: {
+        title: string
+        body: string
+      }
+      failed: {
+        title: string
+        body: string
+      }
+      expired: {
+        title: string
+        body: string
+      }
+      cancelled: {
+        title: string
+        body: string
+      }
+      tryAgain: string
+    }
+    processing: {
+      title: string
+      body: string
+    }
+    descriptions: Record<CheckoutPaymentTargetType | "default", string>
+  }
+  paymentStep: {
+    title: string
+    description: string
+    savedMethods: {
+      title: string
+      countOnFile: string
+      empty: string
+      defaultBadge: string
+      expires: string
+      selected: string
+    }
+    otherOptions: {
+      title: string
+      newCard: {
+        title: string
+        body: string
+        cardholderName: string
+        cardNumber: string
+        expiry: string
+        cardNumberPlaceholder: string
+        expiryPlaceholder: string
+      }
+      hold: {
+        title: string
+        body: string
+      }
+      cardSecurityNote: string
+      brandFallback: string
+    }
+  }
+  collectPaymentDialog: {
+    title: string
+    description: string
+    amountLabel: string
+    amountHelp: string
+    cancel: string
+    done: string
+    generateLink: string
+    validation: {
+      pickHold: string
+      amountAboveZero: string
+      linkReady: string
+    }
+    result: {
+      noLink: string
+      noSession: string
+      ready: string
+      body: string
+      copyLink: string
+      openLink: string
+    }
+  }
+}

--- a/packages/checkout-ui/src/i18n/provider.tsx
+++ b/packages/checkout-ui/src/i18n/provider.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import {
+  createLocaleFormatters,
+  createPackageMessagesContext,
+  type LocaleMessageDefinitions,
+  type LocaleMessageOverrides,
+  type PackageI18nValue,
+  resolvePackageMessages,
+} from "@voyantjs/i18n"
+import type { ReactNode } from "react"
+
+import { checkoutUiEn } from "./en.js"
+import type { CheckoutUiMessages } from "./messages.js"
+import { checkoutUiRo } from "./ro.js"
+
+const fallbackLocale = "en"
+
+export const checkoutUiMessageDefinitions = {
+  en: checkoutUiEn,
+  ro: checkoutUiRo,
+} satisfies LocaleMessageDefinitions<CheckoutUiMessages>
+
+export type CheckoutUiMessageOverrides = LocaleMessageOverrides<CheckoutUiMessages>
+
+const checkoutUiContext = createPackageMessagesContext<CheckoutUiMessages>("CheckoutUiMessages")
+
+const defaultCheckoutUiI18n: PackageI18nValue<CheckoutUiMessages> = {
+  messages: checkoutUiEn,
+  ...createLocaleFormatters(fallbackLocale),
+}
+
+export function resolveCheckoutUiMessages({
+  locale,
+  overrides,
+}: {
+  locale: string | null | undefined
+  overrides?: CheckoutUiMessageOverrides | null
+}) {
+  return resolvePackageMessages({
+    definitions: checkoutUiMessageDefinitions,
+    fallbackLocale,
+    locale,
+    overrides,
+  })
+}
+
+export function getCheckoutUiI18n({
+  locale,
+  overrides,
+}: {
+  locale?: string | null | undefined
+  overrides?: CheckoutUiMessageOverrides | null
+}): PackageI18nValue<CheckoutUiMessages> {
+  const resolvedLocale = locale ?? fallbackLocale
+  return {
+    messages: resolveCheckoutUiMessages({ locale: resolvedLocale, overrides }),
+    ...createLocaleFormatters(resolvedLocale),
+  }
+}
+
+export function CheckoutUiMessagesProvider({
+  children,
+  locale,
+  overrides,
+}: {
+  children: ReactNode
+  locale: string | null | undefined
+  overrides?: CheckoutUiMessageOverrides | null
+}) {
+  return (
+    <checkoutUiContext.ResolvedMessagesProvider
+      definitions={checkoutUiMessageDefinitions}
+      fallbackLocale={fallbackLocale}
+      locale={locale}
+      overrides={overrides}
+    >
+      {children}
+    </checkoutUiContext.ResolvedMessagesProvider>
+  )
+}
+
+export const useCheckoutUiI18n = checkoutUiContext.useI18n
+export const useCheckoutUiMessages = checkoutUiContext.useMessages
+
+export function useCheckoutUiI18nOrDefault() {
+  return checkoutUiContext.useOptionalI18n() ?? defaultCheckoutUiI18n
+}
+
+export function useCheckoutUiMessagesOrDefault() {
+  return useCheckoutUiI18nOrDefault().messages
+}

--- a/packages/checkout-ui/src/i18n/ro.ts
+++ b/packages/checkout-ui/src/i18n/ro.ts
@@ -1,0 +1,122 @@
+import type { CheckoutUiMessages } from "./messages.js"
+
+export const checkoutUiRo: CheckoutUiMessages = {
+  paymentLinkLandingPage: {
+    cardTab: "Plateste cu cardul",
+    bankTab: "Transfer bancar",
+    expires: "Expira {date}",
+    noMethods: {
+      title: "Nicio metoda de plata disponibila",
+      body: "Acest link de plata nu are metode de plata configurate. Contacteaza agentul de turism.",
+    },
+    card: {
+      description: "Vei fi redirectionat catre pagina securizata a procesatorului de carduri.",
+      payAmount: "Plateste {amount}",
+      startFailed: "Plata cu cardul nu a putut fi pregatita.",
+      errorAdvice:
+        "{message} Daca problema persista, plateste prin transfer bancar sau contacteaza agentul de turism.",
+    },
+    bank: {
+      instructions:
+        "Transfera {amount} in contul de mai jos. Rezervarea este confirmata dupa incasarea platii (de obicei 1-3 zile lucratoare).",
+      beneficiary: "Beneficiar",
+      iban: "IBAN",
+      bicSwift: "BIC / SWIFT",
+      bank: "Banca",
+      reference: "Referinta",
+    },
+    copy: {
+      copied: "Copiat",
+      copyValue: "Copiaza {value}",
+    },
+    terminal: {
+      paid: {
+        title: "Plata incasata",
+        body: "Multumim - rezervarea este confirmata. Vei primi in curand un email de confirmare.",
+      },
+      failed: {
+        title: "Plata esuata",
+        body: "Plata nu a putut fi procesata. Incearca din nou sau contacteaza suportul.",
+      },
+      expired: {
+        title: "Link de plata expirat",
+        body: "Acest link de plata a expirat. Cere un link nou de la agentul de turism.",
+      },
+      cancelled: {
+        title: "Plata anulata",
+        body: "Aceasta plata a fost anulata. Contacteaza agentul de turism daca nu te asteptai la asta.",
+      },
+      tryAgain: "Incearca din nou",
+    },
+    processing: {
+      title: "Se proceseaza plata...",
+      body: "Confirmam plata cu procesatorul. De obicei dureaza cateva secunde.",
+    },
+    descriptions: {
+      booking: "Plata rezervare",
+      booking_payment_schedule: "Avans rezervare",
+      booking_guarantee: "Garantie rezervare",
+      invoice: "Plata factura",
+      order: "Plata comanda",
+      flight_order: "Plata zbor",
+      other: "Plata",
+      default: "Plata",
+    },
+  },
+  paymentStep: {
+    title: "Plata",
+    description: "Alege o metoda salvata sau foloseste alta optiune de plata.",
+    savedMethods: {
+      title: "Metode de plata salvate",
+      countOnFile: "{count} salvate",
+      empty: "Nu exista metode salvate pentru acest contact.",
+      defaultBadge: "Implicit",
+      expires: "Expira {month}/{year}",
+      selected: "Selectata",
+    },
+    otherOptions: {
+      title: "Alte optiuni de plata",
+      newCard: {
+        title: "Card nou de credit / debit",
+        body: "Debiteaza acum un card punctual.",
+        cardholderName: "Nume detinator card",
+        cardNumber: "Numar card",
+        expiry: "LL/AA",
+        cardNumberPlaceholder: ".... .... .... ....",
+        expiryPlaceholder: "08/29",
+      },
+      hold: {
+        title: "Retine - genereaza link de plata",
+        body: "Blocheaza comanda si genereaza un link de plata pe care clientul il poate deschide pentru plata cu cardul sau transfer bancar. Distribuie-l cum preferi.",
+      },
+      cardSecurityNote:
+        "Numerele de card introduse aici sunt tokenizate in productie prin formularul gazduit de procesator - nu sunt trimise niciodata prin acest UI.",
+      brandFallback: "card",
+    },
+  },
+  collectPaymentDialog: {
+    title: "Genereaza link de plata",
+    description:
+      "Retine rezervarea si genereaza un link de plata pe care clientul il poate deschide pentru plata cu cardul sau transfer bancar. Distribuie-l cum preferi (email, chat etc.).",
+    amountLabel: "Suma ({currency})",
+    amountHelp:
+      "Implicit este suma de vanzare a rezervarii. Modifica pentru avans sau plata partiala.",
+    cancel: "Anuleaza",
+    done: "Gata",
+    generateLink: "Genereaza link",
+    validation: {
+      pickHold: "Alege 'Retine - genereaza link de plata' pentru a crea un link distribuibil.",
+      amountAboveZero: "Introdu o suma mai mare decat zero.",
+      linkReady: "Linkul de plata este gata - copiaza-l sau trimite-l clientului.",
+    },
+    result: {
+      noLink:
+        "Sesiunea a fost creata, dar linkul nu a putut fi construit. ID sesiune: {sessionId}.",
+      noSession: "-",
+      ready: "Link de plata gata",
+      body: "Trimite acest link clientului. Va alege cardul sau transferul bancar pe pagina.",
+      copyLink: "Copiaza linkul",
+      openLink: "Deschide linkul",
+    },
+  },
+}

--- a/packages/checkout-ui/src/index.ts
+++ b/packages/checkout-ui/src/index.ts
@@ -34,3 +34,15 @@ export {
   type PaymentStepExtraOption,
   type PaymentStepProps,
 } from "./components/payment-step.js"
+export type { CheckoutPaymentTargetType, CheckoutUiMessages } from "./i18n/index.js"
+export {
+  type CheckoutUiMessageOverrides,
+  CheckoutUiMessagesProvider,
+  checkoutUiMessageDefinitions,
+  getCheckoutUiI18n,
+  resolveCheckoutUiMessages,
+  useCheckoutUiI18n,
+  useCheckoutUiI18nOrDefault,
+  useCheckoutUiMessages,
+  useCheckoutUiMessagesOrDefault,
+} from "./i18n/index.js"

--- a/packages/checkout-ui/tsconfig.json
+++ b/packages/checkout-ui/tsconfig.json
@@ -8,5 +8,6 @@
     "moduleResolution": "Bundler",
     "jsx": "react-jsx"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1104,6 +1104,9 @@ importers:
       '@voyantjs/auth-react':
         specifier: workspace:*
         version: link:../auth-react
+      '@voyantjs/i18n':
+        specifier: workspace:*
+        version: link:../i18n
       '@voyantjs/types':
         specifier: workspace:*
         version: link:../types
@@ -1870,6 +1873,9 @@ importers:
       '@voyantjs/finance-react':
         specifier: workspace:*
         version: link:../finance-react
+      '@voyantjs/i18n':
+        specifier: workspace:*
+        version: link:../i18n
       '@voyantjs/ui':
         specifier: workspace:*
         version: link:../ui


### PR DESCRIPTION
## Summary
- Add provider-backed English and Romanian i18n surfaces for `@voyantjs/auth-ui` and `@voyantjs/checkout-ui`.
- Route the auth service API keys page and checkout payment flows through package message providers instead of hardcoded literals.
- Export public i18n subpaths and add package tests covering default, Romanian, override, and merge behavior.

## Verification
- `pnpm --filter @voyantjs/auth-ui lint`
- `pnpm --filter @voyantjs/auth-ui typecheck`
- `pnpm --filter @voyantjs/auth-ui test`
- `pnpm --filter @voyantjs/auth-ui build`
- `pnpm --filter @voyantjs/checkout-ui lint`
- `pnpm --filter @voyantjs/checkout-ui typecheck`
- `pnpm --filter @voyantjs/checkout-ui test`
- `pnpm --filter @voyantjs/checkout-ui build`
- `pnpm verify:fast`
- pre-push `pnpm test`

Refs #676