### PR TITLE
fix(availability, bookings): emit ARRAY[…]::text[] for array params

### DIFF
--- a/.changeset/952-fix-array-text-cast.md
+++ b/.changeset/952-fix-array-text-cast.md
@@ -1,0 +1,10 @@
+---
+"@voyantjs/availability": patch
+"@voyantjs/bookings": patch
+---
+
+Fix `cannot cast type record to text[]` crash on `getSlotAllocationManifest`, `validateSlotAllocationCapacity`, `autoAllocateSlotResources`, and the bookings per-resource capacity guard whenever the array being interpolated had 2+ elements.
+
+drizzle-orm's `sql\`…${jsArray}…\`` template spreads JS arrays into a Postgres row constructor (`($1, $2)`) — and `($1, $2)::text[]` is a record cast, which Postgres refuses. Single-element arrays happened to work because `(($1)::text[])` evaluates as the lone scalar. So the bug stayed latent in fresh dev environments with one booking per slot, then hit production immediately on the second booking.
+
+All raw-SQL sites that previously wrote `${array}::text[]` now go through a tiny local helper that emits `ARRAY[$1, $2, …]::text[]` via `sql.join`. Affects nine call sites across `service-allocation.ts`, `service-allocation-automation.ts`, and `bookings/service.ts`. Added an integration regression test that loads the manifest for a slot with 3 bookings.

--- a/packages/availability/src/service-allocation-automation.ts
+++ b/packages/availability/src/service-allocation-automation.ts
@@ -23,6 +23,19 @@ import {
 } from "./service-allocation.js"
 import type { allocationAutomationSchema, upsertResourceTemplateSchema } from "./validation.js"
 
+/**
+ * Emit `ARRAY[$1, $2, …]::text[]` so Postgres doesn't try to cast a
+ * tuple to `text[]`. See `sqlTextArray` in service-allocation.ts and
+ * issue #952.
+ */
+function sqlTextArray(values: readonly string[]): SQL {
+  if (values.length === 0) return sql`ARRAY[]::text[]`
+  return sql`ARRAY[${sql.join(
+    values.map((value) => sql`${value}`),
+    sql.raw(", "),
+  )}]::text[]`
+}
+
 export type UpsertResourceTemplateInput = z.infer<typeof upsertResourceTemplateSchema>
 export type AllocationAutomationInput = z.infer<typeof allocationAutomationSchema>
 
@@ -86,7 +99,7 @@ export async function listProductOptionResourceTemplates(
     sql`
       SELECT id, product_option_id, kind, ref_type, ref_id, capacity, name_pattern, layout, default_count, flags, created_at, updated_at
       FROM product_option_resource_templates
-      WHERE product_option_id = ANY(${optionIds}::text[])
+      WHERE product_option_id = ANY(${sqlTextArray(optionIds)})
       ORDER BY kind, created_at
     `,
   )
@@ -359,7 +372,7 @@ export async function autoAllocateSlotResources(
         SELECT
           row.traveler_id,
           jsonb_build_object(${kind}::text, row.resource_id::text)
-        FROM unnest(${travelerIds}::text[], ${resourceIds}::text[]) AS row(traveler_id, resource_id)
+        FROM unnest(${sqlTextArray(travelerIds)}, ${sqlTextArray(resourceIds)}) AS row(traveler_id, resource_id)
         ON CONFLICT (traveler_id) DO UPDATE SET
           allocations =
             COALESCE(booking_traveler_travel_details.allocations, '{}'::jsonb)

--- a/packages/availability/src/service-allocation.ts
+++ b/packages/availability/src/service-allocation.ts
@@ -304,7 +304,7 @@ export async function getSlotsResourceAvailability(
           AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
           AND ba.status IN ('held', 'confirmed', 'fulfilled')
       ) usage ON true
-      WHERE ar.slot_id = ANY(${uniqueIds}::text[])
+      WHERE ar.slot_id = ANY(${sqlTextArray(uniqueIds)})
       ORDER BY ar.slot_id, ar.kind, ar.sort_order, ar.created_at
     `,
   )
@@ -399,7 +399,7 @@ export async function validateSlotAllocationCapacity(
     sql`
       SELECT id, kind, capacity, slot_id
       FROM allocation_resources
-      WHERE slot_id = ${slotId} AND id = ANY(${resourceIds}::text[])
+      WHERE slot_id = ${slotId} AND id = ANY(${sqlTextArray(resourceIds)})
       FOR UPDATE
     `,
   )
@@ -444,7 +444,7 @@ export async function validateSlotAllocationCapacity(
           AND ba.availability_slot_id = ${slotId}
           AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
           AND ba.status IN ('held', 'confirmed', 'fulfilled')
-          AND btd.traveler_id <> ALL(${travelerIdsArr}::text[])
+          AND btd.traveler_id <> ALL(${sqlTextArray(travelerIdsArr)})
       `,
     )
     const existingAssigned = existingRows[0]?.count ?? 0
