### PR TITLE
Enable scheduled agent runner leasing

### DIFF
--- a/apps/agent-runner/README.md
+++ b/apps/agent-runner/README.md
@@ -76,6 +76,9 @@ The deployment uses three Cloudflare persistence surfaces:
   when the runner environment also configures the corresponding supervised
   repair command outside this Worker.
 - `AGENT_RUNNER_HOLDER`: default lease holder, for example `runner:cloudflare`.
+- `AGENT_RUNNER_LEASE_TTL_SECONDS`: optional default lease TTL used when a
+  supervisor tick does not provide `ttlSeconds`. Keep this short for Cron
+  because the Worker is lease-only and command execution remains external.
 - `AGENT_RUNNER_MAX_DAILY_LEASES`: optional daily lease budget for deployed
   API and Cron ticks. Requires `AGENT_RUNNER_TICKS`; real leases are refused if
   the budget is configured without persistent tick storage. The value is
@@ -93,11 +96,11 @@ The deployment uses three Cloudflare persistence surfaces:
 - `AGENT_CONTROL_PLANE_URL`: deployed control-plane URL.
 - `AGENT_CONTROL_PLANE_TOKEN`: bearer token for the control plane.
 
-Cron triggers should stay disabled until queue snapshots, control-plane dispatch
-intent storage, R2 tick storage, D1 ledger storage, Durable Object coordination,
-and an explicit daily lease budget are configured. Keep provider execution
-outside this Worker unless a later design adds sandbox policy and task-scoped
-credentials.
+Cron triggers should stay constrained to one low-risk lifecycle action until an
+external executor is attached. The production pilot uses `sync-pr`, a 300 second
+lease TTL, and a three-lease daily budget so stale lease-only reservations age
+out quickly. Keep provider execution outside this Worker unless a later design
+adds sandbox policy and task-scoped credentials.
 
 ## Deployment Pilot
 
