### PR TITLE
Surface schedule invoice generation feedback

### DIFF
--- a/.changeset/notify-schedule-invoices.md
+++ b/.changeset/notify-schedule-invoices.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/bookings-ui": patch
+---
+
+Show success and failure toasts when issuing schedule invoices and refresh invoice lists after generation.

--- a/packages/bookings-ui/package.json
+++ b/packages/bookings-ui/package.json
@@ -49,7 +49,8 @@
     "zod": "^4.3.6"
   },
   "dependencies": {
-    "@voyantjs/i18n": "workspace:*"
+    "@voyantjs/i18n": "workspace:*",
+    "sonner": "^2.0.7"
   },
   "devDependencies": {
     "@tanstack/react-query": "^5.100.11",
@@ -74,6 +75,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-hook-form": "^7.60.0",
+    "sonner": "^2.0.7",
     "typescript": "^6.0.2",
     "vitest": "^4.1.2",
     "zod": "^4.3.6"

--- a/packages/bookings-ui/src/components/booking-payment-schedule-list.tsx
+++ b/packages/bookings-ui/src/components/booking-payment-schedule-list.tsx
@@ -1,8 +1,10 @@
 "use client"
 
+import { useQueryClient } from "@tanstack/react-query"
 import { useBooking } from "@voyantjs/bookings-react"
 import {
   type BookingPaymentScheduleRecord,
+  financeQueryKeys,
   useBookingPaymentScheduleMutation,
   useBookingPaymentSchedules,
   useInvoiceMutation,
@@ -16,6 +18,7 @@ import {
 } from "@voyantjs/ui/components/dropdown-menu"
 import { CalendarClock, FileText, Loader2, Pencil, Plus, Receipt, Trash2 } from "lucide-react"
 import * as React from "react"
+import { toast } from "sonner"
 
 import { useBookingsUiI18nOrDefault, useBookingsUiMessagesOrDefault } from "../i18n/provider.js"
 import { BookingPaymentScheduleDialog } from "./booking-payment-schedule-dialog.js"
@@ -43,6 +46,7 @@ export function BookingPaymentScheduleList({ bookingId }: BookingPaymentSchedule
   const booking = bookingData?.data ?? null
   const { createFromBooking: createInvoiceFromBooking, render: renderInvoice } =
     useInvoiceMutation()
+  const queryClient = useQueryClient()
   const { formatCurrency } = useBookingsUiI18nOrDefault()
   const messages = useBookingsUiMessagesOrDefault()
 
@@ -68,6 +72,15 @@ export function BookingPaymentScheduleList({ bookingId }: BookingPaymentSchedule
         invoiceType,
       })
       await renderInvoice.mutateAsync({ id: invoice.id, input: { format: "pdf" } })
+      await queryClient.invalidateQueries({ queryKey: financeQueryKeys.invoices() })
+      toast.success(messages.bookingPaymentScheduleList.actions.issueDocumentSuccess)
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : null
+      toast.error(
+        errorMessage
+          ? `${messages.bookingPaymentScheduleList.actions.issueDocumentFailure}: ${errorMessage}`
+          : messages.bookingPaymentScheduleList.actions.issueDocumentFailure,
+      )
     } finally {
       setGeneratingInvoiceForId(null)
     }

--- a/packages/bookings-ui/src/i18n/en.ts
+++ b/packages/bookings-ui/src/i18n/en.ts
@@ -867,6 +867,8 @@ export const bookingsUiEn = {
       issueDocument: "Issue document",
       issueInvoice: "Issue invoice",
       issueProforma: "Issue proforma",
+      issueDocumentSuccess: "Document issued.",
+      issueDocumentFailure: "Could not issue document",
     },
   },
   bookingPaymentReconciliationBanner: {

--- a/packages/bookings-ui/src/i18n/messages.ts
+++ b/packages/bookings-ui/src/i18n/messages.ts
@@ -789,6 +789,8 @@ export type BookingsUiMessages = {
       issueDocument: string
       issueInvoice: string
       issueProforma: string
+      issueDocumentSuccess: string
+      issueDocumentFailure: string
     }
   }
   bookingPaymentReconciliationBanner: {

--- a/packages/bookings-ui/src/i18n/ro.ts
+++ b/packages/bookings-ui/src/i18n/ro.ts
@@ -869,6 +869,8 @@ export const bookingsUiRo = {
       issueDocument: "Emite document",
       issueInvoice: "Emite factura",
       issueProforma: "Emite proforma",
+      issueDocumentSuccess: "Document emis.",
+      issueDocumentFailure: "Documentul nu a putut fi emis",
     },
   },
   bookingPaymentReconciliationBanner: {

--- a/packages/bookings-ui/tests/unit/booking-payment-schedule-list.test.tsx
+++ b/packages/bookings-ui/tests/unit/booking-payment-schedule-list.test.tsx
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+
+import type * as ReactTypes from "react"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const testState = vi.hoisted(() => ({
+  createFromBooking: vi.fn(async () => ({ id: "inv_123" })),
+  renderInvoice: vi.fn(async () => ({ id: "rend_123" })),
+  invalidateQueries: vi.fn(async () => undefined),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+  removeSchedule: vi.fn(),
+}))
+
+;(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({
+    invalidateQueries: testState.invalidateQueries,
+  }),
+}))
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: testState.toastSuccess,
+    error: testState.toastError,
+  },
+}))
+
+vi.mock("@voyantjs/bookings-react", () => ({
+  useBooking: () => ({
+    data: {
+      data: {
+        id: "book_123",
+        bookingNumber: "BK-2026-000001",
+      },
+    },
+  }),
+}))
+
+vi.mock("@voyantjs/finance-react", () => ({
+  financeQueryKeys: {
+    invoices: () => ["voyant", "finance", "invoices"],
+  },
+  useBookingPaymentScheduleMutation: () => ({
+    remove: { mutate: testState.removeSchedule },
+  }),
+  useBookingPaymentSchedules: () => ({
+    data: {
+      data: [
+        {
+          id: "sched_123",
+          bookingId: "book_123",
+          bookingItemId: null,
+          scheduleType: "deposit",
+          status: "due",
+          dueDate: "2026-05-30",
+          currency: "EUR",
+          amountCents: 16500,
+          notes: null,
+          createdAt: "2026-05-23T00:00:00.000Z",
+          updatedAt: "2026-05-23T00:00:00.000Z",
+        },
+      ],
+    },
+  }),
+  useInvoiceMutation: () => ({
+    createFromBooking: { mutateAsync: testState.createFromBooking },
+    render: { mutateAsync: testState.renderInvoice },
+  }),
+}))
+
+vi.mock("@voyantjs/ui/components", () => ({
+  Badge: ({ children }: { children?: ReactTypes.ReactNode }) => <span>{children}</span>,
+  Button: ({ children, ...props }: ReactTypes.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+  Card: ({ children }: { children?: ReactTypes.ReactNode }) => <section>{children}</section>,
+  CardContent: ({ children }: { children?: ReactTypes.ReactNode }) => <div>{children}</div>,
+  CardHeader: ({ children }: { children?: ReactTypes.ReactNode }) => <header>{children}</header>,
+  CardTitle: ({ children }: { children?: ReactTypes.ReactNode }) => <h2>{children}</h2>,
+}))
+
+vi.mock("@voyantjs/ui/components/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children?: ReactTypes.ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children?: ReactTypes.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    onClick,
+  }: {
+    children?: ReactTypes.ReactNode
+    onClick?: () => void
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  DropdownMenuTrigger: ({ render }: { render: ReactTypes.ReactElement }) => render,
+}))
+
+vi.mock("../../src/components/booking-payment-schedule-dialog.js", () => ({
+  BookingPaymentScheduleDialog: () => null,
+}))
+
+import { BookingPaymentScheduleList } from "../../src/components/booking-payment-schedule-list.js"
+
+function clickButton(container: HTMLElement, label: string) {
+  const button = [...container.querySelectorAll("button")].find((candidate) =>
+    candidate.textContent?.includes(label),
+  )
+  if (!button) throw new Error(`Button not found: ${label}`)
+  button.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+}
+
+describe("BookingPaymentScheduleList", () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    testState.createFromBooking.mockReset()
+    testState.createFromBooking.mockResolvedValue({ id: "inv_123" })
+    testState.renderInvoice.mockReset()
+    testState.renderInvoice.mockResolvedValue({ id: "rend_123" })
+    testState.invalidateQueries.mockReset()
+    testState.invalidateQueries.mockResolvedValue(undefined)
+    testState.toastSuccess.mockReset()
+    testState.toastError.mockReset()
+    testState.removeSchedule.mockReset()
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it("toasts success and refreshes invoices after issuing a document", async () => {
+    await act(async () => {
+      root.render(<BookingPaymentScheduleList bookingId="book_123" />)
+    })
+
+    await act(async () => {
+      clickButton(container, "Issue invoice")
+    })
+
+    expect(testState.createFromBooking).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bookingId: "book_123",
+        invoiceType: "invoice",
+      }),
+    )
+    expect(testState.renderInvoice).toHaveBeenCalledWith({
+      id: "inv_123",
+      input: { format: "pdf" },
+    })
+    expect(testState.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["voyant", "finance", "invoices"],
+    })
+    expect(testState.toastSuccess).toHaveBeenCalledWith("Document issued.")
+    expect(testState.toastError).not.toHaveBeenCalled()
+  })
+
+  it("toasts failure details when document issuing fails", async () => {
+    testState.createFromBooking.mockRejectedValue(new Error("Internal Server Error"))
+
+    await act(async () => {
+      root.render(<BookingPaymentScheduleList bookingId="book_123" />)
+    })
+
+    await act(async () => {
+      clickButton(container, "Issue invoice")
+    })
+
+    expect(testState.renderInvoice).not.toHaveBeenCalled()
+    expect(testState.invalidateQueries).not.toHaveBeenCalled()
+    expect(testState.toastSuccess).not.toHaveBeenCalled()
+    expect(testState.toastError).toHaveBeenCalledWith(
+      "Could not issue document: Internal Server Error",
+    )
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1501,6 +1501,9 @@ importers:
       '@voyantjs/i18n':
         specifier: workspace:*
         version: link:../i18n
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@tanstack/react-query':
         specifier: ^5.100.11


### PR DESCRIPTION
## Summary
- Show localized success and failure toasts when issuing a payment schedule invoice/proforma
- Await invoice-list invalidation after rendering the generated document so invoice panels refresh
- Add focused tests for success and failure feedback paths
- Add a patch changeset for `@voyantjs/bookings-ui`

Closes #1118

## Verification
- `pnpm --filter @voyantjs/bookings-ui test`
- `pnpm --filter @voyantjs/bookings-ui typecheck`
- `pnpm --filter @voyantjs/bookings-ui lint`
- commit hook: `pnpm lint` and `pnpm typecheck`
- pre-push hook: `pnpm test`