### PR TITLE
Expose phone auth status in customer portal preflight

### DIFF
--- a/.changeset/customer-portal-phone-auth-preflight.md
+++ b/.changeset/customer-portal-phone-auth-preflight.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/customer-portal": patch
+---
+
+Expose phone auth-account existence and verification status from customer portal contact preflight.

--- a/packages/customer-portal/src/service-public.ts
+++ b/packages/customer-portal/src/service-public.ts
@@ -1502,10 +1502,22 @@ export const publicCustomerPortalService = {
     phone: string,
   ): Promise<CustomerPortalPhoneContactExistsResult> {
     const normalizedPhone = normalizePhone(phone)
-    const customerCandidates = await listCustomerRecordCandidatesByPhone(db, normalizedPhone)
+    const [authAccount, customerCandidates] = await Promise.all([
+      db
+        .select({
+          id: authUser.id,
+          phoneNumberVerified: authUser.phoneNumberVerified,
+        })
+        .from(authUser)
+        .where(eq(authUser.phoneNumber, normalizedPhone))
+        .limit(1),
+      listCustomerRecordCandidatesByPhone(db, normalizedPhone),
+    ])
 
     return {
       phone: normalizedPhone,
+      authAccountExists: Boolean(authAccount[0]),
+      authAccountVerified: Boolean(authAccount[0]?.phoneNumberVerified),
       customerRecordExists: customerCandidates.length > 0,
       linkedCustomerRecordExists: customerCandidates.some(
         (candidate) => candidate.claimedByAnotherUser,

--- a/packages/customer-portal/src/validation-public.ts
+++ b/packages/customer-portal/src/validation-public.ts
@@ -330,6 +330,8 @@ export const customerPortalPhoneContactExistsQuerySchema = z.object({
 
 export const customerPortalPhoneContactExistsResultSchema = z.object({
   phone: z.string(),
+  authAccountExists: z.boolean(),
+  authAccountVerified: z.boolean(),
   customerRecordExists: z.boolean(),
   linkedCustomerRecordExists: z.boolean(),
 })

--- a/packages/customer-portal/tests/integration/public-routes.test.ts
+++ b/packages/customer-portal/tests/integration/public-routes.test.ts
@@ -78,6 +78,8 @@ describe.skipIf(!DB_AVAILABLE)("Public customer portal routes", () => {
       name: "Ana Maria Popescu",
       email: "ana@example.com",
       emailVerified: true,
+      phoneNumber: "+40123456789",
+      phoneNumberVerified: true,
       image: null,
       createdAt: new Date("2026-01-01T00:00:00.000Z"),
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
@@ -206,8 +208,31 @@ describe.skipIf(!DB_AVAILABLE)("Public customer portal routes", () => {
     expect(res.status).toBe(200)
     expect((await res.json()).data).toEqual({
       phone: "+40123456789",
+      authAccountExists: true,
+      authAccountVerified: true,
       customerRecordExists: true,
       linkedCustomerRecordExists: true,
+    })
+  })
+
+  it("distinguishes CRM-only phone contact matches from auth accounts", async () => {
+    await crmService.createPerson(db, {
+      firstName: "Mihai",
+      lastName: "Ionescu",
+      relation: "client",
+      status: "active",
+      phone: "+40999999999",
+    })
+
+    const res = await preflightApp.request("/contact-exists/phone?phone=%2B40999999999")
+
+    expect(res.status).toBe(200)
+    expect((await res.json()).data).toEqual({
+      phone: "+40999999999",
+      authAccountExists: false,
+      authAccountVerified: false,
+      customerRecordExists: true,
+      linkedCustomerRecordExists: false,
     })
   })
 


### PR DESCRIPTION
## Summary
- add auth-account and phone verification status to phone contact preflight
- keep existing CRM candidate flags for phone lookup
- cover auth-backed and CRM-only phone preflight responses

## Verification
- `pnpm --filter @voyantjs/customer-portal typecheck`
- `pnpm --filter @voyantjs/customer-portal lint`
- `pnpm --filter @voyantjs/customer-portal test -- tests/integration/public-routes.test.ts` (DB-backed integration cases skipped locally; `TEST_DATABASE_URL` is not set)
- `pnpm --filter @voyantjs/customer-portal-react typecheck`
- `pnpm --filter @voyantjs/customer-portal-react lint`
- `pnpm --filter @voyantjs/customer-portal-react test`
- `git diff --check`
- `pnpm test` via pre-push hook

`pnpm verify:fast` currently stops on the existing `@voyantjs/ui` components barrel export check.

Closes #1313