### PR TITLE
Add booking workspace page

### DIFF
--- a/.changeset/booking-workspace-page.md
+++ b/.changeset/booking-workspace-page.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/bookings-ui": minor
+---
+
+Add `BookingWorkspacePage`, a reusable operator workspace shell that mounts `BookingDetailPage` with cross-module navigation, typed slots, sidebars, and bulk-action context.

--- a/packages/bookings-ui/README.md
+++ b/packages/bookings-ui/README.md
@@ -18,11 +18,35 @@ that spacing when a shell owns the page chrome.
 
 ## Components
 
-- `BookingsPage`, `BookingDetailPage`
+- `BookingsPage`, `BookingDetailPage`, `BookingWorkspacePage`
 - `BookingList`, `BookingDialog`, `BookingCreateDialog`, `BookingCancellationDialog`, `StatusChangeDialog`
 - `TravelerList`, `TravelerDialog`, `BookingItemList`, `BookingGroupSection`
 - `BookingPaymentsSummary`, `BookingPaymentScheduleList`, `BookingGuaranteeList`
 - `SupplierStatusList`, `BookingActivityTimeline`, `BookingNotes`
+
+`BookingWorkspacePage` wraps the existing `BookingDetailPage` in a reusable
+operator workspace shell. It publishes cross-module navigation for booking,
+finance, legal, travelers, and activity work while keeping module-specific
+surfaces app-owned through typed slots:
+
+```tsx
+<BookingWorkspacePage
+  id={bookingId}
+  slots={{
+    actionBar: ({ booking }) => <button type="button">Assign {booking.bookingNumber}</button>,
+    financeSidebar: ({ bookingId }) => <FinanceStatusCard bookingId={bookingId} />,
+    legalTab: ({ bookingId }) => <ContractChecklist bookingId={bookingId} />,
+    travelersTabExtensions: ({ bulkActions }) => (
+      <BatchTravelerTools selectedTravelerIds={bulkActions.selectedTravelerIds} />
+    ),
+    activityTab: ({ bookingId }) => <OperatorTimeline bookingId={bookingId} />,
+  }}
+/>
+```
+
+Slot render functions receive the booking, active workspace section, section
+setter, and bulk-action state for traveler and finance selections. Use
+`bookingDetailSlots` to pass slots through to the mounted `BookingDetailPage`.
 
 ## I18n
 

