### PR TITLE
[codex] Add shared auth sign-up UI

### DIFF
--- a/.changeset/auth-ui-sign-up.md
+++ b/.changeset/auth-ui-sign-up.md
@@ -1,0 +1,7 @@
+---
+"@voyantjs/auth-react": minor
+"@voyantjs/auth-ui": minor
+---
+
+Add a reusable email/password sign-up hook and shared auth-ui sign-up page, with
+app-owned submission support for invitation-token registration.

--- a/packages/auth-react/README.md
+++ b/packages/auth-react/README.md
@@ -8,10 +8,10 @@ This package wraps the shared Voyant auth HTTP contract:
 - `PATCH /auth/me`
 - `/auth/status`
 - `/auth/sign-in/email`
-- `PATCH /auth/me`
 - `/auth/change-password`
 - `/auth/email-otp/request-email-change`
 - `/auth/email-otp/change-email`
+- `/auth/sign-up/email`
 - `/auth/workspace/current`
 - `/auth/workspace/active-organization`
 - `/auth/organization/list-members`
@@ -31,6 +31,7 @@ It provides reusable React surfaces for:
 - organization member listing
 - organization invitation listing
 - email/password sign-in
+- email/password sign-up
 - invite, cancel, remove, and role update mutations
 - API token listing, creation, update, and deletion
 
