### PR TITLE
feat(storefront-sdk): add booking engine facade

### DIFF
--- a/.changeset/custom-booking-engine-surface.md
+++ b/.changeset/custom-booking-engine-surface.md
@@ -1,0 +1,8 @@
+---
+"@voyantjs/storefront-sdk": minor
+---
+
+Add a first-class `bookingEngine` facade for custom storefront booking flows.
+The facade wraps public booking-session and checkout operations with
+flow-oriented methods, returns canonical engine snapshots, and exposes
+structured booking-engine error metadata.

--- a/docs/architecture/custom-storefront-sdk.md
+++ b/docs/architecture/custom-storefront-sdk.md
@@ -27,7 +27,7 @@ Use this stack for custom booking UIs:
 
 1. Public Hono route modules expose `/v1/public/*` capability contracts.
 2. `@voyantjs/storefront-sdk` provides framework-agnostic TypeScript operations
-   and booking-engine state helpers.
+   and a first-class `bookingEngine` facade.
 3. `@voyantjs/storefront-react` provides React Query hooks on top of the SDK.
 4. Registry UI blocks and app/template storefronts provide presentation.
 
@@ -59,6 +59,87 @@ These states are derived from existing public booking-session snapshots:
 
 The state model is intentionally derived rather than persisted. The canonical
 backend lifecycle remains the `bookings` status model plus public session state.
+
+## Booking Engine Facade
+
+Custom booking UIs should start from `createVoyantStorefrontClient(...)` and use
+the `bookingEngine` property for customer checkout flow code:
+
+```ts
+const voyant = createVoyantStorefrontClient({ baseUrl })
+const booking = await voyant.bookingEngine.reserve(input)
+
+await voyant.bookingEngine.updateTravelers(booking.session.sessionId, {
+  travelers,
+})
+
+await voyant.bookingEngine.updateProgress(booking.session.sessionId, {
+  currentStep: "terms",
+  completedSteps: ["billing", "travelers"],
+})
+
+const repriced = await voyant.bookingEngine.reprice(booking.session.sessionId, {
+  applyToSession: true,
+  selections,
+})
+
+const payableSession = repriced.session
+if (payableSession?.engine.state === "ready_for_payment") {
+  await voyant.bookingEngine.startPayment(payableSession.session.sessionId, {
+    method: "card",
+  })
+}
+```
+
+The facade deliberately returns a `{ session, engine }` snapshot for session
+reads and mutations. `session` is the public booking-session DTO. `engine` is
+the canonical derived state, current step, hold expiry, checklist readiness, and
+allowed actions. This lets a custom UI branch on one stable object without
+persisting another backend lifecycle field.
+
+The public route family behind the facade remains:
+
+| Flow step | SDK method | Public route |
+| --- | --- | --- |
+| Reserve capacity | `bookingEngine.reserve` | `POST /v1/public/bookings/sessions` |
+| Resume session | `bookingEngine.getSnapshot` | `GET /v1/public/bookings/sessions/:sessionId` |
+| Update travelers/session data | `bookingEngine.updateTravelers`, `bookingEngine.updateSession` | `PATCH /v1/public/bookings/sessions/:sessionId` |
+| Persist UI progress | `bookingEngine.updateProgress` | `PUT /v1/public/bookings/sessions/:sessionId/state` |
+| Quote or reprice | `bookingEngine.reprice` | `POST /v1/public/bookings/sessions/:sessionId/reprice` |
+| Start checkout collection | `bookingEngine.startPayment` | `POST /v1/public/checkout/bookings/:bookingId/initiate-collection` |
+| Resume redirect/bootstrap | `bookingEngine.bootstrapPayment` | `POST /v1/public/checkout/collections/bootstrap` |
+| Finalize booking | `bookingEngine.confirm` | `POST /v1/public/bookings/sessions/:sessionId/confirm` |
+| Expire abandoned hold | `bookingEngine.expire` | `POST /v1/public/bookings/sessions/:sessionId/expire` |
+| Success summary | `bookingEngine.getOverview` | `GET /v1/public/bookings/overview` |
+
+## Errors
+
+`VoyantStorefrontApiError` exposes `normalizedError` when a public route returns
+a structured error envelope. Custom booking engines should prefer this field
+over parsing raw response bodies.
+
+The booking-engine error vocabulary is exported from
+`@voyantjs/storefront-sdk/errors`:
+
+- `contract_template_missing`
+- `reservation_expired`
+- `departure_unavailable`
+- `invalid_traveler_payload`
+- `payment_provider_unavailable`
+- `payment_url_missing`
+- `payment_webhook_pending`
+- `checkout_finalization_failed`
+
+Structured errors use:
+
+```ts
+{
+  code: "payment_webhook_pending",
+  message: "Payment webhook has not finalized the booking yet.",
+  recoverable: true,
+  nextAction: "poll_payment_status",
+}
+```
 
 ## Rules
 