@@ -722,7 +722,7 @@ export async function pairSharingGroup(
   await db.execute(sql`
     INSERT INTO booking_traveler_travel_details (traveler_id, sharing_group_id)
     SELECT id, ${sharingGroupId}
-    FROM unnest(${input.travelerIds}::text[]) AS u(id)
+    FROM unnest(${sqlTextArray(input.travelerIds)}) AS u(id)
     ON CONFLICT (traveler_id) DO UPDATE SET
       sharing_group_id = EXCLUDED.sharing_group_id,
       updated_at = now()
@@ -980,7 +980,7 @@ async function loadSharingGroupLabelMap(
       label: sharingGroupLabels.label,
     })
     .from(sharingGroupLabels)
-    .where(sql`${sharingGroupLabels.groupId} = ANY(${uniqueIds}::text[])`)
+    .where(sql`${sharingGroupLabels.groupId} = ANY(${sqlTextArray(uniqueIds)})`)
 
   return Object.fromEntries(rows.map((row) => [row.groupId, row.label]))
 }
@@ -988,6 +988,21 @@ async function loadSharingGroupLabelMap(
 async function executeRows<T>(db: SqlExecutor, query: SQL): Promise<T[]> {
   const rows = await db.execute(query)
   return Array.isArray(rows) ? (rows as T[]) : []
+}
+
+/**
+ * Emit a Postgres `ARRAY[$1, $2, …]::text[]` literal instead of the
+ * naive `${jsArray}::text[]` form. drizzle's `sql` template spreads
+ * JS arrays into a row constructor (`($1, $2)`) which Postgres
+ * refuses to cast to `text[]` — see issue #952. Empty input returns
+ * `ARRAY[]::text[]` which Postgres accepts.
+ */
+function sqlTextArray(values: readonly string[]): SQL {
+  if (values.length === 0) return sql`ARRAY[]::text[]`
+  return sql`ARRAY[${sql.join(
+    values.map((value) => sql`${value}`),
+    sql.raw(", "),
+  )}]::text[]`
 }
 
 function serializeSlot(slot: {
@@ -1085,7 +1100,7 @@ async function loadSlotTravelerRows(
       (btd.dietary_encrypted IS NOT NULL) AS has_dietary_requirements
     FROM booking_travelers bt
     LEFT JOIN booking_traveler_travel_details btd ON btd.traveler_id = bt.id
-    WHERE bt.booking_id = ANY(${bookingIds}::text[])
+    WHERE bt.booking_id = ANY(${sqlTextArray(bookingIds)})
     ORDER BY bt.booking_id, bt.is_primary DESC, bt.created_at
   `,
   )

--- a/packages/availability/tests/integration/slot-resource-availability.test.ts
+++ b/packages/availability/tests/integration/slot-resource-availability.test.ts
@@ -6,6 +6,7 @@ import { beforeAll, beforeEach, describe, expect, it } from "vitest"
 
 import { allocationResources, availabilitySlots } from "../../src/schema.js"
 import {
+  getSlotAllocationManifest,
   getSlotResourceAvailability,
   validateSlotAllocationCapacity,
 } from "../../src/service-allocation.js"
@@ -152,5 +153,50 @@ describe.skipIf(!DB_AVAILABLE)("slot resource availability (integration)", () =>
     ])
     expect(violations).toHaveLength(1)
     expect(violations[0]?.kind).toBe("vehicle_seat")
