### PR TITLE
[codex] Add workflow-runs trigger route

### DIFF
--- a/.changeset/workflow-runs-trigger-route.md
+++ b/.changeset/workflow-runs-trigger-route.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/workflow-runs": minor
+---
+
+Add an admin workflow trigger-by-name route at `POST /v1/admin/workflows/:name/runs` backed by explicitly triggerable `WorkflowRunnerRegistry` entries.

--- a/packages/workflow-runs/README.md
+++ b/packages/workflow-runs/README.md
@@ -29,7 +29,7 @@ export function WorkflowsRoute() {
 
 ## Mount the admin routes
 
-`mountWorkflowRunsAdminRoutes` adds the workflow-run list, detail, rerun, and resume endpoints under `/v1/admin/workflow-runs`.
+`mountWorkflowRunsAdminRoutes` adds the workflow-run list, detail, rerun, and resume endpoints under `/v1/admin/workflow-runs`, plus an explicit trigger endpoint at `POST /v1/admin/workflows/:name/runs`.
 
 ```ts
 import { mountWorkflowRunsAdminRoutes, WorkflowRunnerRegistry } from "@voyantjs/workflow-runs"
@@ -45,6 +45,15 @@ workflowRunnerRegistry.register({
   idempotency: "unsafe",
   description:
     "Confirms the booking and issues the final invoice. Use Resume to retry from a failed step.",
+  trigger: async (input, ctx) => {
+    const saved = await workflowServer.trigger({
+      workflowId: "checkout-finalize",
+      input,
+      tags: ctx.tags,
+      triggeredByUserId: ctx.triggeredByUserId,
+    })
+    return { runId: saved.id }
+  },
   rerun: async (input, ctx) => {
     const saved = await workflowServer.trigger({
       workflowId: "checkout-finalize",
@@ -69,6 +78,32 @@ workflowRunnerRegistry.register({
 mountWorkflowRunsAdminRoutes(hono, {
   runners: workflowRunnerRegistry,
 })
+```
+
+Triggerable workflows must opt in by implementing `trigger(...)` on their registered runner. This keeps rerun/resume-only workflows closed to arbitrary admin dispatch while still allowing operators, cron jobs, queues, and API keys with `workflows:trigger` permission to call:
+
+```http
+POST /v1/admin/workflows/checkout-finalize/runs
+Content-Type: application/json
+
+{
+  "input": { "bookingId": "bk_123" },
+  "idempotencyKey": "checkout-finalize:bk_123",
+  "correlationId": "bk_123",
+  "tags": ["source:admin"]
+}
+```
+
+The route returns `202 Accepted` with the queued run id:
+
+```json
+{
+  "data": {
+    "runId": "wfrn_...",
+    "workflowName": "checkout-finalize",
+    "status": "queued"
+  }
+}
 ```
 
 For self-hosted workflow services, keep runner registration close to the code that mounts the workflow service. The registry should dispatch to your external workflow server instead of importing worker-only runtime code into the admin API process. The resume path sends `ctx.resumeFromStep` plus `ctx.seedResults`; the self-host server starts a new run, pre-populates the journal with the seeded step outputs, and executes from the failed step onward.
@@ -117,6 +152,6 @@ export const syncCatalogWorkflow = recordedWorkflow(
 )
 ```
 
-This helper only records observability data. Rerun and resume support still uses
-`WorkflowRunnerRegistry` registration so apps can choose which workflows are
-safe to dispatch from the admin UI.
+This helper only records observability data. Trigger, rerun, and resume support
+still uses `WorkflowRunnerRegistry` registration so apps can choose which
+workflows are safe to dispatch from the admin UI.

--- a/packages/workflow-runs/src/index.ts
+++ b/packages/workflow-runs/src/index.ts
@@ -29,6 +29,7 @@ export {
   type WorkflowResumeContext,
   type WorkflowRunner,
   WorkflowRunnerRegistry,
+  type WorkflowTriggerContext,
 } from "./runner.js"
 export {
   type NewWorkflowRun,

--- a/packages/workflow-runs/src/routes.ts
+++ b/packages/workflow-runs/src/routes.ts
@@ -3,6 +3,7 @@
  *
  *   GET  /v1/admin/workflow-runs          → list (filter by workflow / status / tag)
  *   GET  /v1/admin/workflow-runs/:id      → run + ordered steps
+ *   POST /v1/admin/workflows/:name/runs   → trigger registered workflow by name
  *   POST /v1/admin/workflow-runs/:id/rerun  → fresh run with the recorded input
  *   POST /v1/admin/workflow-runs/:id/resume → re-run starting at the failed step
  *
@@ -14,6 +15,7 @@
  * endpoints return 501 with a clear error.
  */
 
+import { handleApiError, parseJsonBody } from "@voyantjs/hono"
 import type { Hono } from "hono"
 import { z } from "zod"
 
@@ -33,6 +35,32 @@ const rerunBodySchema = z.object({
   /** Required when runner.idempotency === "unsafe". */
   confirm: z.boolean().optional(),
 })
+
+const triggerWorkflowBodySchema = z
+  .object({
+    input: z.unknown().optional(),
+    idempotencyKey: z.string().trim().min(1).max(255).optional(),
+    correlationId: z.string().trim().min(1).max(255).optional(),
+    tags: z.array(z.string().trim().min(1).max(128)).max(50).optional(),
+  })
+  .strict()
+
+function hasWorkflowTriggerScope(scopes: unknown): boolean {
+  if (!Array.isArray(scopes) || !scopes.every((scope) => typeof scope === "string")) {
+    return false
+  }
+
+  return scopes.some((scope) => {
+    const normalized = scope.trim().toLowerCase()
+    return (
+      normalized === "*" ||
+      normalized === "*:*" ||
+      normalized === "*:trigger" ||
+      normalized === "workflows:*" ||
+      normalized === "workflows:trigger"
+    )
+  })
+}
 
 export interface MountWorkflowRunsAdminRoutesOptions {
   /**
@@ -95,6 +123,66 @@ export function mountWorkflowRunsAdminRoutes(
           error: "get_failed",
           detail: err instanceof Error ? err.message : String(err),
         },
+        500,
+      )
+    }
+  })
+
+  hono.post("/v1/admin/workflows/:name/runs", async (c) => {
+    if (!opts.runners) {
+      return c.json(
+        { error: "trigger_not_configured", detail: "no WorkflowRunnerRegistry mounted" },
+        501,
+      )
+    }
+
+    let body: z.infer<typeof triggerWorkflowBodySchema>
+    try {
+      body = await parseJsonBody(c, triggerWorkflowBodySchema)
+    } catch (err) {
+      return handleApiError(err, c)
+    }
+
+    const workflowName = c.req.param("name")
+    const runner = opts.runners.get(workflowName)
+    if (!runner) {
+      return c.json(
+        {
+          error: "runner_not_registered",
+          detail: `No runner registered for workflow "${workflowName}"`,
+        },
+        404,
+      )
+    }
+    if (!runner.trigger) {
+      return c.json(
+        {
+          error: "trigger_not_supported",
+          detail: `Workflow "${runner.name}" does not expose admin trigger support.`,
+        },
+        501,
+      )
+    }
+
+    const auth = c as { get(name: string): unknown }
+    if (auth.get("callerType") === "api_key" && !hasWorkflowTriggerScope(auth.get("scopes"))) {
+      return c.json({ error: "Forbidden: API key missing workflows:trigger permission" }, 403)
+    }
+
+    const userId = opts.resolveUserId?.(c) ?? null
+    try {
+      const input = Object.hasOwn(body, "input") ? body.input : {}
+      const { runId } = await runner.trigger(input, {
+        triggeredByUserId: userId,
+        correlationId: body.correlationId ?? null,
+        tags: body.tags ?? [],
+        idempotencyKey: body.idempotencyKey ?? null,
+      })
+      return c.json({ data: { runId, workflowName: runner.name, status: "queued" } }, 202)
+    } catch (err) {
+      console.error("[workflow-runs] trigger failed", err)
+      return c.json(
+        { error: "trigger_failed", detail: err instanceof Error ? err.message : String(err) },
         500,
       )
     }

--- a/packages/workflow-runs/src/runner.ts
+++ b/packages/workflow-runs/src/runner.ts
@@ -49,6 +49,17 @@ export interface WorkflowResumeContext extends WorkflowRerunContext {
   seedResults: Record<string, unknown>
 }
 
+export interface WorkflowTriggerContext {
+  /** User or API key actor that triggered the workflow, when available. */
+  triggeredByUserId: string | null
+  /** Optional correlation id supplied by the caller. */
+  correlationId: string | null
+  /** Tags supplied by the caller for observability and filtering. */
+  tags: ReadonlyArray<string>
+  /** Optional caller-supplied idempotency key forwarded to the runner. */
+  idempotencyKey: string | null
+}
+
 export interface WorkflowRunner {
   /** Workflow name — must match `workflow_runs.workflow_name`. */
   name: string
@@ -59,6 +70,12 @@ export interface WorkflowRunner {
   idempotency: WorkflowIdempotency
   /** Human-friendly label shown in the rerun confirm dialog. */
   description?: string
+  /**
+   * Trigger the workflow by name from an admin/internal route. Runners that
+   * expose this method are intentionally triggerable; missing methods keep
+   * rerun/resume-only workflows closed to arbitrary dispatch.
+   */
+  trigger?(input: unknown, ctx: WorkflowTriggerContext): Promise<{ runId: string }>
   /**
    * Run the workflow fresh with the recorded input. Returns the new
    * run's id (the recorder's `runId`).

--- a/packages/workflow-runs/tests/unit/routes.test.ts
+++ b/packages/workflow-runs/tests/unit/routes.test.ts
@@ -1,0 +1,321 @@
+import { requireActor } from "@voyantjs/hono"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { Hono } from "hono"
+import { describe, expect, test } from "vitest"
+
+import { beginWorkflowRun } from "../../src/recorder.js"
+import { mountWorkflowRunsAdminRoutes } from "../../src/routes.js"
+import { type WorkflowRunner, WorkflowRunnerRegistry } from "../../src/runner.js"
+import { workflowRuns } from "../../src/schema.js"
+import { workflowRunsService } from "../../src/service.js"
+
+describe("workflow-runs admin routes", () => {
+  test("triggers a registered workflow by name and records an observable run", async () => {
+    const db = createMemoryWorkflowRunsDb()
+    const registry = new WorkflowRunnerRegistry()
+    registry.register(
+      makeRunner({
+        name: "checkout-finalize",
+        async trigger(input, ctx) {
+          const recorder = await beginWorkflowRun(db, {
+            workflowName: "checkout-finalize",
+            trigger: "admin",
+            correlationId: ctx.correlationId,
+            tags: ctx.tags,
+            input: input as Record<string, unknown>,
+            triggeredByUserId: ctx.triggeredByUserId,
+          })
+          await recorder.complete({ queued: true })
+          return { runId: recorder.runId }
+        },
+      }),
+    )
+    const app = makeAuthorizedApp({ registry, db, actor: "staff", userId: "user_123" })
+
+    const res = await app.request("/v1/admin/workflows/checkout-finalize/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        input: { bookingId: "bk_123" },
+        correlationId: "corr_123",
+        tags: ["source:admin"],
+      }),
+    })
+
+    expect(res.status).toBe(202)
+    const body = (await res.json()) as {
+      data: { runId: string; workflowName: string; status: string }
+    }
+    expect(body.data).toMatchObject({
+      workflowName: "checkout-finalize",
+      status: "queued",
+    })
+
+    const runs = await workflowRunsService.listRuns(db, { workflowName: "checkout-finalize" })
+    expect(runs.total).toBe(1)
+    expect(runs.data[0]).toMatchObject({
+      id: body.data.runId,
+      workflowName: "checkout-finalize",
+      trigger: "admin",
+      correlationId: "corr_123",
+      tags: ["source:admin"],
+      input: { bookingId: "bk_123" },
+      status: "succeeded",
+      triggeredByUserId: "user_123",
+      result: { queued: true },
+    })
+  })
+
+  test("allows API keys with workflows:trigger permission", async () => {
+    for (const scopes of [["workflows:trigger"], ["workflows:*"], ["*:trigger"], ["*"]]) {
+      const registry = new WorkflowRunnerRegistry()
+      registry.register(makeRunner({ name: "sync-products" }))
+      const app = makeAuthorizedApp({
+        registry,
+        callerType: "api_key",
+        scopes,
+      })
+
+      const res = await app.request("/v1/admin/workflows/sync-products/runs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ input: { full: true } }),
+      })
+
+      expect(res.status).toBe(202)
+    }
+  })
+
+  test("rejects anonymous and insufficiently scoped callers before dispatch", async () => {
+    const registry = new WorkflowRunnerRegistry()
+    let calls = 0
+    registry.register(
+      makeRunner({
+        name: "sync-products",
+        async trigger() {
+          calls += 1
+          return { runId: "run_forbidden" }
+        },
+      }),
+    )
+
+    const anonymous = makeAuthorizedApp({ registry })
+    const anonymousRes = await anonymous.request("/v1/admin/workflows/sync-products/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ input: {} }),
+    })
+    expect(anonymousRes.status).toBe(401)
+
+    for (const scopes of [["workflows:read"], ["workflows:write"], ["workflows:relay"]]) {
+      const apiKey = makeAuthorizedApp({
+        registry,
+        callerType: "api_key",
+        scopes,
+      })
+      const scopedRes = await apiKey.request("/v1/admin/workflows/sync-products/runs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ input: {} }),
+      })
+      expect(scopedRes.status).toBe(403)
+    }
+    expect(calls).toBe(0)
+  })
+
+  test("returns validation and unknown workflow errors", async () => {
+    const registry = new WorkflowRunnerRegistry()
+    registry.register(makeRunner({ name: "known-workflow" }))
+    const app = makeAuthorizedApp({ registry, actor: "staff" })
+
+    const malformed = await app.request("/v1/admin/workflows/known-workflow/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    })
+    expect(malformed.status).toBe(400)
+    expect((await malformed.json()) as { code: string }).toMatchObject({
+      code: "invalid_request",
+    })
+
+    const unknown = await app.request("/v1/admin/workflows/missing-workflow/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ input: {} }),
+    })
+    expect(unknown.status).toBe(404)
+    expect((await unknown.json()) as { error: string }).toMatchObject({
+      error: "runner_not_registered",
+    })
+  })
+
+  test("surfaces runner failures as trigger_failed", async () => {
+    const registry = new WorkflowRunnerRegistry()
+    registry.register(
+      makeRunner({
+        name: "send-invoices",
+        async trigger() {
+          throw new Error("invoice provider unavailable")
+        },
+      }),
+    )
+    const app = makeAuthorizedApp({ registry, actor: "staff" })
+
+    const res = await app.request("/v1/admin/workflows/send-invoices/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ input: { invoiceId: "inv_123" } }),
+    })
+
+    expect(res.status).toBe(500)
+    expect((await res.json()) as { error: string; detail: string }).toMatchObject({
+      error: "trigger_failed",
+      detail: "invoice provider unavailable",
+    })
+  })
+})
+
+function makeRunner(input: Partial<WorkflowRunner> & { name: string }): WorkflowRunner {
+  return {
+    idempotency: "safe",
+    async trigger() {
+      return { runId: "run_queued" }
+    },
+    async rerun() {
+      return { runId: "run_rerun" }
+    },
+    async resume() {
+      return { runId: "run_resume" }
+    },
+    ...input,
+  }
+}
+
+function makeAuthorizedApp(options: {
+  registry: WorkflowRunnerRegistry
+  db?: PostgresJsDatabase
+  actor?: string
+  userId?: string
+  callerType?: "api_key"
+  scopes?: string[]
+}) {
+  const app = new Hono()
+  app.use("*", async (c, next) => {
+    if (options.db) c.set("db" as never, options.db)
+    if (options.actor) c.set("actor" as never, options.actor)
+    if (options.userId) c.set("userId" as never, options.userId)
+    if (options.callerType) c.set("callerType" as never, options.callerType)
+    if (options.scopes) c.set("scopes" as never, options.scopes)
+    await next()
+  })
+  app.use("/v1/admin/*", requireActor("staff"))
+  mountWorkflowRunsAdminRoutes(app, {
+    runners: options.registry,
+    resolveUserId(c) {
+      return (c as { get(name: "userId"): string | undefined }).get("userId") ?? null
+    },
+  })
+  return app
+}
+
+function createMemoryWorkflowRunsDb(): PostgresJsDatabase {
+  const runs: Array<Record<string, unknown>> = []
+  const steps: Array<Record<string, unknown>> = []
+  let runSeq = 0
+  let stepSeq = 0
+
+  function rowsFor(table: unknown): Array<Record<string, unknown>> {
+    return table === workflowRuns ? runs : steps
+  }
+
+  function nextId(table: unknown): string {
+    if (table === workflowRuns) {
+      runSeq += 1
+      return `wfrn_test_${runSeq}`
+    }
+    stepSeq += 1
+    return `wfrs_test_${stepSeq}`
+  }
+
+  const db = {
+    insert(table: unknown) {
+      return {
+        values(value: Record<string, unknown>) {
+          const row = {
+            id: value.id ?? nextId(table),
+            ...value,
+            startedAt: value.startedAt ?? new Date(),
+            createdAt: value.createdAt ?? new Date(),
+            updatedAt: value.updatedAt ?? new Date(),
+          }
+          rowsFor(table).push(row)
+          return {
+            returning() {
+              return [{ id: row.id }]
+            },
+          }
+        },
+      }
+    },
+    update(table: unknown) {
+      return {
+        set(patch: Record<string, unknown>) {
+          return {
+            where() {
+              for (const row of rowsFor(table)) Object.assign(row, patch)
+              return Promise.resolve()
+            },
+          }
+        },
+      }
+    },
+    select(selection?: Record<string, unknown>) {
+      return {
+        from(table: unknown) {
+          return makeQuery(rowsFor(table), selection)
+        },
+      }
+    },
+  }
+  return db as PostgresJsDatabase
+}
+
+function makeQuery(rows: Array<Record<string, unknown>>, selection?: Record<string, unknown>) {
+  let limitValue: number | undefined
+  const query = {
+    where() {
+      if (selection && "count" in selection) return materializeRows(rows, selection, undefined, 0)
+      return query
+    },
+    orderBy() {
+      return query
+    },
+    limit(value: number) {
+      limitValue = value
+      return withOffset(materializeRows(rows, selection, limitValue, 0), (offsetValue) =>
+        materializeRows(rows, selection, limitValue, offsetValue),
+      )
+    },
+  }
+  return query
+}
+
+function materializeRows(
+  rows: Array<Record<string, unknown>>,
+  selection: Record<string, unknown> | undefined,
+  limitValue: number | undefined,
+  offsetValue: number,
+): Array<Record<string, unknown>> {
+  if (selection && "count" in selection) return [{ count: rows.length }]
+  const end = limitValue === undefined ? undefined : offsetValue + limitValue
+  return rows.slice(offsetValue, end)
+}
+
+function withOffset<T>(
+  rows: T[],
+  resolveOffset: (offset: number) => T[],
+): T[] & { offset(offset: number): T[] } {
+  return Object.assign(rows, {
+    offset: resolveOffset,
+  })
+}


### PR DESCRIPTION
## Summary

Adds an opt-in admin trigger-by-name route for workflow runs:

- `POST /v1/admin/workflows/:name/runs` validates JSON with the shared Hono parser and returns `202 Accepted` queued metadata.
- `WorkflowRunner` can now expose an optional `trigger(...)` method with actor, correlation, tags, and idempotency context.
- Route tests cover successful dispatch, API-key `workflows:trigger` authorization, anonymous/under-scoped rejection, malformed JSON, unknown workflow names, runner failures, and observable workflow-run recording.
- Documents the route and adds a changeset.

Closes #874.

## Validation

- `pnpm exec biome check packages/workflow-runs/tests/unit/routes.test.ts packages/workflow-runs/src/routes.ts packages/workflow-runs/src/runner.ts packages/workflow-runs/src/index.ts`
- `pnpm --filter @voyantjs/workflow-runs lint`
- `pnpm --filter @voyantjs/workflow-runs typecheck`
- `pnpm --filter @voyantjs/workflow-runs test`
- Commit hook: lint-staged, `verify:agent-quality:changed` report-only, repo `pnpm typecheck`
- Push hook: repo `pnpm test`

## Notes

`pnpm verify:fast` was attempted before commit and stopped in `lint:changed` on a pre-existing unstaged formatting issue in `packages/workflows-cloud-adapter/src/index.ts`, which is outside this PR scope and was left untouched.