### PR TITLE
Add finance schedule line description format option

### DIFF
--- a/.changeset/finance-payment-schedule-line-format.md
+++ b/.changeset/finance-payment-schedule-line-format.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/finance": patch
+---
+
+Add invoice-from-booking schedule line description format options for product-first and product-only legal line names.

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -267,6 +267,7 @@ export type {
   InvoiceRenderedEvent,
   InvoiceVoidedEvent,
   PaymentCompletedEvent,
+  PaymentScheduleLineDescriptionFormat,
   ResolvedInvoiceLine,
   UnifiedPaymentRow,
 } from "./service.js"

--- a/packages/finance/src/route-runtime.ts
+++ b/packages/finance/src/route-runtime.ts
@@ -3,7 +3,10 @@ import type { EventBus } from "@voyantjs/core"
 import type { InvoiceFxOptions } from "./invoice-fx.js"
 import type { FinanceDocumentRouteOptions, InvoiceDocumentGenerator } from "./routes-documents.js"
 import type { FinanceSettlementRouteOptions, InvoiceSettlementPoller } from "./routes-settlement.js"
-import type { InvoiceLineDescriptionResolver } from "./service.js"
+import type {
+  InvoiceLineDescriptionResolver,
+  PaymentScheduleLineDescriptionFormat,
+} from "./service.js"
 
 export type FinanceRouteRuntime = {
   invoiceDocumentGenerator?: InvoiceDocumentGenerator
@@ -11,6 +14,7 @@ export type FinanceRouteRuntime = {
   invoiceSettlementPollers: Record<string, InvoiceSettlementPoller>
   eventBus?: EventBus
   descriptionResolver?: InvoiceLineDescriptionResolver
+  paymentScheduleLineDescriptionFormat?: PaymentScheduleLineDescriptionFormat
 } & InvoiceFxOptions
 
 export const FINANCE_ROUTE_RUNTIME_CONTAINER_KEY = "providers.finance.runtime"
@@ -20,6 +24,7 @@ export interface FinanceRuntimeOptions
     FinanceSettlementRouteOptions,
     InvoiceFxOptions {
   descriptionResolver?: InvoiceLineDescriptionResolver
+  paymentScheduleLineDescriptionFormat?: PaymentScheduleLineDescriptionFormat
 }
 
 export function buildFinanceRouteRuntime(
@@ -34,6 +39,7 @@ export function buildFinanceRouteRuntime(
       options.resolveInvoiceSettlementPollers?.(bindings) ?? options.invoiceSettlementPollers ?? {},
     eventBus: options.resolveEventBus?.(bindings) ?? options.eventBus,
     descriptionResolver: options.descriptionResolver,
+    paymentScheduleLineDescriptionFormat: options.paymentScheduleLineDescriptionFormat,
     invoiceFxSettings: options.invoiceFxSettings,
     resolveInvoiceFxSettings: options.resolveInvoiceFxSettings,
     updateInvoiceFxSettings: options.updateInvoiceFxSettings,

--- a/packages/finance/src/service.ts
+++ b/packages/finance/src/service.ts
@@ -271,6 +271,9 @@ export interface UnifiedPaymentRow {
 type InvoiceListQuery = z.infer<typeof invoiceListQuerySchema>
 type CreateInvoiceInput = z.infer<typeof insertInvoiceSchema>
 export type CreateInvoiceFromBookingInput = z.infer<typeof invoiceFromBookingSchema>
+export type PaymentScheduleLineDescriptionFormat = NonNullable<
+  CreateInvoiceFromBookingInput["paymentScheduleLineDescriptionFormat"]
+>
 type UpdateInvoiceInput = z.infer<typeof updateInvoiceSchema>
 type VoidInvoiceInput = z.infer<typeof voidInvoiceSchema>
 type CreateInvoiceLineItemInput = z.infer<typeof insertInvoiceLineItemSchema>
@@ -532,6 +535,7 @@ function bookingPaymentScheduleToInvoiceLine(
   booking: InvoiceFromBookingData["booking"],
   schedule: NonNullable<InvoiceFromBookingData["paymentSchedule"]>,
   item: InvoiceFromBookingData["items"][number] | undefined,
+  descriptionFormat: PaymentScheduleLineDescriptionFormat = "schedule_first",
 ): ResolvedInvoiceLine {
   const label = PAYMENT_SCHEDULE_LINE_LABELS[schedule.scheduleType]
   const percent = getPaymentSchedulePercent(booking, schedule)
@@ -545,13 +549,33 @@ function bookingPaymentScheduleToInvoiceLine(
   return {
     bookingItemId: schedule.bookingItemId ?? null,
     bookingPaymentScheduleId: schedule.id,
-    description: dates ? `${head} ${base} | ${dates}` : `${head} ${base}`,
+    description: renderPaymentScheduleLineDescription({ base, dates, head, descriptionFormat }),
     quantity: 1,
     unitPriceCents: schedule.amountCents,
     totalCents: schedule.amountCents,
     taxAmountCents: 0,
     taxRate: null,
     sortOrder: 0,
+  }
+}
+
+function renderPaymentScheduleLineDescription(input: {
+  head: string
+  base: string
+  dates: string | null
+  descriptionFormat: PaymentScheduleLineDescriptionFormat
+}) {
+  switch (input.descriptionFormat) {
+    case "product_only":
+      return input.dates ? `${input.base} | ${input.dates}` : input.base
+    case "product_first":
+      return input.dates
+        ? `${input.base} - ${input.head} | ${input.dates}`
+        : `${input.base} - ${input.head}`
+    case "schedule_first":
+      return input.dates
+        ? `${input.head} ${input.base} | ${input.dates}`
+        : `${input.head} ${input.base}`
   }
 }
 
@@ -960,6 +984,7 @@ export interface FinanceServiceRuntime extends InvoiceFxOptions {
   actionLedgerContext?: ActionLedgerRequestContextValues
   actionLedgerAuthorizationSource?: string | null
   descriptionResolver?: InvoiceLineDescriptionResolver
+  paymentScheduleLineDescriptionFormat?: PaymentScheduleLineDescriptionFormat
 }
 
 export interface InvoiceVoidedEvent {
@@ -3816,10 +3841,21 @@ export const financeService = {
     const scheduleItem = paymentSchedule
       ? resolvePaymentScheduleDisplayItem(paymentSchedule, items)
       : undefined
+    const paymentScheduleLineDescriptionFormat =
+      data.paymentScheduleLineDescriptionFormat ??
+      runtime.paymentScheduleLineDescriptionFormat ??
+      "schedule_first"
     const resolvedLineItems =
       overrideLineItems ??
       (paymentSchedule
-        ? [bookingPaymentScheduleToInvoiceLine(booking, paymentSchedule, scheduleItem)]
+        ? [
+            bookingPaymentScheduleToInvoiceLine(
+              booking,
+              paymentSchedule,
+              scheduleItem,
+              paymentScheduleLineDescriptionFormat,
+            ),
+          ]
         : invoiceItems.length > 0
           ? invoiceItems.map((item, sortOrder) => ({
               ...bookingItemToInvoiceLine(item, taxesByBookingItemId.get(item.id) ?? [], sortOrder),

--- a/packages/finance/src/validation-billing.ts
+++ b/packages/finance/src/validation-billing.ts
@@ -159,6 +159,9 @@ export const invoiceFromBookingSchema = z
     taxCents: z.number().int().min(0).optional(),
     totalCents: z.number().int().min(0).optional(),
     lineItems: z.array(invoiceFromBookingLineItemSchema).min(1).optional(),
+    paymentScheduleLineDescriptionFormat: z
+      .enum(["schedule_first", "product_first", "product_only"])
+      .optional(),
     externalRefs: z.array(invoiceExternalRefCoreSchema).optional(),
     /**
      * Document kind. Defaults to a regular invoice; bank-transfer

--- a/packages/finance/tests/unit/route-runtime.test.ts
+++ b/packages/finance/tests/unit/route-runtime.test.ts
@@ -5,8 +5,12 @@ import { buildFinanceRouteRuntime } from "../../src/route-runtime.js"
 describe("buildFinanceRouteRuntime", () => {
   it("exposes invoice line description resolver options", async () => {
     const descriptionResolver = () => "Custom legal line"
-    const runtime = buildFinanceRouteRuntime({}, { descriptionResolver })
+    const runtime = buildFinanceRouteRuntime(
+      {},
+      { descriptionResolver, paymentScheduleLineDescriptionFormat: "product_only" },
+    )
 
+    expect(runtime.paymentScheduleLineDescriptionFormat).toBe("product_only")
     expect(
       runtime.descriptionResolver?.({
         booking: {

--- a/packages/finance/tests/unit/service-invoice-number-allocation.test.ts
+++ b/packages/finance/tests/unit/service-invoice-number-allocation.test.ts
@@ -487,6 +487,107 @@ describe("financeService.createInvoiceFromBooking number allocation", () => {
     ])
   })
 
+  it("supports product-only schedule line descriptions from runtime options", async () => {
+    const { db, insertedInvoiceLineItems } = makeDb({})
+
+    await financeService.createInvoiceFromBooking(
+      db,
+      {
+        bookingId: "book_123",
+        invoiceNumber: "MANUAL-1",
+        issueDate: "2026-05-23",
+        dueDate: "2026-06-23",
+      },
+      {
+        booking: {
+          ...bookingData.booking,
+          bookingNumber: "BK-2605-5046",
+          sellAmountCents: 64_000,
+          startDate: "2026-06-13",
+          endDate: "2026-06-13",
+        },
+        paymentSchedule: {
+          id: "bps_123",
+          bookingId: "book_123",
+          bookingItemId: null,
+          scheduleType: "balance",
+          dueDate: "2026-06-01",
+          currency: "RON",
+          amountCents: 32_000,
+        },
+        items: [
+          {
+            id: "bkit_123",
+            title: "Fallback booking item title",
+            productNameSnapshot: "Excursie Bulgaria",
+            quantity: 2,
+            startDate: "2026-06-18",
+            unitSellAmountCents: 32_000,
+            totalSellAmountCents: 64_000,
+          },
+        ],
+      },
+      { paymentScheduleLineDescriptionFormat: "product_only" },
+    )
+
+    expect(insertedInvoiceLineItems[0]).toMatchObject({
+      bookingItemId: null,
+      bookingPaymentScheduleId: "bps_123",
+      description: "Excursie Bulgaria | 2026-06-18",
+    })
+  })
+
+  it("lets invoice-from-booking callers choose product-first schedule line descriptions", async () => {
+    const { db, insertedInvoiceLineItems } = makeDb({})
+
+    await financeService.createInvoiceFromBooking(
+      db,
+      {
+        bookingId: "book_123",
+        invoiceNumber: "MANUAL-1",
+        issueDate: "2026-05-23",
+        dueDate: "2026-06-23",
+        paymentScheduleLineDescriptionFormat: "product_first",
+      },
+      {
+        booking: {
+          ...bookingData.booking,
+          bookingNumber: "BK-2605-5046",
+          sellAmountCents: 64_000,
+          startDate: "2026-06-13",
+          endDate: "2026-06-13",
+        },
+        paymentSchedule: {
+          id: "bps_123",
+          bookingId: "book_123",
+          bookingItemId: null,
+          scheduleType: "balance",
+          dueDate: "2026-06-01",
+          currency: "RON",
+          amountCents: 32_000,
+        },
+        items: [
+          {
+            id: "bkit_123",
+            title: "Fallback booking item title",
+            productNameSnapshot: "Excursie Bulgaria",
+            quantity: 2,
+            startDate: "2026-06-18",
+            unitSellAmountCents: 32_000,
+            totalSellAmountCents: 64_000,
+          },
+        ],
+      },
+      { paymentScheduleLineDescriptionFormat: "product_only" },
+    )
+
+    expect(insertedInvoiceLineItems[0]).toMatchObject({
+      bookingItemId: null,
+      bookingPaymentScheduleId: "bps_123",
+      description: "Excursie Bulgaria - Balance 50% | 2026-06-18",
+    })
+  })
+
   it("lets callers override schedule line descriptions", async () => {
     const { db, insertedInvoiceLineItems } = makeDb({})
 


### PR DESCRIPTION
## Summary
- Add `paymentScheduleLineDescriptionFormat` to invoice-from-booking input and finance runtime configuration.
- Support `schedule_first` as the default, plus `product_first` and `product_only` for schedule-derived invoice line descriptions.
- Cover request-level override behavior and runtime forwarding in finance tests.

Fixes #1327

## Verification
- `pnpm --filter @voyantjs/finance exec vitest run tests/unit/service-invoice-number-allocation.test.ts tests/unit/route-runtime.test.ts`
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/finance lint`
- `pnpm --filter @voyantjs/finance exec biome check tests/unit/service-invoice-number-allocation.test.ts tests/unit/route-runtime.test.ts`
- `git diff --check`
- `pnpm verify:route-authoring`
- `pnpm verify:tenant-scoping`
- pre-push `pnpm test`