### PR TITLE
Fix admin booking search contact snapshots

### DIFF
--- a/.changeset/quick-bookings-search.md
+++ b/.changeset/quick-bookings-search.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/bookings": patch
+---
+
+Expand admin booking search to include contact snapshot fields, normalized phone numbers, addresses, and external booking references.

--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -125,6 +125,8 @@ function buildBookingSearchCondition(search: string): SQL | undefined {
 
   const term = `%${trimmed}%`
   const normalizedPhoneTerm = trimmed.replace(/\D/g, "")
+  const shouldSearchNormalizedPhone =
+    normalizedPhoneTerm.length >= 7 && /^[+\d\s().-]+$/.test(trimmed)
   const searchConditions: SQL[] = [
     ilike(bookings.bookingNumber, term),
     ilike(bookings.externalBookingRef, term),
@@ -141,7 +143,7 @@ function buildBookingSearchCondition(search: string): SQL | undefined {
     ilike(bookings.contactPostalCode, term),
   ]
 
-  if (normalizedPhoneTerm) {
+  if (shouldSearchNormalizedPhone) {
     searchConditions.push(
       sql`regexp_replace(coalesce(${bookings.contactPhone}, ''), '[^0-9]+', '', 'g') like ${`%${normalizedPhoneTerm}%`}`,
     )

--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -119,6 +119,37 @@ function sqlTextArray(values: readonly string[]): SQL {
   )}]::text[]`
 }
 
+function buildBookingSearchCondition(search: string): SQL | undefined {
+  const trimmed = search.trim()
+  if (!trimmed) return undefined
+
+  const term = `%${trimmed}%`
+  const normalizedPhoneTerm = trimmed.replace(/\D/g, "")
+  const searchConditions: SQL[] = [
+    ilike(bookings.bookingNumber, term),
+    ilike(bookings.externalBookingRef, term),
+    ilike(bookings.internalNotes, term),
+    ilike(bookings.contactFirstName, term),
+    ilike(bookings.contactLastName, term),
+    sql`concat_ws(' ', ${bookings.contactFirstName}, ${bookings.contactLastName}) ilike ${term}`,
+    ilike(bookings.contactEmail, term),
+    ilike(bookings.contactPhone, term),
+    ilike(bookings.contactCountry, term),
+    ilike(bookings.contactRegion, term),
+    ilike(bookings.contactCity, term),
+    ilike(bookings.contactAddressLine1, term),
+    ilike(bookings.contactPostalCode, term),
+  ]
+
+  if (normalizedPhoneTerm) {
+    searchConditions.push(
+      sql`regexp_replace(coalesce(${bookings.contactPhone}, ''), '[^0-9]+', '', 'g') like ${`%${normalizedPhoneTerm}%`}`,
+    )
+  }
+
+  return or(...searchConditions)
+}
+
 type BookingListQuery = z.infer<typeof bookingListQuerySchema>
 type ConvertProductInput = z.infer<typeof convertProductSchema>
 type CreateBookingInput = z.infer<typeof insertBookingSchema>
@@ -2476,8 +2507,10 @@ export const bookingsService = {
     }
 
     if (query.search) {
-      const term = `%${query.search}%`
-      conditions.push(or(ilike(bookings.bookingNumber, term), ilike(bookings.internalNotes, term)))
+      const searchCondition = buildBookingSearchCondition(query.search)
+      if (searchCondition) {
+        conditions.push(searchCondition)
+      }
     }
 
     if (query.personId) {

--- a/packages/bookings/tests/integration/routes.test.ts
+++ b/packages/bookings/tests/integration/routes.test.ts
@@ -722,6 +722,53 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
       expect(body.total).toBeGreaterThanOrEqual(1)
     })
 
+    it("searches booking contact snapshots and external references", async () => {
+      const target = await seedBooking({
+        bookingNumber: "BK-CONTACT-0001",
+        externalBookingRef: "WHATSAPP-REF-42",
+        contactFirstName: "Ana",
+        contactLastName: "Cimpoeru",
+        contactEmail: "ana.cimpoeru@example.com",
+        contactPhone: "+40 712 345 678",
+        contactCountry: "Romania",
+        contactRegion: "Cluj",
+        contactCity: "Cluj-Napoca",
+        contactAddressLine1: "Strada Memorandumului 10",
+        contactPostalCode: "400114",
+        internalNotes: "Prefers an aisle seat",
+      })
+      const other = await seedBooking({
+        bookingNumber: "BK-CONTACT-0002",
+        externalBookingRef: "OTHER-REF-42",
+        contactFirstName: "Maria",
+        contactLastName: "Ionescu",
+        contactEmail: "maria.ionescu@example.com",
+        contactPhone: "+33 1 44 55 66 77",
+        contactCountry: "France",
+        contactRegion: "Ile-de-France",
+        contactCity: "Paris",
+        contactAddressLine1: "Rue de Rivoli 1",
+        contactPostalCode: "75001",
+      })
+
+      async function expectOnlyTargetForSearch(search: string) {
+        const res = await app.request(`/?search=${encodeURIComponent(search)}`, { method: "GET" })
+        expect(res.status).toBe(200)
+        const body = await res.json()
+        const ids = body.data.map((row: { id: string }) => row.id)
+        expect(ids).toContain(target.id)
+        expect(ids).not.toContain(other.id)
+      }
+
+      await expectOnlyTargetForSearch("Ana Cimpoeru")
+      await expectOnlyTargetForSearch("ANA.CIMPOERU")
+      await expectOnlyTargetForSearch("40712345678")
+      await expectOnlyTargetForSearch("WHATSAPP-REF-42")
+      await expectOnlyTargetForSearch("Memorandumului")
+      await expectOnlyTargetForSearch("Cluj-Napoca")
+      await expectOnlyTargetForSearch("400114")
+    })
+
     it("hydrates booking list item summaries with product names", async () => {
       const { product } = await seedProductBundle()
       const booking = await seedBooking()

--- a/packages/bookings/tests/integration/routes.test.ts
+++ b/packages/bookings/tests/integration/routes.test.ts
@@ -725,7 +725,7 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
     it("searches booking contact snapshots and external references", async () => {
       const target = await seedBooking({
         bookingNumber: "BK-CONTACT-0001",
-        externalBookingRef: "WHATSAPP-REF-42",
+        externalBookingRef: "WHATSAPP-REF-40712345678",
         contactFirstName: "Ana",
         contactLastName: "Cimpoeru",
         contactEmail: "ana.cimpoeru@example.com",
@@ -750,6 +750,13 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
         contactAddressLine1: "Rue de Rivoli 1",
         contactPostalCode: "75001",
       })
+      const phoneOnly = await seedBooking({
+        bookingNumber: "BK-CONTACT-0003",
+        contactFirstName: "Ioana",
+        contactLastName: "Phone",
+        contactEmail: "ioana.phone@example.com",
+        contactPhone: "+40 712 345 678",
+      })
 
       async function expectOnlyTargetForSearch(search: string) {
         const res = await app.request(`/?search=${encodeURIComponent(search)}`, { method: "GET" })
@@ -758,12 +765,20 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
         const ids = body.data.map((row: { id: string }) => row.id)
         expect(ids).toContain(target.id)
         expect(ids).not.toContain(other.id)
+        expect(ids).not.toContain(phoneOnly.id)
       }
+
+      const phoneRes = await app.request(`/?search=${encodeURIComponent("40712345678")}`, {
+        method: "GET",
+      })
+      expect(phoneRes.status).toBe(200)
+      const phoneIds = (await phoneRes.json()).data.map((row: { id: string }) => row.id)
+      expect(phoneIds).toContain(target.id)
+      expect(phoneIds).toContain(phoneOnly.id)
 
       await expectOnlyTargetForSearch("Ana Cimpoeru")
       await expectOnlyTargetForSearch("ANA.CIMPOERU")
-      await expectOnlyTargetForSearch("40712345678")
-      await expectOnlyTargetForSearch("WHATSAPP-REF-42")
+      await expectOnlyTargetForSearch("WHATSAPP-REF-40712345678")
       await expectOnlyTargetForSearch("Memorandumului")
       await expectOnlyTargetForSearch("Cluj-Napoca")
       await expectOnlyTargetForSearch("400114")


### PR DESCRIPTION
## Summary

- Expand `GET /v1/admin/bookings?search=...` to match contact snapshot fields, full contact name, address fields, and external booking references.
- Add digit-stripped phone matching so formatted and unformatted phone searches resolve the same booking.
- Add a bookings changeset and integration coverage for contact-name, email, phone, external reference, address, city, and postal-code search.

Closes #1295.

## Testing

- `pnpm --filter @voyantjs/bookings typecheck`
- `pnpm --filter @voyantjs/bookings lint`
- `pnpm exec biome check packages/bookings/src/service.ts packages/bookings/tests/integration/routes.test.ts .changeset/quick-bookings-search.md`
- `pnpm --filter @voyantjs/bookings test -- tests/integration/routes.test.ts` (DB-backed integration tests skipped because `TEST_DATABASE_URL` is not set)
- Pre-push `pnpm test` passed: 127 tasks successful; DB-backed integration tests skipped where no database URL is configured.

Note: the initial pre-commit full typecheck hit existing `templates/operator` and `templates/dmc` failures in `packages/finance/src/service-booking-create.ts`; the scoped bookings typecheck passed.