### PR TITLE
Preserve explicit 'No room' choice in bookings hydration effect

### DIFF
--- a/.changeset/preserve-explicit-no-room-choice.md
+++ b/.changeset/preserve-explicit-no-room-choice.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/bookings-ui": patch
+---
+
+Preserve the operator's explicit "No room" choice in `TravelersSection`. The hydration effect added in the previous patch couldn't distinguish "race-null" (units hadn't loaded yet) from "operator picked No room from the Room select" — both produced `roomUnitId: null`, and the next render silently re-assigned a unit, overriding the operator's choice. Now runs exactly one hydration pass per units-load transition and treats subsequent nulls as intentional.

--- a/packages/bookings-ui/src/components/travelers-section.tsx
+++ b/packages/bookings-ui/src/components/travelers-section.tsx
@@ -363,15 +363,24 @@ export function TravelersSection({
   // end up with `roomUnitId: null`. Once units arrive, back-fill any
   // missing assignments so the static fallback's role hint (Child /
   // Infant) is honored and `redistributeByAge` doesn't silently price
-  // them as adults.
+  // them as adults. Runs exactly once per units-load transition — after
+  // that, `roomUnitId: null` is treated as the operator's explicit
+  // "No room" choice from the Room select and left alone. Reset on
+  // empty `roomUnits` so the next load (e.g. product change) rehydrates.
+  const hasHydratedNullsRef = React.useRef(false)
   React.useEffect(() => {
-    if (!roomUnits || roomUnits.length === 0) return
+    if (!roomUnits || roomUnits.length === 0) {
+      hasHydratedNullsRef.current = false
+      return
+    }
+    if (hasHydratedNullsRef.current) return
+    hasHydratedNullsRef.current = true
     if (!value.travelers.some((t) => !t.roomUnitId)) return
     const next = value.travelers.map((t) =>
       t.roomUnitId ? t : { ...t, roomUnitId: pickRoomUnitIdForNewTraveler(t.dateOfBirth, t.role) },
     )
-    // Guard against infinite re-runs if hydration can't find a unit
-    // (e.g. empty roomGroups): no point dispatching an onChange that
+    // Guard against a stray onChange if hydration can't find a unit
+    // (e.g. empty roomGroups): no point dispatching an update that
     // doesn't actually change anything.
     const changed = next.some((t, i) => t.roomUnitId !== value.travelers[i]?.roomUnitId)
     if (!changed) return


### PR DESCRIPTION
## Summary

Follow-up to #1263 — addresses [codex review feedback](https://github.com/voyantjs/voyant/pull/1263#discussion_r4534779178-ish) on `TravelersSection`'s hydration effect.

The hydration effect added in #1263 couldn't distinguish "race-null" (units hadn't loaded yet) from "operator explicitly picked No room from the Room select" — both produced `roomUnitId: null`. The next render would silently re-assign a unit, overriding the operator's choice.

Fix: gate the effect with a `useRef` so we run exactly one hydration pass per units-load transition. After that, treat `roomUnitId: null` as the operator's intentional unassign and leave it alone. Reset the ref when `roomUnits` empties so a product change still rehydrates.

## Test plan

- [x] `pnpm -F @voyantjs/bookings-ui typecheck` — clean
- [x] `pnpm -F @voyantjs/bookings-ui test` — 52/52 pass
- [ ] Manual: open dialog before product selected → add billing person → pick product → verify traveler hydrates to Adult (or matching band)
- [ ] Manual: from that hydrated state, open the Room dropdown and pick "No room" → confirm it stays unassigned across re-renders
- [ ] Manual: switch products → confirm hydration runs again for the new product's units