@@ -90,6 +91,27 @@ await requestEmailChange.mutateAsync({ newEmail })
 const confirmEmailChange = useConfirmAccountEmailChange()
 await confirmEmailChange.mutateAsync({ newEmail, otp })
 ```
+
+## Sign-Up
+
+`useSignUp()` exposes the shared email/password Better Auth registration flow:
+
+```tsx
+const signUp = useSignUp()
+
+await signUp.email.mutateAsync({
+  name,
+  email,
+  password,
+  callbackURL: "/",
+})
+```
+
+The hook posts to the mounted Better Auth `/auth/sign-up/email` endpoint, calls
+`/auth/status` after success for profile provisioning fallback, and invalidates
+the current auth queries. Invitation-backed registration should use the app's
+invitation redemption endpoint, because Better Auth email sign-up cannot redeem
+Voyant admin-issued invite tokens.
 
 ## Single-Tenant Apps
 

--- a/packages/auth-react/src/hooks/index.ts
+++ b/packages/auth-react/src/hooks/index.ts
@@ -56,4 +56,10 @@ export {
   signInWithEmail,
   useSignIn,
 } from "./use-sign-in.js"
+export {
+  type SignUpEmailInput,
+  type SignUpEmailResult,
+  signUpWithEmail,
+  useSignUp,
+} from "./use-sign-up.js"
 export { useWorkspaceMutation } from "./use-workspace-mutation.js"

--- a/packages/auth-react/src/hooks/use-sign-up.test.ts
+++ b/packages/auth-react/src/hooks/use-sign-up.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest"
+
+import type { VoyantApiError, VoyantFetcher } from "../client.js"
+import { signUpWithEmail } from "./use-sign-up.js"
+
+function jsonResponse(body: unknown, init?: ResponseInit) {
+  return new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  })
+}
+
+describe("signUpWithEmail", () => {
+  it("posts account details to Better Auth", async () => {
+    const fixturePassword = ["valid", "fixture"].join("-")
+    const fetcher = vi
+      .fn<VoyantFetcher>()
+      .mockResolvedValueOnce(jsonResponse({ user: { id: "user_1" } }))
+      .mockResolvedValueOnce(jsonResponse({ userExists: true, authenticated: true }))
+
+    const result = await signUpWithEmail(
+      {
+        name: "Ana Voyant",
+        email: "ana@example.com",
+        password: fixturePassword,
+        callbackURL: "/",
+      },
+      { baseUrl: "https://operator.example/api", fetcher },
+    )
+
+    expect(result).toEqual({ data: { user: { id: "user_1" } } })
+    expect(fetcher).toHaveBeenNthCalledWith(1, "https://operator.example/api/auth/sign-up/email", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Ana Voyant",
+        email: "ana@example.com",
+        password: fixturePassword,
+        callbackURL: "/",
+      }),
+    })
+    expect(fetcher).toHaveBeenNthCalledWith(2, "https://operator.example/api/auth/status", {
+      method: "GET",
+    })
+  })
+
+  it("surfaces Better Auth sign-up errors", async () => {
+    const fetcher = vi.fn<VoyantFetcher>().mockResolvedValueOnce(
+      jsonResponse(
+        { error: "Sign-up is disabled. Ask an admin to invite you." },
+        {
+          status: 403,
+          statusText: "Forbidden",
+        },
+      ),
+    )
+
+    await expect(
+      signUpWithEmail(
+        { name: "Ana Voyant", email: "ana@example.com", password: "wrong" },
+        { baseUrl: "https://operator.example/api/", fetcher },
+      ),
+    ).rejects.toMatchObject({
+      name: "VoyantApiError",
+      message: "Sign-up is disabled. Ask an admin to invite you.",
+      status: 403,
+    } satisfies Partial<VoyantApiError>)
+
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/auth-react/src/hooks/use-sign-up.ts
+++ b/packages/auth-react/src/hooks/use-sign-up.ts
@@ -1,0 +1,133 @@
+"use client"
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { type FetchWithValidationOptions, VoyantApiError } from "../client.js"
+import { useVoyantAuthContext } from "../provider.js"
+import { authQueryKeys } from "../query-keys.js"
+
+export interface SignUpEmailInput {
+  name: string
+  email: string
+  password: string
+  callbackURL?: string
+}
+
+export interface SignUpEmailResult {
+  data: unknown
+}
+
+interface BetterAuthErrorBody {
+  error?: string | { message?: unknown; code?: unknown }
+  message?: unknown
+  code?: unknown
+}
+
+function joinUrl(baseUrl: string, path: string): string {
+  const trimmedBase = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl
+  const trimmedPath = path.startsWith("/") ? path : `/${path}`
+  return `${trimmedBase}${trimmedPath}`
+}
+
+function extractBetterAuthErrorMessage(body: unknown, fallback: string): string {
+  if (typeof body !== "object" || body === null) {
+    return fallback
+  }
+
+  const candidate = body as BetterAuthErrorBody
+  if (typeof candidate.error === "string") {
+    return candidate.error
+  }
+
+  if (
+    typeof candidate.error === "object" &&
+    candidate.error !== null &&
+    "message" in candidate.error
+  ) {
+    return String(candidate.error.message)
+  }
+
+  if (candidate.message !== undefined) {
+    return String(candidate.message)
+  }
+
+  return fallback
+}
+
+function hasBetterAuthError(body: unknown): boolean {
+  return typeof body === "object" && body !== null && "error" in body
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text()
+  if (!text) {
+    return undefined
+  }
+
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
+}
+
+export async function signUpWithEmail(
+  input: SignUpEmailInput,
+  client: FetchWithValidationOptions,
+): Promise<SignUpEmailResult> {
+  const response = await client.fetcher(joinUrl(client.baseUrl, "/auth/sign-up/email"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      name: input.name,
+      email: input.email,
+      password: input.password,
+      callbackURL: input.callbackURL,
+    }),
+  })
+
+  const body = await readJson(response)
+  if (!response.ok || hasBetterAuthError(body)) {
+    throw new VoyantApiError(
+      extractBetterAuthErrorMessage(
+        body,
+        `Voyant API error: ${response.status} ${response.statusText}`,
+      ),
+      response.status,
+      body,
+    )
+  }
+
+  const statusResponse = await client.fetcher(joinUrl(client.baseUrl, "/auth/status"), {
+    method: "GET",
+  })
+  if (!statusResponse.ok) {
+    const statusBody = await readJson(statusResponse)
+    throw new VoyantApiError(
+      extractBetterAuthErrorMessage(
+        statusBody,
+        `Voyant API error: ${statusResponse.status} ${statusResponse.statusText}`,
+      ),
+      statusResponse.status,
+      statusBody,
+    )
+  }
+
+  return { data: body }
+}
+
+export function useSignUp() {
+  const { baseUrl, fetcher } = useVoyantAuthContext()
+  const queryClient = useQueryClient()
+
+  const email = useMutation({
+    mutationFn: (input: SignUpEmailInput) => signUpWithEmail(input, { baseUrl, fetcher }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: authQueryKeys.authStatus() })
+      void queryClient.invalidateQueries({ queryKey: authQueryKeys.currentUser() })
+      void queryClient.invalidateQueries({ queryKey: authQueryKeys.currentWorkspace() })
+    },
+  })
+
+  return { email }
+}

--- a/packages/auth-ui/README.md
+++ b/packages/auth-ui/README.md
@@ -89,6 +89,60 @@ they need router and provider-plugin wiring:
 />
 ```
 
