### PR TITLE
Prefer matching room units in auto allocation

### DIFF
--- a/.changeset/room-unit-allocation.md
+++ b/.changeset/room-unit-allocation.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/availability": patch
+---
+
+Prefer matching room option units during automatic room allocation.

--- a/packages/availability/src/auto-allocator.ts
+++ b/packages/availability/src/auto-allocator.ts
@@ -6,6 +6,9 @@ export interface AllocatorTraveler {
   sharingGroupId: string | null
   hasAccessibilityNeeds: boolean
   existingAllocationId: string | null
+  optionId?: string | null
+  optionUnitId?: string | null
+  optionUnitCode?: string | null
 }
 
 export interface AllocatorResource {
@@ -14,6 +17,9 @@ export interface AllocatorResource {
   capacity: number
   flags: Record<string, unknown>
   parentId: string | null
+  refType?: string | null
+  refId?: string | null
+  label?: string | null
   row?: number
   column?: string
   position?: "window" | "aisle" | "middle"
@@ -31,6 +37,9 @@ interface InternalGroup {
   travelerIds: string[]
   needsAccessibility: boolean
   leadTravelerId: string | null
+  optionIds: Set<string>
+  optionUnitIds: Set<string>
+  optionUnitCodes: Set<string>
 }
 
 function activeTravelers(travelers: AllocatorTraveler[]): AllocatorTraveler[] {
@@ -51,14 +60,59 @@ function groupTravelers(travelers: AllocatorTraveler[]): Map<string, InternalGro
       travelerIds: [],
       needsAccessibility: false,
       leadTravelerId: null,
+      optionIds: new Set<string>(),
+      optionUnitIds: new Set<string>(),
+      optionUnitCodes: new Set<string>(),
     }
     group.travelerIds.push(traveler.id)
     if (traveler.hasAccessibilityNeeds) group.needsAccessibility = true
     if (traveler.isLeadTraveler && !group.leadTravelerId) group.leadTravelerId = traveler.id
+    if (traveler.optionId) group.optionIds.add(traveler.optionId)
+    if (traveler.optionUnitId) group.optionUnitIds.add(traveler.optionUnitId)
+    if (traveler.optionUnitCode) group.optionUnitCodes.add(traveler.optionUnitCode)
     groups.set(group.key, group)
   }
 
   return groups
+}
+
+function groupUnitMatchScore(resource: AllocatorResource, group: InternalGroup): number {
+  let score = 0
+  const optionId = singleSetValue(group.optionIds)
+  if (optionId && resource.flags.templateOptionId === optionId) score += 4
+
+  const optionUnitId = singleSetValue(group.optionUnitIds)
+  if (optionUnitId && resource.refType === "option_unit" && resource.refId === optionUnitId) {
+    score += 2
+  }
+
+  const optionUnitCode = singleSetValue(group.optionUnitCodes)
+  if (optionUnitCode && labelStartsWithUnitCode(resource.label, optionUnitCode)) score += 1
+
+  return score
+}
+
+function singleSetValue(values: Set<string>): string | null {
+  return values.size === 1 ? ([...values][0] ?? null) : null
+}
+
+function labelStartsWithUnitCode(label: string | null | undefined, code: string): boolean {
+  const prefix = normalizeUnitCodePrefix(code)
+  if (!prefix || !label) return false
+  return label
+    .trim()
+    .toLowerCase()
+    .replace(/^[^a-z0-9]+/, "")
+    .startsWith(prefix)
+}
+
+function normalizeUnitCodePrefix(code: string): string | null {
+  return (
+    code
+      .trim()
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)[0] ?? null
+  )
 }
 
 export function planRoomAllocation(
@@ -103,6 +157,10 @@ export function planRoomAllocation(
       } else if (leftAccessible !== rightAccessible) {
         return leftAccessible ? 1 : -1
       }
+
+      const leftUnitMatch = groupUnitMatchScore(left, group)
+      const rightUnitMatch = groupUnitMatchScore(right, group)
+      if (leftUnitMatch !== rightUnitMatch) return rightUnitMatch - leftUnitMatch
 
       const leftFree = left.capacity - (occupancy.get(left.id) ?? 0)
       const rightFree = right.capacity - (occupancy.get(right.id) ?? 0)

--- a/packages/availability/src/service-allocation-automation.ts
+++ b/packages/availability/src/service-allocation-automation.ts
@@ -727,6 +727,9 @@ function toAllocatorTravelers(manifest: SlotAllocationManifest, kind: string): A
         sharingGroupId: traveler.sharingGroupId,
         hasAccessibilityNeeds: traveler.hasAccessibilityNeeds,
         existingAllocationId: traveler.allocations[kind] ?? null,
+        optionId: traveler.optionId,
+        optionUnitId: traveler.optionUnitId,
+        optionUnitCode: traveler.optionUnitCode,
       })
     }
   }
