### PR TITLE
Fix product brochure markdown rendering

### DIFF
--- a/.changeset/bright-brochures-render.md
+++ b/.changeset/bright-brochures-render.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/products": patch
+---
+
+Render markdown brochure bodies to HTML for browser PDF printers while preserving inline HTML from rich-text day descriptions.

--- a/packages/products/package.json
+++ b/packages/products/package.json
@@ -47,10 +47,13 @@
     "@voyantjs/storage": "workspace:*",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.10",
+    "marked": "^18.0.3",
     "pdf-lib": "^1.17.1",
+    "sanitize-html": "^2.17.4",
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@types/sanitize-html": "^2.16.1",
     "@voyantjs/voyant-typescript-config": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/packages/products/src/tasks/brochure-printers.ts
+++ b/packages/products/src/tasks/brochure-printers.ts
@@ -1,5 +1,7 @@
 import { renderPdfDocument } from "@voyantjs/utils/pdf-renderer"
 import type { StructuredTemplateBodyFormat } from "@voyantjs/utils/template-renderer"
+import { marked } from "marked"
+import sanitizeHtml from "sanitize-html"
 
 import type {
   ProductBrochureTemplateContext,
@@ -42,15 +44,66 @@ function escapeHtml(value: string) {
     .replaceAll("'", "&#39;")
 }
 
+function renderMarkdownBrochureBody(body: string) {
+  return sanitizeHtml(marked(body, { async: false }), {
+    allowedTags: [
+      "a",
+      "b",
+      "blockquote",
+      "br",
+      "code",
+      "del",
+      "div",
+      "em",
+      "h1",
+      "h2",
+      "h3",
+      "h4",
+      "h5",
+      "h6",
+      "hr",
+      "i",
+      "li",
+      "ol",
+      "p",
+      "pre",
+      "s",
+      "span",
+      "strong",
+      "table",
+      "tbody",
+      "td",
+      "tfoot",
+      "th",
+      "thead",
+      "tr",
+      "u",
+      "ul",
+    ],
+    allowedAttributes: {
+      a: ["href", "name", "rel", "target", "title"],
+      "*": ["class", "title"],
+    },
+    allowedSchemes: ["http", "https", "mailto", "tel"],
+    allowedSchemesAppliedToAttributes: ["href"],
+    allowProtocolRelative: false,
+    disallowedTagsMode: "discard",
+  })
+}
+
 export function brochureBodyToHtml(
   body: string,
   bodyFormat: StructuredTemplateBodyFormat,
   title: string,
 ) {
-  const content =
-    bodyFormat === "html"
-      ? body
-      : `<pre style="white-space: pre-wrap; font-family: system-ui, sans-serif;">${escapeHtml(body)}</pre>`
+  let content: string
+  if (bodyFormat === "html") {
+    content = body
+  } else if (bodyFormat === "markdown") {
+    content = renderMarkdownBrochureBody(body)
+  } else {
+    content = `<pre style="white-space: pre-wrap; font-family: system-ui, sans-serif;">${escapeHtml(body)}</pre>`
+  }
 
   return [
     "<!doctype html>",

--- a/packages/products/tests/unit/brochure-printers.test.ts
+++ b/packages/products/tests/unit/brochure-printers.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
+  brochureBodyToHtml,
   createBasicPdfProductBrochurePrinter,
   createCloudflareBrowserProductBrochurePrinter,
   createCloudflareBrowserProductBrochurePrinterFromEnv,
@@ -131,6 +132,65 @@ describe("product brochure template and printers", () => {
       browserMsUsed: "91",
       productId: "prod_123",
     })
+  })
+
+  it("converts markdown brochure bodies to HTML for browser printers", () => {
+    const html = brochureBodyToHtml(
+      [
+        "# Voyant City Break",
+        "",
+        "## Day 1: Arrival",
+        "",
+        '<div class="payload-richtext"><p><strong>Airport transfer</strong></p></div>',
+      ].join("\n"),
+      "markdown",
+      "Voyant City Break brochure",
+    )
+
+    expect(html).toContain("<h1>Voyant City Break</h1>")
+    expect(html).toContain("<h2>Day 1: Arrival</h2>")
+    expect(html).toContain(
+      '<div class="payload-richtext"><p><strong>Airport transfer</strong></p></div>',
+    )
+    expect(html).not.toContain("<pre")
+    expect(html).not.toContain("&lt;div")
+  })
+
+  it("sanitizes unsafe markdown HTML before browser rendering", () => {
+    const html = brochureBodyToHtml(
+      [
+        "# Safe brochure",
+        "",
+        '<p onclick="alert(1)">Rich <strong>text</strong></p>',
+        '<script>alert("xss")</script>',
+        '<img src="https://example.com/tracker.png" onerror="alert(1)" />',
+        '<a href="javascript:alert(1)">Unsafe link</a>',
+        '<a href="https://example.com/details" target="_blank">Safe link</a>',
+      ].join("\n"),
+      "markdown",
+      "Safe brochure",
+    )
+
+    expect(html).toContain("<h1>Safe brochure</h1>")
+    expect(html).toContain("<p>Rich <strong>text</strong></p>")
+    expect(html).toContain('<a href="https://example.com/details" target="_blank">Safe link</a>')
+    expect(html).not.toContain("<script")
+    expect(html).not.toContain("<img")
+    expect(html).not.toContain("onclick")
+    expect(html).not.toContain("onerror")
+    expect(html).not.toContain("javascript:")
+    expect(html).not.toContain("alert(")
+  })
+
+  it("keeps unknown brochure body formats in escaped preformatted text", () => {
+    const html = brochureBodyToHtml(
+      '{"root":{"type":"root","children":[]}}',
+      "lexical_json",
+      "Lexical brochure",
+    )
+
+    expect(html).toContain("<pre")
+    expect(html).toContain("&quot;root&quot;")
   })
 
   it("requires Cloudflare credentials when building a printer from env", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4173,13 +4173,22 @@ importers:
       hono:
         specifier: ^4.12.10
         version: 4.12.10
+      marked:
+        specifier: ^18.0.3
+        version: 18.0.3
       pdf-lib:
         specifier: ^1.17.1
         version: 1.17.1
+      sanitize-html:
+        specifier: ^2.17.4
+        version: 2.17.4
       zod:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@types/sanitize-html':
+        specifier: ^2.16.1
+        version: 2.16.1
       '@voyantjs/voyant-typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
@@ -9395,6 +9404,9 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/sanitize-html@2.16.1':
+    resolution: {integrity: sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==}
+
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
@@ -10123,6 +10135,9 @@ packages:
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -10466,6 +10481,10 @@ packages:
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
 
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
@@ -10945,6 +10964,10 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
@@ -11076,6 +11099,9 @@ packages:
 
   launch-editor@2.13.2:
     resolution: {integrity: sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==}
+
+  launder@1.7.1:
+    resolution: {integrity: sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==}
 
   libphonenumber-js@1.12.41:
     resolution: {integrity: sha512-lsmMmGXBxXIK/VMLEj0kL6MtUs1kBGj1nTCzi6zgQoG1DEwqwt2DQyHxcLykceIxAnfE3hya7NuIh6PpC6S3fA==}
@@ -11243,6 +11269,11 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  marked@18.0.3:
+    resolution: {integrity: sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -11588,6 +11619,9 @@ packages:
   parse-passwd@1.0.0:
     resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
     engines: {node: '>=0.10.0'}
+
+  parse-srcset@1.0.2:
+    resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
 
   parse5-htmlparser2-tree-adapter@7.1.0:
     resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
@@ -12091,6 +12125,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sanitize-html@2.17.4:
+    resolution: {integrity: sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==}
 
   sass@1.77.4:
     resolution: {integrity: sha512-vcF3Ckow6g939GMA4PeU7b2K/9FALXk2KF9J87txdHzXbUF9XRQRwSxcAs/fGaTnJeBFd7UoV22j3lzMLdM0Pw==}
@@ -15871,6 +15908,10 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/sanitize-html@2.16.1':
+    dependencies:
+      htmlparser2: 10.1.0
+
   '@types/statuses@2.0.6': {}
 
   '@types/use-sync-external-store@0.0.6': {}
@@ -16714,6 +16755,8 @@ snapshots:
 
   date-fns@4.1.0: {}
 
+  dayjs@1.11.20: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -17068,6 +17111,8 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
+
+  escape-string-regexp@4.0.0: {}
 
   esprima@4.0.1: {}
 
@@ -17541,6 +17586,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-plain-object@5.0.0: {}
+
   is-potential-custom-element-name@1.0.1: {}
 
   is-promise@4.0.0: {}
@@ -17678,6 +17725,10 @@ snapshots:
     dependencies:
       picocolors: 1.1.1
       shell-quote: 1.8.3
+
+  launder@1.7.1:
+    dependencies:
+      dayjs: 1.11.20
 
   libphonenumber-js@1.12.41: {}
 
@@ -17818,6 +17869,8 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  marked@18.0.3: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -18200,6 +18253,8 @@ snapshots:
   parse-ms@4.0.0: {}
 
   parse-passwd@1.0.0: {}
+
+  parse-srcset@1.0.2: {}
 
   parse5-htmlparser2-tree-adapter@7.1.0:
     dependencies:
@@ -18753,6 +18808,16 @@ snapshots:
       queue-microtask: 1.2.3
 
   safer-buffer@2.1.2: {}
+
+  sanitize-html@2.17.4:
+    dependencies:
+      deepmerge: 4.3.1
+      escape-string-regexp: 4.0.0
+      htmlparser2: 10.1.0
+      is-plain-object: 5.0.0
+      launder: 1.7.1
+      parse-srcset: 1.0.2
+      postcss: 8.5.12
 
   sass@1.77.4:
     dependencies:


### PR DESCRIPTION
## Summary

- Render `bodyFormat: "markdown"` brochure bodies to HTML inside the server-side brochure printer path.
- Sanitize markdown-rendered brochure HTML with a conservative rich-text allowlist before browser rendering.
- Preserve safe inline rich-text tags from day descriptions while stripping scripts, event handlers, image/resource tags, and unsafe URL schemes.
- Keep first-party templates on server-side Voyant Cloud browser rendering via `client.browser.pdf(...)`; no browser/client-side brochure rendering is introduced.
- Add coverage for markdown rendering, sanitizer behavior, and the escaped fallback for other body formats.
- Add a patch changeset for `@voyantjs/products`.

Fixes #971.

## Verification

- `pnpm install`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @voyantjs/products typecheck`
- `pnpm --filter @voyantjs/products test`
- `pnpm exec biome check packages/products/src/tasks/brochure-printers.ts packages/products/tests/unit/brochure-printers.test.ts packages/products/package.json`
- Earlier pre-push `pnpm test` hook passed: 127 tasks successful.

## Note

A pre-commit broad `pnpm typecheck` run was killed by exit 137 in unrelated packages (`operator`, `dmc`, `@voyantjs/external-refs-ui`) after the focused products checks had passed. The later pre-push test hook completed successfully.