### PR TITLE
Fix SmartBill seeded invoice number write-back

### DIFF
--- a/.changeset/smartbill-seeded-invoice-number.md
+++ b/.changeset/smartbill-seeded-invoice-number.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/plugin-smartbill": patch
+---
+
+Preserve canonical invoice numbers from externally seeded SmartBill refs.

--- a/packages/plugins/smartbill/src/sync.ts
+++ b/packages/plugins/smartbill/src/sync.ts
@@ -237,12 +237,30 @@ async function applyExternalAllocationIfRequired(
 ) {
   if (event.externalAllocationRequired !== true || !result.number) return
 
+  await applyExternalAllocationNumber(
+    event,
+    documentType,
+    body,
+    result,
+    runtime,
+    formatExternalInvoiceNumber(result.series ?? body.seriesName, result.number),
+  )
+}
+
+async function applyExternalAllocationNumber(
+  event: VoyantInvoiceEvent,
+  documentType: SmartbillDocumentType,
+  body: SmartbillInvoiceBody,
+  result: SmartbillInvoiceResponse | undefined,
+  runtime: SmartbillSyncRuntime,
+  invoiceNumber: string,
+) {
   const db = await resolveArtifactDb(event, documentType, body, result, runtime)
   if (!db) {
     throw new Error("SmartBill external allocation requires artifact database access")
   }
   const allocation = await financeService.applyExternalInvoiceAllocation(db, event.id, {
-    invoiceNumber: formatExternalInvoiceNumber(result.series ?? body.seriesName, result.number),
+    invoiceNumber,
   })
   if (allocation.status === "applied") {
     runtime.logger.info?.(`[smartbill] external number applied for ${event.id}`, allocation.invoice)
@@ -267,19 +285,19 @@ async function applyExternalAllocationFromRefIfRequired(
   if (!number) {
     throw new Error("SmartBill external allocation requires an existing external number")
   }
-  await applyExternalAllocationIfRequired(
+  const refSeries = metadataString(metadata, "series") ?? metadataString(metadata, "seriesName")
+  const refResult: SmartbillInvoiceResponse = {
+    number,
+    series: refSeries ?? undefined,
+    url: externalRef.externalUrl ?? undefined,
+  }
+  await applyExternalAllocationNumber(
     event,
     documentType,
     body,
-    {
-      number,
-      series:
-        metadataString(metadata, "series") ??
-        metadataString(metadata, "seriesName") ??
-        body.seriesName,
-      url: externalRef.externalUrl ?? undefined,
-    },
+    refResult,
     runtime,
+    formatExternalInvoiceNumber(refSeries ?? undefined, number),
   )
 }
 
@@ -288,6 +306,7 @@ async function resolveWriteBackInvoiceNumber(
   body: SmartbillInvoiceBody,
   result: SmartbillInvoiceResponse,
   writeBackInvoiceNumber: boolean | SmartbillInvoiceNumberWriteBackFormatter | undefined,
+  options: { useBodySeriesFallback?: boolean } = {},
 ) {
   if (!writeBackInvoiceNumber) return null
   if (typeof writeBackInvoiceNumber === "function") {
@@ -298,7 +317,9 @@ async function resolveWriteBackInvoiceNumber(
     return invoiceNumber
   }
   if (!result.number) return null
-  return formatExternalInvoiceNumber(result.series ?? body.seriesName, result.number)
+  const series =
+    result.series ?? (options.useBodySeriesFallback === false ? undefined : body.seriesName)
+  return formatExternalInvoiceNumber(series, result.number)
 }
 
 async function writeBackInvoiceNumberIfRequired(
@@ -316,6 +337,17 @@ async function writeBackInvoiceNumberIfRequired(
   )
   if (!invoiceNumber) return
 
+  await writeBackResolvedInvoiceNumber(event, documentType, body, result, runtime, invoiceNumber)
+}
+
+async function writeBackResolvedInvoiceNumber(
+  event: VoyantInvoiceEvent,
+  documentType: SmartbillDocumentType,
+  body: SmartbillInvoiceBody,
+  result: SmartbillInvoiceResponse | undefined,
+  runtime: SmartbillSyncRuntime,
+  invoiceNumber: string,
+) {
   const db = await resolveArtifactDb(event, documentType, body, result, runtime)
   if (!db) {
     throw new Error("SmartBill invoice number write-back requires artifact database access")
@@ -345,20 +377,22 @@ async function writeBackInvoiceNumberFromRefIfRequired(
     null
   if (!number) return
 
-  await writeBackInvoiceNumberIfRequired(
+  const refSeries = metadataString(metadata, "series") ?? metadataString(metadata, "seriesName")
+  const refResult: SmartbillInvoiceResponse = {
+    number,
+    series: refSeries ?? undefined,
+    url: externalRef.externalUrl ?? undefined,
+  }
+  const invoiceNumber = await resolveWriteBackInvoiceNumber(
     event,
-    documentType,
     body,
-    {
-      number,
-      series:
-        metadataString(metadata, "series") ??
-        metadataString(metadata, "seriesName") ??
-        body.seriesName,
-      url: externalRef.externalUrl ?? undefined,
-    },
-    runtime,
+    refResult,
+    runtime.writeBackInvoiceNumber,
+    { useBodySeriesFallback: false },
   )
+  if (!invoiceNumber) return
+
+  await writeBackResolvedInvoiceNumber(event, documentType, body, refResult, runtime, invoiceNumber)
 }
 
 async function recordSyncError(

--- a/packages/plugins/smartbill/tests/unit/plugin.test.ts
+++ b/packages/plugins/smartbill/tests/unit/plugin.test.ts
@@ -300,6 +300,55 @@ describe("smartbillPlugin — invoice.issued subscriber", () => {
     )
   })
 
+  it("applies an externally seeded SmartBill number without prepending the configured series", async () => {
+    financeServiceMock.listInvoiceExternalRefs.mockResolvedValueOnce([
+      {
+        id: "iex_existing",
+        invoiceId: "inv_external_seeded",
+        provider: "smartbill",
+        externalId: "remote_A0250",
+        externalNumber: "A0250",
+        externalUrl: null,
+        status: "issued",
+        syncError: null,
+        metadata: null,
+      },
+    ])
+    const fetchMock = vi.fn<SmartbillFetch>(async () =>
+      jsonResponse(200, { ...okEnvelope, number: "ignored", series: "ignored" }),
+    )
+    const dbResolver = vi.fn(() => ({}))
+    const plugin = smartbillPlugin({
+      ...baseOptions,
+      seriesName: "B",
+      fetch: fetchMock,
+      artifacts: { db: dbResolver as never },
+      logger: makeLogger(),
+    })
+    const handler = subscriberFor(plugin, "invoice.issued").handler
+
+    await handler(
+      eventEnvelope({
+        id: "inv_external_seeded",
+        externalAllocationRequired: true,
+        invoiceNumber: "PENDING-INVOICE-abc",
+        lineItems: [],
+      }),
+    )
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(financeServiceMock.applyExternalInvoiceAllocation).toHaveBeenCalledWith(
+      expect.anything(),
+      "inv_external_seeded",
+      { invoiceNumber: "A0250" },
+    )
+    expect(dbResolver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        result: expect.objectContaining({ number: "A0250", series: undefined }),
+      }),
+    )
+  })
+
   it("writes the SmartBill series-number back to the invoice when configured", async () => {
     const fetchMock = vi.fn<SmartbillFetch>(async () =>
       jsonResponse(200, { ...okEnvelope, number: "0127", series: "B" }),
@@ -415,6 +464,103 @@ describe("smartbillPlugin — invoice.issued subscriber", () => {
       expect.anything(),
       "inv_existing_write_back",
       { invoiceNumber: "B-0127" },
+    )
+  })
+
+  it("writes an externally seeded SmartBill number back without prepending the configured series", async () => {
+    financeServiceMock.listInvoiceExternalRefs.mockResolvedValueOnce([
+      {
+        id: "iex_existing",
+        invoiceId: "inv_seeded_write_back",
+        provider: "smartbill",
+        externalId: "remote_A0250",
+        externalNumber: "A0250",
+        externalUrl: null,
+        status: "issued",
+        syncError: null,
+        metadata: null,
+      },
+    ])
+    const fetchMock = vi.fn<SmartbillFetch>(async () =>
+      jsonResponse(200, { ...okEnvelope, number: "ignored", series: "ignored" }),
+    )
+    const plugin = smartbillPlugin({
+      ...baseOptions,
+      seriesName: "B",
+      fetch: fetchMock,
+      artifacts: { db: {} as never },
+      logger: makeLogger(),
+      writeBackInvoiceNumber: true,
+    })
+    const handler = subscriberFor(plugin, "invoice.issued").handler
+
+    await handler(
+      eventEnvelope({
+        id: "inv_seeded_write_back",
+        invoiceNumber: "A0250",
+        lineItems: [],
+      }),
+    )
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(financeServiceMock.updateInvoice).toHaveBeenCalledWith(
+      expect.anything(),
+      "inv_seeded_write_back",
+      { invoiceNumber: "A0250" },
+    )
+  })
+
+  it("uses a custom write-back formatter for an externally seeded SmartBill ref", async () => {
+    financeServiceMock.listInvoiceExternalRefs.mockResolvedValueOnce([
+      {
+        id: "iex_existing",
+        invoiceId: "inv_seeded_custom_write_back",
+        provider: "smartbill",
+        externalId: "remote_A0250",
+        externalNumber: "A0250",
+        externalUrl: "https://smartbill.test/invoice/A0250",
+        status: "issued",
+        syncError: null,
+        metadata: null,
+      },
+    ])
+    const fetchMock = vi.fn<SmartbillFetch>(async () =>
+      jsonResponse(200, { ...okEnvelope, number: "ignored", series: "ignored" }),
+    )
+    const writeBackInvoiceNumber = vi.fn(async (_event, result) => {
+      return `external/${result.number}`
+    })
+    const plugin = smartbillPlugin({
+      ...baseOptions,
+      seriesName: "B",
+      fetch: fetchMock,
+      artifacts: { db: {} as never },
+      logger: makeLogger(),
+      writeBackInvoiceNumber,
+    })
+    const handler = subscriberFor(plugin, "invoice.issued").handler
+
+    await handler(
+      eventEnvelope({
+        id: "inv_seeded_custom_write_back",
+        invoiceNumber: "A0250",
+        lineItems: [],
+      }),
+    )
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(writeBackInvoiceNumber).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "inv_seeded_custom_write_back" }),
+      expect.objectContaining({
+        number: "A0250",
+        series: undefined,
+        url: "https://smartbill.test/invoice/A0250",
+      }),
+    )
+    expect(financeServiceMock.updateInvoice).toHaveBeenCalledWith(
+      expect.anything(),
+      "inv_seeded_custom_write_back",
+      { invoiceNumber: "external/A0250" },
     )
   })
 


### PR DESCRIPTION
## Summary

- Preserve canonical invoice numbers from externally seeded SmartBill refs when no series is recorded on ref metadata.
- Keep series-prefix formatting for SmartBill-created responses and refs that explicitly record a series.
- Add regressions for write-back and external allocation with seeded refs.

Closes #1223

## Verification

- `pnpm --filter @voyantjs/plugin-smartbill test`
- `pnpm --filter @voyantjs/plugin-smartbill typecheck`
- `pnpm --filter @voyantjs/plugin-smartbill lint`
- push hook repository test lane: 127 tasks successful