### PR TITLE
Add storefront transport eligibility checks

### DIFF
--- a/.changeset/storefront-transport-eligibility.md
+++ b/.changeset/storefront-transport-eligibility.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/storefront": minor
+---
+
+Add resolver-backed transport eligibility schemas and public departure eligibility routes for passport and document rules.

--- a/packages/storefront/README.md
+++ b/packages/storefront/README.md
@@ -1,0 +1,74 @@
+# @voyantjs/storefront
+
+Public storefront routes and service helpers for checkout-adjacent product, departure,
+offer, and eligibility flows.
+
+## Transport Eligibility
+
+Storefronts can check whether traveler document facts satisfy departure-level
+transport rules before checkout confirmation.
+
+```ts
+import { createStorefrontPublicRoutes } from "@voyantjs/storefront"
+
+createStorefrontPublicRoutes({
+  transportEligibilityRules: [
+    {
+      id: "egypt-passport-validity",
+      label: "Egypt passport validity",
+      productId: "prod_123",
+      destinationCountries: ["EG"],
+      nationalityCountries: ["RO"],
+      requiredDocumentType: "passport",
+      minValidityDaysAfterReturn: 180,
+      visaRequired: true,
+    },
+  ],
+})
+```
+
+Schemas and the standalone evaluator are exported from
+`@voyantjs/storefront/transport-eligibility`.
+
+The public API is available at:
+
+- `POST /departures/:departureId/eligibility`
+- `POST /products/:productId/departures/:departureId/eligibility`
+
+Request bodies contain only eligibility facts:
+
+```json
+{
+  "travelStartsOn": "2026-08-01",
+  "travelEndsOn": "2026-08-08",
+  "travelers": [
+    {
+      "travelerRef": "traveler_1",
+      "nationalityCountry": "RO",
+      "dateOfBirth": "1990-01-01",
+      "documents": [
+        {
+          "type": "passport",
+          "issuingCountry": "RO",
+          "expiresOn": "2027-03-01"
+        }
+      ],
+      "hasVisa": true
+    }
+  ]
+}
+```
+
+Responses return a top-level `eligible` flag plus traveler-specific blocking
+issues and warnings. Supported rule dimensions are product, departure,
+destination country, nationality country, required document type, minimum
+validity after return, age range, visa requirement, minor consent requirement,
+and warning/blocking severity.
+
+Do not send or store raw passport numbers through this surface. The route and
+schemas only model document type, issuing country, expiry date, nationality,
+birth date, and boolean evidence such as `hasVisa`.
+
+This first slice is API-only. Admin CRUD and operator UI for managing transport
+rules should persist normalized rule objects and can call the same public
+eligibility service once added.

--- a/packages/storefront/package.json
+++ b/packages/storefront/package.json
@@ -7,6 +7,7 @@
     ".": "./src/index.ts",
     "./public-routes": "./src/routes-public.ts",
     "./service": "./src/service.ts",
