### PR TITLE
[codex] Expand product form editable fields

### DIFF
--- a/.changeset/product-form-detail-fields.md
+++ b/.changeset/product-form-detail-fields.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/products-ui": patch
+---
+
+Extend ProductForm to edit detail-page product fields including facility, tax class, visibility, capacity mode, timezone, pax, and reservation timeout.

--- a/packages/products-ui/src/components/product-facility-combobox.tsx
+++ b/packages/products-ui/src/components/product-facility-combobox.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import { fetchWithValidation, useVoyantProductsContext } from "@voyantjs/products-react"
+import {
+  Combobox,
+  ComboboxCollection,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from "@voyantjs/ui/components/combobox"
+import * as React from "react"
+import { z } from "zod"
+
+import { useProductsUiMessagesOrDefault } from "../i18n/provider.js"
+
+type Props = {
+  value: string | null | undefined
+  onChange: (value: string | null) => void
+  placeholder?: string
+  disabled?: boolean
+}
+
+const PAGE_SIZE = 25
+
+const facilityRecordSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    kind: z.string().nullable().optional(),
+    code: z.string().nullable().optional(),
+    country: z.string().nullable().optional(),
+  })
+  .passthrough()
+
+type FacilityRecord = z.infer<typeof facilityRecordSchema>
+
+const facilityListResponse = z.object({
+  data: z.array(facilityRecordSchema),
+  total: z.number().int(),
+  limit: z.number().int(),
+  offset: z.number().int(),
+})
+
+const facilitySingleResponse = z.object({ data: facilityRecordSchema })
+
+function useFacilityOptions(search: string) {
+  const { baseUrl, fetcher } = useVoyantProductsContext()
+
+  return useQuery({
+    queryKey: ["voyant", "products-ui", "facility-combobox", "list", { search }] as const,
+    queryFn: () => {
+      const params = new URLSearchParams()
+      params.set("limit", String(PAGE_SIZE))
+      params.set("status", "active")
+      if (search) params.set("search", search)
+      return fetchWithValidation(`/v1/facilities/facilities?${params}`, facilityListResponse, {
+        baseUrl,
+        fetcher,
+      })
+    },
+  })
+}
+
+function useSelectedFacility(id: string | null | undefined) {
+  const { baseUrl, fetcher } = useVoyantProductsContext()
+
+  return useQuery({
+    queryKey: ["voyant", "products-ui", "facility-combobox", "detail", id] as const,
+    queryFn: async () => {
+      if (!id) throw new Error("useSelectedFacility requires an id")
+      const { data } = await fetchWithValidation(
+        `/v1/facilities/facilities/${id}`,
+        facilitySingleResponse,
+        { baseUrl, fetcher },
+      )
+      return data
+    },
+    enabled: Boolean(id),
+  })
+}
+
+export function ProductFacilityCombobox({ value, onChange, placeholder, disabled }: Props) {
+  const messages = useProductsUiMessagesOrDefault()
+  const [search, setSearch] = React.useState("")
+  const listQuery = useFacilityOptions(search)
+  const selectedQuery = useSelectedFacility(value)
+
+  const items = React.useMemo(() => {
+    const map = new Map<string, FacilityRecord>()
+    for (const item of listQuery.data?.data ?? []) map.set(item.id, item)
+    if (selectedQuery.data) map.set(selectedQuery.data.id, selectedQuery.data)
+    return Array.from(map.values())
+  }, [listQuery.data?.data, selectedQuery.data])
+
+  const itemMap = React.useMemo(() => new Map(items.map((item) => [item.id, item])), [items])
+  const selected = value ? itemMap.get(value) : undefined
+  const selectedLabel = selected ? selected.name : ""
+  const [inputValue, setInputValue] = React.useState(selectedLabel)
+
+  React.useEffect(() => {
+    setInputValue(selectedLabel)
+  }, [selectedLabel])
+
+  return (
+    <Combobox
+      items={items.map((item) => item.id)}
+      value={value ?? null}
+      inputValue={inputValue}
+      autoHighlight
+      disabled={disabled}
+      itemToStringValue={(id) => itemMap.get(id as string)?.name ?? ""}
+      onInputValueChange={(next) => {
+        setInputValue(next)
+        setSearch(next)
+        if (!next) onChange(null)
+      }}
+      onValueChange={(next) => {
+        const id = (next as string | null) ?? null
+        onChange(id)
+        setInputValue(id ? (itemMap.get(id)?.name ?? "") : "")
+      }}
+    >
+      <ComboboxInput
+        placeholder={placeholder ?? messages.comboboxes.facility.placeholder}
+        showClear={!!value}
+      />
+      <ComboboxContent>
+        <ComboboxEmpty>
+          {listQuery.isPending || selectedQuery.isPending
+            ? messages.common.loading
+            : messages.comboboxes.facility.empty}
+        </ComboboxEmpty>
+        <ComboboxList>
+          <ComboboxCollection>
+            {(id) => {
+              const item = itemMap.get(id as string)
+              if (!item) return null
+              const subtitle = [item.kind, item.code, item.country].filter(Boolean).join(" · ")
+              return (
+                <ComboboxItem key={item.id} value={item.id}>
+                  <div className="flex min-w-0 flex-col">
+                    <span className="truncate font-medium">{item.name}</span>
+                    {subtitle ? (
+                      <span className="truncate text-xs text-muted-foreground">{subtitle}</span>
+                    ) : null}
+                  </div>
+                </ComboboxItem>
+              )
+            }}
+          </ComboboxCollection>
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
+  )
+}