--- a/packages/bookings-ui/src/components/booking-workspace-page.tsx
+++ b/packages/bookings-ui/src/components/booking-workspace-page.tsx
@@ -1,0 +1,385 @@
+"use client"
+
+import { type BookingRecord, useBooking } from "@voyantjs/bookings-react"
+import { Button, Card, CardContent, cn } from "@voyantjs/ui/components"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@voyantjs/ui/components/tabs"
+import { ArrowLeft, BriefcaseBusiness, FileText, Landmark, ListChecks, Users } from "lucide-react"
+import {
+  createContext,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+
+import { useBookingsUiMessagesOrDefault } from "../i18n/index.js"
+import { BookingDetailPage, type BookingDetailPageSlots } from "./booking-detail-page.js"
+
+export type BookingWorkspaceSection = "booking" | "finance" | "legal" | "travelers" | "activity"
+
+export interface BookingWorkspaceBulkActionContext {
+  bookingId: string
+  selectedTravelerIds: string[]
+  selectedFinanceItemIds: string[]
+  setSelectedTravelerIds: Dispatch<SetStateAction<string[]>>
+  setSelectedFinanceItemIds: Dispatch<SetStateAction<string[]>>
+  clearBulkSelection: () => void
+}
+
+export interface BookingWorkspaceSlotContext {
+  booking: BookingRecord
+  bookingId: string
+  activeSection: BookingWorkspaceSection
+  setActiveSection: (section: BookingWorkspaceSection) => void
+  bulkActions: BookingWorkspaceBulkActionContext
+}
+
+export interface BookingWorkspaceNavigationItem {
+  value: BookingWorkspaceSection
+  label: string
+  badge?: ReactNode
+  disabled?: boolean
+}
+
+export interface BookingWorkspacePageSlots {
+  actionBar?: (context: BookingWorkspaceSlotContext) => ReactNode
+  bulkActionBar?: (context: BookingWorkspaceSlotContext) => ReactNode
+  afterNavigation?: (context: BookingWorkspaceSlotContext) => ReactNode
+  workspaceSidebar?: (context: BookingWorkspaceSlotContext) => ReactNode
+  financeSidebar?: (context: BookingWorkspaceSlotContext) => ReactNode
+  legalSidebar?: (context: BookingWorkspaceSlotContext) => ReactNode
+  travelersSidebar?: (context: BookingWorkspaceSlotContext) => ReactNode
+  activitySidebar?: (context: BookingWorkspaceSlotContext) => ReactNode
+  financeTab?: (context: BookingWorkspaceSlotContext) => ReactNode
+  legalTab?: (context: BookingWorkspaceSlotContext) => ReactNode
+  travelersTabExtensions?: (context: BookingWorkspaceSlotContext) => ReactNode
+  activityTab?: (context: BookingWorkspaceSlotContext) => ReactNode
+}
+
+export interface BookingWorkspacePageProps {
+  id: string
+  className?: string
+  locale?: string
+  defaultSection?: BookingWorkspaceSection
+  navigationItems?: BookingWorkspaceNavigationItem[]
+  onBack?: () => void
+  onPersonOpen?: (personId: string) => void
+  onOrganizationOpen?: (organizationId: string) => void
+  onCollectPayment?: (booking: BookingRecord) => void
+  bookingDetailSlots?: BookingDetailPageSlots
+  slots?: BookingWorkspacePageSlots
+}
+
+export interface BookingWorkspaceShellProps extends BookingWorkspacePageProps {
+  booking?: BookingRecord | null
+  isLoading?: boolean
+}
+
+const BookingWorkspaceBulkActionsContext = createContext<BookingWorkspaceBulkActionContext | null>(
+  null,
+)
+
+export function useBookingWorkspaceBulkActions() {
+  const context = useContext(BookingWorkspaceBulkActionsContext)
+  if (!context) {
+    throw new Error("useBookingWorkspaceBulkActions must be used inside BookingWorkspacePage")
+  }
+  return context
+}
+
+export function BookingWorkspacePage(props: BookingWorkspacePageProps) {
+  const bookingQuery = useBooking(props.id)
+
+  return (
+    <BookingWorkspaceShell
+      {...props}
+      booking={bookingQuery.data?.data ?? null}
+      isLoading={bookingQuery.isPending}
+    />
+  )
+}
+
+export function BookingWorkspaceShell({
+  id,
+  className,
+  locale,
+  defaultSection = "booking",
+  navigationItems,
+  onBack,
+  onPersonOpen,
+  onOrganizationOpen,
+  onCollectPayment,
+  bookingDetailSlots,
+  slots,
+  booking,
+  isLoading = false,
+}: BookingWorkspaceShellProps) {
+  const messages = useBookingsUiMessagesOrDefault()
+  const workspaceMessages = messages.bookingWorkspacePage
+  const [activeSection, setActiveSection] = useState<BookingWorkspaceSection>(defaultSection)
+  const [selectedTravelerIds, setSelectedTravelerIds] = useState<string[]>([])
+  const [selectedFinanceItemIds, setSelectedFinanceItemIds] = useState<string[]>([])
+  const bookingId = booking?.id ?? id
+  const previousBookingId = useRef(bookingId)
+
+  useEffect(() => {
+    if (previousBookingId.current === bookingId) return
+    previousBookingId.current = bookingId
+    setSelectedTravelerIds([])
+    setSelectedFinanceItemIds([])
+  }, [bookingId])
+
+  const bulkActions = useMemo<BookingWorkspaceBulkActionContext>(
+    () => ({
+      bookingId,
+      selectedTravelerIds,
+      selectedFinanceItemIds,
+      setSelectedTravelerIds,
+      setSelectedFinanceItemIds,
+      clearBulkSelection: () => {
+        setSelectedTravelerIds([])
+        setSelectedFinanceItemIds([])
+      },
+    }),
+    [bookingId, selectedFinanceItemIds, selectedTravelerIds],
+  )
+
+  if (isLoading) {
+    return (
+      <div data-slot="booking-workspace-page" className={cn("flex flex-col gap-6 p-6", className)}>
+        <WorkspaceHeader title={workspaceMessages.loadingTitle} onBack={onBack} />
+        <Card className="border-dashed">
+          <CardContent className="flex min-h-48 items-center justify-center py-10">
+            <p className="text-sm text-muted-foreground">{messages.common.loading}</p>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  if (!booking) {
+    return (
+      <div data-slot="booking-workspace-page" className={cn("flex flex-col gap-6 p-6", className)}>
+        <WorkspaceHeader title={workspaceMessages.notFoundTitle} onBack={onBack} />
+        <Card className="border-dashed">
+          <CardContent className="flex min-h-48 flex-col items-center justify-center gap-4 py-10">
+            <p className="text-sm text-muted-foreground">{workspaceMessages.notFoundDescription}</p>
+            {onBack ? (
+              <Button type="button" variant="outline" onClick={onBack}>
+                {messages.bookingDetailPage.backToBookings}
+              </Button>
+            ) : null}
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  const context: BookingWorkspaceSlotContext = {
+    booking,
+    bookingId,
+    activeSection,
+    setActiveSection,
+    bulkActions,
+  }
+  const items = navigationItems ?? getDefaultNavigationItems(workspaceMessages.tabs)
+  const sidebar = renderSidebar(activeSection, slots, context)
+  const hasSidebar = Boolean(sidebar)
+
+  return (
+    <BookingWorkspaceBulkActionsContext.Provider value={bulkActions}>
+      <div data-slot="booking-workspace-page" className={cn("flex flex-col gap-5 p-6", className)}>
+        <WorkspaceHeader
+          title={booking.bookingNumber}
+          description={workspaceMessages.description}
+          onBack={onBack}
+          actions={slots?.actionBar?.(context)}
+        />
+
+        {slots?.bulkActionBar?.(context)}
+
+        <Tabs
+          value={activeSection}
+          onValueChange={(value) => setActiveSection(value as BookingWorkspaceSection)}
+          className="flex min-w-0 flex-col gap-5"
+        >
+          <div className="overflow-x-auto">
+            <TabsList className="h-auto min-w-max justify-start">
+              {items.map((item) => (
+                <TabsTrigger
+                  key={item.value}
+                  value={item.value}
+                  disabled={item.disabled}
+                  className="gap-2"
+                >
+                  <WorkspaceTabIcon section={item.value} />
+                  <span>{item.label}</span>
+                  {item.badge}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </div>
+
+          {slots?.afterNavigation?.(context)}
+
+          <div
+            className={cn(
+              "grid min-w-0 gap-6",
+              hasSidebar ? "xl:grid-cols-[minmax(0,1fr)_320px]" : "xl:grid-cols-1",
+            )}
+          >
+            <div className="min-w-0">
+              <TabsContent value="booking" className="mt-0">
+                <BookingDetailPage
+                  id={bookingId}
+                  className="p-0"
+                  locale={locale}
+                  onBack={onBack}
+                  onPersonOpen={onPersonOpen}
+                  onOrganizationOpen={onOrganizationOpen}
+                  onCollectPayment={onCollectPayment}
+                  slots={bookingDetailSlots}
+                />
+              </TabsContent>
+
+              <TabsContent value="finance" className="mt-0">
+                {renderTabSlot(slots?.financeTab, context, workspaceMessages.empty.finance)}
+              </TabsContent>
+
+              <TabsContent value="legal" className="mt-0">
+                {renderTabSlot(slots?.legalTab, context, workspaceMessages.empty.legal)}
+              </TabsContent>
+
+              <TabsContent value="travelers" className="mt-0">
+                {renderTabSlot(
+                  slots?.travelersTabExtensions,
+                  context,
+                  workspaceMessages.empty.travelers,
+                )}
+              </TabsContent>
+
+              <TabsContent value="activity" className="mt-0">
+                {renderTabSlot(slots?.activityTab, context, workspaceMessages.empty.activity)}
+              </TabsContent>
+            </div>
+
+            {hasSidebar ? (
+              <aside data-slot="booking-workspace-sidebar" className="flex min-w-0 flex-col gap-4">
+                {sidebar}
+              </aside>
+            ) : null}
+          </div>
+        </Tabs>
+      </div>
+    </BookingWorkspaceBulkActionsContext.Provider>
+  )
+}
+
+function WorkspaceHeader({
+  title,
+  description,
+  onBack,
+  actions,
+}: {
+  title: string
+  description?: string
+  onBack?: () => void
+  actions?: ReactNode
+}) {
+  return (
+    <div
+      data-slot="booking-workspace-header"
+      className="flex flex-col gap-4 border-b pb-4 sm:flex-row sm:items-start sm:justify-between"
+    >
+      <div className="min-w-0 space-y-1">
+        <div className="flex min-w-0 items-center gap-2">
+          {onBack ? (
+            <Button type="button" variant="ghost" size="icon-sm" onClick={onBack}>
+              <ArrowLeft className="size-4" aria-hidden="true" />
+              <span className="sr-only">Back</span>
+            </Button>
+          ) : null}
+          <h1 className="truncate text-2xl font-semibold tracking-tight">{title}</h1>
+        </div>
+        {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
+      </div>
+      {actions ? <div className="flex flex-wrap items-center gap-2">{actions}</div> : null}
+    </div>
+  )
+}
+
+function WorkspaceTabIcon({ section }: { section: BookingWorkspaceSection }) {
+  const iconClassName = "size-4"
+  switch (section) {
+    case "booking":
+      return <BriefcaseBusiness className={iconClassName} aria-hidden="true" />
+    case "finance":
+      return <Landmark className={iconClassName} aria-hidden="true" />
+    case "legal":
+      return <FileText className={iconClassName} aria-hidden="true" />
+    case "travelers":
+      return <Users className={iconClassName} aria-hidden="true" />
+    case "activity":
+      return <ListChecks className={iconClassName} aria-hidden="true" />
+  }
+}
+
+function renderTabSlot(
+  slot: ((context: BookingWorkspaceSlotContext) => ReactNode) | undefined,
+  context: BookingWorkspaceSlotContext,
+  emptyMessage: string,
+) {
+  const content = slot?.(context)
+  if (content) return content
+
+  return (
+    <Card className="border-dashed">
+      <CardContent className="flex min-h-48 items-center justify-center py-10">
+        <p className="max-w-md text-center text-sm text-muted-foreground">{emptyMessage}</p>
+      </CardContent>
+    </Card>
+  )
+}
+
+function renderSidebar(
+  activeSection: BookingWorkspaceSection,
+  slots: BookingWorkspacePageSlots | undefined,
+  context: BookingWorkspaceSlotContext,
+) {
+  const sectionSidebar =
+    activeSection === "finance"
+      ? slots?.financeSidebar?.(context)
+      : activeSection === "legal"
+        ? slots?.legalSidebar?.(context)
+        : activeSection === "travelers"
+          ? slots?.travelersSidebar?.(context)
+          : activeSection === "activity"
+            ? slots?.activitySidebar?.(context)
+            : null
+  const workspaceSidebar = slots?.workspaceSidebar?.(context)
+
+  if (!workspaceSidebar && !sectionSidebar) return null
+
+  return (
+    <>
+      {sectionSidebar}
+      {workspaceSidebar}
+    </>
+  )
+}
+
+function getDefaultNavigationItems(
+  tabs: Record<BookingWorkspaceSection, string>,
+): BookingWorkspaceNavigationItem[] {
+  return [
+    { value: "booking", label: tabs.booking },
+    { value: "finance", label: tabs.finance },
+    { value: "legal", label: tabs.legal },
+    { value: "travelers", label: tabs.travelers },
+    { value: "activity", label: tabs.activity },
+  ]
+}

--- a/packages/bookings-ui/src/i18n/en.ts
+++ b/packages/bookings-ui/src/i18n/en.ts
@@ -71,6 +71,25 @@ export const bookingsUiEn = {
     billingAddress: "Address",
     documentsSlotEmpty: "Provide a documents slot to render booking documents.",
   },
+  bookingWorkspacePage: {
+    description: "Coordinate booking, finance, legal, traveler, and activity work.",
+    loadingTitle: "Booking workspace",
+    notFoundTitle: "Booking workspace",
+    notFoundDescription: "The booking workspace could not find this booking.",
+    tabs: {
+      booking: "Booking",
+      finance: "Finance",
+      legal: "Legal",
+      travelers: "Travelers",
+      activity: "Activity",
+    },
+    empty: {
+      finance: "Provide a finance tab slot to render invoices, payment status, or collections.",
+      legal: "Provide a legal tab slot to render contracts, waivers, or compliance tasks.",
+      travelers: "Provide traveler tab extensions for batch edits and operational checks.",
+      activity: "Provide an activity tab slot to render the operator timeline or audit trail.",
+    },
+  },
   travelerDialog: {
     titles: {
       create: "Add traveler",

--- a/packages/bookings-ui/src/i18n/messages.ts
+++ b/packages/bookings-ui/src/i18n/messages.ts
@@ -64,6 +64,14 @@ export type BookingsUiMessages = {
     billingAddress: string
     documentsSlotEmpty: string
   }
+  bookingWorkspacePage: {
+    description: string
+    loadingTitle: string
+    notFoundTitle: string
+    notFoundDescription: string
+    tabs: Record<"booking" | "finance" | "legal" | "travelers" | "activity", string>
+    empty: Record<"finance" | "legal" | "travelers" | "activity", string>
+  }
   travelerDialog: {
     titles: {
       create: string

--- a/packages/bookings-ui/src/i18n/ro.ts
+++ b/packages/bookings-ui/src/i18n/ro.ts
@@ -70,6 +70,25 @@ export const bookingsUiRo = {
     billingAddress: "Adresa",
     documentsSlotEmpty: "Furnizeaza un slot de documente pentru rezervare.",
   },
+  bookingWorkspacePage: {
+    description: "Coordoneaza rezervarea, financiarul, legalul, calatorii si activitatea.",
+    loadingTitle: "Spatiu de lucru rezervare",
+    notFoundTitle: "Spatiu de lucru rezervare",
+    notFoundDescription: "Spatiul de lucru nu a gasit aceasta rezervare.",
+    tabs: {
+      booking: "Rezervare",
+      finance: "Financiar",
+      legal: "Legal",
+      travelers: "Calatori",
+      activity: "Activitate",
+    },
+    empty: {
+      finance: "Furnizeaza un slot financiar pentru facturi, statusuri de plata sau incasari.",
+      legal: "Furnizeaza un slot legal pentru contracte, declaratii sau sarcini de conformitate.",
+      travelers: "Furnizeaza extensii pentru editari in masa si verificari operationale.",
+      activity: "Furnizeaza un slot de activitate pentru cronologie sau audit.",
+    },
+  },
   travelerDialog: {
     titles: {
       create: "Adauga calator",

--- a/packages/bookings-ui/src/index.ts
+++ b/packages/bookings-ui/src/index.ts
@@ -71,6 +71,18 @@ export {
   BookingPaymentsSummary,
   type BookingPaymentsSummaryProps,
 } from "./components/booking-payments-summary.js"
+export {
+  type BookingWorkspaceBulkActionContext,
+  type BookingWorkspaceNavigationItem,
+  BookingWorkspacePage,
+  type BookingWorkspacePageProps,
+  type BookingWorkspacePageSlots,
+  type BookingWorkspaceSection,
+  BookingWorkspaceShell,
+  type BookingWorkspaceShellProps,
+  type BookingWorkspaceSlotContext,
+  useBookingWorkspaceBulkActions,
+} from "./components/booking-workspace-page.js"
 export { BookingsPage, type BookingsPageProps } from "./components/bookings-page.js"
 export {
   FileDropzone,

--- a/packages/bookings-ui/tests/unit/booking-workspace-page.test.tsx
+++ b/packages/bookings-ui/tests/unit/booking-workspace-page.test.tsx
@@ -1,0 +1,81 @@
+import type { BookingRecord } from "@voyantjs/bookings-react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("../../src/components/booking-detail-page.js", () => ({
+  BookingDetailPage: ({ id, className }: { id: string; className?: string }) => (
+    <section data-testid="booking-detail" className={className}>
+      Booking detail {id}
+    </section>
+  ),
+}))
+
+import { BookingWorkspaceShell } from "../../src/components/booking-workspace-page.js"
+
+const booking: BookingRecord = {
+  id: "booking_123",
+  bookingNumber: "BK-123",
+  status: "confirmed",
+  personId: "person_123",
+  organizationId: null,
+  sellCurrency: "USD",
+  sellAmountCents: 120000,
+  costAmountCents: 90000,
+  marginPercent: 25,
+  startDate: "2026-06-01",
+  endDate: "2026-06-08",
+  pax: 2,
+  internalNotes: null,
+  createdAt: "2026-05-01T00:00:00.000Z",
+  updatedAt: "2026-05-02T00:00:00.000Z",
+}
+
+describe("BookingWorkspaceShell", () => {
+  it("renders a loading workspace state", () => {
+    const html = renderToStaticMarkup(<BookingWorkspaceShell id="booking_123" isLoading />)
+
+    expect(html).toContain("Booking workspace")
+    expect(html).toContain("Loading...")
+  })
+
+  it("renders an empty workspace state", () => {
+    const html = renderToStaticMarkup(<BookingWorkspaceShell id="missing" booking={null} />)
+
+    expect(html).toContain("The booking workspace could not find this booking.")
+  })
+
+  it("mounts the booking detail page as the primary workspace surface", () => {
+    const html = renderToStaticMarkup(<BookingWorkspaceShell id={booking.id} booking={booking} />)
+
+    expect(html).toContain("BK-123")
+    expect(html).toContain("Booking detail booking_123")
+    expect(html).toContain("Booking")
+    expect(html).toContain("Finance")
+    expect(html).toContain("Legal")
+    expect(html).toContain("Travelers")
+    expect(html).toContain("Activity")
+  })
+
+  it("renders typed workspace slots with bulk-action context", () => {
+    const html = renderToStaticMarkup(
+      <BookingWorkspaceShell
+        id={booking.id}
+        booking={booking}
+        defaultSection="finance"
+        slots={{
+          actionBar: ({ booking }) => <button type="button">Assign {booking.bookingNumber}</button>,
+          financeTab: ({ bookingId, bulkActions }) => (
+            <section>
+              Finance panel {bookingId} travelers {bulkActions.selectedTravelerIds.length}
+            </section>
+          ),
+          financeSidebar: ({ bookingId }) => <aside>Finance sidebar {bookingId}</aside>,
+        }}
+      />,
+    )
+
+    expect(html).toContain("Assign BK-123")
+    expect(html).toContain("Finance panel booking_123 travelers 0")
+    expect(html).toContain("Finance sidebar booking_123")
+  })
+})


### PR DESCRIPTION
## Summary
- Add `BookingWorkspacePage` and `BookingWorkspaceShell` for operator booking workspaces.
- Expose typed slots for finance, legal, traveler, activity, action bar, sidebars, and bulk selection state.
- Export the new API, document usage, add i18n strings, and include a changeset.

Closes #876

## Verification
- `pnpm --filter @voyantjs/bookings-ui typecheck`
- `pnpm --filter @voyantjs/bookings-ui test`
- `pnpm --filter @voyantjs/bookings-ui lint`
- `pnpm --filter @voyantjs/bookings-ui build`
- pre-push `pnpm test` hook passed: 125 packages successful

No browser harness was added; the workspace states are covered with server-rendered component tests.