### PR TITLE
[codex] Add finance rendition rendered event

### DIFF
--- a/.changeset/finance-rendition-rendered-event.md
+++ b/.changeset/finance-rendition-rendered-event.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/finance": minor
+---
+
+Add `financeService.bindInvoiceRendition` for transactional ready-rendition binding and emit the metadata-only `invoice.rendered` event after successful invoice document rendition completion.

--- a/packages/finance/README.md
+++ b/packages/finance/README.md
@@ -33,6 +33,32 @@ const app = createApp({
 - **Tax regimes** (`txrg`)
 - **Invoice external refs** (`iner`)
 
+## Invoice Rendition Events
+
+Use `financeService.bindInvoiceRendition(db, invoiceId, artifact, { eventBus })`
+when a rendered invoice artifact has already been stored and should be bound to
+the invoice as the ready rendition. The helper creates the `invoice_renditions`
+row with `status: "ready"` inside a transaction, optionally marks previous
+renditions of the same format as `stale` when `replaceExisting` is true, and
+then emits `invoice.rendered` after the transaction commits.
+
+`invoice.rendered` is an internal service event. Subscribers receive metadata
+only:
+
+- `invoiceId`
+- `invoiceStatus`
+- `invoiceType`
+- `renditionId`
+- `format`
+- `storageKey`
+- `contentType`
+- `byteSize`
+- `contentHash`
+
+The event does not include rendered document bodies or signed download URLs.
+Subscriber failures do not roll back the rendition write; use a durable job or
+workflow when a downstream reaction needs retries.
+
 ## Exports
 
 | Entry | Description |

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -203,9 +203,11 @@ export {
   vouchers,
 } from "./schema.js"
 export type {
+  BindInvoiceRenditionInput,
   BookingPaymentSchedulePaidEvent,
   CreateInvoiceFromBookingInput,
   InvoiceFromBookingData,
+  InvoiceRenderedEvent,
   PaymentCompletedEvent,
   UnifiedPaymentRow,
 } from "./service.js"

--- a/packages/finance/src/service-documents.ts
+++ b/packages/finance/src/service-documents.ts
@@ -17,6 +17,7 @@ import type { GenerateInvoiceDocumentInput } from "./validation.js"
 export interface GeneratedInvoiceRenditionArtifact {
   format?: "html" | "pdf" | "xml" | "json"
   storageKey?: string | null
+  contentType?: string | null
   fileSize?: number | null
   checksum?: string | null
   language?: string | null
@@ -211,6 +212,7 @@ export function createStorageBackedInvoiceDocumentGenerator(
     return {
       format,
       storageKey: uploaded.key,
+      contentType: defaultInvoiceDocumentMimeType(format),
       fileSize: getBodySize(upload.body),
       language: upload.language ?? context.language,
       metadata: {
@@ -318,36 +320,32 @@ export const financeDocumentsService = {
       return { status: "generator_failed" }
     }
 
-    if (input.replaceExisting) {
-      const existing = await financeService.listInvoiceRenditions(db, invoiceId)
-      for (const rendition of existing) {
-        if (
-          rendition.format === (artifact.format ?? prepared.targetFormat) &&
-          rendition.status !== "stale"
-        ) {
-          await financeService.updateInvoiceRendition(db, rendition.id, { status: "stale" })
-        }
-      }
-    }
-
-    const rendition = await financeService.createInvoiceRendition(db, invoiceId, {
-      templateId: prepared.template?.id ?? null,
-      format: artifact.format ?? prepared.targetFormat,
-      status: "ready",
-      storageKey: artifact.storageKey ?? null,
-      fileSize: artifact.fileSize ?? null,
-      checksum: artifact.checksum ?? null,
-      language: artifact.language ?? prepared.language ?? null,
-      generatedAt: new Date().toISOString(),
-      metadata: {
-        ...(artifact.metadata ?? {}),
-        renderedBodyFormat: prepared.renderedBodyFormat,
+    const format = artifact.format ?? prepared.targetFormat
+    const bindResult = await financeService.bindInvoiceRendition(
+      db,
+      invoiceId,
+      {
+        templateId: prepared.template?.id ?? null,
+        format,
+        storageKey: artifact.storageKey?.trim() || null,
+        contentType: artifact.contentType ?? defaultInvoiceDocumentMimeType(format),
+        fileSize: artifact.fileSize ?? null,
+        checksum: artifact.checksum ?? null,
+        language: artifact.language ?? prepared.language ?? null,
+        generatedAt: new Date().toISOString(),
+        metadata: {
+          ...(artifact.metadata ?? {}),
+          renderedBodyFormat: prepared.renderedBodyFormat,
+        },
+        replaceExisting: input.replaceExisting,
       },
-    })
+      { eventBus: runtime.eventBus },
+    )
 
-    if (!rendition) {
+    if (bindResult.status !== "bound") {
       return { status: "not_found" }
     }
+    const { rendition } = bindResult
 
     await runtime.eventBus?.emit(
       "invoice.document.generated",

--- a/packages/finance/src/service.ts
+++ b/packages/finance/src/service.ts
@@ -415,6 +415,31 @@ export interface PaymentCompletedEvent {
   provider: string | null
 }
 
+export interface BindInvoiceRenditionInput {
+  templateId?: string | null
+  format: (typeof invoiceRenditions.$inferSelect)["format"]
+  storageKey?: string | null
+  contentType: string
+  fileSize?: number | null
+  checksum?: string | null
+  language?: string | null
+  generatedAt?: string | null
+  metadata?: Record<string, unknown> | null
+  replaceExisting?: boolean
+}
+
+export interface InvoiceRenderedEvent {
+  invoiceId: string
+  invoiceStatus: (typeof invoices.$inferSelect)["status"]
+  invoiceType: (typeof invoices.$inferSelect)["invoiceType"]
+  renditionId: string
+  format: (typeof invoiceRenditions.$inferSelect)["format"]
+  storageKey: string | null
+  contentType: string
+  byteSize: number | null
+  contentHash: string | null
+}
+
 export function buildBookingPaymentSchedulePaidEvent(
   schedule: typeof bookingPaymentSchedules.$inferSelect,
   session: typeof paymentSessions.$inferSelect,
@@ -2923,6 +2948,88 @@ export const financeService = {
       .where(eq(invoiceRenditions.id, id))
       .returning()
     return row ?? null
+  },
+
+  async bindInvoiceRendition(
+    db: PostgresJsDatabase,
+    invoiceId: string,
+    data: BindInvoiceRenditionInput,
+    runtime: FinanceServiceRuntime = {},
+  ) {
+    const result = await db.transaction(async (tx) => {
+      const [invoice] = await tx
+        .select({
+          id: invoices.id,
+          status: invoices.status,
+          invoiceType: invoices.invoiceType,
+        })
+        .from(invoices)
+        .where(eq(invoices.id, invoiceId))
+        .limit(1)
+
+      if (!invoice) return { status: "not_found" as const }
+
+      if (data.replaceExisting) {
+        await tx
+          .update(invoiceRenditions)
+          .set({ status: "stale", updatedAt: new Date() })
+          .where(
+            and(
+              eq(invoiceRenditions.invoiceId, invoiceId),
+              eq(invoiceRenditions.format, data.format),
+              ne(invoiceRenditions.status, "stale"),
+            ),
+          )
+      }
+
+      const [rendition] = await tx
+        .insert(invoiceRenditions)
+        .values({
+          invoiceId,
+          templateId: data.templateId ?? null,
+          format: data.format,
+          status: "ready",
+          storageKey: data.storageKey?.trim() || null,
+          fileSize: data.fileSize ?? null,
+          checksum: data.checksum ?? null,
+          language: data.language ?? null,
+          generatedAt: toTimestamp(data.generatedAt),
+          metadata: {
+            ...(data.metadata ?? {}),
+            contentType: data.contentType,
+          },
+        })
+        .returning()
+
+      if (!rendition) return { status: "not_found" as const }
+
+      return { status: "bound" as const, invoice, rendition }
+    })
+
+    if (result.status !== "bound") {
+      return result
+    }
+
+    await runtime.eventBus?.emit(
+      "invoice.rendered",
+      {
+        invoiceId: result.invoice.id,
+        invoiceStatus: result.invoice.status,
+        invoiceType: result.invoice.invoiceType,
+        renditionId: result.rendition.id,
+        format: result.rendition.format,
+        storageKey: result.rendition.storageKey,
+        contentType: data.contentType,
+        byteSize: result.rendition.fileSize,
+        contentHash: result.rendition.checksum,
+      } satisfies InvoiceRenderedEvent,
+      {
+        category: "internal",
+        source: "service",
+      },
+    )
+
+    return result
   },
 
   async deleteInvoiceRendition(db: PostgresJsDatabase, id: string) {

--- a/packages/finance/tests/integration/document-routes.test.ts
+++ b/packages/finance/tests/integration/document-routes.test.ts
@@ -11,6 +11,7 @@ import {
   invoices,
   invoiceTemplates,
 } from "../../src/schema.js"
+import { financeService } from "../../src/service.js"
 
 const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
 
@@ -24,6 +25,8 @@ describe.skipIf(!DB_AVAILABLE)("Finance document routes", () => {
   let db: PostgresJsDatabase
   let generatedKeys: string[]
   let documentEvents: Array<Record<string, unknown>>
+  let renderedEvents: Array<Record<string, unknown>>
+  let failNextGeneration: boolean
 
   beforeAll(async () => {
     const { createTestDb, cleanupTestDb } = await import("@voyantjs/db/test-utils")
@@ -37,8 +40,12 @@ describe.skipIf(!DB_AVAILABLE)("Finance document routes", () => {
     })
     const eventBus = createEventBus()
     documentEvents = []
+    renderedEvents = []
     eventBus.subscribe("invoice.document.generated", (event) => {
       documentEvents.push(event as Record<string, unknown>)
+    })
+    eventBus.subscribe("invoice.rendered", (event) => {
+      renderedEvents.push(event as Record<string, unknown>)
     })
     app.route(
       "/",
@@ -47,11 +54,15 @@ describe.skipIf(!DB_AVAILABLE)("Finance document routes", () => {
         resolveDocumentDownloadUrl: (_bindings, storageKey) =>
           `https://signed.example.com/${storageKey}`,
         invoiceDocumentGenerator: async ({ invoice }) => {
+          if (failNextGeneration) {
+            throw new Error("generation failed")
+          }
           const storageKey = `invoices/${invoice.id}/rendition-${generatedKeys.length + 1}.pdf`
           generatedKeys.push(storageKey)
           return {
             format: "pdf",
             storageKey,
+            contentType: "application/pdf",
             fileSize: 2048,
             checksum: `sha-${generatedKeys.length}`,
             metadata: {
@@ -69,6 +80,8 @@ describe.skipIf(!DB_AVAILABLE)("Finance document routes", () => {
     await cleanupTestDb(db)
     generatedKeys = []
     documentEvents = []
+    renderedEvents = []
+    failNextGeneration = false
   })
 
   it("generates and then regenerates a ready invoice rendition", async () => {
@@ -150,6 +163,40 @@ describe.skipIf(!DB_AVAILABLE)("Finance document routes", () => {
     expect(renditions).toHaveLength(2)
     expect(renditions.filter((entry) => entry.status === "ready")).toHaveLength(1)
     expect(renditions.filter((entry) => entry.status === "stale")).toHaveLength(1)
+    expect(renderedEvents).toEqual([
+      expect.objectContaining({
+        name: "invoice.rendered",
+        metadata: {
+          category: "internal",
+          source: "service",
+        },
+        data: expect.objectContaining({
+          invoiceId: invoice.id,
+          invoiceType: "invoice",
+          format: "pdf",
+          storageKey: expect.stringContaining("rendition-1.pdf"),
+          contentType: "application/pdf",
+          byteSize: 2048,
+          contentHash: "sha-1",
+        }),
+      }),
+      expect.objectContaining({
+        name: "invoice.rendered",
+        metadata: {
+          category: "internal",
+          source: "service",
+        },
+        data: expect.objectContaining({
+          invoiceId: invoice.id,
+          invoiceType: "invoice",
+          format: "pdf",
+          storageKey: expect.stringContaining("rendition-2.pdf"),
+          contentType: "application/pdf",
+          byteSize: 2048,
+          contentHash: "sha-2",
+        }),
+      }),
+    ])
     expect(documentEvents).toEqual([
       expect.objectContaining({
         name: "invoice.document.generated",
@@ -187,5 +234,180 @@ describe.skipIf(!DB_AVAILABLE)("Finance document routes", () => {
     expect(downloadRes.headers.get("location")).toBe(
       `https://signed.example.com/${readyRendition?.storageKey}`,
     )
+  })
+
+  it("binds a ready rendition artifact and emits invoice.rendered", async () => {
+    const [invoice] = await db
+      .insert(invoices)
+      .values({
+        invoiceNumber: "INV-BIND-1",
+        invoiceType: "invoice",
+        status: "sent",
+        currency: "EUR",
+        issueDate: "2026-05-01",
+        dueDate: "2026-05-05",
+        subtotalCents: 5000,
+        taxCents: 0,
+        totalCents: 5000,
+        paidCents: 0,
+        balanceDueCents: 5000,
+      })
+      .returning()
+
+    const eventBus = createEventBus()
+    const events: Array<Record<string, unknown>> = []
+    eventBus.subscribe("invoice.rendered", (event) => {
+      events.push(event as Record<string, unknown>)
+    })
+
+    const result = await financeService.bindInvoiceRendition(
+      db,
+      invoice.id,
+      {
+        format: "pdf",
+        storageKey: `invoices/${invoice.id}/rendition.pdf`,
+        contentType: "application/pdf",
+        fileSize: 1234,
+        checksum: "sha256:abc",
+        language: "ro",
+        metadata: { source: "unit-test" },
+      },
+      { eventBus },
+    )
+
+    expect(result.status).toBe("bound")
+    if (result.status !== "bound") return
+    expect(result.rendition).toEqual(
+      expect.objectContaining({
+        invoiceId: invoice.id,
+        status: "ready",
+        storageKey: `invoices/${invoice.id}/rendition.pdf`,
+        fileSize: 1234,
+        checksum: "sha256:abc",
+        language: "ro",
+        metadata: {
+          source: "unit-test",
+          contentType: "application/pdf",
+        },
+      }),
+    )
+    expect(events).toEqual([
+      expect.objectContaining({
+        name: "invoice.rendered",
+        metadata: {
+          category: "internal",
+          source: "service",
+        },
+        data: {
+          invoiceId: invoice.id,
+          invoiceStatus: "sent",
+          invoiceType: "invoice",
+          renditionId: result.rendition.id,
+          format: "pdf",
+          storageKey: `invoices/${invoice.id}/rendition.pdf`,
+          contentType: "application/pdf",
+          byteSize: 1234,
+          contentHash: "sha256:abc",
+        },
+      }),
+    ])
+  })
+
+  it("does not emit rendition completion events when generation fails", async () => {
+    const [invoice] = await db
+      .insert(invoices)
+      .values({
+        invoiceNumber: "INV-FAIL-1",
+        invoiceType: "invoice",
+        status: "sent",
+        currency: "EUR",
+        issueDate: "2026-05-01",
+        dueDate: "2026-05-05",
+        subtotalCents: 5000,
+        taxCents: 0,
+        totalCents: 5000,
+        paidCents: 0,
+        balanceDueCents: 5000,
+      })
+      .returning()
+
+    failNextGeneration = true
+    const res = await app.request(`/invoices/${invoice.id}/generate-document`, {
+      method: "POST",
+      ...json({}),
+    })
+
+    expect(res.status).toBe(502)
+    expect(documentEvents).toEqual([])
+    expect(renderedEvents).toEqual([])
+
+    const renditions = await db
+      .select()
+      .from(invoiceRenditions)
+      .where(eq(invoiceRenditions.invoiceId, invoice.id))
+    expect(renditions).toEqual([])
+  })
+
+  it("preserves ready URL-only rendition artifacts", async () => {
+    const [invoice] = await db
+      .insert(invoices)
+      .values({
+        invoiceNumber: "INV-URL-1",
+        invoiceType: "invoice",
+        status: "sent",
+        currency: "EUR",
+        issueDate: "2026-05-01",
+        dueDate: "2026-05-05",
+        subtotalCents: 5000,
+        taxCents: 0,
+        totalCents: 5000,
+        paidCents: 0,
+        balanceDueCents: 5000,
+      })
+      .returning()
+
+    const eventBus = createEventBus()
+    const events: Array<Record<string, unknown>> = []
+    eventBus.subscribe("invoice.rendered", (event) => {
+      events.push(event as Record<string, unknown>)
+    })
+
+    const result = await financeService.bindInvoiceRendition(
+      db,
+      invoice.id,
+      {
+        format: "pdf",
+        storageKey: null,
+        contentType: "application/pdf",
+        fileSize: 1234,
+        checksum: "sha256:url-only",
+        metadata: {
+          url: "https://files.example.com/invoices/url-only.pdf",
+        },
+      },
+      { eventBus },
+    )
+
+    expect(result.status).toBe("bound")
+    if (result.status !== "bound") return
+    expect(result.rendition.storageKey).toBeNull()
+    expect(result.rendition.status).toBe("ready")
+    expect(result.rendition.metadata).toEqual({
+      url: "https://files.example.com/invoices/url-only.pdf",
+      contentType: "application/pdf",
+    })
+    expect(events).toEqual([
+      expect.objectContaining({
+        name: "invoice.rendered",
+        data: expect.objectContaining({
+          invoiceId: invoice.id,
+          renditionId: result.rendition.id,
+          storageKey: null,
+          contentType: "application/pdf",
+          byteSize: 1234,
+          contentHash: "sha256:url-only",
+        }),
+      }),
+    ])
   })
 })


### PR DESCRIPTION
## Summary

Closes #880.

Adds a first-class invoice rendition completion path in `@voyantjs/finance`:

- introduces `financeService.bindInvoiceRendition(...)` to create a ready `invoice_renditions` row in a transaction and optionally stale prior renditions of the same format
- emits metadata-only `invoice.rendered` after a successful bind with invoice id, rendition id, storage key, content type, byte size, and content hash
- routes invoice document generation through the new binding helper while preserving `invoice.document.generated`
- documents subscriber semantics and adds a changeset

## Validation

- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/finance lint`
- `pnpm --filter @voyantjs/finance test -- tests/integration/document-routes.test.ts` (integration tests skipped where `TEST_DATABASE_URL` is unset; finance unit tests passed)
- `pnpm verify:fast`
- pre-commit hook: changed-file lint, agent-quality report-only, repo lint, full typecheck
- pre-push hook: repo test command

Note: `verify:agent-quality:changed` reports existing `packages/finance/src/service.ts` file-size/raw-SQL/unsafe-cast findings in report-only mode because this PR touches that file; it does not fail verification.