### PR TITLE
Add invoice FX settings and SmartBill exchange rates

### DIFF
--- a/.changeset/invoice-fx-settings.md
+++ b/.changeset/invoice-fx-settings.md
@@ -3,4 +3,4 @@
 "@voyantjs/plugin-smartbill": patch
 ---
 
-Add operator-configurable invoice FX settings, data FX exchange-rate resolution helpers, invoice-issued event enrichment, and SmartBill exchange-rate mapping.
+Add operator-configurable invoice FX settings, data FX exchange-rate resolution helpers, non-fatal invoice FX resolver error handling, invoice-issued event enrichment, and SmartBill exchange-rate mapping.

--- a/.changeset/invoice-fx-settings.md
+++ b/.changeset/invoice-fx-settings.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/finance": patch
+"@voyantjs/plugin-smartbill": patch
+---
+
+Add operator-configurable invoice FX settings, data FX exchange-rate resolution helpers, invoice-issued event enrichment, and SmartBill exchange-rate mapping.

--- a/packages/finance/README.md
+++ b/packages/finance/README.md
@@ -125,11 +125,41 @@ import {
 } from "@voyantjs/finance/booking-tax"
 ```
 
+## Invoice FX Settings
+
+Invoice issuing can enrich `invoice.issued` events with operator accounting
+currency, FX rate, FX commission, and effective provider rate. Configure the
+finance module with `invoiceFxSettings` or `resolveInvoiceFxSettings`, plus an
+exchange-rate resolver:
+
+```typescript
+import {
+  createFinanceHonoModule,
+  createVoyantDataFxExchangeRateResolver,
+} from "@voyantjs/finance"
+
+createFinanceHonoModule({
+  invoiceFxSettings: {
+    baseCurrency: "RON",
+    fxCommissionBps: 200,
+    fxCommissionInvoiceMention: "2% comision curs risc valutar",
+  },
+  resolveInvoiceExchangeRate: createVoyantDataFxExchangeRateResolver({
+    apiKey: process.env.VOYANT_DATA_API_KEY!,
+  }),
+})
+```
+
+The default data resolver calls the Voyant Data FX pair route
+`/data/fx/v1/fx/pair/{invoiceCurrency}/{baseCurrency}`. If the invoice currency
+matches the operator base currency, no FX fields are emitted.
+
 ## Exports
 
 | Entry | Description |
 | --- | --- |
 | `.` | Module export |
+| `./invoice-fx` | Invoice FX settings, route helpers, and data FX resolver |
 | `./schema` | Drizzle tables |
 | `./validation` | Zod schemas |
 | `./booking-tax` | Booking sell-side tax policy helpers and route mounting |

--- a/packages/finance/package.json
+++ b/packages/finance/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./action-ledger-drift": "./src/action-ledger-drift.ts",
+    "./invoice-fx": "./src/invoice-fx.ts",
     "./payment-link": "./src/payment-link.ts",
     "./schema": "./src/schema.ts",
     "./validation": "./src/validation.ts",
@@ -55,6 +56,11 @@
         "types": "./dist/action-ledger-drift.d.ts",
         "import": "./dist/action-ledger-drift.js",
         "default": "./dist/action-ledger-drift.js"
+      },
+      "./invoice-fx": {
+        "types": "./dist/invoice-fx.d.ts",
+        "import": "./dist/invoice-fx.js",
+        "default": "./dist/invoice-fx.js"
       },
       "./payment-link": {
         "types": "./dist/payment-link.d.ts",

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -2,6 +2,7 @@ import type { LinkableDefinition, Module } from "@voyantjs/core"
 import type { HonoModule } from "@voyantjs/hono/module"
 import { Hono } from "hono"
 
+import { createInvoiceFxRoutes } from "./invoice-fx.js"
 import {
   buildFinanceRouteRuntime,
   FINANCE_ROUTE_RUNTIME_CONTAINER_KEY,
@@ -64,6 +65,7 @@ export function createFinanceHonoModule(options: FinanceHonoModuleOptions = {}):
   const adminRoutes = new Hono()
     .route("/", financeRoutes)
     .route("/", financeActionLedgerRoutes)
+    .route("/", createInvoiceFxRoutes(options))
     .route("/", createFinanceAdminDocumentRoutes(options))
     .route("/", createFinanceAdminSettlementRoutes(options))
 
@@ -108,6 +110,24 @@ export {
   type TaxPolicyCondition,
   type UpdateBookingTaxSettings,
 } from "./booking-tax.js"
+export {
+  createInvoiceFxHonoExtension,
+  createInvoiceFxRoutes,
+  createVoyantDataFxExchangeRateResolver,
+  type InvoiceFxContext,
+  type InvoiceFxOptions,
+  type InvoiceFxRouteOptions,
+  type InvoiceFxSettings,
+  mountInvoiceFxRoutes,
+  type ResolvedInvoiceFxSettings,
+  type ResolveInvoiceExchangeRate,
+  type ResolveInvoiceExchangeRateInput,
+  type ResolveInvoiceFxSettings,
+  resolveInvoiceFxContext,
+  resolveInvoiceFxSettingsOrDefault,
+  type UpdateInvoiceFxSettings,
+  type VoyantDataFxResolverOptions,
+} from "./invoice-fx.js"
 export type {
   ComputedScheduleEntry,
   ComputeScheduleInput,

--- a/packages/finance/src/invoice-fx.ts
+++ b/packages/finance/src/invoice-fx.ts
@@ -35,11 +35,17 @@ export type ResolveInvoiceExchangeRate = (
   input: ResolveInvoiceExchangeRateInput,
 ) => number | null | undefined | Promise<number | null | undefined>
 
+export type HandleInvoiceFxResolutionError = (
+  error: unknown,
+  input: ResolveInvoiceExchangeRateInput,
+) => void | Promise<void>
+
 export interface InvoiceFxOptions {
   invoiceFxSettings?: InvoiceFxSettings | null
   resolveInvoiceFxSettings?: ResolveInvoiceFxSettings
   updateInvoiceFxSettings?: UpdateInvoiceFxSettings
   resolveInvoiceExchangeRate?: ResolveInvoiceExchangeRate
+  onInvoiceFxResolutionError?: HandleInvoiceFxResolutionError
 }
 
 export interface InvoiceFxRouteOptions extends InvoiceFxOptions {}
@@ -106,11 +112,19 @@ export async function resolveInvoiceFxContext(
   if (!baseCurrency || !invoiceCurrency || invoiceCurrency === baseCurrency) return null
   if (!options.resolveInvoiceExchangeRate) return null
 
-  const fxRate = await options.resolveInvoiceExchangeRate({
+  const rateInput = {
     baseCurrency: invoiceCurrency,
     quoteCurrency: baseCurrency,
     date: toDateString(invoice.issueDate),
-  })
+  }
+  let fxRate: number | null | undefined
+
+  try {
+    fxRate = await options.resolveInvoiceExchangeRate(rateInput)
+  } catch (error) {
+    await notifyInvoiceFxResolutionError(options, error, rateInput)
+    return null
+  }
 
   if (typeof fxRate !== "number" || !Number.isFinite(fxRate) || fxRate <= 0) return null
 
@@ -216,6 +230,18 @@ async function resolveConfiguredInvoiceFxSettings(
 function normalizeCurrency(value: string | null | undefined) {
   const normalized = value?.trim().toUpperCase()
   return normalized ? normalized : null
+}
+
+async function notifyInvoiceFxResolutionError(
+  options: InvoiceFxOptions,
+  error: unknown,
+  input: ResolveInvoiceExchangeRateInput,
+) {
+  try {
+    await options.onInvoiceFxResolutionError?.(error, input)
+  } catch {
+    // FX enrichment is optional; a reporting hook must not fail invoice issuance.
+  }
 }
 
 function normalizeBasisPoints(value: number | null | undefined) {

--- a/packages/finance/src/invoice-fx.ts
+++ b/packages/finance/src/invoice-fx.ts
@@ -1,0 +1,236 @@
+import type { Extension } from "@voyantjs/core"
+import { ApiHttpError, parseJsonBody } from "@voyantjs/hono"
+import type { HonoExtension } from "@voyantjs/hono/module"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import type { Hono } from "hono"
+import { Hono as HonoApp } from "hono"
+import { z } from "zod"
+
+import type { Env } from "./routes-shared.js"
+
+export type InvoiceFxSettings = {
+  baseCurrency?: string | null
+  fxCommissionBps?: number | null
+  fxCommissionInvoiceMention?: string | null
+}
+
+export type ResolveInvoiceFxSettings = (
+  db: PostgresJsDatabase,
+) => InvoiceFxSettings | null | undefined | Promise<InvoiceFxSettings | null | undefined>
+
+export type UpdateInvoiceFxSettings = (
+  db: PostgresJsDatabase,
+  settings: InvoiceFxSettings,
+) => InvoiceFxSettings | null | undefined | Promise<InvoiceFxSettings | null | undefined>
+
+export type ResolveInvoiceExchangeRateInput = {
+  /** Currency being invoiced, e.g. EUR. */
+  baseCurrency: string
+  /** Operator accounting/reporting currency, e.g. RON. */
+  quoteCurrency: string
+  date?: string
+}
+
+export type ResolveInvoiceExchangeRate = (
+  input: ResolveInvoiceExchangeRateInput,
+) => number | null | undefined | Promise<number | null | undefined>
+
+export interface InvoiceFxOptions {
+  invoiceFxSettings?: InvoiceFxSettings | null
+  resolveInvoiceFxSettings?: ResolveInvoiceFxSettings
+  updateInvoiceFxSettings?: UpdateInvoiceFxSettings
+  resolveInvoiceExchangeRate?: ResolveInvoiceExchangeRate
+}
+
+export interface InvoiceFxRouteOptions extends InvoiceFxOptions {}
+
+export type InvoiceFxInvoice = {
+  currency: string
+  baseCurrency?: string | null
+  issueDate?: string | Date | null
+}
+
+export type InvoiceFxContext = {
+  baseCurrency: string
+  fxRate: number
+  fxCommissionBps: number
+  effectiveRate: number
+  fxCommissionInvoiceMention?: string
+}
+
+export type ResolvedInvoiceFxSettings = {
+  baseCurrency: string
+  fxCommissionBps: number
+  fxCommissionInvoiceMention?: string
+}
+
+export type VoyantDataFxResolverOptions = {
+  baseUrl?: string
+  apiKey: string
+  authHeader?: string
+  authScheme?: string | null
+  fetch?: typeof fetch
+}
+
+const DEFAULT_DATA_BASE_URL = "https://api.voyantjs.com"
+
+const invoiceFxSettingsPatchSchema = z.object({
+  baseCurrency: z.string().min(3).max(8).nullable().optional(),
+  fxCommissionBps: z.number().int().min(0).max(100_000).nullable().optional(),
+  fxCommissionInvoiceMention: z.string().nullable().optional(),
+})
+
+export async function resolveInvoiceFxSettingsOrDefault(
+  db: PostgresJsDatabase,
+  options: InvoiceFxOptions = {},
+): Promise<ResolvedInvoiceFxSettings> {
+  const settings = await resolveConfiguredInvoiceFxSettings(db, options)
+
+  return {
+    baseCurrency: normalizeCurrency(settings?.baseCurrency) ?? "RON",
+    fxCommissionBps: normalizeBasisPoints(settings?.fxCommissionBps),
+    fxCommissionInvoiceMention: normalizeOptionalText(settings?.fxCommissionInvoiceMention),
+  }
+}
+
+export async function resolveInvoiceFxContext(
+  db: PostgresJsDatabase,
+  invoice: InvoiceFxInvoice,
+  options: InvoiceFxOptions = {},
+): Promise<InvoiceFxContext | null> {
+  const settings = await resolveConfiguredInvoiceFxSettings(db, options)
+  const baseCurrency =
+    normalizeCurrency(settings?.baseCurrency) ?? normalizeCurrency(invoice.baseCurrency) ?? "RON"
+  const invoiceCurrency = normalizeCurrency(invoice.currency)
+
+  if (!baseCurrency || !invoiceCurrency || invoiceCurrency === baseCurrency) return null
+  if (!options.resolveInvoiceExchangeRate) return null
+
+  const fxRate = await options.resolveInvoiceExchangeRate({
+    baseCurrency: invoiceCurrency,
+    quoteCurrency: baseCurrency,
+    date: toDateString(invoice.issueDate),
+  })
+
+  if (typeof fxRate !== "number" || !Number.isFinite(fxRate) || fxRate <= 0) return null
+
+  const fxCommissionBps = normalizeBasisPoints(settings?.fxCommissionBps)
+  const effectiveRate = roundRate(fxRate * (1 + fxCommissionBps / 10_000))
+
+  return {
+    baseCurrency,
+    fxRate: roundRate(fxRate),
+    fxCommissionBps,
+    effectiveRate,
+    ...(fxCommissionBps > 0 && normalizeOptionalText(settings?.fxCommissionInvoiceMention)
+      ? { fxCommissionInvoiceMention: normalizeOptionalText(settings?.fxCommissionInvoiceMention) }
+      : {}),
+  }
+}
+
+export function createVoyantDataFxExchangeRateResolver(
+  options: VoyantDataFxResolverOptions,
+): ResolveInvoiceExchangeRate {
+  const fetchImpl = options.fetch ?? fetch
+  const baseUrl = options.baseUrl ?? DEFAULT_DATA_BASE_URL
+  const authHeader = options.authHeader ?? "authorization"
+  const authScheme = options.authScheme === undefined ? "Bearer" : options.authScheme
+
+  return async ({ baseCurrency, quoteCurrency }) => {
+    const url = new URL(
+      `/data/fx/v1/fx/pair/${encodeURIComponent(baseCurrency)}/${encodeURIComponent(
+        quoteCurrency,
+      )}`,
+      baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`,
+    )
+    const headers = new Headers()
+    headers.set(authHeader, authScheme ? `${authScheme} ${options.apiKey}` : options.apiKey)
+    headers.set("x-voyant-sdk", "voyant-finance")
+
+    const response = await fetchImpl(url, { headers })
+    const body = (await response.json()) as Record<string, unknown>
+    if (!response.ok) {
+      throw new Error(`Voyant Data FX request failed with status ${response.status}`)
+    }
+
+    const rate = body.conversionRate ?? body.conversion_rate
+    return typeof rate === "number" && Number.isFinite(rate) ? rate : null
+  }
+}
+
+export function createInvoiceFxRoutes(options: InvoiceFxRouteOptions = {}) {
+  return new HonoApp<Env>()
+    .get("/invoice-fx-settings", async (c) => {
+      return c.json({
+        data: await resolveInvoiceFxSettingsOrDefault(c.get("db"), options),
+      })
+    })
+    .patch("/invoice-fx-settings", async (c) => {
+      if (!options.updateInvoiceFxSettings) {
+        throw new ApiHttpError("Invoice FX settings updates are not configured", {
+          status: 501,
+          code: "invoice_fx_settings_update_not_configured",
+        })
+      }
+
+      const current = await resolveInvoiceFxSettingsOrDefault(c.get("db"), options)
+      const patch = await parseJsonBody(c, invoiceFxSettingsPatchSchema)
+      const next = await options.updateInvoiceFxSettings(c.get("db"), {
+        ...current,
+        ...patch,
+      })
+
+      return c.json({
+        data: await resolveInvoiceFxSettingsOrDefault(c.get("db"), { invoiceFxSettings: next }),
+      })
+    })
+}
+
+export function mountInvoiceFxRoutes(hono: Hono, options: InvoiceFxRouteOptions = {}): Hono {
+  hono.route("/v1/admin/finance", createInvoiceFxRoutes(options))
+  return hono
+}
+
+export function createInvoiceFxHonoExtension(options: InvoiceFxRouteOptions = {}): HonoExtension {
+  const extension: Extension = {
+    name: "finance.invoice-fx",
+    module: "finance",
+  }
+
+  return {
+    extension,
+    adminRoutes: createInvoiceFxRoutes(options),
+    routes: createInvoiceFxRoutes(options),
+  }
+}
+
+async function resolveConfiguredInvoiceFxSettings(
+  db: PostgresJsDatabase,
+  options: InvoiceFxOptions,
+) {
+  return options.invoiceFxSettings !== undefined
+    ? options.invoiceFxSettings
+    : ((await options.resolveInvoiceFxSettings?.(db)) ?? null)
+}
+
+function normalizeCurrency(value: string | null | undefined) {
+  const normalized = value?.trim().toUpperCase()
+  return normalized ? normalized : null
+}
+
+function normalizeBasisPoints(value: number | null | undefined) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.round(value) : 0
+}
+
+function normalizeOptionalText(value: string | null | undefined) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined
+}
+
+function toDateString(value: string | Date | null | undefined) {
+  if (value instanceof Date) return value.toISOString().slice(0, 10)
+  return typeof value === "string" && value.length > 0 ? value : undefined
+}
+
+function roundRate(value: number) {
+  return Number(value.toFixed(8))
+}

