### PR TITLE
Guard R2 signed URL configuration

### DIFF
--- a/.changeset/r2-signed-url-guard.md
+++ b/.changeset/r2-signed-url-guard.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/storage": patch
+---
+
+Throw from the R2 provider's `signedUrl` when neither a signer nor public base URL is configured instead of returning the raw storage key.

--- a/apps/dev/src/api/app.ts
+++ b/apps/dev/src/api/app.ts
@@ -31,7 +31,12 @@ import authHandler, { hasAuthPermission, resolveAuthRequest } from "./auth/handl
 import { getDashboardSummary } from "./dashboard-summary"
 import { createInvitationsRoutes } from "./invitations"
 import { getDbFromHyperdrive } from "./lib/db"
-import { createMediaStorage, guessMimeType, resolveDocumentDownloadUrl } from "./lib/storage"
+import {
+  createDocumentStorage,
+  createMediaStorage,
+  guessMimeType,
+  resolveDocumentDownloadUrl,
+} from "./lib/storage"
 
 const notificationsHonoModule = createNotificationsHonoModule({
   resolveProviders: resolveNotificationProviders,
@@ -184,6 +189,32 @@ export const app = createApp<CloudflareBindings>({
         mimeType: file.type,
         size: file.size,
       })
+    })
+
+    // GET /v1/admin/documents/files/* — admin-only stream of private document bytes.
+    hono.get("/v1/admin/documents/files/*", async (c) => {
+      const storage = createDocumentStorage(c.env)
+      if (!storage) {
+        return c.json({ error: "Storage not configured" }, 503)
+      }
+
+      const rawKey = c.req.path.replace("/v1/admin/documents/files/", "")
+      const key = rawKey
+        .split("/")
+        .map((segment) => decodeURIComponent(segment))
+        .join("/")
+      if (!key) return c.json({ error: "Missing key" }, 400)
+
+      const buffer = await storage.get(key)
+      if (!buffer) return c.json({ error: "Not found" }, 404)
+
+      const headers = new Headers()
+      headers.set("Content-Type", guessMimeType(key))
+      headers.set("Cache-Control", "private, no-store")
+      headers.set("Content-Length", String(buffer.byteLength))
+      headers.set("Content-Disposition", `inline; filename="${key.split("/").pop() ?? "document"}"`)
+
+      return new Response(buffer, { headers })
     })
 
     // GET /v1/media/* — serve public media via the configured media storage provider.

--- a/apps/dev/src/api/lib/storage.ts
+++ b/apps/dev/src/api/lib/storage.ts
@@ -1,5 +1,8 @@
 import type { StorageProvider } from "@voyantjs/storage"
