### PR TITLE
fix: drop operator template from availability-page changeset

### DIFF
--- a/.changeset/promote-availability-page.md
+++ b/.changeset/promote-availability-page.md
@@ -1,6 +1,5 @@
 ---
 "@voyantjs/availability-ui": minor
-"operator": patch
 ---
 
 Promote the slimmed-down operator availability page into `@voyantjs/availability-ui`.


### PR DESCRIPTION
The release workflow's `detect-pending-publication` step failed on main with:

```
Error: Found mixed changeset promote-availability-page
Found ignored packages: operator
Found not ignored packages: @voyantjs/availability-ui
Mixed changesets that contain both ignored and not ignored packages are not allowed
```

The `templates/operator` package is in changesets' ignore set; templates pick up their dependency bump through the workspace resolver, not through the changeset entry. Following the convention from #1352 (which also touched `templates/operator/package.json` but listed only `@voyantjs/auth` in its changeset).

## Test plan

- [x] Diff is a one-line removal of `"operator": patch` from `.changeset/promote-availability-page.md`
- [ ] Release workflow's `Detect pending npm publication` step passes on main after merge