### PR TITLE
[codex] Add booking combobox to finance dialogs

### DIFF
--- a/.changeset/entity-booking-combobox.md
+++ b/.changeset/entity-booking-combobox.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/bookings-ui": minor
+"@voyantjs/finance-ui": minor
+---
+
+Add a reusable booking combobox and use it in finance dialogs instead of raw booking ID inputs.

--- a/packages/bookings-ui/src/components/booking-combobox.tsx
+++ b/packages/bookings-ui/src/components/booking-combobox.tsx
@@ -1,0 +1,96 @@
+"use client"
+
+import { type BookingRecord, useBooking, useBookings } from "@voyantjs/bookings-react"
+import { AsyncCombobox } from "@voyantjs/ui/components/async-combobox"
+import * as React from "react"
+
+import { useBookingsUiMessagesOrDefault } from "../i18n/provider.js"
+
+export interface BookingComboboxProps {
+  value: string | null | undefined
+  onChange: (value: string | null) => void
+  placeholder?: string
+  emptyText?: string
+  disabled?: boolean
+  className?: string
+  triggerClassName?: string
+  clearable?: boolean
+  limit?: number
+}
+
+const DEFAULT_LIMIT = 20
+
+function compact(parts: Array<string | null | undefined>) {
+  return parts.map((part) => part?.trim()).filter(Boolean) as string[]
+}
+
+function formatCustomer(booking: BookingRecord) {
+  const name = compact([booking.contactFirstName, booking.contactLastName]).join(" ")
+  return name || booking.contactEmail || null
+}
+
+function formatPrimaryItem(booking: BookingRecord) {
+  return booking.items?.find((item) => item.title.trim())?.title ?? null
+}
+
+function formatDateRange(booking: BookingRecord) {
+  const start = booking.startDate ?? booking.startsAt
+  const end = booking.endDate ?? booking.endsAt
+  if (start && end) return `${start} - ${end}`
+  return start ?? end ?? null
+}
+
+function formatBookingLabel(booking: BookingRecord) {
+  return compact([booking.bookingNumber, formatCustomer(booking), formatPrimaryItem(booking)]).join(
+    " - ",
+  )
+}
+
+function formatBookingSecondary(booking: BookingRecord) {
+  return compact([formatDateRange(booking), booking.sellCurrency]).join(" - ")
+}
+
+export function BookingCombobox({
+  value,
+  onChange,
+  placeholder,
+  emptyText,
+  disabled,
+  className,
+  triggerClassName,
+  clearable = true,
+  limit = DEFAULT_LIMIT,
+}: BookingComboboxProps) {
+  const messages = useBookingsUiMessagesOrDefault().bookingCombobox
+  const [search, setSearch] = React.useState("")
+  const listQuery = useBookings({
+    search: search || undefined,
+    limit,
+  })
+  const selectedQuery = useBooking(value ?? undefined, { enabled: Boolean(value) })
+  const selectedBooking = selectedQuery.data?.data ?? null
+  const bookings = listQuery.data?.data ?? []
+
+  return (
+    <AsyncCombobox<BookingRecord>
+      value={value ?? null}
+      onChange={onChange}
+      items={bookings}
+      selectedItem={selectedBooking}
+      getKey={(booking) => booking.id}
+      getLabel={formatBookingLabel}
+      getSecondary={formatBookingSecondary}
+      onSearchChange={setSearch}
+      placeholder={placeholder ?? messages.placeholder}
+      emptyText={
+        listQuery.isPending || selectedQuery.isPending
+          ? messages.loading
+          : (emptyText ?? messages.empty)
+      }
+      disabled={disabled}
+      className={className}
+      triggerClassName={triggerClassName}
+      clearable={clearable}
+    />
+  )
+}

--- a/packages/bookings-ui/src/i18n/en.ts
+++ b/packages/bookings-ui/src/i18n/en.ts
@@ -32,6 +32,11 @@ export const bookingsUiEn = {
     description:
       "Create a booking, select the billed customer, add travelers, and schedule payment.",
   },
