### PR TITLE
Allow override status to suppress lifecycle events

### DIFF
--- a/.changeset/bookings-override-status-lifecycle-events.md
+++ b/.changeset/bookings-override-status-lifecycle-events.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/bookings": patch
+"@voyantjs/bookings-react": patch
+---
+
+Allow booking status overrides to suppress confirmed lifecycle events while preserving audit events.

--- a/packages/bookings-react/src/hooks/use-booking-status-mutation.ts
+++ b/packages/bookings-react/src/hooks/use-booking-status-mutation.ts
@@ -24,6 +24,11 @@ export interface UpdateBookingStatusInput {
    * sending. Lets the operator confirm a booking silently.
    */
   suppressNotifications?: boolean
+  /**
+   * When true and the status change falls through to override-status, keep
+   * the audit event but skip verb-specific lifecycle events.
+   */
+  suppressLifecycleEvents?: boolean
 }
 
 export function useBookingStatusMutation(bookingId: string) {
@@ -37,7 +42,10 @@ export function useBookingStatusMutation(bookingId: string) {
         input.currentStatus,
         input.status,
         input.note,
-        { suppressNotifications: input.suppressNotifications },
+        {
+          suppressNotifications: input.suppressNotifications,
+          suppressLifecycleEvents: input.suppressLifecycleEvents,
+        },
       )
       const { data } = await fetchWithValidation(
         target.path,
@@ -77,9 +85,11 @@ export function useBookingStatusByIdMutation() {
       status,
       note,
       suppressNotifications,
+      suppressLifecycleEvents,
     }: UpdateBookingStatusByIdInput) => {
       const target = dispatchBookingStatusChange(bookingId, currentStatus, status, note, {
         suppressNotifications,
+        suppressLifecycleEvents,
       })
       const { data } = await fetchWithValidation(
         target.path,

--- a/packages/bookings/src/routes.ts
+++ b/packages/bookings/src/routes.ts
@@ -1843,7 +1843,8 @@ export const bookingRoutes = new Hono<Env>()
   // 11c. POST /:id/override-status — Admin override that bypasses the
   // transition graph. Updates the booking row only — no cascade to items,
   // allocations, or fulfillments. Always emits booking.status_overridden for
-  // audit. Requires a non-empty `reason`.
+  // audit. Confirmed overrides also emit booking.confirmed unless
+  // suppressLifecycleEvents is true. Requires a non-empty `reason`.
   .post("/:id/override-status", async (c) => {
     const bookingId = c.req.param("id")
     const data = await parseJsonBody(c, overrideBookingStatusSchema)

--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -4362,12 +4362,10 @@ export const bookingsService = {
           } satisfies BookingStatusOverriddenEvent,
           { category: "domain", source: "service" },
         )
-        // Also emit `booking.confirmed` when the override target is
-        // confirmed so subscribers (auto-dispatch, contract auto-gen)
-        // fire — the dialog's "Confirm after creating" flow goes
-        // through override-status for draft → confirmed and would
-        // otherwise leave those subscribers silent.
-        if (result.toStatus === "confirmed") {
+        // Keep draft → confirmed overrides compatible with the create dialog,
+        // but let data-correction callers preserve the audit event without
+        // re-running the full confirm lifecycle.
+        if (result.toStatus === "confirmed" && data.suppressLifecycleEvents !== true) {
           await runtime.eventBus?.emit(
             "booking.confirmed",
             {

--- a/packages/bookings/src/status-dispatch.ts
+++ b/packages/bookings/src/status-dispatch.ts
@@ -33,7 +33,7 @@ export function dispatchBookingStatusChange(
   current: BookingStatus,
   target: BookingStatus,
   note?: string | null,
-  options?: { suppressNotifications?: boolean },
+  options?: { suppressNotifications?: boolean; suppressLifecycleEvents?: boolean },
 ): BookingStatusDispatchTarget {
   const noteBody = note ? { note } : {}
   // Only carry the suppression flag on transitions to `confirmed` —
@@ -42,6 +42,10 @@ export function dispatchBookingStatusChange(
   const suppress =
     target === "confirmed" && options?.suppressNotifications === true
       ? { suppressNotifications: true }
+      : {}
+  const lifecycleSuppression =
+    target === "confirmed" && options?.suppressLifecycleEvents === true
+      ? { suppressLifecycleEvents: true }
       : {}
 
   if (current === "on_hold" && target === "confirmed") {
@@ -78,6 +82,12 @@ export function dispatchBookingStatusChange(
   const reason = note?.trim() || defaultReason
   return {
     path: `/v1/bookings/${bookingId}/override-status`,
-    body: { status: target, reason, ...(note ? { note } : {}), ...suppress },
+    body: {
+      status: target,
+      reason,
+      ...(note ? { note } : {}),
+      ...suppress,
+      ...lifecycleSuppression,
+    },
   }
 }

--- a/packages/bookings/src/validation.ts
+++ b/packages/bookings/src/validation.ts
@@ -351,17 +351,24 @@ export const completeBookingSchema = z.object({
  * the operator has to explain why they're bypassing lifecycle laws. Use the
  * verb-specific endpoints (/confirm, /cancel, /start, /complete, /expire) for
  * normal state changes; this is for data-correction and exceptional cases.
+ * Confirmed overrides emit `booking.confirmed` by default for create-dialog
+ * compatibility; pass `suppressLifecycleEvents` for pure data correction.
  */
 export const overrideBookingStatusSchema = z.object({
   status: bookingStatusSchema,
   reason: z.string().min(1).max(2000),
   note: z.string().optional().nullable(),
   /**
-   * Same opt-out as `confirmBookingSchema.suppressNotifications`. The
-   * override-status path also emits `booking.confirmed` when the target
-   * is `confirmed`, so subscribers need the same hint.
+   * Same notification opt-out as `confirmBookingSchema.suppressNotifications`.
+   * Only applies when the override path emits `booking.confirmed`.
    */
   suppressNotifications: z.boolean().optional(),
+  /**
+   * When true, skip verb-specific lifecycle events such as
+   * `booking.confirmed`. The audit event `booking.status_overridden` still
+   * emits either way.
+   */
+  suppressLifecycleEvents: z.boolean().optional(),
 })
 
 export const reserveBookingFromTransactionSchema = bookingCoreSchema

--- a/packages/bookings/tests/integration/routes.test.ts
+++ b/packages/bookings/tests/integration/routes.test.ts
@@ -1874,6 +1874,80 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
       expect(received).toHaveLength(0)
     })
 
+    it("emits booking.confirmed for confirmed override by default", async () => {
+      const draft = await seedBooking()
+
+      const confirmedEvents: unknown[] = []
+      const statusOverrideEvents: unknown[] = []
+      const confirmedSub = eventBus.subscribe("booking.confirmed", (event) => {
+        confirmedEvents.push(event.data)
+      })
+      const overrideSub = eventBus.subscribe("booking.status_overridden", (event) => {
+        statusOverrideEvents.push(event.data)
+      })
+
+      try {
+        const res = await app.request(`/${draft.id}/override-status`, {
+          method: "POST",
+          ...json({
+            status: "confirmed",
+            reason: "Confirm after create",
+          }),
+        })
+        expect(res.status).toBe(200)
+      } finally {
+        confirmedSub.unsubscribe()
+        overrideSub.unsubscribe()
+      }
+
+      expect(statusOverrideEvents).toHaveLength(1)
+      expect(confirmedEvents).toHaveLength(1)
+      expect(confirmedEvents[0]).toMatchObject({
+        bookingId: draft.id,
+        bookingNumber: draft.bookingNumber,
+        actorId: "test-user-id",
+      })
+    })
+
+    it("suppresses booking.confirmed for confirmed override while keeping audit event", async () => {
+      const draft = await seedBooking()
+
+      const confirmedEvents: unknown[] = []
+      const statusOverrideEvents: unknown[] = []
+      const confirmedSub = eventBus.subscribe("booking.confirmed", (event) => {
+        confirmedEvents.push(event.data)
+      })
+      const overrideSub = eventBus.subscribe("booking.status_overridden", (event) => {
+        statusOverrideEvents.push(event.data)
+      })
+
+      try {
+        const res = await app.request(`/${draft.id}/override-status`, {
+          method: "POST",
+          ...json({
+            status: "confirmed",
+            reason: "Correct imported status",
+            suppressLifecycleEvents: true,
+          }),
+        })
+        expect(res.status).toBe(200)
+      } finally {
+        confirmedSub.unsubscribe()
+        overrideSub.unsubscribe()
+      }
+
+      expect(statusOverrideEvents).toHaveLength(1)
+      expect(statusOverrideEvents[0]).toMatchObject({
+        bookingId: draft.id,
+        bookingNumber: draft.bookingNumber,
+        fromStatus: "draft",
+        toStatus: "confirmed",
+        reason: "Correct imported status",
+        actorId: "test-user-id",
+      })
+      expect(confirmedEvents).toHaveLength(0)
+    })
+
     it("extends an on-hold booking", async () => {
       const slot = await seedSlot()
       const reserveRes = await app.request("/reserve", {

--- a/packages/bookings/tests/unit/status-dispatch.test.ts
+++ b/packages/bookings/tests/unit/status-dispatch.test.ts
@@ -99,4 +99,33 @@ describe("dispatchBookingStatusChange — override fallback", () => {
       note: "manual confirm",
     })
   })
+
+  it("can suppress lifecycle events on confirmed override fallbacks", () => {
+    const target = dispatchBookingStatusChange(
+      BOOKING_ID,
+      "draft",
+      "confirmed",
+      "data correction",
+      { suppressLifecycleEvents: true },
+    )
+    expect(target.path).toBe(`/v1/bookings/${BOOKING_ID}/override-status`)
+    expect(target.body).toEqual({
+      status: "confirmed",
+      reason: "data correction",
+      note: "data correction",
+      suppressLifecycleEvents: true,
+    })
+  })
+
+  it("does not send lifecycle suppression to named confirm route", () => {
+    const target = dispatchBookingStatusChange(
+      BOOKING_ID,
+      "on_hold",
+      "confirmed",
+      "normal confirm",
+      { suppressLifecycleEvents: true },
+    )
+    expect(target.path).toBe(`/v1/bookings/${BOOKING_ID}/confirm`)
+    expect(target.body).toEqual({ note: "normal confirm" })
+  })
 })

--- a/packages/bookings/tests/unit/validation-booking.test.ts
+++ b/packages/bookings/tests/unit/validation-booking.test.ts
@@ -206,6 +206,15 @@ describe("Override booking status schema", () => {
     })
     expect(result.note).toBe("Customer cancelled by phone")
   })
+
+  it("accepts lifecycle event suppression", () => {
+    const result = overrideBookingStatusSchema.parse({
+      status: "confirmed",
+      reason: "Data correction",
+      suppressLifecycleEvents: true,
+    })
+    expect(result.suppressLifecycleEvents).toBe(true)
+  })
 })
 
 describe("Convert product schema", () => {


### PR DESCRIPTION
## Summary
- Add `suppressLifecycleEvents` to booking override status payloads
- Keep `booking.status_overridden` audit events while skipping `booking.confirmed` when requested
- Thread the flag through status dispatch/react mutation helpers and add regression coverage

Closes #1198

## Verification
- `pnpm --filter @voyantjs/bookings test -- tests/unit/validation-booking.test.ts tests/unit/status-dispatch.test.ts`
- `pnpm --filter @voyantjs/bookings typecheck`
- `pnpm --filter @voyantjs/bookings-react typecheck`
- `pnpm --filter @voyantjs/bookings lint`
- `pnpm --filter @voyantjs/bookings-react lint`
- `pnpm --filter @voyantjs/bookings build`
- `pnpm --filter @voyantjs/bookings-react build`
- `git diff --check`