### PR TITLE
Cover accommodation booking create lines

### DIFF
--- a/.changeset/normalize-accommodation-create-lines.md
+++ b/.changeset/normalize-accommodation-create-lines.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/finance": patch
+---
+
+Normalize legacy person-keyed accommodation booking-create item lines onto their inventory unit before item insertion, linking, and server-side draft verification.

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -582,6 +582,51 @@ async function loadProductOptionUnits(
   }))
 }
 
+function isInventoryOptionUnit(unit: PricingAssignmentUnit): boolean {
+  return unit.unitType === "room" || unit.unitType === "vehicle"
+}
+
+function isPersonOptionUnit(unit: PricingAssignmentUnit): boolean {
+  return unit.unitType == null || unit.unitType === "person"
+}
+
+function normalizeAccommodationItemLinesToInventoryUnits(options: {
+  itemLines: NonNullable<BookingCreateInput["itemLines"]> | undefined
+  units: readonly PricingAssignmentUnit[]
+}): NonNullable<BookingCreateInput["itemLines"]> | undefined {
+  if (!options.itemLines?.length || options.units.length === 0) return options.itemLines
+
+  const unitsByOption = new Map<string, PricingAssignmentUnit[]>()
+  const unitById = new Map<string, PricingAssignmentUnit>()
+  const unitToPrimaryInventory = new Map<string, PricingAssignmentUnit>()
+  for (const unit of options.units) {
+    const optionKey = unit.optionId ?? unit.optionUnitId
+    unitById.set(unit.optionUnitId, unit)
+    const optionUnits = unitsByOption.get(optionKey)
+    if (optionUnits) optionUnits.push(unit)
+    else unitsByOption.set(optionKey, [unit])
+  }
+
+  for (const optionUnits of unitsByOption.values()) {
+    const primaryInventory = optionUnits.find(isInventoryOptionUnit)
+    if (!primaryInventory) continue
+    for (const unit of optionUnits) {
+      unitToPrimaryInventory.set(unit.optionUnitId, primaryInventory)
+    }
+  }
+
+  return options.itemLines.map((line) => {
+    const submittedUnit = unitById.get(line.optionUnitId)
+    const targetInventory = unitToPrimaryInventory.get(line.optionUnitId)
+    if (!submittedUnit || !targetInventory) return line
+    if (isInventoryOptionUnit(submittedUnit) || !isPersonOptionUnit(submittedUnit)) return line
+    return {
+      ...line,
+      optionUnitId: targetInventory.optionUnitId,
+    }
+  })
+}
+
 function hasResolverRejectionSignals(input: {
   travelers: NonNullable<BookingCreateInput["travelers"]>
   itemLines: NonNullable<BookingCreateInput["itemLines"]>
@@ -869,6 +914,13 @@ export async function createBooking(
   let result: BookingCreateResult
   try {
     result = await db.transaction(async (tx) => {
+      const productOptionUnits = input.itemLines?.length
+        ? await loadProductOptionUnits(tx, input.productId)
+        : []
+      const normalizedItemLines = normalizeAccommodationItemLinesToInventoryUnits({
+        itemLines: input.itemLines,
+        units: productOptionUnits,
+      })
       // 1. Booking from product
       const booking = await bookingsService.createBookingFromProduct(tx, {
         productId: input.productId,
@@ -894,7 +946,7 @@ export async function createBooking(
         contactCity: input.contactCity ?? null,
         contactAddressLine1: input.contactAddressLine1 ?? null,
         contactPostalCode: input.contactPostalCode ?? null,
-        itemLines: input.itemLines,
+        itemLines: normalizedItemLines,
       })
       if (!booking) {
         // Caller gave us a product that doesn't resolve. Throw so drizzle
@@ -984,14 +1036,14 @@ export async function createBooking(
       // doesn't run them in the orchestrator); we look them up by
       // the `metadata.bookingCreateLineKey` the converter stamped.
       await linkBookingCreateItemsToTravelers(tx, booking.id, travelers, input.travelers ?? [], [
-        ...(input.itemLines ?? []),
+        ...(normalizedItemLines ?? []),
         ...(input.extraLines ?? []),
       ])
 
       // 2c. Re-run the resolver server-side against the submitted
       // itemLines + travelers and reject any client/server drift on
       // per-band quantities. See voyantjs/voyant#1272.
-      await verifyBookingCreatePayload(tx, input)
+      await verifyBookingCreatePayload(tx, { ...input, itemLines: normalizedItemLines })
 
       // 3. Payment schedules
       const paymentSchedules: BookingPaymentSchedule[] = []

--- a/packages/finance/tests/integration/booking-create.test.ts
+++ b/packages/finance/tests/integration/booking-create.test.ts
@@ -161,6 +161,61 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
     return { productId, optionId, unitId, childUnitId, infantUnitId }
   }
 
+  async function seedAccommodationProduct() {
+    productSeq += 1
+    const productId = `prod_bc_accom_${productSeq}`
+    const optionId = `popt_bc_accom_${productSeq}`
+    const roomUnitId = `opun_bc_accom_${productSeq}_dbl`
+    const adultUnitId = `opun_bc_accom_${productSeq}_adult`
+    const itineraryId = `piti_bc_accom_${productSeq}`
+    await db.execute(sql`
+      INSERT INTO products (id, name, sell_currency, sell_amount_cents, cost_amount_cents, margin_percent, start_date, end_date, pax)
+      VALUES (
+        ${productId},
+        ${`Accommodation Product ${productSeq}`},
+        'EUR',
+        50000,
+        30000,
+        40,
+        '2026-07-01',
+        '2026-07-03',
+        2
+      )
+    `)
+    await db.execute(sql`
+      INSERT INTO product_options (id, product_id, name, status, is_default, sort_order)
+      VALUES (${optionId}, ${productId}, 'DBL', 'active', true, 0)
+    `)
+    await db.execute(sql`
+      INSERT INTO option_units (
+        id,
+        option_id,
+        name,
+        code,
+        unit_type,
+        min_age,
+        occupancy_min,
+        occupancy_max,
+        is_required,
+        min_quantity,
+        sort_order
+      )
+      VALUES
+        (${roomUnitId}, ${optionId}, 'DBL room', 'dbl_room', 'room', null, 1, 2, true, 1, 0),
+        (${adultUnitId}, ${optionId}, 'Adult', 'adult', 'person', 18, null, null, true, 1, 1)
+    `)
+    await db.execute(sql`
+      INSERT INTO product_itineraries (id, product_id, name, is_default, sort_order)
+      VALUES (${itineraryId}, ${productId}, 'Default', true, 0)
+    `)
+    await db.execute(sql`
+      INSERT INTO product_ticket_settings (id, product_id, fulfillment_mode, default_delivery_format, ticket_per_unit)
+      VALUES (${`ptix_bc_accom_${productSeq}`}, ${productId}, 'per_item', 'qr_code', false)
+    `)
+
+    return { productId, optionId, roomUnitId, adultUnitId }
+  }
+
   async function seedVoucher(
     overrides: {
       code?: string
@@ -665,6 +720,127 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
       { item_title: "Adult", traveler_last_name: "Lead" },
       { item_title: "Lunch", traveler_last_name: "Traveler" },
     ])
+  })
+
+  it("creates a multi-day accommodation booking as one room item linked to both travelers", async () => {
+    const { productId, roomUnitId } = await seedAccommodationProduct()
+    const bundledTotalAmountCents = 60_000
+
+    const outcome = await createBooking(db, {
+      productId,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+      catalogSellAmountCents: bundledTotalAmountCents,
+      confirmedSellAmountCents: bundledTotalAmountCents,
+      travelers: [
+        {
+          firstName: "Alice",
+          lastName: "Lead",
+          email: "alice@example.com",
+          participantType: "traveler",
+          travelerCategory: "adult",
+          isPrimary: true,
+        },
+        {
+          firstName: "Bob",
+          lastName: "Companion",
+          participantType: "traveler",
+          travelerCategory: "adult",
+        },
+      ],
+      itemLines: [
+        {
+          clientLineKey: `unit:${roomUnitId}`,
+          optionUnitId: roomUnitId,
+          quantity: 1,
+          title: "DBL room",
+          unitSellAmountCents: bundledTotalAmountCents,
+          totalSellAmountCents: bundledTotalAmountCents,
+          travelerIndexes: [0, 1],
+        },
+      ],
+    })
+
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+    expect(outcome.result.booking.sellAmountCents).toBe(bundledTotalAmountCents)
+
+    const itemRows = await db
+      .select()
+      .from(bookingItems)
+      .where(eq(bookingItems.bookingId, outcome.result.booking.id))
+    expect(itemRows).toHaveLength(1)
+    expect(itemRows[0]).toMatchObject({
+      optionUnitId: roomUnitId,
+      quantity: 1,
+      totalSellAmountCents: bundledTotalAmountCents,
+    })
+
+    const links = await db
+      .select()
+      .from(bookingItemTravelers)
+      .where(eq(bookingItemTravelers.bookingItemId, itemRows[0]!.id))
+    expect(links).toHaveLength(2)
+  })
+
+  it("normalizes legacy adult-keyed accommodation item lines onto the room unit", async () => {
+    const { productId, roomUnitId, adultUnitId } = await seedAccommodationProduct()
+    const bundledTotalAmountCents = 60_000
+
+    const outcome = await createBooking(db, {
+      productId,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+      catalogSellAmountCents: bundledTotalAmountCents,
+      confirmedSellAmountCents: bundledTotalAmountCents,
+      travelers: [
+        {
+          firstName: "Alice",
+          lastName: "Lead",
+          email: "alice@example.com",
+          participantType: "traveler",
+          travelerCategory: "adult",
+          isPrimary: true,
+        },
+        {
+          firstName: "Bob",
+          lastName: "Companion",
+          participantType: "traveler",
+          travelerCategory: "adult",
+        },
+      ],
+      itemLines: [
+        {
+          clientLineKey: `unit:${adultUnitId}`,
+          optionUnitId: adultUnitId,
+          quantity: 1,
+          title: "Adult",
+          unitSellAmountCents: bundledTotalAmountCents,
+          totalSellAmountCents: bundledTotalAmountCents,
+          travelerIndexes: [0, 1],
+        },
+      ],
+    })
+
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+
+    const itemRows = await db
+      .select()
+      .from(bookingItems)
+      .where(eq(bookingItems.bookingId, outcome.result.booking.id))
+    expect(itemRows).toHaveLength(1)
+    expect(itemRows[0]).toMatchObject({
+      optionUnitId: roomUnitId,
+      quantity: 1,
+      totalSellAmountCents: bundledTotalAmountCents,
+    })
+
+    const links = await db
+      .select()
+      .from(bookingItemTravelers)
+      .where(eq(bookingItemTravelers.bookingItemId, itemRows[0]!.id))
+    expect(links).toHaveLength(2)
   })
 
   it("rejects duplicate stable traveler keys", async () => {


### PR DESCRIPTION
## Summary

- Add an accommodation booking-create integration fixture with a room unit plus adult pricing unit.
- Cover the post-#1282 room-unit line shape: one `booking_items` row on the DBL room, two traveler links, and bundled booking total.
- Normalize legacy person-keyed accommodation item lines onto the primary inventory unit before item insertion, traveler linking, and server-side draft verification.
- Add a compatibility integration assertion for the legacy adult-keyed payload.

Closes #1274.

## Verification

- `pnpm --filter @voyantjs/finance test -- booking-create`
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm lint:changed`