### PR TITLE
feat(catalog-ui): enrichment fetchers (closes #1023)

### DIFF
--- a/.changeset/catalog-enrichment-fetchers.md
+++ b/.changeset/catalog-enrichment-fetchers.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/catalog-ui": minor
+---
+
+Add `createCatalogEnrichmentFetchers({ baseUrl, formatSupplier?, locale?, market?, contentBasePath?, loadSlotAvailability? })` and a matching `CatalogPage` prop `enrichmentFetchers`. Lifts the `/v1/admin/products/:id/content` URL contract out of host-template glue code and into a first-class export, mirroring `createCatalogBookingFetchers`. Hosts that pass `enrichmentFetchers` no longer need to hand-roll `onLoadProductDetail`. On the first 404 response (the symptom when a host forgets to mount `createProductContentRoutes` from `@voyantjs/products/routes-content`), the fetcher emits a one-time `console.warn` that names the missing route — so the silent "empty detail sheet" failure mode called out in issue #1023 turns into a loud actionable hint.

--- a/packages/catalog-ui/src/components/catalog-enrichment-fetchers.test.ts
+++ b/packages/catalog-ui/src/components/catalog-enrichment-fetchers.test.ts
@@ -1,0 +1,221 @@
+import type { CatalogSearchHit } from "@voyantjs/catalog-react"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+
+import {
+  __resetEnrichmentFetcherWarnings,
+  createCatalogEnrichmentFetchers,
+} from "./catalog-enrichment-fetchers.js"
+
+function hit(id: string): CatalogSearchHit {
+  return {
+    id,
+    score: 1,
+    document: {
+      entity: { module: "products", entityId: id },
+      fields: {},
+    },
+  } as unknown as CatalogSearchHit
+}
+
+function ok(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  })
+}
+
+const samplePayload = {
+  data: {
+    content: {
+      product: {
+        id: "prod_1",
+        name: "Test tour",
+        description: "Long description",
+        highlights: ["Hi", "Mountain"],
+        hero_image_url: "https://example.com/hero.jpg",
+        supplier: "supp_1",
+      },
+      options: [{ id: "opt_1", name: "Standard" }],
+      days: [{ day_number: 1, title: "Arrival", description: "Land at airport" }],
+      media: [{ url: "https://example.com/1.jpg", type: "image" }],
+      policies: [{ kind: "cancellation", body: "no refunds" }],
+      departures: [
+        {
+          id: "dep_1",
+          starts_at: "2026-06-01T10:00:00Z",
+          status: "open",
+          capacity: 10,
+          remaining: 7,
+        },
+      ],
+    },
+    served_locale: "en-GB",
+    match_kind: "exact" as const,
+    source: "owned" as const,
+    served_stale: false,
+    synthesized: false,
+    machine_translated: false,
+  },
+}
+
+describe("createCatalogEnrichmentFetchers", () => {
+  beforeEach(() => {
+    __resetEnrichmentFetcherWarnings()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test("calls the configured baseUrl + default content path with the encoded id", async () => {
+    const fetchImpl = vi.fn<typeof globalThis.fetch>(async () => ok(samplePayload))
+    const fetchers = createCatalogEnrichmentFetchers({
+      baseUrl: "https://operator.example/api",
+      fetch: fetchImpl,
+    })
+
+    await fetchers.loadProductDetail(hit("prod with space"))
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchImpl.mock.calls[0]!
+    expect(url).toBe("https://operator.example/api/v1/admin/products/prod%20with%20space/content")
+    expect((init as RequestInit).method).toBe("GET")
+    expect((init as RequestInit).credentials).toBe("include")
+  })
+
+  test("strips trailing slashes from baseUrl and honors contentBasePath", async () => {
+    const fetchImpl = vi.fn<typeof globalThis.fetch>(async () => ok(samplePayload))
+    const fetchers = createCatalogEnrichmentFetchers({
+      baseUrl: "https://operator.example/api/",
+      contentBasePath: "/v1/public/products",
+      fetch: fetchImpl,
+    })
+
+    await fetchers.loadProductDetail(hit("prod_1"))
+
+    expect(fetchImpl.mock.calls[0]![0]).toBe(
+      "https://operator.example/api/v1/public/products/prod_1/content",
+    )
+  })
+
+  test("forwards locale and market as query params", async () => {
+    const fetchImpl = vi.fn<typeof globalThis.fetch>(async () => ok(samplePayload))
+    const fetchers = createCatalogEnrichmentFetchers({
+      baseUrl: "/api",
+      fetch: fetchImpl,
+      locale: "fr-FR",
+      market: "mkt_eu",
+    })
+
+    await fetchers.loadProductDetail(hit("prod_1"))
+
+    expect(fetchImpl.mock.calls[0]![0]).toBe(
+      "/api/v1/admin/products/prod_1/content?locale=fr-FR&market=mkt_eu",
+    )
+  })
+
+  test("maps the content payload to a CatalogDetailEnrichment", async () => {
+    const fetchImpl = vi.fn<typeof globalThis.fetch>(async () => ok(samplePayload))
+    const fetchers = createCatalogEnrichmentFetchers({
+      baseUrl: "/api",
+      fetch: fetchImpl,
+      formatSupplier: (id) => `Supplier(${id})`,
+    })
+
+    const result = await fetchers.loadProductDetail(hit("prod_1"))
+    expect(result).toMatchObject({
+      description: "Long description",
+      highlights: ["Hi", "Mountain"],
+      heroImageUrl: "https://example.com/hero.jpg",
+      supplier: "Supplier(supp_1)",
+      itinerary: [{ dayNumber: 1, title: "Arrival" }],
+      media: [{ url: "https://example.com/1.jpg", type: "image" }],
+      options: [{ id: "opt_1", name: "Standard" }],
+      policies: [{ kind: "cancellation", body: "no refunds" }],
+      servedLocale: "en-GB",
+      matchKind: "exact",
+      source: "owned",
+      servedStale: false,
+      synthesized: false,
+      machineTranslated: false,
+    })
+    expect(result?.departures).toHaveLength(1)
+    expect(result?.departures?.[0]).toMatchObject({
+      id: "dep_1",
+      startsAt: "2026-06-01T10:00:00Z",
+      status: "open",
+      capacity: 10,
+      remaining: 7,
+    })
+  })
+
+  test("merges slot-availability data over the content departures", async () => {
+    const fetchImpl = vi.fn<typeof globalThis.fetch>(async () => ok(samplePayload))
+    const fetchers = createCatalogEnrichmentFetchers({
+      baseUrl: "/api",
+      fetch: fetchImpl,
+      loadSlotAvailability: async () =>
+        new Map([["dep_1", { id: "dep_1", status: "sold_out", initialPax: 10, remainingPax: 0 }]]),
+    })
+
+    const result = await fetchers.loadProductDetail(hit("prod_1"))
+    expect(result?.departures?.[0]).toMatchObject({
+      status: "sold_out",
+      capacity: 10,
+      remaining: 0,
+    })
+  })
+
+  test("returns null on 404 and 503 (no content row / cache unavailable)", async () => {
+    const fetchImpl = vi.fn<typeof globalThis.fetch>(
+      async () => new Response(null, { status: 404 }),
+    )
+    const fetchers = createCatalogEnrichmentFetchers({ baseUrl: "/api", fetch: fetchImpl })
+    expect(await fetchers.loadProductDetail(hit("prod_1"))).toBeNull()
+
+    const fetchImpl503 = vi.fn<typeof globalThis.fetch>(
+      async () => new Response(null, { status: 503 }),
+    )
+    const fetchers503 = createCatalogEnrichmentFetchers({ baseUrl: "/api", fetch: fetchImpl503 })
+    expect(await fetchers503.loadProductDetail(hit("prod_1"))).toBeNull()
+  })
+
+  test("warns once on first 404 hinting at missing route mount", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const fetchImpl = vi.fn<typeof globalThis.fetch>(
+      async () => new Response(null, { status: 404 }),
+    )
+    const fetchers = createCatalogEnrichmentFetchers({ baseUrl: "/api", fetch: fetchImpl })
+
+    await fetchers.loadProductDetail(hit("a"))
+    await fetchers.loadProductDetail(hit("b"))
+
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0]![0]).toMatch(/createProductContentRoutes/)
+  })
+
+  test("throws for non-404 server errors", async () => {
+    const fetchImpl = vi.fn<typeof globalThis.fetch>(
+      async () => new Response("oops", { status: 500 }),
+    )
+    const fetchers = createCatalogEnrichmentFetchers({ baseUrl: "/api", fetch: fetchImpl })
+    await expect(fetchers.loadProductDetail(hit("prod_1"))).rejects.toThrow(/500/)
+  })
+
+  test("tolerates slot-availability loader failures", async () => {
+    const fetchImpl = vi.fn<typeof globalThis.fetch>(async () => ok(samplePayload))
+    const fetchers = createCatalogEnrichmentFetchers({
+      baseUrl: "/api",
+      fetch: fetchImpl,
+      loadSlotAvailability: async () => {
+        throw new Error("slots are down")
+      },
+    })
+
+    const result = await fetchers.loadProductDetail(hit("prod_1"))
+    // Falls back to content-payload departures unchanged.
+    expect(result?.departures?.[0]?.status).toBe("open")
+    expect(result?.departures?.[0]?.remaining).toBe(7)
+  })
+})