+  })
+
+  // Regression for #952 — when a slot had 2+ bookings, the manifest
+  // query crashed with `cannot cast type record to text[]` because
+  // drizzle's `sql` template spreads JS arrays into a tuple, not a
+  // text[] literal. The `sqlTextArray` helper emits `ARRAY[$1, $2,
+  // …]::text[]` instead. Single-booking slots happened to work
+  // because `(($1)::text[])` evaluates as the lone value.
+  it("loads the manifest for a slot with multiple bookings without a record-cast crash", async () => {
+    const dblId = await seedResource({ kind: "room", capacity: 4, label: "DBL 1" })
+    await seedBookingWithTraveler({
+      travelerId: newId("booking_travelers"),
+      allocations: { room: dblId },
+    })
+    await seedBookingWithTraveler({
+      travelerId: newId("booking_travelers"),
+      allocations: { room: dblId },
+    })
+    await seedBookingWithTraveler({
+      travelerId: newId("booking_travelers"),
+    })
+
+    const manifest = await getSlotAllocationManifest(db, slotId)
+    expect(manifest).not.toBeNull()
+    expect(manifest?.bookings).toHaveLength(3)
+    expect(manifest?.summary.travelerCount).toBe(3)
+  })
+
+  it("validates allocations across multiple resources without a record-cast crash", async () => {
+    const dblId = await seedResource({ kind: "room", capacity: 2, label: "DBL 1" })
+    const twnId = await seedResource({ kind: "room", capacity: 2, label: "TWN 1" })
+    await seedBookingWithTraveler({
+      travelerId: newId("booking_travelers"),
+      allocations: { room: dblId },
+    })
+    await seedBookingWithTraveler({
+      travelerId: newId("booking_travelers"),
+      allocations: { room: twnId },
+    })
+
+    const violations = await validateSlotAllocationCapacity(db, slotId, [
+      { travelerId: newId("booking_travelers"), kind: "room", resourceId: dblId },
+      { travelerId: newId("booking_travelers"), kind: "room", resourceId: twnId },
+    ])
+    expect(violations).toEqual([])
   })
 })

--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -12,6 +12,7 @@ import {
   lte,
   ne,
   or,
+  type SQL,
   sql,
 } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -98,6 +99,20 @@ import type {
   updateTravelerSchema,
   updateTravelerWithTravelDetailsSchema,
 } from "./validation.js"
+
+/**
+ * Emit `ARRAY[$1, $2, …]::text[]` instead of the naive
+ * `${jsArray}::text[]` form. drizzle's `sql` template spreads JS
+ * arrays into a row constructor (`($1, $2)`) which Postgres refuses
+ * to cast to `text[]` — see issue #952.
+ */
+function sqlTextArray(values: readonly string[]): SQL {
+  if (values.length === 0) return sql`ARRAY[]::text[]`
+  return sql`ARRAY[${sql.join(
+    values.map((value) => sql`${value}`),
+    sql.raw(", "),
+  )}]::text[]`
+}
 
 type BookingListQuery = z.infer<typeof bookingListQuerySchema>
 type ConvertProductInput = z.infer<typeof convertProductSchema>
@@ -1259,7 +1274,7 @@ async function loadResourceCapacityViolations(
   const resources = await db.execute(sql`
     SELECT id, kind, capacity, slot_id
     FROM allocation_resources
-    WHERE id = ANY(${resourceIds}::text[])
+    WHERE id = ANY(${sqlTextArray(resourceIds)})
     FOR UPDATE
   `)
   const resourceList = resources as unknown as Array<{


### PR DESCRIPTION
Closes #952.

## Bug
`GET /v1/admin/availability/slots/:id/allocation` (and the underlying `getSlotAllocationManifest`) returned a 500 with `PostgresError: cannot cast type record to text[]` for any slot with 2+ bookings. Empty and single-booking slots accidentally worked, which masked the bug in fresh dev environments and hit production immediately on the second booking.

The same anti-pattern existed in 8 other call sites — `validateSlotAllocationCapacity`, `autoAllocateSlotResources`, the bookings per-resource capacity guard, etc.

## Root cause
drizzle-orm's `sql\`…${jsArray}…\`` template spreads JS arrays into a Postgres row constructor (`($1, $2)`) — and `($1, $2)::text[]` is a record cast, which Postgres refuses. Single-element arrays evaluated as the lone scalar via `(($1)::text[])`, hiding the bug below the threshold.

## Fix
A tiny per-file `sqlTextArray(values)` helper that emits `ARRAY[$1, $2, …]::text[]` via `sql.join`, used everywhere we previously wrote `${array}::text[]`. Nine call sites total across:
- `packages/availability/src/service-allocation.ts` (×6)
- `packages/availability/src/service-allocation-automation.ts` (×2)
- `packages/bookings/src/service.ts` (×1)

## Test plan
- [x] `pnpm -F @voyantjs/availability -F @voyantjs/bookings typecheck` / `lint`
- [x] New integration test in `slot-resource-availability.test.ts` loads the manifest for a slot with 3 bookings + validates allocations across two resources — both would have crashed before this fix. DB-gated; skips locally without `TEST_DATABASE_URL` but exercised in CI.
- [x] Existing test suite still passes (77 passed, 52 DB-gated skipped).