### PR TITLE
Add booking payment reconciliation banner

### DIFF
--- a/.changeset/payment-reconciliation-banner.md
+++ b/.changeset/payment-reconciliation-banner.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/bookings-ui": patch
+---
+
+Add a booking payment reconciliation banner that compares invoice paid totals, completed payment rows, and paid schedule rows.

--- a/packages/bookings-ui/src/components/booking-detail-page.tsx
+++ b/packages/bookings-ui/src/components/booking-detail-page.tsx
@@ -47,6 +47,7 @@ import { BookingGroupSection } from "./booking-group-section.js"
 import { BookingGuaranteeList } from "./booking-guarantee-list.js"
 import { BookingItemList } from "./booking-item-list.js"
 import { BookingNotes } from "./booking-notes.js"
+import { BookingPaymentReconciliationBanner } from "./booking-payment-reconciliation-banner.js"
 import { BookingPaymentScheduleList } from "./booking-payment-schedule-list.js"
 import { BookingPaymentsSummary } from "./booking-payments-summary.js"
 import { StatusChangeDialog } from "./status-change-dialog.js"
@@ -339,6 +340,7 @@ export function BookingDetailPage({
             </div>
           ) : null}
           {slots?.financeStart?.(booking)}
+          <BookingPaymentReconciliationBanner bookingId={id} />
           <BookingPaymentsSummary bookingId={id} variant="admin" />
           <BookingPaymentScheduleList bookingId={id} />
           <BookingGuaranteeList bookingId={id} />

