### PR TITLE
Complete flight adapter capability contract

### DIFF
--- a/.changeset/flight-adapter-capabilities.md
+++ b/.changeset/flight-adapter-capabilities.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/flights": minor
+---
+
+Complete the flight connector contract with optional capability-gated methods for post-book seat selection, check-in, exchange, refund, void, and SSR operations. Extend adapter context with optional request, idempotency, logger, abort signal, and environment fields.

--- a/apps/flights-demo-api/README.md
+++ b/apps/flights-demo-api/README.md
@@ -42,4 +42,5 @@ rather than at first request.
 | POST   | `/orders/:orderId/cancel`         | `cancelOrder`    |
 | POST   | `/ancillaries`                    | `getAncillaries` |
 | POST   | `/seatmap`                        | `getSeatMap`     |
+| POST   | `/seat-selection`                 | `selectSeats`    |
 | GET    | `/health`                         | (liveness probe) |

--- a/apps/flights-demo-api/src/routes.ts
+++ b/apps/flights-demo-api/src/routes.ts
@@ -11,6 +11,7 @@
  *   POST   /orders/:orderId/cancel       cancelOrder
  *   POST   /ancillaries                  getAncillaries
  *   POST   /seatmap                      getSeatMap
+ *   POST   /seat-selection               selectSeats
  */
 
 import type {
@@ -20,6 +21,7 @@ import type {
   FlightOrderStatus,
   FlightSearchRequest,
   SeatMapRequest,
+  SeatSelectionRequest,
 } from "@voyantjs/flights/contract/types"
 import { Hono } from "hono"
 
@@ -161,5 +163,61 @@ export function createRoutes(db: DemoFlightsDb): Hono {
     })
   })
 
+  // ── Seat selection ───────────────────────────────────────────────────
+  app.post("/seat-selection", async (c) => {
+    const body = await c.req.json<SeatSelectionRequest>()
+    const existing = await store.getOrder(db, body.orderId)
+    if (!existing) return c.json({ error: "Order not found" }, 404)
+
+    const passengerIds = new Set(existing.passengers.map((passenger) => passenger.passengerId))
+    const segmentIds = new Set(
+      existing.offer.itineraries.flatMap((itinerary) =>
+        itinerary.segments.map((segment) => segment.segmentId),
+      ),
+    )
+    const invalidSelection = body.selections.find(
+      (selection) =>
+        !passengerIds.has(selection.passengerId) || !segmentIds.has(selection.segmentId),
+    )
+    if (invalidSelection) {
+      return c.json(
+        {
+          error: `Invalid seat selection for passenger ${invalidSelection.passengerId} on segment ${invalidSelection.segmentId}`,
+        },
+        400,
+      )
+    }
+
+    const additionalAmount = totalSelectionPrice(body.selections)
+    const updated: FlightOrder = {
+      ...existing,
+      providerData: {
+        ...(existing.providerData ?? {}),
+        seatSelections: body.selections,
+      },
+      updatedAt: new Date().toISOString(),
+    }
+    await store.updateOrder(db, body.orderId, updated)
+    return c.json({
+      order: updated,
+      selections: body.selections,
+      ...(additionalAmount ? { additionalAmount } : {}),
+    })
+  })
+
   return app
+}
+
+function totalSelectionPrice(
+  selections: SeatSelectionRequest["selections"],
+): { amount: string; currency: string } | null {
+  let currency: string | null = null
+  let amount = 0
+  for (const selection of selections) {
+    if (!selection.price) continue
+    if (currency && selection.price.currency !== currency) return null
+    currency = selection.price.currency
+    amount += Number.parseFloat(selection.price.amount)
+  }
+  return currency ? { amount: amount.toFixed(2), currency } : null
 }

--- a/docs/architecture/catalog-flights-architecture.md
+++ b/docs/architecture/catalog-flights-architecture.md
@@ -67,9 +67,9 @@ If any of these cannot be implemented, the connection is not a flight connection
 | `flight/holds` | `ticketOrder` (two-step hold-then-ticket flow) |
 | `flight/seatmap` | `getSeatMap` |
 | `flight/seat-selection` | `selectSeats` |
