### PR TITLE
Allow invoice numbers per document type

### DIFF
--- a/.changeset/invoice-number-type-unique.md
+++ b/.changeset/invoice-number-type-unique.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/finance": patch
+---
+
+Allow invoice numbers to repeat across distinct finance document types while preserving same-type uniqueness.

--- a/apps/dev/migrations/0033_invoice_number_type_unique.sql
+++ b/apps/dev/migrations/0033_invoice_number_type_unique.sql
@@ -1,0 +1,15 @@
+ALTER TABLE "invoices" DROP CONSTRAINT IF EXISTS "invoices_invoice_number_unique";--> statement-breakpoint
+ALTER TABLE "invoices" DROP CONSTRAINT IF EXISTS "invoices_invoice_number_key";--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'invoices_invoice_number_type_unique'
+      AND conrelid = 'invoices'::regclass
+  ) THEN
+    ALTER TABLE "invoices"
+      ADD CONSTRAINT "invoices_invoice_number_type_unique"
+      UNIQUE ("invoice_number", "invoice_type");
+  END IF;
+END $$;

--- a/apps/dev/migrations/meta/_journal.json
+++ b/apps/dev/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1779465900000,
       "tag": "0032_invoice_number_external_allocation",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1779561950332,
+      "tag": "0033_invoice_number_type_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/finance/src/routes-public.ts
+++ b/packages/finance/src/routes-public.ts
@@ -83,13 +83,10 @@ export function createPublicFinanceRoutes(options: PublicFinanceRouteOptions = {
       return c.json({ data: result })
     })
     .get("/documents/by-reference", async (c) => {
-      const document = await publicFinanceService.getDocumentByReference(
-        c.get("db"),
-        parseQuery(c, publicFinanceDocumentLookupQuerySchema).reference,
-        {
-          resolveDocumentDownloadUrl: (storageKey) => resolveDocumentDownloadUrl(c.env, storageKey),
-        },
-      )
+      const query = parseQuery(c, publicFinanceDocumentLookupQuerySchema)
+      const document = await publicFinanceService.getDocumentByReference(c.get("db"), query, {
+        resolveDocumentDownloadUrl: (storageKey) => resolveDocumentDownloadUrl(c.env, storageKey),
+      })
 
       if (document?.bookingId) {
         await requireBookingCheckoutCapability(c, document.bookingId, "payment:read")
@@ -112,11 +109,12 @@ export function createPublicFinanceRoutes(options: PublicFinanceRouteOptions = {
     })
     .get("/bookings/:bookingId/documents/by-reference", async (c) => {
       await requireBookingCheckoutCapability(c, c.req.param("bookingId"), "payment:read")
+      const query = parseQuery(c, publicFinanceDocumentLookupQuerySchema)
 
       const document = await publicFinanceService.getBookingDocumentByReference(
         c.get("db"),
         c.req.param("bookingId"),
-        parseQuery(c, publicFinanceDocumentLookupQuerySchema).reference,
+        query,
         {
           resolveDocumentDownloadUrl: (storageKey) => resolveDocumentDownloadUrl(c.env, storageKey),
         },

--- a/packages/finance/src/schema.ts
+++ b/packages/finance/src/schema.ts
@@ -11,6 +11,7 @@ import {
   pgTable,
   text,
   timestamp,
+  unique,
   uniqueIndex,
 } from "drizzle-orm/pg-core"
 
@@ -716,7 +717,7 @@ export const invoices = pgTable(
   {
     id: typeId("invoices"),
 
-    invoiceNumber: text("invoice_number").notNull().unique(),
+    invoiceNumber: text("invoice_number").notNull(),
     invoiceType: invoiceTypeEnum("invoice_type").notNull().default("invoice"),
     /**
      * Source proforma when this row is the final invoice that
@@ -769,6 +770,7 @@ export const invoices = pgTable(
     index("idx_invoices_status_created").on(table.status, table.createdAt),
     index("idx_invoices_fx_rate_set").on(table.fxRateSetId),
     index("idx_invoices_number").on(table.invoiceNumber),
+    unique("invoices_invoice_number_type_unique").on(table.invoiceNumber, table.invoiceType),
     index("idx_invoices_due_date").on(table.dueDate),
     index("idx_invoices_converted_from").on(table.convertedFromInvoiceId),
     // base_currency covers every base_*_cents column. If any base amount is

--- a/packages/finance/src/service-public.ts
+++ b/packages/finance/src/service-public.ts
@@ -17,6 +17,7 @@ import type {
   PublicBookingFinancePayments,
   PublicFinanceBookingDocument,
   PublicFinanceDocumentLookup,
+  PublicFinanceDocumentLookupQuery,
   PublicPaymentOptionsQuery,
   PublicStartPaymentSessionInput,
   PublicValidateVoucherInput,
@@ -80,6 +81,12 @@ function maybeUrl(value: string | null | undefined) {
 
 function getMetadataDownloadUrl(record: Record<string, unknown> | null) {
   return maybeUrl(getMetadataString(record, "url"))
+}
+
+function normalizeDocumentLookupQuery(
+  query: PublicFinanceDocumentLookupQuery | string,
+): PublicFinanceDocumentLookupQuery {
+  return typeof query === "string" ? { reference: query } : query
 }
 
 function toPublicPaymentSession(
@@ -202,25 +209,35 @@ export const publicFinanceService = {
 
   async getDocumentByReference(
     db: PostgresJsDatabase,
-    reference: string,
+    query: PublicFinanceDocumentLookupQuery | string,
     runtime: PublicFinanceRuntimeOptions = {},
   ): Promise<PublicFinanceDocumentLookup | null> {
+    const lookup = normalizeDocumentLookupQuery(query)
+    const invoiceConditions = [eq(invoices.invoiceNumber, lookup.reference)]
+    if (lookup.invoiceType) {
+      invoiceConditions.push(eq(invoices.invoiceType, lookup.invoiceType))
+    }
+
     const [invoiceMatch, paymentMatch] = await Promise.all([
       db
         .select()
         .from(invoices)
-        .where(eq(invoices.invoiceNumber, reference))
+        .where(and(...invoiceConditions))
         .orderBy(desc(invoices.createdAt))
-        .limit(1),
+        .limit(2),
       db
         .select({
           invoiceId: payments.invoiceId,
         })
         .from(payments)
-        .where(eq(payments.referenceNumber, reference))
+        .where(eq(payments.referenceNumber, lookup.reference))
         .orderBy(desc(payments.createdAt))
         .limit(1),
     ])
+
+    if (invoiceMatch.length > 1) {
+      return null
+    }
 
     const invoiceId = invoiceMatch[0]?.id ?? paymentMatch[0]?.invoiceId ?? null
     if (!invoiceId) {
@@ -248,26 +265,41 @@ export const publicFinanceService = {
   async getBookingDocumentByReference(
     db: PostgresJsDatabase,
     bookingId: string,
-    reference: string,
+    query: PublicFinanceDocumentLookupQuery | string,
     runtime: PublicFinanceRuntimeOptions = {},
   ): Promise<PublicFinanceDocumentLookup | null> {
+    const lookup = normalizeDocumentLookupQuery(query)
+    const invoiceConditions = [
+      eq(invoices.bookingId, bookingId),
+      eq(invoices.invoiceNumber, lookup.reference),
+    ]
+    if (lookup.invoiceType) {
+      invoiceConditions.push(eq(invoices.invoiceType, lookup.invoiceType))
+    }
+
     const [invoiceMatch, paymentMatch] = await Promise.all([
       db
         .select()
         .from(invoices)
-        .where(and(eq(invoices.bookingId, bookingId), eq(invoices.invoiceNumber, reference)))
+        .where(and(...invoiceConditions))
         .orderBy(desc(invoices.createdAt))
-        .limit(1),
+        .limit(2),
       db
         .select({
           invoiceId: payments.invoiceId,
         })
         .from(payments)
         .innerJoin(invoices, eq(payments.invoiceId, invoices.id))
-        .where(and(eq(invoices.bookingId, bookingId), eq(payments.referenceNumber, reference)))
+        .where(
+          and(eq(invoices.bookingId, bookingId), eq(payments.referenceNumber, lookup.reference)),
+        )
         .orderBy(desc(payments.createdAt))
         .limit(1),
     ])
+
+    if (invoiceMatch.length > 1) {
+      return null
+    }
 
     const invoiceId = invoiceMatch[0]?.id ?? paymentMatch[0]?.invoiceId ?? null
     if (!invoiceId) {

--- a/packages/finance/src/service.ts
+++ b/packages/finance/src/service.ts
@@ -446,6 +446,7 @@ function isInvoiceNumberUniqueConstraintError(error: unknown) {
   const constraint = typeof candidate.constraint === "string" ? candidate.constraint : ""
   const detail = typeof candidate.detail === "string" ? candidate.detail : ""
   return (
+    constraint === "invoices_invoice_number_type_unique" ||
     constraint === "invoices_invoice_number_unique" ||
     constraint === "invoices_invoice_number_key" ||
     detail.includes("invoice_number")

--- a/packages/finance/src/validation-public.ts
+++ b/packages/finance/src/validation-public.ts
@@ -58,6 +58,7 @@ export const publicValidateVoucherSchema = z.object({
 
 export const publicFinanceDocumentLookupQuerySchema = z.object({
   reference: z.string().min(1).max(255),
+  invoiceType: publicFinanceInvoiceTypeSchema.optional(),
 })
 
 export const publicPaymentAccountSchema = z.object({

--- a/packages/finance/tests/integration/public-routes.test.ts
+++ b/packages/finance/tests/integration/public-routes.test.ts
@@ -387,6 +387,61 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
     })
   })
 
+  it("requires document type when an invoice reference matches multiple document types", async () => {
+    const booking = await seedBooking()
+    const invoiceNumber = "PF-SHARED-0127"
+    const invoice = await seedInvoice(booking.id, {
+      invoiceNumber,
+      invoiceType: "invoice",
+    })
+    const proforma = await seedInvoice(booking.id, {
+      invoiceNumber,
+      invoiceType: "proforma",
+    })
+
+    const ambiguousPublicRes = await app.request(
+      `/documents/by-reference?reference=${invoiceNumber}`,
+      {
+        headers: await capabilityHeaders(booking.id),
+      },
+    )
+    expect(ambiguousPublicRes.status).toBe(404)
+
+    const ambiguousBookingRes = await app.request(
+      `/bookings/${booking.id}/documents/by-reference?reference=${invoiceNumber}`,
+      {
+        headers: await capabilityHeaders(booking.id),
+      },
+    )
+    expect(ambiguousBookingRes.status).toBe(404)
+
+    const invoiceRes = await app.request(
+      `/bookings/${booking.id}/documents/by-reference?reference=${invoiceNumber}&invoiceType=invoice`,
+      {
+        headers: await capabilityHeaders(booking.id),
+      },
+    )
+    expect(invoiceRes.status).toBe(200)
+    expect((await invoiceRes.json()).data).toMatchObject({
+      invoiceId: invoice.id,
+      invoiceNumber,
+      invoiceType: "invoice",
+    })
+
+    const proformaRes = await app.request(
+      `/documents/by-reference?reference=${invoiceNumber}&invoiceType=proforma`,
+      {
+        headers: await capabilityHeaders(booking.id),
+      },
+    )
+    expect(proformaRes.status).toBe(200)
+    expect((await proformaRes.json()).data).toMatchObject({
+      invoiceId: proforma.id,
+      invoiceNumber,
+      invoiceType: "proforma",
+    })
+  })
+
   it("rejects booking-scoped finance document lookup without matching access", async () => {
     const booking = await seedBooking()
     const otherBooking = await seedBooking()

--- a/packages/finance/tests/integration/routes.test.ts
+++ b/packages/finance/tests/integration/routes.test.ts
@@ -1454,6 +1454,41 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       })
     })
 
+    it("allows the same external number for an invoice and proforma", async () => {
+      const booking = await seedBooking({ sellAmountCents: 33000 })
+      const schedule = await seedBookingPaymentSchedule(booking.id, {
+        amountCents: 16500,
+        scheduleType: "balance",
+      })
+
+      const invoiceNumber = "SMARTBILL-B-0127"
+      const commonInput = {
+        bookingId: booking.id,
+        bookingPaymentScheduleId: schedule.id,
+        invoiceNumber,
+        issueDate: "2025-06-01",
+        dueDate: "2025-07-01",
+      }
+
+      const invoice = await app.request("/invoices/from-booking", {
+        method: "POST",
+        ...json({ ...commonInput, invoiceType: "invoice" }),
+      })
+      expect(invoice.status).toBe(201)
+
+      const proforma = await app.request("/invoices/from-booking", {
+        method: "POST",
+        ...json({ ...commonInput, invoiceType: "proforma" }),
+      })
+      expect(proforma.status).toBe(201)
+
+      const invoiceBody = await invoice.json()
+      const proformaBody = await proforma.json()
+      expect(invoiceBody.data).toMatchObject({ invoiceNumber, invoiceType: "invoice" })
+      expect(proformaBody.data).toMatchObject({ invoiceNumber, invoiceType: "proforma" })
+      expect(proformaBody.data.id).not.toBe(invoiceBody.data.id)
+    })
+
     it("does not derive base amounts from booking sell currency for cross-currency schedule invoices", async () => {
       const booking = await seedBooking({
         sellCurrency: "USD",

--- a/templates/dmc/migrations/0013_invoice_number_type_unique.sql
+++ b/templates/dmc/migrations/0013_invoice_number_type_unique.sql
@@ -1,0 +1,15 @@
+ALTER TABLE "invoices" DROP CONSTRAINT IF EXISTS "invoices_invoice_number_unique";--> statement-breakpoint
+ALTER TABLE "invoices" DROP CONSTRAINT IF EXISTS "invoices_invoice_number_key";--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'invoices_invoice_number_type_unique'
+      AND conrelid = 'invoices'::regclass
+  ) THEN
+    ALTER TABLE "invoices"
+      ADD CONSTRAINT "invoices_invoice_number_type_unique"
+      UNIQUE ("invoice_number", "invoice_type");
+  END IF;
+END $$;

--- a/templates/dmc/migrations/meta/_journal.json
+++ b/templates/dmc/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1779295200000,
       "tag": "0012_product_terms",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1779561950332,
+      "tag": "0013_invoice_number_type_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/templates/operator/migrations/0032_invoice_number_type_unique.sql
+++ b/templates/operator/migrations/0032_invoice_number_type_unique.sql
@@ -1,0 +1,15 @@
+ALTER TABLE "invoices" DROP CONSTRAINT IF EXISTS "invoices_invoice_number_unique";--> statement-breakpoint
+ALTER TABLE "invoices" DROP CONSTRAINT IF EXISTS "invoices_invoice_number_key";--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'invoices_invoice_number_type_unique'
+      AND conrelid = 'invoices'::regclass
+  ) THEN
+    ALTER TABLE "invoices"
+      ADD CONSTRAINT "invoices_invoice_number_type_unique"
+      UNIQUE ("invoice_number", "invoice_type");
+  END IF;
+END $$;

--- a/templates/operator/migrations/meta/_journal.json
+++ b/templates/operator/migrations/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1779466000000,
       "tag": "0031_default_proforma_invoice_series",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1779561950332,
+      "tag": "0032_invoice_number_type_unique",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Replace flat invoice-number uniqueness with `(invoice_number, invoice_type)` uniqueness in the finance schema.
- Add forward migrations for dev, operator, and DMC runtimes, with migration journal entries.
- Keep duplicate same-type number conflicts normalized and add route regression coverage for invoice/proforma number reuse.
- Guard public document reference lookups against cross-type collisions by requiring `invoiceType` when an invoice number is ambiguous.

Closes #1171.

## Tests
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/finance lint`
- `pnpm --filter @voyantjs/finance test -- public-routes tests/integration/routes.test.ts service-invoice-number-allocation`
- `pnpm lint:changed`
- `pnpm -C templates/operator db:check`
- `pnpm -C apps/dev db:check`
- `pnpm -C templates/dmc db:check`
- Pre-commit broad `pnpm lint` and `pnpm typecheck`
- Pre-push `pnpm test`

`pnpm verify:fast` still stops on the unrelated existing `verify:ui-components-barrel` missing exports in `packages/ui/src/components/index.tsx`; changed-file lint passes.