### PR TITLE
feat(agent-runner): allow deployed CI repair leases

### DIFF
--- a/apps/agent-runner/README.md
+++ b/apps/agent-runner/README.md
@@ -45,9 +45,13 @@ provider commands, or spend model budget.
 - `AGENT_RUNNER_ENABLED`: must be `true` before scheduled ticks can lease
   dispatch intents.
 - `AGENT_RUNNER_ALLOWED_ACTIONS`: optional comma-separated lifecycle action
-  allow-list. Defaults to all runner-supported lifecycle actions.
+  allow-list. Defaults to runner-supported lifecycle actions except opt-in CI
+  repair actions.
 - `AGENT_RUNNER_ACTION`: optional default lifecycle action filter, useful when
   `AGENT_RUNNER_ALLOWED_ACTIONS` restricts Cron to one action such as `sync-pr`.
+  Add `repair-ci` or `remote-repair-ci` to `AGENT_RUNNER_ALLOWED_ACTIONS` only
+  when the runner environment also configures the corresponding supervised
+  repair command outside this Worker.
 - `AGENT_RUNNER_HOLDER`: default lease holder, for example `runner:cloudflare`.
 - `AGENT_RUNNER_MAX_LEASE_TTL_SECONDS`: optional maximum lease TTL. Defaults to
   900 seconds and is clamped to 60..3600 seconds.

