### PR TITLE
feat(agent-runner): surface deployed queue snapshots

### DIFF
--- a/apps/agent-runner/README.md
+++ b/apps/agent-runner/README.md
@@ -82,8 +82,9 @@ pnpm agent:queue:deployed-status -- --repo voyantjs/voyant
 ```
 
 The status command uses the same environment, checks the deployed control-plane
-and runner endpoints, and prints the latest plus recent runner supervisor
-ticks.
+and runner endpoints, and prints the latest plus recent control-plane queue
+snapshots and runner supervisor ticks. Add `--issue <number> --action <name>`
+to include the active dispatch pointer for one lifecycle action.
 Pass `--smoke-tick` after submitting at least one queue snapshot to validate
 that the deployed runner can call the control plane's read-only dispatch-plan
 path:

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -425,8 +425,10 @@ values.
 For day-to-day operator checks after deployment, run
 `pnpm agent:queue:deployed-status -- --repo <owner/name>`. It reads the same
 environment, reports control-plane and runner readiness, and prints the latest
-plus recent runner supervisor ticks without performing a smoke tick or leasing
-work.
+plus recent control-plane queue snapshots and runner supervisor ticks without
+performing a smoke tick or leasing work. Pass `--issue <number> --action
+<name>` when you also need to inspect the active dispatch pointer for a specific
+lifecycle action.
 After submitting at least one queue snapshot, pass
 `--smoke-tick --repo <owner/name>` to make the deployed runner perform a
 dry-run supervisor tick that validates the control-plane read path without

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1398,8 +1398,10 @@ Verification:
   dispatch-plan path without leasing work.
 - Operators can use `pnpm agent:queue:deployed-status -- --repo <owner/name>`
   for the steady-state read-only view. It checks the same deployed endpoints
-  and summarizes the runner supervisor's latest and recent ticks without
-  triggering a smoke tick.
+  and summarizes the control plane's latest queue snapshots plus the runner
+  supervisor's latest and recent ticks without triggering a smoke tick. Pass
+  `--issue <number> --action <name>` to include the active dispatch pointer for
+  a specific lifecycle action.
 
 ## Open Questions
 

--- a/scripts/agent-runner-deployed-status.mjs
+++ b/scripts/agent-runner-deployed-status.mjs
@@ -1,9 +1,13 @@
 import { currentRepositoryFromOrigin, fail, parseArgs, runGit } from "./lib/agent-project-queue.mjs"
 import {
   buildDeployedStatusReport,
+  latestControlPlaneTickSnapshot,
   latestRunnerSupervisorTick,
+  recentControlPlaneTickSnapshots,
   recentRunnerSupervisorTicks,
+  summarizeActiveDispatchIntent,
 } from "./lib/agent-runner-deployed-status.mjs"
+import { dispatchableActions } from "./lib/agent-runner-dispatch.mjs"
 import { maybePrintHelp, repositoryOptions } from "./lib/agent-runner-help.mjs"
 
 const args = parseArgs(process.argv.slice(2))
@@ -18,7 +22,12 @@ maybePrintHelp(args, {
     ["--runner-token <token>", "Runner app bearer token. Defaults to AGENT_RUNNER_TOKEN."],
     [
       "--limit <n>",
-      "Number of recent supervisor ticks to include. Defaults to 5 and is clamped by the deployed app.",
+      "Number of recent queue snapshots and supervisor ticks to include. Defaults to 5 and is clamped by deployed apps.",
+    ],
+    ["--issue <number>", "Optional issue number for an active dispatch pointer lookup."],
+    [
+      "--action <name>",
+      `Optional lifecycle action for an active dispatch pointer lookup. Allowed: ${Array.from(dispatchableActions).join(", ")}.`,
     ],
     ["--json", "Print machine-readable JSON."],
     ...repositoryOptions,
@@ -28,9 +37,11 @@ maybePrintHelp(args, {
 const repoRoot = runGit(["rev-parse", "--show-toplevel"])
 const repository = args.repo ?? currentRepositoryFromOrigin(repoRoot)
 const limit = positiveIntegerArg(args.limit, "limit", 5)
+const activeDispatchRequest = optionalActiveDispatchRequest(args, repository)
 
 try {
   const report = await buildDeployedStatusReport({
+    activeDispatchRequest,
     args,
     limit,
     repository,
@@ -58,7 +69,63 @@ function printHumanSummary(report) {
     console.log(`  ${check.detail}`)
   }
 
+  printControlPlaneSnapshotDetails(report.controlPlane?.recentTickSnapshots)
+  printActiveDispatchDetails(report.controlPlane?.activeDispatch)
   printRunnerSupervisorDetails(report.runner?.supervisorStatus)
+}
+
+function printControlPlaneSnapshotDetails(snapshotHistory) {
+  if (!snapshotHistory) return
+
+  const latest = latestControlPlaneTickSnapshot(snapshotHistory)
+  const recent = recentControlPlaneTickSnapshots(snapshotHistory)
+
+  console.log("")
+  console.log("Control-plane queue snapshots:")
+  if (latest) {
+    console.log(`  latest accepted: ${latest.acceptedAt ?? "unknown"}`)
+    console.log(`  latest recommendations: ${String(latest.recommendationCount ?? "unknown")}`)
+    console.log(
+      `  latest dispatchable: ${String(latest.dispatchableRecommendationCount ?? "unknown")}`,
+    )
+    if (latest.firstDispatchableIssueNumber) {
+      console.log(
+        `  first dispatchable: #${latest.firstDispatchableIssueNumber} ${latest.firstDispatchableAction ?? "unknown"}`,
+      )
+    }
+  } else {
+    console.log("  latest: none")
+  }
+
+  if (recent.length === 0) return
+
+  console.log("  recent:")
+  for (const snapshot of recent) {
+    console.log(
+      `  - ${snapshot.acceptedAt ?? "unknown"} recommendations=${String(snapshot.recommendationCount ?? "unknown")} dispatchable=${String(snapshot.dispatchableRecommendationCount ?? "unknown")}`,
+    )
+  }
+}
+
+function printActiveDispatchDetails(activeDispatch) {
+  if (!activeDispatch) return
+
+  const summary = summarizeActiveDispatchIntent(activeDispatch)
+
+  console.log("")
+  console.log("Control-plane active dispatch:")
+  if (!summary.found) {
+    console.log("  intent: none")
+    return
+  }
+
+  console.log(`  intent: ${summary.intentId ?? "unknown"}`)
+  console.log(`  issue: #${summary.issueNumber ?? "unknown"}`)
+  console.log(`  action: ${summary.action ?? "unknown"}`)
+  console.log(`  status: ${summary.status ?? "unknown"}`)
+  console.log(`  active: ${String(summary.active)}`)
+  console.log(`  holder: ${summary.holder ?? "unknown"}`)
+  console.log(`  lease expires: ${summary.expiresAt ?? "unknown"}`)
 }
 
 function printRunnerSupervisorDetails(status) {
@@ -101,4 +168,25 @@ function positiveIntegerArg(value, name, fallback) {
     fail(`invalid ${name}: ${value}`)
   }
   return number
+}
+
+function optionalActiveDispatchRequest(args, repository) {
+  const issueProvided = args.issue !== undefined
+  const actionProvided = args.action !== undefined
+  if (!issueProvided && !actionProvided) return undefined
+  if (!issueProvided || !actionProvided) {
+    fail("active dispatch lookup requires both --issue and --action")
+  }
+
+  const issueNumber = positiveIntegerArg(args.issue, "issue")
+  const action = String(args.action).trim()
+  if (!dispatchableActions.has(action)) {
+    fail(`action ${action} is not dispatchable`)
+  }
+
+  return {
+    action,
+    issueNumber,
+    repository,
+  }
 }

