### PR TITLE
Fix finance booking schedule invoice line names

### DIFF
--- a/.changeset/finance-booking-schedule-line-names.md
+++ b/.changeset/finance-booking-schedule-line-names.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/finance": patch
+---
+
+Preserve booking item display context for invoice-from-booking payment schedule lines and expose invoice line description resolution through finance route runtime options.

--- a/packages/finance/src/route-runtime.ts
+++ b/packages/finance/src/route-runtime.ts
@@ -3,12 +3,14 @@ import type { EventBus } from "@voyantjs/core"
 import type { InvoiceFxOptions } from "./invoice-fx.js"
 import type { FinanceDocumentRouteOptions, InvoiceDocumentGenerator } from "./routes-documents.js"
 import type { FinanceSettlementRouteOptions, InvoiceSettlementPoller } from "./routes-settlement.js"
+import type { InvoiceLineDescriptionResolver } from "./service.js"
 
 export type FinanceRouteRuntime = {
   invoiceDocumentGenerator?: InvoiceDocumentGenerator
   resolveDocumentDownloadUrl?: FinanceDocumentRouteOptions["resolveDocumentDownloadUrl"]
   invoiceSettlementPollers: Record<string, InvoiceSettlementPoller>
   eventBus?: EventBus
+  descriptionResolver?: InvoiceLineDescriptionResolver
 } & InvoiceFxOptions
 
 export const FINANCE_ROUTE_RUNTIME_CONTAINER_KEY = "providers.finance.runtime"
@@ -16,7 +18,9 @@ export const FINANCE_ROUTE_RUNTIME_CONTAINER_KEY = "providers.finance.runtime"
 export interface FinanceRuntimeOptions
   extends FinanceDocumentRouteOptions,
     FinanceSettlementRouteOptions,
