### PR TITLE
[codex] add auth account self-service

### DIFF
--- a/.changeset/auth-account-self-service.md
+++ b/.changeset/auth-account-self-service.md
@@ -1,0 +1,7 @@
+---
+"@voyantjs/auth": minor
+"@voyantjs/auth-react": minor
+"@voyantjs/auth-ui": minor
+---
+
+Add shared account self-service profile helpers, account mutation hooks, and reusable account page/forms.

--- a/packages/auth-react/README.md
+++ b/packages/auth-react/README.md
@@ -8,6 +8,10 @@ This package wraps the shared Voyant auth HTTP contract:
 - `PATCH /auth/me`
 - `/auth/status`
 - `/auth/sign-in/email`
+- `PATCH /auth/me`
+- `/auth/change-password`
+- `/auth/email-otp/request-email-change`
+- `/auth/email-otp/change-email`
 - `/auth/workspace/current`
 - `/auth/workspace/active-organization`
 - `/auth/organization/list-members`
@@ -22,7 +26,7 @@ This package wraps the shared Voyant auth HTTP contract:
 It provides reusable React surfaces for:
 
 - current user state
-- account profile updates
+- account profile, password, and email-change mutations
 - optional workspace and organization state
 - organization member listing
 - organization invitation listing
@@ -48,11 +52,10 @@ After Better Auth accepts the credentials, the hook calls `/auth/status` to
 provision the Voyant user profile if needed and invalidates the current auth
 queries.
 
-## Profile Completion
+## Account self-service
 
-`updateAccountProfile()` and `useUpdateAccountProfile()` call `PATCH /auth/me`
-with the current user's profile fields and refresh the cached current user on
-success:
+`useUpdateAccountProfile()` updates Voyant profile fields through
+`PATCH /auth/me` and refreshes the current-user query:
 
 ```tsx
 const updateProfile = useUpdateAccountProfile()
@@ -62,11 +65,31 @@ await updateProfile.mutateAsync({
   lastName: "Pop",
   locale: "ro",
   timezone: "Europe/Bucharest",
+  profilePictureUrl: null,
 })
 ```
 
 Apps can mount `handleAccountProfileRequest(...)` from `@voyantjs/auth/server`
-to provide this route without depending on a specific template.
+to provide this route without depending on a specific template. The mounted
+route validates the session, calls `updateCurrentUserProfile(...)` from
+`@voyantjs/auth/workspace`, and returns the updated current-user shape.
+
+Password and email changes call the mounted Better Auth API:
+
+```tsx
+const changePassword = useChangeAccountPassword()
+await changePassword.mutateAsync({
+  currentPassword,
+  newPassword,
+  revokeOtherSessions: true,
+})
+
+const requestEmailChange = useRequestAccountEmailChange()
+await requestEmailChange.mutateAsync({ newEmail })
+
+const confirmEmailChange = useConfirmAccountEmailChange()
+await confirmEmailChange.mutateAsync({ newEmail, otp })
+```
 
 ## Single-Tenant Apps
 

--- a/packages/auth-react/src/hooks/index.ts
+++ b/packages/auth-react/src/hooks/index.ts
@@ -1,3 +1,18 @@
+export {
+  type ChangeAccountPasswordInput,
+  type ConfirmAccountEmailChangeInput,
+  changeAccountPassword,
+  confirmAccountEmailChange,
+  type RequestAccountEmailChangeInput,
+  requestAccountEmailChange,
+  type UpdateAccountProfileInput,
+  updateAccountProfile,
+  useAccountMutation,
+  useChangeAccountPassword,
+  useConfirmAccountEmailChange,
+  useRequestAccountEmailChange,
+  useUpdateAccountProfile,
+} from "./use-account-mutation.js"
 export { type UseAuthStatusOptions, useAuthStatus } from "./use-auth-status.js"
 export { type UseCurrentUserOptions, useCurrentUser } from "./use-current-user.js"
 export { type UseCurrentWorkspaceOptions, useCurrentWorkspace } from "./use-current-workspace.js"
@@ -41,10 +56,4 @@ export {
   signInWithEmail,
   useSignIn,
 } from "./use-sign-in.js"
-export {
-  type UpdateAccountProfileInput,
-  type UpdateAccountProfileResult,
-  updateAccountProfile,
-  useUpdateAccountProfile,
-} from "./use-update-account-profile.js"
 export { useWorkspaceMutation } from "./use-workspace-mutation.js"

