### PR TITLE
Show invoice type badge in detail header

### DIFF
--- a/.changeset/finance-ui-invoice-type-badge.md
+++ b/.changeset/finance-ui-invoice-type-badge.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/finance-ui": patch
+---
+
+Show localized invoice type badges in invoice detail headers when invoice records include an invoice type.

--- a/packages/finance-ui/src/components/invoice-detail-page.tsx
+++ b/packages/finance-ui/src/components/invoice-detail-page.tsx
@@ -330,7 +330,7 @@ export function InvoiceDetailHeader({
   const messages = useFinanceUiMessagesOrDefault()
   const detail = messages.invoiceDetailPage
   const canDelete = invoice.status === "draft"
-  const invoiceType = invoice.invoiceType ?? "invoice"
+  const invoiceType = invoice.invoiceType
 
   return (
     <div
@@ -349,7 +349,15 @@ export function InvoiceDetailHeader({
           <Badge variant={invoiceStatusVariant[invoice.status] ?? "secondary"}>
             {messages.common.invoiceStatusLabels[invoice.status]}
           </Badge>
-          <Badge variant="outline">{detail.invoiceTypeLabels[invoiceType]}</Badge>
+          {invoiceType ? (
+            <Badge
+              data-slot="invoice-type-badge"
+              data-invoice-type={invoiceType}
+              variant={invoiceTypeVariant[invoiceType] ?? "secondary"}
+            >
+              {detail.invoiceTypeLabels[invoiceType]}
+            </Badge>
+          ) : null}
         </div>
         <p className="mt-1 truncate font-mono text-muted-foreground text-sm">
           {invoice.invoiceNumber}
@@ -1308,6 +1316,15 @@ export const invoiceStatusVariant: Record<
   paid: "default",
   overdue: "destructive",
   void: "secondary",
+}
+
+export const invoiceTypeVariant: Record<
+  string,
+  "default" | "secondary" | "outline" | "destructive"
+> = {
+  invoice: "default",
+  proforma: "outline",
+  credit_note: "destructive",
 }
 
 export const paymentStatusVariant: Record<

--- a/packages/finance-ui/src/invoice-detail-page.test.tsx
+++ b/packages/finance-ui/src/invoice-detail-page.test.tsx
@@ -1,0 +1,52 @@
+import type { InvoiceRecord } from "@voyantjs/finance-react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+
+import { InvoiceDetailHeader } from "./components/invoice-detail-page.js"
+
+function invoice(data: Partial<InvoiceRecord> = {}): InvoiceRecord {
+  return {
+    id: "inv_123",
+    invoiceNumber: "PF-2026-001",
+    bookingId: "book_123",
+    personId: null,
+    organizationId: null,
+    status: "draft",
+    currency: "EUR",
+    subtotalCents: 10000,
+    taxCents: 1900,
+    totalCents: 11900,
+    paidCents: 0,
+    balanceDueCents: 11900,
+    issueDate: "2026-05-22",
+    dueDate: "2026-06-01",
+    notes: null,
+    createdAt: "2026-05-22T00:00:00.000Z",
+    updatedAt: "2026-05-22T00:00:00.000Z",
+    ...data,
+  }
+}
+
+describe("InvoiceDetailHeader", () => {
+  it("renders a localized type badge when invoiceType is present", () => {
+    const html = renderToStaticMarkup(
+      <InvoiceDetailHeader
+        invoice={invoice({ invoiceType: "proforma" })}
+        onEdit={() => {}}
+        onDelete={async () => {}}
+      />,
+    )
+
+    expect(html).toContain('data-slot="invoice-type-badge"')
+    expect(html).toContain('data-invoice-type="proforma"')
+    expect(html).toContain("Proforma")
+  })
+
+  it("does not render a type badge for legacy invoices without invoiceType", () => {
+    const html = renderToStaticMarkup(
+      <InvoiceDetailHeader invoice={invoice()} onEdit={() => {}} onDelete={async () => {}} />,
+    )
+
+    expect(html).not.toContain('data-slot="invoice-type-badge"')
+  })
+})


### PR DESCRIPTION
Fixes #1033.

## Summary
- show a localized invoice type badge next to the status badge when `invoice.invoiceType` is present
- map `invoice` to default, `proforma` to outline, and `credit_note` to destructive badge variants
- keep legacy records without `invoiceType` from rendering an extra type badge
- add a finance UI regression test and changeset

## Validation
- `pnpm --filter @voyantjs/finance-ui test`
- `pnpm --filter @voyantjs/finance-ui typecheck`
- `pnpm --filter @voyantjs/finance-ui lint`
- pre-push `pnpm test` passed: 127 successful tasks

Note: commit-time full typecheck is currently blocked by existing SmartBill UI type errors on `main`; the focused finance UI typecheck passes.