### PR TITLE
Reject booking draft resolver mismatches

### DIFF
--- a/packages/bookings-ui/src/components/booking-create-dialog.tsx
+++ b/packages/bookings-ui/src/components/booking-create-dialog.tsx
@@ -21,6 +21,7 @@ import {
   type BookingRecord,
   useBookingCreateMutation,
   useBookingTaxPreview,
+  VoyantApiError,
 } from "@voyantjs/bookings-react"
 import { useOrganization, usePerson } from "@voyantjs/crm-react"
 import { type ProductExtraRecord, useProductExtras } from "@voyantjs/extras-react"
@@ -229,6 +230,50 @@ function sameRoomUnits(left: OptionUnitsStepperUnit[], right: OptionUnitsStepper
   })
 }
 
+interface PayloadResolverMismatch {
+  kind: "qty" | "missing" | "extra"
+  optionUnitId: string
+  submittedQuantity: number
+  resolvedQuantity: number
+}
+
+function isPayloadResolverMismatchBody(
+  body: unknown,
+): body is { code: "payload_resolver_mismatch"; mismatches: PayloadResolverMismatch[] } {
+  if (typeof body !== "object" || body === null) return false
+  const candidate = body as { code?: unknown; mismatches?: unknown }
+  return (
+    candidate.code === "payload_resolver_mismatch" &&
+    Array.isArray(candidate.mismatches) &&
+    candidate.mismatches.every((mismatch) => {
+      if (typeof mismatch !== "object" || mismatch === null) return false
+      const item = mismatch as Record<string, unknown>
+      return (
+        (item.kind === "qty" || item.kind === "missing" || item.kind === "extra") &&
+        typeof item.optionUnitId === "string" &&
+        typeof item.submittedQuantity === "number" &&
+        typeof item.resolvedQuantity === "number"
+      )
+    })
+  )
+}
+
+function formatPayloadResolverMismatchError(
+  body: { mismatches: PayloadResolverMismatch[] },
+  unitLabels: Record<string, string>,
+) {
+  const details = body.mismatches
+    .map((mismatch) => {
+      const label = unitLabels[mismatch.optionUnitId] ?? mismatch.optionUnitId
+      return `${label}: sent ${mismatch.submittedQuantity}, expected ${mismatch.resolvedQuantity}`
+    })
+    .join("; ")
+
+  return details
+    ? `Booking options are out of sync. Review these lines: ${details}.`
+    : "Booking options are out of sync. Review the selected traveler and option lines."
+}
+
 export interface BookingCreateDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -331,6 +376,7 @@ export function BookingCreateForm({
   // bundle. Defaults on so the operator opts out, not in.
   const [notifyTraveler, setNotifyTraveler] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
+  const [payloadMismatchUnitIds, setPayloadMismatchUnitIds] = React.useState<string[]>([])
   const { formatDate } = useBookingsUiI18nOrDefault()
   const messages = useBookingsUiMessagesOrDefault()
   const availabilityClient = useVoyantAvailabilityContext()
@@ -363,6 +409,7 @@ export function BookingCreateForm({
       setCreateAsDraft(false)
       setNotifyTraveler(true)
       setError(null)
+      setPayloadMismatchUnitIds([])
     } else if (resolvedDefaultProductId) {
       setProduct((prev) => {
         const optionId = defaultSlotId
@@ -385,6 +432,7 @@ export function BookingCreateForm({
     setRoomUnits([])
     setSharedRoom(emptySharedRoomValue)
     setExtraLines([])
+    setPayloadMismatchUnitIds([])
   }, [product.productId, defaultSlotId])
 
   const [slotsFromIso, setSlotsFromIso] = React.useState(() => new Date().toISOString())
@@ -419,6 +467,7 @@ export function BookingCreateForm({
   )
   const setSelectedSlot = React.useCallback(
     (nextSlotId: string | null) => {
+      setPayloadMismatchUnitIds([])
       const selectedSlot = nextSlotId ? allOpenSlots.find((slot) => slot.id === nextSlotId) : null
       if (selectedSlot?.optionId && selectedSlot.optionId !== product.optionId) {
         setProduct((prev) => ({ ...prev, optionId: selectedSlot.optionId }))
@@ -430,6 +479,7 @@ export function BookingCreateForm({
   React.useEffect(() => {
     setRooms(emptyOptionUnitsStepperValue)
     setRoomUnits([])
+    setPayloadMismatchUnitIds([])
     if (!slotId || !product.optionId) return
     const selectedDeparture =
       allOpenSlots.find((slot) => slot.id === slotId) ??
@@ -660,6 +710,7 @@ export function BookingCreateForm({
 
   const handleSubmit = async () => {
     setError(null)
+    setPayloadMismatchUnitIds([])
 
     if (!product.productId) {
       setError(messages.bookingCreateDialog.validation.selectProduct)
@@ -886,6 +937,13 @@ export function BookingCreateForm({
 
       onCreated?.(booking)
     } catch (err) {
+      if (err instanceof VoyantApiError && isPayloadResolverMismatchBody(err.body)) {
+        setPayloadMismatchUnitIds(
+          Array.from(new Set(err.body.mismatches.map((mismatch) => mismatch.optionUnitId))),
+        )
+        setError(formatPayloadResolverMismatchError(err.body, roomUnitLabels))
+        return
+      }
       setError(
         err instanceof Error ? err.message : messages.bookingCreateDialog.validation.createFailed,
       )
@@ -901,7 +959,10 @@ export function BookingCreateForm({
         <div className="flex flex-1 flex-col gap-4 overflow-y-auto px-1 pb-2">
           <ProductPickerSection
             value={product}
-            onChange={setProduct}
+            onChange={(next) => {
+              setPayloadMismatchUnitIds([])
+              setProduct(next)
+            }}
             enabled={enabled}
             lockProduct={Boolean(defaultProductId || defaultSlotId)}
             labels={{
@@ -932,7 +993,10 @@ export function BookingCreateForm({
           {product.productId && slotId ? (
             <OptionUnitsStepperSection
               value={rooms}
-              onChange={setRooms}
+              onChange={(next) => {
+                setPayloadMismatchUnitIds([])
+                setRooms(next)
+              }}
               productId={product.productId}
               slotId={slotId}
               optionId={product.optionId}
@@ -943,6 +1007,7 @@ export function BookingCreateForm({
                 !selectedSlot?.unlimited &&
                 typeof selectedSlot?.remainingPax === "number"
               }
+              invalidOptionUnitIds={payloadMismatchUnitIds}
               labels={{
                 heading: messages.bookingCreateDialog.labels.roomsHeading,
                 noOption: messages.bookingCreateDialog.labels.roomsNoOption,
@@ -1010,7 +1075,10 @@ export function BookingCreateForm({
           {product.productId && slotId ? (
             <TravelersSection
               value={travelers}
-              onChange={setTravelers}
+              onChange={(next) => {
+                setPayloadMismatchUnitIds([])
+                setTravelers(next)
+              }}
               roomUnits={roomUnitOptions.length > 0 ? roomUnitOptions : undefined}
               roomGroups={roomGroups.length > 0 ? roomGroups : undefined}
               billingPersonId={(person.billTo ?? "person") === "person" ? person.personId : null}

--- a/packages/bookings-ui/src/components/option-units-stepper-section.tsx
+++ b/packages/bookings-ui/src/components/option-units-stepper-section.tsx
@@ -64,8 +64,10 @@ export interface OptionUnitsStepperSectionProps {
     remaining?: string
     unlimited?: string
     fillsSlotCapacity?: string
+    reviewLine?: string
   }
   slotHasFiniteCapacity?: boolean
+  invalidOptionUnitIds?: readonly string[]
 }
 
 /**
@@ -98,6 +100,7 @@ export function OptionUnitsStepperSection({
   onUnitsChange,
   labels,
   slotHasFiniteCapacity = false,
+  invalidOptionUnitIds = [],
 }: OptionUnitsStepperSectionProps) {
   const productsClient = useVoyantProductsContext()
   const messages = useBookingsUiMessagesOrDefault()
@@ -184,6 +187,10 @@ export function OptionUnitsStepperSection({
   const units = React.useMemo(
     () => mergeStepperUnits(availabilityUnitRows, optionUnitRows, slotOptionId, Boolean(slotId)),
     [availabilityUnitRows, optionUnitRows, slotOptionId, slotId],
+  )
+  const invalidOptionUnitIdSet = React.useMemo(
+    () => new Set(invalidOptionUnitIds),
+    [invalidOptionUnitIds],
   )
 
   React.useEffect(() => {
@@ -272,6 +279,7 @@ export function OptionUnitsStepperSection({
       <div className="flex flex-col gap-2">
         {optionRows.map(({ optionKey, optionName, primary, allUnits, totalRemaining }) => {
           const qty = value.quantities[primary.optionUnitId] ?? 0
+          const isInvalid = optionRowHasInvalidUnit(allUnits, invalidOptionUnitIdSet)
           const remainingLabel = resolveOptionRemainingLabel({
             totalRemaining,
             units: allUnits,
@@ -283,9 +291,22 @@ export function OptionUnitsStepperSection({
           const atMax = totalRemaining !== null && qty >= totalRemaining
 
           return (
-            <div key={optionKey} className="flex items-center gap-3 rounded-md border px-3 py-2">
+            <div
+              key={optionKey}
+              className={`flex items-center gap-3 rounded-md border px-3 py-2 ${
+                isInvalid ? "border-destructive/70 bg-destructive/5 ring-1 ring-destructive/20" : ""
+              }`}
+              aria-invalid={isInvalid ? true : undefined}
+            >
               <div className="flex-1">
-                <div className="text-sm font-medium">{optionName}</div>
+                <div className="flex flex-wrap items-center gap-2 text-sm font-medium">
+                  <span>{optionName}</span>
+                  {isInvalid ? (
+                    <span className="rounded-sm bg-destructive/10 px-1.5 py-0.5 text-[10px] font-medium text-destructive">
+                      {merged.reviewLine}
+                    </span>
+                  ) : null}
+                </div>
                 <div className="text-xs text-muted-foreground">{remainingLabel}</div>
               </div>
               <div className="flex items-center gap-2">
@@ -341,6 +362,13 @@ export function resolveOptionRemainingLabel({
     return fillsSlotCapacity ?? unlimited
   }
   return unlimited
+}
+
+export function optionRowHasInvalidUnit(
+  units: ReadonlyArray<Pick<OptionUnitsStepperUnit, "optionUnitId">>,
+  invalidOptionUnitIds: ReadonlySet<string>,
+) {
+  return units.some((unit) => invalidOptionUnitIds.has(unit.optionUnitId))
 }
 
 /**

--- a/packages/bookings-ui/src/i18n/en.ts
+++ b/packages/bookings-ui/src/i18n/en.ts
@@ -490,6 +490,7 @@ export const bookingsUiEn = {
       fillsSlotCapacity: "fills slot capacity",
       decreaseUnitPrefix: "Decrease",
       increaseUnitPrefix: "Increase",
+      reviewLine: "Review this line",
     },
   },
   sharedRoomSection: {

--- a/packages/bookings-ui/src/i18n/messages.ts
+++ b/packages/bookings-ui/src/i18n/messages.ts
@@ -447,6 +447,7 @@ export type BookingsUiMessages = {
       fillsSlotCapacity: string
       decreaseUnitPrefix: string
       increaseUnitPrefix: string
+      reviewLine: string
     }
   }
   sharedRoomSection: {

--- a/packages/bookings-ui/src/i18n/ro.ts
+++ b/packages/bookings-ui/src/i18n/ro.ts
@@ -489,6 +489,7 @@ export const bookingsUiRo = {
       fillsSlotCapacity: "umple capacitatea plecarii",
       decreaseUnitPrefix: "Scade",
       increaseUnitPrefix: "Creste",
+      reviewLine: "Verifica aceasta linie",
     },
   },
   sharedRoomSection: {

--- a/packages/bookings-ui/tests/unit/option-units-stepper-merge.test.ts
+++ b/packages/bookings-ui/tests/unit/option-units-stepper-merge.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   mergeStepperUnits,
   type OptionUnitsStepperUnit,
+  optionRowHasInvalidUnit,
   resolveOptionRemainingLabel,
   resolveSlotOptionId,
 } from "../../src/components/option-units-stepper-section.js"
@@ -136,5 +137,24 @@ describe("resolveOptionRemainingLabel", () => {
         fillsSlotCapacity: "fills slot capacity",
       }),
     ).toBe("43 left")
+  })
+})
+
+describe("optionRowHasInvalidUnit", () => {
+  it("matches any unit in a grouped option row, not just the primary unit", () => {
+    expect(
+      optionRowHasInvalidUnit(
+        [
+          { optionUnitId: "adult" },
+          { optionUnitId: "child" },
+          { optionUnitId: "infant" },
+        ],
+        new Set(["child"]),
+      ),
+    ).toBe(true)
+  })
+
+  it("returns false when no grouped unit is affected", () => {
+    expect(optionRowHasInvalidUnit([{ optionUnitId: "adult" }], new Set(["single"]))).toBe(false)
   })
 })

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -282,6 +282,7 @@ export type {
   BookingCreatedEvent,
   BookingCreateInput,
   BookingCreateOutcome,
+  BookingCreateRejectedEvent,
   BookingCreateResult,
   BookingCreateRuntime,
   BookingCreateTravelerInput,

--- a/packages/finance/src/routes-booking-create.ts
+++ b/packages/finance/src/routes-booking-create.ts
@@ -53,6 +53,15 @@ const createBookingRoutes = new Hono<{
           },
           400,
         )
+      case "payload_resolver_mismatch":
+        return c.json(
+          {
+            error: "Booking payload does not match the resolved draft",
+            code: "payload_resolver_mismatch",
+            mismatches: outcome.mismatches,
+          },
+          400,
+        )
       case "product_not_found":
         return c.json({ error: "Product not found or unavailable" }, 404)
       case "voucher_not_found":
@@ -103,6 +112,16 @@ const createBookingRoutes = new Hono<{
             ...body,
             error: `${which}: invalid payment schedules`,
             issues: reason.issues,
+          },
+          400,
+        )
+      case "payload_resolver_mismatch":
+        return c.json(
+          {
+            ...body,
+            error: `${which}: booking payload does not match the resolved draft`,
+            code: "payload_resolver_mismatch",
+            mismatches: reason.mismatches,
           },
           400,
         )

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -4,6 +4,7 @@ import {
   bookingsService,
 } from "@voyantjs/bookings"
 import {
+  type BookingDraftMismatch,
   type PricingAssignmentUnit,
   verifyBookingDraft,
 } from "@voyantjs/bookings/pricing-assignment"
@@ -361,6 +362,18 @@ export interface BookingCreatedEvent {
   occurredAt: Date
 }
 
+export interface BookingCreateRejectedEvent {
+  reason: "payload_resolver_mismatch"
+  productId: string
+  optionId: string | null
+  slotId: string | null
+  bookingNumber: string
+  mismatchCount: number
+  mismatches: BookingDraftMismatch[]
+  createdByUserId: string | null
+  occurredAt: Date
+}
+
 // ---------- result shape ----------
 
 export interface BookingCreateResult {
@@ -391,6 +404,7 @@ export interface BookingCreateValidationIssue {
 export type BookingCreateOutcome =
   | { status: "ok"; result: BookingCreateResult }
   | { status: "invalid_payment_schedules"; issues: BookingCreateValidationIssue[] }
+  | { status: "payload_resolver_mismatch"; mismatches: BookingDraftMismatch[] }
   | { status: "product_not_found" }
   | { status: "voucher_not_found" }
   | { status: "voucher_inactive" }
@@ -428,6 +442,16 @@ class BookingCreateAbort extends Error {
   constructor(readonly outcome: Exclude<BookingCreateOutcome, { status: "ok" }>) {
     super(`create aborted: ${outcome.status}`)
     this.name = "BookingCreateAbort"
+  }
+}
+
+class BookingCreateValidationError extends Error {
+  constructor(
+    readonly code: "payload_resolver_mismatch",
+    readonly mismatches: BookingDraftMismatch[],
+  ) {
+    super(code)
+    this.name = "BookingCreateValidationError"
   }
 }
 
@@ -488,11 +512,28 @@ async function loadProductOptionUnits(
   }))
 }
 
+function hasResolverRejectionSignals(input: {
+  travelers: NonNullable<BookingCreateInput["travelers"]>
+  itemLines: NonNullable<BookingCreateInput["itemLines"]>
+}) {
+  return (
+    input.travelers.every(
+      (traveler) =>
+        traveler.travelerCategory === "adult" ||
+        traveler.travelerCategory === "child" ||
+        traveler.travelerCategory === "infant",
+    ) &&
+    input.itemLines.every(
+      (line) => Array.isArray(line.travelerIndexes) && line.travelerIndexes.length > 0,
+    )
+  )
+}
+
 /**
  * Re-runs `resolveBookingDraft` against the submitted payload and
- * logs any mismatches between submitted itemLines quantities and
- * what the resolver would derive. Log-only for now — see the
- * inline note at the call site.
+ * rejects mismatches between submitted itemLines quantities and
+ * what the resolver would derive when the request carries the
+ * traveler band + line assignment metadata the verifier needs.
  */
 async function verifyBookingCreatePayload(tx: PostgresJsDatabase, input: BookingCreateInput) {
   const itemLines = input.itemLines ?? []
@@ -507,10 +548,14 @@ async function verifyBookingCreatePayload(tx: PostgresJsDatabase, input: Booking
   })
 
   if (!verification.ok) {
-    console.warn(
-      `[bookings/create] payload drift for product=${input.productId}`,
-      JSON.stringify(verification.mismatches),
-    )
+    if (!hasResolverRejectionSignals({ travelers, itemLines })) {
+      console.warn(
+        `[bookings/create] payload drift skipped hard rejection for product=${input.productId}`,
+        JSON.stringify(verification.mismatches),
+      )
+      return
+    }
+    throw new BookingCreateValidationError("payload_resolver_mismatch", verification.mismatches)
   }
 }
 
@@ -827,21 +872,10 @@ export async function createBooking(
         ...(input.extraLines ?? []),
       ])
 
-      // 2c. Log-only verification: re-run the resolver server-side
-      // against the submitted itemLines + travelers to surface any
-      // client/server drift on the per-band quantities. Useful for
-      // catching #1262-class bugs in flight without rejecting
-      // payloads — a follow-up will flip this to a hard rejection
-      // once we've observed real traffic and confirmed no legitimate
-      // clients trip the warning. See voyantjs/voyant#1267.
-      try {
-        await verifyBookingCreatePayload(tx, input)
-      } catch (error) {
-        // Verification is best-effort; never block a booking commit
-        // because of a verifier exception (e.g. catalog query
-        // failure). Surface the unexpected case for observability.
-        console.warn("[bookings/create] verifier threw", error)
-      }
+      // 2c. Re-run the resolver server-side against the submitted
+      // itemLines + travelers and reject any client/server drift on
+      // per-band quantities. See voyantjs/voyant#1272.
+      await verifyBookingCreatePayload(tx, input)
 
       // 3. Payment schedules
       const paymentSchedules: BookingPaymentSchedule[] = []
@@ -948,6 +982,24 @@ export async function createBooking(
   } catch (error) {
     if (error instanceof BookingCreateAbort) {
       return error.outcome
+    }
+    if (error instanceof BookingCreateValidationError) {
+      await runtime?.eventBus?.emit(
+        "booking_create.rejected",
+        {
+          reason: error.code,
+          productId: input.productId,
+          optionId: input.optionId ?? null,
+          slotId: input.slotId ?? null,
+          bookingNumber: input.bookingNumber,
+          mismatchCount: error.mismatches.length,
+          mismatches: error.mismatches,
+          createdByUserId: userId ?? null,
+          occurredAt: new Date(),
+        } satisfies BookingCreateRejectedEvent,
+        { category: "internal", source: "service" },
+      )
+      return { status: error.code, mismatches: error.mismatches }
     }
     if (error instanceof VoucherServiceError) {
       if (error.code === "voucher_not_found") return { status: "voucher_not_found" }

--- a/packages/finance/tests/integration/booking-create.test.ts
+++ b/packages/finance/tests/integration/booking-create.test.ts
@@ -90,7 +90,13 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
     await closeTestDb()
   })
 
-  async function seedProduct({ pax = 2 }: { pax?: number | null } = {}) {
+  async function seedProduct({
+    pax = 2,
+    ageBandedUnits = false,
+  }: {
+    pax?: number | null
+    ageBandedUnits?: boolean
+  } = {}) {
     productSeq += 1
     // Raw SQL keeps this free of a cross-package schema import. The booking-
     // create path only needs products + a default option + one option_unit;
@@ -99,6 +105,8 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
     const productId = `prod_bc_${productSeq}`
     const optionId = `popt_bc_${productSeq}`
     const unitId = `opun_bc_${productSeq}`
+    const childUnitId = `opun_bc_${productSeq}_child`
+    const infantUnitId = `opun_bc_${productSeq}_infant`
     const itineraryId = `piti_bc_${productSeq}`
     await db.execute(sql`
       INSERT INTO products (id, name, sell_currency, sell_amount_cents, cost_amount_cents, margin_percent, start_date, end_date, pax)
@@ -119,9 +127,28 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
       VALUES (${optionId}, ${productId}, 'Standard', 'active', true, 0)
     `)
     await db.execute(sql`
-      INSERT INTO option_units (id, option_id, name, unit_type, is_required, min_quantity, sort_order)
-      VALUES (${unitId}, ${optionId}, 'Adult', 'person', true, 1, 0)
+      INSERT INTO option_units (id, option_id, name, code, unit_type, min_age, max_age, is_required, min_quantity, sort_order)
+      VALUES (
+        ${unitId},
+        ${optionId},
+        'Adult',
+        ${ageBandedUnits ? "ADULT" : null},
+        'person',
+        ${ageBandedUnits ? 13 : null},
+        null,
+        true,
+        1,
+        0
+      )
     `)
+    if (ageBandedUnits) {
+      await db.execute(sql`
+        INSERT INTO option_units (id, option_id, name, code, unit_type, min_age, max_age, is_required, min_quantity, sort_order)
+        VALUES
+          (${childUnitId}, ${optionId}, 'Child 6-12', 'CHILD', 'person', 6, 12, false, 0, 1),
+          (${infantUnitId}, ${optionId}, 'Infant 0-5', 'INFANT', 'person', 0, 5, false, 0, 2)
+      `)
+    }
     await db.execute(sql`
       INSERT INTO product_itineraries (id, product_id, name, is_default, sort_order)
       VALUES (${itineraryId}, ${productId}, 'Default', true, 0)
@@ -131,7 +158,7 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
       VALUES (${`ptix_bc_${productSeq}`}, ${productId}, 'per_item', 'qr_code', false)
     `)
 
-    return { productId, optionId, unitId }
+    return { productId, optionId, unitId, childUnitId, infantUnitId }
   }
 
   async function seedVoucher(
@@ -571,6 +598,162 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
         WHERE ${bookingItems.bookingId} = ${outcome.result.booking.id}
       )`)
     expect(links).toHaveLength(4)
+  })
+
+  it("rejects booking-create payloads that drift from the server draft resolver", async () => {
+    const { productId, unitId, childUnitId, infantUnitId } = await seedProduct({
+      ageBandedUnits: true,
+    })
+    const eventBus = createEventBus()
+    const rejectedEvents: unknown[] = []
+    eventBus.subscribe("booking_create.rejected", (event) => {
+      rejectedEvents.push(event)
+    })
+
+    const outcome = await createBooking(
+      db,
+      {
+        productId,
+        bookingNumber: nextBookingNumber(),
+        ...bookingParty(),
+        travelers: [
+          {
+            firstName: "Alice",
+            lastName: "Lead",
+            email: "alice@example.com",
+            participantType: "traveler",
+            travelerCategory: "adult",
+            isPrimary: true,
+          },
+          {
+            firstName: "Child",
+            lastName: "Traveler",
+            participantType: "traveler",
+            travelerCategory: "child",
+          },
+          {
+            firstName: "Infant",
+            lastName: "Traveler",
+            participantType: "traveler",
+            travelerCategory: "infant",
+          },
+        ],
+        itemLines: [
+          {
+            clientLineKey: `unit:${unitId}`,
+            optionUnitId: unitId,
+            quantity: 3,
+            title: "Adult",
+            travelerIndexes: [0, 1, 2],
+          },
+        ],
+      },
+      { runtime: { eventBus }, userId: "usrp_tester" },
+    )
+
+    expect(outcome.status).toBe("payload_resolver_mismatch")
+    if (outcome.status !== "payload_resolver_mismatch") return
+    expect(outcome.mismatches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          optionUnitId: unitId,
+          submittedQuantity: 3,
+          resolvedQuantity: 1,
+        }),
+        expect.objectContaining({
+          optionUnitId: childUnitId,
+          submittedQuantity: 0,
+          resolvedQuantity: 1,
+        }),
+        expect.objectContaining({
+          optionUnitId: infantUnitId,
+          submittedQuantity: 0,
+          resolvedQuantity: 1,
+        }),
+      ]),
+    )
+    expect(await db.select().from(bookings)).toHaveLength(0)
+    expect(await db.select().from(bookingTravelers)).toHaveLength(0)
+    expect(await db.select().from(bookingItems)).toHaveLength(0)
+
+    expect(rejectedEvents).toHaveLength(1)
+    const event = rejectedEvents[0] as {
+      name: string
+      data: {
+        reason: string
+        productId: string
+        mismatchCount: number
+        createdByUserId: string | null
+      }
+      metadata?: { category?: string; source?: string }
+    }
+    expect(event.name).toBe("booking_create.rejected")
+    expect(event.data.reason).toBe("payload_resolver_mismatch")
+    expect(event.data.productId).toBe(productId)
+    expect(event.data.mismatchCount).toBeGreaterThan(0)
+    expect(event.data.createdByUserId).toBe("usrp_tester")
+    expect(event.metadata).toMatchObject({ category: "internal", source: "service" })
+  })
+
+  it("keeps accepting legacy age-banded item lines without traveler assignment metadata", async () => {
+    const { productId, unitId, childUnitId, infantUnitId } = await seedProduct({
+      ageBandedUnits: true,
+    })
+
+    const outcome = await createBooking(db, {
+      productId,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+      travelers: [
+        {
+          firstName: "Alice",
+          lastName: "Lead",
+          email: "alice@example.com",
+          participantType: "traveler",
+          isPrimary: true,
+        },
+        {
+          firstName: "Child",
+          lastName: "Traveler",
+          participantType: "traveler",
+        },
+        {
+          firstName: "Infant",
+          lastName: "Traveler",
+          participantType: "traveler",
+        },
+      ],
+      itemLines: [
+        {
+          optionUnitId: unitId,
+          quantity: 1,
+          title: "Adult",
+        },
+        {
+          optionUnitId: childUnitId,
+          quantity: 1,
+          title: "Child",
+        },
+        {
+          optionUnitId: infantUnitId,
+          quantity: 1,
+          title: "Infant",
+        },
+      ],
+    })
+
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+
+    const itemRows = await db
+      .select()
+      .from(bookingItems)
+      .where(eq(bookingItems.bookingId, outcome.result.booking.id))
+    expect(itemRows.map((item) => [item.optionUnitId, item.quantity])).toEqual([
+      [unitId, 1],
+      [childUnitId, 1],
+      [infantUnitId, 1],
+    ])
   })
 
   it("redeems voucher and decrements remaining balance", async () => {


### PR DESCRIPTION
## Summary

- Flip booking-create draft verification from warning-only to a structured `payload_resolver_mismatch` rejection when the request includes complete traveler band and line assignment metadata.
- Keep under-specified legacy payloads non-blocking while still logging resolver drift for observability.
- Emit `booking_create.rejected` for hard payload resolver rejections so ops can monitor spikes after rollout.
- Return mismatch details from single and dual booking-create routes so clients can identify affected option-unit lines.
- Surface the structured mismatch in the operator booking-create dialog with per-line submitted vs expected quantities and highlight affected option rows in the stepper.
- Add finance integration coverage for resolver drift rejection, rejection event emission, and legacy age-banded payload compatibility; add bookings UI coverage for grouped-row mismatch highlighting.

Closes #1272.

## Verification

- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/bookings-ui typecheck`
- `pnpm --filter @voyantjs/finance lint`
- `pnpm --filter @voyantjs/bookings-ui lint`
- `pnpm --filter @voyantjs/finance test -- tests/integration/booking-create.test.ts` (DB-gated integration tests skipped without `TEST_DATABASE_URL`)
- `pnpm --filter @voyantjs/bookings-ui test -- tests/unit/option-units-stepper-merge.test.ts`
- Pre-push `pnpm test` lane passed before the final focused compatibility/event/UI updates