### PR TITLE
Assert invoice line items persist

### DIFF
--- a/.changeset/quiet-invoices-warn.md
+++ b/.changeset/quiet-invoices-warn.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/finance": patch
+---
+
+Assert invoice line item persistence when creating invoices from bookings.

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -268,6 +268,7 @@ export type {
 } from "./service.js"
 export {
   financeService,
+  InvoiceLineItemsPersistenceError,
   InvoiceNumberAllocationError,
   InvoiceNumberConflictError,
   renderInvoiceBody,

--- a/packages/finance/src/service.ts
+++ b/packages/finance/src/service.ts
@@ -358,6 +358,21 @@ export class InvoiceFromBookingValidationError extends Error {
   }
 }
 
+export class InvoiceLineItemsPersistenceError extends Error {
+  readonly code = "invoice_line_items_not_persisted"
+  readonly invoiceId: string
+  readonly expectedCount: number
+  readonly actualCount: number
+
+  constructor(invoiceId: string, expectedCount: number, actualCount: number) {
+    super("Invoice line items were not persisted")
+    this.name = "InvoiceLineItemsPersistenceError"
+    this.invoiceId = invoiceId
+    this.expectedCount = expectedCount
+    this.actualCount = actualCount
+  }
+}
+
 /** Booking data needed for createInvoiceFromBooking — supplied by the caller (template). */
 export interface InvoiceFromBookingData {
   booking: {
@@ -3678,18 +3693,27 @@ export const financeService = {
             .values(invoiceFromBookingExternalRefValues(invoice.id, data.externalRefs))
         }
 
-        await tx.insert(invoiceLineItems).values(
-          lineItems.map((line) => ({
-            invoiceId: invoice.id,
-            bookingItemId: line.bookingItemId,
-            description: line.description,
-            quantity: line.quantity,
-            unitPriceCents: line.unitPriceCents,
-            totalCents: line.totalCents,
-            taxRate: line.taxRate,
-            sortOrder: line.sortOrder,
-          })),
-        )
+        const lineItemValues = lineItems.map((line) => ({
+          invoiceId: invoice.id,
+          bookingItemId: line.bookingItemId,
+          description: line.description,
+          quantity: line.quantity,
+          unitPriceCents: line.unitPriceCents,
+          totalCents: line.totalCents,
+          taxRate: line.taxRate,
+          sortOrder: line.sortOrder,
+        }))
+        const insertedLineItems = await tx
+          .insert(invoiceLineItems)
+          .values(lineItemValues)
+          .returning({ id: invoiceLineItems.id })
+        if (insertedLineItems.length !== lineItemValues.length) {
+          throw new InvoiceLineItemsPersistenceError(
+            invoice.id,
+            lineItemValues.length,
+            insertedLineItems.length,
+          )
+        }
 
         return invoice
       })

--- a/packages/finance/src/validation-billing.ts
+++ b/packages/finance/src/validation-billing.ts
@@ -1,4 +1,4 @@
-import { booleanQueryParam } from "@voyantjs/db"
+import { booleanQueryParam } from "@voyantjs/db/helpers"
 import { z } from "zod"
 
 import {

--- a/packages/finance/tests/integration/create-invoice-from-booking.test.ts
+++ b/packages/finance/tests/integration/create-invoice-from-booking.test.ts
@@ -1,0 +1,115 @@
+import { eq } from "drizzle-orm"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { invoiceExternalRefs, invoiceLineItems } from "../../src/schema.js"
+import { financeService, type InvoiceFromBookingData } from "../../src/service.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+let counter = 0
+function next(prefix: string) {
+  counter += 1
+  return `${prefix}-${String(counter).padStart(6, "0")}`
+}
+
+const bookingData: InvoiceFromBookingData = {
+  booking: {
+    id: "book_invoice_from_booking",
+    bookingNumber: "BK-IFB",
+    personId: null,
+    organizationId: null,
+    sellCurrency: "RON",
+    baseCurrency: null,
+    fxRateSetId: null,
+    sellAmountCents: 59_500,
+    baseSellAmountCents: null,
+  },
+  items: [],
+}
+
+describe.skipIf(!DB_AVAILABLE)("createInvoiceFromBooking", () => {
+  let db: ReturnType<typeof import("@voyantjs/db/test-utils").createTestDb>
+
+  beforeAll(async () => {
+    const { createTestDb, cleanupTestDb } = await import("@voyantjs/db/test-utils")
+    db = createTestDb()
+    await cleanupTestDb(db)
+  })
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyantjs/db/test-utils")
+    await closeTestDb()
+  })
+
+  beforeEach(async () => {
+    const { cleanupTestDb } = await import("@voyantjs/db/test-utils")
+    await cleanupTestDb(db)
+  })
+
+  it("persists caller-supplied line items when external refs are supplied", async () => {
+    const invoice = await financeService.createInvoiceFromBooking(
+      db,
+      {
+        bookingId: bookingData.booking.id,
+        invoiceNumber: next("SB"),
+        issueDate: "2026-05-25",
+        dueDate: "2026-06-25",
+        currency: "RON",
+        subtotalCents: 50_000,
+        taxCents: 9_500,
+        totalCents: 59_500,
+        lineItems: [
+          {
+            description: "SmartBill fiscal line",
+            quantity: 1,
+            unitAmountCents: 50_000,
+            taxRateBps: 1_900,
+            taxAmountCents: 9_500,
+          },
+        ],
+        externalRefs: [
+          {
+            provider: "smartbill",
+            externalId: "remote_42",
+            externalNumber: "42",
+            externalUrl: "https://smartbill.test/invoices/42",
+            status: "issued",
+            syncedAt: "2026-05-25T10:30:00.000Z",
+          },
+        ],
+      },
+      bookingData,
+    )
+
+    expect(invoice).toBeTruthy()
+
+    const lines = await db
+      .select()
+      .from(invoiceLineItems)
+      .where(eq(invoiceLineItems.invoiceId, invoice?.id ?? ""))
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toMatchObject({
+      invoiceId: invoice?.id,
+      bookingItemId: null,
+      description: "SmartBill fiscal line",
+      quantity: 1,
+      unitPriceCents: 50_000,
+      totalCents: 50_000,
+      taxRate: 19,
+      sortOrder: 0,
+    })
+
+    const refs = await db
+      .select()
+      .from(invoiceExternalRefs)
+      .where(eq(invoiceExternalRefs.invoiceId, invoice?.id ?? ""))
+    expect(refs).toHaveLength(1)
+    expect(refs[0]).toMatchObject({
+      invoiceId: invoice?.id,
+      provider: "smartbill",
+      externalId: "remote_42",
+      externalNumber: "42",
+      status: "issued",
+    })
+  })
+})

