### PR TITLE
Add invoice integration slot and SmartBill panel

### DIFF
--- a/.changeset/smartbill-invoice-integration-ui.md
+++ b/.changeset/smartbill-invoice-integration-ui.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/finance-ui": minor
+"@voyantjs/plugin-smartbill": minor
+---
+
+Add a first-class invoice integrations slot and ship SmartBill invoice UI hooks, helpers, and a reusable panel for displaying provider external-reference state.

--- a/packages/finance-ui/README.md
+++ b/packages/finance-ui/README.md
@@ -20,6 +20,12 @@ slots. Use `lineItemsContent`, `paymentsContent`, `creditNotesContent`,
 `attachmentsContent`, or `notesContent` when an app needs fully custom inline
 management controls for that section.
 
+`integrationsContent` is the dedicated invoice integration mount point. It is
+rendered immediately after the invoice summary cards and may be either a React
+node or a render function that receives `{ invoice }`. Provider plugins can
+mount one or more external-reference panels there without replacing core invoice
+sections.
+
 ## Components
 
 - `InvoicesPage`, `InvoiceDetailPage`, and `PaymentsPage` publish

--- a/packages/finance-ui/src/components/invoice-detail-page.tsx
+++ b/packages/finance-ui/src/components/invoice-detail-page.tsx
@@ -50,6 +50,7 @@ import { InvoiceDialog } from "./invoice-dialog.js"
 
 export interface InvoiceDetailPageSlots {
   afterHeader?: ReactNode
+  integrationsContent?: InvoiceDetailIntegrationContent
   afterSummary?: ReactNode
   lineItemsContent?: ReactNode
   afterLineItems?: ReactNode
@@ -63,6 +64,14 @@ export interface InvoiceDetailPageSlots {
   afterNotes?: ReactNode
   dialogs?: ReactNode
 }
+
+export interface InvoiceDetailIntegrationSlotContext {
+  invoice: InvoiceRecord
+}
+
+export type InvoiceDetailIntegrationContent =
+  | ReactNode
+  | ((context: InvoiceDetailIntegrationSlotContext) => ReactNode)
 
 export interface InvoiceDetailPageProps {
   id: string
@@ -140,6 +149,9 @@ export function InvoiceDetailPage({
   const creditNotes = creditNotesQuery.data?.data ?? []
   const attachments = attachmentsQuery.data?.data ?? []
   const notes = notesQuery.data?.data ?? []
+  const integrationsContent = renderInvoiceDetailIntegrationContent(slots?.integrationsContent, {
+    invoice,
+  })
   const handleCreateNote = async (nextContent: string) => {
     const content = nextContent.trim()
     if (!content) return
@@ -172,6 +184,11 @@ export function InvoiceDetailPage({
           onOrganizationOpen={onOrganizationOpen}
         />
       </div>
+      {integrationsContent ? (
+        <div data-slot="invoice-integrations-content" className="grid gap-3">
+          {integrationsContent}
+        </div>
+      ) : null}
       {slots?.afterSummary}
 
       {slots?.lineItemsContent !== undefined ? (
@@ -284,6 +301,13 @@ export function InvoiceDetailPage({
       {slots?.dialogs}
     </div>
   )
+}
+
+function renderInvoiceDetailIntegrationContent(
+  content: InvoiceDetailIntegrationContent | undefined,
+  context: InvoiceDetailIntegrationSlotContext,
+) {
+  return typeof content === "function" ? content(context) : content
 }
 
 export interface InvoiceDetailHeaderProps {

--- a/packages/finance-ui/src/index.ts
+++ b/packages/finance-ui/src/index.ts
@@ -26,6 +26,8 @@ export {
   type InvoiceDetailCardProps,
   InvoiceDetailHeader,
   type InvoiceDetailHeaderProps,
+  type InvoiceDetailIntegrationContent,
+  type InvoiceDetailIntegrationSlotContext,
   InvoiceDetailLoading,
   InvoiceDetailPage,
   type InvoiceDetailPageProps,

--- a/packages/plugins/smartbill/README.md
+++ b/packages/plugins/smartbill/README.md
@@ -79,6 +79,47 @@ Use `retrySmartbillInvoiceArtifact({ runtime, client, externalRef, documentType
 })` to re-download and re-attach a SmartBill PDF from an existing external ref
 without issuing a new document.
 
+## Invoice UI
+
+The optional `./invoice-ui` entry ships React helpers for invoice detail pages.
+It reads SmartBill refs from `/v1/finance/invoices/:id/external-refs` using the
+`@voyantjs/finance-react` provider context and can be mounted in
+`InvoiceDetailPage`'s integration slot.
+
+```tsx
+import { InvoiceDetailPage } from "@voyantjs/finance-ui"
+import { SmartbillInvoicePanel } from "@voyantjs/plugin-smartbill/invoice-ui"
+
+export function InvoicePage({ invoiceId }: { invoiceId: string }) {
+  return (
+    <InvoiceDetailPage
+      id={invoiceId}
+      slots={{
+        integrationsContent: ({ invoice }) => (
+          <SmartbillInvoicePanel
+            invoiceId={invoice.id}
+            sendAction={{
+              onClick: () => requestSmartbillSend(invoice.id),
+            }}
+            retryAction={{
+              onClick: () => requestSmartbillRetry(invoice.id),
+            }}
+          />
+        ),
+      }}
+    />
+  )
+}
+```
+
+`SmartbillInvoicePanel` displays the SmartBill series, number, document type,
+sync status, sync errors, and document/PDF links when the external ref contains
+them. Hosts provide action callbacks such as send, retry, or proforma
+conversion because route shape and permissions remain app-owned. For custom
+layouts, use `useSmartbillInvoiceRef(invoiceId)` together with
+`resolveSmartbillInvoiceReferenceParts(ref)` and
+`getSmartbillInvoiceDocumentLinks(ref)`.
+
 ## Workflow Factories
 
 The package also ships scheduler-agnostic workflow factories for recurring
@@ -126,6 +167,7 @@ finance records.
 | `.` | Barrel re-exports |
 | `./plugin` | `smartbillPlugin(options)` — packaged adapter/subscriber bundle |
 | `./client` | `createSmartbillClient` — `createInvoice`, `cancelInvoice`, `viewPdf`, `getPaymentStatus`, etc. |
+| `./invoice-ui` | Optional React hooks, display helpers, and `SmartbillInvoicePanel` for invoice detail integrations |
 | `./mock` | `createSmartbillMockServer` — stateful local SmartBill-compatible mock for tests |
 | `./workflows` | Proforma conversion polling and drift reconciliation factories |
 | `./types` | SmartBill adapter and bundle types |

--- a/packages/plugins/smartbill/package.json
+++ b/packages/plugins/smartbill/package.json
@@ -8,6 +8,7 @@
     "./client": "./src/client.ts",
     "./mock": "./src/mock.ts",
     "./plugin": "./src/plugin.ts",
+    "./invoice-ui": "./src/invoice-ui.tsx",
     "./settlement": "./src/settlement.ts",
     "./workflows": "./src/workflows.ts",
     "./types": "./src/types.ts"
@@ -27,8 +28,44 @@
     "drizzle-orm": "^0.45.2",
     "zod": "^4.3.6"
   },
+  "peerDependencies": {
+    "@tanstack/react-query": "^5.0.0",
+    "@voyantjs/finance-react": "workspace:*",
+    "@voyantjs/ui": "workspace:*",
+    "lucide-react": "^0.475.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@tanstack/react-query": {
+      "optional": true
+    },
+    "@voyantjs/finance-react": {
+      "optional": true
+    },
+    "@voyantjs/ui": {
+      "optional": true
+    },
+    "lucide-react": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@tanstack/react-query": "^5.100.11",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@voyantjs/finance-react": "workspace:*",
+    "@voyantjs/ui": "workspace:*",
     "@voyantjs/voyant-typescript-config": "workspace:*",
+    "lucide-react": "^0.475.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
     "typescript": "^6.0.2",
     "vitest": "^4.1.2"
   },
@@ -57,6 +94,11 @@
         "types": "./dist/plugin.d.ts",
         "import": "./dist/plugin.js",
         "default": "./dist/plugin.js"
+      },
+      "./invoice-ui": {
+        "types": "./dist/invoice-ui.d.ts",
+        "import": "./dist/invoice-ui.js",
+        "default": "./dist/invoice-ui.js"
       },
       "./settlement": {
         "types": "./dist/settlement.d.ts",

--- a/packages/plugins/smartbill/src/invoice-ui-data.ts
+++ b/packages/plugins/smartbill/src/invoice-ui-data.ts
@@ -1,0 +1,88 @@
+import { z } from "zod"
+
+export const smartbillInvoiceExternalRefSchema = z.object({
+  id: z.string(),
+  invoiceId: z.string(),
+  provider: z.string(),
+  externalId: z.string().nullable(),
+  externalNumber: z.string().nullable(),
+  externalUrl: z.string().nullable(),
+  status: z.string().nullable(),
+  metadata: z.record(z.string(), z.unknown()).nullable(),
+  syncedAt: z.union([z.string(), z.date()]).nullable(),
+  syncError: z.string().nullable(),
+  createdAt: z.union([z.string(), z.date()]).nullable(),
+  updatedAt: z.union([z.string(), z.date()]).nullable(),
+})
+
+export const smartbillInvoiceExternalRefsResponseSchema = z.object({
+  data: z.array(smartbillInvoiceExternalRefSchema),
+})
+
+export type SmartbillInvoiceExternalRef = z.infer<typeof smartbillInvoiceExternalRefSchema>
+
+export interface SmartbillInvoiceReferenceParts {
+  companyVatCode: string | null
+  seriesName: string | null
+  number: string | null
+  documentType: "invoice" | "proforma" | string | null
+}
+
+export interface SmartbillInvoiceDocumentLink {
+  label: string
+  href: string
+}
+
+export function selectSmartbillInvoiceRef(
+  refs: ReadonlyArray<SmartbillInvoiceExternalRef>,
+): SmartbillInvoiceExternalRef | null {
+  return refs.find((ref) => ref.provider === "smartbill") ?? null
+}
+
+export function resolveSmartbillInvoiceReferenceParts(
+  ref: SmartbillInvoiceExternalRef | null | undefined,
+): SmartbillInvoiceReferenceParts {
+  const metadata = coerceMetadata(ref?.metadata)
+  return {
+    companyVatCode: readMetadataString(metadata, "companyVatCode", "vatCode"),
+    seriesName: readMetadataString(metadata, "seriesName", "series"),
+    number:
+      readMetadataString(metadata, "number", "invoiceNumber") ??
+      ref?.externalNumber ??
+      ref?.externalId ??
+      null,
+    documentType: readMetadataString(metadata, "documentType"),
+  }
+}
+
+export function getSmartbillInvoiceDocumentLinks(
+  ref: SmartbillInvoiceExternalRef | null | undefined,
+): SmartbillInvoiceDocumentLink[] {
+  const metadata = coerceMetadata(ref?.metadata)
+  const candidates = [
+    { label: "SmartBill document", href: ref?.externalUrl },
+    { label: "SmartBill PDF", href: readMetadataString(metadata, "pdfUrl", "downloadUrl") },
+    { label: "SmartBill invoice", href: readMetadataString(metadata, "invoiceUrl", "documentUrl") },
+  ]
+  const seen = new Set<string>()
+  return candidates.flatMap((candidate) => {
+    const href = candidate.href?.trim()
+    if (!href || seen.has(href)) return []
+    seen.add(href)
+    return [{ label: candidate.label, href }]
+  })
+}
+
+function coerceMetadata(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function readMetadataString(metadata: Record<string, unknown> | null, ...keys: string[]) {
+  for (const key of keys) {
+    const value = metadata?.[key]
+    if (typeof value === "string" && value.trim()) return value.trim()
+  }
+  return null
+}

--- a/packages/plugins/smartbill/src/invoice-ui.tsx
+++ b/packages/plugins/smartbill/src/invoice-ui.tsx
@@ -1,0 +1,238 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import { fetchWithValidation, useVoyantFinanceContext } from "@voyantjs/finance-react"
+import {
+  Badge,
+  Button,
+  buttonVariants,
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@voyantjs/ui/components"
+import { cn } from "@voyantjs/ui/lib/utils"
+import { ExternalLink, FileText, Loader2, RefreshCw, Send } from "lucide-react"
+import type { ReactNode } from "react"
+
+import {
+  getSmartbillInvoiceDocumentLinks,
+  resolveSmartbillInvoiceReferenceParts,
+  type SmartbillInvoiceExternalRef,
+  selectSmartbillInvoiceRef,
+  smartbillInvoiceExternalRefsResponseSchema,
+} from "./invoice-ui-data.js"
+
+export {
+  getSmartbillInvoiceDocumentLinks,
+  resolveSmartbillInvoiceReferenceParts,
+  type SmartbillInvoiceDocumentLink,
+  type SmartbillInvoiceExternalRef,
+  type SmartbillInvoiceReferenceParts,
+  selectSmartbillInvoiceRef,
+} from "./invoice-ui-data.js"
+
+export interface UseSmartbillInvoiceRefsOptions {
+  enabled?: boolean
+}
+
+export interface SmartbillInvoiceAction {
+  label?: string
+  pending?: boolean
+  disabled?: boolean
+  onClick: () => void | Promise<void>
+}
+
+export interface SmartbillInvoicePanelProps {
+  invoiceId: string
+  externalRef?: SmartbillInvoiceExternalRef | null
+  title?: ReactNode
+  className?: string
+  hideWhenEmpty?: boolean
+  sendAction?: SmartbillInvoiceAction
+  retryAction?: SmartbillInvoiceAction
+  convertProformaAction?: SmartbillInvoiceAction
+  extraActions?: ReactNode
+}
+
+export function useSmartbillInvoiceRefs(
+  invoiceId: string | null | undefined,
+  options: UseSmartbillInvoiceRefsOptions = {},
+) {
+  const { baseUrl, fetcher } = useVoyantFinanceContext()
+  const { enabled = true } = options
+
+  return useQuery({
+    queryKey: ["voyant", "smartbill", "invoice", invoiceId, "external-refs"],
+    queryFn: async () => {
+      const response = await fetchWithValidation(
+        `/v1/finance/invoices/${encodeURIComponent(invoiceId ?? "")}/external-refs`,
+        smartbillInvoiceExternalRefsResponseSchema,
+        { baseUrl, fetcher },
+      )
+      return response.data.filter((ref) => ref.provider === "smartbill")
+    },
+    enabled: enabled && Boolean(invoiceId),
+  })
+}
+
+export function useSmartbillInvoiceRef(
+  invoiceId: string | null | undefined,
+  options: UseSmartbillInvoiceRefsOptions = {},
+) {
+  const query = useSmartbillInvoiceRefs(invoiceId, options)
+  return {
+    ...query,
+    data: query.data ? selectSmartbillInvoiceRef(query.data) : undefined,
+  }
+}
+
+export function SmartbillInvoicePanel({
+  invoiceId,
+  externalRef,
+  title = "SmartBill",
+  className,
+  hideWhenEmpty = false,
+  sendAction,
+  retryAction,
+  convertProformaAction,
+  extraActions,
+}: SmartbillInvoicePanelProps) {
+  const query = useSmartbillInvoiceRef(invoiceId, { enabled: externalRef === undefined })
+  const ref = externalRef === undefined ? query.data : externalRef
+  const isLoading = externalRef === undefined && query.isPending
+  const isError = externalRef === undefined && query.isError
+
+  if (hideWhenEmpty && !isLoading && !isError && !ref) {
+    return null
+  }
+
+  const reference = resolveSmartbillInvoiceReferenceParts(ref)
+  const documentLinks = getSmartbillInvoiceDocumentLinks(ref)
+  const status = ref?.syncError ? "error" : (ref?.status ?? null)
+  const canConvertProforma = reference.documentType === "proforma" && convertProformaAction
+
+  return (
+    <Card data-slot="smartbill-invoice-panel" size="sm" className={className}>
+      <CardHeader>
+        <CardTitle className="flex min-w-0 items-center gap-2">
+          <FileText className="size-4 text-muted-foreground" aria-hidden="true" />
+          <span className="truncate">{title}</span>
+        </CardTitle>
+        <CardAction>
+          {status ? (
+            <Badge variant={status === "error" ? "destructive" : "outline"}>{status}</Badge>
+          ) : null}
+        </CardAction>
+      </CardHeader>
+      <CardContent className="grid gap-4">
+        {isLoading ? (
+          <div className="flex items-center gap-2 text-muted-foreground text-sm">
+            <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+            Loading SmartBill state
+          </div>
+        ) : isError ? (
+          <p className="text-destructive text-sm">SmartBill state could not be loaded.</p>
+        ) : ref ? (
+          <div className="grid gap-3 text-sm">
+            <dl className="grid gap-2 sm:grid-cols-2">
+              <SmartbillField label="Series">{reference.seriesName ?? "-"}</SmartbillField>
+              <SmartbillField label="Number">{reference.number ?? "-"}</SmartbillField>
+              <SmartbillField label="Type">{reference.documentType ?? "-"}</SmartbillField>
+              <SmartbillField label="Synced">{formatDateTime(ref.syncedAt) ?? "-"}</SmartbillField>
+            </dl>
+            {ref.syncError ? (
+              <p className="rounded-md border border-destructive/20 bg-destructive/5 p-2 text-destructive">
+                {ref.syncError}
+              </p>
+            ) : null}
+            {documentLinks.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {documentLinks.map((link) => (
+                  <a
+                    key={link.href}
+                    href={link.href}
+                    target="_blank"
+                    rel="noreferrer"
+                    className={buttonVariants({ variant: "outline", size: "sm" })}
+                  >
+                    <ExternalLink className="size-4" aria-hidden="true" />
+                    {link.label}
+                  </a>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        ) : (
+          <p className="text-muted-foreground text-sm">No SmartBill reference is linked yet.</p>
+        )}
+
+        <div className="flex flex-wrap items-center gap-2">
+          {!ref && sendAction ? (
+            <SmartbillActionButton action={sendAction} icon={<Send className="size-4" />}>
+              {sendAction.label ?? "Send to SmartBill"}
+            </SmartbillActionButton>
+          ) : null}
+          {retryAction ? (
+            <SmartbillActionButton action={retryAction} icon={<RefreshCw className="size-4" />}>
+              {retryAction.label ?? "Retry sync"}
+            </SmartbillActionButton>
+          ) : null}
+          {canConvertProforma ? (
+            <SmartbillActionButton
+              action={convertProformaAction}
+              icon={<RefreshCw className="size-4" />}
+            >
+              {convertProformaAction.label ?? "Convert proforma"}
+            </SmartbillActionButton>
+          ) : null}
+          {extraActions}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function SmartbillField({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="grid gap-1">
+      <dt className="text-muted-foreground text-xs uppercase">{label}</dt>
+      <dd className="break-words font-medium">{children}</dd>
+    </div>
+  )
+}
+
+function SmartbillActionButton({
+  action,
+  icon,
+  children,
+}: {
+  action: SmartbillInvoiceAction
+  icon: ReactNode
+  children: ReactNode
+}) {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      disabled={action.disabled || action.pending}
+      onClick={() => void action.onClick()}
+    >
+      <span className={cn(action.pending && "animate-spin")}>
+        {action.pending ? <Loader2 className="size-4" aria-hidden="true" /> : icon}
+      </span>
+      {children}
+    </Button>
+  )
+}
+
+function formatDateTime(value: string | Date | null | undefined) {
+  if (!value) return null
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(
+    date,
+  )
+}

--- a/packages/plugins/smartbill/tests/unit/invoice-ui-data.test.ts
+++ b/packages/plugins/smartbill/tests/unit/invoice-ui-data.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  getSmartbillInvoiceDocumentLinks,
+  resolveSmartbillInvoiceReferenceParts,
+  type SmartbillInvoiceExternalRef,
+  selectSmartbillInvoiceRef,
+} from "../../src/invoice-ui-data.js"
+
+const baseRef: SmartbillInvoiceExternalRef = {
+  id: "invext_1",
+  invoiceId: "inv_1",
+  provider: "smartbill",
+  externalId: "42",
+  externalNumber: "42",
+  externalUrl: "https://smartbill.example.test/invoice/42",
+  status: "issued",
+  metadata: {
+    companyVatCode: "RO123",
+    seriesName: "SB",
+    number: "42",
+    documentType: "invoice",
+    pdfUrl: "https://smartbill.example.test/invoice/42.pdf",
+  },
+  syncedAt: "2026-05-22T04:00:00.000Z",
+  syncError: null,
+  createdAt: "2026-05-22T04:00:00.000Z",
+  updatedAt: "2026-05-22T04:00:00.000Z",
+}
+
+describe("SmartBill invoice UI data helpers", () => {
+  it("selects the SmartBill ref from mixed provider refs", () => {
+    expect(
+      selectSmartbillInvoiceRef([{ ...baseRef, id: "stripe_1", provider: "stripe" }, baseRef]),
+    ).toBe(baseRef)
+  })
+
+  it("resolves display reference parts from metadata with external id fallbacks", () => {
+    expect(resolveSmartbillInvoiceReferenceParts(baseRef)).toEqual({
+      companyVatCode: "RO123",
+      seriesName: "SB",
+      number: "42",
+      documentType: "invoice",
+    })
+
+    expect(
+      resolveSmartbillInvoiceReferenceParts({
+        ...baseRef,
+        externalId: "99",
+        externalNumber: null,
+        metadata: null,
+      }).number,
+    ).toBe("99")
+  })
+
+  it("deduplicates document links from external url and metadata", () => {
+    expect(getSmartbillInvoiceDocumentLinks(baseRef)).toEqual([
+      {
+        label: "SmartBill document",
+        href: "https://smartbill.example.test/invoice/42",
+      },
+      {
+        label: "SmartBill PDF",
+        href: "https://smartbill.example.test/invoice/42.pdf",
+      },
+    ])
+
+    expect(
+      getSmartbillInvoiceDocumentLinks({
+        ...baseRef,
+        metadata: { pdfUrl: baseRef.externalUrl },
+      }),
+    ).toHaveLength(1)
+  })
+})

--- a/packages/plugins/smartbill/tsconfig.json
+++ b/packages/plugins/smartbill/tsconfig.json
@@ -1,11 +1,12 @@
 {
-  "extends": "@voyantjs/voyant-typescript-config/base.json",
+  "extends": "@voyantjs/voyant-typescript-config/react-library.json",
   "compilerOptions": {
     "composite": false,
     "outDir": "dist",
     "rootDir": "src",
     "module": "ESNext",
-    "moduleResolution": "Bundler"
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx"
   },
   "include": ["src/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3910,9 +3910,33 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@tanstack/react-query':
+        specifier: ^5.100.11
+        version: 5.100.11(react@19.2.4)
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@voyantjs/finance-react':
+        specifier: workspace:*
+        version: link:../../finance-react
+      '@voyantjs/ui':
+        specifier: workspace:*
+        version: link:../../ui
       '@voyantjs/voyant-typescript-config':
         specifier: workspace:*
         version: link:../../typescript-config
+      lucide-react:
+        specifier: ^0.475.0
+        version: 0.475.0(react@19.2.4)
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
       typescript:
         specifier: ^6.0.2
         version: 6.0.2


### PR DESCRIPTION
## Summary
- add a dedicated `integrationsContent` mount point to `InvoiceDetailPage` near the invoice summary
- ship `@voyantjs/plugin-smartbill/invoice-ui` with SmartBill invoice-ref hooks, display helpers, and `SmartbillInvoicePanel`
- document how to mount SmartBill UI into the finance invoice detail page and add release notes

Closes #1035
Closes #1036

## Verification
- `pnpm --filter @voyantjs/finance-ui typecheck`
- `pnpm --filter @voyantjs/finance-ui lint`
- `pnpm --filter @voyantjs/finance-ui test`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @voyantjs/finance-ui build`
- `pnpm --filter @voyantjs/plugin-smartbill typecheck`
- `pnpm --filter @voyantjs/plugin-smartbill lint`
- `pnpm --filter @voyantjs/plugin-smartbill test -- invoice-ui-data.test.ts`
- `pnpm --filter @voyantjs/plugin-smartbill build`
- `git diff --check`