### PR TITLE
Handle empty legal contract optionals

### DIFF
--- a/.changeset/legal-contract-empty-optionals.md
+++ b/.changeset/legal-contract-empty-optionals.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/legal": patch
+---
+
+Treat empty strings for optional legal contract fields as omitted during create/update validation.

--- a/packages/legal/src/contracts/validation.ts
+++ b/packages/legal/src/contracts/validation.ts
@@ -33,6 +33,13 @@ const paginationSchema = z.object({
   offset: z.coerce.number().int().min(0).default(0),
 })
 
+function optionalNullableString(schema: z.ZodString = z.string()) {
+  return z
+    .union([z.literal("").transform(() => undefined), schema])
+    .optional()
+    .nullable()
+}
+
 const contractTemplateBodySchema = z
   .string()
   .min(1)
@@ -123,19 +130,19 @@ export const contractNumberSeriesListQuerySchema = z.object({
 // ---------- contracts ----------
 
 const contractCoreSchema = z.object({
-  contractNumber: z.string().trim().min(1).max(100).optional().nullable(),
+  contractNumber: optionalNullableString(z.string().trim().min(1).max(100)),
   scope: contractScopeSchema,
   status: contractStatusSchema.default("draft"),
   title: z.string().min(1).max(500),
-  templateVersionId: z.string().optional().nullable(),
-  seriesId: z.string().optional().nullable(),
-  personId: z.string().optional().nullable(),
-  organizationId: z.string().optional().nullable(),
-  supplierId: z.string().optional().nullable(),
-  channelId: z.string().optional().nullable(),
-  bookingId: z.string().optional().nullable(),
-  orderId: z.string().optional().nullable(),
-  expiresAt: z.string().optional().nullable(),
+  templateVersionId: optionalNullableString(),
+  seriesId: optionalNullableString(),
+  personId: optionalNullableString(),
+  organizationId: optionalNullableString(),
+  supplierId: optionalNullableString(),
+  channelId: optionalNullableString(),
+  bookingId: optionalNullableString(),
+  orderId: optionalNullableString(),
+  expiresAt: optionalNullableString(),
   language: z.string().min(2).max(10).default("en"),
   variables: z.record(z.string(), z.unknown()).optional().nullable(),
   metadata: z.record(z.string(), z.unknown()).optional().nullable(),

--- a/packages/legal/tests/unit/validation.test.ts
+++ b/packages/legal/tests/unit/validation.test.ts
@@ -4,6 +4,7 @@ import {
   contractNumberSeriesListQuerySchema,
   contractTemplateListQuerySchema,
   insertContractSchema,
+  updateContractSchema,
 } from "../../src/contracts/validation.js"
 
 describe("legal contract validation", () => {
@@ -28,6 +29,54 @@ describe("legal contract validation", () => {
       }),
     ).toMatchObject({
       contractNumber: "A-169",
+    })
+  })
+
+  it("treats empty optional contract fields as omitted on create input", () => {
+    expect(
+      insertContractSchema.parse({
+        scope: "customer",
+        title: "Imported contract",
+        contractNumber: "M 162",
+        bookingId: "book_123",
+        personId: "",
+        organizationId: "",
+        supplierId: "",
+        seriesId: "",
+        expiresAt: "",
+        language: "ro",
+      }),
+    ).toMatchObject({
+      bookingId: "book_123",
+      personId: undefined,
+      organizationId: undefined,
+      supplierId: undefined,
+      seriesId: undefined,
+      expiresAt: undefined,
+    })
+  })
+
+  it("treats empty optional contract fields as omitted on update input", () => {
+    expect(
+      updateContractSchema.parse({
+        templateVersionId: "",
+        personId: "",
+        organizationId: "",
+        supplierId: "",
+        channelId: "",
+        bookingId: "",
+        orderId: "",
+        expiresAt: "",
+      }),
+    ).toEqual({
+      templateVersionId: undefined,
+      personId: undefined,
+      organizationId: undefined,
+      supplierId: undefined,
+      channelId: undefined,
+      bookingId: undefined,
+      orderId: undefined,
+      expiresAt: undefined,
     })
   })
 })


### PR DESCRIPTION
## Summary
- Normalize empty strings for optional legal contract string fields during create/update validation
- Add regression coverage for empty-string optional relation/date fields
- Add a patch changeset for @voyantjs/legal

Closes #1193

## Verification
- pnpm --filter @voyantjs/legal test -- tests/unit/validation.test.ts
- pnpm --filter @voyantjs/legal typecheck
- pnpm --filter @voyantjs/legal lint
- pnpm --filter @voyantjs/legal build
- pnpm --filter @voyantjs/legal-ui typecheck
- pnpm --filter operator typecheck
- pnpm --filter @voyantjs/workflows-orchestrator test -- src/__tests__/driver-compliance.test.ts

Note: the first pre-push suite hit a transient @voyantjs/workflows-orchestrator timing failure; the failed package test passed on rerun.