-| `flight/ancillaries` | `getAncillaries`, `addAncillary` |
+| `flight/ancillaries` | `getAncillaries`; selected ancillaries are submitted through `bookFlight` |
 | `flight/checkin` | `checkIn` |
-| `flight/exchange` | `exchangeOrder` |
+| `flight/exchange` | `modifyOrder` |
 | `flight/refund` | `refundOrder` |
 | `flight/void` | `voidOrder` (same-day void) |
 | `flight/ssr` | `addSpecialServiceRequest` (meals, wheelchair, infant-on-lap, UM) |

--- a/packages/flights/README.md
+++ b/packages/flights/README.md
@@ -23,8 +23,10 @@ pnpm add @voyantjs/flights
   discriminated union. Shapes mirror voyant-cloud's `connect-flight-contract`
   so adapters are portable across `voyant-cloud` and Voyant Catalog.
 - **`./contract/adapter`** — `FlightConnectorAdapter` interface (5 core methods
-  + capability declarations). Provider-agnostic; implementations come from
-  Voyant Connect, third-party providers, or operator-built adapters.
+  + optional capability-gated methods for holds, seat maps, post-book seat
+  selection, check-in, exchange, refund, void, SSR, ancillaries, and order
+  listing). Provider-agnostic; implementations come from Voyant Connect,
+  third-party providers, or operator-built adapters.
 - **`./orchestration/fingerprint`** — Itinerary fingerprint helper. Two
   providers selling the same flight produce identical fingerprints.
 - **`./orchestration/fan-out`** — Multi-connection fan-out search:

