### PR TITLE
Derive booking pax from travelers

### DIFF
--- a/.changeset/derive-booking-create-pax.md
+++ b/.changeset/derive-booking-create-pax.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/bookings": patch
+"@voyantjs/finance": patch
+---
+
+Derive booking-create pax from supplied travelers when pax is omitted, while preserving explicit pax values.

--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -2660,6 +2660,7 @@ export const bookingsService = {
     }
 
     const initialStatus = data.initialStatus ?? "draft"
+    const bookingPax = Object.hasOwn(data, "pax") ? (data.pax ?? null) : product.pax
     // Map the booking lifecycle status onto the booking-item lifecycle.
     // Items don't have an `awaiting_payment` state — when the booking is
     // committed (confirmed / awaiting payment / in progress) the items
@@ -2720,7 +2721,7 @@ export const bookingsService = {
         marginPercent: product.marginPercent,
         startDate,
         endDate,
-        pax: product.pax,
+        pax: bookingPax,
         internalNotes: data.internalNotes ?? null,
       })
       .returning()
@@ -2810,8 +2811,8 @@ export const bookingsService = {
         : unitsToSeed.length > 0
           ? unitsToSeed.map((unit, index) => {
               const quantity =
-                unit.unitType === "person" && product.pax
-                  ? product.pax
+                unit.unitType === "person" && bookingPax
+                  ? bookingPax
                   : unit.minQuantity && unit.minQuantity > 0
                     ? unit.minQuantity
                     : 1

--- a/packages/bookings/src/validation.ts
+++ b/packages/bookings/src/validation.ts
@@ -163,6 +163,7 @@ export const convertProductSchema = z
     bookingNumber: z.string().min(1).max(50),
     personId: z.string().optional().nullable(),
     organizationId: z.string().optional().nullable(),
+    pax: z.number().int().positive().optional().nullable(),
     internalNotes: z.string().optional().nullable(),
     /**
      * Override the seed `sellAmountCents` on the new booking + line item.

--- a/packages/bookings/tests/unit/validation-operations.test.ts
+++ b/packages/bookings/tests/unit/validation-operations.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   cancelBookingSchema,
   confirmBookingSchema,
+  convertProductSchema,
   expireBookingSchema,
   expireStaleBookingsSchema,
   extendBookingHoldSchema,
@@ -16,6 +17,16 @@ import {
 } from "../../src/validation.js"
 
 describe("Reservation schemas", () => {
+  it("parses explicit pax for product conversion", () => {
+    const result = convertProductSchema.parse({
+      productId: "prod_123",
+      bookingNumber: "BK-CONVERT-001",
+      pax: 3,
+    })
+
+    expect(result.pax).toBe(3)
+  })
+
   it("parses reserve booking input with policy-resolved hold minutes", () => {
     const result = reserveBookingSchema.parse({
       bookingNumber: "BK-RES-001",

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -243,6 +243,7 @@ const bookingCreateBaseSchema = z.object({
   bookingNumber: z.string().min(1),
   personId: z.string().optional().nullable(),
   organizationId: z.string().optional().nullable(),
+  pax: z.number().int().positive().optional().nullable(),
   internalNotes: z.string().optional().nullable(),
   /**
    * Override the seed `sellAmountCents` on the new booking + line item.
@@ -448,6 +449,22 @@ function todayIsoDate() {
   return new Date().toISOString().slice(0, 10)
 }
 
+export function deriveBookingCreatePax(input: {
+  pax?: number | null
+  travelers?: readonly { participantType?: string | null }[] | null
+}) {
+  if (Object.hasOwn(input, "pax")) {
+    return input.pax ?? null
+  }
+
+  const pax =
+    input.travelers?.filter((traveler) =>
+      [undefined, null, "traveler", "occupant"].includes(traveler.participantType),
+    ).length ?? 0
+
+  return pax > 0 ? pax : null
+}
+
 export async function createBooking(
   db: PostgresJsDatabase,
   rawInput: BookingCreateInput,
@@ -465,6 +482,7 @@ export async function createBooking(
     contractDocument: false,
     invoiceDocument: false,
   }
+  const pax = deriveBookingCreatePax(input)
 
   // Validate voucher up-front so we can short-circuit before the tx starts.
   // This is a cheap read — the authoritative balance check still happens
@@ -500,6 +518,7 @@ export async function createBooking(
         bookingNumber: input.bookingNumber,
         personId: input.personId ?? null,
         organizationId: input.organizationId ?? null,
+        pax,
         internalNotes: input.internalNotes ?? null,
         sellAmountCentsOverride: input.sellAmountCentsOverride ?? null,
         catalogSellAmountCents: input.catalogSellAmountCents ?? null,

--- a/packages/finance/tests/integration/booking-create.test.ts
+++ b/packages/finance/tests/integration/booking-create.test.ts
@@ -83,7 +83,7 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
     await closeTestDb()
   })
 
-  async function seedProduct() {
+  async function seedProduct({ pax = 2 }: { pax?: number | null } = {}) {
     productSeq += 1
     // Raw SQL keeps this free of a cross-package schema import. The booking-
     // create path only needs products + a default option + one option_unit;
@@ -104,7 +104,7 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
         40,
         '2026-07-01',
         '2026-07-03',
-        2
+        ${pax}
       )
     `)
     await db.execute(sql`
@@ -178,6 +178,75 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
       ],
     }
   }
+
+  it("derives booking pax from travelers when pax is omitted", async () => {
+    const { productId } = await seedProduct({ pax: null })
+
+    const outcome = await createBooking(db, {
+      productId,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+      travelers: [
+        {
+          firstName: "Alice",
+          lastName: "Lead",
+          email: "alice@example.com",
+          participantType: "traveler",
+          isPrimary: true,
+        },
+        {
+          firstName: "Bob",
+          lastName: "Companion",
+          participantType: "traveler",
+        },
+      ],
+    })
+
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+    expect(outcome.result.booking.pax).toBe(2)
+
+    const [bookingRow] = await db
+      .select()
+      .from(bookings)
+      .where(eq(bookings.id, outcome.result.booking.id))
+    expect(bookingRow?.pax).toBe(2)
+  })
+
+  it("keeps explicit booking pax when travelers are also supplied", async () => {
+    const { productId } = await seedProduct({ pax: null })
+
+    const outcome = await createBooking(db, {
+      productId,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+      pax: 4,
+      travelers: [
+        {
+          firstName: "Alice",
+          lastName: "Lead",
+          email: "alice@example.com",
+          participantType: "traveler",
+          isPrimary: true,
+        },
+        {
+          firstName: "Bob",
+          lastName: "Companion",
+          participantType: "traveler",
+        },
+      ],
+    })
+
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+    expect(outcome.result.booking.pax).toBe(4)
+
+    const [bookingRow] = await db
+      .select()
+      .from(bookings)
+      .where(eq(bookings.id, outcome.result.booking.id))
+    expect(bookingRow?.pax).toBe(4)
+  })
 
   it("creates booking + travelers + payment schedules atomically", async () => {
     const { productId } = await seedProduct()

--- a/packages/finance/tests/unit/validation-booking-create.test.ts
+++ b/packages/finance/tests/unit/validation-booking-create.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { bookingCreateSchema } from "../../src/service-booking-create.js"
+import { bookingCreateSchema, deriveBookingCreatePax } from "../../src/service-booking-create.js"
 
 describe("bookingCreateSchema", () => {
   const valid = {
@@ -128,5 +128,35 @@ describe("bookingCreateSchema", () => {
         contactPhone: "test-phone-number",
       }),
     ).toThrow("Billing email cannot be a placeholder address")
+  })
+})
+
+describe("deriveBookingCreatePax", () => {
+  it("keeps explicit pax", () => {
+    expect(deriveBookingCreatePax({ pax: 4, travelers: [{}, {}] })).toBe(4)
+  })
+
+  it("keeps explicit null pax", () => {
+    expect(deriveBookingCreatePax({ pax: null, travelers: [{}, {}] })).toBeNull()
+  })
+
+  it("derives pax from supplied travelers when omitted", () => {
+    expect(deriveBookingCreatePax({ travelers: [{}, {}] })).toBe(2)
+  })
+
+  it("excludes other participants when deriving pax", () => {
+    expect(
+      deriveBookingCreatePax({
+        travelers: [
+          { participantType: "traveler" },
+          { participantType: "other" },
+          { participantType: "occupant" },
+        ],
+      }),
+    ).toBe(2)
+  })
+
+  it("preserves null when pax and travelers are absent", () => {
+    expect(deriveBookingCreatePax({})).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary
- accept explicit `pax` in the finance booking-create payload and pass it through to product conversion
- derive booking `pax` from same-payload travelers when callers omit it
- preserve explicit `pax` values and add coverage for derived, explicit, and absent derivation cases

Closes #1130

## Verification
- `pnpm --filter @voyantjs/finance test -- tests/unit/validation-booking-create.test.ts`
- `pnpm --filter @voyantjs/bookings test -- tests/unit/validation-operations.test.ts`
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/bookings typecheck`
- commit hook: full lint and typecheck lanes
- pre-push hook: full test lane