### PR TITLE
feat(agent-runner): enforce daily lease budgets

### DIFF
--- a/apps/agent-runner/README.md
+++ b/apps/agent-runner/README.md
@@ -20,7 +20,9 @@ provider commands, or spend model budget.
   `AGENT_RUNNER_ENABLED=true` and `{ "dryRun": false }`, it leases one dispatch
   intent from `POST /api/dispatch-intents/latest` on the control plane. When
   `AGENT_RUNNER_TICKS` is bound, the result is persisted as the latest
-  supervisor tick for the repository.
+  supervisor tick for the repository. If `AGENT_RUNNER_MAX_DAILY_LEASES` is
+  configured, real leases are refused once the R2 lease-specific history shows
+  the daily limit has been used.
   For deployment smoke tests, pass
   `{ "dryRun": true, "validateControlPlane": true }` to call the control
   plane's read-only latest dispatch-plan endpoint without leasing work.
@@ -54,6 +56,10 @@ provider commands, or spend model budget.
   when the runner environment also configures the corresponding supervised
   repair command outside this Worker.
 - `AGENT_RUNNER_HOLDER`: default lease holder, for example `runner:cloudflare`.
+- `AGENT_RUNNER_MAX_DAILY_LEASES`: optional daily lease budget for deployed
+  API and Cron ticks. Requires `AGENT_RUNNER_TICKS`; real leases are refused if
+  the budget is configured without persistent tick storage. The value is
+  clamped to 1..100.
 - `AGENT_RUNNER_MAX_LEASE_TTL_SECONDS`: optional maximum lease TTL. Defaults to
   900 seconds and is clamped to 60..3600 seconds.
 - `AGENT_RUNNER_REPOSITORY`: default repository, for example `voyantjs/voyant`.
@@ -63,10 +69,10 @@ provider commands, or spend model budget.
 - `AGENT_CONTROL_PLANE_URL`: deployed control-plane URL.
 - `AGENT_CONTROL_PLANE_TOKEN`: bearer token for the control plane.
 
-Cron triggers should stay disabled until queue snapshots and control-plane
-dispatch intent storage are configured. Keep provider execution outside this
-Worker unless a later design adds explicit budget controls, sandbox policy, and
-task-scoped credentials.
+Cron triggers should stay disabled until queue snapshots, control-plane dispatch
+intent storage, runner tick storage, and an explicit daily lease budget are
+configured. Keep provider execution outside this Worker unless a later design
+adds sandbox policy and task-scoped credentials.
 
 Before enabling Cron, validate the deployed control plane and runner app from
 the repository checkout:
@@ -92,8 +98,9 @@ snapshots, current read-only dispatch plan, and runner supervisor ticks. The
 dispatch plan uses the deployed runner's default action filter when one is
 configured. It also reports the deployed runner policy, including allowed
 action count, default action, whether an action filter is required, and whether
-CI repair actions are explicitly enabled. Add `--issue <number> --action
-<name>` to include the active dispatch pointer for one lifecycle action.
+CI repair actions are explicitly enabled. It also prints the configured daily
+lease budget when present. Add `--issue <number> --action <name>` to include
+the active dispatch pointer for one lifecycle action.
 Pass `--smoke-tick` after submitting at least one queue snapshot to validate
 that the deployed runner can call the control plane's read-only dispatch-plan
 path:

--- a/apps/agent-runner/src/app.test.ts
+++ b/apps/agent-runner/src/app.test.ts
@@ -87,6 +87,7 @@ describe("agent runner app", () => {
           policy: {
             allowedActions: Array.from(runnerDefaultDispatchActions).sort(),
             defaultAction: null,
+            maxDailyLeases: null,
             maxLeaseTtlSeconds: 900,
             requiresActionFilter: false,
           },
@@ -470,9 +471,12 @@ describe("agent runner app", () => {
   })
 })
 
