### PR TITLE
Fix availability overview aggregate counts

### DIFF
--- a/.changeset/availability-overview-server-aggregates.md
+++ b/.changeset/availability-overview-server-aggregates.md
@@ -1,0 +1,7 @@
+---
+"@voyantjs/availability": patch
+"@voyantjs/availability-react": patch
+"@voyantjs/availability-ui": patch
+---
+
+Add a server-backed availability overview endpoint and React hook so operator overview metrics and attention lists are computed from the full dataset instead of the first paginated list page.

--- a/packages/availability-react/src/hooks/index.ts
+++ b/packages/availability-react/src/hooks/index.ts
@@ -1,3 +1,5 @@
+export type { UseAvailabilityOverviewOptions } from "./use-availability-overview.js"
+export { useAvailabilityOverview } from "./use-availability-overview.js"
 export { useAvailabilityRuleMutation } from "./use-availability-rule-mutation.js"
 export { useAvailabilitySlotMutation } from "./use-availability-slot-mutation.js"
 export { useAvailabilityStartTimeMutation } from "./use-availability-start-time-mutation.js"

--- a/packages/availability-react/src/hooks/use-availability-overview.ts
+++ b/packages/availability-react/src/hooks/use-availability-overview.ts
@@ -1,0 +1,17 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+
+import { useVoyantAvailabilityContext } from "../provider.js"
+import type { AvailabilityOverviewFilters } from "../query-keys.js"
+import { getAvailabilityOverviewQueryOptions } from "../query-options.js"
+
+export interface UseAvailabilityOverviewOptions extends AvailabilityOverviewFilters {
+  enabled?: boolean
+}
+
+export function useAvailabilityOverview(options: UseAvailabilityOverviewOptions = {}) {
+  const client = useVoyantAvailabilityContext()
+  const { enabled = true } = options
+  return useQuery({ ...getAvailabilityOverviewQueryOptions(client, options), enabled })
+}

