### PR TITLE
Expose contract settlement variables

### DIFF
--- a/.changeset/settlement-contract-variables.md
+++ b/.changeset/settlement-contract-variables.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/legal": patch
+---
+
+Expose booking settlement variables for generated contracts from finance invoices and completed payments, including latest completed payment metadata for templates.

--- a/packages/legal/package.json
+++ b/packages/legal/package.json
@@ -28,6 +28,7 @@
     "@voyantjs/core": "workspace:*",
     "@voyantjs/crm": "workspace:*",
     "@voyantjs/db": "workspace:*",
+    "@voyantjs/finance": "workspace:*",
     "@voyantjs/hono": "workspace:*",
     "@voyantjs/suppliers": "workspace:*",
     "@voyantjs/utils": "workspace:*",

--- a/packages/legal/src/contracts/service-auto-generate.ts
+++ b/packages/legal/src/contracts/service-auto-generate.ts
@@ -1,4 +1,6 @@
 import { bookingsService } from "@voyantjs/bookings"
+import { invoices, payments } from "@voyantjs/finance/schema"
+import { and, desc, eq, ne } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import type { ContractLifecycleHook } from "./lifecycle.js"
@@ -311,6 +313,11 @@ export interface DefaultContractVariables {
     /** Alias for `capturedAt`, exposed for templates that prefer the
      *  `created_at` naming. */
     createdAt: string
+    latestCompleted?: {
+      method: string
+      methodLabel: string
+      date: string
+    }
   }
 
   operator: OperatorContextVariables
