### PR TITLE
Add flight contract runtime schemas

### DIFF
--- a/.changeset/flight-contract-runtime-schemas.md
+++ b/.changeset/flight-contract-runtime-schemas.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/flights": minor
+---
+
+Add zod runtime schemas for the public flight connector contract, including requests, responses, enums, value objects, adapter context, and capability declarations.

--- a/docs/architecture/catalog-flights-architecture.md
+++ b/docs/architecture/catalog-flights-architecture.md
@@ -77,6 +77,12 @@ If any of these cannot be implemented, the connection is not a flight connection
 
 The capability set is open-ended; new capability ids are added when a real provider needs them. This is exactly the "narrow at the edges, broad at the center" shape from the foundation §5.6 — applied to flights specifically.
 
+The package also ships zod runtime schemas for the public flight contract
+under `@voyantjs/flights/contract/schemas`. Any consumer exposing the
+adapter contract over HTTP, queues, RPC, or another wire boundary should
+validate with those shipped schemas instead of maintaining a parallel local
+copy of the contract shape.
+
 **Provider escape hatch.** Each `FlightOffer` and `FlightOrder` carries an opaque `providerData` field. Provider-specific data round-trips through the contract without leaking into the consumer-facing surface. If a consumer needs to read `providerData.amadeusXYZ` to make their integration work, the contract has leaked and needs widening.
 
 ### 3.1. Slice-based search and intent-driven booking

--- a/packages/flights/README.md
+++ b/packages/flights/README.md
@@ -27,6 +27,9 @@ pnpm add @voyantjs/flights
   selection, check-in, exchange, refund, void, SSR, ancillaries, and order
   listing). Provider-agnostic; implementations come from Voyant Connect,
   third-party providers, or operator-built adapters.
+- **`./contract/schemas`** — zod schemas for the public flight contract
+  request, response, enum, and value-object shapes. Use these at HTTP, queue,
+  RPC, and adapter boundaries instead of re-declaring runtime validators.
 - **`./orchestration/fingerprint`** — Itinerary fingerprint helper. Two
   providers selling the same flight produce identical fingerprints.
 - **`./orchestration/fan-out`** — Multi-connection fan-out search:
