### PR TITLE
Expose booking payment edit and delete actions

### DIFF
--- a/.changeset/booking-payment-actions.md
+++ b/.changeset/booking-payment-actions.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/bookings-ui": patch
+"@voyantjs/finance-ui": patch
+---
+
+Expose payment view/edit/delete wiring from booking detail finance cards and add optional edit/delete actions to payment detail headers.

--- a/.changeset/pricing-rrule-esm-compat.md
+++ b/.changeset/pricing-rrule-esm-compat.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/pricing": patch
+---
+
+Load rrule through its default CommonJS export so built ESM entrypoints import cleanly in Node.

--- a/packages/bookings-ui/src/components/booking-detail-page.tsx
+++ b/packages/bookings-ui/src/components/booking-detail-page.tsx
@@ -50,7 +50,10 @@ import { BookingItemList } from "./booking-item-list.js"
 import { BookingNotes } from "./booking-notes.js"
 import { BookingPaymentReconciliationBanner } from "./booking-payment-reconciliation-banner.js"
 import { BookingPaymentScheduleList } from "./booking-payment-schedule-list.js"
-import { BookingPaymentsSummary } from "./booking-payments-summary.js"
+import {
+  BookingPaymentsSummary,
+  type BookingPaymentsSummaryRow,
+} from "./booking-payments-summary.js"
 import { StatusChangeDialog } from "./status-change-dialog.js"
 import { SupplierStatusList } from "./supplier-status-list.js"
 import { TravelerList } from "./traveler-list.js"
@@ -64,8 +67,10 @@ import { TravelerList } from "./traveler-list.js"
 export interface BookingDetailTabSlot {
   label?: string
   /** Receives the loaded booking so the slot can use sell amount, ids, etc. */
-  content: ReactNode | ((booking: BookingRecord) => ReactNode)
+  content: BookingDetailSlotContent
 }