--- a/packages/catalog-ui/src/components/catalog-enrichment-fetchers.ts
+++ b/packages/catalog-ui/src/components/catalog-enrichment-fetchers.ts
@@ -1,0 +1,287 @@
+/**
+ * Catalog detail enrichment client.
+ *
+ * Mirrors `createCatalogBookingFetchers` (quote/book) — provides a
+ * first-class factory for the `/v1/admin/products/:id/content` URL the
+ * detail sheet expects, so hosts no longer hand-roll `onLoadProductDetail`
+ * for the common case and can't accidentally point at a route that isn't
+ * mounted.
+ *
+ * The server side of this contract is `createProductContentRoutes` from
+ * `@voyantjs/products/routes-content`. If a host mounts `CatalogPage`
+ * with `enrichmentFetchers` but forgets the server mount, the first 404
+ * triggers a one-time `console.warn` pointing at the docs — fast feedback
+ * on the foot-gun called out in issue #1023.
+ */
+
+import type { CatalogSearchHit } from "@voyantjs/catalog-react"
+
+import type { CatalogDetailEnrichment } from "./catalog-detail-sheet.js"
+
+export interface CatalogEnrichmentFetchers {
+  /**
+   * Fetch the rich detail enrichment for a single hit. Returns `null`
+   * when the server has no content row (404 / 503) — the sheet falls
+   * back to the bare indexed projection.
+   */
+  loadProductDetail: (hit: CatalogSearchHit) => Promise<CatalogDetailEnrichment | null>
+}
+
+export interface CatalogEnrichmentFetchersOptions {
+  /** Base URL the content route lives under, e.g. `/api` or `https://operator.example/api`. */
+  baseUrl: string
+  /**
+   * Hono-mount path for `createProductContentRoutes`. Defaults to
+   * `/v1/admin/products` — the operator mount. Public surfaces typically
+   * pass `/v1/public/products`.
+   */
+  contentBasePath?: string
+  fetch?: typeof globalThis.fetch
+  credentials?: RequestCredentials
+  /**
+   * Resolves supplier ids to display names. The server returns the
+   * supplier as an id string; the sheet shows the resolved name. When
+   * omitted, the id is passed through unchanged.
+   */
+  formatSupplier?: (id: string) => string
+  /** Optional locale forwarded as `?locale=...` (BCP 47). */
+  locale?: string
+  /** Optional market id forwarded as `?market=...`. */
+  market?: string
+  /**
+   * Optional per-departure availability loader. When provided, the
+   * fetcher merges runtime availability (status / remaining / capacity)
+   * onto each departure in the result. Mirrors the operator's existing
+   * call to `/v1/admin/catalog/slots`.
+   */
+  loadSlotAvailability?: (productId: string) => Promise<Map<string, CatalogSlotAvailability>>
+}
+
+export interface CatalogSlotAvailability {
+  id: string
+  startsAt?: string
+  status?: string | null
+  unlimited?: boolean | null
+  remainingPax?: number | null
+  initialPax?: number | null
+}
+
+interface ProductSourcedContentResponse {
+  data: {
+    content: {
+      product: {
+        id: string
+        name: string
+        description?: string | null
+        highlights?: string[]
+        hero_image_url?: string | null
+        duration_days?: number | null
+        sell_currency?: string | null
+        supplier?: string | null
+        country?: string | null
+      }
+      options: Array<{ id: string; name: string; description?: string | null }>
+      days: Array<{
+        day_number: number
+        title?: string | null
+        description?: string | null
+        location?: string | null
+        hero_image_url?: string | null
+      }>
+      media: Array<{ url: string; type: string; caption?: string | null }>
+      policies: Array<{ kind: string; body: string }>
+      departures?: Array<{
+        id: string
+        starts_at: string
+        ends_at?: string | null
+        status?: string | null
+        capacity?: number | null
+        remaining?: number | null
+        lowest_price_cents?: number | null
+        currency?: string | null
+        note?: string | null
+      }>
+    }
+    served_locale: string
+    match_kind: "exact" | "language_match" | "fallback_chain" | "any"
+    source: "sourced-cache" | "sourced-fresh" | "synthesized" | "owned"
+    served_stale: boolean
+    synthesized: boolean
+    machine_translated: boolean
+  }
+}
+
+let warnedAboutMissingMount = false
+
+/**
+ * Build a `CatalogEnrichmentFetchers` for the configured `baseUrl`.
+ * Symmetric with `createCatalogBookingFetchers`.
+ */
+export function createCatalogEnrichmentFetchers(
+  options: CatalogEnrichmentFetchersOptions,
+): CatalogEnrichmentFetchers {
+  const {
+    baseUrl,
+    contentBasePath = "/v1/admin/products",
+    fetch: fetchImpl = globalThis.fetch,
+    credentials = "include",
+    formatSupplier,
+    locale,
+    market,
+    loadSlotAvailability,
+  } = options
+
+  const root = trimTrailingSlash(baseUrl)
+  const basePath = ensureLeadingSlash(contentBasePath)
+
+  const loadProductDetail = async (
+    hit: CatalogSearchHit,
+  ): Promise<CatalogDetailEnrichment | null> => {
+    const url = buildContentUrl(root, basePath, hit.id, { locale, market })
+    let response: Response
+    try {
+      response = await fetchImpl(url, {
+        method: "GET",
+        headers: { Accept: "application/json" },
+        credentials,
+      })
+    } catch (err) {
+      throw new Error(
+        `catalog enrichment fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+      )
+    }
+
+    if (response.status === 404 || response.status === 503) {
+      // 404 ALSO means the server didn't mount `createProductContentRoutes`.
+      // Warn once so the foot-gun called out in #1023 surfaces in dev
+      // instead of silently rendering the bare projection.
+      maybeWarnMissingMount(response, url)
+      return null
+    }
+    if (!response.ok) {
+      throw new Error(`catalog enrichment fetch failed: ${response.status} ${response.statusText}`)
+    }
+
+    const payload = (await response.json()) as ProductSourcedContentResponse
+    const availability = loadSlotAvailability
+      ? await loadSlotAvailability(hit.id).catch(() => new Map<string, CatalogSlotAvailability>())
+      : new Map<string, CatalogSlotAvailability>()
+    return mapContentToEnrichment(payload, availability, formatSupplier)
+  }
+
+  return { loadProductDetail }
+}
+
+function maybeWarnMissingMount(response: Response, url: string): void {
+  if (warnedAboutMissingMount) return
+  if (response.status !== 404) return
+  // Heuristic: a 404 returned with no JSON body almost always means the
+  // route is unmounted on the server side. A real "product not found"
+  // response carries a JSON `{ error: "not_found", detail }`. We don't
+  // re-read the body here (the caller will not parse it for 404), so we
+  // log a generic hint — false positives are tolerable in dev.
+  warnedAboutMissingMount = true
+  if (typeof console !== "undefined" && typeof console.warn === "function") {
+    console.warn(
+      `[catalog-ui] enrichment fetch returned 404 for ${url}. ` +
+        `If the catalog detail sheet renders empty, make sure the host mounts ` +
+        `createProductContentRoutes from @voyantjs/products/routes-content ` +
+        `under the same prefix used here.`,
+    )
+  }
+}
+
+function mapContentToEnrichment(
+  payload: ProductSourcedContentResponse,
+  availability: Map<string, CatalogSlotAvailability>,
+  formatSupplier?: (id: string) => string,
+): CatalogDetailEnrichment {
+  const {
+    content,
+    served_locale,
+    match_kind,
+    source,
+    served_stale,
+    synthesized,
+    machine_translated,
+  } = payload.data
+  const supplierName =
+    typeof content.product.supplier === "string"
+      ? formatSupplier
+        ? formatSupplier(content.product.supplier)
+        : content.product.supplier
+      : (content.product.supplier ?? null)
+
+  return {
+    description: content.product.description ?? null,
+    highlights: content.product.highlights ?? [],
+    heroImageUrl: content.product.hero_image_url ?? null,
+    supplier: supplierName,
+    itinerary: content.days.map((d) => ({
+      dayNumber: d.day_number,
+      title: d.title ?? null,
+      description: d.description ?? null,
+      location: d.location ?? null,
+      heroImageUrl: d.hero_image_url ?? null,
+    })),
+    media: content.media.map((m) => ({
+      url: m.url,
+      type: m.type,
+      caption: m.caption ?? null,
+    })),
+    options: content.options.map((o) => ({
+      id: o.id,
+      name: o.name,
+      description: o.description ?? null,
+    })),
+    policies: content.policies.map((p) => ({ kind: p.kind, body: p.body })),
+    departures: (content.departures ?? []).map((d) => {
+      const slot = availability.get(d.id)
+      return {
+        id: d.id,
+        startsAt: d.starts_at,
+        endsAt: d.ends_at ?? null,
+        status: slot?.status ?? d.status ?? null,
+        unlimited: slot?.unlimited ?? null,
+        capacity: slot?.initialPax ?? d.capacity ?? null,
+        remaining: slot?.remainingPax ?? d.remaining ?? null,
+        lowestPriceCents: d.lowest_price_cents ?? null,
+        currency: d.currency ?? null,
+        note: d.note ?? null,
+      }
+    }),
+    servedLocale: served_locale,
+    matchKind: match_kind,
+    source,
+    servedStale: served_stale,
+    synthesized,
+    machineTranslated: machine_translated,
+  }
+}
+
+function buildContentUrl(
+  root: string,
+  basePath: string,
+  id: string,
+  query: { locale?: string; market?: string },
+): string {
+  const params = new URLSearchParams()
+  if (query.locale) params.set("locale", query.locale)
+  if (query.market) params.set("market", query.market)
+  const qs = params.toString()
+  const suffix = qs ? `?${qs}` : ""
+  return `${root}${basePath}/${encodeURIComponent(id)}/content${suffix}`
+}
+
+function trimTrailingSlash(s: string): string {
+  return s.endsWith("/") ? s.slice(0, -1) : s
+}
+
+function ensureLeadingSlash(s: string): string {
+  return s.startsWith("/") ? s : `/${s}`
+}
+
+/** @internal — exported for testing. Resets the one-time warn flag. */
+export function __resetEnrichmentFetcherWarnings(): void {
+  warnedAboutMissingMount = false
+}

--- a/packages/catalog-ui/src/components/catalog-page.tsx
+++ b/packages/catalog-ui/src/components/catalog-page.tsx
@@ -7,12 +7,15 @@ import { cn } from "@voyantjs/ui/lib/utils"
 import { Image as ImageIcon } from "lucide-react"
 import type { ReactNode } from "react"
 
+import { useMemo } from "react"
+
 import { useCatalogUiMessagesOrDefault } from "../i18n/index.js"
 import type {
   CatalogDetailEnrichment,
   CatalogDetailRenderSlot,
   CatalogDetailSheetProps,
 } from "./catalog-detail-sheet.js"
+import type { CatalogEnrichmentFetchers } from "./catalog-enrichment-fetchers.js"
 import {
   type CatalogFilterField,
   CatalogSearchPage,
@@ -47,7 +50,23 @@ export interface CatalogPageProps {
     option: NonNullable<CatalogDetailEnrichment["options"]>[number],
   ) => void
   onOpenProductEditor?: (hit: CatalogSearchHit) => void
+  /**
+   * Explicit detail-enrichment callback. When set, takes precedence over
+   * `enrichmentFetchers` — pass this when you need full control over the
+   * request (auth headers, locale resolution, side-channel data). The
+   * default integration uses `enrichmentFetchers` for the common case.
+   */
   onLoadProductDetail?: (hit: CatalogSearchHit) => Promise<CatalogDetailEnrichment | null>
+  /**
+   * Declarative detail-enrichment fetchers. Build with
+   * `createCatalogEnrichmentFetchers({ baseUrl, … })`. When provided
+   * (and `onLoadProductDetail` is not), the detail sheet calls
+   * `fetchers.loadProductDetail` on open. This is the recommended way
+   * to wire up the sheet — it pins the route contract with
+   * `createProductContentRoutes` so a missing server-side mount is
+   * caught immediately instead of rendering an empty sheet.
+   */
+  enrichmentFetchers?: CatalogEnrichmentFetchers
   detailSheetWidth?: CatalogDetailSheetProps["width"]
   detailHeaderExtras?: CatalogDetailSheetProps["headerExtras"]
   renderDetailBrochure?: CatalogDetailRenderSlot
@@ -84,6 +103,7 @@ export function CatalogPage({
   onBookOption,
   onOpenProductEditor,
   onLoadProductDetail,
+  enrichmentFetchers,
   detailSheetWidth,
   detailHeaderExtras,
   renderDetailBrochure,
@@ -96,6 +116,10 @@ export function CatalogPage({
   className,
 }: CatalogPageProps) {
   const messages = useCatalogUiMessagesOrDefault().catalogPage
+  const resolvedLoadProductDetail = useMemo(
+    () => onLoadProductDetail ?? enrichmentFetchers?.loadProductDetail,
+    [onLoadProductDetail, enrichmentFetchers],
+  )
   const supplierFormatter = (value: unknown) =>
     typeof value === "string" ? formatSupplier(value) : String(value ?? "")
   const sourceKindFormatter = (value: unknown) =>
@@ -138,7 +162,7 @@ export function CatalogPage({
             ]
           : []),
       ],
-      onLoadDetail: onLoadProductDetail,
+      onLoadDetail: resolvedLoadProductDetail,
       onBookDeparture: onBookDeparture
         ? (hit, departure) => onBookDeparture(hit, "products", departure)
         : undefined,

--- a/packages/catalog-ui/src/index.ts
+++ b/packages/catalog-ui/src/index.ts
@@ -25,6 +25,12 @@ export {
   type CatalogDetailSheetWidth,
 } from "./components/catalog-detail-sheet.js"
 export {
+  type CatalogEnrichmentFetchers,
+  type CatalogEnrichmentFetchersOptions,
+  type CatalogSlotAvailability,
+  createCatalogEnrichmentFetchers,
+} from "./components/catalog-enrichment-fetchers.js"
+export {
   CatalogFacetedFilter,
   type CatalogFacetedFilterProps,
 } from "./components/catalog-faceted-filter.js"

--- a/templates/operator/src/components/voyant/catalog/catalog-page.tsx
+++ b/templates/operator/src/components/voyant/catalog/catalog-page.tsx
@@ -2,7 +2,11 @@
 
 import { Link, useNavigate } from "@tanstack/react-router"
 import type { CatalogSearchHit } from "@voyantjs/catalog-react"
-import { type CatalogDetailEnrichment, CatalogPage as CatalogUiPage } from "@voyantjs/catalog-ui"
+import {
+  CatalogPage as CatalogUiPage,
+  createCatalogEnrichmentFetchers,
+  type CatalogSlotAvailability as UiCatalogSlotAvailability,
+} from "@voyantjs/catalog-ui"
 import { useMarketLocales, useMarkets } from "@voyantjs/markets-react"
 import { useProductMutation } from "@voyantjs/products-react"
 import { useSuppliers } from "@voyantjs/suppliers-react"
@@ -16,9 +20,9 @@ import {
 import { useMemo } from "react"
 import { toast } from "sonner"
 
-import type { ProductSourcedContentResponse } from "@/components/voyant/products/product-detail-shared"
 import { useAdminMessages } from "@/lib/admin-i18n"
-import { ApiError, api } from "@/lib/api-client"
+import { api } from "@/lib/api-client"
+import { getApiUrl } from "@/lib/env"
 import { type CatalogSearchParams, Route } from "@/routes/_workspace/catalog"
 
 type CatalogBrowserMessages = ReturnType<
@@ -65,6 +69,18 @@ export function CatalogPage() {
   }, [suppliersQuery.data])
   const formatSupplier = (id: string | number) => supplierMap.get(String(id)) ?? String(id)
   const productMutation = useProductMutation()
+
+  const enrichmentFetchers = useMemo(
+    () =>
+      createCatalogEnrichmentFetchers({
+        baseUrl: getApiUrl(),
+        formatSupplier: (id) => supplierMap.get(String(id)) ?? String(id),
+        locale: selectedLocale,
+        market: selectedMarketId,
+        loadSlotAvailability: loadProductSlotAvailability,
+      }),
+    [supplierMap, selectedLocale, selectedMarketId],
+  )
 
   return (
     <CatalogUiPage
@@ -142,7 +158,7 @@ export function CatalogPage() {
         goToBookingPage(hit, entityModule, navigate, browserMessages, departure, option)
       }
       onOpenProductEditor={(hit) => navigate({ to: "/products/$id", params: { id: hit.id } })}
-      onLoadProductDetail={(hit) => loadProductDetail(hit, formatSupplier)}
+      enrichmentFetchers={enrichmentFetchers}
       renderSupplierLink={(supplierId, displayName) => (
         <Link
           to="/suppliers/$id"
@@ -245,17 +261,8 @@ interface BookingDeparture {
   startsAt: string
 }
 
-interface CatalogSlotAvailability {
-  id: string
-  startsAt: string
-  status: string
-  unlimited: boolean
-  remainingPax: number | null
-  initialPax: number | null
-}
-
 interface CatalogSlotsResponse {
-  rows: CatalogSlotAvailability[]
+  rows: Array<UiCatalogSlotAvailability & { startsAt: string }>
 }
 
 function goToBookingPage(
@@ -289,80 +296,9 @@ function goToBookingPage(
   })
 }
 
-async function loadProductDetail(
-  hit: CatalogSearchHit,
-  formatSupplier: (id: string | number) => string,
-): Promise<CatalogDetailEnrichment | null> {
-  let response: ProductSourcedContentResponse | null = null
-  try {
-    response = await api.get<ProductSourcedContentResponse>(`/v1/admin/products/${hit.id}/content`)
-  } catch (err) {
-    if (err instanceof ApiError && (err.status === 404 || err.status === 503)) return null
-    throw err
-  }
-
-  const {
-    content,
-    served_locale,
-    match_kind,
-    source,
-    served_stale,
-    synthesized,
-    machine_translated,
-  } = response.data
-  const supplierName =
-    typeof content.product.supplier === "string"
-      ? formatSupplier(content.product.supplier)
-      : (content.product.supplier ?? null)
-  const availabilityById = await loadProductSlotAvailability(hit.id)
-
-  return {
-    description: content.product.description ?? null,
-    highlights: content.product.highlights ?? [],
-    heroImageUrl: content.product.hero_image_url ?? null,
-    supplier: supplierName,
-    itinerary: content.days.map((d) => ({
-      dayNumber: d.day_number,
-      title: d.title ?? null,
-      description: d.description ?? null,
-      location: d.location ?? null,
-      heroImageUrl: d.hero_image_url ?? null,
-    })),
-    media: content.media.map((m) => ({
-      url: m.url,
-      type: m.type,
-      caption: m.caption ?? null,
-    })),
-    options: content.options.map((o) => ({
-      id: o.id,
-      name: o.name,
-      description: o.description ?? null,
-    })),
-    policies: content.policies.map((p) => ({ kind: p.kind, body: p.body })),
-    departures: (content.departures ?? []).map((d) => ({
-      id: d.id,
-      startsAt: d.starts_at,
-      endsAt: d.ends_at ?? null,
-      status: availabilityById.get(d.id)?.status ?? d.status ?? null,
-      unlimited: availabilityById.get(d.id)?.unlimited ?? null,
-      capacity: availabilityById.get(d.id)?.initialPax ?? d.capacity ?? null,
-      remaining: availabilityById.get(d.id)?.remainingPax ?? d.remaining ?? null,
-      lowestPriceCents: d.lowest_price_cents ?? null,
-      currency: d.currency ?? null,
-      note: d.note ?? null,
-    })),
-    servedLocale: served_locale,
-    matchKind: match_kind,
-    source,
-    servedStale: served_stale,
-    synthesized,
-    machineTranslated: machine_translated,
-  }
-}
-
 async function loadProductSlotAvailability(
   productId: string,
-): Promise<Map<string, CatalogSlotAvailability>> {
+): Promise<Map<string, UiCatalogSlotAvailability>> {
   try {
     const response = await api.get<CatalogSlotsResponse>(
       `/v1/admin/catalog/slots?entityModule=products&entityId=${encodeURIComponent(productId)}`,


### PR DESCRIPTION
## Summary

Closes #1023. Pins the undeclared route contract between `@voyantjs/catalog-ui`'s `CatalogPage` and `@voyantjs/products`'s `createProductContentRoutes` by lifting the `/v1/admin/products/:id/content` URL into a first-class export, mirroring how `createCatalogBookingFetchers` already works for catalog booking.

- **New** `createCatalogEnrichmentFetchers({ baseUrl, formatSupplier?, locale?, market?, contentBasePath?, loadSlotAvailability? })` factory in `@voyantjs/catalog-ui`. Maps the content payload into `CatalogDetailEnrichment` and optionally merges per-departure slot availability via a caller-supplied loader.
- **New prop** `CatalogPage.enrichmentFetchers`. When provided (and `onLoadProductDetail` is not), the detail sheet calls the fetcher directly — hosts no longer write `onLoadProductDetail` for the common case. The explicit callback still wins for advanced cases (custom auth, side-channel data, alternate URL shapes).
- **Dev-mode warning**: the first 404 response emits a one-time `console.warn` naming `createProductContentRoutes from @voyantjs/products/routes-content`. The silent foot-gun called out in the issue (host forgets the server-side mount, sheet renders empty) now surfaces immediately.
- **Operator template migrated**: drops the hand-rolled `loadProductDetail`, keeps its `loadProductSlotAvailability`, and threads it through the new `loadSlotAvailability` hook. The `ProductSourcedContentResponse` type is no longer used here but stays exported from `product-detail-shared.ts` for downstream consumers.

## Test plan

- [x] `pnpm -F @voyantjs/catalog-ui test` — 9 new unit tests cover default URL, trailing-slash + custom `contentBasePath`, query-param forwarding, payload → enrichment mapping, slot-availability merge, 404/503 → null, one-time 404 warn, non-404 server errors throw, slot loader failures tolerated.
- [x] `pnpm -F @voyantjs/catalog-ui typecheck`
- [x] `pnpm -F operator typecheck`
- [x] `pnpm -F @voyantjs/catalog-ui lint`
- [ ] Manual: open the operator catalog detail sheet, confirm content + departures + slot availability still render. (Local dev — best validated by the maintainer who can hit a real DB.)