### PR TITLE
[codex] Add auth onboarding profile flow

### DIFF
--- a/.changeset/auth-onboarding-profile.md
+++ b/.changeset/auth-onboarding-profile.md
@@ -1,0 +1,7 @@
+---
+"@voyantjs/auth": minor
+"@voyantjs/auth-react": minor
+"@voyantjs/auth-ui": minor
+---
+
+Add the shared account profile update contract, React mutation helper, and card-less onboarding profile completion page.

--- a/packages/auth-react/README.md
+++ b/packages/auth-react/README.md
@@ -5,6 +5,7 @@ React runtime package for Voyant authentication and optional workspace state.
 This package wraps the shared Voyant auth HTTP contract:
 
 - `/auth/me`
+- `PATCH /auth/me`
 - `/auth/status`
 - `/auth/sign-in/email`
 - `/auth/workspace/current`
@@ -21,6 +22,7 @@ This package wraps the shared Voyant auth HTTP contract:
 It provides reusable React surfaces for:
 
 - current user state
+- account profile updates
 - optional workspace and organization state
 - organization member listing
 - organization invitation listing
@@ -45,6 +47,26 @@ await signIn.email.mutateAsync({
 After Better Auth accepts the credentials, the hook calls `/auth/status` to
 provision the Voyant user profile if needed and invalidates the current auth
 queries.
+
+## Profile Completion
+
+`updateAccountProfile()` and `useUpdateAccountProfile()` call `PATCH /auth/me`
+with the current user's profile fields and refresh the cached current user on
+success:
+
+```tsx
+const updateProfile = useUpdateAccountProfile()
+
+await updateProfile.mutateAsync({
+  firstName: "Ana",
+  lastName: "Pop",
+  locale: "ro",
+  timezone: "Europe/Bucharest",
+})
+```
+
+Apps can mount `handleAccountProfileRequest(...)` from `@voyantjs/auth/server`
+to provide this route without depending on a specific template.
 
 ## Single-Tenant Apps
 

--- a/packages/auth-react/src/hooks/index.ts
+++ b/packages/auth-react/src/hooks/index.ts
@@ -41,4 +41,10 @@ export {
   signInWithEmail,
   useSignIn,
 } from "./use-sign-in.js"
+export {
+  type UpdateAccountProfileInput,
+  type UpdateAccountProfileResult,
+  updateAccountProfile,
+  useUpdateAccountProfile,
+} from "./use-update-account-profile.js"
 export { useWorkspaceMutation } from "./use-workspace-mutation.js"

--- a/packages/auth-react/src/hooks/use-update-account-profile.test.ts
+++ b/packages/auth-react/src/hooks/use-update-account-profile.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest"
+
+import type { VoyantFetcher } from "../client.js"
+import { updateAccountProfile } from "./use-update-account-profile.js"
+
+function jsonResponse(body: unknown, init?: ResponseInit) {
+  return new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  })
+}
+
+describe("updateAccountProfile", () => {
+  it("patches the current user's profile fields", async () => {
+    const fetcher = vi.fn<VoyantFetcher>().mockResolvedValueOnce(
+      jsonResponse({
+        id: "user_1",
+        email: "ana@example.com",
+        phoneNumber: null,
+        firstName: "Ana",
+        lastName: "Pop",
+        locale: "ro",
+        timezone: "Europe/Bucharest",
+        isSuperAdmin: false,
+        isSupportUser: false,
+        createdAt: "2026-05-12T00:00:00.000Z",
+        profilePictureUrl: null,
+      }),
+    )
+
+    const result = await updateAccountProfile(
+      {
+        firstName: "Ana",
+        lastName: "Pop",
+        locale: "ro",
+        timezone: "Europe/Bucharest",
+      },
+      { baseUrl: "https://operator.example/api", fetcher },
+    )
+
+    expect(result.firstName).toBe("Ana")
+    expect(result.locale).toBe("ro")
+    expect(fetcher).toHaveBeenCalledWith("https://operator.example/api/auth/me", {
+      method: "PATCH",
+      headers: new Headers({ "Content-Type": "application/json" }),
+      body: JSON.stringify({
+        firstName: "Ana",
+        lastName: "Pop",
+        locale: "ro",
+        timezone: "Europe/Bucharest",
+      }),
+    })
+  })
+
+  it("preserves explicit null fields in the patch body", async () => {
+    const fetcher = vi.fn<VoyantFetcher>().mockResolvedValueOnce(
+      jsonResponse({
+        id: "user_1",
+        email: "ana@example.com",
+        firstName: null,
+        lastName: null,
+        locale: "en",
+        timezone: null,
+        isSuperAdmin: false,
+        isSupportUser: false,
+        createdAt: "2026-05-12T00:00:00.000Z",
+      }),
+    )
+
+    await updateAccountProfile(
+      { firstName: null, lastName: null, timezone: null },
+      { baseUrl: "https://operator.example/api/", fetcher },
+    )
+
+    expect(fetcher).toHaveBeenCalledWith("https://operator.example/api/auth/me", {
+      method: "PATCH",
+      headers: new Headers({ "Content-Type": "application/json" }),
+      body: JSON.stringify({ firstName: null, lastName: null, timezone: null }),
+    })
+  })
+})

