### PR TITLE
@voyantjs/cruises: static admin routes are shadowed by /:key route

### DIFF
--- a/.changeset/cruises-admin-static-routes.md
+++ b/.changeset/cruises-admin-static-routes.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/cruises": patch
+---
+
+Fix admin cruise route ordering so static subresource endpoints like `/sailings`, `/ships`, and `/prices` are handled before generic cruise-key routes.

--- a/docs/agent-plans/active/855-voyantjs-cruises-static-admin-routes-are-shadowed-by-key-rou.md
+++ b/docs/agent-plans/active/855-voyantjs-cruises-static-admin-routes-are-shadowed-by-key-rou.md
@@ -1,0 +1,112 @@
+# @voyantjs/cruises: static admin routes are shadowed by /:key route
+
+Issue: https://github.com/voyantjs/voyant/issues/855
+Branch: bug/855-voyantjs-cruises-static-admin-routes-are-shadowed-by-key-rou
+State: active
+
+## Purpose
+
+Prepare an implementation workspace for the maintainer-approved issue.
+
+## Current State
+
+- Project item: PVTI_lADODiwsuc4BXR16zgspO94
+- Repository: voyantjs/voyant
+- Base ref: origin/main
+- Local workspace: /home/mihai/voyant/voyant/.agent-worktrees/855-voyantjs-cruises-static-admin-routes-are-shadowed-by-key-rou
+- Risk: Low
+- Security risk: None
+- Verification lane: verify:fast
+
+## Agent Brief
+
+**Category:** bug
+**Summary:** Fix `@voyantjs/cruises` admin route ordering so static cruise subresource routes are not captured by the generic `/:key` route.
+
+**Current behavior:**
+`GET /v1/admin/cruises/sailings?limit=25&offset=0` is handled by the earlier cruise detail route and parses `sailings` as a cruise key, returning `400 invalid_key`. The same shadowing risk exists for other static admin subresource routes declared after `/:key`.
+
+**Desired behavior:**
+Static admin routes under `/v1/admin/cruises` should match their intended handlers before the generic cruise detail route. Existing valid cruise detail behavior for local TypeID keys and external provider keys must continue to work.
+
+**Key interfaces:**
+- `cruiseAdminRoutes` in `packages/cruises/src/routes.ts`
+- Route shape coverage in `packages/cruises/tests/unit/routes-shape.test.ts`
+- Public client contract in `packages/cruises-react/src/query-options.ts` and related hooks that call `/v1/admin/cruises/sailings`, `/ships`, `/enrichment/:programId`, and `/search-index/*`
+
+**Acceptance criteria:**
+- [ ] Add a regression test showing `GET /sailings` is not handled by `GET /:key` and no longer returns `invalid_key`.
+- [ ] Audit and protect other static admin subresource routes that are currently declared after `/:key`.
+- [ ] Preserve existing tests for `GET /:key`, external cruise keys, `/:key/sailings`, refresh, detach, and external read-only behavior.
+- [ ] Add or update a Changeset for the public package behavior fix.
+
+**Verification lane:**
+Run `pnpm --filter @voyantjs/cruises test`, `pnpm --filter @voyantjs/cruises typecheck`, `pnpm --filter @voyantjs/cruises-react typecheck`, `pnpm lint:changed`, and `pnpm verify:agent-quality:changed`.
+
+**Security:**
+Low security risk. This changes route matching for existing admin endpoints but must not alter authentication, authorization, or tenant scoping behavior.
+
+**Artifacts required:**
+None beyond test output and the eventual PR diff.
+
+**Out of scope:**
+- Do not redesign the cruises route API.
+- Do not change response envelope schemas.
+- Do not add new cruise resources or UI behavior.
+
+## Desired Behavior
+
+The issue is implemented according to its acceptance criteria and handed off
+with evidence.
+
+## Scope
+
+In scope:
+
+- Read the issue, linked comments, relevant docs, and affected code.
+- Update this plan with concrete milestones before implementation.
+- Keep changes on branch `bug/855-voyantjs-cruises-static-admin-routes-are-shadowed-by-key-rou`.
+
+Out of scope:
+
+- Running an implementation agent before the plan is reviewed.
+- Pushing branches or opening PRs from this local prepare step.
+
+## Milestones
+
+- [x] Expand current-state notes from issue context and codebase findings.
+- [x] Identify the narrow implementation path.
+- [x] Define focused verification commands.
+- [x] Implement and verify.
+- [x] Prepare evidence packet.
+
+## Decisions
+
+- 2026-05-13 17:29 UTC - Local workspace and execution plan prepared by the runner.
+- 2026-05-13 17:45 UTC - Route audit found `GET /:key` registered before static `GET /sailings`, `GET /prices`, and `GET /ships`; multi-segment static routes are not exact-match shadowed today, but moving all per-cruise wildcard routes after the static subresource block protects the full reserved-segment surface.
+- 2026-05-13 17:45 UTC - Implementation path: reorder `cruiseAdminRoutes` so static subresource routes register before wildcard cruise-key routes, add route-shape regression coverage for `GET /sailings`, and add a patch changeset for `@voyantjs/cruises`.
+
+## Progress Log
+
+- 2026-05-13 17:29 UTC - Created local worktree and plan file. No implementation agent
+  has run.
+- 2026-05-13 17:45 UTC - Read GitHub issue #855, confirmed there are no comments, reviewed route-authoring guidance, and inspected affected route/test/client files.
+- 2026-05-13 17:50 UTC - Reordered cruises admin routes so static subresources register before wildcard cruise-key routes.
+- 2026-05-13 17:50 UTC - Added route-shape regression tests for `GET /sailings`, plus static collection coverage for `GET /ships` and `GET /prices`.
+- 2026-05-13 17:51 UTC - Added a patch changeset for `@voyantjs/cruises`.
+- 2026-05-13 17:55 UTC - Installed workspace dependencies with `pnpm install` because the worktree had no linked `node_modules`.
+- 2026-05-13 17:58 UTC - Verification passed: `pnpm --filter @voyantjs/cruises test`, `pnpm --filter @voyantjs/cruises typecheck`, `pnpm --filter @voyantjs/cruises-react typecheck`, `pnpm lint:changed`, `pnpm verify:agent-quality:changed`, and `pnpm verify:fast`.
+- 2026-05-13 17:58 UTC - `verify:agent-quality:changed` reported the existing `packages/cruises/src/routes.ts` file-size finding in report-only mode; `routes.ts` was already over the threshold on `origin/main` and this change only reorders handlers.
+
+## Verification Plan
+
+- `pnpm --filter @voyantjs/cruises test`
+- `pnpm --filter @voyantjs/cruises typecheck`
+- `pnpm --filter @voyantjs/cruises-react typecheck`
+- `pnpm lint:changed`
+- `pnpm verify:agent-quality:changed`
+
+## Risks And Rollback
+
+- Remove the local worktree with `git worktree remove /home/mihai/voyant/voyant/.agent-worktrees/855-voyantjs-cruises-static-admin-routes-are-shadowed-by-key-rou` if this
+  task is abandoned before implementation.

