### PR TITLE
Align cruise adapter contract for Connect

### DIFF
--- a/.changeset/cruise-connect-adapter-contract.md
+++ b/.changeset/cruise-connect-adapter-contract.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/cruises": minor
+---
+
+Align the external cruise adapter contract for Connect-backed inventory by preserving full SourceRef route keys, passenger composition, external pricing terms, and booking snapshots.

--- a/docs/architecture/cruises-module.md
+++ b/docs/architecture/cruises-module.md
@@ -612,12 +612,30 @@ export interface CruiseAdapter {
 
   // Booking commit — used when creating a booking against an external cruise.
   // Returns the upstream confirmation reference plus a fully-resolved snapshot to store
-  // in booking_cruise_details.quotedComponentsJson + connectorBookingRef.
+  // in booking_cruise_details quote, terms, passenger-composition, and connector fields.
   createBooking(input: CreateExternalBookingInput): Promise<ExternalBookingResult>
 }
 
 export type SourceRef = { connectionId?: string; externalId: string; [k: string]: unknown }
 ```
+
+`SourceRef` is round-trippable adapter state, not a display id. Connect-backed
+refs should preserve connection id, provider/source key, upstream cruise,
+sailing, ship, cabin ids, synced-row ids, and opaque metadata needed by the
+adapter. Admin route keys and catalog shim entity ids use the URL-safe
+`encodeSourceRef(...)` form (`<provider>:sr_<base64url-json>`) so punctuation
+and adapter metadata are not reconstructed from a lossy slug.
+
+Connect compatibility decisions live next to the adapter contract in
+`packages/cruises/src/adapters/connect-compat.ts`:
+
+| Connect concern | Framework mapping |
+|---|---|
+| cruise type | `ocean`, `river`, `expedition`, `coastal` map directly; `yacht`, `rail`, and `tour` are rejected for products/other vertical routing |
+| cabin room type | direct matches stay direct; `studio` maps to `single`; `villa`/unknown suite-like categories map to `suite` |
+| inclusion kind | cruise inclusions that affect quote display map to price components; flight inclusions map to `airfare` and still require flight-line orchestration when sold as a separate booking |
+| enrichment kind | Connect `domain_expert` maps to framework `expert` |
+| price components | taxes, port charges, gratuities, NCF, airfare, transfers, insurance, onboard credit, single supplements, and residual `other` components are preserved with `addition` / `inclusion` / `credit` direction |
 
 Two registration points in a template:
 
@@ -674,6 +692,8 @@ A cruise booking is a booking. The bookings module already has the right shape (
 | `quotedPricePerPerson` | numeric(12,2) not null | snapshot at booking time |
 | `quotedCurrency` | char(3) not null | |
 | `quotedComponentsJson` | jsonb | full components array snapshotted at booking time — survives later promo edits |
+| `bookingTermsSnapshotJson` | jsonb | structured cancellation/payment terms shown at quote or commit time |
+| `passengerCompositionSnapshotJson` | jsonb | adapter-bound passenger composition (`adults`, `children`, ages, infants, etc.) |
 | `connectorBookingRef` | text | line's confirmation number, if booking goes through |
 | `connectorStatus` | text | line-side status |
 | `notes` | text | |

--- a/packages/cruises/src/adapters/connect-compat.ts
+++ b/packages/cruises/src/adapters/connect-compat.ts
@@ -1,0 +1,142 @@
+import type { ExternalCabinCategory, ExternalCruise, ExternalPriceComponent } from "./index.js"
+
+export type ConnectCruiseType =
+  | "ocean"
+  | "river"
+  | "expedition"
+  | "coastal"
+  | "yacht"
+  | "rail"
+  | "tour"
+
+export type ConnectCabinRoomType =
+  | "inside"
+  | "oceanview"
+  | "balcony"
+  | "suite"
+  | "penthouse"
+  | "single"
+  | "studio"
+  | "villa"
+  | "unknown"
+
+export type ConnectInclusionKind =
+  | "meals"
+  | "drinks"
+  | "gratuities"
+  | "transfers"
+  | "excursions"
+  | "wifi"
+  | "flight"
+  | "insurance"
+  | "other"
+
+export type ConnectEnrichmentKind =
+  | "naturalist"
+  | "historian"
+  | "photographer"
+  | "lecturer"
+  | "domain_expert"
+  | "other"
+
+export type ConnectPriceComponentKind =
+  | "tax"
+  | "port_charge"
+  | "gratuity"
+  | "non_commissionable_fare"
+  | "onboard_credit"
+  | "airfare"
+  | "transfer"
+  | "insurance"
+  | "single_supplement"
+  | "other"
+
+export type CompatibilityMappingResult<T> =
+  | { status: "mapped"; value: T }
+  | { status: "reject"; reason: string; rerouteTo?: string }
+
+export function mapConnectCruiseType(
+  value: ConnectCruiseType,
+): CompatibilityMappingResult<ExternalCruise["cruiseType"]> {
+  if (value === "ocean" || value === "river" || value === "expedition" || value === "coastal") {
+    return { status: "mapped", value }
+  }
+  if (value === "yacht") {
+    return {
+      status: "reject",
+      reason: "Yacht-style per-suite products do not fit the cruises occupancy grid.",
+      rerouteTo: "products",
+    }
+  }
+  return {
+    status: "reject",
+    reason: `${value} is not a cruise vertical product type.`,
+    rerouteTo: "products",
+  }
+}
+
+export function mapConnectCabinRoomType(
+  value: ConnectCabinRoomType,
+): CompatibilityMappingResult<ExternalCabinCategory["roomType"]> {
+  if (
+    value === "inside" ||
+    value === "oceanview" ||
+    value === "balcony" ||
+    value === "suite" ||
+    value === "penthouse" ||
+    value === "single"
+  ) {
+    return { status: "mapped", value }
+  }
+  if (value === "studio") return { status: "mapped", value: "single" }
+  if (value === "villa") return { status: "mapped", value: "suite" }
+  return { status: "mapped", value: "suite" }
+}
+
+export function mapConnectInclusionKind(
+  value: ConnectInclusionKind,
+): CompatibilityMappingResult<ExternalPriceComponent["kind"]> {
+  if (value === "flight") return { status: "mapped", value: "airfare" }
+  if (value === "gratuities") return { status: "mapped", value: "gratuity" }
+  if (value === "transfers") return { status: "mapped", value: "transfer" }
+  if (value === "insurance") return { status: "mapped", value: "insurance" }
+  if (value === "other") return { status: "mapped", value: "other" }
+  return { status: "mapped", value: "other" }
+}
+
+export function mapConnectEnrichmentKind(
+  value: ConnectEnrichmentKind,
+): CompatibilityMappingResult<
+  "naturalist" | "historian" | "photographer" | "lecturer" | "expert" | "other"
+> {
+  if (
+    value === "naturalist" ||
+    value === "historian" ||
+    value === "photographer" ||
+    value === "lecturer" ||
+    value === "other"
+  ) {
+    return { status: "mapped", value }
+  }
+  return { status: "mapped", value: "expert" }
+}
+
+export function mapConnectPriceComponentKind(
+  value: ConnectPriceComponentKind,
+): CompatibilityMappingResult<ExternalPriceComponent["kind"]> {
+  if (value === "non_commissionable_fare") return { status: "mapped", value: "ncf" }
+  if (
+    value === "tax" ||
+    value === "port_charge" ||
+    value === "gratuity" ||
+    value === "onboard_credit" ||
+    value === "airfare" ||
+    value === "transfer" ||
+    value === "insurance" ||
+    value === "single_supplement" ||
+    value === "other"
+  ) {
+    return { status: "mapped", value }
+  }
+  return { status: "mapped", value: "other" }
+}

--- a/packages/cruises/src/adapters/index.ts
+++ b/packages/cruises/src/adapters/index.ts
@@ -11,7 +11,7 @@
  * implementation instead. See docs/architecture/cruises-module.md §10.
  */
 
-import type { Quote, QuoteComponent } from "../service-pricing.js"
+import type { Quote, QuoteBookingTerms, QuoteComponent } from "../service-pricing.js"
 
 // ---------- pointers + provenance ----------
 
@@ -25,6 +25,17 @@ export type SourceRef = {
   externalId: string
   [key: string]: unknown
 }
+
+export type ExternalPassengerComposition = {
+  adults: number
+  children?: number
+  childAges?: number[]
+  infants?: number
+  seniors?: number
+  [key: string]: unknown
+}
+
+export type ExternalBookingTerms = QuoteBookingTerms
 
 // ---------- canonical external shapes ----------
 // These mirror the local cruises schema fields the UI renders. Adapters return
@@ -115,6 +126,7 @@ export type ExternalPriceRow = {
   sourceRef?: SourceRef
   cabinCategoryRef: SourceRef
   occupancy: number
+  passengerComposition?: ExternalPassengerComposition | null
   fareCode?: string | null
   fareCodeName?: string | null
   currency: string
@@ -127,6 +139,7 @@ export type ExternalPriceRow = {
   requiresRequest?: boolean
   notes?: string | null
   components?: ExternalPriceComponent[]
+  bookingTerms?: ExternalBookingTerms | null
 }
 
 export type ExternalPriceComponent = {
@@ -139,6 +152,8 @@ export type ExternalPriceComponent = {
     | "airfare"
     | "transfer"
     | "insurance"
+    | "single_supplement"
+    | "other"
   label?: string | null
   amount: string
   currency: string
@@ -238,9 +253,11 @@ export type CreateExternalBookingInput = {
   sailingRef: SourceRef
   cabinCategoryRef: SourceRef
   occupancy: number
+  passengerComposition?: ExternalPassengerComposition | null
   fareCode?: string | null
   passengers: ExternalPassengerInput[]
   contact: ExternalContactInput
+  bookingTerms?: ExternalBookingTerms | null
   notes?: string | null
 }
 
@@ -254,6 +271,8 @@ export type ExternalBookingResult = {
   finalQuote?: Quote
   /** Optional snapshot components to override the locally-composed list. */
   finalComponents?: QuoteComponent[]
+  /** Commercial terms confirmed by the upstream at commit time. */
+  finalBookingTerms?: ExternalBookingTerms | null
 }
 
 // ---------- the contract itself ----------
@@ -300,6 +319,20 @@ export interface CruiseAdapter {
 export type AdapterCallContext = { adapterName: string; method: string }
 
 // ---------- catalog SourceAdapter shim ----------
+
+export {
+  type CompatibilityMappingResult,
+  type ConnectCabinRoomType,
+  type ConnectCruiseType,
+  type ConnectEnrichmentKind,
+  type ConnectInclusionKind,
+  type ConnectPriceComponentKind,
+  mapConnectCabinRoomType,
+  mapConnectCruiseType,
+  mapConnectEnrichmentKind,
+  mapConnectInclusionKind,
+  mapConnectPriceComponentKind,
+} from "./connect-compat.js"
 
 export {
   type CruiseSourceAdapterShim,

--- a/packages/cruises/src/adapters/memoize.ts
+++ b/packages/cruises/src/adapters/memoize.ts
@@ -75,9 +75,17 @@ class TTLCache<K, V> {
 }
 
 function refKey(ref: SourceRef): string {
-  // Stable serialization for cache lookup. Preserves connectionId + externalId
-  // and any extra adapter-specific fields.
-  return JSON.stringify(ref, Object.keys(ref).sort())
+  return JSON.stringify(sortValue(ref))
+}
+
+function sortValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortValue)
+  if (!value || typeof value !== "object") return value
+  const out: Record<string, unknown> = {}
+  for (const key of Object.keys(value).sort()) {
+    out[key] = sortValue((value as Record<string, unknown>)[key])
+  }
+  return out
 }
 
 export function memoizeCruiseAdapter(

--- a/packages/cruises/src/adapters/mock.ts
+++ b/packages/cruises/src/adapters/mock.ts
@@ -38,7 +38,17 @@ type SeededCruise = {
 }
 
 function refKey(ref: SourceRef): string {
-  return `${ref.connectionId ?? "_"}|${ref.externalId}`
+  return JSON.stringify(sortValue(ref))
+}
+
+function sortValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortValue)
+  if (!value || typeof value !== "object") return value
+  const out: Record<string, unknown> = {}
+  for (const key of Object.keys(value).sort()) {
+    out[key] = sortValue((value as Record<string, unknown>)[key])
+  }
+  return out
 }
 
 export class MockCruiseAdapter implements CruiseAdapter {

--- a/packages/cruises/src/adapters/source-adapter-shim.ts
+++ b/packages/cruises/src/adapters/source-adapter-shim.ts
@@ -43,6 +43,7 @@ import type {
 import type { Provenance } from "@voyantjs/catalog/provenance"
 
 import { CRUISES_CONTENT_SCHEMA_VERSION, type CruiseContent } from "../content-shape.js"
+import { decodeSourceRef, encodeSourceRef } from "../lib/key.js"
 
 import type {
   CruiseAdapter,
@@ -242,7 +243,7 @@ export function cruiseAdapterToSourceAdapter(
       return {
         entity_module: "cruises",
         entity_id: request.entity_id,
-        source_ref: cruise.sourceRef.externalId,
+        source_ref: encodeSourceRef(cruise.sourceRef),
         returned_locale: request.locale,
         content,
         content_schema_version: CRUISES_CONTENT_SCHEMA_VERSION,
@@ -384,9 +385,12 @@ function toCatalogProjection(
 ): CatalogProjection {
   const provenance: Provenance = {
     source_kind: sourceKind,
-    source_provider: entry.sourceRef.connectionId,
+    source_provider:
+      typeof entry.sourceRef.provider === "string"
+        ? entry.sourceRef.provider
+        : entry.sourceRef.connectionId,
     source_connection_id: entry.sourceRef.connectionId,
-    source_ref: entry.sourceRef.externalId,
+    source_ref: encodeSourceRef(entry.sourceRef),
     source_freshness: "sync",
     last_sourced_at: new Date(),
   }
@@ -440,32 +444,22 @@ function encodeCursor(offset: number): DiscoveryCursor {
 }
 
 /**
- * Default `entity_id` builder. Produces stable Voyant-side ids of the
- * form `crus_<slug>` from the upstream `externalId`. Stability is
- * load-bearing: `catalog_sourced_entries` is keyed on `entity_id`, so
- * if this changes between syncs we'd lose the link to overlays /
- * snapshots.
+ * Default `entity_id` builder. Produces a stable URL-safe id that embeds the
+ * full SourceRef. Stability is load-bearing: `catalog_sourced_entries` is keyed
+ * on `entity_id`, so drift on the id maps to a new sourced row.
  */
 function defaultBuildEntityId(sourceRef: SourceRef): string {
-  const slug =
-    String(sourceRef.externalId)
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "_")
-      .replace(/^_+|_+$/g, "")
-      .slice(0, 26) || "unknown"
-  return `crus_${slug}`
+  return `crus_${encodeSourceRef(sourceRef)}`
 }
 
 /**
- * Inverse of `defaultBuildEntityId` — recovers a `SourceRef` from a
- * catalog-side entity_id. Used by `getContent` when the catalog
- * dispatches by entity_id rather than by SourceRef. Returns a minimal
- * `SourceRef` (just the externalId) — the upstream connectionId / vendor
- * fields are NOT recoverable from the entity_id alone, so callers that
- * need the connection should pass `SourceAdapterContext.connection_id`
- * via the adapter context.
+ * Inverse of `defaultBuildEntityId`. The legacy `crus_<slug>` fallback keeps
+ * pre-encoded sourced rows readable, but new rows preserve the exact SourceRef.
  */
 function entityIdToSourceRef(entityId: string): SourceRef {
-  const externalId = entityId.startsWith("crus_") ? entityId.slice("crus_".length) : entityId
+  const raw = entityId.startsWith("crus_") ? entityId.slice("crus_".length) : entityId
+  const decoded = decodeSourceRef(raw)
+  if (decoded) return decoded
+  const externalId = raw
   return { externalId }
 }

--- a/packages/cruises/src/booking-extension.ts
+++ b/packages/cruises/src/booking-extension.ts
@@ -18,9 +18,9 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
 import { z } from "zod"
 
-import type { SourceRef } from "./adapters/index.js"
+import type { ExternalPassengerComposition, SourceRef } from "./adapters/index.js"
 import { cruiseSourceEnum } from "./schema-shared.js"
-import type { QuoteComponent } from "./service-pricing.js"
+import type { QuoteBookingTerms, QuoteComponent } from "./service-pricing.js"
 
 // ---------- enums ----------
 
@@ -64,6 +64,10 @@ export const bookingCruiseDetails = pgTable(
     quotedTotalForCabin: numeric("quoted_total_for_cabin", { precision: 12, scale: 2 }).notNull(),
     quotedCurrency: char("quoted_currency", { length: 3 }).notNull(),
     quotedComponentsJson: jsonb("quoted_components_json").$type<QuoteComponent[]>().default([]),
+    bookingTermsSnapshotJson: jsonb("booking_terms_snapshot_json").$type<QuoteBookingTerms>(),
+    passengerCompositionSnapshotJson: jsonb(
+      "passenger_composition_snapshot_json",
+    ).$type<ExternalPassengerComposition>(),
     connectorBookingRef: text("connector_booking_ref"),
     connectorStatus: text("connector_status"),
     /**
@@ -116,6 +120,7 @@ export const bookingGroupCruiseDetails = pgTable(
     totalQuotedAmount: numeric("total_quoted_amount", { precision: 12, scale: 2 }).notNull(),
     quotedCurrency: char("quoted_currency", { length: 3 }).notNull(),
     connectorBookingRef: text("connector_booking_ref"),
+    bookingTermsSnapshotJson: jsonb("booking_terms_snapshot_json").$type<QuoteBookingTerms>(),
     notes: text("notes"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
@@ -140,6 +145,16 @@ const sourceRefValueSchema = z
   })
   .catchall(z.unknown())
 
+const passengerCompositionValueSchema = z
+  .object({
+    adults: z.number().int().min(0),
+    children: z.number().int().min(0).optional(),
+    infants: z.number().int().min(0).optional(),
+    seniors: z.number().int().min(0).optional(),
+    childAges: z.array(z.number().int().min(0).max(17)).optional(),
+  })
+  .catchall(z.unknown())
+
 const cruiseDetailUpsertSchema = z
   .object({
     source: z.enum(["local", "external"]).default("local"),
@@ -157,6 +172,8 @@ const cruiseDetailUpsertSchema = z
     quotedTotalForCabin: z.string().regex(/^-?\d+(\.\d{1,2})?$/),
     quotedCurrency: z.string().length(3),
     quotedComponentsJson: z.array(z.unknown()).optional().nullable(),
+    bookingTermsSnapshotJson: z.record(z.string(), z.unknown()).optional().nullable(),
+    passengerCompositionSnapshotJson: passengerCompositionValueSchema.optional().nullable(),
     connectorBookingRef: z.string().optional().nullable(),
     connectorStatus: z.string().optional().nullable(),
     airArrangement: z.enum(["cruise_line", "independent", "none"]).optional().nullable(),
@@ -204,6 +221,7 @@ const groupCruiseDetailUpsertSchema = z
     totalQuotedAmount: z.string().regex(/^-?\d+(\.\d{1,2})?$/),
     quotedCurrency: z.string().length(3),
     connectorBookingRef: z.string().optional().nullable(),
+    bookingTermsSnapshotJson: z.record(z.string(), z.unknown()).optional().nullable(),
     notes: z.string().optional().nullable(),
   })
   .superRefine((value, ctx) => {

--- a/packages/cruises/src/index.ts
+++ b/packages/cruises/src/index.ts
@@ -4,6 +4,19 @@ import type { HonoModule } from "@voyantjs/hono/module"
 import { cruiseAdminRoutes } from "./routes.js"
 import { cruisePublicRoutes } from "./routes-public.js"
 
+export {
+  type CompatibilityMappingResult,
+  type ConnectCabinRoomType,
+  type ConnectCruiseType,
+  type ConnectEnrichmentKind,
+  type ConnectInclusionKind,
+  type ConnectPriceComponentKind,
+  mapConnectCabinRoomType,
+  mapConnectCruiseType,
+  mapConnectEnrichmentKind,
+  mapConnectInclusionKind,
+  mapConnectPriceComponentKind,
+} from "./adapters/connect-compat.js"
 // Adapter contract + registry — re-exported so templates can import everything
 // from `@voyantjs/cruises` without reaching into sub-paths. Sub-path
 // `@voyantjs/cruises/adapters` remains the lighter import for adapter-only
@@ -14,12 +27,14 @@ export type {
   CruiseAdapter,
   CruiseSearchProjectionEntry,
   ExternalBookingResult,
+  ExternalBookingTerms,
   ExternalCabinCategory,
   ExternalContactInput,
   ExternalCruise,
   ExternalCruiseSummary,
   ExternalDeck,
   ExternalItineraryDay,
+  ExternalPassengerComposition,
   ExternalPassengerInput,
   ExternalPriceComponent,
   ExternalPriceRow,

--- a/packages/cruises/src/lib/key.ts
+++ b/packages/cruises/src/lib/key.ts
@@ -17,6 +17,13 @@ export type ParsedKey =
   | { kind: "invalid"; raw: string }
 
 const TYPEID_RE = /^[a-z]+_[0-9a-zA-Z]+$/
+const ENCODED_SOURCE_REF_PREFIX = "sr_"
+
+export type EncodableSourceRef = {
+  externalId: string
+  connectionId?: string
+  [key: string]: unknown
+}
 
 export function parseUnifiedKey(raw: string): ParsedKey {
   const decoded = decodeURIComponent(raw)
@@ -29,4 +36,62 @@ export function parseUnifiedKey(raw: string): ParsedKey {
   }
   if (TYPEID_RE.test(decoded)) return { kind: "local", id: decoded }
   return { kind: "invalid", raw: decoded }
+}
+
+export function makeExternalSourceKey(provider: string, sourceRef: EncodableSourceRef): string {
+  return `${provider}:${encodeSourceRef(sourceRef)}`
+}
+
+export function encodeSourceRef(sourceRef: EncodableSourceRef): string {
+  return `${ENCODED_SOURCE_REF_PREFIX}${base64UrlEncode(stableStringify(sourceRef))}`
+}
+
+export function decodeSourceRef(encoded: string): EncodableSourceRef | null {
+  if (!encoded.startsWith(ENCODED_SOURCE_REF_PREFIX)) return null
+  try {
+    const decoded = JSON.parse(base64UrlDecode(encoded.slice(ENCODED_SOURCE_REF_PREFIX.length)))
+    if (
+      decoded &&
+      typeof decoded === "object" &&
+      typeof (decoded as { externalId?: unknown }).externalId === "string"
+    ) {
+      return decoded as EncodableSourceRef
+    }
+  } catch {
+    // Invalid encoded refs are treated as legacy raw external ids by callers.
+  }
+  return null
+}
+
+export function sourceRefFromExternalKeyRef(ref: string): EncodableSourceRef {
+  return decodeSourceRef(ref) ?? { externalId: ref }
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(sortValue(value))
+}
+
+function sortValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortValue)
+  if (!value || typeof value !== "object") return value
+  const out: Record<string, unknown> = {}
+  for (const key of Object.keys(value).sort()) {
+    out[key] = sortValue((value as Record<string, unknown>)[key])
+  }
+  return out
+}
+
+function base64UrlEncode(input: string): string {
+  const bytes = new TextEncoder().encode(input)
+  let binary = ""
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+}
+
+function base64UrlDecode(input: string): string {
+  const padded = input.padEnd(Math.ceil(input.length / 4) * 4, "=")
+  const binary = atob(padded.replace(/-/g, "+").replace(/_/g, "/"))
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i)
+  return new TextDecoder().decode(bytes)
 }

--- a/packages/cruises/src/routes-content.ts
+++ b/packages/cruises/src/routes-content.ts
@@ -28,7 +28,7 @@ import type { AnyDrizzleDb } from "@voyantjs/db"
 import type { Context } from "hono"
 import { Hono } from "hono"
 
-import { parseUnifiedKey } from "./lib/key.js"
+import { encodeSourceRef, parseUnifiedKey, sourceRefFromExternalKeyRef } from "./lib/key.js"
 import { type CruiseContentScope, getCruiseContent } from "./service-content.js"
 
 export interface CruiseContentRoutesEnv {
@@ -144,22 +144,14 @@ export function createCruiseContentRoutes(
 }
 
 /**
- * Translate a parsed external key (`<provider>:<ref>`) into the
- * catalog-side entity_id. Mirrors the default `buildEntityId` from
- * `cruiseAdapterToSourceAdapter` — `crus_<slug-of-ref>`. Templates
- * that override `buildEntityId` on the shim must wrap this route
- * factory with their own translator.
+ * Translate a parsed external key (`<provider>:<ref>`) into the catalog-side
+ * entity_id. Mirrors the default `buildEntityId` from
+ * `cruiseAdapterToSourceAdapter`: `crus_<encoded SourceRef>`.
  */
 function entityIdFromExternal(
   parsed: Extract<ReturnType<typeof parseUnifiedKey>, { kind: "external" }>,
 ): string {
-  const slug =
-    String(parsed.ref)
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "_")
-      .replace(/^_+|_+$/g, "")
-      .slice(0, 26) || "unknown"
-  return `crus_${slug}`
+  return `crus_${encodeSourceRef(sourceRefFromExternalKeyRef(parsed.ref))}`
 }
 
 export function parseAcceptLanguage(header: string): string[] {

--- a/packages/cruises/src/routes-public.ts
+++ b/packages/cruises/src/routes-public.ts
@@ -3,7 +3,9 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
 import { z } from "zod"
 
+import type { ExternalPassengerComposition, SourceRef } from "./adapters/index.js"
 import { resolveCruiseAdapter } from "./adapters/registry.js"
+import { encodeSourceRef, parseUnifiedKey, sourceRefFromExternalKeyRef } from "./lib/key.js"
 import { cruisesService } from "./service.js"
 import { composeQuote, pricingService } from "./service-pricing.js"
 import { cruisesSearchService } from "./service-search.js"
@@ -23,10 +25,76 @@ function isTypeId(s: string): boolean {
 
 const quotePayloadSchema = z.object({
   cabinCategoryId: z.string(),
+  cabinCategoryRef: z.record(z.string(), z.unknown()).optional().nullable(),
   occupancy: z.number().int().min(1).max(8),
-  guestCount: z.number().int().min(1).max(8),
+  guestCount: z.number().int().min(1).max(8).optional(),
+  passengerComposition: passengerCompositionSchema().optional().nullable(),
   fareCode: z.string().optional().nullable(),
+  bookingTerms: z.record(z.string(), z.unknown()).optional().nullable(),
 })
+
+function passengerCompositionSchema() {
+  return z
+    .object({
+      adults: z.number().int().min(0),
+      children: z.number().int().min(0).optional(),
+      childAges: z.array(z.number().int().min(0).max(17)).optional(),
+      infants: z.number().int().min(0).optional(),
+      seniors: z.number().int().min(0).optional(),
+    })
+    .catchall(z.unknown())
+    .refine(
+      (value) =>
+        value.adults + (value.children ?? 0) + (value.infants ?? 0) + (value.seniors ?? 0) > 0,
+      "passengerComposition must include at least one passenger",
+    )
+}
+
+function passengerCountFromComposition(
+  composition: ExternalPassengerComposition | null | undefined,
+): number | null {
+  if (!composition) return null
+  return (
+    composition.adults +
+    (composition.children ?? 0) +
+    (composition.infants ?? 0) +
+    (composition.seniors ?? 0)
+  )
+}
+
+function resolveExternalKey(key: string): { provider: string; sourceRef: SourceRef } | null {
+  const parsed = parseUnifiedKey(key)
+  if (parsed.kind !== "external") return null
+  return { provider: parsed.provider, sourceRef: sourceRefFromExternalKeyRef(parsed.ref) }
+}
+
+function sourceRefFromPayload(
+  maybeRef: Record<string, unknown> | null | undefined,
+  externalId: string,
+): SourceRef {
+  if (maybeRef && typeof maybeRef.externalId === "string") return maybeRef as SourceRef
+  return { externalId }
+}
+
+function sourceRefMatches(candidate: SourceRef, requested: SourceRef): boolean {
+  if (encodeSourceRef(candidate) === encodeSourceRef(requested)) return true
+  const candidateIsLegacy = Object.keys(candidate).length === 1
+  const requestedIsLegacy = Object.keys(requested).length === 1
+  return (candidateIsLegacy || requestedIsLegacy) && candidate.externalId === requested.externalId
+}
+
+function passengerCompositionMatches(
+  candidate: ExternalPassengerComposition | null | undefined,
+  requested: ExternalPassengerComposition | null | undefined,
+): boolean {
+  if (!requested || !candidate) return true
+  return (
+    encodeSourceRef({
+      externalId: "composition",
+      ...candidate,
+    }) === encodeSourceRef({ externalId: "composition", ...requested })
+  )
+}
 
 /**
  * Public/storefront routes. Reads exclusively from `cruise_search_index` for
@@ -109,19 +177,15 @@ export const cruisePublicRoutes = new Hono<Env>()
       if (!sailing) return c.json({ error: "not_found" }, 404)
       return c.json({ data: { source: "local", sailing } })
     }
-    // External keys: <provider>:<ref>
-    const colon = key.indexOf(":")
-    if (colon <= 0) return c.json({ error: "invalid_key" }, 400)
-    const provider = key.slice(0, colon)
-    const externalId = key.slice(colon + 1)
-    const adapter = resolveCruiseAdapter(provider)
+    const parsed = resolveExternalKey(key)
+    if (!parsed) return c.json({ error: "invalid_key" }, 400)
+    const adapter = resolveCruiseAdapter(parsed.provider)
     if (!adapter) return c.json({ error: "adapter_not_registered" }, 501)
-    const ref = { externalId }
-    const sailing = await adapter.fetchSailing(ref)
+    const sailing = await adapter.fetchSailing(parsed.sourceRef)
     if (!sailing) return c.json({ error: "not_found" }, 404)
     const [pricing, itinerary] = await Promise.all([
-      adapter.fetchSailingPricing(ref),
-      adapter.fetchSailingItinerary(ref),
+      adapter.fetchSailingPricing(parsed.sourceRef),
+      adapter.fetchSailingItinerary(parsed.sourceRef),
     ])
     return c.json({
       data: { source: "external", sourceProvider: adapter.name, sailing, pricing, itinerary },
@@ -130,29 +194,40 @@ export const cruisePublicRoutes = new Hono<Env>()
   .post("/sailings/:key/quote", async (c) => {
     const key = c.req.param("key")
     const payload = await parseJsonBody(c, quotePayloadSchema)
+    const guestCount =
+      payload.guestCount ?? passengerCountFromComposition(payload.passengerComposition)
+    if (!guestCount) {
+      return c.json(
+        {
+          error: "guest_count_required",
+          detail: "Provide guestCount or passengerComposition for cruise quote requests.",
+        },
+        400,
+      )
+    }
 
     if (isTypeId(key)) {
       const quote = await pricingService.assembleQuote(c.get("db"), {
         sailingId: key,
         cabinCategoryId: payload.cabinCategoryId,
         occupancy: payload.occupancy,
-        guestCount: payload.guestCount,
+        guestCount,
         fareCode: payload.fareCode ?? null,
       })
       return c.json({ data: quote })
     }
 
-    const colon = key.indexOf(":")
-    if (colon <= 0) return c.json({ error: "invalid_key" }, 400)
-    const provider = key.slice(0, colon)
-    const externalId = key.slice(colon + 1)
-    const adapter = resolveCruiseAdapter(provider)
+    const parsed = resolveExternalKey(key)
+    if (!parsed) return c.json({ error: "invalid_key" }, 400)
+    const adapter = resolveCruiseAdapter(parsed.provider)
     if (!adapter) return c.json({ error: "adapter_not_registered" }, 501)
-    const prices = await adapter.fetchSailingPricing({ externalId })
+    const prices = await adapter.fetchSailingPricing(parsed.sourceRef)
+    const cabinCategoryRef = sourceRefFromPayload(payload.cabinCategoryRef, payload.cabinCategoryId)
     const matching = prices.find(
       (p) =>
-        p.cabinCategoryRef.externalId === payload.cabinCategoryId &&
+        sourceRefMatches(p.cabinCategoryRef, cabinCategoryRef) &&
         p.occupancy === payload.occupancy &&
+        passengerCompositionMatches(p.passengerComposition, payload.passengerComposition) &&
         (!payload.fareCode || p.fareCode === payload.fareCode),
     )
     if (!matching) return c.json({ error: "no_matching_price" }, 404)
@@ -174,7 +249,8 @@ export const cruisePublicRoutes = new Hono<Env>()
         perPerson: c.perPerson,
       })),
       occupancy: payload.occupancy,
-      guestCount: payload.guestCount,
+      guestCount,
+      bookingTerms: payload.bookingTerms ?? matching.bookingTerms ?? null,
     })
     return c.json({ data: quote })
   })
@@ -189,13 +265,11 @@ export const cruisePublicRoutes = new Hono<Env>()
       ])
       return c.json({ data: { ...ship, decks, categories } })
     }
-    const colon = key.indexOf(":")
-    if (colon <= 0) return c.json({ error: "invalid_key" }, 400)
-    const provider = key.slice(0, colon)
-    const externalId = key.slice(colon + 1)
-    const adapter = resolveCruiseAdapter(provider)
+    const parsed = resolveExternalKey(key)
+    if (!parsed) return c.json({ error: "invalid_key" }, 400)
+    const adapter = resolveCruiseAdapter(parsed.provider)
     if (!adapter) return c.json({ error: "adapter_not_registered" }, 501)
-    const ship = await adapter.fetchShip({ externalId })
+    const ship = await adapter.fetchShip(parsed.sourceRef)
     if (!ship) return c.json({ error: "not_found" }, 404)
     return c.json({ data: ship })
   })

--- a/packages/cruises/src/routes.ts
+++ b/packages/cruises/src/routes.ts
@@ -74,9 +74,15 @@ type Env = {
 
 import type { Context } from "hono"
 
-import type { CruiseAdapter, SourceRef } from "./adapters/index.js"
+import type { CruiseAdapter, ExternalPassengerComposition, SourceRef } from "./adapters/index.js"
 import { listCruiseAdapters, resolveCruiseAdapter } from "./adapters/registry.js"
-import { type ParsedKey, parseUnifiedKey } from "./lib/key.js"
+import {
+  encodeSourceRef,
+  makeExternalSourceKey,
+  type ParsedKey,
+  parseUnifiedKey,
+  sourceRefFromExternalKeyRef,
+} from "./lib/key.js"
 import { type CruiseContentScope, getCruiseContent } from "./service-content.js"
 import { detachExternalCruise } from "./service-detach.js"
 
@@ -101,11 +107,11 @@ function resolveExternal(parsed: Extract<ParsedKey, { kind: "external" }>): {
 } | null {
   const adapter = resolveCruiseAdapter(parsed.provider)
   if (!adapter) return null
-  return { adapter, sourceRef: { externalId: parsed.ref } }
+  return { adapter, sourceRef: sourceRefFromExternalKeyRef(parsed.ref) }
 }
 
 function makeExternalKey(adapter: CruiseAdapter, ref: SourceRef): string {
-  return `${adapter.name}:${ref.externalId}`
+  return makeExternalSourceKey(adapter.name, ref)
 }
 
 const registryNotConfigured = () => ({
@@ -116,18 +122,11 @@ const registryNotConfigured = () => ({
 
 /**
  * Translate a parsed external key into the catalog-side `entity_id`.
- * Mirrors `cruiseAdapterToSourceAdapter`'s default `buildEntityId` —
- * `crus_<slug-of-ref>`. Templates that override the shim's
- * `buildEntityId` should also patch this helper (TODO: factory).
+ * Mirrors `cruiseAdapterToSourceAdapter`'s default `buildEntityId`:
+ * `crus_<encoded SourceRef>`.
  */
 function entityIdFromExternal(parsed: Extract<ParsedKey, { kind: "external" }>): string {
-  const slug =
-    String(parsed.ref)
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "_")
-      .replace(/^_+|_+$/g, "")
-      .slice(0, 26) || "unknown"
-  return `crus_${slug}`
+  return `crus_${encodeSourceRef(sourceRefFromExternalKeyRef(parsed.ref))}`
 }
 
 /**
@@ -182,8 +181,10 @@ function parseAcceptLanguageHeader(header: string): string[] {
 const createBookingPayloadSchema = z.object({
   sailingId: z.string(),
   cabinCategoryId: z.string(),
+  cabinCategoryRef: z.record(z.string(), z.unknown()).optional().nullable(),
   cabinId: z.string().optional().nullable(),
   occupancy: z.number().int().min(1).max(8),
+  passengerComposition: passengerCompositionSchema().optional().nullable(),
   fareCode: z.string().optional().nullable(),
   mode: z.enum(["inquiry", "reserve"]).optional(),
   personId: z.string().optional().nullable(),
@@ -276,10 +277,69 @@ const createPartyBookingPayloadSchema = z.object({
 
 const quotePayloadSchema = z.object({
   cabinCategoryId: z.string(),
+  cabinCategoryRef: z.record(z.string(), z.unknown()).optional().nullable(),
   occupancy: z.number().int().min(1).max(8),
-  guestCount: z.number().int().min(1).max(8),
+  guestCount: z.number().int().min(1).max(8).optional(),
+  passengerComposition: passengerCompositionSchema().optional().nullable(),
   fareCode: z.string().optional().nullable(),
 })
+
+function passengerCompositionSchema() {
+  return z
+    .object({
+      adults: z.number().int().min(0),
+      children: z.number().int().min(0).optional(),
+      childAges: z.array(z.number().int().min(0).max(17)).optional(),
+      infants: z.number().int().min(0).optional(),
+      seniors: z.number().int().min(0).optional(),
+    })
+    .catchall(z.unknown())
+    .refine(
+      (value) =>
+        value.adults + (value.children ?? 0) + (value.infants ?? 0) + (value.seniors ?? 0) > 0,
+      "passengerComposition must include at least one passenger",
+    )
+}
+
+function passengerCountFromComposition(
+  composition: ExternalPassengerComposition | null | undefined,
+): number | null {
+  if (!composition) return null
+  return (
+    composition.adults +
+    (composition.children ?? 0) +
+    (composition.infants ?? 0) +
+    (composition.seniors ?? 0)
+  )
+}
+
+function sourceRefFromPayload(
+  maybeRef: Record<string, unknown> | null | undefined,
+  externalId: string,
+): SourceRef {
+  if (maybeRef && typeof maybeRef.externalId === "string") return maybeRef as SourceRef
+  return { externalId }
+}
+
+function sourceRefMatches(candidate: SourceRef, requested: SourceRef): boolean {
+  if (encodeSourceRef(candidate) === encodeSourceRef(requested)) return true
+  const candidateIsLegacy = Object.keys(candidate).length === 1
+  const requestedIsLegacy = Object.keys(requested).length === 1
+  return (candidateIsLegacy || requestedIsLegacy) && candidate.externalId === requested.externalId
+}
+
+function passengerCompositionMatches(
+  candidate: ExternalPassengerComposition | null | undefined,
+  requested: ExternalPassengerComposition | null | undefined,
+): boolean {
+  if (!requested || !candidate) return true
+  return (
+    encodeSourceRef({
+      externalId: "composition",
+      ...candidate,
+    }) === encodeSourceRef({ externalId: "composition", ...requested })
+  )
+}
 
 // ---------- routes ----------
 
@@ -475,16 +535,32 @@ export const cruiseAdminRoutes = new Hono<Env>()
     const parsed = parseUnifiedKey(c.req.param("key"))
     if (parsed.kind === "invalid") return c.json(invalidKey(parsed.raw), 400)
     const payload = await parseJsonBody(c, quotePayloadSchema)
+    const guestCount =
+      payload.guestCount ?? passengerCountFromComposition(payload.passengerComposition)
+    if (!guestCount) {
+      return c.json(
+        {
+          error: "guest_count_required",
+          detail: "Provide guestCount or passengerComposition for cruise quote requests.",
+        },
+        400,
+      )
+    }
     if (parsed.kind === "external") {
       const ext = resolveExternal(parsed)
       if (!ext) return c.json(adapterNotRegistered(parsed.provider), 501)
       // Fetch upstream pricing then compose locally — the cabinCategoryId in
       // the payload is interpreted as the upstream cabin category externalId.
       const prices = await ext.adapter.fetchSailingPricing(ext.sourceRef)
+      const cabinCategoryRef = sourceRefFromPayload(
+        payload.cabinCategoryRef,
+        payload.cabinCategoryId,
+      )
       const matching = prices.find(
         (p) =>
-          p.cabinCategoryRef.externalId === payload.cabinCategoryId &&
+          sourceRefMatches(p.cabinCategoryRef, cabinCategoryRef) &&
           p.occupancy === payload.occupancy &&
+          passengerCompositionMatches(p.passengerComposition, payload.passengerComposition) &&
           (!payload.fareCode || p.fareCode === payload.fareCode),
       )
       if (!matching) return c.json({ error: "no_matching_price" }, 404)
@@ -507,7 +583,8 @@ export const cruiseAdminRoutes = new Hono<Env>()
           perPerson: c.perPerson,
         })),
         occupancy: payload.occupancy,
-        guestCount: payload.guestCount,
+        guestCount,
+        bookingTerms: matching.bookingTerms ?? null,
       })
       return c.json({ data: quote })
     }
@@ -515,7 +592,7 @@ export const cruiseAdminRoutes = new Hono<Env>()
       sailingId: parsed.id,
       cabinCategoryId: payload.cabinCategoryId,
       occupancy: payload.occupancy,
-      guestCount: payload.guestCount,
+      guestCount,
       fareCode: payload.fareCode ?? null,
     })
     return c.json({ data: quote })
@@ -533,9 +610,10 @@ export const cruiseAdminRoutes = new Hono<Env>()
         {
           adapter: ext.adapter,
           sailingRef: ext.sourceRef,
-          cabinCategoryRef: { externalId: payload.cabinCategoryId },
+          cabinCategoryRef: sourceRefFromPayload(payload.cabinCategoryRef, payload.cabinCategoryId),
           cabinId: payload.cabinId ?? null,
           occupancy: payload.occupancy,
+          passengerComposition: payload.passengerComposition ?? null,
           fareCode: payload.fareCode ?? null,
           mode: payload.mode,
           personId: payload.personId ?? null,

--- a/packages/cruises/src/schema-search.ts
+++ b/packages/cruises/src/schema-search.ts
@@ -12,11 +12,9 @@ import {
   timestamp,
   uniqueIndex,
 } from "drizzle-orm/pg-core"
-
+import type { SourceRef } from "./adapters/index.js"
 import { cruises } from "./schema-core.js"
 import { cruiseSourceEnum, cruiseTypeEnum } from "./schema-shared.js"
-
-type SourceRef = { connectionId?: string; externalId?: string; [k: string]: unknown }
 
 export const cruiseSearchIndex = pgTable(
   "cruise_search_index",
@@ -57,7 +55,7 @@ export const cruiseSearchIndex = pgTable(
     index("idx_cruise_search_index_regions_gin").using("gin", table.regions),
     index("idx_cruise_search_index_themes_gin").using("gin", table.themes),
     uniqueIndex("uidx_cruise_search_index_external")
-      .on(table.sourceProvider, sql`(${table.sourceRef}->>'externalId')`)
+      .on(table.sourceProvider, table.sourceRef)
       .where(sql`${table.source} = 'external'`),
   ],
 )

--- a/packages/cruises/src/service-bookings.ts
+++ b/packages/cruises/src/service-bookings.ts
@@ -1,7 +1,12 @@
 import { bookingGroupsService, bookingsService } from "@voyantjs/bookings"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
-import type { CruiseAdapter, SourceRef } from "./adapters/index.js"
+import type {
+  CruiseAdapter,
+  ExternalBookingTerms,
+  ExternalPassengerComposition,
+  SourceRef,
+} from "./adapters/index.js"
 import {
   type BookingCruiseDetail,
   type BookingGroupCruiseDetail,
@@ -90,6 +95,102 @@ function priceCentsFromString(s: string): number {
   const fracPadded = `${frac}00`.slice(0, 2)
   const cents = Number(whole) * 100 + Number(fracPadded)
   return negative ? -cents : cents
+}
+
+function passengerCompositionFromPassengers(
+  passengers: CruiseBookingPassenger[],
+): ExternalPassengerComposition {
+  let adults = 0
+  let children = 0
+  let infants = 0
+  let seniors = 0
+  for (const passenger of passengers) {
+    if (passenger.travelerCategory === "child") children += 1
+    else if (passenger.travelerCategory === "infant") infants += 1
+    else if (passenger.travelerCategory === "senior") seniors += 1
+    else adults += 1
+  }
+  return { adults, children, infants, seniors }
+}
+
+function passengerCompositionCount(composition: ExternalPassengerComposition): number {
+  return (
+    composition.adults +
+    (composition.children ?? 0) +
+    (composition.infants ?? 0) +
+    (composition.seniors ?? 0)
+  )
+}
+
+function assertPassengerCompositionMatchesPassengers(
+  supplied: ExternalPassengerComposition | null | undefined,
+  passengers: CruiseBookingPassenger[],
+): ExternalPassengerComposition {
+  const inferred = passengerCompositionFromPassengers(passengers)
+  if (!supplied) return inferred
+
+  const expected = {
+    adults: supplied.adults,
+    children: supplied.children ?? 0,
+    infants: supplied.infants ?? 0,
+    seniors: supplied.seniors ?? 0,
+  }
+  const actual = {
+    adults: inferred.adults,
+    children: inferred.children ?? 0,
+    infants: inferred.infants ?? 0,
+    seniors: inferred.seniors ?? 0,
+  }
+  if (
+    expected.adults !== actual.adults ||
+    expected.children !== actual.children ||
+    expected.infants !== actual.infants ||
+    expected.seniors !== actual.seniors
+  ) {
+    throw new Error(
+      `passengerComposition does not match passengers: composition=${JSON.stringify(
+        expected,
+      )} passengers=${JSON.stringify(actual)}`,
+    )
+  }
+  if (supplied.childAges && supplied.childAges.length !== expected.children) {
+    throw new Error(
+      `passengerComposition.childAges length (${supplied.childAges.length}) must match children (${expected.children})`,
+    )
+  }
+  return supplied
+}
+
+function sourceRefKey(ref: SourceRef): string {
+  return JSON.stringify(sortValue(ref))
+}
+
+function sortValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortValue)
+  if (!value || typeof value !== "object") return value
+  const out: Record<string, unknown> = {}
+  for (const key of Object.keys(value).sort()) {
+    out[key] = sortValue((value as Record<string, unknown>)[key])
+  }
+  return out
+}
+
+function sourceRefMatches(candidate: SourceRef, requested: SourceRef): boolean {
+  if (sourceRefKey(candidate) === sourceRefKey(requested)) return true
+  const candidateIsLegacy = Object.keys(candidate).length === 1
+  const requestedIsLegacy = Object.keys(requested).length === 1
+  return (candidateIsLegacy || requestedIsLegacy) && candidate.externalId === requested.externalId
+}
+
+function passengerCompositionMatches(
+  candidate: ExternalPassengerComposition | null | undefined,
+  requested: ExternalPassengerComposition | null | undefined,
+): boolean {
+  if (!candidate || !requested) return true
+  return (
+    sourceRefKey({ externalId: "composition", ...candidate }) ===
+    sourceRefKey({ externalId: "composition", ...requested })
+  )
 }
 
 export const cruisesBookingService = {
@@ -414,7 +515,11 @@ export const cruisesBookingService = {
     input: CreateExternalCruiseBookingInput,
     userId?: string,
   ): Promise<CreateCruiseBookingResult & { sourceProvider: string; sourceRef: SourceRef }> {
-    const guestCount = input.passengers.length
+    const passengerComposition = assertPassengerCompositionMatchesPassengers(
+      input.passengerComposition,
+      input.passengers,
+    )
+    const guestCount = passengerCompositionCount(passengerComposition)
     if (guestCount < 1) throw new Error("At least one passenger is required")
     if (guestCount > input.occupancy) {
       throw new Error(
@@ -426,8 +531,9 @@ export const cruisesBookingService = {
     const prices = await input.adapter.fetchSailingPricing(input.sailingRef)
     const matching = prices.find(
       (p) =>
-        p.cabinCategoryRef.externalId === input.cabinCategoryRef.externalId &&
+        sourceRefMatches(p.cabinCategoryRef, input.cabinCategoryRef) &&
         p.occupancy === input.occupancy &&
+        passengerCompositionMatches(p.passengerComposition, passengerComposition) &&
         (!input.fareCode || p.fareCode === input.fareCode),
     )
     if (!matching) {
@@ -456,6 +562,7 @@ export const cruisesBookingService = {
       })),
       occupancy: input.occupancy,
       guestCount,
+      bookingTerms: input.bookingTerms ?? matching.bookingTerms ?? null,
     })
 
     // 3. Commit upstream BEFORE writing local rows so we can fail loudly if the
@@ -464,9 +571,11 @@ export const cruisesBookingService = {
       sailingRef: input.sailingRef,
       cabinCategoryRef: input.cabinCategoryRef,
       occupancy: input.occupancy,
+      passengerComposition,
       fareCode: input.fareCode ?? null,
       passengers: input.passengers,
       contact: input.contact,
+      bookingTerms: input.bookingTerms ?? matching.bookingTerms ?? null,
       notes: input.notes ?? null,
     })
 
@@ -474,6 +583,12 @@ export const cruisesBookingService = {
     // Prefer the upstream-resolved quote when present.
     const finalQuote = upstream.finalQuote ?? quote
     const finalComponents = upstream.finalComponents ?? quote.components
+    const finalBookingTerms =
+      upstream.finalBookingTerms ??
+      finalQuote.bookingTerms ??
+      input.bookingTerms ??
+      matching.bookingTerms ??
+      null
 
     // 4. Local persistence (now that upstream confirmation is in hand).
     return db.transaction(async (tx) => {
@@ -545,6 +660,8 @@ export const cruisesBookingService = {
         quotedTotalForCabin: finalQuote.totalForCabin,
         quotedCurrency: finalQuote.currency,
         quotedComponentsJson: finalComponents,
+        bookingTermsSnapshotJson: finalBookingTerms,
+        passengerCompositionSnapshotJson: passengerComposition,
         connectorBookingRef: upstream.connectorBookingRef,
         connectorStatus: upstream.connectorStatus ?? null,
         notes: input.notes ?? null,
@@ -595,11 +712,13 @@ export type CreateExternalCruiseBookingInput = {
   cabinCategoryRef: SourceRef
   cabinId?: string | null
   occupancy: number
+  passengerComposition?: ExternalPassengerComposition | null
   fareCode?: string | null
   mode?: CruiseBookingMode
   personId?: string | null
   organizationId?: string | null
   contact: CruiseBookingContact
   passengers: CruiseBookingPassenger[]
+  bookingTerms?: ExternalBookingTerms | null
   notes?: string | null
 }

--- a/packages/cruises/src/service-pricing.ts
+++ b/packages/cruises/src/service-pricing.ts
@@ -55,8 +55,37 @@ function percentOf(cents: bigint, percentString: string): bigint {
 
 // ---------- composition (pure function) ----------
 
+export type QuotePriceComponentKind = CruisePriceComponent["kind"] | "single_supplement" | "other"
+
+export type QuoteBookingTerms = {
+  cancellationPolicy?: {
+    summary?: string | null
+    rules?: Array<{
+      from?: string | null
+      until?: string | null
+      penaltyAmount?: string | null
+      penaltyCurrency?: string | null
+      penaltyPercent?: string | null
+      description?: string | null
+    }>
+    [key: string]: unknown
+  } | null
+  paymentTerms?: {
+    summary?: string | null
+    depositAmount?: string | null
+    depositCurrency?: string | null
+    depositPercent?: string | null
+    dueDate?: string | null
+    schedule?: Array<Record<string, unknown>>
+    [key: string]: unknown
+  } | null
+  supplierTermsUrl?: string | null
+  notes?: string | null
+  [key: string]: unknown
+}
+
 export type QuoteComponent = {
-  kind: CruisePriceComponent["kind"]
+  kind: QuotePriceComponentKind
   label: string | null
   amount: string
   currency: string
@@ -74,6 +103,7 @@ export type Quote = {
   components: QuoteComponent[]
   totalPerPerson: string
   totalForCabin: string
+  bookingTerms?: QuoteBookingTerms | null
 }
 
 export type ComposeQuoteInput = {
@@ -87,10 +117,13 @@ export type ComposeQuoteInput = {
     | "fareCodeName"
   >
   components: Array<
-    Pick<CruisePriceComponent, "kind" | "label" | "amount" | "currency" | "direction" | "perPerson">
+    Pick<CruisePriceComponent, "label" | "amount" | "currency" | "direction" | "perPerson"> & {
+      kind: QuotePriceComponentKind
+    }
   >
   occupancy: number
   guestCount: number
+  bookingTerms?: QuoteBookingTerms | null
 }
 
 export function composeQuote(input: ComposeQuoteInput): Quote {
@@ -158,6 +191,7 @@ export function composeQuote(input: ComposeQuoteInput): Quote {
     components: renderedComponents,
     totalPerPerson: centsToDecimalString(totalPerPersonCents),
     totalForCabin: centsToDecimalString(totalForCabinCents),
+    bookingTerms: input.bookingTerms ?? null,
   }
 }
 

--- a/packages/cruises/src/service-search.ts
+++ b/packages/cruises/src/service-search.ts
@@ -347,7 +347,6 @@ async function findExisting(
     if (row) return row
   }
   if (entry.source === "external" && entry.sourceProvider && entry.sourceRef) {
-    const externalId = String(entry.sourceRef.externalId ?? "")
     const [row] = await db
       .select()
       .from(cruiseSearchIndex)
@@ -355,7 +354,7 @@ async function findExisting(
         and(
           eq(cruiseSearchIndex.source, "external"),
           eq(cruiseSearchIndex.sourceProvider, entry.sourceProvider),
-          sql`${cruiseSearchIndex.sourceRef}->>'externalId' = ${externalId}`,
+          sql`${cruiseSearchIndex.sourceRef} = ${sourceRefIdentityJson(entry.sourceRef)}::jsonb`,
         ),
       )
       .limit(1)
@@ -368,6 +367,20 @@ async function findExisting(
     .where(eq(cruiseSearchIndex.slug, entry.slug))
     .limit(1)
   return bySlug ?? null
+}
+
+export function sourceRefIdentityJson(sourceRef: SourceRef): string {
+  return JSON.stringify(sortValue(sourceRef))
+}
+
+function sortValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortValue)
+  if (!value || typeof value !== "object") return value
+  const out: Record<string, unknown> = {}
+  for (const key of Object.keys(value).sort()) {
+    out[key] = sortValue((value as Record<string, unknown>)[key])
+  }
+  return out
 }
 
 async function buildLocalEntry(

--- a/packages/cruises/tests/unit/adapter-mock.test.ts
+++ b/packages/cruises/tests/unit/adapter-mock.test.ts
@@ -42,6 +42,24 @@ describe("MockCruiseAdapter — fetch round-trips", () => {
     expect(await adapter.fetchCruise({ externalId: "missing" })).toBeNull()
   })
 
+  it("keeps adapter-specific SourceRef fields distinct", async () => {
+    const adapter = new MockCruiseAdapter()
+    const first = {
+      ...seedCruise,
+      sourceRef: { externalId: "same-id", connectionId: "conn-1", provider: "line-a" },
+      slug: "same-a",
+    }
+    const second = {
+      ...seedCruise,
+      sourceRef: { externalId: "same-id", connectionId: "conn-2", provider: "line-b" },
+      slug: "same-b",
+    }
+    adapter.addCruise(first)
+    adapter.addCruise(second)
+    expect(await adapter.fetchCruise(first.sourceRef)).toEqual(first)
+    expect(await adapter.fetchCruise(second.sourceRef)).toEqual(second)
+  })
+
   it("returns seeded sailing via fetchSailing", async () => {
     const adapter = new MockCruiseAdapter()
     adapter.addCruise(seedCruise, [seedSailing])

--- a/packages/cruises/tests/unit/compose-quote.test.ts
+++ b/packages/cruises/tests/unit/compose-quote.test.ts
@@ -224,6 +224,45 @@ describe("composeQuote — price components", () => {
     expect(quote.totalPerPerson).toBe("995.00")
     expect(quote.components).toHaveLength(4)
   })
+
+  it("preserves residual components and booking terms in external quote snapshots", () => {
+    const quote = composeQuote({
+      price: makePrice({ pricePerPerson: "1000.00" }),
+      components: [
+        {
+          kind: "other",
+          label: "Supplier adjustment",
+          amount: "25.00",
+          currency: "USD",
+          direction: "addition",
+          perPerson: false,
+        },
+        {
+          kind: "single_supplement",
+          label: "Single supplement",
+          amount: "100.00",
+          currency: "USD",
+          direction: "addition",
+          perPerson: false,
+        },
+      ],
+      occupancy: 1,
+      guestCount: 1,
+      bookingTerms: {
+        cancellationPolicy: {
+          summary: "Refundable until final payment.",
+          rules: [{ until: "2027-01-01", penaltyPercent: "0.00" }],
+        },
+        paymentTerms: { depositPercent: "25.00", dueDate: "2026-12-01" },
+      },
+    })
+    expect(quote.totalForCabin).toBe("1125.00")
+    expect(quote.components.map((component) => component.kind)).toEqual([
+      "other",
+      "single_supplement",
+    ])
+    expect(quote.bookingTerms?.cancellationPolicy?.summary).toBe("Refundable until final payment.")
+  })
 })
 
 describe("composeQuote — currency", () => {

--- a/packages/cruises/tests/unit/connect-compat.test.ts
+++ b/packages/cruises/tests/unit/connect-compat.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  mapConnectCabinRoomType,
+  mapConnectCruiseType,
+  mapConnectEnrichmentKind,
+  mapConnectInclusionKind,
+  mapConnectPriceComponentKind,
+} from "../../src/adapters/index.js"
+
+describe("Connect cruise compatibility mapping", () => {
+  it("maps supported cruise types and rejects categories that belong elsewhere", () => {
+    expect(mapConnectCruiseType("river")).toEqual({ status: "mapped", value: "river" })
+    expect(mapConnectCruiseType("yacht")).toEqual({
+      status: "reject",
+      reason: "Yacht-style per-suite products do not fit the cruises occupancy grid.",
+      rerouteTo: "products",
+    })
+    expect(mapConnectCruiseType("rail")).toEqual({
+      status: "reject",
+      reason: "rail is not a cruise vertical product type.",
+      rerouteTo: "products",
+    })
+  })
+
+  it("maps Connect cabin room types onto framework cabin categories", () => {
+    expect(mapConnectCabinRoomType("studio")).toEqual({ status: "mapped", value: "single" })
+    expect(mapConnectCabinRoomType("villa")).toEqual({ status: "mapped", value: "suite" })
+    expect(mapConnectCabinRoomType("balcony")).toEqual({ status: "mapped", value: "balcony" })
+  })
+
+  it("maps inclusions and pricing component vocabulary", () => {
+    expect(mapConnectInclusionKind("flight")).toEqual({ status: "mapped", value: "airfare" })
+    expect(mapConnectPriceComponentKind("non_commissionable_fare")).toEqual({
+      status: "mapped",
+      value: "ncf",
+    })
+    expect(mapConnectPriceComponentKind("single_supplement")).toEqual({
+      status: "mapped",
+      value: "single_supplement",
+    })
+  })
+
+  it("maps domain experts to the framework expert enrichment kind", () => {
+    expect(mapConnectEnrichmentKind("domain_expert")).toEqual({
+      status: "mapped",
+      value: "expert",
+    })
+  })
+})

--- a/packages/cruises/tests/unit/key.test.ts
+++ b/packages/cruises/tests/unit/key.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest"
 
-import { parseUnifiedKey } from "../../src/lib/key.js"
+import {
+  decodeSourceRef,
+  encodeSourceRef,
+  makeExternalSourceKey,
+  parseUnifiedKey,
+  sourceRefFromExternalKeyRef,
+} from "../../src/lib/key.js"
 
 describe("parseUnifiedKey — local TypeIDs", () => {
   it("parses a standard cruise TypeID", () => {
@@ -38,6 +44,39 @@ describe("parseUnifiedKey — external adapter keys", () => {
   it("decodes URI-encoded refs", () => {
     const result = parseUnifiedKey("voyant-connect%3Acnx_abc")
     expect(result).toEqual({ kind: "external", provider: "voyant-connect", ref: "cnx_abc" })
+  })
+
+  it("round-trips full SourceRef values through URL-safe refs", () => {
+    const sourceRef = {
+      connectionId: "conn_123",
+      provider: "scenic",
+      externalId: "sailing/2027:AU/NZ#42",
+      syncedRowId: "cnx_row_abc",
+      metadata: { shipId: "ship:99", cabinId: "A/101" },
+    }
+    const key = makeExternalSourceKey("voyant-connect", sourceRef)
+    const parsed = parseUnifiedKey(key)
+    expect(parsed.kind).toBe("external")
+    if (parsed.kind !== "external") return
+    expect(parsed.provider).toBe("voyant-connect")
+    expect(sourceRefFromExternalKeyRef(parsed.ref)).toEqual(sourceRef)
+  })
+
+  it("treats unencoded external refs as legacy externalId refs", () => {
+    expect(sourceRefFromExternalKeyRef("legacy:upstream/id")).toEqual({
+      externalId: "legacy:upstream/id",
+    })
+  })
+
+  it("uses deterministic encoding independent of key order", () => {
+    const a = encodeSourceRef({ externalId: "x", connectionId: "c", metadata: { b: 1, a: 2 } })
+    const b = encodeSourceRef({ metadata: { a: 2, b: 1 }, connectionId: "c", externalId: "x" })
+    expect(a).toBe(b)
+    expect(decodeSourceRef(a)).toEqual({
+      connectionId: "c",
+      externalId: "x",
+      metadata: { a: 2, b: 1 },
+    })
   })
 })
 

--- a/packages/cruises/tests/unit/routes-content.test.ts
+++ b/packages/cruises/tests/unit/routes-content.test.ts
@@ -1,6 +1,6 @@
 import type { SourceAdapterRegistry } from "@voyantjs/catalog/booking-engine"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-
+import { encodeSourceRef, makeExternalSourceKey } from "../../src/lib/key.js"
 import { createCruiseContentRoutes, parseAcceptLanguage } from "../../src/routes-content.js"
 
 describe("parseAcceptLanguage (cruises copy)", () => {
@@ -84,12 +84,27 @@ describe("createCruiseContentRoutes — GET /:key/content", () => {
     expect(res.status).toBe(404)
   })
 
-  it("translates external key to entity_id with crus_<slug> convention", async () => {
+  it("translates legacy external keys to encoded SourceRef entity ids", async () => {
     mockedGetCruiseContent.mockResolvedValueOnce(null)
     const { app } = buildApp()
     await app.request("/voyant-connect:cruise-1/content")
     const callArgs = mockedGetCruiseContent.mock.calls[0]
-    expect(callArgs?.[1]).toBe("crus_cruise_1")
+    expect(callArgs?.[1]).toBe(`crus_${encodeSourceRef({ externalId: "cruise-1" })}`)
+  })
+
+  it("preserves full SourceRef values from encoded external keys", async () => {
+    mockedGetCruiseContent.mockResolvedValueOnce(null)
+    const sourceRef = {
+      connectionId: "conn-123",
+      provider: "scenic",
+      externalId: "cruise/1:departure",
+      syncedRowId: "sync-row-7",
+    }
+    const key = makeExternalSourceKey("voyant-connect", sourceRef)
+    const { app } = buildApp()
+    await app.request(`/${key}/content`)
+    const callArgs = mockedGetCruiseContent.mock.calls[0]
+    expect(callArgs?.[1]).toBe(`crus_${encodeSourceRef(sourceRef)}`)
   })
 
   it("returns CruiseContent payload + resolution metadata when found", async () => {

--- a/packages/cruises/tests/unit/routes-public.test.ts
+++ b/packages/cruises/tests/unit/routes-public.test.ts
@@ -1,0 +1,132 @@
+import { mountTestApp } from "@voyantjs/voyant-test-utils/http"
+import { afterEach, describe, expect, it } from "vitest"
+
+import type { ExternalCruise, ExternalSailing, ExternalShip } from "../../src/adapters/index.js"
+import { MockCruiseAdapter } from "../../src/adapters/mock.js"
+import { clearCruiseAdapters, registerCruiseAdapter } from "../../src/adapters/registry.js"
+import { makeExternalSourceKey } from "../../src/lib/key.js"
+import { cruisePublicRoutes } from "../../src/routes-public.js"
+
+afterEach(() => {
+  clearCruiseAdapters()
+})
+
+const cruiseRef = {
+  externalId: "same-id",
+  connectionId: "conn-public",
+  provider: "line-a",
+}
+
+const sailingRef = {
+  externalId: "sailing-1",
+  connectionId: "conn-public",
+  provider: "line-a",
+}
+
+const shipRef = {
+  externalId: "ship-1",
+  connectionId: "conn-public",
+  provider: "line-a",
+}
+
+const seedCruise: ExternalCruise = {
+  sourceRef: cruiseRef,
+  name: "Public Fjords",
+  slug: "public-fjords",
+  cruiseType: "ocean",
+  lineName: "Acme Cruises",
+  defaultShipRef: shipRef,
+  nights: 7,
+}
+
+const seedSailing: ExternalSailing = {
+  sourceRef: sailingRef,
+  cruiseRef,
+  shipRef,
+  departureDate: "2027-06-01",
+  returnDate: "2027-06-08",
+  salesStatus: "open",
+}
+
+const seedShip: ExternalShip = {
+  sourceRef: shipRef,
+  name: "MV Public",
+  slug: "mv-public",
+  shipType: "ocean",
+}
+
+describe("public cruise routes - external encoded keys", () => {
+  it("decodes full SourceRef keys for sailing and ship routes", async () => {
+    const adapter = new MockCruiseAdapter({ name: "voyant-connect" })
+    adapter.addCruise(seedCruise, [seedSailing])
+    adapter.addShip(seedShip)
+    registerCruiseAdapter(adapter)
+    const app = mountTestApp(cruisePublicRoutes, { db: undefined })
+
+    const sailingKey = makeExternalSourceKey("voyant-connect", sailingRef)
+    const sailingRes = await app.request(`/sailings/${sailingKey}`)
+    expect(sailingRes.status).toBe(200)
+    const sailingBody = (await sailingRes.json()) as {
+      data: { sailing: { sourceRef: typeof sailingRef } }
+    }
+    expect(sailingBody.data.sailing.sourceRef).toEqual(sailingRef)
+
+    const shipKey = makeExternalSourceKey("voyant-connect", shipRef)
+    const shipRes = await app.request(`/ships/${shipKey}`)
+    expect(shipRes.status).toBe(200)
+    const shipBody = (await shipRes.json()) as { data: { sourceRef: typeof shipRef } }
+    expect(shipBody.data.sourceRef).toEqual(shipRef)
+  })
+
+  it("matches public quote rows by full cabin SourceRef and passenger composition", async () => {
+    const adapter = new MockCruiseAdapter({ name: "voyant-connect" })
+    const cabinA = { externalId: "cat-A", connectionId: "conn-public", provider: "line-a" }
+    const cabinB = { externalId: "cat-A", connectionId: "other-conn", provider: "line-a" }
+    adapter.addCruise(seedCruise, [seedSailing])
+    adapter.setSailingPricing(sailingRef, [
+      {
+        cabinCategoryRef: cabinB,
+        occupancy: 2,
+        passengerComposition: { adults: 2 },
+        currency: "USD",
+        pricePerPerson: "500.00",
+        availability: "available",
+      },
+      {
+        cabinCategoryRef: cabinA,
+        occupancy: 2,
+        passengerComposition: { adults: 1, children: 1, childAges: [9] },
+        currency: "USD",
+        pricePerPerson: "1000.00",
+        availability: "available",
+        bookingTerms: {
+          cancellationPolicy: { summary: "Refundable before final payment." },
+        },
+      },
+    ])
+    registerCruiseAdapter(adapter)
+    const app = mountTestApp(cruisePublicRoutes, { db: undefined })
+
+    const res = await app.request(
+      `/sailings/${makeExternalSourceKey("voyant-connect", sailingRef)}/quote`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          cabinCategoryId: "cat-A",
+          cabinCategoryRef: cabinA,
+          occupancy: 2,
+          passengerComposition: { adults: 1, children: 1, childAges: [9] },
+        }),
+      },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      data: { totalForCabin: string; bookingTerms?: { cancellationPolicy?: { summary?: string } } }
+    }
+    expect(body.data.totalForCabin).toBe("2000.00")
+    expect(body.data.bookingTerms?.cancellationPolicy?.summary).toBe(
+      "Refundable before final payment.",
+    )
+  })
+})

--- a/packages/cruises/tests/unit/service-bookings.test.ts
+++ b/packages/cruises/tests/unit/service-bookings.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest"
+
+import type { CruiseAdapter } from "../../src/adapters/index.js"
+import { cruisesBookingService } from "../../src/service-bookings.js"
+
+function makeAdapter(): CruiseAdapter {
+  return {
+    name: "test-adapter",
+    version: "1.0.0",
+    listEntries: vi.fn(async () => ({ entries: [] })),
+    searchProjection: vi.fn(async function* () {}),
+    fetchCruise: vi.fn(async () => null),
+    fetchSailing: vi.fn(async () => null),
+    fetchSailingPricing: vi.fn(async () => [
+      {
+        cabinCategoryRef: { externalId: "cat-A" },
+        occupancy: 2,
+        passengerComposition: { adults: 2 },
+        currency: "USD",
+        pricePerPerson: "1000.00",
+        availability: "available",
+      },
+    ]),
+    fetchSailingItinerary: vi.fn(async () => []),
+    fetchShip: vi.fn(async () => null),
+    listSailingsForCruise: vi.fn(async () => []),
+    createBooking: vi.fn(async () => ({
+      connectorBookingRef: "UPSTREAM-1",
+      connectorStatus: "confirmed",
+    })),
+  }
+}
+
+describe("cruisesBookingService.createExternalCruiseBooking", () => {
+  it("rejects passengerComposition that does not match passenger rows before upstream commit", async () => {
+    const adapter = makeAdapter()
+
+    await expect(
+      cruisesBookingService.createExternalCruiseBooking({} as never, {
+        adapter,
+        sailingRef: { externalId: "sailing-1" },
+        cabinCategoryRef: { externalId: "cat-A" },
+        occupancy: 2,
+        passengerComposition: { adults: 2 },
+        contact: { firstName: "Ann", lastName: "Test" },
+        passengers: [{ firstName: "Ann", lastName: "Test", travelerCategory: "adult" }],
+      }),
+    ).rejects.toThrow(/passengerComposition does not match passengers/)
+
+    expect(adapter.fetchSailingPricing).not.toHaveBeenCalled()
+    expect(adapter.createBooking).not.toHaveBeenCalled()
+  })
+
+  it("rejects child age arrays that do not match child passenger count", async () => {
+    const adapter = makeAdapter()
+
+    await expect(
+      cruisesBookingService.createExternalCruiseBooking({} as never, {
+        adapter,
+        sailingRef: { externalId: "sailing-1" },
+        cabinCategoryRef: { externalId: "cat-A" },
+        occupancy: 2,
+        passengerComposition: { adults: 1, children: 1, childAges: [] },
+        contact: { firstName: "Ann", lastName: "Test" },
+        passengers: [
+          { firstName: "Ann", lastName: "Test", travelerCategory: "adult" },
+          { firstName: "Bo", lastName: "Test", travelerCategory: "child" },
+        ],
+      }),
+    ).rejects.toThrow(/childAges length/)
+
+    expect(adapter.fetchSailingPricing).not.toHaveBeenCalled()
+    expect(adapter.createBooking).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cruises/tests/unit/service-search.test.ts
+++ b/packages/cruises/tests/unit/service-search.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+
+import { sourceRefIdentityJson } from "../../src/service-search.js"
+
+describe("cruisesSearchService sourceRef identity", () => {
+  it("keeps connection and provider context in external search-index identity", () => {
+    const first = sourceRefIdentityJson({
+      externalId: "same-id",
+      connectionId: "conn-a",
+      provider: "line-a",
+    })
+    const second = sourceRefIdentityJson({
+      externalId: "same-id",
+      connectionId: "conn-b",
+      provider: "line-a",
+    })
+
+    expect(first).not.toBe(second)
+  })
+
+  it("is deterministic for nested SourceRef metadata", () => {
+    const first = sourceRefIdentityJson({
+      externalId: "same-id",
+      metadata: { b: 2, a: 1 },
+    })
+    const second = sourceRefIdentityJson({
+      metadata: { a: 1, b: 2 },
+      externalId: "same-id",
+    })
+
+    expect(first).toBe(second)
+  })
+})

--- a/packages/cruises/tests/unit/source-adapter-shim.test.ts
+++ b/packages/cruises/tests/unit/source-adapter-shim.test.ts
@@ -8,6 +8,7 @@ import type {
 } from "../../src/adapters/index.js"
 import { cruiseAdapterToSourceAdapter } from "../../src/adapters/source-adapter-shim.js"
 import { CRUISES_CONTENT_SCHEMA_VERSION } from "../../src/content-shape.js"
+import { encodeSourceRef } from "../../src/lib/key.js"
 
 function makeProjectionEntries(count: number): CruiseSearchProjectionEntry[] {
   const out: CruiseSearchProjectionEntry[] = []
@@ -163,9 +164,9 @@ describe("cruiseAdapterToSourceAdapter.discover", () => {
     const page = await shim.discover({ connection_id: "conn-x" })
     expect(page.projections).toHaveLength(3)
     expect(page.projections[0]?.entity_module).toBe("cruises")
-    expect(page.projections[0]?.entity_id).toBe("crus_cruise_0")
+    expect(page.projections[0]?.entity_id).toBe(`crus_${encodeSourceRef(entries[0]!.sourceRef)}`)
     expect(page.projections[0]?.provenance.source_kind).toBe("cruise:stub")
-    expect(page.projections[0]?.provenance.source_ref).toBe("cruise-0")
+    expect(page.projections[0]?.provenance.source_ref).toBe(encodeSourceRef(entries[0]!.sourceRef))
     expect(page.projections[0]?.provenance.source_freshness).toBe("sync")
     expect(page.projections[0]?.fields.cruise_line).toBe("Sample Line")
     expect(page.projections[0]?.fields.duration_nights).toBe(7)
@@ -227,14 +228,17 @@ describe("cruiseAdapterToSourceAdapter.getContent", () => {
   it("composes fetchCruise + fetchShip + listSailingsForCruise into a CruiseContent payload", async () => {
     const adapter = makeStubAdapter()
     const shim = cruiseAdapterToSourceAdapter(adapter)
+    const entityId = `crus_${encodeSourceRef({ externalId: "cruise-1", connectionId: "conn-x" })}`
     const result = await shim.getContent!(
       { connection_id: "conn-x" },
-      { entity_module: "cruises", entity_id: "crus_cruise-1", locale: "en-GB" },
+      { entity_module: "cruises", entity_id: entityId, locale: "en-GB" },
     )
 
     expect(result.entity_module).toBe("cruises")
-    expect(result.entity_id).toBe("crus_cruise-1")
-    expect(result.source_ref).toBe("cruise-1")
+    expect(result.entity_id).toBe(entityId)
+    expect(result.source_ref).toBe(
+      encodeSourceRef({ externalId: "cruise-1", connectionId: "conn-x" }),
+    )
     expect(result.returned_locale).toBe("en-GB")
     expect(result.content_schema_version).toBe(CRUISES_CONTENT_SCHEMA_VERSION)
 

--- a/templates/operator/migrations/0045_cruise_external_terms_snapshot.sql
+++ b/templates/operator/migrations/0045_cruise_external_terms_snapshot.sql
@@ -1,0 +1,12 @@
+ALTER TABLE "booking_cruise_details"
+  ADD COLUMN IF NOT EXISTS "booking_terms_snapshot_json" jsonb,
+  ADD COLUMN IF NOT EXISTS "passenger_composition_snapshot_json" jsonb;
+--> statement-breakpoint
+ALTER TABLE "booking_group_cruise_details"
+  ADD COLUMN IF NOT EXISTS "booking_terms_snapshot_json" jsonb;
+--> statement-breakpoint
+DROP INDEX IF EXISTS "uidx_cruise_search_index_external";
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uidx_cruise_search_index_external"
+  ON "cruise_search_index" USING btree ("source_provider", "source_ref")
+  WHERE "cruise_search_index"."source" = 'external';


### PR DESCRIPTION
## Summary
- Preserve full external cruise SourceRef values through encoded route/catalog keys instead of reconstructing from synthetic ids.
- Extend the external cruise adapter contract for passenger composition, richer price components, and structured booking terms.
- Snapshot external booking terms and passenger composition on cruise booking details, with an operator migration.
- Document and test Connect compatibility mappings for cruise type, cabin type, inclusions, enrichment, and price components.

Closes #1384

## Verification
- pnpm --filter @voyantjs/cruises lint
- pnpm --filter @voyantjs/cruises typecheck
- pnpm --filter @voyantjs/cruises test
- commit/push hooks: affected checks and full test task passed

Note: pnpm verify:fast still stops on an unrelated existing @voyantjs/ui components barrel check before the later lanes.