### PR TITLE
Expose storefront SDK booking session bootstrap

### DIFF
--- a/.changeset/bright-mirrors-bootstrap.md
+++ b/.changeset/bright-mirrors-bootstrap.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/storefront-sdk": patch
+---
+
+Expose `bootstrapBookingSession` and `booking.bootstrapSession(...)` for the native storefront booking-session bootstrap route.

--- a/packages/storefront-sdk/README.md
+++ b/packages/storefront-sdk/README.md
@@ -29,6 +29,15 @@ const session = await voyant.booking.createSession({
 const state = voyant.booking.deriveState(session)
 ```
 
+Use `voyant.booking.bootstrapSession(...)` or the lower-level
+`bootstrapBookingSession(...)` operation when the storefront has a selected
+departure slot and quote and needs the native combined bootstrap payload:
+session, availability, repricing, payment plan/schedule, allocation, and the
+checkout capability attached at `session.checkoutCapability`. Use
+`voyant.booking.createSession(...)` / `createPublicBookingSession(...)` only
+when the UI intentionally wants to reserve a bare public booking session and
+orchestrate pricing, availability, and payment setup separately.
+
 For custom booking engines, prefer the `bookingEngine` facade. It keeps the
 route-shaped public booking and checkout calls behind flow-oriented methods and
 returns a canonical engine snapshot alongside session reads and mutations.

--- a/packages/storefront-sdk/src/index.ts
+++ b/packages/storefront-sdk/src/index.ts
@@ -20,6 +20,7 @@ import {
   deriveBookingEngineState,
 } from "./engine-state.js"
 import {
+  bootstrapBookingSession,
   bootstrapCheckoutCollection,
   confirmPublicBookingSession,
   createPublicBookingSession,
@@ -121,6 +122,10 @@ export function createVoyantStorefrontClient(options: VoyantStorefrontClientOpti
         getStorefrontOfferBySlug(client, slug, query),
     },
     booking: {
+      bootstrapSession: (
+        input: Parameters<typeof bootstrapBookingSession>[1],
+        requestOptions?: Parameters<typeof bootstrapBookingSession>[2],
+      ) => bootstrapBookingSession(client, input, requestOptions),
       createSession: (
         input: Parameters<typeof createPublicBookingSession>[1],
         requestOptions?: Parameters<typeof createPublicBookingSession>[2],

--- a/packages/storefront-sdk/src/operations.ts
+++ b/packages/storefront-sdk/src/operations.ts
@@ -8,6 +8,7 @@ import {
 import {
   type BootstrapCheckoutCollectionInput,
   bootstrapCheckoutCollectionSchema,
+  bootstrappedBookingSessionResponseSchema,
   bootstrappedCheckoutCollectionResponseSchema,
   checkoutCollectionPlanResponseSchema,
   type InitiateCheckoutCollectionInput,
@@ -31,6 +32,7 @@ import {
   publicRepriceBookingSessionSchema,
   publicUpdateBookingSessionSchema,
   publicUpsertBookingSessionStateSchema,
+  type StorefrontBookingSessionBootstrapInput,
   type StorefrontDepartureListQuery,
   type StorefrontDeparturePricePreviewInput,
   type StorefrontLeadIntakeInput,
@@ -38,6 +40,7 @@ import {
   type StorefrontProductAvailabilitySummaryQuery,
   type StorefrontProductExtensionsQuery,
   type StorefrontPromotionalOfferListQuery,
+  storefrontBookingSessionBootstrapInputSchema,
   storefrontDepartureItineraryResponseSchema,
   storefrontDepartureListQuerySchema,
   storefrontDepartureListResponseSchema,
@@ -219,6 +222,20 @@ export function createPublicBookingSession(
   return storefrontFetchWithValidation(
     "/v1/public/bookings/sessions",
     publicBookingSessionResponseSchema,
+    client,
+    { method: "POST", headers: requestHeaders(options), body: JSON.stringify(parsed) },
+  ).then((response) => response.data)
+}
+
+export function bootstrapBookingSession(
+  client: ResolvedClientOptions,
+  input: StorefrontBookingSessionBootstrapInput,
+  options?: StorefrontRequestOptions,
+) {
+  const parsed = storefrontBookingSessionBootstrapInputSchema.parse(input)
+  return storefrontFetchWithValidation(
+    "/v1/public/bookings/sessions/bootstrap",
+    bootstrappedBookingSessionResponseSchema,
     client,
     { method: "POST", headers: requestHeaders(options), body: JSON.stringify(parsed) },
   ).then((response) => response.data)

--- a/packages/storefront-sdk/src/schemas.ts
+++ b/packages/storefront-sdk/src/schemas.ts
@@ -5,6 +5,7 @@ import {
   publicBookingSessionRepriceResultSchema,
   publicBookingSessionSchema,
   publicBookingSessionStateSchema,
+  publicCheckoutCapabilitySchema,
   publicCreateBookingSessionSchema,
   publicRepriceBookingSessionSchema,
   publicUpdateBookingSessionSchema,
@@ -19,6 +20,8 @@ import {
   previewCheckoutCollectionSchema,
 } from "@voyantjs/checkout/validation"
 import {
+  storefrontBookingSessionBootstrapInputSchema,
+  storefrontBookingSessionBootstrapSchema,
   storefrontDepartureItinerarySchema,
   storefrontDepartureListQuerySchema,
   storefrontDepartureListResponseSchema,
@@ -68,10 +71,13 @@ export {
   publicBookingSessionRepriceResultSchema,
   publicBookingSessionSchema,
   publicBookingSessionStateSchema,
+  publicCheckoutCapabilitySchema,
   publicCreateBookingSessionSchema,
   publicRepriceBookingSessionSchema,
   publicUpdateBookingSessionSchema,
   publicUpsertBookingSessionStateSchema,
+  storefrontBookingSessionBootstrapInputSchema,
+  storefrontBookingSessionBootstrapSchema,
   storefrontDepartureItinerarySchema,
   storefrontDepartureListQuerySchema,
   storefrontDepartureListResponseSchema,
@@ -137,6 +143,14 @@ export const publicBookingSessionRepriceResponseSchema = storefrontSingleEnvelop
 export const publicBookingOverviewResponseSchema = storefrontSingleEnvelopeSchema(
   publicBookingOverviewSchema,
 )
+export const bootstrappedBookingSessionSchema = storefrontBookingSessionBootstrapSchema.extend({
+  session: publicBookingSessionSchema.extend({
+    checkoutCapability: publicCheckoutCapabilitySchema,
+  }),
+})
+export const bootstrappedBookingSessionResponseSchema = storefrontSingleEnvelopeSchema(
+  bootstrappedBookingSessionSchema,
+)
 
 export const checkoutCollectionPlanResponseSchema = storefrontSingleEnvelopeSchema(
   checkoutCollectionPlanSchema,
@@ -193,6 +207,11 @@ export type PublicBookingSessionRepriceResultRecord = z.infer<
   typeof publicBookingSessionRepriceResultSchema
 >
 export type PublicBookingOverviewRecord = z.infer<typeof publicBookingOverviewSchema>
+export type StorefrontBookingSessionBootstrapInput = z.input<
+  typeof storefrontBookingSessionBootstrapInputSchema
+>
+export type StorefrontBookingSessionBootstrap = z.infer<typeof bootstrappedBookingSessionSchema>
+export type StorefrontBookingSessionBootstrapRecord = StorefrontBookingSessionBootstrap
 
 export type PreviewCheckoutCollectionInput = z.input<typeof previewCheckoutCollectionSchema>
 export type InitiateCheckoutCollectionInput = z.input<typeof initiateCheckoutCollectionSchema>

--- a/packages/storefront-sdk/tests/unit/booking-session-bootstrap.test.ts
+++ b/packages/storefront-sdk/tests/unit/booking-session-bootstrap.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  bootstrapBookingSession,
+  bootstrappedBookingSessionResponseSchema,
+  createVoyantStorefrontClient,
+} from "../../src/index.js"
+
+function bootstrapInput() {
+  return {
+    departureId: "dep_123",
+    slotId: "slot_123",
+    quote: {
+      currencyCode: "EUR",
+      totalSellAmountCents: 10000,
+      quotedAt: "2026-06-01T10:00:00.000Z",
+      expiresAt: "2026-06-01T10:30:00.000Z",
+    },
+    session: {
+      sellCurrency: "EUR",
+      items: [
+        {
+          title: "Danube tour",
+          availabilitySlotId: "slot_123",
+          quantity: 1,
+          totalSellAmountCents: 10000,
+        },
+      ],
+    },
+  }
+}
+
+function bootstrapPayload() {
+  return {
+    session: {
+      sessionId: "book_123",
+      bookingNumber: "BK-2605-000001",
+      status: "on_hold",
+      externalBookingRef: null,
+      communicationLanguage: null,
+      sellCurrency: "EUR",
+      sellAmountCents: 10000,
+      startDate: null,
+      endDate: null,
+      pax: 1,
+      holdExpiresAt: "2026-06-01T10:30:00.000Z",
+      confirmedAt: null,
+      expiredAt: null,
+      cancelledAt: null,
+      completedAt: null,
+      travelers: [],
+      items: [],
+      allocations: [],
+      checklist: {
+        hasTravelers: false,
+        hasPrimaryTraveler: false,
+        hasItems: true,
+        hasAllocations: true,
+        readyForConfirmation: false,
+      },
+      state: null,
+      checkoutCapability: {
+        token: "cap_123",
+        expiresAt: "2026-06-01T10:30:00.000Z",
+        actions: ["session:read", "payment:start"],
+      },
+    },
+    paymentPlan: {
+      source: "storefront_default",
+      depositKind: "percent",
+      depositPercent: 20,
+      depositAmountCents: null,
+      requiresFullPayment: false,
+    },
+    paymentSchedule: [
+      {
+        id: "bps_123",
+        scheduleType: "deposit",
+        status: "due",
+        dueDate: "2026-06-01",
+        currency: "EUR",
+        amountCents: 2000,
+        notes: null,
+      },
+    ],
+    repricing: {
+      originalQuote: {
+        currencyCode: "EUR",
+        totalSellAmountCents: 10000,
+        quotedAt: "2026-06-01T10:00:00.000Z",
+        expiresAt: "2026-06-01T10:30:00.000Z",
+      },
+      current: {
+        sessionId: "book_123",
+        catalogId: null,
+        currencyCode: "EUR",
+        totalSellAmountCents: 10000,
+        items: [],
+        warnings: [],
+        appliedToSession: true,
+      },
+      deltaAmountCents: 0,
+      staleQuote: false,
+    },
+    availability: {
+      departureId: "dep_123",
+      slotId: "slot_123",
+      productId: "prod_123",
+      optionId: null,
+      dateLocal: "2026-06-01",
+      startsAt: "2026-06-01T10:00:00.000Z",
+      endsAt: "2026-06-01T12:00:00.000Z",
+      timezone: "Europe/Bucharest",
+      status: "open",
+      capacity: 10,
+      remaining: 9,
+    },
+    allocation: [],
+    currency: "EUR",
+  }
+}
+
+describe("booking session bootstrap", () => {
+  it("posts to the native bootstrap route and parses the combined payload", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = []
+    const client = {
+      baseUrl: "https://operator.example.com",
+      fetcher: async (url: string, init?: RequestInit) => {
+        calls.push({ url, init })
+        return Response.json({ data: bootstrapPayload() }, { status: 201 })
+      },
+    }
+
+    const result = await bootstrapBookingSession(client, bootstrapInput(), {
+      idempotencyKey: "bootstrap-1",
+    })
+
+    expect(calls[0]?.url).toBe("https://operator.example.com/v1/public/bookings/sessions/bootstrap")
+    expect(calls[0]?.init?.method).toBe("POST")
+    expect(new Headers(calls[0]?.init?.headers).get("Idempotency-Key")).toBe("bootstrap-1")
+    expect(result.session.checkoutCapability.token).toBe("cap_123")
+    expect(result.paymentSchedule[0]?.amountCents).toBe(2000)
+  })
+
+  it("exposes bootstrap through the storefront client booking facade", async () => {
+    const voyant = createVoyantStorefrontClient({
+      baseUrl: "https://operator.example.com",
+      fetcher: async () => Response.json({ data: bootstrapPayload() }, { status: 201 }),
+    })
+
+    const result = await voyant.booking.bootstrapSession(bootstrapInput())
+
+    expect(result.session.sessionId).toBe("book_123")
+    expect(result.availability.slotId).toBe("slot_123")
+  })
+
+  it("requires the checkout capability returned by the route", () => {
+    const payload = bootstrapPayload()
+    const { checkoutCapability, ...session } = payload.session
+
+    const result = bootstrappedBookingSessionResponseSchema.safeParse({
+      data: { ...payload, session },
+    })
+
+    expect(checkoutCapability.token).toBe("cap_123")
+    expect(result.success).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Add `bootstrapBookingSession(client, input, options?)` for `POST /v1/public/bookings/sessions/bootstrap`.
- Add `createVoyantStorefrontClient(...).booking.bootstrapSession(...)`.
- Export bootstrap input/output schemas and types, with the route-issued `session.checkoutCapability` required on the SDK response schema.
- Document when to use bootstrap vs bare `createSession`.

Closes #912.

## Verification

- `pnpm --filter @voyantjs/storefront-sdk lint`
- `pnpm --filter @voyantjs/storefront-sdk typecheck`
- `pnpm --filter @voyantjs/storefront-sdk test`
- `pnpm --filter @voyantjs/storefront-sdk build`
- Pre-push `pnpm test` hook passed.

Note: `pnpm verify:package-exports` could not run in the clean worktree because many packages did not have `dist/` build outputs yet. The pre-commit full typecheck hook also hit exit 137 in unrelated `@voyantjs/identity-ui` and `@voyantjs/external-refs-ui` tasks; the storefront SDK package typecheck passed independently.