### PR TITLE
Fix lead traveler adult category state

### DIFF
--- a/.changeset/lead-traveler-adult-category.md
+++ b/.changeset/lead-traveler-adult-category.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/bookings-ui": patch
+---
+
+Show the Adult traveler category as selected for lead travelers in booking creation.

--- a/packages/bookings-ui/src/components/traveler-category-buttons.ts
+++ b/packages/bookings-ui/src/components/traveler-category-buttons.ts
@@ -1,0 +1,51 @@
+export type TravelerCategoryRole = "lead" | "adult" | "child" | "infant"
+
+export interface TravelerCategoryState {
+  role: TravelerCategoryRole
+  roomUnitId: string | null
+}
+
+export interface TravelerCategoryUnitState {
+  unitId: string
+  unitCode: string | null
+}
+
+export function inferTravelerRoleFromUnit(
+  unit: TravelerCategoryUnitState,
+): Exclude<TravelerCategoryRole, "lead"> {
+  const codeLower = (unit.unitCode ?? "").toLowerCase()
+  if (codeLower === "child") return "child"
+  if (codeLower === "infant") return "infant"
+  return "adult"
+}
+
+export function getStaticTravelerCategoryButtonState(
+  traveler: TravelerCategoryState,
+  category: Exclude<TravelerCategoryRole, "lead">,
+): { active: boolean; nextRole: TravelerCategoryRole; shouldUpdate: boolean } {
+  const active = traveler.role === category || (traveler.role === "lead" && category === "adult")
+  const nextRole = traveler.role === "lead" && category === "adult" ? "lead" : category
+
+  return {
+    active,
+    nextRole,
+    shouldUpdate: traveler.role !== nextRole,
+  }
+}
+
+export function getDynamicTravelerCategoryButtonState(
+  traveler: TravelerCategoryState,
+  unit: TravelerCategoryUnitState,
+): { active: boolean; nextRole: TravelerCategoryRole; shouldUpdate: boolean } {
+  const inferredRole = inferTravelerRoleFromUnit(unit)
+  const active =
+    traveler.roomUnitId === unit.unitId ||
+    (traveler.role === "lead" && inferredRole === "adult" && traveler.roomUnitId == null)
+  const nextRole = traveler.role === "lead" && inferredRole === "adult" ? "lead" : inferredRole
+
+  return {
+    active,
+    nextRole,
+    shouldUpdate: traveler.roomUnitId !== unit.unitId || traveler.role !== nextRole,
+  }
+}

