### PR TITLE
legal: add default storefront contract template selector

### DIFF
--- a/.changeset/legal-default-contract-template.md
+++ b/.changeset/legal-default-contract-template.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/legal": minor
+"@voyantjs/legal-react": minor
+---
+
+Add explicit default storefront contract templates with optional channel scoping and selector fallback support.

--- a/packages/legal-react/src/query-keys.ts
+++ b/packages/legal-react/src/query-keys.ts
@@ -14,6 +14,7 @@ export interface LegalContractTemplatesListFilters {
   search?: string | undefined
   scope?: string | undefined
   language?: string | undefined
+  channelId?: string | undefined
   active?: boolean | undefined
   limit?: number | undefined
   offset?: number | undefined

--- a/packages/legal-react/src/schemas.ts
+++ b/packages/legal-react/src/schemas.ts
@@ -93,6 +93,8 @@ export const legalContractAttachmentSingleResponse = singleEnvelope(
 export const legalContractTemplateRecordSchema = insertContractTemplateSchema.extend({
   id: z.string(),
   description: z.string().nullable(),
+  channelId: z.string().nullable().optional(),
+  isDefault: z.boolean(),
   variableSchema: z.record(z.string(), z.unknown()).nullable().optional(),
   currentVersionId: z.string().nullable().optional(),
   createdAt: z.string(),

--- a/packages/legal/README.md
+++ b/packages/legal/README.md
@@ -25,11 +25,30 @@ const app = createApp({
 ### Contracts
 
 - **Contracts** (`cont`) — legal document instances with status lifecycle
-- **Contract templates** (`ctpl`) — reusable templates with variable schemas
+- **Contract templates** (`ctpl`) — reusable templates with variable schemas,
+  optional channel scope, and explicit storefront defaults
 - **Contract template versions** (`ctpv`) — immutable version snapshots
 - **Contract signatures** (`ctsi`) — signing records (who/when/method/ip)
 - **Contract number series** (`ctns`) — series definitions with auto-increment
 - **Contract attachments** (`ctat`) — rendered PDFs and appendices
+
+## Default Storefront Contract Templates
+
+Contract templates can be marked with `isDefault: true`. At most one default
+template can exist for a given `(scope, channelId, language)` selector. A
+default with `channelId: null` is the global fallback for that scope/language;
+a channel-specific default wins when callers pass `channelId`.
+
+Storefronts can resolve the active customer-safe template through:
+
+- `GET /v1/public/legal/contracts/templates/default`
+- `GET /v1/admin/legal/contracts/templates/default`
+
+Supported query parameters are `scope` (defaults to `customer`), `channelId`,
+`language`, and comma-separated `fallbackLanguages`. Selection checks requested
+and fallback languages in order, prefers channel-specific defaults over global
+defaults, ignores inactive templates, and falls back to the newest active
+matching template only when no explicit default exists for that selector.
 
 ### Policies
 

--- a/packages/legal/src/contracts/index.ts
+++ b/packages/legal/src/contracts/index.ts
@@ -103,6 +103,7 @@ export {
   contractScopeSchema,
   contractSignatureMethodSchema,
   contractStatusSchema,
+  contractTemplateDefaultQuerySchema,
   contractTemplateListQuerySchema,
   generateContractDocumentInputSchema,
   generatedContractDocumentAttachmentSchema,

--- a/packages/legal/src/contracts/schema.ts
+++ b/packages/legal/src/contracts/schema.ts
@@ -67,6 +67,8 @@ export const contractTemplates = pgTable(
     body: text("body").notNull(),
     variableSchema: jsonb("variable_schema"),
     currentVersionId: typeIdRef("current_version_id"),
+    channelId: typeIdRef("channel_id"),
+    isDefault: boolean("is_default").notNull().default(false),
     active: boolean("active").notNull().default(true),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
@@ -74,7 +76,15 @@ export const contractTemplates = pgTable(
   (table) => [
     index("idx_contract_templates_scope").on(table.scope),
     index("idx_contract_templates_language").on(table.language),
+    index("idx_contract_templates_channel").on(table.channelId),
     index("idx_contract_templates_active").on(table.active),
+    index("idx_contract_templates_default_selector").on(
+      table.scope,
+      table.channelId,
+      table.language,
+      table.isDefault,
+      table.active,
+    ),
     index("idx_contract_templates_scope_updated").on(table.scope, table.updatedAt),
     index("idx_contract_templates_language_updated").on(table.language, table.updatedAt),
     index("idx_contract_templates_active_updated").on(table.active, table.updatedAt),
@@ -84,6 +94,12 @@ export const contractTemplates = pgTable(
       table.updatedAt,
     ),
     uniqueIndex("uq_contract_templates_slug").on(table.slug),
+    uniqueIndex("uidx_contract_templates_default_global")
+      .on(table.scope, table.language)
+      .where(sql`${table.isDefault} = true AND ${table.channelId} IS NULL`),
+    uniqueIndex("uidx_contract_templates_default_channel")
+      .on(table.scope, table.channelId, table.language)
+      .where(sql`${table.isDefault} = true AND ${table.channelId} IS NOT NULL`),
   ],
 )
 

--- a/packages/legal/src/contracts/service-shared.ts
+++ b/packages/legal/src/contracts/service-shared.ts
@@ -10,6 +10,7 @@ import type { z } from "zod"
 import { contractNumberSeries, contracts } from "./schema.js"
 import type {
   contractListQuerySchema,
+  contractTemplateDefaultQuerySchema,
   contractTemplateListQuerySchema,
   insertContractAttachmentSchema,
   insertContractNumberSeriesSchema,
@@ -26,6 +27,7 @@ import type {
 
 export type ContractListQuery = z.infer<typeof contractListQuerySchema>
 export type ContractTemplateListQuery = z.infer<typeof contractTemplateListQuerySchema>
+export type ContractTemplateDefaultQuery = z.infer<typeof contractTemplateDefaultQuerySchema>
 export type CreateContractTemplateInput = z.infer<typeof insertContractTemplateSchema>
 export type UpdateContractTemplateInput = z.infer<typeof updateContractTemplateSchema>
 export type CreateContractTemplateVersionInput = z.infer<typeof insertContractTemplateVersionSchema>

--- a/packages/legal/src/contracts/service-templates.ts
+++ b/packages/legal/src/contracts/service-templates.ts
@@ -1,8 +1,9 @@
-import { and, desc, eq, ilike, or, sql } from "drizzle-orm"
+import { and, desc, eq, ilike, isNull, ne, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { contractTemplates, contractTemplateVersions } from "./schema.js"
 import {
+  type ContractTemplateDefaultQuery,
   type ContractTemplateListQuery,
   type CreateContractTemplateInput,
   type CreateContractTemplateVersionInput,
@@ -13,11 +14,41 @@ import {
   validateContractTemplateBody,
 } from "./service-shared.js"
 
+type ContractTemplateRow = typeof contractTemplates.$inferSelect
+
+function normalizeLanguage(value: string | undefined | null) {
+  const normalized = value?.trim().toLowerCase()
+  return normalized || null
+}
+
+function buildLanguageFallbackOrder(query: ContractTemplateDefaultQuery) {
+  return [query.language, ...(query.fallbackLanguages ?? [])]
+    .map(normalizeLanguage)
+    .filter(
+      (value, index, values): value is string => Boolean(value) && values.indexOf(value) === index,
+    )
+}
+
+function pickBestDefaultTemplate(
+  rows: ContractTemplateRow[],
+  channelId: string | undefined,
+): ContractTemplateRow | null {
+  const channelDefault = channelId
+    ? rows.find((row) => row.isDefault && row.channelId === channelId)
+    : null
+  const globalDefault = rows.find((row) => row.isDefault && row.channelId === null)
+  const channelFallback = channelId ? rows.find((row) => row.channelId === channelId) : null
+  const globalFallback = rows.find((row) => row.channelId === null)
+
+  return channelDefault ?? globalDefault ?? channelFallback ?? globalFallback ?? null
+}
+
 export const contractTemplatesService = {
   async listTemplates(db: PostgresJsDatabase, query: ContractTemplateListQuery) {
     const conditions = []
     if (query.scope) conditions.push(eq(contractTemplates.scope, query.scope))
     if (query.language) conditions.push(eq(contractTemplates.language, query.language))
+    if (query.channelId) conditions.push(eq(contractTemplates.channelId, query.channelId))
     if (query.active !== undefined) conditions.push(eq(contractTemplates.active, query.active))
     if (query.search) {
       const term = `%${query.search}%`
@@ -63,46 +94,73 @@ export const contractTemplatesService = {
       .limit(1)
     return row ?? null
   },
-  async getDefaultTemplate(
-    db: PostgresJsDatabase,
-    query: {
-      scope: "customer" | "supplier" | "partner" | "channel" | "other"
-      language?: string
-      fallbackLanguages?: string[]
-    },
-  ) {
+  async getDefaultTemplate(db: PostgresJsDatabase, query: ContractTemplateDefaultQuery) {
+    const channelId = query.channelId?.trim() || undefined
+    const channelConditions = channelId
+      ? or(eq(contractTemplates.channelId, channelId), isNull(contractTemplates.channelId))
+      : isNull(contractTemplates.channelId)
+
     const rows = await db
       .select()
       .from(contractTemplates)
-      .where(and(eq(contractTemplates.scope, query.scope), eq(contractTemplates.active, true)))
-      .orderBy(desc(contractTemplates.updatedAt))
+      .where(
+        and(
+          eq(contractTemplates.scope, query.scope),
+          eq(contractTemplates.active, true),
+          channelConditions,
+        ),
+      )
+      .orderBy(
+        desc(contractTemplates.updatedAt),
+        desc(contractTemplates.createdAt),
+        desc(contractTemplates.id),
+      )
 
     if (rows.length === 0) {
       return null
     }
 
-    const preferredLanguages = [
-      query.language?.trim().toLowerCase(),
-      ...(query.fallbackLanguages ?? []).map((value) => value.trim().toLowerCase()),
-    ].filter(
-      (value, index, values): value is string => Boolean(value) && values.indexOf(value) === index,
-    )
+    const preferredLanguages = buildLanguageFallbackOrder(query)
 
     if (preferredLanguages.length === 0) {
-      return rows[0] ?? null
+      return pickBestDefaultTemplate(rows, channelId)
     }
 
     for (const language of preferredLanguages) {
-      const match = rows.find((row) => row.language.trim().toLowerCase() === language)
+      const match = pickBestDefaultTemplate(
+        rows.filter((row) => row.language.trim().toLowerCase() === language),
+        channelId,
+      )
       if (match) {
         return match
       }
     }
 
-    return rows[0] ?? null
+    return pickBestDefaultTemplate(rows, channelId)
   },
   async createTemplate(db: PostgresJsDatabase, data: CreateContractTemplateInput) {
     validateContractTemplateBody(data.body)
+    if (data.isDefault) {
+      const [existingDefault] = await db
+        .select({ id: contractTemplates.id })
+        .from(contractTemplates)
+        .where(
+          and(
+            eq(contractTemplates.scope, data.scope),
+            eq(contractTemplates.language, data.language),
+            data.channelId
+              ? eq(contractTemplates.channelId, data.channelId)
+              : isNull(contractTemplates.channelId),
+            eq(contractTemplates.isDefault, true),
+          ),
+        )
+        .limit(1)
+      if (existingDefault) {
+        throw new Error(
+          "A default contract template already exists for this scope/channel/language",
+        )
+      }
+    }
     const [row] = await db.insert(contractTemplates).values(data).returning()
     return row ?? null
   },
@@ -139,6 +197,30 @@ export const contractTemplatesService = {
 
       const changedBody =
         typeof data.body === "string" && data.body !== existing.body ? data.body : null
+      const nextTemplate = { ...existing, ...data }
+
+      if (nextTemplate.isDefault) {
+        const [existingDefault] = await tx
+          .select({ id: contractTemplates.id })
+          .from(contractTemplates)
+          .where(
+            and(
+              eq(contractTemplates.scope, nextTemplate.scope),
+              eq(contractTemplates.language, nextTemplate.language),
+              nextTemplate.channelId
+                ? eq(contractTemplates.channelId, nextTemplate.channelId)
+                : isNull(contractTemplates.channelId),
+              eq(contractTemplates.isDefault, true),
+              ne(contractTemplates.id, id),
+            ),
+          )
+          .limit(1)
+        if (existingDefault) {
+          throw new Error(
+            "A default contract template already exists for this scope/channel/language",
+          )
+        }
+      }
 
       let nextCurrentVersionId = existing.currentVersionId
       if (changedBody !== null) {

--- a/packages/legal/src/contracts/validation.ts
+++ b/packages/legal/src/contracts/validation.ts
@@ -50,6 +50,8 @@ const contractTemplateCoreSchema = z.object({
   description: z.string().max(2000).optional().nullable(),
   body: contractTemplateBodySchema,
   variableSchema: z.record(z.string(), z.unknown()).optional().nullable(),
+  channelId: z.string().optional().nullable(),
+  isDefault: z.boolean().default(false),
   active: z.boolean().default(true),
 })
 
@@ -59,12 +61,14 @@ export const updateContractTemplateSchema = contractTemplateCoreSchema.partial()
 export const contractTemplateListQuerySchema = paginationSchema.extend({
   scope: contractScopeSchema.optional(),
   language: z.string().optional(),
+  channelId: z.string().optional(),
   active: z.coerce.boolean().optional(),
   search: z.string().optional(),
 })
 
 export const contractTemplateDefaultQuerySchema = z.object({
   scope: contractScopeSchema.default("customer"),
+  channelId: z.string().optional(),
   language: z.string().min(2).max(10).optional(),
   fallbackLanguages: z
     .string()

--- a/packages/legal/tests/integration/public-routes.test.ts
+++ b/packages/legal/tests/integration/public-routes.test.ts
@@ -113,6 +113,102 @@ describe.skipIf(!DB_AVAILABLE)("Legal public routes", () => {
     expect((await adminRes.json()).data.slug).toBe("customer-en")
   })
 
+  it("selects explicit channel defaults before global defaults", async () => {
+    await db.insert(contractTemplates).values([
+      {
+        name: "Global Customer RO",
+        slug: "global-customer-ro",
+        scope: "customer",
+        language: "ro",
+        body: "Global RO",
+        isDefault: true,
+        active: true,
+      },
+      {
+        name: "Web Customer RO",
+        slug: "web-customer-ro",
+        scope: "customer",
+        language: "ro",
+        channelId: "channel_web",
+        body: "Web RO",
+        isDefault: true,
+        active: true,
+      },
+      {
+        name: "Inactive Web Customer EN",
+        slug: "inactive-web-customer-en",
+        scope: "customer",
+        language: "en",
+        channelId: "channel_web",
+        body: "Inactive Web EN",
+        isDefault: true,
+        active: false,
+      },
+      {
+        name: "Global Customer EN",
+        slug: "global-customer-en",
+        scope: "customer",
+        language: "en",
+        body: "Global EN",
+        isDefault: true,
+        active: true,
+      },
+    ])
+
+    const channelRes = await publicApp.request(
+      "/templates/default?scope=customer&channelId=channel_web&language=ro&fallbackLanguages=en",
+    )
+    expect(channelRes.status).toBe(200)
+    expect((await channelRes.json()).data.slug).toBe("web-customer-ro")
+
+    const globalRes = await publicApp.request(
+      "/templates/default?scope=customer&language=ro&fallbackLanguages=en",
+    )
+    expect(globalRes.status).toBe(200)
+    expect((await globalRes.json()).data.slug).toBe("global-customer-ro")
+
+    const fallbackRes = await publicApp.request(
+      "/templates/default?scope=customer&channelId=channel_web&language=de&fallbackLanguages=en",
+    )
+    expect(fallbackRes.status).toBe(200)
+    expect((await fallbackRes.json()).data.slug).toBe("global-customer-en")
+  })
+
+  it("enforces one default template per scope, channel, and language", async () => {
+    await db.insert(contractTemplates).values({
+      name: "Default Customer EN",
+      slug: "default-customer-en",
+      scope: "customer",
+      language: "en",
+      body: "Default EN",
+      isDefault: true,
+      active: true,
+    })
+
+    await expect(
+      db.insert(contractTemplates).values({
+        name: "Duplicate Default Customer EN",
+        slug: "duplicate-default-customer-en",
+        scope: "customer",
+        language: "en",
+        body: "Duplicate default EN",
+        isDefault: true,
+        active: true,
+      }),
+    ).rejects.toThrow()
+
+    await db.insert(contractTemplates).values({
+      name: "Channel Default Customer EN",
+      slug: "channel-default-customer-en",
+      scope: "customer",
+      language: "en",
+      channelId: "channel_partner",
+      body: "Channel default EN",
+      isDefault: true,
+      active: true,
+    })
+  })
+
   it("renders a public preview from an active template", async () => {
     const [template] = await db
       .insert(contractTemplates)

--- a/templates/dmc/migrations/0007_default_contract_templates.sql
+++ b/templates/dmc/migrations/0007_default_contract_templates.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "contract_templates" ADD COLUMN "channel_id" text;--> statement-breakpoint
+ALTER TABLE "contract_templates" ADD COLUMN "is_default" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+CREATE INDEX "idx_contract_templates_channel" ON "contract_templates" USING btree ("channel_id");--> statement-breakpoint
+CREATE INDEX "idx_contract_templates_default_selector" ON "contract_templates" USING btree ("scope","channel_id","language","is_default","active");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_contract_templates_default_global" ON "contract_templates" USING btree ("scope","language") WHERE "contract_templates"."is_default" = true AND "contract_templates"."channel_id" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_contract_templates_default_channel" ON "contract_templates" USING btree ("scope","channel_id","language") WHERE "contract_templates"."is_default" = true AND "contract_templates"."channel_id" IS NOT NULL;

--- a/templates/dmc/migrations/meta/_journal.json
+++ b/templates/dmc/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1778582674000,
       "tag": "0004_storefront_verification_challenges",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1778778986000,
+      "tag": "0007_default_contract_templates",
+      "breakpoints": true
     }
   ]
 }

--- a/templates/operator/migrations/0015_default_contract_templates.sql
+++ b/templates/operator/migrations/0015_default_contract_templates.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "contract_templates" ADD COLUMN "channel_id" text;--> statement-breakpoint
+ALTER TABLE "contract_templates" ADD COLUMN "is_default" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+CREATE INDEX "idx_contract_templates_channel" ON "contract_templates" USING btree ("channel_id");--> statement-breakpoint
+CREATE INDEX "idx_contract_templates_default_selector" ON "contract_templates" USING btree ("scope","channel_id","language","is_default","active");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_contract_templates_default_global" ON "contract_templates" USING btree ("scope","language") WHERE "contract_templates"."is_default" = true AND "contract_templates"."channel_id" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_contract_templates_default_channel" ON "contract_templates" USING btree ("scope","channel_id","language") WHERE "contract_templates"."is_default" = true AND "contract_templates"."channel_id" IS NOT NULL;

--- a/templates/operator/migrations/meta/_journal.json
+++ b/templates/operator/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1778582674000,
       "tag": "0011_storefront_verification_challenges",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1778778986000,
+      "tag": "0015_default_contract_templates",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add explicit `isDefault` and optional `channelId` fields to legal contract templates with template migrations
- make `/templates/default` resolve channel/global defaults with locale fallback and deterministic legacy fallback
- document the selector contract and add route tests plus changeset

Fixes #875

## Verification
- pnpm --filter @voyantjs/legal lint
- pnpm --filter @voyantjs/legal-react lint
- pnpm --filter @voyantjs/legal typecheck
- pnpm --filter @voyantjs/legal-react typecheck
- pnpm --filter @voyantjs/legal test
- TEST_DATABASE_URL=postgres://test:test@localhost:5436/voyant_test pnpm --filter @voyantjs/legal exec vitest run tests/integration/public-routes.test.ts
- pnpm build
- pnpm verify:package-exports
- pre-push test hook: 125 successful tasks

Note: the full DB-backed `@voyantjs/legal` test suite still fails in this local test DB because the pushed DMC test schema lacks `person_directory`; the focused public-route integration suite covering this change passes.