### PR TITLE
Guard pricing rrule ESM import

### DIFF
--- a/packages/pricing/tests/rrule-import.test.ts
+++ b/packages/pricing/tests/rrule-import.test.ts
@@ -1,0 +1,23 @@
+import { readFile } from "node:fs/promises"
+
+import ts from "typescript"
+import { describe, expect, it } from "vitest"
+
+describe("service-rule-resolver rrule import", () => {
+  it("does not emit a default import from rrule when built", async () => {
+    const source = await readFile(
+      new URL("../src/service-rule-resolver.ts", import.meta.url),
+      "utf8",
+    )
+    const { outputText } = ts.transpileModule(source, {
+      compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2022,
+      },
+      fileName: "service-rule-resolver.ts",
+    })
+
+    expect(outputText).toMatch(/from ["']rrule["']/)
+    expect(outputText).not.toMatch(/import\s+[A-Za-z_$][\w$]*(?:\s*,|\s+from\s+["']rrule["'])/)
+  })
+})


### PR DESCRIPTION
## Summary
- Confirm `@voyantjs/pricing` package build emits `import * as rrulePackage from "rrule";` instead of the default import reported in #1325
- Add a regression test that transpiles `src/service-rule-resolver.ts` and asserts the emitted JS keeps an ESM-compatible `rrule` import, without requiring prebuilt `dist/`
- No changeset: test-only guard for the already-correct runtime output on `main`

Closes #1325

## Verification
- `pnpm --filter @voyantjs/pricing test -- --run tests/rrule-import.test.ts`
- `pnpm --dir packages/pricing exec vitest run tests/rrule-import.test.ts`
- `pnpm --filter @voyantjs/pricing test`
- `pnpm --filter @voyantjs/pricing typecheck`
- `pnpm --filter @voyantjs/pricing lint`
- `pnpm exec biome check packages/pricing/tests/rrule-import.test.ts`
- commit hook: lint + typecheck
- pre-push hook: full test lane