### PR TITLE
[codex] add billing party release changeset

### DIFF
--- a/.changeset/quiet-billing-parties.md
+++ b/.changeset/quiet-billing-parties.md
@@ -1,0 +1,12 @@
+---
+"@voyantjs/bookings": patch
+"@voyantjs/bookings-react": patch
+"@voyantjs/bookings-ui": patch
+"@voyantjs/transactions": patch
+"@voyantjs/plugin-smartbill": patch
+"@voyantjs/i18n": patch
+"@voyantjs/availability-ui": patch
+"@voyantjs/extras-ui": patch
+---
+
+Release booking billing party snapshots so existing bookings can store individual or company billing details, including VAT/tax ID, and the billing dialog can prefill from CRM people or organizations.


### PR DESCRIPTION
## Summary

- add a Changesets patch entry for the already-merged billing party snapshot work from PR #1371
- includes the public packages affected by billing snapshots, CRM-prefill UI, SmartBill VAT selection, transaction snapshots, and the i18n literal-check follow-up

## Why

PR #1371 merged after v0.84.2 and did not include a changeset, so the billing contact company/VAT support is on main but not part of the latest release train. This gives Changesets releasable metadata so the next release includes it.

## Validation

- `pnpm exec changeset status --since v0.84.2`
- commit hook: changed agent-quality check, repo lint, repo typecheck
- push hook: repo test suite