### PR TITLE
Surface neon-http transaction mismatch at startup, not on first write

### DIFF
--- a/.changeset/transactional-db-assertion.md
+++ b/.changeset/transactional-db-assertion.md
@@ -1,0 +1,17 @@
+---
+"@voyantjs/db": minor
+"@voyantjs/core": minor
+"@voyantjs/hono": minor
+"@voyantjs/action-ledger": patch
+"@voyantjs/availability": patch
+"@voyantjs/bookings": patch
+"@voyantjs/charters": patch
+"@voyantjs/crm": patch
+"@voyantjs/cruises": patch
+"@voyantjs/finance": patch
+"@voyantjs/legal": patch
+"@voyantjs/notifications": patch
+"@voyantjs/transactions": patch
+---
+
+Extract `withOptionalTransaction` into `@voyantjs/db/transaction` so the soft-fallback helper that action-ledger has used since 0.62.0 can be shared by any package that needs it. Add `Module.requiresTransactionalDb` so modules whose write paths use interactive transactions declare it, and have `createApp()` assert on first request that the resolved db adapter supports `db.transaction(async (tx) => …)`. With the neon-http (edge) adapter that assertion now throws an actionable error pointing at `createServerlessDbClient` (neon-serverless / WebSocket) or `createDbClient(url, { adapter: "node" })` — instead of the cryptic "No transactions support in neon-http driver" exception thrown on first write.

--- a/packages/action-ledger/src/service.ts
+++ b/packages/action-ledger/src/service.ts
@@ -1,6 +1,6 @@
 import type { AnyDrizzleDb } from "@voyantjs/db"
 import { newId } from "@voyantjs/db/lib/typeid"
