### PR TITLE
[codex] Add storefront public intake

### DIFF
--- a/.changeset/public-storefront-intake.md
+++ b/.changeset/public-storefront-intake.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/storefront": minor
+"@voyantjs/crm": minor
+---
+
+Add public storefront lead and newsletter intake backed by CRM customer signals, including host-owned spam guard hooks, newsletter double-opt-in callback wiring, and a documented `customer.signal.created` event.

--- a/packages/crm/README.md
+++ b/packages/crm/README.md
@@ -32,12 +32,28 @@ const app = createApp({
 - **Notes** — person (`pnot`), organization (`onot`)
 - **Communication log** (`clog`)
 - **Segments** + **segment members** (`seg`, `segm`)
+- **Customer signals** (`csg`) — inquiry, wishlist, notify, request-offer, and referral signals used by admin CRM and public storefront intake
+
+## Events
+
+`customer.signal.created` is emitted when public storefront intake accepts a
+lead or newsletter subscription. Subscribe to it from app code to send
+operator notifications:
+
+```ts
+eventBus.subscribe("customer.signal.created", async ({ data }) => {
+  if (data.intake?.surface === "storefront") {
+    await notifySalesTeam(data.id)
+  }
+})
+```
 
 ## Exports
 
 | Entry | Description |
 | --- | --- |
 | `.` | Module export + public types |
+| `./events` | CRM event names, payload types, and emit helpers |
 | `./schema` | Drizzle tables + linkable definitions |
 | `./validation` | Zod schemas |
 | `./routes` | Hono routes for admin/public surfaces |

--- a/packages/crm/package.json
+++ b/packages/crm/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./events": "./src/events.ts",
     "./schema": "./src/schema.ts",
     "./validation": "./src/validation.ts",
     "./routes": "./src/routes/index.ts",
@@ -42,6 +43,11 @@
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js",
         "default": "./dist/index.js"
+      },
+      "./events": {
+        "types": "./dist/events.d.ts",
+        "import": "./dist/events.js",
+        "default": "./dist/events.js"
       },
       "./schema": {
         "types": "./dist/schema.d.ts",

--- a/packages/crm/src/events.ts
+++ b/packages/crm/src/events.ts
@@ -1,0 +1,38 @@
+import type { EventBus, EventSource } from "@voyantjs/core"
+
+export const CUSTOMER_SIGNAL_CREATED_EVENT = "customer.signal.created" as const
+
+export type CustomerSignalCreatedIntake =
+  | {
+      surface: "storefront"
+      type: "lead"
+    }
+  | {
+      surface: "storefront"
+      type: "newsletter"
+      doubleOptIn: "not_configured" | "requested"
+    }
+
+export interface CustomerSignalCreatedEvent {
+  id: string
+  personId: string
+  kind: "wishlist" | "notify" | "inquiry" | "request_offer" | "referral"
+  source: "form" | "phone" | "admin" | "abandoned_cart" | "website" | "booking"
+  status: "new" | "contacted" | "qualified" | "converted" | "lost" | "expired"
+  productId?: string | null
+  optionUnitId?: string | null
+  sourceSubmissionId?: string | null
+  intake?: CustomerSignalCreatedIntake
+}
+
+export async function emitCustomerSignalCreated(
+  eventBus: EventBus | undefined,
+  payload: CustomerSignalCreatedEvent,
+  source: EventSource = "service",
+): Promise<void> {
+  if (!eventBus) return
+  await eventBus.emit(CUSTOMER_SIGNAL_CREATED_EVENT, payload, {
+    category: "domain",
+    source,
+  })
+}

--- a/packages/crm/src/index.ts
+++ b/packages/crm/src/index.ts
@@ -1,6 +1,6 @@
 import type { LinkableDefinition, Module } from "@voyantjs/core"
 import type { HonoModule } from "@voyantjs/hono/module"
-
+import { CUSTOMER_SIGNAL_CREATED_EVENT, emitCustomerSignalCreated } from "./events.js"
 import {
   buildCrmRouteRuntime,
   CRM_ROUTE_RUNTIME_CONTAINER_KEY,
@@ -61,6 +61,7 @@ export function createCrmHonoModule(options: CrmHonoModuleOptions = {}): HonoMod
 export const crmHonoModule: HonoModule = createCrmHonoModule()
 
 export { crmBookingExtension } from "./booking-extension.js"
+export type { CustomerSignalCreatedEvent, CustomerSignalCreatedIntake } from "./events.js"
 export type {
   CrmRouteRuntime,
   CrmRouteRuntimeOptions,
@@ -232,4 +233,4 @@ export {
   updateStageSchema,
   upsertCustomFieldValueSchema,
 } from "./validation.js"
-export { crmService }
+export { CUSTOMER_SIGNAL_CREATED_EVENT, crmService, emitCustomerSignalCreated }

--- a/packages/storefront/README.md
+++ b/packages/storefront/README.md
@@ -3,6 +3,45 @@
 Public storefront routes and service helpers for checkout-adjacent product, departure,
 offer, and eligibility flows.
 
+## Public Intake
+
+Storefront can accept public CRM intake at the public root:
+
+- `POST /leads`
+- `POST /newsletter/subscribe`
+
+When mounted through `createStorefrontHonoModule`, these become
+`/v1/public/leads` and `/v1/public/newsletter/subscribe`.
+
+Both routes create a CRM person and a CRM customer signal. Lead intake accepts
+the CRM signal `kind`, `source`, product/option references, bounded payload
+metadata, and consent metadata. Newsletter intake records a `notify` signal and
+uses `sourceSubmissionId` for idempotency; when omitted, the email address is
+used to derive a stable newsletter submission key.
+
+```ts
+import { createStorefrontHonoModule } from "@voyantjs/storefront"
+
+createStorefrontHonoModule({
+  intake: {
+    guard({ body, context }) {
+      // Install host-owned rate-limit, captcha, signature, or abuse checks.
+      if (!isCaptchaValid(body, context)) {
+        return { allowed: false, status: 429, error: "Captcha required" }
+      }
+    },
+    async requestNewsletterDoubleOptIn({ email, signalId }) {
+      await sendDoubleOptInEmail(email, { signalId })
+    },
+  },
+})
+```
+
+Accepted intake emits `customer.signal.created` on the app event bus with
+`metadata.category: "domain"` and an `intake` payload describing whether the
+signal came from `lead` or `newsletter` intake. Notification adapters can
+subscribe to that event to send CRM email, Slack, or other operator alerts.
+
 ## Transport Eligibility
 
 Storefronts can check whether traveler document facts satisfy departure-level

--- a/packages/storefront/package.json
+++ b/packages/storefront/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@voyantjs/availability": "workspace:*",
     "@voyantjs/core": "workspace:*",
+    "@voyantjs/crm": "workspace:*",
     "@voyantjs/extras": "workspace:*",
     "@voyantjs/hono": "workspace:*",
     "@voyantjs/pricing": "workspace:*",

--- a/packages/storefront/src/index.ts
+++ b/packages/storefront/src/index.ts
@@ -11,12 +11,25 @@ export type {
   StorefrontServiceOptions,
 } from "./service.js"
 export { createStorefrontService, resolveStorefrontSettings } from "./service.js"
+export type {
+  StorefrontIntakeGuard,
+  StorefrontIntakeGuardDecision,
+  StorefrontIntakeOptions,
+  StorefrontNewsletterDoubleOptInHook,
+} from "./service-intake.js"
+export { CUSTOMER_SIGNAL_CREATED_EVENT } from "./service-intake.js"
 export { evaluateStorefrontTransportEligibility } from "./service-transport-eligibility.js"
 export type {
   StorefrontAppliedOffer,
   StorefrontDepartureListQuery,
   StorefrontFormField,
   StorefrontFormFieldInput,
+  StorefrontIntakeConsent,
+  StorefrontIntakeResponse,
+  StorefrontLeadContact,
+  StorefrontLeadIntakeInput,
+  StorefrontNewsletterSubscribeInput,
+  StorefrontNewsletterSubscribeResponse,
   StorefrontOfferApplyInput,
   StorefrontOfferMutationResult,
   StorefrontOfferRedeemInput,
@@ -40,6 +53,12 @@ export {
   storefrontFormFieldOptionSchema,
   storefrontFormFieldSchema,
   storefrontFormFieldTypeSchema,
+  storefrontIntakeConsentSchema,
+  storefrontIntakeResponseSchema,
+  storefrontLeadContactSchema,
+  storefrontLeadIntakeInputSchema,
+  storefrontNewsletterSubscribeInputSchema,
+  storefrontNewsletterSubscribeResponseSchema,
   storefrontOfferApplyInputSchema,
   storefrontOfferAudienceSchema,
   storefrontOfferConflictSchema,

--- a/packages/storefront/src/routes-public.ts
+++ b/packages/storefront/src/routes-public.ts
@@ -1,3 +1,4 @@
+import type { EventBus } from "@voyantjs/core"
 import { parseJsonBody, parseQuery } from "@voyantjs/hono"
 import type { Context } from "hono"
 import { Hono } from "hono"
@@ -8,8 +9,12 @@ import {
   type StorefrontServiceOptions,
 } from "./service.js"
 import {
+  type StorefrontLeadIntakeInput,
+  type StorefrontNewsletterSubscribeInput,
   storefrontDepartureListQuerySchema,
   storefrontDeparturePricePreviewInputSchema,
+  storefrontLeadIntakeInputSchema,
+  storefrontNewsletterSubscribeInputSchema,
   storefrontOfferApplyInputSchema,
   storefrontOfferRedeemInputSchema,
   storefrontProductAvailabilitySummaryQuerySchema,
@@ -21,6 +26,7 @@ import { storefrontTransportEligibilityInputSchema } from "./validation-transpor
 type Env = {
   Variables: {
     db: unknown
+    eventBus?: EventBus
   }
 }
 
@@ -30,14 +36,68 @@ export function createStorefrontPublicRoutes(options?: StorefrontServiceOptions)
   function getRequestContext(c: Context<Env>): StorefrontRequestContext {
     return {
       db: c.get("db" as never) as StorefrontRequestContext["db"],
+      eventBus: c.get("eventBus" as never) as StorefrontRequestContext["eventBus"],
       env: c.env,
       context: c,
     } satisfies StorefrontRequestContext
   }
 
+  async function runIntakeGuard(
+    input:
+      | {
+          kind: "lead"
+          body: StorefrontLeadIntakeInput
+          context: StorefrontRequestContext
+        }
+      | {
+          kind: "newsletter"
+          body: StorefrontNewsletterSubscribeInput
+          context: StorefrontRequestContext
+        },
+  ) {
+    const decision = await storefrontService.checkIntakeGuard(input)
+    if (!decision || decision.allowed) return null
+    return {
+      status: decision.status ?? 403,
+      error: decision.error ?? "Storefront intake rejected",
+    }
+  }
+
   return new Hono<Env>()
     .get("/settings", async (c) => {
       return c.json({ data: await storefrontService.resolveSettings(getRequestContext(c)) })
+    })
+    .post("/leads", async (c) => {
+      const context = getRequestContext(c)
+      const body = await parseJsonBody(c, storefrontLeadIntakeInputSchema)
+      const rejected = await runIntakeGuard({ kind: "lead", body, context })
+      if (rejected) return c.json({ error: rejected.error }, rejected.status)
+
+      return c.json(
+        {
+          data: await storefrontService.createLead({
+            body,
+            context,
+          }),
+        },
+        201,
+      )
+    })
+    .post("/newsletter/subscribe", async (c) => {
+      const context = getRequestContext(c)
+      const body = await parseJsonBody(c, storefrontNewsletterSubscribeInputSchema)
+      const rejected = await runIntakeGuard({ kind: "newsletter", body, context })
+      if (rejected) return c.json({ error: rejected.error }, rejected.status)
+
+      return c.json(
+        {
+          data: await storefrontService.subscribeNewsletter({
+            body,
+            context,
+          }),
+        },
+        202,
+      )
     })
     .get("/departures/:departureId", async (c) => {
       const departure = await storefrontService.getDeparture(

--- a/packages/storefront/src/service-intake.ts
+++ b/packages/storefront/src/service-intake.ts
@@ -1,0 +1,295 @@
+import { crmService } from "@voyantjs/crm"
+import { CUSTOMER_SIGNAL_CREATED_EVENT, emitCustomerSignalCreated } from "@voyantjs/crm/events"
+import { customerSignals } from "@voyantjs/crm/schema"
+import { and, eq } from "drizzle-orm"
+
+import type { StorefrontRequestContext } from "./service.js"
+import type {
+  StorefrontIntakeResponse,
+  StorefrontLeadContact,
+  StorefrontLeadIntakeInput,
+  StorefrontNewsletterSubscribeInput,
+  StorefrontNewsletterSubscribeResponse,
+} from "./validation.js"
+
+export { CUSTOMER_SIGNAL_CREATED_EVENT }
+
+export interface StorefrontIntakeGuardDecision {
+  allowed: boolean
+  status?: 400 | 403 | 429
+  error?: string
+}
+
+export type StorefrontIntakeGuard = (
+  input:
+    | {
+        kind: "lead"
+        body: StorefrontLeadIntakeInput
+        context: StorefrontRequestContext
+      }
+    | {
+        kind: "newsletter"
+        body: StorefrontNewsletterSubscribeInput
+        context: StorefrontRequestContext
+      },
+) => Promise<StorefrontIntakeGuardDecision | undefined> | StorefrontIntakeGuardDecision | undefined
+
+export type StorefrontNewsletterDoubleOptInHook = (input: {
+  email: string
+  personId: string
+  signalId: string
+  sourceSubmissionId: string
+  body: StorefrontNewsletterSubscribeInput
+  context: StorefrontRequestContext
+}) => Promise<void> | void
+
+export interface StorefrontIntakeOptions {
+  guard?: StorefrontIntakeGuard
+  requestNewsletterDoubleOptIn?: StorefrontNewsletterDoubleOptInHook
+}
+
+function requireDb(context: StorefrontRequestContext) {
+  if (!context.db) {
+    throw new Error("Storefront intake requires a request database")
+  }
+  return context.db
+}
+
+function splitName(name: string | undefined): { firstName?: string; lastName?: string } {
+  if (!name) return {}
+  const parts = name.trim().split(/\s+/)
+  if (parts.length === 0) return {}
+  if (parts.length === 1) return { firstName: parts[0] }
+  return { firstName: parts[0], lastName: parts.slice(1).join(" ") }
+}
+
+function personNameFromContact(contact: StorefrontLeadContact) {
+  const split = splitName(contact.name)
+  return {
+    firstName: contact.firstName ?? split.firstName ?? "Storefront",
+    lastName: contact.lastName ?? split.lastName ?? "Lead",
+  }
+}
+
+function personNameFromNewsletter(input: StorefrontNewsletterSubscribeInput) {
+  const split = splitName(input.name)
+  const emailLocalPart = input.email
+    .split("@")[0]
+    ?.replace(/[._-]+/g, " ")
+    .trim()
+  return {
+    firstName: input.firstName ?? split.firstName ?? emailLocalPart ?? "Newsletter",
+    lastName: input.lastName ?? split.lastName ?? "Subscriber",
+  }
+}
+
+function normalizeEmail(email: string) {
+  return email.trim().toLowerCase()
+}
+
+function defaultNewsletterSubmissionId(email: string) {
+  return `newsletter:${normalizeEmail(email)}`
+}
+
+async function findExistingSignal(
+  db: ReturnType<typeof requireDb>,
+  input: {
+    kind: StorefrontLeadIntakeInput["kind"]
+    sourceSubmissionId?: string | null
+  },
+) {
+  if (!input.sourceSubmissionId) return null
+  const [row] = await db
+    .select()
+    .from(customerSignals)
+    .where(
+      and(
+        eq(customerSignals.kind, input.kind),
+        eq(customerSignals.sourceSubmissionId, input.sourceSubmissionId),
+      ),
+    )
+    .limit(1)
+  return row ?? null
+}
+
+function leadResponse(
+  signal: NonNullable<Awaited<ReturnType<typeof findExistingSignal>>>,
+  duplicate: boolean,
+): StorefrontIntakeResponse {
+  return {
+    id: signal.id,
+    personId: signal.personId,
+    kind: signal.kind,
+    source: signal.source,
+    status: signal.status,
+    duplicate,
+  }
+}
+
+function newsletterDoubleOptInFromSignal(
+  signal: NonNullable<Awaited<ReturnType<typeof findExistingSignal>>>,
+) {
+  const metadata = signal.metadata
+  const newsletter =
+    metadata && typeof metadata === "object" && "newsletter" in metadata
+      ? metadata.newsletter
+      : null
+  if (!newsletter || typeof newsletter !== "object" || !("doubleOptIn" in newsletter)) {
+    return "not_configured"
+  }
+  return newsletter.doubleOptIn === "requested" ? "requested" : "not_configured"
+}
+
+export async function createStorefrontLeadSignal(input: {
+  body: StorefrontLeadIntakeInput
+  context: StorefrontRequestContext
+}): Promise<StorefrontIntakeResponse> {
+  const db = requireDb(input.context)
+  const existing = await findExistingSignal(db, {
+    kind: input.body.kind,
+    sourceSubmissionId: input.body.sourceSubmissionId,
+  })
+  if (existing) return leadResponse(existing, true)
+
+  const { firstName, lastName } = personNameFromContact(input.body.contact)
+  const person = await crmService.createPerson(db, {
+    firstName,
+    lastName,
+    status: "active",
+    website: null,
+    email: input.body.contact.email ? normalizeEmail(input.body.contact.email) : null,
+    phone: input.body.contact.phone ?? null,
+    source: "storefront",
+    sourceRef: input.body.sourceSubmissionId ?? null,
+    tags: input.body.tags,
+  })
+  if (!person) throw new Error("Failed to create CRM person for storefront lead")
+
+  const signal = await crmService.createCustomerSignal(db, {
+    personId: person.id,
+    productId: input.body.productId ?? null,
+    optionUnitId: input.body.optionUnitId ?? null,
+    kind: input.body.kind,
+    source: input.body.source,
+    status: "new",
+    priority: "normal",
+    notes: input.body.notes ?? null,
+    tags: input.body.tags,
+    sourceSubmissionId: input.body.sourceSubmissionId ?? null,
+    metadata: {
+      intake: { surface: "storefront", type: "lead" },
+      payload: input.body.payload,
+      consent: input.body.consent,
+      source: {
+        url: input.body.sourceUrl ?? null,
+        locale: input.body.locale ?? null,
+      },
+    },
+  })
+  if (!signal) throw new Error("Failed to create CRM customer signal for storefront lead")
+
+  await emitCustomerSignalCreated(
+    input.context.eventBus,
+    {
+      id: signal.id,
+      personId: signal.personId,
+      kind: signal.kind,
+      source: signal.source,
+      status: signal.status,
+      productId: signal.productId,
+      optionUnitId: signal.optionUnitId,
+      sourceSubmissionId: signal.sourceSubmissionId,
+      intake: { surface: "storefront", type: "lead" },
+    },
+    "route",
+  )
+
+  return leadResponse(signal, false)
+}
+
+export async function subscribeStorefrontNewsletter(input: {
+  body: StorefrontNewsletterSubscribeInput
+  context: StorefrontRequestContext
+  requestDoubleOptIn?: StorefrontNewsletterDoubleOptInHook
+}): Promise<StorefrontNewsletterSubscribeResponse> {
+  const db = requireDb(input.context)
+  const email = normalizeEmail(input.body.email)
+  const sourceSubmissionId =
+    input.body.sourceSubmissionId ?? defaultNewsletterSubmissionId(input.body.email)
+  const existing = await findExistingSignal(db, {
+    kind: "notify",
+    sourceSubmissionId,
+  })
+  if (existing) {
+    return {
+      ...leadResponse(existing, true),
+      doubleOptIn: newsletterDoubleOptInFromSignal(existing),
+    }
+  }
+
+  const { firstName, lastName } = personNameFromNewsletter(input.body)
+  const person = await crmService.createPerson(db, {
+    firstName,
+    lastName,
+    status: "active",
+    website: null,
+    email,
+    source: "storefront-newsletter",
+    sourceRef: sourceSubmissionId,
+    tags: input.body.tags,
+  })
+  if (!person) throw new Error("Failed to create CRM person for newsletter subscription")
+
+  const doubleOptIn = input.requestDoubleOptIn ? "requested" : "not_configured"
+  const signal = await crmService.createCustomerSignal(db, {
+    personId: person.id,
+    kind: "notify",
+    source: input.body.source,
+    status: "new",
+    priority: "normal",
+    notes: "Newsletter subscription",
+    tags: input.body.tags,
+    sourceSubmissionId,
+    metadata: {
+      intake: { surface: "storefront", type: "newsletter" },
+      newsletter: { email, doubleOptIn },
+      payload: input.body.payload,
+      consent: input.body.consent,
+      source: {
+        url: input.body.sourceUrl ?? null,
+        locale: input.body.locale ?? null,
+      },
+    },
+  })
+  if (!signal) throw new Error("Failed to create CRM customer signal for newsletter subscription")
+
+  await input.requestDoubleOptIn?.({
+    email,
+    personId: person.id,
+    signalId: signal.id,
+    sourceSubmissionId,
+    body: input.body,
+    context: input.context,
+  })
+
+  await emitCustomerSignalCreated(
+    input.context.eventBus,
+    {
+      id: signal.id,
+      personId: signal.personId,
+      kind: signal.kind,
+      source: signal.source,
+      status: signal.status,
+      productId: signal.productId,
+      optionUnitId: signal.optionUnitId,
+      sourceSubmissionId: signal.sourceSubmissionId,
+      intake: { surface: "storefront", type: "newsletter", doubleOptIn },
+    },
+    "route",
+  )
+
+  return {
+    ...leadResponse(signal, false),
+    doubleOptIn,
+  }
+}

--- a/packages/storefront/src/service-intake.ts
+++ b/packages/storefront/src/service-intake.ts
@@ -140,6 +140,23 @@ function newsletterDoubleOptInFromSignal(
   return newsletter.doubleOptIn === "requested" ? "requested" : "not_configured"
 }
 
+function newsletterSignalMetadata(input: {
+  email: string
+  doubleOptIn: "not_configured" | "requested"
+  body: StorefrontNewsletterSubscribeInput
+}) {
+  return {
+    intake: { surface: "storefront", type: "newsletter" },
+    newsletter: { email: input.email, doubleOptIn: input.doubleOptIn },
+    payload: input.body.payload,
+    consent: input.body.consent,
+    source: {
+      url: input.body.sourceUrl ?? null,
+      locale: input.body.locale ?? null,
+    },
+  }
+}
+
 export async function createStorefrontLeadSignal(input: {
   body: StorefrontLeadIntakeInput
   context: StorefrontRequestContext
@@ -241,7 +258,7 @@ export async function subscribeStorefrontNewsletter(input: {
   if (!person) throw new Error("Failed to create CRM person for newsletter subscription")
 
   const doubleOptIn = input.requestDoubleOptIn ? "requested" : "not_configured"
-  const signal = await crmService.createCustomerSignal(db, {
+  let signal = await crmService.createCustomerSignal(db, {
     personId: person.id,
     kind: "notify",
     source: input.body.source,
@@ -250,27 +267,39 @@ export async function subscribeStorefrontNewsletter(input: {
     notes: "Newsletter subscription",
     tags: input.body.tags,
     sourceSubmissionId,
-    metadata: {
-      intake: { surface: "storefront", type: "newsletter" },
-      newsletter: { email, doubleOptIn },
-      payload: input.body.payload,
-      consent: input.body.consent,
-      source: {
-        url: input.body.sourceUrl ?? null,
-        locale: input.body.locale ?? null,
-      },
-    },
+    metadata: newsletterSignalMetadata({
+      email,
+      doubleOptIn: "not_configured",
+      body: input.body,
+    }),
   })
   if (!signal) throw new Error("Failed to create CRM customer signal for newsletter subscription")
 
-  await input.requestDoubleOptIn?.({
-    email,
-    personId: person.id,
-    signalId: signal.id,
-    sourceSubmissionId,
-    body: input.body,
-    context: input.context,
-  })
+  if (input.requestDoubleOptIn) {
+    try {
+      await input.requestDoubleOptIn({
+        email,
+        personId: person.id,
+        signalId: signal.id,
+        sourceSubmissionId,
+        body: input.body,
+        context: input.context,
+      })
+    } catch (error) {
+      await crmService.deleteCustomerSignal(db, signal.id).catch(() => null)
+      await crmService.deletePerson(db, person.id).catch(() => null)
+      throw error
+    }
+
+    signal =
+      (await crmService.updateCustomerSignal(db, signal.id, {
+        metadata: newsletterSignalMetadata({
+          email,
+          doubleOptIn,
+          body: input.body,
+        }),
+      })) ?? signal
+  }
 
   await emitCustomerSignalCreated(
     input.context.eventBus,

--- a/packages/storefront/src/service.ts
+++ b/packages/storefront/src/service.ts
@@ -1,3 +1,4 @@
+import type { EventBus } from "@voyantjs/core"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import {
@@ -8,12 +9,20 @@ import {
   listStorefrontProductDepartures,
   previewStorefrontDeparturePrice,
 } from "./service-departures.js"
+import {
+  createStorefrontLeadSignal,
+  type StorefrontIntakeGuard,
+  type StorefrontIntakeOptions,
+  subscribeStorefrontNewsletter,
+} from "./service-intake.js"
 import { evaluateStorefrontTransportEligibility } from "./service-transport-eligibility.js"
 import {
   type StorefrontDepartureListQuery,
   type StorefrontDeparturePricePreviewInput,
   type StorefrontFormField,
   type StorefrontFormFieldInput,
+  type StorefrontLeadIntakeInput,
+  type StorefrontNewsletterSubscribeInput,
   type StorefrontOfferApplyInput,
   type StorefrontOfferMutationResult,
   type StorefrontOfferRedeemInput,
@@ -57,10 +66,12 @@ export interface StorefrontServiceOptions {
   ) =>
     | Promise<StorefrontTransportEligibilityRuleInput[]>
     | StorefrontTransportEligibilityRuleInput[]
+  intake?: StorefrontIntakeOptions
 }
 
 export interface StorefrontRequestContext {
   db?: PostgresJsDatabase
+  eventBus?: EventBus
   env?: unknown
   context?: unknown
 }
@@ -184,6 +195,22 @@ export function createStorefrontService(options?: StorefrontServiceOptions) {
     )
   }
 
+  async function checkIntakeGuard(
+    input:
+      | {
+          kind: "lead"
+          body: StorefrontLeadIntakeInput
+          context: StorefrontRequestContext
+        }
+      | {
+          kind: "newsletter"
+          body: StorefrontNewsletterSubscribeInput
+          context: StorefrontRequestContext
+        },
+  ) {
+    return options?.intake?.guard?.(input)
+  }
+
   return {
     getSettings(): StorefrontSettings {
       return settings
@@ -302,5 +329,20 @@ export function createStorefrontService(options?: StorefrontServiceOptions) {
         )) ?? null
       )
     },
+    checkIntakeGuard,
+    createLead(input: { body: StorefrontLeadIntakeInput; context: StorefrontRequestContext }) {
+      return createStorefrontLeadSignal(input)
+    },
+    subscribeNewsletter(input: {
+      body: StorefrontNewsletterSubscribeInput
+      context: StorefrontRequestContext
+    }) {
+      return subscribeStorefrontNewsletter({
+        ...input,
+        requestDoubleOptIn: options?.intake?.requestNewsletterDoubleOptIn,
+      })
+    },
   }
 }
+
+export type { StorefrontIntakeGuard, StorefrontIntakeOptions }

--- a/packages/storefront/src/validation.ts
+++ b/packages/storefront/src/validation.ts
@@ -1,4 +1,9 @@
 import { availabilitySlotStatusSchema } from "@voyantjs/availability/validation"
+import {
+  customerSignalKindSchema,
+  customerSignalSourceSchema,
+  customerSignalStatusSchema,
+} from "@voyantjs/crm/validation"
 import { extraPricingModeSchema } from "@voyantjs/extras/validation"
 import { z } from "zod"
 
@@ -7,6 +12,90 @@ const languageTagSchema = z
   .trim()
   .regex(/^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$/)
 const urlOrNullSchema = z.url().nullable()
+const boundedRecordSchema = z
+  .record(z.string(), z.unknown())
+  .refine((value) => JSON.stringify(value).length <= 8000, {
+    message: "Object payload must be 8KB or smaller",
+  })
+
+const storefrontIntakeTagsSchema = z.array(z.string().trim().min(1).max(64)).max(20).default([])
+
+export const storefrontIntakeConsentSchema = z.object({
+  marketing: z.boolean().default(false),
+  newsletter: z.boolean().default(false),
+  gdpr: z.boolean().default(false),
+  scope: z.string().trim().min(1).max(120).nullable().optional(),
+  acceptedAt: z.string().datetime().nullable().optional(),
+})
+
+export const storefrontLeadContactSchema = z
+  .object({
+    name: z.string().trim().min(1).max(240).optional(),
+    firstName: z.string().trim().min(1).max(120).optional(),
+    lastName: z.string().trim().min(1).max(120).optional(),
+    email: z.email().max(320).optional(),
+    phone: z.string().trim().min(3).max(64).optional(),
+  })
+  .refine((value) => Boolean(value.email || value.phone), {
+    message: "Either contact.email or contact.phone is required",
+  })
+
+export const storefrontLeadIntakeInputSchema = z.object({
+  kind: customerSignalKindSchema.default("inquiry"),
+  source: customerSignalSourceSchema.default("website"),
+  contact: storefrontLeadContactSchema,
+  productId: z.string().trim().min(1).max(160).nullable().optional(),
+  optionUnitId: z.string().trim().min(1).max(160).nullable().optional(),
+  notes: z.string().trim().max(4000).nullable().optional(),
+  tags: storefrontIntakeTagsSchema,
+  sourceSubmissionId: z.string().trim().min(1).max(160).nullable().optional(),
+  sourceUrl: z.url().nullable().optional(),
+  locale: languageTagSchema.optional(),
+  payload: boundedRecordSchema.default({}),
+  consent: storefrontIntakeConsentSchema.default({
+    marketing: false,
+    newsletter: false,
+    gdpr: false,
+  }),
+})
+
+export const storefrontNewsletterSubscribeInputSchema = z.object({
+  email: z.email().max(320),
+  name: z.string().trim().min(1).max(240).optional(),
+  firstName: z.string().trim().min(1).max(120).optional(),
+  lastName: z.string().trim().min(1).max(120).optional(),
+  source: customerSignalSourceSchema.default("website"),
+  sourceSubmissionId: z.string().trim().min(1).max(160).nullable().optional(),
+  sourceUrl: z.url().nullable().optional(),
+  locale: languageTagSchema.optional(),
+  tags: storefrontIntakeTagsSchema,
+  payload: boundedRecordSchema.default({}),
+  consent: storefrontIntakeConsentSchema.extend({ newsletter: z.literal(true) }),
+})
+
+export const storefrontIntakeResponseSchema = z.object({
+  id: z.string(),
+  personId: z.string(),
+  kind: customerSignalKindSchema,
+  source: customerSignalSourceSchema,
+  status: customerSignalStatusSchema,
+  duplicate: z.boolean(),
+})
+
+export const storefrontNewsletterSubscribeResponseSchema = storefrontIntakeResponseSchema.extend({
+  doubleOptIn: z.enum(["not_configured", "requested"]),
+})
+
+export type StorefrontIntakeConsent = z.infer<typeof storefrontIntakeConsentSchema>
+export type StorefrontLeadContact = z.infer<typeof storefrontLeadContactSchema>
+export type StorefrontLeadIntakeInput = z.infer<typeof storefrontLeadIntakeInputSchema>
+export type StorefrontNewsletterSubscribeInput = z.infer<
+  typeof storefrontNewsletterSubscribeInputSchema
+>
+export type StorefrontIntakeResponse = z.infer<typeof storefrontIntakeResponseSchema>
+export type StorefrontNewsletterSubscribeResponse = z.infer<
+  typeof storefrontNewsletterSubscribeResponseSchema
+>
 
 export const storefrontPaymentMethodCodeSchema = z.enum([
   "card",

--- a/packages/storefront/tests/integration/public-routes.test.ts
+++ b/packages/storefront/tests/integration/public-routes.test.ts
@@ -1,4 +1,6 @@
 import { availabilitySlots, availabilityStartTimes } from "@voyantjs/availability/schema"
+import { createEventBus } from "@voyantjs/core"
+import { customerSignals } from "@voyantjs/crm/schema"
 import { cleanupTestDb, createTestDb } from "@voyantjs/db/test-utils"
 import { productExtras } from "@voyantjs/extras/schema"
 import {
@@ -17,8 +19,9 @@ import {
   productOptions,
   products,
 } from "@voyantjs/products/schema"
+import { and, eq } from "drizzle-orm"
 import { Hono } from "hono"
-import { beforeEach, describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { createStorefrontPublicRoutes } from "../../src/routes-public.js"
 
@@ -37,6 +40,184 @@ const app = new Hono()
 describe.skipIf(!DB_AVAILABLE)("Storefront public routes", () => {
   beforeEach(async () => {
     await cleanupTestDb(db)
+  })
+
+  it("creates a CRM customer signal for public lead intake", async () => {
+    const eventBus = createEventBus()
+    const events: unknown[] = []
+    eventBus.subscribe("customer.signal.created", (event) => {
+      events.push(event)
+    })
+    const intakeApp = new Hono()
+      .use("*", async (c, next) => {
+        c.set("db" as never, db)
+        c.set("eventBus" as never, eventBus)
+        await next()
+      })
+      .route("/", createStorefrontPublicRoutes())
+
+    const res = await intakeApp.request("/leads", {
+      method: "POST",
+      body: JSON.stringify({
+        kind: "request_offer",
+        source: "form",
+        contact: {
+          name: "Ana Popescu",
+          email: "ana@example.com",
+          phone: "+40723123456",
+        },
+        productId: "prod_public_intake",
+        optionUnitId: "ount_public_intake",
+        notes: "Interested in a private trip.",
+        sourceSubmissionId: "lead_form_123",
+        payload: {
+          travelers: 4,
+          month: "August",
+        },
+        consent: {
+          gdpr: true,
+          marketing: true,
+          scope: "lead-follow-up",
+          acceptedAt: "2026-05-14T10:00:00.000Z",
+        },
+      }),
+      headers: {
+        "content-type": "application/json",
+      },
+    })
+
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.data).toMatchObject({
+      kind: "request_offer",
+      source: "form",
+      status: "new",
+      duplicate: false,
+    })
+
+    const [signal] = await db
+      .select()
+      .from(customerSignals)
+      .where(eq(customerSignals.id, body.data.id))
+      .limit(1)
+
+    expect(signal).toMatchObject({
+      personId: body.data.personId,
+      productId: "prod_public_intake",
+      optionUnitId: "ount_public_intake",
+      kind: "request_offer",
+      source: "form",
+      sourceSubmissionId: "lead_form_123",
+    })
+    expect(signal.metadata).toMatchObject({
+      intake: { surface: "storefront", type: "lead" },
+      payload: { travelers: 4, month: "August" },
+      consent: { gdpr: true, marketing: true, scope: "lead-follow-up" },
+    })
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      name: "customer.signal.created",
+      data: {
+        id: body.data.id,
+        personId: body.data.personId,
+        intake: { surface: "storefront", type: "lead" },
+      },
+      metadata: { category: "domain", source: "route" },
+    })
+  })
+
+  it("records newsletter subscriptions idempotently and requests double opt-in once", async () => {
+    const requestNewsletterDoubleOptIn = vi.fn()
+    const eventBus = createEventBus()
+    const events: unknown[] = []
+    eventBus.subscribe("customer.signal.created", (event) => {
+      events.push(event)
+    })
+    const intakeApp = new Hono()
+      .use("*", async (c, next) => {
+        c.set("db" as never, db)
+        c.set("eventBus" as never, eventBus)
+        await next()
+      })
+      .route(
+        "/",
+        createStorefrontPublicRoutes({
+          intake: { requestNewsletterDoubleOptIn },
+        }),
+      )
+
+    const payload = {
+      email: "NEWS@example.com",
+      name: "Newsletter Reader",
+      sourceSubmissionId: "newsletter_homepage_news@example.com",
+      payload: {
+        campaign: "homepage",
+      },
+      consent: {
+        newsletter: true,
+        gdpr: true,
+        scope: "newsletter",
+      },
+    }
+
+    const first = await intakeApp.request("/newsletter/subscribe", {
+      method: "POST",
+      body: JSON.stringify(payload),
+      headers: { "content-type": "application/json" },
+    })
+    const second = await intakeApp.request("/newsletter/subscribe", {
+      method: "POST",
+      body: JSON.stringify(payload),
+      headers: { "content-type": "application/json" },
+    })
+
+    expect(first.status).toBe(202)
+    expect(second.status).toBe(202)
+    const firstBody = await first.json()
+    const secondBody = await second.json()
+    expect(firstBody.data).toMatchObject({
+      kind: "notify",
+      duplicate: false,
+      doubleOptIn: "requested",
+    })
+    expect(secondBody.data).toMatchObject({
+      id: firstBody.data.id,
+      duplicate: true,
+      doubleOptIn: "requested",
+    })
+    expect(requestNewsletterDoubleOptIn).toHaveBeenCalledTimes(1)
+    expect(requestNewsletterDoubleOptIn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "news@example.com",
+        signalId: firstBody.data.id,
+        sourceSubmissionId: "newsletter_homepage_news@example.com",
+      }),
+    )
+
+    const rows = await db
+      .select()
+      .from(customerSignals)
+      .where(
+        and(
+          eq(customerSignals.kind, "notify"),
+          eq(customerSignals.sourceSubmissionId, "newsletter_homepage_news@example.com"),
+        ),
+      )
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.metadata).toMatchObject({
+      intake: { surface: "storefront", type: "newsletter" },
+      newsletter: { email: "news@example.com", doubleOptIn: "requested" },
+      payload: { campaign: "homepage" },
+      consent: { newsletter: true, gdpr: true, scope: "newsletter" },
+    })
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      data: {
+        id: firstBody.data.id,
+        intake: { surface: "storefront", type: "newsletter", doubleOptIn: "requested" },
+      },
+    })
   })
 
   it("returns public departures for a product", async () => {

--- a/packages/storefront/tests/unit/public-routes.test.ts
+++ b/packages/storefront/tests/unit/public-routes.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import { createStorefrontPublicRoutes } from "../../src/routes-public.js"
 
@@ -159,6 +159,46 @@ describe("createStorefrontPublicRoutes", () => {
         },
       },
     })
+  })
+
+  it("lets host apps reject public intake through the guard hook", async () => {
+    const guard = vi.fn(() => ({
+      allowed: false,
+      status: 429 as const,
+      error: "Captcha required",
+    }))
+    const app = new Hono().route(
+      "/",
+      createStorefrontPublicRoutes({
+        intake: { guard },
+      }),
+    )
+
+    const res = await app.request("/leads", {
+      method: "POST",
+      body: JSON.stringify({
+        contact: {
+          email: "ana@example.com",
+        },
+        consent: {
+          gdpr: true,
+        },
+      }),
+      headers: {
+        "content-type": "application/json",
+      },
+    })
+
+    expect(res.status).toBe(429)
+    expect(await res.json()).toEqual({ error: "Captcha required" })
+    expect(guard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "lead",
+        body: expect.objectContaining({
+          contact: expect.objectContaining({ email: "ana@example.com" }),
+        }),
+      }),
+    )
   })
 
   it("resolves storefront settings from request context", async () => {

--- a/packages/storefront/tests/unit/service-intake.test.ts
+++ b/packages/storefront/tests/unit/service-intake.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const crmMocks = vi.hoisted(() => ({
+  createCustomerSignal: vi.fn(),
+  createPerson: vi.fn(),
+  deleteCustomerSignal: vi.fn(),
+  deletePerson: vi.fn(),
+  updateCustomerSignal: vi.fn(),
+}))
+
+vi.mock("@voyantjs/crm", () => ({
+  crmService: crmMocks,
+}))
+
+import { subscribeStorefrontNewsletter } from "../../src/service-intake.js"
+import type { StorefrontNewsletterSubscribeInput } from "../../src/validation.js"
+
+function createDbWithoutExistingSignals() {
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => []),
+        })),
+      })),
+    })),
+  }
+}
+
+function createSignalRow(data: Record<string, unknown>) {
+  return {
+    id: "csig_newsletter",
+    personId: data.personId,
+    kind: data.kind,
+    source: data.source,
+    status: data.status,
+    productId: null,
+    optionUnitId: null,
+    sourceSubmissionId: data.sourceSubmissionId,
+    metadata: data.metadata,
+  }
+}
+
+describe("subscribeStorefrontNewsletter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    crmMocks.createPerson.mockResolvedValue({ id: "pers_newsletter" })
+    crmMocks.createCustomerSignal.mockImplementation(async (_db, data) => createSignalRow(data))
+    crmMocks.updateCustomerSignal.mockImplementation(async (_db, _id, data) => ({
+      ...createSignalRow({}),
+      metadata: data.metadata,
+    }))
+    crmMocks.deleteCustomerSignal.mockResolvedValue({ id: "csig_newsletter" })
+    crmMocks.deletePerson.mockResolvedValue({ id: "pers_newsletter" })
+  })
+
+  it("does not persist requested double opt-in until the hook succeeds", async () => {
+    const db = createDbWithoutExistingSignals()
+    const eventBus = { emit: vi.fn() }
+    const requestDoubleOptIn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("mail provider down"))
+      .mockResolvedValueOnce(undefined)
+    const body = {
+      email: "News@Example.com",
+      sourceSubmissionId: "newsletter_homepage_news@example.com",
+      tags: [],
+      payload: {},
+      consent: {
+        newsletter: true,
+        gdpr: true,
+      },
+    } satisfies StorefrontNewsletterSubscribeInput
+
+    await expect(
+      subscribeStorefrontNewsletter({
+        body,
+        context: { db: db as never, eventBus },
+        requestDoubleOptIn,
+      }),
+    ).rejects.toThrow("mail provider down")
+
+    expect(crmMocks.createCustomerSignal.mock.calls[0]?.[1].metadata.newsletter).toEqual({
+      email: "news@example.com",
+      doubleOptIn: "not_configured",
+    })
+    expect(crmMocks.updateCustomerSignal).not.toHaveBeenCalled()
+    expect(crmMocks.deleteCustomerSignal).toHaveBeenCalledWith(db, "csig_newsletter")
+    expect(crmMocks.deletePerson).toHaveBeenCalledWith(db, "pers_newsletter")
+    expect(eventBus.emit).not.toHaveBeenCalled()
+
+    const result = await subscribeStorefrontNewsletter({
+      body,
+      context: { db: db as never, eventBus },
+      requestDoubleOptIn,
+    })
+
+    expect(requestDoubleOptIn).toHaveBeenCalledTimes(2)
+    expect(crmMocks.createCustomerSignal.mock.calls[1]?.[1].metadata.newsletter).toEqual({
+      email: "news@example.com",
+      doubleOptIn: "not_configured",
+    })
+    expect(crmMocks.updateCustomerSignal.mock.calls[0]?.[2].metadata.newsletter).toEqual({
+      email: "news@example.com",
+      doubleOptIn: "requested",
+    })
+    expect(result.doubleOptIn).toBe("requested")
+    expect(eventBus.emit).toHaveBeenCalledTimes(1)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4660,6 +4660,9 @@ importers:
       '@voyantjs/core':
         specifier: workspace:*
         version: link:../core
+      '@voyantjs/crm':
+        specifier: workspace:*
+        version: link:../crm
       '@voyantjs/extras':
         specifier: workspace:*
         version: link:../extras

--- a/templates/dmc/src/api/app.ts
+++ b/templates/dmc/src/api/app.ts
@@ -105,6 +105,8 @@ export const app = createApp<CloudflareBindings>({
     "/v1/public/storefront-verification",
     "/v1/public/checkout",
     "/v1/public/invitations",
+    "/v1/public/leads",
+    "/v1/public/newsletter",
   ],
   modules: [
     crmHonoModule,

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -769,6 +769,10 @@ export const app = createApp<CloudflareBindings>({
     "/v1/public/products",
     "/v1/public/cruises",
     "/v1/public/hospitality",
+    // Storefront public CRM intake. Host deployments can wire captcha /
+    // rate-limit checks through the storefront intake guard.
+    "/v1/public/leads",
+    "/v1/public/newsletter",
     // Storefront contract preview — the booking journey resolves the
     // active customer-scope template and renders its preview HTML
     // before the customer accepts. Both the slug-resolution lookup


### PR DESCRIPTION
## Summary

Adds public storefront intake primitives backed by CRM customer signals for issue #869.

- Adds `POST /v1/public/leads` and `POST /v1/public/newsletter/subscribe` through the storefront public module root.
- Creates CRM people and customer signals with bounded payload and consent metadata.
- Adds host-owned intake guard and newsletter double-opt-in hooks without choosing a captcha, rate-limit, or email vendor.
- Emits the documented `customer.signal.created` domain event for notification subscribers.
- Updates operator/DMC public path allowlists, docs, package exports, lockfile, and changeset.

## Validation

Passed locally:

- `pnpm --filter @voyantjs/storefront typecheck`
- `pnpm --filter @voyantjs/storefront lint`
- `pnpm --filter @voyantjs/storefront test`
- `pnpm --filter @voyantjs/crm typecheck`
- `pnpm --filter @voyantjs/crm lint`
- `pnpm --filter @voyantjs/crm test`
- `git diff --check`
- pre-push `pnpm test` hook passed

Notes:

- `pnpm verify:fast` and the pre-commit full `pnpm typecheck` were stopped after they sat in the large `operator`/`dmc` template typechecks without diagnostics. The focused package checks above and the pre-push test hook completed successfully.
- The changed-file agent-quality checker reported existing large-file and unsafe-cast warnings in report-only mode.