### PR TITLE
Drop private-package entries from invoice-void changeset

### DIFF
--- a/.changeset/invoice-void-admin-finance.md
+++ b/.changeset/invoice-void-admin-finance.md
@@ -3,9 +3,6 @@
 "@voyantjs/finance-react": patch
 "@voyantjs/finance-ui": patch
 "@voyantjs/i18n": patch
-"operator": patch
-"dev": patch
-"dmc": patch
 ---
 
 Add admin invoice voiding and route finance admin clients through `/v1/admin/finance`.


### PR DESCRIPTION
## Summary
- `.changeset/invoice-void-admin-finance.md` listed `operator`, `dev`, and `dmc` (all `private: true`) alongside four public `@voyantjs/*` packages.
- `@changesets/assemble-release-plan` skips private packages by default, so the mix tripped its `Found mixed changeset` guard.
- That guard runs inside `scripts/detect-pending-publication.cjs`, which blocked every `Release` workflow run on `main` since the changeset landed (e.g. run #26401185587 for #1256).
- Private templates/apps don't publish to npm, so removing them from the changeset has no effect on what ships.

## Test plan
- [x] `node scripts/detect-pending-publication.cjs` no longer throws (returns `hasReleasableChangesets: true` cleanly).
- [ ] Once merged, next push-to-main `Release` run should reach `Create Release PR or Publish` instead of failing at `Detect pending npm publication`.