### PR TITLE
Bump finance data SDK to 0.1.3

### DIFF
--- a/.changeset/wise-clouds-fix.md
+++ b/.changeset/wise-clouds-fix.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/finance": patch
+---
+
+Bump the Voyant Data SDK dependency to avoid the consumer-side global this runtime issue.

--- a/packages/finance/package.json
+++ b/packages/finance/package.json
@@ -28,7 +28,7 @@
     "@voyantjs/action-ledger": "workspace:*",
     "@voyantjs/bookings": "workspace:*",
     "@voyantjs/core": "workspace:*",
-    "@voyantjs/data-sdk": "0.1.2",
+    "@voyantjs/data-sdk": "0.1.3",
     "@voyantjs/db": "workspace:*",
     "@voyantjs/hono": "workspace:*",
     "@voyantjs/products": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2848,8 +2848,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@voyantjs/data-sdk':
-        specifier: 0.1.2
-        version: 0.1.2
+        specifier: 0.1.3
+        version: 0.1.3
       '@voyantjs/db':
         specifier: workspace:*
         version: link:../db
@@ -9739,8 +9739,8 @@ packages:
   '@voyantjs/core@0.19.0':
     resolution: {integrity: sha512-L3ielbbWsjGJLkyS6Mzee0z6OD98rqyTxksKBIsaKSiCO0R/a32AXSZ/l4Y8Ek8I8ucYrwe7P4+lr+clppIrBQ==}
 
-  '@voyantjs/data-sdk@0.1.2':
-    resolution: {integrity: sha512-aVTylUeRD9IquB61G2zuau6ggB/dzF+pWhlN74W+eORI/Lw2mGS/X+N/BnrI1fE1ciYOzak8QfU2OiJriGm/4w==}
+  '@voyantjs/data-sdk@0.1.3':
+    resolution: {integrity: sha512-3BxQYksdvD5eaPSJSoNYrQwYCY4Gaj0r8SEV5f/7YgcXdP18Di3Qepme5vzqkq/5W37aj9Ia5uTRgNBQiSbOXg==}
     bundledDependencies:
       - '@voyant-sdk/sdk-core'
 
@@ -16497,7 +16497,7 @@ snapshots:
 
   '@voyantjs/core@0.19.0': {}
 
-  '@voyantjs/data-sdk@0.1.2': {}
+  '@voyantjs/data-sdk@0.1.3': {}
 
   '@voyantjs/workflows-errors@0.19.0': {}
 


### PR DESCRIPTION
## Summary
- Bump `@voyantjs/data-sdk` from `0.1.2` to `0.1.3` in `@voyantjs/finance`.
- Refresh the pnpm lockfile to resolve the new SDK package integrity.
- Add a finance patch changeset so consuming apps receive the global `this` runtime fix through the published package.

## Verification
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/finance lint`
- `pnpm --filter @voyantjs/finance test -- tests/unit/invoice-fx.test.ts`
- Commit hook passed: changed-file quality report, full lint, full typecheck
- Pre-push hook passed: full test lane