### PR TITLE
crm: accept empty person email as absent

### DIFF
--- a/.changeset/crm-empty-email.md
+++ b/.changeset/crm-empty-email.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/crm": patch
+---
+
+Allow CRM person validation to treat an empty email string as absent while still validating non-empty email values.

--- a/packages/crm/src/validation.ts
+++ b/packages/crm/src/validation.ts
@@ -130,7 +130,10 @@ export const personCoreSchema = z.object({
   loyaltyEncrypted: z.lazy(() => kmsEnvelopeSchema).optional(),
   insuranceEncrypted: z.lazy(() => kmsEnvelopeSchema).optional(),
   // Inline identity fields — synced to identity module on create/update
-  email: z.string().email().nullable().optional(),
+  email: z.preprocess(
+    (value) => (value === "" ? null : value),
+    z.string().email().nullable().optional(),
+  ),
   phone: z.string().nullable().optional(),
   website: z
     .string()

--- a/packages/crm/tests/unit/validation-accounts.test.ts
+++ b/packages/crm/tests/unit/validation-accounts.test.ts
@@ -157,6 +157,15 @@ describe("Person schemas", () => {
       expect(result.email).toBeNull()
     })
 
+    it("transforms empty email to null", () => {
+      const result = insertPersonSchema.parse({
+        firstName: "John",
+        lastName: "Doe",
+        email: "",
+      })
+      expect(result.email).toBeNull()
+    })
+
     it("accepts phone number", () => {
       const result = insertPersonSchema.parse({
         firstName: "John",


### PR DESCRIPTION
## Summary

- Normalize `email: ""` to `null` in CRM person validation while preserving validation for non-empty email values.
- Add unit coverage for empty email form payloads.
- Add a patch changeset for `@voyantjs/crm`.

Closes #1129.

## Verification

- `pnpm --filter @voyantjs/crm exec vitest run tests/unit/validation-accounts.test.ts`
- `pnpm --filter @voyantjs/crm typecheck`
- `pnpm --filter @voyantjs/crm lint`
- `pnpm --filter @voyantjs/crm test`
- `pnpm typecheck:affected`
- `pnpm test:affected`
- `pnpm verify:architecture`
- commit hook: full lint + full typecheck
- pre-push hook: full test suite