### PR TITLE
Create bookings from slot allocation

### DIFF
--- a/.changeset/create-booking-from-slot-allocation.md
+++ b/.changeset/create-booking-from-slot-allocation.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/allocation-ui": patch
+"@voyantjs/bookings-ui": patch
+---
+
+Add an opt-in slot allocation create-booking action and allow booking creation to lock a default slot.

--- a/packages/allocation-ui/src/components/slot-allocation-page.tsx
+++ b/packages/allocation-ui/src/components/slot-allocation-page.tsx
@@ -33,7 +33,17 @@ import {
   TabsList,
   TabsTrigger,
 } from "@voyantjs/ui/components"
-import { AlertTriangle, Armchair, ArrowLeft, Bed, Plus, Sparkles, Users, Wand2 } from "lucide-react"
+import {
+  AlertTriangle,
+  Armchair,
+  ArrowLeft,
+  Bed,
+  BookOpen,
+  Plus,
+  Sparkles,
+  Users,
+  Wand2,
+} from "lucide-react"
 import { type FormEvent, type ReactNode, useMemo, useState } from "react"
 
 import { useAllocationUiMessagesOrDefault } from "../i18n/index.js"
@@ -80,6 +90,7 @@ export interface SlotAllocationPageProps {
    */
   onBookingOpen?: (bookingId: string) => void
   renderExtraActions?: (context: { slotId: string; kind: string }) => ReactNode
+  onCreateBooking?: (input: { slotId: string; productId: string }) => void
   renderTravelerActions?: (traveler: AllocationManifestTraveler) => ReactNode
   renderHeaderEnd?: (context: SlotAllocationPageRenderContext) => ReactNode
   renderBefore?: (context: SlotAllocationPageRenderContext) => ReactNode
@@ -100,6 +111,7 @@ export function SlotAllocationPage({
   onBack,
   onBookingOpen,
   renderExtraActions,
+  onCreateBooking,
   renderTravelerActions,
   renderHeaderEnd,
   renderBefore,
@@ -309,6 +321,7 @@ export function SlotAllocationPage({
 
   const isSeatMap = activeKind === VEHICLE_SEAT_KIND
   const canManuallyAddResource = !isSeatMap
+  const createBookingProductId = data.slot.productId
   const context: SlotAllocationPageRenderContext = {
     slotId,
     tabId: activeTabId,
@@ -332,6 +345,15 @@ export function SlotAllocationPage({
       {selectedExtraTab || !hasAllocationView
         ? null
         : renderExtraActions?.({ slotId, kind: activeKind })}
+      {onCreateBooking && createBookingProductId ? (
+        <Button
+          variant="outline"
+          onClick={() => onCreateBooking({ slotId, productId: createBookingProductId })}
+        >
+          <BookOpen data-icon="inline-start" aria-hidden="true" />
+          {messages.createBooking}
+        </Button>
+      ) : null}
       {selectedExtraTab || !hasAllocationView ? null : resources.length === 0 ? (
         <Button
           variant="outline"

--- a/packages/allocation-ui/src/i18n/provider.tsx
+++ b/packages/allocation-ui/src/i18n/provider.tsx
@@ -23,6 +23,7 @@ export type AllocationUiMessages = Record<string, unknown> & {
   generatingResources: string
   autoAllocate: string
   autoAllocating: string
+  createBooking: string
   exportPassengers: string
   exportRooming: string
   auditLog: string
@@ -134,6 +135,7 @@ export const allocationUiEn = {
   generatingResources: "Generating...",
   autoAllocate: "Auto-allocate",
   autoAllocating: "Allocating...",
+  createBooking: "Create booking",
   exportPassengers: "Passengers",
   exportRooming: "Rooming",
   auditLog: "Audit log",
@@ -273,6 +275,7 @@ export const allocationUiRo = {
   generatingResources: "Se genereaza...",
   autoAllocate: "Auto-aloca",
   autoAllocating: "Se aloca...",
+  createBooking: "Creeaza rezervare",
   exportPassengers: "Pasageri",
   exportRooming: "Rooming",
   auditLog: "Istoric",

--- a/packages/bookings-ui/src/components/booking-create-dialog.tsx
+++ b/packages/bookings-ui/src/components/booking-create-dialog.tsx
@@ -1,7 +1,12 @@
 "use client"
 
-import { useQueries } from "@tanstack/react-query"
-import { useSlots, useSlotUnitAvailability } from "@voyantjs/availability-react"
+import { useQueries, useQuery } from "@tanstack/react-query"
+import {
+  getSlotQueryOptions,
+  useSlots,
+  useSlotUnitAvailability,
+  useVoyantAvailabilityContext,
+} from "@voyantjs/availability-react"
 import {
   type BookingCreateExtraLineInput,
   type BookingCreateGroupMembershipInput,
@@ -400,12 +405,16 @@ export interface BookingCreateDialogProps {
   onCreated?: (booking: BookingRecord) => void
   /** When provided, pre-selects this product and hides the product picker. */
   defaultProductId?: string
+  /** When provided, pre-selects and locks the departure slot. */
+  defaultSlotId?: string
 }
 
 export interface BookingCreateFormProps {
   onCreated?: (booking: BookingRecord) => void
   /** When provided, pre-selects this product and hides the product picker. */
   defaultProductId?: string
+  /** When provided, pre-selects and locks the departure slot. */
+  defaultSlotId?: string
   /** Gates data fetching and resets transient form state when false. */
   enabled?: boolean
   onCancel?: () => void
@@ -427,6 +436,7 @@ export function BookingCreateDialog({
   onOpenChange,
   onCreated,
   defaultProductId,
+  defaultSlotId,
 }: BookingCreateDialogProps) {
   const messages = useBookingsUiMessagesOrDefault()
 
@@ -439,6 +449,7 @@ export function BookingCreateDialog({
         <BookingCreateForm
           enabled={open}
           defaultProductId={defaultProductId}
+          defaultSlotId={defaultSlotId}
           onCancel={() => onOpenChange(false)}
           onCreated={(booking) => {
             onOpenChange(false)
@@ -453,6 +464,7 @@ export function BookingCreateDialog({
 export function BookingCreateForm({
   onCreated,
   defaultProductId,
+  defaultSlotId,
   enabled = true,
   onCancel,
 }: BookingCreateFormProps) {
@@ -460,7 +472,7 @@ export function BookingCreateForm({
     productId: defaultProductId ?? "",
     optionId: null,
   })
-  const [slotId, setSlotId] = React.useState<string | null>(null)
+  const [slotId, setSlotId] = React.useState<string | null>(defaultSlotId ?? null)
   const [rooms, setRooms] = React.useState<OptionUnitsStepperValue>(emptyOptionUnitsStepperValue)
   const [roomUnits, setRoomUnits] = React.useState<OptionUnitsStepperUnit[]>([])
   const [extraLines, setExtraLines] = React.useState<BookingCreateExtraLineInput[]>([])
@@ -491,11 +503,21 @@ export function BookingCreateForm({
   const [error, setError] = React.useState<string | null>(null)
   const { formatDate } = useBookingsUiI18nOrDefault()
   const messages = useBookingsUiMessagesOrDefault()
+  const availabilityClient = useVoyantAvailabilityContext()
+  const defaultSlotQuery = useQuery({
+    ...getSlotQueryOptions(availabilityClient, defaultSlotId),
+    enabled: enabled && Boolean(defaultSlotId),
+  })
+  const defaultSlot = defaultSlotQuery.data?.data ?? null
+  const resolvedDefaultProductId = defaultProductId ?? defaultSlot?.productId ?? ""
 
   React.useEffect(() => {
     if (!enabled) {
-      setProduct({ productId: defaultProductId ?? "", optionId: null })
-      setSlotId(null)
+      setProduct({
+        productId: resolvedDefaultProductId,
+        optionId: defaultSlotId ? (defaultSlot?.optionId ?? null) : null,
+      })
+      setSlotId(defaultSlotId ?? null)
       setRooms(emptyOptionUnitsStepperValue)
       setRoomUnits([])
       setExtraLines([])
@@ -511,23 +533,29 @@ export function BookingCreateForm({
       setCreateAsDraft(false)
       setNotifyTraveler(true)
       setError(null)
-    } else if (defaultProductId) {
-      setProduct((prev) =>
-        prev.productId === defaultProductId
+    } else if (resolvedDefaultProductId) {
+      setProduct((prev) => {
+        const optionId = defaultSlotId
+          ? (defaultSlot?.optionId ?? null)
+          : prev.productId === resolvedDefaultProductId
+            ? prev.optionId
+            : null
+        return prev.productId === resolvedDefaultProductId && prev.optionId === optionId
           ? prev
-          : { productId: defaultProductId, optionId: null },
-      )
+          : { productId: resolvedDefaultProductId, optionId }
+      })
+      if (defaultSlotId) setSlotId(defaultSlotId)
     }
-  }, [enabled, defaultProductId])
+  }, [enabled, resolvedDefaultProductId, defaultSlotId, defaultSlot?.optionId])
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: booking-create intentionally resets transient departure state only when product id changes; option changes are reconciled against the selected departure below.
   React.useEffect(() => {
-    setSlotId(null)
+    setSlotId(defaultSlotId ?? null)
     setRooms(emptyOptionUnitsStepperValue)
     setRoomUnits([])
     setSharedRoom(emptySharedRoomValue)
     setExtraLines([])
-  }, [product.productId])
+  }, [product.productId, defaultSlotId])
 
   const [slotsFromIso, setSlotsFromIso] = React.useState(() => new Date().toISOString())
   React.useEffect(() => {
@@ -555,8 +583,9 @@ export function BookingCreateForm({
     return optionSlots.length > 0 ? optionSlots : allOpenSlots
   }, [slotsData?.data, slotsFromIso, product.optionId, allOpenSlots])
   const selectedSlot = React.useMemo(
-    () => slots.find((slot) => slot.id === slotId) ?? null,
-    [slots, slotId],
+    () =>
+      slots.find((slot) => slot.id === slotId) ?? (defaultSlot?.id === slotId ? defaultSlot : null),
+    [slots, slotId, defaultSlot],
   )
   const setSelectedSlot = React.useCallback(
     (nextSlotId: string | null) => {
@@ -572,11 +601,17 @@ export function BookingCreateForm({
     setRooms(emptyOptionUnitsStepperValue)
     setRoomUnits([])
     if (!slotId || !product.optionId) return
-    const selectedSlot = allOpenSlots.find((slot) => slot.id === slotId)
-    if (selectedSlot?.optionId && selectedSlot.optionId !== product.optionId) {
+    const selectedDeparture =
+      allOpenSlots.find((slot) => slot.id === slotId) ??
+      (defaultSlot?.id === slotId ? defaultSlot : null)
+    if (selectedDeparture?.optionId && selectedDeparture.optionId !== product.optionId) {
+      if (defaultSlotId && selectedDeparture.id === defaultSlotId) {
+        setProduct((prev) => ({ ...prev, optionId: selectedDeparture.optionId }))
+        return
+      }
       setSlotId(null)
     }
-  }, [allOpenSlots, product.optionId, slotId])
+  }, [allOpenSlots, product.optionId, slotId, defaultSlotId, defaultSlot])
 
   const formatSlotLabel = React.useCallback(
     (slot: (typeof slots)[number]) => {
@@ -1014,7 +1049,7 @@ export function BookingCreateForm({
             value={product}
             onChange={setProduct}
             enabled={enabled}
-            lockProduct={Boolean(defaultProductId)}
+            lockProduct={Boolean(defaultProductId || defaultSlotId)}
             labels={{
               optionNone: messages.bookingCreateDialog.labels.noSpecificOption,
             }}
@@ -1028,13 +1063,14 @@ export function BookingCreateForm({
                 value={slotId}
                 onChange={(v) => setSelectedSlot(v)}
                 items={slots}
-                selectedItem={slots.find((s) => s.id === slotId) ?? null}
+                selectedItem={selectedSlot}
                 getKey={(slot) => slot.id}
                 getLabel={(slot) => formatSlotLabel(slot)}
                 placeholder={messages.bookingCreateDialog.placeholders.departure}
                 emptyText={messages.bookingCreateDialog.placeholders.departureEmpty}
                 triggerClassName="w-full"
-                clearable
+                disabled={Boolean(defaultSlotId)}
+                clearable={!defaultSlotId}
               />
             </div>
           ) : null}

--- a/packages/bookings-ui/src/components/booking-create-page.tsx
+++ b/packages/bookings-ui/src/components/booking-create-page.tsx
@@ -9,6 +9,8 @@ export interface BookingCreatePageProps {
   onCancel?: () => void
   /** When provided, pre-selects this product and hides the product picker. */
   defaultProductId?: string
+  /** When provided, pre-selects and locks the departure slot. */
+  defaultSlotId?: string
 }
 
 /**
@@ -18,6 +20,7 @@ export function BookingCreatePage({
   onCreated,
   onCancel,
   defaultProductId,
+  defaultSlotId,
 }: BookingCreatePageProps) {
   const messages = useBookingsUiMessagesOrDefault()
 
@@ -34,6 +37,7 @@ export function BookingCreatePage({
           onCreated={onCreated}
           onCancel={onCancel}
           defaultProductId={defaultProductId}
+          defaultSlotId={defaultSlotId}
         />
       </section>
     </main>

--- a/packages/bookings-ui/src/components/booking-dialog.tsx
+++ b/packages/bookings-ui/src/components/booking-dialog.tsx
@@ -66,6 +66,11 @@ export interface BookingDialogProps {
    * a product detail page. Ignored when editing an existing booking.
    */
   defaultProductId?: string
+  /**
+   * Pre-seeds and locks the departure picker in create mode. Useful when opened from
+   * a slot allocation page. Ignored when editing an existing booking.
+   */
+  defaultSlotId?: string
 }
 
 const BOOKING_STATUS_VALUES = [
@@ -92,6 +97,7 @@ export function BookingDialog({
   booking,
   onSuccess,
   defaultProductId,
+  defaultSlotId,
 }: BookingDialogProps) {
   if (!booking) {
     return (
@@ -99,6 +105,7 @@ export function BookingDialog({
         open={open}
         onOpenChange={onOpenChange}
         defaultProductId={defaultProductId}
+        defaultSlotId={defaultSlotId}
         onCreated={onSuccess}
       />
     )

--- a/templates/operator/src/routes/_workspace/availability/$id.tsx
+++ b/templates/operator/src/routes/_workspace/availability/$id.tsx
@@ -9,6 +9,7 @@ import {
   getAvailabilitySlotProductQueryOptions,
   loadAvailabilitySlotDetailPage,
 } from "@voyantjs/availability-ui"
+import { BookingCreateDialog } from "@voyantjs/bookings-ui"
 import {
   Sheet,
   SheetContent,
@@ -42,6 +43,10 @@ function RouteComponent() {
   })
   const productName = productQuery.data?.data?.name ?? null
   const [bookingPreviewId, setBookingPreviewId] = useState<string | null>(null)
+  const [bookingCreateDefaults, setBookingCreateDefaults] = useState<{
+    slotId: string
+    productId: string
+  } | null>(null)
 
   useAdminBreadcrumbs([
     { label: messages.availability.title, href: "/availability" },
@@ -74,8 +79,19 @@ function RouteComponent() {
             slotId={slotId}
             embed
             onBookingOpen={(bookingId) => setBookingPreviewId(bookingId)}
+            onCreateBooking={(input) => setBookingCreateDefaults(input)}
           />
         )}
+      />
+
+      <BookingCreateDialog
+        open={Boolean(bookingCreateDefaults)}
+        onOpenChange={(open) => {
+          if (!open) setBookingCreateDefaults(null)
+        }}
+        defaultProductId={bookingCreateDefaults?.productId}
+        defaultSlotId={bookingCreateDefaults?.slotId}
+        onCreated={(booking) => setBookingPreviewId(booking.id)}
       />
 
       <Sheet

--- a/templates/operator/src/routes/_workspace/bookings/$id.tsx
+++ b/templates/operator/src/routes/_workspace/bookings/$id.tsx
@@ -15,6 +15,7 @@ import { operatorFetcher } from "@/lib/voyant-fetcher"
 
 const bookingRouteSearchSchema = z.object({
   productId: z.string().optional(),
+  slotId: z.string().optional(),
 })
 
 export const Route = createFileRoute("/_workspace/bookings/$id")({
@@ -47,6 +48,7 @@ function BookingDetailRoute() {
     return (
       <BookingCreatePage
         defaultProductId={search.productId}
+        defaultSlotId={search.slotId}
         onCancel={() => void navigate({ to: "/bookings" })}
         onCreated={(booking) => void navigate({ to: "/bookings/$id", params: { id: booking.id } })}
       />


### PR DESCRIPTION
## Summary
- add `defaultSlotId` to booking create dialog/form/page flows so a departure can be preselected and locked
- add an opt-in `onCreateBooking` action to `SlotAllocationPage`
- wire the operator slot allocation page to open booking creation for the current slot and preview the created booking

Closes #1237

## Validation
- `pnpm --filter @voyantjs/bookings-ui typecheck`
- `pnpm --filter @voyantjs/bookings-ui lint`
- `pnpm --filter @voyantjs/bookings-ui test`
- `pnpm --filter @voyantjs/allocation-ui typecheck`
- `pnpm --filter @voyantjs/allocation-ui lint`
- `pnpm --filter @voyantjs/allocation-ui test`
- `pnpm --filter operator typecheck`
- `pnpm --filter operator lint`
- `git diff --check`
- commit hook: repo lint and repo typecheck passed

## Notes
- `pnpm verify:fast` still stops at the existing `@voyantjs/ui` component barrel check for unrelated missing exports.
- The report-only quality check flags the touched allocation and booking create files for pre-existing file-size thresholds.