### PR TITLE
feat(availability): consume allocation_resources from storefront and bookings

### DIFF
--- a/apps/dev/migrations/0027_resource_template_default_count.sql
+++ b/apps/dev/migrations/0027_resource_template_default_count.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "product_option_resource_templates"
+  ADD COLUMN IF NOT EXISTS "default_count" integer;

--- a/docs/architecture/allocation-resources-lifecycle.md
+++ b/docs/architecture/allocation-resources-lifecycle.md
@@ -1,0 +1,108 @@
+# Allocation resources lifecycle
+
+`allocation_resources` is the per-slot inventory primitive used by
+tour/circuit products where an operator buys a fixed block from a
+supplier per departure (a hotel allotment, a vehicle's seat map, a
+guide roster, etc.). It sits next to the existing `availability_slots`
+pax bucket — slot-level pax is the gross capacity, and resources break
+that capacity into typed, individually-bookable units.
+
+## Tables
+
+- **`product_option_resource_templates`** (catalog) — the canonical
+  resource mix per `product_option`. Stores `kind`, `capacity` per
+  resource, a `name_pattern` for label rendering, and `default_count`
+  (how many to instantiate per slot).
+- **`allocation_resources`** (per-slot) — the materialised instances
+  for one `availability_slot`. Cascades on slot delete.
+- **`booking_traveler_travel_details.allocations`** (`jsonb`) — maps
+  `kind → resource_id` for one traveler.
+
+## Lifecycle
+
+```
+catalog                slot publish               admin / auto             read-side
+─────────              ────────────               ─────────────            ──────────
+template (DBL, cap 2, ──► generateAvailability   ─► allocation_resources ──► storefront
+ default_count 20)       Slots() seeds resources    (20 DBL rooms with     resourceManifest
+                         from template defaults    sortOrder labels)       (capacity / assigned
+                                                                            / available)
+
+                                                                          bookings.create
+                                                                          TravelerWithTravel
+                                                                          Details enforces
+                                                                          per-resource cap.
+```
+
+### 1. Catalog: templates
+
+Operators describe each option's room mix once at the catalog level
+via `productOptionResourceTemplates`. Each row carries:
+
+- `kind` — e.g. `"room_sgl"`, `"room_dbl"`, `"room_tpl"`,
+  `"vehicle_seat"`.
+- `capacity` — pax per instance.
+- `name_pattern` — `"DBL {sequence}"` rendered when a resource is
+  created.
+- `default_count` — how many of this template to instantiate per
+  slot at publish time. **`null` disables auto-materialisation** —
+  the operator must seed resources manually or via the admin
+  "auto-materialise" route once bookings exist.
+
+### 2. Slot publish: auto-materialisation
+
+`generateAvailabilitySlots()` calls
+`materializeSlotResourcesFromTemplateDefaults()` for every newly-
+created slot whose `optionId` has templates with a non-null
+`default_count`. The helper is idempotent — kinds already seeded for
+the slot are skipped, so re-running `generateAvailabilitySlots` after
+an admin override won't blow away custom inventory.
+
+Vehicle-seat layouts (`kind === "vehicle_seat"`) are intentionally
+out of scope for the default-count path — they need pax-aware
+hierarchy (vehicle parent + seat children). Use the admin
+`autoMaterializeAllocationResources` route for those once the slot
+has bookings.
+
+### 3. Admin overrides
+
+Operators can:
+
+- Add/edit/delete `allocation_resources` for a slot directly.
+- Re-seed a kind from templates via the admin route after deleting
+  the current resources for that kind.
+- Manually assign/unassign travelers to resources via
+  `assignTravelerAllocation()` — the per-resource capacity check
+  there matches the one used during booking creation.
+
+### 4. Read-side: storefront
+
+Storefront's departure response now includes a `resourceManifest`:
+
+```jsonc
+{
+  "kinds":     [{ "kind": "room_dbl", "capacity": 40, "assigned": 6, "available": 34 }],
+  "resources": [
+    { "id": "alrs_…", "kind": "room_dbl", "label": "DBL 1",
+      "capacity": 2, "assigned": 2, "available": 0, "flags": {…}, … }
+  ]
+}
+```
+
+`assigned` is a DISTINCT-traveler count across live bookings on the
+slot — same logic the per-traveler assignment guard uses, so the
+read-side and write-side agree.
+
+### 5. Booking: per-resource enforcement
+
+`bookings.createTravelerWithTravelDetails` /
+`updateTravelerWithTravelDetails` validate any
+`travelDetails.allocations` payload against per-resource capacity
+before persisting. A request that fits inside the slot's
+`remaining_pax` but oversells a specific resource is rejected with
+`BookingServiceError.code === "resource_capacity_exhausted"` citing
+the offending resource (`kind`, `resourceId`, `capacity`,
+`existingAssigned`).
+
+The slot-level pax check (`adjustSlotCapacity`) still runs at
+reservation time — both gates must pass for a booking to confirm.

--- a/packages/availability/src/generate-slots.ts
+++ b/packages/availability/src/generate-slots.ts
@@ -3,6 +3,7 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { expandRRule } from "./rrule.js"
 import { availabilityRules, availabilitySlots } from "./schema.js"
