### PR TITLE
chore: changeset for unreleased main work (#991 / #992 / #994)

### DIFF
--- a/.changeset/inclusions-exclusions-cancel-pending-barrel-cleanup.md
+++ b/.changeset/inclusions-exclusions-cancel-pending-barrel-cleanup.md
@@ -1,0 +1,32 @@
+---
+"@voyantjs/products": minor
+"@voyantjs/products-react": minor
+"@voyantjs/products-ui": minor
+"@voyantjs/catalog": minor
+"@voyantjs/ui": minor
+"@voyantjs/admin": minor
+---
+
+Release the changes accumulated on main since 0.58.0 that landed without
+their own changesets.
+
+- **products / products-react / products-ui** — add `inclusionsHtml` and
+  `exclusionsHtml` rich-text fields on `ProductRecord` plus the supporting
+  product-form + product-detail UI (#994). Consumer test fixtures may need
+  `inclusionsHtml: null, exclusionsHtml: null` added.
+- **catalog** — widen `CancelResult.status` to include `"pending"` for
+  adapters that submit async cancellations (email / partner portal / batch)
+  with a `pending_channel` (#991). Downstream consumers using the narrow
+  `"cancelled" | "refused" | "failed"` union need to either widen their
+  surface or map `"pending"` at the boundary.
+- **ui** — drop heavy passthrough re-exports from `@voyantjs/ui/components`
+  barrel: `RichTextEditor`, `chart`, `dashboard-widgets`, `phone-input`,
+  and all `NotificationTemplate*` / `notification-template-dialog` /
+  `notification-{deliveries,reminder-rules,reminder-runs}-page` entries.
+  Import these via subpath from `@voyantjs/ui/components/<file>` instead
+  (e.g. `@voyantjs/ui/components/rich-text-editor`). Was leaking ~600 KB
+  of tiptap/prosemirror, ~390 KB of recharts, and ~200 KB of
+  libphonenumber-js into every barrel consumer.
+- **admin** — drop `DashboardPage` from the `@voyantjs/admin` barrel for
+  the same reason (recharts leakage). Import from
+  `@voyantjs/admin/dashboard` instead.


### PR DESCRIPTION
## Summary

Three feature PRs landed on main without their own changesets, so the next \`chore: release packages\` PR would have produced a no-op release:

| PR | Touches published packages | Was missing a changeset |
|---|---|---|
| #991 catalog adapter "pending" cancel status | \`@voyantjs/catalog\` | yes |
| #992 operator perf + barrel cleanup | \`@voyantjs/ui\`, \`@voyantjs/admin\` | yes |
| #994 rich-text inclusions/exclusions | \`@voyantjs/products\`, \`-react\`, \`-ui\` | yes |

Single \`minor\` changeset captures all of them. Because the workspace uses a \`fixed\` group, the bump level is the only thing that matters for versions; the named packages drive the CHANGELOG entries.

**No major bump** — staying on 0.x. By semver convention, breaking changes on 0.x go in the minor slot, which is the right place for the \`@voyantjs/ui\` + \`@voyantjs/admin\` barrel removals from #992.

## Breaking notes (carried in the CHANGELOG entry)

- \`@voyantjs/ui/components\` barrel no longer re-exports \`RichTextEditor\`, \`chart\`, \`dashboard-widgets\`, \`phone-input\`, or the \`NotificationTemplate*\` / \`notification-{deliveries,reminder-rules,reminder-runs}-page\` entries. Use the subpath imports: \`@voyantjs/ui/components/rich-text-editor\`, etc.
- \`@voyantjs/admin\` barrel no longer re-exports \`DashboardPage\`. Use \`@voyantjs/admin/dashboard\`.
- \`@voyantjs/catalog\` widens \`CancelResult.status\` to include \`"pending"\` with an optional \`pending_channel\`. Consumers narrow on this type need to handle the new case or map at the boundary (the operator runtime does the latter).

## Test plan

- [ ] CI green
- [ ] Once merged, the auto-opened "Release" PR bumps the fixed group from \`0.58.0\` → \`0.59.0\` and lists each affected package's CHANGELOG entry