### PR TITLE
Emit SmartBill parseable default bodies

### DIFF
--- a/.changeset/smartbill-parseable-defaults.md
+++ b/.changeset/smartbill-parseable-defaults.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/plugin-smartbill": patch
+---
+
+Emit SmartBill-parseable default client and product fields from the default mapper.

--- a/packages/plugins/smartbill/src/mapping.ts
+++ b/packages/plugins/smartbill/src/mapping.ts
@@ -12,6 +12,10 @@ export type SmartbillEventValue<T> = T | ((event: VoyantInvoiceEvent) => Smartbi
 const DEFAULT_ART311_SPECIAL_REGIME_TEXT =
   "Regimul special de taxare - agentie de turism (Art. 311 Cod Fiscal)"
 
+const COUNTRY_CODE_OVERRIDES: Record<string, string> = {
+  RO: "Romania",
+}
+
 /**
  * Options for the default invoice mapper.
  */
@@ -24,6 +28,8 @@ export interface SmartbillMappingOptions {
   language?: string
   /** Whether VAT is included in line item prices. Defaults to `true`. */
   isTaxIncluded?: boolean
+  /** SmartBill product unit name. Defaults to `"buc"`. */
+  measuringUnitName?: SmartbillEventValue<string | null | undefined>
   /** Whether to use Art. 311 special regime (margin scheme for travel). */
   art311SpecialRegime?: boolean
   /** Text appended to mentions when Art. 311 special regime is enabled. */
@@ -39,6 +45,7 @@ interface ResolvedMappingOptions {
   seriesName: string
   language?: string
   isTaxIncluded?: boolean
+  measuringUnitName?: string
   art311SpecialRegime?: boolean
   art311SpecialRegimeText?: string
   mentions?: string
@@ -49,17 +56,22 @@ interface ResolvedMappingOptions {
 
 /**
  * Extract the SmartBill client block from a Voyant invoice event.
- * Falls back to empty strings for missing fields.
+ * Falls back to SmartBill-parseable defaults for fields the API treats as required.
  */
 export function mapClient(event: VoyantInvoiceEvent): SmartbillClient {
+  const vatCode = asStringOrUndefined(event.clientVatCode ?? event.customerVatCode)
+
   return {
     name: asString(event.clientName ?? event.customerName, "Client"),
-    vatCode: asStringOrUndefined(event.clientVatCode ?? event.customerVatCode),
+    vatCode,
     regCom: asStringOrUndefined(event.clientRegCom),
-    address: asStringOrUndefined(event.clientAddress ?? event.customerAddress),
-    city: asStringOrUndefined(event.clientCity ?? event.customerCity),
+    address: asString(event.clientAddress ?? event.customerAddress, "-"),
+    city: asString(event.clientCity ?? event.customerCity, "-"),
     county: asStringOrUndefined(event.clientCounty ?? event.customerCounty),
-    country: asStringOrUndefined(event.clientCountry ?? event.customerCountry),
+    country:
+      normalizeCountryName(asStringOrUndefined(event.clientCountry ?? event.customerCountry)) ??
+      "Romania",
+    isTaxPayer: Boolean(vatCode),
     email: asStringOrUndefined(event.clientEmail ?? event.customerEmail),
     phone: asStringOrUndefined(event.clientPhone ?? event.customerPhone),
     saveToDb: false,
@@ -73,7 +85,7 @@ export function mapClient(event: VoyantInvoiceEvent): SmartbillClient {
  */
 export function mapLineItems(
   event: VoyantInvoiceEvent,
-  options: Pick<SmartbillMappingOptions, "isTaxIncluded">,
+  options: Pick<SmartbillMappingOptions, "isTaxIncluded"> & { measuringUnitName?: string },
 ): SmartbillProduct[] {
   const items = event.lineItems
   if (!Array.isArray(items)) return []
@@ -81,11 +93,15 @@ export function mapLineItems(
   return items.map((item: Record<string, unknown>) => ({
     name: asString(item.description ?? item.name, "Item"),
     code: asStringOrUndefined(item.code ?? item.sku),
-    measureUnit: asString(item.measureUnit ?? item.unit, "buc"),
+    measuringUnitName: asString(
+      item.measuringUnitName ?? item.measureUnit ?? item.unit ?? options.measuringUnitName,
+      "buc",
+    ),
     quantity: asNumber(item.quantity, 1),
     price: asNumber(item.unitPrice ?? item.price, 0),
     currency: asString(item.currency ?? event.currency, "RON"),
     isTaxIncluded: options.isTaxIncluded ?? true,
+    isDiscount: false,
     taxName: asStringOrUndefined(item.taxName),
     taxPercentage: item.taxPercentage != null ? asNumber(item.taxPercentage, 0) : undefined,
     isService: item.isService === true,
@@ -176,6 +192,9 @@ function resolveMappingOptionsSync(
     seriesName: resolveRequiredEventValueSync(event, options.seriesName, "seriesName"),
     language: options.language,
     isTaxIncluded: options.isTaxIncluded,
+    measuringUnitName: normalizeOptionalText(
+      resolveEventValueSync(event, options.measuringUnitName, "measuringUnitName"),
+    ),
     art311SpecialRegime: options.art311SpecialRegime,
     art311SpecialRegimeText: options.art311SpecialRegimeText,
     mentions: normalizeOptionalText(resolveEventValueSync(event, options.mentions, "mentions")),
@@ -196,6 +215,9 @@ async function resolveMappingOptions(
     seriesName: await resolveRequiredEventValue(event, options.seriesName, "seriesName"),
     language: options.language,
     isTaxIncluded: options.isTaxIncluded,
+    measuringUnitName: normalizeOptionalText(
+      await resolveEventValue(event, options.measuringUnitName),
+    ),
     art311SpecialRegime: options.art311SpecialRegime,
     art311SpecialRegimeText: options.art311SpecialRegimeText,
     mentions: normalizeOptionalText(await resolveEventValue(event, options.mentions)),
@@ -265,6 +287,29 @@ function isPromiseLike<T>(value: T | Promise<T> | undefined): value is Promise<T
 
 function normalizeOptionalText(value: string | null | undefined) {
   return typeof value === "string" && value.length > 0 ? value : undefined
+}
+
+function normalizeCountryName(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+
+  const upper = trimmed.toUpperCase()
+  const overridden = COUNTRY_CODE_OVERRIDES[upper]
+  if (overridden) return overridden
+
+  if (/^[A-Z]{2}$/.test(upper)) {
+    try {
+      const displayName = new Intl.DisplayNames(["en"], { type: "region" }).of(upper)
+      return displayName && displayName !== upper && displayName !== "Unknown Region"
+        ? displayName
+        : trimmed
+    } catch {
+      return trimmed
+    }
+  }
+
+  return trimmed
 }
 
 function asString(value: unknown, fallback: string): string {

--- a/packages/plugins/smartbill/src/runtime.ts
+++ b/packages/plugins/smartbill/src/runtime.ts
@@ -29,6 +29,7 @@ export function createSmartbillSyncRuntime(options: SmartbillPluginOptions): Sma
     seriesName: options.seriesName,
     language: options.language,
     isTaxIncluded: options.isTaxIncluded,
+    measuringUnitName: options.measuringUnitName,
     art311SpecialRegime: options.art311SpecialRegime,
     art311SpecialRegimeText: options.art311SpecialRegimeText,
     mentions: options.mentions,

--- a/packages/plugins/smartbill/src/types.ts
+++ b/packages/plugins/smartbill/src/types.ts
@@ -16,11 +16,15 @@ export interface VoyantInvoiceEvent {
 export interface SmartbillProduct {
   name: string
   code?: string
-  measureUnit: string
+  /** SmartBill's invoice/estimate API field for the product unit name. */
+  measuringUnitName?: string
+  /** @deprecated SmartBill ignores this field; use `measuringUnitName`. */
+  measureUnit?: string
   quantity: number
   price: number
   currency: string
   isTaxIncluded: boolean
+  isDiscount?: boolean
   taxName?: string
   taxPercentage?: number
   isService?: boolean

--- a/packages/plugins/smartbill/src/validation.ts
+++ b/packages/plugins/smartbill/src/validation.ts
@@ -128,6 +128,7 @@ export const smartbillPluginOptionsSchema = z.object({
   fetch: optionalFetch.optional(),
   language: optionalString,
   isTaxIncluded: z.boolean().optional(),
+  measuringUnitName: optionalEventText.optional(),
   art311SpecialRegime: z.boolean().optional(),
   art311SpecialRegimeText: optionalString,
   mentions: optionalEventText.optional(),

--- a/packages/plugins/smartbill/tests/unit/mapping.test.ts
+++ b/packages/plugins/smartbill/tests/unit/mapping.test.ts
@@ -35,6 +35,8 @@ describe("mapClient", () => {
     expect(result.vatCode).toBe("RO999")
     expect(result.address).toBe("Str. Test 1")
     expect(result.city).toBe("Bucharest")
+    expect(result.country).toBe("Romania")
+    expect(result.isTaxPayer).toBe(true)
     expect(result.email).toBe("acme@test.com")
     expect(result.saveToDb).toBe(false)
   })
@@ -49,11 +51,20 @@ describe("mapClient", () => {
     expect(result.name).toBe("Client")
   })
 
-  it("returns undefined for missing optional fields", () => {
+  it("fills SmartBill-safe client defaults", () => {
     const result = mapClient(event())
     expect(result.vatCode).toBeUndefined()
-    expect(result.address).toBeUndefined()
+    expect(result.address).toBe("-")
+    expect(result.city).toBe("-")
+    expect(result.country).toBe("Romania")
+    expect(result.isTaxPayer).toBe(false)
     expect(result.email).toBeUndefined()
+  })
+
+  it("resolves country codes and passes through country names", () => {
+    expect(mapClient(event({ clientCountry: "DE" })).country).toBe("Germany")
+    expect(mapClient(event({ clientCountry: "Atlantis" })).country).toBe("Atlantis")
+    expect(mapClient(event({ clientCountry: "ZZ" })).country).toBe("ZZ")
   })
 })
 
@@ -78,10 +89,13 @@ describe("mapLineItems", () => {
     expect(result).toHaveLength(1)
     expect(result[0]!.name).toBe("Safari Tour")
     expect(result[0]!.code).toBe("TOUR-1")
+    expect(result[0]!.measuringUnitName).toBe("buc")
+    expect(result[0]!.measureUnit).toBeUndefined()
     expect(result[0]!.quantity).toBe(2)
     expect(result[0]!.price).toBe(50000)
     expect(result[0]!.isService).toBe(true)
     expect(result[0]!.isTaxIncluded).toBe(true)
+    expect(result[0]!.isDiscount).toBe(false)
   })
 
   it("returns empty array when no lineItems", () => {
@@ -105,6 +119,14 @@ describe("mapLineItems", () => {
       isTaxIncluded: false,
     })
     expect(result[0]!.isTaxIncluded).toBe(false)
+  })
+
+  it("uses measuringUnitName from options when the item has no unit", () => {
+    const result = mapLineItems(event({ lineItems: [{ name: "X", quantity: 1, price: 10 }] }), {
+      ...defaultOptions,
+      measuringUnitName: "serv",
+    })
+    expect(result[0]!.measuringUnitName).toBe("serv")
   })
 
   it("passes through taxPercentage when present", () => {
@@ -152,6 +174,37 @@ describe("mapVoyantInvoiceToSmartbill", () => {
     expect(result.products).toHaveLength(1)
     expect(result.issueDate).toBe("2026-01-15")
     expect(result.dueDate).toBe("2026-02-15")
+  })
+
+  it("emits SmartBill-parseable client and product defaults", () => {
+    const result = mapVoyantInvoiceToSmartbill(
+      event({
+        clientName: "Test SRL",
+        lineItems: [{ name: "Tour Package", quantity: 1, unitPrice: 50000 }],
+      }),
+      defaultOptions,
+    )
+
+    expect(result.client).toEqual({
+      name: "Test SRL",
+      vatCode: undefined,
+      regCom: undefined,
+      address: "-",
+      city: "-",
+      county: undefined,
+      country: "Romania",
+      isTaxPayer: false,
+      email: undefined,
+      phone: undefined,
+      saveToDb: false,
+    })
+    expect(result.products[0]).toMatchObject({
+      name: "Tour Package",
+      measuringUnitName: "buc",
+      isDiscount: false,
+      isTaxIncluded: true,
+    })
+    expect(result.products[0]!.measureUnit).toBeUndefined()
   })
 
   it("sets isDraft when event has isDraft=true", () => {


### PR DESCRIPTION
## Summary
- Fill SmartBill-safe client defaults for tax payer, address, city, and country
- Emit default-mapped products with `measuringUnitName`, `isDiscount`, and tax-included defaults
- Add a `measuringUnitName` mapping option, validation/runtime wiring, focused mapper coverage, and a patch changeset

Closes #1151

## Verification
- `pnpm --filter @voyantjs/plugin-smartbill test`
- `pnpm --filter @voyantjs/plugin-smartbill typecheck`
- `pnpm --filter @voyantjs/plugin-smartbill lint`
- `pnpm exec biome check packages/plugins/smartbill/src/mapping.ts packages/plugins/smartbill/src/runtime.ts packages/plugins/smartbill/src/types.ts packages/plugins/smartbill/src/validation.ts packages/plugins/smartbill/tests/unit/mapping.test.ts .changeset/smartbill-parseable-defaults.md --no-errors-on-unmatched`
- `node scripts/check-agent-code-quality.mjs --changed --report-only`
- pre-commit hook: changed-file formatting, secretlint, changed-file quality, repository lint, repository typecheck
- pre-push hook: `pnpm test`