### PR TITLE
@voyantjs/workflows: export ./events so drizzle-kit can load dependent schemas

### DIFF
--- a/.changeset/clever-workflows-events.md
+++ b/.changeset/clever-workflows-events.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/workflows": patch
+---
+
+Add default export conditions to the published workflows subpaths so tooling that uses default/CJS-style resolution can load `@voyantjs/workflows/events`.

--- a/docs/agent-plans/active/859-voyantjs-workflows-export-events-so-drizzle-kit-can-load-dep.md
+++ b/docs/agent-plans/active/859-voyantjs-workflows-export-events-so-drizzle-kit-can-load-dep.md
@@ -1,0 +1,109 @@
+# @voyantjs/workflows: export ./events so drizzle-kit can load dependent schemas
+
+Issue: https://github.com/voyantjs/voyant/issues/859
+Branch: bug/859-voyantjs-workflows-export-events-so-drizzle-kit-can-load-dep
+State: active
+
+## Purpose
+
+Prepare an implementation workspace for the maintainer-approved issue.
+
+## Current State
+
+- Project item: PVTI_lADODiwsuc4BXR16zgss0v4
+- Repository: voyantjs/voyant
+- Base ref: origin/main
+- Local workspace: /home/mihai/voyant/voyant/.agent-worktrees/859-voyantjs-workflows-export-events-so-drizzle-kit-can-load-dep
+- Risk: Low
+- Security risk: None
+- Verification lane: verify:fast
+
+## Agent Brief
+
+**Category:** bug
+**Summary:** Make the published `@voyantjs/workflows/events` subpath resolvable for Drizzle/schema-generation consumers.
+
+**Current behavior:**
+A consuming app that includes Voyant workflow-run persistence in its Drizzle schema can fail during `drizzle-kit generate` with `ERR_PACKAGE_PATH_NOT_EXPORTED` for `@voyantjs/workflows/events`. The source and npm metadata currently show a `./events` subpath, so the likely failing contract is the published export conditions used by Drizzle/CJS-style resolution: `@voyantjs/workflows` declares `types` and `import` conditions but does not include the `default` condition used by other Voyant packages that support Drizzle schema loading.
+
+**Desired behavior:**
+Published consumers should be able to resolve `@voyantjs/workflows/events` while loading app schemas through Drizzle tooling. The fix should align `@voyantjs/workflows` public subpath export conditions with the package-export pattern used by Voyant schema/runtime packages, especially for `./events`, without removing existing ESM or type resolution behavior.
+
+**Key interfaces:**
+- `@voyantjs/workflows` package `exports` and `publishConfig.exports`
+- `@voyantjs/workflows/events` runtime event helpers used by orchestrator and Hono packages
+- Package export/tarball verification scripts that protect published manifest shape
+- Drizzle schema-generation consumer path that loads Voyant packages from `node_modules`
+
+**Acceptance criteria:**
+- [ ] Add a regression test or package-export assertion proving `@voyantjs/workflows/events` is present in the published manifest with resolver-compatible conditions.
+- [ ] Update the published `@voyantjs/workflows` export map so `./events` resolves for Drizzle/schema-generation tooling while preserving existing `types` and `import` targets.
+- [ ] Audit sibling `@voyantjs/workflows` public subpaths and apply the same condition pattern where needed so the package surface is internally consistent.
+- [ ] Confirm packages that import `@voyantjs/workflows/events` still typecheck and build.
+- [ ] Add a Changeset for the public package behavior fix.
+
+**Verification lane:**
+Run focused workflow package checks plus the export verification lane: `pnpm --filter @voyantjs/workflows test`, `pnpm --filter @voyantjs/workflows typecheck`, `pnpm --filter @voyantjs/workflows build`, `pnpm verify:package-exports`, and `pnpm verify:package-tarballs` if practical. Run `pnpm verify:fast` before handoff if the change touches shared package verification scripts or multiple workflow packages.
+
+**Security:**
+Not security-sensitive. This is package resolution metadata for an existing public subpath. Do not expose new runtime capabilities, schema tables, secrets, or admin endpoints.
+
+**Artifacts required:**
+None beyond test output and the eventual PR diff.
+
+**Out of scope:**
+- Do not redesign workflow event APIs.
+- Do not remove existing orchestrator or Hono imports of `@voyantjs/workflows/events` unless a compatibility-preserving replacement is added.
+- Do not change workflow-run schema shape or generate a consuming-app migration as the primary fix.
+
+## Desired Behavior
+
+The issue is implemented according to its acceptance criteria and handed off
+with evidence.
+
+## Scope
+
+In scope:
+
+- Read the issue, linked comments, relevant docs, and affected code.
+- Update this plan with concrete milestones before implementation.
+- Keep changes on branch `bug/859-voyantjs-workflows-export-events-so-drizzle-kit-can-load-dep`.
+
+Out of scope:
+
+- Running an implementation agent before the plan is reviewed.
+- Pushing branches or opening PRs from this local prepare step.
+
+## Milestones
+
+- [x] Expand current-state notes from issue context and codebase findings.
+- [x] Identify the narrow implementation path.
+- [x] Define focused verification commands.
+- [x] Implement and verify.
+- [x] Prepare evidence packet.
+
+## Decisions
+
+- 2026-05-14 06:26 UTC - Local workspace and execution plan prepared by the runner.
+- 2026-05-14 06:42 UTC - Keep implementation scoped to `@voyantjs/workflows`: add `default` resolver conditions to its public subpaths, add a package test for `./events` and sibling export consistency, and include a patch changeset.
+
+## Progress Log
+
+- 2026-05-14 06:26 UTC - Created local worktree and plan file. No implementation agent
+  has run.
+- 2026-05-14 06:42 UTC - Confirmed issue brief from GitHub and local plan match. Found `@voyantjs/workflows` already declares `./events` but its conditional exports only expose `types` and `import`, unlike schema/runtime packages that include `default`.
+- 2026-05-14 06:55 UTC - Added `default` conditions for every `@voyantjs/workflows` public subpath in source and publish export maps, added a package export regression test for `./events` and sibling consistency, and added a patch changeset.
+- 2026-05-14 06:55 UTC - Verification passed: `pnpm --filter @voyantjs/workflows test`, `pnpm --filter @voyantjs/workflows typecheck`, `pnpm --filter @voyantjs/workflows build`, `pnpm verify:package-exports`, `NODE_OPTIONS=--max-old-space-size=8192 pnpm verify:publish-tarballs`, and `pnpm verify:fast`. A default-heap `pnpm build` and default-heap `pnpm verify:publish-tarballs` hit unrelated UI package Node heap OOMs before the successful high-heap tarball rerun.
+
+## Verification Plan
+
+- `pnpm --filter @voyantjs/workflows test`
+- `pnpm --filter @voyantjs/workflows typecheck`
+- `pnpm --filter @voyantjs/workflows build`
+- `pnpm verify:package-exports`
+- `pnpm verify:publish-tarballs`
+
+## Risks And Rollback
+
+- Remove the local worktree with `git worktree remove /home/mihai/voyant/voyant/.agent-worktrees/859-voyantjs-workflows-export-events-so-drizzle-kit-can-load-dep` if this
+  task is abandoned before implementation.

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -13,51 +13,63 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     },
     "./testing": {
       "types": "./src/testing/index.ts",
-      "import": "./src/testing/index.ts"
+      "import": "./src/testing/index.ts",
+      "default": "./src/testing/index.ts"
     },
     "./protocol": {
       "types": "./src/protocol/index.ts",
-      "import": "./src/protocol/index.ts"
+      "import": "./src/protocol/index.ts",
+      "default": "./src/protocol/index.ts"
     },
     "./handler": {
       "types": "./src/handler/index.ts",
-      "import": "./src/handler/index.ts"
+      "import": "./src/handler/index.ts",
+      "default": "./src/handler/index.ts"
     },
     "./auth": {
       "types": "./src/auth/index.ts",
-      "import": "./src/auth/index.ts"
+      "import": "./src/auth/index.ts",
+      "default": "./src/auth/index.ts"
     },
     "./bindings": {
       "types": "./src/bindings.ts",
-      "import": "./src/bindings.ts"
+      "import": "./src/bindings.ts",
+      "default": "./src/bindings.ts"
     },
     "./config": {
       "types": "./src/config.ts",
-      "import": "./src/config.ts"
+      "import": "./src/config.ts",
+      "default": "./src/config.ts"
     },
     "./errors": {
       "types": "./src/errors.ts",
-      "import": "./src/errors.ts"
+      "import": "./src/errors.ts",
+      "default": "./src/errors.ts"
     },
     "./rate-limit": {
       "types": "./src/rate-limit/index.ts",
-      "import": "./src/rate-limit/index.ts"
+      "import": "./src/rate-limit/index.ts",
+      "default": "./src/rate-limit/index.ts"
     },
     "./driver": {
       "types": "./src/driver.ts",
-      "import": "./src/driver.ts"
+      "import": "./src/driver.ts",
+      "default": "./src/driver.ts"
     },
     "./events": {
       "types": "./src/events/index.ts",
-      "import": "./src/events/index.ts"
+      "import": "./src/events/index.ts",
+      "default": "./src/events/index.ts"
     },
     "./http-ingest": {
       "types": "./src/http-ingest.ts",
-      "import": "./src/http-ingest.ts"
+      "import": "./src/http-ingest.ts",
+      "default": "./src/http-ingest.ts"
     }
   },
   "main": "./dist/index.js",
