### PR TITLE
Fix i18n scanner false positive on arrow-function bodies

### DIFF
--- a/scripts/check-ui-hardcoded-strings.mjs
+++ b/scripts/check-ui-hardcoded-strings.mjs
@@ -73,7 +73,10 @@ const nonUserFacingLiterals = new Set([
 ])
 
 const suspiciousPatterns = [
-  />\s*[^<{]*[A-Za-z][^<{]*</,
+  // Negative lookbehind on `=` skips arrow-function bodies like
+  // `([a, b]) => (map.get(a) ?? 0) < b` where the `>` belongs to `=>`
+  // and the `<` is a comparison, not JSX.
+  /(?<!=)>\s*[^<{]*[A-Za-z][^<{]*</,
   /\b(?:title|placeholder|label|description|emptyMessage|buttonLabel|confirmLabel|aria-label)\s*=\s*(?:"[^"]*[A-Za-z][^"]*"|'[^']*[A-Za-z][^']*'|`[^`]*[A-Za-z][^`]*`)/,
   /(?:\?\s*|:\s*|return\s+)(?:"(?:[^"\n]* [^"\n]*|[A-Z][A-Za-z][^"\n]*)"|'(?:[^'\n]* [^'\n]*|[A-Z][A-Za-z][^'\n]*)')/,
 ]

--- a/scripts/tests/check-ui-hardcoded-strings.test.mjs
+++ b/scripts/tests/check-ui-hardcoded-strings.test.mjs
@@ -49,6 +49,20 @@ describe("check-ui-hardcoded-strings", () => {
     })
   })
 
+  it("does not flag arrow-function bodies with comparisons", async () => {
+    const root = await createFixture({
+      "packages/example-ui/src/helpers.tsx": `export function pickFirst(entries: Array<[string, number]>) {
+  const counts = new Map<string, number>()
+  return entries.find(([candidate, total]) => (counts.get(candidate) ?? 0) < total)?.[0]
+}
+`,
+    })
+
+    const result = await runChecker(root)
+
+    assert.match(result.stdout, /ui hardcoded string scan passed/)
+  })
+
   it("allows JSX text supplied by message expressions", async () => {
     const root = await createFixture({
       "packages/example-ui/src/button.tsx": `export function ExampleButton({ messages }) {


### PR DESCRIPTION
## Summary
- CI on `main` has been red since #1247 because the hardcoded-UI-string scanner flags `([candidate, total]) => (assignedForDefaulting.get(candidate) ?? 0) < total,` in `packages/bookings-ui/src/components/booking-create-dialog.tsx:314`.
- Pattern #1 (`/>\s*[^<{]*[A-Za-z][^<{]*</`) was matching the `>` from `=>` followed by a `<` comparison as if it were JSX text.
- Added a negative lookbehind on `=` so arrow-function bodies are skipped, plus a regression test.

## Test plan
- [x] `node --test scripts/tests/check-ui-hardcoded-strings.test.mjs` (3/3 pass, incl. new arrow-function case)
- [x] `pnpm i18n:check` passes locally