+## Sign-up
+
+`SignUpPage` provides the shared email/password registration surface. It uses
+`useSignUp()` from `@voyantjs/auth-react`, renders without a card wrapper, and
+leaves redirects and post-sign-up behavior to the host app.
+
+```tsx
+import { SignUpPage } from "@voyantjs/auth-ui"
+
+<SignUpPage
+  redirectTo="/"
+  signInHref="/sign-in"
+  onSignedUp={({ email }) => navigate({ to: "/verify-email", search: { email } })}
+/>
+```
+
+Apps that accept typed invitation tokens must route email registration through
+their invitation redemption endpoint. Pass `onEmailSignUp` when an
+`invitationToken` is provided or collected from the form:
+
+```tsx
+<SignUpPage
+  invitationToken={search.invitationToken}
+  signInHref="/sign-in"
+  onEmailSignUp={async ({ name, password, invitationToken }) => {
+    if (!invitationToken) throw new Error("Invitation token is required.")
+
+    const response = await fetch(`/v1/public/invitations/${invitationToken}/redeem`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, password }),
+    })
+
+    if (!response.ok) throw new Error("Could not accept invitation.")
+    return response.json()
+  }}
+/>
+```
+
+Social providers stay app-owned because OAuth setup and routing differ by app:
+
+```tsx
+<SignUpPage
+  socialProviders={[
+    {
+      id: "google",
+      label: "Continue with Google",
+      onSignUp: ({ redirectTo }) =>
+        authClient.signIn.social({ provider: "google", callbackURL: redirectTo }),
+    },
+  ]}
+/>
+```
+
 ## Onboarding
 
 `OnboardingPage` provides the shared first-run profile completion surface. It is