--- a/packages/auth-react/src/hooks/use-account-mutation.test.ts
+++ b/packages/auth-react/src/hooks/use-account-mutation.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest"
+
+import type { VoyantFetcher } from "../client.js"
+import {
+  changeAccountPassword,
+  confirmAccountEmailChange,
+  requestAccountEmailChange,
+  updateAccountProfile,
+} from "./use-account-mutation.js"
+
+function jsonResponse(body: unknown, init?: ResponseInit) {
+  return new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  })
+}
+
+describe("account mutation request helpers", () => {
+  it("patches the Voyant profile endpoint", async () => {
+    const fetcher = vi.fn<VoyantFetcher>().mockResolvedValueOnce(
+      jsonResponse({
+        id: "user_1",
+        email: "ana@example.com",
+        firstName: "Ana",
+        lastName: "Pop",
+        isSuperAdmin: false,
+        isSupportUser: false,
+        createdAt: "2026-05-12T00:00:00.000Z",
+        profilePictureUrl: null,
+      }),
+    )
+
+    await updateAccountProfile(
+      { firstName: "Ana", lastName: "Pop", profilePictureUrl: null },
+      { baseUrl: "https://operator.example/api", fetcher },
+    )
+
+    expect(fetcher).toHaveBeenCalledWith("https://operator.example/api/auth/me", {
+      method: "PATCH",
+      headers: expect.any(Headers),
+      body: JSON.stringify({
+        firstName: "Ana",
+        lastName: "Pop",
+        profilePictureUrl: null,
+      }),
+    })
+  })
+
+  it("posts password changes to the mounted Better Auth endpoint", async () => {
+    const fetcher = vi.fn<VoyantFetcher>().mockResolvedValueOnce(jsonResponse({ success: true }))
+
+    await changeAccountPassword(
+      {
+        currentPassword: "old-password",
+        newPassword: "new-password",
+        revokeOtherSessions: true,
+      },
+      { baseUrl: "https://operator.example/api/", fetcher },
+    )
+
+    expect(fetcher).toHaveBeenCalledWith("https://operator.example/api/auth/change-password", {
+      method: "POST",
+      headers: expect.any(Headers),
+      body: JSON.stringify({
+        currentPassword: "old-password",
+        newPassword: "new-password",
+        revokeOtherSessions: true,
+      }),
+    })
+  })
+
+  it("posts email-change requests to the Email OTP endpoint", async () => {
+    const fetcher = vi.fn<VoyantFetcher>().mockResolvedValueOnce(jsonResponse({ success: true }))
+
+    await requestAccountEmailChange(
+      { newEmail: "new@example.com" },
+      { baseUrl: "https://operator.example/api", fetcher },
+    )
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://operator.example/api/auth/email-otp/request-email-change",
+      {
+        method: "POST",
+        headers: expect.any(Headers),
+        body: JSON.stringify({ newEmail: "new@example.com" }),
+      },
+    )
+  })
+
+  it("posts email-change confirmations to the Email OTP endpoint", async () => {
+    const fetcher = vi.fn<VoyantFetcher>().mockResolvedValueOnce(jsonResponse({ success: true }))
+
+    await confirmAccountEmailChange(
+      { newEmail: "new@example.com", otp: "123456" },
+      { baseUrl: "https://operator.example/api", fetcher },
+    )
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://operator.example/api/auth/email-otp/change-email",
+      {
+        method: "POST",
+        headers: expect.any(Headers),
+        body: JSON.stringify({ newEmail: "new@example.com", otp: "123456" }),
+      },
+    )
+  })
+})

--- a/packages/auth-react/src/hooks/use-account-mutation.ts
+++ b/packages/auth-react/src/hooks/use-account-mutation.ts
@@ -1,0 +1,122 @@
+"use client"
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { z } from "zod"
+
+import { type FetchWithValidationOptions, fetchWithValidation } from "../client.js"
+import { useVoyantAuthContext } from "../provider.js"
+import { authQueryKeys } from "../query-keys.js"
+import { useUpdateAccountProfile } from "./use-update-account-profile.js"
+
+export type {
+  UpdateAccountProfileInput,
+  UpdateAccountProfileResult,
+} from "./use-update-account-profile.js"
+export {
+  updateAccountProfile,
+  useUpdateAccountProfile,
+} from "./use-update-account-profile.js"
+
+const accountMutationResultSchema = z.unknown()
+
+export interface ChangeAccountPasswordInput {
+  currentPassword: string
+  newPassword: string
+  revokeOtherSessions?: boolean
+}
+
+export interface RequestAccountEmailChangeInput {
+  newEmail: string
+  otp?: string
+}
+
+export interface ConfirmAccountEmailChangeInput {
+  newEmail: string
+  otp: string
+}
+
+export async function changeAccountPassword(
+  input: ChangeAccountPasswordInput,
+  client: FetchWithValidationOptions,
+) {
+  return fetchWithValidation("/auth/change-password", accountMutationResultSchema, client, {
+    method: "POST",
+    body: JSON.stringify({
+      currentPassword: input.currentPassword,
+      newPassword: input.newPassword,
+      revokeOtherSessions: input.revokeOtherSessions,
+    }),
+  })
+}
+
+export async function requestAccountEmailChange(
+  input: RequestAccountEmailChangeInput,
+  client: FetchWithValidationOptions,
+) {
+  return fetchWithValidation(
+    "/auth/email-otp/request-email-change",
+    accountMutationResultSchema,
+    client,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        newEmail: input.newEmail,
+        otp: input.otp,
+      }),
+    },
+  )
+}
+
+export async function confirmAccountEmailChange(
+  input: ConfirmAccountEmailChangeInput,
+  client: FetchWithValidationOptions,
+) {
+  return fetchWithValidation("/auth/email-otp/change-email", accountMutationResultSchema, client, {
+    method: "POST",
+    body: JSON.stringify({
+      newEmail: input.newEmail,
+      otp: input.otp,
+    }),
+  })
+}
+
+export function useChangeAccountPassword() {
+  const { baseUrl, fetcher } = useVoyantAuthContext()
+
+  return useMutation({
+    mutationFn: (input: ChangeAccountPasswordInput) =>
+      changeAccountPassword(input, { baseUrl, fetcher }),
+  })
+}
+
+export function useRequestAccountEmailChange() {
+  const { baseUrl, fetcher } = useVoyantAuthContext()
+
+  return useMutation({
+    mutationFn: (input: RequestAccountEmailChangeInput) =>
+      requestAccountEmailChange(input, { baseUrl, fetcher }),
+  })
+}
+
+export function useConfirmAccountEmailChange() {
+  const { baseUrl, fetcher } = useVoyantAuthContext()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (input: ConfirmAccountEmailChangeInput) =>
+      confirmAccountEmailChange(input, { baseUrl, fetcher }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: authQueryKeys.currentUser() })
+      void queryClient.invalidateQueries({ queryKey: authQueryKeys.authStatus() })
+    },
+  })
+}
+
+export function useAccountMutation() {
+  return {
+    updateProfile: useUpdateAccountProfile(),
+    changePassword: useChangeAccountPassword(),
+    requestEmailChange: useRequestAccountEmailChange(),
+    confirmEmailChange: useConfirmAccountEmailChange(),
+  }
+}

--- a/packages/auth-react/src/hooks/use-update-account-profile.ts
+++ b/packages/auth-react/src/hooks/use-update-account-profile.ts
@@ -12,6 +12,7 @@ export interface UpdateAccountProfileInput {
   lastName?: string | null
   locale?: string | null
   timezone?: string | null
+  profilePictureUrl?: string | null
 }
 
 export type UpdateAccountProfileResult = CurrentUser
@@ -47,6 +48,7 @@ function profilePatchBody(input: UpdateAccountProfileInput) {
   if ("lastName" in input) body.lastName = input.lastName
   if ("locale" in input) body.locale = input.locale
   if ("timezone" in input) body.timezone = input.timezone
+  if ("profilePictureUrl" in input) body.profilePictureUrl = input.profilePictureUrl
 
   return body
 }

