### PR TITLE
fix(allocation-ui): render SlotAllocationPage when slot has no travelers

### DIFF
--- a/packages/allocation-ui/src/components/slot-allocation-page.tsx
+++ b/packages/allocation-ui/src/components/slot-allocation-page.tsx
@@ -80,9 +80,6 @@ export function SlotAllocationPage({
   const [resourceLabel, setResourceLabel] = useState("")
   const [resourceCapacity, setResourceCapacity] = useState(2)
   const [error, setError] = useState<string | null>(null)
-  const hasPageExtensions = Boolean(
-    renderHeaderEnd || renderBefore || renderAfter || extraTabs.length,
-  )
 
   const data = allocation.data?.data
   const templates = useProductResourceTemplates({
@@ -221,7 +218,14 @@ export function SlotAllocationPage({
     )
   }
 
-  if (!data || (travelers.length === 0 && !hasPageExtensions)) {
+  // Only short-circuit when we genuinely have no data to render
+  // against. The page intentionally renders even when both resources
+  // and travelers are empty so operators can seed the per-departure
+  // resource block before any bookings exist — setting up the room
+  // block before selling is the canonical flow. The per-kind resource
+  // view handles its own empty state (and the "Add resource" /
+  // "Generate resources" affordances stay reachable).
+  if (!data) {
     return (
       <div className={cn("flex flex-col items-center justify-center gap-3 p-8", className)}>
         <Users className="size-6 text-muted-foreground" aria-hidden="true" />

--- a/packages/allocation-ui/src/i18n/provider.tsx
+++ b/packages/allocation-ui/src/i18n/provider.tsx
@@ -76,7 +76,7 @@ export type AllocationUiMessages = Record<string, unknown> & {
 export const allocationUiEn = {
   pageTitle: "Allocation",
   loading: "Loading allocation...",
-  empty: "No travelers on this departure yet.",
+  empty: "Allocation data unavailable for this departure.",
   back: "Back",
   addRoom: "Add room",
   addResource: "Add resource",
@@ -151,7 +151,7 @@ export const allocationUiEn = {
 export const allocationUiRo = {
   pageTitle: "Alocare",
   loading: "Se incarca alocarea...",
-  empty: "Nu exista calatori pe aceasta plecare.",
+  empty: "Datele de alocare nu sunt disponibile pentru aceasta plecare.",
   back: "Inapoi",
   addRoom: "Adauga camera",
   addResource: "Adauga resursa",


### PR DESCRIPTION
Closes #940.

## Summary
- `SlotAllocationPage` rendered an empty state whenever a slot had zero travelers, hiding the resource editor (Add resource / Generate resources / Auto-allocate) until a customer booked — backwards from the canonical flow where operators seed the per-departure room block *before* selling.
- Drop the travelers/extensions guard entirely. The page now renders whenever `data` is loaded; the per-kind resource view already shows its own inline empty state for the active tab, so the page reads cleanly when both resources and travelers are empty.
- The remaining \`!data\` fallback only fires when the slot itself is missing, so retarget its copy ("Allocation data unavailable…") instead of the stale "no travelers" wording.

## Test plan
- [x] \`pnpm -F @voyantjs/allocation-ui typecheck\` / \`lint\` / \`test\`
- [ ] Manually mount \`<SlotAllocationPage slotId={…} />\` on a freshly-published slot with no bookings — page renders with the tabs, Add resource, Generate resources, and Auto-allocate affordances reachable.