### PR TITLE
Use data SDK for finance FX resolver

### DIFF
--- a/.changeset/flat-falcons-compare.md
+++ b/.changeset/flat-falcons-compare.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/finance": patch
+"@voyantjs/finance-react": patch
+---
+
+Use `@voyantjs/data-sdk` for the Voyant Data FX resolver and expose optional FX provenance fields.

--- a/packages/finance-react/src/schemas.ts
+++ b/packages/finance-react/src/schemas.ts
@@ -237,6 +237,9 @@ export const invoiceFxRateRecordSchema = z.object({
   quoteCurrency: z.string(),
   date: z.string().optional(),
   rate: z.number(),
+  source: z.string().optional(),
+  quotedAt: z.string().optional(),
+  validUntil: z.string().optional(),
 })
 
 export type InvoiceFxRateRecord = z.infer<typeof invoiceFxRateRecordSchema>

--- a/packages/finance/README.md
+++ b/packages/finance/README.md
@@ -150,9 +150,12 @@ createFinanceHonoModule({
 })
 ```
 
-The default data resolver calls the Voyant Data FX pair route
-`/data/fx/v1/fx/pair/{invoiceCurrency}/{baseCurrency}`. If the invoice currency
-matches the operator base currency, no FX fields are emitted.
+The default data resolver uses `@voyantjs/data-sdk` to call the Voyant Data FX
+pair route `/data/fx/v1/fx/pair/{invoiceCurrency}/{baseCurrency}`. SDK
+responses can add provenance metadata such as `source`, `quotedAt`, and
+`validUntil`; invoice-issued events expose those as `fxRateSource`,
+`fxRateQuotedAt`, and `fxRateValidUntil`. If the invoice currency matches the
+operator base currency, no FX fields are emitted.
 
 The same resolver also backs `GET /v1/finance/invoice-fx-rate`, which lets
 operator UI surfaces auto-fill cross-currency payment rates without exposing

--- a/packages/finance/package.json
+++ b/packages/finance/package.json
@@ -28,11 +28,12 @@
     "@voyantjs/action-ledger": "workspace:*",
     "@voyantjs/bookings": "workspace:*",
     "@voyantjs/core": "workspace:*",
+    "@voyantjs/data-sdk": "0.1.2",
     "@voyantjs/db": "workspace:*",
     "@voyantjs/hono": "workspace:*",
     "@voyantjs/products": "workspace:*",
-    "@voyantjs/utils": "workspace:*",
     "@voyantjs/storage": "workspace:*",
+    "@voyantjs/utils": "workspace:*",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.10",
     "zod": "^4.3.6"

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -127,6 +127,7 @@ export {
   createInvoiceFxHonoExtension,
   createInvoiceFxRoutes,
   createVoyantDataFxExchangeRateResolver,
+  type InvoiceExchangeRateResolution,
   type InvoiceFxContext,
   type InvoiceFxOptions,
   type InvoiceFxRouteOptions,

--- a/packages/finance/src/invoice-fx.ts
+++ b/packages/finance/src/invoice-fx.ts
@@ -1,4 +1,5 @@
 import type { Extension, ModuleContainer } from "@voyantjs/core"
+import { createVoyantDataClient } from "@voyantjs/data-sdk"
 import { ApiHttpError, parseJsonBody, parseQuery } from "@voyantjs/hono"
 import type { HonoExtension } from "@voyantjs/hono/module"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -36,9 +37,21 @@ export type ResolveInvoiceExchangeRateInput = {
   date?: string
 }
 
+export type InvoiceExchangeRateResolution = {
+  rate: number
+  source?: string
+  quotedAt?: string
+  validUntil?: string
+}
+
 export type ResolveInvoiceExchangeRate = (
   input: ResolveInvoiceExchangeRateInput,
-) => number | null | undefined | Promise<number | null | undefined>
+) =>
+  | number
+  | InvoiceExchangeRateResolution
+  | null
+  | undefined
+  | Promise<number | InvoiceExchangeRateResolution | null | undefined>
 
 export type HandleInvoiceFxResolutionError = (
   error: unknown,
@@ -67,6 +80,9 @@ export type InvoiceFxInvoice = {
 export type InvoiceFxContext = {
   baseCurrency: string
   fxRate: number
+  fxRateSource?: string
+  fxRateQuotedAt?: string
+  fxRateValidUntil?: string
   fxCommissionBps: number
   effectiveRate: number
   fxCommissionInvoiceMention?: string
@@ -84,9 +100,9 @@ export type VoyantDataFxResolverOptions = {
   authHeader?: string
   authScheme?: string | null
   fetch?: typeof fetch
+  headers?: HeadersInit
+  userAgent?: string
 }
-
-const DEFAULT_DATA_BASE_URL = "https://api.voyantjs.com"
 
 const invoiceFxSettingsPatchSchema = z.object({
   baseCurrency: z.string().min(3).max(8).nullable().optional(),
@@ -149,23 +165,27 @@ export async function resolveInvoiceFxContext(
     quoteCurrency: baseCurrency,
     date: toDateString(invoice.issueDate),
   }
-  let fxRate: number | null | undefined
+  let fxResolution: number | InvoiceExchangeRateResolution | null | undefined
 
   try {
-    fxRate = await options.resolveInvoiceExchangeRate(rateInput)
+    fxResolution = await options.resolveInvoiceExchangeRate(rateInput)
   } catch (error) {
     await notifyInvoiceFxResolutionError(options, error, rateInput)
     return null
   }
 
-  if (typeof fxRate !== "number" || !Number.isFinite(fxRate) || fxRate <= 0) return null
+  const resolvedRate = normalizeInvoiceExchangeRateResolution(fxResolution)
+  if (!resolvedRate) return null
 
   const fxCommissionBps = normalizeBasisPoints(settings?.fxCommissionBps)
-  const effectiveRate = roundRate(fxRate * (1 + fxCommissionBps / 10_000))
+  const effectiveRate = roundRate(resolvedRate.rate * (1 + fxCommissionBps / 10_000))
 
   return {
     baseCurrency,
-    fxRate: roundRate(fxRate),
+    fxRate: roundRate(resolvedRate.rate),
+    ...(resolvedRate.source ? { fxRateSource: resolvedRate.source } : {}),
+    ...(resolvedRate.quotedAt ? { fxRateQuotedAt: resolvedRate.quotedAt } : {}),
+    ...(resolvedRate.validUntil ? { fxRateValidUntil: resolvedRate.validUntil } : {}),
     fxCommissionBps,
     effectiveRate,
     ...(fxCommissionBps > 0 && normalizeOptionalText(settings?.fxCommissionInvoiceMention)
@@ -177,30 +197,32 @@ export async function resolveInvoiceFxContext(
 export function createVoyantDataFxExchangeRateResolver(
   options: VoyantDataFxResolverOptions,
 ): ResolveInvoiceExchangeRate {
-  const fetchImpl = options.fetch ?? fetch
-  const baseUrl = options.baseUrl ?? DEFAULT_DATA_BASE_URL
-  const authHeader = options.authHeader ?? "authorization"
-  const authScheme = options.authScheme === undefined ? "Bearer" : options.authScheme
+  const client = createVoyantDataClient({
+    apiKey: options.apiKey,
+    ...(options.baseUrl ? { baseUrl: options.baseUrl } : {}),
+    ...(options.authHeader ? { authHeader: options.authHeader } : {}),
+    ...(options.authScheme !== undefined ? { authScheme: options.authScheme } : {}),
+    ...(options.fetch ? { fetch: options.fetch } : {}),
+    ...(options.headers ? { headers: options.headers } : {}),
+    userAgent: options.userAgent ?? "voyant-finance",
+  })
 
   return async ({ baseCurrency, quoteCurrency }) => {
-    const url = new URL(
-      `/data/fx/v1/fx/pair/${encodeURIComponent(baseCurrency)}/${encodeURIComponent(
-        quoteCurrency,
-      )}`,
-      baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`,
-    )
-    const headers = new Headers()
-    headers.set(authHeader, authScheme ? `${authScheme} ${options.apiKey}` : options.apiKey)
-    headers.set("x-voyant-sdk", "voyant-finance")
-
-    const response = await fetchImpl(url, { headers })
-    const body = (await response.json()) as Record<string, unknown>
-    if (!response.ok) {
-      throw new Error(`Voyant Data FX request failed with status ${response.status}`)
+    const quote = await client.fx.pair(baseCurrency, quoteCurrency)
+    if (typeof quote.conversionRate !== "number" || !Number.isFinite(quote.conversionRate)) {
+      return null
     }
 
-    const rate = body.conversionRate ?? body.conversion_rate
-    return typeof rate === "number" && Number.isFinite(rate) ? rate : null
+    const source = normalizeOptionalText(quote.source)
+    const quotedAt = normalizeOptionalText(quote.timeLastUpdateUtc)
+    const validUntil = normalizeOptionalText(quote.timeNextUpdateUtc)
+
+    return {
+      rate: quote.conversionRate,
+      ...(source ? { source } : {}),
+      ...(quotedAt ? { quotedAt } : {}),
+      ...(validUntil ? { validUntil } : {}),
+    }
   }
 }
 
