### PR TITLE
[codex] Handle proforma conversion number conflicts

### DIFF
--- a/packages/finance/src/routes.ts
+++ b/packages/finance/src/routes.ts
@@ -1183,9 +1183,24 @@ export const financeRoutes = new Hono<Env>()
       }
     })()
 
-    const result = await convertProformaToInvoice(c.get("db"), c.req.param("id"), input, {
-      eventBus: runtime?.eventBus,
-    })
+    let result: Awaited<ReturnType<typeof convertProformaToInvoice>>
+    try {
+      result = await convertProformaToInvoice(c.get("db"), c.req.param("id"), input, {
+        eventBus: runtime?.eventBus,
+      })
+    } catch (error) {
+      if (error instanceof InvoiceNumberConflictError) {
+        return c.json(
+          {
+            error: "Invoice number already exists",
+            code: error.code,
+            invoiceNumber: error.invoiceNumber,
+          },
+          409,
+        )
+      }
+      throw error
+    }
 
     if (result.status === "not_found") {
       return c.json({ error: "Invoice not found" }, 404)

--- a/packages/finance/src/service-issue.ts
+++ b/packages/finance/src/service-issue.ts
@@ -19,6 +19,7 @@ import {
   type FinanceServiceRuntime,
   financeService,
   type InvoiceFromBookingData,
+  InvoiceNumberConflictError,
 } from "./service.js"
 
 /**
@@ -518,91 +519,98 @@ export async function convertProformaToInvoice(
   const dueDate = options.dueDate ?? toDateString(proforma.dueDate)
 
   const now = new Date()
-  const created = await db.transaction(async (tx) => {
-    const [inserted] = await tx
-      .insert(invoices)
-      .values({
-        invoiceNumber: newInvoiceNumber,
-        invoiceType: "invoice",
-        convertedFromInvoiceId: proforma.id,
-        seriesId: proforma.seriesId,
-        templateId: proforma.templateId,
-        taxRegimeId: proforma.taxRegimeId,
-        language: proforma.language,
-        bookingId: proforma.bookingId,
-        personId: proforma.personId,
-        organizationId: proforma.organizationId,
-        status: "issued",
-        currency: proforma.currency,
-        baseCurrency: proforma.baseCurrency,
-        fxRateSetId: proforma.fxRateSetId,
-        subtotalCents: proforma.subtotalCents,
-        baseSubtotalCents: proforma.baseSubtotalCents,
-        taxCents: proforma.taxCents,
-        baseTaxCents: proforma.baseTaxCents,
-        totalCents: proforma.totalCents,
-        baseTotalCents: proforma.baseTotalCents,
-        // Carry the proforma's settled amounts forward — a partially
-        // (or fully) paid proforma must convert to an invoice that
-        // reflects those payments, otherwise the new invoice shows the
-        // full total as outstanding and the payment rows reassigned
-        // below would orphan the balance.
-        paidCents: proforma.paidCents,
-        basePaidCents: proforma.basePaidCents,
-        balanceDueCents: proforma.totalCents - proforma.paidCents,
-        baseBalanceDueCents:
-          proforma.baseTotalCents !== null && proforma.basePaidCents !== null
-            ? proforma.baseTotalCents - proforma.basePaidCents
-            : proforma.baseTotalCents,
-        commissionPercent: proforma.commissionPercent,
-        commissionAmountCents: proforma.commissionAmountCents,
-        issueDate,
-        dueDate,
-        notes: proforma.notes,
-      })
-      .returning()
+  const created = await db
+    .transaction(async (tx) => {
+      const [inserted] = await tx
+        .insert(invoices)
+        .values({
+          invoiceNumber: newInvoiceNumber,
+          invoiceType: "invoice",
+          convertedFromInvoiceId: proforma.id,
+          seriesId: proforma.seriesId,
+          templateId: proforma.templateId,
+          taxRegimeId: proforma.taxRegimeId,
+          language: proforma.language,
+          bookingId: proforma.bookingId,
+          personId: proforma.personId,
+          organizationId: proforma.organizationId,
+          status: "issued",
+          currency: proforma.currency,
+          baseCurrency: proforma.baseCurrency,
+          fxRateSetId: proforma.fxRateSetId,
+          subtotalCents: proforma.subtotalCents,
+          baseSubtotalCents: proforma.baseSubtotalCents,
+          taxCents: proforma.taxCents,
+          baseTaxCents: proforma.baseTaxCents,
+          totalCents: proforma.totalCents,
+          baseTotalCents: proforma.baseTotalCents,
+          // Carry the proforma's settled amounts forward — a partially
+          // (or fully) paid proforma must convert to an invoice that
+          // reflects those payments, otherwise the new invoice shows the
+          // full total as outstanding and the payment rows reassigned
+          // below would orphan the balance.
+          paidCents: proforma.paidCents,
+          basePaidCents: proforma.basePaidCents,
+          balanceDueCents: proforma.totalCents - proforma.paidCents,
+          baseBalanceDueCents:
+            proforma.baseTotalCents !== null && proforma.basePaidCents !== null
+              ? proforma.baseTotalCents - proforma.basePaidCents
+              : proforma.baseTotalCents,
+          commissionPercent: proforma.commissionPercent,
+          commissionAmountCents: proforma.commissionAmountCents,
+          issueDate,
+          dueDate,
+          notes: proforma.notes,
+        })
+        .returning()
 
-    if (!inserted) return null
+      if (!inserted) return null
 
-    if (lineItems.length > 0) {
-      await tx.insert(invoiceLineItems).values(
-        lineItems.map((line) => ({
-          invoiceId: inserted.id,
-          bookingItemId: line.bookingItemId,
-          description: line.description,
-          quantity: line.quantity,
-          unitPriceCents: line.unitPriceCents,
-          totalCents: line.totalCents,
-          taxRate: line.taxRate,
-          sortOrder: line.sortOrder,
-        })),
-      )
-    }
+      if (lineItems.length > 0) {
+        await tx.insert(invoiceLineItems).values(
+          lineItems.map((line) => ({
+            invoiceId: inserted.id,
+            bookingItemId: line.bookingItemId,
+            description: line.description,
+            quantity: line.quantity,
+            unitPriceCents: line.unitPriceCents,
+            totalCents: line.totalCents,
+            taxRate: line.taxRate,
+            sortOrder: line.sortOrder,
+          })),
+        )
+      }
 
-    // Reassign payments off the proforma so they don't sit attached to
-    // a void document. The proforma's payment rows become the final
-    // invoice's payment history.
-    await tx
-      .update(payments)
-      .set({ invoiceId: inserted.id, updatedAt: now })
-      .where(eq(payments.invoiceId, proforma.id))
+      // Reassign payments off the proforma so they don't sit attached to
+      // a void document. The proforma's payment rows become the final
+      // invoice's payment history.
+      await tx
+        .update(payments)
+        .set({ invoiceId: inserted.id, updatedAt: now })
+        .where(eq(payments.invoiceId, proforma.id))
 
-    await tx
-      .update(invoices)
-      .set({
-        status: "void",
-        paidCents: 0,
-        basePaidCents: proforma.basePaidCents == null ? null : 0,
-        balanceDueCents: 0,
-        baseBalanceDueCents: proforma.baseBalanceDueCents == null ? null : 0,
-        voidedAt: now,
-        voidReason: `Converted to invoice ${inserted.invoiceNumber}`,
-        updatedAt: now,
-      })
-      .where(eq(invoices.id, proforma.id))
+      await tx
+        .update(invoices)
+        .set({
+          status: "void",
+          paidCents: 0,
+          basePaidCents: proforma.basePaidCents == null ? null : 0,
+          balanceDueCents: 0,
+          baseBalanceDueCents: proforma.baseBalanceDueCents == null ? null : 0,
+          voidedAt: now,
+          voidReason: `Converted to invoice ${inserted.invoiceNumber}`,
+          updatedAt: now,
+        })
+        .where(eq(invoices.id, proforma.id))
 
-    return inserted
-  })
+      return inserted
+    })
+    .catch((error: unknown) => {
+      if (isInvoiceNumberUniqueConstraintError(error)) {
+        throw new InvoiceNumberConflictError(newInvoiceNumber)
+      }
+      throw error
+    })
 
   if (!created) return { status: "not_found" }
 
@@ -615,6 +623,21 @@ function deriveInvoiceNumberFromProforma(proformaNumber: string): string {
     return proformaNumber.replace(/^PRO-/i, "INV-")
   }
   return `${proformaNumber}-INV`
+}
+
+function isInvoiceNumberUniqueConstraintError(error: unknown) {
+  if (!error || typeof error !== "object") return false
+  const candidate = error as { code?: unknown; constraint?: unknown; detail?: unknown }
+  if (candidate.code !== "23505") return false
+  const constraint = typeof candidate.constraint === "string" ? candidate.constraint : ""
+  const detail = typeof candidate.detail === "string" ? candidate.detail : ""
+  return (
+    constraint === "invoices_invoice_number_type_active_idx" ||
+    constraint === "invoices_invoice_number_type_unique" ||
+    constraint === "invoices_invoice_number_unique" ||
+    constraint === "invoices_invoice_number_key" ||
+    detail.includes("invoice_number")
+  )
 }
 
 function buildClientName(booking: typeof bookings.$inferSelect | undefined): string {

--- a/packages/finance/tests/integration/routes.test.ts
+++ b/packages/finance/tests/integration/routes.test.ts
@@ -1389,6 +1389,44 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       })
     })
 
+    it("returns a conflict when conversion would reuse an active invoice number", async () => {
+      const booking = await seedBooking()
+      await seedInvoice(booking.id, {
+        invoiceNumber: "INV-CONVERT-DUP",
+        invoiceType: "invoice",
+        status: "issued",
+      })
+      const proforma = await seedInvoice(booking.id, {
+        invoiceNumber: "PRO-CONVERT-DUP",
+        invoiceType: "proforma",
+        status: "issued",
+      })
+      invoiceIssuedEvents.length = 0
+
+      const res = await app.request(`/invoices/${proforma.id}/convert-to-invoice`, {
+        method: "POST",
+        ...json({ invoiceNumber: "INV-CONVERT-DUP" }),
+      })
+
+      expect(res.status).toBe(409)
+      await expect(res.json()).resolves.toMatchObject({
+        code: "invoice_number_conflict",
+        invoiceNumber: "INV-CONVERT-DUP",
+      })
+      const refreshedProforma = await financeService.getInvoiceById(db, proforma.id)
+      expect(refreshedProforma).toMatchObject({
+        status: "issued",
+        voidedAt: null,
+        voidReason: null,
+      })
+      expect(invoiceIssuedEvents).toHaveLength(0)
+      const converted = await db
+        .select({ id: invoices.id })
+        .from(invoices)
+        .where(eq(invoices.convertedFromInvoiceId, proforma.id))
+      expect(converted).toHaveLength(0)
+    })
+
     it("rejects new payments on converted void proformas with redirect details", async () => {
       const booking = await seedBooking()
       const proforma = await seedInvoice(booking.id, {


### PR DESCRIPTION
## Summary

Fixes the Pro Travel admin 500 that occurred when converting a proforma while reusing an active final invoice number.

## Root Cause

Max sent `invoiceNumber: B-0137` while converting proforma `B-0137`. A final invoice with `B-0137` already existed, so Postgres raised the active invoice-number unique constraint. The conversion route did not map that DB error and returned a generic 500.

## Changes

- Wrap proforma conversion inserts so invoice-number unique violations become `InvoiceNumberConflictError`.
- Return `409 invoice_number_conflict` from `POST /invoices/:id/convert-to-invoice` instead of 500.
- Add an integration regression test proving the proforma remains issued and no converted invoice is created when the final number conflicts.

## Validation

- `pnpm --filter @voyantjs/finance test -- packages/finance/tests/integration/routes.test.ts`
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm --filter @voyantjs/finance lint`
- Pre-commit full lint/typecheck completed during commit.
- Pre-push full test suite completed during push.