--- a/packages/pricing-ui/src/components/option-unit-price-rule-combobox.tsx
+++ b/packages/pricing-ui/src/components/option-unit-price-rule-combobox.tsx
@@ -34,8 +34,10 @@ export function OptionUnitPriceRuleCombobox({ value, onChange, placeholder, disa
   const items = React.useMemo(() => {
     const map = new Map<string, OptionUnitPriceRuleRecord>()
     for (const item of listQuery.data?.data ?? []) {
-      const label = `${item.optionId} / ${item.unitId}`
-      if (!search || label.toLowerCase().includes(search.toLowerCase())) map.set(item.id, item)
+      const searchableText = `${item.optionId} / ${item.unitId}`
+      if (!search || searchableText.toLowerCase().includes(search.toLowerCase())) {
+        map.set(item.id, item)
+      }
     }
     if (selectedQuery.data) map.set(selectedQuery.data.id, selectedQuery.data)
     return Array.from(map.values())

--- a/packages/storefront-sdk/README.md
+++ b/packages/storefront-sdk/README.md
@@ -29,5 +29,29 @@ const session = await voyant.booking.createSession({
 const state = voyant.booking.deriveState(session)
 ```
 
+For custom booking engines, prefer the `bookingEngine` facade. It keeps the
+route-shaped public booking and checkout calls behind flow-oriented methods and
+returns a canonical engine snapshot alongside session reads and mutations.
+
+```ts
+const booking = await voyant.bookingEngine.reserve({
+  sellCurrency: "EUR",
+  items: [
+    {
+      title: "Danube tour",
+      availabilitySlotId: "slot_123",
+      quantity: 2,
+      totalSellAmountCents: 24000,
+    },
+  ],
+})
+
+if (voyant.bookingEngine.canRunAction(booking.engine.state, "start_payment")) {
+  await voyant.bookingEngine.startPayment(booking.session.sessionId, {
+    method: "card",
+  })
+}
+```
+
 React consumers should layer React Query hooks on top of this package rather
 than reimplementing request paths directly.

--- a/packages/storefront-sdk/package.json
+++ b/packages/storefront-sdk/package.json
@@ -11,8 +11,10 @@
   "sideEffects": false,
   "exports": {
     ".": "./src/index.ts",
+    "./booking-engine": "./src/booking-engine.ts",
     "./client": "./src/client.ts",
     "./engine-state": "./src/engine-state.ts",
+    "./errors": "./src/errors.ts",
     "./operations": "./src/operations.ts",
     "./schemas": "./src/schemas.ts"
   },
@@ -50,6 +52,11 @@
         "import": "./dist/index.js",
         "default": "./dist/index.js"
       },
+      "./booking-engine": {
+        "types": "./dist/booking-engine.d.ts",
+        "import": "./dist/booking-engine.js",
+        "default": "./dist/booking-engine.js"
+      },
       "./client": {
         "types": "./dist/client.d.ts",
         "import": "./dist/client.js",
@@ -59,6 +66,11 @@
         "types": "./dist/engine-state.d.ts",
         "import": "./dist/engine-state.js",
         "default": "./dist/engine-state.js"
+      },
+      "./errors": {
+        "types": "./dist/errors.d.ts",
+        "import": "./dist/errors.js",
+        "default": "./dist/errors.js"
       },
       "./operations": {
         "types": "./dist/operations.d.ts",

--- a/packages/storefront-sdk/src/booking-engine.ts
+++ b/packages/storefront-sdk/src/booking-engine.ts
@@ -1,0 +1,170 @@
+import type { StorefrontRequestOptions, VoyantStorefrontClientOptions } from "./client.js"
+import { type BookingEngineSnapshot, createBookingEngineSnapshot } from "./engine-state.js"
+import {
+  bootstrapCheckoutCollection,
+  confirmPublicBookingSession,
+  createPublicBookingSession,
+  expirePublicBookingSession,
+  getPublicBookingOverview,
+  getPublicBookingSession,
+  getPublicBookingSessionState,
+  initiateCheckoutCollection,
+  previewCheckoutCollection,
+  repricePublicBookingSession,
+  updatePublicBookingSession,
+  updatePublicBookingSessionState,
+} from "./operations.js"
+import type {
+  BootstrapCheckoutCollectionInput,
+  InitiateCheckoutCollectionInput,
+  PreviewCheckoutCollectionInput,
+  PublicBookingOverviewLookupQuery,
+  PublicBookingSessionMutationInput,
+  PublicBookingSessionRecord,
+  PublicBookingSessionRepriceInput,
+  PublicCreateBookingSessionInput,
+  PublicUpdateBookingSessionInput,
+  PublicUpsertBookingSessionStateInput,
+} from "./schemas.js"
+
+type ResolvedClientOptions = Required<Pick<VoyantStorefrontClientOptions, "baseUrl" | "fetcher">> &
+  Pick<VoyantStorefrontClientOptions, "headers">
+
+export interface BookingEngineSessionSnapshot {
+  session: PublicBookingSessionRecord
+  engine: BookingEngineSnapshot
+}
+
+export interface BookingEngineRepriceResult {
+  pricing: Awaited<ReturnType<typeof repricePublicBookingSession>>["pricing"]
+  session: BookingEngineSessionSnapshot | null
+}
+
+export type BookingEngineTravelerUpdateInput = Pick<
+  PublicUpdateBookingSessionInput,
+  "travelers" | "removedTravelerIds" | "pax"
+>
+
+export function createBookingEngineSessionSnapshot(
+  session: PublicBookingSessionRecord,
+): BookingEngineSessionSnapshot {
+  return {
+    session,
+    engine: createBookingEngineSnapshot(session),
+  }
+}
+
+export async function reserveBookingEngineSession(
+  client: ResolvedClientOptions,
+  input: PublicCreateBookingSessionInput,
+  options?: StorefrontRequestOptions,
+) {
+  const session = await createPublicBookingSession(client, input, options)
+  return createBookingEngineSessionSnapshot(session)
+}
+
+export async function getBookingEngineSessionSnapshot(
+  client: ResolvedClientOptions,
+  sessionId: string,
+) {
+  const session = await getPublicBookingSession(client, sessionId)
+  return createBookingEngineSessionSnapshot(session)
+}
+
+export async function updateBookingEngineSession(
+  client: ResolvedClientOptions,
+  sessionId: string,
+  input: PublicUpdateBookingSessionInput,
+  options?: StorefrontRequestOptions,
+) {
+  const session = await updatePublicBookingSession(client, sessionId, input, options)
+  return createBookingEngineSessionSnapshot(session)
+}
+
+export function updateBookingEngineTravelers(
+  client: ResolvedClientOptions,
+  sessionId: string,
+  input: BookingEngineTravelerUpdateInput,
+  options?: StorefrontRequestOptions,
+) {
+  return updateBookingEngineSession(client, sessionId, input, options)
+}
+
+export function getBookingEngineProgress(client: ResolvedClientOptions, sessionId: string) {
+  return getPublicBookingSessionState(client, sessionId)
+}
+
+export function updateBookingEngineProgress(
+  client: ResolvedClientOptions,
+  sessionId: string,
+  input: PublicUpsertBookingSessionStateInput,
+  options?: StorefrontRequestOptions,
+) {
+  return updatePublicBookingSessionState(client, sessionId, input, options)
+}
+
+export async function repriceBookingEngineSession(
+  client: ResolvedClientOptions,
+  sessionId: string,
+  input: PublicBookingSessionRepriceInput,
+  options?: StorefrontRequestOptions,
+): Promise<BookingEngineRepriceResult> {
+  const result = await repricePublicBookingSession(client, sessionId, input, options)
+  return {
+    pricing: result.pricing,
+    session: result.session ? createBookingEngineSessionSnapshot(result.session) : null,
+  }
+}
+
+export async function confirmBookingEngineSession(
+  client: ResolvedClientOptions,
+  sessionId: string,
+  input: PublicBookingSessionMutationInput = {},
+  options?: StorefrontRequestOptions,
+) {
+  const session = await confirmPublicBookingSession(client, sessionId, input, options)
+  return createBookingEngineSessionSnapshot(session)
+}
+
+export async function expireBookingEngineSession(
+  client: ResolvedClientOptions,
+  sessionId: string,
+  input: PublicBookingSessionMutationInput = {},
+  options?: StorefrontRequestOptions,
+) {
+  const session = await expirePublicBookingSession(client, sessionId, input, options)
+  return createBookingEngineSessionSnapshot(session)
+}
+
+export function getBookingEngineOverview(
+  client: ResolvedClientOptions,
+  query: PublicBookingOverviewLookupQuery,
+) {
+  return getPublicBookingOverview(client, query)
+}
+
+export function previewBookingEnginePayment(
+  client: ResolvedClientOptions,
+  bookingId: string,
+  input: PreviewCheckoutCollectionInput,
+  options?: StorefrontRequestOptions,
+) {
+  return previewCheckoutCollection(client, bookingId, input, options)
+}
+
+export function startBookingEnginePayment(
+  client: ResolvedClientOptions,
+  bookingId: string,
+  input: InitiateCheckoutCollectionInput,
+  options?: StorefrontRequestOptions,
+) {
+  return initiateCheckoutCollection(client, bookingId, input, options)
+}
+
+export function bootstrapBookingEnginePayment(
+  client: ResolvedClientOptions,
+  input: BootstrapCheckoutCollectionInput,
+  options?: StorefrontRequestOptions,
+) {
+  return bootstrapCheckoutCollection(client, input, options)
+}

--- a/packages/storefront-sdk/src/client.ts
+++ b/packages/storefront-sdk/src/client.ts
@@ -1,5 +1,7 @@
 import type { z } from "zod"
 
+import { parseStorefrontApiErrorEnvelope, type StorefrontApiErrorEnvelope } from "./errors.js"
+
 export type VoyantStorefrontFetcher = (url: string, init?: RequestInit) => Promise<Response>
 
 export const defaultStorefrontFetcher: VoyantStorefrontFetcher = (url, init) =>
@@ -8,12 +10,19 @@ export const defaultStorefrontFetcher: VoyantStorefrontFetcher = (url, init) =>
 export class VoyantStorefrontApiError extends Error {
   readonly status: number
   readonly body: unknown
+  readonly normalizedError: StorefrontApiErrorEnvelope | null
 
-  constructor(message: string, status: number, body: unknown) {
+  constructor(
+    message: string,
+    status: number,
+    body: unknown,
+    normalizedError: StorefrontApiErrorEnvelope | null = parseStorefrontApiErrorEnvelope(body),
+  ) {
     super(message)
     this.name = "VoyantStorefrontApiError"
     this.status = status
     this.body = body
+    this.normalizedError = normalizedError
   }
 }
 
@@ -120,6 +129,9 @@ export function requestHeaders(options?: StorefrontRequestOptions): HeadersInit 
 }
 
 function extractErrorMessage(status: number, statusText: string, body: unknown): string {
+  const normalizedError = parseStorefrontApiErrorEnvelope(body)
+  if (normalizedError) return normalizedError.message
+
   if (typeof body === "object" && body !== null && "error" in body) {
     const err = (body as { error: unknown }).error
     if (typeof err === "string") return err

--- a/packages/storefront-sdk/src/errors.ts
+++ b/packages/storefront-sdk/src/errors.ts
@@ -1,0 +1,66 @@
+import { z } from "zod"
+
+export const bookingEngineErrorCodes = [
+  "contract_template_missing",
+  "reservation_expired",
+  "departure_unavailable",
+  "invalid_traveler_payload",
+  "payment_provider_unavailable",
+  "payment_url_missing",
+  "payment_webhook_pending",
+  "checkout_finalization_failed",
+] as const
+
+export type BookingEngineErrorCode = (typeof bookingEngineErrorCodes)[number]
+
+export const bookingEngineNextActions = [
+  "configure_contract_template",
+  "restart_reservation",
+  "choose_another_departure",
+  "correct_traveler_payload",
+  "choose_another_payment_method",
+  "retry_payment_start",
+  "poll_payment_status",
+  "contact_operator",
+] as const
+
+export type BookingEngineNextAction = (typeof bookingEngineNextActions)[number]
+
+export const storefrontApiErrorEnvelopeSchema = z.object({
+  code: z.string().optional(),
+  message: z.string(),
+  recoverable: z.boolean().optional(),
+  nextAction: z.string().optional(),
+  details: z.record(z.string(), z.unknown()).optional(),
+})
+
+export const bookingEngineErrorEnvelopeSchema = storefrontApiErrorEnvelopeSchema.extend({
+  code: z.enum(bookingEngineErrorCodes),
+  nextAction: z.enum(bookingEngineNextActions).optional(),
+})
+
+export type StorefrontApiErrorEnvelope = z.infer<typeof storefrontApiErrorEnvelopeSchema>
+export type BookingEngineErrorEnvelope = z.infer<typeof bookingEngineErrorEnvelopeSchema>
+
+export function parseStorefrontApiErrorEnvelope(body: unknown): StorefrontApiErrorEnvelope | null {
+  const direct = storefrontApiErrorEnvelopeSchema.safeParse(body)
+  if (direct.success) {
+    return direct.data
+  }
+
+  if (typeof body !== "object" || body === null || !("error" in body)) {
+    return null
+  }
+
+  const error = (body as { error: unknown }).error
+  if (typeof error === "string") {
+    const code =
+      typeof (body as { code?: unknown }).code === "string"
+        ? (body as { code?: string }).code
+        : undefined
+    return { code, message: error }
+  }
+
+  const nested = storefrontApiErrorEnvelopeSchema.safeParse(error)
+  return nested.success ? nested.data : null
+}

--- a/packages/storefront-sdk/src/index.ts
+++ b/packages/storefront-sdk/src/index.ts
@@ -1,3 +1,18 @@
+import {
+  bootstrapBookingEnginePayment,
+  confirmBookingEngineSession,
+  expireBookingEngineSession,
+  getBookingEngineOverview,
+  getBookingEngineProgress,
+  getBookingEngineSessionSnapshot,
+  previewBookingEnginePayment,
+  repriceBookingEngineSession,
+  reserveBookingEngineSession,
+  startBookingEnginePayment,
+  updateBookingEngineProgress,
+  updateBookingEngineSession,
+  updateBookingEngineTravelers,
+} from "./booking-engine.js"
 import { defaultStorefrontFetcher, type VoyantStorefrontClientOptions } from "./client.js"
 import {
   canRunBookingEngineAction,
@@ -28,6 +43,7 @@ import {
   updatePublicBookingSessionState,
 } from "./operations.js"
 
+export * from "./booking-engine.js"
 export type {
   StorefrontQueryParamValue,
   StorefrontRequestOptions,
@@ -53,6 +69,7 @@ export {
   deriveBookingEngineState,
   getAllowedBookingEngineActions,
 } from "./engine-state.js"
+export * from "./errors.js"
 export * from "./operations.js"
 export * from "./schemas.js"
 
@@ -127,6 +144,63 @@ export function createVoyantStorefrontClient(options: VoyantStorefrontClientOpti
       ) => expirePublicBookingSession(client, sessionId, input, requestOptions),
       getOverview: (query: Parameters<typeof getPublicBookingOverview>[1]) =>
         getPublicBookingOverview(client, query),
+      deriveState: deriveBookingEngineState,
+      createSnapshot: createBookingEngineSnapshot,
+      canRunAction: canRunBookingEngineAction,
+    },
+    bookingEngine: {
+      reserve: (
+        input: Parameters<typeof reserveBookingEngineSession>[1],
+        requestOptions?: Parameters<typeof reserveBookingEngineSession>[2],
+      ) => reserveBookingEngineSession(client, input, requestOptions),
+      getSnapshot: (sessionId: string) => getBookingEngineSessionSnapshot(client, sessionId),
+      updateSession: (
+        sessionId: string,
+        input: Parameters<typeof updateBookingEngineSession>[2],
+        requestOptions?: Parameters<typeof updateBookingEngineSession>[3],
+      ) => updateBookingEngineSession(client, sessionId, input, requestOptions),
+      updateTravelers: (
+        sessionId: string,
+        input: Parameters<typeof updateBookingEngineTravelers>[2],
+        requestOptions?: Parameters<typeof updateBookingEngineTravelers>[3],
+      ) => updateBookingEngineTravelers(client, sessionId, input, requestOptions),
+      getProgress: (sessionId: string) => getBookingEngineProgress(client, sessionId),
+      updateProgress: (
+        sessionId: string,
+        input: Parameters<typeof updateBookingEngineProgress>[2],
+        requestOptions?: Parameters<typeof updateBookingEngineProgress>[3],
+      ) => updateBookingEngineProgress(client, sessionId, input, requestOptions),
+      reprice: (
+        sessionId: string,
+        input: Parameters<typeof repriceBookingEngineSession>[2],
+        requestOptions?: Parameters<typeof repriceBookingEngineSession>[3],
+      ) => repriceBookingEngineSession(client, sessionId, input, requestOptions),
+      confirm: (
+        sessionId: string,
+        input?: Parameters<typeof confirmBookingEngineSession>[2],
+        requestOptions?: Parameters<typeof confirmBookingEngineSession>[3],
+      ) => confirmBookingEngineSession(client, sessionId, input, requestOptions),
+      expire: (
+        sessionId: string,
+        input?: Parameters<typeof expireBookingEngineSession>[2],
+        requestOptions?: Parameters<typeof expireBookingEngineSession>[3],
+      ) => expireBookingEngineSession(client, sessionId, input, requestOptions),
+      getOverview: (query: Parameters<typeof getBookingEngineOverview>[1]) =>
+        getBookingEngineOverview(client, query),
+      previewPayment: (
+        bookingId: string,
+        input: Parameters<typeof previewBookingEnginePayment>[2],
+        requestOptions?: Parameters<typeof previewBookingEnginePayment>[3],
+      ) => previewBookingEnginePayment(client, bookingId, input, requestOptions),
+      startPayment: (
+        bookingId: string,
+        input: Parameters<typeof startBookingEnginePayment>[2],
+        requestOptions?: Parameters<typeof startBookingEnginePayment>[3],
+      ) => startBookingEnginePayment(client, bookingId, input, requestOptions),
+      bootstrapPayment: (
+        input: Parameters<typeof bootstrapBookingEnginePayment>[1],
+        requestOptions?: Parameters<typeof bootstrapBookingEnginePayment>[2],
+      ) => bootstrapBookingEnginePayment(client, input, requestOptions),
       deriveState: deriveBookingEngineState,
       createSnapshot: createBookingEngineSnapshot,
       canRunAction: canRunBookingEngineAction,

--- a/packages/storefront-sdk/tests/unit/booking-engine.test.ts
+++ b/packages/storefront-sdk/tests/unit/booking-engine.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest"
+
+import { createVoyantStorefrontClient, type PublicBookingSessionRecord } from "../../src/index.js"
+
+function session(overrides: Partial<PublicBookingSessionRecord> = {}): PublicBookingSessionRecord {
+  return {
+    sessionId: "book_123",
+    bookingNumber: "BK-2605-000001",
+    status: "on_hold",
+    externalBookingRef: null,
+    communicationLanguage: null,
+    sellCurrency: "EUR",
+    sellAmountCents: 10000,
+    startDate: null,
+    endDate: null,
+    pax: 1,
+    holdExpiresAt: "2026-06-01T10:00:00.000Z",
+    confirmedAt: null,
+    expiredAt: null,
+    cancelledAt: null,
+    completedAt: null,
+    travelers: [],
+    items: [],
+    allocations: [],
+    checklist: {
+      hasTravelers: false,
+      hasPrimaryTraveler: false,
+      hasItems: true,
+      hasAllocations: true,
+      readyForConfirmation: false,
+    },
+    state: null,
+    ...overrides,
+  }
+}
+
+describe("bookingEngine facade", () => {
+  it("fetches a session and returns a canonical engine snapshot", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = []
+    const voyant = createVoyantStorefrontClient({
+      baseUrl: "https://operator.example.com/",
+      fetcher: async (url, init) => {
+        calls.push({ url, init })
+        return Response.json({ data: session() })
+      },
+    })
+
+    const snapshot = await voyant.bookingEngine.getSnapshot("book_123")
+
+    expect(calls[0]?.url).toBe("https://operator.example.com/v1/public/bookings/sessions/book_123")
+    expect(snapshot.session.sessionId).toBe("book_123")
+    expect(snapshot.engine.state).toBe("reserved")
+    expect(snapshot.engine.allowedActions).toContain("update_travelers")
+  })
+
+  it("reserves a session through the booking-engine API", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = []
+    const voyant = createVoyantStorefrontClient({
+      baseUrl: "https://operator.example.com",
+      fetcher: async (url, init) => {
+        calls.push({ url, init })
+        return Response.json({ data: session() })
+      },
+    })
+
+    const snapshot = await voyant.bookingEngine.reserve({
+      sellCurrency: "EUR",
+      items: [
+        {
+          title: "Danube tour",
+          quantity: 1,
+          totalSellAmountCents: 10000,
+          availabilitySlotId: "slot_123",
+        },
+      ],
+    })
+
+    expect(calls[0]?.url).toBe("https://operator.example.com/v1/public/bookings/sessions")
+    expect(calls[0]?.init?.method).toBe("POST")
+    expect(snapshot.engine.state).toBe("reserved")
+  })
+
+  it("normalizes public booking-engine error envelopes", async () => {
+    const voyant = createVoyantStorefrontClient({
+      baseUrl: "https://operator.example.com",
+      fetcher: async () =>
+        Response.json(
+          {
+            error: {
+              code: "payment_webhook_pending",
+              message: "Payment webhook has not finalized the booking yet.",
+              recoverable: true,
+              nextAction: "poll_payment_status",
+            },
+          },
+          { status: 409 },
+        ),
+    })
+
+    await expect(voyant.bookingEngine.confirm("book_123")).rejects.toMatchObject({
+      status: 409,
+      message: "Payment webhook has not finalized the booking yet.",
+      normalizedError: {
+        code: "payment_webhook_pending",
+        recoverable: true,
+        nextAction: "poll_payment_status",
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- add a first-class `bookingEngine` facade to `@voyantjs/storefront-sdk` for reserve/resume/update/reprice/payment/finalization flows
- return canonical `{ session, engine }` snapshots and expose structured booking-engine error metadata
- document the custom booking-engine route mapping and add unit coverage

Closes #633.

## Verification

- pnpm --filter @voyantjs/storefront-sdk lint
- pnpm --filter @voyantjs/storefront-sdk typecheck
- pnpm --filter @voyantjs/storefront-sdk test
- pnpm --filter @voyantjs/storefront-sdk build
- pnpm verify:fast

Note: `pnpm verify:package-exports` is blocked in this worktree by missing dist output across many unrelated packages; `@voyantjs/storefront-sdk` itself builds successfully.