### PR TITLE
Add adapter capability changeset

### DIFF
--- a/.changeset/bright-adapters-fetch.md
+++ b/.changeset/bright-adapters-fetch.md
@@ -1,0 +1,10 @@
+---
+"@voyantjs/catalog": minor
+"@voyantjs/accommodations": patch
+"@voyantjs/cruises": patch
+"@voyantjs/products": patch
+---
+
+Extend the source-adapter contract with cache-ownership and reservation-retrieval capabilities. Adapters can now declare `ownsContentCache`, `ownsAvailabilityCache`, and `supportsReservationRetrieval`, and can implement `getReservation` / `listReservations` for authoritative upstream booking reads.
+
+Products, accommodations, and cruises content services now honor `ownsContentCache` by treating adapter content reads as pass-through and skipping sourced-content cache reads and writes.


### PR DESCRIPTION
## Summary

- Add the missing changeset for the adapter cache-ownership and reservation-retrieval work from #998 and #999.

## Verification

- Not run per request; pushed with hooks skipped.

Closes #998
Closes #999