### PR TITLE
feat(agent-runner): release dispatch intents by reference

### DIFF
--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -169,6 +169,14 @@ AGENT_CONTROL_PLANE_TOKEN=... \
 pnpm agent:queue:finish-dispatch -- --intent intent_579 --holder supervisor:local --status completed
 ```
 
+Release an expired active dispatch intent without copying its holder manually:
+
+```bash
+AGENT_CONTROL_PLANE_URL=https://agent-control-plane.example.workers.dev \
+AGENT_CONTROL_PLANE_TOKEN=... \
+pnpm agent:queue:release-dispatch -- --issue 579 --action sync-pr --repo voyantjs/voyant
+```
+
 Run the full local supervisor path for one dispatchable item:
 
 ```bash

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -412,6 +412,10 @@ If a supervisor hits lease contention or needs to inspect the current holder, us
 `pnpm agent:queue:active-dispatch -- --issue <number> --action <name>` to read
 the control-plane active pointer without mutating it. The read reports whether
 the stored pointer is still active or only an expired/terminal record.
+Use `pnpm agent:queue:release-dispatch -- --issue <number> --action <name>` to
+release an expired active pointer by reference. It refuses unexpired active
+leases unless `--force` is passed, then records the dispatch intent as
+`released` with the stored holder.
 Before enabling a deployed control plane or scheduled runner, run
 `pnpm agent:queue:deployment-doctor -- --json` from the repository checkout.
 It reads `AGENT_CONTROL_PLANE_URL`, `AGENT_CONTROL_PLANE_TOKEN`,

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1344,6 +1344,11 @@ Verification:
   `POST /api/dispatch-intents/:id/finish` and records `completed`, `failed`, or
   `released` without waiting for lease TTL expiry. The holder must match the
   holder recorded on the lease.
+- Operators can release an expired active dispatch intent by reference with
+  `pnpm agent:queue:release-dispatch -- --issue <number> --action <name>`.
+  The command reads the active pointer, refuses still-active leases unless
+  `--force` is passed, and then finishes the intent as `released` using the
+  stored holder.
 - A local supervisor can run one complete leased lifecycle step with
   `pnpm agent:queue:run-dispatch-intent -- --holder <id> --yes`. It leases the
   next intent from the control plane, validates that the command is an allowed

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "agent:queue:lease-dispatch": "node scripts/agent-runner-lease-dispatch.mjs",
     "agent:queue:active-dispatch": "node scripts/agent-runner-active-dispatch.mjs",
     "agent:queue:finish-dispatch": "node scripts/agent-runner-finish-dispatch.mjs",
+    "agent:queue:release-dispatch": "node scripts/agent-runner-release-dispatch.mjs",
     "agent:queue:run-dispatch-intent": "node scripts/agent-runner-run-dispatch-intent.mjs",
     "agent:queue:control-plane-loop": "node scripts/agent-runner-control-plane-loop.mjs",
     "agent:queue:dispatch": "node scripts/agent-runner-dispatch.mjs",

