### PR TITLE
fix(action-ledger, workflow-runs): stop dragging database drivers into client bundle (#968)

### DIFF
--- a/.changeset/issue-968-action-ledger-client-bundle.md
+++ b/.changeset/issue-968-action-ledger-client-bundle.md
@@ -1,0 +1,14 @@
+---
+"@voyantjs/action-ledger": patch
+"@voyantjs/workflow-runs": patch
+---
+
+Fix `@voyantjs/action-ledger` dragging database drivers into client bundles (issue #968).
+
+`action-ledger/service.ts` imported `newId` from `@voyantjs/db` (the package root), and `action-ledger/schema.ts` imported `typeId` from the same place. The `@voyantjs/db` root entry pulls `drizzle-orm/postgres-js`, `drizzle-orm/neon-http`, and `postgres`, which references Node's `Buffer`. Any client component that imported a pure constant from `@voyantjs/finance`/`@voyantjs/bookings`/`@voyantjs/products` (e.g. `noDepositPolicy`) — packages whose service trees re-export action-ledger — pulled the entire chain into the browser bundle and crashed at runtime with `ReferenceError: Buffer is not defined`.
+
+Both action-ledger imports now use leaf subpaths (`@voyantjs/db/lib/typeid` for `newId`, `@voyantjs/db/lib/typeid-column` for `typeId`). The remaining `AnyDrizzleDb` reference in `service.ts` is now `import type` only, so it is erased at build time.
+
+`@voyantjs/workflow-runs/schema.ts` had the same top-level `@voyantjs/db` import; switched to the leaf subpath as well to prevent the same regression resurfacing through that package.
+
+Adds a regression guard (`packages/action-ledger/tests/unit/no-db-root-imports.test.ts`) that walks every `packages/*/src/**/*.ts` file in the workspace and fails CI if any non-allow-listed module performs a runtime `import`/`export` from `@voyantjs/db` (the package root). The allow list is just the auth package (`auth/src/server.ts`, `auth/src/edge.ts`), which legitimately needs `getDb`.

--- a/packages/action-ledger/src/schema.ts
+++ b/packages/action-ledger/src/schema.ts
@@ -1,4 +1,4 @@
-import { typeId } from "@voyantjs/db"
+import { typeId } from "@voyantjs/db/lib/typeid-column"
 import { sql } from "drizzle-orm"
 import {
   boolean,

--- a/packages/action-ledger/src/service.ts
+++ b/packages/action-ledger/src/service.ts
@@ -1,4 +1,5 @@
-import { type AnyDrizzleDb, newId } from "@voyantjs/db"
+import type { AnyDrizzleDb } from "@voyantjs/db"
+import { newId } from "@voyantjs/db/lib/typeid"
 import { and, desc, eq, gte, inArray, lt, lte, or, type SQL, sql } from "drizzle-orm"
 
 import {

--- a/packages/action-ledger/tests/unit/no-db-root-imports.test.ts
+++ b/packages/action-ledger/tests/unit/no-db-root-imports.test.ts
@@ -1,0 +1,103 @@
+import { readdirSync, readFileSync, statSync } from "node:fs"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+const WORKSPACE_ROOT = join(fileURLToPath(import.meta.url), "../../../../..")
+const PACKAGES_DIR = join(WORKSPACE_ROOT, "packages")
+
+// Files allowed to runtime-import from the `@voyantjs/db` root entry. These
+// are server-only modules whose code never reaches client bundles. Every
+// other consumer must import from a leaf subpath (e.g. `@voyantjs/db/lib/typeid`)
+// to avoid dragging `drizzle-orm/postgres-js` + `postgres` (and Node `Buffer`)
+// into transitive client bundles — see issue #968.
+const ALLOW_LIST = new Set(["auth/src/server.ts", "auth/src/edge.ts"])
+
+function* walkTsFiles(dir: string): Generator<string> {
+  let entries: string[]
+  try {
+    entries = readdirSync(dir)
+  } catch {
+    return
+  }
+  for (const entry of entries) {
+    if (entry === "node_modules" || entry === "dist" || entry.startsWith(".")) continue
+    const abs = join(dir, entry)
+    const st = statSync(abs)
+    if (st.isDirectory()) {
+      yield* walkTsFiles(abs)
+    } else if (entry.endsWith(".ts") && !entry.endsWith(".d.ts")) {
+      yield abs
+    }
+  }
+}
+
+function findDbRootRuntimeImports(file: string, source: string): number[] {
+  const lines = source.split("\n")
+  const offenders: number[] = []
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!
+    if (!line.includes("@voyantjs/db")) continue
+    if (!/from\s+["']@voyantjs\/db["']/.test(line)) continue
+    // Walk backwards to find the line that opens this import/export statement
+    // (handles multi-line imports).
+    let start = i
+    while (start > 0 && !/^\s*(import|export)\b/.test(lines[start]!)) start--
+    const opener = lines[start]!
+    // Skip pure type-only declarations.
+    if (/^\s*(import|export)\s+type\b/.test(opener)) continue
+    offenders.push(i + 1)
+  }
+  return offenders
+}
+
+describe("no @voyantjs/db root runtime imports outside the allow list", () => {
+  it("findDbRootRuntimeImports flags runtime imports but skips type-only ones", () => {
+    // Self-check: catch regressions where the detector goes blind.
+    const sample = [
+      `import { newId } from "@voyantjs/db"`, // runtime — line 1
+      `import type { AnyDrizzleDb } from "@voyantjs/db"`, // type — skip
+      `import {`, // multi-line runtime — opens at line 3
+      `  newId,`,
+      `} from "@voyantjs/db"`, // line 5 (offender)
+      `import type {`, // multi-line type — opens at line 6
+      `  AnyDrizzleDb,`,
+      `} from "@voyantjs/db"`, // line 8 (skip)
+      `export * from "@voyantjs/db"`, // runtime re-export — line 9
+    ].join("\n")
+    expect(findDbRootRuntimeImports("inline", sample)).toEqual([1, 5, 9])
+  })
+
+  it("server packages must use leaf subpaths so client bundles don't drag drizzle/postgres (issue #968)", () => {
+    const offenders: string[] = []
+    let packages: string[]
+    try {
+      packages = readdirSync(PACKAGES_DIR)
+    } catch (error) {
+      throw new Error(`Cannot read workspace packages dir at ${PACKAGES_DIR}: ${String(error)}`)
+    }
+
+    // Skip `db` itself — its src files import via `./` relatives, not via the
+    // `@voyantjs/db` package name.
+    for (const pkg of packages) {
+      if (pkg === "db") continue
+      const srcDir = join(PACKAGES_DIR, pkg, "src")
+      for (const file of walkTsFiles(srcDir)) {
+        const rel = file.slice(PACKAGES_DIR.length + 1)
+        if (ALLOW_LIST.has(rel)) continue
+        const source = readFileSync(file, "utf8")
+        for (const lineNumber of findDbRootRuntimeImports(file, source)) {
+          offenders.push(`${rel}:${lineNumber}`)
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      `Found runtime imports from "@voyantjs/db" (root). Use a leaf subpath like ` +
+        `"@voyantjs/db/lib/typeid" or "@voyantjs/db/lib/typeid-column" so client ` +
+        `bundles don't pull drizzle-orm/postgres-js + postgres. Offenders:\n` +
+        offenders.join("\n"),
+    ).toEqual([])
+  })
+})

--- a/packages/workflow-runs/src/schema.ts
+++ b/packages/workflow-runs/src/schema.ts
@@ -16,7 +16,7 @@
  * tag with `bookingId:<id>`, `paymentSessionId:<id>`, etc.
  */
 
-import { typeId, typeIdRef } from "@voyantjs/db"
+import { typeId, typeIdRef } from "@voyantjs/db/lib/typeid-column"
 import { sql } from "drizzle-orm"
 import { check, index, integer, jsonb, pgEnum, pgTable, text, timestamp } from "drizzle-orm/pg-core"
 


### PR DESCRIPTION
## Summary

Fixes #968.

`@voyantjs/action-ledger/service.ts` and `schema.ts` imported `newId` / `typeId` from the `@voyantjs/db` package root, which transitively pulls `drizzle-orm/postgres-js` + `postgres` + Node `Buffer`. Any client component that imported a pure constant from `@voyantjs/finance`, `@voyantjs/bookings`, or `@voyantjs/products` (e.g. `noDepositPolicy`) dragged the chain into the browser bundle and crashed at runtime with `ReferenceError: Buffer is not defined`.

- Switch both action-ledger imports to leaf subpaths (`@voyantjs/db/lib/typeid`, `@voyantjs/db/lib/typeid-column`); `AnyDrizzleDb` is now `import type` only so it is erased at build time.
- Apply the same leaf-subpath fix to `@voyantjs/workflow-runs/src/schema.ts`, which had the identical pattern.
- Add a regression guard in `packages/action-ledger/tests/unit/no-db-root-imports.test.ts` that walks every `packages/*/src/**/*.ts` and fails CI if any non-allow-listed module performs a runtime `import`/`export` from `@voyantjs/db` (root). Allow list is just `auth/src/server.ts` and `auth/src/edge.ts`, which legitimately need `getDb`. Includes a self-check that exercises the detector against runtime and type-only fixtures so a broken regex cannot silently pass.

## Test plan

- [x] `pnpm -F @voyantjs/action-ledger test` — 106 passed (incl. the new guard + its self-check)
- [x] `pnpm -F @voyantjs/action-ledger -F @voyantjs/workflow-runs... -F @voyantjs/finance -F @voyantjs/bookings -F @voyantjs/products typecheck` — clean
- [x] Pre-commit full-workspace typecheck — clean
- [ ] Verify in a real Vite/TanStack Start app that `import { noDepositPolicy } from '@voyantjs/finance'` no longer pulls `drizzle-orm/postgres-js` or `postgres` into the client bundle