@@ -76,6 +88,7 @@
     "check-types": "tsc --noEmit",
     "dev": "tsc -w -p tsconfig.json",
     "test": "vitest run",
+    "typecheck": "tsc --noEmit",
     "test:watch": "vitest"
   },
   "dependencies": {
@@ -100,51 +113,63 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       },
       "./testing": {
         "types": "./dist/testing/index.d.ts",
-        "import": "./dist/testing/index.js"
+        "import": "./dist/testing/index.js",
+        "default": "./dist/testing/index.js"
       },
       "./protocol": {
         "types": "./dist/protocol/index.d.ts",
-        "import": "./dist/protocol/index.js"
+        "import": "./dist/protocol/index.js",
+        "default": "./dist/protocol/index.js"
       },
       "./handler": {
         "types": "./dist/handler/index.d.ts",
-        "import": "./dist/handler/index.js"
+        "import": "./dist/handler/index.js",
+        "default": "./dist/handler/index.js"
       },
       "./auth": {
         "types": "./dist/auth/index.d.ts",
-        "import": "./dist/auth/index.js"
+        "import": "./dist/auth/index.js",
+        "default": "./dist/auth/index.js"
       },
       "./bindings": {
         "types": "./dist/bindings.d.ts",
-        "import": "./dist/bindings.js"
+        "import": "./dist/bindings.js",
+        "default": "./dist/bindings.js"
       },
       "./config": {
         "types": "./dist/config.d.ts",
-        "import": "./dist/config.js"
+        "import": "./dist/config.js",
+        "default": "./dist/config.js"
       },
       "./errors": {
         "types": "./dist/errors.d.ts",
-        "import": "./dist/errors.js"
+        "import": "./dist/errors.js",
+        "default": "./dist/errors.js"
       },
       "./rate-limit": {
         "types": "./dist/rate-limit/index.d.ts",
-        "import": "./dist/rate-limit/index.js"
+        "import": "./dist/rate-limit/index.js",
+        "default": "./dist/rate-limit/index.js"
       },
       "./driver": {
         "types": "./dist/driver.d.ts",
-        "import": "./dist/driver.js"
+        "import": "./dist/driver.js",
+        "default": "./dist/driver.js"
       },
       "./events": {
         "types": "./dist/events/index.d.ts",
-        "import": "./dist/events/index.js"
+        "import": "./dist/events/index.js",
+        "default": "./dist/events/index.js"
       },
       "./http-ingest": {
         "types": "./dist/http-ingest.d.ts",
-        "import": "./dist/http-ingest.js"
+        "import": "./dist/http-ingest.js",
+        "default": "./dist/http-ingest.js"
       }
     },
     "main": "./dist/index.js",

