### PR TITLE
fix(finance): allow invoice number reuse after void

### DIFF
--- a/.changeset/active-invoice-number-unique.md
+++ b/.changeset/active-invoice-number-unique.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/finance": patch
+"@voyantjs/plugin-smartbill": patch
+---
+
+Allow voided invoices to release external invoice numbers for reissue and surface external allocation writeback conflicts on SmartBill refs.

--- a/apps/dev/migrations/0040_invoice_number_active_unique.sql
+++ b/apps/dev/migrations/0040_invoice_number_active_unique.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "invoices" DROP CONSTRAINT IF EXISTS "invoices_invoice_number_type_unique";--> statement-breakpoint
+DROP INDEX IF EXISTS "invoices_invoice_number_type_unique";--> statement-breakpoint
+DROP INDEX IF EXISTS "invoices_invoice_number_type_active_idx";--> statement-breakpoint
+CREATE UNIQUE INDEX "invoices_invoice_number_type_active_idx" ON "invoices" USING btree ("invoice_number", "invoice_type") WHERE "status" <> 'void';

--- a/apps/dev/migrations/meta/_journal.json
+++ b/apps/dev/migrations/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1779748565000,
       "tag": "0039_invoice_line_item_payment_schedule",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1779830000000,
+      "tag": "0040_invoice_number_active_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/finance/src/schema.ts
+++ b/packages/finance/src/schema.ts
@@ -11,7 +11,6 @@ import {
   pgTable,
   text,
   timestamp,
-  unique,
   uniqueIndex,
 } from "drizzle-orm/pg-core"
 
