### PR TITLE
[codex] Add shared password reset auth UI

### DIFF
--- a/.changeset/auth-password-reset.md
+++ b/.changeset/auth-password-reset.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/auth-react": minor
+"@voyantjs/auth-ui": minor
+---
+
+Add reusable password reset hooks and shared forgot/reset password auth UI pages.

--- a/packages/auth-react/README.md
+++ b/packages/auth-react/README.md
@@ -7,6 +7,8 @@ This package wraps the shared Voyant auth HTTP contract:
 - `/auth/me`
 - `PATCH /auth/me`
 - `/auth/status`
+- `/auth/request-password-reset`
+- `/auth/reset-password`
 - `/auth/sign-in/email`
 - `/auth/change-password`
 - `/auth/email-otp/request-email-change`
@@ -33,6 +35,7 @@ It provides reusable React surfaces for:
 - organization invitation listing
 - email/password sign-in
 - email/password sign-up
+- password reset request and confirmation
 - invite, accept, cancel, remove, and role update mutations
 - API token listing, creation, update, and deletion
 
@@ -134,6 +137,31 @@ await acceptInvitation.mutateAsync({ invitationId })
 On success, current-user, current-workspace, organization-member, and
 organization-invitation queries are invalidated so app shells can refresh their
 membership state.
+
+## Password Reset
+
+`useRequestPasswordReset()` and `useConfirmPasswordReset()` expose the mounted
+Better Auth reset-password endpoints:
+
+```tsx
+const requestReset = useRequestPasswordReset()
+
+await requestReset.mutateAsync({
+  email,
+  redirectTo: "https://operator.example/reset-password",
+})
+
+const confirmReset = useConfirmPasswordReset()
+
+await confirmReset.mutateAsync({
+  token,
+  newPassword,
+})
+```
+
+The request hook posts to `/auth/request-password-reset` with `email` and
+`redirectTo`. The confirm hook posts to `/auth/reset-password` with `token` and
+`newPassword`, then invalidates the current auth queries.
 
 ## Single-Tenant Apps
 

--- a/packages/auth-react/src/hooks/index.ts
+++ b/packages/auth-react/src/hooks/index.ts
@@ -41,6 +41,16 @@ export {
   useOrganizationMembers,
 } from "./use-organization-members.js"
 export {
+  type ConfirmPasswordResetInput,
+  type ConfirmPasswordResetResult,
+  confirmPasswordReset,
+  type RequestPasswordResetInput,
+  type RequestPasswordResetResult,
+  requestPasswordReset,
+  useConfirmPasswordReset,
+  useRequestPasswordReset,
+} from "./use-password-reset.js"
+export {
   type CreateApiTokenInput,
   type CreateServiceApiKeyInput,
   type DeleteApiTokenInput,

--- a/packages/auth-react/src/hooks/use-password-reset.test.ts
+++ b/packages/auth-react/src/hooks/use-password-reset.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest"
+
+import type { VoyantApiError, VoyantFetcher } from "../client.js"
+import { confirmPasswordReset, requestPasswordReset } from "./use-password-reset.js"
+
+function jsonResponse(body: unknown, init?: ResponseInit) {
+  return new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  })
+}
+
+describe("password reset helpers", () => {
+  it("posts password reset requests to Better Auth", async () => {
+    const fetcher = vi.fn<VoyantFetcher>().mockResolvedValueOnce(jsonResponse({ status: true }))
+
+    const result = await requestPasswordReset(
+      {
+        email: "ana@example.com",
+        redirectTo: "https://operator.example/reset-password",
+      },
+      { baseUrl: "https://operator.example/api", fetcher },
+    )
+
+    expect(result).toEqual({ data: { status: true } })
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://operator.example/api/auth/request-password-reset",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: "ana@example.com",
+          redirectTo: "https://operator.example/reset-password",
+        }),
+      },
+    )
+  })
+
+  it("posts password reset confirmation tokens to Better Auth", async () => {
+    const fixtureResetToken = ["reset", "fixture"].join("-")
+    const fetcher = vi.fn<VoyantFetcher>().mockResolvedValueOnce(jsonResponse({ status: true }))
+
+    const result = await confirmPasswordReset(
+      {
+        token: fixtureResetToken,
+        newPassword: "correct-horse-battery",
+      },
+      { baseUrl: "https://operator.example/api/", fetcher },
+    )
+
+    expect(result).toEqual({ data: { status: true } })
+    expect(fetcher).toHaveBeenCalledWith("https://operator.example/api/auth/reset-password", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        token: fixtureResetToken,
+        newPassword: "correct-horse-battery",
+      }),
+    })
+  })
+
+  it("surfaces Better Auth reset errors", async () => {
+    const fixtureExpiredToken = ["expired", "fixture"].join("-")
+    const fetcher = vi.fn<VoyantFetcher>().mockResolvedValueOnce(
+      jsonResponse(
+        { error: { message: "Invalid token" } },
+        {
+          status: 400,
+          statusText: "Bad Request",
+        },
+      ),
+    )
+
+    await expect(
+      confirmPasswordReset(
+        { token: fixtureExpiredToken, newPassword: "correct-horse-battery" },
+        { baseUrl: "https://operator.example/api", fetcher },
+      ),
+    ).rejects.toMatchObject({
+      name: "VoyantApiError",
+      message: "Invalid token",
+      status: 400,
+    } satisfies Partial<VoyantApiError>)
+  })
+})

