### PR TITLE
[codex] Export slot allocation manifest helper

### DIFF
--- a/.changeset/availability-slot-allocation-export.md
+++ b/.changeset/availability-slot-allocation-export.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/availability": patch
+---
+
+Export `getSlotAllocationManifest` and its manifest result types from the root package entrypoint.

--- a/packages/availability/src/index.ts
+++ b/packages/availability/src/index.ts
@@ -75,10 +75,14 @@ export {
   sharingGroupLabels,
 } from "./schema.js"
 export {
+  type AllocationManifestBooking,
+  type AllocationManifestTraveler,
+  getSlotAllocationManifest,
   getSlotResourceAvailability,
   getSlotsResourceAvailability,
   type PlannedAllocation,
   type ResourceCapacityViolation,
+  type SlotAllocationManifest,
   type SlotResourceAvailability,
   validateSlotAllocationCapacity,
 } from "./service-allocation.js"

--- a/packages/availability/tests/unit/public-surface.test.ts
+++ b/packages/availability/tests/unit/public-surface.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+import { getSlotAllocationManifest, type SlotAllocationManifest } from "../../src/index.js"
+
+describe("availability public surface", () => {
+  it("exports the slot allocation manifest helper from the root entrypoint", () => {
+    expect(getSlotAllocationManifest).toEqual(expect.any(Function))
+  })
+
+  it("exports the slot allocation manifest type from the root entrypoint", () => {
+    const manifest = {
+      slot: {
+        id: "avsl_123",
+        productId: "prod_123",
+        startsAt: "2026-05-27T09:00:00.000Z",
+        endsAt: null,
+      },
+      bookings: [],
+      resources: [],
+      sharingGroupLabels: {},
+      summary: {
+        bookingCount: 0,
+        travelerCount: 0,
+        leadTravelerCount: 0,
+        bookingsByStatus: {},
+      },
+    } satisfies SlotAllocationManifest
+
+    expect(manifest.summary.travelerCount).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- export `getSlotAllocationManifest` from the `@voyantjs/availability` root entrypoint
- export the slot allocation manifest result types from the same public surface
- add a public-surface regression test and patch changeset

I chose the root entrypoint export instead of adding `./service-allocation` as a subpath because `service-allocation.ts` also contains lower-level allocation mutation helpers; exporting the single requested helper keeps the public package surface narrow.

Closes #1370.

## Verification
- `pnpm --filter @voyantjs/availability typecheck`
- `pnpm --filter @voyantjs/availability lint`
- `pnpm --filter @voyantjs/availability test`
- commit hook full lint/typecheck
- pre-push full test hook