### PR TITLE
Add invoice void action and admin mutation feedback

### DIFF
--- a/.changeset/finance-invoice-void-ui.md
+++ b/.changeset/finance-invoice-void-ui.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/finance": patch
+"@voyantjs/finance-react": patch
+---
+
+Add issued-invoice voiding and visible admin invoice mutation feedback.

--- a/apps/dev/migrations/0036_invoice_void_fields.sql
+++ b/apps/dev/migrations/0036_invoice_void_fields.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "invoices" ADD COLUMN "voided_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "invoices" ADD COLUMN "void_reason" text;

--- a/apps/dev/migrations/meta/_journal.json
+++ b/apps/dev/migrations/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1779626814451,
       "tag": "0035_booking_reference_foreign_keys",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1779710400000,
+      "tag": "0036_invoice_void_fields",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/dev/src/components/voyant/finance/invoice-detail-page.tsx
+++ b/apps/dev/src/components/voyant/finance/invoice-detail-page.tsx
@@ -10,9 +10,24 @@ import {
   useInvoicePayments,
 } from "@voyantjs/finance-react"
 import { InvoiceDialog } from "@voyantjs/finance-ui/components/invoice-dialog"
-import { Badge, Button } from "@voyantjs/ui/components"
-import { ArrowLeft, Loader2, Pencil, Trash2 } from "lucide-react"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+  Badge,
+  Button,
+  ConfirmActionButton,
+  Textarea,
+} from "@voyantjs/ui/components"
+import { ArrowLeft, Ban, Loader2, Pencil } from "lucide-react"
 import { useState } from "react"
