### PR TITLE
Fix terminal booking status override cascades

### DIFF
--- a/.changeset/terminal-booking-overrides-cascade.md
+++ b/.changeset/terminal-booking-overrides-cascade.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/bookings": patch
+---
+
+Cascade terminal booking status overrides to booking items and allocations, including slot capacity release for cancelled and expired overrides.

--- a/packages/bookings/src/routes.ts
+++ b/packages/bookings/src/routes.ts
@@ -1841,10 +1841,11 @@ export const bookingRoutes = new Hono<Env>()
   })
 
   // 11c. POST /:id/override-status — Admin override that bypasses the
-  // transition graph. Updates the booking row only — no cascade to items,
-  // allocations, or fulfillments. Always emits booking.status_overridden for
-  // audit. Confirmed overrides also emit booking.confirmed unless
-  // suppressLifecycleEvents is true. Requires a non-empty `reason`.
+  // transition graph. Terminal overrides cascade to items and allocations;
+  // non-terminal overrides remain booking-row data correction. Always emits
+  // booking.status_overridden for audit. Confirmed overrides also emit
+  // booking.confirmed unless suppressLifecycleEvents is true. Requires a
+  // non-empty `reason`.
   .post("/:id/override-status", async (c) => {
     const bookingId = c.req.param("id")
     const data = await parseJsonBody(c, overrideBookingStatusSchema)

--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -183,6 +183,22 @@ function allocationStatusForBookingItemStatus(status: BookingItemStatus): Bookin
   return "held"
 }
 
+function terminalBookingItemStatusForOverride(status: BookingStatus): BookingItemStatus | null {
+  if (status === "cancelled") return "cancelled"
+  if (status === "expired") return "expired"
+  if (status === "completed") return "fulfilled"
+  return null
+}
+
+function terminalBookingAllocationStatusForOverride(
+  status: BookingStatus,
+): BookingAllocationStatus | null {
+  if (status === "cancelled") return "cancelled"
+  if (status === "expired") return "expired"
+  if (status === "completed") return "fulfilled"
+  return null
+}
+
 function allocationStatusConsumesSlotCapacity(status: BookingAllocationStatus) {
   return status === "held" || status === "confirmed" || status === "fulfilled"
 }
@@ -1622,7 +1638,7 @@ async function releaseAllocationCapacity(
     return undefined
   }
 
-  if (allocation.status !== "held" && allocation.status !== "confirmed") {
+  if (!allocationStatusConsumesSlotCapacity(allocation.status)) {
     return undefined
   }
 
@@ -4328,11 +4344,9 @@ export const bookingsService = {
   },
 
   /**
-   * Admin-only force: bypasses the transition graph. Updates the booking row
-   * only — does NOT cascade to items, allocations, or fulfillments. If the
-   * operator needs cascaded behavior (e.g. release allocations), they should
-   * call the verb-specific method instead. The override is for data
-   * correction; misuse leaves child state inconsistent with the parent.
+   * Admin-only force: bypasses the transition graph. Terminal overrides
+   * cascade to items and allocations so reporting and capacity stay
+   * consistent; non-terminal overrides remain booking-row data correction.
    */
   async overrideBookingStatus(
     db: PostgresJsDatabase,
@@ -4341,6 +4355,7 @@ export const bookingsService = {
     userId?: string,
     runtime: BookingServiceRuntime = {},
   ) {
+    const slotChanges: AvailabilitySlotChangedEventPayload[] = []
     try {
       const result = await db.transaction(async (tx) => {
         const rows = await tx.execute(
@@ -4360,6 +4375,8 @@ export const bookingsService = {
         }
 
         const now = new Date()
+        const terminalItemStatus = terminalBookingItemStatusForOverride(data.status)
+        const terminalAllocationStatus = terminalBookingAllocationStatusForOverride(data.status)
         const updates: Record<string, unknown> = {
           status: data.status,
           confirmedAt: confirmedAtForStatus(data.status, null, now),
@@ -4368,6 +4385,70 @@ export const bookingsService = {
         if (data.status === "expired") updates.expiredAt = now
         if (data.status === "cancelled") updates.cancelledAt = now
         if (data.status === "completed") updates.completedAt = now
+
+        if (terminalItemStatus && terminalAllocationStatus) {
+          if (data.status === "cancelled" || data.status === "expired") {
+            const allocations = await tx
+              .select()
+              .from(bookingAllocations)
+              .where(
+                and(
+                  eq(bookingAllocations.bookingId, id),
+                  or(
+                    eq(bookingAllocations.status, "held"),
+                    eq(bookingAllocations.status, "confirmed"),
+                    eq(bookingAllocations.status, "fulfilled"),
+                  ),
+                ),
+              )
+
+            for (const allocation of allocations) {
+              const change = await releaseAllocationCapacity(
+                tx as PostgresJsDatabase,
+                allocation,
+                data.status === "expired" ? "expire" : "cancel",
+              )
+              if (change) slotChanges.push(change)
+            }
+          }
+
+          const allocationUpdates: Record<string, unknown> = {
+            status: terminalAllocationStatus,
+            updatedAt: now,
+          }
+          if (data.status === "cancelled" || data.status === "expired") {
+            allocationUpdates.releasedAt = now
+          }
+
+          await tx
+            .update(bookingAllocations)
+            .set(allocationUpdates)
+            .where(
+              and(
+                eq(bookingAllocations.bookingId, id),
+                or(
+                  eq(bookingAllocations.status, "held"),
+                  eq(bookingAllocations.status, "confirmed"),
+                  eq(bookingAllocations.status, "fulfilled"),
+                ),
+              ),
+            )
+
+          await tx
+            .update(bookingItems)
+            .set({ status: terminalItemStatus, updatedAt: now })
+            .where(
+              and(
+                eq(bookingItems.bookingId, id),
+                or(
+                  eq(bookingItems.status, "draft"),
+                  eq(bookingItems.status, "on_hold"),
+                  eq(bookingItems.status, "confirmed"),
+                  eq(bookingItems.status, "fulfilled"),
+                ),
+              ),
+            )
+        }
 
         const [row] = await tx.update(bookings).set(updates).where(eq(bookings.id, id)).returning()
 
@@ -4437,6 +4518,7 @@ export const bookingsService = {
             { category: "domain", source: "service" },
           )
         }
+        await emitSlotChanges(runtime, slotChanges)
       }
 
       return { status: result.status, booking: result.booking }

--- a/packages/bookings/tests/integration/routes.test.ts
+++ b/packages/bookings/tests/integration/routes.test.ts
@@ -1948,6 +1948,220 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
       expect(confirmedEvents).toHaveLength(0)
     })
 
+    it("cascades cancelled override to child rows and releases capacity", async () => {
+      const slot = await seedSlot({ initialPax: 3, remainingPax: 3 })
+      const reserveRes = await app.request("/reserve", {
+        method: "POST",
+        ...json({
+          bookingNumber: nextBookingNumber(),
+          sellCurrency: "USD",
+          items: [{ title: "Adult ticket", availabilitySlotId: slot.id, quantity: 2 }],
+        }),
+      })
+      const { data: booking } = await reserveRes.json()
+      await app.request(`/${booking.id}/confirm`, { method: "POST", ...json({}) })
+
+      const slotEvents: unknown[] = []
+      const sub = eventBus.subscribe("availability.slot.changed", (event) => {
+        slotEvents.push(event.data)
+      })
+
+      try {
+        const res = await app.request(`/${booking.id}/override-status`, {
+          method: "POST",
+          ...json({ status: "cancelled", reason: "Force cancel after failed transition" }),
+        })
+        expect(res.status).toBe(200)
+        expect((await res.json()).data.status).toBe("cancelled")
+      } finally {
+        sub.unsubscribe()
+      }
+
+      const [item] = await db
+        .select()
+        .from(bookingItems)
+        .where(eq(bookingItems.bookingId, booking.id))
+      const [allocation] = await db
+        .select()
+        .from(bookingAllocations)
+        .where(eq(bookingAllocations.bookingId, booking.id))
+      const [updatedSlot] = await db
+        .select()
+        .from(availabilitySlotsRef)
+        .where(eq(availabilitySlotsRef.id, slot.id))
+
+      expect(item?.status).toBe("cancelled")
+      expect(allocation?.status).toBe("cancelled")
+      expect(allocation?.releasedAt).toBeTruthy()
+      expect(updatedSlot?.remainingPax).toBe(3)
+      expect(slotEvents).toHaveLength(1)
+      expect(slotEvents[0]).toMatchObject({
+        slotId: slot.id,
+        source: "cancel",
+        remainingPax: 3,
+      })
+    })
+
+    it("cascades expired override to child rows and releases capacity", async () => {
+      const slot = await seedSlot({ initialPax: 3, remainingPax: 3 })
+      const reserveRes = await app.request("/reserve", {
+        method: "POST",
+        ...json({
+          bookingNumber: nextBookingNumber(),
+          sellCurrency: "USD",
+          items: [{ title: "Adult ticket", availabilitySlotId: slot.id, quantity: 2 }],
+        }),
+      })
+      const { data: booking } = await reserveRes.json()
+
+      const slotEvents: unknown[] = []
+      const sub = eventBus.subscribe("availability.slot.changed", (event) => {
+        slotEvents.push(event.data)
+      })
+
+      try {
+        const res = await app.request(`/${booking.id}/override-status`, {
+          method: "POST",
+          ...json({ status: "expired", reason: "Force expire stale hold" }),
+        })
+        expect(res.status).toBe(200)
+        expect((await res.json()).data.status).toBe("expired")
+      } finally {
+        sub.unsubscribe()
+      }
+
+      const [item] = await db
+        .select()
+        .from(bookingItems)
+        .where(eq(bookingItems.bookingId, booking.id))
+      const [allocation] = await db
+        .select()
+        .from(bookingAllocations)
+        .where(eq(bookingAllocations.bookingId, booking.id))
+      const [updatedSlot] = await db
+        .select()
+        .from(availabilitySlotsRef)
+        .where(eq(availabilitySlotsRef.id, slot.id))
+
+      expect(item?.status).toBe("expired")
+      expect(allocation?.status).toBe("expired")
+      expect(allocation?.releasedAt).toBeTruthy()
+      expect(updatedSlot?.remainingPax).toBe(3)
+      expect(slotEvents).toHaveLength(1)
+      expect(slotEvents[0]).toMatchObject({
+        slotId: slot.id,
+        source: "expire",
+        remainingPax: 3,
+      })
+    })
+
+    it("cascades completed override to fulfilled child rows without releasing capacity", async () => {
+      const slot = await seedSlot({ initialPax: 3, remainingPax: 3 })
+      const reserveRes = await app.request("/reserve", {
+        method: "POST",
+        ...json({
+          bookingNumber: nextBookingNumber(),
+          sellCurrency: "USD",
+          items: [{ title: "Adult ticket", availabilitySlotId: slot.id, quantity: 2 }],
+        }),
+      })
+      const { data: booking } = await reserveRes.json()
+      await app.request(`/${booking.id}/confirm`, { method: "POST", ...json({}) })
+
+      const slotEvents: unknown[] = []
+      const sub = eventBus.subscribe("availability.slot.changed", (event) => {
+        slotEvents.push(event.data)
+      })
+
+      try {
+        const res = await app.request(`/${booking.id}/override-status`, {
+          method: "POST",
+          ...json({ status: "completed", reason: "Force complete reconciled booking" }),
+        })
+        expect(res.status).toBe(200)
+        expect((await res.json()).data.status).toBe("completed")
+      } finally {
+        sub.unsubscribe()
+      }
+
+      const [item] = await db
+        .select()
+        .from(bookingItems)
+        .where(eq(bookingItems.bookingId, booking.id))
+      const [allocation] = await db
+        .select()
+        .from(bookingAllocations)
+        .where(eq(bookingAllocations.bookingId, booking.id))
+      const [updatedSlot] = await db
+        .select()
+        .from(availabilitySlotsRef)
+        .where(eq(availabilitySlotsRef.id, slot.id))
+
+      expect(item?.status).toBe("fulfilled")
+      expect(allocation?.status).toBe("fulfilled")
+      expect(allocation?.releasedAt).toBeNull()
+      expect(updatedSlot?.remainingPax).toBe(1)
+      expect(slotEvents).toHaveLength(0)
+    })
+
+    it("cascades cancelled override from completed children and releases capacity", async () => {
+      const slot = await seedSlot({ initialPax: 3, remainingPax: 3 })
+      const reserveRes = await app.request("/reserve", {
+        method: "POST",
+        ...json({
+          bookingNumber: nextBookingNumber(),
+          sellCurrency: "USD",
+          items: [{ title: "Adult ticket", availabilitySlotId: slot.id, quantity: 2 }],
+        }),
+      })
+      const { data: booking } = await reserveRes.json()
+      await app.request(`/${booking.id}/confirm`, { method: "POST", ...json({}) })
+      await app.request(`/${booking.id}/override-status`, {
+        method: "POST",
+        ...json({ status: "completed", reason: "Force complete reconciled booking" }),
+      })
+
+      const slotEvents: unknown[] = []
+      const sub = eventBus.subscribe("availability.slot.changed", (event) => {
+        slotEvents.push(event.data)
+      })
+
+      try {
+        const res = await app.request(`/${booking.id}/override-status`, {
+          method: "POST",
+          ...json({ status: "cancelled", reason: "Correct completed booking" }),
+        })
+        expect(res.status).toBe(200)
+        expect((await res.json()).data.status).toBe("cancelled")
+      } finally {
+        sub.unsubscribe()
+      }
+
+      const [item] = await db
+        .select()
+        .from(bookingItems)
+        .where(eq(bookingItems.bookingId, booking.id))
+      const [allocation] = await db
+        .select()
+        .from(bookingAllocations)
+        .where(eq(bookingAllocations.bookingId, booking.id))
+      const [updatedSlot] = await db
+        .select()
+        .from(availabilitySlotsRef)
+        .where(eq(availabilitySlotsRef.id, slot.id))
+
+      expect(item?.status).toBe("cancelled")
+      expect(allocation?.status).toBe("cancelled")
+      expect(allocation?.releasedAt).toBeTruthy()
+      expect(updatedSlot?.remainingPax).toBe(3)
+      expect(slotEvents).toHaveLength(1)
+      expect(slotEvents[0]).toMatchObject({
+        slotId: slot.id,
+        source: "cancel",
+        remainingPax: 3,
+      })
+    })
+
     it("extends an on-hold booking", async () => {
       const slot = await seedSlot()
       const reserveRes = await app.request("/reserve", {


### PR DESCRIPTION
## Summary
- cascade terminal override statuses to booking items and allocations
- release slot capacity and emit slot-change events for cancelled and expired overrides
- cover cancelled, expired, and completed override behavior in booking route tests

Fixes #1225

## Verification
- `pnpm --filter @voyantjs/bookings typecheck`
- `pnpm --filter @voyantjs/bookings test -- tests/integration/routes.test.ts`
- pre-push `pnpm test` hook