--- a/packages/finance/src/route-runtime.ts
+++ b/packages/finance/src/route-runtime.ts
@@ -1,5 +1,6 @@
 import type { EventBus } from "@voyantjs/core"
 
+import type { InvoiceFxOptions } from "./invoice-fx.js"
 import type { FinanceDocumentRouteOptions, InvoiceDocumentGenerator } from "./routes-documents.js"
 import type { FinanceSettlementRouteOptions, InvoiceSettlementPoller } from "./routes-settlement.js"
 
@@ -8,13 +9,14 @@ export type FinanceRouteRuntime = {
   resolveDocumentDownloadUrl?: FinanceDocumentRouteOptions["resolveDocumentDownloadUrl"]
   invoiceSettlementPollers: Record<string, InvoiceSettlementPoller>
   eventBus?: EventBus
-}
+} & InvoiceFxOptions
 
 export const FINANCE_ROUTE_RUNTIME_CONTAINER_KEY = "providers.finance.runtime"
 
 export interface FinanceRuntimeOptions
   extends FinanceDocumentRouteOptions,
-    FinanceSettlementRouteOptions {}
+    FinanceSettlementRouteOptions,
+    InvoiceFxOptions {}
 
 export function buildFinanceRouteRuntime(
   bindings: Record<string, unknown>,
@@ -27,5 +29,9 @@ export function buildFinanceRouteRuntime(
     invoiceSettlementPollers:
       options.resolveInvoiceSettlementPollers?.(bindings) ?? options.invoiceSettlementPollers ?? {},
     eventBus: options.resolveEventBus?.(bindings) ?? options.eventBus,
+    invoiceFxSettings: options.invoiceFxSettings,
+    resolveInvoiceFxSettings: options.resolveInvoiceFxSettings,
+    updateInvoiceFxSettings: options.updateInvoiceFxSettings,
+    resolveInvoiceExchangeRate: options.resolveInvoiceExchangeRate,
   }
 }

