### PR TITLE
[codex] Add detail page replacement slots

### DIFF
--- a/.changeset/silver-panels-edit.md
+++ b/.changeset/silver-panels-edit.md
@@ -1,0 +1,7 @@
+---
+"@voyantjs/crm-ui": patch
+"@voyantjs/finance-ui": patch
+"@voyantjs/legal-ui": patch
+---
+
+Add replacement content slots to operator detail pages so consumers can mount custom CRUD panels without duplicating the shipped read-only sections.

--- a/packages/crm-ui/README.md
+++ b/packages/crm-ui/README.md
@@ -62,6 +62,27 @@ standard place to mount those relationships.
 />
 ```
 
+### Detail Tab Replacement Slots
+
+Detail pages also expose `*Content` slots for replacing built-in tab panels while
+keeping the default tabs, counts, layout, and append-only `*End` slots. Use these
+when an app needs inline CRUD controls without rendering a second panel below the
+read-only default.
+
+```tsx
+<PersonDetailPage
+  id={personId}
+  slots={{
+    activitiesContent: <EditableActivitiesPanel personId={personId} />,
+  }}
+/>
+```
+
+`PersonDetailPage` supports `overviewContent`, `opportunitiesContent`,
+`activitiesContent`, `relationshipsContent`, and `documentsContent`.
+`OrganizationDetailPage` supports `overviewContent`, `peopleContent`,
+`opportunitiesContent`, and `activitiesContent`.
+
 ## I18n
 
 Components render English by default. To localize them, wrap your UI in

--- a/packages/crm-ui/src/components/organization-detail-sections.tsx
+++ b/packages/crm-ui/src/components/organization-detail-sections.tsx
@@ -103,9 +103,13 @@ export interface OrganizationCommercialContextTabSlot {
 export interface OrganizationDetailPageSlots {
   afterTopBar?: ReactNode
   sidebarEnd?: ReactNode
+  overviewContent?: ReactNode
   overviewEnd?: ReactNode
+  peopleContent?: ReactNode
   peopleEnd?: ReactNode
+  opportunitiesContent?: ReactNode
   opportunitiesEnd?: ReactNode
+  activitiesContent?: ReactNode
   activitiesEnd?: ReactNode
   bookingsTab?: OrganizationCommercialContextTabSlot
   invoicesTab?: OrganizationCommercialContextTabSlot
@@ -431,40 +435,48 @@ export function OrganizationMain({
           </CardHeader>
           <CardContent className="pt-4">
             <TabsContent value="overview" className="m-0">
-              <dl className="grid grid-cols-1 gap-4 text-sm sm:grid-cols-2">
-                <div>
-                  <dt className="text-xs font-medium uppercase text-muted-foreground">
-                    {messages.organizationDetail.sections.created}
-                  </dt>
-                  <dd className="mt-0.5">{formatCrmDate(i18n, org.createdAt)}</dd>
-                </div>
-                <div>
-                  <dt className="text-xs font-medium uppercase text-muted-foreground">
-                    {messages.organizationDetail.sections.updated}
-                  </dt>
-                  <dd className="mt-0.5">{formatCrmRelative(i18n, org.updatedAt)}</dd>
-                </div>
-                {org.notes && (
-                  <div className="sm:col-span-2">
-                    <dt className="text-xs font-medium uppercase text-muted-foreground">
-                      {messages.organizationDetail.sections.notes}
-                    </dt>
-                    <dd className="mt-0.5 whitespace-pre-wrap">{org.notes}</dd>
-                  </div>
-                )}
-              </dl>
-              <Separator className="my-4" />
-              <InlineField
-                label={messages.organizationDetail.sections.notes}
-                kind="textarea"
-                value={org.notes}
-                onSave={(next) => onUpdateField({ notes: next })}
-              />
+              {slots?.overviewContent !== undefined ? (
+                slots.overviewContent
+              ) : (
+                <>
+                  <dl className="grid grid-cols-1 gap-4 text-sm sm:grid-cols-2">
+                    <div>
+                      <dt className="text-xs font-medium uppercase text-muted-foreground">
+                        {messages.organizationDetail.sections.created}
+                      </dt>
+                      <dd className="mt-0.5">{formatCrmDate(i18n, org.createdAt)}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-medium uppercase text-muted-foreground">
+                        {messages.organizationDetail.sections.updated}
+                      </dt>
+                      <dd className="mt-0.5">{formatCrmRelative(i18n, org.updatedAt)}</dd>
+                    </div>
+                    {org.notes && (
+                      <div className="sm:col-span-2">
+                        <dt className="text-xs font-medium uppercase text-muted-foreground">
+                          {messages.organizationDetail.sections.notes}
+                        </dt>
+                        <dd className="mt-0.5 whitespace-pre-wrap">{org.notes}</dd>
+                      </div>
+                    )}
+                  </dl>
+                  <Separator className="my-4" />
+                  <InlineField
+                    label={messages.organizationDetail.sections.notes}
+                    kind="textarea"
+                    value={org.notes}
+                    onSave={(next) => onUpdateField({ notes: next })}
+                  />
+                </>
+              )}
               {slots?.overviewEnd}
             </TabsContent>
 
             <TabsContent value="people" className="m-0">
-              {peoplePending ? (
+              {slots?.peopleContent !== undefined ? (
+                slots.peopleContent
+              ) : peoplePending ? (
                 <div className="flex justify-center py-6">
                   <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
                 </div>
@@ -513,7 +525,9 @@ export function OrganizationMain({
             </TabsContent>
 
             <TabsContent value="opportunities" className="m-0">
-              {opportunitiesPending ? (
+              {slots?.opportunitiesContent !== undefined ? (
+                slots.opportunitiesContent
+              ) : opportunitiesPending ? (
                 <div className="flex justify-center py-6">
                   <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
                 </div>
@@ -559,7 +573,9 @@ export function OrganizationMain({
             </TabsContent>
 
             <TabsContent value="activities" className="m-0">
-              {activitiesPending ? (
+              {slots?.activitiesContent !== undefined ? (
+                slots.activitiesContent
+              ) : activitiesPending ? (
                 <div className="flex justify-center py-6">
                   <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
                 </div>

--- a/packages/crm-ui/src/components/person-detail-page.tsx
+++ b/packages/crm-ui/src/components/person-detail-page.tsx
@@ -154,10 +154,15 @@ export interface PersonCommercialContextTabSlot {
 export interface PersonDetailPageSlots {
   afterTopBar?: ReactNode
   sidebarEnd?: ReactNode
+  overviewContent?: ReactNode
   overviewEnd?: ReactNode
+  opportunitiesContent?: ReactNode
   opportunitiesEnd?: ReactNode
+  activitiesContent?: ReactNode
   activitiesEnd?: ReactNode
+  relationshipsContent?: ReactNode
   relationshipsEnd?: ReactNode
+  documentsContent?: ReactNode
   documentsEnd?: ReactNode
   bookingsTab?: PersonCommercialContextTabSlot
   invoicesTab?: PersonCommercialContextTabSlot
@@ -658,43 +663,63 @@ export function PersonMain({
           </CardHeader>
           <CardContent className="pt-4">
             <TabsContent value="overview" className="m-0">
-              <PersonOverviewPanel
-                person={person}
-                organization={organization}
-                travelSnapshot={travelSnapshot}
-                travelSnapshotPending={travelSnapshotPending}
-                onUpdateField={onUpdateField}
-              />
+              {slots?.overviewContent !== undefined ? (
+                slots.overviewContent
+              ) : (
+                <PersonOverviewPanel
+                  person={person}
+                  organization={organization}
+                  travelSnapshot={travelSnapshot}
+                  travelSnapshotPending={travelSnapshotPending}
+                  onUpdateField={onUpdateField}
+                />
+              )}
               {slots?.overviewEnd}
             </TabsContent>
             <TabsContent value="opportunities" className="m-0">
-              <PersonOpportunitiesPanel
-                opportunities={opportunities}
-                opportunitiesPending={opportunitiesPending}
-              />
+              {slots?.opportunitiesContent !== undefined ? (
+                slots.opportunitiesContent
+              ) : (
+                <PersonOpportunitiesPanel
+                  opportunities={opportunities}
+                  opportunitiesPending={opportunitiesPending}
+                />
+              )}
               {slots?.opportunitiesEnd}
             </TabsContent>
             <TabsContent value="activities" className="m-0">
-              <PersonActivitiesPanel
-                activities={activities}
-                activitiesPending={activitiesPending}
-              />
+              {slots?.activitiesContent !== undefined ? (
+                slots.activitiesContent
+              ) : (
+                <PersonActivitiesPanel
+                  activities={activities}
+                  activitiesPending={activitiesPending}
+                />
+              )}
               {slots?.activitiesEnd}
             </TabsContent>
             <TabsContent value="relationships" className="m-0">
-              <PersonRelationshipsPanel
-                personId={person.id}
-                relationships={relationships}
-                relationshipsPending={relationshipsPending}
-              />
+              {slots?.relationshipsContent !== undefined ? (
+                slots.relationshipsContent
+              ) : (
+                <PersonRelationshipsPanel
+                  personId={person.id}
+                  relationships={relationships}
+                  relationshipsPending={relationshipsPending}
+                />
+              )}
               {slots?.relationshipsEnd}
             </TabsContent>
             <TabsContent value="documents" className="m-0">
-              <PersonDocumentsPanel
-                documents={documents}
-                documentsPending={documentsPending}
-                primaryCount={primaryDocuments.length}
-              />
+              {slots?.documentsContent !== undefined ? (
+                slots.documentsContent
+              ) : (
+                <PersonDocumentsPanel
+                  documents={documents}
+                  documentsPending={documentsPending}
+                  primaryCount={primaryDocuments.length}
+                />
+              )}
               {slots?.documentsEnd}
             </TabsContent>
             {slots?.bookingsTab ? (

--- a/packages/finance-ui/README.md
+++ b/packages/finance-ui/README.md
@@ -12,6 +12,14 @@ pnpm add @voyantjs/finance-ui @voyantjs/finance-react @voyantjs/ui @tanstack/rea
 
 All components accept a `className` prop and merge it with `cn()`. Wrap or compose to extend; use the registry copy-paste path (`npx shadcn add @voyant/...`) for components you want to fork outright.
 
+## Detail Section Replacement Slots
+
+`InvoiceDetailPage` exposes `*Content` slots for replacing built-in list
+sections while keeping the surrounding detail page and append-only `after*`
+slots. Use `lineItemsContent`, `paymentsContent`, `creditNotesContent`,
+`attachmentsContent`, or `notesContent` when an app needs fully custom inline
+management controls for that section.
+
 ## Components
 
 - `InvoicesPage`, `InvoiceDetailPage`, and `PaymentsPage` publish

--- a/packages/finance-ui/src/components/invoice-detail-page.tsx
+++ b/packages/finance-ui/src/components/invoice-detail-page.tsx
@@ -51,10 +51,15 @@ import { InvoiceDialog } from "./invoice-dialog.js"
 export interface InvoiceDetailPageSlots {
   afterHeader?: ReactNode
   afterSummary?: ReactNode
+  lineItemsContent?: ReactNode
   afterLineItems?: ReactNode
+  paymentsContent?: ReactNode
   afterPayments?: ReactNode
+  creditNotesContent?: ReactNode
   afterCreditNotes?: ReactNode
+  attachmentsContent?: ReactNode
   afterAttachments?: ReactNode
+  notesContent?: ReactNode
   afterNotes?: ReactNode
   dialogs?: ReactNode
 }
@@ -169,64 +174,84 @@ export function InvoiceDetailPage({
       </div>
       {slots?.afterSummary}
 
-      <InvoiceLineItemsCard
-        invoice={invoice}
-        lineItems={lineItems}
-        pending={lineItemsQuery.isPending}
-        deletePending={removeLineItem.isPending}
-        onCreate={onLineItemCreate}
-        onEdit={onLineItemEdit}
-        onDelete={async (lineItemId) => {
-          await removeLineItem.mutateAsync(lineItemId)
-        }}
-      />
+      {slots?.lineItemsContent !== undefined ? (
+        slots.lineItemsContent
+      ) : (
+        <InvoiceLineItemsCard
+          invoice={invoice}
+          lineItems={lineItems}
+          pending={lineItemsQuery.isPending}
+          deletePending={removeLineItem.isPending}
+          onCreate={onLineItemCreate}
+          onEdit={onLineItemEdit}
+          onDelete={async (lineItemId) => {
+            await removeLineItem.mutateAsync(lineItemId)
+          }}
+        />
+      )}
       {slots?.afterLineItems}
 
-      <InvoicePaymentsCard
-        invoice={invoice}
-        payments={payments}
-        pending={paymentsQuery.isPending}
-        onCreate={onPaymentCreate}
-      />
+      {slots?.paymentsContent !== undefined ? (
+        slots.paymentsContent
+      ) : (
+        <InvoicePaymentsCard
+          invoice={invoice}
+          payments={payments}
+          pending={paymentsQuery.isPending}
+          onCreate={onPaymentCreate}
+        />
+      )}
       {slots?.afterPayments}
 
-      <InvoiceCreditNotesCard
-        invoice={invoice}
-        creditNotes={creditNotes}
-        pending={creditNotesQuery.isPending}
-        onCreate={onCreditNoteCreate}
-      />
+      {slots?.creditNotesContent !== undefined ? (
+        slots.creditNotesContent
+      ) : (
+        <InvoiceCreditNotesCard
+          invoice={invoice}
+          creditNotes={creditNotes}
+          pending={creditNotesQuery.isPending}
+          onCreate={onCreditNoteCreate}
+        />
+      )}
       {slots?.afterCreditNotes}
 
-      <InvoiceAttachmentsCard
-        invoice={invoice}
-        attachments={attachments}
-        pending={attachmentsQuery.isPending}
-        deletePending={removeAttachment.isPending}
-        getDownloadHref={
-          getAttachmentDownloadHref ??
-          ((attachment) => `/v1/finance/invoice-attachments/${attachment.id}/download`)
-        }
-        onCreate={() => {
-          setEditingAttachment(undefined)
-          setAttachmentOpen(true)
-        }}
-        onEdit={(attachment) => {
-          setEditingAttachment(attachment)
-          setAttachmentOpen(true)
-        }}
-        onDelete={async (attachmentId) => {
-          await removeAttachment.mutateAsync(attachmentId)
-        }}
-      />
+      {slots?.attachmentsContent !== undefined ? (
+        slots.attachmentsContent
+      ) : (
+        <InvoiceAttachmentsCard
+          invoice={invoice}
+          attachments={attachments}
+          pending={attachmentsQuery.isPending}
+          deletePending={removeAttachment.isPending}
+          getDownloadHref={
+            getAttachmentDownloadHref ??
+            ((attachment) => `/v1/finance/invoice-attachments/${attachment.id}/download`)
+          }
+          onCreate={() => {
+            setEditingAttachment(undefined)
+            setAttachmentOpen(true)
+          }}
+          onEdit={(attachment) => {
+            setEditingAttachment(attachment)
+            setAttachmentOpen(true)
+          }}
+          onDelete={async (attachmentId) => {
+            await removeAttachment.mutateAsync(attachmentId)
+          }}
+        />
+      )}
       {slots?.afterAttachments}
 
-      <InvoiceNotesCard
-        notes={notes}
-        pending={notesQuery.isPending}
-        addPending={addNote.isPending}
-        onCreate={() => setNoteOpen(true)}
-      />
+      {slots?.notesContent !== undefined ? (
+        slots.notesContent
+      ) : (
+        <InvoiceNotesCard
+          notes={notes}
+          pending={notesQuery.isPending}
+          addPending={addNote.isPending}
+          onCreate={() => setNoteOpen(true)}
+        />
+      )}
       {slots?.afterNotes}
 
       <InvoiceDialog open={editOpen} onOpenChange={setEditOpen} invoice={invoice} />

--- a/packages/legal-ui/README.md
+++ b/packages/legal-ui/README.md
@@ -12,6 +12,13 @@ pnpm add @voyantjs/legal-ui @voyantjs/legal-react @voyantjs/ui @tanstack/react-q
 
 All components accept a `className` prop and merge it with `cn()`. Wrap or compose to extend; use the registry copy-paste path (`npx shadcn add @voyant/...`) for components you want to fork outright.
 
+## Detail Tab Replacement Slots
+
+`ContractDetailPage` exposes `slots` for replacing built-in tab content while
+keeping the default tab navigation. Use `detailsContent`, `partiesContent`,
+`signaturesContent`, or `documentsContent` when an app needs custom inline
+management controls instead of the shipped read-only table.
+
 ## I18n
 
 Components render English by default. To localize them, wrap your UI in

--- a/packages/legal-ui/src/components/contract-detail-page.tsx
+++ b/packages/legal-ui/src/components/contract-detail-page.tsx
@@ -47,6 +47,14 @@ export interface ContractDetailPageProps {
   renderContractDialog?: (props: ContractDetailDialogRenderProps) => ReactNode
   renderReference?: (props: ContractReferenceRenderProps) => ReactNode
   getAttachmentDownloadHref?: (attachment: LegalContractAttachmentRecord) => string
+  slots?: ContractDetailPageSlots
+}
+
+export interface ContractDetailPageSlots {
+  detailsContent?: ReactNode
+  partiesContent?: ReactNode
+  signaturesContent?: ReactNode
+  documentsContent?: ReactNode
 }
 
 export type ContractReferenceKind =
@@ -76,6 +84,7 @@ export function ContractDetailPage({
   renderContractDialog,
   renderReference,
   getAttachmentDownloadHref,
+  slots,
 }: ContractDetailPageProps) {
   const queryClient = useQueryClient()
   const i18n = useLegalUiI18nOrDefault()
@@ -208,181 +217,197 @@ export function ContractDetailPage({
           <TabsTrigger value="documents">{f.sections.documents}</TabsTrigger>
         </TabsList>
         <TabsContent value="details" className="mt-4">
-          <ContractSection title={f.sections.details}>
-            <div className="grid gap-3 text-sm">
-              <DetailRow label={f.fields.language}>{contract.language}</DetailRow>
-              {contract.templateVersionId ? (
-                <DetailRow label={f.fields.templateVersion}>
-                  <span className="font-mono text-xs">{contract.templateVersionId}</span>
-                </DetailRow>
-              ) : null}
-              {contract.seriesId ? (
-                <DetailRow label={f.fields.series}>
-                  <span className="font-mono text-xs">{contract.seriesId}</span>
-                </DetailRow>
-              ) : null}
-              {contract.expiresAt ? (
-                <DetailRow label={f.fields.expires}>
-                  {i18n.formatDate(contract.expiresAt)}
-                </DetailRow>
-              ) : null}
-              <div className="mt-2 border-t pt-3">
-                <DetailRow label={f.fields.created}>
-                  {i18n.formatDate(contract.createdAt)}
-                </DetailRow>
-                <DetailRow label={f.fields.updated}>
-                  {i18n.formatDate(contract.updatedAt)}
-                </DetailRow>
+          {slots?.detailsContent !== undefined ? (
+            slots.detailsContent
+          ) : (
+            <ContractSection title={f.sections.details}>
+              <div className="grid gap-3 text-sm">
+                <DetailRow label={f.fields.language}>{contract.language}</DetailRow>
+                {contract.templateVersionId ? (
+                  <DetailRow label={f.fields.templateVersion}>
+                    <span className="font-mono text-xs">{contract.templateVersionId}</span>
+                  </DetailRow>
+                ) : null}
+                {contract.seriesId ? (
+                  <DetailRow label={f.fields.series}>
+                    <span className="font-mono text-xs">{contract.seriesId}</span>
+                  </DetailRow>
+                ) : null}
+                {contract.expiresAt ? (
+                  <DetailRow label={f.fields.expires}>
+                    {i18n.formatDate(contract.expiresAt)}
+                  </DetailRow>
+                ) : null}
+                <div className="mt-2 border-t pt-3">
+                  <DetailRow label={f.fields.created}>
+                    {i18n.formatDate(contract.createdAt)}
+                  </DetailRow>
+                  <DetailRow label={f.fields.updated}>
+                    {i18n.formatDate(contract.updatedAt)}
+                  </DetailRow>
+                </div>
               </div>
-            </div>
-          </ContractSection>
+            </ContractSection>
+          )}
         </TabsContent>
         <TabsContent value="parties" className="mt-4">
-          <ContractSection title={f.sections.parties}>
-            <div className="grid gap-3 text-sm">
-              {contract.personId ? (
-                <DetailRow label={f.fields.person}>
-                  {renderReferenceValue("person", contract.personId)}
-                </DetailRow>
-              ) : null}
-              {contract.organizationId ? (
-                <DetailRow label={f.fields.organization}>
-                  {renderReferenceValue("organization", contract.organizationId)}
-                </DetailRow>
-              ) : null}
-              {contract.supplierId ? (
-                <DetailRow label={f.fields.supplier}>
-                  {renderReferenceValue("supplier", contract.supplierId)}
-                </DetailRow>
-              ) : null}
-              {contract.channelId ? (
-                <DetailRow label={f.fields.channel}>
-                  {renderReferenceValue("channel", contract.channelId)}
-                </DetailRow>
-              ) : null}
-              {contract.bookingId ? (
-                <DetailRow label={f.fields.booking}>
-                  {renderReferenceValue("booking", contract.bookingId)}
-                </DetailRow>
-              ) : null}
-              {contract.orderId ? (
-                <DetailRow label={f.fields.order}>
-                  {renderReferenceValue("order", contract.orderId)}
-                </DetailRow>
-              ) : null}
-              {!contract.personId &&
-              !contract.organizationId &&
-              !contract.supplierId &&
-              !contract.channelId &&
-              !contract.bookingId &&
-              !contract.orderId ? (
-                <p className="text-muted-foreground">{f.empty.noParties}</p>
-              ) : null}
-            </div>
-          </ContractSection>
+          {slots?.partiesContent !== undefined ? (
+            slots.partiesContent
+          ) : (
+            <ContractSection title={f.sections.parties}>
+              <div className="grid gap-3 text-sm">
+                {contract.personId ? (
+                  <DetailRow label={f.fields.person}>
+                    {renderReferenceValue("person", contract.personId)}
+                  </DetailRow>
+                ) : null}
+                {contract.organizationId ? (
+                  <DetailRow label={f.fields.organization}>
+                    {renderReferenceValue("organization", contract.organizationId)}
+                  </DetailRow>
+                ) : null}
+                {contract.supplierId ? (
+                  <DetailRow label={f.fields.supplier}>
+                    {renderReferenceValue("supplier", contract.supplierId)}
+                  </DetailRow>
+                ) : null}
+                {contract.channelId ? (
+                  <DetailRow label={f.fields.channel}>
+                    {renderReferenceValue("channel", contract.channelId)}
+                  </DetailRow>
+                ) : null}
+                {contract.bookingId ? (
+                  <DetailRow label={f.fields.booking}>
+                    {renderReferenceValue("booking", contract.bookingId)}
+                  </DetailRow>
+                ) : null}
+                {contract.orderId ? (
+                  <DetailRow label={f.fields.order}>
+                    {renderReferenceValue("order", contract.orderId)}
+                  </DetailRow>
+                ) : null}
+                {!contract.personId &&
+                !contract.organizationId &&
+                !contract.supplierId &&
+                !contract.channelId &&
+                !contract.bookingId &&
+                !contract.orderId ? (
+                  <p className="text-muted-foreground">{f.empty.noParties}</p>
+                ) : null}
+              </div>
+            </ContractSection>
+          )}
         </TabsContent>
         <TabsContent value="signatures" className="mt-4">
-          <ContractSection
-            title={f.sections.signatures}
-            action={
-              canAddSignature ? (
-                <Button size="sm" onClick={() => setSignOpen(true)}>
-                  <Plus className="mr-2 size-4" aria-hidden="true" />
-                  {f.actions.addSignature}
-                </Button>
-              ) : null
-            }
-          >
-            {!signatures || signatures.length === 0 ? (
-              <p className="py-4 text-center text-sm text-muted-foreground">
-                {f.empty.noSignatures}
-              </p>
-            ) : (
-              <div className="rounded border bg-background">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>{f.fields.name}</TableHead>
-                      <TableHead>{f.fields.email}</TableHead>
-                      <TableHead>{f.fields.role}</TableHead>
-                      <TableHead>{f.fields.method}</TableHead>
-                      <TableHead>{f.fields.signedAt}</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {signatures.map((signature) => (
-                      <TableRow key={signature.id}>
-                        <TableCell>{signature.signerName}</TableCell>
-                        <TableCell>
-                          {signature.signerEmail ?? messages.common.noResultsDash}
-                        </TableCell>
-                        <TableCell>
-                          {signature.signerRole ?? messages.common.noResultsDash}
-                        </TableCell>
-                        <TableCell>{signature.method}</TableCell>
-                        <TableCell>{i18n.formatDateTime(signature.signedAt)}</TableCell>
+          {slots?.signaturesContent !== undefined ? (
+            slots.signaturesContent
+          ) : (
+            <ContractSection
+              title={f.sections.signatures}
+              action={
+                canAddSignature ? (
+                  <Button size="sm" onClick={() => setSignOpen(true)}>
+                    <Plus className="mr-2 size-4" aria-hidden="true" />
+                    {f.actions.addSignature}
+                  </Button>
+                ) : null
+              }
+            >
+              {!signatures || signatures.length === 0 ? (
+                <p className="py-4 text-center text-sm text-muted-foreground">
+                  {f.empty.noSignatures}
+                </p>
+              ) : (
+                <div className="rounded border bg-background">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>{f.fields.name}</TableHead>
+                        <TableHead>{f.fields.email}</TableHead>
+                        <TableHead>{f.fields.role}</TableHead>
+                        <TableHead>{f.fields.method}</TableHead>
+                        <TableHead>{f.fields.signedAt}</TableHead>
                       </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-            )}
-          </ContractSection>
+                    </TableHeader>
+                    <TableBody>
+                      {signatures.map((signature) => (
+                        <TableRow key={signature.id}>
+                          <TableCell>{signature.signerName}</TableCell>
+                          <TableCell>
+                            {signature.signerEmail ?? messages.common.noResultsDash}
+                          </TableCell>
+                          <TableCell>
+                            {signature.signerRole ?? messages.common.noResultsDash}
+                          </TableCell>
+                          <TableCell>{signature.method}</TableCell>
+                          <TableCell>{i18n.formatDateTime(signature.signedAt)}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
+            </ContractSection>
+          )}
         </TabsContent>
         <TabsContent value="documents" className="mt-4">
-          <ContractSection
-            title={f.sections.documents}
-            action={
-              <Button
-                size="sm"
-                onClick={() => {
-                  setEditingAttachment(undefined)
-                  setAttachOpen(true)
-                }}
-              >
-                <Plus className="mr-2 size-4" aria-hidden="true" />
-                {f.actions.addDocument}
-              </Button>
-            }
-          >
-            {!attachments || attachments.length === 0 ? (
-              <p className="py-4 text-center text-sm text-muted-foreground">
-                {f.empty.noAttachments}
-              </p>
-            ) : (
-              <div className="rounded border bg-background">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>{f.fields.name}</TableHead>
-                      <TableHead>{f.fields.kind}</TableHead>
-                      <TableHead>{f.fields.mimeType}</TableHead>
-                      <TableHead>{f.fields.size}</TableHead>
-                      <TableHead className="w-16" />
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {attachments.map((attachment) => (
-                      <AttachmentRow
-                        key={attachment.id}
-                        attachment={attachment}
-                        downloadHref={getAttachmentDownloadHref?.(attachment)}
-                        onEdit={() => {
-                          setEditingAttachment(attachment)
-                          setAttachOpen(true)
-                        }}
-                        onDelete={() => {
-                          if (confirm(f.deleteAttachmentConfirm)) {
-                            removeAttachment.mutate({ contractId: id, id: attachment.id })
-                          }
-                        }}
-                      />
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-            )}
-          </ContractSection>
+          {slots?.documentsContent !== undefined ? (
+            slots.documentsContent
+          ) : (
+            <ContractSection
+              title={f.sections.documents}
+              action={
+                <Button
+                  size="sm"
+                  onClick={() => {
+                    setEditingAttachment(undefined)
+                    setAttachOpen(true)
+                  }}
+                >
+                  <Plus className="mr-2 size-4" aria-hidden="true" />
+                  {f.actions.addDocument}
+                </Button>
+              }
+            >
+              {!attachments || attachments.length === 0 ? (
+                <p className="py-4 text-center text-sm text-muted-foreground">
+                  {f.empty.noAttachments}
+                </p>
+              ) : (
+                <div className="rounded border bg-background">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>{f.fields.name}</TableHead>
+                        <TableHead>{f.fields.kind}</TableHead>
+                        <TableHead>{f.fields.mimeType}</TableHead>
+                        <TableHead>{f.fields.size}</TableHead>
+                        <TableHead className="w-16" />
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {attachments.map((attachment) => (
+                        <AttachmentRow
+                          key={attachment.id}
+                          attachment={attachment}
+                          downloadHref={getAttachmentDownloadHref?.(attachment)}
+                          onEdit={() => {
+                            setEditingAttachment(attachment)
+                            setAttachOpen(true)
+                          }}
+                          onDelete={() => {
+                            if (confirm(f.deleteAttachmentConfirm)) {
+                              removeAttachment.mutate({ contractId: id, id: attachment.id })
+                            }
+                          }}
+                        />
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
+            </ContractSection>
+          )}
         </TabsContent>
       </Tabs>
 

--- a/packages/legal-ui/src/index.ts
+++ b/packages/legal-ui/src/index.ts
@@ -8,6 +8,7 @@ export {
   type ContractDetailDialogRenderProps,
   ContractDetailPage,
   type ContractDetailPageProps,
+  type ContractDetailPageSlots,
   type ContractReferenceKind,
   type ContractReferenceRenderProps,
 } from "./components/contract-detail-page.js"


### PR DESCRIPTION
## Summary
- Add replace-content slots to CRM person and organization detail tabs while preserving existing append-only slots.
- Add invoice detail replacement slots for line items, payments, credit notes, attachments, and notes.
- Add legal contract detail tab replacement slots and export the new slot type.
- Document the new extension points and add a changeset for the published UI packages.

## Validation
- pnpm lint:changed
- pnpm --filter @voyantjs/crm-ui typecheck
- pnpm --filter @voyantjs/finance-ui typecheck
- pnpm --filter @voyantjs/legal-ui typecheck
- pnpm --filter @voyantjs/crm-ui build
- pnpm --filter @voyantjs/finance-ui build
- pnpm --filter @voyantjs/legal-ui build
- pre-commit hook: lint + typecheck
- pre-push hook: test

Note: pnpm verify:package-exports was attempted, but this fresh worktree is missing unrelated package dist outputs required by that repository-wide check.

Closes #818