### PR TITLE
Apply departure price overrides to storefront pricing

### DIFF
--- a/.changeset/departure-price-overrides.md
+++ b/.changeset/departure-price-overrides.md
@@ -1,0 +1,7 @@
+---
+"@voyantjs/bookings": patch
+"@voyantjs/sellability": patch
+"@voyantjs/storefront": patch
+---
+
+Apply active departure price overrides to storefront departure pricing, price previews, and booking session repricing.

--- a/packages/bookings/src/pricing-ref.ts
+++ b/packages/bookings/src/pricing-ref.ts
@@ -51,3 +51,14 @@ export const optionUnitTiersRef = pgTable("option_unit_tiers", {
   active: boolean("active").notNull().default(true),
   sortOrder: integer("sort_order").notNull().default(0),
 })
+
+export const departurePriceOverridesRef = pgTable("departure_price_overrides", {
+  id: typeId("departure_price_overrides").primaryKey(),
+  departureId: text("departure_id").notNull(),
+  optionId: text("option_id").notNull(),
+  optionUnitId: text("option_unit_id").notNull(),
+  priceCatalogId: typeIdRef("price_catalog_id").notNull(),
+  sellAmountCents: integer("sell_amount_cents").notNull(),
+  costAmountCents: integer("cost_amount_cents"),
+  active: boolean("active").notNull().default(true),
+})

