### PR TITLE
feat(notifications): add booking document bundle lifecycle

### DIFF
--- a/.changeset/booking-document-bundle-lifecycle.md
+++ b/.changeset/booking-document-bundle-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/notifications": minor
+---
+
+Add first-class booking document-bundle lifecycle hooks for confirmation and fully-paid transitions, with default legal/finance bundle composition and host-overridable notification policy.

--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -104,6 +104,57 @@ should override that behavior with `documentAttachmentResolver` or
 or `createNotificationsHonoModule()`, so attachment URLs are resolved at send
 time from the current storage/runtime context.
 
+## Booking Document Bundle Lifecycle
+
+`createNotificationsHonoModule()` can subscribe to booking confirmation and
+fully-paid lifecycle signals through `documentBundleLifecycle`. The hook
+resolves the booking, primary customer/recipient, travelers, booking items, and
+existing legal/finance document bundle before invoking the configured policy.
+
+```ts
+const notificationsModule = createNotificationsHonoModule({
+  resolveDb: (bindings) => getDbFromEnv(bindings),
+  resolveProviders,
+  documentBundleLifecycle: {
+    enabled: true,
+    confirmation: {
+      notification: { templateSlug: "booking-confirmation" },
+    },
+    fullyPaid: {
+      documentTypes: ["contract", "invoice"],
+      notification: { templateSlug: "booking-paid-in-full" },
+    },
+    ensureLegalDocuments: async (context) => {
+      await generateContractForBooking(context.booking.id)
+    },
+    ensureFinanceDocuments: async (context, request) => {
+      await generateInvoiceDocuments(context.booking.id, request.documentTypes)
+    },
+    notificationPolicy: async (context, result) => ({
+      templateSlug:
+        context.trigger === "booking.fully-paid"
+          ? "booking-paid-in-full"
+          : "booking-confirmation",
+      documentTypes: result.documents.map((document) => document.documentType),
+    }),
+  },
+})
+```
+
+The default policy is idempotent by document type: confirmation asks for
+`contract` + `proforma`, and fully-paid asks for `contract` + `invoice`. If a
+contract was already generated at confirmation, the fully-paid hook records it
+as existing and only calls the configured finance generator for the missing
+invoice. Generator exceptions are returned as failed lifecycle results and the
+module subscriber logs booking id plus status only; it does not log document
+contents, attachment bodies, or customer data.
+
+Host apps can replace the entire policy with `policy`, or keep the default
+composition and override only `notificationPolicy`. Product brochures remain an
+extension point via `resolveBrochureDocuments`, so apps that install
+`@voyantjs/products` can add current brochure artifacts without making
+notifications depend on products at runtime.
+
 ## Exports
 
 | Entry | Description |

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -11,6 +11,13 @@ import {
 } from "./routes.js"
 import { notificationsModule } from "./schema.js"
 import { createNotificationService } from "./service.js"
