### PR TITLE
feat(agent-runner): add deployed status command

### DIFF
--- a/apps/agent-runner/README.md
+++ b/apps/agent-runner/README.md
@@ -74,6 +74,16 @@ The command reads `AGENT_CONTROL_PLANE_URL`, `AGENT_CONTROL_PLANE_TOKEN`,
 `AGENT_RUNNER_URL`, and `AGENT_RUNNER_TOKEN`, calls both capability endpoints,
 checks the runner supervisor status endpoint, and reports persistence and
 execution mode without printing token values.
+
+For steady-state operator checks without a smoke tick:
+
+```bash
+pnpm agent:queue:deployed-status -- --repo voyantjs/voyant
+```
+
+The status command uses the same environment, checks the deployed control-plane
+and runner endpoints, and prints the latest plus recent runner supervisor
+ticks.
 Pass `--smoke-tick` after submitting at least one queue snapshot to validate
 that the deployed runner can call the control plane's read-only dispatch-plan
 path:

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -422,6 +422,11 @@ It reads `AGENT_CONTROL_PLANE_URL`, `AGENT_CONTROL_PLANE_TOKEN`,
 `AGENT_RUNNER_URL`, and `AGENT_RUNNER_TOKEN`, calls both `/api/capabilities`
 endpoints, and reports persistence and execution mode without printing token
 values.
+For day-to-day operator checks after deployment, run
+`pnpm agent:queue:deployed-status -- --repo <owner/name>`. It reads the same
+environment, reports control-plane and runner readiness, and prints the latest
+plus recent runner supervisor ticks without performing a smoke tick or leasing
+work.
 After submitting at least one queue snapshot, pass
 `--smoke-tick --repo <owner/name>` to make the deployed runner perform a
 dry-run supervisor tick that validates the control-plane read path without

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1396,6 +1396,10 @@ Verification:
   printing bearer tokens. After at least one queue snapshot is stored,
   `--smoke-tick` makes the deployed runner call the control plane's read-only
   dispatch-plan path without leasing work.
+- Operators can use `pnpm agent:queue:deployed-status -- --repo <owner/name>`
+  for the steady-state read-only view. It checks the same deployed endpoints
+  and summarizes the runner supervisor's latest and recent ticks without
+  triggering a smoke tick.
 
 ## Open Questions
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "verify:fast": "pnpm lint:changed && pnpm verify:agent-quality:changed && pnpm verify:ui-components-barrel && pnpm verify:native-date-inputs && pnpm verify:raw-minor-unit-labels && pnpm typecheck:affected && pnpm test:affected && pnpm verify:architecture",
     "verify:full": "pnpm lint && pnpm verify:agent-quality && pnpm verify:ui-components-barrel && pnpm verify:native-date-inputs && pnpm verify:raw-minor-unit-labels && pnpm typecheck && pnpm test && pnpm verify:architecture && pnpm build && pnpm verify:package-exports && pnpm verify:publish-tarballs && pnpm i18n:check",
     "agent:queue:doctor": "node scripts/agent-runner-doctor.mjs",
+    "agent:queue:deployed-status": "node scripts/agent-runner-deployed-status.mjs",
     "agent:queue:deployment-doctor": "node scripts/agent-runner-deployment-doctor.mjs",
     "agent:queue:dry-run": "node scripts/agent-runner-dry-run.mjs",
     "agent:queue:events": "node scripts/agent-runner-events.mjs",