+import { materializeSlotResourcesFromTemplateDefaults } from "./service-allocation-automation.js"
 
 export type GenerateAvailabilitySlotsOptions = {
   /** If provided, only generate slots for this rule. Otherwise, process all active rules. */
@@ -15,12 +16,20 @@ export type GenerateAvailabilitySlotsOptions = {
   perRuleLimit?: number
   /** Override "now" for deterministic generation. Defaults to new Date(). */
   now?: Date
+  /**
+   * Auto-seed `allocation_resources` for each freshly-created slot from
+   * its option's `product_option_resource_templates.default_count`.
+   * Templates without `default_count` are still skipped — those need
+   * pax-aware materialisation via the admin route. Defaults to true.
+   */
+  materializeResources?: boolean
 }
 
 export type GenerateAvailabilitySlotsResult = {
   rulesProcessed: number
   slotsCreated: number
   slotsSkipped: number
+  resourcesMaterialized: number
 }
 
 /**
@@ -38,6 +47,7 @@ export async function generateAvailabilitySlots(
   const defaultStartTime = options.defaultStartTime ?? "09:00"
   const perRuleLimit = options.perRuleLimit ?? 1000
   const now = options.now ?? new Date()
+  const shouldMaterializeResources = options.materializeResources !== false
 
   const from = new Date(now)
   from.setUTCHours(0, 0, 0, 0)
@@ -54,6 +64,7 @@ export async function generateAvailabilitySlots(
 
   let slotsCreated = 0
   let slotsSkipped = 0
+  let resourcesMaterialized = 0
 
   for (const rule of rules) {
     const dates = expandRRule(rule.recurrenceRule, from, to, perRuleLimit)
@@ -101,13 +112,25 @@ export async function generateAvailabilitySlots(
       }
     })
 
-    await db.insert(availabilitySlots).values(rows)
-    slotsCreated += rows.length
+    const inserted = await db
+      .insert(availabilitySlots)
+      .values(rows)
+      .returning({ id: availabilitySlots.id, optionId: availabilitySlots.optionId })
+    slotsCreated += inserted.length
+
+    if (shouldMaterializeResources && rule.optionId) {
+      for (const created of inserted) {
+        if (!created.optionId) continue
+        const result = await materializeSlotResourcesFromTemplateDefaults(db, created.id)
+        resourcesMaterialized += result.created
+      }
+    }
   }
 
   return {
     rulesProcessed: rules.length,
     slotsCreated,
     slotsSkipped,
+    resourcesMaterialized,
   }
 }

--- a/packages/availability/src/index.ts
+++ b/packages/availability/src/index.ts
@@ -74,6 +74,18 @@ export {
   sharingGroupLabels,
 } from "./schema.js"
 export {
+  getSlotResourceAvailability,
+  getSlotsResourceAvailability,
+  type PlannedAllocation,
+  type ResourceCapacityViolation,
+  type SlotResourceAvailability,
+  validateSlotAllocationCapacity,
+} from "./service-allocation.js"
+export {
+  type MaterializeSlotResourcesFromTemplatesOptions,
+  materializeSlotResourcesFromTemplateDefaults,
+} from "./service-allocation-automation.js"
+export {
   allocationExportFilename,
   buildAllocationPassengersCsv,
   buildAllocationRoomingCsv,

--- a/packages/availability/src/schema.ts
+++ b/packages/availability/src/schema.ts
@@ -226,6 +226,14 @@ export const productOptionResourceTemplates = pgTable(
     capacity: integer("capacity").notNull(),
     namePattern: text("name_pattern").notNull(),
     layout: text("layout"),
+    /**
+     * How many resources to instantiate per slot when auto-materialising
+     * from this template (e.g. "5 SGL, 20 DBL"). Null skips the
+     * template during slot-publish auto-seed — admins must seed those
+     * resources manually or via `autoMaterializeAllocationResources`
+     * once bookings exist.
+     */
+    defaultCount: integer("default_count"),
     flags: jsonb("flags").$type<Record<string, unknown>>().notNull().default({}),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/availability/src/service-allocation-automation.ts
+++ b/packages/availability/src/service-allocation-automation.ts
@@ -39,6 +39,7 @@ export interface ResourceTemplate {
   capacity: number
   namePattern: string
   layout: string | null
+  defaultCount: number | null
   flags: Record<string, unknown>
   createdAt: string
   updatedAt: string
@@ -83,7 +84,7 @@ export async function listProductOptionResourceTemplates(
   const templateRows = await executeRows<ResourceTemplateRow>(
     db,
     sql`
-      SELECT id, product_option_id, kind, ref_type, ref_id, capacity, name_pattern, layout, flags, created_at, updated_at
+      SELECT id, product_option_id, kind, ref_type, ref_id, capacity, name_pattern, layout, default_count, flags, created_at, updated_at
       FROM product_option_resource_templates
       WHERE product_option_id = ANY(${optionIds}::text[])
       ORDER BY kind, created_at
@@ -128,6 +129,7 @@ export async function upsertProductOptionResourceTemplate(
       capacity: input.capacity,
       namePattern: input.namePattern,
       layout: input.layout ?? null,
+      defaultCount: input.defaultCount ?? null,
       flags: input.flags ?? {},
     })
     .onConflictDoUpdate({
@@ -138,6 +140,7 @@ export async function upsertProductOptionResourceTemplate(
         capacity: input.capacity,
         namePattern: input.namePattern,
         layout: input.layout ?? null,
+        defaultCount: input.defaultCount ?? null,
         flags: input.flags ?? {},
         updatedAt: new Date(),
       },
@@ -154,6 +157,7 @@ export async function upsertProductOptionResourceTemplate(
     capacity: row.capacity,
     namePattern: row.namePattern,
     layout: row.layout,
+    defaultCount: row.defaultCount,
     flags: row.flags,
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
@@ -375,6 +379,100 @@ export async function autoAllocateSlotResources(
   return { kind, assigned: plan.assignments.length, skipped: plan.skipped }
 }
 
+export interface MaterializeSlotResourcesFromTemplatesOptions {
+  /**
+   * Restrict materialisation to a single template kind. When omitted,
+   * all templates with a non-null `defaultCount` for the slot's option
+   * are seeded.
+   */
+  kind?: string
+  /**
+   * Skip templates whose `kind` already has resources for the slot.
+   * Defaults to true so the helper is safe to call repeatedly during
+   * slot generation.
+   */
+  skipExisting?: boolean
+}
+
+/**
+ * Auto-seed `allocation_resources` for a freshly-published slot from
+ * its option's `product_option_resource_templates` rows that declare a
+ * `default_count`. Distinct from `autoMaterializeAllocationResources`,
+ * which derives counts from existing bookings. Templates without
+ * `default_count` are skipped — operators handle those via the admin
+ * materialise route once pax is known.
+ *
+ * Vehicle-seat layouts are out of scope here; use the existing
+ * `autoMaterializeAllocationResources` path for those once the slot
+ * has bookings (it knows pax-per-option).
+ */
+export async function materializeSlotResourcesFromTemplateDefaults(
+  db: PostgresJsDatabase,
+  slotId: string,
+  opts: MaterializeSlotResourcesFromTemplatesOptions = {},
+): Promise<{ created: number; resources: AllocationResource[] }> {
+  const [slot] = await db
+    .select({ id: availabilitySlots.id, optionId: availabilitySlots.optionId })
+    .from(availabilitySlots)
+    .where(eq(availabilitySlots.id, slotId))
+    .limit(1)
+  if (!slot?.optionId) return { created: 0, resources: [] }
+
+  const templateConditions = [eq(productOptionResourceTemplates.productOptionId, slot.optionId)]
+  if (opts.kind) {
+    templateConditions.push(eq(productOptionResourceTemplates.kind, opts.kind))
+  }
+
+  const templates = await db
+    .select()
+    .from(productOptionResourceTemplates)
+    .where(and(...templateConditions))
+    .orderBy(productOptionResourceTemplates.kind, productOptionResourceTemplates.createdAt)
+
+  if (templates.length === 0) return { created: 0, resources: [] }
+
+  const skipExisting = opts.skipExisting !== false
+  const existing = skipExisting
+    ? await executeRows<{ kind: string }>(
+        db,
+        sql`SELECT DISTINCT kind FROM allocation_resources WHERE slot_id = ${slotId}`,
+      )
+    : []
+  const existingKinds = new Set(existing.map((row) => row.kind))
+
+  const resources: AllocationResource[] = []
+  let sequence = 0
+
+  for (const template of templates) {
+    if (template.defaultCount == null || template.defaultCount <= 0) continue
+    if (template.kind === "vehicle_seat") continue
+    if (skipExisting && existingKinds.has(template.kind)) continue
+
+    for (let index = 0; index < template.defaultCount; index++) {
+      sequence += 1
+      const [row] = await db
+        .insert(allocationResources)
+        .values({
+          slotId,
+          kind: template.kind,
+          refType: template.refType,
+          refId: template.refId,
+          label: renderNamePattern(template.namePattern, {
+            sequence: String(sequence),
+            index: String(index + 1),
+          }),
+          capacity: template.capacity,
+          flags: { ...(template.flags ?? {}), templateOptionId: template.productOptionId },
+          sortOrder: sequence,
+        })
+        .returning()
+      if (row) resources.push(row)
+    }
+  }
+
+  return { created: resources.length, resources }
+}
+
 async function materializeVehicleSeatGroup(
   db: PostgresJsDatabase,
   slotId: string,
@@ -460,6 +558,7 @@ function toResourceTemplate(row: ResourceTemplateRow): ResourceTemplate {
     capacity: row.capacity,
     namePattern: row.name_pattern,
     layout: row.layout,
+    defaultCount: row.default_count ?? null,
     flags: row.flags ?? {},
     createdAt: new Date(row.created_at).toISOString(),
     updatedAt: new Date(row.updated_at).toISOString(),
@@ -566,6 +665,7 @@ interface ResourceTemplateRow {
   capacity: number
   name_pattern: string
   layout: string | null
+  default_count: number | null
   flags: Record<string, unknown>
   created_at: string | Date
   updated_at: string | Date

--- a/packages/availability/src/service-allocation.ts
+++ b/packages/availability/src/service-allocation.ts
@@ -224,6 +224,239 @@ export async function listAllocationResources(db: PostgresJsDatabase, slotId: st
     )
 }
 
+/**
+ * Per-resource availability summary for a single slot: capacity, how
+ * many travelers are currently assigned to that resource (across all
+ * live bookings on the slot), and the resulting remaining headroom.
+ * The summary is consumer-facing — `assigned` is the same DISTINCT-
+ * traveler count `countResourceOccupants` uses internally, so the
+ * read-side and the per-traveler assignment guardrail agree.
+ *
+ * Returned in (kind, sortOrder, createdAt) order so consumers can
+ * render rooming grids without resorting.
+ */
+export interface SlotResourceAvailability {
+  id: string
+  slotId: string
+  kind: string
+  label: string | null
+  refType: string | null
+  refId: string | null
+  parentId: string | null
+  capacity: number
+  assigned: number
+  available: number
+  flags: Record<string, unknown>
+  sortOrder: number
+}
+
+export async function getSlotResourceAvailability(
+  db: PostgresJsDatabase,
+  slotId: string,
+): Promise<SlotResourceAvailability[]> {
+  const map = await getSlotsResourceAvailability(db, [slotId])
+  return map.get(slotId) ?? []
+}
+
+export async function getSlotsResourceAvailability(
+  db: PostgresJsDatabase,
+  slotIds: string[],
+): Promise<Map<string, SlotResourceAvailability[]>> {
+  const uniqueIds = [...new Set(slotIds)].filter(Boolean)
+  if (uniqueIds.length === 0) return new Map()
+
+  const rows = await executeRows<{
+    id: string
+    slot_id: string
+    kind: string
+    label: string | null
+    ref_type: string | null
+    ref_id: string | null
+    parent_id: string | null
+    capacity: number
+    assigned: number
+    flags: Record<string, unknown> | null
+    sort_order: number
+  }>(
+    db,
+    sql`
+      SELECT
+        ar.id,
+        ar.slot_id,
+        ar.kind,
+        ar.label,
+        ar.ref_type,
+        ar.ref_id,
+        ar.parent_id,
+        ar.capacity,
+        COALESCE(usage.assigned, 0)::int AS assigned,
+        ar.flags,
+        ar.sort_order
+      FROM allocation_resources ar
+      LEFT JOIN LATERAL (
+        SELECT COUNT(DISTINCT btd.traveler_id)::int AS assigned
+        FROM booking_traveler_travel_details btd
+        JOIN booking_travelers bt ON bt.id = btd.traveler_id
+        JOIN booking_allocations ba ON ba.booking_id = bt.booking_id
+        JOIN bookings b ON b.id = bt.booking_id
+        WHERE btd.allocations ->> ar.kind = ar.id
+          AND ba.availability_slot_id = ar.slot_id
+          AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
+          AND ba.status IN ('held', 'confirmed', 'fulfilled')
+      ) usage ON true
+      WHERE ar.slot_id = ANY(${uniqueIds}::text[])
+      ORDER BY ar.slot_id, ar.kind, ar.sort_order, ar.created_at
+    `,
+  )
+
+  const out = new Map<string, SlotResourceAvailability[]>()
+  for (const row of rows) {
+    const capacity = row.capacity
+    const assigned = row.assigned ?? 0
+    const list = out.get(row.slot_id) ?? []
+    list.push({
+      id: row.id,
+      slotId: row.slot_id,
+      kind: row.kind,
+      label: row.label,
+      refType: row.ref_type,
+      refId: row.ref_id,
+      parentId: row.parent_id,
+      capacity,
+      assigned,
+      available: Math.max(0, capacity - assigned),
+      flags: row.flags ?? {},
+      sortOrder: row.sort_order,
+    })
+    out.set(row.slot_id, list)
+  }
+  return out
+}
+
+export interface PlannedAllocation {
+  /** Traveler id whose allocation is being planned. */
+  travelerId: string
+  /** Resource kind, e.g. "room" or "vehicle_seat". */
+  kind: string
+  /** Resource id the traveler is being assigned to. */
+  resourceId: string
+}
+
+export interface ResourceCapacityViolation {
+  slotId: string
+  resourceId: string
+  kind: string
+  capacity: number
+  existingAssigned: number
+  requested: number
+}
+
+/**
+ * Validate that a batch of planned traveler→resource assignments fits
+ * inside the per-resource capacity of the given slot. Read-only —
+ * callers run this before persisting so they can surface
+ * `resource_capacity_exhausted` with the offending resource cited.
+ *
+ * Travelers in `planned` are deduped per (kind, resourceId) so the
+ * caller can pass the full booking payload (one row per traveler)
+ * without inflating the count. Existing usage already credited to a
+ * traveler being re-planned is excluded so re-saving the same payload
+ * is idempotent.
+ */
+export async function validateSlotAllocationCapacity(
+  db: PostgresJsDatabase,
+  slotId: string,
+  planned: PlannedAllocation[],
+): Promise<ResourceCapacityViolation[]> {
+  if (planned.length === 0) return []
+
+  const byResource = new Map<string, { kind: string; travelerIds: Set<string> }>()
+  for (const entry of planned) {
+    if (!entry.resourceId || !entry.kind) continue
+    const bucket = byResource.get(entry.resourceId) ?? {
+      kind: entry.kind,
+      travelerIds: new Set<string>(),
+    }
+    bucket.travelerIds.add(entry.travelerId)
+    byResource.set(entry.resourceId, bucket)
+  }
+
+  if (byResource.size === 0) return []
+
+  const resourceIds = [...byResource.keys()]
+  const resources = await executeRows<{
+    id: string
+    kind: string
+    capacity: number
+    slot_id: string
+  }>(
+    db,
+    sql`
+      SELECT id, kind, capacity, slot_id
+      FROM allocation_resources
+      WHERE slot_id = ${slotId} AND id = ANY(${resourceIds}::text[])
+    `,
+  )
+  const resourceById = new Map(resources.map((r) => [r.id, r]))
+
+  const violations: ResourceCapacityViolation[] = []
+  for (const [resourceId, plan] of byResource) {
+    const resource = resourceById.get(resourceId)
+    if (!resource) {
+      violations.push({
+        slotId,
+        resourceId,
+        kind: plan.kind,
+        capacity: 0,
+        existingAssigned: 0,
+        requested: plan.travelerIds.size,
+      })
+      continue
+    }
+    if (resource.kind !== plan.kind) {
+      violations.push({
+        slotId,
+        resourceId,
+        kind: plan.kind,
+        capacity: resource.capacity,
+        existingAssigned: 0,
+        requested: plan.travelerIds.size,
+      })
+      continue
+    }
+
+    const travelerIdsArr = [...plan.travelerIds]
+    const existingRows = await executeRows<{ count: number }>(
+      db,
+      sql`
+        SELECT COUNT(DISTINCT btd.traveler_id)::int AS count
+        FROM booking_traveler_travel_details btd
+        JOIN booking_travelers bt ON bt.id = btd.traveler_id
+        JOIN booking_allocations ba ON ba.booking_id = bt.booking_id
+        JOIN bookings b ON b.id = bt.booking_id
+        WHERE btd.allocations ->> ${plan.kind} = ${resourceId}
+          AND ba.availability_slot_id = ${slotId}
+          AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
+          AND ba.status IN ('held', 'confirmed', 'fulfilled')
+          AND btd.traveler_id <> ALL(${travelerIdsArr}::text[])
+      `,
+    )
+    const existingAssigned = existingRows[0]?.count ?? 0
+    const total = existingAssigned + plan.travelerIds.size
+    if (total > resource.capacity) {
+      violations.push({
+        slotId,
+        resourceId,
+        kind: plan.kind,
+        capacity: resource.capacity,
+        existingAssigned,
+        requested: plan.travelerIds.size,
+      })
+    }
+  }
+  return violations
+}
+
 export async function createAllocationResource(
   db: PostgresJsDatabase,
   slotId: string,

--- a/packages/availability/src/service-allocation.ts
+++ b/packages/availability/src/service-allocation.ts
@@ -384,6 +384,11 @@ export async function validateSlotAllocationCapacity(
   if (byResource.size === 0) return []
 
   const resourceIds = [...byResource.keys()]
+  // Lock the targeted rows so a concurrent caller cannot pass the
+  // same check before this one persists. Callers must run inside a
+  // transaction for the lock to span until commit; outside one this
+  // is the same race as before, but the helper at least documents
+  // the contract.
   const resources = await executeRows<{
     id: string
     kind: string
@@ -395,6 +400,7 @@ export async function validateSlotAllocationCapacity(
       SELECT id, kind, capacity, slot_id
       FROM allocation_resources
       WHERE slot_id = ${slotId} AND id = ANY(${resourceIds}::text[])
+      FOR UPDATE
     `,
   )
   const resourceById = new Map(resources.map((r) => [r.id, r]))

--- a/packages/availability/src/validation.ts
+++ b/packages/availability/src/validation.ts
@@ -164,6 +164,7 @@ export const upsertResourceTemplateSchema = z.object({
   refType: z.string().trim().min(1).nullable().optional(),
   refId: z.string().trim().min(1).nullable().optional(),
   layout: z.string().trim().min(1).nullable().optional(),
+  defaultCount: z.number().int().min(0).nullable().optional(),
   flags: allocationResourceFlagsSchema.default({}),
 })
 

--- a/packages/availability/tests/integration/materialize-template-defaults.test.ts
+++ b/packages/availability/tests/integration/materialize-template-defaults.test.ts
@@ -1,0 +1,145 @@
+import { newId } from "@voyantjs/db/lib/typeid"
+import { cleanupTestDb, createTestDb } from "@voyantjs/db/test-utils"
+import { productOptions, products } from "@voyantjs/products/schema"
+import { sql } from "drizzle-orm"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { generateAvailabilitySlots } from "../../src/generate-slots.js"
+import {
+  availabilityRules,
+  availabilitySlots,
+  productOptionResourceTemplates,
+} from "../../src/schema.js"
+import { materializeSlotResourcesFromTemplateDefaults } from "../../src/service-allocation-automation.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+describe.skipIf(!DB_AVAILABLE)("materialize template defaults (integration)", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: drizzle test client
+  let db: any
+  let productId: string
+  let optionId: string
+
+  beforeAll(() => {
+    db = createTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDb(db)
+    productId = newId("products")
+    optionId = newId("product_options")
+    await db.insert(products).values({
+      id: productId,
+      name: "Romanian Circuit",
+      sellCurrency: "EUR",
+      bookingMode: "date",
+    })
+    await db.insert(productOptions).values({
+      id: optionId,
+      productId,
+      name: "Standard Circuit",
+      status: "active",
+      sortOrder: 0,
+    })
+  })
+
+  it("seeds resources per template default_count on slot create", async () => {
+    // Unique index on (product_option_id, kind) — model rooming as two
+    // distinct kinds ("room_sgl", "room_dbl") so we can express both
+    // buckets at the catalog level.
+    await db.insert(productOptionResourceTemplates).values([
+      {
+        productOptionId: optionId,
+        kind: "room_sgl",
+        capacity: 1,
+        namePattern: "SGL {sequence}",
+        defaultCount: 5,
+        flags: { roomType: "SGL" },
+      },
+      {
+        productOptionId: optionId,
+        kind: "room_dbl",
+        capacity: 2,
+        namePattern: "DBL {sequence}",
+        defaultCount: 20,
+        flags: { roomType: "DBL" },
+      },
+    ])
+
+    const slotId = newId("availability_slots")
+    await db.insert(availabilitySlots).values({
+      id: slotId,
+      productId,
+      optionId,
+      dateLocal: "2026-06-01",
+      startsAt: new Date("2026-06-01T08:00:00Z"),
+      timezone: "UTC",
+      status: "open",
+      unlimited: false,
+      initialPax: 49,
+      remainingPax: 49,
+    })
+
+    const result = await materializeSlotResourcesFromTemplateDefaults(db, slotId)
+    expect(result.created).toBe(25)
+    const rooms = await db.execute(sql`
+      SELECT label, capacity, kind FROM allocation_resources WHERE slot_id = ${slotId} ORDER BY sort_order
+    `)
+    const rows = rooms as unknown as Array<{ label: string; capacity: number; kind: string }>
+    expect(rows.filter((r) => r.kind === "room_sgl")).toHaveLength(5)
+    expect(rows.filter((r) => r.kind === "room_dbl")).toHaveLength(20)
+  })
+
+  it("skips templates with null default_count (manual seeding only)", async () => {
+    await db.insert(productOptionResourceTemplates).values({
+      productOptionId: optionId,
+      kind: "room",
+      capacity: 1,
+      namePattern: "SGL {sequence}",
+      defaultCount: null,
+    })
+
+    const slotId = newId("availability_slots")
+    await db.insert(availabilitySlots).values({
+      id: slotId,
+      productId,
+      optionId,
+      dateLocal: "2026-06-01",
+      startsAt: new Date("2026-06-01T08:00:00Z"),
+      timezone: "UTC",
+      status: "open",
+      unlimited: false,
+      initialPax: 5,
+      remainingPax: 5,
+    })
+
+    const result = await materializeSlotResourcesFromTemplateDefaults(db, slotId)
+    expect(result.created).toBe(0)
+  })
+
+  it("auto-materializes during generateAvailabilitySlots", async () => {
+    await db.insert(productOptionResourceTemplates).values({
+      productOptionId: optionId,
+      kind: "room",
+      capacity: 2,
+      namePattern: "DBL {sequence}",
+      defaultCount: 3,
+    })
+    await db.insert(availabilityRules).values({
+      id: newId("availability_rules"),
+      productId,
+      optionId,
+      timezone: "UTC",
+      recurrenceRule: "FREQ=DAILY;COUNT=1",
+      maxCapacity: 6,
+      active: true,
+    })
+
+    const result = await generateAvailabilitySlots(db, {
+      horizonDays: 2,
+      now: new Date("2026-06-01T00:00:00Z"),
+    })
+    expect(result.slotsCreated).toBeGreaterThan(0)
+    expect(result.resourcesMaterialized).toBeGreaterThanOrEqual(3)
+  })
+})

--- a/packages/availability/tests/integration/slot-resource-availability.test.ts
+++ b/packages/availability/tests/integration/slot-resource-availability.test.ts
@@ -1,0 +1,156 @@
+import { newId } from "@voyantjs/db/lib/typeid"
+import { cleanupTestDb, createTestDb } from "@voyantjs/db/test-utils"
+import { products } from "@voyantjs/products/schema"
+import { sql } from "drizzle-orm"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { allocationResources, availabilitySlots } from "../../src/schema.js"
+import {
+  getSlotResourceAvailability,
+  validateSlotAllocationCapacity,
+} from "../../src/service-allocation.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+describe.skipIf(!DB_AVAILABLE)("slot resource availability (integration)", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: drizzle test client
+  let db: any
+  let productId: string
+  let slotId: string
+
+  beforeAll(() => {
+    db = createTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDb(db)
+    productId = newId("products")
+    slotId = newId("availability_slots")
+    await db.insert(products).values({
+      id: productId,
+      name: "Bali Wellness Retreat",
+      sellCurrency: "USD",
+      bookingMode: "date",
+    })
+    await db.insert(availabilitySlots).values({
+      id: slotId,
+      productId,
+      dateLocal: "2026-06-01",
+      startsAt: new Date("2026-06-01T08:00:00Z"),
+      timezone: "UTC",
+      status: "open",
+      unlimited: false,
+      initialPax: 49,
+      remainingPax: 49,
+    })
+  })
+
+  async function seedResource(input: {
+    kind: string
+    capacity: number
+    label: string
+    sortOrder?: number
+  }) {
+    const id = newId("allocation_resources")
+    await db.insert(allocationResources).values({
+      id,
+      slotId,
+      kind: input.kind,
+      label: input.label,
+      capacity: input.capacity,
+      sortOrder: input.sortOrder ?? 0,
+      flags: {},
+    })
+    return id
+  }
+
+  async function seedBookingWithTraveler(input: {
+    travelerId: string
+    allocations?: Record<string, string>
+  }) {
+    const bookingId = newId("bookings")
+    await db.execute(sql`
+      INSERT INTO bookings (id, booking_number, status, sell_currency)
+      VALUES (${bookingId}, ${`B${bookingId.slice(-6)}`}, 'confirmed', 'USD')
+    `)
+    await db.execute(sql`
+      INSERT INTO booking_allocations (id, booking_id, availability_slot_id, quantity, allocation_type, status)
+      VALUES (${newId("booking_allocations")}, ${bookingId}, ${slotId}, 1, 'unit', 'confirmed')
+    `)
+    await db.execute(sql`
+      INSERT INTO booking_travelers (id, booking_id, participant_type, first_name, last_name)
+      VALUES (${input.travelerId}, ${bookingId}, 'traveler', 'Test', 'Traveler')
+    `)
+    if (input.allocations) {
+      await db.execute(sql`
+        INSERT INTO booking_traveler_travel_details (traveler_id, allocations)
+        VALUES (${input.travelerId}, ${JSON.stringify(input.allocations)}::jsonb)
+      `)
+    }
+    return bookingId
+  }
+
+  it("reports capacity / assigned / available per resource", async () => {
+    const dblId = await seedResource({ kind: "room", capacity: 2, label: "DBL 1", sortOrder: 1 })
+    const sglId = await seedResource({ kind: "room", capacity: 1, label: "SGL 1", sortOrder: 2 })
+
+    await seedBookingWithTraveler({
+      travelerId: newId("booking_travelers"),
+      allocations: { room: dblId },
+    })
+
+    const manifest = await getSlotResourceAvailability(db, slotId)
+    expect(manifest).toHaveLength(2)
+    const dbl = manifest.find((r) => r.id === dblId)
+    const sgl = manifest.find((r) => r.id === sglId)
+    expect(dbl?.assigned).toBe(1)
+    expect(dbl?.available).toBe(1)
+    expect(sgl?.assigned).toBe(0)
+    expect(sgl?.available).toBe(1)
+  })
+
+  it("returns a violation when planned travelers exceed resource capacity", async () => {
+    const dblId = await seedResource({ kind: "room", capacity: 2, label: "DBL 1" })
+    // Two existing travelers in DBL — at capacity.
+    await seedBookingWithTraveler({
+      travelerId: newId("booking_travelers"),
+      allocations: { room: dblId },
+    })
+    await seedBookingWithTraveler({
+      travelerId: newId("booking_travelers"),
+      allocations: { room: dblId },
+    })
+
+    const plannedTravelerId = newId("booking_travelers")
+    const violations = await validateSlotAllocationCapacity(db, slotId, [
+      { travelerId: plannedTravelerId, kind: "room", resourceId: dblId },
+    ])
+    expect(violations).toHaveLength(1)
+    expect(violations[0]?.resourceId).toBe(dblId)
+    expect(violations[0]?.capacity).toBe(2)
+    expect(violations[0]?.existingAssigned).toBe(2)
+  })
+
+  it("treats re-saving the same traveler as idempotent", async () => {
+    const dblId = await seedResource({ kind: "room", capacity: 2, label: "DBL 1" })
+    const travelerId = newId("booking_travelers")
+    await seedBookingWithTraveler({
+      travelerId,
+      allocations: { room: dblId },
+    })
+
+    const violations = await validateSlotAllocationCapacity(db, slotId, [
+      { travelerId, kind: "room", resourceId: dblId },
+    ])
+    expect(violations).toEqual([])
+  })
+
+  it("flags a resource-kind mismatch as a violation", async () => {
+    const dblId = await seedResource({ kind: "room", capacity: 2, label: "DBL 1" })
+    const violations = await validateSlotAllocationCapacity(db, slotId, [
+      { travelerId: newId("booking_travelers"), kind: "vehicle_seat", resourceId: dblId },
+    ])
+    expect(violations).toHaveLength(1)
+    expect(violations[0]?.kind).toBe("vehicle_seat")
+  })
+})

