### PR TITLE
[codex] Add auth invitation acceptance flow

### DIFF
--- a/.changeset/auth-accept-invitation.md
+++ b/.changeset/auth-accept-invitation.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/auth-react": minor
+"@voyantjs/auth-ui": minor
+---
+
+Add shared organization invitation acceptance hooks and a router-agnostic accept-invitation page.

--- a/packages/auth-react/README.md
+++ b/packages/auth-react/README.md
@@ -17,6 +17,7 @@ This package wraps the shared Voyant auth HTTP contract:
 - `/auth/organization/list-members`
 - `/auth/organization/list-invitations`
 - `/auth/organization/invite-member`
+- `/auth/organization/accept-invitation`
 - `/auth/organization/update-member-role`
 - `/auth/organization/remove-member`
 - `/auth/organization/cancel-invitation`
@@ -32,7 +33,7 @@ It provides reusable React surfaces for:
 - organization invitation listing
 - email/password sign-in
 - email/password sign-up
-- invite, cancel, remove, and role update mutations
+- invite, accept, cancel, remove, and role update mutations
 - API token listing, creation, update, and deletion
 
 ## Sign-In
@@ -112,6 +113,27 @@ The hook posts to the mounted Better Auth `/auth/sign-up/email` endpoint, calls
 the current auth queries. Invitation-backed registration should use the app's
 invitation redemption endpoint, because Better Auth email sign-up cannot redeem
 Voyant admin-issued invite tokens.
+
+## Invitation Acceptance
+
+`useAcceptInvitation()` posts a Better Auth organization invitation token to the
+mounted `/auth/organization/accept-invitation` endpoint:
+
+```tsx
+const acceptInvitation = useAcceptInvitation()
+
+await acceptInvitation.mutateAsync({ token: invitationId })
+```
+
+The helper also accepts Better Auth's native field name:
+
+```tsx
+await acceptInvitation.mutateAsync({ invitationId })
+```
+
+On success, current-user, current-workspace, organization-member, and
+organization-invitation queries are invalidated so app shells can refresh their
+membership state.
 
 ## Single-Tenant Apps
 

--- a/packages/auth-react/src/hooks/index.ts
+++ b/packages/auth-react/src/hooks/index.ts
@@ -1,4 +1,10 @@
 export {
+  type AcceptInvitationInput,
+  type AcceptInvitationResult,
+  acceptInvitation,
+  useAcceptInvitation,
+} from "./use-accept-invitation.js"
+export {
   type ChangeAccountPasswordInput,
   type ConfirmAccountEmailChangeInput,
   changeAccountPassword,

--- a/packages/auth-react/src/hooks/use-accept-invitation.test.ts
+++ b/packages/auth-react/src/hooks/use-accept-invitation.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest"
+
+import type { VoyantFetcher } from "../client.js"
+import { acceptInvitation } from "./use-accept-invitation.js"
+
+function jsonResponse(body: unknown, init?: ResponseInit) {
+  return new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  })
+}
+
+describe("acceptInvitation", () => {
+  it("posts the invitation token to the mounted Better Auth organization endpoint", async () => {
+    const invitationToken = ["invitation", "123"].join("_")
+    const fetcher = vi.fn<VoyantFetcher>().mockResolvedValueOnce(jsonResponse({ success: true }))
+
+    const result = await acceptInvitation(
+      { token: invitationToken },
+      { baseUrl: "https://operator.example/api", fetcher },
+    )
+
+    expect(result).toEqual({ data: { success: true } })
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://operator.example/api/auth/organization/accept-invitation",
+      {
+        method: "POST",
+        body: JSON.stringify({ invitationId: invitationToken }),
+        headers: expect.any(Headers),
+      },
+    )
+  })
+
+  it("also accepts Better Auth's invitationId field name", async () => {
+    const invitationToken = ["invitation", "456"].join("_")
+    const fetcher = vi
+      .fn<VoyantFetcher>()
+      .mockResolvedValueOnce(jsonResponse({ id: ["member", "123"].join("_") }))
+
+    await acceptInvitation(
+      { invitationId: invitationToken },
+      { baseUrl: "https://operator.example/api/", fetcher },
+    )
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://operator.example/api/auth/organization/accept-invitation",
+      expect.objectContaining({
+        body: JSON.stringify({ invitationId: invitationToken }),
+      }),
+    )
+  })
+
+  it("requires a token or invitationId", async () => {
+    const fetcher = vi.fn<VoyantFetcher>()
+
+    await expect(
+      acceptInvitation({ token: " " }, { baseUrl: "https://operator.example/api", fetcher }),
+    ).rejects.toThrow("Invitation token is required.")
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+})