--- a/packages/flights/src/contract/adapter.test.ts
+++ b/packages/flights/src/contract/adapter.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  type FlightAdapterContext,
+  FlightCapabilityNotSupportedError,
+  type FlightConnectorAdapter,
+  requireCapability,
+} from "./adapter.js"
+import { FLIGHT_CAPABILITIES, type FlightOffer, type FlightOrder } from "./types.js"
+
+const offer: FlightOffer = {
+  offerId: "offer_1",
+  source: "test",
+  itineraries: [
+    {
+      segments: [
+        {
+          segmentId: "seg_1",
+          carrierCode: "BA",
+          flightNumber: "177",
+          departure: { iataCode: "LHR", at: "2026-10-15T11:00:00+00:00" },
+          arrival: { iataCode: "JFK", at: "2026-10-15T14:00:00-04:00" },
+          cabin: "economy",
+        },
+      ],
+    },
+  ],
+  fareBreakdowns: [
+    {
+      passengerType: "adult",
+      passengerCount: 1,
+      baseFare: { amount: "500.00", currency: "USD" },
+      taxes: { amount: "100.00", currency: "USD" },
+      total: { amount: "600.00", currency: "USD" },
+    },
+  ],
+  totalPrice: { amount: "600.00", currency: "USD" },
+}
+
+const order: FlightOrder = {
+  orderId: "order_1",
+  pnr: "ABC123",
+  status: "ticketed",
+  offer,
+  passengers: [
+    {
+      passengerId: "pax_1",
+      type: "adult",
+      firstName: "Ada",
+      lastName: "Lovelace",
+      dateOfBirth: "1980-01-01",
+    },
+  ],
+  totalPrice: offer.totalPrice,
+  createdAt: "2026-10-01T10:00:00Z",
+}
+
+function makeCoreAdapter(): FlightConnectorAdapter {
+  return {
+    capabilities: { provider: "core", declared: [] },
+    async searchFlights() {
+      return { offers: [offer] }
+    },
+    async priceOffer() {
+      return { offer, valid: true }
+    },
+    async bookFlight() {
+      return { order }
+    },
+    async getOrder() {
+      return { order }
+    },
+    async cancelOrder() {
+      return { order: { ...order, status: "cancelled" } }
+    },
+  }
+}
+
+describe("FlightConnectorAdapter contract", () => {
+  it("allows core-only adapters to omit every optional capability method", async () => {
+    const adapter = makeCoreAdapter()
+
+    await expect(adapter.searchFlights({ connectionId: "conn" }, {} as never)).resolves.toEqual({
+      offers: [offer],
+    })
+    expect(adapter.selectSeats).toBeUndefined()
+    expect(adapter.checkIn).toBeUndefined()
+    expect(adapter.modifyOrder).toBeUndefined()
+    expect(adapter.refundOrder).toBeUndefined()
+    expect(adapter.voidOrder).toBeUndefined()
+    expect(adapter.addSpecialServiceRequest).toBeUndefined()
+  })
+
+  it("allows adapters to implement every declared capability method", async () => {
+    const adapter: FlightConnectorAdapter = {
+      ...makeCoreAdapter(),
+      capabilities: {
+        provider: "full",
+        declared: Object.values(FLIGHT_CAPABILITIES),
+      },
+      async listOrders() {
+        return { orders: [order], pagination: { total: 1, hasMore: false } }
+      },
+      async ticketOrder() {
+        return { order }
+      },
+      async getAncillaries() {
+        return { catalog: { baggage: [], assistance: [], extras: [] } }
+      },
+      async getSeatMap() {
+        return {
+          seatMap: {
+            segmentId: "seg_1",
+            cabin: "economy",
+            columnLayout: ["A", "B", "C", null, "D", "E", "F"],
+            rows: [],
+          },
+        }
+      },
+      async selectSeats(_ctx, request) {
+        return { order, selections: request.selections }
+      },
+      async checkIn() {
+        return { order, status: "checked_in", boardingPasses: [] }
+      },
+      async modifyOrder() {
+        return { order, priceDifference: { amount: "0.00", currency: "USD" } }
+      },
+      async refundOrder() {
+        return { order: { ...order, status: "cancelled" }, refundedAmount: order.totalPrice }
+      },
+      async voidOrder() {
+        return { order: { ...order, status: "cancelled" }, voidedAt: "2026-10-01T11:00:00Z" }
+      },
+      async addSpecialServiceRequest() {
+        return { order, status: "requested" }
+      },
+    }
+
+    await expect(
+      adapter.selectSeats?.({ connectionId: "conn" }, { orderId: order.orderId, selections: [] }),
+    ).resolves.toEqual({ order, selections: [] })
+    await expect(
+      adapter.refundOrder?.({ connectionId: "conn" }, { orderId: order.orderId }),
+    ).resolves.toEqual({
+      order: { ...order, status: "cancelled" },
+      refundedAmount: order.totalPrice,
+    })
+  })
+
+  it("types the new adapter context fields as optional runtime signals", () => {
+    const controller = new AbortController()
+    const loggerMessages: string[] = []
+    const context: FlightAdapterContext = {
+      connectionId: "conn",
+      requestId: "req_1",
+      correlationId: "corr_1",
+      idempotencyKey: "idem_1",
+      environment: "sandbox",
+      signal: controller.signal,
+      logger: {
+        debug: (message) => loggerMessages.push(message),
+        info: (message) => loggerMessages.push(message),
+        warn: (message) => loggerMessages.push(message),
+        error: (message) => loggerMessages.push(message),
+      },
+    }
+
+    context.logger?.info("context ready")
+
+    expect(context.requestId).toBe("req_1")
+    expect(context.signal).toBe(controller.signal)
+    expect(loggerMessages).toEqual(["context ready"])
+  })
+
+  it.each([
+    [FLIGHT_CAPABILITIES.SEAT_SELECTION, "selectSeats"],
+    [FLIGHT_CAPABILITIES.CHECKIN, "checkIn"],
+    [FLIGHT_CAPABILITIES.EXCHANGE, "modifyOrder"],
+    [FLIGHT_CAPABILITIES.REFUND, "refundOrder"],
+    [FLIGHT_CAPABILITIES.VOID, "voidOrder"],
+    [FLIGHT_CAPABILITIES.SSR, "addSpecialServiceRequest"],
+  ] as const)("throws the standard not-supported error for %s", (capability, operation) => {
+    expect(() =>
+      requireCapability({ provider: "core", declared: [] }, capability, operation),
+    ).toThrow(FlightCapabilityNotSupportedError)
+
+    try {
+      requireCapability({ provider: "core", declared: [] }, capability, operation)
+    } catch (error) {
+      expect(error).toMatchObject({ provider: "core", capability, operation })
+    }
+  })
+})