--- a/packages/finance/tests/unit/service-invoice-number-allocation.test.ts
+++ b/packages/finance/tests/unit/service-invoice-number-allocation.test.ts
@@ -10,6 +10,7 @@ import {
   financeService,
   type InvoiceFromBookingData,
   type InvoiceFromBookingValidationError,
+  type InvoiceLineItemsPersistenceError,
   type InvoiceNumberAllocationError,
   type InvoiceNumberConflictError,
 } from "../../src/service.js"
@@ -55,6 +56,7 @@ function makeDb(options: {
   explicitSeries?: Record<string, unknown> | null
   defaultSeries?: Record<string, unknown> | null
   invoiceInsertError?: unknown
+  invoiceLineItemsReturning?: Array<Record<string, unknown>>
 }) {
   const insertedInvoices: Array<Record<string, unknown>> = []
   const insertedInvoiceExternalRefs: Array<Record<string, unknown>> = []
@@ -104,7 +106,9 @@ function makeDb(options: {
         }
         if (table === invoiceLineItems) {
           insertedInvoiceLineItems.push(...values)
-          return Promise.resolve(values)
+          return {
+            returning: vi.fn(async () => options.invoiceLineItemsReturning ?? values),
+          }
         }
         if (table === invoiceExternalRefs) {
           insertedInvoiceExternalRefs.push(...values)
@@ -404,6 +408,44 @@ describe("financeService.createInvoiceFromBooking number allocation", () => {
         syncError: null,
       }),
     ])
+  })
+
+  it("fails the transaction when override line items are not persisted", async () => {
+    const { db } = makeDb({ invoiceLineItemsReturning: [] })
+
+    await expect(
+      financeService.createInvoiceFromBooking(
+        db,
+        {
+          bookingId: "book_123",
+          invoiceNumber: "SB-42",
+          issueDate: "2026-05-23",
+          dueDate: "2026-06-23",
+          lineItems: [
+            {
+              description: "SmartBill fiscal line",
+              quantity: 1,
+              unitAmountCents: 50_000,
+              taxRateBps: 1_900,
+            },
+          ],
+          externalRefs: [
+            {
+              provider: "smartbill",
+              externalNumber: "42",
+              status: "issued",
+            },
+          ],
+        },
+        bookingData,
+      ),
+    ).rejects.toMatchObject({
+      name: "InvoiceLineItemsPersistenceError",
+      code: "invoice_line_items_not_persisted",
+      invoiceId: "inv_123",
+      expectedCount: 1,
+      actualCount: 0,
+    } satisfies Partial<InvoiceLineItemsPersistenceError>)
   })
 
   it("rejects cross-currency overrides without the booking sell currency as base", async () => {


### PR DESCRIPTION
## Summary
- assert createInvoiceFromBooking line-item inserts with returning() so a zero-row insert rolls back instead of creating a half-formed invoice
- add unit coverage for the zero-row insert failure path
- add an integration regression for caller-supplied lineItems with externalRefs

Closes #1244

## Validation
- pnpm --filter @voyantjs/finance test -- service-invoice-number-allocation create-invoice-from-booking validation-billing
- pnpm --filter @voyantjs/finance typecheck
- pnpm --filter @voyantjs/finance lint
- pnpm --filter @voyantjs/action-ledger test -- no-db-root-imports
- git diff --check
- pre-commit: repo-wide lint/typecheck
- pre-push: repo-wide test