### PR TITLE
Expose Better Auth user options

### DIFF
--- a/.changeset/quiet-rules-protect.md
+++ b/.changeset/quiet-rules-protect.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/auth": patch
+---
+
+Forward Better Auth `user` options from `createBetterAuth`, including `user.additionalFields`, while preserving Voyant's default change-email support.

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -23,6 +23,14 @@ const auth = createBetterAuth({
   db,
   secret: env.AUTH_SECRET,
   trustedOrigins: ["https://example.com"],
+  user: {
+    additionalFields: {
+      surfaces: {
+        type: "string",
+        required: false,
+      },
+    },
+  },
 })
 
 const profileResponse = await handleAccountProfileRequest(request, auth, { db })
@@ -36,6 +44,11 @@ return auth.handler(request)
 
 Auth provider wiring is template-owned — core Voyant packages only depend on
 the normalized `{ userId, actor }` contract, not on Better Auth specifically.
+
+`createBetterAuth` forwards Better Auth's `user` options, including
+`user.additionalFields`, while preserving Voyant's default change-email support.
+When using additional user fields with the Drizzle adapter, the consuming app is
+responsible for adding matching columns and migrations to the auth user table.
 
 The package also exposes a narrow shared-secret bearer-token helper surface via
 `@voyantjs/utils/session-claims` for runtime-local verification. That helper is

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -8,7 +8,7 @@ import {
   authVerification,
   userProfilesTable,
 } from "@voyantjs/db/schema/iam"
-import { betterAuth } from "better-auth"
+import { type BetterAuthOptions, betterAuth } from "better-auth"
 import { drizzleAdapter } from "better-auth/adapters/drizzle"
 import { emailOTP } from "better-auth/plugins"
 import type { BetterAuthPlugin } from "better-auth/types"
@@ -433,13 +433,40 @@ function expandTrustedOrigins(origins: string[], baseURL: string): string[] {
   return Array.from(new Set([...origins, ...LOCAL_WILDCARDS]))
 }
 