-import { createR2Provider } from "@voyantjs/storage/providers/r2"
+import {
+  createR2Provider,
+  R2_SIGNED_URL_CONFIGURATION_ERROR_MESSAGE,
+} from "@voyantjs/storage/providers/r2"
 
 const MIME_BY_EXT: Record<string, string> = {
   pdf: "application/pdf",
@@ -111,10 +114,15 @@ export function createDocumentStorage(env: CloudflareBindings): StorageProvider 
 export async function resolveDocumentDownloadUrl(
   env: CloudflareBindings,
   storageKey: string,
-  _expiresIn = DEFAULT_DOCUMENT_URL_EXPIRES_IN,
+  expiresIn = DEFAULT_DOCUMENT_URL_EXPIRES_IN,
 ): Promise<string | null> {
   const storage = createDocumentStorage(env)
   if (!storage) return null
+  try {
+    return await storage.signedUrl(storageKey, expiresIn)
+  } catch (error) {
+    if (!isR2SignedUrlConfigurationError(error)) throw error
+  }
   const urlEnv = env as CloudflareBindings & {
     API_BASE_URL?: string
     DOCUMENTS_BASE_URL?: string
@@ -134,4 +142,8 @@ export function encodeStorageKeyPath(key: string): string {
     .split("/")
     .map((segment) => encodeURIComponent(segment))
     .join("/")
+}
+
+function isR2SignedUrlConfigurationError(error: unknown): boolean {
+  return error instanceof Error && error.message === R2_SIGNED_URL_CONFIGURATION_ERROR_MESSAGE
 }

--- a/apps/dev/src/api/lib/storage.ts
+++ b/apps/dev/src/api/lib/storage.ts
@@ -111,9 +111,27 @@ export function createDocumentStorage(env: CloudflareBindings): StorageProvider 
 export async function resolveDocumentDownloadUrl(
   env: CloudflareBindings,
   storageKey: string,
-  expiresIn = DEFAULT_DOCUMENT_URL_EXPIRES_IN,
+  _expiresIn = DEFAULT_DOCUMENT_URL_EXPIRES_IN,
 ): Promise<string | null> {
   const storage = createDocumentStorage(env)
   if (!storage) return null
-  return storage.signedUrl(storageKey, expiresIn)
+  const urlEnv = env as CloudflareBindings & {
+    API_BASE_URL?: string
+    DOCUMENTS_BASE_URL?: string
+  }
+  const apiBase = (
+    urlEnv.APP_URL?.trim() ||
+    urlEnv.API_BASE_URL?.trim() ||
+    urlEnv.DOCUMENTS_BASE_URL?.trim() ||
+    ""
+  ).replace(/\/$/, "")
+  const path = `/v1/admin/documents/files/${encodeStorageKeyPath(storageKey)}`
+  return apiBase ? `${apiBase}${path}` : path
+}
+
+export function encodeStorageKeyPath(key: string): string {
+  return key
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/")
 }

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -29,6 +29,10 @@ const url = await storage.signedUrl({ key: "files/x.pdf", expiresIn: 300 })
 
 The S3 provider supports `forcePathStyle` and a custom `endpoint` for S3-compatible services (Wasabi, MinIO, etc.). SigV4 signing is verified against AWS canonical test vectors.
 
+The R2 binding provider cannot mint signed URLs by itself. Configure either
+`publicBaseUrl` or a custom `signer` before calling `signedUrl`; otherwise the
+provider throws instead of returning a raw storage key.
+
 ## Exports
 
 | Entry | Description |

--- a/packages/storage/src/providers/r2.ts
+++ b/packages/storage/src/providers/r2.ts
@@ -1,5 +1,8 @@
 import type { StorageObject, StorageProvider, StorageUploadBody, UploadOptions } from "../types.js"
 
+export const R2_SIGNED_URL_CONFIGURATION_ERROR_MESSAGE =
+  "R2 provider: signedUrl requires either `publicBaseUrl` or `signer` to be configured"
+
 /**
  * Subset of the Cloudflare Workers `R2Bucket` binding we depend on. Kept
  * as a minimal structural type so this package does not need a runtime
@@ -89,9 +92,7 @@ export function createR2Provider(options: R2ProviderOptions): StorageProvider {
     async signedUrl(key, expiresIn) {
       if (options.signer) return options.signer(key, expiresIn)
       if (!publicBaseUrl) {
-        throw new Error(
-          "R2 provider: signedUrl requires either `publicBaseUrl` or `signer` to be configured",
-        )
+        throw new Error(R2_SIGNED_URL_CONFIGURATION_ERROR_MESSAGE)
       }
       return `${publicBaseUrl}${key}`
     },

--- a/packages/storage/src/providers/r2.ts
+++ b/packages/storage/src/providers/r2.ts
@@ -41,7 +41,9 @@ export interface R2ProviderOptions {
    * signed URLs directly; templates pass a custom signer that either:
    *   - returns a short-lived Worker route URL, or
    *   - calls R2's S3-compatible API with SigV4 credentials.
-   * When omitted, `signedUrl` returns `${publicBaseUrl}${key}`.
+   * When omitted, `signedUrl` returns `${publicBaseUrl}${key}`. Calling
+   * `signedUrl` without either a signer or public base URL is a
+   * configuration error because a raw R2 object key is not a URL.
    */
   signer?: (key: string, expiresIn: number) => Promise<string> | string
   /** Provider name (defaults to `"r2"`). */
@@ -86,7 +88,12 @@ export function createR2Provider(options: R2ProviderOptions): StorageProvider {
     },
     async signedUrl(key, expiresIn) {
       if (options.signer) return options.signer(key, expiresIn)
-      return publicBaseUrl ? `${publicBaseUrl}${key}` : key
+      if (!publicBaseUrl) {
+        throw new Error(
+          "R2 provider: signedUrl requires either `publicBaseUrl` or `signer` to be configured",
+        )
+      }
+      return `${publicBaseUrl}${key}`
     },
     async get(key) {
       const obj = await options.bucket.get(key)

--- a/packages/storage/tests/unit/r2.test.ts
+++ b/packages/storage/tests/unit/r2.test.ts
@@ -94,4 +94,13 @@ describe("createR2Provider", () => {
     })
     expect(await provider.signedUrl("k", 60)).toBe("https://cdn.example.com/k")
   })
+
+  it("signedUrl throws when neither publicBaseUrl nor signer is configured", async () => {
+    const bucket = fakeBucket()
+    const provider = createR2Provider({ bucket })
+
+    await expect(provider.signedUrl("file.pdf", 300)).rejects.toThrow(
+      "R2 provider: signedUrl requires either `publicBaseUrl` or `signer` to be configured",
+    )
+  })
 })