@@ -740,6 +743,9 @@ function toAllocatorResource(resource: AllocationResource): AllocatorResource {
     capacity: resource.capacity,
     flags: resource.flags ?? {},
     parentId: resource.parentId,
+    refType: resource.refType,
+    refId: resource.refId,
+    label: resource.label,
     row: typeof resource.flags?.row === "number" ? resource.flags.row : undefined,
     column: typeof resource.flags?.column === "string" ? resource.flags.column : undefined,
     position:

--- a/packages/availability/src/service-allocation.ts
+++ b/packages/availability/src/service-allocation.ts
@@ -66,6 +66,9 @@ export interface AllocationManifestTraveler {
   isLeadTraveler: boolean
   isPrimary: boolean
   sharingGroupId: string | null
+  optionId: string | null
+  optionUnitId: string | null
+  optionUnitCode: string | null
   roomTypeId: string | null
   bedPreference: string | null
   allocations: Record<string, string>
@@ -146,6 +149,8 @@ export async function getSlotAllocationManifest(
 
   const bookingIds = bookingRows.map((row) => row.id)
   const travelerRows = await loadSlotTravelerRows(db, bookingIds)
+  const bookingUnitRows = await loadSlotBookingUnitRows(db, slotId, bookingIds)
+  const selectedUnitByBookingId = new Map(bookingUnitRows.map((row) => [row.booking_id, row]))
   const bookingById = new Map(bookingRows.map((row) => [row.id, row]))
   // Assign 1-based slot-local sequence by booking createdAt. The SQL above
   // already orders by `created_at` then `booking_number`, so iterating in
@@ -173,6 +178,9 @@ export async function getSlotAllocationManifest(
       isLeadTraveler: row.is_lead_traveler ?? false,
       isPrimary: row.is_primary,
       sharingGroupId: row.sharing_group_id,
+      optionId: selectedUnitByBookingId.get(row.booking_id)?.option_id ?? null,
+      optionUnitId: selectedUnitByBookingId.get(row.booking_id)?.option_unit_id ?? null,
+      optionUnitCode: selectedUnitByBookingId.get(row.booking_id)?.option_unit_code ?? null,
       roomTypeId: row.room_type_id,
       bedPreference: row.bed_preference,
       allocations: normalizeAllocationMap(row.allocations),
@@ -1130,6 +1138,13 @@ interface TravelerRow {
   has_dietary_requirements: boolean
 }
 
+interface BookingUnitRow {
+  booking_id: string
+  option_id: string | null
+  option_unit_id: string | null
+  option_unit_code: string | null
+}
+
 async function loadSlotBookingRows(db: PostgresJsDatabase, slotId: string): Promise<BookingRow[]> {
   // `invoices` and `booking_payment_schedules` are LEFT JOIN aggregations that
   // may reference tables missing in catalog-less / finance-less deploys.
@@ -1370,6 +1385,69 @@ async function loadSlotTravelerRows(
     LEFT JOIN booking_traveler_travel_details btd ON btd.traveler_id = bt.id
     WHERE bt.booking_id = ANY(${sqlTextArray(bookingIds)})
     ORDER BY bt.booking_id, bt.is_primary DESC, bt.created_at
+  `,
+  )
+}
+
+async function loadSlotBookingUnitRows(
+  db: PostgresJsDatabase,
+  slotId: string,
+  bookingIds: string[],
+): Promise<BookingUnitRow[]> {
+  try {
+    return await executeRows<BookingUnitRow>(
+      db,
+      sql`
+      SELECT DISTINCT ON (ba.booking_id)
+        ba.booking_id,
+        ba.option_id,
+        ba.option_unit_id,
+        ou.code AS option_unit_code
+      FROM booking_allocations ba
+      LEFT JOIN option_units ou ON ou.id = ba.option_unit_id
+      WHERE ba.booking_id = ANY(${sqlTextArray(bookingIds)})
+        AND ba.availability_slot_id = ${slotId}
+        AND ba.status IN ('held', 'confirmed', 'fulfilled')
+      ORDER BY
+        ba.booking_id,
+        (ba.option_unit_id IS NULL),
+        CASE ba.status
+          WHEN 'fulfilled' THEN 0
+          WHEN 'confirmed' THEN 1
+          WHEN 'held' THEN 2
+          ELSE 3
+        END,
+        ba.updated_at DESC,
+        ba.created_at DESC
+    `,
+    )
+  } catch (error) {
+    if (!isUndefinedTableError(error)) throw error
+  }
+
+  return executeRows<BookingUnitRow>(
+    db,
+    sql`
+    SELECT DISTINCT ON (ba.booking_id)
+      ba.booking_id,
+      ba.option_id,
+      ba.option_unit_id,
+      NULL::text AS option_unit_code
+    FROM booking_allocations ba
+    WHERE ba.booking_id = ANY(${sqlTextArray(bookingIds)})
+      AND ba.availability_slot_id = ${slotId}
+      AND ba.status IN ('held', 'confirmed', 'fulfilled')
+    ORDER BY
+      ba.booking_id,
+      (ba.option_unit_id IS NULL),
+      CASE ba.status
+        WHEN 'fulfilled' THEN 0
+        WHEN 'confirmed' THEN 1
+        WHEN 'held' THEN 2
+        ELSE 3
+      END,
+      ba.updated_at DESC,
+      ba.created_at DESC
   `,
   )
 }

--- a/packages/availability/tests/integration/slot-resource-availability.test.ts
+++ b/packages/availability/tests/integration/slot-resource-availability.test.ts
@@ -1,6 +1,6 @@
 import { newId } from "@voyantjs/db/lib/typeid"
 import { cleanupTestDb, createTestDb } from "@voyantjs/db/test-utils"
-import { products } from "@voyantjs/products/schema"
+import { optionUnits, productOptions, products } from "@voyantjs/products/schema"
 import { sql } from "drizzle-orm"
 import { beforeAll, beforeEach, describe, expect, it } from "vitest"
 
@@ -179,6 +179,66 @@ describe.skipIf(!DB_AVAILABLE)("slot resource availability (integration)", () =>
     expect(manifest).not.toBeNull()
     expect(manifest?.bookings).toHaveLength(3)
     expect(manifest?.summary.travelerCount).toBe(3)
+  })
+
+  it("uses the newest active booking allocation row for unit preferences", async () => {
+    const optionId = newId("product_options")
+    const dblUnitId = newId("option_units")
+    const twnUnitId = newId("option_units")
+    await db.insert(productOptions).values({
+      id: optionId,
+      productId,
+      name: "Standard",
+    })
+    await db.insert(optionUnits).values([
+      {
+        id: dblUnitId,
+        optionId,
+        name: "DBL room",
+        code: "dbl_room",
+        unitType: "person",
+        sortOrder: 0,
+      },
+      {
+        id: twnUnitId,
+        optionId,
+        name: "TWN room",
+        code: "twn_room",
+        unitType: "person",
+        sortOrder: 1,
+      },
+    ])
+
+    const bookingId = newId("bookings")
+    const travelerId = newId("booking_travelers")
+    const oldItemId = newId("booking_items")
+    const newItemId = newId("booking_items")
+    await db.execute(sql`
+      INSERT INTO bookings (id, booking_number, status, sell_currency)
+      VALUES (${bookingId}, 'BK-UNIT-EDIT', 'confirmed', 'USD')
+    `)
+    await db.execute(sql`
+      INSERT INTO booking_items (id, booking_id, title, sell_currency, quantity, option_id, option_unit_id)
+      VALUES
+        (${oldItemId}, ${bookingId}, 'Old DBL', 'USD', 2, ${optionId}, ${dblUnitId}),
+        (${newItemId}, ${bookingId}, 'New TWN', 'USD', 2, ${optionId}, ${twnUnitId})
+    `)
+    await db.execute(sql`
+      INSERT INTO booking_allocations
+        (id, booking_id, booking_item_id, product_id, option_id, option_unit_id, availability_slot_id, quantity, allocation_type, status, created_at, updated_at)
+      VALUES
+        (${newId("booking_allocations")}, ${bookingId}, ${oldItemId}, ${productId}, ${optionId}, ${dblUnitId}, ${slotId}, 2, 'unit', 'confirmed', ${new Date("2026-01-01T00:00:00Z")}, ${new Date("2026-01-01T00:00:00Z")}),
+        (${newId("booking_allocations")}, ${bookingId}, ${newItemId}, ${productId}, ${optionId}, ${twnUnitId}, ${slotId}, 2, 'unit', 'confirmed', ${new Date("2026-01-02T00:00:00Z")}, ${new Date("2026-01-02T00:00:00Z")})
+    `)
+    await db.execute(sql`
+      INSERT INTO booking_travelers (id, booking_id, participant_type, first_name, last_name)
+      VALUES (${travelerId}, ${bookingId}, 'traveler', 'Edited', 'Traveler')
+    `)
+
+    const manifest = await getSlotAllocationManifest(db, slotId)
+    const traveler = manifest?.bookings[0]?.travelers[0]
+    expect(traveler?.optionUnitId).toBe(twnUnitId)
+    expect(traveler?.optionUnitCode).toBe("twn_room")
   })
 
   it("validates allocations across multiple resources without a record-cast crash", async () => {

--- a/packages/availability/tests/unit/auto-allocator.test.ts
+++ b/packages/availability/tests/unit/auto-allocator.test.ts
@@ -81,6 +81,75 @@ describe("planRoomAllocation", () => {
     expect(plan.assignments).toEqual([{ travelerId: "t1", resourceId: "r-single" }])
   })
 
+  it("prefers rooms with a matching template option before capacity tie-breakers", () => {
+    const plan = planRoomAllocation(
+      [
+        traveler({ id: "t1", bookingId: "b1", optionId: "option-dbl" }),
+        traveler({ id: "t2", bookingId: "b1", optionId: "option-dbl" }),
+      ],
+      [
+        room({ id: "r-twn", capacity: 2, flags: { templateOptionId: "option-twn" } }),
+        room({ id: "r-dbl", capacity: 2, flags: { templateOptionId: "option-dbl" } }),
+      ],
+    )
+
+    expect(plan.assignments.find((row) => row.travelerId === "t1")?.resourceId).toBe("r-dbl")
+    expect(plan.assignments.find((row) => row.travelerId === "t2")?.resourceId).toBe("r-dbl")
+  })
+
+  it("prefers rooms linked to the selected option unit", () => {
+    const plan = planRoomAllocation(
+      [
+        traveler({ id: "t1", bookingId: "b1", optionUnitId: "unit-dbl" }),
+        traveler({ id: "t2", bookingId: "b1", optionUnitId: "unit-dbl" }),
+      ],
+      [
+        room({ id: "r-twn", capacity: 2, refType: "option_unit", refId: "unit-twn" }),
+        room({ id: "r-dbl", capacity: 2, refType: "option_unit", refId: "unit-dbl" }),
+      ],
+    )
+
+    expect(plan.assignments.find((row) => row.travelerId === "t1")?.resourceId).toBe("r-dbl")
+    expect(plan.assignments.find((row) => row.travelerId === "t2")?.resourceId).toBe("r-dbl")
+  })
+
+  it("falls back to the resource label prefix for hand-materialized room types", () => {
+    const plan = planRoomAllocation(
+      [
+        traveler({ id: "t1", bookingId: "b1", optionUnitCode: "dbl_room" }),
+        traveler({ id: "t2", bookingId: "b1", optionUnitCode: "dbl_room" }),
+      ],
+      [
+        room({ id: "r-twn", capacity: 2, label: "TWN #1" }),
+        room({ id: "r-dbl", capacity: 2, label: "DBL #1" }),
+      ],
+    )
+
+    expect(plan.assignments.find((row) => row.travelerId === "t1")?.resourceId).toBe("r-dbl")
+    expect(plan.assignments.find((row) => row.travelerId === "t2")?.resourceId).toBe("r-dbl")
+  })
+
+  it("uses another room type when the preferred option-unit room is full", () => {
+    const plan = planRoomAllocation(
+      [
+        traveler({
+          id: "existing",
+          bookingId: "b0",
+          existingAllocationId: "r-dbl",
+          optionUnitCode: "dbl_room",
+        }),
+        traveler({ id: "t1", bookingId: "b1", optionUnitCode: "dbl_room" }),
+        traveler({ id: "t2", bookingId: "b1", optionUnitCode: "dbl_room" }),
+      ],
+      [room({ id: "r-dbl", capacity: 1, label: "DBL #1" }), room({ id: "r-twn", capacity: 2 })],
+    )
+
+    expect(plan.assignments.find((row) => row.travelerId === "existing")).toBeUndefined()
+    expect(plan.assignments.find((row) => row.travelerId === "t1")?.resourceId).toBe("r-twn")
+    expect(plan.assignments.find((row) => row.travelerId === "t2")?.resourceId).toBe("r-twn")
+    expect(plan.skipped).toBe(0)
+  })
+
   it("preserves existing assignments as no-op plan rows", () => {
     const plan = planRoomAllocation(
       [


### PR DESCRIPTION
## Summary

- Carry selected booking option/unit metadata into allocation manifest travelers and allocator input.
- Let room auto-allocation prefer matching resources via template option flags, option-unit refs, or label-prefix fallback.
- Preserve existing fallback behavior when the preferred room type has no capacity.

Closes #1233

## Verification

- `pnpm --filter @voyantjs/availability test`
- `pnpm --filter @voyantjs/availability typecheck`
- `pnpm --filter @voyantjs/availability lint`
- commit hook affected lint/typecheck: 126 tasks successful
- push hook repository test lane: 127 tasks successful