### PR TITLE
Add API token rotation

### DIFF
--- a/.changeset/modern-tokens-rotate.md
+++ b/.changeset/modern-tokens-rotate.md
@@ -1,0 +1,9 @@
+---
+"@voyantjs/auth": minor
+"@voyantjs/auth-react": minor
+"@voyantjs/auth-ui": minor
+"@voyantjs/hono": minor
+"@voyantjs/core": minor
+---
+
+Add first-class API token rotation and audit-facing token context. The auth facade now supports `POST /auth/api-tokens/:keyId/rotate`, the React hooks and UI expose rotation, and Hono request context includes `apiTokenId` for downstream audit log writers.

--- a/docs/architecture/service-api-keys.md
+++ b/docs/architecture/service-api-keys.md
@@ -95,6 +95,11 @@ Examples:
 Session callers still use the normal actor checks. Internal requests still
 bypass the actor guard through `isInternalRequest`.
 
+When a `voy_` token authenticates, the auth middleware also sets
+`callerType: "api_key"`, `apiTokenId`, the legacy alias `apiKeyId`, and
+`scopes` on the request context. Audit-log consumers should record
+`apiTokenId` instead of the raw bearer secret.
+
 ## Creating Tokens
 
 Use the operator template's Settings -> API Tokens screen, or call Voyant's
@@ -122,3 +127,20 @@ automation secret store, then use it as:
 ```http
 Authorization: Bearer voy_...
 ```
+
+## Rotating Tokens
+
+Operators can rotate a token secret without replacing the token record:
+
+```ts
+await fetch("/auth/api-tokens/key_123/rotate", {
+  method: "POST",
+})
+```
+
+Rotation returns a new one-time `key` value, preserves the existing token id,
+name, permissions, usage counters, and expiration, and updates the stored hash
+so the previous secret stops authenticating immediately. The facade appends
+non-secret rotation metadata under `metadata.voyant.apiToken`, including the
+last rotation timestamp and previous displayed starts. Do not log the returned
+secret after handing it to the operator.