--- a/packages/bookings/src/service-public.ts
+++ b/packages/bookings/src/service-public.ts
@@ -2,6 +2,7 @@ import { and, asc, desc, eq, inArray, or } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import {
+  departurePriceOverridesRef,
   optionPriceRulesRef,
   optionUnitPriceRulesRef,
   optionUnitTiersRef,
@@ -747,6 +748,7 @@ export async function resolveSessionPricingSnapshot(
   productId: string,
   input: {
     catalogId?: string | undefined
+    departureId?: string | undefined
     optionId?: string | undefined
     /** Public/session flows require storefront-visible products. Admin previews can price active internal products. */
     requirePublicProduct?: boolean | undefined
@@ -868,9 +870,9 @@ export async function resolveSessionPricingSnapshot(
       .orderBy(asc(optionUnitPriceRulesRef.sortOrder), asc(optionUnitPriceRulesRef.createdAt)),
   ])
 
-  const tiers =
+  const [tiers, departureOverrides] = await Promise.all([
     unitPrices.length > 0
-      ? await db
+      ? db
           .select({
             id: optionUnitTiersRef.id,
             optionUnitPriceRuleId: optionUnitTiersRef.optionUnitPriceRuleId,
@@ -890,7 +892,23 @@ export async function resolveSessionPricingSnapshot(
             ),
           )
           .orderBy(asc(optionUnitTiersRef.sortOrder), asc(optionUnitTiersRef.minQuantity))
-      : []
+      : Promise.resolve([]),
+    input.departureId
+      ? db
+          .select({
+            optionUnitId: departurePriceOverridesRef.optionUnitId,
+            sellAmountCents: departurePriceOverridesRef.sellAmountCents,
+          })
+          .from(departurePriceOverridesRef)
+          .where(
+            and(
+              eq(departurePriceOverridesRef.departureId, input.departureId),
+              eq(departurePriceOverridesRef.priceCatalogId, catalog.id),
+              eq(departurePriceOverridesRef.active, true),
+            ),
+          )
+      : Promise.resolve([]),
+  ])
 
   const tiersByUnitPriceId = new Map<string, typeof tiers>()
   for (const tier of tiers) {
@@ -898,15 +916,22 @@ export async function resolveSessionPricingSnapshot(
     existing.push(tier)
     tiersByUnitPriceId.set(tier.optionUnitPriceRuleId, existing)
   }
+  const departureOverrideByUnitId = new Map(
+    departureOverrides.map((row) => [row.optionUnitId, row] as const),
+  )
 
   return {
     catalog: catalog satisfies SessionPricingCatalog,
     options: options satisfies SessionPricingOption[],
     rules: rules satisfies SessionPricingRule[],
-    unitPrices: unitPrices.map((row) => ({
-      ...row,
-      tiers: tiersByUnitPriceId.get(row.id) ?? [],
-    })) satisfies Array<
+    unitPrices: unitPrices.map((row) => {
+      const override = departureOverrideByUnitId.get(row.unitId)
+      return {
+        ...row,
+        sellAmountCents: override?.sellAmountCents ?? row.sellAmountCents,
+        tiers: override ? [] : (tiersByUnitPriceId.get(row.id) ?? []),
+      }
+    }) satisfies Array<
       SessionPricingUnitPrice & {
         tiers: Array<{
           minQuantity: number
@@ -1425,6 +1450,7 @@ export const publicBookingsService = {
 
       const snapshot = await resolveSessionPricingSnapshot(db, item.productId, {
         catalogId: input.catalogId,
+        departureId: item.availabilitySlotId ?? undefined,
         optionId,
       })
       if (!snapshot) {

--- a/packages/sellability/src/service.ts
+++ b/packages/sellability/src/service.ts
@@ -1481,11 +1481,12 @@ export const sellabilityService = {
           : null
 
         if (unitRule?.pricingMode === "on_request") onRequest = true
+        const overrideUnitId = request.unitId ?? unitRule?.unitId ?? null
         const override =
-          request.unitId == null
+          overrideUnitId == null
             ? null
             : (departureOverrideMap.get(
-                `${slot.id}:${chosenRule.priceCatalogId}:${request.unitId}`,
+                `${slot.id}:${chosenRule.priceCatalogId}:${overrideUnitId}`,
               ) ?? null)
         const item = computeUnitAmounts(
           request,

--- a/packages/sellability/src/service.ts
+++ b/packages/sellability/src/service.ts
@@ -14,6 +14,7 @@ import {
   markets,
 } from "@voyantjs/markets/schema"
 import {
+  departurePriceOverrides,
   optionPriceRules,
   optionStartTimeRules,
   optionUnitPriceRules,
@@ -201,10 +202,16 @@ function computeUnitAmounts(
     sellAmountCents: number | null
     costAmountCents: number | null
   } | null,
+  override: {
+    sellAmountCents: number
+    costAmountCents: number | null
+  } | null,
 ): ResolvedPriceBreakdown {
   const pricingMode = unitRule?.pricingMode ?? "per_unit"
-  const baseSell = tier?.sellAmountCents ?? unitRule?.sellAmountCents ?? 0
-  const baseCost = tier?.costAmountCents ?? unitRule?.costAmountCents ?? 0
+  const baseSell =
+    override?.sellAmountCents ?? tier?.sellAmountCents ?? unitRule?.sellAmountCents ?? 0
+  const baseCost =
+    override?.costAmountCents ?? tier?.costAmountCents ?? unitRule?.costAmountCents ?? 0
 
   if (pricingMode === "included" || pricingMode === "free") {
     return {
@@ -1137,6 +1144,7 @@ export const sellabilityService = {
       allotmentTargetRows,
       releaseRuleRows,
       exchangeRateRow,
+      departureOverrideRows,
     ] = await Promise.all([
       query.marketId
         ? db
@@ -1285,6 +1293,23 @@ export const sellabilityService = {
             .where(eq(exchangeRates.quoteCurrency, query.currencyCode))
             .orderBy(desc(fxRateSets.effectiveAt))
         : Promise.resolve([]),
+      slotIds.length
+        ? db
+            .select({
+              departureId: departurePriceOverrides.departureId,
+              priceCatalogId: departurePriceOverrides.priceCatalogId,
+              optionUnitId: departurePriceOverrides.optionUnitId,
+              sellAmountCents: departurePriceOverrides.sellAmountCents,
+              costAmountCents: departurePriceOverrides.costAmountCents,
+            })
+            .from(departurePriceOverrides)
+            .where(
+              and(
+                inArray(departurePriceOverrides.departureId, slotIds),
+                eq(departurePriceOverrides.active, true),
+              ),
+            )
+        : Promise.resolve([]),
     ])
 
     const optionMap = new Map(optionRows.map((row) => [row.optionId, row]))
@@ -1293,6 +1318,12 @@ export const sellabilityService = {
     const catalogMap = new Map(catalogRows.map((row) => [row.id, row]))
     const unitMap = new Map(unitRows.map((row) => [row.id, row]))
     const pricingCategoryMap = new Map(pricingCategoryRows.map((row) => [row.id, row]))
+    const departureOverrideMap = new Map(
+      departureOverrideRows.map((row) => [
+        `${row.departureId}:${row.priceCatalogId}:${row.optionUnitId}`,
+        row,
+      ]),
+    )
 
     const candidates = []
 
@@ -1450,6 +1481,12 @@ export const sellabilityService = {
           : null
 
         if (unitRule?.pricingMode === "on_request") onRequest = true
+        const override =
+          request.unitId == null
+            ? null
+            : (departureOverrideMap.get(
+                `${slot.id}:${chosenRule.priceCatalogId}:${request.unitId}`,
+              ) ?? null)
         const item = computeUnitAmounts(
           request,
           {
@@ -1461,6 +1498,7 @@ export const sellabilityService = {
           },
           unitRule,
           tier,
+          override,
         )
         breakdown.push(item)
         components.push({

--- a/packages/sellability/tests/integration/resolve-departure-overrides.test.ts
+++ b/packages/sellability/tests/integration/resolve-departure-overrides.test.ts
@@ -1,0 +1,153 @@
+import { availabilitySlots } from "@voyantjs/availability/schema"
+import { cleanupTestDb, createTestDb } from "@voyantjs/db/test-utils"
+import {
+  departurePriceOverrides,
+  optionPriceRules,
+  optionUnitPriceRules,
+  priceCatalogs,
+  pricingCategories,
+} from "@voyantjs/pricing/schema"
+import { optionUnits, productOptions, products } from "@voyantjs/products/schema"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { sellabilityService } from "../../src/service.js"
+
+const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
+const DB_AVAILABLE = !!TEST_DATABASE_URL
+
+const db = DB_AVAILABLE ? createTestDb() : (null as never)
+
+describe.skipIf(!DB_AVAILABLE)("sellabilityService.resolve departure overrides", () => {
+  beforeEach(async () => {
+    await cleanupTestDb(db)
+  })
+
+  it("applies departure overrides when requested unit resolves by pricing category", async () => {
+    const [product] = await db
+      .insert(products)
+      .values({
+        name: "Category Override Tour",
+        status: "active",
+        activated: true,
+        visibility: "public",
+        sellCurrency: "EUR",
+      })
+      .returning()
+
+    const [option] = await db
+      .insert(productOptions)
+      .values({
+        productId: product.id,
+        name: "Standard",
+        status: "active",
+        isDefault: true,
+      })
+      .returning()
+
+    const [unit] = await db
+      .insert(optionUnits)
+      .values({
+        optionId: option.id,
+        name: "Adult",
+        unitType: "person",
+        isHidden: false,
+      })
+      .returning()
+
+    const [category] = await db
+      .insert(pricingCategories)
+      .values({
+        productId: product.id,
+        optionId: option.id,
+        unitId: unit.id,
+        code: "adult",
+        name: "Adult",
+        categoryType: "adult",
+        active: true,
+      })
+      .returning()
+
+    const [catalog] = await db
+      .insert(priceCatalogs)
+      .values({
+        code: "PUBLIC-EUR",
+        name: "Public EUR",
+        currencyCode: "EUR",
+        catalogType: "public",
+        isDefault: true,
+        active: true,
+      })
+      .returning()
+
+    const [rule] = await db
+      .insert(optionPriceRules)
+      .values({
+        productId: product.id,
+        optionId: option.id,
+        priceCatalogId: catalog.id,
+        name: "Public rate",
+        pricingMode: "per_person",
+        isDefault: true,
+        active: true,
+      })
+      .returning()
+
+    await db.insert(optionUnitPriceRules).values({
+      optionPriceRuleId: rule.id,
+      optionId: option.id,
+      unitId: unit.id,
+      pricingCategoryId: category.id,
+      pricingMode: "per_unit",
+      sellAmountCents: 30000,
+      active: true,
+    })
+
+    const [slot] = await db
+      .insert(availabilitySlots)
+      .values({
+        productId: product.id,
+        optionId: option.id,
+        dateLocal: "2026-08-01",
+        startsAt: new Date("2026-08-01T08:00:00.000Z"),
+        endsAt: new Date("2026-08-01T10:00:00.000Z"),
+        timezone: "Europe/Bucharest",
+        status: "open",
+        remainingPax: 12,
+        pastCutoff: false,
+        tooEarly: false,
+      })
+      .returning()
+
+    await db.insert(departurePriceOverrides).values({
+      departureId: slot.id,
+      optionId: option.id,
+      optionUnitId: unit.id,
+      priceCatalogId: catalog.id,
+      sellAmountCents: 45000,
+      active: true,
+    })
+
+    const resolved = await sellabilityService.resolve(db, {
+      productId: product.id,
+      optionId: option.id,
+      slotId: slot.id,
+      requestedUnits: [
+        {
+          pricingCategoryId: category.id,
+          quantity: 2,
+        },
+      ],
+      limit: 10,
+    })
+
+    expect(resolved.data).toHaveLength(1)
+    expect(resolved.data[0]?.pricing.sellAmountCents).toBe(90000)
+    expect(resolved.data[0]?.pricing.components[0]).toEqual(
+      expect.objectContaining({
+        kind: "unit",
+        sellAmountCents: 90000,
+        sourceRuleId: expect.any(String),
+      }),
+    )
+  })
+})

--- a/packages/storefront/src/service-booking-session-bootstrap.ts
+++ b/packages/storefront/src/service-booking-session-bootstrap.ts
@@ -145,6 +145,7 @@ async function previewBootstrapPricing(
 
     const snapshot = await resolveSessionPricingSnapshot(db, productId, {
       catalogId: input.catalogId,
+      departureId: input.slotId,
       optionId,
     })
 

--- a/packages/storefront/src/service-departures.ts
+++ b/packages/storefront/src/service-departures.ts
@@ -5,6 +5,7 @@ import {
 } from "@voyantjs/availability"
 import { availabilitySlots, availabilityStartTimes } from "@voyantjs/availability/schema"
 import { productExtras } from "@voyantjs/extras/schema"
+import { loadDeparturePriceOverrides } from "@voyantjs/pricing"
 import {
   extraPriceRules,
   optionPriceRules,
@@ -116,6 +117,13 @@ type PricingContext = {
     sellAmountCents: number | null
     sortOrder: number
   }>
+  unitPriceOverrides: Map<
+    string,
+    {
+      sellAmountCents: number
+      costAmountCents: number | null
+    }
+  >
 }
 
 type ResolvedPricingComponent = {
@@ -251,6 +259,21 @@ function selectTierAmount(
   const tier = selectUnitTier(unitRule, tiers, quantity)
 
   return tier?.sellAmountCents ?? unitRule.sellAmountCents ?? null
+}
+
+function selectUnitAmount(
+  context: PricingContext,
+  unitRule: PricingContext["unitRules"][number] | undefined,
+  quantity: number,
+) {
+  if (!unitRule) {
+    return null
+  }
+
+  return (
+    context.unitPriceOverrides.get(unitRule.unitId)?.sellAmountCents ??
+    selectTierAmount(unitRule, context.tiers, quantity)
+  )
 }
 
 function findNamedUnit(
@@ -509,6 +532,7 @@ async function resolvePricingContext(
   db: PostgresJsDatabase,
   productId: string,
   optionId?: string | null,
+  departureId?: string | null,
 ): Promise<PricingContext> {
   const [product] = await db
     .select({
@@ -562,6 +586,7 @@ async function resolvePricingContext(
       unitRules: [],
       tiers: [],
       extraRules: [],
+      unitPriceOverrides: new Map(),
     }
   }
 
@@ -610,6 +635,7 @@ async function resolvePricingContext(
       unitRules: [],
       tiers: [],
       extraRules: [],
+      unitPriceOverrides: new Map(),
     }
   }
 
@@ -668,6 +694,13 @@ async function resolvePricingContext(
     .where(and(eq(extraPriceRules.optionPriceRuleId, rule.id), eq(extraPriceRules.active, true)))
     .orderBy(asc(extraPriceRules.sortOrder), asc(extraPriceRules.createdAt))
 
+  const unitPriceOverrides = departureId
+    ? await loadDeparturePriceOverrides(db, {
+        departureId,
+        catalogId: catalog.id,
+      })
+    : new Map()
+
   return {
     product: product ?? null,
     catalog,
@@ -677,6 +710,7 @@ async function resolvePricingContext(
     unitRules,
     tiers,
     extraRules,
+    unitPriceOverrides,
   }
 }
 
@@ -691,7 +725,7 @@ function buildRatePlans(context: PricingContext) {
     .map((unit) => {
       const unitRule = context.unitRules.find((row) => row.unitId === unit.id)
       const quantityHint = Math.max(1, unit.occupancyMax ?? unit.occupancyMin ?? 1)
-      const amount = centsToAmount(selectTierAmount(unitRule, context.tiers, quantityHint))
+      const amount = centsToAmount(selectUnitAmount(context, unitRule, quantityHint))
       if (amount == null) {
         return null
       }
@@ -763,9 +797,9 @@ function computeFallbackLineItems(args: {
         continue
       }
 
-      const amountCents = selectTierAmount(
+      const amountCents = selectUnitAmount(
+        args.context,
         unitRule,
-        args.context.tiers,
         Math.max(1, room.occupancy * room.quantity),
       )
       const unitAmount = centsToAmount(amountCents) ?? 0
@@ -800,7 +834,7 @@ function computeFallbackLineItems(args: {
       }
 
       const unitAmount =
-        centsToAmount(selectTierAmount(unitRule, args.context.tiers, request.quantity)) ?? 0
+        centsToAmount(selectUnitAmount(args.context, unitRule, request.quantity)) ?? 0
       const totalAmount = Number((unitAmount * request.quantity).toFixed(2))
       total += totalAmount
       const unit = request.unitId
@@ -1294,7 +1328,7 @@ async function buildDeparture(
   meetingPointByProduct?: Map<string, string>,
   resourceAvailability?: SlotResourceAvailability[],
 ) {
-  const context = await resolvePricingContext(db, slot.productId, slot.optionId)
+  const context = await resolvePricingContext(db, slot.productId, slot.optionId, slot.id)
   const itineraryId = slot.itineraryId ?? defaultItineraryByProduct.get(slot.productId) ?? null
   const resources = resourceAvailability ?? []
 
@@ -1599,7 +1633,7 @@ export async function previewStorefrontDeparturePrice(
     return null
   }
 
-  const context = await resolvePricingContext(db, slot.productId, slot.optionId)
+  const context = await resolvePricingContext(db, slot.productId, slot.optionId, slot.id)
   const adults = Math.max(0, input.pax?.adults ?? 1)
   const children = Math.max(0, input.pax?.children ?? 0)
   const infants = Math.max(0, input.pax?.infants ?? 0)

--- a/packages/storefront/tests/integration/booking-session-bootstrap.test.ts
+++ b/packages/storefront/tests/integration/booking-session-bootstrap.test.ts
@@ -2,7 +2,12 @@ import { availabilitySlots } from "@voyantjs/availability/schema"
 import { cleanupTestDb, closeTestDb, createTestDb } from "@voyantjs/db/test-utils"
 import { bookingPaymentSchedules } from "@voyantjs/finance/schema"
 import { handleApiError } from "@voyantjs/hono"
-import { optionPriceRules, optionUnitPriceRules, priceCatalogs } from "@voyantjs/pricing/schema"
+import {
+  departurePriceOverrides,
+  optionPriceRules,
+  optionUnitPriceRules,
+  priceCatalogs,
+} from "@voyantjs/pricing/schema"
 import { optionUnits, productOptions, products } from "@voyantjs/products/schema"
 import { eq } from "drizzle-orm"
 import { Hono } from "hono"
@@ -194,7 +199,7 @@ describe.skipIf(!DB_AVAILABLE)("Storefront booking-session bootstrap route", () 
       })
       .returning()
 
-    return { product, option, unit, slot }
+    return { product, option, unit, catalog, slot }
   }
 
   function bootstrapPayload(seed: Awaited<ReturnType<typeof seedDeparture>>) {
@@ -357,6 +362,50 @@ describe.skipIf(!DB_AVAILABLE)("Storefront booking-session bootstrap route", () 
       .where(eq(availabilitySlots.id, seed.slot.id))
       .limit(1)
     expect(slot?.remainingPax).toBe(9)
+  })
+
+  it("prices bootstrap sessions with departure price overrides", async () => {
+    const seed = await seedDeparture()
+    await db.insert(departurePriceOverrides).values({
+      departureId: seed.slot.id,
+      optionId: seed.option.id,
+      optionUnitId: seed.unit.id,
+      priceCatalogId: seed.catalog.id,
+      sellAmountCents: 70000,
+      active: true,
+    })
+
+    const payload = bootstrapPayload(seed)
+    payload.quote.totalSellAmountCents = 70000
+
+    const res = await app.request("/bookings/sessions/bootstrap", {
+      method: "POST",
+      ...json(payload),
+    })
+
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.data.session.sellAmountCents).toBe(70000)
+    expect(body.data.session.items[0]).toEqual(
+      expect.objectContaining({
+        optionUnitId: seed.unit.id,
+        unitSellAmountCents: 70000,
+        totalSellAmountCents: 70000,
+      }),
+    )
+    expect(body.data.repricing.current).toEqual(
+      expect.objectContaining({
+        totalSellAmountCents: 70000,
+        appliedToSession: true,
+      }),
+    )
+    expect(body.data.repricing.current.items[0]).toEqual(
+      expect.objectContaining({
+        optionUnitId: seed.unit.id,
+        unitSellAmountCents: 70000,
+        totalSellAmountCents: 70000,
+      }),
+    )
   })
 
   it("prices omitted item option ids against the selected slot option", async () => {

--- a/packages/storefront/tests/integration/public-routes.test.ts
+++ b/packages/storefront/tests/integration/public-routes.test.ts
@@ -4,6 +4,7 @@ import { customerSignals } from "@voyantjs/crm/schema"
 import { cleanupTestDb, createTestDb } from "@voyantjs/db/test-utils"
 import { productExtras } from "@voyantjs/extras/schema"
 import {
+  departurePriceOverrides,
   extraPriceRules,
   optionPriceRules,
   optionUnitPriceRules,
@@ -335,6 +336,15 @@ describe.skipIf(!DB_AVAILABLE)("Storefront public routes", () => {
       })
       .returning()
 
+    await db.insert(departurePriceOverrides).values({
+      departureId: slot.id,
+      optionId: option.id,
+      optionUnitId: unit.id,
+      priceCatalogId: catalog.id,
+      sellAmountCents: 150000,
+      active: true,
+    })
+
     const listRes = await app.request(`/products/${product.id}/departures`)
     expect(listRes.status).toBe(200)
     expect(await listRes.json()).toEqual({
@@ -369,7 +379,7 @@ describe.skipIf(!DB_AVAILABLE)("Storefront public routes", () => {
               basePrices: [],
               roomPrices: [
                 {
-                  amount: 1200,
+                  amount: 1500,
                   currencyCode: "EUR",
                   roomType: {
                     id: unit.id,
@@ -561,6 +571,15 @@ describe.skipIf(!DB_AVAILABLE)("Storefront public routes", () => {
       })
       .returning()
 
+    await db.insert(departurePriceOverrides).values({
+      departureId: slot.id,
+      optionId: option.id,
+      optionUnitId: adultUnit.id,
+      priceCatalogId: catalog.id,
+      sellAmountCents: 40000,
+      active: true,
+    })
+
     const previewApp = new Hono()
       .use("*", async (c, next) => {
         c.set("db" as never, db)
@@ -618,16 +637,16 @@ describe.skipIf(!DB_AVAILABLE)("Storefront public routes", () => {
         productId: product.id,
         optionId: option.id,
         currencyCode: "USD",
-        basePrice: 1200,
+        basePrice: 1600,
         taxAmount: 0,
-        total: 1107,
+        total: 1467,
         notes: null,
         lineItems: [
           {
             name: "Standard · Adult",
-            total: 1200,
+            total: 1600,
             quantity: 2,
-            unitPrice: 600,
+            unitPrice: 800,
           },
           {
             name: "Airport transfer",
@@ -666,8 +685,8 @@ describe.skipIf(!DB_AVAILABLE)("Storefront public routes", () => {
               unitType: "person",
               quantity: 2,
               pricingMode: "per_unit",
-              unitPrice: 600,
-              total: 1200,
+              unitPrice: 800,
+              total: 1600,
               currencyCode: "USD",
               tierId: null,
             },
@@ -682,8 +701,8 @@ describe.skipIf(!DB_AVAILABLE)("Storefront public routes", () => {
             unitType: "person",
             quantity: 2,
             pricingMode: "per_unit",
-            unitPrice: 600,
-            total: 1200,
+            unitPrice: 800,
+            total: 1600,
             currencyCode: "USD",
             tierId: null,
           },
@@ -714,8 +733,8 @@ describe.skipIf(!DB_AVAILABLE)("Storefront public routes", () => {
               status: "applied",
               reason: null,
               selected: true,
-              discountAppliedCents: 12300,
-              discountedPriceCents: 110700,
+              discountAppliedCents: 16300,
+              discountedPriceCents: 146700,
             },
           ],
           requested: [],
@@ -723,8 +742,8 @@ describe.skipIf(!DB_AVAILABLE)("Storefront public routes", () => {
             {
               offerId: "offer_early_10",
               offerName: "Early booking",
-              discountAppliedCents: 12300,
-              discountedPriceCents: 110700,
+              discountAppliedCents: 16300,
+              discountedPriceCents: 146700,
               currency: "USD",
               discountKind: "percentage",
               discountPercent: 10,
@@ -734,21 +753,21 @@ describe.skipIf(!DB_AVAILABLE)("Storefront public routes", () => {
             },
           ],
           conflict: null,
-          discountTotal: 123,
-          discountTotalCents: 12300,
-          totalAfterDiscount: 1107,
+          discountTotal: 163,
+          discountTotalCents: 16300,
+          totalAfterDiscount: 1467,
           currencyCode: "USD",
         },
         totals: {
           currencyCode: "USD",
-          base: 1200,
+          base: 1600,
           extras: 30,
-          subtotal: 1230,
-          discount: 123,
+          subtotal: 1630,
+          discount: 163,
           tax: 0,
-          total: 1107,
-          perPerson: 553.5,
-          perBooking: 1107,
+          total: 1467,
+          perPerson: 733.5,
+          perBooking: 1467,
         },
       },
     })


### PR DESCRIPTION
## Summary
- apply active departure price overrides to storefront departure rate plans and fallback preview pricing
- apply the same overrides in sellability-backed price previews and booking session repricing
- add regression coverage for public departure pricing, price preview totals, and booking session bootstrap totals

## Verification
- `pnpm --filter @voyantjs/storefront typecheck`
- `pnpm --filter @voyantjs/sellability typecheck`
- `pnpm --filter @voyantjs/bookings typecheck`
- `pnpm --filter @voyantjs/storefront lint`
- `pnpm --filter @voyantjs/sellability lint`
- `pnpm --filter @voyantjs/bookings lint`
- `pnpm --filter @voyantjs/storefront test -- tests/integration/public-routes.test.ts tests/integration/booking-session-bootstrap.test.ts` (DB-backed integration cases skipped locally; `TEST_DATABASE_URL` is not set)
- `pnpm --filter @voyantjs/bookings test`
- `pnpm --filter @voyantjs/sellability test`
- `git diff --check`

`pnpm verify:fast` currently stops on the existing `@voyantjs/ui` components barrel export check; the changed-file quality check is report-only and also reports pre-existing large-file warnings in touched files.

Closes #1317