### PR TITLE
Add legal and finance document operations

### DIFF
--- a/.changeset/legal-finance-document-operations.md
+++ b/.changeset/legal-finance-document-operations.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/legal": minor
+"@voyantjs/finance": minor
+---
+
+Add stable legal document operation routes for contract template previews, stored document attachment, and PDF regeneration, plus booking-scoped customer-safe finance document lookup by reference.

--- a/packages/finance/README.md
+++ b/packages/finance/README.md
@@ -59,6 +59,20 @@ The event does not include rendered document bodies or signed download URLs.
 Subscriber failures do not roll back the rendition write; use a durable job or
 workflow when a downstream reaction needs retries.
 
+## Customer-Safe Document Lookup
+
+Public finance routes include booking-scoped document lookup for customer
+portal and checkout surfaces:
+
+- `GET /v1/public/finance/bookings/:bookingId/documents`
+- `GET /v1/public/finance/bookings/:bookingId/documents/by-reference?reference=...`
+- `GET /v1/public/finance/documents/by-reference?reference=...`
+
+Booking-scoped routes require a checkout capability for the requested booking.
+The by-reference variant resolves invoice numbers and payment reference numbers
+only inside that booking, so a valid capability for one booking cannot retrieve
+documents from another booking.
+
 ## Exports
 
 | Entry | Description |

--- a/packages/finance/src/routes-public.ts
+++ b/packages/finance/src/routes-public.ts
@@ -110,6 +110,20 @@ export function createPublicFinanceRoutes(options: PublicFinanceRouteOptions = {
 
       return documents ? c.json({ data: documents }) : notFound(c, "Booking documents not found")
     })
+    .get("/bookings/:bookingId/documents/by-reference", async (c) => {
+      await requireBookingCheckoutCapability(c, c.req.param("bookingId"), "payment:read")
+
+      const document = await publicFinanceService.getBookingDocumentByReference(
+        c.get("db"),
+        c.req.param("bookingId"),
+        parseQuery(c, publicFinanceDocumentLookupQuerySchema).reference,
+        {
+          resolveDocumentDownloadUrl: (storageKey) => resolveDocumentDownloadUrl(c.env, storageKey),
+        },
+      )
+
+      return document ? c.json({ data: document }) : notFound(c, "Finance document not found")
+    })
     .get("/bookings/:bookingId/payments", async (c) => {
       await requireBookingCheckoutCapability(c, c.req.param("bookingId"), "payment:read")
 

--- a/packages/finance/src/service-public.ts
+++ b/packages/finance/src/service-public.ts
@@ -245,6 +245,57 @@ export const publicFinanceService = {
     }
   },
 
+  async getBookingDocumentByReference(
+    db: PostgresJsDatabase,
+    bookingId: string,
+    reference: string,
+    runtime: PublicFinanceRuntimeOptions = {},
+  ): Promise<PublicFinanceDocumentLookup | null> {
+    const [invoiceMatch, paymentMatch] = await Promise.all([
+      db
+        .select()
+        .from(invoices)
+        .where(and(eq(invoices.bookingId, bookingId), eq(invoices.invoiceNumber, reference)))
+        .orderBy(desc(invoices.createdAt))
+        .limit(1),
+      db
+        .select({
+          invoiceId: payments.invoiceId,
+        })
+        .from(payments)
+        .innerJoin(invoices, eq(payments.invoiceId, invoices.id))
+        .where(and(eq(invoices.bookingId, bookingId), eq(payments.referenceNumber, reference)))
+        .orderBy(desc(payments.createdAt))
+        .limit(1),
+    ])
+
+    const invoiceId = invoiceMatch[0]?.id ?? paymentMatch[0]?.invoiceId ?? null
+    if (!invoiceId) {
+      return null
+    }
+
+    const [invoice] = await db
+      .select()
+      .from(invoices)
+      .where(and(eq(invoices.id, invoiceId), eq(invoices.bookingId, bookingId)))
+      .limit(1)
+
+    if (!invoice?.bookingId) {
+      return null
+    }
+
+    const renditions = await db
+      .select()
+      .from(invoiceRenditions)
+      .where(eq(invoiceRenditions.invoiceId, invoice.id))
+      .orderBy(desc(invoiceRenditions.createdAt))
+
+    return {
+      bookingId: invoice.bookingId,
+      ...(await mapInvoiceDocument(invoice, renditions, runtime)),
+    }
+  },
+
   async getBookingPaymentOptions(
     db: PostgresJsDatabase,
     bookingId: string,

--- a/packages/finance/tests/integration/public-routes.test.ts
+++ b/packages/finance/tests/integration/public-routes.test.ts
@@ -370,6 +370,70 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
       invoiceId: invoice.id,
       invoiceNumber: "PF-REF-1001",
     })
