### PR TITLE
fix(registry): point bookings stepper at renamed file

### DIFF
--- a/.changeset/registry-stepper-rename-fix.md
+++ b/.changeset/registry-stepper-rename-fix.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/ui": patch
+---
+
+Fix `packages/ui/registry.json` so the bookings stepper entry points at `option-units-stepper-section.tsx` (and exposes it as `voyant-bookings-option-units-stepper-section`). The previous 0.52.1 release renamed the file but left the registry source-of-truth pointing at the old `rooms-stepper-section.tsx` path, which caused `shadcn build` to ENOENT in the release workflow.

--- a/packages/ui/registry.json
+++ b/packages/ui/registry.json
@@ -835,17 +835,17 @@
       ]
     },
     {
-      "name": "voyant-bookings-rooms-stepper-section",
+      "name": "voyant-bookings-option-units-stepper-section",
       "type": "registry:component",
-      "title": "Booking Rooms Stepper Section",
+      "title": "Booking Option Units Stepper Section",
       "description": "Per-option-unit quantity stepper for booking-create, driven by GET /v1/availability/slots/:id/unit-availability. Shows live 'N left' counters; min/max enforced against the server's remaining count so the UI can't queue up a 409.",
       "dependencies": ["@voyantjs/availability-react", "lucide-react"],
       "registryDependencies": ["button", "label"],
       "files": [
         {
-          "path": "registry/bookings/rooms-stepper-section.tsx",
+          "path": "registry/bookings/option-units-stepper-section.tsx",
           "type": "registry:component",
-          "target": "components/voyant/bookings/rooms-stepper-section.tsx"
+          "target": "components/voyant/bookings/option-units-stepper-section.tsx"
         }
       ]
     },
@@ -885,7 +885,7 @@
         "voyant-bookings-product-picker-section",
         "voyant-bookings-person-picker-section",
         "voyant-bookings-shared-room-section",
-        "voyant-bookings-rooms-stepper-section",
+        "voyant-bookings-option-units-stepper-section",
         "voyant-bookings-travelers-section",
         "voyant-bookings-price-breakdown-section",
         "voyant-bookings-voucher-picker-section",


### PR DESCRIPTION
## Summary
The release workflow on main started failing after #957 merged — `shadcn build` aborts with `ENOENT: no such file or directory, open '.../packages/ui/registry/bookings/rooms-stepper-section.tsx'`. The file was renamed to `option-units-stepper-section.tsx` in the 0.52.1 release but `packages/ui/registry.json` still pointed at the old path.

This patch renames the registry entry (id, paths, and the `voyant-bookings-booking-create-dialog` dependency reference) to match. Generated artifacts under `packages/ui/public/r/` and `apps/registry/public/r/` are regenerated by CI on each release, so they're not committed here.

## Test plan
- [x] `pnpm registry:build` succeeds locally and aggregates 215 registry items.
- [ ] `release` workflow's "Build registry artifacts" step succeeds on the next run.

Run that failed: https://github.com/voyantjs/voyant/actions/runs/26001889148/job/76426501772