--- a/packages/flights/src/contract/adapter.ts
+++ b/packages/flights/src/contract/adapter.ts
@@ -16,20 +16,41 @@
 import type {
   AncillaryRequest,
   AncillaryResponse,
+  CheckInRequest,
+  CheckInResponse,
   FlightBookRequest,
   FlightCapability,
+  FlightModifyRequest,
+  FlightModifyResponse,
   FlightOffer,
   FlightOrder,
   FlightOrderStatus,
+  FlightRefundRequest,
+  FlightRefundResponse,
   FlightSearchPaginationMeta,
   FlightSearchRequest,
+  FlightVoidResponse,
   SeatMapRequest,
   SeatMapResponse,
+  SeatSelectionRequest,
+  SeatSelectionResponse,
+  SsrRequest,
+  SsrResponse,
 } from "./types.js"
+
+export interface AdapterLogger {
+  debug(message: string, meta?: Record<string, unknown>): void
+  info(message: string, meta?: Record<string, unknown>): void
+  warn(message: string, meta?: Record<string, unknown>): void
+  error(message: string, meta?: Record<string, unknown>): void
+}
+
+export type FlightAdapterEnvironment = "sandbox" | "production"
 
 /**
  * Context passed to every adapter call. Identifies the connection and
- * carries credentials, optional point-of-sale, tracing identifiers.
+ * carries credentials, optional point-of-sale, tracing identifiers,
+ * cancellation, idempotency, logging, and environment selection signals.
  *
  * `deps` is an escape hatch for adapter-specific runtime dependencies that
  * shouldn't bleed into the contract — e.g. a Postgres handle for a demo
@@ -41,7 +62,18 @@ export interface FlightAdapterContext {
   credentials?: Record<string, string>
   /** Operator's IATA office id / pseudo-city / point-of-sale, when applicable. */
   pointOfSale?: string
+  /** Upstream trace id, usually propagated from the caller. */
   correlationId?: string
+  /** Per-call request id for adapter-local tracing. */
+  requestId?: string
+  /** Idempotency key for replay-safe writes: book, modify, refund, void. */
+  idempotencyKey?: string
+  /** Adapter-scoped logger with provider/connection/request metadata bound in. */
+  logger?: AdapterLogger
+  /** Cancellation signal propagated from the orchestration layer. */
+  signal?: AbortSignal
+  /** Selects the supplier environment when the adapter supports both. */
+  environment?: FlightAdapterEnvironment
   deps?: Record<string, unknown>
 }
 
@@ -142,7 +174,14 @@ export interface FlightConnectorAdapter {
     request: FlightSearchRequest,
   ): Promise<FlightSearchResponse>
 
-  /** Re-price an offer immediately before booking. */
+  /**
+   * Re-price an offer immediately before booking.
+   *
+   * This is also the canonical re-quote path for offers approaching
+   * `FlightOffer.expiresAt` or `lastTicketingDate`. Callers should invoke it
+   * before booking whenever the offer is older than the provider's freshness
+   * window or the UI is resuming a saved/held offer.
+   */
   priceOffer(ctx: FlightAdapterContext, request: FlightPriceRequest): Promise<FlightPriceResponse>
 
   /**
@@ -198,6 +237,33 @@ export interface FlightConnectorAdapter {
    * are submitted at book time via `FlightBookRequest.ancillaries.seats`.
    */
   getSeatMap?(ctx: FlightAdapterContext, request: SeatMapRequest): Promise<SeatMapResponse>
