### PR TITLE
Add inline invoice rendition wait responses

### DIFF
--- a/.changeset/invoice-rendition-wait.md
+++ b/.changeset/invoice-rendition-wait.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/finance": minor
+---
+
+Add bounded invoice rendition wait responses with inline document download URLs for interactive finance flows.

--- a/docs/architecture/invoice-rendition-wait.md
+++ b/docs/architecture/invoice-rendition-wait.md
@@ -1,0 +1,26 @@
+# Invoice Rendition Wait Contract
+
+Interactive invoice callers may request a short bounded wait for a generated
+document by passing `wait: "pdf"` or `wait=true` on supported invoice routes.
+The wait is additive: omitted or `wait: "none"` preserves the historical
+response shape.
+
+Supported surfaces:
+
+- `POST /v1/admin/finance/invoices/from-booking`
+- `POST /v1/admin/finance/invoices/:id/render`
+- `POST /v1/admin/finance/invoices/:id/generate-document` and
+  `/regenerate-document` attach a `download` envelope when the generated
+  rendition already has a resolvable URL.
+
+Waits are capped at 60 seconds and default to 30 seconds. Routes poll
+`invoice_renditions` for the target invoice and requested format until a
+terminal `ready` or `failed` rendition exists. A ready rendition returns an
+inline `download` envelope when the deployment has a document URL resolver or
+the rendition metadata carries a URL. Timeout, failed, or not-downloadable
+renditions return `202 Accepted` with the invoice/rendition metadata so callers
+can continue with the regular rendition download or polling flow.
+
+Routes must use the shared `waitForInvoiceRendition(...)` helper and
+`resolveStoredDocumentDownload(...)` rather than implementing custom polling or
+metadata URL parsing.

