### PR TITLE
Validate booking create payment schedules

### DIFF
--- a/.changeset/quick-jars-validate.md
+++ b/.changeset/quick-jars-validate.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/finance": patch
+---
+
+Validate booking-create payment schedule currencies and confirmed totals before persisting schedules.

--- a/packages/finance/src/routes-booking-create.ts
+++ b/packages/finance/src/routes-booking-create.ts
@@ -45,6 +45,14 @@ const createBookingRoutes = new Hono<{
     switch (outcome.status) {
       case "ok":
         return c.json({ data: outcome.result }, 201)
+      case "invalid_payment_schedules":
+        return c.json(
+          {
+            error: "Invalid payment schedules",
+            issues: outcome.issues,
+          },
+          400,
+        )
       case "product_not_found":
         return c.json({ error: "Product not found or unavailable" }, 404)
       case "voucher_not_found":
@@ -89,6 +97,15 @@ const createBookingRoutes = new Hono<{
     const reason = outcome.reason
     const body: Record<string, unknown> = { which, reasonStatus: reason.status }
     switch (reason.status) {
+      case "invalid_payment_schedules":
+        return c.json(
+          {
+            ...body,
+            error: `${which}: invalid payment schedules`,
+            issues: reason.issues,
+          },
+          400,
+        )
       case "product_not_found":
         return c.json({ ...body, error: `${which}: product not found or unavailable` }, 404)
       case "voucher_not_found":

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -364,8 +364,14 @@ export interface BookingCreateResult {
   payments: Payment[]
 }
 
+export interface BookingCreateValidationIssue {
+  path: Array<string | number>
+  message: string
+}
+
 export type BookingCreateOutcome =
   | { status: "ok"; result: BookingCreateResult }
+  | { status: "invalid_payment_schedules"; issues: BookingCreateValidationIssue[] }
   | { status: "product_not_found" }
   | { status: "voucher_not_found" }
   | { status: "voucher_inactive" }
@@ -426,6 +432,38 @@ function parseAlreadyPaidScheduleMetadata(notes: string | null | undefined) {
 function isAlreadyPaidSchedule(schedule: BookingCreatePaymentScheduleInput) {
   const metadata = parseAlreadyPaidScheduleMetadata(schedule.notes)
   return schedule.status === "paid" || metadata?.alreadyPaid === true
+}
+
+function validatePaymentSchedules(
+  input: BookingCreateInput,
+  booking: Booking,
+): BookingCreateValidationIssue[] {
+  const schedules = input.paymentSchedules ?? []
+  if (schedules.length === 0) return []
+
+  const issues: BookingCreateValidationIssue[] = []
+  const expectedCurrency = booking.sellCurrency
+
+  schedules.forEach((schedule, index) => {
+    if (schedule.currency !== expectedCurrency) {
+      issues.push({
+        path: ["paymentSchedules", index, "currency"],
+        message: `paymentSchedules[${index}].currency must equal the booking's sellCurrency (${expectedCurrency}); got ${schedule.currency}`,
+      })
+    }
+  })
+
+  if (typeof input.confirmedSellAmountCents === "number") {
+    const sum = schedules.reduce((total, schedule) => total + schedule.amountCents, 0)
+    if (sum !== input.confirmedSellAmountCents) {
+      issues.push({
+        path: ["paymentSchedules"],
+        message: `paymentSchedules amountCents sum (${sum}) must equal confirmedSellAmountCents (${input.confirmedSellAmountCents})`,
+      })
+    }
+  }
+
+  return issues
 }
 
 function bookingItemStatusForInitialStatus(
@@ -541,6 +579,13 @@ export async function createBooking(
         // Caller gave us a product that doesn't resolve. Throw so drizzle
         // rolls back any writes the convert helper may have made.
         throw new BookingCreateAbort({ status: "product_not_found" })
+      }
+      const paymentScheduleIssues = validatePaymentSchedules(input, booking)
+      if (paymentScheduleIssues.length > 0) {
+        throw new BookingCreateAbort({
+          status: "invalid_payment_schedules",
+          issues: paymentScheduleIssues,
+        })
       }
 
       if (input.extraLines?.length) {

--- a/packages/finance/tests/integration/booking-create.test.ts
+++ b/packages/finance/tests/integration/booking-create.test.ts
@@ -186,6 +186,8 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
       productId,
       bookingNumber: nextBookingNumber(),
       ...bookingParty(),
+      catalogSellAmountCents: 50000,
+      confirmedSellAmountCents: 50000,
       travelers: [
         {
           firstName: "Alice",
@@ -309,6 +311,76 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
       .from(bookingPaymentSchedules)
       .where(eq(bookingPaymentSchedules.bookingId, outcome.result.booking.id))
     expect(scheduleRows).toHaveLength(2)
+  })
+
+  it("rejects payment schedules in a currency different from booking sell currency", async () => {
+    const { productId } = await seedProduct()
+
+    const outcome = await createBooking(db, {
+      productId,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+      catalogSellAmountCents: 33000,
+      confirmedSellAmountCents: 33000,
+      paymentSchedules: [
+        {
+          scheduleType: "deposit",
+          status: "pending",
+          dueDate: "2026-02-21",
+          currency: "RON",
+          amountCents: 16500,
+        },
+        {
+          scheduleType: "balance",
+          status: "pending",
+          dueDate: "2026-05-20",
+          currency: "EUR",
+          amountCents: 16500,
+        },
+      ],
+    })
+
+    expect(outcome.status).toBe("invalid_payment_schedules")
+    if (outcome.status !== "invalid_payment_schedules") return
+    expect(outcome.issues).toContainEqual({
+      path: ["paymentSchedules", 0, "currency"],
+      message: "paymentSchedules[0].currency must equal the booking's sellCurrency (EUR); got RON",
+    })
+
+    const bookingsRows = await db.select().from(bookings)
+    expect(bookingsRows).toHaveLength(0)
+  })
+
+  it("rejects payment schedule totals that do not match confirmed booking total", async () => {
+    const { productId } = await seedProduct()
+
+    const outcome = await createBooking(db, {
+      productId,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+      catalogSellAmountCents: 33000,
+      confirmedSellAmountCents: 33000,
+      paymentSchedules: [
+        {
+          scheduleType: "deposit",
+          status: "pending",
+          dueDate: "2026-02-21",
+          currency: "EUR",
+          amountCents: 16500,
+        },
+      ],
+    })
+
+    expect(outcome.status).toBe("invalid_payment_schedules")
+    if (outcome.status !== "invalid_payment_schedules") return
+    expect(outcome.issues).toContainEqual({
+      path: ["paymentSchedules"],
+      message:
+        "paymentSchedules amountCents sum (16500) must equal confirmedSellAmountCents (33000)",
+    })
+
+    const bookingsRows = await db.select().from(bookings)
+    expect(bookingsRows).toHaveLength(0)
   })
 
   it("creates an invoice and completed payment records for already-paid schedules", async () => {


### PR DESCRIPTION
Fixes #1208

## Summary
- Validate booking-create payment schedule currency against the product-resolved booking sell currency before schedules are persisted.
- Reject schedule amount totals that do not match `confirmedSellAmountCents` when a confirmed total is supplied.
- Bump `@voyantjs/data-sdk` to `0.1.3` to avoid the consumer-side global `this` runtime issue.
- Map invalid schedule outcomes to HTTP 400 for single and dual booking-create flows and add integration coverage.

## Verification
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/finance lint`
- `pnpm --filter @voyantjs/finance test -- tests/integration/booking-create.test.ts`
- `pnpm --filter @voyantjs/finance test -- tests/unit/invoice-fx.test.ts`
- Commit hook passed: staged lint, changed-file quality report, full lint, full typecheck
- Pre-push hook passed: full test lane
- `pnpm verify:fast` stops at existing `verify:ui-components-barrel` missing exports in `packages/ui/src/components/index.tsx` for unrelated UI modules