### PR TITLE
Fix schedule row invoice amounts

### DIFF
--- a/.changeset/schedule-row-invoices.md
+++ b/.changeset/schedule-row-invoices.md
@@ -1,0 +1,7 @@
+---
+"@voyantjs/finance": patch
+"@voyantjs/finance-react": patch
+"@voyantjs/bookings-ui": patch
+---
+
+Create booking invoices from a targeted payment schedule row when one is provided.

--- a/packages/bookings-ui/src/components/booking-payment-schedule-list.tsx
+++ b/packages/bookings-ui/src/components/booking-payment-schedule-list.tsx
@@ -65,6 +65,7 @@ export function BookingPaymentScheduleList({ bookingId }: BookingPaymentSchedule
       const prefix = invoiceType === "proforma" ? "PRO" : "INV"
       const invoice = await createInvoiceFromBooking.mutateAsync({
         bookingId: booking.id,
+        bookingPaymentScheduleId: schedule.id,
         invoiceNumber: `${prefix}-${booking.bookingNumber}-${schedule.scheduleType.toUpperCase().slice(0, 3)}`,
         issueDate: todayIso,
         dueDate: dueIso,

--- a/packages/bookings-ui/tests/unit/booking-payment-schedule-list.test.tsx
+++ b/packages/bookings-ui/tests/unit/booking-payment-schedule-list.test.tsx
@@ -154,6 +154,7 @@ describe("BookingPaymentScheduleList", () => {
     expect(testState.createFromBooking).toHaveBeenCalledWith(
       expect.objectContaining({
         bookingId: "book_123",
+        bookingPaymentScheduleId: "sched_123",
         invoiceType: "invoice",
       }),
     )

--- a/packages/finance-react/src/hooks/use-invoice-mutation.ts
+++ b/packages/finance-react/src/hooks/use-invoice-mutation.ts
@@ -85,9 +85,8 @@ export function useInvoiceMutation() {
 
   /**
    * Create + issue an invoice (or proforma) from an existing booking. The
-   * server walks the booking's items, builds line items, and emits an
-   * `invoice.issued` event post-commit. Used by the Documents tab on the
-   * booking detail page to bootstrap an invoice when none exists yet.
+   * server builds line items from either the booking items or a targeted
+   * payment schedule row, then emits an `invoice.issued` event post-commit.
    */
   const createFromBooking = useMutation({
     mutationFn: async (input: CreateInvoiceFromBookingInput) => {
@@ -163,6 +162,7 @@ export interface ConvertProformaInput {
 
 export interface CreateInvoiceFromBookingInput {
   bookingId: string
+  bookingPaymentScheduleId?: string
   invoiceNumber: string
   issueDate: string
   dueDate: string

--- a/packages/finance/src/routes.ts
+++ b/packages/finance/src/routes.ts
@@ -934,17 +934,19 @@ export const financeRoutes = new Hono<Env>()
     )
   })
 
-  // POST /invoices/from-booking — Create + issue invoice (or proforma) from booking + booking items
+  // POST /invoices/from-booking — Create + issue invoice/proforma from a booking or schedule row
   .post("/invoices/from-booking", async (c) => {
     const input = await parseJsonBody(c, invoiceFromBookingSchema)
     const waitRequest = resolveWaitRequest(input, parseQuery(c, invoiceDocumentWaitQuerySchema))
     const db = c.get("db")
     const [
       { bookingItems, bookings },
-      { eq },
+      { bookingPaymentSchedules },
+      { and, eq },
       { issueInvoiceFromBooking, issueProformaFromBooking },
     ] = await Promise.all([
       import("@voyantjs/bookings/schema"),
+      import("./schema.js"),
       import("drizzle-orm"),
       import("./service-issue.js"),
     ])
@@ -960,6 +962,22 @@ export const financeRoutes = new Hono<Env>()
     }
 
     const items = await db.select().from(bookingItems).where(eq(bookingItems.bookingId, booking.id))
+    const [paymentSchedule] = input.bookingPaymentScheduleId
+      ? await db
+          .select()
+          .from(bookingPaymentSchedules)
+          .where(
+            and(
+              eq(bookingPaymentSchedules.id, input.bookingPaymentScheduleId),
+              eq(bookingPaymentSchedules.bookingId, booking.id),
+            ),
+          )
+          .limit(1)
+      : []
+
+    if (input.bookingPaymentScheduleId && !paymentSchedule) {
+      return c.json({ error: "Booking payment schedule not found" }, 404)
+    }
 
     const runtime = (() => {
       try {
@@ -989,6 +1007,17 @@ export const financeRoutes = new Hono<Env>()
             sellAmountCents: booking.sellAmountCents,
             baseSellAmountCents: booking.baseSellAmountCents,
           },
+          paymentSchedule: paymentSchedule
+            ? {
+                id: paymentSchedule.id,
+                bookingId: paymentSchedule.bookingId,
+                bookingItemId: paymentSchedule.bookingItemId,
+                scheduleType: paymentSchedule.scheduleType,
+                dueDate: paymentSchedule.dueDate,
+                currency: paymentSchedule.currency,
+                amountCents: paymentSchedule.amountCents,
+              }
+            : null,
           items: items.map((item) => ({
             id: item.id,
             title: item.title,

--- a/packages/finance/src/service.ts
+++ b/packages/finance/src/service.ts
@@ -340,6 +340,15 @@ export interface InvoiceFromBookingData {
     sellAmountCents: number | null
     baseSellAmountCents: number | null
   }
+  paymentSchedule?: {
+    id: string
+    bookingId: string
+    bookingItemId: string | null
+    scheduleType: "deposit" | "installment" | "balance" | "hold" | "other"
+    dueDate: string
+    currency: string
+    amountCents: number
+  } | null
   items: Array<{
     id: string
     title: string
@@ -347,6 +356,17 @@ export interface InvoiceFromBookingData {
     unitSellAmountCents: number | null
     totalSellAmountCents: number | null
   }>
+}
+
+const PAYMENT_SCHEDULE_LINE_LABELS: Record<
+  NonNullable<InvoiceFromBookingData["paymentSchedule"]>["scheduleType"],
+  string
+> = {
+  deposit: "Deposit",
+  installment: "Installment",
+  balance: "Balance",
+  hold: "Hold",
+  other: "Payment schedule",
 }
 
 function bookingItemToInvoiceLine(
@@ -377,6 +397,35 @@ function bookingItemToInvoiceLine(
         : null,
     sortOrder,
   }
+}
+
+function bookingPaymentScheduleToInvoiceLine(
+  booking: InvoiceFromBookingData["booking"],
+  schedule: NonNullable<InvoiceFromBookingData["paymentSchedule"]>,
+) {
+  const label = PAYMENT_SCHEDULE_LINE_LABELS[schedule.scheduleType]
+
+  return {
+    bookingItemId: null as string | null,
+    description: `${label} for booking ${booking.bookingNumber}`,
+    quantity: 1,
+    unitPriceCents: schedule.amountCents,
+    totalCents: schedule.amountCents,
+    taxRate: null,
+    sortOrder: 0,
+  }
+}
+
+function resolveBookingInvoiceBaseAmount(
+  booking: InvoiceFromBookingData["booking"],
+  invoiceCurrency: string,
+  amountCents: number,
+) {
+  if (!booking.baseCurrency) return null
+  if (invoiceCurrency === booking.baseCurrency) return amountCents
+  if (invoiceCurrency !== booking.sellCurrency || booking.baseSellAmountCents == null) return null
+  if (!booking.sellAmountCents || booking.sellAmountCents <= 0) return booking.baseSellAmountCents
+  return Math.round((amountCents / booking.sellAmountCents) * booking.baseSellAmountCents)
 }
 
 function toTimestamp(value?: string | null) {
@@ -3175,10 +3224,11 @@ export const financeService = {
     data: CreateInvoiceFromBookingInput,
     bookingData: InvoiceFromBookingData,
   ) {
-    const { booking, items } = bookingData
+    const { booking, items, paymentSchedule } = bookingData
     const numberAssignment = await resolveInvoiceNumberForBooking(db, data)
 
-    const itemIds = items.map((item) => item.id)
+    const invoiceItems = paymentSchedule ? [] : items
+    const itemIds = invoiceItems.map((item) => item.id)
 
     const taxes =
       itemIds.length === 0
@@ -3203,9 +3253,10 @@ export const financeService = {
       taxesByBookingItemId.set(tax.bookingItemId, existing)
     }
 
-    const lineItems =
-      items.length > 0
-        ? items.map((item, sortOrder) => ({
+    const lineItems = paymentSchedule
+      ? [bookingPaymentScheduleToInvoiceLine(booking, paymentSchedule)]
+      : invoiceItems.length > 0
+        ? invoiceItems.map((item, sortOrder) => ({
             ...bookingItemToInvoiceLine(item, taxesByBookingItemId.get(item.id) ?? [], sortOrder),
           }))
         : [
@@ -3242,6 +3293,10 @@ export const financeService = {
     // baseCurrency null — propagate that NULL across every base_*
     // field so the constraint stays satisfied.
     const hasBaseCurrency = Boolean(booking.baseCurrency)
+    const invoiceCurrency = paymentSchedule?.currency ?? booking.sellCurrency
+    const invoiceBaseAmountCents = paymentSchedule
+      ? resolveBookingInvoiceBaseAmount(booking, invoiceCurrency, paymentSchedule.amountCents)
+      : (booking.baseSellAmountCents ?? null)
 
     return db.transaction(async (tx) => {
       const [invoice] = await tx
@@ -3255,19 +3310,19 @@ export const financeService = {
           personId: booking.personId,
           organizationId: booking.organizationId,
           status: numberAssignment.status,
-          currency: booking.sellCurrency,
+          currency: invoiceCurrency,
           baseCurrency: booking.baseCurrency,
           fxRateSetId: booking.fxRateSetId,
           subtotalCents,
-          baseSubtotalCents: hasBaseCurrency ? (booking.baseSellAmountCents ?? null) : null,
+          baseSubtotalCents: hasBaseCurrency ? invoiceBaseAmountCents : null,
           taxCents,
           baseTaxCents: null,
           totalCents,
-          baseTotalCents: hasBaseCurrency ? (booking.baseSellAmountCents ?? null) : null,
+          baseTotalCents: hasBaseCurrency ? invoiceBaseAmountCents : null,
           paidCents: 0,
           basePaidCents: hasBaseCurrency ? 0 : null,
           balanceDueCents: totalCents,
-          baseBalanceDueCents: hasBaseCurrency ? (booking.baseSellAmountCents ?? null) : null,
+          baseBalanceDueCents: hasBaseCurrency ? invoiceBaseAmountCents : null,
           commissionAmountCents: commissionAmountCents > 0 ? commissionAmountCents : null,
           issueDate: data.issueDate,
           dueDate: data.dueDate,

--- a/packages/finance/src/validation-billing.ts
+++ b/packages/finance/src/validation-billing.ts
@@ -116,6 +116,7 @@ const invoiceDocumentWaitFieldsSchema = z.object({
 
 export const invoiceFromBookingSchema = z.object({
   bookingId: z.string().min(1),
+  bookingPaymentScheduleId: z.string().min(1).optional(),
   invoiceNumber: z.string().min(1).max(50).optional(),
   seriesId: z.string().min(1).optional(),
   issueDate: z.string().min(1),

--- a/packages/finance/tests/integration/routes.test.ts
+++ b/packages/finance/tests/integration/routes.test.ts
@@ -8,6 +8,7 @@ import { FINANCE_ROUTE_RUNTIME_CONTAINER_KEY } from "../../src/route-runtime.js"
 import { financeRoutes } from "../../src/routes.js"
 import {
   bookingPaymentSchedules,
+  invoiceLineItems,
   invoiceRenditions,
   paymentAuthorizations,
   paymentCaptures,
@@ -1330,6 +1331,81 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       expect(res.status).toBe(201)
       const { data } = await res.json()
       expect(data.subtotalCents).toBe(50000) // uses booking.sellAmountCents
+    })
+
+    it("creates an invoice from a single booking payment schedule row", async () => {
+      const booking = await seedBooking({ sellAmountCents: 33000 })
+      await seedBookingItem(booking.id)
+      await seedBookingItem(booking.id)
+      const schedule = await seedBookingPaymentSchedule(booking.id, {
+        amountCents: 16500,
+        scheduleType: "balance",
+      })
+
+      const res = await app.request("/invoices/from-booking", {
+        method: "POST",
+        ...json({
+          bookingId: booking.id,
+          bookingPaymentScheduleId: schedule.id,
+          invoiceNumber: nextInvoiceNumber(),
+          issueDate: "2025-06-01",
+          dueDate: "2025-07-01",
+        }),
+      })
+
+      expect(res.status).toBe(201)
+      const { data } = await res.json()
+      expect(data.bookingId).toBe(booking.id)
+      expect(data.subtotalCents).toBe(16500)
+      expect(data.totalCents).toBe(16500)
+      expect(data.balanceDueCents).toBe(16500)
+
+      const lines = await db
+        .select()
+        .from(invoiceLineItems)
+        .where(eq(invoiceLineItems.invoiceId, data.id))
+      expect(lines).toHaveLength(1)
+      expect(lines[0]).toMatchObject({
+        bookingItemId: null,
+        description: `Balance for booking ${booking.bookingNumber}`,
+        quantity: 1,
+        unitPriceCents: 16500,
+        totalCents: 16500,
+      })
+    })
+
+    it("does not derive base amounts from booking sell currency for cross-currency schedule invoices", async () => {
+      const booking = await seedBooking({
+        sellCurrency: "USD",
+        sellAmountCents: 33000,
+        baseCurrency: "RON",
+        baseSellAmountCents: 150000,
+      })
+      const schedule = await seedBookingPaymentSchedule(booking.id, {
+        currency: "EUR",
+        amountCents: 16500,
+        scheduleType: "balance",
+      })
+
+      const res = await app.request("/invoices/from-booking", {
+        method: "POST",
+        ...json({
+          bookingId: booking.id,
+          bookingPaymentScheduleId: schedule.id,
+          invoiceNumber: nextInvoiceNumber(),
+          issueDate: "2025-06-01",
+          dueDate: "2025-07-01",
+        }),
+      })
+
+      expect(res.status).toBe(201)
+      const { data } = await res.json()
+      expect(data.currency).toBe("EUR")
+      expect(data.baseCurrency).toBe("RON")
+      expect(data.subtotalCents).toBe(16500)
+      expect(data.baseSubtotalCents).toBeNull()
+      expect(data.baseTotalCents).toBeNull()
+      expect(data.baseBalanceDueCents).toBeNull()
     })
 
     it("returns 404 for non-existent booking", async () => {


### PR DESCRIPTION
## Summary

- Forward the clicked booking payment schedule id from `BookingPaymentScheduleList` when issuing invoices or proformas.
- Extend `POST /v1/finance/invoices/from-booking` to resolve an optional schedule row for the booking and create a single schedule-sized invoice line item.
- Add regression coverage for the UI payload and the finance invoice-from-booking route, plus a patch changeset.

Closes #1117.

## Tests

- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/finance-react typecheck`
- `pnpm --filter @voyantjs/bookings-ui typecheck`
- `pnpm --filter @voyantjs/bookings-ui test -- booking-payment-schedule-list`
- `pnpm --filter @voyantjs/finance test -- tests/integration/routes.test.ts`
- `pnpm --filter @voyantjs/finance lint`
- `pnpm --filter @voyantjs/finance-react lint`
- `pnpm --filter @voyantjs/bookings-ui lint`
- Pre-push `pnpm test` hook passed

`pnpm verify:fast` currently stops on an unrelated existing `verify:ui-components-barrel` failure for missing exports in `packages/ui/src/components/index.tsx`. The changed-file lint step passed before that failure.