### PR TITLE
Relax booking billing contact validation

### DIFF
--- a/.changeset/soft-phones-wave.md
+++ b/.changeset/soft-phones-wave.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/finance": patch
+---
+
+Allow booking creation payloads with a billing person to use a phone number as the required contact channel when no real email is available.

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -153,6 +153,7 @@ function requireCompleteBookingParty(
     contactFirstName?: string | null
     contactLastName?: string | null
     contactEmail?: string | null
+    contactPhone?: string | null
     travelers?: Array<{
       firstName: string
       lastName: string
@@ -178,11 +179,21 @@ function requireCompleteBookingParty(
         message: "Billing person requires first and last name",
       })
     }
-    if (!isRealEmail(value.contactEmail)) {
+    const hasRealEmail = isRealEmail(value.contactEmail)
+    const hasPhone = Boolean(value.contactPhone?.trim())
+
+    if (value.contactEmail && !hasRealEmail) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["contactEmail"],
-        message: "Billing person requires a real email address",
+        message: "Billing email cannot be a placeholder address",
+      })
+    }
+    if (!hasRealEmail && !hasPhone) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["contactEmail"],
+        message: "Billing person requires an email or phone number",
       })
     }
   } else if (value.contactEmail && !isRealEmail(value.contactEmail)) {

--- a/packages/finance/tests/unit/validation-booking-create.test.ts
+++ b/packages/finance/tests/unit/validation-booking-create.test.ts
@@ -90,6 +90,27 @@ describe("bookingCreateSchema", () => {
     ).toThrow()
   })
 
+  it("accepts phone-only billing contact for a person", () => {
+    const result = bookingCreateSchema.parse({
+      ...valid,
+      contactEmail: null,
+      contactPhone: "test-phone-number",
+    })
+
+    expect(result.contactPhone).toBe("test-phone-number")
+    expect(result.contactEmail).toBeNull()
+  })
+
+  it("requires billing person email or phone", () => {
+    expect(() =>
+      bookingCreateSchema.parse({
+        ...valid,
+        contactEmail: null,
+        contactPhone: "   ",
+      }),
+    ).toThrow("Billing person requires an email or phone number")
+  })
+
   it("rejects placeholder billing emails", () => {
     expect(() =>
       bookingCreateSchema.parse({
@@ -97,5 +118,15 @@ describe("bookingCreateSchema", () => {
         contactEmail: "noreply@example.com",
       }),
     ).toThrow()
+  })
+
+  it("rejects placeholder billing emails even when a phone is supplied", () => {
+    expect(() =>
+      bookingCreateSchema.parse({
+        ...valid,
+        contactEmail: "noreply@example.com",
+        contactPhone: "test-phone-number",
+      }),
+    ).toThrow("Billing email cannot be a placeholder address")
   })
 })


### PR DESCRIPTION
## Summary

- Allow booking create payloads with a billing person to satisfy contact requirements with either a real email or a non-empty phone value.
- Keep placeholder email rejection when an email is supplied, even if a phone is also present.
- Add finance validation coverage and a patch changeset for @voyantjs/finance.

Closes #1125

## Validation

- pnpm --filter @voyantjs/finance test -- --runInBand packages/finance/tests/unit/validation-booking-create.test.ts
- pnpm --filter @voyantjs/finance typecheck
- pnpm --filter @voyantjs/finance lint
- pre-commit hook: full lint/typecheck
- pre-push hook: monorepo tests