### PR TITLE
[codex] Extract catalog booking runtime

### DIFF
--- a/templates/operator/src/api/catalog-booking-runtime.ts
+++ b/templates/operator/src/api/catalog-booking-runtime.ts
@@ -1,0 +1,173 @@
+import {
+  type CatalogBookingRoutesOptions,
+  catalogQuotesTable,
+  OWNED_SOURCE_KIND,
+  type QuoteEntityResult,
+} from "@voyantjs/catalog/booking-engine"
+import type { AnyDrizzleDb } from "@voyantjs/db"
+import { computeBookingItemTaxLine, resolveBookingSellTaxRate } from "@voyantjs/finance"
+import { products } from "@voyantjs/products"
+import { createCatalogPromotionEvaluator } from "@voyantjs/promotions/service-catalog-evaluator"
+import { suppliers } from "@voyantjs/suppliers"
+import { eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import type { Context } from "hono"
+import {
+  getBookingEngineRegistryFromContext,
+  getOwnedBookingHandlerRegistryFromContext,
+} from "./lib/booking-engine-runtime"
+import { resolveBookingTaxSettings } from "./settings"
+
+const DEFAULT_HOLD_TTL_MS = 30 * 60 * 1000
+
+export function getCatalogBookingDb(c: Context): AnyDrizzleDb {
+  return (c.var as { db: AnyDrizzleDb }).db
+}
+
+export function createOperatorCatalogBookingRoutesOptions(): CatalogBookingRoutesOptions {
+  return {
+    resolveDb: getCatalogBookingDb,
+    resolveSourceRegistry: getBookingEngineRegistryFromContext,
+    resolveOwnedHandlers: getOwnedBookingHandlerRegistryFromContext,
+    resolveHoldTtlMs: ({ db, entityModule, entityId }) =>
+      resolveHoldTtlMs(db, entityModule, entityId),
+    // Promotions hook wires the per-request db into the evaluator. When
+    // the customer-supplied promotion code fails validation, quoteEntity
+    // surfaces a code_* invalidReason and tax recompute below sees no
+    // discount on base_amount.
+    resolveEvaluatePromotions: ({ db }) => createCatalogPromotionEvaluator(db),
+    transformQuoteResult: ({ db, result, request, provenance }) =>
+      applyOperatorTaxToQuoteResult(
+        db,
+        result,
+        request.entityModule,
+        request.entityId,
+        provenance.sourceKind,
+      ),
+    onDraftConsumedError: ({ error }) => {
+      console.warn("[catalog-booking] markDraftConsumed failed:", error)
+    },
+  }
+}
+
+function positiveMinutes(value: number | null | undefined) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : null
+}
+
+async function resolveHoldTtlMs(
+  db: AnyDrizzleDb,
+  entityModule: string,
+  entityId: string,
+): Promise<number> {
+  if (entityModule !== "products") {
+    return DEFAULT_HOLD_TTL_MS
+  }
+
+  const [product] = await db
+    .select({
+      supplierId: products.supplierId,
+      reservationTimeoutMinutes: products.reservationTimeoutMinutes,
+    })
+    .from(products)
+    .where(eq(products.id, entityId))
+    .limit(1)
+
+  const productMinutes = positiveMinutes(product?.reservationTimeoutMinutes)
+  if (productMinutes !== null) {
+    return productMinutes * 60 * 1000
+  }
+
+  if (!product?.supplierId) {
+    return DEFAULT_HOLD_TTL_MS
+  }
+
+  const [supplier] = await db
+    .select({ reservationTimeoutMinutes: suppliers.reservationTimeoutMinutes })
+    .from(suppliers)
+    .where(eq(suppliers.id, product.supplierId))
+    .limit(1)
+
+  return (positiveMinutes(supplier?.reservationTimeoutMinutes) ?? 30) * 60 * 1000
+}
+
+export async function applyOperatorTaxToQuoteResult(
+  db: AnyDrizzleDb,
+  result: QuoteEntityResult,
+  entityModule: string,
+  entityId: string,
+  sourceKind: string,
+): Promise<QuoteEntityResult> {
+  if (!result.available || !result.pricing) return result
+  // When promotional offers were applied at quote time, quoteEntity
+  // clears taxes + breakdown because the upstream values were computed
+  // against the un-discounted base. Recompute taxes here even for owned
+  // quotes so discounted customer-facing totals remain correct.
+  const hasAppliedOffers = (result.pricing.appliedOffers?.length ?? 0) > 0
+  if (sourceKind === OWNED_SOURCE_KIND && !hasAppliedOffers) return result
+  if (result.pricing.taxes > 0 && !hasAppliedOffers) return result
+
+  const pricing = result.pricing
+  const taxableCents = pricing.base_amount
+  const taxRate = await resolveBookingSellTaxRate(
+    db as PostgresJsDatabase,
+    {
+      productId: entityModule === "products" ? entityId : null,
+      facts: { hasAccommodation: false, accommodationCountries: [] },
+    },
+    {
+      resolveBookingTaxSettings,
+    },
+  )
+  const taxLine = computeBookingItemTaxLine(taxRate, taxableCents, pricing.currency)
+  if (!taxLine) return result
+
+  const inclusive = taxLine.includedInPrice
+  const subtotal = inclusive ? Math.max(0, taxableCents - taxLine.amountCents) : taxableCents
+  const total = inclusive ? taxableCents : taxableCents + taxLine.amountCents
+  const adjustedPricing = {
+    ...pricing,
+    base_amount: subtotal,
+    taxes: taxLine.amountCents,
+    breakdown: {
+      currency: pricing.currency,
+      lines: [
+        {
+          kind: "base",
+          label: "Base",
+          quantity: 1,
+          unitAmount: taxableCents,
+          totalAmount: taxableCents,
+          taxIncluded: inclusive,
+        },
+      ],
+      taxes: [
+        {
+          code: taxLine.code ?? "tax",
+          label: taxLine.name,
+          rate: (taxLine.rateBasisPoints ?? 0) / 10_000,
+          amount: taxLine.amountCents,
+          base: subtotal,
+          includedInPrice: inclusive,
+          scope: taxLine.scope,
+        },
+      ],
+      subtotal,
+      taxTotal: taxLine.amountCents,
+      total,
+    },
+  }
+
+  await (db as PostgresJsDatabase)
+    .update(catalogQuotesTable)
+    .set({
+      pricing_base_amount: String(adjustedPricing.base_amount),
+      pricing_taxes: String(adjustedPricing.taxes),
+      pricing_fees: String(adjustedPricing.fees),
+      pricing_surcharges: String(adjustedPricing.surcharges),
+      pricing_currency: adjustedPricing.currency,
+      pricing_breakdown: adjustedPricing.breakdown,
+    })
+    .where(eq(catalogQuotesTable.id, result.quoteId))
+
+  return { ...result, pricing: adjustedPricing }
+}