--- a/packages/availability/tests/unit/validation.test.ts
+++ b/packages/availability/tests/unit/validation.test.ts
@@ -24,6 +24,7 @@ import {
   pickupTimingModeSchema,
   updateAllocationResourceSchema,
   updateTravelerSharingGroupSchema,
+  upsertResourceTemplateSchema,
 } from "../../src/validation.js"
 
 describe("Enum schemas", () => {
@@ -120,6 +121,24 @@ describe("Allocation schema", () => {
         travelerIds: ["traveler_a", "traveler_b"],
       }),
     ).toEqual({ travelerIds: ["traveler_a", "traveler_b"] })
+  })
+
+  it("accepts resource templates with default_count for slot-publish auto-seed", () => {
+    const result = upsertResourceTemplateSchema.parse({
+      capacity: 2,
+      namePattern: "DBL {sequence}",
+      defaultCount: 20,
+    })
+    expect(result.defaultCount).toBe(20)
+    expect(result.capacity).toBe(2)
+  })
+
+  it("treats omitted default_count as undefined (manual seeding only)", () => {
+    const result = upsertResourceTemplateSchema.parse({
+      capacity: 2,
+      namePattern: "TPL {sequence}",
+    })
+    expect(result.defaultCount).toBeUndefined()
   })
 })
 