--- a/packages/finance/src/service-issue.ts
+++ b/packages/finance/src/service-issue.ts
@@ -7,6 +7,7 @@ import type { EventBus } from "@voyantjs/core"
 import { asc, eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
+import { type InvoiceFxOptions, resolveInvoiceFxContext } from "./invoice-fx.js"
 import { invoiceLineItems, invoices, payments } from "./schema.js"
 import {
   buildInvoiceIssuedActionLedgerInput,
@@ -25,7 +26,7 @@ import {
  * (a status change that's also a system signal).
  */
 
-export interface InvoiceIssueRuntime {
+export interface InvoiceIssueRuntime extends InvoiceFxOptions {
   eventBus?: EventBus
   actionLedgerContext?: ActionLedgerRequestContextValues
   actionLedgerAuthorizationSource?: string | null
@@ -38,6 +39,16 @@ export interface InvoiceIssuedEvent {
   bookingId: string | null
   totalCents: number
   currency: string
+  /** Operator accounting/reporting currency when different from `currency`. */
+  baseCurrency?: string
+  /** Spot rate for `currency` → `baseCurrency`. */
+  fxRate?: number
+  /** Operator FX commission added on top of the spot rate. */
+  fxCommissionBps?: number
+  /** `fxRate` after commission. Invoice providers should prefer this rate. */
+  effectiveRate?: number
+  /** Optional invoice mention appended by providers when commission is non-zero. */
+  fxCommissionInvoiceMention?: string
   /** Linkage when this invoice replaced a proforma. */
   convertedFromInvoiceId?: string | null
   clientName?: string
@@ -205,6 +216,8 @@ async function emitIssued(
     issueDate: toDateString(invoice.issueDate),
     dueDate: toDateString(invoice.dueDate),
   }
+  const fx = await resolveInvoiceFxContext(db, invoice, runtime)
+  if (fx) Object.assign(payload, fx)
   await runtime.eventBus.emit(eventName, payload)
 }
 

--- a/packages/finance/tests/unit/invoice-fx.test.ts
+++ b/packages/finance/tests/unit/invoice-fx.test.ts
@@ -29,6 +29,32 @@ describe("invoice FX", () => {
     })
   })
 
+  it("omits FX context when exchange-rate resolution fails", async () => {
+    const error = new Error("FX provider timeout")
+    const onInvoiceFxResolutionError = vi.fn()
+    const context = await resolveInvoiceFxContext(
+      {} as never,
+      { currency: "eur", issueDate: "2026-05-22" },
+      {
+        invoiceFxSettings: {
+          baseCurrency: "ron",
+          fxCommissionBps: 200,
+        },
+        resolveInvoiceExchangeRate: async () => {
+          throw error
+        },
+        onInvoiceFxResolutionError,
+      },
+    )
+
+    expect(context).toBeNull()
+    expect(onInvoiceFxResolutionError).toHaveBeenCalledWith(error, {
+      baseCurrency: "EUR",
+      quoteCurrency: "RON",
+      date: "2026-05-22",
+    })
+  })
+
   it("uses the Voyant Data FX pair route for exchange-rate resolution", async () => {
     const fetch = vi.fn<typeof globalThis.fetch>(async () => {
       return new Response(JSON.stringify({ conversionRate: 4.97 }), {

--- a/packages/finance/tests/unit/invoice-fx.test.ts
+++ b/packages/finance/tests/unit/invoice-fx.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  createVoyantDataFxExchangeRateResolver,
+  resolveInvoiceFxContext,
+} from "../../src/invoice-fx.js"
+
+describe("invoice FX", () => {
+  it("resolves invoice FX context from operator settings", async () => {
+    const context = await resolveInvoiceFxContext(
+      {} as never,
+      { currency: "eur", issueDate: "2026-05-22" },
+      {
+        invoiceFxSettings: {
+          baseCurrency: "ron",
+          fxCommissionBps: 200,
+          fxCommissionInvoiceMention: "2% comision curs risc valutar",
+        },
+        resolveInvoiceExchangeRate: async () => 4.97,
+      },
+    )
+
+    expect(context).toEqual({
+      baseCurrency: "RON",
+      fxRate: 4.97,
+      fxCommissionBps: 200,
+      effectiveRate: 5.0694,
+      fxCommissionInvoiceMention: "2% comision curs risc valutar",
+    })
+  })
+
+  it("uses the Voyant Data FX pair route for exchange-rate resolution", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => {
+      return new Response(JSON.stringify({ conversionRate: 4.97 }), {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      })
+    })
+    const apiKey = `data_${"key"}`
+    const resolve = createVoyantDataFxExchangeRateResolver({
+      apiKey,
+      baseUrl: "https://data.test",
+      fetch,
+    })
+
+    await expect(resolve({ baseCurrency: "EUR", quoteCurrency: "RON" })).resolves.toBe(4.97)
+
+    const [url, init] = fetch.mock.calls[0]!
+    expect(String(url)).toBe("https://data.test/data/fx/v1/fx/pair/EUR/RON")
+    expect(new Headers(init?.headers).get("authorization")).toBe(`Bearer ${apiKey}`)
+    expect(new Headers(init?.headers).get("x-voyant-sdk")).toBe("voyant-finance")
+  })
+})

--- a/packages/finance/tests/unit/service-issue.test.ts
+++ b/packages/finance/tests/unit/service-issue.test.ts
@@ -147,4 +147,94 @@ describe("issueInvoiceFromBooking", () => {
       ],
     })
   })
+
+  it("enriches issued invoice events with operator FX settings", async () => {
+    const draftInvoice = {
+      id: "inv_fx",
+      invoiceNumber: "INV-FX",
+      invoiceType: "invoice",
+      bookingId: "book_fx",
+      totalCents: 10000,
+      currency: "EUR",
+      baseCurrency: null,
+      convertedFromInvoiceId: null,
+      issueDate: "2026-05-22",
+      dueDate: "2026-05-29",
+    }
+    const issuedInvoice = { ...draftInvoice, status: "sent" }
+    vi.mocked(financeService.createInvoiceFromBooking).mockResolvedValue(
+      draftInvoice as Awaited<ReturnType<typeof financeService.createInvoiceFromBooking>>,
+    )
+
+    const db = {
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn(() => ({
+            returning: vi.fn(async () => [issuedInvoice]),
+          })),
+        })),
+      })),
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(async () => [{ bookingNumber: "BK-FX" }]),
+            orderBy: vi.fn(async () => []),
+          })),
+        })),
+      })),
+    } as PostgresJsDatabase
+
+    const eventBus = createEventBus()
+    const emitted: Array<EventEnvelope<InvoiceIssuedEvent>> = []
+    eventBus.subscribe<InvoiceIssuedEvent>("invoice.issued", (event) => {
+      emitted.push(event)
+    })
+    const resolveInvoiceExchangeRate = vi.fn(async () => 4.97)
+
+    await issueInvoiceFromBooking(
+      db,
+      {
+        invoiceNumber: "INV-FX",
+        bookingId: "book_fx",
+        issueDate: "2026-05-22",
+        dueDate: "2026-05-29",
+      },
+      {
+        booking: {
+          id: "book_fx",
+          bookingNumber: "BK-FX",
+          personId: null,
+          organizationId: null,
+          sellCurrency: "EUR",
+          baseCurrency: null,
+          fxRateSetId: null,
+          sellAmountCents: 10000,
+          baseSellAmountCents: null,
+        },
+        items: [],
+      },
+      {
+        eventBus,
+        invoiceFxSettings: {
+          baseCurrency: "RON",
+          fxCommissionBps: 200,
+          fxCommissionInvoiceMention: "2% comision curs risc valutar",
+        },
+        resolveInvoiceExchangeRate,
+      },
+    )
+
+    expect(resolveInvoiceExchangeRate).toHaveBeenCalledWith({
+      baseCurrency: "EUR",
+      quoteCurrency: "RON",
+      date: "2026-05-22",
+    })
+    expect(emitted[0]?.data).toMatchObject({
+      baseCurrency: "RON",
+      fxRate: 4.97,
+      fxCommissionBps: 200,
+      effectiveRate: 5.0694,
+      fxCommissionInvoiceMention: "2% comision curs risc valutar",
+    })
+  })
 })

