### PR TITLE
Use finance invoice number allocation in operator checkout

### DIFF
--- a/templates/operator/migrations/0031_default_proforma_invoice_series.sql
+++ b/templates/operator/migrations/0031_default_proforma_invoice_series.sql
@@ -1,0 +1,83 @@
+WITH chosen_invoice_series AS (
+  SELECT "id"
+  FROM "invoice_number_series"
+  WHERE "scope" = 'invoice' AND "active" = true
+  ORDER BY "created_at" ASC, "id" ASC
+  LIMIT 1
+)
+UPDATE "invoice_number_series"
+SET "is_default" = true, "updated_at" = now()
+WHERE "id" = (SELECT "id" FROM chosen_invoice_series)
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "invoice_number_series"
+    WHERE "scope" = 'invoice' AND "active" = true AND "is_default" = true
+  );--> statement-breakpoint
+
+WITH chosen_proforma_series AS (
+  SELECT "id"
+  FROM "invoice_number_series"
+  WHERE "scope" = 'proforma' AND "active" = true
+  ORDER BY "created_at" ASC, "id" ASC
+  LIMIT 1
+)
+UPDATE "invoice_number_series"
+SET "is_default" = true, "updated_at" = now()
+WHERE "id" = (SELECT "id" FROM chosen_proforma_series)
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "invoice_number_series"
+    WHERE "scope" = 'proforma' AND "active" = true AND "is_default" = true
+  );--> statement-breakpoint
+
+DO $$
+DECLARE
+  proforma_code text := 'PRO-2026';
+  proforma_suffix integer := 1;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM "invoice_number_series"
+    WHERE "scope" = 'proforma' AND "active" = true AND "is_default" = true
+  ) THEN
+    WHILE EXISTS (
+      SELECT 1
+      FROM "invoice_number_series"
+      WHERE "code" = proforma_code
+    ) LOOP
+      proforma_code := 'PRO-2026-' || proforma_suffix::text;
+      proforma_suffix := proforma_suffix + 1;
+    END LOOP;
+
+    INSERT INTO "invoice_number_series" (
+      "id",
+      "code",
+      "name",
+      "prefix",
+      "separator",
+      "pad_length",
+      "current_sequence",
+      "reset_strategy",
+      "scope",
+      "is_default",
+      "active",
+      "created_at",
+      "updated_at"
+    )
+    VALUES (
+      'invs_00000000000000000000115000',
+      proforma_code,
+      'Proformas 2026',
+      proforma_code || '-',
+      '',
+      5,
+      0,
+      'never',
+      'proforma',
+      true,
+      true,
+      now(),
+      now()
+    );
+  END IF;
+END $$;

--- a/templates/operator/migrations/meta/_journal.json
+++ b/templates/operator/migrations/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1779465900000,
       "tag": "0030_invoice_number_external_allocation",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1779466000000,
+      "tag": "0031_default_proforma_invoice_series",
+      "breakpoints": true
     }
   ]
 }

--- a/templates/operator/scripts/seed.ts
+++ b/templates/operator/scripts/seed.ts
@@ -447,6 +447,7 @@ const TAX_POLICY_RO_TRAVEL = newId("tax_policy_profiles")
 const TAX_RULE_RO_ACCOMMODATION = newId("tax_policy_rules")
 const TAX_RULE_RO_FALLBACK = newId("tax_policy_rules")
 const INV_SERIES = newId("invoice_number_series")
+const PROFORMA_SERIES = newId("invoice_number_series")
 const INV_TMPL = newId("invoice_templates")
 
 async function seedMarketsAndFinanceSetup() {
@@ -677,16 +678,32 @@ async function seedMarketsAndFinanceSetup() {
     },
   ])
 