--- a/packages/auth-react/src/hooks/use-accept-invitation.ts
+++ b/packages/auth-react/src/hooks/use-accept-invitation.ts
@@ -1,0 +1,61 @@
+"use client"
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { z } from "zod"
+
+import { type FetchWithValidationOptions, fetchWithValidation } from "../client.js"
+import { useVoyantAuthContext } from "../provider.js"
+import { authQueryKeys } from "../query-keys.js"
+
+export interface AcceptInvitationInput {
+  invitationId?: string | undefined
+  token?: string | undefined
+}
+
+export interface AcceptInvitationResult {
+  data: unknown
+}
+
+const acceptInvitationResponseSchema = z.unknown()
+
+function invitationIdFromInput(input: AcceptInvitationInput): string {
+  const invitationId = input.invitationId ?? input.token
+  if (!invitationId?.trim()) {
+    throw new Error("Invitation token is required.")
+  }
+
+  return invitationId.trim()
+}
+
+export async function acceptInvitation(
+  input: AcceptInvitationInput,
+  client: FetchWithValidationOptions,
+): Promise<AcceptInvitationResult> {
+  const invitationId = invitationIdFromInput(input)
+  const data = await fetchWithValidation(
+    "/auth/organization/accept-invitation",
+    acceptInvitationResponseSchema,
+    client,
+    {
+      method: "POST",
+      body: JSON.stringify({ invitationId }),
+    },
+  )
+
+  return { data }
+}
+
+export function useAcceptInvitation() {
+  const { baseUrl, fetcher } = useVoyantAuthContext()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (input: AcceptInvitationInput) => acceptInvitation(input, { baseUrl, fetcher }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: authQueryKeys.currentUser() })
+      void queryClient.invalidateQueries({ queryKey: authQueryKeys.currentWorkspace() })
+      void queryClient.invalidateQueries({ queryKey: authQueryKeys.organizationMembers() })
+      void queryClient.invalidateQueries({ queryKey: authQueryKeys.organizationInvitations() })
+    },
+  })
+}

--- a/packages/auth-ui/README.md
+++ b/packages/auth-ui/README.md
@@ -164,3 +164,35 @@ import { OnboardingPage } from "@voyantjs/auth-ui"
 The page submits first name, last name, and optional locale/timezone fields via
 `useUpdateAccountProfile()`. Pass `showLocale={false}` or
 `showTimezone={false}` if the mounted app API does not support those fields.
+
+## Invitation Acceptance
+
+`AcceptInvitationPage` provides a card-less, router-agnostic organization
+invitation flow. Pass a token when the route already parsed one, or omit it to
+render a token input. Signed-out and new-user flows stay app-owned through
+callbacks or links so apps can wire their own sign-in and sign-up routes.
+
+```tsx
+import { AcceptInvitationPage } from "@voyantjs/auth-ui"
+
+<AcceptInvitationPage
+  token={search.id}
+  isAuthenticated={Boolean(user)}
+  signInHref={`/sign-in?next=${encodeURIComponent(location.href)}`}
+  signUpHref={`/sign-up?next=${encodeURIComponent(location.href)}`}
+  continueHref="/"
+  onAccepted={({ token }) => console.log("accepted", token)}
+/>
+```
+
+For apps that handle navigation imperatively, use the handoff callbacks instead
+of hrefs:
+
+```tsx
+<AcceptInvitationPage
+  defaultToken={search.id}
+  isAuthenticated={false}
+  onSignIn={({ token }) => navigate({ to: "/sign-in", search: { invitation: token } })}
+  onSignUp={({ token }) => navigate({ to: "/sign-up", search: { invitation: token } })}
+/>
+```