--- a/packages/products-ui/src/components/product-form.tsx
+++ b/packages/products-ui/src/components/product-form.tsx
@@ -21,6 +21,8 @@ import { Textarea } from "@voyantjs/ui/components/textarea"
 import { Loader2, X } from "lucide-react"
 import * as React from "react"
 import { useProductsUiMessagesOrDefault } from "../i18n/index.js"
+import { ProductFacilityCombobox } from "./product-facility-combobox.js"
+import { ProductTaxClassCombobox } from "./product-tax-class-combobox.js"
 import { ProductTypeCombobox } from "./product-type-combobox.js"
 
 export type ProductFormMode = { kind: "create" } | { kind: "edit"; product: ProductRecord }
@@ -36,10 +38,17 @@ interface FormState {
   description: string
   status: "draft" | "active" | "archived"
   bookingMode: "date" | "date_time" | "open" | "stay" | "transfer" | "itinerary" | "other"
+  capacityMode: ProductRecord["capacityMode"]
+  visibility: ProductRecord["visibility"]
+  timezone: string
+  facilityId: string
   productTypeId: string
+  taxClassId: string
   sellCurrency: string
   sellAmount: string
   costAmount: string
+  pax: string
+  reservationTimeoutMinutes: string
   tags: string[]
 }
 
@@ -51,10 +60,18 @@ function initialState(mode: ProductFormMode): FormState {
       description: product.description ?? "",
       status: product.status,
       bookingMode: product.bookingMode,
+      capacityMode: product.capacityMode,
+      visibility: product.visibility,
+      timezone: product.timezone ?? "",
+      facilityId: product.facilityId ?? "__none__",
       productTypeId: product.productTypeId ?? "__none__",
+      taxClassId: product.taxClassId ?? "__none__",
       sellCurrency: product.sellCurrency,
       sellAmount: product.sellAmountCents != null ? String(product.sellAmountCents / 100) : "",
       costAmount: product.costAmountCents != null ? String(product.costAmountCents / 100) : "",
+      pax: product.pax != null ? String(product.pax) : "",
+      reservationTimeoutMinutes:
+        product.reservationTimeoutMinutes != null ? String(product.reservationTimeoutMinutes) : "",
       tags: product.tags ?? [],
     }
   }
@@ -64,10 +81,17 @@ function initialState(mode: ProductFormMode): FormState {
     description: "",
     status: "draft",
     bookingMode: "itinerary",
+    capacityMode: "limited",
+    visibility: "private",
+    timezone: "",
+    facilityId: "__none__",
     productTypeId: "__none__",
+    taxClassId: "__none__",
     sellCurrency: "EUR", // i18n-literal-ok ISO default currency
     sellAmount: "",
     costAmount: "",
+    pax: "",
+    reservationTimeoutMinutes: "",
     tags: [],
   }
 }