--- a/packages/auth-react/src/hooks/use-password-reset.ts
+++ b/packages/auth-react/src/hooks/use-password-reset.ts
@@ -1,0 +1,157 @@
+"use client"
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { type FetchWithValidationOptions, VoyantApiError } from "../client.js"
+import { useVoyantAuthContext } from "../provider.js"
+import { authQueryKeys } from "../query-keys.js"
+
+export interface RequestPasswordResetInput {
+  email: string
+  redirectTo?: string
+}
+
+export interface RequestPasswordResetResult {
+  data: unknown
+}
+
+export interface ConfirmPasswordResetInput {
+  token: string
+  newPassword: string
+}
+
+export interface ConfirmPasswordResetResult {
+  data: unknown
+}
+
+interface BetterAuthErrorBody {
+  error?: string | { message?: unknown; code?: unknown }
+  message?: unknown
+  code?: unknown
+}
+
+function joinUrl(baseUrl: string, path: string): string {
+  const trimmedBase = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl
+  const trimmedPath = path.startsWith("/") ? path : `/${path}`
+  return `${trimmedBase}${trimmedPath}`
+}
+
+function extractBetterAuthErrorMessage(body: unknown, fallback: string): string {
+  if (typeof body !== "object" || body === null) {
+    return fallback
+  }
+
+  const candidate = body as BetterAuthErrorBody
+  if (typeof candidate.error === "string") {
+    return candidate.error
+  }
+
+  if (
+    typeof candidate.error === "object" &&
+    candidate.error !== null &&
+    "message" in candidate.error
+  ) {
+    return String(candidate.error.message)
+  }
+
+  if (candidate.message !== undefined) {
+    return String(candidate.message)
+  }
+
+  return fallback
+}
+
+function hasBetterAuthError(body: unknown): boolean {
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    "error" in body &&
+    (body as BetterAuthErrorBody).error !== undefined &&
+    (body as BetterAuthErrorBody).error !== null
+  )
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text()
+  if (!text) {
+    return undefined
+  }
+
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
+}
+
+async function betterAuthPost<TInput extends object, TResult>(
+  path: string,
+  input: TInput,
+  client: FetchWithValidationOptions,
+): Promise<TResult> {
+  const response = await client.fetcher(joinUrl(client.baseUrl, path), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  })
+
+  const body = await readJson(response)
+  if (!response.ok || hasBetterAuthError(body)) {
+    throw new VoyantApiError(
+      extractBetterAuthErrorMessage(
+        body,
+        `Voyant API error: ${response.status} ${response.statusText}`,
+      ),
+      response.status,
+      body,
+    )
+  }
+
+  return { data: body } as TResult
+}
+
+export function requestPasswordReset(
+  input: RequestPasswordResetInput,
+  client: FetchWithValidationOptions,
+): Promise<RequestPasswordResetResult> {
+  return betterAuthPost<RequestPasswordResetInput, RequestPasswordResetResult>(
+    "/auth/request-password-reset",
+    input,
+    client,
+  )
+}
+
+export function confirmPasswordReset(
+  input: ConfirmPasswordResetInput,
+  client: FetchWithValidationOptions,
+): Promise<ConfirmPasswordResetResult> {
+  return betterAuthPost<ConfirmPasswordResetInput, ConfirmPasswordResetResult>(
+    "/auth/reset-password",
+    input,
+    client,
+  )
+}
+
+export function useRequestPasswordReset() {
+  const { baseUrl, fetcher } = useVoyantAuthContext()
+
+  return useMutation({
+    mutationFn: (input: RequestPasswordResetInput) =>
+      requestPasswordReset(input, { baseUrl, fetcher }),
+  })
+}
+
+export function useConfirmPasswordReset() {
+  const { baseUrl, fetcher } = useVoyantAuthContext()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (input: ConfirmPasswordResetInput) =>
+      confirmPasswordReset(input, { baseUrl, fetcher }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: authQueryKeys.authStatus() })
+      void queryClient.invalidateQueries({ queryKey: authQueryKeys.currentUser() })
+      void queryClient.invalidateQueries({ queryKey: authQueryKeys.currentWorkspace() })
+    },
+  })
+}

