### PR TITLE
Add idempotency to admin create routes

### DIFF
--- a/.changeset/quiet-create-idempotency.md
+++ b/.changeset/quiet-create-idempotency.md
@@ -1,0 +1,8 @@
+---
+"@voyantjs/crm": patch
+"@voyantjs/finance": patch
+"@voyantjs/hono": patch
+"@voyantjs/legal": patch
+---
+
+Add `Idempotency-Key` replay support to admin create routes for CRM people and organizations, finance invoices, and legal contracts.

--- a/packages/crm/src/routes/accounts.ts
+++ b/packages/crm/src/routes/accounts.ts
@@ -1,4 +1,4 @@
-import { parseJsonBody, parseQuery, requireUserId } from "@voyantjs/hono"
+import { idempotencyKey, parseJsonBody, parseQuery, requireUserId } from "@voyantjs/hono"
 import {
   insertAddressSchema,
   insertContactPointSchema,
@@ -43,17 +43,21 @@ export const accountRoutes = new Hono<Env>()
     const query = parseQuery(c, organizationListQuerySchema)
     return c.json(await crmService.listOrganizations(c.get("db"), query))
   })
-  .post("/organizations", async (c) => {
-    return c.json(
-      {
-        data: await crmService.createOrganization(
-          c.get("db"),
-          await parseJsonBody(c, insertOrganizationSchema),
-        ),
-      },
-      201,
-    )
-  })
+  .post(
+    "/organizations",
+    idempotencyKey({ scope: "POST /v1/admin/crm/organizations" }),
+    async (c) => {
+      return c.json(
+        {
+          data: await crmService.createOrganization(
+            c.get("db"),
+            await parseJsonBody(c, insertOrganizationSchema),
+          ),
+        },
+        201,
+      )
+    },
+  )
   .get("/organizations/:id", async (c) => {
     const row = await crmService.getOrganizationById(c.get("db"), c.req.param("id"))
     if (!row) return c.json({ error: "Organization not found" }, 404)
@@ -146,7 +150,7 @@ export const accountRoutes = new Hono<Env>()
     const query = parseQuery(c, personListQuerySchema)
     return c.json(await crmService.listPeople(c.get("db"), query))
   })
