### PR TITLE
Fix agent PR opening with generated artifacts

### DIFF
--- a/apps/agent-runner/README.md
+++ b/apps/agent-runner/README.md
@@ -138,10 +138,16 @@ pnpm agent:queue:executor -- \
   --iterations 10 \
   --sleep-seconds 60 \
   --event-log .agent-runs/executor.jsonl \
-  --implementation-command "pnpm verify:fast" \
+  --implementation-command 'codex exec --sandbox danger-full-access --skip-git-repo-check "<agent prompt>"' \
   --release-expired-intents \
   --yes
 ```
+
+The dedicated executor host is the sandbox boundary for implementation work.
+Use `codex exec --sandbox danger-full-access` on trusted server runners so
+Codex can run the package manager, tests, browser tooling, and repository
+scripts without the local bubblewrap sandbox blocking normal shell execution.
+Do not use this mode for shared or untrusted runner hosts.
 
 Use narrower action filters and command templates in production. Without a
 concrete implementation command or browser dev-server command, implementation

--- a/docs/architecture/agentic-engineering-orchestration.md
+++ b/docs/architecture/agentic-engineering-orchestration.md
@@ -1407,6 +1407,13 @@ Verification:
   gate and fails the intent without running the command if placeholders,
   missing command inputs, invalid remote ports, or blocked destructive git
   patterns are present.
+- Trusted dedicated server runners should pass implementation work to Codex with
+  full local shell access, for example
+  `codex exec --sandbox danger-full-access --skip-git-repo-check "<agent prompt>"`.
+  In this model the runner host, worktree, repository credentials, and queue
+  gates are the isolation boundary. Avoid the local Codex workspace sandbox on
+  these hosts when it blocks normal package-manager, test, browser, or network
+  commands.
 - The executor can recover from stale active dispatch pointers with
   `--release-expired-intents`. When the control plane rejects a lease because an
   active intent has already expired, the executor finishes that intent as

--- a/scripts/lib/agent-runner-pr.mjs
+++ b/scripts/lib/agent-runner-pr.mjs
@@ -6,6 +6,11 @@ import { actionableReviewDetails, reviewRepairBlocker } from "./agent-runner-rev
 import { localWorkspaceReferencePlan } from "./agent-runner-workspace.mjs"
 
 export const openPullRequestStates = new Set(["Human Review", "CI Repair", "Changes Requested"])
+const generatedAgentArtifactPrefixes = [
+  "docs/agent-evidence/active/",
+  "docs/agent-evidence/browser/",
+  "docs/agent-plans/active/",
+]
 const successfulCheckConclusions = new Set(["SUCCESS", "SKIPPED", "NEUTRAL"])
 const failedCheckConclusions = new Set([
   "ACTION_REQUIRED",
@@ -81,8 +86,47 @@ export function assertWorkspaceReadyForPullRequest({ allowDirty = false, branch,
   }
 
   const status = runGit(["status", "--porcelain"], { cwd: workspace })
-  if (status && !allowDirty) {
-    fail("workspace has uncommitted changes; commit them or pass --allow-dirty")
+  const nonArtifactPaths = uncommittedNonAgentArtifactPaths(status)
+  if (nonArtifactPaths.length > 0 && !allowDirty) {
+    fail(
+      `workspace has uncommitted changes outside generated agent artifacts: ${nonArtifactPaths.join(
+        ", ",
+      )}; commit them or pass --allow-dirty`,
+    )
+  }
+}
+
+export function uncommittedNonAgentArtifactPaths(status) {
+  return parsePorcelainStatusPaths(status).filter((filePath) => !isAgentArtifactPath(filePath))
+}
+
+export function isAgentArtifactPath(filePath) {
+  return generatedAgentArtifactPrefixes.some((prefix) => filePath.startsWith(prefix))
+}
+
+function parsePorcelainStatusPaths(status) {
+  if (!status) return []
+
+  return status
+    .split("\n")
+    .flatMap((line) => {
+      const filePath = line.slice(3).trim()
+      if (!filePath) return []
+      if (filePath.includes(" -> ")) {
+        return filePath.split(" -> ").map((part) => unquotePath(part))
+      }
+      return [unquotePath(filePath)]
+    })
+    .filter(Boolean)
+}
+
+function unquotePath(filePath) {
+  if (!filePath.startsWith('"') || !filePath.endsWith('"')) return filePath
+
+  try {
+    return JSON.parse(filePath)
+  } catch {
+    return filePath.slice(1, -1)
   }
 }
 

--- a/scripts/tests/agent-runner-pr.test.mjs
+++ b/scripts/tests/agent-runner-pr.test.mjs
@@ -4,6 +4,7 @@ import { describe, it } from "node:test"
 import {
   evaluatePullRequestCompletion,
   evaluatePullRequestGate,
+  isAgentArtifactPath,
   isRemoteReference,
   pullRequestBody,
   pullRequestCompletionFieldValues,
@@ -15,6 +16,7 @@ import {
   pullRequestTitle,
   summarizeChecks,
   summarizeReviewThreads,
+  uncommittedNonAgentArtifactPaths,
 } from "../lib/agent-runner-pr.mjs"
 import { workItem } from "./agent-fixtures.mjs"
 
@@ -62,6 +64,30 @@ describe("agent runner PR helpers", () => {
     assert.equal(isRemoteReference("docs/agent-evidence/active/579-test.md"), false)
     assert.match(body, /- https:\/\/github\.com\/voyantjs\/voyant\/issues\/579#issuecomment-1/)
     assert.doesNotMatch(body, /<details>/)
+  })
+
+  it("allows generated agent artifacts to remain uncommitted before opening a PR", () => {
+    assert.equal(isAgentArtifactPath("docs/agent-plans/active/579-test.md"), true)
+    assert.equal(isAgentArtifactPath("docs/agent-evidence/active/579-test.md"), true)
+    assert.equal(
+      isAgentArtifactPath(
+        "docs/agent-evidence/browser/579-test/2026-05-10T12-34-56-000Z/summary.json",
+      ),
+      true,
+    )
+    assert.equal(isAgentArtifactPath("apps/agent-control-plane/src/control-plane.test.ts"), false)
+
+    assert.deepEqual(
+      uncommittedNonAgentArtifactPaths(
+        [
+          "?? docs/agent-plans/active/579-test.md",
+          "?? docs/agent-evidence/active/579-test.md",
+          " M apps/agent-control-plane/src/control-plane.test.ts",
+          "R  docs/agent-evidence/active/old.md -> docs/agent-evidence/active/new.md",
+        ].join("\n"),
+      ),
+      ["apps/agent-control-plane/src/control-plane.test.ts"],
+    )
   })
 
   it("opens same-repository PRs with an unqualified head branch", () => {


### PR DESCRIPTION
## Summary
- Allow agent open-pr automation to proceed when only generated agent plan/evidence artifacts are uncommitted.
- Keep blocking dirty source changes unless --allow-dirty is explicitly passed.
- Document trusted server runners using full Codex shell access.

## Verification
- node --test scripts/tests/agent-runner-pr.test.mjs
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- pre-commit hook full repo typecheck passed