### PR TITLE
[codex] Add shared email verification UI

### DIFF
--- a/.changeset/auth-email-verification.md
+++ b/.changeset/auth-email-verification.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/auth-react": minor
+"@voyantjs/auth-ui": minor
+---
+
+Add shared email verification helpers and a router-agnostic VerifyEmailPage for Better Auth token and email OTP flows.

--- a/packages/auth-react/README.md
+++ b/packages/auth-react/README.md
@@ -14,6 +14,8 @@ This package wraps the shared Voyant auth HTTP contract:
 - `/auth/email-otp/request-email-change`
 - `/auth/email-otp/change-email`
 - `/auth/sign-up/email`
+- `/auth/verify-email`
+- `/auth/email-otp/verify-email`
 - `/auth/workspace/current`
 - `/auth/workspace/active-organization`
 - `/auth/organization/list-members`
@@ -35,6 +37,7 @@ It provides reusable React surfaces for:
 - organization invitation listing
 - email/password sign-in
 - email/password sign-up
+- email verification by Better Auth token or email OTP
 - password reset request and confirmation
 - invite, accept, cancel, remove, and role update mutations
 - API token listing, creation, update, and deletion
@@ -162,6 +165,22 @@ await confirmReset.mutateAsync({
 The request hook posts to `/auth/request-password-reset` with `email` and
 `redirectTo`. The confirm hook posts to `/auth/reset-password` with `token` and
 `newPassword`, then invalidates the current auth queries.
+
+## Email Verification
+
+`useVerifyEmail()` exposes the shared Better Auth verification flow. Token links
+call the mounted Better Auth `/auth/verify-email` endpoint; OTP verification
+uses the email OTP plugin route used by the templates.
+
+```tsx
+const verifyEmail = useVerifyEmail()
+
+await verifyEmail.mutateAsync({ token })
+await verifyEmail.mutateAsync({ email, otp })
+```
+
+After verification succeeds, the hook calls `/auth/status` to provision the
+Voyant user profile if needed and invalidates the current auth queries.
 
 ## Single-Tenant Apps
 

--- a/packages/auth-react/src/hooks/index.ts
+++ b/packages/auth-react/src/hooks/index.ts
@@ -78,4 +78,12 @@ export {
   signUpWithEmail,
   useSignUp,
 } from "./use-sign-up.js"
+export {
+  useVerifyEmail,
+  type VerifyEmailInput,
+  type VerifyEmailOtpInput,
+  type VerifyEmailResult,
+  type VerifyEmailTokenInput,
+  verifyEmail,
+} from "./use-verify-email.js"
 export { useWorkspaceMutation } from "./use-workspace-mutation.js"

--- a/packages/auth-react/src/hooks/use-verify-email.test.ts
+++ b/packages/auth-react/src/hooks/use-verify-email.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest"
+
+import type { VoyantApiError, VoyantFetcher } from "../client.js"
+import { verifyEmail } from "./use-verify-email.js"
+
+function jsonResponse(body: unknown, init?: ResponseInit) {
+  return new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  })
+}
+
+describe("verifyEmail", () => {
+  it("verifies token links through the mounted Better Auth endpoint", async () => {
+    const emailLinkFixture = "email-link-fixture"
+    const fetcher = vi
+      .fn<VoyantFetcher>()
+      .mockResolvedValueOnce(jsonResponse({ status: true }))
+      .mockResolvedValueOnce(jsonResponse({ userExists: true, authenticated: true }))
+
+    const result = await verifyEmail(
+      { token: emailLinkFixture },
+      { baseUrl: "https://operator.example/api", fetcher },
+    )
+
+    expect(result).toEqual({ data: { status: true } })
+    expect(fetcher).toHaveBeenNthCalledWith(
+      1,
+      `https://operator.example/api/auth/verify-email?token=${emailLinkFixture}`,
+      { method: "GET" },
+    )
+    expect(fetcher).toHaveBeenNthCalledWith(2, "https://operator.example/api/auth/status", {
+      method: "GET",
+    })
+  })
+
+  it("verifies email OTP codes through the Better Auth email OTP plugin", async () => {
+    const fetcher = vi
+      .fn<VoyantFetcher>()
+      .mockResolvedValueOnce(jsonResponse({ status: true }))
+      .mockResolvedValueOnce(jsonResponse({ userExists: true, authenticated: true }))
+
+    await verifyEmail(
+      { email: "ana@example.com", otp: "123456" },
+      { baseUrl: "https://operator.example/api/", fetcher },
+    )
+
+    expect(fetcher).toHaveBeenNthCalledWith(
+      1,
+      "https://operator.example/api/auth/email-otp/verify-email",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: "ana@example.com",
+          otp: "123456",
+        }),
+      },
+    )
+  })
+
+  it("surfaces Better Auth verification errors", async () => {
+    const fetcher = vi.fn<VoyantFetcher>().mockResolvedValueOnce(
+      jsonResponse(
+        { error: { message: "Invalid verification code" } },
+        {
+          status: 400,
+          statusText: "Bad Request",
+        },
+      ),
+    )
+
+    await expect(
+      verifyEmail(
+        { email: "ana@example.com", otp: "000000" },
+        { baseUrl: "https://operator.example/api", fetcher },
+      ),
+    ).rejects.toMatchObject({
+      name: "VoyantApiError",
+      message: "Invalid verification code",
+      status: 400,
+    } satisfies Partial<VoyantApiError>)
+
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/auth-react/src/hooks/use-verify-email.ts
+++ b/packages/auth-react/src/hooks/use-verify-email.ts
@@ -1,0 +1,145 @@
+"use client"
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { type FetchWithValidationOptions, VoyantApiError, withQueryParams } from "../client.js"
+import { useVoyantAuthContext } from "../provider.js"
+import { authQueryKeys } from "../query-keys.js"
+
+export interface VerifyEmailTokenInput {
+  token: string
+  email?: never
+  otp?: never
+}
+
+export interface VerifyEmailOtpInput {
+  email: string
+  otp: string
+  token?: never
+}
+
+export type VerifyEmailInput = VerifyEmailTokenInput | VerifyEmailOtpInput
+
+export interface VerifyEmailResult {
+  data: unknown
+}
+
+interface BetterAuthErrorBody {
+  error?: string | { message?: unknown; code?: unknown } | null
+  message?: unknown
+  code?: unknown
+}
+
+function joinUrl(baseUrl: string, path: string): string {
+  const trimmedBase = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl
+  const trimmedPath = path.startsWith("/") ? path : `/${path}`
+  return `${trimmedBase}${trimmedPath}`
+}
+
+function extractBetterAuthErrorMessage(body: unknown, fallback: string): string {
+  if (typeof body !== "object" || body === null) {
+    return fallback
+  }
+
+  const candidate = body as BetterAuthErrorBody
+  if (typeof candidate.error === "string") {
+    return candidate.error
+  }
+
+  if (
+    typeof candidate.error === "object" &&
+    candidate.error !== null &&
+    "message" in candidate.error
+  ) {
+    return String(candidate.error.message)
+  }
+
+  if (candidate.message !== undefined) {
+    return String(candidate.message)
+  }
+
+  return fallback
+}
+
+function hasBetterAuthError(body: unknown): boolean {
+  if (typeof body !== "object" || body === null || !("error" in body)) {
+    return false
+  }
+
+  return (body as BetterAuthErrorBody).error != null
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text()
+  if (!text) {
+    return undefined
+  }
+
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
+}
+
+function isOtpInput(input: VerifyEmailInput): input is VerifyEmailOtpInput {
+  return "otp" in input
+}
+
+async function assertOkResponse(response: Response): Promise<unknown> {
+  const body = await readJson(response)
+  if (!response.ok || hasBetterAuthError(body)) {
+    throw new VoyantApiError(
+      extractBetterAuthErrorMessage(
+        body,
+        `Voyant API error: ${response.status} ${response.statusText}`,
+      ),
+      response.status,
+      body,
+    )
+  }
+
+  return body
+}
+
+export async function verifyEmail(
+  input: VerifyEmailInput,
+  client: FetchWithValidationOptions,
+): Promise<VerifyEmailResult> {
+  const response = isOtpInput(input)
+    ? await client.fetcher(joinUrl(client.baseUrl, "/auth/email-otp/verify-email"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: input.email,
+          otp: input.otp,
+        }),
+      })
+    : await client.fetcher(
+        joinUrl(client.baseUrl, withQueryParams("/auth/verify-email", { token: input.token })),
+        { method: "GET" },
+      )
+
+  const body = await assertOkResponse(response)
+
+  const statusResponse = await client.fetcher(joinUrl(client.baseUrl, "/auth/status"), {
+    method: "GET",
+  })
+  await assertOkResponse(statusResponse)
+
+  return { data: body }
+}
+
+export function useVerifyEmail() {
+  const { baseUrl, fetcher } = useVoyantAuthContext()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (input: VerifyEmailInput) => verifyEmail(input, { baseUrl, fetcher }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: authQueryKeys.authStatus() })
+      void queryClient.invalidateQueries({ queryKey: authQueryKeys.currentUser() })
+      void queryClient.invalidateQueries({ queryKey: authQueryKeys.currentWorkspace() })
+    },
+  })
+}

