### PR TITLE
Fix rrule import for app builds

### DIFF
--- a/packages/pricing/src/service-rule-resolver.ts
+++ b/packages/pricing/src/service-rule-resolver.ts
@@ -1,12 +1,22 @@
 import { and, eq, inArray } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-import rrulePackage from "rrule"
+import * as rrulePackage from "rrule"
 
 import { priceSchedules } from "./schema-catalogs.js"
 import { departurePriceOverrides } from "./schema-departure-overrides.js"
 import { optionPriceRules } from "./schema-option-rules.js"
 
-const { rrulestr } = rrulePackage
+type RRulePackage = typeof import("rrule")
+type RRulePackageCompat = RRulePackage & {
+  default?: RRulePackage
+  rrule?: RRulePackage
+}
+
+const rrulePackageCompat = rrulePackage as RRulePackageCompat
+const { rrulestr } =
+  rrulePackageCompat.rrulestr != null
+    ? rrulePackageCompat
+    : (rrulePackageCompat.default ?? rrulePackageCompat.rrule ?? rrulePackageCompat)
 
 export interface ResolverRuleInput {
   id: string


### PR DESCRIPTION
## Summary
- Replace the `rrule` default import in pricing with a namespace import plus compatibility fallback.
- Keep `rrulestr` available for both Node runtime package export checks and app bundling.

## Verification
- `pnpm --filter @voyantjs/pricing typecheck`
- `pnpm --filter @voyantjs/pricing lint`
- `pnpm --filter @voyantjs/pricing test`
- `pnpm --filter dmc build`
- `pnpm --filter @voyantjs/pricing build && pnpm --filter @voyantjs/storefront build && pnpm verify:package-exports`
- Commit hook changed-file quality/lint/typecheck lane
- Push hook test lane