-function inMemorySupervisorTickStore(): SupervisorTickStore {
+function inMemorySupervisorTickStore(records: SupervisorTickRecord[] = []): SupervisorTickStore {
   const latest = new Map<string, SupervisorTickRecord>()
-  const recent: SupervisorTickRecord[] = []
+  const recent: SupervisorTickRecord[] = [...records]
+  for (const record of records) {
+    latest.set(record.repository.toLowerCase(), record)
+  }
 
   return {
     async getLatest(repository) {

--- a/apps/agent-runner/src/app.ts
+++ b/apps/agent-runner/src/app.ts
@@ -2,11 +2,17 @@ import { Hono } from "hono"
 
 import {
   buildRunnerCapabilities,
+  planSupervisorTick,
   type RunnerConfig,
   runSupervisorTick,
+  type SupervisorTickRequest,
   supervisorTickRequestSchema,
 } from "./runner.js"
-import { createSupervisorTickRecord, type SupervisorTickStore } from "./supervisor-tick-store.js"
+import {
+  createSupervisorTickRecord,
+  type SupervisorLeaseRecord,
+  type SupervisorTickStore,
+} from "./supervisor-tick-store.js"
 
 interface AppOptions {
   authTokens?: string[]
@@ -112,26 +118,16 @@ export function createApp({
       )
     }
 
-    const recordedAt = now()
-    const result = await runSupervisorTick({
-      config,
-      fetchImpl,
-      request: parsed.data,
-      source: "api",
-    })
-    const repository = parsed.data.repository ?? config.repository
-    const storage = await persistSupervisorTick({
-      recordedAt,
-      repository,
-      result,
-      supervisorTickStore,
-    })
-
-    return c.json({
-      plannedAt: recordedAt.toISOString(),
-      result,
-      storage,
-    })
+    return c.json(
+      await runPersistentSupervisorTick({
+        config,
+        fetchImpl,
+        now,
+        request: parsed.data,
+        source: "api",
+        supervisorTickStore,
+      }),
+    )
   })
 
   app.get("/api/supervisor/ticks/latest", async (c) => {
@@ -173,6 +169,91 @@ export function createApp({
   return app
 }
 
+export async function runPersistentSupervisorTick({
+  config,
+  fetchImpl = fetch,
+  now = () => new Date(),
+  request = {},
+  source,
+  supervisorTickStore,
+}: {
+  config: RunnerConfig
+  fetchImpl?: typeof fetch
+  now?: () => Date
+  request?: SupervisorTickRequest
+  source: "api" | "scheduled"
+  supervisorTickStore?: SupervisorTickStore
+}) {
+  const recordedAt = now()
+  const budget = await evaluateSupervisorLeaseBudget({
+    config,
+    recordedAt,
+    request,
+    supervisorTickStore,
+  })
+  let result = budget.blocked
+    ? {
+        budget,
+        leased: false,
+        plan: planSupervisorTick({ config, request, source }),
+        reason: "lease_budget_exhausted",
+      }
+    : budget.configured
+      ? {
+          ...(await runSupervisorTick({
+            config,
+            fetchImpl,
+            request,
+            source,
+          })),
+          budget,
+        }
+      : await runSupervisorTick({
+          config,
+          fetchImpl,
+          request,
+          source,
+        })
+  const repository = request.repository ?? config.repository
+  if (
+    budget.configured &&
+    "usedLeases" in budget &&
+    "maxDailyLeases" in budget &&
+    !budget.blocked &&
+    repository &&
+    isLeasedResult(result)
+  ) {
+    await supervisorTickStore?.putLease?.(
+      createSupervisorLeaseRecord({
+        leasedAt: recordedAt,
+        repository,
+        result,
+      }),
+    )
+    const usedLeases = budget.usedLeases + 1
+    result = {
+      ...result,
+      budget: {
+        ...budget,
+        remainingLeases: Math.max(budget.maxDailyLeases - usedLeases, 0),
+        usedLeases,
+      },
+    }
+  }
+  const storage = await persistSupervisorTick({
+    recordedAt,
+    repository,
+    result,
+    supervisorTickStore,
+  })
+
+  return {
+    plannedAt: recordedAt.toISOString(),
+    result,
+    storage,
+  }
+}
+
 export async function persistSupervisorTick({
   recordedAt,
   repository,
@@ -203,6 +284,96 @@ export async function persistSupervisorTick({
   return { key: write.key, persisted: true }
 }
 
+async function evaluateSupervisorLeaseBudget({
+  config,
+  recordedAt,
+  request,
+  supervisorTickStore,
+}: {
+  config: RunnerConfig
+  recordedAt: Date
+  request: SupervisorTickRequest
+  supervisorTickStore?: SupervisorTickStore
+}) {
+  const maxDailyLeases = normalizeDailyLeaseLimit(config.maxDailyLeases)
+  if (!maxDailyLeases) {
+    return { blocked: false, configured: false }
+  }
+
+  const repository = request.repository ?? config.repository
+  const dryRun = request.dryRun ?? true
+  const windowStartedAt = new Date(recordedAt.getTime() - 24 * 60 * 60 * 1000).toISOString()
+  const base = {
+    blocked: false,
+    configured: true,
+    maxDailyLeases,
+    remainingLeases: maxDailyLeases,
+    usedLeases: 0,
+    windowStartedAt,
+  }
+
+  if (dryRun || !config.enabled) {
+    return base
+  }
+
+  if (!repository) {
+    return base
+  }
+
+  if (!supervisorTickStore?.listLeases || !supervisorTickStore.putLease) {
+    return {
+      ...base,
+      blocked: true,
+      reason: "lease budget requires supervisor lease history storage",
+      remainingLeases: 0,
+    }
+  }
+
+  const recentLeases = await supervisorTickStore.listLeases(repository, { since: windowStartedAt })
+  const usedLeases = recentLeases.length
+  const remainingLeases = Math.max(maxDailyLeases - usedLeases, 0)
+
+  return {
+    ...base,
+    blocked: usedLeases >= maxDailyLeases,
+    remainingLeases,
+    usedLeases,
+    ...(usedLeases >= maxDailyLeases ? { reason: "daily lease budget exhausted" } : {}),
+  }
+}
+
+function normalizeDailyLeaseLimit(value: number | undefined) {
+  if (!value) return null
+  return Math.min(Math.max(Math.trunc(value), 1), 100)
+}
+
+function isLeasedResult(result: unknown): result is { leased: true } {
+  return Boolean(
+    result && typeof result === "object" && "leased" in result && result.leased === true,
+  )
+}
+
+function createSupervisorLeaseRecord({
+  leasedAt,
+  repository,
+  result,
+}: {
+  leasedAt: Date
+  repository: string
+  result: unknown
+}): SupervisorLeaseRecord {
+  return {
+    id: leaseRecordId(leasedAt),
+    leasedAt: leasedAt.toISOString(),
+    repository,
+    result,
+  }
+}
+
+function leaseRecordId(leasedAt: Date) {
+  return `lease_${leasedAt.getTime()}_${Math.random().toString(36).slice(2)}`
+}
+
 function bearerToken(header: string | undefined) {
   const match = header?.match(/^Bearer\s+(.+)$/i)
   return match?.[1]?.trim()
@@ -224,6 +395,7 @@ function parseLimit(value: string | undefined) {
 function supervisorTickCapabilities(supervisorTickStore: SupervisorTickStore | undefined) {
   return {
     history: Boolean(supervisorTickStore),
+    leaseBudgetHistory: Boolean(supervisorTickStore?.listLeases && supervisorTickStore.putLease),
     persistence: supervisorTickStore ? "latest" : "none",
   }
 }

--- a/apps/agent-runner/src/runner.ts
+++ b/apps/agent-runner/src/runner.ts
@@ -49,6 +49,7 @@ export interface RunnerConfig {
   defaultAction?: string
   enabled: boolean
   holder?: string
+  maxDailyLeases?: number
   maxLeaseTtlSeconds?: number
   repository?: string
 }
@@ -329,6 +330,7 @@ function buildDispatchIntentRequest({
 function buildRunnerPolicy(config: RunnerConfig) {
   const configuredAllowedActions = normalizeConfiguredAllowedActions(config.allowedActions)
   const allowedActions = configuredAllowedActions ?? Array.from(runnerDefaultDispatchActions).sort()
+  const maxDailyLeases = normalizeMaxDailyLeases(config.maxDailyLeases)
   const maxLeaseTtlSeconds = normalizeMaxLeaseTtlSeconds(config.maxLeaseTtlSeconds)
   const restrictsActions = configuredAllowedActions
     ? runnerDispatchActions.some((action) => !allowedActions.includes(action))
@@ -337,6 +339,7 @@ function buildRunnerPolicy(config: RunnerConfig) {
   return {
     allowedActions,
     defaultAction: config.defaultAction ?? null,
+    maxDailyLeases,
     maxLeaseTtlSeconds,
     requiresActionFilter: restrictsActions,
   }
@@ -355,6 +358,11 @@ function normalizeConfiguredAllowedActions(allowedActions: string[] | undefined)
 function normalizeMaxLeaseTtlSeconds(value: number | undefined) {
   if (!value) return 900
   return Math.min(Math.max(value, 60), 3600)
+}
+
+function normalizeMaxDailyLeases(value: number | undefined) {
+  if (!value) return null
+  return Math.min(Math.max(Math.trunc(value), 1), 100)
 }
 
 function actionPolicyBlocker({

--- a/apps/agent-runner/src/supervisor-budget.test.ts
+++ b/apps/agent-runner/src/supervisor-budget.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "vitest"
+
+import { createApp } from "./app.js"
+import type {
+  SupervisorLeaseRecord,
+  SupervisorTickRecord,
+  SupervisorTickStore,
+} from "./supervisor-tick-store.js"
+
+describe("agent runner supervisor lease budget", () => {
+  it("refuses real leases when a configured daily budget has no storage", async () => {
+    const calls: string[] = []
+    const app = createApp({
+      authTokens: ["token"],
+      config: {
+        controlPlaneConfigured: true,
+        controlPlaneToken: "control-token",
+        controlPlaneUrl: "https://control.example.com/",
+        enabled: true,
+        holder: "runner:cloudflare",
+        maxDailyLeases: 3,
+        repository: "voyantjs/voyant",
+      },
+      fetchImpl: async (url) => {
+        calls.push(String(url))
+        return new Response(JSON.stringify({ reason: "leased" }), { status: 201 })
+      },
+      now: () => new Date("2026-05-12T12:00:00.000Z"),
+    })
+
+    const response = await app.request("/api/supervisor/ticks", {
+      body: JSON.stringify({ action: "sync-pr", dryRun: false }),
+      headers: {
+        authorization: "Bearer token",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      result: {
+        budget: {
+          blocked: true,
+          maxDailyLeases: 3,
+          reason: "lease budget requires supervisor lease history storage",
+          remainingLeases: 0,
+        },
+        leased: false,
+        reason: "lease_budget_exhausted",
+      },
+      storage: {
+        persisted: false,
+        reason: "supervisor_tick_storage_not_configured",
+      },
+    })
+    expect(calls).toEqual([])
+  })
+
+  it("counts recent successful leases before leasing from the control plane", async () => {
+    const calls: string[] = []
+    const app = createApp({
+      authTokens: ["token"],
+      config: {
+        controlPlaneConfigured: true,
+        controlPlaneToken: "control-token",
+        controlPlaneUrl: "https://control.example.com/",
+        enabled: true,
+        holder: "runner:cloudflare",
+        maxDailyLeases: 1,
+        repository: "voyantjs/voyant",
+      },
+      fetchImpl: async (url) => {
+        calls.push(String(url))
+        return new Response(JSON.stringify({ reason: "leased" }), { status: 201 })
+      },
+      now: () => new Date("2026-05-12T12:00:00.000Z"),
+      supervisorTickStore: inMemorySupervisorTickStore({
+        leases: [
+          {
+            id: "lease_1",
+            leasedAt: "2026-05-12T11:30:00.000Z",
+            repository: "voyantjs/voyant",
+            result: {
+              leased: true,
+              reason: "leased",
+            },
+          },
+        ],
+        ticks: Array.from({ length: 50 }, (_, index) => ({
+          recordedAt: `2026-05-12T11:${String(index).padStart(2, "0")}:00.000Z`,
+          repository: "voyantjs/voyant",
+          result: {
+            leased: false,
+            reason: "lease_budget_exhausted",
+          },
+        })),
+      }),
+    })
+
+    const response = await app.request("/api/supervisor/ticks", {
+      body: JSON.stringify({ action: "sync-pr", dryRun: false }),
+      headers: {
+        authorization: "Bearer token",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      result: {
+        budget: {
+          blocked: true,
+          maxDailyLeases: 1,
+          reason: "daily lease budget exhausted",
+          remainingLeases: 0,
+          usedLeases: 1,
+        },
+        leased: false,
+        reason: "lease_budget_exhausted",
+      },
+      storage: {
+        persisted: true,
+      },
+    })
+    expect(calls).toEqual([])
+  })
+
+  it("records successful leases in lease-specific history", async () => {
+    const store = inMemorySupervisorTickStore()
+    const app = createApp({
+      authTokens: ["token"],
+      config: {
+        controlPlaneConfigured: true,
+        controlPlaneToken: "control-token",
+        controlPlaneUrl: "https://control.example.com/",
+        enabled: true,
+        holder: "runner:cloudflare",
+        maxDailyLeases: 2,
+        repository: "voyantjs/voyant",
+      },
+      fetchImpl: async () =>
+        new Response(
+          JSON.stringify({
+            intent: {
+              id: "intent_579",
+              plan: {
+                action: "sync-pr",
+              },
+              status: "leased",
+            },
+            reason: "leased",
+          }),
+          { status: 201 },
+        ),
+      now: () => new Date("2026-05-12T12:00:00.000Z"),
+      supervisorTickStore: store,
+    })
+
+    const response = await app.request("/api/supervisor/ticks", {
+      body: JSON.stringify({ action: "sync-pr", dryRun: false }),
+      headers: {
+        authorization: "Bearer token",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      result: {
+        budget: {
+          blocked: false,
+          maxDailyLeases: 2,
+          remainingLeases: 1,
+          usedLeases: 1,
+        },
+        leased: true,
+        reason: "leased",
+      },
+    })
+    await expect(
+      store.listLeases?.("voyantjs/voyant", { since: "2026-05-11T12:00:00.000Z" }),
+    ).resolves.toMatchObject([
+      {
+        leasedAt: "2026-05-12T12:00:00.000Z",
+        repository: "voyantjs/voyant",
+      },
+    ])
+  })
+})
+
+function inMemorySupervisorTickStore({
+  leases = [],
+  ticks = [],
+}: {
+  leases?: SupervisorLeaseRecord[]
+  ticks?: SupervisorTickRecord[]
+} = {}): SupervisorTickStore {
+  const latest = new Map<string, SupervisorTickRecord>()
+  const recent: SupervisorTickRecord[] = [...ticks]
+  const leaseHistory: SupervisorLeaseRecord[] = [...leases]
+  for (const record of ticks) {
+    latest.set(record.repository.toLowerCase(), record)
+  }
+
+  return {
+    async getLatest(repository) {
+      return latest.get(repository.toLowerCase()) ?? null
+    },
+    async listRecent(repository) {
+      return recent.filter((record) => record.repository.toLowerCase() === repository.toLowerCase())
+    },
+    async listLeases(repository, { since }) {
+      return leaseHistory.filter(
+        (record) =>
+          record.repository.toLowerCase() === repository.toLowerCase() && record.leasedAt >= since,
+      )
+    },
+    async putLease(record) {
+      leaseHistory.unshift(record)
+      return { key: `leases/${record.repository.toLowerCase()}/${record.id}.json` }
+    },
+    async putLatest(record) {
+      latest.set(record.repository.toLowerCase(), record)
+      recent.unshift(record)
+      return { key: `latest/${record.repository.toLowerCase()}.json` }
+    },
+  }
+}

--- a/apps/agent-runner/src/supervisor-tick-store.test.ts
+++ b/apps/agent-runner/src/supervisor-tick-store.test.ts
@@ -47,4 +47,72 @@ describe("supervisor tick storage", () => {
     await expect(store.getLatest("VoyantJS/Voyant")).resolves.toEqual(record)
     await expect(store.listRecent("VoyantJS/Voyant")).resolves.toEqual([record])
   })
+
+  it("stores and lists lease-specific history separately from tick history", async () => {
+    const objects = new Map<string, string>()
+    const store = createR2SupervisorTickStore({
+      bucket: {
+        async get(key: string) {
+          const text = objects.get(key)
+          return text ? { text: async () => text } : null
+        },
+        async list({
+          cursor,
+          limit = 100,
+          prefix,
+        }: {
+          cursor?: string
+          limit?: number
+          prefix?: string
+        } = {}) {
+          const keys = Array.from(objects.keys())
+            .filter((key) => !prefix || key.startsWith(prefix))
+            .sort()
+          const start = cursor ? Number(cursor) : 0
+          const selected = keys.slice(start, start + limit)
+          const next = start + limit < keys.length ? String(start + limit) : undefined
+          return {
+            cursor: next,
+            objects: selected.map((key) => ({ key })),
+            truncated: Boolean(next),
+          }
+        },
+        async put(key: string, value: string) {
+          objects.set(key, String(value))
+          return null
+        },
+      } satisfies SupervisorTickBucket,
+      keyPrefix: "runner",
+    })
+
+    const olderLease = {
+      id: "lease_old",
+      leasedAt: "2026-05-10T12:00:00.000Z",
+      repository: "voyantjs/voyant",
+      result: { leased: true },
+    }
+    const currentLease = {
+      id: "lease_current",
+      leasedAt: "2026-05-12T12:00:00.000Z",
+      repository: "voyantjs/voyant",
+      result: { leased: true },
+    }
+
+    await store.putLatest({
+      recordedAt: "2026-05-12T12:01:00.000Z",
+      repository: "voyantjs/voyant",
+      result: {
+        leased: false,
+        reason: "lease_budget_exhausted",
+      },
+    })
+    await expect(store.putLease?.(olderLease)).resolves.toMatchObject({
+      key: expect.stringContaining("supervisor-leases/history/voyantjs%2Fvoyant"),
+    })
+    await store.putLease?.(currentLease)
+
+    await expect(
+      store.listLeases?.("VoyantJS/Voyant", { since: "2026-05-11T12:00:00.000Z" }),
+    ).resolves.toEqual([currentLease])
+  })
 })

--- a/apps/agent-runner/src/supervisor-tick-store.ts
+++ b/apps/agent-runner/src/supervisor-tick-store.ts
@@ -8,9 +8,20 @@ export const supervisorTickRecordSchema = z.object({
 
 export type SupervisorTickRecord = z.infer<typeof supervisorTickRecordSchema>
 
+export const supervisorLeaseRecordSchema = z.object({
+  id: z.string().trim().min(1),
+  leasedAt: z.string().datetime(),
+  repository: z.string().trim().min(1),
+  result: z.unknown().optional(),
+})
+
+export type SupervisorLeaseRecord = z.infer<typeof supervisorLeaseRecordSchema>
+
 export interface SupervisorTickStore {
   getLatest(repository: string): Promise<SupervisorTickRecord | null>
+  listLeases?(repository: string, options: { since: string }): Promise<SupervisorLeaseRecord[]>
   listRecent(repository: string, options?: { limit?: number }): Promise<SupervisorTickRecord[]>
+  putLease?(record: SupervisorLeaseRecord): Promise<SupervisorTickStoreWrite>
   putLatest(record: SupervisorTickRecord): Promise<SupervisorTickStoreWrite>
 }
 
@@ -96,6 +107,60 @@ export function createR2SupervisorTickStore({
       return records
     },
 
+    async listLeases(repository, { since }) {
+      if (!bucket.list) {
+        return []
+      }
+
+      const records: SupervisorLeaseRecord[] = []
+      const prefix = leaseHistoryPrefix({ keyPrefix, repository })
+      let cursor: string | undefined
+      let done = false
+
+      do {
+        const listed = await bucket.list({
+          cursor,
+          limit: 100,
+          prefix,
+        })
+        cursor = listed.cursor
+
+        for (const object of listed.objects) {
+          const stored = await bucket.get(object.key)
+          if (!stored) continue
+
+          const parsed = supervisorLeaseRecordSchema.safeParse(JSON.parse(await stored.text()))
+          if (!parsed.success) {
+            throw new Error(`stored supervisor lease is invalid for ${repository}`)
+          }
+          if (parsed.data.leasedAt < since) {
+            done = true
+            break
+          }
+          records.push(parsed.data)
+        }
+      } while (!done && cursor)
+
+      return records
+    },
+
+    async putLease(record) {
+      const key = leaseHistoryKey({
+        id: record.id,
+        keyPrefix,
+        leasedAt: record.leasedAt,
+        repository: record.repository,
+      })
+      const value = JSON.stringify(record)
+      await bucket.put(key, value, {
+        httpMetadata: {
+          contentType: "application/json",
+        },
+      })
+
+      return { key }
+    },
+
     async putLatest(record) {
       const key = latestTickKey({ keyPrefix, repository: record.repository })
       const historyKey = historyTickKey({
@@ -131,6 +196,13 @@ function historyTickPrefix({ keyPrefix, repository }: { keyPrefix: string; repos
   return normalizedPrefix ? `${normalizedPrefix}/${key}` : key
 }
 
+function leaseHistoryPrefix({ keyPrefix, repository }: { keyPrefix: string; repository: string }) {
+  const normalizedPrefix = keyPrefix.replace(/^\/+|\/+$/g, "")
+  const encodedRepository = encodeURIComponent(repository.trim().toLowerCase())
+  const key = `supervisor-leases/history/${encodedRepository}/`
+  return normalizedPrefix ? `${normalizedPrefix}/${key}` : key
+}
+
 function historyTickKey({
   keyPrefix,
   recordedAt,
@@ -145,6 +217,24 @@ function historyTickKey({
     ? String(Number.MAX_SAFE_INTEGER - timestamp).padStart(16, "0")
     : encodeURIComponent(recordedAt)
   return `${historyTickPrefix({ keyPrefix, repository })}${sortable}-${encodeURIComponent(recordedAt)}.json`
+}
+
+function leaseHistoryKey({
+  id,
+  keyPrefix,
+  leasedAt,
+  repository,
+}: {
+  id: string
+  keyPrefix: string
+  leasedAt: string
+  repository: string
+}) {
+  const timestamp = Date.parse(leasedAt)
+  const sortable = Number.isFinite(timestamp)
+    ? String(Number.MAX_SAFE_INTEGER - timestamp).padStart(16, "0")
+    : encodeURIComponent(leasedAt)
+  return `${leaseHistoryPrefix({ keyPrefix, repository })}${sortable}-${encodeURIComponent(leasedAt)}-${encodeURIComponent(id)}.json`
 }
 
 function boundedLimit(limit = 20) {

--- a/apps/agent-runner/src/worker.ts
+++ b/apps/agent-runner/src/worker.ts
@@ -1,5 +1,4 @@
-import { createApp, persistSupervisorTick } from "./app.js"
-import { runSupervisorTick } from "./runner.js"
+import { createApp, runPersistentSupervisorTick } from "./app.js"
 import { createR2SupervisorTickStore } from "./supervisor-tick-store.js"
 
 interface Env {
@@ -9,6 +8,7 @@ interface Env {
   AGENT_RUNNER_ALLOWED_ACTIONS?: string
   AGENT_RUNNER_ENABLED?: string
   AGENT_RUNNER_HOLDER?: string
+  AGENT_RUNNER_MAX_DAILY_LEASES?: string
   AGENT_RUNNER_MAX_LEASE_TTL_SECONDS?: string
   AGENT_RUNNER_REPOSITORY?: string
   AGENT_RUNNER_TICK_KEY_PREFIX?: string
@@ -27,22 +27,22 @@ export default {
   },
 
   async scheduled(_event: ScheduledController, env: Env): Promise<void> {
-    const recordedAt = new Date()
-    const result = await runSupervisorTick({
+    const tick = await runPersistentSupervisorTick({
       config: runnerConfigFromEnv(env),
       request: {
         dryRun: env.AGENT_RUNNER_ENABLED !== "true",
         reason: "cloudflare-cron",
       },
       source: "scheduled",
-    })
-    const storage = await persistSupervisorTick({
-      recordedAt,
-      repository: env.AGENT_RUNNER_REPOSITORY,
-      result,
       supervisorTickStore: supervisorTickStoreFromEnv(env),
     })
-    console.log(JSON.stringify({ service: "agent-runner", supervisorTick: result, storage }))
+    console.log(
+      JSON.stringify({
+        service: "agent-runner",
+        storage: tick.storage,
+        supervisorTick: tick.result,
+      }),
+    )
   },
 } satisfies ExportedHandler<Env>
 
@@ -55,6 +55,7 @@ function runnerConfigFromEnv(env: Env) {
     defaultAction: env.AGENT_RUNNER_ACTION,
     enabled: env.AGENT_RUNNER_ENABLED === "true",
     holder: env.AGENT_RUNNER_HOLDER,
+    maxDailyLeases: parsePositiveInteger(env.AGENT_RUNNER_MAX_DAILY_LEASES),
     maxLeaseTtlSeconds: parsePositiveInteger(env.AGENT_RUNNER_MAX_LEASE_TTL_SECONDS),
     repository: env.AGENT_RUNNER_REPOSITORY,
   }

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -489,7 +489,11 @@ Deployed runner policy uses the same lifecycle vocabulary for lease-only
 supervisor ticks. CI repair actions are not part of the default deployed
 allow-list; include `repair-ci` or `remote-repair-ci` in
 `AGENT_RUNNER_ALLOWED_ACTIONS` only for environments where the trusted command
-runner has the matching `AGENT_CI_REPAIR_COMMAND` configuration.
+runner has the matching `AGENT_CI_REPAIR_COMMAND` configuration. Use
+`AGENT_RUNNER_MAX_DAILY_LEASES` with the `AGENT_RUNNER_TICKS` R2 binding before
+enabling Cron so API or scheduled ticks cannot lease more than the configured
+daily budget. If the budget is configured without persistent tick storage, real
+leases are refused.
 
 Use loop for a bounded supervisor pass:
 

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1379,8 +1379,8 @@ Verification:
   one dispatch intent from the control-plane app's latest stored queue snapshot,
   but it still does not execute lifecycle commands, mutate GitHub directly,
   create workspaces, or spend model budget. Command execution remains owned by
-  trusted runner processes until budget controls, sandbox policy, and
-  task-scoped provider credentials are wired into a later slice.
+  trusted runner processes until sandbox policy and task-scoped provider
+  credentials are wired into a later slice.
 - The runner app can persist the latest supervisor tick result per repository
   to R2 through the `AGENT_RUNNER_TICKS` binding and expose it at
   `GET /api/supervisor/ticks/latest` and recent records at
@@ -1399,13 +1399,18 @@ Verification:
 - The runner app enforces a local dispatch policy before calling the control
   plane. `AGENT_RUNNER_ALLOWED_ACTIONS` limits which lifecycle actions a
   deployed runner can lease, `AGENT_RUNNER_ACTION` supplies a default action
-  filter for Cron, and `AGENT_RUNNER_MAX_LEASE_TTL_SECONDS` caps lease TTLs.
+  filter for Cron, `AGENT_RUNNER_MAX_LEASE_TTL_SECONDS` caps lease TTLs, and
+  `AGENT_RUNNER_MAX_DAILY_LEASES` caps deployed API or Cron leases using the
+  persisted R2 lease-specific history.
   If the action allow-list is narrower than the full lifecycle set, the runner
   refuses unfiltered ticks so the control plane cannot choose a different
   queued action. The deployed runner can lease `repair-ci` and
   `remote-repair-ci` intents, but those actions are excluded from the default
   deployed allow-list and should only be enabled in environments where a
   trusted external command runner owns the configured CI repair command.
+  Daily lease budgets are opt-in but, when configured, real leases are refused
+  unless runner tick storage is configured so the budget is enforceable across
+  scheduled invocations.
 - Deployed control-plane and runner setup should be checked with
   `pnpm agent:queue:deployment-doctor` before enabling Cron. The command calls
   both capability endpoints, reads the runner supervisor status, verifies auth

--- a/scripts/agent-runner-deployed-status.mjs
+++ b/scripts/agent-runner-deployed-status.mjs
@@ -192,6 +192,7 @@ function printRunnerPolicyDetails(policy) {
   console.log("Runner policy:")
   console.log(`  allowed actions: ${String(policy.allowedActionCount ?? "unknown")}`)
   console.log(`  default action: ${policy.defaultAction ?? "none"}`)
+  console.log(`  daily lease budget: ${policy.maxDailyLeases ?? "none"}`)
   console.log(`  requires action filter: ${String(policy.requiresActionFilter ?? "unknown")}`)
   console.log(
     `  CI repair opt-in: ${policy.ciRepairEnabled ? policy.ciRepairAllowedActions.join(", ") : "off"}`,

--- a/scripts/lib/agent-runner-deployment-doctor.mjs
+++ b/scripts/lib/agent-runner-deployment-doctor.mjs
@@ -164,6 +164,7 @@ export function summarizeRunnerPolicy(capabilities) {
       ciRepairEnabled: false,
       defaultAction: capabilities?.defaults?.action ?? null,
       detail: "policy: unknown",
+      maxDailyLeases: null,
       ok: true,
       requiresActionFilter: null,
     }
@@ -182,9 +183,11 @@ export function summarizeRunnerPolicy(capabilities) {
     ciRepairAllowedActions,
     ciRepairEnabled: ciRepairAllowedActions.length > 0,
     defaultAction,
+    maxDailyLeases: policy.maxDailyLeases ?? null,
     detail: [
       `allowed actions: ${allowedActions.length}`,
       `default action: ${defaultAction ?? "none"}`,
+      `daily lease budget: ${policy.maxDailyLeases ?? "none"}`,
       `requires action filter: ${String(policy.requiresActionFilter ?? "unknown")}`,
       `CI repair opt-in: ${ciRepairAllowedActions.length > 0 ? ciRepairAllowedActions.join(",") : "off"}`,
       defaultActionAllowed ? null : "default action is not allowed",

--- a/scripts/tests/agent-runner-deployed-status.test.mjs
+++ b/scripts/tests/agent-runner-deployed-status.test.mjs
@@ -49,7 +49,8 @@ describe("agent runner deployed status helpers", () => {
       ciRepairEnabled: false,
       defaultAction: "remote-bootstrap",
       detail:
-        "allowed actions: 2; default action: remote-bootstrap; requires action filter: true; CI repair opt-in: off",
+        "allowed actions: 2; default action: remote-bootstrap; daily lease budget: 6; requires action filter: true; CI repair opt-in: off",
+      maxDailyLeases: 6,
       ok: true,
       requiresActionFilter: true,
     })
@@ -367,6 +368,7 @@ function responseForUrl(url) {
       policy: {
         allowedActions: ["remote-bootstrap", "sync-pr"],
         defaultAction: "remote-bootstrap",
+        maxDailyLeases: 6,
         maxLeaseTtlSeconds: 900,
         requiresActionFilter: true,
       },

--- a/scripts/tests/agent-runner-deployment-doctor.test.mjs
+++ b/scripts/tests/agent-runner-deployment-doctor.test.mjs
@@ -228,7 +228,7 @@ describe("agent runner deployment doctor helpers", () => {
       }),
       {
         detail:
-          "execution: disabled; enabled: false; tick persistence: latest; allowed actions: 2; default action: none; requires action filter: true; CI repair opt-in: off",
+          "execution: disabled; enabled: false; tick persistence: latest; allowed actions: 2; default action: none; daily lease budget: none; requires action filter: true; CI repair opt-in: off",
         ok: true,
       },
     )
@@ -329,6 +329,7 @@ describe("agent runner deployment doctor helpers", () => {
         },
         policy: {
           allowedActions: ["remote-repair-ci", "sync-pr"],
+          maxDailyLeases: 4,
           requiresActionFilter: true,
         },
       }),
@@ -338,7 +339,8 @@ describe("agent runner deployment doctor helpers", () => {
         ciRepairEnabled: true,
         defaultAction: "remote-repair-ci",
         detail:
-          "allowed actions: 2; default action: remote-repair-ci; requires action filter: true; CI repair opt-in: remote-repair-ci",
+          "allowed actions: 2; default action: remote-repair-ci; daily lease budget: 4; requires action filter: true; CI repair opt-in: remote-repair-ci",
+        maxDailyLeases: 4,
         ok: true,
         requiresActionFilter: true,
       },
@@ -360,7 +362,8 @@ describe("agent runner deployment doctor helpers", () => {
         ciRepairEnabled: false,
         defaultAction: "repair-ci",
         detail:
-          "allowed actions: 1; default action: repair-ci; requires action filter: false; CI repair opt-in: off; default action is not allowed",
+          "allowed actions: 1; default action: repair-ci; daily lease budget: none; requires action filter: false; CI repair opt-in: off; default action is not allowed",
+        maxDailyLeases: null,
         ok: false,
         requiresActionFilter: false,
       },
@@ -382,7 +385,8 @@ describe("agent runner deployment doctor helpers", () => {
         ciRepairEnabled: false,
         defaultAction: "syn-pr",
         detail:
-          "allowed actions: 1; default action: syn-pr; requires action filter: true; CI repair opt-in: off; default action is not dispatchable",
+          "allowed actions: 1; default action: syn-pr; daily lease budget: none; requires action filter: true; CI repair opt-in: off; default action is not dispatchable",
+        maxDailyLeases: null,
         ok: false,
         requiresActionFilter: true,
       },


### PR DESCRIPTION
## Summary
- add an optional daily lease budget for deployed runner API and Cron ticks
- require persisted runner tick storage when the budget is configured so the cap is enforceable across invocations
- surface the budget in runner capabilities, deployed status output, and deployment docs

## Verification
- pnpm --filter @voyantjs/agent-runner test
- pnpm --filter @voyantjs/agent-runner typecheck
- node --test scripts/tests/agent-runner-deployment-doctor.test.mjs scripts/tests/agent-runner-deployed-status.test.mjs
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- pnpm verify:fast
- pre-push pnpm test