### PR TITLE
fix(availability-ui): consume page filters server-side on list tabs (closes #1076)

### DIFF
--- a/.changeset/availability-page-list-server-filters.md
+++ b/.changeset/availability-page-list-server-filters.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/availability-ui": patch
+---
+
+Fix `AvailabilityPage` list tabs (Slots, Rules, Start Times, Closeouts, Pickup Points) rendering empty when the selected product's rows sit past the first paginated page. Pass the page's product/status/date/active filters through to `useRules`/`useStartTimes`/`useSlots`/`useCloseouts`/`usePickupPoints` so the server narrows the first 25 rows; client-side filters stay as the safety net for dimensions the API doesn't expose. Mirrors the overview-aggregate fix (#1047) but for list tabs (#1076).

--- a/packages/availability-ui/src/components/availability-page.tsx
+++ b/packages/availability-ui/src/components/availability-page.tsx
@@ -207,16 +207,38 @@ export function AvailabilityPage({
     AvailabilityPickupPointRow | undefined
   >()
 
+  const productIdFilter = productFilter === "all" ? undefined : productFilter
+  const slotStatusFilterParam = slotStatusFilter === "all" ? undefined : slotStatusFilter
+  const pickupPointActiveParam =
+    pickupPointActiveFilter === "all" ? undefined : pickupPointActiveFilter === "active"
+
   const productsQuery = useProducts({ search: productSearch || undefined, limit: 25, offset: 0 })
   const overviewQuery = useAvailabilityOverview({
-    productId: productFilter === "all" ? undefined : productFilter,
+    productId: productIdFilter,
     attentionLimit: 4,
   })
-  const rulesQuery = useRules({ limit: 25, offset: 0 })
-  const startTimesQuery = useStartTimes({ limit: 25, offset: 0 })
-  const slotsQuery = useSlots({ limit: 25, offset: 0 })
-  const closeoutsQuery = useCloseouts({ limit: 25, offset: 0 })
-  const pickupPointsQuery = usePickupPoints({ limit: 25, offset: 0 })
+  // Pass the page filters through to the hooks so the server narrows the
+  // first 25 rows to the selection. Without this the list tabs renders empty
+  // whenever the selected product/status/date's matching rows happen to sit
+  // past the first page (mirror of #1043, but for list tabs).
+  // Client-side filters below stay as the safety net for dimensions the API
+  // doesn't expose (rule/start-time `active`, closeout date range).
+  const rulesQuery = useRules({ limit: 25, offset: 0, productId: productIdFilter })
+  const startTimesQuery = useStartTimes({ limit: 25, offset: 0, productId: productIdFilter })
+  const slotsQuery = useSlots({
+    limit: 25,
+    offset: 0,
+    productId: productIdFilter,
+    status: slotStatusFilterParam,
+    startsAtFrom: slotDateRange?.from ?? undefined,
+  })
+  const closeoutsQuery = useCloseouts({ limit: 25, offset: 0, productId: productIdFilter })
+  const pickupPointsQuery = usePickupPoints({
+    limit: 25,
+    offset: 0,
+    productId: productIdFilter,
+    active: pickupPointActiveParam,
+  })
 
   const products = productsQuery.data?.data ?? []
   const rules = rulesQuery.data?.data ?? []

--- a/templates/dmc/src/components/voyant/availability/availability-page.tsx
+++ b/templates/dmc/src/components/voyant/availability/availability-page.tsx
@@ -112,12 +112,14 @@ export function AvailabilityPage({
     AvailabilityPickupPointRow | undefined
   >()
 
+  const productIdFilter = productFilter === "all" ? undefined : productFilter
+
   const productsQuery = useQuery(getAvailabilityProductsQueryOptions())
-  const rulesQuery = useQuery(getAvailabilityRulesQueryOptions())
-  const startTimesQuery = useQuery(getAvailabilityStartTimesQueryOptions())
-  const slotsQuery = useQuery(getAvailabilitySlotsQueryOptions())
-  const closeoutsQuery = useQuery(getAvailabilityCloseoutsQueryOptions())
-  const pickupPointsQuery = useQuery(getAvailabilityPickupPointsQueryOptions())
+  const rulesQuery = useQuery(getAvailabilityRulesQueryOptions(productIdFilter))
+  const startTimesQuery = useQuery(getAvailabilityStartTimesQueryOptions(productIdFilter))
+  const slotsQuery = useQuery(getAvailabilitySlotsQueryOptions(productIdFilter))
+  const closeoutsQuery = useQuery(getAvailabilityCloseoutsQueryOptions(productIdFilter))
+  const pickupPointsQuery = useQuery(getAvailabilityPickupPointsQueryOptions(productIdFilter))
 
   const products = productsQuery.data?.data ?? []
   const rules = rulesQuery.data?.data ?? []

--- a/templates/dmc/src/components/voyant/availability/availability-shared.tsx
+++ b/templates/dmc/src/components/voyant/availability/availability-shared.tsx
@@ -381,26 +381,30 @@ export const pickupPointColumns = (
   },
 ]
 
+// All wrappers accept an optional `productId` so the page can narrow the
+// server response to the selected product (issue #1076 sibling). Without
+// this, the hooks fetch the first 25 rows unfiltered and `.filter()` on
+// the client misses every product whose rows sit past page 1.
 export function getAvailabilityProductsQueryOptions() {
   return getProductsQueryOptionsBase(client, { limit: 25, offset: 0 })
 }
 
-export function getAvailabilityRulesQueryOptions() {
-  return getRulesQueryOptionsBase(client, { limit: 25, offset: 0 })
+export function getAvailabilityRulesQueryOptions(productId?: string) {
+  return getRulesQueryOptionsBase(client, { limit: 25, offset: 0, productId })
 }
 
-export function getAvailabilityStartTimesQueryOptions() {
-  return getStartTimesQueryOptionsBase(client, { limit: 25, offset: 0 })
+export function getAvailabilityStartTimesQueryOptions(productId?: string) {
+  return getStartTimesQueryOptionsBase(client, { limit: 25, offset: 0, productId })
 }
 
-export function getAvailabilitySlotsQueryOptions() {
-  return getSlotsQueryOptionsBase(client, { limit: 25, offset: 0 })
+export function getAvailabilitySlotsQueryOptions(productId?: string) {
+  return getSlotsQueryOptionsBase(client, { limit: 25, offset: 0, productId })
 }
 
-export function getAvailabilityCloseoutsQueryOptions() {
-  return getCloseoutsQueryOptionsBase(client, { limit: 25, offset: 0 })
+export function getAvailabilityCloseoutsQueryOptions(productId?: string) {
+  return getCloseoutsQueryOptionsBase(client, { limit: 25, offset: 0, productId })
 }
 
-export function getAvailabilityPickupPointsQueryOptions() {
-  return getPickupPointsQueryOptionsBase(client, { limit: 25, offset: 0 })
+export function getAvailabilityPickupPointsQueryOptions(productId?: string) {
+  return getPickupPointsQueryOptionsBase(client, { limit: 25, offset: 0, productId })
 }


### PR DESCRIPTION
## Summary
Closes #1076.

Mirror of #1047 (overview tile) but for the list tabs. The five list tabs on `AvailabilityPage` (Slots, Rules, Start Times, Closeouts, Pickup Points) were calling their hooks as `useXxx({ limit: 25, offset: 0 })` — no filters — and then narrowing the response client-side via `.filter(...)`. When the selected product's matching rows sat past the first 25, the tab rendered "No slots match the current filters." even though the overview tile correctly reported a positive count.

The hook contracts (`AvailabilitySlotsListFilters`, etc.) already supported `productId`, `status`, `startsAtFrom`, `active` — they just weren't being used.

## Changes

**`packages/availability-ui/src/components/availability-page.tsx`** — pass through to hooks:
- `useRules({ productId })`
- `useStartTimes({ productId })`
- `useSlots({ productId, status, startsAtFrom })`
- `useCloseouts({ productId })`
- `usePickupPoints({ productId, active })`

Client-side `.filter()` stays as the safety net for dimensions the API doesn't expose (rule/start-time `active`, closeout date range, slot date-range upper bound).

The `calendar` tab uses `filteredSlots` (downstream of the server-narrowed `slotsQuery`), so it's covered transitively.

**`templates/dmc/src/components/voyant/availability/availability-{page,shared}.tsx`** — same root cause in the DMC template's local copy of the page. The shared `getAvailability*QueryOptions` wrappers now accept an optional `productId`; the page passes the active filter through.

## Out of scope
- `templates/dmc/src/components/voyant/resources/resources-page.tsx` uses the same client-filter pattern but on `kindFilter`/`search` (not `productId`). Different filter set, different fix shape — worth a separate issue if it surfaces in practice.
- Pagination footers driving new `useXxx` calls per page (mentioned in #1076 as natural next step) — out of scope here.

## Test plan
- [ ] Operator availability page with ≥30 slots across multiple products; pick a product whose slots all sit past row 25 and confirm the Slots/Rules/Start Times/Closeouts/Pickup Points tabs render the matching rows.
- [ ] Same against DMC template.
- [x] `pnpm -F @voyantjs/availability-ui -F dmc typecheck`
- [x] `pnpm exec biome check` on edited files