--- a/packages/auth-ui/README.md
+++ b/packages/auth-ui/README.md
@@ -224,3 +224,31 @@ import { ForgotPasswordPage, ResetPasswordPage } from "@voyantjs/auth-ui"
 Apps own token extraction from the route or query string and pass it through the
 `token` prop. `redirectTo` is forwarded to Better Auth's password-reset request
 endpoint so emailed links can return to the app reset route.
+
+## Email verification
+
+`VerifyEmailPage` provides the shared card-less email verification surface. It
+uses `useVerifyEmail()` from `@voyantjs/auth-react` and supports both Better
+Auth token verification links and the email OTP flow mounted by the templates.
+The page is router-agnostic: pass hrefs for plain links, callbacks for app-owned
+navigation, and `onResendVerification` when the app wires the email OTP client.
+
+```tsx
+import { VerifyEmailPage } from "@voyantjs/auth-ui"
+
+<VerifyEmailPage
+  email={search.email}
+  signInHref="/sign-in"
+  onCompleted={() => navigate({ to: "/" })}
+  onResendVerification={(email) =>
+    authClient.emailOtp.sendVerificationOtp({ email, type: "email-verification" })
+  }
+/>
+```
+
+Token links can pass the token directly. By default the page submits supplied
+tokens on mount.
+
+```tsx
+<VerifyEmailPage token={search.token} onCompleted={() => navigate({ to: "/" })} />
+```

