### PR TITLE
feat(agent-runner): add supervisor status endpoint

### DIFF
--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -153,7 +153,8 @@ AGENT_RUNNER_TOKEN=... \
 pnpm agent:queue:deployment-doctor -- --json
 ```
 
-The doctor calls both `/api/capabilities` endpoints and reports persistence and
+The doctor calls both `/api/capabilities` endpoints, reads
+`/api/supervisor/status` from the runner app, and reports persistence and
 execution mode without printing token values.
 After a queue snapshot exists, add `--smoke-tick --repo voyantjs/voyant` to
 verify that the deployed runner can call `POST /api/dispatch-plans/latest`

--- a/apps/agent-runner/README.md
+++ b/apps/agent-runner/README.md
@@ -27,6 +27,11 @@ provider commands, or spend model budget.
   If the control plane rejects the lease because an active intent already
   exists, the tick result includes that active intent so operators can inspect
   the holder and expiration from the persisted supervisor status.
+- `GET /api/supervisor/status?repository=<owner/name>&limit=<n>` returns a
+  non-mutating operator view with runner capabilities, tick storage state, the
+  latest persisted supervisor tick, and recent tick history. If `repository` is
+  omitted, the configured `AGENT_RUNNER_REPOSITORY` is used. The endpoint still
+  returns capabilities when `AGENT_RUNNER_TICKS` is not bound.
 - `GET /api/supervisor/ticks/latest?repository=<owner/name>` returns the latest
   persisted supervisor tick for a repository. Requires `AGENT_RUNNER_TOKENS`
   and the `AGENT_RUNNER_TICKS` binding.
@@ -67,7 +72,8 @@ pnpm agent:queue:deployment-doctor -- --json
 
 The command reads `AGENT_CONTROL_PLANE_URL`, `AGENT_CONTROL_PLANE_TOKEN`,
 `AGENT_RUNNER_URL`, and `AGENT_RUNNER_TOKEN`, calls both capability endpoints,
-and reports persistence and execution mode without printing token values.
+checks the runner supervisor status endpoint, and reports persistence and
+execution mode without printing token values.
 Pass `--smoke-tick` after submitting at least one queue snapshot to validate
 that the deployed runner can call the control plane's read-only dispatch-plan
 path:

--- a/apps/agent-runner/src/app.ts
+++ b/apps/agent-runner/src/app.ts
@@ -52,12 +52,53 @@ export function createApp({
   app.get("/api/capabilities", (c) =>
     c.json({
       ...buildRunnerCapabilities(config),
-      supervisorTicks: {
-        history: Boolean(supervisorTickStore),
-        persistence: supervisorTickStore ? "latest" : "none",
-      },
+      supervisorTicks: supervisorTickCapabilities(supervisorTickStore),
     }),
   )
+
+  app.get("/api/supervisor/status", async (c) => {
+    const repository = c.req.query("repository")?.trim() || config.repository
+    if (!repository) {
+      return c.json({ error: "missing_repository" }, 400)
+    }
+
+    const capabilities = {
+      ...buildRunnerCapabilities(config),
+      supervisorTicks: supervisorTickCapabilities(supervisorTickStore),
+    }
+
+    if (!supervisorTickStore) {
+      return c.json({
+        capabilities,
+        repository,
+        service: "agent-runner",
+        supervisorTicks: {
+          latest: null,
+          recent: [],
+          storage: {
+            configured: false,
+            persistence: "none",
+          },
+        },
+      })
+    }
+
+    return c.json({
+      capabilities,
+      repository,
+      service: "agent-runner",
+      supervisorTicks: {
+        latest: await supervisorTickStore.getLatest(repository),
+        recent: await supervisorTickStore.listRecent(repository, {
+          limit: parseLimit(c.req.query("limit")) ?? 5,
+        }),
+        storage: {
+          configured: true,
+          persistence: "latest",
+        },
+      },
+    })
+  })
 
   app.post("/api/supervisor/ticks", async (c) => {
     const parsed = supervisorTickRequestSchema.safeParse(await c.req.json().catch(() => ({})))
@@ -178,4 +219,11 @@ function parseLimit(value: string | undefined) {
   if (!value) return undefined
   const parsed = Number(value)
   return Number.isFinite(parsed) ? parsed : undefined
+}
+
+function supervisorTickCapabilities(supervisorTickStore: SupervisorTickStore | undefined) {
+  return {
+    history: Boolean(supervisorTickStore),
+    persistence: supervisorTickStore ? "latest" : "none",
+  }
 }

--- a/apps/agent-runner/src/supervisor-status.test.ts
+++ b/apps/agent-runner/src/supervisor-status.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest"
+
+import { createApp } from "./app.js"
+import type { SupervisorTickRecord, SupervisorTickStore } from "./supervisor-tick-store.js"
+
+describe("agent runner supervisor status", () => {
+  it("combines capabilities with latest and recent supervisor ticks", async () => {
+    const app = createApp({
+      authTokens: ["token"],
+      config: {
+        controlPlaneConfigured: true,
+        controlPlaneUrl: "https://control.example.com",
+        enabled: true,
+        holder: "runner:cloudflare",
+        repository: "voyantjs/voyant",
+      },
+      now: () => new Date("2026-05-12T12:00:00.000Z"),
+      supervisorTickStore: inMemorySupervisorTickStore(),
+    })
+
+    const tick = await app.request("/api/supervisor/ticks", {
+      body: JSON.stringify({ dryRun: true }),
+      headers: {
+        authorization: "Bearer token",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+    expect(tick.status).toBe(200)
+
+    const response = await app.request("/api/supervisor/status?repository=voyantjs%2Fvoyant", {
+      headers: {
+        authorization: "Bearer token",
+      },
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      capabilities: {
+        execution: {
+          enabled: true,
+          mode: "lease-only",
+        },
+        supervisorTicks: {
+          history: true,
+          persistence: "latest",
+        },
+      },
+      repository: "voyantjs/voyant",
+      service: "agent-runner",
+      supervisorTicks: {
+        latest: {
+          recordedAt: "2026-05-12T12:00:00.000Z",
+          result: {
+            reason: "dry_run",
+          },
+        },
+        recent: [
+          {
+            recordedAt: "2026-05-12T12:00:00.000Z",
+            result: {
+              reason: "dry_run",
+            },
+          },
+        ],
+        storage: {
+          configured: true,
+          persistence: "latest",
+        },
+      },
+    })
+  })
+
+  it("reports supervisor status without tick storage", async () => {
+    const app = createApp({
+      authTokens: ["token"],
+      config: {
+        controlPlaneConfigured: false,
+        enabled: false,
+        repository: "voyantjs/voyant",
+      },
+    })
+
+    const response = await app.request("/api/supervisor/status", {
+      headers: {
+        authorization: "Bearer token",
+      },
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      capabilities: {
+        execution: {
+          enabled: false,
+          mode: "disabled",
+        },
+        supervisorTicks: {
+          history: false,
+          persistence: "none",
+        },
+      },
+      repository: "voyantjs/voyant",
+      service: "agent-runner",
+      supervisorTicks: {
+        latest: null,
+        recent: [],
+        storage: {
+          configured: false,
+          persistence: "none",
+        },
+      },
+    })
+  })
+})
+
+function inMemorySupervisorTickStore(): SupervisorTickStore {
+  const latest = new Map<string, SupervisorTickRecord>()
+  const recent: SupervisorTickRecord[] = []
+
+  return {
+    async getLatest(repository) {
+      return latest.get(repository.toLowerCase()) ?? null
+    },
+    async listRecent(repository) {
+      return recent.filter((record) => record.repository.toLowerCase() === repository.toLowerCase())
+    },
+    async putLatest(record) {
+      latest.set(record.repository.toLowerCase(), record)
+      recent.unshift(record)
+      return { key: `latest/${record.repository.toLowerCase()}.json` }
+    },
+  }
+}

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1370,6 +1370,10 @@ Verification:
   database. Lease-conflict ticks preserve the active intent returned by the
   control plane so maintainers can see the holder, issue, action, and expiration
   that blocked the run.
+- `GET /api/supervisor/status` combines runner capabilities with latest and
+  recent supervisor tick history for one repository. It is non-mutating and
+  still reports capabilities when tick storage is not configured, so operators
+  have one deployed-readiness endpoint before enabling Cron.
 - Operators can inspect persisted control-plane and runner history with
   `pnpm agent:queue:history`, using `--source control-plane` for queue
   snapshots or `--source runner` for deployed supervisor ticks.
@@ -1382,11 +1386,11 @@ Verification:
   queued action.
 - Deployed control-plane and runner setup should be checked with
   `pnpm agent:queue:deployment-doctor` before enabling Cron. The command calls
-  both capability endpoints, verifies auth reaches the deployed apps, and
-  reports persistence and execution mode without printing bearer tokens. After
-  at least one queue snapshot is stored, `--smoke-tick` makes the deployed
-  runner call the control plane's read-only dispatch-plan path without leasing
-  work.
+  both capability endpoints, reads the runner supervisor status, verifies auth
+  reaches the deployed apps, and reports persistence and execution mode without
+  printing bearer tokens. After at least one queue snapshot is stored,
+  `--smoke-tick` makes the deployed runner call the control plane's read-only
+  dispatch-plan path without leasing work.
 
 ## Open Questions
 

--- a/scripts/agent-runner-deployment-doctor.mjs
+++ b/scripts/agent-runner-deployment-doctor.mjs
@@ -5,18 +5,20 @@ import {
 } from "./lib/agent-runner-control-plane.mjs"
 import {
   requestRunnerAppCapabilities,
+  requestRunnerAppSupervisorStatus,
   requestRunnerAppSupervisorTick,
   runnerAppConfigFromArgs,
   summarizeControlPlaneCapabilities,
   summarizeRunnerAppCapabilities,
   summarizeRunnerSmokeTick,
+  summarizeRunnerSupervisorStatus,
 } from "./lib/agent-runner-deployment-doctor.mjs"
 import { maybePrintHelp } from "./lib/agent-runner-help.mjs"
 
 const args = parseArgs(process.argv.slice(2))
 maybePrintHelp(args, {
   command: "agent:queue:deployment-doctor",
-  summary: "Check deployed control-plane and runner app capability endpoints.",
+  summary: "Check deployed control-plane and runner app readiness endpoints.",
   usage: "pnpm agent:queue:deployment-doctor -- [--json]",
   options: [
     ["--control-plane-url <url>", "Control-plane base URL. Defaults to AGENT_CONTROL_PLANE_URL."],
@@ -26,7 +28,7 @@ maybePrintHelp(args, {
     ["--smoke-tick", "Run a dry-run supervisor tick that validates the control-plane read path."],
     [
       "--repo <owner/name>",
-      "Repository for --smoke-tick. Defaults to the deployed runner default.",
+      "Repository for runner supervisor status and --smoke-tick. Defaults to the deployed runner default.",
     ],
     ["--action <name>", "Optional lifecycle action filter for --smoke-tick."],
     ["--json", "Print machine-readable JSON."],
@@ -110,6 +112,25 @@ async function checkRunnerApp() {
     record({
       detail: error instanceof Error ? error.message : String(error),
       name: "runner app capabilities",
+      ok: false,
+    })
+  }
+
+  try {
+    const status = await requestRunnerAppSupervisorStatus({
+      limit: 5,
+      ...(args.repo ? { repository: args.repo } : {}),
+      token: config.token,
+      url: config.url,
+    })
+    record({
+      name: "runner app supervisor status",
+      ...summarizeRunnerSupervisorStatus(status),
+    })
+  } catch (error) {
+    record({
+      detail: error instanceof Error ? error.message : String(error),
+      name: "runner app supervisor status",
       ok: false,
     })
   }

--- a/scripts/lib/agent-runner-deployment-doctor.mjs
+++ b/scripts/lib/agent-runner-deployment-doctor.mjs
@@ -52,6 +52,28 @@ export async function requestRunnerAppSupervisorTick({ fetchImpl = fetch, reques
   })
 }
 
+export async function requestRunnerAppSupervisorStatus({
+  fetchImpl = fetch,
+  limit,
+  repository,
+  token,
+  url,
+}) {
+  const query = new URLSearchParams({
+    ...(repository ? { repository } : {}),
+    ...(limit ? { limit: String(limit) } : {}),
+  })
+  const path =
+    query.size > 0 ? `/api/supervisor/status?${query.toString()}` : "/api/supervisor/status"
+  return requestRunnerAppJson({
+    endpoint: "supervisor status",
+    fetchImpl,
+    path,
+    token,
+    url,
+  })
+}
+
 export async function requestRecentRunnerSupervisorTicks({
   fetchImpl = fetch,
   limit,
@@ -138,6 +160,18 @@ export function summarizeRunnerSmokeTick(response) {
       Number(controlPlaneStatus) >= 200 &&
       Number(controlPlaneStatus) < 300,
     detail: `reason: ${result?.reason ?? "unknown"}; control plane status: ${String(controlPlaneStatus)}; storage persisted: ${String(response?.storage?.persisted ?? "unknown")}`,
+  }
+}
+
+export function summarizeRunnerSupervisorStatus(status) {
+  const persistence = status?.supervisorTicks?.storage?.persistence ?? "unknown"
+  const latestReason = status?.supervisorTicks?.latest?.result?.reason ?? "none"
+  const recentCount = Array.isArray(status?.supervisorTicks?.recent)
+    ? status.supervisorTicks.recent.length
+    : "unknown"
+  return {
+    ok: status?.service === "agent-runner" && Boolean(status?.capabilities?.execution),
+    detail: `repository: ${status?.repository ?? "unknown"}; tick persistence: ${persistence}; latest: ${latestReason}; recent: ${String(recentCount)}`,
   }
 }
 

--- a/scripts/tests/agent-runner-deployment-doctor.test.mjs
+++ b/scripts/tests/agent-runner-deployment-doctor.test.mjs
@@ -3,11 +3,13 @@ import { describe, it } from "node:test"
 
 import {
   requestRunnerAppCapabilities,
+  requestRunnerAppSupervisorStatus,
   requestRunnerAppSupervisorTick,
   runnerAppConfigFromArgs,
   summarizeControlPlaneCapabilities,
   summarizeRunnerAppCapabilities,
   summarizeRunnerSmokeTick,
+  summarizeRunnerSupervisorStatus,
 } from "../lib/agent-runner-deployment-doctor.mjs"
 
 describe("agent runner deployment doctor helpers", () => {
@@ -123,6 +125,52 @@ describe("agent runner deployment doctor helpers", () => {
     )
   })
 
+  it("reads deployed runner supervisor status", async () => {
+    const calls = []
+    const response = await requestRunnerAppSupervisorStatus({
+      fetchImpl: async (url, init) => {
+        calls.push({ init, url })
+        return new Response(
+          JSON.stringify({
+            capabilities: {
+              execution: {
+                enabled: true,
+                mode: "lease-only",
+              },
+            },
+            repository: "voyantjs/voyant",
+            service: "agent-runner",
+            supervisorTicks: {
+              latest: {
+                result: {
+                  reason: "dry_run",
+                },
+              },
+              recent: [{ result: { reason: "dry_run" } }],
+              storage: {
+                configured: true,
+                persistence: "latest",
+              },
+            },
+          }),
+          { status: 200 },
+        )
+      },
+      limit: 5,
+      repository: "voyantjs/voyant",
+      token: "tok",
+      url: "https://runner.example.com/",
+    })
+
+    assert.equal(response.service, "agent-runner")
+    assert.equal(
+      calls[0].url,
+      "https://runner.example.com/api/supervisor/status?repository=voyantjs%2Fvoyant&limit=5",
+    )
+    assert.equal(calls[0].init.method, "GET")
+    assert.equal(calls[0].init.headers.authorization, "Bearer tok")
+  })
+
   it("surfaces rejected deployed runner supervisor smoke ticks", async () => {
     await assert.rejects(
       requestRunnerAppSupervisorTick({
@@ -190,6 +238,33 @@ describe("agent runner deployment doctor helpers", () => {
       }),
       {
         detail: "reason: dry_run; control plane status: 200; storage persisted: true",
+        ok: true,
+      },
+    )
+
+    assert.deepEqual(
+      summarizeRunnerSupervisorStatus({
+        capabilities: {
+          execution: {
+            enabled: true,
+          },
+        },
+        repository: "voyantjs/voyant",
+        service: "agent-runner",
+        supervisorTicks: {
+          latest: {
+            result: {
+              reason: "dry_run",
+            },
+          },
+          recent: [{ result: { reason: "dry_run" } }],
+          storage: {
+            persistence: "latest",
+          },
+        },
+      }),
+      {
+        detail: "repository: voyantjs/voyant; tick persistence: latest; latest: dry_run; recent: 1",
         ok: true,
       },
     )


### PR DESCRIPTION
## Summary
- Add an authenticated `/api/supervisor/status` endpoint that combines runner capabilities with latest and recent supervisor tick history.
- Extend deployment doctor to read and summarize runner supervisor status.
- Add focused runner and deployment-doctor tests, and update the operator docs.

## Verification
- pnpm --filter @voyantjs/agent-runner test
- pnpm --filter @voyantjs/agent-runner check-types
- node --test scripts/tests/agent-runner-deployment-doctor.test.mjs
- pnpm agent:queue:test
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- pnpm agent:queue:deployment-doctor -- --help
- git diff --check
- pre-commit hook
- pre-push hook full test lane