+
+  /** `flight/seat-selection` — change/add seat selections on an existing order. */
+  selectSeats?(
+    ctx: FlightAdapterContext,
+    request: SeatSelectionRequest,
+  ): Promise<SeatSelectionResponse>
+
+  /** `flight/checkin` — initiate or complete online check-in for passengers. */
+  checkIn?(ctx: FlightAdapterContext, request: CheckInRequest): Promise<CheckInResponse>
+
+  /** `flight/exchange` — change an existing order's itinerary, fare, pax, or extras. */
+  modifyOrder?(
+    ctx: FlightAdapterContext,
+    request: FlightModifyRequest,
+  ): Promise<FlightModifyResponse>
+
+  /** `flight/refund` — refund a ticketed order after the ticketing/void window. */
+  refundOrder?(
+    ctx: FlightAdapterContext,
+    request: FlightRefundRequest,
+  ): Promise<FlightRefundResponse>
+
+  /** `flight/void` — void a ticketed order inside the supplier void window. */
+  voidOrder?(ctx: FlightAdapterContext, orderId: string): Promise<FlightVoidResponse>
+
+  /** `flight/ssr` — add a special service request such as wheelchair, meal, or UMNR. */
+  addSpecialServiceRequest?(ctx: FlightAdapterContext, request: SsrRequest): Promise<SsrResponse>
 }
 
 /**

--- a/packages/flights/src/contract/post-book-types.ts
+++ b/packages/flights/src/contract/post-book-types.ts
@@ -1,0 +1,136 @@
+import type {
+  AncillarySelection,
+  FlightOffer,
+  FlightOrder,
+  FlightPassenger,
+  Money,
+} from "./types.js"
+
+export interface SeatAssignment {
+  passengerId: string
+  segmentId: string
+  seatNumber: string
+  /** Per-pax seat fee. Omitted = included in fare or already paid. */
+  price?: Money
+  /** Provider-specific data — opaque round-trip. */
+  providerData?: Record<string, unknown>
+}
+
+export interface SeatSelectionRequest {
+  orderId: string
+  selections: SeatAssignment[]
+}
+
+export interface SeatSelectionResponse {
+  order: FlightOrder
+  selections: SeatAssignment[]
+  /** Total additional charge collected for the seat change, if any. */
+  additionalAmount?: Money
+}
+
+export type CheckInStatus = "initiated" | "checked_in" | "failed"
+
+export interface CheckInRequest {
+  orderId: string
+  passengerIds?: string[]
+  segmentIds?: string[]
+}
+
+export interface FlightBoardingPass {
+  passengerId: string
+  segmentId: string
+  boardingPassId?: string
+  seatNumber?: string
+  sequenceNumber?: string
+  zone?: string
+  /** Provider-specific data — opaque round-trip. */
+  providerData?: Record<string, unknown>
+}
+
+export interface CheckInResponse {
+  order: FlightOrder
+  status: CheckInStatus
+  boardingPasses?: FlightBoardingPass[]
+}
+
+export type FlightModifyReason =
+  | "customer_request"
+  | "schedule_change"
+  | "name_correction"
+  | "disruption"
+  | "operational"
+
+export interface FlightModifyRequest {
+  orderId: string
+  /** Re-priced replacement offer when the modification changes itinerary/fare. */
+  offer?: FlightOffer
+  /** Replacement passenger details for corrections allowed by the provider. */
+  passengers?: FlightPassenger[]
+  /** Add or replace ancillary picks as part of the modification. */
+  ancillaries?: AncillarySelection
+  reason?: FlightModifyReason
+}
+
+export interface FlightModifyResponse {
+  order: FlightOrder
+  /** Positive means collect more from the traveler; negative means credit due. */
+  priceDifference?: Money
+  penalties?: Money[]
+}
+
+export type FlightRefundReason =
+  | "customer_request"
+  | "schedule_change"
+  | "disruption"
+  | "duplicate_booking"
+  | "medical"
+  | "other"
+
+export interface FlightRefundRequest {
+  orderId: string
+  reason?: FlightRefundReason
+  /** Omit for a full refund; provide for supplier-supported partial refunds. */
+  amount?: Money
+}
+
+export interface FlightRefundResponse {
+  order: FlightOrder
+  refundId?: string
+  refundedAmount: Money
+  penalties?: Money[]
+}
+
+export interface FlightVoidResponse {
+  order: FlightOrder
+  voidId?: string
+  voidedAt: string
+}
+
+export type SsrCode =
+  | "WCHR"
+  | "WCHS"
+  | "WCHC"
+  | "BLND"
+  | "DEAF"
+  | "MAAS"
+  | "UMNR"
+  | "INFT"
+  | "PETC"
+  | "VGML"
+  | "KSML"
+  | "MOML"
+  | "OTHER"
+
+export interface SsrRequest {
+  orderId: string
+  code: SsrCode
+  passengerIds?: string[]
+  segmentIds?: string[]
+  text?: string
+}
+
+export interface SsrResponse {
+  order: FlightOrder
+  ssrId?: string
+  status: "requested" | "confirmed" | "rejected"
+}

