### PR TITLE
Fix finance FX base amount normalization

### DIFF
--- a/.changeset/silent-lemons-convert.md
+++ b/.changeset/silent-lemons-convert.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/finance": patch
+---
+
+Auto-compute base amounts for cross-currency finance records using configured FX commission and persisted rate-set links.

--- a/packages/finance/src/fx-money.ts
+++ b/packages/finance/src/fx-money.ts
@@ -1,0 +1,271 @@
+import { and, desc, eq, isNull, lte, or } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import type {
+  InvoiceExchangeRateResolution,
+  InvoiceFxOptions,
+  InvoiceFxSettings,
+  ResolveInvoiceExchangeRateInput,
+} from "./invoice-fx.js"
+import { exchangeRatesRef } from "./markets-ref.js"
+
+export type FxMoneyInput = {
+  amountCents: number
+  currency: string
+  baseCurrency?: string | null
+  baseAmountCents?: number | null
+  fxRateSetId?: string | null
+}
+
+export type ResolveFxMoneyBaseAmountOptions = InvoiceFxOptions & {
+  targetBaseCurrency?: string | null
+  fallbackFxRateSetId?: string | null
+  date?: string | Date | null
+  setBaseCurrencyWhenUnresolved?: boolean
+}
+
+type PersistedRate = {
+  rate: number
+  fxRateSetId: string
+}
+
+export async function resolveFxMoneyBaseAmount<T extends FxMoneyInput>(
+  db: PostgresJsDatabase,
+  input: T,
+  options: ResolveFxMoneyBaseAmountOptions = {},
+): Promise<T> {
+  const settings = await resolveConfiguredFxSettings(db, options)
+  const currency = normalizeCurrency(input.currency) ?? input.currency
+  const configuredBaseCurrency = normalizeCurrency(settings?.baseCurrency)
+  const targetBaseCurrency =
+    normalizeCurrency(input.baseCurrency) ??
+    normalizeCurrency(options.targetBaseCurrency) ??
+    configuredBaseCurrency
+
+  if (!targetBaseCurrency) {
+    return {
+      ...input,
+      currency,
+      baseCurrency: normalizeCurrency(input.baseCurrency) ?? input.baseCurrency ?? null,
+      fxRateSetId: normalizeOptionalText(input.fxRateSetId) ?? input.fxRateSetId ?? null,
+    }
+  }
+
+  const existingBaseAmountCents = normalizeAmount(input.baseAmountCents)
+  const fallbackFxRateSetId =
+    normalizeOptionalText(input.fxRateSetId) ??
+    normalizeOptionalText(options.fallbackFxRateSetId) ??
+    null
+
+  if (existingBaseAmountCents !== null) {
+    return {
+      ...input,
+      currency,
+      baseCurrency: targetBaseCurrency,
+      baseAmountCents: existingBaseAmountCents,
+      fxRateSetId: currency === targetBaseCurrency ? null : fallbackFxRateSetId,
+    }
+  }
+
+  if (currency === targetBaseCurrency) {
+    return {
+      ...input,
+      currency,
+      baseCurrency: targetBaseCurrency,
+      baseAmountCents: input.amountCents,
+      fxRateSetId: null,
+    }
+  }
+
+  const persistedRate = await resolvePersistedExchangeRate(db, currency, targetBaseCurrency, {
+    fxRateSetId: fallbackFxRateSetId,
+    date: options.date,
+  })
+  const resolvedRate = persistedRate
+    ? { rate: persistedRate.rate, fxRateSetId: persistedRate.fxRateSetId }
+    : await resolveRuntimeExchangeRate(currency, targetBaseCurrency, options)
+
+  if (!resolvedRate) {
+    return {
+      ...input,
+      currency,
+      baseCurrency: options.setBaseCurrencyWhenUnresolved
+        ? targetBaseCurrency
+        : (normalizeCurrency(input.baseCurrency) ?? input.baseCurrency ?? null),
+      baseAmountCents: input.baseAmountCents ?? null,
+      fxRateSetId: fallbackFxRateSetId,
+    }
+  }
+
+  const fxCommissionBps = normalizeBasisPoints(settings?.fxCommissionBps)
+  const effectiveRate = resolvedRate.rate * (1 + fxCommissionBps / 10_000)
+
+  return {
+    ...input,
+    currency,
+    baseCurrency: targetBaseCurrency,
+    baseAmountCents: Math.round(input.amountCents * effectiveRate),
+    fxRateSetId: resolvedRate.fxRateSetId ?? null,
+  }
+}
+
+async function resolveConfiguredFxSettings(
+  db: PostgresJsDatabase,
+  options: InvoiceFxOptions,
+): Promise<InvoiceFxSettings | null> {
+  if (options.invoiceFxSettings !== undefined) return options.invoiceFxSettings
+  return (await options.resolveInvoiceFxSettings?.(db)) ?? null
+}
+
+async function resolveRuntimeExchangeRate(
+  baseCurrency: string,
+  quoteCurrency: string,
+  options: ResolveFxMoneyBaseAmountOptions,
+) {
+  if (!options.resolveInvoiceExchangeRate) return null
+
+  const input: ResolveInvoiceExchangeRateInput = {
+    baseCurrency,
+    quoteCurrency,
+    date: toDateString(options.date),
+  }
+
+  try {
+    return normalizeExchangeRateResolution(await options.resolveInvoiceExchangeRate(input))
+  } catch (error) {
+    try {
+      await options.onInvoiceFxResolutionError?.(error, input)
+    } catch {
+      // FX resolution failure hooks should not mask the original write path.
+    }
+    return null
+  }
+}
+
+async function resolvePersistedExchangeRate(
+  db: PostgresJsDatabase,
+  baseCurrency: string,
+  quoteCurrency: string,
+  options: { fxRateSetId?: string | null; date?: string | Date | null },
+): Promise<PersistedRate | null> {
+  if (options.fxRateSetId) {
+    return (
+      (await queryPersistedExchangeRate(db, baseCurrency, quoteCurrency, {
+        fxRateSetId: options.fxRateSetId,
+      })) ??
+      (await queryPersistedExchangeRate(db, quoteCurrency, baseCurrency, {
+        fxRateSetId: options.fxRateSetId,
+        inverse: true,
+      }))
+    )
+  }
+
+  const asOf = toDateEnd(options.date)
+  return (
+    (await queryPersistedExchangeRate(db, baseCurrency, quoteCurrency, { asOf })) ??
+    (await queryPersistedExchangeRate(db, quoteCurrency, baseCurrency, {
+      asOf,
+      inverse: true,
+    })) ??
+    (await queryPersistedExchangeRate(db, baseCurrency, quoteCurrency, {})) ??
+    (await queryPersistedExchangeRate(db, quoteCurrency, baseCurrency, { inverse: true }))
+  )
+}
+
+async function queryPersistedExchangeRate(
+  db: PostgresJsDatabase,
+  baseCurrency: string,
+  quoteCurrency: string,
+  options: { fxRateSetId?: string | null; asOf?: Date | null; inverse?: boolean },
+): Promise<PersistedRate | null> {
+  const conditions = [
+    eq(exchangeRatesRef.baseCurrency, baseCurrency),
+    eq(exchangeRatesRef.quoteCurrency, quoteCurrency),
+  ]
+  if (options.fxRateSetId) {
+    conditions.push(eq(exchangeRatesRef.fxRateSetId, options.fxRateSetId))
+  }
+  if (options.asOf) {
+    const asOfCondition = or(
+      isNull(exchangeRatesRef.observedAt),
+      lte(exchangeRatesRef.observedAt, options.asOf),
+    )
+    if (asOfCondition) conditions.push(asOfCondition)
+  }
+
+  const [row] = await db
+    .select({
+      fxRateSetId: exchangeRatesRef.fxRateSetId,
+      rateDecimal: exchangeRatesRef.rateDecimal,
+      inverseRateDecimal: exchangeRatesRef.inverseRateDecimal,
+    })
+    .from(exchangeRatesRef)
+    .where(and(...conditions))
+    .orderBy(desc(exchangeRatesRef.observedAt), desc(exchangeRatesRef.createdAt))
+    .limit(1)
+
+  if (!row) return null
+  const rate = options.inverse
+    ? (normalizeRate(row.inverseRateDecimal) ?? inverseRate(row.rateDecimal))
+    : normalizeRate(row.rateDecimal)
+
+  return rate ? { rate, fxRateSetId: row.fxRateSetId } : null
+}
+
+function normalizeExchangeRateResolution(
+  resolution: number | InvoiceExchangeRateResolution | null | undefined,
+): (InvoiceExchangeRateResolution & { fxRateSetId?: string }) | null {
+  if (typeof resolution === "number") {
+    return Number.isFinite(resolution) && resolution > 0 ? { rate: resolution } : null
+  }
+  if (!resolution || typeof resolution !== "object") return null
+  if (typeof resolution.rate !== "number" || !Number.isFinite(resolution.rate)) return null
+  if (resolution.rate <= 0) return null
+
+  const fxRateSetId = normalizeOptionalText(resolution.fxRateSetId)
+  return {
+    rate: resolution.rate,
+    ...(fxRateSetId ? { fxRateSetId } : {}),
+  }
+}
+
+function normalizeAmount(value: number | null | undefined) {
+  return typeof value === "number" && Number.isFinite(value) ? Math.round(value) : null
+}
+
+function normalizeRate(value: string | number | null | undefined) {
+  const parsed = typeof value === "number" ? value : Number.parseFloat(value ?? "")
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+}
+
+function inverseRate(value: string | number | null | undefined) {
+  const rate = normalizeRate(value)
+  return rate ? 1 / rate : null
+}
+
+function normalizeBasisPoints(value: number | null | undefined) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.round(value) : 0
+}
+
+function normalizeCurrency(value: string | null | undefined) {
+  const normalized = value?.trim().toUpperCase()
+  return normalized ? normalized : null
+}
+
+function normalizeOptionalText(value: string | null | undefined) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined
+}
+
+function toDateString(value: string | Date | null | undefined) {
+  if (value instanceof Date) return value.toISOString().slice(0, 10)
+  return typeof value === "string" && value.length > 0 ? value : undefined
+}
+
+function toDateEnd(value: string | Date | null | undefined) {
+  if (value instanceof Date) return value
+  if (!value) return null
+  const parsed = /^\d{4}-\d{2}-\d{2}$/.test(value)
+    ? new Date(`${value}T23:59:59.999Z`)
+    : new Date(value)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}

