### PR TITLE
Add tokenized public document delivery URLs

### DIFF
--- a/.changeset/public-document-delivery.md
+++ b/.changeset/public-document-delivery.md
@@ -1,0 +1,8 @@
+---
+"@voyantjs/db": minor
+"@voyantjs/finance": minor
+"@voyantjs/hono": minor
+"@voyantjs/legal": minor
+---
+
+Add tokenized public document delivery grants, a public document download route, and opt-in public download envelopes for generated finance and legal documents.

--- a/apps/dev/migrations/0041_public_document_delivery_grants.sql
+++ b/apps/dev/migrations/0041_public_document_delivery_grants.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS "public_document_delivery_grants" (
+  "id" text PRIMARY KEY NOT NULL,
+  "token_hash" text NOT NULL,
+  "storage_key" text NOT NULL,
+  "storage_provider" text,
+  "filename" text,
+  "content_type" text DEFAULT 'application/octet-stream' NOT NULL,
+  "source_module" text,
+  "source_entity" text,
+  "source_id" text,
+  "created_by" text,
+  "created_by_type" text,
+  "metadata" jsonb,
+  "access_count" integer DEFAULT 0 NOT NULL,
+  "last_accessed_at" timestamp with time zone,
+  "last_accessed_ip" text,
+  "last_accessed_user_agent" text,
+  "revoked_at" timestamp with time zone,
+  "revoked_by" text,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "expires_at" timestamp with time zone NOT NULL
+);--> statement-breakpoint
+ALTER TABLE "public_document_delivery_grants" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uidx_public_document_delivery_grants_token_hash"
+  ON "public_document_delivery_grants" USING btree ("token_hash");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_public_document_delivery_grants_expires_at"
+  ON "public_document_delivery_grants" USING btree ("expires_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_public_document_delivery_grants_source"
+  ON "public_document_delivery_grants" USING btree ("source_module","source_entity","source_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_public_document_delivery_grants_revoked_at"
+  ON "public_document_delivery_grants" USING btree ("revoked_at");

--- a/apps/dev/migrations/meta/_journal.json
+++ b/apps/dev/migrations/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1779830000000,
       "tag": "0040_invoice_number_active_unique",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1779905100000,
+      "tag": "0041_public_document_delivery_grants",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/dev/src/api/app.ts
+++ b/apps/dev/src/api/app.ts
@@ -11,7 +11,7 @@ import { extrasHonoModule } from "@voyantjs/extras"
 import { facilitiesHonoModule } from "@voyantjs/facilities"
 import { createFinanceHonoModule, createVoyantDataFxExchangeRateResolver } from "@voyantjs/finance"
 import { groundHonoModule } from "@voyantjs/ground"
-import { createApp } from "@voyantjs/hono"
+import { createApp, createPublicDocumentDeliveryHonoModule } from "@voyantjs/hono"
 import { identityHonoModule } from "@voyantjs/identity"
 import { marketsHonoModule } from "@voyantjs/markets"
 import {
@@ -79,6 +79,10 @@ const financeModule = createFinanceHonoModule({
   },
 })
 
+const publicDocumentDeliveryModule = createPublicDocumentDeliveryHonoModule<CloudflareBindings>({
+  resolveStorage: createDocumentStorage,
+})
+
 const crmHonoModule = createCrmHonoModule()
 const bookingsHonoModule = createBookingsHonoModule({
   resolveTravelSnapshot: (db, personId, { kms }) =>
@@ -108,6 +112,7 @@ export const app = createApp<CloudflareBindings>({
   publicPaths: [
     "/v1/public/customer-portal/contact-exists",
     "/v1/public/checkout",
+    "/v1/public/documents",
     "/v1/public/invitations",
   ],
   modules: [
@@ -132,6 +137,7 @@ export const app = createApp<CloudflareBindings>({
     productsHonoModule,
     bookingsHonoModule,
     financeModule,
+    publicDocumentDeliveryModule,
     storefrontHonoModule,
     customerPortalHonoModule,
     checkoutHonoModule,

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -41,6 +41,7 @@
     "./schema/infra/domains": "./src/schema/infra/domains.ts",
     "./schema/infra/email_domain_records": "./src/schema/infra/email_domain_records.ts",
     "./schema/infra/idempotency_keys": "./src/schema/infra/idempotency_keys.ts",
+    "./schema/infra/public_document_delivery_grants": "./src/schema/infra/public_document_delivery_grants.ts",
     "./schema/infra/rate_limit_buckets": "./src/schema/infra/rate_limit_buckets.ts",
     "./schema/infra/webhook_deliveries": "./src/schema/infra/webhook_deliveries.ts",
     "./schema/infra/webhook_subscriptions": "./src/schema/infra/webhook_subscriptions.ts",
@@ -221,6 +222,11 @@
         "types": "./dist/schema/infra/idempotency_keys.d.ts",
         "import": "./dist/schema/infra/idempotency_keys.js",
         "default": "./dist/schema/infra/idempotency_keys.js"
+      },
+      "./schema/infra/public_document_delivery_grants": {
+        "types": "./dist/schema/infra/public_document_delivery_grants.d.ts",
+        "import": "./dist/schema/infra/public_document_delivery_grants.js",
+        "default": "./dist/schema/infra/public_document_delivery_grants.js"
       },
       "./schema/infra/rate_limit_buckets": {
         "types": "./dist/schema/infra/rate_limit_buckets.d.ts",

--- a/packages/db/src/lib/typeid-prefixes.ts
+++ b/packages/db/src/lib/typeid-prefixes.ts
@@ -19,6 +19,7 @@ export const PREFIXES = {
   webhook_subscriptions: "hksub",
   webhook_deliveries: "whde",
   rate_limit_buckets: "rlbk",
+  public_document_delivery_grants: "pddg",
   domains: "dom",
   email_domain_records: "emdr",
   idempotency_keys: "ikey",

--- a/packages/db/src/schema/infra/index.ts
+++ b/packages/db/src/schema/infra/index.ts
@@ -1,6 +1,7 @@
 // audit_log: REMOVED - migrated to Tinybird (audit_log.datasource)
 export * from "./domains.js"
 export * from "./idempotency_keys.js"
+export * from "./public_document_delivery_grants.js"
 export * from "./rate_limit_buckets.js"
 export * from "./webhook_deliveries.js"
 export * from "./webhook_subscriptions.js"

--- a/packages/db/src/schema/infra/public_document_delivery_grants.ts
+++ b/packages/db/src/schema/infra/public_document_delivery_grants.ts
@@ -1,0 +1,50 @@
+import { index, integer, jsonb, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core"
+
+import { typeId } from "../../lib/index.js"
+
+/**
+ * Token grants for unauthenticated, customer-safe document delivery.
+ *
+ * Only the SHA-256 hash of the opaque token is stored. Each row grants access
+ * to exactly one object-storage key until it expires or is revoked.
+ */
+export const infraPublicDocumentDeliveryGrantsTable = pgTable(
+  "public_document_delivery_grants",
+  {
+    id: typeId("public_document_delivery_grants"),
+    tokenHash: text("token_hash").notNull(),
+    storageKey: text("storage_key").notNull(),
+    storageProvider: text("storage_provider"),
+    filename: text("filename"),
+    contentType: text("content_type").notNull().default("application/octet-stream"),
+    sourceModule: text("source_module"),
+    sourceEntity: text("source_entity"),
+    sourceId: text("source_id"),
+    createdBy: text("created_by"),
+    createdByType: text("created_by_type"),
+    metadata: jsonb("metadata"),
+    accessCount: integer("access_count").notNull().default(0),
+    lastAccessedAt: timestamp("last_accessed_at", { withTimezone: true }),
+    lastAccessedIp: text("last_accessed_ip"),
+    lastAccessedUserAgent: text("last_accessed_user_agent"),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+    revokedBy: text("revoked_by"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+  },
+  (table) => [
+    uniqueIndex("uidx_public_document_delivery_grants_token_hash").on(table.tokenHash),
+    index("idx_public_document_delivery_grants_expires_at").on(table.expiresAt),
+    index("idx_public_document_delivery_grants_source").on(
+      table.sourceModule,
+      table.sourceEntity,
+      table.sourceId,
+    ),
+    index("idx_public_document_delivery_grants_revoked_at").on(table.revokedAt),
+  ],
+).enableRLS()
+
+export type InsertInfraPublicDocumentDeliveryGrant =
+  typeof infraPublicDocumentDeliveryGrantsTable.$inferInsert
+export type SelectInfraPublicDocumentDeliveryGrant =
+  typeof infraPublicDocumentDeliveryGrantsTable.$inferSelect

--- a/packages/finance/src/routes-documents.ts
+++ b/packages/finance/src/routes-documents.ts
@@ -1,7 +1,11 @@
 import type { EventBus, ModuleContainer } from "@voyantjs/core"
-import { parseOptionalJsonBody } from "@voyantjs/hono"
+import {
+  createDrizzlePublicDocumentDeliveryGrantStore,
+  createPublicDocumentDeliveryGrant,
+  parseOptionalJsonBody,
+} from "@voyantjs/hono"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-import { Hono } from "hono"
+import { type Context, Hono } from "hono"
 
 import { resolveStoredDocumentDownload } from "./document-download.js"
 import {
@@ -59,10 +63,11 @@ export function createFinanceAdminDocumentRoutes(options: FinanceDocumentRouteOp
         return c.json({ error: "Invoice document generator is not configured" }, 501)
       }
 
+      const input = await parseOptionalJsonBody(c, generateInvoiceDocumentInputSchema)
       const result = await financeDocumentsService.generateInvoiceDocument(
         c.get("db"),
         c.req.param("id"),
-        await parseOptionalJsonBody(c, generateInvoiceDocumentInputSchema),
+        input,
         { generator, bindings: c.env, eventBus: runtime.eventBus },
       )
 
@@ -74,7 +79,7 @@ export function createFinanceAdminDocumentRoutes(options: FinanceDocumentRouteOp
         return c.json({ error: "Invoice document generation failed" }, 502)
       }
 
-      return c.json({ data: await attachDownloadEnvelope(c.env, runtime, result) }, 201)
+      return c.json({ data: await attachDownloadEnvelope(c, runtime, result, input) }, 201)
     })
     .post("/invoices/:id/regenerate-document", async (c) => {
       const runtime = getRuntime(options, c.env, (key) => c.var.container?.resolve(key))
@@ -83,10 +88,11 @@ export function createFinanceAdminDocumentRoutes(options: FinanceDocumentRouteOp
         return c.json({ error: "Invoice document generator is not configured" }, 501)
       }
 
+      const input = await parseOptionalJsonBody(c, generateInvoiceDocumentInputSchema)
       const result = await financeDocumentsService.regenerateInvoiceDocument(
         c.get("db"),
         c.req.param("id"),
-        await parseOptionalJsonBody(c, generateInvoiceDocumentInputSchema),
+        input,
         { generator, bindings: c.env, eventBus: runtime.eventBus },
       )
 
@@ -98,7 +104,7 @@ export function createFinanceAdminDocumentRoutes(options: FinanceDocumentRouteOp
         return c.json({ error: "Invoice document generation failed" }, 502)
       }
 
-      return c.json({ data: await attachDownloadEnvelope(c.env, runtime, result) })
+      return c.json({ data: await attachDownloadEnvelope(c, runtime, result, input) })
     })
     .get("/invoice-renditions/:id/download", async (c) => {
       const runtime = getRuntime(options, c.env, (key) => c.var.container?.resolve(key))
@@ -123,11 +129,48 @@ export function createFinanceAdminDocumentRoutes(options: FinanceDocumentRouteOp
 }
 
 async function attachDownloadEnvelope<
-  T extends { rendition: { storageKey?: string | null; metadata?: unknown } },
->(bindings: Record<string, unknown>, runtime: FinanceRouteRuntime, result: T) {
+  T extends {
+    rendition: {
+      id?: string | null
+      format?: string | null
+      storageKey?: string | null
+      metadata?: unknown
+    }
+  },
+>(
+  c: Context<Env>,
+  runtime: FinanceRouteRuntime,
+  result: T,
+  input: { publicDelivery?: boolean; publicDeliveryTtlSeconds?: number | undefined },
+) {
   const download = await resolveStoredDocumentDownload(result.rendition, {
-    bindings,
+    bindings: c.env,
     resolveDocumentDownloadUrl: runtime.resolveDocumentDownloadUrl,
   })
-  return download.status === "ready" ? { ...result, download: download.download } : result
+  const withAdminDownload =
+    download.status === "ready" ? { ...result, download: download.download } : result
+
+  if (!input.publicDelivery || !result.rendition.storageKey) {
+    return withAdminDownload
+  }
+
+  const publicDownload = await createPublicDocumentDeliveryGrant(
+    createDrizzlePublicDocumentDeliveryGrantStore(c.get("db")),
+    {
+      storageKey: result.rendition.storageKey,
+      publicBaseUrl: new URL(c.req.url).origin,
+      ttlSeconds: input.publicDeliveryTtlSeconds,
+      filename: download.status === "ready" ? download.download.filename : null,
+      contentType: result.rendition.format === "pdf" ? "application/pdf" : null,
+      source: {
+        module: "finance",
+        entity: "invoice_rendition",
+        id: result.rendition.id ?? null,
+      },
+      createdBy: c.get("userId") ?? null,
+      createdByType: c.get("userId") ? "staff" : null,
+    },
+  )
+
+  return { ...withAdminDownload, publicDownload }
 }

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -1262,7 +1262,7 @@ export async function createBooking(
           const generated = await financeDocumentsService.generateInvoiceDocument(
             db,
             invoice.id,
-            { format: "pdf", replaceExisting: true },
+            { format: "pdf", replaceExisting: true, publicDelivery: false },
             {
               generator: runtime.invoiceDocumentGenerator,
               eventBus: runtime.eventBus,

--- a/packages/finance/src/validation-billing.ts
+++ b/packages/finance/src/validation-billing.ts
@@ -455,6 +455,13 @@ export const renderInvoiceInputSchema = z.object({
 
 export const generateInvoiceDocumentInputSchema = renderInvoiceInputSchema.extend({
   replaceExisting: z.boolean().default(true),
+  publicDelivery: z.boolean().default(false),
+  publicDeliveryTtlSeconds: z
+    .number()
+    .int()
+    .min(1)
+    .max(30 * 24 * 60 * 60)
+    .optional(),
 })
 
 export const invoiceDocumentWaitQuerySchema = invoiceDocumentWaitFieldsSchema

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -9,6 +9,7 @@
     "./module": "./src/module.ts",
     "./plugin": "./src/plugin.ts",
     "./document-download": "./src/document-download.ts",
+    "./public-document-delivery": "./src/public-document-delivery.ts",
     "./types": "./src/types.ts",
     "./middleware": "./src/middleware/index.ts",
     "./middleware/auth": "./src/middleware/auth.ts",
@@ -34,6 +35,7 @@
   "dependencies": {
     "@voyantjs/core": "workspace:*",
     "@voyantjs/db": "workspace:*",
+    "@voyantjs/storage": "workspace:*",
     "@voyantjs/types": "workspace:*",
     "@voyantjs/utils": "workspace:*",
     "@voyantjs/workflows": "workspace:*",
@@ -78,6 +80,11 @@
         "types": "./dist/document-download.d.ts",
         "import": "./dist/document-download.js",
         "default": "./dist/document-download.js"
+      },
+      "./public-document-delivery": {
+        "types": "./dist/public-document-delivery.d.ts",
+        "import": "./dist/public-document-delivery.js",
+        "default": "./dist/public-document-delivery.js"
       },
       "./types": {
         "types": "./dist/types.d.ts",

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -62,6 +62,23 @@ export {
   serializePublicCapabilityCookie,
   verifyPublicCapabilityToken,
 } from "./public-capability.js"
+export {
+  type CreatePublicDocumentDeliveryInput,
+  createDrizzlePublicDocumentDeliveryGrantStore,
+  createPublicDocumentDeliveryGrant,
+  createPublicDocumentDeliveryHonoModule,
+  createPublicDocumentDeliveryRoutes,
+  type PublicDocumentDeliveryAccessContext,
+  type PublicDocumentDeliveryEnvelope,
+  type PublicDocumentDeliveryGrant,
+  type PublicDocumentDeliveryGrantStore,
+  type PublicDocumentDeliveryResolution,
+  type PublicDocumentDeliveryRouteOptions,
+  type PublicDocumentDeliverySource,
+  type RevokePublicDocumentDeliveryGrantInput,
+  resolvePublicDocumentDeliveryGrant,
+  revokePublicDocumentDeliveryGrant,
+} from "./public-document-delivery.js"
 export type {
   DbFactory,
   LogEntry,

--- a/packages/hono/src/public-document-delivery.ts
+++ b/packages/hono/src/public-document-delivery.ts
@@ -1,0 +1,378 @@
+import type {
+  InsertInfraPublicDocumentDeliveryGrant,
+  SelectInfraPublicDocumentDeliveryGrant,
+} from "@voyantjs/db/schema/infra"
+import { infraPublicDocumentDeliveryGrantsTable } from "@voyantjs/db/schema/infra"
+import type { StorageProvider } from "@voyantjs/storage"
+import { and, eq, isNull, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { Hono } from "hono"
+
+import { sha256Base64Url } from "./auth/crypto.js"
+import type { DocumentDownloadEnvelope } from "./document-download.js"
+import type { HonoModule } from "./module.js"
+
+const DEFAULT_PUBLIC_DOCUMENT_TTL_SECONDS = 24 * 60 * 60
+const MAX_PUBLIC_DOCUMENT_TTL_SECONDS = 30 * 24 * 60 * 60
+const PUBLIC_DOCUMENT_TOKEN_BYTES = 32
+const DEFAULT_CONTENT_TYPE = "application/octet-stream"
+const DEFAULT_PUBLIC_DOCUMENT_PATH = "/v1/public/documents"
+
+export interface PublicDocumentDeliveryEnvelope extends DocumentDownloadEnvelope {
+  grantId: string
+}
+
+export interface PublicDocumentDeliverySource {
+  module?: string | null
+  entity?: string | null
+  id?: string | null
+}
+
+export interface CreatePublicDocumentDeliveryInput {
+  storageKey: string
+  publicBaseUrl: string
+  publicPath?: string
+  ttlSeconds?: number
+  expiresAt?: Date
+  filename?: string | null
+  contentType?: string | null
+  storageProvider?: string | null
+  source?: PublicDocumentDeliverySource | null
+  createdBy?: string | null
+  createdByType?: string | null
+  metadata?: unknown
+  now?: Date
+}
+
+export interface PublicDocumentDeliveryAccessContext {
+  accessedAt?: Date
+  ip?: string | null
+  userAgent?: string | null
+}
+
+export interface RevokePublicDocumentDeliveryGrantInput {
+  id: string
+  revokedAt?: Date
+  revokedBy?: string | null
+}
+
+export type PublicDocumentDeliveryGrant = SelectInfraPublicDocumentDeliveryGrant
+
+export type PublicDocumentDeliveryResolution =
+  | { status: "ready"; grant: PublicDocumentDeliveryGrant }
+  | { status: "not_found" }
+  | { status: "expired"; grant: PublicDocumentDeliveryGrant }
+  | { status: "revoked"; grant: PublicDocumentDeliveryGrant }
+
+export interface PublicDocumentDeliveryGrantStore {
+  create(input: InsertInfraPublicDocumentDeliveryGrant): Promise<PublicDocumentDeliveryGrant>
+  findByTokenHash(tokenHash: string): Promise<PublicDocumentDeliveryGrant | null>
+  recordAccess(id: string, context: Required<PublicDocumentDeliveryAccessContext>): Promise<void>
+  revoke(input: RevokePublicDocumentDeliveryGrantInput): Promise<PublicDocumentDeliveryGrant | null>
+}
+
+type Env<TBindings extends object = Record<string, unknown>> = {
+  Bindings: TBindings
+  Variables: {
+    db: PostgresJsDatabase
+  }
+}
+
+export interface PublicDocumentDeliveryRouteOptions<
+  TBindings extends object = Record<string, unknown>,
+> {
+  storage?: StorageProvider | null
+  resolveStorage?: (bindings: TBindings) => StorageProvider | null | undefined
+  store?: PublicDocumentDeliveryGrantStore
+  resolveStore?: (
+    bindings: TBindings,
+    db: PostgresJsDatabase,
+  ) => PublicDocumentDeliveryGrantStore | undefined
+}
+
+function base64UrlEncode(bytes: Uint8Array) {
+  let binary = ""
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+}
+
+function createOpaqueToken() {
+  const bytes = new Uint8Array(PUBLIC_DOCUMENT_TOKEN_BYTES)
+  crypto.getRandomValues(bytes)
+  return base64UrlEncode(bytes)
+}
+
+function normalizePublicBaseUrl(publicBaseUrl: string) {
+  const trimmed = publicBaseUrl.trim().replace(/\/+$/, "")
+  if (!/^https?:\/\//i.test(trimmed)) {
+    throw new Error("publicBaseUrl must be an absolute HTTP(S) URL")
+  }
+  return trimmed
+}
+
+function normalizePublicPath(path: string | undefined) {
+  const value = path?.trim() || DEFAULT_PUBLIC_DOCUMENT_PATH
+  return `/${value.replace(/^\/+|\/+$/g, "")}`
+}
+
+function resolveExpiresAt(input: CreatePublicDocumentDeliveryInput) {
+  const now = input.now ?? new Date()
+  if (input.expiresAt) {
+    if (input.expiresAt <= now) {
+      throw new Error("expiresAt must be in the future")
+    }
+    const maxExpiresAt = new Date(now.getTime() + MAX_PUBLIC_DOCUMENT_TTL_SECONDS * 1000)
+    if (input.expiresAt > maxExpiresAt) {
+      throw new Error("expiresAt exceeds the public document delivery maximum TTL")
+    }
+    return input.expiresAt
+  }
+
+  const ttlSeconds = input.ttlSeconds ?? DEFAULT_PUBLIC_DOCUMENT_TTL_SECONDS
+  if (!Number.isFinite(ttlSeconds) || ttlSeconds <= 0) {
+    throw new Error("ttlSeconds must be greater than zero")
+  }
+  return new Date(now.getTime() + Math.min(ttlSeconds, MAX_PUBLIC_DOCUMENT_TTL_SECONDS) * 1000)
+}
+
+function maybeString(value: string | null | undefined) {
+  const trimmed = value?.trim()
+  return trimmed && trimmed.length > 0 ? trimmed : null
+}
+
+function safeAsciiFilename(filename: string | null | undefined) {
+  const normalized = maybeString(filename)
+  if (!normalized) return "document"
+
+  const safe = normalized
+    .normalize("NFKD")
+    .replace(/[^\w .-]+/g, "-")
+    .replace(/[\r\n"\\]+/g, "-")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 160)
+
+  return safe || "document"
+}
+
+function filenameFromStorageKey(storageKey: string) {
+  return storageKey.split("/").filter(Boolean).at(-1) ?? "document"
+}
+
+function contentDisposition(filename: string | null) {
+  return `attachment; filename="${safeAsciiFilename(filename)}"`
+}
+
+function safeContentType(contentType: string | null | undefined) {
+  const normalized = maybeString(contentType)
+  if (!normalized) return DEFAULT_CONTENT_TYPE
+  return /^[A-Za-z0-9!#$&^_.+-]+\/[A-Za-z0-9!#$&^_.+-]+(?:;\s*[A-Za-z0-9!#$&^_.+-]+=[A-Za-z0-9!#$&^_.+-]+)*$/.test(
+    normalized,
+  )
+    ? normalized
+    : DEFAULT_CONTENT_TYPE
+}
+
+function isPlausiblePublicDocumentToken(token: string) {
+  return /^[A-Za-z0-9_-]{32,256}$/.test(token)
+}
+
+function getClientIp(headers: Headers) {
+  return (
+    headers.get("cf-connecting-ip") ??
+    headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    headers.get("x-real-ip") ??
+    null
+  )
+}
+
+function getStore<TBindings extends object>(
+  options: PublicDocumentDeliveryRouteOptions<TBindings>,
+  bindings: TBindings,
+  db: PostgresJsDatabase,
+) {
+  return (
+    options.resolveStore?.(bindings, db) ??
+    options.store ??
+    createDrizzlePublicDocumentDeliveryGrantStore(db)
+  )
+}
+
+function getStorage<TBindings extends object>(
+  options: PublicDocumentDeliveryRouteOptions<TBindings>,
+  bindings: TBindings,
+) {
+  return options.resolveStorage?.(bindings) ?? options.storage ?? null
+}
+
+export function createDrizzlePublicDocumentDeliveryGrantStore(
+  db: PostgresJsDatabase,
+): PublicDocumentDeliveryGrantStore {
+  return {
+    async create(input) {
+      const [row] = await db
+        .insert(infraPublicDocumentDeliveryGrantsTable)
+        .values(input)
+        .returning()
+      if (!row) throw new Error("Failed to create public document delivery grant")
+      return row
+    },
+    async findByTokenHash(tokenHash) {
+      const [row] = await db
+        .select()
+        .from(infraPublicDocumentDeliveryGrantsTable)
+        .where(eq(infraPublicDocumentDeliveryGrantsTable.tokenHash, tokenHash))
+        .limit(1)
+      return row ?? null
+    },
+    async recordAccess(id, context) {
+      await db
+        .update(infraPublicDocumentDeliveryGrantsTable)
+        .set({
+          accessCount: sql`${infraPublicDocumentDeliveryGrantsTable.accessCount} + 1`,
+          lastAccessedAt: context.accessedAt,
+          lastAccessedIp: context.ip,
+          lastAccessedUserAgent: context.userAgent,
+        })
+        .where(eq(infraPublicDocumentDeliveryGrantsTable.id, id))
+    },
+    async revoke(input) {
+      const [row] = await db
+        .update(infraPublicDocumentDeliveryGrantsTable)
+        .set({
+          revokedAt: input.revokedAt ?? new Date(),
+          revokedBy: input.revokedBy ?? null,
+        })
+        .where(
+          and(
+            eq(infraPublicDocumentDeliveryGrantsTable.id, input.id),
+            isNull(infraPublicDocumentDeliveryGrantsTable.revokedAt),
+          ),
+        )
+        .returning()
+      return row ?? null
+    },
+  }
+}
+
+export async function createPublicDocumentDeliveryGrant(
+  store: PublicDocumentDeliveryGrantStore,
+  input: CreatePublicDocumentDeliveryInput,
+): Promise<PublicDocumentDeliveryEnvelope> {
+  const storageKey = maybeString(input.storageKey)
+  if (!storageKey) {
+    throw new Error("storageKey is required")
+  }
+
+  const token = createOpaqueToken()
+  const tokenHash = await sha256Base64Url(token)
+  const expiresAt = resolveExpiresAt(input)
+  const filename = maybeString(input.filename) ?? filenameFromStorageKey(storageKey)
+  const contentType = maybeString(input.contentType) ?? DEFAULT_CONTENT_TYPE
+
+  const grant = await store.create({
+    tokenHash,
+    storageKey,
+    storageProvider: maybeString(input.storageProvider),
+    filename,
+    contentType,
+    sourceModule: maybeString(input.source?.module),
+    sourceEntity: maybeString(input.source?.entity),
+    sourceId: maybeString(input.source?.id),
+    createdBy: maybeString(input.createdBy),
+    createdByType: maybeString(input.createdByType),
+    metadata: input.metadata ?? null,
+    expiresAt,
+  })
+
+  return {
+    grantId: grant.id,
+    url: `${normalizePublicBaseUrl(input.publicBaseUrl)}${normalizePublicPath(input.publicPath)}/${token}`,
+    expiresAt: expiresAt.toISOString(),
+    filename,
+  }
+}
+
+export async function resolvePublicDocumentDeliveryGrant(
+  store: PublicDocumentDeliveryGrantStore,
+  token: string,
+  now = new Date(),
+): Promise<PublicDocumentDeliveryResolution> {
+  if (!isPlausiblePublicDocumentToken(token)) {
+    return { status: "not_found" }
+  }
+
+  const grant = await store.findByTokenHash(await sha256Base64Url(token))
+  if (!grant) {
+    return { status: "not_found" }
+  }
+  if (grant.revokedAt) {
+    return { status: "revoked", grant }
+  }
+  if (grant.expiresAt <= now) {
+    return { status: "expired", grant }
+  }
+  return { status: "ready", grant }
+}
+
+export async function revokePublicDocumentDeliveryGrant(
+  store: PublicDocumentDeliveryGrantStore,
+  input: RevokePublicDocumentDeliveryGrantInput,
+) {
+  return store.revoke(input)
+}
+
+export function createPublicDocumentDeliveryRoutes<
+  TBindings extends object = Record<string, unknown>,
+>(options: PublicDocumentDeliveryRouteOptions<TBindings> = {}) {
+  return new Hono<Env<TBindings>>().get("/:token", async (c) => {
+    const token = c.req.param("token")
+    const store = getStore(options, c.env, c.get("db"))
+    const resolution = await resolvePublicDocumentDeliveryGrant(store, token)
+
+    if (resolution.status === "not_found") {
+      return c.body(null, 404)
+    }
+    if (resolution.status === "expired" || resolution.status === "revoked") {
+      return c.body(null, 410)
+    }
+
+    const storage = getStorage(options, c.env)
+    if (!storage) {
+      return c.json({ error: "Document storage is not configured" }, 503)
+    }
+
+    const body = await storage.get(resolution.grant.storageKey)
+    if (!body) {
+      return c.body(null, 404)
+    }
+
+    await store.recordAccess(resolution.grant.id, {
+      accessedAt: new Date(),
+      ip: getClientIp(c.req.raw.headers),
+      userAgent: c.req.header("user-agent") ?? null,
+    })
+
+    return new Response(body, {
+      headers: {
+        "Cache-Control": "private, max-age=0, must-revalidate",
+        "Content-Type": safeContentType(resolution.grant.contentType),
+        "Content-Length": String(body.byteLength),
+        "Content-Disposition": contentDisposition(resolution.grant.filename),
+      },
+    })
+  })
+}
+
+export function createPublicDocumentDeliveryHonoModule<
+  TBindings extends object = Record<string, unknown>,
+>(options: PublicDocumentDeliveryRouteOptions<TBindings> = {}): HonoModule {
+  return {
+    module: {
+      name: "documents",
+    },
+    publicRoutes: createPublicDocumentDeliveryRoutes(options),
+  }
+}

--- a/packages/hono/tests/unit/public-document-delivery.test.ts
+++ b/packages/hono/tests/unit/public-document-delivery.test.ts
@@ -1,0 +1,240 @@
+import { createLocalStorageProvider } from "@voyantjs/storage/providers/local"
+import { Hono } from "hono"
+import { describe, expect, it } from "vitest"
+
+import {
+  createPublicDocumentDeliveryGrant,
+  createPublicDocumentDeliveryRoutes,
+  type PublicDocumentDeliveryAccessContext,
+  type PublicDocumentDeliveryGrant,
+  type PublicDocumentDeliveryGrantStore,
+  type RevokePublicDocumentDeliveryGrantInput,
+  resolvePublicDocumentDeliveryGrant,
+  revokePublicDocumentDeliveryGrant,
+} from "../../src/public-document-delivery.js"
+
+function createMemoryGrantStore(): PublicDocumentDeliveryGrantStore & {
+  grants: PublicDocumentDeliveryGrant[]
+  accesses: PublicDocumentDeliveryAccessContext[]
+} {
+  const grants: PublicDocumentDeliveryGrant[] = []
+  const accesses: PublicDocumentDeliveryAccessContext[] = []
+
+  return {
+    grants,
+    accesses,
+    async create(input) {
+      const now = new Date("2026-05-27T12:00:00.000Z")
+      const grant: PublicDocumentDeliveryGrant = {
+        id: `pddg_${grants.length + 1}`,
+        tokenHash: input.tokenHash,
+        storageKey: input.storageKey,
+        storageProvider: input.storageProvider ?? null,
+        filename: input.filename ?? null,
+        contentType: input.contentType ?? "application/octet-stream",
+        sourceModule: input.sourceModule ?? null,
+        sourceEntity: input.sourceEntity ?? null,
+        sourceId: input.sourceId ?? null,
+        createdBy: input.createdBy ?? null,
+        createdByType: input.createdByType ?? null,
+        metadata: input.metadata ?? null,
+        accessCount: input.accessCount ?? 0,
+        lastAccessedAt: input.lastAccessedAt ?? null,
+        lastAccessedIp: input.lastAccessedIp ?? null,
+        lastAccessedUserAgent: input.lastAccessedUserAgent ?? null,
+        revokedAt: input.revokedAt ?? null,
+        revokedBy: input.revokedBy ?? null,
+        createdAt: input.createdAt ?? now,
+        expiresAt: input.expiresAt,
+      }
+      grants.push(grant)
+      return grant
+    },
+    async findByTokenHash(tokenHash) {
+      return grants.find((grant) => grant.tokenHash === tokenHash) ?? null
+    },
+    async recordAccess(id, context) {
+      accesses.push(context)
+      const grant = grants.find((candidate) => candidate.id === id)
+      if (grant) {
+        grant.accessCount += 1
+        grant.lastAccessedAt = context.accessedAt
+        grant.lastAccessedIp = context.ip
+        grant.lastAccessedUserAgent = context.userAgent
+      }
+    },
+    async revoke(input: RevokePublicDocumentDeliveryGrantInput) {
+      const grant = grants.find((candidate) => candidate.id === input.id)
+      if (!grant || grant.revokedAt) return null
+      grant.revokedAt = input.revokedAt ?? new Date()
+      grant.revokedBy = input.revokedBy ?? null
+      return grant
+    },
+  }
+}
+
+function createRouteApp(options: Parameters<typeof createPublicDocumentDeliveryRoutes>[0]) {
+  const app = new Hono()
+  app.use("*", async (c, next) => {
+    c.set("db", {})
+    await next()
+  })
+  app.route("/v1/public/documents", createPublicDocumentDeliveryRoutes(options))
+  return app
+}
+
+describe("public document delivery", () => {
+  it("creates opaque single-document URLs and resolves them by token hash", async () => {
+    const store = createMemoryGrantStore()
+    const envelope = await createPublicDocumentDeliveryGrant(store, {
+      storageKey: "invoices/inv_123.pdf",
+      publicBaseUrl: "https://docs.example.com/",
+      ttlSeconds: 60,
+      filename: "invoice.pdf",
+      contentType: "application/pdf",
+      source: { module: "finance", entity: "invoice_rendition", id: "rend_123" },
+      now: new Date("2026-05-27T12:00:00.000Z"),
+    })
+
+    expect(envelope).toMatchObject({
+      grantId: "pddg_1",
+      url: expect.stringMatching(
+        /^https:\/\/docs\.example\.com\/v1\/public\/documents\/[A-Za-z0-9_-]+$/,
+      ),
+      expiresAt: "2026-05-27T12:01:00.000Z",
+      filename: "invoice.pdf",
+    })
+    expect(store.grants[0]).toMatchObject({
+      tokenHash: expect.not.stringContaining(envelope.url.split("/").at(-1) ?? ""),
+      storageKey: "invoices/inv_123.pdf",
+      contentType: "application/pdf",
+      sourceModule: "finance",
+      sourceEntity: "invoice_rendition",
+      sourceId: "rend_123",
+    })
+
+    const token = new URL(envelope.url).pathname.split("/").at(-1) ?? ""
+    await expect(
+      resolvePublicDocumentDeliveryGrant(store, token, new Date("2026-05-27T12:00:30.000Z")),
+    ).resolves.toMatchObject({
+      status: "ready",
+      grant: { storageKey: "invoices/inv_123.pdf" },
+    })
+  })
+
+  it("serves stored bytes with safe document headers and records access", async () => {
+    const store = createMemoryGrantStore()
+    const storage = createLocalStorageProvider()
+    await storage.upload(new Uint8Array([1, 2, 3]), {
+      key: "contracts/contract.pdf",
+      contentType: "application/pdf",
+    })
+    const envelope = await createPublicDocumentDeliveryGrant(store, {
+      storageKey: "contracts/contract.pdf",
+      publicBaseUrl: "https://docs.example.com",
+      filename: 'contract "final".pdf',
+      contentType: "application/pdf",
+    })
+
+    const app = createRouteApp({ store, storage })
+    const path = new URL(envelope.url).pathname
+    const res = await app.request(path, {
+      headers: {
+        "user-agent": "vitest",
+        "x-forwarded-for": "203.0.113.10, 10.0.0.1",
+      },
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toBe("application/pdf")
+    expect(res.headers.get("content-length")).toBe("3")
+    expect(res.headers.get("content-disposition")).toBe(
+      'attachment; filename="contract -final-.pdf"',
+    )
+    expect(Array.from(new Uint8Array(await res.arrayBuffer()))).toEqual([1, 2, 3])
+    expect(store.grants[0]?.accessCount).toBe(1)
+    expect(store.accesses[0]).toMatchObject({
+      ip: "203.0.113.10",
+      userAgent: "vitest",
+    })
+  })
+
+  it("does not touch storage for malformed or unknown tokens", async () => {
+    let storageReads = 0
+    const app = createRouteApp({
+      store: createMemoryGrantStore(),
+      storage: {
+        name: "spy",
+        upload: async () => ({ key: "unused", url: "" }),
+        delete: async () => {},
+        signedUrl: async () => "",
+        get: async () => {
+          storageReads += 1
+          return null
+        },
+      },
+    })
+
+    const malformed = await app.request("/v1/public/documents/not-a-token")
+    const unknown = await app.request(
+      "/v1/public/documents/abcdefghijklmnopqrstuvwxyzABCDE1234567890_-",
+    )
+
+    expect(malformed.status).toBe(404)
+    expect(unknown.status).toBe(404)
+    expect(storageReads).toBe(0)
+  })
+
+  it("falls back to a safe content type when stored metadata is invalid", async () => {
+    const store = createMemoryGrantStore()
+    const storage = createLocalStorageProvider()
+    await storage.upload(new Uint8Array([1]), { key: "documents/file.bin" })
+    const envelope = await createPublicDocumentDeliveryGrant(store, {
+      storageKey: "documents/file.bin",
+      publicBaseUrl: "https://docs.example.com",
+      contentType: "application/pdf\r\nx-bad: yes",
+    })
+
+    const res = await createRouteApp({ store, storage }).request(new URL(envelope.url).pathname)
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toBe("application/octet-stream")
+  })
+
+  it("returns gone for expired and revoked tokens", async () => {
+    const store = createMemoryGrantStore()
+    const expired = await createPublicDocumentDeliveryGrant(store, {
+      storageKey: "expired.pdf",
+      publicBaseUrl: "https://docs.example.com",
+      ttlSeconds: 1,
+      now: new Date("2020-01-01T00:00:00.000Z"),
+    })
+    const revoked = await createPublicDocumentDeliveryGrant(store, {
+      storageKey: "revoked.pdf",
+      publicBaseUrl: "https://docs.example.com",
+    })
+    await revokePublicDocumentDeliveryGrant(store, {
+      id: revoked.grantId,
+      revokedAt: new Date("2026-05-27T12:00:00.000Z"),
+      revokedBy: "user_1",
+    })
+
+    const app = createRouteApp({
+      store,
+      storage: createLocalStorageProvider(),
+    })
+
+    const expiredPath = new URL(expired.url).pathname
+    const revokedPath = new URL(revoked.url).pathname
+
+    await expect(
+      resolvePublicDocumentDeliveryGrant(
+        store,
+        expiredPath.split("/").at(-1) ?? "",
+        new Date("2026-05-27T12:00:02.000Z"),
+      ),
+    ).resolves.toMatchObject({ status: "expired" })
+    await expect(app.request(expiredPath)).resolves.toMatchObject({ status: 410 })
+    await expect(app.request(revokedPath)).resolves.toMatchObject({ status: 410 })
+  })
+})

--- a/packages/legal/src/contracts/routes.ts
+++ b/packages/legal/src/contracts/routes.ts
@@ -1,5 +1,7 @@
 import type { EventBus, ModuleContainer } from "@voyantjs/core"
 import {
+  createDrizzlePublicDocumentDeliveryGrantStore,
+  createPublicDocumentDeliveryGrant,
   idempotencyKey,
   parseJsonBody,
   parseOptionalJsonBody,
@@ -252,17 +254,13 @@ async function regenerateContractDocument(
     return c.json({ error: "Contract document generator is not configured" }, 501)
   }
 
-  const result = await contractsService.regenerateContractDocument(
-    c.get("db"),
-    contractId,
-    await parseOptionalJsonBody(c, generateContractDocumentInputSchema),
-    {
-      generator,
-      bindings: c.env,
-      eventBus: runtime.eventBus,
-      lifecycleHooks: runtime.lifecycleHooks,
-    },
-  )
+  const input = await parseOptionalJsonBody(c, generateContractDocumentInputSchema)
+  const result = await contractsService.regenerateContractDocument(c.get("db"), contractId, input, {
+    generator,
+    bindings: c.env,
+    eventBus: runtime.eventBus,
+    lifecycleHooks: runtime.lifecycleHooks,
+  })
 
   if (result.status === "not_found") return c.json({ error: "Contract not found" }, 404)
   if (result.status === "not_draft") {
@@ -278,7 +276,7 @@ async function regenerateContractDocument(
     return c.json({ error: "Contract document generation failed" }, 502)
   }
 
-  return c.json({ data: await attachDownloadEnvelope(c.env, runtime, result) })
+  return c.json({ data: await attachDownloadEnvelope(c, runtime, result, input) })
 }
 
 async function generateContractDocumentForBooking(c: Context<Env>, options: ContractsRouteOptions) {
@@ -346,7 +344,7 @@ async function generateContractDocumentForBooking(c: Context<Env>, options: Cont
 
   return c.json(
     {
-      data: await attachDownloadEnvelope(c.env, runtime, { contract, attachment }),
+      data: await attachDownloadEnvelope(c, runtime, { contract, attachment }, input),
     },
     201,
   )
@@ -551,10 +549,11 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
         return c.json({ error: "Contract document generator is not configured" }, 501)
       }
 
+      const input = await parseOptionalJsonBody(c, generateContractDocumentInputSchema)
       const result = await contractsService.generateContractDocument(
         c.get("db"),
         c.req.param("id"),
-        await parseOptionalJsonBody(c, generateContractDocumentInputSchema),
+        input,
         {
           generator,
           bindings: c.env,
@@ -580,7 +579,7 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
         return c.json({ error: "Contract document generation failed" }, 502)
       }
 
-      return c.json({ data: await attachDownloadEnvelope(c.env, runtime, result) }, 201)
+      return c.json({ data: await attachDownloadEnvelope(c, runtime, result, input) }, 201)
     })
     .post("/:id/regenerate-document", async (c) => {
       return regenerateContractDocument(c, options, c.req.param("id"))
@@ -695,17 +694,54 @@ export const contractsAdminRoutes = createContractsAdminRoutes()
 
 async function attachDownloadEnvelope<
   T extends {
-    attachment: { storageKey?: string | null; metadata?: unknown; name?: string | null }
+    attachment: {
+      id?: string | null
+      storageKey?: string | null
+      metadata?: unknown
+      name?: string | null
+      mimeType?: string | null
+    }
   },
->(bindings: Record<string, unknown>, runtime: ContractsRouteRuntime, result: T) {
+>(
+  c: Context<Env>,
+  runtime: ContractsRouteRuntime,
+  result: T,
+  input: { publicDelivery?: boolean; publicDeliveryTtlSeconds?: number | undefined },
+) {
   const download = await resolveStoredDocumentDownload(
     { ...result.attachment, filename: result.attachment.name },
     {
-      bindings,
+      bindings: c.env,
       resolveDocumentDownloadUrl: runtime.resolveDocumentDownloadUrl,
     },
   )
-  return download.status === "ready" ? { ...result, download: download.download } : result
+  const withAdminDownload =
+    download.status === "ready" ? { ...result, download: download.download } : result
+
+  if (!input.publicDelivery || !result.attachment.storageKey) {
+    return withAdminDownload
+  }
+
+  const publicDownload = await createPublicDocumentDeliveryGrant(
+    createDrizzlePublicDocumentDeliveryGrantStore(c.get("db")),
+    {
+      storageKey: result.attachment.storageKey,
+      publicBaseUrl: new URL(c.req.url).origin,
+      ttlSeconds: input.publicDeliveryTtlSeconds,
+      filename:
+        result.attachment.name ?? (download.status === "ready" ? download.download.filename : null),
+      contentType: result.attachment.mimeType,
+      source: {
+        module: "legal",
+        entity: "contract_attachment",
+        id: result.attachment.id ?? null,
+      },
+      createdBy: c.get("userId") ?? null,
+      createdByType: c.get("userId") ? "staff" : null,
+    },
+  )
+
+  return { ...withAdminDownload, publicDownload }
 }
 
 export function createContractsPublicRoutes(options: ContractsRouteOptions = {}) {

--- a/packages/legal/src/contracts/service-auto-generate.ts
+++ b/packages/legal/src/contracts/service-auto-generate.ts
@@ -952,6 +952,7 @@ export async function autoGenerateContractForBooking(
       issueIfDraft: true,
       replaceExisting: true,
       kind: "document",
+      publicDelivery: false,
     },
     {
       generator: runtime.generator,

--- a/packages/legal/src/contracts/validation.ts
+++ b/packages/legal/src/contracts/validation.ts
@@ -183,6 +183,13 @@ export const generateContractDocumentInputSchema = z.object({
   kind: z.string().min(1).max(50).default("document"),
   replaceExisting: z.boolean().default(true),
   issueIfDraft: z.boolean().default(true),
+  publicDelivery: z.boolean().default(false),
+  publicDeliveryTtlSeconds: z
+    .number()
+    .int()
+    .min(1)
+    .max(30 * 24 * 60 * 60)
+    .optional(),
 })
 
 export const generateContractForBookingInputSchema = z.object({
@@ -191,6 +198,13 @@ export const generateContractForBookingInputSchema = z.object({
   channelId: z.string().optional().nullable(),
   fallbackLanguages: z.array(z.string().min(2).max(10)).optional().default([]),
   requireNumberSeries: z.boolean().default(true),
+  publicDelivery: z.boolean().default(false),
+  publicDeliveryTtlSeconds: z
+    .number()
+    .int()
+    .min(1)
+    .max(30 * 24 * 60 * 60)
+    .optional(),
 })
 
 export type GenerateContractForBookingInput = z.infer<typeof generateContractForBookingInputSchema>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3182,6 +3182,9 @@ importers:
       '@voyantjs/db':
         specifier: workspace:*
         version: link:../db
+      '@voyantjs/storage':
+        specifier: workspace:*
+        version: link:../storage
       '@voyantjs/types':
         specifier: workspace:*
         version: link:../types

--- a/templates/dmc/migrations/0023_public_document_delivery_grants.sql
+++ b/templates/dmc/migrations/0023_public_document_delivery_grants.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS "public_document_delivery_grants" (
+  "id" text PRIMARY KEY NOT NULL,
+  "token_hash" text NOT NULL,
+  "storage_key" text NOT NULL,
+  "storage_provider" text,
+  "filename" text,
+  "content_type" text DEFAULT 'application/octet-stream' NOT NULL,
+  "source_module" text,
+  "source_entity" text,
+  "source_id" text,
+  "created_by" text,
+  "created_by_type" text,
+  "metadata" jsonb,
+  "access_count" integer DEFAULT 0 NOT NULL,
+  "last_accessed_at" timestamp with time zone,
+  "last_accessed_ip" text,
+  "last_accessed_user_agent" text,
+  "revoked_at" timestamp with time zone,
+  "revoked_by" text,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "expires_at" timestamp with time zone NOT NULL
+);--> statement-breakpoint
+ALTER TABLE "public_document_delivery_grants" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uidx_public_document_delivery_grants_token_hash"
+  ON "public_document_delivery_grants" USING btree ("token_hash");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_public_document_delivery_grants_expires_at"
+  ON "public_document_delivery_grants" USING btree ("expires_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_public_document_delivery_grants_source"
+  ON "public_document_delivery_grants" USING btree ("source_module","source_entity","source_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_public_document_delivery_grants_revoked_at"
+  ON "public_document_delivery_grants" USING btree ("revoked_at");

--- a/templates/dmc/migrations/meta/_journal.json
+++ b/templates/dmc/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1779830000000,
       "tag": "0022_invoice_number_active_unique",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1779905100000,
+      "tag": "0023_public_document_delivery_grants",
+      "breakpoints": true
     }
   ]
 }

--- a/templates/dmc/src/api/app.ts
+++ b/templates/dmc/src/api/app.ts
@@ -15,7 +15,7 @@ import {
   createVoyantDataFxExchangeRateResolver,
 } from "@voyantjs/finance"
 import { groundHonoModule } from "@voyantjs/ground"
-import { createApp } from "@voyantjs/hono"
+import { createApp, createPublicDocumentDeliveryHonoModule } from "@voyantjs/hono"
 import { identityHonoModule } from "@voyantjs/identity"
 import { createLegalHonoModule } from "@voyantjs/legal"
 import { marketsHonoModule } from "@voyantjs/markets"
@@ -103,6 +103,10 @@ const legalModule = createLegalHonoModule({
     createDocumentStorage(bindings as unknown as CloudflareBindings),
 })
 
+const publicDocumentDeliveryModule = createPublicDocumentDeliveryHonoModule<CloudflareBindings>({
+  resolveStorage: createDocumentStorage,
+})
+
 const crmHonoModule = createCrmHonoModule()
 const bookingsHonoModule = createBookingsHonoModule({
   resolveTravelSnapshot: (db, personId, { kms }) =>
@@ -138,6 +142,7 @@ export const app = createApp<CloudflareBindings>({
     "/v1/public/customer-portal/contact-exists",
     "/v1/public/storefront-verification",
     "/v1/public/checkout",
+    "/v1/public/documents",
     "/v1/public/invitations",
     "/v1/public/leads",
     "/v1/public/newsletter",
@@ -164,6 +169,7 @@ export const app = createApp<CloudflareBindings>({
     bookingsHonoModule,
     financeModule,
     legalModule,
+    publicDocumentDeliveryModule,
     storefrontHonoModule,
     customerPortalHonoModule,
     storefrontVerificationHonoModule,

--- a/templates/operator/migrations/0042_public_document_delivery_grants.sql
+++ b/templates/operator/migrations/0042_public_document_delivery_grants.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS "public_document_delivery_grants" (
+  "id" text PRIMARY KEY NOT NULL,
+  "token_hash" text NOT NULL,
+  "storage_key" text NOT NULL,
+  "storage_provider" text,
+  "filename" text,
+  "content_type" text DEFAULT 'application/octet-stream' NOT NULL,
+  "source_module" text,
+  "source_entity" text,
+  "source_id" text,
+  "created_by" text,
+  "created_by_type" text,
+  "metadata" jsonb,
+  "access_count" integer DEFAULT 0 NOT NULL,
+  "last_accessed_at" timestamp with time zone,
+  "last_accessed_ip" text,
+  "last_accessed_user_agent" text,
+  "revoked_at" timestamp with time zone,
+  "revoked_by" text,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "expires_at" timestamp with time zone NOT NULL
+);--> statement-breakpoint
+ALTER TABLE "public_document_delivery_grants" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uidx_public_document_delivery_grants_token_hash"
+  ON "public_document_delivery_grants" USING btree ("token_hash");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_public_document_delivery_grants_expires_at"
+  ON "public_document_delivery_grants" USING btree ("expires_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_public_document_delivery_grants_source"
+  ON "public_document_delivery_grants" USING btree ("source_module","source_entity","source_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_public_document_delivery_grants_revoked_at"
+  ON "public_document_delivery_grants" USING btree ("revoked_at");

--- a/templates/operator/migrations/meta/_journal.json
+++ b/templates/operator/migrations/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1779830000000,
       "tag": "0041_invoice_number_active_unique",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1779905100000,
+      "tag": "0042_public_document_delivery_grants",
+      "breakpoints": true
     }
   ]
 }

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -22,7 +22,7 @@ import {
   financeService,
 } from "@voyantjs/finance"
 import { bookingPaymentSchedules, invoices, paymentSessions } from "@voyantjs/finance/schema"
-import { createApp } from "@voyantjs/hono"
+import { createApp, createPublicDocumentDeliveryHonoModule } from "@voyantjs/hono"
 import { identityHonoModule } from "@voyantjs/identity"
 import {
   type AutoGenerateContractOptions,
@@ -869,6 +869,10 @@ const legalModule = createLegalHonoModule({
   autoGenerateContractOnConfirmed: AUTO_GENERATE_CONTRACT_OPTIONS,
 })
 
+const publicDocumentDeliveryModule = createPublicDocumentDeliveryHonoModule<CloudflareBindings>({
+  resolveStorage: createDocumentStorage,
+})
+
 interface StoredContractAcceptance {
   templateId?: string
   templateSlug?: string
@@ -1065,6 +1069,7 @@ export const app = createApp<CloudflareBindings>({
     // before the customer accepts. Both the slug-resolution lookup
     // and the by-slug preview render live under this prefix.
     "/v1/public/legal",
+    "/v1/public/documents",
     // Operator profile + customer payment policy (sanitized subset).
     // The storefront contract preview reads operator name / address /
     // license + the deposit terms from here so it can render the
@@ -1104,6 +1109,7 @@ export const app = createApp<CloudflareBindings>({
     bookingsHonoModule,
     financeModule,
     legalModule,
+    publicDocumentDeliveryModule,
     notificationsHonoModule,
     storefrontHonoModule,
     customerPortalHonoModule,


### PR DESCRIPTION
Closes #1359

Summary:
- Add durable public document delivery grants that store hashed opaque tokens, TTLs, source scope, audit metadata, and revocation state.
- Add a public document delivery route that validates grants before storage reads and returns safe download headers.
- Add opt-in public download envelopes for generated finance invoices and legal contract documents, mounted in dev, DMC, and operator runtimes.

Verification:
- pnpm test:affected
- pnpm --filter @voyantjs/hono test
- pnpm --filter @voyantjs/hono typecheck
- pnpm --filter @voyantjs/db test
- pnpm --filter @voyantjs/db typecheck
- pnpm --filter @voyantjs/finance test
- pnpm --filter @voyantjs/finance typecheck
- pnpm --filter @voyantjs/legal test
- pnpm --filter @voyantjs/legal typecheck
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter dev typecheck
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter dmc typecheck
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter operator typecheck
- pnpm verify:architecture
- pnpm verify:raw-minor-unit-labels
- Commit hook: full lint and full typecheck passed
- Pre-push hook: full test suite passed

Note:
- pnpm verify:fast still stops at the existing @voyantjs/ui components barrel export check before reaching later lanes.