### PR TITLE
Configure public payment link base URL

### DIFF
--- a/.changeset/payment-link-base-url.md
+++ b/.changeset/payment-link-base-url.md
@@ -1,0 +1,9 @@
+---
+"@voyantjs/checkout": patch
+"@voyantjs/checkout-react": patch
+"@voyantjs/checkout-ui": patch
+"@voyantjs/finance": patch
+"@voyantjs/notifications": patch
+---
+
+Add configurable customer-facing payment-link base URLs for generated links and notification template context.

--- a/packages/checkout-react/src/hooks/use-checkout-payment-link-config.ts
+++ b/packages/checkout-react/src/hooks/use-checkout-payment-link-config.ts
@@ -5,6 +5,7 @@ import { useQuery } from "@tanstack/react-query"
 import { useVoyantCheckoutContext } from "../provider.js"
 
 export interface CheckoutPaymentLinkConfig {
+  publicCheckoutBaseUrl?: string | null
   bankTransfer: {
     provider?: string | null
     beneficiary: string

--- a/packages/checkout-ui/src/components/collect-payment-dialog.tsx
+++ b/packages/checkout-ui/src/components/collect-payment-dialog.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import type { InitiatedCheckoutCollectionRecord } from "@voyantjs/checkout"
-import { useCollectPayment } from "@voyantjs/checkout-react"
+import { useCheckoutPaymentLinkConfig, useCollectPayment } from "@voyantjs/checkout-react"
+import { buildPaymentLinkUrl } from "@voyantjs/finance/payment-link"
 import {
   type BookingPaymentScheduleRecord,
   useBookingPaymentSchedules,
@@ -272,9 +273,14 @@ function formatScheduleOption(
 
 function ResultPanel({ result }: { result: InitiatedCheckoutCollectionRecord }) {
   const messages = useCheckoutUiMessagesOrDefault().collectPaymentDialog
+  const configQuery = useCheckoutPaymentLinkConfig()
   const sessionId = result.paymentSession?.id ?? null
   const landingUrl =
-    sessionId && typeof window !== "undefined" ? `${window.location.origin}/pay/${sessionId}` : null
+    sessionId && typeof window !== "undefined"
+      ? buildPaymentLinkUrl(sessionId, {
+          baseUrl: configQuery.data?.publicCheckoutBaseUrl ?? window.location.origin,
+        })
+      : null
 
   if (!landingUrl) {
     return (

--- a/packages/checkout/src/routes.ts
+++ b/packages/checkout/src/routes.ts
@@ -43,6 +43,8 @@ export type CheckoutRoutesOptions = {
   resolveBankTransferDetails?: (
     bindings: Record<string, unknown>,
   ) => CheckoutBankTransferDetails | null
+  publicCheckoutBaseUrl?: string | null
+  resolvePublicCheckoutBaseUrl?: (bindings: Record<string, unknown>) => string | null | undefined
 }
 
 export type CheckoutRouteRuntime = {
@@ -50,6 +52,7 @@ export type CheckoutRouteRuntime = {
   providers: ReadonlyArray<NotificationProvider>
   paymentStarters: Record<string, CheckoutPaymentStarter>
   bankTransferDetails: CheckoutBankTransferDetails | null
+  publicCheckoutBaseUrl?: string | null
 }
 
 export const CHECKOUT_ROUTE_RUNTIME_CONTAINER_KEY = "providers.checkout.runtime"
@@ -186,5 +189,7 @@ export function buildCheckoutRouteRuntime(
     paymentStarters: options.resolvePaymentStarters?.(bindings) ?? options.paymentStarters ?? {},
     bankTransferDetails:
       options.resolveBankTransferDetails?.(bindings) ?? options.bankTransferDetails ?? null,
+    publicCheckoutBaseUrl:
+      options.resolvePublicCheckoutBaseUrl?.(bindings) ?? options.publicCheckoutBaseUrl ?? null,
   }
 }

--- a/packages/checkout/src/service.ts
+++ b/packages/checkout/src/service.ts
@@ -138,6 +138,7 @@ export interface CheckoutRuntimeOptions {
   bindings?: Record<string, unknown>
   bankTransferDetails?: CheckoutBankTransferDetails | null
   paymentStarters?: Record<string, CheckoutPaymentStarter>
+  publicCheckoutBaseUrl?: string | null
 }
 
 export interface CheckoutReminderRunSummary {
@@ -631,7 +632,7 @@ export async function initiateCheckoutCollection(
         db,
         dispatcher,
         invoice.id,
-        input.invoiceNotification,
+        withPaymentLinkBaseUrl(input.invoiceNotification, runtime.publicCheckoutBaseUrl),
       )
     }
   } else if (plan.paymentSessionTarget === "invoice") {
@@ -658,7 +659,7 @@ export async function initiateCheckoutCollection(
         db,
         dispatcher,
         invoice.id,
-        input.invoiceNotification,
+        withPaymentLinkBaseUrl(input.invoiceNotification, runtime.publicCheckoutBaseUrl),
       )
     }
 
@@ -667,7 +668,7 @@ export async function initiateCheckoutCollection(
         db,
         dispatcher,
         paymentSession.id,
-        input.paymentSessionNotification,
+        withPaymentLinkBaseUrl(input.paymentSessionNotification, runtime.publicCheckoutBaseUrl),
       )
     }
   } else {
@@ -693,7 +694,7 @@ export async function initiateCheckoutCollection(
         db,
         dispatcher,
         paymentSession.id,
-        input.paymentSessionNotification,
+        withPaymentLinkBaseUrl(input.paymentSessionNotification, runtime.publicCheckoutBaseUrl),
       )
     }
   }
@@ -743,6 +744,14 @@ export async function initiateCheckoutCollection(
     bankTransferInstructions,
     providerStart,
   }
+}
+
+function withPaymentLinkBaseUrl<T extends { paymentLinkBaseUrl?: string | null }>(
+  input: T,
+  publicCheckoutBaseUrl: string | null | undefined,
+): T {
+  if (input.paymentLinkBaseUrl || !publicCheckoutBaseUrl) return input
+  return { ...input, paymentLinkBaseUrl: publicCheckoutBaseUrl }
 }
 
 export async function bootstrapCheckoutCollection(

--- a/packages/checkout/tests/unit/routes.test.ts
+++ b/packages/checkout/tests/unit/routes.test.ts
@@ -48,6 +48,7 @@ describe("createCheckoutRoutes", () => {
     const paymentStarter = vi.fn()
     const routes = createCheckoutRoutes({
       resolvePaymentStarters: () => ({ netopia: paymentStarter }),
+      resolvePublicCheckoutBaseUrl: () => "https://brand.example.com",
       resolveBankTransferDetails: () => ({
         provider: "manual",
         beneficiary: "Program Travel",
@@ -100,6 +101,7 @@ describe("createCheckoutRoutes", () => {
         beneficiary: "Program Travel",
         iban: "RO49RNCB0857180852250001",
       },
+      publicCheckoutBaseUrl: "https://brand.example.com",
     })
     expect(runtime.paymentStarters.netopia).toBe(paymentStarter)
   })

--- a/packages/finance/package.json
+++ b/packages/finance/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./action-ledger-drift": "./src/action-ledger-drift.ts",
+    "./payment-link": "./src/payment-link.ts",
     "./schema": "./src/schema.ts",
     "./validation": "./src/validation.ts",
     "./booking-tax": "./src/booking-tax.ts",
@@ -54,6 +55,11 @@
         "types": "./dist/action-ledger-drift.d.ts",
         "import": "./dist/action-ledger-drift.js",
         "default": "./dist/action-ledger-drift.js"
+      },
+      "./payment-link": {
+        "types": "./dist/payment-link.d.ts",
+        "import": "./dist/payment-link.js",
+        "default": "./dist/payment-link.js"
       },
       "./schema": {
         "types": "./dist/schema.d.ts",

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -13,6 +13,7 @@ import { createFinanceAdminDocumentRoutes } from "./routes-documents.js"
 import { createPublicFinanceRoutes, type PublicFinanceRouteOptions } from "./routes-public.js"
 import { createFinanceAdminSettlementRoutes } from "./routes-settlement.js"
 
+export { type BuildPaymentLinkUrlOptions, buildPaymentLinkUrl } from "./payment-link.js"
 export type { FinanceRoutes } from "./routes.js"
 export type { PublicFinanceRoutes } from "./routes-public.js"
 export {

--- a/packages/finance/src/payment-link.ts
+++ b/packages/finance/src/payment-link.ts
@@ -1,0 +1,29 @@
+export interface BuildPaymentLinkUrlOptions {
+  /**
+   * Customer-facing site base URL. When omitted in a browser, the current
+   * origin is used; outside a browser, the helper returns a root-relative URL.
+   */
+  baseUrl?: string | null
+}
+
+export function buildPaymentLinkUrl(
+  paymentSessionId: string,
+  options: BuildPaymentLinkUrlOptions = {},
+): string {
+  const path = `/pay/${encodeURIComponent(paymentSessionId)}`
+  const baseUrl = normalizePaymentLinkBaseUrl(options.baseUrl ?? getBrowserOrigin())
+
+  return baseUrl ? `${baseUrl}${path}` : path
+}
+
+function normalizePaymentLinkBaseUrl(baseUrl: string | null | undefined): string | null {
+  const trimmed = baseUrl?.trim()
+  if (!trimmed) return null
+
+  return trimmed.replace(/\/+$/, "")
+}
+
+function getBrowserOrigin(): string | null {
+  const location = (globalThis as { location?: { origin?: unknown } }).location
+  return typeof location?.origin === "string" && location.origin.length > 0 ? location.origin : null
+}

--- a/packages/finance/tests/unit/payment-link.test.ts
+++ b/packages/finance/tests/unit/payment-link.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest"
+
+import { buildPaymentLinkUrl } from "../../src/payment-link.js"
+
+describe("buildPaymentLinkUrl", () => {
+  it("builds a customer-facing payment URL from a configured base", () => {
+    expect(buildPaymentLinkUrl("pmss_123", { baseUrl: "https://travel.example.com/" })).toBe(
+      "https://travel.example.com/pay/pmss_123",
+    )
+  })
+
+  it("preserves base URL path prefixes", () => {
+    expect(buildPaymentLinkUrl("pmss_123", { baseUrl: "https://example.com/ro" })).toBe(
+      "https://example.com/ro/pay/pmss_123",
+    )
+  })
+
+  it("falls back to a root-relative URL outside the browser", () => {
+    expect(buildPaymentLinkUrl("pmss 123")).toBe("/pay/pmss%20123")
+  })
+})

--- a/packages/notifications/src/routes.ts
+++ b/packages/notifications/src/routes.ts
@@ -47,6 +47,8 @@ type Env = {
 export type NotificationsRoutesOptions = {
   providers?: ReadonlyArray<NotificationProvider>
   resolveProviders?: (bindings: Record<string, unknown>) => ReadonlyArray<NotificationProvider>
+  publicCheckoutBaseUrl?: string | null
+  resolvePublicCheckoutBaseUrl?: (bindings: Record<string, unknown>) => string | null | undefined
   documentAttachmentResolver?: BookingDocumentAttachmentResolver
   resolveDocumentAttachmentResolver?: (
     bindings: Record<string, unknown>,
@@ -57,6 +59,7 @@ export type NotificationsRoutesOptions = {
 
 export type NotificationsRouteRuntime = {
   providers: ReadonlyArray<NotificationProvider>
+  publicCheckoutBaseUrl?: string | null
   documentAttachmentResolver?: BookingDocumentAttachmentResolver
   eventBus?: EventBus
 }
@@ -69,6 +72,8 @@ export function buildNotificationsRouteRuntime(
 ): NotificationsRouteRuntime {
   return {
     providers: options?.resolveProviders?.(bindings) ?? options?.providers ?? [],
+    publicCheckoutBaseUrl:
+      options?.resolvePublicCheckoutBaseUrl?.(bindings) ?? options?.publicCheckoutBaseUrl ?? null,
     documentAttachmentResolver:
       options?.resolveDocumentAttachmentResolver?.(bindings) ?? options?.documentAttachmentResolver,
     eventBus: options?.resolveEventBus?.(bindings) ?? options?.eventBus,
@@ -295,7 +300,10 @@ export function createNotificationsRoutes(options?: NotificationsRoutesOptions) 
           c.get("db"),
           dispatcher,
           c.req.param("id"),
-          await parseJsonBody(c, sendPaymentSessionNotificationSchema),
+          withPaymentLinkBaseUrl(
+            await parseJsonBody(c, sendPaymentSessionNotificationSchema),
+            runtime.publicCheckoutBaseUrl,
+          ),
         )
         if (!row) return c.json({ error: "Payment session not found" }, 404)
         return c.json({ data: row }, 201)
@@ -313,7 +321,10 @@ export function createNotificationsRoutes(options?: NotificationsRoutesOptions) 
           c.get("db"),
           dispatcher,
           c.req.param("id"),
-          await parseJsonBody(c, sendInvoiceNotificationSchema),
+          withPaymentLinkBaseUrl(
+            await parseJsonBody(c, sendInvoiceNotificationSchema),
+            runtime.publicCheckoutBaseUrl,
+          ),
         )
         if (!row) return c.json({ error: "Invoice not found" }, 404)
         return c.json({ data: row }, 201)
@@ -444,4 +455,12 @@ export function createNotificationsRoutes(options?: NotificationsRoutesOptions) 
         return c.json({ error: message }, 400)
       }
     })
+}
+
+function withPaymentLinkBaseUrl<T extends { paymentLinkBaseUrl?: string | null }>(
+  input: T,
+  publicCheckoutBaseUrl: string | null | undefined,
+): T {
+  if (input.paymentLinkBaseUrl || !publicCheckoutBaseUrl) return input
+  return { ...input, paymentLinkBaseUrl: publicCheckoutBaseUrl }
 }

--- a/packages/notifications/src/service-deliveries.ts
+++ b/packages/notifications/src/service-deliveries.ts
@@ -1,5 +1,6 @@
 import { bookings } from "@voyantjs/bookings/schema"
 import { invoices, paymentSessions } from "@voyantjs/finance"
+import { buildPaymentLinkUrl } from "@voyantjs/finance/payment-link"
 import { desc, eq, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
@@ -102,6 +103,29 @@ function serializeNotificationError(error: unknown) {
     responseBody: readErrorField(error, "responseBody") ?? readErrorField(error, "body"),
     data: readErrorField(error, "data"),
     notificationRequest: readErrorField(error, "notificationRequest"),
+  }
+}
+
+export function resolveNotificationPaymentUrl(
+  paymentSessionId: string,
+  options: { paymentLinkBaseUrl?: string | null; redirectUrl?: string | null } = {},
+) {
+  if (options.paymentLinkBaseUrl?.trim()) {
+    return buildPaymentLinkUrl(paymentSessionId, { baseUrl: options.paymentLinkBaseUrl })
+  }
+
+  return normalizeAbsolutePaymentUrl(options.redirectUrl)
+}
+
+function normalizeAbsolutePaymentUrl(value: string | null | undefined) {
+  const trimmed = value?.trim()
+  if (!trimmed) return null
+
+  try {
+    const url = new URL(trimmed)
+    return url.protocol === "http:" || url.protocol === "https:" ? trimmed : null
+  } catch {
+    return null
   }
 }
 
@@ -406,6 +430,10 @@ export async function sendPaymentSessionNotification(
         provider: session.provider,
         currency: session.currency,
         amountCents: session.amountCents,
+        paymentUrl: resolveNotificationPaymentUrl(session.id, {
+          paymentLinkBaseUrl: input.paymentLinkBaseUrl,
+          redirectUrl: session.redirectUrl,
+        }),
         redirectUrl: session.redirectUrl,
         returnUrl: session.returnUrl,
         cancelUrl: session.cancelUrl,
@@ -537,6 +565,10 @@ export async function sendInvoiceNotification(
             id: latestSession.id,
             status: latestSession.status,
             provider: latestSession.provider,
+            paymentUrl: resolveNotificationPaymentUrl(latestSession.id, {
+              paymentLinkBaseUrl: input.paymentLinkBaseUrl,
+              redirectUrl: latestSession.redirectUrl,
+            }),
             redirectUrl: latestSession.redirectUrl,
             expiresAt: latestSession.expiresAt,
             amountCents: latestSession.amountCents,

--- a/packages/notifications/src/validation.ts
+++ b/packages/notifications/src/validation.ts
@@ -342,6 +342,7 @@ const transportNotificationCoreSchema = z.object({
   data: z.record(z.string(), z.unknown()).optional().nullable(),
   metadata: z.record(z.string(), z.unknown()).optional().nullable(),
   scheduledFor: z.string().optional().nullable(),
+  paymentLinkBaseUrl: z.string().optional().nullable(),
 })
 
 export const sendPaymentSessionNotificationSchema = transportNotificationCoreSchema.refine(

--- a/packages/notifications/tests/unit/service.test.ts
+++ b/packages/notifications/tests/unit/service.test.ts
@@ -6,6 +6,7 @@ import {
   NotificationError,
   renderNotificationTemplate,
 } from "../../src/service.js"
+import { resolveNotificationPaymentUrl } from "../../src/service-deliveries.js"
 import { resolveReminderRecipient } from "../../src/service-shared.js"
 import type { NotificationProvider } from "../../src/types.js"
 
@@ -174,6 +175,36 @@ describe("renderNotificationTemplate", () => {
     )
 
     expect(rendered).toBe("Pay 1250 RON by 2026-05-15 at https://pay.example.test/session")
+  })
+
+  it("prefers configured payment URLs over provider redirects in payment context", () => {
+    const rendered = renderNotificationTemplate("Pay {{ payment.link }}", {
+      paymentSession: {
+        paymentUrl: "https://brand.example.com/pay/pmss_123",
+        redirectUrl: "https://processor.example.test/session",
+      },
+    })
+
+    expect(rendered).toBe("Pay https://brand.example.com/pay/pmss_123")
+  })
+
+  it("resolves absolute payment URLs for outbound notification context", () => {
+    expect(
+      resolveNotificationPaymentUrl("pmss_123", {
+        paymentLinkBaseUrl: "https://checkout.example.test/",
+        redirectUrl: "https://processor.example.test/session",
+      }),
+    ).toBe("https://checkout.example.test/pay/pmss_123")
+    expect(
+      resolveNotificationPaymentUrl("pmss_123", {
+        redirectUrl: "https://processor.example.test/session",
+      }),
+    ).toBe("https://processor.example.test/session")
+    expect(
+      resolveNotificationPaymentUrl("pmss_123", {
+        redirectUrl: "/provider/session",
+      }),
+    ).toBeNull()
   })
 
   it("fills confirmation payment fields from a paid session and open balance schedule", () => {

--- a/templates/operator/.dev.vars.example
+++ b/templates/operator/.dev.vars.example
@@ -1,8 +1,9 @@
 # Cloudflare Workers runtime secrets — loaded by wrangler in dev.
 # Copy to `.dev.vars` and fill in values. Never commit .dev.vars.
 #
-# Public vars (APP_URL, DASH_BASE_URL, GCP_* non-key fields, EMAIL_FROM) already
-# live in wrangler.jsonc under env.dev.vars — only secrets belong here.
+# Public vars (APP_URL, DASH_BASE_URL, PUBLIC_CHECKOUT_BASE_URL,
+# GCP_* non-key fields, EMAIL_FROM) already live in wrangler.jsonc under
+# env.dev.vars — only secrets belong here.
 
 # Database (Neon Postgres — accessed via the Neon serverless HTTP driver in
 # both dev and prod; no Hyperdrive binding required)

--- a/templates/operator/env.d.ts
+++ b/templates/operator/env.d.ts
@@ -65,6 +65,11 @@ interface CloudflareBindings {
   // App URLs
   APP_URL: string
   API_BASE_URL: string
+  /**
+   * Customer-facing site that hosts `/pay/:sessionId` links. Defaults to
+   * DASH_BASE_URL/APP_URL when omitted, preserving single-worker deployments.
+   */
+  PUBLIC_CHECKOUT_BASE_URL?: string
   CORS_ALLOWLIST: string
   DASH_BASE_URL: string
   /**

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -113,6 +113,7 @@ import {
 
 const notificationsHonoModule = createNotificationsHonoModule({
   resolveProviders: resolveNotificationProviders,
+  resolvePublicCheckoutBaseUrl: resolvePublicCheckoutBaseUrlFromBindings,
   resolveDocumentAttachmentResolver: (bindings) => async (document) => {
     if (document.storageKey) {
       const contentBase64 = await readDocumentContentBase64(
@@ -215,6 +216,18 @@ function resolveBankTransferDetails(
   }
 }
 
+function resolvePublicCheckoutBaseUrlFromBindings(
+  bindings: Record<string, unknown>,
+): string | null {
+  const env = bindings as unknown as CloudflareBindings
+  return (
+    env.PUBLIC_CHECKOUT_BASE_URL?.trim() ||
+    env.DASH_BASE_URL?.trim() ||
+    env.APP_URL?.trim().replace(/\/api\/?$/, "") ||
+    null
+  )
+}
+
 function bankTransferDetailsFromOperatorSettings(
   operatorProfile: Awaited<ReturnType<typeof getOperatorProfile>>,
   paymentInstructions: Awaited<ReturnType<typeof getOperatorPaymentInstructions>>,
@@ -289,6 +302,7 @@ const checkoutHonoModule = createCheckoutHonoModule({
     netopia: netopiaCheckoutStarter,
   }),
   resolveBankTransferDetails,
+  resolvePublicCheckoutBaseUrl: resolvePublicCheckoutBaseUrlFromBindings,
 })
 /**
  * Process-wide registry of workflow runners. Bundles register their
@@ -1315,6 +1329,9 @@ export const app = createApp<CloudflareBindings>({
       )
       return c.json({
         data: {
+          publicCheckoutBaseUrl: resolvePublicCheckoutBaseUrlFromBindings(
+            c.env as Record<string, unknown>,
+          ),
           bankTransfer,
         },
       })

--- a/templates/operator/src/api/travel-composer-runtime.ts
+++ b/templates/operator/src/api/travel-composer-runtime.ts
@@ -13,7 +13,7 @@ import {
 import type { PricingBasis } from "@voyantjs/catalog/snapshot/schema"
 import type { EventBus } from "@voyantjs/core"
 import type { AnyDrizzleDb } from "@voyantjs/db"
-import { financeService, type PaymentCompletedEvent } from "@voyantjs/finance"
+import { buildPaymentLinkUrl, financeService, type PaymentCompletedEvent } from "@voyantjs/finance"
 import type {
   AncillarySelection,
   FlightBookRequest,
@@ -538,8 +538,19 @@ async function startTripCheckout(
   return {
     kind: input.intent === "bank_transfer" ? "bank_transfer_instructions" : "payment_session",
     paymentSessionId: session.id,
-    checkoutUrl: `/pay/${session.id}`,
+    checkoutUrl: buildPaymentLinkUrl(session.id, {
+      baseUrl: resolvePublicCheckoutBaseUrl(c.env as CloudflareBindings),
+    }),
   }
+}
+
+function resolvePublicCheckoutBaseUrl(env: CloudflareBindings): string | null {
+  return (
+    env.PUBLIC_CHECKOUT_BASE_URL?.trim() ||
+    env.DASH_BASE_URL?.trim() ||
+    env.APP_URL?.trim().replace(/\/api\/?$/, "") ||
+    null
+  )
 }
 
 function checkoutResultToComponentResult(

--- a/templates/operator/src/components/voyant/bookings/booking-pending-payment-sessions.tsx
+++ b/templates/operator/src/components/voyant/bookings/booking-pending-payment-sessions.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { buildPaymentLinkUrl } from "@voyantjs/finance/payment-link"
 import { PaymentSessionActionLedgerCard } from "@voyantjs/finance-ui/components/invoice-action-ledger-card"
 import { Button } from "@voyantjs/ui/components/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@voyantjs/ui/components/card"
@@ -26,6 +27,12 @@ interface PendingPaymentSession {
 interface ListResponse {
   data: PendingPaymentSession[]
   total: number
+}
+
+interface PaymentLinkConfigResponse {
+  data: {
+    publicCheckoutBaseUrl?: string | null
+  }
 }
 
 /**
@@ -58,6 +65,11 @@ export function BookingPendingPaymentSessions({
           bookingId,
         )}&status=pending&limit=10`,
       ),
+  })
+  const { data: paymentLinkConfig } = useQuery({
+    queryKey: ["payment-link-config"],
+    queryFn: () => api.get<PaymentLinkConfigResponse>("/v1/public/payment-link-config"),
+    staleTime: 5 * 60 * 1000,
   })
 
   const markReceived = useMutation({
@@ -128,7 +140,9 @@ export function BookingPendingPaymentSessions({
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={() => void copyPaymentLink(session.id)}
+                  onClick={() =>
+                    void copyPaymentLink(session.id, paymentLinkConfig?.data.publicCheckoutBaseUrl)
+                  }
                 >
                   <Copy className="mr-1.5 h-3.5 w-3.5" />
                   Copy payment link
@@ -164,9 +178,14 @@ export function BookingPendingPaymentSessions({
   )
 }
 
-async function copyPaymentLink(paymentSessionId: string): Promise<void> {
+async function copyPaymentLink(
+  paymentSessionId: string,
+  publicCheckoutBaseUrl?: string | null,
+): Promise<void> {
   if (typeof window === "undefined") return
-  const url = new URL(`/pay/${paymentSessionId}`, window.location.origin).toString()
+  const url = buildPaymentLinkUrl(paymentSessionId, {
+    baseUrl: publicCheckoutBaseUrl ?? window.location.origin,
+  })
   try {
     await navigator.clipboard.writeText(url)
     toast.success("Payment link copied")

--- a/templates/operator/src/routes/_workspace/trips/$id.tsx
+++ b/templates/operator/src/routes/_workspace/trips/$id.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
 import { useOrganization, usePerson } from "@voyantjs/crm-react"
+import { buildPaymentLinkUrl } from "@voyantjs/finance/payment-link"
 import { formatMessage } from "@voyantjs/i18n"
 import type { Trip, TripComponent } from "@voyantjs/travel-composer"
 import { getTripQueryOptions } from "@voyantjs/travel-composer-react"
@@ -247,12 +248,30 @@ function TripRecordPage({ trip, onEdit }: { trip: Trip; onEdit(): void }) {
 
 async function copyPaymentLink(paymentSessionId: string): Promise<boolean> {
   if (!paymentSessionId || typeof window === "undefined") return false
-  const url = new URL(`/pay/${paymentSessionId}`, window.location.origin).toString()
+  const publicCheckoutBaseUrl = await fetchPublicCheckoutBaseUrl()
+  const url = buildPaymentLinkUrl(paymentSessionId, {
+    baseUrl: publicCheckoutBaseUrl ?? window.location.origin,
+  })
   try {
     await navigator.clipboard.writeText(url)
     return true
   } catch {
     return false
+  }
+}
+
+async function fetchPublicCheckoutBaseUrl(): Promise<string | null> {
+  try {
+    const res = await fetch(`${getApiUrl()}/v1/public/payment-link-config`, {
+      headers: { Accept: "application/json" },
+    })
+    if (!res.ok) return null
+    const body = (await res.json()) as {
+      data?: { publicCheckoutBaseUrl?: string | null }
+    }
+    return body.data?.publicCheckoutBaseUrl ?? null
+  } catch {
+    return null
   }
 }
 


### PR DESCRIPTION
## Summary
- add a shared finance payment-link URL builder and public checkout base URL runtime wiring for checkout/notifications
- expose `PUBLIC_CHECKOUT_BASE_URL` in the operator template and return it from payment-link config
- update operator copy-link and generated checkout URL surfaces to use the configured customer-facing host

Closes #1031

## Verification
- `pnpm --filter @voyantjs/finance test -- payment-link.test.ts`
- `pnpm --filter @voyantjs/checkout test -- routes.test.ts`
- `pnpm --filter @voyantjs/notifications test -- service.test.ts`
- `pnpm --filter @voyantjs/checkout-ui test`
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/checkout typecheck && pnpm --filter @voyantjs/notifications typecheck`
- `pnpm --filter @voyantjs/checkout-react typecheck`
- `pnpm --filter @voyantjs/checkout-ui typecheck`
- `pnpm --filter @voyantjs/finance lint`
- `pnpm --filter @voyantjs/checkout lint`
- `pnpm --filter @voyantjs/notifications lint`
- `pnpm --filter @voyantjs/checkout-react lint`
- `pnpm --filter @voyantjs/checkout-ui lint`
- `pnpm --filter operator lint`
- `git diff --check`

## Known Baseline Blocker
- `pnpm --filter operator typecheck` and repo-wide hook typechecks fail on existing `@voyantjs/action-ledger` module resolution errors from `packages/crm/src/action-ledger-capabilities.ts` and `packages/crm/src/routes/person-documents.ts`.
- Full pre-push tests also hit the same baseline dependency resolution through CRM, customer-portal, and storefront tests.