### PR TITLE
Fix itinerary service picker pass-through

### DIFF
--- a/.changeset/product-itinerary-service-picker.md
+++ b/.changeset/product-itinerary-service-picker.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/products-ui": patch
+---
+
+Forward supplier-service picker hooks through ProductDetailPage and ProductItinerarySection, and wire the itinerary section service dialogs to the product day service form.

--- a/packages/products-ui/src/components/product-day-service-dialog.tsx
+++ b/packages/products-ui/src/components/product-day-service-dialog.tsx
@@ -1,0 +1,75 @@
+"use client"
+
+import type { ProductDayServiceRecord } from "@voyantjs/products-react"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@voyantjs/ui/components/dialog"
+
+import { useProductsUiMessagesOrDefault } from "../i18n/provider.js"
+import {
+  ProductDayServiceForm,
+  type ProductDayServiceFormProps,
+} from "./product-day-service-form.js"
+
+export interface ProductDayServiceDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  productId: string
+  dayId: string
+  service?: ProductDayServiceRecord
+  onSuccess?: (service: ProductDayServiceRecord) => void
+  renderSupplierServiceField?: ProductDayServiceFormProps["renderSupplierServiceField"]
+  onSupplierServiceSelected?: ProductDayServiceFormProps["onSupplierServiceSelected"]
+}
+
+export function ProductDayServiceDialog({
+  open,
+  onOpenChange,
+  productId,
+  dayId,
+  service,
+  onSuccess,
+  renderSupplierServiceField,
+  onSupplierServiceSelected,
+}: ProductDayServiceDialogProps) {
+  const isEdit = Boolean(service)
+  const messages = useProductsUiMessagesOrDefault()
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent data-slot="product-day-service-dialog" className="sm:max-w-[720px]">
+        <DialogHeader>
+          <DialogTitle>
+            {isEdit
+              ? messages.productDayServiceDialog.titles.edit
+              : messages.productDayServiceDialog.titles.create}
+          </DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? messages.productDayServiceDialog.descriptions.edit
+              : messages.productDayServiceDialog.descriptions.create}
+          </DialogDescription>
+        </DialogHeader>
+        <ProductDayServiceForm
+          mode={
+            service
+              ? { kind: "edit", productId, dayId, service }
+              : { kind: "create", productId, dayId }
+          }
+          renderSupplierServiceField={renderSupplierServiceField}
+          onSupplierServiceSelected={onSupplierServiceSelected}
+          onSuccess={(savedService) => {
+            onSuccess?.(savedService)
+            onOpenChange(false)
+          }}
+          onCancel={() => onOpenChange(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/packages/products-ui/src/components/product-detail-page.tsx
+++ b/packages/products-ui/src/components/product-detail-page.tsx
@@ -7,6 +7,7 @@ import {
   type ProductRecord,
   useProduct,
   useProductDayMutation,
+  useProductDayServiceMutation,
   useProductItineraries,
   useProductItineraryDays,
   useProductItineraryMutation,
@@ -34,6 +35,8 @@ import * as React from "react"
 
 import { useProductsUiI18nOrDefault, useProductsUiMessagesOrDefault } from "../i18n/provider.js"
 import { ProductDayDialog } from "./product-day-dialog.js"
+import { ProductDayServiceDialog } from "./product-day-service-dialog.js"
+import type { ProductDayServiceFormProps } from "./product-day-service-form.js"
 import { ProductDialog } from "./product-dialog.js"
 import {
   ProductItineraryDayRow,
@@ -69,6 +72,8 @@ export interface ProductDetailPageProps {
   renderOptionDetails?: ProductOptionsSectionProps["renderOptionDetails"]
   renderItineraryDayDetails?: (context: ProductItineraryDayRowRenderContext) => React.ReactNode
   renderItineraryServiceActions?: (service: ProductDayServiceRecord) => React.ReactNode
+  renderSupplierServiceField?: ProductDayServiceFormProps["renderSupplierServiceField"]
+  onSupplierServiceSelected?: ProductDayServiceFormProps["onSupplierServiceSelected"]
   slots?: ProductDetailPageSlots
 }
 
@@ -82,6 +87,8 @@ export function ProductDetailPage({
   renderOptionDetails,
   renderItineraryDayDetails,
   renderItineraryServiceActions,
+  renderSupplierServiceField,
+  onSupplierServiceSelected,
   slots,
 }: ProductDetailPageProps) {
   const messages = useProductsUiMessagesOrDefault()
@@ -159,6 +166,8 @@ export function ProductDetailPage({
             productId={product.id}
             renderDayDetails={renderItineraryDayDetails}
             renderServiceActions={renderItineraryServiceActions}
+            renderSupplierServiceField={renderSupplierServiceField}
+            onSupplierServiceSelected={onSupplierServiceSelected}
           />
           {slots?.itineraryEnd}
 
@@ -393,6 +402,8 @@ export interface ProductItinerarySectionProps {
   description?: string
   renderDayDetails?: (context: ProductItineraryDayRowRenderContext) => React.ReactNode
   renderServiceActions?: (service: ProductDayServiceRecord) => React.ReactNode
+  renderSupplierServiceField?: ProductDayServiceFormProps["renderSupplierServiceField"]
+  onSupplierServiceSelected?: ProductDayServiceFormProps["onSupplierServiceSelected"]
   className?: string
 }
 
@@ -402,6 +413,8 @@ export function ProductItinerarySection({
   description,
   renderDayDetails,
   renderServiceActions,
+  renderSupplierServiceField,
+  onSupplierServiceSelected,
   className,
 }: ProductItinerarySectionProps) {
   const messages = useProductsUiMessagesOrDefault()
@@ -423,12 +436,16 @@ export function ProductItinerarySection({
   )
   const itineraryMutation = useProductItineraryMutation()
   const dayMutation = useProductDayMutation()
+  const serviceMutation = useProductDayServiceMutation()
   const [itineraryDialogOpen, setItineraryDialogOpen] = React.useState(false)
   const [editingItinerary, setEditingItinerary] = React.useState<ProductItineraryRecord | null>(
     null,
   )
   const [dayDialogOpen, setDayDialogOpen] = React.useState(false)
   const [editingDay, setEditingDay] = React.useState<ProductDayRecord | null>(null)
+  const [serviceDialogOpen, setServiceDialogOpen] = React.useState(false)
+  const [serviceDayId, setServiceDayId] = React.useState<string | null>(null)
+  const [editingService, setEditingService] = React.useState<ProductDayServiceRecord | null>(null)
   const [expandedDayId, setExpandedDayId] = React.useState<string | null>(null)
 
   React.useEffect(() => {
@@ -586,6 +603,32 @@ export function ProductItinerarySection({
                       itineraryId: day.itineraryId,
                     })
                   }}
+                  onAddService={() => {
+                    setServiceDayId(day.id)
+                    setEditingService(null)
+                    setExpandedDayId(day.id)
+                    setServiceDialogOpen(true)
+                  }}
+                  onEditService={(service) => {
+                    setServiceDayId(day.id)
+                    setEditingService(service)
+                    setExpandedDayId(day.id)
+                    setServiceDialogOpen(true)
+                  }}
+                  onDeleteService={(service) => {
+                    if (
+                      !confirm(
+                        pageMessages.states.deleteServiceConfirm.replace("{name}", service.name),
+                      )
+                    ) {
+                      return
+                    }
+                    void serviceMutation.remove.mutateAsync({
+                      productId,
+                      dayId: day.id,
+                      serviceId: service.id,
+                    })
+                  }}
                   renderDayDetails={renderDayDetails}
                   renderServiceActions={renderServiceActions}
                 />
@@ -615,6 +658,23 @@ export function ProductItinerarySection({
             setExpandedDayId(day.id)
             setEditingDay(null)
           }}
+        />
+      ) : null}
+      {serviceDayId ? (
+        <ProductDayServiceDialog
+          open={serviceDialogOpen}
+          onOpenChange={(open) => {
+            setServiceDialogOpen(open)
+            if (!open) {
+              setEditingService(null)
+            }
+          }}
+          productId={productId}
+          dayId={serviceDayId}
+          service={editingService ?? undefined}
+          renderSupplierServiceField={renderSupplierServiceField}
+          onSupplierServiceSelected={onSupplierServiceSelected}
+          onSuccess={() => setEditingService(null)}
         />
       ) : null}
     </Card>

--- a/packages/products-ui/src/i18n/en.ts
+++ b/packages/products-ui/src/i18n/en.ts
@@ -153,6 +153,7 @@ export const productsUiEn = {
       deleteConfirm: 'Delete product "{name}"?',
       deleteItineraryConfirm: 'Delete itinerary "{name}"?',
       deleteDayConfirm: 'Delete day "{dayNumber}"?',
+      deleteServiceConfirm: 'Delete service "{name}"?',
       deleteFailed: "Failed to delete product.",
       minutes: "{count} min",
     },
@@ -510,6 +511,16 @@ export const productsUiEn = {
     actions: {
       addService: "Add service",
       saveService: "Save service",
+    },
+  },
+  productDayServiceDialog: {
+    titles: {
+      create: "Add service",
+      edit: "Edit service",
+    },
+    descriptions: {
+      create: "Add an operational service to this itinerary day.",
+      edit: "Update the operational service for this itinerary day.",
     },
   },
   productItineraryDayRow: {

--- a/packages/products-ui/src/i18n/messages.ts
+++ b/packages/products-ui/src/i18n/messages.ts
@@ -138,6 +138,7 @@ export type ProductsUiMessages = {
       deleteConfirm: string
       deleteItineraryConfirm: string
       deleteDayConfirm: string
+      deleteServiceConfirm: string
       deleteFailed: string
       minutes: string
     }
@@ -493,6 +494,16 @@ export type ProductsUiMessages = {
     actions: {
       addService: string
       saveService: string
+    }
+  }
+  productDayServiceDialog: {
+    titles: {
+      create: string
+      edit: string
+    }
+    descriptions: {
+      create: string
+      edit: string
     }
   }
   productItineraryDayRow: {

--- a/packages/products-ui/src/i18n/ro.ts
+++ b/packages/products-ui/src/i18n/ro.ts
@@ -153,6 +153,7 @@ export const productsUiRo = {
       deleteConfirm: 'Stergi produsul "{name}"?',
       deleteItineraryConfirm: 'Stergi itinerarul "{name}"?',
       deleteDayConfirm: 'Stergi ziua "{dayNumber}"?',
+      deleteServiceConfirm: 'Stergi serviciul "{name}"?',
       deleteFailed: "Produsul nu a putut fi sters.",
       minutes: "{count} min",
     },
@@ -511,6 +512,16 @@ export const productsUiRo = {
     actions: {
       addService: "Adauga serviciu",
       saveService: "Salveaza serviciul",
+    },
+  },
+  productDayServiceDialog: {
+    titles: {
+      create: "Adauga serviciu",
+      edit: "Editeaza serviciu",
+    },
+    descriptions: {
+      create: "Adauga un serviciu operational pentru aceasta zi de itinerar.",
+      edit: "Actualizeaza serviciul operational pentru aceasta zi de itinerar.",
     },
   },
   productItineraryDayRow: {

--- a/packages/products-ui/src/index.ts
+++ b/packages/products-ui/src/index.ts
@@ -25,6 +25,10 @@ export {
   type ProductDayMediaTrayProps,
 } from "./components/product-day-media-tray.js"
 export {
+  ProductDayServiceDialog,
+  type ProductDayServiceDialogProps,
+} from "./components/product-day-service-dialog.js"
+export {
   ProductDayServiceForm,
   type ProductDayServiceFormHelpers,
   type ProductDayServiceFormProps,


### PR DESCRIPTION
## Summary
- add ProductDayServiceDialog to @voyantjs/products-ui and export it
- wire ProductItinerarySection service add/edit/delete actions into the built-in service dialog
- pass renderSupplierServiceField and onSupplierServiceSelected through ProductDetailPage and ProductItinerarySection into ProductDayServiceForm
- add i18n copy and a patch changeset

Closes #821.

## Validation
- pnpm --filter @voyantjs/products-ui typecheck
- pnpm --filter @voyantjs/products-ui lint
- pnpm --filter @voyantjs/products-ui test
- pnpm --filter @voyantjs/products-ui build
- pnpm verify:architecture
- git push pre-push hook: pnpm test (125/125 successful)

Note: pnpm verify:fast was started, but stopped after scoped checks because the broad affected typecheck phase was taking too long under local TypeScript workload.