### PR TITLE
Add SmartBill admin invoice sync

### DIFF
--- a/.changeset/smartbill-admin-sync.md
+++ b/.changeset/smartbill-admin-sync.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/plugin-smartbill": patch
+"@voyantjs/finance": patch
+---
+
+Add SmartBill admin invoice sync helpers, Hono routes, and default invoice panel actions.

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -310,7 +310,11 @@ export {
   financeDocumentsService,
 } from "./service-documents.js"
 export type { InvoiceIssuedEvent, InvoiceIssueRuntime } from "./service-issue.js"
-export { issueInvoiceFromBooking, issueProformaFromBooking } from "./service-issue.js"
+export {
+  buildInvoiceIssuedEvent,
+  issueInvoiceFromBooking,
+  issueProformaFromBooking,
+} from "./service-issue.js"
 export {
   getLatestInvoiceRendition,
   type InvoiceRenditionWaitMode,

--- a/packages/finance/src/service-issue.ts
+++ b/packages/finance/src/service-issue.ts
@@ -221,6 +221,14 @@ async function emitIssued(
   invoice: typeof invoices.$inferSelect,
 ): Promise<void> {
   if (!runtime.eventBus) return
+  await runtime.eventBus.emit(eventName, await buildInvoiceIssuedEvent(db, invoice, runtime))
+}
+
+export async function buildInvoiceIssuedEvent(
+  db: PostgresJsDatabase,
+  invoice: typeof invoices.$inferSelect,
+  runtime: InvoiceIssueRuntime = {},
+): Promise<InvoiceIssuedEvent> {
   const [booking] = invoice.bookingId
     ? await db.select().from(bookings).where(eq(bookings.id, invoice.bookingId)).limit(1)
     : []
@@ -284,7 +292,7 @@ async function emitIssued(
   }
   const fx = await resolveInvoiceFxContext(db, invoice, runtime)
   if (fx) Object.assign(payload, fx)
-  await runtime.eventBus.emit(eventName, payload)
+  return payload
 }
 
 async function loadLineTaxMetadata(

--- a/packages/plugins/smartbill/README.md
+++ b/packages/plugins/smartbill/README.md
@@ -75,6 +75,37 @@ deduplication elsewhere. Create failures are recorded as SmartBill external refs
 with `status: "error"` and `syncError`; `onError(event, error)` can be supplied
 for application-specific reporting.
 
+Use `syncSmartbillInvoice({ db, invoiceId, pluginOptions })` to run the same
+create-or-retry flow from an admin action. It loads the finance invoice,
+booking, line items, and tax metadata, maps them through the configured
+SmartBill options, reuses an existing non-error SmartBill ref when present, and
+persists external refs/PDF artifacts through the configured artifact runtime.
+
+Apps that use `@voyantjs/hono` can mount the packaged admin module:
+
+```typescript
+import { createSmartbillAdminModule } from "@voyantjs/plugin-smartbill/hono"
+
+const app = createApp({
+  plugins: [smartbillSync],
+  modules: [
+    createSmartbillAdminModule({
+      pluginOptions: {
+        username: env.SMARTBILL_USERNAME,
+        apiToken: env.SMARTBILL_API_TOKEN,
+        companyVatCode: "RO12345678",
+        seriesName: "A",
+        artifacts: { documentStorage },
+      },
+    }),
+  ],
+})
+```
+
+The admin module mounts `POST /v1/admin/smartbill/invoices/:id/sync`. The route
+uses the request database for external-ref and artifact persistence unless
+`pluginOptions.artifacts.db` supplies a custom database resolver.
+
 Use `retrySmartbillInvoiceArtifact({ runtime, client, externalRef, documentType
 })` to re-download and re-attach a SmartBill PDF from an existing external ref
 without issuing a new document.
@@ -96,15 +127,7 @@ export function InvoicePage({ invoiceId }: { invoiceId: string }) {
       id={invoiceId}
       slots={{
         integrationsContent: ({ invoice }) => (
-          <SmartbillInvoicePanel
-            invoiceId={invoice.id}
-            sendAction={{
-              onClick: () => requestSmartbillSend(invoice.id),
-            }}
-            retryAction={{
-              onClick: () => requestSmartbillRetry(invoice.id),
-            }}
-          />
+          <SmartbillInvoicePanel invoiceId={invoice.id} />
         ),
       }}
     />
@@ -114,9 +137,11 @@ export function InvoicePage({ invoiceId }: { invoiceId: string }) {
 
 `SmartbillInvoicePanel` displays the SmartBill series, number, document type,
 sync status, sync errors, and document/PDF links when the external ref contains
-them. Hosts provide action callbacks such as send, retry, or proforma
-conversion because route shape and permissions remain app-owned. For custom
-layouts, use `useSmartbillInvoiceRef(invoiceId)` together with
+them. By default, send and retry actions call
+`POST /v1/admin/smartbill/invoices/:id/sync`, and proforma conversion calls the
+finance `POST /v1/finance/invoices/:id/convert-to-invoice` endpoint. Pass
+`sendAction`, `retryAction`, or `convertProformaAction` to override those
+defaults. For custom layouts, use `useSmartbillInvoiceRef(invoiceId)` together with
 `resolveSmartbillInvoiceReferenceParts(ref)` and
 `getSmartbillInvoiceDocumentLinks(ref)`.
 
@@ -167,6 +192,8 @@ finance records.
 | `.` | Barrel re-exports |
 | `./plugin` | `smartbillPlugin(options)` — packaged adapter/subscriber bundle |
 | `./client` | `createSmartbillClient` — `createInvoice`, `cancelInvoice`, `viewPdf`, `getPaymentStatus`, etc. |
+| `./hono` | `createSmartbillAdminModule(options)` and admin sync routes |
+| `./sync` | `syncSmartbillInvoice(...)` and event-level sync helpers |
 | `./invoice-ui` | Optional React hooks, display helpers, and `SmartbillInvoicePanel` for invoice detail integrations |
 | `./mock` | `createSmartbillMockServer` — stateful local SmartBill-compatible mock for tests |
 | `./workflows` | Proforma conversion polling and drift reconciliation factories |

--- a/packages/plugins/smartbill/package.json
+++ b/packages/plugins/smartbill/package.json
@@ -8,6 +8,8 @@
     "./client": "./src/client.ts",
     "./mock": "./src/mock.ts",
     "./plugin": "./src/plugin.ts",
+    "./hono": "./src/hono.ts",
+    "./sync": "./src/sync.ts",
     "./invoice-ui": "./src/invoice-ui.tsx",
     "./settlement": "./src/settlement.ts",
     "./workflows": "./src/workflows.ts",
@@ -24,8 +26,10 @@
   "dependencies": {
     "@voyantjs/core": "workspace:*",
     "@voyantjs/finance": "workspace:*",
+    "@voyantjs/hono": "workspace:*",
     "@voyantjs/storage": "workspace:*",
     "drizzle-orm": "^0.45.2",
+    "hono": "^4.12.10",
     "zod": "^4.3.6"
   },
   "peerDependencies": {
@@ -94,6 +98,16 @@
         "types": "./dist/plugin.d.ts",
         "import": "./dist/plugin.js",
         "default": "./dist/plugin.js"
+      },
+      "./hono": {
+        "types": "./dist/hono.d.ts",
+        "import": "./dist/hono.js",
+        "default": "./dist/hono.js"
+      },
+      "./sync": {
+        "types": "./dist/sync.d.ts",
+        "import": "./dist/sync.js",
+        "default": "./dist/sync.js"
       },
       "./invoice-ui": {
         "types": "./dist/invoice-ui.d.ts",

--- a/packages/plugins/smartbill/src/hono.ts
+++ b/packages/plugins/smartbill/src/hono.ts
@@ -1,0 +1,124 @@
+import type { Module, ModuleContainer } from "@voyantjs/core"
+import { FINANCE_ROUTE_RUNTIME_CONTAINER_KEY, type FinanceRouteRuntime } from "@voyantjs/finance"
+import type { HonoModule } from "@voyantjs/hono/module"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { Hono } from "hono"
+
+import type { SmartbillPluginOptions } from "./plugin.js"
+import { syncSmartbillInvoice } from "./sync.js"
+
+type Env = {
+  Bindings: Record<string, unknown>
+  Variables: {
+    container?: ModuleContainer
+    db: PostgresJsDatabase
+    userId?: string
+  }
+}
+
+export interface SmartbillAdminModuleOptions {
+  pluginOptions: SmartbillPluginOptions | SmartbillPluginOptionsResolver
+}
+
+export type SmartbillPluginOptionsResolver = (
+  bindings: Record<string, unknown>,
+) => SmartbillPluginOptions
+
+export interface SmartbillAdminRouteRuntime {
+  pluginOptions: SmartbillPluginOptions
+}
+
+export const SMARTBILL_ADMIN_RUNTIME_CONTAINER_KEY = "providers.smartbill.adminRuntime"
+
+export function createSmartbillAdminRoutes(options: SmartbillAdminModuleOptions) {
+  return new Hono<Env>().post("/invoices/:id/sync", async (c) => {
+    try {
+      const runtime = resolveSmartbillAdminRouteRuntime(c, options)
+      const financeRuntime = resolveFinanceRouteRuntime(c.var.container)
+      const result = await syncSmartbillInvoice({
+        db: c.get("db"),
+        invoiceId: c.req.param("id"),
+        pluginOptions: runtime.pluginOptions,
+        issueRuntime: financeRuntime,
+      })
+
+      if (result.status === "not_found") {
+        return c.json({ error: "Invoice not found" }, 404)
+      }
+      if (result.status === "unsupported_document_type") {
+        return c.json({ error: `SmartBill sync does not support ${result.invoiceType}` }, 409)
+      }
+
+      return c.json({ data: result }, result.status === "created" ? 201 : 200)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "SmartBill sync failed"
+      return c.json({ error: message }, 502)
+    }
+  })
+}
+
+export function createSmartbillAdminModule(options: SmartbillAdminModuleOptions): HonoModule {
+  const module: Module = {
+    name: "smartbill",
+    bootstrap: ({ bindings, container }) => {
+      container.register(
+        SMARTBILL_ADMIN_RUNTIME_CONTAINER_KEY,
+        buildSmartbillAdminRouteRuntime(bindings as Record<string, unknown>, options),
+      )
+    },
+  }
+
+  return {
+    module,
+    adminRoutes: createSmartbillAdminRoutes(options),
+  }
+}
+
+export function buildSmartbillAdminRouteRuntime(
+  bindings: Record<string, unknown>,
+  options: SmartbillAdminModuleOptions,
+): SmartbillAdminRouteRuntime {
+  return {
+    pluginOptions:
+      typeof options.pluginOptions === "function"
+        ? options.pluginOptions(bindings)
+        : options.pluginOptions,
+  }
+}
+
+function resolveSmartbillAdminRouteRuntime(
+  c: {
+    env: Record<string, unknown>
+    var: { container?: ModuleContainer }
+  },
+  options: SmartbillAdminModuleOptions,
+): SmartbillAdminRouteRuntime {
+  if (c.var.container) {
+    try {
+      return c.var.container.resolve<SmartbillAdminRouteRuntime>(
+        SMARTBILL_ADMIN_RUNTIME_CONTAINER_KEY,
+      )
+    } catch {
+      // Fall through for tests and minimal apps that mount routes without bootstrap.
+    }
+  }
+
+  return buildSmartbillAdminRouteRuntime(c.env, options)
+}
+
+function resolveFinanceRouteRuntime(container: ModuleContainer | undefined) {
+  if (!container) return undefined
+  try {
+    const runtime = container.resolve<FinanceRouteRuntime>(FINANCE_ROUTE_RUNTIME_CONTAINER_KEY)
+    return {
+      invoiceFxSettings: runtime.invoiceFxSettings,
+      resolveInvoiceFxSettings: runtime.resolveInvoiceFxSettings,
+      updateInvoiceFxSettings: runtime.updateInvoiceFxSettings,
+      resolveInvoiceExchangeRate: runtime.resolveInvoiceExchangeRate,
+      resolveInvoiceExchangeRateResolver: runtime.resolveInvoiceExchangeRateResolver,
+      onInvoiceFxResolutionError: runtime.onInvoiceFxResolutionError,
+    }
+  } catch {
+    return undefined
+  }
+}

--- a/packages/plugins/smartbill/src/index.ts
+++ b/packages/plugins/smartbill/src/index.ts
@@ -14,6 +14,17 @@ export { retrySmartbillInvoiceArtifact } from "./artifacts.js"
 export type { SmartbillClientApi, SmartbillClientOptions } from "./client.js"
 export { createSmartbillClient } from "./client.js"
 export type {
+  SmartbillAdminModuleOptions,
+  SmartbillAdminRouteRuntime,
+  SmartbillPluginOptionsResolver,
+} from "./hono.js"
+export {
+  buildSmartbillAdminRouteRuntime,
+  createSmartbillAdminModule,
+  createSmartbillAdminRoutes,
+  SMARTBILL_ADMIN_RUNTIME_CONTAINER_KEY,
+} from "./hono.js"
+export type {
   SmartbillEventValue,
   SmartbillMappingOptions,
   SmartbillMaybePromise,
@@ -60,6 +71,13 @@ export type {
   SmartbillSettlementSeriesContext,
 } from "./settlement.js"
 export { createSmartbillInvoiceSettlementPoller } from "./settlement.js"
+export type {
+  SyncSmartbillInvoiceEventInput,
+  SyncSmartbillInvoiceEventResult,
+  SyncSmartbillInvoiceInput,
+  SyncSmartbillInvoiceResult,
+} from "./sync.js"
+export { syncSmartbillInvoice, syncSmartbillInvoiceEvent } from "./sync.js"
 export type {
   SmartbillClient,
   SmartbillEnvelope,

--- a/packages/plugins/smartbill/src/invoice-ui.tsx
+++ b/packages/plugins/smartbill/src/invoice-ui.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useQuery } from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { fetchWithValidation, useVoyantFinanceContext } from "@voyantjs/finance-react"
 import {
   Badge,
@@ -13,8 +13,9 @@ import {
   CardTitle,
 } from "@voyantjs/ui/components"
 import { cn } from "@voyantjs/ui/lib/utils"
-import { ExternalLink, FileText, Loader2, RefreshCw, Send } from "lucide-react"
+import { ArrowRightLeft, ExternalLink, FileText, Loader2, RefreshCw, Send } from "lucide-react"
 import type { ReactNode } from "react"
+import { z } from "zod"
 
 import {
   getSmartbillInvoiceDocumentLinks,
@@ -23,6 +24,8 @@ import {
   selectSmartbillInvoiceRef,
   smartbillInvoiceExternalRefsResponseSchema,
 } from "./invoice-ui-data.js"
+
+const actionResponseSchema = z.object({ data: z.unknown().optional() })
 
 export {
   getSmartbillInvoiceDocumentLinks,
@@ -100,6 +103,8 @@ export function SmartbillInvoicePanel({
   extraActions,
 }: SmartbillInvoicePanelProps) {
   const query = useSmartbillInvoiceRef(invoiceId, { enabled: externalRef === undefined })
+  const defaultSyncAction = useSmartbillInvoiceSyncAction(invoiceId)
+  const defaultConvertProformaAction = useSmartbillConvertProformaAction(invoiceId)
   const ref = externalRef === undefined ? query.data : externalRef
   const isLoading = externalRef === undefined && query.isPending
   const isError = externalRef === undefined && query.isError
@@ -111,7 +116,11 @@ export function SmartbillInvoicePanel({
   const reference = resolveSmartbillInvoiceReferenceParts(ref)
   const documentLinks = getSmartbillInvoiceDocumentLinks(ref)
   const status = ref?.syncError ? "error" : (ref?.status ?? null)
-  const canConvertProforma = reference.documentType === "proforma" && convertProformaAction
+  const effectiveSendAction = sendAction ?? defaultSyncAction
+  const effectiveRetryAction = retryAction ?? (ref ? defaultSyncAction : undefined)
+  const effectiveConvertProformaAction = convertProformaAction ?? defaultConvertProformaAction
+  const canConvertProforma =
+    reference.documentType === "proforma" && Boolean(effectiveConvertProformaAction)
 
   return (
     <Card data-slot="smartbill-invoice-panel" size="sm" className={className}>
@@ -169,22 +178,25 @@ export function SmartbillInvoicePanel({
         )}
 
         <div className="flex flex-wrap items-center gap-2">
-          {!ref && sendAction ? (
-            <SmartbillActionButton action={sendAction} icon={<Send className="size-4" />}>
-              {sendAction.label ?? "Send to SmartBill"}
+          {!ref && !isLoading && !isError ? (
+            <SmartbillActionButton action={effectiveSendAction} icon={<Send className="size-4" />}>
+              {effectiveSendAction.label ?? "Send to SmartBill"}
             </SmartbillActionButton>
           ) : null}
-          {retryAction ? (
-            <SmartbillActionButton action={retryAction} icon={<RefreshCw className="size-4" />}>
-              {retryAction.label ?? "Retry sync"}
-            </SmartbillActionButton>
-          ) : null}
-          {canConvertProforma ? (
+          {effectiveRetryAction ? (
             <SmartbillActionButton
-              action={convertProformaAction}
+              action={effectiveRetryAction}
               icon={<RefreshCw className="size-4" />}
             >
-              {convertProformaAction.label ?? "Convert proforma"}
+              {effectiveRetryAction.label ?? "Retry sync"}
+            </SmartbillActionButton>
+          ) : null}
+          {canConvertProforma && effectiveConvertProformaAction ? (
+            <SmartbillActionButton
+              action={effectiveConvertProformaAction}
+              icon={<ArrowRightLeft className="size-4" />}
+            >
+              {effectiveConvertProformaAction.label ?? "Convert proforma"}
             </SmartbillActionButton>
           ) : null}
           {extraActions}
@@ -192,6 +204,56 @@ export function SmartbillInvoicePanel({
       </CardContent>
     </Card>
   )
+}
+
+export function useSmartbillInvoiceSyncAction(invoiceId: string): SmartbillInvoiceAction {
+  const { baseUrl, fetcher } = useVoyantFinanceContext()
+  const queryClient = useQueryClient()
+  const mutation = useMutation({
+    mutationFn: async () =>
+      fetchWithValidation(
+        `/v1/admin/smartbill/invoices/${encodeURIComponent(invoiceId)}/sync`,
+        actionResponseSchema,
+        { baseUrl, fetcher },
+        { method: "POST" },
+      ),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["voyant"] })
+    },
+  })
+
+  return {
+    pending: mutation.isPending,
+    disabled: !invoiceId,
+    onClick: async () => {
+      await mutation.mutateAsync()
+    },
+  }
+}
+
+export function useSmartbillConvertProformaAction(invoiceId: string): SmartbillInvoiceAction {
+  const { baseUrl, fetcher } = useVoyantFinanceContext()
+  const queryClient = useQueryClient()
+  const mutation = useMutation({
+    mutationFn: async () =>
+      fetchWithValidation(
+        `/v1/finance/invoices/${encodeURIComponent(invoiceId)}/convert-to-invoice`,
+        actionResponseSchema,
+        { baseUrl, fetcher },
+        { method: "POST", body: JSON.stringify({}) },
+      ),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["voyant"] })
+    },
+  })
+
+  return {
+    pending: mutation.isPending,
+    disabled: !invoiceId,
+    onClick: async () => {
+      await mutation.mutateAsync()
+    },
+  }
 }
 
 function SmartbillField({ label, children }: { label: string; children: ReactNode }) {

--- a/packages/plugins/smartbill/src/plugin.ts
+++ b/packages/plugins/smartbill/src/plugin.ts
@@ -1,22 +1,12 @@
 import type { Plugin, Subscriber } from "@voyantjs/core"
-import { financeService } from "@voyantjs/finance"
-import { ZodError } from "zod"
 
-import {
-  isSmartbillPdfPersistMetadataUpdateError,
-  persistSmartbillInvoiceArtifact,
-  recordSmartbillInvoiceArtifactFailure,
-  retrySmartbillInvoiceArtifact,
-  type SmartbillArtifactPersistenceOptions,
-  type SmartbillArtifactStorageContext,
-  type SmartbillDocumentType,
-  type SmartbillExternalRef,
-} from "./artifacts.js"
+import type { SmartbillArtifactPersistenceOptions } from "./artifacts.js"
 import type { SmartbillClientOptions } from "./client.js"
 import type { SmartbillMappingOptions } from "./mapping.js"
 import { createSmartbillSyncRuntime } from "./runtime.js"
+import { syncSmartbillInvoiceEvent } from "./sync.js"
 import type { SmartbillInvoiceBody, SmartbillInvoiceResponse, VoyantInvoiceEvent } from "./types.js"
-import { smartbillPluginOptionsSchema } from "./validation.js"
+import { parseSmartbillPluginOptions } from "./validation.js"
 
 export interface SmartbillSyncEventNames {
   issued?: string
@@ -92,275 +82,8 @@ function coerceEvent(data: unknown): VoyantInvoiceEvent | null {
 
 export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
   const validatedOptions = parseSmartbillPluginOptions(options)
-  const {
-    client,
-    logger,
-    mapEvent,
-    eventNames,
-    artifacts,
-    idempotency,
-    onError,
-    writeBackInvoiceNumber,
-  } = createSmartbillSyncRuntime(validatedOptions)
-
-  async function resolveMaybe<TContext, TValue>(
-    value: TValue | ((context: TContext) => TValue | Promise<TValue>) | undefined | null,
-    context: TContext,
-  ) {
-    return typeof value === "function"
-      ? await (value as (context: TContext) => TValue | Promise<TValue>)(context)
-      : value
-  }
-
-  async function resolveArtifactDb(
-    event: VoyantInvoiceEvent,
-    documentType: SmartbillDocumentType,
-    body?: SmartbillInvoiceBody,
-    result?: SmartbillInvoiceResponse,
-  ) {
-    if (!artifacts.db) return null
-    const context: SmartbillArtifactStorageContext = {
-      event,
-      documentType,
-      body: body ?? {
-        companyVatCode: validatedOptions.companyVatCode,
-        client: { name: "Client" },
-        seriesName: "unknown",
-        currency: "RON",
-        products: [],
-      },
-      result: result ?? {},
-    }
-    return (await resolveMaybe(artifacts.db, context)) ?? null
-  }
-
-  async function findExistingSmartbillRef(
-    event: VoyantInvoiceEvent,
-    documentType: SmartbillDocumentType,
-    body: SmartbillInvoiceBody,
-  ): Promise<SmartbillExternalRef | null> {
-    if (idempotency.skipExistingExternalRef === false) return null
-    const db = await resolveArtifactDb(event, documentType, body)
-    if (!db) return null
-
-    const refs = await financeService.listInvoiceExternalRefs(db, event.id)
-    return refs.find((ref) => isMatchingSmartbillRef(ref, documentType)) ?? null
-  }
-
-  async function handleExistingSmartbillRef(
-    event: VoyantInvoiceEvent,
-    documentType: SmartbillDocumentType,
-    body: SmartbillInvoiceBody,
-    externalRef: SmartbillExternalRef,
-  ) {
-    logger.info?.(
-      `[smartbill] ${documentType} already has SmartBill ref for ${event.id}; skipping create`,
-      externalRef,
-    )
-    await applyExternalAllocationFromRefIfRequired(event, documentType, body, externalRef)
-    await writeBackInvoiceNumberFromRefIfRequired(event, documentType, body, externalRef)
-    try {
-      const persisted = await retrySmartbillInvoiceArtifact({
-        runtime: artifacts,
-        client,
-        externalRef,
-        documentType,
-      })
-      if (persisted.status === "persisted") {
-        logger.info?.(`[smartbill] ${documentType} PDF re-attached for ${event.id}`, persisted)
-      }
-    } catch (err) {
-      const message = isSmartbillPdfPersistMetadataUpdateError(err)
-        ? `[smartbill] artifact re-attach metadata update failed for ${event.id}`
-        : `[smartbill] artifact re-attach failed for ${event.id}`
-      logger.error(message, err)
-    }
-  }
-
-  async function persistArtifact(
-    event: VoyantInvoiceEvent,
-    documentType: SmartbillDocumentType,
-    body: Awaited<ReturnType<SmartbillMapFn>>,
-    result: Awaited<ReturnType<typeof client.createInvoice>>,
-  ) {
-    try {
-      const persisted = await persistSmartbillInvoiceArtifact({
-        runtime: artifacts,
-        client,
-        event,
-        documentType,
-        body,
-        result,
-      })
-      if (persisted.status === "persisted") {
-        logger.info?.(`[smartbill] ${documentType} PDF persisted for ${event.id}`, persisted)
-      }
-    } catch (err) {
-      if (isSmartbillPdfPersistMetadataUpdateError(err)) {
-        logger.error(`[smartbill] artifact persistence metadata update failed for ${event.id}`, err)
-        return
-      }
-      logger.error(`[smartbill] artifact persistence failed for ${event.id}`, err)
-      try {
-        await recordSmartbillInvoiceArtifactFailure({
-          runtime: artifacts,
-          event,
-          documentType,
-          body,
-          result,
-          error: err,
-        })
-      } catch (recordError) {
-        logger.error(
-          `[smartbill] artifact failure external-ref update failed for ${event.id}`,
-          recordError,
-        )
-      }
-    }
-  }
-
-  async function applyExternalAllocationIfRequired(
-    event: VoyantInvoiceEvent,
-    documentType: SmartbillDocumentType,
-    body: SmartbillInvoiceBody,
-    result: SmartbillInvoiceResponse,
-  ) {
-    if (event.externalAllocationRequired !== true || !result.number) return
-
-    const db = await resolveArtifactDb(event, documentType, body, result)
-    if (!db) {
-      throw new Error("SmartBill external allocation requires artifact database access")
-    }
-    const allocation = await financeService.applyExternalInvoiceAllocation(db, event.id, {
-      invoiceNumber: formatExternalInvoiceNumber(result.series ?? body.seriesName, result.number),
-    })
-    if (allocation.status === "applied") {
-      logger.info?.(`[smartbill] external number applied for ${event.id}`, allocation.invoice)
-    }
-  }
-
-  async function applyExternalAllocationFromRefIfRequired(
-    event: VoyantInvoiceEvent,
-    documentType: SmartbillDocumentType,
-    body: SmartbillInvoiceBody,
-    externalRef: SmartbillExternalRef,
-  ) {
-    if (event.externalAllocationRequired !== true) return
-
-    const metadata = coerceMetadata(externalRef.metadata)
-    const number =
-      metadataString(metadata, "number") ??
-      externalRef.externalNumber ??
-      externalRef.externalId ??
-      null
-    if (!number) {
-      throw new Error("SmartBill external allocation requires an existing external number")
-    }
-    await applyExternalAllocationIfRequired(event, documentType, body, {
-      number,
-      series:
-        metadataString(metadata, "series") ??
-        metadataString(metadata, "seriesName") ??
-        body.seriesName,
-      url: externalRef.externalUrl ?? undefined,
-    })
-  }
-
-  async function resolveWriteBackInvoiceNumber(
-    event: VoyantInvoiceEvent,
-    body: SmartbillInvoiceBody,
-    result: SmartbillInvoiceResponse,
-  ) {
-    if (!writeBackInvoiceNumber) return null
-    if (typeof writeBackInvoiceNumber === "function") {
-      const invoiceNumber = await writeBackInvoiceNumber(event, result)
-      if (typeof invoiceNumber !== "string" || invoiceNumber.trim().length === 0) {
-        throw new Error("SmartBill invoice number write-back formatter returned an empty value")
-      }
-      return invoiceNumber
-    }
-    if (!result.number) return null
-    return formatExternalInvoiceNumber(result.series ?? body.seriesName, result.number)
-  }
-
-  async function writeBackInvoiceNumberIfRequired(
-    event: VoyantInvoiceEvent,
-    documentType: SmartbillDocumentType,
-    body: SmartbillInvoiceBody,
-    result: SmartbillInvoiceResponse,
-  ) {
-    const invoiceNumber = await resolveWriteBackInvoiceNumber(event, body, result)
-    if (!invoiceNumber) return
-
-    const db = await resolveArtifactDb(event, documentType, body, result)
-    if (!db) {
-      throw new Error("SmartBill invoice number write-back requires artifact database access")
-    }
-
-    const invoice = await financeService.updateInvoice(db, event.id, { invoiceNumber })
-    if (!invoice) {
-      throw new Error(`SmartBill invoice number write-back failed for missing invoice ${event.id}`)
-    }
-    logger.info?.(`[smartbill] invoice number write-back applied for ${event.id}`, invoice)
-  }
-
-  async function writeBackInvoiceNumberFromRefIfRequired(
-    event: VoyantInvoiceEvent,
-    documentType: SmartbillDocumentType,
-    body: SmartbillInvoiceBody,
-    externalRef: SmartbillExternalRef,
-  ) {
-    if (!writeBackInvoiceNumber) return
-
-    const metadata = coerceMetadata(externalRef.metadata)
-    const number =
-      metadataString(metadata, "number") ??
-      externalRef.externalNumber ??
-      externalRef.externalId ??
-      null
-    if (!number) return
-
-    await writeBackInvoiceNumberIfRequired(event, documentType, body, {
-      number,
-      series:
-        metadataString(metadata, "series") ??
-        metadataString(metadata, "seriesName") ??
-        body.seriesName,
-      url: externalRef.externalUrl ?? undefined,
-    })
-  }
-
-  async function recordSyncError(
-    event: VoyantInvoiceEvent,
-    documentType: SmartbillDocumentType,
-    err: unknown,
-  ) {
-    try {
-      await onError?.(event, err)
-    } catch (handlerError) {
-      logger.error(`[smartbill] onError handler failed for ${event.id}`, handlerError)
-    }
-
-    try {
-      const db = await resolveArtifactDb(event, documentType)
-      if (!db) return
-      const refs = await financeService.listInvoiceExternalRefs(db, event.id)
-      if (refs.some((ref) => isMatchingSmartbillRef(ref, documentType))) return
-
-      await financeService.registerInvoiceExternalRef(db, event.id, {
-        provider: "smartbill",
-        externalId: null,
-        externalNumber: null,
-        externalUrl: null,
-        status: "error",
-        syncedAt: new Date().toISOString(),
-        syncError: errorMessage(err),
-        metadata: { documentType },
-      })
-    } catch (recordError) {
-      logger.error(`[smartbill] error external-ref recording failed for ${event.id}`, recordError)
-    }
-  }
+  const runtime = createSmartbillSyncRuntime(validatedOptions)
+  const { client, logger, eventNames } = runtime
 
   async function resolveConfiguredSeriesName(event: VoyantInvoiceEvent) {
     const value = validatedOptions.seriesName
@@ -380,26 +103,15 @@ export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
         const event = coerceEvent(envelope.data)
         if (!event) return
         try {
-          const body = await mapEvent(event)
-          const existingRef = await findExistingSmartbillRef(event, "invoice", body)
-          if (existingRef) {
-            await handleExistingSmartbillRef(event, "invoice", body, existingRef)
-            return
-          }
-          const result = await client.createInvoice(body)
-          logger.info?.(
-            `[smartbill] invoice created: ${result.series}-${result.number} for ${event.id}`,
-            result,
-          )
-          await persistArtifact(event, "invoice", body, result)
-          await writeBackInvoiceNumberIfRequired(event, "invoice", body, result)
-          await applyExternalAllocationIfRequired(event, "invoice", body, result)
-        } catch (err) {
-          logger.error(
-            `[smartbill] createInvoice on "${eventNames.issued}" failed for ${event.id}`,
-            err,
-          )
-          await recordSyncError(event, "invoice", err)
+          await syncSmartbillInvoiceEvent({
+            event,
+            documentType: "invoice",
+            runtime,
+            pluginOptions: validatedOptions,
+            operationLabel: `createInvoice on "${eventNames.issued}"`,
+          })
+        } catch {
+          // `syncSmartbillInvoiceEvent` logs and records retryable state.
         }
       },
     },
@@ -409,28 +121,15 @@ export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
         const event = coerceEvent(envelope.data)
         if (!event) return
         try {
-          // Same shape as createInvoice — SmartBill's `/proforma`
-          // endpoint accepts the same body as `/invoice`.
-          const body = await mapEvent(event)
-          const existingRef = await findExistingSmartbillRef(event, "proforma", body)
-          if (existingRef) {
-            await handleExistingSmartbillRef(event, "proforma", body, existingRef)
-            return
-          }
-          const result = await client.createProforma(body)
-          logger.info?.(
-            `[smartbill] proforma created: ${result.series}-${result.number} for ${event.id}`,
-            result,
-          )
-          await persistArtifact(event, "proforma", body, result)
-          await writeBackInvoiceNumberIfRequired(event, "proforma", body, result)
-          await applyExternalAllocationIfRequired(event, "proforma", body, result)
-        } catch (err) {
-          logger.error(
-            `[smartbill] createProforma on "${eventNames.proformaIssued}" failed for ${event.id}`,
-            err,
-          )
-          await recordSyncError(event, "proforma", err)
+          await syncSmartbillInvoiceEvent({
+            event,
+            documentType: "proforma",
+            runtime,
+            pluginOptions: validatedOptions,
+            operationLabel: `createProforma on "${eventNames.proformaIssued}"`,
+          })
+        } catch {
+          // `syncSmartbillInvoiceEvent` logs and records retryable state.
         }
       },
     },
@@ -506,74 +205,5 @@ export function smartbillPlugin(options: SmartbillPluginOptions): Plugin {
     name: "smartbill",
     version: "0.1.0",
     subscribers,
-  }
-}
-
-function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error)
-}
-
-function coerceMetadata(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null
-}
-
-function metadataString(metadata: Record<string, unknown> | null, key: string) {
-  const value = metadata?.[key]
-  return typeof value === "string" && value.length > 0 ? value : null
-}
-
-function formatExternalInvoiceNumber(seriesName: string | undefined, number: string) {
-  const trimmedNumber = number.trim()
-  const trimmedSeries = seriesName?.trim()
-  if (!trimmedSeries || trimmedNumber.startsWith(`${trimmedSeries}-`)) return trimmedNumber
-  return `${trimmedSeries}-${trimmedNumber}`
-}
-
-function isUsableSmartbillRef(ref: {
-  provider: string
-  status?: string | null
-  syncError?: string | null
-  externalNumber?: string | null
-  externalId?: string | null
-}) {
-  return (
-    ref.provider === "smartbill" &&
-    ref.status !== "error" &&
-    !ref.syncError &&
-    Boolean(ref.externalNumber || ref.externalId)
-  )
-}
-
-function isMatchingSmartbillRef(
-  ref: {
-    provider: string
-    status?: string | null
-    syncError?: string | null
-    externalNumber?: string | null
-    externalId?: string | null
-    metadata?: unknown
-  },
-  documentType: SmartbillDocumentType,
-) {
-  if (!isUsableSmartbillRef(ref)) return false
-  return metadataString(coerceMetadata(ref.metadata), "documentType") === documentType
-}
-
-function parseSmartbillPluginOptions(options: SmartbillPluginOptions): SmartbillPluginOptions {
-  try {
-    return smartbillPluginOptionsSchema.parse(options)
-  } catch (error) {
-    if (error instanceof ZodError) {
-      const detail = error.issues
-        .map((issue) => {
-          const path = issue.path.join(".") || "options"
-          return `${path}: ${issue.message}`
-        })
-        .join("; ")
-      throw new Error(`Invalid SmartBill plugin options: ${detail}`)
-    }
-    throw error
   }
 }

--- a/packages/plugins/smartbill/src/runtime.ts
+++ b/packages/plugins/smartbill/src/runtime.ts
@@ -1,5 +1,5 @@
 import type { SmartbillArtifactPersistenceOptions } from "./artifacts.js"
-import { createSmartbillClient } from "./client.js"
+import { createSmartbillClient, type SmartbillClientApi } from "./client.js"
 import { mapVoyantInvoiceToSmartbillAsync, type SmartbillMappingOptions } from "./mapping.js"
 import type { SmartbillLogger, SmartbillMapFn, SmartbillPluginOptions } from "./plugin.js"
 import type { VoyantInvoiceEvent } from "./types.js"
@@ -22,8 +22,15 @@ export interface SmartbillSyncRuntime {
   writeBackInvoiceNumber: SmartbillPluginOptions["writeBackInvoiceNumber"]
 }
 
-export function createSmartbillSyncRuntime(options: SmartbillPluginOptions): SmartbillSyncRuntime {
-  const client = createSmartbillClient(options)
+export interface SmartbillSyncRuntimeOverrides {
+  client?: SmartbillClientApi
+}
+
+export function createSmartbillSyncRuntime(
+  options: SmartbillPluginOptions,
+  overrides: SmartbillSyncRuntimeOverrides = {},
+): SmartbillSyncRuntime {
+  const client = overrides.client ?? createSmartbillClient(options)
   const logger = options.logger ?? console
   const mappingOptions: SmartbillMappingOptions = {
     companyVatCode: options.companyVatCode,

--- a/packages/plugins/smartbill/src/sync.ts
+++ b/packages/plugins/smartbill/src/sync.ts
@@ -1,0 +1,519 @@
+import {
+  buildInvoiceIssuedEvent,
+  financeService,
+  type Invoice,
+  type InvoiceIssueRuntime,
+} from "@voyantjs/finance"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import {
+  isSmartbillPdfPersistMetadataUpdateError,
+  persistSmartbillInvoiceArtifact,
+  recordSmartbillInvoiceArtifactFailure,
+  retrySmartbillInvoiceArtifact,
+  type SmartbillArtifactStorageContext,
+  type SmartbillDocumentType,
+  type SmartbillExternalRef,
+} from "./artifacts.js"
+import type { SmartbillClientApi } from "./client.js"
+import type {
+  SmartbillInvoiceNumberWriteBackFormatter,
+  SmartbillMapFn,
+  SmartbillPluginOptions,
+} from "./plugin.js"
+import { createSmartbillSyncRuntime, type SmartbillSyncRuntime } from "./runtime.js"
+import type { SmartbillInvoiceBody, SmartbillInvoiceResponse, VoyantInvoiceEvent } from "./types.js"
+import { parseSmartbillPluginOptions } from "./validation.js"
+
+export interface SyncSmartbillInvoiceInput {
+  db: PostgresJsDatabase
+  invoiceId: string
+  pluginOptions: SmartbillPluginOptions
+  client?: SmartbillClientApi
+  issueRuntime?: Omit<InvoiceIssueRuntime, "eventBus">
+}
+
+export interface SyncSmartbillInvoiceEventInput {
+  event: VoyantInvoiceEvent
+  documentType: SmartbillDocumentType
+  runtime: SmartbillSyncRuntime
+  pluginOptions: Pick<SmartbillPluginOptions, "companyVatCode" | "seriesName">
+  operationLabel?: string
+}
+
+export type SyncSmartbillInvoiceResult =
+  | {
+      status: "not_found"
+      invoiceId: string
+    }
+  | {
+      status: "unsupported_document_type"
+      invoiceId: string
+      invoiceType: string
+    }
+  | SyncSmartbillInvoiceEventResult
+
+export type SyncSmartbillInvoiceEventResult =
+  | {
+      status: "existing_ref"
+      invoiceId: string
+      documentType: SmartbillDocumentType
+      externalRef: SmartbillExternalRef
+      artifact: Awaited<ReturnType<typeof retrySmartbillInvoiceArtifact>> | null
+    }
+  | {
+      status: "created"
+      invoiceId: string
+      documentType: SmartbillDocumentType
+      result: SmartbillInvoiceResponse
+      artifact: Awaited<ReturnType<typeof persistSmartbillInvoiceArtifact>> | null
+    }
+
+export async function syncSmartbillInvoice({
+  db,
+  invoiceId,
+  pluginOptions,
+  client,
+  issueRuntime,
+}: SyncSmartbillInvoiceInput): Promise<SyncSmartbillInvoiceResult> {
+  const invoice = await financeService.getInvoiceById(db, invoiceId)
+  if (!invoice) return { status: "not_found", invoiceId }
+
+  const documentType = documentTypeForInvoice(invoice)
+  if (!documentType) {
+    return { status: "unsupported_document_type", invoiceId, invoiceType: invoice.invoiceType }
+  }
+
+  const validatedOptions = parseSmartbillPluginOptions(withDefaultArtifactDb(pluginOptions, db))
+  const runtime = createSmartbillSyncRuntime(validatedOptions, client ? { client } : undefined)
+  const issuedEvent = await buildInvoiceIssuedEvent(db, invoice, issueRuntime)
+  const event: VoyantInvoiceEvent = { ...issuedEvent, id: issuedEvent.invoiceId }
+
+  return syncSmartbillInvoiceEvent({
+    event,
+    documentType,
+    runtime,
+    pluginOptions: validatedOptions,
+    operationLabel: documentType === "proforma" ? "createProforma" : "createInvoice",
+  })
+}
+
+export async function syncSmartbillInvoiceEvent({
+  event,
+  documentType,
+  runtime,
+  pluginOptions,
+  operationLabel = documentType === "proforma" ? "createProforma" : "createInvoice",
+}: SyncSmartbillInvoiceEventInput): Promise<SyncSmartbillInvoiceEventResult> {
+  try {
+    const body = await runtime.mapEvent(event)
+    const existingRef = await findExistingSmartbillRef(event, documentType, body, runtime)
+    if (existingRef) {
+      return handleExistingSmartbillRef(event, documentType, body, existingRef, runtime)
+    }
+
+    const result =
+      documentType === "proforma"
+        ? await runtime.client.createProforma(body)
+        : await runtime.client.createInvoice(body)
+    runtime.logger.info?.(
+      `[smartbill] ${documentType} created: ${result.series}-${result.number} for ${event.id}`,
+      result,
+    )
+    const artifact = await persistArtifact(event, documentType, body, result, runtime)
+    await writeBackInvoiceNumberIfRequired(event, documentType, body, result, runtime)
+    await applyExternalAllocationIfRequired(event, documentType, body, result, runtime)
+    return { status: "created", invoiceId: event.id, documentType, result, artifact }
+  } catch (err) {
+    runtime.logger.error(`[smartbill] ${operationLabel} failed for ${event.id}`, err)
+    await recordSyncError(event, documentType, err, runtime, pluginOptions)
+    throw err
+  }
+}
+
+async function findExistingSmartbillRef(
+  event: VoyantInvoiceEvent,
+  documentType: SmartbillDocumentType,
+  body: SmartbillInvoiceBody,
+  runtime: SmartbillSyncRuntime,
+): Promise<SmartbillExternalRef | null> {
+  if (runtime.idempotency.skipExistingExternalRef === false) return null
+  const db = await resolveArtifactDb(event, documentType, body, undefined, runtime)
+  if (!db) return null
+
+  const refs = await financeService.listInvoiceExternalRefs(db, event.id)
+  return refs.find((ref) => isMatchingSmartbillRef(ref, documentType)) ?? null
+}
+
+async function handleExistingSmartbillRef(
+  event: VoyantInvoiceEvent,
+  documentType: SmartbillDocumentType,
+  body: SmartbillInvoiceBody,
+  externalRef: SmartbillExternalRef,
+  runtime: SmartbillSyncRuntime,
+): Promise<SyncSmartbillInvoiceEventResult> {
+  runtime.logger.info?.(
+    `[smartbill] ${documentType} already has SmartBill ref for ${event.id}; skipping create`,
+    externalRef,
+  )
+  await applyExternalAllocationFromRefIfRequired(event, documentType, body, externalRef, runtime)
+  await writeBackInvoiceNumberFromRefIfRequired(event, documentType, body, externalRef, runtime)
+
+  let artifact: Awaited<ReturnType<typeof retrySmartbillInvoiceArtifact>> | null = null
+  try {
+    artifact = await retrySmartbillInvoiceArtifact({
+      runtime: runtime.artifacts,
+      client: runtime.client,
+      externalRef,
+      documentType,
+    })
+    if (artifact.status === "persisted") {
+      runtime.logger.info?.(`[smartbill] ${documentType} PDF re-attached for ${event.id}`, artifact)
+    }
+  } catch (err) {
+    const message = isSmartbillPdfPersistMetadataUpdateError(err)
+      ? `[smartbill] artifact re-attach metadata update failed for ${event.id}`
+      : `[smartbill] artifact re-attach failed for ${event.id}`
+    runtime.logger.error(message, err)
+  }
+
+  return { status: "existing_ref", invoiceId: event.id, documentType, externalRef, artifact }
+}
+
+async function persistArtifact(
+  event: VoyantInvoiceEvent,
+  documentType: SmartbillDocumentType,
+  body: Awaited<ReturnType<SmartbillMapFn>>,
+  result: Awaited<ReturnType<SmartbillClientApi["createInvoice"]>>,
+  runtime: SmartbillSyncRuntime,
+) {
+  try {
+    const persisted = await persistSmartbillInvoiceArtifact({
+      runtime: runtime.artifacts,
+      client: runtime.client,
+      event,
+      documentType,
+      body,
+      result,
+    })
+    if (persisted.status === "persisted") {
+      runtime.logger.info?.(`[smartbill] ${documentType} PDF persisted for ${event.id}`, persisted)
+    }
+    return persisted
+  } catch (err) {
+    if (isSmartbillPdfPersistMetadataUpdateError(err)) {
+      runtime.logger.error(
+        `[smartbill] artifact persistence metadata update failed for ${event.id}`,
+        err,
+      )
+      return null
+    }
+    runtime.logger.error(`[smartbill] artifact persistence failed for ${event.id}`, err)
+    try {
+      await recordSmartbillInvoiceArtifactFailure({
+        runtime: runtime.artifacts,
+        event,
+        documentType,
+        body,
+        result,
+        error: err,
+      })
+    } catch (recordError) {
+      runtime.logger.error(
+        `[smartbill] artifact failure external-ref update failed for ${event.id}`,
+        recordError,
+      )
+    }
+    return null
+  }
+}
+
+async function applyExternalAllocationIfRequired(
+  event: VoyantInvoiceEvent,
+  documentType: SmartbillDocumentType,
+  body: SmartbillInvoiceBody,
+  result: SmartbillInvoiceResponse,
+  runtime: SmartbillSyncRuntime,
+) {
+  if (event.externalAllocationRequired !== true || !result.number) return
+
+  const db = await resolveArtifactDb(event, documentType, body, result, runtime)
+  if (!db) {
+    throw new Error("SmartBill external allocation requires artifact database access")
+  }
+  const allocation = await financeService.applyExternalInvoiceAllocation(db, event.id, {
+    invoiceNumber: formatExternalInvoiceNumber(result.series ?? body.seriesName, result.number),
+  })
+  if (allocation.status === "applied") {
+    runtime.logger.info?.(`[smartbill] external number applied for ${event.id}`, allocation.invoice)
+  }
+}
+
+async function applyExternalAllocationFromRefIfRequired(
+  event: VoyantInvoiceEvent,
+  documentType: SmartbillDocumentType,
+  body: SmartbillInvoiceBody,
+  externalRef: SmartbillExternalRef,
+  runtime: SmartbillSyncRuntime,
+) {
+  if (event.externalAllocationRequired !== true) return
+
+  const metadata = coerceMetadata(externalRef.metadata)
+  const number =
+    metadataString(metadata, "number") ??
+    externalRef.externalNumber ??
+    externalRef.externalId ??
+    null
+  if (!number) {
+    throw new Error("SmartBill external allocation requires an existing external number")
+  }
+  await applyExternalAllocationIfRequired(
+    event,
+    documentType,
+    body,
+    {
+      number,
+      series:
+        metadataString(metadata, "series") ??
+        metadataString(metadata, "seriesName") ??
+        body.seriesName,
+      url: externalRef.externalUrl ?? undefined,
+    },
+    runtime,
+  )
+}
+
+async function resolveWriteBackInvoiceNumber(
+  event: VoyantInvoiceEvent,
+  body: SmartbillInvoiceBody,
+  result: SmartbillInvoiceResponse,
+  writeBackInvoiceNumber: boolean | SmartbillInvoiceNumberWriteBackFormatter | undefined,
+) {
+  if (!writeBackInvoiceNumber) return null
+  if (typeof writeBackInvoiceNumber === "function") {
+    const invoiceNumber = await writeBackInvoiceNumber(event, result)
+    if (typeof invoiceNumber !== "string" || invoiceNumber.trim().length === 0) {
+      throw new Error("SmartBill invoice number write-back formatter returned an empty value")
+    }
+    return invoiceNumber
+  }
+  if (!result.number) return null
+  return formatExternalInvoiceNumber(result.series ?? body.seriesName, result.number)
+}
+
+async function writeBackInvoiceNumberIfRequired(
+  event: VoyantInvoiceEvent,
+  documentType: SmartbillDocumentType,
+  body: SmartbillInvoiceBody,
+  result: SmartbillInvoiceResponse,
+  runtime: SmartbillSyncRuntime,
+) {
+  const invoiceNumber = await resolveWriteBackInvoiceNumber(
+    event,
+    body,
+    result,
+    runtime.writeBackInvoiceNumber,
+  )
+  if (!invoiceNumber) return
+
+  const db = await resolveArtifactDb(event, documentType, body, result, runtime)
+  if (!db) {
+    throw new Error("SmartBill invoice number write-back requires artifact database access")
+  }
+
+  const invoice = await financeService.updateInvoice(db, event.id, { invoiceNumber })
+  if (!invoice) {
+    throw new Error(`SmartBill invoice number write-back failed for missing invoice ${event.id}`)
+  }
+  runtime.logger.info?.(`[smartbill] invoice number write-back applied for ${event.id}`, invoice)
+}
+
+async function writeBackInvoiceNumberFromRefIfRequired(
+  event: VoyantInvoiceEvent,
+  documentType: SmartbillDocumentType,
+  body: SmartbillInvoiceBody,
+  externalRef: SmartbillExternalRef,
+  runtime: SmartbillSyncRuntime,
+) {
+  if (!runtime.writeBackInvoiceNumber) return
+
+  const metadata = coerceMetadata(externalRef.metadata)
+  const number =
+    metadataString(metadata, "number") ??
+    externalRef.externalNumber ??
+    externalRef.externalId ??
+    null
+  if (!number) return
+
+  await writeBackInvoiceNumberIfRequired(
+    event,
+    documentType,
+    body,
+    {
+      number,
+      series:
+        metadataString(metadata, "series") ??
+        metadataString(metadata, "seriesName") ??
+        body.seriesName,
+      url: externalRef.externalUrl ?? undefined,
+    },
+    runtime,
+  )
+}
+
+async function recordSyncError(
+  event: VoyantInvoiceEvent,
+  documentType: SmartbillDocumentType,
+  err: unknown,
+  runtime: SmartbillSyncRuntime,
+  pluginOptions: Pick<SmartbillPluginOptions, "companyVatCode" | "seriesName">,
+) {
+  try {
+    await runtime.onError?.(event, err)
+  } catch (handlerError) {
+    runtime.logger.error(`[smartbill] onError handler failed for ${event.id}`, handlerError)
+  }
+
+  try {
+    const db = await resolveArtifactDb(
+      event,
+      documentType,
+      undefined,
+      undefined,
+      runtime,
+      pluginOptions,
+    )
+    if (!db) return
+    const refs = await financeService.listInvoiceExternalRefs(db, event.id)
+    if (refs.some((ref) => isMatchingSmartbillRef(ref, documentType))) return
+
+    await financeService.registerInvoiceExternalRef(db, event.id, {
+      provider: "smartbill",
+      externalId: null,
+      externalNumber: null,
+      externalUrl: null,
+      status: "error",
+      syncedAt: new Date().toISOString(),
+      syncError: errorMessage(err),
+      metadata: { documentType },
+    })
+  } catch (recordError) {
+    runtime.logger.error(
+      `[smartbill] error external-ref recording failed for ${event.id}`,
+      recordError,
+    )
+  }
+}
+
+async function resolveArtifactDb(
+  event: VoyantInvoiceEvent,
+  documentType: SmartbillDocumentType,
+  body: SmartbillInvoiceBody | undefined,
+  result: SmartbillInvoiceResponse | undefined,
+  runtime: SmartbillSyncRuntime,
+  pluginOptions?: Pick<SmartbillPluginOptions, "companyVatCode" | "seriesName">,
+) {
+  if (!runtime.artifacts.db) return null
+  const context: SmartbillArtifactStorageContext = {
+    event,
+    documentType,
+    body: body ?? {
+      companyVatCode: pluginOptions?.companyVatCode ?? "",
+      client: { name: "Client" },
+      seriesName: await resolveSeriesName(pluginOptions?.seriesName, event),
+      currency: "RON",
+      products: [],
+    },
+    result: result ?? {},
+  }
+  return (await resolveMaybe(runtime.artifacts.db, context)) ?? null
+}
+
+function withDefaultArtifactDb(
+  pluginOptions: SmartbillPluginOptions,
+  db: PostgresJsDatabase,
+): SmartbillPluginOptions {
+  if (pluginOptions.artifacts?.db || pluginOptions.db) return pluginOptions
+  return {
+    ...pluginOptions,
+    artifacts: {
+      ...pluginOptions.artifacts,
+      db,
+    },
+  }
+}
+
+function documentTypeForInvoice(invoice: Invoice): SmartbillDocumentType | null {
+  if (invoice.invoiceType === "proforma") return "proforma"
+  if (invoice.invoiceType === "invoice") return "invoice"
+  return null
+}
+
+async function resolveSeriesName(
+  seriesName: SmartbillPluginOptions["seriesName"] | undefined,
+  event: VoyantInvoiceEvent,
+) {
+  if (typeof seriesName === "function") return seriesName(event)
+  return seriesName ?? "unknown"
+}
+
+async function resolveMaybe<TContext, TValue>(
+  value: TValue | ((context: TContext) => TValue | Promise<TValue>) | undefined | null,
+  context: TContext,
+) {
+  return typeof value === "function"
+    ? await (value as (context: TContext) => TValue | Promise<TValue>)(context)
+    : value
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function coerceMetadata(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function metadataString(metadata: Record<string, unknown> | null, key: string) {
+  const value = metadata?.[key]
+  return typeof value === "string" && value.length > 0 ? value : null
+}
+
+function formatExternalInvoiceNumber(seriesName: string | undefined, number: string) {
+  const trimmedNumber = number.trim()
+  const trimmedSeries = seriesName?.trim()
+  if (!trimmedSeries || trimmedNumber.startsWith(`${trimmedSeries}-`)) return trimmedNumber
+  return `${trimmedSeries}-${trimmedNumber}`
+}
+
+function isUsableSmartbillRef(ref: {
+  provider: string
+  status?: string | null
+  syncError?: string | null
+  externalNumber?: string | null
+  externalId?: string | null
+}) {
+  return (
+    ref.provider === "smartbill" &&
+    ref.status !== "error" &&
+    !ref.syncError &&
+    Boolean(ref.externalNumber || ref.externalId)
+  )
+}
+
+function isMatchingSmartbillRef(
+  ref: {
+    provider: string
+    status?: string | null
+    syncError?: string | null
+    externalNumber?: string | null
+    externalId?: string | null
+    metadata?: unknown
+  },
+  documentType: SmartbillDocumentType,
+) {
+  if (!isUsableSmartbillRef(ref)) return false
+  return metadataString(coerceMetadata(ref.metadata), "documentType") === documentType
+}

--- a/packages/plugins/smartbill/src/validation.ts
+++ b/packages/plugins/smartbill/src/validation.ts
@@ -1,4 +1,4 @@
-import { z } from "zod"
+import { ZodError, z } from "zod"
 import type {
   SmartbillArtifactPersistenceOptions,
   SmartbillDbResolver,
@@ -152,3 +152,22 @@ export const smartbillPluginOptionsSchema = z.object({
   documentStorage: optionalDocumentStorage.optional(),
   documentStorageKeyPrefix: optionalDocumentStorageKeyPrefix.optional(),
 }) satisfies z.ZodType<SmartbillPluginOptions>
+
+export function parseSmartbillPluginOptions(
+  options: SmartbillPluginOptions,
+): SmartbillPluginOptions {
+  try {
+    return smartbillPluginOptionsSchema.parse(options)
+  } catch (error) {
+    if (error instanceof ZodError) {
+      const detail = error.issues
+        .map((issue) => {
+          const path = issue.path.join(".") || "options"
+          return `${path}: ${issue.message}`
+        })
+        .join("; ")
+      throw new Error(`Invalid SmartBill plugin options: ${detail}`)
+    }
+    throw error
+  }
+}

--- a/packages/plugins/smartbill/tests/unit/hono.test.ts
+++ b/packages/plugins/smartbill/tests/unit/hono.test.ts
@@ -1,0 +1,123 @@
+import { Hono } from "hono"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { createSmartbillAdminRoutes } from "../../src/hono.js"
+
+const financeRuntimeKey = vi.hoisted(() => "providers.finance.runtime")
+const syncSmartbillInvoiceMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@voyantjs/finance", () => ({
+  FINANCE_ROUTE_RUNTIME_CONTAINER_KEY: financeRuntimeKey,
+}))
+
+vi.mock("../../src/sync.js", () => ({
+  syncSmartbillInvoice: syncSmartbillInvoiceMock,
+}))
+
+const pluginOptions = {
+  username: "user@test.com",
+  apiToken: "tok",
+  companyVatCode: "RO12345678",
+  seriesName: "A",
+}
+
+function buildApp(runtime?: unknown) {
+  const db = { name: "db" }
+  const container = runtime
+    ? {
+        resolve: vi.fn((key: string) => {
+          if (key === financeRuntimeKey) return runtime
+          throw new Error(`Unknown container key ${key}`)
+        }),
+      }
+    : undefined
+  const app = new Hono()
+  app.use("*", async (c, next) => {
+    c.set("db", db)
+    if (container) c.set("container", container)
+    await next()
+  })
+  app.route("/v1/admin/smartbill", createSmartbillAdminRoutes({ pluginOptions }))
+  return { app, db, container }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("createSmartbillAdminRoutes", () => {
+  it("syncs an invoice through the shared SmartBill service", async () => {
+    const resolveInvoiceExchangeRate = vi.fn()
+    const onInvoiceFxResolutionError = vi.fn()
+    const financeRuntime = {
+      eventBus: {},
+      invoiceSettlementPollers: {},
+      invoiceFxSettings: { baseCurrency: "RON", fxCommissionBps: 200 },
+      resolveInvoiceExchangeRate,
+      onInvoiceFxResolutionError,
+    }
+    syncSmartbillInvoiceMock.mockResolvedValueOnce({
+      status: "created",
+      invoiceId: "inv_123",
+      documentType: "invoice",
+      result: { number: "42", series: "A" },
+      artifact: null,
+    })
+    const { app, db } = buildApp(financeRuntime)
+
+    const response = await app.request("/v1/admin/smartbill/invoices/inv_123/sync", {
+      method: "POST",
+    })
+
+    expect(response.status).toBe(201)
+    expect(await response.json()).toEqual({
+      data: {
+        status: "created",
+        invoiceId: "inv_123",
+        documentType: "invoice",
+        result: { number: "42", series: "A" },
+        artifact: null,
+      },
+    })
+    expect(syncSmartbillInvoiceMock).toHaveBeenCalledWith({
+      db,
+      invoiceId: "inv_123",
+      pluginOptions,
+      issueRuntime: {
+        invoiceFxSettings: { baseCurrency: "RON", fxCommissionBps: 200 },
+        resolveInvoiceExchangeRate,
+        resolveInvoiceExchangeRateResolver: undefined,
+        resolveInvoiceFxSettings: undefined,
+        updateInvoiceFxSettings: undefined,
+        onInvoiceFxResolutionError,
+      },
+    })
+  })
+
+  it("returns not found for missing invoices", async () => {
+    syncSmartbillInvoiceMock.mockResolvedValueOnce({
+      status: "not_found",
+      invoiceId: "missing",
+    })
+    const { app } = buildApp()
+
+    const response = await app.request("/v1/admin/smartbill/invoices/missing/sync", {
+      method: "POST",
+    })
+
+    expect(response.status).toBe(404)
+    expect(await response.json()).toEqual({ error: "Invoice not found" })
+  })
+
+  it("returns bad gateway when SmartBill sync fails", async () => {
+    syncSmartbillInvoiceMock.mockRejectedValueOnce(new Error("SmartBill unavailable"))
+    const { app } = buildApp()
+
+    const response = await app.request("/v1/admin/smartbill/invoices/inv_123/sync", {
+      method: "POST",
+    })
+
+    expect(response.status).toBe(502)
+    expect(await response.json()).toEqual({ error: "SmartBill unavailable" })
+  })
+})

--- a/packages/plugins/smartbill/tests/unit/sync.test.ts
+++ b/packages/plugins/smartbill/tests/unit/sync.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { syncSmartbillInvoice, syncSmartbillInvoiceEvent } from "../../src/sync.js"
+
+const financeServiceMock = vi.hoisted(() => ({
+  getInvoiceById: vi.fn(),
+  listInvoiceExternalRefs: vi.fn(),
+  registerInvoiceExternalRef: vi.fn(),
+  applyExternalInvoiceAllocation: vi.fn(),
+  updateInvoice: vi.fn(),
+}))
+
+const buildInvoiceIssuedEventMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@voyantjs/finance", () => ({
+  buildInvoiceIssuedEvent: buildInvoiceIssuedEventMock,
+  financeService: financeServiceMock,
+}))
+
+const basePluginOptions = {
+  username: "user@test.com",
+  apiToken: "tok",
+  companyVatCode: "RO12345678",
+  seriesName: "A",
+}
+
+function makeClient() {
+  return {
+    createInvoice: vi.fn().mockResolvedValue({ number: "42", series: "A" }),
+    createProforma: vi.fn().mockResolvedValue({ number: "9", series: "P" }),
+    cancelInvoice: vi.fn(),
+    reverseInvoice: vi.fn(),
+    restoreInvoice: vi.fn(),
+    deleteInvoice: vi.fn(),
+    getPaymentStatus: vi.fn(),
+    listTaxes: vi.fn(),
+    listSeries: vi.fn(),
+    viewInvoicePdf: vi.fn(),
+    viewPdf: vi.fn(),
+    viewEstimatePdf: vi.fn(),
+    listEstimateInvoices: vi.fn(),
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  financeServiceMock.getInvoiceById.mockResolvedValue({ id: "inv_123", invoiceType: "invoice" })
+  financeServiceMock.listInvoiceExternalRefs.mockResolvedValue([])
+  financeServiceMock.registerInvoiceExternalRef.mockResolvedValue({ id: "iex_1" })
+  financeServiceMock.applyExternalInvoiceAllocation.mockResolvedValue({
+    status: "applied",
+    invoice: { id: "inv_123" },
+  })
+  financeServiceMock.updateInvoice.mockResolvedValue({ id: "inv_123" })
+  buildInvoiceIssuedEventMock.mockResolvedValue({
+    invoiceId: "inv_123",
+    invoiceNumber: "INV-1",
+    invoiceType: "invoice",
+    bookingId: null,
+    totalCents: 10000,
+    currency: "RON",
+    lineItems: [{ description: "Tour", quantity: 1, unitPrice: 100, currency: "RON" }],
+  })
+})
+
+describe("syncSmartbillInvoice", () => {
+  it("loads the finance invoice event and creates a SmartBill invoice", async () => {
+    const db = {} as never
+    const client = makeClient()
+
+    const result = await syncSmartbillInvoice({
+      db,
+      invoiceId: "inv_123",
+      pluginOptions: basePluginOptions,
+      client,
+    })
+
+    expect(result.status).toBe("created")
+    expect(buildInvoiceIssuedEventMock).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ id: "inv_123" }),
+      undefined,
+    )
+    expect(client.createInvoice).toHaveBeenCalledWith(
+      expect.objectContaining({
+        companyVatCode: "RO12345678",
+        seriesName: "A",
+        client: expect.objectContaining({ name: "Client" }),
+      }),
+    )
+    expect(financeServiceMock.registerInvoiceExternalRef).toHaveBeenCalledWith(
+      db,
+      "inv_123",
+      expect.objectContaining({
+        provider: "smartbill",
+        externalNumber: "42",
+        status: "issued",
+      }),
+    )
+  })
+
+  it("returns unsupported_document_type for credit notes", async () => {
+    financeServiceMock.getInvoiceById.mockResolvedValueOnce({
+      id: "cred_1",
+      invoiceType: "credit_note",
+    })
+
+    await expect(
+      syncSmartbillInvoice({
+        db: {} as never,
+        invoiceId: "cred_1",
+        pluginOptions: basePluginOptions,
+        client: makeClient(),
+      }),
+    ).resolves.toEqual({
+      status: "unsupported_document_type",
+      invoiceId: "cred_1",
+      invoiceType: "credit_note",
+    })
+  })
+})
+
+describe("syncSmartbillInvoiceEvent", () => {
+  it("reuses an existing matching SmartBill ref instead of creating again", async () => {
+    const client = makeClient()
+    const externalRef = {
+      id: "iex_existing",
+      invoiceId: "inv_123",
+      provider: "smartbill",
+      externalId: "42",
+      externalNumber: "42",
+      externalUrl: null,
+      status: "issued",
+      syncError: null,
+      metadata: {
+        companyVatCode: "RO12345678",
+        seriesName: "A",
+        series: "A",
+        number: "42",
+        documentType: "invoice",
+      },
+    }
+    financeServiceMock.listInvoiceExternalRefs.mockResolvedValueOnce([externalRef])
+
+    const result = await syncSmartbillInvoiceEvent({
+      event: { id: "inv_123", lineItems: [] },
+      documentType: "invoice",
+      runtime: {
+        client,
+        logger: { error: vi.fn(), info: vi.fn() },
+        mapEvent: vi.fn().mockResolvedValue({
+          companyVatCode: "RO12345678",
+          client: { name: "Client" },
+          seriesName: "A",
+          currency: "RON",
+          products: [],
+        }),
+        eventNames: {
+          issued: "invoice.issued",
+          proformaIssued: "invoice.proforma.issued",
+          voided: "invoice.voided",
+          syncRequested: "invoice.external.sync.requested",
+        },
+        artifacts: { db: {} as never },
+        idempotency: { skipExistingExternalRef: true },
+        onError: undefined,
+        writeBackInvoiceNumber: undefined,
+      },
+      pluginOptions: basePluginOptions,
+    })
+
+    expect(result.status).toBe("existing_ref")
+    expect(client.createInvoice).not.toHaveBeenCalled()
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3903,12 +3903,18 @@ importers:
       '@voyantjs/finance':
         specifier: workspace:*
         version: link:../../finance
+      '@voyantjs/hono':
+        specifier: workspace:*
+        version: link:../../hono
       '@voyantjs/storage':
         specifier: workspace:*
         version: link:../../storage
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260426.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
+      hono:
+        specifier: ^4.12.10
+        version: 4.12.10
       zod:
         specifier: ^4.3.6
         version: 4.3.6


### PR DESCRIPTION
## Summary
- add reusable SmartBill invoice sync helpers that load finance invoice event data and share plugin create/retry behavior
- add SmartBill admin Hono routes at `POST /v1/admin/smartbill/invoices/:id/sync`
- default-wire `SmartbillInvoicePanel` send/retry/proforma actions and document the new route/export surface

## Verification
- `pnpm --filter @voyantjs/plugin-smartbill exec biome check src tests --write`
- `pnpm --filter @voyantjs/plugin-smartbill typecheck`
- `pnpm --filter @voyantjs/plugin-smartbill test`
- `pnpm --filter @voyantjs/plugin-smartbill build`
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/finance test`
- `pnpm verify:package-exports`
- pre-push repo test lane passed

Closes #1180