--- a/packages/auth-ui/README.md
+++ b/packages/auth-ui/README.md
@@ -30,7 +30,7 @@ accepts slot/render-prop panels for app-specific account sections such as API
 tokens, sessions, or MFA enrollment.
 
 ```tsx
-import { AccountPage } from "@voyantjs/auth-ui"
+import { AccountPage } from "@voyantjs/auth-ui/account"
 
 <AccountPage
   slots={{

--- a/packages/auth-ui/README.md
+++ b/packages/auth-ui/README.md
@@ -22,6 +22,37 @@ card-less, centered form surfaces intended to sit inside an app-owned auth
 layout. Pass `className` to extend or override spacing when a shell owns the
 page chrome.
 
+## Account self-service
+
+`AccountPage` renders the reusable operator account surface with profile,
+email-change, and password-change forms. It uses `OperatorAdminPageShell` and
+accepts slot/render-prop panels for app-specific account sections such as API
+tokens, sessions, or MFA enrollment.
+
+```tsx
+import { AccountPage } from "@voyantjs/auth-ui"
+
+<AccountPage
+  slots={{
+    apiTokensPanel: ({ user }) => <ApiTokensPanel userId={user?.id ?? null} />,
+  }}
+/>
+```
+
+The forms are also exported independently:
+
+```tsx
+import {
+  AccountChangeEmailForm,
+  AccountChangePasswordForm,
+  AccountProfileForm,
+} from "@voyantjs/auth-ui"
+```
+
+`AccountProfileForm` expects the app to support `PATCH /auth/me`.
+`AccountChangePasswordForm`, `AccountChangeEmailForm`, and `AccountPage` use the
+Better Auth password and Email OTP endpoints mounted under `/auth`.
+
 ## Sign-in
 
 `SignInPage` provides the shared email/password sign-in surface. It uses

--- a/packages/auth-ui/package.json
+++ b/packages/auth-ui/package.json
@@ -27,6 +27,7 @@
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.0.0",
+    "@voyantjs/admin": "workspace:*",
     "@voyantjs/auth-react": "workspace:*",
     "@voyantjs/i18n": "workspace:*",
     "@voyantjs/types": "workspace:*",
@@ -39,6 +40,7 @@
     "@tanstack/react-query": "^5.96.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@voyantjs/admin": "workspace:*",
     "@voyantjs/auth-react": "workspace:*",
     "@voyantjs/i18n": "workspace:*",
     "@voyantjs/types": "workspace:*",

--- a/packages/auth-ui/package.json
+++ b/packages/auth-ui/package.json
@@ -11,6 +11,7 @@
   "sideEffects": false,
   "exports": {
     ".": "./src/index.ts",
+    "./account": "./src/components/account-page.tsx",
     "./styles.css": "./src/styles.css",
     "./i18n": "./src/i18n/index.ts",
     "./i18n/en": "./src/i18n/en.ts",
@@ -35,6 +36,11 @@
     "lucide-react": "^0.475.0 || ^1.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@voyantjs/admin": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@tanstack/react-query": "^5.96.2",
@@ -63,6 +69,11 @@
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js",
         "default": "./dist/index.js"
+      },
+      "./account": {
+        "types": "./dist/components/account-page.d.ts",
+        "import": "./dist/components/account-page.js",
+        "default": "./dist/components/account-page.js"
       },
       "./styles.css": {
         "default": "./src/styles.css"

--- a/packages/auth-ui/src/account-page.test.tsx
+++ b/packages/auth-ui/src/account-page.test.tsx
@@ -16,6 +16,8 @@ const fixtureUser: CurrentUser = {
   email: "ana@example.com",
   firstName: "Ana",
   lastName: "Popescu",
+  locale: "ro",
+  timezone: "Europe/Bucharest",
   isSuperAdmin: false,
   isSupportUser: false,
   createdAt: "2026-05-12T00:00:00.000Z",

--- a/packages/auth-ui/src/account-page.test.tsx
+++ b/packages/auth-ui/src/account-page.test.tsx
@@ -1,0 +1,69 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { type CurrentUser, VoyantAuthProvider, type VoyantFetcher } from "@voyantjs/auth-react"
+import type { ReactNode } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+
+import {
+  AccountChangeEmailForm,
+  AccountChangePasswordForm,
+  AccountPage,
+  AccountProfileForm,
+} from "./components/account-page.js"
+
+const fixtureUser: CurrentUser = {
+  id: "user_1",
+  email: "ana@example.com",
+  firstName: "Ana",
+  lastName: "Popescu",
+  isSuperAdmin: false,
+  isSupportUser: false,
+  createdAt: "2026-05-12T00:00:00.000Z",
+  profilePictureUrl: null,
+}
+
+function renderWithProviders(element: ReactNode) {
+  const fetcher: VoyantFetcher = async () => new Response(null, { status: 204 })
+
+  return renderToStaticMarkup(
+    <QueryClientProvider client={new QueryClient()}>
+      <VoyantAuthProvider baseUrl="https://operator.example/api" fetcher={fetcher}>
+        {element}
+      </VoyantAuthProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe("AccountPage", () => {
+  it("renders the account self-service page and extension panels", () => {
+    const markup = renderWithProviders(
+      <AccountPage
+        currentUser={fixtureUser}
+        showSidebarTrigger={false}
+        slots={{
+          apiTokensPanel: <section>API tokens panel</section>,
+        }}
+      />,
+    )
+
+    expect(markup).toContain("Account")
+    expect(markup).toContain("account-profile-first-name")
+    expect(markup).toContain("account-new-email")
+    expect(markup).toContain("account-current-password")
+    expect(markup).toContain("API tokens panel")
+  })
+
+  it("renders standalone account forms", () => {
+    const markup = renderWithProviders(
+      <>
+        <AccountProfileForm currentUser={fixtureUser} />
+        <AccountChangeEmailForm currentEmail={fixtureUser.email} />
+        <AccountChangePasswordForm />
+      </>,
+    )
+
+    expect(markup).toContain("Save profile")
+    expect(markup).toContain("Send code")
+    expect(markup).toContain("Update password")
+  })
+})

--- a/packages/auth-ui/src/components/account-forms.tsx
+++ b/packages/auth-ui/src/components/account-forms.tsx
@@ -1,0 +1,478 @@
+"use client"
+
+import {
+  type ConfirmAccountEmailChangeInput,
+  type CurrentUser,
+  useChangeAccountPassword,
+  useConfirmAccountEmailChange,
+  useCurrentUser,
+  useRequestAccountEmailChange,
+  useUpdateAccountProfile,
+} from "@voyantjs/auth-react"
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Checkbox,
+  Input,
+  Label,
+} from "@voyantjs/ui/components"
+import { KeyRound, Loader2, Mail, Save, UserRound } from "lucide-react"
+import { type FormEvent, useEffect, useState } from "react"
+
+import {
+  type AccountChangeEmailFormMessages,
+  type AccountChangePasswordFormMessages,
+  type AccountProfileFormMessages,
+  defaultAccountPageMessages,
+  messageFromError,
+} from "./account-page-shared.js"
+
+export interface AccountProfileFormProps {
+  className?: string
+  currentUser?: CurrentUser | null
+  messages?: Partial<AccountProfileFormMessages>
+  onUpdated?: (user: CurrentUser) => Promise<void> | void
+}
+
+export interface AccountChangeEmailFormProps {
+  className?: string
+  currentEmail?: string | null
+  messages?: Partial<AccountChangeEmailFormMessages>
+  onCodeSent?: (input: { newEmail: string }) => Promise<void> | void
+  onChanged?: (input: ConfirmAccountEmailChangeInput) => Promise<void> | void
+}
+
+export interface AccountChangePasswordFormProps {
+  className?: string
+  messages?: Partial<AccountChangePasswordFormMessages>
+  minPasswordLength?: number
+  revokeOtherSessionsDefault?: boolean
+  onChanged?: () => Promise<void> | void
+}
+
+export function AccountProfileForm({
+  className,
+  currentUser,
+  messages: messageOverrides,
+  onUpdated,
+}: AccountProfileFormProps) {
+  const messages = { ...defaultAccountPageMessages.profile, ...messageOverrides }
+  const userQuery = useCurrentUser({ enabled: currentUser === undefined })
+  const user = currentUser === undefined ? (userQuery.data ?? null) : currentUser
+  const mutation = useUpdateAccountProfile()
+
+  const [firstName, setFirstName] = useState("")
+  const [lastName, setLastName] = useState("")
+  const [profilePictureUrl, setProfilePictureUrl] = useState("")
+  const [status, setStatus] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!user) return
+    setFirstName(user.firstName ?? "")
+    setLastName(user.lastName ?? "")
+    setProfilePictureUrl(user.profilePictureUrl ?? "")
+  }, [user])
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+    setStatus(null)
+
+    try {
+      const updated = await mutation.mutateAsync({
+        firstName,
+        lastName,
+        profilePictureUrl: profilePictureUrl.trim() || null,
+      })
+      await onUpdated?.(updated)
+      setStatus(messages.success)
+    } catch (err) {
+      setError(messageFromError(err, messages.error))
+    }
+  }
+
+  return (
+    <Card data-slot="account-profile-form" className={className}>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <UserRound className="h-4 w-4" />
+          {messages.title}
+        </CardTitle>
+        <CardDescription>{messages.description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {userQuery.isError ? (
+          <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {messages.loadFailed}
+          </div>
+        ) : null}
+
+        {!user && !userQuery.isLoading ? (
+          <div className="rounded-md border px-3 py-2 text-sm text-muted-foreground">
+            {messages.noUser}
+          </div>
+        ) : null}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error ? (
+            <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </div>
+          ) : null}
+          {status ? (
+            <div className="rounded-md bg-primary/10 px-3 py-2 text-sm text-primary">{status}</div>
+          ) : null}
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="account-profile-first-name">{messages.firstNameLabel}</Label>
+              <Input
+                id="account-profile-first-name"
+                value={firstName}
+                onChange={(event) => setFirstName(event.target.value)}
+                placeholder={messages.firstNamePlaceholder}
+                autoComplete="given-name"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="account-profile-last-name">{messages.lastNameLabel}</Label>
+              <Input
+                id="account-profile-last-name"
+                value={lastName}
+                onChange={(event) => setLastName(event.target.value)}
+                placeholder={messages.lastNamePlaceholder}
+                autoComplete="family-name"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="account-profile-picture-url">{messages.profilePictureUrlLabel}</Label>
+            <Input
+              id="account-profile-picture-url"
+              value={profilePictureUrl}
+              onChange={(event) => setProfilePictureUrl(event.target.value)}
+              placeholder={messages.profilePictureUrlPlaceholder}
+              autoComplete="photo"
+            />
+          </div>
+
+          <Button type="submit" disabled={!user || mutation.isPending}>
+            {mutation.isPending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Save className="mr-2 h-4 w-4" />
+            )}
+            {mutation.isPending ? messages.saving : messages.submit}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}
+
+export function AccountChangeEmailForm({
+  className,
+  currentEmail,
+  messages: messageOverrides,
+  onCodeSent,
+  onChanged,
+}: AccountChangeEmailFormProps) {
+  const messages = { ...defaultAccountPageMessages.email, ...messageOverrides }
+  const requestEmailChange = useRequestAccountEmailChange()
+  const confirmEmailChange = useConfirmAccountEmailChange()
+  const [newEmail, setNewEmail] = useState("")
+  const [verificationCode, setVerificationCode] = useState("")
+  const [codeSentTo, setCodeSentTo] = useState<string | null>(null)
+  const [status, setStatus] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSendCode = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+    setStatus(null)
+
+    const trimmedEmail = newEmail.trim()
+    if (!trimmedEmail) {
+      setError(messages.emailRequired)
+      return
+    }
+
+    try {
+      await requestEmailChange.mutateAsync({ newEmail: trimmedEmail })
+      await onCodeSent?.({ newEmail: trimmedEmail })
+      setCodeSentTo(trimmedEmail)
+      setVerificationCode("")
+      setStatus(messages.codeSent)
+    } catch (err) {
+      setError(messageFromError(err, messages.error))
+    }
+  }
+
+  const handleConfirm = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+    setStatus(null)
+
+    const trimmedCode = verificationCode.trim()
+    if (!codeSentTo) {
+      setError(messages.emailRequired)
+      return
+    }
+
+    if (!trimmedCode) {
+      setError(messages.codeRequired)
+      return
+    }
+
+    try {
+      const input = { newEmail: codeSentTo, otp: trimmedCode }
+      await confirmEmailChange.mutateAsync(input)
+      await onChanged?.(input)
+      setNewEmail("")
+      setVerificationCode("")
+      setCodeSentTo(null)
+      setStatus(messages.success)
+    } catch (err) {
+      setError(messageFromError(err, messages.error))
+    }
+  }
+
+  return (
+    <Card data-slot="account-change-email-form" className={className}>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Mail className="h-4 w-4" />
+          {messages.title}
+        </CardTitle>
+        <CardDescription>{messages.description}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {error ? (
+          <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {error}
+          </div>
+        ) : null}
+        {status ? (
+          <div className="rounded-md bg-primary/10 px-3 py-2 text-sm text-primary">{status}</div>
+        ) : null}
+
+        <form onSubmit={handleSendCode} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="account-current-email">{messages.currentEmailLabel}</Label>
+            <Input
+              id="account-current-email"
+              value={currentEmail ?? messages.currentEmailMissing}
+              readOnly
+              disabled
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="account-new-email">{messages.newEmailLabel}</Label>
+            <Input
+              id="account-new-email"
+              type="email"
+              value={newEmail}
+              onChange={(event) => {
+                const value = event.target.value
+                setNewEmail(value)
+                if (codeSentTo && value.trim().toLowerCase() !== codeSentTo.toLowerCase()) {
+                  setCodeSentTo(null)
+                  setVerificationCode("")
+                }
+              }}
+              placeholder={messages.newEmailPlaceholder}
+              autoComplete="email"
+              required
+            />
+          </div>
+          <Button
+            type="submit"
+            variant="outline"
+            disabled={requestEmailChange.isPending || newEmail.trim().length === 0}
+          >
+            {requestEmailChange.isPending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Mail className="mr-2 h-4 w-4" />
+            )}
+            {requestEmailChange.isPending ? messages.sendingCode : messages.sendCode}
+          </Button>
+        </form>
+
+        {codeSentTo ? (
+          <form onSubmit={handleConfirm} className="space-y-4 border-t pt-5">
+            <div className="space-y-2">
+              <Label htmlFor="account-email-verification-code">
+                {messages.verificationCodeLabel}
+              </Label>
+              <Input
+                id="account-email-verification-code"
+                value={verificationCode}
+                onChange={(event) => setVerificationCode(event.target.value)}
+                placeholder={messages.verificationCodePlaceholder}
+                inputMode="numeric"
+                required
+              />
+            </div>
+            <Button
+              type="submit"
+              disabled={confirmEmailChange.isPending || verificationCode.trim().length === 0}
+            >
+              {confirmEmailChange.isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Save className="mr-2 h-4 w-4" />
+              )}
+              {confirmEmailChange.isPending ? messages.confirming : messages.confirm}
+            </Button>
+          </form>
+        ) : null}
+      </CardContent>
+    </Card>
+  )
+}
+
+export function AccountChangePasswordForm({
+  className,
+  messages: messageOverrides,
+  minPasswordLength = 8,
+  revokeOtherSessionsDefault = true,
+  onChanged,
+}: AccountChangePasswordFormProps) {
+  const messages = { ...defaultAccountPageMessages.password, ...messageOverrides }
+  const mutation = useChangeAccountPassword()
+  const [currentPassword, setCurrentPassword] = useState("")
+  const [newPassword, setNewPassword] = useState("")
+  const [confirmPassword, setConfirmPassword] = useState("")
+  const [revokeOtherSessions, setRevokeOtherSessions] = useState(revokeOtherSessionsDefault)
+  const [status, setStatus] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+    setStatus(null)
+
+    if (!currentPassword) {
+      setError(messages.currentPasswordRequired)
+      return
+    }
+
+    if (!newPassword) {
+      setError(messages.newPasswordRequired)
+      return
+    }
+
+    if (newPassword.length < minPasswordLength) {
+      setError(messages.passwordTooShort)
+      return
+    }
+
+    if (newPassword !== confirmPassword) {
+      setError(messages.passwordsDoNotMatch)
+      return
+    }
+
+    try {
+      await mutation.mutateAsync({
+        currentPassword,
+        newPassword,
+        revokeOtherSessions,
+      })
+      await onChanged?.()
+      setCurrentPassword("")
+      setNewPassword("")
+      setConfirmPassword("")
+      setStatus(messages.success)
+    } catch (err) {
+      setError(messageFromError(err, messages.error))
+    }
+  }
+
+  return (
+    <Card data-slot="account-change-password-form" className={className}>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <KeyRound className="h-4 w-4" />
+          {messages.title}
+        </CardTitle>
+        <CardDescription>{messages.description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error ? (
+            <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </div>
+          ) : null}
+          {status ? (
+            <div className="rounded-md bg-primary/10 px-3 py-2 text-sm text-primary">{status}</div>
+          ) : null}
+
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="space-y-2">
+              <Label htmlFor="account-current-password">{messages.currentPasswordLabel}</Label>
+              <Input
+                id="account-current-password"
+                type="password"
+                value={currentPassword}
+                onChange={(event) => setCurrentPassword(event.target.value)}
+                autoComplete="current-password"
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="account-new-password">{messages.newPasswordLabel}</Label>
+              <Input
+                id="account-new-password"
+                type="password"
+                value={newPassword}
+                onChange={(event) => setNewPassword(event.target.value)}
+                autoComplete="new-password"
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="account-confirm-password">{messages.confirmPasswordLabel}</Label>
+              <Input
+                id="account-confirm-password"
+                type="password"
+                value={confirmPassword}
+                onChange={(event) => setConfirmPassword(event.target.value)}
+                autoComplete="new-password"
+                required
+              />
+            </div>
+          </div>
+
+          <label
+            htmlFor="account-revoke-other-sessions"
+            className="flex cursor-pointer items-center gap-3 text-sm"
+          >
+            <Checkbox
+              id="account-revoke-other-sessions"
+              checked={revokeOtherSessions}
+              onCheckedChange={(value) => setRevokeOtherSessions(value === true)}
+            />
+            <span>{messages.revokeOtherSessionsLabel}</span>
+          </label>
+
+          <Button type="submit" disabled={mutation.isPending}>
+            {mutation.isPending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Save className="mr-2 h-4 w-4" />
+            )}
+            {mutation.isPending ? messages.saving : messages.submit}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/packages/auth-ui/src/components/account-page-shared.ts
+++ b/packages/auth-ui/src/components/account-page-shared.ts
@@ -1,0 +1,176 @@
+import type { CurrentUser } from "@voyantjs/auth-react"
+import type { ReactNode } from "react"
+
+export interface AccountProfileFormMessages {
+  title: string
+  description: string
+  firstNameLabel: string
+  firstNamePlaceholder: string
+  lastNameLabel: string
+  lastNamePlaceholder: string
+  profilePictureUrlLabel: string
+  profilePictureUrlPlaceholder: string
+  submit: string
+  saving: string
+  success: string
+  loadFailed: string
+  noUser: string
+  error: string
+}
+
+export interface AccountChangeEmailFormMessages {
+  title: string
+  description: string
+  currentEmailLabel: string
+  currentEmailMissing: string
+  newEmailLabel: string
+  newEmailPlaceholder: string
+  verificationCodeLabel: string
+  verificationCodePlaceholder: string
+  sendCode: string
+  sendingCode: string
+  confirm: string
+  confirming: string
+  codeSent: string
+  success: string
+  emailRequired: string
+  codeRequired: string
+  error: string
+}
+
+export interface AccountChangePasswordFormMessages {
+  title: string
+  description: string
+  currentPasswordLabel: string
+  newPasswordLabel: string
+  confirmPasswordLabel: string
+  revokeOtherSessionsLabel: string
+  submit: string
+  saving: string
+  success: string
+  currentPasswordRequired: string
+  newPasswordRequired: string
+  passwordsDoNotMatch: string
+  passwordTooShort: string
+  error: string
+}
+
+export interface AccountPageMessages {
+  title: string
+  description: string
+  loading: string
+  loadFailed: string
+  profile: AccountProfileFormMessages
+  email: AccountChangeEmailFormMessages
+  password: AccountChangePasswordFormMessages
+}
+
+export interface AccountPageRenderContext {
+  user: CurrentUser | null
+  refreshUser: () => Promise<unknown>
+}
+
+export type AccountPageSlot = ReactNode | ((context: AccountPageRenderContext) => ReactNode)
+
+export interface AccountPageSlots {
+  /**
+   * Renders beside the built-in profile form. Use for app-owned preferences.
+   */
+  profilePanel?: AccountPageSlot
+  /**
+   * Renders beside the built-in password/email forms. Use for security panels
+   * such as sessions, MFA enrollment, or recovery codes.
+   */
+  securityPanel?: AccountPageSlot
+  /**
+   * Renders after the built-in forms. Intended for panels such as API tokens.
+   */
+  apiTokensPanel?: AccountPageSlot
+  afterContent?: AccountPageSlot
+}
+
+export type PartialAccountPageMessages = Partial<
+  Omit<AccountPageMessages, "profile" | "email" | "password">
+> & {
+  profile?: Partial<AccountProfileFormMessages>
+  email?: Partial<AccountChangeEmailFormMessages>
+  password?: Partial<AccountChangePasswordFormMessages>
+}
+
+export const defaultAccountPageMessages: AccountPageMessages = {
+  title: "Account",
+  description: "Manage your profile, sign-in email, and password.",
+  loading: "Loading account...",
+  loadFailed: "Could not load the current account.",
+  profile: {
+    title: "Profile",
+    description: "Update the name and avatar shown across operator tools.",
+    firstNameLabel: "First name",
+    firstNamePlaceholder: "Ana",
+    lastNameLabel: "Last name",
+    lastNamePlaceholder: "Popescu",
+    profilePictureUrlLabel: "Profile picture URL",
+    profilePictureUrlPlaceholder: "https://example.com/avatar.png",
+    submit: "Save profile",
+    saving: "Saving",
+    success: "Profile updated.",
+    loadFailed: "Could not load profile details.",
+    noUser: "No signed-in user was found.",
+    error: "Could not update the profile.",
+  },
+  email: {
+    title: "Change email",
+    description: "Send a verification code to the new email address before changing it.",
+    currentEmailLabel: "Current email",
+    currentEmailMissing: "No email is set.",
+    newEmailLabel: "New email",
+    newEmailPlaceholder: "name@example.com",
+    verificationCodeLabel: "Verification code",
+    verificationCodePlaceholder: "Enter the 6-digit code",
+    sendCode: "Send code",
+    sendingCode: "Sending",
+    confirm: "Verify and change email",
+    confirming: "Updating",
+    codeSent: "Verification code sent.",
+    success: "Email updated.",
+    emailRequired: "Enter a new email address.",
+    codeRequired: "Enter the verification code.",
+    error: "Could not change the email address.",
+  },
+  password: {
+    title: "Change password",
+    description: "Use your current password to set a new one.",
+    currentPasswordLabel: "Current password",
+    newPasswordLabel: "New password",
+    confirmPasswordLabel: "Confirm new password",
+    revokeOtherSessionsLabel: "Sign out other sessions",
+    submit: "Update password",
+    saving: "Updating",
+    success: "Password updated.",
+    currentPasswordRequired: "Enter your current password.",
+    newPasswordRequired: "Enter a new password.",
+    passwordsDoNotMatch: "The new passwords do not match.",
+    passwordTooShort: "The new password is too short.",
+    error: "Could not update the password.",
+  },
+}
+
+export function mergeAccountPageMessages(
+  overrides?: PartialAccountPageMessages,
+): AccountPageMessages {
+  return {
+    ...defaultAccountPageMessages,
+    ...overrides,
+    profile: { ...defaultAccountPageMessages.profile, ...overrides?.profile },
+    email: { ...defaultAccountPageMessages.email, ...overrides?.email },
+    password: { ...defaultAccountPageMessages.password, ...overrides?.password },
+  }
+}
+
+export function messageFromError(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message
+  }
+
+  return fallback
+}

--- a/packages/auth-ui/src/components/account-page.tsx
+++ b/packages/auth-ui/src/components/account-page.tsx
@@ -1,0 +1,135 @@
+"use client"
+
+import { OperatorAdminPageShell } from "@voyantjs/admin"
+import { type CurrentUser, useCurrentUser } from "@voyantjs/auth-react"
+import { cn } from "@voyantjs/ui/components"
+import { type ReactNode, useMemo } from "react"
+
+import {
+  AccountChangeEmailForm,
+  AccountChangePasswordForm,
+  AccountProfileForm,
+} from "./account-forms.js"
+import {
+  type AccountPageMessages,
+  type AccountPageRenderContext,
+  type AccountPageSlot,
+  type AccountPageSlots,
+  mergeAccountPageMessages,
+  type PartialAccountPageMessages,
+} from "./account-page-shared.js"
+
+export {
+  AccountChangeEmailForm,
+  type AccountChangeEmailFormProps,
+  AccountChangePasswordForm,
+  type AccountChangePasswordFormProps,
+  AccountProfileForm,
+  type AccountProfileFormProps,
+} from "./account-forms.js"
+export {
+  type AccountChangeEmailFormMessages,
+  type AccountChangePasswordFormMessages,
+  type AccountPageMessages,
+  type AccountPageRenderContext,
+  type AccountPageSlot,
+  type AccountPageSlots,
+  type AccountProfileFormMessages,
+  defaultAccountPageMessages,
+} from "./account-page-shared.js"
+
+export interface AccountPageProps {
+  actions?: ReactNode
+  breadcrumbs?: ReactNode
+  className?: string
+  contentClassName?: string
+  currentUser?: CurrentUser | null
+  messages?: PartialAccountPageMessages
+  slots?: AccountPageSlots
+  showSidebarTrigger?: boolean
+}
+
+function renderSlot(slot: AccountPageSlot | undefined, context: AccountPageRenderContext) {
+  if (typeof slot === "function") {
+    return slot(context)
+  }
+
+  return slot
+}
+
+export function AccountPage({
+  actions,
+  breadcrumbs,
+  className,
+  contentClassName,
+  currentUser,
+  messages: messageOverrides,
+  slots,
+  showSidebarTrigger,
+}: AccountPageProps) {
+  const messages: AccountPageMessages = mergeAccountPageMessages(messageOverrides)
+  const userQuery = useCurrentUser({ enabled: currentUser === undefined })
+  const user = currentUser === undefined ? (userQuery.data ?? null) : currentUser
+  const isLoading = currentUser === undefined && userQuery.isLoading
+  const isError = currentUser === undefined && userQuery.isError
+
+  const context = useMemo<AccountPageRenderContext>(
+    () => ({
+      user,
+      refreshUser: () => userQuery.refetch(),
+    }),
+    [user, userQuery],
+  )
+
+  return (
+    <OperatorAdminPageShell
+      actions={actions}
+      breadcrumbs={breadcrumbs}
+      contentClassName={contentClassName}
+      showSidebarTrigger={showSidebarTrigger}
+    >
+      <div
+        data-slot="account-page"
+        className={cn("mx-auto flex w-full max-w-5xl flex-col gap-6", className)}
+      >
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold tracking-tight">{messages.title}</h1>
+          <p className="text-sm text-muted-foreground">{messages.description}</p>
+        </div>
+
+        {isLoading ? (
+          <div className="rounded-md border px-4 py-3 text-sm text-muted-foreground">
+            {messages.loading}
+          </div>
+        ) : null}
+
+        {isError ? (
+          <div className="rounded-md bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            {messages.loadFailed}
+          </div>
+        ) : null}
+
+        {!isLoading && !isError ? (
+          <>
+            <div className="grid gap-6 xl:grid-cols-2">
+              <AccountProfileForm currentUser={user} messages={messages.profile} />
+              {renderSlot(slots?.profilePanel, context)}
+            </div>
+
+            <div className="grid gap-6 xl:grid-cols-2">
+              <AccountChangeEmailForm
+                currentEmail={user?.email ?? null}
+                messages={messages.email}
+              />
+              <AccountChangePasswordForm messages={messages.password} />
+              {renderSlot(slots?.securityPanel, context)}
+            </div>
+
+            {renderSlot(slots?.apiTokensPanel, context)}
+            {renderSlot(slots?.afterContent, context)}
+          </>
+        ) : null}
+      </div>
+    </OperatorAdminPageShell>
+  )
+}

--- a/packages/auth-ui/src/index.ts
+++ b/packages/auth-ui/src/index.ts
@@ -1,12 +1,4 @@
 export {
-  defaultOnboardingPageMessages,
-  OnboardingPage,
-  type OnboardingPageInitialProfile,
-  type OnboardingPageMessages,
-  type OnboardingPageProps,
-  type OnboardingPageSlots,
-} from "./components/onboarding-page.js"
-export {
   AccountChangeEmailForm,
   type AccountChangeEmailFormProps,
   AccountChangePasswordForm,
@@ -24,6 +16,14 @@ export {
   type AccountProfileFormMessages,
   defaultAccountPageMessages,
 } from "./components/account-page-shared.js"
+export {
+  defaultOnboardingPageMessages,
+  OnboardingPage,
+  type OnboardingPageInitialProfile,
+  type OnboardingPageMessages,
+  type OnboardingPageProps,
+  type OnboardingPageSlots,
+} from "./components/onboarding-page.js"
 export {
   ApiTokensPage,
   type ApiTokensPageProps,

--- a/packages/auth-ui/src/index.ts
+++ b/packages/auth-ui/src/index.ts
@@ -7,6 +7,24 @@ export {
   type OnboardingPageSlots,
 } from "./components/onboarding-page.js"
 export {
+  AccountChangeEmailForm,
+  type AccountChangeEmailFormProps,
+  AccountChangePasswordForm,
+  type AccountChangePasswordFormProps,
+  AccountProfileForm,
+  type AccountProfileFormProps,
+} from "./components/account-forms.js"
+export {
+  type AccountChangeEmailFormMessages,
+  type AccountChangePasswordFormMessages,
+  type AccountPageMessages,
+  type AccountPageRenderContext,
+  type AccountPageSlot,
+  type AccountPageSlots,
+  type AccountProfileFormMessages,
+  defaultAccountPageMessages,
+} from "./components/account-page-shared.js"
+export {
   ApiTokensPage,
   type ApiTokensPageProps,
   ServiceApiKeysPage,

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -53,10 +53,14 @@ Mount `handleApiTokenManagementRequest(...)` before falling through to
 ## Account Profile
 
 Voyant auth UIs use `PATCH /auth/me` to update the signed-in user's basic
-profile fields: `firstName`, `lastName`, `locale`, and `timezone`. Mount
-`handleAccountProfileRequest(...)` before falling through to `auth.handler`
-when the app wants the shared onboarding/profile completion UI to submit
-directly to the auth facade.
+profile fields: `firstName`, `lastName`, `locale`, `timezone`, and
+`profilePictureUrl`. Mount `handleAccountProfileRequest(...)` before falling
+through to `auth.handler` when the app wants shared onboarding or account UI to
+submit directly to the auth facade.
+
+`updateCurrentUserProfile(db, { userId, ...patch })` from
+`@voyantjs/auth/workspace` updates the Voyant profile row and returns the
+normalized `CurrentUser`.
 
 ## Exports
 
@@ -66,6 +70,7 @@ directly to the auth facade.
 | `./server` | Node.js/server `createAuth` factory |
 | `./edge` | Edge/Workers `createAuth` factory |
 | `./backend` | Backend helpers (session inspection, API keys) |
+| `./workspace` | Current-user/profile helpers for mounted auth routes |
 | `./permissions` | Permission/role contracts |
 
 ## License

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -179,7 +179,13 @@ function readProfileUpdate(
 ): Omit<UpdateCurrentUserProfileInput, "userId"> {
   const input: Omit<UpdateCurrentUserProfileInput, "userId"> = {}
 
-  for (const field of ["firstName", "lastName", "locale", "timezone"] as const) {
+  for (const field of [
+    "firstName",
+    "lastName",
+    "locale",
+    "timezone",
+    "profilePictureUrl",
+  ] as const) {
     const value = body[field]
     if (value === undefined) continue
 
@@ -187,7 +193,14 @@ function readProfileUpdate(
       throw Object.assign(new Error(`${field} must be a string or null`), { status: 400 })
     }
 
-    const maxLength = field === "locale" ? 10 : field === "timezone" ? 64 : 200
+    const maxLength =
+      field === "locale"
+        ? 10
+        : field === "timezone"
+          ? 64
+          : field === "profilePictureUrl"
+            ? 2048
+            : 200
     if (typeof value === "string" && value.length > maxLength) {
       throw Object.assign(new Error(`${field} must be ${maxLength} characters or fewer`), {
         status: 400,

--- a/packages/auth/src/workspace.ts
+++ b/packages/auth/src/workspace.ts
@@ -24,6 +24,7 @@ export type UpdateCurrentUserProfileInput = {
   lastName?: string | null
   locale?: string | null
   timezone?: string | null
+  profilePictureUrl?: string | null
 }
 
 export type AuthStatus = {
@@ -156,17 +157,23 @@ export async function ensureCurrentUserProfile(
 }
 
 function profilePatchValues(input: UpdateCurrentUserProfileInput) {
-  const values: {
-    firstName?: string | null
-    lastName?: string | null
-    locale?: string
-    timezone?: string | null
-  } = {}
+  const values: Partial<typeof userProfilesTable.$inferInsert> = {}
 
-  if ("firstName" in input) values.firstName = input.firstName ?? null
-  if ("lastName" in input) values.lastName = input.lastName ?? null
+  if ("firstName" in input) values.firstName = normalizeOptionalText(input.firstName)
+  if ("lastName" in input) values.lastName = normalizeOptionalText(input.lastName)
   if ("locale" in input) values.locale = input.locale ?? "en"
-  if ("timezone" in input) values.timezone = input.timezone ?? null
+  if ("timezone" in input) values.timezone = normalizeOptionalText(input.timezone)
+  if ("profilePictureUrl" in input)
+    values.avatarUrl = normalizeOptionalText(input.profilePictureUrl)
 
   return values
+}
+
+function normalizeOptionalText(value: string | null | undefined): string | null {
+  if (value === undefined || value === null) {
+    return null
+  }
+
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1101,6 +1101,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      '@voyantjs/admin':
+        specifier: workspace:*
+        version: link:../admin
       '@voyantjs/auth-react':
         specifier: workspace:*
         version: link:../auth-react


### PR DESCRIPTION
Advances #787 and #655.

## What changed
- Added @voyantjs/auth-react account mutation helpers/hooks for profile updates, password changes, email-change requests, and email-change confirmations.
- Added @voyantjs/auth-ui AccountPage plus AccountProfileForm, AccountChangeEmailForm, and AccountChangePasswordForm using the operator page shell and slot/render-prop panels for app-specific sections such as API tokens.
- Added @voyantjs/auth workspace helper for profile updates, exports/docs/tests, and a changeset.

## Validation
- pnpm --filter @voyantjs/auth test
- pnpm --filter @voyantjs/auth-react test
- pnpm --filter @voyantjs/auth-ui test
- pnpm --filter @voyantjs/auth typecheck
- pnpm --filter @voyantjs/auth-react typecheck
- pnpm --filter @voyantjs/auth-ui typecheck
- pnpm --filter @voyantjs/auth build
- pnpm --filter @voyantjs/auth-react build
- pnpm --filter @voyantjs/auth-ui build
- pnpm --filter @voyantjs/auth lint
- pnpm --filter @voyantjs/auth-react lint
- pnpm --filter @voyantjs/auth-ui lint
- pnpm lint:changed
- pre-push pnpm test (125 tasks passed)

## Notes
- Template route wiring was left untouched; docs call out that apps should mount PATCH /auth/me using updateCurrentUserProfile(...).