@@ -80,16 +104,36 @@ function toAmountCents(value: string): number | null {
   return Math.round(parsed * 100)
 }
 
+function toIntegerOrNull(value: string): number | null {
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  const parsed = Number(trimmed)
+  if (!Number.isInteger(parsed) || parsed < 0) return null
+  return parsed
+}
+
+function toPositiveIntegerOrNull(value: string): number | null {
+  const parsed = toIntegerOrNull(value)
+  return parsed == null || parsed < 1 ? null : parsed
+}
+
 function toPayload(state: FormState): CreateProductInput {
   return {
     name: state.name.trim(),
     description: state.description.trim() || null,
     status: state.status,
     bookingMode: state.bookingMode,
+    capacityMode: state.capacityMode,
+    visibility: state.visibility,
+    timezone: state.timezone.trim() || null,
+    facilityId: state.facilityId === "__none__" ? null : state.facilityId,
     productTypeId: state.productTypeId === "__none__" ? null : state.productTypeId,
+    taxClassId: state.taxClassId === "__none__" ? null : state.taxClassId,
     sellCurrency: state.sellCurrency.trim().toUpperCase(),
     sellAmountCents: toAmountCents(state.sellAmount),
     costAmountCents: toAmountCents(state.costAmount),
+    pax: toPositiveIntegerOrNull(state.pax),
+    reservationTimeoutMinutes: toIntegerOrNull(state.reservationTimeoutMinutes),
     tags: state.tags,
   }
 }
@@ -125,6 +169,24 @@ export function ProductForm({ mode, onSuccess, onCancel }: ProductFormProps) {
       ] as const,
     [messages],
   )
+  const capacityModes = React.useMemo(
+    () =>
+      [
+        { value: "free_sale", label: messages.common.productCapacityModeLabels.free_sale },
+        { value: "limited", label: messages.common.productCapacityModeLabels.limited },
+        { value: "on_request", label: messages.common.productCapacityModeLabels.on_request },
+      ] as const,
+    [messages],
+  )
+  const visibilityOptions = React.useMemo(
+    () =>
+      [
+        { value: "public", label: messages.common.productVisibilityLabels.public },
+        { value: "private", label: messages.common.productVisibilityLabels.private },
+        { value: "hidden", label: messages.common.productVisibilityLabels.hidden },
+      ] as const,
+    [messages],
+  )
 
   const field =
     <K extends keyof FormState>(key: K) =>
@@ -146,6 +208,19 @@ export function ProductForm({ mode, onSuccess, onCancel }: ProductFormProps) {
       return
     }
 