--- a/scripts/agent-runner-deployed-status.mjs
+++ b/scripts/agent-runner-deployed-status.mjs
@@ -1,0 +1,104 @@
+import { currentRepositoryFromOrigin, fail, parseArgs, runGit } from "./lib/agent-project-queue.mjs"
+import {
+  buildDeployedStatusReport,
+  latestRunnerSupervisorTick,
+  recentRunnerSupervisorTicks,
+} from "./lib/agent-runner-deployed-status.mjs"
+import { maybePrintHelp, repositoryOptions } from "./lib/agent-runner-help.mjs"
+
+const args = parseArgs(process.argv.slice(2))
+maybePrintHelp(args, {
+  command: "agent:queue:deployed-status",
+  summary: "Inspect deployed control-plane and runner supervisor status.",
+  usage: "pnpm agent:queue:deployed-status -- [--json] [--repo <owner/name>]",
+  options: [
+    ["--control-plane-url <url>", "Control-plane base URL. Defaults to AGENT_CONTROL_PLANE_URL."],
+    ["AGENT_CONTROL_PLANE_TOKEN", "Bearer token environment variable used for control-plane APIs."],
+    ["--runner-url <url>", "Runner app base URL. Defaults to AGENT_RUNNER_URL."],
+    ["--runner-token <token>", "Runner app bearer token. Defaults to AGENT_RUNNER_TOKEN."],
+    [
+      "--limit <n>",
+      "Number of recent supervisor ticks to include. Defaults to 5 and is clamped by the deployed app.",
+    ],
+    ["--json", "Print machine-readable JSON."],
+    ...repositoryOptions,
+  ],
+})
+
+const repoRoot = runGit(["rev-parse", "--show-toplevel"])
+const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
+const limit = positiveIntegerArg(args.limit, "limit", 5)
+
+try {
+  const report = await buildDeployedStatusReport({
+    args,
+    limit,
+    repository,
+  })
+
+  if (args.json) {
+    console.log(JSON.stringify(report, null, 2))
+  } else {
+    printHumanSummary(report)
+  }
+
+  process.exitCode = report.ok ? 0 : 1
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error))
+}
+
+function printHumanSummary(report) {
+  console.log(`agent-runner deployed status: ${report.ok ? "OK" : "DEGRADED"}`)
+  console.log(`repository: ${report.repository}`)
+  console.log(`recent tick limit: ${report.limit}`)
+  console.log("")
+
+  for (const check of report.checks) {
+    console.log(`${check.ok ? "OK" : "FAIL"} ${check.name}`)
+    console.log(`  ${check.detail}`)
+  }
+
+  printRunnerSupervisorDetails(report.runner?.supervisorStatus)
+}
+
+function printRunnerSupervisorDetails(status) {
+  if (!status) return
+
+  const storage = status.supervisorTicks?.storage
+  const latest = latestRunnerSupervisorTick(status)
+  const recent = recentRunnerSupervisorTicks(status)
+
+  console.log("")
+  console.log("Runner supervisor:")
+  console.log(`  storage configured: ${String(storage?.configured ?? "unknown")}`)
+  console.log(`  persistence: ${storage?.persistence ?? "unknown"}`)
+  if (latest) {
+    console.log(`  latest: ${latest.recordedAt ?? "unknown"} ${latest.reason ?? "unknown"}`)
+    console.log(`  latest leased: ${String(latest.leased ?? "unknown")}`)
+    if (latest.intentId) {
+      console.log(`  latest intent: ${latest.intentId}`)
+    }
+  } else {
+    console.log("  latest: none")
+  }
+
+  if (recent.length === 0) return
+
+  console.log("  recent:")
+  for (const tick of recent) {
+    const intent = tick.intentId ? ` intent=${tick.intentId}` : ""
+    console.log(
+      `  - ${tick.recordedAt ?? "unknown"} ${tick.reason ?? "unknown"} leased=${String(tick.leased ?? "unknown")}${intent}`,
+    )
+  }
+}
+
+function positiveIntegerArg(value, name, fallback) {
+  if (value === undefined) return fallback
+
+  const number = Number(value)
+  if (!Number.isInteger(number) || number < 1) {
+    fail(`invalid ${name}: ${value}`)
+  }
+  return number
+}

