### PR TITLE
Enforce paid schedule payment coverage

### DIFF
--- a/.changeset/paid-schedule-payment-coverage.md
+++ b/.changeset/paid-schedule-payment-coverage.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/finance": patch
+---
+
+Require linked completed payment coverage before booking payment schedules can become paid.

--- a/packages/finance/src/routes.ts
+++ b/packages/finance/src/routes.ts
@@ -224,19 +224,30 @@ export const financeRoutes = new Hono<Env>()
   })
 
   .post("/payment-sessions/:id/complete", async (c) => {
-    const runtime = getFinanceRouteRuntime(c)
-    const row = await financeService.completePaymentSession(
-      c.get("db"),
-      c.req.param("id"),
-      await parseJsonBody(c, completePaymentSessionSchema),
-      {
-        eventBus: runtime?.eventBus,
-        actionLedgerContext: getActionLedgerRequestContext(c),
-        actionLedgerAuthorizationSource: "finance.payment_session.route",
-      },
-    )
-    if (!row) return c.json({ error: "Payment session not found" }, 404)
-    return c.json({ data: row })
+    try {
+      const runtime = getFinanceRouteRuntime(c)
+      const row = await financeService.completePaymentSession(
+        c.get("db"),
+        c.req.param("id"),
+        await parseJsonBody(c, completePaymentSessionSchema),
+        {
+          eventBus: runtime?.eventBus,
+          actionLedgerContext: getActionLedgerRequestContext(c),
+          actionLedgerAuthorizationSource: "finance.payment_session.route",
+        },
+      )
+      if (!row) return c.json({ error: "Payment session not found" }, 404)
+      return c.json({ data: row })
+    } catch (error) {
+      if (error instanceof PaymentValidationError) {
+        return c.json(
+          { error: error.message, code: error.code, details: error.details },
+          error.status,
+        )
+      }
+
+      throw error
+    }
   })
 
   .post("/payment-sessions/:id/fail", async (c) => {
@@ -500,23 +511,34 @@ export const financeRoutes = new Hono<Env>()
   })
 
   .post("/bookings/:bookingId/payment-schedules", async (c) => {
-    const runtime = getFinanceRouteRuntime(c)
-    const row = await financeService.createBookingPaymentSchedule(
-      c.get("db"),
-      c.req.param("bookingId"),
-      await parseJsonBody(c, insertBookingPaymentScheduleSchema),
-      {
-        eventBus: runtime?.eventBus,
-        actionLedgerContext: getActionLedgerRequestContext(c),
-        actionLedgerAuthorizationSource: "finance.booking_payment_schedule.route",
-      },
-    )
+    try {
+      const runtime = getFinanceRouteRuntime(c)
+      const row = await financeService.createBookingPaymentSchedule(
+        c.get("db"),
+        c.req.param("bookingId"),
+        await parseJsonBody(c, insertBookingPaymentScheduleSchema),
+        {
+          eventBus: runtime?.eventBus,
+          actionLedgerContext: getActionLedgerRequestContext(c),
+          actionLedgerAuthorizationSource: "finance.booking_payment_schedule.route",
+        },
+      )
 
-    if (!row) {
-      return c.json({ error: "Booking not found" }, 404)
+      if (!row) {
+        return c.json({ error: "Booking not found" }, 404)
+      }
+
+      return c.json({ data: row }, 201)
+    } catch (error) {
+      if (error instanceof PaymentValidationError) {
+        return c.json(
+          { error: error.message, code: error.code, details: error.details },
+          error.status,
+        )
+      }
+
+      throw error
     }
-
-    return c.json({ data: row }, 201)
   })
 
   .post("/bookings/:bookingId/payment-schedules/default-plan", async (c) => {
@@ -540,23 +562,34 @@ export const financeRoutes = new Hono<Env>()
   })
 
   .patch("/bookings/:bookingId/payment-schedules/:scheduleId", async (c) => {
-    const runtime = getFinanceRouteRuntime(c)
-    const row = await financeService.updateBookingPaymentSchedule(
-      c.get("db"),
-      c.req.param("scheduleId"),
-      await parseJsonBody(c, updateBookingPaymentScheduleSchema),
-      {
-        eventBus: runtime?.eventBus,
-        actionLedgerContext: getActionLedgerRequestContext(c),
-        actionLedgerAuthorizationSource: "finance.booking_payment_schedule.route",
-      },
-    )
+    try {
+      const runtime = getFinanceRouteRuntime(c)
+      const row = await financeService.updateBookingPaymentSchedule(
+        c.get("db"),
+        c.req.param("scheduleId"),
+        await parseJsonBody(c, updateBookingPaymentScheduleSchema),
+        {
+          eventBus: runtime?.eventBus,
+          actionLedgerContext: getActionLedgerRequestContext(c),
+          actionLedgerAuthorizationSource: "finance.booking_payment_schedule.route",
+        },
+      )
 
-    if (!row) {
-      return c.json({ error: "Payment schedule not found" }, 404)
+      if (!row) {
+        return c.json({ error: "Payment schedule not found" }, 404)
+      }
+
+      return c.json({ data: row })
+    } catch (error) {
+      if (error instanceof PaymentValidationError) {
+        return c.json(
+          { error: error.message, code: error.code, details: error.details },
+          error.status,
+        )
+      }
+
+      throw error
     }
-
-    return c.json({ data: row })
   })
 
   .post("/bookings/:bookingId/payment-schedules/:scheduleId/payment-session", async (c) => {

--- a/packages/finance/src/service.ts
+++ b/packages/finance/src/service.ts
@@ -5,7 +5,7 @@ import {
 import { bookingItems, bookings } from "@voyantjs/bookings/schema"
 import type { EventBus } from "@voyantjs/core"
 import { renderStructuredTemplate } from "@voyantjs/utils/template-renderer"
-import { and, asc, desc, eq, gte, ilike, lte, ne, or, sql } from "drizzle-orm"
+import { and, asc, desc, eq, gt, gte, ilike, lte, ne, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
 import {
@@ -670,6 +670,87 @@ function assertPaymentCanSettleInvoice(invoiceCurrency: string, data: CreatePaym
   )
 }
 
+async function resolveInvoiceForPaymentSession(
+  db: PostgresJsDatabase,
+  session: typeof paymentSessions.$inferSelect,
+) {
+  if (session.invoiceId) {
+    const [invoice] = await db.select().from(invoices).where(eq(invoices.id, session.invoiceId))
+    return invoice ?? null
+  }
+
+  if (!session.bookingPaymentScheduleId) {
+    return null
+  }
+
+  const [schedule] = await db
+    .select()
+    .from(bookingPaymentSchedules)
+    .where(eq(bookingPaymentSchedules.id, session.bookingPaymentScheduleId))
+    .limit(1)
+
+  if (!schedule) {
+    return null
+  }
+
+  const [invoice] = await db
+    .select()
+    .from(invoices)
+    .where(
+      and(
+        eq(invoices.bookingId, schedule.bookingId),
+        eq(invoices.currency, schedule.currency),
+        ne(invoices.status, "void"),
+        gt(invoices.balanceDueCents, 0),
+      ),
+    )
+    .orderBy(desc(invoices.createdAt))
+    .limit(1)
+
+  return invoice ?? null
+}
+
+async function assertBookingPaymentScheduleHasPaymentCoverage(
+  db: PostgresJsDatabase,
+  schedule: Pick<
+    typeof bookingPaymentSchedules.$inferSelect,
+    "id" | "bookingId" | "amountCents" | "currency"
+  >,
+) {
+  const paymentRows = await db
+    .select({
+      id: payments.id,
+      amountCents: payments.amountCents,
+    })
+    .from(paymentSessions)
+    .innerJoin(payments, eq(paymentSessions.paymentId, payments.id))
+    .innerJoin(invoices, eq(payments.invoiceId, invoices.id))
+    .where(
+      and(
+        eq(paymentSessions.bookingPaymentScheduleId, schedule.id),
+        eq(paymentSessions.status, "paid"),
+        eq(payments.status, "completed"),
+        eq(payments.currency, schedule.currency),
+        eq(invoices.bookingId, schedule.bookingId),
+      ),
+    )
+    .groupBy(payments.id, payments.amountCents)
+
+  const paidCents = paymentRows.reduce((total, payment) => total + payment.amountCents, 0)
+  if (paidCents < schedule.amountCents) {
+    throw new PaymentValidationError(
+      "Cannot mark booking payment schedule as paid without linked completed payment coverage",
+      {
+        scheduleId: schedule.id,
+        bookingId: schedule.bookingId,
+        requiredCents: schedule.amountCents,
+        coveredCents: paidCents,
+        currency: schedule.currency,
+      },
+    )
+  }
+}
+
 export const financeService = {
   vouchers: vouchersService,
   getFinanceAggregates,
@@ -1214,6 +1295,26 @@ export const financeService = {
       let authorizationId = session.paymentAuthorizationId
       let captureId = session.paymentCaptureId
       let paymentId = session.paymentId
+      const invoiceForPayment =
+        data.status === "paid" && !paymentId
+          ? await resolveInvoiceForPaymentSession(tx, session)
+          : null
+
+      if (
+        data.status === "paid" &&
+        session.bookingPaymentScheduleId &&
+        !paymentId &&
+        !invoiceForPayment
+      ) {
+        throw new PaymentValidationError(
+          "Cannot complete a booking payment schedule session without an outstanding booking invoice",
+          {
+            paymentSessionId: session.id,
+            bookingPaymentScheduleId: session.bookingPaymentScheduleId,
+          },
+        )
+      }
+
       // Settlement payload to emit after the tx commits, so subscribers see
       // a consistent post-update view. Stays null when this call doesn't
       // result in a new payment being applied to an invoice.
@@ -1226,7 +1327,7 @@ export const financeService = {
           .values({
             bookingId: session.bookingId ?? null,
             orderId: session.orderId ?? null,
-            invoiceId: session.invoiceId ?? null,
+            invoiceId: invoiceForPayment?.id ?? session.invoiceId ?? null,
             bookingGuaranteeId: session.bookingGuaranteeId ?? null,
             paymentInstrumentId: data.paymentInstrumentId ?? session.paymentInstrumentId ?? null,
             status: data.status === "paid" ? "captured" : "authorized",
@@ -1272,7 +1373,7 @@ export const financeService = {
           .insert(paymentCaptures)
           .values({
             paymentAuthorizationId: authorizationId,
-            invoiceId: session.invoiceId ?? null,
+            invoiceId: invoiceForPayment?.id ?? session.invoiceId ?? null,
             status: "completed",
             currency: session.currency,
             amountCents: session.amountCents,
@@ -1288,90 +1389,63 @@ export const financeService = {
         captureId = capture?.id ?? null
       }
 
-      if (data.status === "paid" && session.invoiceId && !paymentId) {
-        const [invoice] = await tx
-          .select()
-          .from(invoices)
-          .where(eq(invoices.id, session.invoiceId))
-          .limit(1)
+      if (data.status === "paid" && invoiceForPayment && !paymentId) {
+        const [payment] = await tx
+          .insert(payments)
+          .values({
+            invoiceId: invoiceForPayment.id,
+            amountCents: session.amountCents,
+            currency: session.currency,
+            paymentMethod: data.paymentMethod ?? session.paymentMethod ?? "other",
+            paymentInstrumentId: data.paymentInstrumentId ?? session.paymentInstrumentId ?? null,
+            paymentAuthorizationId: authorizationId,
+            paymentCaptureId: captureId,
+            status: "completed",
+            referenceNumber:
+              data.referenceNumber ?? data.externalReference ?? session.externalReference ?? null,
+            paymentDate: (data.paymentDate ? new Date(data.paymentDate) : new Date())
+              .toISOString()
+              .slice(0, 10),
+            notes: data.notes ?? session.notes ?? null,
+          })
+          .returning({ id: payments.id })
 
-        if (invoice) {
-          const [payment] = await tx
-            .insert(payments)
-            .values({
-              invoiceId: session.invoiceId,
-              amountCents: session.amountCents,
-              currency: session.currency,
-              paymentMethod: data.paymentMethod ?? session.paymentMethod ?? "other",
-              paymentInstrumentId: data.paymentInstrumentId ?? session.paymentInstrumentId ?? null,
-              paymentAuthorizationId: authorizationId,
-              paymentCaptureId: captureId,
-              status: "completed",
-              referenceNumber:
-                data.referenceNumber ?? data.externalReference ?? session.externalReference ?? null,
-              paymentDate: (data.paymentDate ? new Date(data.paymentDate) : new Date())
-                .toISOString()
-                .slice(0, 10),
-              notes: data.notes ?? session.notes ?? null,
-            })
-            .returning({ id: payments.id })
+        paymentId = payment?.id ?? null
 
-          paymentId = payment?.id ?? null
-
-          const [sumResult] = await tx
-            .select({ total: sql<number>`coalesce(sum(amount_cents), 0)::int` })
-            .from(payments)
-            .where(and(eq(payments.invoiceId, session.invoiceId), eq(payments.status, "completed")))
-
-          const paidCents = sumResult?.total ?? 0
-          const balanceDueCents = Math.max(0, invoice.totalCents - paidCents)
-
-          await tx
-            .update(invoices)
-            .set({
-              paidCents,
-              balanceDueCents,
-              status:
-                paidCents >= invoice.totalCents
-                  ? "paid"
-                  : paidCents > 0
-                    ? "partially_paid"
-                    : invoice.status,
-              updatedAt: new Date(),
-            })
-            .where(eq(invoices.id, session.invoiceId))
-
-          if (paymentId) {
-            settlementForEmit = {
-              invoiceId: session.invoiceId,
-              paymentId,
-              provider: session.provider ?? "internal",
-              newlyAppliedAmountCents: session.amountCents,
-              paidCents,
-              balanceDueCents,
-            }
-          }
-        }
-      }
-
-      if (data.status === "paid" && session.bookingPaymentScheduleId) {
-        const [paidSchedule] = await tx
-          .update(bookingPaymentSchedules)
-          .set({ status: "paid", updatedAt: new Date() })
+        const [sumResult] = await tx
+          .select({ total: sql<number>`coalesce(sum(amount_cents), 0)::int` })
+          .from(payments)
           .where(
-            and(
-              eq(bookingPaymentSchedules.id, session.bookingPaymentScheduleId),
-              ne(bookingPaymentSchedules.status, "paid"),
-            ),
+            and(eq(payments.invoiceId, invoiceForPayment.id), eq(payments.status, "completed")),
           )
-          .returning()
 
-        if (paidSchedule) {
-          bookingSchedulePaidForEmit = buildBookingPaymentSchedulePaidEvent(
-            paidSchedule,
-            session,
+        const paidCents = sumResult?.total ?? 0
+        const balanceDueCents = Math.max(0, invoiceForPayment.totalCents - paidCents)
+
+        await tx
+          .update(invoices)
+          .set({
+            paidCents,
+            balanceDueCents,
+            status:
+              paidCents >= invoiceForPayment.totalCents
+                ? "paid"
+                : paidCents > 0
+                  ? "partially_paid"
+                  : invoiceForPayment.status,
+            updatedAt: new Date(),
+          })
+          .where(eq(invoices.id, invoiceForPayment.id))
+
+        if (paymentId) {
+          settlementForEmit = {
+            invoiceId: invoiceForPayment.id,
             paymentId,
-          )
+            provider: session.provider ?? "internal",
+            newlyAppliedAmountCents: session.amountCents,
+            paidCents,
+            balanceDueCents,
+          }
         }
       }
 
@@ -1398,6 +1472,7 @@ export const financeService = {
           paymentAuthorizationId: authorizationId,
           paymentCaptureId: captureId,
           paymentId,
+          invoiceId: invoiceForPayment?.id ?? session.invoiceId ?? undefined,
           providerSessionId: data.providerSessionId ?? session.providerSessionId ?? undefined,
           providerPaymentId: data.providerPaymentId ?? session.providerPaymentId ?? undefined,
           externalReference: data.externalReference ?? session.externalReference ?? undefined,
@@ -1431,6 +1506,37 @@ export const financeService = {
         )
       }
 
+      if (data.status === "paid" && session.bookingPaymentScheduleId) {
+        const [schedule] = await tx
+          .select()
+          .from(bookingPaymentSchedules)
+          .where(eq(bookingPaymentSchedules.id, session.bookingPaymentScheduleId))
+          .limit(1)
+
+        if (schedule) {
+          await assertBookingPaymentScheduleHasPaymentCoverage(tx, schedule)
+
+          const [paidSchedule] = await tx
+            .update(bookingPaymentSchedules)
+            .set({ status: "paid", updatedAt: new Date() })
+            .where(
+              and(
+                eq(bookingPaymentSchedules.id, session.bookingPaymentScheduleId),
+                ne(bookingPaymentSchedules.status, "paid"),
+              ),
+            )
+            .returning()
+
+          if (paidSchedule && updated) {
+            bookingSchedulePaidForEmit = buildBookingPaymentSchedulePaidEvent(
+              paidSchedule,
+              updated,
+              paymentId,
+            )
+          }
+        }
+      }
+
       return {
         updated: updated ?? null,
         settlement: settlementForEmit,
@@ -1458,10 +1564,14 @@ export const financeService = {
     // generic target instead of booking/order/invoice columns; those still
     // need the completion event keyed by targetType/targetId.
     if (data.status === "paid" && txResult.updated) {
-      await runtime.eventBus?.emit("payment.completed", buildPaymentCompletedEvent(session), {
-        category: "domain",
-        source: "service",
-      })
+      await runtime.eventBus?.emit(
+        "payment.completed",
+        buildPaymentCompletedEvent(txResult.updated),
+        {
+          category: "domain",
+          source: "service",
+        },
+      )
     }
 
     return txResult.updated
@@ -1792,6 +1902,13 @@ export const financeService = {
     data: CreateBookingPaymentScheduleInput,
     runtime: FinanceServiceRuntime = {},
   ) {
+    if (data.status === "paid") {
+      throw new PaymentValidationError(
+        "Create booking payment schedules as pending or due, then settle them through a payment session",
+        { bookingId },
+      )
+    }
+
     const createSchedule = async (writer: PostgresJsDatabase) => {
       const [booking] = await writer
         .select({ id: bookings.id })
@@ -2105,12 +2222,35 @@ export const financeService = {
     data: UpdateBookingPaymentScheduleInput,
     runtime: FinanceServiceRuntime = {},
   ) {
-    const updateSchedule = (writer: PostgresJsDatabase) =>
-      writer
+    const updateSchedule = async (writer: PostgresJsDatabase) => {
+      const [existing] = await writer
+        .select()
+        .from(bookingPaymentSchedules)
+        .where(eq(bookingPaymentSchedules.id, scheduleId))
+        .limit(1)
+
+      if (!existing) {
+        return []
+      }
+
+      const nextSchedule = {
+        id: existing.id,
+        bookingId: existing.bookingId,
+        amountCents: data.amountCents ?? existing.amountCents,
+        currency: data.currency ?? existing.currency,
+      }
+      const nextStatus = data.status ?? existing.status
+
+      if (nextStatus === "paid") {
+        await assertBookingPaymentScheduleHasPaymentCoverage(writer, nextSchedule)
+      }
+
+      return writer
         .update(bookingPaymentSchedules)
         .set({ ...data, updatedAt: new Date() })
         .where(eq(bookingPaymentSchedules.id, scheduleId))
         .returning()
+    }
 
     const actionLedgerContext = runtime.actionLedgerContext
     if (actionLedgerContext) {

--- a/packages/finance/tests/integration/routes.test.ts
+++ b/packages/finance/tests/integration/routes.test.ts
@@ -626,6 +626,10 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
     it("completes a paid session and marks the linked booking schedule as paid", async () => {
       const booking = await seedBooking()
       const schedule = await seedBookingPaymentSchedule(booking.id)
+      const invoice = await seedInvoice(booking.id, {
+        totalCents: schedule.amountCents,
+        balanceDueCents: schedule.amountCents,
+      })
       const createRes = await app.request("/payment-sessions", {
         method: "POST",
         ...json({
@@ -643,18 +647,27 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
         ...json({ status: "paid", paymentMethod: "credit_card" }),
       })
       expect(res.status).toBe(200)
+      const { data } = await res.json()
 
       const [storedSchedule] = await db
         .select()
         .from(bookingPaymentSchedules)
         .where(eq(bookingPaymentSchedules.id, schedule.id))
       expect(storedSchedule?.status).toBe("paid")
+      const [payment] = await db.select().from(payments).where(eq(payments.id, data.paymentId))
+      expect(payment?.status).toBe("completed")
+      expect(payment?.invoiceId).toBe(invoice.id)
+
+      const [storedInvoice] = await db.select().from(invoices).where(eq(invoices.id, invoice.id))
+      expect(storedInvoice?.paidCents).toBe(schedule.amountCents)
+      expect(storedInvoice?.balanceDueCents).toBe(0)
+      expect(storedInvoice?.status).toBe("paid")
       expect(schedulePaidEvents).toHaveLength(1)
       expect(schedulePaidEvents[0]).toMatchObject({
         bookingId: booking.id,
         bookingPaymentScheduleId: schedule.id,
         paymentSessionId: session.id,
-        paymentId: null,
+        paymentId: data.paymentId,
         scheduleType: schedule.scheduleType,
         amountCents: schedule.amountCents,
         currency: schedule.currency,
@@ -666,6 +679,7 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
         targetType: "booking_payment_schedule",
         targetId: schedule.id,
         bookingId: booking.id,
+        invoiceId: invoice.id,
         bookingPaymentScheduleId: schedule.id,
         bookingGuaranteeId: null,
         amountCents: 25000,
@@ -679,6 +693,87 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       })
       expect(retryRes.status).toBe(200)
       expect(schedulePaidEvents).toHaveLength(1)
+    })
+
+    it("does not double-count one payment linked by multiple paid sessions", async () => {
+      const booking = await seedBooking()
+      const schedule = await seedBookingPaymentSchedule(booking.id, { amountCents: 10000 })
+      const invoice = await seedInvoice(booking.id, { totalCents: 10000, balanceDueCents: 10000 })
+
+      const paymentRes = await app.request(`/invoices/${invoice.id}/payments`, {
+        method: "POST",
+        ...json({
+          amountCents: 6000,
+          currency: "USD",
+          paymentMethod: "bank_transfer",
+          paymentDate: "2025-06-20",
+          status: "completed",
+        }),
+      })
+      expect(paymentRes.status).toBe(201)
+      const { data: payment } = await paymentRes.json()
+
+      for (const clientReference of ["duplicate-a", "duplicate-b"]) {
+        const sessionRes = await app.request("/payment-sessions", {
+          method: "POST",
+          ...json({
+            targetType: "booking_payment_schedule",
+            targetId: schedule.id,
+            bookingId: booking.id,
+            invoiceId: invoice.id,
+            bookingPaymentScheduleId: schedule.id,
+            paymentId: payment.id,
+            status: "paid",
+            currency: "USD",
+            amountCents: 6000,
+            clientReference,
+          }),
+        })
+        expect(sessionRes.status).toBe(201)
+      }
+
+      const res = await app.request(`/bookings/${booking.id}/payment-schedules/${schedule.id}`, {
+        method: "PATCH",
+        ...json({ status: "paid" }),
+      })
+      expect(res.status).toBe(400)
+
+      const [storedSchedule] = await db
+        .select()
+        .from(bookingPaymentSchedules)
+        .where(eq(bookingPaymentSchedules.id, schedule.id))
+      expect(storedSchedule?.status).toBe("pending")
+    })
+
+    it("rejects completing a paid booking schedule session when no invoice can receive the payment", async () => {
+      const booking = await seedBooking()
+      const schedule = await seedBookingPaymentSchedule(booking.id)
+      const createRes = await app.request("/payment-sessions", {
+        method: "POST",
+        ...json({
+          bookingId: booking.id,
+          bookingPaymentScheduleId: schedule.id,
+          currency: "USD",
+          amountCents: 25000,
+          provider: "netopia",
+        }),
+      })
+      const { data: session } = await createRes.json()
+
+      const res = await app.request(`/payment-sessions/${session.id}/complete`, {
+        method: "POST",
+        ...json({ status: "paid", paymentMethod: "credit_card" }),
+      })
+      expect(res.status).toBe(400)
+
+      const [storedSchedule] = await db
+        .select()
+        .from(bookingPaymentSchedules)
+        .where(eq(bookingPaymentSchedules.id, schedule.id))
+      expect(storedSchedule?.status).toBe("pending")
+
+      const storedPayments = await db.select().from(payments)
+      expect(storedPayments).toHaveLength(0)
     })
 
     it("fails and lists payment sessions by status", async () => {
@@ -1903,11 +1998,33 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
 
       const res = await app.request(`/bookings/${booking.id}/payment-schedules/${schedule.id}`, {
         method: "PATCH",
-        ...json({ status: "paid" }),
+        ...json({ status: "due" }),
       })
       expect(res.status).toBe(200)
       const { data } = await res.json()
-      expect(data.status).toBe("paid")
+      expect(data.status).toBe("due")
+    })
+
+    it("rejects directly marking a payment schedule paid without linked completed payment coverage", async () => {
+      const booking = await seedBooking()
+
+      const createRes = await app.request(`/bookings/${booking.id}/payment-schedules`, {
+        method: "POST",
+        ...json({ dueDate: "2025-06-15", currency: "USD", amountCents: 10000 }),
+      })
+      const { data: schedule } = await createRes.json()
+
+      const res = await app.request(`/bookings/${booking.id}/payment-schedules/${schedule.id}`, {
+        method: "PATCH",
+        ...json({ status: "paid" }),
+      })
+      expect(res.status).toBe(400)
+
+      const [storedSchedule] = await db
+        .select()
+        .from(bookingPaymentSchedules)
+        .where(eq(bookingPaymentSchedules.id, schedule.id))
+      expect(storedSchedule?.status).toBe("pending")
     })
 
     it("deletes a payment schedule", async () => {


### PR DESCRIPTION
## Summary
- Require booking payment schedules to have linked completed payment coverage before they can be marked `paid`
- Materialize a `payments` row against an outstanding booking invoice when a schedule payment session completes
- Return validation errors for direct paid schedule mutations that would create drift

Closes #1119

## Verification
- `pnpm --filter @voyantjs/finance lint`
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/finance test`
- Push hook full test lane: 127 successful / 127 total