--- a/scripts/agent-runner-release-dispatch.mjs
+++ b/scripts/agent-runner-release-dispatch.mjs
@@ -1,0 +1,141 @@
+import { currentRepositoryFromOrigin, fail, parseArgs, runGit } from "./lib/agent-project-queue.mjs"
+import {
+  controlPlaneConfigFromArgs,
+  finishDispatchIntent,
+  requestActiveDispatchIntent,
+} from "./lib/agent-runner-control-plane.mjs"
+import { dispatchableActions } from "./lib/agent-runner-dispatch.mjs"
+import { planDispatchIntentRelease } from "./lib/agent-runner-dispatch-release.mjs"
+import { maybePrintHelp, repositoryOptions } from "./lib/agent-runner-help.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:release-dispatch",
+  summary: "Release an expired active dispatch intent by repository, issue, and action.",
+  usage:
+    "pnpm agent:queue:release-dispatch -- --issue <number> --action <name> [--repo <owner/name>] [--force] [--json]",
+  options: [
+    ["--control-plane-url <url>", "Control-plane base URL. Defaults to AGENT_CONTROL_PLANE_URL."],
+    ["AGENT_CONTROL_PLANE_TOKEN", "Bearer token environment variable used for API routes."],
+    ["--issue <number>", "Issue number for the active intent reference."],
+    [
+      "--action <name>",
+      `Dispatch lifecycle action. Allowed: ${Array.from(dispatchableActions).join(", ")}.`,
+    ],
+    ["--reason <text>", "Optional release note for audit context."],
+    ["--force", "Release even when the active lease has not expired."],
+    ["--json", "Print machine-readable JSON."],
+    ...repositoryOptions,
+  ],
+})
+
+const repository =
+  args.repo ?? currentRepositoryFromOrigin(runGit(["rev-parse", "--show-toplevel"]))
+const issueNumber = requiredPositiveInteger(args.issue, "issue")
+const action = requiredAction(args.action)
+const config = readControlPlaneConfig()
+
+try {
+  const active = await requestActiveDispatchIntent({
+    request: {
+      action,
+      issueNumber,
+      repository,
+    },
+    token: config.token,
+    url: config.url,
+  })
+  const releasePlan = planDispatchIntentRelease({
+    activeResult: active,
+    force: Boolean(args.force),
+    now: new Date(),
+    ...(args.reason ? { reason: String(args.reason) } : {}),
+  })
+
+  if (!releasePlan.release) {
+    const result = {
+      active,
+      reason: releasePlan.reason,
+      released: false,
+    }
+    if (args.json) {
+      console.log(JSON.stringify(result, null, 2))
+    } else {
+      printSkipped({ active, controlPlaneUrl: config.url, reason: releasePlan.reason })
+    }
+    process.exitCode = 1
+  } else {
+    const finish = await finishDispatchIntent({
+      id: releasePlan.id,
+      request: releasePlan.request,
+      token: config.token,
+      url: config.url,
+    })
+    const result = {
+      active,
+      finish,
+      released: true,
+    }
+    if (args.json) {
+      console.log(JSON.stringify(result, null, 2))
+    } else {
+      printReleased({ controlPlaneUrl: config.url, finish })
+    }
+  }
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error))
+}
+
+function printReleased({ controlPlaneUrl, finish }) {
+  console.log("agent-runner dispatch intent release")
+  console.log(`control plane: ${controlPlaneUrl}`)
+  console.log(`intent: ${finish.intent.id}`)
+  console.log(`status: ${finish.intent.status}`)
+  console.log(`holder: ${finish.intent.resolution?.holder ?? finish.intent.lease.holder}`)
+  if (finish.intent.resolution?.finishedAt) {
+    console.log(`finished: ${finish.intent.resolution.finishedAt}`)
+  }
+  if (finish.intent.resolution?.reason) {
+    console.log(`reason: ${finish.intent.resolution.reason}`)
+  }
+  console.log(`active updated: ${finish.storage.activeUpdated ? "yes" : "no"}`)
+}
+
+function printSkipped({ active, controlPlaneUrl, reason }) {
+  console.log("agent-runner dispatch intent release")
+  console.log(`control plane: ${controlPlaneUrl}`)
+  console.log(`intent: ${active.intent.id}`)
+  console.log(`status: ${active.intent.status}`)
+  console.log(`active: ${active.active ? "yes" : "no"}`)
+  console.log(`holder: ${active.intent.lease.holder}`)
+  console.log(`lease expires: ${active.intent.lease.expiresAt}`)
+  console.log(`release skipped: ${reason}`)
+}
+
+function readControlPlaneConfig() {
+  try {
+    return controlPlaneConfigFromArgs(args)
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error))
+  }
+}
+
+function requiredAction(value) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    fail("missing required --action")
+  }
+
+  const action = value.trim()
+  if (!dispatchableActions.has(action)) {
+    fail(`action ${action} is not dispatchable`)
+  }
+  return action
+}
+
+function requiredPositiveInteger(value, name) {
+  const number = Number(value)
+  if (!Number.isInteger(number) || number < 1) {
+    fail(`invalid ${name}: ${value ?? ""}`)
+  }
+  return number
+}

--- a/scripts/lib/agent-runner-dispatch-release.mjs
+++ b/scripts/lib/agent-runner-dispatch-release.mjs
@@ -1,0 +1,47 @@
+export function planDispatchIntentRelease({
+  activeResult,
+  force = false,
+  now = new Date(),
+  reason,
+}) {
+  const intent = activeResult?.intent
+  if (!intent) {
+    return {
+      release: false,
+      reason: "missing_intent",
+    }
+  }
+
+  if (intent.status !== "leased") {
+    return {
+      intent,
+      release: false,
+      reason: "intent_not_leased",
+    }
+  }
+
+  const expiresAt = Date.parse(intent.lease.expiresAt)
+  const expired = Number.isFinite(expiresAt) && expiresAt <= now.getTime()
+  if (activeResult.active && !force) {
+    return {
+      expired,
+      intent,
+      release: false,
+      reason: "intent_still_active",
+    }
+  }
+
+  return {
+    expired,
+    id: intent.id,
+    intent,
+    release: true,
+    request: {
+      holder: intent.lease.holder,
+      reason:
+        reason?.trim() ||
+        (expired ? "released expired dispatch intent" : "released dispatch intent by operator"),
+      status: "released",
+    },
+  }
+}

