### PR TITLE
fix: typecheck regressions on main from #991 + #994 interactions

### DIFF
--- a/packages/extras-ui/src/i18n.test.tsx
+++ b/packages/extras-ui/src/i18n.test.tsx
@@ -15,6 +15,8 @@ const product = {
   name: "Danube Cruise",
   status: "active",
   description: null,
+  inclusionsHtml: null,
+  exclusionsHtml: null,
   bookingMode: "date_time",
   capacityMode: "limited",
   timezone: null,

--- a/packages/sellability-ui/src/i18n.test.tsx
+++ b/packages/sellability-ui/src/i18n.test.tsx
@@ -44,6 +44,8 @@ const product = {
   name: "Danube Cruise",
   status: "active",
   description: null,
+  inclusionsHtml: null,
+  exclusionsHtml: null,
   bookingMode: "date_time",
   capacityMode: "limited",
   timezone: null,

--- a/templates/operator/src/api/travel-composer-runtime.ts
+++ b/templates/operator/src/api/travel-composer-runtime.ts
@@ -417,11 +417,26 @@ async function cancelComponent(
     },
   )
 
+  // Catalog adapters can return "pending" when an async cancel was submitted
+  // (email/partner-portal/batch) and the inventory hasn't been released yet.
+  // The travel-composer's `CancelComponentResult` doesn't model that state —
+  // surface it as `refused` with a reason so the trip lands in remediation
+  // and the operator follows up out-of-band. `pending_channel` flows through
+  // the reason so the UI can show where the request went.
+  const status: CancelComponentResult["status"] =
+    result.status === "pending" ? "refused" : result.status
+  const reason =
+    result.status === "cancelled"
+      ? undefined
+      : result.status === "pending"
+        ? `cancel_pending${result.pendingChannel ? `:${result.pendingChannel}` : ""}`
+        : `cancel_${result.status}`
+
   return {
-    status: result.status,
+    status,
     refundAmountCents: result.refundAmount,
     refundCurrency: result.refundCurrency,
-    reason: result.status === "cancelled" ? undefined : `cancel_${result.status}`,
+    reason,
     snapshot: { snapshotId: result.snapshotId },
   }
 }


### PR DESCRIPTION
## Summary

Main is red after #992 merged on top of #991 (catalog adapter "pending" cancel status) + #994 (rich-text inclusions/exclusions on ProductRecord). Three packages fail typecheck:

- **`@voyantjs/extras-ui` / `@voyantjs/sellability-ui`** — `i18n.test.tsx` ProductRecord fixtures miss the new required `inclusionsHtml` / `exclusionsHtml` fields added by #994. Both passed CI on their own merges (their fixtures pre-dated #994), but the combined merge surfaced the gap. Setting both to `null`.

- **`templates/operator/src/api/travel-composer-runtime.ts`** — catalog `CancelResult.status` was widened to `"cancelled" | "pending" | "refused" | "failed"` in #991, but the travel-composer's `CancelComponentResult` contract still only models `"cancelled" | "refused" | "failed"`. The operator runtime assigned `result.status` straight through, which used to work and now doesn't. Mapping `"pending"` → `"refused"` at the operator boundary with a `cancel_pending[:channel]` reason; that pushes the trip into remediation while the async cancel resolves out-of-band, and threads `pending_channel` through so the UI can show where the request went.

Failing run for reference: https://github.com/voyantjs/voyant/actions/runs/26142687516

## Test plan

- [x] `pnpm -F @voyantjs/extras-ui -F @voyantjs/sellability-ui -F operator typecheck` — clean locally
- [ ] CI typecheck green on all 126 workspace projects