### PR TITLE
fix(allocation): paymentStatus fallbacks + booking sequence + seat-view parity (closes #1079)

### DIFF
--- a/.changeset/allocation-payment-status-and-badges.md
+++ b/.changeset/allocation-payment-status-and-badges.md
@@ -1,0 +1,12 @@
+---
+"@voyantjs/availability": minor
+"@voyantjs/availability-react": minor
+"@voyantjs/allocation-ui": minor
+---
+
+Allocation chip polish:
+
+- **Fix #1079**: `derivePaymentStatus` now falls back to `bookings.paid_at` and the sum of paid `booking_payment_schedules` before declaring a booking unpaid via invoice math. Operators who bill via deposit milestones (or who confirm bookings without issuing an invoice) no longer see false-red allocation chips. Manifest SQL surfaces `paid_at`, `created_at`, and `schedules_paid_cents`; the rollup checks them in order before falling through to the legacy invoice rule.
+- **Booking sequence numbers**: each booking gets a slot-local 1-based ordinal (by `bookings.created_at`), surfaced on `AllocationManifestBooking` and `AllocationManifestTraveler` as `bookingSequence`. All chips for the same booking render with a `(N)` prefix so operators can scan the resource grid and spot at a glance which travelers belong together.
+- **Visible payment-status colors**: `paymentStatusChipClass` bumped from `/5 + /40` (basically invisible on dark themes) to `/20 + /70` plus an explicit text color. Lives in `slot-allocation-shared` so both the resource view and the seat view share the same look.
+- **Seat-view parity**: `VehicleSeatCell` now applies the payment-status color + tooltip and shows the `(N)` prefix on the occupant name. The booking ref click-through was already there; this aligns the rest of the affordances with the room view.

--- a/packages/allocation-ui/src/components/slot-allocation-resource-view.tsx
+++ b/packages/allocation-ui/src/components/slot-allocation-resource-view.tsx
@@ -47,7 +47,11 @@ import {
   groupResourcesBySubType,
   kindLabel,
 } from "./slot-allocation-model.js"
-import { AllocationColumn } from "./slot-allocation-shared.js"
+import {
+  AllocationColumn,
+  paymentStatusChipClass,
+  paymentStatusTooltip,
+} from "./slot-allocation-shared.js"
 
 export interface EditResourceInput {
   label: string | null
@@ -381,6 +385,11 @@ function TravelerChip({
       )}
       title={paymentStatusTooltip(traveler.paymentStatus, messages)}
     >
+      {traveler.bookingSequence > 0 ? (
+        <span className="text-muted-foreground tabular-nums" aria-hidden="true">
+          ({traveler.bookingSequence})
+        </span>
+      ) : null}
       <span className="truncate font-medium" title={sharingGroupLabel ?? undefined}>
         {traveler.fullName}
       </span>
@@ -407,29 +416,6 @@ function TravelerChip({
       </Button>
     </span>
   )
-}
-
-/**
- * Border + background tint that mirrors the booking's payment status:
- * red for unpaid, amber for partial, emerald for paid. Tailwind classes
- * are explicit (no template strings) so the v4 JIT scanner picks them up.
- */
-function paymentStatusChipClass(status: AllocationPaymentStatus): string {
-  switch (status) {
-    case "paid":
-      return "border-emerald-500/40 bg-emerald-500/5"
-    case "partial":
-      return "border-amber-500/40 bg-amber-500/5"
-    case "unpaid":
-      return "border-rose-500/40 bg-rose-500/5"
-  }
-}
-
-function paymentStatusTooltip(
-  status: AllocationPaymentStatus,
-  messages: ReturnType<typeof useAllocationUiMessagesOrDefault>,
-): string {
-  return messages.paymentStatusLabels?.[status] ?? status
 }
 
 function AssignTravelerPopover({

--- a/packages/allocation-ui/src/components/slot-allocation-seat-view.tsx
+++ b/packages/allocation-ui/src/components/slot-allocation-seat-view.tsx
@@ -29,7 +29,13 @@ import {
   seatName,
   seatRows,
 } from "./slot-allocation-model.js"
-import { AllocationColumn, SeatPositionBadge, TravelerTile } from "./slot-allocation-shared.js"
+import {
+  AllocationColumn,
+  paymentStatusChipClass,
+  paymentStatusTooltip,
+  SeatPositionBadge,
+  TravelerTile,
+} from "./slot-allocation-shared.js"
 
 export function VehicleSeatsView({
   seats,
@@ -167,14 +173,20 @@ function VehicleSeatCell({
 }) {
   const messages = useAllocationUiMessagesOrDefault()
   const [pickerOpen, setPickerOpen] = useState(false)
+  const occupiedClasses = occupant ? paymentStatusChipClass(occupant.paymentStatus) : null
   const cellClasses = cn(
     "flex min-h-24 flex-col rounded-md border bg-background p-2 text-left text-xs",
+    occupiedClasses,
     overflow ? "border-destructive bg-destructive/5" /* i18n-literal-ok CSS class token */ : null,
   )
 
   if (occupant) {
     return (
-      <div id={`seat:${seat.id}`} className={cellClasses}>
+      <div
+        id={`seat:${seat.id}`}
+        className={cellClasses}
+        title={paymentStatusTooltip(occupant.paymentStatus, messages)}
+      >
         <div className="flex items-start justify-between gap-2">
           <span className="font-medium">{seat.label ?? seatName(seat, messages)}</span>
           <SeatPositionBadge seat={seat} />
@@ -183,6 +195,11 @@ function VehicleSeatCell({
           <div className="flex items-center gap-1">
             {occupant.isLeadTraveler ? (
               <Crown className="size-3 text-amber-500" aria-label={messages.lead} />
+            ) : null}
+            {occupant.bookingSequence > 0 ? (
+              <span className="text-muted-foreground tabular-nums" aria-hidden="true">
+                ({occupant.bookingSequence})
+              </span>
             ) : null}
             <span className="truncate font-medium">{occupant.fullName}</span>
           </div>

--- a/packages/allocation-ui/src/components/slot-allocation-shared.tsx
+++ b/packages/allocation-ui/src/components/slot-allocation-shared.tsx
@@ -3,9 +3,10 @@
 import type {
   AllocationAuditLogEntry,
   AllocationManifestTraveler,
+  AllocationPaymentStatus,
   AllocationResource,
 } from "@voyantjs/availability-react"
-import { Badge, Card, CardContent, CardHeader, CardTitle } from "@voyantjs/ui/components"
+import { Badge, Card, CardContent, CardHeader, CardTitle, cn } from "@voyantjs/ui/components"
 import { Accessibility, CircleAlert, Crown, History, UtensilsCrossed } from "lucide-react"
 import type { ReactNode } from "react"
 
@@ -72,11 +73,22 @@ export function TravelerTile({
   const messages = useAllocationUiMessagesOrDefault()
 
   return (
-    <div className="group flex items-start justify-between gap-3 rounded-md border bg-background p-3 text-sm shadow-sm">
+    <div
+      className={cn(
+        "group flex items-start justify-between gap-3 rounded-md border bg-background p-3 text-sm shadow-sm",
+        paymentStatusChipClass(traveler.paymentStatus),
+      )}
+      title={paymentStatusTooltip(traveler.paymentStatus, messages)}
+    >
       <div className="min-w-0">
         <div className="flex min-w-0 flex-wrap items-center gap-1.5">
           {traveler.isLeadTraveler ? (
             <Crown className="size-3.5 text-amber-500" aria-label={messages.lead} />
+          ) : null}
+          {traveler.bookingSequence > 0 ? (
+            <span className="text-muted-foreground tabular-nums" aria-hidden="true">
+              ({traveler.bookingSequence})
+            </span>
           ) : null}
           <span className="truncate font-medium">{traveler.fullName}</span>
           {traveler.sharingGroupId ? (
@@ -239,4 +251,33 @@ function entryDetail(entry: AllocationAuditLogEntry) {
     return [after.sharingGroupId, after.label].filter(Boolean).join(" · ")
   }
   return JSON.stringify(after)
+}
+
+/**
+ * Border + background tint that mirrors the booking's payment status:
+ * red for unpaid, amber for partial, emerald for paid. Tailwind class
+ * names are written explicitly (no template strings) so the v4 JIT
+ * scanner picks them up.
+ *
+ * The saturation was bumped to `/20` background + `/70` border (from the
+ * earlier `/5` + `/40`) because the lower opacities rendered as no color
+ * on dark themes — the chips looked uncolored even though the helper
+ * was being applied.
+ */
+export function paymentStatusChipClass(status: AllocationPaymentStatus): string {
+  switch (status) {
+    case "paid":
+      return "border-emerald-500/70 bg-emerald-500/20 text-emerald-700 dark:text-emerald-200"
+    case "partial":
+      return "border-amber-500/70 bg-amber-500/20 text-amber-700 dark:text-amber-200"
+    case "unpaid":
+      return "border-rose-500/70 bg-rose-500/20 text-rose-700 dark:text-rose-200"
+  }
+}
+
+export function paymentStatusTooltip(
+  status: AllocationPaymentStatus,
+  messages: ReturnType<typeof useAllocationUiMessagesOrDefault>,
+): string {
+  return messages.paymentStatusLabels?.[status] ?? status
 }

--- a/packages/availability-react/src/schemas.ts
+++ b/packages/availability-react/src/schemas.ts
@@ -226,6 +226,13 @@ export const allocationManifestTravelerSchema = z.object({
   bookingId: z.string(),
   bookingNumber: z.string(),
   bookingStatus: z.string(),
+  /**
+   * Per-slot booking ordinal (1-based, ordered by booking createdAt). All
+   * travelers on the same booking share the same number so the operator
+   * can see at a glance which chips belong together. Defaults to 0 for
+   * back-compat when the server is older.
+   */
+  bookingSequence: z.number().int().nonnegative().default(0),
   paymentStatus: allocationPaymentStatusSchema.default("unpaid"),
   firstName: z.string(),
   lastName: z.string(),
@@ -250,6 +257,8 @@ export const allocationManifestBookingSchema = z.object({
   id: z.string(),
   bookingNumber: z.string(),
   status: z.string(),
+  /** Per-slot ordinal (1-based, by booking createdAt). */
+  bookingSequence: z.number().int().nonnegative().default(0),
   paymentStatus: allocationPaymentStatusSchema.default("unpaid"),
   contactFirstName: z.string().nullable(),
   contactLastName: z.string().nullable(),

--- a/packages/availability/src/service-allocation.ts
+++ b/packages/availability/src/service-allocation.ts
@@ -1131,104 +1131,174 @@ interface TravelerRow {
 }
 
 async function loadSlotBookingRows(db: PostgresJsDatabase, slotId: string): Promise<BookingRow[]> {
-  // `invoice_totals` and `schedule_totals` are LEFT JOIN aggregations that
+  // `invoices` and `booking_payment_schedules` are LEFT JOIN aggregations that
   // may reference tables missing in catalog-less / finance-less deploys.
-  // The retries below progressively drop joins that hit "undefined_table"
-  // (Postgres 42P01) so the manifest still loads with `unpaid` rollups —
-  // each fallback fills the missing fields with zeros (see issue #1079
-  // for the rationale on schedule_totals).
+  // We try four query shapes in order of decreasing data, falling through on
+  // any "undefined_table" (Postgres 42P01). The ordering matters: if invoices
+  // exists but schedules doesn't, we still want to preserve invoice data
+  // (and vice versa) — so we try the invoices-only and schedules-only paths
+  // separately rather than collapsing both joins together.
   try {
-    return await executeRows<BookingRow>(
-      db,
-      sql`
-      SELECT DISTINCT
-        b.id,
-        b.booking_number,
-        b.status,
-        b.created_at,
-        b.paid_at,
-        b.contact_first_name,
-        b.contact_last_name,
-        b.contact_email,
-        b.contact_phone,
-        b.sell_currency,
-        b.pax,
-        b.sell_amount_cents,
-        COALESCE(inv.total_cents, 0) AS invoice_total_cents,
-        COALESCE(inv.paid_cents, 0) AS invoice_paid_cents,
-        COALESCE(sch.paid_cents, 0) AS schedules_paid_cents
-      FROM bookings b
-      JOIN booking_allocations ba ON ba.booking_id = b.id
-      LEFT JOIN (
-        SELECT
-          booking_id,
-          SUM(total_cents) AS total_cents,
-          SUM(paid_cents) AS paid_cents
-        FROM invoices
-        WHERE status <> 'void'
-        GROUP BY booking_id
-      ) inv ON inv.booking_id = b.id
-      LEFT JOIN (
-        SELECT
-          booking_id,
-          SUM(amount_cents) AS paid_cents
-        FROM booking_payment_schedules
-        WHERE status = 'paid'
-        GROUP BY booking_id
-      ) sch ON sch.booking_id = b.id
-      WHERE ba.availability_slot_id = ${slotId}
-        AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
-        AND ba.status IN ('held', 'confirmed', 'fulfilled')
-      ORDER BY b.created_at, b.booking_number
-    `,
-    )
+    return await loadSlotBookingRowsBothJoins(db, slotId)
   } catch (error) {
     if (!isUndefinedTableError(error)) throw error
   }
 
-  // Retry without the schedules join (booking_payment_schedules missing).
+  // Drop the schedules join (preserves invoice rollups when schedules is missing).
   try {
-    return await executeRows<BookingRow>(
-      db,
-      sql`
-      SELECT DISTINCT
-        b.id,
-        b.booking_number,
-        b.status,
-        b.created_at,
-        b.paid_at,
-        b.contact_first_name,
-        b.contact_last_name,
-        b.contact_email,
-        b.contact_phone,
-        b.sell_currency,
-        b.pax,
-        b.sell_amount_cents,
-        COALESCE(inv.total_cents, 0) AS invoice_total_cents,
-        COALESCE(inv.paid_cents, 0) AS invoice_paid_cents,
-        0 AS schedules_paid_cents
-      FROM bookings b
-      JOIN booking_allocations ba ON ba.booking_id = b.id
-      LEFT JOIN (
-        SELECT
-          booking_id,
-          SUM(total_cents) AS total_cents,
-          SUM(paid_cents) AS paid_cents
-        FROM invoices
-        WHERE status <> 'void'
-        GROUP BY booking_id
-      ) inv ON inv.booking_id = b.id
-      WHERE ba.availability_slot_id = ${slotId}
-        AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
-        AND ba.status IN ('held', 'confirmed', 'fulfilled')
-      ORDER BY b.created_at, b.booking_number
-    `,
-    )
+    return await loadSlotBookingRowsInvoicesOnly(db, slotId)
   } catch (error) {
     if (!isUndefinedTableError(error)) throw error
   }
 
-  // Final fallback: invoices + schedules both missing — pure bookings query.
+  // Drop the invoices join (preserves schedule rollups when invoices is missing).
+  try {
+    return await loadSlotBookingRowsSchedulesOnly(db, slotId)
+  } catch (error) {
+    if (!isUndefinedTableError(error)) throw error
+  }
+
+  // Final fallback: both tables missing — bare bookings query.
+  return loadSlotBookingRowsBare(db, slotId)
+}
+
+async function loadSlotBookingRowsBothJoins(
+  db: PostgresJsDatabase,
+  slotId: string,
+): Promise<BookingRow[]> {
+  return executeRows<BookingRow>(
+    db,
+    sql`
+    SELECT DISTINCT
+      b.id,
+      b.booking_number,
+      b.status,
+      b.created_at,
+      b.paid_at,
+      b.contact_first_name,
+      b.contact_last_name,
+      b.contact_email,
+      b.contact_phone,
+      b.sell_currency,
+      b.pax,
+      b.sell_amount_cents,
+      COALESCE(inv.total_cents, 0) AS invoice_total_cents,
+      COALESCE(inv.paid_cents, 0) AS invoice_paid_cents,
+      COALESCE(sch.paid_cents, 0) AS schedules_paid_cents
+    FROM bookings b
+    JOIN booking_allocations ba ON ba.booking_id = b.id
+    LEFT JOIN (
+      SELECT
+        booking_id,
+        SUM(total_cents) AS total_cents,
+        SUM(paid_cents) AS paid_cents
+      FROM invoices
+      WHERE status <> 'void'
+      GROUP BY booking_id
+    ) inv ON inv.booking_id = b.id
+    LEFT JOIN (
+      SELECT
+        booking_id,
+        SUM(amount_cents) AS paid_cents
+      FROM booking_payment_schedules
+      WHERE status = 'paid'
+      GROUP BY booking_id
+    ) sch ON sch.booking_id = b.id
+    WHERE ba.availability_slot_id = ${slotId}
+      AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
+      AND ba.status IN ('held', 'confirmed', 'fulfilled')
+    ORDER BY b.created_at, b.booking_number
+  `,
+  )
+}
+
+async function loadSlotBookingRowsInvoicesOnly(
+  db: PostgresJsDatabase,
+  slotId: string,
+): Promise<BookingRow[]> {
+  return executeRows<BookingRow>(
+    db,
+    sql`
+    SELECT DISTINCT
+      b.id,
+      b.booking_number,
+      b.status,
+      b.created_at,
+      b.paid_at,
+      b.contact_first_name,
+      b.contact_last_name,
+      b.contact_email,
+      b.contact_phone,
+      b.sell_currency,
+      b.pax,
+      b.sell_amount_cents,
+      COALESCE(inv.total_cents, 0) AS invoice_total_cents,
+      COALESCE(inv.paid_cents, 0) AS invoice_paid_cents,
+      0 AS schedules_paid_cents
+    FROM bookings b
+    JOIN booking_allocations ba ON ba.booking_id = b.id
+    LEFT JOIN (
+      SELECT
+        booking_id,
+        SUM(total_cents) AS total_cents,
+        SUM(paid_cents) AS paid_cents
+      FROM invoices
+      WHERE status <> 'void'
+      GROUP BY booking_id
+    ) inv ON inv.booking_id = b.id
+    WHERE ba.availability_slot_id = ${slotId}
+      AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
+      AND ba.status IN ('held', 'confirmed', 'fulfilled')
+    ORDER BY b.created_at, b.booking_number
+  `,
+  )
+}
+
+async function loadSlotBookingRowsSchedulesOnly(
+  db: PostgresJsDatabase,
+  slotId: string,
+): Promise<BookingRow[]> {
+  return executeRows<BookingRow>(
+    db,
+    sql`
+    SELECT DISTINCT
+      b.id,
+      b.booking_number,
+      b.status,
+      b.created_at,
+      b.paid_at,
+      b.contact_first_name,
+      b.contact_last_name,
+      b.contact_email,
+      b.contact_phone,
+      b.sell_currency,
+      b.pax,
+      b.sell_amount_cents,
+      0 AS invoice_total_cents,
+      0 AS invoice_paid_cents,
+      COALESCE(sch.paid_cents, 0) AS schedules_paid_cents
+    FROM bookings b
+    JOIN booking_allocations ba ON ba.booking_id = b.id
+    LEFT JOIN (
+      SELECT
+        booking_id,
+        SUM(amount_cents) AS paid_cents
+      FROM booking_payment_schedules
+      WHERE status = 'paid'
+      GROUP BY booking_id
+    ) sch ON sch.booking_id = b.id
+    WHERE ba.availability_slot_id = ${slotId}
+      AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
+      AND ba.status IN ('held', 'confirmed', 'fulfilled')
+    ORDER BY b.created_at, b.booking_number
+  `,
+  )
+}
+
+async function loadSlotBookingRowsBare(
+  db: PostgresJsDatabase,
+  slotId: string,
+): Promise<BookingRow[]> {
   const rows = await executeRows<
     Omit<BookingRow, "invoice_total_cents" | "invoice_paid_cents" | "schedules_paid_cents">
   >(

--- a/packages/availability/src/service-allocation.ts
+++ b/packages/availability/src/service-allocation.ts
@@ -49,6 +49,13 @@ export interface AllocationManifestTraveler {
   bookingId: string
   bookingNumber: string
   bookingStatus: string
+  /**
+   * Per-slot booking ordinal (1-based) derived from each booking's
+   * createdAt. All travelers on the same booking share the same number,
+   * so the operator can scan the resource grid and spot at a glance
+   * which chips belong together.
+   */
+  bookingSequence: number
   /** Aggregated payment status of the parent booking (see derivePaymentStatus). */
   paymentStatus: AllocationPaymentStatus
   firstName: string
@@ -72,6 +79,8 @@ export interface AllocationManifestBooking {
   id: string
   bookingNumber: string
   status: string
+  /** Per-slot ordinal (1-based) by createdAt; same number as the travelers on this booking. */
+  bookingSequence: number
   /** Aggregated payment status of the booking (see derivePaymentStatus). */
   paymentStatus: AllocationPaymentStatus
   contactFirstName: string | null
@@ -138,6 +147,13 @@ export async function getSlotAllocationManifest(
   const bookingIds = bookingRows.map((row) => row.id)
   const travelerRows = await loadSlotTravelerRows(db, bookingIds)
   const bookingById = new Map(bookingRows.map((row) => [row.id, row]))
+  // Assign 1-based slot-local sequence by booking createdAt. The SQL above
+  // already orders by `created_at` then `booking_number`, so iterating in
+  // array order is the same as iterating in chronological order.
+  const sequenceByBookingId = new Map<string, number>()
+  for (const [index, row] of bookingRows.entries()) {
+    sequenceByBookingId.set(row.id, index + 1)
+  }
   const travelersByBooking = new Map<string, AllocationManifestTraveler[]>()
 
   for (const row of travelerRows) {
@@ -147,6 +163,7 @@ export async function getSlotAllocationManifest(
       bookingId: row.booking_id,
       bookingNumber: booking?.booking_number ?? "",
       bookingStatus: booking?.status ?? "unknown",
+      bookingSequence: sequenceByBookingId.get(row.booking_id) ?? 0,
       paymentStatus: booking ? derivePaymentStatus(booking) : "unpaid",
       firstName: row.first_name,
       lastName: row.last_name,
@@ -170,10 +187,11 @@ export async function getSlotAllocationManifest(
   }
 
   const bookings = bookingRows.map(
-    (row): AllocationManifestBooking => ({
+    (row, index): AllocationManifestBooking => ({
       id: row.id,
       bookingNumber: row.booking_number,
       status: row.status,
+      bookingSequence: index + 1,
       paymentStatus: derivePaymentStatus(row),
       contactFirstName: row.contact_first_name,
       contactLastName: row.contact_last_name,
@@ -1036,10 +1054,12 @@ function serializeSlot(slot: {
   }
 }
 
-interface BookingRow {
+export interface BookingRow {
   id: string
   booking_number: string
   status: string
+  created_at: string | Date | null
+  paid_at: string | Date | null
   contact_first_name: string | null
   contact_last_name: string | null
   contact_email: string | null
@@ -1049,30 +1069,46 @@ interface BookingRow {
   sell_amount_cents: number | null
   invoice_total_cents: number | null
   invoice_paid_cents: number | null
+  schedules_paid_cents: number | null
 }
 
 export type AllocationPaymentStatus = "paid" | "partial" | "unpaid"
 
 /**
- * Roll up a booking's invoices into a single paid / partial / unpaid
- * status for the allocation chip's color coding.
+ * Roll up a booking's payment state into a single paid / partial / unpaid
+ * status for the allocation chip's color coding. Signals checked in order:
  *
- *   - No invoices issued → `unpaid` (booking exists but hasn't been
- *     billed yet; operator has charged no money).
- *   - Free booking (sell amount 0) → `paid` (nothing owed).
- *   - All invoices fully paid → `paid`.
- *   - Some paid, some still due → `partial`.
- *   - Nothing paid → `unpaid`.
+ *   1. Free booking (`sell_amount_cents <= 0`) → `paid` (nothing owed).
+ *   2. `bookings.paid_at` is set → `paid` (operator marked the booking
+ *      settled; this is authoritative regardless of invoice plumbing).
+ *   3. Sum of `booking_payment_schedules.amount_cents WHERE status='paid'`
+ *      covers `sell_amount_cents` → `paid` (deposit-milestone flows that
+ *      never run a final invoice).
+ *   4. That schedule sum is positive → `partial`.
+ *   5. No invoices issued (`invoice_total_cents = 0`) → `unpaid`.
+ *   6. `invoice_paid_cents <= 0` → `unpaid`.
+ *   7. `invoice_paid_cents >= invoice_total_cents` → `paid`.
+ *   8. Otherwise → `partial`.
+ *
+ * The schedule and `paid_at` checks were added because the invoice-only
+ * rule mis-colored booked-and-settled trips as red whenever the operator
+ * billed via schedules without issuing an invoice, or recorded settlement
+ * on the schedule rather than a `payments` row (issue #1079).
  */
-function derivePaymentStatus(row: BookingRow): AllocationPaymentStatus {
+export function derivePaymentStatus(row: BookingRow): AllocationPaymentStatus {
   const sellAmount = row.sell_amount_cents ?? 0
   if (sellAmount <= 0) return "paid"
+  if (row.paid_at != null) return "paid"
+
+  const schedulesPaid = row.schedules_paid_cents ?? 0
+  if (schedulesPaid >= sellAmount) return "paid"
+
   const invoiceTotal = row.invoice_total_cents ?? 0
   const invoicePaid = row.invoice_paid_cents ?? 0
-  if (invoiceTotal === 0) return "unpaid"
-  if (invoicePaid <= 0) return "unpaid"
-  if (invoicePaid >= invoiceTotal) return "paid"
-  return "partial"
+  if (invoicePaid >= invoiceTotal && invoiceTotal > 0) return "paid"
+
+  if (schedulesPaid > 0 || invoicePaid > 0) return "partial"
+  return "unpaid"
 }
 
 interface TravelerRow {
@@ -1095,11 +1131,12 @@ interface TravelerRow {
 }
 
 async function loadSlotBookingRows(db: PostgresJsDatabase, slotId: string): Promise<BookingRow[]> {
-  // `invoice_totals` is a LEFT JOIN aggregation that may reference a
-  // missing `invoices` table in catalog-less / finance-less deploys —
-  // we'd want to silently fall back to `unpaid` for every booking
-  // rather than crash the manifest fetch. Hence the try / catch on
-  // `undefined_table` (Postgres 42P01) with a non-aggregating retry.
+  // `invoice_totals` and `schedule_totals` are LEFT JOIN aggregations that
+  // may reference tables missing in catalog-less / finance-less deploys.
+  // The retries below progressively drop joins that hit "undefined_table"
+  // (Postgres 42P01) so the manifest still loads with `unpaid` rollups —
+  // each fallback fills the missing fields with zeros (see issue #1079
+  // for the rationale on schedule_totals).
   try {
     return await executeRows<BookingRow>(
       db,
@@ -1108,6 +1145,8 @@ async function loadSlotBookingRows(db: PostgresJsDatabase, slotId: string): Prom
         b.id,
         b.booking_number,
         b.status,
+        b.created_at,
+        b.paid_at,
         b.contact_first_name,
         b.contact_last_name,
         b.contact_email,
@@ -1116,7 +1155,58 @@ async function loadSlotBookingRows(db: PostgresJsDatabase, slotId: string): Prom
         b.pax,
         b.sell_amount_cents,
         COALESCE(inv.total_cents, 0) AS invoice_total_cents,
-        COALESCE(inv.paid_cents, 0) AS invoice_paid_cents
+        COALESCE(inv.paid_cents, 0) AS invoice_paid_cents,
+        COALESCE(sch.paid_cents, 0) AS schedules_paid_cents
+      FROM bookings b
+      JOIN booking_allocations ba ON ba.booking_id = b.id
+      LEFT JOIN (
+        SELECT
+          booking_id,
+          SUM(total_cents) AS total_cents,
+          SUM(paid_cents) AS paid_cents
+        FROM invoices
+        WHERE status <> 'void'
+        GROUP BY booking_id
+      ) inv ON inv.booking_id = b.id
+      LEFT JOIN (
+        SELECT
+          booking_id,
+          SUM(amount_cents) AS paid_cents
+        FROM booking_payment_schedules
+        WHERE status = 'paid'
+        GROUP BY booking_id
+      ) sch ON sch.booking_id = b.id
+      WHERE ba.availability_slot_id = ${slotId}
+        AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
+        AND ba.status IN ('held', 'confirmed', 'fulfilled')
+      ORDER BY b.created_at, b.booking_number
+    `,
+    )
+  } catch (error) {
+    if (!isUndefinedTableError(error)) throw error
+  }
+
+  // Retry without the schedules join (booking_payment_schedules missing).
+  try {
+    return await executeRows<BookingRow>(
+      db,
+      sql`
+      SELECT DISTINCT
+        b.id,
+        b.booking_number,
+        b.status,
+        b.created_at,
+        b.paid_at,
+        b.contact_first_name,
+        b.contact_last_name,
+        b.contact_email,
+        b.contact_phone,
+        b.sell_currency,
+        b.pax,
+        b.sell_amount_cents,
+        COALESCE(inv.total_cents, 0) AS invoice_total_cents,
+        COALESCE(inv.paid_cents, 0) AS invoice_paid_cents,
+        0 AS schedules_paid_cents
       FROM bookings b
       JOIN booking_allocations ba ON ba.booking_id = b.id
       LEFT JOIN (
@@ -1131,35 +1221,46 @@ async function loadSlotBookingRows(db: PostgresJsDatabase, slotId: string): Prom
       WHERE ba.availability_slot_id = ${slotId}
         AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
         AND ba.status IN ('held', 'confirmed', 'fulfilled')
-      ORDER BY b.booking_number
+      ORDER BY b.created_at, b.booking_number
     `,
     )
   } catch (error) {
     if (!isUndefinedTableError(error)) throw error
-    const rows = await executeRows<Omit<BookingRow, "invoice_total_cents" | "invoice_paid_cents">>(
-      db,
-      sql`
-      SELECT DISTINCT
-        b.id,
-        b.booking_number,
-        b.status,
-        b.contact_first_name,
-        b.contact_last_name,
-        b.contact_email,
-        b.contact_phone,
-        b.sell_currency,
-        b.pax,
-        b.sell_amount_cents
-      FROM bookings b
-      JOIN booking_allocations ba ON ba.booking_id = b.id
-      WHERE ba.availability_slot_id = ${slotId}
-        AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
-        AND ba.status IN ('held', 'confirmed', 'fulfilled')
-      ORDER BY b.booking_number
-    `,
-    )
-    return rows.map((row) => ({ ...row, invoice_total_cents: 0, invoice_paid_cents: 0 }))
   }
+
+  // Final fallback: invoices + schedules both missing — pure bookings query.
+  const rows = await executeRows<
+    Omit<BookingRow, "invoice_total_cents" | "invoice_paid_cents" | "schedules_paid_cents">
+  >(
+    db,
+    sql`
+    SELECT DISTINCT
+      b.id,
+      b.booking_number,
+      b.status,
+      b.created_at,
+      b.paid_at,
+      b.contact_first_name,
+      b.contact_last_name,
+      b.contact_email,
+      b.contact_phone,
+      b.sell_currency,
+      b.pax,
+      b.sell_amount_cents
+    FROM bookings b
+    JOIN booking_allocations ba ON ba.booking_id = b.id
+    WHERE ba.availability_slot_id = ${slotId}
+      AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
+      AND ba.status IN ('held', 'confirmed', 'fulfilled')
+    ORDER BY b.created_at, b.booking_number
+  `,
+  )
+  return rows.map((row) => ({
+    ...row,
+    invoice_total_cents: 0,
+    invoice_paid_cents: 0,
+    schedules_paid_cents: 0,
+  }))
 }
 
 function isUndefinedTableError(error: unknown): boolean {

--- a/packages/availability/tests/unit/derive-payment-status.test.ts
+++ b/packages/availability/tests/unit/derive-payment-status.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest"
+
+import { type BookingRow, derivePaymentStatus } from "../../src/service-allocation.js"
+
+function bookingRow(overrides: Partial<BookingRow> = {}): BookingRow {
+  return {
+    id: "book_1",
+    booking_number: "B-001",
+    status: "confirmed",
+    created_at: "2026-05-22T08:00:00.000Z",
+    paid_at: null,
+    contact_first_name: null,
+    contact_last_name: null,
+    contact_email: null,
+    contact_phone: null,
+    sell_currency: "EUR",
+    pax: 2,
+    sell_amount_cents: 10_000,
+    invoice_total_cents: 0,
+    invoice_paid_cents: 0,
+    schedules_paid_cents: 0,
+    ...overrides,
+  }
+}
+
+describe("derivePaymentStatus", () => {
+  it("returns paid for a free booking regardless of invoice/schedule state", () => {
+    expect(derivePaymentStatus(bookingRow({ sell_amount_cents: 0 }))).toBe("paid")
+    expect(derivePaymentStatus(bookingRow({ sell_amount_cents: null }))).toBe("paid")
+  })
+
+  it("prefers bookings.paid_at over invoice math (issue #1079, scenario 1)", () => {
+    // Operator confirmed and marked the booking paid via schedules; never
+    // issued an invoice — paid_at is set, invoice_total stays 0.
+    const row = bookingRow({
+      paid_at: "2026-05-22T09:00:00.000Z",
+      invoice_total_cents: 0,
+      invoice_paid_cents: 0,
+      schedules_paid_cents: 0,
+    })
+    expect(derivePaymentStatus(row)).toBe("paid")
+  })
+
+  it("falls back to paid schedules when invoices are missing (issue #1079, scenario 2)", () => {
+    // Same flow but paid_at wasn't set; the schedule sum equals sell amount.
+    const row = bookingRow({
+      paid_at: null,
+      sell_amount_cents: 10_000,
+      schedules_paid_cents: 10_000,
+      invoice_total_cents: 0,
+      invoice_paid_cents: 0,
+    })
+    expect(derivePaymentStatus(row)).toBe("paid")
+  })
+
+  it("returns partial when schedules cover some of the sell amount", () => {
+    const row = bookingRow({
+      sell_amount_cents: 10_000,
+      schedules_paid_cents: 3_000,
+      invoice_total_cents: 0,
+      invoice_paid_cents: 0,
+    })
+    expect(derivePaymentStatus(row)).toBe("partial")
+  })
+
+  it("returns partial when an invoice is partially paid", () => {
+    const row = bookingRow({
+      sell_amount_cents: 10_000,
+      invoice_total_cents: 10_000,
+      invoice_paid_cents: 4_000,
+    })
+    expect(derivePaymentStatus(row)).toBe("partial")
+  })
+
+  it("returns paid when invoices cover the booking and schedules are empty", () => {
+    const row = bookingRow({
+      sell_amount_cents: 10_000,
+      invoice_total_cents: 10_000,
+      invoice_paid_cents: 10_000,
+    })
+    expect(derivePaymentStatus(row)).toBe("paid")
+  })
+
+  it("returns unpaid when nothing has been billed or scheduled", () => {
+    const row = bookingRow({
+      sell_amount_cents: 10_000,
+      invoice_total_cents: 0,
+      invoice_paid_cents: 0,
+      schedules_paid_cents: 0,
+      paid_at: null,
+    })
+    expect(derivePaymentStatus(row)).toBe("unpaid")
+  })
+
+  it("treats schedule overpayment the same as exact coverage", () => {
+    const row = bookingRow({
+      sell_amount_cents: 10_000,
+      schedules_paid_cents: 12_000,
+    })
+    expect(derivePaymentStatus(row)).toBe("paid")
+  })
+
+  it("returns paid when paid_at is set even with no invoice/schedule data", () => {
+    // Confirmation flow where the operator marks paid manually without
+    // issuing an invoice or recording the schedule rollup.
+    const row = bookingRow({
+      paid_at: "2026-05-22T10:00:00.000Z",
+      invoice_total_cents: 0,
+      invoice_paid_cents: 0,
+      schedules_paid_cents: 0,
+    })
+    expect(derivePaymentStatus(row)).toBe("paid")
+  })
+})


### PR DESCRIPTION
## Summary
Closes #1079 plus two related polish items on the allocation chip.

### 1. `derivePaymentStatus` fallbacks (issue #1079)
The old rule only consulted `invoices` / `payments`, so a fully-settled booking that was billed via deposit schedules (or marked paid manually) lit up red on the allocation grid. New ordering:

1. `sell_amount_cents <= 0` → `paid`
2. **`bookings.paid_at IS NOT NULL` → `paid`** (authoritative)
3. **sum of paid `booking_payment_schedules` covers sell amount → `paid`**
4. that sum > 0 or invoice partial → `partial`
5. invoice paid → `paid` / invoice partial → `partial`
6. otherwise `unpaid`

Manifest SQL now surfaces `paid_at`, `created_at`, and `schedules_paid_cents`. Two-stage fallback handles finance-less deploys: drop the schedules join if `booking_payment_schedules` is missing, drop both joins if `invoices` is also missing.

### 2. Booking sequence number on every chip
Each booking gets a slot-local 1-based ordinal (ordered by `bookings.created_at`), exposed as `AllocationManifestBooking.bookingSequence` / `AllocationManifestTraveler.bookingSequence`. The chip / seat-cell renders it as `(N)` before the name, so on the screenshot's example: `(1) Neculae Burlacelu` / `(1) Maria Burlacelu` share a booking; the next booking gets `(2)`, etc.

### 3. Visible payment colors + seat-view parity
`paymentStatusChipClass` moved to `slot-allocation-shared` and bumped from `/5 + /40` (basically invisible on dark themes) to `/20 + /70` plus explicit `text-*-700 dark:text-*-200`. Now the seat view (`VehicleSeatCell`) and unallocated tiles (`TravelerTile`) use the same look as the rooms view — including the tooltip showing the localized "Paid / Partially paid / Unpaid" label. The booking ref was already clickable in the seat view; this adds the missing color + tooltip + sequence prefix to match.

## Schema additions (back-compat)
- `AllocationManifestTraveler.bookingSequence: number` — `.default(0)` so older servers don't break the client; the renderer skips the `(N)` prefix when the value is 0.
- Same field on `AllocationManifestBooking`.

## Test plan
- [x] 9 new unit tests for `derivePaymentStatus` covering each new branch + the legacy paths (`pnpm -F @voyantjs/availability test`).
- [x] `pnpm -F @voyantjs/availability -F @voyantjs/availability-react -F @voyantjs/allocation-ui typecheck`.
- [x] `pnpm i18n:check`, `pnpm lint`.
- [ ] **Manual** — open a slot in the operator with bookings in different `paid_at` states; confirm chips are green for paid (including paid-via-schedules), amber for partial, red for unpaid, and that the booking sequence prefixes group families together.