--- a/packages/auth-react/src/hooks/index.ts
+++ b/packages/auth-react/src/hooks/index.ts
@@ -55,6 +55,8 @@ export {
   type CreateServiceApiKeyInput,
   type DeleteApiTokenInput,
   type DeleteServiceApiKeyInput,
+  type RotateApiTokenInput,
+  type RotateServiceApiKeyInput,
   type UpdateApiTokenInput,
   type UpdateServiceApiKeyInput,
   useApiTokenMutation,

--- a/packages/auth-react/src/hooks/use-service-api-key-mutation.ts
+++ b/packages/auth-react/src/hooks/use-service-api-key-mutation.ts
@@ -37,6 +37,13 @@ export interface UpdateServiceApiKeyInput {
 
 export type UpdateApiTokenInput = UpdateServiceApiKeyInput
 
+export interface RotateServiceApiKeyInput {
+  keyId: string
+  configId?: string
+}
+
+export type RotateApiTokenInput = RotateServiceApiKeyInput
+
 export interface DeleteServiceApiKeyInput {
   keyId: string
   configId?: string
@@ -96,6 +103,20 @@ export function useServiceApiKeyMutation() {
     onSuccess: () => invalidateApiKeyQueries(queryClient),
   })
 
+  const rotate = useMutation({
+    mutationFn: async (input: RotateServiceApiKeyInput) =>
+      fetchWithValidation(
+        `/auth/api-tokens/${encodeURIComponent(input.keyId)}/rotate`,
+        serviceApiKeyWithSecretSchema,
+        { baseUrl, fetcher },
+        {
+          method: "POST",
+          body: JSON.stringify({ configId: input.configId }),
+        },
+      ),
+    onSuccess: () => invalidateApiKeyQueries(queryClient),
+  })
+
   const remove = useMutation({
     mutationFn: async (input: DeleteServiceApiKeyInput) =>
       fetchWithValidation(
@@ -107,7 +128,7 @@ export function useServiceApiKeyMutation() {
     onSuccess: () => invalidateApiKeyQueries(queryClient),
   })
 
-  return { create, update, remove }
+  return { create, update, rotate, remove }
 }
 
 export const useApiTokenMutation = useServiceApiKeyMutation

--- a/packages/auth-ui/src/components/service-api-keys-page.tsx
+++ b/packages/auth-ui/src/components/service-api-keys-page.tsx
@@ -131,7 +131,7 @@ export function ServiceApiKeysPage({
   const [selectedPermissions, setSelectedPermissions] = useState<ApiKeyPermissions>({
     ...API_KEY_PERMISSION_PRESETS["catalog-read"].permissions,
   })
-  const [createdKey, setCreatedKey] = useState<ApiTokenWithSecret | null>(null)
+  const [issuedKey, setIssuedKey] = useState<ApiTokenWithSecret | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   const selectedDescription = useMemo(
@@ -150,7 +150,7 @@ export function ServiceApiKeysPage({
   const handleCreate = async (event: FormEvent) => {
     event.preventDefault()
     setError(null)
-    setCreatedKey(null)
+    setIssuedKey(null)
 
     if (!name.trim()) {
       setError(messages.create.errors.nameRequired)
@@ -168,7 +168,7 @@ export function ServiceApiKeysPage({
         permissions: selectedPermissions,
         expiresIn: expiresInSeconds(expirationDays),
       })
-      setCreatedKey(result)
+      setIssuedKey(result)
       setName("")
     } catch (err) {
       setError(err instanceof Error ? err.message : messages.create.errors.createFailed)
@@ -182,7 +182,7 @@ export function ServiceApiKeysPage({
         <p className="text-sm text-muted-foreground">{pageDescription}</p>
       </div>
 
-      {createdKey && (
+      {issuedKey && (
         <Card className="border-primary/30 bg-primary/5">
           <CardHeader>
             <CardTitle className="flex items-center gap-2 text-base">
@@ -192,13 +192,13 @@ export function ServiceApiKeysPage({
             <CardDescription>{messages.createdToken.description}</CardDescription>
           </CardHeader>
           <CardContent className="flex flex-col gap-3 sm:flex-row">
-            <Input value={createdKey.key} readOnly className="font-mono text-xs" />
+            <Input value={issuedKey.key} readOnly className="font-mono text-xs" />
             <Button
               type="button"
               variant="outline"
-              onClick={() => void clipboard.copy(createdKey.id, createdKey.key)}
+              onClick={() => void clipboard.copy(issuedKey.id, issuedKey.key)}
             >
-              {clipboard.copied === createdKey.id ? (
+              {clipboard.copied === issuedKey.id ? (
                 <Check className="mr-2 h-4 w-4" />
               ) : (
                 <Copy className="mr-2 h-4 w-4" />
@@ -344,7 +344,12 @@ export function ServiceApiKeysPage({
       ) : keys.data?.apiKeys.length ? (
         <div className="space-y-3">
           {keys.data.apiKeys.map((key) => (
-            <ServiceApiKeyRow key={key.id} apiKey={key} />
+            <ServiceApiKeyRow
+              key={key.id}
+              apiKey={key}
+              onError={setError}
+              onSecretIssued={setIssuedKey}
+            />
           ))}
         </div>
       ) : (
@@ -360,11 +365,33 @@ export function ServiceApiKeysPage({
 
 export const ApiTokensPage = ServiceApiKeysPage
 
-function ServiceApiKeyRow({ apiKey }: { apiKey: ApiToken }) {
+function ServiceApiKeyRow({
+  apiKey,
+  onError,
+  onSecretIssued,
+}: {
+  apiKey: ApiToken
+  onError: (error: string | null) => void
+  onSecretIssued: (apiKey: ApiTokenWithSecret) => void
+}) {
   const i18n = useAuthUiI18nOrDefault()
   const messages = i18n.messages.serviceApiKeysPage
   const mutations = useApiTokenMutation()
   const enabled = apiKey.enabled !== false
+  const rotateToken = async () => {
+    if (!window.confirm(messages.list.rotateConfirm)) return
+    onError(null)
+
+    try {
+      const result = await mutations.rotate.mutateAsync({
+        keyId: apiKey.id,
+        configId: apiKey.configId,
+      })
+      onSecretIssued(result)
+    } catch (err) {
+      onError(err instanceof Error ? err.message : messages.list.rotateFailed)
+    }
+  }
 
   return (
     <Card>
@@ -408,6 +435,20 @@ function ServiceApiKeyRow({ apiKey }: { apiKey: ApiToken }) {
           >
             {enabled ? <PowerOff className="mr-2 h-4 w-4" /> : <Power className="mr-2 h-4 w-4" />}
             {enabled ? messages.list.disable : messages.list.enable}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={mutations.rotate.isPending}
+            onClick={() => void rotateToken()}
+          >
+            {mutations.rotate.isPending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <RefreshCw className="mr-2 h-4 w-4" />
+            )}
+            {messages.list.rotate}
           </Button>
           <Button
             type="button"

--- a/packages/auth-ui/src/i18n/en.ts
+++ b/packages/auth-ui/src/i18n/en.ts
@@ -198,8 +198,8 @@ export const authUiEn: AuthUiMessages = {
     description:
       "Create permissioned API tokens for automation, integrations, and third-party systems.",
     createdToken: {
-      title: "New token",
-      description: "This token is shown once. Store it before leaving.",
+      title: "Token secret",
+      description: "This token secret is shown once. Store it before leaving.",
       copy: "Copy",
     },
     create: {
@@ -233,6 +233,9 @@ export const authUiEn: AuthUiMessages = {
       metadata: "Created {created} · Expires {expires} · Last used {lastUsed}",
       disable: "Disable",
       enable: "Enable",
+      rotate: "Rotate",
+      rotateConfirm: "Rotate this token secret? The current secret will stop working.",
+      rotateFailed: "Could not rotate API token.",
       delete: "Delete",
     },
     permissions: {

--- a/packages/auth-ui/src/i18n/messages.ts
+++ b/packages/auth-ui/src/i18n/messages.ts
@@ -260,6 +260,9 @@ export type AuthUiMessages = {
       metadata: string
       disable: string
       enable: string
+      rotate: string
+      rotateConfirm: string
+      rotateFailed: string
       delete: string
     }
     permissions: {

--- a/packages/auth-ui/src/i18n/ro.ts
+++ b/packages/auth-ui/src/i18n/ro.ts
@@ -199,8 +199,8 @@ export const authUiRo: AuthUiMessages = {
     description:
       "Creeaza tokenuri API cu permisiuni pentru automatizari, integrari si sisteme terte.",
     createdToken: {
-      title: "Token nou",
-      description: "Acest token este afisat o singura data. Salveaza-l inainte sa pleci.",
+      title: "Secret token",
+      description: "Acest secret de token este afisat o singura data. Salveaza-l inainte sa pleci.",
       copy: "Copiaza",
     },
     create: {
@@ -234,6 +234,9 @@ export const authUiRo: AuthUiMessages = {
       metadata: "Creat {created} · Expira {expires} · Ultima utilizare {lastUsed}",
       disable: "Dezactiveaza",
       enable: "Activeaza",
+      rotate: "Roteste",
+      rotateConfirm: "Rotesti secretul acestui token? Secretul curent nu va mai functiona.",
+      rotateFailed: "Tokenul API nu a putut fi rotit.",
       delete: "Sterge",
     },
     permissions: {

--- a/packages/auth/src/api-token-rotation.ts
+++ b/packages/auth/src/api-token-rotation.ts
@@ -1,0 +1,213 @@
+import type { getDb } from "@voyantjs/db"
+import { apikeyTable, type SelectApikey } from "@voyantjs/db/schema/iam"
+import { eq } from "drizzle-orm"
+
+const API_TOKEN_SECRET_PREFIX = "voy_"
+const API_TOKEN_SECRET_LENGTH = 64
+const API_TOKEN_SECRET_ALPHABET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+type ApiTokenRotationRow = Pick<
+  SelectApikey,
+  | "id"
+  | "configId"
+  | "name"
+  | "start"
+  | "prefix"
+  | "referenceId"
+  | "enabled"
+  | "rateLimitEnabled"
+  | "rateLimitTimeWindow"
+  | "rateLimitMax"
+  | "requestCount"
+  | "remaining"
+  | "lastRequest"
+  | "createdAt"
+  | "updatedAt"
+  | "expiresAt"
+  | "permissions"
+  | "metadata"
+>
+
+interface ApiTokenSecretRotation {
+  keyHash: string
+  start: string
+  updatedAt: Date
+  metadata: string | null
+}
+
+type ApiTokenRotationDb = Pick<ReturnType<typeof getDb>, "select" | "update">
+
+export interface ApiTokenRotationStore {
+  getApiToken(keyId: string): Promise<ApiTokenRotationRow | null>
+  rotateApiTokenSecret(
+    keyId: string,
+    rotation: ApiTokenSecretRotation,
+  ): Promise<ApiTokenRotationRow | null>
+}
+
+export interface ApiTokenRotationOptions {
+  db?: ApiTokenRotationDb
+  rotationStore?: ApiTokenRotationStore
+  generateApiTokenSecret?: (prefix: string) => string
+}
+
+interface RotateApiTokenSecretArgs {
+  keyId: string
+  body: Record<string, unknown>
+  userId: string
+  options: ApiTokenRotationOptions
+  authorize: (input: {
+    keyId: string
+    configId?: string
+    enabled: boolean
+    userId: string
+  }) => Promise<void>
+}
+
+function encodeBase64Url(bytes: Uint8Array): string {
+  let binary = ""
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+}
+
+async function sha256Base64Url(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input)
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data)
+  return encodeBase64Url(new Uint8Array(hashBuffer))
+}
+
+function generateApiTokenSecret(prefix: string): string {
+  let secret = prefix
+
+  while (secret.length < prefix.length + API_TOKEN_SECRET_LENGTH) {
+    const bytes = new Uint8Array(API_TOKEN_SECRET_LENGTH)
+    crypto.getRandomValues(bytes)
+
+    for (const byte of bytes) {
+      if (byte >= 208) continue
+      secret += API_TOKEN_SECRET_ALPHABET[byte % API_TOKEN_SECRET_ALPHABET.length]
+      if (secret.length >= prefix.length + API_TOKEN_SECRET_LENGTH) break
+    }
+  }
+
+  return secret
+}
+
+function parseJsonObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || value === undefined) return null
+  if (typeof value === "object" && !Array.isArray(value)) return value as Record<string, unknown>
+  if (typeof value !== "string" || value.trim().length === 0) return null
+
+  try {
+    const parsed = JSON.parse(value) as unknown
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null
+  } catch {
+    return null
+  }
+}
+
+function appendRotationMetadata(metadata: unknown, rotatedAt: Date, previousStart: string | null) {
+  const parsed = parseJsonObject(metadata) ?? {}
+  const voyant = parseJsonObject(parsed.voyant) ?? {}
+  const apiToken = parseJsonObject(voyant.apiToken) ?? {}
+  const previousStarts = Array.isArray(apiToken.previousStarts)
+    ? apiToken.previousStarts.filter((value): value is string => typeof value === "string")
+    : []
+
+  return {
+    ...parsed,
+    voyant: {
+      ...voyant,
+      apiToken: {
+        ...apiToken,
+        rotationCount: Number(apiToken.rotationCount ?? 0) + 1,
+        lastRotatedAt: rotatedAt.toISOString(),
+        previousStarts: previousStart
+          ? Array.from(new Set([previousStart, ...previousStarts])).slice(0, 10)
+          : previousStarts,
+      },
+    },
+  }
+}
+
+function serializeApiTokenRow(row: ApiTokenRotationRow, key?: string) {
+  return {
+    ...row,
+    ...(key ? { key } : {}),
+    metadata: parseJsonObject(row.metadata),
+    permissions: parseJsonObject(row.permissions),
+  }
+}
+
+function createDrizzleApiTokenRotationStore(db: ApiTokenRotationDb): ApiTokenRotationStore {
+  return {
+    async getApiToken(keyId) {
+      const [row] = await db.select().from(apikeyTable).where(eq(apikeyTable.id, keyId)).limit(1)
+      return row ?? null
+    },
+    async rotateApiTokenSecret(keyId, rotation) {
+      const [row] = await db
+        .update(apikeyTable)
+        .set({
+          key: rotation.keyHash,
+          start: rotation.start,
+          updatedAt: rotation.updatedAt,
+          metadata: rotation.metadata,
+        })
+        .where(eq(apikeyTable.id, keyId))
+        .returning()
+      return row ?? null
+    },
+  }
+}
+
+export async function rotateApiTokenSecret({
+  keyId,
+  body,
+  userId,
+  options,
+  authorize,
+}: RotateApiTokenSecretArgs) {
+  const rotationStore =
+    options.rotationStore ??
+    (options.db ? createDrizzleApiTokenRotationStore(options.db) : undefined)
+
+  if (!rotationStore) {
+    throw Object.assign(new Error("API token rotation requires a rotation store"), {
+      status: 500,
+    })
+  }
+
+  const existing = await rotationStore.getApiToken(keyId)
+  if (!existing) {
+    throw Object.assign(new Error("API token not found"), { status: 404 })
+  }
+
+  await authorize({
+    keyId,
+    userId,
+    enabled: existing.enabled,
+    configId: typeof body.configId === "string" ? body.configId : undefined,
+  })
+
+  const prefix = existing.prefix ?? API_TOKEN_SECRET_PREFIX
+  const key = (options.generateApiTokenSecret ?? generateApiTokenSecret)(prefix)
+  const now = new Date()
+  const metadata = appendRotationMetadata(existing.metadata, now, existing.start)
+  const updated = await rotationStore.rotateApiTokenSecret(keyId, {
+    keyHash: await sha256Base64Url(key),
+    start: key.substring(0, 6),
+    updatedAt: now,
+    metadata: JSON.stringify(metadata),
+  })
+
+  if (!updated) {
+    throw Object.assign(new Error("API token not found"), { status: 404 })
+  }
+
+  return serializeApiTokenRow(updated, key)
+}

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -15,6 +15,11 @@ import type { BetterAuthPlugin } from "better-auth/types"
 import { sql } from "drizzle-orm"
 
 import {
+  type ApiTokenRotationOptions,
+  type ApiTokenRotationStore,
+  rotateApiTokenSecret,
+} from "./api-token-rotation.js"
+import {
   type CurrentUser,
   type UpdateCurrentUserProfileInput,
   updateCurrentUserProfile,
@@ -38,7 +43,7 @@ export type BetterAuthApiTokenManagement = {
   api: BetterAuthApiKeyApi
 }
 
-export interface HandleApiTokenManagementRequestOptions {
+export interface HandleApiTokenManagementRequestOptions extends ApiTokenRotationOptions {
   /**
    * Auth route mount path. Voyant operator APIs mount Better Auth under
    * `/auth`, which makes the facade routes `/auth/api-tokens`.
@@ -91,6 +96,8 @@ const API_TOKEN_UPDATE_FIELDS = [
   "metadata",
   "permissions",
 ] as const
+
+export type { ApiTokenRotationStore }
 
 export function getAuthSecret(): string {
   const secret = process.env.BETTER_AUTH_SECRET || process.env.SESSION_CLAIMS_SECRET || ""
@@ -250,15 +257,7 @@ async function requireAccountProfileSession(auth: BetterAuthApiTokenManagement, 
   return session
 }
 
-/**
- * Handles Voyant's stable account-profile update facade:
- *
- * - `PATCH /auth/me`
- *
- * Apps can mount this before falling through to `auth.handler(request)` for
- * the rest of Better Auth. The route updates only the current session user's
- * non-sensitive `user_profiles` fields.
- */
+/** Handles Voyant's stable `PATCH /auth/me` account-profile facade. */
 export async function handleAccountProfileRequest(
   request: Request,
   auth: { api: unknown },
@@ -291,21 +290,8 @@ export async function handleAccountProfileRequest(
 }
 
 /**
- * Handles Voyant's stable API-token management facade:
- *
- * - `GET /auth/api-tokens`
- * - `POST /auth/api-tokens`
- * - `POST /auth/api-tokens/:keyId`
- * - `DELETE /auth/api-tokens/:keyId`
- *
- * Better Auth's API Key plugin exposes canonical routes under
- * `/auth/api-key/*`, but its HTTP client rejects server-only fields such as
- * `permissions`, `remaining`, and `enabled`. Voyant's management UI needs
- * those fields, so this facade calls the Better Auth server API and attaches
- * the signed-in user's id where required.
- *
- * Returns `null` when the request is outside the facade path, allowing callers
- * to fall through to `auth.handler(request)` for the rest of Better Auth.
+ * Handles Voyant's stable `/auth/api-tokens` management facade, including
+ * create, list, update, delete, and secret rotation.
  */
 export async function handleApiTokenManagementRequest(
   request: Request,
@@ -316,6 +302,7 @@ export async function handleApiTokenManagementRequest(
   if (path === null) return null
 
   const api = auth.api as BetterAuthApiKeyApi
+  const rotateMatch = path.match(/^\/api-tokens\/([^/]+)\/rotate$/)
   const keyMatch = path.match(/^\/api-tokens\/([^/]+)$/)
 
   try {
@@ -341,6 +328,32 @@ export async function handleApiTokenManagementRequest(
       }
 
       return methodNotAllowed(["GET", "POST"])
+    }
+
+    if (rotateMatch?.[1]) {
+      if (request.method !== "POST") return methodNotAllowed(["POST"])
+
+      const keyId = decodeURIComponent(rotateMatch[1])
+      const body = await readOptionalJson(request)
+      const session = await requireApiTokenSession({ api }, request.headers)
+      const result = await rotateApiTokenSecret({
+        keyId,
+        body,
+        userId: session.user.id,
+        options,
+        authorize: async ({ configId, enabled, keyId, userId }) => {
+          await api.updateApiKey({
+            body: {
+              ...(configId ? { configId } : {}),
+              keyId,
+              enabled,
+              userId,
+            },
+          })
+        },
+      })
+
+      return jsonResponse(result)
     }
 
     if (keyMatch?.[1]) {

--- a/packages/auth/tests/unit/api-tokens.test.ts
+++ b/packages/auth/tests/unit/api-tokens.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest"
 
 import {
+  type ApiTokenRotationStore,
   type BetterAuthApiTokenManagement,
   handleApiTokenManagementRequest,
 } from "../../src/server.js"
@@ -29,6 +30,49 @@ function createAuthMock(): BetterAuthApiTokenManagement {
 async function responseJson(response: Response | null): Promise<unknown> {
   expect(response).not.toBeNull()
   return response?.json()
+}
+
+async function sha256Base64Url(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input)
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data)
+  let binary = ""
+  for (const byte of new Uint8Array(hashBuffer)) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+}
+
+function createRotationStore() {
+  const row = {
+    id: "key_123",
+    configId: "default",
+    name: "CMS sync",
+    start: "voy_ol",
+    prefix: "voy_",
+    referenceId: "user_123",
+    enabled: true,
+    rateLimitEnabled: false,
+    rateLimitTimeWindow: null,
+    rateLimitMax: null,
+    requestCount: 12,
+    remaining: null,
+    lastRequest: new Date("2026-05-11T00:00:00.000Z"),
+    createdAt: new Date("2026-05-10T00:00:00.000Z"),
+    updatedAt: new Date("2026-05-11T00:00:00.000Z"),
+    expiresAt: null,
+    permissions: JSON.stringify({ products: ["read"] }),
+    metadata: JSON.stringify({ owner: "integrations" }),
+  }
+  const store: ApiTokenRotationStore = {
+    getApiToken: vi.fn(async () => row as never),
+    rotateApiTokenSecret: vi.fn(async (_keyId, rotation) => ({
+      ...row,
+      start: rotation.start,
+      updatedAt: rotation.updatedAt,
+      metadata: rotation.metadata,
+    })),
+  }
+  return { row, store }
 }
 
 describe("handleApiTokenManagementRequest", () => {
@@ -141,6 +185,72 @@ describe("handleApiTokenManagementRequest", () => {
       body: { configId: "default", keyId: "key_123" },
       headers: expect.any(Headers),
     })
+  })
+
+  it("rotates API tokens while preserving id, permissions, usage metadata, and audit history", async () => {
+    const auth = createAuthMock()
+    const { store } = createRotationStore()
+    const oldHash = await sha256Base64Url("voy_oldsecret")
+
+    const response = await handleApiTokenManagementRequest(
+      new Request("https://example.com/auth/api-tokens/key_123/rotate", {
+        method: "POST",
+      }),
+      auth,
+      {
+        rotationStore: store,
+        generateApiTokenSecret: () => "voy_newsecret",
+      },
+    )
+
+    expect(response?.status).toBe(200)
+    expect(auth.api.updateApiKey).toHaveBeenCalledWith({
+      body: {
+        keyId: "key_123",
+        enabled: true,
+        userId: "user_123",
+      },
+    })
+    expect(store.rotateApiTokenSecret).toHaveBeenCalledWith(
+      "key_123",
+      expect.objectContaining({
+        keyHash: await sha256Base64Url("voy_newsecret"),
+        start: "voy_ne",
+      }),
+    )
+    expect(store.rotateApiTokenSecret).not.toHaveBeenCalledWith(
+      "key_123",
+      expect.objectContaining({ keyHash: oldHash }),
+    )
+
+    const body = (await responseJson(response)) as {
+      id: string
+      key: string
+      requestCount: number
+      permissions: Record<string, string[]>
+      metadata: { voyant?: { apiToken?: { previousStarts?: string[]; rotationCount?: number } } }
+    }
+    expect(body).toMatchObject({
+      id: "key_123",
+      key: "voy_newsecret",
+      requestCount: 12,
+      permissions: { products: ["read"] },
+    })
+    expect(body.metadata.voyant?.apiToken?.rotationCount).toBe(1)
+    expect(body.metadata.voyant?.apiToken?.previousStarts).toContain("voy_ol")
+  })
+
+  it("requires POST for API token rotation", async () => {
+    const auth = createAuthMock()
+    const response = await handleApiTokenManagementRequest(
+      new Request("https://example.com/auth/api-tokens/key_123/rotate", { method: "GET" }),
+      auth,
+      { rotationStore: createRotationStore().store },
+    )
+
+    expect(response?.status).toBe(405)
+    expect(response?.headers.get("Allow")).toBe("POST")
+    expect(auth.api.updateApiKey).not.toHaveBeenCalled()
   })
 
   it("normalizes missing sessions to 401 responses", async () => {

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -17,6 +17,7 @@ export interface VoyantAuthContext {
   actor?: Actor
   scopes?: string[] | null
   isInternalRequest?: boolean
+  apiTokenId?: string
   apiKeyId?: string
   email?: string | null
 }

--- a/packages/hono/src/middleware/auth.ts
+++ b/packages/hono/src/middleware/auth.ts
@@ -29,6 +29,7 @@ function applyAuthContext(
   if (auth.actor) c.set("actor", auth.actor)
   if (auth.scopes !== undefined) c.set("scopes", auth.scopes)
   if (auth.isInternalRequest !== undefined) c.set("isInternalRequest", auth.isInternalRequest)
+  if (auth.apiTokenId) c.set("apiTokenId", auth.apiTokenId)
   if (auth.apiKeyId) c.set("apiKeyId", auth.apiKeyId)
 }
 
@@ -133,6 +134,7 @@ export function requireAuth<TBindings extends VoyantBindings>(
           organizationId: row.referenceId,
           scopes,
           callerType: "api_key",
+          apiTokenId: row.id,
           apiKeyId: row.id,
           // Core-owned API keys (`voy_` prefix) are server-to-server credentials
           // issued to operator staff. The actor stays explicit here so that

--- a/packages/hono/src/middleware/require-permission.ts
+++ b/packages/hono/src/middleware/require-permission.ts
@@ -80,6 +80,7 @@ export function requirePermission<TBindings extends VoyantBindings>(
           callerType: c.get("callerType"),
           scopes,
           isInternalRequest: c.get("isInternalRequest"),
+          apiTokenId: c.get("apiTokenId"),
           apiKeyId: c.get("apiKeyId"),
         },
         permission,

--- a/packages/hono/tests/unit/require-actor.test.ts
+++ b/packages/hono/tests/unit/require-actor.test.ts
@@ -133,6 +133,22 @@ describe("requireActor", () => {
     expect(body.error).toMatch(/required permission/)
   })
 
+  it("applies API key permissions to the route resource prefix only", async () => {
+    const app = makeApp((c) => {
+      c.set("callerType", "api_key")
+      c.set("scopes", ["products:read"])
+    })
+    app.use("*", requireActor("staff"))
+    app.get("/v1/admin/products/:id/media", (c) => c.json({ ok: true }))
+    app.get("/v1/admin/bookings/:id", (c) => c.json({ ok: true }))
+
+    const products = await app.request("/v1/admin/products/prod_1/media")
+    const bookings = await app.request("/v1/admin/bookings/book_1")
+
+    expect(products.status).toBe(200)
+    expect(bookings.status).toBe(403)
+  })
+
   it("allows workflow trigger and webhook relay API key permissions on POST routes", async () => {
     const app = makeApp((c) => {
       c.set("callerType", "api_key")

--- a/packages/hono/tests/unit/require-permission.test.ts
+++ b/packages/hono/tests/unit/require-permission.test.ts
@@ -75,6 +75,45 @@ describe("requirePermission", () => {
     expect(hasPermission).toHaveBeenCalledTimes(1)
   })
 
+  it("passes API token audit metadata to custom permission checkers", async () => {
+    const hasPermission = vi.fn().mockResolvedValue(true)
+
+    const app = new Hono()
+    app.use("*", async (c, next) => {
+      c.set("userId", "user_123")
+      c.set("actor", "staff")
+      c.set("callerType", "api_key")
+      c.set("apiTokenId", "key_123")
+      c.set("apiKeyId", "key_123")
+      c.set("scopes", [])
+      await next()
+    })
+    app.use(
+      "*",
+      requirePermission(() => ({}) as never, "crm", "write", {
+        auth: { hasPermission },
+      }),
+    )
+    app.get("/secure", (c) => c.json({ ok: true }))
+
+    const response = await app.fetch(
+      new Request("http://example.com/secure"),
+      {},
+      mockExecutionCtx(),
+    )
+
+    expect(response.status).toBe(200)
+    expect(hasPermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auth: expect.objectContaining({
+          apiTokenId: "key_123",
+          apiKeyId: "key_123",
+          scopes: [],
+        }),
+      }),
+    )
+  })
+
   it("returns 401 when userId is set but actor is not (upstream wiring bug)", async () => {
     // `requirePermission` runs after `requireActor`. If actor is missing here,
     // it means the auth pipeline silently let an unresolved request through —

--- a/templates/operator/src/api/auth/handler.ts
+++ b/templates/operator/src/api/auth/handler.ts
@@ -339,8 +339,9 @@ async function handleApiTokensFacade(c: Context<AuthHonoEnv>) {
   try {
     const betterAuth = buildBetterAuth(c.env, db)
     return (
-      (await handleApiTokenManagementRequest(c.req.raw, betterAuth)) ??
-      c.json({ error: "Not found" }, 404)
+      (await handleApiTokenManagementRequest(c.req.raw, betterAuth, {
+        db,
+      })) ?? c.json({ error: "Not found" }, 404)
     )
   } finally {
     c.executionCtx.waitUntil(dispose())
@@ -349,6 +350,7 @@ async function handleApiTokensFacade(c: Context<AuthHonoEnv>) {
 
 auth.all("/auth/api-tokens", handleApiTokensFacade)
 auth.all("/auth/api-tokens/:keyId", handleApiTokensFacade)
+auth.all("/auth/api-tokens/:keyId/rotate", handleApiTokensFacade)
 
 /**
  * Catch-all: delegate to Better Auth handler.


### PR DESCRIPTION
Closes #879

## Summary
- Add a service API token rotation endpoint that authorizes through Better Auth, replaces the stored secret hash, and preserves token identity, scopes, metadata, counters, and expiration.
- Wire rotation through the operator auth handler, React mutation hook, and service API keys UI with one-time secret display after rotate.
- Add audit-facing API token context via `apiTokenId` while preserving the existing `apiKeyId`, and document scoped service API key rotation behavior.
- Add a changeset for the affected auth, auth-react, auth-ui, hono, and core packages.

## Security Notes
- Raw token secrets are only returned on create/rotate responses and are not persisted in metadata.
- Rotation stores a new SHA-256 base64url hash and no longer accepts/retains the previous raw secret hash in tests.
- Rotation metadata records non-secret display prefixes and rotation timestamps/counts for audit/debug context.

## Validation
- `pnpm verify:fast`
- `pnpm --filter @voyantjs/auth test`
- `pnpm --filter @voyantjs/hono test`
- `pnpm --filter @voyantjs/auth typecheck`
- `pnpm --filter @voyantjs/auth-react typecheck`
- `pnpm --filter @voyantjs/auth-ui typecheck`
- `pnpm --filter @voyantjs/hono typecheck`
- `pnpm --filter @voyantjs/core typecheck`
- `pnpm --filter operator typecheck`
- `pnpm --filter @voyantjs/auth lint`
- `pnpm --filter operator lint`
- Push hook also ran `pnpm test`: 125 successful, 125 total.

## Notes
- Browser screenshot was attempted against local operator at `/settings/api-tokens`, but the route cannot render in this worktree without local current-user/auth setup; the captured page was the expected current-user fetch error rather than useful UI evidence.
- `pnpm verify:agent-quality:changed` is report-only and still reports existing operator handler unsafe casts plus existing lint-disable warnings; the new changed auth server file is 591 lines, above the report-only 500-line warning threshold.