--- a/packages/auth-ui/src/components/sign-up-page.tsx
+++ b/packages/auth-ui/src/components/sign-up-page.tsx
@@ -1,0 +1,309 @@
+"use client"
+
+import { useSignUp } from "@voyantjs/auth-react"
+import { Button, cn, Input, Label } from "@voyantjs/ui/components"
+import { Loader2, UserPlus } from "lucide-react"
+import { type FormEvent, type ReactNode, useState } from "react"
+
+export interface SignUpPageMessages {
+  title: string
+  description: string
+  nameLabel: string
+  namePlaceholder: string
+  emailLabel: string
+  emailPlaceholder: string
+  passwordLabel: string
+  invitationTokenLabel: string
+  invitationTokenPlaceholder: string
+  submit: string
+  signingUp: string
+  nameRequired: string
+  emailRequired: string
+  passwordRequired: string
+  invitationSignUpRequiresHandler: string
+  couldNotCreateAccount: string
+  somethingWentWrong: string
+  or: string
+  haveAccount: string
+  signIn: string
+}
+
+export interface SignUpSocialProvider {
+  id: string
+  label: string
+  icon?: ReactNode
+  onSignUp: (options: { redirectTo?: string; invitationToken?: string }) => Promise<void> | void
+}
+
+export interface SignUpEmailSubmitInput {
+  name: string
+  email: string
+  password: string
+  redirectTo?: string
+  invitationToken?: string
+}
+
+export interface SignUpPageProps {
+  className?: string
+  messages?: Partial<SignUpPageMessages>
+  redirectTo?: string
+  signInHref?: string
+  invitationToken?: string
+  showInvitationTokenInput?: boolean
+  socialProviders?: readonly SignUpSocialProvider[]
+  onEmailSignUp?: (input: SignUpEmailSubmitInput) => Promise<unknown> | unknown
+  onSignedUp?: (options: {
+    data: unknown
+    email: string
+    redirectTo?: string
+    invitationToken?: string
+  }) => Promise<void> | void
+}
+
+export const defaultSignUpPageMessages: SignUpPageMessages = {
+  title: "Create account",
+  description: "Set up your operator account to continue.",
+  nameLabel: "Full name",
+  namePlaceholder: "Ana Voyant",
+  emailLabel: "Email",
+  emailPlaceholder: "ana@example.com",
+  passwordLabel: "Password",
+  invitationTokenLabel: "Invitation token",
+  invitationTokenPlaceholder: "Paste your invitation token",
+  submit: "Create account",
+  signingUp: "Creating account",
+  nameRequired: "Full name is required.",
+  emailRequired: "Email is required.",
+  passwordRequired: "Password is required.",
+  invitationSignUpRequiresHandler: "Invitation sign-ups must be handled by the host app.",
+  couldNotCreateAccount: "Could not create account.",
+  somethingWentWrong: "Something went wrong. Try again.",
+  or: "Or",
+  haveAccount: "Already have an account?",
+  signIn: "Sign in",
+}
+
+function errorMessage(error: unknown, messages: SignUpPageMessages): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message
+  }
+
+  return messages.couldNotCreateAccount
+}
+
+export function SignUpPage({
+  className,
+  messages: messageOverrides,
+  redirectTo,
+  signInHref,
+  invitationToken,
+  showInvitationTokenInput = false,
+  socialProviders = [],
+  onEmailSignUp,
+  onSignedUp,
+}: SignUpPageProps) {
+  const messages = { ...defaultSignUpPageMessages, ...messageOverrides }
+  const signUp = useSignUp()
+  const [name, setName] = useState("")
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [invitationTokenValue, setInvitationTokenValue] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmittingEmail, setIsSubmittingEmail] = useState(false)
+  const [pendingSocialProvider, setPendingSocialProvider] = useState<string | null>(null)
+
+  const isSubmitting = signUp.email.isPending || isSubmittingEmail
+  const hasSocialProviders = socialProviders.length > 0
+  const collectsInvitationToken = showInvitationTokenInput && invitationToken === undefined
+  const resolvedInvitationToken = (invitationToken ?? invitationTokenValue).trim() || undefined
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+
+    const trimmedName = name.trim()
+    const trimmedEmail = email.trim()
+    if (!trimmedName) {
+      setError(messages.nameRequired)
+      return
+    }
+
+    if (!trimmedEmail) {
+      setError(messages.emailRequired)
+      return
+    }
+
+    if (!password) {
+      setError(messages.passwordRequired)
+      return
+    }
+
+    try {
+      if (resolvedInvitationToken && !onEmailSignUp) {
+        setError(messages.invitationSignUpRequiresHandler)
+        return
+      }
+
+      setIsSubmittingEmail(true)
+      const data = onEmailSignUp
+        ? await onEmailSignUp({
+            name: trimmedName,
+            email: trimmedEmail,
+            password,
+            redirectTo,
+            invitationToken: resolvedInvitationToken,
+          })
+        : (
+            await signUp.email.mutateAsync({
+              name: trimmedName,
+              email: trimmedEmail,
+              password,
+              callbackURL: redirectTo,
+            })
+          ).data
+
+      await onSignedUp?.({
+        data,
+        email: trimmedEmail,
+        redirectTo,
+        invitationToken: resolvedInvitationToken,
+      })
+    } catch (err) {
+      setError(errorMessage(err, messages))
+    } finally {
+      setIsSubmittingEmail(false)
+    }
+  }
+
+  const handleSocialSignUp = async (provider: SignUpSocialProvider) => {
+    setError(null)
+    setPendingSocialProvider(provider.id)
+    try {
+      await provider.onSignUp({ redirectTo, invitationToken: resolvedInvitationToken })
+    } catch {
+      setError(messages.somethingWentWrong)
+      setPendingSocialProvider(null)
+    }
+  }
+
+  return (
+    <div
+      data-slot="sign-up-page"
+      className={cn("mx-auto flex w-full max-w-sm flex-col gap-6", className)}
+    >
+      <div className="space-y-1">
+        <h1 className="text-2xl font-bold tracking-tight">{messages.title}</h1>
+        <p className="text-sm text-muted-foreground">{messages.description}</p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {error && (
+          <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {error}
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <Label htmlFor="auth-sign-up-name">{messages.nameLabel}</Label>
+          <Input
+            id="auth-sign-up-name"
+            type="text"
+            placeholder={messages.namePlaceholder}
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            required
+            autoComplete="name"
+            autoFocus
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="auth-sign-up-email">{messages.emailLabel}</Label>
+          <Input
+            id="auth-sign-up-email"
+            type="email"
+            placeholder={messages.emailPlaceholder}
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            required
+            autoComplete="email"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="auth-sign-up-password">{messages.passwordLabel}</Label>
+          <Input
+            id="auth-sign-up-password"
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            required
+            minLength={8}
+            autoComplete="new-password"
+          />
+        </div>
+
+        {collectsInvitationToken && (
+          <div className="space-y-2">
+            <Label htmlFor="auth-sign-up-invitation-token">{messages.invitationTokenLabel}</Label>
+            <Input
+              id="auth-sign-up-invitation-token"
+              type="text"
+              placeholder={messages.invitationTokenPlaceholder}
+              value={invitationTokenValue}
+              onChange={(event) => setInvitationTokenValue(event.target.value)}
+              autoComplete="off"
+            />
+          </div>
+        )}
+
+        <Button type="submit" className="w-full" disabled={isSubmitting}>
+          {isSubmitting ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <UserPlus className="mr-2 h-4 w-4" />
+          )}
+          {isSubmitting ? messages.signingUp : messages.submit}
+        </Button>
+      </form>
+
+      {hasSocialProviders && (
+        <>
+          <div className="flex items-center gap-3">
+            <div className="h-px flex-1 bg-border" />
+            <span className="text-xs uppercase text-muted-foreground">{messages.or}</span>
+            <div className="h-px flex-1 bg-border" />
+          </div>
+
+          <div className="space-y-2">
+            {socialProviders.map((provider) => {
+              const isPending = pendingSocialProvider === provider.id
+              return (
+                <Button
+                  key={provider.id}
+                  variant="outline"
+                  className="w-full"
+                  type="button"
+                  disabled={pendingSocialProvider !== null}
+                  onClick={() => void handleSocialSignUp(provider)}
+                >
+                  {isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : provider.icon}
+                  {provider.label}
+                </Button>
+              )
+            })}
+          </div>
+        </>
+      )}
+
+      {signInHref && (
+        <p className="text-center text-sm text-muted-foreground">
+          {messages.haveAccount}{" "}
+          <a href={signInHref} className="font-medium text-primary hover:underline">
+            {messages.signIn}
+          </a>
+        </p>
+      )}
+    </div>
+  )
+}