--- a/packages/availability-react/src/index.ts
+++ b/packages/availability-react/src/index.ts
@@ -14,6 +14,7 @@ export {
 } from "./provider.js"
 export { availabilityQueryKeys } from "./query-keys.js"
 export {
+  getAvailabilityOverviewQueryOptions,
   getCloseoutsQueryOptions,
   getPickupPointsQueryOptions,
   getProductQueryOptions,

--- a/packages/availability-react/src/query-keys.ts
+++ b/packages/availability-react/src/query-keys.ts
@@ -27,6 +27,11 @@ export interface AvailabilitySlotsListFilters extends PaginationFilters {
   status?: string | undefined
 }
 
+export interface AvailabilityOverviewFilters {
+  productId?: string | undefined
+  attentionLimit?: number | undefined
+}
+
 export interface AvailabilityCloseoutsListFilters extends PaginationFilters {
   productId?: string | undefined
   slotId?: string | undefined
@@ -61,6 +66,8 @@ export const availabilityQueryKeys = {
   slots: () => [...availabilityQueryKeys.all, "slots"] as const,
   slotsList: (filters: AvailabilitySlotsListFilters) =>
     [...availabilityQueryKeys.slots(), "list", filters] as const,
+  overview: (filters: AvailabilityOverviewFilters) =>
+    [...availabilityQueryKeys.all, "overview", filters] as const,
 
   closeouts: () => [...availabilityQueryKeys.all, "closeouts"] as const,
   closeoutsList: (filters: AvailabilityCloseoutsListFilters) =>

--- a/packages/availability-react/src/query-options.ts
+++ b/packages/availability-react/src/query-options.ts
@@ -9,10 +9,11 @@ import type { UseProductsOptions } from "./hooks/use-products.js"
 import type { UseRulesOptions } from "./hooks/use-rules.js"
 import type { UseSlotsOptions } from "./hooks/use-slots.js"
 import type { UseStartTimesOptions } from "./hooks/use-start-times.js"
-import { availabilityQueryKeys } from "./query-keys.js"
+import { type AvailabilityOverviewFilters, availabilityQueryKeys } from "./query-keys.js"
 import {
   allocationAuditLogResponse,
   availabilityCloseoutListResponse,
+  availabilityOverviewResponse,
   availabilityPickupPointListResponse,
   availabilityRuleListResponse,
   availabilitySlotAssignmentListResponse,
@@ -116,6 +117,29 @@ export function getSlotsQueryOptions(
       return fetchWithValidation(
         `/v1/availability/slots${qs ? `?${qs}` : ""}`,
         availabilitySlotListResponse,
+        client,
+      )
+    },
+  })
+}
+
+export function getAvailabilityOverviewQueryOptions(
+  client: FetchWithValidationOptions,
+  options: AvailabilityOverviewFilters = {},
+) {
+  const filters = options
+  return queryOptions({
+    queryKey: availabilityQueryKeys.overview(filters),
+    queryFn: () => {
+      const params = new URLSearchParams()
+      if (filters.productId) params.set("productId", filters.productId)
+      if (filters.attentionLimit !== undefined) {
+        params.set("attentionLimit", String(filters.attentionLimit))
+      }
+      const qs = params.toString()
+      return fetchWithValidation(
+        `/v1/availability/overview${qs ? `?${qs}` : ""}`,
+        availabilityOverviewResponse,
         client,
       )
     },

--- a/packages/availability-react/src/schemas.ts
+++ b/packages/availability-react/src/schemas.ts
@@ -176,6 +176,18 @@ export const availabilityStartTimeSingleResponse = singleEnvelope(availabilitySt
 export const availabilitySlotListResponse = paginatedEnvelope(availabilitySlotRecordSchema)
 export const availabilitySlotRecordResponse = singleEnvelope(availabilitySlotRecordSchema)
 export const availabilitySlotSingleResponse = singleEnvelope(availabilitySlotDetailSchema)
+export const availabilityOverviewResponse = singleEnvelope(
+  z.object({
+    openSlotsCount: z.number().int(),
+    constrainedSlotsCount: z.number().int(),
+    activeRulesCount: z.number().int(),
+    activePickupPointsCount: z.number().int(),
+    productsWithoutUpcomingDeparturesCount: z.number().int(),
+    productsWithoutUpcomingDepartures: z.array(productOptionSchema),
+    constrainedSlots: z.array(availabilitySlotRecordSchema),
+  }),
+)
+export type AvailabilityOverviewData = z.infer<typeof availabilityOverviewResponse>["data"]
 export const availabilityCloseoutListResponse = paginatedEnvelope(availabilityCloseoutRecordSchema)
 export const availabilityPickupPointListResponse = paginatedEnvelope(
   availabilityPickupPointRecordSchema,

--- a/packages/availability-ui/src/components/availability-overview.tsx
+++ b/packages/availability-ui/src/components/availability-overview.tsx
@@ -76,10 +76,14 @@ export function AvailabilityOverview({
   messages,
   products,
   constrainedSlots,
+  constrainedSlotsCount: providedConstrainedSlotsCount,
   openSlotsCount: providedOpenSlotsCount,
+  activeRulesCount: providedActiveRulesCount,
+  activePickupPointsCount: providedActivePickupPointsCount,
   filteredRules,
   filteredPickupPoints,
   productsWithoutUpcomingDepartures,
+  productsWithoutUpcomingDeparturesCount: providedProductsWithoutUpcomingDeparturesCount,
   search,
   setSearch,
   productFilter,
@@ -94,10 +98,14 @@ export function AvailabilityOverview({
   messages: AvailabilityOverviewMessages
   products: ProductOption[]
   constrainedSlots: AvailabilitySlotRow[]
+  constrainedSlotsCount?: number
   openSlotsCount?: number
+  activeRulesCount?: number
+  activePickupPointsCount?: number
   filteredRules: AvailabilityRuleRow[]
   filteredPickupPoints: AvailabilityPickupPointRow[]
   productsWithoutUpcomingDepartures: ProductOption[]
+  productsWithoutUpcomingDeparturesCount?: number
   search: string
   setSearch: (value: string) => void
   productFilter: string
@@ -112,14 +120,17 @@ export function AvailabilityOverview({
   useAvailabilityUiMessagesOrDefault()
   const openSlotsCount =
     providedOpenSlotsCount ?? constrainedSlots.filter((slot) => slot.status === "open").length
-  const activeRulesCount = filteredRules.filter((rule) => rule.active).length
-  const activePickupPointsCount = filteredPickupPoints.filter(
-    (pickupPoint) => pickupPoint.active,
-  ).length
+  const constrainedSlotsCount = providedConstrainedSlotsCount ?? constrainedSlots.length
+  const activeRulesCount =
+    providedActiveRulesCount ?? filteredRules.filter((rule) => rule.active).length
+  const activePickupPointsCount =
+    providedActivePickupPointsCount ??
+    filteredPickupPoints.filter((pickupPoint) => pickupPoint.active).length
 
-  const noDeparturesCount = productsWithoutUpcomingDepartures.length
+  const noDeparturesCount =
+    providedProductsWithoutUpcomingDeparturesCount ?? productsWithoutUpcomingDepartures.length
   const hasNoDeparturesProducts = noDeparturesCount > 0
-  const hasConstrainedSlots = constrainedSlots.length > 0
+  const hasConstrainedSlots = constrainedSlotsCount > 0
   const hasAttention = hasNoDeparturesProducts || hasConstrainedSlots
 
   return (
@@ -154,7 +165,7 @@ export function AvailabilityOverview({
         />
         <OverviewMetric
           title={messages.overview.constrainedSlotsTitle}
-          value={constrainedSlots.length}
+          value={constrainedSlotsCount}
           description={messages.overview.constrainedSlotsDescription}
           icon={Clock3}
         />
@@ -179,7 +190,7 @@ export function AvailabilityOverview({
             {messages.overview.attentionTitle}
             {hasAttention ? (
               <Badge variant="secondary" className="tabular-nums">
-                {noDeparturesCount + constrainedSlots.length}
+                {noDeparturesCount + constrainedSlotsCount}
               </Badge>
             ) : null}
           </CardTitle>
@@ -208,7 +219,7 @@ export function AvailabilityOverview({
               />
               <AttentionColumn
                 title={messages.overview.capacityWatchlistTitle}
-                count={constrainedSlots.length}
+                count={constrainedSlotsCount}
                 items={constrainedSlots.slice(0, 4).map((slot) => ({
                   id: slot.id,
                   primary: `${productNameById(products, slot.productId, slot.productName)} · ${slot.dateLocal}`,

--- a/packages/availability-ui/src/components/availability-page.tsx
+++ b/packages/availability-ui/src/components/availability-page.tsx
@@ -16,6 +16,7 @@ import {
   type UpdateAvailabilityRuleInput,
   type UpdateAvailabilitySlotInput,
   type UpdateAvailabilityStartTimeInput,
+  useAvailabilityOverview,
   useAvailabilityRuleMutation,
   useAvailabilitySlotMutation,
   useAvailabilityStartTimeMutation,
@@ -207,6 +208,10 @@ export function AvailabilityPage({
   >()
 
   const productsQuery = useProducts({ search: productSearch || undefined, limit: 25, offset: 0 })
+  const overviewQuery = useAvailabilityOverview({
+    productId: productFilter === "all" ? undefined : productFilter,
+    attentionLimit: 4,
+  })
   const rulesQuery = useRules({ limit: 25, offset: 0 })
   const startTimesQuery = useStartTimes({ limit: 25, offset: 0 })
   const slotsQuery = useSlots({ limit: 25, offset: 0 })
@@ -219,6 +224,7 @@ export function AvailabilityPage({
   const availabilitySlots = slotsQuery.data?.data ?? []
   const closeouts = closeoutsQuery.data?.data ?? []
   const pickupPoints = pickupPointsQuery.data?.data ?? []
+  const overview = overviewQuery.data?.data
 
   const matchesProduct = (productId: string) =>
     productFilter === "all" || productId === productFilter
@@ -284,7 +290,7 @@ export function AvailabilityPage({
     }
   })
 
-  const queries = [
+  const primaryQueries = [
     productsQuery,
     rulesQuery,
     startTimesQuery,
@@ -292,8 +298,8 @@ export function AvailabilityPage({
     closeoutsQuery,
     pickupPointsQuery,
   ]
-  const isLoading = queries.some((query) => query.isPending)
-  const isError = queries.some((query) => query.isError)
+  const isLoading = primaryQueries.some((query) => query.isPending)
+  const isError = primaryQueries.some((query) => query.isError)
 
   const refreshAll = async () => {
     await queryClient.invalidateQueries({ queryKey: availabilityQueryKeys.all })
@@ -396,11 +402,19 @@ export function AvailabilityPage({
           <AvailabilityOverview
             messages={messages}
             products={products}
-            constrainedSlots={constrainedSlots}
-            openSlotsCount={filteredSlots.filter((slot) => slot.status === "open").length}
+            constrainedSlots={overview?.constrainedSlots ?? constrainedSlots}
+            constrainedSlotsCount={overview?.constrainedSlotsCount}
+            openSlotsCount={overview?.openSlotsCount}
+            activeRulesCount={overview?.activeRulesCount}
+            activePickupPointsCount={overview?.activePickupPointsCount}
             filteredRules={filteredRules}
             filteredPickupPoints={filteredPickupPoints}
-            productsWithoutUpcomingDepartures={productsWithoutUpcomingDepartures}
+            productsWithoutUpcomingDepartures={
+              overview?.productsWithoutUpcomingDepartures ?? productsWithoutUpcomingDepartures
+            }
+            productsWithoutUpcomingDeparturesCount={
+              overview?.productsWithoutUpcomingDeparturesCount
+            }
             search=""
             setSearch={() => {}}
             productFilter={productFilter}

--- a/packages/availability/src/index.ts
+++ b/packages/availability/src/index.ts
@@ -96,6 +96,7 @@ export {
   allocationAutomationSchema,
   assignTravelerAllocationSchema,
   availabilityCloseoutListQuerySchema,
+  availabilityOverviewQuerySchema,
   availabilityPickupPointListQuerySchema,
   availabilityRuleListQuerySchema,
   availabilitySlotListQuerySchema,

--- a/packages/availability/src/routes-core.ts
+++ b/packages/availability/src/routes-core.ts
@@ -12,6 +12,7 @@ import { availabilityService } from "./service.js"
 import {
   availabilityAggregatesQuerySchema,
   availabilityCloseoutListQuerySchema,
+  availabilityOverviewQuerySchema,
   availabilityRuleListQuerySchema,
   availabilitySlotListQuerySchema,
   availabilityStartTimeListQuerySchema,
@@ -39,6 +40,12 @@ export const availabilityCoreRoutes = new Hono<Env>()
     const query = await parseQuery(c, availabilityAggregatesQuerySchema)
     return c.json({
       data: await availabilityService.getAvailabilityAggregates(c.get("db"), query),
+    })
+  })
+  .get("/overview", async (c) => {
+    const query = await parseQuery(c, availabilityOverviewQuerySchema)
+    return c.json({
+      data: await availabilityService.getAvailabilityOverview(c.get("db"), query),
     })
   })
   .get("/rules", async (c) => {

--- a/packages/availability/src/service-overview.ts
+++ b/packages/availability/src/service-overview.ts
@@ -1,0 +1,120 @@
+import { and, asc, eq, getTableColumns, gte, inArray, notExists, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { productsRef } from "./products-ref.js"
+import { availabilityPickupPoints, availabilityRules, availabilitySlots } from "./schema.js"
+
+export interface AvailabilityOverviewOptions {
+  productId?: string
+  attentionLimit?: number
+}
+
+export interface AvailabilityOverview {
+  openSlotsCount: number
+  constrainedSlotsCount: number
+  activeRulesCount: number
+  activePickupPointsCount: number
+  productsWithoutUpcomingDeparturesCount: number
+  productsWithoutUpcomingDepartures: Array<{ id: string; name: string }>
+  constrainedSlots: Array<
+    typeof availabilitySlots.$inferSelect & {
+      productName: string | null
+    }
+  >
+}
+
+export async function getAvailabilityOverview(
+  db: PostgresJsDatabase,
+  options: AvailabilityOverviewOptions = {},
+): Promise<AvailabilityOverview> {
+  const now = new Date()
+  const attentionLimit = options.attentionLimit ?? 4
+
+  const productSlotCondition = options.productId
+    ? eq(availabilitySlots.productId, options.productId)
+    : undefined
+  const productRuleCondition = options.productId
+    ? eq(availabilityRules.productId, options.productId)
+    : undefined
+  const productPickupCondition = options.productId
+    ? eq(availabilityPickupPoints.productId, options.productId)
+    : undefined
+  const productCondition = options.productId ? eq(productsRef.id, options.productId) : undefined
+
+  const openUpcomingWhere = and(
+    productSlotCondition,
+    eq(availabilitySlots.status, "open"),
+    gte(availabilitySlots.startsAt, now),
+  )
+  const constrainedUpcomingWhere = and(
+    productSlotCondition,
+    inArray(availabilitySlots.status, ["closed", "sold_out"]),
+    gte(availabilitySlots.startsAt, now),
+  )
+  const coverageGapWhere = and(
+    productCondition,
+    notExists(
+      db
+        .select({ one: sql`1` })
+        .from(availabilitySlots)
+        .where(
+          and(
+            eq(availabilitySlots.productId, productsRef.id),
+            eq(availabilitySlots.status, "open"),
+            gte(availabilitySlots.startsAt, now),
+          ),
+        ),
+    ),
+  )
+
+  const [
+    openSlotsRow,
+    constrainedSlotsRow,
+    constrainedSlots,
+    activeRulesRow,
+    activePickupPointsRow,
+    coverageGapRow,
+    productsWithoutUpcomingDepartures,
+  ] = await Promise.all([
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(availabilitySlots)
+      .where(openUpcomingWhere),
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(availabilitySlots)
+      .where(constrainedUpcomingWhere),
+    db
+      .select({ ...getTableColumns(availabilitySlots), productName: productsRef.name })
+      .from(availabilitySlots)
+      .leftJoin(productsRef, eq(availabilitySlots.productId, productsRef.id))
+      .where(constrainedUpcomingWhere)
+      .orderBy(asc(availabilitySlots.startsAt))
+      .limit(attentionLimit),
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(availabilityRules)
+      .where(and(productRuleCondition, eq(availabilityRules.active, true))),
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(availabilityPickupPoints)
+      .where(and(productPickupCondition, eq(availabilityPickupPoints.active, true))),
+    db.select({ count: sql<number>`count(*)::int` }).from(productsRef).where(coverageGapWhere),
+    db
+      .select({ id: productsRef.id, name: productsRef.name })
+      .from(productsRef)
+      .where(coverageGapWhere)
+      .orderBy(asc(productsRef.name))
+      .limit(attentionLimit),
+  ])
+
+  return {
+    openSlotsCount: openSlotsRow[0]?.count ?? 0,
+    constrainedSlotsCount: constrainedSlotsRow[0]?.count ?? 0,
+    activeRulesCount: activeRulesRow[0]?.count ?? 0,
+    activePickupPointsCount: activePickupPointsRow[0]?.count ?? 0,
+    productsWithoutUpcomingDeparturesCount: coverageGapRow[0]?.count ?? 0,
+    productsWithoutUpcomingDepartures,
+    constrainedSlots,
+  }
+}

--- a/packages/availability/src/service-shared.ts
+++ b/packages/availability/src/service-shared.ts
@@ -2,6 +2,7 @@ import type { z } from "zod"
 
 import type {
   availabilityCloseoutListQuerySchema,
+  availabilityOverviewQuerySchema,
   availabilityPickupPointListQuerySchema,
   availabilityRuleListQuerySchema,
   availabilitySlotListQuerySchema,
@@ -39,6 +40,7 @@ import type {
 export type AvailabilityRuleListQuery = z.infer<typeof availabilityRuleListQuerySchema>
 export type AvailabilityStartTimeListQuery = z.infer<typeof availabilityStartTimeListQuerySchema>
 export type AvailabilitySlotListQuery = z.infer<typeof availabilitySlotListQuerySchema>
+export type AvailabilityOverviewQuery = z.infer<typeof availabilityOverviewQuerySchema>
 export type AvailabilityCloseoutListQuery = z.infer<typeof availabilityCloseoutListQuerySchema>
 export type AvailabilityPickupPointListQuery = z.infer<
   typeof availabilityPickupPointListQuerySchema

--- a/packages/availability/src/service.ts
+++ b/packages/availability/src/service.ts
@@ -31,6 +31,7 @@ import {
   updateSlot,
   updateStartTime,
 } from "./service-core.js"
+import { getAvailabilityOverview } from "./service-overview.js"
 import {
   createCustomPickupArea,
   createLocationPickupTime,
@@ -81,6 +82,7 @@ export const availabilityService = {
   pairSharingGroup,
   getSlotUnitAvailability,
   getAvailabilityAggregates,
+  getAvailabilityOverview,
   listRules,
   getRuleById,
   createRule,

--- a/packages/availability/src/validation.ts
+++ b/packages/availability/src/validation.ts
@@ -104,6 +104,11 @@ export const availabilityAggregatesQuerySchema = z.object({
   to: z.string().datetime().optional(),
 })
 
+export const availabilityOverviewQuerySchema = z.object({
+  productId: z.string().optional(),
+  attentionLimit: z.coerce.number().int().min(1).max(20).default(4),
+})
+
 export const availabilityCloseoutCoreSchema = z.object({
   productId: z.string(),
   slotId: z.string().nullable().optional(),

--- a/packages/availability/tests/integration/routes.test.ts
+++ b/packages/availability/tests/integration/routes.test.ts
@@ -6,6 +6,7 @@ import { Hono } from "hono"
 import { beforeAll, beforeEach, describe, expect, it } from "vitest"
 
 import { availabilityRoutes } from "../../src/routes.js"
+import { availabilityPickupPoints, availabilitySlots } from "../../src/schema.js"
 
 const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
 const DB_AVAILABLE = !!TEST_DATABASE_URL
@@ -303,6 +304,77 @@ describe.skipIf(!DB_AVAILABLE)("Availability routes", () => {
         method: "GET",
       })
       expect(res.status).toBe(404)
+    })
+  })
+
+  describe("Overview", () => {
+    it("derives overview counts from the full dataset, not the first slots page", async () => {
+      const productWithoutFutureSlotId = newId("products")
+      await db.insert(products).values({
+        id: productWithoutFutureSlotId,
+        name: "No Departures",
+        sellCurrency: "USD",
+      })
+
+      await db.insert(availabilitySlots).values(
+        Array.from({ length: 26 }, (_, index) => ({
+          id: newId("availability_slots"),
+          productId,
+          dateLocal: `2024-01-${String(index + 1).padStart(2, "0")}`,
+          startsAt: new Date(`2024-01-${String(index + 1).padStart(2, "0")}T09:00:00.000Z`),
+          timezone: "Europe/London",
+          status: "closed" as const,
+        })),
+      )
+      await db.insert(availabilitySlots).values([
+        {
+          id: newId("availability_slots"),
+          productId,
+          dateLocal: "2099-06-15",
+          startsAt: new Date("2099-06-15T09:00:00.000Z"),
+          timezone: "Europe/London",
+          status: "open",
+          remainingPax: 8,
+        },
+        {
+          id: newId("availability_slots"),
+          productId,
+          dateLocal: "2099-06-16",
+          startsAt: new Date("2099-06-16T09:00:00.000Z"),
+          timezone: "Europe/London",
+          status: "sold_out",
+          remainingPax: 0,
+        },
+      ])
+      await app.request("/rules", {
+        method: "POST",
+        ...json({
+          productId,
+          timezone: "Europe/London",
+          recurrenceRule: "FREQ=DAILY",
+          maxCapacity: 20,
+        }),
+      })
+      await db.insert(availabilityPickupPoints).values({
+        id: newId("availability_pickup_points"),
+        productId,
+        name: "Hotel Lobby",
+      })
+
+      const res = await app.request("/overview?attentionLimit=10", { method: "GET" })
+      expect(res.status).toBe(200)
+      const body = await res.json()
+
+      expect(body.data.openSlotsCount).toBe(1)
+      expect(body.data.constrainedSlotsCount).toBe(1)
+      expect(body.data.activeRulesCount).toBe(1)
+      expect(body.data.activePickupPointsCount).toBe(1)
+      expect(body.data.constrainedSlots).toHaveLength(1)
+      expect(body.data.constrainedSlots[0].status).toBe("sold_out")
+      expect(body.data.productsWithoutUpcomingDeparturesCount).toBe(1)
+      expect(body.data.productsWithoutUpcomingDepartures).toEqual([
+        { id: productWithoutFutureSlotId, name: "No Departures" },
+      ])
     })
   })
 

--- a/packages/availability/tests/unit/aggregates-query.test.ts
+++ b/packages/availability/tests/unit/aggregates-query.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest"
 
-import { availabilityAggregatesQuerySchema } from "../../src/validation.js"
+import {
+  availabilityAggregatesQuerySchema,
+  availabilityOverviewQuerySchema,
+} from "../../src/validation.js"
 
 describe("availabilityAggregatesQuerySchema", () => {
   it("accepts an empty object", () => {
@@ -19,5 +22,25 @@ describe("availabilityAggregatesQuerySchema", () => {
 
   it("rejects non-datetime strings", () => {
     expect(() => availabilityAggregatesQuerySchema.parse({ from: "yesterday" })).toThrow()
+  })
+})
+
+describe("availabilityOverviewQuerySchema", () => {
+  it("defaults the attention limit", () => {
+    const result = availabilityOverviewQuerySchema.parse({})
+    expect(result.attentionLimit).toBe(4)
+  })
+
+  it("accepts product filters and coerces the attention limit", () => {
+    const result = availabilityOverviewQuerySchema.parse({
+      productId: "prod_123",
+      attentionLimit: "10",
+    })
+    expect(result.productId).toBe("prod_123")
+    expect(result.attentionLimit).toBe(10)
+  })
+
+  it("rejects an unbounded attention limit", () => {
+    expect(() => availabilityOverviewQuerySchema.parse({ attentionLimit: 100 })).toThrow()
   })
 })


### PR DESCRIPTION
## Summary

- Add a server-backed `/v1/availability/overview` endpoint for exact overview counts and bounded attention rows.
- Add a `useAvailabilityOverview` React hook and wire `AvailabilityPage` to use server overview data instead of deriving KPIs from the first paginated list page.
- Add regression coverage for tenants with many past closed slots before future open inventory.

Fixes #1043.

## Verification

- `pnpm --filter @voyantjs/availability typecheck`
- `pnpm --filter @voyantjs/availability-react typecheck`
- `pnpm --filter @voyantjs/availability-ui typecheck`
- `pnpm --filter @voyantjs/availability lint`
- `pnpm --filter @voyantjs/availability-react lint`
- `pnpm --filter @voyantjs/availability-ui lint`
- `pnpm --filter @voyantjs/availability test`
- Pre-commit full lint/typecheck completed successfully.

Pre-push repository test suite was attempted; it failed in unrelated `@voyantjs/workflows-orchestrator` test `delay continues scheduling later DATETIME waits after the trigger delay fires` with `expected "spy" to be called 1 times, but got 0 times` after 126 successful tasks.