--- a/apps/agent-runner/src/app.test.ts
+++ b/apps/agent-runner/src/app.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { createApp } from "./app.js"
-import { runnerDispatchActions } from "./runner.js"
+import { runnerDefaultDispatchActions, runnerDispatchActions } from "./runner.js"
 import type { SupervisorTickRecord, SupervisorTickStore } from "./supervisor-tick-store.js"
 
 describe("agent runner app", () => {
@@ -85,7 +85,7 @@ describe("agent runner app", () => {
           iterations: 3,
           mode: "lease-only",
           policy: {
-            allowedActions: Array.from(runnerDispatchActions).sort(),
+            allowedActions: Array.from(runnerDefaultDispatchActions).sort(),
             defaultAction: null,
             maxLeaseTtlSeconds: 900,
             requiresActionFilter: false,

--- a/apps/agent-runner/src/runner-smoke.test.ts
+++ b/apps/agent-runner/src/runner-smoke.test.ts
@@ -102,4 +102,108 @@ describe("agent runner smoke ticks", () => {
       reason: "control_plane_rejected",
     })
   })
+
+  it("keeps CI repair actions out of the default deployed runner policy", async () => {
+    const calls: string[] = []
+    const result = await runSupervisorTick({
+      config: {
+        controlPlaneConfigured: true,
+        controlPlaneToken: "control-token",
+        controlPlaneUrl: "https://control.example.com/",
+        enabled: true,
+        holder: "runner:cloudflare",
+        repository: "voyantjs/voyant",
+      },
+      fetchImpl: async (url) => {
+        calls.push(String(url))
+        return new Response(JSON.stringify({ reason: "leased" }), { status: 201 })
+      },
+      request: {
+        action: "repair-ci",
+        dryRun: false,
+      },
+      source: "scheduled",
+    })
+
+    expect(result).toMatchObject({
+      leased: false,
+      plan: {
+        accepted: false,
+        blockers: ["action repair-ci is not allowed by runner policy"],
+        policy: {
+          allowedActions: expect.not.arrayContaining(["repair-ci", "remote-repair-ci"]),
+          requiresActionFilter: false,
+        },
+      },
+      reason: "blocked",
+    })
+    expect(calls).toEqual([])
+  })
+
+  it.each([
+    "repair-ci",
+    "remote-repair-ci",
+  ] as const)("allows deployed supervisors to lease %s when policy permits it", async (action) => {
+    const calls: Array<{ body: unknown; url: string }> = []
+    const result = await runSupervisorTick({
+      config: {
+        allowedActions: [action],
+        controlPlaneConfigured: true,
+        controlPlaneToken: "control-token",
+        controlPlaneUrl: "https://control.example.com/",
+        defaultAction: action,
+        enabled: true,
+        holder: "runner:cloudflare",
+        repository: "voyantjs/voyant",
+      },
+      fetchImpl: async (url, init) => {
+        calls.push({
+          body: JSON.parse(String(init?.body)),
+          url: String(url),
+        })
+        return new Response(
+          JSON.stringify({
+            intent: {
+              id: `intent_${action}`,
+              plan: {
+                action,
+              },
+              status: "leased",
+            },
+            reason: "leased",
+          }),
+          { status: 201 },
+        )
+      },
+      request: {
+        dryRun: false,
+      },
+      source: "scheduled",
+    })
+
+    expect(result).toMatchObject({
+      intent: {
+        plan: {
+          action,
+        },
+        status: "leased",
+      },
+      leased: true,
+      reason: "leased",
+    })
+    expect(calls).toEqual([
+      {
+        body: {
+          filters: {
+            action,
+          },
+          lease: {
+            holder: "runner:cloudflare",
+          },
+          repository: "voyantjs/voyant",
+        },
+        url: "https://control.example.com/api/dispatch-intents/latest",
+      },
+    ])
+  })
 })

--- a/apps/agent-runner/src/runner.ts
+++ b/apps/agent-runner/src/runner.ts
@@ -10,10 +10,16 @@ export const runnerDispatchActions = [
   "remote-cleanup",
   "remote-open-pr",
   "remote-publish-evidence",
+  "remote-repair-ci",
+  "repair-ci",
   "start",
   "sync-pr",
 ] as const
 
+const runnerOptInDispatchActions = new Set<string>(["remote-repair-ci", "repair-ci"])
+export const runnerDefaultDispatchActions = runnerDispatchActions.filter(
+  (action) => !runnerOptInDispatchActions.has(action),
+)
 const runnerDispatchActionSet = new Set<string>(runnerDispatchActions)
 
 export const supervisorTickRequestSchema = z
@@ -320,9 +326,12 @@ function buildDispatchIntentRequest({
 }
 
 function buildRunnerPolicy(config: RunnerConfig) {
-  const allowedActions = normalizeAllowedActions(config.allowedActions)
+  const configuredAllowedActions = normalizeConfiguredAllowedActions(config.allowedActions)
+  const allowedActions = configuredAllowedActions ?? Array.from(runnerDefaultDispatchActions).sort()
   const maxLeaseTtlSeconds = normalizeMaxLeaseTtlSeconds(config.maxLeaseTtlSeconds)
-  const restrictsActions = runnerDispatchActions.some((action) => !allowedActions.includes(action))
+  const restrictsActions = configuredAllowedActions
+    ? runnerDispatchActions.some((action) => !allowedActions.includes(action))
+    : false
 
   return {
     allowedActions,
@@ -332,8 +341,10 @@ function buildRunnerPolicy(config: RunnerConfig) {
   }
 }
 
-function normalizeAllowedActions(allowedActions: string[] | undefined) {
-  const normalized = (allowedActions?.length ? allowedActions : Array.from(runnerDispatchActions))
+function normalizeConfiguredAllowedActions(allowedActions: string[] | undefined) {
+  if (!allowedActions?.length) return null
+
+  const normalized = allowedActions
     .map((action) => action.trim())
     .filter((action) => action.length > 0)
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -478,6 +478,11 @@ Successful dispatch attempts append local JSONL audit events to
 `.agent-runs/events.jsonl` by default; pass `--event-log <path>` when a
 supervisor needs a different local ledger path. The same path is passed to the
 nested lifecycle command so dispatch and lifecycle events stay in one ledger.
+Deployed runner policy uses the same lifecycle vocabulary for lease-only
+supervisor ticks. CI repair actions are not part of the default deployed
+allow-list; include `repair-ci` or `remote-repair-ci` in
+`AGENT_RUNNER_ALLOWED_ACTIONS` only for environments where the trusted command
+runner has the matching `AGENT_CI_REPAIR_COMMAND` configuration.
 
 Use loop for a bounded supervisor pass:
 

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1397,7 +1397,10 @@ Verification:
   filter for Cron, and `AGENT_RUNNER_MAX_LEASE_TTL_SECONDS` caps lease TTLs.
   If the action allow-list is narrower than the full lifecycle set, the runner
   refuses unfiltered ticks so the control plane cannot choose a different
-  queued action.
+  queued action. The deployed runner can lease `repair-ci` and
+  `remote-repair-ci` intents, but those actions are excluded from the default
+  deployed allow-list and should only be enabled in environments where a
+  trusted external command runner owns the configured CI repair command.
 - Deployed control-plane and runner setup should be checked with
   `pnpm agent:queue:deployment-doctor` before enabling Cron. The command calls
   both capability endpoints, reads the runner supervisor status, verifies auth


### PR DESCRIPTION
## Summary
- Adds `repair-ci` and `remote-repair-ci` to the deployed runner lifecycle allow-list.
- Covers restricted runner policy leasing for both CI repair actions.
- Documents when deployed runner policy should enable CI repair actions.

## Verification
- `pnpm --filter @voyantjs/agent-runner test`
- `pnpm --filter @voyantjs/agent-runner typecheck`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm --filter @voyantjs/finance-ui test`
- `pnpm --filter @voyantjs/finance-ui typecheck`
- pre-push `pnpm test` hook passed