### PR TITLE
Support fiscal overrides for invoice-from-booking

### DIFF
--- a/.changeset/sharp-invoices-trade.md
+++ b/.changeset/sharp-invoices-trade.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/finance": patch
+"@voyantjs/finance-react": patch
+---
+
+Allow invoice-from-booking requests to override invoice currency and line items while validating external fiscal totals.

--- a/packages/finance-react/src/hooks/use-invoice-mutation.ts
+++ b/packages/finance-react/src/hooks/use-invoice-mutation.ts
@@ -167,8 +167,23 @@ export interface CreateInvoiceFromBookingInput {
   issueDate: string
   dueDate: string
   notes?: string | null
+  currency?: string
+  baseCurrency?: string
+  fxRateSetId?: string
+  subtotalCents?: number
+  taxCents?: number
+  totalCents?: number
+  lineItems?: CreateInvoiceFromBookingLineItemInput[]
   /** Defaults to `invoice` on the server. Pass `proforma` for placeholders. */
   invoiceType?: "invoice" | "proforma"
+}
+
+export interface CreateInvoiceFromBookingLineItemInput {
+  description: string
+  quantity: number
+  unitAmountCents: number
+  taxRateBps?: number | null
+  taxAmountCents?: number | null
 }
 
 export interface RenderInvoiceInput {

--- a/packages/finance/src/routes.ts
+++ b/packages/finance/src/routes.ts
@@ -8,6 +8,7 @@ import type { publicFinanceRoutes } from "./routes-public.js"
 import type { Env } from "./routes-shared.js"
 import {
   financeService,
+  InvoiceFromBookingValidationError,
   InvoiceNumberAllocationError,
   InvoiceNumberConflictError,
   PaymentValidationError,
@@ -1065,6 +1066,12 @@ export const financeRoutes = new Hono<Env>()
               invoiceNumber: error.invoiceNumber,
             },
             409,
+          )
+        }
+        if (error instanceof InvoiceFromBookingValidationError) {
+          return c.json(
+            { error: error.message, code: error.code, details: error.details },
+            error.status,
           )
         }
         throw error

--- a/packages/finance/src/service.ts
+++ b/packages/finance/src/service.ts
@@ -340,6 +340,18 @@ export class InvoiceNumberConflictError extends Error {
   }
 }
 
