### PR TITLE
Fix booking create unit capacity labels

### DIFF
--- a/.changeset/quiet-rooms-fill.md
+++ b/.changeset/quiet-rooms-fill.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/bookings-ui": patch
+---
+
+Fix booking-create room assignment and per-person capacity labels for finite slots.

--- a/packages/bookings-ui/src/components/booking-create-dialog.tsx
+++ b/packages/bookings-ui/src/components/booking-create-dialog.tsx
@@ -177,6 +177,13 @@ function stripUnitSuffix(name: string): string {
   return idx > 0 ? name.slice(0, idx) : name
 }
 
+function isRoomUnit(unit: {
+  optionUnitId: string
+  unitType?: OptionUnitsStepperUnit["unitType"]
+}): boolean {
+  return unit.unitType === "room"
+}
+
 /**
  * Any payment-schedule entry the operator has marked as already
  * paid. Drives the smart-default booking status on submit — if money
@@ -526,6 +533,10 @@ export function BookingCreateForm({
     })
     return optionSlots.length > 0 ? optionSlots : allOpenSlots
   }, [slotsData?.data, slotsFromIso, product.optionId, allOpenSlots])
+  const selectedSlot = React.useMemo(
+    () => slots.find((slot) => slot.id === slotId) ?? null,
+    [slots, slotId],
+  )
   const setSelectedSlot = React.useCallback(
     (nextSlotId: string | null) => {
       const selectedSlot = nextSlotId ? allOpenSlots.find((slot) => slot.id === nextSlotId) : null
@@ -583,10 +594,12 @@ export function BookingCreateForm({
       optionUnitId: string
       unitName: string
       unitCode?: string | null
+      unitType?: OptionUnitsStepperUnit["unitType"]
       occupancyMax: number | null
     }
-    const units: UnitLike[] =
+    const units: UnitLike[] = (
       roomUnits.length > 0 ? roomUnits : (slotUnitAvailability.data?.data ?? [])
+    ).filter(isRoomUnit)
     if (units.length === 0) return []
     const optionGroups = new Map<
       string,
@@ -1001,6 +1014,11 @@ export function BookingCreateForm({
               optionId={product.optionId}
               enabled={enabled}
               onUnitsChange={handleRoomUnitsChange}
+              slotHasFiniteCapacity={
+                Boolean(selectedSlot) &&
+                !selectedSlot?.unlimited &&
+                typeof selectedSlot?.remainingPax === "number"
+              }
               labels={{
                 heading: messages.bookingCreateDialog.labels.roomsHeading,
                 noOption: messages.bookingCreateDialog.labels.roomsNoOption,

--- a/packages/bookings-ui/src/components/option-units-stepper-section.tsx
+++ b/packages/bookings-ui/src/components/option-units-stepper-section.tsx
@@ -63,7 +63,9 @@ export interface OptionUnitsStepperSectionProps {
     noUnits?: string
     remaining?: string
     unlimited?: string
+    fillsSlotCapacity?: string
   }
+  slotHasFiniteCapacity?: boolean
 }
 
 /**
@@ -95,6 +97,7 @@ export function OptionUnitsStepperSection({
   enabled = true,
   onUnitsChange,
   labels,
+  slotHasFiniteCapacity = false,
 }: OptionUnitsStepperSectionProps) {
   const productsClient = useVoyantProductsContext()
   const messages = useBookingsUiMessagesOrDefault()
@@ -141,14 +144,14 @@ export function OptionUnitsStepperSection({
   // row, so we look it up from the units we already fetched per option.
   const optionByUnitId = React.useMemo(() => {
     const map = new Map<string, string>()
-    productOptions.forEach((option, index) => {
-      const units = optionUnitQueries[index]?.data?.data ?? []
-      for (const unit of units) {
-        map.set(unit.id, option.id)
-      }
-    })
+    for (const unit of optionUnitRows) {
+      if (unit.optionId) map.set(unit.optionUnitId, unit.optionId)
+    }
     return map
-  }, [productOptions, optionUnitQueries])
+  }, [optionUnitRows])
+  const productUnitById = React.useMemo(() => {
+    return new Map(optionUnitRows.map((unit) => [unit.optionUnitId, unit]))
+  }, [optionUnitRows])
   // The slot's bound option, derived from the first availability row.
   // `null` when the slot is product-level (no option_id) — that path goes
   // through the product-level fallback below.
@@ -158,11 +161,18 @@ export function OptionUnitsStepperSection({
   )
   const availabilityUnitRows = React.useMemo(
     () =>
-      (availability.data?.data ?? []).map((unit) => ({
-        ...unit,
-        optionId: slotOptionId ?? optionId ?? null,
-      })),
-    [availability.data?.data, slotOptionId, optionId],
+      (availability.data?.data ?? []).map((unit) => {
+        const productUnit = productUnitById.get(unit.optionUnitId)
+        return {
+          ...unit,
+          optionId: productUnit?.optionId ?? slotOptionId ?? optionId ?? null,
+          unitCode: productUnit?.unitCode ?? null,
+          minAge: productUnit?.minAge ?? null,
+          maxAge: productUnit?.maxAge ?? null,
+          unitType: productUnit?.unitType ?? null,
+        }
+      }),
+    [availability.data?.data, productUnitById, slotOptionId, optionId],
   )
   // Slot-bound per-unit availability stays authoritative for the slot's
   // option (real-time `remaining` from active bookings). For *other*
@@ -215,6 +225,7 @@ export function OptionUnitsStepperSection({
         optionKey,
         optionName,
         primary: group.primary,
+        allUnits: group.allUnits,
         totalRemaining,
       }
     })
@@ -259,10 +270,16 @@ export function OptionUnitsStepperSection({
     <div className="flex flex-col gap-2 rounded-md border p-3">
       <Label>{merged.heading}</Label>
       <div className="flex flex-col gap-2">
-        {optionRows.map(({ optionKey, optionName, primary, totalRemaining }) => {
+        {optionRows.map(({ optionKey, optionName, primary, allUnits, totalRemaining }) => {
           const qty = value.quantities[primary.optionUnitId] ?? 0
-          const remainingLabel =
-            totalRemaining === null ? merged.unlimited : `${totalRemaining} ${merged.remaining}`
+          const remainingLabel = resolveOptionRemainingLabel({
+            totalRemaining,
+            units: allUnits,
+            slotHasFiniteCapacity,
+            remaining: merged.remaining,
+            unlimited: merged.unlimited,
+            fillsSlotCapacity: merged.fillsSlotCapacity,
+          })
           const atMax = totalRemaining !== null && qty >= totalRemaining
 
           return (
@@ -302,6 +319,28 @@ export function OptionUnitsStepperSection({
       </div>
     </div>
   )
+}
+
+export function resolveOptionRemainingLabel({
+  totalRemaining,
+  units,
+  slotHasFiniteCapacity,
+  remaining,
+  unlimited,
+  fillsSlotCapacity,
+}: {
+  totalRemaining: number | null
+  units: ReadonlyArray<Pick<OptionUnitsStepperUnit, "unitType">>
+  slotHasFiniteCapacity: boolean
+  remaining: string
+  unlimited: string
+  fillsSlotCapacity?: string
+}): string {
+  if (totalRemaining !== null) return `${totalRemaining} ${remaining}`
+  if (slotHasFiniteCapacity && units.length > 0 && units.every(isPersonUnit)) {
+    return fillsSlotCapacity ?? unlimited
+  }
+  return unlimited
 }
 
 /**
@@ -350,6 +389,10 @@ function isAdultUnit(unit: OptionUnitsStepperUnit): boolean {
   // unit object doesn't carry the code, so fall back to name-matching
   // when the upstream code isn't surfaced.
   return /\badult\b/i.test(unit.unitName)
+}
+
+function isPersonUnit(unit: Pick<OptionUnitsStepperUnit, "unitType">): boolean {
+  return unit.unitType === "person"
 }
 
 function optionUnitToStepperUnit(

--- a/packages/bookings-ui/src/i18n/en.ts
+++ b/packages/bookings-ui/src/i18n/en.ts
@@ -439,6 +439,7 @@ export const bookingsUiEn = {
       noUnits: "This departure has no per-unit availability configured.",
       remaining: "left",
       unlimited: "unlimited",
+      fillsSlotCapacity: "fills slot capacity",
       decreaseUnitPrefix: "Decrease",
       increaseUnitPrefix: "Increase",
     },

--- a/packages/bookings-ui/src/i18n/messages.ts
+++ b/packages/bookings-ui/src/i18n/messages.ts
@@ -416,6 +416,7 @@ export type BookingsUiMessages = {
       noUnits: string
       remaining: string
       unlimited: string
+      fillsSlotCapacity: string
       decreaseUnitPrefix: string
       increaseUnitPrefix: string
     }

--- a/packages/bookings-ui/src/i18n/ro.ts
+++ b/packages/bookings-ui/src/i18n/ro.ts
@@ -438,6 +438,7 @@ export const bookingsUiRo = {
       noUnits: "Aceasta plecare nu are disponibilitate configurata pe unitati.",
       remaining: "ramase",
       unlimited: "nelimitat",
+      fillsSlotCapacity: "umple capacitatea plecarii",
       decreaseUnitPrefix: "Scade",
       increaseUnitPrefix: "Creste",
     },

--- a/packages/bookings-ui/tests/unit/option-units-stepper-merge.test.ts
+++ b/packages/bookings-ui/tests/unit/option-units-stepper-merge.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   mergeStepperUnits,
   type OptionUnitsStepperUnit,
+  resolveOptionRemainingLabel,
   resolveSlotOptionId,
 } from "../../src/components/option-units-stepper-section.js"
 
@@ -94,5 +95,46 @@ describe("mergeStepperUnits", () => {
     const productRows = [sgl, dbl]
 
     expect(mergeStepperUnits([], productRows, "popt_SGL", true)).toEqual(productRows)
+  })
+})
+
+describe("resolveOptionRemainingLabel", () => {
+  it("uses the slot-capacity label for uncapped person units on finite slots", () => {
+    expect(
+      resolveOptionRemainingLabel({
+        totalRemaining: null,
+        units: [{ unitType: "person" }],
+        slotHasFiniteCapacity: true,
+        remaining: "left",
+        unlimited: "unlimited",
+        fillsSlotCapacity: "fills slot capacity",
+      }),
+    ).toBe("fills slot capacity")
+  })
+
+  it("keeps unlimited for uncapped room units", () => {
+    expect(
+      resolveOptionRemainingLabel({
+        totalRemaining: null,
+        units: [{ unitType: "room" }],
+        slotHasFiniteCapacity: true,
+        remaining: "left",
+        unlimited: "unlimited",
+        fillsSlotCapacity: "fills slot capacity",
+      }),
+    ).toBe("unlimited")
+  })
+
+  it("shows explicit remaining counts when option units are capped", () => {
+    expect(
+      resolveOptionRemainingLabel({
+        totalRemaining: 43,
+        units: [{ unitType: "person" }],
+        slotHasFiniteCapacity: true,
+        remaining: "left",
+        unlimited: "unlimited",
+        fillsSlotCapacity: "fills slot capacity",
+      }),
+    ).toBe("43 left")
   })
 })


### PR DESCRIPTION
## Summary

- Preserve product unit metadata on slot availability rows so booking-create can distinguish person units from room units.
- Filter traveler room assignment options to actual `room` units only.
- Replace the per-person uncapped option label with slot-capacity wording when the selected slot has finite capacity.

Closes #1024
Closes #1025

## Verification

- `pnpm --filter @voyantjs/bookings-ui test`
- `pnpm --filter @voyantjs/bookings-ui typecheck`
- `pnpm --filter @voyantjs/bookings-ui lint`
- `git diff --check`

Full pre-commit/pre-push lanes currently fail on `main` with unrelated `@voyantjs/action-ledger` resolution errors from `packages/crm/src/routes/person-documents.ts` in CRM dependents.