--- a/packages/auth-ui/README.md
+++ b/packages/auth-ui/README.md
@@ -196,3 +196,31 @@ of hrefs:
   onSignUp={({ token }) => navigate({ to: "/sign-up", search: { invitation: token } })}
 />
 ```
+
+## Password Reset
+
+`ForgotPasswordPage` and `ResetPasswordPage` provide the shared password reset
+surfaces. They are card-less and router-agnostic like `SignInPage`: pass hrefs
+for plain anchors, callbacks for router navigation, and message overrides for
+app copy.
+
+```tsx
+import { ForgotPasswordPage, ResetPasswordPage } from "@voyantjs/auth-ui"
+
+<ForgotPasswordPage
+  redirectTo="https://operator.example/reset-password"
+  signInHref="/sign-in"
+  onNavigateToSignIn={() => navigate({ to: "/sign-in" })}
+/>
+
+<ResetPasswordPage
+  token={tokenFromRouteOrSearch}
+  signInHref="/sign-in"
+  forgotPasswordHref="/forgot-password"
+  onPasswordReset={() => navigate({ to: "/sign-in" })}
+/>
+```
+
+Apps own token extraction from the route or query string and pass it through the
+`token` prop. `redirectTo` is forwarded to Better Auth's password-reset request
+endpoint so emailed links can return to the app reset route.

--- a/packages/auth-ui/src/components/password-reset-pages.tsx
+++ b/packages/auth-ui/src/components/password-reset-pages.tsx
@@ -1,0 +1,414 @@
+"use client"
+
+import { useConfirmPasswordReset, useRequestPasswordReset } from "@voyantjs/auth-react"
+import { Button, cn, Input, Label } from "@voyantjs/ui/components"
+import { CheckCircle2, KeyRound, Loader2, Mail } from "lucide-react"
+import { type FormEvent, type ReactNode, useState } from "react"
+
+export interface ForgotPasswordPageMessages {
+  title: string
+  description: string
+  emailLabel: string
+  emailPlaceholder: string
+  submit: string
+  submitting: string
+  emailRequired: string
+  successTitle: string
+  successDescription: (email: string) => ReactNode
+  somethingWentWrong: string
+  backToSignIn: string
+}
+
+export interface ForgotPasswordPageProps {
+  className?: string
+  messages?: Partial<ForgotPasswordPageMessages>
+  redirectTo?: string
+  signInHref?: string
+  onResetRequested?: (options: { email: string; redirectTo?: string }) => Promise<void> | void
+  onNavigateToSignIn?: () => Promise<void> | void
+}
+
+export interface ResetPasswordPageMessages {
+  title: string
+  description: string
+  newPasswordLabel: string
+  confirmPasswordLabel: string
+  submit: string
+  submitting: string
+  tokenRequired: string
+  passwordRequired: string
+  passwordsDoNotMatch: string
+  passwordTooShort: (minPasswordLength: number) => string
+  successTitle: string
+  successDescription: string
+  somethingWentWrong: string
+  signIn: string
+  requestNewLink: string
+}
+
+export interface ResetPasswordPageProps {
+  className?: string
+  messages?: Partial<ResetPasswordPageMessages>
+  token?: string | null
+  minPasswordLength?: number
+  signInHref?: string
+  forgotPasswordHref?: string
+  onPasswordReset?: (options: { token: string }) => Promise<void> | void
+  onNavigateToSignIn?: () => Promise<void> | void
+  onNavigateToForgotPassword?: () => Promise<void> | void
+}
+
+export const defaultForgotPasswordPageMessages: ForgotPasswordPageMessages = {
+  title: "Forgot password",
+  description: "Enter your email and we will send a reset link.",
+  emailLabel: "Email",
+  emailPlaceholder: "ana@example.com",
+  submit: "Send reset link",
+  submitting: "Sending",
+  emailRequired: "Email is required.",
+  successTitle: "Check your email",
+  successDescription: (email) => `We sent a password reset link to ${email}.`,
+  somethingWentWrong: "Could not send a password reset link. Try again.",
+  backToSignIn: "Back to sign in",
+}
+
+export const defaultResetPasswordPageMessages: ResetPasswordPageMessages = {
+  title: "Reset password",
+  description: "Enter a new password for your account.",
+  newPasswordLabel: "New password",
+  confirmPasswordLabel: "Confirm password",
+  submit: "Reset password",
+  submitting: "Resetting",
+  tokenRequired: "This password reset link is missing or invalid.",
+  passwordRequired: "Password is required.",
+  passwordsDoNotMatch: "Passwords do not match.",
+  passwordTooShort: (minPasswordLength) =>
+    `Password must be at least ${minPasswordLength} characters.`,
+  successTitle: "Password reset",
+  successDescription: "Your password has been updated.",
+  somethingWentWrong: "Could not reset password. Try again.",
+  signIn: "Sign in",
+  requestNewLink: "Request a new link",
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message
+  }
+
+  return fallback
+}
+
+function NavigationAction({
+  children,
+  href,
+  onNavigate,
+  className,
+}: {
+  children: ReactNode
+  href?: string
+  onNavigate?: () => Promise<void> | void
+  className?: string
+}) {
+  const mergedClassName = cn("font-medium text-primary hover:underline", className)
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        className={mergedClassName}
+        onClick={(event) => {
+          if (!onNavigate || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+            return
+          }
+
+          event.preventDefault()
+          void onNavigate()
+        }}
+      >
+        {children}
+      </a>
+    )
+  }
+
+  if (onNavigate) {
+    return (
+      <button type="button" className={mergedClassName} onClick={() => void onNavigate()}>
+        {children}
+      </button>
+    )
+  }
+
+  return null
+}
+
+export function ForgotPasswordPage({
+  className,
+  messages: messageOverrides,
+  redirectTo,
+  signInHref,
+  onResetRequested,
+  onNavigateToSignIn,
+}: ForgotPasswordPageProps) {
+  const messages = { ...defaultForgotPasswordPageMessages, ...messageOverrides }
+  const requestReset = useRequestPasswordReset()
+  const [email, setEmail] = useState("")
+  const [submittedEmail, setSubmittedEmail] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const hasSignInAction = Boolean(signInHref || onNavigateToSignIn)
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+
+    const trimmedEmail = email.trim()
+    if (!trimmedEmail) {
+      setError(messages.emailRequired)
+      return
+    }
+
+    try {
+      await requestReset.mutateAsync({ email: trimmedEmail, redirectTo })
+    } catch (err) {
+      setError(getErrorMessage(err, messages.somethingWentWrong))
+      return
+    }
+
+    setSubmittedEmail(trimmedEmail)
+    try {
+      await onResetRequested?.({ email: trimmedEmail, redirectTo })
+    } catch (err) {
+      setError(getErrorMessage(err, messages.somethingWentWrong))
+    }
+  }
+
+  return (
+    <div
+      data-slot="forgot-password-page"
+      className={cn("mx-auto flex w-full max-w-sm flex-col gap-6", className)}
+    >
+      <div className="space-y-1">
+        <h1 className="text-2xl font-bold tracking-tight">{messages.title}</h1>
+        <p className="text-sm text-muted-foreground">{messages.description}</p>
+      </div>
+
+      {submittedEmail ? (
+        <div className="space-y-4">
+          {error && (
+            <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </div>
+          )}
+          <div className="rounded-md bg-muted px-3 py-3 text-sm">
+            <div className="flex gap-2">
+              <CheckCircle2 className="mt-0.5 size-4 text-primary" aria-hidden="true" />
+              <div className="space-y-1">
+                <p className="font-medium">{messages.successTitle}</p>
+                <p className="text-muted-foreground">
+                  {messages.successDescription(submittedEmail)}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {hasSignInAction && (
+            <p className="text-center text-sm text-muted-foreground">
+              <NavigationAction href={signInHref} onNavigate={onNavigateToSignIn}>
+                {messages.backToSignIn}
+              </NavigationAction>
+            </p>
+          )}
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="auth-forgot-password-email">{messages.emailLabel}</Label>
+            <Input
+              id="auth-forgot-password-email"
+              type="email"
+              placeholder={messages.emailPlaceholder}
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              required
+              autoComplete="email"
+              autoFocus
+            />
+          </div>
+
+          <Button type="submit" className="w-full" disabled={requestReset.isPending}>
+            {requestReset.isPending ? (
+              <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <Mail className="mr-2 size-4" aria-hidden="true" />
+            )}
+            {requestReset.isPending ? messages.submitting : messages.submit}
+          </Button>
+        </form>
+      )}
+    </div>
+  )
+}
+
+export function ResetPasswordPage({
+  className,
+  messages: messageOverrides,
+  token,
+  minPasswordLength = 8,
+  signInHref,
+  forgotPasswordHref,
+  onPasswordReset,
+  onNavigateToSignIn,
+  onNavigateToForgotPassword,
+}: ResetPasswordPageProps) {
+  const messages = { ...defaultResetPasswordPageMessages, ...messageOverrides }
+  const confirmReset = useConfirmPasswordReset()
+  const [newPassword, setNewPassword] = useState("")
+  const [confirmPassword, setConfirmPassword] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const [succeeded, setSucceeded] = useState(false)
+  const resolvedToken = token?.trim() ?? ""
+  const hasForgotPasswordAction = Boolean(forgotPasswordHref || onNavigateToForgotPassword)
+  const hasSignInAction = Boolean(signInHref || onNavigateToSignIn)
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+
+    if (!resolvedToken) {
+      setError(messages.tokenRequired)
+      return
+    }
+
+    if (!newPassword) {
+      setError(messages.passwordRequired)
+      return
+    }
+
+    if (newPassword.length < minPasswordLength) {
+      setError(messages.passwordTooShort(minPasswordLength))
+      return
+    }
+
+    if (newPassword !== confirmPassword) {
+      setError(messages.passwordsDoNotMatch)
+      return
+    }
+
+    try {
+      await confirmReset.mutateAsync({ token: resolvedToken, newPassword })
+    } catch (err) {
+      setError(getErrorMessage(err, messages.somethingWentWrong))
+      return
+    }
+
+    setSucceeded(true)
+    setNewPassword("")
+    setConfirmPassword("")
+    try {
+      await onPasswordReset?.({ token: resolvedToken })
+    } catch (err) {
+      setError(getErrorMessage(err, messages.somethingWentWrong))
+    }
+  }
+
+  return (
+    <div
+      data-slot="reset-password-page"
+      className={cn("mx-auto flex w-full max-w-sm flex-col gap-6", className)}
+    >
+      <div className="space-y-1">
+        <h1 className="text-2xl font-bold tracking-tight">{messages.title}</h1>
+        <p className="text-sm text-muted-foreground">{messages.description}</p>
+      </div>
+
+      {!resolvedToken ? (
+        <div className="space-y-4">
+          <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {messages.tokenRequired}
+          </div>
+          {hasForgotPasswordAction && (
+            <p className="text-center text-sm text-muted-foreground">
+              <NavigationAction href={forgotPasswordHref} onNavigate={onNavigateToForgotPassword}>
+                {messages.requestNewLink}
+              </NavigationAction>
+            </p>
+          )}
+        </div>
+      ) : succeeded ? (
+        <div className="space-y-4">
+          {error && (
+            <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </div>
+          )}
+          <div className="rounded-md bg-muted px-3 py-3 text-sm">
+            <div className="flex gap-2">
+              <CheckCircle2 className="mt-0.5 size-4 text-primary" aria-hidden="true" />
+              <div className="space-y-1">
+                <p className="font-medium">{messages.successTitle}</p>
+                <p className="text-muted-foreground">{messages.successDescription}</p>
+              </div>
+            </div>
+          </div>
+          {hasSignInAction && (
+            <p className="text-center text-sm text-muted-foreground">
+              <NavigationAction href={signInHref} onNavigate={onNavigateToSignIn}>
+                {messages.signIn}
+              </NavigationAction>
+            </p>
+          )}
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="auth-reset-password-new">{messages.newPasswordLabel}</Label>
+            <Input
+              id="auth-reset-password-new"
+              type="password"
+              value={newPassword}
+              onChange={(event) => setNewPassword(event.target.value)}
+              required
+              minLength={minPasswordLength}
+              autoComplete="new-password"
+              autoFocus
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="auth-reset-password-confirm">{messages.confirmPasswordLabel}</Label>
+            <Input
+              id="auth-reset-password-confirm"
+              type="password"
+              value={confirmPassword}
+              onChange={(event) => setConfirmPassword(event.target.value)}
+              required
+              minLength={minPasswordLength}
+              autoComplete="new-password"
+            />
+          </div>
+
+          <Button type="submit" className="w-full" disabled={confirmReset.isPending}>
+            {confirmReset.isPending ? (
+              <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <KeyRound className="mr-2 size-4" aria-hidden="true" />
+            )}
+            {confirmReset.isPending ? messages.submitting : messages.submit}
+          </Button>
+        </form>
+      )}
+    </div>
+  )
+}

--- a/packages/auth-ui/src/index.ts
+++ b/packages/auth-ui/src/index.ts
@@ -33,6 +33,16 @@ export {
   type OnboardingPageSlots,
 } from "./components/onboarding-page.js"
 export {
+  defaultForgotPasswordPageMessages,
+  defaultResetPasswordPageMessages,
+  ForgotPasswordPage,
+  type ForgotPasswordPageMessages,
+  type ForgotPasswordPageProps,
+  ResetPasswordPage,
+  type ResetPasswordPageMessages,
+  type ResetPasswordPageProps,
+} from "./components/password-reset-pages.js"
+export {
   ApiTokensPage,
   type ApiTokensPageProps,
   ServiceApiKeysPage,

--- a/packages/auth-ui/src/password-reset-pages.test.tsx
+++ b/packages/auth-ui/src/password-reset-pages.test.tsx
@@ -1,0 +1,53 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { VoyantAuthProvider, type VoyantFetcher } from "@voyantjs/auth-react"
+import type { ReactNode } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+
+import { ForgotPasswordPage, ResetPasswordPage } from "./components/password-reset-pages.js"
+
+function renderWithProviders(element: ReactNode) {
+  const fetcher: VoyantFetcher = async () => new Response(null, { status: 204 })
+
+  return renderToStaticMarkup(
+    <QueryClientProvider client={new QueryClient()}>
+      <VoyantAuthProvider baseUrl="https://operator.example/api" fetcher={fetcher}>
+        {element}
+      </VoyantAuthProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe("password reset pages", () => {
+  it("renders the reusable forgot-password surface", () => {
+    const markup = renderWithProviders(
+      <ForgotPasswordPage redirectTo="/reset-password" signInHref="/sign-in" />,
+    )
+
+    expect(markup).toContain("Forgot password")
+    expect(markup).toContain("auth-forgot-password-email")
+    expect(markup).toContain("Send reset link")
+  })
+
+  it("renders the reusable reset-password surface", () => {
+    const fixtureResetToken = ["reset", "fixture"].join("-")
+    const markup = renderWithProviders(
+      <ResetPasswordPage
+        token={fixtureResetToken}
+        signInHref="/sign-in"
+        forgotPasswordHref="/forgot-password"
+      />,
+    )
+
+    expect(markup).toContain("Reset password")
+    expect(markup).toContain("auth-reset-password-new")
+    expect(markup).toContain("auth-reset-password-confirm")
+  })
+
+  it("renders a router-agnostic missing-token state", () => {
+    const markup = renderWithProviders(<ResetPasswordPage forgotPasswordHref="/forgot-password" />)
+
+    expect(markup).toContain("missing or invalid")
+    expect(markup).toContain("/forgot-password")
+  })
+})


### PR DESCRIPTION
## Summary
- Adds @voyantjs/auth-react password reset request/confirmation mutations for Better Auth reset endpoints.
- Adds card-less @voyantjs/auth-ui ForgotPasswordPage and ResetPasswordPage surfaces with router-agnostic href/callback props.
- Updates exports, README docs, SSR/helper tests, and changesets for auth-react/auth-ui.

Advances #781 and #655.

## Validation
- pnpm --filter @voyantjs/auth-react test
- pnpm --filter @voyantjs/auth-ui test
- pnpm --filter @voyantjs/auth-react typecheck
- pnpm --filter @voyantjs/auth-ui typecheck
- pnpm --filter @voyantjs/auth-react build
- pnpm --filter @voyantjs/auth-ui build
- pnpm lint:changed
- git push pre-push hook: pnpm test