--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -1250,10 +1250,17 @@ async function loadResourceCapacityViolations(
   if (entries.length === 0) return []
 
   const resourceIds = entries.map(([, resourceId]) => resourceId)
+  // Lock the targeted allocation_resources rows so concurrent
+  // assignments to the same resource serialise — otherwise two
+  // requests can both see one seat free and both write, leaving the
+  // resource over capacity. The caller is responsible for invoking
+  // this inside a transaction; outside one this lock degrades to a
+  // single-statement no-op which is the same race we had before.
   const resources = await db.execute(sql`
     SELECT id, kind, capacity, slot_id
     FROM allocation_resources
     WHERE id = ANY(${resourceIds}::text[])
+    FOR UPDATE
   `)
   const resourceList = resources as unknown as Array<{
     id: string
@@ -1329,6 +1336,39 @@ async function assertResourceCapacityForAllocations(
         .join(", ")}`,
     )
   }
+}
+
+/**
+ * Lock the targeted resource rows, validate, and write in one
+ * transaction so two concurrent assignments to the last seat in a
+ * resource cannot both pass a stale capacity check. When there are no
+ * allocations to enforce, we skip the wrapping transaction entirely —
+ * avoids the round trip for the common path and keeps the unit-test
+ * mocks (which don't stub `db.transaction`) working unchanged.
+ */
+async function persistTravelDetailsWithCapacityCheck(
+  db: PostgresJsDatabase,
+  travelerId: string,
+  input: UpsertBookingTravelerTravelDetailInput,
+  opts: { pii: BookingPiiService; actorId?: string | null },
+) {
+  const allocations = input.allocations
+  const hasAllocations =
+    allocations != null && Object.values(allocations).some((value) => Boolean(value))
+
+  if (!hasAllocations) {
+    return opts.pii.upsertTravelerTravelDetails(db, travelerId, input, opts.actorId)
+  }
+
+  return db.transaction(async (tx) => {
+    await assertResourceCapacityForAllocations(tx as PostgresJsDatabase, travelerId, allocations)
+    return opts.pii.upsertTravelerTravelDetails(
+      tx as PostgresJsDatabase,
+      travelerId,
+      input,
+      opts.actorId,
+    )
+  })
 }
 
 async function releaseAllocationCapacity(
@@ -4064,13 +4104,11 @@ export const bookingsService = {
       travelDetailInput = applyTravelDetailSnapshot(travelDetailInput, snapshot)
     }
 
-    await assertResourceCapacityForAllocations(db, traveler.id, travelDetailInput.allocations)
-
-    const travelDetails = await opts.pii.upsertTravelerTravelDetails(
+    const travelDetails = await persistTravelDetailsWithCapacityCheck(
       db,
       traveler.id,
       travelDetailInput,
-      opts.actorId,
+      opts,
     )
 
     return { traveler, travelDetails }
@@ -4109,13 +4147,11 @@ export const bookingsService = {
     }
 
     const travelDetailInput = pickTravelDetailFields(data)
-    await assertResourceCapacityForAllocations(db, traveler.id, travelDetailInput.allocations)
-
-    const travelDetails = await opts.pii.upsertTravelerTravelDetails(
+    const travelDetails = await persistTravelDetailsWithCapacityCheck(
       db,
       traveler.id,
       travelDetailInput,
-      opts.actorId,
+      opts,
     )
 
     return { traveler, travelDetails }

--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -1211,6 +1211,126 @@ async function adjustSlotCapacity(
   }
 }
 
+/**
+ * Per-resource capacity check used when a traveler is being assigned
+ * to one or more allocation_resources via `travelDetails.allocations`.
+ *
+ * The slot-level pax check (`adjustSlotCapacity`) only enforces total
+ * pax against `availability_slots.remaining_pax` — it cannot tell
+ * that a request fits in the slot's room total but oversells the DBL
+ * bucket. This helper walks each requested (kind, resourceId) pair,
+ * loads the resource, and counts other travelers already assigned to
+ * it across live bookings on the same slot. If the new traveler would
+ * push that count above the resource's `capacity`, we throw
+ * `resource_capacity_exhausted` citing the offending resource so
+ * the caller can surface a useful error to the client.
+ *
+ * Implemented with raw SQL because @voyantjs/bookings deliberately
+ * has no runtime dep on @voyantjs/availability (see the module-
+ * decoupling notes in CLAUDE.md / MEMORY.md). The schema is stable —
+ * `allocation_resources` and `booking_traveler_travel_details.allocations`
+ * are migration-frozen.
+ */
+export interface BookingResourceCapacityViolation {
+  slotId: string
+  resourceId: string
+  kind: string
+  capacity: number
+  existingAssigned: number
+}
+
+async function loadResourceCapacityViolations(
+  db: PostgresJsDatabase,
+  travelerId: string,
+  allocations: Record<string, string>,
+): Promise<BookingResourceCapacityViolation[]> {
+  const entries = Object.entries(allocations ?? {}).filter(
+    ([kind, resourceId]) => kind && resourceId,
+  )
+  if (entries.length === 0) return []
+
+  const resourceIds = entries.map(([, resourceId]) => resourceId)
+  const resources = await db.execute(sql`
+    SELECT id, kind, capacity, slot_id
+    FROM allocation_resources
+    WHERE id = ANY(${resourceIds}::text[])
+  `)
+  const resourceList = resources as unknown as Array<{
+    id: string
+    kind: string
+    capacity: number
+    slot_id: string
+  }>
+
+  const resourceById = new Map(resourceList.map((row) => [row.id, row]))
+  const violations: BookingResourceCapacityViolation[] = []
+
+  for (const [kind, resourceId] of entries) {
+    const resource = resourceById.get(resourceId)
+    if (!resource) {
+      violations.push({
+        slotId: "",
+        resourceId,
+        kind,
+        capacity: 0,
+        existingAssigned: 0,
+      })
+      continue
+    }
+    if (resource.kind !== kind) {
+      violations.push({
+        slotId: resource.slot_id,
+        resourceId,
+        kind,
+        capacity: resource.capacity,
+        existingAssigned: 0,
+      })
+      continue
+    }
+
+    const counts = await db.execute(sql`
+      SELECT COUNT(DISTINCT btd.traveler_id)::int AS count
+      FROM booking_traveler_travel_details btd
+      JOIN booking_travelers bt ON bt.id = btd.traveler_id
+      JOIN booking_allocations ba ON ba.booking_id = bt.booking_id
+      JOIN bookings b ON b.id = bt.booking_id
+      WHERE btd.allocations ->> ${kind} = ${resourceId}
+        AND ba.availability_slot_id = ${resource.slot_id}
+        AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
+        AND ba.status IN ('held', 'confirmed', 'fulfilled')
+        AND btd.traveler_id <> ${travelerId}
+    `)
+    const existingAssigned = (counts as unknown as Array<{ count: number | null }>)[0]?.count ?? 0
+    if (existingAssigned + 1 > resource.capacity) {
+      violations.push({
+        slotId: resource.slot_id,
+        resourceId,
+        kind,
+        capacity: resource.capacity,
+        existingAssigned,
+      })
+    }
+  }
+  return violations
+}
+
+async function assertResourceCapacityForAllocations(
+  db: PostgresJsDatabase,
+  travelerId: string,
+  allocations: Record<string, string> | undefined | null,
+): Promise<void> {
+  if (!allocations) return
+  const violations = await loadResourceCapacityViolations(db, travelerId, allocations)
+  if (violations.length > 0) {
+    throw new BookingServiceError(
+      "resource_capacity_exhausted",
+      `Allocation resource over capacity: ${violations
+        .map((v) => `${v.kind}=${v.resourceId} (cap ${v.capacity}, assigned ${v.existingAssigned})`)
+        .join(", ")}`,
+    )
+  }
+}
+
 async function releaseAllocationCapacity(
   db: PostgresJsDatabase,
   allocation: Pick<
@@ -3944,6 +4064,8 @@ export const bookingsService = {
       travelDetailInput = applyTravelDetailSnapshot(travelDetailInput, snapshot)
     }
 
+    await assertResourceCapacityForAllocations(db, traveler.id, travelDetailInput.allocations)
+
     const travelDetails = await opts.pii.upsertTravelerTravelDetails(
       db,
       traveler.id,
@@ -3986,10 +4108,13 @@ export const bookingsService = {
       return null
     }
 
+    const travelDetailInput = pickTravelDetailFields(data)
+    await assertResourceCapacityForAllocations(db, traveler.id, travelDetailInput.allocations)
+
     const travelDetails = await opts.pii.upsertTravelerTravelDetails(
       db,
       traveler.id,
-      pickTravelDetailFields(data),
+      travelDetailInput,
       opts.actorId,
     )
 

--- a/packages/bookings/tests/integration/resource-capacity.test.ts
+++ b/packages/bookings/tests/integration/resource-capacity.test.ts
@@ -1,0 +1,180 @@
+import { sql } from "drizzle-orm"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { createBookingPiiService } from "../../src/pii.js"
+import { bookings, bookingTravelers } from "../../src/schema.js"
+import { bookingsService } from "../../src/service.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+let seq = 0
+function nextBookingNumber() {
+  seq++
+  return `BK-RES-${String(seq).padStart(6, "0")}`
+}
+
+describe.skipIf(!DB_AVAILABLE)(
+  "createTravelerWithTravelDetails enforces per-resource capacity",
+  () => {
+    // biome-ignore lint/suspicious/noExplicitAny: drizzle test client
+    let db: any
+
+    beforeAll(async () => {
+      const { createTestDb, cleanupTestDb } = await import("@voyantjs/db/test-utils")
+      db = createTestDb()
+      await cleanupTestDb(db)
+      await db.execute(sql`DROP TABLE IF EXISTS booking_traveler_travel_details CASCADE`)
+      await db.execute(sql`
+        CREATE TABLE booking_traveler_travel_details (
+          traveler_id text PRIMARY KEY NOT NULL REFERENCES booking_travelers(id) ON DELETE cascade,
+          identity_encrypted jsonb,
+          dietary_encrypted jsonb,
+          accessibility_encrypted jsonb,
+          passport_person_document_id text,
+          is_lead_traveler boolean DEFAULT false NOT NULL,
+          sharing_group_id text,
+          room_type_id text,
+          bed_preference text,
+          allocations jsonb DEFAULT '{}'::jsonb NOT NULL,
+          created_at timestamp with time zone DEFAULT now() NOT NULL,
+          updated_at timestamp with time zone DEFAULT now() NOT NULL
+        )
+      `)
+    })
+
+    beforeEach(async () => {
+      seq = 0
+      const { cleanupTestDb } = await import("@voyantjs/db/test-utils")
+      await cleanupTestDb(db)
+    })
+
+    afterAll(async () => {
+      const { closeTestDb } = await import("@voyantjs/db/test-utils")
+      await closeTestDb()
+    })
+
+    async function buildPii() {
+      const { generateEnvKmsKey, EnvKmsProvider } = await import("@voyantjs/utils")
+      return createBookingPiiService({
+        kms: new EnvKmsProvider({ key: generateEnvKmsKey() }),
+      })
+    }
+
+    async function seedSlot(input: { slotId: string; productId: string }) {
+      await db.execute(sql`
+        INSERT INTO availability_slots (
+          id, product_id, date_local, starts_at, timezone, status, unlimited, remaining_pax
+        ) VALUES (
+          ${input.slotId},
+          ${input.productId},
+          '2026-06-01',
+          '2026-06-01 08:00:00+00',
+          'UTC',
+          'open',
+          false,
+          10
+        )
+      `)
+    }
+
+    async function seedResource(input: {
+      resourceId: string
+      slotId: string
+      kind: string
+      capacity: number
+    }) {
+      await db.execute(sql`
+        INSERT INTO allocation_resources (id, slot_id, kind, capacity, sort_order, flags)
+        VALUES (${input.resourceId}, ${input.slotId}, ${input.kind}, ${input.capacity}, 0, '{}'::jsonb)
+      `)
+    }
+
+    async function seedBookingOnSlot(input: { slotId: string }): Promise<string> {
+      const [booking] = await db
+        .insert(bookings)
+        .values({ bookingNumber: nextBookingNumber(), sellCurrency: "EUR" })
+        .returning()
+      await db.execute(sql`
+        INSERT INTO booking_allocations (id, booking_id, availability_slot_id, quantity, allocation_type, status)
+        VALUES (
+          'balc_' || substr(md5(random()::text), 1, 24),
+          ${booking.id},
+          ${input.slotId},
+          1,
+          'unit',
+          'confirmed'
+        )
+      `)
+      return booking.id
+    }
+
+    it("rejects assigning a traveler to a resource at capacity", async () => {
+      const slotId = "slot_capacity_test_1"
+      const resourceId = "alrs_dbl_test_1"
+      await seedSlot({ slotId, productId: "prod_test_1" })
+      await seedResource({ resourceId, slotId, kind: "room", capacity: 1 })
+
+      const bookingA = await seedBookingOnSlot({ slotId })
+      const [travelerA] = await db
+        .insert(bookingTravelers)
+        .values({
+          bookingId: bookingA,
+          firstName: "Alpha",
+          lastName: "One",
+          participantType: "traveler",
+        })
+        .returning()
+      const pii = await buildPii()
+      await pii.upsertTravelerTravelDetails(db, travelerA.id, {
+        allocations: { room: resourceId },
+      })
+
+      const bookingB = await seedBookingOnSlot({ slotId })
+      await expect(
+        bookingsService.createTravelerWithTravelDetails(
+          db,
+          bookingB,
+          {
+            firstName: "Bravo",
+            lastName: "Two",
+            participantType: "traveler",
+            allocations: { room: resourceId },
+          },
+          { pii },
+        ),
+      ).rejects.toMatchObject({ code: "resource_capacity_exhausted" })
+    })
+
+    it("allows re-saving the same traveler against the same resource", async () => {
+      const slotId = "slot_capacity_test_2"
+      const resourceId = "alrs_dbl_test_2"
+      await seedSlot({ slotId, productId: "prod_test_2" })
+      await seedResource({ resourceId, slotId, kind: "room", capacity: 2 })
+
+      const bookingId = await seedBookingOnSlot({ slotId })
+      const pii = await buildPii()
+      const created = await bookingsService.createTravelerWithTravelDetails(
+        db,
+        bookingId,
+        {
+          firstName: "Charlie",
+          lastName: "Three",
+          participantType: "traveler",
+          allocations: { room: resourceId },
+        },
+        { pii },
+      )
+      expect(created?.traveler.id).toBeDefined()
+
+      // Re-saving the same traveler is idempotent — the existing
+      // assignment is excluded from the capacity check.
+      const updated = await bookingsService.updateTravelerWithTravelDetails(
+        db,
+        created!.traveler.id,
+        { firstName: "Charlie", allocations: { room: resourceId } },
+        { pii },
+      )
+      expect(updated?.traveler.id).toBe(created!.traveler.id)
+    })
+  },
+)

--- a/packages/storefront/src/service-departures.ts
+++ b/packages/storefront/src/service-departures.ts
@@ -1,3 +1,8 @@
+import {
+  getSlotResourceAvailability,
+  getSlotsResourceAvailability,
+  type SlotResourceAvailability,
+} from "@voyantjs/availability"
 import { availabilitySlots, availabilityStartTimes } from "@voyantjs/availability/schema"
 import { productExtras } from "@voyantjs/extras/schema"
 import {
@@ -1287,9 +1292,11 @@ async function buildDeparture(
   slot: SlotRow,
   defaultItineraryByProduct: Map<string, string>,
   meetingPointByProduct?: Map<string, string>,
+  resourceAvailability?: SlotResourceAvailability[],
 ) {
   const context = await resolvePricingContext(db, slot.productId, slot.optionId)
   const itineraryId = slot.itineraryId ?? defaultItineraryByProduct.get(slot.productId) ?? null
+  const resources = resourceAvailability ?? []
 
   return {
     id: slot.id,
@@ -1316,6 +1323,34 @@ async function buildDeparture(
     nights: slot.nights,
     days: slot.days,
     ratePlans: buildRatePlans(context),
+    resourceManifest: buildResourceManifest(resources),
+  }
+}
+
+function buildResourceManifest(resources: SlotResourceAvailability[]) {
+  if (resources.length === 0) return null
+  const totals = new Map<string, { capacity: number; assigned: number; available: number }>()
+  for (const resource of resources) {
+    const bucket = totals.get(resource.kind) ?? { capacity: 0, assigned: 0, available: 0 }
+    bucket.capacity += resource.capacity
+    bucket.assigned += resource.assigned
+    bucket.available += resource.available
+    totals.set(resource.kind, bucket)
+  }
+  return {
+    kinds: [...totals.entries()].map(([kind, totals]) => ({ kind, ...totals })),
+    resources: resources.map((resource) => ({
+      id: resource.id,
+      kind: resource.kind,
+      label: resource.label,
+      refType: resource.refType,
+      refId: resource.refId,
+      capacity: resource.capacity,
+      assigned: resource.assigned,
+      available: resource.available,
+      parentId: resource.parentId,
+      flags: resource.flags,
+    })),
   }
 }
 
@@ -1325,12 +1360,20 @@ export async function getStorefrontDeparture(db: PostgresJsDatabase, departureId
     return null
   }
 
-  const [meetingPointByProduct, defaultItineraryByProduct] = await Promise.all([
-    listMeetingPointsByProductIds(db, [slot.productId]),
-    listDefaultItineraryIdsByProductIds(db, [slot.productId]),
-  ])
+  const [meetingPointByProduct, defaultItineraryByProduct, resourceAvailability] =
+    await Promise.all([
+      listMeetingPointsByProductIds(db, [slot.productId]),
+      listDefaultItineraryIdsByProductIds(db, [slot.productId]),
+      getSlotsResourceAvailability(db, [slot.id]),
+    ])
 
-  return buildDeparture(db, slot, defaultItineraryByProduct, meetingPointByProduct)
+  return buildDeparture(
+    db,
+    slot,
+    defaultItineraryByProduct,
+    meetingPointByProduct,
+    resourceAvailability.get(slot.id) ?? [],
+  )
 }
 
 export async function listStorefrontProductDepartures(
@@ -1353,12 +1396,25 @@ export async function listStorefrontProductDepartures(
     }),
     countSlots(db, filters),
   ])
-  const [meetingPointByProduct, defaultItineraryByProduct] = await Promise.all([
-    listMeetingPointsByProductIds(db, [productId]),
-    listDefaultItineraryIdsByProductIds(db, [productId]),
-  ])
+  const [meetingPointByProduct, defaultItineraryByProduct, resourceAvailability] =
+    await Promise.all([
+      listMeetingPointsByProductIds(db, [productId]),
+      listDefaultItineraryIdsByProductIds(db, [productId]),
+      getSlotsResourceAvailability(
+        db,
+        slots.map((slot) => slot.id),
+      ),
+    ])
   const data = await Promise.all(
-    slots.map((slot) => buildDeparture(db, slot, defaultItineraryByProduct, meetingPointByProduct)),
+    slots.map((slot) =>
+      buildDeparture(
+        db,
+        slot,
+        defaultItineraryByProduct,
+        meetingPointByProduct,
+        resourceAvailability.get(slot.id) ?? [],
+      ),
+    ),
   )
 
   return {
@@ -1657,6 +1713,8 @@ export async function previewStorefrontDeparturePrice(
   const total = offers.totalAfterDiscount
   const extrasTotal = withExtras.impacts.reduce((sum, extra) => sum + extra.total, 0)
   const basePrice = Number((subtotal - extrasTotal).toFixed(2))
+  const slotResources = await getSlotResourceAvailability(db, slot.id)
+  const resourceManifest = buildResourceManifest(slotResources)
 
   return {
     departureId: slot.id,
@@ -1689,6 +1747,7 @@ export async function previewStorefrontDeparturePrice(
         remaining: slot.remainingPax ?? slot.remainingResources ?? null,
         pastCutoff: slot.pastCutoff,
         tooEarly: slot.tooEarly,
+        resourceManifest,
       },
       pax: {
         adults,

--- a/templates/dmc/migrations/0009_resource_template_default_count.sql
+++ b/templates/dmc/migrations/0009_resource_template_default_count.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "product_option_resource_templates"
+  ADD COLUMN IF NOT EXISTS "default_count" integer;


### PR DESCRIPTION
Closes #939.

## Summary
- Surface per-(slot, kind) allocation inventory on the consumer side so storefront callers can see what's left in each room/seat bucket and the booking flow can reject oversells of a single resource even when the slot's total pax bucket still has room.
- Auto-seed `allocation_resources` from `product_option_resource_templates` on slot publish (gated by a new nullable `default_count` column) so operators stop hand-seeding every departure.
- Document the lifecycle from catalog template → per-slot resource → traveler assignment in `docs/architecture/allocation-resources-lifecycle.md`.

## Changes
- `@voyantjs/availability`
  - `getSlotResourceAvailability` / `getSlotsResourceAvailability`: per-resource `{ capacity, assigned, available }` derived from a single LATERAL join — matches the DISTINCT-traveler count used by `assignTravelerAllocation` so the read-side and the assignment guard agree.
  - `validateSlotAllocationCapacity`: pre-persist guard returning offending resources for a planned set of traveler → resource assignments.
  - `materializeSlotResourcesFromTemplateDefaults`: instantiates `default_count` resources per template, wired into `generateAvailabilitySlots`. Idempotent — kinds already seeded for the slot are skipped. Vehicle-seat layouts deliberately stay on the existing pax-aware admin path.
  - New `default_count` column on `product_option_resource_templates`. Migrations: `apps/dev/migrations/0027_…`, `templates/dmc/migrations/0009_…`.
- `@voyantjs/storefront`
  - Departure responses (`getStorefrontDeparture`, `listStorefrontProductDepartures`, `previewStorefrontDeparturePrice`) now carry a `resourceManifest` with per-kind totals and per-resource availability.
- `@voyantjs/bookings`
  - `createTravelerWithTravelDetails` / `updateTravelerWithTravelDetails` validate `travelDetails.allocations` against per-resource capacity and reject with `BookingServiceError` code `resource_capacity_exhausted` (re-saving the same traveler is idempotent — its existing assignment is excluded). Implemented inline so `@voyantjs/bookings` keeps its no-runtime-dep posture on `@voyantjs/availability` (per module-decoupling notes).

## Test plan
- [x] `pnpm -F @voyantjs/availability test` — 77 passed, 50 skipped (DB-gated)
- [x] `pnpm -F @voyantjs/bookings test` — 240 passed, 120 skipped (DB-gated)
- [x] `pnpm -F @voyantjs/storefront test` — 24 passed, 12 skipped (DB-gated)
- [x] `pnpm -F '@voyantjs/availability...' -F '@voyantjs/bookings...' -F '@voyantjs/storefront...' typecheck`
- [x] `pnpm -F @voyantjs/availability lint` / bookings / storefront
- [ ] Run the new DB-gated integration tests against a populated `TEST_DATABASE_URL` once a reviewer has one handy:
  - `packages/availability/tests/integration/slot-resource-availability.test.ts`
  - `packages/availability/tests/integration/materialize-template-defaults.test.ts`
  - `packages/bookings/tests/integration/resource-capacity.test.ts`