--- a/packages/workflows/src/__tests__/package-exports.test.ts
+++ b/packages/workflows/src/__tests__/package-exports.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+interface ConditionalExport {
+  types: string
+  import: string
+  default: string
+}
+
+interface PackageJson {
+  exports: Record<string, ConditionalExport>
+  publishConfig: {
+    exports: Record<string, ConditionalExport>
+  }
+}
+
+const packageJson = JSON.parse(
+  readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+) as PackageJson
+
+const publicSubpaths = [
+  ".",
+  "./testing",
+  "./protocol",
+  "./handler",
+  "./auth",
+  "./bindings",
+  "./config",
+  "./errors",
+  "./rate-limit",
+  "./driver",
+  "./events",
+  "./http-ingest",
+]
+
+describe("@voyantjs/workflows package exports", () => {
+  it("publishes the events subpath with resolver-compatible conditions", () => {
+    expect(packageJson.publishConfig.exports["./events"]).toEqual({
+      types: "./dist/events/index.d.ts",
+      import: "./dist/events/index.js",
+      default: "./dist/events/index.js",
+    })
+  })
+
+  it("keeps public subpath export conditions internally consistent", () => {
+    for (const exportPath of publicSubpaths) {
+      expect(packageJson.exports[exportPath]).toMatchObject({
+        types: expect.any(String),
+        import: expect.any(String),
+        default: expect.any(String),
+      })
+      expect(packageJson.exports[exportPath].default).toBe(packageJson.exports[exportPath].import)
+
+      expect(packageJson.publishConfig.exports[exportPath]).toMatchObject({
+        types: expect.any(String),
+        import: expect.any(String),
+        default: expect.any(String),
+      })
+      expect(packageJson.publishConfig.exports[exportPath].default).toBe(
+        packageJson.publishConfig.exports[exportPath].import,
+      )
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Implements #859.
- See the evidence packet for the detailed change summary and verification notes.

## Evidence
- https://github.com/voyantjs/voyant/issues/859#issuecomment-4448409992

## Review
- Repository: voyantjs/voyant
- Branch: bug/859-voyantjs-workflows-export-events-so-drizzle-kit-can-load-dep
- Verification lane: verify:fast
