### PR TITLE
Extract operator contract document routes

### DIFF
--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -2,7 +2,6 @@ import { actionLedgerHonoModule } from "@voyantjs/action-ledger"
 import { availabilityHonoModule } from "@voyantjs/availability"
 import { bookingRequirementsHonoModule } from "@voyantjs/booking-requirements"
 import { bookingsSupplierExtension, createBookingsHonoModule } from "@voyantjs/bookings"
-import { bookingItems, bookings } from "@voyantjs/bookings/schema"
 import { createCatalogSearchHonoModule } from "@voyantjs/catalog"
 import { type EmbeddingProvider, executeSemanticSearch } from "@voyantjs/catalog-rag"
 import { type CheckoutPaymentStarter, createCheckoutHonoModule } from "@voyantjs/checkout"
@@ -16,18 +15,9 @@ import {
   createFinanceHonoModule,
   createVoyantDataFxExchangeRateResolver,
 } from "@voyantjs/finance"
-import { bookingPaymentSchedules } from "@voyantjs/finance/schema"
 import { createApp, createPublicDocumentDeliveryHonoModule } from "@voyantjs/hono"
 import { identityHonoModule } from "@voyantjs/identity"
-import {
-  type AutoGenerateContractOptions,
-  autoGenerateContractForBooking,
-  type ContractDocumentGenerator,
-  createBrowserRenderedPdfContractDocumentSerializer,
-  createLegalHonoModule,
-  createPdfContractDocumentGenerator,
-  createStorageBackedContractDocumentGenerator,
-} from "@voyantjs/legal"
+import { createLegalHonoModule } from "@voyantjs/legal"
 import { marketsHonoModule } from "@voyantjs/markets"
 import {
   createDefaultBookingDocumentAttachment,
@@ -35,12 +25,7 @@ import {
 } from "@voyantjs/notifications"
 import { createNetopiaCheckoutStarter, netopiaHonoBundle } from "@voyantjs/plugin-netopia"
 import { pricingHonoModule } from "@voyantjs/pricing"
-import {
-  createDefaultProductBrochureTemplate,
-  generateAndStoreProductBrochure,
-  productsBookingExtension,
-  productsHonoModule,
-} from "@voyantjs/products"
+import { productsBookingExtension, productsHonoModule } from "@voyantjs/products"
 import { promotionsHonoModule } from "@voyantjs/promotions"
 import { createPromotionsStorefrontResolvers } from "@voyantjs/promotions/service-storefront"
 import { resourcesHonoModule } from "@voyantjs/resources"
@@ -52,12 +37,8 @@ import { transactionsBookingExtension, transactionsHonoModule } from "@voyantjs/
 import { createTravelComposerHonoModule } from "@voyantjs/travel-composer"
 import { mountWorkflowRunsAdminRoutes, WorkflowRunnerRegistry } from "@voyantjs/workflow-runs"
 import { createCloudflareEdgeDriver } from "@voyantjs/workflows-orchestrator-cloudflare"
-import { asc, eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-import { createProductBrochurePrinter } from "../lib/brochure-printer"
 import { resolveNotificationProviders } from "../lib/notifications"
-import { createVideoUploadTicket } from "../lib/video-uploads"
-import { tryGetCloudClient } from "../lib/voyant-cloud"
 import { mountActionLedgerHealthRoutes } from "./action-ledger-health"
 import authHandler, {
   hasAuthPermission,
@@ -68,7 +49,6 @@ import {
   bookingScheduleBundle,
   mountBookingPaymentScheduleRoutes,
   mountPublicPaymentPolicyRoutes,
-  readPolicySourceFromInternalNotes,
 } from "./booking-schedule"
 import { mountBookingTaxPreviewRoutes } from "./booking-tax-preview"
 import { mountCatalogBookingRoutes } from "./catalog-booking"
@@ -80,6 +60,12 @@ import {
 } from "./catalog-checkout"
 import { mountCatalogContentRoutes } from "./catalog-content"
 import { channelPushBundle, mountChannelPushAdminRoutes } from "./channel-push"
+import { mountOperatorContractDocumentRoutes } from "./contract-document-routes"
+import {
+  AUTO_GENERATE_CONTRACT_OPTIONS,
+  generateContractPdfForBooking,
+  resolveContractDocumentGenerator,
+} from "./contract-document-runtime"
 import { mountFlightRoutes } from "./flights"
 import { createInvitationsRoutes } from "./invitations"
 import { mountOperatorLazyAdditionalRoutes } from "./lazy-additional-routes"
@@ -87,21 +73,16 @@ import { buildCatalogContext } from "./lib/catalog-context"
 import { dbFromEnvForApp, getDbFromEnv } from "./lib/db"
 import {
   createDocumentStorage,
-  createMediaStorage,
-  guessMimeType,
   readDocumentContentBase64,
   resolveDocumentDownloadUrl,
 } from "./lib/storage"
 import { mountCatalogMcpRoutes } from "./mcp"
+import { mountOperatorMediaUploadRoutes } from "./media-upload-routes"
 import {
   resolveBankTransferDetails,
   resolvePublicCheckoutBaseUrlFromBindings,
 } from "./payment-config"
-import {
-  getOperatorPaymentInstructions,
-  getOperatorProfile,
-  mountOperatorSettingsRoutes,
-} from "./settings"
+import { mountOperatorSettingsRoutes } from "./settings"
 import { createSmartbillSettlementPollers, smartbillOperatorBundle } from "./smartbill"
 import {
   createOperatorTravelComposerRoutesOptions,
@@ -273,483 +254,6 @@ const financeModule = createFinanceHonoModule({
   resolveInvoiceSettlementPollers: (bindings) =>
     createSmartbillSettlementPollers(bindings as unknown as CloudflareBindings),
 })
-/**
- * Build the `ContractDocumentGenerator` configured for this template.
- * Used by both the legal module's `resolveDocumentGenerator` (for the
- * subscriber + admin regenerate route) and by the explicit
- * `generate_contract_pdf` step in `checkout-finalize`. Centralising
- * here means both paths use the same renderer (Cloud SDK browser
- * rendering when available, basic pdf-lib otherwise).
- *
- * Returns `null` when no DOCUMENTS_BUCKET is configured — callers
- * treat that as "contract documents are not stored on this deploy".
- */
-function resolveContractDocumentGenerator(
-  env: CloudflareBindings,
-): ContractDocumentGenerator | null {
-  const storage = createDocumentStorage(env)
-  if (!storage) return null
-  const cloud = tryGetCloudClient(env)
-  if (cloud) {
-    return createStorageBackedContractDocumentGenerator({
-      storage,
-      serializer: createBrowserRenderedPdfContractDocumentSerializer({
-        cloudClient: cloud,
-      }),
-    })
-  }
-  // Local dev / no cloud key — fall back to the basic pdf-lib
-  // serializer. Contract PDFs will be plain text but the worker
-  // boots and downstream flows complete. Prod deploys MUST set
-  // VOYANT_CLOUD_API_KEY.
-  console.warn(
-    "[operator] VOYANT_CLOUD_API_KEY not set — using basic pdf-lib serializer. " +
-      "Contract PDFs will be unstyled. Set the key to enable browser-rendered output.",
-  )
-  return createPdfContractDocumentGenerator({ storage })
-}
-
-/**
- * Auto-generate config for the customer-sales-agreement template.
- * Shared by the legal module's `booking.confirmed` subscriber AND by
- * the explicit `generate_contract_pdf` step in `checkout-finalize` so
- * both paths produce identical contracts. The function
- * `autoGenerateContractForBooking` is idempotent — if a contract
- * document already exists for the booking, the second caller becomes
- * a no-op (whichever path runs first wins).
- *
- * Template slug must match a row in `contract_templates` whose
- * `currentVersionId` points at a published Liquid version. The
- * operator seed script creates `customer-sales-agreement`.
- */
-/**
- * Default contract number series name. `autoGenerateContractForBooking`
- * looks up an active series with this name at issue time (post-payment)
- * and allocates the next number — that's how contracts get
- * `CTR-2026-00001` / etc. instead of staying unnumbered. The series
- * row is created lazily on first checkout fire (see
- * `ensureDefaultContractSeries`) so a fresh deploy doesn't need a
- * manual seed step. Operators can rename / customise the prefix
- * afterwards via the admin Series page without breaking the wiring
- * — lookup is by name, not id.
- */
-const DEFAULT_CONTRACT_SERIES_NAME = "customer-contracts"
-const MAX_BROCHURE_PDF_BYTES = 5 * 1024 * 1024
-
-const AUTO_GENERATE_CONTRACT_OPTIONS: AutoGenerateContractOptions = {
-  enabled: true,
-  templateSlug: "customer-sales-agreement",
-  scope: "customer",
-  language: "en",
-  seriesName: DEFAULT_CONTRACT_SERIES_NAME,
-  // Promote the storefront's acceptance marker (saved by
-  // catalog-checkout into booking.internalNotes) into the proper
-  // `acceptance.*` variables, and fold in the operator profile
-  // (from Settings -> Operator profile) so the post-confirm render
-  // fills `operator.*` instead of leaving every variable blank.
-  resolveVariables: async ({ db, booking, defaults, bindings }) => {
-    const env = bindings as unknown as CloudflareBindings
-    const acceptance = parseAcceptanceMarker(booking.internalNotes ?? "")
-    const schedule = await loadBookingPaymentSchedule(db, booking.id)
-    const roomsSummary = await deriveRoomsSummary(db, booking.id)
-    const [operatorProfile, paymentInstructions] = await Promise.all([
-      getOperatorProfile(db),
-      getOperatorPaymentInstructions(db),
-    ])
-
-    // Hydrate the customer block from the linked CRM person /
-    // identity record when the booking's snapshot columns are
-    // empty. Bookings created before snapshot-at-create landed
-    // still have `contact_*` nulls; without this fallback the
-    // contract template renders blank customer info even though
-    // the data lives on the linked person.
-    const customerOverride = await resolveCustomerVariables(
-      db,
-      booking.personId,
-      booking.organizationId,
-    )
-
-    // Public base URL for any external resources templates load when
-    // CF Browser Rendering pulls the HTML to a PDF. In dev this falls
-    // back to APP_URL (localhost) so existing template authoring
-    // workflows keep working — CF will fail to fetch the localhost
-    // resources but the inline-styled PDF still generates. In prod
-    // this MUST be set to a publicly-reachable URL.
-    const documentsBaseUrl = env?.DOCUMENTS_BASE_URL?.trim() || env?.APP_URL?.trim() || ""
-
-    return {
-      ...defaults,
-      documents: {
-        // Templates use this to compose absolute URLs for logos /
-        // signatures / hosted fonts. Examples in Liquid:
-        //   <img src="{{ documents.base_url }}/v1/media/logo.png">
-        //   <link rel="stylesheet" href="{{ documents.base_url }}/css/contract.css">
-        //
-        // Aliased keys (`baseUrl` + `base_url`) so template authors
-        // can use either casing without editing the resolver.
-        baseUrl: documentsBaseUrl,
-        base_url: documentsBaseUrl,
-      },
-      booking: {
-        ...defaults.booking,
-        depositAmountCents: schedule.depositAmountCents,
-        depositDueDate: schedule.depositDueDate,
-        balanceAmountCents: schedule.balanceAmountCents,
-        balanceDueDate: schedule.balanceDueDate,
-        paymentPolicy: {
-          // The booking-schedule subscriber stamps the resolved
-          // cascade layer onto the booking's internalNotes when it
-          // computes the schedule. Read it back here so the
-          // contract reflects which layer applied
-          // (supplier / operator_default / category / listing /
-          // booking).
-          source:
-            readPolicySourceFromInternalNotes(booking.internalNotes ?? "") ?? "operator_default",
-        },
-        roomsSummary,
-      },
-      payment: {
-        ...defaults.payment,
-        schedule: schedule.entries,
-      },
-      operator: {
-        ...defaults.operator,
-        name: operatorProfile?.name ?? "",
-        legalName: operatorProfile?.legalName ?? operatorProfile?.name ?? "",
-        vatId: operatorProfile?.vatId ?? "",
-        registrationNumber: operatorProfile?.registrationNumber ?? "",
-        address: operatorProfile?.address ?? "",
-        phone: operatorProfile?.phone ?? "",
-        email: operatorProfile?.email ?? "",
-        website: operatorProfile?.website ?? "",
-        iban: paymentInstructions?.iban ?? "",
-        bank: paymentInstructions?.bank ?? "",
-        license: operatorProfile?.license ?? "",
-        licenseAuthority: operatorProfile?.licenseAuthority ?? "",
-        signatoryName: operatorProfile?.signatoryName ?? "",
-        signatoryRole: operatorProfile?.signatoryRole ?? "",
-      },
-      acceptance: {
-        ...defaults.acceptance,
-        ipAddress: acceptance?.clientIp ?? "",
-        userAgent: acceptance?.userAgent ?? "",
-        acceptedAt: acceptance?.acceptedAt ?? "",
-        marketingConsent: acceptance?.acceptedMarketing ?? false,
-        templateSlug: acceptance?.templateSlug ?? defaults.acceptance.templateSlug,
-        templateId: acceptance?.templateId ?? defaults.acceptance.templateId,
-      },
-      contract: {
-        ...defaults.contract,
-        signedAt: acceptance?.acceptedAt ?? defaults.contract.signedAt,
-        // Drive `contract.source` from the booking's origin so
-        // contract templates can branch on whether the deal came
-        // through self-service (storefront), an agent / partner,
-        // or a back-office issue. Fallback to the legal default
-        // ("self_service") when the booking sourceType is missing
-        // or unrecognised.
-        source: bookingSourceTypeToContractSource(booking.sourceType),
-      },
-      customer: customerOverride
-        ? {
-            ...defaults.customer,
-            // Booking snapshot wins when present; live CRM data fills
-            // any gap. Falsy snapshot strings (`""`) lose to non-empty
-            // overrides so legacy bookings without contact_* still
-            // render a populated customer block.
-            firstName: defaults.customer.firstName || customerOverride.firstName,
-            lastName: defaults.customer.lastName || customerOverride.lastName,
-            fullName: defaults.customer.fullName || customerOverride.fullName,
-            email: defaults.customer.email || customerOverride.email,
-            phone: defaults.customer.phone || customerOverride.phone,
-            dateOfBirth: defaults.customer.dateOfBirth || customerOverride.dateOfBirth,
-            companyName: defaults.customer.companyName || customerOverride.companyName,
-            address: {
-              ...defaults.customer.address,
-              line1: defaults.customer.address.line1 || customerOverride.address.line1,
-              city: defaults.customer.address.city || customerOverride.address.city,
-              region: defaults.customer.address.region || customerOverride.address.region,
-              postal: defaults.customer.address.postal || customerOverride.address.postal,
-              country: defaults.customer.address.country || customerOverride.address.country,
-            },
-          }
-        : defaults.customer,
-    }
-  },
-}
-
-/**
- * Fetch the customer's CRM record + primary identity address so the
- * contract render falls back to live data when the booking row's
- * snapshot columns are empty (legacy bookings, or bookings created
- * via flows that didn't snapshot). Returns null when no CRM record
- * is linked — the resolver keeps `defaults.customer` (snapshot only).
- */
-async function resolveCustomerVariables(
-  db: PostgresJsDatabase,
-  personId: string | null,
-  organizationId: string | null,
-): Promise<{
-  firstName: string
-  lastName: string
-  fullName: string
-  email: string
-  phone: string
-  dateOfBirth: string
-  companyName: string
-  address: { line1: string; city: string; region: string; postal: string; country: string }
-} | null> {
-  if (personId) {
-    const person = await crmService.getPersonById(db, personId)
-    if (!person) return null
-    const addresses = await crmService.listAddresses(db, "person", person.id).catch(() => [])
-    const primary = addresses.find((a) => a.isPrimary) ?? addresses[0] ?? null
-    const fullName = [person.firstName, person.lastName].filter(Boolean).join(" ").trim()
-    return {
-      firstName: person.firstName ?? "",
-      lastName: person.lastName ?? "",
-      fullName,
-      email: person.email ?? "",
-      phone: person.phone ?? "",
-      dateOfBirth: person.dateOfBirth ?? "",
-      companyName: "",
-      address: {
-        line1: primary?.line1 ?? "",
-        city: primary?.city ?? "",
-        region: primary?.region ?? "",
-        postal: primary?.postalCode ?? "",
-        country: primary?.country ?? "",
-      },
-    }
-  }
-  if (organizationId) {
-    const org = await crmService.getOrganizationById(db, organizationId)
-    if (!org) return null
-    const addresses = await crmService.listAddresses(db, "organization", org.id).catch(() => [])
-    const primary = addresses.find((a) => a.isPrimary) ?? addresses[0] ?? null
-    return {
-      firstName: "",
-      lastName: "",
-      fullName: org.name ?? "",
-      email: "",
-      phone: "",
-      dateOfBirth: "",
-      companyName: org.name ?? "",
-      address: {
-        line1: primary?.line1 ?? "",
-        city: primary?.city ?? "",
-        region: primary?.region ?? "",
-        postal: primary?.postalCode ?? "",
-        country: primary?.country ?? "",
-      },
-    }
-  }
-  return null
-}
-
-/**
- * Generate (or fetch existing) the contract PDF for a booking, using
- * the same template + variables config as the legal subscriber.
- * Idempotent — `autoGenerateContractForBooking` short-circuits when a
- * contract document already exists for this booking.
- *
- * Wired into `createCatalogCheckoutBundle({ generateContractPdf })`
- * so the explicit `generate_contract_pdf` checkout-finalize step can
- * call it.
- *
- * **Failure semantics**: on any non-`ok` status, this throws with a
- * structured message. The catalog workflow step's `runStep` wrapper
- * catches the throw and records it as a `failed` step in
- * `workflow_run_steps`, which the dashboard renders red with the
- * error message — operators get to SEE that the PDF generation
- * failed instead of silently looking at a green run with no
- * attachment. The booking + invoice + payment-link steps already
- * succeeded so the resume-from-failed-step UX picks up here without
- * re-issuing the invoice.
- *
- * Returns null only when the generator is intentionally unwired
- * (no DOCUMENTS_BUCKET binding) — that's a deployment choice, not
- * a failure to surface.
- */
-/**
- * Idempotent: ensures the default `customer-contracts` series exists.
- * Called lazily from the contract-generation path so a fresh deploy
- * doesn't need a manual seed step before the first checkout. Once
- * the series exists we skip the insert; renames + prefix changes by
- * operators stick because lookup is by name, not id.
- */
-async function ensureDefaultContractSeries(db: PostgresJsDatabase): Promise<void> {
-  const { contractsService } = await import("@voyantjs/legal/contracts")
-  const existing = await contractsService.findSeriesByName(db, DEFAULT_CONTRACT_SERIES_NAME)
-  if (existing) return
-  try {
-    await contractsService.createSeries(db, {
-      name: DEFAULT_CONTRACT_SERIES_NAME,
-      // CTR-2026-00001 — year-stamped prefix because most operators
-      // reset contract numbers per fiscal year. The series'
-      // `resetStrategy: "never"` default works fine here; bumping to
-      // "yearly" later just resets the sequence on Jan 1 without
-      // changing the prefix.
-      prefix: `CTR-${new Date().getFullYear()}-`,
-      separator: "",
-      padLength: 5,
-      resetStrategy: "never",
-      scope: "customer",
-      active: true,
-    })
-  } catch (err) {
-    console.warn("[operator] ensureDefaultContractSeries failed", err)
-  }
-}
-
-/**
- * Reset every existing customer contract for the booking so the next
- * `autoGenerateContractForBooking` invocation rebuilds variables from
- * the latest booking data and re-renders the template.
- *
- * Steps per contract:
- *   - delete any `document` attachments (legal cascades to storage cleanup
- *     via attachment lifecycle hooks)
- *   - null out `renderedBody` so `ensureRenderedContract` re-renders from
- *     the current template body with the freshly-resolved variables
- *
- * Used by the Documents tab's per-row Regenerate action — the legacy
- * `regenerateDocument` mutation just re-runs the PDF printer over the
- * previously-stored variables/body, which is why placeholders looked
- * unfilled when the initial render had partial inputs.
- */
-async function resetContractDocumentForBooking(
-  db: PostgresJsDatabase,
-  bookingId: string,
-): Promise<void> {
-  const { contractsService } = await import("@voyantjs/legal/contracts")
-  const { contracts: contractsTable } = await import("@voyantjs/legal/schema")
-  const existing = await contractsService.listContracts(db, { bookingId, limit: 25, offset: 0 })
-  for (const contract of existing.data) {
-    const attachments = await contractsService.listAttachments(db, contract.id)
-    for (const attachment of attachments) {
-      if (attachment.kind === "document") {
-        await contractsService.deleteAttachment(db, attachment.id)
-      }
-    }
-    await db
-      .update(contractsTable)
-      .set({ renderedBody: null, updatedAt: new Date() })
-      .where(eq(contractsTable.id, contract.id))
-  }
-}
-
-async function generateContractPdfForBooking(
-  env: CloudflareBindings,
-  db: PostgresJsDatabase,
-  eventBus: import("@voyantjs/core").EventBus | undefined,
-  bookingId: string,
-  options: { force?: boolean } = {},
-): Promise<{ contractId: string; attachmentId: string } | null> {
-  const generator = resolveContractDocumentGenerator(env)
-  if (!generator) return null
-
-  // Lazy seed — creates the default series on the first contract
-  // generation. No-ops on subsequent fires.
-  await ensureDefaultContractSeries(db)
-
-  // Resolve bookingNumber for the event payload — `autoGenerateContractForBooking`
-  // requires it (it's used for the contract title).
-  const [bookingRow] = await db
-    .select({ bookingNumber: bookings.bookingNumber })
-    .from(bookings)
-    .where(eq(bookings.id, bookingId))
-    .limit(1)
-  if (!bookingRow) {
-    throw new Error(`generateContractPdfForBooking: booking ${bookingId} not found`)
-  }
-
-  // Force-regenerate path: `autoGenerateContractForBooking` is idempotent —
-  // it short-circuits when a document attachment already exists. To rebuild
-  // variables from current booking data and re-render the PDF, we first
-  // delete the existing document attachment(s) and clear `renderedBody` on
-  // the contract row so the rebuild branch fires with fresh inputs.
-  if (options.force) {
-    await resetContractDocumentForBooking(db, bookingId)
-  }
-
-  const result = await autoGenerateContractForBooking(
-    db,
-    { bookingId, bookingNumber: bookingRow.bookingNumber, actorId: null },
-    AUTO_GENERATE_CONTRACT_OPTIONS,
-    { generator, eventBus, bindings: env as unknown as Record<string, unknown> },
-  )
-
-  if (result.status === "ok") {
-    return { contractId: result.contractId, attachmentId: result.attachmentId }
-  }
-
-  // Surface the underlying failure reason so the dashboard step
-  // row says e.g. "document_failed: generator_failed" instead of
-  // sitting silent. `result.reason` is set by autoGenerateContractForBooking
-  // to whatever generateContractDocument returned — typically
-  // `generator_failed` (Cloud SDK / R2 upload error) or
-  // `template_not_found`.
-  const reason = "reason" in result && typeof result.reason === "string" ? result.reason : "unknown"
-  throw new Error(
-    `Contract PDF generation failed: ${result.status} (${reason}). ` +
-      "Check wrangler logs for the underlying generator error " +
-      "(Cloud SDK call, R2 upload, or template render).",
-  )
-}
-
-/**
- * Server-side preview of the contract that `generateContractPdfForBooking`
- * would produce. Runs the same template lookup + variable build pipeline
- * (so the operator sees exactly what the customer would receive) but
- * stops after the HTML render — no contract row, no PDF, no storage.
- */
-async function previewContractForBooking(
-  env: CloudflareBindings,
-  db: PostgresJsDatabase,
-  bookingId: string,
-): Promise<{ html: string; templateName: string; templateLanguage: string } | null> {
-  const generator = resolveContractDocumentGenerator(env)
-  // `generator` is required by the AutoGenerateContractRuntime type but
-  // never invoked on the preview branch — we satisfy the contract with
-  // the real generator when available, otherwise a no-op stub.
-  const previewGenerator =
-    generator ??
-    (((): never => {
-      throw new Error("Contract document generator not configured")
-    }) as unknown as ContractDocumentGenerator)
-
-  const [bookingRow] = await db
-    .select({ bookingNumber: bookings.bookingNumber })
-    .from(bookings)
-    .where(eq(bookings.id, bookingId))
-    .limit(1)
-  if (!bookingRow) {
-    throw new Error(`previewContractForBooking: booking ${bookingId} not found`)
-  }
-
-  const result = await autoGenerateContractForBooking(
-    db,
-    { bookingId, bookingNumber: bookingRow.bookingNumber, actorId: null },
-    { ...AUTO_GENERATE_CONTRACT_OPTIONS, previewMode: true },
-    { generator: previewGenerator, bindings: env as unknown as Record<string, unknown> },
-  )
-
-  if (result.status === "preview") {
-    return {
-      html: result.html,
-      templateName: result.templateName,
-      templateLanguage: result.templateLanguage,
-    }
-  }
-
-  if (result.status === "template_not_found" || result.status === "template_version_missing") {
-    return null
-  }
-
-  const reason = "reason" in result && typeof result.reason === "string" ? result.reason : "unknown"
-  throw new Error(`Contract preview failed: ${result.status} (${reason})`)
-}
-
 const legalModule = createLegalHonoModule({
   // KNOWN LEAK: same shape as the bookings `resolveDb` above — leaks a
   // Pool per legal-event subscriber call until the module factory's
@@ -767,141 +271,6 @@ const legalModule = createLegalHonoModule({
 const publicDocumentDeliveryModule = createPublicDocumentDeliveryHonoModule<CloudflareBindings>({
   resolveStorage: createDocumentStorage,
 })
-
-interface StoredContractAcceptance {
-  templateId?: string
-  templateSlug?: string
-  acceptedAt?: string
-  acceptedMarketing?: boolean
-  clientIp?: string
-  userAgent?: string
-  renderedHtmlLength?: number
-}
-
-const ACCEPTANCE_MARKER_PREFIX = "__contract_acceptance__:"
-
-function parseAcceptanceMarker(internalNotes: string): StoredContractAcceptance | null {
-  for (const line of internalNotes.split(/\r?\n/)) {
-    const trimmed = line.trim()
-    if (trimmed.startsWith(ACCEPTANCE_MARKER_PREFIX)) {
-      try {
-        return JSON.parse(trimmed.slice(ACCEPTANCE_MARKER_PREFIX.length))
-      } catch {
-        return null
-      }
-    }
-  }
-  return null
-}
-
-/**
- * Map the booking's `source_type` enum onto the contract template's
- * `contract.source` — used by templates to branch on how the booking
- * came in (e.g. agent-issued contracts list two signature lines, the
- * self-service path embeds an acceptance fingerprint).
- *
- * Mapping:
- *   `manual` / `internal`   → `"staff_issued"`  (operator-issued
- *                             from the admin)
- *   `direct`                → `"self_service"` (customer self-served
- *                             via the storefront)
- *   `affiliate` / `ota`     → `"agent"`        (third-party seller)
- *   `reseller` / `api_partner` → `"agent"`
- *   anything else / null    → `"self_service"` (safe default — most
- *                             contracts use the digital-acceptance
- *                             flow)
- */
-function bookingSourceTypeToContractSource(sourceType: string | null | undefined): string {
-  switch (sourceType) {
-    case "manual":
-    case "internal":
-      return "staff_issued"
-    case "direct":
-      return "self_service"
-    case "affiliate":
-    case "ota":
-    case "reseller":
-    case "api_partner":
-      return "agent"
-    default:
-      return "self_service"
-  }
-}
-
-interface ScheduleSummary {
-  entries: Array<{
-    index: number
-    type: string
-    amountCents: number
-    currency: string
-    dueDate: string
-    status: string
-  }>
-  depositAmountCents: number
-  depositDueDate: string
-  balanceAmountCents: number
-  balanceDueDate: string
-}
-
-/**
- * Read the booking's payment schedule and surface a deposit / balance
- * summary alongside the full schedule list. Both surfaces are exposed
- * to contract templates: the deposit + balance keys for the typical
- * "advance / remainder" copy pattern, and `payment.schedule[]` for
- * templates that want to render every installment.
- */
-async function loadBookingPaymentSchedule(
-  db: PostgresJsDatabase,
-  bookingId: string,
-): Promise<ScheduleSummary> {
-  const rows = await db
-    .select()
-    .from(bookingPaymentSchedules)
-    .where(eq(bookingPaymentSchedules.bookingId, bookingId))
-    .orderBy(asc(bookingPaymentSchedules.dueDate), asc(bookingPaymentSchedules.createdAt))
-
-  const entries = rows.map((row, idx) => ({
-    index: idx + 1,
-    type: row.scheduleType,
-    amountCents: row.amountCents,
-    currency: row.currency,
-    dueDate: row.dueDate,
-    status: row.status,
-  }))
-
-  const deposit = rows.find((r) => r.scheduleType === "deposit")
-  const balance = rows.find((r) => r.scheduleType === "balance")
-
-  return {
-    entries,
-    depositAmountCents: deposit?.amountCents ?? 0,
-    depositDueDate: deposit?.dueDate ?? "",
-    balanceAmountCents: balance?.amountCents ?? 0,
-    balanceDueDate: balance?.dueDate ?? "",
-  }
-}
-
-/**
- * Best-effort accommodation summary from the booking's items. Uses
- * the title field on each line so the operator gets whatever wording
- * was used at booking time ("1× Double room — BB"). Operators with a
- * structured cabin/room model override via their own
- * `resolveVariables` callback.
- */
-async function deriveRoomsSummary(db: PostgresJsDatabase, bookingId: string): Promise<string> {
-  const rows = await db
-    .select({
-      title: bookingItems.title,
-      quantity: bookingItems.quantity,
-      itemType: bookingItems.itemType,
-    })
-    .from(bookingItems)
-    .where(eq(bookingItems.bookingId, bookingId))
-
-  const accommodationLines = rows.filter((r) => r.itemType === "accommodation")
-  const lines = accommodationLines.length > 0 ? accommodationLines : []
-  return lines.map((r) => `${r.quantity}× ${r.title}`).join(", ")
-}
 
 export const app = createApp<CloudflareBindings>({
   // `dbFromEnvForApp` returns `{ db, dispose }`; the Hono db middleware
@@ -1088,52 +457,7 @@ export const app = createApp<CloudflareBindings>({
       }
     })
 
-    // Manual contract-PDF generation for the booking detail page's
-    // Documents tab. Reuses the same `autoGenerateContractForBooking`
-    // flow the `booking.confirmed` subscriber + the checkout-finalize
-    // step use, so the variables (booking number, customer, operator
-    // block, totals) match between automatic and manual paths.
-    // POST /v1/admin/bookings/:bookingId/generate-contract
-    hono.post("/v1/admin/bookings/:bookingId/generate-contract", async (c) => {
-      const bookingId = c.req.param("bookingId")
-      // Body is optional: callers may post `{}` (initial generate),
-      // `{ force: true }` (regenerate — rebuild variables + re-render),
-      // or `{ preview: true }` (render HTML preview without persisting
-      // — used by the operator's "Add contract" dialog).
-      const body = await c.req
-        .json<{ force?: boolean; preview?: boolean }>()
-        .catch(() => ({}) as { force?: boolean; preview?: boolean })
-      try {
-        if (body.preview === true) {
-          const preview = await previewContractForBooking(
-            c.env,
-            c.get("db") as unknown as PostgresJsDatabase,
-            bookingId,
-          )
-          if (!preview) {
-            return c.json({ error: "Contract template not found" }, 404)
-          }
-          return c.json({ data: preview })
-        }
-        const result = await generateContractPdfForBooking(
-          c.env,
-          c.get("db") as unknown as PostgresJsDatabase,
-          c.get("eventBus"),
-          bookingId,
-          { force: body.force === true },
-        )
-        if (!result) {
-          return c.json(
-            { error: "Contract document storage not configured (missing DOCUMENTS_BUCKET)" },
-            503,
-          )
-        }
-        return c.json({ data: result })
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err)
-        return c.json({ error: message }, 502)
-      }
-    })
+    mountOperatorContractDocumentRoutes(hono)
 
     // Storefront preview policy resolution. The customer-facing
     // booking journey calls this on mount + whenever the
@@ -1142,159 +466,7 @@ export const app = createApp<CloudflareBindings>({
     // POST /v1/public/payment-policy/resolve
     mountPublicPaymentPolicyRoutes(hono)
 
-    // POST /v1/uploads — upload public/editorial media via the configured
-    // media storage provider. Sensitive documents should use private
-    // document-aware flows instead of this route.
-    hono.post("/v1/admin/products/:id/brochure/generate", async (c) => {
-      const storage = createMediaStorage(c.env)
-      if (!storage) {
-        return c.json({ error: "Storage not configured" }, 503)
-      }
-
-      const productId = c.req.param("id")
-      const cloud = tryGetCloudClient(c.env)
-      let generated: Awaited<ReturnType<typeof generateAndStoreProductBrochure>>
-      try {
-        generated = await generateAndStoreProductBrochure(c.get("db"), productId, {
-          storage,
-          template: createDefaultProductBrochureTemplate(),
-          ...(cloud ? { printer: createProductBrochurePrinter(c.env) } : {}),
-          keyPrefix: `brochures/products/${productId}`,
-          filename: ({ productId: generatedProductId, filename }) =>
-            `brochure-${generatedProductId}-${Date.now()}-${filename}`,
-          maxSizeBytes: MAX_BROCHURE_PDF_BYTES,
-        })
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err)
-        if (message.includes("Generated brochure is too large")) {
-          return c.json({ error: message }, 413)
-        }
-        throw err
-      }
-
-      await c.get("eventBus")?.emit("product.content.changed", {
-        id: productId,
-        axis: "media",
-      })
-
-      return c.json({
-        data: generated.brochure,
-        metadata: {
-          filename: generated.filename,
-          sizeBytes: generated.sizeBytes,
-          storageKey: generated.storageKey,
-          url: generated.url,
-        },
-      })
-    })
-
-    hono.post("/v1/uploads", async (c) => {
-      const storage = createMediaStorage(c.env)
-      if (!storage) {
-        return c.json({ error: "Storage not configured" }, 503)
-      }
-
-      const body = await c.req.parseBody()
-      const file = body.file
-      if (!(file instanceof File)) {
-        return c.json({ error: "Missing file field in multipart body" }, 400)
-      }
-
-      const ext = file.name.split(".").pop() ?? "bin"
-      const key = `uploads/${Date.now()}-${crypto.randomUUID().slice(0, 8)}.${ext}`
-
-      const result = await storage.upload(await file.arrayBuffer(), {
-        key,
-        contentType: file.type,
-      })
-
-      return c.json({
-        key: result.key,
-        url: result.url,
-        mimeType: file.type,
-        size: file.size,
-      })
-    })
-
-    // POST /v1/uploads/video — request a one-shot upload ticket for video
-    // bytes. The client uploads the video directly to `uploadUrl` (TUS
-    // protocol). See `src/lib/video-uploads.ts` to swap providers.
-    hono.post("/v1/uploads/video", async (c) => {
-      const body = await c.req.json<{
-        maxDurationSeconds: number
-        name?: string | null
-        requireSignedUrls?: boolean
-        allowedOrigins?: string[]
-        thumbnailTimestampPct?: number | null
-        meta?: Record<string, string>
-      }>()
-      const ticket = await createVideoUploadTicket(c.env as Record<string, unknown>, body)
-      return c.json(ticket)
-    })
-
-    // GET /v1/admin/documents/files/* — admin-only stream of private
-    // documents bytes from the DOCUMENTS_BUCKET. Used as the fallback
-    // download target for environments where the R2 binding isn't
-    // backed by a real S3 SigV4 signer (every dev setup, plus
-    // small-team prod deploys that haven't wired one up). The legal
-    // package's contract-attachment download endpoint redirects here
-    // through `resolveDocumentDownloadUrl`. Auth is the standard staff
-    // guard inherited from `/v1/admin/*` middleware in createApp.
-    hono.get("/v1/admin/documents/files/*", async (c) => {
-      const storage = createDocumentStorage(c.env)
-      if (!storage) {
-        return c.json({ error: "Storage not configured" }, 503)
-      }
-
-      const rawKey = c.req.path.replace("/v1/admin/documents/files/", "")
-      // Decode each path segment — `resolveDocumentDownloadUrl`
-      // encodes them so storage keys with spaces / unicode survive
-      // round-tripping through the URL.
-      const key = rawKey
-        .split("/")
-        .map((segment) => decodeURIComponent(segment))
-        .join("/")
-      if (!key) return c.json({ error: "Missing key" }, 400)
-
-      const buffer = await storage.get(key)
-      if (!buffer) return c.json({ error: "Not found" }, 404)
-
-      const headers = new Headers()
-      headers.set("Content-Type", guessMimeType(key))
-      // Documents are private — keep them out of intermediary caches.
-      headers.set("Cache-Control", "private, no-store")
-      headers.set("Content-Length", String(buffer.byteLength))
-      // Inline disposition lets the browser render PDFs in-tab; the
-      // operator UI's "click on the name" UX expects open-in-tab.
-      headers.set("Content-Disposition", `inline; filename="${key.split("/").pop() ?? "document"}"`)
-
-      return new Response(buffer, { headers })
-    })
-
-    // GET /v1/media/* — serve public media via the configured media storage provider.
-    hono.get("/v1/media/*", async (c) => {
-      const storage = createMediaStorage(c.env)
-      if (!storage) {
-        return c.json({ error: "Storage not configured" }, 503)
-      }
-
-      const key = c.req.path.replace("/v1/media/", "")
-      if (!key) {
-        return c.json({ error: "Missing key" }, 400)
-      }
-
-      const buffer = await storage.get(key)
-      if (!buffer) {
-        return c.json({ error: "Not found" }, 404)
-      }
-
-      const headers = new Headers()
-      headers.set("Content-Type", guessMimeType(key))
-      headers.set("Cache-Control", "public, max-age=31536000, immutable")
-      headers.set("Content-Length", String(buffer.byteLength))
-
-      return new Response(buffer, { headers })
-    })
+    mountOperatorMediaUploadRoutes(hono)
 
     mountOperatorLazyAdditionalRoutes(hono)
 

--- a/templates/operator/src/api/contract-document-routes.test.ts
+++ b/templates/operator/src/api/contract-document-routes.test.ts
@@ -1,0 +1,96 @@
+import type { EventBus } from "@voyantjs/core"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { Hono } from "hono"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { mountOperatorContractDocumentRoutes } from "./contract-document-routes"
+
+type GenerateContractPdfForBooking = (
+  env: CloudflareBindings,
+  db: PostgresJsDatabase,
+  eventBus: EventBus | undefined,
+  bookingId: string,
+  options?: { force?: boolean },
+) => Promise<{ contractId: string; attachmentId: string } | null>
+
+type PreviewContractForBooking = (
+  env: CloudflareBindings,
+  db: PostgresJsDatabase,
+  bookingId: string,
+) => Promise<{ html: string; templateName: string; templateLanguage: string } | null>
+
+type TestRouteEnv = {
+  Bindings: CloudflareBindings
+  Variables: {
+    db: PostgresJsDatabase
+    eventBus?: EventBus
+  }
+}
+
+const runtime = vi.hoisted(() => ({
+  generateContractPdfForBooking: vi.fn<GenerateContractPdfForBooking>(async () => ({
+    contractId: "ctr_123",
+    attachmentId: "att_123",
+  })),
+  previewContractForBooking: vi.fn<PreviewContractForBooking>(async () => ({
+    html: "<p>Preview</p>",
+    templateName: "Customer agreement",
+    templateLanguage: "en",
+  })),
+}))
+
+vi.mock("./contract-document-runtime", () => runtime)
+
+describe("operator contract document routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("dispatches manual contract generation", async () => {
+    const app = new Hono<TestRouteEnv>()
+    const db = {} as PostgresJsDatabase
+    app.use("*", async (c, next) => {
+      c.set("db", db)
+      await next()
+    })
+    mountOperatorContractDocumentRoutes(app)
+
+    const response = await app.request("/v1/admin/bookings/bk_123/generate-contract", {
+      method: "POST",
+      body: JSON.stringify({ force: true }),
+      headers: { "content-type": "application/json" },
+    })
+
+    await expect(response.json()).resolves.toEqual({
+      data: { contractId: "ctr_123", attachmentId: "att_123" },
+    })
+    expect(runtime.generateContractPdfForBooking).toHaveBeenCalledOnce()
+    expect(runtime.generateContractPdfForBooking.mock.calls[0]?.[3]).toBe("bk_123")
+    expect(runtime.generateContractPdfForBooking.mock.calls[0]?.[4]).toEqual({ force: true })
+  })
+
+  it("dispatches contract preview generation", async () => {
+    const app = new Hono<TestRouteEnv>()
+    const db = {} as PostgresJsDatabase
+    app.use("*", async (c, next) => {
+      c.set("db", db)
+      await next()
+    })
+    mountOperatorContractDocumentRoutes(app)
+
+    const response = await app.request("/v1/admin/bookings/bk_123/generate-contract", {
+      method: "POST",
+      body: JSON.stringify({ preview: true }),
+      headers: { "content-type": "application/json" },
+    })
+
+    await expect(response.json()).resolves.toEqual({
+      data: {
+        html: "<p>Preview</p>",
+        templateName: "Customer agreement",
+        templateLanguage: "en",
+      },
+    })
+    expect(runtime.previewContractForBooking).toHaveBeenCalledOnce()
+    expect(runtime.previewContractForBooking.mock.calls[0]?.[2]).toBe("bk_123")
+  })
+})

--- a/templates/operator/src/api/contract-document-routes.ts
+++ b/templates/operator/src/api/contract-document-routes.ts
@@ -1,0 +1,88 @@
+import type { EventBus } from "@voyantjs/core"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import type { Hono } from "hono"
+import {
+  generateContractPdfForBooking,
+  previewContractForBooking,
+} from "./contract-document-runtime"
+import { createDocumentStorage, guessMimeType } from "./lib/storage"
+
+type OperatorContractDocumentRouteEnv = {
+  Bindings: CloudflareBindings
+  Variables: {
+    db: PostgresJsDatabase
+    eventBus?: EventBus
+  }
+}
+
+export function mountOperatorContractDocumentRoutes(
+  hono: Hono<OperatorContractDocumentRouteEnv>,
+): void {
+  // Manual contract-PDF generation for the booking detail page's Documents tab.
+  // POST /v1/admin/bookings/:bookingId/generate-contract
+  hono.post("/v1/admin/bookings/:bookingId/generate-contract", async (c) => {
+    const bookingId = c.req.param("bookingId")
+    if (!bookingId) return c.json({ error: "bookingId route param is required" }, 400)
+
+    const body = await c.req
+      .json<{ force?: boolean; preview?: boolean }>()
+      .catch(() => ({}) as { force?: boolean; preview?: boolean })
+    try {
+      if (body.preview === true) {
+        const preview = await previewContractForBooking(c.env, c.get("db"), bookingId)
+        if (!preview) {
+          return c.json({ error: "Contract template not found" }, 404)
+        }
+        return c.json({ data: preview })
+      }
+
+      const result = await generateContractPdfForBooking(
+        c.env,
+        c.get("db"),
+        c.get("eventBus"),
+        bookingId,
+        { force: body.force === true },
+      )
+      if (!result) {
+        return c.json(
+          { error: "Contract document storage not configured (missing DOCUMENTS_BUCKET)" },
+          503,
+        )
+      }
+      return c.json({ data: result })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return c.json({ error: message }, 502)
+    }
+  })
+
+  // GET /v1/admin/documents/files/* — admin-only stream of private
+  // documents bytes from the DOCUMENTS_BUCKET. Used as the fallback
+  // download target for environments where the R2 binding isn't backed by a
+  // real S3 SigV4 signer. Auth is the standard staff guard inherited from
+  // `/v1/admin/*` middleware in createApp.
+  hono.get("/v1/admin/documents/files/*", async (c) => {
+    const storage = createDocumentStorage(c.env)
+    if (!storage) {
+      return c.json({ error: "Storage not configured" }, 503)
+    }
+
+    const rawKey = c.req.path.replace("/v1/admin/documents/files/", "")
+    const key = rawKey
+      .split("/")
+      .map((segment) => decodeURIComponent(segment))
+      .join("/")
+    if (!key) return c.json({ error: "Missing key" }, 400)
+
+    const buffer = await storage.get(key)
+    if (!buffer) return c.json({ error: "Not found" }, 404)
+
+    const headers = new Headers()
+    headers.set("Content-Type", guessMimeType(key))
+    headers.set("Cache-Control", "private, no-store")
+    headers.set("Content-Length", String(buffer.byteLength))
+    headers.set("Content-Disposition", `inline; filename="${key.split("/").pop() ?? "document"}"`)
+
+    return new Response(buffer, { headers })
+  })
+}

--- a/templates/operator/src/api/contract-document-runtime.ts
+++ b/templates/operator/src/api/contract-document-runtime.ts
@@ -1,0 +1,186 @@
+import { bookings } from "@voyantjs/bookings/schema"
+import type { EventBus } from "@voyantjs/core"
+import type { ContractDocumentGenerator } from "@voyantjs/legal"
+import { eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { tryGetCloudClient } from "../lib/voyant-cloud"
+import {
+  AUTO_GENERATE_CONTRACT_OPTIONS,
+  contractVariableBindings,
+  DEFAULT_CONTRACT_SERIES_NAME,
+} from "./contract-document-variables"
+import { createDocumentStorage } from "./lib/storage"
+
+export { AUTO_GENERATE_CONTRACT_OPTIONS } from "./contract-document-variables"
+
+/**
+ * Build the `ContractDocumentGenerator` configured for this template.
+ * Used by both the legal module's `resolveDocumentGenerator` and by the
+ * explicit `generate_contract_pdf` checkout-finalize step.
+ *
+ * The returned generator lazy-imports the concrete PDF/browser helpers so the
+ * operator Hono app can assemble routes without loading the document rendering
+ * implementation until a contract is actually generated.
+ */
+export function resolveContractDocumentGenerator(
+  env: CloudflareBindings,
+): ContractDocumentGenerator | null {
+  const storage = createDocumentStorage(env)
+  if (!storage) return null
+
+  return async (context) => {
+    const cloud = tryGetCloudClient(env)
+    const legal = await import("@voyantjs/legal")
+    if (cloud) {
+      const generator = legal.createStorageBackedContractDocumentGenerator({
+        storage,
+        serializer: legal.createBrowserRenderedPdfContractDocumentSerializer({
+          cloudClient: cloud,
+        }),
+      })
+      return generator(context)
+    }
+
+    // Local dev / no cloud key — fall back to the basic pdf-lib
+    // serializer. Contract PDFs will be plain text but the worker
+    // boots and downstream flows complete. Prod deploys MUST set
+    // VOYANT_CLOUD_API_KEY.
+    console.warn(
+      "[operator] VOYANT_CLOUD_API_KEY not set — using basic pdf-lib serializer. " +
+        "Contract PDFs will be unstyled. Set the key to enable browser-rendered output.",
+    )
+    const generator = legal.createPdfContractDocumentGenerator({ storage })
+    return generator(context)
+  }
+}
+
+export async function generateContractPdfForBooking(
+  env: CloudflareBindings,
+  db: PostgresJsDatabase,
+  eventBus: EventBus | undefined,
+  bookingId: string,
+  options: { force?: boolean } = {},
+): Promise<{ contractId: string; attachmentId: string } | null> {
+  const generator = resolveContractDocumentGenerator(env)
+  if (!generator) return null
+
+  // Lazy seed — creates the default series on the first contract generation.
+  await ensureDefaultContractSeries(db)
+
+  const [bookingRow] = await db
+    .select({ bookingNumber: bookings.bookingNumber })
+    .from(bookings)
+    .where(eq(bookings.id, bookingId))
+    .limit(1)
+  if (!bookingRow) {
+    throw new Error(`generateContractPdfForBooking: booking ${bookingId} not found`)
+  }
+
+  if (options.force) {
+    await resetContractDocumentForBooking(db, bookingId)
+  }
+
+  const { autoGenerateContractForBooking } = await import("@voyantjs/legal")
+  const result = await autoGenerateContractForBooking(
+    db,
+    { bookingId, bookingNumber: bookingRow.bookingNumber, actorId: null },
+    AUTO_GENERATE_CONTRACT_OPTIONS,
+    { generator, eventBus, bindings: contractVariableBindings(env) },
+  )
+
+  if (result.status === "ok") {
+    return { contractId: result.contractId, attachmentId: result.attachmentId }
+  }
+
+  const reason = "reason" in result && typeof result.reason === "string" ? result.reason : "unknown"
+  throw new Error(
+    `Contract PDF generation failed: ${result.status} (${reason}). ` +
+      "Check wrangler logs for the underlying generator error " +
+      "(Cloud SDK call, R2 upload, or template render).",
+  )
+}
+
+export async function previewContractForBooking(
+  env: CloudflareBindings,
+  db: PostgresJsDatabase,
+  bookingId: string,
+): Promise<{ html: string; templateName: string; templateLanguage: string } | null> {
+  const generator = resolveContractDocumentGenerator(env)
+  const previewGenerator: ContractDocumentGenerator =
+    generator ??
+    (() => {
+      throw new Error("Contract document generator not configured")
+    })
+
+  const [bookingRow] = await db
+    .select({ bookingNumber: bookings.bookingNumber })
+    .from(bookings)
+    .where(eq(bookings.id, bookingId))
+    .limit(1)
+  if (!bookingRow) {
+    throw new Error(`previewContractForBooking: booking ${bookingId} not found`)
+  }
+
+  const { autoGenerateContractForBooking } = await import("@voyantjs/legal")
+  const result = await autoGenerateContractForBooking(
+    db,
+    { bookingId, bookingNumber: bookingRow.bookingNumber, actorId: null },
+    { ...AUTO_GENERATE_CONTRACT_OPTIONS, previewMode: true },
+    { generator: previewGenerator, bindings: contractVariableBindings(env) },
+  )
+
+  if (result.status === "preview") {
+    return {
+      html: result.html,
+      templateName: result.templateName,
+      templateLanguage: result.templateLanguage,
+    }
+  }
+
+  if (result.status === "template_not_found" || result.status === "template_version_missing") {
+    return null
+  }
+
+  const reason = "reason" in result && typeof result.reason === "string" ? result.reason : "unknown"
+  throw new Error(`Contract preview failed: ${result.status} (${reason})`)
+}
+
+async function ensureDefaultContractSeries(db: PostgresJsDatabase): Promise<void> {
+  const { contractsService } = await import("@voyantjs/legal/contracts")
+  const existing = await contractsService.findSeriesByName(db, DEFAULT_CONTRACT_SERIES_NAME)
+  if (existing) return
+  try {
+    await contractsService.createSeries(db, {
+      name: DEFAULT_CONTRACT_SERIES_NAME,
+      prefix: `CTR-${new Date().getFullYear()}-`,
+      separator: "",
+      padLength: 5,
+      resetStrategy: "never",
+      scope: "customer",
+      active: true,
+    })
+  } catch (err) {
+    console.warn("[operator] ensureDefaultContractSeries failed", err)
+  }
+}
+
+async function resetContractDocumentForBooking(
+  db: PostgresJsDatabase,
+  bookingId: string,
+): Promise<void> {
+  const { contractsService } = await import("@voyantjs/legal/contracts")
+  const { contracts: contractsTable } = await import("@voyantjs/legal/schema")
+  const existing = await contractsService.listContracts(db, { bookingId, limit: 25, offset: 0 })
+  for (const contract of existing.data) {
+    const attachments = await contractsService.listAttachments(db, contract.id)
+    for (const attachment of attachments) {
+      if (attachment.kind === "document") {
+        await contractsService.deleteAttachment(db, attachment.id)
+      }
+    }
+    await db
+      .update(contractsTable)
+      .set({ renderedBody: null, updatedAt: new Date() })
+      .where(eq(contractsTable.id, contract.id))
+  }
+}

--- a/templates/operator/src/api/contract-document-variables.ts
+++ b/templates/operator/src/api/contract-document-variables.ts
@@ -1,0 +1,307 @@
+import { bookingItems } from "@voyantjs/bookings/schema"
+import { crmService } from "@voyantjs/crm"
+import { bookingPaymentSchedules } from "@voyantjs/finance/schema"
+import type { AutoGenerateContractOptions } from "@voyantjs/legal"
+import { asc, eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { readPolicySourceFromInternalNotes } from "./booking-schedule"
+import { getOperatorPaymentInstructions, getOperatorProfile } from "./settings"
+
+export const DEFAULT_CONTRACT_SERIES_NAME = "customer-contracts"
+
+export const AUTO_GENERATE_CONTRACT_OPTIONS: AutoGenerateContractOptions = {
+  enabled: true,
+  templateSlug: "customer-sales-agreement",
+  scope: "customer",
+  language: "en",
+  seriesName: DEFAULT_CONTRACT_SERIES_NAME,
+  // Promote the storefront's acceptance marker (saved by
+  // catalog-checkout into booking.internalNotes) into the proper
+  // `acceptance.*` variables, and fold in the operator profile
+  // (from Settings -> Operator profile) so the post-confirm render
+  // fills `operator.*` instead of leaving every variable blank.
+  resolveVariables: async ({ db, booking, defaults, bindings }) => {
+    const acceptance = parseAcceptanceMarker(booking.internalNotes ?? "")
+    const schedule = await loadBookingPaymentSchedule(db, booking.id)
+    const roomsSummary = await deriveRoomsSummary(db, booking.id)
+    const [operatorProfile, paymentInstructions] = await Promise.all([
+      getOperatorProfile(db),
+      getOperatorPaymentInstructions(db),
+    ])
+
+    // Hydrate the customer block from the linked CRM person /
+    // identity record when the booking's snapshot columns are
+    // empty. Bookings created before snapshot-at-create landed
+    // still have `contact_*` nulls; without this fallback the
+    // contract template renders blank customer info even though
+    // the data lives on the linked person.
+    const customerOverride = await resolveCustomerVariables(
+      db,
+      booking.personId,
+      booking.organizationId,
+    )
+
+    // Public base URL for any external resources templates load when
+    // CF Browser Rendering pulls the HTML to a PDF. In dev this falls
+    // back to APP_URL (localhost) so existing template authoring
+    // workflows keep working; in prod this MUST be set to a
+    // publicly-reachable URL.
+    const documentsBaseUrl =
+      readStringBinding(bindings, "DOCUMENTS_BASE_URL") || readStringBinding(bindings, "APP_URL")
+
+    return {
+      ...defaults,
+      documents: {
+        baseUrl: documentsBaseUrl,
+        base_url: documentsBaseUrl,
+      },
+      booking: {
+        ...defaults.booking,
+        depositAmountCents: schedule.depositAmountCents,
+        depositDueDate: schedule.depositDueDate,
+        balanceAmountCents: schedule.balanceAmountCents,
+        balanceDueDate: schedule.balanceDueDate,
+        paymentPolicy: {
+          source:
+            readPolicySourceFromInternalNotes(booking.internalNotes ?? "") ?? "operator_default",
+        },
+        roomsSummary,
+      },
+      payment: {
+        ...defaults.payment,
+        schedule: schedule.entries,
+      },
+      operator: {
+        ...defaults.operator,
+        name: operatorProfile?.name ?? "",
+        legalName: operatorProfile?.legalName ?? operatorProfile?.name ?? "",
+        vatId: operatorProfile?.vatId ?? "",
+        registrationNumber: operatorProfile?.registrationNumber ?? "",
+        address: operatorProfile?.address ?? "",
+        phone: operatorProfile?.phone ?? "",
+        email: operatorProfile?.email ?? "",
+        website: operatorProfile?.website ?? "",
+        iban: paymentInstructions?.iban ?? "",
+        bank: paymentInstructions?.bank ?? "",
+        license: operatorProfile?.license ?? "",
+        licenseAuthority: operatorProfile?.licenseAuthority ?? "",
+        signatoryName: operatorProfile?.signatoryName ?? "",
+        signatoryRole: operatorProfile?.signatoryRole ?? "",
+      },
+      acceptance: {
+        ...defaults.acceptance,
+        ipAddress: acceptance?.clientIp ?? "",
+        userAgent: acceptance?.userAgent ?? "",
+        acceptedAt: acceptance?.acceptedAt ?? "",
+        marketingConsent: acceptance?.acceptedMarketing ?? false,
+        templateSlug: acceptance?.templateSlug ?? defaults.acceptance.templateSlug,
+        templateId: acceptance?.templateId ?? defaults.acceptance.templateId,
+      },
+      contract: {
+        ...defaults.contract,
+        signedAt: acceptance?.acceptedAt ?? defaults.contract.signedAt,
+        source: bookingSourceTypeToContractSource(booking.sourceType),
+      },
+      customer: customerOverride
+        ? {
+            ...defaults.customer,
+            firstName: defaults.customer.firstName || customerOverride.firstName,
+            lastName: defaults.customer.lastName || customerOverride.lastName,
+            fullName: defaults.customer.fullName || customerOverride.fullName,
+            email: defaults.customer.email || customerOverride.email,
+            phone: defaults.customer.phone || customerOverride.phone,
+            dateOfBirth: defaults.customer.dateOfBirth || customerOverride.dateOfBirth,
+            companyName: defaults.customer.companyName || customerOverride.companyName,
+            address: {
+              ...defaults.customer.address,
+              line1: defaults.customer.address.line1 || customerOverride.address.line1,
+              city: defaults.customer.address.city || customerOverride.address.city,
+              region: defaults.customer.address.region || customerOverride.address.region,
+              postal: defaults.customer.address.postal || customerOverride.address.postal,
+              country: defaults.customer.address.country || customerOverride.address.country,
+            },
+          }
+        : defaults.customer,
+    }
+  },
+}
+
+export function contractVariableBindings(env: CloudflareBindings): Record<string, unknown> {
+  return {
+    APP_URL: env.APP_URL,
+    DOCUMENTS_BASE_URL: env.DOCUMENTS_BASE_URL,
+  }
+}
+
+interface StoredContractAcceptance {
+  templateId?: string
+  templateSlug?: string
+  acceptedAt?: string
+  acceptedMarketing?: boolean
+  clientIp?: string
+  userAgent?: string
+  renderedHtmlLength?: number
+}
+
+const ACCEPTANCE_MARKER_PREFIX = "__contract_acceptance__:"
+
+function readStringBinding(
+  bindings: Record<string, unknown> | null | undefined,
+  key: string,
+): string {
+  const value = bindings?.[key]
+  return typeof value === "string" ? value.trim() : ""
+}
+
+function parseAcceptanceMarker(internalNotes: string): StoredContractAcceptance | null {
+  for (const line of internalNotes.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (trimmed.startsWith(ACCEPTANCE_MARKER_PREFIX)) {
+      try {
+        return JSON.parse(trimmed.slice(ACCEPTANCE_MARKER_PREFIX.length))
+      } catch {
+        return null
+      }
+    }
+  }
+  return null
+}
+
+function bookingSourceTypeToContractSource(sourceType: string | null | undefined): string {
+  switch (sourceType) {
+    case "manual":
+    case "internal":
+      return "staff_issued"
+    case "direct":
+      return "self_service"
+    case "affiliate":
+    case "ota":
+    case "reseller":
+    case "api_partner":
+      return "agent"
+    default:
+      return "self_service"
+  }
+}
+
+async function resolveCustomerVariables(
+  db: PostgresJsDatabase,
+  personId: string | null,
+  organizationId: string | null,
+): Promise<{
+  firstName: string
+  lastName: string
+  fullName: string
+  email: string
+  phone: string
+  dateOfBirth: string
+  companyName: string
+  address: { line1: string; city: string; region: string; postal: string; country: string }
+} | null> {
+  if (personId) {
+    const person = await crmService.getPersonById(db, personId)
+    if (!person) return null
+    const addresses = await crmService.listAddresses(db, "person", person.id).catch(() => [])
+    const primary = addresses.find((a) => a.isPrimary) ?? addresses[0] ?? null
+    const fullName = [person.firstName, person.lastName].filter(Boolean).join(" ").trim()
+    return {
+      firstName: person.firstName ?? "",
+      lastName: person.lastName ?? "",
+      fullName,
+      email: person.email ?? "",
+      phone: person.phone ?? "",
+      dateOfBirth: person.dateOfBirth ?? "",
+      companyName: "",
+      address: {
+        line1: primary?.line1 ?? "",
+        city: primary?.city ?? "",
+        region: primary?.region ?? "",
+        postal: primary?.postalCode ?? "",
+        country: primary?.country ?? "",
+      },
+    }
+  }
+  if (organizationId) {
+    const org = await crmService.getOrganizationById(db, organizationId)
+    if (!org) return null
+    const addresses = await crmService.listAddresses(db, "organization", org.id).catch(() => [])
+    const primary = addresses.find((a) => a.isPrimary) ?? addresses[0] ?? null
+    return {
+      firstName: "",
+      lastName: "",
+      fullName: org.name ?? "",
+      email: "",
+      phone: "",
+      dateOfBirth: "",
+      companyName: org.name ?? "",
+      address: {
+        line1: primary?.line1 ?? "",
+        city: primary?.city ?? "",
+        region: primary?.region ?? "",
+        postal: primary?.postalCode ?? "",
+        country: primary?.country ?? "",
+      },
+    }
+  }
+  return null
+}
+
+interface ScheduleSummary {
+  entries: Array<{
+    index: number
+    type: string
+    amountCents: number
+    currency: string
+    dueDate: string
+    status: string
+  }>
+  depositAmountCents: number
+  depositDueDate: string
+  balanceAmountCents: number
+  balanceDueDate: string
+}
+
+async function loadBookingPaymentSchedule(
+  db: PostgresJsDatabase,
+  bookingId: string,
+): Promise<ScheduleSummary> {
+  const rows = await db
+    .select()
+    .from(bookingPaymentSchedules)
+    .where(eq(bookingPaymentSchedules.bookingId, bookingId))
+    .orderBy(asc(bookingPaymentSchedules.dueDate), asc(bookingPaymentSchedules.createdAt))
+
+  const entries = rows.map((row, idx) => ({
+    index: idx + 1,
+    type: row.scheduleType,
+    amountCents: row.amountCents,
+    currency: row.currency,
+    dueDate: row.dueDate,
+    status: row.status,
+  }))
+
+  const deposit = rows.find((r) => r.scheduleType === "deposit")
+  const balance = rows.find((r) => r.scheduleType === "balance")
+
+  return {
+    entries,
+    depositAmountCents: deposit?.amountCents ?? 0,
+    depositDueDate: deposit?.dueDate ?? "",
+    balanceAmountCents: balance?.amountCents ?? 0,
+    balanceDueDate: balance?.dueDate ?? "",
+  }
+}
+
+async function deriveRoomsSummary(db: PostgresJsDatabase, bookingId: string): Promise<string> {
+  const rows = await db
+    .select({
+      title: bookingItems.title,
+      quantity: bookingItems.quantity,
+      itemType: bookingItems.itemType,
+    })
+    .from(bookingItems)
+    .where(eq(bookingItems.bookingId, bookingId))
+
+  const accommodationLines = rows.filter((r) => r.itemType === "accommodation")
+  return accommodationLines.map((r) => `${r.quantity}× ${r.title}`).join(", ")
+}

--- a/templates/operator/src/api/media-upload-routes.test.ts
+++ b/templates/operator/src/api/media-upload-routes.test.ts
@@ -1,0 +1,42 @@
+import type { EventBus } from "@voyantjs/core"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { Hono } from "hono"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { mountOperatorMediaUploadRoutes } from "./media-upload-routes"
+
+type TestRouteEnv = {
+  Bindings: CloudflareBindings
+  Variables: {
+    db: PostgresJsDatabase
+    eventBus?: EventBus
+  }
+}
+
+const storage = vi.hoisted(() => ({
+  createMediaStorage: vi.fn(),
+}))
+
+vi.mock("./lib/storage", () => ({
+  createMediaStorage: storage.createMediaStorage,
+  guessMimeType: (key: string) => (key.endsWith(".pdf") ? "application/pdf" : "text/plain"),
+}))
+
+describe("operator media upload routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("streams stored media by key", async () => {
+    const app = new Hono<TestRouteEnv>()
+    storage.createMediaStorage.mockReturnValue({
+      get: vi.fn(async () => new TextEncoder().encode("pdf").buffer),
+    })
+    mountOperatorMediaUploadRoutes(app)
+
+    const response = await app.request("/v1/media/brochures/example.pdf")
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("content-type")).toBe("application/pdf")
+    await expect(response.text()).resolves.toBe("pdf")
+  })
+})

--- a/templates/operator/src/api/media-upload-routes.ts
+++ b/templates/operator/src/api/media-upload-routes.ts
@@ -1,0 +1,133 @@
+import type { EventBus } from "@voyantjs/core"
+import {
+  createDefaultProductBrochureTemplate,
+  generateAndStoreProductBrochure,
+} from "@voyantjs/products"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import type { Hono } from "hono"
+import { createProductBrochurePrinter } from "../lib/brochure-printer"
+import { createVideoUploadTicket } from "../lib/video-uploads"
+import { tryGetCloudClient } from "../lib/voyant-cloud"
+import { createMediaStorage, guessMimeType } from "./lib/storage"
+
+const MAX_BROCHURE_PDF_BYTES = 5 * 1024 * 1024
+
+type OperatorMediaUploadRouteEnv = {
+  Bindings: CloudflareBindings
+  Variables: {
+    db: PostgresJsDatabase
+    eventBus?: EventBus
+  }
+}
+
+export function mountOperatorMediaUploadRoutes(hono: Hono<OperatorMediaUploadRouteEnv>): void {
+  hono.post("/v1/admin/products/:id/brochure/generate", async (c) => {
+    const storage = createMediaStorage(c.env)
+    if (!storage) {
+      return c.json({ error: "Storage not configured" }, 503)
+    }
+
+    const productId = c.req.param("id")
+    if (!productId) return c.json({ error: "id route param is required" }, 400)
+
+    const cloud = tryGetCloudClient(c.env)
+    let generated: Awaited<ReturnType<typeof generateAndStoreProductBrochure>>
+    try {
+      generated = await generateAndStoreProductBrochure(c.get("db"), productId, {
+        storage,
+        template: createDefaultProductBrochureTemplate(),
+        ...(cloud ? { printer: createProductBrochurePrinter(c.env) } : {}),
+        keyPrefix: `brochures/products/${productId}`,
+        filename: ({ productId: generatedProductId, filename }) =>
+          `brochure-${generatedProductId}-${Date.now()}-${filename}`,
+        maxSizeBytes: MAX_BROCHURE_PDF_BYTES,
+      })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      if (message.includes("Generated brochure is too large")) {
+        return c.json({ error: message }, 413)
+      }
+      throw err
+    }
+
+    await c.get("eventBus")?.emit("product.content.changed", {
+      id: productId,
+      axis: "media",
+    })
+
+    return c.json({
+      data: generated.brochure,
+      metadata: {
+        filename: generated.filename,
+        sizeBytes: generated.sizeBytes,
+        storageKey: generated.storageKey,
+        url: generated.url,
+      },
+    })
+  })
+
+  hono.post("/v1/uploads", async (c) => {
+    const storage = createMediaStorage(c.env)
+    if (!storage) {
+      return c.json({ error: "Storage not configured" }, 503)
+    }
+
+    const body = await c.req.parseBody()
+    const file = body.file
+    if (!(file instanceof File)) {
+      return c.json({ error: "Missing file field in multipart body" }, 400)
+    }
+
+    const ext = file.name.split(".").pop() ?? "bin"
+    const key = `uploads/${Date.now()}-${crypto.randomUUID().slice(0, 8)}.${ext}`
+
+    const result = await storage.upload(await file.arrayBuffer(), {
+      key,
+      contentType: file.type,
+    })
+
+    return c.json({
+      key: result.key,
+      url: result.url,
+      mimeType: file.type,
+      size: file.size,
+    })
+  })
+
+  hono.post("/v1/uploads/video", async (c) => {
+    const body = await c.req.json<{
+      maxDurationSeconds: number
+      name?: string | null
+      requireSignedUrls?: boolean
+      allowedOrigins?: string[]
+      thumbnailTimestampPct?: number | null
+      meta?: Record<string, string>
+    }>()
+    const ticket = await createVideoUploadTicket(c.env, body)
+    return c.json(ticket)
+  })
+
+  hono.get("/v1/media/*", async (c) => {
+    const storage = createMediaStorage(c.env)
+    if (!storage) {
+      return c.json({ error: "Storage not configured" }, 503)
+    }
+
+    const key = c.req.path.replace("/v1/media/", "")
+    if (!key) {
+      return c.json({ error: "Missing key" }, 400)
+    }
+
+    const buffer = await storage.get(key)
+    if (!buffer) {
+      return c.json({ error: "Not found" }, 404)
+    }
+
+    const headers = new Headers()
+    headers.set("Content-Type", guessMimeType(key))
+    headers.set("Cache-Control", "public, max-age=31536000, immutable")
+    headers.set("Content-Length", String(buffer.byteLength))
+
+    return new Response(buffer, { headers })
+  })
+}


### PR DESCRIPTION
## Summary
- Extract operator contract document generation and private document download routes out of the monolithic API app
- Move contract variable resolution into a dedicated module and lazy-load legal PDF/rendering helpers at generation time
- Extract media upload/brochure/media streaming routes with route-level coverage

## Verification
- pnpm -C templates/operator typecheck
- pnpm -C templates/operator test
- pnpm -C templates/operator lint
- pnpm verify:architecture
- pnpm -C templates/operator measure:startup -- --top 12
- commit hook: repository lint/typecheck
- pre-push hook: repository tests

Note: agent-quality remains report-only and still flags pre-existing double assertions in templates/operator/src/api/app.ts.