-export interface CreateBetterAuthOptions {
+type DefinedBetterAuthUserOptions<UserOptions extends BetterAuthOptions["user"]> =
+  UserOptions extends undefined ? Record<PropertyKey, never> : NonNullable<UserOptions>
+
+type ResolvedBetterAuthChangeEmail<UserOptions extends BetterAuthOptions["user"]> =
+  DefinedBetterAuthUserOptions<UserOptions> extends { changeEmail?: infer ChangeEmail }
+    ? ChangeEmail extends { enabled: infer Enabled }
+      ? Omit<ChangeEmail, "enabled"> & { enabled: Enabled }
+      : NonNullable<ChangeEmail> & { enabled: true }
+    : { enabled: true }
+
+type ResolvedBetterAuthUserOptions<UserOptions extends BetterAuthOptions["user"]> = Omit<
+  DefinedBetterAuthUserOptions<UserOptions>,
+  "changeEmail"
+> & {
+  changeEmail: ResolvedBetterAuthChangeEmail<UserOptions>
+}
+
+type ResolvedCreateBetterAuthOptions<UserOptions extends BetterAuthOptions["user"]> = Omit<
+  BetterAuthOptions,
+  "user"
+> & {
+  user: ResolvedBetterAuthUserOptions<UserOptions>
+}
+
+export interface CreateBetterAuthOptions<
+  UserOptions extends BetterAuthOptions["user"] = BetterAuthOptions["user"],
+> {
   db?: ReturnType<typeof getDb>
   secret?: string
   baseURL?: string
   basePath?: string
   trustedOrigins?: string[]
   plugins?: BetterAuthPlugin[]
+  user?: UserOptions
   /** Called when a user requests a password reset. If not provided, logs to console. */
   sendResetPassword?: (data: {
     user: { email: string; name: string }
@@ -456,7 +483,9 @@ export interface CreateBetterAuthOptions {
  * Accepts optional overrides for db, secret, baseURL, trustedOrigins.
  * Does NOT depend on Next.js — safe to use in Hono workers, TanStack Start, etc.
  */
-export function createBetterAuth(options: CreateBetterAuthOptions = {}) {
+export function createBetterAuth<const UserOptions extends BetterAuthOptions["user"] = undefined>(
+  options: CreateBetterAuthOptions<UserOptions> = {},
+) {
   const db = options.db ?? getDb("edge")
   const secret = options.secret ?? getAuthSecret()
   const baseURL =
@@ -471,7 +500,7 @@ export function createBetterAuth(options: CreateBetterAuthOptions = {}) {
   )
   const extraPlugins = options.plugins ?? []
 
-  return betterAuth({
+  const authOptions = {
     appName: "Voyant",
     baseURL,
     ...(options.basePath ? { basePath: options.basePath } : {}),
@@ -506,10 +535,12 @@ export function createBetterAuth(options: CreateBetterAuthOptions = {}) {
       autoSignInAfterVerification: true,
     },
     user: {
+      ...options.user,
       changeEmail: {
         enabled: true,
+        ...options.user?.changeEmail,
       },
-    },
+    } as ResolvedBetterAuthUserOptions<UserOptions>,
     socialProviders: {
       google: {
         clientId: process.env.GOOGLE_CLIENT_ID || "",
@@ -586,5 +617,7 @@ export function createBetterAuth(options: CreateBetterAuthOptions = {}) {
     advanced: {
       useSecureCookies: process.env.NODE_ENV === "production",
     },
-  })
+  } as ResolvedCreateBetterAuthOptions<UserOptions>
+
+  return betterAuth<ResolvedCreateBetterAuthOptions<UserOptions>>(authOptions)
 }

--- a/packages/auth/tests/unit/create-better-auth.test.ts
+++ b/packages/auth/tests/unit/create-better-auth.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { CreateBetterAuthOptions } from "../../src/server.js"
+
+const { betterAuthMock, drizzleAdapterMock } = vi.hoisted(() => ({
+  betterAuthMock: vi.fn((config: Record<string, unknown>) => ({ config })),
+  drizzleAdapterMock: vi.fn(() => ({ adapter: "drizzle" })),
+}))
+
+vi.mock("@better-auth/api-key", () => ({
+  apiKey: vi.fn((options: Record<string, unknown>) => ({ id: "apiKey", options })),
+}))
+
+vi.mock("@voyantjs/db", () => ({
+  getDb: vi.fn(() => ({ id: "default-db" })),
+}))
+
+vi.mock("@voyantjs/db/schema/iam", () => ({
+  apikeyTable: { name: "apikey" },
+  authAccount: { name: "account" },
+  authSession: { name: "session" },
+  authUser: { name: "user" },
+  authVerification: { name: "verification" },
+  userProfilesTable: { name: "userProfiles" },
+}))
+
+vi.mock("better-auth", () => ({
+  betterAuth: betterAuthMock,
+}))
+
+vi.mock("better-auth/adapters/drizzle", () => ({
+  drizzleAdapter: drizzleAdapterMock,
+}))
+
+vi.mock("better-auth/plugins", () => ({
+  emailOTP: vi.fn((options: Record<string, unknown>) => ({ id: "emailOTP", options })),
+}))
+
+describe("createBetterAuth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("forwards Better Auth user options and keeps Voyant's default change-email setting", async () => {
+    const { createBetterAuth } = await import("../../src/server.js")
+    const user = {
+      additionalFields: {
+        surfaces: {
+          type: "string",
+          required: false,
+          input: true,
+        },
+      },
+      deleteUser: {
+        enabled: true,
+      },
+    } satisfies NonNullable<CreateBetterAuthOptions["user"]>
+
+    createBetterAuth({
+      db: { id: "db" } as never,
+      secret: "x".repeat(32),
+      baseURL: "https://auth.example.com",
+      user,
+    })
+
+    expect(betterAuthMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user: {
+          ...user,
+          changeEmail: {
+            enabled: true,
+          },
+        },
+      }),
+    )
+  })
+
+  it("lets consumers override the default change-email setting", async () => {
+    const { createBetterAuth } = await import("../../src/server.js")
+
+    createBetterAuth({
+      db: { id: "db" } as never,
+      secret: "x".repeat(32),
+      baseURL: "https://auth.example.com",
+      user: {
+        changeEmail: {
+          enabled: false,
+        },
+      },
+    })
+
+    expect(betterAuthMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user: {
+          changeEmail: {
+            enabled: false,
+          },
+        },
+      }),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- Forward Better Auth `user` options through `createBetterAuth`, including `user.additionalFields`.
- Preserve Voyant's default `changeEmail.enabled = true` while allowing callers to override it.
- Preserve additional user field inference on `typeof auth.$Infer.Session.user`.
- Document the Drizzle migration responsibility for additional user fields and add a patch changeset.

## Validation

- `pnpm --filter @voyantjs/auth lint`
- `pnpm --filter @voyantjs/auth typecheck`
- `pnpm --filter @voyantjs/auth test`
- `pnpm --filter @voyantjs/auth build`
- Standalone TypeScript inference check for `session.user.surfaces`
- `pnpm test`: 126 workspace test tasks passed

Fixes #918