@@ -118,8 +121,8 @@ pnpm -C apps/agent-runner wrangler secret put AGENT_CONTROL_PLANE_TOKEN
 ```
 
 Deploy with `AGENT_RUNNER_ENABLED=false` first. Run deployment doctor and
-deployed status checks. Only then set a narrow action allow-list, a daily lease
-budget, and enable Cron.
+deployed status checks. Only then set a narrow action allow-list, a short lease
+TTL, a daily lease budget, and enable Cron.
 
 Run command execution from a trusted external executor, not inside the Worker.
 For a bounded always-on loop:

--- a/apps/agent-runner/src/app.test.ts
+++ b/apps/agent-runner/src/app.test.ts
@@ -356,6 +356,61 @@ describe("agent runner app", () => {
       },
     ])
   })
+
+  it("uses the configured default lease TTL when a tick omits ttlSeconds", async () => {
+    const calls: Array<{ body: unknown; url: string }> = []
+    const app = createApp({
+      authTokens: ["token"],
+      config: {
+        allowedActions: ["sync-pr"],
+        controlPlaneConfigured: true,
+        controlPlaneToken: "control-token",
+        controlPlaneUrl: "https://control.example.com/",
+        defaultAction: "sync-pr",
+        enabled: true,
+        holder: "runner:cloudflare",
+        leaseTtlSeconds: 300,
+        maxLeaseTtlSeconds: 300,
+        repository: "voyantjs/voyant",
+      },
+      fetchImpl: async (url, init) => {
+        calls.push({ body: JSON.parse(String(init?.body)), url: String(url) })
+        return new Response(JSON.stringify({ reason: "idle" }), { status: 200 })
+      },
+    })
+
+    const response = await app.request("/api/supervisor/ticks", {
+      body: JSON.stringify({ dryRun: false }),
+      headers: {
+        authorization: "Bearer token",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      result: {
+        leased: false,
+        reason: "idle",
+      },
+    })
+    expect(calls).toEqual([
+      {
+        body: {
+          filters: {
+            action: "sync-pr",
+          },
+          lease: {
+            holder: "runner:cloudflare",
+            ttlSeconds: 300,
+          },
+          repository: "voyantjs/voyant",
+        },
+        url: "https://control.example.com/api/dispatch-intents/latest",
+      },
+    ])
+  })
 })
 
 function inMemorySupervisorTickStore(records: SupervisorTickRecord[] = []): SupervisorTickStore {

--- a/apps/agent-runner/src/runner.ts
+++ b/apps/agent-runner/src/runner.ts
@@ -52,6 +52,7 @@ export interface RunnerConfig {
   defaultAction?: string
   enabled: boolean
   holder?: string
+  leaseTtlSeconds?: number
   maxDailyLeases?: number
   maxLeaseTtlSeconds?: number
   repository?: string
@@ -76,6 +77,7 @@ export function buildRunnerCapabilities(config: RunnerConfig) {
     defaults: {
       action: config.defaultAction ?? null,
       holder: config.holder ?? null,
+      leaseTtlSeconds: config.leaseTtlSeconds ?? null,
       repository: config.repository ?? null,
     },
     policy: buildRunnerPolicy(config),
@@ -101,6 +103,7 @@ export function planSupervisorTick({
   const iterations = request.iterations ?? 1
   const policy = buildRunnerPolicy(config)
   const action = request.action ?? config.defaultAction
+  const ttlSeconds = request.ttlSeconds ?? config.leaseTtlSeconds
 
   const blockers = [
     config.enabled ? null : "runner execution is disabled",
@@ -108,7 +111,7 @@ export function planSupervisorTick({
     holder ? null : "holder is not configured",
     repository ? null : "repository is not configured",
     actionPolicyBlocker({ action, policy }),
-    ttlPolicyBlocker({ policy, ttlSeconds: request.ttlSeconds }),
+    ttlPolicyBlocker({ policy, ttlSeconds }),
   ].filter((blocker): blocker is string => Boolean(blocker))
 
   return {
@@ -119,6 +122,7 @@ export function planSupervisorTick({
       holder,
       iterations,
       repository,
+      ttlSeconds,
     }),
     dryRun: request.dryRun ?? true,
     iterations,
@@ -324,12 +328,13 @@ function buildDispatchIntentRequest({
   const holder = request.holder ?? config.holder
   const repository = request.repository ?? config.repository
   const action = request.action ?? config.defaultAction
+  const ttlSeconds = request.ttlSeconds ?? config.leaseTtlSeconds
 
   return {
     repository,
     lease: {
       holder,
-      ...(request.ttlSeconds ? { ttlSeconds: request.ttlSeconds } : {}),
+      ...(ttlSeconds ? { ttlSeconds } : {}),
     },
     ...(action || request.issue
       ? {
@@ -429,11 +434,13 @@ function buildLocalEquivalentCommand({
   holder,
   iterations,
   repository,
+  ttlSeconds,
 }: {
   controlPlaneUrl?: string
   holder?: string
   iterations: number
   repository?: string
+  ttlSeconds?: number
 }) {
   const command = ["pnpm", "agent:queue:control-plane-loop", "--"]
   if (repository) {
@@ -443,6 +450,9 @@ function buildLocalEquivalentCommand({
     command.push("--holder", holder)
   }
   command.push("--iterations", String(iterations), "--yes")
+  if (ttlSeconds) {
+    command.push("--ttl-seconds", String(ttlSeconds))
+  }
   if (controlPlaneUrl) {
     command.push("--control-plane-url", controlPlaneUrl)
   }

--- a/apps/agent-runner/src/worker.ts
+++ b/apps/agent-runner/src/worker.ts
@@ -13,6 +13,7 @@ interface Env {
   AGENT_RUNNER_DB?: D1Database
   AGENT_RUNNER_ENABLED?: string
   AGENT_RUNNER_HOLDER?: string
+  AGENT_RUNNER_LEASE_TTL_SECONDS?: string
   AGENT_RUNNER_MAX_DAILY_LEASES?: string
   AGENT_RUNNER_MAX_LEASE_TTL_SECONDS?: string
   AGENT_RUNNER_REPOSITORY?: string
@@ -68,6 +69,7 @@ function runnerConfigFromEnv(env: Env) {
     defaultAction: env.AGENT_RUNNER_ACTION,
     enabled: env.AGENT_RUNNER_ENABLED === "true",
     holder: env.AGENT_RUNNER_HOLDER,
+    leaseTtlSeconds: parsePositiveInteger(env.AGENT_RUNNER_LEASE_TTL_SECONDS),
     maxDailyLeases: parsePositiveInteger(env.AGENT_RUNNER_MAX_DAILY_LEASES),
     maxLeaseTtlSeconds: parsePositiveInteger(env.AGENT_RUNNER_MAX_LEASE_TTL_SECONDS),
     repository: env.AGENT_RUNNER_REPOSITORY,

--- a/apps/agent-runner/wrangler.jsonc
+++ b/apps/agent-runner/wrangler.jsonc
@@ -1,8 +1,8 @@
 {
   // Reference Cloudflare Worker for the agent queue runner shell.
-  // This first deployment is intentionally non-executing: it exposes the
-  // deployable surface, auth, scheduled handler, and control-plane wiring before
-  // any remote GitHub or provider mutation is enabled.
+  // This deployment is intentionally lease-only: the Worker can reserve tightly
+  // scoped dispatch intents from the control plane, while command execution
+  // remains owned by trusted external executors.
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "voyant-agent-runner",
   "main": "src/worker.ts",
@@ -10,10 +10,9 @@
   // Configure AGENT_RUNNER_TOKENS as a secret before exposing /api/*:
   // pnpm -C apps/agent-runner wrangler secret put AGENT_RUNNER_TOKENS
   // Configure AGENT_CONTROL_PLANE_TOKEN separately when the runner is allowed to
-  // call the control plane. Cron triggers should stay disabled until execution
-  // policy, queue budget, and provider credentials are configured.
-  // Optional: set AGENT_RUNNER_ALLOWED_ACTIONS and AGENT_RUNNER_ACTION to keep
-  // scheduled ticks constrained to one approved lifecycle action.
+  // call the control plane. Keep AGENT_RUNNER_ALLOWED_ACTIONS and
+  // AGENT_RUNNER_ACTION constrained to one approved lifecycle action while the
+  // runner is lease-only.
   // Optional: bind an R2 bucket as AGENT_RUNNER_TICKS to store the latest
   // supervisor tick status per repository. Set AGENT_RUNNER_TICK_KEY_PREFIX
   // when multiple environments share one bucket.
@@ -23,12 +22,16 @@
     "AGENT_CONTROL_PLANE_URL": "https://voyant-agent-control-plane.pixelmakers.workers.dev",
     "AGENT_RUNNER_ACTION": "sync-pr",
     "AGENT_RUNNER_ALLOWED_ACTIONS": "sync-pr",
-    "AGENT_RUNNER_ENABLED": "false",
+    "AGENT_RUNNER_ENABLED": "true",
     "AGENT_RUNNER_HOLDER": "runner:cloudflare",
-    "AGENT_RUNNER_MAX_DAILY_LEASES": "5",
-    "AGENT_RUNNER_MAX_LEASE_TTL_SECONDS": "900",
+    "AGENT_RUNNER_LEASE_TTL_SECONDS": "300",
+    "AGENT_RUNNER_MAX_DAILY_LEASES": "3",
+    "AGENT_RUNNER_MAX_LEASE_TTL_SECONDS": "300",
     "AGENT_RUNNER_REPOSITORY": "voyantjs/voyant",
     "AGENT_RUNNER_TICK_KEY_PREFIX": "prod"
+  },
+  "triggers": {
+    "crons": ["*/15 * * * *"]
   },
   "d1_databases": [
     {


### PR DESCRIPTION
## Summary

- Enable the deployed runner's lease-only Cron path with a narrow `sync-pr` action policy.
- Add a default lease TTL config so scheduled leases are capped at 300 seconds.
- Document the production pilot limits: one action, short TTL, three leases per day, and external command execution.

## Validation

- `pnpm --dir apps/agent-runner test`
- `pnpm --dir apps/agent-runner typecheck`
- `pnpm --dir apps/agent-runner lint`
- `pnpm agent:queue:deployment-doctor -- --repo voyantjs/voyant --json`
- `pnpm agent:queue:deployment-doctor -- --smoke-tick --repo voyantjs/voyant --json`
- Deployed real supervisor tick returned `no dispatchable recommendation matched` with `--ttl-seconds 300`.
