### PR TITLE
Record SmartBill PDF persistence status

### DIFF
--- a/.changeset/smartbill-pdf-persist-status.md
+++ b/.changeset/smartbill-pdf-persist-status.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/plugin-smartbill": patch
+---
+
+Record SmartBill PDF persistence success and failure metadata on invoice external refs.

--- a/packages/plugins/smartbill/src/artifacts.ts
+++ b/packages/plugins/smartbill/src/artifacts.ts
@@ -52,6 +52,15 @@ export interface PersistSmartbillInvoiceArtifactInput {
   result: SmartbillInvoiceResponse
 }
 
+export interface RecordSmartbillInvoiceArtifactFailureInput {
+  runtime: SmartbillArtifactPersistenceRuntime
+  event: VoyantInvoiceEvent
+  documentType: SmartbillDocumentType
+  body: SmartbillInvoiceBody
+  result: SmartbillInvoiceResponse
+  error: unknown
+}
+
 export type SmartbillExternalRef = Pick<
   InvoiceExternalRef,
   "id" | "invoiceId" | "externalId" | "externalNumber" | "externalUrl" | "metadata"
@@ -66,6 +75,27 @@ export interface RetrySmartbillInvoiceArtifactInput {
 
 type InvoiceAttachmentRecord = Awaited<ReturnType<typeof financeService.createInvoiceAttachment>>
 type InvoiceRenditionRecord = Awaited<ReturnType<typeof financeService.createInvoiceRendition>>
+
+export type SmartbillPdfPersistStage =
+  | "attachment_lookup"
+  | "viewInvoicePdf"
+  | "viewEstimatePdf"
+  | "storage_upload"
+  | "rendition_insert"
+  | "attachment_insert"
+  | "unknown"
+
+export class SmartbillPdfPersistError extends Error {
+  readonly stage: SmartbillPdfPersistStage
+  readonly originalError: unknown
+
+  constructor(stage: SmartbillPdfPersistStage, error: unknown) {
+    super(`SmartBill PDF persist failed at ${stage}: ${errorMessage(error)}`)
+    this.name = "SmartbillPdfPersistError"
+    this.stage = stage
+    this.originalError = error
+  }
+}
 
 export type SmartbillArtifactPersistenceResult =
   | {
@@ -129,6 +159,74 @@ function metadataString(metadata: Record<string, unknown> | null, key: string) {
   return typeof value === "string" && value.length > 0 ? value : null
 }
 
+function errorMessage(error: unknown) {
+  if (error instanceof SmartbillPdfPersistError) return errorMessage(error.originalError)
+  if (error instanceof Error) return error.message
+  return String(error)
+}
+
+function errorStage(error: unknown): SmartbillPdfPersistStage {
+  return error instanceof SmartbillPdfPersistError ? error.stage : "unknown"
+}
+
+async function withPdfPersistStage<T>(
+  stage: SmartbillPdfPersistStage,
+  operation: () => Promise<T>,
+) {
+  try {
+    return await operation()
+  } catch (error) {
+    throw new SmartbillPdfPersistError(stage, error)
+  }
+}
+
+function buildSmartbillExternalRefMetadata({
+  body,
+  result,
+  documentType,
+  extra,
+}: {
+  body: SmartbillInvoiceBody
+  result: SmartbillInvoiceResponse
+  documentType: SmartbillDocumentType
+  extra?: Record<string, unknown>
+}) {
+  return {
+    companyVatCode: body.companyVatCode,
+    seriesName: body.seriesName,
+    series: result.series ?? body.seriesName,
+    number: result.number ?? null,
+    documentType,
+    ...extra,
+  }
+}
+
+async function registerSmartbillExternalRef(
+  db: PostgresJsDatabase,
+  invoiceId: string,
+  body: SmartbillInvoiceBody,
+  result: SmartbillInvoiceResponse,
+  documentType: SmartbillDocumentType,
+  metadataExtra?: Record<string, unknown>,
+) {
+  const number = result.number
+  return financeService.registerInvoiceExternalRef(db, invoiceId, {
+    provider: "smartbill",
+    externalId: number ?? null,
+    externalNumber: number ?? null,
+    externalUrl: result.url ?? null,
+    status: result.errorText ? "error" : "issued",
+    syncedAt: new Date().toISOString(),
+    syncError: result.errorText ?? null,
+    metadata: buildSmartbillExternalRefMetadata({
+      body,
+      result,
+      documentType,
+      extra: metadataExtra,
+    }),
+  })
+}
+
 export async function persistSmartbillInvoiceArtifact({
   runtime,
   client,
@@ -146,22 +244,7 @@ export async function persistSmartbillInvoiceArtifact({
   const seriesName = result.series ?? body.seriesName
   const number = result.number
 
-  const externalRef = await financeService.registerInvoiceExternalRef(db, event.id, {
-    provider: "smartbill",
-    externalId: number ?? null,
-    externalNumber: number ?? null,
-    externalUrl: result.url ?? null,
-    status: result.errorText ? "error" : "issued",
-    syncedAt: new Date().toISOString(),
-    syncError: result.errorText ?? null,
-    metadata: {
-      companyVatCode: body.companyVatCode,
-      seriesName: body.seriesName,
-      series: seriesName,
-      number: number ?? null,
-      documentType,
-    },
-  })
+  const externalRef = await registerSmartbillExternalRef(db, event.id, body, result, documentType)
   if (!externalRef) return { status: "skipped" as const, reason: "missing_invoice" as const }
 
   const storage = await resolveMaybe(runtime.documentStorage, context)
@@ -169,7 +252,7 @@ export async function persistSmartbillInvoiceArtifact({
   if (!number) return { status: "registered_ref" as const, reason: "missing_number" as const }
 
   const keyPrefix = await resolveMaybe(runtime.documentStorageKeyPrefix, context)
-  return persistSmartbillPdfArtifact({
+  const persisted = await persistSmartbillPdfArtifact({
     db,
     storage,
     client,
@@ -181,6 +264,42 @@ export async function persistSmartbillInvoiceArtifact({
     language: body.language ?? null,
     keyPrefix,
   })
+
+  if (persisted.status === "persisted" || persisted.status === "already_exists") {
+    await registerSmartbillExternalRef(db, event.id, body, result, documentType, {
+      pdfPersistStatus: "ready",
+      pdfPersistedAt: new Date().toISOString(),
+      pdfStorageKey: persisted.attachment?.storageKey ?? null,
+      pdfPersistError: null,
+      pdfPersistStage: null,
+    })
+  }
+
+  return persisted
+}
+
+export async function recordSmartbillInvoiceArtifactFailure({
+  runtime,
+  event,
+  documentType,
+  body,
+  result,
+  error,
+}: RecordSmartbillInvoiceArtifactFailureInput): Promise<SmartbillArtifactPersistenceResult> {
+  if (!runtime.db) return { status: "skipped" as const, reason: "missing_db" as const }
+
+  const context: SmartbillArtifactStorageContext = { event, documentType, body, result }
+  const db = await resolveMaybe(runtime.db, context)
+  if (!db) return { status: "skipped" as const, reason: "missing_db" as const }
+
+  const externalRef = await registerSmartbillExternalRef(db, event.id, body, result, documentType, {
+    pdfPersistStatus: "failed",
+    pdfPersistError: errorMessage(error),
+    pdfPersistStage: errorStage(error),
+    pdfPersistedAt: null,
+  })
+  if (!externalRef) return { status: "skipped" as const, reason: "missing_invoice" as const }
+  return { status: "registered_ref" as const }
 }
 
 export async function retrySmartbillInvoiceArtifact({
@@ -229,18 +348,57 @@ export async function retrySmartbillInvoiceArtifact({
   if (!storage) return { status: "skipped" as const, reason: "missing_document_storage" as const }
 
   const keyPrefix = await resolveMaybe(runtime.documentStorageKeyPrefix, context)
-  return persistSmartbillPdfArtifact({
-    db,
-    storage,
-    client,
-    invoiceId: externalRef.invoiceId,
-    documentType,
-    companyVatCode,
-    seriesName,
-    number,
-    language: metadataString(metadata, "language"),
-    keyPrefix,
-  })
+  const result = context.result
+  try {
+    const persisted = await persistSmartbillPdfArtifact({
+      db,
+      storage,
+      client,
+      invoiceId: externalRef.invoiceId,
+      documentType,
+      companyVatCode,
+      seriesName,
+      number,
+      language: metadataString(metadata, "language"),
+      keyPrefix,
+    })
+
+    if (persisted.status === "persisted" || persisted.status === "already_exists") {
+      await registerSmartbillExternalRef(
+        db,
+        externalRef.invoiceId,
+        context.body,
+        result,
+        documentType,
+        {
+          ...(metadata ?? {}),
+          pdfPersistStatus: "ready",
+          pdfPersistedAt: new Date().toISOString(),
+          pdfStorageKey: persisted.attachment?.storageKey ?? null,
+          pdfPersistError: null,
+          pdfPersistStage: null,
+        },
+      )
+    }
+
+    return persisted
+  } catch (error) {
+    await registerSmartbillExternalRef(
+      db,
+      externalRef.invoiceId,
+      context.body,
+      result,
+      documentType,
+      {
+        ...(metadata ?? {}),
+        pdfPersistStatus: "failed",
+        pdfPersistError: errorMessage(error),
+        pdfPersistStage: errorStage(error),
+        pdfPersistedAt: null,
+      },
+    )
+    throw error
+  }
 }
 
 async function persistSmartbillPdfArtifact({
@@ -266,7 +424,9 @@ async function persistSmartbillPdfArtifact({
   language?: string | null
   keyPrefix?: string
 }): Promise<SmartbillArtifactPersistenceResult> {
-  const existingAttachments = await financeService.listInvoiceAttachments(db, invoiceId)
+  const existingAttachments = await withPdfPersistStage("attachment_lookup", () =>
+    financeService.listInvoiceAttachments(db, invoiceId),
+  )
   const existingSmartbillAttachment = existingAttachments.find(
     (attachment) => attachment.kind === SMARTBILL_ATTACHMENT_KIND,
   )
@@ -276,25 +436,31 @@ async function persistSmartbillPdfArtifact({
 
   const pdf =
     documentType === "proforma"
-      ? await client.viewEstimatePdf(companyVatCode, seriesName, number)
-      : await client.viewInvoicePdf(companyVatCode, seriesName, number)
+      ? await withPdfPersistStage("viewEstimatePdf", () =>
+          client.viewEstimatePdf(companyVatCode, seriesName, number),
+        )
+      : await withPdfPersistStage("viewInvoicePdf", () =>
+          client.viewInvoicePdf(companyVatCode, seriesName, number),
+        )
 
   const defaultPrefix = `invoices/${invoiceId}/smartbill`
   const resolvedKeyPrefix = keyPrefix ?? defaultPrefix
   const key = `${resolvedKeyPrefix.replace(/\/$/, "")}/${documentType}-${sanitizeKeyPart(seriesName)}-${sanitizeKeyPart(number)}.pdf`
   const contentType = pdf.contentType || "application/pdf"
   const checksum = await sha256(pdf.bytes)
-  const uploaded = await storage.upload(pdf.bytes, {
-    key,
-    contentType,
-    metadata: {
-      provider: "smartbill",
-      documentType,
-      invoiceId,
-      seriesName,
-      number,
-    },
-  })
+  const uploaded = await withPdfPersistStage("storage_upload", () =>
+    storage.upload(pdf.bytes, {
+      key,
+      contentType,
+      metadata: {
+        provider: "smartbill",
+        documentType,
+        invoiceId,
+        seriesName,
+        number,
+      },
+    }),
+  )
 
   const commonMetadata = {
     provider: "smartbill",
@@ -306,29 +472,33 @@ async function persistSmartbillPdfArtifact({
     ...(uploaded.url ? { url: uploaded.url } : {}),
   }
 
-  const rendition = await financeService.createInvoiceRendition(db, invoiceId, {
-    format: "pdf",
-    status: "ready",
-    storageKey: uploaded.key,
-    fileSize: pdf.bytes.byteLength,
-    checksum,
-    language: language ?? null,
-    generatedAt: new Date().toISOString(),
-    metadata: commonMetadata,
-  })
+  const rendition = await withPdfPersistStage("rendition_insert", () =>
+    financeService.createInvoiceRendition(db, invoiceId, {
+      format: "pdf",
+      status: "ready",
+      storageKey: uploaded.key,
+      fileSize: pdf.bytes.byteLength,
+      checksum,
+      language: language ?? null,
+      generatedAt: new Date().toISOString(),
+      metadata: commonMetadata,
+    }),
+  )
 
-  const attachment = await financeService.createInvoiceAttachment(db, invoiceId, {
-    kind: SMARTBILL_ATTACHMENT_KIND,
-    name: smartbillAttachmentName(documentType, seriesName, number),
-    mimeType: contentType,
-    fileSize: pdf.bytes.byteLength,
-    storageKey: uploaded.key,
-    checksum,
-    metadata: {
-      ...commonMetadata,
-      renditionId: rendition?.id ?? null,
-    },
-  })
+  const attachment = await withPdfPersistStage("attachment_insert", () =>
+    financeService.createInvoiceAttachment(db, invoiceId, {
+      kind: SMARTBILL_ATTACHMENT_KIND,
+      name: smartbillAttachmentName(documentType, seriesName, number),
+      mimeType: contentType,
+      fileSize: pdf.bytes.byteLength,
+      storageKey: uploaded.key,
+      checksum,
+      metadata: {
+        ...commonMetadata,
+        renditionId: rendition?.id ?? null,
+      },
+    }),
+  )
 
   return { status: "persisted" as const, rendition, attachment }
 }

--- a/packages/plugins/smartbill/src/artifacts.ts
+++ b/packages/plugins/smartbill/src/artifacts.ts
@@ -97,6 +97,22 @@ export class SmartbillPdfPersistError extends Error {
   }
 }
 
+export class SmartbillPdfPersistMetadataUpdateError extends Error {
+  readonly originalError: unknown
+
+  constructor(error: unknown) {
+    super(`SmartBill PDF persist metadata update failed: ${errorMessage(error)}`)
+    this.name = "SmartbillPdfPersistMetadataUpdateError"
+    this.originalError = error
+  }
+}
+
+export function isSmartbillPdfPersistMetadataUpdateError(
+  error: unknown,
+): error is SmartbillPdfPersistMetadataUpdateError {
+  return error instanceof SmartbillPdfPersistMetadataUpdateError
+}
+
 export type SmartbillArtifactPersistenceResult =
   | {
       status: "skipped"
@@ -227,6 +243,29 @@ async function registerSmartbillExternalRef(
   })
 }
 
+async function recordSmartbillInvoiceArtifactReady(
+  db: PostgresJsDatabase,
+  invoiceId: string,
+  body: SmartbillInvoiceBody,
+  result: SmartbillInvoiceResponse,
+  documentType: SmartbillDocumentType,
+  storageKey: string | null,
+  existingMetadata?: Record<string, unknown> | null,
+) {
+  try {
+    await registerSmartbillExternalRef(db, invoiceId, body, result, documentType, {
+      ...(existingMetadata ?? {}),
+      pdfPersistStatus: "ready",
+      pdfPersistedAt: new Date().toISOString(),
+      pdfStorageKey: storageKey,
+      pdfPersistError: null,
+      pdfPersistStage: null,
+    })
+  } catch (error) {
+    throw new SmartbillPdfPersistMetadataUpdateError(error)
+  }
+}
+
 export async function persistSmartbillInvoiceArtifact({
   runtime,
   client,
@@ -266,13 +305,14 @@ export async function persistSmartbillInvoiceArtifact({
   })
 
   if (persisted.status === "persisted" || persisted.status === "already_exists") {
-    await registerSmartbillExternalRef(db, event.id, body, result, documentType, {
-      pdfPersistStatus: "ready",
-      pdfPersistedAt: new Date().toISOString(),
-      pdfStorageKey: persisted.attachment?.storageKey ?? null,
-      pdfPersistError: null,
-      pdfPersistStage: null,
-    })
+    await recordSmartbillInvoiceArtifactReady(
+      db,
+      event.id,
+      body,
+      result,
+      documentType,
+      persisted.attachment?.storageKey ?? null,
+    )
   }
 
   return persisted
@@ -349,8 +389,9 @@ export async function retrySmartbillInvoiceArtifact({
 
   const keyPrefix = await resolveMaybe(runtime.documentStorageKeyPrefix, context)
   const result = context.result
+  let persisted: SmartbillArtifactPersistenceResult
   try {
-    const persisted = await persistSmartbillPdfArtifact({
+    persisted = await persistSmartbillPdfArtifact({
       db,
       storage,
       client,
@@ -362,26 +403,6 @@ export async function retrySmartbillInvoiceArtifact({
       language: metadataString(metadata, "language"),
       keyPrefix,
     })
-
-    if (persisted.status === "persisted" || persisted.status === "already_exists") {
-      await registerSmartbillExternalRef(
-        db,
-        externalRef.invoiceId,
-        context.body,
-        result,
-        documentType,
-        {
-          ...(metadata ?? {}),
-          pdfPersistStatus: "ready",
-          pdfPersistedAt: new Date().toISOString(),
-          pdfStorageKey: persisted.attachment?.storageKey ?? null,
-          pdfPersistError: null,
-          pdfPersistStage: null,
-        },
-      )
-    }
-
-    return persisted
   } catch (error) {
     await registerSmartbillExternalRef(
       db,
@@ -399,6 +420,20 @@ export async function retrySmartbillInvoiceArtifact({
     )
     throw error
   }
+
+  if (persisted.status === "persisted" || persisted.status === "already_exists") {
+    await recordSmartbillInvoiceArtifactReady(
+      db,
+      externalRef.invoiceId,
+      context.body,
+      result,
+      documentType,
+      persisted.attachment?.storageKey ?? null,
+      metadata,
+    )
+  }
+
+  return persisted
 }
 
 async function persistSmartbillPdfArtifact({

--- a/packages/plugins/smartbill/src/plugin.ts
+++ b/packages/plugins/smartbill/src/plugin.ts
@@ -3,6 +3,7 @@ import { financeService } from "@voyantjs/finance"
 import { ZodError } from "zod"
 
 import {
+  isSmartbillPdfPersistMetadataUpdateError,
   persistSmartbillInvoiceArtifact,
   recordSmartbillInvoiceArtifactFailure,
   retrySmartbillInvoiceArtifact,
@@ -149,7 +150,10 @@ export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
         logger.info?.(`[smartbill] ${documentType} PDF re-attached for ${event.id}`, persisted)
       }
     } catch (err) {
-      logger.error(`[smartbill] artifact re-attach failed for ${event.id}`, err)
+      const message = isSmartbillPdfPersistMetadataUpdateError(err)
+        ? `[smartbill] artifact re-attach metadata update failed for ${event.id}`
+        : `[smartbill] artifact re-attach failed for ${event.id}`
+      logger.error(message, err)
     }
   }
 
@@ -172,6 +176,10 @@ export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
         logger.info?.(`[smartbill] ${documentType} PDF persisted for ${event.id}`, persisted)
       }
     } catch (err) {
+      if (isSmartbillPdfPersistMetadataUpdateError(err)) {
+        logger.error(`[smartbill] artifact persistence metadata update failed for ${event.id}`, err)
+        return
+      }
       logger.error(`[smartbill] artifact persistence failed for ${event.id}`, err)
       try {
         await recordSmartbillInvoiceArtifactFailure({

--- a/packages/plugins/smartbill/src/plugin.ts
+++ b/packages/plugins/smartbill/src/plugin.ts
@@ -4,6 +4,7 @@ import { ZodError } from "zod"
 
 import {
   persistSmartbillInvoiceArtifact,
+  recordSmartbillInvoiceArtifactFailure,
   retrySmartbillInvoiceArtifact,
   type SmartbillArtifactPersistenceOptions,
   type SmartbillArtifactStorageContext,
@@ -172,6 +173,21 @@ export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
       }
     } catch (err) {
       logger.error(`[smartbill] artifact persistence failed for ${event.id}`, err)
+      try {
+        await recordSmartbillInvoiceArtifactFailure({
+          runtime: artifacts,
+          event,
+          documentType,
+          body,
+          result,
+          error: err,
+        })
+      } catch (recordError) {
+        logger.error(
+          `[smartbill] artifact failure external-ref update failed for ${event.id}`,
+          recordError,
+        )
+      }
     }
   }
 

--- a/packages/plugins/smartbill/tests/unit/plugin.test.ts
+++ b/packages/plugins/smartbill/tests/unit/plugin.test.ts
@@ -536,6 +536,81 @@ describe("smartbillPlugin — invoice PDF artifacts", () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  it("does not mark retry PDF persistence failed when the ready metadata update fails", async () => {
+    const pdfBytes = new TextEncoder().encode("%PDF-1.7 smartbill retry")
+    financeServiceMock.registerInvoiceExternalRef.mockRejectedValueOnce(
+      new Error("ref update unavailable"),
+    )
+    const upload = vi
+      .fn()
+      .mockResolvedValue({ key: "invoices/inv_retry/smartbill/invoice-A-1.pdf", url: "" })
+    const storage = {
+      name: "test-storage",
+      upload,
+      delete: vi.fn(),
+      signedUrl: vi.fn(),
+      get: vi.fn(),
+    }
+
+    await expect(
+      retrySmartbillInvoiceArtifact({
+        runtime: {
+          db: {} as never,
+          documentStorage: storage,
+        },
+        client: {
+          createInvoice: vi.fn(),
+          createProforma: vi.fn(),
+          cancelInvoice: vi.fn(),
+          reverseInvoice: vi.fn(),
+          restoreInvoice: vi.fn(),
+          deleteInvoice: vi.fn(),
+          getPaymentStatus: vi.fn(),
+          listTaxes: vi.fn(),
+          listSeries: vi.fn(),
+          viewInvoicePdf: async () => ({
+            bytes: pdfBytes,
+            contentType: "application/pdf",
+          }),
+          viewPdf: vi.fn(),
+          viewEstimatePdf: vi.fn(),
+          listEstimateInvoices: vi.fn(),
+        },
+        externalRef: {
+          id: "iex_retry",
+          invoiceId: "inv_retry",
+          externalId: null,
+          externalNumber: "1",
+          externalUrl: null,
+          metadata: {
+            companyVatCode: "RO12345678",
+            seriesName: "A",
+            series: "A",
+            number: "1",
+          },
+        },
+        documentType: "invoice",
+      }),
+    ).rejects.toThrow("metadata update failed")
+
+    expect(upload).toHaveBeenCalledWith(
+      pdfBytes,
+      expect.objectContaining({ contentType: "application/pdf" }),
+    )
+    expect(financeServiceMock.registerInvoiceExternalRef).toHaveBeenCalledTimes(1)
+    expect(financeServiceMock.registerInvoiceExternalRef).toHaveBeenCalledWith(
+      expect.anything(),
+      "inv_retry",
+      expect.objectContaining({
+        metadata: expect.objectContaining({ pdfPersistStatus: "ready" }),
+      }),
+    )
+    const failedCalls = financeServiceMock.registerInvoiceExternalRef.mock.calls.filter(
+      ([, , input]) => input.metadata?.pdfPersistStatus === "failed",
+    )
+    expect(failedCalls).toHaveLength(0)
+  })
+
   it("registers the SmartBill ref and persists the generated invoice PDF when storage is configured", async () => {
     const pdfBytes = new TextEncoder().encode("%PDF-1.7 smartbill")
     const fetchMock = vi
@@ -617,6 +692,68 @@ describe("smartbillPlugin — invoice PDF artifacts", () => {
         name: "SmartBill invoice A-1.pdf",
         storageKey: "invoices/inv_123/smartbill/invoice-A-1.pdf",
       }),
+    )
+  })
+
+  it("does not record a PDF persistence failure after a successful PDF persist metadata update fails", async () => {
+    const pdfBytes = new TextEncoder().encode("%PDF-1.7 smartbill")
+    const fetchMock = vi
+      .fn<SmartbillFetch>()
+      .mockResolvedValueOnce(jsonResponse(200, { ...okEnvelope, number: "1", series: "A" }))
+      .mockResolvedValueOnce(bytesResponse(200, pdfBytes))
+    const upload = vi.fn().mockResolvedValue({
+      key: "invoices/inv_ready_update_fail/smartbill/invoice-A-1.pdf",
+      url: "",
+    })
+    const storage = {
+      name: "test-storage",
+      upload,
+      delete: vi.fn(),
+      signedUrl: vi.fn(),
+      get: vi.fn(),
+    }
+    const logger = makeLogger()
+    financeServiceMock.registerInvoiceExternalRef
+      .mockResolvedValueOnce({ id: "iex_1" })
+      .mockRejectedValueOnce(new Error("ref update unavailable"))
+    const plugin = smartbillPlugin({
+      ...baseOptions,
+      fetch: fetchMock,
+      logger,
+      artifacts: {
+        db: {} as never,
+        documentStorage: storage,
+      },
+    })
+    const handler = subscriberFor(plugin, "invoice.issued").handler
+
+    await handler(
+      eventEnvelope({
+        id: "inv_ready_update_fail",
+        clientName: "Test SRL",
+        currency: "RON",
+        lineItems: [{ name: "Tour", quantity: 1, unitPrice: 50000 }],
+      }),
+    )
+
+    expect(financeServiceMock.createInvoiceRendition).toHaveBeenCalled()
+    expect(financeServiceMock.createInvoiceAttachment).toHaveBeenCalled()
+    expect(financeServiceMock.registerInvoiceExternalRef).toHaveBeenCalledTimes(2)
+    expect(financeServiceMock.registerInvoiceExternalRef).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      "inv_ready_update_fail",
+      expect.objectContaining({
+        metadata: expect.objectContaining({ pdfPersistStatus: "ready" }),
+      }),
+    )
+    const failedCalls = financeServiceMock.registerInvoiceExternalRef.mock.calls.filter(
+      ([, , input]) => input.metadata?.pdfPersistStatus === "failed",
+    )
+    expect(failedCalls).toHaveLength(0)
+    expect(logger.error).toHaveBeenCalledWith(
+      "[smartbill] artifact persistence metadata update failed for inv_ready_update_fail",
+      expect.any(Error),
     )
   })
 

--- a/packages/plugins/smartbill/tests/unit/plugin.test.ts
+++ b/packages/plugins/smartbill/tests/unit/plugin.test.ts
@@ -106,7 +106,10 @@ beforeEach(() => {
   })
   financeServiceMock.listInvoiceAttachments.mockResolvedValue([])
   financeServiceMock.createInvoiceRendition.mockResolvedValue({ id: "invr_1" })
-  financeServiceMock.createInvoiceAttachment.mockResolvedValue({ id: "inva_1" })
+  financeServiceMock.createInvoiceAttachment.mockResolvedValue({
+    id: "inva_1",
+    storageKey: "invoices/inv_123/smartbill/invoice-A-1.pdf",
+  })
 })
 
 describe("smartbillPlugin structure", () => {
@@ -579,6 +582,18 @@ describe("smartbillPlugin — invoice PDF artifacts", () => {
         status: "issued",
       }),
     )
+    expect(financeServiceMock.registerInvoiceExternalRef).toHaveBeenCalledWith(
+      expect.anything(),
+      "inv_123",
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          pdfPersistStatus: "ready",
+          pdfStorageKey: "invoices/inv_123/smartbill/invoice-A-1.pdf",
+          pdfPersistError: null,
+          pdfPersistStage: null,
+        }),
+      }),
+    )
     expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(String(fetchMock.mock.calls[1]![0])).toContain("/invoice/pdf")
     expect(upload).toHaveBeenCalledWith(
@@ -602,6 +617,62 @@ describe("smartbillPlugin — invoice PDF artifacts", () => {
         name: "SmartBill invoice A-1.pdf",
         storageKey: "invoices/inv_123/smartbill/invoice-A-1.pdf",
       }),
+    )
+  })
+
+  it("records PDF persistence failures on the SmartBill external ref", async () => {
+    const fetchMock = vi
+      .fn<SmartbillFetch>()
+      .mockResolvedValueOnce(jsonResponse(200, { ...okEnvelope, number: "1", series: "A" }))
+      .mockResolvedValueOnce(textResponse(503, "pdf unavailable"))
+    const logger = makeLogger()
+    const plugin = smartbillPlugin({
+      ...baseOptions,
+      fetch: fetchMock,
+      logger,
+      artifacts: {
+        db: {} as never,
+        documentStorage: {
+          name: "test-storage",
+          upload: vi.fn(),
+          delete: vi.fn(),
+          signedUrl: vi.fn(),
+          get: vi.fn(),
+        },
+      },
+    })
+    const handler = subscriberFor(plugin, "invoice.issued").handler
+
+    await handler(
+      eventEnvelope({
+        id: "inv_pdf_fail",
+        clientName: "Test SRL",
+        currency: "RON",
+        lineItems: [{ name: "Tour", quantity: 1, unitPrice: 50000 }],
+      }),
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(financeServiceMock.registerInvoiceExternalRef).toHaveBeenCalledWith(
+      expect.anything(),
+      "inv_pdf_fail",
+      expect.objectContaining({
+        provider: "smartbill",
+        externalNumber: "1",
+        status: "issued",
+        metadata: expect.objectContaining({
+          pdfPersistStatus: "failed",
+          pdfPersistStage: "viewInvoicePdf",
+          pdfPersistError: expect.stringContaining("503"),
+          pdfPersistedAt: null,
+        }),
+      }),
+    )
+    expect(financeServiceMock.createInvoiceRendition).not.toHaveBeenCalled()
+    expect(financeServiceMock.createInvoiceAttachment).not.toHaveBeenCalled()
+    expect(logger.error).toHaveBeenCalledWith(
+      "[smartbill] artifact persistence failed for inv_pdf_fail",
+      expect.any(Error),
     )
   })
 


### PR DESCRIPTION
## Summary
- Record SmartBill PDF persistence ready/failed metadata on invoice external refs
- Tag PDF persistence errors with the failing stage for fetch, storage, rendition, and attachment steps
- Apply the same metadata updates from manual artifact retries
- Add a patch changeset for @voyantjs/plugin-smartbill

Closes #1160

## Verification
- `pnpm exec biome check packages/plugins/smartbill/src/artifacts.ts packages/plugins/smartbill/src/plugin.ts packages/plugins/smartbill/tests/unit/plugin.test.ts .changeset/smartbill-pdf-persist-status.md --write --no-errors-on-unmatched`
- `pnpm --filter @voyantjs/plugin-smartbill lint`
- `pnpm --filter @voyantjs/plugin-smartbill test -- plugin`
- `pnpm --filter @voyantjs/plugin-smartbill typecheck`
- `git diff --check`
- pre-commit hook: changed-file formatting, secretlint, changed-file quality report-only, repository lint, repository typecheck
- pre-push hook: `pnpm test`
