### PR TITLE
Add catalog adapter runtime schemas and scoped cancellation contract

### DIFF
--- a/.changeset/catalog-adapter-runtime-schemas.md
+++ b/.changeset/catalog-adapter-runtime-schemas.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/catalog": minor
+---
+
+Add zod runtime schemas for the public catalog source-adapter contract, including request/result payloads, capabilities, provenance, adapter context, and channel-push shapes. Extend reserve/cancel adapter writes with optional request scope and idempotency keys, and model async cancellation with pending status metadata.

--- a/docs/architecture/catalog-sourced-content.md
+++ b/docs/architecture/catalog-sourced-content.md
@@ -224,7 +224,38 @@ export interface AdapterCapabilities {
 
 Adapters that don't implement `getContent` (the demo upstream, simple bedbanks that only have prices) declare `supportsContentFetch: false`. The catalog plane then renders thin content from the indexer projection — same as today, no regression.
 
+`@voyantjs/catalog` also ships zod runtime schemas for the public
+`SourceAdapter` payload contract under `@voyantjs/catalog/adapter/schemas`.
+Consumers that cross HTTP, queue, RPC, or adapter-process boundaries should
+validate with those shipped schemas rather than maintaining parallel local
+validators.
+
 The locale field is required, not optional. Adapters that genuinely have only one locale (a single-language tour operator) accept any value and return their canonical content with `returned_locale` pointing at what they actually have. The contract is "tell me your best for this locale" — never "give me whatever you have."
+
+### 3.1.1. Scoped reserve and async cancellation
+
+Booking-forwarding adapter writes carry their own request scope. `ReserveRequest`
+and `CancelRequest` may include the same `{ locale, audience, market, currency? }`
+shape used by `LiveResolveRequest.scope`, plus an `idempotency_key` for
+replay-safe retries. These fields are optional so existing adapters remain
+valid, but multi-market suppliers should treat them as the source of truth for
+market-sensitive booking writes rather than deriving scope from connection
+credentials.
+
+Cancellation can be synchronous or async. Adapters that can confirm the upstream
+state during the `cancel` call return terminal statuses: `"cancelled"`,
+`"refused"`, or `"failed"`. Adapters that submit the cancellation out of band
+(email, partner portal, batch export, fax) declare
+`supportsSyncCancellation: false` and may return `status: "pending"` with an
+optional `pending_channel` such as `"partner portal"`. The booking engine
+surfaces that channel in the cancel result for audit and consumer messaging;
+callers should show "cancellation in progress" until a later transition settles
+the booking.
+
+The adapter owns that later transition. Depending on the supplier, it can arrive
+through a drift event, connector-managed polling, the next live/status check, or
+another reconciliation job. The framework models and preserves the pending
+state; it does not add a generic polling loop here.
 
 ### 3.2. Per-vertical content cache
 

--- a/packages/catalog/README.md
+++ b/packages/catalog/README.md
@@ -25,6 +25,7 @@ pnpm add @voyantjs/catalog
 - **`./drift/events`** — drift event types for upstream change detection.
 - **`./events/taxonomy`** — catalog event names + visibility-filtered payload builders, emitted via `@voyantjs/core/events` and consumed by the existing webhook pipeline.
 - **`./adapter/contract`** — public source-adapter contract. Voyant Connect, third-party providers, operator-built adapters all implement this.
+- **`./adapter/schemas`** — zod schemas for source-adapter runtime payloads. Use these at HTTP, queue, RPC, and adapter boundaries instead of re-declaring validators.
 - **`./booking-engine`** — quote/book services plus the Hono route module that backs `@voyantjs/catalog-react/booking-engine` and `@voyantjs/bookings-ui/journey`.
 
 ## Architectural rules
@@ -63,6 +64,19 @@ export const productCatalogPolicy = defineFieldPolicy([
 ```
 
 See `docs/architecture/catalog-architecture.md` for the full contract and worked examples.
+
+## Source-adapter runtime validation
+
+```typescript
+import { reserveRequestSchema } from "@voyantjs/catalog/adapter/schemas"
+import type { ReserveRequest } from "@voyantjs/catalog/adapter/contract"
+
+const request: ReserveRequest = reserveRequestSchema.parse(await req.json())
+```
+
+Reserve and cancel requests may include a `scope` matching live resolution plus
+an `idempotency_key`; cancel results may return `status: "pending"` with
+`pending_channel` for async upstream workflows.
 
 ## BookingJourney HTTP routes
 

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -19,6 +19,7 @@
     "./drift/events": "./src/drift/events.ts",
     "./events/taxonomy": "./src/events/taxonomy.ts",
     "./adapter/contract": "./src/adapter/contract.ts",
+    "./adapter/schemas": "./src/adapter/schemas.ts",
     "./services/overlay": "./src/services/overlay-service.ts",
     "./services/snapshot": "./src/services/snapshot-service.ts",
     "./services/indexer": "./src/services/indexer-service.ts",
@@ -119,6 +120,11 @@
         "types": "./dist/adapter/contract.d.ts",
         "import": "./dist/adapter/contract.js",
         "default": "./dist/adapter/contract.js"
+      },
+      "./adapter/schemas": {
+        "types": "./dist/adapter/schemas.d.ts",
+        "import": "./dist/adapter/schemas.js",
+        "default": "./dist/adapter/schemas.js"
       },
       "./services/overlay": {
         "types": "./dist/services/overlay-service.d.ts",

--- a/packages/catalog/src/adapter/booking-forwarding.ts
+++ b/packages/catalog/src/adapter/booking-forwarding.ts
@@ -1,0 +1,49 @@
+export interface SourceAdapterRequestScope {
+  locale: string
+  audience: string
+  market: string
+  currency?: string
+}
+
+export interface ReserveRequest {
+  entity_module: string
+  entity_id: string
+  parameters: Record<string, unknown>
+  /** Customer / passenger identity, vertical-shaped. */
+  party?: Record<string, unknown>
+  /** Payment intent for verticals that distinguish hold vs ticket. */
+  payment_intent?: Record<string, unknown>
+  /** Per-request scope. Mirrors `LiveResolveRequest.scope`. */
+  scope?: SourceAdapterRequestScope
+  /** Replay-safe write key. Same key on retries means same upstream effect. */
+  idempotency_key?: string
+}
+
+export interface ReserveResult {
+  /** Upstream order / booking identifier — used as `source_ref` in snapshots. */
+  upstream_ref: string
+  /** Status returned by the upstream system. */
+  status: "held" | "confirmed" | "ticketed" | "failed"
+  /** Opaque per-vertical payload echoed back to the snapshot graph. */
+  upstream_payload?: Record<string, unknown>
+}
+
+export interface CancelRequest {
+  upstream_ref: string
+  reason?: string
+  /** Per-request scope. Mirrors `LiveResolveRequest.scope`. */
+  scope?: SourceAdapterRequestScope
+  /** Replay-safe write key. Same key on retries means same upstream effect. */
+  idempotency_key?: string
+}
+
+export interface CancelResult {
+  status: "cancelled" | "pending" | "refused" | "failed"
+  refund_amount?: number
+  refund_currency?: string
+  /**
+   * Free-text channel through which an async cancellation was submitted
+   * when `status` is "pending" (email, partner portal, batch, etc.).
+   */
+  pending_channel?: string
+}

--- a/packages/catalog/src/adapter/contract.test.ts
+++ b/packages/catalog/src/adapter/contract.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, it } from "vitest"
 
 import type {
   AdapterCapabilities,
+  CancelRequest,
+  CancelResult,
   GetContentRequest,
   GetContentResult,
+  ReserveRequest,
   SourceAdapter,
 } from "./contract.js"
+import { cancelRequestSchema, reserveRequestSchema } from "./schemas.js"
 
 describe("AdapterCapabilities — content fetch declaration", () => {
   it("accepts adapters that omit supportsContentFetch (backward compatible)", () => {
@@ -152,5 +156,92 @@ describe("SourceAdapter — getContent capability gating", () => {
     )
     expect(result.returned_locale).toBe("en-GB")
     expect(result.content_schema_version).toBe("products/v1")
+  })
+})
+
+describe("ReserveRequest / CancelRequest scoped write shape", () => {
+  it("round-trips reserve requests with request scope and idempotency key", () => {
+    const request: ReserveRequest = {
+      entity_module: "products",
+      entity_id: "prod_abc",
+      parameters: { departureId: "dep_1" },
+      party: { travelers: 2 },
+      scope: {
+        locale: "en-GB",
+        audience: "customer",
+        market: "GB",
+        currency: "GBP",
+      },
+      idempotency_key: "reserve_abc",
+    }
+
+    expect(reserveRequestSchema.parse(request)).toEqual(request)
+  })
+
+  it("round-trips cancel requests with request scope and idempotency key", () => {
+    const request: CancelRequest = {
+      upstream_ref: "booking_abc",
+      reason: "customer_request",
+      scope: {
+        locale: "en-GB",
+        audience: "customer",
+        market: "GB",
+        currency: "GBP",
+      },
+      idempotency_key: "cancel_abc",
+    }
+
+    expect(cancelRequestSchema.parse(request)).toEqual(request)
+  })
+})
+
+describe("SourceAdapter — cancellation capability declaration", () => {
+  it("typechecks sync cancellation adapters that return terminal statuses", async () => {
+    const adapter: SourceAdapter = {
+      kind: "sync-cancel",
+      capabilities: {
+        verticals: ["products"],
+        supportsLiveResolution: false,
+        supportsDriftDetection: false,
+        supportsBookingForwarding: true,
+        supportsSyncCancellation: true,
+        postBookOperations: ["cancel"],
+      },
+      async cancel(): Promise<CancelResult> {
+        return { status: "cancelled", refund_amount: 100, refund_currency: "GBP" }
+      },
+    }
+
+    await expect(
+      adapter.cancel!({ connection_id: "conn_1" }, { upstream_ref: "up_1" }),
+    ).resolves.toEqual({
+      status: "cancelled",
+      refund_amount: 100,
+      refund_currency: "GBP",
+    })
+  })
+
+  it("typechecks async cancellation adapters that return pending", async () => {
+    const adapter: SourceAdapter = {
+      kind: "async-cancel",
+      capabilities: {
+        verticals: ["products"],
+        supportsLiveResolution: false,
+        supportsDriftDetection: true,
+        supportsBookingForwarding: true,
+        supportsSyncCancellation: false,
+        postBookOperations: ["cancel"],
+      },
+      async cancel(): Promise<CancelResult> {
+        return { status: "pending", pending_channel: "partner portal" }
+      },
+    }
+
+    await expect(
+      adapter.cancel!({ connection_id: "conn_1" }, { upstream_ref: "up_1" }),
+    ).resolves.toEqual({
+      status: "pending",
+      pending_channel: "partner portal",
+    })
   })
 })

--- a/packages/catalog/src/adapter/contract.ts
+++ b/packages/catalog/src/adapter/contract.ts
@@ -17,6 +17,21 @@
 
 import type { CatalogDriftEvent } from "../drift/events.js"
 import type { Provenance } from "../provenance.js"
+import type {
+  CancelRequest,
+  CancelResult,
+  ReserveRequest,
+  ReserveResult,
+  SourceAdapterRequestScope,
+} from "./booking-forwarding.js"
+
+export type {
+  CancelRequest,
+  CancelResult,
+  ReserveRequest,
+  ReserveResult,
+  SourceAdapterRequestScope,
+} from "./booking-forwarding.js"
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Connection lifecycle
@@ -44,6 +59,13 @@ export interface AdapterCapabilities {
   supportsDriftDetection: boolean
   /** Whether the adapter forwards bookings to the upstream source. */
   supportsBookingForwarding: boolean
+  /**
+   * Whether `cancel` returns a terminal upstream status synchronously.
+   * When false, the adapter may return `status: "pending"` and drive the
+   * final transition later through drift, polling, or connector-specific
+   * reconciliation.
+   */
+  supportsSyncCancellation?: boolean
   /** Post-book operations the adapter supports (modify, cancel, status, refund). */
   postBookOperations: ReadonlyArray<"modify" | "cancel" | "status" | "refund" | "exchange" | "void">
   /**
@@ -157,12 +179,7 @@ export interface DiscoveryPage {
 export interface LiveResolveRequest {
   ids: string[]
   /** Variant scope for the request (mirrors the resolver's scope). */
-  scope: {
-    locale: string
-    audience: string
-    market: string
-    currency?: string
-  }
+  scope: SourceAdapterRequestScope
   /** Date range or other vertical-specific parameters. */
   parameters?: Record<string, unknown>
 }
@@ -263,40 +280,6 @@ export interface GetContentResult {
   fresh_until?: Date
   /** ETag-style marker for HTTP-cache revalidation on the next pull. */
   etag?: string
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Booking forwarding
-// ─────────────────────────────────────────────────────────────────────────────
-
-export interface ReserveRequest {
-  entity_module: string
-  entity_id: string
-  parameters: Record<string, unknown>
-  /** Customer / passenger identity, vertical-shaped. */
-  party?: Record<string, unknown>
-  /** Payment intent for verticals that distinguish hold vs ticket. */
-  payment_intent?: Record<string, unknown>
-}
-
-export interface ReserveResult {
-  /** Upstream order / booking identifier — used as `source_ref` in snapshots. */
-  upstream_ref: string
-  /** Status returned by the upstream system. */
-  status: "held" | "confirmed" | "ticketed" | "failed"
-  /** Opaque per-vertical payload echoed back to the snapshot graph. */
-  upstream_payload?: Record<string, unknown>
-}
-
-export interface CancelRequest {
-  upstream_ref: string
-  reason?: string
-}
-
-export interface CancelResult {
-  status: "cancelled" | "refused" | "failed"
-  refund_amount?: number
-  refund_currency?: string
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/catalog/src/adapter/schemas.test.ts
+++ b/packages/catalog/src/adapter/schemas.test.ts
@@ -1,0 +1,379 @@
+import { describe, expect, it } from "vitest"
+import type { z } from "zod"
+import type { Provenance } from "../provenance.js"
+import type {
+  AdapterCapabilities,
+  CancelRequest,
+  CancelResult,
+  CatalogProjection,
+  ConnectionState,
+  DiscoveryCursor,
+  DiscoveryPage,
+  GetContentRequest,
+  GetContentResult,
+  LiveResolveRequest,
+  LiveResolveResult,
+  PushAvailabilityRequest,
+  PushAvailabilityResult,
+  PushBookingRequest,
+  PushBookingResult,
+  PushContentRequest,
+  PushContentResult,
+  ReserveRequest,
+  ReserveResult,
+  SourceAdapter,
+  SourceAdapterContext,
+  SourceAdapterRequestScope,
+} from "./contract.js"
+import {
+  adapterCapabilitiesSchema,
+  cancelRequestSchema,
+  cancelResultSchema,
+  catalogProjectionSchema,
+  connectionStateSchema,
+  discoveryCursorSchema,
+  discoveryPageSchema,
+  getContentRequestSchema,
+  getContentResultSchema,
+  liveResolveRequestSchema,
+  liveResolveResultSchema,
+  provenanceSchema,
+  pushAvailabilityRequestSchema,
+  pushAvailabilityResultSchema,
+  pushBookingRequestSchema,
+  pushBookingResultSchema,
+  pushContentRequestSchema,
+  pushContentResultSchema,
+  reserveRequestSchema,
+  reserveResultSchema,
+  sourceAdapterContextSchema,
+  sourceAdapterRequestScopeSchema,
+  sourceAdapterSchema,
+} from "./schemas.js"
+
+type AssertEquivalent<Actual, Expected> = Actual extends Expected
+  ? Expected extends Actual
+    ? true
+    : never
+  : never
+
+const typeChecks: [
+  AssertEquivalent<z.infer<typeof adapterCapabilitiesSchema>, AdapterCapabilities>,
+  AssertEquivalent<z.infer<typeof connectionStateSchema>, ConnectionState>,
+  AssertEquivalent<z.infer<typeof sourceAdapterContextSchema>, SourceAdapterContext>,
+  AssertEquivalent<z.infer<typeof provenanceSchema>, Provenance>,
+  AssertEquivalent<z.infer<typeof catalogProjectionSchema>, CatalogProjection>,
+  AssertEquivalent<z.infer<typeof discoveryCursorSchema>, DiscoveryCursor>,
+  AssertEquivalent<z.infer<typeof discoveryPageSchema>, DiscoveryPage>,
+  AssertEquivalent<z.infer<typeof liveResolveRequestSchema>, LiveResolveRequest>,
+  AssertEquivalent<z.infer<typeof sourceAdapterRequestScopeSchema>, SourceAdapterRequestScope>,
+  AssertEquivalent<z.infer<typeof liveResolveResultSchema>, LiveResolveResult>,
+  AssertEquivalent<z.infer<typeof getContentRequestSchema>, GetContentRequest>,
+  AssertEquivalent<z.infer<typeof getContentResultSchema>, GetContentResult>,
+  AssertEquivalent<z.infer<typeof reserveRequestSchema>, ReserveRequest>,
+  AssertEquivalent<z.infer<typeof reserveResultSchema>, ReserveResult>,
+  AssertEquivalent<z.infer<typeof cancelRequestSchema>, CancelRequest>,
+  AssertEquivalent<z.infer<typeof cancelResultSchema>, CancelResult>,
+  AssertEquivalent<z.infer<typeof pushBookingRequestSchema>, PushBookingRequest>,
+  AssertEquivalent<z.infer<typeof pushBookingResultSchema>, PushBookingResult>,
+  AssertEquivalent<z.infer<typeof pushAvailabilityRequestSchema>, PushAvailabilityRequest>,
+  AssertEquivalent<z.infer<typeof pushAvailabilityResultSchema>, PushAvailabilityResult>,
+  AssertEquivalent<z.infer<typeof pushContentRequestSchema>, PushContentRequest>,
+  AssertEquivalent<z.infer<typeof pushContentResultSchema>, PushContentResult>,
+  AssertEquivalent<z.infer<typeof sourceAdapterSchema>, SourceAdapter>,
+] = [
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+]
+void typeChecks
+
+const capabilities: AdapterCapabilities = {
+  verticals: ["products"],
+  supportsLiveResolution: true,
+  supportsDriftDetection: true,
+  supportsBookingForwarding: true,
+  supportsSyncCancellation: false,
+  postBookOperations: ["cancel", "status"],
+  cacheTtlSeconds: 300,
+  supportsContentFetch: true,
+  supportedContentLocales: ["en-GB", "ro-RO"],
+  holdReleaseGraceMs: 1000,
+  supportsBookingPush: true,
+  supportsAvailabilityPush: true,
+  supportsContentPush: true,
+}
+
+const context: SourceAdapterContext = {
+  connection_id: "conn_123",
+  credentials: { apiKey: "secret" },
+  tenant_id: "tenant_1",
+  correlation_id: "corr_1",
+}
+
+const provenance: Provenance = {
+  source_kind: "direct:tui",
+  source_provider: "tui",
+  source_connection_id: "conn_123",
+  source_ref: "TUI-123",
+  source_freshness: "sync",
+  last_sourced_at: new Date("2026-01-01T00:00:00Z"),
+}
+
+const projection: CatalogProjection = {
+  entity_module: "products",
+  entity_id: "prod_123",
+  provenance,
+  fields: { title: "Sample tour", country: "RO" },
+}
+
+const discoveryPage: DiscoveryPage = {
+  projections: [projection],
+  next_cursor: "cursor_2",
+}
+
+const liveResolveRequest: LiveResolveRequest = {
+  ids: ["prod_123"],
+  scope: {
+    locale: "en-GB",
+    audience: "customer",
+    market: "GB",
+    currency: "GBP",
+  },
+  parameters: { departureId: "dep_1" },
+}
+
+const sourceAdapterRequestScope: SourceAdapterRequestScope = liveResolveRequest.scope
+
+const liveResolveResult: LiveResolveResult = {
+  values: {
+    prod_123: {
+      price: { amount: "100.00", currency: "GBP" },
+      remainingPax: 4,
+    },
+  },
+  failed: { prod_missing: "not_found" },
+}
+
+const getContentRequest: GetContentRequest = {
+  entity_module: "products",
+  entity_id: "prod_123",
+  locale: "ro-RO",
+  market: "RO",
+  currency: "RON",
+}
+
+const getContentResult: GetContentResult = {
+  entity_module: "products",
+  entity_id: "prod_123",
+  source_ref: "TUI-123",
+  returned_locale: "en-GB",
+  machine_translated: false,
+  content: { product: { title: "Sample tour" } },
+  content_schema_version: "products/v1",
+  source_updated_at: new Date("2026-01-02T00:00:00Z"),
+  fresh_until: new Date("2026-01-03T00:00:00Z"),
+  etag: "etag-1",
+}
+
+const reserveRequest: ReserveRequest = {
+  entity_module: "products",
+  entity_id: "prod_123",
+  parameters: { departureId: "dep_1" },
+  party: { travelers: 2 },
+  payment_intent: { type: "hold" },
+  scope: sourceAdapterRequestScope,
+  idempotency_key: "reserve_123",
+}
+
+const reserveResult: ReserveResult = {
+  upstream_ref: "booking_123",
+  status: "held",
+  upstream_payload: { holdToken: "hold_1" },
+}
+
+const cancelRequest: CancelRequest = {
+  upstream_ref: "booking_123",
+  reason: "customer_request",
+  scope: sourceAdapterRequestScope,
+  idempotency_key: "cancel_123",
+}
+
+const cancelResult: CancelResult = {
+  status: "pending",
+  pending_channel: "partner portal",
+}
+
+const pushBookingRequest: PushBookingRequest = {
+  idempotencyKey: "idem_1",
+  bookingId: "book_1",
+  bookingItemId: "item_1",
+  externalProductId: "EXT-1",
+  externalRateId: "RATE-1",
+  externalCategoryId: "CAT-1",
+  channelId: "channel_1",
+  contractPolicy: { commission: 0.1 },
+  payload: { travelers: 2 },
+}
+
+const pushBookingResult: PushBookingResult = {
+  upstreamRef: "upstream_1",
+  externalReference: "CONF-1",
+  externalStatus: "confirmed",
+  upstreamPayload: { ok: true },
+}
+
+const pushAvailabilityRequest: PushAvailabilityRequest = {
+  channelId: "channel_1",
+  externalProductId: "EXT-1",
+  externalRateId: "RATE-1",
+  externalCategoryId: "CAT-1",
+  slotId: "slot_1",
+  productId: "prod_123",
+  optionId: "opt_1",
+  startsAt: new Date("2026-02-01T10:00:00Z"),
+  remainingPax: 8,
+  source: "booking",
+}
+
+const pushAvailabilityResult: PushAvailabilityResult = {
+  externalStatus: "updated",
+  upstreamPayload: { ok: true },
+}
+
+const pushContentRequest: PushContentRequest = {
+  channelId: "channel_1",
+  externalProductId: "EXT-1",
+  productId: "prod_123",
+  contentHash: "hash_123",
+  content: { product: { title: "Sample tour" } },
+  contentSchemaVersion: "products/v1",
+  locale: "en-GB",
+}
+
+const pushContentResult: PushContentResult = {
+  externalStatus: "updated",
+  upstreamPayload: { ok: true },
+  acknowledgedHash: "hash_123",
+}
+
+const sourceAdapter: SourceAdapter = {
+  kind: "direct:tui",
+  capabilities,
+  async connect() {},
+  async getState() {
+    return "active"
+  },
+  async discover() {
+    return discoveryPage
+  },
+  async getContent(_ctx, request) {
+    return { ...getContentResult, entity_id: request.entity_id }
+  },
+}
+
+const roundTripCases = [
+  ["adapterCapabilitiesSchema", adapterCapabilitiesSchema, capabilities],
+  ["connectionStateSchema", connectionStateSchema, "active" satisfies ConnectionState],
+  ["sourceAdapterContextSchema", sourceAdapterContextSchema, context],
+  ["provenanceSchema", provenanceSchema, provenance],
+  ["catalogProjectionSchema", catalogProjectionSchema, projection],
+  ["discoveryCursorSchema", discoveryCursorSchema, "cursor_2" satisfies DiscoveryCursor],
+  ["discoveryPageSchema", discoveryPageSchema, discoveryPage],
+  ["sourceAdapterRequestScopeSchema", sourceAdapterRequestScopeSchema, sourceAdapterRequestScope],
+  ["liveResolveRequestSchema", liveResolveRequestSchema, liveResolveRequest],
+  ["liveResolveResultSchema", liveResolveResultSchema, liveResolveResult],
+  ["getContentRequestSchema", getContentRequestSchema, getContentRequest],
+  ["getContentResultSchema", getContentResultSchema, getContentResult],
+  ["reserveRequestSchema", reserveRequestSchema, reserveRequest],
+  ["reserveResultSchema", reserveResultSchema, reserveResult],
+  ["cancelRequestSchema", cancelRequestSchema, cancelRequest],
+  ["cancelResultSchema", cancelResultSchema, cancelResult],
+  ["pushBookingRequestSchema", pushBookingRequestSchema, pushBookingRequest],
+  ["pushBookingResultSchema", pushBookingResultSchema, pushBookingResult],
+  ["pushAvailabilityRequestSchema", pushAvailabilityRequestSchema, pushAvailabilityRequest],
+  ["pushAvailabilityResultSchema", pushAvailabilityResultSchema, pushAvailabilityResult],
+  ["pushContentRequestSchema", pushContentRequestSchema, pushContentRequest],
+  ["pushContentResultSchema", pushContentResultSchema, pushContentResult],
+  ["sourceAdapterSchema", sourceAdapterSchema, sourceAdapter],
+] as const
+
+const invalidCases = [
+  ["adapterCapabilitiesSchema", adapterCapabilitiesSchema, { ...capabilities, verticals: [123] }],
+  ["connectionStateSchema", connectionStateSchema, "reconnecting"],
+  ["sourceAdapterContextSchema", sourceAdapterContextSchema, { credentials: { apiKey: "secret" } }],
+  ["provenanceSchema", provenanceSchema, { ...provenance, source_freshness: "live" }],
+  ["catalogProjectionSchema", catalogProjectionSchema, { ...projection, entity_module: 123 }],
+  ["discoveryCursorSchema", discoveryCursorSchema, 123],
+  ["discoveryPageSchema", discoveryPageSchema, { projections: [{ fields: {} }] }],
+  [
+    "sourceAdapterRequestScopeSchema",
+    sourceAdapterRequestScopeSchema,
+    { ...sourceAdapterRequestScope, currency: "GB" },
+  ],
+  [
+    "liveResolveRequestSchema",
+    liveResolveRequestSchema,
+    { ...liveResolveRequest, scope: { ...liveResolveRequest.scope, locale: "not_locale" } },
+  ],
+  ["liveResolveResultSchema", liveResolveResultSchema, { values: {}, failed: { prod_1: "gone" } }],
+  ["getContentRequestSchema", getContentRequestSchema, { ...getContentRequest, currency: "EU" }],
+  [
+    "getContentResultSchema",
+    getContentResultSchema,
+    { ...getContentResult, content_schema_version: undefined },
+  ],
+  ["reserveRequestSchema", reserveRequestSchema, { ...reserveRequest, parameters: undefined }],
+  ["reserveResultSchema", reserveResultSchema, { ...reserveResult, status: "pending" }],
+  ["cancelRequestSchema", cancelRequestSchema, { reason: "customer_request" }],
+  ["cancelResultSchema", cancelResultSchema, { ...cancelResult, refund_currency: "GB" }],
+  [
+    "pushBookingRequestSchema",
+    pushBookingRequestSchema,
+    { ...pushBookingRequest, payload: undefined },
+  ],
+  ["pushBookingResultSchema", pushBookingResultSchema, { externalStatus: "confirmed" }],
+  [
+    "pushAvailabilityRequestSchema",
+    pushAvailabilityRequestSchema,
+    { ...pushAvailabilityRequest, remainingPax: -1 },
+  ],
+  ["pushAvailabilityResultSchema", pushAvailabilityResultSchema, { upstreamPayload: "ok" }],
+  [
+    "pushContentRequestSchema",
+    pushContentRequestSchema,
+    { ...pushContentRequest, locale: "not_locale" },
+  ],
+  ["pushContentResultSchema", pushContentResultSchema, { acknowledgedHash: 123 }],
+  ["sourceAdapterSchema", sourceAdapterSchema, { ...sourceAdapter, discover: "yes" }],
+] as const
+
+describe("catalog source-adapter schemas", () => {
+  it.each(roundTripCases)("parses %s fixtures without changing shape", (_name, schema, value) => {
+    expect(schema.parse(value)).toEqual(value)
+  })
+
+  it.each(invalidCases)("rejects invalid %s fixtures", (_name, schema, value) => {
+    expect(schema.safeParse(value).success).toBe(false)
+  })
+})

--- a/packages/catalog/src/adapter/schemas.ts
+++ b/packages/catalog/src/adapter/schemas.ts
@@ -1,0 +1,237 @@
+import { z } from "zod"
+
+import type { SourceAdapter } from "./contract.js"
+
+const recordSchema = z.record(z.string(), z.unknown())
+const localeSchema = z.string().regex(/^[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8})*$/)
+const currencySchema = z.string().length(3)
+const dateOrStringSchema = z.union([z.date(), z.string()])
+const catalogVerticalSchema = z.string()
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null
+
+const optionalFunction = (value: unknown) => value === undefined || typeof value === "function"
+
+export const postBookOperationSchema = z.enum([
+  "modify",
+  "cancel",
+  "status",
+  "refund",
+  "exchange",
+  "void",
+])
+
+export const adapterCapabilitiesSchema = z.object({
+  verticals: z.array(catalogVerticalSchema),
+  supportsLiveResolution: z.boolean(),
+  supportsDriftDetection: z.boolean(),
+  supportsBookingForwarding: z.boolean(),
+  supportsSyncCancellation: z.boolean().optional(),
+  postBookOperations: z.array(postBookOperationSchema).readonly(),
+  cacheTtlSeconds: z.number().int().min(0).nullable().optional(),
+  supportsContentFetch: z.boolean().optional(),
+  supportedContentLocales: z.array(localeSchema).readonly().optional(),
+  holdReleaseGraceMs: z.number().int().min(0).optional(),
+  supportsBookingPush: z.boolean().optional(),
+  supportsAvailabilityPush: z.boolean().optional(),
+  supportsContentPush: z.boolean().optional(),
+})
+
+export const connectionStateSchema = z.enum(["active", "paused", "disconnected", "error"])
+
+export const sourceAdapterContextSchema = z.object({
+  connection_id: z.string(),
+  credentials: z.record(z.string(), z.string()).optional(),
+  tenant_id: z.string().optional(),
+  correlation_id: z.string().optional(),
+})
+
+export const sourceFreshnessSchema = z.enum(["sync", "event", "request", "static"]).nullable()
+
+export const provenanceSchema = z.object({
+  source_kind: z.string(),
+  source_provider: z.string().optional(),
+  source_connection_id: z.string().optional(),
+  source_ref: z.string().optional(),
+  source_freshness: sourceFreshnessSchema,
+  last_sourced_at: z.date().optional(),
+})
+
+export const catalogProjectionSchema = z.object({
+  entity_module: catalogVerticalSchema,
+  entity_id: z.string(),
+  provenance: provenanceSchema,
+  fields: recordSchema,
+})
+
+export const discoveryCursorSchema = z.custom<string | undefined>(
+  (value) => value === undefined || typeof value === "string",
+)
+
+export const discoveryPageSchema = z.object({
+  projections: z.array(catalogProjectionSchema),
+  next_cursor: discoveryCursorSchema,
+})
+
+export const liveResolveScopeSchema = z.object({
+  locale: localeSchema,
+  audience: z.string(),
+  market: z.string(),
+  currency: currencySchema.optional(),
+})
+
+export const sourceAdapterRequestScopeSchema = liveResolveScopeSchema
+
+export const liveResolveRequestSchema = z.object({
+  ids: z.array(z.string()),
+  scope: liveResolveScopeSchema,
+  parameters: recordSchema.optional(),
+})
+
+export const liveResolveFailedReasonSchema = z.enum([
+  "timeout",
+  "not_found",
+  "unavailable",
+  "departure_not_found",
+  "departure_unavailable",
+  "unsupported",
+  "error",
+])
+
+export const liveResolveResultSchema = z.object({
+  values: z.record(z.string(), recordSchema),
+  failed: z.record(z.string(), liveResolveFailedReasonSchema).optional(),
+})
+
+export const getContentRequestSchema = z.object({
+  entity_module: catalogVerticalSchema,
+  entity_id: z.string(),
+  locale: localeSchema,
+  market: z.string().optional(),
+  currency: currencySchema.optional(),
+})
+
+export const getContentResultSchema = z.object({
+  entity_module: catalogVerticalSchema,
+  entity_id: z.string(),
+  source_ref: z.string(),
+  returned_locale: localeSchema,
+  machine_translated: z.boolean().optional(),
+  content: z.unknown(),
+  content_schema_version: z.string(),
+  source_updated_at: z.date().optional(),
+  fresh_until: z.date().optional(),
+  etag: z.string().optional(),
+})
+
+export const reserveRequestSchema = z.object({
+  entity_module: catalogVerticalSchema,
+  entity_id: z.string(),
+  parameters: recordSchema,
+  party: recordSchema.optional(),
+  payment_intent: recordSchema.optional(),
+  scope: sourceAdapterRequestScopeSchema.optional(),
+  idempotency_key: z.string().optional(),
+})
+
+export const reserveStatusSchema = z.enum(["held", "confirmed", "ticketed", "failed"])
+
+export const reserveResultSchema = z.object({
+  upstream_ref: z.string(),
+  status: reserveStatusSchema,
+  upstream_payload: recordSchema.optional(),
+})
+
+export const cancelRequestSchema = z.object({
+  upstream_ref: z.string(),
+  reason: z.string().optional(),
+  scope: sourceAdapterRequestScopeSchema.optional(),
+  idempotency_key: z.string().optional(),
+})
+
+export const cancelStatusSchema = z.enum(["cancelled", "pending", "refused", "failed"])
+
+export const cancelResultSchema = z.object({
+  status: cancelStatusSchema,
+  refund_amount: z.number().optional(),
+  refund_currency: currencySchema.optional(),
+  pending_channel: z.string().optional(),
+})
+
+export const pushBookingRequestSchema = z.object({
+  idempotencyKey: z.string(),
+  bookingId: z.string(),
+  bookingItemId: z.string().optional(),
+  externalProductId: z.string(),
+  externalRateId: z.string().optional(),
+  externalCategoryId: z.string().optional(),
+  channelId: z.string(),
+  contractPolicy: recordSchema.optional(),
+  payload: recordSchema,
+})
+
+export const pushBookingResultSchema = z.object({
+  upstreamRef: z.string(),
+  externalReference: z.string().optional(),
+  externalStatus: z.string().optional(),
+  upstreamPayload: recordSchema.optional(),
+})
+
+export const pushAvailabilityRequestSchema = z.object({
+  channelId: z.string(),
+  externalProductId: z.string(),
+  externalRateId: z.string().optional(),
+  externalCategoryId: z.string().optional(),
+  slotId: z.string(),
+  productId: z.string(),
+  optionId: z.string().optional(),
+  startsAt: dateOrStringSchema,
+  remainingPax: z.number().int().min(0),
+  source: z.string(),
+})
+
+export const pushAvailabilityResultSchema = z.object({
+  externalStatus: z.string().optional(),
+  upstreamPayload: recordSchema.optional(),
+})
+
+export const pushContentRequestSchema = z.object({
+  channelId: z.string(),
+  externalProductId: z.string(),
+  productId: z.string(),
+  contentHash: z.string(),
+  content: z.unknown(),
+  contentSchemaVersion: z.string().optional(),
+  locale: localeSchema.optional(),
+})
+
+export const pushContentResultSchema = z.object({
+  externalStatus: z.string().optional(),
+  upstreamPayload: recordSchema.optional(),
+  acknowledgedHash: z.string().optional(),
+})
+
+export const sourceAdapterSchema = z.custom<SourceAdapter>(
+  (value) => {
+    if (!isRecord(value) || typeof value.kind !== "string") return false
+    if (!adapterCapabilitiesSchema.safeParse(value.capabilities).success) return false
+    return [
+      "connect",
+      "pause",
+      "disconnect",
+      "getState",
+      "discover",
+      "freshnessCheck",
+      "liveResolve",
+      "getContent",
+      "reserve",
+      "cancel",
+      "pushBooking",
+      "pushAvailability",
+      "pushContent",
+      "onDrift",
+    ].every((key) => optionalFunction(value[key]))
+  },
+  { message: "Invalid source adapter" },
+)

--- a/packages/catalog/src/booking-engine/book.ts
+++ b/packages/catalog/src/booking-engine/book.ts
@@ -18,7 +18,11 @@ import type { AnyDrizzleDb } from "@voyantjs/db"
 import { newId } from "@voyantjs/db/lib/typeid"
 import { eq } from "drizzle-orm"
 
-import type { ReserveRequest, SourceAdapterContext } from "../adapter/contract.js"
+import type {
+  ReserveRequest,
+  SourceAdapterContext,
+  SourceAdapterRequestScope,
+} from "../adapter/contract.js"
 import { type CaptureSnapshotInput, captureSnapshot } from "../services/snapshot-service.js"
 import {
   bookingCatalogSnapshotTable,
@@ -48,6 +52,10 @@ export type BookingPaymentIntent =
   | { type: "hold" }
   | { type: "card"; tokenizedCard: string }
   | { type: "ticket_on_credit"; agencyAccount: string }
+
+function paymentIntentToAdapterRecord(intent: BookingPaymentIntent): Record<string, unknown> {
+  return { ...intent }
+}
 
 export interface BookEntityRequest {
   /** Quote previously returned from `quoteEntity`. */
@@ -92,6 +100,13 @@ export interface BookEntityRequest {
     market?: string
     currency?: string
   }
+
+  /**
+   * Per-request supplier scope forwarded to `SourceAdapter.reserve`.
+   * Kept separate from `contentScope`: this controls upstream write
+   * semantics, while `contentScope` controls snapshot-content capture.
+   */
+  adapterScope?: SourceAdapterRequestScope
 }
 
 export interface BookEntityResult {
@@ -250,7 +265,9 @@ export async function bookEntity(
     entity_id: quote.entity_id,
     parameters: request.parameters ?? {},
     party: request.party,
-    payment_intent: paymentIntent as unknown as Record<string, unknown>,
+    payment_intent: paymentIntentToAdapterRecord(paymentIntent),
+    scope: request.adapterScope,
+    idempotency_key: request.idempotencyKey,
   }
 
   const reserveResult = await adapter.reserve(request.adapterContext, reserveRequest)

--- a/packages/catalog/src/booking-engine/cancel.ts
+++ b/packages/catalog/src/booking-engine/cancel.ts
@@ -11,7 +11,11 @@
 import type { AnyDrizzleDb } from "@voyantjs/db"
 import { and, eq } from "drizzle-orm"
 
-import type { CancelResult, SourceAdapterContext } from "../adapter/contract.js"
+import type {
+  CancelResult,
+  SourceAdapterContext,
+  SourceAdapterRequestScope,
+} from "../adapter/contract.js"
 import {
   bookingCatalogSnapshotTable,
   type SelectBookingCatalogSnapshot,
@@ -25,6 +29,8 @@ export interface CancelEntityRequest {
   entityModule: string
   entityId: string
   reason?: string
+  scope?: SourceAdapterRequestScope
+  idempotencyKey?: string
   adapterContext: SourceAdapterContext
 }
 
@@ -32,6 +38,7 @@ export interface CancelEntityResult {
   status: CancelResult["status"]
   refundAmount?: number
   refundCurrency?: string
+  pendingChannel?: string
   /** The snapshot row's id — exposed for callers that want to log the cancel against it. */
   snapshotId: string
 }
@@ -66,12 +73,15 @@ export async function cancelEntity(
   const result = await adapter.cancel(request.adapterContext, {
     upstream_ref: snapshot.source_ref ?? snapshot.id,
     reason: request.reason,
+    scope: request.scope,
+    idempotency_key: request.idempotencyKey,
   })
 
   return {
     status: result.status,
     refundAmount: result.refund_amount,
     refundCurrency: result.refund_currency,
+    pendingChannel: result.pending_channel,
     snapshotId: snapshot.id,
   }
 }

--- a/packages/catalog/src/index.ts
+++ b/packages/catalog/src/index.ts
@@ -27,7 +27,9 @@ export {
   type ReserveResult,
   type SourceAdapter,
   type SourceAdapterContext,
+  type SourceAdapterRequestScope,
 } from "./adapter/contract.js"
+export * from "./adapter/schemas.js"
 // BookingJourney HTTP contract — root export matches the Hono module pattern
 // used by the vertical packages while keeping the ./booking-engine subpath.
 export {


### PR DESCRIPTION
## Summary

- Add zod v4 runtime schemas for the public catalog source-adapter payload contract, including capabilities, provenance, context, discovery, live resolve, content, booking forwarding, and channel-push shapes.
- Export schemas from the package root and `@voyantjs/catalog/adapter/schemas`.
- Extend reserve/cancel adapter writes with optional request scope and idempotency keys, and model async cancellation with `pending` status plus `pending_channel`.
- Forward scoped/idempotent reserve/cancel data through the booking engine and preserve pending-channel metadata in cancel results.
- Add type-equivalence, parse/reject tests, docs, and a changeset.

Closes #989.
Closes #990.

## Verification

- `pnpm --filter @voyantjs/catalog typecheck`
- `pnpm --filter @voyantjs/catalog test`
- `pnpm --filter @voyantjs/catalog lint`
- `pnpm --filter @voyantjs/catalog build`
- `pnpm verify:fast`
- pre-commit hook: changed-file formatting/secret checks, agent-quality, repository lint/typecheck
- pre-push hook: repository test task