--- a/packages/finance/src/fx-money.ts
+++ b/packages/finance/src/fx-money.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNull, lte, or } from "drizzle-orm"
+import { and, asc, desc, eq, isNull, lte, or } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import type {
@@ -201,7 +201,11 @@ async function queryPersistedExchangeRate(
     })
     .from(exchangeRatesRef)
     .where(and(...conditions))
-    .orderBy(desc(exchangeRatesRef.observedAt), desc(exchangeRatesRef.createdAt))
+    .orderBy(
+      asc(isNull(exchangeRatesRef.observedAt)),
+      desc(exchangeRatesRef.observedAt),
+      desc(exchangeRatesRef.createdAt),
+    )
     .limit(1)
 
   if (!row) return null

--- a/packages/finance/src/invoice-fx.ts
+++ b/packages/finance/src/invoice-fx.ts
@@ -39,6 +39,7 @@ export type ResolveInvoiceExchangeRateInput = {
 
 export type InvoiceExchangeRateResolution = {
   rate: number
+  fxRateSetId?: string
   source?: string
   quotedAt?: string
   validUntil?: string
@@ -79,6 +80,7 @@ export type InvoiceFxInvoice = {
 
 export type InvoiceFxContext = {
   baseCurrency: string
+  fxRateSetId?: string
   fxRate: number
   fxRateSource?: string
   fxRateQuotedAt?: string
@@ -182,6 +184,7 @@ export async function resolveInvoiceFxContext(
 
   return {
     baseCurrency,
+    ...(resolvedRate.fxRateSetId ? { fxRateSetId: resolvedRate.fxRateSetId } : {}),
     fxRate: roundRate(resolvedRate.rate),
     ...(resolvedRate.source ? { fxRateSource: resolvedRate.source } : {}),
     ...(resolvedRate.quotedAt ? { fxRateQuotedAt: resolvedRate.quotedAt } : {}),
@@ -292,6 +295,7 @@ export function createInvoiceFxRoutes(options: InvoiceFxRouteOptions = {}) {
         data: {
           ...input,
           rate: roundRate(resolvedRate.rate),
+          ...(resolvedRate.fxRateSetId ? { fxRateSetId: resolvedRate.fxRateSetId } : {}),
           ...(resolvedRate.source ? { source: resolvedRate.source } : {}),
           ...(resolvedRate.quotedAt ? { quotedAt: resolvedRate.quotedAt } : {}),
           ...(resolvedRate.validUntil ? { validUntil: resolvedRate.validUntil } : {}),
@@ -359,11 +363,13 @@ function normalizeInvoiceExchangeRateResolution(
   if (resolution.rate <= 0) return null
 
   const source = normalizeOptionalText(resolution.source)
+  const fxRateSetId = normalizeOptionalText(resolution.fxRateSetId)
   const quotedAt = normalizeOptionalText(resolution.quotedAt)
   const validUntil = normalizeOptionalText(resolution.validUntil)
 
   return {
     rate: resolution.rate,
+    ...(fxRateSetId ? { fxRateSetId } : {}),
     ...(source ? { source } : {}),
     ...(quotedAt ? { quotedAt } : {}),
     ...(validUntil ? { validUntil } : {}),

--- a/packages/finance/src/markets-ref.ts
+++ b/packages/finance/src/markets-ref.ts
@@ -1,0 +1,18 @@
+import { typeId, typeIdRef } from "@voyantjs/db/lib/typeid-column"
+import { numeric, pgTable, text, timestamp } from "drizzle-orm/pg-core"
+
+/**
+ * Local reference to `markets.exchange_rates`. Finance stores plain-text
+ * `fx_rate_set_id` links and reads this table opportunistically to normalize
+ * cross-currency payment/document amounts without taking a hard markets dep.
+ */
+export const exchangeRatesRef = pgTable("exchange_rates", {
+  id: typeId("exchange_rates").primaryKey(),
+  fxRateSetId: typeIdRef("fx_rate_set_id").notNull(),
+  baseCurrency: text("base_currency").notNull(),
+  quoteCurrency: text("quote_currency").notNull(),
+  rateDecimal: numeric("rate_decimal", { precision: 18, scale: 8 }).notNull(),
+  inverseRateDecimal: numeric("inverse_rate_decimal", { precision: 18, scale: 8 }),
+  observedAt: timestamp("observed_at", { withTimezone: true }),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+})

--- a/packages/finance/src/route-runtime.ts
+++ b/packages/finance/src/route-runtime.ts
@@ -35,5 +35,6 @@ export function buildFinanceRouteRuntime(
     resolveInvoiceExchangeRate:
       options.resolveInvoiceExchangeRateResolver?.(bindings) ?? options.resolveInvoiceExchangeRate,
     resolveInvoiceExchangeRateResolver: options.resolveInvoiceExchangeRateResolver,
+    onInvoiceFxResolutionError: options.onInvoiceFxResolutionError,
   }
 }

--- a/packages/finance/src/routes.ts
+++ b/packages/finance/src/routes.ts
@@ -890,7 +890,7 @@ export const financeRoutes = new Hono<Env>()
           c.get("db"),
           await parseJsonBody(c, insertSupplierPaymentSchema),
           {
-            eventBus: runtime?.eventBus,
+            ...(runtime ?? {}),
             actionLedgerContext: getActionLedgerRequestContext(c),
             actionLedgerAuthorizationSource: "finance.supplier_payment.route",
           },
@@ -908,7 +908,7 @@ export const financeRoutes = new Hono<Env>()
       c.req.param("id"),
       await parseJsonBody(c, updateSupplierPaymentSchema),
       {
-        eventBus: runtime?.eventBus,
+        ...(runtime ?? {}),
         actionLedgerContext: getActionLedgerRequestContext(c),
         actionLedgerAuthorizationSource: "finance.supplier_payment.route",
       },
@@ -1021,7 +1021,7 @@ export const financeRoutes = new Hono<Env>()
               organizationId: booking.organizationId,
               sellCurrency: booking.sellCurrency,
               baseCurrency: booking.baseCurrency,
-              fxRateSetId: null,
+              fxRateSetId: booking.fxRateSetId,
               sellAmountCents: booking.sellAmountCents,
               baseSellAmountCents: booking.baseSellAmountCents,
             },
@@ -1045,7 +1045,7 @@ export const financeRoutes = new Hono<Env>()
             })),
           },
           {
-            eventBus: runtime?.eventBus,
+            ...(runtime ?? {}),
             actionLedgerContext: getActionLedgerRequestContext(c),
             actionLedgerAuthorizationSource: "finance.invoice.from_booking.route",
           },
@@ -1292,7 +1292,7 @@ export const financeRoutes = new Hono<Env>()
         c.req.param("id"),
         await parseJsonBody(c, insertPaymentSchema),
         {
-          eventBus: runtime?.eventBus,
+          ...(runtime ?? {}),
           actionLedgerContext: getActionLedgerRequestContext(c),
           actionLedgerAuthorizationSource: "finance.payment.route",
         },
@@ -1334,7 +1334,7 @@ export const financeRoutes = new Hono<Env>()
       c.req.param("id"),
       await parseJsonBody(c, insertCreditNoteSchema),
       {
-        eventBus: runtime?.eventBus,
+        ...(runtime ?? {}),
         actionLedgerContext: getActionLedgerRequestContext(c),
         actionLedgerAuthorizationSource: "finance.credit_note.route",
       },
@@ -1355,7 +1355,7 @@ export const financeRoutes = new Hono<Env>()
       c.req.param("creditNoteId"),
       await parseJsonBody(c, updateCreditNoteSchema),
       {
-        eventBus: runtime?.eventBus,
+        ...(runtime ?? {}),
         actionLedgerContext: getActionLedgerRequestContext(c),
         actionLedgerAuthorizationSource: "finance.credit_note.route",
       },

--- a/packages/finance/src/service-issue.ts
+++ b/packages/finance/src/service-issue.ts
@@ -48,6 +48,8 @@ export interface InvoiceIssuedEvent {
   currency: string
   /** Operator accounting/reporting currency when different from `currency`. */
   baseCurrency?: string
+  /** Rate set used to resolve `currency` -> `baseCurrency`, when available. */
+  fxRateSetId?: string
   /** Spot rate for `currency` → `baseCurrency`. */
   fxRate?: number
   /** Provider or reference source for `fxRate`, for example `bnr`. */
@@ -136,7 +138,7 @@ export async function issueInvoiceFromBooking(
   bookingData: InvoiceFromBookingData,
   runtime: InvoiceIssueRuntime = {},
 ) {
-  const draft = await financeService.createInvoiceFromBooking(db, input, bookingData)
+  const draft = await financeService.createInvoiceFromBooking(db, input, bookingData, runtime)
   if (!draft) return null
   const status = draft.status === "pending_external_allocation" ? draft.status : "issued"
 
@@ -184,7 +186,7 @@ export async function issueProformaFromBooking(
   bookingData: InvoiceFromBookingData,
   runtime: InvoiceIssueRuntime = {},
 ) {
-  const draft = await financeService.createInvoiceFromBooking(db, input, bookingData)
+  const draft = await financeService.createInvoiceFromBooking(db, input, bookingData, runtime)
   if (!draft) return null
   const status = draft.status === "pending_external_allocation" ? draft.status : "issued"
 

--- a/packages/finance/src/service.ts
+++ b/packages/finance/src/service.ts
@@ -8,6 +8,8 @@ import { renderStructuredTemplate } from "@voyantjs/utils/template-renderer"
 import { and, asc, desc, eq, gt, gte, ilike, lte, ne, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
+import { resolveFxMoneyBaseAmount } from "./fx-money.js"
+import type { InvoiceFxOptions } from "./invoice-fx.js"
 import {
   bookingGuarantees,
   bookingItemCommissions,
@@ -647,7 +649,7 @@ async function paginate<T extends object>(
  * when no eventBus is provided, so direct callers (tests, scripts) don't
  * have to wire one up.
  */
-export interface FinanceServiceRuntime {
+export interface FinanceServiceRuntime extends InvoiceFxOptions {
   eventBus?: EventBus
   actionLedgerContext?: ActionLedgerRequestContextValues
   actionLedgerAuthorizationSource?: string | null
@@ -852,6 +854,107 @@ function assertPaymentCanSettleInvoice(invoiceCurrency: string, data: CreatePaym
       fields: ["baseCurrency", "baseAmountCents"],
     },
   )
+}
+
+function shouldNormalizeBaseAmount(data: {
+  amountCents?: number | null
+  currency?: string | null
+  baseCurrency?: string | null
+  baseAmountCents?: number | null
+  fxRateSetId?: string | null
+  paymentDate?: string | null
+}) {
+  return (
+    data.amountCents !== undefined ||
+    data.currency !== undefined ||
+    data.baseCurrency !== undefined ||
+    data.baseAmountCents !== undefined ||
+    data.fxRateSetId !== undefined ||
+    data.paymentDate !== undefined
+  )
+}
+
+async function resolveSupplierPaymentUpdateData(
+  db: PostgresJsDatabase,
+  id: string,
+  data: UpdateSupplierPaymentInput,
+  runtime: FinanceServiceRuntime,
+): Promise<UpdateSupplierPaymentInput | null> {
+  const [existing] = await db
+    .select()
+    .from(supplierPayments)
+    .where(eq(supplierPayments.id, id))
+    .limit(1)
+  if (!existing) return null
+  if (!shouldNormalizeBaseAmount(data)) return data
+
+  const bookingId = data.bookingId ?? existing.bookingId
+  const [booking] = await db.select().from(bookings).where(eq(bookings.id, bookingId)).limit(1)
+  const normalized = await resolveFxMoneyBaseAmount(
+    db,
+    {
+      amountCents: data.amountCents ?? existing.amountCents,
+      currency: data.currency ?? existing.currency,
+      baseCurrency: data.baseCurrency ?? existing.baseCurrency,
+      baseAmountCents: data.baseAmountCents ?? null,
+      fxRateSetId: data.fxRateSetId ?? existing.fxRateSetId,
+    },
+    {
+      ...runtime,
+      targetBaseCurrency: booking?.baseCurrency ?? null,
+      fallbackFxRateSetId: booking?.fxRateSetId ?? null,
+      date: data.paymentDate ?? existing.paymentDate,
+    },
+  )
+
+  return {
+    ...data,
+    baseCurrency: normalized.baseCurrency ?? null,
+    baseAmountCents: normalized.baseAmountCents ?? null,
+    fxRateSetId: normalized.fxRateSetId ?? null,
+  }
+}
+
+async function resolveCreditNoteUpdateData(
+  db: PostgresJsDatabase,
+  id: string,
+  data: UpdateCreditNoteInput,
+  runtime: FinanceServiceRuntime,
+): Promise<UpdateCreditNoteInput | null> {
+  const [existing] = await db.select().from(creditNotes).where(eq(creditNotes.id, id)).limit(1)
+  if (!existing) return null
+  if (!shouldNormalizeBaseAmount(data)) return data
+
+  const [invoice] = await db
+    .select()
+    .from(invoices)
+    .where(eq(invoices.id, existing.invoiceId))
+    .limit(1)
+  if (!invoice) return null
+
+  const normalized = await resolveFxMoneyBaseAmount(
+    db,
+    {
+      amountCents: data.amountCents ?? existing.amountCents,
+      currency: data.currency ?? existing.currency,
+      baseCurrency: data.baseCurrency ?? existing.baseCurrency,
+      baseAmountCents: data.baseAmountCents ?? null,
+      fxRateSetId: data.fxRateSetId ?? existing.fxRateSetId,
+    },
+    {
+      ...runtime,
+      targetBaseCurrency: invoice.currency,
+      fallbackFxRateSetId: invoice.fxRateSetId ?? null,
+      date: new Date(),
+    },
+  )
+
+  return {
+    ...data,
+    baseCurrency: normalized.baseCurrency ?? null,
+    baseAmountCents: normalized.baseAmountCents ?? null,
+    fxRateSetId: normalized.fxRateSetId ?? null,
+  }
 }
 
 async function resolveInvoiceForPaymentSession(
@@ -3089,10 +3192,21 @@ export const financeService = {
     data: CreateSupplierPaymentInput,
     runtime: FinanceServiceRuntime = {},
   ) {
+    const [booking] = await db
+      .select()
+      .from(bookings)
+      .where(eq(bookings.id, data.bookingId))
+      .limit(1)
+    const paymentData = await resolveFxMoneyBaseAmount(db, data, {
+      ...runtime,
+      targetBaseCurrency: booking?.baseCurrency ?? null,
+      fallbackFxRateSetId: booking?.fxRateSetId ?? null,
+      date: data.paymentDate,
+    })
     const createPayment = (writer: PostgresJsDatabase) =>
       writer
         .insert(supplierPayments)
-        .values({ ...data, paymentInstrumentId: data.paymentInstrumentId ?? null })
+        .values({ ...paymentData, paymentInstrumentId: paymentData.paymentInstrumentId ?? null })
         .returning()
 
     const actionLedgerContext = runtime.actionLedgerContext
@@ -3127,10 +3241,13 @@ export const financeService = {
     data: UpdateSupplierPaymentInput,
     runtime: FinanceServiceRuntime = {},
   ) {
+    const updateData = await resolveSupplierPaymentUpdateData(db, id, data, runtime)
+    if (!updateData) return null
+
     const updatePayment = (writer: PostgresJsDatabase) =>
       writer
         .update(supplierPayments)
-        .set({ ...data, updatedAt: new Date() })
+        .set({ ...updateData, updatedAt: new Date() })
         .where(eq(supplierPayments.id, id))
         .returning()
 
@@ -3144,7 +3261,7 @@ export const financeService = {
             tx,
             buildSupplierPaymentUpdateActionLedgerInput(
               actionLedgerContext,
-              { payment: updated[0], changes: data },
+              { payment: updated[0], changes: updateData },
               { authorizationSource: runtime.actionLedgerAuthorizationSource },
             ),
           )
@@ -3248,6 +3365,7 @@ export const financeService = {
     db: PostgresJsDatabase,
     data: CreateInvoiceFromBookingInput,
     bookingData: InvoiceFromBookingData,
+    runtime: FinanceServiceRuntime = {},
   ) {
     const { booking, items, paymentSchedule } = bookingData
     const numberAssignment = await resolveInvoiceNumberForBooking(db, data)
@@ -3314,14 +3432,32 @@ export const financeService = {
 
     // The `ck_invoices_base_currency_amounts` constraint requires
     // that whenever ANY base_*_cents column is non-null, base_currency
-    // must be set too. Bookings without an FX-rate set leave
-    // baseCurrency null — propagate that NULL across every base_*
-    // field so the constraint stays satisfied.
-    const hasBaseCurrency = Boolean(booking.baseCurrency)
+    // must be set too. Resolve the base side once and propagate nulls
+    // consistently when no booking/runtime base currency is available.
     const invoiceCurrency = paymentSchedule?.currency ?? booking.sellCurrency
-    const invoiceBaseAmountCents = paymentSchedule
+    const bookingBaseAmountCents = paymentSchedule
       ? resolveBookingInvoiceBaseAmount(booking, invoiceCurrency, paymentSchedule.amountCents)
       : (booking.baseSellAmountCents ?? null)
+    const resolvedInvoiceBase = await resolveFxMoneyBaseAmount(
+      db,
+      {
+        amountCents: totalCents,
+        currency: invoiceCurrency,
+        baseCurrency: booking.baseCurrency ?? null,
+        baseAmountCents: bookingBaseAmountCents,
+        fxRateSetId: booking.fxRateSetId ?? null,
+      },
+      {
+        ...runtime,
+        targetBaseCurrency: booking.baseCurrency ?? null,
+        fallbackFxRateSetId: booking.fxRateSetId ?? null,
+        date: data.issueDate,
+        setBaseCurrencyWhenUnresolved: Boolean(booking.baseCurrency),
+      },
+    )
+    const invoiceBaseCurrency = resolvedInvoiceBase.baseCurrency ?? null
+    const invoiceBaseAmountCents = resolvedInvoiceBase.baseAmountCents ?? null
+    const hasBaseCurrency = Boolean(invoiceBaseCurrency)
 
     try {
       return await db.transaction(async (tx) => {
@@ -3337,8 +3473,8 @@ export const financeService = {
             organizationId: booking.organizationId,
             status: numberAssignment.status,
             currency: invoiceCurrency,
-            baseCurrency: booking.baseCurrency,
-            fxRateSetId: booking.fxRateSetId,
+            baseCurrency: invoiceBaseCurrency,
+            fxRateSetId: resolvedInvoiceBase.fxRateSetId ?? null,
             subtotalCents,
             baseSubtotalCents: hasBaseCurrency ? invoiceBaseAmountCents : null,
             taxCents,
@@ -3869,17 +4005,24 @@ export const financeService = {
       return null
     }
 
-    assertPaymentCanSettleInvoice(invoice.currency, data)
+    const paymentData = await resolveFxMoneyBaseAmount(db, data, {
+      ...runtime,
+      targetBaseCurrency: invoice.currency,
+      fallbackFxRateSetId: invoice.fxRateSetId ?? null,
+      date: data.paymentDate,
+    })
+
+    assertPaymentCanSettleInvoice(invoice.currency, paymentData)
 
     return db.transaction(async (tx) => {
       const [payment] = await tx
         .insert(payments)
         .values({
-          ...data,
+          ...paymentData,
           invoiceId,
-          paymentInstrumentId: data.paymentInstrumentId ?? null,
-          paymentAuthorizationId: data.paymentAuthorizationId ?? null,
-          paymentCaptureId: data.paymentCaptureId ?? null,
+          paymentInstrumentId: paymentData.paymentInstrumentId ?? null,
+          paymentAuthorizationId: paymentData.paymentAuthorizationId ?? null,
+          paymentCaptureId: paymentData.paymentCaptureId ?? null,
         })
         .returning()
 
@@ -3943,10 +4086,17 @@ export const financeService = {
       return null
     }
 
+    const creditNoteData = await resolveFxMoneyBaseAmount(db, data, {
+      ...runtime,
+      targetBaseCurrency: invoice.currency,
+      fallbackFxRateSetId: invoice.fxRateSetId ?? null,
+      date: new Date(),
+    })
+
     return db.transaction(async (tx) => {
       const [row] = await tx
         .insert(creditNotes)
-        .values({ ...data, invoiceId })
+        .values({ ...creditNoteData, invoiceId })
         .returning()
 
       if (row && runtime.actionLedgerContext) {
@@ -3975,10 +4125,13 @@ export const financeService = {
     data: UpdateCreditNoteInput,
     runtime: FinanceServiceRuntime = {},
   ) {
+    const updateData = await resolveCreditNoteUpdateData(db, creditNoteId, data, runtime)
+    if (!updateData) return null
+
     const updateCreditNoteRow = async (writer: PostgresJsDatabase) => {
       const [row] = await writer
         .update(creditNotes)
-        .set({ ...data, updatedAt: new Date() })
+        .set({ ...updateData, updatedAt: new Date() })
         .where(eq(creditNotes.id, creditNoteId))
         .returning()
 
@@ -4005,7 +4158,7 @@ export const financeService = {
             tx,
             buildCreditNoteUpdateActionLedgerInput(
               actionLedgerContext,
-              { ...updated, changes: data },
+              { ...updated, changes: updateData },
               { authorizationSource: runtime.actionLedgerAuthorizationSource },
             ),
           )

--- a/packages/finance/tests/integration/routes.test.ts
+++ b/packages/finance/tests/integration/routes.test.ts
@@ -1868,9 +1868,15 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       const booking = await seedBooking()
       const fxRateSetId = `fxrs_${seq + 1}`
       const exchangeRateId = `fxrt_${seq + 1}`
+      const undatedFxRateSetId = `fxrs_undated_${seq + 1}`
+      const undatedExchangeRateId = `fxrt_undated_${seq + 1}`
       await db.execute(sql`
         INSERT INTO fx_rate_sets (id, base_currency, effective_at, observed_at)
         VALUES (${fxRateSetId}, 'EUR', '2025-06-13T00:00:00.000Z', '2025-06-13T00:00:00.000Z')
+      `)
+      await db.execute(sql`
+        INSERT INTO fx_rate_sets (id, base_currency, effective_at, observed_at)
+        VALUES (${undatedFxRateSetId}, 'EUR', '2025-06-14T00:00:00.000Z', NULL)
       `)
       await db.execute(sql`
         INSERT INTO exchange_rates (
@@ -1892,10 +1898,29 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
           '2025-06-13T00:00:00.000Z'
         )
       `)
+      await db.execute(sql`
+        INSERT INTO exchange_rates (
+          id,
+          fx_rate_set_id,
+          base_currency,
+          quote_currency,
+          rate_decimal,
+          inverse_rate_decimal,
+          observed_at
+        )
+        VALUES (
+          ${undatedExchangeRateId},
+          ${undatedFxRateSetId},
+          'RON',
+          'EUR',
+          '0.5',
+          '2',
+          NULL
+        )
+      `)
       const expectedBaseAmountCents = Math.round(86000 * 0.197 * 1.02)
       const inv = await seedInvoice(booking.id, {
         currency: "EUR",
-        fxRateSetId,
         totalCents: expectedBaseAmountCents,
         balanceDueCents: expectedBaseAmountCents,
       })

--- a/packages/finance/tests/integration/routes.test.ts
+++ b/packages/finance/tests/integration/routes.test.ts
@@ -87,6 +87,8 @@ async function cleanupFinanceTestData(
     "tax_regimes",
     "booking_items",
     "bookings",
+    "exchange_rates",
+    "fx_rate_sets",
   ]
 
   const existingTables = (await db.execute<{ tablename: string }>(sql`
@@ -279,6 +281,9 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
     const financeRouteRuntime = {
       eventBus,
       invoiceSettlementPollers: {},
+      invoiceFxSettings: {
+        fxCommissionBps: 200,
+      },
       resolveDocumentDownloadUrl: (_bindings: unknown, storageKey: string) =>
         `https://files.example/${storageKey}`,
     }
@@ -1855,6 +1860,65 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       const check = await app.request(`/invoices/${inv.id}`, { method: "GET" })
       const { data: paidInv } = await check.json()
       expect(paidInv.paidCents).toBe(10000)
+      expect(paidInv.balanceDueCents).toBe(0)
+      expect(paidInv.status).toBe("paid")
+    })
+
+    it("auto-computes completed cross-currency payment base amounts with FX commission", async () => {
+      const booking = await seedBooking()
+      const fxRateSetId = `fxrs_${seq + 1}`
+      const exchangeRateId = `fxrt_${seq + 1}`
+      await db.execute(sql`
+        INSERT INTO fx_rate_sets (id, base_currency, effective_at, observed_at)
+        VALUES (${fxRateSetId}, 'EUR', '2025-06-13T00:00:00.000Z', '2025-06-13T00:00:00.000Z')
+      `)
+      await db.execute(sql`
+        INSERT INTO exchange_rates (
+          id,
+          fx_rate_set_id,
+          base_currency,
+          quote_currency,
+          rate_decimal,
+          inverse_rate_decimal,
+          observed_at
+        )
+        VALUES (
+          ${exchangeRateId},
+          ${fxRateSetId},
+          'RON',
+          'EUR',
+          '0.197',
+          '5.07614213',
+          '2025-06-13T00:00:00.000Z'
+        )
+      `)
+      const expectedBaseAmountCents = Math.round(86000 * 0.197 * 1.02)
+      const inv = await seedInvoice(booking.id, {
+        currency: "EUR",
+        fxRateSetId,
+        totalCents: expectedBaseAmountCents,
+        balanceDueCents: expectedBaseAmountCents,
+      })
+
+      const res = await app.request(`/invoices/${inv.id}/payments`, {
+        method: "POST",
+        ...json({
+          amountCents: 86000,
+          currency: "RON",
+          paymentMethod: "bank_transfer",
+          paymentDate: "2025-06-15",
+          status: "completed",
+        }),
+      })
+      expect(res.status).toBe(201)
+      const { data: payment } = await res.json()
+      expect(payment.baseCurrency).toBe("EUR")
+      expect(payment.baseAmountCents).toBe(expectedBaseAmountCents)
+      expect(payment.fxRateSetId).toBe(fxRateSetId)
+
+      const check = await app.request(`/invoices/${inv.id}`, { method: "GET" })
+      const { data: paidInv } = await check.json()
+      expect(paidInv.paidCents).toBe(expectedBaseAmountCents)
       expect(paidInv.balanceDueCents).toBe(0)
       expect(paidInv.status).toBe("paid")
     })


### PR DESCRIPTION
## Summary
- Auto-compute base amounts for cross-currency customer payments, supplier payments, issued invoices, and credit notes when callers omit `baseAmountCents`.
- Resolve rates from persisted `exchange_rates` rows first, preserving `fxRateSetId`, and apply configured `fxCommissionBps` to the computed amount.
- Pass finance FX runtime options through the affected routes and add a regression for the RON payment -> EUR invoice example.

## Verification
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/finance lint`
- `pnpm --filter @voyantjs/finance test -- tests/integration/routes.test.ts -t "auto-computes completed cross-currency payment base amounts"`
- `git push` pre-push test hook: passed
- `pnpm verify:fast` stops at existing `verify:ui-components-barrel` missing exports in `packages/ui/src/components/index.tsx` for unrelated UI modules