--- a/templates/operator/src/api/catalog-booking.ts
+++ b/templates/operator/src/api/catalog-booking.ts
@@ -30,9 +30,7 @@
 import { availabilitySlots } from "@voyantjs/availability/schema"
 import {
   BookingEngineError,
-  type CatalogBookingRoutesOptions,
   cancelEntity,
-  catalogQuotesTable,
   createCatalogBookingRoutes,
   getOrderById,
   listOrders,
@@ -40,34 +38,26 @@ import {
   NO_HANDLER_REGISTERED,
   ORDER_ALREADY_CANCELLED,
   ORDER_NOT_FOUND,
-  OWNED_SOURCE_KIND,
   QUOTE_EXPIRED,
   QUOTE_MISMATCH,
   QUOTE_NOT_FOUND,
-  type QuoteEntityResult,
   RESERVE_FAILED,
 } from "@voyantjs/catalog/booking-engine"
 import { readSourcedEntry } from "@voyantjs/catalog/services/sourced-entry"
 import type { AnyDrizzleDb } from "@voyantjs/db"
-import { computeBookingItemTaxLine, resolveBookingSellTaxRate } from "@voyantjs/finance"
-import { products } from "@voyantjs/products"
 import { getProductContent } from "@voyantjs/products/service-content"
-import { createCatalogPromotionEvaluator } from "@voyantjs/promotions/service-catalog-evaluator"
-import { suppliers } from "@voyantjs/suppliers"
 import { and, asc, eq, gte } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context, Hono } from "hono"
 
 import {
-  getBookingEngineRegistryFromContext,
-  getOwnedBookingHandlerRegistryFromContext,
-} from "./lib/booking-engine-runtime"
-import { resolveBookingTaxSettings } from "./settings"
-
-const DEFAULT_HOLD_TTL_MS = 30 * 60 * 1000
+  createOperatorCatalogBookingRoutesOptions,
+  getCatalogBookingDb,
+} from "./catalog-booking-runtime"
+import { getBookingEngineRegistryFromContext } from "./lib/booking-engine-runtime"
 
 function getDb(c: Context): AnyDrizzleDb {
-  return (c.var as { db: AnyDrizzleDb }).db
+  return getCatalogBookingDb(c)
 }
 
 interface CancelBody {
@@ -99,33 +89,6 @@ export function mountCatalogBookingRoutes(hono: Hono): void {
   // captured content payload so operators can see exactly what the
   // customer was quoted at booking time.
   hono.get("/v1/admin/bookings/:id/catalog-snapshot", handleGetBookingSnapshot)
-}
-
-export function createOperatorCatalogBookingRoutesOptions(): CatalogBookingRoutesOptions {
-  return {
-    resolveDb: getDb,
-    resolveSourceRegistry: getBookingEngineRegistryFromContext,
-    resolveOwnedHandlers: getOwnedBookingHandlerRegistryFromContext,
-    resolveHoldTtlMs: ({ db, entityModule, entityId }) =>
-      resolveHoldTtlMs(db, entityModule, entityId),
-    // Promotions hook — wires the per-request `db` into the
-    // evaluator. When the customer-supplied promotion code fails
-    // validation, quoteEntity surfaces a `code_*` invalidReason
-    // and tax recompute below sees no discount on `base_amount`.
-    // Per docs/architecture/promotions-architecture.md §3.6.
-    resolveEvaluatePromotions: ({ db }) => createCatalogPromotionEvaluator(db),
-    transformQuoteResult: ({ db, result, request, provenance }) =>
-      applyOperatorTaxToQuoteResult(
-        db,
-        result,
-        request.entityModule,
-        request.entityId,
-        provenance.sourceKind,
-      ),
-    onDraftConsumedError: ({ error }) => {
-      console.warn("[catalog-booking] markDraftConsumed failed:", error)
-    },
-  }
 }
 
 // ─────────────────────────────────────────────────────────────────
@@ -209,7 +172,7 @@ async function handleListSlots(c: Context): Promise<Response> {
     return c.json({ rows: [] })
   }
 
-  const db = (c.var as { db: AnyDrizzleDb }).db as PostgresJsDatabase
+  const db = getDb(c) as PostgresJsDatabase
 
   // Sourced products carry their schedule in the sourced-content
   // payload — the upstream's `getContent` is the source of truth, not
@@ -282,46 +245,6 @@ async function handleListSlots(c: Context): Promise<Response> {
   return c.json({ rows })
 }
 
-function positiveMinutes(value: number | null | undefined) {
-  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : null
-}
-
-async function resolveHoldTtlMs(
-  db: AnyDrizzleDb,
-  entityModule: string,
-  entityId: string,
-): Promise<number> {
-  if (entityModule !== "products") {
-    return DEFAULT_HOLD_TTL_MS
-  }
-
-  const [product] = await db
-    .select({
-      supplierId: products.supplierId,
-      reservationTimeoutMinutes: products.reservationTimeoutMinutes,
-    })
-    .from(products)
-    .where(eq(products.id, entityId))
-    .limit(1)
-
-  const productMinutes = positiveMinutes(product?.reservationTimeoutMinutes)
-  if (productMinutes !== null) {
-    return productMinutes * 60 * 1000
-  }
-
-  if (!product?.supplierId) {
-    return DEFAULT_HOLD_TTL_MS
-  }
-
-  const [supplier] = await db
-    .select({ reservationTimeoutMinutes: suppliers.reservationTimeoutMinutes })
-    .from(suppliers)
-    .where(eq(suppliers.id, product.supplierId))
-    .limit(1)
-
-  return (positiveMinutes(supplier?.reservationTimeoutMinutes) ?? 30) * 60 * 1000
-}
-
 // ─────────────────────────────────────────────────────────────────
 // Helpers
 // ─────────────────────────────────────────────────────────────────
@@ -361,92 +284,6 @@ function cryptoRandom(): string {
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
 }
 
-export async function applyOperatorTaxToQuoteResult(
-  db: AnyDrizzleDb,
-  result: QuoteEntityResult,
-  entityModule: string,
-  entityId: string,
-  sourceKind: string,
-): Promise<QuoteEntityResult> {
-  if (!result.available || !result.pricing) return result
-  // When promotional offers were applied at quote time, `quoteEntity`
-  // clears `taxes` + `breakdown` because the upstream values were
-  // computed against the un-discounted base (per
-  // docs/architecture/promotions-architecture.md §7.1). In that case
-  // we MUST recompute taxes here even for owned quotes — the owned
-  // handler's pre-discount breakdown is stale. Without this branch the
-  // owned discounted quote would round-trip with `taxes: 0` and a
-  // missing breakdown, mis-displaying the customer-facing total.
-  const hasAppliedOffers = (result.pricing.appliedOffers?.length ?? 0) > 0
-  if (sourceKind === OWNED_SOURCE_KIND && !hasAppliedOffers) return result
-  if (result.pricing.taxes > 0 && !hasAppliedOffers) return result
-
-  const pricing = result.pricing
-  const taxableCents = pricing.base_amount
-  const taxRate = await resolveBookingSellTaxRate(
-    db as PostgresJsDatabase,
-    {
-      productId: entityModule === "products" ? entityId : null,
-      facts: { hasAccommodation: false, accommodationCountries: [] },
-    },
-    {
-      resolveBookingTaxSettings,
-    },
-  )
-  const taxLine = computeBookingItemTaxLine(taxRate, taxableCents, pricing.currency)
-  if (!taxLine) return result
-
-  const inclusive = taxLine.includedInPrice
-  const subtotal = inclusive ? Math.max(0, taxableCents - taxLine.amountCents) : taxableCents
-  const total = inclusive ? taxableCents : taxableCents + taxLine.amountCents
-  const adjustedPricing = {
-    ...pricing,
-    base_amount: subtotal,
-    taxes: taxLine.amountCents,
-    breakdown: {
-      currency: pricing.currency,
-      lines: [
-        {
-          kind: "base",
-          label: "Base",
-          quantity: 1,
-          unitAmount: taxableCents,
-          totalAmount: taxableCents,
-          taxIncluded: inclusive,
-        },
-      ],
-      taxes: [
-        {
-          code: taxLine.code ?? "tax",
-          label: taxLine.name,
-          rate: (taxLine.rateBasisPoints ?? 0) / 10_000,
-          amount: taxLine.amountCents,
-          base: subtotal,
-          includedInPrice: inclusive,
-          scope: taxLine.scope,
-        },
-      ],
-      subtotal,
-      taxTotal: taxLine.amountCents,
-      total,
-    },
-  }
-
-  await (db as PostgresJsDatabase)
-    .update(catalogQuotesTable)
-    .set({
-      pricing_base_amount: String(adjustedPricing.base_amount),
-      pricing_taxes: String(adjustedPricing.taxes),
-      pricing_fees: String(adjustedPricing.fees),
-      pricing_surcharges: String(adjustedPricing.surcharges),
-      pricing_currency: adjustedPricing.currency,
-      pricing_breakdown: adjustedPricing.breakdown,
-    })
-    .where(eq(catalogQuotesTable.id, result.quoteId))
-
-  return { ...result, pricing: adjustedPricing }
-}
-
 /**
  * GET /v1/admin/bookings/:id/catalog-snapshot
  *
@@ -471,7 +308,7 @@ export async function applyOperatorTaxToQuoteResult(
 async function handleGetBookingSnapshot(c: Context): Promise<Response> {
   const bookingId = c.req.param("id")
   if (!bookingId) return c.json({ error: "id is required" }, 400)
-  const db = getDb(c)
+  const db = getDb(c) as PostgresJsDatabase
 
   const { bookingCatalogSnapshotTable } = await import("@voyantjs/catalog")
   const [snapshot] = await db
@@ -484,7 +321,7 @@ async function handleGetBookingSnapshot(c: Context): Promise<Response> {
     return c.json({ error: "snapshot_not_found" }, 404)
   }
 
-  const resolved = await resolveSnapshotForAdmin(db as unknown as PostgresJsDatabase, {
+  const resolved = await resolveSnapshotForAdmin(db, {
     entity_module: snapshot.entity_module,
     entity_id: snapshot.entity_id,
     source_kind: snapshot.source_kind,

--- a/templates/operator/src/api/travel-composer-runtime.ts
+++ b/templates/operator/src/api/travel-composer-runtime.ts
@@ -55,7 +55,7 @@ import {
 } from "@voyantjs/travel-composer"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
-import { applyOperatorTaxToQuoteResult } from "./catalog-booking"
+import { applyOperatorTaxToQuoteResult } from "./catalog-booking-runtime"
 import {
   CatalogCheckoutStartError,
   type CatalogCheckoutStartResult,
@@ -86,7 +86,7 @@ export const travelComposerPaymentBundle: HonoBundle = {
 
       try {
         await withDbFromEnv(env, async (rawDb) => {
-          const db = rawDb as unknown as PostgresJsDatabase
+          const db = rawDb as PostgresJsDatabase
           await travelComposerService.completeTripCheckout(db, {
             envelopeId: data.targetId ?? undefined,
             paymentSessionId: data.paymentSessionId,
@@ -477,7 +477,7 @@ async function startTripCheckout(
   c: Context,
   input: TripCheckoutInput,
 ): Promise<TripCheckoutResult> {
-  const db = getDb(c) as unknown as Parameters<typeof financeService.createPaymentSession>[0]
+  const db = getDb(c) as Parameters<typeof financeService.createPaymentSession>[0]
   const pricing = await checkoutPricingForTrip(c, input.trip, input.request)
   if (pricing.totalAmountCents <= 0) {
     throw new Error("trip_checkout_total_required")


### PR DESCRIPTION
## Summary
- Moves catalog booking runtime/options behavior into `catalog-booking-runtime.ts`.
- Keeps `catalog-booking.ts` focused on Hono route mounting, order handlers, slots, and snapshot admin response shaping.
- Updates travel composer to import the shared quote tax transform from the runtime module instead of from the route module.
- Removes two double assertions from `travel-composer-runtime.ts` while touching its import.

## Why
This continues issue #1358 cleanup by deepening the catalog booking module seam. The quote/tax transform and booking-engine route options are runtime behavior used by more than one caller; keeping them in the route file made `travel-composer-runtime.ts` depend on a Hono route module just to reuse quote behavior.

## Validation
- `pnpm -C templates/operator exec biome check --write src/api/catalog-booking.ts src/api/catalog-booking-runtime.ts src/api/travel-composer-runtime.ts`
- `pnpm -C templates/operator typecheck`
- `pnpm -C templates/operator lint`
- `pnpm -C templates/operator test`
- `pnpm verify:architecture`
- `pnpm -C templates/operator measure:startup -- --top 12` (wall 270.82ms; sampled 264.77ms; top self-time is runtime idle)
- commit hook affected lint/typecheck: 126 successful tasks
- pre-push test lane: 127 successful tasks

## Notes
- `node scripts/check-agent-code-quality.mjs --changed --report-only` reports one existing file-size finding for `travel-composer-runtime.ts` now that this PR changes its import line. That file is the next sensible extraction target.