### PR TITLE
[codex] add storefront offer apply/redeem flow

### DIFF
--- a/.changeset/public-offer-apply-redeem.md
+++ b/.changeset/public-offer-apply-redeem.md
@@ -1,0 +1,7 @@
+---
+"@voyantjs/storefront": minor
+"@voyantjs/storefront-react": minor
+"@voyantjs/promotions": minor
+---
+
+Add public storefront offer apply/redeem contracts, React mutation helpers, and promotions-backed resolver support for customer-facing manual and code-gated offer flows.

--- a/docs/architecture/promotions-architecture.md
+++ b/docs/architecture/promotions-architecture.md
@@ -598,6 +598,8 @@ The public HTTP routes live under the public capability namespace, not an extra 
 
 Both parse JSON through `parseJsonBody(...)`, return customer-safe status/reason codes, echo booking/session identifiers when provided, and include price-impact plus conflict metadata. They do not replace finance voucher validation and they do not create payment captures. Booking-level redemption audit rows are still written from confirmed quotes by the `booking.confirmed` subscriber.
 
+Offer mutation requests require the caller to provide `pax` explicitly. The resolver does not infer traveler counts from booking/session IDs; omitting `pax` would make the evaluator treat minimum-traveler conditions as catalog-plane conditional offers instead of checkout exclusions.
+
 ## 9. Reindex + event surface
 
 Mirrors the `availability.slot.changed` precedent (PR3 of #493 + the lifecycle work in #510 / #512), with one addition that pricing didn't need: a **boundary scheduler** for time-driven transitions.

--- a/docs/architecture/promotions-architecture.md
+++ b/docs/architecture/promotions-architecture.md
@@ -67,7 +67,7 @@ Splitting them produces two near-duplicate evaluators that drift. They ship toge
 
 Not a sub-path of `packages/pricing`. Pricing rules answer *what is the configured price right now for this option, in this catalog, on this date* — they're per-option rate tables (per #493 PR4). Promotions answer *what discount applies on top of that price for this slice*. The two have different lifecycles, different operator UIs, different audit trails (redemption tracking is a promotions concern only), and different reindex triggers. Co-locating them in `pricing` would obscure both.
 
-`packages/promotions` follows the same shape as the recently-shipped vertical packages: `schema.ts`, `service.ts`, `routes.ts`, `validation.ts`, `events.ts`. It depends on `@voyantjs/products` (for the contract type imports + scope-by-product link) and on `@voyantjs/markets` (for scope-by-market). Catalog plane wiring lives in `packages/promotions/src/service-catalog-plane-promotions.ts` (matching the `service-catalog-plane-departures` precedent in `@voyantjs/availability`). Storefront integration ships an explicit `createPromotionsStorefrontResolvers(db)` factory that consumers wire into the storefront service's resolver-hook fields.
+`packages/promotions` follows the same shape as the recently-shipped vertical packages: `schema.ts`, `service.ts`, `routes.ts`, `validation.ts`, `events.ts`. It depends on `@voyantjs/products` (for the contract type imports + scope-by-product link) and on `@voyantjs/markets` (for scope-by-market). Catalog plane wiring lives in `packages/promotions/src/service-catalog-plane-promotions.ts` (matching the `service-catalog-plane-departures` precedent in `@voyantjs/availability`). Storefront integration ships an explicit `createPromotionsStorefrontResolvers()` factory that consumers wire into the storefront service's resolver-hook fields; the resolver reads the request-scoped db supplied by `@voyantjs/storefront`.
 
 ### 3.2. Scope is a typed discriminated union, not a list of foreign keys
 
@@ -110,6 +110,8 @@ An offer either auto-applies (no `code` column value) or is code-gated (`code` i
 A single offer row cannot be both auto-applied and code-gated. The marketing pattern "advertise the discount AND require a code" is modelled as **two separate offers** — one auto-applied (drives the badge), one code-gated (drives the redemption when the customer types the code). Both flow through the evaluator together at checkout (the algorithm in §5.2 does NOT exclude auto offers when a code is supplied), so stacking semantics (§3.3) decide whether they compose. Operators typically share a name across the pair for clarity but the system treats them as independent rows.
 
 Code uniqueness is enforced at the offer-table level: a partial unique index `(lower(code)) WHERE code IS NOT NULL AND active = true` catches double-use across active offers. Archived offers (`active = false`) free up their code for reuse. Code matching is case-insensitive (stored lowercase, compared lowercase); the customer's typed casing is preserved on the redemption row for audit.
+
+Customer-facing manual application follows the same conflict policy as quote-time pricing. `POST /v1/public/offers/:slug/apply` only applies non-code offers; code-gated offers must go through `POST /v1/public/offers/redeem`. When a manually applied or code-gated offer collides with auto-applied offers, all eligible candidates enter the evaluator together. The best non-stackable discount wins by default. Stackable offers compose only when the selected path is entirely stackable. Public responses return conflict metadata (`best_discount_wins` or `stackable_compose`) instead of exposing internal rule details.
 
 ### 3.5. Redemption tracking is per-booking, not per-customer or per-line-item
 
@@ -572,13 +574,15 @@ Both the catalog-bridge `captureSnapshotGraph` subscriber AND the promotions red
 
 ## 8. Storefront integration
 
-The existing placeholder hooks in `packages/storefront/src/service.ts` (`listApplicableOffers`, `getOfferBySlug`) get a real implementation in `packages/promotions/src/service-storefront.ts`:
+The existing placeholder hooks in `packages/storefront/src/service.ts` (`listApplicableOffers`, `getOfferBySlug`) get a real implementation in `packages/promotions/src/service-storefront.ts`. The same resolver surface owns customer-facing mutations:
 
 ```ts
-export function createPromotionsStorefrontResolvers(getDb: () => AnyDrizzleDb): StorefrontOfferResolvers {
+export function createPromotionsStorefrontResolvers(): StorefrontOfferResolvers {
   return {
     listApplicableOffers: async ({ productId, departureId, locale }) => { ... },
     getOfferBySlug: async ({ slug, locale }) => { ... },
+    applyOffer: async ({ slug, body }) => { ... },
+    redeemOffer: async ({ body }) => { ... },
   }
 }
 ```
@@ -586,6 +590,13 @@ export function createPromotionsStorefrontResolvers(getDb: () => AnyDrizzleDb): 
 Templates wire this in their storefront service composition. The `StorefrontPromotionalOffer` DTO shape stays as-is (it already covers what the new schema produces); the resolver just implements the previously-empty hooks.
 
 The `applicableProductIds` and `applicableDepartureIds` array fields on the DTO are populated from `promotional_offer_products` (and a future `promotional_offer_departures` table — not v1; v1 returns empty `applicableDepartureIds` for any departure-scoped use case, since v1 doesn't model departure-scoped offers).
+
+The public HTTP routes live under the public capability namespace, not an extra storefront namespace:
+
+- `POST /v1/public/offers/:slug/apply`
+- `POST /v1/public/offers/redeem`
+
+Both parse JSON through `parseJsonBody(...)`, return customer-safe status/reason codes, echo booking/session identifiers when provided, and include price-impact plus conflict metadata. They do not replace finance voucher validation and they do not create payment captures. Booking-level redemption audit rows are still written from confirmed quotes by the `booking.confirmed` subscriber.
 
 ## 9. Reindex + event surface
 
@@ -747,7 +758,7 @@ Recorded here as the rationale trail. The two larger architectural threads have 
 - `packages/promotions/src/service-booking-confirmed.ts`: `createBookingConfirmedRedemptionSubscriber(env)` subscriber factory + `recordPromotionRedemptionsForBooking(db, bookingId)` core logic (idempotent upsert per §4.3).
 - Operator template wires the evaluator into `quoteEntity` deps and registers the subscriber on the event bus alongside the existing `captureSnapshotGraph` subscriber.
 - Storefront DTO mapping (`packages/storefront/src/validation.ts:392`) verified to remain compatible — likely no changes.
-- `packages/promotions/src/service-storefront.ts`: `createPromotionsStorefrontResolvers(db)` factory.
+- `packages/promotions/src/service-storefront.ts`: `createPromotionsStorefrontResolvers()` factory.
 - Operator template wires the resolver into its storefront service composition. **No new public routes** — the storefront already exposes `/v1/public/products/:productId/offers` and `/v1/public/offers/:slug` (`packages/storefront/src/routes-public.ts:99-120`); the resolver implementation makes those previously-empty endpoints functional.
 - Integration tests: end-to-end quote with valid code → discount applied; quote with invalid code → error; commit creates redemption row; snapshot round-trip preserves `appliedOffers`.
 

--- a/packages/promotions/README.md
+++ b/packages/promotions/README.md
@@ -4,6 +4,19 @@ Promotional offers for Voyant — auto-applied catalog discounts (badges, strike
 
 PR1 ships the schema + admin CRUD only. Catalog plane wiring lands in PR3, booking-engine integration in PR4. See `docs/architecture/promotions-architecture.md` for the full design.
 
+Storefront runtimes can wire `createPromotionsStorefrontResolvers()` into
+`@voyantjs/storefront` to expose:
+
+- `GET /v1/public/products/:productId/offers`
+- `GET /v1/public/offers/:slug`
+- `POST /v1/public/offers/:slug/apply`
+- `POST /v1/public/offers/redeem`
+
+Manual and code-gated offers use the same evaluator as quote-time pricing:
+best non-stackable discount wins, and explicitly stackable offers compose when
+the selected path is stackable. Public mutation responses include conflict
+metadata without leaking internal rule details.
+
 ## Install
 
 ```bash
@@ -32,6 +45,7 @@ const app = createApp({
 | `./routes` | Hono admin routes mounted at `/v1/admin/promotions/*` |
 | `./events` | `PROMOTION_CHANGED_EVENT` + payload types |
 | `./service` | `promotionsService` (CRUD + scope materialization) |
+| `./service-storefront` | Storefront offer discovery, apply, and redeem resolver factory |
 
 ## License
 

--- a/packages/promotions/src/service-storefront.ts
+++ b/packages/promotions/src/service-storefront.ts
@@ -29,6 +29,10 @@
 
 import type { AnyDrizzleDb } from "@voyantjs/db"
 import type {
+  StorefrontAppliedOffer,
+  StorefrontOfferApplyInput,
+  StorefrontOfferMutationResult,
+  StorefrontOfferRedeemInput,
   StorefrontOfferResolvers,
   StorefrontPromotionalOffer,
   StorefrontRequestContext,
@@ -36,6 +40,11 @@ import type {
 import { and, eq, gte, inArray, isNull, lte, or } from "drizzle-orm"
 
 import { type PromotionalOffer, promotionalOfferProducts, promotionalOffers } from "./schema.js"
+import {
+  type CodeStatus,
+  createDrizzleOfferDataSource,
+  evaluateOffersForProduct,
+} from "./service-evaluator.js"
 import type { PromotionalOfferScope } from "./validation.js"
 
 export function createPromotionsStorefrontResolvers(): StorefrontOfferResolvers {
@@ -94,16 +103,48 @@ export function createPromotionsStorefrontResolvers(): StorefrontOfferResolvers 
       const db = resolveDb(input)
       if (!db) return null
 
-      const rows = await db
-        .select()
-        .from(promotionalOffers)
-        .where(and(eq(promotionalOffers.slug, input.slug), eq(promotionalOffers.active, true)))
-        .limit(1)
-      const offer = rows[0]
+      const offer = await findActiveOfferBySlug(db, input.slug)
       if (!offer) return null
 
       const links = await loadApplicableProductIds(db, [offer.id])
       return toStorefrontDto(offer, links.get(offer.id) ?? [])
+    },
+
+    async applyOffer(input) {
+      const db = resolveDb(input)
+      if (!db) return notConfiguredResult(input.body)
+
+      const offer = await findActiveOfferBySlug(db, input.slug)
+      if (!offer) {
+        return emptyResult(input.body, "invalid", "offer_not_found", null)
+      }
+
+      if (offer.code != null) {
+        return emptyResult(input.body, "invalid", "code_required", await dtoForOffer(db, offer))
+      }
+
+      const validity = currentValidityStatus(offer, new Date())
+      if (validity !== null) {
+        return emptyResult(input.body, "invalid", validity, await dtoForOffer(db, offer))
+      }
+
+      return evaluateStorefrontMutation(db, input.body, {
+        manualOffer: offer,
+        code: undefined,
+        offer: await dtoForOffer(db, offer),
+      })
+    },
+
+    async redeemOffer(input) {
+      const db = resolveDb(input)
+      if (!db) return notConfiguredResult(input.body)
+
+      const offer = await findActiveOfferByCode(db, input.body.code)
+      return evaluateStorefrontMutation(db, input.body, {
+        manualOffer: offer,
+        code: input.body.code,
+        offer: offer ? await dtoForOffer(db, offer) : null,
+      })
     },
   }
 }
@@ -186,4 +227,199 @@ function toStorefrontDto(
   }
 }
 
-export const __test__ = { matchesProduct, toStorefrontDto }
+async function findActiveOfferBySlug(
+  db: AnyDrizzleDb,
+  slug: string,
+): Promise<PromotionalOffer | null> {
+  const rows = await db
+    .select()
+    .from(promotionalOffers)
+    .where(and(eq(promotionalOffers.slug, slug), eq(promotionalOffers.active, true)))
+    .limit(1)
+  return rows[0] ?? null
+}
+
+async function findActiveOfferByCode(
+  db: AnyDrizzleDb,
+  code: string,
+): Promise<PromotionalOffer | null> {
+  const rows = await db
+    .select()
+    .from(promotionalOffers)
+    .where(and(eq(promotionalOffers.active, true), eq(promotionalOffers.code, code.toLowerCase())))
+    .limit(1)
+  return rows[0] ?? null
+}
+
+async function dtoForOffer(
+  db: AnyDrizzleDb,
+  offer: PromotionalOffer,
+): Promise<StorefrontPromotionalOffer> {
+  const links = await loadApplicableProductIds(db, [offer.id])
+  return toStorefrontDto(offer, links.get(offer.id) ?? [])
+}
+
+function currentValidityStatus(
+  offer: PromotionalOffer,
+  now: Date,
+): "offer_expired" | "offer_not_yet_valid" | null {
+  if (offer.validUntil != null && offer.validUntil < now) return "offer_expired"
+  if (offer.validFrom != null && offer.validFrom > now) return "offer_not_yet_valid"
+  return null
+}
+
+type MutationBody = StorefrontOfferApplyInput | StorefrontOfferRedeemInput
+
+function emptyResult(
+  input: MutationBody,
+  status: StorefrontOfferMutationResult["status"],
+  reason: NonNullable<StorefrontOfferMutationResult["reason"]>,
+  offer: StorefrontPromotionalOffer | null,
+): StorefrontOfferMutationResult {
+  return {
+    status,
+    reason,
+    offer,
+    target: targetFromInput(input),
+    pricing: {
+      basePriceCents: input.basePriceCents,
+      currency: input.currency,
+      discountAppliedCents: 0,
+      discountedPriceCents: input.basePriceCents,
+    },
+    appliedOffers: [],
+    conflict: null,
+  }
+}
+
+function notConfiguredResult(input: MutationBody): StorefrontOfferMutationResult {
+  return emptyResult(input, "invalid", "offer_not_found", null)
+}
+
+async function evaluateStorefrontMutation(
+  db: AnyDrizzleDb,
+  input: MutationBody,
+  options: {
+    manualOffer: PromotionalOffer | null
+    code?: string
+    offer: StorefrontPromotionalOffer | null
+  },
+): Promise<StorefrontOfferMutationResult> {
+  const evaluation = await evaluateOffersForProduct(createDrizzleOfferDataSource(db), {
+    productId: input.productId,
+    slice: {
+      audience: input.audience,
+      market: input.market,
+    },
+    pax: input.pax,
+    code: options.code,
+    basePriceCents: input.basePriceCents,
+    baseCurrency: input.currency,
+  })
+
+  const codeReason = codeStatusToReason(evaluation.codeStatus)
+  if (codeReason != null) {
+    return emptyResult(input, "invalid", codeReason, options.offer)
+  }
+
+  const appliedOffers = evaluation.applied.map(toStorefrontAppliedOffer)
+  const manualOfferId = options.manualOffer?.id ?? null
+  const selectedOfferIds = appliedOffers.map((offer) => offer.offerId)
+  const manualSelected = manualOfferId ? selectedOfferIds.includes(manualOfferId) : false
+  const autoAppliedOfferIds = appliedOffers
+    .filter((offer) => offer.appliedCode == null && offer.offerId !== manualOfferId)
+    .map((offer) => offer.offerId)
+  const conflict = manualOfferId
+    ? buildConflict({
+        autoAppliedOfferIds,
+        manualOfferId,
+        selectedOfferIds,
+        manualSelected,
+      })
+    : null
+
+  if (evaluation.total.discountAppliedCents <= 0) {
+    return {
+      ...emptyResult(input, "not_applicable", "no_discount", options.offer),
+      conflict,
+    }
+  }
+
+  const status = manualOfferId && !manualSelected ? "conflict" : "applied"
+
+  return {
+    status,
+    reason: status === "conflict" ? "conflict" : null,
+    offer: options.offer,
+    target: targetFromInput(input),
+    pricing: {
+      basePriceCents: input.basePriceCents,
+      currency: input.currency,
+      discountAppliedCents: evaluation.total.discountAppliedCents,
+      discountedPriceCents: evaluation.total.discountedPriceCents,
+    },
+    appliedOffers,
+    conflict,
+  }
+}
+
+function codeStatusToReason(
+  status: CodeStatus,
+): NonNullable<StorefrontOfferMutationResult["reason"]> | null {
+  if (status == null || status.kind === "code_valid") return null
+  if (status.kind === "code_not_applicable") return status.reason
+  return status.kind
+}
+
+function toStorefrontAppliedOffer(offer: StorefrontAppliedOffer): StorefrontAppliedOffer {
+  return {
+    offerId: offer.offerId,
+    offerName: offer.offerName,
+    discountAppliedCents: offer.discountAppliedCents,
+    discountedPriceCents: offer.discountedPriceCents,
+    currency: offer.currency,
+    discountKind: offer.discountKind,
+    discountPercent: offer.discountPercent,
+    discountAmountCents: offer.discountAmountCents,
+    appliedCode: offer.appliedCode,
+    stackable: offer.stackable,
+  }
+}
+
+function targetFromInput(input: MutationBody): StorefrontOfferMutationResult["target"] {
+  return {
+    bookingId: input.bookingId ?? null,
+    sessionId: input.sessionId ?? null,
+    productId: input.productId,
+    departureId: input.departureId ?? null,
+  }
+}
+
+function buildConflict(input: {
+  autoAppliedOfferIds: string[]
+  manualOfferId: string | null
+  selectedOfferIds: string[]
+  manualSelected: boolean
+}): StorefrontOfferMutationResult["conflict"] {
+  if (input.autoAppliedOfferIds.length === 0 && input.manualSelected) return null
+
+  const policy = input.manualSelected ? "stackable_compose" : "best_discount_wins"
+  return {
+    policy,
+    autoAppliedOfferIds: input.autoAppliedOfferIds,
+    manualOfferId: input.manualOfferId,
+    selectedOfferIds: input.selectedOfferIds,
+    message:
+      policy === "stackable_compose"
+        ? "The manually applied offer composes with selected auto-applied offers because every selected offer is stackable."
+        : "The best discount wins when a manually applied or code offer competes with non-stackable auto-applied offers.",
+  }
+}
+
+export const __test__ = {
+  buildConflict,
+  codeStatusToReason,
+  currentValidityStatus,
+  matchesProduct,
+  toStorefrontDto,
+}

--- a/packages/storefront-react/src/hooks/index.ts
+++ b/packages/storefront-react/src/hooks/index.ts
@@ -8,6 +8,8 @@ export {
 } from "./use-storefront-departure-itinerary.js"
 export { useStorefrontDeparturePricePreviewMutation } from "./use-storefront-departure-price-preview-mutation.js"
 export { type UseStorefrontOfferOptions, useStorefrontOffer } from "./use-storefront-offer.js"
+export { useStorefrontOfferApplyMutation } from "./use-storefront-offer-apply-mutation.js"
+export { useStorefrontOfferRedeemMutation } from "./use-storefront-offer-redeem-mutation.js"
 export {
   type UseStorefrontProductDeparturesOptions,
   useStorefrontProductDepartures,

--- a/packages/storefront-react/src/hooks/use-storefront-offer-apply-mutation.ts
+++ b/packages/storefront-react/src/hooks/use-storefront-offer-apply-mutation.ts
@@ -1,0 +1,21 @@
+"use client"
+
+import { useMutation } from "@tanstack/react-query"
+
+import { applyStorefrontOffer } from "../operations.js"
+import { useVoyantStorefrontContext } from "../provider.js"
+import type { StorefrontOfferApplyInput } from "../schemas.js"
+
+export function useStorefrontOfferApplyMutation(slug: string | null | undefined) {
+  const { baseUrl, fetcher } = useVoyantStorefrontContext()
+
+  return useMutation({
+    mutationFn: async (input: StorefrontOfferApplyInput) => {
+      if (!slug) {
+        throw new Error("useStorefrontOfferApplyMutation requires a slug")
+      }
+
+      return applyStorefrontOffer({ baseUrl, fetcher }, slug, input)
+    },
+  })
+}

--- a/packages/storefront-react/src/hooks/use-storefront-offer-redeem-mutation.ts
+++ b/packages/storefront-react/src/hooks/use-storefront-offer-redeem-mutation.ts
@@ -1,0 +1,17 @@
+"use client"
+
+import { useMutation } from "@tanstack/react-query"
+
+import { redeemStorefrontOffer } from "../operations.js"
+import { useVoyantStorefrontContext } from "../provider.js"
+import type { StorefrontOfferRedeemInput } from "../schemas.js"
+
+export function useStorefrontOfferRedeemMutation() {
+  const { baseUrl, fetcher } = useVoyantStorefrontContext()
+
+  return useMutation({
+    mutationFn: async (input: StorefrontOfferRedeemInput) => {
+      return redeemStorefrontOffer({ baseUrl, fetcher }, input)
+    },
+  })
+}

--- a/packages/storefront-react/src/index.ts
+++ b/packages/storefront-react/src/index.ts
@@ -7,6 +7,7 @@ export {
 } from "./client.js"
 export * from "./hooks/index.js"
 export {
+  applyStorefrontOffer,
   getStorefrontDeparture,
   getStorefrontDepartureItinerary,
   getStorefrontOfferBySlug,
@@ -15,6 +16,7 @@ export {
   listStorefrontProductExtensions,
   listStorefrontProductOffers,
   previewStorefrontDeparturePrice,
+  redeemStorefrontOffer,
 } from "./operations.js"
 export {
   useVoyantStorefrontContext,

--- a/packages/storefront-react/src/operations.ts
+++ b/packages/storefront-react/src/operations.ts
@@ -4,6 +4,8 @@ import { type FetchWithValidationOptions, fetchWithValidation, withQueryParams }
 import {
   type StorefrontDepartureListQuery,
   type StorefrontDeparturePricePreviewInput,
+  type StorefrontOfferApplyInput,
+  type StorefrontOfferRedeemInput,
   type StorefrontProductExtensionsQuery,
   type StorefrontPromotionalOfferListQuery,
   storefrontDepartureItineraryResponseSchema,
@@ -11,6 +13,9 @@ import {
   storefrontDeparturePricePreviewInputSchema,
   storefrontDeparturePricePreviewResponseSchema,
   storefrontDepartureResponseSchema,
+  storefrontOfferApplyInputSchema,
+  storefrontOfferMutationResponseSchema,
+  storefrontOfferRedeemInputSchema,
   storefrontProductExtensionsResponseSchema,
   storefrontPromotionalOfferListResponseSchema,
   storefrontPromotionalOfferResponseSchema,
@@ -101,5 +106,37 @@ export function getStorefrontOfferBySlug(
     withQueryParams(`/v1/public/offers/${slug}`, query),
     storefrontPromotionalOfferResponseSchema,
     client,
+  )
+}
+
+export function applyStorefrontOffer(
+  client: FetchWithValidationOptions,
+  slug: string,
+  input: StorefrontOfferApplyInput,
+) {
+  const parsed = storefrontOfferApplyInputSchema.parse(input)
+
+  return fetchWithValidation(
+    `/v1/public/offers/${slug}/apply`,
+    storefrontOfferMutationResponseSchema,
+    client,
+    { method: "POST", body: JSON.stringify(parsed) },
+  )
+}
+
+export function redeemStorefrontOffer(
+  client: FetchWithValidationOptions,
+  input: StorefrontOfferRedeemInput,
+) {
+  const parsed = storefrontOfferRedeemInputSchema.parse(input)
+
+  return fetchWithValidation(
+    "/v1/public/offers/redeem",
+    storefrontOfferMutationResponseSchema,
+    client,
+    {
+      method: "POST",
+      body: JSON.stringify(parsed),
+    },
   )
 }

--- a/packages/storefront-react/src/schemas.ts
+++ b/packages/storefront-react/src/schemas.ts
@@ -5,6 +5,10 @@ import {
   storefrontDeparturePricePreviewInputSchema,
   storefrontDeparturePricePreviewSchema,
   storefrontDepartureSchema,
+  storefrontOfferApplyInputSchema,
+  storefrontOfferMutationResponseSchema,
+  storefrontOfferMutationResultSchema,
+  storefrontOfferRedeemInputSchema,
   storefrontProductExtensionsQuerySchema,
   storefrontProductExtensionsResponseSchema,
   storefrontPromotionalOfferListQuerySchema,
@@ -23,6 +27,10 @@ export {
   storefrontDeparturePricePreviewInputSchema,
   storefrontDeparturePricePreviewSchema,
   storefrontDepartureSchema,
+  storefrontOfferApplyInputSchema,
+  storefrontOfferMutationResponseSchema,
+  storefrontOfferMutationResultSchema,
+  storefrontOfferRedeemInputSchema,
   storefrontProductExtensionsQuerySchema,
   storefrontProductExtensionsResponseSchema,
   storefrontPromotionalOfferListQuerySchema,
@@ -62,3 +70,6 @@ export type StorefrontPromotionalOfferListQuery = z.input<
   typeof storefrontPromotionalOfferListQuerySchema
 >
 export type StorefrontPromotionalOfferRecord = z.infer<typeof storefrontPromotionalOfferSchema>
+export type StorefrontOfferApplyInput = z.input<typeof storefrontOfferApplyInputSchema>
+export type StorefrontOfferRedeemInput = z.input<typeof storefrontOfferRedeemInputSchema>
+export type StorefrontOfferMutationRecord = z.infer<typeof storefrontOfferMutationResultSchema>

--- a/packages/storefront/src/index.ts
+++ b/packages/storefront/src/index.ts
@@ -12,9 +12,13 @@ export type {
 } from "./service.js"
 export { createStorefrontService, resolveStorefrontSettings } from "./service.js"
 export type {
+  StorefrontAppliedOffer,
   StorefrontDepartureListQuery,
   StorefrontFormField,
   StorefrontFormFieldInput,
+  StorefrontOfferApplyInput,
+  StorefrontOfferMutationResult,
+  StorefrontOfferRedeemInput,
   StorefrontPaymentMethod,
   StorefrontPaymentMethodCode,
   StorefrontPaymentMethodInput,
@@ -24,6 +28,7 @@ export type {
   StorefrontSettingsInput,
 } from "./validation.js"
 export {
+  storefrontAppliedOfferSchema,
   storefrontDepartureItinerarySchema,
   storefrontDepartureListQuerySchema,
   storefrontDepartureListResponseSchema,
@@ -34,6 +39,14 @@ export {
   storefrontFormFieldOptionSchema,
   storefrontFormFieldSchema,
   storefrontFormFieldTypeSchema,
+  storefrontOfferApplyInputSchema,
+  storefrontOfferAudienceSchema,
+  storefrontOfferConflictSchema,
+  storefrontOfferMutationReasonSchema,
+  storefrontOfferMutationResponseSchema,
+  storefrontOfferMutationResultSchema,
+  storefrontOfferMutationStatusSchema,
+  storefrontOfferRedeemInputSchema,
   storefrontPaymentMethodCodeSchema,
   storefrontPaymentMethodInputSchema,
   storefrontPaymentMethodSchema,

--- a/packages/storefront/src/routes-public.ts
+++ b/packages/storefront/src/routes-public.ts
@@ -10,6 +10,8 @@ import {
 import {
   storefrontDepartureListQuerySchema,
   storefrontDeparturePricePreviewInputSchema,
+  storefrontOfferApplyInputSchema,
+  storefrontOfferRedeemInputSchema,
   storefrontProductAvailabilitySummaryQuerySchema,
   storefrontProductExtensionsQuerySchema,
   storefrontPromotionalOfferListQuerySchema,
@@ -117,6 +119,27 @@ export function createStorefrontPublicRoutes(options?: StorefrontServiceOptions)
       })
 
       return offer ? c.json({ data: offer }) : c.json({ error: "Storefront offer not found" }, 404)
+    })
+    .post("/offers/:slug/apply", async (c) => {
+      const result = await storefrontService.applyOffer({
+        slug: c.req.param("slug"),
+        body: await parseJsonBody(c, storefrontOfferApplyInputSchema),
+        context: getRequestContext(c),
+      })
+
+      return result
+        ? c.json({ data: result })
+        : c.json({ error: "Storefront offer application is not configured" }, 501)
+    })
+    .post("/offers/redeem", async (c) => {
+      const result = await storefrontService.redeemOffer({
+        body: await parseJsonBody(c, storefrontOfferRedeemInputSchema),
+        context: getRequestContext(c),
+      })
+
+      return result
+        ? c.json({ data: result })
+        : c.json({ error: "Storefront offer redemption is not configured" }, 501)
     })
 }
 

--- a/packages/storefront/src/service.ts
+++ b/packages/storefront/src/service.ts
@@ -13,6 +13,9 @@ import {
   type StorefrontDeparturePricePreviewInput,
   type StorefrontFormField,
   type StorefrontFormFieldInput,
+  type StorefrontOfferApplyInput,
+  type StorefrontOfferMutationResult,
+  type StorefrontOfferRedeemInput,
   type StorefrontPaymentMethod,
   type StorefrontPaymentMethodCode,
   type StorefrontPaymentMethodInput,
@@ -59,6 +62,17 @@ export interface StorefrontOfferResolvers {
       locale?: string
     } & StorefrontRequestContext,
   ) => Promise<StorefrontPromotionalOffer | null> | StorefrontPromotionalOffer | null
+  applyOffer?: (
+    input: {
+      slug: string
+      body: StorefrontOfferApplyInput
+    } & StorefrontRequestContext,
+  ) => Promise<StorefrontOfferMutationResult> | StorefrontOfferMutationResult
+  redeemOffer?: (
+    input: {
+      body: StorefrontOfferRedeemInput
+    } & StorefrontRequestContext,
+  ) => Promise<StorefrontOfferMutationResult> | StorefrontOfferMutationResult
 }
 
 const defaultPaymentLabels: Record<StorefrontPaymentMethodCode, string> = {
@@ -197,6 +211,29 @@ export function createStorefrontService(options?: StorefrontServiceOptions) {
       return (
         (await resolveOffers(context)?.then((resolvers) =>
           resolvers?.getOfferBySlug?.({ ...offerInput, ...(context ?? {}) }),
+        )) ?? null
+      )
+    },
+    async applyOffer(input: {
+      slug: string
+      body: StorefrontOfferApplyInput
+      context?: StorefrontRequestContext
+    }): Promise<StorefrontOfferMutationResult | null> {
+      const { context, ...offerInput } = input
+      return (
+        (await resolveOffers(context)?.then((resolvers) =>
+          resolvers?.applyOffer?.({ ...offerInput, ...(context ?? {}) }),
+        )) ?? null
+      )
+    },
+    async redeemOffer(input: {
+      body: StorefrontOfferRedeemInput
+      context?: StorefrontRequestContext
+    }): Promise<StorefrontOfferMutationResult | null> {
+      const { context, ...offerInput } = input
+      return (
+        (await resolveOffers(context)?.then((resolvers) =>
+          resolvers?.redeemOffer?.({ ...offerInput, ...(context ?? {}) }),
         )) ?? null
       )
     },

--- a/packages/storefront/src/validation.ts
+++ b/packages/storefront/src/validation.ts
@@ -431,7 +431,7 @@ const storefrontOfferTargetInputSchema = z.object({
   bookingId: z.string().trim().min(1).optional().nullable(),
   sessionId: z.string().trim().min(1).optional().nullable(),
   locale: z.string().trim().min(2).optional(),
-  pax: z.coerce.number().int().min(0).optional(),
+  pax: z.coerce.number().int().min(1),
   audience: storefrontOfferAudienceSchema.default("customer"),
   market: z.string().trim().min(1).default("default"),
   basePriceCents: z.coerce.number().int().min(0),

--- a/packages/storefront/src/validation.ts
+++ b/packages/storefront/src/validation.ts
@@ -423,6 +423,102 @@ export const storefrontPromotionalOfferResponseSchema = z.object({
   data: storefrontPromotionalOfferSchema,
 })
 
+export const storefrontOfferAudienceSchema = z.enum(["staff", "customer", "partner", "supplier"])
+
+const storefrontOfferTargetInputSchema = z.object({
+  productId: z.string().trim().min(1),
+  departureId: z.string().trim().min(1).optional().nullable(),
+  bookingId: z.string().trim().min(1).optional().nullable(),
+  sessionId: z.string().trim().min(1).optional().nullable(),
+  locale: z.string().trim().min(2).optional(),
+  pax: z.coerce.number().int().min(0).optional(),
+  audience: storefrontOfferAudienceSchema.default("customer"),
+  market: z.string().trim().min(1).default("default"),
+  basePriceCents: z.coerce.number().int().min(0),
+  currency: z
+    .string()
+    .trim()
+    .length(3)
+    .transform((value) => value.toUpperCase()),
+})
+
+export const storefrontOfferApplyInputSchema = storefrontOfferTargetInputSchema
+
+export const storefrontOfferRedeemInputSchema = storefrontOfferTargetInputSchema.extend({
+  code: z.string().trim().min(1).max(80),
+})
+
+export const storefrontAppliedOfferSchema = z.object({
+  offerId: z.string(),
+  offerName: z.string(),
+  discountAppliedCents: z.number().int(),
+  discountedPriceCents: z.number().int(),
+  currency: z.string(),
+  discountKind: z.enum(["percentage", "fixed_amount"]),
+  discountPercent: z.number().nullable(),
+  discountAmountCents: z.number().int().nullable(),
+  appliedCode: z.string().nullable(),
+  stackable: z.boolean(),
+})
+
+export const storefrontOfferMutationStatusSchema = z.enum([
+  "applied",
+  "not_applicable",
+  "invalid",
+  "conflict",
+])
+
+export const storefrontOfferMutationReasonSchema = z
+  .enum([
+    "offer_not_found",
+    "offer_expired",
+    "offer_not_yet_valid",
+    "code_not_found",
+    "code_required",
+    "code_expired",
+    "code_not_yet_valid",
+    "scope",
+    "min_pax",
+    "currency",
+    "no_discount",
+    "booking_mismatch",
+    "session_mismatch",
+    "conflict",
+  ])
+  .nullable()
+
+export const storefrontOfferConflictSchema = z.object({
+  policy: z.enum(["best_discount_wins", "stackable_compose"]),
+  autoAppliedOfferIds: z.array(z.string()),
+  manualOfferId: z.string().nullable(),
+  selectedOfferIds: z.array(z.string()),
+  message: z.string(),
+})
+
+export const storefrontOfferMutationResultSchema = z.object({
+  status: storefrontOfferMutationStatusSchema,
+  reason: storefrontOfferMutationReasonSchema,
+  offer: storefrontPromotionalOfferSchema.nullable(),
+  target: z.object({
+    bookingId: z.string().nullable(),
+    sessionId: z.string().nullable(),
+    productId: z.string(),
+    departureId: z.string().nullable(),
+  }),
+  pricing: z.object({
+    basePriceCents: z.number().int(),
+    currency: z.string(),
+    discountAppliedCents: z.number().int(),
+    discountedPriceCents: z.number().int(),
+  }),
+  appliedOffers: z.array(storefrontAppliedOfferSchema),
+  conflict: storefrontOfferConflictSchema.nullable(),
+})
+
+export const storefrontOfferMutationResponseSchema = z.object({
+  data: storefrontOfferMutationResultSchema,
+})
+
 export type StorefrontFormFieldInput = z.infer<typeof storefrontFormFieldInputSchema>
 export type StorefrontFormField = z.infer<typeof storefrontFormFieldSchema>
 export type StorefrontPaymentMethodInput = z.infer<typeof storefrontPaymentMethodInputSchema>
@@ -438,3 +534,7 @@ export type StorefrontDeparturePricePreviewInput = z.infer<
   typeof storefrontDeparturePricePreviewInputSchema
 >
 export type StorefrontPromotionalOffer = z.infer<typeof storefrontPromotionalOfferSchema>
+export type StorefrontOfferApplyInput = z.infer<typeof storefrontOfferApplyInputSchema>
+export type StorefrontOfferRedeemInput = z.infer<typeof storefrontOfferRedeemInputSchema>
+export type StorefrontAppliedOffer = z.infer<typeof storefrontAppliedOfferSchema>
+export type StorefrontOfferMutationResult = z.infer<typeof storefrontOfferMutationResultSchema>

--- a/packages/storefront/tests/unit/public-routes.test.ts
+++ b/packages/storefront/tests/unit/public-routes.test.ts
@@ -347,4 +347,158 @@ describe("createStorefrontPublicRoutes", () => {
     expect(res.status).toBe(200)
     expect((await res.json()).data[0].id).toBe("offer_context")
   })
+
+  it("applies a storefront offer through the injected resolver", async () => {
+    const app = new Hono().route(
+      "/",
+      createStorefrontPublicRoutes({
+        offers: {
+          applyOffer({ slug, body }) {
+            expect(slug).toBe("early-booking")
+            expect(body).toMatchObject({
+              productId: "prod_123",
+              basePriceCents: 10000,
+              currency: "USD",
+              audience: "customer",
+              market: "default",
+            })
+
+            return {
+              status: "applied",
+              reason: null,
+              offer: {
+                id: "offer_1",
+                name: "Early booking",
+                slug: "early-booking",
+                description: null,
+                discountType: "percentage",
+                discountValue: "15",
+                currency: null,
+                applicableProductIds: ["prod_123"],
+                applicableDepartureIds: [],
+                validFrom: null,
+                validTo: null,
+                minTravelers: null,
+                imageMobileUrl: null,
+                imageDesktopUrl: null,
+                stackable: false,
+                createdAt: "2026-04-01T00:00:00.000Z",
+                updatedAt: "2026-04-01T00:00:00.000Z",
+              },
+              target: {
+                bookingId: "book_123",
+                sessionId: null,
+                productId: "prod_123",
+                departureId: null,
+              },
+              pricing: {
+                basePriceCents: 10000,
+                currency: "USD",
+                discountAppliedCents: 1500,
+                discountedPriceCents: 8500,
+              },
+              appliedOffers: [
+                {
+                  offerId: "offer_1",
+                  offerName: "Early booking",
+                  discountAppliedCents: 1500,
+                  discountedPriceCents: 8500,
+                  currency: "USD",
+                  discountKind: "percentage",
+                  discountPercent: 15,
+                  discountAmountCents: null,
+                  appliedCode: null,
+                  stackable: false,
+                },
+              ],
+              conflict: null,
+            }
+          },
+        },
+      }),
+    )
+
+    const res = await app.request("/offers/early-booking/apply", {
+      method: "POST",
+      body: JSON.stringify({
+        productId: "prod_123",
+        bookingId: "book_123",
+        basePriceCents: 10000,
+        currency: "usd",
+      }),
+      headers: { "content-type": "application/json" },
+    })
+
+    expect(res.status).toBe(200)
+    expect((await res.json()).data.pricing.discountedPriceCents).toBe(8500)
+  })
+
+  it("redeems a code-based storefront offer through the injected resolver", async () => {
+    const app = new Hono().route(
+      "/",
+      createStorefrontPublicRoutes({
+        offers: {
+          redeemOffer({ body }) {
+            expect(body.code).toBe("SPRING25")
+            return {
+              status: "invalid",
+              reason: "code_expired",
+              offer: null,
+              target: {
+                bookingId: null,
+                sessionId: "sess_123",
+                productId: "prod_123",
+                departureId: null,
+              },
+              pricing: {
+                basePriceCents: 10000,
+                currency: "EUR",
+                discountAppliedCents: 0,
+                discountedPriceCents: 10000,
+              },
+              appliedOffers: [],
+              conflict: null,
+            }
+          },
+        },
+      }),
+    )
+
+    const res = await app.request("/offers/redeem", {
+      method: "POST",
+      body: JSON.stringify({
+        code: "SPRING25",
+        productId: "prod_123",
+        sessionId: "sess_123",
+        basePriceCents: 10000,
+        currency: "EUR",
+      }),
+      headers: { "content-type": "application/json" },
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({
+      data: {
+        status: "invalid",
+        reason: "code_expired",
+      },
+    })
+  })
+
+  it("returns 501 when offer mutation resolvers are not configured", async () => {
+    const app = new Hono().route("/", createStorefrontPublicRoutes())
+
+    const res = await app.request("/offers/redeem", {
+      method: "POST",
+      body: JSON.stringify({
+        code: "SPRING25",
+        productId: "prod_123",
+        basePriceCents: 10000,
+        currency: "USD",
+      }),
+      headers: { "content-type": "application/json" },
+    })
+
+    expect(res.status).toBe(501)
+  })
 })

--- a/packages/storefront/tests/unit/public-routes.test.ts
+++ b/packages/storefront/tests/unit/public-routes.test.ts
@@ -359,6 +359,7 @@ describe("createStorefrontPublicRoutes", () => {
               productId: "prod_123",
               basePriceCents: 10000,
               currency: "USD",
+              pax: 2,
               audience: "customer",
               market: "default",
             })
@@ -425,6 +426,7 @@ describe("createStorefrontPublicRoutes", () => {
         bookingId: "book_123",
         basePriceCents: 10000,
         currency: "usd",
+        pax: 2,
       }),
       headers: { "content-type": "application/json" },
     })
@@ -472,6 +474,7 @@ describe("createStorefrontPublicRoutes", () => {
         sessionId: "sess_123",
         basePriceCents: 10000,
         currency: "EUR",
+        pax: 2,
       }),
       headers: { "content-type": "application/json" },
     })
@@ -495,6 +498,7 @@ describe("createStorefrontPublicRoutes", () => {
         productId: "prod_123",
         basePriceCents: 10000,
         currency: "USD",
+        pax: 2,
       }),
       headers: { "content-type": "application/json" },
     })


### PR DESCRIPTION
## Summary

Closes #878.

Adds customer-facing storefront promotional-offer mutation contracts:

- `POST /v1/public/offers/:slug/apply`
- `POST /v1/public/offers/redeem`

Wires the storefront resolver surface through `@voyantjs/promotions` using the existing promotion evaluator, so manual/code offer conflict behavior stays aligned with quote-time pricing. Adds typed `@voyantjs/storefront-react` operations and mutation hooks, route tests, docs, and a changeset.

## Validation

- `pnpm --filter @voyantjs/storefront test`
- `pnpm --filter @voyantjs/storefront typecheck`
- `pnpm --filter @voyantjs/storefront-react typecheck`
- `pnpm --filter @voyantjs/promotions test`
- `pnpm --filter @voyantjs/promotions typecheck`
- `pnpm --filter @voyantjs/storefront lint`
- `pnpm --filter @voyantjs/storefront-react lint`
- `pnpm --filter @voyantjs/promotions lint`
- `pnpm verify:fast`

Notes: `verify:fast` passes with report-only file-size warnings on changed storefront files (`validation.ts`, `public-routes.test.ts`). Commit and push hooks also ran lint/typecheck/test successfully.