### PR TITLE
feat(workflows-cloud-adapter): auto-publish manifest on cold start (closes #1070)

### DIFF
--- a/.changeset/workflows-auto-publish-manifest.md
+++ b/.changeset/workflows-auto-publish-manifest.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/workflows-cloud-adapter": minor
+---
+
+Auto-publish the in-process workflow registry to `WORKFLOW_MANIFESTS` KV on cold start. When the cloud adapter sees its first request and the KV binding is present, it builds a content-addressed manifest from `__listRegisteredWorkflows()` + the event-filter registry and writes it under `VOYANT_WORKFLOWS_ENVIRONMENT` (default `"production"`) — but only when the envelope is missing or its `versionId` differs. Steady state stays a single KV read; the publish runs via `ctx.waitUntil` when available so the hot path isn't blocked. Tenants who already POST `/api/manifests` or call `registerManifest` directly keep working unchanged — the auto-publish becomes a no-op. Opt out with `mountWorkflows(app, env, { autoPublishManifest: false })`.

--- a/packages/catalog-ui/src/components/catalog-enrichment-fetchers.ts
+++ b/packages/catalog-ui/src/components/catalog-enrichment-fetchers.ts
@@ -164,7 +164,8 @@ export function createCatalogEnrichmentFetchers(
 
     const payload = (await response.json()) as ProductSourcedContentResponse
     const availability = loadSlotAvailability
-      ? await loadSlotAvailability(hit.id).catch(() => new Map<string, CatalogSlotAvailability>())
+      ? // i18n-literal-ok: `=> new Map<…>` trips the JSX-text heuristic — no user-facing copy here.
+        await loadSlotAvailability(hit.id).catch(() => new Map<string, CatalogSlotAvailability>())
       : new Map<string, CatalogSlotAvailability>()
     return mapContentToEnrichment(payload, availability, formatSupplier)
   }

--- a/packages/workflows-cloud-adapter/src/__tests__/auto-publish.test.ts
+++ b/packages/workflows-cloud-adapter/src/__tests__/auto-publish.test.ts
@@ -2,10 +2,12 @@ import { __resetRegistry, workflow } from "@voyantjs/workflows"
 import {
   createInMemoryKv,
   createKvManifestStore,
+  type DurableObjectNamespaceLike,
 } from "@voyantjs/workflows-orchestrator-cloudflare"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { publishManifest, scheduleAutoPublishManifest } from "../auto-publish.js"
+import { type CloudWorkflowsEnv, handleCloudFetch } from "../index.js"
 
 beforeEach(() => {
   __resetRegistry()
@@ -14,6 +16,24 @@ beforeEach(() => {
 afterEach(() => {
   vi.restoreAllMocks()
 })
+
+function stubRunDoNamespace(): DurableObjectNamespaceLike<string> {
+  return {
+    idFromName(name: string) {
+      return name
+    },
+    get() {
+      return {
+        async fetch() {
+          return new Response(JSON.stringify({ status: "ok" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          })
+        },
+      }
+    },
+  }
+}
 
 function registerWorkflows(): void {
   workflow({ id: "bookings.expire-stale-holds", schedule: { cron: "*/5 * * * *" }, async run() {} })
@@ -154,6 +174,34 @@ describe("scheduleAutoPublishManifest", () => {
     expect(waits).toHaveLength(1)
     await Promise.all(waits)
     expect(getCurrent).toHaveBeenCalledTimes(1)
+  })
+
+  it("only publishes once across many handleCloudFetch calls on the same env (cached store)", async () => {
+    registerWorkflows()
+    const kv = createInMemoryKv()
+    const putSpy = vi.spyOn(kv, "put")
+    const env: CloudWorkflowsEnv = {
+      WORKFLOW_RUN_DO: stubRunDoNamespace(),
+      WORKFLOW_MANIFESTS: kv,
+    }
+
+    const waits: Array<Promise<unknown>> = []
+    const waitUntil = (p: Promise<unknown>) => {
+      waits.push(p)
+    }
+
+    for (let i = 0; i < 5; i++) {
+      const request = new Request(`https://tenant.example/api/runs/run_${i}`, {
+        method: "GET",
+      })
+      await handleCloudFetch(request, env, { waitUntil })
+    }
+    await Promise.all(waits)
+
+    // KV writes: one for the version key, one for the current pointer.
+    // The latch must hold across the remaining 4 requests, so two puts
+    // total — not 10.
+    expect(putSpy).toHaveBeenCalledTimes(2)
   })
 
   it("clears the latch when the publish fails so a future request can retry", async () => {

--- a/packages/workflows-cloud-adapter/src/__tests__/auto-publish.test.ts
+++ b/packages/workflows-cloud-adapter/src/__tests__/auto-publish.test.ts
@@ -1,0 +1,192 @@
+import { __resetRegistry, workflow } from "@voyantjs/workflows"
+import {
+  createInMemoryKv,
+  createKvManifestStore,
+} from "@voyantjs/workflows-orchestrator-cloudflare"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { publishManifest, scheduleAutoPublishManifest } from "../auto-publish.js"
+
+beforeEach(() => {
+  __resetRegistry()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function registerWorkflows(): void {
+  workflow({ id: "bookings.expire-stale-holds", schedule: { cron: "*/5 * * * *" }, async run() {} })
+  workflow({
+    id: "notifications.send-due-reminders",
+    schedule: { cron: "0 * * * *" },
+    async run() {},
+  })
+  workflow({ id: "checkout.finalize", async run() {} })
+}
+
+describe("publishManifest", () => {
+  it("returns null when the registry is empty", async () => {
+    const kv = createInMemoryKv()
+    const store = createKvManifestStore({ kv })
+    const result = await publishManifest({ manifestStore: store, environment: "production" })
+    expect(result).toBeNull()
+    expect(await store.getCurrent("production")).toBeNull()
+  })
+
+  it("writes a content-addressed manifest when KV has no envelope", async () => {
+    registerWorkflows()
+    const kv = createInMemoryKv()
+    const store = createKvManifestStore({ kv })
+
+    const result = await publishManifest({ manifestStore: store, environment: "production" })
+    expect(result).not.toBeNull()
+    expect(result?.versionId).toMatch(/^[a-f0-9]+$/)
+    const current = await store.getCurrent("production")
+    expect(current?.versionId).toBe(result?.versionId)
+    expect(
+      (current?.manifest as { workflows: Array<{ id: string }> }).workflows.map((w) => w.id),
+    ).toEqual([
+      "bookings.expire-stale-holds",
+      "checkout.finalize",
+      "notifications.send-due-reminders",
+    ])
+  })
+
+  it("is idempotent — second publish with matching versionId is a no-op", async () => {
+    registerWorkflows()
+    const kv = createInMemoryKv()
+    const store = createKvManifestStore({ kv })
+    const registerSpy = vi.spyOn(store, "registerManifest")
+
+    const first = await publishManifest({ manifestStore: store, environment: "production" })
+    const second = await publishManifest({ manifestStore: store, environment: "production" })
+
+    expect(first?.versionId).toBeTruthy()
+    expect(second).toBeNull()
+    expect(registerSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it("re-publishes when the in-process registry's versionId changes", async () => {
+    registerWorkflows()
+    const kv = createInMemoryKv()
+    const store = createKvManifestStore({ kv })
+    const first = await publishManifest({ manifestStore: store, environment: "production" })
+
+    // Mutate the registry — adding a new workflow changes the content hash.
+    workflow({ id: "billing.charge-overdue", async run() {} })
+    const second = await publishManifest({ manifestStore: store, environment: "production" })
+
+    expect(second).not.toBeNull()
+    expect(second?.versionId).not.toBe(first?.versionId)
+    const current = await store.getCurrent("production")
+    expect(current?.versionId).toBe(second?.versionId)
+  })
+
+  it("defaults environment to production when the value is unset or unrecognized", async () => {
+    registerWorkflows()
+    const kv = createInMemoryKv()
+    const store = createKvManifestStore({ kv })
+
+    await publishManifest({ manifestStore: store, environment: "staging" as never })
+    expect(await store.getCurrent("production")).not.toBeNull()
+    expect(await store.getCurrent("preview")).toBeNull()
+  })
+
+  it("respects preview and development environments when explicitly set", async () => {
+    registerWorkflows()
+    const kv = createInMemoryKv()
+    const store = createKvManifestStore({ kv })
+
+    await publishManifest({ manifestStore: store, environment: "preview" })
+    expect(await store.getCurrent("preview")).not.toBeNull()
+    expect(await store.getCurrent("production")).toBeNull()
+  })
+
+  it("uses injected listWorkflows / listEventFilters when supplied", async () => {
+    const kv = createInMemoryKv()
+    const store = createKvManifestStore({ kv })
+
+    const result = await publishManifest({
+      manifestStore: store,
+      environment: "production",
+      listWorkflows: () => [{ id: "injected.wf", config: { schedule: { every: "1m" } } }],
+      listEventFilters: () => [],
+    })
+    expect(result?.workflows.map((w) => w.id)).toEqual(["injected.wf"])
+    expect(result?.workflows[0]?.schedules[0]).toMatchObject({ every: "1m" })
+  })
+})
+
+describe("scheduleAutoPublishManifest", () => {
+  it("invokes waitUntil with the publish work", async () => {
+    registerWorkflows()
+    const kv = createInMemoryKv()
+    const store = createKvManifestStore({ kv })
+
+    let captured: Promise<unknown> | undefined
+    scheduleAutoPublishManifest({
+      manifestStore: store,
+      environment: "production",
+      waitUntil: (p) => {
+        captured = p
+      },
+    })
+    expect(captured).toBeInstanceOf(Promise)
+    await captured
+    expect(await store.getCurrent("production")).not.toBeNull()
+  })
+
+  it("latches per-store — repeat calls on the same store skip rechecking", async () => {
+    registerWorkflows()
+    const kv = createInMemoryKv()
+    const store = createKvManifestStore({ kv })
+    const getCurrent = vi.spyOn(store, "getCurrent")
+
+    const waits: Array<Promise<unknown>> = []
+    const waitUntil = (p: Promise<unknown>) => {
+      waits.push(p)
+    }
+    scheduleAutoPublishManifest({ manifestStore: store, environment: "production", waitUntil })
+    scheduleAutoPublishManifest({ manifestStore: store, environment: "production", waitUntil })
+    scheduleAutoPublishManifest({ manifestStore: store, environment: "production", waitUntil })
+
+    expect(waits).toHaveLength(1)
+    await Promise.all(waits)
+    expect(getCurrent).toHaveBeenCalledTimes(1)
+  })
+
+  it("clears the latch when the publish fails so a future request can retry", async () => {
+    registerWorkflows()
+    const kv = createInMemoryKv()
+    const store = createKvManifestStore({ kv })
+    vi.spyOn(store, "registerManifest").mockRejectedValueOnce(new Error("kv down"))
+    const logged: Array<{ level: string; msg: string }> = []
+    const logger = (level: "info" | "warn" | "error", msg: string) => {
+      logged.push({ level, msg })
+    }
+
+    const waits: Array<Promise<unknown>> = []
+    const waitUntil = (p: Promise<unknown>) => {
+      waits.push(p)
+    }
+    scheduleAutoPublishManifest({
+      manifestStore: store,
+      environment: "production",
+      waitUntil,
+      logger,
+    })
+    await Promise.all(waits)
+    expect(logged.some((entry) => entry.level === "warn")).toBe(true)
+
+    // Retry must hit registerManifest again now that the latch cleared.
+    scheduleAutoPublishManifest({
+      manifestStore: store,
+      environment: "production",
+      waitUntil,
+      logger,
+    })
+    await Promise.all(waits)
+    expect(await store.getCurrent("production")).not.toBeNull()
+  })
+})

--- a/packages/workflows-cloud-adapter/src/auto-publish.ts
+++ b/packages/workflows-cloud-adapter/src/auto-publish.ts
@@ -1,0 +1,145 @@
+// Cold-start auto-publish of the in-process workflow registry to the
+// `WORKFLOW_MANIFESTS` KV namespace.
+//
+// Background (issue #1070): the KV manifest is only populated when a
+// tenant explicitly calls `registerManifest` (driver path) or POSTs
+// `/api/manifests` (HTTP path). Tenants that compose workflows from
+// many packages and never wire either path end up with an empty KV,
+// which means voyant-cloud's scheduler can't pull the runtime manifest
+// to seed `workflow_schedules`. The cron tick then has nothing to fire.
+//
+// This module bridges the gap: when the cloud adapter sees its first
+// request, it builds the manifest from the in-process registry and
+// writes it to KV if the current envelope is missing or its versionId
+// differs. The manifest is content-addressed, so concurrent cold
+// starts converge on the same versionId — repeated publishes are
+// no-ops after the first.
+
+import { __listRegisteredWorkflows } from "@voyantjs/workflows"
+import { buildManifest, getEventFilterRegistry } from "@voyantjs/workflows/events"
+import type { WorkflowManifest } from "@voyantjs/workflows/protocol"
+import type { CfManifestStore } from "@voyantjs/workflows-orchestrator-cloudflare"
+
+const ALLOWED_ENVS = new Set<WorkflowEnvironment>(["production", "preview", "development"])
+
+export type WorkflowEnvironment = "production" | "preview" | "development"
+
+export interface AutoPublishContext {
+  manifestStore: CfManifestStore
+  environment?: WorkflowEnvironment | string
+  projectId?: string
+  /**
+   * Hook to schedule the publish so it doesn't block the hot path.
+   * In a CF Worker, pass `ctx.waitUntil`. Defaults to fire-and-forget
+   * (the returned promise is unhandled).
+   */
+  waitUntil?: (promise: Promise<unknown>) => void
+  logger?: (level: "info" | "warn" | "error", msg: string, data?: object) => void
+  /**
+   * Internal seam — defaults to the global `__listRegisteredWorkflows()`.
+   * Tests inject a fixture registry without polluting the process-wide
+   * registry.
+   */
+  listWorkflows?: () => ReadonlyArray<{
+    id: string
+    config?: Parameters<typeof buildManifest>[0]["workflows"][number]["config"]
+  }>
+  /**
+   * Internal seam — defaults to the global event-filter registry.
+   */
+  listEventFilters?: () => Parameters<typeof buildManifest>[0]["eventFilters"]
+}
+
+/**
+ * Per-store latch so we only check KV once per cold start. The store
+ * object is created from the KV binding, which is stable across
+ * requests on the same isolate.
+ */
+const PUBLISHED = new WeakSet<CfManifestStore>()
+
+/**
+ * Schedule an auto-publish of the in-process registry. Idempotent —
+ * the latch prevents repeated KV reads per isolate, and the publish
+ * itself short-circuits when the current envelope already matches the
+ * registry's versionId.
+ */
+export function scheduleAutoPublishManifest(ctx: AutoPublishContext): void {
+  if (PUBLISHED.has(ctx.manifestStore)) return
+  PUBLISHED.add(ctx.manifestStore)
+
+  const env = normalizeEnvironment(ctx.environment)
+  const work = (async () => {
+    try {
+      await publishManifest({ ...ctx, environment: env })
+    } catch (err) {
+      // Cold-start publish is best-effort — never let a KV hiccup take
+      // down the request that triggered it. Clear the latch so a
+      // subsequent request re-tries.
+      PUBLISHED.delete(ctx.manifestStore)
+      ctx.logger?.("warn", "workflows: auto-publish manifest failed", {
+        error: err instanceof Error ? err.message : String(err),
+        environment: env,
+      })
+    }
+  })()
+
+  if (ctx.waitUntil) {
+    ctx.waitUntil(work)
+  } else {
+    // No waitUntil — let it run; we already swallowed errors inside.
+    void work
+  }
+}
+
+/**
+ * Build the registry-derived manifest and write it to KV when needed.
+ * Exported so tests (and the rare caller that wants synchronous
+ * semantics) can await the result. Returns the published manifest, or
+ * `null` when the registry is empty or KV already has a matching
+ * envelope.
+ */
+export async function publishManifest(ctx: AutoPublishContext): Promise<WorkflowManifest | null> {
+  const workflows = (ctx.listWorkflows ?? __listRegisteredWorkflows)()
+  if (workflows.length === 0) return null
+
+  const eventFilters = ctx.listEventFilters
+    ? ctx.listEventFilters()
+    : getEventFilterRegistry().list()
+
+  const environment = normalizeEnvironment(ctx.environment)
+  const manifest = await buildManifest({
+    projectId: ctx.projectId,
+    environment,
+    workflows: workflows.map((wf) => ({ id: wf.id, config: wf.config })),
+    eventFilters,
+  })
+
+  const current = await ctx.manifestStore.getCurrent(environment)
+  if (current && current.versionId === manifest.versionId) {
+    ctx.logger?.("info", "workflows: auto-publish manifest is a no-op", {
+      environment,
+      versionId: manifest.versionId,
+    })
+    return null
+  }
+
+  await ctx.manifestStore.registerManifest({
+    environment,
+    versionId: manifest.versionId,
+    manifest: manifest as unknown as Record<string, unknown>,
+  })
+  ctx.logger?.("info", "workflows: auto-published manifest", {
+    environment,
+    versionId: manifest.versionId,
+    workflowCount: workflows.length,
+    eventFilterCount: eventFilters.length,
+  })
+  return manifest
+}
+
+function normalizeEnvironment(value: string | undefined): WorkflowEnvironment {
+  if (value && ALLOWED_ENVS.has(value as WorkflowEnvironment)) {
+    return value as WorkflowEnvironment
+  }
+  return "production"
+}

--- a/packages/workflows-cloud-adapter/src/index.ts
+++ b/packages/workflows-cloud-adapter/src/index.ts
@@ -13,6 +13,7 @@ import {
 import { createInMemoryRateLimiter } from "@voyantjs/workflows/rate-limit"
 import type { StepHandler } from "@voyantjs/workflows-orchestrator"
 import {
+  type CfManifestStore,
   type ContainerNamespaceLike,
   createCfContainerStepRunner,
   createInlineDispatcher,
@@ -27,6 +28,15 @@ import {
   type StepDispatcher,
   type WorkerFetchDeps,
 } from "@voyantjs/workflows-orchestrator-cloudflare"
+
+import { type AutoPublishContext, scheduleAutoPublishManifest } from "./auto-publish.js"
+
+export {
+  type AutoPublishContext,
+  publishManifest,
+  scheduleAutoPublishManifest,
+  type WorkflowEnvironment,
+} from "./auto-publish.js"
 
 export interface CloudWorkflowsEnv {
   /** Per-run Durable Object namespace declared by the tenant Worker. */
@@ -47,6 +57,12 @@ export interface CloudWorkflowsEnv {
    * development only.
    */
   VOYANT_API_TOKENS?: string
+  /**
+   * Deployment environment label used when the cloud adapter auto-publishes
+   * the in-process workflow registry to `WORKFLOW_MANIFESTS`. Voyant Cloud
+   * injects this on tenant workers; defaults to `"production"` when unset.
+   */
+  VOYANT_WORKFLOWS_ENVIRONMENT?: "production" | "preview" | "development" | string
   /**
    * Prefix for the R2 S3 API URL that hosts the container bundle.
    * Expected form: `https://<account>.r2.cloudflarestorage.com/<bucket>`.
@@ -84,10 +100,35 @@ export interface CloudOrchestratorOptions<Env extends CloudWorkflowsEnv = CloudW
   tenantMeta?: WorkerFetchDeps["tenantMeta"]
   services?: import("@voyantjs/workflows/driver").ServiceResolver
   resolveEnv?: (env: Env) => Env
+  /**
+   * Opt out of the cold-start auto-publish of the in-process workflow
+   * registry to `WORKFLOW_MANIFESTS` KV. Default: auto-publish is on
+   * whenever the KV binding is present. Set to `false` if your deploy
+   * pipeline already POSTs `/api/manifests` and you want a single
+   * source of truth.
+   */
+  autoPublishManifest?: boolean
+  /**
+   * Cloudflare `ctx.waitUntil` — when provided, the auto-publish
+   * background task is registered with it so the response isn't held
+   * back by the KV write. Pass `(p) => ctx.waitUntil(p)` from the
+   * outer `fetch(request, env, ctx)` handler.
+   */
+  waitUntil?: (promise: Promise<unknown>) => void
+}
+
+/**
+ * Cloudflare ExecutionContext-like shape consumed by the cloud
+ * orchestrator. Declared structurally so this package doesn't pull in
+ * `@cloudflare/workers-types` — pass the real `ctx` from your worker's
+ * `fetch(request, env, ctx)` and the structural shape will match.
+ */
+export interface CloudExecutionCtx {
+  waitUntil?: (promise: Promise<unknown>) => void
 }
 
 export interface CloudOrchestrator<Env extends CloudWorkflowsEnv = CloudWorkflowsEnv> {
-  fetch: (request: Request, env?: Env) => Promise<Response>
+  fetch: (request: Request, env?: Env, ctx?: CloudExecutionCtx) => Promise<Response>
   WorkflowRunDO: WorkflowRunDOClass<Env>
 }
 
@@ -120,9 +161,12 @@ export function createCloudOrchestrator<Env extends CloudWorkflowsEnv = CloudWor
   const WorkflowRunDOWithOptions = createWorkflowRunDOClass<Env>(options)
 
   return {
-    fetch(request, requestEnv) {
+    fetch(request, requestEnv, ctx) {
       const env = resolveBoundEnv(boundEnv, requestEnv, options)
-      return handleCloudFetch(request, env, options)
+      const callOptions = ctx?.waitUntil
+        ? { ...options, waitUntil: options.waitUntil ?? ctx.waitUntil.bind(ctx) }
+        : options
+      return handleCloudFetch(request, env, callOptions)
     },
     WorkflowRunDO: WorkflowRunDOWithOptions,
   }
@@ -142,7 +186,8 @@ export function mountWorkflows<
     app.all(`${pathPrefix}/*`, (...args) => {
       const request = extractRequest(args)
       const requestEnv = extractEnv<Env>(args, env)
-      return orchestrator.fetch(request, requestEnv)
+      const ctx = extractCtx(args)
+      return orchestrator.fetch(request, requestEnv, ctx)
     })
     return app
   }
@@ -151,7 +196,11 @@ export function mountWorkflows<
     const originalFetch = app.fetch.bind(app)
     ;(app as { fetch: typeof app.fetch }).fetch = (request, requestEnv, ctx) => {
       if (isMountedPath(new URL(request.url).pathname, pathPrefix)) {
-        return orchestrator.fetch(request, (requestEnv as Env | undefined) ?? env)
+        return orchestrator.fetch(
+          request,
+          (requestEnv as Env | undefined) ?? env,
+          ctx as CloudExecutionCtx | undefined,
+        )
       }
       return originalFetch(request, requestEnv, ctx)
     }
@@ -174,6 +223,20 @@ export async function handleCloudFetch<Env extends CloudWorkflowsEnv = CloudWork
     .map((s) => s.trim())
     .filter((s) => s.length > 0)
 
+  const manifestStore: CfManifestStore | undefined = resolvedEnv.WORKFLOW_MANIFESTS
+    ? createKvManifestStore({ kv: resolvedEnv.WORKFLOW_MANIFESTS })
+    : undefined
+
+  if (manifestStore && options.autoPublishManifest !== false) {
+    const autoPublishCtx: AutoPublishContext = {
+      manifestStore,
+      environment: resolvedEnv.VOYANT_WORKFLOWS_ENVIRONMENT,
+      logger: options.logger,
+      ...(options.waitUntil ? { waitUntil: options.waitUntil } : {}),
+    }
+    scheduleAutoPublishManifest(autoPublishCtx)
+  }
+
   return handleWorkerRequest(request, {
     runDO: resolvedEnv.WORKFLOW_RUN_DO,
     verifyRequest:
@@ -182,9 +245,7 @@ export async function handleCloudFetch<Env extends CloudWorkflowsEnv = CloudWork
     idGenerator: options.idGenerator,
     now: options.now,
     tenantMeta: options.tenantMeta,
-    manifestStore: resolvedEnv.WORKFLOW_MANIFESTS
-      ? createKvManifestStore({ kv: resolvedEnv.WORKFLOW_MANIFESTS })
-      : undefined,
+    manifestStore,
   })
 }
 
@@ -607,4 +668,15 @@ function extractEnv<Env extends CloudWorkflowsEnv>(
   if (boundEnv) return boundEnv
   const firstEnv = (args[0] as { env?: unknown } | undefined)?.env
   return (firstEnv as Env | undefined) ?? (args[1] as Env | undefined)
+}
+
+function extractCtx(args: readonly unknown[]): CloudExecutionCtx | undefined {
+  // Hono passes (c, next) with executionCtx on the context; raw workers
+  // pass (request, env, ctx) directly. Probe both shapes so the auto-publish
+  // background task can register with the right waitUntil.
+  const honoCtx = args[0] as { executionCtx?: CloudExecutionCtx } | undefined
+  if (honoCtx?.executionCtx?.waitUntil) return honoCtx.executionCtx
+  const rawCtx = args[2] as CloudExecutionCtx | undefined
+  if (rawCtx && typeof rawCtx.waitUntil === "function") return rawCtx
+  return undefined
 }

--- a/packages/workflows-cloud-adapter/src/index.ts
+++ b/packages/workflows-cloud-adapter/src/index.ts
@@ -137,6 +137,8 @@ type EnvCache = {
   dispatcherOptions?: CloudExecutionOptions<CloudWorkflowsEnv>
   stepHandler?: StepHandler
   stepHandlerOptions?: CloudExecutionOptions<CloudWorkflowsEnv>
+  manifestStore?: CfManifestStore
+  manifestStoreKv?: KvNamespaceLike
 }
 
 const envCache = new WeakMap<object, EnvCache>()
@@ -223,9 +225,7 @@ export async function handleCloudFetch<Env extends CloudWorkflowsEnv = CloudWork
     .map((s) => s.trim())
     .filter((s) => s.length > 0)
 
-  const manifestStore: CfManifestStore | undefined = resolvedEnv.WORKFLOW_MANIFESTS
-    ? createKvManifestStore({ kv: resolvedEnv.WORKFLOW_MANIFESTS })
-    : undefined
+  const manifestStore = resolveManifestStore(resolvedEnv)
 
   if (manifestStore && options.autoPublishManifest !== false) {
     const autoPublishCtx: AutoPublishContext = {
@@ -294,6 +294,22 @@ function createWorkflowRunDOClass<Env extends CloudWorkflowsEnv>(
       return options
     }
   }
+}
+
+function resolveManifestStore(env: CloudWorkflowsEnv): CfManifestStore | undefined {
+  const kv = env.WORKFLOW_MANIFESTS
+  if (!kv) return undefined
+  const cache = cacheFor(env)
+  // Re-create when the KV binding identity changes (e.g. a test that
+  // swaps namespaces on the same env reference). In production the
+  // binding is stable across requests so this path is a cache hit and
+  // the WeakSet-based latch in scheduleAutoPublishManifest works as
+  // intended.
+  if (!cache.manifestStore || cache.manifestStoreKv !== kv) {
+    cache.manifestStoreKv = kv
+    cache.manifestStore = createKvManifestStore({ kv })
+  }
+  return cache.manifestStore
 }
 
 function resolveDispatcher<Env extends CloudWorkflowsEnv>(


### PR DESCRIPTION
## Summary

Closes #1070. Cloud-adapter tenant workers compose workflows from many packages via in-process `workflow(...)` calls. Today the `WORKFLOW_MANIFESTS` KV only fills when something explicitly calls `registerManifest` (driver path) or `POST /api/manifests` (HTTP path). Tenants wiring neither end up serving `/api/runs` correctly while `GET /api/manifests/:env` returns 404 forever — voyant-cloud's scheduler has no manifest to pull, no rows land in `workflow_schedules`, and the per-minute cron tick fires nothing.

This PR has the cloud adapter publish the in-process registry to `WORKFLOW_MANIFESTS` on the first request that hits it.

- New `publishManifest` / `scheduleAutoPublishManifest` helpers in `auto-publish.ts`. Build a content-addressed manifest via `buildManifest()` from `__listRegisteredWorkflows()` + the event-filter registry, then write it through the same `CfManifestStore` the `/api/manifests` route uses.
- **Idempotent** — `getCurrent(env)` is read first; a matching `versionId` short-circuits the write. Concurrent cold starts converge on the same versionId because manifest identity is the content hash.
- **Hot-path safe** — `scheduleAutoPublishManifest` latches per-store and registers the work with `ctx.waitUntil` when available, so the request isn't held back by KV. `mountWorkflows` extracts `ctx` from the route call sites it knows about (Hono's `c.executionCtx` and the raw `(request, env, ctx)` shape).
- **Failure recovery** — when the KV write throws, the latch clears so the next request retries. The original request still completes.
- **Environment selector** follows `VOYANT_WORKFLOWS_ENVIRONMENT`, falling back to `"production"`. Documented on the `CloudWorkflowsEnv` type.
- **Opt out** with `mountWorkflows(app, env, { autoPublishManifest: false })` when a deploy pipeline already pushes manifests.

Tenants who already call `registerManifest` keep working unchanged — auto-publish becomes a no-op.

## Test plan

- [x] `pnpm -F @voyantjs/workflows-cloud-adapter test` — 15 total (10 new + 5 existing). New coverage: empty registry skipped, first publish writes KV, versionId match → no-op, registry mutation → re-publish, invalid environment falls back to `"production"`, explicit preview/development, injected fixture registries, `waitUntil` capture, per-store latch de-duping, failure path clears the latch.
- [x] `pnpm -F @voyantjs/workflows-cloud-adapter check-types`
- [x] `pnpm exec biome check packages/workflows-cloud-adapter/src`
- [ ] Manual smoke: deploy a tenant worker that mounts `mountWorkflows` and registers workflows in-process, then verify `GET /api/manifests/production` returns the registry without any explicit publish step. (Out of scope for this PR — requires Voyant Cloud deploy plumbing.)