--- a/packages/storage/tests/unit/r2.test.ts
+++ b/packages/storage/tests/unit/r2.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest"
 
 import type { R2BucketLike } from "../../src/providers/r2.js"
-import { createR2Provider } from "../../src/providers/r2.js"
+import {
+  createR2Provider,
+  R2_SIGNED_URL_CONFIGURATION_ERROR_MESSAGE,
+} from "../../src/providers/r2.js"
 
 function fakeBucket(): R2BucketLike & {
   store: Map<string, { bytes: Uint8Array; options: unknown }>
@@ -100,7 +103,7 @@ describe("createR2Provider", () => {
     const provider = createR2Provider({ bucket })
 
     await expect(provider.signedUrl("file.pdf", 300)).rejects.toThrow(
-      "R2 provider: signedUrl requires either `publicBaseUrl` or `signer` to be configured",
+      R2_SIGNED_URL_CONFIGURATION_ERROR_MESSAGE,
     )
   })
 })

--- a/templates/dmc/src/api/app.ts
+++ b/templates/dmc/src/api/app.ts
@@ -239,6 +239,32 @@ export const app = createApp<CloudflareBindings>({
       return c.json(ticket)
     })
 
+    // GET /v1/admin/documents/files/* — admin-only stream of private document bytes.
+    hono.get("/v1/admin/documents/files/*", async (c) => {
+      const storage = createDocumentStorage(c.env)
+      if (!storage) {
+        return c.json({ error: "Storage not configured" }, 503)
+      }
+
+      const rawKey = c.req.path.replace("/v1/admin/documents/files/", "")
+      const key = rawKey
+        .split("/")
+        .map((segment) => decodeURIComponent(segment))
+        .join("/")
+      if (!key) return c.json({ error: "Missing key" }, 400)
+
+      const buffer = await storage.get(key)
+      if (!buffer) return c.json({ error: "Not found" }, 404)
+
+      const headers = new Headers()
+      headers.set("Content-Type", guessMimeType(key))
+      headers.set("Cache-Control", "private, no-store")
+      headers.set("Content-Length", String(buffer.byteLength))
+      headers.set("Content-Disposition", `inline; filename="${key.split("/").pop() ?? "document"}"`)
+
+      return new Response(buffer, { headers })
+    })
+
     // GET /v1/media/* — serve public media via the configured media storage provider.
     hono.get("/v1/media/*", async (c) => {
       const storage = createMediaStorage(c.env)

--- a/templates/dmc/src/api/lib/storage.ts
+++ b/templates/dmc/src/api/lib/storage.ts
@@ -111,9 +111,26 @@ export function createDocumentStorage(env: CloudflareBindings): StorageProvider 
 export async function resolveDocumentDownloadUrl(
   env: CloudflareBindings,
   storageKey: string,
-  expiresIn = DEFAULT_DOCUMENT_URL_EXPIRES_IN,
+  _expiresIn = DEFAULT_DOCUMENT_URL_EXPIRES_IN,
 ): Promise<string | null> {
   const storage = createDocumentStorage(env)
   if (!storage) return null
-  return storage.signedUrl(storageKey, expiresIn)
+  const urlEnv = env as CloudflareBindings & {
+    DOCUMENTS_BASE_URL?: string
+  }
+  const apiBase = (
+    urlEnv.APP_URL?.trim() ||
+    urlEnv.API_BASE_URL?.trim() ||
+    urlEnv.DOCUMENTS_BASE_URL?.trim() ||
+    ""
+  ).replace(/\/$/, "")
+  const path = `/v1/admin/documents/files/${encodeStorageKeyPath(storageKey)}`
+  return apiBase ? `${apiBase}${path}` : path
+}
+
+export function encodeStorageKeyPath(key: string): string {
+  return key
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/")
 }

--- a/templates/dmc/src/api/lib/storage.ts
+++ b/templates/dmc/src/api/lib/storage.ts
@@ -1,5 +1,8 @@
 import type { StorageProvider } from "@voyantjs/storage"
-import { createR2Provider } from "@voyantjs/storage/providers/r2"
+import {
+  createR2Provider,
+  R2_SIGNED_URL_CONFIGURATION_ERROR_MESSAGE,
+} from "@voyantjs/storage/providers/r2"
 
 const MIME_BY_EXT: Record<string, string> = {
   pdf: "application/pdf",
@@ -111,10 +114,15 @@ export function createDocumentStorage(env: CloudflareBindings): StorageProvider 
 export async function resolveDocumentDownloadUrl(
   env: CloudflareBindings,
   storageKey: string,
-  _expiresIn = DEFAULT_DOCUMENT_URL_EXPIRES_IN,
+  expiresIn = DEFAULT_DOCUMENT_URL_EXPIRES_IN,
 ): Promise<string | null> {
   const storage = createDocumentStorage(env)
   if (!storage) return null
+  try {
+    return await storage.signedUrl(storageKey, expiresIn)
+  } catch (error) {
+    if (!isR2SignedUrlConfigurationError(error)) throw error
+  }
   const urlEnv = env as CloudflareBindings & {
     DOCUMENTS_BASE_URL?: string
   }
@@ -133,4 +141,8 @@ export function encodeStorageKeyPath(key: string): string {
     .split("/")
     .map((segment) => encodeURIComponent(segment))
     .join("/")
+}
+
+function isR2SignedUrlConfigurationError(error: unknown): boolean {
+  return error instanceof Error && error.message === R2_SIGNED_URL_CONFIGURATION_ERROR_MESSAGE
 }

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -1265,9 +1265,8 @@ export const app = createApp<CloudflareBindings>({
     // backed by a real S3 SigV4 signer (every dev setup, plus
     // small-team prod deploys that haven't wired one up). The legal
     // package's contract-attachment download endpoint redirects here
-    // when its `resolveDocumentDownloadUrl` resolves to a relative
-    // storage key. Auth is the standard staff guard inherited from
-    // `/v1/admin/*` middleware in createApp.
+    // through `resolveDocumentDownloadUrl`. Auth is the standard staff
+    // guard inherited from `/v1/admin/*` middleware in createApp.
     hono.get("/v1/admin/documents/files/*", async (c) => {
       const storage = createDocumentStorage(c.env)
       if (!storage) {

--- a/templates/operator/src/api/lib/storage.ts
+++ b/templates/operator/src/api/lib/storage.ts
@@ -131,56 +131,24 @@ export async function readDocumentContentBase64(
 export async function resolveDocumentDownloadUrl(
   env: CloudflareBindings,
   storageKey: string,
-  expiresIn = DEFAULT_DOCUMENT_URL_EXPIRES_IN,
+  _expiresIn = DEFAULT_DOCUMENT_URL_EXPIRES_IN,
 ): Promise<string | null> {
   const storage = createDocumentStorage(env)
   if (!storage) return null
-  const signed = await storage.signedUrl(storageKey, expiresIn)
-  // R2's bucket binding doesn't natively produce signed URLs — the
-  // storage provider's `signedUrl` falls back to returning the raw
-  // storage key when no SigV4 signer is configured. That's not a
-  // usable URL: a redirect to "contracts/cont_…/contract.pdf"
-  // resolves relative to the request URL and 404s.
-  //
-  // Detect the "key passed through" case (no scheme prefix) and
-  // rewrite it to an ABSOLUTE URL on the operator's
-  // `/v1/admin/documents/files/*` streaming proxy. APP_URL is the
-  // operator-dashboard origin used by the browser; this is what we
-  // want for the redirect that the browser follows out of the
-  // attachment-download route. DOCUMENTS_BASE_URL is reserved for
-  // cases where the URL must be reachable by external systems on a
-  // different host (Cloudflare Browser Rendering hitting the
-  // operator from outside the worker, an email-rendering pipeline
-  // embedding the URL, etc.) and is consulted only as a fallback
-  // when APP_URL isn't configured. In dev that order matters: APP_URL
-  // points at localhost (correct for the browser) while
-  // DOCUMENTS_BASE_URL is often set to a production host (which
-  // can't see the local R2). Picking DOCUMENTS_BASE_URL first there
-  // broke browser-side downloads.
-  // In production with a real S3 signer, the signed `https://…`
-  // URL is returned as-is and used directly without any rewrite.
-  if (signed && /^https?:\/\//i.test(signed)) {
-    return signed
-  }
-  if (!signed) return null
   const apiBase = (
     env.APP_URL?.trim() ||
     env.API_BASE_URL?.trim() ||
     env.DOCUMENTS_BASE_URL?.trim() ||
     ""
   ).replace(/\/$/, "")
+  const path = `/v1/admin/documents/files/${encodeStorageKeyPath(storageKey)}`
   if (!apiBase) {
-    // Without a configured API base we have no way to compose an
-    // absolute URL. Fall back to a root-relative URL with no `/api`
-    // prefix — same-origin same-path deploys (no SPA mount) will
-    // work; reverse-proxied deploys won't, but that's a configuration
-    // issue surfaced as a 404, not a silent corruption.
-    return `/v1/admin/documents/files/${encodeStorageKeyPath(signed)}`
+    return path
   }
-  return `${apiBase}/v1/admin/documents/files/${encodeStorageKeyPath(signed)}`
+  return `${apiBase}${path}`
 }
 
-function encodeStorageKeyPath(key: string): string {
+export function encodeStorageKeyPath(key: string): string {
   return key
     .split("/")
     .map((segment) => encodeURIComponent(segment))

--- a/templates/operator/src/api/lib/storage.ts
+++ b/templates/operator/src/api/lib/storage.ts
@@ -1,5 +1,8 @@
 import type { StorageProvider } from "@voyantjs/storage"
-import { createR2Provider } from "@voyantjs/storage/providers/r2"
+import {
+  createR2Provider,
+  R2_SIGNED_URL_CONFIGURATION_ERROR_MESSAGE,
+} from "@voyantjs/storage/providers/r2"
 
 const MIME_BY_EXT: Record<string, string> = {
   pdf: "application/pdf",
@@ -131,10 +134,15 @@ export async function readDocumentContentBase64(
 export async function resolveDocumentDownloadUrl(
   env: CloudflareBindings,
   storageKey: string,
-  _expiresIn = DEFAULT_DOCUMENT_URL_EXPIRES_IN,
+  expiresIn = DEFAULT_DOCUMENT_URL_EXPIRES_IN,
 ): Promise<string | null> {
   const storage = createDocumentStorage(env)
   if (!storage) return null
+  try {
+    return await storage.signedUrl(storageKey, expiresIn)
+  } catch (error) {
+    if (!isR2SignedUrlConfigurationError(error)) throw error
+  }
   const apiBase = (
     env.APP_URL?.trim() ||
     env.API_BASE_URL?.trim() ||
@@ -153,4 +161,8 @@ export function encodeStorageKeyPath(key: string): string {
     .split("/")
     .map((segment) => encodeURIComponent(segment))
     .join("/")
+}
+
+function isR2SignedUrlConfigurationError(error: unknown): boolean {
+  return error instanceof Error && error.message === R2_SIGNED_URL_CONFIGURATION_ERROR_MESSAGE
 }


### PR DESCRIPTION
## Summary
- make the R2 provider throw when `signedUrl` is called without either `publicBaseUrl` or a custom signer
- add a storage regression test and README note for the misconfiguration
- route dev, DMC, and operator private document downloads through authenticated document-file endpoints instead of depending on raw-key passthrough

Closes #1090.

## Verification
- pnpm --filter @voyantjs/storage test -- tests/unit/r2.test.ts
- pnpm --filter @voyantjs/storage typecheck
- pnpm lint:changed
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter dev typecheck
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter dmc typecheck
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter operator typecheck
- pnpm test