+  bookingCombobox: {
+    placeholder: "Search bookings...",
+    empty: "No bookings found.",
+    loading: "Loading bookings...",
+  },
   bookingDetailPage: {
     notFound: "Booking not found",
     backToBookings: "Back to bookings",

--- a/packages/bookings-ui/src/i18n/messages.ts
+++ b/packages/bookings-ui/src/i18n/messages.ts
@@ -25,6 +25,11 @@ export type BookingsUiMessages = {
     title: string
     description: string
   }
+  bookingCombobox: {
+    placeholder: string
+    empty: string
+    loading: string
+  }
   bookingDetailPage: {
     notFound: string
     backToBookings: string

--- a/packages/bookings-ui/src/i18n/ro.ts
+++ b/packages/bookings-ui/src/i18n/ro.ts
@@ -31,6 +31,11 @@ export const bookingsUiRo = {
     title: "Rezervare noua",
     description: "Creeaza o rezervare, alege platitorul, adauga pasageri si programeaza plata.",
   },
+  bookingCombobox: {
+    placeholder: "Cauta rezervari...",
+    empty: "Nu s-au gasit rezervari.",
+    loading: "Se incarca rezervarile...",
+  },
   bookingDetailPage: {
     notFound: "Rezervarea nu a fost gasita",
     backToBookings: "Inapoi la rezervari",

--- a/packages/bookings-ui/src/index.ts
+++ b/packages/bookings-ui/src/index.ts
@@ -7,6 +7,10 @@ export {
   type BookingCancellationDialogProps,
 } from "./components/booking-cancellation-dialog.js"
 export {
+  BookingCombobox,
+  type BookingComboboxProps,
+} from "./components/booking-combobox.js"
+export {
   BookingCreateDialog,
   type BookingCreateDialogProps,
   BookingCreateForm,

--- a/packages/finance-ui/package.json
+++ b/packages/finance-ui/package.json
@@ -27,6 +27,7 @@
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.0.0",
+    "@voyantjs/bookings-ui": "workspace:*",
     "@voyantjs/finance": "workspace:*",
     "@voyantjs/finance-react": "workspace:*",
     "@voyantjs/ui": "workspace:*",
@@ -42,6 +43,7 @@
     "@tanstack/react-query": "^5.96.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@voyantjs/bookings-ui": "workspace:*",
     "@voyantjs/finance": "workspace:*",
     "@voyantjs/finance-react": "workspace:*",
     "@voyantjs/i18n": "workspace:*",

--- a/packages/finance-ui/src/components/invoice-dialog.tsx
+++ b/packages/finance-ui/src/components/invoice-dialog.tsx
@@ -1,3 +1,4 @@
+import { BookingCombobox } from "@voyantjs/bookings-ui"
 import { type InvoiceRecord, useInvoiceMutation } from "@voyantjs/finance-react"
 import {
   Button,
@@ -206,8 +207,14 @@ export function InvoiceDialog({ open, onOpenChange, invoice, onSuccess }: Invoic
             <div className="grid grid-cols-2 gap-4">
               <div className="flex flex-col gap-2">
                 <Label>{messages.invoiceDialog.fields.bookingId}</Label>
-                <Input
-                  {...form.register("bookingId")}
+                <BookingCombobox
+                  value={form.watch("bookingId") || null}
+                  onChange={(next) =>
+                    form.setValue("bookingId", next ?? "", {
+                      shouldDirty: true,
+                      shouldValidate: true,
+                    })
+                  }
                   placeholder={messages.invoiceDialog.placeholders.bookingId}
                 />
                 {form.formState.errors.bookingId ? (

--- a/packages/finance-ui/src/components/supplier-payment-dialog.tsx
+++ b/packages/finance-ui/src/components/supplier-payment-dialog.tsx
@@ -1,3 +1,4 @@
+import { BookingCombobox } from "@voyantjs/bookings-ui"
 import { useSupplierPaymentMutation } from "@voyantjs/finance-react"
 import {
   Button,
@@ -126,8 +127,14 @@ export function SupplierPaymentDialog({
             <div className="grid grid-cols-2 gap-4">
               <div className="flex flex-col gap-2">
                 <Label>{messages.supplierPaymentDialog.fields.bookingId}</Label>
-                <Input
-                  {...form.register("bookingId")}
+                <BookingCombobox
+                  value={form.watch("bookingId") || null}
+                  onChange={(next) =>
+                    form.setValue("bookingId", next ?? "", {
+                      shouldDirty: true,
+                      shouldValidate: true,
+                    })
+                  }
                   placeholder={messages.supplierPaymentDialog.placeholders.bookingId}
                 />
                 {form.formState.errors.bookingId ? (

--- a/packages/finance-ui/src/i18n/en.ts
+++ b/packages/finance-ui/src/i18n/en.ts
@@ -45,7 +45,7 @@ export const financeUiEn = {
     fields: {
       invoiceNumber: "Invoice Number",
       status: "Status",
-      bookingId: "Booking ID",
+      bookingId: "Booking",
       currency: "Currency",
       subtotalCents: "Subtotal",
       taxCents: "Tax",
@@ -56,7 +56,7 @@ export const financeUiEn = {
     },
     placeholders: {
       invoiceNumber: "INV-2025-1234",
-      bookingId: "book_...",
+      bookingId: "Search by booking number, customer, or product",
       issueDate: "Pick issue date",
       dueDate: "Pick due date",
       notes: "Invoice notes...",
@@ -66,7 +66,7 @@ export const financeUiEn = {
     },
     validation: {
       invoiceNumberRequired: "Invoice number is required",
-      bookingIdRequired: "Booking ID is required",
+      bookingIdRequired: "Booking is required",
       currencyIsoCode: "Use 3-letter ISO code",
       issueDateRequired: "Issue date is required",
       dueDateRequired: "Due date is required",
@@ -485,7 +485,7 @@ export const financeUiEn = {
   supplierPaymentDialog: {
     title: "Record Supplier Payment",
     fields: {
-      bookingId: "Booking ID",
+      bookingId: "Booking",
       supplierId: "Supplier ID (optional)",
       amountCents: "Amount",
       currency: "Currency",
@@ -496,7 +496,7 @@ export const financeUiEn = {
       notes: "Notes",
     },
     placeholders: {
-      bookingId: "book_...",
+      bookingId: "Search by booking number, customer, or product",
       supplierId: "supp_...",
       paymentDate: "Select payment date",
       referenceNumber: "TXN-12345",
@@ -506,7 +506,7 @@ export const financeUiEn = {
       create: "Record Payment",
     },
     validation: {
-      bookingIdRequired: "Booking ID is required",
+      bookingIdRequired: "Booking is required",
       amountMinimum: "Amount must be at least 1",
       paymentDateRequired: "Payment date is required",
     },

--- a/packages/finance-ui/src/i18n/ro.ts
+++ b/packages/finance-ui/src/i18n/ro.ts
@@ -45,7 +45,7 @@ export const financeUiRo = {
     fields: {
       invoiceNumber: "Numar Factura",
       status: "Status",
-      bookingId: "ID Rezervare",
+      bookingId: "Rezervare",
       currency: "Moneda",
       subtotalCents: "Subtotal",
       taxCents: "Taxa",
@@ -56,7 +56,7 @@ export const financeUiRo = {
     },
     placeholders: {
       invoiceNumber: "INV-2025-1234",
-      bookingId: "book_...",
+      bookingId: "Cauta dupa numar, client sau produs",
       issueDate: "Alege data emiterii",
       dueDate: "Alege data scadentei",
       notes: "Note factura...",
@@ -66,7 +66,7 @@ export const financeUiRo = {
     },
     validation: {
       invoiceNumberRequired: "Numarul facturii este obligatoriu",
-      bookingIdRequired: "ID-ul rezervarii este obligatoriu",
+      bookingIdRequired: "Rezervarea este obligatorie",
       currencyIsoCode: "Foloseste cod ISO din 3 litere",
       issueDateRequired: "Data emiterii este obligatorie",
       dueDateRequired: "Data scadentei este obligatorie",
@@ -489,7 +489,7 @@ export const financeUiRo = {
   supplierPaymentDialog: {
     title: "Inregistreaza Plata Furnizorului",
     fields: {
-      bookingId: "ID Rezervare",
+      bookingId: "Rezervare",
       supplierId: "ID Furnizor (optional)",
       amountCents: "Suma",
       currency: "Moneda",
@@ -500,7 +500,7 @@ export const financeUiRo = {
       notes: "Note",
     },
     placeholders: {
-      bookingId: "book_...",
+      bookingId: "Cauta dupa numar, client sau produs",
       supplierId: "supp_...",
       paymentDate: "Selecteaza data platii",
       referenceNumber: "TXN-12345",
@@ -510,7 +510,7 @@ export const financeUiRo = {
       create: "Inregistreaza Plata",
     },
     validation: {
-      bookingIdRequired: "ID-ul rezervarii este obligatoriu",
+      bookingIdRequired: "Rezervarea este obligatorie",
       amountMinimum: "Suma trebuie sa fie cel putin 1",
       paymentDateRequired: "Data platii este obligatorie",
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2830,6 +2830,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      '@voyantjs/bookings-ui':
+        specifier: workspace:*
+        version: link:../bookings-ui
       '@voyantjs/finance':
         specifier: workspace:*
         version: link:../finance


### PR DESCRIPTION
## Summary
- add a reusable `BookingCombobox` in `@voyantjs/bookings-ui` backed by `useBookings` search and selected-booking resolution
- replace raw `bookingId` inputs in finance invoice and supplier-payment dialogs with the combobox
- update finance copy so operator-facing fields say `Booking`, not `Booking ID`

## Notes
This is the first vertical slice for #667: it removes the raw booking UUID workflow from the finance dialogs called out in the issue and establishes the shared booking picker for the remaining migrations. The broader cross-package entity-picker rollout should continue in follow-up PRs.

Refs #667

## Validation
- `pnpm --filter @voyantjs/bookings-ui typecheck`
- `pnpm --filter @voyantjs/finance-ui typecheck`
- `pnpm --filter @voyantjs/bookings-ui lint`
- `pnpm --filter @voyantjs/finance-ui lint`
- `pnpm --filter @voyantjs/bookings-ui test`
- `pnpm --filter @voyantjs/finance-ui test`
- `pnpm --filter @voyantjs/bookings-ui build`
- `pnpm --filter @voyantjs/finance-ui build`
- `pnpm verify:fast`
- pre-commit lint + full typecheck hook
- pre-push full test hook
