### PR TITLE
Materialize booking travelers from wizard state

### DIFF
--- a/.changeset/booking-session-state-travelers.md
+++ b/.changeset/booking-session-state-travelers.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/bookings": patch
+---
+
+Materialize public booking traveler rows from wizard session state updates.

--- a/packages/bookings/src/routes-public.ts
+++ b/packages/bookings/src/routes-public.ts
@@ -184,6 +184,7 @@ export const publicBookingRoutes = new Hono<Env>()
         c.req.param("sessionId"),
         await parseJsonBody(c, publicUpsertBookingSessionStateSchema),
         publicResolvers(c),
+        c.get("userId"),
       )
 
       if (result.status === "not_found") {

--- a/packages/bookings/src/service-public.ts
+++ b/packages/bookings/src/service-public.ts
@@ -34,6 +34,7 @@ import type {
   PublicUpdateBookingSessionInput,
   PublicUpsertBookingSessionStateInput,
 } from "./validation-public.js"
+import { publicBookingSessionTravelerInputSchema } from "./validation-public.js"
 
 /**
  * Optional resolver bundle for storefront/public booking flows. When
@@ -104,8 +105,13 @@ async function safeResolveBillingPerson(
   }
 }
 
-const travelerParticipantTypes = new Set(["traveler", "occupant"])
+const travelerParticipantTypeValues = ["traveler", "occupant"] as const
+const travelerParticipantTypes = new Set<string>(travelerParticipantTypeValues)
 const WIZARD_STATE_KEY = "wizard" as const
+
+type PublicBookingSessionTravelerInput = NonNullable<
+  PublicUpdateBookingSessionInput["travelers"]
+>[number]
 
 type SessionPricingCatalog = {
   id: string
@@ -187,6 +193,10 @@ function getRecordString(record: Record<string, unknown> | null, keys: string[])
   return null
 }
 
+function getArray(value: unknown) {
+  return Array.isArray(value) ? value : null
+}
+
 function extractBookingContactFromStatePayload(
   payload: Record<string, unknown> | null | undefined,
 ) {
@@ -214,10 +224,139 @@ function extractBookingContactFromStatePayload(
   }
 }
 
+function extractBookingTravelersFromStatePayload(
+  payload: Record<string, unknown> | null | undefined,
+): PublicBookingSessionTravelerInput[] | null {
+  const root = getRecord(payload)
+  const stepData = getNestedRecord(root, ["stepData", "steps"])
+  const travelersRecord =
+    getNestedRecord(root, ["travelers"]) ?? getNestedRecord(stepData, ["travelers"])
+  const travelers =
+    getArray(travelersRecord?.travelers) ??
+    getArray(root?.travelers) ??
+    getArray(stepData?.travelers)
+
+  if (!travelers) {
+    return null
+  }
+
+  const parsed = publicBookingSessionTravelerInputSchema.array().safeParse(travelers)
+  return parsed.success ? parsed.data : null
+}
+
 function countTravelerParticipants(participants: Array<{ participantType: string }>) {
   return participants.filter((participant) =>
     travelerParticipantTypes.has(participant.participantType),
   ).length
+}
+
+async function resolveTravelerPersonForParticipant(
+  db: PostgresJsDatabase,
+  resolver: ResolveBookingTravelerPerson | undefined,
+  participant: PublicBookingSessionTravelerInput,
+  bookingId: string,
+  existingPersonId?: string | null,
+) {
+  if (existingPersonId) {
+    return existingPersonId
+  }
+
+  return safeResolveTravelerPerson(
+    db,
+    resolver,
+    {
+      firstName: participant.firstName,
+      lastName: participant.lastName,
+      email: participant.email ?? null,
+      phone: participant.phone ?? null,
+      preferredLanguage: participant.preferredLanguage ?? null,
+    },
+    bookingId,
+  )
+}
+
+async function syncTravelerRowsFromStatePayload(
+  db: PostgresJsDatabase,
+  bookingId: string,
+  payload: Record<string, unknown>,
+  resolvers: PublicBookingsServiceResolvers,
+  userId?: string,
+) {
+  const travelers = extractBookingTravelersFromStatePayload(payload)
+  if (!travelers) {
+    return
+  }
+
+  const existingTravelers = await db
+    .select()
+    .from(bookingTravelers)
+    .where(
+      and(
+        eq(bookingTravelers.bookingId, bookingId),
+        inArray(bookingTravelers.participantType, [...travelerParticipantTypeValues]),
+      ),
+    )
+    .orderBy(asc(bookingTravelers.createdAt))
+
+  const existingById = new Map(existingTravelers.map((traveler) => [traveler.id, traveler]))
+  const usedExistingIds = new Set<string>()
+
+  for (const participant of travelers) {
+    const matchingExisting =
+      (participant.id ? existingById.get(participant.id) : undefined) ??
+      (participant.id
+        ? undefined
+        : existingTravelers.find((traveler) => !usedExistingIds.has(traveler.id)))
+    const reusablePersonId =
+      participant.id && matchingExisting?.id === participant.id ? matchingExisting.personId : null
+    const personId = await resolveTravelerPersonForParticipant(
+      db,
+      resolvers.resolveTravelerPerson,
+      participant,
+      bookingId,
+      reusablePersonId,
+    )
+    const travelerRecord = {
+      participantType: participant.participantType,
+      travelerCategory: participant.travelerCategory ?? null,
+      firstName: participant.firstName,
+      lastName: participant.lastName,
+      email: participant.email ?? null,
+      phone: participant.phone ?? null,
+      preferredLanguage: participant.preferredLanguage ?? null,
+      specialRequests: participant.specialRequests ?? null,
+      isPrimary: participant.isPrimary,
+      notes: participant.notes ?? null,
+      personId,
+    }
+
+    if (matchingExisting) {
+      await bookingsService.updateTravelerRecord(db, matchingExisting.id, travelerRecord)
+      usedExistingIds.add(matchingExisting.id)
+      continue
+    }
+
+    const created = await bookingsService.createTravelerRecord(
+      db,
+      bookingId,
+      travelerRecord,
+      userId,
+    )
+    if (created) {
+      usedExistingIds.add(created.id)
+    }
+  }
+
+  for (const existing of existingTravelers) {
+    if (!usedExistingIds.has(existing.id)) {
+      await bookingsService.deleteTravelerRecord(db, existing.id)
+    }
+  }
+
+  const travelerCount = countTravelerParticipants(travelers)
+  await bookingsService.updateBooking(db, bookingId, {
+    pax: travelerCount > 0 ? travelerCount : null,
+  })
 }
 
 function normalizeSessionState(
@@ -1022,6 +1161,7 @@ export const publicBookingsService = {
     bookingId: string,
     input: PublicUpsertBookingSessionStateInput,
     resolvers: PublicBookingsServiceResolvers = {},
+    userId?: string,
   ) {
     const booking = await bookingsService.getBookingById(db, bookingId)
     if (!booking) {
@@ -1058,6 +1198,9 @@ export const publicBookingsService = {
         ...(personId && booking.personId !== personId ? { personId } : {}),
       })
     }
+
+    await syncTravelerRowsFromStatePayload(db, bookingId, state.payload, resolvers, userId)
+
     return { status: "ok" as const, state }
   },
 

--- a/packages/bookings/tests/integration/public-routes.test.ts
+++ b/packages/bookings/tests/integration/public-routes.test.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from "@voyantjs/hono"
 import { optionUnits, productOptions, products } from "@voyantjs/products/schema"
-import { eq } from "drizzle-orm"
+import { asc, eq } from "drizzle-orm"
 import { Hono } from "hono"
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
 
@@ -10,8 +10,14 @@ import {
   optionUnitPriceRulesRef,
   priceCatalogsRef,
 } from "../../src/pricing-ref.js"
+import { BOOKING_ROUTE_RUNTIME_CONTAINER_KEY } from "../../src/route-runtime.js"
 import { publicBookingRoutes } from "../../src/routes-public.js"
-import { bookingDocuments, bookingFulfillments, bookings } from "../../src/schema.js"
+import {
+  bookingDocuments,
+  bookingFulfillments,
+  bookings,
+  bookingTravelers,
+} from "../../src/schema.js"
 
 const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
 const DB_AVAILABLE = !!TEST_DATABASE_URL
@@ -21,6 +27,14 @@ const json = (body: Record<string, unknown>) => ({
   headers: { "Content-Type": "application/json" },
   body: JSON.stringify(body),
 })
+
+function travelerPersonId(traveler: {
+  firstName: string
+  lastName: string
+  email?: string | null
+}) {
+  return `person:${traveler.email ?? `${traveler.firstName}:${traveler.lastName}`}`
+}
 
 describe.skipIf(!DB_AVAILABLE)("Public booking routes", () => {
   let app: Hono
@@ -36,6 +50,20 @@ describe.skipIf(!DB_AVAILABLE)("Public booking routes", () => {
       .use("*", async (c, next) => {
         c.set("db" as never, db)
         c.set("userId" as never, "public-test-user")
+        c.set("container" as never, {
+          resolve: (key: string) => {
+            if (key !== BOOKING_ROUTE_RUNTIME_CONTAINER_KEY) {
+              return undefined
+            }
+
+            return {
+              resolveTravelerPerson: async (
+                _db: unknown,
+                traveler: { firstName: string; lastName: string; email?: string | null },
+              ) => travelerPersonId(traveler),
+            }
+          },
+        })
         await next()
       })
       .route("/", publicBookingRoutes)
@@ -372,6 +400,217 @@ describe.skipIf(!DB_AVAILABLE)("Public booking routes", () => {
     const sessionBody = await sessionRes.json()
     expect(sessionBody.data.state.currentStep).toBe("rooms")
     expect(sessionBody.data.state.completedSteps).toEqual(["travelers"])
+  })
+
+  it("materializes wizard travelers into booking traveler rows", async () => {
+    const slot = await seedSlot()
+
+    const createRes = await app.request("/sessions", {
+      method: "POST",
+      ...json({
+        sellCurrency: "EUR",
+        items: [
+          {
+            title: "Brasov weekend",
+            availabilitySlotId: slot.id,
+            quantity: 1,
+            totalSellAmountCents: 18000,
+            productId: slot.productId,
+            optionId: slot.optionId,
+          },
+        ],
+      }),
+    })
+
+    const session = (await createRes.json()).data
+
+    const stateRes = await app.request(`/sessions/${session.sessionId}/state`, {
+      method: "PUT",
+      headers: { ...json({}).headers, ...capabilityHeaders(session) },
+      body: JSON.stringify({
+        currentStep: "rooms",
+        completedSteps: ["travelers"],
+        payload: {
+          stepData: {
+            travelers: {
+              travelers: [
+                {
+                  firstName: "Ana",
+                  lastName: "Popescu",
+                  email: "ana@example.com",
+                  isPrimary: true,
+                  travelerCategory: "adult",
+                },
+                {
+                  firstName: "Bogdan",
+                  lastName: "Popescu",
+                  phone: "+40700111222",
+                  participantType: "occupant",
+                  travelerCategory: "adult",
+                },
+              ],
+            },
+          },
+        },
+      }),
+    })
+
+    expect(stateRes.status).toBe(200)
+
+    const rows = await db
+      .select()
+      .from(bookingTravelers)
+      .where(eq(bookingTravelers.bookingId, session.sessionId))
+      .orderBy(asc(bookingTravelers.createdAt))
+
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toEqual(
+      expect.objectContaining({
+        firstName: "Ana",
+        lastName: "Popescu",
+        email: "ana@example.com",
+        isPrimary: true,
+        participantType: "traveler",
+        personId: travelerPersonId({
+          firstName: "Ana",
+          lastName: "Popescu",
+          email: "ana@example.com",
+        }),
+      }),
+    )
+    expect(rows[1]).toEqual(
+      expect.objectContaining({
+        firstName: "Bogdan",
+        lastName: "Popescu",
+        phone: "+40700111222",
+        participantType: "occupant",
+        personId: travelerPersonId({
+          firstName: "Bogdan",
+          lastName: "Popescu",
+        }),
+      }),
+    )
+
+    const sessionRes = await app.request(`/sessions/${session.sessionId}`, {
+      method: "GET",
+      headers: capabilityHeaders(session),
+    })
+    expect(sessionRes.status).toBe(200)
+    const sessionBody = await sessionRes.json()
+    expect(sessionBody.data.travelers).toHaveLength(2)
+    expect(sessionBody.data.checklist.hasTravelers).toBe(true)
+    expect(sessionBody.data.pax).toBe(2)
+
+    const reorderRes = await app.request(`/sessions/${session.sessionId}/state`, {
+      method: "PUT",
+      headers: { ...json({}).headers, ...capabilityHeaders(session) },
+      body: JSON.stringify({
+        currentStep: "rooms",
+        completedSteps: ["travelers"],
+        payload: {
+          stepData: {
+            travelers: {
+              travelers: [
+                {
+                  firstName: "Bogdan",
+                  lastName: "Popescu",
+                  phone: "+40700111222",
+                  participantType: "occupant",
+                  travelerCategory: "adult",
+                },
+                {
+                  firstName: "Ana",
+                  lastName: "Popescu",
+                  email: "ana@example.com",
+                  isPrimary: true,
+                  travelerCategory: "adult",
+                },
+              ],
+            },
+          },
+        },
+      }),
+    })
+
+    expect(reorderRes.status).toBe(200)
+
+    const reorderedRows = await db
+      .select()
+      .from(bookingTravelers)
+      .where(eq(bookingTravelers.bookingId, session.sessionId))
+      .orderBy(asc(bookingTravelers.createdAt))
+
+    expect(reorderedRows).toHaveLength(2)
+    expect(reorderedRows[0]).toEqual(
+      expect.objectContaining({
+        id: rows[0].id,
+        firstName: "Bogdan",
+        personId: travelerPersonId({
+          firstName: "Bogdan",
+          lastName: "Popescu",
+        }),
+      }),
+    )
+    expect(reorderedRows[1]).toEqual(
+      expect.objectContaining({
+        id: rows[1].id,
+        firstName: "Ana",
+        personId: travelerPersonId({
+          firstName: "Ana",
+          lastName: "Popescu",
+          email: "ana@example.com",
+        }),
+      }),
+    )
+
+    const updateRes = await app.request(`/sessions/${session.sessionId}/state`, {
+      method: "PUT",
+      headers: { ...json({}).headers, ...capabilityHeaders(session) },
+      body: JSON.stringify({
+        currentStep: "rooms",
+        completedSteps: ["travelers"],
+        payload: {
+          stepData: {
+            travelers: {
+              travelers: [
+                {
+                  id: reorderedRows[1].id,
+                  firstName: "Ana Maria",
+                  lastName: "Popescu",
+                  email: "ana@example.com",
+                  phone: "+40700999888",
+                  isPrimary: true,
+                  travelerCategory: "adult",
+                },
+              ],
+            },
+          },
+        },
+      }),
+    })
+
+    expect(updateRes.status).toBe(200)
+
+    const updatedRows = await db
+      .select()
+      .from(bookingTravelers)
+      .where(eq(bookingTravelers.bookingId, session.sessionId))
+      .orderBy(asc(bookingTravelers.createdAt))
+
+    expect(updatedRows).toHaveLength(1)
+    expect(updatedRows[0]).toEqual(
+      expect.objectContaining({
+        id: reorderedRows[1].id,
+        firstName: "Ana Maria",
+        phone: "+40700999888",
+        participantType: "traveler",
+        personId: travelerPersonId({
+          firstName: "Ana",
+          lastName: "Popescu",
+          email: "ana@example.com",
+        }),
+      }),
+    )
   })
 
   it("syncs billing contact from wizard state into the booking snapshot", async () => {


### PR DESCRIPTION
## Summary

- materialize `booking_travelers` from public wizard traveler state saves
- sync rows by persisted traveler id when available, with ordered matching for pre-id wizard payloads
- keep booking `pax` aligned with the materialized traveler rows

Fixes #1050

## Verification

- `pnpm --filter @voyantjs/bookings typecheck`
- `pnpm --filter @voyantjs/bookings test`
- `pnpm --filter @voyantjs/bookings lint`
- pre-commit workspace lint/typecheck hook
- pre-push workspace test hook