### PR TITLE
Hide empty slot allocation rooms tab

### DIFF
--- a/.changeset/slot-allocation-no-room-default.md
+++ b/.changeset/slot-allocation-no-room-default.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/allocation-ui": patch
+---
+
+Hide allocation tabs when a slot has no matching resources or templates.

--- a/packages/allocation-ui/src/components/slot-allocation-model.test.ts
+++ b/packages/allocation-ui/src/components/slot-allocation-model.test.ts
@@ -1,7 +1,11 @@
 import type { AllocationResource } from "@voyantjs/availability-react"
 import { describe, expect, it } from "vitest"
 
-import { groupResourcesBySubType, summarizeResourceCapacity } from "./slot-allocation-model.js"
+import {
+  deriveAllocationKinds,
+  groupResourcesBySubType,
+  summarizeResourceCapacity,
+} from "./slot-allocation-model.js"
 
 function resource(overrides: Partial<AllocationResource> & { id: string }): AllocationResource {
   return {
@@ -19,6 +23,48 @@ function resource(overrides: Partial<AllocationResource> & { id: string }): Allo
     updatedAt: overrides.updatedAt ?? "2026-01-01T00:00:00Z",
   }
 }
+
+describe("deriveAllocationKinds", () => {
+  it("does not seed rooms when the slot has no resources or templates", () => {
+    expect(deriveAllocationKinds({ resources: [], templateOptions: [] })).toEqual([])
+  })
+
+  it("includes room only when a room resource or template exists", () => {
+    expect(
+      deriveAllocationKinds({
+        resources: [resource({ id: "room_1", kind: "room" })],
+        templateOptions: [],
+      }),
+    ).toEqual(["room"])
+
+    expect(
+      deriveAllocationKinds({
+        resources: [],
+        templateOptions: [
+          {
+            templates: [{ kind: "room" }],
+          },
+        ],
+      }),
+    ).toEqual(["room"])
+  })
+
+  it("deduplicates resource and template kinds while skipping parent-only kinds", () => {
+    expect(
+      deriveAllocationKinds({
+        resources: [
+          resource({ id: "vehicle_1", kind: "vehicle" }),
+          resource({ id: "seat_1", kind: "vehicle_seat" }),
+        ],
+        templateOptions: [
+          {
+            templates: [{ kind: "vehicle" }, { kind: "vehicle_seat" }, { kind: "cabin" }],
+          },
+        ],
+      }),
+    ).toEqual(["vehicle_seat", "cabin"])
+  })
+})
 
 describe("groupResourcesBySubType", () => {
   it("groups by alphabetic label prefix so DBLs and SGLs stay together", () => {

--- a/packages/allocation-ui/src/components/slot-allocation-model.ts
+++ b/packages/allocation-ui/src/components/slot-allocation-model.ts
@@ -18,6 +18,29 @@ export type AllocationOccupants = {
   unallocated: AllocationManifestTraveler[]
 }
 
+export function deriveAllocationKinds({
+  resources,
+  templateOptions,
+}: {
+  resources: ReadonlyArray<Pick<AllocationResource, "kind">>
+  templateOptions: ReadonlyArray<{
+    templates: ReadonlyArray<{ kind: string | null | undefined }>
+  }>
+}) {
+  const kinds: string[] = []
+  const addKind = (kind: string | null | undefined) => {
+    if (!kind || PARENT_ONLY_KINDS.has(kind) || kinds.includes(kind)) return
+    kinds.push(kind)
+  }
+
+  for (const resource of resources) addKind(resource.kind)
+  for (const option of templateOptions) {
+    for (const template of option.templates) addKind(template.kind)
+  }
+
+  return kinds
+}
+
 export type ValidationIssue = {
   id: string
   label: string

--- a/packages/allocation-ui/src/components/slot-allocation-page.tsx
+++ b/packages/allocation-ui/src/components/slot-allocation-page.tsx
@@ -40,8 +40,8 @@ import { useAllocationUiMessagesOrDefault } from "../i18n/index.js"
 import {
   collectOccupants,
   defaultCapacityFor,
+  deriveAllocationKinds,
   kindLabel,
-  PARENT_ONLY_KINDS,
   parentKindFor,
   type ResourceCapacitySummary,
   ROOM_KIND,
@@ -138,19 +138,10 @@ export function SlotAllocationPage({
   }, [data?.bookings])
 
   const allocationKinds = useMemo(() => {
-    const kinds: string[] = []
-    const addKind = (kind: string | null | undefined) => {
-      if (!kind || PARENT_ONLY_KINDS.has(kind) || kinds.includes(kind)) return
-      kinds.push(kind)
-    }
-
-    addKind(ROOM_KIND)
-    for (const resource of data?.resources ?? []) addKind(resource.kind)
-    for (const option of templates.data?.data ?? []) {
-      for (const template of option.templates) addKind(template.kind)
-    }
-
-    return kinds
+    return deriveAllocationKinds({
+      resources: data?.resources ?? [],
+      templateOptions: templates.data?.data ?? [],
+    })
   }, [data?.resources, templates.data?.data])
 
   // option_id → option name, used by ResourceColumnsView to badge each
@@ -163,14 +154,19 @@ export function SlotAllocationPage({
     return map
   }, [templates.data?.data])
 
-  const activeKind = allocationKinds.includes(selectedKind)
-    ? selectedKind
-    : (allocationKinds[0] ?? ROOM_KIND)
   const visibleExtraTabs = extraTabs.filter((tab) => !allocationKinds.includes(tab.id))
-  const selectedExtraTab = allocationKinds.includes(selectedKind)
+  const selectedAllocationKind = allocationKinds.includes(selectedKind) ? selectedKind : undefined
+  const selectedExtraTab = selectedAllocationKind
     ? undefined
-    : visibleExtraTabs.find((tab) => tab.id === selectedKind)
+    : (visibleExtraTabs.find((tab) => tab.id === selectedKind) ??
+      (allocationKinds.length === 0 ? visibleExtraTabs[0] : undefined))
+  const activeAllocationKind = selectedExtraTab
+    ? undefined
+    : (selectedAllocationKind ?? allocationKinds[0])
+  const activeKind = activeAllocationKind ?? ROOM_KIND
   const activeTabId = selectedExtraTab?.id ?? activeKind
+  const hasAllocationView = Boolean(activeAllocationKind)
+  const hasTabs = allocationKinds.length > 0 || visibleExtraTabs.length > 0
   const resources = useMemo(
     () => (data?.resources ?? []).filter((resource) => resource.kind === activeKind),
     [data?.resources, activeKind],
@@ -325,7 +321,7 @@ export function SlotAllocationPage({
 
   const summaryLine = (
     <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-      {selectedExtraTab ? null : (
+      {selectedExtraTab || !hasAllocationView ? null : (
         <CapacitySummaryBadges summary={capacitySummary} messages={messages} kind={activeKind} />
       )}
     </div>
@@ -333,8 +329,10 @@ export function SlotAllocationPage({
 
   const actionsCluster = (
     <div className="flex flex-wrap items-center gap-2">
-      {selectedExtraTab ? null : renderExtraActions?.({ slotId, kind: activeKind })}
-      {selectedExtraTab ? null : resources.length === 0 ? (
+      {selectedExtraTab || !hasAllocationView
+        ? null
+        : renderExtraActions?.({ slotId, kind: activeKind })}
+      {selectedExtraTab || !hasAllocationView ? null : resources.length === 0 ? (
         <Button
           variant="outline"
           onClick={() => void generateResources()}
@@ -357,7 +355,7 @@ export function SlotAllocationPage({
             : messages.autoAllocate}
         </Button>
       )}
-      {!selectedExtraTab && canManuallyAddResource ? (
+      {!selectedExtraTab && hasAllocationView && canManuallyAddResource ? (
         <Button
           variant="outline"
           onClick={() => {
@@ -404,29 +402,36 @@ export function SlotAllocationPage({
 
       {renderBefore?.(context)}
 
-      <Tabs value={activeTabId} onValueChange={setSelectedKind}>
-        <TabsList className="flex h-auto w-fit flex-wrap justify-start">
-          {allocationKinds.map((kind) => (
-            <TabsTrigger key={kind} value={kind} className="gap-2">
-              {kind === VEHICLE_SEAT_KIND ? (
-                <Armchair className="size-4" aria-hidden="true" />
-              ) : (
-                <Bed className="size-4" aria-hidden="true" />
-              )}
-              {kindLabel(kind, messages)}
-            </TabsTrigger>
-          ))}
-          {visibleExtraTabs.map((tab) => (
-            <TabsTrigger key={tab.id} value={tab.id} className="gap-2">
-              {tab.icon}
-              {tab.label}
-            </TabsTrigger>
-          ))}
-        </TabsList>
-      </Tabs>
+      {hasTabs ? (
+        <Tabs value={activeTabId} onValueChange={setSelectedKind}>
+          <TabsList className="flex h-auto w-fit flex-wrap justify-start">
+            {allocationKinds.map((kind) => (
+              <TabsTrigger key={kind} value={kind} className="gap-2">
+                {kind === VEHICLE_SEAT_KIND ? (
+                  <Armchair className="size-4" aria-hidden="true" />
+                ) : (
+                  <Bed className="size-4" aria-hidden="true" />
+                )}
+                {kindLabel(kind, messages)}
+              </TabsTrigger>
+            ))}
+            {visibleExtraTabs.map((tab) => (
+              <TabsTrigger key={tab.id} value={tab.id} className="gap-2">
+                {tab.icon}
+                {tab.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+      ) : null}
 
       {selectedExtraTab ? (
         selectedExtraTab.render(context)
+      ) : !hasAllocationView ? (
+        <div className="flex flex-col items-center justify-center gap-3 rounded-md border border-dashed p-8 text-center">
+          <Users className="size-6 text-muted-foreground" aria-hidden="true" />
+          <p className="text-sm text-muted-foreground">{messages.noAllocationsToManage}</p>
+        </div>
       ) : (
         <>
           {error ? (

--- a/packages/allocation-ui/src/i18n/provider.tsx
+++ b/packages/allocation-ui/src/i18n/provider.tsx
@@ -77,6 +77,7 @@ export type AllocationUiMessages = Record<string, unknown> & {
   noRooms: string
   noResources: string
   noSeats: string
+  noAllocationsToManage: string
   windowSeat: string
   aisleSeat: string
   middleSeat: string
@@ -199,6 +200,7 @@ export const allocationUiEn = {
   noRooms: "No rooms have been added for this slot.",
   noResources: "No resources have been added for this slot.",
   noSeats: "No vehicle seats have been generated for this slot.",
+  noAllocationsToManage: "This slot has no allocations to manage.",
   windowSeat: "Window",
   aisleSeat: "Aisle",
   middleSeat: "Middle",
@@ -337,6 +339,7 @@ export const allocationUiRo = {
   noRooms: "Nu exista camere adaugate pentru acest slot.",
   noResources: "Nu exista resurse adaugate pentru acest slot.",
   noSeats: "Nu exista locuri generate pentru acest slot.",
+  noAllocationsToManage: "Acest slot nu are alocari de gestionat.",
   windowSeat: "Geam",
   aisleSeat: "Culoar",
   middleSeat: "Mijloc",


### PR DESCRIPTION
## Summary
- derive allocation tabs from actual slot resources and product resource templates instead of seeding `room`
- render a no-allocations empty state when a slot has no allocation kinds, while preserving extension tabs
- add regression coverage for allocation-kind derivation and a patch changeset

Closes #1236

## Validation
- `pnpm --filter @voyantjs/allocation-ui test`
- `pnpm --filter @voyantjs/allocation-ui typecheck`
- `pnpm --filter @voyantjs/allocation-ui lint`
- `git diff --check`
- commit hook: repo lint and repo typecheck passed

## Notes
- `pnpm verify:fast` still stops at the existing `@voyantjs/ui` component barrel check for unrelated missing exports.