+
+export type BookingDetailSlotContent = ReactNode | ((booking: BookingRecord) => ReactNode)
 
 export interface BookingDetailPageSlots {
   /** Rendered between the title row and the summary card. */
@@ -76,6 +81,8 @@ export interface BookingDetailPageSlots {
   overviewEnd?: (booking: BookingRecord) => ReactNode
   travelersStart?: (booking: BookingRecord) => ReactNode
   financeStart?: (booking: BookingRecord) => ReactNode
+  /** Replaces the default finance-tab `BookingPaymentsSummary` card. */
+  paymentsContent?: BookingDetailSlotContent
   financeEnd?: (booking: BookingRecord) => ReactNode
   documents?: (booking: BookingRecord) => ReactNode
   activityEnd?: (booking: BookingRecord) => ReactNode
@@ -99,6 +106,12 @@ export interface BookingDetailPageProps {
   onCollectPayment?: (booking: BookingRecord) => void
   /** Wired to a secondary `Record payment` button on the Payments tab. */
   onRecordPayment?: (booking: BookingRecord) => void
+  /** Forwarded to the finance-tab `BookingPaymentsSummary` row menu. */
+  onViewPayment?: (row: BookingPaymentsSummaryRow) => void
+  /** Forwarded to the finance-tab `BookingPaymentsSummary` row menu. */
+  onEditPayment?: (row: BookingPaymentsSummaryRow) => void
+  /** Forwarded to the finance-tab `BookingPaymentsSummary` row menu. */
+  onDeletePayment?: (row: BookingPaymentsSummaryRow) => Promise<void> | void
   slots?: BookingDetailPageSlots
 }
 
@@ -112,6 +125,9 @@ export function BookingDetailPage({
   onOrganizationOpen,
   onCollectPayment,
   onRecordPayment,
+  onViewPayment,
+  onEditPayment,
+  onDeletePayment,
   slots,
 }: BookingDetailPageProps) {
   const i18n = useBookingsUiI18nOrDefault()
@@ -343,11 +359,18 @@ export function BookingDetailPage({
           ) : null}
           {slots?.financeStart?.(booking)}
           <BookingPaymentReconciliationBanner bookingId={id} />
-          <BookingPaymentsSummary
-            bookingId={id}
-            variant="admin"
-            onConvertProforma={(row) => convertToInvoice.mutateAsync({ id: row.invoiceId })}
-          />
+          {slots?.paymentsContent ? (
+            renderDetailSlot(slots.paymentsContent, booking)
+          ) : (
+            <BookingPaymentsSummary
+              bookingId={id}
+              variant="admin"
+              onViewPayment={onViewPayment}
+              onConvertProforma={(row) => convertToInvoice.mutateAsync({ id: row.invoiceId })}
+              onEditPayment={onEditPayment}
+              onDeletePayment={onDeletePayment}
+            />
+          )}
           <BookingPaymentScheduleList bookingId={id} />
           <BookingGuaranteeList bookingId={id} />
           {slots?.financeEnd?.(booking)}
@@ -355,7 +378,7 @@ export function BookingDetailPage({
 
         {slots?.invoicesTab ? (
           <TabsContent value="invoices" className="mt-4 flex flex-col gap-6">
-            {renderTabSlot(slots.invoicesTab.content, booking)}
+            {renderDetailSlot(slots.invoicesTab.content, booking)}
           </TabsContent>
         ) : null}
 
@@ -381,7 +404,7 @@ export function BookingDetailPage({
 
         {slots?.ledgerTab ? (
           <TabsContent value="ledger" className="mt-4 flex flex-col gap-6">
-            {renderTabSlot(slots.ledgerTab.content, booking)}
+            {renderDetailSlot(slots.ledgerTab.content, booking)}
           </TabsContent>
         ) : null}
       </Tabs>
@@ -404,10 +427,7 @@ export function BookingDetailPage({
   )
 }
 
-function renderTabSlot(
-  content: BookingDetailTabSlot["content"],
-  booking: BookingRecord,
-): ReactNode {
+function renderDetailSlot(content: BookingDetailSlotContent, booking: BookingRecord): ReactNode {
   return typeof content === "function" ? content(booking) : content
 }
 

--- a/packages/bookings-ui/src/components/booking-payments-summary.tsx
+++ b/packages/bookings-ui/src/components/booking-payments-summary.tsx
@@ -1,6 +1,11 @@
 "use client"
 
-import { useAdminBookingPayments, usePublicBookingPayments } from "@voyantjs/finance-react"
+import {
+  type PaymentMethod,
+  type PaymentStatus,
+  useAdminBookingPayments,
+  usePublicBookingPayments,
+} from "@voyantjs/finance-react"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -71,8 +76,8 @@ export interface BookingPaymentsSummaryRow {
   invoiceType?: "invoice" | "proforma" | "credit_note"
   amountCents: number
   currency: string
-  status: string
-  paymentMethod: string
+  status: PaymentStatus
+  paymentMethod: PaymentMethod
   paymentDate: string
   referenceNumber: string | null
   notes: string | null

--- a/packages/bookings-ui/src/index.ts
+++ b/packages/bookings-ui/src/index.ts
@@ -25,6 +25,7 @@ export {
   BookingDetailPage,
   type BookingDetailPageProps,
   type BookingDetailPageSlots,
+  type BookingDetailSlotContent,
   type BookingDetailTabSlot,
 } from "./components/booking-detail-page.js"
 export { BookingDialog, type BookingDialogProps } from "./components/booking-dialog.js"
@@ -75,6 +76,7 @@ export {
 export {
   BookingPaymentsSummary,
   type BookingPaymentsSummaryProps,
+  type BookingPaymentsSummaryRow,
 } from "./components/booking-payments-summary.js"
 export {
   BookingQuickViewSheet,

--- a/packages/finance-ui/src/components/payment-detail-page.tsx
+++ b/packages/finance-ui/src/components/payment-detail-page.tsx
@@ -1,9 +1,17 @@
 "use client"
 
 import { type UnifiedPaymentRecord, usePayment } from "@voyantjs/finance-react"
-import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from "@voyantjs/ui/components"
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  ConfirmActionButton,
+} from "@voyantjs/ui/components"
 import { cn } from "@voyantjs/ui/lib/utils"
-import { ArrowLeft, ExternalLink, Loader2 } from "lucide-react"
+import { ArrowLeft, ExternalLink, Loader2, Pencil } from "lucide-react"
 import type * as React from "react"
 
 import { useFinanceUiI18nOrDefault, useFinanceUiMessagesOrDefault } from "../i18n/index.js"
@@ -24,6 +32,9 @@ export interface PaymentDetailPageProps {
   onPersonOpen?: (personId: string, payment: UnifiedPaymentRecord) => void
   onOrganizationOpen?: (organizationId: string, payment: UnifiedPaymentRecord) => void
   onSupplierOpen?: (supplierId: string, payment: UnifiedPaymentRecord) => void
+  onEdit?: (payment: UnifiedPaymentRecord) => void
+  onDelete?: (paymentId: string) => Promise<void> | void
+  deletePending?: boolean
   slots?: PaymentDetailPageSlots
 }
 
@@ -36,6 +47,9 @@ export function PaymentDetailPage({
   onPersonOpen,
   onOrganizationOpen,
   onSupplierOpen,
+  onEdit,
+  onDelete,
+  deletePending,
   slots,
 }: PaymentDetailPageProps) {
   const messages = useFinanceUiMessagesOrDefault()
@@ -65,7 +79,13 @@ export function PaymentDetailPage({
 
   return (
     <div data-slot="payment-detail-page" className={cn("flex flex-col gap-6 p-6", className)}>
-      <PaymentDetailHeader payment={payment} onBack={onBack} />
+      <PaymentDetailHeader
+        payment={payment}
+        onBack={onBack}
+        onEdit={onEdit}
+        onDelete={onDelete}
+        deletePending={deletePending}
+      />
       {slots?.afterHeader}
 
       <div className="grid gap-4 md:grid-cols-2">
@@ -91,10 +111,20 @@ export function PaymentDetailPage({
 export interface PaymentDetailHeaderProps {
   payment: UnifiedPaymentRecord
   onBack?: () => void
+  onEdit?: (payment: UnifiedPaymentRecord) => void
+  onDelete?: (paymentId: string) => Promise<void> | void
+  deletePending?: boolean
   className?: string
 }
 
-export function PaymentDetailHeader({ payment, onBack, className }: PaymentDetailHeaderProps) {
+export function PaymentDetailHeader({
+  payment,
+  onBack,
+  onEdit,
+  onDelete,
+  deletePending,
+  className,
+}: PaymentDetailHeaderProps) {
   const messages = useFinanceUiMessagesOrDefault()
   const relatedNumber = payment.kind === "customer" ? payment.invoiceNumber : payment.bookingNumber
 
@@ -115,9 +145,30 @@ export function PaymentDetailHeader({ payment, onBack, className }: PaymentDetai
           <p className="mt-1 text-sm text-muted-foreground">{relatedNumber}</p>
         ) : null}
       </div>
-      <Badge variant={paymentStatusVariant[payment.status] ?? "secondary"}>
-        {messages.common.supplierPaymentStatusLabels[payment.status]}
-      </Badge>
+      <div className="flex flex-wrap items-center gap-2 md:justify-end">
+        <Badge variant={paymentStatusVariant[payment.status] ?? "secondary"}>
+          {messages.common.supplierPaymentStatusLabels[payment.status]}
+        </Badge>
+        {onEdit ? (
+          <Button type="button" variant="outline" size="sm" onClick={() => onEdit(payment)}>
+            <Pencil className="size-4" aria-hidden="true" />
+            {messages.paymentDetailPage.actions.edit}
+          </Button>
+        ) : null}
+        {onDelete ? (
+          <ConfirmActionButton
+            buttonLabel={messages.paymentDetailPage.actions.delete}
+            confirmLabel={messages.paymentDetailPage.actions.delete}
+            cancelLabel={messages.common.cancel}
+            title={messages.paymentDetailPage.actions.deleteTitle}
+            description={messages.paymentDetailPage.actions.deleteDescription}
+            variant="destructive"
+            confirmVariant="destructive"
+            disabled={deletePending}
+            onConfirm={() => onDelete(payment.id)}
+          />
+        ) : null}
+      </div>
     </div>
   )
 }

--- a/packages/finance-ui/src/i18n/en.ts
+++ b/packages/finance-ui/src/i18n/en.ts
@@ -262,6 +262,10 @@ export const financeUiEn = {
       viewPerson: "View person",
       viewOrganization: "View organization",
       viewSupplier: "View supplier",
+      edit: "Edit",
+      delete: "Delete",
+      deleteTitle: "Delete this payment?",
+      deleteDescription: "This permanently removes the payment and recomputes the related balance.",
     },
     titles: {
       summary: "Summary",

--- a/packages/finance-ui/src/i18n/messages.ts
+++ b/packages/finance-ui/src/i18n/messages.ts
@@ -378,6 +378,10 @@ export type FinanceUiMessages = {
       viewPerson: string
       viewOrganization: string
       viewSupplier: string
+      edit: string
+      delete: string
+      deleteTitle: string
+      deleteDescription: string
     }
     titles: {
       summary: string

--- a/packages/finance-ui/src/i18n/ro.ts
+++ b/packages/finance-ui/src/i18n/ro.ts
@@ -263,6 +263,10 @@ export const financeUiRo = {
       viewPerson: "Vezi persoana",
       viewOrganization: "Vezi organizatia",
       viewSupplier: "Vezi furnizorul",
+      edit: "Editeaza",
+      delete: "Sterge",
+      deleteTitle: "Stergi aceasta plata?",
+      deleteDescription: "Plata va fi stearsa definitiv si soldul asociat va fi recalculat.",
     },
     titles: {
       summary: "Rezumat",

--- a/packages/finance-ui/src/payment-detail-page.test.tsx
+++ b/packages/finance-ui/src/payment-detail-page.test.tsx
@@ -1,0 +1,53 @@
+import type { UnifiedPaymentRecord } from "@voyantjs/finance-react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+
+import { PaymentDetailHeader } from "./components/payment-detail-page.js"
+
+function payment(data: Partial<UnifiedPaymentRecord> = {}): UnifiedPaymentRecord {
+  return {
+    kind: "customer",
+    id: "pay_123",
+    invoiceId: "inv_123",
+    invoiceNumber: "INV-2026-001",
+    bookingId: "book_123",
+    bookingNumber: "BK-2026-001",
+    supplierId: null,
+    supplierName: null,
+    personId: "per_123",
+    personName: "Ana Pop",
+    organizationId: null,
+    organizationName: null,
+    amountCents: 32000,
+    currency: "RON",
+    baseCurrency: null,
+    baseAmountCents: null,
+    paymentMethod: "bank_transfer",
+    status: "completed",
+    referenceNumber: null,
+    paymentDate: "2026-05-26",
+    notes: null,
+    createdAt: "2026-05-26T00:00:00.000Z",
+    updatedAt: "2026-05-26T00:00:00.000Z",
+    ...data,
+  }
+}
+
+describe("PaymentDetailHeader", () => {
+  it("renders edit and delete actions when handlers are provided", () => {
+    const html = renderToStaticMarkup(
+      <PaymentDetailHeader payment={payment()} onEdit={() => {}} onDelete={async () => {}} />,
+    )
+
+    expect(html).toContain("Edit")
+    expect(html).toContain("Delete")
+    expect(html).toContain("pay_123")
+  })
+
+  it("omits edit and delete actions when handlers are absent", () => {
+    const html = renderToStaticMarkup(<PaymentDetailHeader payment={payment()} />)
+
+    expect(html).not.toContain("Edit")
+    expect(html).not.toContain("Delete")
+  })
+})

--- a/packages/pricing/src/service-rule-resolver.ts
+++ b/packages/pricing/src/service-rule-resolver.ts
@@ -1,10 +1,12 @@
 import { and, eq, inArray } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-import { rrulestr } from "rrule"
+import rrulePackage from "rrule"
 
 import { priceSchedules } from "./schema-catalogs.js"
 import { departurePriceOverrides } from "./schema-departure-overrides.js"
 import { optionPriceRules } from "./schema-option-rules.js"
+
+const { rrulestr } = rrulePackage
 
 export interface ResolverRuleInput {
   id: string

--- a/templates/operator/src/components/voyant/bookings/booking-detail-page.tsx
+++ b/templates/operator/src/components/voyant/bookings/booking-detail-page.tsx
@@ -4,7 +4,9 @@ import { useNavigate } from "@tanstack/react-router"
 import { useAdminBreadcrumbs, useLocale } from "@voyantjs/admin"
 import { useBooking } from "@voyantjs/bookings-react"
 import { BookingDetailPage as CanonicalBookingDetailPage } from "@voyantjs/bookings-ui/components/booking-detail-page"
+import type { BookingPaymentsSummaryRow } from "@voyantjs/bookings-ui/components/booking-payments-summary"
 import { CollectPaymentDialog } from "@voyantjs/checkout-ui"
+import { usePaymentMutation } from "@voyantjs/finance-react"
 import { RecordBookingPaymentDialog } from "@voyantjs/finance-ui"
 import { useState } from "react"
 import { AdminWidgetSlotRenderer } from "@/components/admin/admin-widget-slot"
@@ -39,6 +41,8 @@ export function BookingDetailPage({ id }: { id: string }) {
   const navigate = useNavigate()
   const [collectPaymentOpen, setCollectPaymentOpen] = useState(false)
   const [recordPaymentOpen, setRecordPaymentOpen] = useState(false)
+  const [editingPayment, setEditingPayment] = useState<BookingPaymentsSummaryRow | null>(null)
+  const { remove: removePayment } = usePaymentMutation()
   // Mirror the booking fetch so the admin chrome can render
   // breadcrumbs and the payment dialogs can read sell currency /
   // contact snapshots without prop-drilling through the canonical.
@@ -68,6 +72,16 @@ export function BookingDetailPage({ id }: { id: string }) {
         }
         onCollectPayment={() => setCollectPaymentOpen(true)}
         onRecordPayment={() => setRecordPaymentOpen(true)}
+        onViewPayment={(row) =>
+          void navigate({ to: "/finance/payments/$id", params: { id: row.id } })
+        }
+        onEditPayment={(row) => {
+          setEditingPayment(row)
+          setRecordPaymentOpen(true)
+        }}
+        onDeletePayment={async (row) => {
+          await removePayment.mutateAsync(row.id)
+        }}
         slots={{
           header: (b) => (
             <AdminWidgetSlotRenderer slot="booking.details.header" props={{ booking: b }} />
@@ -120,9 +134,29 @@ export function BookingDetailPage({ id }: { id: string }) {
           />
           <RecordBookingPaymentDialog
             open={recordPaymentOpen}
-            onOpenChange={setRecordPaymentOpen}
+            onOpenChange={(open) => {
+              setRecordPaymentOpen(open)
+              if (!open) setEditingPayment(null)
+            }}
             bookingId={id}
             defaultCurrency={booking.sellCurrency}
+            editingPayment={
+              editingPayment
+                ? {
+                    id: editingPayment.id,
+                    invoiceId: editingPayment.invoiceId,
+                    amountCents: editingPayment.amountCents,
+                    currency: editingPayment.currency,
+                    baseCurrency: null,
+                    baseAmountCents: null,
+                    paymentMethod: editingPayment.paymentMethod,
+                    status: editingPayment.status,
+                    paymentDate: editingPayment.paymentDate,
+                    referenceNumber: editingPayment.referenceNumber,
+                    notes: editingPayment.notes,
+                  }
+                : null
+            }
           />
         </>
       ) : null}


### PR DESCRIPTION
## Summary
- Forward payment view, edit, and delete handlers from `BookingDetailPage` into the finance tab payments card, with a replacement slot for custom payments content.
- Add optional edit/delete actions to `PaymentDetailPage` headers.
- Wire the operator booking detail page to view, edit, and delete payments through the existing payment mutation hook and record-payment dialog.

Closes #1315

## Verification
- `pnpm --filter @voyantjs/bookings-ui typecheck`
- `pnpm --filter @voyantjs/bookings-ui lint`
- `pnpm --filter @voyantjs/finance-ui typecheck`
- `pnpm --filter @voyantjs/finance-ui lint`
- `pnpm --filter @voyantjs/finance-ui test`
- `pnpm --filter operator typecheck`
- `pnpm --filter operator lint`
- `pnpm verify:package-exports`
- Commit hook changed-file quality/lint/typecheck lane
- Push hook test lane