### PR TITLE
Use admin invoice attachment downloads in operator template

### DIFF
--- a/templates/operator/src/components/voyant/finance/invoice-detail-sections.tsx
+++ b/templates/operator/src/components/voyant/finance/invoice-detail-sections.tsx
@@ -469,7 +469,7 @@ export function InvoiceAttachmentsCard({ invoiceId }: { invoiceId: string }) {
                   </p>
                 </div>
                 <a
-                  href={`${apiBase}/v1/finance/invoice-attachments/${attachment.id}/download`}
+                  href={`${apiBase}/v1/admin/finance/invoice-attachments/${attachment.id}/download`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center gap-1.5 rounded px-2 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"


### PR DESCRIPTION
## Summary
- Update the operator template invoice attachment link to use the admin-mounted finance download route
- Preserve the template API base so path-prefixed deployments keep `/api` in generated download URLs

Closes #1085

## Verification
- `pnpm exec biome check templates/operator/src/components/voyant/finance/invoice-detail-sections.tsx --write --no-errors-on-unmatched`
- `pnpm --filter operator typecheck`
- `pnpm --filter operator test`
- `pnpm --filter @voyantjs/finance-ui test -- invoice-detail-page`
- `git diff --check`
- pre-commit hook: changed-file formatting, secretlint, changed-file quality report-only, repository lint, repository typecheck
- pre-push hook: `pnpm test`