### PR TITLE
Enforce booking confirmed timestamp invariant

### DIFF
--- a/.changeset/bookings-confirmed-at-invariant.md
+++ b/.changeset/bookings-confirmed-at-invariant.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/bookings": patch
+---
+
+Keep booking `confirmedAt` aligned with the confirmed status during create, update, and status transitions.

--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -460,6 +460,23 @@ function toTimestamp(value?: string | null) {
   return value ? new Date(value) : null
 }
 
+function confirmedAtForStatus(status: BookingStatus, value: Date | null, now = new Date()) {
+  if (status !== "confirmed") return null
+  return value ?? now
+}
+
+function confirmedAtForBookingUpdate(
+  currentStatus: BookingStatus,
+  data: UpdateBookingInput,
+  now = new Date(),
+) {
+  const nextStatus = data.status ?? currentStatus
+  if (nextStatus !== "confirmed") return null
+  if (data.confirmedAt !== undefined)
+    return confirmedAtForStatus(nextStatus, toTimestamp(data.confirmedAt), now)
+  return currentStatus === "confirmed" ? undefined : now
+}
+
 function toDateValue(value: Date | string) {
   return value instanceof Date ? value : new Date(value)
 }
@@ -3323,10 +3340,12 @@ export const bookingsService = {
 
   async createBooking(db: PostgresJsDatabase, data: CreateBookingInput, userId?: string) {
     return db.transaction(async (tx) => {
+      const status = data.status ?? "draft"
       const [row] = await tx
         .insert(bookings)
         .values({
           ...data,
+          status,
           contactFirstName: data.contactFirstName ?? null,
           contactLastName: data.contactLastName ?? null,
           contactEmail: data.contactEmail ?? null,
@@ -3338,7 +3357,7 @@ export const bookingsService = {
           contactAddressLine1: data.contactAddressLine1 ?? null,
           contactPostalCode: data.contactPostalCode ?? null,
           holdExpiresAt: toTimestamp(data.holdExpiresAt),
-          confirmedAt: toTimestamp(data.confirmedAt),
+          confirmedAt: confirmedAtForStatus(status, toTimestamp(data.confirmedAt)),
           expiredAt: toTimestamp(data.expiredAt),
           cancelledAt: toTimestamp(data.cancelledAt),
           completedAt: toTimestamp(data.completedAt),
@@ -3362,41 +3381,54 @@ export const bookingsService = {
   },
 
   async updateBooking(db: PostgresJsDatabase, id: string, data: UpdateBookingInput) {
-    const [row] = await db
-      .update(bookings)
-      .set({
-        ...data,
-        contactFirstName:
-          data.contactFirstName === undefined ? undefined : (data.contactFirstName ?? null),
-        contactLastName:
-          data.contactLastName === undefined ? undefined : (data.contactLastName ?? null),
-        contactEmail: data.contactEmail === undefined ? undefined : (data.contactEmail ?? null),
-        contactPhone: data.contactPhone === undefined ? undefined : (data.contactPhone ?? null),
-        contactPreferredLanguage:
-          data.contactPreferredLanguage === undefined
-            ? undefined
-            : (data.contactPreferredLanguage ?? null),
-        contactCountry:
-          data.contactCountry === undefined ? undefined : (data.contactCountry ?? null),
-        contactRegion: data.contactRegion === undefined ? undefined : (data.contactRegion ?? null),
-        contactCity: data.contactCity === undefined ? undefined : (data.contactCity ?? null),
-        contactAddressLine1:
-          data.contactAddressLine1 === undefined ? undefined : (data.contactAddressLine1 ?? null),
-        contactPostalCode:
-          data.contactPostalCode === undefined ? undefined : (data.contactPostalCode ?? null),
-        holdExpiresAt:
-          data.holdExpiresAt === undefined ? undefined : toTimestamp(data.holdExpiresAt),
-        confirmedAt: data.confirmedAt === undefined ? undefined : toTimestamp(data.confirmedAt),
-        expiredAt: data.expiredAt === undefined ? undefined : toTimestamp(data.expiredAt),
-        cancelledAt: data.cancelledAt === undefined ? undefined : toTimestamp(data.cancelledAt),
-        completedAt: data.completedAt === undefined ? undefined : toTimestamp(data.completedAt),
-        redeemedAt: data.redeemedAt === undefined ? undefined : toTimestamp(data.redeemedAt),
-        updatedAt: new Date(),
-      })
-      .where(eq(bookings.id, id))
-      .returning()
+    return db.transaction(async (tx) => {
+      const rows = await tx.execute(
+        sql`SELECT status
+            FROM ${bookings}
+            WHERE ${bookings.id} = ${id}
+            FOR UPDATE`,
+      )
+      const existing = toRows<{ status: BookingStatus }>(rows)[0]
 
-    return row ?? null
+      if (!existing) return null
+
+      const [row] = await tx
+        .update(bookings)
+        .set({
+          ...data,
+          contactFirstName:
+            data.contactFirstName === undefined ? undefined : (data.contactFirstName ?? null),
+          contactLastName:
+            data.contactLastName === undefined ? undefined : (data.contactLastName ?? null),
+          contactEmail: data.contactEmail === undefined ? undefined : (data.contactEmail ?? null),
+          contactPhone: data.contactPhone === undefined ? undefined : (data.contactPhone ?? null),
+          contactPreferredLanguage:
+            data.contactPreferredLanguage === undefined
+              ? undefined
+              : (data.contactPreferredLanguage ?? null),
+          contactCountry:
+            data.contactCountry === undefined ? undefined : (data.contactCountry ?? null),
+          contactRegion:
+            data.contactRegion === undefined ? undefined : (data.contactRegion ?? null),
+          contactCity: data.contactCity === undefined ? undefined : (data.contactCity ?? null),
+          contactAddressLine1:
+            data.contactAddressLine1 === undefined ? undefined : (data.contactAddressLine1 ?? null),
+          contactPostalCode:
+            data.contactPostalCode === undefined ? undefined : (data.contactPostalCode ?? null),
+          holdExpiresAt:
+            data.holdExpiresAt === undefined ? undefined : toTimestamp(data.holdExpiresAt),
+          confirmedAt: confirmedAtForBookingUpdate(existing.status, data),
+          expiredAt: data.expiredAt === undefined ? undefined : toTimestamp(data.expiredAt),
+          cancelledAt: data.cancelledAt === undefined ? undefined : toTimestamp(data.cancelledAt),
+          completedAt: data.completedAt === undefined ? undefined : toTimestamp(data.completedAt),
+          redeemedAt: data.redeemedAt === undefined ? undefined : toTimestamp(data.redeemedAt),
+          updatedAt: new Date(),
+        })
+        .where(eq(bookings.id, id))
+        .returning()
+
+      return row ?? null
+    })
   },
 
   async deleteBooking(db: PostgresJsDatabase, id: string) {
@@ -4270,9 +4302,9 @@ export const bookingsService = {
         const now = new Date()
         const updates: Record<string, unknown> = {
           status: data.status,
+          confirmedAt: confirmedAtForStatus(data.status, null, now),
           updatedAt: now,
         }
-        if (data.status === "confirmed") updates.confirmedAt = now
         if (data.status === "expired") updates.expiredAt = now
         if (data.status === "cancelled") updates.cancelledAt = now
         if (data.status === "completed") updates.completedAt = now

--- a/packages/bookings/src/state-machine.ts
+++ b/packages/bookings/src/state-machine.ts
@@ -31,7 +31,7 @@ export function canTransitionBooking(from: BookingStatus, to: BookingStatus): bo
 
 export interface BookingStatusPatch {
   status: BookingStatus
-  confirmedAt?: Date
+  confirmedAt?: Date | null
   expiredAt?: Date
   cancelledAt?: Date
   completedAt?: Date
@@ -60,6 +60,8 @@ export function transitionBooking(
   if (to === "confirmed") {
     patch.confirmedAt = now
     if (from === "awaiting_payment") patch.paidAt = now
+  } else {
+    patch.confirmedAt = null
   }
   if (to === "expired") patch.expiredAt = now
   if (to === "cancelled") patch.cancelledAt = now

--- a/packages/bookings/tests/integration/routes.test.ts
+++ b/packages/bookings/tests/integration/routes.test.ts
@@ -902,6 +902,43 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
     })
   })
 
+  describe("Booking updates", () => {
+    it("clears confirmedAt when a generic update leaves the booking non-confirmed", async () => {
+      const booking = await seedBooking({
+        status: "draft",
+        confirmedAt: "2026-06-01T10:00:00.000Z",
+      })
+
+      expect(booking.status).toBe("draft")
+      expect(booking.confirmedAt).toBeNull()
+
+      const res = await app.request(`/${booking.id}`, {
+        method: "PATCH",
+        ...json({ confirmedAt: "2026-06-01T10:00:00.000Z" }),
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data.status).toBe("draft")
+      expect(body.data.confirmedAt).toBeNull()
+    })
+
+    it("clears confirmedAt when a generic update moves a booking out of confirmed", async () => {
+      const booking = await seedBooking({ status: "confirmed" })
+      expect(booking.confirmedAt).toBeTruthy()
+
+      const res = await app.request(`/${booking.id}`, {
+        method: "PATCH",
+        ...json({ status: "draft" }),
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data.status).toBe("draft")
+      expect(body.data.confirmedAt).toBeNull()
+    })
+  })
+
   describe("Reservation flow", () => {
     it("reserves a slot and creates on-hold allocations", async () => {
       const slot = await seedSlot()

--- a/packages/bookings/tests/unit/status-transitions.test.ts
+++ b/packages/bookings/tests/unit/status-transitions.test.ts
@@ -70,13 +70,14 @@ describe("transitionBooking()", () => {
     const now = new Date("2026-01-01T00:00:00Z")
     const patch = transitionBooking("confirmed", "cancelled", { now })
     expect(patch.cancelledAt).toEqual(now)
-    expect(patch.confirmedAt).toBeUndefined()
+    expect(patch.confirmedAt).toBeNull()
   })
 
   it("stamps expiredAt when transitioning to expired", () => {
     const now = new Date("2026-01-01T00:00:00Z")
     const patch = transitionBooking("on_hold", "expired", { now })
     expect(patch.expiredAt).toEqual(now)
+    expect(patch.confirmedAt).toBeNull()
   })
 
   it("stamps completedAt when transitioning to completed", () => {
@@ -87,7 +88,7 @@ describe("transitionBooking()", () => {
 
   it("does not stamp a timestamp when moving to in_progress (no dedicated column)", () => {
     const patch = transitionBooking("confirmed", "in_progress")
-    expect(patch.confirmedAt).toBeUndefined()
+    expect(patch.confirmedAt).toBeNull()
     expect(patch.cancelledAt).toBeUndefined()
     expect(patch.expiredAt).toBeUndefined()
     expect(patch.completedAt).toBeUndefined()


### PR DESCRIPTION
## Summary
- Clear `confirmedAt` whenever a booking create/update/override leaves the booking outside `confirmed`
- Make state-machine transitions clear `confirmedAt` on non-confirmed target statuses
- Add regression coverage for generic booking updates that previously left draft rows with `confirmedAt` set

Closes #1195

## Verification
- pnpm --filter @voyantjs/bookings test -- tests/unit/status-transitions.test.ts
- pnpm --filter @voyantjs/bookings typecheck
- pnpm --filter @voyantjs/bookings lint
- pnpm --filter @voyantjs/bookings build
- git diff --check