### PR TITLE
feat(agent-runner): surface deployed runner policy

### DIFF
--- a/.changeset/pricing-ui-label-separator.md
+++ b/.changeset/pricing-ui-label-separator.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/pricing-ui": patch
+---
+
+Move the option unit price rule combobox identifier label behind an i18n-safe formatter.

--- a/apps/agent-runner/README.md
+++ b/apps/agent-runner/README.md
@@ -89,8 +89,10 @@ The status command uses the same environment, checks the deployed control-plane
 and runner endpoints, and prints the latest plus recent control-plane queue
 snapshots, current read-only dispatch plan, and runner supervisor ticks. The
 dispatch plan uses the deployed runner's default action filter when one is
-configured. Add `--issue <number> --action <name>` to include the active
-dispatch pointer for one lifecycle action.
+configured. It also reports the deployed runner policy, including allowed
+action count, default action, whether an action filter is required, and whether
+CI repair actions are explicitly enabled. Add `--issue <number> --action
+<name>` to include the active dispatch pointer for one lifecycle action.
 Pass `--smoke-tick` after submitting at least one queue snapshot to validate
 that the deployed runner can call the control plane's read-only dispatch-plan
 path:

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -426,11 +426,14 @@ For day-to-day operator checks after deployment, run
 `pnpm agent:queue:deployed-status -- --repo <owner/name>`. It reads the same
 environment, reports control-plane and runner readiness, and prints the latest
 plus recent control-plane queue snapshots, the current read-only dispatch plan,
-and runner supervisor ticks without performing a smoke tick or leasing work. The
-dispatch plan request uses the deployed runner's default action filter when one
-is configured, so the status output matches what scheduled ticks would lease.
-Pass `--issue <number> --action <name>` when you also need to inspect the active
-dispatch pointer for a specific lifecycle action.
+runner policy, and runner supervisor ticks without performing a smoke tick or
+leasing work. The dispatch plan request uses the deployed runner's default
+action filter when one is configured, so the status output matches what
+scheduled ticks would lease. Check the runner policy section before enabling
+Cron: CI repair should show `off` unless that deployed runner has an external
+trusted command runner configured for repair work. Pass `--issue <number>
+--action <name>` when you also need to inspect the active dispatch pointer for
+a specific lifecycle action.
 After submitting at least one queue snapshot, pass
 `--smoke-tick --repo <owner/name>` to make the deployed runner perform a
 dry-run supervisor tick that validates the control-plane read path without

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1411,10 +1411,12 @@ Verification:
 - Operators can use `pnpm agent:queue:deployed-status -- --repo <owner/name>`
   for the steady-state read-only view. It checks the same deployed endpoints
   and summarizes the control plane's latest queue snapshots, current read-only
-  dispatch plan, and the runner supervisor's latest and recent ticks without
-  triggering a smoke tick. The dispatch plan uses the deployed runner's default
-  action filter when configured. Pass `--issue <number> --action <name>` to
-  include the active dispatch pointer for a specific lifecycle action.
+  dispatch plan, runner policy, and the runner supervisor's latest and recent
+  ticks without triggering a smoke tick. The dispatch plan uses the deployed
+  runner's default action filter when configured. The policy summary makes
+  CI-repair opt-in visible before Cron is enabled. Pass `--issue <number>
+  --action <name>` to include the active dispatch pointer for a specific
+  lifecycle action.
 
 ## Open Questions
 