-    InvoiceFxOptions {}
+    InvoiceFxOptions {
+  descriptionResolver?: InvoiceLineDescriptionResolver
+}
 
 export function buildFinanceRouteRuntime(
   bindings: Record<string, unknown>,
@@ -29,6 +33,7 @@ export function buildFinanceRouteRuntime(
     invoiceSettlementPollers:
       options.resolveInvoiceSettlementPollers?.(bindings) ?? options.invoiceSettlementPollers ?? {},
     eventBus: options.resolveEventBus?.(bindings) ?? options.eventBus,
+    descriptionResolver: options.descriptionResolver,
     invoiceFxSettings: options.invoiceFxSettings,
     resolveInvoiceFxSettings: options.resolveInvoiceFxSettings,
     updateInvoiceFxSettings: options.updateInvoiceFxSettings,

--- a/packages/finance/src/routes.ts
+++ b/packages/finance/src/routes.ts
@@ -1012,7 +1012,7 @@ export const financeRoutes = new Hono<Env>()
       const [
         { bookingItems, bookings },
         { bookingPaymentSchedules },
-        { and, eq },
+        { and, asc, eq },
         { issueInvoiceFromBooking, issueProformaFromBooking },
       ] = await Promise.all([
         import("@voyantjs/bookings/schema"),
@@ -1035,6 +1035,7 @@ export const financeRoutes = new Hono<Env>()
         .select()
         .from(bookingItems)
         .where(eq(bookingItems.bookingId, booking.id))
+        .orderBy(asc(bookingItems.createdAt), asc(bookingItems.id))
       const [paymentSchedule] = input.bookingPaymentScheduleId
         ? await db
             .select()
@@ -1096,6 +1097,14 @@ export const financeRoutes = new Hono<Env>()
             items: items.map((item) => ({
               id: item.id,
               title: item.title,
+              productId: item.productId,
+              productName: item.productNameSnapshot,
+              productNameSnapshot: item.productNameSnapshot,
+              optionNameSnapshot: item.optionNameSnapshot,
+              unitNameSnapshot: item.unitNameSnapshot,
+              departureLabelSnapshot: item.departureLabelSnapshot,
+              startDate: item.serviceDate ?? item.startsAt,
+              endDate: item.endsAt ?? item.serviceDate,
               quantity: item.quantity,
               unitSellAmountCents: item.unitSellAmountCents,
               totalSellAmountCents: item.totalSellAmountCents,

--- a/packages/finance/src/service.ts
+++ b/packages/finance/src/service.ts
@@ -450,6 +450,10 @@ export interface InvoiceFromBookingData {
     title: string
     productId?: string | null
     productName?: string | null
+    productNameSnapshot?: string | null
+    optionNameSnapshot?: string | null
+    unitNameSnapshot?: string | null
+    departureLabelSnapshot?: string | null
     startDate?: string | Date | null
     endDate?: string | Date | null
     quantity: number
@@ -532,11 +536,10 @@ function bookingPaymentScheduleToInvoiceLine(
   const label = PAYMENT_SCHEDULE_LINE_LABELS[schedule.scheduleType]
   const percent = getPaymentSchedulePercent(booking, schedule)
   const head = percent != null && percent < 100 ? `${label} ${percent}%` : label
-  const base =
-    item?.productName?.trim() || item?.title?.trim() || `booking ${booking.bookingNumber}`
+  const base = resolveBookingItemDisplayName(item) ?? `booking ${booking.bookingNumber}`
   const dates = formatInvoiceLineDateRange(
     item?.startDate ?? booking.startDate,
-    item?.endDate ?? booking.endDate,
+    item?.endDate ?? item?.startDate ?? booking.endDate,
   )
 
   return {
@@ -550,6 +553,54 @@ function bookingPaymentScheduleToInvoiceLine(
     taxRate: null,
     sortOrder: 0,
   }
+}
+
+function resolvePaymentScheduleDisplayItem(
+  schedule: NonNullable<InvoiceFromBookingData["paymentSchedule"]>,
+  items: InvoiceFromBookingData["items"],
+) {
+  if (schedule.bookingItemId) {
+    return items.find((item) => item.id === schedule.bookingItemId)
+  }
+
+  const namedItems = items.filter((item) => resolveBookingItemDisplayName(item))
+  return [...(namedItems.length > 0 ? namedItems : items)].sort(
+    compareBookingItemsForScheduleDisplay,
+  )[0]
+}
+
+function resolveBookingItemDisplayName(item: InvoiceFromBookingData["items"][number] | undefined) {
+  return (
+    item?.productNameSnapshot?.trim() || item?.productName?.trim() || item?.title?.trim() || null
+  )
+}
+
+function compareBookingItemsForScheduleDisplay(
+  left: InvoiceFromBookingData["items"][number],
+  right: InvoiceFromBookingData["items"][number],
+) {
+  return (
+    compareNullableStrings(
+      resolveBookingItemDateSortKey(left),
+      resolveBookingItemDateSortKey(right),
+    ) ||
+    compareNullableStrings(
+      resolveBookingItemDisplayName(left),
+      resolveBookingItemDisplayName(right),
+    ) ||
+    left.id.localeCompare(right.id)
+  )
+}
+
+function resolveBookingItemDateSortKey(item: InvoiceFromBookingData["items"][number]) {
+  return toDateOnly(item.startDate) ?? toDateOnly(item.endDate)
+}
+
+function compareNullableStrings(left: string | null, right: string | null) {
+  if (left && right) return left.localeCompare(right)
+  if (left) return -1
+  if (right) return 1
+  return 0
 }
 
 function getPaymentSchedulePercent(
@@ -610,8 +661,8 @@ async function resolveInvoiceLineDescriptions(
   },
 ) {
   if (!context.descriptionResolver) return lineItems
-  const scheduleItem = context.paymentSchedule?.bookingItemId
-    ? context.items.find((item) => item.id === context.paymentSchedule?.bookingItemId)
+  const scheduleItem = context.paymentSchedule
+    ? resolvePaymentScheduleDisplayItem(context.paymentSchedule, context.items)
     : undefined
 
   return Promise.all(
@@ -3762,8 +3813,8 @@ export const financeService = {
       taxesByBookingItemId.set(tax.bookingItemId, existing)
     }
 
-    const scheduleItem = paymentSchedule?.bookingItemId
-      ? items.find((item) => item.id === paymentSchedule.bookingItemId)
+    const scheduleItem = paymentSchedule
+      ? resolvePaymentScheduleDisplayItem(paymentSchedule, items)
       : undefined
     const resolvedLineItems =
       overrideLineItems ??

--- a/packages/finance/tests/integration/routes.test.ts
+++ b/packages/finance/tests/integration/routes.test.ts
@@ -357,7 +357,10 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
     return row!
   }
 
-  async function seedBookingItem(bookingId: string) {
+  async function seedBookingItem(
+    bookingId: string,
+    overrides: Partial<typeof bookingItems.$inferInsert> = {},
+  ) {
     const [row] = await db
       .insert(bookingItems)
       .values({
@@ -367,6 +370,7 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
         sellCurrency: "USD",
         unitSellAmountCents: 5000,
         totalSellAmountCents: 10000,
+        ...overrides,
       })
       .returning()
     return row!
@@ -1683,7 +1687,51 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       expect(lines).toHaveLength(1)
       expect(lines[0]).toMatchObject({
         bookingItemId: null,
-        description: `Balance for booking ${booking.bookingNumber}`,
+        description: "Balance 50% Test Service | 2025-06-01",
+        quantity: 1,
+        unitPriceCents: 16500,
+        totalCents: 16500,
+      })
+    })
+
+    it("uses booking item snapshots for schedule invoices without an item link", async () => {
+      const booking = await seedBooking({
+        sellAmountCents: 33000,
+        startDate: "2026-06-13",
+      })
+      await seedBookingItem(booking.id, {
+        title: "Fallback booking item title",
+        productNameSnapshot: "Excursie Bulgaria",
+        serviceDate: "2026-06-18",
+      })
+      const schedule = await seedBookingPaymentSchedule(booking.id, {
+        amountCents: 16500,
+        scheduleType: "balance",
+      })
+
+      const res = await app.request("/invoices/from-booking", {
+        method: "POST",
+        ...json({
+          bookingId: booking.id,
+          bookingPaymentScheduleId: schedule.id,
+          invoiceNumber: nextInvoiceNumber(),
+          issueDate: "2025-06-01",
+          dueDate: "2025-07-01",
+        }),
+      })
+
+      expect(res.status).toBe(201)
+      const { data } = await res.json()
+      const lines = await db
+        .select()
+        .from(invoiceLineItems)
+        .where(eq(invoiceLineItems.invoiceId, data.id))
+
+      expect(lines).toHaveLength(1)
+      expect(lines[0]).toMatchObject({
+        bookingItemId: null,
+        bookingPaymentScheduleId: schedule.id,
+        description: "Balance 50% Excursie Bulgaria | 2026-06-18",
         quantity: 1,
         unitPriceCents: 16500,
         totalCents: 16500,

--- a/packages/finance/tests/unit/route-runtime.test.ts
+++ b/packages/finance/tests/unit/route-runtime.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+
+import { buildFinanceRouteRuntime } from "../../src/route-runtime.js"
+
+describe("buildFinanceRouteRuntime", () => {
+  it("exposes invoice line description resolver options", async () => {
+    const descriptionResolver = () => "Custom legal line"
+    const runtime = buildFinanceRouteRuntime({}, { descriptionResolver })
+
+    expect(
+      runtime.descriptionResolver?.({
+        booking: {
+          id: "book_123",
+          bookingNumber: "BK-123",
+          personId: null,
+          organizationId: null,
+          sellCurrency: "RON",
+          baseCurrency: null,
+          fxRateSetId: null,
+          sellAmountCents: 12_000,
+          baseSellAmountCents: null,
+        },
+        line: {
+          bookingItemId: null,
+          bookingPaymentScheduleId: null,
+          description: "Fallback line",
+          quantity: 1,
+          unitPriceCents: 12_000,
+          totalCents: 12_000,
+          taxAmountCents: 0,
+          taxRate: null,
+          sortOrder: 0,
+        },
+      }),
+    ).toBe("Custom legal line")
+  })
+})

--- a/packages/finance/tests/unit/service-invoice-number-allocation.test.ts
+++ b/packages/finance/tests/unit/service-invoice-number-allocation.test.ts
@@ -424,6 +424,69 @@ describe("financeService.createInvoiceFromBooking number allocation", () => {
     ])
   })
 
+  it("uses booking item snapshots for schedule descriptions without an item link", async () => {
+    const { db, insertedInvoiceLineItems } = makeDb({})
+
+    await financeService.createInvoiceFromBooking(
+      db,
+      {
+        bookingId: "book_123",
+        invoiceNumber: "MANUAL-1",
+        issueDate: "2026-05-23",
+        dueDate: "2026-06-23",
+      },
+      {
+        booking: {
+          ...bookingData.booking,
+          bookingNumber: "BK-2605-5046",
+          sellAmountCents: 64_000,
+          startDate: "2026-06-13",
+          endDate: "2026-06-13",
+        },
+        paymentSchedule: {
+          id: "bps_123",
+          bookingId: "book_123",
+          bookingItemId: null,
+          scheduleType: "balance",
+          dueDate: "2026-06-01",
+          currency: "RON",
+          amountCents: 32_000,
+        },
+        items: [
+          {
+            id: "bkit_999",
+            title: "Later booking item title",
+            productNameSnapshot: "Zanzibar Cruise",
+            quantity: 1,
+            startDate: "2026-06-20",
+            unitSellAmountCents: 32_000,
+            totalSellAmountCents: 32_000,
+          },
+          {
+            id: "bkit_123",
+            title: "Fallback booking item title",
+            productNameSnapshot: "Excursie Bulgaria",
+            quantity: 2,
+            startDate: "2026-06-18",
+            unitSellAmountCents: 32_000,
+            totalSellAmountCents: 64_000,
+          },
+        ],
+      },
+    )
+
+    expect(insertedInvoiceLineItems).toEqual([
+      expect.objectContaining({
+        bookingItemId: null,
+        bookingPaymentScheduleId: "bps_123",
+        description: "Balance 50% Excursie Bulgaria | 2026-06-18",
+        quantity: 1,
+        unitPriceCents: 32_000,
+        totalCents: 32_000,
+      }),
+    ])
+  })
+
   it("lets callers override schedule line descriptions", async () => {
     const { db, insertedInvoiceLineItems } = makeDb({})
 


### PR DESCRIPTION
## Summary

- Preserve booking item display context when creating invoices from bookings.
- Use booking item snapshots for payment schedule invoice descriptions when the schedule is not linked to a specific booking item.
- Expose invoice line description resolution through finance route runtime options.
- Add regression coverage for schedule invoice line naming.

Fixes #1327

## Verification

- `pnpm --filter @voyantjs/finance exec vitest run tests/unit/service-invoice-number-allocation.test.ts tests/unit/route-runtime.test.ts tests/integration/routes.test.ts`
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/finance lint`
- `pnpm --filter @voyantjs/finance exec biome check tests/unit/route-runtime.test.ts tests/unit/service-invoice-number-allocation.test.ts tests/integration/routes.test.ts`
- `pnpm verify:route-authoring`
- `pnpm verify:tenant-scoping`
- pre-push `pnpm test` hook passed

Note: `pnpm verify:fast` stopped on the existing `verify:ui-components-barrel` failure for missing `@voyantjs/ui` component barrel exports unrelated to this finance change.