### PR TITLE
Fix auth signup guard surface scoping

### DIFF
--- a/.changeset/green-auth-surfaces.md
+++ b/.changeset/green-auth-surfaces.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/auth": patch
+---
+
+Scope the default Better Auth signup guard to admin-surface users so customer-facing auth plugins can create storefront users.

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -50,6 +50,29 @@ the normalized `{ userId, actor }` contract, not on Better Auth specifically.
 When using additional user fields with the Drizzle adapter, the consuming app is
 responsible for adding matching columns and migrations to the auth user table.
 
+By default, `createBetterAuth` keeps Voyant's single-tenant guard for admin
+signups: once any user exists, another user without explicit surfaces, or with
+the `admin` surface, cannot self-register. Customer-facing auth plugins can
+still create users by setting a non-admin surface such as `storefront`.
+
+```typescript
+const auth = createBetterAuth({
+  db,
+  user: {
+    additionalFields: {
+      surfaces: {
+        type: "string",
+        required: false,
+        input: true,
+      },
+    },
+  },
+  disableSignupWhenUsersExist: {
+    surfaces: ["admin"],
+  },
+})
+```
+
 Better Auth server plugins that define their own tables must pass those Drizzle
 tables through `extraSchema` so the shared Drizzle adapter can resolve them:
 

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -459,6 +459,63 @@ type ResolvedBetterAuthPlugins<Plugins extends BetterAuthPlugin[] | undefined> =
     ? [...VoyantBetterAuthPlugins, ...Plugins]
     : VoyantBetterAuthPlugins
 
+const DEFAULT_SIGNUP_BLOCK_SURFACES = ["admin"] as const
+
+export interface DisableSignupWhenUsersExistOptions {
+  /**
+   * Set to false when the consuming app owns all signup admission checks.
+   *
+   * Defaults to true.
+   */
+  enabled?: boolean
+  /**
+   * User surfaces that should keep the single-tenant signup guard. New users
+   * with only other explicit surfaces can still be created by customer-facing
+   * auth plugins such as phone OTP.
+   *
+   * Defaults to ["admin"]. Users without an explicit surfaces array are
+   * treated as admin users for backward compatibility.
+   */
+  surfaces?: readonly string[]
+}
+
+type SignupBlockUserPayload = {
+  surfaces?: unknown
+}
+
+function normalizeSignupBlockSurfaces(
+  options: DisableSignupWhenUsersExistOptions | undefined,
+): readonly string[] {
+  return options?.surfaces ?? DEFAULT_SIGNUP_BLOCK_SURFACES
+}
+
+function isSignupBlockEnabled(options: DisableSignupWhenUsersExistOptions | undefined): boolean {
+  return options?.enabled !== false
+}
+
+function signupBlockAppliesToUser(
+  user: SignupBlockUserPayload | undefined,
+  blockedSurfaces: readonly string[],
+): boolean {
+  if (blockedSurfaces.length === 0) return false
+
+  const surfaces = user?.surfaces
+  if (Array.isArray(surfaces)) {
+    const explicitSurfaces = surfaces.filter(
+      (surface): surface is string => typeof surface === "string",
+    )
+    if (explicitSurfaces.length > 0) {
+      return explicitSurfaces.some((surface) => blockedSurfaces.includes(surface))
+    }
+  }
+
+  if (typeof surfaces === "string" && surfaces.length > 0) {
+    return blockedSurfaces.includes(surfaces)
+  }
+
+  return blockedSurfaces.includes("admin")
+}
+
 type ResolvedCreateBetterAuthOptions<
   UserOptions extends BetterAuthOptions["user"],
   Plugins extends BetterAuthPlugin[] | undefined,
@@ -485,6 +542,7 @@ export interface CreateBetterAuthOptions<
   extraSchema?: BetterAuthDrizzleSchema
   plugins?: Plugins
   user?: UserOptions
