### PR TITLE
Storefront booking session bootstrap contract

### DIFF
--- a/.changeset/storefront-booking-session-bootstrap.md
+++ b/.changeset/storefront-booking-session-bootstrap.md
@@ -1,0 +1,10 @@
+---
+"@voyantjs/storefront": minor
+---
+
+Add a public storefront booking-session bootstrap contract at
+`POST /v1/public/bookings/sessions/bootstrap`. The route validates the selected
+departure/slot and original quote, creates the public booking session, applies a
+finance payment schedule, and returns customer-safe session, repricing,
+availability, allocation, payment plan, due schedule, and checkout capability
+state in one response.

--- a/docs/architecture/custom-storefront-sdk.md
+++ b/docs/architecture/custom-storefront-sdk.md
@@ -101,6 +101,7 @@ The public route family behind the facade remains:
 
 | Flow step | SDK method | Public route |
 | --- | --- | --- |
+| Reserve + bootstrap checkout state | `bookingEngine.bootstrapSession` | `POST /v1/public/bookings/sessions/bootstrap` |
 | Reserve capacity | `bookingEngine.reserve` | `POST /v1/public/bookings/sessions` |
 | Resume session | `bookingEngine.getSnapshot` | `GET /v1/public/bookings/sessions/:sessionId` |
 | Update travelers/session data | `bookingEngine.updateTravelers`, `bookingEngine.updateSession` | `PATCH /v1/public/bookings/sessions/:sessionId` |
@@ -111,6 +112,25 @@ The public route family behind the facade remains:
 | Finalize booking | `bookingEngine.confirm` | `POST /v1/public/bookings/sessions/:sessionId/confirm` |
 | Expire abandoned hold | `bookingEngine.expire` | `POST /v1/public/bookings/sessions/:sessionId/expire` |
 | Success summary | `bookingEngine.getOverview` | `GET /v1/public/bookings/overview` |
+
+`POST /v1/public/bookings/sessions/bootstrap` is the composite storefront
+bootstrap contract for custom checkout UIs that need one round-trip after a
+customer selects a departure. The request carries:
+
+- `departureId` and `slotId`, both resolved against the public availability
+  slot used for the reservation
+- `quote`, the storefront's original customer-visible total and currency
+- `session`, the same public booking-session creation payload accepted by
+  `POST /v1/public/bookings/sessions`
+- optional `catalogId` when the storefront is quoting against a specific public
+  price catalog
+
+The response returns a customer-safe object with `session` including
+`session.checkoutCapability`, `paymentPlan`, persisted `paymentSchedule`,
+`repricing` with the original quote, current total, delta, and stale flag, the
+post-reservation `availability` snapshot, selected `allocation`, and `currency`.
+The route rejects stale or expired quotes before creating the session, and it
+does not expose admin notes, provider internals, or mutable payment config.
 
 ## Errors
 