@@ -590,6 +597,7 @@ export async function autoGenerateContractForBooking(
   const startDate = booking.startDate ?? ""
   const endDate = booking.endDate ?? ""
   const durationNights = computeNights(startDate, endDate)
+  const settlement = await resolveBookingSettlementVariables(db, booking.id, sellCurrency)
 
   const mappedTravelers: ContractTravelerVariable[] = travelers.map((t, i) => {
     const fullName = [t.firstName, t.lastName].filter(Boolean).join(" ").trim()
@@ -687,8 +695,8 @@ export async function autoGenerateContractForBooking(
       taxAmountCents: 0,
       discountAmountCents: 0,
 
-      paidAmountCents: 0,
-      balanceDueCents: totalCents,
+      paidAmountCents: settlement.paidAmountCents,
+      balanceDueCents: settlement.balanceDueCents ?? totalCents,
 
       depositAmountCents: 0,
       depositDueDate: "",
@@ -800,12 +808,13 @@ export async function autoGenerateContractForBooking(
 
     payment: {
       intent: "",
-      method: "",
+      method: settlement.latestCompleted?.methodLabel ?? "",
       amountCents: totalCents,
       currency: sellCurrency,
       schedule: [],
-      capturedAt: "",
-      createdAt: "",
+      capturedAt: settlement.latestCompleted?.date ?? "",
+      createdAt: settlement.latestCompleted?.date ?? "",
+      latestCompleted: settlement.latestCompleted,
     },
 
     operator: {
@@ -960,6 +969,100 @@ export async function autoGenerateContractForBooking(
 
 function defaultVariablesToRecord(defaults: DefaultContractVariables): Record<string, unknown> {
   return { ...defaults }
+}
+
+type SettlementInvoiceRow = Pick<
+  typeof invoices.$inferSelect,
+  "currency" | "baseCurrency" | "balanceDueCents" | "baseBalanceDueCents"
+>
+
+type SettlementPaymentRow = Pick<
+  typeof payments.$inferSelect,
+  "amountCents" | "currency" | "baseCurrency" | "baseAmountCents" | "paymentMethod" | "paymentDate"
+>
+
+async function resolveBookingSettlementVariables(
+  db: PostgresJsDatabase,
+  bookingId: string,
+  bookingCurrency: string,
+): Promise<{
+  paidAmountCents: number
+  balanceDueCents: number | null
+  latestCompleted?: DefaultContractVariables["payment"]["latestCompleted"]
+}> {
+  const invoiceRows = await db
+    .select({
+      currency: invoices.currency,
+      baseCurrency: invoices.baseCurrency,
+      balanceDueCents: invoices.balanceDueCents,
+      baseBalanceDueCents: invoices.baseBalanceDueCents,
+    })
+    .from(invoices)
+    .where(and(eq(invoices.bookingId, bookingId), ne(invoices.status, "void")))
+
+  const currency = bookingCurrency || invoiceRows[0]?.currency || ""
+
+  const completedPaymentRows = await db
+    .select({
+      amountCents: payments.amountCents,
+      currency: payments.currency,
+      baseCurrency: payments.baseCurrency,
+      baseAmountCents: payments.baseAmountCents,
+      paymentMethod: payments.paymentMethod,
+      paymentDate: payments.paymentDate,
+    })
+    .from(payments)
+    .innerJoin(invoices, eq(payments.invoiceId, invoices.id))
+    .where(
+      and(
+        eq(invoices.bookingId, bookingId),
+        ne(invoices.status, "void"),
+        eq(payments.status, "completed"),
+      ),
+    )
+    .orderBy(desc(payments.paymentDate), desc(payments.createdAt))
+
+  const paidAmountCents = completedPaymentRows.reduce(
+    (sum, payment) => sum + amountInCurrency(payment, currency),
+    0,
+  )
+  const balanceDueCents =
+    invoiceRows.length > 0
+      ? invoiceRows.reduce((sum, invoice) => sum + invoiceBalanceInCurrency(invoice, currency), 0)
+      : null
+  const latestPayment = completedPaymentRows[0]
+
+  return {
+    paidAmountCents,
+    balanceDueCents,
+    latestCompleted: latestPayment
+      ? {
+          method: latestPayment.paymentMethod,
+          methodLabel: formatPaymentMethodLabel(latestPayment.paymentMethod),
+          date: latestPayment.paymentDate,
+        }
+      : undefined,
+  }
+}
+
+function amountInCurrency(payment: SettlementPaymentRow, currency: string): number {
+  if (!currency || payment.currency === currency) return payment.amountCents
+  if (payment.baseCurrency === currency) return payment.baseAmountCents ?? 0
+  return 0
+}
+
+function invoiceBalanceInCurrency(invoice: SettlementInvoiceRow, currency: string): number {
+  if (!currency || invoice.currency === currency) return invoice.balanceDueCents
+  if (invoice.baseCurrency === currency) return invoice.baseBalanceDueCents ?? 0
+  return 0
+}
+
+function formatPaymentMethodLabel(method: string): string {
+  return method
+    .split("_")
+    .filter(Boolean)
+    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+    .join(" ")
 }
 
 function computeNights(startDate: string, endDate: string): number {

--- a/packages/legal/src/contracts/template-authoring.ts
+++ b/packages/legal/src/contracts/template-authoring.ts
@@ -211,14 +211,16 @@ export const contractTemplateVariableCatalog: ContractTemplateVariableCategory[]
       {
         key: "booking.paidAmountCents",
         label: "Paid so far",
-        example: "0",
+        example: "50000",
         type: "cents",
+        description: "Customer settlement total from completed payments.",
       },
       {
         key: "booking.balanceDueCents",
         label: "Balance due",
-        example: "249900",
+        example: "199900",
         type: "cents",
+        description: "Current customer balance from non-void invoice balances.",
       },
       // Payment-schedule-derived (deposit / balance from
       // booking_payment_schedules)
@@ -565,7 +567,13 @@ export const contractTemplateVariableCatalog: ContractTemplateVariableCategory[]
         type: "string",
         description: "card | bank_transfer | hold | inquiry | ticket_on_credit",
       },
-      { key: "payment.method", label: "Method label", example: "Card payment", type: "string" },
+      {
+        key: "payment.method",
+        label: "Method label",
+        example: "Bank Transfer",
+        type: "string",
+        description: "Alias for `payment.latestCompleted.methodLabel` when a payment exists.",
+      },
       {
         key: "payment.amountCents",
         label: "Amount",
@@ -578,6 +586,7 @@ export const contractTemplateVariableCatalog: ContractTemplateVariableCategory[]
         label: "Captured at",
         example: "2026-05-04T10:05:12Z",
         type: "datetime",
+        description: "Alias for `payment.latestCompleted.date` when a payment exists.",
       },
       {
         key: "payment.createdAt",
@@ -585,6 +594,24 @@ export const contractTemplateVariableCatalog: ContractTemplateVariableCategory[]
         example: "2026-05-04T10:05:12Z",
         type: "datetime",
         description: "Alias for `payment.capturedAt`.",
+      },
+      {
+        key: "payment.latestCompleted.method",
+        label: "Latest payment method",
+        example: "bank_transfer",
+        type: "string",
+      },
+      {
+        key: "payment.latestCompleted.methodLabel",
+        label: "Latest payment method label",
+        example: "Bank Transfer",
+        type: "string",
+      },
+      {
+        key: "payment.latestCompleted.date",
+        label: "Latest payment date",
+        example: "2026-05-04",
+        type: "date",
       },
     ],
   },
@@ -796,10 +823,21 @@ No lead traveler on file.
 </table>`,
   },
   {
+    id: "settlement-summary",
+    label: "Settlement summary",
+    description: "Render customer-paid and remaining amounts from actual settlement state.",
+    code: `{% if booking.paidAmountCents > 0 %}
+Achitat: {{ booking.paidAmountCents | cents: booking.currency, "ro-RO" }}{% if payment.latestCompleted %} prin {{ payment.latestCompleted.methodLabel }} în data de {{ payment.latestCompleted.date | format_date: "long", "ro-RO" }}{% endif %}.
+{% endif %}
+{% if booking.balanceDueCents > 0 %}
+Diferență de plată: {{ booking.balanceDueCents | cents: booking.currency, "ro-RO" }}.
+{% endif %}`,
+  },
+  {
     id: "deposit-balance",
     label: "Deposit + balance line",
     description:
-      "Render the typical advance + remainder copy. Falls through gracefully when no schedule is on file.",
+      "Render the scheduled advance + remainder policy. Use the settlement snippet for current paid/remaining state.",
     code: `{% if booking.depositAmountCents > 0 %}
 Avansul este: {{ booking.depositAmountCents | cents: booking.currency, "ro-RO" }}, achitat cu {{ payment.method }} în data de {{ payment.capturedAt | format_date: "long", "ro-RO" }}.
 Diferență plată {{ booking.balanceAmountCents | cents: booking.currency, "ro-RO" }} până la data de {{ booking.balanceDueDate | format_date: "long", "ro-RO" }}.

--- a/packages/legal/tests/integration/auto-generate.test.ts
+++ b/packages/legal/tests/integration/auto-generate.test.ts
@@ -1,5 +1,6 @@
 import { bookings, bookingTravelers } from "@voyantjs/bookings/schema"
 import { createEventBus } from "@voyantjs/core"
+import { invoices, payments } from "@voyantjs/finance/schema"
 import { eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
@@ -263,6 +264,77 @@ describe.skipIf(!DB_AVAILABLE)("autoGenerateContractForBooking", () => {
     )
     expect(outcome.status).toBe("ok")
     expect(bodies[0]).toContain("Overridden Lead")
+  })
+
+  it("exposes settlement variables from invoices and completed payments", async () => {
+    const { template, version } = await seedTemplate("cust-settlement-1")
+    await db
+      .update(contractTemplateVersions)
+      .set({
+        body: [
+          "Paid {{ booking.paidAmountCents }}",
+          "Balance {{ booking.balanceDueCents }}",
+          "Latest {{ payment.latestCompleted.methodLabel }}",
+          "Date {{ payment.latestCompleted.date }}",
+        ].join(" | "),
+      })
+      .where(eq(contractTemplateVersions.id, version.id))
+
+    const booking = await seedBooking({
+      sellCurrency: "RON",
+      sellAmountCents: 32000,
+    })
+    const [invoice] = await db
+      .insert(invoices)
+      .values({
+        invoiceNumber: `INV-${booking.bookingNumber}`,
+        bookingId: booking.id,
+        status: "paid",
+        currency: "RON",
+        subtotalCents: 32000,
+        taxCents: 0,
+        totalCents: 32000,
+        paidCents: 32000,
+        balanceDueCents: 0,
+        issueDate: "2026-05-01",
+        dueDate: "2026-05-10",
+      })
+      .returning()
+    await db.insert(payments).values({
+      invoiceId: invoice!.id,
+      amountCents: 32000,
+      currency: "RON",
+      paymentMethod: "bank_transfer",
+      status: "completed",
+      paymentDate: "2026-05-04",
+    })
+
+    const bodies: string[] = []
+    const outcome = await autoGenerateContractForBooking(
+      db,
+      { bookingId: booking.id, bookingNumber: booking.bookingNumber, actorId: null },
+      { enabled: true, templateSlug: template.slug },
+      { generator: makeGenerator(bodies) },
+    )
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+
+    const contract = await contractRecordsService.getContractById(db, outcome.contractId)
+    const variables = contract?.variables as Record<string, unknown>
+    const bookingVariables = variables.booking as Record<string, unknown>
+    const paymentVariables = variables.payment as Record<string, unknown>
+    const latestCompleted = paymentVariables.latestCompleted as Record<string, unknown>
+
+    expect(bookingVariables.paidAmountCents).toBe(32000)
+    expect(bookingVariables.balanceDueCents).toBe(0)
+    expect(latestCompleted).toMatchObject({
+      method: "bank_transfer",
+      methodLabel: "Bank Transfer",
+      date: "2026-05-04",
+    })
+    expect(paymentVariables.method).toBe("Bank Transfer")
+    expect(paymentVariables.capturedAt).toBe("2026-05-04")
+    expect(bodies[0]).toContain("Paid 32000 | Balance 0 | Latest Bank Transfer")
   })
 
   it("resolves a series by name and writes seriesId onto the contract", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3378,6 +3378,9 @@ importers:
       '@voyantjs/db':
         specifier: workspace:*
         version: link:../db
+      '@voyantjs/finance':
+        specifier: workspace:*
+        version: link:../finance
       '@voyantjs/hono':
         specifier: workspace:*
         version: link:../hono


### PR DESCRIPTION
## Summary
- Hydrate generated contract defaults with booking settlement values from finance invoices and completed payments.
- Add `payment.latestCompleted` metadata and keep existing payment method/date aliases populated from the latest completed payment.
- Document the settlement variables in the template authoring catalog and add integration coverage plus a changeset.

Resolves #1345.

## Verification
- `pnpm --filter @voyantjs/legal typecheck`
- `pnpm --filter @voyantjs/legal lint`
- `pnpm --filter @voyantjs/legal test` (DB-backed integration tests skipped locally because `TEST_DATABASE_URL` is not set)
- Pre-commit full typecheck: failed in unrelated `apps/dev` and `templates/dmc` `BookingPaymentsSummaryProps` usages (`onConvertProforma` / `getInvoiceHref` props)
- Pre-push full test: failed in unrelated `@voyantjs/workflows-orchestrator` timing test `delay continues scheduling later DATETIME waits after the trigger delay fires`