+  disableSignupWhenUsersExist?: DisableSignupWhenUsersExistOptions
   /** Called when a user requests a password reset. If not provided, logs to console. */
   sendResetPassword?: (data: {
     user: { email: string; name: string }
@@ -518,6 +576,8 @@ export function createBetterAuth<
     baseURL,
   )
   const extraPlugins = options.plugins ?? []
+  const signupBlockSurfaces = normalizeSignupBlockSurfaces(options.disableSignupWhenUsersExist)
+  const signupBlockEnabled = isSignupBlockEnabled(options.disableSignupWhenUsersExist)
   const schema = {
     user: authUser,
     session: authSession,
@@ -604,7 +664,14 @@ export function createBetterAuth<
           // social sign-ins still work because this hook only fires on CREATE.
           // Seed scripts do raw drizzle inserts, so they bypass this hook —
           // which is intentional.
-          before: async () => {
+          before: async (user) => {
+            if (
+              !signupBlockEnabled ||
+              !signupBlockAppliesToUser(user as SignupBlockUserPayload, signupBlockSurfaces)
+            ) {
+              return
+            }
+
             const [row] = await db.select({ count: sql<number>`count(*)::int` }).from(authUser)
             if ((row?.count ?? 0) > 0) {
               throw new Error("Sign-up is disabled. Ask an admin to invite you.")

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -502,15 +502,15 @@ function signupBlockAppliesToUser(
   const surfaces = user?.surfaces
   if (Array.isArray(surfaces)) {
     const explicitSurfaces = surfaces.filter(
-      (surface): surface is string => typeof surface === "string",
+      (surface): surface is string => typeof surface === "string" && surface.trim().length > 0,
     )
     if (explicitSurfaces.length > 0) {
-      return explicitSurfaces.some((surface) => blockedSurfaces.includes(surface))
+      return explicitSurfaces.some((surface) => blockedSurfaces.includes(surface.trim()))
     }
   }
 
-  if (typeof surfaces === "string" && surfaces.length > 0) {
-    return blockedSurfaces.includes(surfaces)
+  if (typeof surfaces === "string" && surfaces.trim().length > 0) {
+    return blockedSurfaces.includes(surfaces.trim())
   }
 
   return blockedSurfaces.includes("admin")

--- a/packages/auth/tests/unit/create-better-auth.test.ts
+++ b/packages/auth/tests/unit/create-better-auth.test.ts
@@ -213,6 +213,23 @@ describe("createBetterAuth", () => {
     expect(select).not.toHaveBeenCalled()
   })
 
+  it("treats blank surface array entries as missing surfaces for the signup block", async () => {
+    const { createBetterAuth } = await import("../../src/server.js")
+    const { db } = createDbWithUserCount(1)
+
+    createBetterAuth({
+      db: db as never,
+      secret: "x".repeat(32),
+      baseURL: "https://auth.example.com",
+    })
+
+    await expect(
+      latestBetterAuthConfig().databaseHooks.user.create.before({
+        surfaces: ["", "  "],
+      }),
+    ).rejects.toThrow("Sign-up is disabled. Ask an admin to invite you.")
+  })
+
   it("lets consumers customize the surfaces guarded by the signup block", async () => {
     const { createBetterAuth } = await import("../../src/server.js")
     const { db, select } = createDbWithUserCount(1)

--- a/packages/auth/tests/unit/create-better-auth.test.ts
+++ b/packages/auth/tests/unit/create-better-auth.test.ts
@@ -2,6 +2,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import type { CreateBetterAuthOptions } from "../../src/server.js"
 
+type BetterAuthConfig = {
+  databaseHooks: {
+    user: {
+      create: {
+        before: (user?: Record<string, unknown>) => Promise<void>
+      }
+    }
+  }
+}
+
 const { betterAuthMock, drizzleAdapterMock } = vi.hoisted(() => ({
   betterAuthMock: vi.fn((config: Record<string, unknown>) => ({ config })),
   drizzleAdapterMock: vi.fn(() => ({ adapter: "drizzle" })),
@@ -40,6 +50,20 @@ describe("createBetterAuth", () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
+
+  function latestBetterAuthConfig(): BetterAuthConfig {
+    return betterAuthMock.mock.calls.at(-1)?.[0] as BetterAuthConfig
+  }
+
+  function createDbWithUserCount(count: number) {
+    const from = vi.fn(async () => [{ count }])
+    const select = vi.fn(() => ({ from }))
+    return {
+      db: { select },
+      from,
+      select,
+    }
+  }
 
   it("forwards Better Auth user options and keeps Voyant's default change-email setting", async () => {
     const { createBetterAuth } = await import("../../src/server.js")
@@ -154,5 +178,84 @@ describe("createBetterAuth", () => {
         ],
       }),
     )
+  })
+
+  it("keeps the default signup block for admin users once any user exists", async () => {
+    const { createBetterAuth } = await import("../../src/server.js")
+    const { db } = createDbWithUserCount(1)
+
+    createBetterAuth({
+      db: db as never,
+      secret: "x".repeat(32),
+      baseURL: "https://auth.example.com",
+    })
+
+    await expect(latestBetterAuthConfig().databaseHooks.user.create.before()).rejects.toThrow(
+      "Sign-up is disabled. Ask an admin to invite you.",
+    )
+  })
+
+  it("does not apply the default signup block to explicit non-admin surfaces", async () => {
+    const { createBetterAuth } = await import("../../src/server.js")
+    const { db, select } = createDbWithUserCount(1)
+
+    createBetterAuth({
+      db: db as never,
+      secret: "x".repeat(32),
+      baseURL: "https://auth.example.com",
+    })
+
+    await expect(
+      latestBetterAuthConfig().databaseHooks.user.create.before({
+        surfaces: ["storefront"],
+      }),
+    ).resolves.toBeUndefined()
+    expect(select).not.toHaveBeenCalled()
+  })
+
+  it("lets consumers customize the surfaces guarded by the signup block", async () => {
+    const { createBetterAuth } = await import("../../src/server.js")
+    const { db, select } = createDbWithUserCount(1)
+
+    createBetterAuth({
+      db: db as never,
+      secret: "x".repeat(32),
+      baseURL: "https://auth.example.com",
+      disableSignupWhenUsersExist: {
+        surfaces: ["staff"],
+      },
+    })
+
+    await expect(
+      latestBetterAuthConfig().databaseHooks.user.create.before({
+        surfaces: ["admin"],
+      }),
+    ).resolves.toBeUndefined()
+    expect(select).not.toHaveBeenCalled()
+
+    await expect(
+      latestBetterAuthConfig().databaseHooks.user.create.before({
+        surfaces: ["staff"],
+      }),
+    ).rejects.toThrow("Sign-up is disabled. Ask an admin to invite you.")
+  })
+
+  it("lets consumers disable the bundled signup block", async () => {
+    const { createBetterAuth } = await import("../../src/server.js")
+    const { db, select } = createDbWithUserCount(1)
+
+    createBetterAuth({
+      db: db as never,
+      secret: "x".repeat(32),
+      baseURL: "https://auth.example.com",
+      disableSignupWhenUsersExist: {
+        enabled: false,
+      },
+    })
+
+    await expect(
+      latestBetterAuthConfig().databaseHooks.user.create.before(),
+    ).resolves.toBeUndefined()
+    expect(select).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

- Add `disableSignupWhenUsersExist` options to `createBetterAuth` so the bundled signup guard applies only to configured user surfaces.
- Keep the current default admin/staff behavior while allowing explicit non-admin users, such as storefront phone-OTP users, to be created.
- Document the option and add a patch changeset for `@voyantjs/auth`.

Closes #1312.

## Verification

- `pnpm --filter @voyantjs/auth test`
- `pnpm --filter @voyantjs/auth typecheck`
- `pnpm --filter @voyantjs/auth lint`
- commit hook: repo lint + typecheck
- push hook: repo test suite