### PR TITLE
Add proforma conversion conflict changeset

### DIFF
--- a/.changeset/proforma-conversion-conflicts.md
+++ b/.changeset/proforma-conversion-conflicts.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/finance": patch
+---
+
+Return a structured conflict response when proforma conversion attempts to reuse an active final invoice number, preserving the original proforma instead of surfacing a generic server error.


### PR DESCRIPTION
## Summary

Adds the missing patch changeset for the proforma conversion conflict fix merged in #1381.

## Validation

- `pnpm changeset status --since v0.84.3`
- Commit hook ran changed-file quality checks plus full typecheck successfully.
- Pre-push hook ran the repository test suite successfully.