--- a/packages/finance/tests/unit/service-issue.test.ts
+++ b/packages/finance/tests/unit/service-issue.test.ts
@@ -237,4 +237,101 @@ describe("issueInvoiceFromBooking", () => {
       fxCommissionInvoiceMention: "2% comision curs risc valutar",
     })
   })
+
+  it("still emits issued invoice events when FX resolution fails", async () => {
+    const draftInvoice = {
+      id: "inv_fx_failure",
+      invoiceNumber: "INV-FX-FAIL",
+      invoiceType: "invoice",
+      bookingId: "book_fx_failure",
+      totalCents: 10000,
+      currency: "EUR",
+      baseCurrency: null,
+      convertedFromInvoiceId: null,
+      issueDate: "2026-05-22",
+      dueDate: "2026-05-29",
+    }
+    const issuedInvoice = { ...draftInvoice, status: "sent" }
+    vi.mocked(financeService.createInvoiceFromBooking).mockResolvedValue(
+      draftInvoice as Awaited<ReturnType<typeof financeService.createInvoiceFromBooking>>,
+    )
+
+    const db = {
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn(() => ({
+            returning: vi.fn(async () => [issuedInvoice]),
+          })),
+        })),
+      })),
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(async () => [{ bookingNumber: "BK-FX-FAIL" }]),
+            orderBy: vi.fn(async () => []),
+          })),
+        })),
+      })),
+    } as PostgresJsDatabase
+
+    const eventBus = createEventBus()
+    const emitted: Array<EventEnvelope<InvoiceIssuedEvent>> = []
+    eventBus.subscribe<InvoiceIssuedEvent>("invoice.issued", (event) => {
+      emitted.push(event)
+    })
+    const error = new Error("FX provider timeout")
+    const resolveInvoiceExchangeRate = vi.fn(async () => {
+      throw error
+    })
+    const onInvoiceFxResolutionError = vi.fn()
+
+    await expect(
+      issueInvoiceFromBooking(
+        db,
+        {
+          invoiceNumber: "INV-FX-FAIL",
+          bookingId: "book_fx_failure",
+          issueDate: "2026-05-22",
+          dueDate: "2026-05-29",
+        },
+        {
+          booking: {
+            id: "book_fx_failure",
+            bookingNumber: "BK-FX-FAIL",
+            personId: null,
+            organizationId: null,
+            sellCurrency: "EUR",
+            baseCurrency: null,
+            fxRateSetId: null,
+            sellAmountCents: 10000,
+            baseSellAmountCents: null,
+          },
+          items: [],
+        },
+        {
+          eventBus,
+          invoiceFxSettings: {
+            baseCurrency: "RON",
+            fxCommissionBps: 200,
+          },
+          resolveInvoiceExchangeRate,
+          onInvoiceFxResolutionError,
+        },
+      ),
+    ).resolves.toEqual(issuedInvoice)
+
+    expect(onInvoiceFxResolutionError).toHaveBeenCalledWith(error, {
+      baseCurrency: "EUR",
+      quoteCurrency: "RON",
+      date: "2026-05-22",
+    })
+    expect(emitted).toHaveLength(1)
+    expect(emitted[0]?.data).toMatchObject({
+      invoiceId: "inv_fx_failure",
+      invoiceNumber: "INV-FX-FAIL",
+      currency: "EUR",
+    })
+    expect(emitted[0]?.data).not.toHaveProperty("fxRate")
+    expect(emitted[0]?.data).not.toHaveProperty("effectiveRate")
+  })
 })

