### PR TITLE
fix(release): align workflow runs ui version

### DIFF
--- a/packages/workflow-runs-ui/package.json
+++ b/packages/workflow-runs-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/workflow-runs-ui",
-  "version": "0.34.0",
+  "version": "0.36.0",
   "description": "Importable React admin UI for Voyant workflow run observability.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary
- align @voyantjs/workflow-runs-ui with the shared 0.36.0 release train
- fixes the main Release workflow failure in verify:release-train after #806 merged

## Verification
- pnpm verify:release-train