--- a/packages/auth-react/src/hooks/use-update-account-profile.ts
+++ b/packages/auth-react/src/hooks/use-update-account-profile.ts
@@ -1,0 +1,52 @@
+"use client"
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { type FetchWithValidationOptions, fetchWithValidation } from "../client.js"
+import { useVoyantAuthContext } from "../provider.js"
+import { authQueryKeys } from "../query-keys.js"
+import { type CurrentUser, currentUserSchema } from "../schemas.js"
+
+export interface UpdateAccountProfileInput {
+  firstName?: string | null
+  lastName?: string | null
+  locale?: string | null
+  timezone?: string | null
+}
+
+export type UpdateAccountProfileResult = CurrentUser
+
+export async function updateAccountProfile(
+  input: UpdateAccountProfileInput,
+  client: FetchWithValidationOptions,
+): Promise<UpdateAccountProfileResult> {
+  return fetchWithValidation("/auth/me", currentUserSchema, client, {
+    method: "PATCH",
+    body: JSON.stringify(profilePatchBody(input)),
+  })
+}
+
+export function useUpdateAccountProfile() {
+  const { baseUrl, fetcher } = useVoyantAuthContext()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (input: UpdateAccountProfileInput) =>
+      updateAccountProfile(input, { baseUrl, fetcher }),
+    onSuccess: (user) => {
+      queryClient.setQueryData(authQueryKeys.currentUser(), user)
+      void queryClient.invalidateQueries({ queryKey: authQueryKeys.authStatus() })
+    },
+  })
+}
+
+function profilePatchBody(input: UpdateAccountProfileInput) {
+  const body: UpdateAccountProfileInput = {}
+
+  if ("firstName" in input) body.firstName = input.firstName
+  if ("lastName" in input) body.lastName = input.lastName
+  if ("locale" in input) body.locale = input.locale
+  if ("timezone" in input) body.timezone = input.timezone
+
+  return body
+}

