### PR TITLE
SmartBill workflow factories

### DIFF
--- a/.changeset/smartbill-workflow-factories.md
+++ b/.changeset/smartbill-workflow-factories.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/plugin-smartbill": minor
+---
+
+Add SmartBill proforma conversion polling and drift reconciliation workflow factories.

--- a/packages/plugins/smartbill/README.md
+++ b/packages/plugins/smartbill/README.md
@@ -95,7 +95,7 @@ import {
 const pollProformas = createSmartbillProformaConversionPoller({
   db,
   client: smartbillClient,
-  onConverted: async (conversion) => {
+  onConverted: async (proformaRef, conversion) => {
     // Record a Voyant payment or emit a domain event in the host app.
     // The plugin reports the SmartBill invoice series/number and source
     // proforma ref, but leaves payment semantics to the consumer.

--- a/packages/plugins/smartbill/README.md
+++ b/packages/plugins/smartbill/README.md
@@ -79,6 +79,46 @@ Use `retrySmartbillInvoiceArtifact({ runtime, client, externalRef, documentType
 })` to re-download and re-attach a SmartBill PDF from an existing external ref
 without issuing a new document.
 
+## Workflow Factories
+
+The package also ships scheduler-agnostic workflow factories for recurring
+SmartBill maintenance. They return async functions that can be called from
+`@voyantjs/workflows`, a Cloudflare cron handler, Trigger.dev, Hatchet, or any
+other job runner.
+
+```typescript
+import {
+  createSmartbillDriftReconciler,
+  createSmartbillProformaConversionPoller,
+} from "@voyantjs/plugin-smartbill"
+
+const pollProformas = createSmartbillProformaConversionPoller({
+  db,
+  client: smartbillClient,
+  onConverted: async (conversion) => {
+    // Record a Voyant payment or emit a domain event in the host app.
+    // The plugin reports the SmartBill invoice series/number and source
+    // proforma ref, but leaves payment semantics to the consumer.
+  },
+})
+
+const reconcileSmartbill = createSmartbillDriftReconciler({
+  db,
+  client: smartbillClient,
+  listRemoteDocuments: async () => remoteSmartbillInventory,
+  onFinding: async (finding) => {
+    // Log, alert, or open an operator ticket.
+  },
+})
+```
+
+`createSmartbillProformaConversionPoller` scans SmartBill proforma external refs
+and calls `client.listEstimateInvoices(...)` to detect SmartBill-created final
+invoices. `createSmartbillDriftReconciler` verifies known SmartBill refs by
+default and can compare a caller-provided remote inventory for `missing_local`
+findings. The reconciler only reports drift; it does not delete, void, or create
+finance records.
+
 ## Exports
 
 | Entry | Description |
@@ -87,6 +127,7 @@ without issuing a new document.
 | `./plugin` | `smartbillPlugin(options)` — packaged adapter/subscriber bundle |
 | `./client` | `createSmartbillClient` — `createInvoice`, `cancelInvoice`, `viewPdf`, `getPaymentStatus`, etc. |
 | `./mock` | `createSmartbillMockServer` — stateful local SmartBill-compatible mock for tests |
+| `./workflows` | Proforma conversion polling and drift reconciliation factories |
 | `./types` | SmartBill adapter and bundle types |
 
 ## Local SmartBill Mock

--- a/packages/plugins/smartbill/package.json
+++ b/packages/plugins/smartbill/package.json
@@ -9,6 +9,7 @@
     "./mock": "./src/mock.ts",
     "./plugin": "./src/plugin.ts",
     "./settlement": "./src/settlement.ts",
+    "./workflows": "./src/workflows.ts",
     "./types": "./src/types.ts"
   },
   "scripts": {
@@ -61,6 +62,11 @@
         "types": "./dist/settlement.d.ts",
         "import": "./dist/settlement.js",
         "default": "./dist/settlement.js"
+      },
+      "./workflows": {
+        "types": "./dist/workflows.d.ts",
+        "import": "./dist/workflows.js",
+        "default": "./dist/workflows.js"
       },
       "./types": {
         "types": "./dist/types.d.ts",

--- a/packages/plugins/smartbill/src/index.ts
+++ b/packages/plugins/smartbill/src/index.ts
@@ -74,3 +74,26 @@ export type {
   SmartbillTaxesResponse,
   VoyantInvoiceEvent,
 } from "./types.js"
+export type {
+  SmartbillDriftFinding,
+  SmartbillDriftFindingType,
+  SmartbillDriftReconciler,
+  SmartbillDriftReconcilerOptions,
+  SmartbillDriftReconcilerResult,
+  SmartbillProformaConversion,
+  SmartbillProformaConversionPoller,
+  SmartbillProformaConversionPollerOptions,
+  SmartbillProformaConversionPollerResult,
+  SmartbillReferenceParts,
+  SmartbillRemoteDocument,
+  SmartbillRemoteDocumentStatus,
+  SmartbillWorkflowDocumentType,
+  SmartbillWorkflowError,
+  SmartbillWorkflowExternalRef,
+  SmartbillWorkflowInvoice,
+  SmartbillWorkflowLogger,
+} from "./workflows.js"
+export {
+  createSmartbillDriftReconciler,
+  createSmartbillProformaConversionPoller,
+} from "./workflows.js"

--- a/packages/plugins/smartbill/src/workflows.ts
+++ b/packages/plugins/smartbill/src/workflows.ts
@@ -74,7 +74,10 @@ export interface SmartbillProformaConversionPollerOptions {
   companyVatCode?: string
   logger?: SmartbillWorkflowLogger
   listExternalRefs?: () => Promise<SmartbillWorkflowExternalRef[]>
-  onConverted: (conversion: SmartbillProformaConversion) => void | Promise<void>
+  onConverted: (
+    proformaRef: SmartbillWorkflowExternalRef,
+    conversion: SmartbillProformaConversion,
+  ) => void | Promise<void>
   onError?: (error: SmartbillWorkflowError) => void | Promise<void>
 }
 
@@ -195,7 +198,7 @@ export function createSmartbillProformaConversionPoller(
             response,
             smartbillInvoice,
           }
-          await options.onConverted(conversion)
+          await options.onConverted(ref, conversion)
           options.logger?.info?.("[smartbill] proforma conversion detected", conversion)
           result.converted.push(conversion)
         }
@@ -375,6 +378,11 @@ async function defaultVerifyRemoteDocument(
 function paymentStatusToRemoteStatus(
   status: SmartbillStatusResponse,
 ): SmartbillRemoteDocumentStatus {
+  const providerStatus = `${status.message ?? ""} ${status.errorText ?? ""}`.toLowerCase()
+  if (providerStatus.includes("cancel")) return "cancelled"
+  if (providerStatus.includes("reverse")) return "reversed"
+  if (providerStatus.includes("void")) return "voided"
+  if (providerStatus.includes("delete")) return "deleted"
   if (status.paid) return "paid"
   if ((status.paidAmount ?? 0) > 0) return "partially_paid"
   return "unpaid"

--- a/packages/plugins/smartbill/src/workflows.ts
+++ b/packages/plugins/smartbill/src/workflows.ts
@@ -1,0 +1,449 @@
+import {
+  type Invoice,
+  type InvoiceExternalRef,
+  invoiceExternalRefs,
+  invoices,
+} from "@voyantjs/finance"
+import { desc, eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import type { SmartbillClientApi } from "./client.js"
+import type {
+  SmartbillEstimateInvoicesResponse,
+  SmartbillInvoiceResponse,
+  SmartbillStatusResponse,
+} from "./types.js"
+
+export type SmartbillWorkflowDocumentType = "invoice" | "proforma"
+
+export interface SmartbillWorkflowLogger {
+  info?: (message: string, meta?: unknown) => void
+  error?: (message: string, meta?: unknown) => void
+}
+
+export interface SmartbillWorkflowInvoice {
+  id: string
+  invoiceNumber: string
+  invoiceType: Invoice["invoiceType"]
+  status: Invoice["status"]
+  currency: string
+  totalCents: number
+  paidCents: number
+  balanceDueCents: number
+}
+
+export interface SmartbillWorkflowExternalRef {
+  id: string
+  invoiceId: string
+  provider: string
+  externalId: string | null
+  externalNumber: string | null
+  externalUrl: string | null
+  status: string | null
+  metadata: unknown
+  syncError: string | null
+  createdAt?: Date | null
+  updatedAt?: Date | null
+  invoice?: SmartbillWorkflowInvoice | null
+}
+
+export interface SmartbillReferenceParts {
+  companyVatCode: string
+  seriesName: string
+  number: string
+  documentType: SmartbillWorkflowDocumentType
+}
+
+export interface SmartbillProformaConversion {
+  proformaRef: SmartbillWorkflowExternalRef
+  invoice: SmartbillWorkflowInvoice | null
+  companyVatCode: string
+  proformaSeriesName: string
+  proformaNumber: string
+  invoiceSeriesName: string
+  invoiceNumber: string
+  invoiceUrl: string | null
+  response: SmartbillEstimateInvoicesResponse
+  smartbillInvoice: SmartbillInvoiceResponse
+}
+
+export interface SmartbillProformaConversionPollerOptions {
+  db?: PostgresJsDatabase
+  client: SmartbillClientApi
+  limit?: number
+  companyVatCode?: string
+  logger?: SmartbillWorkflowLogger
+  listExternalRefs?: () => Promise<SmartbillWorkflowExternalRef[]>
+  onConverted: (conversion: SmartbillProformaConversion) => void | Promise<void>
+  onError?: (error: SmartbillWorkflowError) => void | Promise<void>
+}
+
+export interface SmartbillWorkflowError {
+  ref?: SmartbillWorkflowExternalRef
+  error: unknown
+}
+
+export interface SmartbillProformaConversionPollerResult {
+  checked: number
+  converted: SmartbillProformaConversion[]
+  skipped: Array<{ ref: SmartbillWorkflowExternalRef; reason: string }>
+  errors: SmartbillWorkflowError[]
+}
+
+export type SmartbillRemoteDocumentStatus =
+  | "present"
+  | "issued"
+  | "paid"
+  | "unpaid"
+  | "partially_paid"
+  | "voided"
+  | "cancelled"
+  | "reversed"
+  | "deleted"
+  | "missing"
+
+export interface SmartbillRemoteDocument extends SmartbillReferenceParts {
+  status?: SmartbillRemoteDocumentStatus
+  metadata?: Record<string, unknown>
+}
+
+export type SmartbillDriftFindingType = "missing_local" | "missing_remote" | "voided_remote"
+
+export interface SmartbillDriftFinding {
+  type: SmartbillDriftFindingType
+  document: SmartbillReferenceParts
+  ref?: SmartbillWorkflowExternalRef
+  invoice?: SmartbillWorkflowInvoice | null
+  remote?: SmartbillRemoteDocument | null
+  error?: unknown
+}
+
+export interface SmartbillDriftReconcilerOptions {
+  db?: PostgresJsDatabase
+  client: SmartbillClientApi
+  limit?: number
+  companyVatCode?: string
+  logger?: SmartbillWorkflowLogger
+  listExternalRefs?: () => Promise<SmartbillWorkflowExternalRef[]>
+  listRemoteDocuments?: (context: {
+    refs: SmartbillWorkflowExternalRef[]
+  }) => Promise<SmartbillRemoteDocument[]>
+  verifyRemoteDocument?: (context: {
+    ref: SmartbillWorkflowExternalRef
+    document: SmartbillReferenceParts
+  }) => Promise<SmartbillRemoteDocumentStatus | SmartbillRemoteDocument>
+  onFinding?: (finding: SmartbillDriftFinding) => void | Promise<void>
+  onError?: (error: SmartbillWorkflowError) => void | Promise<void>
+}
+
+export interface SmartbillDriftReconcilerResult {
+  checked: number
+  findings: SmartbillDriftFinding[]
+  skipped: Array<{ ref: SmartbillWorkflowExternalRef; reason: string }>
+  errors: SmartbillWorkflowError[]
+}
+
+export type SmartbillProformaConversionPoller =
+  () => Promise<SmartbillProformaConversionPollerResult>
+
+export type SmartbillDriftReconciler = () => Promise<SmartbillDriftReconcilerResult>
+
+export function createSmartbillProformaConversionPoller(
+  options: SmartbillProformaConversionPollerOptions,
+): SmartbillProformaConversionPoller {
+  return async () => {
+    const result: SmartbillProformaConversionPollerResult = {
+      checked: 0,
+      converted: [],
+      skipped: [],
+      errors: [],
+    }
+    const refs = await loadSmartbillExternalRefs(options)
+
+    for (const ref of refs) {
+      const document = resolveReferenceParts(ref, options.companyVatCode)
+      if (document?.documentType !== "proforma") continue
+      result.checked += 1
+
+      try {
+        const response = await options.client.listEstimateInvoices(
+          document.companyVatCode,
+          document.seriesName,
+          document.number,
+        )
+        const convertedInvoices = convertedInvoicesFromResponse(response)
+        if (convertedInvoices.length === 0) {
+          result.skipped.push({ ref, reason: "not_converted" })
+          continue
+        }
+
+        for (const smartbillInvoice of convertedInvoices) {
+          if (!smartbillInvoice.series || !smartbillInvoice.number) {
+            result.skipped.push({ ref, reason: "missing_converted_invoice_number" })
+            continue
+          }
+
+          const conversion: SmartbillProformaConversion = {
+            proformaRef: ref,
+            invoice: ref.invoice ?? null,
+            companyVatCode: document.companyVatCode,
+            proformaSeriesName: document.seriesName,
+            proformaNumber: document.number,
+            invoiceSeriesName: smartbillInvoice.series,
+            invoiceNumber: smartbillInvoice.number,
+            invoiceUrl: smartbillInvoice.url ?? null,
+            response,
+            smartbillInvoice,
+          }
+          await options.onConverted(conversion)
+          options.logger?.info?.("[smartbill] proforma conversion detected", conversion)
+          result.converted.push(conversion)
+        }
+      } catch (error) {
+        await recordWorkflowError(options, result.errors, { ref, error })
+      }
+    }
+
+    return result
+  }
+}
+
+export function createSmartbillDriftReconciler(
+  options: SmartbillDriftReconcilerOptions,
+): SmartbillDriftReconciler {
+  return async () => {
+    const result: SmartbillDriftReconcilerResult = {
+      checked: 0,
+      findings: [],
+      skipped: [],
+      errors: [],
+    }
+    const refs = await loadSmartbillExternalRefs(options)
+    const remoteDocuments = await options.listRemoteDocuments?.({ refs })
+    const remoteDocumentMap = new Map(
+      (remoteDocuments ?? []).map((remote) => [documentKey(remote), remote]),
+    )
+    const hasRemoteInventory = remoteDocuments !== undefined
+    const localDocuments = new Map<string, SmartbillReferenceParts>()
+
+    for (const ref of refs) {
+      const document = resolveReferenceParts(ref, options.companyVatCode)
+      if (!document) {
+        result.skipped.push({ ref, reason: "missing_smartbill_reference" })
+        continue
+      }
+      const key = documentKey(document)
+      localDocuments.set(key, document)
+      result.checked += 1
+
+      try {
+        const remote = hasRemoteInventory
+          ? (remoteDocumentMap.get(key) ?? { ...document, status: "missing" as const })
+          : await verifyRemoteDocument(options, ref, document)
+        if (remote.status === "missing" || remote.status === "deleted") {
+          await recordFinding(options, result.findings, {
+            type: "missing_remote",
+            document,
+            ref,
+            invoice: ref.invoice ?? null,
+            remote,
+          })
+        } else if (isVoidedRemote(remote.status) && ref.invoice?.status !== "void") {
+          await recordFinding(options, result.findings, {
+            type: "voided_remote",
+            document,
+            ref,
+            invoice: ref.invoice ?? null,
+            remote,
+          })
+        }
+      } catch (error) {
+        await recordWorkflowError(options, result.errors, { ref, error })
+        await recordFinding(options, result.findings, {
+          type: "missing_remote",
+          document,
+          ref,
+          invoice: ref.invoice ?? null,
+          remote: null,
+          error,
+        })
+      }
+    }
+
+    for (const remote of remoteDocuments ?? []) {
+      if (!localDocuments.has(documentKey(remote))) {
+        await recordFinding(options, result.findings, {
+          type: "missing_local",
+          document: remote,
+          remote,
+        })
+      }
+    }
+
+    return result
+  }
+}
+
+async function loadSmartbillExternalRefs(options: {
+  db?: PostgresJsDatabase
+  limit?: number
+  listExternalRefs?: () => Promise<SmartbillWorkflowExternalRef[]>
+}) {
+  if (options.listExternalRefs) return options.listExternalRefs()
+  if (!options.db) throw new Error("SmartBill workflow requires db or listExternalRefs")
+
+  const rows = await options.db
+    .select({
+      ref: invoiceExternalRefs,
+      invoice: {
+        id: invoices.id,
+        invoiceNumber: invoices.invoiceNumber,
+        invoiceType: invoices.invoiceType,
+        status: invoices.status,
+        currency: invoices.currency,
+        totalCents: invoices.totalCents,
+        paidCents: invoices.paidCents,
+        balanceDueCents: invoices.balanceDueCents,
+      },
+    })
+    .from(invoiceExternalRefs)
+    .leftJoin(invoices, eq(invoiceExternalRefs.invoiceId, invoices.id))
+    .where(eq(invoiceExternalRefs.provider, "smartbill"))
+    .orderBy(desc(invoiceExternalRefs.createdAt))
+    .limit(options.limit ?? 500)
+
+  return rows.map((row) => toWorkflowExternalRef(row.ref, row.invoice))
+}
+
+function toWorkflowExternalRef(
+  ref: InvoiceExternalRef,
+  invoice: SmartbillWorkflowInvoice | null,
+): SmartbillWorkflowExternalRef {
+  return {
+    id: ref.id,
+    invoiceId: ref.invoiceId,
+    provider: ref.provider,
+    externalId: ref.externalId,
+    externalNumber: ref.externalNumber,
+    externalUrl: ref.externalUrl,
+    status: ref.status,
+    metadata: ref.metadata,
+    syncError: ref.syncError,
+    createdAt: ref.createdAt,
+    updatedAt: ref.updatedAt,
+    invoice,
+  }
+}
+
+function convertedInvoicesFromResponse(response: SmartbillEstimateInvoicesResponse) {
+  if (Array.isArray(response.invoices) && response.invoices.length > 0) {
+    return response.invoices.filter((invoice) => invoice.series && invoice.number)
+  }
+  if (response.areInvoicesCreated && response.series && response.number) {
+    return [{ series: response.series, number: response.number }]
+  }
+  return []
+}
+
+async function verifyRemoteDocument(
+  options: SmartbillDriftReconcilerOptions,
+  ref: SmartbillWorkflowExternalRef,
+  document: SmartbillReferenceParts,
+): Promise<SmartbillRemoteDocument> {
+  const verified = await (options.verifyRemoteDocument
+    ? options.verifyRemoteDocument({ ref, document })
+    : defaultVerifyRemoteDocument(options.client, document))
+  return typeof verified === "string" ? { ...document, status: verified } : verified
+}
+
+async function defaultVerifyRemoteDocument(
+  client: SmartbillClientApi,
+  document: SmartbillReferenceParts,
+): Promise<SmartbillRemoteDocumentStatus> {
+  if (document.documentType === "proforma") {
+    await client.listEstimateInvoices(document.companyVatCode, document.seriesName, document.number)
+    return "present"
+  }
+  const status = await client.getPaymentStatus(
+    document.companyVatCode,
+    document.seriesName,
+    document.number,
+  )
+  return paymentStatusToRemoteStatus(status)
+}
+
+function paymentStatusToRemoteStatus(
+  status: SmartbillStatusResponse,
+): SmartbillRemoteDocumentStatus {
+  if (status.paid) return "paid"
+  if ((status.paidAmount ?? 0) > 0) return "partially_paid"
+  return "unpaid"
+}
+
+function resolveReferenceParts(
+  ref: SmartbillWorkflowExternalRef,
+  fallbackCompanyVatCode?: string,
+): SmartbillReferenceParts | null {
+  const metadata = coerceMetadata(ref.metadata)
+  const documentType = coerceDocumentType(metadata?.documentType)
+  const companyVatCode =
+    metadataString(metadata, "companyVatCode") ??
+    metadataString(metadata, "vatCode") ??
+    fallbackCompanyVatCode
+  const seriesName = metadataString(metadata, "series") ?? metadataString(metadata, "seriesName")
+  const number = metadataString(metadata, "number") ?? ref.externalNumber ?? ref.externalId
+
+  if (!documentType || !companyVatCode || !seriesName || !number) return null
+  return { companyVatCode, seriesName, number, documentType }
+}
+
+function coerceMetadata(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function metadataString(metadata: Record<string, unknown> | null, key: string) {
+  const value = metadata?.[key]
+  return typeof value === "string" && value.length > 0 ? value : null
+}
+
+function coerceDocumentType(value: unknown): SmartbillWorkflowDocumentType | null {
+  return value === "invoice" || value === "proforma" ? value : null
+}
+
+function documentKey(document: SmartbillReferenceParts) {
+  return [
+    document.documentType,
+    document.companyVatCode,
+    document.seriesName,
+    document.number,
+  ].join(":")
+}
+
+function isVoidedRemote(status: SmartbillRemoteDocumentStatus | undefined) {
+  return status === "voided" || status === "cancelled" || status === "reversed"
+}
+
+async function recordFinding(
+  options: SmartbillDriftReconcilerOptions,
+  findings: SmartbillDriftFinding[],
+  finding: SmartbillDriftFinding,
+) {
+  findings.push(finding)
+  options.logger?.info?.("[smartbill] drift finding", finding)
+  await options.onFinding?.(finding)
+}
+
+async function recordWorkflowError(
+  options: {
+    logger?: SmartbillWorkflowLogger
+    onError?: (error: SmartbillWorkflowError) => void | Promise<void>
+  },
+  errors: SmartbillWorkflowError[],
+  error: SmartbillWorkflowError,
+) {
+  errors.push(error)
+  options.logger?.error?.("[smartbill] workflow error", error)
+  await options.onError?.(error)
+}

--- a/packages/plugins/smartbill/tests/unit/workflows.test.ts
+++ b/packages/plugins/smartbill/tests/unit/workflows.test.ts
@@ -81,7 +81,8 @@ describe("createSmartbillProformaConversionPoller", () => {
 
     expect(client.listEstimateInvoices).toHaveBeenCalledWith("RO12345678", "PF", "1")
     expect(onConverted).toHaveBeenCalledOnce()
-    expect(onConverted.mock.calls[0]![0]).toMatchObject({
+    expect(onConverted.mock.calls[0]![0]).toBe(ref)
+    expect(onConverted.mock.calls[0]![1]).toMatchObject({
       proformaRef: ref,
       invoiceSeriesName: "INV",
       invoiceNumber: "42",
@@ -206,6 +207,51 @@ describe("createSmartbillDriftReconciler", () => {
     expect(result.findings[0]).toMatchObject({
       type: "voided_remote",
       document: { seriesName: "INV", number: "7" },
+    })
+  })
+
+  it("reports voided remote invoices from default payment status messages", async () => {
+    const ref = smartbillRef({
+      metadata: {
+        companyVatCode: "RO12345678",
+        seriesName: "INV",
+        number: "8",
+        documentType: "invoice",
+      },
+      invoice: {
+        id: "inv_8",
+        invoiceNumber: "INV-8",
+        invoiceType: "invoice",
+        status: "sent",
+        currency: "RON",
+        totalCents: 10000,
+        paidCents: 0,
+        balanceDueCents: 10000,
+      },
+    })
+    const client = makeClient({
+      getPaymentStatus: vi.fn(async () => ({
+        status: "Ok",
+        message: "Invoice cancelled",
+        errorText: "",
+        paid: false,
+        invoiceTotalAmount: 100,
+        paidAmount: 0,
+        unpaidAmount: 100,
+        payments: [],
+      })),
+    })
+
+    const result = await createSmartbillDriftReconciler({
+      client,
+      listExternalRefs: async () => [ref],
+    })()
+
+    expect(client.getPaymentStatus).toHaveBeenCalledWith("RO12345678", "INV", "8")
+    expect(result.findings[0]).toMatchObject({
+      type: "voided_remote",
+      document: { seriesName: "INV", number: "8" },
+      remote: { status: "cancelled" },
     })
   })
 })

--- a/packages/plugins/smartbill/tests/unit/workflows.test.ts
+++ b/packages/plugins/smartbill/tests/unit/workflows.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from "vitest"
+
+import type { SmartbillClientApi } from "../../src/client.js"
+import {
+  createSmartbillDriftReconciler,
+  createSmartbillProformaConversionPoller,
+  type SmartbillWorkflowExternalRef,
+} from "../../src/workflows.js"
+
+function makeClient(overrides: Partial<SmartbillClientApi> = {}): SmartbillClientApi {
+  return {
+    createInvoice: vi.fn(),
+    createProforma: vi.fn(),
+    cancelInvoice: vi.fn(),
+    restoreInvoice: vi.fn(),
+    deleteInvoice: vi.fn(),
+    reverseInvoice: vi.fn(),
+    viewInvoicePdf: vi.fn(),
+    viewPdf: vi.fn(),
+    viewEstimatePdf: vi.fn(),
+    getPaymentStatus: vi.fn(),
+    listTaxes: vi.fn(),
+    listSeries: vi.fn(),
+    listEstimateInvoices: vi.fn(),
+    ...overrides,
+  } as SmartbillClientApi
+}
+
+function smartbillRef(
+  overrides: Partial<SmartbillWorkflowExternalRef> = {},
+): SmartbillWorkflowExternalRef {
+  return {
+    id: "iex_1",
+    invoiceId: "inv_1",
+    provider: "smartbill",
+    externalId: "1",
+    externalNumber: "1",
+    externalUrl: null,
+    status: "issued",
+    syncError: null,
+    metadata: {
+      companyVatCode: "RO12345678",
+      seriesName: "PF",
+      series: "PF",
+      number: "1",
+      documentType: "proforma",
+    },
+    invoice: {
+      id: "inv_1",
+      invoiceNumber: "PF-1",
+      invoiceType: "proforma",
+      status: "sent",
+      currency: "RON",
+      totalCents: 10000,
+      paidCents: 0,
+      balanceDueCents: 10000,
+    },
+    ...overrides,
+  }
+}
+
+describe("createSmartbillProformaConversionPoller", () => {
+  it("detects converted proformas and calls onConverted", async () => {
+    const ref = smartbillRef()
+    const onConverted = vi.fn()
+    const client = makeClient({
+      listEstimateInvoices: vi.fn(async () => ({
+        status: "Ok",
+        areInvoicesCreated: true,
+        invoices: [{ series: "INV", number: "42", url: "https://smartbill.test/inv-42.pdf" }],
+      })),
+    })
+
+    const poller = createSmartbillProformaConversionPoller({
+      client,
+      listExternalRefs: async () => [ref],
+      onConverted,
+    })
+
+    const result = await poller()
+
+    expect(client.listEstimateInvoices).toHaveBeenCalledWith("RO12345678", "PF", "1")
+    expect(onConverted).toHaveBeenCalledOnce()
+    expect(onConverted.mock.calls[0]![0]).toMatchObject({
+      proformaRef: ref,
+      invoiceSeriesName: "INV",
+      invoiceNumber: "42",
+      invoiceUrl: "https://smartbill.test/inv-42.pdf",
+    })
+    expect(result.converted).toHaveLength(1)
+    expect(result.skipped).toEqual([])
+  })
+
+  it("skips unconverted proformas", async () => {
+    const client = makeClient({
+      listEstimateInvoices: vi.fn(async () => ({
+        status: "Ok",
+        areInvoicesCreated: false,
+        invoices: [],
+      })),
+    })
+
+    const result = await createSmartbillProformaConversionPoller({
+      client,
+      listExternalRefs: async () => [smartbillRef()],
+      onConverted: vi.fn(),
+    })()
+
+    expect(result.converted).toEqual([])
+    expect(result.skipped[0]?.reason).toBe("not_converted")
+  })
+})
+
+describe("createSmartbillDriftReconciler", () => {
+  it("reports missing local documents from a remote inventory callback", async () => {
+    const onFinding = vi.fn()
+    const client = makeClient({
+      listEstimateInvoices: vi.fn(async () => ({ status: "Ok", areInvoicesCreated: false })),
+    })
+
+    const result = await createSmartbillDriftReconciler({
+      client,
+      listExternalRefs: async () => [smartbillRef()],
+      listRemoteDocuments: async () => [
+        {
+          documentType: "proforma",
+          companyVatCode: "RO12345678",
+          seriesName: "PF",
+          number: "1",
+          status: "issued",
+        },
+        {
+          documentType: "invoice",
+          companyVatCode: "RO12345678",
+          seriesName: "INV",
+          number: "99",
+          status: "issued",
+        },
+      ],
+      onFinding,
+    })()
+
+    expect(result.findings).toHaveLength(1)
+    expect(result.findings[0]).toMatchObject({
+      type: "missing_local",
+      document: { seriesName: "INV", number: "99" },
+    })
+    expect(onFinding).toHaveBeenCalledWith(result.findings[0])
+  })
+
+  it("reports missing remote documents when provider verification fails", async () => {
+    const ref = smartbillRef({
+      metadata: {
+        companyVatCode: "RO12345678",
+        seriesName: "INV",
+        series: "INV",
+        number: "42",
+        documentType: "invoice",
+      },
+      invoice: {
+        id: "inv_42",
+        invoiceNumber: "INV-42",
+        invoiceType: "invoice",
+        status: "sent",
+        currency: "RON",
+        totalCents: 10000,
+        paidCents: 0,
+        balanceDueCents: 10000,
+      },
+    })
+    const client = makeClient({
+      getPaymentStatus: vi.fn(async () => {
+        throw new Error("not found")
+      }),
+    })
+
+    const result = await createSmartbillDriftReconciler({
+      client,
+      listExternalRefs: async () => [ref],
+    })()
+
+    expect(client.getPaymentStatus).toHaveBeenCalledWith("RO12345678", "INV", "42")
+    expect(result.findings[0]).toMatchObject({
+      type: "missing_remote",
+      ref,
+      document: { seriesName: "INV", number: "42" },
+    })
+  })
+
+  it("reports voided remote documents that are still active locally", async () => {
+    const result = await createSmartbillDriftReconciler({
+      client: makeClient(),
+      listExternalRefs: async () => [
+        smartbillRef({
+          metadata: {
+            companyVatCode: "RO12345678",
+            seriesName: "INV",
+            number: "7",
+            documentType: "invoice",
+          },
+        }),
+      ],
+      verifyRemoteDocument: async () => "cancelled",
+    })()
+
+    expect(result.findings[0]).toMatchObject({
+      type: "voided_remote",
+      document: { seriesName: "INV", number: "7" },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add scheduler-agnostic SmartBill proforma conversion poller using listEstimateInvoices
- add SmartBill drift reconciler for missing_local, missing_remote, and voided_remote findings
- export the new workflows from the package root and ./workflows subpath
- document workflow usage and add a changeset

Closes #826

## Verification
- pnpm --filter @voyantjs/plugin-smartbill test
- pnpm --filter @voyantjs/plugin-smartbill lint
- pnpm --filter @voyantjs/plugin-smartbill build
- git diff --check

Note: pnpm verify:package-exports was attempted but requires missing build outputs for unrelated workspace packages in this fresh worktree.