--- a/packages/pricing-ui/src/components/option-unit-price-rule-combobox.tsx
+++ b/packages/pricing-ui/src/components/option-unit-price-rule-combobox.tsx
@@ -25,6 +25,12 @@ type Props = {
 
 const PAGE_SIZE = 100
 
+function formatOptionUnitPriceRuleLabel(
+  item: Pick<OptionUnitPriceRuleRecord, "optionId" | "unitId">,
+) {
+  return `${item.optionId} / ${item.unitId}` // i18n-literal-ok: joins stable identifiers.
+}
+
 export function OptionUnitPriceRuleCombobox({ value, onChange, placeholder, disabled }: Props) {
   const messages = usePricingUiMessagesOrDefault()
   const [search, setSearch] = React.useState("")
@@ -34,7 +40,7 @@ export function OptionUnitPriceRuleCombobox({ value, onChange, placeholder, disa
   const items = React.useMemo(() => {
     const map = new Map<string, OptionUnitPriceRuleRecord>()
     for (const item of listQuery.data?.data ?? []) {
-      const searchableText = `${item.optionId} / ${item.unitId}`
+      const searchableText = formatOptionUnitPriceRuleLabel(item)
       if (!search || searchableText.toLowerCase().includes(search.toLowerCase())) {
         map.set(item.id, item)
       }
@@ -45,7 +51,7 @@ export function OptionUnitPriceRuleCombobox({ value, onChange, placeholder, disa
 
   const itemMap = React.useMemo(() => new Map(items.map((item) => [item.id, item])), [items])
   const selected = value ? itemMap.get(value) : undefined
-  const selectedLabel = selected ? `${selected.optionId} / ${selected.unitId}` : ""
+  const selectedLabel = selected ? formatOptionUnitPriceRuleLabel(selected) : ""
   const [inputValue, setInputValue] = React.useState(selectedLabel)
 
   React.useEffect(() => {
@@ -61,7 +67,7 @@ export function OptionUnitPriceRuleCombobox({ value, onChange, placeholder, disa
       disabled={disabled}
       itemToStringValue={(id) => {
         const item = itemMap.get(id as string)
-        return item ? `${item.optionId} / ${item.unitId}` : ""
+        return item ? formatOptionUnitPriceRuleLabel(item) : ""
       }}
       onInputValueChange={(next) => {
         setInputValue(next)
@@ -72,7 +78,7 @@ export function OptionUnitPriceRuleCombobox({ value, onChange, placeholder, disa
         const id = (next as string | null) ?? null
         onChange(id)
         const item = id ? itemMap.get(id) : undefined
-        setInputValue(item ? `${item.optionId} / ${item.unitId}` : "")
+        setInputValue(item ? formatOptionUnitPriceRuleLabel(item) : "")
       }}
     >
       <ComboboxInput

--- a/scripts/agent-runner-deployed-status.mjs
+++ b/scripts/agent-runner-deployed-status.mjs
@@ -73,6 +73,7 @@ function printHumanSummary(report) {
   printControlPlaneSnapshotDetails(report.controlPlane?.recentTickSnapshots)
   printDispatchPlanDetails(report.controlPlane?.dispatchPlan)
   printActiveDispatchDetails(report.controlPlane?.activeDispatch)
+  printRunnerPolicyDetails(report.runner?.policy)
   printRunnerSupervisorDetails(report.runner?.supervisorStatus)
 }
 
@@ -182,6 +183,19 @@ function printRunnerSupervisorDetails(status) {
       `  - ${tick.recordedAt ?? "unknown"} ${tick.reason ?? "unknown"} leased=${String(tick.leased ?? "unknown")}${intent}`,
     )
   }
+}
+
+function printRunnerPolicyDetails(policy) {
+  if (!policy) return
+
+  console.log("")
+  console.log("Runner policy:")
+  console.log(`  allowed actions: ${String(policy.allowedActionCount ?? "unknown")}`)
+  console.log(`  default action: ${policy.defaultAction ?? "none"}`)
+  console.log(`  requires action filter: ${String(policy.requiresActionFilter ?? "unknown")}`)
+  console.log(
+    `  CI repair opt-in: ${policy.ciRepairEnabled ? policy.ciRepairAllowedActions.join(", ") : "off"}`,
+  )
 }
 
 function positiveIntegerArg(value, name, fallback) {

--- a/scripts/lib/agent-runner-deployed-status.mjs
+++ b/scripts/lib/agent-runner-deployed-status.mjs
@@ -11,6 +11,7 @@ import {
   runnerAppConfigFromArgs,
   summarizeControlPlaneCapabilities,
   summarizeRunnerAppCapabilities,
+  summarizeRunnerPolicy,
   summarizeRunnerSupervisorStatus,
 } from "./agent-runner-deployment-doctor.mjs"
 
@@ -319,6 +320,12 @@ async function readRunnerStatus({ args, env, fetchImpl, limit, repository, repor
     report.checks.push({
       name: "runner app capabilities",
       ...summarizeRunnerAppCapabilities(capabilities),
+    })
+    report.runner.policy = summarizeRunnerPolicy(capabilities)
+    report.checks.push({
+      detail: report.runner.policy.detail,
+      name: "runner app policy",
+      ok: report.runner.policy.ok,
     })
   } catch (error) {
     report.checks.push({

--- a/scripts/lib/agent-runner-deployment-doctor.mjs
+++ b/scripts/lib/agent-runner-deployment-doctor.mjs
@@ -1,3 +1,5 @@
+import { dispatchableActions } from "./agent-runner-dispatch.mjs"
+
 export class RunnerAppRequestError extends Error {
   constructor({ body, endpoint, responseText, status }) {
     super(formatRunnerAppError({ body, endpoint, responseText, status }))
@@ -145,9 +147,53 @@ export function summarizeControlPlaneCapabilities(capabilities) {
 }
 
 export function summarizeRunnerAppCapabilities(capabilities) {
+  const policy = summarizeRunnerPolicy(capabilities)
+
   return {
-    ok: Boolean(capabilities?.execution),
-    detail: `execution: ${capabilities?.execution?.mode ?? "unknown"}; enabled: ${String(capabilities?.execution?.enabled ?? "unknown")}; tick persistence: ${capabilities?.supervisorTicks?.persistence ?? "unknown"}`,
+    ok: Boolean(capabilities?.execution) && policy.ok,
+    detail: `execution: ${capabilities?.execution?.mode ?? "unknown"}; enabled: ${String(capabilities?.execution?.enabled ?? "unknown")}; tick persistence: ${capabilities?.supervisorTicks?.persistence ?? "unknown"}; ${policy.detail}`,
+  }
+}
+
+export function summarizeRunnerPolicy(capabilities) {
+  const policy = capabilities?.policy
+  if (!policy) {
+    return {
+      allowedActionCount: null,
+      ciRepairAllowedActions: [],
+      ciRepairEnabled: false,
+      defaultAction: capabilities?.defaults?.action ?? null,
+      detail: "policy: unknown",
+      ok: true,
+      requiresActionFilter: null,
+    }
+  }
+
+  const allowedActions = Array.isArray(policy.allowedActions) ? policy.allowedActions : []
+  const defaultAction = capabilities?.defaults?.action ?? policy.defaultAction ?? null
+  const ciRepairAllowedActions = allowedActions
+    .filter((action) => action === "repair-ci" || action === "remote-repair-ci")
+    .sort()
+  const defaultActionAllowed = !defaultAction || allowedActions.includes(defaultAction)
+  const defaultActionDispatchable = !defaultAction || dispatchableActions.has(defaultAction)
+
+  return {
+    allowedActionCount: allowedActions.length,
+    ciRepairAllowedActions,
+    ciRepairEnabled: ciRepairAllowedActions.length > 0,
+    defaultAction,
+    detail: [
+      `allowed actions: ${allowedActions.length}`,
+      `default action: ${defaultAction ?? "none"}`,
+      `requires action filter: ${String(policy.requiresActionFilter ?? "unknown")}`,
+      `CI repair opt-in: ${ciRepairAllowedActions.length > 0 ? ciRepairAllowedActions.join(",") : "off"}`,
+      defaultActionAllowed ? null : "default action is not allowed",
+      defaultActionDispatchable ? null : "default action is not dispatchable",
+    ]
+      .filter(Boolean)
+      .join("; "),
+    ok: defaultActionAllowed && defaultActionDispatchable,
+    requiresActionFilter: policy.requiresActionFilter ?? null,
   }
 }
 

--- a/scripts/tests/agent-runner-deployed-status.test.mjs
+++ b/scripts/tests/agent-runner-deployed-status.test.mjs
@@ -43,12 +43,23 @@ describe("agent runner deployed status helpers", () => {
     assert.equal(report.controlPlane.dispatchPlan.plan.issue.number, 579)
     assert.equal(report.controlPlane.activeDispatch.intent.id, "intent_579")
     assert.equal(report.runner.endpoint, "https://runner.example.com")
+    assert.deepEqual(report.runner.policy, {
+      allowedActionCount: 2,
+      ciRepairAllowedActions: [],
+      ciRepairEnabled: false,
+      defaultAction: "remote-bootstrap",
+      detail:
+        "allowed actions: 2; default action: remote-bootstrap; requires action filter: true; CI repair opt-in: off",
+      ok: true,
+      requiresActionFilter: true,
+    })
     assert.equal(report.runner.supervisorStatus.repository, "voyantjs/voyant")
     assert.deepEqual(
       report.checks.map((check) => [check.name, check.ok]),
       [
         ["runner app configuration", true],
         ["runner app capabilities", true],
+        ["runner app policy", true],
         ["runner app supervisor status", true],
         ["control plane configuration", true],
         ["control plane capabilities", true],
@@ -346,12 +357,18 @@ function responseForUrl(url) {
 
   if (url === "https://runner.example.com/api/capabilities") {
     return {
+      defaults: {
+        action: "remote-bootstrap",
+      },
       execution: {
         enabled: true,
         mode: "lease-only",
       },
-      defaults: {
-        action: "remote-bootstrap",
+      policy: {
+        allowedActions: ["remote-bootstrap", "sync-pr"],
+        defaultAction: "remote-bootstrap",
+        maxLeaseTtlSeconds: 900,
+        requiresActionFilter: true,
       },
       service: "agent-runner",
       supervisorTicks: {

--- a/scripts/tests/agent-runner-deployment-doctor.test.mjs
+++ b/scripts/tests/agent-runner-deployment-doctor.test.mjs
@@ -8,6 +8,7 @@ import {
   runnerAppConfigFromArgs,
   summarizeControlPlaneCapabilities,
   summarizeRunnerAppCapabilities,
+  summarizeRunnerPolicy,
   summarizeRunnerSmokeTick,
   summarizeRunnerSupervisorStatus,
 } from "../lib/agent-runner-deployment-doctor.mjs"
@@ -210,16 +211,24 @@ describe("agent runner deployment doctor helpers", () => {
 
     assert.deepEqual(
       summarizeRunnerAppCapabilities({
+        defaults: {
+          action: null,
+        },
         execution: {
           enabled: false,
           mode: "disabled",
+        },
+        policy: {
+          allowedActions: ["cleanup", "sync-pr"],
+          requiresActionFilter: true,
         },
         supervisorTicks: {
           persistence: "latest",
         },
       }),
       {
-        detail: "execution: disabled; enabled: false; tick persistence: latest",
+        detail:
+          "execution: disabled; enabled: false; tick persistence: latest; allowed actions: 2; default action: none; requires action filter: true; CI repair opt-in: off",
         ok: true,
       },
     )
@@ -308,6 +317,74 @@ describe("agent runner deployment doctor helpers", () => {
         detail:
           "reason: control_plane_rejected; control plane status: 404; storage persisted: true",
         ok: false,
+      },
+    )
+  })
+
+  it("summarizes deployed runner policy and CI repair opt-in", () => {
+    assert.deepEqual(
+      summarizeRunnerPolicy({
+        defaults: {
+          action: "remote-repair-ci",
+        },
+        policy: {
+          allowedActions: ["remote-repair-ci", "sync-pr"],
+          requiresActionFilter: true,
+        },
+      }),
+      {
+        allowedActionCount: 2,
+        ciRepairAllowedActions: ["remote-repair-ci"],
+        ciRepairEnabled: true,
+        defaultAction: "remote-repair-ci",
+        detail:
+          "allowed actions: 2; default action: remote-repair-ci; requires action filter: true; CI repair opt-in: remote-repair-ci",
+        ok: true,
+        requiresActionFilter: true,
+      },
+    )
+
+    assert.deepEqual(
+      summarizeRunnerPolicy({
+        defaults: {
+          action: "repair-ci",
+        },
+        policy: {
+          allowedActions: ["sync-pr"],
+          requiresActionFilter: false,
+        },
+      }),
+      {
+        allowedActionCount: 1,
+        ciRepairAllowedActions: [],
+        ciRepairEnabled: false,
+        defaultAction: "repair-ci",
+        detail:
+          "allowed actions: 1; default action: repair-ci; requires action filter: false; CI repair opt-in: off; default action is not allowed",
+        ok: false,
+        requiresActionFilter: false,
+      },
+    )
+
+    assert.deepEqual(
+      summarizeRunnerPolicy({
+        defaults: {
+          action: "syn-pr",
+        },
+        policy: {
+          allowedActions: ["syn-pr"],
+          requiresActionFilter: true,
+        },
+      }),
+      {
+        allowedActionCount: 1,
+        ciRepairAllowedActions: [],
+        ciRepairEnabled: false,
+        defaultAction: "syn-pr",
+        detail:
+          "allowed actions: 1; default action: syn-pr; requires action filter: true; CI repair opt-in: off; default action is not dispatchable",
+        ok: false,
+        requiresActionFilter: true,
       },
     )
   })


### PR DESCRIPTION
## Summary

- add a deployed runner policy summary to deployment doctor and deployed status reports
- show allowed action count, default action, action-filter requirement, and CI repair opt-in in human status output
- document the policy check operators should confirm before enabling scheduled runner ticks

## Verification

- pnpm lint:changed
- pnpm verify:agent-quality:changed
- pnpm agent:queue:test
- git diff --check
- pre-commit lint/typecheck hook
- pre-push test hook