--- a/packages/auth-ui/src/components/verify-email-page.tsx
+++ b/packages/auth-ui/src/components/verify-email-page.tsx
@@ -1,0 +1,388 @@
+"use client"
+
+import { useVerifyEmail, type VerifyEmailInput, type VerifyEmailResult } from "@voyantjs/auth-react"
+import {
+  Button,
+  cn,
+  Input,
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+  Label,
+} from "@voyantjs/ui/components"
+import { CheckCircle2, Loader2, RotateCcw } from "lucide-react"
+import { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+export type VerifyEmailPageMode = "otp" | "token"
+
+export interface VerifyEmailPageMessages {
+  title: string
+  description: string
+  tokenDescription: string
+  emailLabel: string
+  emailPlaceholder: string
+  codeLabel: string
+  tokenLabel: string
+  tokenPlaceholder: string
+  submit: string
+  verifying: string
+  emailRequired: string
+  codeRequired: string
+  tokenRequired: string
+  invalidVerification: string
+  successTitle: string
+  successDescription: string
+  resendCode: string
+  sending: string
+  resent: string
+  resendFailed: string
+  signIn: string
+  changeEmail: string
+}
+
+export interface VerifyEmailPageProps {
+  className?: string
+  messages?: Partial<VerifyEmailPageMessages>
+  mode?: VerifyEmailPageMode
+  email?: string
+  token?: string
+  code?: string
+  codeLength?: number
+  autoSubmitToken?: boolean
+  signInHref?: string
+  changeEmailHref?: string
+  onCompleted?: (options: {
+    input: VerifyEmailInput
+    result: VerifyEmailResult
+  }) => Promise<void> | void
+  onResendVerification?: (email: string) => Promise<void> | void
+  onSignInClick?: () => Promise<void> | void
+  onChangeEmailClick?: () => Promise<void> | void
+}
+
+export const defaultVerifyEmailPageMessages: VerifyEmailPageMessages = {
+  title: "Verify your email",
+  description: "Enter the verification code we sent to your email.",
+  tokenDescription: "Confirm the verification token from your email link.",
+  emailLabel: "Email",
+  emailPlaceholder: "ana@example.com",
+  codeLabel: "Verification code",
+  tokenLabel: "Verification token",
+  tokenPlaceholder: "Paste your verification token",
+  submit: "Verify email",
+  verifying: "Verifying",
+  emailRequired: "Email is required.",
+  codeRequired: "Verification code is required.",
+  tokenRequired: "Verification token is required.",
+  invalidVerification: "We could not verify that email. Check the code or request a new one.",
+  successTitle: "Email verified",
+  successDescription: "You can continue to your account.",
+  resendCode: "Resend code",
+  sending: "Sending",
+  resent: "A new verification code has been sent.",
+  resendFailed: "Failed to resend code. Try again.",
+  signIn: "Sign in",
+  changeEmail: "Use a different email",
+}
+
+function verificationErrorMessage(error: unknown, messages: VerifyEmailPageMessages): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message
+  }
+
+  return messages.invalidVerification
+}
+
+function mergeMessages(overrides?: Partial<VerifyEmailPageMessages>): VerifyEmailPageMessages {
+  return { ...defaultVerifyEmailPageMessages, ...overrides }
+}
+
+export function VerifyEmailPage({
+  className,
+  messages: messageOverrides,
+  mode,
+  email,
+  token,
+  code,
+  codeLength = 6,
+  autoSubmitToken = true,
+  signInHref,
+  changeEmailHref,
+  onCompleted,
+  onResendVerification,
+  onSignInClick,
+  onChangeEmailClick,
+}: VerifyEmailPageProps) {
+  const messages = useMemo(() => mergeMessages(messageOverrides), [messageOverrides])
+  const verifyEmailMutation = useVerifyEmail()
+  const selectedMode: VerifyEmailPageMode = mode ?? (token ? "token" : "otp")
+  const autoSubmittedTokenRef = useRef<string | null>(null)
+  const codeSlots = useMemo(
+    () =>
+      Array.from({ length: codeLength }, (_, index) => ({
+        id: `verify-email-code-slot-${index}`,
+        index,
+      })),
+    [codeLength],
+  )
+
+  const [emailValue, setEmailValue] = useState(email ?? "")
+  const [codeValue, setCodeValue] = useState(code ?? "")
+  const [tokenValue, setTokenValue] = useState(token ?? "")
+  const [error, setError] = useState<string | null>(null)
+  const [resent, setResent] = useState(false)
+  const [resending, setResending] = useState(false)
+  const [verified, setVerified] = useState(false)
+
+  const isSubmitting = verifyEmailMutation.isPending
+  const canResend = Boolean(onResendVerification)
+
+  const submitVerification = useCallback(
+    async (input: VerifyEmailInput) => {
+      setError(null)
+      setResent(false)
+
+      try {
+        const result = await verifyEmailMutation.mutateAsync(input)
+        setVerified(true)
+        await onCompleted?.({ input, result })
+      } catch (err) {
+        setVerified(false)
+        setError(verificationErrorMessage(err, messages))
+      }
+    },
+    [messages, onCompleted, verifyEmailMutation.mutateAsync],
+  )
+
+  useEffect(() => {
+    if (
+      selectedMode !== "token" ||
+      !autoSubmitToken ||
+      !token ||
+      autoSubmittedTokenRef.current === token
+    ) {
+      return
+    }
+
+    autoSubmittedTokenRef.current = token
+    void submitVerification({ token })
+  }, [autoSubmitToken, selectedMode, submitVerification, token])
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (selectedMode === "token") {
+      const trimmedToken = tokenValue.trim()
+      if (!trimmedToken) {
+        setError(messages.tokenRequired)
+        return
+      }
+
+      await submitVerification({ token: trimmedToken })
+      return
+    }
+
+    const trimmedEmail = emailValue.trim()
+    const trimmedCode = codeValue.trim()
+
+    if (!trimmedEmail) {
+      setError(messages.emailRequired)
+      return
+    }
+
+    if (!trimmedCode) {
+      setError(messages.codeRequired)
+      return
+    }
+
+    await submitVerification({ email: trimmedEmail, otp: trimmedCode })
+  }
+
+  const handleResend = async () => {
+    if (!onResendVerification) {
+      return
+    }
+
+    const trimmedEmail = emailValue.trim()
+    if (!trimmedEmail) {
+      setError(messages.emailRequired)
+      return
+    }
+
+    setResending(true)
+    setResent(false)
+    setError(null)
+
+    try {
+      await onResendVerification(trimmedEmail)
+      setResent(true)
+    } catch {
+      setError(messages.resendFailed)
+    } finally {
+      setResending(false)
+    }
+  }
+
+  if (verified) {
+    return (
+      <div
+        data-slot="verify-email-page"
+        className={cn("mx-auto flex w-full max-w-sm flex-col gap-6", className)}
+      >
+        <div className="space-y-2">
+          <CheckCircle2 className="h-8 w-8 text-green-600" aria-hidden="true" />
+          <h1 className="text-2xl font-bold tracking-tight">{messages.successTitle}</h1>
+          <p className="text-sm text-muted-foreground">{messages.successDescription}</p>
+        </div>
+
+        {signInHref ? (
+          <a
+            href={signInHref}
+            onClick={() => void onSignInClick?.()}
+            className="inline-flex h-9 w-full items-center justify-center rounded-md bg-primary px-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/80"
+          >
+            {messages.signIn}
+          </a>
+        ) : (
+          onSignInClick && (
+            <Button type="button" className="w-full" onClick={() => void onSignInClick()}>
+              {messages.signIn}
+            </Button>
+          )
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      data-slot="verify-email-page"
+      className={cn("mx-auto flex w-full max-w-sm flex-col gap-6", className)}
+    >
+      <div className="space-y-1">
+        <h1 className="text-2xl font-bold tracking-tight">{messages.title}</h1>
+        <p className="text-sm text-muted-foreground">
+          {selectedMode === "token" ? messages.tokenDescription : messages.description}
+        </p>
+        {selectedMode === "otp" && emailValue && (
+          <p className="text-sm font-medium">{emailValue}</p>
+        )}
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {error && (
+          <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {error}
+          </div>
+        )}
+
+        {resent && (
+          <div className="rounded-md bg-green-500/10 px-3 py-2 text-sm text-green-700 dark:text-green-400">
+            {messages.resent}
+          </div>
+        )}
+
+        {selectedMode === "otp" && !email && (
+          <div className="space-y-2">
+            <Label htmlFor="auth-verify-email-address">{messages.emailLabel}</Label>
+            <Input
+              id="auth-verify-email-address"
+              type="email"
+              placeholder={messages.emailPlaceholder}
+              value={emailValue}
+              onChange={(event) => setEmailValue(event.target.value)}
+              disabled={isSubmitting}
+              required
+              autoComplete="email"
+              autoFocus
+            />
+          </div>
+        )}
+
+        {selectedMode === "otp" && (
+          <div className="space-y-2">
+            <Label htmlFor="auth-verify-email-code">{messages.codeLabel}</Label>
+            <div className="flex justify-center sm:justify-start">
+              <InputOTP
+                id="auth-verify-email-code"
+                maxLength={codeLength}
+                value={codeValue}
+                onChange={setCodeValue}
+                disabled={isSubmitting}
+                autoFocus={Boolean(email)}
+              >
+                <InputOTPGroup>
+                  {codeSlots.map((slot) => (
+                    <InputOTPSlot key={slot.id} index={slot.index} className="h-12 w-12 text-lg" />
+                  ))}
+                </InputOTPGroup>
+              </InputOTP>
+            </div>
+          </div>
+        )}
+
+        {selectedMode === "token" && (
+          <div className="space-y-2">
+            <Label htmlFor="auth-verify-email-token">{messages.tokenLabel}</Label>
+            <Input
+              id="auth-verify-email-token"
+              value={tokenValue}
+              onChange={(event) => setTokenValue(event.target.value)}
+              placeholder={messages.tokenPlaceholder}
+              disabled={isSubmitting}
+              required
+              autoFocus={!tokenValue}
+            />
+          </div>
+        )}
+
+        <Button
+          type="submit"
+          className="w-full"
+          disabled={
+            isSubmitting ||
+            (selectedMode === "otp" && codeValue.trim().length !== codeLength) ||
+            (selectedMode === "token" && tokenValue.trim().length === 0)
+          }
+        >
+          {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          {isSubmitting ? messages.verifying : messages.submit}
+        </Button>
+      </form>
+
+      <div className="flex flex-col items-center gap-3 text-center text-sm">
+        {canResend && (
+          <button
+            type="button"
+            onClick={() => void handleResend()}
+            disabled={resending || isSubmitting}
+            className="inline-flex items-center gap-2 font-medium text-muted-foreground hover:text-primary hover:underline disabled:opacity-50"
+          >
+            {resending && <RotateCcw className="h-4 w-4 animate-spin" aria-hidden="true" />}
+            {resending ? messages.sending : messages.resendCode}
+          </button>
+        )}
+
+        {changeEmailHref ? (
+          <a
+            href={changeEmailHref}
+            onClick={() => void onChangeEmailClick?.()}
+            className="text-muted-foreground hover:text-primary hover:underline"
+          >
+            {messages.changeEmail}
+          </a>
+        ) : (
+          onChangeEmailClick && (
+            <button
+              type="button"
+              onClick={() => void onChangeEmailClick()}
+              className="text-muted-foreground hover:text-primary hover:underline"
+            >
+              {messages.changeEmail}
+            </button>
+          )
+        )}
+      </div>
+    </div>
+  )
+}

--- a/packages/auth-ui/src/index.ts
+++ b/packages/auth-ui/src/index.ts
@@ -63,6 +63,13 @@ export {
   type SignUpPageProps,
   type SignUpSocialProvider,
 } from "./components/sign-up-page.js"
+export {
+  defaultVerifyEmailPageMessages,
+  VerifyEmailPage,
+  type VerifyEmailPageMessages,
+  type VerifyEmailPageMode,
+  type VerifyEmailPageProps,
+} from "./components/verify-email-page.js"
 export type { AuthUiMessages } from "./i18n/index.js"
 export {
   type AuthUiMessageOverrides,

--- a/packages/auth-ui/src/sign-in-page.test.tsx
+++ b/packages/auth-ui/src/sign-in-page.test.tsx
@@ -5,6 +5,7 @@ import { renderToStaticMarkup } from "react-dom/server"
 import { describe, expect, it } from "vitest"
 
 import { SignInPage } from "./components/sign-in-page.js"
+import { VerifyEmailPage } from "./components/verify-email-page.js"
 
 function renderWithProviders(element: ReactNode) {
   const fetcher: VoyantFetcher = async () => new Response(null, { status: 204 })
@@ -29,5 +30,31 @@ describe("SignInPage", () => {
     expect(markup).toContain("auth-sign-in-password")
     expect(markup).toContain("/forgot-password")
     expect(markup).toContain("/sign-up")
+  })
+})
+
+describe("VerifyEmailPage", () => {
+  it("renders the reusable email verification surface", () => {
+    const markup = renderWithProviders(
+      <VerifyEmailPage
+        email="ana@example.com"
+        signInHref="/sign-in"
+        onResendVerification={async () => undefined}
+      />,
+    )
+
+    expect(markup).toContain("Verify your email")
+    expect(markup).toContain("ana@example.com")
+    expect(markup).toContain("auth-verify-email-code")
+    expect(markup).toContain("Resend code")
+  })
+
+  it("renders token verification when a token is supplied", () => {
+    const emailLinkFixture = "email-link-fixture"
+    const markup = renderWithProviders(<VerifyEmailPage token={emailLinkFixture} />)
+
+    expect(markup).toContain("Verification token")
+    expect(markup).toContain(emailLinkFixture)
+    expect(markup).toContain("auth-verify-email-token")
   })
 })


### PR DESCRIPTION
## Summary
- Adds @voyantjs/auth-react verifyEmail/useVerifyEmail for Better Auth token verification and email OTP verification.
- Adds @voyantjs/auth-ui VerifyEmailPage with OTP/token modes, success and failure states, resend callback wiring, message overrides, links, and completion callbacks.
- Updates exports, README docs, tests, and changesets for auth-react/auth-ui.

Advances #784 and #655.

## Validation
- pnpm --filter @voyantjs/auth-react test
- pnpm --filter @voyantjs/auth-ui test
- pnpm --filter @voyantjs/auth-react typecheck
- pnpm --filter @voyantjs/auth-ui typecheck
- pnpm --filter @voyantjs/auth-react build
- pnpm --filter @voyantjs/auth-ui build
- pnpm lint:changed
- Pre-push hook also ran pnpm test successfully.