+
+    const bookingScopedRes = await app.request(
+      `/bookings/${booking.id}/documents/by-reference?reference=PAY-REF-1001`,
+      {
+        headers: await capabilityHeaders(booking.id),
+      },
+    )
+
+    expect(bookingScopedRes.status).toBe(200)
+    expect((await bookingScopedRes.json()).data).toMatchObject({
+      bookingId: booking.id,
+      invoiceId: invoice.id,
+      invoiceNumber: "PF-REF-1001",
+      documentStatus: "ready",
+    })
+  })
+
+  it("rejects booking-scoped finance document lookup without matching access", async () => {
+    const booking = await seedBooking()
+    const otherBooking = await seedBooking()
+    const invoice = await seedInvoice(booking.id, {
+      invoiceNumber: "PF-SCOPED-1001",
+      invoiceType: "proforma",
+    })
+    const otherInvoice = await seedInvoice(otherBooking.id, {
+      invoiceNumber: "PF-SCOPED-2002",
+      invoiceType: "proforma",
+    })
+
+    await db.insert(invoiceRenditions).values([
+      {
+        invoiceId: invoice.id,
+        format: "pdf",
+        status: "ready",
+        metadata: { url: "https://example.com/scoped-1001.pdf" },
+      },
+      {
+        invoiceId: otherInvoice.id,
+        format: "pdf",
+        status: "ready",
+        metadata: { url: "https://example.com/scoped-2002.pdf" },
+      },
+    ])
+
+    const missingCapabilityRes = await app.request(
+      `/bookings/${booking.id}/documents/by-reference?reference=PF-SCOPED-1001`,
+    )
+    expect(missingCapabilityRes.status).toBe(401)
+
+    const mismatchedCapabilityRes = await app.request(
+      `/bookings/${booking.id}/documents/by-reference?reference=PF-SCOPED-1001`,
+      {
+        headers: await capabilityHeaders(otherBooking.id),
+      },
+    )
+    expect(mismatchedCapabilityRes.status).toBe(401)
+
+    const mismatchedReferenceRes = await app.request(
+      `/bookings/${booking.id}/documents/by-reference?reference=PF-SCOPED-2002`,
+      {
+        headers: await capabilityHeaders(booking.id),
+      },
+    )
+    expect(mismatchedReferenceRes.status).toBe(404)
   })
 
   it("lists booking-scoped public finance payments with invoice context", async () => {

--- a/packages/legal/README.md
+++ b/packages/legal/README.md
@@ -50,6 +50,24 @@ and fallback languages in order, prefers channel-specific defaults over global
 defaults, ignores inactive templates, and falls back to the newest active
 matching template only when no explicit default exists for that selector.
 
+## Contract Document Operations
+
+The contracts route surface exposes stable operations for storefront previews
+and stored document handling:
+
+- `POST /v1/public/legal/contracts/templates/:id/render-preview`
+- `POST /v1/public/legal/contracts/templates/by-slug/:slug/render-preview`
+- `POST /v1/admin/legal/contracts/templates/:id/render-preview`
+- `POST /v1/admin/legal/contracts/:id/attach-document`
+- `POST /v1/admin/legal/contracts/:id/regenerate-pdf`
+
+Preview routes accept `{ variables }` and return only the rendered text. Public
+preview routes require the template to be active. `attach-document` expects a
+multipart `file` field plus optional `name` and `kind`, uploads through the
+configured `documentStorage`, and persists a contract attachment. `regenerate-pdf`
+uses the configured contract document generator and replaces the canonical
+generated document artifact.
+
 ### Policies
 
 - **Policies** (`pol`) — policy definitions by kind (cancellation, payment, T&C, etc.)

--- a/packages/legal/src/contracts/routes.ts
+++ b/packages/legal/src/contracts/routes.ts
@@ -171,6 +171,115 @@ async function parseAttachmentUploadRequest(c: Context<Env>) {
   return { form, file }
 }
 
+async function renderAdminTemplatePreview(c: Context<Env>) {
+  const id = c.req.param("id")
+  if (!id) return c.json({ error: "Template not found" }, 404)
+  const input = await parseJsonBody(c, renderTemplateInputSchema)
+  const template = await contractsService.getTemplateById(c.get("db"), id)
+  if (!template) return c.json({ error: "Template not found" }, 404)
+  const body = input.body ?? template.body
+  return renderPreviewResponse(c, { ...input, body })
+}
+
+async function renderPublicTemplatePreview(c: Context<Env>) {
+  const id = c.req.param("id")
+  if (!id) return c.json({ error: "Template not found" }, 404)
+  const input = await parseJsonBody(c, publicRenderTemplatePreviewInputSchema)
+  const template = await contractsService.getTemplateById(c.get("db"), id)
+  if (!template?.active) return c.json({ error: "Template not found" }, 404)
+  return renderPreviewResponse(c, {
+    variables: input.variables,
+    body: template.body,
+  })
+}
+
+async function renderPublicTemplatePreviewBySlug(c: Context<Env>) {
+  const slug = c.req.param("slug")
+  if (!slug) return c.json({ error: "Template not found" }, 404)
+  const input = await parseJsonBody(c, publicRenderTemplatePreviewInputSchema)
+  const template = await contractsService.findTemplateBySlug(c.get("db"), slug)
+  if (!template?.active) return c.json({ error: "Template not found" }, 404)
+  return renderPreviewResponse(
+    c,
+    {
+      variables: input.variables,
+      body: template.body,
+    },
+    {
+      template: {
+        id: template.id,
+        slug: template.slug,
+        name: template.name,
+        language: template.language,
+        scope: template.scope,
+      },
+    },
+  )
+}
+
+async function uploadContractAttachment(
+  c: Context<Env>,
+  options: ContractsRouteOptions,
+  contractId: string,
+) {
+  const runtime = getRuntime(options, c.env, (key) => c.var.container?.resolve(key))
+  const storage = runtime.documentStorage
+  if (!storage) {
+    return c.json({ error: "Contract document storage is not configured" }, 501)
+  }
+
+  const contract = await contractsService.getContractById(c.get("db"), contractId)
+  if (!contract) return c.json({ error: "Contract not found" }, 404)
+
+  const parsed = await parseAttachmentUploadRequest(c)
+  if ("error" in parsed) return parsed.error
+
+  const row = await contractsService.createAttachment(
+    c.get("db"),
+    contractId,
+    await buildUploadedAttachmentInput({
+      storage,
+      contractId,
+      form: parsed.form,
+      file: parsed.file,
+    }),
+  )
+  if (!row) return c.json({ error: "Contract not found" }, 404)
+  return c.json({ data: row }, 201)
+}
+
+async function regenerateContractDocument(
+  c: Context<Env>,
+  options: ContractsRouteOptions,
+  contractId: string,
+) {
+  const runtime = getRuntime(options, c.env, (key) => c.var.container?.resolve(key))
+  const generator = runtime.documentGenerator
+  if (!generator) {
+    return c.json({ error: "Contract document generator is not configured" }, 501)
+  }
+
+  const result = await contractsService.regenerateContractDocument(
+    c.get("db"),
+    contractId,
+    await parseOptionalJsonBody(c, generateContractDocumentInputSchema),
+    { generator, bindings: c.env, eventBus: runtime.eventBus },
+  )
+
+  if (result.status === "not_found") return c.json({ error: "Contract not found" }, 404)
+  if (result.status === "not_draft") {
+    return c.json({ error: "Only draft contracts can be auto-issued for document generation" }, 409)
+  }
+  if (result.status === "render_unavailable") {
+    return c.json({ error: "Contract has no renderable body or template version" }, 409)
+  }
+  if (result.status === "generator_failed") {
+    return c.json({ error: "Contract document generation failed" }, 502)
+  }
+
+  return c.json({ data: result })
+}
+
 export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) {
   return new Hono<Env>()
     .get("/templates", async (c) => {
@@ -209,13 +318,8 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
       if (!row) return c.json({ error: "Template not found" }, 404)
       return c.json({ success: true })
     })
-    .post("/templates/:id/preview", async (c) => {
-      const input = await parseJsonBody(c, renderTemplateInputSchema)
-      const template = await contractsService.getTemplateById(c.get("db"), c.req.param("id"))
-      if (!template) return c.json({ error: "Template not found" }, 404)
-      const body = input.body ?? template.body
-      return renderPreviewResponse(c, { ...input, body })
-    })
+    .post("/templates/:id/preview", renderAdminTemplatePreview)
+    .post("/templates/:id/render-preview", renderAdminTemplatePreview)
     .get("/templates/:id/versions", async (c) => {
       const rows = await contractsService.listTemplateVersions(c.get("db"), c.req.param("id"))
       return c.json({ data: rows })
@@ -375,34 +479,10 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
       return c.json({ data: result }, 201)
     })
     .post("/:id/regenerate-document", async (c) => {
-      const runtime = getRuntime(options, c.env, (key) => c.var.container?.resolve(key))
-      const generator = runtime.documentGenerator
-      if (!generator) {
-        return c.json({ error: "Contract document generator is not configured" }, 501)
-      }
-
-      const result = await contractsService.regenerateContractDocument(
-        c.get("db"),
-        c.req.param("id"),
-        await parseOptionalJsonBody(c, generateContractDocumentInputSchema),
-        { generator, bindings: c.env, eventBus: runtime.eventBus },
-      )
-
-      if (result.status === "not_found") return c.json({ error: "Contract not found" }, 404)
-      if (result.status === "not_draft") {
-        return c.json(
-          { error: "Only draft contracts can be auto-issued for document generation" },
-          409,
-        )
-      }
-      if (result.status === "render_unavailable") {
-        return c.json({ error: "Contract has no renderable body or template version" }, 409)
-      }
-      if (result.status === "generator_failed") {
-        return c.json({ error: "Contract document generation failed" }, 502)
-      }
-
-      return c.json({ data: result })
+      return regenerateContractDocument(c, options, c.req.param("id"))
+    })
+    .post("/:id/regenerate-pdf", async (c) => {
+      return regenerateContractDocument(c, options, c.req.param("id"))
     })
     .get("/:id/signatures", async (c) => {
       const rows = await contractsService.listSignatures(c.get("db"), c.req.param("id"))
@@ -422,27 +502,10 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
       return c.json({ data: row }, 201)
     })
     .post("/:id/attachments/upload", async (c) => {
-      const runtime = getRuntime(options, c.env, (key) => c.var.container?.resolve(key))
-      const storage = runtime.documentStorage
-      if (!storage) {
-        return c.json({ error: "Contract document storage is not configured" }, 501)
-      }
-
-      const parsed = await parseAttachmentUploadRequest(c)
-      if ("error" in parsed) return parsed.error
-
-      const row = await contractsService.createAttachment(
-        c.get("db"),
-        c.req.param("id"),
-        await buildUploadedAttachmentInput({
-          storage,
-          contractId: c.req.param("id"),
-          form: parsed.form,
-          file: parsed.file,
-        }),
-      )
-      if (!row) return c.json({ error: "Contract not found" }, 404)
-      return c.json({ data: row }, 201)
+      return uploadContractAttachment(c, options, c.req.param("id"))
+    })
+    .post("/:id/attach-document", async (c) => {
+      return uploadContractAttachment(c, options, c.req.param("id"))
     })
     .patch("/attachments/:attachmentId", async (c) => {
       const row = await contractsService.updateAttachment(
@@ -533,42 +596,16 @@ export function createContractsPublicRoutes() {
         if (!row) return c.json({ error: "Template not found" }, 404)
         return c.json({ data: row })
       })
-      .post("/templates/:id/preview", async (c) => {
-        const input = await parseJsonBody(c, publicRenderTemplatePreviewInputSchema)
-        const template = await contractsService.getTemplateById(c.get("db"), c.req.param("id"))
-        if (!template?.active) return c.json({ error: "Template not found" }, 404)
-        return renderPreviewResponse(c, {
-          variables: input.variables,
-          body: template.body,
-        })
-      })
+      .post("/templates/:id/preview", renderPublicTemplatePreview)
+      .post("/templates/:id/render-preview", renderPublicTemplatePreview)
       /**
        * Slug-based variant — storefronts wire products to a contract
        * template via slug at config time, not id, so they can render the
        * preview in the booking journey before any contract row exists.
        * The dialog at /shop/book/... POSTs here with the draft variables.
        */
-      .post("/templates/by-slug/:slug/preview", async (c) => {
-        const input = await parseJsonBody(c, publicRenderTemplatePreviewInputSchema)
-        const template = await contractsService.findTemplateBySlug(c.get("db"), c.req.param("slug"))
-        if (!template?.active) return c.json({ error: "Template not found" }, 404)
-        return renderPreviewResponse(
-          c,
-          {
-            variables: input.variables,
-            body: template.body,
-          },
-          {
-            template: {
-              id: template.id,
-              slug: template.slug,
-              name: template.name,
-              language: template.language,
-              scope: template.scope,
-            },
-          },
-        )
-      })
+      .post("/templates/by-slug/:slug/preview", renderPublicTemplatePreviewBySlug)
+      .post("/templates/by-slug/:slug/render-preview", renderPublicTemplatePreviewBySlug)
       .get("/:id", async (c) => {
         const row = await contractsService.getContractById(c.get("db"), c.req.param("id"))
         if (!row) return c.json({ error: "Contract not found" }, 404)

--- a/packages/legal/tests/integration/public-routes.test.ts
+++ b/packages/legal/tests/integration/public-routes.test.ts
@@ -1,4 +1,5 @@
 import { createEventBus } from "@voyantjs/core"
+import type { StorageProvider, StorageUploadBody } from "@voyantjs/storage"
 import { eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
@@ -25,6 +26,7 @@ describe.skipIf(!DB_AVAILABLE)("Legal public routes", () => {
   let db: PostgresJsDatabase
   let generatedNames: string[]
   let documentEvents: Array<Record<string, unknown>>
+  let uploadedObjects: Array<{ key: string; size: number; contentType: string | null }>
 
   beforeAll(async () => {
     const { createTestDb, cleanupTestDb } = await import("@voyantjs/db/test-utils")
@@ -41,10 +43,33 @@ describe.skipIf(!DB_AVAILABLE)("Legal public routes", () => {
     eventBus.subscribe("contract.document.generated", (event) => {
       documentEvents.push(event as Record<string, unknown>)
     })
+    uploadedObjects = []
+    const documentStorage: StorageProvider = {
+      name: "legal-test-storage",
+      async upload(body: StorageUploadBody, options = {}) {
+        const key = options.key ?? `contracts/test/${uploadedObjects.length + 1}`
+        const size =
+          body instanceof Blob
+            ? body.size
+            : body instanceof Uint8Array
+              ? body.byteLength
+              : body.byteLength
+        uploadedObjects.push({ key, size, contentType: options.contentType ?? null })
+        return { key, url: `https://cdn.example.com/${key}` }
+      },
+      async delete() {},
+      async signedUrl(key: string) {
+        return `https://signed.example.com/${key}`
+      },
+      async get() {
+        return null
+      },
+    }
     adminApp.route(
       "/",
       createContractsAdminRoutes({
         eventBus,
+        documentStorage,
         resolveDocumentDownloadUrl: (_bindings, storageKey) =>
           `https://signed.example.com/${storageKey}`,
         documentGenerator: async ({ contract }) => {
@@ -78,6 +103,7 @@ describe.skipIf(!DB_AVAILABLE)("Legal public routes", () => {
     await cleanupTestDb(db)
     generatedNames = []
     documentEvents = []
+    uploadedObjects = []
   })
 
   it("selects the default active template using language fallback order", async () => {
@@ -235,6 +261,20 @@ describe.skipIf(!DB_AVAILABLE)("Legal public routes", () => {
     expect((await res.json()).data).toEqual({
       rendered: "Salut Ana Popescu",
     })
+
+    const stableAliasRes = await publicApp.request(`/templates/${template.id}/render-preview`, {
+      method: "POST",
+      ...json({
+        variables: {
+          customer: { firstName: "Mara", lastName: "Ionescu" },
+        },
+      }),
+    })
+
+    expect(stableAliasRes.status).toBe(200)
+    expect((await stableAliasRes.json()).data).toEqual({
+      rendered: "Salut Mara Ionescu",
+    })
   })
 
   it("generates and regenerates a canonical contract document attachment", async () => {
@@ -296,7 +336,7 @@ describe.skipIf(!DB_AVAILABLE)("Legal public routes", () => {
     expect(issuedContract?.status).toBe("issued")
     expect(issuedContract?.renderedBody).toBe("Salut Ana")
 
-    const secondRes = await adminApp.request(`/${contract.id}/regenerate-document`, {
+    const secondRes = await adminApp.request(`/${contract.id}/regenerate-pdf`, {
       method: "POST",
       ...json({}),
     })
@@ -349,5 +389,61 @@ describe.skipIf(!DB_AVAILABLE)("Legal public routes", () => {
     expect(downloadRes.headers.get("location")).toBe(
       `https://signed.example.com/${latestAttachment?.storageKey}`,
     )
+  })
+
+  it("attaches an uploaded stored document to a contract", async () => {
+    const [contract] = await db
+      .insert(contracts)
+      .values({
+        title: "Uploaded contract",
+        scope: "customer",
+        status: "issued",
+      })
+      .returning()
+
+    const form = new FormData()
+    form.set("name", "Signed contract.pdf")
+    form.set("kind", "signed_contract")
+    form.set("file", new File(["signed body"], "signed.pdf", { type: "application/pdf" }))
+
+    const res = await adminApp.request(`/${contract.id}/attach-document`, {
+      method: "POST",
+      body: form,
+    })
+
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.data).toMatchObject({
+      contractId: contract.id,
+      kind: "signed_contract",
+      name: "Signed contract.pdf",
+      mimeType: "application/pdf",
+      fileSize: 11,
+      checksum: expect.stringMatching(/^sha256:/),
+    })
+    expect(body.data.storageKey).toContain(`contracts/${contract.id}/attachments/`)
+    expect(uploadedObjects).toEqual([
+      expect.objectContaining({
+        key: body.data.storageKey,
+        size: 11,
+        contentType: "application/pdf",
+      }),
+    ])
+  })
+
+  it("does not upload a stored document for a missing contract", async () => {
+    const form = new FormData()
+    form.set("name", "Missing contract.pdf")
+    form.set("kind", "signed_contract")
+    form.set("file", new File(["signed body"], "missing.pdf", { type: "application/pdf" }))
+
+    const res = await adminApp.request("/00000000-0000-0000-0000-000000000000/attach-document", {
+      method: "POST",
+      body: form,
+    })
+
+    expect(res.status).toBe(404)
+    expect(await res.json()).toEqual({ error: "Contract not found" })
+    expect(uploadedObjects).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary
- add stable legal contract preview aliases, stored-document attachment, and PDF regeneration routes
- add booking-scoped public finance document lookup by invoice or payment reference
- document the public/admin route surfaces and add a changeset

## Validation
- pnpm --filter @voyantjs/legal typecheck
- pnpm --filter @voyantjs/finance typecheck
- pnpm --filter @voyantjs/legal lint
- pnpm --filter @voyantjs/finance lint
- pnpm --filter @voyantjs/legal test -- tests/integration/public-routes.test.ts
- pnpm --filter @voyantjs/finance test -- tests/integration/public-routes.test.ts
- pnpm lint:changed
- pnpm verify:route-authoring

Notes:
- DB-gated integration cases were skipped because TEST_DATABASE_URL is not set locally.
- The broad pre-push monorepo test hook failed while running outside the scoped legal/finance lane.

Closes #871
