### PR TITLE
Fix booking status override audit reason

### DIFF
--- a/.changeset/silent-buses-walk.md
+++ b/.changeset/silent-buses-walk.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/bookings": patch
+---
+
+Ensure booking status override dispatches always include a non-empty audit reason when no operator note is supplied.

--- a/packages/bookings/src/status-dispatch.ts
+++ b/packages/bookings/src/status-dispatch.ts
@@ -11,9 +11,8 @@ export interface BookingStatusDispatchTarget {
    *
    * - For named verbs (`/confirm`, `/expire`, `/start`, `/complete`, `/cancel`)
    *   this is `{ note }` when a note is provided, otherwise an empty object.
-   * - For `/override-status` it is `{ status, reason, note? }` — the server
-   *   rejects empty reasons with a 400, so callers should pass a meaningful
-   *   note when the dispatch falls through to override.
+   * - For `/override-status` it is `{ status, reason, note? }`. When callers
+   *   do not provide a note, the dispatcher supplies a non-empty audit reason.
    */
   body: Record<string, unknown>
 }
@@ -23,7 +22,7 @@ export interface BookingStatusDispatchTarget {
  * arrows that have a named verb on the server go to that verb; everything else
  * (non-adjacent jumps, e.g. cancelled → confirmed for data correction) falls
  * through to /override-status, which requires a reason. The note text is used
- * as the reason — the server rejects empty reasons with a 400.
+ * as the reason when provided; otherwise a non-empty audit reason is generated.
  *
  * Framework-agnostic: returns the URL + body to send. Callers own the
  * transport (fetch, axios, the React hook, server-to-server scripts, etc).
@@ -70,15 +69,10 @@ export function dispatchBookingStatusChange(
     return { path: `/v1/bookings/${bookingId}/cancel`, body: noteBody }
   }
 
-  // The override-status route rejects empty reasons. For the common
-  // post-create transitions out of `draft` (the operator commits the
-  // booking to either confirmed-with-money-in or awaiting-payment) we
-  // don't want to force a reason prompt, so supply a benign default.
-  // Callers can still pass an explicit note to override.
-  const defaultReason =
-    current === "draft" && (target === "confirmed" || target === "awaiting_payment")
-      ? `Set to ${target} after create`
-      : ""
+  // The override-status route rejects empty reasons. Callers can pass an
+  // explicit note for the audit reason; otherwise generate a concise default
+  // so UI flows with optional notes never submit an invalid override payload.
+  const defaultReason = `Status override from ${current} to ${target}`
   const reason = note?.trim() || defaultReason
   return {
     path: `/v1/bookings/${bookingId}/override-status`,

--- a/packages/bookings/tests/unit/status-dispatch.test.ts
+++ b/packages/bookings/tests/unit/status-dispatch.test.ts
@@ -74,10 +74,23 @@ describe("dispatchBookingStatusChange — override fallback", () => {
     })
   })
 
-  it("override sets reason to empty string when no note (server will reject — surfacing 400)", () => {
+  it("override uses a default audit reason when no note is provided", () => {
     const target = dispatchBookingStatusChange(BOOKING_ID, "completed", "draft")
     expect(target.path).toBe(`/v1/bookings/${BOOKING_ID}/override-status`)
-    expect(target.body).toEqual({ status: "draft", reason: "" })
+    expect(target.body).toEqual({
+      status: "draft",
+      reason: "Status override from completed to draft",
+    })
+  })
+
+  it("override uses a default audit reason when note is blank", () => {
+    const target = dispatchBookingStatusChange(BOOKING_ID, "cancelled", "confirmed", "   ")
+    expect(target.path).toBe(`/v1/bookings/${BOOKING_ID}/override-status`)
+    expect(target.body).toEqual({
+      status: "confirmed",
+      reason: "Status override from cancelled to confirmed",
+      note: "   ",
+    })
   })
 
   it("expired → confirmed falls through to /override-status (no named verb)", () => {


### PR DESCRIPTION
## Summary

- Generate a non-empty default audit reason for booking status override fallbacks when no operator note is supplied.
- Update status dispatch tests for missing and blank override notes.
- Add a patch changeset for `@voyantjs/bookings`.

Closes #1342.

## Verification

- `pnpm --filter @voyantjs/bookings test -- status-dispatch`
- `pnpm --filter @voyantjs/bookings typecheck`
- `pnpm --filter @voyantjs/bookings lint`
- `pnpm test` via pre-push hook

Note: `pnpm verify:fast` currently stops on an existing `packages/ui` components barrel check reporting missing exports unrelated to this change.