### PR TITLE
Support Better Auth plugin schemas

### DIFF
--- a/.changeset/auth-plugin-schema.md
+++ b/.changeset/auth-plugin-schema.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/auth": patch
+---
+
+Allow Better Auth plugin Drizzle tables to be passed through createBetterAuth.

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -50,6 +50,29 @@ the normalized `{ userId, actor }` contract, not on Better Auth specifically.
 When using additional user fields with the Drizzle adapter, the consuming app is
 responsible for adding matching columns and migrations to the auth user table.
 
+Better Auth server plugins that define their own tables must pass those Drizzle
+tables through `extraSchema` so the shared Drizzle adapter can resolve them:
+
+```typescript
+import { createBetterAuth } from "@voyantjs/auth/server"
+import { authInvitation, authMember, authOrganization } from "@voyantjs/db/schema/iam"
+import { organization } from "better-auth/plugins"
+
+const auth = createBetterAuth({
+  db,
+  plugins: [organization()],
+  extraSchema: {
+    organization: authOrganization,
+    member: authMember,
+    invitation: authInvitation,
+  },
+})
+```
+
+The app that mounts the plugin owns the plugin migrations. `extraSchema` only
+connects existing Drizzle table definitions to Better Auth; it does not create
+or run migrations.
+
 The package also exposes a narrow shared-secret bearer-token helper surface via
 `@voyantjs/utils/session-claims` for runtime-local verification. That helper is
 not a replacement for Better Auth session cookies and does not imply a

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -13,6 +13,7 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle"
 import { emailOTP } from "better-auth/plugins"
 import type { BetterAuthPlugin } from "better-auth/types"
 import { sql } from "drizzle-orm"
+import type { AnyPgTable } from "drizzle-orm/pg-core"
 
 import {
   type ApiTokenRotationOptions,
@@ -450,22 +451,38 @@ type ResolvedBetterAuthUserOptions<UserOptions extends BetterAuthOptions["user"]
   changeEmail: ResolvedBetterAuthChangeEmail<UserOptions>
 }
 