@@ -772,7 +771,9 @@ export const invoices = pgTable(
     index("idx_invoices_status_created").on(table.status, table.createdAt),
     index("idx_invoices_fx_rate_set").on(table.fxRateSetId),
     index("idx_invoices_number").on(table.invoiceNumber),
-    unique("invoices_invoice_number_type_unique").on(table.invoiceNumber, table.invoiceType),
+    uniqueIndex("invoices_invoice_number_type_active_idx")
+      .on(table.invoiceNumber, table.invoiceType)
+      .where(sql`${table.status} <> 'void'`),
     index("idx_invoices_due_date").on(table.dueDate),
     index("idx_invoices_converted_from").on(table.convertedFromInvoiceId),
     // base_currency covers every base_*_cents column. If any base amount is

--- a/packages/finance/src/service.ts
+++ b/packages/finance/src/service.ts
@@ -696,6 +696,7 @@ function isInvoiceNumberUniqueConstraintError(error: unknown) {
   const constraint = typeof candidate.constraint === "string" ? candidate.constraint : ""
   const detail = typeof candidate.detail === "string" ? candidate.detail : ""
   return (
+    constraint === "invoices_invoice_number_type_active_idx" ||
     constraint === "invoices_invoice_number_type_unique" ||
     constraint === "invoices_invoice_number_unique" ||
     constraint === "invoices_invoice_number_key" ||
@@ -3952,28 +3953,35 @@ export const financeService = {
         .where(eq(invoices.id, id))
         .returning()
 
-    const actionLedgerContext = runtime.actionLedgerContext
-    if (actionLedgerContext) {
-      return db.transaction(async (tx) => {
-        const [row] = await updateInvoiceRow(tx)
+    try {
+      const actionLedgerContext = runtime.actionLedgerContext
+      if (actionLedgerContext) {
+        return await db.transaction(async (tx) => {
+          const [row] = await updateInvoiceRow(tx)
 
-        if (row) {
-          await appendActionLedgerMutation(
-            tx,
-            buildInvoiceUpdateActionLedgerInput(
-              actionLedgerContext,
-              { invoice: row, changes: data },
-              { authorizationSource: runtime.actionLedgerAuthorizationSource },
-            ),
-          )
-        }
+          if (row) {
+            await appendActionLedgerMutation(
+              tx,
+              buildInvoiceUpdateActionLedgerInput(
+                actionLedgerContext,
+                { invoice: row, changes: data },
+                { authorizationSource: runtime.actionLedgerAuthorizationSource },
+              ),
+            )
+          }
 
-        return row ?? null
-      })
+          return row ?? null
+        })
+      }
+
+      const [row] = await updateInvoiceRow(db)
+      return row ?? null
+    } catch (error) {
+      if (data.invoiceNumber && isInvoiceNumberUniqueConstraintError(error)) {
+        throw new InvoiceNumberConflictError(data.invoiceNumber)
+      }
+      throw error
     }
-
-    const [row] = await updateInvoiceRow(db)
-    return row ?? null
   },
 
   async deleteInvoice(db: PostgresJsDatabase, id: string, runtime: FinanceServiceRuntime = {}) {
@@ -5263,15 +5271,24 @@ export const financeService = {
       return { status: "not_pending_external_allocation" as const, invoice: existing }
     }
 
-    const [invoice] = await db
-      .update(invoices)
-      .set({
-        invoiceNumber: data.invoiceNumber,
-        status: data.status ?? "issued",
-        updatedAt: new Date(),
-      })
-      .where(eq(invoices.id, invoiceId))
-      .returning()
+    let invoice: typeof invoices.$inferSelect | undefined
+    try {
+      const [updatedInvoice] = await db
+        .update(invoices)
+        .set({
+          invoiceNumber: data.invoiceNumber,
+          status: data.status ?? "issued",
+          updatedAt: new Date(),
+        })
+        .where(eq(invoices.id, invoiceId))
+        .returning()
+      invoice = updatedInvoice
+    } catch (error) {
+      if (isInvoiceNumberUniqueConstraintError(error)) {
+        throw new InvoiceNumberConflictError(data.invoiceNumber)
+      }
+      throw error
+    }
 
     return invoice ? { status: "applied" as const, invoice } : { status: "not_found" as const }
   },

--- a/packages/finance/tests/unit/service-invoice-number-allocation.test.ts
+++ b/packages/finance/tests/unit/service-invoice-number-allocation.test.ts
@@ -635,6 +635,144 @@ describe("financeService.createInvoiceFromBooking number allocation", () => {
   })
 })
 
+describe("financeService.applyExternalInvoiceAllocation", () => {
+  const pendingInvoice = {
+    id: "inv_new",
+    invoiceNumber: "PENDING-PROFORMA-abc",
+    invoiceType: "proforma",
+    bookingId: "book_123",
+    personId: null,
+    organizationId: null,
+    status: "pending_external_allocation",
+    currency: "RON",
+    baseCurrency: null,
+    fxRateSetId: null,
+    subtotalCents: 12_000,
+    baseSubtotalCents: null,
+    taxCents: 0,
+    baseTaxCents: null,
+    totalCents: 12_000,
+    baseTotalCents: null,
+    paidCents: 0,
+    basePaidCents: null,
+    balanceDueCents: 12_000,
+    baseBalanceDueCents: null,
+    commissionPercent: null,
+    commissionAmountCents: null,
+    issueDate: "2026-05-23",
+    dueDate: "2026-06-23",
+    notes: null,
+    voidedAt: null,
+    voidReason: null,
+    convertedFromInvoiceId: null,
+    seriesId: null,
+    sequence: null,
+    templateId: null,
+    taxRegimeId: null,
+    language: null,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  }
+
+  function makeExternalAllocationDb(options: {
+    existing?: Record<string, unknown>
+    updateError?: unknown
+  }) {
+    const updates: Array<Record<string, unknown>> = []
+    const db = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(async () => (options.existing ? [options.existing] : [])),
+          })),
+        })),
+      })),
+      update: vi.fn(() => ({
+        set: vi.fn((values) => {
+          updates.push(values)
+          return {
+            where: vi.fn(() => ({
+              returning: vi.fn(async () => {
+                if (options.updateError) throw options.updateError
+                return options.existing ? [{ ...options.existing, ...values }] : []
+              }),
+            })),
+          }
+        }),
+      })),
+    }
+
+    return { db: db as never, updates }
+  }
+
+  it("applies an external provider invoice number to pending invoices", async () => {
+    const { db, updates } = makeExternalAllocationDb({ existing: pendingInvoice })
+
+    const result = await financeService.applyExternalInvoiceAllocation(db, "inv_new", {
+      invoiceNumber: "B-0133",
+    })
+
+    expect(result.status).toBe("applied")
+    expect(updates[0]).toMatchObject({
+      invoiceNumber: "B-0133",
+      status: "issued",
+    })
+  })
+
+  it("normalizes duplicate external allocation numbers into a typed conflict", async () => {
+    const { db } = makeExternalAllocationDb({
+      existing: pendingInvoice,
+      updateError: {
+        code: "23505",
+        constraint: "invoices_invoice_number_type_active_idx",
+      },
+    })
+
+    await expect(
+      financeService.applyExternalInvoiceAllocation(db, "inv_new", {
+        invoiceNumber: "B-0133",
+      }),
+    ).rejects.toMatchObject({
+      name: "InvoiceNumberConflictError",
+      code: "invoice_number_conflict",
+      invoiceNumber: "B-0133",
+    } satisfies Partial<InvoiceNumberConflictError>)
+  })
+})
+
+describe("financeService.updateInvoice number writeback", () => {
+  function makeUpdateInvoiceDb(updateError: unknown) {
+    return {
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn(() => ({
+            returning: vi.fn(async () => {
+              throw updateError
+            }),
+          })),
+        })),
+      })),
+    } as never
+  }
+
+  it("normalizes duplicate writeback numbers into a typed conflict", async () => {
+    const db = makeUpdateInvoiceDb({
+      code: "23505",
+      constraint: "invoices_invoice_number_type_active_idx",
+    })
+
+    await expect(
+      financeService.updateInvoice(db, "inv_new", {
+        invoiceNumber: "B-0133",
+      }),
+    ).rejects.toMatchObject({
+      name: "InvoiceNumberConflictError",
+      code: "invoice_number_conflict",
+      invoiceNumber: "B-0133",
+    } satisfies Partial<InvoiceNumberConflictError>)
+  })
+})
+
 describe("financeService.ensureExternalInvoiceNumberSeries", () => {
   it("creates default external-provider placeholder series per scope", async () => {
     const insertedRows: Array<Record<string, unknown>> = []

--- a/packages/plugins/smartbill/src/sync.ts
+++ b/packages/plugins/smartbill/src/sync.ts
@@ -521,7 +521,23 @@ async function recordSyncError(
     )
     if (!db) return
     const refs = await financeService.listInvoiceExternalRefs(db, event.id)
-    if (refs.some((ref) => isMatchingSmartbillRef(ref, documentType))) return
+    const matchingRef = refs.find((ref) => isMatchingSmartbillRef(ref, documentType))
+    if (matchingRef) {
+      await financeService.registerInvoiceExternalRef(db, event.id, {
+        provider: "smartbill",
+        externalId: matchingRef.externalId ?? null,
+        externalNumber: matchingRef.externalNumber ?? null,
+        externalUrl: matchingRef.externalUrl ?? null,
+        status: matchingRef.status ?? "error",
+        syncedAt: new Date().toISOString(),
+        syncError: errorMessage(err),
+        metadata: {
+          ...(coerceMetadata(matchingRef.metadata) ?? {}),
+          documentType,
+        },
+      })
+      return
+    }
 
     await financeService.registerInvoiceExternalRef(db, event.id, {
       provider: "smartbill",
@@ -603,7 +619,12 @@ async function resolveMaybe<TContext, TValue>(
 }
 
 function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error)
+  if (error instanceof Error) {
+    const maybeCode = (error as Error & { code?: unknown }).code
+    const code = typeof maybeCode === "string" ? maybeCode : null
+    return code ? `${code}: ${error.message}` : error.message
+  }
+  return String(error)
 }
 
 function coerceMetadata(value: unknown): Record<string, unknown> | null {
@@ -634,7 +655,6 @@ function isUsableSmartbillRef(ref: {
   return (
     ref.provider === "smartbill" &&
     ref.status !== "error" &&
-    !ref.syncError &&
     Boolean(ref.externalNumber || ref.externalId)
   )
 }

--- a/packages/plugins/smartbill/tests/unit/plugin.test.ts
+++ b/packages/plugins/smartbill/tests/unit/plugin.test.ts
@@ -680,7 +680,12 @@ describe("smartbillPlugin — invoice.issued subscriber", () => {
   })
 
   it("keeps the SmartBill ref retryable when external allocation fails", async () => {
-    financeServiceMock.applyExternalInvoiceAllocation.mockRejectedValueOnce(new Error("db down"))
+    financeServiceMock.applyExternalInvoiceAllocation.mockRejectedValueOnce(
+      Object.assign(new Error("Invoice number already exists"), {
+        code: "invoice_number_conflict",
+        invoiceNumber: "SB-42",
+      }),
+    )
     financeServiceMock.listInvoiceExternalRefs.mockResolvedValueOnce([]).mockResolvedValueOnce([
       {
         id: "iex_existing",
@@ -721,8 +726,9 @@ describe("smartbillPlugin — invoice.issued subscriber", () => {
       }),
     )
 
-    expect(financeServiceMock.registerInvoiceExternalRef).toHaveBeenCalledOnce()
-    expect(financeServiceMock.registerInvoiceExternalRef).toHaveBeenCalledWith(
+    expect(financeServiceMock.registerInvoiceExternalRef).toHaveBeenCalledTimes(2)
+    expect(financeServiceMock.registerInvoiceExternalRef).toHaveBeenNthCalledWith(
+      1,
       expect.anything(),
       "inv_external_retry",
       expect.objectContaining({
@@ -731,13 +737,24 @@ describe("smartbillPlugin — invoice.issued subscriber", () => {
         status: "issued",
       }),
     )
+    expect(financeServiceMock.registerInvoiceExternalRef).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      "inv_external_retry",
+      expect.objectContaining({
+        provider: "smartbill",
+        externalNumber: "42",
+        status: "issued",
+        syncError: expect.stringContaining("invoice_number_conflict"),
+      }),
+    )
     expect(logger.error).toHaveBeenCalledWith(
       expect.stringContaining("createInvoice"),
       expect.any(Error),
     )
   })
 
-  it("skips duplicate create calls when a non-error SmartBill ref already exists", async () => {
+  it("skips duplicate create calls when a non-error SmartBill ref already exists with a local sync error", async () => {
     financeServiceMock.listInvoiceExternalRefs.mockResolvedValueOnce([
       {
         id: "iex_existing",
@@ -747,7 +764,7 @@ describe("smartbillPlugin — invoice.issued subscriber", () => {
         externalNumber: "1",
         externalUrl: null,
         status: "issued",
-        syncError: null,
+        syncError: "invoice_number_conflict: Invoice number already exists",
         metadata: {
           companyVatCode: "RO12345678",
           seriesName: "A",

--- a/templates/dmc/migrations/0022_invoice_number_active_unique.sql
+++ b/templates/dmc/migrations/0022_invoice_number_active_unique.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "invoices" DROP CONSTRAINT IF EXISTS "invoices_invoice_number_type_unique";--> statement-breakpoint
+DROP INDEX IF EXISTS "invoices_invoice_number_type_unique";--> statement-breakpoint
+DROP INDEX IF EXISTS "invoices_invoice_number_type_active_idx";--> statement-breakpoint
+CREATE UNIQUE INDEX "invoices_invoice_number_type_active_idx" ON "invoices" USING btree ("invoice_number", "invoice_type") WHERE "status" <> 'void';

--- a/templates/dmc/migrations/meta/_journal.json
+++ b/templates/dmc/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1779748565000,
       "tag": "0021_invoice_line_item_payment_schedule",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1779830000000,
+      "tag": "0022_invoice_number_active_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/templates/operator/migrations/0041_invoice_number_active_unique.sql
+++ b/templates/operator/migrations/0041_invoice_number_active_unique.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "invoices" DROP CONSTRAINT IF EXISTS "invoices_invoice_number_type_unique";--> statement-breakpoint
+DROP INDEX IF EXISTS "invoices_invoice_number_type_unique";--> statement-breakpoint
+DROP INDEX IF EXISTS "invoices_invoice_number_type_active_idx";--> statement-breakpoint
+CREATE UNIQUE INDEX "invoices_invoice_number_type_active_idx" ON "invoices" USING btree ("invoice_number", "invoice_type") WHERE "status" <> 'void';

--- a/templates/operator/migrations/meta/_journal.json
+++ b/templates/operator/migrations/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1779748565000,
       "tag": "0040_invoice_line_item_payment_schedule",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1779830000000,
+      "tag": "0041_invoice_number_active_unique",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- replace the invoice number/type uniqueness constraint with an active-row partial unique index that excludes voided invoices
- normalize external allocation and invoice-number writeback unique violations into `InvoiceNumberConflictError`
- persist SmartBill sync errors onto existing external refs so failed local writebacks are visible and retryable

## Verification
- `pnpm --filter @voyantjs/finance lint`
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/finance test`
- `pnpm --filter @voyantjs/plugin-smartbill lint`
- `pnpm --filter @voyantjs/plugin-smartbill typecheck`
- `pnpm --filter @voyantjs/plugin-smartbill test`
- `pnpm verify:architecture`