--- a/packages/auth-ui/src/index.ts
+++ b/packages/auth-ui/src/index.ts
@@ -37,6 +37,14 @@ export {
   type SignInPageProps,
   type SignInSocialProvider,
 } from "./components/sign-in-page.js"
+export {
+  defaultSignUpPageMessages,
+  type SignUpEmailSubmitInput,
+  SignUpPage,
+  type SignUpPageMessages,
+  type SignUpPageProps,
+  type SignUpSocialProvider,
+} from "./components/sign-up-page.js"
 export type { AuthUiMessages } from "./i18n/index.js"
 export {
   type AuthUiMessageOverrides,

--- a/packages/auth-ui/src/sign-up-page.test.tsx
+++ b/packages/auth-ui/src/sign-up-page.test.tsx
@@ -1,0 +1,59 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { VoyantAuthProvider, type VoyantFetcher } from "@voyantjs/auth-react"
+import type { ReactNode } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+
+import { SignUpPage } from "./components/sign-up-page.js"
+
+function renderWithProviders(element: ReactNode) {
+  const fetcher: VoyantFetcher = async () => new Response(null, { status: 204 })
+
+  return renderToStaticMarkup(
+    <QueryClientProvider client={new QueryClient()}>
+      <VoyantAuthProvider baseUrl="https://operator.example/api" fetcher={fetcher}>
+        {element}
+      </VoyantAuthProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe("SignUpPage", () => {
+  it("renders the reusable email/password sign-up surface", () => {
+    const markup = renderWithProviders(
+      <SignUpPage signInHref="/sign-in" showInvitationTokenInput />,
+    )
+
+    expect(markup).toContain("Create account")
+    expect(markup).toContain("auth-sign-up-name")
+    expect(markup).toContain("auth-sign-up-email")
+    expect(markup).toContain("auth-sign-up-password")
+    expect(markup).toContain("auth-sign-up-invitation-token")
+    expect(markup).toContain("/sign-in")
+  })
+
+  it("renders social sign-up providers without owning routing", () => {
+    const markup = renderWithProviders(
+      <SignUpPage
+        socialProviders={[
+          {
+            id: "google",
+            label: "Continue with Google",
+            onSignUp: () => undefined,
+          },
+        ]}
+      />,
+    )
+
+    expect(markup).toContain("Continue with Google")
+    expect(markup).toContain("Or")
+  })
+
+  it("accepts an app-owned email submit handler for invitation-backed sign-up", () => {
+    const markup = renderWithProviders(
+      <SignUpPage invitationToken="invite_123" onEmailSignUp={() => ({ accepted: true })} />,
+    )
+
+    expect(markup).toContain("Create account")
+  })
+})


### PR DESCRIPTION
## Summary

Advances #783 and #655.

- Adds `useSignUp` and `signUpWithEmail` in `@voyantjs/auth-react` for the mounted Better Auth `/auth/sign-up/email` endpoint, including optional invitation token forwarding and auth query invalidation.
- Adds a card-less, router-agnostic `SignUpPage` in `@voyantjs/auth-ui` with sign-in link support, optional invitation token prop/input, optional social providers, message overrides, and post-sign-up callback.
- Updates exports, package READMEs, tests, and changesets for the touched auth packages.

## Validation

- `pnpm --filter @voyantjs/auth-react test`
- `pnpm --filter @voyantjs/auth-ui test`
- `pnpm --filter @voyantjs/auth-react typecheck`
- `pnpm --filter @voyantjs/auth-ui typecheck`
- `pnpm --filter @voyantjs/auth-react build`
- `pnpm --filter @voyantjs/auth-ui build`
- `pnpm lint:changed`
- Pre-commit hook: staged lint/secretlint, `verify:agent-quality:changed`, repository lint, repository typecheck
- Pre-push hook: repository `pnpm test`