--- a/packages/bookings-ui/src/components/travelers-section.tsx
+++ b/packages/bookings-ui/src/components/travelers-section.tsx
@@ -34,6 +34,10 @@ import {
 import { Pencil, Trash2, UserPlus } from "lucide-react"
 import * as React from "react"
 import { useBookingsUiMessagesOrDefault } from "../i18n/provider.js"
+import {
+  getDynamicTravelerCategoryButtonState,
+  getStaticTravelerCategoryButtonState,
+} from "./traveler-category-buttons.js"
 
 export type TravelerRole = "lead" | "adult" | "child" | "infant"
 
@@ -772,9 +776,10 @@ function TravelerCategoryButtons({
               ["infant", fallbackLabels.infant],
             ] as const
           ).map(([category, label]) => {
-            const active = traveler.role === category
-            const nextRole: TravelerRole =
-              traveler.role === "lead" && category === "adult" ? "lead" : category
+            const { active, nextRole, shouldUpdate } = getStaticTravelerCategoryButtonState(
+              traveler,
+              category,
+            )
             return (
               <Button
                 key={category}
@@ -782,7 +787,9 @@ function TravelerCategoryButtons({
                 size="sm"
                 variant={active ? "default" : "outline"}
                 className="h-7 text-xs"
-                onClick={() => onPickUnit(traveler.roomUnitId, nextRole)}
+                onClick={() => {
+                  if (shouldUpdate) onPickUnit(traveler.roomUnitId, nextRole)
+                }}
               >
                 {label}
               </Button>
@@ -801,16 +808,10 @@ function TravelerCategoryButtons({
         style={{ gridTemplateColumns: `repeat(${categoryUnits.length}, minmax(0, 1fr))` }}
       >
         {categoryUnits.map((unit) => {
-          const active = traveler.roomUnitId === unit.unitId
-          // Keep the lead flag when the operator clicks the ADULT-coded
-          // unit (or one whose age band covers adults); otherwise the
-          // traveler's role tracks the unit code/name for the submit
-          // path's travelerCategory mapping.
-          const codeLower = (unit.unitCode ?? "").toLowerCase()
-          const inferredRole: Exclude<TravelerRole, "lead"> =
-            codeLower === "child" ? "child" : codeLower === "infant" ? "infant" : "adult"
-          const nextRole: TravelerRole =
-            traveler.role === "lead" && inferredRole === "adult" ? "lead" : inferredRole
+          const { active, nextRole, shouldUpdate } = getDynamicTravelerCategoryButtonState(
+            traveler,
+            unit,
+          )
           return (
             <Button
               key={unit.unitId}
@@ -818,7 +819,9 @@ function TravelerCategoryButtons({
               size="sm"
               variant={active ? "default" : "outline"}
               className="h-7 text-xs"
-              onClick={() => onPickUnit(unit.unitId, nextRole)}
+              onClick={() => {
+                if (shouldUpdate) onPickUnit(unit.unitId, nextRole)
+              }}
               title={
                 unit.minAge != null || unit.maxAge != null
                   ? `${unit.minAge ?? "0"}–${unit.maxAge ?? "∞"}`

--- a/packages/bookings-ui/tests/unit/traveler-category-buttons.test.ts
+++ b/packages/bookings-ui/tests/unit/traveler-category-buttons.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  getDynamicTravelerCategoryButtonState,
+  getStaticTravelerCategoryButtonState,
+} from "../../src/components/traveler-category-buttons.js"
+
+describe("traveler category button state", () => {
+  it("treats the lead traveler as adult-active in the static fallback buttons", () => {
+    expect(
+      getStaticTravelerCategoryButtonState({ role: "lead", roomUnitId: null }, "adult"),
+    ).toEqual({
+      active: true,
+      nextRole: "lead",
+      shouldUpdate: false,
+    })
+  })
+
+  it("keeps non-adult static buttons inactive for the lead traveler", () => {
+    expect(
+      getStaticTravelerCategoryButtonState({ role: "lead", roomUnitId: null }, "child"),
+    ).toEqual({
+      active: false,
+      nextRole: "child",
+      shouldUpdate: true,
+    })
+  })
+
+  it("preserves the lead role when the assigned dynamic unit is adult-coded", () => {
+    expect(
+      getDynamicTravelerCategoryButtonState(
+        { role: "lead", roomUnitId: "optu_adult" },
+        { unitId: "optu_adult", unitCode: "ADULT" },
+      ),
+    ).toEqual({
+      active: true,
+      nextRole: "lead",
+      shouldUpdate: false,
+    })
+  })
+
+  it("allows a lead traveler on a child unit to switch role when child is clicked", () => {
+    expect(
+      getDynamicTravelerCategoryButtonState(
+        { role: "lead", roomUnitId: "optu_child" },
+        { unitId: "optu_child", unitCode: "CHILD" },
+      ),
+    ).toEqual({
+      active: true,
+      nextRole: "child",
+      shouldUpdate: true,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Treats `role: lead` as Adult-active in booking-create traveler category buttons.
- Preserves lead identity when the already-selected Adult category is clicked.
- Adds internal state-helper coverage and a patch changeset for `@voyantjs/bookings-ui`.

Closes #1234.

## Validation

- `pnpm --filter @voyantjs/bookings-ui test`
- `pnpm --filter @voyantjs/bookings-ui typecheck`
- `pnpm --filter @voyantjs/bookings-ui lint`
- Commit hook repo lint and repo typecheck passed.
- `pnpm verify:fast` stops on the existing `@voyantjs/ui` component barrel export check unrelated to these files.
