### PR TITLE
fix: promote availability page composition into availability-ui (#1354)

### DIFF
--- a/.changeset/promote-availability-page.md
+++ b/.changeset/promote-availability-page.md
@@ -1,0 +1,12 @@
+---
+"@voyantjs/availability-ui": minor
+"operator": patch
+---
+
+Promote the slimmed-down operator availability page into `@voyantjs/availability-ui`.
+
+The reusable `AvailabilityPage` is now the slots + calendar layout from the recent operator refactor: header create button, product/status/date-range filters bar, ToggleGroup view switch, bulk status select, edit-slot dialog. Removed the legacy 6-tab overview shell (overview + rules/start-times/closeouts/pickup-points tabs) — nothing in the repo consumed it. Operator's local `availability-page.tsx` is now a thin shell that injects `api.post/patch` for bulk update/delete and slot mutate.
+
+Prop changes:
+- New: `defaultView`, `onSlotOpen`, optional `onSlotSubmit`, `slots.{headerEnd,beforeFilters,afterFilters,dialogs}`.
+- Removed: `defaultTab`, rule/start-time/closeout/pickup-point handlers and helpers, `AvailabilityPageActiveFilter`, `AvailabilityPageTab`.

--- a/packages/availability-ui/src/components/availability-page.tsx
+++ b/packages/availability-ui/src/components/availability-page.tsx
@@ -3,25 +3,12 @@
 import { useQueryClient } from "@tanstack/react-query"
 import type { RowSelectionState } from "@tanstack/react-table"
 import {
-  type AvailabilityCloseoutRow,
-  type AvailabilityPickupPointRow,
-  type AvailabilityRuleRow,
   type AvailabilitySlotRow,
-  type AvailabilityStartTimeRow,
   availabilityQueryKeys,
-  type CreateAvailabilityRuleInput,
   type CreateAvailabilitySlotInput,
-  type CreateAvailabilityStartTimeInput,
   type ProductOption,
-  type UpdateAvailabilityRuleInput,
   type UpdateAvailabilitySlotInput,
-  type UpdateAvailabilityStartTimeInput,
-  useAvailabilityOverview,
-  useAvailabilityRuleMutation,
   useAvailabilitySlotMutation,
-  useAvailabilityStartTimeMutation,
-  useCloseouts,
-  usePickupPoints,
   useProducts,
   useRules,
   useSlots,
@@ -39,259 +26,120 @@ import { DateRangePicker, type DateRangeValue } from "@voyantjs/ui/components/da
 import {
   Select,
   SelectContent,
-  SelectGroup,
   SelectItem,
   SelectTrigger,
   SelectValue,
 } from "@voyantjs/ui/components/select"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@voyantjs/ui/components/tabs"
+import { ToggleGroup, ToggleGroupItem } from "@voyantjs/ui/components/toggle-group"
+import { CalendarDays, List, Plus } from "lucide-react"
 import type { ReactNode } from "react"
 import { useState } from "react"
 
 import { useAvailabilityUiMessagesOrDefault } from "../i18n/index.js"
 import {
-  AvailabilityCloseoutDialog,
-  type AvailabilityCloseoutSubmitPayload,
-  AvailabilityPickupPointDialog,
-  type AvailabilityPickupPointSubmitPayload,
-  AvailabilityRuleDialog,
-  type AvailabilityRuleSubmitPayload,
   AvailabilitySlotDialog,
   type AvailabilitySlotSubmitPayload,
-  AvailabilityStartTimeDialog,
-  type AvailabilityStartTimeSubmitPayload,
 } from "./availability-dialogs.js"
-import { AvailabilityOverview } from "./availability-overview.js"
 import { AvailabilityBodySkeleton } from "./availability-skeletons.js"
 import {
   type AvailabilityBulkDeleteFn,
   type AvailabilityBulkUpdateFn,
-  AvailabilityCloseoutsTab,
-  AvailabilityPickupPointsTab,
-  AvailabilityRulesTab,
   AvailabilitySlotsTab,
-  AvailabilityStartTimesTab,
 } from "./availability-tabs.js"
 
-export type AvailabilityPageTab =
-  | "slots"
-  | "rules"
-  | "start-times"
-  | "closeouts"
-  | "pickup-points"
-  | "calendar"
-
-export type AvailabilityPageActiveFilter = "all" | "active" | "inactive"
+export type AvailabilityPageView = "list" | "calendar"
 export type AvailabilityPageSlotStatusFilter = "all" | AvailabilitySlotRow["status"]
-
 export type AvailabilityPageBulkUpdateHandler = AvailabilityBulkUpdateFn
 export type AvailabilityPageBulkDeleteHandler = AvailabilityBulkDeleteFn
 
 type DialogSubmitContext = { isEditing: boolean; id?: string }
-
-export type AvailabilityPageRuleSubmitHandler = (
-  payload: AvailabilityRuleSubmitPayload,
-  context: DialogSubmitContext,
-) => Promise<void> // i18n-literal-ok type annotation
-
-export type AvailabilityPageStartTimeSubmitHandler = (
-  payload: AvailabilityStartTimeSubmitPayload,
-  context: DialogSubmitContext,
-) => Promise<void> // i18n-literal-ok type annotation
 
 export type AvailabilityPageSlotSubmitHandler = (
   payload: AvailabilitySlotSubmitPayload,
   context: DialogSubmitContext,
 ) => Promise<void> // i18n-literal-ok type annotation
 
-export type AvailabilityPageCloseoutSubmitHandler = (
-  payload: AvailabilityCloseoutSubmitPayload,
-  context: DialogSubmitContext,
-) => Promise<void> // i18n-literal-ok type annotation
-
-export type AvailabilityPagePickupPointSubmitHandler = (
-  payload: AvailabilityPickupPointSubmitPayload,
-  context: DialogSubmitContext,
-) => Promise<void> // i18n-literal-ok type annotation
-
 export interface AvailabilityPageSlots {
   headerEnd?: ReactNode
-  beforeOverview?: ReactNode
-  afterOverview?: ReactNode
-  beforeTabs?: ReactNode
-  afterTabs?: ReactNode
+  beforeFilters?: ReactNode
+  afterFilters?: ReactNode
   dialogs?: ReactNode
 }
 
 export interface AvailabilityPageProps {
   className?: string
-  defaultTab?: AvailabilityPageTab
+  defaultView?: AvailabilityPageView
   bulkActionTarget?: string | null
   onBulkUpdate: AvailabilityPageBulkUpdateHandler
   onBulkDelete: AvailabilityPageBulkDeleteHandler
   onSlotOpen?: (slotId: string) => void
-  onRuleOpen?: (ruleId: string) => void
-  onStartTimeOpen?: (startTimeId: string) => void
-  onProductOpen?: (productId: string) => void
-  onCloseoutCreate?: () => void
-  onCloseoutEdit?: (closeout: AvailabilityCloseoutRow) => void
-  onPickupPointCreate?: () => void
-  onPickupPointEdit?: (pickupPoint: AvailabilityPickupPointRow) => void
-  onRuleSubmit?: AvailabilityPageRuleSubmitHandler
-  onStartTimeSubmit?: AvailabilityPageStartTimeSubmitHandler
   onSlotSubmit?: AvailabilityPageSlotSubmitHandler
-  onCloseoutSubmit?: AvailabilityPageCloseoutSubmitHandler
-  onPickupPointSubmit?: AvailabilityPagePickupPointSubmitHandler
   slots?: AvailabilityPageSlots
 }
 
-const noop = () => undefined
 const noopId = (_id: string) => undefined
-const noopCloseout = (_row: AvailabilityCloseoutRow) => undefined
-const noopPickupPoint = (_row: AvailabilityPickupPointRow) => undefined
 
 export function AvailabilityPage({
   className,
-  defaultTab = "slots",
+  defaultView = "list",
   bulkActionTarget = null,
   onBulkUpdate,
   onBulkDelete,
   onSlotOpen = noopId,
-  onRuleOpen = noopId,
-  onStartTimeOpen = noopId,
-  onProductOpen = noopId,
-  onCloseoutCreate = noop,
-  onCloseoutEdit = noopCloseout,
-  onPickupPointCreate = noop,
-  onPickupPointEdit = noopPickupPoint,
-  onRuleSubmit,
-  onStartTimeSubmit,
   onSlotSubmit,
-  onCloseoutSubmit,
-  onPickupPointSubmit,
   slots: pageSlots,
 }: AvailabilityPageProps) {
   const messages = useAvailabilityUiMessagesOrDefault()
-  const page = messages.page
+  const toolbar = messages.toolbar
   const queryClient = useQueryClient()
-  const ruleMutation = useAvailabilityRuleMutation()
-  const startTimeMutation = useAvailabilityStartTimeMutation()
   const slotMutation = useAvailabilitySlotMutation()
+
   const [productFilter, setProductFilter] = useState("all")
   const [productSearch, setProductSearch] = useState("")
   const [slotStatusFilter, setSlotStatusFilter] = useState<AvailabilityPageSlotStatusFilter>("all")
   const [slotDateRange, setSlotDateRange] = useState<DateRangeValue | null>(null)
-  const [ruleActiveFilter, setRuleActiveFilter] = useState<AvailabilityPageActiveFilter>("all")
-  const [startTimeActiveFilter, setStartTimeActiveFilter] =
-    useState<AvailabilityPageActiveFilter>("all")
-  const [closeoutDateRange, setCloseoutDateRange] = useState<DateRangeValue | null>(null)
-  const [pickupPointActiveFilter, setPickupPointActiveFilter] =
-    useState<AvailabilityPageActiveFilter>("all")
-  const [activeTab, setActiveTab] = useState<AvailabilityPageTab>(defaultTab)
+  const [view, setView] = useState<AvailabilityPageView>(defaultView)
   const [calendarView, setCalendarView] = useState<TCalendarView>("month")
-  const [ruleSelection, setRuleSelection] = useState<RowSelectionState>({})
-  const [startTimeSelection, setStartTimeSelection] = useState<RowSelectionState>({})
   const [slotSelection, setSlotSelection] = useState<RowSelectionState>({})
-  const [closeoutSelection, setCloseoutSelection] = useState<RowSelectionState>({})
-  const [pickupPointSelection, setPickupPointSelection] = useState<RowSelectionState>({})
-  const [ruleDialogOpen, setRuleDialogOpen] = useState(false)
-  const [startTimeDialogOpen, setStartTimeDialogOpen] = useState(false)
   const [slotDialogOpen, setSlotDialogOpen] = useState(false)
-  const [closeoutDialogOpen, setCloseoutDialogOpen] = useState(false)
-  const [pickupPointDialogOpen, setPickupPointDialogOpen] = useState(false)
-  const [editingRule, setEditingRule] = useState<AvailabilityRuleRow | undefined>()
-  const [editingStartTime, setEditingStartTime] = useState<AvailabilityStartTimeRow | undefined>()
   const [editingSlot, setEditingSlot] = useState<AvailabilitySlotRow | undefined>()
-  const [editingCloseout, setEditingCloseout] = useState<AvailabilityCloseoutRow | undefined>()
-  const [editingPickupPoint, setEditingPickupPoint] = useState<
-    AvailabilityPickupPointRow | undefined
-  >()
 
   const productIdFilter = productFilter === "all" ? undefined : productFilter
   const slotStatusFilterParam = slotStatusFilter === "all" ? undefined : slotStatusFilter
-  const pickupPointActiveParam =
-    pickupPointActiveFilter === "all" ? undefined : pickupPointActiveFilter === "active"
 
   const productsQuery = useProducts({ search: productSearch || undefined, limit: 25, offset: 0 })
-  const overviewQuery = useAvailabilityOverview({
-    productId: productIdFilter,
-    attentionLimit: 4,
-  })
-  // Pass the page filters through to the hooks so the server narrows the
-  // first 25 rows to the selection. Without this the list tabs renders empty
-  // whenever the selected product/status/date's matching rows happen to sit
-  // past the first page (mirror of #1043, but for list tabs).
-  // Client-side filters below stay as the safety net for dimensions the API
-  // doesn't expose (rule/start-time `active`, closeout date range).
-  const rulesQuery = useRules({ limit: 25, offset: 0, productId: productIdFilter })
-  const startTimesQuery = useStartTimes({ limit: 25, offset: 0, productId: productIdFilter })
+  // Rules + start times back the slot create/edit dialog. Eager-load so the
+  // dialog opens with full options the first time, but keep the queries cheap
+  // (no filters). Slots query honors the page filters so server returns the
+  // matching first page rather than a stale 25-row prefix.
+  const rulesQuery = useRules({ limit: 25, offset: 0 })
+  const startTimesQuery = useStartTimes({ limit: 25, offset: 0 })
+  // Date range is filtered client-side via matchesDateRange. The server's
+  // startsAtFrom expects an ISO datetime, but the date picker yields a
+  // yyyy-MM-dd string — passing it through gets rejected by the validator.
   const slotsQuery = useSlots({
     limit: 25,
     offset: 0,
     productId: productIdFilter,
     status: slotStatusFilterParam,
-    startsAtFrom: slotDateRange?.from ?? undefined,
-  })
-  const closeoutsQuery = useCloseouts({ limit: 25, offset: 0, productId: productIdFilter })
-  const pickupPointsQuery = usePickupPoints({
-    limit: 25,
-    offset: 0,
-    productId: productIdFilter,
-    active: pickupPointActiveParam,
   })
 
   const products = productsQuery.data?.data ?? []
   const rules = rulesQuery.data?.data ?? []
   const startTimes = startTimesQuery.data?.data ?? []
-  const availabilitySlots = slotsQuery.data?.data ?? []
-  const closeouts = closeoutsQuery.data?.data ?? []
-  const pickupPoints = pickupPointsQuery.data?.data ?? []
-  const overview = overviewQuery.data?.data
+  const slots = slotsQuery.data?.data ?? []
 
   const matchesProduct = (productId: string) =>
     productFilter === "all" || productId === productFilter
-  const matchesActive = (active: boolean, filter: AvailabilityPageActiveFilter) =>
-    filter === "all" || (filter === "active" ? active : !active)
   const matchesDateRange = (date: string, range: DateRangeValue | null) =>
     (!range?.from || date >= range.from) && (!range?.to || date <= range.to) // i18n-literal-ok comparison expression
 
-  const filteredRules = rules.filter(
-    (rule) => matchesProduct(rule.productId) && matchesActive(rule.active, ruleActiveFilter),
-  )
-  const filteredStartTimes = startTimes.filter(
-    (startTime) =>
-      matchesProduct(startTime.productId) && matchesActive(startTime.active, startTimeActiveFilter),
-  )
-  const productFilteredSlots = availabilitySlots.filter((slot) => matchesProduct(slot.productId))
+  const productFilteredSlots = slots.filter((slot) => matchesProduct(slot.productId))
   const filteredSlots = productFilteredSlots.filter(
     (slot) =>
       (slotStatusFilter === "all" || slot.status === slotStatusFilter) &&
       matchesDateRange(slot.dateLocal, slotDateRange),
   )
-  const filteredCloseouts = closeouts.filter(
-    (closeout) =>
-      matchesProduct(closeout.productId) && matchesDateRange(closeout.dateLocal, closeoutDateRange),
-  )
-  const filteredPickupPoints = pickupPoints.filter(
-    (pickupPoint) =>
-      matchesProduct(pickupPoint.productId) &&
-      matchesActive(pickupPoint.active, pickupPointActiveFilter),
-  )
-  const filteredProducts = products.filter(
-    (product) => productFilter === "all" || product.id === productFilter,
-  )
-  const constrainedSlots = [...filteredSlots]
-    .filter((slot) => slot.status === "sold_out" || slot.status === "closed")
-    .sort((left, right) => left.startsAt.localeCompare(right.startsAt))
-  const nowIso = new Date().toISOString()
-  const productsWithoutUpcomingDepartures = filteredProducts.filter(
-    (product) =>
-      !productFilteredSlots.some(
-        (slot) =>
-          slot.productId === product.id && slot.status === "open" && slot.startsAt >= nowIso,
-      ),
-  )
-  const hasFilters = productFilter !== "all"
   const selectedProduct = products.find((product) => product.id === productFilter) ?? null
 
   const slotStatusToColor: Record<AvailabilitySlotRow["status"], IEvent["color"]> = {
@@ -306,89 +154,46 @@ export function AvailabilityPage({
       id: slot.id,
       startDate: slot.startsAt,
       endDate: slot.endsAt ?? slot.startsAt,
-      title: productName ?? slot.productName ?? messages.tabs.slots.title,
+      title: productName ?? slot.productName ?? messages.slotFallbackTitle,
       description: slot.notes ?? "",
       color: slotStatusToColor[slot.status],
     }
   })
 
-  const primaryQueries = [
-    productsQuery,
-    rulesQuery,
-    startTimesQuery,
-    slotsQuery,
-    closeoutsQuery,
-    pickupPointsQuery,
-  ]
-  const isLoading = primaryQueries.some((query) => query.isPending)
-  const isError = primaryQueries.some((query) => query.isError)
+  const filtersHaveValues =
+    productFilter !== "all" ||
+    slotStatusFilter !== "all" ||
+    Boolean(slotDateRange?.from) ||
+    Boolean(slotDateRange?.to)
 
   const refreshAll = async () => {
     await queryClient.invalidateQueries({ queryKey: availabilityQueryKeys.all })
   }
 
-  const handleRuleSubmit: AvailabilityPageRuleSubmitHandler =
-    onRuleSubmit ??
-    (async (payload, context) => {
-      if (context.isEditing) {
-        await ruleMutation.update.mutateAsync({
-          id: requireEditingId(context),
-          input: payload as UpdateAvailabilityRuleInput,
-        })
-        return
-      }
-
-      await ruleMutation.create.mutateAsync(payload as CreateAvailabilityRuleInput)
-    })
-
-  const handleStartTimeSubmit: AvailabilityPageStartTimeSubmitHandler =
-    onStartTimeSubmit ??
-    (async (payload, context) => {
-      if (context.isEditing) {
-        await startTimeMutation.update.mutateAsync({
-          id: requireEditingId(context),
-          input: payload as UpdateAvailabilityStartTimeInput,
-        })
-        return
-      }
-
-      await startTimeMutation.create.mutateAsync(payload as CreateAvailabilityStartTimeInput)
-    })
-
   const handleSlotSubmit: AvailabilityPageSlotSubmitHandler =
     onSlotSubmit ??
     (async (payload, context) => {
       if (context.isEditing) {
+        if (!context.id) throw new Error("AvailabilityPage slot edit requires an id.")
         await slotMutation.update.mutateAsync({
-          id: requireEditingId(context),
+          id: context.id,
           input: payload as UpdateAvailabilitySlotInput,
         })
         return
       }
-
       await slotMutation.create.mutateAsync(payload as CreateAvailabilitySlotInput)
     })
 
-  const closeRuleDialog = () => {
-    setRuleDialogOpen(false)
-    setEditingRule(undefined)
-  }
-  const closeStartTimeDialog = () => {
-    setStartTimeDialogOpen(false)
-    setEditingStartTime(undefined)
-  }
   const closeSlotDialog = () => {
     setSlotDialogOpen(false)
     setEditingSlot(undefined)
   }
-  const closeCloseoutDialog = () => {
-    setCloseoutDialogOpen(false)
-    setEditingCloseout(undefined)
-  }
-  const closePickupPointDialog = () => {
-    setPickupPointDialogOpen(false)
-    setEditingPickupPoint(undefined)
-  }
+
+  const isLoading =
+    productsQuery.isPending ||
+    rulesQuery.isPending ||
+    startTimesQuery.isPending ||
+    slotsQuery.isPending
 
   return (
     <div className={cn("flex flex-col gap-6 p-6", className)}>
@@ -397,250 +202,148 @@ export function AvailabilityPage({
           <h1 className="text-2xl font-bold tracking-tight">{messages.title}</h1>
           <p className="text-sm text-muted-foreground">{messages.description}</p>
         </div>
-        <div className="flex w-full flex-col gap-3 md:w-72">
-          <AsyncCombobox<ProductOption>
-            value={productFilter === "all" ? null : productFilter}
-            onChange={(value) => setProductFilter(value ?? "all")}
-            items={products}
-            selectedItem={selectedProduct}
-            getKey={(product) => product.id}
-            getLabel={(product) => product.name}
-            onSearchChange={setProductSearch}
-            placeholder={messages.allProducts}
-            emptyText={productsQuery.isFetching ? page.loading : page.filters.productSearchEmpty}
-            triggerClassName="w-full"
-          />
+        <div className="flex items-center gap-2">
           {pageSlots?.headerEnd}
+          <Button
+            onClick={() => {
+              setEditingSlot(undefined)
+              setSlotDialogOpen(true)
+            }}
+          >
+            <Plus className="mr-2 size-4" />
+            {messages.tabs.slots.actionLabel}
+          </Button>
         </div>
       </div>
 
+      {pageSlots?.beforeFilters}
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end sm:justify-between">
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="availability-product-filter" className="text-xs">
+              {messages.productLabel}
+            </Label>
+            <AsyncCombobox<ProductOption>
+              value={productFilter === "all" ? null : productFilter}
+              onChange={(value) => setProductFilter(value ?? "all")}
+              items={products}
+              selectedItem={selectedProduct}
+              getKey={(product) => product.id}
+              getLabel={(product) => product.name}
+              onSearchChange={setProductSearch}
+              placeholder={messages.allProducts}
+              emptyText={
+                productsQuery.isFetching
+                  ? messages.productsComboboxSearching
+                  : messages.productsComboboxEmpty
+              }
+              triggerClassName="w-full sm:w-64"
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="availability-slot-status" className="text-xs">
+              {messages.statusLabel}
+            </Label>
+            <Select
+              value={slotStatusFilter}
+              onValueChange={(value) =>
+                setSlotStatusFilter((value as AvailabilityPageSlotStatusFilter) ?? "all")
+              }
+            >
+              <SelectTrigger id="availability-slot-status" className="w-full sm:w-44">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">{toolbar.statusAll}</SelectItem>
+                <SelectItem value="open">{messages.statusOpen}</SelectItem>
+                <SelectItem value="closed">{messages.statusClosed}</SelectItem>
+                <SelectItem value="sold_out">{messages.statusSoldOut}</SelectItem>
+                <SelectItem value="cancelled">{messages.statusCancelled}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label className="text-xs">{toolbar.dateRangeLabel}</Label>
+            <DateRangePicker
+              value={slotDateRange}
+              onChange={setSlotDateRange}
+              className="w-full sm:w-72"
+              placeholder={toolbar.dateRangePlaceholder}
+            />
+          </div>
+          {filtersHaveValues ? (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setProductFilter("all")
+                setSlotStatusFilter("all")
+                setSlotDateRange(null)
+              }}
+            >
+              {toolbar.reset}
+            </Button>
+          ) : null}
+        </div>
+        <ToggleGroup
+          value={[view]}
+          onValueChange={(values) => {
+            const next = values[values.length - 1]
+            if (next === "list" || next === "calendar") setView(next)
+          }}
+          variant="outline"
+          aria-label={messages.title}
+        >
+          <ToggleGroupItem value="list" aria-label={messages.tabSlots}>
+            <List className="mr-2 size-4" />
+            {messages.tabSlots}
+          </ToggleGroupItem>
+          <ToggleGroupItem value="calendar" aria-label={messages.tabCalendar}>
+            <CalendarDays className="mr-2 size-4" />
+            {messages.tabCalendar}
+          </ToggleGroupItem>
+        </ToggleGroup>
+      </div>
+
+      {pageSlots?.afterFilters}
+
       {isLoading ? (
         <AvailabilityBodySkeleton />
-      ) : isError ? (
-        <div className="rounded-md border p-6 text-sm text-muted-foreground">{page.loadFailed}</div>
+      ) : view === "list" ? (
+        <AvailabilitySlotsTab
+          messages={messages}
+          products={products}
+          filteredSlots={filteredSlots}
+          slotSelection={slotSelection}
+          setSlotSelection={setSlotSelection}
+          bulkActionTarget={bulkActionTarget}
+          handleBulkUpdate={onBulkUpdate}
+          handleBulkDelete={onBulkDelete}
+          onCreate={() => {
+            setEditingSlot(undefined)
+            setSlotDialogOpen(true)
+          }}
+          onOpenRoute={onSlotOpen}
+          onEdit={(row) => {
+            setEditingSlot(row)
+            setSlotDialogOpen(true)
+          }}
+          hideHeader
+          asPanel={false}
+          hideBulkDelete
+          bulkStatusSelect
+        />
       ) : (
-        <>
-          {pageSlots?.beforeOverview}
-          <AvailabilityOverview
-            messages={messages}
-            products={products}
-            constrainedSlots={overview?.constrainedSlots ?? constrainedSlots}
-            constrainedSlotsCount={overview?.constrainedSlotsCount}
-            openSlotsCount={overview?.openSlotsCount}
-            activeRulesCount={overview?.activeRulesCount}
-            activePickupPointsCount={overview?.activePickupPointsCount}
-            filteredRules={filteredRules}
-            filteredPickupPoints={filteredPickupPoints}
-            productsWithoutUpcomingDepartures={
-              overview?.productsWithoutUpcomingDepartures ?? productsWithoutUpcomingDepartures
-            }
-            productsWithoutUpcomingDeparturesCount={
-              overview?.productsWithoutUpcomingDeparturesCount
-            }
-            search=""
-            setSearch={() => {}}
-            productFilter={productFilter}
-            setProductFilter={setProductFilter}
-            hasFilters={hasFilters}
-            onClearFilters={() => setProductFilter("all")}
-            onOpenSlot={onSlotOpen}
-            onOpenProduct={onProductOpen}
-            onJumpToSlots={() => setActiveTab("slots")}
-            showFilters={false}
+        <CalendarProvider events={calendarEvents} onEventClick={(event) => onSlotOpen(event.id)}>
+          <CalendarView
+            view={calendarView}
+            onViewChange={setCalendarView}
+            onDayClick={() => setCalendarView("day")}
           />
-          {pageSlots?.afterOverview}
-          {pageSlots?.beforeTabs}
-
-          <Tabs
-            value={activeTab}
-            onValueChange={(value) => setActiveTab((value ?? "slots") as AvailabilityPageTab)}
-          >
-            <TabsList className="flex w-full justify-start overflow-x-auto">
-              <TabsTrigger value="slots">{messages.tabSlots}</TabsTrigger>
-              <TabsTrigger value="rules">{messages.tabRules}</TabsTrigger>
-              <TabsTrigger value="start-times">{messages.tabStartTimes}</TabsTrigger>
-              <TabsTrigger value="closeouts">{messages.tabCloseouts}</TabsTrigger>
-              <TabsTrigger value="pickup-points">{messages.tabPickupPoints}</TabsTrigger>
-              <TabsTrigger value="calendar">{page.calendarTab}</TabsTrigger>
-            </TabsList>
-
-            <AvailabilitySlotsTab
-              messages={messages}
-              products={products}
-              filteredSlots={filteredSlots}
-              slotSelection={slotSelection}
-              setSlotSelection={setSlotSelection}
-              bulkActionTarget={bulkActionTarget}
-              handleBulkUpdate={onBulkUpdate}
-              handleBulkDelete={onBulkDelete}
-              onCreate={() => {
-                setEditingSlot(undefined)
-                setSlotDialogOpen(true)
-              }}
-              onOpenRoute={onSlotOpen}
-              onEdit={(row) => {
-                setEditingSlot(row)
-                setSlotDialogOpen(true)
-              }}
-              toolbar={
-                <SlotsToolbar
-                  value={slotStatusFilter}
-                  onValueChange={setSlotStatusFilter}
-                  dateRange={slotDateRange}
-                  onDateRangeChange={setSlotDateRange}
-                />
-              }
-            />
-            <AvailabilityRulesTab
-              messages={messages}
-              products={products}
-              filteredRules={filteredRules}
-              ruleSelection={ruleSelection}
-              setRuleSelection={setRuleSelection}
-              bulkActionTarget={bulkActionTarget}
-              handleBulkUpdate={onBulkUpdate}
-              handleBulkDelete={onBulkDelete}
-              onCreate={() => {
-                setEditingRule(undefined)
-                setRuleDialogOpen(true)
-              }}
-              onOpenRoute={onRuleOpen}
-              onEdit={(row) => {
-                setEditingRule(row)
-                setRuleDialogOpen(true)
-              }}
-              toolbar={
-                <ActiveToolbar value={ruleActiveFilter} onValueChange={setRuleActiveFilter} />
-              }
-            />
-            <AvailabilityStartTimesTab
-              messages={messages}
-              products={products}
-              filteredStartTimes={filteredStartTimes}
-              startTimeSelection={startTimeSelection}
-              setStartTimeSelection={setStartTimeSelection}
-              bulkActionTarget={bulkActionTarget}
-              handleBulkUpdate={onBulkUpdate}
-              handleBulkDelete={onBulkDelete}
-              onCreate={() => {
-                setEditingStartTime(undefined)
-                setStartTimeDialogOpen(true)
-              }}
-              onOpenRoute={onStartTimeOpen}
-              onEdit={(row) => {
-                setEditingStartTime(row)
-                setStartTimeDialogOpen(true)
-              }}
-              toolbar={
-                <ActiveToolbar
-                  value={startTimeActiveFilter}
-                  onValueChange={setStartTimeActiveFilter}
-                />
-              }
-            />
-            <AvailabilityCloseoutsTab
-              messages={messages}
-              products={products}
-              filteredCloseouts={filteredCloseouts}
-              closeoutSelection={closeoutSelection}
-              setCloseoutSelection={setCloseoutSelection}
-              bulkActionTarget={bulkActionTarget}
-              handleBulkDelete={onBulkDelete}
-              onCreate={
-                onCloseoutSubmit
-                  ? () => {
-                      setEditingCloseout(undefined)
-                      setCloseoutDialogOpen(true)
-                    }
-                  : onCloseoutCreate
-              }
-              onEdit={(row) => {
-                if (onCloseoutSubmit) {
-                  setEditingCloseout(row)
-                  setCloseoutDialogOpen(true)
-                  return
-                }
-
-                onCloseoutEdit(row)
-              }}
-              toolbar={
-                <DateRangeToolbar value={closeoutDateRange} onValueChange={setCloseoutDateRange} />
-              }
-            />
-            <AvailabilityPickupPointsTab
-              messages={messages}
-              products={products}
-              filteredPickupPoints={filteredPickupPoints}
-              pickupPointSelection={pickupPointSelection}
-              setPickupPointSelection={setPickupPointSelection}
-              bulkActionTarget={bulkActionTarget}
-              handleBulkUpdate={onBulkUpdate}
-              handleBulkDelete={onBulkDelete}
-              onCreate={
-                onPickupPointSubmit
-                  ? () => {
-                      setEditingPickupPoint(undefined)
-                      setPickupPointDialogOpen(true)
-                    }
-                  : onPickupPointCreate
-              }
-              onEdit={(row) => {
-                if (onPickupPointSubmit) {
-                  setEditingPickupPoint(row)
-                  setPickupPointDialogOpen(true)
-                  return
-                }
-
-                onPickupPointEdit(row)
-              }}
-              toolbar={
-                <ActiveToolbar
-                  value={pickupPointActiveFilter}
-                  onValueChange={setPickupPointActiveFilter}
-                />
-              }
-            />
-            <TabsContent value="calendar" className="flex flex-col gap-4">
-              <CalendarProvider
-                events={calendarEvents}
-                onEventClick={(event) => onSlotOpen(event.id)}
-              >
-                <CalendarView
-                  view={calendarView}
-                  onViewChange={setCalendarView}
-                  onDayClick={() => setCalendarView("day")}
-                />
-              </CalendarProvider>
-            </TabsContent>
-          </Tabs>
-          {pageSlots?.afterTabs}
-        </>
+        </CalendarProvider>
       )}
 
-      <AvailabilityRuleDialog
-        messages={messages}
-        open={ruleDialogOpen}
-        onOpenChange={setRuleDialogOpen}
-        rule={editingRule}
-        products={products}
-        onSubmit={handleRuleSubmit}
-        onSuccess={() => {
-          closeRuleDialog()
-          void refreshAll()
-        }}
-      />
-      <AvailabilityStartTimeDialog
-        messages={messages}
-        open={startTimeDialogOpen}
-        onOpenChange={setStartTimeDialogOpen}
-        startTime={editingStartTime}
-        products={products}
-        onSubmit={handleStartTimeSubmit}
-        onSuccess={() => {
-          closeStartTimeDialog()
-          void refreshAll()
-        }}
-      />
       <AvailabilitySlotDialog
         messages={messages}
         open={slotDialogOpen}
@@ -655,179 +358,8 @@ export function AvailabilityPage({
           void refreshAll()
         }}
       />
-      {onCloseoutSubmit ? (
-        <AvailabilityCloseoutDialog
-          messages={messages}
-          open={closeoutDialogOpen}
-          onOpenChange={setCloseoutDialogOpen}
-          closeout={editingCloseout}
-          products={products}
-          slots={availabilitySlots}
-          onSubmit={onCloseoutSubmit}
-          onSuccess={() => {
-            closeCloseoutDialog()
-            void refreshAll()
-          }}
-        />
-      ) : null}
-      {onPickupPointSubmit ? (
-        <AvailabilityPickupPointDialog
-          messages={messages}
-          open={pickupPointDialogOpen}
-          onOpenChange={setPickupPointDialogOpen}
-          pickupPoint={editingPickupPoint}
-          products={products}
-          onSubmit={onPickupPointSubmit}
-          onSuccess={() => {
-            closePickupPointDialog()
-            void refreshAll()
-          }}
-        />
-      ) : null}
+
       {pageSlots?.dialogs}
-    </div>
-  )
-}
-
-function requireEditingId(context: DialogSubmitContext) {
-  if (!context.id) throw new Error("AvailabilityPage edit submit requires an id.")
-  return context.id
-}
-
-function SlotsToolbar({
-  value,
-  onValueChange,
-  dateRange,
-  onDateRangeChange,
-}: {
-  value: AvailabilityPageSlotStatusFilter
-  onValueChange: (value: AvailabilityPageSlotStatusFilter) => void
-  dateRange: DateRangeValue | null
-  onDateRangeChange: (value: DateRangeValue | null) => void
-}) {
-  const messages = useAvailabilityUiMessagesOrDefault()
-  const page = messages.page
-  const hasFilters = value !== "all" || Boolean(dateRange?.from) || Boolean(dateRange?.to)
-
-  return (
-    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
-      <div className="flex flex-col gap-1.5">
-        <Label htmlFor="availability-slot-status" className="text-xs">
-          {page.filters.statusLabel}
-        </Label>
-        <Select
-          value={value}
-          onValueChange={(nextValue) =>
-            onValueChange((nextValue ?? "all") as AvailabilityPageSlotStatusFilter)
-          }
-        >
-          <SelectTrigger id="availability-slot-status" className="w-full sm:w-44">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectGroup>
-              <SelectItem value="all">{page.filters.allStatuses}</SelectItem>
-              <SelectItem value="open">{messages.statusOpen}</SelectItem>
-              <SelectItem value="closed">{messages.statusClosed}</SelectItem>
-              <SelectItem value="sold_out">{messages.statusSoldOut}</SelectItem>
-              <SelectItem value="cancelled">{messages.statusCancelled}</SelectItem>
-            </SelectGroup>
-          </SelectContent>
-        </Select>
-      </div>
-      <div className="flex flex-col gap-1.5">
-        <Label className="text-xs">{page.filters.dateRangeLabel}</Label>
-        <DateRangePicker
-          value={dateRange}
-          onChange={onDateRangeChange}
-          className="w-full sm:w-72"
-          placeholder={page.filters.anyDate}
-        />
-      </div>
-      {hasFilters ? (
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => {
-            onValueChange("all")
-            onDateRangeChange(null)
-          }}
-        >
-          {page.filters.reset}
-        </Button>
-      ) : null}
-    </div>
-  )
-}
-
-function DateRangeToolbar({
-  value,
-  onValueChange,
-}: {
-  value: DateRangeValue | null
-  onValueChange: (value: DateRangeValue | null) => void
-}) {
-  const page = useAvailabilityUiMessagesOrDefault().page
-  const hasFilters = Boolean(value?.from) || Boolean(value?.to)
-
-  return (
-    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
-      <div className="flex flex-col gap-1.5">
-        <Label className="text-xs">{page.filters.dateRangeLabel}</Label>
-        <DateRangePicker
-          value={value}
-          onChange={onValueChange}
-          className="w-full sm:w-72"
-          placeholder={page.filters.anyDate}
-        />
-      </div>
-      {hasFilters ? (
-        <Button variant="outline" size="sm" onClick={() => onValueChange(null)}>
-          {page.filters.reset}
-        </Button>
-      ) : null}
-    </div>
-  )
-}
-
-function ActiveToolbar({
-  value,
-  onValueChange,
-}: {
-  value: AvailabilityPageActiveFilter
-  onValueChange: (value: AvailabilityPageActiveFilter) => void
-}) {
-  const page = useAvailabilityUiMessagesOrDefault().page
-
-  return (
-    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
-      <div className="flex flex-col gap-1.5">
-        <Label htmlFor="availability-active-filter" className="text-xs">
-          {page.filters.stateLabel}
-        </Label>
-        <Select
-          value={value}
-          onValueChange={(nextValue) =>
-            onValueChange((nextValue ?? "all") as AvailabilityPageActiveFilter)
-          }
-        >
-          <SelectTrigger id="availability-active-filter" className="w-full sm:w-44">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectGroup>
-              <SelectItem value="all">{page.filters.allStates}</SelectItem>
-              <SelectItem value="active">{page.filters.active}</SelectItem>
-              <SelectItem value="inactive">{page.filters.inactive}</SelectItem>
-            </SelectGroup>
-          </SelectContent>
-        </Select>
-      </div>
-      {value !== "all" ? (
-        <Button variant="outline" size="sm" onClick={() => onValueChange("all")}>
-          {page.filters.reset}
-        </Button>
-      ) : null}
     </div>
   )
 }

--- a/packages/availability-ui/src/index.ts
+++ b/packages/availability-ui/src/index.ts
@@ -26,18 +26,13 @@ export {
 } from "./components/availability-overview.js"
 export {
   AvailabilityPage,
-  type AvailabilityPageActiveFilter,
   type AvailabilityPageBulkDeleteHandler,
   type AvailabilityPageBulkUpdateHandler,
-  type AvailabilityPageCloseoutSubmitHandler,
-  type AvailabilityPagePickupPointSubmitHandler,
   type AvailabilityPageProps,
-  type AvailabilityPageRuleSubmitHandler,
   type AvailabilityPageSlotStatusFilter,
   type AvailabilityPageSlotSubmitHandler,
   type AvailabilityPageSlots,
-  type AvailabilityPageStartTimeSubmitHandler,
-  type AvailabilityPageTab,
+  type AvailabilityPageView,
 } from "./components/availability-page.js"
 export {
   AvailabilityRuleDetailPage,

--- a/templates/operator/src/components/voyant/availability/availability-page.tsx
+++ b/templates/operator/src/components/voyant/availability/availability-page.tsx
@@ -1,211 +1,35 @@
-import { useQuery } from "@tanstack/react-query"
+import { useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
-import type { RowSelectionState } from "@tanstack/react-table"
 import { formatMessage } from "@voyantjs/admin"
-import { AvailabilityBodySkeleton, AvailabilitySlotsTab } from "@voyantjs/availability-ui"
-import { AsyncCombobox } from "@voyantjs/ui/components/async-combobox"
+import { availabilityQueryKeys } from "@voyantjs/availability-react"
 import {
-  CalendarProvider,
-  CalendarView,
-  type IEvent,
-  type TCalendarView,
-} from "@voyantjs/ui/components/big-calendar"
-import { Button } from "@voyantjs/ui/components/button"
-import { DateRangePicker, type DateRangeValue } from "@voyantjs/ui/components/date-picker"
-import { Label } from "@voyantjs/ui/components/label"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@voyantjs/ui/components/select"
-import { ToggleGroup, ToggleGroupItem } from "@voyantjs/ui/components/toggle-group"
-import { CalendarDays, List, Plus } from "lucide-react"
+  AvailabilityPage as AvailabilityPageBase,
+  type AvailabilityPageBulkDeleteHandler,
+  type AvailabilityPageBulkUpdateHandler,
+  type AvailabilityPageSlotSubmitHandler,
+} from "@voyantjs/availability-ui"
 import { useState } from "react"
 import { toast } from "sonner"
-import type {
-  AvailabilitySlotRow,
-  BatchMutationResponse,
-} from "@/components/voyant/availability/availability-shared"
-import {
-  formatLocalizedSelectionLabel,
-  getAvailabilityProductsQueryOptions,
-  getAvailabilityRulesQueryOptions,
-  getAvailabilitySlotsQueryOptions,
-  getAvailabilityStartTimesQueryOptions,
-} from "@/components/voyant/availability/availability-shared"
+import type { BatchMutationResponse } from "@/components/voyant/availability/availability-shared"
+import { formatLocalizedSelectionLabel } from "@/components/voyant/availability/availability-shared"
 import { useAdminMessages } from "@/lib/admin-i18n"
 import { api } from "@/lib/api-client"
-import { AvailabilitySlotDialog } from "./availability-dialogs"
 
-type AvailabilityView = "list" | "calendar"
+const SLOTS_ENDPOINT = "/v1/availability/slots"
 
 export function AvailabilityPage() {
   const messages = useAdminMessages()
   const navigate = useNavigate()
-  const [productFilter, setProductFilter] = useState("all")
-  const [productSearch, setProductSearch] = useState("")
-  const [slotStatusFilter, setSlotStatusFilter] = useState<
-    "all" | "open" | "closed" | "sold_out" | "cancelled"
-  >("all")
-  const [slotDateRange, setSlotDateRange] = useState<DateRangeValue | null>(null)
-  const [view, setView] = useState<AvailabilityView>("list")
-  const [calendarView, setCalendarView] = useState<TCalendarView>("month")
+  const queryClient = useQueryClient()
   const [bulkActionTarget, setBulkActionTarget] = useState<string | null>(null)
-  const [slotSelection, setSlotSelection] = useState<RowSelectionState>({})
-  const [slotDialogOpen, setSlotDialogOpen] = useState(false)
-  const [editingSlot, setEditingSlot] = useState<AvailabilitySlotRow | undefined>()
 
-  const productsQuery = useQuery(
-    getAvailabilityProductsQueryOptions({ search: productSearch || undefined, limit: 25 }),
-  )
-  const rulesQuery = useQuery(getAvailabilityRulesQueryOptions())
-  const startTimesQuery = useQuery(getAvailabilityStartTimesQueryOptions())
-  const slotsQuery = useQuery(getAvailabilitySlotsQueryOptions())
+  const refreshAvailability = () =>
+    queryClient.invalidateQueries({ queryKey: availabilityQueryKeys.all })
 
-  const products = productsQuery.data?.data ?? []
-  const rules = rulesQuery.data?.data ?? []
-  const startTimes = startTimesQuery.data?.data ?? []
-  const slots = slotsQuery.data?.data ?? []
-  const matchesProduct = (productId: string) =>
-    productFilter === "all" || productId === productFilter
-  const matchesDateRange = (date: string, range: DateRangeValue | null) =>
-    (!range?.from || date >= range.from) && (!range?.to || date <= range.to)
+  const slotsNounSingular = messages.availability.tabs.slots.title
+  const slotsNounPlural = messages.availability.tabs.slots.title
 
-  const productFilteredSlots = slots.filter((slot) => matchesProduct(slot.productId))
-  const filteredSlots = productFilteredSlots.filter(
-    (slot) =>
-      (slotStatusFilter === "all" || slot.status === slotStatusFilter) &&
-      matchesDateRange(slot.dateLocal, slotDateRange),
-  )
-  const selectedProduct = products.find((product) => product.id === productFilter) ?? null
-
-  const slotStatusToColor: Record<AvailabilitySlotRow["status"], IEvent["color"]> = {
-    open: "green",
-    closed: "gray",
-    sold_out: "red",
-    cancelled: "yellow",
-  }
-  const calendarEvents: IEvent[] = filteredSlots.map((slot) => {
-    const productName = products.find((product) => product.id === slot.productId)?.name
-    return {
-      id: slot.id,
-      startDate: slot.startsAt,
-      endDate: slot.endsAt ?? slot.startsAt,
-      title: productName ?? slot.productName ?? messages.availability.slotFallbackTitle,
-      description: slot.notes ?? "",
-      color: slotStatusToColor[slot.status],
-    }
-  })
-
-  const toolbar = messages.availability.toolbar
-  const filtersHaveValues =
-    productFilter !== "all" ||
-    slotStatusFilter !== "all" ||
-    Boolean(slotDateRange?.from) ||
-    Boolean(slotDateRange?.to)
-  const filtersBar = (
-    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end sm:justify-between">
-      <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
-        <div className="flex flex-col gap-1.5">
-          <Label htmlFor="product-filter" className="text-xs">
-            {messages.availability.productLabel}
-          </Label>
-          <AsyncCombobox
-            value={productFilter === "all" ? null : productFilter}
-            onChange={(value) => setProductFilter(value ?? "all")}
-            items={products}
-            selectedItem={selectedProduct}
-            getKey={(product) => product.id}
-            getLabel={(product) => product.name}
-            onSearchChange={setProductSearch}
-            placeholder={messages.availability.allProducts}
-            emptyText={
-              productsQuery.isFetching
-                ? messages.availability.productsComboboxSearching
-                : messages.availability.productsComboboxEmpty
-            }
-            triggerClassName="w-full sm:w-64"
-          />
-        </div>
-        <div className="flex flex-col gap-1.5">
-          <Label htmlFor="slot-status" className="text-xs">
-            {messages.availability.statusLabel}
-          </Label>
-          <Select
-            value={slotStatusFilter}
-            onValueChange={(value) =>
-              setSlotStatusFilter((value as typeof slotStatusFilter) ?? "all")
-            }
-          >
-            <SelectTrigger id="slot-status" className="w-full sm:w-44">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">{toolbar.statusAll}</SelectItem>
-              <SelectItem value="open">{messages.availability.statusOpen}</SelectItem>
-              <SelectItem value="closed">{messages.availability.statusClosed}</SelectItem>
-              <SelectItem value="sold_out">{messages.availability.statusSoldOut}</SelectItem>
-              <SelectItem value="cancelled">{messages.availability.statusCancelled}</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="flex flex-col gap-1.5">
-          <Label className="text-xs">{toolbar.dateRangeLabel}</Label>
-          <DateRangePicker
-            value={slotDateRange}
-            onChange={setSlotDateRange}
-            className="w-full sm:w-72"
-            placeholder={toolbar.dateRangePlaceholder}
-          />
-        </div>
-        {filtersHaveValues ? (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              setProductFilter("all")
-              setSlotStatusFilter("all")
-              setSlotDateRange(null)
-            }}
-          >
-            {toolbar.reset}
-          </Button>
-        ) : null}
-      </div>
-      <ToggleGroup
-        value={[view]}
-        onValueChange={(values) => {
-          const next = values[values.length - 1]
-          if (next === "list" || next === "calendar") setView(next)
-        }}
-        variant="outline"
-        aria-label={messages.availability.title}
-      >
-        <ToggleGroupItem value="list" aria-label={messages.availability.tabSlots}>
-          <List className="mr-2 size-4" />
-          {messages.availability.tabSlots}
-        </ToggleGroupItem>
-        <ToggleGroupItem value="calendar" aria-label={messages.availability.tabCalendar}>
-          <CalendarDays className="mr-2 size-4" />
-          {messages.availability.tabCalendar}
-        </ToggleGroupItem>
-      </ToggleGroup>
-    </div>
-  )
-
-  const refreshAll = async () => {
-    await Promise.all([rulesQuery.refetch(), startTimesQuery.refetch(), slotsQuery.refetch()])
-  }
-
-  const isLoading =
-    productsQuery.isPending ||
-    rulesQuery.isPending ||
-    startTimesQuery.isPending ||
-    slotsQuery.isPending
-
-  const handleBulkUpdate = async ({
+  const handleBulkUpdate: AvailabilityPageBulkUpdateHandler = async ({
     ids,
     endpoint,
     target,
@@ -214,15 +38,6 @@ export function AvailabilityPage() {
     payload,
     successVerb,
     clearSelection,
-  }: {
-    ids: string[]
-    endpoint: string
-    target: string
-    nounSingular: string
-    nounPlural: string
-    payload: Record<string, unknown>
-    successVerb: string
-    clearSelection: () => void
   }) => {
     if (ids.length === 0) return
 
@@ -233,16 +48,20 @@ export function AvailabilityPage() {
       patch: payload,
     })
 
-    await refreshAll()
+    await refreshAvailability()
     clearSelection()
     setBulkActionTarget(null)
 
     const succeededSelection = formatLocalizedSelectionLabel(
       result.succeeded,
-      nounSingular,
-      nounPlural,
+      nounSingular ?? slotsNounSingular,
+      nounPlural ?? slotsNounPlural,
     )
-    const totalSelection = formatLocalizedSelectionLabel(result.total, nounSingular, nounPlural)
+    const totalSelection = formatLocalizedSelectionLabel(
+      result.total,
+      nounSingular ?? slotsNounSingular,
+      nounPlural ?? slotsNounPlural,
+    )
 
     if (result.failed.length === 0) {
       toast.success(
@@ -263,20 +82,13 @@ export function AvailabilityPage() {
     )
   }
 
-  const handleBulkDelete = async ({
+  const handleBulkDelete: AvailabilityPageBulkDeleteHandler = async ({
     ids,
     endpoint,
     target,
     nounSingular,
     nounPlural,
     clearSelection,
-  }: {
-    ids: string[]
-    endpoint: string
-    target: string
-    nounSingular: string
-    nounPlural: string
-    clearSelection: () => void
   }) => {
     if (ids.length === 0) return
 
@@ -284,16 +96,20 @@ export function AvailabilityPage() {
 
     const result = await api.post<BatchMutationResponse>(`${endpoint}/batch-delete`, { ids })
 
-    await refreshAll()
+    await refreshAvailability()
     clearSelection()
     setBulkActionTarget(null)
 
     const succeededSelection = formatLocalizedSelectionLabel(
       result.succeeded,
-      nounSingular,
-      nounPlural,
+      nounSingular ?? slotsNounSingular,
+      nounPlural ?? slotsNounPlural,
     )
-    const totalSelection = formatLocalizedSelectionLabel(result.total, nounSingular, nounPlural)
+    const totalSelection = formatLocalizedSelectionLabel(
+      result.total,
+      nounSingular ?? slotsNounSingular,
+      nounPlural ?? slotsNounPlural,
+    )
 
     if (result.failed.length === 0) {
       toast.success(
@@ -312,82 +128,21 @@ export function AvailabilityPage() {
     )
   }
 
+  const handleSlotSubmit: AvailabilityPageSlotSubmitHandler = async (payload, context) => {
+    if (context.isEditing) {
+      await api.patch(`${SLOTS_ENDPOINT}/${context.id}`, payload)
+      return
+    }
+    await api.post(SLOTS_ENDPOINT, payload)
+  }
+
   return (
-    <div className="flex flex-col gap-6 p-6">
-      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight">{messages.availability.title}</h1>
-          <p className="text-sm text-muted-foreground">{messages.availability.description}</p>
-        </div>
-        <Button
-          onClick={() => {
-            setEditingSlot(undefined)
-            setSlotDialogOpen(true)
-          }}
-        >
-          <Plus className="mr-2 size-4" />
-          {messages.availability.tabs.slots.actionLabel}
-        </Button>
-      </div>
-
-      {filtersBar}
-
-      {isLoading ? (
-        <AvailabilityBodySkeleton />
-      ) : view === "list" ? (
-        <AvailabilitySlotsTab
-          messages={messages.availability}
-          products={products}
-          filteredSlots={filteredSlots}
-          slotSelection={slotSelection}
-          setSlotSelection={setSlotSelection}
-          bulkActionTarget={bulkActionTarget}
-          handleBulkUpdate={handleBulkUpdate}
-          handleBulkDelete={handleBulkDelete}
-          onCreate={() => {
-            setEditingSlot(undefined)
-            setSlotDialogOpen(true)
-          }}
-          onOpenRoute={(slotId) =>
-            void navigate({ to: "/availability/$id", params: { id: slotId } })
-          }
-          onEdit={(row) => {
-            setEditingSlot(row)
-            setSlotDialogOpen(true)
-          }}
-          hideHeader
-          asPanel={false}
-          hideBulkDelete
-          bulkStatusSelect
-        />
-      ) : (
-        <CalendarProvider
-          events={calendarEvents}
-          onEventClick={(event) =>
-            void navigate({ to: "/availability/$id", params: { id: event.id } })
-          }
-        >
-          <CalendarView
-            view={calendarView}
-            onViewChange={setCalendarView}
-            onDayClick={() => setCalendarView("day")}
-          />
-        </CalendarProvider>
-      )}
-
-      <AvailabilitySlotDialog
-        open={slotDialogOpen}
-        onOpenChange={setSlotDialogOpen}
-        slot={editingSlot}
-        products={products}
-        rules={rules}
-        startTimes={startTimes}
-        onSuccess={() => {
-          setSlotDialogOpen(false)
-          setEditingSlot(undefined)
-          void refreshAll()
-        }}
-      />
-    </div>
+    <AvailabilityPageBase
+      bulkActionTarget={bulkActionTarget}
+      onBulkUpdate={handleBulkUpdate}
+      onBulkDelete={handleBulkDelete}
+      onSlotOpen={(slotId) => void navigate({ to: "/availability/$id", params: { id: slotId } })}
+      onSlotSubmit={handleSlotSubmit}
+    />
   )
 }


### PR DESCRIPTION
Closes #1354.

## Summary

- Rewrite `@voyantjs/availability-ui`'s exported `AvailabilityPage` so it matches the current operator template UX: header create button, product/status/date-range filters bar, list/calendar `ToggleGroup`, bulk-status select, and the built-in slot create/edit dialog.
- Drop the legacy 6-tab overview surface (overview + rules/start-times/closeouts/pickup-points tabs) — nothing in the repo consumed it; DMC and apps/dev each maintain their own local fork for the older design.
- Reduce `templates/operator/.../availability-page.tsx` from ~390 lines to ~140 lines: it now just provides `api.post/patch` bulk handlers, the slot submit handler, and a navigate callback to the packaged component.

## Prop shape

New: `defaultView`, `onSlotOpen`, optional `onSlotSubmit`, `slots.{headerEnd,beforeFilters,afterFilters,dialogs}`.
Removed: `defaultTab`, the rule/start-time/closeout/pickup-point handlers, `AvailabilityPageActiveFilter`, `AvailabilityPageTab`.

## Test plan

- [x] `pnpm -F @voyantjs/availability-ui typecheck && pnpm -F @voyantjs/availability-ui test`
- [x] `pnpm -F operator typecheck && pnpm -F operator test`
- [x] `pnpm -F dmc typecheck && pnpm -F dev typecheck`
- [x] `pnpm typecheck` (full workspace, 126/126)
- [x] `pnpm test` (full workspace, 127/127)
- [x] `pnpm lint` (only pre-existing warning unrelated to this PR)
- [x] `pnpm i18n:check`
- [ ] Manual smoke: load `/availability` in operator and confirm filters / toggle / slot dialog behave the same