-import { dbSupportsTransactions } from "@voyantjs/db/transaction-capability"
+import { withOptionalTransaction } from "@voyantjs/db/transaction"
 import { and, asc, desc, eq, gt, gte, inArray, lt, lte, or, type SQL, sql } from "drizzle-orm"
 
 import {
@@ -964,51 +964,6 @@ type ActionLedgerRelayOutboxSqlRow = {
   last_error: string | null
   created_at: Date | string
   processed_at: Date | string | null
-}
-
-type TransactionalDrizzleDb = AnyDrizzleDb & {
-  transaction?: <T>(callback: (tx: AnyDrizzleDb) => Promise<T>) => Promise<T>
-}
-
-const activeTransactionDbs = new WeakSet<object>()
-
-function isUnsupportedTransactionError(error: unknown): boolean {
-  return error instanceof Error && /No transactions support/i.test(error.message)
-}
-
-async function withOptionalTransaction<T>(
-  db: AnyDrizzleDb,
-  callback: (tx: AnyDrizzleDb) => Promise<T>,
-): Promise<T> {
-  if (activeTransactionDbs.has(db as object)) {
-    return callback(db)
-  }
-
-  if (dbSupportsTransactions(db) === false) {
-    return callback(db)
-  }
-
-  const maybeTransactional = db as TransactionalDrizzleDb
-  if (typeof maybeTransactional.transaction === "function") {
-    let callbackStarted = false
-    try {
-      return await maybeTransactional.transaction(async (tx) => {
-        callbackStarted = true
-        activeTransactionDbs.add(tx as object)
-        try {
-          return await callback(tx)
-        } finally {
-          activeTransactionDbs.delete(tx as object)
-        }
-      })
-    } catch (error) {
-      if (!callbackStarted && isUnsupportedTransactionError(error)) {
-        return callback(db)
-      }
-      throw error
-    }
-  }
-  return callback(db)
 }
 
 function actionLedgerRelayOutboxFromSqlRow(

--- a/packages/availability/src/index.ts
+++ b/packages/availability/src/index.ts
@@ -8,6 +8,7 @@ export type { AvailabilityAdminRoutes, AvailabilityRoutes } from "./routes.js"
 
 export const availabilityModule: Module = {
   name: "availability",
+  requiresTransactionalDb: true,
 }
 
 export const availabilityHonoModule: HonoModule = {

--- a/packages/bookings/src/index.ts
+++ b/packages/bookings/src/index.ts
@@ -83,6 +83,7 @@ export const bookingsLinkable = {
 export const bookingsModule: Module = {
   name: "bookings",
   linkable: bookingsLinkable,
+  requiresTransactionalDb: true,
 }
 
 export interface BookingsHonoModuleOptions extends BookingRouteRuntimeOptions {}

--- a/packages/charters/src/index.ts
+++ b/packages/charters/src/index.ts
@@ -113,6 +113,7 @@ export const chartersModule: Module = {
     charter_voyage: charterVoyageLinkable,
     charter_yacht: charterYachtLinkable,
   },
+  requiresTransactionalDb: true,
 }
 
 export const chartersHonoModule: HonoModule = {

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -111,6 +111,25 @@ export interface Module {
    * {@link workflows} above.
    */
   eventFilters?: readonly EventFilterDescriptor[]
+
+  /**
+   * Declares that this module's write paths use interactive transactions
+   * (`db.transaction(async (tx) => …)`) and therefore require a
+   * transaction-capable database adapter at runtime.
+   *
+   * `createApp()` collects this flag across mounted modules and, on the
+   * first request, asserts that the resolved db driver supports
+   * interactive transactions. If the resolved driver explicitly reports
+   * `dbSupportsTransactions(db) === false` (e.g. `neon-http`), the app
+   * throws a clear error naming the offending modules and points at the
+   * supported adapters (`createServerlessDbClient` /
+   * `createDbClient(url, { adapter: "node" })`).
+   *
+   * This converts the otherwise-late "No transactions support in
+   * neon-http driver" exception thrown on first write into an
+   * actionable startup error.
+   */
+  requiresTransactionalDb?: boolean
 }
 
 /**

--- a/packages/crm/src/index.ts
+++ b/packages/crm/src/index.ts
@@ -31,6 +31,7 @@ export const crmModule: Module = {
     person: personLinkable,
     organization: organizationLinkable,
   },
+  requiresTransactionalDb: true,
 }
 
 export interface CrmHonoModuleOptions extends CrmRouteRuntimeOptions {}

--- a/packages/cruises/src/index.ts
+++ b/packages/cruises/src/index.ts
@@ -118,6 +118,7 @@ export const cruisesModule: Module = {
     cruise_sailing: cruiseSailingLinkable,
     cruise_ship: cruiseShipLinkable,
   },
+  requiresTransactionalDb: true,
 }
 
 export const cruisesHonoModule: HonoModule = {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -21,6 +21,7 @@
     "./helpers": "./src/helpers.ts",
     "./types": "./src/types.ts",
     "./transaction-capability": "./src/transaction-capability.ts",
+    "./transaction": "./src/transaction.ts",
     "./crud": "./src/crud.ts",
     "./links": "./src/links.ts",
     "./queries": "./src/queries/index.ts",
@@ -115,6 +116,11 @@
         "types": "./dist/transaction-capability.d.ts",
         "import": "./dist/transaction-capability.js",
         "default": "./dist/transaction-capability.js"
+      },
+      "./transaction": {
+        "types": "./dist/transaction.d.ts",
+        "import": "./dist/transaction.js",
+        "default": "./dist/transaction.js"
       },
       "./crud": {
         "types": "./dist/crud.d.ts",

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -192,6 +192,7 @@ export * from "./lib/index.js"
 export * from "./lifecycle.js"
 // Re-export queries
 export * from "./queries/index.js"
+export { withOptionalTransaction } from "./transaction.js"
 export * from "./transaction-capability.js"
 export * from "./types.js"
 export * from "./utils.js"

--- a/packages/db/src/transaction.ts
+++ b/packages/db/src/transaction.ts
@@ -1,0 +1,83 @@
+import { dbSupportsTransactions } from "./transaction-capability.js"
+
+const activeTransactionDbs = new WeakSet<object>()
+
+function isUnsupportedTransactionError(error: unknown): boolean {
+  return error instanceof Error && /No transactions support/i.test(error.message)
+}
+
+type TransactionalLike<TDb, T> = {
+  transaction?: (callback: (tx: TDb) => Promise<T>) => Promise<T>
+}
+
+/**
+ * Run `callback` inside a database transaction when the driver supports one,
+ * or invoke it directly against the same `db` handle when it doesn't.
+ *
+ * Designed for Voyant services that share code paths between drivers with
+ * different transaction semantics:
+ *
+ * - `postgres-js` (node) and `neon-serverless` (WebSocket): real transactions.
+ *   The driver's `transaction(...)` method is used.
+ * - `neon-http` (edge): the HTTP driver tagged with
+ *   `VOYANT_DB_SUPPORTS_TRANSACTIONS = false` by `createDbClient`. The
+ *   callback runs directly against `db`. Writes execute as independent
+ *   statements — atomicity is lost on this driver. Callers that need true
+ *   atomicity must select a transaction-capable adapter at startup.
+ *
+ * Nested calls are detected via a `WeakSet`: when invoked with a `tx` handle
+ * that the helper already opened, the callback runs in-place against that
+ * same handle (no second `BEGIN`).
+ *
+ * As a defense-in-depth, if a driver's `transaction()` throws with
+ * "No transactions support …" *before* the callback executes (i.e. the
+ * capability tag is missing on an HTTP-like driver), the helper retries by
+ * invoking the callback directly. Errors raised *after* the callback starts
+ * are not retried — they propagate.
+ */
+export async function withOptionalTransaction<TDb, T>(
+  db: TDb,
+  callback: (tx: TDb) => Promise<T>,
+): Promise<T> {
+  if (db && typeof db === "object" && activeTransactionDbs.has(db as object)) {
+    return callback(db)
+  }
+
+  if (dbSupportsTransactions(db) === false) {
+    return callback(db)
+  }
+
+  const maybeTransactional = db as TransactionalLike<TDb, T>
+  if (typeof maybeTransactional.transaction !== "function") {
+    return callback(db)
+  }
+
+  let callbackStarted = false
+  try {
+    return await maybeTransactional.transaction(async (tx) => {
+      callbackStarted = true
+      const txKey = tx as unknown
+      const trackable = txKey && typeof txKey === "object"
+      if (trackable) {
+        activeTransactionDbs.add(txKey as object)
+      }
+      try {
+        return await callback(tx)
+      } finally {
+        if (trackable) {
+          activeTransactionDbs.delete(txKey as object)
+        }
+      }
+    })
+  } catch (error) {
+    if (!callbackStarted && isUnsupportedTransactionError(error)) {
+      return callback(db)
+    }
+    throw error
+  }
+}
+
+/** @internal — exposed for tests so they can assert WeakSet behavior */
+export const __test__ = {
+  activeTransactionDbs,
+}

--- a/packages/db/tests/unit/transaction.test.ts
+++ b/packages/db/tests/unit/transaction.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test, vi } from "vitest"
+import { withOptionalTransaction } from "../../src/transaction.js"
+import { VOYANT_DB_SUPPORTS_TRANSACTIONS } from "../../src/transaction-capability.js"
+
+describe("withOptionalTransaction", () => {
+  test("skips transaction when capability tag says transactions are unsupported", async () => {
+    const db = {
+      [VOYANT_DB_SUPPORTS_TRANSACTIONS]: false,
+      transaction: vi.fn(() => {
+        throw new Error("transaction should not be called")
+      }),
+    }
+
+    const result = await withOptionalTransaction(db, async (tx) => {
+      expect(tx).toBe(db)
+      return "ok"
+    })
+
+    expect(result).toBe("ok")
+    expect(db.transaction).not.toHaveBeenCalled()
+  })
+
+  test("invokes transaction() when capability tag says transactions are supported", async () => {
+    const fakeTx = { kind: "tx" } as Record<string, unknown>
+    const db = {
+      [VOYANT_DB_SUPPORTS_TRANSACTIONS]: true,
+      transaction: vi.fn(async <T>(callback: (tx: typeof fakeTx) => Promise<T>) =>
+        callback(fakeTx),
+      ),
+    }
+
+    const result = await withOptionalTransaction(db, async (tx) => {
+      expect(tx).toBe(fakeTx)
+      return "wrapped"
+    })
+
+    expect(result).toBe("wrapped")
+    expect(db.transaction).toHaveBeenCalledOnce()
+  })
+
+  test("invokes callback directly when the db has no transaction method", async () => {
+    const db = {} as Record<string, unknown>
+
+    const result = await withOptionalTransaction(db, async (tx) => {
+      expect(tx).toBe(db)
+      return "no-tx-method"
+    })
+
+    expect(result).toBe("no-tx-method")
+  })
+
+  test("falls back when an untagged HTTP driver throws before the callback starts", async () => {
+    const db = {
+      transaction: vi.fn(() => {
+        throw new Error("No transactions support in neon-http driver")
+      }),
+    }
+
+    const result = await withOptionalTransaction(db, async (tx) => {
+      expect(tx).toBe(db)
+      return "fallback"
+    })
+
+    expect(result).toBe("fallback")
+    expect(db.transaction).toHaveBeenCalledOnce()
+  })
+
+  test("does not retry when an error is raised after the callback starts", async () => {
+    const fakeTx = { kind: "tx" } as Record<string, unknown>
+    const callbackTargets: unknown[] = []
+    const db = {
+      [VOYANT_DB_SUPPORTS_TRANSACTIONS]: true,
+      async transaction<T>(callback: (tx: typeof fakeTx) => Promise<T>) {
+        return callback(fakeTx)
+      },
+    }
+
+    await expect(
+      withOptionalTransaction(db, async (tx) => {
+        callbackTargets.push(tx)
+        throw new Error("No transactions support in a nested write")
+      }),
+    ).rejects.toThrow(/nested write/)
+
+    expect(callbackTargets).toEqual([fakeTx])
+  })
+
+  test("propagates non-transaction errors without retrying", async () => {
+    const db = {
+      [VOYANT_DB_SUPPORTS_TRANSACTIONS]: true,
+      transaction: vi.fn(() => {
+        throw new Error("unrelated boom")
+      }),
+    }
+
+    await expect(withOptionalTransaction(db, async () => "should-not-reach")).rejects.toThrow(
+      /unrelated boom/,
+    )
+
+    expect(db.transaction).toHaveBeenCalledOnce()
+  })
+
+  test("reuses an already-active transaction handle for nested calls", async () => {
+    const fakeTx = { kind: "tx" } as Record<string, unknown>
+    const innerOuterCalls: number[] = []
+    const db = {
+      [VOYANT_DB_SUPPORTS_TRANSACTIONS]: true,
+      transaction: vi.fn(async <T>(callback: (tx: typeof fakeTx) => Promise<T>) =>
+        callback(fakeTx),
+      ),
+    }
+
+    const result = await withOptionalTransaction(db, async (outerTx) => {
+      innerOuterCalls.push(1)
+      const inner = await withOptionalTransaction(outerTx, async (innerTx) => {
+        innerOuterCalls.push(2)
+        expect(innerTx).toBe(outerTx)
+        return "inner"
+      })
+      return inner
+    })
+
+    expect(result).toBe("inner")
+    expect(innerOuterCalls).toEqual([1, 2])
+    expect(db.transaction).toHaveBeenCalledOnce()
+  })
+
+  test("releases nested-tx tracking after the outer transaction returns", async () => {
+    const fakeTx = { kind: "tx" } as Record<string, unknown>
+    const db = {
+      [VOYANT_DB_SUPPORTS_TRANSACTIONS]: true,
+      transaction: vi.fn(async <T>(callback: (tx: typeof fakeTx) => Promise<T>) =>
+        callback(fakeTx),
+      ),
+    }
+
+    await withOptionalTransaction(db, async () => "first")
+    await withOptionalTransaction(db, async () => "second")
+
+    expect(db.transaction).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -52,6 +52,7 @@ export const financeLinkable = {
 export const financeModule: Module = {
   name: "finance",
   linkable: financeLinkable,
+  requiresTransactionalDb: true,
 }
 
 export interface FinanceHonoModuleOptions

--- a/packages/hono/src/app.ts
+++ b/packages/hono/src/app.ts
@@ -269,8 +269,14 @@ export function createApp<TBindings extends VoyantBindings>(
   // Auth middleware for all other routes
   app.use("*", requireAuth(config.db, { publicPaths: config.publicPaths, auth: config.auth }))
 
-  // DB middleware — sets c.var.db for all downstream handlers
-  app.use("*", db(config.db))
+  // DB middleware — sets c.var.db for all downstream handlers.
+  // Pass the list of modules that need interactive transactions so the
+  // middleware can throw a clear startup-style error on first request if
+  // the wired adapter is neon-http (which doesn't support db.transaction).
+  const txRequiringModules = allModules
+    .filter((m) => m.module.requiresTransactionalDb)
+    .map((m) => m.module.name)
+  app.use("*", db(config.db, { requiresTransactionalDb: txRequiringModules }))
 
   // Actor guards for the two API surfaces
   app.use("/v1/admin/*", requireActor("staff"))

--- a/packages/hono/src/middleware/db.ts
+++ b/packages/hono/src/middleware/db.ts
@@ -66,13 +66,17 @@ export function db<TBindings extends VoyantBindings>(
   Variables: { db: VoyantDb }
 }> {
   const requiresTx = options.requiresTransactionalDb ?? []
-  let txCapabilityChecked = false
+  // Stays `false` until a request resolves a db whose capability tag is
+  // anything other than an explicit `false`. As long as the adapter is
+  // wired wrong, every request keeps surfacing the actionable error —
+  // we don't want the first failing request to silence subsequent
+  // checks and let later writes crash with the deep transaction error.
+  let txCapabilityVerified = false
   return async (c, next) => {
     const result = factory(c.env)
     const { db, dispose } = resolveDbFactoryResult(result)
-    if (!txCapabilityChecked) {
-      txCapabilityChecked = true
-      if (requiresTx.length > 0 && dbSupportsTransactions(db) === false) {
+    if (!txCapabilityVerified && requiresTx.length > 0) {
+      if (dbSupportsTransactions(db) === false) {
         if (dispose) {
           try {
             await dispose()
@@ -82,6 +86,7 @@ export function db<TBindings extends VoyantBindings>(
         }
         throw buildIncapableDbError(requiresTx)
       }
+      txCapabilityVerified = true
     }
     if (dispose) {
       c.set("db", db)

--- a/packages/hono/src/middleware/db.ts
+++ b/packages/hono/src/middleware/db.ts
@@ -1,3 +1,4 @@
+import { dbSupportsTransactions } from "@voyantjs/db/transaction-capability"
 import type { MiddlewareHandler } from "hono"
 
 import {
@@ -6,6 +7,32 @@ import {
   type VoyantBindings,
   type VoyantDb,
 } from "../types.js"
+
+export interface DbMiddlewareOptions {
+  /**
+   * Names of modules that require a transaction-capable db adapter
+   * (those that set `Module.requiresTransactionalDb`). If non-empty
+   * and the first resolved db reports
+   * `dbSupportsTransactions(db) === false`, the middleware throws a
+   * clear error naming the offending modules. A capability of
+   * `undefined` (untagged drivers like raw `drizzle-orm/node-postgres`)
+   * is treated as "assume capable" — only an explicit `false`
+   * (neon-http) trips the assertion.
+   */
+  requiresTransactionalDb?: readonly string[]
+}
+
+function buildIncapableDbError(modules: readonly string[]): Error {
+  const list = [...modules].sort().join(", ")
+  return new Error(
+    `[voyant] db adapter does not support interactive transactions, but the ` +
+      `following modules require it: ${list}. ` +
+      `Use createServerlessDbClient (neon-serverless / WebSocket) for ` +
+      `Cloudflare Workers, or createDbClient(url, { adapter: "node" }) for ` +
+      `Node deployments. The "edge" adapter (neon-http) is read-mostly ` +
+      `and cannot run db.transaction(async (tx) => …).`,
+  )
+}
 
 /**
  * Structural shape of the Cloudflare Workers `ExecutionContext`. Defined
@@ -33,13 +60,29 @@ interface ExecutionContextLike {
  */
 export function db<TBindings extends VoyantBindings>(
   factory: DbFactory<TBindings>,
+  options: DbMiddlewareOptions = {},
 ): MiddlewareHandler<{
   Bindings: TBindings
   Variables: { db: VoyantDb }
 }> {
+  const requiresTx = options.requiresTransactionalDb ?? []
+  let txCapabilityChecked = false
   return async (c, next) => {
     const result = factory(c.env)
     const { db, dispose } = resolveDbFactoryResult(result)
+    if (!txCapabilityChecked) {
+      txCapabilityChecked = true
+      if (requiresTx.length > 0 && dbSupportsTransactions(db) === false) {
+        if (dispose) {
+          try {
+            await dispose()
+          } catch {
+            // swallow dispose errors — the original throw is the actionable one
+          }
+        }
+        throw buildIncapableDbError(requiresTx)
+      }
+    }
     if (dispose) {
       c.set("db", db)
       try {

--- a/packages/hono/tests/unit/db-middleware.test.ts
+++ b/packages/hono/tests/unit/db-middleware.test.ts
@@ -1,0 +1,105 @@
+import { VOYANT_DB_SUPPORTS_TRANSACTIONS } from "@voyantjs/db/transaction-capability"
+import { Hono } from "hono"
+import { describe, expect, it, vi } from "vitest"
+
+import { db } from "../../src/middleware/db.js"
+import type { VoyantDb } from "../../src/types.js"
+
+function fakeDb(supportsTransactions?: boolean): VoyantDb {
+  const handle: Record<PropertyKey, unknown> = {}
+  if (typeof supportsTransactions === "boolean") {
+    handle[VOYANT_DB_SUPPORTS_TRANSACTIONS] = supportsTransactions
+  }
+  return handle as unknown as VoyantDb
+}
+
+function buildApp(opts: Parameters<typeof db>[1] | undefined, factory: () => VoyantDb) {
+  const app = new Hono()
+  // Surface the thrown middleware error in the response body so tests can
+  // assert on it (matches the createApp + handleApiError shape in prod).
+  app.onError((err, c) => c.json({ error: err.message }, 500))
+  // biome-ignore lint/suspicious/noExplicitAny: simplified bindings for the test
+  app.use("*", db(factory as any, opts))
+  app.get("/", (c) => c.json({ db: typeof c.get("db") }))
+  return app
+}
+
+describe("db middleware — transactional adapter assertion", () => {
+  it("passes when no modules require transactions", async () => {
+    const factory = vi.fn(() => fakeDb(false))
+    const app = buildApp({ requiresTransactionalDb: [] }, factory)
+
+    const res = await app.request("/")
+
+    expect(res.status).toBe(200)
+    expect(factory).toHaveBeenCalledOnce()
+  })
+
+  it("passes when the db is tagged transaction-capable", async () => {
+    const factory = vi.fn(() => fakeDb(true))
+    const app = buildApp({ requiresTransactionalDb: ["bookings"] }, factory)
+
+    const res = await app.request("/")
+
+    expect(res.status).toBe(200)
+  })
+
+  it("passes when the db is untagged (assume capable)", async () => {
+    const factory = vi.fn(() => fakeDb(undefined))
+    const app = buildApp({ requiresTransactionalDb: ["bookings"] }, factory)
+
+    const res = await app.request("/")
+
+    expect(res.status).toBe(200)
+  })
+
+  it("throws when the db is tagged not-transaction-capable and a module needs it", async () => {
+    const factory = vi.fn(() => fakeDb(false))
+    const app = buildApp({ requiresTransactionalDb: ["bookings", "finance"] }, factory)
+
+    const res = await app.request("/")
+    const body = (await res.json()) as { error: string }
+
+    expect(res.status).toBe(500)
+    expect(body.error).toMatch(/db adapter does not support interactive transactions/)
+    expect(body.error).toMatch(/bookings, finance/)
+  })
+
+  it("error message points at the supported adapters", async () => {
+    const factory = vi.fn(() => fakeDb(false))
+    const app = buildApp({ requiresTransactionalDb: ["bookings"] }, factory)
+
+    const res = await app.request("/")
+    const body = (await res.json()) as { error: string }
+
+    expect(body.error).toMatch(/createServerlessDbClient/)
+    expect(body.error).toMatch(/adapter:\s*"node"/)
+  })
+
+  it("runs the capability check only once per middleware instance", async () => {
+    const factory = vi.fn(() => fakeDb(true))
+    const app = buildApp({ requiresTransactionalDb: ["bookings"] }, factory)
+
+    await app.request("/")
+    await app.request("/")
+    await app.request("/")
+
+    // Capability tag lookup is cheap, but we still want to confirm the
+    // middleware doesn't repeat the throw-decision work each request.
+    // Indirect proof: three successful requests, factory called three
+    // times (per-request lifecycle), but no thrown error means the
+    // once-only check passed and was not re-evaluated.
+    expect(factory).toHaveBeenCalledTimes(3)
+  })
+
+  it("disposes a per-request handle even when the capability check fails", async () => {
+    const dispose = vi.fn(async () => {})
+    const factory = () => ({ db: fakeDb(false), dispose })
+    const app = buildApp({ requiresTransactionalDb: ["bookings"] }, factory as never)
+
+    const res = await app.request("/")
+
+    expect(res.status).toBe(500)
+    expect(dispose).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/hono/tests/unit/db-middleware.test.ts
+++ b/packages/hono/tests/unit/db-middleware.test.ts
@@ -92,6 +92,24 @@ describe("db middleware — transactional adapter assertion", () => {
     expect(factory).toHaveBeenCalledTimes(3)
   })
 
+  it("keeps throwing on every request as long as the adapter is misconfigured", async () => {
+    const factory = vi.fn(() => fakeDb(false))
+    const app = buildApp({ requiresTransactionalDb: ["bookings"] }, factory)
+
+    const res1 = await app.request("/")
+    const res2 = await app.request("/")
+    const res3 = await app.request("/")
+
+    for (const res of [res1, res2, res3]) {
+      expect(res.status).toBe(500)
+      const body = (await res.json()) as { error: string }
+      expect(body.error).toMatch(/db adapter does not support interactive transactions/)
+    }
+    // Factory keeps being invoked per-request, not short-circuited after
+    // the first throw.
+    expect(factory).toHaveBeenCalledTimes(3)
+  })
+
   it("disposes a per-request handle even when the capability check fails", async () => {
     const dispose = vi.fn(async () => {})
     const factory = () => ({ db: fakeDb(false), dispose })

--- a/packages/legal/src/index.ts
+++ b/packages/legal/src/index.ts
@@ -28,6 +28,7 @@ export const legalLinkable = {
 export const legalModule: Module = {
   name: "legal",
   linkable: legalLinkable,
+  requiresTransactionalDb: true,
 }
 
 export interface CreateLegalHonoModuleOptions extends ContractsRouteOptions {

--- a/packages/notifications/src/schema.ts
+++ b/packages/notifications/src/schema.ts
@@ -481,6 +481,7 @@ export const notificationsLinkable = {
 export const notificationsModule: Module = {
   name: "notifications",
   linkable: notificationsLinkable,
+  requiresTransactionalDb: true,
 }
 
 // Created in index.ts once routes are available.

--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -39,6 +39,7 @@ export const transactionsLinkable = {
 export const transactionsModule: Module = {
   name: "transactions",
   linkable: transactionsLinkable,
+  requiresTransactionalDb: true,
 }
 
 export function createTransactionsHonoModule(): HonoModule {


### PR DESCRIPTION
## Summary

- Promote `withOptionalTransaction` from a private helper inside `@voyantjs/action-ledger` into a shared `@voyantjs/db/transaction` export, so every package that needs the neon-http soft-fallback shape (currently just action-ledger) can use the same implementation.
- Add a `Module.requiresTransactionalDb` flag on the core `Module` interface, and have `createApp()` collect it across mounted modules. On the first request, the db middleware asserts that the resolved adapter reports `dbSupportsTransactions(db) !== false`. If neon-http (edge) is wired into an app whose modules need `db.transaction(async (tx) => …)`, the middleware throws an actionable error pointing at `createServerlessDbClient` (neon-serverless / WebSocket) or `createDbClient(url, { adapter: "node" })` — instead of the cryptic *"No transactions support in neon-http driver"* exception that surfaced deep inside the first booking write.
- Opt in the nine packages whose service layers use interactive transactions: bookings, finance, legal, transactions, charters, cruises, availability, crm, notifications.

## Why now

A downstream project wired against the published `bookings` package was hitting *"No transactions support in neon-http driver"* on `POST /v1/bookings/create`, even though Voyant already supports real transactions via `createServerlessDbClient` (the neon-serverless / WebSocket driver introduced in #1010). The crash happens deep inside `createBooking`, not at boot, so the operator had no obvious signal that the adapter was the problem. This PR converts that into a startup-time error with the fix-it message.

## Tradeoff considered

We explicitly chose **not** to sweep every `db.transaction(...)` call site to use `withOptionalTransaction`. Soft-fallback semantics would silently strip atomicity for write paths like `createBooking` under neon-http — a partial booking on failure is worse than a loud crash. The right answer for write-path code is to use a transaction-capable adapter; this PR makes that requirement explicit at app boundary instead of papering over it. `action-ledger` continues to use the soft helper because it's idempotent and append-only.

## Test plan

- [ ] `pnpm -F @voyantjs/db test` — 73 passed (8 new tests for `withOptionalTransaction`).
- [ ] `pnpm -F @voyantjs/hono test` — 83 passed (6 new tests for the db middleware assertion).
- [ ] `pnpm -F @voyantjs/action-ledger test` — 109 passed (helper extraction is behaviorally identical).
- [ ] Full pre-commit pipeline ran lint + typecheck across all 126 packages; clean.
- [ ] Pre-push test pipeline green (one flaky timing test in `@voyantjs/workflows-orchestrator/driver-compliance.test.ts:254` — unrelated to this PR, passes on rerun).
- [ ] Manually verify in a downstream project on Cloudflare Workers: misconfigured `getDb()` returning neon-http throws the new error with the message; switching the factory to `dbFromEnvForApp` (neon-serverless) fixes it.

## Out of scope

A full sweep migrating call sites to `withOptionalTransaction`, and any rework of the existing `withTransaction` helper in `@voyantjs/db/queries` (still unused, kept as strict-tx alternative).