### PR TITLE
feat(bookings, crm): resolver hooks for booking person upsert (#961)

### DIFF
--- a/.changeset/issue-961-booking-person-resolver.md
+++ b/.changeset/issue-961-booking-person-resolver.md
@@ -1,0 +1,25 @@
+---
+"@voyantjs/crm": minor
+"@voyantjs/bookings": minor
+---
+
+Add CRM person resolution to the storefront booking flow (issue #961).
+
+Before this change, `publicBookingsService.createSession` and `updateSessionState` never created or linked a CRM `people` row. Storefront bookings landed with `bookings.person_id = NULL` and `booking_travelers.person_id = NULL`, so customers who completed a booking ended up outside the CRM even though the same package's lead/newsletter intake (`createStorefrontLeadSignal` / `subscribeStorefrontNewsletter`) did upsert people. Every operator-side repo had to wire its own `booking.confirmed` subscriber to bridge contact → person, racing with the next lead form that created duplicates.
+
+**`@voyantjs/crm`** — new resolution primitives, exported from the package root and rolled into `crmService`:
+
+- `personNameFromContact(contact)` — derives `{ firstName, lastName }` from a partial contact snapshot. Prefers explicit first/last, then a `name` split, then the email local-part. Never inserts the literal `"Unknown"` (acceptance criterion from the issue); falls back to `"Customer" / "Guest"` only when there is nothing else to work with.
+- `findPersonByContactPoint(db, { kind, value })` — looks a person up by normalized email/phone/website via `identity_contact_points`.
+- `upsertPersonFromContact(db, contact, { source, sourceRef })` — finds-or-creates a CRM person. Lookup order: email → phone. Creates with the supplied source/sourceRef so the audit trail mirrors lead/newsletter signals.
+
+**`@voyantjs/bookings`** — wires CRM-free resolver hooks through `BookingRouteRuntime` (mirrors the existing `ResolveBookingTravelSnapshot` pattern, so the bookings package stays free of any direct CRM dependency):
+
+- New runtime fields: `resolveBillingPerson` and `resolveTravelerPerson`. Templates supply them via `createBookingsHonoModule({ resolveBillingPerson, resolveTravelerPerson })` — typically wired to `crmService.upsertPersonFromContact`.
+- `publicBookingsService.createSession` / `updateSession` / `updateSessionState` now accept an optional `PublicBookingsServiceResolvers` arg. Public routes pull the resolvers from the runtime container and pass them through.
+- `createSession` and `updateSession` resolve a CRM person per traveler before inserting `booking_travelers` rows.
+- `updateSessionState` resolves a CRM person from the billing contact when the wizard's billing payload first arrives, and stamps `bookings.person_id`. Existing `bookings.person_id` values are never overwritten.
+- Resolver failures are caught and logged; the booking still lands without a person link rather than aborting the flow.
+- Default behaviour (resolvers omitted) is unchanged — bookings continue to land with `person_id = NULL`, so the feature is opt-in via template wiring.
+
+**Tests** — five unit tests for `personNameFromContact`, plus DB-gated integration tests for `findPersonByContactPoint` / `upsertPersonFromContact` covering the dedupe-vs-create path and the email-local-part fallback from the issue acceptance criteria.

--- a/apps/dev/src/api/app.ts
+++ b/apps/dev/src/api/app.ts
@@ -72,6 +72,24 @@ const crmHonoModule = createCrmHonoModule()
 const bookingsHonoModule = createBookingsHonoModule({
   resolveTravelSnapshot: (db, personId, { kms }) =>
     crmService.loadPersonTravelSnapshot(db, personId, { kms }),
+  // See issue #961 — storefront booking flows resolve CRM people from
+  // billing contact + per-traveler snapshots, dedupe by normalized
+  // email/phone, upsert on miss. Mirrored from the DMC + operator
+  // templates so the dev playground sees the same shape.
+  resolveBillingPerson: async (db, contact, ctx) => {
+    const person = await crmService.upsertPersonFromContact(db, contact, {
+      source: ctx.source,
+      sourceRef: ctx.sourceRef,
+    })
+    return person?.id ?? null
+  },
+  resolveTravelerPerson: async (db, contact, ctx) => {
+    const person = await crmService.upsertPersonFromContact(db, contact, {
+      source: ctx.source,
+      sourceRef: ctx.sourceRef,
+    })
+    return person?.id ?? null
+  },
 })
 
 export const app = createApp<CloudflareBindings>({

--- a/packages/bookings/src/index.ts
+++ b/packages/bookings/src/index.ts
@@ -109,9 +109,13 @@ export function createBookingsHonoModule(options: BookingsHonoModuleOptions = {}
 export const bookingsHonoModule: HonoModule = createBookingsHonoModule()
 
 export type {
+  BookingPersonResolverContact,
   BookingRouteRuntime,
   BookingRouteRuntimeOptions,
+  ResolveBookingBillingPerson,
   ResolveBookingKmsProvider,
+  ResolveBookingTravelerPerson,
+  ResolveBookingTravelSnapshot,
 } from "./route-runtime.js"
 export {
   BOOKING_ROUTE_RUNTIME_CONTAINER_KEY,
@@ -195,7 +199,11 @@ export {
   bookings,
   bookingTravelers,
 } from "./schema.js"
-export { publicBookingsService, resolveSessionPricingSnapshot } from "./service-public.js"
+export {
+  type PublicBookingsServiceResolvers,
+  publicBookingsService,
+  resolveSessionPricingSnapshot,
+} from "./service-public.js"
 export {
   addBookingGroupMemberSchema,
   bookingGroupKindSchema,

--- a/packages/bookings/src/route-runtime.ts
+++ b/packages/bookings/src/route-runtime.ts
@@ -21,9 +21,52 @@ export type ResolveBookingTravelSnapshot = (
   ctx: { kms: KmsProvider },
 ) => Promise<BookingTravelerSnapshot | null>
 
+/**
+ * Best-effort contact snapshot the booking-session bootstrap + update
+ * flows hand to the caller's person resolver. Mirrors the storefront
+ * lead-intake `StorefrontLeadContact` shape so the same resolver can
+ * service both surfaces.
+ */
+export interface BookingPersonResolverContact {
+  firstName: string | null
+  lastName: string | null
+  email: string | null
+  phone: string | null
+  preferredLanguage: string | null
+}
+
+/**
+ * Resolves (or upserts) a CRM person from a booking's billing contact
+ * snapshot. Returns the resolved person id, or `null` to leave the
+ * booking's `person_id` unset. Templates wire this from
+ * `crmService.upsertPersonFromContact` so the bookings package stays
+ * free of any direct CRM dependency — see issue #961.
+ */
+export type ResolveBookingBillingPerson = (
+  db: PostgresJsDatabase,
+  contact: BookingPersonResolverContact,
+  ctx: { bookingId: string; source: string; sourceRef: string },
+) => Promise<string | null>
+
+/**
+ * Resolves (or upserts) a CRM person from a booking traveler payload.
+ * Called from `publicBookingsService.createSession` /
+ * `updateSession` per-traveler so storefront-originated bookings
+ * produce CRM person links per traveler (not just for the billing
+ * contact). Returns the resolved person id, or `null` to keep
+ * `booking_travelers.person_id` unset.
+ */
+export type ResolveBookingTravelerPerson = (
+  db: PostgresJsDatabase,
+  contact: BookingPersonResolverContact,
+  ctx: { bookingId: string; source: string; sourceRef: string },
+) => Promise<string | null>
+
 export interface BookingRouteRuntime {
   getKmsProvider(): Promise<KmsProvider>
   resolveTravelSnapshot?: ResolveBookingTravelSnapshot
+  resolveBillingPerson?: ResolveBookingBillingPerson
+  resolveTravelerPerson?: ResolveBookingTravelerPerson
 }
 
 /**
@@ -40,6 +83,8 @@ export type ResolveBookingKmsProvider = (
 export interface BookingRouteRuntimeOptions {
   resolveKmsProvider?: ResolveBookingKmsProvider
   resolveTravelSnapshot?: ResolveBookingTravelSnapshot
+  resolveBillingPerson?: ResolveBookingBillingPerson
+  resolveTravelerPerson?: ResolveBookingTravelerPerson
 }
 
 function buildRuntimeEnv(bindings: KmsBindings): Record<string, string | undefined> {
@@ -70,5 +115,7 @@ export function buildBookingRouteRuntime(
       return createKmsProviderFromEnv(runtimeEnv)
     },
     resolveTravelSnapshot: options.resolveTravelSnapshot,
+    resolveBillingPerson: options.resolveBillingPerson,
+    resolveTravelerPerson: options.resolveTravelerPerson,
   }
 }

--- a/packages/bookings/src/routes-public.ts
+++ b/packages/bookings/src/routes-public.ts
@@ -9,8 +9,13 @@ import {
   issueCheckoutCapability,
   requireCheckoutCapability,
 } from "./checkout-capability.js"
+import {
+  BOOKING_ROUTE_RUNTIME_CONTAINER_KEY,
+  type BookingRouteRuntime,
+  buildBookingRouteRuntime,
+} from "./route-runtime.js"
 import { type Env, getRuntimeEnv, notFound } from "./routes-shared.js"
-import { publicBookingsService } from "./service-public.js"
+import { type PublicBookingsServiceResolvers, publicBookingsService } from "./service-public.js"
 import {
   publicBookingOverviewLookupQuerySchema,
   publicBookingSessionMutationSchema,
@@ -77,12 +82,34 @@ function sessionCapability(action: CheckoutCapabilityAction): MiddlewareHandler<
   }
 }
 
+function getRouteRuntime(c: Context): BookingRouteRuntime {
+  const container = (c.var as { container?: { resolve: (key: string) => unknown } }).container
+  try {
+    return (
+      (container?.resolve(BOOKING_ROUTE_RUNTIME_CONTAINER_KEY) as
+        | BookingRouteRuntime
+        | undefined) ?? buildBookingRouteRuntime(c.env as Record<string, string | undefined>)
+    )
+  } catch {
+    return buildBookingRouteRuntime(c.env as Record<string, string | undefined>)
+  }
+}
+
+function publicResolvers(c: Context): PublicBookingsServiceResolvers {
+  const runtime = getRouteRuntime(c)
+  return {
+    resolveBillingPerson: runtime.resolveBillingPerson,
+    resolveTravelerPerson: runtime.resolveTravelerPerson,
+  }
+}
+
 export const publicBookingRoutes = new Hono<Env>()
   .post("/sessions", idempotencyKey({ scope: "POST /v1/public/bookings/sessions" }), async (c) => {
     const result = await publicBookingsService.createSession(
       c.get("db"),
       await parseJsonBody(c, publicCreateBookingSessionSchema),
       c.get("userId"),
+      publicResolvers(c),
     )
 
     if (result.status === "slot_not_found") {
@@ -126,6 +153,7 @@ export const publicBookingRoutes = new Hono<Env>()
         c.req.param("sessionId"),
         await parseJsonBody(c, publicUpdateBookingSessionSchema),
         c.get("userId"),
+        publicResolvers(c),
       )
 
       if (result.status === "not_found") {
@@ -155,6 +183,7 @@ export const publicBookingRoutes = new Hono<Env>()
         c.get("db"),
         c.req.param("sessionId"),
         await parseJsonBody(c, publicUpsertBookingSessionStateSchema),
+        publicResolvers(c),
       )
 
       if (result.status === "not_found") {

--- a/packages/bookings/src/service-public.ts
+++ b/packages/bookings/src/service-public.ts
@@ -8,6 +8,11 @@ import {
   priceCatalogsRef,
 } from "./pricing-ref.js"
 import { optionUnitsRef, productOptionsRef, productsRef } from "./products-ref.js"
+import type {
+  BookingPersonResolverContact,
+  ResolveBookingBillingPerson,
+  ResolveBookingTravelerPerson,
+} from "./route-runtime.js"
 import {
   bookingAllocations,
   bookingDocuments,
@@ -29,6 +34,75 @@ import type {
   PublicUpdateBookingSessionInput,
   PublicUpsertBookingSessionStateInput,
 } from "./validation-public.js"
+
+/**
+ * Optional resolver bundle for storefront/public booking flows. When
+ * supplied, billing-contact + traveler payloads are run through the
+ * caller's resolver to look up (or create) the matching CRM person
+ * and the booking / traveler rows pick up the resulting `person_id`.
+ * Default (omitted) behaviour is the historic one: rows land with
+ * `person_id = NULL`. See issue #961.
+ */
+export interface PublicBookingsServiceResolvers {
+  resolveBillingPerson?: ResolveBookingBillingPerson
+  resolveTravelerPerson?: ResolveBookingTravelerPerson
+}
+
+const BOOKING_PERSON_SOURCE = "storefront-booking" as const
+
+async function safeResolveTravelerPerson(
+  db: PostgresJsDatabase,
+  resolver: ResolveBookingTravelerPerson | undefined,
+  participant: {
+    firstName: string
+    lastName: string
+    email: string | null
+    phone: string | null
+    preferredLanguage: string | null
+  },
+  bookingId: string,
+): Promise<string | null> {
+  if (!resolver) return null
+  const contact: BookingPersonResolverContact = {
+    firstName: participant.firstName,
+    lastName: participant.lastName,
+    email: participant.email,
+    phone: participant.phone,
+    preferredLanguage: participant.preferredLanguage,
+  }
+  try {
+    return await resolver(db, contact, {
+      bookingId,
+      source: BOOKING_PERSON_SOURCE,
+      sourceRef: bookingId,
+    })
+  } catch (error) {
+    // Person resolution is best-effort — a CRM hiccup must not block
+    // the actual booking. Log and fall back to `null` so the traveler
+    // row still lands without a person link.
+    console.error("[bookings] resolveTravelerPerson failed for booking", bookingId, error)
+    return null
+  }
+}
+
+async function safeResolveBillingPerson(
+  db: PostgresJsDatabase,
+  resolver: ResolveBookingBillingPerson | undefined,
+  contact: BookingPersonResolverContact,
+  bookingId: string,
+): Promise<string | null> {
+  if (!resolver) return null
+  try {
+    return await resolver(db, contact, {
+      bookingId,
+      source: BOOKING_PERSON_SOURCE,
+      sourceRef: bookingId,
+    })
+  } catch (error) {
+    console.error("[bookings] resolveBillingPerson failed for booking", bookingId, error)
+    return null
+  }
+}
 
 const travelerParticipantTypes = new Set(["traveler", "occupant"])
 const WIZARD_STATE_KEY = "wizard" as const
@@ -846,6 +920,7 @@ export const publicBookingsService = {
     db: PostgresJsDatabase,
     input: PublicCreateBookingSessionInput,
     userId?: string,
+    resolvers: PublicBookingsServiceResolvers = {},
   ) {
     const travelers = input.travelers ?? []
     const travelerCount = countTravelerParticipants(travelers)
@@ -893,6 +968,18 @@ export const publicBookingsService = {
     }
 
     for (const participant of travelers) {
+      const personId = await safeResolveTravelerPerson(
+        db,
+        resolvers.resolveTravelerPerson,
+        {
+          firstName: participant.firstName,
+          lastName: participant.lastName,
+          email: participant.email ?? null,
+          phone: participant.phone ?? null,
+          preferredLanguage: participant.preferredLanguage ?? null,
+        },
+        result.booking.id,
+      )
       await bookingsService.createTravelerRecord(
         db,
         result.booking.id,
@@ -907,7 +994,7 @@ export const publicBookingsService = {
           specialRequests: participant.specialRequests ?? null,
           isPrimary: participant.isPrimary,
           notes: participant.notes ?? null,
-          personId: null,
+          personId,
         },
         userId,
       )
@@ -934,6 +1021,7 @@ export const publicBookingsService = {
     db: PostgresJsDatabase,
     bookingId: string,
     input: PublicUpsertBookingSessionStateInput,
+    resolvers: PublicBookingsServiceResolvers = {},
   ) {
     const booking = await bookingsService.getBookingById(db, bookingId)
     if (!booking) {
@@ -947,7 +1035,28 @@ export const publicBookingsService = {
 
     const bookingContact = extractBookingContactFromStatePayload(state.payload)
     if (bookingContact) {
-      await bookingsService.updateBooking(db, bookingId, bookingContact)
+      // Resolve a CRM person from the billing snapshot when a resolver
+      // is wired — issue #961 calls out that storefront bookings used
+      // to land with `person_id = NULL`, leaving every customer outside
+      // the CRM until each operator wired their own bridge.
+      const personId = booking.personId
+        ? booking.personId
+        : await safeResolveBillingPerson(
+            db,
+            resolvers.resolveBillingPerson,
+            {
+              firstName: bookingContact.contactFirstName,
+              lastName: bookingContact.contactLastName,
+              email: bookingContact.contactEmail,
+              phone: bookingContact.contactPhone,
+              preferredLanguage: null,
+            },
+            bookingId,
+          )
+      await bookingsService.updateBooking(db, bookingId, {
+        ...bookingContact,
+        ...(personId && booking.personId !== personId ? { personId } : {}),
+      })
     }
     return { status: "ok" as const, state }
   },
@@ -957,6 +1066,7 @@ export const publicBookingsService = {
     bookingId: string,
     input: PublicUpdateBookingSessionInput,
     userId?: string,
+    resolvers: PublicBookingsServiceResolvers = {},
   ) {
     const booking = await bookingsService.getBookingById(db, bookingId)
     if (!booking) {
@@ -1012,6 +1122,18 @@ export const publicBookingsService = {
           continue
         }
 
+        const personId = await safeResolveTravelerPerson(
+          db,
+          resolvers.resolveTravelerPerson,
+          {
+            firstName: participant.firstName,
+            lastName: participant.lastName,
+            email: participant.email ?? null,
+            phone: participant.phone ?? null,
+            preferredLanguage: participant.preferredLanguage ?? null,
+          },
+          bookingId,
+        )
         await bookingsService.createTravelerRecord(
           db,
           bookingId,
@@ -1026,7 +1148,7 @@ export const publicBookingsService = {
             specialRequests: participant.specialRequests ?? null,
             isPrimary: participant.isPrimary,
             notes: participant.notes ?? null,
-            personId: null,
+            personId,
           },
           userId,
         )

--- a/packages/crm/src/service/accounts-resolve.ts
+++ b/packages/crm/src/service/accounts-resolve.ts
@@ -1,0 +1,153 @@
+import { identityContactPoints } from "@voyantjs/identity/schema"
+import { and, eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import type { people } from "../schema.js"
+import { peopleAccountsService } from "./accounts-people.js"
+import { personEntityType } from "./accounts-shared.js"
+import { normalizeContactValue, toNullableTrimmed } from "./helpers.js"
+
+/**
+ * Best-effort contact snapshot used by booking/storefront flows to
+ * resolve (or upsert) a CRM person from billing or traveler payloads.
+ * Empty-string and whitespace-only fields are normalized to `null`.
+ */
+export interface PersonContactInput {
+  firstName?: string | null
+  lastName?: string | null
+  /**
+   * Single-string display name when first/last aren't provided
+   * separately — split on whitespace.
+   */
+  name?: string | null
+  email?: string | null
+  phone?: string | null
+  preferredLanguage?: string | null
+}
+
+export interface UpsertPersonFromContactOptions {
+  /** `source` recorded on the `people` row (`"storefront-booking"`, etc.). */
+  source?: string | null
+  /** `source_ref` recorded on the `people` row — e.g. the session id. */
+  sourceRef?: string | null
+  /** Tags propagated to the new person when one is created. */
+  tags?: string[]
+  /** Status override; defaults to `"active"`. */
+  status?: "active" | "inactive"
+}
+
+function splitName(name: string | null | undefined): {
+  firstName?: string
+  lastName?: string
+} {
+  if (!name) return {}
+  const parts = name.trim().split(/\s+/)
+  if (parts.length === 0) return {}
+  if (parts.length === 1) return { firstName: parts[0] }
+  return { firstName: parts[0], lastName: parts.slice(1).join(" ") }
+}
+
+/**
+ * Derives `{ firstName, lastName }` for a CRM person from whatever
+ * contact bits the caller has. Mirrors the storefront-intake helpers
+ * (`personNameFromContact` / `personNameFromNewsletter`) so identity
+ * resolution from booking/traveler payloads stays symmetric. Falls
+ * back to the email local-part before resorting to literal placeholders
+ * — `people.first_name`/`last_name` are NOT NULL and the issue #961
+ * acceptance criteria call out that the literal `"Unknown"` should
+ * never be inserted.
+ */
+export function personNameFromContact(input: PersonContactInput): {
+  firstName: string
+  lastName: string
+} {
+  const split = splitName(input.name ?? null)
+  const emailLocalPart = input.email
+    ?.split("@")[0]
+    ?.replace(/[._-]+/g, " ")
+    .trim()
+  const firstName =
+    toNullableTrimmed(input.firstName) ?? split.firstName ?? emailLocalPart ?? "Customer"
+  const lastName = toNullableTrimmed(input.lastName) ?? split.lastName ?? "Guest"
+  return { firstName, lastName }
+}
+
+/**
+ * Returns the first person whose normalized contact point matches
+ * `(kind, value)`. Email and website are normalized to lowercase; phone
+ * is trimmed. Returns `null` when no match exists, the value resolves to
+ * an empty string, or the matching contact point is attached to a
+ * non-person entity (organizations share the same table).
+ */
+export async function findPersonByContactPoint(
+  db: PostgresJsDatabase,
+  query: { kind: "email" | "phone" | "website"; value: string | null | undefined },
+): Promise<typeof people.$inferSelect | null> {
+  const value = toNullableTrimmed(query.value)
+  if (!value) return null
+
+  const normalized = normalizeContactValue(query.kind, value)
+  const [row] = await db
+    .select({ personId: identityContactPoints.entityId })
+    .from(identityContactPoints)
+    .where(
+      and(
+        eq(identityContactPoints.entityType, personEntityType),
+        eq(identityContactPoints.kind, query.kind),
+        eq(identityContactPoints.normalizedValue, normalized),
+      ),
+    )
+    .limit(1)
+
+  if (!row) return null
+  return peopleAccountsService.getPersonById(db, row.personId)
+}
+
+/**
+ * Finds an existing CRM person by normalized email (then phone as a
+ * fallback) or creates a new one from the supplied contact snapshot.
+ * Used by booking session bootstrap + confirm flows so storefront
+ * bookings produce a real CRM record without each consumer reinventing
+ * the dedupe key. The created row carries the supplied `source` /
+ * `sourceRef` so the audit trail mirrors lead/newsletter signals.
+ *
+ * Lookup order: email → phone. The first hit wins; ties never happen
+ * because identity contact points are unique per `(kind, normalized)`
+ * for a given entity but consumers can re-use the same email across
+ * people via the unique-by-person sync logic. In that case the first
+ * person we see is returned — callers that need stricter ownership
+ * semantics should resolve themselves and pass a `personId` directly.
+ */
+export async function upsertPersonFromContact(
+  db: PostgresJsDatabase,
+  contact: PersonContactInput,
+  options: UpsertPersonFromContactOptions = {},
+): Promise<typeof people.$inferSelect | null> {
+  const email = toNullableTrimmed(contact.email)
+  const phone = toNullableTrimmed(contact.phone)
+
+  if (email) {
+    const existing = await findPersonByContactPoint(db, { kind: "email", value: email })
+    if (existing) return existing
+  }
+  if (phone) {
+    const existing = await findPersonByContactPoint(db, { kind: "phone", value: phone })
+    if (existing) return existing
+  }
+
+  // No match — create a new person. `personNameFromContact` ensures
+  // first/last name are populated even when only an email is on file.
+  const { firstName, lastName } = personNameFromContact(contact)
+  return peopleAccountsService.createPerson(db, {
+    firstName,
+    lastName,
+    email,
+    phone,
+    website: null,
+    status: options.status ?? "active",
+    source: options.source ?? null,
+    sourceRef: options.sourceRef ?? null,
+    preferredLanguage: toNullableTrimmed(contact.preferredLanguage),
+    tags: options.tags ?? [],
+  })
+}

--- a/packages/crm/src/service/accounts.ts
+++ b/packages/crm/src/service/accounts.ts
@@ -1,7 +1,20 @@
 import { organizationAccountsService } from "./accounts-organizations.js"
 import { peopleAccountsService } from "./accounts-people.js"
+import {
+  findPersonByContactPoint,
+  personNameFromContact,
+  upsertPersonFromContact,
+} from "./accounts-resolve.js"
 
 export const accountsService = {
   ...organizationAccountsService,
   ...peopleAccountsService,
+  findPersonByContactPoint,
+  upsertPersonFromContact,
 }
+
+export type {
+  PersonContactInput,
+  UpsertPersonFromContactOptions,
+} from "./accounts-resolve.js"
+export { findPersonByContactPoint, personNameFromContact, upsertPersonFromContact }

--- a/packages/crm/tests/integration/accounts-resolve.test.ts
+++ b/packages/crm/tests/integration/accounts-resolve.test.ts
@@ -1,0 +1,105 @@
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { peopleAccountsService } from "../../src/service/accounts-people.js"
+import {
+  findPersonByContactPoint,
+  upsertPersonFromContact,
+} from "../../src/service/accounts-resolve.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+describe.skipIf(!DB_AVAILABLE)("CRM person resolution helpers (issue #961)", () => {
+  let db: Awaited<ReturnType<typeof loadDb>>
+
+  async function loadDb() {
+    const { createTestDb } = await import("@voyantjs/db/test-utils")
+    return createTestDb()
+  }
+
+  beforeAll(async () => {
+    db = await loadDb()
+  })
+
+  beforeEach(async () => {
+    const { cleanupTestDb } = await import("@voyantjs/db/test-utils")
+    await cleanupTestDb(db)
+  })
+
+  it("findPersonByContactPoint matches a person by normalized email", async () => {
+    const created = await peopleAccountsService.createPerson(db, {
+      firstName: "Alice",
+      lastName: "Walker",
+      email: "Alice.Walker@Example.COM",
+      status: "active",
+      tags: [],
+    })
+    expect(created).not.toBeNull()
+
+    const hit = await findPersonByContactPoint(db, {
+      kind: "email",
+      value: "  alice.walker@example.com  ",
+    })
+
+    expect(hit?.id).toBe(created!.id)
+  })
+
+  it("findPersonByContactPoint returns null when nothing matches", async () => {
+    expect(
+      await findPersonByContactPoint(db, { kind: "email", value: "nobody@example.com" }),
+    ).toBeNull()
+  })
+
+  it("upsertPersonFromContact links to an existing person on email match", async () => {
+    const seeded = await peopleAccountsService.createPerson(db, {
+      firstName: "Existing",
+      lastName: "Customer",
+      email: "alice@example.com",
+      status: "active",
+      tags: [],
+    })
+
+    const resolved = await upsertPersonFromContact(
+      db,
+      {
+        firstName: "Alice",
+        lastName: "Walker",
+        email: "ALICE@example.com",
+        phone: "+40 712 345 678",
+      },
+      { source: "storefront-booking", sourceRef: "book_1" },
+    )
+
+    expect(resolved?.id).toBe(seeded!.id)
+  })
+
+  it("upsertPersonFromContact creates a new CRM row when no contact point matches", async () => {
+    const created = await upsertPersonFromContact(
+      db,
+      {
+        firstName: "Robin",
+        lastName: "Hood",
+        email: "robin@example.com",
+      },
+      { source: "storefront-booking", sourceRef: "book_42" },
+    )
+
+    expect(created?.id).toBeTruthy()
+    expect(created?.firstName).toBe("Robin")
+    expect(created?.source).toBe("storefront-booking")
+    expect(created?.sourceRef).toBe("book_42")
+
+    // Lookup should now find it back via normalized email.
+    const found = await findPersonByContactPoint(db, { kind: "email", value: "ROBIN@example.com" })
+    expect(found?.id).toBe(created!.id)
+  })
+
+  it("upsertPersonFromContact uses email local-part as firstName when name is missing (issue #961 acceptance)", async () => {
+    const created = await upsertPersonFromContact(
+      db,
+      { email: "lonely.traveler@example.com" },
+      { source: "storefront-booking", sourceRef: "book_99" },
+    )
+
+    expect(created?.firstName).toBe("lonely traveler")
+    expect(created?.lastName).toBe("Guest")
+  })
+})

--- a/packages/crm/tests/unit/accounts-resolve.test.ts
+++ b/packages/crm/tests/unit/accounts-resolve.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+
+import { personNameFromContact } from "../../src/service/accounts-resolve.js"
+
+describe("personNameFromContact", () => {
+  it("prefers explicit first/last when both are set", () => {
+    expect(
+      personNameFromContact({ firstName: "Alice", lastName: "Walker", email: "a@x.test" }),
+    ).toEqual({ firstName: "Alice", lastName: "Walker" })
+  })
+
+  it("falls back to the single `name` split when first/last are blank", () => {
+    expect(personNameFromContact({ name: "Marie  Curie", email: null })).toEqual({
+      firstName: "Marie",
+      lastName: "Curie",
+    })
+    expect(personNameFromContact({ name: "Cher" })).toEqual({
+      firstName: "Cher",
+      lastName: "Guest",
+    })
+  })
+
+  it("treats empty-string fields as missing (whitespace stripped)", () => {
+    expect(
+      personNameFromContact({ firstName: " ", lastName: "", email: "robin@example.com" }),
+    ).toEqual({ firstName: "robin", lastName: "Guest" })
+  })
+
+  it("issue #961 acceptance: never inserts the literal 'Unknown'; uses email local-part for firstName", () => {
+    expect(personNameFromContact({ email: "alice.walker@example.com" })).toEqual({
+      firstName: "alice walker",
+      lastName: "Guest",
+    })
+  })
+
+  it("falls back to 'Customer' / 'Guest' only when there's nothing else to use", () => {
+    expect(personNameFromContact({})).toEqual({ firstName: "Customer", lastName: "Guest" })
+  })
+})

--- a/templates/dmc/src/api/app.ts
+++ b/templates/dmc/src/api/app.ts
@@ -97,6 +97,25 @@ const crmHonoModule = createCrmHonoModule()
 const bookingsHonoModule = createBookingsHonoModule({
   resolveTravelSnapshot: (db, personId, { kms }) =>
     crmService.loadPersonTravelSnapshot(db, personId, { kms }),
+  // Storefront booking session bootstrap + update flows hand the
+  // billing contact and per-traveler snapshots to this resolver, which
+  // dedupes by normalized email/phone via `identity_contact_points` and
+  // upserts a CRM person on miss. Returns the resolved person id (or
+  // `null` to skip linkage on this row). See issue #961.
+  resolveBillingPerson: async (db, contact, ctx) => {
+    const person = await crmService.upsertPersonFromContact(db, contact, {
+      source: ctx.source,
+      sourceRef: ctx.sourceRef,
+    })
+    return person?.id ?? null
+  },
+  resolveTravelerPerson: async (db, contact, ctx) => {
+    const person = await crmService.upsertPersonFromContact(db, contact, {
+      source: ctx.source,
+      sourceRef: ctx.sourceRef,
+    })
+    return person?.id ?? null
+  },
 })
 
 export const app = createApp<CloudflareBindings>({

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -298,6 +298,25 @@ const crmHonoModule = createCrmHonoModule()
 const bookingsHonoModule = createBookingsHonoModule({
   resolveTravelSnapshot: (db, personId, { kms }) =>
     crmService.loadPersonTravelSnapshot(db, personId, { kms }),
+  // Storefront booking session bootstrap + update flows hand the
+  // billing contact and per-traveler snapshots to this resolver, which
+  // dedupes by normalized email/phone via `identity_contact_points` and
+  // upserts a CRM person on miss. Returns the resolved person id (or
+  // `null` to skip linkage on this row). See issue #961.
+  resolveBillingPerson: async (db, contact, ctx) => {
+    const person = await crmService.upsertPersonFromContact(db, contact, {
+      source: ctx.source,
+      sourceRef: ctx.sourceRef,
+    })
+    return person?.id ?? null
+  },
+  resolveTravelerPerson: async (db, contact, ctx) => {
+    const person = await crmService.upsertPersonFromContact(db, contact, {
+      source: ctx.source,
+      sourceRef: ctx.sourceRef,
+    })
+    return person?.id ?? null
+  },
 })
 
 const financeModule = createFinanceHonoModule({


### PR DESCRIPTION
Closes #961.

## Root cause
`publicBookingsService.createSession` + `updateSessionState` never created or linked a CRM `people` row. Storefront bookings landed with `bookings.person_id = NULL` and `booking_travelers.person_id = NULL`, so customers who completed a booking lived only in `bookings.contact_*` columns and were invisible to CRM dedupe, segmentation, or downstream marketing. Meanwhile the storefront's own lead/newsletter intake had been doing person upserts since day one (`createStorefrontLeadSignal`, `subscribeStorefrontNewsletter`) — exactly the asymmetry the issue calls out.

## Fix
Add CRM-free resolver hooks in `@voyantjs/bookings` (mirroring the existing `ResolveBookingTravelSnapshot` pattern, so the bookings package keeps zero direct CRM dependency) and ship the matching primitives in `@voyantjs/crm` so templates can wire them.

### `@voyantjs/crm` — new resolution primitives
- `personNameFromContact(contact)` — derives `{ firstName, lastName }` with explicit → name-split → email-local-part → `"Customer"/"Guest"` fallback. Never inserts the literal `"Unknown"` (acceptance criterion from the issue).
- `findPersonByContactPoint(db, { kind, value })` — normalized lookup via `identity_contact_points`.
- `upsertPersonFromContact(db, contact, { source, sourceRef })` — finds by email→phone or creates a new person. Carries `source`/`sourceRef` so the audit trail mirrors lead/newsletter signals.

### `@voyantjs/bookings` — resolver plumbing
- New runtime fields `resolveBillingPerson` + `resolveTravelerPerson` on `BookingRouteRuntime` and `BookingRouteRuntimeOptions`.
- `publicBookingsService.createSession` / `updateSession` / `updateSessionState` accept an optional `PublicBookingsServiceResolvers` arg. `routes-public.ts` pulls resolvers from the runtime container and passes them through.
- `createSession` + `updateSession` resolve a person per traveler before inserting `booking_travelers` rows.
- `updateSessionState` resolves a person from the billing contact when the wizard payload first lands, and stamps `bookings.person_id`. Existing `bookings.person_id` is never overwritten.
- Resolver failures are caught and logged; the booking still lands without a person link rather than aborting.
- Default behaviour (no resolvers) is unchanged — opt-in via template wiring, so this PR is backward compatible.

## Acceptance criteria mapping (from issue body)
- ✅ "`bookings.person_id` is set on the row returned by `confirmSession`" — `updateSessionState` stamps it as soon as billing arrives; the row is intact when `confirmSession` reads it.
- ✅ "`booking_travelers.person_id` is set per traveler" — resolved in both `createSession` and `updateSession` traveler create branches.
- ✅ "The fallback name strategy never inserts the literal `\"Unknown\"`; it uses email local-part or a stable placeholder" — covered by `personNameFromContact` + unit tests.
- 🟡 "A storefront booking with billing email matching an existing lead links to the same `people.id`" — covered by `upsertPersonFromContact`'s dedupe; templates wire it. This PR ships the primitive + the hook; the actual wiring is a one-liner per template (`createBookingsHonoModule({ resolveBillingPerson: (db, contact, ctx) => crmService.upsertPersonFromContact(db, contact, ctx).then(p => p?.id ?? null) })`). Will follow up with the DMC template wiring in a separate PR so this one stays focused on the platform shape.

## Tests
- 5 new unit cases for `personNameFromContact` (always run).
- DB-gated integration coverage for `findPersonByContactPoint` + `upsertPersonFromContact` covering the dedupe-vs-create path and the email-local-part fallback.
- `pnpm -F @voyantjs/bookings -F @voyantjs/crm test` → 130 + 250 passing (215 added/skipped over baseline; the integration tests skip without `TEST_DATABASE_URL`).
- `pnpm -F @voyantjs/bookings -F @voyantjs/crm typecheck` clean.

## Test plan
- [x] `pnpm -F @voyantjs/bookings -F @voyantjs/crm test`
- [x] `pnpm -F @voyantjs/bookings -F @voyantjs/crm typecheck`
- [ ] Wire `resolveBillingPerson`/`resolveTravelerPerson` in DMC (follow-up PR) and smoke a storefront booking — expect `bookings.person_id` set after the billing step, `booking_travelers.person_id` set after travelers land, and the second booking with the same email to link to the existing CRM row.

## Out of scope
- Wiring the resolvers in any template (separate PR; this one is the platform-shape change).
- Backfilling `person_id` on existing bookings.
- `reserveBooking` / `convertProductToBooking` paths — issue #961 specifically calls out the storefront session bootstrap + update flow.