### PR TITLE
Fix Sprite pool slot retry behavior

### DIFF
--- a/apps/agent-runner/src/remote-workspace-pool.ts
+++ b/apps/agent-runner/src/remote-workspace-pool.ts
@@ -58,11 +58,13 @@ export function parseSpritePoolConfig(value: string | undefined): RemoteWorkspac
 
 export async function acquireRemoteWorkspaceSlot({
   coordinator,
+  excludedWorkspaceReferences = new Set(),
   holder,
   pool,
   ttlSeconds,
 }: {
   coordinator?: CoordinatorService
+  excludedWorkspaceReferences?: ReadonlySet<string>
   holder: string
   pool?: RemoteWorkspacePool
   ttlSeconds: number
@@ -79,6 +81,8 @@ export async function acquireRemoteWorkspaceSlot({
   }
 
   for (const slot of pool.slots) {
+    if (excludedWorkspaceReferences.has(slot.workspaceReference)) continue
+
     const response = await coordinator.fetch(
       jsonRequest("https://agent-runner-coordinator.internal/locks/acquire", {
         holder,

--- a/apps/agent-runner/src/runner-remote-workspace-pool.test.ts
+++ b/apps/agent-runner/src/runner-remote-workspace-pool.test.ts
@@ -1,0 +1,334 @@
+import { describe, expect, it } from "vitest"
+
+import { parseSpritePoolConfig } from "./remote-workspace-pool.js"
+import { runSupervisorTick } from "./runner.js"
+
+describe("agent runner remote workspace pool", () => {
+  it("leases a Sprite pool slot before requesting remote bootstrap work", async () => {
+    const controlPlaneCalls: Array<{ body: unknown; url: string }> = []
+    const coordinatorCalls: Array<{ body: unknown; url: string }> = []
+    const result = await runSupervisorTick({
+      config: {
+        allowedActions: ["remote-bootstrap"],
+        controlPlaneConfigured: true,
+        controlPlaneToken: "control-token",
+        controlPlaneUrl: "https://control.example.com/",
+        defaultAction: "remote-bootstrap",
+        enabled: true,
+        holder: "runner:cloudflare",
+        remoteWorkspacePool: parseSpritePoolConfig("voyant-agent-01:2,voyant-agent-02:2"),
+        repository: "voyantjs/voyant",
+      },
+      coordinatorService: {
+        fetch: async (input) => {
+          const request = input instanceof Request ? input : new Request(input)
+          const body = (await request.json()) as { holder: string; key: string }
+          coordinatorCalls.push({ body, url: request.url })
+          return new Response(
+            JSON.stringify({
+              acquired: true,
+              lock: {
+                acquiredAt: "2026-05-12T12:00:00.000Z",
+                expiresAt: "2026-05-12T12:05:00.000Z",
+                holder: body.holder,
+                key: body.key,
+              },
+            }),
+            { status: 201 },
+          )
+        },
+      },
+      fetchImpl: async (url, init) => {
+        controlPlaneCalls.push({
+          body: JSON.parse(String(init?.body)),
+          url: String(url),
+        })
+        return new Response(
+          JSON.stringify({
+            intent: {
+              id: "intent_579",
+              plan: {
+                action: "remote-bootstrap",
+              },
+              status: "leased",
+            },
+            reason: "leased",
+          }),
+          { status: 201 },
+        )
+      },
+      request: {
+        dryRun: false,
+        ttlSeconds: 300,
+      },
+      source: "scheduled",
+    })
+
+    expect(result).toMatchObject({
+      leased: true,
+      reason: "leased",
+      remoteWorkspaceLease: {
+        key: "remote-workspace:sprite:voyant-agent-01-slot-1",
+        slot: {
+          sprite: "voyant-agent-01",
+          workspaceReference: "sandbox:sprite:voyant-agent-01-slot-1",
+        },
+      },
+    })
+    expect(coordinatorCalls).toEqual([
+      {
+        body: {
+          holder: "runner:cloudflare",
+          key: "remote-workspace:sprite:voyant-agent-01-slot-1",
+          ttlSeconds: 300,
+        },
+        url: "https://agent-runner-coordinator.internal/locks/acquire",
+      },
+    ])
+    expect(controlPlaneCalls).toEqual([
+      {
+        body: {
+          filters: {
+            action: "start",
+          },
+          lease: {
+            holder: "runner:cloudflare",
+            ttlSeconds: 300,
+          },
+          options: {
+            remoteWorkspace: "sandbox:sprite:voyant-agent-01-slot-1",
+          },
+          repository: "voyantjs/voyant",
+        },
+        url: "https://control.example.com/api/dispatch-intents/latest",
+      },
+    ])
+  })
+
+  it("retries the next Sprite pool slot when the first workspace is already assigned", async () => {
+    const controlPlaneCalls: Array<{ body: unknown; url: string }> = []
+    const coordinatorCalls: Array<{ body: unknown; url: string }> = []
+    const result = await runSupervisorTick({
+      config: {
+        allowedActions: ["remote-bootstrap"],
+        controlPlaneConfigured: true,
+        controlPlaneToken: "control-token",
+        controlPlaneUrl: "https://control.example.com/",
+        defaultAction: "remote-bootstrap",
+        enabled: true,
+        holder: "runner:cloudflare",
+        remoteWorkspacePool: parseSpritePoolConfig("voyant-agent-01:2"),
+        repository: "voyantjs/voyant",
+      },
+      coordinatorService: {
+        fetch: async (input) => {
+          const request = input instanceof Request ? input : new Request(input)
+          const body = (await request.json()) as { holder: string; key: string }
+          coordinatorCalls.push({ body, url: request.url })
+          if (request.url.endsWith("/locks/release")) {
+            return new Response(JSON.stringify({ released: true }), { status: 200 })
+          }
+          return new Response(
+            JSON.stringify({
+              acquired: true,
+              lock: {
+                acquiredAt: "2026-05-12T12:00:00.000Z",
+                expiresAt: "2026-05-12T12:05:00.000Z",
+                holder: body.holder,
+                key: body.key,
+              },
+            }),
+            { status: 201 },
+          )
+        },
+      },
+      fetchImpl: async (url, init) => {
+        const body = JSON.parse(String(init?.body))
+        controlPlaneCalls.push({
+          body,
+          url: String(url),
+        })
+        if (body.options.remoteWorkspace === "sandbox:sprite:voyant-agent-01-slot-1") {
+          return new Response(
+            JSON.stringify({
+              intent: null,
+              reason: "remote workspace sandbox:sprite:voyant-agent-01-slot-1 is already assigned",
+            }),
+            { status: 200 },
+          )
+        }
+        return new Response(
+          JSON.stringify({
+            intent: {
+              id: "intent_580",
+              plan: {
+                action: "remote-bootstrap",
+              },
+              status: "leased",
+            },
+            reason: "leased",
+          }),
+          { status: 201 },
+        )
+      },
+      request: {
+        dryRun: false,
+        ttlSeconds: 300,
+      },
+      source: "scheduled",
+    })
+
+    expect(result).toMatchObject({
+      intent: {
+        id: "intent_580",
+      },
+      leased: true,
+      reason: "leased",
+      remoteWorkspaceLease: {
+        key: "remote-workspace:sprite:voyant-agent-01-slot-2",
+        slot: {
+          workspaceReference: "sandbox:sprite:voyant-agent-01-slot-2",
+        },
+      },
+    })
+    expect(coordinatorCalls).toEqual([
+      {
+        body: {
+          holder: "runner:cloudflare",
+          key: "remote-workspace:sprite:voyant-agent-01-slot-1",
+          ttlSeconds: 300,
+        },
+        url: "https://agent-runner-coordinator.internal/locks/acquire",
+      },
+      {
+        body: {
+          holder: "runner:cloudflare",
+          key: "remote-workspace:sprite:voyant-agent-01-slot-1",
+        },
+        url: "https://agent-runner-coordinator.internal/locks/release",
+      },
+      {
+        body: {
+          holder: "runner:cloudflare",
+          key: "remote-workspace:sprite:voyant-agent-01-slot-2",
+          ttlSeconds: 300,
+        },
+        url: "https://agent-runner-coordinator.internal/locks/acquire",
+      },
+    ])
+    expect(controlPlaneCalls.map((call) => call.body)).toEqual([
+      expect.objectContaining({
+        options: {
+          remoteWorkspace: "sandbox:sprite:voyant-agent-01-slot-1",
+        },
+      }),
+      expect.objectContaining({
+        options: {
+          remoteWorkspace: "sandbox:sprite:voyant-agent-01-slot-2",
+        },
+      }),
+    ])
+  })
+
+  it("stops Sprite pool retries when releasing an assigned slot fails", async () => {
+    const controlPlaneCalls: Array<{ body: unknown; url: string }> = []
+    const coordinatorCalls: Array<{ body: unknown; url: string }> = []
+    const result = await runSupervisorTick({
+      config: {
+        allowedActions: ["remote-bootstrap"],
+        controlPlaneConfigured: true,
+        controlPlaneToken: "control-token",
+        controlPlaneUrl: "https://control.example.com/",
+        defaultAction: "remote-bootstrap",
+        enabled: true,
+        holder: "runner:cloudflare",
+        remoteWorkspacePool: parseSpritePoolConfig("voyant-agent-01:2"),
+        repository: "voyantjs/voyant",
+      },
+      coordinatorService: {
+        fetch: async (input) => {
+          const request = input instanceof Request ? input : new Request(input)
+          const body = (await request.json()) as { holder: string; key: string }
+          coordinatorCalls.push({ body, url: request.url })
+          if (request.url.endsWith("/locks/release")) {
+            return new Response(JSON.stringify({ reason: "holder_mismatch", released: false }), {
+              status: 409,
+            })
+          }
+          return new Response(
+            JSON.stringify({
+              acquired: true,
+              lock: {
+                acquiredAt: "2026-05-12T12:00:00.000Z",
+                expiresAt: "2026-05-12T12:05:00.000Z",
+                holder: body.holder,
+                key: body.key,
+              },
+            }),
+            { status: 201 },
+          )
+        },
+      },
+      fetchImpl: async (url, init) => {
+        const body = JSON.parse(String(init?.body))
+        controlPlaneCalls.push({
+          body,
+          url: String(url),
+        })
+        return new Response(
+          JSON.stringify({
+            intent: null,
+            reason: "remote workspace sandbox:sprite:voyant-agent-01-slot-1 is already assigned",
+          }),
+          { status: 200 },
+        )
+      },
+      request: {
+        dryRun: false,
+        ttlSeconds: 300,
+      },
+      source: "scheduled",
+    })
+
+    expect(result).toMatchObject({
+      intent: null,
+      leased: false,
+      reason: "remote_workspace_release_failed",
+      remoteWorkspaceLease: {
+        key: "remote-workspace:sprite:voyant-agent-01-slot-1",
+      },
+      remoteWorkspaceRelease: {
+        released: false,
+        response: {
+          reason: "holder_mismatch",
+          released: false,
+        },
+        status: 409,
+      },
+    })
+    expect(coordinatorCalls).toEqual([
+      {
+        body: {
+          holder: "runner:cloudflare",
+          key: "remote-workspace:sprite:voyant-agent-01-slot-1",
+          ttlSeconds: 300,
+        },
+        url: "https://agent-runner-coordinator.internal/locks/acquire",
+      },
+      {
+        body: {
+          holder: "runner:cloudflare",
+          key: "remote-workspace:sprite:voyant-agent-01-slot-1",
+        },
+        url: "https://agent-runner-coordinator.internal/locks/release",
+      },
+    ])
+    expect(controlPlaneCalls.map((call) => call.body)).toEqual([
+      expect.objectContaining({
+        options: {
+          remoteWorkspace: "sandbox:sprite:voyant-agent-01-slot-1",
+        },
+      }),
+    ])
+  })
+})

--- a/apps/agent-runner/src/runner-remote-workspace-pool.ts
+++ b/apps/agent-runner/src/runner-remote-workspace-pool.ts
@@ -1,0 +1,172 @@
+import {
+  acquireRemoteWorkspaceSlot,
+  type RemoteWorkspaceSlotLease,
+  releaseRemoteWorkspaceSlot,
+} from "./remote-workspace-pool.js"
+import type { planSupervisorTick, RunnerConfig, SupervisorTickRequest } from "./runner.js"
+
+type CoordinatorService = Pick<Fetcher, "fetch">
+
+interface DispatchIntentResponse {
+  body: Record<string, unknown> | null
+  bodyText: string
+  ok: boolean
+  status: number
+}
+
+export async function leaseDispatchIntentWithRemoteWorkspacePool({
+  config,
+  coordinatorService,
+  plan,
+  request,
+  requestIntent,
+}: {
+  config: RunnerConfig
+  coordinatorService?: CoordinatorService
+  plan: ReturnType<typeof planSupervisorTick>
+  request: SupervisorTickRequest
+  requestIntent: (remoteWorkspace?: string) => Promise<DispatchIntentResponse>
+}) {
+  const attemptedWorkspaceReferences = new Set<string>()
+
+  for (;;) {
+    const workspaceLease = await maybeAcquireRemoteWorkspaceSlot({
+      config,
+      coordinatorService,
+      excludedWorkspaceReferences: attemptedWorkspaceReferences,
+      request,
+    })
+    if (workspaceLease.blocked) {
+      return {
+        leased: false,
+        plan,
+        reason: workspaceLease.reason,
+        remoteWorkspacePool: {
+          ...workspaceLease.remoteWorkspacePool,
+          attempted: attemptedWorkspaceReferences.size,
+        },
+      }
+    }
+
+    const result = await requestIntent(workspaceLease.lease?.slot.workspaceReference)
+    if (!result.ok) {
+      await releaseRemoteWorkspaceSlot({
+        coordinator: coordinatorService,
+        holder: request.holder ?? config.holder ?? "",
+        lease: workspaceLease.lease,
+      })
+      return {
+        controlPlane: {
+          ...(result.body?.intent ? { activeIntent: result.body.intent } : {}),
+          error: result.body?.error ?? result.bodyText,
+          status: result.status,
+        },
+        leased: false,
+        plan,
+        reason: "control_plane_rejected",
+        ...(workspaceLease.lease ? { remoteWorkspaceLease: workspaceLease.lease } : {}),
+      }
+    }
+
+    if (result.body?.intent) {
+      return {
+        controlPlane: {
+          status: result.status,
+        },
+        intent: result.body.intent,
+        leased: true,
+        plan,
+        reason: result.body.reason ?? "leased",
+        ...(workspaceLease.lease ? { remoteWorkspaceLease: workspaceLease.lease } : {}),
+      }
+    }
+
+    const remoteWorkspaceRelease = await releaseRemoteWorkspaceSlot({
+      coordinator: coordinatorService,
+      holder: request.holder ?? config.holder ?? "",
+      lease: workspaceLease.lease,
+    })
+
+    const workspaceReference = workspaceLease.lease?.slot.workspaceReference
+    if (!workspaceReference || !isRemoteWorkspaceAlreadyAssignedReason(result.body?.reason)) {
+      return {
+        controlPlane: {
+          status: result.status,
+        },
+        intent: null,
+        leased: false,
+        plan,
+        reason: result.body?.reason ?? "no_intent",
+        ...(workspaceLease.lease ? { remoteWorkspaceLease: workspaceLease.lease } : {}),
+      }
+    }
+
+    if (!remoteWorkspaceRelease.released) {
+      return {
+        controlPlane: {
+          status: result.status,
+        },
+        intent: null,
+        leased: false,
+        plan,
+        reason: "remote_workspace_release_failed",
+        remoteWorkspaceLease: workspaceLease.lease,
+        remoteWorkspaceRelease,
+      }
+    }
+
+    attemptedWorkspaceReferences.add(workspaceReference)
+  }
+}
+
+async function maybeAcquireRemoteWorkspaceSlot({
+  config,
+  coordinatorService,
+  excludedWorkspaceReferences,
+  request,
+}: {
+  config: RunnerConfig
+  coordinatorService?: CoordinatorService
+  excludedWorkspaceReferences?: ReadonlySet<string>
+  request: SupervisorTickRequest
+}): Promise<
+  | { blocked: false; lease?: RemoteWorkspaceSlotLease }
+  | {
+      blocked: true
+      reason: "remote_workspace_pool_full" | "remote_workspace_pool_not_configured"
+      remoteWorkspacePool: { configured: boolean; slots: number }
+    }
+> {
+  const holder = request.holder ?? config.holder
+  if (!holder) return { blocked: false }
+
+  const ttlSeconds = request.ttlSeconds ?? config.leaseTtlSeconds ?? 900
+  const acquired = await acquireRemoteWorkspaceSlot({
+    coordinator: coordinatorService,
+    excludedWorkspaceReferences,
+    holder,
+    pool: config.remoteWorkspacePool,
+    ttlSeconds,
+  })
+  if (acquired.acquired) {
+    return { blocked: false, lease: acquired.lease }
+  }
+
+  const remoteWorkspacePool = {
+    configured: Boolean(config.remoteWorkspacePool?.configured),
+    slots: config.remoteWorkspacePool?.slots.length ?? 0,
+  }
+
+  return {
+    blocked: true,
+    reason:
+      acquired.reason === "pool_full"
+        ? "remote_workspace_pool_full"
+        : "remote_workspace_pool_not_configured",
+    remoteWorkspacePool,
+  }
+}
+
+function isRemoteWorkspaceAlreadyAssignedReason(reason: unknown) {
+  return typeof reason === "string" && /^remote workspace .+ is already assigned$/.test(reason)
+}

--- a/apps/agent-runner/src/runner-smoke.test.ts
+++ b/apps/agent-runner/src/runner-smoke.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest"
 
-import { parseSpritePoolConfig } from "./remote-workspace-pool.js"
 import { runSupervisorTick } from "./runner.js"
 
 describe("agent runner smoke ticks", () => {
@@ -261,107 +260,6 @@ describe("agent runner smoke ticks", () => {
           },
           lease: {
             holder: "runner:cloudflare",
-          },
-          repository: "voyantjs/voyant",
-        },
-        url: "https://control.example.com/api/dispatch-intents/latest",
-      },
-    ])
-  })
-
-  it("leases a Sprite pool slot before requesting remote bootstrap work", async () => {
-    const controlPlaneCalls: Array<{ body: unknown; url: string }> = []
-    const coordinatorCalls: Array<{ body: unknown; url: string }> = []
-    const result = await runSupervisorTick({
-      config: {
-        allowedActions: ["remote-bootstrap"],
-        controlPlaneConfigured: true,
-        controlPlaneToken: "control-token",
-        controlPlaneUrl: "https://control.example.com/",
-        defaultAction: "remote-bootstrap",
-        enabled: true,
-        holder: "runner:cloudflare",
-        remoteWorkspacePool: parseSpritePoolConfig("voyant-agent-01:2,voyant-agent-02:2"),
-        repository: "voyantjs/voyant",
-      },
-      coordinatorService: {
-        fetch: async (input) => {
-          const request = input instanceof Request ? input : new Request(input)
-          const body = (await request.json()) as { holder: string; key: string }
-          coordinatorCalls.push({ body, url: request.url })
-          return new Response(
-            JSON.stringify({
-              acquired: true,
-              lock: {
-                acquiredAt: "2026-05-12T12:00:00.000Z",
-                expiresAt: "2026-05-12T12:05:00.000Z",
-                holder: body.holder,
-                key: body.key,
-              },
-            }),
-            { status: 201 },
-          )
-        },
-      },
-      fetchImpl: async (url, init) => {
-        controlPlaneCalls.push({
-          body: JSON.parse(String(init?.body)),
-          url: String(url),
-        })
-        return new Response(
-          JSON.stringify({
-            intent: {
-              id: "intent_579",
-              plan: {
-                action: "remote-bootstrap",
-              },
-              status: "leased",
-            },
-            reason: "leased",
-          }),
-          { status: 201 },
-        )
-      },
-      request: {
-        dryRun: false,
-        ttlSeconds: 300,
-      },
-      source: "scheduled",
-    })
-
-    expect(result).toMatchObject({
-      leased: true,
-      reason: "leased",
-      remoteWorkspaceLease: {
-        key: "remote-workspace:sprite:voyant-agent-01-slot-1",
-        slot: {
-          sprite: "voyant-agent-01",
-          workspaceReference: "sandbox:sprite:voyant-agent-01-slot-1",
-        },
-      },
-    })
-    expect(coordinatorCalls).toEqual([
-      {
-        body: {
-          holder: "runner:cloudflare",
-          key: "remote-workspace:sprite:voyant-agent-01-slot-1",
-          ttlSeconds: 300,
-        },
-        url: "https://agent-runner-coordinator.internal/locks/acquire",
-      },
-    ])
-    expect(controlPlaneCalls).toEqual([
-      {
-        body: {
-          filters: {
-            action: "start",
-          },
-          lease: {
-            holder: "runner:cloudflare",
-            ttlSeconds: 300,
-          },
-          options: {
-            remoteWorkspace: "sandbox:sprite:voyant-agent-01-slot-1",
           },
           repository: "voyantjs/voyant",
         },

--- a/apps/agent-runner/src/runner.ts
+++ b/apps/agent-runner/src/runner.ts
@@ -1,10 +1,6 @@
 import { z } from "zod"
-import {
-  acquireRemoteWorkspaceSlot,
-  type RemoteWorkspacePool,
-  type RemoteWorkspaceSlotLease,
-  releaseRemoteWorkspaceSlot,
-} from "./remote-workspace-pool.js"
+import type { RemoteWorkspacePool } from "./remote-workspace-pool.js"
+import { leaseDispatchIntentWithRemoteWorkspacePool } from "./runner-remote-workspace-pool.js"
 
 export const runnerDispatchActions = [
   "collect-ci",
@@ -197,24 +193,37 @@ export async function runSupervisorTick({
     })
   }
 
-  const workspaceLease = await maybeAcquireRemoteWorkspaceSlot({
-    config,
-    coordinatorService,
-    request,
-  })
-  if (workspaceLease.blocked) {
-    return {
-      leased: false,
+  if (usesRemoteWorkspacePool({ config, request })) {
+    return await leaseDispatchIntentWithRemoteWorkspacePool({
+      config,
+      coordinatorService,
       plan,
-      reason: workspaceLease.reason,
-      remoteWorkspacePool: workspaceLease.remoteWorkspacePool,
-    }
+      request,
+      requestIntent: async (remoteWorkspace) => {
+        const response = await requestControlPlane({
+          body: buildDispatchIntentRequest({
+            config,
+            remoteWorkspace,
+            request,
+          }),
+          config,
+          fetchImpl,
+          path: "/api/dispatch-intents/latest",
+        })
+        const bodyText = await response.text()
+        return {
+          body: parseJsonBody(bodyText),
+          bodyText,
+          ok: response.ok,
+          status: response.status,
+        }
+      },
+    })
   }
 
   const response = await requestControlPlane({
     body: buildDispatchIntentRequest({
       config,
-      remoteWorkspace: workspaceLease.lease?.slot.workspaceReference,
       request,
     }),
     config,
@@ -225,11 +234,6 @@ export async function runSupervisorTick({
   const body = parseJsonBody(bodyText)
 
   if (!response.ok) {
-    await releaseRemoteWorkspaceSlot({
-      coordinator: coordinatorService,
-      holder: request.holder ?? config.holder ?? "",
-      lease: workspaceLease.lease,
-    })
     return {
       controlPlane: {
         ...(body?.intent ? { activeIntent: body.intent } : {}),
@@ -239,16 +243,7 @@ export async function runSupervisorTick({
       leased: false,
       plan,
       reason: "control_plane_rejected",
-      ...(workspaceLease.lease ? { remoteWorkspaceLease: workspaceLease.lease } : {}),
     }
-  }
-
-  if (!body?.intent) {
-    await releaseRemoteWorkspaceSlot({
-      coordinator: coordinatorService,
-      holder: request.holder ?? config.holder ?? "",
-      lease: workspaceLease.lease,
-    })
   }
 
   return {
@@ -259,58 +254,6 @@ export async function runSupervisorTick({
     leased: Boolean(body?.intent),
     plan,
     reason: body?.reason ?? (body?.intent ? "leased" : "no_intent"),
-    ...(workspaceLease.lease ? { remoteWorkspaceLease: workspaceLease.lease } : {}),
-  }
-}
-
-async function maybeAcquireRemoteWorkspaceSlot({
-  config,
-  coordinatorService,
-  request,
-}: {
-  config: RunnerConfig
-  coordinatorService?: CoordinatorService
-  request: SupervisorTickRequest
-}): Promise<
-  | { blocked: false; lease?: RemoteWorkspaceSlotLease }
-  | {
-      blocked: true
-      reason: "remote_workspace_pool_full" | "remote_workspace_pool_not_configured"
-      remoteWorkspacePool: { configured: boolean; slots: number }
-    }
-> {
-  if (!usesRemoteWorkspacePool({ config, request })) {
-    return { blocked: false }
-  }
-
-  const holder = request.holder ?? config.holder
-  if (!holder) {
-    return { blocked: false }
-  }
-
-  const ttlSeconds = request.ttlSeconds ?? config.leaseTtlSeconds ?? 900
-  const acquired = await acquireRemoteWorkspaceSlot({
-    coordinator: coordinatorService,
-    holder,
-    pool: config.remoteWorkspacePool,
-    ttlSeconds,
-  })
-  if (acquired.acquired) {
-    return { blocked: false, lease: acquired.lease }
-  }
-
-  const remoteWorkspacePool = {
-    configured: Boolean(config.remoteWorkspacePool?.configured),
-    slots: config.remoteWorkspacePool?.slots.length ?? 0,
-  }
-
-  return {
-    blocked: true,
-    reason:
-      acquired.reason === "pool_full"
-        ? "remote_workspace_pool_full"
-        : "remote_workspace_pool_not_configured",
-    remoteWorkspacePool,
   }
 }
 


### PR DESCRIPTION
## Summary
- retry the next configured Sprite pool slot when the control plane reports the selected workspace is already assigned
- release the rejected short-lived slot lock before trying another slot
- move Sprite pool dispatch retry logic out of the main runner module
- add regression coverage for assigned-slot retry behavior

## Verification
- pnpm --dir apps/agent-runner test
- pnpm --dir apps/agent-runner typecheck
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- git diff --check origin/main...HEAD
- pre-push pnpm test: 125 successful tasks
