### PR TITLE
Add stable booking traveler keys

### DIFF
--- a/.changeset/stable-traveler-create-keys.md
+++ b/.changeset/stable-traveler-create-keys.md
@@ -1,0 +1,8 @@
+---
+"@voyantjs/bookings": patch
+"@voyantjs/bookings-react": patch
+"@voyantjs/bookings-ui": patch
+"@voyantjs/finance": patch
+---
+
+Add stable booking-create traveler keys for item and extra line traveler linkage, while keeping deprecated position-based traveler indexes as a transition fallback.

--- a/packages/bookings-react/src/hooks/use-booking-create-mutation.ts
+++ b/packages/bookings-react/src/hooks/use-booking-create-mutation.ts
@@ -9,6 +9,12 @@ import { bookingsQueryKeys } from "../query-keys.js"
 import { type BookingStatus, bookingRecordSchema } from "../schemas.js"
 
 export interface BookingCreateTravelerInput {
+  /**
+   * Stable client-side traveler identity used by itemLines/extraLines
+   * `travelerKeys` to link created booking items to travelers without
+   * relying on request-array position.
+   */
+  clientTravelerKey?: string | null
   firstName: string
   lastName: string
   email?: string | null
@@ -21,9 +27,9 @@ export interface BookingCreateTravelerInput {
   /**
    * Deprecated compatibility alias for the traveler's pricing-tier option
    * unit. The server accepts this field but does not persist it; item-line
-   * `travelerIndexes` carry the supported traveler-to-item linkage.
+   * `travelerKeys` carry the supported traveler-to-item linkage.
    *
-   * @deprecated Use itemLines[].travelerIndexes to express traveler-priced
+   * @deprecated Use itemLines[].travelerKeys to express traveler-priced
    * lines and inventory placement.
    */
   roomUnitId?: string | null
@@ -49,7 +55,7 @@ export interface BookingCreateItemLineInput {
   /**
    * Stable client-side key (e.g. `unit:optu_adult`) the server uses
    * to look up this item after insert and link it to the travelers
-   * referenced in `travelerIndexes`. Server writes
+   * referenced in `travelerKeys`. Server writes
    * `metadata.bookingCreateLineKey` so the lookup survives the
    * round-trip. See voyantjs/voyant#1267.
    */
@@ -62,11 +68,17 @@ export interface BookingCreateItemLineInput {
   unitSellAmountCents?: number | null
   totalSellAmountCents?: number | null
   /**
-   * Indexes (into the request's `travelers` array) of travelers
-   * mapped to this item. The server inserts one
+   * Stable `clientTravelerKey` values of travelers mapped to this item. The server inserts one
    * `booking_item_travelers` row per traveler, linking the created
    * `booking_item` to the corresponding `booking_traveler`. Null or
    * empty = unlinked (no per-traveler ledger entry).
+   */
+  travelerKeys?: string[] | null
+  /**
+   * Indexes (into the request's `travelers` array) of travelers
+   * mapped to this item.
+   *
+   * @deprecated Use travelerKeys. Removal target: next booking-create wire-format major.
    */
   travelerIndexes?: number[] | null
 }
@@ -84,7 +96,13 @@ export interface BookingCreateExtraLineInput {
   sellCurrency: string
   unitSellAmountCents?: number | null
   totalSellAmountCents?: number | null
-  /** See `BookingCreateItemLineInput.travelerIndexes`. */
+  /** See `BookingCreateItemLineInput.travelerKeys`. */
+  travelerKeys?: string[] | null
+  /**
+   * See `BookingCreateItemLineInput.travelerIndexes`.
+   *
+   * @deprecated Use travelerKeys. Removal target: next booking-create wire-format major.
+   */
   travelerIndexes?: number[] | null
 }
 

--- a/packages/bookings-ui/src/components/booking-create-dialog.tsx
+++ b/packages/bookings-ui/src/components/booking-create-dialog.tsx
@@ -797,7 +797,7 @@ export function BookingCreateForm({
       // format needs from the result. Person-priced options get
       // per-band quantities (1 adult + 1 child + 1 infant, not
       // "3 x Adult"); accommodation options keep operator-picked
-      // room quantities. Server gets `clientLineKey` + `travelerIndexes`
+      // room quantities. Server gets `clientLineKey` + `travelerKeys`
       // on each line so it can write `booking_item_travelers` rows.
       const submitUnits =
         roomUnits.length > 0
@@ -813,16 +813,32 @@ export function BookingCreateForm({
         travelers: travelers.travelers,
         units: submitUnits as PricingAssignmentUnit[],
       })
+      const travelerKeysByUnitId = Object.fromEntries(
+        Object.entries(redistributed.travelerIndexesByUnitId).map(([unitId, indexes]) => [
+          unitId,
+          indexes.every((index) => Boolean(redistributed.travelers[index]?.clientTravelerKey))
+            ? indexes
+                .map((index) => redistributed.travelers[index]?.clientTravelerKey)
+                .filter((key): key is string => Boolean(key))
+            : [],
+        ]),
+      )
+      const travelerKeys = redistributed.travelers
+        .map((traveler) => traveler.clientTravelerKey)
+        .filter((key): key is string => Boolean(key))
 
       const itemLines = itemLinesToRows(
         redistributed.quantities,
         submitUnits,
         pricing,
         redistributed.travelerIndexesByUnitId,
+        travelerKeysByUnitId,
       )
       const resolvedExtraLines = resolveBookingExtraLines({
         extraLines,
         travelerCount: travelers.travelers.length,
+        travelerKeys:
+          travelerKeys.length === redistributed.travelers.length ? travelerKeys : undefined,
       })
 
       const travelerRows = travelersToRows({ travelers: redistributed.travelers })

--- a/packages/bookings-ui/src/components/booking-create-utils.ts
+++ b/packages/bookings-ui/src/components/booking-create-utils.ts
@@ -132,6 +132,7 @@ export function itemLinesToRows(
   units: BookingCreateUnitLineRecord[],
   pricing: BookingCreatePricingRecord | null,
   travelerIndexesByUnitId: Record<string, number[]> = {},
+  travelerKeysByUnitId: Record<string, string[]> = {},
 ): BookingCreateItemLineInput[] {
   const unitsById = new Map(units.map((unit) => [unit.optionUnitId, unit]))
   const unitNames = new Map(units.map((unit) => [unit.optionUnitId, unit.unitName]))
@@ -165,18 +166,24 @@ export function itemLinesToRows(
       pricedLine?.unitAmountCents ??
       (totalSellAmountCents != null ? Math.floor(totalSellAmountCents / quantity) : null)
     const travelerIndexes = travelerIndexesByUnitId[optionUnitId]
+    const travelerKeys = travelerKeysByUnitId[optionUnitId]
+    const hasTravelerLinks = Boolean(travelerKeys?.length || travelerIndexes?.length)
     return {
       // Server uses `clientLineKey` to look up this item after insert
       // and link it to travelers via `booking_item_travelers`. Only
       // stamp when there's an actual traveler mapping to write.
-      clientLineKey: travelerIndexes?.length ? `unit:${optionUnitId}` : undefined,
+      clientLineKey: hasTravelerLinks ? `unit:${optionUnitId}` : undefined,
       optionId: unitsById.get(optionUnitId)?.optionId ?? null,
       optionUnitId,
       quantity,
       title: pricedLine?.label ?? unitNames.get(optionUnitId) ?? null,
       unitSellAmountCents,
       totalSellAmountCents,
-      travelerIndexes: travelerIndexes?.length ? travelerIndexes : undefined,
+      ...(travelerKeys?.length
+        ? { travelerKeys }
+        : travelerIndexes?.length
+          ? { travelerIndexes }
+          : {}),
     }
   })
 }

--- a/packages/bookings-ui/src/components/travelers-section.tsx
+++ b/packages/bookings-ui/src/components/travelers-section.tsx
@@ -43,6 +43,8 @@ export type TravelerRole = "lead" | "adult" | "child" | "infant"
 export type TravelerUnitAssignmentSource = "auto" | "manual" | "none"
 
 export interface TravelerEntry {
+  /** Stable client-side identity used by item/extra travelerKeys links. */
+  clientTravelerKey?: string
   personId: string | null
   firstName: string
   lastName: string
@@ -70,9 +72,18 @@ export interface TravelerListValue {
 
 export const emptyTravelerListValue: TravelerListValue = { travelers: [] }
 
+function createClientTravelerKey(): string {
+  const random =
+    typeof globalThis.crypto?.randomUUID === "function"
+      ? globalThis.crypto.randomUUID().replace(/-/g, "")
+      : `${Date.now().toString(36)}${Math.random().toString(36).slice(2)}`
+  return `trav:${random}`
+}
+
 /** Factory for a blank row — `role` defaults to `adult` unless the list is empty. */
 export function createBlankTraveler(role: TravelerRole = "adult"): TravelerEntry {
   return {
+    clientTravelerKey: createClientTravelerKey(),
     personId: null,
     firstName: "",
     lastName: "",
@@ -794,6 +805,7 @@ function createTravelerFromPerson(person: PersonRecord, role: TravelerRole): Tra
   const effectiveRole: TravelerRole =
     role === "lead" ? "lead" : deriveTravelerRoleFromDob(dateOfBirth)
   return {
+    clientTravelerKey: createClientTravelerKey(),
     personId: person.id,
     firstName: person.firstName,
     lastName: person.lastName,

--- a/packages/bookings-ui/tests/unit/booking-create-utils.test.ts
+++ b/packages/bookings-ui/tests/unit/booking-create-utils.test.ts
@@ -160,6 +160,22 @@ describe("booking create helpers", () => {
     ])
   })
 
+  it("uses stable traveler keys on selected unit lines when supplied", () => {
+    const result = itemLinesToRows(
+      { optu_double: 1 },
+      [{ optionId: "opto_dbl", optionUnitId: "optu_double", unitName: "DBL" }],
+      null,
+      { optu_double: [1, 0] },
+      { optu_double: ["trav:second", "trav:first"] },
+    )
+
+    expect(result[0]).toMatchObject({
+      clientLineKey: "unit:optu_double",
+      travelerKeys: ["trav:second", "trav:first"],
+    })
+    expect(result[0]?.travelerIndexes).toBeUndefined()
+  })
+
   it("uses the selected unit for new shared-room groups", () => {
     expect(
       getSelectedSharedRoomUnitId({

--- a/packages/bookings/src/pricing-assignment.ts
+++ b/packages/bookings/src/pricing-assignment.ts
@@ -686,6 +686,8 @@ export function verifyBookingDraft(input: {
   // when present; fall back to deprecated `travelerIndexes` for
   // legacy clients. If neither is present, we can't verify
   // per-traveler assignment — just compare aggregate quantities.
+  // Booking-create schema validation rejects unknown traveler keys
+  // before this verifier runs.
   const unitById = new Map(input.units.map((unit) => [unit.optionUnitId, unit]))
   const travelerIndexByKey = new Map<string, number>()
   for (const [index, traveler] of input.travelers.entries()) {

--- a/packages/bookings/src/pricing-assignment.ts
+++ b/packages/bookings/src/pricing-assignment.ts
@@ -33,6 +33,8 @@ export type AssignmentRoleHint = "adult" | "child" | "infant"
 export type BookingDraftUnitAssignmentSource = "auto" | "manual" | "none"
 
 export interface BookingDraftTraveler {
+  /** Stable client-side traveler key used by wire-format travelerKeys links. */
+  clientTravelerKey?: string | null
   personId: string | null
   firstName: string
   lastName: string
@@ -91,8 +93,8 @@ export interface ResolvedBookingDraft<TTraveler extends BookingDraftTraveler> {
   /**
    * For each unit that ended up assigned, the indexes (into the input
    * traveler array) of travelers mapped to it. Used at submit time to
-   * stamp `travelerIndexes` on `booking_item` lines so the server can
-   * link items to travelers through `booking_item_travelers`.
+   * stamp stable `travelerKeys` on `booking_item` lines so the server
+   * can link items to travelers through `booking_item_travelers`.
    */
   travelerIndexesByUnitId: Record<string, number[]>
 }
@@ -111,6 +113,7 @@ export interface ResolvableExtraLine {
   unitSellAmountCents?: number | null
   totalSellAmountCents?: number | null
   clientLineKey?: string | null
+  travelerKeys?: string[] | null
   travelerIndexes?: number[] | null
 }
 
@@ -523,20 +526,26 @@ export function resolveBookingDraft<TTraveler extends BookingDraftTraveler>(opti
 
 /**
  * Normalize per-person extras to charged traveler quantity and
- * stamp `travelerIndexes` + `clientLineKey` so the server can link
+ * stamp traveler links + `clientLineKey` so the server can link
  * each extra line to the travelers it applies to via
  * `booking_item_travelers`.
  *
  * Per-person mode (`pricingMode === "per_person"` or
  * `pricedPerPerson === true`): quantity multiplied by travelerCount,
- * `travelerIndexes` set to all travelers (uniform applicability).
+ * `travelerKeys` set to all travelers when stable keys are supplied;
+ * otherwise `travelerIndexes` is set as a deprecated fallback.
  * Non-per-person lines pass through with `clientLineKey` only.
  */
 export function resolveBookingExtraLines<TLine extends ResolvableExtraLine>(options: {
   extraLines: readonly TLine[]
   travelerCount: number
+  travelerKeys?: readonly (string | null | undefined)[]
 }): TLine[] {
   const travelerIndexes = Array.from({ length: options.travelerCount }, (_, index) => index)
+  const travelerKeys = (options.travelerKeys ?? []).filter(
+    (key): key is string => typeof key === "string" && key.trim().length > 0,
+  )
+  const useTravelerKeys = travelerKeys.length === options.travelerCount
   return options.extraLines.map((line) => {
     const perPerson = line.pricingMode === "per_person" || line.pricedPerPerson === true
     if (!perPerson) {
@@ -554,7 +563,7 @@ export function resolveBookingExtraLines<TLine extends ResolvableExtraLine>(opti
         line.unitSellAmountCents == null
           ? line.totalSellAmountCents
           : line.unitSellAmountCents * quantity,
-      travelerIndexes,
+      ...(useTravelerKeys ? { travelerKeys } : { travelerIndexes }),
     }
   })
 }
@@ -566,12 +575,13 @@ export function resolveBookingExtraLines<TLine extends ResolvableExtraLine>(opti
  *
  * `roomUnitId` is a deprecated compatibility alias for the pricing tier
  * option unit. Inventory placement is expressed only by item lines and their
- * `travelerIndexes`; the server accepts this field but does not persist it.
+ * `travelerKeys`; the server accepts this field but does not persist it.
  */
 export function travelersToRows(
   value: { travelers: readonly BookingDraftTraveler[] },
   now: Date = new Date(),
 ): Array<{
+  clientTravelerKey: string | null
   personId: string | null
   firstName: string
   lastName: string
@@ -584,6 +594,7 @@ export function travelersToRows(
   roomUnitId: string | null
 }> {
   return value.travelers.map((traveler) => ({
+    clientTravelerKey: traveler.clientTravelerKey?.trim() || null,
     personId: traveler.personId,
     firstName: traveler.firstName.trim(),
     lastName: traveler.lastName.trim(),
@@ -607,6 +618,7 @@ export function travelersToRows(
  * implicitly maps to.
  */
 export interface VerifiableTraveler {
+  clientTravelerKey?: string | null
   isPrimary?: boolean | null
   travelerCategory?: "adult" | "child" | "infant" | "senior" | "other" | null
 }
@@ -618,6 +630,7 @@ export interface VerifiableTraveler {
 export interface VerifiableItemLine {
   optionUnitId: string
   quantity: number
+  travelerKeys?: string[] | null
   travelerIndexes?: number[] | null
 }
 
@@ -651,9 +664,10 @@ export interface VerifyBookingDraftResult {
  * Notes on the reconstruction:
  *   - The wire format doesn't carry split per-traveler assignment
  *     fields (the join-table model encodes them through
- *     `itemLines[].travelerIndexes`), so we reconstruct the relevant
+ *     `itemLines[].travelerKeys`), so we reconstruct the relevant
  *     pricing or inventory unit by walking item lines and matching
- *     them to traveler indexes.
+ *     them to traveler keys. Deprecated `travelerIndexes` remain a
+ *     fallback for older clients.
  *   - DOB doesn't round-trip on the wire today either; we feed the
  *     resolver the `travelerCategory` as a role hint so age-banded
  *     options can still be re-derived.
@@ -668,13 +682,24 @@ export function verifyBookingDraft(input: {
   }
 
   // Walk the submitted itemLines to recover the per-traveler unit
-  // assignment the client intended. If the client didn't send
-  // `travelerIndexes` (legacy clients), we can't verify per-traveler
-  // assignment — just compare aggregate quantities.
+  // assignment the client intended. Prefer stable `travelerKeys`
+  // when present; fall back to deprecated `travelerIndexes` for
+  // legacy clients. If neither is present, we can't verify
+  // per-traveler assignment — just compare aggregate quantities.
   const unitById = new Map(input.units.map((unit) => [unit.optionUnitId, unit]))
+  const travelerIndexByKey = new Map<string, number>()
+  for (const [index, traveler] of input.travelers.entries()) {
+    const key = traveler.clientTravelerKey?.trim()
+    if (key && !travelerIndexByKey.has(key)) travelerIndexByKey.set(key, index)
+  }
   const unitByTravelerIndex = new Map<number, string>()
   for (const line of input.itemLines) {
-    for (const idx of line.travelerIndexes ?? []) {
+    const travelerKeys = (line.travelerKeys ?? []).filter((key) => key.trim().length > 0)
+    const keyedIndexes = travelerKeys
+      .map((key) => travelerIndexByKey.get(key.trim()))
+      .filter((index): index is number => typeof index === "number")
+    const indexes = travelerKeys.length > 0 ? keyedIndexes : (line.travelerIndexes ?? [])
+    for (const idx of indexes) {
       unitByTravelerIndex.set(idx, line.optionUnitId)
     }
   }

--- a/packages/bookings/src/validation.ts
+++ b/packages/bookings/src/validation.ts
@@ -232,6 +232,8 @@ export const convertProductSchema = z
           description: z.string().max(5000).optional().nullable(),
           unitSellAmountCents: z.number().int().min(0).optional().nullable(),
           totalSellAmountCents: z.number().int().min(0).optional().nullable(),
+          travelerKeys: z.array(z.string().min(1).max(255)).optional().nullable(),
+          travelerIndexes: z.array(z.number().int().min(0)).optional().nullable(),
         }),
       )
       .optional(),

--- a/packages/bookings/tests/unit/pricing-assignment.test.ts
+++ b/packages/bookings/tests/unit/pricing-assignment.test.ts
@@ -32,6 +32,7 @@ function unit(
 
 function traveler(partial: Partial<BookingDraftTraveler> = {}): BookingDraftTraveler {
   return {
+    clientTravelerKey: partial.clientTravelerKey ?? null,
     personId: partial.personId ?? null,
     firstName: partial.firstName ?? "Test",
     lastName: partial.lastName ?? "Traveler",
@@ -428,6 +429,28 @@ describe("resolveBookingExtraLines", () => {
       },
     ])
   })
+
+  it("uses stable traveler keys for per-person extra links when supplied", () => {
+    const result = resolveBookingExtraLines({
+      travelerCount: 2,
+      travelerKeys: ["trav:lead", "trav:child"],
+      extraLines: [
+        {
+          productExtraId: "lunch",
+          pricingMode: "per_person",
+          pricedPerPerson: true,
+          quantity: 1,
+          unitSellAmountCents: 1000,
+        },
+      ],
+    })
+
+    expect(result[0]).toMatchObject({
+      clientLineKey: "extra:lunch",
+      travelerKeys: ["trav:lead", "trav:child"],
+    })
+    expect(result[0]?.travelerIndexes).toBeUndefined()
+  })
 })
 
 describe("travelersToRows", () => {
@@ -447,6 +470,14 @@ describe("travelersToRows", () => {
     expect(rows[1]).toMatchObject({ isPrimary: false, travelerCategory: "child" })
     // DOB wins over role for the third traveler — they're 7y old, so "child"
     expect(rows[2]).toMatchObject({ isPrimary: false, travelerCategory: "child" })
+  })
+
+  it("carries stable traveler keys into the booking-create wire rows", () => {
+    const rows = travelersToRows({
+      travelers: [traveler({ clientTravelerKey: "trav:lead", role: "lead" })],
+    })
+
+    expect(rows[0]?.clientTravelerKey).toBe("trav:lead")
   })
 
   it("keeps legacy roomUnitId wire field as a pricing-tier alias", () => {
@@ -523,6 +554,50 @@ describe("verifyBookingDraft", () => {
         { optionUnitId: "u_adult", quantity: 1, travelerIndexes: [0] },
         { optionUnitId: "u_child_6_12", quantity: 1, travelerIndexes: [1] },
         { optionUnitId: "u_child_0_5", quantity: 1, travelerIndexes: [2] },
+      ],
+    })
+    expect(result.ok).toBe(true)
+    expect(result.mismatches).toEqual([])
+  })
+
+  it("returns ok when submitted lines reference reordered travelers by stable keys", () => {
+    const result = verifyBookingDraft({
+      units: krushunaUnits,
+      travelers: [
+        { clientTravelerKey: "trav:child", isPrimary: false, travelerCategory: "child" },
+        { clientTravelerKey: "trav:adult", isPrimary: true, travelerCategory: "adult" },
+        { clientTravelerKey: "trav:infant", isPrimary: false, travelerCategory: "infant" },
+      ],
+      itemLines: [
+        { optionUnitId: "u_adult", quantity: 1, travelerKeys: ["trav:adult"] },
+        { optionUnitId: "u_child_6_12", quantity: 1, travelerKeys: ["trav:child"] },
+        { optionUnitId: "u_child_0_5", quantity: 1, travelerKeys: ["trav:infant"] },
+      ],
+    })
+    expect(result.ok).toBe(true)
+    expect(result.mismatches).toEqual([])
+  })
+
+  it("prefers stable traveler keys over deprecated indexes", () => {
+    const result = verifyBookingDraft({
+      units: krushunaUnits,
+      travelers: [
+        { clientTravelerKey: "trav:child", isPrimary: false, travelerCategory: "child" },
+        { clientTravelerKey: "trav:adult", isPrimary: true, travelerCategory: "adult" },
+      ],
+      itemLines: [
+        {
+          optionUnitId: "u_adult",
+          quantity: 1,
+          travelerKeys: ["trav:adult"],
+          travelerIndexes: [0],
+        },
+        {
+          optionUnitId: "u_child_6_12",
+          quantity: 1,
+          travelerKeys: ["trav:child"],
+          travelerIndexes: [1],
+        },
       ],
     })
     expect(result.ok).toBe(true)

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -36,6 +36,7 @@ import {
 // ---------- validation ----------
 
 const travelerInputSchema = z.object({
+  clientTravelerKey: z.string().min(1).max(255).optional().nullable(),
   firstName: z.string().min(1).max(255),
   lastName: z.string().min(1).max(255),
   email: z.string().email().optional().nullable(),
@@ -48,7 +49,7 @@ const travelerInputSchema = z.object({
   /**
    * Deprecated compatibility alias for the traveler's pricing-tier option
    * unit. Accepted by the input schema for wire compatibility but not
-   * persisted; item-line travelerIndexes are the supported traveler-to-item
+   * persisted; item-line travelerKeys are the supported traveler-to-item
    * linkage.
    */
   roomUnitId: z.string().optional().nullable(),
@@ -87,9 +88,13 @@ const itemLineInputSchema = z.object({
   unitSellAmountCents: z.number().int().min(0).optional().nullable(),
   totalSellAmountCents: z.number().int().min(0).optional().nullable(),
   /**
-   * Indexes (into the request's `travelers` array) of travelers this
-   * item applies to. Server inserts one `booking_item_travelers` row
-   * per traveler.
+   * Stable traveler keys this item applies to. Server inserts one
+   * `booking_item_travelers` row per traveler.
+   */
+  travelerKeys: z.array(z.string().min(1).max(255)).optional().nullable(),
+  /**
+   * Deprecated position-based traveler links. Removal target: next
+   * booking-create wire-format major.
    */
   travelerIndexes: z.array(z.number().int().min(0)).optional().nullable(),
 })
@@ -106,6 +111,7 @@ const extraLineInputSchema = z.object({
   sellCurrency: z.string().length(3),
   unitSellAmountCents: z.number().int().min(0).optional().nullable(),
   totalSellAmountCents: z.number().int().min(0).optional().nullable(),
+  travelerKeys: z.array(z.string().min(1).max(255)).optional().nullable(),
   travelerIndexes: z.array(z.number().int().min(0)).optional().nullable(),
 })
 
@@ -515,16 +521,17 @@ function hasResolverRejectionSignals(input: {
   travelers: NonNullable<BookingCreateInput["travelers"]>
   itemLines: NonNullable<BookingCreateInput["itemLines"]>
 }) {
+  const hasTravelerLinks = (line: NonNullable<BookingCreateInput["itemLines"]>[number]) =>
+    (Array.isArray(line.travelerKeys) && line.travelerKeys.length > 0) ||
+    (Array.isArray(line.travelerIndexes) && line.travelerIndexes.length > 0)
+
   return (
     input.travelers.every(
       (traveler) =>
         traveler.travelerCategory === "adult" ||
         traveler.travelerCategory === "child" ||
         traveler.travelerCategory === "infant",
-    ) &&
-    input.itemLines.every(
-      (line) => Array.isArray(line.travelerIndexes) && line.travelerIndexes.length > 0,
-    )
+    ) && input.itemLines.every(hasTravelerLinks)
   )
 }
 
@@ -559,7 +566,7 @@ async function verifyBookingCreatePayload(tx: PostgresJsDatabase, input: Booking
 }
 
 /**
- * Filter + dedupe `travelerIndexes` against the inserted traveler
+ * Filter + dedupe deprecated `travelerIndexes` against the inserted traveler
  * array, dropping any indexes outside `[0, travelersLength)`.
  */
 function uniqueValidTravelerIndexes(
@@ -574,6 +581,19 @@ function uniqueValidTravelerIndexes(
     if (seen.has(index)) continue
     seen.add(index)
     result.push(index)
+  }
+  return result
+}
+
+function uniqueTravelerKeys(keys: readonly string[] | null | undefined): string[] {
+  if (!keys?.length) return []
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const key of keys) {
+    const normalized = key.trim()
+    if (!normalized || seen.has(normalized)) continue
+    seen.add(normalized)
+    result.push(normalized)
   }
   return result
 }
@@ -593,18 +613,36 @@ async function linkBookingCreateItemsToTravelers(
   tx: PostgresJsDatabase,
   bookingId: string,
   travelers: readonly BookingTraveler[],
+  travelerInputs: readonly Pick<BookingCreateTravelerInput, "clientTravelerKey">[],
   lines: ReadonlyArray<{
     clientLineKey?: string | null
+    travelerKeys?: readonly string[] | null
     travelerIndexes?: readonly number[] | null
   }>,
 ) {
   if (travelers.length === 0 || lines.length === 0) return
-  const requestedLinks = lines.flatMap((line) =>
-    uniqueValidTravelerIndexes(line.travelerIndexes, travelers.length).map((travelerIndex) => ({
-      clientLineKey: line.clientLineKey ?? null,
-      travelerIndex,
-    })),
-  )
+  const travelerByClientKey = new Map<string, BookingTraveler>()
+  for (const [index, travelerInput] of travelerInputs.entries()) {
+    const key = travelerInput.clientTravelerKey?.trim()
+    const traveler = travelers[index]
+    if (key && traveler && !travelerByClientKey.has(key)) travelerByClientKey.set(key, traveler)
+  }
+
+  const requestedLinks = lines.flatMap((line) => {
+    const travelerKeys = uniqueTravelerKeys(line.travelerKeys)
+    if (travelerKeys.length > 0) {
+      return travelerKeys.map((travelerKey) => ({
+        clientLineKey: line.clientLineKey ?? null,
+        traveler: travelerByClientKey.get(travelerKey) ?? null,
+      }))
+    }
+    return uniqueValidTravelerIndexes(line.travelerIndexes, travelers.length).map(
+      (travelerIndex) => ({
+        clientLineKey: line.clientLineKey ?? null,
+        traveler: travelers[travelerIndex] ?? null,
+      }),
+    )
+  })
   if (requestedLinks.length === 0) return
 
   const itemRows = await tx.select().from(bookingItems).where(eq(bookingItems.bookingId, bookingId))
@@ -616,10 +654,9 @@ async function linkBookingCreateItemsToTravelers(
   }
 
   const seen = new Set<string>()
-  const linkRows = requestedLinks.flatMap(({ clientLineKey, travelerIndex }) => {
+  const linkRows = requestedLinks.flatMap(({ clientLineKey, traveler }) => {
     if (!clientLineKey) return []
     const item = itemByClientLineKey.get(clientLineKey)
-    const traveler = travelers[travelerIndex]
     if (!item || !traveler) return []
     const dedupeKey = `${item.id}:${traveler.id}`
     if (seen.has(dedupeKey)) return []
@@ -861,12 +898,13 @@ export async function createBooking(
       }
 
       // 2b. Link booking_items + extras to specific travelers when
-      // the caller supplied `clientLineKey` + `travelerIndexes` on
-      // any line. Item rows were inserted earlier by
+      // the caller supplied `clientLineKey` + `travelerKeys` on any
+      // line. Deprecated `travelerIndexes` remain a fallback. Item
+      // rows were inserted earlier by
       // `convertProductToBooking` (this slice's product converter
       // doesn't run them in the orchestrator); we look them up by
       // the `metadata.bookingCreateLineKey` the converter stamped.
-      await linkBookingCreateItemsToTravelers(tx, booking.id, travelers, [
+      await linkBookingCreateItemsToTravelers(tx, booking.id, travelers, input.travelers ?? [], [
         ...(input.itemLines ?? []),
         ...(input.extraLines ?? []),
       ])

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -282,6 +282,40 @@ function requireUniqueClientTravelerKeys(
   }
 }
 
+function requireKnownTravelerKeys(
+  value: {
+    travelers?: Array<{ clientTravelerKey?: string | null }>
+    itemLines?: Array<{ travelerKeys?: string[] | null }>
+    extraLines?: Array<{ travelerKeys?: string[] | null }>
+  },
+  ctx: z.RefinementCtx,
+) {
+  const knownKeys = new Set(
+    (value.travelers ?? [])
+      .map((traveler) => traveler.clientTravelerKey?.trim())
+      .filter((key): key is string => Boolean(key)),
+  )
+  const checkLines = (
+    field: "itemLines" | "extraLines",
+    lines: Array<{ travelerKeys?: string[] | null }> | undefined,
+  ) => {
+    lines?.forEach((line, lineIndex) => {
+      line.travelerKeys?.forEach((travelerKey, keyIndex) => {
+        const key = travelerKey.trim()
+        if (!key || knownKeys.has(key)) return
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [field, lineIndex, "travelerKeys", keyIndex],
+          message: `Unknown travelerKey: ${key}`,
+        })
+      })
+    })
+  }
+
+  checkLines("itemLines", value.itemLines)
+  checkLines("extraLines", value.extraLines)
+}
+
 function isRealEmail(value: string | null | undefined): value is string {
   const normalized = value?.trim().toLowerCase() ?? ""
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized) && !placeholderEmails.has(normalized)
@@ -355,12 +389,14 @@ export const bookingCreateSchema = bookingCreateBaseSchema
   .superRefine(requirePriceOverrideReason)
   .superRefine(requireCompleteBookingParty)
   .superRefine(requireUniqueClientTravelerKeys)
+  .superRefine(requireKnownTravelerKeys)
 
 export const bookingCreateSubSchema = bookingCreateBaseSchema
   .omit({ groupMembership: true })
   .superRefine(requirePriceOverrideReason)
   .superRefine(requireCompleteBookingParty)
   .superRefine(requireUniqueClientTravelerKeys)
+  .superRefine(requireKnownTravelerKeys)
 
 export type BookingCreateInput = z.infer<typeof bookingCreateSchema>
 type BookingCreatePaymentScheduleInput = NonNullable<BookingCreateInput["paymentSchedules"]>[number]
@@ -667,6 +703,7 @@ async function linkBookingCreateItemsToTravelers(
     if (travelerKeys.length > 0) {
       return travelerKeys.map((travelerKey) => ({
         clientLineKey: line.clientLineKey ?? null,
+        travelerKey,
         traveler: travelerByClientKey.get(travelerKey) ?? null,
       }))
     }
@@ -688,6 +725,14 @@ async function linkBookingCreateItemsToTravelers(
   }
 
   const seen = new Set<string>()
+  const unknownTravelerKeys = requestedLinks
+    .filter((link) => "travelerKey" in link && !link.traveler)
+    .map((link) => ("travelerKey" in link ? link.travelerKey : null))
+    .filter((key): key is string => Boolean(key))
+  if (unknownTravelerKeys.length > 0) {
+    throw new Error(`Unknown travelerKey: ${unknownTravelerKeys.join(", ")}`)
+  }
+
   const linkRows = requestedLinks.flatMap(({ clientLineKey, traveler }) => {
     if (!clientLineKey) return []
     const item = itemByClientLineKey.get(clientLineKey)

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -255,6 +255,33 @@ function requireCompleteBookingParty(
   })
 }
 
+function findDuplicateClientTravelerKeys(
+  travelers: readonly { clientTravelerKey?: string | null }[] | null | undefined,
+): string[] {
+  const seen = new Set<string>()
+  const duplicates = new Set<string>()
+  for (const traveler of travelers ?? []) {
+    const key = traveler.clientTravelerKey?.trim()
+    if (!key) continue
+    if (seen.has(key)) duplicates.add(key)
+    else seen.add(key)
+  }
+  return [...duplicates]
+}
+
+function requireUniqueClientTravelerKeys(
+  value: { travelers?: Array<{ clientTravelerKey?: string | null }> },
+  ctx: z.RefinementCtx,
+) {
+  for (const duplicateKey of findDuplicateClientTravelerKeys(value.travelers)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["travelers"],
+      message: `Duplicate clientTravelerKey: ${duplicateKey}`,
+    })
+  }
+}
+
 function isRealEmail(value: string | null | undefined): value is string {
   const normalized = value?.trim().toLowerCase() ?? ""
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized) && !placeholderEmails.has(normalized)
@@ -327,11 +354,13 @@ const bookingCreateBaseSchema = z.object({
 export const bookingCreateSchema = bookingCreateBaseSchema
   .superRefine(requirePriceOverrideReason)
   .superRefine(requireCompleteBookingParty)
+  .superRefine(requireUniqueClientTravelerKeys)
 
 export const bookingCreateSubSchema = bookingCreateBaseSchema
   .omit({ groupMembership: true })
   .superRefine(requirePriceOverrideReason)
   .superRefine(requireCompleteBookingParty)
+  .superRefine(requireUniqueClientTravelerKeys)
 
 export type BookingCreateInput = z.infer<typeof bookingCreateSchema>
 type BookingCreatePaymentScheduleInput = NonNullable<BookingCreateInput["paymentSchedules"]>[number]
@@ -621,6 +650,11 @@ async function linkBookingCreateItemsToTravelers(
   }>,
 ) {
   if (travelers.length === 0 || lines.length === 0) return
+  const duplicateTravelerKeys = findDuplicateClientTravelerKeys(travelerInputs)
+  if (duplicateTravelerKeys.length > 0) {
+    throw new Error(`Duplicate clientTravelerKey: ${duplicateTravelerKeys.join(", ")}`)
+  }
+
   const travelerByClientKey = new Map<string, BookingTraveler>()
   for (const [index, travelerInput] of travelerInputs.entries()) {
     const key = travelerInput.clientTravelerKey?.trim()

--- a/packages/finance/tests/integration/booking-create.test.ts
+++ b/packages/finance/tests/integration/booking-create.test.ts
@@ -713,6 +713,64 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
     )
   })
 
+  it("rejects item and extra lines that reference unknown stable traveler keys", async () => {
+    const { productId, unitId } = await seedProduct()
+
+    const result = bookingCreateSchema.safeParse({
+      productId,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+      travelers: [
+        {
+          clientTravelerKey: "trav:lead",
+          firstName: "Alice",
+          lastName: "Lead",
+          participantType: "traveler",
+          travelerCategory: "adult",
+          isPrimary: true,
+        },
+      ],
+      itemLines: [
+        {
+          clientLineKey: `unit:${unitId}`,
+          optionUnitId: unitId,
+          quantity: 1,
+          title: "Adult",
+          travelerKeys: ["trav:missing-item"],
+        },
+      ],
+      extraLines: [
+        {
+          clientLineKey: "extra:lunch",
+          productExtraId: "lunch",
+          name: "Lunch",
+          pricingMode: "per_person",
+          pricedPerPerson: true,
+          quantity: 1,
+          sellCurrency: "EUR",
+          unitSellAmountCents: 1000,
+          totalSellAmountCents: 1000,
+          travelerKeys: ["trav:missing-extra"],
+        },
+      ],
+    })
+
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: ["itemLines", 0, "travelerKeys", 0],
+          message: "Unknown travelerKey: trav:missing-item",
+        }),
+        expect.objectContaining({
+          path: ["extraLines", 0, "travelerKeys", 0],
+          message: "Unknown travelerKey: trav:missing-extra",
+        }),
+      ]),
+    )
+  })
+
   it("rejects booking-create payloads that drift from the server draft resolver", async () => {
     const { productId, unitId, childUnitId, infantUnitId } = await seedProduct({
       ageBandedUnits: true,

--- a/packages/finance/tests/integration/booking-create.test.ts
+++ b/packages/finance/tests/integration/booking-create.test.ts
@@ -600,6 +600,73 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
     expect(links).toHaveLength(4)
   })
 
+  it("links item and extra lines to reordered travelers through stable keys", async () => {
+    const { productId, unitId } = await seedProduct()
+
+    const outcome = await createBooking(db, {
+      productId,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+      travelers: [
+        {
+          clientTravelerKey: "trav:child",
+          firstName: "Child",
+          lastName: "Traveler",
+          participantType: "traveler",
+          travelerCategory: "child",
+        },
+        {
+          clientTravelerKey: "trav:lead",
+          firstName: "Alice",
+          lastName: "Lead",
+          email: "alice@example.com",
+          participantType: "traveler",
+          travelerCategory: "adult",
+          isPrimary: true,
+        },
+      ],
+      itemLines: [
+        {
+          clientLineKey: `unit:${unitId}`,
+          optionUnitId: unitId,
+          quantity: 1,
+          title: "Adult",
+          travelerKeys: ["trav:lead"],
+        },
+      ],
+      extraLines: [
+        {
+          clientLineKey: "extra:lunch",
+          productExtraId: "lunch",
+          name: "Lunch",
+          pricingMode: "per_person",
+          pricedPerPerson: true,
+          quantity: 1,
+          sellCurrency: "EUR",
+          unitSellAmountCents: 1000,
+          totalSellAmountCents: 1000,
+          travelerKeys: ["trav:child"],
+        },
+      ],
+    })
+
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+
+    const linkedRows = await db.execute<{ item_title: string; traveler_last_name: string }>(sql`
+      SELECT bi.title AS item_title, bt.last_name AS traveler_last_name
+      FROM booking_item_travelers bit
+      JOIN booking_items bi ON bi.id = bit.booking_item_id
+      JOIN booking_travelers bt ON bt.id = bit.traveler_id
+      WHERE bi.booking_id = ${outcome.result.booking.id}
+      ORDER BY bi.title, bt.last_name
+    `)
+    expect(linkedRows).toEqual([
+      { item_title: "Adult", traveler_last_name: "Lead" },
+      { item_title: "Lunch", traveler_last_name: "Traveler" },
+    ])
+  })
+
   it("rejects booking-create payloads that drift from the server draft resolver", async () => {
     const { productId, unitId, childUnitId, infantUnitId } = await seedProduct({
       ageBandedUnits: true,

--- a/packages/finance/tests/integration/booking-create.test.ts
+++ b/packages/finance/tests/integration/booking-create.test.ts
@@ -18,7 +18,7 @@ import {
   voucherRedemptions,
   vouchers,
 } from "../../src/schema.js"
-import { createBooking } from "../../src/service-booking-create.js"
+import { bookingCreateSchema, createBooking } from "../../src/service-booking-create.js"
 
 const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
 
@@ -665,6 +665,52 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
       { item_title: "Adult", traveler_last_name: "Lead" },
       { item_title: "Lunch", traveler_last_name: "Traveler" },
     ])
+  })
+
+  it("rejects duplicate stable traveler keys", async () => {
+    const { productId, unitId } = await seedProduct()
+
+    const result = bookingCreateSchema.safeParse({
+      productId,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+      travelers: [
+        {
+          clientTravelerKey: "trav:duplicate",
+          firstName: "Alice",
+          lastName: "Lead",
+          participantType: "traveler",
+          travelerCategory: "adult",
+          isPrimary: true,
+        },
+        {
+          clientTravelerKey: "trav:duplicate",
+          firstName: "Bob",
+          lastName: "Traveler",
+          participantType: "traveler",
+          travelerCategory: "adult",
+        },
+      ],
+      itemLines: [
+        {
+          clientLineKey: `unit:${unitId}`,
+          optionUnitId: unitId,
+          quantity: 1,
+          title: "Adult",
+          travelerKeys: ["trav:duplicate"],
+        },
+      ],
+    })
+
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: "Duplicate clientTravelerKey: trav:duplicate",
+        }),
+      ]),
+    )
   })
 
   it("rejects booking-create payloads that drift from the server draft resolver", async () => {


### PR DESCRIPTION
## Summary

- Add `clientTravelerKey` on booking-create travelers and `travelerKeys` on item/extra lines.
- Keep deprecated `travelerIndexes` as a transition fallback, with key-based resolution preferred when present.
- Mint stable traveler keys in the booking-create dialog and submit key-based item/extra traveler links.
- Update server item-to-traveler linking and payload verification to resolve stable keys.

Closes #1275.

## Verification

- `pnpm --filter @voyantjs/bookings test -- pricing-assignment`
- `pnpm --filter @voyantjs/bookings-ui test -- booking-create-utils`
- `pnpm --filter @voyantjs/finance test -- booking-create`
- `pnpm --filter @voyantjs/bookings typecheck`
- `pnpm --filter @voyantjs/bookings-react typecheck`
- `pnpm --filter @voyantjs/bookings-ui typecheck`
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm lint:changed`