### PR TITLE
Add Sprite API remote adapter

### DIFF
--- a/.agents/remote-workspaces.example.mjs
+++ b/.agents/remote-workspaces.example.mjs
@@ -1,5 +1,5 @@
-import { spriteCliRemoteWorkspaceAdapter } from "../scripts/lib/agent-runner-sprite-workspace.mjs"
+import { spriteRemoteWorkspaceAdapter } from "../scripts/lib/agent-runner-sprite-workspace.mjs"
 
 export const remoteWorkspaceAdapters = {
-  sprite: (workspace) => spriteCliRemoteWorkspaceAdapter(workspace),
+  sprite: (workspace) => spriteRemoteWorkspaceAdapter(workspace),
 }

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -141,7 +141,9 @@ Remote adapter config is intentionally explicit: pass
 trusted `.agents/remote-workspaces.mjs` config on the runner branch. The module
 should export `remoteWorkspaceAdapters` or a default adapter map keyed by
 provider name. Use `.agents/remote-workspaces.example.mjs` as the local template
-for enabling the CLI-backed Sprite adapter.
+for enabling the Sprite adapter. When `SPRITES_TOKEN` or `SPRITE_TOKEN` is set,
+the adapter uses the Sprites API. Without a token it falls back to the local
+`sprite` CLI for one-shot command execution.
 
 When a remote adapter declares command execution, maintainers can run a guarded
 one-shot command without updating Project state:
@@ -152,6 +154,8 @@ pnpm agent:queue:remote-exec -- --workspace sandbox:sprite:<id> --command "pwd" 
 
 This is an adapter validation tool, not the full implementation runner. It does
 not write evidence, open PRs, collect browser artifacts, or perform cleanup.
+Set `SPRITES_API_URL` only when testing against a non-default API endpoint; the
+default is `https://api.sprites.dev`.
 
 Use `remote-bootstrap` to clone or update the repository inside the remote
 workspace before running real commands:

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -812,6 +812,13 @@ reject `sandbox:` workspace references explicitly. Queue recommendation code
 must also pause remote-workspace items with adapter wait states instead of
 dispatching local lifecycle commands.
 