-type ResolvedCreateBetterAuthOptions<UserOptions extends BetterAuthOptions["user"]> = Omit<
-  BetterAuthOptions,
-  "user"
-> & {
+type VoyantBetterAuthPlugins = [ReturnType<typeof apiKey>, ReturnType<typeof emailOTP>]
+
+type ResolvedBetterAuthPlugins<Plugins extends BetterAuthPlugin[] | undefined> =
+  Plugins extends BetterAuthPlugin[]
+    ? [...VoyantBetterAuthPlugins, ...Plugins]
+    : VoyantBetterAuthPlugins
+
+type ResolvedCreateBetterAuthOptions<
+  UserOptions extends BetterAuthOptions["user"],
+  Plugins extends BetterAuthPlugin[] | undefined,
+> = Omit<BetterAuthOptions, "plugins" | "user"> & {
+  plugins: ResolvedBetterAuthPlugins<Plugins>
   user: ResolvedBetterAuthUserOptions<UserOptions>
 }
 
+export type BetterAuthDrizzleSchema = Record<string, AnyPgTable>
+
 export interface CreateBetterAuthOptions<
   UserOptions extends BetterAuthOptions["user"] = BetterAuthOptions["user"],
+  Plugins extends BetterAuthPlugin[] | undefined = BetterAuthPlugin[] | undefined,
 > {
   db?: ReturnType<typeof getDb>
   secret?: string
   baseURL?: string
   basePath?: string
   trustedOrigins?: string[]
-  plugins?: BetterAuthPlugin[]
+  /**
+   * Additional Drizzle tables for Better Auth plugins. The consuming app owns
+   * matching migrations for every table passed here.
+   */
+  extraSchema?: BetterAuthDrizzleSchema
+  plugins?: Plugins
   user?: UserOptions
   /** Called when a user requests a password reset. If not provided, logs to console. */
   sendResetPassword?: (data: {
@@ -483,9 +500,10 @@ export interface CreateBetterAuthOptions<
  * Accepts optional overrides for db, secret, baseURL, trustedOrigins.
  * Does NOT depend on Next.js — safe to use in Hono workers, TanStack Start, etc.
  */
-export function createBetterAuth<const UserOptions extends BetterAuthOptions["user"] = undefined>(
-  options: CreateBetterAuthOptions<UserOptions> = {},
-) {
+export function createBetterAuth<
+  const UserOptions extends BetterAuthOptions["user"] = undefined,
+  const Plugins extends BetterAuthPlugin[] | undefined = undefined,
+>(options: CreateBetterAuthOptions<UserOptions, Plugins> = {}) {
   const db = options.db ?? getDb("edge")
   const secret = options.secret ?? getAuthSecret()
   const baseURL =
@@ -499,6 +517,14 @@ export function createBetterAuth<const UserOptions extends BetterAuthOptions["us
     baseURL,
   )
   const extraPlugins = options.plugins ?? []
+  const schema = {
+    user: authUser,
+    session: authSession,
+    account: authAccount,
+    verification: authVerification,
+    apikey: apikeyTable,
+    ...(options.extraSchema ?? {}),
+  } satisfies BetterAuthDrizzleSchema
 
   const authOptions = {
     appName: "Voyant",
@@ -507,13 +533,7 @@ export function createBetterAuth<const UserOptions extends BetterAuthOptions["us
     secret,
     database: drizzleAdapter(db, {
       provider: "pg",
-      schema: {
-        user: authUser,
-        session: authSession,
-        account: authAccount,
-        verification: authVerification,
-        apikey: apikeyTable,
-      },
+      schema,
     }),
     emailAndPassword: {
       enabled: true,
@@ -573,7 +593,7 @@ export function createBetterAuth<const UserOptions extends BetterAuthOptions["us
         },
       }),
       ...extraPlugins,
-    ],
+    ] as ResolvedBetterAuthPlugins<Plugins>,
     databaseHooks: {
       user: {
         create: {
@@ -617,7 +637,7 @@ export function createBetterAuth<const UserOptions extends BetterAuthOptions["us
     advanced: {
       useSecureCookies: process.env.NODE_ENV === "production",
     },
-  } as ResolvedCreateBetterAuthOptions<UserOptions>
+  } as ResolvedCreateBetterAuthOptions<UserOptions, Plugins>
 
-  return betterAuth<ResolvedCreateBetterAuthOptions<UserOptions>>(authOptions)
+  return betterAuth<ResolvedCreateBetterAuthOptions<UserOptions, Plugins>>(authOptions)
 }

--- a/packages/auth/tests/unit/create-better-auth.test.ts
+++ b/packages/auth/tests/unit/create-better-auth.test.ts
@@ -99,4 +99,32 @@ describe("createBetterAuth", () => {
       }),
     )
   })
+
+  it("merges extra Better Auth plugin tables into the Drizzle adapter schema", async () => {
+    const { createBetterAuth } = await import("../../src/server.js")
+    const jwksTable = { name: "jwks" }
+
+    createBetterAuth({
+      db: { id: "db" } as never,
+      secret: "x".repeat(32),
+      baseURL: "https://auth.example.com",
+      extraSchema: {
+        jwks: jwksTable,
+      } as never,
+    })
+
+    const [, adapterConfig] = drizzleAdapterMock.mock.calls[0] as [
+      unknown,
+      { schema: Record<string, unknown> },
+    ]
+
+    expect(adapterConfig.schema).toMatchObject({
+      user: { name: "user" },
+      session: { name: "session" },
+      account: { name: "account" },
+      verification: { name: "verification" },
+      apikey: { name: "apikey" },
+      jwks: jwksTable,
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Add `extraSchema` to `createBetterAuth` so consumer-mounted Better Auth plugins can provide their Drizzle tables to the shared adapter.
- Preserve consumer plugin tuple types when composing Voyant's built-in auth plugins with extra plugins.
- Document plugin table wiring and migration ownership, with a regression test for adapter schema merging.

Closes #919.

## Validation

- `pnpm --filter @voyantjs/auth typecheck`
- `pnpm --filter @voyantjs/auth test`
- `pnpm --filter @voyantjs/auth lint`
- `pnpm --filter @voyantjs/auth build`
- `git diff --check`
- Pre-push `pnpm test` hook: 126 tasks passed

Note: the pre-commit broad Turbo typecheck was stopped after it hung with no failing output; the auth package typecheck and build completed successfully.