### PR TITLE
Fix catalog price-from for rate-plan pricing

### DIFF
--- a/.changeset/future-rate-plan-price-from.md
+++ b/.changeset/future-rate-plan-price-from.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/pricing": patch
+---
+
+Derive catalog price-from values from future bookable rate-plan prices before falling back to product-row pricing, and treat zero as missing.

--- a/packages/pricing/src/service-catalog-plane-pricing.ts
+++ b/packages/pricing/src/service-catalog-plane-pricing.ts
@@ -184,11 +184,14 @@ async function defaultLoadRatePlanPricing(
       roomPrices: roomPrice == null ? [] : [roomPrice],
       basePrices: basePrice == null ? [] : [basePrice],
     }
-  } catch {
+  } catch (error) {
     // Slim test fixtures may omit availability_slots/product_options/
     // option_units. Keep reindex failure-isolated and fall back to the
-    // product row instead of failing the whole document build.
-    return { roomPrices: [], basePrices: [] }
+    // product row only for those expected schema gaps.
+    if (isMissingCatalogPricingDependencyError(error)) {
+      return { roomPrices: [], basePrices: [] }
+    }
+    throw error
   }
 }
 
@@ -360,6 +363,19 @@ function readNullableInt(row: unknown, key: string): number | null {
   return null
 }
 
