### PR TITLE
Fix CRM people search by contact points

### DIFF
--- a/.changeset/sharp-crm-contact-search.md
+++ b/.changeset/sharp-crm-contact-search.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/crm": patch
+---
+
+Include person email and phone contact points in CRM people search, with phone digit matching tolerant of formatting differences.

--- a/packages/crm/src/service/accounts-people.ts
+++ b/packages/crm/src/service/accounts-people.ts
@@ -1,5 +1,6 @@
+import { identityContactPoints } from "@voyantjs/identity/schema"
 import { identityService } from "@voyantjs/identity/service"
-import { and, asc, desc, eq, gte, ilike, lte, or, sql } from "drizzle-orm"
+import { and, asc, desc, eq, exists, gte, ilike, lte, or, type SQL, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import {
@@ -37,23 +38,53 @@ import {
 } from "./accounts-shared.js"
 import { paginate } from "./helpers.js"
 
+function buildPersonSearchCondition(db: PostgresJsDatabase, search: string): SQL | undefined {
+  const term = `%${search}%`
+  const digits = search.replace(/\D/g, "")
+  const contactPointConditions: SQL[] = [
+    ilike(identityContactPoints.value, term),
+    ilike(identityContactPoints.normalizedValue, term),
+  ]
+
+  if (digits) {
+    const digitsTerm = `%${digits}%`
+    contactPointConditions.push(
+      sql`regexp_replace(${identityContactPoints.value}, '[^0-9]+', '', 'g') ILIKE ${digitsTerm}`,
+      sql`regexp_replace(coalesce(${identityContactPoints.normalizedValue}, ''), '[^0-9]+', '', 'g') ILIKE ${digitsTerm}`,
+    )
+  }
+
+  return or(
+    ilike(people.firstName, term),
+    ilike(people.lastName, term),
+    ilike(people.jobTitle, term),
+    exists(
+      db
+        .select({ one: sql`1` })
+        .from(identityContactPoints)
+        .where(
+          and(
+            eq(identityContactPoints.entityType, personEntityType),
+            eq(identityContactPoints.entityId, people.id),
+            or(eq(identityContactPoints.kind, "email"), eq(identityContactPoints.kind, "phone")),
+            or(...contactPointConditions),
+          ),
+        ),
+    ),
+  )
+}
+
 export const peopleAccountsService = {
   async listPeople(db: PostgresJsDatabase, query: PersonListQuery) {
-    const conditions = []
+    const conditions: SQL[] = []
 
     if (query.organizationId) conditions.push(eq(people.organizationId, query.organizationId))
     if (query.ownerId) conditions.push(eq(people.ownerId, query.ownerId))
     if (query.relation) conditions.push(eq(people.relation, query.relation))
     if (query.status) conditions.push(eq(people.status, query.status))
     if (query.search) {
-      const term = `%${query.search}%`
-      conditions.push(
-        or(
-          ilike(people.firstName, term),
-          ilike(people.lastName, term),
-          ilike(people.jobTitle, term),
-        ),
-      )
+      const searchCondition = buildPersonSearchCondition(db, query.search)
+      if (searchCondition) conditions.push(searchCondition)
     }
 
     const where = conditions.length ? and(...conditions) : undefined

--- a/packages/crm/tests/integration/accounts.test.ts
+++ b/packages/crm/tests/integration/accounts.test.ts
@@ -247,6 +247,46 @@ describe.skipIf(!DB_AVAILABLE)("Account routes", () => {
       expect(listBody.data[0]?.phone).toBe("+40123456789")
     })
 
+    it("searches people by email contact point", async () => {
+      await app.request("/people", {
+        method: "POST",
+        ...json({ firstName: "Email", lastName: "Match", email: "client@example.com" }),
+      })
+      await app.request("/people", {
+        method: "POST",
+        ...json({ firstName: "Other", lastName: "Person", email: "other@example.com" }),
+      })
+
+      const res = await app.request(`/people?search=${encodeURIComponent("CLIENT@example.com")}`, {
+        method: "GET",
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.total).toBe(1)
+      expect(body.data[0]?.email).toBe("client@example.com")
+    })
+
+    it("searches people by formatted phone contact point", async () => {
+      await app.request("/people", {
+        method: "POST",
+        ...json({ firstName: "Phone", lastName: "Match", phone: "+40 (712) 345-678" }),
+      })
+      await app.request("/people", {
+        method: "POST",
+        ...json({ firstName: "Other", lastName: "Person", phone: "+40 799 000 000" }),
+      })
+
+      const res = await app.request(`/people?search=${encodeURIComponent("40712 345")}`, {
+        method: "GET",
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.total).toBe(1)
+      expect(body.data[0]?.phone).toBe("+40 (712) 345-678")
+    })
+
     it("lists people", async () => {
       await app.request("/people", {
         method: "POST",


### PR DESCRIPTION
## Summary
- Include CRM person email and phone contact points in `GET /v1/crm/people?search=...` filtering.
- Match phone searches by digits so formatting differences like spaces, plus signs, parentheses, and dashes do not block results.
- Add a patch changeset and integration coverage for email and formatted phone search.

Resolves #1294

## Verification
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed` (report-only warnings only: existing file size warning plus reviewed raw SQL for phone digit normalization)
- `pnpm --filter @voyantjs/crm typecheck`
- `pnpm --filter @voyantjs/crm test` (database-backed integration tests skipped without `TEST_DATABASE_URL`)

## Notes
- `pnpm verify:fast` stops on an existing `@voyantjs/ui` component barrel export check unrelated to this CRM change.
- The broad pre-commit typecheck currently fails in `packages/finance/src/service-booking-create.ts` via the `dmc`/`operator` template typechecks, unrelated to this change.
- The broad pre-push test run currently fails one timing-sensitive `@voyantjs/workflows-orchestrator` driver compliance test, unrelated to this change.