--- a/packages/finance/src/document-download.ts
+++ b/packages/finance/src/document-download.ts
@@ -1,0 +1,83 @@
+export interface DocumentDownloadEnvelope {
+  url: string
+  expiresAt: string | null
+}
+
+export type DocumentDownloadResolution =
+  | { status: "ready"; download: DocumentDownloadEnvelope }
+  | { status: "resolver_not_configured" }
+  | { status: "not_available" }
+
+export type DocumentDownloadResolver = (
+  bindings: unknown,
+  storageKey: string,
+) => Promise<string | null> | string | null
+
+export interface StoredDocumentReference {
+  storageKey?: string | null
+  metadata?: unknown
+}
+
+function getMetadataRecord(metadata: unknown) {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return null
+  }
+
+  return metadata as Record<string, unknown>
+}
+
+function maybeUrl(value: unknown) {
+  return typeof value === "string" && /^https?:\/\//i.test(value) ? value : null
+}
+
+function maybeIsoString(value: unknown) {
+  return typeof value === "string" && value.length > 0 ? value : null
+}
+
+function getFallbackDownload(metadata: unknown): DocumentDownloadEnvelope | null {
+  const record = getMetadataRecord(metadata)
+  if (!record) {
+    return null
+  }
+
+  const url = maybeUrl(record.url) ?? maybeUrl(record.downloadUrl)
+  if (!url) {
+    return null
+  }
+
+  return {
+    url,
+    expiresAt: maybeIsoString(record.expiresAt) ?? maybeIsoString(record.expires_at),
+  }
+}
+
+export async function resolveStoredDocumentDownload(
+  reference: StoredDocumentReference,
+  options: {
+    bindings: unknown
+    resolveDocumentDownloadUrl?: DocumentDownloadResolver
+  },
+): Promise<DocumentDownloadResolution> {
+  let needsResolver = false
+  if (reference.storageKey) {
+    if (!options.resolveDocumentDownloadUrl) {
+      needsResolver = true
+    } else {
+      const url = await options.resolveDocumentDownloadUrl(options.bindings, reference.storageKey)
+      if (url) {
+        return { status: "ready" as const, download: { url, expiresAt: null } }
+      }
+    }
+  }
+
+  const fallback = getFallbackDownload(reference.metadata)
+  if (fallback) {
+    return { status: "ready" as const, download: fallback }
+  }
+
+  if (needsResolver) {
+    return { status: "resolver_not_configured" as const }
+  }
+
+  return { status: "not_available" as const }
+}

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -111,6 +111,13 @@ export {
   type UpdateBookingTaxSettings,
 } from "./booking-tax.js"
 export {
+  type DocumentDownloadEnvelope,
+  type DocumentDownloadResolution,
+  type DocumentDownloadResolver,
+  resolveStoredDocumentDownload,
+  type StoredDocumentReference,
+} from "./document-download.js"
+export {
   createInvoiceFxHonoExtension,
   createInvoiceFxRoutes,
   createVoyantDataFxExchangeRateResolver,
@@ -299,6 +306,14 @@ export {
 } from "./service-documents.js"
 export type { InvoiceIssuedEvent, InvoiceIssueRuntime } from "./service-issue.js"
 export { issueInvoiceFromBooking, issueProformaFromBooking } from "./service-issue.js"
+export {
+  getLatestInvoiceRendition,
+  type InvoiceRenditionWaitMode,
+  type WaitForInvoiceRenditionOptions,
+  type WaitForInvoiceRenditionResult,
+  waitForInvoiceRendition,
+  waitFormatForMode,
+} from "./service-rendition-wait.js"
 export type {
   FinanceSettlementRuntimeOptions,
   InvoiceSettledEvent,

--- a/packages/finance/src/routes-documents.ts
+++ b/packages/finance/src/routes-documents.ts
@@ -3,6 +3,7 @@ import { parseOptionalJsonBody } from "@voyantjs/hono"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
 
+import { resolveStoredDocumentDownload } from "./document-download.js"
 import {
   buildFinanceRouteRuntime,
   FINANCE_ROUTE_RUNTIME_CONTAINER_KEY,
@@ -49,27 +50,6 @@ function getRuntime(
   )
 }
 
-function getMetadataRecord(metadata: unknown) {
-  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
-    return null
-  }
-
-  return metadata as Record<string, unknown>
-}
-
-function maybeUrl(value: unknown) {
-  return typeof value === "string" && /^https?:\/\//i.test(value) ? value : null
-}
-
-function getFallbackDownloadUrl(metadata: unknown) {
-  const record = getMetadataRecord(metadata)
-  if (!record) {
-    return null
-  }
-
-  return maybeUrl(record.url)
-}
-
 export function createFinanceAdminDocumentRoutes(options: FinanceDocumentRouteOptions = {}) {
   return new Hono<Env>()
     .post("/invoices/:id/generate-document", async (c) => {
@@ -90,8 +70,11 @@ export function createFinanceAdminDocumentRoutes(options: FinanceDocumentRouteOp
       if (result.status === "generator_failed") {
         return c.json({ error: "Invoice document generation failed" }, 502)
       }
+      if (!("rendition" in result)) {
+        return c.json({ error: "Invoice document generation failed" }, 502)
+      }
 
-      return c.json({ data: result }, 201)
+      return c.json({ data: await attachDownloadEnvelope(c.env, runtime, result) }, 201)
     })
     .post("/invoices/:id/regenerate-document", async (c) => {
       const runtime = getRuntime(options, c.env, (key) => c.var.container?.resolve(key))
@@ -111,28 +94,40 @@ export function createFinanceAdminDocumentRoutes(options: FinanceDocumentRouteOp
       if (result.status === "generator_failed") {
         return c.json({ error: "Invoice document generation failed" }, 502)
       }
+      if (!("rendition" in result)) {
+        return c.json({ error: "Invoice document generation failed" }, 502)
+      }
 
-      return c.json({ data: result })
+      return c.json({ data: await attachDownloadEnvelope(c.env, runtime, result) })
     })
     .get("/invoice-renditions/:id/download", async (c) => {
+      const runtime = getRuntime(options, c.env, (key) => c.var.container?.resolve(key))
       const rendition = await financeService.getInvoiceRenditionById(c.get("db"), c.req.param("id"))
       if (!rendition) {
         return c.json({ error: "Invoice rendition not found" }, 404)
       }
 
-      let location: string | null = null
-      if (rendition.storageKey) {
-        if (!options.resolveDocumentDownloadUrl) {
-          return c.json({ error: "Document download resolver is not configured" }, 501)
-        }
-        location = await options.resolveDocumentDownloadUrl(c.env, rendition.storageKey)
+      const download = await resolveStoredDocumentDownload(rendition, {
+        bindings: c.env,
+        resolveDocumentDownloadUrl: runtime.resolveDocumentDownloadUrl,
+      })
+      if (download.status === "resolver_not_configured") {
+        return c.json({ error: "Document download resolver is not configured" }, 501)
       }
-
-      location ??= getFallbackDownloadUrl(rendition.metadata)
-      if (!location) {
+      if (download.status !== "ready") {
         return c.json({ error: "Invoice document is not available" }, 404)
       }
 
-      return c.redirect(location, 302)
+      return c.redirect(download.download.url, 302)
     })
+}
+
+async function attachDownloadEnvelope<
+  T extends { rendition: { storageKey?: string | null; metadata?: unknown } },
+>(bindings: Record<string, unknown>, runtime: FinanceRouteRuntime, result: T) {
+  const download = await resolveStoredDocumentDownload(result.rendition, {
+    bindings,
+    resolveDocumentDownloadUrl: runtime.resolveDocumentDownloadUrl,
+  })
+  return download.status === "ready" ? { ...result, download: download.download } : result
 }

--- a/packages/finance/src/routes.ts
+++ b/packages/finance/src/routes.ts
@@ -2,10 +2,16 @@ import { parseJsonBody, parseQuery, requireUserId } from "@voyantjs/hono"
 import type { Context } from "hono"
 import { Hono } from "hono"
 
+import { resolveStoredDocumentDownload } from "./document-download.js"
 import { FINANCE_ROUTE_RUNTIME_CONTAINER_KEY, type FinanceRouteRuntime } from "./route-runtime.js"
 import type { publicFinanceRoutes } from "./routes-public.js"
 import type { Env } from "./routes-shared.js"
 import { financeService, InvoiceNumberAllocationError, PaymentValidationError } from "./service.js"
+import {
+  type InvoiceRenditionWaitMode,
+  waitForInvoiceRendition,
+  waitFormatForMode,
+} from "./service-rendition-wait.js"
 import { VoucherServiceError } from "./service-vouchers.js"
 import {
   agingReportQuerySchema,
@@ -42,6 +48,7 @@ import {
   insertTaxPolicyRuleSchema,
   insertTaxRegimeSchema,
   insertVoucherSchema,
+  invoiceDocumentWaitQuerySchema,
   invoiceFromBookingSchema,
   invoiceListQuerySchema,
   invoiceNumberSeriesListQuerySchema,
@@ -88,25 +95,27 @@ import {
 // Finance Routes — method-chained for Hono RPC type inference
 // ==========================================================================
 
-function getMetadataRecord(metadata: unknown) {
-  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
-    return null
-  }
+const DEFAULT_RENDITION_WAIT_TIMEOUT_MS = 30_000
 
-  return metadata as Record<string, unknown>
+function resolveWaitRequest(
+  body: { wait?: InvoiceRenditionWaitMode; waitTimeoutMs?: number | undefined },
+  query: { wait?: InvoiceRenditionWaitMode; waitTimeoutMs?: number | undefined },
+) {
+  return {
+    mode: query.wait ?? body.wait ?? "none",
+    timeoutMs: query.waitTimeoutMs ?? body.waitTimeoutMs ?? DEFAULT_RENDITION_WAIT_TIMEOUT_MS,
+  }
 }
 
-function maybeUrl(value: unknown) {
-  return typeof value === "string" && /^https?:\/\//i.test(value) ? value : null
-}
-
-function getFallbackDownloadUrl(metadata: unknown) {
-  const record = getMetadataRecord(metadata)
-  if (!record) {
-    return null
-  }
-
-  return maybeUrl(record.url)
+async function buildInlineDownload(
+  c: Context<Env>,
+  reference: { storageKey?: string | null; metadata?: unknown },
+) {
+  const runtime = getFinanceRouteRuntime(c)
+  return resolveStoredDocumentDownload(reference, {
+    bindings: c.env,
+    resolveDocumentDownloadUrl: runtime?.resolveDocumentDownloadUrl,
+  })
 }
 
 function getFinanceRouteRuntime(c: { var: { container?: { resolve: <T>(key: string) => T } } }) {
@@ -928,6 +937,7 @@ export const financeRoutes = new Hono<Env>()
   // POST /invoices/from-booking — Create + issue invoice (or proforma) from booking + booking items
   .post("/invoices/from-booking", async (c) => {
     const input = await parseJsonBody(c, invoiceFromBookingSchema)
+    const waitRequest = resolveWaitRequest(input, parseQuery(c, invoiceDocumentWaitQuerySchema))
     const db = c.get("db")
     const [
       { bookingItems, bookings },
@@ -1003,7 +1013,29 @@ export const financeRoutes = new Hono<Env>()
       throw error
     }
 
-    return c.json({ data: row }, 201)
+    if (!row || waitRequest.mode === "none") {
+      return c.json({ data: row }, 201)
+    }
+
+    const waitResult = await waitForInvoiceRendition(db, row.id, {
+      format: waitFormatForMode(waitRequest.mode),
+      timeoutMs: waitRequest.timeoutMs,
+    })
+    const payload = {
+      invoice: row,
+      rendition: waitResult.rendition,
+    }
+
+    if (waitResult.status !== "ready") {
+      return c.json({ data: payload }, 202)
+    }
+
+    const download = await buildInlineDownload(c, waitResult.rendition)
+    if (download.status !== "ready") {
+      return c.json({ data: payload }, 202)
+    }
+
+    return c.json({ data: { ...payload, download: download.download } }, 201)
   })
 
   // POST /invoices/:id/convert-to-invoice — Convert a proforma into a final invoice
@@ -1623,21 +1655,15 @@ export const financeRoutes = new Hono<Env>()
     const attachment = await financeService.getInvoiceAttachmentById(c.get("db"), c.req.param("id"))
     if (!attachment) return c.json({ error: "Attachment not found" }, 404)
 
-    let location: string | null = null
-    if (attachment.storageKey) {
-      const runtime = getFinanceRouteRuntime(c)
-      if (!runtime?.resolveDocumentDownloadUrl) {
-        return c.json({ error: "Document download resolver is not configured" }, 501)
-      }
-      location = await runtime.resolveDocumentDownloadUrl(c.env, attachment.storageKey)
+    const download = await buildInlineDownload(c, attachment)
+    if (download.status === "resolver_not_configured") {
+      return c.json({ error: "Document download resolver is not configured" }, 501)
     }
-
-    location ??= getFallbackDownloadUrl(attachment.metadata)
-    if (!location) {
+    if (download.status !== "ready") {
       return c.json({ error: "Attachment file is not available" }, 404)
     }
 
-    return c.redirect(location, 302)
+    return c.redirect(download.download.url, 302)
   })
 
   .delete("/invoices/:id/attachments/:attachmentId", async (c) => {
@@ -1652,8 +1678,29 @@ export const financeRoutes = new Hono<Env>()
 
   .post("/invoices/:id/render", async (c) => {
     const input = await parseJsonBody(c, renderInvoiceInputSchema)
+    const waitRequest = resolveWaitRequest(input, parseQuery(c, invoiceDocumentWaitQuerySchema))
     const result = await financeService.renderInvoice(c.get("db"), c.req.param("id"), input)
     if (result.status === "not_found") return c.json({ error: "Invoice not found" }, 404)
+    if (waitRequest.mode !== "none" && result.rendition) {
+      const waitResult = await waitForInvoiceRendition(c.get("db"), c.req.param("id"), {
+        renditionId: result.rendition.id,
+        format: waitFormatForMode(waitRequest.mode),
+        timeoutMs: waitRequest.timeoutMs,
+      })
+      const payload = {
+        rendition: waitResult.rendition ?? result.rendition,
+      }
+      if (waitResult.status !== "ready") {
+        return c.json({ data: payload }, 202)
+      }
+
+      const download = await buildInlineDownload(c, waitResult.rendition)
+      if (download.status !== "ready") {
+        return c.json({ data: payload }, 202)
+      }
+
+      return c.json({ data: { ...payload, download: download.download } }, 201)
+    }
     return c.json({ data: result.rendition }, 201)
   })
 

--- a/packages/finance/src/service-rendition-wait.ts
+++ b/packages/finance/src/service-rendition-wait.ts
@@ -1,0 +1,104 @@
+import { and, desc, eq, inArray } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { type InvoiceRendition, invoiceRenditions } from "./schema.js"
+
+export type InvoiceRenditionWaitMode = "none" | "pdf" | "any"
+
+export interface WaitForInvoiceRenditionOptions {
+  format?: InvoiceRendition["format"]
+  renditionId?: string
+  timeoutMs?: number
+  intervalMs?: number
+}
+
+export type WaitForInvoiceRenditionResult =
+  | { status: "ready"; rendition: InvoiceRendition }
+  | { status: "failed"; rendition: InvoiceRendition }
+  | { status: "timeout"; rendition: InvoiceRendition | null }
+
+const DEFAULT_TIMEOUT_MS = 30_000
+const DEFAULT_INTERVAL_MS = 250
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function clampWaitTimeout(timeoutMs: number | undefined) {
+  if (timeoutMs == null || Number.isNaN(timeoutMs)) return DEFAULT_TIMEOUT_MS
+  return Math.max(0, Math.min(60_000, timeoutMs))
+}
+
+async function findTerminalRendition(
+  db: PostgresJsDatabase,
+  invoiceId: string,
+  options: Pick<WaitForInvoiceRenditionOptions, "format" | "renditionId">,
+) {
+  const conditions = [
+    eq(invoiceRenditions.invoiceId, invoiceId),
+    inArray(invoiceRenditions.status, ["ready", "failed"]),
+  ]
+  if (options.renditionId) conditions.push(eq(invoiceRenditions.id, options.renditionId))
+  if (options.format) conditions.push(eq(invoiceRenditions.format, options.format))
+
+  const [row] = await db
+    .select()
+    .from(invoiceRenditions)
+    .where(and(...conditions))
+    .orderBy(desc(invoiceRenditions.createdAt))
+    .limit(1)
+
+  return row ?? null
+}
+
+export async function getLatestInvoiceRendition(
+  db: PostgresJsDatabase,
+  invoiceId: string,
+  options: Pick<WaitForInvoiceRenditionOptions, "format" | "renditionId"> = {},
+) {
+  const conditions = [eq(invoiceRenditions.invoiceId, invoiceId)]
+  if (options.renditionId) conditions.push(eq(invoiceRenditions.id, options.renditionId))
+  if (options.format) conditions.push(eq(invoiceRenditions.format, options.format))
+
+  const [row] = await db
+    .select()
+    .from(invoiceRenditions)
+    .where(and(...conditions))
+    .orderBy(desc(invoiceRenditions.createdAt))
+    .limit(1)
+
+  return row ?? null
+}
+
+export async function waitForInvoiceRendition(
+  db: PostgresJsDatabase,
+  invoiceId: string,
+  options: WaitForInvoiceRenditionOptions = {},
+): Promise<WaitForInvoiceRenditionResult> {
+  const timeoutMs = clampWaitTimeout(options.timeoutMs)
+  const intervalMs = Math.max(10, options.intervalMs ?? DEFAULT_INTERVAL_MS)
+  const deadline = Date.now() + timeoutMs
+
+  while (true) {
+    const rendition = await findTerminalRendition(db, invoiceId, options)
+    if (rendition) {
+      return rendition.status === "ready"
+        ? { status: "ready" as const, rendition }
+        : { status: "failed" as const, rendition }
+    }
+
+    const remainingMs = deadline - Date.now()
+    if (remainingMs <= 0) {
+      return {
+        status: "timeout" as const,
+        rendition: await getLatestInvoiceRendition(db, invoiceId, options),
+      }
+    }
+
+    await sleep(Math.min(intervalMs, remainingMs))
+  }
+}
+
+export function waitFormatForMode(mode: InvoiceRenditionWaitMode) {
+  return mode === "pdf" ? "pdf" : undefined
+}

--- a/packages/finance/src/validation-billing.ts
+++ b/packages/finance/src/validation-billing.ts
@@ -99,6 +99,21 @@ export const invoiceListQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(50),
   offset: z.coerce.number().int().min(0).default(0),
 })
+
+const invoiceDocumentWaitModeSchema = z.preprocess(
+  (value) => {
+    if (value === true || value === "true") return "pdf"
+    if (value === false || value === "false") return "none"
+    return value
+  },
+  z.enum(["none", "pdf", "any"]),
+)
+
+const invoiceDocumentWaitFieldsSchema = z.object({
+  wait: invoiceDocumentWaitModeSchema.optional(),
+  waitTimeoutMs: z.coerce.number().int().min(0).max(60_000).optional(),
+})
+
 export const invoiceFromBookingSchema = z.object({
   bookingId: z.string().min(1),
   invoiceNumber: z.string().min(1).max(50).optional(),
@@ -112,6 +127,8 @@ export const invoiceFromBookingSchema = z.object({
    * payment lands and a real invoice replaces it.
    */
   invoiceType: z.enum(["invoice", "proforma"]).default("invoice"),
+  wait: invoiceDocumentWaitModeSchema.optional(),
+  waitTimeoutMs: z.coerce.number().int().min(0).max(60_000).optional(),
 })
 
 const lineItemCoreSchema = z.object({
@@ -379,11 +396,15 @@ export const renderInvoiceInputSchema = z.object({
   templateId: z.string().optional().nullable(),
   format: invoiceRenditionFormatSchema.default("pdf"),
   language: z.string().optional().nullable(),
+  wait: invoiceDocumentWaitModeSchema.optional(),
+  waitTimeoutMs: z.coerce.number().int().min(0).max(60_000).optional(),
 })
 
 export const generateInvoiceDocumentInputSchema = renderInvoiceInputSchema.extend({
   replaceExisting: z.boolean().default(true),
 })
+
+export const invoiceDocumentWaitQuerySchema = invoiceDocumentWaitFieldsSchema
 
 export const generatedInvoiceDocumentResultSchema = z.object({
   invoiceId: z.string(),

--- a/packages/finance/tests/integration/document-routes.test.ts
+++ b/packages/finance/tests/integration/document-routes.test.ts
@@ -146,6 +146,10 @@ describe.skipIf(!DB_AVAILABLE)("Finance document routes", () => {
     expect(firstBody.data.renderedBody).toContain("INV-1001")
     expect(firstBody.data.rendition.status).toBe("ready")
     expect(firstBody.data.rendition.storageKey).toContain("rendition-1.pdf")
+    expect(firstBody.data.download).toEqual({
+      url: `https://signed.example.com/${firstBody.data.rendition.storageKey}`,
+      expiresAt: null,
+    })
 
     const secondRes = await app.request(`/invoices/${invoice.id}/regenerate-document`, {
       method: "POST",

--- a/packages/finance/tests/integration/routes.test.ts
+++ b/packages/finance/tests/integration/routes.test.ts
@@ -8,11 +8,13 @@ import { FINANCE_ROUTE_RUNTIME_CONTAINER_KEY } from "../../src/route-runtime.js"
 import { financeRoutes } from "../../src/routes.js"
 import {
   bookingPaymentSchedules,
+  invoiceRenditions,
   paymentAuthorizations,
   paymentCaptures,
   paymentSessions,
   payments,
 } from "../../src/schema.js"
+import { financeService } from "../../src/service.js"
 
 const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
 const ORIGINAL_TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
@@ -105,6 +107,7 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
   const settlementEvents: Array<Record<string, unknown>> = []
   const paymentCompletedEvents: Array<Record<string, unknown>> = []
   const schedulePaidEvents: Array<Record<string, unknown>> = []
+  const autoRenditionBookings = new Map<string, { delayMs: number; storageKey: string }>()
 
   beforeAll(async () => {
     process.env.TEST_DATABASE_URL = getIsolatedFinanceTestDbUrl(process.env.TEST_DATABASE_URL)
@@ -253,6 +256,20 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
     eventBus.subscribe("booking_payment_schedule.paid", (event) => {
       schedulePaidEvents.push(event as Record<string, unknown>)
     })
+    eventBus.subscribe("invoice.issued", (event) => {
+      const data = event.data as { invoiceId?: string; bookingId?: string | null }
+      if (!data.invoiceId || !data.bookingId) return
+      const request = autoRenditionBookings.get(data.bookingId)
+      if (!request) return
+      setTimeout(() => {
+        void financeService.bindInvoiceRendition(db, data.invoiceId!, {
+          format: "pdf",
+          storageKey: request.storageKey,
+          contentType: "application/pdf",
+          fileSize: 1024,
+        })
+      }, request.delayMs)
+    })
     const financeRouteRuntime = {
       eventBus,
       invoiceSettlementPollers: {},
@@ -283,6 +300,7 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
     settlementEvents.length = 0
     paymentCompletedEvents.length = 0
     schedulePaidEvents.length = 0
+    autoRenditionBookings.clear()
   })
 
   afterAll(async () => {
@@ -1325,6 +1343,66 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
         }),
       })
       expect(res.status).toBe(404)
+    })
+
+    it("waits for an issued invoice PDF and returns its download URL inline", async () => {
+      const booking = await seedBooking({ sellAmountCents: 20000 })
+      await seedBookingItem(booking.id)
+      autoRenditionBookings.set(booking.id, {
+        delayMs: 25,
+        storageKey: `invoices/${booking.id}/smartbill.pdf`,
+      })
+
+      const res = await app.request("/invoices/from-booking?wait=pdf&waitTimeoutMs=2000", {
+        method: "POST",
+        ...json({
+          bookingId: booking.id,
+          invoiceNumber: nextInvoiceNumber(),
+          issueDate: "2025-06-01",
+          dueDate: "2025-07-01",
+        }),
+      })
+
+      expect(res.status).toBe(201)
+      const { data } = await res.json()
+      expect(data.invoice.id).toMatch(/^inv_/)
+      expect(data.invoice.bookingId).toBe(booking.id)
+      expect(data.rendition).toMatchObject({
+        invoiceId: data.invoice.id,
+        format: "pdf",
+        status: "ready",
+        storageKey: `invoices/${booking.id}/smartbill.pdf`,
+      })
+      expect(data.download).toEqual({
+        url: `https://files.example/invoices/${booking.id}/smartbill.pdf`,
+        expiresAt: null,
+      })
+    })
+  })
+
+  describe("Invoice rendition wait", () => {
+    it("returns 202 with the pending rendition when render wait times out", async () => {
+      const booking = await seedBooking()
+      const invoice = await seedInvoice(booking.id)
+
+      const res = await app.request(`/invoices/${invoice.id}/render?wait=pdf&waitTimeoutMs=0`, {
+        method: "POST",
+        ...json({ format: "pdf" }),
+      })
+
+      expect(res.status).toBe(202)
+      const { data } = await res.json()
+      expect(data.rendition).toMatchObject({
+        invoiceId: invoice.id,
+        format: "pdf",
+        status: "pending",
+      })
+
+      const rows = await db
+        .select()
+        .from(invoiceRenditions)
+        .where(eq(invoiceRenditions.invoiceId, invoice.id))
+      expect(rows).toHaveLength(1)
     })
   })
 

--- a/packages/finance/tests/unit/document-download.test.ts
+++ b/packages/finance/tests/unit/document-download.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { resolveStoredDocumentDownload } from "../../src/document-download.js"
+
+describe("resolveStoredDocumentDownload", () => {
+  it("uses resolver URLs for storage-backed documents", async () => {
+    const resolver = vi.fn(async () => "https://signed.example.com/invoice.pdf")
+
+    await expect(
+      resolveStoredDocumentDownload(
+        {
+          storageKey: "invoices/inv_123.pdf",
+          metadata: { url: "https://cdn.example.com/fallback.pdf" },
+        },
+        { bindings: {}, resolveDocumentDownloadUrl: resolver },
+      ),
+    ).resolves.toEqual({
+      status: "ready",
+      download: {
+        url: "https://signed.example.com/invoice.pdf",
+        expiresAt: null,
+      },
+    })
+  })
+
+  it("falls back to metadata URL when the storage resolver is missing", async () => {
+    await expect(
+      resolveStoredDocumentDownload(
+        {
+          storageKey: "invoices/inv_123.pdf",
+          metadata: {
+            url: "https://cdn.example.com/invoice.pdf",
+            expiresAt: "2026-05-23T14:00:00.000Z",
+          },
+        },
+        { bindings: {} },
+      ),
+    ).resolves.toEqual({
+      status: "ready",
+      download: {
+        url: "https://cdn.example.com/invoice.pdf",
+        expiresAt: "2026-05-23T14:00:00.000Z",
+      },
+    })
+  })
+
+  it("reports missing resolver when a storage key has no metadata URL fallback", async () => {
+    await expect(
+      resolveStoredDocumentDownload({ storageKey: "invoices/inv_123.pdf" }, { bindings: {} }),
+    ).resolves.toEqual({ status: "resolver_not_configured" })
+  })
+})

--- a/packages/finance/tests/unit/validation-billing.test.ts
+++ b/packages/finance/tests/unit/validation-billing.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   insertInvoiceNumberSeriesSchema,
   invoiceFromBookingSchema,
+  renderInvoiceInputSchema,
 } from "../../src/validation-billing.js"
 
 describe("invoiceFromBookingSchema", () => {
@@ -28,6 +29,29 @@ describe("invoiceFromBookingSchema", () => {
 
     expect(result.seriesId).toBe("ins_123")
     expect(result.invoiceType).toBe("invoice")
+  })
+
+  it("accepts bounded document wait options", () => {
+    const result = invoiceFromBookingSchema.parse({
+      bookingId: "book_123",
+      invoiceNumber: "INV-123",
+      issueDate: "2026-05-23",
+      dueDate: "2026-06-23",
+      wait: true,
+      waitTimeoutMs: 10_000,
+    })
+
+    expect(result.wait).toBe("pdf")
+    expect(result.waitTimeoutMs).toBe(10_000)
+  })
+})
+
+describe("renderInvoiceInputSchema", () => {
+  it("accepts wait=true as pdf wait mode", () => {
+    const result = renderInvoiceInputSchema.parse({ wait: "true" })
+
+    expect(result.format).toBe("pdf")
+    expect(result.wait).toBe("pdf")
   })
 })
 


### PR DESCRIPTION
## Summary
- Add bounded `wait` support for invoice-from-booking and queued invoice render responses, returning inline download URLs when renditions become ready.
- Add a shared invoice rendition polling helper and shared stored-document download envelope resolver.
- Attach download envelopes to synchronous invoice document generation when a rendition URL is resolvable.
- Document the wait contract and add a changeset.

Fixes #1134

## Verification
- `pnpm --filter @voyantjs/finance test -- --run tests/integration/routes.test.ts tests/integration/document-routes.test.ts tests/unit/validation-billing.test.ts`
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm lint:changed`
- `pnpm verify:architecture`
- commit hook lint/typecheck: `116` lint tasks, `126` typecheck tasks
- push hook full tests: `127 successful`

## Notes
- Local integration DB was not configured, so finance integration tests self-skipped in the local run; the test files were still loaded by Vitest.