--- a/packages/bookings-ui/src/components/booking-payment-reconciliation-banner.tsx
+++ b/packages/bookings-ui/src/components/booking-payment-reconciliation-banner.tsx
@@ -1,0 +1,189 @@
+"use client"
+
+import {
+  type BookingPaymentScheduleRecord,
+  type InvoiceRecord,
+  type PublicFinanceBookingPaymentRecord,
+  useAdminBookingPayments,
+  useBookingPaymentSchedules,
+  useInvoices,
+} from "@voyantjs/finance-react"
+import { Badge } from "@voyantjs/ui/components"
+import { AlertTriangle, CheckCircle2, Loader2 } from "lucide-react"
+
+import { useBookingsUiI18nOrDefault, useBookingsUiMessagesOrDefault } from "../i18n/provider.js"
+
+export interface BookingPaymentReconciliationBannerProps {
+  bookingId: string
+}
+
+type MoneyTotals = Map<string, number>
+
+export function BookingPaymentReconciliationBanner({
+  bookingId,
+}: BookingPaymentReconciliationBannerProps) {
+  const invoicesQuery = useInvoices({ bookingId, limit: 50 })
+  const paymentsQuery = useAdminBookingPayments(bookingId)
+  const schedulesQuery = useBookingPaymentSchedules(bookingId)
+  const { formatCurrency } = useBookingsUiI18nOrDefault()
+  const messages = useBookingsUiMessagesOrDefault().bookingPaymentReconciliationBanner
+
+  const invoices = invoicesQuery.data?.data ?? []
+  const payments = paymentsQuery.data?.data?.payments ?? []
+  const schedules = schedulesQuery.data?.data ?? []
+  const isLoading = invoicesQuery.isLoading || paymentsQuery.isLoading || schedulesQuery.isLoading
+
+  const billedTotals = sumInvoiceTotals(invoices, "totalCents")
+  const invoicePaidTotals = sumInvoiceTotals(invoices, "paidCents")
+  const completedPaymentTotals = sumCompletedPayments(payments)
+  const paidScheduleTotals = sumPaidSchedules(schedules)
+  const driftTotals = calculateDriftTotals([
+    invoicePaidTotals,
+    completedPaymentTotals,
+    paidScheduleTotals,
+  ])
+  const hasRecords = invoices.length > 0 || payments.length > 0 || schedules.length > 0
+  const hasDrift = Array.from(driftTotals.values()).some((cents) => cents > 0)
+
+  if (isLoading && !hasRecords) {
+    return (
+      <section className="rounded-md border bg-muted/30 p-4" aria-live="polite">
+        <div className="flex items-center gap-2 text-muted-foreground text-sm">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          {messages.loading}
+        </div>
+      </section>
+    )
+  }
+
+  return (
+    <section
+      className={
+        hasDrift
+          ? "rounded-md border border-amber-300 bg-amber-50 p-4 text-amber-950 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-100"
+          : "rounded-md border bg-muted/30 p-4"
+      }
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex min-w-0 items-start gap-2">
+          {hasDrift ? (
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" aria-hidden="true" />
+          ) : (
+            <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" aria-hidden="true" />
+          )}
+          <div>
+            <h3 className="font-medium text-sm">{messages.title}</h3>
+            <p className="mt-1 max-w-3xl text-sm opacity-80">
+              {!hasRecords
+                ? messages.empty
+                : hasDrift
+                  ? messages.driftDescription
+                  : messages.reconciledDescription}
+            </p>
+          </div>
+        </div>
+        <Badge variant={hasDrift ? "destructive" : "outline"}>
+          {hasDrift ? messages.driftBadge : messages.reconciledBadge}
+        </Badge>
+      </div>
+
+      <dl className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+        <ReconciliationMetric
+          label={messages.billed}
+          value={formatMoneyTotals(billedTotals, formatCurrency, messages.emptyValue)}
+        />
+        <ReconciliationMetric
+          label={messages.invoicePaid}
+          value={formatMoneyTotals(invoicePaidTotals, formatCurrency, messages.emptyValue)}
+        />
+        <ReconciliationMetric
+          label={messages.recordedPayments}
+          value={formatMoneyTotals(completedPaymentTotals, formatCurrency, messages.emptyValue)}
+        />
+        <ReconciliationMetric
+          label={messages.schedulePaid}
+          value={formatMoneyTotals(paidScheduleTotals, formatCurrency, messages.emptyValue)}
+        />
+        <ReconciliationMetric
+          label={messages.drift}
+          value={formatMoneyTotals(driftTotals, formatCurrency, messages.emptyValue)}
+          emphasis={hasDrift}
+        />
+      </dl>
+    </section>
+  )
+}
+
+function ReconciliationMetric({
+  label,
+  value,
+  emphasis = false,
+}: {
+  label: string
+  value: string
+  emphasis?: boolean
+}) {
+  return (
+    <div>
+      <dt className="text-muted-foreground text-xs">{label}</dt>
+      <dd className={emphasis ? "mt-1 font-mono font-semibold text-sm" : "mt-1 font-mono text-sm"}>
+        {value}
+      </dd>
+    </div>
+  )
+}
+
+function sumInvoiceTotals(invoices: InvoiceRecord[], field: "paidCents" | "totalCents") {
+  const totals: MoneyTotals = new Map()
+  for (const invoice of invoices) {
+    if (invoice.status === "void" || invoice.invoiceType === "credit_note") continue
+    addMoney(totals, invoice.currency, invoice[field])
+  }
+  return totals
+}
+
+function sumCompletedPayments(payments: PublicFinanceBookingPaymentRecord[]) {
+  const totals: MoneyTotals = new Map()
+  for (const payment of payments) {
+    if (payment.status !== "completed") continue
+    addMoney(totals, payment.currency, payment.amountCents)
+  }
+  return totals
+}
+
+function sumPaidSchedules(schedules: BookingPaymentScheduleRecord[]) {
+  const totals: MoneyTotals = new Map()
+  for (const schedule of schedules) {
+    if (schedule.status !== "paid") continue
+    addMoney(totals, schedule.currency, schedule.amountCents)
+  }
+  return totals
+}
+
+function calculateDriftTotals(sources: MoneyTotals[]) {
+  const currencies = new Set(sources.flatMap((source) => Array.from(source.keys())))
+  const drift: MoneyTotals = new Map()
+  for (const currency of currencies) {
+    const amounts = sources.map((source) => source.get(currency) ?? 0)
+    drift.set(currency, Math.max(...amounts) - Math.min(...amounts))
+  }
+  return drift
+}
+
+function addMoney(totals: MoneyTotals, currency: string, cents: number) {
+  if (cents === 0) return
+  totals.set(currency, (totals.get(currency) ?? 0) + cents)
+}
+
+function formatMoneyTotals(
+  totals: MoneyTotals,
+  formatCurrency: (amount: number, currency: string) => string,
+  emptyValue: string,
+) {
+  const entries = Array.from(totals.entries()).filter(([, cents]) => cents > 0)
+  if (entries.length === 0) return emptyValue
+  return entries
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([currency, cents]) => formatCurrency(cents / 100, currency))
+    .join(" / ")
+}

