### PR TITLE
fix: align travel composer release train

### DIFF
--- a/packages/travel-composer-react/package.json
+++ b/packages/travel-composer-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/travel-composer-react",
-  "version": "0.53.0",
+  "version": "0.55.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/travel-composer/package.json
+++ b/packages/travel-composer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/travel-composer",
-  "version": "0.53.0",
+  "version": "0.55.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- align @voyantjs/travel-composer and @voyantjs/travel-composer-react with the 0.55.0 release train
- fixes the release workflow failure on main where those two packages remained at 0.53.0

## Verification
- pnpm verify:release-train
- pnpm --filter @voyantjs/travel-composer typecheck
- pnpm --filter @voyantjs/travel-composer-react typecheck

No changeset is included because this is a release metadata correction after the release versioning step already ran.