+import { toast } from "sonner"
 import { CreditNoteDialog } from "./credit-note-dialog"
 import {
   InvoiceCreditNotesCard,
@@ -33,13 +48,15 @@ export function InvoiceDetailPage({ id }: { id: string }) {
   const [paymentDialogOpen, setPaymentDialogOpen] = useState(false)
   const [creditNoteDialogOpen, setCreditNoteDialogOpen] = useState(false)
   const [noteContent, setNoteContent] = useState("")
+  const [voidDialogOpen, setVoidDialogOpen] = useState(false)
+  const [voidReason, setVoidReason] = useState("")
 
   const { data: invoiceData, isPending } = useInvoice(id)
   const { data: lineItemsData } = useInvoiceLineItems(id)
-  const { data: paymentsData } = useInvoicePayments(id)
-  const { data: creditNotesData } = useInvoiceCreditNotes(id)
+  const paymentsQuery = useInvoicePayments(id)
+  const creditNotesQuery = useInvoiceCreditNotes(id)
   const { data: notesData } = useInvoiceNotes(id)
-  const { remove: deleteInvoice } = useInvoiceMutation()
+  const { remove: deleteInvoice, voidInvoice } = useInvoiceMutation()
   const { remove: deleteLineItem } = useInvoiceLineItemMutation(id)
   const addNoteMutation = useInvoiceNoteMutation(id)
 
@@ -52,6 +69,8 @@ export function InvoiceDetailPage({ id }: { id: string }) {
   }
 
   const invoice = invoiceData?.data
+  const payments = paymentsQuery.data?.data ?? []
+  const creditNotes = creditNotesQuery.data?.data ?? []
   if (!invoice) {
     return (
       <div className="flex flex-col items-center justify-center gap-4 py-12">
@@ -61,6 +80,34 @@ export function InvoiceDetailPage({ id }: { id: string }) {
         </Button>
       </div>
     )
+  }
+
+  const canDelete = invoice.status === "draft"
+  const canVoid =
+    ["issued", "partially_paid", "overdue", "pending_external_allocation"].includes(
+      invoice.status,
+    ) &&
+    !paymentsQuery.isPending &&
+    !creditNotesQuery.isPending &&
+    payments.length === 0 &&
+    creditNotes.length === 0
+
+  const showMutationError = (error: unknown, fallback: string) => {
+    toast.error(error instanceof Error ? error.message : fallback)
+  }
+
+  const handleVoidInvoice = async () => {
+    try {
+      await voidInvoice.mutateAsync({
+        id,
+        input: { reason: voidReason.trim() || null },
+      })
+      toast.success("Invoice voided.")
+      setVoidDialogOpen(false)
+      setVoidReason("")
+    } catch (error) {
+      showMutationError(error, "Unable to void invoice")
+    }
   }
 
   return (
@@ -82,26 +129,71 @@ export function InvoiceDetailPage({ id }: { id: string }) {
             <Pencil className="mr-2 h-4 w-4" />
             Edit
           </Button>
-          <Button
+          <AlertDialog
+            open={voidDialogOpen}
+            onOpenChange={(open) => {
+              setVoidDialogOpen(open)
+              if (!open) setVoidReason("")
+            }}
+          >
+            <AlertDialogTrigger
+              disabled={!canVoid || voidInvoice.isPending}
+              render={<Button type="button" variant="outline" />}
+            >
+              <Ban className="mr-2 h-4 w-4" />
+              Void
+            </AlertDialogTrigger>
+            <AlertDialogContent size="sm">
+              <AlertDialogHeader>
+                <AlertDialogTitle>Void this invoice?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This marks the invoice as void, clears the outstanding balance, and keeps the
+                  audit trail. Invoices with payments or credit notes need a credit note instead.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <div className="grid gap-2">
+                <Textarea
+                  value={voidReason}
+                  onChange={(event) => setVoidReason(event.target.value)}
+                  placeholder="Reason for voiding..."
+                  className="min-h-24"
+                />
+              </div>
+              <AlertDialogFooter>
+                <AlertDialogCancel disabled={voidInvoice.isPending}>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  variant="destructive"
+                  disabled={voidInvoice.isPending}
+                  onClick={() => void handleVoidInvoice()}
+                >
+                  {voidInvoice.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                  Void invoice
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+          <ConfirmActionButton
+            buttonLabel="Delete"
+            confirmLabel="Delete invoice"
+            title="Delete this invoice?"
+            description={
+              canDelete
+                ? "This permanently deletes the draft invoice."
+                : "Only draft invoices can be deleted. Void issued invoices without payments or create a credit note."
+            }
             variant="destructive"
-            onClick={() => {
-              if (invoice.status !== "draft") {
-                alert("Only draft invoices can be deleted")
-                return
-              }
-              if (confirm("Are you sure you want to delete this invoice?")) {
-                deleteInvoice.mutate(id, {
-                  onSuccess: () => {
-                    void navigate({ to: "/finance" })
-                  },
-                })
+            confirmVariant="destructive"
+            disabled={!canDelete || deleteInvoice.isPending}
+            onConfirm={async () => {
+              try {
+                await deleteInvoice.mutateAsync(id)
+                toast.success("Invoice deleted.")
+                void navigate({ to: "/finance" })
+              } catch (error) {
+                showMutationError(error, "Unable to delete invoice")
               }
             }}
-            disabled={deleteInvoice.isPending}
-          >
-            <Trash2 className="mr-2 h-4 w-4" />
-            Delete
-          </Button>
+          />
         </div>
       </div>
 
@@ -125,20 +217,21 @@ export function InvoiceDetailPage({ id }: { id: string }) {
           setEditingLineItem(lineItem)
           setLineItemDialogOpen(true)
         }}
-        onDelete={(lineId) => {
-          if (confirm("Delete this line item?")) {
-            deleteLineItem.mutate(lineId)
+        deletePending={deleteLineItem.isPending}
+        onDelete={async (lineId) => {
+          try {
+            await deleteLineItem.mutateAsync(lineId)
+            toast.success("Line item deleted.")
+          } catch (error) {
+            showMutationError(error, "Unable to delete line item")
           }
         }}
       />
 
-      <InvoicePaymentsCard
-        payments={paymentsData?.data ?? []}
-        onCreate={() => setPaymentDialogOpen(true)}
-      />
+      <InvoicePaymentsCard payments={payments} onCreate={() => setPaymentDialogOpen(true)} />
 
       <InvoiceCreditNotesCard
-        creditNotes={creditNotesData?.data ?? []}
+        creditNotes={creditNotes}
         onCreate={() => setCreditNoteDialogOpen(true)}
       />
 

--- a/apps/dev/src/components/voyant/finance/invoice-detail-sections.tsx
+++ b/apps/dev/src/components/voyant/finance/invoice-detail-sections.tsx
@@ -1,4 +1,13 @@
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
   Badge,
   Button,
   Card,
@@ -124,11 +133,13 @@ export function InvoiceLineItemsCard({
   onCreate,
   onEdit,
   onDelete,
+  deletePending = false,
 }: {
   lineItems: LineItem[]
   onCreate: () => void
   onEdit: (lineItem: LineItem) => void
-  onDelete: (lineId: string) => void
+  onDelete: (lineId: string) => Promise<void> | void
+  deletePending?: boolean
 }) {
   return (
     <Card>
@@ -171,20 +182,50 @@ export function InvoiceLineItemsCard({
                     </td>
                     <td className="p-2">
                       <div className="flex items-center justify-end gap-1">
-                        <button
+                        <Button
                           type="button"
+                          variant="ghost"
+                          size="icon"
                           onClick={() => onEdit(lineItem)}
-                          className="text-muted-foreground hover:text-foreground"
+                          className="size-8"
+                          aria-label="Edit line item"
                         >
                           <Pencil className="h-3.5 w-3.5" />
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => onDelete(lineItem.id)}
-                          className="text-muted-foreground hover:text-destructive"
-                        >
-                          <Trash2 className="h-3.5 w-3.5" />
-                        </button>
+                        </Button>
+                        <AlertDialog>
+                          <AlertDialogTrigger
+                            disabled={deletePending}
+                            render={
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                className="size-8 text-muted-foreground hover:text-destructive"
+                                aria-label="Delete line item"
+                              />
+                            }
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </AlertDialogTrigger>
+                          <AlertDialogContent size="sm">
+                            <AlertDialogHeader>
+                              <AlertDialogTitle>Delete this line item?</AlertDialogTitle>
+                              <AlertDialogDescription>
+                                This removes the line from the invoice.
+                              </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                              <AlertDialogCancel disabled={deletePending}>Cancel</AlertDialogCancel>
+                              <AlertDialogAction
+                                variant="destructive"
+                                disabled={deletePending}
+                                onClick={() => void onDelete(lineItem.id)}
+                              >
+                                Delete line item
+                              </AlertDialogAction>
+                            </AlertDialogFooter>
+                          </AlertDialogContent>
+                        </AlertDialog>
                       </div>
                     </td>
                   </tr>

--- a/apps/dev/src/components/voyant/finance/line-item-dialog.tsx
+++ b/apps/dev/src/components/voyant/finance/line-item-dialog.tsx
@@ -13,6 +13,7 @@ import {
 import { Loader2 } from "lucide-react"
 import { useEffect } from "react"
 import { useForm } from "react-hook-form"
+import { toast } from "sonner"
 import { z } from "zod/v4"
 import { zodResolver } from "@/lib/zod-resolver"
 
@@ -93,12 +94,17 @@ export function LineItemDialog({
       sortOrder: values.sortOrder,
     }
 
-    const saved = isEditing
-      ? await update.mutateAsync({ id: lineItem!.id, input: payload })
-      : await create.mutateAsync(payload)
+    try {
+      const saved = isEditing
+        ? await update.mutateAsync({ id: lineItem!.id, input: payload })
+        : await create.mutateAsync(payload)
 
-    onOpenChange(false)
-    onSuccess?.(saved)
+      toast.success(isEditing ? "Line item updated." : "Line item added.")
+      onOpenChange(false)
+      onSuccess?.(saved)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Unable to save line item")
+    }
   }
 
   const isSubmitting = create.isPending || update.isPending

--- a/packages/finance-react/src/hooks/use-invoice-mutation.ts
+++ b/packages/finance-react/src/hooks/use-invoice-mutation.ts
@@ -27,6 +27,10 @@ export interface CreateInvoiceInput {
 
 export type UpdateInvoiceInput = Partial<CreateInvoiceInput>
 
+export interface VoidInvoiceInput {
+  reason?: string | null
+}
+
 export function useInvoiceMutation() {
   const { baseUrl, fetcher } = useVoyantFinanceContext()
   const queryClient = useQueryClient()
@@ -80,6 +84,22 @@ export function useInvoiceMutation() {
       queryClient.removeQueries({ queryKey: financeQueryKeys.payments(id) })
       queryClient.removeQueries({ queryKey: financeQueryKeys.creditNotes(id) })
       queryClient.removeQueries({ queryKey: financeQueryKeys.notes(id) })
+    },
+  })
+
+  const voidInvoice = useMutation({
+    mutationFn: async ({ id, input }: { id: string; input?: VoidInvoiceInput }) => {
+      const { data } = await fetchWithValidation(
+        `/v1/finance/invoices/${id}/void`,
+        invoiceSingleResponse,
+        { baseUrl, fetcher },
+        { method: "POST", body: JSON.stringify(input ?? {}) },
+      )
+      return data
+    },
+    onSuccess: (data) => {
+      void queryClient.invalidateQueries({ queryKey: financeQueryKeys.invoices() })
+      queryClient.setQueryData(financeQueryKeys.invoice(data.id), { data })
     },
   })
 
@@ -150,7 +170,7 @@ export function useInvoiceMutation() {
     },
   })
 
-  return { create, createFromBooking, convertToInvoice, render, update, remove }
+  return { create, createFromBooking, convertToInvoice, render, update, remove, voidInvoice }
 }
 
 export interface ConvertProformaInput {

--- a/packages/finance/src/routes.ts
+++ b/packages/finance/src/routes.ts
@@ -95,6 +95,7 @@ import {
   updateTaxPolicyRuleSchema,
   updateTaxRegimeSchema,
   updateVoucherSchema,
+  voidInvoiceSchema,
   voucherListQuerySchema,
 } from "./validation.js"
 
@@ -1232,6 +1233,46 @@ export const financeRoutes = new Hono<Env>()
     }
 
     return c.json({ success: true }, 200)
+  })
+
+  // POST /invoices/:id/void — Void an issued invoice without deleting the audit trail
+  .post("/invoices/:id/void", async (c) => {
+    const runtime = getFinanceRouteRuntime(c)
+    const result = await financeService.voidInvoice(
+      c.get("db"),
+      c.req.param("id"),
+      await parseJsonBody(c, voidInvoiceSchema),
+      {
+        eventBus: runtime?.eventBus,
+        actionLedgerContext: getActionLedgerRequestContext(c),
+        actionLedgerAuthorizationSource: "finance.invoice.route",
+      },
+    )
+
+    if (result.status === "not_found") {
+      return c.json({ error: "Invoice not found" }, 404)
+    }
+
+    if (result.status === "already_void") {
+      return c.json({ data: result.invoice }, 200)
+    }
+
+    if (result.status === "not_voidable_status") {
+      return c.json(
+        { error: `Invoices in status "${result.invoice.status}" cannot be voided` },
+        409,
+      )
+    }
+
+    if (result.status === "has_payments") {
+      return c.json({ error: "Invoices with payments must be reversed with a credit note" }, 409)
+    }
+
+    if (result.status === "has_credit_notes") {
+      return c.json({ error: "Invoices with credit notes cannot be voided directly" }, 409)
+    }
+
+    return c.json({ data: result.invoice })
   })
 
   .post("/invoices/:id/payment-session", async (c) => {

--- a/packages/finance/src/schema.ts
+++ b/packages/finance/src/schema.ts
@@ -757,6 +757,8 @@ export const invoices = pgTable(
     issueDate: date("issue_date").notNull(),
     dueDate: date("due_date").notNull(),
     notes: text("notes"),
+    voidedAt: timestamp("voided_at", { withTimezone: true }),
+    voidReason: text("void_reason"),
 
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/finance/src/service.ts
+++ b/packages/finance/src/service.ts
@@ -189,6 +189,7 @@ import type {
   updateTaxPolicyProfileSchema,
   updateTaxPolicyRuleSchema,
   updateTaxRegimeSchema,
+  voidInvoiceSchema,
 } from "./validation.js"
 
 type RevenueReportQuery = z.infer<typeof revenueReportQuerySchema>
@@ -265,6 +266,7 @@ type InvoiceListQuery = z.infer<typeof invoiceListQuerySchema>
 type CreateInvoiceInput = z.infer<typeof insertInvoiceSchema>
 export type CreateInvoiceFromBookingInput = z.infer<typeof invoiceFromBookingSchema>
 type UpdateInvoiceInput = z.infer<typeof updateInvoiceSchema>
+type VoidInvoiceInput = z.infer<typeof voidInvoiceSchema>
 type CreateInvoiceLineItemInput = z.infer<typeof insertInvoiceLineItemSchema>
 type UpdateInvoiceLineItemInput = z.infer<typeof updateInvoiceLineItemSchema>
 type CreatePaymentInput = z.infer<typeof insertPaymentSchema>
@@ -371,6 +373,23 @@ export class InvoiceLineItemsPersistenceError extends Error {
     this.expectedCount = expectedCount
     this.actualCount = actualCount
   }
+}
+
+export interface InvoiceVoidedEvent {
+  id: string
+  invoiceId: string
+  invoiceNumber: string
+  invoiceType: "invoice" | "proforma" | "credit_note"
+  bookingId: string | null
+  totalCents: number
+  currency: string
+  voidedAt: string
+  reason?: string | null
+  externalProvider?: string | null
+  externalId?: string | null
+  externalNumber?: string | null
+  externalSeriesName?: string | null
+  externalUrl?: string | null
 }
 
 /** Booking data needed for createInvoiceFromBooking — supplied by the caller (template). */
@@ -563,6 +582,50 @@ function toTimestamp(value?: string | null) {
 
 function toDateString(value: Date) {
   return value.toISOString().slice(0, 10)
+}
+
+function coerceMetadataRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function metadataString(metadata: Record<string, unknown> | null, key: string) {
+  const value = metadata?.[key]
+  return typeof value === "string" && value.length > 0 ? value : null
+}
+
+function buildInvoiceVoidedEvent(
+  invoice: typeof invoices.$inferSelect,
+  externalRef: typeof invoiceExternalRefs.$inferSelect | null,
+  reason: string | null,
+  voidedAt: Date,
+): InvoiceVoidedEvent {
+  const metadata = coerceMetadataRecord(externalRef?.metadata)
+  const externalSeriesName =
+    metadataString(metadata, "seriesName") ?? metadataString(metadata, "series")
+  const externalNumber =
+    externalRef?.externalNumber ??
+    metadataString(metadata, "number") ??
+    externalRef?.externalId ??
+    null
+
+  return {
+    id: invoice.id,
+    invoiceId: invoice.id,
+    invoiceNumber: invoice.invoiceNumber,
+    invoiceType: invoice.invoiceType,
+    bookingId: invoice.bookingId,
+    totalCents: invoice.totalCents,
+    currency: invoice.currency,
+    voidedAt: voidedAt.toISOString(),
+    reason,
+    externalProvider: externalRef?.provider ?? null,
+    externalId: externalRef?.externalId ?? null,
+    externalNumber,
+    externalSeriesName,
+    externalUrl: externalRef?.externalUrl ?? null,
+  }
 }
 
 function startOfUtcDay(value: Date) {
@@ -3810,6 +3873,120 @@ export const financeService = {
 
     await db.delete(invoices).where(eq(invoices.id, id))
     return { status: "deleted" as const }
+  },
+
+  async voidInvoice(
+    db: PostgresJsDatabase,
+    id: string,
+    input: VoidInvoiceInput = {},
+    runtime: FinanceServiceRuntime = {},
+  ) {
+    const reason = input.reason?.trim() || null
+    const voidedAt = new Date()
+    let voidedEvent: InvoiceVoidedEvent | null = null
+
+    const result = await db.transaction(async (tx) => {
+      const [existing] = await tx.select().from(invoices).where(eq(invoices.id, id)).limit(1)
+
+      if (!existing) {
+        return { status: "not_found" as const }
+      }
+
+      if (existing.status === "void") {
+        return { status: "already_void" as const, invoice: existing }
+      }
+
+      if (
+        !["issued", "partially_paid", "overdue", "pending_external_allocation"].includes(
+          existing.status,
+        )
+      ) {
+        return { status: "not_voidable_status" as const, invoice: existing }
+      }
+
+      const [payment] = await tx
+        .select({ id: payments.id })
+        .from(payments)
+        .where(eq(payments.invoiceId, id))
+        .limit(1)
+
+      if (payment) {
+        return { status: "has_payments" as const, invoice: existing }
+      }
+
+      const [creditNote] = await tx
+        .select({ id: creditNotes.id })
+        .from(creditNotes)
+        .where(eq(creditNotes.invoiceId, id))
+        .limit(1)
+
+      if (creditNote) {
+        return { status: "has_credit_notes" as const, invoice: existing }
+      }
+
+      const [row] = await tx
+        .update(invoices)
+        .set({
+          status: "void",
+          balanceDueCents: 0,
+          baseBalanceDueCents: existing.baseBalanceDueCents == null ? null : 0,
+          voidedAt,
+          voidReason: reason,
+          updatedAt: voidedAt,
+        })
+        .where(eq(invoices.id, id))
+        .returning()
+
+      if (!row) {
+        return { status: "not_found" as const }
+      }
+
+      if (runtime.actionLedgerContext) {
+        await appendActionLedgerMutation(
+          tx,
+          buildInvoiceUpdateActionLedgerInput(
+            runtime.actionLedgerContext,
+            {
+              invoice: row,
+              changes: {
+                status: "void",
+                balanceDueCents: 0,
+                baseBalanceDueCents: row.baseBalanceDueCents,
+              },
+            },
+            { authorizationSource: runtime.actionLedgerAuthorizationSource },
+          ),
+        )
+      }
+
+      const [smartbillRef] = await tx
+        .select()
+        .from(invoiceExternalRefs)
+        .where(
+          and(eq(invoiceExternalRefs.invoiceId, id), eq(invoiceExternalRefs.provider, "smartbill")),
+        )
+        .orderBy(desc(invoiceExternalRefs.createdAt))
+        .limit(1)
+
+      const [latestRef] = smartbillRef
+        ? [smartbillRef]
+        : await tx
+            .select()
+            .from(invoiceExternalRefs)
+            .where(eq(invoiceExternalRefs.invoiceId, id))
+            .orderBy(desc(invoiceExternalRefs.createdAt))
+            .limit(1)
+
+      voidedEvent = buildInvoiceVoidedEvent(row, latestRef ?? null, reason, voidedAt)
+
+      return { status: "voided" as const, invoice: row }
+    })
+
+    if (result.status === "voided" && voidedEvent) {
+      await runtime.eventBus?.emit("invoice.voided", voidedEvent)
+    }
+
+    return result
   },
 
   listInvoiceLineItems(db: PostgresJsDatabase, invoiceId: string) {

--- a/packages/finance/src/validation-billing.ts
+++ b/packages/finance/src/validation-billing.ts
@@ -73,6 +73,10 @@ const invoiceCoreSchema = z.object({
 export const insertInvoiceSchema = invoiceCoreSchema
 export const updateInvoiceSchema = invoiceCoreSchema.partial()
 
+export const voidInvoiceSchema = z.object({
+  reason: z.string().trim().min(1).max(1000).optional().nullable(),
+})
+
 export const invoiceListSortFieldSchema = z.enum([
   "invoiceNumber",
   "status",

--- a/packages/finance/tests/integration/routes.test.ts
+++ b/packages/finance/tests/integration/routes.test.ts
@@ -8,6 +8,7 @@ import { FINANCE_ROUTE_RUNTIME_CONTAINER_KEY } from "../../src/route-runtime.js"
 import { financeRoutes } from "../../src/routes.js"
 import {
   bookingPaymentSchedules,
+  invoiceExternalRefs,
   invoiceLineItems,
   invoiceNumberSeries,
   invoiceRenditions,
@@ -115,6 +116,7 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
   const settlementEvents: Array<Record<string, unknown>> = []
   const paymentCompletedEvents: Array<Record<string, unknown>> = []
   const schedulePaidEvents: Array<Record<string, unknown>> = []
+  const invoiceVoidedEvents: Array<Record<string, unknown>> = []
   const autoRenditionBookings = new Map<string, { delayMs: number; storageKey: string }>()
 
   beforeAll(async () => {
@@ -253,6 +255,10 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
     await db.execute(
       sql`CREATE INDEX IF NOT EXISTS idx_invoice_attachments_invoice_created ON invoice_attachments (invoice_id, created_at)`,
     )
+    await db.execute(
+      sql`ALTER TABLE invoices ADD COLUMN IF NOT EXISTS voided_at timestamp with time zone`,
+    )
+    await db.execute(sql`ALTER TABLE invoices ADD COLUMN IF NOT EXISTS void_reason text`)
 
     const eventBus = createEventBus()
     eventBus.subscribe("invoice.settled", (event) => {
@@ -263,6 +269,9 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
     })
     eventBus.subscribe("booking_payment_schedule.paid", (event) => {
       schedulePaidEvents.push(event as Record<string, unknown>)
+    })
+    eventBus.subscribe("invoice.voided", (event) => {
+      invoiceVoidedEvents.push(event as Record<string, unknown>)
     })
     eventBus.subscribe("invoice.issued", (event) => {
       const data = event.data as { invoiceId?: string; bookingId?: string | null }
@@ -311,6 +320,7 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
     settlementEvents.length = 0
     paymentCompletedEvents.length = 0
     schedulePaidEvents.length = 0
+    invoiceVoidedEvents.length = 0
     autoRenditionBookings.clear()
   })
 
@@ -1200,6 +1210,64 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       expect(res.status).toBe(400)
       const body = await res.json()
       expect(body.error).toContain("draft")
+    })
+
+    it("voids an issued invoice and emits external reference details", async () => {
+      const booking = await seedBooking()
+      const inv = await seedInvoice(booking.id, { status: "issued" })
+      await db.insert(invoiceExternalRefs).values({
+        invoiceId: inv.id,
+        provider: "smartbill",
+        externalId: "SB-42",
+        externalNumber: "42",
+        externalUrl: "https://smartbill.example/invoices/42",
+        metadata: { seriesName: "SB" },
+      })
+
+      const res = await app.request(`/invoices/${inv.id}/void`, {
+        method: "POST",
+        ...json({ reason: "Wrong line item" }),
+      })
+      expect(res.status).toBe(200)
+      const { data } = await res.json()
+      expect(data.status).toBe("void")
+      expect(data.balanceDueCents).toBe(0)
+      expect(data.voidReason).toBe("Wrong line item")
+      expect(data.voidedAt).toBeTruthy()
+
+      expect(invoiceVoidedEvents).toHaveLength(1)
+      expect(invoiceVoidedEvents[0]?.data).toMatchObject({
+        invoiceId: inv.id,
+        invoiceNumber: inv.invoiceNumber,
+        reason: "Wrong line item",
+        externalProvider: "smartbill",
+        externalNumber: "42",
+        externalSeriesName: "SB",
+      })
+    })
+
+    it("rejects voiding invoices with payments", async () => {
+      const booking = await seedBooking()
+      const inv = await seedInvoice(booking.id, { status: "issued" })
+      await app.request(`/invoices/${inv.id}/payments`, {
+        method: "POST",
+        ...json({
+          amountCents: 5000,
+          currency: "USD",
+          paymentMethod: "bank_transfer",
+          status: "pending",
+          paymentDate: "2025-06-05",
+        }),
+      })
+
+      const res = await app.request(`/invoices/${inv.id}/void`, {
+        method: "POST",
+        ...json({ reason: "Wrong line item" }),
+      })
+      expect(res.status).toBe(409)
+      const body = await res.json()
+      expect(body.error).toContain("payments")
+      expect(invoiceVoidedEvents).toHaveLength(0)
     })
 
     it("returns 404 when deleting non-existent invoice", async () => {


### PR DESCRIPTION
## Summary

- Add invoice void metadata, service validation, and `POST /finance/invoices/:id/void` with `invoice.voided` emission for external cancellation.
- Expose the void mutation through `@voyantjs/finance-react`.
- Replace silent invoice and line-item mutation flows in the admin invoice detail page with reusable `@voyantjs/ui` dialogs, buttons, textarea reason entry, and toast feedback.

Closes #1243

## Verification

- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/finance-react typecheck`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter dev typecheck`
- `pnpm --filter @voyantjs/finance test`
- `pnpm --filter @voyantjs/finance-react test`
- `pnpm --filter @voyantjs/finance lint`
- `pnpm --filter @voyantjs/finance-react lint`
- Targeted Biome checks for admin finance UI files
- Commit hook lint/typecheck: 126 tasks successful
- Push hook repository test lane: 127 tasks successful