+    if (state.pax.trim() && toPositiveIntegerOrNull(state.pax) == null) {
+      setError(productMessages.validation.paxInvalid)
+      return
+    }
+
+    if (
+      state.reservationTimeoutMinutes.trim() &&
+      toIntegerOrNull(state.reservationTimeoutMinutes) == null
+    ) {
+      setError(productMessages.validation.reservationTimeoutInvalid)
+      return
+    }
+
     const payload = toPayload(state)
 
     try {
@@ -160,7 +235,11 @@ export function ProductForm({ mode, onSuccess, onCancel }: ProductFormProps) {
   }
 
   return (
-    <form data-slot="product-form" onSubmit={handleSubmit} className="flex flex-col gap-4">
+    <form
+      data-slot="product-form"
+      onSubmit={handleSubmit}
+      className="flex min-h-0 flex-col gap-4 overflow-y-auto pr-1"
+    >
       <div className="grid grid-cols-1 gap-4">
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="product-name">{productMessages.fields.name}</Label>
@@ -266,6 +345,106 @@ export function ProductForm({ mode, onSuccess, onCancel }: ProductFormProps) {
               value={state.productTypeId === "__none__" ? null : state.productTypeId}
               onChange={(value) => field("productTypeId")(value ?? "__none__")}
               placeholder={productMessages.placeholders.productTypeSearch}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label>{productMessages.fields.facility}</Label>
+            <ProductFacilityCombobox
+              value={state.facilityId === "__none__" ? null : state.facilityId}
+              onChange={(value) => field("facilityId")(value ?? "__none__")}
+              placeholder={productMessages.placeholders.facilitySearch}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label>{productMessages.fields.taxClass}</Label>
+            <ProductTaxClassCombobox
+              value={state.taxClassId === "__none__" ? null : state.taxClassId}
+              onChange={(value) => field("taxClassId")(value ?? "__none__")}
+              placeholder={productMessages.placeholders.taxClassSearch}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label>{productMessages.fields.visibility}</Label>
+            <Select
+              items={visibilityOptions}
+              value={state.visibility}
+              onValueChange={(value) =>
+                value && field("visibility")(value as FormState["visibility"])
+              }
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {visibilityOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label>{productMessages.fields.capacityMode}</Label>
+            <Select
+              items={capacityModes}
+              value={state.capacityMode}
+              onValueChange={(value) =>
+                value && field("capacityMode")(value as FormState["capacityMode"])
+              }
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {capacityModes.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="product-timezone">{productMessages.fields.timezone}</Label>
+            <Input
+              id="product-timezone"
+              value={state.timezone}
+              onChange={(event) => field("timezone")(event.target.value)}
+              placeholder={productMessages.placeholders.timezone}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="product-pax">{productMessages.fields.pax}</Label>
+            <Input
+              id="product-pax"
+              type="number"
+              min="1"
+              step="1"
+              value={state.pax}
+              onChange={(event) => field("pax")(event.target.value)}
+              placeholder={productMessages.placeholders.pax}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="product-reservation-timeout">
+              {productMessages.fields.reservationTimeout}
+            </Label>
+            <Input
+              id="product-reservation-timeout"
+              type="number"
+              min="0"
+              step="1"
+              value={state.reservationTimeoutMinutes}
+              onChange={(event) => field("reservationTimeoutMinutes")(event.target.value)}
+              placeholder={productMessages.placeholders.reservationTimeout}
             />
           </div>
 

--- a/packages/products-ui/src/components/product-tax-class-combobox.tsx
+++ b/packages/products-ui/src/components/product-tax-class-combobox.tsx
@@ -1,0 +1,165 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import { fetchWithValidation, useVoyantProductsContext } from "@voyantjs/products-react"
+import {
+  Combobox,
+  ComboboxCollection,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from "@voyantjs/ui/components/combobox"
+import * as React from "react"
+import { z } from "zod"
+
+import { useProductsUiMessagesOrDefault } from "../i18n/provider.js"
+
+type Props = {
+  value: string | null | undefined
+  onChange: (value: string | null) => void
+  placeholder?: string
+  disabled?: boolean
+}
+
+const PAGE_SIZE = 100
+
+const taxClassRecordSchema = z
+  .object({
+    id: z.string(),
+    code: z.string(),
+    label: z.string(),
+    description: z.string().nullable().optional(),
+    active: z.boolean(),
+  })
+  .passthrough()
+
+type TaxClassRecord = z.infer<typeof taxClassRecordSchema>
+
+const taxClassListResponse = z.object({
+  data: z.array(taxClassRecordSchema),
+  total: z.number().int(),
+  limit: z.number().int(),
+  offset: z.number().int(),
+})
+
+const taxClassSingleResponse = z.object({ data: taxClassRecordSchema })
+
+function useTaxClassOptions() {
+  const { baseUrl, fetcher } = useVoyantProductsContext()
+
+  return useQuery({
+    queryKey: ["voyant", "products-ui", "tax-class-combobox", "list"] as const,
+    queryFn: () => {
+      const params = new URLSearchParams()
+      params.set("limit", String(PAGE_SIZE))
+      params.set("active", "true")
+      return fetchWithValidation(`/v1/finance/tax-classes?${params}`, taxClassListResponse, {
+        baseUrl,
+        fetcher,
+      })
+    },
+  })
+}
+
+function useSelectedTaxClass(id: string | null | undefined) {
+  const { baseUrl, fetcher } = useVoyantProductsContext()
+
+  return useQuery({
+    queryKey: ["voyant", "products-ui", "tax-class-combobox", "detail", id] as const,
+    queryFn: async () => {
+      if (!id) throw new Error("useSelectedTaxClass requires an id")
+      const { data } = await fetchWithValidation(
+        `/v1/finance/tax-classes/${id}`,
+        taxClassSingleResponse,
+        { baseUrl, fetcher },
+      )
+      return data
+    },
+    enabled: Boolean(id),
+  })
+}
+
+export function ProductTaxClassCombobox({ value, onChange, placeholder, disabled }: Props) {
+  const messages = useProductsUiMessagesOrDefault()
+  const [search, setSearch] = React.useState("")
+  const listQuery = useTaxClassOptions()
+  const selectedQuery = useSelectedTaxClass(value)
+
+  const items = React.useMemo(() => {
+    const map = new Map<string, TaxClassRecord>()
+    for (const item of listQuery.data?.data ?? []) map.set(item.id, item)
+    if (selectedQuery.data) map.set(selectedQuery.data.id, selectedQuery.data)
+    const normalizedSearch = search.trim().toLowerCase()
+    const values = Array.from(map.values())
+    if (!normalizedSearch) return values
+    return values.filter(
+      (item) =>
+        item.label.toLowerCase().includes(normalizedSearch) ||
+        item.code.toLowerCase().includes(normalizedSearch),
+    )
+  }, [listQuery.data?.data, search, selectedQuery.data])
+
+  const itemMap = React.useMemo(() => new Map(items.map((item) => [item.id, item])), [items])
+  const selected = value ? itemMap.get(value) : selectedQuery.data
+  const selectedLabel = selected ? `${selected.label} · ${selected.code}` : ""
+  const [inputValue, setInputValue] = React.useState(selectedLabel)
+
+  React.useEffect(() => {
+    setInputValue(selectedLabel)
+  }, [selectedLabel])
+
+  return (
+    <Combobox
+      items={items.map((item) => item.id)}
+      value={value ?? null}
+      inputValue={inputValue}
+      autoHighlight
+      disabled={disabled}
+      itemToStringValue={(id) => {
+        const item = itemMap.get(id as string)
+        return item ? `${item.label} · ${item.code}` : ""
+      }}
+      onInputValueChange={(next) => {
+        setInputValue(next)
+        setSearch(next)
+        if (!next) onChange(null)
+      }}
+      onValueChange={(next) => {
+        const id = (next as string | null) ?? null
+        onChange(id)
+        const item = id ? itemMap.get(id) : null
+        setInputValue(item ? `${item.label} · ${item.code}` : "")
+      }}
+    >
+      <ComboboxInput
+        placeholder={placeholder ?? messages.comboboxes.taxClass.placeholder}
+        showClear={!!value}
+      />
+      <ComboboxContent>
+        <ComboboxEmpty>
+          {listQuery.isPending || selectedQuery.isPending
+            ? messages.common.loading
+            : messages.comboboxes.taxClass.empty}
+        </ComboboxEmpty>
+        <ComboboxList>
+          <ComboboxCollection>
+            {(id) => {
+              const item = itemMap.get(id as string)
+              if (!item) return null
+              return (
+                <ComboboxItem key={item.id} value={item.id}>
+                  <div className="flex min-w-0 flex-col">
+                    <span className="truncate font-medium">{item.label}</span>
+                    <span className="truncate text-xs text-muted-foreground">{item.code}</span>
+                  </div>
+                </ComboboxItem>
+              )
+            }}
+          </ComboboxCollection>
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
+  )
+}

--- a/packages/products-ui/src/i18n/en.ts
+++ b/packages/products-ui/src/i18n/en.ts
@@ -45,6 +45,16 @@ export const productsUiEn = {
       itinerary: "Itinerary",
       other: "Other",
     },
+    productCapacityModeLabels: {
+      free_sale: "Free sale",
+      limited: "Limited",
+      on_request: "On request",
+    },
+    productVisibilityLabels: {
+      public: "Public",
+      private: "Private",
+      hidden: "Hidden",
+    },
   },
   comboboxes: {
     product: {
@@ -58,6 +68,14 @@ export const productsUiEn = {
     productType: {
       placeholder: "Search product types...",
       empty: "No product types found.",
+    },
+    facility: {
+      placeholder: "Search facilities...",
+      empty: "No facilities found.",
+    },
+    taxClass: {
+      placeholder: "Search tax classes...",
+      empty: "No tax classes found.",
     },
   },
   catalogCard: {
@@ -157,6 +175,13 @@ export const productsUiEn = {
       status: "Status",
       bookingMode: "Booking Mode",
       productType: "Product Type",
+      facility: "Facility",
+      taxClass: "Tax Class",
+      visibility: "Visibility",
+      capacityMode: "Capacity Mode",
+      timezone: "Timezone",
+      pax: "Pax",
+      reservationTimeout: "Reservation Timeout",
       sellCurrency: "Sell Currency",
       sellAmount: "Sell Amount",
       costAmount: "Cost Amount",
@@ -166,12 +191,19 @@ export const productsUiEn = {
       description: "Brief overview of the product...",
       tagInput: "Type a tag and press Enter",
       productTypeSearch: "Search product types...",
+      facilitySearch: "Search facilities...",
+      taxClassSearch: "Search tax classes...",
+      timezone: "Europe/Bucharest",
+      pax: "2",
+      reservationTimeout: "20",
       currencySearch: "Search currency...",
       amount: "0.00",
     },
     validation: {
       nameRequired: "Product name is required.",
       sellCurrencyInvalid: "Sell currency must be a 3-letter ISO code.",
+      paxInvalid: "Pax must be a whole number greater than zero.",
+      reservationTimeoutInvalid: "Reservation timeout must be a whole number of minutes.",
       saveFailed: "Failed to save product.",
     },
     actions: {

--- a/packages/products-ui/src/i18n/messages.ts
+++ b/packages/products-ui/src/i18n/messages.ts
@@ -2,6 +2,8 @@ import type { ProductRecord } from "@voyantjs/products-react"
 
 export type ProductStatus = ProductRecord["status"]
 export type ProductBookingMode = ProductRecord["bookingMode"]
+export type ProductCapacityMode = ProductRecord["capacityMode"]
+export type ProductVisibility = ProductRecord["visibility"]
 
 export type ProductsUiMessages = {
   common: {
@@ -36,6 +38,8 @@ export type ProductsUiMessages = {
     }
     productStatusLabels: Record<ProductStatus, string>
     productBookingModeLabels: Record<ProductBookingMode, string>
+    productCapacityModeLabels: Record<ProductCapacityMode, string>
+    productVisibilityLabels: Record<ProductVisibility, string>
   }
   comboboxes: {
     product: {
@@ -47,6 +51,14 @@ export type ProductsUiMessages = {
       empty: string
     }
     productType: {
+      placeholder: string
+      empty: string
+    }
+    facility: {
+      placeholder: string
+      empty: string
+    }
+    taxClass: {
       placeholder: string
       empty: string
     }
@@ -148,6 +160,13 @@ export type ProductsUiMessages = {
       status: string
       bookingMode: string
       productType: string
+      facility: string
+      taxClass: string
+      visibility: string
+      capacityMode: string
+      timezone: string
+      pax: string
+      reservationTimeout: string
       sellCurrency: string
       sellAmount: string
       costAmount: string
@@ -157,12 +176,19 @@ export type ProductsUiMessages = {
       description: string
       tagInput: string
       productTypeSearch: string
+      facilitySearch: string
+      taxClassSearch: string
+      timezone: string
+      pax: string
+      reservationTimeout: string
       currencySearch: string
       amount: string
     }
     validation: {
       nameRequired: string
       sellCurrencyInvalid: string
+      paxInvalid: string
+      reservationTimeoutInvalid: string
       saveFailed: string
     }
     actions: {

--- a/packages/products-ui/src/i18n/ro.ts
+++ b/packages/products-ui/src/i18n/ro.ts
@@ -45,6 +45,16 @@ export const productsUiRo = {
       itinerary: "Itinerariu",
       other: "Altul",
     },
+    productCapacityModeLabels: {
+      free_sale: "Vanzare libera",
+      limited: "Limitat",
+      on_request: "La cerere",
+    },
+    productVisibilityLabels: {
+      public: "Public",
+      private: "Privat",
+      hidden: "Ascuns",
+    },
   },
   comboboxes: {
     product: {
@@ -58,6 +68,14 @@ export const productsUiRo = {
     productType: {
       placeholder: "Cauta tipuri de produs...",
       empty: "Nu au fost gasite tipuri de produs.",
+    },
+    facility: {
+      placeholder: "Cauta facilitati...",
+      empty: "Nu au fost gasite facilitati.",
+    },
+    taxClass: {
+      placeholder: "Cauta clase fiscale...",
+      empty: "Nu au fost gasite clase fiscale.",
     },
   },
   catalogCard: {
@@ -157,6 +175,13 @@ export const productsUiRo = {
       status: "Status",
       bookingMode: "Mod rezervare",
       productType: "Tip produs",
+      facility: "Facilitate",
+      taxClass: "Clasa fiscala",
+      visibility: "Vizibilitate",
+      capacityMode: "Mod capacitate",
+      timezone: "Fus orar",
+      pax: "Pax",
+      reservationTimeout: "Timeout rezervare",
       sellCurrency: "Moneda vanzare",
       sellAmount: "Pret vanzare",
       costAmount: "Cost",
@@ -166,12 +191,19 @@ export const productsUiRo = {
       description: "Prezentare scurta a produsului...",
       tagInput: "Scrie o eticheta si apasa Enter",
       productTypeSearch: "Cauta tipuri de produs...",
+      facilitySearch: "Cauta facilitati...",
+      taxClassSearch: "Cauta clase fiscale...",
+      timezone: "Europe/Bucharest",
+      pax: "2",
+      reservationTimeout: "20",
       currencySearch: "Cauta moneda...",
       amount: "0.00",
     },
     validation: {
       nameRequired: "Numele produsului este obligatoriu.",
       sellCurrencyInvalid: "Moneda de vanzare trebuie sa fie un cod ISO din 3 litere.",
+      paxInvalid: "Pax trebuie sa fie un numar intreg mai mare decat zero.",
+      reservationTimeoutInvalid: "Timeout-ul rezervarii trebuie sa fie un numar intreg de minute.",
       saveFailed: "Produsul nu a putut fi salvat.",
     },
     actions: {

--- a/packages/products-ui/src/index.ts
+++ b/packages/products-ui/src/index.ts
@@ -46,6 +46,7 @@ export {
   type ProductOverviewCardProps,
 } from "./components/product-detail-page.js"
 export { ProductDialog, type ProductDialogProps } from "./components/product-dialog.js"
+export { ProductFacilityCombobox } from "./components/product-facility-combobox.js"
 export {
   ProductForm,
   type ProductFormMode,
@@ -85,6 +86,7 @@ export { ProductTagDialog, type ProductTagDialogProps } from "./components/produ
 export { ProductTagForm, type ProductTagFormProps } from "./components/product-tag-form.js"
 export { ProductTagList, type ProductTagListProps } from "./components/product-tag-list.js"
 export { ProductTagsPage, type ProductTagsPageProps } from "./components/product-tags-page.js"
+export { ProductTaxClassCombobox } from "./components/product-tax-class-combobox.js"
 export { ProductTypeCombobox } from "./components/product-type-combobox.js"
 export { ProductTypesPage, type ProductTypesPageProps } from "./components/product-types-page.js"
 export {


### PR DESCRIPTION
## Summary

- Extends `ProductForm` to edit `facilityId`, `taxClassId`, `visibility`, `capacityMode`, `timezone`, `pax`, and `reservationTimeoutMinutes` alongside the existing commercial fields.
- Adds product-owned facility and tax-class comboboxes backed by the existing `/v1/facilities/facilities` and `/v1/finance/tax-classes` endpoints.
- Adds localized labels, placeholders, and validation messages for the new form controls.

Closes #820.

## Validation

- `pnpm --filter @voyantjs/products-ui typecheck`
- `pnpm --filter @voyantjs/products-ui lint`
- `pnpm --filter @voyantjs/products-ui test`
- `pnpm --filter @voyantjs/products-ui build`
- Commit hook: changed-file quality gates, full lint, full typecheck
- Pre-push hook: full test lane

## Notes

- `pnpm verify:package-exports` was attempted, but this fresh worktree is missing dist outputs for many unrelated packages; `@voyantjs/products-ui` itself was built successfully.