--- a/packages/auth-react/src/schemas.ts
+++ b/packages/auth-react/src/schemas.ts
@@ -9,6 +9,8 @@ export const currentUserSchema = z.object({
   phoneNumber: z.string().nullable().optional(),
   firstName: z.string().nullable(),
   lastName: z.string().nullable(),
+  locale: z.string().default("en"),
+  timezone: z.string().nullable().default(null),
   isSuperAdmin: z.boolean(),
   isSupportUser: z.boolean(),
   createdAt: z.string(),

--- a/packages/auth-ui/README.md
+++ b/packages/auth-ui/README.md
@@ -57,3 +57,25 @@ they need router and provider-plugin wiring:
   }
 />
 ```
+
+## Onboarding
+
+`OnboardingPage` provides the shared first-run profile completion surface. It is
+card-less and router-agnostic: apps own the surrounding auth layout and decide
+where to navigate after `onCompleted`.
+
+```tsx
+import { OnboardingPage } from "@voyantjs/auth-ui"
+
+<OnboardingPage
+  initialProfile={user}
+  onCompleted={() => navigate({ to: "/" })}
+  slots={{
+    afterFields: <WorkspaceInvitePicker />,
+  }}
+/>
+```
+
+The page submits first name, last name, and optional locale/timezone fields via
+`useUpdateAccountProfile()`. Pass `showLocale={false}` or
+`showTimezone={false}` if the mounted app API does not support those fields.

--- a/packages/auth-ui/src/components/onboarding-page.tsx
+++ b/packages/auth-ui/src/components/onboarding-page.tsx
@@ -1,0 +1,221 @@
+"use client"
+
+import {
+  type CurrentUser,
+  type UpdateAccountProfileInput,
+  useUpdateAccountProfile,
+} from "@voyantjs/auth-react"
+import { Button, cn, Input, Label } from "@voyantjs/ui/components"
+import { CheckCircle2, Loader2 } from "lucide-react"
+import { type FormEvent, type ReactNode, useMemo, useState } from "react"
+
+export interface OnboardingPageMessages {
+  title: string
+  description: string
+  firstNameLabel: string
+  firstNamePlaceholder: string
+  lastNameLabel: string
+  lastNamePlaceholder: string
+  localeLabel: string
+  localePlaceholder: string
+  timezoneLabel: string
+  timezonePlaceholder: string
+  firstNameRequired: string
+  lastNameRequired: string
+  submit: string
+  submitting: string
+  somethingWentWrong: string
+}
+
+export interface OnboardingPageSlots {
+  beforeFields?: ReactNode
+  afterFields?: ReactNode
+  footer?: ReactNode
+}
+
+export interface OnboardingPageInitialProfile {
+  firstName?: string | null
+  lastName?: string | null
+  locale?: string | null
+  timezone?: string | null
+}
+
+export interface OnboardingPageProps {
+  className?: string
+  initialProfile?: OnboardingPageInitialProfile | null
+  messages?: Partial<OnboardingPageMessages>
+  showLocale?: boolean
+  showTimezone?: boolean
+  slots?: OnboardingPageSlots
+  onCompleted?: (profile: CurrentUser) => Promise<void> | void
+}
+
+export const defaultOnboardingPageMessages: OnboardingPageMessages = {
+  title: "Complete your profile",
+  description: "Add the basic account details your team will see in Voyant.",
+  firstNameLabel: "First name",
+  firstNamePlaceholder: "Ana",
+  lastNameLabel: "Last name",
+  lastNamePlaceholder: "Pop",
+  localeLabel: "Locale",
+  localePlaceholder: "en",
+  timezoneLabel: "Timezone",
+  timezonePlaceholder: "Europe/Bucharest",
+  firstNameRequired: "First name is required.",
+  lastNameRequired: "Last name is required.",
+  submit: "Continue",
+  submitting: "Saving",
+  somethingWentWrong: "Something went wrong. Try again.",
+}
+
+export function OnboardingPage({
+  className,
+  initialProfile,
+  messages: messageOverrides,
+  showLocale = true,
+  showTimezone = true,
+  slots,
+  onCompleted,
+}: OnboardingPageProps) {
+  const messages = useMemo(
+    () => ({ ...defaultOnboardingPageMessages, ...messageOverrides }),
+    [messageOverrides],
+  )
+  const updateProfile = useUpdateAccountProfile()
+  const [firstName, setFirstName] = useState(initialProfile?.firstName ?? "")
+  const [lastName, setLastName] = useState(initialProfile?.lastName ?? "")
+  const [locale, setLocale] = useState(initialProfile?.locale ?? "en")
+  const [timezone, setTimezone] = useState(initialProfile?.timezone ?? "")
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+
+    const trimmedFirstName = firstName.trim()
+    const trimmedLastName = lastName.trim()
+    const trimmedLocale = locale.trim()
+    const trimmedTimezone = timezone.trim()
+
+    if (!trimmedFirstName) {
+      setError(messages.firstNameRequired)
+      return
+    }
+
+    if (!trimmedLastName) {
+      setError(messages.lastNameRequired)
+      return
+    }
+
+    const input: UpdateAccountProfileInput = {
+      firstName: trimmedFirstName,
+      lastName: trimmedLastName,
+    }
+
+    if (showLocale) {
+      input.locale = trimmedLocale || null
+    }
+
+    if (showTimezone) {
+      input.timezone = trimmedTimezone || null
+    }
+
+    try {
+      const profile = await updateProfile.mutateAsync(input)
+      await onCompleted?.(profile)
+    } catch (err) {
+      setError(err instanceof Error && err.message ? err.message : messages.somethingWentWrong)
+    }
+  }
+
+  return (
+    <div
+      data-slot="onboarding-page"
+      className={cn("mx-auto flex w-full max-w-xl flex-col gap-6", className)}
+    >
+      <div className="space-y-1">
+        <h1 className="text-2xl font-bold tracking-tight">{messages.title}</h1>
+        <p className="text-sm text-muted-foreground">{messages.description}</p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {error && (
+          <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {error}
+          </div>
+        )}
+
+        {slots?.beforeFields}
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="auth-onboarding-first-name">{messages.firstNameLabel}</Label>
+            <Input
+              id="auth-onboarding-first-name"
+              value={firstName}
+              placeholder={messages.firstNamePlaceholder}
+              onChange={(event) => setFirstName(event.target.value)}
+              required
+              autoComplete="given-name"
+              autoFocus
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="auth-onboarding-last-name">{messages.lastNameLabel}</Label>
+            <Input
+              id="auth-onboarding-last-name"
+              value={lastName}
+              placeholder={messages.lastNamePlaceholder}
+              onChange={(event) => setLastName(event.target.value)}
+              required
+              autoComplete="family-name"
+            />
+          </div>
+        </div>
+
+        {(showLocale || showTimezone) && (
+          <div className="grid gap-4 sm:grid-cols-2">
+            {showLocale && (
+              <div className="space-y-2">
+                <Label htmlFor="auth-onboarding-locale">{messages.localeLabel}</Label>
+                <Input
+                  id="auth-onboarding-locale"
+                  value={locale}
+                  placeholder={messages.localePlaceholder}
+                  onChange={(event) => setLocale(event.target.value)}
+                  autoComplete="language"
+                />
+              </div>
+            )}
+
+            {showTimezone && (
+              <div className="space-y-2">
+                <Label htmlFor="auth-onboarding-timezone">{messages.timezoneLabel}</Label>
+                <Input
+                  id="auth-onboarding-timezone"
+                  value={timezone}
+                  placeholder={messages.timezonePlaceholder}
+                  onChange={(event) => setTimezone(event.target.value)}
+                />
+              </div>
+            )}
+          </div>
+        )}
+
+        {slots?.afterFields}
+
+        <Button type="submit" className="w-full sm:w-auto" disabled={updateProfile.isPending}>
+          {updateProfile.isPending ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <CheckCircle2 className="mr-2 h-4 w-4" />
+          )}
+          {updateProfile.isPending ? messages.submitting : messages.submit}
+        </Button>
+
+        {slots?.footer}
+      </form>
+    </div>
+  )
+}

--- a/packages/auth-ui/src/index.ts
+++ b/packages/auth-ui/src/index.ts
@@ -1,4 +1,12 @@
 export {
+  defaultOnboardingPageMessages,
+  OnboardingPage,
+  type OnboardingPageInitialProfile,
+  type OnboardingPageMessages,
+  type OnboardingPageProps,
+  type OnboardingPageSlots,
+} from "./components/onboarding-page.js"
+export {
   ApiTokensPage,
   type ApiTokensPageProps,
   ServiceApiKeysPage,

--- a/packages/auth-ui/src/onboarding-page.test.tsx
+++ b/packages/auth-ui/src/onboarding-page.test.tsx
@@ -1,0 +1,58 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { VoyantAuthProvider, type VoyantFetcher } from "@voyantjs/auth-react"
+import type { ReactNode } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+
+import { OnboardingPage } from "./components/onboarding-page.js"
+
+function renderWithProviders(element: ReactNode) {
+  const fetcher: VoyantFetcher = async () => new Response(null, { status: 204 })
+
+  return renderToStaticMarkup(
+    <QueryClientProvider client={new QueryClient()}>
+      <VoyantAuthProvider baseUrl="https://operator.example/api" fetcher={fetcher}>
+        {element}
+      </VoyantAuthProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe("OnboardingPage", () => {
+  it("renders the reusable profile completion surface", () => {
+    const markup = renderWithProviders(
+      <OnboardingPage
+        initialProfile={{
+          firstName: "Ana",
+          lastName: "Pop",
+          locale: "ro",
+          timezone: "Europe/Bucharest",
+        }}
+      />,
+    )
+
+    expect(markup).toContain("Complete your profile")
+    expect(markup).toContain("auth-onboarding-first-name")
+    expect(markup).toContain("auth-onboarding-last-name")
+    expect(markup).toContain("auth-onboarding-locale")
+    expect(markup).toContain("auth-onboarding-timezone")
+    expect(markup).toContain("Europe/Bucharest")
+  })
+
+  it("supports message overrides, optional fields, and app slots", () => {
+    const markup = renderWithProviders(
+      <OnboardingPage
+        showLocale={false}
+        showTimezone={false}
+        messages={{ title: "Set up your account", submit: "Finish" }}
+        slots={{ beforeFields: <div data-testid="workspace-slot">Workspace setup</div> }}
+      />,
+    )
+
+    expect(markup).toContain("Set up your account")
+    expect(markup).toContain("Finish")
+    expect(markup).toContain("Workspace setup")
+    expect(markup).not.toContain("auth-onboarding-locale")
+    expect(markup).not.toContain("auth-onboarding-timezone")
+  })
+})

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -13,13 +13,20 @@ pnpm add @voyantjs/auth better-auth
 ## Usage
 
 ```typescript
-import { createBetterAuth, handleApiTokenManagementRequest } from "@voyantjs/auth/server"
+import {
+  createBetterAuth,
+  handleAccountProfileRequest,
+  handleApiTokenManagementRequest,
+} from "@voyantjs/auth/server"
 
 const auth = createBetterAuth({
   db,
   secret: env.AUTH_SECRET,
   trustedOrigins: ["https://example.com"],
 })
+
+const profileResponse = await handleAccountProfileRequest(request, auth, { db })
+if (profileResponse) return profileResponse
 
 const tokenResponse = await handleApiTokenManagementRequest(request, auth)
 if (tokenResponse) return tokenResponse
@@ -42,6 +49,14 @@ small `/auth/api-tokens` facade for operator management UI because the UI needs
 server-only plugin fields such as `permissions`, `remaining`, and `enabled`.
 Mount `handleApiTokenManagementRequest(...)` before falling through to
 `auth.handler(request)`.
+
+## Account Profile
+
+Voyant auth UIs use `PATCH /auth/me` to update the signed-in user's basic
+profile fields: `firstName`, `lastName`, `locale`, and `timezone`. Mount
+`handleAccountProfileRequest(...)` before falling through to `auth.handler`
+when the app wants the shared onboarding/profile completion UI to submit
+directly to the auth facade.
 
 ## Exports
 

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -14,6 +14,12 @@ import { emailOTP } from "better-auth/plugins"
 import type { BetterAuthPlugin } from "better-auth/types"
 import { sql } from "drizzle-orm"
 
+import {
+  type CurrentUser,
+  type UpdateCurrentUserProfileInput,
+  updateCurrentUserProfile,
+} from "./workspace.js"
+
 type BetterAuthApiKeySession = {
   user: {
     id: string
@@ -39,6 +45,21 @@ export interface HandleApiTokenManagementRequestOptions {
    */
   basePath?: string
 }
+
+export interface HandleAccountProfileRequestOptions {
+  /**
+   * Auth route mount path. Voyant operator APIs mount Better Auth under
+   * `/auth`, which makes the account profile route `/auth/me`.
+   */
+  basePath?: string
+  db: ReturnType<typeof getDb>
+  updateProfile?: AccountProfileUpdateHandler
+}
+
+export type AccountProfileUpdateHandler = (
+  db: ReturnType<typeof getDb>,
+  input: UpdateCurrentUserProfileInput,
+) => Promise<CurrentUser | null>
 
 type ApiTokenErrorStatus = 400 | 401 | 403 | 404 | 405 | 429 | 500
 
@@ -132,6 +153,14 @@ function apiTokenFacadePath(pathname: string, basePath: string): string | null {
   return null
 }
 
+function accountProfileFacadePath(pathname: string, basePath: string): string | null {
+  const trimmedBase = basePath.replace(/^\/+|\/+$/g, "")
+  const normalizedBase = trimmedBase ? `/${trimmedBase}` : ""
+  const normalizedPath = pathname.replace(/\/+$/g, "") || "/"
+
+  return normalizedPath === `${normalizedBase}/me` ? "/me" : null
+}
+
 function readApiKeyQuery(request: Request): Record<string, unknown> {
   const query: Record<string, unknown> = {}
   const params = new URL(request.url).searchParams
@@ -143,6 +172,32 @@ function readApiKeyQuery(request: Request): Record<string, unknown> {
   }
 
   return query
+}
+
+function readProfileUpdate(
+  body: Record<string, unknown>,
+): Omit<UpdateCurrentUserProfileInput, "userId"> {
+  const input: Omit<UpdateCurrentUserProfileInput, "userId"> = {}
+
+  for (const field of ["firstName", "lastName", "locale", "timezone"] as const) {
+    const value = body[field]
+    if (value === undefined) continue
+
+    if (value !== null && typeof value !== "string") {
+      throw Object.assign(new Error(`${field} must be a string or null`), { status: 400 })
+    }
+
+    const maxLength = field === "locale" ? 10 : field === "timezone" ? 64 : 200
+    if (typeof value === "string" && value.length > maxLength) {
+      throw Object.assign(new Error(`${field} must be ${maxLength} characters or fewer`), {
+        status: 400,
+      })
+    }
+
+    input[field] = value
+  }
+
+  return input
 }
 
 async function readOptionalJson(request: Request): Promise<Record<string, unknown>> {
@@ -172,6 +227,56 @@ async function requireApiTokenSession(auth: BetterAuthApiTokenManagement, header
     throw Object.assign(new Error("Unauthorized"), { status: 401 })
   }
   return session
+}
+
+async function requireAccountProfileSession(auth: BetterAuthApiTokenManagement, headers: Headers) {
+  const session = await auth.api.getSession({ headers })
+  if (!session) {
+    throw Object.assign(new Error("Unauthorized"), { status: 401 })
+  }
+  return session
+}
+
+/**
+ * Handles Voyant's stable account-profile update facade:
+ *
+ * - `PATCH /auth/me`
+ *
+ * Apps can mount this before falling through to `auth.handler(request)` for
+ * the rest of Better Auth. The route updates only the current session user's
+ * non-sensitive `user_profiles` fields.
+ */
+export async function handleAccountProfileRequest(
+  request: Request,
+  auth: { api: unknown },
+  options: HandleAccountProfileRequestOptions,
+): Promise<Response | null> {
+  const path = accountProfileFacadePath(new URL(request.url).pathname, options.basePath ?? "/auth")
+  if (path === null) return null
+
+  try {
+    if (request.method !== "PATCH") {
+      return methodNotAllowed(["PATCH"])
+    }
+
+    const session = await requireAccountProfileSession(
+      { api: auth.api as BetterAuthApiKeyApi },
+      request.headers,
+    )
+    const body = await readOptionalJson(request)
+    const profile = await (options.updateProfile ?? updateCurrentUserProfile)(options.db, {
+      userId: session.user.id,
+      ...readProfileUpdate(body),
+    })
+
+    if (!profile) {
+      return jsonResponse({ error: "User not found" }, 404)
+    }
+
+    return jsonResponse(profile)
+  } catch (error) {
+    return authApiErrorResponse(error)
+  }
 }
 
 /**

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -255,9 +255,7 @@ export async function handleAccountProfileRequest(
   if (path === null) return null
 
   try {
-    if (request.method !== "PATCH") {
-      return methodNotAllowed(["PATCH"])
-    }
+    if (request.method !== "PATCH") return null
 
     const session = await requireAccountProfileSession(
       { api: auth.api as BetterAuthApiKeyApi },

--- a/packages/auth/src/workspace.ts
+++ b/packages/auth/src/workspace.ts
@@ -165,7 +165,7 @@ function profilePatchValues(input: UpdateCurrentUserProfileInput) {
 
   if ("firstName" in input) values.firstName = input.firstName ?? null
   if ("lastName" in input) values.lastName = input.lastName ?? null
-  if ("locale" in input && input.locale !== null) values.locale = input.locale
+  if ("locale" in input) values.locale = input.locale ?? "en"
   if ("timezone" in input) values.timezone = input.timezone ?? null
 
   return values

--- a/packages/auth/src/workspace.ts
+++ b/packages/auth/src/workspace.ts
@@ -1,6 +1,6 @@
 import type { getDb } from "@voyantjs/db"
 import { authUser, userProfilesTable } from "@voyantjs/db/schema/iam"
-import { eq } from "drizzle-orm"
+import { eq, sql } from "drizzle-orm"
 
 type WorkspaceDb = ReturnType<typeof getDb>
 
@@ -10,10 +10,20 @@ export type CurrentUser = {
   phoneNumber?: string | null
   firstName: string | null
   lastName: string | null
+  locale: string
+  timezone: string | null
   isSuperAdmin: boolean
   isSupportUser: boolean
   createdAt: string
   profilePictureUrl?: string | null
+}
+
+export type UpdateCurrentUserProfileInput = {
+  userId: string
+  firstName?: string | null
+  lastName?: string | null
+  locale?: string | null
+  timezone?: string | null
 }
 
 export type AuthStatus = {
@@ -34,6 +44,8 @@ export async function getCurrentUser(
       createdAt: authUser.createdAt,
       firstName: userProfilesTable.firstName,
       lastName: userProfilesTable.lastName,
+      locale: userProfilesTable.locale,
+      timezone: userProfilesTable.timezone,
       avatarUrl: userProfilesTable.avatarUrl,
       isSuperAdmin: userProfilesTable.isSuperAdmin,
       isSupportUser: userProfilesTable.isSupportUser,
@@ -53,11 +65,37 @@ export async function getCurrentUser(
     phoneNumber: row.phoneNumber ?? null,
     firstName: row.firstName ?? null,
     lastName: row.lastName ?? null,
+    locale: row.locale ?? "en",
+    timezone: row.timezone ?? null,
     isSuperAdmin: row.isSuperAdmin ?? false,
     isSupportUser: row.isSupportUser ?? false,
     createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
     profilePictureUrl: row.avatarUrl ?? null,
   }
+}
+
+export async function updateCurrentUserProfile(
+  db: WorkspaceDb,
+  input: UpdateCurrentUserProfileInput,
+): Promise<CurrentUser | null> {
+  const values = {
+    id: input.userId,
+    ...profilePatchValues(input),
+    updatedAt: sql`now()`,
+  }
+
+  await db
+    .insert(userProfilesTable)
+    .values(values)
+    .onConflictDoUpdate({
+      target: userProfilesTable.id,
+      set: {
+        ...profilePatchValues(input),
+        updatedAt: sql`now()`,
+      },
+    })
+
+  return getCurrentUser(db, { userId: input.userId })
 }
 
 export async function ensureCurrentUserProfile(
@@ -115,4 +153,20 @@ export async function ensureCurrentUserProfile(
       reason: `Provisioning error: ${message}`,
     }
   }
+}
+
+function profilePatchValues(input: UpdateCurrentUserProfileInput) {
+  const values: {
+    firstName?: string | null
+    lastName?: string | null
+    locale?: string
+    timezone?: string | null
+  } = {}
+
+  if ("firstName" in input) values.firstName = input.firstName ?? null
+  if ("lastName" in input) values.lastName = input.lastName ?? null
+  if ("locale" in input && input.locale !== null) values.locale = input.locale
+  if ("timezone" in input) values.timezone = input.timezone ?? null
+
+  return values
 }

--- a/packages/auth/tests/unit/account-profile.test.ts
+++ b/packages/auth/tests/unit/account-profile.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { type BetterAuthApiTokenManagement, handleAccountProfileRequest } from "../../src/server.js"
+
+function createAuthMock(): BetterAuthApiTokenManagement {
+  return {
+    api: {
+      getSession: vi.fn(async () => ({ user: { id: "user_123" } })),
+      listApiKeys: vi.fn(),
+      createApiKey: vi.fn(),
+      updateApiKey: vi.fn(),
+      deleteApiKey: vi.fn(),
+    },
+  }
+}
+
+async function responseJson(response: Response | null): Promise<unknown> {
+  expect(response).not.toBeNull()
+  return response?.json()
+}
+
+describe("handleAccountProfileRequest", () => {
+  it("returns null for requests outside the profile facade", async () => {
+    const auth = createAuthMock()
+    const updateProfile = vi.fn()
+
+    const response = await handleAccountProfileRequest(
+      new Request("https://example.com/auth/session"),
+      auth,
+      {
+        db: {} as never,
+        updateProfile,
+      },
+    )
+
+    expect(response).toBeNull()
+    expect(updateProfile).not.toHaveBeenCalled()
+  })
+
+  it("patches the signed-in user's profile", async () => {
+    const auth = createAuthMock()
+    const updateProfile = vi.fn(async () => ({
+      id: "user_123",
+      email: "ana@example.com",
+      phoneNumber: null,
+      firstName: "Ana",
+      lastName: "Pop",
+      locale: "ro",
+      timezone: "Europe/Bucharest",
+      isSuperAdmin: false,
+      isSupportUser: false,
+      createdAt: "2026-05-12T00:00:00.000Z",
+      profilePictureUrl: null,
+    }))
+
+    const response = await handleAccountProfileRequest(
+      new Request("https://example.com/auth/me", {
+        method: "PATCH",
+        body: JSON.stringify({
+          firstName: "Ana",
+          lastName: "Pop",
+          locale: "ro",
+          timezone: "Europe/Bucharest",
+          ignored: true,
+        }),
+      }),
+      auth,
+      {
+        db: {} as never,
+        updateProfile,
+      },
+    )
+
+    expect(response?.status).toBe(200)
+    expect(auth.api.getSession).toHaveBeenCalledWith({ headers: expect.any(Headers) })
+    expect(updateProfile).toHaveBeenCalledWith(
+      {},
+      {
+        userId: "user_123",
+        firstName: "Ana",
+        lastName: "Pop",
+        locale: "ro",
+        timezone: "Europe/Bucharest",
+      },
+    )
+    expect(await responseJson(response)).toMatchObject({
+      id: "user_123",
+      firstName: "Ana",
+      locale: "ro",
+    })
+  })
+
+  it("supports custom auth base paths", async () => {
+    const auth = createAuthMock()
+    const updateProfile = vi.fn(async () => ({
+      id: "user_123",
+      email: "ana@example.com",
+      firstName: null,
+      lastName: null,
+      locale: "en",
+      timezone: null,
+      isSuperAdmin: false,
+      isSupportUser: false,
+      createdAt: "2026-05-12T00:00:00.000Z",
+    }))
+
+    const response = await handleAccountProfileRequest(
+      new Request("https://example.com/api/auth/me", {
+        method: "PATCH",
+        body: JSON.stringify({ firstName: null }),
+      }),
+      auth,
+      {
+        basePath: "/api/auth",
+        db: {} as never,
+        updateProfile,
+      },
+    )
+
+    expect(response?.status).toBe(200)
+    expect(updateProfile).toHaveBeenCalled()
+  })
+
+  it("normalizes missing sessions to 401 responses", async () => {
+    const auth = createAuthMock()
+    vi.mocked(auth.api.getSession).mockResolvedValue(null)
+
+    const response = await handleAccountProfileRequest(
+      new Request("https://example.com/auth/me", {
+        method: "PATCH",
+        body: JSON.stringify({ firstName: "Ana" }),
+      }),
+      auth,
+      {
+        db: {} as never,
+        updateProfile: vi.fn(),
+      },
+    )
+
+    expect(response?.status).toBe(401)
+    expect(await responseJson(response)).toEqual({ error: "Unauthorized" })
+  })
+
+  it("rejects unsupported methods and invalid profile fields", async () => {
+    const auth = createAuthMock()
+    const updateProfile = vi.fn()
+
+    const methodResponse = await handleAccountProfileRequest(
+      new Request("https://example.com/auth/me", { method: "POST" }),
+      auth,
+      {
+        db: {} as never,
+        updateProfile,
+      },
+    )
+
+    expect(methodResponse?.status).toBe(405)
+    expect(methodResponse?.headers.get("Allow")).toBe("PATCH")
+
+    const invalidResponse = await handleAccountProfileRequest(
+      new Request("https://example.com/auth/me", {
+        method: "PATCH",
+        body: JSON.stringify({ locale: "x".repeat(11) }),
+      }),
+      auth,
+      {
+        db: {} as never,
+        updateProfile,
+      },
+    )
+
+    expect(invalidResponse?.status).toBe(400)
+    expect(await responseJson(invalidResponse)).toEqual({
+      error: "locale must be 10 characters or fewer",
+    })
+    expect(updateProfile).not.toHaveBeenCalled()
+  })
+})

--- a/packages/auth/tests/unit/account-profile.test.ts
+++ b/packages/auth/tests/unit/account-profile.test.ts
@@ -141,11 +141,11 @@ describe("handleAccountProfileRequest", () => {
     expect(await responseJson(response)).toEqual({ error: "Unauthorized" })
   })
 
-  it("rejects unsupported methods and invalid profile fields", async () => {
+  it("lets non-PATCH profile facade requests fall through", async () => {
     const auth = createAuthMock()
     const updateProfile = vi.fn()
 
-    const methodResponse = await handleAccountProfileRequest(
+    const response = await handleAccountProfileRequest(
       new Request("https://example.com/auth/me", { method: "POST" }),
       auth,
       {
@@ -154,8 +154,14 @@ describe("handleAccountProfileRequest", () => {
       },
     )
 
-    expect(methodResponse?.status).toBe(405)
-    expect(methodResponse?.headers.get("Allow")).toBe("PATCH")
+    expect(response).toBeNull()
+    expect(auth.api.getSession).not.toHaveBeenCalled()
+    expect(updateProfile).not.toHaveBeenCalled()
+  })
+
+  it("rejects invalid profile fields", async () => {
+    const auth = createAuthMock()
+    const updateProfile = vi.fn()
 
     const invalidResponse = await handleAccountProfileRequest(
       new Request("https://example.com/auth/me", {

--- a/packages/auth/tests/unit/workspace.test.ts
+++ b/packages/auth/tests/unit/workspace.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { updateCurrentUserProfile } from "../../src/workspace.js"
+
+describe("updateCurrentUserProfile", () => {
+  it("maps explicit locale resets to the default locale", async () => {
+    const onConflictDoUpdate = vi.fn(async () => undefined)
+    const values = vi.fn(() => ({ onConflictDoUpdate }))
+    const limit = vi.fn(async () => [
+      {
+        id: "user_123",
+        email: "ana@example.com",
+        phoneNumber: null,
+        firstName: null,
+        lastName: null,
+        locale: "en",
+        timezone: null,
+        avatarUrl: null,
+        isSuperAdmin: false,
+        isSupportUser: false,
+        createdAt: new Date("2026-05-12T00:00:00.000Z"),
+      },
+    ])
+    const db = {
+      insert: vi.fn(() => ({ values })),
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          leftJoin: vi.fn(() => ({
+            where: vi.fn(() => ({ limit })),
+          })),
+        })),
+      })),
+    }
+
+    const profile = await updateCurrentUserProfile(db as never, {
+      userId: "user_123",
+      locale: null,
+    })
+
+    expect(values).toHaveBeenCalledWith(expect.objectContaining({ id: "user_123", locale: "en" }))
+    expect(onConflictDoUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        set: expect.objectContaining({ locale: "en" }),
+      }),
+    )
+    expect(profile?.locale).toBe("en")
+  })
+})


### PR DESCRIPTION
## Summary

Advances #786 and #655.

- Adds a shared account profile update contract in `@voyantjs/auth`, including `updateCurrentUserProfile(...)` and a mountable `PATCH /auth/me` facade.
- Adds `updateAccountProfile(...)` and `useUpdateAccountProfile()` in `@voyantjs/auth-react`.
- Adds a card-less, router-agnostic `OnboardingPage` in `@voyantjs/auth-ui` with profile fields, locale/timezone support, completion callback, message overrides, and app-owned slots.
- Updates README docs, exports, tests, and changesets for touched packages.

## Validation

- `pnpm --filter @voyantjs/auth test`
- `pnpm --filter @voyantjs/auth-react test`
- `pnpm --filter @voyantjs/auth-ui test`
- `pnpm --filter @voyantjs/auth typecheck`
- `pnpm --filter @voyantjs/auth-react typecheck`
- `pnpm --filter @voyantjs/auth-ui typecheck`
- `pnpm --filter @voyantjs/auth build`
- `pnpm --filter @voyantjs/auth-react build`
- `pnpm --filter @voyantjs/auth-ui build`
- `pnpm lint:changed`
- pre-commit hook: changed lint + full repo typecheck completed
- pre-push hook: repo test lane completed

## Notes

No template/app routes were modified. Apps that want the shared onboarding page to submit directly should mount `handleAccountProfileRequest(...)` before falling through to Better Auth.