--- a/scripts/lib/agent-runner-deployed-status.mjs
+++ b/scripts/lib/agent-runner-deployed-status.mjs
@@ -1,6 +1,8 @@
 import {
   controlPlaneConfigFromArgs,
+  requestActiveDispatchIntent,
   requestControlPlaneCapabilities,
+  requestRecentTickSnapshots,
 } from "./agent-runner-control-plane.mjs"
 import {
   requestRunnerAppCapabilities,
@@ -15,6 +17,7 @@ export async function buildDeployedStatusReport({
   args = {},
   env = process.env,
   fetchImpl = fetch,
+  activeDispatchRequest,
   limit = 5,
   repository,
 }) {
@@ -27,7 +30,15 @@ export async function buildDeployedStatusReport({
     runner: null,
   }
 
-  await readControlPlaneStatus({ args, env, fetchImpl, report })
+  await readControlPlaneStatus({
+    activeDispatchRequest,
+    args,
+    env,
+    fetchImpl,
+    limit,
+    repository,
+    report,
+  })
   await readRunnerStatus({ args, env, fetchImpl, limit, repository, report })
 
   report.ok = report.checks.every((check) => check.ok)
@@ -48,7 +59,50 @@ export function recentRunnerSupervisorTicks(status) {
   return recent.map(summarizeRunnerTick)
 }
 
-async function readControlPlaneStatus({ args, env, fetchImpl, report }) {
+export function latestControlPlaneTickSnapshot(snapshotHistory) {
+  const latest = snapshotHistory?.records?.[0]
+  if (!latest) return null
+
+  return summarizeTickSnapshot(latest)
+}
+
+export function recentControlPlaneTickSnapshots(snapshotHistory) {
+  const recent = snapshotHistory?.records
+  if (!Array.isArray(recent)) return []
+
+  return recent.map(summarizeTickSnapshot)
+}
+
+export function summarizeActiveDispatchIntent(result) {
+  const intent = result?.intent
+  if (!intent) {
+    return {
+      active: false,
+      found: false,
+    }
+  }
+
+  return {
+    action: intent.plan?.action ?? null,
+    active: Boolean(result.active),
+    expiresAt: intent.lease?.expiresAt ?? null,
+    found: true,
+    holder: intent.lease?.holder ?? null,
+    intentId: intent.id ?? null,
+    issueNumber: intent.plan?.issue?.number ?? null,
+    status: intent.status ?? null,
+  }
+}
+
+async function readControlPlaneStatus({
+  activeDispatchRequest,
+  args,
+  env,
+  fetchImpl,
+  limit,
+  repository,
+  report,
+}) {
   let config
   try {
     config = controlPlaneConfigFromArgs(args, env)
@@ -85,6 +139,68 @@ async function readControlPlaneStatus({ args, env, fetchImpl, report }) {
     report.checks.push({
       detail: errorMessage(error),
       name: "control plane capabilities",
+      ok: false,
+    })
+  }
+
+  try {
+    const recentTickSnapshots = await requestRecentTickSnapshots({
+      fetchImpl,
+      limit,
+      repository,
+      token: config.token,
+      url: config.url,
+    })
+    report.controlPlane.recentTickSnapshots = recentTickSnapshots
+    const latest = latestControlPlaneTickSnapshot(recentTickSnapshots)
+    report.checks.push({
+      detail: latest
+        ? `latest accepted: ${latest.acceptedAt}; recommendations: ${String(latest.recommendationCount)}; dispatchable: ${String(latest.dispatchableRecommendationCount)}`
+        : "no persisted queue snapshots found",
+      name: "control plane queue snapshots",
+      ok: true,
+    })
+  } catch (error) {
+    report.checks.push({
+      detail: errorMessage(error),
+      name: "control plane queue snapshots",
+      ok: false,
+    })
+  }
+
+  if (!activeDispatchRequest) return
+
+  try {
+    const activeDispatch = await requestActiveDispatchIntent({
+      fetchImpl,
+      request: activeDispatchRequest,
+      token: config.token,
+      url: config.url,
+    })
+    report.controlPlane.activeDispatch = activeDispatch
+    const summary = summarizeActiveDispatchIntent(activeDispatch)
+    report.checks.push({
+      detail: `intent: ${summary.intentId}; status: ${summary.status}; active: ${String(summary.active)}; holder: ${summary.holder ?? "unknown"}`,
+      name: "control plane active dispatch",
+      ok: true,
+    })
+  } catch (error) {
+    if (error?.status === 404) {
+      report.controlPlane.activeDispatch = {
+        active: false,
+        intent: null,
+      }
+      report.checks.push({
+        detail: `no active dispatch intent for #${activeDispatchRequest.issueNumber} ${activeDispatchRequest.action}`,
+        name: "control plane active dispatch",
+        ok: true,
+      })
+      return
+    }
+
+    report.checks.push({
+      detail: errorMessage(error),
+      name: "control plane active dispatch",
       ok: false,
     })
   }
@@ -163,6 +279,16 @@ function summarizeRunnerTick(record) {
     leased: result.leased ?? null,
     reason: result.reason ?? null,
     recordedAt: record.recordedAt ?? null,
+  }
+}
+
+function summarizeTickSnapshot(record) {
+  return {
+    acceptedAt: record.acceptedAt ?? null,
+    dispatchableRecommendationCount: record.summary?.dispatchableRecommendationCount ?? null,
+    firstDispatchableAction: record.summary?.firstDispatchableAction ?? null,
+    firstDispatchableIssueNumber: record.summary?.firstDispatchableIssueNumber ?? null,
+    recommendationCount: record.summary?.recommendationCount ?? null,
   }
 }
 

--- a/scripts/tests/agent-runner-deployed-status.test.mjs
+++ b/scripts/tests/agent-runner-deployed-status.test.mjs
@@ -3,8 +3,11 @@ import { describe, it } from "node:test"
 
 import {
   buildDeployedStatusReport,
+  latestControlPlaneTickSnapshot,
   latestRunnerSupervisorTick,
+  recentControlPlaneTickSnapshots,
   recentRunnerSupervisorTicks,
+  summarizeActiveDispatchIntent,
 } from "../lib/agent-runner-deployed-status.mjs"
 
 describe("agent runner deployed status helpers", () => {
@@ -23,12 +26,19 @@ describe("agent runner deployed status helpers", () => {
         calls.push({ init, url })
         return jsonResponse(responseForUrl(url))
       },
+      activeDispatchRequest: {
+        action: "remote-bootstrap",
+        issueNumber: 579,
+        repository: "voyantjs/voyant",
+      },
       limit: 2,
       repository: "voyantjs/voyant",
     })
 
     assert.equal(report.ok, true)
     assert.equal(report.controlPlane.endpoint, "https://control.example.com")
+    assert.equal(report.controlPlane.recentTickSnapshots.records.length, 1)
+    assert.equal(report.controlPlane.activeDispatch.intent.id, "intent_579")
     assert.equal(report.runner.endpoint, "https://runner.example.com")
     assert.equal(report.runner.supervisorStatus.repository, "voyantjs/voyant")
     assert.deepEqual(
@@ -36,6 +46,8 @@ describe("agent runner deployed status helpers", () => {
       [
         ["control plane configuration", true],
         ["control plane capabilities", true],
+        ["control plane queue snapshots", true],
+        ["control plane active dispatch", true],
         ["runner app configuration", true],
         ["runner app capabilities", true],
         ["runner app supervisor status", true],
@@ -45,6 +57,14 @@ describe("agent runner deployed status helpers", () => {
       calls.map((call) => [call.url, call.init.headers.authorization]),
       [
         ["https://control.example.com/api/capabilities", "Bearer control-token"],
+        [
+          "https://control.example.com/api/tick-snapshots/recent?repository=voyantjs%2Fvoyant&limit=2",
+          "Bearer control-token",
+        ],
+        [
+          "https://control.example.com/api/dispatch-intents/active?action=remote-bootstrap&issueNumber=579&repository=voyantjs%2Fvoyant",
+          "Bearer control-token",
+        ],
         ["https://runner.example.com/api/capabilities", "Bearer runner-token"],
         [
           "https://runner.example.com/api/supervisor/status?repository=voyantjs%2Fvoyant&limit=2",
@@ -52,6 +72,38 @@ describe("agent runner deployed status helpers", () => {
         ],
       ],
     )
+  })
+
+  it("treats a missing active dispatch lookup as an empty status", async () => {
+    const report = await buildDeployedStatusReport({
+      args: {
+        controlPlaneUrl: "https://control.example.com/",
+        runnerUrl: "https://runner.example.com/",
+      },
+      env: {
+        AGENT_CONTROL_PLANE_TOKEN: "control-token",
+        AGENT_RUNNER_TOKEN: "runner-token",
+      },
+      fetchImpl: async (url) => {
+        if (url.includes("/api/dispatch-intents/active")) {
+          return jsonResponse({ error: "dispatch_intent_not_found" }, { status: 404 })
+        }
+        return jsonResponse(responseForUrl(url))
+      },
+      activeDispatchRequest: {
+        action: "remote-bootstrap",
+        issueNumber: 579,
+        repository: "voyantjs/voyant",
+      },
+      limit: 2,
+      repository: "voyantjs/voyant",
+    })
+
+    assert.equal(report.ok, true)
+    assert.deepEqual(summarizeActiveDispatchIntent(report.controlPlane.activeDispatch), {
+      active: false,
+      found: false,
+    })
   })
 
   it("reports missing configuration without calling deployed apps", async () => {
@@ -75,6 +127,31 @@ describe("agent runner deployed status helpers", () => {
         ["runner app configuration", false],
       ],
     )
+  })
+
+  it("summarizes latest and recent control-plane snapshots", () => {
+    const history = {
+      records: [
+        queueSnapshot({
+          acceptedAt: "2026-05-12T12:00:00.000Z",
+          dispatchableRecommendationCount: 1,
+          firstDispatchableAction: "remote-bootstrap",
+          firstDispatchableIssueNumber: 579,
+          recommendationCount: 3,
+        }),
+      ],
+    }
+
+    const expected = {
+      acceptedAt: "2026-05-12T12:00:00.000Z",
+      dispatchableRecommendationCount: 1,
+      firstDispatchableAction: "remote-bootstrap",
+      firstDispatchableIssueNumber: 579,
+      recommendationCount: 3,
+    }
+
+    assert.deepEqual(latestControlPlaneTickSnapshot(history), expected)
+    assert.deepEqual(recentControlPlaneTickSnapshots(history), [expected])
   })
 
   it("summarizes latest and recent runner supervisor ticks", () => {
@@ -132,6 +209,33 @@ function responseForUrl(url) {
     }
   }
 
+  if (
+    url ===
+    "https://control.example.com/api/tick-snapshots/recent?repository=voyantjs%2Fvoyant&limit=2"
+  ) {
+    return {
+      records: [
+        queueSnapshot({
+          dispatchableRecommendationCount: 1,
+          firstDispatchableAction: "remote-bootstrap",
+          firstDispatchableIssueNumber: 579,
+          recommendationCount: 3,
+        }),
+      ],
+      repository: "voyantjs/voyant",
+    }
+  }
+
+  if (
+    url ===
+    "https://control.example.com/api/dispatch-intents/active?action=remote-bootstrap&issueNumber=579&repository=voyantjs%2Fvoyant"
+  ) {
+    return {
+      active: true,
+      intent: dispatchIntent(),
+    }
+  }
+
   if (url === "https://runner.example.com/api/capabilities") {
     return {
       execution: {
@@ -169,6 +273,41 @@ function responseForUrl(url) {
   }
 
   throw new Error(`unexpected URL: ${url}`)
+}
+
+function dispatchIntent() {
+  return {
+    id: "intent_579",
+    lease: {
+      expiresAt: "2026-05-12T12:15:00.000Z",
+      holder: "runner:cloudflare",
+    },
+    plan: {
+      action: "remote-bootstrap",
+      issue: {
+        number: 579,
+      },
+    },
+    status: "leased",
+  }
+}
+
+function queueSnapshot({
+  acceptedAt = "2026-05-12T12:00:00.000Z",
+  dispatchableRecommendationCount = 0,
+  firstDispatchableAction,
+  firstDispatchableIssueNumber,
+  recommendationCount = 0,
+} = {}) {
+  return {
+    acceptedAt,
+    summary: {
+      dispatchableRecommendationCount,
+      firstDispatchableAction,
+      firstDispatchableIssueNumber,
+      recommendationCount,
+    },
+  }
 }
 
 function runnerTick({ id, intentId, leased = true, reason = "dry_run" } = {}) {


### PR DESCRIPTION
## Summary
- Extend `agent:queue:deployed-status` with recent control-plane queue snapshots.
- Add optional `--issue` + `--action` active dispatch lookup for a specific lifecycle pointer.
- Treat missing active dispatch pointers as an empty read-only state, and document the expanded operator view.

## Verification
- `node --test scripts/tests/agent-runner-deployed-status.test.mjs scripts/tests/agent-runner-deployment-doctor.test.mjs scripts/tests/agent-runner-control-plane.test.mjs`
- `pnpm agent:queue:deployed-status -- --help`
- `pnpm agent:queue:test`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- pre-commit hook
- pre-push hook full test lane