+The Sprite adapter supports two execution paths behind the same provider key:
+an API path using `SPRITES_TOKEN` or `SPRITE_TOKEN`, and a CLI fallback using
+`sprite`. Prefer the API path for unattended runners because it removes the
+local CLI dependency and can own `inspect`, `exec`, and `dispose` through
+documented HTTP endpoints. Keep Sprite-specific details behind the adapter
+boundary; queue state should continue to use `sandbox:sprite:<id>`.
+
 ```ts
 interface AgentWorkspace {
   id: string

--- a/scripts/lib/agent-runner-sprite-workspace.mjs
+++ b/scripts/lib/agent-runner-sprite-workspace.mjs
@@ -1,5 +1,121 @@
 import { spawnSync } from "node:child_process"
 
+const defaultSpritesApiUrl = "https://api.sprites.dev"
+
+export function spriteRemoteWorkspaceAdapter(descriptor, options = {}) {
+  const env = options.env ?? process.env
+  const token = spritesApiToken({ env, token: options.token })
+  if (token) {
+    return spriteApiRemoteWorkspaceAdapter(descriptor, { ...options, token })
+  }
+
+  return spriteCliRemoteWorkspaceAdapter(descriptor, options)
+}
+
+export function spriteApiRemoteWorkspaceAdapter(descriptor, options = {}) {
+  const env = options.env ?? process.env
+  const token = spritesApiToken({ env, token: options.token })
+  const apiUrl = normalizeSpritesApiUrl(
+    options.apiUrl ?? env.SPRITES_API_URL ?? env.SPRITE_API_URL ?? defaultSpritesApiUrl,
+  )
+  const fetchImpl = options.fetchImpl ?? fetch
+
+  return {
+    id: descriptor.id,
+    kind: descriptor.kind,
+    provider: descriptor.provider,
+    ready: false,
+    reason: "inspect has not run",
+    reference: descriptor.reference,
+    capabilities: {
+      inspect: true,
+      exec: true,
+      spawn: false,
+      exposeHttp: false,
+      collectArtifacts: false,
+      dispose: true,
+    },
+    async inspect() {
+      if (!token) {
+        return {
+          apiUrl,
+          capabilities: this.capabilities,
+          id: this.id,
+          kind: this.kind,
+          provider: this.provider,
+          ready: false,
+          reason: "SPRITES_TOKEN or SPRITE_TOKEN is not configured",
+          reference: this.reference,
+        }
+      }
+
+      const response = await requestSpritesApi({
+        apiUrl,
+        fetchImpl,
+        method: "GET",
+        path: `/v1/sprites/${encodeURIComponent(this.id)}`,
+        token,
+      })
+
+      return {
+        apiUrl,
+        capabilities: this.capabilities,
+        id: this.id,
+        kind: this.kind,
+        provider: this.provider,
+        ready: response.ok,
+        reason: response.ok ? null : spriteApiErrorReason(response),
+        reference: this.reference,
+        sprite: response.body ?? null,
+      }
+    },
+    async exec(command) {
+      if (!token) {
+        throw new Error("sprite API exec requires SPRITES_TOKEN or SPRITE_TOKEN")
+      }
+
+      const commandPlan = spriteApiExecPlan(descriptor, command, { env })
+      const response = await requestSpritesApi({
+        apiUrl,
+        fetchImpl,
+        method: "POST",
+        path: `/v1/sprites/${encodeURIComponent(this.id)}/exec?${commandPlan.query.toString()}`,
+        token,
+      })
+      const output = parseSpriteExecResponse(response)
+
+      return {
+        command: commandPlan.displayCommand,
+        signal: null,
+        status: response.ok ? output.status : 1,
+        stderr: response.ok ? output.stderr : output.stderr || spriteApiErrorReason(response),
+        stdout: response.ok ? output.stdout : output.stdout,
+      }
+    },
+    async dispose() {
+      if (!token) {
+        throw new Error("sprite API dispose requires SPRITES_TOKEN or SPRITE_TOKEN")
+      }
+
+      const response = await requestSpritesApi({
+        apiUrl,
+        fetchImpl,
+        method: "DELETE",
+        path: `/v1/sprites/${encodeURIComponent(this.id)}`,
+        token,
+      })
+      if (!response.ok) {
+        throw new Error(spriteApiErrorReason(response))
+      }
+
+      return {
+        disposed: true,
+        status: response.status,
+      }
+    },
+  }
+}
+
 export function spriteCliRemoteWorkspaceAdapter(descriptor, options = {}) {
   const env = options.env ?? process.env
   const cli = options.cli ?? env.SPRITE_CLI ?? "sprite"
@@ -79,6 +195,24 @@ export function spriteExecPlan(descriptor, command, { env = process.env } = {}) 
   }
 }
 
+export function spriteApiExecPlan(_descriptor, command, { env = process.env } = {}) {
+  const normalizedCommand = normalizeWorkspaceCommand(command)
+  const query = new URLSearchParams()
+  for (const part of normalizedCommand.command) {
+    query.append("cmd", part)
+  }
+  if (normalizedCommand.cwd) query.set("dir", normalizedCommand.cwd)
+  for (const [key, value] of Object.entries(normalizedCommand.env ?? {})) {
+    query.append("env", `${key}=${String(value)}`)
+  }
+
+  return {
+    displayCommand: normalizedCommand.command.join(" "),
+    env: { ...env, ...normalizedCommand.env },
+    query,
+  }
+}
+
 function normalizeWorkspaceCommand(command) {
   if (typeof command === "string") {
     return { command: ["bash", "-lc", command], httpPost: true }
@@ -130,4 +264,114 @@ function runSpriteCommand({ cli, env, runProcess, spriteArgs }) {
     stderr: result.stderr?.trim() ?? "",
     stdout: result.stdout?.trim() ?? "",
   }
+}
+
+async function requestSpritesApi({ apiUrl, fetchImpl, method, path, token }) {
+  const response = await fetchImpl(`${apiUrl}${path}`, {
+    headers: {
+      authorization: `Bearer ${token}`,
+    },
+    method,
+  })
+  const text = await response.text()
+
+  return {
+    body: parseJson(text),
+    ok: response.ok,
+    status: response.status,
+    text,
+  }
+}
+
+function parseSpriteExecResponse(response) {
+  const body = response.body
+  if (body && typeof body === "object" && !Array.isArray(body)) {
+    return {
+      status: numberValue(body.exit_code, body.exitCode, body.status) ?? 0,
+      stderr: stringValue(body.stderr, body.error, body.message),
+      stdout: stringValue(body.stdout, body.output, body.logs),
+    }
+  }
+
+  return parseSpriteExecText(response.text)
+}
+
+function parseSpriteExecText(text) {
+  if (!text) return { status: 0, stderr: "", stdout: "" }
+
+  let status = 0
+  let sawStructuredLine = false
+  const stderr = []
+  const stdout = []
+
+  for (const line of text.split(/\r?\n/)) {
+    if (!line.trim()) continue
+    const event = parseJson(line)
+    if (!event || typeof event !== "object" || Array.isArray(event)) {
+      stdout.push(line)
+      continue
+    }
+
+    sawStructuredLine = true
+    const value = stringValue(event.data, event.message, event.payload, event.text)
+    if (event.type === "stderr") {
+      if (value) stderr.push(value)
+      continue
+    }
+    if (event.type === "stdout") {
+      if (value) stdout.push(value)
+      continue
+    }
+    if (event.type === "exit" || event.type === "exited") {
+      status = numberValue(event.exit_code, event.exitCode, event.code) ?? status
+      continue
+    }
+    if (value) stdout.push(value)
+  }
+
+  return {
+    status,
+    stderr: stderr.join("\n"),
+    stdout: sawStructuredLine ? stdout.join("\n") : text,
+  }
+}
+
+function spriteApiErrorReason(response) {
+  const detail = stringValue(response.body?.error, response.body?.message, response.text)
+  return detail
+    ? `sprite API request failed with ${response.status}: ${detail}`
+    : `sprite API request failed with ${response.status}`
+}
+
+function spritesApiToken({ env, token }) {
+  return token ?? env.SPRITES_TOKEN ?? env.SPRITE_TOKEN
+}
+
+function normalizeSpritesApiUrl(url) {
+  return String(url || defaultSpritesApiUrl).replace(/\/+$/, "")
+}
+
+function parseJson(text) {
+  if (!text) return null
+
+  try {
+    return JSON.parse(text)
+  } catch {
+    return null
+  }
+}
+
+function numberValue(...values) {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) return value
+  }
+  return null
+}
+
+function stringValue(...values) {
+  for (const value of values) {
+    if (typeof value === "string") return value
+    if (typeof value === "number" || typeof value === "boolean") return String(value)
+  }
+  return ""
 }

--- a/scripts/tests/agent-runner-sprite-workspace.test.mjs
+++ b/scripts/tests/agent-runner-sprite-workspace.test.mjs
@@ -2,8 +2,11 @@ import assert from "node:assert/strict"
 import { describe, it } from "node:test"
 
 import {
+  spriteApiExecPlan,
+  spriteApiRemoteWorkspaceAdapter,
   spriteCliRemoteWorkspaceAdapter,
   spriteExecPlan,
+  spriteRemoteWorkspaceAdapter,
 } from "../lib/agent-runner-sprite-workspace.mjs"
 import { parseWorkspaceReference } from "../lib/agent-runner-workspace-contract.mjs"
 
@@ -51,6 +54,143 @@ describe("agent runner sprite workspace adapter", () => {
       displayCommand: "bash -lc pnpm test",
       env: {},
     })
+  })
+
+  it("plans API exec query parameters", () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+    const plan = spriteApiExecPlan(
+      descriptor,
+      {
+        args: ["verify:fast"],
+        command: "pnpm",
+        cwd: "/workspace/voyant",
+        env: { CI: "1" },
+      },
+      { env: { SPRITE_ORG: "voyant" } },
+    )
+
+    assert.equal(plan.displayCommand, "pnpm verify:fast")
+    assert.deepEqual(plan.env, { CI: "1", SPRITE_ORG: "voyant" })
+    assert.deepEqual(Array.from(plan.query.entries()), [
+      ["cmd", "pnpm"],
+      ["cmd", "verify:fast"],
+      ["dir", "/workspace/voyant"],
+      ["env", "CI=1"],
+    ])
+  })
+
+  it("inspects and executes through the Sprite API when a token is configured", async () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+    const calls = []
+    const adapter = spriteApiRemoteWorkspaceAdapter(descriptor, {
+      env: { SPRITES_TOKEN: "token" },
+      fetchImpl: async (url, init) => {
+        calls.push({ headers: init.headers, method: init.method, url: String(url) })
+        if (init.method === "GET") {
+          return jsonResponse({ name: "task-579", status: "running" })
+        }
+
+        return jsonResponse({
+          exit_code: 2,
+          stderr: "bad",
+          stdout: "out",
+        })
+      },
+    })
+
+    assert.deepEqual(await adapter.inspect(), {
+      apiUrl: "https://api.sprites.dev",
+      capabilities: {
+        inspect: true,
+        exec: true,
+        spawn: false,
+        exposeHttp: false,
+        collectArtifacts: false,
+        dispose: true,
+      },
+      id: "task-579",
+      kind: "remote-sandbox",
+      provider: "sprite",
+      ready: true,
+      reason: null,
+      reference: "sandbox:sprite:task-579",
+      sprite: { name: "task-579", status: "running" },
+    })
+    assert.deepEqual(await adapter.exec({ args: ["test"], command: "pnpm" }), {
+      command: "pnpm test",
+      signal: null,
+      status: 2,
+      stderr: "bad",
+      stdout: "out",
+    })
+    assert.deepEqual(calls, [
+      {
+        headers: { authorization: "Bearer token" },
+        method: "GET",
+        url: "https://api.sprites.dev/v1/sprites/task-579",
+      },
+      {
+        headers: { authorization: "Bearer token" },
+        method: "POST",
+        url: "https://api.sprites.dev/v1/sprites/task-579/exec?cmd=pnpm&cmd=test",
+      },
+    ])
+  })
+
+  it("parses API exec NDJSON output", async () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+    const adapter = spriteApiRemoteWorkspaceAdapter(descriptor, {
+      env: { SPRITES_TOKEN: "token" },
+      fetchImpl: async () =>
+        new Response(
+          [
+            JSON.stringify({ data: "hello", type: "stdout" }),
+            JSON.stringify({ data: "warning", type: "stderr" }),
+            JSON.stringify({ exit_code: 7, type: "exit" }),
+          ].join("\n"),
+          { status: 200 },
+        ),
+    })
+
+    assert.deepEqual(await adapter.exec("pnpm test"), {
+      command: "bash -lc pnpm test",
+      signal: null,
+      status: 7,
+      stderr: "warning",
+      stdout: "hello",
+    })
+  })
+
+  it("disposes through the Sprite API", async () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+    const calls = []
+    const adapter = spriteApiRemoteWorkspaceAdapter(descriptor, {
+      env: { SPRITES_TOKEN: "token" },
+      fetchImpl: async (url, init) => {
+        calls.push({ method: init.method, url: String(url) })
+        return new Response(null, { status: 204 })
+      },
+    })
+
+    assert.deepEqual(await adapter.dispose(), { disposed: true, status: 204 })
+    assert.deepEqual(calls, [
+      {
+        method: "DELETE",
+        url: "https://api.sprites.dev/v1/sprites/task-579",
+      },
+    ])
+  })
+
+  it("falls back to the CLI adapter when no API token is configured", async () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
+    const adapter = spriteRemoteWorkspaceAdapter(descriptor, {
+      runProcess() {
+        return { error: new Error("not found"), status: null, stderr: "", stdout: "" }
+      },
+    })
+
+    assert.equal(adapter.capabilities.dispose, false)
+    assert.equal((await adapter.inspect()).reason, "not found")
   })
 
   it("executes through an injected CLI process", async () => {
@@ -125,3 +265,11 @@ describe("agent runner sprite workspace adapter", () => {
     })
   })
 })
+
+function jsonResponse(body, init = {}) {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+    status: 200,
+    ...init,
+  })
+}


### PR DESCRIPTION
## Summary
- add a Sprite API-backed remote workspace adapter for inspect, exec, and dispose
- add a configured Sprite pool with Durable Object slot leases for remote-bootstrap dispatch
- map logical slot workspaces like sandbox:sprite:voyant-agent-01-slot-1 back to their backing Sprite while keeping per-slot repo directories separate
- keep the existing CLI adapter as fallback when no Sprite API token is configured
- update remote workspace docs, architecture docs, runner config, and example config

## Validation
- node --test scripts/tests/agent-runner-sprite-workspace.test.mjs scripts/tests/agent-runner-remote-workspace.test.mjs
- pnpm --filter @voyantjs/agent-runner test -- --runInBand
- pnpm --filter @voyantjs/agent-control-plane test -- --runInBand
- pnpm --filter @voyantjs/agent-runner typecheck
- pnpm --filter @voyantjs/agent-control-plane typecheck
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- git diff --check
- git push pre-push hook: pnpm test