--- a/packages/auth-ui/src/accept-invitation-page.test.tsx
+++ b/packages/auth-ui/src/accept-invitation-page.test.tsx
@@ -1,0 +1,47 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { VoyantAuthProvider, type VoyantFetcher } from "@voyantjs/auth-react"
+import type { ReactNode } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+
+import { AcceptInvitationPage } from "./components/accept-invitation-page.js"
+
+function renderWithProviders(element: ReactNode) {
+  const fetcher: VoyantFetcher = async () => new Response(null, { status: 204 })
+
+  return renderToStaticMarkup(
+    <QueryClientProvider client={new QueryClient()}>
+      <VoyantAuthProvider baseUrl="https://operator.example/api" fetcher={fetcher}>
+        {element}
+      </VoyantAuthProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe("AcceptInvitationPage", () => {
+  it("renders the existing-user acceptance surface", () => {
+    const markup = renderWithProviders(
+      <AcceptInvitationPage token={["invitation", "123"].join("_")} />,
+    )
+
+    expect(markup).toContain("Accept invitation")
+    expect(markup).toContain("Join the organization")
+    expect(markup).toContain("Accept invitation")
+    expect(markup).not.toContain("Invitation token")
+  })
+
+  it("renders token input and new-user handoff links", () => {
+    const markup = renderWithProviders(
+      <AcceptInvitationPage
+        isAuthenticated={false}
+        signInHref="/sign-in?next=/accept-invitation"
+        signUpHref="/sign-up?next=/accept-invitation"
+      />,
+    )
+
+    expect(markup).toContain("Sign in to accept this invitation")
+    expect(markup).toContain("Invitation token")
+    expect(markup).toContain("/sign-in?next=/accept-invitation")
+    expect(markup).toContain("/sign-up?next=/accept-invitation")
+  })
+})

--- a/packages/auth-ui/src/components/accept-invitation-page.tsx
+++ b/packages/auth-ui/src/components/accept-invitation-page.tsx
@@ -1,0 +1,327 @@
+"use client"
+
+import { type AcceptInvitationResult, useAcceptInvitation } from "@voyantjs/auth-react"
+import { VoyantApiError } from "@voyantjs/auth-react/client"
+import { Button, cn, Input, Label } from "@voyantjs/ui/components"
+import { AlertCircle, CheckCircle2, Loader2, LogIn, UserPlus } from "lucide-react"
+import { type FormEvent, useEffect, useId, useState } from "react"
+
+export interface AcceptInvitationPageMessages {
+  title: string
+  description: string
+  tokenLabel: string
+  tokenPlaceholder: string
+  tokenRequired: string
+  submit: string
+  submitting: string
+  handoffTitle: string
+  handoffDescription: string
+  signIn: string
+  signUp: string
+  successTitle: string
+  successDescription: string
+  continue: string
+  failureTitle: string
+  failureDescription: string
+  signInRequired: string
+  somethingWentWrong: string
+}
+
+export interface AcceptInvitationHandoffOptions {
+  token: string
+  invitationId: string
+}
+
+export interface AcceptInvitationAcceptedOptions extends AcceptInvitationHandoffOptions {
+  result: AcceptInvitationResult
+}
+
+export interface AcceptInvitationPageProps {
+  className?: string
+  messages?: Partial<AcceptInvitationPageMessages>
+  token?: string
+  defaultToken?: string
+  isAuthenticated?: boolean
+  signInHref?: string
+  signUpHref?: string
+  continueHref?: string
+  onSignIn?: (options: AcceptInvitationHandoffOptions) => Promise<void> | void
+  onSignUp?: (options: AcceptInvitationHandoffOptions) => Promise<void> | void
+  onAccepted?: (options: AcceptInvitationAcceptedOptions) => Promise<void> | void
+  onContinue?: (options: AcceptInvitationAcceptedOptions) => Promise<void> | void
+}
+
+export const defaultAcceptInvitationPageMessages: AcceptInvitationPageMessages = {
+  title: "Accept invitation",
+  description: "Join the organization that invited you to Voyant.",
+  tokenLabel: "Invitation token",
+  tokenPlaceholder: "Paste your invitation token",
+  tokenRequired: "Invitation token is required.",
+  submit: "Accept invitation",
+  submitting: "Accepting invitation",
+  handoffTitle: "Sign in to accept this invitation",
+  handoffDescription:
+    "Use an existing account or create a new one, then return to accept the invitation.",
+  signIn: "Sign in",
+  signUp: "Create account",
+  successTitle: "Invitation accepted",
+  successDescription: "You can now access the organization.",
+  continue: "Continue",
+  failureTitle: "Invitation could not be accepted",
+  failureDescription: "Check the invitation token or ask for a new invitation.",
+  signInRequired: "Sign in before accepting this invitation.",
+  somethingWentWrong: "Something went wrong. Try again.",
+}
+
+function invitationErrorMessage(error: unknown, messages: AcceptInvitationPageMessages): string {
+  if (error instanceof VoyantApiError && (error.status === 401 || error.status === 403)) {
+    return messages.signInRequired
+  }
+
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message
+  }
+
+  return messages.somethingWentWrong
+}
+
+export function AcceptInvitationPage({
+  className,
+  messages: messageOverrides,
+  token,
+  defaultToken = "",
+  isAuthenticated,
+  signInHref,
+  signUpHref,
+  continueHref,
+  onSignIn,
+  onSignUp,
+  onAccepted,
+  onContinue,
+}: AcceptInvitationPageProps) {
+  const messages = { ...defaultAcceptInvitationPageMessages, ...messageOverrides }
+  const acceptInvitation = useAcceptInvitation()
+  const tokenInputId = useId()
+  const [tokenValue, setTokenValue] = useState(token ?? defaultToken)
+  const [error, setError] = useState<string | null>(null)
+  const [accepted, setAccepted] = useState<AcceptInvitationAcceptedOptions | null>(null)
+  const [handoffPending, setHandoffPending] = useState<"sign-in" | "sign-up" | null>(null)
+
+  useEffect(() => {
+    if (token !== undefined) {
+      setTokenValue(token)
+    }
+  }, [token])
+
+  const currentToken = tokenValue.trim()
+  const tokenIsProvided = token !== undefined
+  const requiresHandoff = isAuthenticated === false
+  const hasSignInAction = Boolean(signInHref || onSignIn)
+  const hasSignUpAction = Boolean(signUpHref || onSignUp)
+  const hasContinueAction = Boolean(continueHref || onContinue)
+  const isSubmitting = acceptInvitation.isPending
+
+  const requireToken = (): string | null => {
+    if (!currentToken) {
+      setError(messages.tokenRequired)
+      return null
+    }
+
+    return currentToken
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+
+    const invitationToken = requireToken()
+    if (!invitationToken || requiresHandoff) {
+      return
+    }
+
+    try {
+      const result = await acceptInvitation.mutateAsync({ token: invitationToken })
+      const acceptedOptions = {
+        token: invitationToken,
+        invitationId: invitationToken,
+        result,
+      }
+      await onAccepted?.(acceptedOptions)
+      setAccepted(acceptedOptions)
+    } catch (err) {
+      setError(invitationErrorMessage(err, messages))
+    }
+  }
+
+  const handleHandoff = async (kind: "sign-in" | "sign-up") => {
+    const invitationToken = requireToken()
+    if (!invitationToken) {
+      return
+    }
+
+    const callback = kind === "sign-in" ? onSignIn : onSignUp
+    if (!callback) {
+      return
+    }
+
+    setError(null)
+    setHandoffPending(kind)
+    try {
+      await callback({ token: invitationToken, invitationId: invitationToken })
+    } catch {
+      setError(messages.somethingWentWrong)
+    } finally {
+      setHandoffPending(null)
+    }
+  }
+
+  const handleContinue = async () => {
+    if (!accepted || !onContinue) {
+      return
+    }
+
+    await onContinue(accepted)
+  }
+
+  if (accepted) {
+    return (
+      <div
+        data-slot="accept-invitation-page"
+        data-state="success"
+        className={cn("mx-auto flex w-full max-w-sm flex-col gap-6", className)}
+      >
+        <div className="space-y-2">
+          <CheckCircle2 className="h-8 w-8 text-primary" aria-hidden="true" />
+          <h1 className="text-2xl font-bold tracking-tight">{messages.successTitle}</h1>
+          <p className="text-sm text-muted-foreground">{messages.successDescription}</p>
+        </div>
+
+        {hasContinueAction && (
+          <div className="flex flex-col gap-2">
+            {onContinue && (
+              <Button type="button" onClick={() => void handleContinue()}>
+                {messages.continue}
+              </Button>
+            )}
+            {continueHref && (
+              <a
+                href={continueHref}
+                className="text-center text-sm font-medium text-primary hover:underline"
+              >
+                {messages.continue}
+              </a>
+            )}
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      data-slot="accept-invitation-page"
+      data-state={requiresHandoff ? "handoff" : error ? "failure" : "idle"}
+      className={cn("mx-auto flex w-full max-w-sm flex-col gap-6", className)}
+    >
+      <div className="space-y-1">
+        <h1 className="text-2xl font-bold tracking-tight">
+          {requiresHandoff ? messages.handoffTitle : messages.title}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {requiresHandoff ? messages.handoffDescription : messages.description}
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {error && (
+          <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            <div className="flex gap-2">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+              <div>
+                <p className="font-medium">{messages.failureTitle}</p>
+                <p>{error || messages.failureDescription}</p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {!tokenIsProvided && (
+          <div className="space-y-2">
+            <Label htmlFor={tokenInputId}>{messages.tokenLabel}</Label>
+            <Input
+              id={tokenInputId}
+              type="text"
+              placeholder={messages.tokenPlaceholder}
+              value={tokenValue}
+              onChange={(event) => setTokenValue(event.target.value)}
+              required
+              autoComplete="off"
+              autoFocus
+            />
+          </div>
+        )}
+
+        {requiresHandoff ? (
+          <div className="space-y-3">
+            {(hasSignInAction || hasSignUpAction) && (
+              <div className="grid gap-2 sm:grid-cols-2">
+                {onSignIn && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={handoffPending !== null}
+                    onClick={() => void handleHandoff("sign-in")}
+                  >
+                    {handoffPending === "sign-in" ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <LogIn className="mr-2 h-4 w-4" />
+                    )}
+                    {messages.signIn}
+                  </Button>
+                )}
+                {onSignUp && (
+                  <Button
+                    type="button"
+                    disabled={handoffPending !== null}
+                    onClick={() => void handleHandoff("sign-up")}
+                  >
+                    {handoffPending === "sign-up" ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <UserPlus className="mr-2 h-4 w-4" />
+                    )}
+                    {messages.signUp}
+                  </Button>
+                )}
+              </div>
+            )}
+            {(signInHref || signUpHref) && (
+              <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm">
+                {signInHref && (
+                  <a href={signInHref} className="font-medium text-primary hover:underline">
+                    {messages.signIn}
+                  </a>
+                )}
+                {signUpHref && (
+                  <a href={signUpHref} className="font-medium text-primary hover:underline">
+                    {messages.signUp}
+                  </a>
+                )}
+              </div>
+            )}
+          </div>
+        ) : (
+          <Button type="submit" className="w-full" disabled={isSubmitting}>
+            {isSubmitting ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <CheckCircle2 className="mr-2 h-4 w-4" />
+            )}
+            {isSubmitting ? messages.submitting : messages.submit}
+          </Button>
+        )}
+      </form>
+    </div>
+  )
+}

--- a/packages/auth-ui/src/index.ts
+++ b/packages/auth-ui/src/index.ts
@@ -1,4 +1,12 @@
 export {
+  type AcceptInvitationAcceptedOptions,
+  type AcceptInvitationHandoffOptions,
+  AcceptInvitationPage,
+  type AcceptInvitationPageMessages,
+  type AcceptInvitationPageProps,
+  defaultAcceptInvitationPageMessages,
+} from "./components/accept-invitation-page.js"
+export {
   AccountChangeEmailForm,
   type AccountChangeEmailFormProps,
   AccountChangePasswordForm,


### PR DESCRIPTION
## Summary

Advances #785 and #655.

- Adds `acceptInvitation` and `useAcceptInvitation` to `@voyantjs/auth-react` for the mounted Better Auth organization invitation acceptance endpoint.
- Adds a card-less, router-agnostic `AcceptInvitationPage` to `@voyantjs/auth-ui` with token input/prop support, signed-in acceptance, signed-out/new-user handoff callbacks and links, success/failure states, and message overrides.
- Updates exports, README docs, package tests, and changesets for the touched auth packages.

## Validation

- `pnpm --filter @voyantjs/auth-react lint`
- `pnpm --filter @voyantjs/auth-ui lint`
- `pnpm --filter @voyantjs/auth-react test`
- `pnpm --filter @voyantjs/auth-ui test`
- `pnpm --filter @voyantjs/auth-react typecheck`
- `pnpm --filter @voyantjs/auth-ui typecheck`
- `pnpm --filter @voyantjs/auth-react build`
- `pnpm --filter @voyantjs/auth-ui build`
- `pnpm lint:changed`
- pre-push `pnpm test` hook: 125 tasks successful
