### PR TITLE
Fix day-tour pricing-as-adult for age-banded unit codes (#1262)

### DIFF
--- a/.changeset/booking-day-tour-age-banded-units.md
+++ b/.changeset/booking-day-tour-age-banded-units.md
@@ -1,0 +1,10 @@
+---
+"@voyantjs/bookings-ui": patch
+---
+
+Fix booking-create-dialog day-tour pricing-as-adult bug for products with age-banded unit codes (e.g. `child_0_5` / `child_6_12`) and for travelers added before the option-units queries resolve.
+
+- `pickUnitForAge` now maps role hints (`infant` / `child` / `adult`) to a representative age and resolves against unit `[minAge, maxAge]` bands, instead of literal `INFANT` / `CHILD` code/name matching. Falls back to code/name matching only for legacy products with no min/max set.
+- `TravelersSection` back-fills missing `roomUnitId`s once `roomUnits` arrives, honoring both DOB and the traveler's role hint via a new `matchUnitByRoleHint` helper. Fixes the race where billing-person auto-add (and the fallback Child/Infant buttons) ran before the stepper's option-units queries resolved, leaving `roomUnitId: null` permanently and collapsing the booking onto a single Adult-priced line.
+
+Both fixes affect the live price preview in `BookingPreviewCard` as well as the submitted booking, since `redistributeByAge` drives both paths.

--- a/packages/bookings-ui/src/components/booking-create-dialog.tsx
+++ b/packages/bookings-ui/src/components/booking-create-dialog.tsx
@@ -216,33 +216,57 @@ function stripOptionPrefix(name: string): string {
  *   1. If we have an age (from DOB) and it falls into a unit's
  *      `[minAge, maxAge]` window, use that unit.
  *   2. Otherwise honor an explicit role hint (Child / Infant / Adult
- *      buttons) by matching unit code or name.
- *   3. Fall back to the ADULT-coded unit, or the first unit when
- *      nothing else matches.
+ *      buttons) by mapping the hint to a representative age and
+ *      matching the age band. This works for products whose units
+ *      encode the band in the code (`child_0_5`, `child_6_12`) instead
+ *      of bare `CHILD`/`INFANT`.
+ *   3. Fall back to code/name matching for legacy products that don't
+ *      configure min/max ages.
  *
  * `roleHint` covers the common case where the operator knows the
  * traveler is a child but doesn't have the exact DOB. Without it, a
  * roleless traveler would silently default to Adult pricing.
  */
-function pickUnitForAge(
+export function pickUnitForAge(
   units: OptionUnitsStepperUnit[],
   age: number | null,
   roleHint: "adult" | "child" | "infant" | null = null,
 ): OptionUnitsStepperUnit | undefined {
   if (units.length === 0) return undefined
-  const findByCode = (code: string) =>
-    units.find((u) => (u.unitCode ?? "").toUpperCase() === code) ??
-    units.find((u) => new RegExp(`\\b${code}\\b`, "i").test(u.unitName))
-  const adult = findByCode("ADULT")
+  const personUnits = units.filter((u) => u.unitType == null || u.unitType === "person")
+  const pool = personUnits.length > 0 ? personUnits : units
+  const sorted = [...pool].sort((a, b) => (a.minAge ?? 0) - (b.minAge ?? 0))
+
+  const matchByAge = (target: number) =>
+    sorted.find(
+      (u) => (u.minAge == null || target >= u.minAge) && (u.maxAge == null || target <= u.maxAge),
+    )
+
   if (age != null) {
-    const match = units.find(
-      (u) => (u.minAge == null || age >= u.minAge) && (u.maxAge == null || age <= u.maxAge),
+    const match = matchByAge(age)
+    if (match) return match
+  }
+
+  if (roleHint) {
+    const HINT_AGE = { adult: 30, child: 8, infant: 1 } as const
+    const hintAge = HINT_AGE[roleHint]
+    // Only consider units with at least one explicit age bound. Without
+    // this, legacy units with null min/max (just bare ADULT/CHILD codes)
+    // would all match every hint age and collapse onto the first sorted
+    // entry (almost always Adult). Code-matching below handles those.
+    const banded = sorted.filter((u) => u.minAge != null || u.maxAge != null)
+    const match = banded.find(
+      (u) => (u.minAge == null || hintAge >= u.minAge) && (u.maxAge == null || hintAge <= u.maxAge),
     )
     if (match) return match
   }
-  if (roleHint === "child") return findByCode("CHILD") ?? adult ?? units[0]
-  if (roleHint === "infant") return findByCode("INFANT") ?? adult ?? units[0]
-  return adult ?? units[0]
+
+  const findByCode = (code: string) =>
+    sorted.find((u) => (u.unitCode ?? "").toUpperCase() === code) ??
+    sorted.find((u) => new RegExp(`\\b${code}\\b`, "i").test(u.unitName))
+  if (roleHint === "child") return findByCode("CHILD") ?? sorted[0]
+  if (roleHint === "infant") return findByCode("INFANT") ?? sorted[0]
+  return findByCode("ADULT") ?? sorted[sorted.length - 1] ?? sorted[0]
 }
 
 /**

--- a/packages/bookings-ui/src/components/travelers-section.tsx
+++ b/packages/bookings-ui/src/components/travelers-section.tsx
@@ -129,6 +129,39 @@ function matchUnitByDob(units: ReadonlyArray<RoomGroupUnit>, dob: string | null)
 }
 
 /**
+ * Find the unit matching a role hint when DOB is missing. Maps the
+ * role to a representative age and matches against `[minAge, maxAge]`.
+ * Returns null when the role doesn't carry an age signal (e.g. `lead`).
+ *
+ * Routes `infant` to whichever band covers ~1y (e.g. `child_0_5`) and
+ * `child` to whichever covers ~8y (e.g. `child_6_12`), regardless of
+ * how the product codes the unit names.
+ */
+function matchUnitByRoleHint(
+  units: ReadonlyArray<RoomGroupUnit>,
+  role: TravelerRole | null,
+): string | null {
+  if (!role || role === "lead") return null
+  const HINT_AGE: Record<"adult" | "child" | "infant", number> = {
+    adult: 30,
+    child: 8,
+    infant: 1,
+  }
+  const hintAge = HINT_AGE[role]
+  if (hintAge == null) return null
+  // Only consider units with explicit age bands — units with null
+  // min/max would all spuriously match any hint age.
+  const banded = units.filter(
+    (u) =>
+      (u.unitType == null || u.unitType === "person") && (u.minAge != null || u.maxAge != null),
+  )
+  const match = banded.find(
+    (u) => (u.minAge == null || hintAge >= u.minAge) && (u.maxAge == null || hintAge <= u.maxAge),
+  )
+  return match?.unitId ?? null
+}
+
+/**
  * The Room dropdown lists one item per option (keyed by the option's
  * primary/ADULT unit id), but a traveler's `roomUnitId` can point at any
  * age-banded unit within that option. Map the traveler's specific unit
@@ -303,20 +336,47 @@ export function TravelersSection({
   // hunt for the dropdown on every traveler — they can still override
   // manually via the Room select. Picks the first option (ordering
   // mirrors the upstream `roomUnits` array, which comes from the
-  // stepper in catalog order). When `roomGroups` is wired and the
-  // traveler has DOB, also pre-pick the matching age-banded unit
-  // within that option so the Category buttons land on the right row.
-  const pickRoomUnitIdForNewTraveler = (dateOfBirth: string | null = null): string | null => {
-    if (!roomUnits || roomUnits.length === 0) return null
-    const pickedRoom =
-      roomUnits.find((unit) => unit.remainingCapacity > 0)?.unitId ?? roomUnits[0]?.unitId ?? null
-    if (!pickedRoom || !roomGroups || roomGroups.length === 0) return pickedRoom
-    const group = roomGroups.find(
-      (g) => g.primaryUnitId === pickedRoom || g.units.some((u) => u.unitId === pickedRoom),
+  // stepper in catalog order). When `roomGroups` is wired, also
+  // pre-pick the matching age-banded unit within that option (DOB
+  // first, role hint second) so the Category buttons land on the
+  // right row and pricing reflects the operator's intent.
+  const pickRoomUnitIdForNewTraveler = React.useCallback(
+    (dateOfBirth: string | null = null, role: TravelerRole | null = null): string | null => {
+      if (!roomUnits || roomUnits.length === 0) return null
+      const pickedRoom =
+        roomUnits.find((unit) => unit.remainingCapacity > 0)?.unitId ?? roomUnits[0]?.unitId ?? null
+      if (!pickedRoom || !roomGroups || roomGroups.length === 0) return pickedRoom
+      const group = roomGroups.find(
+        (g) => g.primaryUnitId === pickedRoom || g.units.some((u) => u.unitId === pickedRoom),
+      )
+      if (!group) return pickedRoom
+      return (
+        matchUnitByDob(group.units, dateOfBirth) ??
+        matchUnitByRoleHint(group.units, role) ??
+        group.primaryUnitId
+      )
+    },
+    [roomUnits, roomGroups],
+  )
+
+  // Race fix: travelers added before the option-units queries resolve
+  // end up with `roomUnitId: null`. Once units arrive, back-fill any
+  // missing assignments so the static fallback's role hint (Child /
+  // Infant) is honored and `redistributeByAge` doesn't silently price
+  // them as adults.
+  React.useEffect(() => {
+    if (!roomUnits || roomUnits.length === 0) return
+    if (!value.travelers.some((t) => !t.roomUnitId)) return
+    const next = value.travelers.map((t) =>
+      t.roomUnitId ? t : { ...t, roomUnitId: pickRoomUnitIdForNewTraveler(t.dateOfBirth, t.role) },
     )
-    if (!group) return pickedRoom
-    return matchUnitByDob(group.units, dateOfBirth) ?? group.primaryUnitId
-  }
+    // Guard against infinite re-runs if hydration can't find a unit
+    // (e.g. empty roomGroups): no point dispatching an onChange that
+    // doesn't actually change anything.
+    const changed = next.some((t, i) => t.roomUnitId !== value.travelers[i]?.roomUnitId)
+    if (!changed) return
+    onChange({ travelers: next })
+  }, [roomUnits, value.travelers, onChange, pickRoomUnitIdForNewTraveler])
 
   const addRow = () => {
     // First traveler defaults to `lead` so the operator doesn't have to
@@ -324,7 +384,10 @@ export function TravelersSection({
     const role: TravelerRole = value.travelers.length === 0 ? "lead" : "adult"
     const blank = createBlankTraveler(role)
     onChange({
-      travelers: [...value.travelers, { ...blank, roomUnitId: pickRoomUnitIdForNewTraveler(null) }],
+      travelers: [
+        ...value.travelers,
+        { ...blank, roomUnitId: pickRoomUnitIdForNewTraveler(null, role) },
+      ],
     })
   }
 
@@ -335,7 +398,7 @@ export function TravelersSection({
     onChange({
       travelers: [
         ...value.travelers,
-        { ...traveler, roomUnitId: pickRoomUnitIdForNewTraveler(traveler.dateOfBirth) },
+        { ...traveler, roomUnitId: pickRoomUnitIdForNewTraveler(traveler.dateOfBirth, role) },
       ],
     })
   }
@@ -346,7 +409,7 @@ export function TravelersSection({
     onChange({
       travelers: [
         ...value.travelers,
-        { ...traveler, roomUnitId: pickRoomUnitIdForNewTraveler(traveler.dateOfBirth) },
+        { ...traveler, roomUnitId: pickRoomUnitIdForNewTraveler(traveler.dateOfBirth, role) },
       ],
     })
   }

--- a/packages/bookings-ui/tests/unit/pick-unit-for-age.test.ts
+++ b/packages/bookings-ui/tests/unit/pick-unit-for-age.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest"
+
+import { pickUnitForAge } from "../../src/components/booking-create-dialog.js"
+import type { OptionUnitsStepperUnit } from "../../src/components/option-units-stepper-section.js"
+
+function unit(
+  partial: Partial<OptionUnitsStepperUnit> & Pick<OptionUnitsStepperUnit, "optionUnitId">,
+): OptionUnitsStepperUnit {
+  return {
+    optionId: partial.optionId ?? "opto_day_tour",
+    optionUnitId: partial.optionUnitId,
+    unitName: partial.unitName ?? partial.optionUnitId,
+    unitCode: partial.unitCode ?? null,
+    minAge: partial.minAge ?? null,
+    maxAge: partial.maxAge ?? null,
+    unitType: partial.unitType ?? "person",
+    occupancyMax: partial.occupancyMax ?? null,
+    initial: partial.initial ?? null,
+    reserved: partial.reserved ?? 0,
+    remaining: partial.remaining ?? null,
+  }
+}
+
+describe("pickUnitForAge — age-banded unit codes (issue #1262)", () => {
+  // Day-tour product whose age bands are encoded in the unit codes
+  // instead of bare ADULT/CHILD/INFANT. Reproduces the layout that
+  // broke after #1241.
+  const ageBandedUnits: OptionUnitsStepperUnit[] = [
+    unit({ optionUnitId: "u_adult", unitCode: "adult", unitName: "Adult", minAge: 13 }),
+    unit({
+      optionUnitId: "u_child_6_12",
+      unitCode: "child_6_12",
+      unitName: "Child 6-12",
+      minAge: 6,
+      maxAge: 12,
+    }),
+    unit({
+      optionUnitId: "u_child_0_5",
+      unitCode: "child_0_5",
+      unitName: "Child 0-5",
+      minAge: 0,
+      maxAge: 5,
+    }),
+  ]
+
+  it("routes a roleHint=infant traveler with no DOB to the 0-5 band", () => {
+    expect(pickUnitForAge(ageBandedUnits, null, "infant")?.optionUnitId).toBe("u_child_0_5")
+  })
+
+  it("routes a roleHint=child traveler with no DOB to the 6-12 band", () => {
+    expect(pickUnitForAge(ageBandedUnits, null, "child")?.optionUnitId).toBe("u_child_6_12")
+  })
+
+  it("routes a roleHint=adult traveler with no DOB to the adult band", () => {
+    expect(pickUnitForAge(ageBandedUnits, null, "adult")?.optionUnitId).toBe("u_adult")
+  })
+
+  it("honors an exact DOB-derived age over the role hint", () => {
+    // age 4 falls into 0-5; role hint is irrelevant when the band matches.
+    expect(pickUnitForAge(ageBandedUnits, 4, "adult")?.optionUnitId).toBe("u_child_0_5")
+  })
+
+  it("falls back to ADULT-coded unit when no role hint and no DOB", () => {
+    expect(pickUnitForAge(ageBandedUnits, null, null)?.optionUnitId).toBe("u_adult")
+  })
+
+  it("returns undefined for empty unit list", () => {
+    expect(pickUnitForAge([], null, "child")).toBeUndefined()
+  })
+})
+
+describe("pickUnitForAge — legacy bare-code units", () => {
+  // Products where units are coded ADULT / CHILD / INFANT without min/max.
+  const bareUnits: OptionUnitsStepperUnit[] = [
+    unit({ optionUnitId: "u_adult", unitCode: "ADULT", unitName: "Adult" }),
+    unit({ optionUnitId: "u_child", unitCode: "CHILD", unitName: "Child" }),
+    unit({ optionUnitId: "u_infant", unitCode: "INFANT", unitName: "Infant" }),
+  ]
+
+  it("matches CHILD by code when no min/max configured", () => {
+    expect(pickUnitForAge(bareUnits, null, "child")?.optionUnitId).toBe("u_child")
+  })
+
+  it("matches INFANT by code when no min/max configured", () => {
+    expect(pickUnitForAge(bareUnits, null, "infant")?.optionUnitId).toBe("u_infant")
+  })
+
+  it("defaults to ADULT when no hint", () => {
+    expect(pickUnitForAge(bareUnits, null, null)?.optionUnitId).toBe("u_adult")
+  })
+})
+
+describe("pickUnitForAge — unit-type filtering", () => {
+  it("skips non-person units when person units are present", () => {
+    const mixed: OptionUnitsStepperUnit[] = [
+      unit({
+        optionUnitId: "u_room",
+        unitCode: "ROOM",
+        unitName: "Room",
+        unitType: "room",
+        minAge: 0,
+      }),
+      unit({
+        optionUnitId: "u_adult",
+        unitCode: "adult",
+        unitName: "Adult",
+        unitType: "person",
+        minAge: 13,
+      }),
+      unit({
+        optionUnitId: "u_child",
+        unitCode: "child",
+        unitName: "Child",
+        unitType: "person",
+        minAge: 0,
+        maxAge: 12,
+      }),
+    ]
+    expect(pickUnitForAge(mixed, null, "child")?.optionUnitId).toBe("u_child")
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #1262 — two compounding bugs left over from #1241 that made day-tour bookings price every traveler as Adult on products with age-banded unit codes (`child_0_5` / `child_6_12`).

- **`pickUnitForAge`** (booking-create-dialog.tsx): role-hint matching was code/name-literal. `roleHint=infant` against units named `Child 0-5` / `Child 6-12` regexed for `\bINFANT\b`, found nothing, and silently fell through to Adult. Now maps role hints onto representative ages (infant→1, child→8, adult→30) and resolves against unit `[minAge, maxAge]` bands. Falls back to code matching only for legacy products with no min/max set.
- **`TravelersSection`** (travelers-section.tsx): travelers added before the option-units queries resolved kept `roomUnitId: null` forever (race between `addBillingPerson` and `OptionUnitsStepperSection`'s `useProductOptions` / `useOptionUnits`). Added a hydration `useEffect` that back-fills missing assignments once `roomUnits` arrives, honoring both DOB and the traveler's role hint via a new `matchUnitByRoleHint` helper.

Both fixes affect the live price preview in `BookingPreviewCard` and the submitted booking, since `redistributeByAge` drives both paths — so operators stop seeing the misleading `3x Adult RON 480.00` total on the right rail.

## Test plan

- [x] `pnpm -F @voyantjs/bookings-ui test` — 52/52 pass (10 new regression tests for age-banded layout and legacy bare-code units)
- [x] `pnpm -F @voyantjs/bookings-ui... typecheck` — clean
- [ ] Manual: repro the issue (day-tour with `adult` / `child_6_12` / `child_0_5` units, Default qty=3, billing person + Child + Infant) and confirm the SUMMARY price line shows the correct per-band breakdown
- [ ] Manual: confirm submitted `booking_items` carry per-traveler `option_unit_id` instead of collapsing onto a single Adult-priced line

Closes #1262.