--- a/packages/flights/src/contract/types.ts
+++ b/packages/flights/src/contract/types.ts
@@ -510,6 +510,26 @@ export interface SeatMapResponse {
   validUntil?: string
 }
 
+export type {
+  CheckInRequest,
+  CheckInResponse,
+  CheckInStatus,
+  FlightBoardingPass,
+  FlightModifyReason,
+  FlightModifyRequest,
+  FlightModifyResponse,
+  FlightRefundReason,
+  FlightRefundRequest,
+  FlightRefundResponse,
+  FlightVoidResponse,
+  SeatAssignment,
+  SeatSelectionRequest,
+  SeatSelectionResponse,
+  SsrCode,
+  SsrRequest,
+  SsrResponse,
+} from "./post-book-types.js"
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Capability ids
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/flights/src/index.ts
+++ b/packages/flights/src/index.ts
@@ -2,9 +2,11 @@
 
 // FlightConnectorAdapter contract.
 export {
+  type AdapterLogger,
   CAPABILITY_NOT_SUPPORTED,
   type FlightAdapterCapabilities,
   type FlightAdapterContext,
+  type FlightAdapterEnvironment,
   type FlightBookResponse,
   type FlightCancelReason,
   type FlightCancelResponse,

--- a/packages/flights/src/orchestration/fan-out.test.ts
+++ b/packages/flights/src/orchestration/fan-out.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import type { FlightConnectorAdapter } from "../contract/adapter.js"
+import type { FlightAdapterContext, FlightConnectorAdapter } from "../contract/adapter.js"
 import type { FlightOffer, FlightSearchRequest } from "../contract/types.js"
 import { fanOutFlightSearch } from "./fan-out.js"
 
@@ -38,7 +38,13 @@ function makeOffer(overrides: Partial<FlightOffer>): FlightOffer {
 
 function makeAdapter(
   provider: string,
-  behaviour: { offers?: FlightOffer[]; throws?: Error; delayMs?: number; maxSlices?: number } = {},
+  behaviour: {
+    offers?: FlightOffer[]
+    throws?: Error
+    delayMs?: number
+    maxSlices?: number
+    captureContext?: (ctx: FlightAdapterContext) => void
+  } = {},
 ): FlightConnectorAdapter {
   return {
     capabilities: {
@@ -46,7 +52,8 @@ function makeAdapter(
       declared: [],
       maxSlicesPerSearch: behaviour.maxSlices,
     },
-    async searchFlights() {
+    async searchFlights(ctx) {
+      behaviour.captureContext?.(ctx)
       if (behaviour.delayMs) {
         await new Promise((r) => setTimeout(r, behaviour.delayMs))
       }
@@ -253,5 +260,41 @@ describe("fanOutFlightSearch", () => {
 
     expect(result.offers).toHaveLength(1)
     expect(result.offers[0]?.cheapest.totalPrice.amount).toBe("100")
+  })
+
+  it("propagates adapter context fields to each connection", async () => {
+    const controller = new AbortController()
+    const captured: FlightAdapterContext[] = []
+
+    await fanOutFlightSearch({
+      adapters: [
+        {
+          connectionId: "conn_a",
+          adapter: makeAdapter("a", {
+            offers: [makeOffer({})],
+            captureContext: (ctx) => {
+              captured.push(ctx)
+            },
+          }),
+          context: {
+            requestId: "req_1",
+            correlationId: "corr_1",
+            idempotencyKey: "idem_1",
+            environment: "sandbox",
+            signal: controller.signal,
+          },
+        },
+      ],
+      request: oneSliceRequest,
+    })
+
+    expect(captured[0]).toMatchObject({
+      connectionId: "conn_a",
+      requestId: "req_1",
+      correlationId: "corr_1",
+      idempotencyKey: "idem_1",
+      environment: "sandbox",
+    })
+    expect(captured[0]?.signal).toBe(controller.signal)
   })
 })

--- a/packages/plugins/flights-demo/src/adapter.ts
+++ b/packages/plugins/flights-demo/src/adapter.ts
@@ -20,13 +20,25 @@ import type {
   FlightPriceResponse,
   FlightSearchResponse,
 } from "@voyantjs/flights/contract/adapter"
+import { requireCapability } from "@voyantjs/flights/contract/adapter"
 import type {
   AncillaryRequest,
   AncillaryResponse,
+  CheckInRequest,
+  CheckInResponse,
   FlightBookRequest,
+  FlightModifyRequest,
+  FlightModifyResponse,
+  FlightRefundRequest,
+  FlightRefundResponse,
   FlightSearchRequest,
+  FlightVoidResponse,
   SeatMapRequest,
   SeatMapResponse,
+  SeatSelectionRequest,
+  SeatSelectionResponse,
+  SsrRequest,
+  SsrResponse,
 } from "@voyantjs/flights/contract/types"
 
 const CAPABILITIES: FlightAdapterCapabilities = {
@@ -58,6 +70,7 @@ export function createDemoFlightAdapter(options: DemoFlightAdapterOptions): Flig
   const fetchImpl = options.fetch ?? globalThis.fetch
 
   async function call<T>(
+    ctx: FlightAdapterContext,
     path: string,
     init?: {
       method?: string
@@ -78,8 +91,15 @@ export function createDemoFlightAdapter(options: DemoFlightAdapterOptions): Flig
     }
     const response = await fetchImpl(url.toString(), {
       method: init?.method ?? "GET",
-      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        ...(ctx.correlationId ? { "x-correlation-id": ctx.correlationId } : {}),
+        ...(ctx.requestId ? { "x-request-id": ctx.requestId } : {}),
+        ...(ctx.idempotencyKey ? { "idempotency-key": ctx.idempotencyKey } : {}),
+      },
       body: init?.body !== undefined ? JSON.stringify(init.body) : undefined,
+      signal: ctx.signal,
     })
     const text = await response.text()
     const json: unknown = text ? JSON.parse(text) : null
@@ -96,31 +116,31 @@ export function createDemoFlightAdapter(options: DemoFlightAdapterOptions): Flig
   return {
     capabilities: CAPABILITIES,
 
-    async searchFlights(_ctx, request: FlightSearchRequest) {
-      return call<FlightSearchResponse>("/search", { method: "POST", body: request })
+    async searchFlights(ctx, request: FlightSearchRequest) {
+      return call<FlightSearchResponse>(ctx, "/search", { method: "POST", body: request })
     },
 
-    async priceOffer(_ctx, request: FlightPriceRequest) {
-      return call<FlightPriceResponse>("/price", { method: "POST", body: request })
+    async priceOffer(ctx, request: FlightPriceRequest) {
+      return call<FlightPriceResponse>(ctx, "/price", { method: "POST", body: request })
     },
 
-    async bookFlight(_ctx, request: FlightBookRequest) {
-      return call<FlightBookResponse>("/book", { method: "POST", body: request })
+    async bookFlight(ctx, request: FlightBookRequest) {
+      return call<FlightBookResponse>(ctx, "/book", { method: "POST", body: request })
     },
 
-    async getOrder(_ctx: FlightAdapterContext, orderId: string) {
-      return call<FlightGetOrderResponse>(`/orders/${encodeURIComponent(orderId)}`)
+    async getOrder(ctx: FlightAdapterContext, orderId: string) {
+      return call<FlightGetOrderResponse>(ctx, `/orders/${encodeURIComponent(orderId)}`)
     },
 
-    async cancelOrder(_ctx, orderId, reason) {
-      return call<FlightCancelResponse>(`/orders/${encodeURIComponent(orderId)}/cancel`, {
+    async cancelOrder(ctx, orderId, reason) {
+      return call<FlightCancelResponse>(ctx, `/orders/${encodeURIComponent(orderId)}/cancel`, {
         method: "POST",
         body: reason ? { reason } : {},
       })
     },
 
-    async listOrders(_ctx, query: FlightOrdersListQuery) {
-      return call<FlightOrdersListResponse>("/orders", {
+    async listOrders(ctx, query: FlightOrdersListQuery) {
+      return call<FlightOrdersListResponse>(ctx, "/orders", {
         query: {
           ...(query.cursor ? { cursor: query.cursor } : {}),
           ...(query.limit !== undefined ? { limit: String(query.limit) } : {}),
@@ -130,12 +150,44 @@ export function createDemoFlightAdapter(options: DemoFlightAdapterOptions): Flig
       })
     },
 
-    async getAncillaries(_ctx, request: AncillaryRequest) {
-      return call<AncillaryResponse>("/ancillaries", { method: "POST", body: request })
+    async getAncillaries(ctx, request: AncillaryRequest) {
+      return call<AncillaryResponse>(ctx, "/ancillaries", { method: "POST", body: request })
     },
 
-    async getSeatMap(_ctx, request: SeatMapRequest) {
-      return call<SeatMapResponse>("/seatmap", { method: "POST", body: request })
+    async getSeatMap(ctx, request: SeatMapRequest) {
+      return call<SeatMapResponse>(ctx, "/seatmap", { method: "POST", body: request })
+    },
+
+    async selectSeats(ctx, request: SeatSelectionRequest) {
+      return call<SeatSelectionResponse>(ctx, "/seat-selection", {
+        method: "POST",
+        body: request,
+      })
+    },
+
+    async checkIn(_ctx, _request: CheckInRequest): Promise<CheckInResponse> {
+      requireCapability(CAPABILITIES, "flight/checkin", "checkIn")
+      throw new Error("unreachable")
+    },
+
+    async modifyOrder(_ctx, _request: FlightModifyRequest): Promise<FlightModifyResponse> {
+      requireCapability(CAPABILITIES, "flight/exchange", "modifyOrder")
+      throw new Error("unreachable")
+    },
+
+    async refundOrder(_ctx, _request: FlightRefundRequest): Promise<FlightRefundResponse> {
+      requireCapability(CAPABILITIES, "flight/refund", "refundOrder")
+      throw new Error("unreachable")
+    },
+
+    async voidOrder(_ctx, _orderId: string): Promise<FlightVoidResponse> {
+      requireCapability(CAPABILITIES, "flight/void", "voidOrder")
+      throw new Error("unreachable")
+    },
+
+    async addSpecialServiceRequest(_ctx, _request: SsrRequest): Promise<SsrResponse> {
+      requireCapability(CAPABILITIES, "flight/ssr", "addSpecialServiceRequest")
+      throw new Error("unreachable")
     },
   }
 }


### PR DESCRIPTION
## Summary

- Add optional capability-gated `FlightConnectorAdapter` methods for post-book seat selection, check-in, exchange/modify, refund, void, and SSR operations.
- Extend `FlightAdapterContext` with optional request/idempotency identifiers, logger, abort signal, and environment fields.
- Add post-book contract types, focused contract/fan-out tests, demo adapter support for seat selection, and explicit unsupported-capability stubs.
- Update the flight architecture docs, package README, demo API README, and add a changeset for `@voyantjs/flights`.

## Verification

- `pnpm verify:fast`
- Commit hook: full workspace lint and typecheck
- Push hook: full workspace test

Closes #983.