### PR TITLE
legal: add contract lifecycle events

### DIFF
--- a/.changeset/legal-contract-lifecycle.md
+++ b/.changeset/legal-contract-lifecycle.md
@@ -1,6 +1,7 @@
 ---
 "@voyantjs/legal": minor
 "@voyantjs/legal-react": patch
+"@voyantjs/legal-ui": patch
 ---
 
 Add an opinionated contract lifecycle with stage history, transition validation, and domain events for issue/send/sign/execute/void transitions.

--- a/.changeset/legal-contract-lifecycle.md
+++ b/.changeset/legal-contract-lifecycle.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/legal": minor
+"@voyantjs/legal-react": patch
+---
+
+Add an opinionated contract lifecycle with stage history, transition validation, and domain events for issue/send/sign/execute/void transitions.

--- a/packages/legal-react/src/schemas.ts
+++ b/packages/legal-react/src/schemas.ts
@@ -1,4 +1,5 @@
 import {
+  contractStageHistoryEntrySchema,
   insertContractAttachmentSchema,
   insertContractNumberSeriesSchema,
   insertContractSchema,
@@ -31,6 +32,7 @@ export const successEnvelope = z.object({ success: z.boolean() })
 export const legalContractRecordSchema = insertContractSchema.extend({
   id: z.string(),
   contractNumber: z.string().nullable(),
+  stageHistory: z.array(contractStageHistoryEntrySchema),
   templateVersionId: z.string().nullable(),
   seriesId: z.string().nullable(),
   personId: z.string().nullable(),

--- a/packages/legal-ui/src/components/contract-detail-page.tsx
+++ b/packages/legal-ui/src/components/contract-detail-page.tsx
@@ -19,7 +19,16 @@ import {
   TableRow,
 } from "@voyantjs/ui/components/table"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@voyantjs/ui/components/tabs"
-import { ArrowLeft, ExternalLink, FileText, Pencil, Plus, Trash2 } from "lucide-react"
+import {
+  ArrowLeft,
+  CheckCircle2,
+  ExternalLink,
+  FileText,
+  Pencil,
+  Plus,
+  Send,
+  Trash2,
+} from "lucide-react"
 import type { ReactNode } from "react"
 import { useState } from "react"
 
@@ -90,7 +99,7 @@ export function ContractDetailPage({
   const i18n = useLegalUiI18nOrDefault()
   const messages = useLegalUiMessagesOrDefault()
   const f = messages.contractDetailPage
-  const { remove, issue, voidContract } = useLegalContractMutation()
+  const { remove, issue, send, execute, voidContract } = useLegalContractMutation()
   const { remove: removeAttachment } = useLegalContractAttachmentMutation()
 
   const [editOpen, setEditOpen] = useState(false)
@@ -132,7 +141,7 @@ export function ContractDetailPage({
   }
 
   const status = contract.status
-  const canAddSignature = status === "issued" || status === "sent" || status === "signed"
+  const canAddSignature = status === "sent" || status === "signed"
   const renderReferenceValue = (kind: ContractReferenceKind, referenceId: string) =>
     renderReference?.({ kind, id: referenceId, contract }) ?? (
       <span className="font-mono text-xs">{referenceId}</span>
@@ -169,6 +178,18 @@ export function ContractDetailPage({
           {status === "draft" ? (
             <Button size="sm" onClick={() => issue.mutate(id)} disabled={issue.isPending}>
               {f.actions.issue}
+            </Button>
+          ) : null}
+          {status === "issued" ? (
+            <Button size="sm" onClick={() => send.mutate(id)} disabled={send.isPending}>
+              <Send className="mr-2 size-4" aria-hidden="true" />
+              {f.actions.send}
+            </Button>
+          ) : null}
+          {status === "signed" ? (
+            <Button size="sm" onClick={() => execute.mutate(id)} disabled={execute.isPending}>
+              <CheckCircle2 className="mr-2 size-4" aria-hidden="true" />
+              {f.actions.execute}
             </Button>
           ) : null}
           {status !== "void" ? (

--- a/packages/legal-ui/src/i18n/en.ts
+++ b/packages/legal-ui/src/i18n/en.ts
@@ -129,6 +129,8 @@ export const legalUiEn = {
     deleteAttachmentConfirm: "Delete this document?",
     actions: {
       issue: "Issue",
+      send: "Send",
+      execute: "Execute",
       void: "Void",
       addSignature: "Add Signature",
       addAttachment: "Add Attachment",

--- a/packages/legal-ui/src/i18n/messages.ts
+++ b/packages/legal-ui/src/i18n/messages.ts
@@ -141,6 +141,8 @@ export type LegalUiMessages = {
     deleteAttachmentConfirm: string
     actions: {
       issue: string
+      send: string
+      execute: string
       void: string
       addSignature: string
       addAttachment: string

--- a/packages/legal-ui/src/i18n/ro.ts
+++ b/packages/legal-ui/src/i18n/ro.ts
@@ -129,6 +129,8 @@ export const legalUiRo = {
     deleteAttachmentConfirm: "Stergi acest document?",
     actions: {
       issue: "Emite",
+      send: "Trimite",
+      execute: "Executa",
       void: "Anuleaza",
       addSignature: "Adauga semnatura",
       addAttachment: "Adauga atasament",

--- a/packages/legal/README.md
+++ b/packages/legal/README.md
@@ -68,6 +68,21 @@ configured `documentStorage`, and persists a contract attachment. `regenerate-pd
 uses the configured contract document generator and replaces the canonical
 generated document artifact.
 
+## Contract Lifecycle
+
+Contract lifecycle transitions are enforced by the contract service:
+
+```text
+draft -> issued -> sent -> signed -> executed
+```
+
+Contracts may be voided from any non-void stage. Each service transition appends
+to `stageHistory` and emits a domain event when an event bus is configured:
+`contract.issued`, `contract.sent`, `contract.signed`, `contract.executed`, or
+`contract.voided`. Event payloads are intentionally minimal: contract IDs,
+relationship IDs, stage names, and timestamps only; rendered bodies, variables,
+metadata, and signature details stay out of the event payload.
+
 ### Policies
 
 - **Policies** (`pol`) — policy definitions by kind (cancellation, payment, T&C, etc.)

--- a/packages/legal/src/contracts/index.ts
+++ b/packages/legal/src/contracts/index.ts
@@ -28,10 +28,28 @@ export const contractsLinkable = {
 }
 
 export type {
+  ContractLifecycleEvent,
+  ContractLifecycleHook,
+  ContractLifecycleRuntimeOptions,
+  ContractLifecycleStage,
+  ContractLifecycleTransition,
+} from "./lifecycle.js"
+export {
+  appendContractStageHistory,
+  buildContractLifecycleEvent,
+  CONTRACT_LIFECYCLE_EVENT_NAMES,
+  CONTRACT_LIFECYCLE_STAGES,
+  checkContractLifecycleTransition,
+  createContractStageHistoryEntry,
+  emitContractLifecycleEvent,
+} from "./lifecycle.js"
+export type {
   Contract,
   ContractAttachment,
   ContractNumberSeries,
   ContractSignature,
+  ContractStageHistoryEntry,
+  ContractStatus,
   ContractTemplate,
   ContractTemplateVersion,
   NewContract,
@@ -45,6 +63,7 @@ export {
   contractAttachments,
   contractNumberSeries,
   contractSignatures,
+  contractStatusValues,
   contracts,
   contractTemplates,
   contractTemplateVersions,
@@ -102,6 +121,7 @@ export {
   contractNumberResetStrategySchema,
   contractScopeSchema,
   contractSignatureMethodSchema,
+  contractStageHistoryEntrySchema,
   contractStatusSchema,
   contractTemplateDefaultQuerySchema,
   contractTemplateListQuerySchema,

--- a/packages/legal/src/contracts/lifecycle.ts
+++ b/packages/legal/src/contracts/lifecycle.ts
@@ -1,0 +1,163 @@
+import type { EventBus } from "@voyantjs/core"
+
+import type { Contract, ContractStageHistoryEntry, ContractStatus } from "./schema.js"
+
+export const CONTRACT_LIFECYCLE_STAGES = [
+  "draft",
+  "issued",
+  "sent",
+  "signed",
+  "executed",
+  "expired",
+  "void",
+] as const satisfies readonly ContractStatus[]
+
+export type ContractLifecycleStage = (typeof CONTRACT_LIFECYCLE_STAGES)[number]
+
+export type ContractLifecycleTransition =
+  | "created"
+  | "issued"
+  | "sent"
+  | "signed"
+  | "executed"
+  | "voided"
+
+export const CONTRACT_LIFECYCLE_EVENT_NAMES = {
+  issued: "contract.issued",
+  sent: "contract.sent",
+  signed: "contract.signed",
+  executed: "contract.executed",
+  voided: "contract.voided",
+} as const satisfies Record<Exclude<ContractLifecycleTransition, "created">, string>
+
+export interface ContractLifecycleEvent {
+  contractId: string
+  contractNumber: string | null
+  scope: Contract["scope"]
+  previousStage: ContractLifecycleStage
+  stage: ContractLifecycleStage
+  transition: Exclude<ContractLifecycleTransition, "created">
+  occurredAt: string
+  personId: string | null
+  organizationId: string | null
+  supplierId: string | null
+  channelId: string | null
+  bookingId: string | null
+  orderId: string | null
+}
+
+export type ContractLifecycleHook = (event: ContractLifecycleEvent) => Promise<void> | void
+
+export interface ContractLifecycleRuntimeOptions {
+  eventBus?: EventBus
+  lifecycleHooks?: readonly ContractLifecycleHook[]
+}
+
+export type ContractLifecycleTransitionCheck =
+  | { ok: true }
+  | { ok: false; reason: "not_draft" | "not_issued" | "not_sent" | "not_signed" | "already_void" }
+
+function isContractLifecycleStage(value: unknown): value is ContractLifecycleStage {
+  return (
+    typeof value === "string" && (CONTRACT_LIFECYCLE_STAGES as readonly string[]).includes(value)
+  )
+}
+
+export function createContractStageHistoryEntry(
+  stage: ContractLifecycleStage,
+  options: {
+    previousStage?: ContractLifecycleStage | null
+    transition?: ContractLifecycleTransition
+    enteredAt?: Date
+    actorId?: string | null
+  } = {},
+): ContractStageHistoryEntry {
+  return {
+    stage,
+    previousStage: options.previousStage ?? null,
+    transition: options.transition ?? "created",
+    enteredAt: (options.enteredAt ?? new Date()).toISOString(),
+    ...(options.actorId === undefined ? {} : { actorId: options.actorId }),
+  }
+}
+
+export function appendContractStageHistory(
+  current: readonly ContractStageHistoryEntry[] | null | undefined,
+  entry: ContractStageHistoryEntry,
+): ContractStageHistoryEntry[] {
+  const existing = Array.isArray(current)
+    ? current.filter(
+        (item): item is ContractStageHistoryEntry =>
+          isContractLifecycleStage(item.stage) &&
+          (item.previousStage === null ||
+            item.previousStage === undefined ||
+            isContractLifecycleStage(item.previousStage)) &&
+          typeof item.transition === "string" &&
+          typeof item.enteredAt === "string",
+      )
+    : []
+  return [...existing, entry]
+}
+
+export function checkContractLifecycleTransition(
+  from: ContractLifecycleStage,
+  transition: Exclude<ContractLifecycleTransition, "created">,
+): ContractLifecycleTransitionCheck {
+  switch (transition) {
+    case "issued":
+      return from === "draft" ? { ok: true } : { ok: false, reason: "not_draft" }
+    case "sent":
+      return from === "issued" || from === "sent"
+        ? { ok: true }
+        : { ok: false, reason: "not_issued" }
+    case "signed":
+      return from === "sent" ? { ok: true } : { ok: false, reason: "not_sent" }
+    case "executed":
+      return from === "signed" ? { ok: true } : { ok: false, reason: "not_signed" }
+    case "voided":
+      return from === "void" ? { ok: false, reason: "already_void" } : { ok: true }
+  }
+}
+
+export function buildContractLifecycleEvent(
+  contract: Contract,
+  previousStage: ContractLifecycleStage,
+  stage: ContractLifecycleStage,
+  transition: Exclude<ContractLifecycleTransition, "created">,
+  occurredAt: Date,
+): ContractLifecycleEvent {
+  return {
+    contractId: contract.id,
+    contractNumber: contract.contractNumber ?? null,
+    scope: contract.scope,
+    previousStage,
+    stage,
+    transition,
+    occurredAt: occurredAt.toISOString(),
+    personId: contract.personId ?? null,
+    organizationId: contract.organizationId ?? null,
+    supplierId: contract.supplierId ?? null,
+    channelId: contract.channelId ?? null,
+    bookingId: contract.bookingId ?? null,
+    orderId: contract.orderId ?? null,
+  }
+}
+
+export async function emitContractLifecycleEvent(
+  runtime: ContractLifecycleRuntimeOptions | undefined,
+  event: ContractLifecycleEvent,
+) {
+  const eventName = CONTRACT_LIFECYCLE_EVENT_NAMES[event.transition]
+  await runtime?.eventBus?.emit(eventName, event, {
+    category: "domain",
+    source: "service",
+  })
+
+  for (const hook of runtime?.lifecycleHooks ?? []) {
+    try {
+      await hook(event)
+    } catch (error) {
+      console.error(`[legal] lifecycle hook failed for ${eventName}:`, error)
+    }
+  }
+}

--- a/packages/legal/src/contracts/route-runtime.ts
+++ b/packages/legal/src/contracts/route-runtime.ts
@@ -1,12 +1,14 @@
 import type { EventBus } from "@voyantjs/core"
 import type { StorageProvider } from "@voyantjs/storage"
 
+import type { ContractLifecycleHook } from "./lifecycle.js"
 import type { ContractDocumentGenerator, ContractsRouteOptions } from "./routes.js"
 
 export type ContractsRouteRuntime = {
   documentGenerator?: ContractDocumentGenerator
   documentStorage?: StorageProvider | null
   eventBus?: EventBus
+  lifecycleHooks?: readonly ContractLifecycleHook[]
 }
 
 export const CONTRACTS_ROUTE_RUNTIME_CONTAINER_KEY = "providers.legal.contracts.runtime"
@@ -19,5 +21,6 @@ export function buildContractsRouteRuntime(
     documentGenerator: options.resolveDocumentGenerator?.(bindings) ?? options.documentGenerator,
     documentStorage: options.resolveDocumentStorage?.(bindings) ?? options.documentStorage,
     eventBus: options.resolveEventBus?.(bindings) ?? options.eventBus,
+    lifecycleHooks: options.resolveLifecycleHooks?.(bindings) ?? options.lifecycleHooks,
   }
 }

--- a/packages/legal/src/contracts/routes.ts
+++ b/packages/legal/src/contracts/routes.ts
@@ -4,7 +4,7 @@ import type { StorageProvider } from "@voyantjs/storage"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
 import { Hono } from "hono"
-
+import type { ContractLifecycleHook } from "./lifecycle.js"
 import {
   buildContractsRouteRuntime,
   CONTRACTS_ROUTE_RUNTIME_CONTAINER_KEY,
@@ -57,6 +57,10 @@ export interface ContractsRouteOptions {
   resolveDocumentStorage?: (bindings: Record<string, unknown>) => StorageProvider | null | undefined
   eventBus?: EventBus
   resolveEventBus?: (bindings: Record<string, unknown>) => EventBus | undefined
+  lifecycleHooks?: readonly ContractLifecycleHook[]
+  resolveLifecycleHooks?: (
+    bindings: Record<string, unknown>,
+  ) => readonly ContractLifecycleHook[] | undefined
 }
 
 function getRuntime(
@@ -263,7 +267,12 @@ async function regenerateContractDocument(
     c.get("db"),
     contractId,
     await parseOptionalJsonBody(c, generateContractDocumentInputSchema),
-    { generator, bindings: c.env, eventBus: runtime.eventBus },
+    {
+      generator,
+      bindings: c.env,
+      eventBus: runtime.eventBus,
+      lifecycleHooks: runtime.lifecycleHooks,
+    },
   )
 
   if (result.status === "not_found") return c.json({ error: "Contract not found" }, 404)
@@ -402,7 +411,8 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
       return c.json({ success: true })
     })
     .post("/:id/issue", async (c) => {
-      const result = await contractsService.issueContract(c.get("db"), c.req.param("id"))
+      const runtime = getRuntime(options, c.env, (key) => c.var.container?.resolve(key))
+      const result = await contractsService.issueContract(c.get("db"), c.req.param("id"), runtime)
       if (result.status === "not_found") return c.json({ error: "Contract not found" }, 404)
       if (result.status === "not_draft") {
         return c.json({ error: "Only draft contracts can be issued" }, 409)
@@ -410,7 +420,8 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
       return c.json({ data: result.contract })
     })
     .post("/:id/send", async (c) => {
-      const result = await contractsService.sendContract(c.get("db"), c.req.param("id"))
+      const runtime = getRuntime(options, c.env, (key) => c.var.container?.resolve(key))
+      const result = await contractsService.sendContract(c.get("db"), c.req.param("id"), runtime)
       if (result.status === "not_found") return c.json({ error: "Contract not found" }, 404)
       if (result.status === "not_issued") {
         return c.json({ error: "Only issued/sent contracts can be sent" }, 409)
@@ -418,8 +429,14 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
       return c.json({ data: result.contract })
     })
     .post("/:id/sign", async (c) => {
+      const runtime = getRuntime(options, c.env, (key) => c.var.container?.resolve(key))
       const input = await parseJsonBody(c, insertContractSignatureSchema)
-      const result = await contractsService.signContract(c.get("db"), c.req.param("id"), input)
+      const result = await contractsService.signContract(
+        c.get("db"),
+        c.req.param("id"),
+        input,
+        runtime,
+      )
       if (result.status === "not_found") return c.json({ error: "Contract not found" }, 404)
       if (result.status === "not_signable") {
         return c.json({ error: "Contract is not in a signable state" }, 409)
@@ -427,7 +444,8 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
       return c.json({ data: { contract: result.contract, signature: result.signature } })
     })
     .post("/:id/execute", async (c) => {
-      const result = await contractsService.executeContract(c.get("db"), c.req.param("id"))
+      const runtime = getRuntime(options, c.env, (key) => c.var.container?.resolve(key))
+      const result = await contractsService.executeContract(c.get("db"), c.req.param("id"), runtime)
       if (result.status === "not_found") return c.json({ error: "Contract not found" }, 404)
       if (result.status === "not_signed") {
         return c.json({ error: "Only signed contracts can be executed" }, 409)
@@ -435,7 +453,8 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
       return c.json({ data: result.contract })
     })
     .post("/:id/void", async (c) => {
-      const result = await contractsService.voidContract(c.get("db"), c.req.param("id"))
+      const runtime = getRuntime(options, c.env, (key) => c.var.container?.resolve(key))
+      const result = await contractsService.voidContract(c.get("db"), c.req.param("id"), runtime)
       if (result.status === "not_found") return c.json({ error: "Contract not found" }, 404)
       if (result.status === "already_void") {
         return c.json({ error: "Contract is already void" }, 409)
@@ -459,7 +478,12 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
         c.get("db"),
         c.req.param("id"),
         await parseOptionalJsonBody(c, generateContractDocumentInputSchema),
-        { generator, bindings: c.env, eventBus: runtime.eventBus },
+        {
+          generator,
+          bindings: c.env,
+          eventBus: runtime.eventBus,
+          lifecycleHooks: runtime.lifecycleHooks,
+        },
       )
 
       if (result.status === "not_found") return c.json({ error: "Contract not found" }, 404)
@@ -587,7 +611,7 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
 
 export const contractsAdminRoutes = createContractsAdminRoutes()
 
-export function createContractsPublicRoutes() {
+export function createContractsPublicRoutes(options: ContractsRouteOptions = {}) {
   return (
     new Hono<Env>()
       .get("/templates/default", async (c) => {
@@ -613,8 +637,14 @@ export function createContractsPublicRoutes() {
         return c.json({ data: publicContract })
       })
       .post("/:id/sign", async (c) => {
+        const runtime = getRuntime(options, c.env, (key) => c.var.container?.resolve(key))
         const input = await parseJsonBody(c, insertContractSignatureSchema)
-        const result = await contractsService.signContract(c.get("db"), c.req.param("id"), input)
+        const result = await contractsService.signContract(
+          c.get("db"),
+          c.req.param("id"),
+          input,
+          runtime,
+        )
         if (result.status === "not_found") return c.json({ error: "Contract not found" }, 404)
         if (result.status === "not_signable") {
           return c.json({ error: "Contract is not in a signable state" }, 409)

--- a/packages/legal/src/contracts/schema.ts
+++ b/packages/legal/src/contracts/schema.ts
@@ -24,7 +24,7 @@ export const contractScopeEnum = pgEnum("contract_scope", [
   "other",
 ])
 
-export const contractStatusEnum = pgEnum("contract_status", [
+export const contractStatusValues = [
   "draft",
   "issued",
   "sent",
@@ -32,7 +32,19 @@ export const contractStatusEnum = pgEnum("contract_status", [
   "executed",
   "expired",
   "void",
-])
+] as const
+
+export const contractStatusEnum = pgEnum("contract_status", contractStatusValues)
+
+export type ContractStatus = (typeof contractStatusValues)[number]
+
+export interface ContractStageHistoryEntry {
+  stage: ContractStatus
+  previousStage: ContractStatus | null
+  transition: "created" | "issued" | "sent" | "signed" | "executed" | "voided"
+  enteredAt: string
+  actorId?: string | null
+}
 
 export const contractSignatureMethodEnum = pgEnum("contract_signature_method", [
   "manual",
@@ -176,6 +188,10 @@ export const contracts = pgTable(
     contractNumber: text("contract_number").unique(),
     scope: contractScopeEnum("scope").notNull(),
     status: contractStatusEnum("status").notNull().default("draft"),
+    stageHistory: jsonb("stage_history")
+      .$type<ContractStageHistoryEntry[]>()
+      .notNull()
+      .default(sql`'[]'::jsonb`),
     title: text("title").notNull(),
 
     templateVersionId: typeIdRef("template_version_id").references(

--- a/packages/legal/src/contracts/service-auto-generate.ts
+++ b/packages/legal/src/contracts/service-auto-generate.ts
@@ -1,6 +1,7 @@
 import { bookingsService } from "@voyantjs/bookings"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
+import type { ContractLifecycleHook } from "./lifecycle.js"
 import { contractRecordsService } from "./service-contracts.js"
 import type { ContractDocumentGenerator } from "./service-documents.js"
 import { contractDocumentsService } from "./service-documents.js"
@@ -380,6 +381,7 @@ export interface AutoGenerateContractOptions {
 export interface AutoGenerateContractRuntime {
   generator: ContractDocumentGenerator
   eventBus?: import("@voyantjs/core").EventBus
+  lifecycleHooks?: readonly ContractLifecycleHook[]
   /**
    * Runtime bindings forwarded into `resolveVariables` so consumers
    * can read deploy-specific env vars (e.g. `DOCUMENTS_BASE_URL`)
@@ -832,6 +834,7 @@ export async function autoGenerateContractForBooking(
     {
       generator: runtime.generator,
       eventBus: runtime.eventBus,
+      lifecycleHooks: runtime.lifecycleHooks,
     },
   )
 

--- a/packages/legal/src/contracts/service-contracts.ts
+++ b/packages/legal/src/contracts/service-contracts.ts
@@ -1,7 +1,14 @@
 import { people, personDirectoryView } from "@voyantjs/crm/schema"
 import { and, desc, eq, getTableColumns, ilike, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-
+import {
+  appendContractStageHistory,
+  buildContractLifecycleEvent,
+  type ContractLifecycleRuntimeOptions,
+  checkContractLifecycleTransition,
+  createContractStageHistoryEntry,
+  emitContractLifecycleEvent,
+} from "./lifecycle.js"
 import {
   contractAttachments,
   contractSignatures,
@@ -78,18 +85,27 @@ export const contractRecordsService = {
     return row ?? null
   },
   async createContract(db: PostgresJsDatabase, data: CreateContractInput) {
+    const now = new Date()
+    const stage = data.status ?? "draft"
     const [row] = await db
       .insert(contracts)
-      .values({ ...data, expiresAt: toTimestamp(data.expiresAt) })
+      .values({
+        ...data,
+        stageHistory: [createContractStageHistoryEntry(stage, { enteredAt: now })],
+        expiresAt: toTimestamp(data.expiresAt),
+      })
       .returning()
     return row ?? null
   },
   async updateContract(db: PostgresJsDatabase, id: string, data: UpdateContractInput) {
+    const { status: _status, ...update } = data as UpdateContractInput & {
+      status?: never
+    }
     const [row] = await db
       .update(contracts)
       .set({
-        ...data,
-        expiresAt: data.expiresAt === undefined ? undefined : toTimestamp(data.expiresAt),
+        ...update,
+        expiresAt: update.expiresAt === undefined ? undefined : toTimestamp(update.expiresAt),
         updatedAt: new Date(),
       })
       .where(eq(contracts.id, id))
@@ -107,8 +123,12 @@ export const contractRecordsService = {
     await db.delete(contracts).where(eq(contracts.id, id))
     return { status: "deleted" as const }
   },
-  async issueContract(db: PostgresJsDatabase, contractId: string) {
-    return db.transaction(async (tx) => {
+  async issueContract(
+    db: PostgresJsDatabase,
+    contractId: string,
+    runtime?: ContractLifecycleRuntimeOptions,
+  ) {
+    const result = await db.transaction(async (tx) => {
       const [contract] = await tx
         .select()
         .from(contracts)
@@ -116,7 +136,8 @@ export const contractRecordsService = {
         .for("update")
         .limit(1)
       if (!contract) return { status: "not_found" as const }
-      if (contract.status !== "draft") return { status: "not_draft" as const }
+      const transition = checkContractLifecycleTransition(contract.status, "issued")
+      if (!transition.ok) return { status: transition.reason }
       let renderedBody = contract.renderedBody
       let renderedBodyFormat = contract.renderedBodyFormat
       if (contract.templateVersionId) {
@@ -136,51 +157,124 @@ export const contractRecordsService = {
         const allocated = await allocateContractNumber(tx as PostgresJsDatabase, contract.seriesId)
         if (allocated) contractNumber = allocated.number
       }
+      const now = new Date()
+      const stageHistory = appendContractStageHistory(
+        contract.stageHistory,
+        createContractStageHistoryEntry("issued", {
+          previousStage: contract.status,
+          transition: "issued",
+          enteredAt: now,
+        }),
+      )
       const [updated] = await tx
         .update(contracts)
         .set({
           status: "issued",
-          issuedAt: new Date(),
+          stageHistory,
+          issuedAt: now,
           renderedBody,
           renderedBodyFormat,
           contractNumber,
-          updatedAt: new Date(),
+          updatedAt: now,
         })
         .where(eq(contracts.id, contractId))
         .returning()
-      return { status: "issued" as const, contract: updated ?? null }
+      return {
+        status: "issued" as const,
+        contract: updated ?? null,
+        event:
+          updated && buildContractLifecycleEvent(updated, contract.status, "issued", "issued", now),
+      }
     })
+    if (result.status === "issued" && result.event) {
+      await emitContractLifecycleEvent(runtime, result.event)
+    }
+    return result
   },
-  async sendContract(db: PostgresJsDatabase, contractId: string) {
-    const [contract] = await db
-      .select({ id: contracts.id, status: contracts.status })
-      .from(contracts)
-      .where(eq(contracts.id, contractId))
-      .limit(1)
-    if (!contract) return { status: "not_found" as const }
-    if (contract.status !== "issued" && contract.status !== "sent")
-      return { status: "not_issued" as const }
-    const [updated] = await db
-      .update(contracts)
-      .set({ status: "sent", sentAt: new Date(), updatedAt: new Date() })
-      .where(eq(contracts.id, contractId))
-      .returning()
-    return { status: "sent" as const, contract: updated ?? null }
+  async sendContract(
+    db: PostgresJsDatabase,
+    contractId: string,
+    runtime?: ContractLifecycleRuntimeOptions,
+  ) {
+    const result = await db.transaction(async (tx) => {
+      const [contract] = await tx
+        .select()
+        .from(contracts)
+        .where(eq(contracts.id, contractId))
+        .for("update")
+        .limit(1)
+      if (!contract) return { status: "not_found" as const }
+      const transition = checkContractLifecycleTransition(contract.status, "sent")
+      if (!transition.ok) return { status: transition.reason }
+      if (contract.status === "sent") {
+        return { status: "sent" as const, contract, event: null }
+      }
+      const now = new Date()
+      const stageHistory = appendContractStageHistory(
+        contract.stageHistory,
+        createContractStageHistoryEntry("sent", {
+          previousStage: contract.status,
+          transition: "sent",
+          enteredAt: now,
+        }),
+      )
+      const [updated] = await tx
+        .update(contracts)
+        .set({ status: "sent", stageHistory, sentAt: now, updatedAt: now })
+        .where(eq(contracts.id, contractId))
+        .returning()
+      return {
+        status: "sent" as const,
+        contract: updated ?? null,
+        event:
+          updated && buildContractLifecycleEvent(updated, contract.status, "sent", "sent", now),
+      }
+    })
+    if (result.status === "sent" && result.event) {
+      await emitContractLifecycleEvent(runtime, result.event)
+    }
+    return result
   },
-  async voidContract(db: PostgresJsDatabase, contractId: string) {
-    const [contract] = await db
-      .select({ id: contracts.id, status: contracts.status })
-      .from(contracts)
-      .where(eq(contracts.id, contractId))
-      .limit(1)
-    if (!contract) return { status: "not_found" as const }
-    if (contract.status === "void") return { status: "already_void" as const }
-    const [updated] = await db
-      .update(contracts)
-      .set({ status: "void", voidedAt: new Date(), updatedAt: new Date() })
-      .where(eq(contracts.id, contractId))
-      .returning()
-    return { status: "voided" as const, contract: updated ?? null }
+  async voidContract(
+    db: PostgresJsDatabase,
+    contractId: string,
+    runtime?: ContractLifecycleRuntimeOptions,
+  ) {
+    const result = await db.transaction(async (tx) => {
+      const [contract] = await tx
+        .select()
+        .from(contracts)
+        .where(eq(contracts.id, contractId))
+        .for("update")
+        .limit(1)
+      if (!contract) return { status: "not_found" as const }
+      const transition = checkContractLifecycleTransition(contract.status, "voided")
+      if (!transition.ok) return { status: transition.reason }
+      const now = new Date()
+      const stageHistory = appendContractStageHistory(
+        contract.stageHistory,
+        createContractStageHistoryEntry("void", {
+          previousStage: contract.status,
+          transition: "voided",
+          enteredAt: now,
+        }),
+      )
+      const [updated] = await tx
+        .update(contracts)
+        .set({ status: "void", stageHistory, voidedAt: now, updatedAt: now })
+        .where(eq(contracts.id, contractId))
+        .returning()
+      return {
+        status: "voided" as const,
+        contract: updated ?? null,
+        event:
+          updated && buildContractLifecycleEvent(updated, contract.status, "void", "voided", now),
+      }
+    })
+    if (result.status === "voided" && result.event) {
+      await emitContractLifecycleEvent(runtime, result.event)
+    }
+    return result
   },
   listSignatures(db: PostgresJsDatabase, contractId: string) {
     return db
@@ -193,42 +287,90 @@ export const contractRecordsService = {
     db: PostgresJsDatabase,
     contractId: string,
     data: CreateContractSignatureInput,
+    runtime?: ContractLifecycleRuntimeOptions,
   ) {
-    return db.transaction(async (tx) => {
+    const result = await db.transaction(async (tx) => {
       const [contract] = await tx
         .select()
         .from(contracts)
         .where(eq(contracts.id, contractId))
+        .for("update")
         .limit(1)
       if (!contract) return { status: "not_found" as const }
-      if (contract.status !== "issued" && contract.status !== "sent")
-        return { status: "not_signable" as const }
+      const transition = checkContractLifecycleTransition(contract.status, "signed")
+      if (!transition.ok) return { status: "not_signable" as const }
       const [signature] = await tx
         .insert(contractSignatures)
         .values({ ...data, contractId })
         .returning()
+      const now = new Date()
+      const stageHistory = appendContractStageHistory(
+        contract.stageHistory,
+        createContractStageHistoryEntry("signed", {
+          previousStage: contract.status,
+          transition: "signed",
+          enteredAt: now,
+        }),
+      )
       const [updated] = await tx
         .update(contracts)
-        .set({ status: "signed", updatedAt: new Date() })
+        .set({ status: "signed", stageHistory, updatedAt: now })
         .where(eq(contracts.id, contractId))
         .returning()
-      return { status: "signed" as const, contract: updated ?? null, signature: signature ?? null }
+      return {
+        status: "signed" as const,
+        contract: updated ?? null,
+        signature: signature ?? null,
+        event:
+          updated && buildContractLifecycleEvent(updated, contract.status, "signed", "signed", now),
+      }
     })
+    if (result.status === "signed" && result.event) {
+      await emitContractLifecycleEvent(runtime, result.event)
+    }
+    return result
   },
-  async executeContract(db: PostgresJsDatabase, contractId: string) {
-    const [contract] = await db
-      .select({ id: contracts.id, status: contracts.status })
-      .from(contracts)
-      .where(eq(contracts.id, contractId))
-      .limit(1)
-    if (!contract) return { status: "not_found" as const }
-    if (contract.status !== "signed") return { status: "not_signed" as const }
-    const [updated] = await db
-      .update(contracts)
-      .set({ status: "executed", executedAt: new Date(), updatedAt: new Date() })
-      .where(eq(contracts.id, contractId))
-      .returning()
-    return { status: "executed" as const, contract: updated ?? null }
+  async executeContract(
+    db: PostgresJsDatabase,
+    contractId: string,
+    runtime?: ContractLifecycleRuntimeOptions,
+  ) {
+    const result = await db.transaction(async (tx) => {
+      const [contract] = await tx
+        .select()
+        .from(contracts)
+        .where(eq(contracts.id, contractId))
+        .for("update")
+        .limit(1)
+      if (!contract) return { status: "not_found" as const }
+      const transition = checkContractLifecycleTransition(contract.status, "executed")
+      if (!transition.ok) return { status: transition.reason }
+      const now = new Date()
+      const stageHistory = appendContractStageHistory(
+        contract.stageHistory,
+        createContractStageHistoryEntry("executed", {
+          previousStage: contract.status,
+          transition: "executed",
+          enteredAt: now,
+        }),
+      )
+      const [updated] = await tx
+        .update(contracts)
+        .set({ status: "executed", stageHistory, executedAt: now, updatedAt: now })
+        .where(eq(contracts.id, contractId))
+        .returning()
+      return {
+        status: "executed" as const,
+        contract: updated ?? null,
+        event:
+          updated &&
+          buildContractLifecycleEvent(updated, contract.status, "executed", "executed", now),
+      }
+    })
+    if (result.status === "executed" && result.event) {
+      await emitContractLifecycleEvent(runtime, result.event)
+    }
+    return result
   },
   listAttachments(db: PostgresJsDatabase, contractId: string) {
     return db

--- a/packages/legal/src/contracts/service-documents.ts
+++ b/packages/legal/src/contracts/service-documents.ts
@@ -3,7 +3,7 @@ import type { StorageProvider, StorageUploadBody } from "@voyantjs/storage"
 import { renderPdfDocument } from "@voyantjs/utils/pdf-renderer"
 import { desc, eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-
+import type { ContractLifecycleHook } from "./lifecycle.js"
 import { contractAttachments, contracts, contractTemplateVersions } from "./schema.js"
 import { contractRecordsService } from "./service-contracts.js"
 import type { CreateContractAttachmentInput } from "./service-shared.js"
@@ -38,6 +38,7 @@ export interface ContractDocumentRuntimeOptions {
   bindings?: Record<string, unknown>
   generator: ContractDocumentGenerator
   eventBus?: EventBus
+  lifecycleHooks?: readonly ContractLifecycleHook[]
 }
 
 export interface StorageBackedContractDocumentUpload {
@@ -260,6 +261,7 @@ async function ensureRenderedContract(
   db: PostgresJsDatabase,
   contractId: string,
   issueIfDraft: boolean,
+  runtime?: Pick<ContractDocumentRuntimeOptions, "eventBus" | "lifecycleHooks">,
 ): Promise<EnsureRenderedContractResult> {
   let contract = await contractRecordsService.getContractById(db, contractId)
   if (!contract) {
@@ -269,7 +271,7 @@ async function ensureRenderedContract(
   if (contract.status === "draft" && issueIfDraft) {
     let issued: Awaited<ReturnType<typeof contractRecordsService.issueContract>>
     try {
-      issued = await contractRecordsService.issueContract(db, contractId)
+      issued = await contractRecordsService.issueContract(db, contractId, runtime)
     } catch (error) {
       if (isContractTemplateSyntaxError(error)) {
         return { status: "render_unavailable" as const, contract, templateVersion: null }
@@ -338,7 +340,7 @@ export const contractDocumentsService = {
     | { status: "not_found" | "not_draft" | "render_unavailable" | "generator_failed" }
     | ({ status: "generated" } & GeneratedContractDocumentRecord)
   > {
-    const prepared = await ensureRenderedContract(db, contractId, input.issueIfDraft)
+    const prepared = await ensureRenderedContract(db, contractId, input.issueIfDraft, runtime)
 
     if (prepared.status === "not_found") {
       return { status: "not_found" }

--- a/packages/legal/src/contracts/validation.ts
+++ b/packages/legal/src/contracts/validation.ts
@@ -13,6 +13,14 @@ export const contractStatusSchema = z.enum([
   "void",
 ])
 
+export const contractStageHistoryEntrySchema = z.object({
+  stage: contractStatusSchema,
+  previousStage: contractStatusSchema.nullable(),
+  transition: z.enum(["created", "issued", "sent", "signed", "executed", "voided"]),
+  enteredAt: z.string(),
+  actorId: z.string().nullable().optional(),
+})
+
 export const contractSignatureMethodSchema = z.enum(["manual", "electronic", "docusign", "other"])
 
 export const contractNumberResetStrategySchema = z.enum(["never", "annual", "monthly"])
@@ -128,7 +136,12 @@ const contractCoreSchema = z.object({
 })
 
 export const insertContractSchema = contractCoreSchema
-export const updateContractSchema = contractCoreSchema.partial()
+export const updateContractSchema = contractCoreSchema
+  .omit({ status: true, language: true })
+  .extend({
+    language: z.string().min(2).max(10).optional(),
+  })
+  .partial()
 
 export const contractListQuerySchema = paginationSchema.extend({
   scope: contractScopeSchema.optional(),

--- a/packages/legal/src/index.ts
+++ b/packages/legal/src/index.ts
@@ -56,16 +56,16 @@ export function createLegalHonoModule(options: CreateLegalHonoModuleOptions = {}
     .route("/policies", policiesAdminRoutes)
 
   const legalPublicRoutes = new Hono()
-    .route("/contracts", createContractsPublicRoutes())
+    .route("/contracts", createContractsPublicRoutes(options))
     .route("/policies", policiesPublicRoutes)
 
   const module: Module = {
     ...legalModule,
     bootstrap: ({ bindings, container, eventBus }) => {
-      container.register(
-        CONTRACTS_ROUTE_RUNTIME_CONTAINER_KEY,
-        buildContractsRouteRuntime(bindings as Record<string, unknown>, options),
-      )
+      const bindingsRecord = bindings as Record<string, unknown>
+      const contractsRuntime = buildContractsRouteRuntime(bindingsRecord, options)
+      contractsRuntime.eventBus ??= eventBus
+      container.register(CONTRACTS_ROUTE_RUNTIME_CONTAINER_KEY, contractsRuntime)
 
       // Auto-generate wiring — opt-in. Mirrors the notifications
       // autoConfirmAndDispatch subscriber pattern. Both fire on the same
@@ -76,8 +76,7 @@ export function createLegalHonoModule(options: CreateLegalHonoModuleOptions = {}
       const auto = options.autoGenerateContractOnConfirmed
       if (auto?.enabled && options.resolveDb) {
         const resolveDb = options.resolveDb
-        const runtime = buildContractsRouteRuntime(bindings as Record<string, unknown>, options)
-        if (!runtime.documentGenerator) {
+        if (!contractsRuntime.documentGenerator) {
           // Mis-configuration — don't silently drop contracts. Log and
           // skip; the template operator will notice on the first confirm.
           console.error(
@@ -85,7 +84,7 @@ export function createLegalHonoModule(options: CreateLegalHonoModuleOptions = {}
           )
           return
         }
-        const generator = runtime.documentGenerator
+        const generator = contractsRuntime.documentGenerator
 
         eventBus.subscribe(
           "booking.confirmed",
@@ -100,7 +99,8 @@ export function createLegalHonoModule(options: CreateLegalHonoModuleOptions = {}
               const result = await autoGenerateContractForBooking(db, event.data, auto, {
                 generator,
                 eventBus,
-                bindings: bindings as Record<string, unknown>,
+                lifecycleHooks: contractsRuntime.lifecycleHooks,
+                bindings: bindingsRecord,
               })
               if (result.status !== "ok") {
                 console.error(

--- a/packages/legal/tests/integration/public-routes.test.ts
+++ b/packages/legal/tests/integration/public-routes.test.ts
@@ -27,6 +27,7 @@ describe.skipIf(!DB_AVAILABLE)("Legal public routes", () => {
   let generatedNames: string[]
   let documentEvents: Array<Record<string, unknown>>
   let uploadedObjects: Array<{ key: string; size: number; contentType: string | null }>
+  let lifecycleEvents: Array<Record<string, unknown>>
 
   beforeAll(async () => {
     const { createTestDb, cleanupTestDb } = await import("@voyantjs/db/test-utils")
@@ -64,6 +65,18 @@ describe.skipIf(!DB_AVAILABLE)("Legal public routes", () => {
       async get() {
         return null
       },
+    }
+    lifecycleEvents = []
+    for (const eventName of [
+      "contract.issued",
+      "contract.sent",
+      "contract.signed",
+      "contract.executed",
+      "contract.voided",
+    ]) {
+      eventBus.subscribe(eventName, (event) => {
+        lifecycleEvents.push(event as Record<string, unknown>)
+      })
     }
     adminApp.route(
       "/",
@@ -104,6 +117,7 @@ describe.skipIf(!DB_AVAILABLE)("Legal public routes", () => {
     generatedNames = []
     documentEvents = []
     uploadedObjects = []
+    lifecycleEvents = []
   })
 
   it("selects the default active template using language fallback order", async () => {
@@ -445,5 +459,83 @@ describe.skipIf(!DB_AVAILABLE)("Legal public routes", () => {
     expect(res.status).toBe(404)
     expect(await res.json()).toEqual({ error: "Contract not found" })
     expect(uploadedObjects).toEqual([])
+  })
+
+  it("validates contract lifecycle transitions, records history, and emits safe events", async () => {
+    const createRes = await adminApp.request("/", {
+      method: "POST",
+      ...json({
+        title: "Lifecycle contract",
+        scope: "customer",
+      }),
+    })
+    expect(createRes.status).toBe(201)
+    const created = (await createRes.json()).data
+    expect(created.stageHistory).toEqual([
+      expect.objectContaining({
+        stage: "draft",
+        previousStage: null,
+        transition: "created",
+      }),
+    ])
+
+    const prematureSign = await adminApp.request(`/${created.id}/sign`, {
+      method: "POST",
+      ...json({
+        signerName: "Ada Lovelace",
+        method: "manual",
+      }),
+    })
+    expect(prematureSign.status).toBe(409)
+
+    const issueRes = await adminApp.request(`/${created.id}/issue`, { method: "POST" })
+    expect(issueRes.status).toBe(200)
+
+    const sendRes = await adminApp.request(`/${created.id}/send`, { method: "POST" })
+    expect(sendRes.status).toBe(200)
+
+    const signRes = await adminApp.request(`/${created.id}/sign`, {
+      method: "POST",
+      ...json({
+        signerName: "Ada Lovelace",
+        method: "manual",
+      }),
+    })
+    expect(signRes.status).toBe(200)
+
+    const executeRes = await adminApp.request(`/${created.id}/execute`, { method: "POST" })
+    expect(executeRes.status).toBe(200)
+
+    const voidRes = await adminApp.request(`/${created.id}/void`, { method: "POST" })
+    expect(voidRes.status).toBe(200)
+    const finalContract = (await voidRes.json()).data
+
+    expect(finalContract.status).toBe("void")
+    expect(finalContract.stageHistory.map((entry: { stage: string }) => entry.stage)).toEqual([
+      "draft",
+      "issued",
+      "sent",
+      "signed",
+      "executed",
+      "void",
+    ])
+    expect(lifecycleEvents.map((event) => event.name)).toEqual([
+      "contract.issued",
+      "contract.sent",
+      "contract.signed",
+      "contract.executed",
+      "contract.voided",
+    ])
+    expect(lifecycleEvents[0]?.metadata).toEqual({
+      category: "domain",
+      source: "service",
+    })
+    expect(lifecycleEvents[0]?.data).toEqual(
+      expect.not.objectContaining({
+        renderedBody: expect.anything(),
+        variables: expect.anything(),
+        metadata: expect.anything(),
+      }),
+    )
   })
 })

--- a/packages/legal/tests/unit/contract-lifecycle.test.ts
+++ b/packages/legal/tests/unit/contract-lifecycle.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  appendContractStageHistory,
+  buildContractLifecycleEvent,
+  checkContractLifecycleTransition,
+  createContractStageHistoryEntry,
+  emitContractLifecycleEvent,
+} from "../../src/contracts/lifecycle.js"
+import type { Contract } from "../../src/contracts/schema.js"
+import { updateContractSchema } from "../../src/contracts/validation.js"
+
+describe("contract lifecycle", () => {
+  it("accepts the documented happy-path transitions", () => {
+    expect(checkContractLifecycleTransition("draft", "issued")).toEqual({ ok: true })
+    expect(checkContractLifecycleTransition("issued", "sent")).toEqual({ ok: true })
+    expect(checkContractLifecycleTransition("sent", "signed")).toEqual({ ok: true })
+    expect(checkContractLifecycleTransition("signed", "executed")).toEqual({ ok: true })
+    expect(checkContractLifecycleTransition("executed", "voided")).toEqual({ ok: true })
+  })
+
+  it("rejects out-of-order transitions", () => {
+    expect(checkContractLifecycleTransition("draft", "signed")).toEqual({
+      ok: false,
+      reason: "not_sent",
+    })
+    expect(checkContractLifecycleTransition("issued", "signed")).toEqual({
+      ok: false,
+      reason: "not_sent",
+    })
+    expect(checkContractLifecycleTransition("sent", "executed")).toEqual({
+      ok: false,
+      reason: "not_signed",
+    })
+    expect(checkContractLifecycleTransition("void", "voided")).toEqual({
+      ok: false,
+      reason: "already_void",
+    })
+  })
+
+  it("does not accept direct status changes through the update schema", () => {
+    expect(updateContractSchema.parse({ title: "Keep status", status: "executed" })).toEqual({
+      title: "Keep status",
+    })
+  })
+
+  it("keeps lifecycle hooks best-effort after event emission", async () => {
+    const calls: string[] = []
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+    const eventBus = {
+      emit: vi.fn(async () => {
+        calls.push("event")
+      }),
+      subscribe: vi.fn(),
+    }
+
+    try {
+      await expect(
+        emitContractLifecycleEvent(
+          {
+            eventBus,
+            lifecycleHooks: [
+              () => {
+                calls.push("hook-1")
+                throw new Error("side effect failed")
+              },
+              () => {
+                calls.push("hook-2")
+              },
+            ],
+          },
+          {
+            contractId: "cont_123",
+            contractNumber: null,
+            scope: "customer",
+            previousStage: "signed",
+            stage: "executed",
+            transition: "executed",
+            occurredAt: "2026-05-14T10:05:00.000Z",
+            personId: null,
+            organizationId: null,
+            supplierId: null,
+            channelId: null,
+            bookingId: null,
+            orderId: null,
+          },
+        ),
+      ).resolves.toBeUndefined()
+
+      expect(calls).toEqual(["event", "hook-1", "hook-2"])
+      expect(eventBus.emit).toHaveBeenCalledWith(
+        "contract.executed",
+        expect.objectContaining({ contractId: "cont_123" }),
+        { category: "domain", source: "service" },
+      )
+      expect(consoleError).toHaveBeenCalledWith(
+        "[legal] lifecycle hook failed for contract.executed:",
+        expect.any(Error),
+      )
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  it("records transition history entries without leaking contract body fields into events", () => {
+    const created = createContractStageHistoryEntry("draft", {
+      enteredAt: new Date("2026-05-14T10:00:00.000Z"),
+    })
+    const issued = createContractStageHistoryEntry("issued", {
+      previousStage: "draft",
+      transition: "issued",
+      enteredAt: new Date("2026-05-14T10:05:00.000Z"),
+    })
+
+    expect(appendContractStageHistory([created], issued)).toEqual([created, issued])
+
+    const event = buildContractLifecycleEvent(
+      {
+        id: "cont_123",
+        contractNumber: "C-1",
+        scope: "customer",
+        status: "issued",
+        stageHistory: [created, issued],
+        title: "Customer contract",
+        templateVersionId: null,
+        seriesId: null,
+        personId: "pers_123",
+        organizationId: null,
+        supplierId: null,
+        channelId: null,
+        bookingId: "book_123",
+        orderId: null,
+        issuedAt: null,
+        sentAt: null,
+        executedAt: null,
+        expiresAt: null,
+        voidedAt: null,
+        language: "en",
+        renderedBodyFormat: "html",
+        renderedBody: "<p>private</p>",
+        variables: null,
+        metadata: null,
+        createdAt: new Date("2026-05-14T10:00:00.000Z"),
+        updatedAt: new Date("2026-05-14T10:05:00.000Z"),
+      } satisfies Contract,
+      "draft",
+      "issued",
+      "issued",
+      new Date("2026-05-14T10:05:00.000Z"),
+    )
+
+    expect(event).toEqual({
+      contractId: "cont_123",
+      contractNumber: "C-1",
+      scope: "customer",
+      previousStage: "draft",
+      stage: "issued",
+      transition: "issued",
+      occurredAt: "2026-05-14T10:05:00.000Z",
+      personId: "pers_123",
+      organizationId: null,
+      supplierId: null,
+      channelId: null,
+      bookingId: "book_123",
+      orderId: null,
+    })
+  })
+})

--- a/packages/legal/tests/unit/module.test.ts
+++ b/packages/legal/tests/unit/module.test.ts
@@ -26,4 +26,17 @@ describe("createLegalHonoModule", () => {
     expect(runtime?.documentGenerator).toBe(generator)
     expect(runtime?.eventBus).toBe(eventBus)
   })
+
+  it("uses the module event bus when no route event bus is configured", () => {
+    const eventBus = createEventBus()
+    const container = createContainer()
+
+    const module = createLegalHonoModule().module
+
+    module.bootstrap?.({ bindings: {}, container, eventBus })
+
+    const runtime = container.resolve(CONTRACTS_ROUTE_RUNTIME_CONTAINER_KEY)
+
+    expect(runtime?.eventBus).toBe(eventBus)
+  })
 })

--- a/templates/dmc/migrations/0008_contract_lifecycle_history.sql
+++ b/templates/dmc/migrations/0008_contract_lifecycle_history.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "contracts" ADD COLUMN "stage_history" jsonb DEFAULT '[]'::jsonb NOT NULL;

--- a/templates/dmc/migrations/meta/_journal.json
+++ b/templates/dmc/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1778778986000,
       "tag": "0007_default_contract_templates",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1778779788000,
+      "tag": "0008_contract_lifecycle_history",
+      "breakpoints": true
     }
   ]
 }

--- a/templates/operator/migrations/0016_contract_lifecycle_history.sql
+++ b/templates/operator/migrations/0016_contract_lifecycle_history.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "contracts" ADD COLUMN "stage_history" jsonb DEFAULT '[]'::jsonb NOT NULL;

--- a/templates/operator/migrations/meta/_journal.json
+++ b/templates/operator/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1778778986000,
       "tag": "0015_default_contract_templates",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1778779788000,
+      "tag": "0016_contract_lifecycle_history",
+      "breakpoints": true
     }
   ]
 }

--- a/templates/operator/src/api/catalog-checkout.ts
+++ b/templates/operator/src/api/catalog-checkout.ts
@@ -1581,6 +1581,7 @@ async function persistAcceptanceDraftContract(
 async function persistAcceptanceSignature(
   db: PostgresJsDatabase,
   contractId: string,
+  eventBus?: EventBus,
 ): Promise<void> {
   const { contractsService } = await import("@voyantjs/legal/contracts")
   const { contracts: contractsTable } = await import("@voyantjs/legal/contracts")
@@ -1603,10 +1604,19 @@ async function persistAcceptanceSignature(
   const acceptance = readContractAcceptance(contract.metadata, booking.internalNotes)
   if (!acceptance) return
 
-  // Already signed? `signContract` requires status ∈ {issued, sent};
-  // idempotency comes from listSignatures.
+  // Already signed? Idempotency comes from listSignatures.
   const existing = await contractsService.listSignatures(db, contractId)
   if (existing.length > 0) return
+
+  if (contract.status === "issued") {
+    const sent = await contractsService.sendContract(db, contractId, { eventBus })
+    if (sent.status !== "sent") {
+      console.warn(
+        `[catalog-checkout] could not send contract before acceptance signature for ${contractId}: ${sent.status}`,
+      )
+      return
+    }
+  }
 
   // Prefer the booking's contact name when available so the signer
   // line on the contract reads as the human, not the booking ref.
@@ -1618,21 +1628,26 @@ async function persistAcceptanceSignature(
     contactName ||
     `Storefront customer${booking.bookingNumber ? ` (${booking.bookingNumber})` : ""}`
 
-  const result = await contractsService.signContract(db, contractId, {
-    signerName,
-    signerEmail: booking.contactEmail ?? null,
-    method: "electronic" as const,
-    ipAddress: acceptance.clientIp ? acceptance.clientIp.slice(0, 64) : null,
-    userAgent: acceptance.userAgent ? acceptance.userAgent.slice(0, 500) : null,
-    metadata: {
-      source: "storefront-checkout",
-      templateId: acceptance.templateId,
-      templateSlug: acceptance.templateSlug,
-      acceptedAt: acceptance.acceptedAt,
-      acceptedMarketing: acceptance.acceptedMarketing,
-      renderedHtmlLength: acceptance.renderedHtmlLength,
-    },
-  } as never)
+  const result = await contractsService.signContract(
+    db,
+    contractId,
+    {
+      signerName,
+      signerEmail: booking.contactEmail ?? null,
+      method: "electronic" as const,
+      ipAddress: acceptance.clientIp ? acceptance.clientIp.slice(0, 64) : null,
+      userAgent: acceptance.userAgent ? acceptance.userAgent.slice(0, 500) : null,
+      metadata: {
+        source: "storefront-checkout",
+        templateId: acceptance.templateId,
+        templateSlug: acceptance.templateSlug,
+        acceptedAt: acceptance.acceptedAt,
+        acceptedMarketing: acceptance.acceptedMarketing,
+        renderedHtmlLength: acceptance.renderedHtmlLength,
+      },
+    } as never,
+    { eventBus },
+  )
 
   if (result.status !== "signed") {
     console.warn(
@@ -2022,7 +2037,7 @@ export function createCatalogCheckoutBundle(opts: {
           try {
             await withDbFromEnv(env, async (rawDb) => {
               const db = rawDb as unknown as PostgresJsDatabase
-              await persistAcceptanceSignature(db, data.contractId)
+              await persistAcceptanceSignature(db, data.contractId, eventBus)
             })
           } catch (err) {
             console.error("[catalog-checkout] persistAcceptanceSignature failed", err)


### PR DESCRIPTION
## Summary
- add contract lifecycle stage history and transition validation for issue/send/sign/execute/void
- emit minimal domain events for contract lifecycle transitions and pass lifecycle runtime hooks through routes and auto-generation
- register DMC/operator migrations, update public schemas/docs, and cover transition/event behavior in tests

Fixes #877

## Verification
- pnpm --filter @voyantjs/legal lint
- pnpm --filter @voyantjs/legal-react lint
- pnpm --filter @voyantjs/legal typecheck
- pnpm --filter @voyantjs/legal-react typecheck
- pnpm --filter @voyantjs/legal test
- pnpm --filter @voyantjs/storefront test
- pnpm --filter @voyantjs/storefront-sdk test
- DATABASE_URL=postgres://test:test@localhost:5436/voyant_test pnpm -C templates/operator db:check
- DATABASE_URL=postgres://test:test@localhost:5436/voyant_test pnpm -C templates/dmc db:check
- TEST_DATABASE_URL=postgres://test:test@localhost:5436/voyant_test pnpm --filter @voyantjs/legal exec vitest run tests/integration/public-routes.test.ts
- pnpm verify:fast
- pnpm --filter @voyantjs/legal build
- pnpm --filter @voyantjs/legal-react build
- pnpm verify:package-exports

## Notes
- pnpm build currently reaches templates/dmc and fails resolving @voyantjs/crm/validation from packages/storefront/src/validation.ts during Vite/Rolldown SSR bundling; Node resolves that package export from templates/dmc.
- The pre-push hook hit @voyantjs/storefront and @voyantjs/storefront-sdk test failures under full-repo concurrency; both package tests pass when rerun directly.