@@ -247,9 +269,9 @@ export function createInvoiceFxRoutes(options: InvoiceFxRouteOptions = {}) {
         quoteCurrency: normalizeCurrency(query.quoteCurrency) ?? query.quoteCurrency,
         date: query.date,
       }
-      let rate: number | null | undefined
+      let rateResolution: number | InvoiceExchangeRateResolution | null | undefined
       try {
-        rate = await runtime.resolveInvoiceExchangeRate(input)
+        rateResolution = await runtime.resolveInvoiceExchangeRate(input)
       } catch (error) {
         await notifyInvoiceFxResolutionError(runtime, error, input)
         throw new ApiHttpError("Invoice FX rate resolution failed", {
@@ -258,7 +280,8 @@ export function createInvoiceFxRoutes(options: InvoiceFxRouteOptions = {}) {
         })
       }
 
-      if (typeof rate !== "number" || !Number.isFinite(rate) || rate <= 0) {
+      const resolvedRate = normalizeInvoiceExchangeRateResolution(rateResolution)
+      if (!resolvedRate) {
         throw new ApiHttpError("Invoice FX rate was not found", {
           status: 404,
           code: "invoice_fx_rate_not_found",
@@ -268,7 +291,10 @@ export function createInvoiceFxRoutes(options: InvoiceFxRouteOptions = {}) {
       return c.json({
         data: {
           ...input,
-          rate: roundRate(rate),
+          rate: roundRate(resolvedRate.rate),
+          ...(resolvedRate.source ? { source: resolvedRate.source } : {}),
+          ...(resolvedRate.quotedAt ? { quotedAt: resolvedRate.quotedAt } : {}),
+          ...(resolvedRate.validUntil ? { validUntil: resolvedRate.validUntil } : {}),
         },
       })
     })
@@ -320,6 +346,28 @@ async function notifyInvoiceFxResolutionError(
 
 function normalizeBasisPoints(value: number | null | undefined) {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.round(value) : 0
+}
+
+function normalizeInvoiceExchangeRateResolution(
+  resolution: number | InvoiceExchangeRateResolution | null | undefined,
+): InvoiceExchangeRateResolution | null {
+  if (typeof resolution === "number") {
+    return Number.isFinite(resolution) && resolution > 0 ? { rate: resolution } : null
+  }
+  if (!resolution || typeof resolution !== "object") return null
+  if (typeof resolution.rate !== "number" || !Number.isFinite(resolution.rate)) return null
+  if (resolution.rate <= 0) return null
+
+  const source = normalizeOptionalText(resolution.source)
+  const quotedAt = normalizeOptionalText(resolution.quotedAt)
+  const validUntil = normalizeOptionalText(resolution.validUntil)
+
+  return {
+    rate: resolution.rate,
+    ...(source ? { source } : {}),
+    ...(quotedAt ? { quotedAt } : {}),
+    ...(validUntil ? { validUntil } : {}),
+  }
 }
 
 function normalizeOptionalText(value: string | null | undefined) {

--- a/packages/finance/src/service-issue.ts
+++ b/packages/finance/src/service-issue.ts
@@ -50,6 +50,12 @@ export interface InvoiceIssuedEvent {
   baseCurrency?: string
   /** Spot rate for `currency` → `baseCurrency`. */
   fxRate?: number
+  /** Provider or reference source for `fxRate`, for example `bnr`. */
+  fxRateSource?: string
+  /** Provider timestamp for the quoted spot rate. */
+  fxRateQuotedAt?: string
+  /** Provider timestamp after which the quoted spot rate is stale. */
+  fxRateValidUntil?: string
   /** Operator FX commission added on top of the spot rate. */
   fxCommissionBps?: number
   /** `fxRate` after commission. Invoice providers should prefer this rate. */

--- a/packages/finance/tests/unit/invoice-fx.test.ts
+++ b/packages/finance/tests/unit/invoice-fx.test.ts
@@ -57,12 +57,49 @@ describe("invoice FX", () => {
     })
   })
 
+  it("preserves exchange-rate provenance in invoice FX context", async () => {
+    const context = await resolveInvoiceFxContext(
+      {} as never,
+      { currency: "eur", issueDate: "2026-05-22" },
+      {
+        invoiceFxSettings: {
+          baseCurrency: "ron",
+          fxCommissionBps: 200,
+        },
+        resolveInvoiceExchangeRate: async () => ({
+          rate: 4.97,
+          source: "bnr",
+          quotedAt: "Fri, 22 May 2026 00:00:01 +0000",
+          validUntil: "Sat, 23 May 2026 00:00:01 +0000",
+        }),
+      },
+    )
+
+    expect(context).toEqual({
+      baseCurrency: "RON",
+      fxRate: 4.97,
+      fxRateSource: "bnr",
+      fxRateQuotedAt: "Fri, 22 May 2026 00:00:01 +0000",
+      fxRateValidUntil: "Sat, 23 May 2026 00:00:01 +0000",
+      fxCommissionBps: 200,
+      effectiveRate: 5.0694,
+    })
+  })
+
   it("uses the Voyant Data FX pair route for exchange-rate resolution", async () => {
     const fetch = vi.fn<typeof globalThis.fetch>(async () => {
-      return new Response(JSON.stringify({ conversionRate: 4.97 }), {
-        headers: { "content-type": "application/json" },
-        status: 200,
-      })
+      return new Response(
+        JSON.stringify({
+          conversion_rate: 4.97,
+          source: "bnr",
+          time_last_update_utc: "Fri, 22 May 2026 00:00:01 +0000",
+          time_next_update_utc: "Sat, 23 May 2026 00:00:01 +0000",
+        }),
+        {
+          headers: { "content-type": "application/json" },
+          status: 200,
+        },
+      )
     })
     const apiKey = `data_${"key"}`
     const resolve = createVoyantDataFxExchangeRateResolver({
@@ -71,7 +108,12 @@ describe("invoice FX", () => {
       fetch,
     })
 
-    await expect(resolve({ baseCurrency: "EUR", quoteCurrency: "RON" })).resolves.toBe(4.97)
+    await expect(resolve({ baseCurrency: "EUR", quoteCurrency: "RON" })).resolves.toEqual({
+      rate: 4.97,
+      source: "bnr",
+      quotedAt: "Fri, 22 May 2026 00:00:01 +0000",
+      validUntil: "Sat, 23 May 2026 00:00:01 +0000",
+    })
 
     const [url, init] = fetch.mock.calls[0]!
     expect(String(url)).toBe("https://data.test/data/fx/v1/fx/pair/EUR/RON")
@@ -80,14 +122,27 @@ describe("invoice FX", () => {
   })
 
   it("exposes configured exchange-rate resolution through the admin route", async () => {
-    const resolveInvoiceExchangeRate = vi.fn(async () => 4.97)
+    const resolveInvoiceExchangeRate = vi.fn(async () => ({
+      rate: 4.97,
+      source: "bnr",
+      quotedAt: "Fri, 22 May 2026 00:00:01 +0000",
+      validUntil: "Sat, 23 May 2026 00:00:01 +0000",
+    }))
     const app = createInvoiceFxRoutes({ resolveInvoiceExchangeRate })
 
     const response = await app.request(
       "/invoice-fx-rate?baseCurrency=eur&quoteCurrency=ron&date=2026-05-22",
     )
     const body = (await response.json()) as {
-      data: { baseCurrency: string; quoteCurrency: string; date: string; rate: number }
+      data: {
+        baseCurrency: string
+        quoteCurrency: string
+        date: string
+        rate: number
+        source: string
+        quotedAt: string
+        validUntil: string
+      }
     }
 
     expect(response.status).toBe(200)
@@ -101,6 +156,9 @@ describe("invoice FX", () => {
       quoteCurrency: "RON",
       date: "2026-05-22",
       rate: 4.97,
+      source: "bnr",
+      quotedAt: "Fri, 22 May 2026 00:00:01 +0000",
+      validUntil: "Sat, 23 May 2026 00:00:01 +0000",
     })
   })
 

--- a/packages/finance/tests/unit/service-issue.test.ts
+++ b/packages/finance/tests/unit/service-issue.test.ts
@@ -418,7 +418,12 @@ describe("issueInvoiceFromBooking", () => {
     eventBus.subscribe<InvoiceIssuedEvent>("invoice.issued", (event) => {
       emitted.push(event)
     })
-    const resolveInvoiceExchangeRate = vi.fn(async () => 4.97)
+    const resolveInvoiceExchangeRate = vi.fn(async () => ({
+      rate: 4.97,
+      source: "bnr",
+      quotedAt: "Fri, 22 May 2026 00:00:01 +0000",
+      validUntil: "Sat, 23 May 2026 00:00:01 +0000",
+    }))
 
     await issueInvoiceFromBooking(
       db,
@@ -461,6 +466,9 @@ describe("issueInvoiceFromBooking", () => {
     expect(emitted[0]?.data).toMatchObject({
       baseCurrency: "RON",
       fxRate: 4.97,
+      fxRateSource: "bnr",
+      fxRateQuotedAt: "Fri, 22 May 2026 00:00:01 +0000",
+      fxRateValidUntil: "Sat, 23 May 2026 00:00:01 +0000",
       fxCommissionBps: 200,
       effectiveRate: 5.0694,
       fxCommissionInvoiceMention: "2% comision curs risc valutar",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2847,6 +2847,9 @@ importers:
       '@voyantjs/core':
         specifier: workspace:*
         version: link:../core
+      '@voyantjs/data-sdk':
+        specifier: 0.1.2
+        version: 0.1.2
       '@voyantjs/db':
         specifier: workspace:*
         version: link:../db
@@ -9736,6 +9739,11 @@ packages:
   '@voyantjs/core@0.19.0':
     resolution: {integrity: sha512-L3ielbbWsjGJLkyS6Mzee0z6OD98rqyTxksKBIsaKSiCO0R/a32AXSZ/l4Y8Ek8I8ucYrwe7P4+lr+clppIrBQ==}
 
+  '@voyantjs/data-sdk@0.1.2':
+    resolution: {integrity: sha512-aVTylUeRD9IquB61G2zuau6ggB/dzF+pWhlN74W+eORI/Lw2mGS/X+N/BnrI1fE1ciYOzak8QfU2OiJriGm/4w==}
+    bundledDependencies:
+      - '@voyant-sdk/sdk-core'
+
   '@voyantjs/workflows-errors@0.19.0':
     resolution: {integrity: sha512-HVG+8K/I0aSkk+ZKRlPM14+cwK2Bc3JLwYknqg8WhPBBuiXTFhCUlkum/BYdS3WsVGSZ6awk+34+8yM+UBdSPw==}
 
@@ -16488,6 +16496,8 @@ snapshots:
       typesense: 3.0.6(@babel/runtime@7.29.2)
 
   '@voyantjs/core@0.19.0': {}
+
+  '@voyantjs/data-sdk@0.1.2': {}
 
   '@voyantjs/workflows-errors@0.19.0': {}
 


### PR DESCRIPTION
## Summary
- rebase `createVoyantDataFxExchangeRateResolver` on `@voyantjs/data-sdk`
- keep numeric exchange-rate resolvers supported while adding an enriched resolver result shape
- expose optional FX provenance through invoice FX context, invoice-issued events, and the finance-react rate response schema
- add a changeset for the public package surface updates

Closes #1206

## Scan note
- found one adjacent non-finance direct Data FX caller in `templates/operator/src/api/travel-composer-runtime.ts`; left it out of this PR to keep the issue scoped to the finance resolver

## Verification
- `pnpm --filter @voyantjs/finance test`
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/finance lint`
- `pnpm --filter @voyantjs/finance-react typecheck`
- `pnpm --filter @voyantjs/finance-react lint`
- `pnpm --filter @voyantjs/finance build`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed` (report-only file-size warnings on touched legacy-large files)
- `git diff --check`
- commit hook: full lint and typecheck
- pre-push hook: full test suite