### PR TITLE
Fix day-tour traveler unit pricing

### DIFF
--- a/.changeset/day-tour-traveler-unit-pricing.md
+++ b/.changeset/day-tour-traveler-unit-pricing.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/bookings-ui": patch
+---
+
+Preserve age-banded traveler unit assignments for person-priced day-tour bookings.

--- a/packages/bookings-ui/src/components/booking-create-dialog.tsx
+++ b/packages/bookings-ui/src/components/booking-create-dialog.tsx
@@ -39,6 +39,7 @@ import {
 import {
   getBookableDepartureSlots,
   getSelectedSharedRoomUnitId,
+  getTravelerAssignableStepperUnits,
   isRealBookingEmail,
   itemLinesToRows,
   validateBillingPersonContact,
@@ -179,13 +180,6 @@ function stripUnitSuffix(name: string): string {
   return idx > 0 ? name.slice(0, idx) : name
 }
 
-function isRoomUnit(unit: {
-  optionUnitId: string
-  unitType?: OptionUnitsStepperUnit["unitType"]
-}): boolean {
-  return unit.unitType === "room"
-}
-
 /**
  * Any payment-schedule entry the operator has marked as already
  * paid. Drives the smart-default booking status on submit — if money
@@ -286,6 +280,7 @@ function redistributeByAge(
   }
 
   const unitToOption = new Map(units.map((u) => [u.optionUnitId, u.optionId]))
+  const unitById = new Map(units.map((u) => [u.optionUnitId, u]))
 
   // Per-option total from the stepper. This is the count the operator
   // committed to when picking rooms.
@@ -297,10 +292,40 @@ function redistributeByAge(
     totalByOption.set(optionId, (totalByOption.get(optionId) ?? 0) + qty)
   }
 
+  const assignedForDefaulting = new Map<string, number>()
+  for (const traveler of travelers) {
+    if (!traveler.roomUnitId) continue
+    const optionId = unitToOption.get(traveler.roomUnitId)
+    if (!optionId) continue
+    assignedForDefaulting.set(optionId, (assignedForDefaulting.get(optionId) ?? 0) + 1)
+  }
+
+  const optionDemand = Array.from(totalByOption.entries())
+  const nextTravelers = travelers.map((traveler) => {
+    if (traveler.roomUnitId && unitById.has(traveler.roomUnitId)) return traveler
+
+    const optionId =
+      optionDemand.find(
+        ([candidate, total]) => (assignedForDefaulting.get(candidate) ?? 0) < total,
+      )?.[0] ?? optionDemand[0]?.[0]
+    if (!optionId) return traveler
+
+    const age = computeAgeYears(traveler.dateOfBirth)
+    const roleHint =
+      traveler.role === "adult" || traveler.role === "child" || traveler.role === "infant"
+        ? traveler.role
+        : null
+    const unit = pickUnitForAge(unitsByOption.get(optionId) ?? [], age, roleHint)
+    if (!unit) return traveler
+
+    assignedForDefaulting.set(optionId, (assignedForDefaulting.get(optionId) ?? 0) + 1)
+    return { ...traveler, roomUnitId: unit.optionUnitId }
+  })
+
   // Count actual traveler assignments per unit + per option.
   const next: Record<string, number> = {}
   const assignedByOption = new Map<string, number>()
-  for (const t of travelers) {
+  for (const t of nextTravelers) {
     if (!t.roomUnitId) continue
     const optionId = unitToOption.get(t.roomUnitId)
     if (!optionId) continue
@@ -320,7 +345,7 @@ function redistributeByAge(
     next[adult.optionUnitId] = (next[adult.optionUnitId] ?? 0) + residual
   }
 
-  return { quantities: next, travelers }
+  return { quantities: next, travelers: nextTravelers }
 }
 
 function travelersToRows(value: TravelerListValue): BookingCreateTravelerInput[] {
@@ -593,9 +618,9 @@ export function BookingCreateForm({
       unitType?: OptionUnitsStepperUnit["unitType"]
       occupancyMax: number | null
     }
-    const units: UnitLike[] = (
-      roomUnits.length > 0 ? roomUnits : (slotUnitAvailability.data?.data ?? [])
-    ).filter(isRoomUnit)
+    const units: UnitLike[] = getTravelerAssignableStepperUnits(
+      roomUnits.length > 0 ? roomUnits : (slotUnitAvailability.data?.data ?? []),
+    )
     if (units.length === 0) return []
     const optionGroups = new Map<
       string,
@@ -657,9 +682,10 @@ export function BookingCreateForm({
   // `roomUnitOptions` but exposes every unit instead of collapsing
   // to one primary.
   const roomGroups: RoomGroup[] = React.useMemo(() => {
-    if (roomUnits.length === 0) return []
+    const travelerUnits = getTravelerAssignableStepperUnits(roomUnits)
+    if (travelerUnits.length === 0) return []
     const groups = new Map<string, RoomGroup>()
-    for (const u of roomUnits) {
+    for (const u of travelerUnits) {
       if (!u.optionId) continue
       const groupKey = u.optionId
       const isAdultCoded = (u.unitCode ?? "").toUpperCase() === "ADULT"
@@ -696,7 +722,12 @@ export function BookingCreateForm({
   // (Adult) unit qty from the stepper, missing the per-traveler split
   // between adult / child / infant tiers.
   const displayQuantities = React.useMemo(
-    () => redistributeByAge(rooms.quantities, travelers.travelers, roomUnits).quantities,
+    () =>
+      redistributeByAge(
+        rooms.quantities,
+        travelers.travelers,
+        getTravelerAssignableStepperUnits(roomUnits),
+      ).quantities,
     [rooms.quantities, travelers.travelers, roomUnits],
   )
 
@@ -838,11 +869,13 @@ export function BookingCreateForm({
       // traveler's matching unit assignment, driven by DOB.
       const submitUnits =
         roomUnits.length > 0
-          ? roomUnits
-          : (slotUnitAvailability.data?.data ?? []).map((unit) => ({
-              ...unit,
-              optionId: product.optionId,
-            }))
+          ? getTravelerAssignableStepperUnits(roomUnits)
+          : getTravelerAssignableStepperUnits(
+              (slotUnitAvailability.data?.data ?? []).map((unit) => ({
+                ...unit,
+                optionId: product.optionId,
+              })),
+            )
       const redistributed = redistributeByAge(rooms.quantities, travelers.travelers, submitUnits)
 
       const itemLines = itemLinesToRows(redistributed.quantities, submitUnits, pricing)

--- a/packages/bookings-ui/src/components/booking-create-utils.ts
+++ b/packages/bookings-ui/src/components/booking-create-utils.ts
@@ -28,6 +28,21 @@ export interface BookingCreatePricingRecord {
   lines: BookingCreatePricingLineRecord[]
 }
 
+type BookingCreateStepperUnitType =
+  | "person"
+  | "group"
+  | "room"
+  | "vehicle"
+  | "service"
+  | "other"
+  | null
+
+export interface BookingCreateTravelerAssignableUnitRecord {
+  optionId?: string | null
+  optionUnitId: string
+  unitType?: BookingCreateStepperUnitType
+}
+
 export function normalizeBookingSearchText(value: string): string {
   return value
     .normalize("NFKD")
@@ -69,6 +84,24 @@ export function validateBillingPersonContact(
   if (email && !isRealBookingEmail(email)) return "invalid-email"
   if (!email && !phone) return "missing-contact"
   return "valid"
+}
+
+export function getTravelerAssignableStepperUnits<
+  TUnit extends BookingCreateTravelerAssignableUnitRecord,
+>(units: readonly TUnit[]): TUnit[] {
+  const hasRoomUnitByOption = new Map<string, boolean>()
+
+  for (const unit of units) {
+    const optionKey = unit.optionId ?? unit.optionUnitId
+    if (unit.unitType === "room") hasRoomUnitByOption.set(optionKey, true)
+    else if (!hasRoomUnitByOption.has(optionKey)) hasRoomUnitByOption.set(optionKey, false)
+  }
+
+  return units.filter((unit) => {
+    if (unit.unitType === "room") return true
+    if (unit.unitType !== "person") return false
+    return !hasRoomUnitByOption.get(unit.optionId ?? unit.optionUnitId)
+  })
 }
 
 export function getBookableDepartureSlots<TSlot extends DepartureSlotSearchRecord>(

--- a/packages/bookings-ui/tests/unit/booking-create-utils.test.ts
+++ b/packages/bookings-ui/tests/unit/booking-create-utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   getBookableDepartureSlots,
   getSelectedSharedRoomUnitId,
+  getTravelerAssignableStepperUnits,
   itemLinesToRows,
   productMatchesPickerSearch,
   validateBillingPersonContact,
@@ -181,5 +182,44 @@ describe("booking create helpers", () => {
     expect(validateBillingPersonContact({ email: "traveler@example.com", phone: "+40 700" })).toBe(
       "invalid-email",
     )
+  })
+
+  it("keeps person units assignable for pure-person day-tour options", () => {
+    const result = getTravelerAssignableStepperUnits([
+      {
+        optionId: "opto_day_tour",
+        optionUnitId: "optu_adult",
+        unitType: "person",
+      },
+      {
+        optionId: "opto_day_tour",
+        optionUnitId: "optu_child",
+        unitType: "person",
+      },
+    ])
+
+    expect(result.map((unit) => unit.optionUnitId)).toEqual(["optu_adult", "optu_child"])
+  })
+
+  it("keeps room units but hides person units when an option has room units", () => {
+    const result = getTravelerAssignableStepperUnits([
+      {
+        optionId: "opto_hotel",
+        optionUnitId: "optu_double",
+        unitType: "room",
+      },
+      {
+        optionId: "opto_hotel",
+        optionUnitId: "optu_child",
+        unitType: "person",
+      },
+      {
+        optionId: "opto_excursion",
+        optionUnitId: "optu_excursion_child",
+        unitType: "person",
+      },
+    ])
+
+    expect(result.map((unit) => unit.optionUnitId)).toEqual(["optu_double", "optu_excursion_child"])
   })
 })


### PR DESCRIPTION
## Summary

- Includes pure-person option units in booking-create traveler assignment for day-tour/activity products.
- Builds traveler category groups from those person units so Adult/Child/Infant selections write the matching `roomUnitId`.
- Defaults missing traveler unit IDs during redistribution using DOB first and role hint second, so preview and submit payloads do not price every traveler as Adult.
- Adds focused helper coverage and a patch changeset for `@voyantjs/bookings-ui`.

Closes #1239.

## Validation

- `pnpm --filter @voyantjs/bookings-ui test`
- `pnpm --filter @voyantjs/bookings-ui typecheck`
- `pnpm --filter @voyantjs/bookings-ui lint`
- Commit hook repo lint and repo typecheck passed.
- `pnpm verify:fast` stops on the existing `@voyantjs/ui` component barrel export check unrelated to these files.
