### PR TITLE
Support cross-currency booking payments

### DIFF
--- a/.changeset/cross-currency-booking-payments.md
+++ b/.changeset/cross-currency-booking-payments.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/finance-ui": patch
+---
+
+Allow booking payment recording to capture cross-currency payments with invoice-currency base amounts.

--- a/packages/finance-ui/src/components/record-booking-payment-dialog.tsx
+++ b/packages/finance-ui/src/components/record-booking-payment-dialog.tsx
@@ -26,6 +26,7 @@ import {
   SelectValue,
   Textarea,
 } from "@voyantjs/ui/components"
+import { CurrencyCombobox } from "@voyantjs/ui/components/currency-combobox"
 import { CurrencyInput } from "@voyantjs/ui/components/currency-input"
 import { DatePicker } from "@voyantjs/ui/components/date-picker"
 import { Loader2 } from "lucide-react"
@@ -49,6 +50,8 @@ interface FormState {
   invoiceId: string
   amountCents: number
   currency: string
+  baseAmountCents: number
+  fxRate: string
   paymentMethod: PaymentMethod
   status: PaymentStatus
   paymentDate: string
@@ -65,6 +68,8 @@ function buildInitialFormState(currency: string): FormState {
     invoiceId: "",
     amountCents: 0,
     currency,
+    baseAmountCents: 0,
+    fxRate: "",
     paymentMethod: "bank_transfer",
     status: "completed",
     paymentDate: todayIso(),
@@ -75,6 +80,23 @@ function buildInitialFormState(currency: string): FormState {
 
 function formatAmount(cents: number): string {
   return (cents / 100).toFixed(2)
+}
+
+function normalizeCurrency(currency: string | null | undefined): string {
+  return currency?.trim().toUpperCase() ?? ""
+}
+
+function parseFxRate(raw: string): number | null {
+  const normalized = raw.trim().replace(",", ".")
+  if (!normalized) return null
+  const value = Number.parseFloat(normalized)
+  return Number.isFinite(value) && value > 0 ? value : null
+}
+
+function deriveBaseAmountCents(amountCents: number, fxRateRaw: string): number | null {
+  const fxRate = parseFxRate(fxRateRaw)
+  if (!fxRate || amountCents <= 0) return null
+  return Math.round(amountCents / fxRate)
 }
 
 export function RecordBookingPaymentDialog({
@@ -114,16 +136,62 @@ export function RecordBookingPaymentDialog({
         invoiceId: target?.id ?? "",
         amountCents: target?.balanceDueCents ?? 0,
         currency: target?.currency ?? defaultCurrency,
+        baseAmountCents: 0,
+        fxRate: "",
       })
       initializedRef.current = true
     }
   }, [open, invoicesQuery.isLoading, selectableInvoices, defaultCurrency])
 
   const selectedInvoice = invoices.find((inv) => inv.id === state.invoiceId) ?? null
+  const invoiceCurrency = selectedInvoice?.currency ?? ""
+  const normalizedInvoiceCurrency = normalizeCurrency(invoiceCurrency)
+  const paymentCurrency = normalizeCurrency(state.currency)
+  const isCrossCurrency = Boolean(
+    normalizedInvoiceCurrency && paymentCurrency && normalizedInvoiceCurrency !== paymentCurrency,
+  )
+  const requiresBaseAmount = isCrossCurrency && state.status === "completed"
   const mutation = useInvoicePaymentMutation(state.invoiceId)
 
   const set = <K extends keyof FormState>(key: K, value: FormState[K]) =>
     setState((prev) => ({ ...prev, [key]: value }))
+
+  const setAmountCents = (amountCents: number) => {
+    setState((prev) => ({
+      ...prev,
+      amountCents,
+      baseAmountCents: deriveBaseAmountCents(amountCents, prev.fxRate) ?? prev.baseAmountCents,
+    }))
+  }
+
+  const setPaymentCurrency = (currency: string) => {
+    const nextCurrency = normalizeCurrency(currency) || normalizedInvoiceCurrency || defaultCurrency
+    setState((prev) => ({
+      ...prev,
+      amountCents:
+        normalizedInvoiceCurrency &&
+        nextCurrency !== normalizedInvoiceCurrency &&
+        normalizeCurrency(prev.currency) === normalizedInvoiceCurrency &&
+        prev.amountCents === selectedInvoice?.balanceDueCents
+          ? 0
+          : prev.amountCents,
+      currency: nextCurrency,
+      baseAmountCents:
+        normalizedInvoiceCurrency && nextCurrency !== normalizedInvoiceCurrency
+          ? prev.baseAmountCents || selectedInvoice?.balanceDueCents || 0
+          : 0,
+      fxRate:
+        normalizedInvoiceCurrency && nextCurrency !== normalizedInvoiceCurrency ? prev.fxRate : "",
+    }))
+  }
+
+  const setFxRate = (fxRate: string) => {
+    setState((prev) => ({
+      ...prev,
+      fxRate,
+      baseAmountCents: deriveBaseAmountCents(prev.amountCents, fxRate) ?? prev.baseAmountCents,
+    }))
+  }
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault()
@@ -136,10 +204,19 @@ export function RecordBookingPaymentDialog({
       setSubmitError(dialog.validation.amountMinimum)
       return
     }
+    if (requiresBaseAmount && state.baseAmountCents <= 0) {
+      setSubmitError(dialog.validation.baseAmountRequired)
+      return
+    }
     try {
       await mutation.mutateAsync({
         amountCents: state.amountCents,
-        currency: state.currency,
+        currency: isCrossCurrency
+          ? paymentCurrency || state.currency
+          : invoiceCurrency || state.currency,
+        baseCurrency: isCrossCurrency ? invoiceCurrency : null,
+        baseAmountCents:
+          isCrossCurrency && state.baseAmountCents > 0 ? state.baseAmountCents : null,
         paymentMethod: state.paymentMethod,
         status: state.status,
         paymentDate: state.paymentDate,
@@ -186,6 +263,8 @@ export function RecordBookingPaymentDialog({
                       invoiceId: id,
                       amountCents: next?.balanceDueCents ?? prev.amountCents,
                       currency: next?.currency ?? prev.currency,
+                      baseAmountCents: 0,
+                      fxRate: "",
                     }))
                   }}
                 >
@@ -218,13 +297,24 @@ export function RecordBookingPaymentDialog({
               ) : null}
             </div>
 
-            <div className="grid grid-cols-3 gap-4">
+            <div className="grid gap-4 sm:grid-cols-3">
               <div className="flex flex-col gap-2">
                 <Label htmlFor="record-amount">{dialog.fields.amountCents}</Label>
                 <CurrencyInput
+                  id="record-amount"
                   value={state.amountCents}
-                  onChange={(next) => set("amountCents", next ?? 0)}
+                  onChange={(next) => setAmountCents(next ?? 0)}
                   currency={state.currency}
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label>{dialog.fields.currency}</Label>
+                <CurrencyCombobox
+                  value={state.currency || null}
+                  onChange={(next) =>
+                    setPaymentCurrency(next ?? selectedInvoice?.currency ?? defaultCurrency)
+                  }
+                  placeholder={dialog.placeholders.currency}
                 />
               </div>
               <div className="flex flex-col gap-2">
@@ -235,6 +325,55 @@ export function RecordBookingPaymentDialog({
                   className="w-full"
                 />
               </div>
+            </div>
+
+            {isCrossCurrency ? (
+              <div className="rounded-md border bg-muted/20 p-3">
+                <div className="mb-3 space-y-1">
+                  <h3 className="text-sm font-medium">{dialog.fx.title}</h3>
+                  <p className="text-xs text-muted-foreground">
+                    {formatMessage(dialog.fx.help, {
+                      invoiceCurrency,
+                      paymentCurrency,
+                    })}
+                  </p>
+                </div>
+                <div className="grid gap-4 sm:grid-cols-3">
+                  <div className="flex flex-col gap-2">
+                    <Label htmlFor="record-base-amount">{dialog.fields.baseAmountCents}</Label>
+                    <CurrencyInput
+                      id="record-base-amount"
+                      value={state.baseAmountCents}
+                      onChange={(next) => set("baseAmountCents", next ?? 0)}
+                      currency={normalizedInvoiceCurrency || invoiceCurrency}
+                    />
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <Label htmlFor="record-fx-rate">{dialog.fields.fxRate}</Label>
+                    <Input
+                      id="record-fx-rate"
+                      value={state.fxRate}
+                      onChange={(event) => setFxRate(event.target.value)}
+                      inputMode="decimal"
+                      placeholder={formatMessage(dialog.placeholders.fxRate, {
+                        invoiceCurrency,
+                        paymentCurrency,
+                      })}
+                    />
+                  </div>
+                  <div className="flex items-end">
+                    <p className="pb-2 text-xs text-muted-foreground">
+                      {formatMessage(dialog.fx.rateHint, {
+                        invoiceCurrency,
+                        paymentCurrency,
+                      })}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ) : null}
+
+            <div className="grid gap-4 sm:grid-cols-3">
               <div className="flex flex-col gap-2">
                 <Label>{dialog.fields.status}</Label>
                 <Select
@@ -253,9 +392,6 @@ export function RecordBookingPaymentDialog({
                   </SelectContent>
                 </Select>
               </div>
-            </div>
-
-            <div className="grid grid-cols-2 gap-4">
               <div className="flex flex-col gap-2">
                 <Label>{dialog.fields.paymentMethod}</Label>
                 <Select
@@ -305,7 +441,12 @@ export function RecordBookingPaymentDialog({
             </Button>
             <Button
               type="submit"
-              disabled={mutation.isPending || !state.invoiceId || state.amountCents <= 0}
+              disabled={
+                mutation.isPending ||
+                !state.invoiceId ||
+                state.amountCents <= 0 ||
+                (requiresBaseAmount && state.baseAmountCents <= 0)
+              }
             >
               {mutation.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
               {dialog.actions.record}

--- a/packages/finance-ui/src/i18n/en.ts
+++ b/packages/finance-ui/src/i18n/en.ts
@@ -523,6 +523,9 @@ export const financeUiEn = {
     fields: {
       invoice: "Invoice",
       amountCents: "Amount",
+      currency: "Payment currency",
+      baseAmountCents: "Invoice-currency amount",
+      fxRate: "FX rate",
       paymentDate: "Payment date",
       paymentMethod: "Method",
       status: "Status",
@@ -531,7 +534,15 @@ export const financeUiEn = {
     },
     placeholders: {
       invoice: "Select invoice",
+      currency: "Select currency...",
+      fxRate: "1 {invoiceCurrency} = ? {paymentCurrency}",
       referenceNumber: "Bank reference, receipt number, etc.",
+    },
+    fx: {
+      title: "Cross-currency settlement",
+      help: "Record the received amount in {paymentCurrency} and the value applied to the invoice in {invoiceCurrency}.",
+      rateHint:
+        "Use the rate as {paymentCurrency} per 1 {invoiceCurrency}; entering it updates the invoice-currency amount.",
     },
     invoiceOption: "{number} — {status} — {balance} {currency} due",
     invoiceMeta: "Total {total} {currency} • paid {paid} {currency} • due {due} {currency}",
@@ -543,6 +554,7 @@ export const financeUiEn = {
     validation: {
       invoiceRequired: "Select an invoice to record this payment against.",
       amountMinimum: "Amount must be greater than zero.",
+      baseAmountRequired: "Enter the amount to apply in the invoice currency.",
       recordFailed: "Failed to record payment.",
     },
   },

--- a/packages/finance-ui/src/i18n/messages.ts
+++ b/packages/finance-ui/src/i18n/messages.ts
@@ -507,6 +507,9 @@ export type FinanceUiMessages = {
     fields: {
       invoice: string
       amountCents: string
+      currency: string
+      baseAmountCents: string
+      fxRate: string
       paymentDate: string
       paymentMethod: string
       status: string
@@ -515,7 +518,17 @@ export type FinanceUiMessages = {
     }
     placeholders: {
       invoice: string
+      currency: string
+      /** Placeholder for manual FX rate. Placeholders: `{invoiceCurrency} {paymentCurrency}`. */
+      fxRate: string
       referenceNumber: string
+    }
+    fx: {
+      title: string
+      /** Help text. Placeholders: `{invoiceCurrency} {paymentCurrency}`. */
+      help: string
+      /** Inline hint. Placeholders: `{invoiceCurrency} {paymentCurrency}`. */
+      rateHint: string
     }
     /** Per-row option label. Placeholders: `{number} {status} {balance} {currency}`. */
     invoiceOption: string
@@ -529,6 +542,7 @@ export type FinanceUiMessages = {
     validation: {
       invoiceRequired: string
       amountMinimum: string
+      baseAmountRequired: string
       recordFailed: string
     }
   }

--- a/packages/finance-ui/src/i18n/ro.ts
+++ b/packages/finance-ui/src/i18n/ro.ts
@@ -527,6 +527,9 @@ export const financeUiRo = {
     fields: {
       invoice: "Factura",
       amountCents: "Suma",
+      currency: "Moneda platii",
+      baseAmountCents: "Suma in moneda facturii",
+      fxRate: "Curs valutar",
       paymentDate: "Data platii",
       paymentMethod: "Metoda",
       status: "Status",
@@ -535,7 +538,15 @@ export const financeUiRo = {
     },
     placeholders: {
       invoice: "Selecteaza factura",
+      currency: "Selecteaza moneda...",
+      fxRate: "1 {invoiceCurrency} = ? {paymentCurrency}",
       referenceNumber: "Referinta bancara, numar de chitanta etc.",
+    },
+    fx: {
+      title: "Decontare in alta moneda",
+      help: "Inregistreaza suma incasata in {paymentCurrency} si valoarea aplicata pe factura in {invoiceCurrency}.",
+      rateHint:
+        "Foloseste cursul ca {paymentCurrency} pentru 1 {invoiceCurrency}; completarea lui actualizeaza suma in moneda facturii.",
     },
     invoiceOption: "{number} — {status} — {balance} {currency} de incasat",
     invoiceMeta:
@@ -549,6 +560,7 @@ export const financeUiRo = {
     validation: {
       invoiceRequired: "Selecteaza o factura pentru aceasta plata.",
       amountMinimum: "Suma trebuie sa fie mai mare decat zero.",
+      baseAmountRequired: "Introdu suma care se aplica in moneda facturii.",
       recordFailed: "Inregistrarea platii a esuat.",
     },
   },

--- a/packages/finance-ui/src/record-booking-payment-dialog.test.tsx
+++ b/packages/finance-ui/src/record-booking-payment-dialog.test.tsx
@@ -1,0 +1,272 @@
+// @vitest-environment jsdom
+
+import type * as ReactTypes from "react"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const testState = vi.hoisted(() => ({
+  invoices: [
+    {
+      id: "inv_123",
+      invoiceNumber: "PF-2026-001",
+      status: "draft",
+      currency: "EUR",
+      totalCents: 66000,
+      paidCents: 0,
+      balanceDueCents: 66000,
+    },
+  ],
+  mutateAsync: vi.fn(async () => ({ data: { id: "pay_123" } })),
+}))
+
+;(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock("@voyantjs/finance-react", () => ({
+  paymentMethodSchema: {
+    options: ["bank_transfer", "credit_card", "cash", "cheque", "other"],
+  },
+  paymentStatusSchema: {
+    options: ["pending", "completed", "failed", "refunded"],
+  },
+  useInvoices: () => ({
+    data: {
+      data: testState.invoices,
+    },
+    isLoading: false,
+  }),
+  useInvoicePaymentMutation: () => ({
+    isPending: false,
+    mutateAsync: testState.mutateAsync,
+  }),
+}))
+
+vi.mock("@voyantjs/ui/components", async () => {
+  return {
+    Button: ({ children, ...props }: ReactTypes.ButtonHTMLAttributes<HTMLButtonElement>) => (
+      <button {...props}>{children}</button>
+    ),
+    Dialog: ({
+      children,
+      open,
+    }: {
+      children: ReactTypes.ReactNode
+      open?: boolean
+      onOpenChange?: (open: boolean) => void
+    }) => (open ? <div>{children}</div> : null),
+    DialogBody: ({ children }: { children: ReactTypes.ReactNode }) => <div>{children}</div>,
+    DialogContent: ({ children }: { children: ReactTypes.ReactNode; size?: string }) => (
+      <div>{children}</div>
+    ),
+    DialogFooter: ({ children }: { children: ReactTypes.ReactNode }) => <div>{children}</div>,
+    DialogHeader: ({ children }: { children: ReactTypes.ReactNode }) => <div>{children}</div>,
+    DialogTitle: ({ children }: { children: ReactTypes.ReactNode }) => <h2>{children}</h2>,
+    Input: (props: ReactTypes.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+    Label: ({ children }: ReactTypes.LabelHTMLAttributes<HTMLLabelElement>) => (
+      <span>{children}</span>
+    ),
+    Select: ({
+      children,
+      onValueChange,
+      value,
+    }: {
+      children: ReactTypes.ReactNode
+      onValueChange?: (value: string) => void
+      value?: string
+    }) => (
+      <select value={value} onChange={(event) => onValueChange?.(event.target.value)}>
+        {children}
+      </select>
+    ),
+    SelectContent: ({ children }: { children: ReactTypes.ReactNode }) => <>{children}</>,
+    SelectItem: ({ children, value }: { children: ReactTypes.ReactNode; value: string }) => (
+      <option value={value}>{children}</option>
+    ),
+    SelectTrigger: () => null,
+    SelectValue: () => null,
+    Textarea: (props: ReactTypes.TextareaHTMLAttributes<HTMLTextAreaElement>) => (
+      <textarea {...props} />
+    ),
+  }
+})
+
+vi.mock("@voyantjs/ui/components/currency-combobox", () => ({
+  CurrencyCombobox: ({
+    onChange,
+    value,
+  }: {
+    onChange: (value: string | null) => void
+    value: string | null | undefined
+  }) => (
+    <select
+      aria-label="Payment currency"
+      value={value ?? ""}
+      onChange={(event) => onChange(event.target.value || null)}
+    >
+      <option value="EUR">EUR</option>
+      <option value="RON">RON</option>
+      <option value="USD">USD</option>
+    </select>
+  ),
+}))
+
+vi.mock("@voyantjs/ui/components/currency-input", () => ({
+  CurrencyInput: ({
+    id,
+    onChange,
+    value,
+  }: {
+    id?: string
+    onChange: (value: number | null) => void
+    value: number | null | undefined
+  }) => (
+    <input
+      id={id}
+      value={value == null ? "" : String(value / 100)}
+      onChange={(event) => onChange(Math.round(Number(event.target.value) * 100))}
+    />
+  ),
+}))
+
+vi.mock("@voyantjs/ui/components/date-picker", () => ({
+  DatePicker: ({
+    onChange,
+    value,
+  }: {
+    onChange: (value: string | null) => void
+    value: string | null | undefined
+  }) => (
+    <input
+      aria-label="Payment date"
+      value={value ?? ""}
+      onChange={(event) => onChange(event.target.value || null)}
+    />
+  ),
+}))
+
+import { RecordBookingPaymentDialog } from "./components/record-booking-payment-dialog.js"
+
+function setNativeInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set
+  setter?.call(input, value)
+  input.dispatchEvent(new Event("input", { bubbles: true }))
+}
+
+describe("RecordBookingPaymentDialog", () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    testState.mutateAsync.mockClear()
+    testState.invoices = [
+      {
+        id: "inv_123",
+        invoiceNumber: "PF-2026-001",
+        status: "draft",
+        currency: "EUR",
+        totalCents: 66000,
+        paidCents: 0,
+        balanceDueCents: 66000,
+      },
+    ]
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it("records a cross-currency booking payment with invoice-currency base amount", async () => {
+    await act(async () => {
+      root.render(
+        <RecordBookingPaymentDialog
+          open
+          onOpenChange={() => {}}
+          bookingId="book_123"
+          defaultCurrency="EUR"
+        />,
+      )
+    })
+
+    await act(async () => {
+      container.querySelector<HTMLSelectElement>('select[aria-label="Payment currency"]')!.value =
+        "RON"
+      container
+        .querySelector<HTMLSelectElement>('select[aria-label="Payment currency"]')!
+        .dispatchEvent(new Event("change", { bubbles: true }))
+    })
+
+    await act(async () => {
+      setNativeInputValue(container.querySelector<HTMLInputElement>("#record-amount")!, "3300")
+    })
+
+    await act(async () => {
+      setNativeInputValue(container.querySelector<HTMLInputElement>("#record-fx-rate")!, "5")
+    })
+
+    await act(async () => {
+      container.querySelector<HTMLFormElement>("form")!.dispatchEvent(
+        new Event("submit", {
+          bubbles: true,
+          cancelable: true,
+        }),
+      )
+    })
+
+    expect(testState.mutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amountCents: 330000,
+        baseAmountCents: 66000,
+        baseCurrency: "EUR",
+        currency: "RON",
+      }),
+    )
+  })
+
+  it("preserves invoice currency casing for same-currency payments", async () => {
+    testState.invoices = [
+      {
+        id: "inv_123",
+        invoiceNumber: "PF-2026-001",
+        status: "draft",
+        currency: "eur",
+        totalCents: 66000,
+        paidCents: 0,
+        balanceDueCents: 66000,
+      },
+    ]
+
+    await act(async () => {
+      root.render(
+        <RecordBookingPaymentDialog
+          open
+          onOpenChange={() => {}}
+          bookingId="book_123"
+          defaultCurrency="EUR"
+        />,
+      )
+    })
+
+    await act(async () => {
+      container.querySelector<HTMLFormElement>("form")!.dispatchEvent(
+        new Event("submit", {
+          bubbles: true,
+          cancelable: true,
+        }),
+      )
+    })
+
+    expect(testState.mutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseAmountCents: null,
+        baseCurrency: null,
+        currency: "eur",
+      }),
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add a payment currency picker to RecordBookingPaymentDialog
- show cross-currency settlement fields when payment currency differs from the invoice currency
- derive the invoice-currency base amount from a manually entered FX rate and submit baseCurrency/baseAmountCents
- add a regression test for recording a RON payment against a EUR invoice
- add a patch changeset for @voyantjs/finance-ui

Fixes #1095

## Verification
- pnpm exec biome check --write packages/finance-ui/src/components/record-booking-payment-dialog.tsx packages/finance-ui/src/record-booking-payment-dialog.test.tsx packages/finance-ui/src/i18n/en.ts packages/finance-ui/src/i18n/ro.ts packages/finance-ui/src/i18n/messages.ts .changeset/cross-currency-booking-payments.md
- pnpm --filter @voyantjs/finance-ui typecheck
- pnpm --filter @voyantjs/finance-ui test -- src/record-booking-payment-dialog.test.tsx
- pnpm lint:changed
- pnpm i18n:check:packages
- commit hook: workspace lint + full typecheck
- pre-push hook: pnpm test