+function isMissingCatalogPricingDependencyError(error: unknown): boolean {
+  const err = error as { code?: unknown; message?: unknown } | null | undefined
+  const code = typeof err?.code === "string" ? err.code : null
+  if (code === "42P01" || code === "42703") return true
+
+  const message = typeof err?.message === "string" ? err.message.toLowerCase() : ""
+  return (
+    (message.includes("relation") && message.includes("does not exist")) ||
+    message.includes("no such table") ||
+    message.includes("no such column")
+  )
+}
+
 function toProjectionMap(a: PricingAggregate): ReadonlyMap<string, unknown> {
   return new Map<string, unknown>([
     ["priceFromAmountCents", a.priceFromAmountCents],
@@ -373,4 +389,5 @@ export const __test__ = {
   aggregatePricing,
   EMPTY_AGGREGATE,
   firstPositiveMin,
+  isMissingCatalogPricingDependencyError,
 }

--- a/packages/pricing/src/service-catalog-plane-pricing.ts
+++ b/packages/pricing/src/service-catalog-plane-pricing.ts
@@ -1,6 +1,6 @@
 /**
  * Projection extension that aggregates a "price from" amount across the
- * product's configured default-rule prices and contributes
+ * product's future bookable rate-plan prices and contributes
  * `priceFromAmountCents`, `priceFromCurrency`, and `hasPricing` to the
  * product search document.
  *
@@ -17,18 +17,16 @@
  * Scope intentionally narrow:
  *   - **No schedule-aware rule resolution.** Only `is_default = true`
  *     rules contribute. Seasonal / promo rules with schedules don't
- *     surface here — they'd require per-slice resolution against a
- *     moving "now" date and are deferred to a follow-up.
+ *     surface here; they require per-slice rule evaluation beyond the
+ *     future-departure presence check below.
  *   - **No per-departure overrides.** Same reason.
  *   - **Currency consistency.** Only rules whose catalog currency matches
  *     the product's `sellCurrency` (or whose catalog currency is null
- *     and therefore inherits the product's) are MIN'd together. This
- *     prevents emitting a misleading "from $50" when one of the rules
- *     is actually €50.
+ *     and therefore inherits the product's) are MIN'd together.
  *
- * Document churn: this projection is `now()`-independent — it reads
- * static configured prices, not date-dependent rule windows. Same
- * product reindexed an hour later produces the same fields.
+ * Document churn: this projection is `now()`-dependent because it only
+ * considers future bookable departures. A product can move to "unpriced"
+ * once its final departure starts unless a row-level fallback remains.
  */
 
 import type { AnyDrizzleDb } from "@voyantjs/db"
@@ -36,18 +34,13 @@ import type {
   IndexerSlice,
   ProductProjectionExtension,
 } from "@voyantjs/products/service-catalog-plane"
-import { and, eq, isNull, or, sql } from "drizzle-orm"
-
-import { priceCatalogs } from "./schema-catalogs.js"
-import { optionPriceRules, optionUnitPriceRules } from "./schema-option-rules.js"
+import { sql } from "drizzle-orm"
 
 interface PricingProjectionOptions {
   /**
-   * Resolve the product's `sellAmountCents` + `sellCurrency` so the
-   * projection can MIN the product-row default into the candidate set
-   * and filter rules by matching currency. Templates inject this — the
-   * default reads the products table via raw SQL, but tests can stub
-   * with a known shape without standing up the products schema.
+   * Resolve the product's row-level `sellAmountCents` + `sellCurrency`.
+   * Templates use the default raw-SQL loader; tests can stub it without
+   * standing up the products schema.
    *
    * Returns `null` for both fields when the product doesn't exist.
    */
@@ -55,12 +48,27 @@ interface PricingProjectionOptions {
     db: AnyDrizzleDb,
     productId: string,
   ) => Promise<{ sellAmountCents: number | null; sellCurrency: string | null }>
+
+  /**
+   * Resolve future bookable rate-plan prices for the product. Tests can
+   * stub this without standing up availability/product option tables.
+   */
+  loadRatePlanPricing?: (
+    db: AnyDrizzleDb,
+    productId: string,
+    productCurrency: string,
+  ) => Promise<RatePlanPricing>
 }
 
 interface PricingAggregate {
   priceFromAmountCents: number | null
   priceFromCurrency: string | null
   hasPricing: boolean
+}
+
+interface RatePlanPricing {
+  roomPrices: number[]
+  basePrices: number[]
 }
 
 const EMPTY_AGGREGATE: PricingAggregate = {
@@ -70,35 +78,21 @@ const EMPTY_AGGREGATE: PricingAggregate = {
 }
 
 /**
- * Pure aggregation kernel — given the product-row pricing and the rule
- * candidate set, produce the projection fields. Exposed via `__test__`
- * for unit coverage that doesn't need a real DB.
- *
- * `productPrice` is the row's `sellAmountCents` (`null` when unset).
- * `currency` is the row's `sellCurrency` (used as the projected
- * currency; rule prices fed in here are pre-filtered to match).
- * `ruleCandidates` is every active default rule's `baseSellAmountCents`
- * AND every active default rule's per-unit `sellAmountCents`, with
- * nulls already filtered out.
+ * Pure aggregation kernel. Room prices take precedence over base/unit
+ * prices, which take precedence over the product-row fallback. Non-
+ * positive values are treated as absent so stale `0` caches don't block
+ * nullish fallbacks in catalog consumers.
  */
 function aggregatePricing(
   productPrice: number | null,
   currency: string | null,
-  ruleCandidates: ReadonlyArray<number>,
+  roomPrices: ReadonlyArray<number>,
+  basePrices: ReadonlyArray<number>,
 ): PricingAggregate {
-  const candidates: number[] = []
-  if (productPrice !== null) candidates.push(productPrice)
-  for (const c of ruleCandidates) candidates.push(c)
+  const min = firstPositiveMin(roomPrices) ?? firstPositiveMin(basePrices) ?? positive(productPrice)
 
-  if (candidates.length === 0) {
+  if (min === null) {
     return { ...EMPTY_AGGREGATE, priceFromCurrency: currency }
-  }
-
-  // MIN with a sentinel; faster than spread+Math.min for large arrays
-  // and avoids the Math.min stack-arg limit edge case.
-  let min = candidates[0] as number
-  for (const c of candidates) {
-    if (c < min) min = c
   }
 
   return {
@@ -111,13 +105,14 @@ function aggregatePricing(
 /**
  * Construct the pricing projection extension.
  *
- * Pass `loadProductPricing` in tests to stub the products-row fetch;
- * production uses the default raw-SQL implementation.
+ * Pass loaders in tests to stub DB reads; production uses raw SQL against
+ * the deployed schema.
  */
 export function createProductPricingProjectionExtension(
   options: PricingProjectionOptions = {},
 ): ProductProjectionExtension {
   const loadProductPricing = options.loadProductPricing ?? defaultLoadProductPricing
+  const loadRatePlanPricing = options.loadRatePlanPricing ?? defaultLoadRatePlanPricing
 
   return {
     name: "products:pricing",
@@ -126,108 +121,206 @@ export function createProductPricingProjectionExtension(
       const currency = product.sellCurrency
 
       // Without a product row currency we can't safely filter rules by
-      // matching currency — emit only the (null) row pricing. This case
-      // is rare in practice (every product has sellCurrency set in the
-      // operator UI) but keeps the projection failure-isolated.
+      // matching currency. Emit only the positive row-level fallback.
       if (!currency) {
-        const out = aggregatePricing(product.sellAmountCents, null, [])
+        const out = aggregatePricing(product.sellAmountCents, null, [], [])
         return toProjectionMap(out)
       }
 
-      const [flatPrices, unitPrices] = await Promise.all([
-        fetchFlatRulePrices(db, productId, currency),
-        fetchUnitRulePrices(db, productId, currency),
-      ])
-
-      const candidates = [...flatPrices, ...unitPrices]
-      const out = aggregatePricing(product.sellAmountCents, currency, candidates)
+      const ratePlans = await loadRatePlanPricing(db, productId, currency)
+      const out = aggregatePricing(
+        product.sellAmountCents,
+        currency,
+        ratePlans.roomPrices,
+        ratePlans.basePrices,
+      )
       return toProjectionMap(out)
     },
   }
 }
 
 /**
- * Read `optionPriceRules.baseSellAmountCents` for the product's active
- * default rules whose catalog currency matches the product currency
- * (or whose catalog has a NULL currency, meaning "inherit product").
- *
- * Filtering on the `(productId, active=true, isDefault=true)` subset
- * keeps the candidate set small even for products with hundreds of
- * seasonal rules.
+ * Resolve the same "from price" value emitted by the pricing projection.
+ * Promotion projection wiring uses this so strikethrough base prices
+ * follow the same rate-plan-first fallback chain.
  */
-async function fetchFlatRulePrices(
+export async function loadProductPriceFrom(
   db: AnyDrizzleDb,
   productId: string,
-  productCurrency: string,
-): Promise<number[]> {
-  const rows = await db
-    .select({ price: optionPriceRules.baseSellAmountCents })
-    .from(optionPriceRules)
-    .innerJoin(priceCatalogs, eq(priceCatalogs.id, optionPriceRules.priceCatalogId))
-    .where(
-      and(
-        eq(optionPriceRules.productId, productId),
-        eq(optionPriceRules.active, true),
-        eq(optionPriceRules.isDefault, true),
-        eq(priceCatalogs.active, true),
-        or(eq(priceCatalogs.currencyCode, productCurrency), isNull(priceCatalogs.currencyCode)),
-      ),
-    )
-
-  const out: number[] = []
-  for (const row of rows) {
-    if (row.price !== null) out.push(row.price)
+): Promise<{ amountCents: number | null; currency: string | null }> {
+  const product = await defaultLoadProductPricing(db, productId)
+  const currency = product.sellCurrency
+  if (!currency) {
+    return { amountCents: positive(product.sellAmountCents), currency: null }
   }
-  return out
+
+  const ratePlans = await defaultLoadRatePlanPricing(db, productId, currency)
+  const amountCents =
+    firstPositiveMin(ratePlans.roomPrices) ??
+    firstPositiveMin(ratePlans.basePrices) ??
+    positive(product.sellAmountCents)
+
+  return { amountCents, currency }
 }
 
 /**
- * Read `optionUnitPriceRules.sellAmountCents` for active per-unit tiers
- * whose parent rule is one of the product's active default rules in a
- * matching-currency catalog. Used for products priced per occupancy
- * (e.g. cabins at "single $X / double $Y / triple $Z") where the parent
- * rule's `baseSellAmountCents` is null and the actual prices live on
- * the unit tiers.
+ * Read positive prices from active default rules that have at least one
+ * future bookable departure. Room prices are separated from base/unit
+ * fallbacks so per-room pricing wins even when the product row contains
+ * a stale zero or stale manual price.
  */
-async function fetchUnitRulePrices(
+async function defaultLoadRatePlanPricing(
   db: AnyDrizzleDb,
   productId: string,
   productCurrency: string,
-): Promise<number[]> {
-  const rows = await db
-    .select({ price: optionUnitPriceRules.sellAmountCents })
-    .from(optionUnitPriceRules)
-    .innerJoin(optionPriceRules, eq(optionPriceRules.id, optionUnitPriceRules.optionPriceRuleId))
-    .innerJoin(priceCatalogs, eq(priceCatalogs.id, optionPriceRules.priceCatalogId))
-    .where(
-      and(
-        eq(optionPriceRules.productId, productId),
-        eq(optionPriceRules.active, true),
-        eq(optionPriceRules.isDefault, true),
-        eq(optionUnitPriceRules.active, true),
-        eq(priceCatalogs.active, true),
-        or(eq(priceCatalogs.currencyCode, productCurrency), isNull(priceCatalogs.currencyCode)),
-      ),
-    )
+): Promise<RatePlanPricing> {
+  try {
+    const [roomPrice, basePrice] = await Promise.all([
+      fetchBookableRoomPrice(db, productId, productCurrency),
+      fetchBookableBasePrice(db, productId, productCurrency),
+    ])
 
-  const out: number[] = []
-  for (const row of rows) {
-    if (row.price !== null) out.push(row.price)
+    return {
+      roomPrices: roomPrice == null ? [] : [roomPrice],
+      basePrices: basePrice == null ? [] : [basePrice],
+    }
+  } catch {
+    // Slim test fixtures may omit availability_slots/product_options/
+    // option_units. Keep reindex failure-isolated and fall back to the
+    // product row instead of failing the whole document build.
+    return { roomPrices: [], basePrices: [] }
   }
-  return out
+}
+
+async function fetchBookableRoomPrice(
+  db: AnyDrizzleDb,
+  productId: string,
+  productCurrency: string,
+): Promise<number | null> {
+  const rows = await executeRows(
+    db,
+    sql`
+    WITH active_rules AS (
+      SELECT opr.id
+      FROM option_price_rules opr
+      INNER JOIN price_catalogs pc ON pc.id = opr.price_catalog_id
+      WHERE opr.product_id = ${productId}
+        AND opr.active = true
+        AND opr.is_default = true
+        AND pc.active = true
+        AND (pc.currency_code = ${productCurrency} OR pc.currency_code IS NULL)
+        AND EXISTS (
+          SELECT 1
+          FROM product_options po
+          WHERE po.id = opr.option_id
+            AND po.product_id = opr.product_id
+            AND po.status = 'active'
+        )
+        AND EXISTS (
+          SELECT 1
+          FROM availability_slots slot
+          WHERE slot.product_id = opr.product_id
+            AND slot.starts_at >= NOW()
+            AND slot.status::text IN ('open', 'planned', 'confirmed')
+            AND (slot.option_id IS NULL OR slot.option_id = opr.option_id)
+        )
+    ),
+    candidates AS (
+      SELECT COALESCE(tier.sell_amount_cents, unit_rule.sell_amount_cents) AS price
+      FROM active_rules rule
+      INNER JOIN option_unit_price_rules unit_rule
+        ON unit_rule.option_price_rule_id = rule.id
+      INNER JOIN option_units unit
+        ON unit.id = unit_rule.unit_id
+      LEFT JOIN option_unit_tiers tier
+        ON tier.option_unit_price_rule_id = unit_rule.id
+       AND tier.active = true
+      WHERE unit_rule.active = true
+        AND unit.unit_type = 'room'
+    )
+    SELECT MIN(price)::int AS price
+    FROM candidates
+    WHERE price > 0
+  `,
+  )
+
+  return readNullableInt(rows[0], "price")
+}
+
+async function fetchBookableBasePrice(
+  db: AnyDrizzleDb,
+  productId: string,
+  productCurrency: string,
+): Promise<number | null> {
+  const rows = await executeRows(
+    db,
+    sql`
+    WITH active_rules AS (
+      SELECT opr.id, opr.base_sell_amount_cents
+      FROM option_price_rules opr
+      INNER JOIN price_catalogs pc ON pc.id = opr.price_catalog_id
+      WHERE opr.product_id = ${productId}
+        AND opr.active = true
+        AND opr.is_default = true
+        AND pc.active = true
+        AND (pc.currency_code = ${productCurrency} OR pc.currency_code IS NULL)
+        AND EXISTS (
+          SELECT 1
+          FROM product_options po
+          WHERE po.id = opr.option_id
+            AND po.product_id = opr.product_id
+            AND po.status = 'active'
+        )
+        AND EXISTS (
+          SELECT 1
+          FROM availability_slots slot
+          WHERE slot.product_id = opr.product_id
+            AND slot.starts_at >= NOW()
+            AND slot.status::text IN ('open', 'planned', 'confirmed')
+            AND (slot.option_id IS NULL OR slot.option_id = opr.option_id)
+        )
+    ),
+    candidates AS (
+      SELECT base_sell_amount_cents AS price
+      FROM active_rules
+      UNION ALL
+      SELECT COALESCE(tier.sell_amount_cents, unit_rule.sell_amount_cents) AS price
+      FROM active_rules rule
+      INNER JOIN option_unit_price_rules unit_rule
+        ON unit_rule.option_price_rule_id = rule.id
+      INNER JOIN option_units unit
+        ON unit.id = unit_rule.unit_id
+      LEFT JOIN option_unit_tiers tier
+        ON tier.option_unit_price_rule_id = unit_rule.id
+       AND tier.active = true
+      WHERE unit_rule.active = true
+        AND unit.unit_type <> 'room'
+    )
+    SELECT MIN(price)::int AS price
+    FROM candidates
+    WHERE price > 0
+  `,
+  )
+
+  return readNullableInt(rows[0], "price")
+}
+
+async function executeRows(db: AnyDrizzleDb, query: ReturnType<typeof sql>): Promise<unknown[]> {
+  // biome-ignore lint/suspicious/noExplicitAny: #1141 supports multiple drizzle driver result shapes
+  const result = await (db as any).execute(query)
+  return Array.isArray(result) ? result : (result?.rows ?? [])
 }
 
 /**
  * Default loader reads the products row via raw SQL so we don't pull
- * the products schema into this file (would create a circular import
- * via the typed schema). The columns we read are stable enough that a
- * rename would break far more than this.
+ * the products schema into this file. The columns we read are stable
+ * enough that a rename would break far more than this.
  */
 async function defaultLoadProductPricing(
   db: AnyDrizzleDb,
   productId: string,
 ): Promise<{ sellAmountCents: number | null; sellCurrency: string | null }> {
-  // biome-ignore lint/suspicious/noExplicitAny: drizzle's typed sql is overkill for two-column read
+  // biome-ignore lint/suspicious/noExplicitAny: #1141 keeps cross-package product lookup driver-agnostic
   const dbAny = db as any
   const result = await dbAny.execute(
     sql`SELECT sell_amount_cents, sell_currency FROM products WHERE id = ${productId} LIMIT 1`,
@@ -244,6 +337,29 @@ async function defaultLoadProductPricing(
   }
 }
 
+function positive(value: number | null | undefined): number | null {
+  return typeof value === "number" && value > 0 ? value : null
+}
+
+function firstPositiveMin(values: ReadonlyArray<number>): number | null {
+  let min: number | null = null
+  for (const value of values) {
+    if (value <= 0) continue
+    if (min === null || value < min) min = value
+  }
+  return min
+}
+
+function readNullableInt(row: unknown, key: string): number | null {
+  const value = (row as Record<string, unknown> | undefined)?.[key]
+  if (typeof value === "number") return Number.isFinite(value) ? value : null
+  if (typeof value === "string") {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
 function toProjectionMap(a: PricingAggregate): ReadonlyMap<string, unknown> {
   return new Map<string, unknown>([
     ["priceFromAmountCents", a.priceFromAmountCents],
@@ -252,8 +368,9 @@ function toProjectionMap(a: PricingAggregate): ReadonlyMap<string, unknown> {
   ])
 }
 
-// Internal exports for unit tests — kept off the public surface.
+// Internal exports for unit tests - kept off the public surface.
 export const __test__ = {
   aggregatePricing,
   EMPTY_AGGREGATE,
+  firstPositiveMin,
 }

--- a/packages/pricing/tests/integration/pricing-projection.test.ts
+++ b/packages/pricing/tests/integration/pricing-projection.test.ts
@@ -1,3 +1,4 @@
+import { availabilitySlots } from "@voyantjs/availability/schema"
 import { newId } from "@voyantjs/db/lib/typeid"
 import { cleanupTestDb, createTestDb } from "@voyantjs/db/test-utils"
 import { optionUnits, productOptions, products } from "@voyantjs/products/schema"
@@ -5,7 +6,11 @@ import type { IndexerSlice } from "@voyantjs/products/service-catalog-plane"
 import { beforeAll, beforeEach, describe, expect, it } from "vitest"
 
 import { priceCatalogs } from "../../src/schema-catalogs.js"
-import { optionPriceRules, optionUnitPriceRules } from "../../src/schema-option-rules.js"
+import {
+  optionPriceRules,
+  optionUnitPriceRules,
+  optionUnitTiers,
+} from "../../src/schema-option-rules.js"
 import { createProductPricingProjectionExtension } from "../../src/service-catalog-plane-pricing.js"
 
 const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
@@ -18,8 +23,7 @@ const enSlice: IndexerSlice = {
 }
 
 describe.skipIf(!DB_AVAILABLE)("createProductPricingProjectionExtension (integration)", () => {
-  // biome-ignore lint/suspicious/noExplicitAny: drizzle test client
-  let db: any
+  let db: ReturnType<typeof createTestDb>
   let productId: string
   let optionId: string
   let unitId: string
@@ -48,8 +52,20 @@ describe.skipIf(!DB_AVAILABLE)("createProductPricingProjectionExtension (integra
     })
     await db
       .insert(productOptions)
-      .values({ id: optionId, productId, name: "Standard", code: "std" })
-    await db.insert(optionUnits).values({ id: unitId, optionId, name: "Adult", code: "adult" })
+      .values({ id: optionId, productId, name: "Standard", code: "std", status: "active" })
+    await db
+      .insert(optionUnits)
+      .values({ id: unitId, optionId, name: "Adult", code: "adult", unitType: "person" })
+    await db.insert(availabilitySlots).values({
+      id: newId("availability_slots"),
+      productId,
+      optionId,
+      dateLocal: "2030-01-01",
+      startsAt: new Date(Date.now() + 90 * 24 * 60 * 60 * 1000),
+      timezone: "UTC",
+      status: "open",
+      unlimited: true,
+    })
     await db.insert(priceCatalogs).values([
       { id: usdCatalogId, name: "Public USD", code: "public-usd", currencyCode: "USD" },
       { id: eurCatalogId, name: "Public EUR", code: "public-eur", currencyCode: "EUR" },
@@ -226,8 +242,7 @@ describe.skipIf(!DB_AVAILABLE)("createProductPricingProjectionExtension (integra
     expect(out.get("priceFromAmountCents")).toBe(8500)
   })
 
-  it("MINs the product row sellAmountCents against rules", async () => {
-    // Row default is 5000, rule is 9900 — row wins.
+  it("prefers future rate-plan rules over stale product row pricing", async () => {
     const { sql } = await import("drizzle-orm")
     await db.execute(sql`UPDATE products SET sell_amount_cents = 5000 WHERE id = ${productId}`)
 
@@ -244,6 +259,56 @@ describe.skipIf(!DB_AVAILABLE)("createProductPricingProjectionExtension (integra
 
     const ext = createProductPricingProjectionExtension()
     const out = await ext.project(db, productId, enSlice)
-    expect(out.get("priceFromAmountCents")).toBe(5000)
+    expect(out.get("priceFromAmountCents")).toBe(9900)
+  })
+
+  it("prefers room prices over base prices and stale zero row pricing", async () => {
+    const { sql } = await import("drizzle-orm")
+    await db.execute(sql`UPDATE products SET sell_amount_cents = 0 WHERE id = ${productId}`)
+
+    const roomUnitId = newId("option_units")
+    await db.insert(optionUnits).values({
+      id: roomUnitId,
+      optionId,
+      name: "Double Room",
+      code: "double",
+      unitType: "room",
+      occupancyMin: 1,
+      occupancyMax: 2,
+    })
+
+    const ruleId = newId("option_price_rules")
+    await db.insert(optionPriceRules).values({
+      id: ruleId,
+      productId,
+      optionId,
+      priceCatalogId: usdCatalogId,
+      name: "room-rate",
+      baseSellAmountCents: 25000,
+      isDefault: true,
+      active: true,
+    })
+
+    const unitRuleId = newId("option_unit_price_rules")
+    await db.insert(optionUnitPriceRules).values({
+      id: unitRuleId,
+      optionPriceRuleId: ruleId,
+      optionId,
+      unitId: roomUnitId,
+      sellAmountCents: 18000,
+      active: true,
+    })
+    await db.insert(optionUnitTiers).values({
+      id: newId("option_unit_tiers"),
+      optionUnitPriceRuleId: unitRuleId,
+      minQuantity: 2,
+      sellAmountCents: 16500,
+      active: true,
+    })
+
+    const ext = createProductPricingProjectionExtension()
+    const out = await ext.project(db, productId, enSlice)
+    expect(out.get("priceFromAmountCents")).toBe(16500)
+    expect(out.get("hasPricing")).toBe(true)
   })
 })

--- a/packages/pricing/tests/pricing-projection.test.ts
+++ b/packages/pricing/tests/pricing-projection.test.ts
@@ -7,7 +7,12 @@ import {
   createProductPricingProjectionExtension,
 } from "../src/service-catalog-plane-pricing.js"
 
-const { aggregatePricing, EMPTY_AGGREGATE, firstPositiveMin } = __test__
+const {
+  aggregatePricing,
+  EMPTY_AGGREGATE,
+  firstPositiveMin,
+  isMissingCatalogPricingDependencyError,
+} = __test__
 
 const customerSlice: IndexerSlice = {
   vertical: "products",
@@ -77,6 +82,22 @@ describe("aggregatePricing (kernel)", () => {
     expect(firstPositiveMin([0, -1, 12000, 8000])).toBe(8000)
     expect(firstPositiveMin([0, -1])).toBeNull()
   })
+
+  it("classifies only expected missing schema errors as fixture gaps", () => {
+    expect(isMissingCatalogPricingDependencyError({ code: "42P01" })).toBe(true)
+    expect(isMissingCatalogPricingDependencyError({ code: "42703" })).toBe(true)
+    expect(
+      isMissingCatalogPricingDependencyError({
+        message: 'relation "availability_slots" does not exist',
+      }),
+    ).toBe(true)
+    expect(isMissingCatalogPricingDependencyError({ message: "no such table: option_units" })).toBe(
+      true,
+    )
+
+    expect(isMissingCatalogPricingDependencyError({ code: "53300" })).toBe(false)
+    expect(isMissingCatalogPricingDependencyError(new Error("connection terminated"))).toBe(false)
+  })
 })
 
 describe("createProductPricingProjectionExtension", () => {
@@ -117,5 +138,36 @@ describe("createProductPricingProjectionExtension", () => {
     })
     const out = await ext.project({} as AnyDrizzleDb, "prod_fallback", customerSlice)
     expect(out.get("priceFromAmountCents")).toBe(18000)
+  })
+
+  it("falls back to row pricing only for expected missing-schema query errors", async () => {
+    const ext = createProductPricingProjectionExtension({
+      loadProductPricing: async () => ({ sellAmountCents: 18000, sellCurrency: "USD" }),
+    })
+    const db = {
+      execute: async () => {
+        throw Object.assign(new Error('relation "availability_slots" does not exist'), {
+          code: "42P01",
+        })
+      },
+    } as AnyDrizzleDb
+
+    const out = await ext.project(db, "prod_fixture", customerSlice)
+    expect(out.get("priceFromAmountCents")).toBe(18000)
+  })
+
+  it("propagates unexpected rate-plan query errors", async () => {
+    const ext = createProductPricingProjectionExtension({
+      loadProductPricing: async () => ({ sellAmountCents: 18000, sellCurrency: "USD" }),
+    })
+    const db = {
+      execute: async () => {
+        throw Object.assign(new Error("connection terminated"), { code: "53300" })
+      },
+    } as AnyDrizzleDb
+
+    await expect(ext.project(db, "prod_error", customerSlice)).rejects.toThrow(
+      "connection terminated",
+    )
   })
 })

--- a/packages/pricing/tests/pricing-projection.test.ts
+++ b/packages/pricing/tests/pricing-projection.test.ts
@@ -7,7 +7,7 @@ import {
   createProductPricingProjectionExtension,
 } from "../src/service-catalog-plane-pricing.js"
 
-const { aggregatePricing, EMPTY_AGGREGATE } = __test__
+const { aggregatePricing, EMPTY_AGGREGATE, firstPositiveMin } = __test__
 
 const customerSlice: IndexerSlice = {
   vertical: "products",
@@ -18,49 +18,48 @@ const customerSlice: IndexerSlice = {
 
 describe("aggregatePricing (kernel)", () => {
   it("returns empty aggregate when product has null price and no rules", () => {
-    expect(aggregatePricing(null, "USD", [])).toEqual({
+    expect(aggregatePricing(null, "USD", [], [])).toEqual({
       ...EMPTY_AGGREGATE,
       priceFromCurrency: "USD",
     })
   })
 
   it("returns the product price when there are no rule candidates", () => {
-    const out = aggregatePricing(15000, "USD", [])
+    const out = aggregatePricing(15000, "USD", [], [])
     expect(out.priceFromAmountCents).toBe(15000)
     expect(out.priceFromCurrency).toBe("USD")
     expect(out.hasPricing).toBe(true)
   })
 
-  it("returns MIN of rule candidates when product price is null", () => {
-    const out = aggregatePricing(null, "USD", [9900, 14900, 19900])
+  it("returns MIN of room candidates when product price is null", () => {
+    const out = aggregatePricing(null, "USD", [9900, 14900, 19900], [])
     expect(out.priceFromAmountCents).toBe(9900)
     expect(out.hasPricing).toBe(true)
   })
 
-  it("MINs the product price into the candidate set", () => {
-    // Product has a default of 5000; one rule is cheaper at 4900.
-    const out = aggregatePricing(5000, "USD", [4900, 9900])
+  it("prefers room prices over stale row-level pricing", () => {
+    const out = aggregatePricing(5000, "USD", [9900, 14900], [])
+    expect(out.priceFromAmountCents).toBe(9900)
+  })
+
+  it("falls back to base prices when no room prices exist", () => {
+    const out = aggregatePricing(1000, "USD", [], [4900, 9900])
     expect(out.priceFromAmountCents).toBe(4900)
   })
 
-  it("product price wins when it's cheaper than every rule", () => {
-    const out = aggregatePricing(1000, "USD", [4900, 9900])
-    expect(out.priceFromAmountCents).toBe(1000)
-  })
-
-  it("handles a mix of unit-rule and flat-rule candidates", () => {
-    // Per-unit prices feed in alongside flat rule prices — no special
-    // handling needed in the kernel; both are just ints to MIN over.
-    const out = aggregatePricing(
-      null,
-      "EUR",
-      [/* flat */ 12000, /* unit single */ 8500, /* unit double */ 14000],
-    )
+  it("handles a mix of base and unit-rule fallback candidates", () => {
+    const out = aggregatePricing(null, "EUR", [], [12000, 8500, 14000])
     expect(out.priceFromAmountCents).toBe(8500)
   })
 
+  it("treats zero as missing instead of a real price", () => {
+    const out = aggregatePricing(0, "EUR", [0], [])
+    expect(out.hasPricing).toBe(false)
+    expect(out.priceFromAmountCents).toBeNull()
+  })
+
   it("hasPricing=false when nothing is priced (currency still surfaced)", () => {
-    const out = aggregatePricing(null, "USD", [])
+    const out = aggregatePricing(null, "USD", [], [])
     expect(out.hasPricing).toBe(false)
     expect(out.priceFromAmountCents).toBeNull()
     // Keep the currency so storefront can format empty states with the
@@ -69,47 +68,23 @@ describe("aggregatePricing (kernel)", () => {
   })
 
   it("preserves currency=null when product currency is missing", () => {
-    const out = aggregatePricing(null, null, [])
+    const out = aggregatePricing(null, null, [], [])
     expect(out.priceFromCurrency).toBeNull()
     expect(out.hasPricing).toBe(false)
+  })
+
+  it("finds the first positive minimum", () => {
+    expect(firstPositiveMin([0, -1, 12000, 8000])).toBe(8000)
+    expect(firstPositiveMin([0, -1])).toBeNull()
   })
 })
 
 describe("createProductPricingProjectionExtension", () => {
-  // biome-ignore lint/suspicious/noExplicitAny: drizzle stub
-  function dbWithRules(flatPrices: Array<number | null>, unitPrices: Array<number | null>): any {
-    const nextRows = flatPrices
-    let calls = 0
-    return {
-      select() {
-        const which = calls++
-        return {
-          from() {
-            return {
-              innerJoin() {
-                return {
-                  innerJoin() {
-                    return {
-                      where: async () =>
-                        (which === 0 ? flatPrices : unitPrices).map((p) => ({ price: p })),
-                    }
-                  },
-                  where: async () => nextRows.map((p) => ({ price: p })),
-                }
-              },
-            }
-          },
-        }
-      },
-    }
-  }
-
   it("short-circuits to row-only pricing when product has no currency", async () => {
     const ext = createProductPricingProjectionExtension({
       loadProductPricing: async () => ({ sellAmountCents: 9900, sellCurrency: null }),
     })
-    // biome-ignore lint/suspicious/noExplicitAny: db unused on this path
-    const out = await ext.project({} as any, "prod_x", customerSlice)
+    const out = await ext.project({} as AnyDrizzleDb, "prod_x", customerSlice)
     expect(out.get("priceFromAmountCents")).toBe(9900)
     expect(out.get("priceFromCurrency")).toBeNull()
     expect(out.get("hasPricing")).toBe(true)
@@ -119,31 +94,28 @@ describe("createProductPricingProjectionExtension", () => {
     const ext = createProductPricingProjectionExtension({
       loadProductPricing: async () => ({ sellAmountCents: null, sellCurrency: null }),
     })
-    // biome-ignore lint/suspicious/noExplicitAny: db unused on this path
-    const out = await ext.project({} as any, "prod_missing", customerSlice)
+    const out = await ext.project({} as AnyDrizzleDb, "prod_missing", customerSlice)
     expect(out.get("hasPricing")).toBe(false)
     expect(out.get("priceFromAmountCents")).toBeNull()
   })
 
-  it("MINs across product price + flat rule prices + unit-rule prices", async () => {
-    const db = dbWithRules([15000, 12000], [8000])
+  it("prefers room rate-plan prices over row-level pricing", async () => {
     const ext = createProductPricingProjectionExtension({
-      loadProductPricing: async () => ({ sellAmountCents: 20000, sellCurrency: "USD" }),
+      loadProductPricing: async () => ({ sellAmountCents: 0, sellCurrency: "USD" }),
+      loadRatePlanPricing: async () => ({ roomPrices: [16500], basePrices: [20000] }),
     })
-    const out = await ext.project(db as AnyDrizzleDb, "prod_multi", customerSlice)
-    expect(out.get("priceFromAmountCents")).toBe(8000)
+    const out = await ext.project({} as AnyDrizzleDb, "prod_multi", customerSlice)
+    expect(out.get("priceFromAmountCents")).toBe(16500)
     expect(out.get("priceFromCurrency")).toBe("USD")
     expect(out.get("hasPricing")).toBe(true)
   })
 
-  it("ignores null rule prices in the candidate set", async () => {
-    // Rule rows that come back with `null` baseSellAmountCents (e.g.
-    // per-unit-priced rules with no flat base) must not collapse to 0.
-    const db = dbWithRules([null, 18000], [null])
+  it("falls back to positive product pricing when no rate-plan price exists", async () => {
     const ext = createProductPricingProjectionExtension({
-      loadProductPricing: async () => ({ sellAmountCents: null, sellCurrency: "USD" }),
+      loadProductPricing: async () => ({ sellAmountCents: 18000, sellCurrency: "USD" }),
+      loadRatePlanPricing: async () => ({ roomPrices: [0], basePrices: [] }),
     })
-    const out = await ext.project(db as AnyDrizzleDb, "prod_nulls", customerSlice)
+    const out = await ext.project({} as AnyDrizzleDb, "prod_fallback", customerSlice)
     expect(out.get("priceFromAmountCents")).toBe(18000)
   })
 })

--- a/packages/products/src/catalog-policy-pricing.ts
+++ b/packages/products/src/catalog-policy-pricing.ts
@@ -1,9 +1,9 @@
 /**
  * Catalog plane field policy for product → pricing denormalization.
  *
- * Aggregates a "price from" value across the product's configured
- * default-rule prices so storefront cards can render `from $X` without
- * fanning out to per-option pricing on every render. See
+ * Aggregates a "price from" value across the product's future bookable
+ * default rate-plan prices so storefront cards can render `from $X`
+ * without fanning out to per-option pricing on every render. See
  * `docs/architecture/catalog-architecture.md` §5.4.
  *
  * Storefront product cards filter and display by:
@@ -26,16 +26,16 @@
  * Why a separate field instead of reusing the existing `sellAmountCents`
  * from `productCatalogPolicy`: that path projects the product-row
  * configured default verbatim. Multi-option products often leave
- * `products.sellAmountCents` null and put the real prices on options —
- * this projection MINs across both, giving storefront a value that's
- * always meaningful even for the option-driven case.
+ * `products.sellAmountCents` null or stale and put the real prices on
+ * active rate-plan room/base/unit rows. This projection prefers those
+ * bookable prices and only falls back to the product row when no rate-
+ * plan price exists.
  *
  * Out of scope here (deferred):
- *   - Schedule-aware rule resolution. The kernel reads `isDefault=true`
- *     rule prices only — it does NOT walk seasonal schedules, per-
- *     departure overrides, or per-unit occupancy tiers. A "true cheapest
- *     bookable price right now" projection requires per-slice rule
- *     evaluation with a moving "now" date and is a follow-up.
+ *   - Full schedule-aware rule resolution. The kernel reads
+ *     `isDefault=true` rule prices on options that have a future
+ *     bookable departure; it does NOT walk seasonal schedules or per-
+ *     departure overrides.
  *   - Per-audience / per-market currency conversion. The currency we
  *     emit is `products.sellCurrency`; multi-catalog operators using
  *     mixed currencies for the same product will see prices clipped
@@ -49,9 +49,9 @@ import { defineFieldPolicy, type FieldPolicyInput } from "@voyantjs/catalog/cont
 
 const PRODUCT_PRICING_FIELD_POLICY: FieldPolicyInput[] = [
   // ── Aggregated "price from" amount ───────────────────────────────────────
-  // MIN across `products.sellAmountCents` and the active default
-  // `optionPriceRules.baseSellAmountCents` (plus option-unit-rule MINs for
-  // per-unit-priced options). `null` when no source has a non-null amount.
+  // MIN across future bookable active default room prices first, then
+  // base/unit fallbacks, then `products.sellAmountCents`. `null` when no
+  // source has a positive amount.
   {
     path: "priceFromAmountCents",
     class: "structural",
@@ -85,8 +85,8 @@ const PRODUCT_PRICING_FIELD_POLICY: FieldPolicyInput[] = [
     sourceFreshness: "sync",
   },
   // ── Existence flag ───────────────────────────────────────────────────────
-  // `false` when neither the product row nor any active default rule has a
-  // configured price. Storefront filters use this for "show only priced
+  // `false` when neither future rate-plan pricing nor the product row has
+  // a positive amount. Storefront filters use this for "show only priced
   // products" and to suppress an empty `from` badge.
   {
     path: "hasPricing",

--- a/packages/promotions/src/service-catalog-plane-promotions.ts
+++ b/packages/promotions/src/service-catalog-plane-promotions.ts
@@ -23,7 +23,7 @@
  * `originalPriceFromAmountCents` resolution: by default we read
  * `products.sell_amount_cents` directly (works for simple products with
  * row-level pricing). Operators with option-driven pricing should pass
- * `loadOriginalPrice` to wire the same MIN-across-options resolver the
+ * `loadOriginalPrice` to wire the same rate-plan-first resolver the
  * pricing extension uses; otherwise the strikethrough may not match the
  * customer-visible list price for option-driven products.
  *
@@ -53,7 +53,7 @@ export interface PromotionsProjectionOptions {
    * Defaults to a direct read of `products.sell_amount_cents` +
    * `products.sell_currency` — works for simple row-priced products.
    * Operators with option-driven pricing should wire this to the same
-   * MIN-across-options resolver the pricing extension uses.
+   * rate-plan-first resolver the pricing extension uses.
    *
    * Returns `null` for amountCents when the product has no configured
    * base price (the extension then short-circuits to an empty projection

--- a/templates/operator/src/api/lib/catalog-runtime.ts
+++ b/templates/operator/src/api/lib/catalog-runtime.ts
@@ -27,7 +27,10 @@ import { cruiseCatalogPolicy } from "@voyantjs/cruises/catalog-policy"
 import type { AnyDrizzleDb } from "@voyantjs/db"
 import { extrasCatalogPolicy } from "@voyantjs/extras/catalog-policy"
 import { marketLocales, markets } from "@voyantjs/markets"
-import { createProductPricingProjectionExtension } from "@voyantjs/pricing/service-catalog-plane-pricing"
+import {
+  createProductPricingProjectionExtension,
+  loadProductPriceFrom,
+} from "@voyantjs/pricing/service-catalog-plane-pricing"
 import { productCatalogPolicy } from "@voyantjs/products/catalog-policy"
 import { productDeparturesCatalogPolicy } from "@voyantjs/products/catalog-policy-departures"
 import { productDestinationsCatalogPolicy } from "@voyantjs/products/catalog-policy-destinations"
@@ -355,7 +358,7 @@ export function createProductsDocumentBuilder(
       createProductTaxonomyProjectionExtension(),
       createProductDeparturesProjectionExtension(),
       createProductPricingProjectionExtension(),
-      createProductPromotionsProjectionExtension(),
+      createProductPromotionsProjectionExtension({ loadOriginalPrice: loadProductPriceFrom }),
     ],
   })
 }


### PR DESCRIPTION
## Summary
- derive catalog `priceFromAmountCents` from future bookable rate-plan room prices before base/unit and product-row fallbacks
- treat zero and negative amounts as missing so `hasPricing` follows a positive headline price signal
- wire promotion original-price lookup to the same rate-plan-first resolver

Closes #1141

## Verification
- `pnpm --filter @voyantjs/pricing test -- tests/pricing-projection.test.ts`
- `pnpm --filter @voyantjs/pricing typecheck`
- `pnpm --filter @voyantjs/pricing lint`
- `pnpm --filter @voyantjs/promotions typecheck`
- `pnpm --filter @voyantjs/promotions lint`
- `pnpm --filter operator lint`
- `pnpm --filter operator typecheck`
- `pnpm typecheck:affected`
- `pnpm test:affected`
- `pnpm verify:architecture`
- push hook: `pnpm test`

Note: `pnpm verify:fast` currently stops at the existing `verify:ui-components-barrel` export check for unrelated `packages/ui/src/components/*` files before reaching the later lanes.