### PR TITLE
fix(release): align storefront ui version

### DIFF
--- a/packages/storefront-ui/package.json
+++ b/packages/storefront-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/storefront-ui",
-  "version": "0.41.0",
+  "version": "0.49.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- align @voyantjs/storefront-ui package version with the shared 0.49.0 release train

## Verification
- NODE_PATH=/Users/mihai/builds/internal/voyant-all/voyant/node_modules node scripts/verify-release-train.cjs
- /Users/mihai/builds/internal/voyant-all/voyant/node_modules/.bin/biome check packages/storefront-ui/package.json
- git diff --check