### PR TITLE
Fix SmartBill PDF accept header

### DIFF
--- a/.changeset/smartbill-pdf-accept-header.md
+++ b/.changeset/smartbill-pdf-accept-header.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/plugin-smartbill": patch
+---
+
+Request SmartBill invoice and proforma PDFs with an octet-stream accept header.

--- a/packages/plugins/smartbill/src/client.ts
+++ b/packages/plugins/smartbill/src/client.ts
@@ -147,7 +147,7 @@ export function createSmartbillClient(options: SmartbillClientOptions): Smartbil
     }
     const response = await fetchImpl(`${apiUrl}${path}`, {
       method: "GET",
-      headers: { ...headers(), Accept: "application/pdf" },
+      headers: { ...headers(), Accept: "application/octet-stream" },
     })
     if (!response.ok) {
       const text = await response.text().catch(() => "")

--- a/packages/plugins/smartbill/tests/unit/client.test.ts
+++ b/packages/plugins/smartbill/tests/unit/client.test.ts
@@ -205,16 +205,18 @@ describe("createSmartbillClient PDF endpoints", () => {
   const pdfBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34])
 
   it("returns PDF bytes from /invoice/pdf", async () => {
-    const fetchMock = vi.fn<SmartbillFetch>(async () => pdfResponse(200, pdfBytes))
+    const fetchMock = vi.fn<SmartbillFetch>(async () =>
+      pdfResponse(200, pdfBytes, "application/octet-stream"),
+    )
     const client = createSmartbillClient({ ...baseOptions, fetch: fetchMock })
     const result = await client.viewInvoicePdf("RO123", "A", "42")
-    expect(result.contentType).toBe("application/pdf")
+    expect(result.contentType).toBe("application/octet-stream")
     expect(result.bytes).toBeInstanceOf(Uint8Array)
     expect(Array.from(result.bytes)).toEqual(Array.from(pdfBytes))
     const [url, init] = fetchMock.mock.calls[0]!
     expect(url).toContain("/invoice/pdf?cif=RO123&seriesname=A&number=42")
     expect(init.method).toBe("GET")
-    expect(init.headers.Accept).toBe("application/pdf")
+    expect(init.headers.Accept).toBe("application/octet-stream")
   })
 
   it("returns PDF bytes from /estimate/pdf", async () => {


### PR DESCRIPTION
## Summary
- Request SmartBill invoice/proforma PDFs with `Accept: application/octet-stream`
- Update the client PDF endpoint test to cover the production response content type
- Add a patch changeset for `@voyantjs/plugin-smartbill`

Closes #1163

## Verification
- `pnpm exec biome check packages/plugins/smartbill/src/client.ts packages/plugins/smartbill/tests/unit/client.test.ts .changeset/smartbill-pdf-accept-header.md --write --no-errors-on-unmatched`
- `pnpm --filter @voyantjs/plugin-smartbill lint`
- `pnpm --filter @voyantjs/plugin-smartbill test -- client`
- `pnpm --filter @voyantjs/plugin-smartbill typecheck`
- `git diff --check`
- pre-commit hook: changed-file formatting, secretlint, changed-file quality report-only, repository lint, repository typecheck
- pre-push hook: `pnpm test`