--- a/packages/cruises/src/routes.ts
+++ b/packages/cruises/src/routes.ts
@@ -353,250 +353,6 @@ export const cruiseAdminRoutes = new Hono<Env>()
     })
     return c.json({ data: row }, 201)
   })
-  // --- per-cruise (parses unified key, dispatches local or external) ---
-  // External branch dispatches through the catalog content service
-  // (cache-first, SWR refresh, synthesizer fallback) — flipped from
-  // ad-hoc adapter.fetchCruise() per the catalog-sourced-content
-  // migration. Returns the rich CruiseContent shape; templates that
-  // need backwards-compatible ExternalCruise can post-process the
-  // response.
-  .get("/:key", async (c) => {
-    const parsed = parseUnifiedKey(c.req.param("key"))
-    if (parsed.kind === "invalid") return c.json(invalidKey(parsed.raw), 400)
-    if (parsed.kind === "external") {
-      const registry = c.get("sourceAdapterRegistry")
-      if (!registry) return c.json(registryNotConfigured(), 503)
-
-      const entityId = entityIdFromExternal(parsed)
-      const result = await getCruiseContent(c.get("db"), entityId, readContentScope(c), {
-        registry,
-      })
-      if (!result) {
-        return c.json(
-          {
-            error: "not_found",
-            detail: `No sourced-entry row for cruise ${parsed.provider}:${parsed.ref} (entity ${entityId}). Run discovery first or check that an adapter is registered for "${parsed.provider}".`,
-          },
-          404,
-        )
-      }
-      return c.json({
-        data: {
-          source: "external",
-          sourceProvider: parsed.provider,
-          sourceRef: parsed.ref,
-          entityId,
-          content: result.content,
-          servedLocale: result.resolution.served_locale,
-          matchKind: result.resolution.match_kind,
-          contentSource: result.source,
-          servedStale: result.served_stale,
-          synthesized: result.synthesized,
-          machineTranslated: result.machine_translated,
-        },
-      })
-    }
-    const includeRaw = c.req.query("include") ?? ""
-    const includes = new Set(
-      includeRaw
-        .split(",")
-        .map((s) => s.trim())
-        .filter(Boolean),
-    )
-    const row = await cruisesService.getCruiseById(c.get("db"), parsed.id, {
-      withSailings: includes.has("sailings"),
-      withDays: includes.has("days"),
-    })
-    if (!row) return c.json({ error: "not_found" }, 404)
-    return c.json({
-      data: {
-        source: "local",
-        sourceProvider: null,
-        sourceRef: null,
-        cruise: row,
-      },
-    })
-  })
-  .put("/:key", async (c) => {
-    const parsed = parseUnifiedKey(c.req.param("key"))
-    if (parsed.kind === "external") {
-      return c.json(
-        {
-          error: "external_cruise_read_only",
-          detail: `External cruise from '${parsed.provider}' cannot be edited locally. Edit at the upstream system, or POST /:key/detach to convert to a local cruise first.`,
-        },
-        409,
-      )
-    }
-    if (parsed.kind === "invalid") return c.json(invalidKey(parsed.raw), 400)
-    const data = await parseJsonBody(c, updateCruiseSchema)
-    const row = await cruisesService.updateCruise(c.get("db"), parsed.id, data, {
-      eventBus: c.get("eventBus"),
-    })
-    if (!row) return c.json({ error: "not_found" }, 404)
-    return c.json({ data: row })
-  })
-  .delete("/:key", async (c) => {
-    const parsed = parseUnifiedKey(c.req.param("key"))
-    if (parsed.kind === "external") {
-      return c.json(
-        {
-          error: "external_cruise_read_only",
-          detail: "External cruises can't be deleted locally.",
-        },
-        409,
-      )
-    }
-    if (parsed.kind === "invalid") return c.json(invalidKey(parsed.raw), 400)
-    const row = await cruisesService.archiveCruise(c.get("db"), parsed.id, {
-      eventBus: c.get("eventBus"),
-    })
-    if (!row) return c.json({ error: "not_found" }, 404)
-    return c.json({ data: row })
-  })
-  .post("/:key/aggregates/recompute", async (c) => {
-    const parsed = parseUnifiedKey(c.req.param("key"))
-    if (parsed.kind === "external") {
-      return c.json(
-        { error: "external_cruise_read_only", detail: "Aggregates only apply to local cruises." },
-        409,
-      )
-    }
-    if (parsed.kind === "invalid") return c.json(invalidKey(parsed.raw), 400)
-    const row = await cruisesService.recomputeCruiseAggregates(c.get("db"), parsed.id)
-    if (!row) return c.json({ error: "not_found" }, 404)
-    return c.json({ data: row })
-  })
-  .get("/:key/sailings", async (c) => {
-    const parsed = parseUnifiedKey(c.req.param("key"))
-    if (parsed.kind === "invalid") return c.json(invalidKey(parsed.raw), 400)
-    if (parsed.kind === "external") {
-      const ext = resolveExternal(parsed)
-      if (!ext) return c.json(adapterNotRegistered(parsed.provider), 501)
-      const sailings = await ext.adapter.listSailingsForCruise(ext.sourceRef)
-      return c.json({
-        data: sailings.map((s) => ({
-          source: "external",
-          sourceProvider: ext.adapter.name,
-          key: makeExternalKey(ext.adapter, s.sourceRef),
-          sailing: s,
-        })),
-        total: sailings.length,
-      })
-    }
-    const result = await cruisesService.listSailings(c.get("db"), {
-      cruiseId: parsed.id,
-      limit: 100,
-      offset: 0,
-    })
-    return c.json(result)
-  })
-  .put("/:key/days/bulk", async (c) => {
-    const parsed = parseUnifiedKey(c.req.param("key"))
-    if (parsed.kind === "external") {
-      return c.json({ error: "external_cruise_read_only" }, 409)
-    }
-    if (parsed.kind === "invalid") return c.json(invalidKey(parsed.raw), 400)
-    const payload = await parseJsonBody(c, replaceCruiseDaysSchema.omit({ cruiseId: true }))
-    const days = await cruisesService.replaceCruiseDays(c.get("db"), {
-      cruiseId: parsed.id,
-      days: payload.days,
-    })
-    return c.json({ data: days })
-  })
-  // --- external-only operations ---
-  // Refresh dispatches through the catalog content service. The
-  // invalidator marks the cache row stale; the subsequent
-  // getCruiseContent call sees the staleness and triggers a SWR
-  // refresh. Templates that need synchronous "force fresh from
-  // upstream" semantics should call adapter.getContent() directly
-  // — this route's contract is "best effort refresh, eventually
-  // consistent."
-  .post("/:key/refresh", async (c) => {
-    const parsed = parseUnifiedKey(c.req.param("key"))
-    if (parsed.kind !== "external") return c.json({ error: "local_cruise_no_refresh" }, 400)
-    const registry = c.get("sourceAdapterRegistry")
-    if (!registry) return c.json(registryNotConfigured(), 503)
-
-    const entityId = entityIdFromExternal(parsed)
-    const { invalidateCruiseContentOnDrift } = await import("./service-content.js")
-    await invalidateCruiseContentOnDrift(c.get("db"), {
-      id: `cnde_refresh_${Date.now()}`,
-      entity_module: "cruises",
-      entity_id: entityId,
-      kind: "content_invalidated",
-      detected_at: new Date(),
-    })
-    const result = await getCruiseContent(c.get("db"), entityId, readContentScope(c), {
-      registry,
-    })
-    if (!result) {
-      return c.json(
-        {
-          error: "not_found",
-          detail: `No sourced-entry row for cruise ${parsed.provider}:${parsed.ref} (entity ${entityId}).`,
-        },
-        404,
-      )
-    }
-    return c.json({
-      data: {
-        source: "external",
-        sourceProvider: parsed.provider,
-        sourceRef: parsed.ref,
-        entityId,
-        content: result.content,
-        contentSource: result.source,
-        servedStale: result.served_stale,
-        refreshedAt: new Date().toISOString(),
-      },
-    })
-  })
-  .post("/:key/detach", async (c) => {
-    const parsed = parseUnifiedKey(c.req.param("key"))
-    if (parsed.kind !== "external") return c.json({ error: "local_cruise_no_detach" }, 400)
-    const ext = resolveExternal(parsed)
-    if (!ext) return c.json(adapterNotRegistered(parsed.provider), 501)
-    const cruise = await detachExternalCruise(c.get("db"), ext.adapter, ext.sourceRef)
-    return c.json({ data: cruise }, 201)
-  })
-  // --- enrichment programs (expedition-focused; local cruises only) ---
-  .get("/:key/enrichment", async (c) => {
-    const parsed = parseUnifiedKey(c.req.param("key"))
-    if (parsed.kind === "external") {
-      const ext = resolveExternal(parsed)
-      if (!ext) return c.json(adapterNotRegistered(parsed.provider), 501)
-      // Adapters surface enrichment via the rich cruise detail; we return an
-      // empty list here for shape compatibility. Templates that need richer
-      // external enrichment should read from adapter.fetchCruise() directly.
-      return c.json({ data: [] })
-    }
-    if (parsed.kind === "invalid") return c.json(invalidKey(parsed.raw), 400)
-    const programs = await cruisesService.listEnrichmentPrograms(c.get("db"), parsed.id)
-    return c.json({ data: programs })
-  })
-  .post("/:key/enrichment", async (c) => {
-    const parsed = parseUnifiedKey(c.req.param("key"))
-    if (parsed.kind === "external") return c.json({ error: "external_cruise_read_only" }, 409)
-    if (parsed.kind === "invalid") return c.json(invalidKey(parsed.raw), 400)
-    const data = await parseJsonBody(c, insertEnrichmentProgramSchema.omit({ cruiseId: true }))
-    const row = await cruisesService.createEnrichmentProgram(c.get("db"), {
-      ...data,
-      cruiseId: parsed.id,
-    })
-    return c.json({ data: row }, 201)
-  })
-  .put("/:key/enrichment/bulk", async (c) => {
-    const parsed = parseUnifiedKey(c.req.param("key"))
-    if (parsed.kind === "external") return c.json({ error: "external_cruise_read_only" }, 409)
-    if (parsed.kind === "invalid") return c.json(invalidKey(parsed.raw), 400)
-    const payload = await parseJsonBody(c, replaceEnrichmentProgramsSchema.omit({ cruiseId: true }))
-    const rows = await cruisesService.replaceEnrichmentPrograms(c.get("db"), {
-      cruiseId: parsed.id,
-      programs: payload.programs,
-    })
-    return c.json({ data: rows })
-  })
   .put("/enrichment/:programId", async (c) => {
     const data = await parseJsonBody(c, updateEnrichmentProgramSchema)
     const row = await cruisesService.updateEnrichmentProgram(
@@ -1025,6 +781,252 @@ export const cruiseAdminRoutes = new Hono<Env>()
   .post("/search-index/rebuild", async (c) => {
     const result = await cruisesSearchService.rebuildAll(c.get("db"))
     return c.json({ data: result })
+  })
+  // --- per-cruise (parses unified key, dispatches local or external) ---
+  // Keep wildcard key routes after static admin subresources so reserved
+  // segments such as /sailings, /ships, and /prices reach their handlers.
+  // External branch dispatches through the catalog content service
+  // (cache-first, SWR refresh, synthesizer fallback) — flipped from
+  // ad-hoc adapter.fetchCruise() per the catalog-sourced-content
+  // migration. Returns the rich CruiseContent shape; templates that
+  // need backwards-compatible ExternalCruise can post-process the
+  // response.
+  .get("/:key", async (c) => {
+    const parsed = parseUnifiedKey(c.req.param("key"))
+    if (parsed.kind === "invalid") return c.json(invalidKey(parsed.raw), 400)
+    if (parsed.kind === "external") {
+      const registry = c.get("sourceAdapterRegistry")
+      if (!registry) return c.json(registryNotConfigured(), 503)
+
+      const entityId = entityIdFromExternal(parsed)
+      const result = await getCruiseContent(c.get("db"), entityId, readContentScope(c), {
+        registry,
+      })
+      if (!result) {
+        return c.json(
+          {
+            error: "not_found",
+            detail: `No sourced-entry row for cruise ${parsed.provider}:${parsed.ref} (entity ${entityId}). Run discovery first or check that an adapter is registered for "${parsed.provider}".`,
+          },
+          404,
+        )
+      }
+      return c.json({
+        data: {
+          source: "external",
+          sourceProvider: parsed.provider,
+          sourceRef: parsed.ref,
+          entityId,
+          content: result.content,
+          servedLocale: result.resolution.served_locale,
+          matchKind: result.resolution.match_kind,
+          contentSource: result.source,
+          servedStale: result.served_stale,
+          synthesized: result.synthesized,
+          machineTranslated: result.machine_translated,
+        },
+      })
+    }
+    const includeRaw = c.req.query("include") ?? ""
+    const includes = new Set(
+      includeRaw
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
+    )
+    const row = await cruisesService.getCruiseById(c.get("db"), parsed.id, {
+      withSailings: includes.has("sailings"),
+      withDays: includes.has("days"),
+    })
+    if (!row) return c.json({ error: "not_found" }, 404)
+    return c.json({
+      data: {
+        source: "local",
+        sourceProvider: null,
+        sourceRef: null,
+        cruise: row,
+      },
+    })
+  })
+  .put("/:key", async (c) => {
+    const parsed = parseUnifiedKey(c.req.param("key"))
+    if (parsed.kind === "external") {
+      return c.json(
+        {
+          error: "external_cruise_read_only",
+          detail: `External cruise from '${parsed.provider}' cannot be edited locally. Edit at the upstream system, or POST /:key/detach to convert to a local cruise first.`,
+        },
+        409,
+      )
+    }
+    if (parsed.kind === "invalid") return c.json(invalidKey(parsed.raw), 400)
+    const data = await parseJsonBody(c, updateCruiseSchema)
+    const row = await cruisesService.updateCruise(c.get("db"), parsed.id, data, {
+      eventBus: c.get("eventBus"),
+    })
+    if (!row) return c.json({ error: "not_found" }, 404)
+    return c.json({ data: row })
+  })
+  .delete("/:key", async (c) => {
+    const parsed = parseUnifiedKey(c.req.param("key"))
+    if (parsed.kind === "external") {
+      return c.json(
+        {
+          error: "external_cruise_read_only",
+          detail: "External cruises can't be deleted locally.",
+        },
+        409,
+      )
+    }
+    if (parsed.kind === "invalid") return c.json(invalidKey(parsed.raw), 400)
+    const row = await cruisesService.archiveCruise(c.get("db"), parsed.id, {
+      eventBus: c.get("eventBus"),
+    })
+    if (!row) return c.json({ error: "not_found" }, 404)
+    return c.json({ data: row })
+  })
+  .post("/:key/aggregates/recompute", async (c) => {
+    const parsed = parseUnifiedKey(c.req.param("key"))
+    if (parsed.kind === "external") {
+      return c.json(
+        { error: "external_cruise_read_only", detail: "Aggregates only apply to local cruises." },
+        409,
+      )
+    }
+    if (parsed.kind === "invalid") return c.json(invalidKey(parsed.raw), 400)
+    const row = await cruisesService.recomputeCruiseAggregates(c.get("db"), parsed.id)
+    if (!row) return c.json({ error: "not_found" }, 404)
+    return c.json({ data: row })
+  })
+  .get("/:key/sailings", async (c) => {
+    const parsed = parseUnifiedKey(c.req.param("key"))
+    if (parsed.kind === "invalid") return c.json(invalidKey(parsed.raw), 400)
+    if (parsed.kind === "external") {
+      const ext = resolveExternal(parsed)
+      if (!ext) return c.json(adapterNotRegistered(parsed.provider), 501)
+      const sailings = await ext.adapter.listSailingsForCruise(ext.sourceRef)
+      return c.json({
+        data: sailings.map((s) => ({
+          source: "external",
+          sourceProvider: ext.adapter.name,
+          key: makeExternalKey(ext.adapter, s.sourceRef),
+          sailing: s,
+        })),
+        total: sailings.length,
+      })
+    }
+    const result = await cruisesService.listSailings(c.get("db"), {
+      cruiseId: parsed.id,
+      limit: 100,
+      offset: 0,
+    })
+    return c.json(result)
+  })
+  .put("/:key/days/bulk", async (c) => {
+    const parsed = parseUnifiedKey(c.req.param("key"))
+    if (parsed.kind === "external") {
+      return c.json({ error: "external_cruise_read_only" }, 409)
+    }
+    if (parsed.kind === "invalid") return c.json(invalidKey(parsed.raw), 400)
+    const payload = await parseJsonBody(c, replaceCruiseDaysSchema.omit({ cruiseId: true }))
+    const days = await cruisesService.replaceCruiseDays(c.get("db"), {
+      cruiseId: parsed.id,
+      days: payload.days,
+    })
+    return c.json({ data: days })
+  })
+  // --- external-only operations ---
+  // Refresh dispatches through the catalog content service. The
+  // invalidator marks the cache row stale; the subsequent
+  // getCruiseContent call sees the staleness and triggers a SWR
+  // refresh. Templates that need synchronous "force fresh from
+  // upstream" semantics should call adapter.getContent() directly
+  // — this route's contract is "best effort refresh, eventually
+  // consistent."
+  .post("/:key/refresh", async (c) => {
+    const parsed = parseUnifiedKey(c.req.param("key"))
+    if (parsed.kind !== "external") return c.json({ error: "local_cruise_no_refresh" }, 400)
+    const registry = c.get("sourceAdapterRegistry")
+    if (!registry) return c.json(registryNotConfigured(), 503)
+
+    const entityId = entityIdFromExternal(parsed)
+    const { invalidateCruiseContentOnDrift } = await import("./service-content.js")
+    await invalidateCruiseContentOnDrift(c.get("db"), {
+      id: `cnde_refresh_${Date.now()}`,
+      entity_module: "cruises",
+      entity_id: entityId,
+      kind: "content_invalidated",
+      detected_at: new Date(),
+    })
+    const result = await getCruiseContent(c.get("db"), entityId, readContentScope(c), {
+      registry,
+    })
+    if (!result) {
+      return c.json(
+        {
+          error: "not_found",
+          detail: `No sourced-entry row for cruise ${parsed.provider}:${parsed.ref} (entity ${entityId}).`,
+        },
+        404,
+      )
+    }
+    return c.json({
+      data: {
+        source: "external",
+        sourceProvider: parsed.provider,
+        sourceRef: parsed.ref,
+        entityId,
+        content: result.content,
+        contentSource: result.source,
+        servedStale: result.served_stale,
+        refreshedAt: new Date().toISOString(),
+      },
+    })
+  })
+  .post("/:key/detach", async (c) => {
+    const parsed = parseUnifiedKey(c.req.param("key"))
+    if (parsed.kind !== "external") return c.json({ error: "local_cruise_no_detach" }, 400)
+    const ext = resolveExternal(parsed)
+    if (!ext) return c.json(adapterNotRegistered(parsed.provider), 501)
+    const cruise = await detachExternalCruise(c.get("db"), ext.adapter, ext.sourceRef)
+    return c.json({ data: cruise }, 201)
+  })
+  // --- enrichment programs (expedition-focused; local cruises only) ---
+  .get("/:key/enrichment", async (c) => {
+    const parsed = parseUnifiedKey(c.req.param("key"))
+    if (parsed.kind === "external") {
+      const ext = resolveExternal(parsed)
+      if (!ext) return c.json(adapterNotRegistered(parsed.provider), 501)
+      // Adapters surface enrichment via the rich cruise detail; we return an
+      // empty list here for shape compatibility. Templates that need richer
+      // external enrichment should read from adapter.fetchCruise() directly.
+      return c.json({ data: [] })
+    }
+    if (parsed.kind === "invalid") return c.json(invalidKey(parsed.raw), 400)
+    const programs = await cruisesService.listEnrichmentPrograms(c.get("db"), parsed.id)
+    return c.json({ data: programs })
+  })
+  .post("/:key/enrichment", async (c) => {
+    const parsed = parseUnifiedKey(c.req.param("key"))
+    if (parsed.kind === "external") return c.json({ error: "external_cruise_read_only" }, 409)
+    if (parsed.kind === "invalid") return c.json(invalidKey(parsed.raw), 400)
+    const data = await parseJsonBody(c, insertEnrichmentProgramSchema.omit({ cruiseId: true }))
+    const row = await cruisesService.createEnrichmentProgram(c.get("db"), {
+      ...data,
+      cruiseId: parsed.id,
+    })
+    return c.json({ data: row }, 201)
+  })
+  .put("/:key/enrichment/bulk", async (c) => {
+    const parsed = parseUnifiedKey(c.req.param("key"))
+    if (parsed.kind === "external") return c.json({ error: "external_cruise_read_only" }, 409)
+    if (parsed.kind === "invalid") return c.json(invalidKey(parsed.raw), 400)
+    const payload = await parseJsonBody(c, replaceEnrichmentProgramsSchema.omit({ cruiseId: true }))
+    const rows = await cruisesService.replaceEnrichmentPrograms(c.get("db"), {
+      cruiseId: parsed.id,
+      programs: payload.programs,
+    })
+    return c.json({ data: rows })
   })
 
 export type CruiseAdminRoutes = typeof cruiseAdminRoutes

--- a/packages/cruises/tests/unit/routes-shape.test.ts
+++ b/packages/cruises/tests/unit/routes-shape.test.ts
@@ -1,12 +1,16 @@
 import { mountTestApp } from "@voyantjs/voyant-test-utils/http"
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import type { ExternalCruise, ExternalSailing } from "../../src/adapters/index.js"
 import { MockCruiseAdapter } from "../../src/adapters/mock.js"
 import { clearCruiseAdapters, registerCruiseAdapter } from "../../src/adapters/registry.js"
 import { cruiseAdminRoutes } from "../../src/routes.js"
+import { cruisesService } from "../../src/service.js"
 
-afterEach(() => clearCruiseAdapters())
+afterEach(() => {
+  clearCruiseAdapters()
+  vi.restoreAllMocks()
+})
 
 const seedCruise: ExternalCruise = {
   sourceRef: { externalId: "ext-cru-1" },
@@ -26,6 +30,51 @@ const seedSailing: ExternalSailing = {
   returnDate: "2026-06-22",
   salesStatus: "open",
 }
+
+describe("admin routes — static subresource ordering", () => {
+  const app = mountTestApp(cruiseAdminRoutes, { db: undefined })
+
+  it("routes GET /sailings to the sailings list handler instead of GET /:key", async () => {
+    const listSailings = vi.spyOn(cruisesService, "listSailings").mockResolvedValueOnce({
+      data: [],
+      total: 0,
+      limit: 25,
+      offset: 0,
+    })
+
+    const res = await app.request("/sailings?limit=25&offset=0")
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data?: unknown[]; error?: string }
+    expect(body.error).not.toBe("invalid_key")
+    expect(body.data).toEqual([])
+    expect(listSailings).toHaveBeenCalledTimes(1)
+    expect(listSailings.mock.calls[0]?.[1]).toMatchObject({ limit: 25, offset: 0 })
+  })
+
+  it("keeps other one-segment static collections ahead of GET /:key", async () => {
+    vi.spyOn(cruisesService, "listShips").mockResolvedValueOnce({
+      data: [],
+      total: 0,
+      limit: 25,
+      offset: 0,
+    })
+    vi.spyOn(cruisesService, "listPrices").mockResolvedValueOnce({
+      data: [],
+      total: 0,
+      limit: 25,
+      offset: 0,
+    })
+
+    const shipsRes = await app.request("/ships?limit=25&offset=0")
+    const pricesRes = await app.request("/prices?limit=25&offset=0")
+
+    expect(shipsRes.status).toBe(200)
+    expect(pricesRes.status).toBe(200)
+    await expect(shipsRes.json()).resolves.toMatchObject({ data: [] })
+    await expect(pricesRes.json()).resolves.toMatchObject({ data: [] })
+  })
+})
 
 describe("admin routes — external key dispatch (no catalog registry configured)", () => {
   // Per the catalog-sourced-content migration, the /:key external


### PR DESCRIPTION
## Summary
- Implements #855.
- See the evidence packet for the detailed change summary and verification notes.

## Evidence
- https://github.com/voyantjs/voyant/issues/855#issuecomment-4447747674

## Review
- Repository: voyantjs/voyant
- Branch: bug/855-voyantjs-cruises-static-admin-routes-are-shadowed-by-key-rou
- Verification lane: verify:fast
