### PR TITLE
Carry tax metadata on invoice issued events

### DIFF
--- a/.changeset/invoice-tax-event-metadata.md
+++ b/.changeset/invoice-tax-event-metadata.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/finance": patch
+"@voyantjs/plugin-smartbill": patch
+---
+
+Carry resolved tax names and regime codes on issued invoice event line items for downstream integrations.

--- a/packages/finance/src/service-issue.ts
+++ b/packages/finance/src/service-issue.ts
@@ -2,13 +2,20 @@ import {
   type ActionLedgerRequestContextValues,
   appendActionLedgerMutation,
 } from "@voyantjs/action-ledger"
-import { bookings } from "@voyantjs/bookings/schema"
+import { bookingItems, bookings } from "@voyantjs/bookings/schema"
 import type { EventBus } from "@voyantjs/core"
-import { asc, eq } from "drizzle-orm"
+import { asc, eq, inArray } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
+import { resolveBookingSellTaxRate } from "./booking-tax.js"
 import { type InvoiceFxOptions, resolveInvoiceFxContext } from "./invoice-fx.js"
-import { invoiceLineItems, invoiceNumberSeries, invoices, payments } from "./schema.js"
+import {
+  bookingItemTaxLines,
+  invoiceLineItems,
+  invoiceNumberSeries,
+  invoices,
+  payments,
+} from "./schema.js"
 import {
   buildInvoiceIssuedActionLedgerInput,
   type CreateInvoiceFromBookingInput,
@@ -77,8 +84,37 @@ export interface InvoiceIssuedLineItem {
   unitPrice: number
   currency: string
   taxPercentage?: number
+  taxName?: string | null
+  taxRegimeCode?: TaxRegimeCode | null
   isService?: boolean
 }
+
+export type TaxRegimeCode =
+  | "standard"
+  | "reduced"
+  | "exempt"
+  | "reverse_charge"
+  | "margin_scheme_art311"
+  | "zero_rated"
+  | "out_of_scope"
+  | "other"
+
+type InvoiceLineTaxMetadata = {
+  taxPercentage?: number
+  taxName?: string | null
+  taxRegimeCode?: TaxRegimeCode | null
+}
+
+const TAX_REGIME_CODES = new Set<TaxRegimeCode>([
+  "standard",
+  "reduced",
+  "exempt",
+  "reverse_charge",
+  "margin_scheme_art311",
+  "zero_rated",
+  "out_of_scope",
+  "other",
+])
 
 const ISSUED_EVENT = "invoice.issued"
 const PROFORMA_ISSUED_EVENT = "invoice.proforma.issued"
@@ -202,6 +238,7 @@ async function emitIssued(
     .from(invoiceLineItems)
     .where(eq(invoiceLineItems.invoiceId, invoice.id))
     .orderBy(asc(invoiceLineItems.sortOrder))
+  const taxMetadataByBookingItemId = await loadLineTaxMetadata(db, lines)
   const payload: InvoiceIssuedEvent = {
     invoiceId: invoice.id,
     invoiceNumber: invoice.invoiceNumber,
@@ -219,14 +256,22 @@ async function emitIssued(
     clientCountry: booking?.contactCountry ?? null,
     clientVatCode: null,
     clientRegCom: null,
-    lineItems: lines.map((line) => ({
-      description: line.description,
-      quantity: line.quantity,
-      unitPrice: centsToMajor(line.unitPriceCents),
-      currency: invoice.currency,
-      ...(line.taxRate == null ? {} : { taxPercentage: line.taxRate }),
-      isService: true,
-    })),
+    lineItems: lines.map((line) => {
+      const taxMetadata =
+        line.bookingItemId == null ? undefined : taxMetadataByBookingItemId.get(line.bookingItemId)
+      const taxPercentage = line.taxRate ?? taxMetadata?.taxPercentage
+
+      return {
+        description: line.description,
+        quantity: line.quantity,
+        unitPrice: centsToMajor(line.unitPriceCents),
+        currency: invoice.currency,
+        ...(taxPercentage == null ? {} : { taxPercentage }),
+        ...(taxMetadata?.taxName == null ? {} : { taxName: taxMetadata.taxName }),
+        ...(taxMetadata?.taxRegimeCode == null ? {} : { taxRegimeCode: taxMetadata.taxRegimeCode }),
+        isService: true,
+      }
+    }),
     bookingNumber: booking?.bookingNumber ?? null,
     issueDate: toDateString(invoice.issueDate),
     dueDate: toDateString(invoice.dueDate),
@@ -241,6 +286,100 @@ async function emitIssued(
   const fx = await resolveInvoiceFxContext(db, invoice, runtime)
   if (fx) Object.assign(payload, fx)
   await runtime.eventBus.emit(eventName, payload)
+}
+
+async function loadLineTaxMetadata(
+  db: PostgresJsDatabase,
+  lines: Array<typeof invoiceLineItems.$inferSelect>,
+): Promise<Map<string, InvoiceLineTaxMetadata>> {
+  const bookingItemIds = [
+    ...new Set(lines.map((line) => line.bookingItemId).filter((id): id is string => Boolean(id))),
+  ]
+  if (bookingItemIds.length === 0) return new Map()
+
+  const taxLines = await db
+    .select({
+      bookingItemId: bookingItemTaxLines.bookingItemId,
+      name: bookingItemTaxLines.name,
+      code: bookingItemTaxLines.code,
+      scope: bookingItemTaxLines.scope,
+      rateBasisPoints: bookingItemTaxLines.rateBasisPoints,
+    })
+    .from(bookingItemTaxLines)
+    .where(inArray(bookingItemTaxLines.bookingItemId, bookingItemIds))
+    .orderBy(
+      asc(bookingItemTaxLines.bookingItemId),
+      asc(bookingItemTaxLines.sortOrder),
+      asc(bookingItemTaxLines.createdAt),
+    )
+
+  const taxLinesByBookingItemId = new Map<string, typeof taxLines>()
+  for (const taxLine of taxLines) {
+    const existing = taxLinesByBookingItemId.get(taxLine.bookingItemId) ?? []
+    existing.push(taxLine)
+    taxLinesByBookingItemId.set(taxLine.bookingItemId, existing)
+  }
+
+  const metadataByBookingItemId = new Map<string, InvoiceLineTaxMetadata>()
+  for (const bookingItemId of bookingItemIds) {
+    const taxLine = selectEventTaxLine(taxLinesByBookingItemId.get(bookingItemId) ?? [])
+    if (!taxLine) continue
+
+    metadataByBookingItemId.set(bookingItemId, {
+      ...(taxLine.rateBasisPoints == null
+        ? {}
+        : { taxPercentage: Math.round(taxLine.rateBasisPoints / 100) }),
+      taxName: taxLine.name,
+      taxRegimeCode: parseTaxRegimeCode(taxLine.code),
+    })
+  }
+
+  await backfillMissingLineTaxMetadata(db, bookingItemIds, metadataByBookingItemId)
+  return metadataByBookingItemId
+}
+
+function selectEventTaxLine<T extends { scope: string; rateBasisPoints: number | null }>(
+  taxLines: T[],
+): T | null {
+  return (
+    taxLines.find((taxLine) => taxLine.scope !== "withheld" && taxLine.rateBasisPoints != null) ??
+    taxLines.find((taxLine) => taxLine.scope !== "withheld") ??
+    null
+  )
+}
+
+async function backfillMissingLineTaxMetadata(
+  db: PostgresJsDatabase,
+  bookingItemIds: string[],
+  metadataByBookingItemId: Map<string, InvoiceLineTaxMetadata>,
+): Promise<void> {
+  const missingBookingItemIds = bookingItemIds.filter((id) => !metadataByBookingItemId.has(id))
+  if (missingBookingItemIds.length === 0) return
+
+  const productRows = await db
+    .select({
+      id: bookingItems.id,
+      productId: bookingItems.productId,
+    })
+    .from(bookingItems)
+    .where(inArray(bookingItems.id, missingBookingItemIds))
+
+  for (const row of productRows) {
+    if (!row.productId) continue
+    const taxRate = await resolveBookingSellTaxRate(db, { productId: row.productId })
+    if (!taxRate) continue
+
+    metadataByBookingItemId.set(row.id, {
+      taxPercentage: Math.round(taxRate.rate * 100),
+      taxName: taxRate.label,
+      taxRegimeCode: parseTaxRegimeCode(taxRate.code),
+    })
+  }
+}
+
+function parseTaxRegimeCode(code: string | null | undefined): TaxRegimeCode | null {
+  const value = code?.split("/").at(-1)
+  return value && TAX_REGIME_CODES.has(value as TaxRegimeCode) ? (value as TaxRegimeCode) : null
 }
 
 /**

--- a/packages/finance/tests/unit/service-issue.test.ts
+++ b/packages/finance/tests/unit/service-issue.test.ts
@@ -2,8 +2,13 @@ import { createEventBus, type EventEnvelope } from "@voyantjs/core"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { resolveBookingSellTaxRate } from "../../src/booking-tax.js"
 import { financeService } from "../../src/service.js"
 import { type InvoiceIssuedEvent, issueInvoiceFromBooking } from "../../src/service-issue.js"
+
+vi.mock("../../src/booking-tax.js", () => ({
+  resolveBookingSellTaxRate: vi.fn(),
+}))
 
 vi.mock("../../src/service.js", () => ({
   financeService: {
@@ -58,7 +63,7 @@ describe("issueInvoiceFromBooking", () => {
       draftInvoice as Awaited<ReturnType<typeof financeService.createInvoiceFromBooking>>,
     )
 
-    const db = {
+    const db = Object.assign({} as PostgresJsDatabase, {
       update: vi.fn(() => ({
         set: vi.fn(() => ({
           where: vi.fn(() => ({
@@ -74,7 +79,7 @@ describe("issueInvoiceFromBooking", () => {
           })),
         })),
       })),
-    } as PostgresJsDatabase
+    })
 
     const eventBus = createEventBus()
     const emitted: Array<EventEnvelope<InvoiceIssuedEvent>> = []
@@ -146,6 +151,230 @@ describe("issueInvoiceFromBooking", () => {
         },
       ],
     })
+  })
+
+  it("carries resolved tax names and regime codes on issued line items", async () => {
+    const draftInvoice = {
+      id: "inv_tax",
+      invoiceNumber: "INV-TAX",
+      invoiceType: "invoice",
+      bookingId: "book_tax",
+      totalCents: 12100,
+      currency: "RON",
+      convertedFromInvoiceId: null,
+      issueDate: "2026-05-23",
+      dueDate: "2026-05-30",
+    }
+    const issuedInvoice = { ...draftInvoice, status: "sent" }
+    const booking = {
+      bookingNumber: "BK-TAX",
+      contactFirstName: "Ana",
+      contactLastName: "Popescu",
+    }
+    const lineRows = [
+      {
+        bookingItemId: "item_tax",
+        description: "Consulting",
+        quantity: 1,
+        unitPriceCents: 12100,
+        taxRate: 21,
+      },
+    ]
+    const taxRows = [
+      {
+        bookingItemId: "item_tax",
+        name: "Normala",
+        code: "ro-b2c/standard",
+        scope: "included",
+        rateBasisPoints: 2100,
+      },
+    ]
+    vi.mocked(financeService.createInvoiceFromBooking).mockResolvedValue(
+      draftInvoice as Awaited<ReturnType<typeof financeService.createInvoiceFromBooking>>,
+    )
+
+    let selectCall = 0
+    const db = Object.assign({} as PostgresJsDatabase, {
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn(() => ({
+            returning: vi.fn(async () => [issuedInvoice]),
+          })),
+        })),
+      })),
+      select: vi.fn(() => {
+        selectCall += 1
+        const currentSelect = selectCall
+        return {
+          from: vi.fn(() => ({
+            where: vi.fn(() => ({
+              limit: vi.fn(async () => (currentSelect === 1 ? [booking] : [])),
+              orderBy: vi.fn(async () => {
+                if (currentSelect === 2) return lineRows
+                if (currentSelect === 3) return taxRows
+                return []
+              }),
+            })),
+          })),
+        }
+      }),
+    })
+
+    const eventBus = createEventBus()
+    const emitted: Array<EventEnvelope<InvoiceIssuedEvent>> = []
+    eventBus.subscribe<InvoiceIssuedEvent>("invoice.issued", (event) => {
+      emitted.push(event)
+    })
+
+    await issueInvoiceFromBooking(
+      db,
+      {
+        invoiceNumber: "INV-TAX",
+        bookingId: "book_tax",
+        issueDate: "2026-05-23",
+        dueDate: "2026-05-30",
+      },
+      {
+        booking: {
+          id: "book_tax",
+          bookingNumber: "BK-TAX",
+          personId: null,
+          organizationId: null,
+          sellCurrency: "RON",
+          baseCurrency: null,
+          fxRateSetId: null,
+          sellAmountCents: 12100,
+          baseSellAmountCents: null,
+        },
+        items: [],
+      },
+      { eventBus },
+    )
+
+    expect(emitted).toHaveLength(1)
+    expect(emitted[0]?.data.lineItems).toEqual([
+      {
+        description: "Consulting",
+        quantity: 1,
+        unitPrice: 121,
+        currency: "RON",
+        taxPercentage: 21,
+        taxName: "Normala",
+        taxRegimeCode: "standard",
+        isService: true,
+      },
+    ])
+  })
+
+  it("falls back to product tax metadata for zero-rate issued line items", async () => {
+    const draftInvoice = {
+      id: "inv_zero_tax",
+      invoiceNumber: "INV-ZERO-TAX",
+      invoiceType: "invoice",
+      bookingId: "book_zero_tax",
+      totalCents: 10000,
+      currency: "RON",
+      convertedFromInvoiceId: null,
+      issueDate: "2026-05-23",
+      dueDate: "2026-05-30",
+    }
+    const issuedInvoice = { ...draftInvoice, status: "sent" }
+    const lineRows = [
+      {
+        bookingItemId: "item_zero_tax",
+        description: "Margin scheme service",
+        quantity: 1,
+        unitPriceCents: 10000,
+        taxRate: null,
+      },
+    ]
+    vi.mocked(financeService.createInvoiceFromBooking).mockResolvedValue(
+      draftInvoice as Awaited<ReturnType<typeof financeService.createInvoiceFromBooking>>,
+    )
+    vi.mocked(resolveBookingSellTaxRate).mockResolvedValue({
+      code: "ro-b2c/exempt",
+      label: "Normala",
+      rate: 0,
+      priceMode: "inclusive",
+    })
+
+    let selectCall = 0
+    const db = Object.assign({} as PostgresJsDatabase, {
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn(() => ({
+            returning: vi.fn(async () => [issuedInvoice]),
+          })),
+        })),
+      })),
+      select: vi.fn(() => {
+        selectCall += 1
+        const currentSelect = selectCall
+        return {
+          from: vi.fn(() => ({
+            where: vi.fn(() => {
+              if (currentSelect === 4) {
+                return Promise.resolve([{ id: "item_zero_tax", productId: "prod_zero_tax" }])
+              }
+
+              return {
+                limit: vi.fn(async () => (currentSelect === 1 ? [{ bookingNumber: "BK-0" }] : [])),
+                orderBy: vi.fn(async () => {
+                  if (currentSelect === 2) return lineRows
+                  if (currentSelect === 3) return []
+                  return []
+                }),
+              }
+            }),
+          })),
+        }
+      }),
+    })
+
+    const eventBus = createEventBus()
+    const emitted: Array<EventEnvelope<InvoiceIssuedEvent>> = []
+    eventBus.subscribe<InvoiceIssuedEvent>("invoice.issued", (event) => {
+      emitted.push(event)
+    })
+
+    await issueInvoiceFromBooking(
+      db,
+      {
+        invoiceNumber: "INV-ZERO-TAX",
+        bookingId: "book_zero_tax",
+        issueDate: "2026-05-23",
+        dueDate: "2026-05-30",
+      },
+      {
+        booking: {
+          id: "book_zero_tax",
+          bookingNumber: "BK-0",
+          personId: null,
+          organizationId: null,
+          sellCurrency: "RON",
+          baseCurrency: null,
+          fxRateSetId: null,
+          sellAmountCents: 10000,
+          baseSellAmountCents: null,
+        },
+        items: [],
+      },
+      { eventBus },
+    )
+
+    expect(resolveBookingSellTaxRate).toHaveBeenCalledWith(db, { productId: "prod_zero_tax" })
+    expect(emitted[0]?.data.lineItems).toEqual([
+      {
+        description: "Margin scheme service",
+        quantity: 1,
+        unitPrice: 100,
+        currency: "RON",
+        taxPercentage: 0,
+        taxName: "Normala",
+        taxRegimeCode: "exempt",
+        isService: true,
+      },
+    ])
   })
 
   it("enriches issued invoice events with operator FX settings", async () => {

--- a/packages/plugins/smartbill/tests/unit/mapping.test.ts
+++ b/packages/plugins/smartbill/tests/unit/mapping.test.ts
@@ -115,6 +115,14 @@ describe("mapLineItems", () => {
     expect(result[0]!.taxPercentage).toBe(19)
   })
 
+  it("passes through taxName when present", () => {
+    const result = mapLineItems(
+      event({ lineItems: [{ name: "X", quantity: 1, price: 10, taxName: "Normala" }] }),
+      defaultOptions,
+    )
+    expect(result[0]!.taxName).toBe("Normala")
+  })
+
   it("omits taxPercentage when not present", () => {
     const result = mapLineItems(
       event({ lineItems: [{ name: "X", quantity: 1, price: 10 }] }),


### PR DESCRIPTION
## Summary
- Add optional `taxName` and `taxRegimeCode` fields to issued invoice event line items
- Enrich invoice events from stored booking tax lines, with a product tax fallback for zero-rate lines without a stored tax line
- Keep SmartBill mapping passing through event `taxName` and add focused coverage
- Add a patch changeset for finance and SmartBill

Closes #1152

## Verification
- `pnpm --filter @voyantjs/finance test`
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/finance lint`
- `pnpm --filter @voyantjs/plugin-smartbill test`
- `pnpm --filter @voyantjs/plugin-smartbill typecheck`
- `pnpm --filter @voyantjs/plugin-smartbill lint`
- commit hook: repo lint and repo typecheck
- `pnpm --filter @voyantjs/workflows-orchestrator test` passed twice after local full pre-push runs hit its unrelated timing flake