+import {
+  BOOKING_FULLY_PAID_EVENT,
+  type BookingDocumentBundleLifecycleOptions,
+  type BookingFullyPaidEvent,
+  bookingDocumentBundleLifecycleService,
+  type RunBookingDocumentBundleLifecycleInput,
+} from "./service-booking-document-lifecycle.js"
 import { bookingDocumentNotificationsService } from "./service-booking-documents.js"
 import {
   bookingIsPaidInFullForNotification,
@@ -73,6 +80,28 @@ export {
   previewNotificationTemplate,
   renderNotificationTemplate,
 } from "./service.js"
+export type {
+  BookingDocumentBundleLifecycleContext,
+  BookingDocumentBundleLifecycleDocumentType,
+  BookingDocumentBundleLifecycleEnsureDocuments,
+  BookingDocumentBundleLifecycleEvent,
+  BookingDocumentBundleLifecycleOptions,
+  BookingDocumentBundleLifecyclePolicy,
+  BookingDocumentBundleLifecyclePolicyResult,
+  BookingDocumentBundleLifecycleResolveBrochures,
+  BookingDocumentBundleLifecycleResult,
+  BookingDocumentBundleLifecycleStageOptions,
+  BookingDocumentBundleLifecycleStep,
+  BookingDocumentBundleLifecycleTrigger,
+  BookingDocumentBundleNotificationPolicy,
+  BookingFullyPaidEvent,
+} from "./service-booking-document-lifecycle.js"
+export {
+  BOOKING_FULLY_PAID_EVENT,
+  bookingDocumentBundleLifecycleService,
+  createDefaultBookingDocumentBundlePolicy,
+  resolveBookingDocumentBundleLifecycleContext,
+} from "./service-booking-document-lifecycle.js"
 export type {
   BookingDocumentAttachmentResolver,
   BookingDocumentsSentEvent,
@@ -178,6 +207,22 @@ export interface CreateNotificationsHonoModuleOptions extends NotificationsRoute
    */
   resolveDb?: (bindings: Record<string, unknown>) => AnyDrizzleDb
   autoConfirmAndDispatch?: NotificationsAutoConfirmAndDispatchOptions
+  /**
+   * First-class booking lifecycle hook for composing customer document
+   * bundles after confirmation and fully-paid transitions. Host apps can
+   * plug legal/finance/brochure generators and override notification policy
+   * without replacing the upstream event wiring.
+   */
+  documentBundleLifecycle?: BookingDocumentBundleLifecycleOptions
+}
+
+function logDocumentBundleLifecycleFailure(
+  input: RunBookingDocumentBundleLifecycleInput,
+  message: string,
+) {
+  console.error(
+    `[notifications] document-bundle lifecycle failed for ${input.trigger} booking ${input.event.bookingId}: ${message}`,
+  )
 }
 
 export function createNotificationsHonoModule(
@@ -234,6 +279,96 @@ export function createNotificationsHonoModule(
               const message = error instanceof Error ? error.message : String(error)
               console.error(
                 `[notifications] auto-dispatch failed for booking ${event.data.bookingId}: ${message}`,
+              )
+            }
+          },
+        )
+      }
+
+      if (options?.documentBundleLifecycle?.enabled && options.resolveDb) {
+        const resolveDb = options.resolveDb
+        const lifecycleOptions = options.documentBundleLifecycle
+        const runtime = buildNotificationsRouteRuntime(bindings as Record<string, unknown>, options)
+        const dispatcher = createNotificationService(runtime.providers)
+
+        const runLifecycle = async (input: RunBookingDocumentBundleLifecycleInput) => {
+          try {
+            const db = resolveDb(bindings as Record<string, unknown>) as PostgresJsDatabase
+            const result = await bookingDocumentBundleLifecycleService.run(
+              db,
+              dispatcher,
+              input,
+              lifecycleOptions,
+              { attachmentResolver: runtime.documentAttachmentResolver, eventBus },
+            )
+            if (result.status === "failed") {
+              logDocumentBundleLifecycleFailure(input, result.error)
+            }
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error)
+            logDocumentBundleLifecycleFailure(input, message)
+          }
+        }
+
+        eventBus.subscribe(
+          "booking.confirmed",
+          async (event: {
+            data: { bookingId: string; bookingNumber: string; actorId: string | null }
+          }) => {
+            await runLifecycle({ trigger: "booking.confirmed", event: event.data })
+          },
+        )
+
+        eventBus.subscribe(
+          BOOKING_FULLY_PAID_EVENT,
+          async (event: { data: BookingFullyPaidEvent }) => {
+            await runLifecycle({ trigger: BOOKING_FULLY_PAID_EVENT, event: event.data })
+          },
+        )
+
+        eventBus.subscribe(
+          "payment.completed",
+          async (event: {
+            data: {
+              paymentSessionId: string
+              bookingId?: string | null
+              orderId?: string | null
+              invoiceId?: string | null
+              amountCents: number
+              currency: string
+              provider: string
+            }
+          }) => {
+            if (!event.data.bookingId) {
+              return
+            }
+
+            try {
+              const db = resolveDb(bindings as Record<string, unknown>) as PostgresJsDatabase
+              const isPaidInFull = await bookingIsPaidInFullForNotification(
+                db,
+                event.data.bookingId,
+              )
+              if (!isPaidInFull) {
+                return
+              }
+
+              await eventBus.emit(
+                BOOKING_FULLY_PAID_EVENT,
+                {
+                  bookingId: event.data.bookingId,
+                  paymentSessionId: event.data.paymentSessionId,
+                  invoiceId: event.data.invoiceId ?? null,
+                  amountCents: event.data.amountCents,
+                  currency: event.data.currency,
+                  provider: event.data.provider,
+                } satisfies BookingFullyPaidEvent,
+                { category: "domain", source: "subscriber" },
+              )
+            } catch (error) {
+              const message = error instanceof Error ? error.message : String(error)
+              console.error(
+                `[notifications] booking.fully-paid dispatch failed for booking ${event.data.bookingId}: ${message}`,
               )
             }
           },

--- a/packages/notifications/src/service-booking-document-lifecycle.ts
+++ b/packages/notifications/src/service-booking-document-lifecycle.ts
@@ -1,0 +1,475 @@
+import { bookings } from "@voyantjs/bookings/schema"
+import type { EventBus } from "@voyantjs/core"
+import { eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import {
+  type BookingDocumentAttachmentResolver,
+  bookingDocumentNotificationsService,
+} from "./service-booking-documents.js"
+import type {
+  BookingDocumentBundleItem,
+  NotificationService,
+  SendBookingDocumentsNotificationInput,
+} from "./service-shared.js"
+import {
+  listBookingNotificationItems,
+  listBookingNotificationParticipants,
+  resolveReminderRecipient,
+} from "./service-shared.js"
+
+export const BOOKING_FULLY_PAID_EVENT = "booking.fully-paid" as const
+
+export type BookingDocumentBundleLifecycleTrigger =
+  | "booking.confirmed"
+  | typeof BOOKING_FULLY_PAID_EVENT
+
+export type BookingDocumentBundleLifecycleDocumentType = BookingDocumentBundleItem["documentType"]
+
+export interface BookingDocumentBundleLifecycleEvent {
+  bookingId: string
+  bookingNumber?: string | null
+  actorId?: string | null
+  [key: string]: unknown
+}
+
+export interface BookingFullyPaidEvent extends BookingDocumentBundleLifecycleEvent {
+  paymentSessionId?: string | null
+  invoiceId?: string | null
+  amountCents?: number | null
+  currency?: string | null
+  provider?: string | null
+}
+
+type BookingNotificationParticipant = Awaited<
+  ReturnType<typeof listBookingNotificationParticipants>
+>[number]
+type BookingNotificationItem = Awaited<ReturnType<typeof listBookingNotificationItems>>[number]
+
+export interface BookingDocumentBundleLifecycleContext {
+  trigger: BookingDocumentBundleLifecycleTrigger
+  event: BookingDocumentBundleLifecycleEvent
+  booking: typeof bookings.$inferSelect
+  customer: ReturnType<typeof resolveReminderRecipient>
+  travelers: BookingNotificationParticipant[]
+  items: BookingNotificationItem[]
+  existingDocuments: BookingDocumentBundleItem[]
+}
+
+export interface BookingDocumentBundleLifecycleStep {
+  source: "legal" | "finance" | "products" | "notification" | "policy"
+  documentType?: BookingDocumentBundleLifecycleDocumentType
+  status: "existing" | "created" | "skipped" | "sent" | "failed"
+  reason?: string
+}
+
+export type BookingDocumentBundleLifecyclePolicyResult =
+  | {
+      status: "ok"
+      bookingId: string
+      documents: BookingDocumentBundleItem[]
+      steps: BookingDocumentBundleLifecycleStep[]
+    }
+  | {
+      status: "failed"
+      bookingId: string
+      steps: BookingDocumentBundleLifecycleStep[]
+      error: string
+    }
+
+export type BookingDocumentBundleLifecycleResult =
+  | BookingDocumentBundleLifecyclePolicyResult
+  | { status: "not_found"; bookingId: string }
+
+export interface BookingDocumentBundleLifecyclePolicyHelpers {
+  refreshDocuments(): Promise<BookingDocumentBundleItem[]>
+  ensureLegalDocuments?: BookingDocumentBundleLifecycleEnsureDocuments
+  ensureFinanceDocuments?: BookingDocumentBundleLifecycleEnsureDocuments
+  resolveBrochureDocuments?: BookingDocumentBundleLifecycleResolveBrochures
+}
+
+export type BookingDocumentBundleLifecyclePolicy = (
+  context: BookingDocumentBundleLifecycleContext,
+  helpers: BookingDocumentBundleLifecyclePolicyHelpers,
+) =>
+  | Promise<BookingDocumentBundleLifecyclePolicyResult>
+  | BookingDocumentBundleLifecyclePolicyResult
+
+export type BookingDocumentBundleLifecycleEnsureDocuments = (
+  context: BookingDocumentBundleLifecycleContext,
+  request: {
+    trigger: BookingDocumentBundleLifecycleTrigger
+    documentTypes: BookingDocumentBundleLifecycleDocumentType[]
+  },
+) =>
+  | Promise<undefined | BookingDocumentBundleLifecycleStep[]>
+  | undefined
+  | BookingDocumentBundleLifecycleStep[]
+
+export type BookingDocumentBundleLifecycleResolveBrochures = (
+  context: BookingDocumentBundleLifecycleContext,
+) => Promise<BookingDocumentBundleItem[]> | BookingDocumentBundleItem[]
+
+export type BookingDocumentBundleNotificationPolicy = (
+  context: BookingDocumentBundleLifecycleContext,
+  result: Extract<BookingDocumentBundleLifecyclePolicyResult, { status: "ok" }>,
+) =>
+  | Promise<SendBookingDocumentsNotificationInput | false | null | undefined>
+  | SendBookingDocumentsNotificationInput
+  | false
+  | null
+  | undefined
+
+export interface BookingDocumentBundleLifecycleStageOptions {
+  documentTypes?: BookingDocumentBundleLifecycleDocumentType[]
+  notification?: SendBookingDocumentsNotificationInput | false
+}
+
+export interface BookingDocumentBundleLifecycleOptions {
+  enabled?: boolean
+  confirmation?: BookingDocumentBundleLifecycleStageOptions
+  fullyPaid?: BookingDocumentBundleLifecycleStageOptions
+  policy?: BookingDocumentBundleLifecyclePolicy
+  notificationPolicy?: BookingDocumentBundleNotificationPolicy
+  ensureLegalDocuments?: BookingDocumentBundleLifecycleEnsureDocuments
+  ensureFinanceDocuments?: BookingDocumentBundleLifecycleEnsureDocuments
+  resolveBrochureDocuments?: BookingDocumentBundleLifecycleResolveBrochures
+}
+
+export interface RunBookingDocumentBundleLifecycleInput {
+  trigger: BookingDocumentBundleLifecycleTrigger
+  event: BookingDocumentBundleLifecycleEvent
+}
+
+export interface BookingDocumentBundleLifecycleRuntime {
+  eventBus?: EventBus
+  attachmentResolver?: BookingDocumentAttachmentResolver
+  resolveContext?: (
+    db: PostgresJsDatabase,
+    input: RunBookingDocumentBundleLifecycleInput,
+  ) => Promise<BookingDocumentBundleLifecycleContext | null>
+}
+
+function stageOptionsForTrigger(
+  options: BookingDocumentBundleLifecycleOptions,
+  trigger: BookingDocumentBundleLifecycleTrigger,
+) {
+  return trigger === BOOKING_FULLY_PAID_EVENT ? options.fullyPaid : options.confirmation
+}
+
+function defaultDocumentTypesForTrigger(
+  trigger: BookingDocumentBundleLifecycleTrigger,
+): BookingDocumentBundleLifecycleDocumentType[] {
+  return trigger === BOOKING_FULLY_PAID_EVENT ? ["contract", "invoice"] : ["contract", "proforma"]
+}
+
+function getRequestedDocumentTypes(
+  options: BookingDocumentBundleLifecycleOptions,
+  trigger: BookingDocumentBundleLifecycleTrigger,
+) {
+  return (
+    stageOptionsForTrigger(options, trigger)?.documentTypes ??
+    defaultDocumentTypesForTrigger(trigger)
+  )
+}
+
+function hasDocument(
+  documents: ReadonlyArray<BookingDocumentBundleItem>,
+  documentType: BookingDocumentBundleLifecycleDocumentType,
+) {
+  return documents.some((document) => document.documentType === documentType)
+}
+
+function isFinanceDocumentType(
+  documentType: BookingDocumentBundleLifecycleDocumentType,
+): documentType is "invoice" | "proforma" {
+  return documentType === "invoice" || documentType === "proforma"
+}
+
+function messageFromError(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function generatorStep(
+  source: "legal" | "finance",
+  documentType: BookingDocumentBundleLifecycleDocumentType,
+  status: BookingDocumentBundleLifecycleStep["status"],
+  reason?: string,
+): BookingDocumentBundleLifecycleStep {
+  return {
+    source,
+    documentType,
+    status,
+    ...(reason ? { reason } : {}),
+  }
+}
+
+export async function resolveBookingDocumentBundleLifecycleContext(
+  db: PostgresJsDatabase,
+  input: RunBookingDocumentBundleLifecycleInput,
+): Promise<BookingDocumentBundleLifecycleContext | null> {
+  const [booking] = await db
+    .select()
+    .from(bookings)
+    .where(eq(bookings.id, input.event.bookingId))
+    .limit(1)
+
+  if (!booking) {
+    return null
+  }
+
+  const [bundle, travelers, items] = await Promise.all([
+    bookingDocumentNotificationsService.listBookingDocumentBundle(db, booking.id),
+    listBookingNotificationParticipants(db, booking.id),
+    listBookingNotificationItems(db, booking.id),
+  ])
+
+  return {
+    trigger: input.trigger,
+    event: input.event,
+    booking,
+    customer: resolveReminderRecipient(booking, travelers),
+    travelers,
+    items,
+    existingDocuments: bundle?.documents ?? [],
+  }
+}
+
+export function createDefaultBookingDocumentBundlePolicy(
+  options: BookingDocumentBundleLifecycleOptions,
+): BookingDocumentBundleLifecyclePolicy {
+  return async (context, helpers) => {
+    const requestedTypes = getRequestedDocumentTypes(options, context.trigger)
+    const steps: BookingDocumentBundleLifecycleStep[] = []
+    let documents = context.existingDocuments
+
+    const missingTypes = requestedTypes.filter(
+      (documentType) => !hasDocument(documents, documentType),
+    )
+    const needsContract = missingTypes.includes("contract")
+    const financeTypes = missingTypes.filter(isFinanceDocumentType)
+
+    if (needsContract) {
+      if (helpers.ensureLegalDocuments) {
+        try {
+          steps.push(
+            ...((await helpers.ensureLegalDocuments(context, {
+              trigger: context.trigger,
+              documentTypes: ["contract"],
+            })) ?? [generatorStep("legal", "contract", "created")]),
+          )
+          documents = await helpers.refreshDocuments()
+        } catch (error) {
+          return {
+            status: "failed",
+            bookingId: context.booking.id,
+            steps: [
+              ...steps,
+              generatorStep("legal", "contract", "failed", messageFromError(error)),
+            ],
+            error: messageFromError(error),
+          }
+        }
+      } else {
+        steps.push(generatorStep("legal", "contract", "skipped", "no_generator"))
+      }
+    } else if (requestedTypes.includes("contract")) {
+      steps.push(generatorStep("legal", "contract", "existing"))
+    }
+
+    for (const documentType of financeTypes) {
+      if (!helpers.ensureFinanceDocuments) {
+        steps.push(generatorStep("finance", documentType, "skipped", "no_generator"))
+        continue
+      }
+
+      try {
+        steps.push(
+          ...((await helpers.ensureFinanceDocuments(context, {
+            trigger: context.trigger,
+            documentTypes: [documentType],
+          })) ?? [generatorStep("finance", documentType, "created")]),
+        )
+        documents = await helpers.refreshDocuments()
+      } catch (error) {
+        return {
+          status: "failed",
+          bookingId: context.booking.id,
+          steps: [
+            ...steps,
+            generatorStep("finance", documentType, "failed", messageFromError(error)),
+          ],
+          error: messageFromError(error),
+        }
+      }
+    }
+
+    for (const documentType of requestedTypes) {
+      if (isFinanceDocumentType(documentType) && !financeTypes.includes(documentType)) {
+        steps.push(generatorStep("finance", documentType, "existing"))
+      }
+    }
+
+    if (requestedTypes.includes("brochure")) {
+      if (helpers.resolveBrochureDocuments) {
+        try {
+          const brochures = await helpers.resolveBrochureDocuments(context)
+          documents = [...documents, ...brochures]
+          steps.push({
+            source: "products",
+            documentType: "brochure",
+            status: brochures.length > 0 ? "existing" : "skipped",
+            ...(brochures.length === 0 ? { reason: "not_available" } : {}),
+          })
+        } catch (error) {
+          return {
+            status: "failed",
+            bookingId: context.booking.id,
+            steps: [
+              ...steps,
+              {
+                source: "products",
+                documentType: "brochure",
+                status: "failed",
+                reason: messageFromError(error),
+              },
+            ],
+            error: messageFromError(error),
+          }
+        }
+      } else {
+        steps.push({
+          source: "products",
+          documentType: "brochure",
+          status: "skipped",
+          reason: "no_resolver",
+        })
+      }
+    }
+
+    return {
+      status: "ok",
+      bookingId: context.booking.id,
+      documents,
+      steps,
+    }
+  }
+}
+
+function defaultNotificationInput(
+  options: BookingDocumentBundleLifecycleOptions,
+  context: BookingDocumentBundleLifecycleContext,
+): SendBookingDocumentsNotificationInput | false | undefined {
+  const stage = stageOptionsForTrigger(options, context.trigger)
+  if (stage?.notification === false) return false
+  return {
+    ...(stage?.notification ?? {}),
+    documentTypes:
+      stage?.notification && "documentTypes" in stage.notification
+        ? stage.notification.documentTypes
+        : getRequestedDocumentTypes(options, context.trigger),
+  }
+}
+
+export const bookingDocumentBundleLifecycleService = {
+  async run(
+    db: PostgresJsDatabase,
+    dispatcher: NotificationService,
+    input: RunBookingDocumentBundleLifecycleInput,
+    options: BookingDocumentBundleLifecycleOptions = {},
+    runtime: BookingDocumentBundleLifecycleRuntime = {},
+  ): Promise<BookingDocumentBundleLifecycleResult> {
+    const resolveContext = runtime.resolveContext ?? resolveBookingDocumentBundleLifecycleContext
+    const context = await resolveContext(db, input)
+    if (!context) {
+      return { status: "not_found", bookingId: input.event.bookingId }
+    }
+
+    const helpers: BookingDocumentBundleLifecyclePolicyHelpers = {
+      refreshDocuments: async () => {
+        const bundle = await bookingDocumentNotificationsService.listBookingDocumentBundle(
+          db,
+          context.booking.id,
+        )
+        return bundle?.documents ?? []
+      },
+      ensureLegalDocuments: options.ensureLegalDocuments,
+      ensureFinanceDocuments: options.ensureFinanceDocuments,
+      resolveBrochureDocuments: options.resolveBrochureDocuments,
+    }
+
+    let policyResult: BookingDocumentBundleLifecyclePolicyResult
+    try {
+      const policy = options.policy ?? createDefaultBookingDocumentBundlePolicy(options)
+      policyResult = await policy(context, helpers)
+    } catch (error) {
+      policyResult = {
+        status: "failed",
+        bookingId: context.booking.id,
+        steps: [{ source: "policy", status: "failed", reason: messageFromError(error) }],
+        error: messageFromError(error),
+      }
+    }
+
+    if (policyResult.status !== "ok") {
+      return policyResult
+    }
+
+    let notificationInput: SendBookingDocumentsNotificationInput | false | null | undefined
+    try {
+      notificationInput =
+        options.notificationPolicy !== undefined
+          ? await options.notificationPolicy(context, policyResult)
+          : defaultNotificationInput(options, context)
+    } catch (error) {
+      return {
+        status: "failed",
+        bookingId: context.booking.id,
+        steps: [
+          ...policyResult.steps,
+          { source: "notification", status: "failed", reason: messageFromError(error) },
+        ],
+        error: messageFromError(error),
+      }
+    }
+
+    if (notificationInput === false || notificationInput == null) {
+      return policyResult
+    }
+
+    let notification: Awaited<
+      ReturnType<typeof bookingDocumentNotificationsService.sendBookingDocumentsNotification>
+    >
+    try {
+      notification = await bookingDocumentNotificationsService.sendBookingDocumentsNotification(
+        db,
+        dispatcher,
+        context.booking.id,
+        notificationInput,
+        { attachmentResolver: runtime.attachmentResolver, eventBus: runtime.eventBus },
+      )
+    } catch (error) {
+      return {
+        status: "failed",
+        bookingId: context.booking.id,
+        steps: [
+          ...policyResult.steps,
+          { source: "notification", status: "failed", reason: messageFromError(error) },
+        ],
+        error: messageFromError(error),
+      }
+    }
+
+    return {
+      ...policyResult,
+      steps: [
+        ...policyResult.steps,
+        {
+          source: "notification",
+          status: notification.status === "sent" ? "sent" : "skipped",
+          reason: notification.status === "sent" ? undefined : notification.status,
+        },
+      ],
+    }
+  },
+}

--- a/packages/notifications/src/validation.ts
+++ b/packages/notifications/src/validation.ts
@@ -47,8 +47,13 @@ export const notificationReminderStageCadenceIntervalSchema = z.object({
   whenDaysUntilDueLT: z.coerce.number().int().optional().nullable(),
   repeatEveryDays: z.coerce.number().int().min(1).max(365),
 })
-export const notificationDocumentTypeSchema = z.enum(["contract", "invoice", "proforma"])
-export const notificationDocumentSourceSchema = z.enum(["legal", "finance"])
+export const notificationDocumentTypeSchema = z.enum([
+  "contract",
+  "invoice",
+  "proforma",
+  "brochure",
+])
+export const notificationDocumentSourceSchema = z.enum(["legal", "finance", "products"])
 export const notificationAttachmentSchema = z
   .object({
     filename: z.string().min(1).max(500),

--- a/packages/notifications/tests/unit/booking-document-lifecycle.test.ts
+++ b/packages/notifications/tests/unit/booking-document-lifecycle.test.ts
@@ -1,0 +1,370 @@
+import type { bookings } from "@voyantjs/bookings/schema"
+import { createContainer, createEventBus } from "@voyantjs/core"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { describe, expect, it, vi } from "vitest"
+
+import { createNotificationsHonoModule } from "../../src/index.js"
+import {
+  BOOKING_FULLY_PAID_EVENT,
+  type BookingDocumentBundleLifecycleContext,
+  bookingDocumentBundleLifecycleService,
+  createDefaultBookingDocumentBundlePolicy,
+} from "../../src/service-booking-document-lifecycle.js"
+import { bookingDocumentNotificationsService } from "../../src/service-booking-documents.js"
+import type { BookingDocumentBundleItem } from "../../src/service-shared.js"
+
+const booking = {
+  id: "book_123",
+  bookingNumber: "BK-123",
+  status: "confirmed",
+  contactFirstName: "Ana",
+  contactLastName: "Popescu",
+  contactEmail: "ana@example.com",
+  contactPhone: null,
+  contactPreferredLanguage: "ro",
+  sellCurrency: "EUR",
+  sellAmountCents: 120000,
+  startDate: null,
+  endDate: null,
+  personId: "per_123",
+  organizationId: "org_123",
+} as typeof bookings.$inferSelect
+
+const contractDocument: BookingDocumentBundleItem = {
+  key: "legal:ctat_123",
+  source: "legal",
+  documentType: "contract",
+  bookingId: "book_123",
+  contractId: "ctr_123",
+  invoiceId: null,
+  attachmentId: "ctat_123",
+  renditionId: null,
+  contractStatus: "issued",
+  invoiceStatus: null,
+  name: "contract.pdf",
+  format: "pdf",
+  mimeType: "application/pdf",
+  storageKey: "contracts/book_123/contract.pdf",
+  downloadUrl: "https://files.example/contract.pdf",
+  language: "ro",
+  metadata: null,
+  createdAt: "2026-05-14T10:00:00.000Z",
+}
+
+const invoiceDocument: BookingDocumentBundleItem = {
+  key: "finance:invr_123",
+  source: "finance",
+  documentType: "invoice",
+  bookingId: "book_123",
+  contractId: null,
+  invoiceId: "inv_123",
+  attachmentId: null,
+  renditionId: "invr_123",
+  contractStatus: null,
+  invoiceStatus: "sent",
+  name: "INV-BK-123.pdf",
+  format: "pdf",
+  mimeType: "application/pdf",
+  storageKey: "invoices/inv_123/rendition.pdf",
+  downloadUrl: "https://files.example/invoice.pdf",
+  language: "ro",
+  metadata: null,
+  createdAt: "2026-05-14T10:05:00.000Z",
+}
+
+function context(
+  overrides: Partial<BookingDocumentBundleLifecycleContext> = {},
+): BookingDocumentBundleLifecycleContext {
+  return {
+    trigger: "booking.confirmed",
+    event: { bookingId: booking.id, bookingNumber: booking.bookingNumber, actorId: "user_1" },
+    booking,
+    customer: {
+      email: "ana@example.com",
+      firstName: "Ana",
+      lastName: "Popescu",
+      participantType: "booking_contact",
+      isPrimary: true,
+    },
+    travelers: [
+      {
+        id: "trav_123",
+        firstName: "Ana",
+        lastName: "Popescu",
+        email: "ana@example.com",
+        participantType: "traveler",
+        isPrimary: true,
+      },
+    ],
+    items: [
+      {
+        id: "item_123",
+        title: "City tour",
+        description: "City tour",
+        quantity: 1,
+        itemType: "service",
+        serviceDate: null,
+        sellCurrency: "EUR",
+        unitSellAmountCents: 120000,
+        totalSellAmountCents: 120000,
+        currency: "EUR",
+        unitPrice: 1200,
+        total: 1200,
+      },
+    ],
+    existingDocuments: [],
+    ...overrides,
+  }
+}
+
+describe("bookingDocumentBundleLifecycleService", () => {
+  it("passes resolved booking and customer context to the configured post-confirmation policy", async () => {
+    const policy = vi.fn(async (resolved: BookingDocumentBundleLifecycleContext) => ({
+      status: "ok" as const,
+      bookingId: resolved.booking.id,
+      documents: [],
+      steps: [{ source: "policy" as const, status: "skipped" as const, reason: "test" }],
+    }))
+
+    const result = await bookingDocumentBundleLifecycleService.run(
+      {} as PostgresJsDatabase,
+      { send: vi.fn(), sendWith: vi.fn(), getProvider: vi.fn() },
+      {
+        trigger: "booking.confirmed",
+        event: { bookingId: booking.id, bookingNumber: booking.bookingNumber, actorId: "user_1" },
+      },
+      { policy, notificationPolicy: () => false },
+      { resolveContext: async () => context() },
+    )
+
+    expect(result.status).toBe("ok")
+    expect(policy).toHaveBeenCalledOnce()
+    expect(policy.mock.calls[0]?.[0]).toMatchObject({
+      trigger: "booking.confirmed",
+      booking: {
+        id: "book_123",
+        bookingNumber: "BK-123",
+        personId: "per_123",
+        organizationId: "org_123",
+      },
+      customer: {
+        email: "ana@example.com",
+        participantType: "booking_contact",
+      },
+      travelers: [
+        expect.objectContaining({
+          email: "ana@example.com",
+          isPrimary: true,
+        }),
+      ],
+    })
+  })
+
+  it("surfaces configured document policy failures instead of silently losing them", async () => {
+    const result = await bookingDocumentBundleLifecycleService.run(
+      {} as PostgresJsDatabase,
+      { send: vi.fn(), sendWith: vi.fn(), getProvider: vi.fn() },
+      {
+        trigger: "booking.confirmed",
+        event: { bookingId: booking.id, bookingNumber: booking.bookingNumber },
+      },
+      {
+        policy: () => {
+          throw new Error("contract generator unavailable")
+        },
+        notificationPolicy: () => false,
+      },
+      { resolveContext: async () => context() },
+    )
+
+    expect(result).toMatchObject({
+      status: "failed",
+      bookingId: "book_123",
+      error: "contract generator unavailable",
+      steps: [{ source: "policy", status: "failed", reason: "contract generator unavailable" }],
+    })
+  })
+
+  it("uses host notification policy output when sending the composed bundle", async () => {
+    const sendSpy = vi
+      .spyOn(bookingDocumentNotificationsService, "sendBookingDocumentsNotification")
+      .mockResolvedValue({
+        status: "sent",
+        bookingId: booking.id,
+        recipient: "ana@example.com",
+        documents: [contractDocument],
+        delivery: {
+          id: "delivery_123",
+          provider: "local",
+        },
+      })
+    const notificationPolicy = vi.fn(() => ({
+      templateSlug: "booking-confirmation",
+      documentTypes: ["contract" as const],
+    }))
+
+    const result = await bookingDocumentBundleLifecycleService.run(
+      {} as PostgresJsDatabase,
+      { send: vi.fn(), sendWith: vi.fn(), getProvider: vi.fn() },
+      {
+        trigger: "booking.confirmed",
+        event: { bookingId: booking.id, bookingNumber: booking.bookingNumber },
+      },
+      {
+        policy: (resolved) => ({
+          status: "ok",
+          bookingId: resolved.booking.id,
+          documents: [contractDocument],
+          steps: [{ source: "legal", documentType: "contract", status: "existing" }],
+        }),
+        notificationPolicy,
+      },
+      { resolveContext: async () => context({ existingDocuments: [contractDocument] }) },
+    )
+
+    expect(result.status).toBe("ok")
+    if (result.status !== "ok") return
+
+    expect(notificationPolicy).toHaveBeenCalledOnce()
+    expect(sendSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      booking.id,
+      { templateSlug: "booking-confirmation", documentTypes: ["contract"] },
+      { attachmentResolver: undefined, eventBus: undefined },
+    )
+    expect(result.steps.at(-1)).toEqual({ source: "notification", status: "sent" })
+
+    sendSpy.mockRestore()
+  })
+
+  it("surfaces notification policy failures as lifecycle failures", async () => {
+    const result = await bookingDocumentBundleLifecycleService.run(
+      {} as PostgresJsDatabase,
+      { send: vi.fn(), sendWith: vi.fn(), getProvider: vi.fn() },
+      {
+        trigger: "booking.confirmed",
+        event: { bookingId: booking.id, bookingNumber: booking.bookingNumber },
+      },
+      {
+        policy: (resolved) => ({
+          status: "ok",
+          bookingId: resolved.booking.id,
+          documents: [contractDocument],
+          steps: [{ source: "legal", documentType: "contract", status: "existing" }],
+        }),
+        notificationPolicy: () => {
+          throw new Error("notification template missing")
+        },
+      },
+      { resolveContext: async () => context({ existingDocuments: [contractDocument] }) },
+    )
+
+    expect(result).toMatchObject({
+      status: "failed",
+      bookingId: booking.id,
+      error: "notification template missing",
+      steps: [
+        { source: "legal", documentType: "contract", status: "existing" },
+        { source: "notification", status: "failed", reason: "notification template missing" },
+      ],
+    })
+  })
+})
+
+describe("createNotificationsHonoModule documentBundleLifecycle", () => {
+  it("wires confirmation and fully-paid events to the lifecycle service", async () => {
+    const runSpy = vi.spyOn(bookingDocumentBundleLifecycleService, "run").mockResolvedValue({
+      status: "ok",
+      bookingId: booking.id,
+      documents: [],
+      steps: [{ source: "policy", status: "skipped", reason: "test" }],
+    })
+    const eventBus = createEventBus()
+    const subscribeSpy = vi.spyOn(eventBus, "subscribe")
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+
+    const module = createNotificationsHonoModule({
+      resolveDb: () => ({}) as PostgresJsDatabase,
+      documentBundleLifecycle: {
+        enabled: true,
+        notificationPolicy: () => false,
+      },
+    })
+
+    await module.module.bootstrap?.({
+      bindings: {},
+      container: createContainer(),
+      eventBus,
+    })
+
+    expect(subscribeSpy.mock.calls.map((call) => call[0])).toContain("booking.confirmed")
+    expect(subscribeSpy.mock.calls.map((call) => call[0])).toContain(BOOKING_FULLY_PAID_EVENT)
+
+    await eventBus.emit("booking.confirmed", {
+      bookingId: booking.id,
+      bookingNumber: booking.bookingNumber,
+      actorId: "user_1",
+    })
+    await eventBus.emit(BOOKING_FULLY_PAID_EVENT, {
+      bookingId: booking.id,
+      paymentSessionId: "ps_123",
+      invoiceId: "inv_123",
+    })
+
+    expect(runSpy).toHaveBeenCalledTimes(2)
+    expect(runSpy.mock.calls[0]?.[2]).toEqual({
+      trigger: "booking.confirmed",
+      event: { bookingId: booking.id, bookingNumber: booking.bookingNumber, actorId: "user_1" },
+    })
+    expect(runSpy.mock.calls[1]?.[2]).toEqual({
+      trigger: BOOKING_FULLY_PAID_EVENT,
+      event: { bookingId: booking.id, paymentSessionId: "ps_123", invoiceId: "inv_123" },
+    })
+
+    runSpy.mockRestore()
+    errorSpy.mockRestore()
+  })
+})
+
+describe("createDefaultBookingDocumentBundlePolicy", () => {
+  it("runs the fully-paid hook independently without duplicating confirmation artifacts", async () => {
+    let documents = [contractDocument]
+    const ensureLegalDocuments = vi.fn()
+    const ensureFinanceDocuments = vi.fn(async () => {
+      documents = [contractDocument, invoiceDocument]
+    })
+
+    const policy = createDefaultBookingDocumentBundlePolicy({})
+    const result = await policy(
+      context({
+        trigger: BOOKING_FULLY_PAID_EVENT,
+        event: { bookingId: booking.id, paymentSessionId: "ps_123" },
+        existingDocuments: documents,
+      }),
+      {
+        refreshDocuments: async () => documents,
+        ensureLegalDocuments,
+        ensureFinanceDocuments,
+      },
+    )
+
+    expect(result.status).toBe("ok")
+    if (result.status !== "ok") return
+
+    expect(ensureLegalDocuments).not.toHaveBeenCalled()
+    expect(ensureFinanceDocuments).toHaveBeenCalledOnce()
+    expect(ensureFinanceDocuments.mock.calls[0]?.[1]).toEqual({
+      trigger: BOOKING_FULLY_PAID_EVENT,
+      documentTypes: ["invoice"],
+    })
+    expect(result.documents.map((document) => document.key)).toEqual([
+      "legal:ctat_123",
+      "finance:invr_123",
+    ])
+    expect(result.steps).toEqual([
+      { source: "legal", documentType: "contract", status: "existing" },
+      { source: "finance", documentType: "invoice", status: "created" },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

- Add a first-class booking document-bundle lifecycle service for `booking.confirmed` and `booking.fully-paid` transitions.
- Wire `createNotificationsHonoModule({ documentBundleLifecycle })` to run the lifecycle policy, derive `booking.fully-paid` from paid booking payment events, and keep host notification policy overridable.
- Add default idempotent legal/finance/brochure bundle composition, public exports, README docs, validation support for brochure/product documents, tests, and a changeset.

## Verification

- `pnpm --filter @voyantjs/notifications typecheck`
- `pnpm --filter @voyantjs/notifications lint`
- `pnpm --filter @voyantjs/notifications test`
- `pnpm --filter @voyantjs/notifications build`
- `pnpm --filter @voyantjs/notifications exec vitest run tests/unit/booking-document-lifecycle.test.ts tests/unit/auto-dispatch.test.ts`
- `pnpm --filter @voyantjs/bookings exec vitest run tests/unit/status-dispatch.test.ts`
- `pnpm --filter @voyantjs/legal exec vitest run tests/unit/module.test.ts`
- `pnpm --filter @voyantjs/finance exec vitest run tests/unit/service-issue.test.ts`
- `node scripts/lint-changed.mjs`
- `node scripts/check-agent-code-quality.mjs --changed --report-only`
- `pnpm verify:ui-components-barrel && pnpm verify:native-date-inputs && pnpm verify:raw-minor-unit-labels && pnpm verify:architecture`

## Notes

- `pnpm verify:fast` was attempted. Changed-file lint and static checks passed, but the affected typecheck phase exhausted Node heap in unrelated UI/template packages (`external-refs-ui`, `identity-ui`, `operator`, `bookings-ui`, `products-ui`, `dmc`, `finance-ui`) before the lane could complete.
- Agent quality reports two pre-existing size warnings on touched large files: `packages/notifications/src/index.ts` and `packages/notifications/src/validation.ts`.

Closes #867