+export class InvoiceFromBookingValidationError extends Error {
+  readonly status = 400
+  readonly code = "invalid_invoice_from_booking"
+  readonly details?: Record<string, unknown>
+
+  constructor(message: string, details?: Record<string, unknown>) {
+    super(message)
+    this.name = "InvoiceFromBookingValidationError"
+    this.details = details
+  }
+}
+
 /** Booking data needed for createInvoiceFromBooking — supplied by the caller (template). */
 export interface InvoiceFromBookingData {
   booking: {
@@ -427,6 +439,58 @@ function bookingPaymentScheduleToInvoiceLine(
     taxRate: null,
     sortOrder: 0,
   }
+}
+
+function invoiceFromBookingOverrideLineItems(
+  lineItems: NonNullable<CreateInvoiceFromBookingInput["lineItems"]>,
+) {
+  return lineItems.map((line, sortOrder) => {
+    const lineSubtotalCents = line.quantity * line.unitAmountCents
+    const taxAmountCents =
+      line.taxAmountCents ??
+      (line.taxRateBps != null ? Math.round((lineSubtotalCents * line.taxRateBps) / 10_000) : 0)
+
+    return {
+      bookingItemId: null as string | null,
+      description: line.description,
+      quantity: line.quantity,
+      unitPriceCents: line.unitAmountCents,
+      totalCents: lineSubtotalCents,
+      taxRate: line.taxRateBps != null ? Math.round(line.taxRateBps / 100) : null,
+      taxAmountCents,
+      sortOrder,
+    }
+  })
+}
+
+function assertInvoiceFromBookingOverrideTotals(
+  data: CreateInvoiceFromBookingInput,
+  totals: { subtotalCents: number; taxCents: number; totalCents: number },
+) {
+  if (data.subtotalCents !== undefined && data.subtotalCents !== totals.subtotalCents) {
+    throw new InvoiceFromBookingValidationError("Invoice subtotal does not match line items", {
+      expectedSubtotalCents: totals.subtotalCents,
+      subtotalCents: data.subtotalCents,
+    })
+  }
+
+  if (data.taxCents !== undefined && data.taxCents !== totals.taxCents) {
+    throw new InvoiceFromBookingValidationError("Invoice tax does not match line items", {
+      expectedTaxCents: totals.taxCents,
+      taxCents: data.taxCents,
+    })
+  }
+
+  if (data.totalCents !== undefined && data.totalCents !== totals.totalCents) {
+    throw new InvoiceFromBookingValidationError("Invoice total does not match subtotal plus tax", {
+      expectedTotalCents: totals.totalCents,
+      totalCents: data.totalCents,
+    })
+  }
+}
+
+function normalizeCurrencyCode(value: string | null | undefined) {
+  return value?.trim().toUpperCase() ?? null
 }
 
 function resolveBookingInvoiceBaseAmount(
@@ -3368,9 +3432,46 @@ export const financeService = {
     runtime: FinanceServiceRuntime = {},
   ) {
     const { booking, items, paymentSchedule } = bookingData
-    const numberAssignment = await resolveInvoiceNumberForBooking(db, data)
+    const requestedCurrency = normalizeCurrencyCode(data.currency)
+    const bookingSellCurrency = normalizeCurrencyCode(booking.sellCurrency) ?? booking.sellCurrency
+    const invoiceCurrency =
+      requestedCurrency ?? normalizeCurrencyCode(paymentSchedule?.currency) ?? bookingSellCurrency
+    const requestedBaseCurrency = normalizeCurrencyCode(data.baseCurrency)
+    const hasCrossCurrencyOverride =
+      requestedCurrency !== null && requestedCurrency !== bookingSellCurrency
 
-    const invoiceItems = paymentSchedule ? [] : items
+    if (
+      hasCrossCurrencyOverride &&
+      (!requestedBaseCurrency || requestedBaseCurrency !== bookingSellCurrency)
+    ) {
+      throw new InvoiceFromBookingValidationError(
+        "Cross-currency invoice overrides require baseCurrency to match the booking sell currency",
+        {
+          currency: invoiceCurrency,
+          baseCurrency: requestedBaseCurrency,
+          bookingSellCurrency,
+        },
+      )
+    }
+
+    const overrideLineItems = data.lineItems
+      ? invoiceFromBookingOverrideLineItems(data.lineItems)
+      : null
+
+    if (hasCrossCurrencyOverride && !overrideLineItems) {
+      throw new InvoiceFromBookingValidationError(
+        "Cross-currency invoice overrides require replacement line items",
+        {
+          currency: invoiceCurrency,
+          baseCurrency: requestedBaseCurrency,
+          bookingSellCurrency,
+          fields: ["lineItems"],
+        },
+      )
+    }
+
+    const shouldUseBookingItems = overrideLineItems === null && !paymentSchedule
+    const invoiceItems = shouldUseBookingItems ? items : []
     const itemIds = invoiceItems.map((item) => item.id)
 
     const taxes =
@@ -3396,68 +3497,91 @@ export const financeService = {
       taxesByBookingItemId.set(tax.bookingItemId, existing)
     }
 
-    const lineItems = paymentSchedule
-      ? [bookingPaymentScheduleToInvoiceLine(booking, paymentSchedule)]
-      : invoiceItems.length > 0
-        ? invoiceItems.map((item, sortOrder) => ({
-            ...bookingItemToInvoiceLine(item, taxesByBookingItemId.get(item.id) ?? [], sortOrder),
-          }))
-        : [
-            {
-              bookingItemId: null as string | null,
-              description: `Booking ${booking.bookingNumber}`,
-              quantity: 1,
-              unitPriceCents: booking.sellAmountCents ?? 0,
-              totalCents: booking.sellAmountCents ?? 0,
-              taxRate: null,
-              sortOrder: 0,
-            },
-          ]
+    const lineItems =
+      overrideLineItems ??
+      (paymentSchedule
+        ? [bookingPaymentScheduleToInvoiceLine(booking, paymentSchedule)]
+        : invoiceItems.length > 0
+          ? invoiceItems.map((item, sortOrder) => ({
+              ...bookingItemToInvoiceLine(item, taxesByBookingItemId.get(item.id) ?? [], sortOrder),
+            }))
+          : [
+              {
+                bookingItemId: null as string | null,
+                description: `Booking ${booking.bookingNumber}`,
+                quantity: 1,
+                unitPriceCents: booking.sellAmountCents ?? 0,
+                totalCents: booking.sellAmountCents ?? 0,
+                taxRate: null,
+                sortOrder: 0,
+              },
+            ])
 
     const grossLineTotalCents = lineItems.reduce((sum, line) => sum + line.totalCents, 0)
-    const includedTaxCents = taxes.reduce((sum, tax) => {
-      if (tax.scope === "withheld" || !tax.includedInPrice) return sum
-      return sum + tax.amountCents
-    }, 0)
-    const excludedTaxCents = taxes.reduce((sum, tax) => {
-      if (tax.scope === "withheld" || tax.includedInPrice) return sum
-      return sum + tax.amountCents
-    }, 0)
+    const includedTaxCents = overrideLineItems
+      ? 0
+      : taxes.reduce((sum, tax) => {
+          if (tax.scope === "withheld" || !tax.includedInPrice) return sum
+          return sum + tax.amountCents
+        }, 0)
+    const excludedTaxCents = overrideLineItems
+      ? overrideLineItems.reduce((sum, line) => sum + line.taxAmountCents, 0)
+      : taxes.reduce((sum, tax) => {
+          if (tax.scope === "withheld" || tax.includedInPrice) return sum
+          return sum + tax.amountCents
+        }, 0)
     const subtotalCents = Math.max(0, grossLineTotalCents - includedTaxCents)
     const taxCents = includedTaxCents + excludedTaxCents
     const totalCents = subtotalCents + taxCents
-    const commissionAmountCents = commissions.reduce((sum, commission) => {
-      return sum + (commission.amountCents ?? 0)
-    }, 0)
+    assertInvoiceFromBookingOverrideTotals(data, { subtotalCents, taxCents, totalCents })
+    const commissionAmountCents = overrideLineItems
+      ? 0
+      : commissions.reduce((sum, commission) => {
+          return sum + (commission.amountCents ?? 0)
+        }, 0)
 
     // The `ck_invoices_base_currency_amounts` constraint requires
     // that whenever ANY base_*_cents column is non-null, base_currency
     // must be set too. Resolve the base side once and propagate nulls
     // consistently when no booking/runtime base currency is available.
-    const invoiceCurrency = paymentSchedule?.currency ?? booking.sellCurrency
     const bookingBaseAmountCents = paymentSchedule
       ? resolveBookingInvoiceBaseAmount(booking, invoiceCurrency, paymentSchedule.amountCents)
       : (booking.baseSellAmountCents ?? null)
+    const invoiceBaseCurrency = requestedBaseCurrency ?? booking.baseCurrency ?? null
+    const invoiceFxRateSetId = data.fxRateSetId ?? booking.fxRateSetId ?? null
     const resolvedInvoiceBase = await resolveFxMoneyBaseAmount(
       db,
       {
         amountCents: totalCents,
         currency: invoiceCurrency,
-        baseCurrency: booking.baseCurrency ?? null,
-        baseAmountCents: bookingBaseAmountCents,
-        fxRateSetId: booking.fxRateSetId ?? null,
+        baseCurrency: invoiceBaseCurrency,
+        baseAmountCents: hasCrossCurrencyOverride ? null : bookingBaseAmountCents,
+        fxRateSetId: invoiceFxRateSetId,
       },
       {
         ...runtime,
-        targetBaseCurrency: booking.baseCurrency ?? null,
-        fallbackFxRateSetId: booking.fxRateSetId ?? null,
+        targetBaseCurrency: invoiceBaseCurrency,
+        fallbackFxRateSetId: invoiceFxRateSetId,
         date: data.issueDate,
-        setBaseCurrencyWhenUnresolved: Boolean(booking.baseCurrency),
+        setBaseCurrencyWhenUnresolved: Boolean(invoiceBaseCurrency),
       },
     )
-    const invoiceBaseCurrency = resolvedInvoiceBase.baseCurrency ?? null
+    const resolvedBaseCurrency = resolvedInvoiceBase.baseCurrency ?? null
     const invoiceBaseAmountCents = resolvedInvoiceBase.baseAmountCents ?? null
-    const hasBaseCurrency = Boolean(invoiceBaseCurrency)
+    const hasBaseCurrency = Boolean(resolvedBaseCurrency)
+
+    if (hasCrossCurrencyOverride && invoiceBaseAmountCents === null) {
+      throw new InvoiceFromBookingValidationError(
+        "Cross-currency invoice overrides require a resolvable base total",
+        {
+          currency: invoiceCurrency,
+          baseCurrency: requestedBaseCurrency,
+          fxRateSetId: invoiceFxRateSetId,
+        },
+      )
+    }
+
+    const numberAssignment = await resolveInvoiceNumberForBooking(db, data)
 
     try {
       return await db.transaction(async (tx) => {
@@ -3473,7 +3597,7 @@ export const financeService = {
             organizationId: booking.organizationId,
             status: numberAssignment.status,
             currency: invoiceCurrency,
-            baseCurrency: invoiceBaseCurrency,
+            baseCurrency: resolvedBaseCurrency,
             fxRateSetId: resolvedInvoiceBase.fxRateSetId ?? null,
             subtotalCents,
             baseSubtotalCents: hasBaseCurrency ? invoiceBaseAmountCents : null,

--- a/packages/finance/src/validation-billing.ts
+++ b/packages/finance/src/validation-billing.ts
@@ -114,6 +114,20 @@ const invoiceDocumentWaitFieldsSchema = z.object({
   waitTimeoutMs: z.coerce.number().int().min(0).max(60_000).optional(),
 })
 
+const currencyCodeSchema = z
+  .string()
+  .trim()
+  .length(3)
+  .transform((value) => value.toUpperCase())
+
+const invoiceFromBookingLineItemSchema = z.object({
+  description: z.string().min(1).max(500),
+  quantity: z.number().int().min(1),
+  unitAmountCents: z.number().int().min(0),
+  taxRateBps: z.number().int().min(0).optional().nullable(),
+  taxAmountCents: z.number().int().min(0).optional().nullable(),
+})
+
 export const invoiceFromBookingSchema = z.object({
   bookingId: z.string().min(1),
   bookingPaymentScheduleId: z.string().min(1).optional(),
@@ -122,6 +136,13 @@ export const invoiceFromBookingSchema = z.object({
   issueDate: z.string().min(1),
   dueDate: z.string().min(1),
   notes: z.string().optional().nullable(),
+  currency: currencyCodeSchema.optional(),
+  baseCurrency: currencyCodeSchema.optional(),
+  fxRateSetId: z.string().min(1).optional(),
+  subtotalCents: z.number().int().min(0).optional(),
+  taxCents: z.number().int().min(0).optional(),
+  totalCents: z.number().int().min(0).optional(),
+  lineItems: z.array(invoiceFromBookingLineItemSchema).min(1).optional(),
   /**
    * Document kind. Defaults to a regular invoice; bank-transfer
    * checkout flows pass `proforma` to issue a placeholder doc until

--- a/packages/finance/tests/unit/service-invoice-number-allocation.test.ts
+++ b/packages/finance/tests/unit/service-invoice-number-allocation.test.ts
@@ -4,6 +4,7 @@ import { invoiceLineItems, invoiceNumberSeries, invoices } from "../../src/schem
 import {
   financeService,
   type InvoiceFromBookingData,
+  type InvoiceFromBookingValidationError,
   type InvoiceNumberAllocationError,
   type InvoiceNumberConflictError,
 } from "../../src/service.js"
@@ -51,6 +52,7 @@ function makeDb(options: {
   invoiceInsertError?: unknown
 }) {
   const insertedInvoices: Array<Record<string, unknown>> = []
+  const insertedInvoiceLineItems: Array<Record<string, unknown>> = []
   const execute = vi.fn(async () => {
     const row = options.explicitSeries ?? options.defaultSeries
     return row
@@ -95,6 +97,7 @@ function makeDb(options: {
           }
         }
         if (table === invoiceLineItems) {
+          insertedInvoiceLineItems.push(...values)
           return Promise.resolve(values)
         }
         return { returning: vi.fn(async () => []) }
@@ -104,10 +107,20 @@ function makeDb(options: {
 
   const db = {
     transaction: vi.fn(async (callback) => callback(tx)),
-    select: vi.fn(() => ({
+    select: vi.fn((selection?: unknown) => ({
       from: vi.fn((table) => {
         if (table !== invoiceNumberSeries) {
-          return { where: vi.fn(async () => []) }
+          const rows: Array<Record<string, unknown>> = []
+          if (selection) {
+            return {
+              where: vi.fn(() => ({
+                orderBy: vi.fn(() => ({
+                  limit: vi.fn(async () => rows),
+                })),
+              })),
+            }
+          }
+          return { where: vi.fn(async () => rows) }
         }
         return {
           where: vi.fn(() => ({
@@ -133,7 +146,7 @@ function makeDb(options: {
     })),
   }
 
-  return { db: db as never, tx, insertedInvoices }
+  return { db: db as never, tx, insertedInvoices, insertedInvoiceLineItems }
 }
 
 describe("financeService.createInvoiceFromBooking number allocation", () => {
@@ -270,5 +283,166 @@ describe("financeService.createInvoiceFromBooking number allocation", () => {
       code: "invoice_number_conflict",
       invoiceNumber: "MANUAL-1",
     } satisfies Partial<InvoiceNumberConflictError>)
+  })
+
+  it("uses override line items and computes cross-currency base totals", async () => {
+    const { db, insertedInvoices, insertedInvoiceLineItems } = makeDb({})
+
+    await financeService.createInvoiceFromBooking(
+      db,
+      {
+        bookingId: "book_123",
+        invoiceNumber: "MANUAL-1",
+        issueDate: "2026-05-23",
+        dueDate: "2026-06-23",
+        currency: "RON",
+        baseCurrency: "EUR",
+        lineItems: [
+          {
+            description: "SmartBill fiscal line",
+            quantity: 1,
+            unitAmountCents: 50_000,
+            taxRateBps: 1_900,
+          },
+        ],
+      },
+      {
+        booking: {
+          ...bookingData.booking,
+          sellCurrency: "EUR",
+        },
+        items: [
+          {
+            id: "bkit_123",
+            title: "Catalog line that should be replaced",
+            quantity: 1,
+            unitSellAmountCents: 12_000,
+            totalSellAmountCents: 12_000,
+          },
+        ],
+      },
+      {
+        resolveInvoiceExchangeRate: vi.fn(async () => ({ rate: 0.2, fxRateSetId: "fxrs_123" })),
+      },
+    )
+
+    expect(insertedInvoices[0]).toMatchObject({
+      currency: "RON",
+      baseCurrency: "EUR",
+      fxRateSetId: "fxrs_123",
+      subtotalCents: 50_000,
+      taxCents: 9_500,
+      totalCents: 59_500,
+      baseTotalCents: 11_900,
+      balanceDueCents: 59_500,
+      baseBalanceDueCents: 11_900,
+    })
+    expect(insertedInvoiceLineItems).toEqual([
+      expect.objectContaining({
+        bookingItemId: null,
+        description: "SmartBill fiscal line",
+        quantity: 1,
+        unitPriceCents: 50_000,
+        totalCents: 50_000,
+        taxRate: 19,
+        sortOrder: 0,
+      }),
+    ])
+  })
+
+  it("rejects cross-currency overrides without the booking sell currency as base", async () => {
+    const { db } = makeDb({})
+
+    await expect(
+      financeService.createInvoiceFromBooking(
+        db,
+        {
+          bookingId: "book_123",
+          invoiceNumber: "MANUAL-1",
+          issueDate: "2026-05-23",
+          dueDate: "2026-06-23",
+          currency: "RON",
+          lineItems: [
+            {
+              description: "SmartBill fiscal line",
+              quantity: 1,
+              unitAmountCents: 50_000,
+            },
+          ],
+        },
+        {
+          booking: {
+            ...bookingData.booking,
+            sellCurrency: "EUR",
+          },
+          items: [],
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: "invalid_invoice_from_booking",
+    } satisfies Partial<InvoiceFromBookingValidationError>)
+  })
+
+  it("rejects cross-currency overrides without replacement line items", async () => {
+    const { db } = makeDb({})
+
+    await expect(
+      financeService.createInvoiceFromBooking(
+        db,
+        {
+          bookingId: "book_123",
+          invoiceNumber: "MANUAL-1",
+          issueDate: "2026-05-23",
+          dueDate: "2026-06-23",
+          currency: "RON",
+          baseCurrency: "EUR",
+        },
+        {
+          booking: {
+            ...bookingData.booking,
+            sellCurrency: "EUR",
+          },
+          items: [
+            {
+              id: "bkit_123",
+              title: "Catalog line that must not be relabeled",
+              quantity: 1,
+              unitSellAmountCents: 12_000,
+              totalSellAmountCents: 12_000,
+            },
+          ],
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: "invalid_invoice_from_booking",
+      message: "Cross-currency invoice overrides require replacement line items",
+    } satisfies Partial<InvoiceFromBookingValidationError>)
+  })
+
+  it("rejects override totals that do not match the supplied line items", async () => {
+    const { db } = makeDb({})
+
+    await expect(
+      financeService.createInvoiceFromBooking(
+        db,
+        {
+          bookingId: "book_123",
+          invoiceNumber: "MANUAL-1",
+          issueDate: "2026-05-23",
+          dueDate: "2026-06-23",
+          subtotalCents: 40_000,
+          lineItems: [
+            {
+              description: "SmartBill fiscal line",
+              quantity: 1,
+              unitAmountCents: 50_000,
+            },
+          ],
+        },
+        bookingData,
+      ),
+    ).rejects.toMatchObject({
+      code: "invalid_invoice_from_booking",
+    } satisfies Partial<InvoiceFromBookingValidationError>)
   })
 })

--- a/packages/finance/tests/unit/validation-billing.test.ts
+++ b/packages/finance/tests/unit/validation-billing.test.ts
@@ -44,6 +44,33 @@ describe("invoiceFromBookingSchema", () => {
     expect(result.wait).toBe("pdf")
     expect(result.waitTimeoutMs).toBe(10_000)
   })
+
+  it("accepts currency and line item overrides for externally issued invoices", () => {
+    const result = invoiceFromBookingSchema.parse({
+      bookingId: "book_123",
+      invoiceNumber: "INV-123",
+      issueDate: "2026-05-23",
+      dueDate: "2026-06-23",
+      currency: "ron",
+      baseCurrency: "eur",
+      fxRateSetId: "fxrs_123",
+      subtotalCents: 50_000,
+      taxCents: 9_500,
+      totalCents: 59_500,
+      lineItems: [
+        {
+          description: "External fiscal invoice line",
+          quantity: 1,
+          unitAmountCents: 50_000,
+          taxRateBps: 1_900,
+        },
+      ],
+    })
+
+    expect(result.currency).toBe("RON")
+    expect(result.baseCurrency).toBe("EUR")
+    expect(result.lineItems?.[0]?.unitAmountCents).toBe(50_000)
+  })
 })
 
 describe("renderInvoiceInputSchema", () => {


### PR DESCRIPTION
## Summary
- add invoice-from-booking currency, base currency, FX rate set, total, and line-item override inputs
- replace catalog-derived invoice lines when override line items are supplied and validate supplied totals against computed line totals
- compute cross-currency base totals through the existing FX resolution path and return structured 400s for invalid override requests
- expose the new input shape from finance-react

Closes #1216

## Verification
- pnpm --filter @voyantjs/finance lint
- pnpm --filter @voyantjs/finance typecheck
- pnpm --filter @voyantjs/finance-react lint
- pnpm --filter @voyantjs/finance-react typecheck
- pnpm --filter @voyantjs/finance test -- --run packages/finance/tests/unit/validation-billing.test.ts packages/finance/tests/unit/service-invoice-number-allocation.test.ts
- pre-commit full lint/typecheck hook
- pre-push full test hook