-  .post("/people", async (c) => {
+  .post("/people", idempotencyKey({ scope: "POST /v1/admin/crm/people" }), async (c) => {
     return c.json(
       {
         data: await crmService.createPerson(

--- a/packages/crm/tests/integration/accounts.test.ts
+++ b/packages/crm/tests/integration/accounts.test.ts
@@ -8,6 +8,10 @@ const json = (body: Record<string, unknown>) => ({
   headers: { "Content-Type": "application/json" },
   body: JSON.stringify(body),
 })
+const jsonWithIdempotency = (body: Record<string, unknown>, key: string) => ({
+  headers: { "Content-Type": "application/json", "Idempotency-Key": key },
+  body: JSON.stringify(body),
+})
 
 describe.skipIf(!DB_AVAILABLE)("Account routes", () => {
   let app: Hono
@@ -43,6 +47,25 @@ describe.skipIf(!DB_AVAILABLE)("Account routes", () => {
       expect(body.data.name).toBe("Acme Corp")
       expect(body.data.id).toBeTruthy()
       expect(body.data.status).toBe("active")
+    })
+
+    it("replays organization creates with the same idempotency key", async () => {
+      const input = { name: "Idempotent Org" }
+      const first = await app.request("/organizations", {
+        method: "POST",
+        ...jsonWithIdempotency(input, "crm-org-create-1"),
+      })
+      const replay = await app.request("/organizations", {
+        method: "POST",
+        ...jsonWithIdempotency(input, "crm-org-create-1"),
+      })
+
+      expect(first.status).toBe(201)
+      expect(replay.status).toBe(201)
+      expect(replay.headers.get("Idempotency-Replayed")).toBe("true")
+      const firstBody = await first.json()
+      const replayBody = await replay.json()
+      expect(replayBody.data.id).toBe(firstBody.data.id)
     })
 
     it("lists organizations", async () => {
@@ -141,6 +164,25 @@ describe.skipIf(!DB_AVAILABLE)("Account routes", () => {
       expect(body.data.firstName).toBe("John")
       expect(body.data.lastName).toBe("Doe")
       expect(body.data.id).toBeTruthy()
+    })
+
+    it("replays person creates with the same idempotency key", async () => {
+      const input = { firstName: "Idempotent", lastName: "Person" }
+      const first = await app.request("/people", {
+        method: "POST",
+        ...jsonWithIdempotency(input, "crm-person-create-1"),
+      })
+      const replay = await app.request("/people", {
+        method: "POST",
+        ...jsonWithIdempotency(input, "crm-person-create-1"),
+      })
+
+      expect(first.status).toBe(201)
+      expect(replay.status).toBe(201)
+      expect(replay.headers.get("Idempotency-Replayed")).toBe("true")
+      const firstBody = await first.json()
+      const replayBody = await replay.json()
+      expect(replayBody.data.id).toBe(firstBody.data.id)
     })
 
     it("reflects contact-point updates without an explicit rebuild (#446 view)", async () => {

--- a/packages/finance/src/routes.ts
+++ b/packages/finance/src/routes.ts
@@ -1,4 +1,4 @@
-import { parseJsonBody, parseQuery, requireUserId } from "@voyantjs/hono"
+import { idempotencyKey, parseJsonBody, parseQuery, requireUserId } from "@voyantjs/hono"
 import type { Context } from "hono"
 import { Hono } from "hono"
 
@@ -101,6 +101,9 @@ import {
 // ==========================================================================
 
 const DEFAULT_RENDITION_WAIT_TIMEOUT_MS = 30_000
+
+const routeIdempotencyKey = (scope: string) =>
+  idempotencyKey<Env["Bindings"], Env["Variables"]>({ scope })
 
 function resolveWaitRequest(
   body: { wait?: InvoiceRenditionWaitMode; waitTimeoutMs?: number | undefined },
@@ -927,7 +930,7 @@ export const financeRoutes = new Hono<Env>()
   })
 
   // POST /invoices — Create invoice
-  .post("/invoices", async (c) => {
+  .post("/invoices", routeIdempotencyKey("POST /v1/admin/finance/invoices"), async (c) => {
     return c.json(
       {
         data: await financeService.createInvoice(
@@ -940,147 +943,154 @@ export const financeRoutes = new Hono<Env>()
   })
 
   // POST /invoices/from-booking — Create + issue invoice/proforma from a booking or schedule row
-  .post("/invoices/from-booking", async (c) => {
-    const input = await parseJsonBody(c, invoiceFromBookingSchema)
-    const waitRequest = resolveWaitRequest(input, parseQuery(c, invoiceDocumentWaitQuerySchema))
-    const db = c.get("db")
-    const [
-      { bookingItems, bookings },
-      { bookingPaymentSchedules },
-      { and, eq },
-      { issueInvoiceFromBooking, issueProformaFromBooking },
-    ] = await Promise.all([
-      import("@voyantjs/bookings/schema"),
-      import("./schema.js"),
-      import("drizzle-orm"),
-      import("./service-issue.js"),
-    ])
+  .post(
+    "/invoices/from-booking",
+    routeIdempotencyKey("POST /v1/admin/finance/invoices/from-booking"),
+    async (c) => {
+      const input = await parseJsonBody(c, invoiceFromBookingSchema)
+      const waitRequest = resolveWaitRequest(input, parseQuery(c, invoiceDocumentWaitQuerySchema))
+      const db = c.get("db")
+      const [
+        { bookingItems, bookings },
+        { bookingPaymentSchedules },
+        { and, eq },
+        { issueInvoiceFromBooking, issueProformaFromBooking },
+      ] = await Promise.all([
+        import("@voyantjs/bookings/schema"),
+        import("./schema.js"),
+        import("drizzle-orm"),
+        import("./service-issue.js"),
+      ])
 
-    const [booking] = await db
-      .select()
-      .from(bookings)
-      .where(eq(bookings.id, input.bookingId))
-      .limit(1)
+      const [booking] = await db
+        .select()
+        .from(bookings)
+        .where(eq(bookings.id, input.bookingId))
+        .limit(1)
 
-    if (!booking) {
-      return c.json({ error: "Booking not found" }, 404)
-    }
+      if (!booking) {
+        return c.json({ error: "Booking not found" }, 404)
+      }
 
-    const items = await db.select().from(bookingItems).where(eq(bookingItems.bookingId, booking.id))
-    const [paymentSchedule] = input.bookingPaymentScheduleId
-      ? await db
-          .select()
-          .from(bookingPaymentSchedules)
-          .where(
-            and(
-              eq(bookingPaymentSchedules.id, input.bookingPaymentScheduleId),
-              eq(bookingPaymentSchedules.bookingId, booking.id),
-            ),
-          )
-          .limit(1)
-      : []
+      const items = await db
+        .select()
+        .from(bookingItems)
+        .where(eq(bookingItems.bookingId, booking.id))
+      const [paymentSchedule] = input.bookingPaymentScheduleId
+        ? await db
+            .select()
+            .from(bookingPaymentSchedules)
+            .where(
+              and(
+                eq(bookingPaymentSchedules.id, input.bookingPaymentScheduleId),
+                eq(bookingPaymentSchedules.bookingId, booking.id),
+              ),
+            )
+            .limit(1)
+        : []
 
-    if (input.bookingPaymentScheduleId && !paymentSchedule) {
-      return c.json({ error: "Booking payment schedule not found" }, 404)
-    }
+      if (input.bookingPaymentScheduleId && !paymentSchedule) {
+        return c.json({ error: "Booking payment schedule not found" }, 404)
+      }
 
-    const runtime = (() => {
+      const runtime = (() => {
+        try {
+          return c.var.container?.resolve<FinanceRouteRuntime>(FINANCE_ROUTE_RUNTIME_CONTAINER_KEY)
+        } catch {
+          return undefined
+        }
+      })()
+
+      const issuer =
+        input.invoiceType === "proforma" ? issueProformaFromBooking : issueInvoiceFromBooking
+
+      let row: Awaited<ReturnType<typeof issuer>>
       try {
-        return c.var.container?.resolve<FinanceRouteRuntime>(FINANCE_ROUTE_RUNTIME_CONTAINER_KEY)
-      } catch {
-        return undefined
-      }
-    })()
-
-    const issuer =
-      input.invoiceType === "proforma" ? issueProformaFromBooking : issueInvoiceFromBooking
-
-    let row: Awaited<ReturnType<typeof issuer>>
-    try {
-      row = await issuer(
-        db,
-        input,
-        {
-          booking: {
-            id: booking.id,
-            bookingNumber: booking.bookingNumber,
-            personId: booking.personId,
-            organizationId: booking.organizationId,
-            sellCurrency: booking.sellCurrency,
-            baseCurrency: booking.baseCurrency,
-            fxRateSetId: null,
-            sellAmountCents: booking.sellAmountCents,
-            baseSellAmountCents: booking.baseSellAmountCents,
-          },
-          paymentSchedule: paymentSchedule
-            ? {
-                id: paymentSchedule.id,
-                bookingId: paymentSchedule.bookingId,
-                bookingItemId: paymentSchedule.bookingItemId,
-                scheduleType: paymentSchedule.scheduleType,
-                dueDate: paymentSchedule.dueDate,
-                currency: paymentSchedule.currency,
-                amountCents: paymentSchedule.amountCents,
-              }
-            : null,
-          items: items.map((item) => ({
-            id: item.id,
-            title: item.title,
-            quantity: item.quantity,
-            unitSellAmountCents: item.unitSellAmountCents,
-            totalSellAmountCents: item.totalSellAmountCents,
-          })),
-        },
-        {
-          eventBus: runtime?.eventBus,
-          actionLedgerContext: getActionLedgerRequestContext(c),
-          actionLedgerAuthorizationSource: "finance.invoice.from_booking.route",
-        },
-      )
-    } catch (error) {
-      if (error instanceof InvoiceNumberAllocationError) {
-        return c.json(
-          { error: error.code, scope: error.scope, seriesId: error.seriesId ?? null },
-          409,
-        )
-      }
-      if (error instanceof InvoiceNumberConflictError) {
-        return c.json(
+        row = await issuer(
+          db,
+          input,
           {
-            error: "Invoice number already exists",
-            code: error.code,
-            invoiceNumber: error.invoiceNumber,
+            booking: {
+              id: booking.id,
+              bookingNumber: booking.bookingNumber,
+              personId: booking.personId,
+              organizationId: booking.organizationId,
+              sellCurrency: booking.sellCurrency,
+              baseCurrency: booking.baseCurrency,
+              fxRateSetId: null,
+              sellAmountCents: booking.sellAmountCents,
+              baseSellAmountCents: booking.baseSellAmountCents,
+            },
+            paymentSchedule: paymentSchedule
+              ? {
+                  id: paymentSchedule.id,
+                  bookingId: paymentSchedule.bookingId,
+                  bookingItemId: paymentSchedule.bookingItemId,
+                  scheduleType: paymentSchedule.scheduleType,
+                  dueDate: paymentSchedule.dueDate,
+                  currency: paymentSchedule.currency,
+                  amountCents: paymentSchedule.amountCents,
+                }
+              : null,
+            items: items.map((item) => ({
+              id: item.id,
+              title: item.title,
+              quantity: item.quantity,
+              unitSellAmountCents: item.unitSellAmountCents,
+              totalSellAmountCents: item.totalSellAmountCents,
+            })),
           },
-          409,
+          {
+            eventBus: runtime?.eventBus,
+            actionLedgerContext: getActionLedgerRequestContext(c),
+            actionLedgerAuthorizationSource: "finance.invoice.from_booking.route",
+          },
         )
+      } catch (error) {
+        if (error instanceof InvoiceNumberAllocationError) {
+          return c.json(
+            { error: error.code, scope: error.scope, seriesId: error.seriesId ?? null },
+            409,
+          )
+        }
+        if (error instanceof InvoiceNumberConflictError) {
+          return c.json(
+            {
+              error: "Invoice number already exists",
+              code: error.code,
+              invoiceNumber: error.invoiceNumber,
+            },
+            409,
+          )
+        }
+        throw error
       }
-      throw error
-    }
 
-    if (!row || waitRequest.mode === "none") {
-      return c.json({ data: row }, 201)
-    }
+      if (!row || waitRequest.mode === "none") {
+        return c.json({ data: row }, 201)
+      }
 
-    const waitResult = await waitForInvoiceRendition(db, row.id, {
-      format: waitFormatForMode(waitRequest.mode),
-      timeoutMs: waitRequest.timeoutMs,
-    })
-    const payload = {
-      invoice: row,
-      rendition: waitResult.rendition,
-    }
+      const waitResult = await waitForInvoiceRendition(db, row.id, {
+        format: waitFormatForMode(waitRequest.mode),
+        timeoutMs: waitRequest.timeoutMs,
+      })
+      const payload = {
+        invoice: row,
+        rendition: waitResult.rendition,
+      }
 
-    if (waitResult.status !== "ready") {
-      return c.json({ data: payload }, 202)
-    }
+      if (waitResult.status !== "ready") {
+        return c.json({ data: payload }, 202)
+      }
 
-    const download = await buildInlineDownload(c, waitResult.rendition)
-    if (download.status !== "ready") {
-      return c.json({ data: payload }, 202)
-    }
+      const download = await buildInlineDownload(c, waitResult.rendition)
+      if (download.status !== "ready") {
+        return c.json({ data: payload }, 202)
+      }
 
-    return c.json({ data: { ...payload, download: download.download } }, 201)
-  })
+      return c.json({ data: { ...payload, download: download.download } }, 201)
+    },
+  )
 
   // POST /invoices/:id/convert-to-invoice — Convert a proforma into a final invoice
   .post("/invoices/:id/convert-to-invoice", async (c) => {

--- a/packages/finance/src/routes.ts
+++ b/packages/finance/src/routes.ts
@@ -102,8 +102,10 @@ import {
 
 const DEFAULT_RENDITION_WAIT_TIMEOUT_MS = 30_000
 
-const routeIdempotencyKey = (scope: string) =>
-  idempotencyKey<Env["Bindings"], Env["Variables"]>({ scope })
+const routeIdempotencyKey = (
+  scope: string,
+  options: { fingerprintSearchParams?: readonly string[] } = {},
+) => idempotencyKey<Env["Bindings"], Env["Variables"]>({ scope, ...options })
 
 function resolveWaitRequest(
   body: { wait?: InvoiceRenditionWaitMode; waitTimeoutMs?: number | undefined },
@@ -945,7 +947,9 @@ export const financeRoutes = new Hono<Env>()
   // POST /invoices/from-booking — Create + issue invoice/proforma from a booking or schedule row
   .post(
     "/invoices/from-booking",
-    routeIdempotencyKey("POST /v1/admin/finance/invoices/from-booking"),
+    routeIdempotencyKey("POST /v1/admin/finance/invoices/from-booking", {
+      fingerprintSearchParams: ["wait", "waitTimeoutMs"],
+    }),
     async (c) => {
       const input = await parseJsonBody(c, invoiceFromBookingSchema)
       const waitRequest = resolveWaitRequest(input, parseQuery(c, invoiceDocumentWaitQuerySchema))

--- a/packages/finance/tests/integration/routes.test.ts
+++ b/packages/finance/tests/integration/routes.test.ts
@@ -24,6 +24,10 @@ const json = (body: Record<string, unknown>) => ({
   headers: { "Content-Type": "application/json" },
   body: JSON.stringify(body),
 })
+const jsonWithIdempotency = (body: Record<string, unknown>, key: string) => ({
+  headers: { "Content-Type": "application/json", "Idempotency-Key": key },
+  body: JSON.stringify(body),
+})
 
 let seq = 0
 function nextInvoiceNumber() {
@@ -1108,6 +1112,37 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       expect(inv.currency).toBe("USD")
     })
 
+    it("replays invoice creates with the same idempotency key", async () => {
+      const booking = await seedBooking()
+      const input = {
+        invoiceNumber: nextInvoiceNumber(),
+        bookingId: booking.id,
+        currency: "USD",
+        issueDate: "2025-06-01",
+        dueDate: "2025-07-01",
+        subtotalCents: 100000,
+        taxCents: 10000,
+        totalCents: 110000,
+        balanceDueCents: 110000,
+      }
+
+      const first = await app.request("/invoices", {
+        method: "POST",
+        ...jsonWithIdempotency(input, "finance-invoice-create-1"),
+      })
+      const replay = await app.request("/invoices", {
+        method: "POST",
+        ...jsonWithIdempotency(input, "finance-invoice-create-1"),
+      })
+
+      expect(first.status).toBe(201)
+      expect(replay.status).toBe(201)
+      expect(replay.headers.get("Idempotency-Replayed")).toBe("true")
+      const firstBody = await first.json()
+      const replayBody = await replay.json()
+      expect(replayBody.data.id).toBe(firstBody.data.id)
+    })
+
     it("gets an invoice by id", async () => {
       const booking = await seedBooking()
       const inv = await seedInvoice(booking.id)
@@ -1336,6 +1371,33 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       // Should have subtotal based on items
       expect(data.subtotalCents).toBeGreaterThan(0)
       expect(data.balanceDueCents).toBeGreaterThan(0)
+    })
+
+    it("replays invoice-from-booking creates with the same idempotency key", async () => {
+      const booking = await seedBooking({ sellAmountCents: 20000 })
+      await seedBookingItem(booking.id)
+      const input = {
+        bookingId: booking.id,
+        invoiceNumber: nextInvoiceNumber(),
+        issueDate: "2025-06-01",
+        dueDate: "2025-07-01",
+      }
+
+      const first = await app.request("/invoices/from-booking", {
+        method: "POST",
+        ...jsonWithIdempotency(input, "finance-invoice-from-booking-1"),
+      })
+      const replay = await app.request("/invoices/from-booking", {
+        method: "POST",
+        ...jsonWithIdempotency(input, "finance-invoice-from-booking-1"),
+      })
+
+      expect(first.status).toBe(201)
+      expect(replay.status).toBe(201)
+      expect(replay.headers.get("Idempotency-Replayed")).toBe("true")
+      const firstBody = await first.json()
+      const replayBody = await replay.json()
+      expect(replayBody.data.id).toBe(firstBody.data.id)
     })
 
     it("creates an invoice from a booking without items (fallback)", async () => {

--- a/packages/finance/tests/integration/routes.test.ts
+++ b/packages/finance/tests/integration/routes.test.ts
@@ -1141,6 +1141,12 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       const firstBody = await first.json()
       const replayBody = await replay.json()
       expect(replayBody.data.id).toBe(firstBody.data.id)
+
+      const conflict = await app.request("/invoices/from-booking?wait=pdf", {
+        method: "POST",
+        ...jsonWithIdempotency(input, "finance-invoice-from-booking-1"),
+      })
+      expect(conflict.status).toBe(409)
     })
 
     it("gets an invoice by id", async () => {

--- a/packages/hono/src/middleware/idempotency-key.ts
+++ b/packages/hono/src/middleware/idempotency-key.ts
@@ -87,11 +87,14 @@ declare module "hono" {
  * the `db` middleware that ships with `createApp`) — caller is responsible
  * for ordering this middleware after `db`.
  */
-export function idempotencyKey<TBindings extends VoyantBindings = VoyantBindings>(
+export function idempotencyKey<
+  TBindings extends object = VoyantBindings,
+  TVariables extends { db: VoyantDb } = VoyantVariables,
+>(
   options: IdempotencyKeyOptions = {},
 ): MiddlewareHandler<{
   Bindings: TBindings
-  Variables: VoyantVariables
+  Variables: TVariables
 }> {
   const ttlMs = options.ttlMs ?? DEFAULT_IDEMPOTENCY_TTL_MS
 

--- a/packages/hono/src/middleware/idempotency-key.ts
+++ b/packages/hono/src/middleware/idempotency-key.ts
@@ -51,6 +51,13 @@ export interface IdempotencyKeyOptions {
    */
   required?: boolean
   /**
+   * Query parameters that affect the response contract and should be included
+   * in the idempotency fingerprint alongside the request body. Reusing the
+   * same key with different fingerprinted query values returns 409 instead of
+   * replaying a response captured under different request semantics.
+   */
+  fingerprintSearchParams?: readonly string[]
+  /**
    * Optional callback that, given the response body that's about to be
    * stored, returns a `referenceId` (typically the booking id). Used for
    * operational queries to correlate replays with the underlying entity.
@@ -113,9 +120,12 @@ export function idempotencyKey<
       return c.json({ error: `${HEADER_NAME} must be 255 characters or fewer` }, 400)
     }
 
-    const scope = options.scope ?? `${c.req.method} ${new URL(c.req.url).pathname}`
+    const requestUrl = new URL(c.req.url)
+    const scope = options.scope ?? `${c.req.method} ${requestUrl.pathname}`
     const rawBody = await c.req.text()
-    const bodyHash = await sha256Hex(rawBody)
+    const bodyHash = await sha256Hex(
+      buildFingerprintInput(rawBody, requestUrl, options.fingerprintSearchParams),
+    )
     // The `db` middleware always unwraps a `DisposableDb` to a plain
     // `VoyantDb` before storing on context, so this cast is safe.
     const db = c.get("db") as VoyantDb | undefined
@@ -227,6 +237,21 @@ export function idempotencyKey<
       // for this request." Logging is the deployment's responsibility.
     }
   }
+}
+
+function buildFingerprintInput(
+  rawBody: string,
+  url: URL,
+  searchParamKeys: readonly string[] | undefined,
+): string {
+  if (!searchParamKeys?.length) return rawBody
+
+  const queryFingerprint = searchParamKeys.map((key) => [key, url.searchParams.getAll(key).sort()])
+
+  return JSON.stringify({
+    body: rawBody,
+    query: queryFingerprint,
+  })
 }
 
 function pickStringField(body: unknown, keys: string[]): string | null {

--- a/packages/hono/tests/unit/idempotency-key.test.ts
+++ b/packages/hono/tests/unit/idempotency-key.test.ts
@@ -223,6 +223,48 @@ describe("idempotencyKey middleware", () => {
     expect(body.error).toMatch(/different request body/)
   })
 
+  it("returns 409 when fingerprinted query params change under the same key", async () => {
+    const fakeDb = createFakeDb()
+    const app = new Hono()
+    let calls = 0
+    app.use("*", async (c, next) => {
+      // biome-ignore lint/suspicious/noExplicitAny: test fake
+      c.set("db", fakeDb as any)
+      await next()
+    })
+    app.post(
+      "/things",
+      idempotencyKey({ scope: "test", fingerprintSearchParams: ["wait"] }),
+      (c) => {
+        calls++
+        return c.json({ id: `book_${calls}` }, 201)
+      },
+    )
+
+    const first = await app.request("/things?wait=none", {
+      method: "POST",
+      headers: { "content-type": "application/json", "Idempotency-Key": "k1" },
+      body: JSON.stringify({ foo: 1 }),
+    })
+    expect(first.status).toBe(201)
+
+    const replay = await app.request("/things?wait=none", {
+      method: "POST",
+      headers: { "content-type": "application/json", "Idempotency-Key": "k1" },
+      body: JSON.stringify({ foo: 1 }),
+    })
+    expect(replay.status).toBe(201)
+    expect(replay.headers.get("Idempotency-Replayed")).toBe("true")
+
+    const conflict = await app.request("/things?wait=pdf", {
+      method: "POST",
+      headers: { "content-type": "application/json", "Idempotency-Key": "k1" },
+      body: JSON.stringify({ foo: 1 }),
+    })
+    expect(conflict.status).toBe(409)
+    expect(calls).toBe(1)
+  })
+
   it("scopes keys per endpoint family — same key on a different scope does not collide", async () => {
     const fakeDb = createFakeDb()
     const app = new Hono()

--- a/packages/legal/src/contracts/routes.ts
+++ b/packages/legal/src/contracts/routes.ts
@@ -1,5 +1,6 @@
 import type { EventBus, ModuleContainer } from "@voyantjs/core"
 import {
+  idempotencyKey,
   parseJsonBody,
   parseOptionalJsonBody,
   parseQuery,
@@ -441,7 +442,7 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
       const query = parseQuery(c, contractListQuerySchema)
       return c.json(await contractsService.listContracts(c.get("db"), query))
     })
-    .post("/", async (c) => {
+    .post("/", idempotencyKey({ scope: "POST /v1/admin/legal/contracts" }), async (c) => {
       const row = await contractsService.createContract(
         c.get("db"),
         await parseJsonBody(c, insertContractSchema),

--- a/packages/legal/tests/integration/public-routes.test.ts
+++ b/packages/legal/tests/integration/public-routes.test.ts
@@ -19,6 +19,10 @@ const json = (body: Record<string, unknown>) => ({
   headers: { "Content-Type": "application/json" },
   body: JSON.stringify(body),
 })
+const jsonWithIdempotency = (body: Record<string, unknown>, key: string) => ({
+  headers: { "Content-Type": "application/json", "Idempotency-Key": key },
+  body: JSON.stringify(body),
+})
 
 describe.skipIf(!DB_AVAILABLE)("Legal public routes", () => {
   let adminApp: Hono
@@ -548,5 +552,27 @@ describe.skipIf(!DB_AVAILABLE)("Legal public routes", () => {
         metadata: expect.anything(),
       }),
     )
+  })
+
+  it("replays contract creates with the same idempotency key", async () => {
+    const input = {
+      title: "Idempotent contract",
+      scope: "customer",
+    }
+    const first = await adminApp.request("/", {
+      method: "POST",
+      ...jsonWithIdempotency(input, "legal-contract-create-1"),
+    })
+    const replay = await adminApp.request("/", {
+      method: "POST",
+      ...jsonWithIdempotency(input, "legal-contract-create-1"),
+    })
+
+    expect(first.status).toBe(201)
+    expect(replay.status).toBe(201)
+    expect(replay.headers.get("Idempotency-Replayed")).toBe("true")
+    const firstBody = await first.json()
+    const replayBody = await replay.json()
+    expect(replayBody.data.id).toBe(firstBody.data.id)
   })
 })


### PR DESCRIPTION
## Summary
- Add `Idempotency-Key` replay middleware to admin legal contract, CRM person/organization, and finance invoice create routes
- Cover direct invoice creation and invoice-from-booking creation with distinct idempotency scopes
- Loosen the shared idempotency middleware typing so packages with narrower route env bindings can use it without casts
- Add regression coverage for replayed create responses and a changeset for affected packages

Closes #1201

## Verification
- `pnpm --filter @voyantjs/crm typecheck`
- `pnpm --filter @voyantjs/legal typecheck`
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/hono typecheck`
- `pnpm --filter @voyantjs/crm test -- tests/integration/accounts.test.ts`
- `pnpm --filter @voyantjs/legal test -- tests/integration/public-routes.test.ts`
- `pnpm --filter @voyantjs/finance test -- tests/integration/routes.test.ts`
- `pnpm --filter @voyantjs/hono test -- tests/unit/idempotency-key.test.ts`
- `pnpm --filter @voyantjs/crm lint`
- `pnpm --filter @voyantjs/legal lint`
- `pnpm --filter @voyantjs/finance lint`
- `pnpm --filter @voyantjs/hono lint`
- `pnpm verify:agent-quality:changed` (report-only: existing large `packages/finance/src/routes.ts` file-size warning)
- `git diff --check`

Pre-push `pnpm test` initially hit a flaky `@voyantjs/workflows-orchestrator` driver compliance timing assertion; rerunning `pnpm --filter @voyantjs/workflows-orchestrator test -- src/__tests__/driver-compliance.test.ts` passed.