--- a/scripts/lib/agent-runner-deployed-status.mjs
+++ b/scripts/lib/agent-runner-deployed-status.mjs
@@ -1,0 +1,171 @@
+import {
+  controlPlaneConfigFromArgs,
+  requestControlPlaneCapabilities,
+} from "./agent-runner-control-plane.mjs"
+import {
+  requestRunnerAppCapabilities,
+  requestRunnerAppSupervisorStatus,
+  runnerAppConfigFromArgs,
+  summarizeControlPlaneCapabilities,
+  summarizeRunnerAppCapabilities,
+  summarizeRunnerSupervisorStatus,
+} from "./agent-runner-deployment-doctor.mjs"
+
+export async function buildDeployedStatusReport({
+  args = {},
+  env = process.env,
+  fetchImpl = fetch,
+  limit = 5,
+  repository,
+}) {
+  const report = {
+    checks: [],
+    controlPlane: null,
+    limit,
+    ok: false,
+    repository,
+    runner: null,
+  }
+
+  await readControlPlaneStatus({ args, env, fetchImpl, report })
+  await readRunnerStatus({ args, env, fetchImpl, limit, repository, report })
+
+  report.ok = report.checks.every((check) => check.ok)
+  return report
+}
+
+export function latestRunnerSupervisorTick(status) {
+  const latest = status?.supervisorTicks?.latest
+  if (!latest) return null
+
+  return summarizeRunnerTick(latest)
+}
+
+export function recentRunnerSupervisorTicks(status) {
+  const recent = status?.supervisorTicks?.recent
+  if (!Array.isArray(recent)) return []
+
+  return recent.map(summarizeRunnerTick)
+}
+
+async function readControlPlaneStatus({ args, env, fetchImpl, report }) {
+  let config
+  try {
+    config = controlPlaneConfigFromArgs(args, env)
+  } catch (error) {
+    report.checks.push({
+      detail: errorMessage(error),
+      name: "control plane configuration",
+      ok: false,
+    })
+    return
+  }
+
+  report.controlPlane = {
+    endpoint: config.url,
+  }
+  report.checks.push({
+    detail: `Using ${config.url}; token configured.`,
+    name: "control plane configuration",
+    ok: true,
+  })
+
+  try {
+    const capabilities = await requestControlPlaneCapabilities({
+      fetchImpl,
+      token: config.token,
+      url: config.url,
+    })
+    report.controlPlane.capabilities = capabilities
+    report.checks.push({
+      name: "control plane capabilities",
+      ...summarizeControlPlaneCapabilities(capabilities),
+    })
+  } catch (error) {
+    report.checks.push({
+      detail: errorMessage(error),
+      name: "control plane capabilities",
+      ok: false,
+    })
+  }
+}
+
+async function readRunnerStatus({ args, env, fetchImpl, limit, repository, report }) {
+  let config
+  try {
+    config = runnerAppConfigFromArgs(args, env)
+  } catch (error) {
+    report.checks.push({
+      detail: errorMessage(error),
+      name: "runner app configuration",
+      ok: false,
+    })
+    return
+  }
+
+  report.runner = {
+    endpoint: config.url,
+  }
+  report.checks.push({
+    detail: `Using ${config.url}; token configured.`,
+    name: "runner app configuration",
+    ok: true,
+  })
+
+  try {
+    const capabilities = await requestRunnerAppCapabilities({
+      fetchImpl,
+      token: config.token,
+      url: config.url,
+    })
+    report.runner.capabilities = capabilities
+    report.checks.push({
+      name: "runner app capabilities",
+      ...summarizeRunnerAppCapabilities(capabilities),
+    })
+  } catch (error) {
+    report.checks.push({
+      detail: errorMessage(error),
+      name: "runner app capabilities",
+      ok: false,
+    })
+  }
+
+  try {
+    const supervisorStatus = await requestRunnerAppSupervisorStatus({
+      fetchImpl,
+      limit,
+      repository,
+      token: config.token,
+      url: config.url,
+    })
+    report.runner.supervisorStatus = supervisorStatus
+    report.checks.push({
+      name: "runner app supervisor status",
+      ...summarizeRunnerSupervisorStatus(supervisorStatus),
+    })
+  } catch (error) {
+    report.checks.push({
+      detail: errorMessage(error),
+      name: "runner app supervisor status",
+      ok: false,
+    })
+  }
+}
+
+function summarizeRunnerTick(record) {
+  const result = record.result ?? {}
+  const intent = result.intent ?? result.activeIntent
+
+  return {
+    id: record.id ?? null,
+    intentId: intent?.id ?? null,
+    leased: result.leased ?? null,
+    reason: result.reason ?? null,
+    recordedAt: record.recordedAt ?? null,
+  }
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/scripts/tests/agent-runner-deployed-status.test.mjs
+++ b/scripts/tests/agent-runner-deployed-status.test.mjs
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import {
+  buildDeployedStatusReport,
+  latestRunnerSupervisorTick,
+  recentRunnerSupervisorTicks,
+} from "../lib/agent-runner-deployed-status.mjs"
+
+describe("agent runner deployed status helpers", () => {
+  it("builds a read-only deployed status report", async () => {
+    const calls = []
+    const report = await buildDeployedStatusReport({
+      args: {
+        controlPlaneUrl: "https://control.example.com/",
+        runnerUrl: "https://runner.example.com/",
+      },
+      env: {
+        AGENT_CONTROL_PLANE_TOKEN: "control-token",
+        AGENT_RUNNER_TOKEN: "runner-token",
+      },
+      fetchImpl: async (url, init) => {
+        calls.push({ init, url })
+        return jsonResponse(responseForUrl(url))
+      },
+      limit: 2,
+      repository: "voyantjs/voyant",
+    })
+
+    assert.equal(report.ok, true)
+    assert.equal(report.controlPlane.endpoint, "https://control.example.com")
+    assert.equal(report.runner.endpoint, "https://runner.example.com")
+    assert.equal(report.runner.supervisorStatus.repository, "voyantjs/voyant")
+    assert.deepEqual(
+      report.checks.map((check) => [check.name, check.ok]),
+      [
+        ["control plane configuration", true],
+        ["control plane capabilities", true],
+        ["runner app configuration", true],
+        ["runner app capabilities", true],
+        ["runner app supervisor status", true],
+      ],
+    )
+    assert.deepEqual(
+      calls.map((call) => [call.url, call.init.headers.authorization]),
+      [
+        ["https://control.example.com/api/capabilities", "Bearer control-token"],
+        ["https://runner.example.com/api/capabilities", "Bearer runner-token"],
+        [
+          "https://runner.example.com/api/supervisor/status?repository=voyantjs%2Fvoyant&limit=2",
+          "Bearer runner-token",
+        ],
+      ],
+    )
+  })
+
+  it("reports missing configuration without calling deployed apps", async () => {
+    const calls = []
+    const report = await buildDeployedStatusReport({
+      args: {},
+      env: {},
+      fetchImpl: async (url, init) => {
+        calls.push({ init, url })
+        return jsonResponse({})
+      },
+      repository: "voyantjs/voyant",
+    })
+
+    assert.equal(report.ok, false)
+    assert.equal(calls.length, 0)
+    assert.deepEqual(
+      report.checks.map((check) => [check.name, check.ok]),
+      [
+        ["control plane configuration", false],
+        ["runner app configuration", false],
+      ],
+    )
+  })
+
+  it("summarizes latest and recent runner supervisor ticks", () => {
+    const status = {
+      supervisorTicks: {
+        latest: runnerTick({
+          id: "tick_latest",
+          intentId: "intent_579",
+          reason: "leased_dispatch_intent",
+        }),
+        recent: [
+          runnerTick({
+            id: "tick_recent",
+            leased: false,
+            reason: "no_dispatch_plan",
+          }),
+        ],
+      },
+    }
+
+    assert.deepEqual(latestRunnerSupervisorTick(status), {
+      id: "tick_latest",
+      intentId: "intent_579",
+      leased: true,
+      reason: "leased_dispatch_intent",
+      recordedAt: "2026-05-12T12:00:00.000Z",
+    })
+    assert.deepEqual(recentRunnerSupervisorTicks(status), [
+      {
+        id: "tick_recent",
+        intentId: null,
+        leased: false,
+        reason: "no_dispatch_plan",
+        recordedAt: "2026-05-12T12:00:00.000Z",
+      },
+    ])
+  })
+})
+
+function responseForUrl(url) {
+  if (url === "https://control.example.com/api/capabilities") {
+    return {
+      dispatchIntentContracts: {
+        latestSnapshotLease: {
+          activeRead: true,
+          persistence: "leased",
+        },
+      },
+      service: "agent-control-plane",
+      snapshotContracts: {
+        tick: {
+          persistence: "latest",
+        },
+      },
+    }
+  }
+
+  if (url === "https://runner.example.com/api/capabilities") {
+    return {
+      execution: {
+        enabled: true,
+        mode: "lease-only",
+      },
+      service: "agent-runner",
+      supervisorTicks: {
+        persistence: "latest",
+      },
+    }
+  }
+
+  if (
+    url === "https://runner.example.com/api/supervisor/status?repository=voyantjs%2Fvoyant&limit=2"
+  ) {
+    return {
+      capabilities: {
+        execution: {
+          enabled: true,
+          mode: "lease-only",
+        },
+      },
+      repository: "voyantjs/voyant",
+      service: "agent-runner",
+      supervisorTicks: {
+        latest: runnerTick({ id: "tick_latest" }),
+        recent: [runnerTick({ id: "tick_recent" })],
+        storage: {
+          configured: true,
+          persistence: "latest",
+        },
+      },
+    }
+  }
+
+  throw new Error(`unexpected URL: ${url}`)
+}
+
+function runnerTick({ id, intentId, leased = true, reason = "dry_run" } = {}) {
+  return {
+    id,
+    recordedAt: "2026-05-12T12:00:00.000Z",
+    result: {
+      ...(intentId ? { intent: { id: intentId } } : {}),
+      leased,
+      reason,
+    },
+  }
+}
+
+function jsonResponse(body, init = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    ...init,
+  })
+}


### PR DESCRIPTION
## Summary
- Add `agent:queue:deployed-status` for read-only control-plane and runner supervisor status checks.
- Reuse deployed endpoint helpers to report capabilities, supervisor storage, latest tick, and recent ticks without running a smoke tick.
- Cover the report builder with tests and document the operator flow.

## Verification
- `node --test scripts/tests/agent-runner-deployed-status.test.mjs scripts/tests/agent-runner-deployment-doctor.test.mjs`
- `pnpm agent:queue:deployed-status -- --help`
- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- pre-commit hook
- pre-push hook full test lane