### PR TITLE
[codex] Fix booking create traveler unit model

### DIFF
--- a/.changeset/clean-booking-draft-resolver.md
+++ b/.changeset/clean-booking-draft-resolver.md
@@ -1,5 +1,8 @@
 ---
 "@voyantjs/bookings-ui": patch
+"@voyantjs/bookings-react": patch
+"@voyantjs/bookings": patch
+"@voyantjs/finance": patch
 ---
 
-Resolve booking-create traveler unit assignments through a shared draft resolver so person-priced excursions derive adult/child/infant quantities from travelers while accommodation products preserve room quantities.
+Resolve booking-create traveler unit assignments through a shared draft resolver so person-priced excursions derive adult/child/infant quantities from travelers while accommodation products preserve room quantities. Booking-create item and extra lines can now carry traveler applicability through to `booking_item_travelers`.

--- a/.changeset/clean-booking-draft-resolver.md
+++ b/.changeset/clean-booking-draft-resolver.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/bookings-ui": patch
+---
+
+Resolve booking-create traveler unit assignments through a shared draft resolver so person-priced excursions derive adult/child/infant quantities from travelers while accommodation products preserve room quantities.

--- a/docs/architecture/booking-journey-architecture.md
+++ b/docs/architecture/booking-journey-architecture.md
@@ -300,6 +300,17 @@ interface BookingDraft {
 
 `TravelerEntry` widens beyond what `PassengersSection` carries today — it gets `dateOfBirth`, `band` ("adult" / "child" / "infant"), and an open-shape `documents` map (passport, national ID, dietary, accessibility) populated according to `BookingDraftShape.travelerFields[]`.
 
+Admin booking-create keeps the same invariant even while it still renders as a
+single dialog:
+
+- traveler age/pricing band, sellable option unit, room/accommodation
+  assignment, and explicit "no room" intent are separate draft concepts;
+- preview totals and submit payloads must be derived from the same draft
+  resolver;
+- item and extra line applicability is persisted through
+  `booking_item_travelers`, not inferred later from display labels or raw
+  traveler counts.
+
 ## 4.5. Pricing tiers — single supplement, triple share
 
 Cruises (and to a lesser extent stays / multi-pax tours) price per-pax with explicit per-occupancy tiers. Real-world cruise systems treat this as a fundamental shape, not an afterthought:

--- a/packages/bookings-react/src/hooks/use-booking-create-mutation.ts
+++ b/packages/bookings-react/src/hooks/use-booking-create-mutation.ts
@@ -44,6 +44,7 @@ export interface BookingCreateDocumentGenerationInput {
 }
 
 export interface BookingCreateItemLineInput {
+  clientLineKey?: string | null
   optionId?: string | null
   optionUnitId: string
   quantity: number
@@ -51,9 +52,11 @@ export interface BookingCreateItemLineInput {
   description?: string | null
   unitSellAmountCents?: number | null
   totalSellAmountCents?: number | null
+  travelerIndexes?: number[] | null
 }
 
 export interface BookingCreateExtraLineInput {
+  clientLineKey?: string | null
   productExtraId: string
   optionExtraConfigId?: string | null
   name: string
@@ -64,6 +67,7 @@ export interface BookingCreateExtraLineInput {
   sellCurrency: string
   unitSellAmountCents?: number | null
   totalSellAmountCents?: number | null
+  travelerIndexes?: number[] | null
 }
 
 export interface BookingCreateVoucherRedemptionInput {

--- a/packages/bookings-ui/src/components/booking-create-dialog.tsx
+++ b/packages/bookings-ui/src/components/booking-create-dialog.tsx
@@ -40,7 +40,11 @@ import {
   useBookingsUiI18nOrDefault,
   useBookingsUiMessagesOrDefault,
 } from "../i18n/provider.js"
-import { resolveBookingDraft, travelersToRows } from "./booking-draft-resolver.js"
+import {
+  resolveBookingDraft,
+  resolveBookingExtraLines,
+  travelersToRows,
+} from "./booking-draft-resolver.js"
 
 export { pickUnitForAge } from "./booking-draft-resolver.js"
 
@@ -581,14 +585,23 @@ export function BookingCreateForm({
 
   // Apply the same draft resolver we use at submit so live pricing and
   // persisted item lines cannot drift.
-  const displayQuantities = React.useMemo(
+  const displayDraft = React.useMemo(
     () =>
       resolveBookingDraft({
         quantities: rooms.quantities,
         travelers: travelers.travelers,
         units: getTravelerAssignableStepperUnits(roomUnits),
-      }).quantities,
+      }),
     [rooms.quantities, travelers.travelers, roomUnits],
+  )
+  const displayQuantities = displayDraft.quantities
+  const displayExtraLines = React.useMemo(
+    () =>
+      resolveBookingExtraLines({
+        extraLines,
+        travelerCount: travelers.travelers.length,
+      }),
+    [extraLines, travelers.travelers.length],
   )
 
   // Currency placeholder — used for voucher + payment schedule display.
@@ -742,7 +755,16 @@ export function BookingCreateForm({
         units: submitUnits,
       })
 
-      const itemLines = itemLinesToRows(redistributed.quantities, submitUnits, pricing)
+      const itemLines = itemLinesToRows(
+        redistributed.quantities,
+        submitUnits,
+        pricing,
+        redistributed.travelerIndexesByUnitId,
+      )
+      const resolvedExtraLines = resolveBookingExtraLines({
+        extraLines,
+        travelerCount: travelers.travelers.length,
+      })
 
       const travelerRows = travelersToRows({ travelers: redistributed.travelers })
 
@@ -842,7 +864,7 @@ export function BookingCreateForm({
         confirmedSellAmountCents,
         priceOverrideReason: priceOverrideReason || null,
         itemLines: itemLines.length > 0 ? itemLines : undefined,
-        extraLines: extraLines.length > 0 ? extraLines : undefined,
+        extraLines: resolvedExtraLines.length > 0 ? resolvedExtraLines : undefined,
         travelers: travelerRows.length > 0 ? travelerRows : undefined,
         paymentSchedules: paymentSchedules.length > 0 ? paymentSchedules : undefined,
         voucherRedemption,
@@ -1161,7 +1183,7 @@ export function BookingCreateForm({
           })()}
           unitQuantities={displayQuantities}
           unitLabels={roomUnitLabels}
-          extraLines={extraLines}
+          extraLines={displayExtraLines}
           travelers={travelers.travelers}
           messages={messages}
           onPricingChange={setPricing}

--- a/packages/bookings-ui/src/components/booking-create-dialog.tsx
+++ b/packages/bookings-ui/src/components/booking-create-dialog.tsx
@@ -11,7 +11,6 @@ import {
   type BookingCreateExtraLineInput,
   type BookingCreateGroupMembershipInput,
   type BookingCreatePaymentScheduleInput,
-  type BookingCreateTravelerInput,
   type BookingCreateVoucherRedemptionInput,
   type BookingRecord,
   useBookingCreateMutation,
@@ -41,6 +40,10 @@ import {
   useBookingsUiI18nOrDefault,
   useBookingsUiMessagesOrDefault,
 } from "../i18n/provider.js"
+import { resolveBookingDraft, travelersToRows } from "./booking-draft-resolver.js"
+
+export { pickUnitForAge } from "./booking-draft-resolver.js"
+
 import {
   getBookableDepartureSlots,
   getSelectedSharedRoomUnitId,
@@ -73,7 +76,6 @@ import {
   type SharedRoomValue,
 } from "./shared-room-section.js"
 import {
-  computeAgeYears,
   emptyTravelerListValue,
   type RoomGroup,
   type RoomUnitOption,
@@ -209,203 +211,6 @@ function hasAnyPaidPayment(schedule: PaymentScheduleValue): boolean {
 function stripOptionPrefix(name: string): string {
   const idx = name.indexOf(" - ")
   return idx > 0 ? name.slice(idx + 3) : name
-}
-
-/**
- * Pick the unit for a traveler. Priorities:
- *   1. If we have an age (from DOB) and it falls into a unit's
- *      `[minAge, maxAge]` window, use that unit.
- *   2. Otherwise honor an explicit role hint (Child / Infant / Adult
- *      buttons) by mapping the hint to a representative age and
- *      matching the age band. This works for products whose units
- *      encode the band in the code (`child_0_5`, `child_6_12`) instead
- *      of bare `CHILD`/`INFANT`.
- *   3. Fall back to code/name matching for legacy products that don't
- *      configure min/max ages.
- *
- * `roleHint` covers the common case where the operator knows the
- * traveler is a child but doesn't have the exact DOB. Without it, a
- * roleless traveler would silently default to Adult pricing.
- */
-export function pickUnitForAge(
-  units: OptionUnitsStepperUnit[],
-  age: number | null,
-  roleHint: "adult" | "child" | "infant" | null = null,
-): OptionUnitsStepperUnit | undefined {
-  if (units.length === 0) return undefined
-  const personUnits = units.filter((u) => u.unitType == null || u.unitType === "person")
-  const pool = personUnits.length > 0 ? personUnits : units
-  const sorted = [...pool].sort((a, b) => (a.minAge ?? 0) - (b.minAge ?? 0))
-
-  const matchByAge = (target: number) =>
-    sorted.find(
-      (u) => (u.minAge == null || target >= u.minAge) && (u.maxAge == null || target <= u.maxAge),
-    )
-
-  if (age != null) {
-    const match = matchByAge(age)
-    if (match) return match
-  }
-
-  if (roleHint) {
-    const HINT_AGE = { adult: 30, child: 8, infant: 1 } as const
-    const hintAge = HINT_AGE[roleHint]
-    // Only consider units with at least one explicit age bound. Without
-    // this, legacy units with null min/max (just bare ADULT/CHILD codes)
-    // would all match every hint age and collapse onto the first sorted
-    // entry (almost always Adult). Code-matching below handles those.
-    const banded = sorted.filter((u) => u.minAge != null || u.maxAge != null)
-    const match = banded.find(
-      (u) => (u.minAge == null || hintAge >= u.minAge) && (u.maxAge == null || hintAge <= u.maxAge),
-    )
-    if (match) return match
-  }
-
-  const findByCode = (code: string) =>
-    sorted.find((u) => (u.unitCode ?? "").toUpperCase() === code) ??
-    sorted.find((u) => new RegExp(`\\b${code}\\b`, "i").test(u.unitName))
-  if (roleHint === "child") return findByCode("CHILD") ?? sorted[0]
-  if (roleHint === "infant") return findByCode("INFANT") ?? sorted[0]
-  return findByCode("ADULT") ?? sorted[sorted.length - 1] ?? sorted[0]
-}
-
-/**
- * Take the operator-picked per-option quantities (which are tracked
- * against each option's primary "Adult" unit by the stepper) plus the
- * travelers list, and redistribute both so that:
- *   - each traveler's `roomUnitId` points at the age-banded unit
- *     matching their DOB (Adult / Child / Infant / etc.)
- *   - `quantities` reflects the per-unit counts after redistribution —
- *     a 3-pax "Standard double" with 2 adults + 1 child becomes
- *     `{ adultUnit: 2, childUnit: 1 }` instead of `{ adultUnit: 3 }`.
- *
- * Slots without a configured `dateOfBirth` keep the option's adult
- * default so partially-filled bookings still typecheck.
- */
-/**
- * Rebuild stepper quantities from per-traveler unit assignments.
- *
- * Each traveler's `roomUnitId` is now the operator's explicit choice
- * (DOB-pre-picked at attach, overridable via the dynamic category
- * buttons), so we count assignments directly and add any per-option
- * residual on the adult/primary unit when the stepper qty exceeds the
- * number of travelers actually assigned. Unlike the older
- * DOB-driven rewrite, this never moves a traveler off their chosen
- * unit — operator selection always wins.
- */
-function redistributeByAge(
-  quantities: Record<string, number>,
-  travelers: TravelerEntry[],
-  units: OptionUnitsStepperUnit[],
-): { quantities: Record<string, number>; travelers: TravelerEntry[] } {
-  if (units.length === 0) return { quantities, travelers }
-
-  const unitsByOption = new Map<string, OptionUnitsStepperUnit[]>()
-  for (const unit of units) {
-    if (!unit.optionId) continue
-    const list = unitsByOption.get(unit.optionId)
-    if (list) list.push(unit)
-    else unitsByOption.set(unit.optionId, [unit])
-  }
-
-  const unitToOption = new Map(units.map((u) => [u.optionUnitId, u.optionId]))
-  const unitById = new Map(units.map((u) => [u.optionUnitId, u]))
-
-  // Per-option total from the stepper. This is the count the operator
-  // committed to when picking rooms.
-  const totalByOption = new Map<string, number>()
-  for (const [unitId, qty] of Object.entries(quantities)) {
-    if (qty <= 0) continue
-    const optionId = unitToOption.get(unitId)
-    if (!optionId) continue
-    totalByOption.set(optionId, (totalByOption.get(optionId) ?? 0) + qty)
-  }
-
-  const assignedForDefaulting = new Map<string, number>()
-  for (const traveler of travelers) {
-    if (!traveler.roomUnitId) continue
-    const optionId = unitToOption.get(traveler.roomUnitId)
-    if (!optionId) continue
-    assignedForDefaulting.set(optionId, (assignedForDefaulting.get(optionId) ?? 0) + 1)
-  }
-
-  const optionDemand = Array.from(totalByOption.entries())
-  const nextTravelers = travelers.map((traveler) => {
-    if (traveler.roomUnitId && unitById.has(traveler.roomUnitId)) return traveler
-
-    const optionId =
-      optionDemand.find(
-        ([candidate, total]) => (assignedForDefaulting.get(candidate) ?? 0) < total,
-      )?.[0] ?? optionDemand[0]?.[0]
-    if (!optionId) return traveler
-
-    const age = computeAgeYears(traveler.dateOfBirth)
-    const roleHint =
-      traveler.role === "adult" || traveler.role === "child" || traveler.role === "infant"
-        ? traveler.role
-        : null
-    const unit = pickUnitForAge(unitsByOption.get(optionId) ?? [], age, roleHint)
-    if (!unit) return traveler
-
-    assignedForDefaulting.set(optionId, (assignedForDefaulting.get(optionId) ?? 0) + 1)
-    return { ...traveler, roomUnitId: unit.optionUnitId }
-  })
-
-  // Count actual traveler assignments per unit + per option.
-  const next: Record<string, number> = {}
-  const assignedByOption = new Map<string, number>()
-  for (const t of nextTravelers) {
-    if (!t.roomUnitId) continue
-    const optionId = unitToOption.get(t.roomUnitId)
-    if (!optionId) continue
-    next[t.roomUnitId] = (next[t.roomUnitId] ?? 0) + 1
-    assignedByOption.set(optionId, (assignedByOption.get(optionId) ?? 0) + 1)
-  }
-
-  // Residual = operator picked N rooms but only added M travelers; put
-  // the leftover on the option's adult/primary unit so the price total
-  // matches the stepper.
-  for (const [optionId, total] of totalByOption) {
-    const assigned = assignedByOption.get(optionId) ?? 0
-    const residual = Math.max(0, total - assigned)
-    if (residual === 0) continue
-    const adult = pickUnitForAge(unitsByOption.get(optionId) ?? [], null)
-    if (!adult) continue
-    next[adult.optionUnitId] = (next[adult.optionUnitId] ?? 0) + residual
-  }
-
-  return { quantities: next, travelers: nextTravelers }
-}
-
-function travelersToRows(value: TravelerListValue): BookingCreateTravelerInput[] {
-  return value.travelers.map((traveler) => {
-    // Age-derived category (DOB-driven). The `role` field still
-    // carries the `lead` flag separately for the booking primary; the
-    // demographic category comes from age, not from a manual select.
-    const age = computeAgeYears(traveler.dateOfBirth)
-    const ageCategory: "adult" | "child" | "infant" | null =
-      age == null
-        ? traveler.role === "child" || traveler.role === "infant" || traveler.role === "adult"
-          ? traveler.role
-          : null
-        : age < 2
-          ? "infant"
-          : age < 18
-            ? "child"
-            : "adult"
-    return {
-      personId: traveler.personId,
-      firstName: traveler.firstName.trim(),
-      lastName: traveler.lastName.trim(),
-      email: traveler.email.trim() || null,
-      phone: traveler.phone.trim() || null,
-      preferredLanguage: traveler.preferredLanguage.trim() || null,
-      participantType: "traveler",
-      travelerCategory: ageCategory,
-      isPrimary: traveler.role === "lead",
-      roomUnitId: traveler.roomUnitId,
-    }
-  })
 }
 
 function sameRoomUnits(left: OptionUnitsStepperUnit[], right: OptionUnitsStepperUnit[]): boolean {
@@ -664,10 +469,9 @@ export function BookingCreateForm({
   // "Standard double", "Junior suite upgrade") — NOT option-units
   // (Adult / Child / Senior). The age-band lives separately on the
   // traveler and only affects pricing; both an adult and a child sit
-  // in the same Standard double room. Each entry's `unitId` is set to
-  // the option's primary unit so existing `roomUnitId`-keyed plumbing
-  // (assignment, redistribution) keeps working — `redistributeByAge`
-  // moves the traveler to the matching age-banded unit at submit.
+  // in the same Standard double room. The resolver separates
+  // person-priced options from room-priced options before it derives
+  // preview and submit quantities.
   const roomUnitOptions: RoomUnitOption[] = React.useMemo(() => {
     type UnitLike = {
       optionId?: string | null
@@ -775,18 +579,15 @@ export function BookingCreateForm({
     return Array.from(groups.values())
   }, [roomUnits])
 
-  // Apply the same age-banded redistribution we use at submit so the
-  // live price preview matches what the operator will actually be
-  // billed. Without this, the breakdown sees only the option's primary
-  // (Adult) unit qty from the stepper, missing the per-traveler split
-  // between adult / child / infant tiers.
+  // Apply the same draft resolver we use at submit so live pricing and
+  // persisted item lines cannot drift.
   const displayQuantities = React.useMemo(
     () =>
-      redistributeByAge(
-        rooms.quantities,
-        travelers.travelers,
-        getTravelerAssignableStepperUnits(roomUnits),
-      ).quantities,
+      resolveBookingDraft({
+        quantities: rooms.quantities,
+        travelers: travelers.travelers,
+        units: getTravelerAssignableStepperUnits(roomUnits),
+      }).quantities,
     [rooms.quantities, travelers.travelers, roomUnits],
   )
 
@@ -935,7 +736,11 @@ export function BookingCreateForm({
                 optionId: product.optionId,
               })),
             )
-      const redistributed = redistributeByAge(rooms.quantities, travelers.travelers, submitUnits)
+      const redistributed = resolveBookingDraft({
+        quantities: rooms.quantities,
+        travelers: travelers.travelers,
+        units: submitUnits,
+      })
 
       const itemLines = itemLinesToRows(redistributed.quantities, submitUnits, pricing)
 

--- a/packages/bookings-ui/src/components/booking-create-utils.ts
+++ b/packages/bookings-ui/src/components/booking-create-utils.ts
@@ -125,6 +125,7 @@ export function itemLinesToRows(
   quantities: Record<string, number>,
   units: BookingCreateUnitLineRecord[],
   pricing: BookingCreatePricingRecord | null,
+  travelerIndexesByUnitId: Record<string, number[]> = {},
 ): BookingCreateItemLineInput[] {
   const unitsById = new Map(units.map((unit) => [unit.optionUnitId, unit]))
   const unitNames = new Map(units.map((unit) => [unit.optionUnitId, unit.unitName]))
@@ -158,12 +159,18 @@ export function itemLinesToRows(
       pricedLine?.unitAmountCents ??
       (totalSellAmountCents != null ? Math.floor(totalSellAmountCents / quantity) : null)
     return {
+      clientLineKey: travelerIndexesByUnitId[optionUnitId]?.length
+        ? `unit:${optionUnitId}`
+        : undefined,
       optionId: unitsById.get(optionUnitId)?.optionId ?? null,
       optionUnitId,
       quantity,
       title: pricedLine?.label ?? unitNames.get(optionUnitId) ?? null,
       unitSellAmountCents,
       totalSellAmountCents,
+      travelerIndexes: travelerIndexesByUnitId[optionUnitId]?.length
+        ? travelerIndexesByUnitId[optionUnitId]
+        : undefined,
     }
   })
 }

--- a/packages/bookings-ui/src/components/booking-draft-resolver.ts
+++ b/packages/bookings-ui/src/components/booking-draft-resolver.ts
@@ -198,6 +198,21 @@ export function resolveBookingDraft<TTraveler extends BookingDraftTraveler>(opti
       roleHintForTraveler(traveler),
     )
 
+  const assignNextDemandUnit = (traveler: TTraveler): TTraveler => {
+    const key = pickOptionWithDemand()
+    if (!key)
+      return { ...traveler, roomUnitId: null, roomUnitAssignmentSource: "auto" } as TTraveler
+    const unit = resolveUnitForTraveler(traveler, key)
+    if (!unit)
+      return { ...traveler, roomUnitId: null, roomUnitAssignmentSource: "auto" } as TTraveler
+    assignedForDefaulting.set(key, (assignedForDefaulting.get(key) ?? 0) + 1)
+    return {
+      ...traveler,
+      roomUnitId: unit.optionUnitId,
+      roomUnitAssignmentSource: "auto",
+    } as TTraveler
+  }
+
   const nextTravelers = travelers.map((traveler) => {
     const source = traveler.roomUnitAssignmentSource ?? "auto"
     if (source === "none") {
@@ -217,18 +232,7 @@ export function resolveBookingDraft<TTraveler extends BookingDraftTraveler>(opti
         : traveler
     }
 
-    if (source === "manual") return traveler
-
-    const key = pickOptionWithDemand()
-    if (!key) return traveler
-    const unit = resolveUnitForTraveler(traveler, key)
-    if (!unit) return traveler
-    assignedForDefaulting.set(key, (assignedForDefaulting.get(key) ?? 0) + 1)
-    return {
-      ...traveler,
-      roomUnitId: unit.optionUnitId,
-      roomUnitAssignmentSource: "auto",
-    } as TTraveler
+    return assignNextDemandUnit(traveler)
   })
 
   const next: BookingDraftQuantities = {}

--- a/packages/bookings-ui/src/components/booking-draft-resolver.ts
+++ b/packages/bookings-ui/src/components/booking-draft-resolver.ts
@@ -1,4 +1,7 @@
-import type { BookingCreateTravelerInput } from "@voyantjs/bookings-react"
+import type {
+  BookingCreateExtraLineInput,
+  BookingCreateTravelerInput,
+} from "@voyantjs/bookings-react"
 
 export type BookingDraftTravelerRole = "lead" | "adult" | "child" | "infant"
 
@@ -44,6 +47,7 @@ export type BookingDraftQuantities = Record<string, number>
 export interface ResolvedBookingDraft<TTraveler extends BookingDraftTraveler> {
   quantities: BookingDraftQuantities
   travelers: TTraveler[]
+  travelerIndexesByUnitId: Record<string, number[]>
 }
 
 export function computeDraftAgeYears(dob: string | null, now: Date = new Date()): number | null {
@@ -142,7 +146,9 @@ export function resolveBookingDraft<TTraveler extends BookingDraftTraveler>(opti
 }): ResolvedBookingDraft<TTraveler> {
   const { quantities, travelers, now = new Date() } = options
   const units = [...options.units]
-  if (units.length === 0) return { quantities, travelers: [...travelers] }
+  if (units.length === 0) {
+    return { quantities, travelers: [...travelers], travelerIndexesByUnitId: {} }
+  }
 
   const unitsByOption = new Map<string, BookingDraftUnit[]>()
   const unitById = new Map<string, BookingDraftUnit>()
@@ -226,6 +232,7 @@ export function resolveBookingDraft<TTraveler extends BookingDraftTraveler>(opti
   })
 
   const next: BookingDraftQuantities = {}
+  const travelerIndexesByUnitId: Record<string, number[]> = {}
 
   for (const [unitId, quantity] of Object.entries(quantities)) {
     if (quantity <= 0) continue
@@ -235,12 +242,17 @@ export function resolveBookingDraft<TTraveler extends BookingDraftTraveler>(opti
   }
 
   const assignedByOption = new Map<string, number>()
-  for (const traveler of nextTravelers) {
+  for (const [index, traveler] of nextTravelers.entries()) {
     if (!traveler.roomUnitId || traveler.roomUnitAssignmentSource === "none") continue
     const key = unitToOption.get(traveler.roomUnitId)
-    if (!key || !personPricedOptions.has(key)) continue
-    next[traveler.roomUnitId] = (next[traveler.roomUnitId] ?? 0) + 1
-    assignedByOption.set(key, (assignedByOption.get(key) ?? 0) + 1)
+    if (!key) continue
+    const unitIndexes = travelerIndexesByUnitId[traveler.roomUnitId] ?? []
+    unitIndexes.push(index)
+    travelerIndexesByUnitId[traveler.roomUnitId] = unitIndexes
+    if (personPricedOptions.has(key)) {
+      next[traveler.roomUnitId] = (next[traveler.roomUnitId] ?? 0) + 1
+      assignedByOption.set(key, (assignedByOption.get(key) ?? 0) + 1)
+    }
   }
 
   for (const [key, total] of totalByOption) {
@@ -253,7 +265,34 @@ export function resolveBookingDraft<TTraveler extends BookingDraftTraveler>(opti
     next[adult.optionUnitId] = (next[adult.optionUnitId] ?? 0) + residual
   }
 
-  return { quantities: next, travelers: nextTravelers }
+  return { quantities: next, travelers: nextTravelers, travelerIndexesByUnitId }
+}
+
+export function resolveBookingExtraLines(options: {
+  extraLines: readonly BookingCreateExtraLineInput[]
+  travelerCount: number
+}): BookingCreateExtraLineInput[] {
+  const travelerIndexes = Array.from({ length: options.travelerCount }, (_, index) => index)
+  return options.extraLines.map((line) => {
+    const perPerson = line.pricingMode === "per_person" || line.pricedPerPerson === true
+    if (!perPerson) {
+      return {
+        ...line,
+        clientLineKey: line.clientLineKey ?? `extra:${line.productExtraId}`,
+      }
+    }
+    const quantity = Math.max(1, options.travelerCount) * line.quantity
+    return {
+      ...line,
+      clientLineKey: line.clientLineKey ?? `extra:${line.productExtraId}`,
+      quantity,
+      totalSellAmountCents:
+        line.unitSellAmountCents == null
+          ? line.totalSellAmountCents
+          : line.unitSellAmountCents * quantity,
+      travelerIndexes,
+    }
+  })
 }
 
 export function travelersToRows(

--- a/packages/bookings-ui/src/components/booking-draft-resolver.ts
+++ b/packages/bookings-ui/src/components/booking-draft-resolver.ts
@@ -1,0 +1,275 @@
+import type { BookingCreateTravelerInput } from "@voyantjs/bookings-react"
+
+export type BookingDraftTravelerRole = "lead" | "adult" | "child" | "infant"
+
+export type BookingDraftUnitAssignmentSource = "auto" | "manual" | "none"
+
+export interface BookingDraftTraveler {
+  personId: string | null
+  firstName: string
+  lastName: string
+  email: string
+  phone: string
+  preferredLanguage: string
+  role: BookingDraftTravelerRole
+  dateOfBirth: string | null
+  /**
+   * Legacy field name kept for compatibility with the current dialog.
+   * For person-priced products it means the traveler's pricing unit; for
+   * accommodation products it means the selected room/accommodation unit.
+   */
+  roomUnitId: string | null
+  /**
+   * Tracks operator intent around the legacy `roomUnitId` field.
+   *
+   * - auto: derived from product shape, DOB, role hints, and selected quantity
+   * - manual: operator explicitly selected a category/room
+   * - none: operator explicitly selected "No room"
+   */
+  roomUnitAssignmentSource?: BookingDraftUnitAssignmentSource
+}
+
+export interface BookingDraftUnit {
+  optionId?: string | null
+  optionUnitId: string
+  unitName: string
+  unitCode?: string | null
+  minAge?: number | null
+  maxAge?: number | null
+  unitType?: "person" | "group" | "room" | "vehicle" | "service" | "other" | null
+}
+
+export type BookingDraftQuantities = Record<string, number>
+
+export interface ResolvedBookingDraft<TTraveler extends BookingDraftTraveler> {
+  quantities: BookingDraftQuantities
+  travelers: TTraveler[]
+}
+
+export function computeDraftAgeYears(dob: string | null, now: Date = new Date()): number | null {
+  if (!dob) return null
+  const birth = new Date(dob)
+  if (Number.isNaN(birth.getTime())) return null
+  let age = now.getFullYear() - birth.getFullYear()
+  const beforeBirthday =
+    now.getMonth() < birth.getMonth() ||
+    (now.getMonth() === birth.getMonth() && now.getDate() < birth.getDate())
+  if (beforeBirthday) age -= 1
+  return age >= 0 ? age : null
+}
+
+export function deriveDraftPaxBand(
+  traveler: Pick<BookingDraftTraveler, "dateOfBirth" | "role">,
+  now: Date = new Date(),
+): "adult" | "child" | "infant" | null {
+  const age = computeDraftAgeYears(traveler.dateOfBirth, now)
+  if (age == null) {
+    return traveler.role === "adult" || traveler.role === "child" || traveler.role === "infant"
+      ? traveler.role
+      : null
+  }
+  if (age < 2) return "infant"
+  if (age < 18) return "child"
+  return "adult"
+}
+
+/**
+ * Pick the unit for a traveler pricing band. DOB-derived age wins over
+ * role hints; role hints cover rows where the operator knows the category
+ * but does not have a DOB yet.
+ */
+export function pickUnitForAge<TUnit extends BookingDraftUnit>(
+  units: TUnit[],
+  age: number | null,
+  roleHint: "adult" | "child" | "infant" | null = null,
+): TUnit | undefined {
+  if (units.length === 0) return undefined
+  const personUnits = units.filter((u) => u.unitType == null || u.unitType === "person")
+  const pool = personUnits.length > 0 ? personUnits : units
+  const sorted = [...pool].sort((a, b) => (a.minAge ?? 0) - (b.minAge ?? 0))
+
+  const matchByAge = (target: number) =>
+    sorted.find(
+      (u) => (u.minAge == null || target >= u.minAge) && (u.maxAge == null || target <= u.maxAge),
+    )
+
+  if (age != null) {
+    const match = matchByAge(age)
+    if (match) return match
+  }
+
+  if (roleHint) {
+    const HINT_AGE = { adult: 30, child: 8, infant: 1 } as const
+    const hintAge = HINT_AGE[roleHint]
+    const banded = sorted.filter((u) => u.minAge != null || u.maxAge != null)
+    const match = banded.find(
+      (u) => (u.minAge == null || hintAge >= u.minAge) && (u.maxAge == null || hintAge <= u.maxAge),
+    )
+    if (match) return match
+  }
+
+  const findByCode = (code: string) =>
+    sorted.find((u) => (u.unitCode ?? "").toUpperCase() === code) ??
+    sorted.find((u) => new RegExp(`\\b${code}\\b`, "i").test(u.unitName))
+  if (roleHint === "child") return findByCode("CHILD") ?? sorted[0]
+  if (roleHint === "infant") return findByCode("INFANT") ?? sorted[0]
+  return findByCode("ADULT") ?? sorted[sorted.length - 1] ?? sorted[0]
+}
+
+function optionKey(unit: BookingDraftUnit): string {
+  return unit.optionId ?? unit.optionUnitId
+}
+
+function isPersonUnit(unit: BookingDraftUnit): boolean {
+  return unit.unitType == null || unit.unitType === "person"
+}
+
+function isRoomUnit(unit: BookingDraftUnit): boolean {
+  return unit.unitType === "room"
+}
+
+function roleHintForTraveler(traveler: BookingDraftTraveler): "adult" | "child" | "infant" | null {
+  return traveler.role === "adult" || traveler.role === "child" || traveler.role === "infant"
+    ? traveler.role
+    : null
+}
+
+export function resolveBookingDraft<TTraveler extends BookingDraftTraveler>(options: {
+  quantities: BookingDraftQuantities
+  travelers: readonly TTraveler[]
+  units: readonly BookingDraftUnit[]
+  now?: Date
+}): ResolvedBookingDraft<TTraveler> {
+  const { quantities, travelers, now = new Date() } = options
+  const units = [...options.units]
+  if (units.length === 0) return { quantities, travelers: [...travelers] }
+
+  const unitsByOption = new Map<string, BookingDraftUnit[]>()
+  const unitById = new Map<string, BookingDraftUnit>()
+  const unitToOption = new Map<string, string>()
+  for (const unit of units) {
+    const key = optionKey(unit)
+    unitById.set(unit.optionUnitId, unit)
+    unitToOption.set(unit.optionUnitId, key)
+    const list = unitsByOption.get(key)
+    if (list) list.push(unit)
+    else unitsByOption.set(key, [unit])
+  }
+
+  const personPricedOptions = new Set<string>()
+  for (const [key, optionUnits] of unitsByOption) {
+    const hasPerson = optionUnits.some(isPersonUnit)
+    const hasRoom = optionUnits.some(isRoomUnit)
+    if (hasPerson && !hasRoom) personPricedOptions.add(key)
+  }
+
+  const totalByOption = new Map<string, number>()
+  for (const [unitId, quantity] of Object.entries(quantities)) {
+    if (quantity <= 0) continue
+    const key = unitToOption.get(unitId)
+    if (!key) continue
+    totalByOption.set(key, (totalByOption.get(key) ?? 0) + quantity)
+  }
+
+  const assignedForDefaulting = new Map<string, number>()
+  for (const traveler of travelers) {
+    if (!traveler.roomUnitId || traveler.roomUnitAssignmentSource === "none") continue
+    const key = unitToOption.get(traveler.roomUnitId)
+    if (!key) continue
+    assignedForDefaulting.set(key, (assignedForDefaulting.get(key) ?? 0) + 1)
+  }
+
+  const optionDemand = Array.from(totalByOption.entries())
+  const pickOptionWithDemand = () =>
+    optionDemand.find(
+      ([candidate, total]) => (assignedForDefaulting.get(candidate) ?? 0) < total,
+    )?.[0] ?? optionDemand[0]?.[0]
+
+  const resolveUnitForTraveler = (traveler: TTraveler, key: string): BookingDraftUnit | undefined =>
+    pickUnitForAge(
+      unitsByOption.get(key) ?? [],
+      computeDraftAgeYears(traveler.dateOfBirth, now),
+      roleHintForTraveler(traveler),
+    )
+
+  const nextTravelers = travelers.map((traveler) => {
+    const source = traveler.roomUnitAssignmentSource ?? "auto"
+    if (source === "none") {
+      return { ...traveler, roomUnitId: null, roomUnitAssignmentSource: "none" } as TTraveler
+    }
+
+    if (traveler.roomUnitId && unitById.has(traveler.roomUnitId)) {
+      const key = unitToOption.get(traveler.roomUnitId)
+      if (!key || source === "manual" || !personPricedOptions.has(key)) return traveler
+      const unit = resolveUnitForTraveler(traveler, key)
+      return unit && unit.optionUnitId !== traveler.roomUnitId
+        ? ({
+            ...traveler,
+            roomUnitId: unit.optionUnitId,
+            roomUnitAssignmentSource: "auto",
+          } as TTraveler)
+        : traveler
+    }
+
+    if (source === "manual") return traveler
+
+    const key = pickOptionWithDemand()
+    if (!key) return traveler
+    const unit = resolveUnitForTraveler(traveler, key)
+    if (!unit) return traveler
+    assignedForDefaulting.set(key, (assignedForDefaulting.get(key) ?? 0) + 1)
+    return {
+      ...traveler,
+      roomUnitId: unit.optionUnitId,
+      roomUnitAssignmentSource: "auto",
+    } as TTraveler
+  })
+
+  const next: BookingDraftQuantities = {}
+
+  for (const [unitId, quantity] of Object.entries(quantities)) {
+    if (quantity <= 0) continue
+    const key = unitToOption.get(unitId)
+    if (!key || personPricedOptions.has(key)) continue
+    next[unitId] = quantity
+  }
+
+  const assignedByOption = new Map<string, number>()
+  for (const traveler of nextTravelers) {
+    if (!traveler.roomUnitId || traveler.roomUnitAssignmentSource === "none") continue
+    const key = unitToOption.get(traveler.roomUnitId)
+    if (!key || !personPricedOptions.has(key)) continue
+    next[traveler.roomUnitId] = (next[traveler.roomUnitId] ?? 0) + 1
+    assignedByOption.set(key, (assignedByOption.get(key) ?? 0) + 1)
+  }
+
+  for (const [key, total] of totalByOption) {
+    if (!personPricedOptions.has(key)) continue
+    const assigned = assignedByOption.get(key) ?? 0
+    const residual = Math.max(0, total - assigned)
+    if (residual === 0) continue
+    const adult = pickUnitForAge(unitsByOption.get(key) ?? [], null, "adult")
+    if (!adult) continue
+    next[adult.optionUnitId] = (next[adult.optionUnitId] ?? 0) + residual
+  }
+
+  return { quantities: next, travelers: nextTravelers }
+}
+
+export function travelersToRows(
+  value: { travelers: readonly BookingDraftTraveler[] },
+  now: Date = new Date(),
+): BookingCreateTravelerInput[] {
+  return value.travelers.map((traveler) => ({
+    personId: traveler.personId,
+    firstName: traveler.firstName.trim(),
+    lastName: traveler.lastName.trim(),
+    email: traveler.email.trim() || null,
+    phone: traveler.phone.trim() || null,
+    preferredLanguage: traveler.preferredLanguage.trim() || null,
+    participantType: "traveler",
+    travelerCategory: deriveDraftPaxBand(traveler, now),
+    isPrimary: traveler.role === "lead",
+    roomUnitId: traveler.roomUnitAssignmentSource === "none" ? null : traveler.roomUnitId,
+  }))
+}

--- a/packages/bookings-ui/src/components/travelers-section.tsx
+++ b/packages/bookings-ui/src/components/travelers-section.tsx
@@ -53,8 +53,18 @@ export interface TravelerEntry {
   role: TravelerRole
   /** ISO `YYYY-MM-DD` date of birth. Drives age-derived unit assignment. */
   dateOfBirth: string | null
-  /** option_unit_id the traveler is assigned to (matches OptionUnitsStepper units). */
+  /**
+   * Legacy assignment id. For person-priced products this is the
+   * age-priced option_unit_id; for accommodation products this is the
+   * selected room/accommodation option_unit_id.
+   */
   roomUnitId: string | null
+  /**
+   * Whether `roomUnitId` was derived by the form or explicitly chosen
+   * by the operator. Keeps stale auto Adult assignments from winning
+   * over a later DOB/person pick, while preserving explicit No room.
+   */
+  roomUnitAssignmentSource?: "auto" | "manual" | "none"
 }
 
 export interface TravelerListValue {
@@ -75,6 +85,7 @@ export function createBlankTraveler(role: TravelerRole = "adult"): TravelerEntry
     role,
     dateOfBirth: null,
     roomUnitId: null,
+    roomUnitAssignmentSource: "auto",
   }
 }
 
@@ -362,9 +373,9 @@ export function TravelersSection({
   // Race fix: travelers added before the option-units queries resolve
   // end up with `roomUnitId: null`. Once units arrive, back-fill any
   // missing assignments so the static fallback's role hint (Child /
-  // Infant) is honored and `redistributeByAge` doesn't silently price
-  // them as adults. Runs exactly once per units-load transition — after
-  // that, `roomUnitId: null` is treated as the operator's explicit
+  // Infant) is honored by the shared draft resolver. Runs exactly once
+  // per units-load transition — after that, `roomUnitId: null` is
+  // treated as the operator's explicit
   // "No room" choice from the Room select and left alone. Reset on
   // empty `roomUnits` so the next load (e.g. product change) rehydrates.
   const hasHydratedNullsRef = React.useRef(false)
@@ -375,9 +386,15 @@ export function TravelersSection({
     }
     if (hasHydratedNullsRef.current) return
     hasHydratedNullsRef.current = true
-    if (!value.travelers.some((t) => !t.roomUnitId)) return
+    if (!value.travelers.some((t) => !t.roomUnitId && t.roomUnitAssignmentSource !== "none")) return
     const next = value.travelers.map((t) =>
-      t.roomUnitId ? t : { ...t, roomUnitId: pickRoomUnitIdForNewTraveler(t.dateOfBirth, t.role) },
+      t.roomUnitId || t.roomUnitAssignmentSource === "none"
+        ? t
+        : {
+            ...t,
+            roomUnitId: pickRoomUnitIdForNewTraveler(t.dateOfBirth, t.role),
+            roomUnitAssignmentSource: "auto" as const,
+          },
     )
     // Guard against a stray onChange if hydration can't find a unit
     // (e.g. empty roomGroups): no point dispatching an update that
@@ -395,7 +412,11 @@ export function TravelersSection({
     onChange({
       travelers: [
         ...value.travelers,
-        { ...blank, roomUnitId: pickRoomUnitIdForNewTraveler(null, role) },
+        {
+          ...blank,
+          roomUnitId: pickRoomUnitIdForNewTraveler(null, role),
+          roomUnitAssignmentSource: "auto",
+        },
       ],
     })
   }
@@ -407,7 +428,11 @@ export function TravelersSection({
     onChange({
       travelers: [
         ...value.travelers,
-        { ...traveler, roomUnitId: pickRoomUnitIdForNewTraveler(traveler.dateOfBirth, role) },
+        {
+          ...traveler,
+          roomUnitId: pickRoomUnitIdForNewTraveler(traveler.dateOfBirth, role),
+          roomUnitAssignmentSource: "auto",
+        },
       ],
     })
   }
@@ -418,7 +443,11 @@ export function TravelersSection({
     onChange({
       travelers: [
         ...value.travelers,
-        { ...traveler, roomUnitId: pickRoomUnitIdForNewTraveler(traveler.dateOfBirth, role) },
+        {
+          ...traveler,
+          roomUnitId: pickRoomUnitIdForNewTraveler(traveler.dateOfBirth, role),
+          roomUnitAssignmentSource: "auto",
+        },
       ],
     })
   }
@@ -524,6 +553,16 @@ export function TravelersSection({
                     phone: person.phone ?? "",
                     preferredLanguage: person.preferredLanguage ?? "",
                     dateOfBirth: person.dateOfBirth ?? null,
+                    ...(traveler.roomUnitAssignmentSource === "manual" ||
+                    traveler.roomUnitAssignmentSource === "none"
+                      ? {}
+                      : {
+                          roomUnitId: pickRoomUnitIdForNewTraveler(
+                            person.dateOfBirth ?? null,
+                            traveler.role,
+                          ),
+                          roomUnitAssignmentSource: "auto" as const,
+                        }),
                   })
                 }
                 onClear={() =>
@@ -535,6 +574,13 @@ export function TravelersSection({
                     phone: "",
                     preferredLanguage: "",
                     dateOfBirth: null,
+                    ...(traveler.roomUnitAssignmentSource === "manual" ||
+                    traveler.roomUnitAssignmentSource === "none"
+                      ? {}
+                      : {
+                          roomUnitId: pickRoomUnitIdForNewTraveler(null, traveler.role),
+                          roomUnitAssignmentSource: "auto" as const,
+                        }),
                   })
                 }
               />
@@ -550,7 +596,11 @@ export function TravelersSection({
                     infant: merged.roleInfant,
                   }}
                   onPickUnit={(unitId, nextRole) =>
-                    updateAt(index, { roomUnitId: unitId, role: nextRole })
+                    updateAt(index, {
+                      roomUnitId: unitId,
+                      role: nextRole,
+                      roomUnitAssignmentSource: "manual",
+                    })
                   }
                 />
 
@@ -566,6 +616,7 @@ export function TravelersSection({
                             v === NO_ROOM || !v
                               ? null
                               : pickUnitForRoomChange(traveler.roomUnitId, v, roomGroups),
+                          roomUnitAssignmentSource: v === NO_ROOM || !v ? "none" : "manual",
                         })
                       }
                     >
@@ -773,6 +824,7 @@ function createTravelerFromPerson(person: PersonRecord, role: TravelerRole): Tra
     role: effectiveRole,
     dateOfBirth,
     roomUnitId: null,
+    roomUnitAssignmentSource: "auto",
   }
 }
 

--- a/packages/bookings-ui/tests/unit/booking-create-utils.test.ts
+++ b/packages/bookings-ui/tests/unit/booking-create-utils.test.ts
@@ -160,6 +160,45 @@ describe("booking create helpers", () => {
     ])
   })
 
+  it("carries traveler applicability on selected item lines", () => {
+    const result = itemLinesToRows(
+      {
+        optu_adult: 1,
+        optu_child: 1,
+      },
+      [
+        { optionId: "opto_tour", optionUnitId: "optu_adult", unitName: "Adult" },
+        { optionId: "opto_tour", optionUnitId: "optu_child", unitName: "Child" },
+      ],
+      {
+        confirmedAmountCents: 29600,
+        lines: [
+          {
+            unitId: "optu_adult",
+            label: "Adult",
+            unitAmountCents: 16000,
+            totalAmountCents: 16000,
+          },
+          {
+            unitId: "optu_child",
+            label: "Child",
+            unitAmountCents: 13600,
+            totalAmountCents: 13600,
+          },
+        ],
+      },
+      {
+        optu_adult: [0],
+        optu_child: [1],
+      },
+    )
+
+    expect(result.map((line) => [line.clientLineKey, line.travelerIndexes])).toEqual([
+      ["unit:optu_adult", [0]],
+      ["unit:optu_child", [1]],
+    ])
+  })
+
   it("uses the selected unit for new shared-room groups", () => {
     expect(
       getSelectedSharedRoomUnitId({

--- a/packages/bookings-ui/tests/unit/booking-draft-resolver.test.ts
+++ b/packages/bookings-ui/tests/unit/booking-draft-resolver.test.ts
@@ -4,6 +4,7 @@ import {
   type BookingDraftTraveler,
   type BookingDraftUnit,
   resolveBookingDraft,
+  resolveBookingExtraLines,
   travelersToRows,
 } from "../../src/components/booking-draft-resolver.js"
 
@@ -77,6 +78,11 @@ describe("resolveBookingDraft", () => {
       "u_child_6_12",
       "u_child_0_5",
     ])
+    expect(result.travelerIndexesByUnitId).toEqual({
+      u_adult: [0],
+      u_child_6_12: [1],
+      u_child_0_5: [2],
+    })
   })
 
   it("recomputes stale auto Adult assignments after an existing child person is selected", () => {
@@ -138,6 +144,7 @@ describe("resolveBookingDraft", () => {
 
     expect(result.quantities).toEqual({ u_double_room: 1 })
     expect(result.travelers.map((t) => t.roomUnitId)).toEqual(["u_double_room", "u_double_room"])
+    expect(result.travelerIndexesByUnitId).toEqual({ u_double_room: [0, 1] })
   })
 
   it("preserves explicit No room assignments", () => {
@@ -164,6 +171,33 @@ describe("resolveBookingDraft", () => {
 
     expect(result.quantities).toEqual({ u_double_room: 1 })
     expect(result.travelers[0]?.roomUnitId).toBeNull()
+  })
+})
+
+describe("resolveBookingExtraLines", () => {
+  it("normalizes per-person extras to charged traveler quantity and traveler links", () => {
+    const result = resolveBookingExtraLines({
+      travelerCount: 3,
+      extraLines: [
+        {
+          productExtraId: "extra_lunch",
+          name: "Lunch",
+          pricingMode: "per_person",
+          pricedPerPerson: true,
+          quantity: 1,
+          sellCurrency: "RON",
+          unitSellAmountCents: 5000,
+          totalSellAmountCents: 5000,
+        },
+      ],
+    })
+
+    expect(result[0]).toMatchObject({
+      clientLineKey: "extra:extra_lunch",
+      quantity: 3,
+      totalSellAmountCents: 15000,
+      travelerIndexes: [0, 1, 2],
+    })
   })
 })
 

--- a/packages/bookings-ui/tests/unit/booking-draft-resolver.test.ts
+++ b/packages/bookings-ui/tests/unit/booking-draft-resolver.test.ts
@@ -123,6 +123,43 @@ describe("resolveBookingDraft", () => {
     expect(result.travelers[0]?.roomUnitId).toBe("u_adult")
   })
 
+  it("re-resolves stale manual person unit assignments against the current unit set", () => {
+    const result = resolveBookingDraft({
+      quantities: { next_adult: 1 },
+      units: [
+        unit({
+          optionId: "opto_next_day_tour",
+          optionUnitId: "next_adult",
+          unitCode: "adult",
+          unitName: "Adult",
+          minAge: 13,
+        }),
+        unit({
+          optionId: "opto_next_day_tour",
+          optionUnitId: "next_child",
+          unitCode: "child",
+          unitName: "Child",
+          minAge: 6,
+          maxAge: 12,
+        }),
+      ],
+      travelers: [
+        traveler({
+          role: "child",
+          dateOfBirth: "2017-06-01",
+          roomUnitId: "previous_child",
+          roomUnitAssignmentSource: "manual",
+        }),
+      ],
+      now: NOW,
+    })
+
+    expect(result.quantities).toEqual({ next_child: 1 })
+    expect(result.travelers[0]?.roomUnitId).toBe("next_child")
+    expect(result.travelers[0]?.roomUnitAssignmentSource).toBe("auto")
+    expect(travelersToRows({ travelers: result.travelers }, NOW)[0]?.roomUnitId).toBe("next_child")
+  })
+
   it("keeps accommodation quantities as room quantities instead of traveler counts", () => {
     const result = resolveBookingDraft({
       quantities: { u_double_room: 1 },
@@ -145,6 +182,35 @@ describe("resolveBookingDraft", () => {
     expect(result.quantities).toEqual({ u_double_room: 1 })
     expect(result.travelers.map((t) => t.roomUnitId)).toEqual(["u_double_room", "u_double_room"])
     expect(result.travelerIndexesByUnitId).toEqual({ u_double_room: [0, 1] })
+  })
+
+  it("reassigns stale manual room assignments to the current selected room", () => {
+    const result = resolveBookingDraft({
+      quantities: { u_next_double_room: 1 },
+      units: [
+        unit({
+          optionId: "opto_next_double",
+          optionUnitId: "u_next_double_room",
+          unitName: "Next double room",
+          unitCode: "DBL",
+          unitType: "room",
+        }),
+      ],
+      travelers: [
+        traveler({
+          role: "lead",
+          dateOfBirth: "1988-01-01",
+          roomUnitId: "u_previous_double_room",
+          roomUnitAssignmentSource: "manual",
+        }),
+      ],
+      now: NOW,
+    })
+
+    expect(result.quantities).toEqual({ u_next_double_room: 1 })
+    expect(result.travelers[0]?.roomUnitId).toBe("u_next_double_room")
+    expect(result.travelers[0]?.roomUnitAssignmentSource).toBe("auto")
+    expect(result.travelerIndexesByUnitId).toEqual({ u_next_double_room: [0] })
   })
 
   it("preserves explicit No room assignments", () => {

--- a/packages/bookings-ui/tests/unit/booking-draft-resolver.test.ts
+++ b/packages/bookings-ui/tests/unit/booking-draft-resolver.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  type BookingDraftTraveler,
+  type BookingDraftUnit,
+  resolveBookingDraft,
+  travelersToRows,
+} from "../../src/components/booking-draft-resolver.js"
+
+const NOW = new Date("2026-05-25T00:00:00.000Z")
+
+function unit(partial: Partial<BookingDraftUnit> & Pick<BookingDraftUnit, "optionUnitId">) {
+  return {
+    optionId: partial.optionId ?? "opto_day_tour",
+    optionUnitId: partial.optionUnitId,
+    unitName: partial.unitName ?? partial.optionUnitId,
+    unitCode: partial.unitCode ?? null,
+    minAge: partial.minAge ?? null,
+    maxAge: partial.maxAge ?? null,
+    unitType: partial.unitType ?? "person",
+  } satisfies BookingDraftUnit
+}
+
+function traveler(partial: Partial<BookingDraftTraveler> = {}) {
+  return {
+    personId: partial.personId ?? null,
+    firstName: partial.firstName ?? "Test",
+    lastName: partial.lastName ?? "Traveler",
+    email: partial.email ?? "",
+    phone: partial.phone ?? "",
+    preferredLanguage: partial.preferredLanguage ?? "",
+    role: partial.role ?? "adult",
+    dateOfBirth: partial.dateOfBirth ?? null,
+    roomUnitId: partial.roomUnitId ?? null,
+    roomUnitAssignmentSource: partial.roomUnitAssignmentSource ?? "auto",
+  } satisfies BookingDraftTraveler
+}
+
+describe("resolveBookingDraft", () => {
+  const krushunaUnits = [
+    unit({ optionUnitId: "u_adult", unitCode: "adult", unitName: "Adult", minAge: 13 }),
+    unit({
+      optionUnitId: "u_child_6_12",
+      unitCode: "child_6_12",
+      unitName: "Child 6-12",
+      minAge: 6,
+      maxAge: 12,
+    }),
+    unit({
+      optionUnitId: "u_child_0_5",
+      unitCode: "child_0_5",
+      unitName: "Child 0-5",
+      minAge: 0,
+      maxAge: 5,
+    }),
+  ]
+
+  it("derives adult, child, and infant quantities for a one-day person-priced excursion", () => {
+    const result = resolveBookingDraft({
+      quantities: { u_adult: 3 },
+      units: krushunaUnits,
+      travelers: [
+        traveler({ role: "lead", dateOfBirth: "1989-04-01", roomUnitId: "u_adult" }),
+        traveler({ role: "adult", dateOfBirth: "2017-06-01", roomUnitId: "u_adult" }),
+        traveler({ role: "adult", dateOfBirth: "2025-01-01", roomUnitId: "u_adult" }),
+      ],
+      now: NOW,
+    })
+
+    expect(result.quantities).toEqual({
+      u_adult: 1,
+      u_child_6_12: 1,
+      u_child_0_5: 1,
+    })
+    expect(result.travelers.map((t) => t.roomUnitId)).toEqual([
+      "u_adult",
+      "u_child_6_12",
+      "u_child_0_5",
+    ])
+  })
+
+  it("recomputes stale auto Adult assignments after an existing child person is selected", () => {
+    const result = resolveBookingDraft({
+      quantities: { u_adult: 1 },
+      units: krushunaUnits,
+      travelers: [
+        traveler({
+          role: "adult",
+          dateOfBirth: "2017-06-01",
+          roomUnitId: "u_adult",
+          roomUnitAssignmentSource: "auto",
+        }),
+      ],
+      now: NOW,
+    })
+
+    expect(result.quantities).toEqual({ u_child_6_12: 1 })
+    expect(result.travelers[0]?.roomUnitId).toBe("u_child_6_12")
+  })
+
+  it("preserves explicit operator category selections", () => {
+    const result = resolveBookingDraft({
+      quantities: { u_adult: 1 },
+      units: krushunaUnits,
+      travelers: [
+        traveler({
+          role: "adult",
+          dateOfBirth: "2017-06-01",
+          roomUnitId: "u_adult",
+          roomUnitAssignmentSource: "manual",
+        }),
+      ],
+      now: NOW,
+    })
+
+    expect(result.quantities).toEqual({ u_adult: 1 })
+    expect(result.travelers[0]?.roomUnitId).toBe("u_adult")
+  })
+
+  it("keeps accommodation quantities as room quantities instead of traveler counts", () => {
+    const result = resolveBookingDraft({
+      quantities: { u_double_room: 1 },
+      units: [
+        unit({
+          optionId: "opto_double",
+          optionUnitId: "u_double_room",
+          unitName: "Double room",
+          unitCode: "DBL",
+          unitType: "room",
+        }),
+      ],
+      travelers: [
+        traveler({ role: "lead", dateOfBirth: "1988-01-01", roomUnitId: "u_double_room" }),
+        traveler({ role: "adult", dateOfBirth: "1990-01-01", roomUnitId: "u_double_room" }),
+      ],
+      now: NOW,
+    })
+
+    expect(result.quantities).toEqual({ u_double_room: 1 })
+    expect(result.travelers.map((t) => t.roomUnitId)).toEqual(["u_double_room", "u_double_room"])
+  })
+
+  it("preserves explicit No room assignments", () => {
+    const result = resolveBookingDraft({
+      quantities: { u_double_room: 1 },
+      units: [
+        unit({
+          optionId: "opto_double",
+          optionUnitId: "u_double_room",
+          unitName: "Double room",
+          unitType: "room",
+        }),
+      ],
+      travelers: [
+        traveler({
+          role: "adult",
+          dateOfBirth: "1988-01-01",
+          roomUnitId: null,
+          roomUnitAssignmentSource: "none",
+        }),
+      ],
+      now: NOW,
+    })
+
+    expect(result.quantities).toEqual({ u_double_room: 1 })
+    expect(result.travelers[0]?.roomUnitId).toBeNull()
+  })
+})
+
+describe("travelersToRows", () => {
+  it("persists traveler category from DOB while keeping lead role separate", () => {
+    const rows = travelersToRows(
+      {
+        travelers: [
+          traveler({ role: "lead", dateOfBirth: "2017-06-01", roomUnitId: "u_child_6_12" }),
+        ],
+      },
+      NOW,
+    )
+
+    expect(rows[0]).toMatchObject({
+      isPrimary: true,
+      travelerCategory: "child",
+      roomUnitId: "u_child_6_12",
+    })
+  })
+})

--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -2824,6 +2824,12 @@ export const bookingsService = {
       productNameSnapshot: product.name,
       optionNameSnapshot: option?.name ?? null,
     } as const
+    const itemLineMetadata = (clientLineKey: string | null | undefined) => {
+      const slotMetadata = (slotFields.metadata ?? {}) as Record<string, unknown>
+      return clientLineKey
+        ? { ...slotMetadata, bookingCreateLineKey: clientLineKey }
+        : slotFields.metadata
+    }
 
     // Seeded line-item totals must match the booking's `sellAmountCents`
     // so checkout / payment / invoicing don't see a list-price item beneath
@@ -2853,6 +2859,7 @@ export const bookingsService = {
               ...productOptionSnapshot,
               unitNameSnapshot: unit.name,
               ...slotFields,
+              metadata: itemLineMetadata(line.clientLineKey),
             }
           })
         : unitsToSeed.length > 0

--- a/packages/bookings/src/validation.ts
+++ b/packages/bookings/src/validation.ts
@@ -217,6 +217,7 @@ export const convertProductSchema = z
     itemLines: z
       .array(
         z.object({
+          clientLineKey: z.string().min(1).max(255).optional().nullable(),
           optionId: z.string().min(1).optional().nullable(),
           optionUnitId: z.string().min(1),
           quantity: z.number().int().min(1),
@@ -224,6 +225,7 @@ export const convertProductSchema = z
           description: z.string().max(5000).optional().nullable(),
           unitSellAmountCents: z.number().int().min(0).optional().nullable(),
           totalSellAmountCents: z.number().int().min(0).optional().nullable(),
+          travelerIndexes: z.array(z.number().int().min(0)).optional().nullable(),
         }),
       )
       .optional(),

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -4,7 +4,7 @@ import {
   bookingsService,
 } from "@voyantjs/bookings"
 import type { Booking, BookingGroupMember, BookingTraveler } from "@voyantjs/bookings/schema"
-import { bookingItems, bookingTravelers } from "@voyantjs/bookings/schema"
+import { bookingItems, bookingItemTravelers, bookingTravelers } from "@voyantjs/bookings/schema"
 import { bookingStatusSchema } from "@voyantjs/bookings/validation"
 import type { EventBus } from "@voyantjs/core"
 import { eq } from "drizzle-orm"
@@ -41,11 +41,10 @@ const travelerInputSchema = z.object({
   preferredLanguage: z.string().max(35).optional().nullable(),
   specialRequests: z.string().optional().nullable(),
   /**
-   * option_unit_id the passenger is assigned to. Accepted by the input
-   * schema so the UI's PassengerListValue can round-trip, but not yet
-   * persisted — bookingTravelers has no room-assignment column and the
-   * allocation flow is owned by the items slice. Follow-up: add a traveler
-   * metadata JSONB or wire into booking_allocations.
+   * Legacy option_unit_id assignment from the create UI. The canonical
+   * persisted relationship is item-line applicability via
+   * booking_item_travelers, carried by itemLines[].travelerIndexes and
+   * extraLines[].travelerIndexes.
    */
   roomUnitId: z.string().optional().nullable(),
   isPrimary: z.boolean().optional().nullable(),
@@ -69,15 +68,18 @@ const documentGenerationInputSchema = z
   .default({ contractDocument: false, invoiceDocument: false })
 
 const itemLineInputSchema = z.object({
+  clientLineKey: z.string().min(1).max(255).optional().nullable(),
   optionUnitId: z.string().min(1),
   quantity: z.number().int().min(1),
   title: z.string().min(1).max(255).optional().nullable(),
   description: z.string().max(5000).optional().nullable(),
   unitSellAmountCents: z.number().int().min(0).optional().nullable(),
   totalSellAmountCents: z.number().int().min(0).optional().nullable(),
+  travelerIndexes: z.array(z.number().int().min(0)).optional().nullable(),
 })
 
 const extraLineInputSchema = z.object({
+  clientLineKey: z.string().min(1).max(255).optional().nullable(),
   productExtraId: z.string().min(1),
   optionExtraConfigId: z.string().min(1).optional().nullable(),
   name: z.string().min(1).max(255),
@@ -88,6 +90,7 @@ const extraLineInputSchema = z.object({
   sellCurrency: z.string().length(3),
   unitSellAmountCents: z.number().int().min(0).optional().nullable(),
   totalSellAmountCents: z.number().int().min(0).optional().nullable(),
+  travelerIndexes: z.array(z.number().int().min(0)).optional().nullable(),
 })
 
 const voucherRedemptionInputSchema = z.object({
@@ -434,6 +437,75 @@ function isAlreadyPaidSchedule(schedule: BookingCreatePaymentScheduleInput) {
   return schedule.status === "paid" || metadata?.alreadyPaid === true
 }
 
+function uniqueValidTravelerIndexes(
+  indexes: readonly number[] | null | undefined,
+  travelerCount: number,
+): number[] {
+  if (!indexes?.length) return []
+  const seen = new Set<number>()
+  const result: number[] = []
+  for (const index of indexes) {
+    if (index < 0 || index >= travelerCount || seen.has(index)) continue
+    seen.add(index)
+    result.push(index)
+  }
+  return result
+}
+
+function bookingCreateLineMetadata(clientLineKey: string | null | undefined) {
+  return clientLineKey ? { bookingCreateLineKey: clientLineKey } : {}
+}
+
+async function linkBookingCreateItemsToTravelers(
+  tx: PostgresJsDatabase,
+  bookingId: string,
+  travelers: readonly BookingTraveler[],
+  lines: ReadonlyArray<{
+    clientLineKey?: string | null
+    travelerIndexes?: readonly number[] | null
+  }>,
+) {
+  if (travelers.length === 0 || lines.length === 0) return
+  const requestedLinks = lines.flatMap((line) =>
+    uniqueValidTravelerIndexes(line.travelerIndexes, travelers.length).map((travelerIndex) => ({
+      clientLineKey: line.clientLineKey ?? null,
+      travelerIndex,
+    })),
+  )
+  if (requestedLinks.length === 0) return
+
+  const itemRows = await tx.select().from(bookingItems).where(eq(bookingItems.bookingId, bookingId))
+  const itemByClientLineKey = new Map<string, (typeof itemRows)[number]>()
+  for (const item of itemRows) {
+    const key = (item.metadata as { bookingCreateLineKey?: unknown } | null | undefined)
+      ?.bookingCreateLineKey
+    if (typeof key === "string") itemByClientLineKey.set(key, item)
+  }
+
+  const seen = new Set<string>()
+  const linkRows = requestedLinks.flatMap(({ clientLineKey, travelerIndex }) => {
+    if (!clientLineKey) return []
+    const item = itemByClientLineKey.get(clientLineKey)
+    const traveler = travelers[travelerIndex]
+    if (!item || !traveler) return []
+    const dedupeKey = `${item.id}:${traveler.id}`
+    if (seen.has(dedupeKey)) return []
+    seen.add(dedupeKey)
+    return [
+      {
+        bookingItemId: item.id,
+        travelerId: traveler.id,
+        role: "traveler" as const,
+        isPrimary: traveler.isPrimary,
+      },
+    ]
+  })
+
+  if (linkRows.length > 0) {
+    await tx.insert(bookingItemTravelers).values(linkRows)
+  }
+}
+
 function validatePaymentSchedules(
   input: BookingCreateInput,
   booking: Booking,
@@ -612,6 +684,7 @@ export async function createBooking(
               optionId: input.optionId ?? null,
               optionUnitId: null,
               metadata: {
+                ...bookingCreateLineMetadata(line.clientLineKey),
                 productExtraId: line.productExtraId,
                 optionExtraConfigId: line.optionExtraConfigId ?? null,
                 pricingMode: line.pricingMode ?? null,
@@ -622,8 +695,9 @@ export async function createBooking(
         )
       }
 
-      // 2. Travelers. roomUnitId is accepted on the input but not persisted
-      // yet — see travelerInputSchema for the follow-up note.
+      // 2. Travelers. Item/extra line applicability is persisted after
+      // traveler rows exist because the create payload addresses travelers
+      // by stable array index within this transaction.
       const travelers: BookingTraveler[] = []
       for (const traveler of input.travelers ?? []) {
         const [row] = await tx
@@ -645,6 +719,11 @@ export async function createBooking(
           .returning()
         if (row) travelers.push(row)
       }
+
+      await linkBookingCreateItemsToTravelers(tx, booking.id, travelers, [
+        ...(input.itemLines ?? []),
+        ...(input.extraLines ?? []),
+      ])
 
       // 3. Payment schedules
       const paymentSchedules: BookingPaymentSchedule[] = []

--- a/packages/finance/tests/integration/booking-create.test.ts
+++ b/packages/finance/tests/integration/booking-create.test.ts
@@ -1,4 +1,10 @@
-import { bookingGroups, bookingItems, bookings, bookingTravelers } from "@voyantjs/bookings/schema"
+import {
+  bookingGroups,
+  bookingItems,
+  bookingItemTravelers,
+  bookings,
+  bookingTravelers,
+} from "@voyantjs/bookings/schema"
 import { createEventBus } from "@voyantjs/core"
 import { eq, sql } from "drizzle-orm"
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
@@ -30,6 +36,7 @@ async function resetTables(
     "payment_instruments",
     "booking_payment_schedules",
     "booking_allocations",
+    "booking_item_travelers",
     "booking_travelers",
     "booking_group_members",
     "booking_groups",
@@ -500,6 +507,67 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
       [unitId, 2],
       [secondUnitId, 1],
     ])
+  })
+
+  it("links explicit item and per-person extra lines to travelers", async () => {
+    const { productId, unitId } = await seedProduct()
+
+    const outcome = await createBooking(db, {
+      productId,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+      travelers: [
+        {
+          firstName: "Alice",
+          lastName: "Lead",
+          email: "alice@example.com",
+          participantType: "traveler",
+          isPrimary: true,
+        },
+        {
+          firstName: "Child",
+          lastName: "Traveler",
+          participantType: "traveler",
+          travelerCategory: "child",
+        },
+      ],
+      itemLines: [
+        {
+          clientLineKey: `unit:${unitId}`,
+          optionUnitId: unitId,
+          quantity: 2,
+          title: "Adult",
+          travelerIndexes: [0, 1],
+        },
+      ],
+      extraLines: [
+        {
+          clientLineKey: "extra:lunch",
+          productExtraId: "lunch",
+          name: "Lunch",
+          pricingMode: "per_person",
+          pricedPerPerson: true,
+          quantity: 2,
+          sellCurrency: "EUR",
+          unitSellAmountCents: 1000,
+          totalSellAmountCents: 2000,
+          travelerIndexes: [0, 1],
+        },
+      ],
+    })
+
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+
+    const links = await db
+      .select()
+      .from(bookingItemTravelers)
+      .where(sql`${bookingItemTravelers.bookingItemId} IN (
+        SELECT ${bookingItems.id}
+        FROM ${bookingItems}
+        WHERE ${bookingItems.bookingId} = ${outcome.result.booking.id}
+      )`)
+    expect(links).toHaveLength(4)
   })
 
   it("redeems voucher and decrements remaining balance", async () => {

--- a/packages/finance/tests/unit/validation-booking-create.test.ts
+++ b/packages/finance/tests/unit/validation-booking-create.test.ts
@@ -47,8 +47,28 @@ describe("bookingCreateSchema", () => {
         invoiceDocument: true,
       },
       itemLines: [
-        { optionUnitId: "opun_dbl", quantity: 2, title: "Double room" },
+        {
+          clientLineKey: "unit:opun_dbl",
+          optionUnitId: "opun_dbl",
+          quantity: 2,
+          title: "Double room",
+          travelerIndexes: [0],
+        },
         { optionUnitId: "opun_sgl", quantity: 1, title: "Single room" },
+      ],
+      extraLines: [
+        {
+          clientLineKey: "extra:lunch",
+          productExtraId: "lunch",
+          name: "Lunch",
+          pricingMode: "per_person",
+          pricedPerPerson: true,
+          quantity: 1,
+          sellCurrency: "EUR",
+          unitSellAmountCents: 1000,
+          totalSellAmountCents: 1000,
+          travelerIndexes: [0],
+        },
       ],
       paymentSchedules: [
         {
@@ -68,6 +88,8 @@ describe("bookingCreateSchema", () => {
     })
 
     expect(result.itemLines).toHaveLength(2)
+    expect(result.itemLines?.[0]?.travelerIndexes).toEqual([0])
+    expect(result.extraLines?.[0]?.clientLineKey).toBe("extra:lunch")
     expect(result.documentGeneration?.invoiceDocument).toBe(true)
     expect(result.paymentSchedules?.[0]?.status).toBe("paid")
   })


### PR DESCRIPTION
## Summary

- adds a shared booking draft resolver for booking-create traveler unit assignment
- separates traveler age/pricing bands, sellable option units, accommodation room assignment, and explicit no-room intent
- derives adult/child/infant quantities for person-priced excursions from travelers, while preserving room/accommodation quantities for multi-day products
- normalizes per-person extras to charged traveler quantity and carries explicit traveler applicability through submit
- persists booking-create option and extra applicability through `booking_item_travelers` using stable client line keys
- documents the booking journey invariant so future changes do not collapse person pricing and room assignment again

## Root Cause

`roomUnitId` was doing too many jobs: person-priced unit, room/accommodation assignment, and explicit no-room state. That let one-day excursions keep stale Adult assignments, made preview and submit disagree, and gave the backend no durable way to know which travelers a selected option or per-person extra applied to.

## Fix Shape

The UI now resolves booking drafts through one shared resolver before both preview and submit. The submit payload carries `clientLineKey` plus `travelerIndexes` for selected option and extra lines. Bookings/finance validation accepts those fields, and finance booking creation links the resulting `booking_items` to concrete travelers in `booking_item_travelers`.

This keeps excursions and accommodation trips on the same model: travelers have age/pricing intent, options/extras are sellable items, rooms are only rooms when the product has accommodation, and no-room is explicit intent rather than a fake room value.

## Validation

- `pnpm --filter @voyantjs/bookings-ui lint`
- `pnpm --filter @voyantjs/bookings-react lint`
- `pnpm --filter @voyantjs/bookings lint`
- `pnpm --filter @voyantjs/finance lint`
- `pnpm --filter @voyantjs/bookings-ui typecheck`
- `pnpm --filter @voyantjs/bookings-react typecheck`
- `pnpm --filter @voyantjs/bookings typecheck`
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/bookings-ui test`
- `pnpm --filter @voyantjs/finance test -- tests/unit/validation-booking-create.test.ts`
- `pnpm --filter @voyantjs/bookings test -- tests/unit/service-convert-product.test.ts tests/unit/validation-participants-items.test.ts`
- pre-commit hook: changed-file quality, repo lint, repo typecheck
- pre-push hook: repo test lane

Refs #1262