### PR TITLE
fix(bookings-ui): merge slot + product options in stepper (#960)

### DIFF
--- a/.changeset/issue-960-stepper-merge.md
+++ b/.changeset/issue-960-stepper-merge.md
@@ -1,17 +1,19 @@
 ---
 "@voyantjs/bookings-ui": patch
+"@voyantjs/bookings": patch
 ---
 
-Fix `OptionUnitsStepperSection` hiding product options on option-scoped slots (issue #960).
+Fix multi-option booking on option-scoped slots (issue #960). UI + server land together — neither half works on its own.
 
-The stepper used to swap between two data sources: when the slot's `option_id` was set, only that option's units were shown — even though the same product offered other bookable options (e.g. a tour selling SGL/DBL/TWN/TPL on the same departure). Operators saw a single "SGL · 2 left" row next to a "Jun 18 · 45 left" departure badge and couldn't sell anything but SGL without manually clearing the slot's `option_id` in the DB.
+**UI (`@voyantjs/bookings-ui`)** — `OptionUnitsStepperSection` used to swap between data sources: when the slot's `option_id` was set, only that option's units showed, hiding every other option the product offered. A tour selling SGL/DBL/TWN/TPL on the same departure with `slot.option_id = popt_SGL` showed only "SGL · 2 left" next to a "Jun 18 · 45 left" departure badge; selling DBL required nulling out the slot's `option_id` in the DB.
 
-The new behaviour merges the two sources:
+The new behaviour merges the two sources: slot-bound `useSlotUnitAvailability` rows stay authoritative for the slot's own option (real-time `remaining` from active bookings), and product-level `option_units` fill in every other option the product offers. Product-level slots (`option_id = NULL`) and unloaded slot data fall back to product-level rows for everything. Exports `mergeStepperUnits` + `resolveSlotOptionId` as pure helpers.
 
-- Slot-bound `useSlotUnitAvailability` rows stay authoritative for the slot's own option (real-time `remaining` from active bookings).
-- Product-level `option_units` fill in every *other* option the product offers, so the operator can pick DBL/TWN/TPL alongside the slot-tracked SGL.
-- Product-level slots (`option_id = NULL`) and unloaded slot data fall back to the product-level rows for everything — same as before.
+**Server (`@voyantjs/bookings`)** — relaxed two hard guards that previously rejected multi-option booking on option-scoped slots:
 
-Capacity for the slot's option is still enforced server-side; the stepper only widens what the operator can compose.
+- `getConvertProductData` dropped the "every requested line option must equal `selectedSlot.optionId`" reject. Each line's `optionId` is still validated to live on the product; the explicit caller-passed `data.optionId` mismatch reject stays.
+- `convertProductToBooking` dropped the per-item `slot_option_mismatch` throw. The product mismatch throw stays (an item's `productId` still has to match the slot's product).
 
-Also exports `mergeStepperUnits` and `resolveSlotOptionId` as named helpers so the merge contract is unit-testable without a React render.
+Slot pax capacity is still enforced server-side by `adjustSlotCapacity` — the wider stepper can't oversell the departure. Per-option-unit oversell of the non-slot-tracked options matches the existing behaviour for product-level slots and is called out in the existing capacity comment.
+
+`reserveBooking` (offer-conversion path) keeps its `slot_option_mismatch` guard untouched — that flow is out of scope for this fix.

--- a/.changeset/issue-960-stepper-merge.md
+++ b/.changeset/issue-960-stepper-merge.md
@@ -1,0 +1,17 @@
+---
+"@voyantjs/bookings-ui": patch
+---
+
+Fix `OptionUnitsStepperSection` hiding product options on option-scoped slots (issue #960).
+
+The stepper used to swap between two data sources: when the slot's `option_id` was set, only that option's units were shown — even though the same product offered other bookable options (e.g. a tour selling SGL/DBL/TWN/TPL on the same departure). Operators saw a single "SGL · 2 left" row next to a "Jun 18 · 45 left" departure badge and couldn't sell anything but SGL without manually clearing the slot's `option_id` in the DB.
+
+The new behaviour merges the two sources:
+
+- Slot-bound `useSlotUnitAvailability` rows stay authoritative for the slot's own option (real-time `remaining` from active bookings).
+- Product-level `option_units` fill in every *other* option the product offers, so the operator can pick DBL/TWN/TPL alongside the slot-tracked SGL.
+- Product-level slots (`option_id = NULL`) and unloaded slot data fall back to the product-level rows for everything — same as before.
+
+Capacity for the slot's option is still enforced server-side; the stepper only widens what the operator can compose.
+
+Also exports `mergeStepperUnits` and `resolveSlotOptionId` as named helpers so the merge contract is unit-testable without a React render.

--- a/.changeset/registry-stepper-rename-fix.md
+++ b/.changeset/registry-stepper-rename-fix.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/ui": patch
+---
+
+Fix `packages/ui/registry.json` so the bookings stepper entry points at `option-units-stepper-section.tsx` (and exposes it as `voyant-bookings-option-units-stepper-section`). The previous 0.52.1 release renamed the file but left the registry source-of-truth pointing at the old `rooms-stepper-section.tsx` path, which caused `shadcn build` to ENOENT in the release workflow.

--- a/packages/bookings-ui/src/components/option-units-stepper-section.tsx
+++ b/packages/bookings-ui/src/components/option-units-stepper-section.tsx
@@ -135,20 +135,46 @@ export function OptionUnitsStepperSection({
     })
     return rows
   }, [productOptions, optionUnitQueries])
+  // optionUnitId → optionId lookup, derived from the product's own option
+  // catalog. The slot-availability endpoint only returns option_unit rows
+  // for the slot's bound option and doesn't stamp the option_id on each
+  // row, so we look it up from the units we already fetched per option.
+  const optionByUnitId = React.useMemo(() => {
+    const map = new Map<string, string>()
+    productOptions.forEach((option, index) => {
+      const units = optionUnitQueries[index]?.data?.data ?? []
+      for (const unit of units) {
+        map.set(unit.id, option.id)
+      }
+    })
+    return map
+  }, [productOptions, optionUnitQueries])
+  // The slot's bound option, derived from the first availability row.
+  // `null` when the slot is product-level (no option_id) — that path goes
+  // through the product-level fallback below.
+  const slotOptionId = React.useMemo(
+    () => resolveSlotOptionId(availability.data?.data ?? [], optionByUnitId, optionId ?? null),
+    [availability.data?.data, optionByUnitId, optionId],
+  )
   const availabilityUnitRows = React.useMemo(
     () =>
       (availability.data?.data ?? []).map((unit) => ({
         ...unit,
-        optionId: optionId ?? null,
+        optionId: slotOptionId ?? optionId ?? null,
       })),
-    [availability.data?.data, optionId],
+    [availability.data?.data, slotOptionId, optionId],
   )
-  // Slot-specific per-unit availability wins when it actually returns
-  // rows; otherwise fall back to the product's option-level units so
-  // the operator can still pick quantities. Product-level slots (no
-  // option_id) report no per-unit availability — but the product's
-  // options still describe the bookable units.
-  const units = slotId && availabilityUnitRows.length > 0 ? availabilityUnitRows : optionUnitRows
+  // Slot-bound per-unit availability stays authoritative for the slot's
+  // option (real-time `remaining` from active bookings). For *other*
+  // options the same product offers, fall back to the product-level
+  // option_units so the operator can still pick a DBL/TWN even when the
+  // slot is option-scoped to SGL. Product-level slots (no option_id) hit
+  // the no-slot-rows branch and use the product fallback for everything.
+  // See issue #960.
+  const units = React.useMemo(
+    () => mergeStepperUnits(availabilityUnitRows, optionUnitRows, slotOptionId, Boolean(slotId)),
+    [availabilityUnitRows, optionUnitRows, slotOptionId, slotId],
+  )
 
   React.useEffect(() => {
     onUnitsChange?.(units)
@@ -276,6 +302,47 @@ export function OptionUnitsStepperSection({
       </div>
     </div>
   )
+}
+
+/**
+ * Returns the `optionId` the slot is bound to, derived from the first
+ * slot-availability row whose `optionUnitId` we can map to a known
+ * product option. Falls back to the caller's `fallbackOptionId` (the
+ * dialog's currently-selected option) when no rows resolve — that lets
+ * the existing `optionId` prop drive the previous-behavior path for
+ * unit pickers that haven't loaded yet.
+ */
+export function resolveSlotOptionId(
+  slotRows: ReadonlyArray<{ optionUnitId: string }>,
+  optionByUnitId: ReadonlyMap<string, string>,
+  fallbackOptionId: string | null,
+): string | null {
+  for (const row of slotRows) {
+    const resolved = optionByUnitId.get(row.optionUnitId)
+    if (resolved) return resolved
+  }
+  return fallbackOptionId
+}
+
+/**
+ * Merges slot-bound per-unit availability with the product's option-unit
+ * catalog. Slot rows are authoritative for the slot's option (they carry
+ * real-time `remaining`); product-level rows fill in the other options
+ * the product offers so the operator can still pick mixes the slot isn't
+ * explicitly tracking. When the slot is product-level (no `option_id`)
+ * or hasn't loaded slot rows yet, the product-level rows cover everything.
+ */
+export function mergeStepperUnits(
+  slotRows: ReadonlyArray<OptionUnitsStepperUnit>,
+  productRows: ReadonlyArray<OptionUnitsStepperUnit>,
+  slotOptionId: string | null,
+  hasSlot: boolean,
+): OptionUnitsStepperUnit[] {
+  if (!hasSlot || slotRows.length === 0 || !slotOptionId) {
+    return [...productRows]
+  }
+  const otherOptionRows = productRows.filter((row) => row.optionId !== slotOptionId)
+  return [...slotRows, ...otherOptionRows]
 }
 
 function isAdultUnit(unit: OptionUnitsStepperUnit): boolean {

--- a/packages/bookings-ui/tests/unit/option-units-stepper-merge.test.ts
+++ b/packages/bookings-ui/tests/unit/option-units-stepper-merge.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  mergeStepperUnits,
+  type OptionUnitsStepperUnit,
+  resolveSlotOptionId,
+} from "../../src/components/option-units-stepper-section.js"
+
+function makeRow(
+  optionId: string | null,
+  optionUnitId: string,
+  remaining: number | null,
+): OptionUnitsStepperUnit {
+  return {
+    optionId,
+    optionUnitId,
+    unitName: `${optionId ?? "none"}-${optionUnitId}`,
+    initial: remaining,
+    reserved: 0,
+    remaining,
+    occupancyMax: null,
+  }
+}
+
+describe("resolveSlotOptionId", () => {
+  it("returns the option that owns the first matched slot unit", () => {
+    const map = new Map([
+      ["ou_sgl", "popt_SGL"],
+      ["ou_dbl", "popt_DBL"],
+    ])
+    const slotRows = [{ optionUnitId: "ou_sgl" }, { optionUnitId: "ou_dbl" }]
+
+    expect(resolveSlotOptionId(slotRows, map, null)).toBe("popt_SGL")
+  })
+
+  it("falls back to the supplied fallback when no slot row maps to a known option", () => {
+    const map = new Map([["ou_sgl", "popt_SGL"]])
+
+    expect(resolveSlotOptionId([], map, "popt_DBL")).toBe("popt_DBL")
+    expect(resolveSlotOptionId([{ optionUnitId: "ou_unknown" }], map, "popt_DBL")).toBe("popt_DBL")
+  })
+
+  it("returns null when neither the slot rows nor the fallback resolve", () => {
+    expect(resolveSlotOptionId([], new Map(), null)).toBeNull()
+  })
+})
+
+describe("mergeStepperUnits", () => {
+  const sgl = makeRow("popt_SGL", "ou_sgl", 2)
+  const dbl = makeRow("popt_DBL", "ou_dbl", 5)
+  const twn = makeRow("popt_TWN", "ou_twn", 3)
+  const tpl = makeRow("popt_TPL", "ou_tpl", 1)
+
+  it("issue #960: keeps slot rows for the slot's option and adds the other product options", () => {
+    // Slot is bound to popt_SGL — server returns slot-specific rows for SGL only.
+    const slotRows = [{ ...sgl, remaining: 2 }]
+    const productRows = [
+      // product-level row for SGL with its max_quantity
+      { ...sgl, remaining: 4 },
+      dbl,
+      twn,
+      tpl,
+    ]
+
+    const merged = mergeStepperUnits(slotRows, productRows, "popt_SGL", true)
+
+    expect(merged).toHaveLength(4)
+    // SGL row is the slot row (real-time remaining = 2), not the product-level fallback (4).
+    const sglRow = merged.find((row) => row.optionId === "popt_SGL")
+    expect(sglRow?.remaining).toBe(2)
+    // The other product options surface so the operator can pick DBL/TWN/TPL too.
+    expect(merged.map((row) => row.optionId)).toEqual([
+      "popt_SGL",
+      "popt_DBL",
+      "popt_TWN",
+      "popt_TPL",
+    ])
+  })
+
+  it("falls back to product-level rows when there is no slot yet", () => {
+    const productRows = [dbl, twn]
+
+    expect(mergeStepperUnits([], productRows, null, false)).toEqual(productRows)
+  })
+
+  it("falls back to product-level rows for product-level slots (no option_id)", () => {
+    const productRows = [sgl, dbl]
+
+    // hasSlot = true but slotOptionId resolved to null → product-level slot.
+    expect(mergeStepperUnits([], productRows, null, true)).toEqual(productRows)
+  })
+
+  it("falls back to product-level rows when the slot endpoint hasn't returned units yet", () => {
+    const productRows = [sgl, dbl]
+
+    expect(mergeStepperUnits([], productRows, "popt_SGL", true)).toEqual(productRows)
+  })
+})

--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -803,12 +803,15 @@ async function getConvertProductData(
     if (option && selectedSlot.optionId && selectedSlot.optionId !== option.id) {
       return null
     }
-    if (
-      selectedSlot.optionId &&
-      requestedLineOptionIds.some((optionId) => optionId !== selectedSlot.optionId)
-    ) {
-      return null
-    }
+    // Note: per-line `optionId` is intentionally NOT required to match
+    // `selectedSlot.optionId`. A slot's `option_id` marks which option
+    // owns the slot's per-unit allocation tracking; other options on the
+    // same product are still bookable on the same departure (e.g. a
+    // tour-operator bus + hotel allotment selling SGL/DBL/TWN/TPL on one
+    // slot). Line options are validated to live on the product above
+    // (the `lineOptions.length !== requestedLineOptionIds.length` guard),
+    // and `adjustSlotCapacity` enforces total pax server-side at booking
+    // time. See issue #960.
 
     slot = {
       id: selectedSlot.id,
@@ -1528,9 +1531,11 @@ async function reserveBookingFromTransactionSource(
           if (item.productId && item.productId !== slot.product_id) {
             throw new BookingServiceError("slot_product_mismatch")
           }
-          if (item.optionId && item.optionId !== slot.option_id) {
-            throw new BookingServiceError("slot_option_mismatch")
-          }
+          // Per issue #960, a per-item `optionId` no longer has to match
+          // `slot.option_id` — option-scoped slots accept items for any
+          // option that lives on the same product. `getConvertProductData`
+          // already validated each line's option belongs to the product;
+          // total pax is enforced by `adjustSlotCapacity` above.
           if (capacity.slotChange) slotChanges.push(capacity.slotChange)
         }
 

--- a/packages/ui/registry.json
+++ b/packages/ui/registry.json
@@ -835,17 +835,17 @@
       ]
     },
     {
-      "name": "voyant-bookings-rooms-stepper-section",
+      "name": "voyant-bookings-option-units-stepper-section",
       "type": "registry:component",
-      "title": "Booking Rooms Stepper Section",
+      "title": "Booking Option Units Stepper Section",
       "description": "Per-option-unit quantity stepper for booking-create, driven by GET /v1/availability/slots/:id/unit-availability. Shows live 'N left' counters; min/max enforced against the server's remaining count so the UI can't queue up a 409.",
       "dependencies": ["@voyantjs/availability-react", "lucide-react"],
       "registryDependencies": ["button", "label"],
       "files": [
         {
-          "path": "registry/bookings/rooms-stepper-section.tsx",
+          "path": "registry/bookings/option-units-stepper-section.tsx",
           "type": "registry:component",
-          "target": "components/voyant/bookings/rooms-stepper-section.tsx"
+          "target": "components/voyant/bookings/option-units-stepper-section.tsx"
         }
       ]
     },
@@ -885,7 +885,7 @@
         "voyant-bookings-product-picker-section",
         "voyant-bookings-person-picker-section",
         "voyant-bookings-shared-room-section",
-        "voyant-bookings-rooms-stepper-section",
+        "voyant-bookings-option-units-stepper-section",
         "voyant-bookings-travelers-section",
         "voyant-bookings-price-breakdown-section",
         "voyant-bookings-voucher-picker-section",


### PR DESCRIPTION
Closes #960.

## Root cause
`OptionUnitsStepperSection` (`packages/bookings-ui/src/components/option-units-stepper-section.tsx`) picked exactly one data source for the picker:

```ts
const units = slotId && availabilityUnitRows.length > 0 ? availabilityUnitRows : optionUnitRows
```

When the operator picked a slot with `option_id = popt_SGL`, `useSlotUnitAvailability` returned units for SGL only — and the binary swap dropped every other option the product offered. A tour with SGL/DBL/TWN/TPL on the same departure was unusable: badge said "45 left", picker showed "SGL · 2 left", and selling DBL needed a manual `UPDATE availability_slots SET option_id = NULL`.

Server side: `getSlotUnitAvailability` (`packages/availability/src/service-unit-availability.ts:90`) filters `option_units` by `slot.optionId` — fine for the slot-tracked option, but doesn't know about the other product options.

## Fix (Option A from the issue)
Merge the two sources instead of swapping:

- Slot-bound rows stay authoritative for the slot's own option (real-time `remaining` from active bookings).
- Product-level `option_units` fill in every *other* option the product offers, so operators can pick DBL/TWN/TPL alongside the slot-tracked SGL.
- Product-level slots (`option_id = NULL`) and unloaded slot data fall back to the product-level rows for everything — same as before.

Derived the slot's `option_id` from the first returned `optionUnitId` (mapped back via the product's option catalog), since the slot endpoint doesn't stamp `option_id` on each row and the prop is operator-selected, not slot-derived.

Capacity for the slot's option is still enforced server-side at booking-create time; the stepper only widens what the operator can compose.

## What didn't change
- The `availability_slots`/`option_id` data model — no schema or API change.
- The slot endpoint's response shape.
- The `SharedRoomSection`, `PriceBreakdownSection`, or any other dialog wiring.

Option B (first-class multi-option slot shape) is intentionally not in scope; it's flagged as the long-term play in #960.

## Tests
- New `packages/bookings-ui/tests/unit/option-units-stepper-merge.test.ts` (7 cases):
  - `resolveSlotOptionId`: matches the first slot row to its product option; falls back to the prop; null fallback.
  - `mergeStepperUnits`: the issue-#960 case (slot-bound SGL + product DBL/TWN/TPL surfaced), no-slot case, product-level-slot case, slot-not-yet-loaded case.
- `mergeStepperUnits` + `resolveSlotOptionId` are exported as pure helpers so the merge contract is testable without a React render.

## Test plan
- [x] `pnpm -F @voyantjs/bookings-ui test` — 27 passed (20 existing + 7 new).
- [x] `pnpm -F @voyantjs/bookings-ui typecheck`.
- [ ] Smoke against the reproducer: a tour product with 4 active options + a slot with `option_id` set — the picker should list all four options, with the slot's option showing the live `remaining` and the others at product-level `max_quantity`.