### PR TITLE
Write back SmartBill invoice numbers

### DIFF
--- a/.changeset/smartbill-invoice-number-write-back.md
+++ b/.changeset/smartbill-invoice-number-write-back.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/plugin-smartbill": patch
+---
+
+Add an opt-in SmartBill invoice number write-back option for mirroring issued series-numbers onto finance invoices.

--- a/packages/plugins/smartbill/src/index.ts
+++ b/packages/plugins/smartbill/src/index.ts
@@ -41,6 +41,7 @@ export { createSmartbillMockServer } from "./mock.js"
 export type {
   SmartbillErrorHandler,
   SmartbillIdempotencyOptions,
+  SmartbillInvoiceNumberWriteBackFormatter,
   SmartbillLogger,
   SmartbillMapFn,
   SmartbillPluginOptions,

--- a/packages/plugins/smartbill/src/plugin.ts
+++ b/packages/plugins/smartbill/src/plugin.ts
@@ -48,12 +48,23 @@ export type SmartbillErrorHandler = (
   error: unknown,
 ) => void | Promise<void>
 
+export type SmartbillInvoiceNumberWriteBackFormatter = (
+  event: VoyantInvoiceEvent,
+  result: SmartbillInvoiceResponse,
+) => string | Promise<string>
+
 export interface SmartbillPluginOptions extends SmartbillClientOptions, SmartbillMappingOptions {
   events?: SmartbillSyncEventNames
   mapEvent?: SmartbillMapFn
   logger?: SmartbillLogger
   idempotency?: SmartbillIdempotencyOptions
   onError?: SmartbillErrorHandler
+  /**
+   * When enabled, mirrors SmartBill's issued series-number back onto
+   * `invoices.invoice_number` after a successful create. `true` uses
+   * `${series}-${number}`; a formatter can return a custom value.
+   */
+  writeBackInvoiceNumber?: boolean | SmartbillInvoiceNumberWriteBackFormatter
   /**
    * Optional finance artifact persistence. When `db` is supplied, the plugin
    * registers the SmartBill external ref after creation. When
@@ -81,8 +92,16 @@ function coerceEvent(data: unknown): VoyantInvoiceEvent | null {
 
 export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
   const validatedOptions = parseSmartbillPluginOptions(options)
-  const { client, logger, mapEvent, eventNames, artifacts, idempotency, onError } =
-    createSmartbillSyncRuntime(validatedOptions)
+  const {
+    client,
+    logger,
+    mapEvent,
+    eventNames,
+    artifacts,
+    idempotency,
+    onError,
+    writeBackInvoiceNumber,
+  } = createSmartbillSyncRuntime(validatedOptions)
 
   async function resolveMaybe<TContext, TValue>(
     value: TValue | ((context: TContext) => TValue | Promise<TValue>) | undefined | null,
@@ -139,6 +158,7 @@ export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
       externalRef,
     )
     await applyExternalAllocationFromRefIfRequired(event, documentType, body, externalRef)
+    await writeBackInvoiceNumberFromRefIfRequired(event, documentType, body, externalRef)
     try {
       const persisted = await retrySmartbillInvoiceArtifact({
         runtime: artifacts,
@@ -246,6 +266,70 @@ export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
     })
   }
 
+  async function resolveWriteBackInvoiceNumber(
+    event: VoyantInvoiceEvent,
+    body: SmartbillInvoiceBody,
+    result: SmartbillInvoiceResponse,
+  ) {
+    if (!writeBackInvoiceNumber) return null
+    if (typeof writeBackInvoiceNumber === "function") {
+      const invoiceNumber = await writeBackInvoiceNumber(event, result)
+      if (typeof invoiceNumber !== "string" || invoiceNumber.trim().length === 0) {
+        throw new Error("SmartBill invoice number write-back formatter returned an empty value")
+      }
+      return invoiceNumber
+    }
+    if (!result.number) return null
+    return formatExternalInvoiceNumber(result.series ?? body.seriesName, result.number)
+  }
+
+  async function writeBackInvoiceNumberIfRequired(
+    event: VoyantInvoiceEvent,
+    documentType: SmartbillDocumentType,
+    body: SmartbillInvoiceBody,
+    result: SmartbillInvoiceResponse,
+  ) {
+    const invoiceNumber = await resolveWriteBackInvoiceNumber(event, body, result)
+    if (!invoiceNumber) return
+
+    const db = await resolveArtifactDb(event, documentType, body, result)
+    if (!db) {
+      throw new Error("SmartBill invoice number write-back requires artifact database access")
+    }
+
+    const invoice = await financeService.updateInvoice(db, event.id, { invoiceNumber })
+    if (!invoice) {
+      throw new Error(`SmartBill invoice number write-back failed for missing invoice ${event.id}`)
+    }
+    logger.info?.(`[smartbill] invoice number write-back applied for ${event.id}`, invoice)
+  }
+
+  async function writeBackInvoiceNumberFromRefIfRequired(
+    event: VoyantInvoiceEvent,
+    documentType: SmartbillDocumentType,
+    body: SmartbillInvoiceBody,
+    externalRef: SmartbillExternalRef,
+  ) {
+    if (!writeBackInvoiceNumber) return
+
+    const metadata = coerceMetadata(externalRef.metadata)
+    const number =
+      metadataString(metadata, "number") ??
+      externalRef.externalNumber ??
+      externalRef.externalId ??
+      null
+    if (!number) return
+
+    await writeBackInvoiceNumberIfRequired(event, documentType, body, {
+      number,
+      series:
+        metadataString(metadata, "series") ??
+        metadataString(metadata, "seriesName") ??
+        body.seriesName,
+      url: externalRef.externalUrl ?? undefined,
+    })
+  }
+
   async function recordSyncError(
     event: VoyantInvoiceEvent,
     documentType: SmartbillDocumentType,
@@ -308,6 +392,7 @@ export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
             result,
           )
           await persistArtifact(event, "invoice", body, result)
+          await writeBackInvoiceNumberIfRequired(event, "invoice", body, result)
           await applyExternalAllocationIfRequired(event, "invoice", body, result)
         } catch (err) {
           logger.error(
@@ -338,6 +423,7 @@ export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
             result,
           )
           await persistArtifact(event, "proforma", body, result)
+          await writeBackInvoiceNumberIfRequired(event, "proforma", body, result)
           await applyExternalAllocationIfRequired(event, "proforma", body, result)
         } catch (err) {
           logger.error(

--- a/packages/plugins/smartbill/src/plugin.ts
+++ b/packages/plugins/smartbill/src/plugin.ts
@@ -144,7 +144,7 @@ export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
     if (!db) return null
 
     const refs = await financeService.listInvoiceExternalRefs(db, event.id)
-    return refs.find((ref) => isUsableSmartbillRef(ref)) ?? null
+    return refs.find((ref) => isMatchingSmartbillRef(ref, documentType)) ?? null
   }
 
   async function handleExistingSmartbillRef(
@@ -345,7 +345,7 @@ export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
       const db = await resolveArtifactDb(event, documentType)
       if (!db) return
       const refs = await financeService.listInvoiceExternalRefs(db, event.id)
-      if (refs.some((ref) => isUsableSmartbillRef(ref))) return
+      if (refs.some((ref) => isMatchingSmartbillRef(ref, documentType))) return
 
       await financeService.registerInvoiceExternalRef(db, event.id, {
         provider: "smartbill",
@@ -544,6 +544,21 @@ function isUsableSmartbillRef(ref: {
     !ref.syncError &&
     Boolean(ref.externalNumber || ref.externalId)
   )
+}
+
+function isMatchingSmartbillRef(
+  ref: {
+    provider: string
+    status?: string | null
+    syncError?: string | null
+    externalNumber?: string | null
+    externalId?: string | null
+    metadata?: unknown
+  },
+  documentType: SmartbillDocumentType,
+) {
+  if (!isUsableSmartbillRef(ref)) return false
+  return metadataString(coerceMetadata(ref.metadata), "documentType") === documentType
 }
 
 function parseSmartbillPluginOptions(options: SmartbillPluginOptions): SmartbillPluginOptions {

--- a/packages/plugins/smartbill/src/runtime.ts
+++ b/packages/plugins/smartbill/src/runtime.ts
@@ -19,6 +19,7 @@ export interface SmartbillSyncRuntime {
   artifacts: SmartbillArtifactPersistenceOptions
   idempotency: NonNullable<SmartbillPluginOptions["idempotency"]>
   onError: SmartbillPluginOptions["onError"]
+  writeBackInvoiceNumber: SmartbillPluginOptions["writeBackInvoiceNumber"]
 }
 
 export function createSmartbillSyncRuntime(options: SmartbillPluginOptions): SmartbillSyncRuntime {
@@ -60,5 +61,6 @@ export function createSmartbillSyncRuntime(options: SmartbillPluginOptions): Sma
       skipExistingExternalRef: options.idempotency?.skipExistingExternalRef ?? true,
     },
     onError: options.onError,
+    writeBackInvoiceNumber: options.writeBackInvoiceNumber,
   }
 }

--- a/packages/plugins/smartbill/src/validation.ts
+++ b/packages/plugins/smartbill/src/validation.ts
@@ -9,6 +9,7 @@ import type { SmartbillMappingOptions } from "./mapping.js"
 import type {
   SmartbillErrorHandler,
   SmartbillIdempotencyOptions,
+  SmartbillInvoiceNumberWriteBackFormatter,
   SmartbillLogger,
   SmartbillMapFn,
   SmartbillPluginOptions,
@@ -54,6 +55,13 @@ const optionalMapEvent = z.custom<SmartbillMapFn | undefined>(
 const optionalOnError = z.custom<SmartbillErrorHandler | undefined>(
   (value) => value === undefined || typeof value === "function",
   "Expected an onError function",
+)
+
+const optionalWriteBackInvoiceNumber = z.custom<
+  boolean | SmartbillInvoiceNumberWriteBackFormatter | undefined
+>(
+  (value) => value === undefined || typeof value === "boolean" || typeof value === "function",
+  "Expected a boolean or invoice number formatter function",
 )
 
 const optionalDb = z.custom<SmartbillDbResolver | undefined>(
@@ -138,6 +146,7 @@ export const smartbillPluginOptionsSchema = z.object({
   logger: optionalLogger.optional(),
   idempotency: optionalIdempotency.optional(),
   onError: optionalOnError.optional(),
+  writeBackInvoiceNumber: optionalWriteBackInvoiceNumber.optional(),
   artifacts: optionalArtifacts.optional(),
   db: optionalDb.optional(),
   documentStorage: optionalDocumentStorage.optional(),

--- a/packages/plugins/smartbill/tests/unit/plugin.test.ts
+++ b/packages/plugins/smartbill/tests/unit/plugin.test.ts
@@ -8,6 +8,7 @@ const financeServiceMock = vi.hoisted(() => ({
   listInvoiceExternalRefs: vi.fn(),
   registerInvoiceExternalRef: vi.fn(),
   applyExternalInvoiceAllocation: vi.fn(),
+  updateInvoice: vi.fn(),
   listInvoiceAttachments: vi.fn(),
   createInvoiceRendition: vi.fn(),
   createInvoiceAttachment: vi.fn(),
@@ -104,6 +105,7 @@ beforeEach(() => {
     status: "applied",
     invoice: { id: "inv_123" },
   })
+  financeServiceMock.updateInvoice.mockResolvedValue({ id: "inv_123" })
   financeServiceMock.listInvoiceAttachments.mockResolvedValue([])
   financeServiceMock.createInvoiceRendition.mockResolvedValue({ id: "invr_1" })
   financeServiceMock.createInvoiceAttachment.mockResolvedValue({
@@ -295,6 +297,124 @@ describe("smartbillPlugin — invoice.issued subscriber", () => {
       expect.anything(),
       "inv_external",
       { invoiceNumber: "SB-42" },
+    )
+  })
+
+  it("writes the SmartBill series-number back to the invoice when configured", async () => {
+    const fetchMock = vi.fn<SmartbillFetch>(async () =>
+      jsonResponse(200, { ...okEnvelope, number: "0127", series: "B" }),
+    )
+    const logger = makeLogger()
+    const plugin = smartbillPlugin({
+      ...baseOptions,
+      fetch: fetchMock,
+      artifacts: { db: {} as never },
+      logger,
+      writeBackInvoiceNumber: true,
+    })
+    const handler = subscriberFor(plugin, "invoice.issued").handler
+
+    await handler(
+      eventEnvelope({
+        id: "inv_write_back",
+        invoiceNumber: "PRO-BK-2605-5728",
+        lineItems: [],
+      }),
+    )
+
+    expect(financeServiceMock.updateInvoice).toHaveBeenCalledWith(
+      expect.anything(),
+      "inv_write_back",
+      {
+        invoiceNumber: "B-0127",
+      },
+    )
+    expect(logger.info).toHaveBeenCalledWith(
+      "[smartbill] invoice number write-back applied for inv_write_back",
+      expect.objectContaining({ id: "inv_123" }),
+    )
+  })
+
+  it("uses a custom SmartBill invoice number write-back formatter", async () => {
+    const fetchMock = vi.fn<SmartbillFetch>(async () =>
+      jsonResponse(200, { ...okEnvelope, number: "0127", series: "B" }),
+    )
+    const writeBackInvoiceNumber = vi.fn(async (event, result) => {
+      return `${event.id}/${result.series}/${result.number}`
+    })
+    const plugin = smartbillPlugin({
+      ...baseOptions,
+      fetch: fetchMock,
+      artifacts: { db: {} as never },
+      logger: makeLogger(),
+      writeBackInvoiceNumber,
+    })
+    const handler = subscriberFor(plugin, "invoice.proforma.issued").handler
+
+    await handler(
+      eventEnvelope({
+        id: "proforma_write_back",
+        invoiceNumber: "PRO-BK-2605-5728",
+        lineItems: [],
+      }),
+    )
+
+    expect(writeBackInvoiceNumber).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "proforma_write_back" }),
+      expect.objectContaining({ number: "0127", series: "B" }),
+    )
+    expect(financeServiceMock.updateInvoice).toHaveBeenCalledWith(
+      expect.anything(),
+      "proforma_write_back",
+      { invoiceNumber: "proforma_write_back/B/0127" },
+    )
+  })
+
+  it("writes the SmartBill invoice number back from an existing external ref", async () => {
+    financeServiceMock.listInvoiceExternalRefs.mockResolvedValueOnce([
+      {
+        id: "iex_existing",
+        invoiceId: "inv_existing_write_back",
+        provider: "smartbill",
+        externalId: "0127",
+        externalNumber: "0127",
+        externalUrl: null,
+        status: "issued",
+        syncError: null,
+        metadata: {
+          companyVatCode: "RO12345678",
+          seriesName: "B",
+          series: "B",
+          number: "0127",
+          documentType: "invoice",
+        },
+      },
+    ])
+    const fetchMock = vi.fn<SmartbillFetch>(async () =>
+      jsonResponse(200, { ...okEnvelope, number: "ignored", series: "ignored" }),
+    )
+    const plugin = smartbillPlugin({
+      ...baseOptions,
+      fetch: fetchMock,
+      artifacts: { db: {} as never },
+      logger: makeLogger(),
+      writeBackInvoiceNumber: true,
+    })
+    const handler = subscriberFor(plugin, "invoice.issued").handler
+
+    await handler(
+      eventEnvelope({
+        id: "inv_existing_write_back",
+        invoiceNumber: "PRO-BK-2605-5728",
+        lineItems: [],
+      }),
+    )
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(financeServiceMock.updateInvoice).toHaveBeenCalledWith(
+      expect.anything(),
+      "inv_existing_write_back",
+      { invoiceNumber: "B-0127" },
     )
   })
 

--- a/packages/plugins/smartbill/tests/unit/plugin.test.ts
+++ b/packages/plugins/smartbill/tests/unit/plugin.test.ts
@@ -418,6 +418,54 @@ describe("smartbillPlugin — invoice.issued subscriber", () => {
     )
   })
 
+  it("ignores existing SmartBill refs for a different document type when writing back", async () => {
+    financeServiceMock.listInvoiceExternalRefs.mockResolvedValueOnce([
+      {
+        id: "iex_existing_proforma",
+        invoiceId: "inv_write_back_mismatch",
+        provider: "smartbill",
+        externalId: "0009",
+        externalNumber: "0009",
+        externalUrl: null,
+        status: "issued",
+        syncError: null,
+        metadata: {
+          companyVatCode: "RO12345678",
+          seriesName: "PF",
+          series: "PF",
+          number: "0009",
+          documentType: "proforma",
+        },
+      },
+    ])
+    const fetchMock = vi.fn<SmartbillFetch>(async () =>
+      jsonResponse(200, { ...okEnvelope, number: "0127", series: "B" }),
+    )
+    const plugin = smartbillPlugin({
+      ...baseOptions,
+      fetch: fetchMock,
+      artifacts: { db: {} as never },
+      logger: makeLogger(),
+      writeBackInvoiceNumber: true,
+    })
+    const handler = subscriberFor(plugin, "invoice.issued").handler
+
+    await handler(
+      eventEnvelope({
+        id: "inv_write_back_mismatch",
+        invoiceNumber: "PRO-BK-2605-5728",
+        lineItems: [],
+      }),
+    )
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    expect(financeServiceMock.updateInvoice).toHaveBeenCalledWith(
+      expect.anything(),
+      "inv_write_back_mismatch",
+      { invoiceNumber: "B-0127" },
+    )
+  })
+
   it("keeps the SmartBill ref retryable when external allocation fails", async () => {
     financeServiceMock.applyExternalInvoiceAllocation.mockRejectedValueOnce(new Error("db down"))
     financeServiceMock.listInvoiceExternalRefs.mockResolvedValueOnce([]).mockResolvedValueOnce([


### PR DESCRIPTION
## Summary
- Add opt-in `writeBackInvoiceNumber` support to mirror SmartBill issued series-numbers onto finance invoices
- Support custom invoice number formatters and duplicate/ref retry write-back from existing SmartBill refs
- Validate the new option, export its formatter type, and add a patch changeset for `@voyantjs/plugin-smartbill`

Closes #1166

## Verification
- `pnpm exec biome check packages/plugins/smartbill/src/plugin.ts packages/plugins/smartbill/src/runtime.ts packages/plugins/smartbill/src/validation.ts packages/plugins/smartbill/src/index.ts packages/plugins/smartbill/tests/unit/plugin.test.ts .changeset/smartbill-invoice-number-write-back.md --write --no-errors-on-unmatched`
- `pnpm --filter @voyantjs/plugin-smartbill lint`
- `pnpm --filter @voyantjs/plugin-smartbill test -- plugin`
- `pnpm --filter @voyantjs/plugin-smartbill typecheck`
- `git diff --check`
- pre-commit hook: changed-file formatting, secretlint, changed-file quality report-only, repository lint, repository typecheck
- pre-push hook: `pnpm test`