-  await db.insert(invoiceNumberSeries).values({
-    id: INV_SERIES,
-    code: "INV-2026",
-    name: "Invoices 2026",
-    prefix: "INV-2026-",
-    separator: "",
-    padLength: 5,
-    currentSequence: 0,
-    resetStrategy: "never",
-  })
+  await db.insert(invoiceNumberSeries).values([
+    {
+      id: INV_SERIES,
+      code: "INV-2026",
+      name: "Invoices 2026",
+      prefix: "INV-2026-",
+      separator: "",
+      padLength: 5,
+      currentSequence: 0,
+      resetStrategy: "never",
+      scope: "invoice",
+      isDefault: true,
+    },
+    {
+      id: PROFORMA_SERIES,
+      code: "PRO-2026",
+      name: "Proformas 2026",
+      prefix: "PRO-2026-",
+      separator: "",
+      padLength: 5,
+      currentSequence: 0,
+      resetStrategy: "never",
+      scope: "proforma",
+      isDefault: true,
+    },
+  ])
 
   await db.insert(invoiceTemplates).values({
     id: INV_TMPL,

--- a/templates/operator/src/api/catalog-checkout.ts
+++ b/templates/operator/src/api/catalog-checkout.ts
@@ -1648,7 +1648,6 @@ async function startBankTransferCheckout(
 
   const proformaInput: CreateInvoiceFromBookingInput = {
     bookingId: booking.id,
-    invoiceNumber: `PRO-${booking.bookingNumber}`,
     issueDate,
     dueDate,
     invoiceType: "proforma",
@@ -2048,7 +2047,6 @@ function buildCheckoutFinalizeDeps(
         db,
         {
           bookingId,
-          invoiceNumber: `INV-${booking.bookingNumber}`,
           issueDate: today,
           dueDate,
           invoiceType: "invoice",
@@ -2294,10 +2292,9 @@ async function dispatchCheckoutFinalize(
  * dashboard's "Rerun" / "Resume" buttons work.
  *
  * The runner is declared `idempotency: "unsafe"` because a fresh
- * rerun would attempt to re-issue the invoice (which collides on
- * `INV-${bookingNumber}`). The dashboard requires a confirm dialog
- * before sending `confirm: true`. The Resume path is always safe —
- * it skips already-completed steps.
+ * rerun would attempt to issue another invoice number. The dashboard
+ * requires a confirm dialog before sending `confirm: true`. The
+ * Resume path is always safe — it skips already-completed steps.
  */
 export function createCatalogCheckoutBundle(opts: {
   workflowRunnerRegistry?: WorkflowRunnerRegistry
@@ -2368,7 +2365,7 @@ export function createCatalogCheckoutBundle(opts: {
           name: "checkout-finalize",
           idempotency: "unsafe",
           description:
-            "Confirms the booking and issues the final invoice. A fresh rerun re-issues the invoice (collides on existing INV- numbers); use Resume to retry from a failed step.",
+            "Confirms the booking and issues the final invoice. A fresh rerun issues another invoice number; use Resume to retry from a failed step.",
           rerun: async (rawInput, ctx) => {
             const input = rawInput as CheckoutFinalizeInput | null
             if (!input?.bookingId) {


### PR DESCRIPTION
## Summary
- Stop passing booking-number placeholders when operator checkout issues proformas and final invoices
- Let finance allocate invoice and proforma numbers from default series
- Seed default invoice and proforma number series for the operator template
- Update checkout-finalize rerun copy to describe duplicate issuance instead of INV-number collision

Closes #1150

## Verification
- `pnpm exec biome check templates/operator/src/api/catalog-checkout.ts templates/operator/scripts/seed.ts --write --no-errors-on-unmatched`
- `pnpm --filter operator typecheck`
- `pnpm --filter operator test`
- `pnpm --filter @voyantjs/finance test -- service-invoice-number-allocation validation-billing`
- `pnpm --filter @voyantjs/finance typecheck`
- `git diff --check`
- pre-commit hook: changed-file formatting, secretlint, changed-file quality report-only, repository lint, repository typecheck
- pre-push hook: `pnpm test`