### PR TITLE
Fix invoice-from-booking external refs

### DIFF
--- a/.changeset/invoice-from-booking-external-refs.md
+++ b/.changeset/invoice-from-booking-external-refs.md
@@ -1,0 +1,7 @@
+---
+"@voyantjs/finance": patch
+"@voyantjs/finance-react": patch
+"@voyantjs/plugin-smartbill": patch
+---
+
+Allow invoice-from-booking requests to pre-seed invoice external refs before issued events run.

--- a/packages/finance-react/src/hooks/use-invoice-mutation.ts
+++ b/packages/finance-react/src/hooks/use-invoice-mutation.ts
@@ -174,8 +174,20 @@ export interface CreateInvoiceFromBookingInput {
   taxCents?: number
   totalCents?: number
   lineItems?: CreateInvoiceFromBookingLineItemInput[]
+  externalRefs?: CreateInvoiceFromBookingExternalRefInput[]
   /** Defaults to `invoice` on the server. Pass `proforma` for placeholders. */
   invoiceType?: "invoice" | "proforma"
+}
+
+export interface CreateInvoiceFromBookingExternalRefInput {
+  provider: string
+  externalId?: string | null
+  externalNumber?: string | null
+  externalUrl?: string | null
+  status?: string | null
+  metadata?: Record<string, unknown> | null
+  syncedAt?: string | null
+  syncError?: string | null
 }
 
 export interface CreateInvoiceFromBookingLineItemInput {

--- a/packages/finance/src/service.ts
+++ b/packages/finance/src/service.ts
@@ -499,6 +499,23 @@ function normalizeCurrencyCode(value: string | null | undefined) {
   return value?.trim().toUpperCase() ?? null
 }
 
+function invoiceFromBookingExternalRefValues(
+  invoiceId: string,
+  refs: NonNullable<CreateInvoiceFromBookingInput["externalRefs"]>,
+) {
+  return refs.map((ref) => ({
+    invoiceId,
+    provider: ref.provider,
+    externalId: ref.externalId ?? null,
+    externalNumber: ref.externalNumber ?? null,
+    externalUrl: ref.externalUrl ?? null,
+    status: ref.status ?? null,
+    metadata: ref.metadata ?? null,
+    syncedAt: toTimestamp(ref.syncedAt),
+    syncError: ref.syncError ?? null,
+  }))
+}
+
 function resolveBookingInvoiceBaseAmount(
   booking: InvoiceFromBookingData["booking"],
   invoiceCurrency: string,
@@ -3653,6 +3670,12 @@ export const financeService = {
 
         if (!invoice) {
           return null
+        }
+
+        if (data.externalRefs?.length) {
+          await tx
+            .insert(invoiceExternalRefs)
+            .values(invoiceFromBookingExternalRefValues(invoice.id, data.externalRefs))
         }
 
         await tx.insert(invoiceLineItems).values(

--- a/packages/finance/src/validation-billing.ts
+++ b/packages/finance/src/validation-billing.ts
@@ -128,30 +128,56 @@ const invoiceFromBookingLineItemSchema = z.object({
   taxAmountCents: z.number().int().min(0).optional().nullable(),
 })
 
-export const invoiceFromBookingSchema = z.object({
-  bookingId: z.string().min(1),
-  bookingPaymentScheduleId: z.string().min(1).optional(),
-  invoiceNumber: z.string().min(1).max(50).optional(),
-  seriesId: z.string().min(1).optional(),
-  issueDate: z.string().min(1),
-  dueDate: z.string().min(1),
-  notes: z.string().optional().nullable(),
-  currency: currencyCodeSchema.optional(),
-  baseCurrency: currencyCodeSchema.optional(),
-  fxRateSetId: z.string().min(1).optional(),
-  subtotalCents: z.number().int().min(0).optional(),
-  taxCents: z.number().int().min(0).optional(),
-  totalCents: z.number().int().min(0).optional(),
-  lineItems: z.array(invoiceFromBookingLineItemSchema).min(1).optional(),
-  /**
-   * Document kind. Defaults to a regular invoice; bank-transfer
-   * checkout flows pass `proforma` to issue a placeholder doc until
-   * payment lands and a real invoice replaces it.
-   */
-  invoiceType: z.enum(["invoice", "proforma"]).default("invoice"),
-  wait: invoiceDocumentWaitModeSchema.optional(),
-  waitTimeoutMs: z.coerce.number().int().min(0).max(60_000).optional(),
+const invoiceExternalRefCoreSchema = z.object({
+  provider: z.string().min(1).max(100),
+  externalId: z.string().max(255).optional().nullable(),
+  externalNumber: z.string().max(255).optional().nullable(),
+  externalUrl: z.string().max(1000).optional().nullable(),
+  status: z.string().max(100).optional().nullable(),
+  metadata: z.record(z.string(), z.unknown()).optional().nullable(),
+  syncedAt: z.string().optional().nullable(),
+  syncError: z.string().optional().nullable(),
 })
+
+export const invoiceFromBookingSchema = z
+  .object({
+    bookingId: z.string().min(1),
+    bookingPaymentScheduleId: z.string().min(1).optional(),
+    invoiceNumber: z.string().min(1).max(50).optional(),
+    seriesId: z.string().min(1).optional(),
+    issueDate: z.string().min(1),
+    dueDate: z.string().min(1),
+    notes: z.string().optional().nullable(),
+    currency: currencyCodeSchema.optional(),
+    baseCurrency: currencyCodeSchema.optional(),
+    fxRateSetId: z.string().min(1).optional(),
+    subtotalCents: z.number().int().min(0).optional(),
+    taxCents: z.number().int().min(0).optional(),
+    totalCents: z.number().int().min(0).optional(),
+    lineItems: z.array(invoiceFromBookingLineItemSchema).min(1).optional(),
+    externalRefs: z.array(invoiceExternalRefCoreSchema).optional(),
+    /**
+     * Document kind. Defaults to a regular invoice; bank-transfer
+     * checkout flows pass `proforma` to issue a placeholder doc until
+     * payment lands and a real invoice replaces it.
+     */
+    invoiceType: z.enum(["invoice", "proforma"]).default("invoice"),
+    wait: invoiceDocumentWaitModeSchema.optional(),
+    waitTimeoutMs: z.coerce.number().int().min(0).max(60_000).optional(),
+  })
+  .superRefine((value, ctx) => {
+    const providers = new Set<string>()
+    for (const [index, ref] of (value.externalRefs ?? []).entries()) {
+      if (providers.has(ref.provider)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Duplicate invoice external ref provider",
+          path: ["externalRefs", index, "provider"],
+        })
+      }
+      providers.add(ref.provider)
+    }
+  })
 
 const lineItemCoreSchema = z.object({
   bookingItemId: z.string().optional().nullable(),
@@ -368,16 +394,6 @@ export const taxPolicyRuleListQuerySchema = paginationSchema.extend({
   active: z.coerce.boolean().optional(),
 })
 
-const invoiceExternalRefCoreSchema = z.object({
-  provider: z.string().min(1).max(100),
-  externalId: z.string().max(255).optional().nullable(),
-  externalNumber: z.string().max(255).optional().nullable(),
-  externalUrl: z.string().max(1000).optional().nullable(),
-  status: z.string().max(100).optional().nullable(),
-  metadata: z.record(z.string(), z.unknown()).optional().nullable(),
-  syncedAt: z.string().optional().nullable(),
-  syncError: z.string().optional().nullable(),
-})
 export const insertInvoiceExternalRefSchema = invoiceExternalRefCoreSchema
 export const updateInvoiceExternalRefSchema = invoiceExternalRefCoreSchema.partial()
 

--- a/packages/finance/tests/unit/service-invoice-number-allocation.test.ts
+++ b/packages/finance/tests/unit/service-invoice-number-allocation.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { invoiceLineItems, invoiceNumberSeries, invoices } from "../../src/schema.js"
+import {
+  invoiceExternalRefs,
+  invoiceLineItems,
+  invoiceNumberSeries,
+  invoices,
+} from "../../src/schema.js"
 import {
   financeService,
   type InvoiceFromBookingData,
@@ -52,6 +57,7 @@ function makeDb(options: {
   invoiceInsertError?: unknown
 }) {
   const insertedInvoices: Array<Record<string, unknown>> = []
+  const insertedInvoiceExternalRefs: Array<Record<string, unknown>> = []
   const insertedInvoiceLineItems: Array<Record<string, unknown>> = []
   const execute = vi.fn(async () => {
     const row = options.explicitSeries ?? options.defaultSeries
@@ -100,6 +106,10 @@ function makeDb(options: {
           insertedInvoiceLineItems.push(...values)
           return Promise.resolve(values)
         }
+        if (table === invoiceExternalRefs) {
+          insertedInvoiceExternalRefs.push(...values)
+          return Promise.resolve(values)
+        }
         return { returning: vi.fn(async () => []) }
       }),
     })),
@@ -146,7 +156,13 @@ function makeDb(options: {
     })),
   }
 
-  return { db: db as never, tx, insertedInvoices, insertedInvoiceLineItems }
+  return {
+    db: db as never,
+    tx,
+    insertedInvoices,
+    insertedInvoiceExternalRefs,
+    insertedInvoiceLineItems,
+  }
 }
 
 describe("financeService.createInvoiceFromBooking number allocation", () => {
@@ -346,6 +362,46 @@ describe("financeService.createInvoiceFromBooking number allocation", () => {
         totalCents: 50_000,
         taxRate: 19,
         sortOrder: 0,
+      }),
+    ])
+  })
+
+  it("persists external refs in the invoice transaction", async () => {
+    const { db, insertedInvoiceExternalRefs } = makeDb({})
+
+    await financeService.createInvoiceFromBooking(
+      db,
+      {
+        bookingId: "book_123",
+        invoiceNumber: "SB-42",
+        issueDate: "2026-05-23",
+        dueDate: "2026-06-23",
+        externalRefs: [
+          {
+            provider: "smartbill",
+            externalId: "remote_42",
+            externalNumber: "42",
+            externalUrl: "https://smartbill.test/invoices/42",
+            status: "issued",
+            metadata: { companyVatCode: "RO12345678" },
+            syncedAt: "2026-05-23T10:30:00.000Z",
+          },
+        ],
+      },
+      bookingData,
+    )
+
+    expect(insertedInvoiceExternalRefs).toEqual([
+      expect.objectContaining({
+        invoiceId: "inv_123",
+        provider: "smartbill",
+        externalId: "remote_42",
+        externalNumber: "42",
+        externalUrl: "https://smartbill.test/invoices/42",
+        status: "issued",
+        metadata: { companyVatCode: "RO12345678" },
+        syncedAt: new Date("2026-05-23T10:30:00.000Z"),
+        syncError: null,
       }),
     ])
   })

--- a/packages/finance/tests/unit/validation-billing.test.ts
+++ b/packages/finance/tests/unit/validation-billing.test.ts
@@ -71,6 +71,50 @@ describe("invoiceFromBookingSchema", () => {
     expect(result.baseCurrency).toBe("EUR")
     expect(result.lineItems?.[0]?.unitAmountCents).toBe(50_000)
   })
+
+  it("accepts external refs for externally issued invoices", () => {
+    const result = invoiceFromBookingSchema.parse({
+      bookingId: "book_123",
+      invoiceNumber: "SB-42",
+      issueDate: "2026-05-23",
+      dueDate: "2026-06-23",
+      externalRefs: [
+        {
+          provider: "smartbill",
+          externalId: "remote_42",
+          externalNumber: "42",
+          externalUrl: "https://smartbill.test/invoices/42",
+          status: "issued",
+          metadata: { companyVatCode: "RO12345678" },
+          syncedAt: "2026-05-23T10:30:00.000Z",
+        },
+      ],
+    })
+
+    expect(result.externalRefs).toEqual([
+      expect.objectContaining({
+        provider: "smartbill",
+        externalId: "remote_42",
+        externalNumber: "42",
+        status: "issued",
+      }),
+    ])
+  })
+
+  it("rejects duplicate external ref providers", () => {
+    expect(() =>
+      invoiceFromBookingSchema.parse({
+        bookingId: "book_123",
+        invoiceNumber: "SB-42",
+        issueDate: "2026-05-23",
+        dueDate: "2026-06-23",
+        externalRefs: [
+          { provider: "smartbill", externalNumber: "42" },
+          { provider: "smartbill", externalNumber: "43" },
+        ],
+      }),
+    ).toThrow("Duplicate invoice external ref provider")
+  })
 })
 
 describe("renderInvoiceInputSchema", () => {

--- a/packages/plugins/smartbill/src/sync.ts
+++ b/packages/plugins/smartbill/src/sync.ts
@@ -515,5 +515,6 @@ function isMatchingSmartbillRef(
   documentType: SmartbillDocumentType,
 ) {
   if (!isUsableSmartbillRef(ref)) return false
-  return metadataString(coerceMetadata(ref.metadata), "documentType") === documentType
+  const metadataDocumentType = metadataString(coerceMetadata(ref.metadata), "documentType")
+  return !metadataDocumentType || metadataDocumentType === documentType
 }

--- a/packages/plugins/smartbill/tests/unit/sync.test.ts
+++ b/packages/plugins/smartbill/tests/unit/sync.test.ts
@@ -172,4 +172,51 @@ describe("syncSmartbillInvoiceEvent", () => {
     expect(result.status).toBe("existing_ref")
     expect(client.createInvoice).not.toHaveBeenCalled()
   })
+
+  it("reuses an externally seeded SmartBill ref without document metadata", async () => {
+    const client = makeClient()
+    financeServiceMock.listInvoiceExternalRefs.mockResolvedValueOnce([
+      {
+        id: "iex_existing",
+        invoiceId: "inv_123",
+        provider: "smartbill",
+        externalId: "remote_42",
+        externalNumber: "42",
+        externalUrl: null,
+        status: "issued",
+        syncError: null,
+        metadata: null,
+      },
+    ])
+
+    const result = await syncSmartbillInvoiceEvent({
+      event: { id: "inv_123", lineItems: [] },
+      documentType: "invoice",
+      runtime: {
+        client,
+        logger: { error: vi.fn(), info: vi.fn() },
+        mapEvent: vi.fn().mockResolvedValue({
+          companyVatCode: "RO12345678",
+          client: { name: "Client" },
+          seriesName: "A",
+          currency: "RON",
+          products: [],
+        }),
+        eventNames: {
+          issued: "invoice.issued",
+          proformaIssued: "invoice.proforma.issued",
+          voided: "invoice.voided",
+          syncRequested: "invoice.external.sync.requested",
+        },
+        artifacts: { db: {} as never },
+        idempotency: { skipExistingExternalRef: true },
+        onError: undefined,
+        writeBackInvoiceNumber: undefined,
+      },
+      pluginOptions: basePluginOptions,
+    })
+
+    expect(result.status).toBe("existing_ref")
+    expect(client.createInvoice).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary
- add `externalRefs[]` to invoice-from-booking validation and persist those refs in the same transaction as the invoice
- expose the new input shape through the finance React mutation type
- let SmartBill reuse a usable pre-seeded ref even when provider-specific document metadata is absent

Closes #1220

## Verification
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/finance-react typecheck`
- `pnpm --filter @voyantjs/plugin-smartbill typecheck`
- `pnpm --filter @voyantjs/finance test -- tests/unit/validation-billing.test.ts tests/unit/service-invoice-number-allocation.test.ts`
- `pnpm --filter @voyantjs/plugin-smartbill test -- tests/unit/sync.test.ts`
- `pnpm --filter @voyantjs/finance lint && pnpm --filter @voyantjs/plugin-smartbill lint && pnpm --filter @voyantjs/finance-react lint`
- pre-push `pnpm test` workspace suite