### PR TITLE
Fix awaiting payment slot allocation visibility

### DIFF
--- a/.changeset/soft-maps-wait.md
+++ b/.changeset/soft-maps-wait.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/availability": patch
+---
+
+Include awaiting payment bookings in slot allocation manifests and allocation demand counts.

--- a/packages/availability/src/auto-allocator.ts
+++ b/packages/availability/src/auto-allocator.ts
@@ -1,3 +1,5 @@
+import { isActiveBookingStatusForSlot } from "./booking-statuses.js"
+
 export interface AllocatorTraveler {
   id: string
   bookingId: string
@@ -30,8 +32,6 @@ export interface AllocationPlan {
   skipped: number
 }
 
-const TERMINAL_BOOKING_STATUSES = new Set(["cancelled", "no_show"])
-
 interface InternalGroup {
   key: string
   travelerIds: string[]
@@ -43,7 +43,7 @@ interface InternalGroup {
 }
 
 function activeTravelers(travelers: AllocatorTraveler[]): AllocatorTraveler[] {
-  return travelers.filter((traveler) => !TERMINAL_BOOKING_STATUSES.has(traveler.bookingStatus))
+  return travelers.filter((traveler) => isActiveBookingStatusForSlot(traveler.bookingStatus))
 }
 
 function groupTravelers(travelers: AllocatorTraveler[]): Map<string, InternalGroup> {

--- a/packages/availability/src/booking-statuses.ts
+++ b/packages/availability/src/booking-statuses.ts
@@ -1,0 +1,22 @@
+import { type SQL, sql } from "drizzle-orm"
+
+export const ACTIVE_BOOKING_STATUSES_FOR_SLOT = [
+  "on_hold",
+  "awaiting_payment",
+  "confirmed",
+  "in_progress",
+  "completed",
+] as const
+
+const activeBookingStatusesForSlot = new Set<string>(ACTIVE_BOOKING_STATUSES_FOR_SLOT)
+
+export function activeBookingStatusesForSlotSql(): SQL {
+  return sql.join(
+    ACTIVE_BOOKING_STATUSES_FOR_SLOT.map((status) => sql`${status}`),
+    sql`, `,
+  )
+}
+
+export function isActiveBookingStatusForSlot(status: string): boolean {
+  return activeBookingStatusesForSlot.has(status)
+}

--- a/packages/availability/src/service-allocation-automation.ts
+++ b/packages/availability/src/service-allocation-automation.ts
@@ -8,6 +8,7 @@ import {
   planRoomAllocation,
   planVehicleSeatAllocation,
 } from "./auto-allocator.js"
+import { activeBookingStatusesForSlotSql } from "./booking-statuses.js"
 import {
   type AllocationResource,
   allocationResources,
@@ -259,7 +260,7 @@ export async function autoMaterializeAllocationResources(
         FROM bookings b
         JOIN booking_allocations ba ON ba.booking_id = b.id
         WHERE ba.availability_slot_id = ${slotId}
-          AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
+          AND b.status IN (${activeBookingStatusesForSlotSql()})
           AND ba.status IN ('held', 'confirmed', 'fulfilled')
       ),
       -- Pax per option = sum of booking_item quantities for items belonging

--- a/packages/availability/src/service-allocation-exports.ts
+++ b/packages/availability/src/service-allocation-exports.ts
@@ -1,3 +1,4 @@
+import { isActiveBookingStatusForSlot } from "./booking-statuses.js"
 import type { AllocationManifestTraveler, SlotAllocationManifest } from "./service-allocation.js"
 
 const PASSENGER_HEADERS = [
@@ -47,7 +48,7 @@ export function buildAllocationPassengersCsv(manifest: SlotAllocationManifest): 
 export function buildAllocationRoomingCsv(manifest: SlotAllocationManifest, kind = "room"): string {
   const rows: Array<Array<string | number | null>> = [[...ROOMING_HEADERS]]
   const travelers = manifest.bookings.flatMap((booking) =>
-    isTerminalBookingStatus(booking.status) ? [] : booking.travelers,
+    isActiveBookingStatusForSlot(booking.status) ? booking.travelers : [],
   )
   const travelersByResource = new Map<string, AllocationManifestTraveler[]>()
   const unallocated: AllocationManifestTraveler[] = []
@@ -99,10 +100,6 @@ export function allocationExportFilename(
 ): string {
   const slug = manifest.slot.productId?.slice(0, 8) ?? "departure"
   return `${prefix}-${slug}-${manifest.slot.id}.csv`
-}
-
-function isTerminalBookingStatus(status: string) {
-  return status === "cancelled" || status === "no_show"
 }
 
 function csvDocument(rows: Array<Array<string | number | boolean | null | undefined>>) {

--- a/packages/availability/src/service-allocation.ts
+++ b/packages/availability/src/service-allocation.ts
@@ -2,6 +2,7 @@ import { newId } from "@voyantjs/db/lib/typeid"
 import { and, asc, desc, eq, type SQL, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
+import { activeBookingStatusesForSlotSql } from "./booking-statuses.js"
 import {
   allocationAuditLog,
   allocationResources,
@@ -333,7 +334,7 @@ export async function getSlotsResourceAvailability(
         JOIN bookings b ON b.id = bt.booking_id
         WHERE btd.allocations ->> ar.kind = ar.id
           AND ba.availability_slot_id = ar.slot_id
-          AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
+          AND b.status IN (${activeBookingStatusesForSlotSql()})
           AND ba.status IN ('held', 'confirmed', 'fulfilled')
       ) usage ON true
       WHERE ar.slot_id = ANY(${sqlTextArray(uniqueIds)})
@@ -474,7 +475,7 @@ export async function validateSlotAllocationCapacity(
         JOIN bookings b ON b.id = bt.booking_id
         WHERE btd.allocations ->> ${plan.kind} = ${resourceId}
           AND ba.availability_slot_id = ${slotId}
-          AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
+          AND b.status IN (${activeBookingStatusesForSlotSql()})
           AND ba.status IN ('held', 'confirmed', 'fulfilled')
           AND btd.traveler_id <> ALL(${sqlTextArray(travelerIdsArr)})
       `,
@@ -923,7 +924,7 @@ async function assertTravelerBelongsToSlot(db: SqlExecutor, slotId: string, trav
     JOIN bookings b ON b.id = bt.booking_id
     WHERE bt.id = ${travelerId}
       AND ba.availability_slot_id = ${slotId}
-      AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
+      AND b.status IN (${activeBookingStatusesForSlotSql()})
       AND ba.status IN ('held', 'confirmed', 'fulfilled')
     LIMIT 1
   `,
@@ -945,7 +946,7 @@ async function assertSharingGroupBelongsToSlot(db: SqlExecutor, slotId: string, 
     JOIN bookings b ON b.id = bt.booking_id
     WHERE btd.sharing_group_id = ${groupId}
       AND ba.availability_slot_id = ${slotId}
-      AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
+      AND b.status IN (${activeBookingStatusesForSlotSql()})
       AND ba.status IN ('held', 'confirmed', 'fulfilled')
     LIMIT 1
   `,
@@ -973,7 +974,7 @@ async function countResourceOccupants(
     JOIN bookings b ON b.id = bt.booking_id
     WHERE btd.allocations ->> ${kind} = ${resourceId}
       AND ba.availability_slot_id = ${slotId}
-      AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
+      AND b.status IN (${activeBookingStatusesForSlotSql()})
       AND ba.status IN ('held', 'confirmed', 'fulfilled')
       AND (${excludeTravelerId ?? null}::text IS NULL OR btd.traveler_id <> ${excludeTravelerId ?? null})
   `,
@@ -1220,7 +1221,7 @@ async function loadSlotBookingRowsBothJoins(
       GROUP BY booking_id
     ) sch ON sch.booking_id = b.id
     WHERE ba.availability_slot_id = ${slotId}
-      AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
+      AND b.status IN (${activeBookingStatusesForSlotSql()})
       AND ba.status IN ('held', 'confirmed', 'fulfilled')
     ORDER BY b.created_at, b.booking_number
   `,
@@ -1262,7 +1263,7 @@ async function loadSlotBookingRowsInvoicesOnly(
       GROUP BY booking_id
     ) inv ON inv.booking_id = b.id
     WHERE ba.availability_slot_id = ${slotId}
-      AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
+      AND b.status IN (${activeBookingStatusesForSlotSql()})
       AND ba.status IN ('held', 'confirmed', 'fulfilled')
     ORDER BY b.created_at, b.booking_number
   `,
@@ -1303,7 +1304,7 @@ async function loadSlotBookingRowsSchedulesOnly(
       GROUP BY booking_id
     ) sch ON sch.booking_id = b.id
     WHERE ba.availability_slot_id = ${slotId}
-      AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
+      AND b.status IN (${activeBookingStatusesForSlotSql()})
       AND ba.status IN ('held', 'confirmed', 'fulfilled')
     ORDER BY b.created_at, b.booking_number
   `,
@@ -1335,7 +1336,7 @@ async function loadSlotBookingRowsBare(
     FROM bookings b
     JOIN booking_allocations ba ON ba.booking_id = b.id
     WHERE ba.availability_slot_id = ${slotId}
-      AND b.status IN ('draft', 'on_hold', 'confirmed', 'in_progress', 'completed')
+      AND b.status IN (${activeBookingStatusesForSlotSql()})
       AND ba.status IN ('held', 'confirmed', 'fulfilled')
     ORDER BY b.created_at, b.booking_number
   `,

--- a/packages/availability/src/service-unit-availability.ts
+++ b/packages/availability/src/service-unit-availability.ts
@@ -1,6 +1,7 @@
 import { and, asc, eq, inArray, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
+import { ACTIVE_BOOKING_STATUSES_FOR_SLOT } from "./booking-statuses.js"
 import { bookingItemsRef, bookingsRef } from "./bookings-ref.js"
 import { optionUnitsRef } from "./option-units-ref.js"
 import { availabilitySlots } from "./schema.js"
@@ -16,19 +17,6 @@ export interface SlotUnitAvailability {
   /** `initial - reserved`, or `null` when the pool is unlimited. */
   remaining: number | null
 }
-
-/**
- * Active booking statuses that count against slot capacity. `cancelled` and
- * `expired` are excluded so operator-visible allocation numbers drop the
- * moment a booking is cancelled — no separate release step needed.
- */
-const ACTIVE_BOOKING_STATUSES = [
-  "draft",
-  "on_hold",
-  "confirmed",
-  "in_progress",
-  "completed",
-] as const
 
 /**
  * Returns per-option-unit availability for a slot. `reserved` is derived from
@@ -66,7 +54,7 @@ export async function getSlotUnitAvailability(
     .innerJoin(bookingsRef, eq(bookingsRef.id, bookingItemsRef.bookingId))
     .where(
       and(
-        inArray(bookingsRef.status, [...ACTIVE_BOOKING_STATUSES]),
+        inArray(bookingsRef.status, [...ACTIVE_BOOKING_STATUSES_FOR_SLOT]),
         sql`${bookingItemsRef.optionUnitId} IS NOT NULL`,
         sql`${bookingItemsRef.metadata}->>'availabilitySlotId' = ${slotId}`,
       ),

--- a/packages/availability/tests/integration/slot-resource-availability.test.ts
+++ b/packages/availability/tests/integration/slot-resource-availability.test.ts
@@ -67,12 +67,13 @@ describe.skipIf(!DB_AVAILABLE)("slot resource availability (integration)", () =>
 
   async function seedBookingWithTraveler(input: {
     travelerId: string
+    status?: "draft" | "on_hold" | "awaiting_payment" | "confirmed" | "in_progress" | "completed"
     allocations?: Record<string, string>
   }) {
     const bookingId = newId("bookings")
     await db.execute(sql`
       INSERT INTO bookings (id, booking_number, status, sell_currency)
-      VALUES (${bookingId}, ${`B${bookingId.slice(-6)}`}, 'confirmed', 'USD')
+      VALUES (${bookingId}, ${`B${bookingId.slice(-6)}`}, ${input.status ?? "confirmed"}, 'USD')
     `)
     await db.execute(sql`
       INSERT INTO booking_allocations (id, booking_id, availability_slot_id, quantity, allocation_type, status)
@@ -108,6 +109,51 @@ describe.skipIf(!DB_AVAILABLE)("slot resource availability (integration)", () =>
     expect(dbl?.available).toBe(1)
     expect(sgl?.assigned).toBe(0)
     expect(sgl?.available).toBe(1)
+  })
+
+  it("treats awaiting_payment bookings as active slot demand", async () => {
+    const dblId = await seedResource({ kind: "room", capacity: 1, label: "DBL 1", sortOrder: 1 })
+    const travelerId = newId("booking_travelers")
+    await seedBookingWithTraveler({
+      travelerId,
+      status: "awaiting_payment",
+      allocations: { room: dblId },
+    })
+
+    const resources = await getSlotResourceAvailability(db, slotId)
+    expect(resources.find((row) => row.id === dblId)?.assigned).toBe(1)
+
+    const manifest = await getSlotAllocationManifest(db, slotId)
+    expect(manifest?.summary.bookingsByStatus.awaiting_payment).toBe(1)
+    expect(manifest?.summary.travelerCount).toBe(1)
+    expect(manifest?.bookings[0]?.travelers[0]?.id).toBe(travelerId)
+
+    const violations = await validateSlotAllocationCapacity(db, slotId, [
+      { travelerId: newId("booking_travelers"), kind: "room", resourceId: dblId },
+    ])
+    expect(violations[0]?.existingAssigned).toBe(1)
+  })
+
+  it("excludes draft bookings from slot allocation demand", async () => {
+    const dblId = await seedResource({ kind: "room", capacity: 1, label: "DBL 1", sortOrder: 1 })
+    await seedBookingWithTraveler({
+      travelerId: newId("booking_travelers"),
+      status: "draft",
+      allocations: { room: dblId },
+    })
+
+    const resources = await getSlotResourceAvailability(db, slotId)
+    expect(resources.find((row) => row.id === dblId)?.assigned).toBe(0)
+
+    const manifest = await getSlotAllocationManifest(db, slotId)
+    expect(manifest?.summary.bookingsByStatus.draft).toBeUndefined()
+    expect(manifest?.summary.travelerCount).toBe(0)
+    expect(manifest?.bookings).toHaveLength(0)
+
+    const violations = await validateSlotAllocationCapacity(db, slotId, [
+      { travelerId: newId("booking_travelers"), kind: "room", resourceId: dblId },
+    ])
+    expect(violations).toEqual([])
   })
 
   it("returns a violation when planned travelers exceed resource capacity", async () => {

--- a/packages/availability/tests/unit/allocation-exports.test.ts
+++ b/packages/availability/tests/unit/allocation-exports.test.ts
@@ -116,4 +116,24 @@ describe("allocation CSV exports", () => {
     expect(csv).toContain("Unallocated,,Bo Pop,1")
     expect(csv).toContain("Total,,,2")
   })
+
+  it("omits expired bookings from the rooming list", () => {
+    const data = manifest()
+    data.bookings[0]!.status = "expired"
+    const csv = buildAllocationRoomingCsv(data)
+
+    expect(csv).not.toContain("Ana Pop")
+    expect(csv).not.toContain("Bo Pop")
+    expect(csv).toContain("Total,,,0")
+  })
+
+  it("omits draft bookings from the rooming list", () => {
+    const data = manifest()
+    data.bookings[0]!.status = "draft"
+    const csv = buildAllocationRoomingCsv(data)
+
+    expect(csv).not.toContain("Ana Pop")
+    expect(csv).not.toContain("Bo Pop")
+    expect(csv).toContain("Total,,,0")
+  })
 })

--- a/packages/availability/tests/unit/auto-allocator.test.ts
+++ b/packages/availability/tests/unit/auto-allocator.test.ts
@@ -45,11 +45,12 @@ function seat(
 }
 
 describe("planRoomAllocation", () => {
-  it("skips terminal booking statuses", () => {
+  it("skips bookings outside the slot-active status set", () => {
     const plan = planRoomAllocation(
       [
-        traveler({ id: "t1", bookingId: "b1", bookingStatus: "cancelled" }),
-        traveler({ id: "t2", bookingId: "b2", bookingStatus: "no_show" }),
+        traveler({ id: "t1", bookingId: "b1", bookingStatus: "draft" }),
+        traveler({ id: "t2", bookingId: "b2", bookingStatus: "expired" }),
+        traveler({ id: "t3", bookingId: "b3", bookingStatus: "cancelled" }),
       ],
       [room({ id: "r1", capacity: 2 })],
     )

--- a/packages/bookings-ui/tests/unit/option-units-stepper-merge.test.ts
+++ b/packages/bookings-ui/tests/unit/option-units-stepper-merge.test.ts
@@ -144,11 +144,7 @@ describe("optionRowHasInvalidUnit", () => {
   it("matches any unit in a grouped option row, not just the primary unit", () => {
     expect(
       optionRowHasInvalidUnit(
-        [
-          { optionUnitId: "adult" },
-          { optionUnitId: "child" },
-          { optionUnitId: "infant" },
-        ],
+        [{ optionUnitId: "adult" }, { optionUnitId: "child" }, { optionUnitId: "infant" }],
         new Set(["child"]),
       ),
     ).toBe(true)


### PR DESCRIPTION
## Summary
- Add a shared slot-active booking status list: `on_hold`, `awaiting_payment`, `confirmed`, `in_progress`, `completed`.
- Use the shared list across slot allocation manifests, resource usage counts, capacity validation, unit availability, and allocation automation.
- Exclude `draft`, `expired`, and `cancelled` from slot allocation demand and rooming output.
- Add regression coverage for `awaiting_payment` inclusion and `draft` exclusion.

Closes #1280

## Verification
- `pnpm --filter @voyantjs/availability typecheck`
- `pnpm --filter @voyantjs/availability test`
- `pnpm --filter @voyantjs/availability lint`
- `git diff --check`

## Notes
- `pnpm verify:fast` is blocked by an existing `verify:ui-components-barrel` failure for missing exports in `packages/ui/src/components/index.tsx`.
- The pre-push `pnpm test` hook failed in `@voyantjs/finance-ui#test`, outside this availability change.