--- a/packages/bookings-ui/src/components/booking-payment-reconciliation-banner.tsx
+++ b/packages/bookings-ui/src/components/booking-payment-reconciliation-banner.tsx
@@ -8,7 +8,7 @@ import {
   useBookingPaymentSchedules,
   useInvoices,
 } from "@voyantjs/finance-react"
-import { Badge } from "@voyantjs/ui/components"
+import { Badge, cn } from "@voyantjs/ui/components"
 import { AlertTriangle, CheckCircle2, Loader2 } from "lucide-react"
 
 import { useBookingsUiI18nOrDefault, useBookingsUiMessagesOrDefault } from "../i18n/provider.js"
@@ -58,11 +58,12 @@ export function BookingPaymentReconciliationBanner({
 
   return (
     <section
-      className={
+      className={cn(
+        "rounded-md border p-4",
         hasDrift
-          ? "rounded-md border border-amber-300 bg-amber-50 p-4 text-amber-950 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-100"
-          : "rounded-md border bg-muted/30 p-4"
-      }
+          ? "border-amber-300 bg-amber-50 text-amber-950 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-100"
+          : "bg-muted/30",
+      )}
     >
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="flex min-w-0 items-start gap-2">

--- a/packages/bookings-ui/src/i18n/en.ts
+++ b/packages/bookings-ui/src/i18n/en.ts
@@ -869,6 +869,23 @@ export const bookingsUiEn = {
       issueProforma: "Issue proforma",
     },
   },
+  bookingPaymentReconciliationBanner: {
+    title: "Payment reconciliation",
+    loading: "Checking payment sources...",
+    empty: "No invoices, payments, or schedule rows have been recorded yet.",
+    reconciledDescription:
+      "Invoice paid totals, recorded payments, and paid schedule rows currently agree.",
+    driftDescription:
+      "Invoice paid totals, recorded payments, and paid schedule rows disagree. Review the source rows before collecting or recording more money.",
+    reconciledBadge: "Reconciled",
+    driftBadge: "Needs review",
+    billed: "Billed",
+    invoicePaid: "Paid on invoices",
+    recordedPayments: "Recorded payments",
+    schedulePaid: "Paid schedule rows",
+    drift: "Drift",
+    emptyValue: "-",
+  },
   supplierStatusList: {
     title: "Supplier confirmations",
     addSupplier: "Add supplier",

--- a/packages/bookings-ui/src/i18n/messages.ts
+++ b/packages/bookings-ui/src/i18n/messages.ts
@@ -791,6 +791,21 @@ export type BookingsUiMessages = {
       issueProforma: string
     }
   }
+  bookingPaymentReconciliationBanner: {
+    title: string
+    loading: string
+    empty: string
+    reconciledDescription: string
+    driftDescription: string
+    reconciledBadge: string
+    driftBadge: string
+    billed: string
+    invoicePaid: string
+    recordedPayments: string
+    schedulePaid: string
+    drift: string
+    emptyValue: string
+  }
   supplierStatusList: {
     title: string
     addSupplier: string

--- a/packages/bookings-ui/src/i18n/ro.ts
+++ b/packages/bookings-ui/src/i18n/ro.ts
@@ -871,6 +871,23 @@ export const bookingsUiRo = {
       issueProforma: "Emite proforma",
     },
   },
+  bookingPaymentReconciliationBanner: {
+    title: "Reconciliere plati",
+    loading: "Se verifica sursele de plata...",
+    empty: "Nu exista facturi, plati sau scadente inregistrate inca.",
+    reconciledDescription:
+      "Totalurile achitate pe facturi, platile inregistrate si scadentele platite sunt aliniate.",
+    driftDescription:
+      "Totalurile achitate pe facturi, platile inregistrate si scadentele platite nu coincid. Verifica randurile sursa inainte de a incasa sau inregistra alti bani.",
+    reconciledBadge: "Reconciliat",
+    driftBadge: "Necesita verificare",
+    billed: "Facturat",
+    invoicePaid: "Achitat pe facturi",
+    recordedPayments: "Plati inregistrate",
+    schedulePaid: "Scadente platite",
+    drift: "Diferenta",
+    emptyValue: "-",
+  },
   supplierStatusList: {
     title: "Confirmari furnizori",
     addSupplier: "Adauga furnizor",

--- a/packages/bookings-ui/src/index.ts
+++ b/packages/bookings-ui/src/index.ts
@@ -61,6 +61,10 @@ export {
 export { BookingList, type BookingListProps } from "./components/booking-list.js"
 export { BookingNotes, type BookingNotesProps } from "./components/booking-notes.js"
 export {
+  BookingPaymentReconciliationBanner,
+  type BookingPaymentReconciliationBannerProps,
+} from "./components/booking-payment-reconciliation-banner.js"
+export {
   BookingPaymentScheduleDialog,
   type BookingPaymentScheduleDialogProps,
 } from "./components/booking-payment-schedule-dialog.js"

--- a/packages/bookings-ui/tests/unit/booking-payment-reconciliation-banner.test.tsx
+++ b/packages/bookings-ui/tests/unit/booking-payment-reconciliation-banner.test.tsx
@@ -30,6 +30,7 @@ vi.mock("@voyantjs/finance-react", () => ({
 
 vi.mock("@voyantjs/ui/components", () => ({
   Badge: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+  cn: (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(" "),
 }))
 
 import { BookingPaymentReconciliationBanner } from "../../src/components/booking-payment-reconciliation-banner.js"

--- a/packages/bookings-ui/tests/unit/booking-payment-reconciliation-banner.test.tsx
+++ b/packages/bookings-ui/tests/unit/booking-payment-reconciliation-banner.test.tsx
@@ -1,0 +1,129 @@
+import type {
+  BookingPaymentScheduleRecord,
+  InvoiceRecord,
+  PublicFinanceBookingPaymentRecord,
+} from "@voyantjs/finance-react"
+import type { ReactNode } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const financeState = vi.hoisted(() => ({
+  invoices: [] as InvoiceRecord[],
+  payments: [] as PublicFinanceBookingPaymentRecord[],
+  schedules: [] as BookingPaymentScheduleRecord[],
+}))
+
+vi.mock("@voyantjs/finance-react", () => ({
+  useAdminBookingPayments: () => ({
+    data: { data: { payments: financeState.payments } },
+    isLoading: false,
+  }),
+  useBookingPaymentSchedules: () => ({
+    data: { data: financeState.schedules },
+    isLoading: false,
+  }),
+  useInvoices: () => ({
+    data: { data: financeState.invoices },
+    isLoading: false,
+  }),
+}))
+
+vi.mock("@voyantjs/ui/components", () => ({
+  Badge: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+}))
+
+import { BookingPaymentReconciliationBanner } from "../../src/components/booking-payment-reconciliation-banner.js"
+
+beforeEach(() => {
+  financeState.invoices = []
+  financeState.payments = []
+  financeState.schedules = []
+})
+
+function invoice(data: Partial<InvoiceRecord> = {}): InvoiceRecord {
+  return {
+    id: "inv_123",
+    bookingId: "book_123",
+    invoiceNumber: "INV-1",
+    invoiceType: "invoice",
+    status: "sent",
+    currency: "EUR",
+    subtotalCents: 16500,
+    taxCents: 0,
+    totalCents: 16500,
+    paidCents: 0,
+    balanceDueCents: 16500,
+    issueDate: "2026-05-23",
+    dueDate: "2026-05-30",
+    notes: null,
+    personId: null,
+    organizationId: null,
+    createdAt: "2026-05-23T00:00:00.000Z",
+    updatedAt: "2026-05-23T00:00:00.000Z",
+    ...data,
+  }
+}
+
+function payment(
+  data: Partial<PublicFinanceBookingPaymentRecord> = {},
+): PublicFinanceBookingPaymentRecord {
+  return {
+    id: "pay_123",
+    invoiceId: "inv_123",
+    invoiceNumber: "INV-1",
+    invoiceType: "invoice",
+    status: "completed",
+    paymentMethod: "bank_transfer",
+    amountCents: 16500,
+    currency: "EUR",
+    paymentDate: "2026-05-23",
+    referenceNumber: null,
+    notes: null,
+    ...data,
+  }
+}
+
+function schedule(data: Partial<BookingPaymentScheduleRecord> = {}): BookingPaymentScheduleRecord {
+  return {
+    id: "bps_123",
+    bookingId: "book_123",
+    bookingItemId: null,
+    scheduleType: "deposit",
+    status: "paid",
+    dueDate: "2026-05-30",
+    currency: "EUR",
+    amountCents: 16500,
+    notes: null,
+    createdAt: "2026-05-23T00:00:00.000Z",
+    updatedAt: "2026-05-23T00:00:00.000Z",
+    ...data,
+  }
+}
+
+describe("BookingPaymentReconciliationBanner", () => {
+  it("flags paid schedule rows that have no matching invoice/payment total", () => {
+    financeState.invoices = [invoice()]
+    financeState.payments = []
+    financeState.schedules = [schedule()]
+
+    const html = renderToStaticMarkup(<BookingPaymentReconciliationBanner bookingId="book_123" />)
+
+    expect(html).toContain("Needs review")
+    expect(html).toContain(
+      "Invoice paid totals, recorded payments, and paid schedule rows disagree",
+    )
+    expect(html).toContain("€165.00")
+  })
+
+  it("marks the booking reconciled when invoice, payment, and schedule paid totals match", () => {
+    financeState.invoices = [invoice({ paidCents: 16500, balanceDueCents: 0 })]
+    financeState.payments = [payment()]
+    financeState.schedules = [schedule()]
+
+    const html = renderToStaticMarkup(<BookingPaymentReconciliationBanner bookingId="book_123" />)
+
+    expect(html).toContain("Reconciled")
+    expect(html).toContain("currently agree")
+    expect(html).not.toContain("Needs review")
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a booking finance-tab reconciliation banner that compares billed invoice totals, invoice paid totals, completed payment rows, and paid schedule rows.
- Flags drift when invoice paid totals, recorded payments, and paid schedule totals disagree, including the paid-schedule/no-payment-row case from #1120.
- Adds English/Romanian copy, exports the component, and includes a patch changeset.

Closes #1120.

## Verification

- `pnpm --filter @voyantjs/bookings-ui test`
- `pnpm --filter @voyantjs/bookings-ui typecheck`
- `pnpm --filter @voyantjs/bookings-ui lint`
- full pre-commit hook: lint + typecheck
- full push hook: test

Note: `pnpm verify:fast` passes changed-file formatting but stops on the existing `verify:ui-components-barrel` issue for missing `@voyantjs/ui` component exports unrelated to this change.