--- a/scripts/tests/agent-runner-dispatch-release.test.mjs
+++ b/scripts/tests/agent-runner-dispatch-release.test.mjs
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { planDispatchIntentRelease } from "../lib/agent-runner-dispatch-release.mjs"
+
+describe("agent runner dispatch release helpers", () => {
+  it("builds a release request for expired active dispatch intents", () => {
+    const plan = planDispatchIntentRelease({
+      activeResult: {
+        active: false,
+        intent: dispatchIntent({
+          expiresAt: "2026-05-12T11:59:00.000Z",
+        }),
+      },
+      now: new Date("2026-05-12T12:00:00.000Z"),
+    })
+
+    assert.deepEqual(plan, {
+      expired: true,
+      id: "intent_579",
+      intent: dispatchIntent({
+        expiresAt: "2026-05-12T11:59:00.000Z",
+      }),
+      release: true,
+      request: {
+        holder: "runner:cloudflare",
+        reason: "released expired dispatch intent",
+        status: "released",
+      },
+    })
+  })
+
+  it("refuses active dispatch intents unless forced", () => {
+    const activeResult = {
+      active: true,
+      intent: dispatchIntent({
+        expiresAt: "2026-05-12T12:15:00.000Z",
+      }),
+    }
+
+    assert.deepEqual(
+      planDispatchIntentRelease({
+        activeResult,
+        now: new Date("2026-05-12T12:00:00.000Z"),
+      }),
+      {
+        expired: false,
+        intent: activeResult.intent,
+        release: false,
+        reason: "intent_still_active",
+      },
+    )
+
+    assert.deepEqual(
+      planDispatchIntentRelease({
+        activeResult,
+        force: true,
+        now: new Date("2026-05-12T12:00:00.000Z"),
+        reason: "operator override",
+      }),
+      {
+        expired: false,
+        id: "intent_579",
+        intent: activeResult.intent,
+        release: true,
+        request: {
+          holder: "runner:cloudflare",
+          reason: "operator override",
+          status: "released",
+        },
+      },
+    )
+  })
+
+  it("trusts the server active flag over local lease expiry", () => {
+    const activeResult = {
+      active: true,
+      intent: dispatchIntent({
+        expiresAt: "2026-05-12T11:59:00.000Z",
+      }),
+    }
+
+    assert.deepEqual(
+      planDispatchIntentRelease({
+        activeResult,
+        now: new Date("2026-05-12T12:00:00.000Z"),
+      }),
+      {
+        expired: true,
+        intent: activeResult.intent,
+        release: false,
+        reason: "intent_still_active",
+      },
+    )
+  })
+
+  it("refuses missing or already-terminal intents", () => {
+    assert.deepEqual(planDispatchIntentRelease({ activeResult: {} }), {
+      release: false,
+      reason: "missing_intent",
+    })
+
+    const terminalIntent = dispatchIntent({
+      status: "completed",
+    })
+    assert.deepEqual(
+      planDispatchIntentRelease({
+        activeResult: {
+          active: false,
+          intent: terminalIntent,
+        },
+      }),
+      {
+        intent: terminalIntent,
+        release: false,
+        reason: "intent_not_leased",
+      },
+    )
+  })
+})
+
+function dispatchIntent({ expiresAt = "2026-05-12T12:15:00.000Z", status = "leased" } = {}) {
+  return {
+    createdAt: "2026-05-12T12:00:00.000Z",
+    id: "intent_579",
+    lease: {
+      acquiredAt: "2026-05-12T12:00:00.000Z",
+      expiresAt,
+      holder: "runner:cloudflare",
+      ttlSeconds: 900,
+    },
+    plan: {
+      action: "sync-pr",
+      command: ["pnpm", "agent:queue:sync-pr"],
+      issue: {
+        number: 579,
+        repository: "voyantjs/voyant",
+        title: "Test issue",
+        url: "https://github.com/voyantjs/voyant/issues/579",
+      },
+      reason: "ready",
+      repository: "voyantjs/voyant",
+      requiresMutation: true,
+    },
+    source: {
+      acceptedAt: "2026-05-12T11:59:00.000Z",
+      recommendationCount: 1,
+      repository: "voyantjs/voyant",
+      type: "latest_tick_snapshot",
+    },
+    status,
+  }
+}


### PR DESCRIPTION
## Summary
- Add `agent:queue:release-dispatch` to release expired active dispatch intents by repository, issue, and action.
- Refuse still-active leases unless `--force` is passed, then finish the intent as `released` using the stored holder.
- Cover the release planner with tests and document the operator flow.

## Verification
- `node --test scripts/tests/agent-runner-dispatch-release.test.mjs scripts/tests/agent-runner-control-plane.test.mjs`
- `pnpm agent:queue:release-dispatch -- --help`
- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- pre-commit hook
- pre-push hook full test lane