@@ -84,6 +87,15 @@ const result = await fanOutFlightSearch({
 // result.offers — merged offers across all connections, deduped by
 // itinerary fingerprint, sorted by cheapest price ascending.
 // result.perConnection — status + latency per connection.
+```
+
+### Runtime validation
+
+```typescript
+import { flightBookRequestSchema } from "@voyantjs/flights/contract/schemas"
+import type { FlightBookRequest } from "@voyantjs/flights/contract/types"
+
+const request: FlightBookRequest = flightBookRequestSchema.parse(await req.json())
 ```
 
 ### Reference data — operator's own Postgres tables

--- a/packages/flights/package.json
+++ b/packages/flights/package.json
@@ -7,6 +7,7 @@
     ".": "./src/index.ts",
     "./contract/types": "./src/contract/types.ts",
     "./contract/adapter": "./src/contract/adapter.ts",
+    "./contract/schemas": "./src/contract/schemas.ts",
     "./orchestration/fingerprint": "./src/orchestration/fingerprint.ts",
     "./orchestration/fan-out": "./src/orchestration/fan-out.ts",
     "./snapshot": "./src/snapshot.ts",
@@ -42,6 +43,11 @@
         "types": "./dist/contract/adapter.d.ts",
         "import": "./dist/contract/adapter.js",
         "default": "./dist/contract/adapter.js"
+      },
+      "./contract/schemas": {
+        "types": "./dist/contract/schemas.d.ts",
+        "import": "./dist/contract/schemas.js",
+        "default": "./dist/contract/schemas.js"
       },
       "./orchestration/fingerprint": {
         "types": "./dist/orchestration/fingerprint.d.ts",
@@ -80,7 +86,8 @@
   "dependencies": {
     "@voyantjs/db": "workspace:*",
     "@voyantjs/catalog": "workspace:*",
-    "drizzle-orm": "^0.45.2"
+    "drizzle-orm": "^0.45.2",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@voyantjs/voyant-typescript-config": "workspace:*",

--- a/packages/flights/src/contract/schemas.test.ts
+++ b/packages/flights/src/contract/schemas.test.ts
@@ -1,0 +1,531 @@
+import { describe, expect, it } from "vitest"
+import type { z } from "zod"
+
+import type {
+  AdapterLogger,
+  FlightAdapterCapabilities,
+  FlightAdapterContext,
+  FlightBookResponse,
+  FlightCancelResponse,
+  FlightGetOrderResponse,
+  FlightOrdersListQuery,
+  FlightOrdersListResponse,
+  FlightPriceRequest,
+  FlightPriceResponse,
+  FlightSearchResponse,
+} from "./adapter.js"
+import {
+  ancillaryRequestSchema,
+  ancillaryResponseSchema,
+  type ancillarySelectionSchema,
+  type billingAddressSchema,
+  checkInRequestSchema,
+  checkInResponseSchema,
+  type fareBreakdownSchema,
+  type fareBundleInclusionsSchema,
+  type fareBundleSchema,
+  flightAdapterCapabilitiesSchema,
+  flightAdapterContextSchema,
+  type flightBoardingPassSchema,
+  flightBookRequestSchema,
+  flightBookResponseSchema,
+  flightCancelResponseSchema,
+  flightGetOrderResponseSchema,
+  type flightItinerarySchema,
+  flightModifyRequestSchema,
+  flightModifyResponseSchema,
+  type flightOfferSchema,
+  flightOrdersListQuerySchema,
+  flightOrdersListResponseSchema,
+  type flightPassengerSchema,
+  flightPriceRequestSchema,
+  flightPriceResponseSchema,
+  flightRefundRequestSchema,
+  flightRefundResponseSchema,
+  type flightSearchPaginationMetaSchema,
+  flightSearchRequestSchema,
+  flightSearchResponseSchema,
+  type flightSegmentSchema,
+  type flightSliceSchema,
+  type flightTicketSchema,
+  flightVoidResponseSchema,
+  moneySchema,
+  type passengerCountsSchema,
+  type paymentIntentSchema,
+  type seatAssignmentSchema,
+  seatMapRequestSchema,
+  seatMapResponseSchema,
+  type seatMapSchema,
+  type seatRowSchema,
+  type seatSchema,
+  seatSelectionRequestSchema,
+  seatSelectionResponseSchema,
+  ssrRequestSchema,
+  ssrResponseSchema,
+  type travelDocumentSchema,
+} from "./schemas.js"
+import type {
+  AncillaryRequest,
+  AncillaryResponse,
+  AncillarySelection,
+  BillingAddress,
+  CheckInRequest,
+  CheckInResponse,
+  FareBreakdown,
+  FareBundle,
+  FareBundleInclusions,
+  FlightBoardingPass,
+  FlightBookRequest,
+  FlightModifyRequest,
+  FlightModifyResponse,
+  FlightOffer,
+  FlightPassenger,
+  FlightRefundRequest,
+  FlightRefundResponse,
+  FlightSearchPaginationMeta,
+  FlightSearchRequest,
+  FlightSegment,
+  FlightSlice,
+  FlightTicket,
+  FlightVoidResponse,
+  Itinerary,
+  Money,
+  PassengerCounts,
+  PaymentIntent,
+  Seat,
+  SeatAssignment,
+  SeatMap,
+  SeatMapRequest,
+  SeatMapResponse,
+  SeatRow,
+  SeatSelectionRequest,
+  SeatSelectionResponse,
+  SsrRequest,
+  SsrResponse,
+  TravelDocument,
+} from "./types.js"
+
+type AssertEquivalent<Actual, Expected> = Actual extends Expected
+  ? Expected extends Actual
+    ? true
+    : never
+  : never
+
+const typeChecks: [
+  AssertEquivalent<z.infer<typeof moneySchema>, Money>,
+  AssertEquivalent<z.infer<typeof flightSliceSchema>, FlightSlice>,
+  AssertEquivalent<z.infer<typeof passengerCountsSchema>, PassengerCounts>,
+  AssertEquivalent<z.infer<typeof flightSegmentSchema>, FlightSegment>,
+  AssertEquivalent<z.infer<typeof flightItinerarySchema>, Itinerary>,
+  AssertEquivalent<z.infer<typeof fareBreakdownSchema>, FareBreakdown>,
+  AssertEquivalent<z.infer<typeof fareBundleInclusionsSchema>, FareBundleInclusions>,
+  AssertEquivalent<z.infer<typeof fareBundleSchema>, FareBundle>,
+  AssertEquivalent<z.infer<typeof flightOfferSchema>, FlightOffer>,
+  AssertEquivalent<z.infer<typeof flightSearchPaginationMetaSchema>, FlightSearchPaginationMeta>,
+  AssertEquivalent<z.infer<typeof flightSearchRequestSchema>, FlightSearchRequest>,
+  AssertEquivalent<z.infer<typeof flightSearchResponseSchema>, FlightSearchResponse>,
+  AssertEquivalent<z.infer<typeof flightPriceRequestSchema>, FlightPriceRequest>,
+  AssertEquivalent<z.infer<typeof flightPriceResponseSchema>, FlightPriceResponse>,
+  AssertEquivalent<z.infer<typeof paymentIntentSchema>, PaymentIntent>,
+  AssertEquivalent<z.infer<typeof billingAddressSchema>, BillingAddress>,
+  AssertEquivalent<z.infer<typeof travelDocumentSchema>, TravelDocument>,
+  AssertEquivalent<z.infer<typeof flightPassengerSchema>, FlightPassenger>,
+  AssertEquivalent<z.infer<typeof ancillarySelectionSchema>, AncillarySelection>,
+  AssertEquivalent<z.infer<typeof flightBookRequestSchema>, FlightBookRequest>,
+  AssertEquivalent<z.infer<typeof flightBookResponseSchema>, FlightBookResponse>,
+  AssertEquivalent<z.infer<typeof flightTicketSchema>, FlightTicket>,
+  AssertEquivalent<z.infer<typeof flightGetOrderResponseSchema>, FlightGetOrderResponse>,
+  AssertEquivalent<z.infer<typeof flightCancelResponseSchema>, FlightCancelResponse>,
+  AssertEquivalent<z.infer<typeof flightOrdersListQuerySchema>, FlightOrdersListQuery>,
+  AssertEquivalent<z.infer<typeof flightOrdersListResponseSchema>, FlightOrdersListResponse>,
+  AssertEquivalent<z.infer<typeof ancillaryRequestSchema>, AncillaryRequest>,
+  AssertEquivalent<z.infer<typeof ancillaryResponseSchema>, AncillaryResponse>,
+  AssertEquivalent<z.infer<typeof seatSchema>, Seat>,
+  AssertEquivalent<z.infer<typeof seatRowSchema>, SeatRow>,
+  AssertEquivalent<z.infer<typeof seatMapSchema>, SeatMap>,
+  AssertEquivalent<z.infer<typeof seatMapRequestSchema>, SeatMapRequest>,
+  AssertEquivalent<z.infer<typeof seatMapResponseSchema>, SeatMapResponse>,
+  AssertEquivalent<z.infer<typeof seatAssignmentSchema>, SeatAssignment>,
+  AssertEquivalent<z.infer<typeof seatSelectionRequestSchema>, SeatSelectionRequest>,
+  AssertEquivalent<z.infer<typeof seatSelectionResponseSchema>, SeatSelectionResponse>,
+  AssertEquivalent<z.infer<typeof flightBoardingPassSchema>, FlightBoardingPass>,
+  AssertEquivalent<z.infer<typeof checkInRequestSchema>, CheckInRequest>,
+  AssertEquivalent<z.infer<typeof checkInResponseSchema>, CheckInResponse>,
+  AssertEquivalent<z.infer<typeof flightModifyRequestSchema>, FlightModifyRequest>,
+  AssertEquivalent<z.infer<typeof flightModifyResponseSchema>, FlightModifyResponse>,
+  AssertEquivalent<z.infer<typeof flightRefundRequestSchema>, FlightRefundRequest>,
+  AssertEquivalent<z.infer<typeof flightRefundResponseSchema>, FlightRefundResponse>,
+  AssertEquivalent<z.infer<typeof flightVoidResponseSchema>, FlightVoidResponse>,
+  AssertEquivalent<z.infer<typeof ssrRequestSchema>, SsrRequest>,
+  AssertEquivalent<z.infer<typeof ssrResponseSchema>, SsrResponse>,
+  AssertEquivalent<z.infer<typeof flightAdapterContextSchema>, FlightAdapterContext>,
+  AssertEquivalent<z.infer<typeof flightAdapterCapabilitiesSchema>, FlightAdapterCapabilities>,
+] = [
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+]
+void typeChecks
+
+const money: Money = { amount: "600.00", currency: "USD" }
+
+const segment: FlightSegment = {
+  segmentId: "seg_1",
+  carrierCode: "BA",
+  flightNumber: "177",
+  departure: { iataCode: "LHR", terminal: "5", at: "2026-10-15T11:00:00+00:00" },
+  arrival: { iataCode: "JFK", terminal: "8", at: "2026-10-15T14:00:00-04:00" },
+  aircraft: "777",
+  cabin: "economy",
+  providerData: { source: "fixture" },
+}
+
+const offer: FlightOffer = {
+  offerId: "offer_1",
+  source: "test",
+  itineraries: [{ segments: [segment], duration: "PT8H" }],
+  fareBreakdowns: [
+    {
+      passengerType: "adult",
+      passengerCount: 1,
+      baseFare: { amount: "500.00", currency: "USD" },
+      taxes: { amount: "100.00", currency: "USD" },
+      total: money,
+    },
+  ],
+  totalPrice: money,
+  validatingCarrier: "BA",
+  expiresAt: "2026-10-01T11:00:00Z",
+  lastTicketingDate: "2026-10-02",
+  fareBundles: [
+    {
+      id: "standard",
+      label: "Standard",
+      tier: "standard",
+      priceDelta: { amount: "30.00", currency: "USD" },
+      inclusions: {
+        cabinBag: { included: true, weightKg: 8 },
+        seatSelection: "standard",
+      },
+    },
+  ],
+}
+
+const passenger: FlightPassenger = {
+  passengerId: "pax_1",
+  type: "adult",
+  firstName: "Ada",
+  lastName: "Lovelace",
+  dateOfBirth: "1980-01-01",
+  documents: [
+    {
+      type: "passport",
+      number: "123456789",
+      countryOfIssue: "GB",
+      expiryDate: "2030-01-01",
+    },
+  ],
+}
+
+const order = {
+  orderId: "order_1",
+  pnr: "ABC123",
+  status: "ticketed",
+  offer,
+  passengers: [passenger],
+  contact: { email: "ada@example.com" },
+  tickets: [{ ticketNumber: "1250000000001", passengerId: "pax_1", segmentIds: ["seg_1"] }],
+  totalPrice: money,
+  createdAt: "2026-10-01T10:00:00Z",
+  providerData: { locator: "ABC123" },
+} satisfies z.infer<typeof flightBookResponseSchema>["order"]
+
+const ancillarySelection: AncillarySelection = {
+  baggage: [{ passengerId: "pax_1", sliceIndex: 0, optionId: "bag_20kg", quantity: 1 }],
+  seats: [{ passengerId: "pax_1", segmentId: "seg_1", seatNumber: "12A" }],
+}
+
+const seatMap: SeatMap = {
+  segmentId: "seg_1",
+  aircraft: "777",
+  cabin: "economy",
+  columnLayout: ["A", "B", "C", null, "D", "E", "F"],
+  rows: [
+    {
+      row: 12,
+      seats: [
+        {
+          seatNumber: "12A",
+          row: 12,
+          column: "A",
+          status: "available",
+          category: "standard",
+          window: true,
+        },
+      ],
+    },
+  ],
+}
+
+const logger: AdapterLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+}
+
+const roundTripCases = [
+  [
+    "flightSearchRequestSchema",
+    flightSearchRequestSchema,
+    {
+      slices: [{ origin: "LHR", destination: "JFK", departureDate: "2026-10-15" }],
+      passengers: { adults: 1 },
+      cabin: "economy",
+    } satisfies FlightSearchRequest,
+  ],
+  ["flightSearchResponseSchema", flightSearchResponseSchema, { offers: [offer] }],
+  ["flightPriceRequestSchema", flightPriceRequestSchema, { offerId: "offer_1", offer }],
+  ["flightPriceResponseSchema", flightPriceResponseSchema, { offer, valid: true }],
+  [
+    "flightBookRequestSchema",
+    flightBookRequestSchema,
+    {
+      offerId: "offer_1",
+      offer,
+      passengers: [passenger],
+      paymentIntent: { type: "hold" },
+      ancillaries: ancillarySelection,
+    } satisfies FlightBookRequest,
+  ],
+  ["flightBookResponseSchema", flightBookResponseSchema, { order }],
+  ["flightGetOrderResponseSchema", flightGetOrderResponseSchema, { order }],
+  ["flightCancelResponseSchema", flightCancelResponseSchema, { order, refundedAmount: money }],
+  [
+    "flightOrdersListQuerySchema",
+    flightOrdersListQuerySchema,
+    { cursor: "next", limit: 20, status: ["ticketed"], search: "ABC" },
+  ],
+  [
+    "flightOrdersListResponseSchema",
+    flightOrdersListResponseSchema,
+    { orders: [order], pagination: { total: 1, hasMore: false } },
+  ],
+  ["ancillaryRequestSchema", ancillaryRequestSchema, { offerId: "offer_1", offer }],
+  [
+    "ancillaryResponseSchema",
+    ancillaryResponseSchema,
+    {
+      catalog: {
+        baggage: [{ id: "bag_20kg", label: "20kg bag", category: "checked", price: money }],
+        assistance: [{ id: "wchr", label: "Wheelchair", category: "wheelchair" }],
+        extras: [{ id: "priority", label: "Priority", category: "boarding", price: money }],
+      },
+      validUntil: "2026-10-01T11:00:00Z",
+    },
+  ],
+  ["seatMapRequestSchema", seatMapRequestSchema, { offerId: "offer_1", segmentId: "seg_1", offer }],
+  ["seatMapResponseSchema", seatMapResponseSchema, { seatMap }],
+  [
+    "seatSelectionRequestSchema",
+    seatSelectionRequestSchema,
+    {
+      orderId: "order_1",
+      selections: [{ passengerId: "pax_1", segmentId: "seg_1", seatNumber: "12A" }],
+    },
+  ],
+  [
+    "seatSelectionResponseSchema",
+    seatSelectionResponseSchema,
+    { order, selections: [{ passengerId: "pax_1", segmentId: "seg_1", seatNumber: "12A" }] },
+  ],
+  ["checkInRequestSchema", checkInRequestSchema, { orderId: "order_1", passengerIds: ["pax_1"] }],
+  [
+    "checkInResponseSchema",
+    checkInResponseSchema,
+    {
+      order,
+      status: "checked_in",
+      boardingPasses: [{ passengerId: "pax_1", segmentId: "seg_1", seatNumber: "12A" }],
+    },
+  ],
+  [
+    "flightModifyRequestSchema",
+    flightModifyRequestSchema,
+    { orderId: "order_1", ancillaries: ancillarySelection },
+  ],
+  [
+    "flightModifyResponseSchema",
+    flightModifyResponseSchema,
+    { order, priceDifference: { amount: "-25.00", currency: "USD" } },
+  ],
+  [
+    "flightRefundRequestSchema",
+    flightRefundRequestSchema,
+    { orderId: "order_1", reason: "customer_request" },
+  ],
+  ["flightRefundResponseSchema", flightRefundResponseSchema, { order, refundedAmount: money }],
+  [
+    "flightVoidResponseSchema",
+    flightVoidResponseSchema,
+    { order, voidedAt: "2026-10-01T11:00:00Z" },
+  ],
+  [
+    "ssrRequestSchema",
+    ssrRequestSchema,
+    { orderId: "order_1", code: "WCHR", passengerIds: ["pax_1"] },
+  ],
+  ["ssrResponseSchema", ssrResponseSchema, { order, status: "requested" }],
+  [
+    "flightAdapterContextSchema",
+    flightAdapterContextSchema,
+    { connectionId: "conn_1", logger, environment: "sandbox" },
+  ],
+  [
+    "flightAdapterCapabilitiesSchema",
+    flightAdapterCapabilitiesSchema,
+    { provider: "demo", declared: ["flight/holds"], maxSlicesPerSearch: 2 },
+  ],
+] as const
+
+const invalidCases = [
+  ["moneySchema", moneySchema, { amount: 600, currency: "USD" }],
+  [
+    "flightSearchRequestSchema",
+    flightSearchRequestSchema,
+    { slices: [], passengers: { adults: -1 } },
+  ],
+  ["flightSearchResponseSchema", flightSearchResponseSchema, { offers: [{ totalPrice: money }] }],
+  ["flightPriceRequestSchema", flightPriceRequestSchema, { offerId: 123 }],
+  ["flightPriceResponseSchema", flightPriceResponseSchema, { offer, valid: "yes" }],
+  ["flightBookRequestSchema", flightBookRequestSchema, { offerId: "offer_1", passengers: [{}] }],
+  [
+    "flightBookResponseSchema",
+    flightBookResponseSchema,
+    { order: { ...order, status: "unknown" } },
+  ],
+  [
+    "flightGetOrderResponseSchema",
+    flightGetOrderResponseSchema,
+    { order: { ...order, totalPrice: { amount: "x", currency: "USD" } } },
+  ],
+  [
+    "flightCancelResponseSchema",
+    flightCancelResponseSchema,
+    { order, refundedAmount: { amount: "1.00", currency: "US" } },
+  ],
+  ["flightOrdersListQuerySchema", flightOrdersListQuerySchema, { limit: 0 }],
+  [
+    "flightOrdersListResponseSchema",
+    flightOrdersListResponseSchema,
+    { orders: [order], pagination: { total: -1, hasMore: false } },
+  ],
+  ["ancillaryRequestSchema", ancillaryRequestSchema, { offerId: 123 }],
+  [
+    "ancillaryResponseSchema",
+    ancillaryResponseSchema,
+    { catalog: { baggage: [], assistance: [] } },
+  ],
+  ["seatMapRequestSchema", seatMapRequestSchema, { offerId: "offer_1" }],
+  ["seatMapResponseSchema", seatMapResponseSchema, { seatMap: { ...seatMap, cabin: "sofa" } }],
+  [
+    "seatSelectionRequestSchema",
+    seatSelectionRequestSchema,
+    { orderId: "order_1", selections: [{ seatNumber: "12A" }] },
+  ],
+  [
+    "seatSelectionResponseSchema",
+    seatSelectionResponseSchema,
+    { order, selections: [{ passengerId: "pax_1" }] },
+  ],
+  ["checkInRequestSchema", checkInRequestSchema, { passengerIds: ["pax_1"] }],
+  ["checkInResponseSchema", checkInResponseSchema, { order, status: "done" }],
+  [
+    "flightModifyRequestSchema",
+    flightModifyRequestSchema,
+    { orderId: "order_1", reason: "vacation" },
+  ],
+  [
+    "flightModifyResponseSchema",
+    flightModifyResponseSchema,
+    { order, penalties: [{ amount: "1.00", currency: "US" }] },
+  ],
+  [
+    "flightRefundRequestSchema",
+    flightRefundRequestSchema,
+    { orderId: "order_1", reason: "changed_mind" },
+  ],
+  [
+    "flightRefundResponseSchema",
+    flightRefundResponseSchema,
+    { order, refundedAmount: { amount: "x", currency: "USD" } },
+  ],
+  ["flightVoidResponseSchema", flightVoidResponseSchema, { order }],
+  ["ssrRequestSchema", ssrRequestSchema, { orderId: "order_1", code: "NOPE" }],
+  ["ssrResponseSchema", ssrResponseSchema, { order, status: "done" }],
+  [
+    "flightAdapterCapabilitiesSchema",
+    flightAdapterCapabilitiesSchema,
+    { provider: "demo", declared: ["flight/nope"] },
+  ],
+  [
+    "flightAdapterContextSchema",
+    flightAdapterContextSchema,
+    { connectionId: "conn_1", logger: {} },
+  ],
+] as const
+
+describe("flight contract schemas", () => {
+  it.each(roundTripCases)("parses %s fixtures without changing shape", (_name, schema, value) => {
+    expect(schema.parse(value)).toEqual(value)
+  })
+
+  it.each(invalidCases)("rejects invalid %s fixtures", (_name, schema, value) => {
+    expect(schema.safeParse(value).success).toBe(false)
+  })
+})

--- a/packages/flights/src/contract/schemas.ts
+++ b/packages/flights/src/contract/schemas.ts
@@ -1,0 +1,597 @@
+import { z } from "zod"
+
+import { FLIGHT_CAPABILITIES, type FlightCapability } from "./types.js"
+
+const decimalStringSchema = z.string().regex(/^\d+(\.\d+)?$/)
+const signedDecimalStringSchema = z.string().regex(/^-?\d+(\.\d+)?$/)
+const iataCodeSchema = z.string().length(3)
+const carrierCodeSchema = z.string().min(2).max(3)
+const currencyCodeSchema = z.string().length(3)
+const providerDataSchema = z.record(z.string(), z.unknown())
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null
+
+export const cabinClassSchema = z.enum(["economy", "premium_economy", "business", "first"])
+export const passengerTypeSchema = z.enum(["adult", "child", "infant", "senior", "youth"])
+export const paymentIntentTypeSchema = z.enum(["hold", "card", "ticket_on_credit"])
+export const flightOrderStatusSchema = z.enum([
+  "pending",
+  "confirmed",
+  "ticketed",
+  "cancelled",
+  "failed",
+])
+export const flightCancelReasonSchema = z.enum([
+  "customer_request",
+  "schedule_change",
+  "operational",
+  "fraud",
+])
+export const flightModifyReasonSchema = z.enum([
+  "customer_request",
+  "schedule_change",
+  "name_correction",
+  "disruption",
+  "operational",
+])
+export const flightRefundReasonSchema = z.enum([
+  "customer_request",
+  "schedule_change",
+  "disruption",
+  "duplicate_booking",
+  "medical",
+  "other",
+])
+export const ssrCodeSchema = z.enum([
+  "WCHR",
+  "WCHS",
+  "WCHC",
+  "BLND",
+  "DEAF",
+  "MAAS",
+  "UMNR",
+  "INFT",
+  "PETC",
+  "VGML",
+  "KSML",
+  "MOML",
+  "OTHER",
+])
+export const checkInStatusSchema = z.enum(["initiated", "checked_in", "failed"])
+export const flightAdapterEnvironmentSchema = z.enum(["sandbox", "production"])
+export const flightCapabilitySchema = z.enum(
+  Object.values(FLIGHT_CAPABILITIES) as [FlightCapability, ...FlightCapability[]],
+)
+
+export const moneySchema = z.object({
+  amount: decimalStringSchema,
+  currency: currencyCodeSchema,
+})
+
+const signedMoneySchema = moneySchema.extend({ amount: signedDecimalStringSchema })
+
+export const flightContactSchema = z.object({
+  email: z.string().optional(),
+  phone: z.string().optional(),
+})
+
+export const pointOfSaleSchema = z.string()
+
+export const flightSegmentEndpointSchema = z.object({
+  iataCode: iataCodeSchema,
+  terminal: z.string().optional(),
+  at: z.string(),
+})
+
+export const flightSegmentSchema = z.object({
+  segmentId: z.string(),
+  carrierCode: carrierCodeSchema,
+  flightNumber: z.string(),
+  operatingCarrierCode: carrierCodeSchema.optional(),
+  operatingFlightNumber: z.string().optional(),
+  departure: flightSegmentEndpointSchema,
+  arrival: flightSegmentEndpointSchema,
+  duration: z.string().optional(),
+  aircraft: z.string().optional(),
+  cabin: cabinClassSchema,
+  fareClass: z.string().optional(),
+  fareBasis: z.string().optional(),
+  status: z.string().optional(),
+  providerData: providerDataSchema.optional(),
+})
+
+export const flightItinerarySchema = z.object({
+  segments: z.array(flightSegmentSchema),
+  duration: z.string().optional(),
+})
+
+export const itinerarySchema = flightItinerarySchema
+
+export const fareBreakdownSchema = z.object({
+  passengerType: passengerTypeSchema,
+  passengerCount: z.number().int().min(0),
+  baseFare: moneySchema,
+  taxes: moneySchema,
+  fees: moneySchema.optional(),
+  total: moneySchema,
+  fareFamily: z.string().optional(),
+})
+
+export const fareBundleInclusionsSchema = z.object({
+  cabinBag: z
+    .object({
+      included: z.boolean(),
+      weightKg: z.number().optional(),
+    })
+    .optional(),
+  checkedBag: z
+    .object({
+      included: z.boolean(),
+      pieces: z.number().optional(),
+      weightKg: z.number().optional(),
+    })
+    .optional(),
+  seatSelection: z.enum(["none", "standard", "free"]).optional(),
+  priorityBoarding: z.boolean().optional(),
+  loungeAccess: z.boolean().optional(),
+  refundable: z.boolean().optional(),
+  changeable: z.boolean().optional(),
+  notes: z.array(z.string()).optional(),
+})
+
+export const fareBundleSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  tier: z.enum(["basic", "standard", "plus", "premium"]),
+  priceDelta: moneySchema,
+  recommended: z.boolean().optional(),
+  inclusions: fareBundleInclusionsSchema,
+  providerData: providerDataSchema.optional(),
+})
+
+export const flightOfferSchema = z.object({
+  offerId: z.string(),
+  source: z.string(),
+  itineraries: z.array(flightItinerarySchema),
+  fareBreakdowns: z.array(fareBreakdownSchema),
+  totalPrice: moneySchema,
+  validatingCarrier: z.string().optional(),
+  expiresAt: z.string().optional(),
+  lastTicketingDate: z.string().optional(),
+  instantTicketing: z.boolean().optional(),
+  fareBundles: z.array(fareBundleSchema).optional(),
+  providerData: providerDataSchema.optional(),
+})
+
+export const flightSliceSchema = z.object({
+  origin: iataCodeSchema,
+  destination: iataCodeSchema,
+  departureDate: z.string(),
+  departureTimeWindow: z
+    .object({
+      earliest: z.string().optional(),
+      latest: z.string().optional(),
+    })
+    .optional(),
+})
+
+export const passengerCountsSchema = z.object({
+  adults: z.number().int().min(0),
+  children: z.number().int().min(0).optional(),
+  infants: z.number().int().min(0).optional(),
+})
+
+export const flightSearchPaginationSchema = z.object({
+  limit: z.number().int().min(1).optional(),
+  cursor: z.string().optional(),
+})
+
+export const flightSearchPaginationMetaSchema = z.object({
+  total: z.number().int().min(0),
+  cursor: z.string().optional(),
+  hasMore: z.boolean(),
+})
+
+export const flightSearchOptionsSchema = z.object({
+  directOnly: z.boolean().optional(),
+  maxStops: z.number().int().min(0).optional(),
+  minConnectionMinutes: z.number().int().min(0).optional(),
+  includeCarriers: z.array(carrierCodeSchema).optional(),
+  excludeCarriers: z.array(carrierCodeSchema).optional(),
+  maxPrice: z.number().min(0).optional(),
+})
+
+export const flightSearchRequestSchema = z.object({
+  slices: z.array(flightSliceSchema),
+  passengers: passengerCountsSchema,
+  cabin: cabinClassSchema.optional(),
+  searchOptions: flightSearchOptionsSchema.optional(),
+  pagination: flightSearchPaginationSchema.optional(),
+})
+
+export const flightSearchResponseSchema = z.object({
+  offers: z.array(flightOfferSchema),
+  pagination: flightSearchPaginationMetaSchema.optional(),
+  providerData: providerDataSchema.optional(),
+})
+
+export const flightPriceRequestSchema = z.object({
+  offerId: z.string(),
+  offer: flightOfferSchema.optional(),
+})
+
+export const flightPriceResponseSchema = z.object({
+  offer: flightOfferSchema,
+  valid: z.boolean(),
+  invalidReason: z.string().optional(),
+})
+
+export const billingAddressSchema = z.object({
+  line1: z.string(),
+  line2: z.string().optional(),
+  city: z.string(),
+  region: z.string().optional(),
+  postalCode: z.string().optional(),
+  countryCode: z.string(),
+})
+
+export const paymentIntentSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("hold") }),
+  z.object({
+    type: z.literal("card"),
+    token: z.string(),
+    cardholderName: z.string().optional(),
+    billingAddress: billingAddressSchema.optional(),
+  }),
+  z.object({
+    type: z.literal("ticket_on_credit"),
+    iataCode: z.string().optional(),
+  }),
+])
+
+export const travelDocumentSchema = z.object({
+  type: z.enum(["passport", "national_id", "visa"]),
+  number: z.string(),
+  countryOfIssue: z.string(),
+  countryOfNationality: z.string().optional(),
+  expiryDate: z.string().optional(),
+})
+
+export const flightPassengerSchema = z.object({
+  passengerId: z.string(),
+  type: passengerTypeSchema,
+  firstName: z.string(),
+  middleName: z.string().optional(),
+  lastName: z.string(),
+  dateOfBirth: z.string(),
+  gender: z.enum(["M", "F", "X"]).optional(),
+  email: z.string().optional(),
+  phone: z.string().optional(),
+  documents: z.array(travelDocumentSchema).optional(),
+})
+
+export const ancillarySelectionSchema = z.object({
+  baggage: z
+    .array(
+      z.object({
+        passengerId: z.string(),
+        sliceIndex: z.number().int().min(0),
+        optionId: z.string(),
+        quantity: z.number().int().min(1).optional(),
+      }),
+    )
+    .optional(),
+  assistance: z
+    .array(
+      z.object({
+        passengerId: z.string(),
+        optionId: z.string(),
+      }),
+    )
+    .optional(),
+  extras: z
+    .array(
+      z.object({
+        passengerId: z.string(),
+        sliceIndex: z.number().int().min(0),
+        optionId: z.string(),
+        quantity: z.number().int().min(1).optional(),
+      }),
+    )
+    .optional(),
+  seats: z
+    .array(
+      z.object({
+        passengerId: z.string(),
+        segmentId: z.string(),
+        seatNumber: z.string(),
+      }),
+    )
+    .optional(),
+  fareBundle: z
+    .array(
+      z.object({
+        passengerId: z.string(),
+        sliceIndex: z.number().int().min(0),
+        bundleId: z.string(),
+      }),
+    )
+    .optional(),
+})
+
+export const flightBookRequestSchema = z.object({
+  offerId: z.string(),
+  offer: flightOfferSchema.optional(),
+  passengers: z.array(flightPassengerSchema),
+  contact: flightContactSchema.optional(),
+  paymentIntent: paymentIntentSchema.optional(),
+  ancillaries: ancillarySelectionSchema.optional(),
+})
+
+export const flightTicketSchema = z.object({
+  ticketNumber: z.string(),
+  passengerId: z.string(),
+  segmentIds: z.array(z.string()),
+  status: z.string().optional(),
+})
+
+export const flightOrderSchema = z.object({
+  orderId: z.string(),
+  pnr: z.string().optional(),
+  status: flightOrderStatusSchema,
+  offer: flightOfferSchema,
+  passengers: z.array(flightPassengerSchema),
+  contact: flightContactSchema.optional(),
+  tickets: z.array(flightTicketSchema).optional(),
+  totalPrice: moneySchema,
+  paymentDeadline: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string().optional(),
+  providerData: providerDataSchema.optional(),
+})
+
+export const flightBookResponseSchema = z.object({
+  order: flightOrderSchema,
+})
+
+export const flightGetOrderResponseSchema = z.object({
+  order: flightOrderSchema,
+})
+
+export const flightCancelResponseSchema = z.object({
+  order: flightOrderSchema,
+  refundedAmount: moneySchema.optional(),
+})
+
+export const flightOrdersListQuerySchema = z.object({
+  cursor: z.string().optional(),
+  limit: z.number().int().min(1).optional(),
+  status: z.array(flightOrderStatusSchema).optional(),
+  search: z.string().optional(),
+})
+
+export const flightOrdersListResponseSchema = z.object({
+  orders: z.array(flightOrderSchema),
+  pagination: z.object({
+    total: z.number().int().min(0),
+    hasMore: z.boolean(),
+    cursor: z.string().optional(),
+  }),
+})
+
+export const ancillaryBaggageOptionSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  category: z.enum(["checked", "cabin", "personal_item", "sports", "oversized"]),
+  weightKg: z.number().optional(),
+  dimensions: z
+    .object({
+      lengthCm: z.number().optional(),
+      widthCm: z.number().optional(),
+      heightCm: z.number().optional(),
+    })
+    .optional(),
+  price: moneySchema,
+  recommended: z.boolean().optional(),
+  providerData: providerDataSchema.optional(),
+})
+
+export const ancillaryAssistanceOptionSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  category: z.enum(["wheelchair", "visual", "hearing", "cognitive", "medical", "other"]),
+  price: moneySchema.optional(),
+  notes: z.string().optional(),
+})
+
+export const ancillaryExtraOptionSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  category: z.string(),
+  price: moneySchema,
+  pricingScope: z.enum(["per_passenger", "per_booking"]).optional(),
+})
+
+export const ancillaryCatalogSchema = z.object({
+  baggage: z.array(ancillaryBaggageOptionSchema),
+  assistance: z.array(ancillaryAssistanceOptionSchema),
+  extras: z.array(ancillaryExtraOptionSchema),
+})
+
+export const ancillaryRequestSchema = z.object({
+  offerId: z.string(),
+  offer: flightOfferSchema.optional(),
+})
+
+export const ancillaryResponseSchema = z.object({
+  catalog: ancillaryCatalogSchema,
+  validUntil: z.string().optional(),
+})
+
+export const seatSchema = z.object({
+  seatNumber: z.string(),
+  row: z.number().int().min(1),
+  column: z.string(),
+  status: z.enum(["available", "blocked", "unavailable", "selected"]),
+  category: z.enum(["standard", "preferred", "extra_legroom", "exit_row", "premium", "bulkhead"]),
+  price: moneySchema.optional(),
+  notes: z.string().optional(),
+  window: z.boolean().optional(),
+  aisle: z.boolean().optional(),
+  providerData: providerDataSchema.optional(),
+})
+
+export const seatRowSchema = z.object({
+  row: z.number().int().min(1),
+  seats: z.array(seatSchema),
+})
+
+export const seatMapSchema = z.object({
+  segmentId: z.string(),
+  aircraft: z.string().optional(),
+  cabin: cabinClassSchema,
+  columnLayout: z.array(z.string().nullable()),
+  rows: z.array(seatRowSchema),
+  providerData: providerDataSchema.optional(),
+})
+
+export const seatMapRequestSchema = z.object({
+  offerId: z.string(),
+  segmentId: z.string(),
+  offer: flightOfferSchema.optional(),
+})
+
+export const seatMapResponseSchema = z.object({
+  seatMap: seatMapSchema,
+  validUntil: z.string().optional(),
+})
+
+export const seatAssignmentSchema = z.object({
+  passengerId: z.string(),
+  segmentId: z.string(),
+  seatNumber: z.string(),
+  price: moneySchema.optional(),
+  providerData: providerDataSchema.optional(),
+})
+
+export const seatSelectionRequestSchema = z.object({
+  orderId: z.string(),
+  selections: z.array(seatAssignmentSchema),
+})
+
+export const seatSelectionResponseSchema = z.object({
+  order: flightOrderSchema,
+  selections: z.array(seatAssignmentSchema),
+  additionalAmount: moneySchema.optional(),
+})
+
+export const flightBoardingPassSchema = z.object({
+  passengerId: z.string(),
+  segmentId: z.string(),
+  boardingPassId: z.string().optional(),
+  seatNumber: z.string().optional(),
+  sequenceNumber: z.string().optional(),
+  zone: z.string().optional(),
+  providerData: providerDataSchema.optional(),
+})
+
+export const checkInRequestSchema = z.object({
+  orderId: z.string(),
+  passengerIds: z.array(z.string()).optional(),
+  segmentIds: z.array(z.string()).optional(),
+})
+
+export const checkInResponseSchema = z.object({
+  order: flightOrderSchema,
+  status: checkInStatusSchema,
+  boardingPasses: z.array(flightBoardingPassSchema).optional(),
+})
+
+export const flightModifyRequestSchema = z.object({
+  orderId: z.string(),
+  offer: flightOfferSchema.optional(),
+  passengers: z.array(flightPassengerSchema).optional(),
+  ancillaries: ancillarySelectionSchema.optional(),
+  reason: flightModifyReasonSchema.optional(),
+})
+
+export const flightModifyResponseSchema = z.object({
+  order: flightOrderSchema,
+  priceDifference: signedMoneySchema.optional(),
+  penalties: z.array(moneySchema).optional(),
+})
+
+export const flightRefundRequestSchema = z.object({
+  orderId: z.string(),
+  reason: flightRefundReasonSchema.optional(),
+  amount: moneySchema.optional(),
+})
+
+export const flightRefundResponseSchema = z.object({
+  order: flightOrderSchema,
+  refundId: z.string().optional(),
+  refundedAmount: moneySchema,
+  penalties: z.array(moneySchema).optional(),
+})
+
+export const flightVoidResponseSchema = z.object({
+  order: flightOrderSchema,
+  voidId: z.string().optional(),
+  voidedAt: z.string(),
+})
+
+export const ssrRequestSchema = z.object({
+  orderId: z.string(),
+  code: ssrCodeSchema,
+  passengerIds: z.array(z.string()).optional(),
+  segmentIds: z.array(z.string()).optional(),
+  text: z.string().optional(),
+})
+
+export const ssrResponseSchema = z.object({
+  order: flightOrderSchema,
+  ssrId: z.string().optional(),
+  status: z.enum(["requested", "confirmed", "rejected"]),
+})
+
+export const adapterLoggerSchema = z.custom<{
+  debug(message: string, meta?: Record<string, unknown>): void
+  info(message: string, meta?: Record<string, unknown>): void
+  warn(message: string, meta?: Record<string, unknown>): void
+  error(message: string, meta?: Record<string, unknown>): void
+}>(
+  (value) =>
+    isRecord(value) &&
+    typeof value.debug === "function" &&
+    typeof value.info === "function" &&
+    typeof value.warn === "function" &&
+    typeof value.error === "function",
+)
+
+export const abortSignalSchema = z.custom<AbortSignal>(
+  (value) =>
+    isRecord(value) &&
+    typeof value.aborted === "boolean" &&
+    typeof value.addEventListener === "function" &&
+    typeof value.removeEventListener === "function",
+)
+
+export const flightAdapterContextSchema = z.object({
+  connectionId: z.string(),
+  credentials: z.record(z.string(), z.string()).optional(),
+  pointOfSale: pointOfSaleSchema.optional(),
+  correlationId: z.string().optional(),
+  requestId: z.string().optional(),
+  idempotencyKey: z.string().optional(),
+  logger: adapterLoggerSchema.optional(),
+  signal: abortSignalSchema.optional(),
+  environment: flightAdapterEnvironmentSchema.optional(),
+  deps: z.record(z.string(), z.unknown()).optional(),
+})
+
+export const flightAdapterCapabilitiesSchema = z.object({
+  provider: z.string(),
+  declared: z.array(flightCapabilitySchema),
+  maxSlicesPerSearch: z.number().int().min(1).optional(),
+  defaultTimeoutMs: z.number().int().min(1).optional(),
+})

--- a/packages/flights/src/index.ts
+++ b/packages/flights/src/index.ts
@@ -18,6 +18,7 @@ export {
   type FlightSearchResponse,
   requireCapability,
 } from "./contract/adapter.js"
+export * from "./contract/schemas.js"
 export * from "./contract/types.js"
 export {
   type ConnectionResult,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2976,6 +2976,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@voyantjs/voyant-typescript-config':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

- Add zod v4 runtime schemas for the public flight contract surface, including request/response shapes, enums, value objects, adapter context, and capability declarations.
- Export schemas from the package root and `@voyantjs/flights/contract/schemas`.
- Add compile-time type-equivalence coverage, parse/reject tests, docs, and a changeset.

Follow-up to #984.
Closes #986.

## Verification

- `pnpm --filter @voyantjs/flights typecheck`
- `pnpm --filter @voyantjs/flights test`
- `pnpm --filter @voyantjs/flights lint`
- `pnpm --filter flights-demo-api typecheck`
- `pnpm --filter @voyantjs/flights build`
- `pnpm verify:fast`
- full pre-commit lint/typecheck hook
- full pre-push test hook