### PR TITLE
ci(release): publish to npm in release-assets workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,26 @@ jobs:
       - name: Build registry artifacts
         run: pnpm registry:build
 
+      # Rescue hatch for when the auto-release loop falls behind npm — devs
+      # land changesets faster than the release PR can merge, so the `release`
+      # job stays in "create release PR" mode and never publishes the
+      # version bumps that already shipped to main's package.json.
+      # `changeset publish` is a no-op for packages whose version is already
+      # on npm, so this is safe to re-run.
+      - name: Verify release train
+        run: pnpm verify:release-train
+
+      - name: Verify package exports
+        run: pnpm verify:package-exports
+
+      - name: Verify publish tarballs
+        env:
+          VOYANT_PACK_REUSE_DIST: "1"
+        run: pnpm verify:publish-tarballs
+
+      - name: Publish pending versions to npm
+        run: pnpm release
+
       - name: Determine release version
         id: version
         run: |


### PR DESCRIPTION
## Summary
Adds an `npm publish` step to the `workflow_dispatch` \"release_assets\" job so we can manually drain pending publishes when the auto-release loop falls behind.

The push-triggered \`release\` job gates the npm publish behind \"no releasable changesets remaining\". When devs land changesets faster than the release PR merges, every workflow run version-bumps + rolls a new release PR, but the previous version bumps never reach npm. Right now main is at **0.68.0** while npm sits at **0.66.6** — four un-published bumps.

`changeset publish` is a no-op for packages already on npm, so this step is safe to re-run. Pre-publish verifiers match the push-triggered `release` job's safety checks. Authentication uses the existing npm Trusted Publisher OIDC scaffold (`id-token: write` + `registry-url`) — no `NPM_TOKEN` needed.

## How to use
1. Merge this PR.
2. Actions → Release → Run workflow → toggle `release_assets: true`.
3. Workflow publishes any package whose `package.json` version is ahead of npm, tags `v0.68.0` (current main version), packages starter archives, and creates the GitHub release.
4. The job stays as a permanent rescue button — it only runs on manual dispatch with the flag set, never automatically.

## Test plan
- [ ] Merge, dispatch with `release_assets: true`.
- [ ] Verify `npm view @voyantjs/i18n version` reports 0.68.0 after run.
- [ ] Verify git tag `v0.68.0` and GitHub release `v0.68.0` exist.