--- a/packages/storefront/package.json
+++ b/packages/storefront/package.json
@@ -21,9 +21,11 @@
   },
   "dependencies": {
     "@voyantjs/availability": "workspace:*",
+    "@voyantjs/bookings": "workspace:*",
     "@voyantjs/core": "workspace:*",
     "@voyantjs/crm": "workspace:*",
     "@voyantjs/extras": "workspace:*",
+    "@voyantjs/finance": "workspace:*",
     "@voyantjs/hono": "workspace:*",
     "@voyantjs/pricing": "workspace:*",
     "@voyantjs/products": "workspace:*",

--- a/packages/storefront/src/index.ts
+++ b/packages/storefront/src/index.ts
@@ -18,6 +18,7 @@ export {
   mergeStorefrontSettingsPatch,
   resolveStorefrontSettings,
 } from "./service.js"
+export type { StorefrontBookingSessionBootstrapOptions } from "./service-booking-session-bootstrap.js"
 export type {
   StorefrontIntakeGuard,
   StorefrontIntakeGuardDecision,
@@ -30,6 +31,8 @@ export type {
   StorefrontAppliedOffer,
   StorefrontBankTransfer,
   StorefrontBankTransferInput,
+  StorefrontBookingSessionBootstrap,
+  StorefrontBookingSessionBootstrapInput,
   StorefrontCurrencyDisplay,
   StorefrontDepartureListQuery,
   StorefrontFormField,
@@ -60,6 +63,12 @@ export {
   storefrontAppliedOfferSchema,
   storefrontBankTransferInputSchema,
   storefrontBankTransferSchema,
+  storefrontBookingSessionAvailabilitySnapshotSchema,
+  storefrontBookingSessionBootstrapInputSchema,
+  storefrontBookingSessionBootstrapSchema,
+  storefrontBookingSessionPaymentPlanSchema,
+  storefrontBookingSessionQuoteSchema,
+  storefrontBookingSessionRepricingSnapshotSchema,
   storefrontCurrencyDisplaySchema,
   storefrontDepartureItinerarySchema,
   storefrontDepartureListQuerySchema,

--- a/packages/storefront/src/routes-public.ts
+++ b/packages/storefront/src/routes-public.ts
@@ -3,8 +3,13 @@ import {
   checkoutCapabilityCookie,
   issueCheckoutCapability,
 } from "@voyantjs/bookings/checkout-capability"
-import type { EventBus } from "@voyantjs/core"
-import { parseJsonBody, parseQuery } from "@voyantjs/hono"
+import {
+  idempotencyKey,
+  parseJsonBody,
+  parseQuery,
+  type VoyantBindings,
+  type VoyantVariables,
+} from "@voyantjs/hono"
 import type { Context } from "hono"
 import { Hono } from "hono"
 
@@ -30,11 +35,10 @@ import {
 import { storefrontTransportEligibilityInputSchema } from "./validation-transport-eligibility.js"
 
 type Env = {
+  Bindings: VoyantBindings
   Variables: {
-    db: unknown
-    eventBus?: EventBus
     userId?: string
-  }
+  } & VoyantVariables
 }
 
 function getRuntimeEnv(c: Context) {
@@ -181,57 +185,61 @@ export function createStorefrontPublicRoutes(options?: StorefrontServiceOptions)
         ? c.json({ data: preview })
         : c.json({ error: "Storefront departure not found" }, 404)
     })
-    .post("/bookings/sessions/bootstrap", async (c) => {
-      const result = await storefrontService.bootstrapBookingSession(
-        getRequestContext(c) as StorefrontRequestContext & {
-          db: NonNullable<StorefrontRequestContext["db"]>
-        },
-        await parseJsonBody(c, storefrontBookingSessionBootstrapInputSchema),
-        c.get("userId" as never),
-      )
+    .post(
+      "/bookings/sessions/bootstrap",
+      idempotencyKey({ scope: "POST /v1/public/bookings/sessions/bootstrap" }),
+      async (c) => {
+        const result = await storefrontService.bootstrapBookingSession(
+          getRequestContext(c) as StorefrontRequestContext & {
+            db: NonNullable<StorefrontRequestContext["db"]>
+          },
+          await parseJsonBody(c, storefrontBookingSessionBootstrapInputSchema),
+          c.get("userId" as never),
+        )
 
-      if (result.status === "departure_not_found") {
-        return c.json({ error: "Storefront departure not found" }, 404)
-      }
+        if (result.status === "departure_not_found") {
+          return c.json({ error: "Storefront departure not found" }, 404)
+        }
 
-      if (result.status === "slot_not_found") {
-        return c.json({ error: "Availability slot not found" }, 404)
-      }
+        if (result.status === "slot_not_found") {
+          return c.json({ error: "Availability slot not found" }, 404)
+        }
 
-      if (result.status !== "ok") {
+        if (result.status !== "ok") {
+          return c.json(
+            {
+              error: sessionConflictError(result.status),
+              ...(result.status === "stale_quote" && "repricing" in result
+                ? { data: { repricing: result.repricing } }
+                : {}),
+            },
+            result.status === "invalid_slot" ? 400 : 409,
+          )
+        }
+        if (!("bootstrap" in result)) {
+          return c.json({ error: "Unable to bootstrap booking session" }, 409)
+        }
+
+        const { bootstrap } = result
+        const capability = await issueCheckoutCapability(
+          bootstrap.session.sessionId,
+          getRuntimeEnv(c),
+        )
+        c.header("Set-Cookie", checkoutCapabilityCookie(capability.token, capability.expiresAt), {
+          append: true,
+        })
+
         return c.json(
           {
-            error: sessionConflictError(result.status),
-            ...(result.status === "stale_quote" && "repricing" in result
-              ? { data: { repricing: result.repricing } }
-              : {}),
+            data: {
+              ...bootstrap,
+              session: attachCheckoutCapability(bootstrap.session, capability),
+            },
           },
-          result.status === "invalid_slot" ? 400 : 409,
+          201,
         )
-      }
-      if (!("bootstrap" in result)) {
-        return c.json({ error: "Unable to bootstrap booking session" }, 409)
-      }
-
-      const { bootstrap } = result
-      const capability = await issueCheckoutCapability(
-        bootstrap.session.sessionId,
-        getRuntimeEnv(c),
-      )
-      c.header("Set-Cookie", checkoutCapabilityCookie(capability.token, capability.expiresAt), {
-        append: true,
-      })
-
-      return c.json(
-        {
-          data: {
-            ...bootstrap,
-            session: attachCheckoutCapability(bootstrap.session, capability),
-          },
-        },
-        201,
-      )
-    })
+      },
+    )
     .post("/departures/:departureId/eligibility", async (c) => {
       return c.json({
         data: await storefrontService.checkDepartureTransportEligibility({

--- a/packages/storefront/src/routes-public.ts
+++ b/packages/storefront/src/routes-public.ts
@@ -1,3 +1,8 @@
+import {
+  checkoutCapabilityActions,
+  checkoutCapabilityCookie,
+  issueCheckoutCapability,
+} from "@voyantjs/bookings/checkout-capability"
 import type { EventBus } from "@voyantjs/core"
 import { parseJsonBody, parseQuery } from "@voyantjs/hono"
 import type { Context } from "hono"
@@ -11,6 +16,7 @@ import {
 import {
   type StorefrontLeadIntakeInput,
   type StorefrontNewsletterSubscribeInput,
+  storefrontBookingSessionBootstrapInputSchema,
   storefrontDepartureListQuerySchema,
   storefrontDeparturePricePreviewInputSchema,
   storefrontLeadIntakeInputSchema,
@@ -27,6 +33,52 @@ type Env = {
   Variables: {
     db: unknown
     eventBus?: EventBus
+    userId?: string
+  }
+}
+
+function getRuntimeEnv(c: Context) {
+  const processEnv =
+    (
+      globalThis as typeof globalThis & {
+        process?: { env?: Record<string, string | undefined> }
+      }
+    ).process?.env ?? {}
+
+  return {
+    ...processEnv,
+    ...(c.env ?? {}),
+  }
+}
+
+function sessionConflictError(status: string) {
+  switch (status) {
+    case "insufficient_capacity":
+      return "Insufficient slot capacity"
+    case "slot_unavailable":
+      return "Availability slot is not bookable"
+    case "pricing_unavailable":
+      return "Pricing is not available for the selected booking session items"
+    case "stale_quote":
+      return "Booking session quote is stale"
+    case "invalid_slot":
+      return "Booking session slot does not match the requested departure"
+    default:
+      return "Unable to bootstrap booking session"
+  }
+}
+
+function attachCheckoutCapability<T extends { sessionId: string }>(
+  session: T,
+  issued: Awaited<ReturnType<typeof issueCheckoutCapability>>,
+) {
+  return {
+    ...session,
+    checkoutCapability: {
+      token: issued.token,
+      expiresAt: issued.expiresAt.toISOString(),
+      actions: [...checkoutCapabilityActions],
+    },
   }
 }
 
@@ -128,6 +180,57 @@ export function createStorefrontPublicRoutes(options?: StorefrontServiceOptions)
       return preview
         ? c.json({ data: preview })
         : c.json({ error: "Storefront departure not found" }, 404)
+    })
+    .post("/bookings/sessions/bootstrap", async (c) => {
+      const result = await storefrontService.bootstrapBookingSession(
+        getRequestContext(c) as StorefrontRequestContext & {
+          db: NonNullable<StorefrontRequestContext["db"]>
+        },
+        await parseJsonBody(c, storefrontBookingSessionBootstrapInputSchema),
+        c.get("userId" as never),
+      )
+
+      if (result.status === "departure_not_found") {
+        return c.json({ error: "Storefront departure not found" }, 404)
+      }
+
+      if (result.status === "slot_not_found") {
+        return c.json({ error: "Availability slot not found" }, 404)
+      }
+
+      if (result.status !== "ok") {
+        return c.json(
+          {
+            error: sessionConflictError(result.status),
+            ...(result.status === "stale_quote" && "repricing" in result
+              ? { data: { repricing: result.repricing } }
+              : {}),
+          },
+          result.status === "invalid_slot" ? 400 : 409,
+        )
+      }
+      if (!("bootstrap" in result)) {
+        return c.json({ error: "Unable to bootstrap booking session" }, 409)
+      }
+
+      const { bootstrap } = result
+      const capability = await issueCheckoutCapability(
+        bootstrap.session.sessionId,
+        getRuntimeEnv(c),
+      )
+      c.header("Set-Cookie", checkoutCapabilityCookie(capability.token, capability.expiresAt), {
+        append: true,
+      })
+
+      return c.json(
+        {
+          data: {
+            ...bootstrap,
+            session: attachCheckoutCapability(bootstrap.session, capability),
+          },
+        },
+        201,
+      )
     })
     .post("/departures/:departureId/eligibility", async (c) => {
       return c.json({

--- a/packages/storefront/src/service-booking-session-bootstrap.ts
+++ b/packages/storefront/src/service-booking-session-bootstrap.ts
@@ -1,0 +1,437 @@
+import { availabilitySlots } from "@voyantjs/availability/schema"
+import { publicBookingsService, resolveSessionPricingSnapshot } from "@voyantjs/bookings"
+import {
+  computePaymentSchedule,
+  financeService,
+  noDepositPolicy,
+  type PaymentPolicy,
+} from "@voyantjs/finance"
+import { eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import type { StorefrontBookingSessionBootstrapInput } from "./validation.js"
+
+export interface StorefrontBootstrapRequestContext {
+  db: PostgresJsDatabase
+  env?: unknown
+  context?: unknown
+}
+
+export interface StorefrontBookingSessionBootstrapOptions {
+  paymentPolicy?: PaymentPolicy
+  resolvePaymentPolicy?: (
+    input: StorefrontBookingSessionBootstrapInput & StorefrontBootstrapRequestContext,
+  ) => Promise<PaymentPolicy | null | undefined> | PaymentPolicy | null | undefined
+  today?: Date
+}
+
+function normalizeDate(value: Date | string | null | undefined) {
+  if (!value) {
+    return null
+  }
+
+  return value instanceof Date ? value.toISOString().slice(0, 10) : value
+}
+
+function normalizeDateTime(value: Date | string | null | undefined) {
+  if (!value) {
+    return null
+  }
+
+  return value instanceof Date ? value.toISOString() : value
+}
+
+function isExpired(value: string | null | undefined, now: Date) {
+  if (!value) {
+    return false
+  }
+
+  const expiresAt = new Date(value)
+  return Number.isNaN(expiresAt.getTime()) || expiresAt.getTime() <= now.getTime()
+}
+
+function resolveTierAmount(
+  tiers: Array<{
+    minQuantity: number
+    maxQuantity: number | null
+    sellAmountCents: number | null
+  }>,
+  quantity: number,
+  fallbackAmount: number | null,
+) {
+  const tier = tiers.find(
+    (candidate) =>
+      quantity >= candidate.minQuantity &&
+      (candidate.maxQuantity === null || quantity <= candidate.maxQuantity),
+  )
+
+  return tier?.sellAmountCents ?? fallbackAmount
+}
+
+function computeLineTotal(
+  pricingMode: string,
+  unitSellAmountCents: number | null,
+  quantity: number,
+  fallbackAmount: number | null,
+) {
+  switch (pricingMode) {
+    case "free":
+    case "included":
+      return 0
+    case "on_request":
+      return null
+    case "per_unit":
+    case "per_person":
+      return unitSellAmountCents === null ? null : unitSellAmountCents * quantity
+    default:
+      return unitSellAmountCents ?? fallbackAmount
+  }
+}
+
+function serializePaymentPlan(policy: PaymentPolicy, requiresFullPayment: boolean) {
+  return {
+    source: "storefront_default" as const,
+    depositKind: policy.deposit.kind,
+    depositPercent: policy.deposit.kind === "percent" ? (policy.deposit.percent ?? 0) : null,
+    depositAmountCents:
+      policy.deposit.kind === "fixed_cents" ? (policy.deposit.amountCents ?? 0) : null,
+    requiresFullPayment,
+  }
+}
+
+async function resolveAvailabilitySlot(db: PostgresJsDatabase, slotId: string) {
+  const [slot] = await db
+    .select()
+    .from(availabilitySlots)
+    .where(eq(availabilitySlots.id, slotId))
+    .limit(1)
+
+  return slot ?? null
+}
+
+async function previewBootstrapPricing(
+  db: PostgresJsDatabase,
+  input: StorefrontBookingSessionBootstrapInput,
+) {
+  const pricedItems: Array<{
+    inputIndex: number
+    itemId: string
+    title: string
+    productId: string | null
+    optionId: string | null
+    optionUnitId: string | null
+    optionUnitName: string | null
+    optionUnitType: string | null
+    pricingCategoryId: string | null
+    quantity: number
+    pricingMode: string
+    unitSellAmountCents: number | null
+    totalSellAmountCents: number | null
+    warnings: string[]
+  }> = []
+  let resolvedCatalogId: string | null = input.catalogId ?? null
+  let resolvedCurrency = input.session.sellCurrency
+
+  for (const [index, item] of input.session.items.entries()) {
+    if (!item.productId) {
+      return { status: "pricing_unavailable" as const }
+    }
+
+    const snapshot = await resolveSessionPricingSnapshot(db, item.productId, {
+      catalogId: input.catalogId,
+      optionId: item.optionId ?? undefined,
+    })
+
+    if (!snapshot) {
+      return { status: "pricing_unavailable" as const }
+    }
+
+    resolvedCatalogId = snapshot.catalog.id
+    resolvedCurrency = snapshot.catalog.currencyCode ?? input.session.sellCurrency
+
+    const option =
+      snapshot.options.find((candidate) => candidate.id === item.optionId) ??
+      snapshot.options[0] ??
+      null
+    if (!option) {
+      return { status: "pricing_unavailable" as const }
+    }
+
+    const rule =
+      snapshot.rules.find((candidate) => candidate.optionId === option.id && candidate.isDefault) ??
+      snapshot.rules.find((candidate) => candidate.optionId === option.id) ??
+      null
+    if (!rule) {
+      return { status: "pricing_unavailable" as const }
+    }
+
+    const selectedUnitId = item.optionUnitId ?? null
+    const pricingCategoryId = item.pricingCategoryId ?? null
+    const ruleUnitPrices = snapshot.unitPrices.filter(
+      (candidate) => candidate.optionPriceRuleId === rule.id,
+    )
+    const unitPriceCandidates = ruleUnitPrices.filter((candidate) => {
+      if (selectedUnitId && candidate.unitId !== selectedUnitId) {
+        return false
+      }
+      if (pricingCategoryId && candidate.pricingCategoryId !== pricingCategoryId) {
+        return false
+      }
+      if (candidate.minQuantity !== null && item.quantity < candidate.minQuantity) {
+        return false
+      }
+      if (candidate.maxQuantity !== null && item.quantity > candidate.maxQuantity) {
+        return false
+      }
+      return true
+    })
+    const fallbackUnitPrice =
+      !pricingCategoryId && !selectedUnitId
+        ? (ruleUnitPrices.find(
+            (candidate) =>
+              candidate.pricingCategoryId === null &&
+              (candidate.minQuantity === null || item.quantity >= candidate.minQuantity) &&
+              (candidate.maxQuantity === null || item.quantity <= candidate.maxQuantity),
+          ) ?? null)
+        : null
+    const unitPrice = unitPriceCandidates[0] ?? fallbackUnitPrice
+
+    if (
+      (selectedUnitId || ruleUnitPrices.length > 0) &&
+      !unitPrice &&
+      rule.pricingMode !== "per_booking"
+    ) {
+      return { status: "pricing_unavailable" as const }
+    }
+
+    const unitSellAmountCents = unitPrice
+      ? resolveTierAmount(unitPrice.tiers, item.quantity, unitPrice.sellAmountCents)
+      : rule.baseSellAmountCents
+    const pricingMode = unitPrice?.pricingMode ?? rule.pricingMode
+    const totalSellAmountCents = computeLineTotal(
+      pricingMode,
+      unitSellAmountCents,
+      item.quantity,
+      rule.baseSellAmountCents,
+    )
+
+    if (totalSellAmountCents === null) {
+      return { status: "pricing_unavailable" as const }
+    }
+
+    pricedItems.push({
+      inputIndex: index,
+      itemId: `input:${index}`,
+      title: item.title,
+      productId: item.productId ?? null,
+      optionId: option.id,
+      optionUnitId: selectedUnitId,
+      optionUnitName: unitPrice?.unitName ?? null,
+      optionUnitType: unitPrice?.unitType ?? null,
+      pricingCategoryId,
+      quantity: item.quantity,
+      pricingMode,
+      unitSellAmountCents,
+      totalSellAmountCents,
+      warnings: [],
+    })
+  }
+
+  return {
+    status: "ok" as const,
+    pricing: {
+      sessionId: "pending",
+      catalogId: resolvedCatalogId,
+      currencyCode: resolvedCurrency,
+      totalSellAmountCents: pricedItems.reduce(
+        (total, item) => total + (item.totalSellAmountCents ?? 0),
+        0,
+      ),
+      items: pricedItems,
+      warnings: [],
+      appliedToSession: true,
+    },
+  }
+}
+
+async function resolveBootstrapPaymentPolicy(
+  input: StorefrontBookingSessionBootstrapInput,
+  context: StorefrontBootstrapRequestContext,
+  options: StorefrontBookingSessionBootstrapOptions | undefined,
+) {
+  return (
+    (await options?.resolvePaymentPolicy?.({
+      ...input,
+      ...context,
+    })) ??
+    options?.paymentPolicy ??
+    noDepositPolicy
+  )
+}
+
+export async function bootstrapStorefrontBookingSession(
+  context: StorefrontBootstrapRequestContext,
+  input: StorefrontBookingSessionBootstrapInput,
+  options: StorefrontBookingSessionBootstrapOptions | undefined,
+  userId?: string,
+) {
+  const now = options?.today ?? new Date()
+  if (isExpired(input.quote.expiresAt, now)) {
+    return { status: "stale_quote" as const }
+  }
+
+  const [departure, slot] = await Promise.all([
+    resolveAvailabilitySlot(context.db, input.departureId),
+    resolveAvailabilitySlot(context.db, input.slotId),
+  ])
+
+  if (!departure) {
+    return { status: "departure_not_found" as const }
+  }
+
+  if (!slot) {
+    return { status: "slot_not_found" as const }
+  }
+
+  if (departure.id !== slot.id) {
+    return { status: "invalid_slot" as const }
+  }
+
+  const mismatchedItem = input.session.items.find(
+    (item) =>
+      item.availabilitySlotId !== input.slotId ||
+      (item.productId !== undefined &&
+        item.productId !== null &&
+        item.productId !== slot.productId) ||
+      (slot.optionId !== null &&
+        item.optionId !== undefined &&
+        item.optionId !== null &&
+        item.optionId !== slot.optionId),
+  )
+  if (mismatchedItem) {
+    return { status: "invalid_slot" as const }
+  }
+
+  const preview = await previewBootstrapPricing(context.db, input)
+  if (preview.status !== "ok") {
+    return preview
+  }
+
+  if (
+    preview.pricing.currencyCode !== input.quote.currencyCode ||
+    preview.pricing.totalSellAmountCents !== input.quote.totalSellAmountCents
+  ) {
+    return {
+      status: "stale_quote" as const,
+      repricing: {
+        originalQuote: input.quote,
+        current: preview.pricing,
+        deltaAmountCents: preview.pricing.totalSellAmountCents - input.quote.totalSellAmountCents,
+        staleQuote: true,
+      },
+    }
+  }
+
+  const createResult = await publicBookingsService.createSession(
+    context.db,
+    {
+      ...input.session,
+      sellCurrency: preview.pricing.currencyCode,
+      sellAmountCents: preview.pricing.totalSellAmountCents,
+      items: input.session.items.map((item, index) => {
+        const pricedItem = preview.pricing.items[index]
+        return {
+          ...item,
+          sellCurrency: preview.pricing.currencyCode,
+          optionId: pricedItem?.optionId ?? item.optionId,
+          optionUnitId: pricedItem?.optionUnitId ?? item.optionUnitId,
+          pricingCategoryId: pricedItem?.pricingCategoryId ?? item.pricingCategoryId,
+          unitSellAmountCents: pricedItem?.unitSellAmountCents ?? item.unitSellAmountCents,
+          totalSellAmountCents: pricedItem?.totalSellAmountCents ?? item.totalSellAmountCents,
+        }
+      }),
+    },
+    userId,
+  )
+
+  if (createResult.status !== "ok") {
+    return createResult
+  }
+  if (!("session" in createResult)) {
+    return { status: "not_found" as const }
+  }
+
+  const createdSession = createResult.session
+  const policy = await resolveBootstrapPaymentPolicy(input, context, options)
+  const computedSchedule = computePaymentSchedule(
+    {
+      totalCents: createdSession.sellAmountCents ?? preview.pricing.totalSellAmountCents,
+      currency: createdSession.sellCurrency,
+      departureDate: slot.dateLocal ?? normalizeDate(slot.startsAt),
+      today: now,
+    },
+    policy,
+  )
+  const persistedSchedule =
+    (await financeService.applyComputedPaymentSchedule(
+      context.db,
+      createdSession.sessionId,
+      computedSchedule,
+    )) ?? []
+  const [slotAfter] = await context.db
+    .select()
+    .from(availabilitySlots)
+    .where(eq(availabilitySlots.id, input.slotId))
+    .limit(1)
+  const availability = slotAfter ?? slot
+  const currentItems = preview.pricing.items.map(({ inputIndex: _inputIndex, ...item }, index) => ({
+    ...item,
+    itemId: createdSession.items[index]?.id ?? item.itemId,
+  }))
+  const current = {
+    ...preview.pricing,
+    sessionId: createdSession.sessionId,
+    items: currentItems,
+  }
+
+  return {
+    status: "ok" as const,
+    bootstrap: {
+      session: createdSession,
+      paymentPlan: serializePaymentPlan(
+        policy,
+        computedSchedule.length === 1 && computedSchedule[0]?.scheduleType === "full",
+      ),
+      paymentSchedule: persistedSchedule.map((schedule) => ({
+        id: schedule.id,
+        scheduleType: schedule.scheduleType,
+        status: schedule.status,
+        dueDate: normalizeDate(schedule.dueDate)!,
+        currency: schedule.currency,
+        amountCents: schedule.amountCents,
+        notes: schedule.notes ?? null,
+      })),
+      repricing: {
+        originalQuote: input.quote,
+        current,
+        deltaAmountCents: 0,
+        staleQuote: false,
+      },
+      availability: {
+        departureId: input.departureId,
+        slotId: input.slotId,
+        productId: availability.productId,
+        optionId: availability.optionId ?? null,
+        dateLocal: availability.dateLocal ?? null,
+        startsAt: normalizeDateTime(availability.startsAt),
+        endsAt: normalizeDateTime(availability.endsAt),
+        timezone: availability.timezone,
+        status: availability.status,
+        capacity: availability.initialPax ?? null,
+        remaining: availability.unlimited ? null : (availability.remainingPax ?? null),
+      },
+      allocation: createdSession.allocations,
+      currency: createdSession.sellCurrency,
+    },
+  }
+}

--- a/packages/storefront/src/service-booking-session-bootstrap.ts
+++ b/packages/storefront/src/service-booking-session-bootstrap.ts
@@ -112,6 +112,10 @@ async function resolveAvailabilitySlot(db: PostgresJsDatabase, slotId: string) {
 async function previewBootstrapPricing(
   db: PostgresJsDatabase,
   input: StorefrontBookingSessionBootstrapInput,
+  slot: {
+    productId: string
+    optionId: string | null
+  },
 ) {
   const pricedItems: Array<{
     inputIndex: number
@@ -133,13 +137,15 @@ async function previewBootstrapPricing(
   let resolvedCurrency = input.session.sellCurrency
 
   for (const [index, item] of input.session.items.entries()) {
-    if (!item.productId) {
+    const productId = item.productId ?? slot.productId
+    const optionId = item.optionId ?? slot.optionId ?? undefined
+    if (!productId) {
       return { status: "pricing_unavailable" as const }
     }
 
-    const snapshot = await resolveSessionPricingSnapshot(db, item.productId, {
+    const snapshot = await resolveSessionPricingSnapshot(db, productId, {
       catalogId: input.catalogId,
-      optionId: item.optionId ?? undefined,
+      optionId,
     })
 
     if (!snapshot) {
@@ -150,9 +156,7 @@ async function previewBootstrapPricing(
     resolvedCurrency = snapshot.catalog.currencyCode ?? input.session.sellCurrency
 
     const option =
-      snapshot.options.find((candidate) => candidate.id === item.optionId) ??
-      snapshot.options[0] ??
-      null
+      snapshot.options.find((candidate) => candidate.id === optionId) ?? snapshot.options[0] ?? null
     if (!option) {
       return { status: "pricing_unavailable" as const }
     }
@@ -223,7 +227,7 @@ async function previewBootstrapPricing(
       inputIndex: index,
       itemId: `input:${index}`,
       title: item.title,
-      productId: item.productId ?? null,
+      productId,
       optionId: option.id,
       optionUnitId: selectedUnitId,
       optionUnitName: unitPrice?.unitName ?? null,
@@ -312,7 +316,10 @@ export async function bootstrapStorefrontBookingSession(
     return { status: "invalid_slot" as const }
   }
 
-  const preview = await previewBootstrapPricing(context.db, input)
+  const preview = await previewBootstrapPricing(context.db, input, {
+    productId: slot.productId,
+    optionId: slot.optionId ?? null,
+  })
   if (preview.status !== "ok") {
     return preview
   }
@@ -343,6 +350,7 @@ export async function bootstrapStorefrontBookingSession(
         return {
           ...item,
           sellCurrency: preview.pricing.currencyCode,
+          productId: pricedItem?.productId ?? item.productId,
           optionId: pricedItem?.optionId ?? item.optionId,
           optionUnitId: pricedItem?.optionUnitId ?? item.optionUnitId,
           pricingCategoryId: pricedItem?.pricingCategoryId ?? item.pricingCategoryId,

--- a/packages/storefront/src/service.ts
+++ b/packages/storefront/src/service.ts
@@ -2,6 +2,10 @@ import type { EventBus } from "@voyantjs/core"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import {
+  bootstrapStorefrontBookingSession,
+  type StorefrontBookingSessionBootstrapOptions,
+} from "./service-booking-session-bootstrap.js"
+import {
   getStorefrontDeparture,
   getStorefrontDepartureItinerary,
   getStorefrontProductAvailabilitySummary,
@@ -17,6 +21,7 @@ import {
 } from "./service-intake.js"
 import { evaluateStorefrontTransportEligibility } from "./service-transport-eligibility.js"
 import {
+  type StorefrontBookingSessionBootstrapInput,
   type StorefrontDepartureListQuery,
   type StorefrontDeparturePricePreviewInput,
   type StorefrontFormField,
@@ -75,6 +80,7 @@ export interface StorefrontServiceOptions {
     | Promise<StorefrontTransportEligibilityRuleInput[]>
     | StorefrontTransportEligibilityRuleInput[]
   intake?: StorefrontIntakeOptions
+  bookingSessionBootstrap?: StorefrontBookingSessionBootstrapOptions
 }
 
 export interface StorefrontRequestContext {
@@ -418,6 +424,18 @@ export function createStorefrontService(options?: StorefrontServiceOptions) {
         travelers: body.travelers,
         rules,
       })
+    },
+    async bootstrapBookingSession(
+      context: StorefrontRequestContext & { db: PostgresJsDatabase },
+      input: StorefrontBookingSessionBootstrapInput,
+      userId?: string,
+    ) {
+      return bootstrapStorefrontBookingSession(
+        context,
+        input,
+        options?.bookingSessionBootstrap,
+        userId,
+      )
     },
     async listApplicableOffers(input: {
       productId: string

--- a/packages/storefront/src/validation.ts
+++ b/packages/storefront/src/validation.ts
@@ -1,10 +1,17 @@
 import { availabilitySlotStatusSchema } from "@voyantjs/availability/validation"
 import {
+  publicBookingSessionAllocationSchema,
+  publicBookingSessionRepriceSummarySchema,
+  publicBookingSessionSchema,
+  publicCreateBookingSessionSchema,
+} from "@voyantjs/bookings/public-validation"
+import {
   customerSignalKindSchema,
   customerSignalSourceSchema,
   customerSignalStatusSchema,
 } from "@voyantjs/crm/validation"
 import { extraPricingModeSchema } from "@voyantjs/extras/validation"
+import { publicBookingPaymentScheduleSchema } from "@voyantjs/finance/public-validation"
 import { z } from "zod"
 
 import { languageTagSchema } from "./validation-settings.js"
@@ -320,6 +327,70 @@ export const storefrontDeparturePricePreviewSchema = z.object({
   lineItems: z.array(storefrontDeparturePriceLineItemSchema),
 })
 
+export const storefrontBookingSessionQuoteSchema = z.object({
+  currencyCode: z.string().trim().min(3).max(3),
+  totalSellAmountCents: z.number().int().min(0),
+  quotedAt: z.string().datetime().optional().nullable(),
+  expiresAt: z.string().datetime().optional().nullable(),
+})
+
+export const storefrontBookingSessionBootstrapInputSchema = z
+  .object({
+    departureId: z.string().trim().min(1),
+    slotId: z.string().trim().min(1),
+    catalogId: z.string().trim().min(1).optional(),
+    quote: storefrontBookingSessionQuoteSchema,
+    session: publicCreateBookingSessionSchema,
+  })
+  .superRefine((value, ctx) => {
+    if (!value.session.items.some((item) => item.availabilitySlotId === value.slotId)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["session", "items"],
+        message: "At least one session item must reference slotId",
+      })
+    }
+  })
+
+export const storefrontBookingSessionPaymentPlanSchema = z.object({
+  source: z.literal("storefront_default"),
+  depositKind: z.enum(["none", "percent", "fixed_cents"]),
+  depositPercent: z.number().nullable(),
+  depositAmountCents: z.number().int().nullable(),
+  requiresFullPayment: z.boolean(),
+})
+
+export const storefrontBookingSessionAvailabilitySnapshotSchema = z.object({
+  departureId: z.string(),
+  slotId: z.string(),
+  productId: z.string(),
+  optionId: z.string().nullable(),
+  dateLocal: z.string().nullable(),
+  startsAt: z.string().nullable(),
+  endsAt: z.string().nullable(),
+  timezone: z.string(),
+  status: storefrontDepartureStatusSchema,
+  capacity: z.number().int().nullable(),
+  remaining: z.number().int().nullable(),
+})
+
+export const storefrontBookingSessionRepricingSnapshotSchema = z.object({
+  originalQuote: storefrontBookingSessionQuoteSchema,
+  current: publicBookingSessionRepriceSummarySchema,
+  deltaAmountCents: z.number().int(),
+  staleQuote: z.boolean(),
+})
+
+export const storefrontBookingSessionBootstrapSchema = z.object({
+  session: publicBookingSessionSchema,
+  paymentPlan: storefrontBookingSessionPaymentPlanSchema,
+  paymentSchedule: z.array(publicBookingPaymentScheduleSchema),
+  repricing: storefrontBookingSessionRepricingSnapshotSchema,
+  availability: storefrontBookingSessionAvailabilitySnapshotSchema,
+  allocation: z.array(publicBookingSessionAllocationSchema),
+  currency: z.string(),
+})
+
 export const storefrontProductExtensionsQuerySchema = z.object({
   optionId: z.string().optional(),
 })
@@ -518,6 +589,12 @@ export type StorefrontProductAvailabilitySummaryQuery = z.infer<
 >
 export type StorefrontDeparturePricePreviewInput = z.infer<
   typeof storefrontDeparturePricePreviewInputSchema
+>
+export type StorefrontBookingSessionBootstrapInput = z.infer<
+  typeof storefrontBookingSessionBootstrapInputSchema
+>
+export type StorefrontBookingSessionBootstrap = z.infer<
+  typeof storefrontBookingSessionBootstrapSchema
 >
 export type StorefrontPromotionalOffer = z.infer<typeof storefrontPromotionalOfferSchema>
 export type StorefrontOfferApplyInput = z.infer<typeof storefrontOfferApplyInputSchema>

--- a/packages/storefront/tests/integration/booking-session-bootstrap.test.ts
+++ b/packages/storefront/tests/integration/booking-session-bootstrap.test.ts
@@ -58,7 +58,7 @@ describe.skipIf(!DB_AVAILABLE)("Storefront booking-session bootstrap route", () 
     await closeTestDb()
   })
 
-  async function seedDeparture() {
+  async function seedDeparture(options: { competingDefaultOption?: boolean } = {}) {
     const [product] = await db
       .insert(products)
       .values({
@@ -76,7 +76,8 @@ describe.skipIf(!DB_AVAILABLE)("Storefront booking-session bootstrap route", () 
         productId: product.id,
         name: "Main departure",
         status: "active",
-        isDefault: true,
+        isDefault: !options.competingDefaultOption,
+        sortOrder: options.competingDefaultOption ? 10 : 0,
       })
       .returning()
 
@@ -103,6 +104,54 @@ describe.skipIf(!DB_AVAILABLE)("Storefront booking-session bootstrap route", () 
         active: true,
       })
       .returning()
+
+    if (options.competingDefaultOption) {
+      const [defaultOption] = await db
+        .insert(productOptions)
+        .values({
+          productId: product.id,
+          name: "Default but unselected departure",
+          status: "active",
+          isDefault: true,
+          sortOrder: 0,
+        })
+        .returning()
+
+      const [defaultUnit] = await db
+        .insert(optionUnits)
+        .values({
+          optionId: defaultOption.id,
+          name: "Default cabin",
+          unitType: "room",
+          occupancyMin: 2,
+          occupancyMax: 2,
+          isHidden: false,
+        })
+        .returning()
+
+      const [defaultRule] = await db
+        .insert(optionPriceRules)
+        .values({
+          productId: product.id,
+          optionId: defaultOption.id,
+          priceCatalogId: catalog.id,
+          name: "Default room rate",
+          pricingMode: "per_booking",
+          baseSellAmountCents: 40000,
+          isDefault: true,
+          active: true,
+        })
+        .returning()
+
+      await db.insert(optionUnitPriceRules).values({
+        optionPriceRuleId: defaultRule.id,
+        optionId: defaultOption.id,
+        unitId: defaultUnit.id,
+        pricingMode: "per_booking",
+        sellAmountCents: 40000,
+        active: true,
+      })
+    }
 
     const [rule] = await db
       .insert(optionPriceRules)
@@ -268,6 +317,68 @@ describe.skipIf(!DB_AVAILABLE)("Storefront booking-session bootstrap route", () 
       .from(bookingPaymentSchedules)
       .where(eq(bookingPaymentSchedules.bookingId, body.data.session.sessionId))
     expect(schedules).toHaveLength(2)
+  })
+
+  it("replays duplicate bootstrap requests with the same idempotency key", async () => {
+    const seed = await seedDeparture()
+    const payload = bootstrapPayload(seed)
+    const headers = {
+      "Content-Type": "application/json",
+      "Idempotency-Key": "bootstrap-idempotency-1",
+    }
+
+    const first = await app.request("/bookings/sessions/bootstrap", {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+    })
+    expect(first.status).toBe(201)
+    const firstBody = await first.json()
+
+    const replay = await app.request("/bookings/sessions/bootstrap", {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+    })
+    expect(replay.status).toBe(201)
+    expect(replay.headers.get("Idempotency-Replayed")).toBe("true")
+    const replayBody = await replay.json()
+    expect(replayBody.data.session.sessionId).toBe(firstBody.data.session.sessionId)
+
+    const schedules = await db
+      .select()
+      .from(bookingPaymentSchedules)
+      .where(eq(bookingPaymentSchedules.bookingId, firstBody.data.session.sessionId))
+    expect(schedules).toHaveLength(2)
+
+    const [slot] = await db
+      .select()
+      .from(availabilitySlots)
+      .where(eq(availabilitySlots.id, seed.slot.id))
+      .limit(1)
+    expect(slot?.remainingPax).toBe(9)
+  })
+
+  it("prices omitted item option ids against the selected slot option", async () => {
+    const seed = await seedDeparture({ competingDefaultOption: true })
+    const payload = bootstrapPayload(seed)
+    delete payload.session.items[0]?.optionId
+
+    const res = await app.request("/bookings/sessions/bootstrap", {
+      method: "POST",
+      ...json(payload),
+    })
+
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.data.repricing.current.totalSellAmountCents).toBe(50000)
+    expect(body.data.session.items[0]).toEqual(
+      expect.objectContaining({
+        productId: seed.product.id,
+        optionId: seed.option.id,
+        optionUnitId: seed.unit.id,
+      }),
+    )
   })
 
   it("rejects missing session input", async () => {

--- a/packages/storefront/tests/integration/booking-session-bootstrap.test.ts
+++ b/packages/storefront/tests/integration/booking-session-bootstrap.test.ts
@@ -1,0 +1,329 @@
+import { availabilitySlots } from "@voyantjs/availability/schema"
+import { cleanupTestDb, closeTestDb, createTestDb } from "@voyantjs/db/test-utils"
+import { bookingPaymentSchedules } from "@voyantjs/finance/schema"
+import { handleApiError } from "@voyantjs/hono"
+import { optionPriceRules, optionUnitPriceRules, priceCatalogs } from "@voyantjs/pricing/schema"
+import { optionUnits, productOptions, products } from "@voyantjs/products/schema"
+import { eq } from "drizzle-orm"
+import { Hono } from "hono"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { createStorefrontPublicRoutes } from "../../src/routes-public.js"
+
+const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
+const DB_AVAILABLE = !!TEST_DATABASE_URL
+const ORIGINAL_CHECKOUT_CAPABILITY_SECRET = process.env.VOYANT_CHECKOUT_CAPABILITY_SECRET
+
+const json = (body: Record<string, unknown>) => ({
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(body),
+})
+
+describe.skipIf(!DB_AVAILABLE)("Storefront booking-session bootstrap route", () => {
+  let app: Hono
+  let db: ReturnType<typeof createTestDb>
+
+  beforeAll(async () => {
+    process.env.VOYANT_CHECKOUT_CAPABILITY_SECRET = "storefront-bootstrap-test-secret-32"
+    db = createTestDb()
+    app = new Hono()
+      .onError(handleApiError)
+      .use("*", async (c, next) => {
+        c.set("db" as never, db)
+        c.set("userId" as never, "storefront-bootstrap-test-user")
+        await next()
+      })
+      .route(
+        "/",
+        createStorefrontPublicRoutes({
+          bookingSessionBootstrap: {
+            today: new Date("2026-05-14T00:00:00.000Z"),
+            paymentPolicy: {
+              deposit: { kind: "percent", percent: 30 },
+              minDaysBeforeDepartureForDeposit: 1,
+              balanceDueDaysBeforeDeparture: 30,
+              balanceDueMinDaysFromNow: 7,
+            },
+          },
+        }),
+      )
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDb(db)
+  })
+
+  afterAll(async () => {
+    process.env.VOYANT_CHECKOUT_CAPABILITY_SECRET = ORIGINAL_CHECKOUT_CAPABILITY_SECRET
+    await closeTestDb()
+  })
+
+  async function seedDeparture() {
+    const [product] = await db
+      .insert(products)
+      .values({
+        name: "Bootstrap Danube Cruise",
+        status: "active",
+        activated: true,
+        visibility: "public",
+        sellCurrency: "EUR",
+      })
+      .returning()
+
+    const [option] = await db
+      .insert(productOptions)
+      .values({
+        productId: product.id,
+        name: "Main departure",
+        status: "active",
+        isDefault: true,
+      })
+      .returning()
+
+    const [unit] = await db
+      .insert(optionUnits)
+      .values({
+        optionId: option.id,
+        name: "Double cabin",
+        unitType: "room",
+        occupancyMin: 2,
+        occupancyMax: 2,
+        isHidden: false,
+      })
+      .returning()
+
+    const [catalog] = await db
+      .insert(priceCatalogs)
+      .values({
+        code: "PUBLIC-EUR",
+        name: "Public EUR",
+        currencyCode: "EUR",
+        catalogType: "public",
+        isDefault: true,
+        active: true,
+      })
+      .returning()
+
+    const [rule] = await db
+      .insert(optionPriceRules)
+      .values({
+        productId: product.id,
+        optionId: option.id,
+        priceCatalogId: catalog.id,
+        name: "Public room rate",
+        pricingMode: "per_booking",
+        baseSellAmountCents: 50000,
+        isDefault: true,
+        active: true,
+      })
+      .returning()
+
+    await db.insert(optionUnitPriceRules).values({
+      optionPriceRuleId: rule.id,
+      optionId: option.id,
+      unitId: unit.id,
+      pricingMode: "per_booking",
+      sellAmountCents: 50000,
+      active: true,
+    })
+
+    const [slot] = await db
+      .insert(availabilitySlots)
+      .values({
+        productId: product.id,
+        optionId: option.id,
+        dateLocal: "2026-08-01",
+        startsAt: new Date("2026-08-01T05:30:00.000Z"),
+        endsAt: new Date("2026-08-08T13:30:00.000Z"),
+        timezone: "Europe/Bucharest",
+        status: "open",
+        unlimited: false,
+        initialPax: 10,
+        remainingPax: 10,
+        pastCutoff: false,
+        tooEarly: false,
+      })
+      .returning()
+
+    return { product, option, unit, slot }
+  }
+
+  function bootstrapPayload(seed: Awaited<ReturnType<typeof seedDeparture>>) {
+    return {
+      departureId: seed.slot.id,
+      slotId: seed.slot.id,
+      quote: {
+        currencyCode: "EUR",
+        totalSellAmountCents: 50000,
+        quotedAt: "2026-05-14T00:00:00.000Z",
+        expiresAt: "2026-05-14T00:30:00.000Z",
+      },
+      session: {
+        sellCurrency: "EUR",
+        pax: 1,
+        startDate: "2026-08-01",
+        endDate: "2026-08-08",
+        items: [
+          {
+            title: "Danube cruise cabin",
+            availabilitySlotId: seed.slot.id,
+            quantity: 1,
+            productId: seed.product.id,
+            optionId: seed.option.id,
+            optionUnitId: seed.unit.id,
+          },
+        ],
+        travelers: [
+          {
+            firstName: "Ana",
+            lastName: "Popescu",
+            email: "ana@example.com",
+            isPrimary: true,
+          },
+        ],
+      },
+    }
+  }
+
+  it("bootstraps a booking session with payment, repricing, availability, and allocation", async () => {
+    const seed = await seedDeparture()
+
+    const res = await app.request("/bookings/sessions/bootstrap", {
+      method: "POST",
+      ...json(bootstrapPayload(seed)),
+    })
+
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.data.currency).toBe("EUR")
+    expect(body.data.session.status).toBe("on_hold")
+    expect(body.data.session.checkoutCapability.actions).toContain("payment:start")
+    expect(body.data.paymentPlan).toEqual({
+      source: "storefront_default",
+      depositKind: "percent",
+      depositPercent: 30,
+      depositAmountCents: null,
+      requiresFullPayment: false,
+    })
+    expect(body.data.paymentSchedule).toEqual([
+      expect.objectContaining({
+        scheduleType: "deposit",
+        status: "due",
+        dueDate: "2026-05-14",
+        currency: "EUR",
+        amountCents: 15000,
+      }),
+      expect.objectContaining({
+        scheduleType: "balance",
+        status: "pending",
+        dueDate: "2026-07-02",
+        currency: "EUR",
+        amountCents: 35000,
+      }),
+    ])
+    expect(body.data.repricing).toEqual({
+      originalQuote: {
+        currencyCode: "EUR",
+        totalSellAmountCents: 50000,
+        quotedAt: "2026-05-14T00:00:00.000Z",
+        expiresAt: "2026-05-14T00:30:00.000Z",
+      },
+      current: expect.objectContaining({
+        sessionId: body.data.session.sessionId,
+        currencyCode: "EUR",
+        totalSellAmountCents: 50000,
+        appliedToSession: true,
+      }),
+      deltaAmountCents: 0,
+      staleQuote: false,
+    })
+    expect(body.data.repricing.current.items[0]).toEqual(
+      expect.objectContaining({
+        itemId: body.data.session.items[0].id,
+        optionUnitId: seed.unit.id,
+        totalSellAmountCents: 50000,
+      }),
+    )
+    expect(body.data.availability).toEqual(
+      expect.objectContaining({
+        departureId: seed.slot.id,
+        slotId: seed.slot.id,
+        productId: seed.product.id,
+        optionId: seed.option.id,
+        remaining: 9,
+      }),
+    )
+    expect(body.data.allocation).toHaveLength(1)
+    expect(body.data.allocation[0]).toEqual(
+      expect.objectContaining({
+        availabilitySlotId: seed.slot.id,
+        optionUnitId: seed.unit.id,
+        quantity: 1,
+        status: "held",
+      }),
+    )
+
+    const schedules = await db
+      .select()
+      .from(bookingPaymentSchedules)
+      .where(eq(bookingPaymentSchedules.bookingId, body.data.session.sessionId))
+    expect(schedules).toHaveLength(2)
+  })
+
+  it("rejects missing session input", async () => {
+    const seed = await seedDeparture()
+
+    const res = await app.request("/bookings/sessions/bootstrap", {
+      method: "POST",
+      ...json({
+        departureId: seed.slot.id,
+        slotId: seed.slot.id,
+        quote: { currencyCode: "EUR", totalSellAmountCents: 50000 },
+      }),
+    })
+
+    expect(res.status).toBe(400)
+  })
+
+  it("rejects invalid departure and slot inputs", async () => {
+    const seed = await seedDeparture()
+
+    const invalidDepartureRes = await app.request("/bookings/sessions/bootstrap", {
+      method: "POST",
+      ...json({ ...bootstrapPayload(seed), departureId: "slot_missing" }),
+    })
+    expect(invalidDepartureRes.status).toBe(404)
+
+    const invalidSlotRes = await app.request("/bookings/sessions/bootstrap", {
+      method: "POST",
+      ...json({ ...bootstrapPayload(seed), slotId: "slot_missing" }),
+    })
+    expect(invalidSlotRes.status).toBe(400)
+  })
+
+  it("rejects stale quote inputs before creating a booking session", async () => {
+    const seed = await seedDeparture()
+    const payload = bootstrapPayload(seed)
+
+    const res = await app.request("/bookings/sessions/bootstrap", {
+      method: "POST",
+      ...json({
+        ...payload,
+        quote: {
+          ...payload.quote,
+          totalSellAmountCents: 49000,
+        },
+      }),
+    })
+
+    expect(res.status).toBe(409)
+    const body = await res.json()
+    expect(body.error).toBe("Booking session quote is stale")
+    expect(body.data.repricing).toEqual(
+      expect.objectContaining({
+        deltaAmountCents: 1000,
+        staleQuote: true,
+      }),
+    )
+  })
+})

--- a/packages/storefront/tests/unit/public-routes.test.ts
+++ b/packages/storefront/tests/unit/public-routes.test.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono"
 import { describe, expect, it, vi } from "vitest"
 
 import { createStorefrontPublicRoutes } from "../../src/routes-public.js"
+import { storefrontBookingSessionBootstrapInputSchema } from "../../src/validation.js"
 
 describe("createStorefrontPublicRoutes", () => {
   it("returns normalized storefront settings", async () => {
@@ -568,5 +569,42 @@ describe("createStorefrontPublicRoutes", () => {
     })
 
     expect(res.status).toBe(501)
+  })
+
+  it("rejects booking-session bootstrap requests without a session payload", () => {
+    const result = storefrontBookingSessionBootstrapInputSchema.safeParse({
+      departureId: "slot_123",
+      slotId: "slot_123",
+      quote: {
+        currencyCode: "EUR",
+        totalSellAmountCents: 50000,
+      },
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects booking-session bootstrap requests whose items do not reference the slot", () => {
+    const result = storefrontBookingSessionBootstrapInputSchema.safeParse({
+      departureId: "slot_123",
+      slotId: "slot_123",
+      quote: {
+        currencyCode: "EUR",
+        totalSellAmountCents: 50000,
+      },
+      session: {
+        sellCurrency: "EUR",
+        items: [
+          {
+            title: "Room",
+            availabilitySlotId: "slot_other",
+            quantity: 1,
+            productId: "prod_123",
+          },
+        ],
+      },
+    })
+
+    expect(result.success).toBe(false)
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4657,6 +4657,9 @@ importers:
       '@voyantjs/availability':
         specifier: workspace:*
         version: link:../availability
+      '@voyantjs/bookings':
+        specifier: workspace:*
+        version: link:../bookings
       '@voyantjs/core':
         specifier: workspace:*
         version: link:../core
@@ -4666,6 +4669,9 @@ importers:
       '@voyantjs/extras':
         specifier: workspace:*
         version: link:../extras
+      '@voyantjs/finance':
+        specifier: workspace:*
+        version: link:../finance
       '@voyantjs/hono':
         specifier: workspace:*
         version: link:../hono


### PR DESCRIPTION
## Summary
Closes #868.

- Add public storefront booking-session bootstrap route at `POST /v1/public/bookings/sessions/bootstrap`.
- Compose booking session creation, current pricing snapshot, finance payment schedule, availability snapshot, allocation, currency, and checkout capability into one customer-safe response.
- Add bootstrap request/response schemas, service options for payment policy resolution, docs, changeset, and validation/DB-backed route tests.

## Verification
- `pnpm --filter @voyantjs/storefront typecheck`
- `pnpm --filter @voyantjs/storefront test`
- `pnpm --filter @voyantjs/storefront lint`
- `pnpm --filter @voyantjs/storefront build`
- `pnpm --filter @voyantjs/bookings typecheck`
- `pnpm --filter @voyantjs/bookings test`
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/finance test`
- `pnpm --filter @voyantjs/checkout typecheck`
- `pnpm --filter @voyantjs/checkout test`
- `NODE_OPTIONS=--max-old-space-size=4096 TURBO_CONCURRENCY=2 pnpm verify:fast`
- pre-push `pnpm test` hook (cached)