+    "./transport-eligibility": "./src/transport-eligibility.ts",
     "./validation": "./src/validation.ts"
   },
   "scripts": {
@@ -55,6 +56,11 @@
         "types": "./dist/service.d.ts",
         "import": "./dist/service.js",
         "default": "./dist/service.js"
+      },
+      "./transport-eligibility": {
+        "types": "./dist/transport-eligibility.d.ts",
+        "import": "./dist/transport-eligibility.js",
+        "default": "./dist/transport-eligibility.js"
       },
       "./validation": {
         "types": "./dist/validation.d.ts",

--- a/packages/storefront/src/index.ts
+++ b/packages/storefront/src/index.ts
@@ -11,6 +11,7 @@ export type {
   StorefrontServiceOptions,
 } from "./service.js"
 export { createStorefrontService, resolveStorefrontSettings } from "./service.js"
+export { evaluateStorefrontTransportEligibility } from "./service-transport-eligibility.js"
 export type {
   StorefrontAppliedOffer,
   StorefrontDepartureListQuery,
@@ -64,6 +65,26 @@ export {
   storefrontSettingsInputSchema,
   storefrontSettingsSchema,
 } from "./validation.js"
+export type {
+  StorefrontTransportEligibilityInput,
+  StorefrontTransportEligibilityIssue,
+  StorefrontTransportEligibilityResult,
+  StorefrontTransportEligibilityRule,
+  StorefrontTransportEligibilityRuleInput,
+} from "./validation-transport-eligibility.js"
+export {
+  storefrontRequiredDocumentTypeSchema,
+  storefrontTransportEligibilityDocumentInputSchema,
+  storefrontTransportEligibilityInputSchema,
+  storefrontTransportEligibilityIssueCodeSchema,
+  storefrontTransportEligibilityIssueSchema,
+  storefrontTransportEligibilityResultSchema,
+  storefrontTransportEligibilityRuleSchema,
+  storefrontTransportEligibilitySeveritySchema,
+  storefrontTransportEligibilityTravelerInputSchema,
+  storefrontTransportEligibilityTravelerResultSchema,
+  storefrontTravelDocumentTypeSchema,
+} from "./validation-transport-eligibility.js"
 
 export const storefrontModule: Module = {
   name: "storefront",

--- a/packages/storefront/src/routes-public.ts
+++ b/packages/storefront/src/routes-public.ts
@@ -16,6 +16,7 @@ import {
   storefrontProductExtensionsQuerySchema,
   storefrontPromotionalOfferListQuerySchema,
 } from "./validation.js"
+import { storefrontTransportEligibilityInputSchema } from "./validation-transport-eligibility.js"
 
 type Env = {
   Variables: {
@@ -67,6 +68,25 @@ export function createStorefrontPublicRoutes(options?: StorefrontServiceOptions)
       return preview
         ? c.json({ data: preview })
         : c.json({ error: "Storefront departure not found" }, 404)
+    })
+    .post("/departures/:departureId/eligibility", async (c) => {
+      return c.json({
+        data: await storefrontService.checkDepartureTransportEligibility({
+          departureId: c.req.param("departureId"),
+          body: await parseJsonBody(c, storefrontTransportEligibilityInputSchema),
+          context: getRequestContext(c),
+        }),
+      })
+    })
+    .post("/products/:productId/departures/:departureId/eligibility", async (c) => {
+      return c.json({
+        data: await storefrontService.checkDepartureTransportEligibility({
+          departureId: c.req.param("departureId"),
+          productId: c.req.param("productId"),
+          body: await parseJsonBody(c, storefrontTransportEligibilityInputSchema),
+          context: getRequestContext(c),
+        }),
+      })
     })
     .get("/products/:productId/extensions", async (c) => {
       const query = await parseQuery(c, storefrontProductExtensionsQuerySchema)

--- a/packages/storefront/src/service-transport-eligibility.ts
+++ b/packages/storefront/src/service-transport-eligibility.ts
@@ -1,0 +1,332 @@
+import type {
+  StorefrontTransportEligibilityInput,
+  StorefrontTransportEligibilityIssue,
+  StorefrontTransportEligibilityResult,
+  StorefrontTransportEligibilityRule,
+  StorefrontTransportEligibilityRuleInput,
+} from "./validation-transport-eligibility.js"
+import { storefrontTransportEligibilityRuleSchema } from "./validation-transport-eligibility.js"
+
+type EligibilityTarget = {
+  departureId: string
+  productId?: string | null
+  travelStartsOn?: string | null
+  travelEndsOn?: string | null
+}
+
+type NormalizedDocument =
+  StorefrontTransportEligibilityInput["travelers"][number]["documents"][number]
+type NormalizedTraveler = StorefrontTransportEligibilityInput["travelers"][number]
+
+function parseDate(value: string | null | undefined): Date | null {
+  if (!value) return null
+  const date = new Date(`${value}T00:00:00.000Z`)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+function addDays(value: string, days: number): string {
+  const date = parseDate(value)
+  if (!date) return value
+  date.setUTCDate(date.getUTCDate() + days)
+  return date.toISOString().slice(0, 10)
+}
+
+function getAgeOn(dateOfBirth: string, onDate: string): number | null {
+  const birth = parseDate(dateOfBirth)
+  const reference = parseDate(onDate)
+  if (!birth || !reference) return null
+
+  let age = reference.getUTCFullYear() - birth.getUTCFullYear()
+  const birthdayThisYear = Date.UTC(
+    reference.getUTCFullYear(),
+    birth.getUTCMonth(),
+    birth.getUTCDate(),
+  )
+
+  if (reference.getTime() < birthdayThisYear) {
+    age -= 1
+  }
+
+  return age
+}
+
+function isBeforeDate(left: string, right: string): boolean {
+  const leftDate = parseDate(left)
+  const rightDate = parseDate(right)
+  if (!leftDate || !rightDate) return false
+  return leftDate.getTime() < rightDate.getTime()
+}
+
+function findDocuments(
+  traveler: NormalizedTraveler,
+  rule: StorefrontTransportEligibilityRule,
+): NormalizedDocument[] {
+  if (rule.requiredDocumentType === "none") return []
+  if (rule.requiredDocumentType === "passport_or_id_card") {
+    return traveler.documents.filter(
+      (document) => document.type === "passport" || document.type === "id_card",
+    )
+  }
+
+  return traveler.documents.filter((document) => document.type === rule.requiredDocumentType)
+}
+
+function documentTypeLabel(rule: StorefrontTransportEligibilityRule): string {
+  switch (rule.requiredDocumentType) {
+    case "passport_or_id_card":
+      return "passport or ID card"
+    case "id_card":
+      return "ID card"
+    case "passport":
+      return "passport"
+    case "none":
+      return "travel document"
+  }
+}
+
+function buildIssue(
+  code: StorefrontTransportEligibilityIssue["code"],
+  traveler: NormalizedTraveler,
+  rule: StorefrontTransportEligibilityRule,
+  message: string,
+): StorefrontTransportEligibilityIssue {
+  return {
+    code,
+    severity: rule.severity,
+    message: rule.message ?? message,
+    travelerRef: traveler.travelerRef,
+    ruleId: rule.id,
+    destinationCountries: rule.destinationCountries,
+    requiredDocumentType: rule.requiredDocumentType,
+  }
+}
+
+function pushIssue(
+  target: {
+    blockingIssues: StorefrontTransportEligibilityIssue[]
+    warnings: StorefrontTransportEligibilityIssue[]
+  },
+  issue: StorefrontTransportEligibilityIssue,
+) {
+  if (issue.severity === "warning") {
+    target.warnings.push(issue)
+  } else {
+    target.blockingIssues.push(issue)
+  }
+}
+
+function appliesToTarget(rule: StorefrontTransportEligibilityRule, target: EligibilityTarget) {
+  if (rule.productId && rule.productId !== target.productId) return false
+  if (rule.departureId && rule.departureId !== target.departureId) return false
+  return true
+}
+
+function appliesToTraveler(
+  rule: StorefrontTransportEligibilityRule,
+  traveler: NormalizedTraveler,
+  travelStartsOn: string | null,
+) {
+  if (rule.nationalityCountries.length > 0) {
+    if (!traveler.nationalityCountry) return "missing_nationality" as const
+    if (!rule.nationalityCountries.includes(traveler.nationalityCountry)) return false
+  }
+
+  if (rule.minAge == null && rule.maxAge == null) return true
+  if (!traveler.dateOfBirth || !travelStartsOn) return "missing_age_basis" as const
+
+  const age = getAgeOn(traveler.dateOfBirth, travelStartsOn)
+  if (age == null) return "missing_age_basis" as const
+  if (rule.minAge != null && age < rule.minAge) return false
+  if (rule.maxAge != null && age > rule.maxAge) return false
+
+  return true
+}
+
+function evaluateTravelerRule(
+  traveler: NormalizedTraveler,
+  rule: StorefrontTransportEligibilityRule,
+  target: { travelStartsOn: string | null; travelEndsOn: string | null },
+) {
+  const blockingIssues: StorefrontTransportEligibilityIssue[] = []
+  const warnings: StorefrontTransportEligibilityIssue[] = []
+  const resultTarget = { blockingIssues, warnings }
+
+  const travelerApplicability = appliesToTraveler(rule, traveler, target.travelStartsOn)
+  if (travelerApplicability === false) {
+    return null
+  }
+
+  if (travelerApplicability === "missing_nationality") {
+    pushIssue(
+      resultTarget,
+      buildIssue(
+        "nationality_required",
+        traveler,
+        rule,
+        "Traveler nationality is required to evaluate destination document rules.",
+      ),
+    )
+  }
+
+  if (travelerApplicability === "missing_age_basis") {
+    pushIssue(
+      resultTarget,
+      buildIssue(
+        "date_of_birth_required",
+        traveler,
+        rule,
+        "Traveler date of birth and travel start date are required to evaluate age rules.",
+      ),
+    )
+  }
+
+  const documents = findDocuments(traveler, rule)
+  if (rule.requiredDocumentType !== "none" && documents.length === 0) {
+    pushIssue(
+      resultTarget,
+      buildIssue(
+        "document_required",
+        traveler,
+        rule,
+        `Traveler needs a ${documentTypeLabel(rule)} for this destination.`,
+      ),
+    )
+  }
+
+  if (rule.minValidityDaysAfterReturn > 0) {
+    if (!target.travelEndsOn) {
+      pushIssue(
+        resultTarget,
+        buildIssue(
+          "travel_dates_required",
+          traveler,
+          rule,
+          "Travel end date is required to evaluate document validity after return.",
+        ),
+      )
+    } else if (documents.length === 0) {
+      // Missing documents are already reported through document_required.
+    } else {
+      const requiredValidUntil = addDays(target.travelEndsOn, rule.minValidityDaysAfterReturn)
+      const documentsWithExpiry = documents.filter(
+        (document): document is NormalizedDocument & { expiresOn: string } =>
+          typeof document.expiresOn === "string",
+      )
+      const hasValidDocument = documentsWithExpiry.some(
+        (document) => !isBeforeDate(document.expiresOn, requiredValidUntil),
+      )
+
+      if (hasValidDocument) {
+        // Any acceptable document can satisfy a passport-or-ID-card validity rule.
+      } else if (documentsWithExpiry.length > 0) {
+        pushIssue(
+          resultTarget,
+          buildIssue(
+            "document_validity",
+            traveler,
+            rule,
+            `Traveler ${documentTypeLabel(rule)} must be valid until at least ${requiredValidUntil}.`,
+          ),
+        )
+      } else {
+        pushIssue(
+          resultTarget,
+          buildIssue(
+            "document_expiry_required",
+            traveler,
+            rule,
+            `Traveler ${documentTypeLabel(rule)} expiry date is required.`,
+          ),
+        )
+      }
+    }
+  }
+
+  if (rule.visaRequired) {
+    const hasVisa =
+      traveler.hasVisa || traveler.documents.some((document) => document.type === "visa")
+    if (!hasVisa) {
+      pushIssue(
+        resultTarget,
+        buildIssue("visa_required", traveler, rule, "Traveler needs a visa for this destination."),
+      )
+    }
+  }
+
+  if (rule.minorConsentRequired) {
+    const age =
+      traveler.dateOfBirth && target.travelStartsOn
+        ? getAgeOn(traveler.dateOfBirth, target.travelStartsOn)
+        : null
+    const isMinor = age == null ? true : age < 18
+    const hasConsent =
+      traveler.hasMinorConsent ||
+      traveler.travelingWithGuardian ||
+      traveler.documents.some((document) => document.type === "minor_consent")
+
+    if (isMinor && !hasConsent) {
+      pushIssue(
+        resultTarget,
+        buildIssue(
+          "minor_consent_required",
+          traveler,
+          rule,
+          "Minor traveler needs guardian travel consent for this departure.",
+        ),
+      )
+    }
+  }
+
+  return { blockingIssues, warnings }
+}
+
+export function evaluateStorefrontTransportEligibility(input: {
+  departureId: string
+  productId?: string | null
+  travelStartsOn?: string | null
+  travelEndsOn?: string | null
+  travelers: StorefrontTransportEligibilityInput["travelers"]
+  rules: StorefrontTransportEligibilityRuleInput[]
+}): StorefrontTransportEligibilityResult {
+  const travelStartsOn = input.travelStartsOn ?? null
+  const travelEndsOn = input.travelEndsOn ?? null
+  const rules = input.rules
+    .map((rule) => storefrontTransportEligibilityRuleSchema.parse(rule))
+    .filter((rule) => appliesToTarget(rule, input))
+  const travelerResults = input.travelers.map((traveler) => {
+    const blockingIssues: StorefrontTransportEligibilityIssue[] = []
+    const warnings: StorefrontTransportEligibilityIssue[] = []
+    const matchedRuleIds: string[] = []
+
+    for (const rule of rules) {
+      const result = evaluateTravelerRule(traveler, rule, { travelStartsOn, travelEndsOn })
+      if (!result) continue
+
+      matchedRuleIds.push(rule.id)
+      blockingIssues.push(...result.blockingIssues)
+      warnings.push(...result.warnings)
+    }
+
+    return {
+      travelerRef: traveler.travelerRef,
+      eligible: blockingIssues.length === 0,
+      matchedRuleIds,
+      blockingIssues,
+      warnings,
+    }
+  })
+
+  const blockingIssues = travelerResults.flatMap((traveler) => traveler.blockingIssues)
+  const warnings = travelerResults.flatMap((traveler) => traveler.warnings)
+
+  return {
+    departureId: input.departureId,
+    productId: input.productId ?? null,
+    travelStartsOn,
+    travelEndsOn,
+    eligible: blockingIssues.length === 0,
+    blockingIssues,
+    warnings,
+    travelers: travelerResults,
+  }
+}

--- a/packages/storefront/src/service.ts
+++ b/packages/storefront/src/service.ts
@@ -8,6 +8,7 @@ import {
   listStorefrontProductDepartures,
   previewStorefrontDeparturePrice,
 } from "./service-departures.js"
+import { evaluateStorefrontTransportEligibility } from "./service-transport-eligibility.js"
 import {
   type StorefrontDepartureListQuery,
   type StorefrontDeparturePricePreviewInput,
@@ -26,6 +27,11 @@ import {
   storefrontSettingsInputSchema,
   storefrontSettingsSchema,
 } from "./validation.js"
+import type {
+  StorefrontTransportEligibilityInput,
+  StorefrontTransportEligibilityResult,
+  StorefrontTransportEligibilityRuleInput,
+} from "./validation-transport-eligibility.js"
 
 export interface StorefrontServiceOptions {
   settings?: StorefrontSettingsInput
@@ -40,6 +46,17 @@ export interface StorefrontServiceOptions {
     | StorefrontOfferResolvers
     | null
     | undefined
+  transportEligibilityRules?: StorefrontTransportEligibilityRuleInput[]
+  resolveTransportEligibilityRules?: (
+    input: {
+      departureId: string
+      productId?: string | null
+      travelStartsOn?: string | null
+      travelEndsOn?: string | null
+    } & StorefrontRequestContext,
+  ) =>
+    | Promise<StorefrontTransportEligibilityRuleInput[]>
+    | StorefrontTransportEligibilityRuleInput[]
 }
 
 export interface StorefrontRequestContext {
@@ -152,6 +169,21 @@ export function createStorefrontService(options?: StorefrontServiceOptions) {
     return (await options?.resolveOffers?.(context)) ?? options?.offers
   }
 
+  async function resolveTransportEligibilityRules(
+    input: {
+      departureId: string
+      productId?: string | null
+      travelStartsOn?: string | null
+      travelEndsOn?: string | null
+    } & StorefrontRequestContext,
+  ) {
+    return (
+      (await options?.resolveTransportEligibilityRules?.(input)) ??
+      options?.transportEligibilityRules ??
+      []
+    )
+  }
+
   return {
     getSettings(): StorefrontSettings {
       return settings
@@ -189,6 +221,39 @@ export function createStorefrontService(options?: StorefrontServiceOptions) {
       input: { departureId: string; productId: string },
     ) {
       return getStorefrontDepartureItinerary(db, input)
+    },
+    async checkDepartureTransportEligibility(input: {
+      departureId: string
+      productId?: string | null
+      body: StorefrontTransportEligibilityInput
+      context?: StorefrontRequestContext
+    }): Promise<StorefrontTransportEligibilityResult> {
+      const { context, body, departureId } = input
+      const needsDeparture =
+        context?.db && (!input.productId || !body.travelStartsOn || !body.travelEndsOn)
+      const departure =
+        needsDeparture && context?.db ? await getStorefrontDeparture(context.db, departureId) : null
+      const productId = input.productId ?? departure?.productId ?? null
+      const travelStartsOn =
+        body.travelStartsOn ?? departure?.dateLocal ?? departure?.startAt?.slice(0, 10) ?? null
+      const travelEndsOn =
+        body.travelEndsOn ?? departure?.endAt?.slice(0, 10) ?? departure?.dateLocal ?? null
+      const rules = await resolveTransportEligibilityRules({
+        ...(context ?? {}),
+        departureId,
+        productId,
+        travelStartsOn,
+        travelEndsOn,
+      })
+
+      return evaluateStorefrontTransportEligibility({
+        departureId,
+        productId,
+        travelStartsOn,
+        travelEndsOn,
+        travelers: body.travelers,
+        rules,
+      })
     },
     async listApplicableOffers(input: {
       productId: string

--- a/packages/storefront/src/transport-eligibility.ts
+++ b/packages/storefront/src/transport-eligibility.ts
@@ -1,0 +1,21 @@
+export { evaluateStorefrontTransportEligibility } from "./service-transport-eligibility.js"
+export type {
+  StorefrontTransportEligibilityInput,
+  StorefrontTransportEligibilityIssue,
+  StorefrontTransportEligibilityResult,
+  StorefrontTransportEligibilityRule,
+  StorefrontTransportEligibilityRuleInput,
+} from "./validation-transport-eligibility.js"
+export {
+  storefrontRequiredDocumentTypeSchema,
+  storefrontTransportEligibilityDocumentInputSchema,
+  storefrontTransportEligibilityInputSchema,
+  storefrontTransportEligibilityIssueCodeSchema,
+  storefrontTransportEligibilityIssueSchema,
+  storefrontTransportEligibilityResultSchema,
+  storefrontTransportEligibilityRuleSchema,
+  storefrontTransportEligibilitySeveritySchema,
+  storefrontTransportEligibilityTravelerInputSchema,
+  storefrontTransportEligibilityTravelerResultSchema,
+  storefrontTravelDocumentTypeSchema,
+} from "./validation-transport-eligibility.js"

--- a/packages/storefront/src/validation-transport-eligibility.ts
+++ b/packages/storefront/src/validation-transport-eligibility.ts
@@ -1,0 +1,125 @@
+import { z } from "zod"
+
+const countryCodeSchema = z
+  .string()
+  .trim()
+  .length(2)
+  .transform((value) => value.toUpperCase())
+
+export const storefrontTravelDocumentTypeSchema = z.enum([
+  "passport",
+  "id_card",
+  "residence_permit",
+  "visa",
+  "minor_consent",
+  "other",
+])
+
+export const storefrontRequiredDocumentTypeSchema = z.enum([
+  "none",
+  "passport",
+  "id_card",
+  "passport_or_id_card",
+])
+
+export const storefrontTransportEligibilitySeveritySchema = z.enum(["blocking", "warning"])
+
+export const storefrontTransportEligibilityRuleSchema = z
+  .object({
+    id: z.string().trim().min(1),
+    label: z.string().trim().min(1),
+    productId: z.string().trim().min(1).optional().nullable(),
+    departureId: z.string().trim().min(1).optional().nullable(),
+    destinationCountries: z.array(countryCodeSchema).min(1),
+    nationalityCountries: z.array(countryCodeSchema).default([]),
+    requiredDocumentType: storefrontRequiredDocumentTypeSchema.default("passport"),
+    minValidityDaysAfterReturn: z.number().int().min(0).default(0),
+    minAge: z.number().int().min(0).optional().nullable(),
+    maxAge: z.number().int().min(0).optional().nullable(),
+    visaRequired: z.boolean().default(false),
+    minorConsentRequired: z.boolean().default(false),
+    severity: storefrontTransportEligibilitySeveritySchema.default("blocking"),
+    message: z.string().trim().min(1).optional().nullable(),
+  })
+  .refine((rule) => rule.minAge == null || rule.maxAge == null || rule.minAge <= rule.maxAge, {
+    message: "minAge must be less than or equal to maxAge",
+    path: ["maxAge"],
+  })
+
+export const storefrontTransportEligibilityDocumentInputSchema = z.object({
+  type: storefrontTravelDocumentTypeSchema,
+  issuingCountry: countryCodeSchema.optional().nullable(),
+  expiresOn: z.string().date().optional().nullable(),
+})
+
+export const storefrontTransportEligibilityTravelerInputSchema = z.object({
+  travelerRef: z.string().trim().min(1),
+  nationalityCountry: countryCodeSchema.optional().nullable(),
+  dateOfBirth: z.string().date().optional().nullable(),
+  documents: z.array(storefrontTransportEligibilityDocumentInputSchema).default([]),
+  hasVisa: z.boolean().default(false),
+  travelingWithGuardian: z.boolean().default(false),
+  hasMinorConsent: z.boolean().default(false),
+})
+
+export const storefrontTransportEligibilityInputSchema = z.object({
+  travelStartsOn: z.string().date().optional().nullable(),
+  travelEndsOn: z.string().date().optional().nullable(),
+  travelers: z.array(storefrontTransportEligibilityTravelerInputSchema).min(1),
+})
+
+export const storefrontTransportEligibilityIssueCodeSchema = z.enum([
+  "date_of_birth_required",
+  "document_required",
+  "document_expiry_required",
+  "document_validity",
+  "nationality_required",
+  "visa_required",
+  "minor_consent_required",
+  "travel_dates_required",
+])
+
+export const storefrontTransportEligibilityIssueSchema = z.object({
+  code: storefrontTransportEligibilityIssueCodeSchema,
+  severity: storefrontTransportEligibilitySeveritySchema,
+  message: z.string(),
+  travelerRef: z.string(),
+  ruleId: z.string(),
+  destinationCountries: z.array(countryCodeSchema),
+  requiredDocumentType: storefrontRequiredDocumentTypeSchema,
+})
+
+export const storefrontTransportEligibilityTravelerResultSchema = z.object({
+  travelerRef: z.string(),
+  eligible: z.boolean(),
+  matchedRuleIds: z.array(z.string()),
+  blockingIssues: z.array(storefrontTransportEligibilityIssueSchema),
+  warnings: z.array(storefrontTransportEligibilityIssueSchema),
+})
+
+export const storefrontTransportEligibilityResultSchema = z.object({
+  departureId: z.string(),
+  productId: z.string().nullable(),
+  travelStartsOn: z.string().nullable(),
+  travelEndsOn: z.string().nullable(),
+  eligible: z.boolean(),
+  blockingIssues: z.array(storefrontTransportEligibilityIssueSchema),
+  warnings: z.array(storefrontTransportEligibilityIssueSchema),
+  travelers: z.array(storefrontTransportEligibilityTravelerResultSchema),
+})
+
+export type StorefrontTransportEligibilityInput = z.infer<
+  typeof storefrontTransportEligibilityInputSchema
+>
+export type StorefrontTransportEligibilityRule = z.infer<
+  typeof storefrontTransportEligibilityRuleSchema
+>
+export type StorefrontTransportEligibilityRuleInput = z.input<
+  typeof storefrontTransportEligibilityRuleSchema
+>
+export type StorefrontTransportEligibilityIssue = z.infer<
+  typeof storefrontTransportEligibilityIssueSchema
+>
+export type StorefrontTransportEligibilityResult = z.infer<
+  typeof storefrontTransportEligibilityResultSchema
+>

--- a/packages/storefront/tests/unit/transport-eligibility-routes.test.ts
+++ b/packages/storefront/tests/unit/transport-eligibility-routes.test.ts
@@ -1,0 +1,87 @@
+import { Hono } from "hono"
+import { describe, expect, it } from "vitest"
+
+import { createStorefrontPublicRoutes } from "../../src/routes-public.js"
+
+describe("storefront transport eligibility routes", () => {
+  it("returns blocking issues and warnings through configured rules", async () => {
+    const app = new Hono().route(
+      "/",
+      createStorefrontPublicRoutes({
+        resolveTransportEligibilityRules({ departureId, productId, travelEndsOn }) {
+          expect(departureId).toBe("dep_456")
+          expect(productId).toBe("prod_123")
+          expect(travelEndsOn).toBe("2026-08-08")
+
+          return [
+            {
+              id: "rule_passport_eg",
+              label: "Egypt passport and visa",
+              productId: "prod_123",
+              destinationCountries: ["EG"],
+              nationalityCountries: ["RO"],
+              minValidityDaysAfterReturn: 180,
+              visaRequired: true,
+            },
+            {
+              id: "rule_minor_ca",
+              label: "Canada minor consent advisory",
+              productId: "prod_123",
+              destinationCountries: ["CA"],
+              nationalityCountries: ["US"],
+              maxAge: 17,
+              minorConsentRequired: true,
+              severity: "warning",
+            },
+          ]
+        },
+      }),
+    )
+
+    const res = await app.request("/products/prod_123/departures/dep_456/eligibility", {
+      method: "POST",
+      body: JSON.stringify({
+        travelStartsOn: "2026-08-01",
+        travelEndsOn: "2026-08-08",
+        travelers: [
+          {
+            travelerRef: "traveler_1",
+            nationalityCountry: "ro",
+            dateOfBirth: "1990-01-01",
+            documents: [
+              {
+                type: "passport",
+                issuingCountry: "ro",
+                expiresOn: "2026-09-01",
+                passportNumber: "AB123456",
+              },
+            ],
+          },
+          {
+            travelerRef: "traveler_2",
+            nationalityCountry: "US",
+            dateOfBirth: "2015-01-01",
+            documents: [{ type: "passport", issuingCountry: "US", expiresOn: "2030-01-01" }],
+          },
+        ],
+      }),
+      headers: { "content-type": "application/json" },
+    })
+
+    expect(res.status).toBe(200)
+    const payload = await res.json()
+    expect(payload.data).toMatchObject({
+      departureId: "dep_456",
+      productId: "prod_123",
+      eligible: false,
+    })
+    expect(payload.data.blockingIssues.map((issue: { code: string }) => issue.code)).toEqual([
+      "document_validity",
+      "visa_required",
+    ])
+    expect(payload.data.warnings.map((issue: { code: string }) => issue.code)).toEqual([
+      "minor_consent_required",
+    ])
+    expect(JSON.stringify(payload)).not.toContain("AB123456")
+  })
+})

--- a/packages/storefront/tests/unit/transport-eligibility-service.test.ts
+++ b/packages/storefront/tests/unit/transport-eligibility-service.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { createStorefrontService } from "../../src/service.js"
+import { getStorefrontDeparture } from "../../src/service-departures.js"
+
+vi.mock("../../src/service-departures.js", () => ({
+  getStorefrontDeparture: vi.fn(),
+  getStorefrontDepartureItinerary: vi.fn(),
+  getStorefrontProductAvailabilitySummary: vi.fn(),
+  getStorefrontProductExtensions: vi.fn(),
+  listStorefrontProductDepartures: vi.fn(),
+  previewStorefrontDeparturePrice: vi.fn(),
+}))
+
+describe("storefront transport eligibility service", () => {
+  beforeEach(() => {
+    vi.mocked(getStorefrontDeparture).mockReset()
+  })
+
+  it("loads departure dates for product-scoped eligibility checks when dates are omitted", async () => {
+    vi.mocked(getStorefrontDeparture).mockResolvedValue({
+      id: "dep_456",
+      productId: "prod_123",
+      dateLocal: "2026-08-01",
+      startAt: "2026-08-01T09:00:00.000Z",
+      endAt: "2026-08-08T18:00:00.000Z",
+    } as Awaited<ReturnType<typeof getStorefrontDeparture>>)
+
+    const requestDb = { tenant: "tenant_123" }
+    const service = createStorefrontService({
+      resolveTransportEligibilityRules({ departureId, productId, travelStartsOn, travelEndsOn }) {
+        expect(departureId).toBe("dep_456")
+        expect(productId).toBe("prod_123")
+        expect(travelStartsOn).toBe("2026-08-01")
+        expect(travelEndsOn).toBe("2026-08-08")
+
+        return [
+          {
+            id: "rule_passport",
+            label: "Passport validity",
+            productId: "prod_123",
+            destinationCountries: ["EG"],
+            minValidityDaysAfterReturn: 180,
+          },
+        ]
+      },
+    })
+
+    const result = await service.checkDepartureTransportEligibility({
+      departureId: "dep_456",
+      productId: "prod_123",
+      body: {
+        travelers: [
+          {
+            travelerRef: "traveler_1",
+            documents: [{ type: "passport", issuingCountry: "RO", expiresOn: "2027-03-01" }],
+            hasVisa: false,
+            travelingWithGuardian: false,
+            hasMinorConsent: false,
+          },
+        ],
+      },
+      context: { db: requestDb as never },
+    })
+
+    expect(getStorefrontDeparture).toHaveBeenCalledWith(requestDb, "dep_456")
+    expect(result.travelStartsOn).toBe("2026-08-01")
+    expect(result.travelEndsOn).toBe("2026-08-08")
+    expect(result.eligible).toBe(true)
+  })
+})

--- a/packages/storefront/tests/unit/transport-eligibility.test.ts
+++ b/packages/storefront/tests/unit/transport-eligibility.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest"
+
+import { evaluateStorefrontTransportEligibility } from "../../src/service-transport-eligibility.js"
+import { storefrontTransportEligibilityInputSchema } from "../../src/validation-transport-eligibility.js"
+
+describe("storefront transport eligibility", () => {
+  it("returns blocking passport validity and visa issues without storing document numbers", () => {
+    const input = storefrontTransportEligibilityInputSchema.parse({
+      travelStartsOn: "2026-08-01",
+      travelEndsOn: "2026-08-08",
+      travelers: [
+        {
+          travelerRef: "traveler_1",
+          nationalityCountry: "ro",
+          dateOfBirth: "1990-01-01",
+          documents: [{ type: "passport", issuingCountry: "ro", expiresOn: "2026-09-01" }],
+        },
+      ],
+    })
+
+    const result = evaluateStorefrontTransportEligibility({
+      departureId: "slot_123",
+      productId: "prod_123",
+      travelStartsOn: input.travelStartsOn,
+      travelEndsOn: input.travelEndsOn,
+      travelers: input.travelers,
+      rules: [
+        {
+          id: "rule_passport",
+          label: "Passport and visa",
+          productId: "prod_123",
+          destinationCountries: ["EG"],
+          nationalityCountries: ["RO"],
+          requiredDocumentType: "passport",
+          minValidityDaysAfterReturn: 180,
+          visaRequired: true,
+          severity: "blocking",
+        },
+      ],
+    })
+
+    expect(result.eligible).toBe(false)
+    expect(result.blockingIssues.map((issue) => issue.code)).toEqual([
+      "document_validity",
+      "visa_required",
+    ])
+    expect(JSON.stringify(result)).not.toContain("passportNumber")
+  })
+
+  it("returns warnings for advisory rules while keeping the traveler eligible", () => {
+    const input = storefrontTransportEligibilityInputSchema.parse({
+      travelStartsOn: "2026-08-01",
+      travelEndsOn: "2026-08-08",
+      travelers: [
+        {
+          travelerRef: "traveler_2",
+          nationalityCountry: "US",
+          dateOfBirth: "2015-01-01",
+          documents: [{ type: "passport", issuingCountry: "US", expiresOn: "2030-01-01" }],
+          travelingWithGuardian: false,
+        },
+      ],
+    })
+
+    const result = evaluateStorefrontTransportEligibility({
+      departureId: "slot_123",
+      productId: "prod_123",
+      travelStartsOn: input.travelStartsOn,
+      travelEndsOn: input.travelEndsOn,
+      travelers: input.travelers,
+      rules: [
+        {
+          id: "rule_minor",
+          label: "Minor consent recommended",
+          productId: "prod_123",
+          destinationCountries: ["CA"],
+          nationalityCountries: ["US"],
+          requiredDocumentType: "passport",
+          maxAge: 17,
+          minorConsentRequired: true,
+          severity: "warning",
+        },
+      ],
+    })
+
+    expect(result.eligible).toBe(true)
+    expect(result.blockingIssues).toEqual([])
+    expect(result.warnings.map((issue) => issue.code)).toEqual(["minor_consent_required"])
+  })
+
+  it("accepts a valid ID card when an alternative passport is expired", () => {
+    const input = storefrontTransportEligibilityInputSchema.parse({
+      travelStartsOn: "2026-08-01",
+      travelEndsOn: "2026-08-08",
+      travelers: [
+        {
+          travelerRef: "traveler_3",
+          nationalityCountry: "RO",
+          documents: [
+            { type: "passport", issuingCountry: "RO", expiresOn: "2026-09-01" },
+            { type: "id_card", issuingCountry: "RO", expiresOn: "2027-03-01" },
+          ],
+        },
+      ],
+    })
+
+    const result = evaluateStorefrontTransportEligibility({
+      departureId: "slot_123",
+      productId: "prod_123",
+      travelStartsOn: input.travelStartsOn,
+      travelEndsOn: input.travelEndsOn,
+      travelers: input.travelers,
+      rules: [
+        {
+          id: "rule_passport_or_id",
+          label: "Passport or ID card",
+          productId: "prod_123",
+          destinationCountries: ["BG"],
+          requiredDocumentType: "passport_or_id_card",
+          minValidityDaysAfterReturn: 180,
+        },
+      ],
+    })
+
+    expect(result.eligible).toBe(true)
+    expect(result.blockingIssues).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

- Adds structured storefront transport eligibility schemas and a standalone evaluator for passport, ID-card, visa, validity, nationality, destination, age, and minor-consent rules.
- Adds resolver-backed public endpoints for departure eligibility checks, including product-scoped and departure-scoped routes.
- Documents the API-only first slice, PII boundaries, and the follow-up admin CRUD/UI scope; adds a changeset for `@voyantjs/storefront`.

Closes #872.

## Validation

- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm --filter @voyantjs/storefront lint`
- `pnpm --filter @voyantjs/storefront typecheck`
- `pnpm --filter @voyantjs/storefront test`

The full pre-push test hook ran 125 tasks and failed in an existing `@voyantjs/admin` dashboard empty-state test (`tests/unit/dashboard-page.test.tsx`) that expects `No revenue in the selected window yet.` while the rendered page was still showing skeletons. The storefront package tests passed in that run.
