### PR TITLE
Split traveler unit assignments

### DIFF
--- a/.changeset/split-traveler-unit-assignments.md
+++ b/.changeset/split-traveler-unit-assignments.md
@@ -1,0 +1,7 @@
+---
+"@voyantjs/bookings": patch
+"@voyantjs/bookings-ui": patch
+"@voyantjs/ui": patch
+---
+
+Split booking traveler draft unit assignment into separate pricing and inventory unit fields.

--- a/apps/registry/public/r/voyant-bookings-travelers-section.json
+++ b/apps/registry/public/r/voyant-bookings-travelers-section.json
@@ -8,7 +8,7 @@
   "files": [
     {
       "path": "registry/bookings/travelers-section.tsx",
-      "content": "export {\n  createBlankTraveler,\n  emptyTravelerListValue,\n  type RoomUnitOption,\n  type TravelerEntry,\n  type TravelerListValue,\n  type TravelerRole,\n  TravelersSection,\n  type TravelersSectionProps,\n} from \"@voyantjs/bookings-ui\"\n",
+      "content": "export {\n  createBlankTraveler,\n  emptyTravelerListValue,\n  type RoomUnitOption,\n  type TravelerEntry,\n  type TravelerListValue,\n  type TravelerRole,\n  TravelersSection,\n  type TravelersSectionProps,\n  type TravelerUnitAssignmentSource,\n} from \"@voyantjs/bookings-ui\"\n",
       "type": "registry:component",
       "target": "components/voyant/bookings/travelers-section.tsx"
     }

--- a/packages/bookings-react/src/hooks/use-booking-create-mutation.ts
+++ b/packages/bookings-react/src/hooks/use-booking-create-mutation.ts
@@ -19,10 +19,12 @@ export interface BookingCreateTravelerInput {
   preferredLanguage?: string | null
   specialRequests?: string | null
   /**
-   * option_unit_id of the room the traveler is assigned to. Round-trips
-   * from the UI TravelersSection even though the server currently doesn't
-   * persist it — the follow-up that adds a traveler→room link will pick it
-   * up without the client changing.
+   * Deprecated compatibility alias for the traveler's pricing-tier option
+   * unit. The server accepts this field but does not persist it; item-line
+   * `travelerIndexes` carry the supported traveler-to-item linkage.
+   *
+   * @deprecated Use itemLines[].travelerIndexes to express traveler-priced
+   * lines and inventory placement.
    */
   roomUnitId?: string | null
   isPrimary?: boolean | null

--- a/packages/bookings-ui/src/components/booking-create-dialog.tsx
+++ b/packages/bookings-ui/src/components/booking-create-dialog.tsx
@@ -516,14 +516,9 @@ export function BookingCreateForm({
   const handleRoomUnitsChange = React.useCallback((units: OptionUnitsStepperUnit[]) => {
     setRoomUnits((prev) => (sameRoomUnits(prev, units) ? prev : units))
   }, [])
-  // Room choices presented to the traveler row are *options* (e.g.
-  // "Standard double", "Junior suite upgrade") — NOT option-units
-  // (Adult / Child / Senior). The age-band lives separately on the
-  // traveler and only affects pricing; both an adult and a child sit
-  // in the same Standard double room. Each entry's `unitId` is set to
-  // the option's primary unit so the existing `roomUnitId`-keyed
-  // plumbing keeps working — `resolveBookingDraft` moves the traveler
-  // to the matching age-banded unit at preview + submit.
+  // Room choices presented to the traveler row are inventory options
+  // (e.g. "Standard double", "Junior suite upgrade"). The age-band
+  // lives separately on the traveler as a pricing unit.
   const roomUnitOptions: RoomUnitOption[] = React.useMemo(() => {
     type UnitLike = {
       optionId?: string | null
@@ -533,8 +528,18 @@ export function BookingCreateForm({
       unitType?: OptionUnitsStepperUnit["unitType"]
       occupancyMax: number | null
     }
-    const units: UnitLike[] = getTravelerAssignableStepperUnits(
-      roomUnits.length > 0 ? roomUnits : (slotUnitAvailability.data?.data ?? []),
+    const sourceUnits: UnitLike[] =
+      roomUnits.length > 0 ? roomUnits : (slotUnitAvailability.data?.data ?? [])
+    const quantityByOption = new Map<string, number>()
+    for (const unit of sourceUnits) {
+      const key = unit.optionId ?? unit.optionUnitId
+      quantityByOption.set(
+        key,
+        (quantityByOption.get(key) ?? 0) + (rooms.quantities[unit.optionUnitId] ?? 0),
+      )
+    }
+    const units = sourceUnits.filter(
+      (unit) => unit.unitType === "room" || unit.unitType === "vehicle",
     )
     if (units.length === 0) return []
     const optionGroups = new Map<
@@ -547,13 +552,9 @@ export function BookingCreateForm({
     >()
     for (const unit of units) {
       const key = unit.optionId ?? unit.optionUnitId
-      // Prefer an ADULT-coded primary; the stepper routes per-option
-      // qty through the same unit so seat math stays consistent.
-      const isAdult = (unit.unitCode ?? "").toUpperCase() === "ADULT"
       const existing = optionGroups.get(key)
       if (existing) {
         existing.units.push(unit)
-        if (isAdult) existing.primaryUnitId = unit.optionUnitId
       } else {
         optionGroups.set(key, {
           primaryUnitId: unit.optionUnitId,
@@ -566,22 +567,18 @@ export function BookingCreateForm({
     }
     return Array.from(optionGroups.values())
       .filter((group) => {
-        const totalQty = group.units.reduce(
-          (sum, u) => sum + (rooms.quantities[u.optionUnitId] ?? 0),
-          0,
-        )
+        const optionKey = group.units[0]?.optionId ?? group.primaryUnitId
+        const totalQty = quantityByOption.get(optionKey) ?? 0
         return totalQty > 0
       })
       .map((group) => {
-        const totalQty = group.units.reduce(
-          (sum, u) => sum + (rooms.quantities[u.optionUnitId] ?? 0),
-          0,
-        )
+        const optionKey = group.units[0]?.optionId ?? group.primaryUnitId
+        const totalQty = quantityByOption.get(optionKey) ?? 0
         const occupancyMax = Math.max(1, ...group.units.map((u) => u.occupancyMax ?? 1))
         const seats = totalQty * occupancyMax
         const optionUnitIds = new Set(group.units.map((u) => u.optionUnitId))
         const assigned = travelers.travelers.filter(
-          (traveler) => traveler.roomUnitId && optionUnitIds.has(traveler.roomUnitId),
+          (traveler) => traveler.inventoryUnitId && optionUnitIds.has(traveler.inventoryUnitId),
         ).length
         return {
           unitId: group.primaryUnitId,
@@ -597,12 +594,12 @@ export function BookingCreateForm({
   // `roomUnitOptions` but exposes every unit instead of collapsing
   // to one primary.
   const roomGroups: RoomGroup[] = React.useMemo(() => {
-    const travelerUnits = getTravelerAssignableStepperUnits(roomUnits)
-    if (travelerUnits.length === 0) return []
+    if (roomUnits.length === 0) return []
     const groups = new Map<string, RoomGroup>()
-    for (const u of travelerUnits) {
+    for (const u of roomUnits) {
       if (!u.optionId) continue
       const groupKey = u.optionId
+      const isInventory = u.unitType === "room" || u.unitType === "vehicle"
       const isAdultCoded = (u.unitCode ?? "").toUpperCase() === "ADULT"
       const unit = {
         unitId: u.optionUnitId,
@@ -618,7 +615,15 @@ export function BookingCreateForm({
       const existing = groups.get(groupKey)
       if (existing) {
         existing.units.push(unit)
-        if (isAdultCoded) existing.primaryUnitId = u.optionUnitId
+        if (isInventory) existing.primaryUnitId = u.optionUnitId
+        else if (
+          isAdultCoded &&
+          !existing.units.some(
+            (candidate) => candidate.unitType === "room" || candidate.unitType === "vehicle",
+          )
+        ) {
+          existing.primaryUnitId = u.optionUnitId
+        }
       } else {
         groups.set(groupKey, {
           optionId: groupKey,
@@ -640,7 +645,7 @@ export function BookingCreateForm({
       resolveBookingDraft({
         quantities: rooms.quantities,
         travelers: travelers.travelers,
-        units: getTravelerAssignableStepperUnits(roomUnits) as PricingAssignmentUnit[],
+        units: roomUnits as PricingAssignmentUnit[],
       }),
     [rooms.quantities, travelers.travelers, roomUnits],
   )
@@ -796,7 +801,7 @@ export function BookingCreateForm({
       // on each line so it can write `booking_item_travelers` rows.
       const submitUnits =
         roomUnits.length > 0
-          ? getTravelerAssignableStepperUnits(roomUnits)
+          ? roomUnits
           : getTravelerAssignableStepperUnits(
               (slotUnitAvailability.data?.data ?? []).map((unit) => ({
                 ...unit,

--- a/packages/bookings-ui/src/components/traveler-category-buttons.ts
+++ b/packages/bookings-ui/src/components/traveler-category-buttons.ts
@@ -2,7 +2,7 @@ export type TravelerCategoryRole = "lead" | "adult" | "child" | "infant"
 
 export interface TravelerCategoryState {
   role: TravelerCategoryRole
-  roomUnitId: string | null
+  pricingUnitId: string | null
 }
 
 export interface TravelerCategoryUnitState {
@@ -39,13 +39,13 @@ export function getDynamicTravelerCategoryButtonState(
 ): { active: boolean; nextRole: TravelerCategoryRole; shouldUpdate: boolean } {
   const inferredRole = inferTravelerRoleFromUnit(unit)
   const active =
-    traveler.roomUnitId === unit.unitId ||
-    (traveler.role === "lead" && inferredRole === "adult" && traveler.roomUnitId == null)
+    traveler.pricingUnitId === unit.unitId ||
+    (traveler.role === "lead" && inferredRole === "adult" && traveler.pricingUnitId == null)
   const nextRole = traveler.role === "lead" && inferredRole === "adult" ? "lead" : inferredRole
 
   return {
     active,
     nextRole,
-    shouldUpdate: traveler.roomUnitId !== unit.unitId || traveler.role !== nextRole,
+    shouldUpdate: traveler.pricingUnitId !== unit.unitId || traveler.role !== nextRole,
   }
 }

--- a/packages/bookings-ui/src/components/travelers-section.tsx
+++ b/packages/bookings-ui/src/components/travelers-section.tsx
@@ -165,14 +165,6 @@ function mapUnitIdToGroupPrimary(
   return group?.primaryUnitId ?? unitId
 }
 
-/**
- * When a room is picked, write only the inventory unit. Pricing tier
- * intent remains owned by the category buttons and the resolver.
- */
-function pickInventoryUnitForRoomChange(nextRoomPrimaryId: string): string {
-  return nextRoomPrimaryId
-}
-
 export interface RoomUnitOption {
   unitId: string
   unitName: string
@@ -602,8 +594,7 @@ export function TravelersSection({
                       }
                       onValueChange={(v) =>
                         updateAt(index, {
-                          inventoryUnitId:
-                            v === NO_ROOM || !v ? null : pickInventoryUnitForRoomChange(v),
+                          inventoryUnitId: v === NO_ROOM || !v ? null : v,
                           inventoryUnitSource: v === NO_ROOM || !v ? "none" : "manual",
                         })
                       }

--- a/packages/bookings-ui/src/components/travelers-section.tsx
+++ b/packages/bookings-ui/src/components/travelers-section.tsx
@@ -40,6 +40,7 @@ import {
 } from "./traveler-category-buttons.js"
 
 export type TravelerRole = "lead" | "adult" | "child" | "infant"
+export type TravelerUnitAssignmentSource = "auto" | "manual" | "none"
 
 export interface TravelerEntry {
   personId: string | null
@@ -53,21 +54,14 @@ export interface TravelerEntry {
   role: TravelerRole
   /** ISO `YYYY-MM-DD` date of birth. Drives age-derived unit assignment. */
   dateOfBirth: string | null
-  /** option_unit_id the traveler is assigned to (matches OptionUnitsStepper units). */
-  roomUnitId: string | null
-  /**
-   * Operator-intent enum for `roomUnitId`:
-   *
-   * - `auto`: assignment was system-derived, eligible to be re-derived
-   *   when units / DOB / role change.
-   * - `manual`: operator clicked a category/room control. Resolver
-   *   respects the value when still valid.
-   * - `none`: operator explicitly picked "No room". Stays null
-   *   through resolver re-runs.
-   *
-   * Defaults to `auto` when omitted. See voyantjs/voyant#1267.
-   */
-  roomUnitAssignmentSource?: "auto" | "manual" | "none"
+  /** option_unit_id of the person pricing tier this traveler is billed as. */
+  pricingUnitId: string | null
+  /** option_unit_id of the room/vehicle this traveler occupies, when applicable. */
+  inventoryUnitId: string | null
+  /** Operator intent for `pricingUnitId`; defaults to `auto` when omitted. */
+  pricingUnitSource?: TravelerUnitAssignmentSource
+  /** Operator intent for `inventoryUnitId`; defaults to `auto` when omitted. */
+  inventoryUnitSource?: TravelerUnitAssignmentSource
 }
 
 export interface TravelerListValue {
@@ -87,8 +81,10 @@ export function createBlankTraveler(role: TravelerRole = "adult"): TravelerEntry
     preferredLanguage: "",
     role,
     dateOfBirth: null,
-    roomUnitId: null,
-    roomUnitAssignmentSource: "auto",
+    pricingUnitId: null,
+    inventoryUnitId: null,
+    pricingUnitSource: "auto",
+    inventoryUnitSource: "auto",
   }
 }
 
@@ -153,11 +149,9 @@ function matchUnitByRoleHint(
 }
 
 /**
- * The Room dropdown lists one item per option (keyed by the option's
- * primary/ADULT unit id), but a traveler's `roomUnitId` can point at any
- * age-banded unit within that option. Map the traveler's specific unit
- * back to the dropdown's primary key so the Select value matches an
- * existing item — otherwise base-ui falls back to rendering the raw id.
+ * The Room dropdown lists one item per inventory option. Map any unit
+ * from the same option back to that option's inventory key so the
+ * Select value matches an existing item.
  */
 function mapUnitIdToGroupPrimary(
   unitId: string | null,
@@ -172,28 +166,11 @@ function mapUnitIdToGroupPrimary(
 }
 
 /**
- * When the operator changes the Room dropdown, preserve the traveler's
- * current category code (Adult/Child/Senior/…) in the destination option
- * if it offers a matching unit. Falls back to the destination's primary
- * unit when no match exists or the previous unit has no code.
+ * When a room is picked, write only the inventory unit. Pricing tier
+ * intent remains owned by the category buttons and the resolver.
  */
-function pickUnitForRoomChange(
-  currentUnitId: string | null,
-  nextRoomPrimaryId: string,
-  roomGroups: ReadonlyArray<RoomGroup> | undefined,
-): string {
-  if (!roomGroups) return nextRoomPrimaryId
-  const nextGroup = roomGroups.find((g) => g.primaryUnitId === nextRoomPrimaryId)
-  if (!nextGroup) return nextRoomPrimaryId
-  if (!currentUnitId) return nextGroup.primaryUnitId
-  const prevGroup = roomGroups.find(
-    (g) => g.primaryUnitId === currentUnitId || g.units.some((u) => u.unitId === currentUnitId),
-  )
-  const prevUnit = prevGroup?.units.find((u) => u.unitId === currentUnitId)
-  const prevCode = (prevUnit?.unitCode ?? "").toLowerCase()
-  if (!prevCode) return nextGroup.primaryUnitId
-  const sameCategory = nextGroup.units.find((u) => (u.unitCode ?? "").toLowerCase() === prevCode)
-  return sameCategory?.unitId ?? nextGroup.primaryUnitId
+function pickInventoryUnitForRoomChange(nextRoomPrimaryId: string): string {
+  return nextRoomPrimaryId
 }
 
 export interface RoomUnitOption {
@@ -323,36 +300,58 @@ export function TravelersSection({
     onChange({ travelers: value.travelers.filter((_, i) => i !== index) })
   }
 
-  // Auto-pick a room with seats available so operators don't have to
-  // hunt for the dropdown on every traveler — they can still override
-  // manually via the Room select. Picks the first option (ordering
-  // mirrors the upstream `roomUnits` array, which comes from the
-  // stepper in catalog order). When `roomGroups` is wired, also
-  // pre-pick the matching age-banded unit within that option (DOB
-  // first, role hint second) so the Category buttons land on the
-  // right row and pricing reflects the operator's intent.
-  const pickRoomUnitIdForNewTraveler = React.useCallback(
-    (dateOfBirth: string | null = null, role: TravelerRole | null = null): string | null => {
-      if (!roomUnits || roomUnits.length === 0) return null
-      const pickedRoom =
-        roomUnits.find((unit) => unit.remainingCapacity > 0)?.unitId ?? roomUnits[0]?.unitId ?? null
-      if (!pickedRoom || !roomGroups || roomGroups.length === 0) return pickedRoom
-      const group = roomGroups.find(
-        (g) => g.primaryUnitId === pickedRoom || g.units.some((u) => u.unitId === pickedRoom),
-      )
-      if (!group) return pickedRoom
+  const pickPricingUnitIdForTraveler = React.useCallback(
+    (
+      dateOfBirth: string | null = null,
+      role: TravelerRole | null = null,
+      preferredUnitId: string | null = null,
+    ): string | null => {
+      if (!roomGroups || roomGroups.length === 0) return null
+      const group =
+        (preferredUnitId
+          ? roomGroups.find(
+              (g) =>
+                g.primaryUnitId === preferredUnitId ||
+                g.units.some((u) => u.unitId === preferredUnitId),
+            )
+          : undefined) ?? roomGroups[0]
+      if (!group) return null
       return (
         matchUnitByDob(group.units, dateOfBirth) ??
         matchUnitByRoleHint(group.units, role) ??
-        group.primaryUnitId
+        group.units.find((unit) => unit.unitType == null || unit.unitType === "person")?.unitId ??
+        null
       )
     },
-    [roomUnits, roomGroups],
+    [roomGroups],
+  )
+
+  // Auto-pick a room with seats available so operators don't have to
+  // hunt for the dropdown on every traveler — they can still override
+  // manually via the Room select. Pricing is picked from the same
+  // option when the product exposes person tiers.
+  const pickAssignmentsForNewTraveler = React.useCallback(
+    (
+      dateOfBirth: string | null = null,
+      role: TravelerRole | null = null,
+    ): Pick<TravelerEntry, "pricingUnitId" | "inventoryUnitId"> => {
+      if (!roomUnits || roomUnits.length === 0) {
+        return { pricingUnitId: null, inventoryUnitId: null }
+      }
+      const pickedRoom =
+        roomUnits.find((unit) => unit.remainingCapacity > 0)?.unitId ?? roomUnits[0]?.unitId ?? null
+      if (!pickedRoom || !roomGroups || roomGroups.length === 0) {
+        return { pricingUnitId: null, inventoryUnitId: pickedRoom }
+      }
+      const pricingUnitId = pickPricingUnitIdForTraveler(dateOfBirth, role, pickedRoom)
+      return { pricingUnitId, inventoryUnitId: pickedRoom }
+    },
+    [roomUnits, roomGroups, pickPricingUnitIdForTraveler],
   )
 
   // Note: there is no hydration effect any more. Travelers attached
-  // before the option-units queries resolve get a `null` roomUnitId
-  // and `roomUnitAssignmentSource: "auto"`; the resolver in
+  // before the option-units queries resolve get null assignment ids
+  // and `*UnitSource: "auto"`; the resolver in
   // `@voyantjs/bookings/pricing-assignment` re-derives them at every
   // preview/submit pass, and respects `"none"` (explicit No room) /
   // `"manual"` (operator click) when set. Operator intent is now
@@ -368,8 +367,9 @@ export function TravelersSection({
         ...value.travelers,
         {
           ...blank,
-          roomUnitId: pickRoomUnitIdForNewTraveler(null, role),
-          roomUnitAssignmentSource: "auto",
+          ...pickAssignmentsForNewTraveler(null, role),
+          pricingUnitSource: "auto",
+          inventoryUnitSource: "auto",
         },
       ],
     })
@@ -384,8 +384,9 @@ export function TravelersSection({
         ...value.travelers,
         {
           ...traveler,
-          roomUnitId: pickRoomUnitIdForNewTraveler(traveler.dateOfBirth, role),
-          roomUnitAssignmentSource: "auto",
+          ...pickAssignmentsForNewTraveler(traveler.dateOfBirth, role),
+          pricingUnitSource: "auto",
+          inventoryUnitSource: "auto",
         },
       ],
     })
@@ -399,8 +400,9 @@ export function TravelersSection({
         ...value.travelers,
         {
           ...traveler,
-          roomUnitId: pickRoomUnitIdForNewTraveler(traveler.dateOfBirth, role),
-          roomUnitAssignmentSource: "auto",
+          ...pickAssignmentsForNewTraveler(traveler.dateOfBirth, role),
+          pricingUnitSource: "auto",
+          inventoryUnitSource: "auto",
         },
       ],
     })
@@ -507,20 +509,31 @@ export function TravelersSection({
                     phone: person.phone ?? "",
                     preferredLanguage: person.preferredLanguage ?? "",
                     dateOfBirth: person.dateOfBirth ?? null,
-                    // Re-derive the unit assignment when the operator
-                    // swaps the linked CRM person — DOB changes, so
-                    // the resolver may move the row to a different
-                    // age band. Skip when the operator has already
-                    // explicitly picked a room/category/"No room".
-                    ...(traveler.roomUnitAssignmentSource === "manual" ||
-                    traveler.roomUnitAssignmentSource === "none"
+                    // Re-derive auto-owned unit assignments when the
+                    // linked CRM person changes. Pricing and inventory
+                    // stay independent: a manual room does not freeze
+                    // DOB-driven pricing, and a manual category does
+                    // not move the room.
+                    ...(traveler.pricingUnitSource === "manual" ||
+                    traveler.pricingUnitSource === "none"
                       ? {}
                       : {
-                          roomUnitId: pickRoomUnitIdForNewTraveler(
+                          pricingUnitId: pickPricingUnitIdForTraveler(
                             person.dateOfBirth ?? null,
                             traveler.role,
+                            traveler.inventoryUnitId,
                           ),
-                          roomUnitAssignmentSource: "auto" as const,
+                          pricingUnitSource: "auto" as const,
+                        }),
+                    ...(traveler.inventoryUnitSource === "manual" ||
+                    traveler.inventoryUnitSource === "none"
+                      ? {}
+                      : {
+                          inventoryUnitId: pickAssignmentsForNewTraveler(
+                            person.dateOfBirth ?? null,
+                            traveler.role,
+                          ).inventoryUnitId,
+                          inventoryUnitSource: "auto" as const,
                         }),
                   })
                 }
@@ -533,12 +546,24 @@ export function TravelersSection({
                     phone: "",
                     preferredLanguage: "",
                     dateOfBirth: null,
-                    ...(traveler.roomUnitAssignmentSource === "manual" ||
-                    traveler.roomUnitAssignmentSource === "none"
+                    ...(traveler.pricingUnitSource === "manual" ||
+                    traveler.pricingUnitSource === "none"
                       ? {}
                       : {
-                          roomUnitId: pickRoomUnitIdForNewTraveler(null, traveler.role),
-                          roomUnitAssignmentSource: "auto" as const,
+                          pricingUnitId: pickPricingUnitIdForTraveler(
+                            null,
+                            traveler.role,
+                            traveler.inventoryUnitId,
+                          ),
+                          pricingUnitSource: "auto" as const,
+                        }),
+                    ...(traveler.inventoryUnitSource === "manual" ||
+                    traveler.inventoryUnitSource === "none"
+                      ? {}
+                      : {
+                          inventoryUnitId: pickAssignmentsForNewTraveler(null, traveler.role)
+                            .inventoryUnitId,
+                          inventoryUnitSource: "auto" as const,
                         }),
                   })
                 }
@@ -556,13 +581,13 @@ export function TravelersSection({
                   }}
                   onPickUnit={(unitId, nextRole, source) =>
                     updateAt(index, {
-                      roomUnitId: unitId,
+                      pricingUnitId: unitId,
                       role: nextRole,
                       // Only freeze as manual when the dynamic button
                       // actually picked a unit. Role-only clicks via
                       // the static fallback stay `auto` so the
                       // resolver can re-derive once real units load.
-                      roomUnitAssignmentSource: source,
+                      pricingUnitSource: source,
                     })
                   }
                 />
@@ -572,14 +597,14 @@ export function TravelersSection({
                     <Label className="text-xs">{merged.room}</Label>
                     <Select
                       items={roomSelectItems}
-                      value={mapUnitIdToGroupPrimary(traveler.roomUnitId, roomGroups) ?? NO_ROOM}
+                      value={
+                        mapUnitIdToGroupPrimary(traveler.inventoryUnitId, roomGroups) ?? NO_ROOM
+                      }
                       onValueChange={(v) =>
                         updateAt(index, {
-                          roomUnitId:
-                            v === NO_ROOM || !v
-                              ? null
-                              : pickUnitForRoomChange(traveler.roomUnitId, v, roomGroups),
-                          roomUnitAssignmentSource: v === NO_ROOM || !v ? "none" : "manual",
+                          inventoryUnitId:
+                            v === NO_ROOM || !v ? null : pickInventoryUnitForRoomChange(v),
+                          inventoryUnitSource: v === NO_ROOM || !v ? "none" : "manual",
                         })
                       }
                     >
@@ -786,8 +811,10 @@ function createTravelerFromPerson(person: PersonRecord, role: TravelerRole): Tra
     preferredLanguage: person.preferredLanguage ?? "",
     role: effectiveRole,
     dateOfBirth,
-    roomUnitId: null,
-    roomUnitAssignmentSource: "auto",
+    pricingUnitId: null,
+    inventoryUnitId: null,
+    pricingUnitSource: "auto",
+    inventoryUnitSource: "auto",
   }
 }
 
@@ -827,18 +854,18 @@ function TravelerCategoryButtons({
    * dynamic per-product button) or merely chose a role with no
    * actual unit pick (`"auto"` — static fallback before units load).
    * The wrapping handler uses `source` to decide whether to freeze
-   * the current `roomUnitId` as a manual choice.
+   * the current `pricingUnitId` as a manual choice.
    */
   onPickUnit: (unitId: string | null, nextRole: TravelerRole, source: "manual" | "auto") => void
 }) {
   const group = React.useMemo<RoomGroup | undefined>(() => {
-    if (!roomGroups || !traveler.roomUnitId) return undefined
+    if (!roomGroups) return undefined
+    const assignedUnitId = traveler.inventoryUnitId ?? traveler.pricingUnitId
+    if (!assignedUnitId) return undefined
     return roomGroups.find(
-      (g) =>
-        g.primaryUnitId === traveler.roomUnitId ||
-        g.units.some((u) => u.unitId === traveler.roomUnitId),
+      (g) => g.primaryUnitId === assignedUnitId || g.units.some((u) => u.unitId === assignedUnitId),
     )
-  }, [roomGroups, traveler.roomUnitId])
+  }, [roomGroups, traveler.inventoryUnitId, traveler.pricingUnitId])
 
   // Surface only person-typed units (Adult, Child, Senior, Infant,
   // …). Vehicles / rooms / services aren't categories the operator
@@ -887,7 +914,7 @@ function TravelerCategoryButtons({
                   // concrete unit. Pass `source: "auto"` so the
                   // resolver re-derives the unit instead of freezing
                   // a stale auto-assignment as manual.
-                  if (shouldUpdate) onPickUnit(traveler.roomUnitId, nextRole, "auto")
+                  if (shouldUpdate) onPickUnit(traveler.pricingUnitId, nextRole, "auto")
                 }}
               >
                 {label}

--- a/packages/bookings-ui/src/index.ts
+++ b/packages/bookings-ui/src/index.ts
@@ -143,6 +143,7 @@ export {
   type TravelerRole,
   TravelersSection,
   type TravelersSectionProps,
+  type TravelerUnitAssignmentSource,
 } from "./components/travelers-section.js"
 export {
   type PickedVoucher,

--- a/packages/bookings-ui/tests/unit/option-units-stepper-merge.test.ts
+++ b/packages/bookings-ui/tests/unit/option-units-stepper-merge.test.ts
@@ -144,11 +144,7 @@ describe("optionRowHasInvalidUnit", () => {
   it("matches any unit in a grouped option row, not just the primary unit", () => {
     expect(
       optionRowHasInvalidUnit(
-        [
-          { optionUnitId: "adult" },
-          { optionUnitId: "child" },
-          { optionUnitId: "infant" },
-        ],
+        [{ optionUnitId: "adult" }, { optionUnitId: "child" }, { optionUnitId: "infant" }],
         new Set(["child"]),
       ),
     ).toBe(true)

--- a/packages/bookings-ui/tests/unit/traveler-category-buttons.test.ts
+++ b/packages/bookings-ui/tests/unit/traveler-category-buttons.test.ts
@@ -8,7 +8,7 @@ import {
 describe("traveler category button state", () => {
   it("treats the lead traveler as adult-active in the static fallback buttons", () => {
     expect(
-      getStaticTravelerCategoryButtonState({ role: "lead", roomUnitId: null }, "adult"),
+      getStaticTravelerCategoryButtonState({ role: "lead", pricingUnitId: null }, "adult"),
     ).toEqual({
       active: true,
       nextRole: "lead",
@@ -18,7 +18,7 @@ describe("traveler category button state", () => {
 
   it("keeps non-adult static buttons inactive for the lead traveler", () => {
     expect(
-      getStaticTravelerCategoryButtonState({ role: "lead", roomUnitId: null }, "child"),
+      getStaticTravelerCategoryButtonState({ role: "lead", pricingUnitId: null }, "child"),
     ).toEqual({
       active: false,
       nextRole: "child",
@@ -29,7 +29,7 @@ describe("traveler category button state", () => {
   it("preserves the lead role when the assigned dynamic unit is adult-coded", () => {
     expect(
       getDynamicTravelerCategoryButtonState(
-        { role: "lead", roomUnitId: "optu_adult" },
+        { role: "lead", pricingUnitId: "optu_adult" },
         { unitId: "optu_adult", unitCode: "ADULT" },
       ),
     ).toEqual({
@@ -42,7 +42,7 @@ describe("traveler category button state", () => {
   it("allows a lead traveler on a child unit to switch role when child is clicked", () => {
     expect(
       getDynamicTravelerCategoryButtonState(
-        { role: "lead", roomUnitId: "optu_child" },
+        { role: "lead", pricingUnitId: "optu_child" },
         { unitId: "optu_child", unitCode: "CHILD" },
       ),
     ).toEqual({

--- a/packages/bookings/src/pricing-assignment.ts
+++ b/packages/bookings/src/pricing-assignment.ts
@@ -18,9 +18,10 @@
  *     quantities **stay as the operator picked them** (1 DBL room is
  *     still 1 line, not 2).
  *
- * The `roomUnitAssignmentSource` enum on the traveler tracks operator
- * intent so the resolver knows when to re-derive ("auto") versus
- * respect an explicit choice ("manual" / "none" for No room).
+ * The `pricingUnitSource` and `inventoryUnitSource` enums on the
+ * traveler track operator intent so the resolver knows when to
+ * re-derive ("auto") versus respect an explicit choice ("manual" /
+ * "none" for No room).
  *
  * No React, no DB, no HTTP — just the assignment math.
  *
@@ -40,26 +41,29 @@ export interface BookingDraftTraveler {
   preferredLanguage: string
   role: TravelerRole
   dateOfBirth: string | null
+  /** option_unit_id of the person pricing tier this traveler is billed as. */
+  pricingUnitId: string | null
+  /** option_unit_id of the room/vehicle this traveler occupies, when applicable. */
+  inventoryUnitId: string | null
   /**
-   * Legacy field name kept for compatibility with the current dialog.
-   * For person-priced products it carries the traveler's pricing
-   * tier; for accommodation products it carries the selected
-   * room/inventory unit. Source of intent disambiguated by
-   * `roomUnitAssignmentSource` below.
-   */
-  roomUnitId: string | null
-  /**
-   * Tracks operator intent around the legacy `roomUnitId` field.
+   * Tracks operator intent around `pricingUnitId`.
    *
    * - `auto`: derived from product shape, DOB, role hints, and
    *   selected quantity. Eligible for re-derivation on every render.
-   * - `manual`: operator explicitly clicked a category/room button.
-   *   The resolver respects the value when it's in the current unit
-   *   set; otherwise it re-derives.
-   * - `none`: operator explicitly picked "No room". Stays null
-   *   regardless of unit demand.
+   * - `manual`: operator explicitly clicked a category button. The
+   *   resolver respects the value when it's in the current unit set;
+   *   otherwise it re-derives.
+   * - `none`: no pricing unit should be assigned.
    */
-  roomUnitAssignmentSource?: BookingDraftUnitAssignmentSource
+  pricingUnitSource?: BookingDraftUnitAssignmentSource
+  /**
+   * Tracks operator intent around `inventoryUnitId`.
+   *
+   * - `auto`: derived from selected quantity and product shape.
+   * - `manual`: operator explicitly clicked a room/vehicle control.
+   * - `none`: operator explicitly picked "No room". Stays null.
+   */
+  inventoryUnitSource?: BookingDraftUnitAssignmentSource
 }
 
 export interface PricingAssignmentUnit {
@@ -279,9 +283,9 @@ function roleHintForTraveler(traveler: BookingDraftTraveler): AssignmentRoleHint
  *     traveler room assignments still update `travelerIndexesByUnitId`
  *     so `booking_item_travelers` rows can be created.
  *
- * Respects `roomUnitAssignmentSource`:
- *   - `none` → traveler stays null (explicit No room)
- *   - `manual` → traveler's existing roomUnitId is kept when valid
+ * Respects assignment sources:
+ *   - `none` → the corresponding field stays null
+ *   - `manual` → the existing unit is kept when valid for the chosen option
  *   - `auto` → re-derived against current options
  */
 export function resolveBookingDraft<TTraveler extends BookingDraftTraveler>(options: {
@@ -308,6 +312,12 @@ export function resolveBookingDraft<TTraveler extends BookingDraftTraveler>(opti
     else unitsByOption.set(key, [unit])
   }
 
+  const primaryInventoryByOption = new Map<string, PricingAssignmentUnit>()
+  for (const [key, optionUnits] of unitsByOption) {
+    const inventoryUnit = optionUnits.find(isInventoryUnit)
+    if (inventoryUnit) primaryInventoryByOption.set(key, inventoryUnit)
+  }
+
   // An option is "person-priced" when it has at least one person unit
   // and no inventory unit (room/vehicle). That's the excursion shape:
   // line quantities derive from travelers, not from the stepper's
@@ -331,8 +341,16 @@ export function resolveBookingDraft<TTraveler extends BookingDraftTraveler>(opti
 
   const assignedForDefaulting = new Map<string, number>()
   for (const traveler of travelers) {
-    if (!traveler.roomUnitId || traveler.roomUnitAssignmentSource === "none") continue
-    const key = unitToOption.get(traveler.roomUnitId)
+    const inventorySource = traveler.inventoryUnitSource ?? "auto"
+    const pricingSource = traveler.pricingUnitSource ?? "auto"
+    const assignedUnitId =
+      inventorySource !== "none" && traveler.inventoryUnitId
+        ? traveler.inventoryUnitId
+        : pricingSource !== "none"
+          ? traveler.pricingUnitId
+          : null
+    if (!assignedUnitId) continue
+    const key = unitToOption.get(assignedUnitId)
     if (!key) continue
     assignedForDefaulting.set(key, (assignedForDefaulting.get(key) ?? 0) + 1)
   }
@@ -343,54 +361,102 @@ export function resolveBookingDraft<TTraveler extends BookingDraftTraveler>(opti
       ([candidate, total]) => (assignedForDefaulting.get(candidate) ?? 0) < total,
     )?.[0] ?? optionDemand[0]?.[0]
 
-  const resolveUnitForTraveler = (
+  const resolvePricingUnitForTraveler = (
     traveler: TTraveler,
     key: string,
   ): PricingAssignmentUnit | undefined =>
     pickUnitForAge(
-      unitsByOption.get(key) ?? [],
+      (unitsByOption.get(key) ?? []).filter(isPersonUnit),
       computeAgeYears(traveler.dateOfBirth, now),
       roleHintForTraveler(traveler),
     )
 
-  const assignNextDemandUnit = (traveler: TTraveler): TTraveler => {
+  const resolveTargetOption = (
+    traveler: TTraveler,
+  ): { key: string; fromDemand: boolean } | null => {
+    const inventorySource = traveler.inventoryUnitSource ?? "auto"
+    if (inventorySource !== "none" && traveler.inventoryUnitId) {
+      const inventoryUnit = unitById.get(traveler.inventoryUnitId)
+      const key = unitToOption.get(traveler.inventoryUnitId)
+      if (key && inventoryUnit && isInventoryUnit(inventoryUnit)) return { key, fromDemand: false }
+    }
+
+    const pricingSource = traveler.pricingUnitSource ?? "auto"
+    if (pricingSource !== "none" && traveler.pricingUnitId) {
+      const pricingUnit = unitById.get(traveler.pricingUnitId)
+      const key = unitToOption.get(traveler.pricingUnitId)
+      if (key && pricingUnit && isPersonUnit(pricingUnit)) return { key, fromDemand: false }
+    }
+
     const key = pickOptionWithDemand()
-    if (!key)
-      return { ...traveler, roomUnitId: null, roomUnitAssignmentSource: "auto" } as TTraveler
-    const unit = resolveUnitForTraveler(traveler, key)
-    if (!unit)
-      return { ...traveler, roomUnitId: null, roomUnitAssignmentSource: "auto" } as TTraveler
-    assignedForDefaulting.set(key, (assignedForDefaulting.get(key) ?? 0) + 1)
-    return {
-      ...traveler,
-      roomUnitId: unit.optionUnitId,
-      roomUnitAssignmentSource: "auto",
-    } as TTraveler
+    return key ? { key, fromDemand: true } : null
   }
 
   const nextTravelers = travelers.map((traveler) => {
-    const source = traveler.roomUnitAssignmentSource ?? "auto"
-    if (source === "none") {
-      return { ...traveler, roomUnitId: null, roomUnitAssignmentSource: "none" } as TTraveler
+    const target = resolveTargetOption(traveler)
+    const pricingSource = traveler.pricingUnitSource ?? "auto"
+    const inventorySource = traveler.inventoryUnitSource ?? "auto"
+
+    if (!target) {
+      return {
+        ...traveler,
+        pricingUnitId: null,
+        inventoryUnitId: null,
+        pricingUnitSource: pricingSource === "none" ? "none" : "auto",
+        inventoryUnitSource: inventorySource === "none" ? "none" : "auto",
+      } as TTraveler
+    }
+    const targetKey = target.key
+
+    const currentPricingUnit = traveler.pricingUnitId
+      ? unitById.get(traveler.pricingUnitId)
+      : undefined
+    const currentPricingKey = traveler.pricingUnitId
+      ? unitToOption.get(traveler.pricingUnitId)
+      : undefined
+    const keepManualPricing =
+      pricingSource === "manual" &&
+      currentPricingUnit &&
+      isPersonUnit(currentPricingUnit) &&
+      currentPricingKey === targetKey
+    const nextPricingUnit =
+      pricingSource === "none"
+        ? null
+        : keepManualPricing
+          ? currentPricingUnit
+          : (resolvePricingUnitForTraveler(traveler, targetKey) ?? null)
+
+    const currentInventoryUnit = traveler.inventoryUnitId
+      ? unitById.get(traveler.inventoryUnitId)
+      : undefined
+    const currentInventoryKey = traveler.inventoryUnitId
+      ? unitToOption.get(traveler.inventoryUnitId)
+      : undefined
+    const keepManualInventory =
+      inventorySource === "manual" &&
+      currentInventoryUnit &&
+      isInventoryUnit(currentInventoryUnit) &&
+      currentInventoryKey === targetKey
+    const targetInventoryUnit = primaryInventoryByOption.get(targetKey) ?? null
+    const nextInventoryUnit =
+      inventorySource === "none"
+        ? null
+        : keepManualInventory
+          ? currentInventoryUnit
+          : targetInventoryUnit
+
+    if (target.fromDemand && (nextPricingUnit || nextInventoryUnit)) {
+      assignedForDefaulting.set(targetKey, (assignedForDefaulting.get(targetKey) ?? 0) + 1)
     }
 
-    if (traveler.roomUnitId && unitById.has(traveler.roomUnitId)) {
-      const key = unitToOption.get(traveler.roomUnitId)
-      if (!key || source === "manual" || !personPricedOptions.has(key)) return traveler
-      // Stale auto-assigned person-priced unit: re-derive against the
-      // current bands so a child traveler who was placed on Adult by
-      // an earlier pass moves to the right band on the next render.
-      const unit = resolveUnitForTraveler(traveler, key)
-      return unit && unit.optionUnitId !== traveler.roomUnitId
-        ? ({
-            ...traveler,
-            roomUnitId: unit.optionUnitId,
-            roomUnitAssignmentSource: "auto",
-          } as TTraveler)
-        : traveler
-    }
-
-    return assignNextDemandUnit(traveler)
+    return {
+      ...traveler,
+      pricingUnitId: nextPricingUnit?.optionUnitId ?? null,
+      inventoryUnitId: nextInventoryUnit?.optionUnitId ?? null,
+      pricingUnitSource: pricingSource === "none" ? "none" : keepManualPricing ? "manual" : "auto",
+      inventoryUnitSource:
+        inventorySource === "none" ? "none" : keepManualInventory ? "manual" : "auto",
+    } as TTraveler
   })
 
   const next: BookingDraftQuantities = {}
@@ -403,20 +469,39 @@ export function resolveBookingDraft<TTraveler extends BookingDraftTraveler>(opti
     if (quantity <= 0) continue
     const key = unitToOption.get(unitId)
     if (!key || personPricedOptions.has(key)) continue
-    next[unitId] = quantity
+    const submittedUnit = unitById.get(unitId)
+    const targetUnitId =
+      submittedUnit && isInventoryUnit(submittedUnit)
+        ? unitId
+        : (primaryInventoryByOption.get(key)?.optionUnitId ?? unitId)
+    next[targetUnitId] = (next[targetUnitId] ?? 0) + quantity
   }
 
   const assignedByOption = new Map<string, number>()
   for (const [index, traveler] of nextTravelers.entries()) {
-    if (!traveler.roomUnitId || traveler.roomUnitAssignmentSource === "none") continue
-    const key = unitToOption.get(traveler.roomUnitId)
+    const pricingSource = traveler.pricingUnitSource ?? "auto"
+    const inventorySource = traveler.inventoryUnitSource ?? "auto"
+    const pricingKey =
+      pricingSource !== "none" && traveler.pricingUnitId
+        ? unitToOption.get(traveler.pricingUnitId)
+        : undefined
+    const inventoryKey =
+      inventorySource !== "none" && traveler.inventoryUnitId
+        ? unitToOption.get(traveler.inventoryUnitId)
+        : undefined
+    const key = inventoryKey ?? pricingKey
     if (!key) continue
-    const unitIndexes = travelerIndexesByUnitId[traveler.roomUnitId] ?? []
-    unitIndexes.push(index)
-    travelerIndexesByUnitId[traveler.roomUnitId] = unitIndexes
     if (personPricedOptions.has(key)) {
-      next[traveler.roomUnitId] = (next[traveler.roomUnitId] ?? 0) + 1
+      if (!traveler.pricingUnitId || pricingSource === "none") continue
+      const unitIndexes = travelerIndexesByUnitId[traveler.pricingUnitId] ?? []
+      unitIndexes.push(index)
+      travelerIndexesByUnitId[traveler.pricingUnitId] = unitIndexes
+      next[traveler.pricingUnitId] = (next[traveler.pricingUnitId] ?? 0) + 1
       assignedByOption.set(key, (assignedByOption.get(key) ?? 0) + 1)
+    } else if (traveler.inventoryUnitId && inventorySource !== "none") {
+      const unitIndexes = travelerIndexesByUnitId[traveler.inventoryUnitId] ?? []
+      unitIndexes.push(index)
+      travelerIndexesByUnitId[traveler.inventoryUnitId] = unitIndexes
     }
   }
 
@@ -477,8 +562,8 @@ export function resolveBookingExtraLines<TLine extends ResolvableExtraLine>(opti
 /**
  * Project a resolved draft's traveler list into the wire-format
  * `BookingCreateTravelerInput[]` shape the dialog submits. Derives
- * the `travelerCategory` from DOB / role and respects the
- * `roomUnitAssignmentSource === "none"` carve-out.
+ * the `travelerCategory` from DOB / role and projects only the
+ * inventory placement into the legacy wire `roomUnitId` field.
  */
 export function travelersToRows(
   value: { travelers: readonly BookingDraftTraveler[] },
@@ -505,7 +590,7 @@ export function travelersToRows(
     participantType: "traveler",
     travelerCategory: deriveDraftPaxBand(traveler, now),
     isPrimary: traveler.role === "lead",
-    roomUnitId: traveler.roomUnitAssignmentSource === "none" ? null : traveler.roomUnitId,
+    roomUnitId: traveler.inventoryUnitSource === "none" ? null : traveler.inventoryUnitId,
   }))
 }
 
@@ -561,10 +646,11 @@ export interface VerifyBookingDraftResult {
  * no legitimate clients trip the warning.
  *
  * Notes on the reconstruction:
- *   - The wire format doesn't carry per-traveler `roomUnitId` (the
- *     join-table model encodes it through `itemLines[].travelerIndexes`),
- *     so we reconstruct it by walking item lines and matching them
- *     to traveler indexes.
+ *   - The wire format doesn't carry split per-traveler assignment
+ *     fields (the join-table model encodes them through
+ *     `itemLines[].travelerIndexes`), so we reconstruct the relevant
+ *     pricing or inventory unit by walking item lines and matching
+ *     them to traveler indexes.
  *   - DOB doesn't round-trip on the wire today either; we feed the
  *     resolver the `travelerCategory` as a role hint so age-banded
  *     options can still be re-derived.
@@ -582,6 +668,7 @@ export function verifyBookingDraft(input: {
   // assignment the client intended. If the client didn't send
   // `travelerIndexes` (legacy clients), we can't verify per-traveler
   // assignment — just compare aggregate quantities.
+  const unitById = new Map(input.units.map((unit) => [unit.optionUnitId, unit]))
   const unitByTravelerIndex = new Map<number, string>()
   for (const line of input.itemLines) {
     for (const idx of line.travelerIndexes ?? []) {
@@ -598,6 +685,7 @@ export function verifyBookingDraft(input: {
           ? cat
           : "adult"
     const assigned = unitByTravelerIndex.get(i)
+    const assignedUnit = assigned ? unitById.get(assigned) : undefined
     return {
       personId: null,
       firstName: "",
@@ -616,8 +704,10 @@ export function verifyBookingDraft(input: {
       // value as ground truth. Otherwise the day-tour bug shape
       // (3 travelers all manually frozen to Adult) would round-trip
       // through the verifier unchanged.
-      roomUnitId: assigned ?? null,
-      roomUnitAssignmentSource: "auto",
+      pricingUnitId: assigned && assignedUnit && isPersonUnit(assignedUnit) ? assigned : null,
+      inventoryUnitId: assigned && assignedUnit && isInventoryUnit(assignedUnit) ? assigned : null,
+      pricingUnitSource: "auto",
+      inventoryUnitSource: "auto",
     }
   })
 

--- a/packages/bookings/src/pricing-assignment.ts
+++ b/packages/bookings/src/pricing-assignment.ts
@@ -562,8 +562,11 @@ export function resolveBookingExtraLines<TLine extends ResolvableExtraLine>(opti
 /**
  * Project a resolved draft's traveler list into the wire-format
  * `BookingCreateTravelerInput[]` shape the dialog submits. Derives
- * the `travelerCategory` from DOB / role and projects only the
- * inventory placement into the legacy wire `roomUnitId` field.
+ * the `travelerCategory` from DOB / role.
+ *
+ * `roomUnitId` is a deprecated compatibility alias for the pricing tier
+ * option unit. Inventory placement is expressed only by item lines and their
+ * `travelerIndexes`; the server accepts this field but does not persist it.
  */
 export function travelersToRows(
   value: { travelers: readonly BookingDraftTraveler[] },
@@ -590,7 +593,7 @@ export function travelersToRows(
     participantType: "traveler",
     travelerCategory: deriveDraftPaxBand(traveler, now),
     isPrimary: traveler.role === "lead",
-    roomUnitId: traveler.inventoryUnitSource === "none" ? null : traveler.inventoryUnitId,
+    roomUnitId: traveler.pricingUnitSource === "none" ? null : traveler.pricingUnitId,
   }))
 }
 

--- a/packages/bookings/tests/unit/pricing-assignment.test.ts
+++ b/packages/bookings/tests/unit/pricing-assignment.test.ts
@@ -431,29 +431,31 @@ describe("travelersToRows", () => {
     expect(rows[2]).toMatchObject({ isPrimary: false, travelerCategory: "child" })
   })
 
-  it("projects inventory placement to the legacy roomUnitId wire field", () => {
+  it("keeps legacy roomUnitId wire field as a pricing-tier alias", () => {
     const rows = travelersToRows({
       travelers: [
         traveler({
           role: "adult",
           pricingUnitId: "u_adult",
+          pricingUnitSource: "manual",
           inventoryUnitId: "u_dbl_room",
           inventoryUnitSource: "manual",
         }),
       ],
     })
 
-    expect(rows[0]?.roomUnitId).toBe("u_dbl_room")
+    expect(rows[0]?.roomUnitId).toBe("u_adult")
   })
 
-  it("nulls out the legacy roomUnitId wire field for inventory source=none", () => {
+  it("nulls out the legacy roomUnitId wire field for pricing source=none", () => {
     const rows = travelersToRows({
       travelers: [
         traveler({
           role: "adult",
           pricingUnitId: "u_adult",
+          pricingUnitSource: "none",
           inventoryUnitId: "u_dbl_room",
-          inventoryUnitSource: "none",
+          inventoryUnitSource: "manual",
         }),
       ],
     })

--- a/packages/bookings/tests/unit/pricing-assignment.test.ts
+++ b/packages/bookings/tests/unit/pricing-assignment.test.ts
@@ -40,8 +40,10 @@ function traveler(partial: Partial<BookingDraftTraveler> = {}): BookingDraftTrav
     preferredLanguage: partial.preferredLanguage ?? "",
     role: partial.role ?? "adult",
     dateOfBirth: partial.dateOfBirth ?? null,
-    roomUnitId: partial.roomUnitId ?? null,
-    roomUnitAssignmentSource: partial.roomUnitAssignmentSource ?? "auto",
+    pricingUnitId: partial.pricingUnitId ?? null,
+    inventoryUnitId: partial.inventoryUnitId ?? null,
+    pricingUnitSource: partial.pricingUnitSource ?? "auto",
+    inventoryUnitSource: partial.inventoryUnitSource ?? "auto",
   }
 }
 
@@ -195,16 +197,16 @@ describe("resolveBookingDraft — person-priced excursion (Bulgaria shape)", () 
       now: NOW,
       quantities: { u_adult: 3 },
       travelers: [
-        traveler({ role: "lead", roomUnitId: "u_adult" }),
+        traveler({ role: "lead", pricingUnitId: "u_adult" }),
         // Auto-assigned to adult by an earlier pass, then DOB filled in:
-        traveler({ role: "adult", roomUnitId: "u_adult", dateOfBirth: "2018-01-01" }),
-        traveler({ role: "infant", roomUnitId: "u_adult" }),
+        traveler({ role: "adult", pricingUnitId: "u_adult", dateOfBirth: "2018-01-01" }),
+        traveler({ role: "infant", pricingUnitId: "u_adult" }),
       ],
       units: krushunaUnits,
     })
 
-    expect(result.travelers[1]?.roomUnitId).toBe("u_child_6_12")
-    expect(result.travelers[2]?.roomUnitId).toBe("u_child_0_5")
+    expect(result.travelers[1]?.pricingUnitId).toBe("u_child_6_12")
+    expect(result.travelers[2]?.pricingUnitId).toBe("u_child_0_5")
   })
 
   it("preserves explicit operator category selections", () => {
@@ -215,16 +217,16 @@ describe("resolveBookingDraft — person-priced excursion (Bulgaria shape)", () 
         traveler({ role: "lead" }),
         traveler({
           role: "child",
-          roomUnitId: "u_adult",
-          roomUnitAssignmentSource: "manual",
+          pricingUnitId: "u_adult",
+          pricingUnitSource: "manual",
         }),
         traveler({ role: "infant" }),
       ],
       units: krushunaUnits,
     })
 
-    expect(result.travelers[1]?.roomUnitId).toBe("u_adult")
-    expect(result.travelers[1]?.roomUnitAssignmentSource).toBe("manual")
+    expect(result.travelers[1]?.pricingUnitId).toBe("u_adult")
+    expect(result.travelers[1]?.pricingUnitSource).toBe("manual")
   })
 
   it("re-resolves stale manual person unit assignments when units change", () => {
@@ -237,33 +239,34 @@ describe("resolveBookingDraft — person-priced excursion (Bulgaria shape)", () 
       travelers: [
         traveler({
           role: "child",
-          roomUnitId: "u_stale_from_other_product",
-          roomUnitAssignmentSource: "manual",
+          pricingUnitId: "u_stale_from_other_product",
+          pricingUnitSource: "manual",
         }),
       ],
       units: krushunaUnits,
     })
 
-    expect(result.travelers[0]?.roomUnitId).toBe("u_child_6_12")
+    expect(result.travelers[0]?.pricingUnitId).toBe("u_child_6_12")
   })
 
-  it("preserves explicit No room assignments", () => {
+  it("keeps No room as inventory-only intent", () => {
     const result = resolveBookingDraft({
       now: NOW,
       quantities: { u_adult: 1 },
       travelers: [
         traveler({
           role: "adult",
-          roomUnitId: null,
-          roomUnitAssignmentSource: "none",
+          inventoryUnitId: null,
+          inventoryUnitSource: "none",
         }),
       ],
       units: krushunaUnits,
     })
 
-    expect(result.travelers[0]?.roomUnitId).toBeNull()
-    expect(result.travelers[0]?.roomUnitAssignmentSource).toBe("none")
-    expect(result.travelerIndexesByUnitId).toEqual({})
+    expect(result.travelers[0]?.pricingUnitId).toBe("u_adult")
+    expect(result.travelers[0]?.inventoryUnitId).toBeNull()
+    expect(result.travelers[0]?.inventoryUnitSource).toBe("none")
+    expect(result.travelerIndexesByUnitId).toEqual({ u_adult: [0] })
   })
 
   it("residual fills onto adult when stepper qty exceeds travelers", () => {
@@ -303,8 +306,25 @@ describe("resolveBookingDraft — accommodation (Moldova DBL shape)", () => {
       now: NOW,
       quantities: { u_dbl_room: 1 },
       travelers: [
-        traveler({ role: "lead", roomUnitId: "u_dbl_room", roomUnitAssignmentSource: "manual" }),
-        traveler({ role: "adult", roomUnitId: "u_dbl_room", roomUnitAssignmentSource: "manual" }),
+        traveler({ role: "lead", inventoryUnitId: "u_dbl_room", inventoryUnitSource: "manual" }),
+        traveler({ role: "adult", inventoryUnitId: "u_dbl_room", inventoryUnitSource: "manual" }),
+      ],
+      units: moldovaDblUnits,
+    })
+
+    expect(result.quantities).toEqual({ u_dbl_room: 1 })
+    expect(result.travelers[0]?.pricingUnitId).toBe("u_adult_mol")
+    expect(result.travelers[0]?.inventoryUnitId).toBe("u_dbl_room")
+    expect(result.travelerIndexesByUnitId).toEqual({ u_dbl_room: [0, 1] })
+  })
+
+  it("normalizes legacy adult-keyed accommodation quantities onto the inventory unit", () => {
+    const result = resolveBookingDraft({
+      now: NOW,
+      quantities: { u_adult_mol: 1 },
+      travelers: [
+        traveler({ role: "lead", inventoryUnitId: "u_dbl_room", inventoryUnitSource: "manual" }),
+        traveler({ role: "adult", inventoryUnitId: "u_dbl_room", inventoryUnitSource: "manual" }),
       ],
       units: moldovaDblUnits,
     })
@@ -314,11 +334,9 @@ describe("resolveBookingDraft — accommodation (Moldova DBL shape)", () => {
   })
 
   it("reassigns stale manual assignments when the option changes", () => {
-    // Operator switched the room from DBL to TWN. The dialog stores
-    // the option's primary (adult-coded) unit id on the traveler, not
-    // the literal room unit id — so the stale value here is
-    // `u_adult_dbl` and the resolver should re-derive to the TWN
-    // option's adult unit on the next render.
+    // Operator switched the room from DBL to TWN. The stale inventory
+    // id is no longer in unitById, so the resolver re-derives both
+    // placement and pricing for the selected option.
     const twnUnits: PricingAssignmentUnit[] = [
       unit({
         optionId: "opto_mol_twn",
@@ -338,14 +356,16 @@ describe("resolveBookingDraft — accommodation (Moldova DBL shape)", () => {
       now: NOW,
       quantities: { u_twn_room: 1 },
       travelers: [
-        traveler({ role: "lead", roomUnitId: "u_adult_dbl", roomUnitAssignmentSource: "manual" }),
-        traveler({ role: "adult", roomUnitId: "u_adult_dbl", roomUnitAssignmentSource: "manual" }),
+        traveler({ role: "lead", inventoryUnitId: "u_dbl_room", inventoryUnitSource: "manual" }),
+        traveler({ role: "adult", inventoryUnitId: "u_dbl_room", inventoryUnitSource: "manual" }),
       ],
       units: twnUnits,
     })
 
-    expect(result.travelers[0]?.roomUnitId).toBe("u_adult_twn")
-    expect(result.travelers[1]?.roomUnitId).toBe("u_adult_twn")
+    expect(result.travelers[0]?.pricingUnitId).toBe("u_adult_twn")
+    expect(result.travelers[1]?.pricingUnitId).toBe("u_adult_twn")
+    expect(result.travelers[0]?.inventoryUnitId).toBe("u_twn_room")
+    expect(result.travelers[1]?.inventoryUnitId).toBe("u_twn_room")
   })
 })
 
@@ -411,13 +431,29 @@ describe("travelersToRows", () => {
     expect(rows[2]).toMatchObject({ isPrimary: false, travelerCategory: "child" })
   })
 
-  it("nulls out roomUnitId for source=none", () => {
+  it("projects inventory placement to the legacy roomUnitId wire field", () => {
     const rows = travelersToRows({
       travelers: [
         traveler({
           role: "adult",
-          roomUnitId: "u_adult",
-          roomUnitAssignmentSource: "none",
+          pricingUnitId: "u_adult",
+          inventoryUnitId: "u_dbl_room",
+          inventoryUnitSource: "manual",
+        }),
+      ],
+    })
+
+    expect(rows[0]?.roomUnitId).toBe("u_dbl_room")
+  })
+
+  it("nulls out the legacy roomUnitId wire field for inventory source=none", () => {
+    const rows = travelersToRows({
+      travelers: [
+        traveler({
+          role: "adult",
+          pricingUnitId: "u_adult",
+          inventoryUnitId: "u_dbl_room",
+          inventoryUnitSource: "none",
         }),
       ],
     })

--- a/packages/bookings/tests/unit/pricing-assignment.test.ts
+++ b/packages/bookings/tests/unit/pricing-assignment.test.ts
@@ -333,6 +333,24 @@ describe("resolveBookingDraft — accommodation (Moldova DBL shape)", () => {
     expect(result.travelerIndexesByUnitId).toEqual({ u_dbl_room: [0, 1] })
   })
 
+  it("preserves valid manual inventory assignments on resolver re-run", () => {
+    const result = resolveBookingDraft({
+      now: NOW,
+      quantities: { u_dbl_room: 1 },
+      travelers: [
+        traveler({ role: "lead", inventoryUnitId: "u_dbl_room", inventoryUnitSource: "manual" }),
+        traveler({ role: "adult", inventoryUnitId: "u_dbl_room", inventoryUnitSource: "manual" }),
+      ],
+      units: moldovaDblUnits,
+    })
+
+    expect(result.travelers[0]?.inventoryUnitId).toBe("u_dbl_room")
+    expect(result.travelers[0]?.inventoryUnitSource).toBe("manual")
+    expect(result.travelers[1]?.inventoryUnitId).toBe("u_dbl_room")
+    expect(result.travelers[1]?.inventoryUnitSource).toBe("manual")
+    expect(result.travelerIndexesByUnitId).toEqual({ u_dbl_room: [0, 1] })
+  })
+
   it("reassigns stale manual assignments when the option changes", () => {
     // Operator switched the room from DBL to TWN. The stale inventory
     // id is no longer in unitById, so the resolver re-derives both

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -46,11 +46,10 @@ const travelerInputSchema = z.object({
   preferredLanguage: z.string().max(35).optional().nullable(),
   specialRequests: z.string().optional().nullable(),
   /**
-   * option_unit_id the passenger is assigned to. Accepted by the input
-   * schema so the UI's PassengerListValue can round-trip, but not yet
-   * persisted — bookingTravelers has no room-assignment column and the
-   * allocation flow is owned by the items slice. Follow-up: add a traveler
-   * metadata JSONB or wire into booking_allocations.
+   * Deprecated compatibility alias for the traveler's pricing-tier option
+   * unit. Accepted by the input schema for wire compatibility but not
+   * persisted; item-line travelerIndexes are the supported traveler-to-item
+   * linkage.
    */
   roomUnitId: z.string().optional().nullable(),
   isPrimary: z.boolean().optional().nullable(),
@@ -834,10 +833,10 @@ export async function createBooking(
         )
       }
 
-      // 2. Travelers. The wire-format `roomUnitId` on a traveler is
-      // accepted for round-trip compatibility but not stored on the
-      // traveler row itself — per-traveler unit assignment is
-      // expressed through `booking_item_travelers` rows linked from
+      // 2. Travelers. The wire-format `roomUnitId` on a traveler is a
+      // deprecated pricing-tier alias accepted for compatibility but
+      // not stored on the traveler row itself. Per-traveler item linkage
+      // is expressed through `booking_item_travelers` rows linked from
       // each `booking_item`. See voyantjs/voyant#1267.
       const travelers: BookingTraveler[] = []
       for (const traveler of input.travelers ?? []) {

--- a/packages/ui/public/r/voyant-bookings-travelers-section.json
+++ b/packages/ui/public/r/voyant-bookings-travelers-section.json
@@ -8,7 +8,7 @@
   "files": [
     {
       "path": "registry/bookings/travelers-section.tsx",
-      "content": "export {\n  createBlankTraveler,\n  emptyTravelerListValue,\n  type RoomUnitOption,\n  type TravelerEntry,\n  type TravelerListValue,\n  type TravelerRole,\n  TravelersSection,\n  type TravelersSectionProps,\n} from \"@voyantjs/bookings-ui\"\n",
+      "content": "export {\n  createBlankTraveler,\n  emptyTravelerListValue,\n  type RoomUnitOption,\n  type TravelerEntry,\n  type TravelerListValue,\n  type TravelerRole,\n  TravelersSection,\n  type TravelersSectionProps,\n  type TravelerUnitAssignmentSource,\n} from \"@voyantjs/bookings-ui\"\n",
       "type": "registry:component",
       "target": "components/voyant/bookings/travelers-section.tsx"
     }

--- a/packages/ui/registry/bookings/travelers-section.tsx
+++ b/packages/ui/registry/bookings/travelers-section.tsx
@@ -7,4 +7,5 @@ export {
   type TravelerRole,
   TravelersSection,
   type TravelersSectionProps,
+  type TravelerUnitAssignmentSource,
 } from "@voyantjs/bookings-ui"


### PR DESCRIPTION
## Summary

- Split booking draft travelers into separate `pricingUnitId` and `inventoryUnitId` fields with independent assignment sources.
- Updated booking-create traveler controls so category buttons own pricing tiers and the room dropdown owns inventory placement.
- Kept create payload wire format unchanged while projecting inventory placement to the legacy traveler `roomUnitId` field.
- Updated pricing-assignment tests and the bookings travelers registry artifact.

Closes #1273.

## Verification

- `pnpm --filter @voyantjs/bookings test -- pricing-assignment`
- `pnpm --filter @voyantjs/bookings-ui test -- traveler-category-buttons`
- `pnpm --filter @voyantjs/bookings typecheck`
- `pnpm --filter @voyantjs/bookings-ui typecheck`
- `pnpm --filter @voyantjs/ui typecheck`
- `pnpm --filter operator typecheck`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter dmc typecheck`
- `pnpm lint:changed`
- `pnpm registry:build`