### PR TITLE
Workflow runs UI requires manual per-workflow recording in consuming apps

### DIFF
--- a/.changeset/workflow-runs-recorded-workflow.md
+++ b/.changeset/workflow-runs-recorded-workflow.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/workflow-runs": patch
+---
+
+Add `recordedWorkflow`, a first-class helper that records `@voyantjs/workflows`
+executions into the workflow runs observability tables on success and failure.

--- a/packages/workflow-runs/README.md
+++ b/packages/workflow-runs/README.md
@@ -72,3 +72,51 @@ mountWorkflowRunsAdminRoutes(hono, {
 ```
 
 For self-hosted workflow services, keep runner registration close to the code that mounts the workflow service. The registry should dispatch to your external workflow server instead of importing worker-only runtime code into the admin API process. The resume path sends `ctx.resumeFromStep` plus `ctx.seedResults`; the self-host server starts a new run, pre-populates the journal with the seeded step outputs, and executes from the failed step onward.
+
+## Record `@voyantjs/workflows` executions
+
+Use `recordedWorkflow` as a drop-in replacement for `workflow(...)` when a
+workflow should appear in the workflow runs admin UI. The helper records start,
+success, and failure rows in `workflow_runs` without repeating recorder
+boilerplate in every workflow body.
+
+```ts
+import { recordedWorkflow } from "@voyantjs/workflow-runs"
+
+export const generatePdfWorkflow = recordedWorkflow({
+  id: "products.generate-pdf",
+  tags: ["products"],
+  async run(input, ctx) {
+    const renderer = ctx.services.resolve("products:pdf-renderer")
+    return renderer.generate(input)
+  },
+})
+```
+
+By default, `recordedWorkflow` resolves a Drizzle database from
+`ctx.services.resolve("db")`. It records the workflow id, trigger, run id as the
+correlation id, configured/runtime tags, input, result, parent run id for child
+workflow triggers, and errors. Recording is best-effort: database or serializer
+failures do not fail the workflow execution.
+
+You can customize the database service key or payload serializers:
+
+```ts
+export const syncCatalogWorkflow = recordedWorkflow(
+  {
+    id: "catalog.sync",
+    async run(input, ctx) {
+      return ctx.services.resolve("catalog:sync").run(input)
+    },
+  },
+  {
+    dbServiceName: "postgres",
+    input: ({ input }) => ({ catalogId: input.catalogId }),
+    result: ({ output }) => ({ changed: output.changed }),
+  },
+)
+```
+
+This helper only records observability data. Rerun and resume support still uses
+`WorkflowRunnerRegistry` registration so apps can choose which workflows are
+safe to dispatch from the admin UI.

--- a/packages/workflow-runs/package.json
+++ b/packages/workflow-runs/package.json
@@ -9,7 +9,8 @@
     "./schema": "./src/schema.ts",
     "./service": "./src/service.ts",
     "./routes": "./src/routes.ts",
-    "./recorder": "./src/recorder.ts"
+    "./recorder": "./src/recorder.ts",
+    "./workflows": "./src/workflows.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
@@ -23,12 +24,14 @@
     "@voyantjs/core": "workspace:*",
     "@voyantjs/db": "workspace:*",
     "@voyantjs/hono": "workspace:*",
+    "@voyantjs/workflows": "workspace:*",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.10",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@voyantjs/voyant-typescript-config": "workspace:*",
+    "@voyantjs/workflows-orchestrator": "workspace:*",
     "typescript": "^6.0.2",
     "vitest": "^4.1.2"
   },
@@ -64,6 +67,11 @@
         "types": "./dist/recorder.d.ts",
         "import": "./dist/recorder.js",
         "default": "./dist/recorder.js"
+      },
+      "./workflows": {
+        "types": "./dist/workflows.d.ts",
+        "import": "./dist/workflows.js",
+        "default": "./dist/workflows.js"
       }
     }
   },

--- a/packages/workflow-runs/src/index.ts
+++ b/packages/workflow-runs/src/index.ts
@@ -46,3 +46,9 @@ export {
   type ListWorkflowRunsResult,
   workflowRunsService,
 } from "./service.js"
+export {
+  type RecordedWorkflowOptions,
+  type RecordedWorkflowResultContext,
+  type RecordedWorkflowRunContext,
+  recordedWorkflow,
+} from "./workflows.js"

--- a/packages/workflow-runs/src/recorder.ts
+++ b/packages/workflow-runs/src/recorder.ts
@@ -25,7 +25,7 @@
  * outages never break the underlying business operation.
  */
 
-import { eq } from "drizzle-orm"
+import { and, desc, eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import {
@@ -83,7 +83,13 @@ export interface WorkflowRunRecorder {
 export async function beginWorkflowRun(
   db: PostgresJsDatabase,
   input: BeginWorkflowRunInput,
+  options: { reuseRunningRun?: boolean } = {},
 ): Promise<WorkflowRunRecorder> {
+  if (options.reuseRunningRun && input.correlationId) {
+    const existingRunId = await findRunningWorkflowRun(db, input)
+    if (existingRunId) return workflowRunRecorder(db, existingRunId)
+  }
+
   const insert: NewWorkflowRun = {
     workflowName: input.workflowName,
     trigger: input.trigger ?? "manual",
@@ -109,6 +115,36 @@ export async function beginWorkflowRun(
 
   if (!runId) return noopRecorder()
 
+  return workflowRunRecorder(db, runId)
+}
+
+async function findRunningWorkflowRun(
+  db: PostgresJsDatabase,
+  input: BeginWorkflowRunInput,
+): Promise<string | null> {
+  const correlationId = input.correlationId
+  if (!correlationId) return null
+
+  try {
+    const [row] = await db
+      .select({ id: workflowRuns.id })
+      .from(workflowRuns)
+      .where(
+        and(
+          eq(workflowRuns.workflowName, input.workflowName),
+          eq(workflowRuns.correlationId, correlationId),
+          eq(workflowRuns.status, "running"),
+        ),
+      )
+      .orderBy(desc(workflowRuns.startedAt))
+      .limit(1)
+    return row?.id ?? null
+  } catch {
+    return null
+  }
+}
+
+function workflowRunRecorder(db: PostgresJsDatabase, runId: string): WorkflowRunRecorder {
   const stepStarts = new Map<string, { stepId: string; sequence: number; startedAt: number }>()
   let nextSequence = 1
 

--- a/packages/workflow-runs/src/workflows.ts
+++ b/packages/workflow-runs/src/workflows.ts
@@ -14,6 +14,7 @@ import {
 
 type MaybePromise<T> = T | Promise<T>
 type JsonRecord = Record<string, unknown>
+const WAITPOINT_PENDING = Symbol.for("voyant.workflows.waitpointPending")
 
 export interface RecordedWorkflowRunContext<TInput> {
   input: TInput
@@ -87,6 +88,7 @@ export function recordedWorkflow<TInput = unknown, TOutput = unknown>(
         await completeRecording(recorder, options, config, input, ctx, output)
         return output
       } catch (err) {
+        if (isWaitpointPending(err)) throw err
         await failRecording(recorder, err)
         throw err
       }
@@ -124,7 +126,7 @@ async function startRecording<TInput, TOutput>(
       ),
       resumeFromStep: await resolveValue(options.resumeFromStep, args, null),
     }
-    return await beginWorkflowRun(db, beginInput)
+    return await beginWorkflowRun(db, beginInput, { reuseRunningRun: ctx.invocationCount > 1 })
   } catch {
     return null
   }
@@ -241,6 +243,14 @@ function isPlainRecord(value: unknown): value is JsonRecord {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return false
   const proto = Object.getPrototypeOf(value)
   return proto === Object.prototype || proto === null
+}
+
+function isWaitpointPending(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { [WAITPOINT_PENDING]?: true })[WAITPOINT_PENDING] === true
+  )
 }
 
 function dedupe(values: readonly string[]): string[] {

--- a/packages/workflow-runs/src/workflows.ts
+++ b/packages/workflow-runs/src/workflows.ts
@@ -1,0 +1,248 @@
+import {
+  type WorkflowConfig,
+  type WorkflowContext,
+  type WorkflowDefinition,
+  workflow,
+} from "@voyantjs/workflows"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import {
+  type BeginWorkflowRunInput,
+  beginWorkflowRun,
+  type WorkflowRunRecorder,
+} from "./recorder.js"
+
+type MaybePromise<T> = T | Promise<T>
+type JsonRecord = Record<string, unknown>
+
+export interface RecordedWorkflowRunContext<TInput> {
+  input: TInput
+  ctx: WorkflowContext<TInput>
+  config: WorkflowConfig<TInput, unknown>
+}
+
+export interface RecordedWorkflowResultContext<TInput, TOutput>
+  extends RecordedWorkflowRunContext<TInput> {
+  output: TOutput
+}
+
+export interface RecordedWorkflowOptions<TInput, TOutput> {
+  /**
+   * Database used by the workflow-runs recorder. When omitted, the helper
+   * resolves `ctx.services.resolve(dbServiceName)`.
+   */
+  db?:
+    | PostgresJsDatabase
+    | ((
+        args: RecordedWorkflowRunContext<TInput>,
+      ) => MaybePromise<PostgresJsDatabase | null | undefined>)
+  /** Service-container key used when `db` is omitted. Defaults to `db`. */
+  dbServiceName?: string
+  workflowName?: string | ((args: RecordedWorkflowRunContext<TInput>) => MaybePromise<string>)
+  trigger?:
+    | string
+    | ((args: RecordedWorkflowRunContext<TInput>) => MaybePromise<string | null | undefined>)
+  correlationId?:
+    | string
+    | ((args: RecordedWorkflowRunContext<TInput>) => MaybePromise<string | null | undefined>)
+  tags?:
+    | ReadonlyArray<string>
+    | ((
+        args: RecordedWorkflowRunContext<TInput>,
+      ) => MaybePromise<ReadonlyArray<string> | null | undefined>)
+  input?:
+    | false
+    | ((args: RecordedWorkflowRunContext<TInput>) => MaybePromise<JsonRecord | null | undefined>)
+  result?:
+    | false
+    | ((
+        args: RecordedWorkflowResultContext<TInput, TOutput>,
+      ) => MaybePromise<JsonRecord | null | undefined>)
+  parentRunId?:
+    | string
+    | ((args: RecordedWorkflowRunContext<TInput>) => MaybePromise<string | null | undefined>)
+  triggeredByUserId?:
+    | string
+    | ((args: RecordedWorkflowRunContext<TInput>) => MaybePromise<string | null | undefined>)
+  resumeFromStep?:
+    | string
+    | ((args: RecordedWorkflowRunContext<TInput>) => MaybePromise<string | null | undefined>)
+}
+
+/**
+ * Declare a `@voyantjs/workflows` workflow whose run lifecycle is mirrored into
+ * the `workflow_runs` observability tables. Recording is best-effort: database,
+ * metadata, or serialization failures never change workflow execution behavior.
+ */
+export function recordedWorkflow<TInput = unknown, TOutput = unknown>(
+  config: WorkflowConfig<TInput, TOutput>,
+  options: RecordedWorkflowOptions<TInput, TOutput> = {},
+): WorkflowDefinition<TInput, TOutput> {
+  return workflow<TInput, TOutput>({
+    ...config,
+    async run(input, ctx) {
+      const recorder = await startRecording(config, options, input, ctx)
+      try {
+        const output = await config.run(input, ctx)
+        await completeRecording(recorder, options, config, input, ctx, output)
+        return output
+      } catch (err) {
+        await failRecording(recorder, err)
+        throw err
+      }
+    },
+  })
+}
+
+async function startRecording<TInput, TOutput>(
+  config: WorkflowConfig<TInput, TOutput>,
+  options: RecordedWorkflowOptions<TInput, TOutput>,
+  input: TInput,
+  ctx: WorkflowContext<TInput>,
+): Promise<WorkflowRunRecorder | null> {
+  try {
+    const args: RecordedWorkflowRunContext<TInput> = {
+      input,
+      ctx,
+      config: config as WorkflowConfig<TInput, unknown>,
+    }
+    const db = await resolveDb(options, args)
+    if (!db) return null
+    const beginInput: BeginWorkflowRunInput = {
+      workflowName: await resolveValue(options.workflowName, args, config.id),
+      trigger: await resolveValue(options.trigger, args, triggerName(ctx)),
+      correlationId: await resolveValue(options.correlationId, args, ctx.run.id),
+      tags: [
+        ...dedupe([...(config.tags ?? []), ...ctx.run.tags, ...(await resolveTags(options, args))]),
+      ],
+      input: await resolveInput(options, args),
+      parentRunId: await resolveValue(options.parentRunId, args, parentRunId(ctx)),
+      triggeredByUserId: await resolveValue(
+        options.triggeredByUserId,
+        args,
+        triggeredByUserId(ctx),
+      ),
+      resumeFromStep: await resolveValue(options.resumeFromStep, args, null),
+    }
+    return await beginWorkflowRun(db, beginInput)
+  } catch {
+    return null
+  }
+}
+
+async function completeRecording<TInput, TOutput>(
+  recorder: WorkflowRunRecorder | null,
+  options: RecordedWorkflowOptions<TInput, TOutput>,
+  config: WorkflowConfig<TInput, TOutput>,
+  input: TInput,
+  ctx: WorkflowContext<TInput>,
+  output: TOutput,
+): Promise<void> {
+  if (!recorder) return
+  try {
+    await recorder.complete(await resolveResult(options, { input, ctx, config, output }))
+  } catch {
+    // best-effort observability only
+  }
+}
+
+async function failRecording(recorder: WorkflowRunRecorder | null, err: unknown): Promise<void> {
+  if (!recorder) return
+  try {
+    await recorder.fail(err)
+  } catch {
+    // best-effort observability only
+  }
+}
+
+async function resolveDb<TInput, TOutput>(
+  options: RecordedWorkflowOptions<TInput, TOutput>,
+  args: RecordedWorkflowRunContext<TInput>,
+): Promise<PostgresJsDatabase | null | undefined> {
+  if (typeof options.db === "function") return options.db(args)
+  if (options.db) return options.db
+  const serviceName = options.dbServiceName ?? "db"
+  return args.ctx.services.resolve<PostgresJsDatabase>(serviceName)
+}
+
+async function resolveTags<TInput, TOutput>(
+  options: RecordedWorkflowOptions<TInput, TOutput>,
+  args: RecordedWorkflowRunContext<TInput>,
+): Promise<ReadonlyArray<string>> {
+  if (Array.isArray(options.tags)) return options.tags
+  if (typeof options.tags === "function") return (await options.tags(args)) ?? []
+  return []
+}
+
+async function resolveInput<TInput, TOutput>(
+  options: RecordedWorkflowOptions<TInput, TOutput>,
+  args: RecordedWorkflowRunContext<TInput>,
+): Promise<JsonRecord | null> {
+  if (options.input === false) return null
+  if (typeof options.input === "function") return (await options.input(args)) ?? null
+  return toJsonRecord(args.input)
+}
+
+async function resolveResult<TInput, TOutput>(
+  options: RecordedWorkflowOptions<TInput, TOutput>,
+  args: RecordedWorkflowResultContext<TInput, TOutput>,
+): Promise<JsonRecord | null> {
+  try {
+    if (options.result === false) return null
+    if (typeof options.result === "function") return (await options.result(args)) ?? null
+    return toJsonRecord(args.output)
+  } catch {
+    return null
+  }
+}
+
+async function resolveValue<TInput, TValue>(
+  value:
+    | TValue
+    | ((args: RecordedWorkflowRunContext<TInput>) => MaybePromise<TValue | null | undefined>)
+    | null
+    | undefined,
+  args: RecordedWorkflowRunContext<TInput>,
+  fallback: TValue,
+): Promise<TValue> {
+  if (typeof value === "function") {
+    return ((await (
+      value as (args: RecordedWorkflowRunContext<TInput>) => MaybePromise<TValue | null | undefined>
+    )(args)) ?? fallback) as TValue
+  }
+  return (value ?? fallback) as TValue
+}
+
+function triggerName(ctx: WorkflowContext<unknown>): string {
+  const trigger = ctx.run.triggeredBy
+  if (trigger.kind === "event") return trigger.eventType
+  if (trigger.kind === "schedule") return `schedule:${trigger.scheduleId}`
+  if (trigger.kind === "parent") return "parent"
+  return "api"
+}
+
+function parentRunId(ctx: WorkflowContext<unknown>): string | null {
+  const trigger = ctx.run.triggeredBy
+  return trigger.kind === "parent" ? trigger.parentRunId : null
+}
+
+function triggeredByUserId(ctx: WorkflowContext<unknown>): string | null {
+  const trigger = ctx.run.triggeredBy
+  return trigger.kind === "api" ? (trigger.actor ?? null) : null
+}
+
+function toJsonRecord(value: unknown): JsonRecord | null {
+  if (value === undefined || value === null) return null
+  if (isPlainRecord(value)) return value
+  return { value }
+}
+
+function isPlainRecord(value: unknown): value is JsonRecord {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false
+  const proto = Object.getPrototypeOf(value)
+  return proto === Object.prototype || proto === null
+}
+
+function dedupe(values: readonly string[]): string[] {
+  return [...new Set(values)]
+}

--- a/packages/workflow-runs/tests/unit/recorded-workflow.test.ts
+++ b/packages/workflow-runs/tests/unit/recorded-workflow.test.ts
@@ -1,4 +1,4 @@
-import { __resetRegistry } from "@voyantjs/workflows"
+import { __resetRegistry, workflow } from "@voyantjs/workflows"
 import type { ServiceResolver } from "@voyantjs/workflows/driver"
 import { createInMemoryDriver } from "@voyantjs/workflows-orchestrator"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -137,6 +137,39 @@ describe("recordedWorkflow persistence", () => {
     })
     expect(recorded?.error).toMatchObject({
       message: "pdf rendering failed",
+    })
+  })
+
+  test("keeps a single running record across waitpoint replay", async () => {
+    const db = createMemoryWorkflowRunsDb()
+    const child = workflow<{ value: number }, number>({
+      id: uniqueId("recorded-child"),
+      async run(input) {
+        return input.value + 1
+      },
+    })
+    const workflowId = uniqueId("recorded-waitpoint")
+    const wf = recordedWorkflow<{ value: number }, { value: number }>({
+      id: workflowId,
+      async run(input, ctx) {
+        const value = await ctx.invoke(child, input)
+        return { value }
+      },
+    })
+    const driver = makeDriver(makeResolver({ db }))
+
+    const run = await driver.trigger(wf, { value: 41 })
+
+    expect(run.status).toBe("completed")
+    const runs = await workflowRunsService.listRuns(db, { workflowName: workflowId })
+    expect(runs.total).toBe(1)
+    expect(runs.data[0]).toMatchObject({
+      workflowName: workflowId,
+      correlationId: run.id,
+      status: "succeeded",
+      input: { value: 41 },
+      result: { value: 42 },
+      error: null,
     })
   })
 })

--- a/packages/workflow-runs/tests/unit/recorded-workflow.test.ts
+++ b/packages/workflow-runs/tests/unit/recorded-workflow.test.ts
@@ -1,0 +1,245 @@
+import { __resetRegistry } from "@voyantjs/workflows"
+import type { ServiceResolver } from "@voyantjs/workflows/driver"
+import { createInMemoryDriver } from "@voyantjs/workflows-orchestrator"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+
+import { workflowRuns } from "../../src/schema.js"
+import { workflowRunsService } from "../../src/service.js"
+import { recordedWorkflow } from "../../src/workflows.js"
+
+let unique = 0
+
+function uniqueId(prefix: string): string {
+  unique += 1
+  return `${prefix}-${unique}`
+}
+
+function makeResolver(entries: Record<string, unknown> = {}): ServiceResolver {
+  return {
+    resolve<T>(name: string): T {
+      if (!(name in entries)) throw new Error(`test service "${name}" is not registered`)
+      return entries[name] as T
+    },
+    has(name: string): boolean {
+      return name in entries
+    },
+  }
+}
+
+function makeDriver(services = makeResolver()) {
+  return createInMemoryDriver({ disableScheduleRunner: true })({
+    services,
+    logger: () => {
+      // no-op
+    },
+  })
+}
+
+describe("recordedWorkflow", () => {
+  beforeEach(() => {
+    __resetRegistry()
+  })
+
+  afterEach(() => {
+    __resetRegistry()
+  })
+
+  test("does not fail the workflow when recording dependencies are unavailable", async () => {
+    const wf = recordedWorkflow<string, string>({
+      id: uniqueId("recording-unavailable"),
+      async run(input) {
+        return `handled:${input}`
+      },
+    })
+    const driver = makeDriver()
+
+    const run = await driver.trigger(wf, "input")
+
+    expect(run.status).toBe("completed")
+  })
+})
+
+describe("recordedWorkflow persistence", () => {
+  beforeEach(() => {
+    __resetRegistry()
+  })
+
+  afterEach(() => {
+    __resetRegistry()
+  })
+
+  test("records a successful workflow run visible through the workflow-runs service", async () => {
+    const db = createMemoryWorkflowRunsDb()
+    const workflowId = uniqueId("recorded-success")
+    const wf = recordedWorkflow<{ bookingId: string }, { ok: true; runId: string }>(
+      {
+        id: workflowId,
+        tags: ["configured"],
+        async run(_input, ctx) {
+          return { ok: true, runId: ctx.run.id }
+        },
+      },
+      { tags: ["observability"] },
+    )
+    const driver = makeDriver(makeResolver({ db }))
+
+    const run = await driver.trigger(wf, { bookingId: "bk_123" }, { tags: ["runtime"] })
+
+    expect(run.status).toBe("completed")
+    const runs = await workflowRunsService.listRuns(db, { workflowName: workflowId })
+    expect(runs.total).toBe(1)
+    const recorded = runs.data[0]
+    expect(recorded).toMatchObject({
+      workflowName: workflowId,
+      trigger: "api",
+      correlationId: run.id,
+      status: "succeeded",
+      input: { bookingId: "bk_123" },
+      result: { ok: true, runId: run.id },
+      error: null,
+    })
+    expect(recorded?.tags).toEqual(["configured", "runtime", "observability"])
+
+    const detail = await workflowRunsService.getRunById(db, recorded!.id)
+    expect(detail?.run.id).toBe(recorded?.id)
+  })
+
+  test("records a failed workflow run while preserving workflow failure status", async () => {
+    const db = createMemoryWorkflowRunsDb()
+    const workflowId = uniqueId("recorded-failure")
+    const wf = recordedWorkflow<{ attempt: number }, never>({
+      id: workflowId,
+      async run() {
+        const err = new Error("pdf rendering failed")
+        ;(err as Error & { code?: string }).code = "PDF_RENDER_FAILED"
+        throw err
+      },
+    })
+    const driver = makeDriver(makeResolver({ db }))
+
+    const run = await driver.trigger(wf, { attempt: 2 })
+
+    expect(run.status).toBe("failed")
+    const runs = await workflowRunsService.listRuns(db, {
+      workflowName: workflowId,
+      status: "failed",
+    })
+    expect(runs.total).toBe(1)
+    const recorded = runs.data[0]
+    expect(recorded).toMatchObject({
+      workflowName: workflowId,
+      trigger: "api",
+      correlationId: run.id,
+      status: "failed",
+      input: { attempt: 2 },
+      result: null,
+    })
+    expect(recorded?.error).toMatchObject({
+      message: "pdf rendering failed",
+    })
+  })
+})
+
+function createMemoryWorkflowRunsDb(): PostgresJsDatabase {
+  const runs: Array<Record<string, unknown>> = []
+  const steps: Array<Record<string, unknown>> = []
+  let runSeq = 0
+  let stepSeq = 0
+
+  function rowsFor(table: unknown): Array<Record<string, unknown>> {
+    return table === workflowRuns ? runs : steps
+  }
+
+  function nextId(table: unknown): string {
+    if (table === workflowRuns) {
+      runSeq += 1
+      return `wfrn_test_${runSeq}`
+    }
+    stepSeq += 1
+    return `wfrs_test_${stepSeq}`
+  }
+
+  const db = {
+    insert(table: unknown) {
+      return {
+        values(value: Record<string, unknown>) {
+          const row = {
+            id: value.id ?? nextId(table),
+            ...value,
+            startedAt: value.startedAt ?? new Date(),
+            createdAt: value.createdAt ?? new Date(),
+            updatedAt: value.updatedAt ?? new Date(),
+          }
+          rowsFor(table).push(row)
+          return {
+            returning() {
+              return [{ id: row.id }]
+            },
+          }
+        },
+      }
+    },
+    update(table: unknown) {
+      return {
+        set(patch: Record<string, unknown>) {
+          return {
+            where() {
+              for (const row of rowsFor(table)) Object.assign(row, patch)
+              return Promise.resolve()
+            },
+          }
+        },
+      }
+    },
+    select(selection?: Record<string, unknown>) {
+      return {
+        from(table: unknown) {
+          const query = makeQuery(rowsFor(table), selection)
+          return query
+        },
+      }
+    },
+  }
+  return db as PostgresJsDatabase
+}
+
+function makeQuery(rows: Array<Record<string, unknown>>, selection?: Record<string, unknown>) {
+  let limitValue: number | undefined
+  const query = {
+    where() {
+      if (selection && "count" in selection) return materializeRows(rows, selection, undefined, 0)
+      return query
+    },
+    orderBy() {
+      return query
+    },
+    limit(value: number) {
+      limitValue = value
+      return withOffset(materializeRows(rows, selection, limitValue, 0), (offsetValue) =>
+        materializeRows(rows, selection, limitValue, offsetValue),
+      )
+    },
+  }
+  return query
+}
+
+function materializeRows(
+  rows: Array<Record<string, unknown>>,
+  selection: Record<string, unknown> | undefined,
+  limitValue: number | undefined,
+  offsetValue: number,
+): Array<Record<string, unknown>> {
+  if (selection && "count" in selection) return [{ count: rows.length }]
+  const end = limitValue === undefined ? undefined : offsetValue + limitValue
+  return rows.slice(offsetValue, end)
+}
+
+function withOffset<T>(
+  rows: T[],
+  resolveOffset: (offset: number) => T[],
+): T[] & { offset(offset: number): T[] } {
+  return Object.assign(rows, {
+    offset: resolveOffset,
+  })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5193,6 +5193,9 @@ importers:
       '@voyantjs/hono':
         specifier: workspace:*
         version: link:../hono
+      '@voyantjs/workflows':
+        specifier: workspace:*
+        version: link:../workflows
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
@@ -5206,6 +5209,9 @@ importers:
       '@voyantjs/voyant-typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
+      '@voyantjs/workflows-orchestrator':
+        specifier: workspace:*
+        version: link:../workflows-orchestrator
       typescript:
         specifier: ^6.0.2
         version: 6.0.2


### PR DESCRIPTION
## Summary
- Implements #858.
- See the evidence packet for the detailed change summary and verification notes.

## Evidence
- https://github.com/voyantjs/voyant/issues/858#issuecomment-4447918773

## Review
- Repository: voyantjs/voyant
- Branch: task/858-workflow-runs-ui-requires-manual-per-workflow-recording-in-c
- Verification lane: verify:fast
