### PR TITLE
Fix schedule invoice number retries

### DIFF
--- a/.changeset/schedule-invoice-number-allocation.md
+++ b/.changeset/schedule-invoice-number-allocation.md
@@ -1,0 +1,7 @@
+---
+"@voyantjs/bookings-ui": patch
+"@voyantjs/finance": patch
+"@voyantjs/finance-react": patch
+---
+
+Let schedule-row invoice actions use server-side invoice number allocation and return conflicts for duplicate manual invoice numbers.

--- a/packages/bookings-ui/src/components/booking-payment-schedule-list.tsx
+++ b/packages/bookings-ui/src/components/booking-payment-schedule-list.tsx
@@ -61,12 +61,9 @@ export function BookingPaymentScheduleList({ bookingId }: BookingPaymentSchedule
     try {
       const todayIso = new Date().toISOString().slice(0, 10)
       const dueIso = schedule.dueDate || todayIso
-      // i18n-literal-ok: invoice number prefix, not user-facing copy
-      const prefix = invoiceType === "proforma" ? "PRO" : "INV"
       const invoice = await createInvoiceFromBooking.mutateAsync({
         bookingId: booking.id,
         bookingPaymentScheduleId: schedule.id,
-        invoiceNumber: `${prefix}-${booking.bookingNumber}-${schedule.scheduleType.toUpperCase().slice(0, 3)}`,
         issueDate: todayIso,
         dueDate: dueIso,
         notes: schedule.notes ?? null,

--- a/packages/bookings-ui/tests/unit/booking-payment-schedule-list.test.tsx
+++ b/packages/bookings-ui/tests/unit/booking-payment-schedule-list.test.tsx
@@ -158,6 +158,9 @@ describe("BookingPaymentScheduleList", () => {
         invoiceType: "invoice",
       }),
     )
+    expect(testState.createFromBooking).toHaveBeenCalledWith(
+      expect.not.objectContaining({ invoiceNumber: expect.any(String) }),
+    )
     expect(testState.renderInvoice).toHaveBeenCalledWith({
       id: "inv_123",
       input: { format: "pdf" },

--- a/packages/finance-react/src/hooks/use-invoice-mutation.ts
+++ b/packages/finance-react/src/hooks/use-invoice-mutation.ts
@@ -163,7 +163,7 @@ export interface ConvertProformaInput {
 export interface CreateInvoiceFromBookingInput {
   bookingId: string
   bookingPaymentScheduleId?: string
-  invoiceNumber: string
+  invoiceNumber?: string
   issueDate: string
   dueDate: string
   notes?: string | null

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -259,7 +259,12 @@ export type {
   PaymentCompletedEvent,
   UnifiedPaymentRow,
 } from "./service.js"
-export { financeService, InvoiceNumberAllocationError, renderInvoiceBody } from "./service.js"
+export {
+  financeService,
+  InvoiceNumberAllocationError,
+  InvoiceNumberConflictError,
+  renderInvoiceBody,
+} from "./service.js"
 export type {
   FinanceAggregateOutstandingInvoice,
   FinanceAggregates,

--- a/packages/finance/src/routes.ts
+++ b/packages/finance/src/routes.ts
@@ -6,7 +6,12 @@ import { resolveStoredDocumentDownload } from "./document-download.js"
 import { FINANCE_ROUTE_RUNTIME_CONTAINER_KEY, type FinanceRouteRuntime } from "./route-runtime.js"
 import type { publicFinanceRoutes } from "./routes-public.js"
 import type { Env } from "./routes-shared.js"
-import { financeService, InvoiceNumberAllocationError, PaymentValidationError } from "./service.js"
+import {
+  financeService,
+  InvoiceNumberAllocationError,
+  InvoiceNumberConflictError,
+  PaymentValidationError,
+} from "./service.js"
 import {
   type InvoiceRenditionWaitMode,
   waitForInvoiceRendition,
@@ -1036,6 +1041,16 @@ export const financeRoutes = new Hono<Env>()
       if (error instanceof InvoiceNumberAllocationError) {
         return c.json(
           { error: error.code, scope: error.scope, seriesId: error.seriesId ?? null },
+          409,
+        )
+      }
+      if (error instanceof InvoiceNumberConflictError) {
+        return c.json(
+          {
+            error: "Invoice number already exists",
+            code: error.code,
+            invoiceNumber: error.invoiceNumber,
+          },
           409,
         )
       }

--- a/packages/finance/src/service.ts
+++ b/packages/finance/src/service.ts
@@ -327,6 +327,17 @@ export class InvoiceNumberAllocationError extends Error {
   }
 }
 
+export class InvoiceNumberConflictError extends Error {
+  readonly code = "invoice_number_conflict"
+  readonly invoiceNumber: string
+
+  constructor(invoiceNumber: string) {
+    super("Invoice number already exists")
+    this.name = "InvoiceNumberConflictError"
+    this.invoiceNumber = invoiceNumber
+  }
+}
+
 /** Booking data needed for createInvoiceFromBooking — supplied by the caller (template). */
 export interface InvoiceFromBookingData {
   booking: {
@@ -426,6 +437,19 @@ function resolveBookingInvoiceBaseAmount(
   if (invoiceCurrency !== booking.sellCurrency || booking.baseSellAmountCents == null) return null
   if (!booking.sellAmountCents || booking.sellAmountCents <= 0) return booking.baseSellAmountCents
   return Math.round((amountCents / booking.sellAmountCents) * booking.baseSellAmountCents)
+}
+
+function isInvoiceNumberUniqueConstraintError(error: unknown) {
+  if (!error || typeof error !== "object") return false
+  const candidate = error as { code?: unknown; constraint?: unknown; detail?: unknown }
+  if (candidate.code !== "23505") return false
+  const constraint = typeof candidate.constraint === "string" ? candidate.constraint : ""
+  const detail = typeof candidate.detail === "string" ? candidate.detail : ""
+  return (
+    constraint === "invoices_invoice_number_unique" ||
+    constraint === "invoices_invoice_number_key" ||
+    detail.includes("invoice_number")
+  )
 }
 
 function toTimestamp(value?: string | null) {
@@ -3298,57 +3322,64 @@ export const financeService = {
       ? resolveBookingInvoiceBaseAmount(booking, invoiceCurrency, paymentSchedule.amountCents)
       : (booking.baseSellAmountCents ?? null)
 
-    return db.transaction(async (tx) => {
-      const [invoice] = await tx
-        .insert(invoices)
-        .values({
-          invoiceNumber: numberAssignment.invoiceNumber,
-          invoiceType: data.invoiceType,
-          seriesId: numberAssignment.seriesId,
-          sequence: numberAssignment.sequence,
-          bookingId: booking.id,
-          personId: booking.personId,
-          organizationId: booking.organizationId,
-          status: numberAssignment.status,
-          currency: invoiceCurrency,
-          baseCurrency: booking.baseCurrency,
-          fxRateSetId: booking.fxRateSetId,
-          subtotalCents,
-          baseSubtotalCents: hasBaseCurrency ? invoiceBaseAmountCents : null,
-          taxCents,
-          baseTaxCents: null,
-          totalCents,
-          baseTotalCents: hasBaseCurrency ? invoiceBaseAmountCents : null,
-          paidCents: 0,
-          basePaidCents: hasBaseCurrency ? 0 : null,
-          balanceDueCents: totalCents,
-          baseBalanceDueCents: hasBaseCurrency ? invoiceBaseAmountCents : null,
-          commissionAmountCents: commissionAmountCents > 0 ? commissionAmountCents : null,
-          issueDate: data.issueDate,
-          dueDate: data.dueDate,
-          notes: data.notes ?? null,
-        })
-        .returning()
+    try {
+      return await db.transaction(async (tx) => {
+        const [invoice] = await tx
+          .insert(invoices)
+          .values({
+            invoiceNumber: numberAssignment.invoiceNumber,
+            invoiceType: data.invoiceType,
+            seriesId: numberAssignment.seriesId,
+            sequence: numberAssignment.sequence,
+            bookingId: booking.id,
+            personId: booking.personId,
+            organizationId: booking.organizationId,
+            status: numberAssignment.status,
+            currency: invoiceCurrency,
+            baseCurrency: booking.baseCurrency,
+            fxRateSetId: booking.fxRateSetId,
+            subtotalCents,
+            baseSubtotalCents: hasBaseCurrency ? invoiceBaseAmountCents : null,
+            taxCents,
+            baseTaxCents: null,
+            totalCents,
+            baseTotalCents: hasBaseCurrency ? invoiceBaseAmountCents : null,
+            paidCents: 0,
+            basePaidCents: hasBaseCurrency ? 0 : null,
+            balanceDueCents: totalCents,
+            baseBalanceDueCents: hasBaseCurrency ? invoiceBaseAmountCents : null,
+            commissionAmountCents: commissionAmountCents > 0 ? commissionAmountCents : null,
+            issueDate: data.issueDate,
+            dueDate: data.dueDate,
+            notes: data.notes ?? null,
+          })
+          .returning()
 
-      if (!invoice) {
-        return null
+        if (!invoice) {
+          return null
+        }
+
+        await tx.insert(invoiceLineItems).values(
+          lineItems.map((line) => ({
+            invoiceId: invoice.id,
+            bookingItemId: line.bookingItemId,
+            description: line.description,
+            quantity: line.quantity,
+            unitPriceCents: line.unitPriceCents,
+            totalCents: line.totalCents,
+            taxRate: line.taxRate,
+            sortOrder: line.sortOrder,
+          })),
+        )
+
+        return invoice
+      })
+    } catch (error) {
+      if (isInvoiceNumberUniqueConstraintError(error)) {
+        throw new InvoiceNumberConflictError(numberAssignment.invoiceNumber)
       }
-
-      await tx.insert(invoiceLineItems).values(
-        lineItems.map((line) => ({
-          invoiceId: invoice.id,
-          bookingItemId: line.bookingItemId,
-          description: line.description,
-          quantity: line.quantity,
-          unitPriceCents: line.unitPriceCents,
-          totalCents: line.totalCents,
-          taxRate: line.taxRate,
-          sortOrder: line.sortOrder,
-        })),
-      )
-
-      return invoice
-    })
+      throw error
+    }
   },
 
   async getInvoiceById(db: PostgresJsDatabase, id: string) {

--- a/packages/finance/tests/integration/routes.test.ts
+++ b/packages/finance/tests/integration/routes.test.ts
@@ -9,6 +9,7 @@ import { financeRoutes } from "../../src/routes.js"
 import {
   bookingPaymentSchedules,
   invoiceLineItems,
+  invoiceNumberSeries,
   invoiceRenditions,
   paymentAuthorizations,
   paymentCaptures,
@@ -393,6 +394,27 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
     expect(res.status).toBe(201)
     const { data } = await res.json()
     return data as { id: string; [k: string]: unknown }
+  }
+
+  async function seedInvoiceNumberSeries(
+    overrides: Partial<typeof invoiceNumberSeries.$inferInsert> = {},
+  ) {
+    const [row] = await db
+      .insert(invoiceNumberSeries)
+      .values({
+        code: `series-${seq + 1}`,
+        name: "Default invoice series",
+        prefix: "INV",
+        separator: "-",
+        padLength: 4,
+        currentSequence: 0,
+        scope: "invoice",
+        isDefault: true,
+        active: true,
+        ...overrides,
+      })
+      .returning()
+    return row!
   }
 
   // ── Payment Instruments ───────────────────────────────────────
@@ -1371,6 +1393,64 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
         quantity: 1,
         unitPriceCents: 16500,
         totalCents: 16500,
+      })
+    })
+
+    it("allocates a number for schedule-row invoices when the UI omits invoiceNumber", async () => {
+      await seedInvoiceNumberSeries({ currentSequence: 41 })
+      const booking = await seedBooking({ sellAmountCents: 33000 })
+      const schedule = await seedBookingPaymentSchedule(booking.id, {
+        amountCents: 16500,
+        scheduleType: "balance",
+      })
+
+      const res = await app.request("/invoices/from-booking", {
+        method: "POST",
+        ...json({
+          bookingId: booking.id,
+          bookingPaymentScheduleId: schedule.id,
+          issueDate: "2025-06-01",
+          dueDate: "2025-07-01",
+        }),
+      })
+
+      expect(res.status).toBe(201)
+      const { data } = await res.json()
+      expect(data.invoiceNumber).toBe("INV-0042")
+      expect(data.seriesId).toMatch(/^ins_/)
+      expect(data.sequence).toBe(42)
+      expect(data.totalCents).toBe(16500)
+    })
+
+    it("returns 409 when a caller supplies a duplicate invoice number", async () => {
+      const booking = await seedBooking({ sellAmountCents: 33000 })
+      const schedule = await seedBookingPaymentSchedule(booking.id, {
+        amountCents: 16500,
+        scheduleType: "balance",
+      })
+
+      const input = {
+        bookingId: booking.id,
+        bookingPaymentScheduleId: schedule.id,
+        invoiceNumber: "MANUAL-DUPLICATE",
+        issueDate: "2025-06-01",
+        dueDate: "2025-07-01",
+      }
+      const first = await app.request("/invoices/from-booking", {
+        method: "POST",
+        ...json(input),
+      })
+      expect(first.status).toBe(201)
+
+      const second = await app.request("/invoices/from-booking", {
+        method: "POST",
+        ...json(input),
+      })
+      expect(second.status).toBe(409)
+      await expect(second.json()).resolves.toMatchObject({
+        error: "Invoice number already exists",
+        code: "invoice_number_conflict",
+        invoiceNumber: "MANUAL-DUPLICATE",
       })
     })
 

--- a/packages/finance/tests/unit/service-invoice-number-allocation.test.ts
+++ b/packages/finance/tests/unit/service-invoice-number-allocation.test.ts
@@ -5,6 +5,7 @@ import {
   financeService,
   type InvoiceFromBookingData,
   type InvoiceNumberAllocationError,
+  type InvoiceNumberConflictError,
 } from "../../src/service.js"
 
 const bookingData: InvoiceFromBookingData = {
@@ -47,6 +48,7 @@ function series(overrides: Record<string, unknown> = {}) {
 function makeDb(options: {
   explicitSeries?: Record<string, unknown> | null
   defaultSeries?: Record<string, unknown> | null
+  invoiceInsertError?: unknown
 }) {
   const insertedInvoices: Array<Record<string, unknown>> = []
   const execute = vi.fn(async () => {
@@ -77,6 +79,9 @@ function makeDb(options: {
     insert: vi.fn((table) => ({
       values: vi.fn((values) => {
         if (table === invoices) {
+          if (options.invoiceInsertError) {
+            throw options.invoiceInsertError
+          }
           insertedInvoices.push(values)
           return {
             returning: vi.fn(async () => [
@@ -239,5 +244,31 @@ describe("financeService.createInvoiceFromBooking number allocation", () => {
       sequence: null,
       status: "pending_external_allocation",
     })
+  })
+
+  it("normalizes duplicate invoice numbers into a typed conflict", async () => {
+    const { db } = makeDb({
+      invoiceInsertError: {
+        code: "23505",
+        constraint: "invoices_invoice_number_unique",
+      },
+    })
+
+    await expect(
+      financeService.createInvoiceFromBooking(
+        db,
+        {
+          bookingId: "book_123",
+          invoiceNumber: "MANUAL-1",
+          issueDate: "2026-05-23",
+          dueDate: "2026-06-23",
+        },
+        bookingData,
+      ),
+    ).rejects.toMatchObject({
+      name: "InvoiceNumberConflictError",
+      code: "invoice_number_conflict",
+      invoiceNumber: "MANUAL-1",
+    } satisfies Partial<InvoiceNumberConflictError>)
   })
 })


### PR DESCRIPTION
## Summary
- Stop schedule-row document actions from sending deterministic invoice numbers; the finance route now allocates from the active series when omitted.
- Normalize invoice-number unique violations into a structured 409 response for duplicate manual numbers.
- Add UI, finance service, and route regression coverage plus a patch changeset.

Closes #1116.

## Tests
- `pnpm --filter @voyantjs/bookings-ui typecheck`
- `pnpm --filter @voyantjs/finance-react typecheck`
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/bookings-ui test -- booking-payment-schedule-list`
- `pnpm --filter @voyantjs/finance test -- service-invoice-number-allocation tests/integration/routes.test.ts`
- `pnpm --filter @voyantjs/bookings-ui lint`
- `pnpm --filter @voyantjs/finance-react lint`
- `pnpm --filter @voyantjs/finance lint`
- `pnpm lint:changed`
- Pre-commit `pnpm typecheck`
- Pre-push `pnpm test`

`pnpm verify:fast` still stops on an unrelated existing `verify:ui-components-barrel` failure for missing exports in `packages/ui/src/components/index.tsx`; changed-file lint passes.