### PR TITLE
[codex] Allow booking workspace tab override

### DIFF
--- a/.changeset/booking-workspace-tab-slot.md
+++ b/.changeset/booking-workspace-tab-slot.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/bookings-ui": patch
+---
+
+Allow BookingWorkspacePage consumers to replace the default booking tab content with a typed bookingTab slot.

--- a/packages/bookings-ui/README.md
+++ b/packages/bookings-ui/README.md
@@ -34,6 +34,7 @@ surfaces app-owned through typed slots:
   id={bookingId}
   slots={{
     actionBar: ({ booking }) => <button type="button">Assign {booking.bookingNumber}</button>,
+    bookingTab: ({ booking }) => <BookingOverviewPanel booking={booking} />,
     financeSidebar: ({ bookingId }) => <FinanceStatusCard bookingId={bookingId} />,
     legalTab: ({ bookingId }) => <ContractChecklist bookingId={bookingId} />,
     travelersTabExtensions: ({ bulkActions }) => (
@@ -46,7 +47,10 @@ surfaces app-owned through typed slots:
 
 Slot render functions receive the booking, active workspace section, section
 setter, and bulk-action state for traveler and finance selections. Use
-`bookingDetailSlots` to pass slots through to the mounted `BookingDetailPage`.
+`bookingTab` when an app wants to use top-level finance, legal, traveler, or
+activity tabs without nesting the default `BookingDetailPage` tabs. When
+`bookingTab` is omitted, the workspace keeps mounting `BookingDetailPage`; use
+`bookingDetailSlots` to pass slots through to that default detail page.
 
 ## I18n
 

--- a/packages/bookings-ui/src/components/booking-workspace-page.tsx
+++ b/packages/bookings-ui/src/components/booking-workspace-page.tsx
@@ -54,6 +54,7 @@ export interface BookingWorkspacePageSlots {
   legalSidebar?: (context: BookingWorkspaceSlotContext) => ReactNode
   travelersSidebar?: (context: BookingWorkspaceSlotContext) => ReactNode
   activitySidebar?: (context: BookingWorkspaceSlotContext) => ReactNode
+  bookingTab?: (context: BookingWorkspaceSlotContext) => ReactNode
   financeTab?: (context: BookingWorkspaceSlotContext) => ReactNode
   legalTab?: (context: BookingWorkspaceSlotContext) => ReactNode
   travelersTabExtensions?: (context: BookingWorkspaceSlotContext) => ReactNode
@@ -234,16 +235,20 @@ export function BookingWorkspaceShell({
           >
             <div className="min-w-0">
               <TabsContent value="booking" className="mt-0">
-                <BookingDetailPage
-                  id={bookingId}
-                  className="p-0"
-                  locale={locale}
-                  onBack={onBack}
-                  onPersonOpen={onPersonOpen}
-                  onOrganizationOpen={onOrganizationOpen}
-                  onCollectPayment={onCollectPayment}
-                  slots={bookingDetailSlots}
-                />
+                {slots?.bookingTab ? (
+                  slots.bookingTab(context)
+                ) : (
+                  <BookingDetailPage
+                    id={bookingId}
+                    className="p-0"
+                    locale={locale}
+                    onBack={onBack}
+                    onPersonOpen={onPersonOpen}
+                    onOrganizationOpen={onOrganizationOpen}
+                    onCollectPayment={onCollectPayment}
+                    slots={bookingDetailSlots}
+                  />
+                )}
               </TabsContent>
 
               <TabsContent value="finance" className="mt-0">

--- a/packages/bookings-ui/tests/unit/booking-workspace-page.test.tsx
+++ b/packages/bookings-ui/tests/unit/booking-workspace-page.test.tsx
@@ -56,6 +56,25 @@ describe("BookingWorkspaceShell", () => {
     expect(html).toContain("Activity")
   })
 
+  it("allows consumers to replace the booking tab content", () => {
+    const html = renderToStaticMarkup(
+      <BookingWorkspaceShell
+        id={booking.id}
+        booking={booking}
+        slots={{
+          bookingTab: ({ bookingId, booking }) => (
+            <section>
+              Overview only {booking.bookingNumber} for {bookingId}
+            </section>
+          ),
+        }}
+      />,
+    )
+
+    expect(html).toContain("Overview only BK-123 for booking_123")
+    expect(html).not.toContain("Booking detail booking_123")
+  })
+
   it("renders typed workspace slots with bulk-action context", () => {
     const html = renderToStaticMarkup(
       <BookingWorkspaceShell


### PR DESCRIPTION
## Summary

Closes #915

- Adds a `bookingTab` slot to `BookingWorkspacePageSlots` so consumers can replace the default top-level booking tab content.
- Keeps the existing `BookingDetailPage` rendering unchanged when `bookingTab` is omitted.
- Documents the slot for apps that want top-level finance/legal/traveler/activity tabs without nested `BookingDetailPage` tabs.

## Validation

- `pnpm --filter @voyantjs/bookings-ui typecheck`
- `pnpm --filter @voyantjs/bookings-ui test`
- `pnpm --filter @voyantjs/bookings-ui lint`
- `pnpm --filter @voyantjs/bookings-ui build`
- `pnpm verify:package-exports`
- `git diff --check`
- `node scripts/check-agent-code-quality.mjs --changed --report-only`
- Commit hook: full workspace lint and typecheck passed
- Pre-push hook: full workspace `pnpm test` passed