### PR TITLE
Fix booking journey copy from billing for phone-only contacts

### DIFF
--- a/.changeset/copy-phone-billing-contact.md
+++ b/.changeset/copy-phone-billing-contact.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/bookings-ui": patch
+---
+
+Show the booking journey Copy from billing action when the billing contact has only a phone number or last name.

--- a/packages/bookings-ui/src/journey/components/journey-steps.tsx
+++ b/packages/bookings-ui/src/journey/components/journey-steps.tsx
@@ -21,6 +21,7 @@ import { Textarea } from "@voyantjs/ui/components/textarea"
 import { Loader2 } from "lucide-react"
 import { formatMessage, useBookingsUiMessagesOrDefault } from "../../i18n/index.js"
 import {
+  canCopyBillingContactToTraveler,
   type Draft,
   patchBilling,
   patchConfigure,
@@ -827,7 +828,7 @@ function TravelerCard({
   // traveler (the common B2C case). Doesn't touch travel-document
   // fields since those are personal to each traveler.
   const billingContact = draft.billing.contact
-  const canCopyFromBilling = Boolean(billingContact.firstName || billingContact.email)
+  const canCopyFromBilling = canCopyBillingContactToTraveler(billingContact)
   const copyFromBilling = () => {
     updateTraveler(draft, setDraft, idx, {
       firstName: billingContact.firstName,

--- a/packages/bookings-ui/src/journey/lib/draft-state.ts
+++ b/packages/bookings-ui/src/journey/lib/draft-state.ts
@@ -50,6 +50,10 @@ export function patchBilling(draft: Draft, patch: Partial<Draft["billing"]>): Dr
   return { ...draft, billing: { ...draft.billing, ...patch } }
 }
 
+export function canCopyBillingContactToTraveler(contact: Draft["billing"]["contact"]): boolean {
+  return Boolean(contact.firstName || contact.lastName || contact.email || contact.phone)
+}
+
 export function patchPaxCount(draft: Draft, band: string, count: number): Draft {
   const safeCount = Number.isFinite(count) && count >= 0 ? Math.floor(count) : 0
   return patchConfigure(draft, {

--- a/packages/bookings-ui/tests/unit/draft-state.test.ts
+++ b/packages/bookings-ui/tests/unit/draft-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  canCopyBillingContactToTraveler,
   emptyDraft,
   patchBilling,
   patchConfigure,
@@ -59,6 +60,32 @@ describe("draft-state", () => {
     const next = patchBilling(draft, { buyerType: "B2B" })
     expect(next.billing.buyerType).toBe("B2B")
     expect(next.billing.contact).toBe(draft.billing.contact)
+  })
+
+  it("allows copying billing contact when any traveler contact field is present", () => {
+    expect(
+      canCopyBillingContactToTraveler({
+        firstName: "",
+        lastName: "",
+        email: "",
+        phone: "",
+      }),
+    ).toBe(false)
+    expect(
+      canCopyBillingContactToTraveler({
+        firstName: "",
+        lastName: "",
+        email: "",
+        phone: "+40722111222",
+      }),
+    ).toBe(true)
+    expect(
+      canCopyBillingContactToTraveler({
+        firstName: "",
+        lastName: "Ionescu",
+        email: "",
+      }),
+    ).toBe(true)
   })
 
   it("patchConfigure preserves the pax record", () => {


### PR DESCRIPTION
## Summary
- Show the traveler Copy from billing action when billing contact has first name, last name, email, or phone
- Add focused coverage for phone-only and last-name-only billing contacts
- Add a patch changeset for `@voyantjs/bookings-ui`

Closes #1128

## Verification
- `pnpm --filter @voyantjs/bookings-ui test`
- `pnpm --filter @voyantjs/bookings-ui typecheck`
- `pnpm --filter @voyantjs/bookings-ui lint`
- commit hook: `pnpm lint` and `pnpm typecheck`
- pre-push hook: `pnpm test`