--- a/packages/plugins/smartbill/src/mapping.ts
+++ b/packages/plugins/smartbill/src/mapping.ts
@@ -132,6 +132,10 @@ function buildSmartbillInvoiceBody(
   if (typeof event.dueDate === "string") body.dueDate = event.dueDate
   if (typeof event.issueDate === "string") body.issueDate = event.issueDate
   if (typeof event.deliveryDate === "string") body.deliveryDate = event.deliveryDate
+  const exchangeRate = asNumberOrUndefined(
+    event.effectiveRate ?? event.fxRate ?? event.exchangeRate,
+  )
+  if (exchangeRate) body.exchangeRate = exchangeRate
 
   const mentions = options.hasMentionsOverride
     ? options.mentions
@@ -142,6 +146,11 @@ function buildSmartbillInvoiceBody(
     ? options.observations
     : asStringOrUndefined(event.observations)
   if (observations) body.observations = observations
+
+  const fxCommissionMention = asStringOrUndefined(event.fxCommissionInvoiceMention)
+  if (fxCommissionMention && asNumber(event.fxCommissionBps, 0) > 0) {
+    body.mentions = [body.mentions, fxCommissionMention].filter(Boolean).join("\n")
+  }
 
   if (options.art311SpecialRegime) {
     body.mentions = [
@@ -270,4 +279,9 @@ function asStringOrUndefined(value: unknown): string | undefined {
 function asNumber(value: unknown, fallback: number): number {
   if (typeof value === "number" && !Number.isNaN(value)) return value
   return fallback
+}
+
+function asNumberOrUndefined(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) return value
+  return undefined
 }

--- a/packages/plugins/smartbill/src/types.ts
+++ b/packages/plugins/smartbill/src/types.ts
@@ -60,6 +60,7 @@ export interface SmartbillInvoiceBody {
   deliveryDate?: string
   precision?: number
   useEstimateDetails?: boolean
+  exchangeRate?: number
   mentions?: string
   observations?: string
   products: SmartbillProduct[]

--- a/packages/plugins/smartbill/tests/unit/mapping.test.ts
+++ b/packages/plugins/smartbill/tests/unit/mapping.test.ts
@@ -191,6 +191,33 @@ describe("mapVoyantInvoiceToSmartbill", () => {
     expect(result.observations).toBe("Test obs")
   })
 
+  it("maps effective FX rate to SmartBill exchangeRate", () => {
+    const result = mapVoyantInvoiceToSmartbill(
+      event({
+        currency: "EUR",
+        fxRate: 4.97,
+        fxCommissionBps: 200,
+        effectiveRate: 5.0694,
+      }),
+      defaultOptions,
+    )
+
+    expect(result.exchangeRate).toBe(5.0694)
+  })
+
+  it("appends FX commission mention when commission is non-zero", () => {
+    const result = mapVoyantInvoiceToSmartbill(
+      event({
+        mentions: "Existing mention",
+        fxCommissionBps: 200,
+        fxCommissionInvoiceMention: "2% comision curs risc valutar",
+      }),
+      defaultOptions,
+    )
+
+    expect(result.mentions).toBe("Existing mention\n2% comision curs risc valutar")
+  })
+
   it("resolves synchronous mapping callbacks", () => {
     const result = mapVoyantInvoiceToSmartbill(event({ channel: "proforma" }), {
       ...defaultOptions,


### PR DESCRIPTION
Fixes #1032.

## Summary
- add finance invoice FX settings and admin route helpers for operator base currency, FX commission bps, and invoice commission mention text
- add a Voyant Data FX pair-route resolver for `invoice currency -> operator base currency` exchange rates
- handle exchange-rate resolver failures as non-fatal FX enrichment misses during invoice issuance
- enrich `invoice.issued` payloads with `baseCurrency`, `fxRate`, `fxCommissionBps`, `effectiveRate`, and optional commission mention
- map enriched invoice events into SmartBill `exchangeRate` and append the configured FX commission mention
- document the finance module wiring and add changesets

## Validation
- `pnpm --filter @voyantjs/finance test`
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/finance lint`
- `pnpm --filter @voyantjs/plugin-smartbill test`
- `pnpm --filter @voyantjs/plugin-smartbill typecheck`
- `pnpm --filter @voyantjs/plugin-smartbill lint`
- `pnpm typecheck`
- pre-push `pnpm test` passed: 127 successful tasks