### PR TITLE
Add Sprite pool leases

### DIFF
--- a/apps/agent-control-plane/src/control-plane.test.ts
+++ b/apps/agent-control-plane/src/control-plane.test.ts
@@ -167,6 +167,38 @@ describe("agent control plane", () => {
     })
   })
 
+  it("turns ready items into remote bootstrap plans when a remote workspace is assigned", () => {
+    expect(
+      selectDispatchPlan({
+        filters: { action: "start" },
+        options: { remoteWorkspace: "sandbox:sprite:voyant-agent-01-slot-1" },
+        recommendations,
+        repository: "voyantjs/voyant",
+      }),
+    ).toEqual({
+      reason: "matched",
+      plan: {
+        action: "remote-bootstrap",
+        command: [
+          "pnpm",
+          "agent:queue:remote-bootstrap",
+          "--",
+          "--issue",
+          "579",
+          "--repo",
+          "voyantjs/voyant",
+          "--workspace",
+          "sandbox:sprite:voyant-agent-01-slot-1",
+          "--yes",
+        ],
+        issue: recommendations[1]?.issue,
+        reason: "maintainer-approved item is ready to claim",
+        repository: "voyantjs/voyant",
+        requiresMutation: true,
+      },
+    })
+  })
+
   it("applies issue, action, and repository filters", () => {
     expect(
       selectDispatchPlan({

--- a/apps/agent-control-plane/src/control-plane.ts
+++ b/apps/agent-control-plane/src/control-plane.ts
@@ -1,4 +1,10 @@
 import { z } from "zod"
+import {
+  dispatchCommand,
+  effectiveDispatchAction,
+  remoteWorkspaceAlreadyAssigned,
+  repositoriesMatch,
+} from "./dispatch-planning.js"
 
 export const dispatchableActions = [
   "collect-ci",
@@ -38,6 +44,7 @@ const queueRecommendationSchema = z
     priority: z.number().finite().optional(),
     reason: z.string().min(1),
     state: z.string().nullable().optional(),
+    workspace: z.string().nullable().optional(),
   })
   .passthrough()
 
@@ -61,6 +68,7 @@ const dispatchPlanOptionsSchema = z
     eventLog: z.string().min(1).optional(),
     implementationCommand: z.string().trim().min(1).optional(),
     remoteImplementationCommand: z.string().trim().min(1).optional(),
+    remoteWorkspace: z.string().trim().min(1).optional(),
     updateBody: z.boolean().optional(),
   })
   .optional()
@@ -303,9 +311,19 @@ export function buildTickSnapshotRecord(
 export function selectDispatchPlan(request: DispatchPlanRequest): DispatchPlanResult {
   const actionFilter = request.filters?.action
   if (actionFilter && !dispatchableActionSet.has(actionFilter)) {
+    return { plan: null, reason: `action ${actionFilter} is not dispatchable` }
+  }
+
+  if (
+    request.options?.remoteWorkspace &&
+    remoteWorkspaceAlreadyAssigned({
+      recommendations: request.recommendations,
+      workspace: request.options.remoteWorkspace,
+    })
+  ) {
     return {
       plan: null,
-      reason: `action ${actionFilter} is not dispatchable`,
+      reason: `remote workspace ${request.options.remoteWorkspace} is already assigned`,
     }
   }
 
@@ -322,7 +340,10 @@ export function selectDispatchPlan(request: DispatchPlanRequest): DispatchPlanRe
     }
     if (!repositoriesMatch(recommendation.issue.repository, request.repository)) continue
 
-    const action = recommendation.action
+    const action = effectiveDispatchAction({
+      recommendationAction: recommendation.action,
+      remoteWorkspace: request.options?.remoteWorkspace,
+    })
 
     const commandResult = dispatchCommand({
       action,
@@ -331,6 +352,7 @@ export function selectDispatchPlan(request: DispatchPlanRequest): DispatchPlanRe
       implementationCommand: request.options?.implementationCommand,
       issueNumber: recommendation.issue.number,
       remoteImplementationCommand: request.options?.remoteImplementationCommand,
+      remoteWorkspace: request.options?.remoteWorkspace,
       repository: request.repository,
       updateBody: request.options?.updateBody,
     })
@@ -451,101 +473,6 @@ export function finishDispatchIntent({
   }
 }
 
-function dispatchCommand({
-  action,
-  ciRepairCommand,
-  eventLog,
-  implementationCommand,
-  issueNumber,
-  remoteImplementationCommand,
-  repository,
-  updateBody,
-}: {
-  action: DispatchPlan["action"]
-  ciRepairCommand?: string
-  eventLog?: string
-  implementationCommand?: string
-  issueNumber: number
-  remoteImplementationCommand?: string
-  repository: string
-  updateBody?: boolean
-}) {
-  const commandOption = implementationCommandForAction({
-    action,
-    implementationCommand,
-    remoteImplementationCommand,
-  })
-  if (!commandOption.ok) {
-    return commandOption
-  }
-
-  const command = [
-    "pnpm",
-    `agent:queue:${action}`,
-    "--",
-    "--issue",
-    String(issueNumber),
-    "--repo",
-    repository,
-  ]
-
-  if (commandOption.command) {
-    command.push("--command", commandOption.command)
-  }
-
-  command.push("--yes")
-
-  if (eventLog) {
-    command.push("--event-log", eventLog)
-  }
-
-  if (ciRepairCommand && (action === "repair-ci" || action === "remote-repair-ci")) {
-    command.push("--ci-repair-command", ciRepairCommand)
-  }
-
-  if (updateBody && action === "sync-pr") {
-    command.push("--update-body")
-  }
-
-  return { ok: true as const, command }
-}
-
-function implementationCommandForAction({
-  action,
-  implementationCommand,
-  remoteImplementationCommand,
-}: {
-  action: DispatchPlan["action"]
-  implementationCommand?: string
-  remoteImplementationCommand?: string
-}) {
-  if (action === "run-command") {
-    if (!implementationCommand) {
-      return { ok: false as const, reason: "run-command requires implementation command" }
-    }
-
-    return { ok: true as const, command: implementationCommand }
-  }
-
-  if (action === "remote-run-command") {
-    const command = remoteImplementationCommand ?? implementationCommand
-    if (!command) {
-      return {
-        ok: false as const,
-        reason: "remote-run-command requires remote implementation command",
-      }
-    }
-
-    return { ok: true as const, command }
-  }
-
-  return { ok: true as const, command: null }
-}
-
 function isDispatchableAction(action: string): action is DispatchPlan["action"] {
   return dispatchableActionSet.has(action)
-}
-
-function repositoriesMatch(left: string, right: string) {
-  return left.trim().toLowerCase() === right.trim().toLowerCase()
 }

--- a/apps/agent-control-plane/src/dispatch-planning.ts
+++ b/apps/agent-control-plane/src/dispatch-planning.ts
@@ -1,0 +1,113 @@
+import type { DispatchPlan, DispatchPlanRequest } from "./control-plane.js"
+
+export function dispatchCommand({
+  action,
+  ciRepairCommand,
+  eventLog,
+  implementationCommand,
+  issueNumber,
+  remoteImplementationCommand,
+  remoteWorkspace,
+  repository,
+  updateBody,
+}: {
+  action: DispatchPlan["action"]
+  ciRepairCommand?: string
+  eventLog?: string
+  implementationCommand?: string
+  issueNumber: number
+  remoteImplementationCommand?: string
+  remoteWorkspace?: string
+  repository: string
+  updateBody?: boolean
+}) {
+  const commandOption = implementationCommandForAction({
+    action,
+    implementationCommand,
+    remoteImplementationCommand,
+  })
+  if (!commandOption.ok) return commandOption
+
+  const command = [
+    "pnpm",
+    `agent:queue:${action}`,
+    "--",
+    "--issue",
+    String(issueNumber),
+    "--repo",
+    repository,
+  ]
+
+  if (commandOption.command) command.push("--command", commandOption.command)
+  if (remoteWorkspace && action === "remote-bootstrap") {
+    command.push("--workspace", remoteWorkspace)
+  }
+
+  command.push("--yes")
+  if (eventLog) command.push("--event-log", eventLog)
+  if (ciRepairCommand && (action === "repair-ci" || action === "remote-repair-ci")) {
+    command.push("--ci-repair-command", ciRepairCommand)
+  }
+  if (updateBody && action === "sync-pr") command.push("--update-body")
+
+  return { ok: true as const, command }
+}
+
+export function effectiveDispatchAction({
+  recommendationAction,
+  remoteWorkspace,
+}: {
+  recommendationAction: string
+  remoteWorkspace?: string
+}): DispatchPlan["action"] {
+  return recommendationAction === "start" && remoteWorkspace
+    ? "remote-bootstrap"
+    : (recommendationAction as DispatchPlan["action"])
+}
+
+export function remoteWorkspaceAlreadyAssigned({
+  recommendations,
+  workspace,
+}: {
+  recommendations: DispatchPlanRequest["recommendations"]
+  workspace: string
+}) {
+  return recommendations.some(
+    (recommendation) =>
+      recommendation.workspace === workspace && recommendation.issue.state !== "CLOSED",
+  )
+}
+
+export function repositoriesMatch(left: string, right: string) {
+  return left.trim().toLowerCase() === right.trim().toLowerCase()
+}
+
+function implementationCommandForAction({
+  action,
+  implementationCommand,
+  remoteImplementationCommand,
+}: {
+  action: DispatchPlan["action"]
+  implementationCommand?: string
+  remoteImplementationCommand?: string
+}) {
+  if (action === "run-command") {
+    if (!implementationCommand) {
+      return { ok: false as const, reason: "run-command requires implementation command" }
+    }
+
+    return { ok: true as const, command: implementationCommand }
+  }
+
+  if (action !== "remote-run-command") return { ok: true as const, command: null }
+
+  const command = remoteImplementationCommand ?? implementationCommand
+  if (!command) {
+    return {
+      ok: false as const,
+      reason: "remote-run-command requires remote implementation command",
+    }
+  }
+
+  return { ok: true as const, command }
+}

--- a/apps/agent-runner/README.md
+++ b/apps/agent-runner/README.md
@@ -93,14 +93,19 @@ The deployment uses three Cloudflare persistence surfaces:
   `migrations/0001_agent_runner_ledger.sql` before enabling Cron.
 - `AGENT_RUNNER_COORDINATOR`: Durable Object binding for run/repository
   coordination locks.
+- `AGENT_SPRITE_POOL`: optional comma-separated Sprite pool, for example
+  `voyant-agent-01:2,voyant-agent-02:2,voyant-agent-03:2`. Each `:<n>` creates
+  `n` logical slots on that Sprite. The runner leases one slot before asking
+  the control plane for `remote-bootstrap`; the control plane injects the
+  matching `--workspace sandbox:sprite:<slot>` value into the leased command.
 - `AGENT_CONTROL_PLANE_URL`: deployed control-plane URL.
 - `AGENT_CONTROL_PLANE_TOKEN`: bearer token for the control plane.
 
-Cron triggers should stay constrained to one low-risk lifecycle action until an
-external executor is attached. The production pilot uses `sync-pr`, a 300 second
-lease TTL, and a three-lease daily budget so stale lease-only reservations age
-out quickly. Keep provider execution outside this Worker unless a later design
-adds sandbox policy and task-scoped credentials.
+Cron triggers should stay constrained to one lifecycle action. For remote
+bootstrap, configure `AGENT_RUNNER_ACTION=remote-bootstrap`,
+`AGENT_RUNNER_ALLOWED_ACTIONS=remote-bootstrap`, and `AGENT_SPRITE_POOL`. The
+Worker only leases a dispatch intent and a Sprite slot; provider execution
+still happens in a trusted external executor with task-scoped credentials.
 
 ## Deployment Pilot
 

--- a/apps/agent-runner/src/app.ts
+++ b/apps/agent-runner/src/app.ts
@@ -33,6 +33,7 @@ interface AppOptions {
   now?: () => Date
   runLedgerStore?: AgentRunnerLedgerStore
   coordinatorConfigured?: boolean
+  coordinatorService?: Pick<Fetcher, "fetch">
   supervisorTickStore?: SupervisorTickStore
 }
 
@@ -46,6 +47,7 @@ export function createApp({
   now = () => new Date(),
   runLedgerStore,
   coordinatorConfigured = false,
+  coordinatorService,
   supervisorTickStore,
 }: AppOptions = {}): Hono {
   const app = new Hono()
@@ -246,6 +248,7 @@ export function createApp({
     return c.json(
       await runPersistentSupervisorTick({
         config,
+        coordinatorService,
         fetchImpl,
         now,
         request: parsed.data,
@@ -297,6 +300,7 @@ export function createApp({
 
 export async function runPersistentSupervisorTick({
   config,
+  coordinatorService,
   fetchImpl = fetch,
   now = () => new Date(),
   request = {},
@@ -305,6 +309,7 @@ export async function runPersistentSupervisorTick({
   supervisorTickStore,
 }: {
   config: RunnerConfig
+  coordinatorService?: Pick<Fetcher, "fetch">
   fetchImpl?: typeof fetch
   now?: () => Date
   request?: SupervisorTickRequest
@@ -330,6 +335,7 @@ export async function runPersistentSupervisorTick({
       ? {
           ...(await runSupervisorTick({
             config,
+            coordinatorService,
             fetchImpl,
             request,
             source,
@@ -338,6 +344,7 @@ export async function runPersistentSupervisorTick({
         }
       : await runSupervisorTick({
           config,
+          coordinatorService,
           fetchImpl,
           request,
           source,

--- a/apps/agent-runner/src/remote-workspace-pool.ts
+++ b/apps/agent-runner/src/remote-workspace-pool.ts
@@ -1,0 +1,152 @@
+export interface RemoteWorkspacePoolSlot {
+  id: string
+  lockKey: string
+  provider: "sprite"
+  slot: number
+  sprite: string
+  workspaceReference: string
+}
+
+export interface RemoteWorkspacePool {
+  configured: boolean
+  provider: "sprite"
+  slots: RemoteWorkspacePoolSlot[]
+}
+
+export interface RemoteWorkspaceSlotLease {
+  acquiredAt: string
+  expiresAt: string
+  holder: string
+  key: string
+  slot: RemoteWorkspacePoolSlot
+}
+
+type CoordinatorService = Pick<Fetcher, "fetch">
+
+export function parseSpritePoolConfig(value: string | undefined): RemoteWorkspacePool {
+  const slots: RemoteWorkspacePoolSlot[] = []
+  const entries = (value ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+
+  for (const entry of entries) {
+    const [spriteName, rawCapacity] = entry.split(":")
+    const sprite = spriteName?.trim()
+    const capacity = parseCapacity(rawCapacity)
+    if (!sprite || !isValidSpriteName(sprite)) continue
+
+    for (let index = 1; index <= capacity; index += 1) {
+      const id = capacity === 1 ? sprite : `${sprite}-slot-${index}`
+      slots.push({
+        id,
+        lockKey: `remote-workspace:sprite:${id}`,
+        provider: "sprite",
+        slot: index,
+        sprite,
+        workspaceReference: `sandbox:sprite:${id}`,
+      })
+    }
+  }
+
+  return {
+    configured: slots.length > 0,
+    provider: "sprite",
+    slots,
+  }
+}
+
+export async function acquireRemoteWorkspaceSlot({
+  coordinator,
+  holder,
+  pool,
+  ttlSeconds,
+}: {
+  coordinator?: CoordinatorService
+  holder: string
+  pool?: RemoteWorkspacePool
+  ttlSeconds: number
+}): Promise<
+  | { acquired: true; lease: RemoteWorkspaceSlotLease }
+  | { acquired: false; reason: "coordinator_not_configured" | "pool_not_configured" | "pool_full" }
+> {
+  if (!pool?.configured || pool.slots.length === 0) {
+    return { acquired: false, reason: "pool_not_configured" }
+  }
+
+  if (!coordinator) {
+    return { acquired: false, reason: "coordinator_not_configured" }
+  }
+
+  for (const slot of pool.slots) {
+    const response = await coordinator.fetch(
+      jsonRequest("https://agent-runner-coordinator.internal/locks/acquire", {
+        holder,
+        key: slot.lockKey,
+        ttlSeconds,
+      }),
+    )
+    const body = await response.json().catch(() => null)
+
+    if (response.status === 201 && body && typeof body === "object" && "lock" in body) {
+      const lock = body.lock as Omit<RemoteWorkspaceSlotLease, "slot">
+      return {
+        acquired: true,
+        lease: {
+          acquiredAt: lock.acquiredAt,
+          expiresAt: lock.expiresAt,
+          holder: lock.holder,
+          key: lock.key,
+          slot,
+        },
+      }
+    }
+  }
+
+  return { acquired: false, reason: "pool_full" }
+}
+
+export async function releaseRemoteWorkspaceSlot({
+  coordinator,
+  holder,
+  lease,
+}: {
+  coordinator?: CoordinatorService
+  holder: string
+  lease?: RemoteWorkspaceSlotLease
+}) {
+  if (!coordinator || !lease) return { released: false, reason: "not_configured" as const }
+
+  const response = await coordinator.fetch(
+    jsonRequest("https://agent-runner-coordinator.internal/locks/release", {
+      holder,
+      key: lease.key,
+    }),
+  )
+  const body = await response.json().catch(() => null)
+  return {
+    released: response.ok,
+    response: body,
+    status: response.status,
+  }
+}
+
+function jsonRequest(url: string, body: unknown) {
+  return new Request(url, {
+    body: JSON.stringify(body),
+    headers: {
+      "content-type": "application/json",
+    },
+    method: "POST",
+  })
+}
+
+function parseCapacity(value: string | undefined) {
+  if (!value) return 1
+  const capacity = Number(value.trim())
+  return Number.isInteger(capacity) && capacity > 0 ? Math.min(capacity, 10) : 1
+}
+
+function isValidSpriteName(value: string) {
+  return /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(value)
+}

--- a/apps/agent-runner/src/runner-smoke.test.ts
+++ b/apps/agent-runner/src/runner-smoke.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 
+import { parseSpritePoolConfig } from "./remote-workspace-pool.js"
 import { runSupervisorTick } from "./runner.js"
 
 describe("agent runner smoke ticks", () => {
@@ -260,6 +261,107 @@ describe("agent runner smoke ticks", () => {
           },
           lease: {
             holder: "runner:cloudflare",
+          },
+          repository: "voyantjs/voyant",
+        },
+        url: "https://control.example.com/api/dispatch-intents/latest",
+      },
+    ])
+  })
+
+  it("leases a Sprite pool slot before requesting remote bootstrap work", async () => {
+    const controlPlaneCalls: Array<{ body: unknown; url: string }> = []
+    const coordinatorCalls: Array<{ body: unknown; url: string }> = []
+    const result = await runSupervisorTick({
+      config: {
+        allowedActions: ["remote-bootstrap"],
+        controlPlaneConfigured: true,
+        controlPlaneToken: "control-token",
+        controlPlaneUrl: "https://control.example.com/",
+        defaultAction: "remote-bootstrap",
+        enabled: true,
+        holder: "runner:cloudflare",
+        remoteWorkspacePool: parseSpritePoolConfig("voyant-agent-01:2,voyant-agent-02:2"),
+        repository: "voyantjs/voyant",
+      },
+      coordinatorService: {
+        fetch: async (input) => {
+          const request = input instanceof Request ? input : new Request(input)
+          const body = (await request.json()) as { holder: string; key: string }
+          coordinatorCalls.push({ body, url: request.url })
+          return new Response(
+            JSON.stringify({
+              acquired: true,
+              lock: {
+                acquiredAt: "2026-05-12T12:00:00.000Z",
+                expiresAt: "2026-05-12T12:05:00.000Z",
+                holder: body.holder,
+                key: body.key,
+              },
+            }),
+            { status: 201 },
+          )
+        },
+      },
+      fetchImpl: async (url, init) => {
+        controlPlaneCalls.push({
+          body: JSON.parse(String(init?.body)),
+          url: String(url),
+        })
+        return new Response(
+          JSON.stringify({
+            intent: {
+              id: "intent_579",
+              plan: {
+                action: "remote-bootstrap",
+              },
+              status: "leased",
+            },
+            reason: "leased",
+          }),
+          { status: 201 },
+        )
+      },
+      request: {
+        dryRun: false,
+        ttlSeconds: 300,
+      },
+      source: "scheduled",
+    })
+
+    expect(result).toMatchObject({
+      leased: true,
+      reason: "leased",
+      remoteWorkspaceLease: {
+        key: "remote-workspace:sprite:voyant-agent-01-slot-1",
+        slot: {
+          sprite: "voyant-agent-01",
+          workspaceReference: "sandbox:sprite:voyant-agent-01-slot-1",
+        },
+      },
+    })
+    expect(coordinatorCalls).toEqual([
+      {
+        body: {
+          holder: "runner:cloudflare",
+          key: "remote-workspace:sprite:voyant-agent-01-slot-1",
+          ttlSeconds: 300,
+        },
+        url: "https://agent-runner-coordinator.internal/locks/acquire",
+      },
+    ])
+    expect(controlPlaneCalls).toEqual([
+      {
+        body: {
+          filters: {
+            action: "start",
+          },
+          lease: {
+            holder: "runner:cloudflare",
+            ttlSeconds: 300,
+          },
+          options: {
+            remoteWorkspace: "sandbox:sprite:voyant-agent-01-slot-1",
           },
           repository: "voyantjs/voyant",
         },

--- a/apps/agent-runner/src/runner.ts
+++ b/apps/agent-runner/src/runner.ts
@@ -1,4 +1,10 @@
 import { z } from "zod"
+import {
+  acquireRemoteWorkspaceSlot,
+  type RemoteWorkspacePool,
+  type RemoteWorkspaceSlotLease,
+  releaseRemoteWorkspaceSlot,
+} from "./remote-workspace-pool.js"
 
 export const runnerDispatchActions = [
   "collect-ci",
@@ -24,6 +30,7 @@ export const runnerDefaultDispatchActions = runnerDispatchActions.filter(
 const runnerDispatchActionSet = new Set<string>(runnerDispatchActions)
 
 type ControlPlaneService = Pick<Fetcher, "fetch">
+type CoordinatorService = Pick<Fetcher, "fetch">
 
 export const supervisorTickRequestSchema = z
   .object({
@@ -55,6 +62,7 @@ export interface RunnerConfig {
   leaseTtlSeconds?: number
   maxDailyLeases?: number
   maxLeaseTtlSeconds?: number
+  remoteWorkspacePool?: RemoteWorkspacePool
   repository?: string
 }
 
@@ -81,6 +89,11 @@ export function buildRunnerCapabilities(config: RunnerConfig) {
       repository: config.repository ?? null,
     },
     policy: buildRunnerPolicy(config),
+    remoteWorkspacePool: {
+      configured: Boolean(config.remoteWorkspacePool?.configured),
+      provider: config.remoteWorkspacePool?.provider ?? null,
+      slots: config.remoteWorkspacePool?.slots.length ?? 0,
+    },
     scheduler: {
       cronCompatible: true,
       mode: "lease-only",
@@ -135,11 +148,13 @@ export function planSupervisorTick({
 
 export async function runSupervisorTick({
   config,
+  coordinatorService,
   fetchImpl = fetch,
   request = {},
   source,
 }: {
   config: RunnerConfig
+  coordinatorService?: CoordinatorService
   fetchImpl?: typeof fetch
   request?: SupervisorTickRequest
   source: "api" | "scheduled"
@@ -182,8 +197,26 @@ export async function runSupervisorTick({
     })
   }
 
+  const workspaceLease = await maybeAcquireRemoteWorkspaceSlot({
+    config,
+    coordinatorService,
+    request,
+  })
+  if (workspaceLease.blocked) {
+    return {
+      leased: false,
+      plan,
+      reason: workspaceLease.reason,
+      remoteWorkspacePool: workspaceLease.remoteWorkspacePool,
+    }
+  }
+
   const response = await requestControlPlane({
-    body: buildDispatchIntentRequest({ config, request }),
+    body: buildDispatchIntentRequest({
+      config,
+      remoteWorkspace: workspaceLease.lease?.slot.workspaceReference,
+      request,
+    }),
     config,
     fetchImpl,
     path: "/api/dispatch-intents/latest",
@@ -192,6 +225,11 @@ export async function runSupervisorTick({
   const body = parseJsonBody(bodyText)
 
   if (!response.ok) {
+    await releaseRemoteWorkspaceSlot({
+      coordinator: coordinatorService,
+      holder: request.holder ?? config.holder ?? "",
+      lease: workspaceLease.lease,
+    })
     return {
       controlPlane: {
         ...(body?.intent ? { activeIntent: body.intent } : {}),
@@ -201,7 +239,16 @@ export async function runSupervisorTick({
       leased: false,
       plan,
       reason: "control_plane_rejected",
+      ...(workspaceLease.lease ? { remoteWorkspaceLease: workspaceLease.lease } : {}),
     }
+  }
+
+  if (!body?.intent) {
+    await releaseRemoteWorkspaceSlot({
+      coordinator: coordinatorService,
+      holder: request.holder ?? config.holder ?? "",
+      lease: workspaceLease.lease,
+    })
   }
 
   return {
@@ -212,6 +259,58 @@ export async function runSupervisorTick({
     leased: Boolean(body?.intent),
     plan,
     reason: body?.reason ?? (body?.intent ? "leased" : "no_intent"),
+    ...(workspaceLease.lease ? { remoteWorkspaceLease: workspaceLease.lease } : {}),
+  }
+}
+
+async function maybeAcquireRemoteWorkspaceSlot({
+  config,
+  coordinatorService,
+  request,
+}: {
+  config: RunnerConfig
+  coordinatorService?: CoordinatorService
+  request: SupervisorTickRequest
+}): Promise<
+  | { blocked: false; lease?: RemoteWorkspaceSlotLease }
+  | {
+      blocked: true
+      reason: "remote_workspace_pool_full" | "remote_workspace_pool_not_configured"
+      remoteWorkspacePool: { configured: boolean; slots: number }
+    }
+> {
+  if (!usesRemoteWorkspacePool({ config, request })) {
+    return { blocked: false }
+  }
+
+  const holder = request.holder ?? config.holder
+  if (!holder) {
+    return { blocked: false }
+  }
+
+  const ttlSeconds = request.ttlSeconds ?? config.leaseTtlSeconds ?? 900
+  const acquired = await acquireRemoteWorkspaceSlot({
+    coordinator: coordinatorService,
+    holder,
+    pool: config.remoteWorkspacePool,
+    ttlSeconds,
+  })
+  if (acquired.acquired) {
+    return { blocked: false, lease: acquired.lease }
+  }
+
+  const remoteWorkspacePool = {
+    configured: Boolean(config.remoteWorkspacePool?.configured),
+    slots: config.remoteWorkspacePool?.slots.length ?? 0,
+  }
+
+  return {
+    blocked: true,
+    reason:
+      acquired.reason === "pool_full"
+        ? "remote_workspace_pool_full"
+        : "remote_workspace_pool_not_configured",
+    remoteWorkspacePool,
   }
 }
 
@@ -289,28 +388,32 @@ async function requestControlPlane({
 
 function buildDispatchPlanRequest({
   config,
+  remoteWorkspace,
   request,
 }: {
   config: RunnerConfig
+  remoteWorkspace?: string
   request: SupervisorTickRequest
 }) {
   const repository = request.repository ?? config.repository
   const action = request.action ?? config.defaultAction
+  const filterAction = remoteWorkspace && action === "remote-bootstrap" ? "start" : action
 
   return {
     repository,
-    ...(action || request.issue
+    ...(filterAction || request.issue
       ? {
           filters: {
-            ...(action ? { action } : {}),
+            ...(filterAction ? { action: filterAction } : {}),
             ...(request.issue ? { issueNumber: request.issue } : {}),
           },
         }
       : {}),
-    ...(request.eventLog || request.updateBody
+    ...(request.eventLog || request.updateBody || remoteWorkspace
       ? {
           options: {
             ...(request.eventLog ? { eventLog: request.eventLog } : {}),
+            ...(remoteWorkspace ? { remoteWorkspace } : {}),
             ...(request.updateBody ? { updateBody: true } : {}),
           },
         }
@@ -320,14 +423,17 @@ function buildDispatchPlanRequest({
 
 function buildDispatchIntentRequest({
   config,
+  remoteWorkspace,
   request,
 }: {
   config: RunnerConfig
+  remoteWorkspace?: string
   request: SupervisorTickRequest
 }) {
   const holder = request.holder ?? config.holder
   const repository = request.repository ?? config.repository
   const action = request.action ?? config.defaultAction
+  const filterAction = remoteWorkspace && action === "remote-bootstrap" ? "start" : action
   const ttlSeconds = request.ttlSeconds ?? config.leaseTtlSeconds
 
   return {
@@ -336,23 +442,35 @@ function buildDispatchIntentRequest({
       holder,
       ...(ttlSeconds ? { ttlSeconds } : {}),
     },
-    ...(action || request.issue
+    ...(filterAction || request.issue
       ? {
           filters: {
-            ...(action ? { action } : {}),
+            ...(filterAction ? { action: filterAction } : {}),
             ...(request.issue ? { issueNumber: request.issue } : {}),
           },
         }
       : {}),
-    ...(request.eventLog || request.updateBody
+    ...(request.eventLog || request.updateBody || remoteWorkspace
       ? {
           options: {
             ...(request.eventLog ? { eventLog: request.eventLog } : {}),
+            ...(remoteWorkspace ? { remoteWorkspace } : {}),
             ...(request.updateBody ? { updateBody: true } : {}),
           },
         }
       : {}),
   }
+}
+
+function usesRemoteWorkspacePool({
+  config,
+  request,
+}: {
+  config: RunnerConfig
+  request: SupervisorTickRequest
+}) {
+  if (!config.remoteWorkspacePool?.configured) return false
+  return (request.action ?? config.defaultAction) === "remote-bootstrap"
 }
 
 function buildRunnerPolicy(config: RunnerConfig) {

--- a/apps/agent-runner/src/worker.ts
+++ b/apps/agent-runner/src/worker.ts
@@ -1,5 +1,6 @@
 import { createApp, runPersistentSupervisorTick } from "./app.js"
 import { AgentRunnerCoordinator } from "./coordinator.js"
+import { parseSpritePoolConfig } from "./remote-workspace-pool.js"
 import { createD1AgentRunnerLedgerStore } from "./run-ledger-store.js"
 import { createR2SupervisorTickStore } from "./supervisor-tick-store.js"
 
@@ -17,6 +18,7 @@ interface Env {
   AGENT_RUNNER_MAX_DAILY_LEASES?: string
   AGENT_RUNNER_MAX_LEASE_TTL_SECONDS?: string
   AGENT_RUNNER_REPOSITORY?: string
+  AGENT_SPRITE_POOL?: string
   AGENT_RUNNER_TICK_KEY_PREFIX?: string
   AGENT_RUNNER_TICKS?: R2Bucket
   AGENT_RUNNER_TOKENS?: string
@@ -28,6 +30,7 @@ export default {
       authTokens: parseTokens(env.AGENT_RUNNER_TOKENS),
       config: runnerConfigFromEnv(env),
       coordinatorConfigured: Boolean(env.AGENT_RUNNER_COORDINATOR),
+      coordinatorService: coordinatorServiceFromEnv(env),
       runLedgerStore: runLedgerStoreFromEnv(env),
       supervisorTickStore: supervisorTickStoreFromEnv(env),
     })
@@ -37,6 +40,7 @@ export default {
   async scheduled(_event: ScheduledController, env: Env): Promise<void> {
     const tick = await runPersistentSupervisorTick({
       config: runnerConfigFromEnv(env),
+      coordinatorService: coordinatorServiceFromEnv(env),
       request: {
         dryRun: env.AGENT_RUNNER_ENABLED !== "true",
         reason: "cloudflare-cron",
@@ -72,8 +76,17 @@ function runnerConfigFromEnv(env: Env) {
     leaseTtlSeconds: parsePositiveInteger(env.AGENT_RUNNER_LEASE_TTL_SECONDS),
     maxDailyLeases: parsePositiveInteger(env.AGENT_RUNNER_MAX_DAILY_LEASES),
     maxLeaseTtlSeconds: parsePositiveInteger(env.AGENT_RUNNER_MAX_LEASE_TTL_SECONDS),
+    remoteWorkspacePool: parseSpritePoolConfig(env.AGENT_SPRITE_POOL),
     repository: env.AGENT_RUNNER_REPOSITORY,
   }
+}
+
+function coordinatorServiceFromEnv(env: Env) {
+  if (!env.AGENT_RUNNER_COORDINATOR) return undefined
+
+  return env.AGENT_RUNNER_COORDINATOR.get(
+    env.AGENT_RUNNER_COORDINATOR.idFromName("agent-runner-global"),
+  )
 }
 
 function supervisorTickStoreFromEnv(env: Env) {

--- a/apps/agent-runner/wrangler.jsonc
+++ b/apps/agent-runner/wrangler.jsonc
@@ -20,15 +20,16 @@
   // the placeholder database_id with the id created by `wrangler d1 create`.
   "vars": {
     "AGENT_CONTROL_PLANE_URL": "https://voyant-agent-control-plane.pixelmakers.workers.dev",
-    "AGENT_RUNNER_ACTION": "sync-pr",
-    "AGENT_RUNNER_ALLOWED_ACTIONS": "sync-pr",
+    "AGENT_RUNNER_ACTION": "remote-bootstrap",
+    "AGENT_RUNNER_ALLOWED_ACTIONS": "remote-bootstrap",
     "AGENT_RUNNER_ENABLED": "true",
     "AGENT_RUNNER_HOLDER": "runner:cloudflare",
-    "AGENT_RUNNER_LEASE_TTL_SECONDS": "300",
-    "AGENT_RUNNER_MAX_DAILY_LEASES": "3",
-    "AGENT_RUNNER_MAX_LEASE_TTL_SECONDS": "300",
+    "AGENT_RUNNER_LEASE_TTL_SECONDS": "900",
+    "AGENT_RUNNER_MAX_DAILY_LEASES": "6",
+    "AGENT_RUNNER_MAX_LEASE_TTL_SECONDS": "900",
     "AGENT_RUNNER_REPOSITORY": "voyantjs/voyant",
-    "AGENT_RUNNER_TICK_KEY_PREFIX": "prod"
+    "AGENT_RUNNER_TICK_KEY_PREFIX": "prod",
+    "AGENT_SPRITE_POOL": "voyant-agent-01:2,voyant-agent-02:2,voyant-agent-03:2"
   },
   "triggers": {
     "crons": ["*/15 * * * *"]

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -144,6 +144,13 @@ provider name. Use `.agents/remote-workspaces.example.mjs` as the local template
 for enabling the Sprite adapter. When `SPRITES_TOKEN` or `SPRITE_TOKEN` is set,
 the adapter uses the Sprites API. Without a token it falls back to the local
 `sprite` CLI for one-shot command execution.
+For pooled Sprite capacity, set `AGENT_SPRITE_POOL` on the deployed runner, for
+example `voyant-agent-01:2,voyant-agent-02:2,voyant-agent-03:2`. The runner
+turns each entry into logical slot references such as
+`sandbox:sprite:voyant-agent-01-slot-1` and leases a Durable Object lock before
+asking the control plane to reserve `remote-bootstrap` work. The Sprite adapter
+maps those logical slot IDs back to the backing Sprite name while keeping each
+slot's repository directory separate.
 
 When a remote adapter declares command execution, maintainers can run a guarded
 one-shot command without updating Project state:
@@ -498,6 +505,11 @@ runner has the matching `AGENT_CI_REPAIR_COMMAND` configuration. Use
 enabling Cron so API or scheduled ticks cannot lease more than the configured
 daily budget. If the budget is configured without persistent tick storage, real
 leases are refused.
+When `AGENT_RUNNER_ACTION=remote-bootstrap` and `AGENT_SPRITE_POOL` is set, the
+deployed runner acquires one Sprite slot, asks the control plane for the next
+ready item, and injects `--workspace sandbox:sprite:<slot>` into the leased
+remote-bootstrap command. If all slots are busy, the tick records
+`remote_workspace_pool_full` and does not lease work.
 
 Use loop for a bounded supervisor pass:
 

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -819,6 +819,16 @@ local CLI dependency and can own `inspect`, `exec`, and `dispose` through
 documented HTTP endpoints. Keep Sprite-specific details behind the adapter
 boundary; queue state should continue to use `sandbox:sprite:<id>`.
 
+For the first always-on pool, pre-create three Sprites named
+`voyant-agent-01`, `voyant-agent-02`, and `voyant-agent-03`, then configure the
+runner with `AGENT_SPRITE_POOL=voyant-agent-01:2,voyant-agent-02:2,voyant-agent-03:2`.
+The runner expands that into six logical slots, leases one slot through the
+Durable Object coordinator, and asks the control plane to turn the next ready
+item into a `remote-bootstrap` dispatch intent with the selected
+`--workspace sandbox:sprite:<slot>` value. Slot IDs map back to their backing
+Sprite inside the adapter, while repository paths remain slot-specific so two
+agents on one Sprite do not share a checkout.
+
 ```ts
 interface AgentWorkspace {
   id: string

--- a/scripts/lib/agent-runner-sprite-workspace.mjs
+++ b/scripts/lib/agent-runner-sprite-workspace.mjs
@@ -15,6 +15,7 @@ export function spriteRemoteWorkspaceAdapter(descriptor, options = {}) {
 export function spriteApiRemoteWorkspaceAdapter(descriptor, options = {}) {
   const env = options.env ?? process.env
   const token = spritesApiToken({ env, token: options.token })
+  const target = resolveSpriteTarget(descriptor, { env, pool: options.pool })
   const apiUrl = normalizeSpritesApiUrl(
     options.apiUrl ?? env.SPRITES_API_URL ?? env.SPRITE_API_URL ?? defaultSpritesApiUrl,
   )
@@ -46,6 +47,7 @@ export function spriteApiRemoteWorkspaceAdapter(descriptor, options = {}) {
           ready: false,
           reason: "SPRITES_TOKEN or SPRITE_TOKEN is not configured",
           reference: this.reference,
+          spriteName: target.sprite,
         }
       }
 
@@ -53,7 +55,7 @@ export function spriteApiRemoteWorkspaceAdapter(descriptor, options = {}) {
         apiUrl,
         fetchImpl,
         method: "GET",
-        path: `/v1/sprites/${encodeURIComponent(this.id)}`,
+        path: `/v1/sprites/${encodeURIComponent(target.sprite)}`,
         token,
       })
 
@@ -66,6 +68,8 @@ export function spriteApiRemoteWorkspaceAdapter(descriptor, options = {}) {
         ready: response.ok,
         reason: response.ok ? null : spriteApiErrorReason(response),
         reference: this.reference,
+        spriteName: target.sprite,
+        slot: target.slot,
         sprite: response.body ?? null,
       }
     },
@@ -79,7 +83,7 @@ export function spriteApiRemoteWorkspaceAdapter(descriptor, options = {}) {
         apiUrl,
         fetchImpl,
         method: "POST",
-        path: `/v1/sprites/${encodeURIComponent(this.id)}/exec?${commandPlan.query.toString()}`,
+        path: `/v1/sprites/${encodeURIComponent(target.sprite)}/exec?${commandPlan.query.toString()}`,
         token,
       })
       const output = parseSpriteExecResponse(response)
@@ -97,11 +101,43 @@ export function spriteApiRemoteWorkspaceAdapter(descriptor, options = {}) {
         throw new Error("sprite API dispose requires SPRITES_TOKEN or SPRITE_TOKEN")
       }
 
+      if (target.pooled) {
+        const commandPlan = spriteApiExecPlan(
+          descriptor,
+          {
+            args: ["-rf", `/home/sprite/voyant-workspaces/${target.id}`],
+            command: "rm",
+          },
+          { env },
+        )
+        const response = await requestSpritesApi({
+          apiUrl,
+          fetchImpl,
+          method: "POST",
+          path: `/v1/sprites/${encodeURIComponent(target.sprite)}/exec?${commandPlan.query.toString()}`,
+          token,
+        })
+        if (!response.ok) {
+          throw new Error(spriteApiErrorReason(response))
+        }
+
+        const output = parseSpriteExecResponse(response)
+        return {
+          disposed: output.status === 0,
+          method: "workspace-directory",
+          pooled: true,
+          slot: target.slot,
+          spriteName: target.sprite,
+          status: output.status,
+          workspaceRoot: `/home/sprite/voyant-workspaces/${target.id}`,
+        }
+      }
+
       const response = await requestSpritesApi({
         apiUrl,
         fetchImpl,
         method: "DELETE",
-        path: `/v1/sprites/${encodeURIComponent(this.id)}`,
+        path: `/v1/sprites/${encodeURIComponent(target.sprite)}`,
         token,
       })
       if (!response.ok) {
@@ -111,6 +147,7 @@ export function spriteApiRemoteWorkspaceAdapter(descriptor, options = {}) {
       return {
         disposed: true,
         status: response.status,
+        spriteName: target.sprite,
       }
     },
   }
@@ -178,7 +215,8 @@ export function spriteCliRemoteWorkspaceAdapter(descriptor, options = {}) {
 
 export function spriteExecPlan(descriptor, command, { env = process.env } = {}) {
   const normalizedCommand = normalizeWorkspaceCommand(command)
-  const args = ["exec", "--sprite", descriptor.id]
+  const target = resolveSpriteTarget(descriptor, { env })
+  const args = ["exec", "--sprite", target.sprite]
   const org = normalizedCommand.org ?? env.SPRITE_ORG
   if (org) args.push("--org", org)
   if (normalizedCommand.cwd) args.push("--dir", normalizedCommand.cwd)
@@ -210,6 +248,51 @@ export function spriteApiExecPlan(_descriptor, command, { env = process.env } = 
     displayCommand: normalizedCommand.command.join(" "),
     env: { ...env, ...normalizedCommand.env },
     query,
+  }
+}
+
+export function parseSpritePool(value) {
+  return (value ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+    .flatMap((entry) => {
+      const [rawSprite, rawCapacity] = entry.split(":")
+      const sprite = rawSprite?.trim()
+      if (!sprite || !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(sprite)) return []
+
+      const parsedCapacity = Number(rawCapacity)
+      const capacity =
+        rawCapacity && Number.isInteger(parsedCapacity) && parsedCapacity > 0
+          ? Math.min(parsedCapacity, 10)
+          : 1
+
+      return Array.from({ length: capacity }, (_, index) => ({
+        id: capacity === 1 ? sprite : `${sprite}-slot-${index + 1}`,
+        slot: index + 1,
+        sprite,
+        workspaceReference: `sandbox:sprite:${capacity === 1 ? sprite : `${sprite}-slot-${index + 1}`}`,
+      }))
+    })
+}
+
+export function resolveSpriteTarget(descriptor, { env = process.env, pool } = {}) {
+  const slots = pool ?? parseSpritePool(env.AGENT_SPRITE_POOL ?? env.SPRITE_POOL)
+  const slot = slots.find((candidate) => candidate.id === descriptor.id)
+  if (slot) {
+    return {
+      id: descriptor.id,
+      pooled: true,
+      slot: slot.slot,
+      sprite: slot.sprite,
+    }
+  }
+
+  return {
+    id: descriptor.id,
+    pooled: false,
+    slot: null,
+    sprite: descriptor.id,
   }
 }
 

--- a/scripts/lib/agent-runner-tick-remote.mjs
+++ b/scripts/lib/agent-runner-tick-remote.mjs
@@ -263,6 +263,7 @@ function recommendation(item, { action, command, heartbeat = null, priority, rea
     priority,
     reason,
     state: item.fields["Agent State"] ?? null,
+    workspace: item.fields.Workspace ?? null,
   }
 }
 

--- a/scripts/lib/agent-runner-tick.mjs
+++ b/scripts/lib/agent-runner-tick.mjs
@@ -355,6 +355,7 @@ function recommendation(item, { action, command, heartbeat = null, priority, rea
     priority,
     reason,
     state: item.fields["Agent State"] ?? null,
+    workspace: item.fields.Workspace ?? null,
   }
 }
 

--- a/scripts/tests/agent-runner-sprite-workspace.test.mjs
+++ b/scripts/tests/agent-runner-sprite-workspace.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict"
 import { describe, it } from "node:test"
 
 import {
+  parseSpritePool,
+  resolveSpriteTarget,
   spriteApiExecPlan,
   spriteApiRemoteWorkspaceAdapter,
   spriteCliRemoteWorkspaceAdapter,
@@ -79,6 +81,42 @@ describe("agent runner sprite workspace adapter", () => {
     ])
   })
 
+  it("maps pooled Sprite slot references to the backing Sprite name", () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:voyant-agent-01-slot-2", {
+      repoRoot: "/repo",
+    })
+
+    assert.deepEqual(parseSpritePool("voyant-agent-01:2,voyant-agent-02:1"), [
+      {
+        id: "voyant-agent-01-slot-1",
+        slot: 1,
+        sprite: "voyant-agent-01",
+        workspaceReference: "sandbox:sprite:voyant-agent-01-slot-1",
+      },
+      {
+        id: "voyant-agent-01-slot-2",
+        slot: 2,
+        sprite: "voyant-agent-01",
+        workspaceReference: "sandbox:sprite:voyant-agent-01-slot-2",
+      },
+      {
+        id: "voyant-agent-02",
+        slot: 1,
+        sprite: "voyant-agent-02",
+        workspaceReference: "sandbox:sprite:voyant-agent-02",
+      },
+    ])
+    assert.deepEqual(
+      resolveSpriteTarget(descriptor, { env: { AGENT_SPRITE_POOL: "voyant-agent-01:2" } }),
+      {
+        id: "voyant-agent-01-slot-2",
+        pooled: true,
+        slot: 2,
+        sprite: "voyant-agent-01",
+      },
+    )
+  })
+
   it("inspects and executes through the Sprite API when a token is configured", async () => {
     const descriptor = parseWorkspaceReference("sandbox:sprite:task-579", { repoRoot: "/repo" })
     const calls = []
@@ -114,7 +152,9 @@ describe("agent runner sprite workspace adapter", () => {
       ready: true,
       reason: null,
       reference: "sandbox:sprite:task-579",
+      slot: null,
       sprite: { name: "task-579", status: "running" },
+      spriteName: "task-579",
     })
     assert.deepEqual(await adapter.exec({ args: ["test"], command: "pnpm" }), {
       command: "pnpm test",
@@ -172,11 +212,49 @@ describe("agent runner sprite workspace adapter", () => {
       },
     })
 
-    assert.deepEqual(await adapter.dispose(), { disposed: true, status: 204 })
+    assert.deepEqual(await adapter.dispose(), {
+      disposed: true,
+      spriteName: "task-579",
+      status: 204,
+    })
     assert.deepEqual(calls, [
       {
         method: "DELETE",
         url: "https://api.sprites.dev/v1/sprites/task-579",
+      },
+    ])
+  })
+
+  it("cleans pooled Sprite slots without deleting the backing Sprite", async () => {
+    const descriptor = parseWorkspaceReference("sandbox:sprite:voyant-agent-01-slot-1", {
+      repoRoot: "/repo",
+    })
+    const calls = []
+    const adapter = spriteApiRemoteWorkspaceAdapter(descriptor, {
+      env: { AGENT_SPRITE_POOL: "voyant-agent-01:2", SPRITES_TOKEN: "token" },
+      fetchImpl: async (url, init) => {
+        calls.push({ method: init.method, url: String(url) })
+        return jsonResponse({
+          exit_code: 0,
+          stderr: "",
+          stdout: "",
+        })
+      },
+    })
+
+    assert.deepEqual(await adapter.dispose(), {
+      disposed: true,
+      method: "workspace-directory",
+      pooled: true,
+      slot: 1,
+      spriteName: "voyant-agent-01",
+      status: 0,
+      workspaceRoot: "/home/sprite/voyant-workspaces/voyant-agent-01-slot-1",
+    })
+    assert.deepEqual(calls, [
+      {
+        method: "POST",
+        url: "https://api.sprites.dev/v1/sprites/voyant-agent-01/exec?cmd=rm&cmd=-rf&cmd=%2Fhome%2Fsprite%2Fvoyant-workspaces%2Fvoyant-agent-01-slot-1",
       },
     ])
   })


### PR DESCRIPTION
## Summary
- add a configured Sprite pool with Durable Object slot leases for remote-bootstrap dispatch
- map logical slot workspaces like sandbox:sprite:voyant-agent-01-slot-1 back to their backing Sprite while keeping per-slot repo directories separate
- teach the control plane to turn a ready item into remote-bootstrap when the runner assigns a remote workspace
- update runner deployment config and docs for a 3-Sprite, 2-slot-per-Sprite pool

## Validation
- node --test scripts/tests/agent-runner-sprite-workspace.test.mjs scripts/tests/agent-runner-remote-workspace.test.mjs
- pnpm --filter @voyantjs/agent-runner test -- --runInBand
- pnpm --filter @voyantjs/agent-control-plane test -- --runInBand
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- git diff --check
- git push pre-push hook: pnpm test