### PR TITLE
[codex] Enrich invoice issued events for SmartBill

### DIFF
--- a/.changeset/smartbill-invoice-events.md
+++ b/.changeset/smartbill-invoice-events.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/finance": patch
+---
+
+Enrich `invoice.issued` and `invoice.proforma.issued` event payloads with booking contact fields, issue/due dates, and persisted invoice line items so billing adapter default mappers can build complete invoice bodies.

--- a/packages/finance/src/service-issue.ts
+++ b/packages/finance/src/service-issue.ts
@@ -33,16 +33,16 @@ export interface InvoiceIssuedEvent {
   currency: string
   /** Linkage when this invoice replaced a proforma. */
   convertedFromInvoiceId?: string | null
-  clientName: string
-  clientEmail: string | null
-  clientPhone: string | null
-  clientAddress: string | null
-  clientCity: string | null
-  clientCounty: string | null
-  clientCountry: string | null
-  clientVatCode: string | null
-  clientRegCom: string | null
-  lineItems: InvoiceIssuedLineItem[]
+  clientName?: string
+  clientEmail?: string | null
+  clientPhone?: string | null
+  clientAddress?: string | null
+  clientCity?: string | null
+  clientCounty?: string | null
+  clientCountry?: string | null
+  clientVatCode?: string | null
+  clientRegCom?: string | null
+  lineItems?: InvoiceIssuedLineItem[]
   bookingNumber?: string | null
   issueDate?: string
   dueDate?: string

--- a/packages/finance/src/service-issue.ts
+++ b/packages/finance/src/service-issue.ts
@@ -1,8 +1,9 @@
+import { bookings } from "@voyantjs/bookings/schema"
 import type { EventBus } from "@voyantjs/core"
-import { eq } from "drizzle-orm"
+import { asc, eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
-import { invoices } from "./schema.js"
+import { invoiceLineItems, invoices } from "./schema.js"
 import {
   type CreateInvoiceFromBookingInput,
   financeService,
@@ -32,6 +33,28 @@ export interface InvoiceIssuedEvent {
   currency: string
   /** Linkage when this invoice replaced a proforma. */
   convertedFromInvoiceId?: string | null
+  clientName: string
+  clientEmail: string | null
+  clientPhone: string | null
+  clientAddress: string | null
+  clientCity: string | null
+  clientCounty: string | null
+  clientCountry: string | null
+  clientVatCode: string | null
+  clientRegCom: string | null
+  lineItems: InvoiceIssuedLineItem[]
+  bookingNumber?: string | null
+  issueDate?: string
+  dueDate?: string
+}
+
+export interface InvoiceIssuedLineItem {
+  description: string
+  quantity: number
+  unitPrice: number
+  currency: string
+  taxPercentage?: number
+  isService?: boolean
 }
 
 const ISSUED_EVENT = "invoice.issued"
@@ -59,7 +82,7 @@ export async function issueInvoiceFromBooking(
     .returning()
 
   const row = issued ?? draft
-  await emitIssued(runtime, ISSUED_EVENT, row)
+  await emitIssued(db, runtime, ISSUED_EVENT, row)
   return row
 }
 
@@ -85,16 +108,25 @@ export async function issueProformaFromBooking(
     .returning()
 
   const row = issued ?? draft
-  await emitIssued(runtime, PROFORMA_ISSUED_EVENT, row)
+  await emitIssued(db, runtime, PROFORMA_ISSUED_EVENT, row)
   return row
 }
 
 async function emitIssued(
+  db: PostgresJsDatabase,
   runtime: InvoiceIssueRuntime,
   eventName: typeof ISSUED_EVENT | typeof PROFORMA_ISSUED_EVENT,
   invoice: typeof invoices.$inferSelect,
 ): Promise<void> {
   if (!runtime.eventBus) return
+  const [booking] = invoice.bookingId
+    ? await db.select().from(bookings).where(eq(bookings.id, invoice.bookingId)).limit(1)
+    : []
+  const lines = await db
+    .select()
+    .from(invoiceLineItems)
+    .where(eq(invoiceLineItems.invoiceId, invoice.id))
+    .orderBy(asc(invoiceLineItems.sortOrder))
   const payload: InvoiceIssuedEvent = {
     invoiceId: invoice.id,
     invoiceNumber: invoice.invoiceNumber,
@@ -103,6 +135,41 @@ async function emitIssued(
     totalCents: invoice.totalCents,
     currency: invoice.currency,
     convertedFromInvoiceId: invoice.convertedFromInvoiceId,
+    clientName: buildClientName(booking),
+    clientEmail: booking?.contactEmail ?? null,
+    clientPhone: booking?.contactPhone ?? null,
+    clientAddress: booking?.contactAddressLine1 ?? null,
+    clientCity: booking?.contactCity ?? null,
+    clientCounty: booking?.contactRegion ?? null,
+    clientCountry: booking?.contactCountry ?? null,
+    clientVatCode: null,
+    clientRegCom: null,
+    lineItems: lines.map((line) => ({
+      description: line.description,
+      quantity: line.quantity,
+      unitPrice: centsToMajor(line.unitPriceCents),
+      currency: invoice.currency,
+      ...(line.taxRate == null ? {} : { taxPercentage: line.taxRate }),
+      isService: true,
+    })),
+    bookingNumber: booking?.bookingNumber ?? null,
+    issueDate: toDateString(invoice.issueDate),
+    dueDate: toDateString(invoice.dueDate),
   }
   await runtime.eventBus.emit(eventName, payload)
+}
+
+function buildClientName(booking: typeof bookings.$inferSelect | undefined): string {
+  const name = [booking?.contactFirstName, booking?.contactLastName]
+    .filter((part): part is string => typeof part === "string" && part.length > 0)
+    .join(" ")
+  return name || "Client"
+}
+
+function centsToMajor(cents: number): number {
+  return cents / 100
+}
+
+function toDateString(value: string | Date): string {
+  return typeof value === "string" ? value : value.toISOString().slice(0, 10)
 }

--- a/packages/finance/tests/unit/service-issue.test.ts
+++ b/packages/finance/tests/unit/service-issue.test.ts
@@ -1,0 +1,150 @@
+import { createEventBus, type EventEnvelope } from "@voyantjs/core"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { financeService } from "../../src/service.js"
+import { type InvoiceIssuedEvent, issueInvoiceFromBooking } from "../../src/service-issue.js"
+
+vi.mock("../../src/service.js", () => ({
+  financeService: {
+    createInvoiceFromBooking: vi.fn(),
+  },
+}))
+
+describe("issueInvoiceFromBooking", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("emits invoice.issued with booking contact fields and invoice line items", async () => {
+    const draftInvoice = {
+      id: "inv_123",
+      invoiceNumber: "INV-1",
+      invoiceType: "invoice",
+      bookingId: "book_123",
+      totalCents: 13500,
+      currency: "RON",
+      convertedFromInvoiceId: null,
+      issueDate: "2026-05-13",
+      dueDate: "2026-05-20",
+    }
+    const issuedInvoice = { ...draftInvoice, status: "sent" }
+    const booking = {
+      bookingNumber: "BK-1",
+      contactFirstName: "Ana",
+      contactLastName: "Popescu",
+      contactEmail: "ana@example.com",
+      contactPhone: "+40720000000",
+      contactAddressLine1: "Strada 1",
+      contactCity: "Cluj-Napoca",
+      contactRegion: "Cluj",
+      contactCountry: "RO",
+    }
+    const lineRows = [
+      {
+        description: "City tour",
+        quantity: 2,
+        unitPriceCents: 6000,
+        taxRate: 19,
+      },
+      {
+        description: "Booking fee",
+        quantity: 1,
+        unitPriceCents: 1500,
+        taxRate: null,
+      },
+    ]
+    vi.mocked(financeService.createInvoiceFromBooking).mockResolvedValue(
+      draftInvoice as Awaited<ReturnType<typeof financeService.createInvoiceFromBooking>>,
+    )
+
+    const db = {
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn(() => ({
+            returning: vi.fn(async () => [issuedInvoice]),
+          })),
+        })),
+      })),
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(async () => [booking]),
+            orderBy: vi.fn(async () => lineRows),
+          })),
+        })),
+      })),
+    } as PostgresJsDatabase
+
+    const eventBus = createEventBus()
+    const emitted: Array<EventEnvelope<InvoiceIssuedEvent>> = []
+    eventBus.subscribe<InvoiceIssuedEvent>("invoice.issued", (event) => {
+      emitted.push(event)
+    })
+
+    await issueInvoiceFromBooking(
+      db,
+      {
+        invoiceNumber: "INV-1",
+        bookingId: "book_123",
+        issueDate: "2026-05-13",
+        dueDate: "2026-05-20",
+      },
+      {
+        booking: {
+          id: "book_123",
+          bookingNumber: "BK-1",
+          personId: null,
+          organizationId: null,
+          sellCurrency: "RON",
+          baseCurrency: null,
+          fxRateSetId: null,
+          sellAmountCents: 13500,
+          baseSellAmountCents: null,
+        },
+        items: [],
+      },
+      { eventBus },
+    )
+
+    expect(emitted).toHaveLength(1)
+    expect(emitted[0]?.data).toMatchObject({
+      invoiceId: "inv_123",
+      invoiceNumber: "INV-1",
+      invoiceType: "invoice",
+      bookingId: "book_123",
+      totalCents: 13500,
+      currency: "RON",
+      convertedFromInvoiceId: null,
+      clientName: "Ana Popescu",
+      clientEmail: "ana@example.com",
+      clientPhone: "+40720000000",
+      clientAddress: "Strada 1",
+      clientCity: "Cluj-Napoca",
+      clientCounty: "Cluj",
+      clientCountry: "RO",
+      clientVatCode: null,
+      clientRegCom: null,
+      bookingNumber: "BK-1",
+      issueDate: "2026-05-13",
+      dueDate: "2026-05-20",
+      lineItems: [
+        {
+          description: "City tour",
+          quantity: 2,
+          unitPrice: 60,
+          currency: "RON",
+          taxPercentage: 19,
+          isService: true,
+        },
+        {
+          description: "Booking fee",
+          quantity: 1,
+          unitPrice: 15,
+          currency: "RON",
+          isService: true,
+        },
+      ],
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes #824.

This enriches the `invoice.issued` and `invoice.proforma.issued` payloads emitted by `@voyantjs/finance` so default billing-provider mappers have enough data to build a real invoice body.

## Changes

- Load the booking contact row and persisted `invoice_line_items` before emitting issued invoice events.
- Include client fields, booking number, issue/due dates, and line items with major-unit `unitPrice` values in emitted payloads.
- Keep the newly documented event fields optional in the exported TypeScript interface so existing test fixtures and consumers remain source-compatible.
- Add a unit test covering the SmartBill-relevant payload shape and cents-to-major-unit conversion.
- Add a patch changeset for `@voyantjs/finance`.

## Validation

- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/finance lint`
- `pnpm exec biome check packages/finance/tests/unit/service-issue.test.ts`
- `pnpm --filter @voyantjs/finance test -- tests/unit/service-issue.test.ts`
- Pre-push hook: root `pnpm test` via `scripts/run-tests.cjs`