### PR TITLE
Document cruise adapter extension contract

### DIFF
--- a/.changeset/cruise-adapter-contract-docs.md
+++ b/.changeset/cruise-adapter-contract-docs.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/cruises": patch
+---
+
+Document the external cruise adapter contract and export a provider-neutral compatibility fixture for adapter packages.

--- a/docs/architecture/cruise-adapter-contract.md
+++ b/docs/architecture/cruise-adapter-contract.md
@@ -1,0 +1,181 @@
+# External Cruise Adapter Contract
+
+Status: active architecture note
+Audience: developers implementing an external adapter package for
+`@voyantjs/cruises`.
+
+This contract keeps the cruises framework provider-neutral. The framework owns
+the normalized cruise shapes, route behavior, SourceRef encoding, search-index
+projection shape, booking snapshot shape, and compatibility tests. Adapter
+packages own upstream clients, credentials, polling, retries, throttling, and
+provider-specific mappings.
+
+## Boundary
+
+An adapter package implements `CruiseAdapter` from `@voyantjs/cruises/adapters`
+and registers it at application startup. The framework must not import the
+adapter package. The adapter package can depend on `@voyantjs/cruises` for
+types, helpers, and compatibility tests.
+
+```ts
+import { memoizeCruiseAdapter, registerCruiseAdapter } from "@voyantjs/cruises/adapters"
+import { createCruiseAdapter } from "external-cruise-adapter"
+
+const adapter = createCruiseAdapter({
+  token: process.env.CRUISE_ADAPTER_TOKEN,
+  endpoint: process.env.CRUISE_ADAPTER_ENDPOINT,
+})
+
+registerCruiseAdapter(memoizeCruiseAdapter(adapter, { ttlMs: 60_000 }))
+```
+
+The adapter `name` is the source-provider prefix used in external keys:
+`<adapter.name>:<encoded-source-ref>`. Keep it stable for the lifetime of the
+deployment.
+
+## SourceRef Semantics
+
+`SourceRef` is identity, not display text:
+
+```ts
+type SourceRef = {
+  externalId: string
+  connectionId?: string
+  [key: string]: unknown
+}
+```
+
+Rules:
+
+- Preserve the full `SourceRef` returned by the upstream adapter across list,
+  projection, detail, pricing, booking, and catalog-shim flows.
+- Treat `connectionId`, source namespace, market, account, or other adapter
+  fields as part of identity. Two refs with the same `externalId` but different
+  connection context are different rows.
+- Use `makeExternalSourceKey(provider, sourceRef)` or `encodeSourceRef(sourceRef)`
+  when building route keys or catalog entity ids. Do not split or slugify a ref
+  and then reconstruct `{ externalId }`.
+- Return the same full `SourceRef` from `fetchCruise`, `fetchSailing`,
+  `fetchShip`, `searchProjection`, `listEntries`, and pricing rows.
+
+## Method Expectations
+
+`listEntries(options)` is a browse method. It returns lightweight summaries for
+admin list views and should preserve full source identity. It may be paginated
+with an adapter-owned cursor.
+
+`searchProjection(options)` is an index/projection method. It feeds
+`cruise_search_index` for storefront list and SEO flows. It should be safe to
+run in background jobs and may return cached or replicated data, as long as the
+projection is internally consistent and emits full refs.
+
+`fetchCruise`, `fetchSailing`, `fetchSailingPricing`, `fetchSailingItinerary`,
+`fetchShip`, and `listSailingsForCruise` are detail reads. They are used by
+admin detail routes, storefront detail routes, quote assembly, refresh, detach,
+and content composition. They should read authoritative current upstream state
+or the adapter package's own normalized live replica.
+
+`createBooking(input)` is the commit boundary. It receives the full sailing ref,
+cabin category ref, occupancy, passenger composition, passenger rows, contact,
+fare code, and booking terms accepted by the caller. It returns an upstream
+confirmation reference and any final quote, component, or terms snapshot the
+framework should store locally.
+
+## Catalog SourceAdapter Shim
+
+When a deployment wants catalog-plane content integration for external cruise
+rows, wrap the same `CruiseAdapter` with `cruiseAdapterToSourceAdapter(...)` and
+register the shim in the catalog `SourceAdapterRegistry`.
+
+The default shim entity id is `crus_${encodeSourceRef(sourceRef)}`. This is
+load-bearing: `catalog_sourced_entries`, cruise content routes, admin refresh,
+and storefront keys all depend on stable full-ref identity.
+
+The shim currently supports discovery and content fetch. Reservation and
+cancellation through the catalog source adapter remain explicit capability
+stubs; external cruise booking commits should use the cruises vertical booking
+path.
+
+## Compatibility Tests
+
+External adapter packages can run the framework compatibility fixture in their
+own test suite:
+
+```ts
+import { describe, it } from "vitest"
+import { assertCruiseAdapterCompatibility } from "@voyantjs/cruises/adapters"
+import { createCruiseAdapter } from "../src/index.js"
+
+describe("cruise adapter contract", () => {
+  it("satisfies @voyantjs/cruises", async () => {
+    const adapter = createCruiseAdapter({ mode: "sandbox" })
+
+    await assertCruiseAdapterCompatibility(adapter, {
+      primaryCruiseRef: {
+        externalId: "fixture-cruise",
+        connectionId: "sandbox-a",
+      },
+      alternateCruiseRef: {
+        externalId: "fixture-cruise",
+        connectionId: "sandbox-b",
+      },
+      sailingRef: {
+        externalId: "fixture-sailing",
+        connectionId: "sandbox-a",
+      },
+      shipRef: {
+        externalId: "fixture-ship",
+        connectionId: "sandbox-a",
+      },
+      cabinCategoryRef: {
+        externalId: "fixture-cabin",
+        connectionId: "sandbox-a",
+      },
+      minimumItineraryDays: 1,
+      passengerComposition: { adults: 2 },
+      fareCode: "FLEX",
+      bookingInput: {
+        sailingRef: { externalId: "fixture-sailing", connectionId: "sandbox-a" },
+        cabinCategoryRef: { externalId: "fixture-cabin", connectionId: "sandbox-a" },
+        occupancy: 2,
+        passengerComposition: { adults: 2 },
+        fareCode: "FLEX",
+        passengers: [
+          { firstName: "Test", lastName: "One", travelerCategory: "adult", isPrimary: true },
+          { firstName: "Test", lastName: "Two", travelerCategory: "adult" },
+        ],
+        contact: { firstName: "Test", lastName: "One", email: "test@example.test" },
+      },
+    })
+  })
+})
+```
+
+The fixture checks:
+
+- full `SourceRef` round-tripping through `listEntries` and `searchProjection`;
+- multi-connection identity with two refs sharing the same `externalId`;
+- cruise, sailing, itinerary, ship, and cruise-to-sailings detail lookup;
+- sailing pricing lookup by cabin ref, passenger composition, and fare code;
+- booking commit payload acceptance and upstream confirmation return.
+
+Adapter packages should run this fixture against a sandbox data set where the
+two cruise refs intentionally share the same upstream id and differ only by
+connection/source context. The primary cruise should expose the fixture sailing
+through both `fetchSailing(...)` and `listSailingsForCruise(...)`, and the
+fixture sailing should expose at least `minimumItineraryDays` itinerary days.
+That catches the most common integration bug: collapsing identity to
+`externalId`.
+
+## Provider-Neutrality Checklist
+
+- The framework package imports only framework code and shared types.
+- Adapter packages keep credentials, HTTP clients, OAuth flows, throttling, and
+  provider mappings outside `@voyantjs/cruises`.
+- Route keys, catalog entity ids, search-index identity, and booking snapshots
+  use full refs.
+- Projection methods can be scheduled or replicated by the adapter package;
+  live detail and booking methods must be current enough for user-facing quote
+  and booking flows.
+- The adapter package owns any destructive upstream operation. The framework
+  stores the resulting local booking snapshot and connector confirmation refs.

--- a/docs/architecture/cruises-module.md
+++ b/docs/architecture/cruises-module.md
@@ -17,7 +17,10 @@ So: a new opt-in `@voyantjs/cruises` package, modeled native to Voyant's existin
 The module supports two provenance modes for cruise inventory, side by side:
 
 - **Self-managed cruises** — operators that publish their own cruise products (a boutique line, a private charter operation) own those rows in their local DB. Full canonical schema, full admin CRUD.
-- **External cruises** — sourced from an upstream **adapter**. Voyant Connect is the default adapter (and the one Voyant's own templates assume); agencies that prefer their own connectivity engine implement the same adapter contract. Admin reads external cruises live through the adapter; bookings for them snapshot the upstream state into the local booking row.
+- **External cruises** — sourced from an upstream **adapter**. Deployments choose
+  the adapter package at startup. Admin reads external cruises live through the
+  adapter; bookings for them snapshot the upstream state into the local booking
+  row.
 
 Both modes coexist in the same admin experience — a unified list with an `External` badge on adapter-sourced rows — and the bookings/payments/CRM/finance plumbing is identical across them. The architectural details are in §3.5.
 
@@ -29,15 +32,22 @@ Both modes coexist in the same admin experience — a unified list with an `Exte
 - Strict opt-in. Tenants that don't sell cruises must not have cruise tables in their database, cruise routes mounted, or cruise types bleeding into their TypeScript surface.
 - Full integration with the rest of Voyant — bookings, finance, CRM, suppliers, storage — through the same extension and link patterns the platform already uses.
 - Lead-gen and payment-capable booking, switchable per template (some agencies want one, some the other, some both depending on the line).
-- A small, well-defined **adapter contract** so Voyant Connect (default) or a custom agency-built adapter can serve external cruise inventory through the same admin and storefront paths self-managed cruises use.
+- A small, well-defined **adapter contract** so external adapter packages can
+  serve cruise inventory through the same admin and storefront paths
+  self-managed cruises use.
 - A pricing model that survives the real shape of cruise pricing: occupancy variants, fare codes, dated promotions, onboard credits, gratuities, port charges, taxes, currency, and per-sailing schedule overrides.
 - **v1 is migration-complete.** A real luxury-cruise reseller (multi-line, mixed inquiry/payment, party bookings, specific-cabin selection, dated promo overlays) can run end-to-end on v1 without waiting for a follow-up release. Anything left for "later" is called out explicitly in the non-goals; everything else ships.
 
 ### Non-goals (for v1)
 
 - **Yacht charters** (Aman, Four Seasons, Ritz-Carlton, SeaDream, A&K, Orient Express). The booking unit is a named suite at a flat price, sometimes whole-yacht. They look like cruises on the website and nothing like cruises in the schema. A separate `charters` module is the right home; until it lands, agencies that need to model these can use `products`. Forcing them into the cruise grid would re-pollute the namespace we're trying to keep clean.
-- **Cruise-line connectors bundled in OSS.** Voyant Connect owns the connectivity layer (provider applications, connections, gateway data plane, normalized replica reads) and ships per-line connectors there. This module defines the adapter contract Connect targets; it does not ship the connectors themselves.
-- **Sync orchestration / scheduling / polling.** Same reasoning — Connect handles that for its own connectors; an agency's custom adapter handles its own. The cruises module is the canonical storage + service + routes layer plus the adapter contract that runs in front of it.
+- **Cruise-line connectors bundled in OSS.** Connectivity packages own provider
+  applications, connections, gateway data planes, normalized replica reads, and
+  per-line connectors. This module defines the adapter contract; it does not
+  ship the connectors themselves.
+- **Sync orchestration / scheduling / polling.** Adapter packages own their
+  polling and retry loops. The cruises module is the canonical storage +
+  service + routes layer plus the adapter contract that runs in front of it.
 - **Real-time hold / live-book against cruise reservation systems.** Connect's domain when it lands; the cruise schema reserves `connectorBookingRef` so live bookings have somewhere to land.
 - **Wholesaler net-rate / commission split modeling.** Will piggyback on the existing channels module when it lands.
 
@@ -60,7 +70,11 @@ The same cruise the operator's customer sees can come from one of two places:
 
 **Self-managed (`source: 'local'`)** — operator publishes their own cruises. The full canonical schema in §6 is populated locally. Admin offers full CRUD. Bookings against these cruises don't talk to any upstream. Use case: a boutique line, a private charter, an in-house product an operator owns end-to-end.
 
-**External (`source: 'external'`)** — cruise lives in an upstream system reached via an **adapter**. The adapter's identity is captured by `sourceProvider` (e.g. `'voyant-connect'`, `'custom'`) and `sourceRef` (the upstream pointer). The local DB stores nothing about the cruise itself; all reads go through the adapter. Bookings snapshot the upstream state into the local booking row at confirmation time.
+**External (`source: 'external'`)** — cruise lives in an upstream system reached
+via an **adapter**. The adapter's identity is captured by `sourceProvider`
+(adapter name) and `sourceRef` (the upstream pointer). The local DB stores
+nothing about the cruise itself; all reads go through the adapter. Bookings
+snapshot the upstream state into the local booking row at confirmation time.
 
 ### What lives where
 
@@ -212,7 +226,7 @@ This section is detailed because the schema is most of the design. All tables us
 | `lowestPriceCached` | numeric(12,2) | denormalized MIN across sailings; recomputed by background task |
 | `earliestDepartureCached` | date | |
 | `latestDepartureCached` | date | |
-| `externalRefs` | jsonb | `{ "voyant-connect": "...", "<adapter-source>": "...", ... }` source-keyed external IDs |
+| `externalRefs` | jsonb | `{ "<adapter-source>": "...", ... }` source-keyed external IDs |
 | `createdAt` / `updatedAt` | timestamptz | |
 
 Indexes: `(cruiseType, status)`, `(lineSupplierId, status)`, `(slug)` unique, `(earliestDepartureCached, status)`.
@@ -429,7 +443,7 @@ This is the deliberate departure from the JSONB-per-sailing shortcut described i
 |---|---|---|
 | `id` | typeId | prefix `crsi` |
 | `source` | `cruise_source_enum` not null | `'local' \| 'external'` |
-| `sourceProvider` | text | `'voyant-connect'` \| `'custom'` (or any custom adapter name) for `external`; null for `local` |
+| `sourceProvider` | text | adapter name for `external`; null for `local` |
 | `sourceRef` | jsonb | for `external`: `{ connectionId, externalId, ... }` — opaque pointer back to the adapter |
 | `localCruiseId` | text | for `source='local'`: FK to `cruises.id`. Null for `external` |
 | `slug` | text not null | URL slug for the storefront — unique across the index |
@@ -526,7 +540,11 @@ Two Hono apps, mounted by template via `createApp({ modules: [cruisesHonoModule]
 
 ### Admin routes — `/v1/admin/cruises/*`
 
-Identifiers in admin use a unified key format: local cruises are addressed by their `cru_*` TypeID; external cruises by `<sourceProvider>:<urlSafeRef>` (e.g. `voyant-connect:cnx_abc/abc-123`). The route layer parses the key and routes to the appropriate backing store.
+Identifiers in admin use a unified key format: local cruises are addressed by
+their `cru_*` TypeID; external cruises by
+`<sourceProvider>:<encodedSourceRef>` (for example,
+`external-cruises:sr_<base64url-json>`). The route layer parses the key and
+routes to the appropriate backing store.
 
 ```
 # unified — works for any source
@@ -586,45 +604,44 @@ The `POST /sailings/:key/quote` endpoint is what an inquiry-style booking flow c
 
 ## 10. Adapter contract
 
-External cruises reach the module through a registered **adapter**. Voyant Connect is the default adapter Voyant's own templates wire up; an agency that prefers their own connectivity engine implements the same contract and registers it instead. The adapter is **swappable**, not baked in: a template can switch from Connect to a custom adapter without changing any cruises-module code.
+External cruises reach the module through a registered **adapter**. The adapter is
+**swappable**, not baked in: a template chooses the adapter package at startup
+without changing any cruises-module code. The detailed implementation contract,
+compatibility fixture, SourceRef rules, and provider-neutrality checklist live in
+[`cruise-adapter-contract.md`](./cruise-adapter-contract.md).
 
-The contract has three methods, deliberately small:
+The contract has browse/projection methods, live detail reads, and a booking
+commit method:
 
 ```ts
 // packages/cruises/src/adapters/index.ts
 export interface CruiseAdapter {
-  readonly name: string                         // 'voyant-connect', 'custom', etc.
+  readonly name: string
   readonly version: string
 
-  // Storefront projection — push slim entries into cruise_search_index.
-  // Connect calls this via a delta-stream subscription; a custom adapter can call it
-  // on whatever schedule it likes. No-op for operators that don't run a Voyant storefront.
-  searchProjection(opts: { since?: Date; cursor?: string }): AsyncIterable<CruiseSearchProjectionEntry>
+  listEntries(options?: ListEntriesOptions): Promise<ListEntriesResult>
+  searchProjection(options?: ListEntriesOptions): AsyncIterable<CruiseSearchProjectionEntry>
 
-  // Detail read for a specific external cruise / sailing / ship.
-  // Called from admin routes and from public detail routes.
-  // Shapes match the canonical types in §6 (no need to flatten — return what the upstream gives, normalized).
-  fetchCruise(sourceRef: SourceRef): Promise<ExternalCruise>
-  fetchSailing(sourceRef: SourceRef): Promise<ExternalSailing>
+  fetchCruise(sourceRef: SourceRef): Promise<ExternalCruise | null>
+  fetchSailing(sourceRef: SourceRef): Promise<ExternalSailing | null>
   fetchSailingPricing(sourceRef: SourceRef): Promise<ExternalPriceRow[]>
   fetchSailingItinerary(sourceRef: SourceRef): Promise<ExternalItineraryDay[]>
-  fetchShip(sourceRef: SourceRef): Promise<ExternalShip>
+  fetchShip(sourceRef: SourceRef): Promise<ExternalShip | null>
+  listSailingsForCruise(cruiseRef: SourceRef): Promise<ExternalSailing[]>
 
-  // Booking commit — used when creating a booking against an external cruise.
-  // Returns the upstream confirmation reference plus a fully-resolved snapshot to store
-  // in booking_cruise_details quote, terms, passenger-composition, and connector fields.
   createBooking(input: CreateExternalBookingInput): Promise<ExternalBookingResult>
 }
 
 export type SourceRef = { connectionId?: string; externalId: string; [k: string]: unknown }
 ```
 
-`SourceRef` is round-trippable adapter state, not a display id. Connect-backed
-refs should preserve connection id, provider/source key, upstream cruise,
-sailing, ship, cabin ids, synced-row ids, and opaque metadata needed by the
-adapter. Admin route keys and catalog shim entity ids use the URL-safe
+`SourceRef` is round-trippable adapter state, not a display id. Adapter-backed
+refs must preserve connection id, source namespace, upstream cruise, sailing,
+ship, cabin ids, synced-row ids, and opaque metadata needed by the adapter.
+Admin route keys and catalog shim entity ids use the URL-safe
 `encodeSourceRef(...)` form (`<provider>:sr_<base64url-json>`) so punctuation
-and adapter metadata are not reconstructed from a lossy slug.
+and adapter metadata are not reconstructed from a lossy slug. Two refs with the
+same `externalId` but different connection/source context are different rows.
 
 Connect compatibility decisions live next to the adapter contract in
 `packages/cruises/src/adapters/connect-compat.ts`:
@@ -640,19 +657,19 @@ Connect compatibility decisions live next to the adapter contract in
 Two registration points in a template:
 
 ```ts
-// templates/dmc/src/index.ts
 import { createApp } from "@voyantjs/hono"
 import { cruisesHonoModule, registerCruiseAdapter } from "@voyantjs/cruises"
-import { createConnectCruiseAdapter } from "@voyantjs/cruises-adapter-connect"
+import { createCruiseAdapter } from "external-cruise-adapter"
 
-registerCruiseAdapter(createConnectCruiseAdapter({ apiKey: env.VOYANT_CONNECT_API_KEY }))
+registerCruiseAdapter(createCruiseAdapter({ token: env.CRUISE_ADAPTER_TOKEN }))
 
 export const app = createApp({
   modules: [cruisesHonoModule, ...],
 })
 ```
 
-Templates default to the Connect adapter. Swapping it for a custom one is a single-line change.
+The framework never imports the concrete adapter package; the deployment wiring
+does.
 
 ### Where the adapter sits at request time
 

--- a/packages/cruises/README.md
+++ b/packages/cruises/README.md
@@ -4,12 +4,27 @@ Opt-in cruises module for OTA, tour-operator, and DMC deployments. Provides the
 canonical schema, services, and admin/storefront/booking integration for cruise
 inventory - both self-managed (a tour operator or DMC publishes its own
 small-scale or specialized cruises) and external (sourced from a registered
-adapter such as Voyant Connect).
+adapter package).
 
 Cruises are an inventory and operations capability inside the target scenarios,
 not a separate cruise-line implementation scenario.
 
-See [docs/architecture/cruises-module.md](../../docs/architecture/cruises-module.md) for the full design.
+See [docs/architecture/cruises-module.md](../../docs/architecture/cruises-module.md)
+for the full design and
+[docs/architecture/cruise-adapter-contract.md](../../docs/architecture/cruise-adapter-contract.md)
+for external adapter implementation requirements.
+
+## External Adapter Contract
+
+`@voyantjs/cruises` exports the provider-neutral `CruiseAdapter` contract from
+`@voyantjs/cruises/adapters`. Adapter packages register at application startup
+and keep upstream clients, credentials, and provider-specific mappings outside
+the framework package.
+
+Adapter packages can run
+`assertCruiseAdapterCompatibility(...)` against a sandbox fixture to verify full
+`SourceRef` round-tripping, multi-connection identity, detail lookup, pricing
+lookup, and booking commit payload handling.
 
 ## Status
 

--- a/packages/cruises/src/adapters/contract-fixture.ts
+++ b/packages/cruises/src/adapters/contract-fixture.ts
@@ -1,0 +1,236 @@
+import type {
+  CreateExternalBookingInput,
+  CruiseAdapter,
+  ExternalPassengerComposition,
+  ExternalPriceRow,
+  SourceRef,
+} from "./index.js"
+
+export type CruiseAdapterCompatibilityFixture = {
+  /**
+   * Two cruise refs with the same upstream `externalId` but different
+   * connection/source context. This proves the adapter keys by full SourceRef.
+   */
+  primaryCruiseRef: SourceRef
+  alternateCruiseRef: SourceRef
+  sailingRef: SourceRef
+  shipRef: SourceRef
+  cabinCategoryRef: SourceRef
+  minimumItineraryDays?: number
+  passengerComposition?: ExternalPassengerComposition | null
+  fareCode?: string | null
+  bookingInput: CreateExternalBookingInput
+}
+
+export type CruiseAdapterCompatibilityCheckName =
+  | "sourceRef.roundTrip.listEntries"
+  | "sourceRef.roundTrip.searchProjection"
+  | "sourceRef.multiConnection.fetchCruise"
+  | "detail.fetchCruise"
+  | "detail.fetchSailing"
+  | "detail.listSailingsForCruise"
+  | "detail.fetchSailingItinerary"
+  | "detail.fetchShip"
+  | "pricing.fetchSailingPricing"
+  | "booking.createBooking"
+
+export type CruiseAdapterCompatibilityCheck = {
+  name: CruiseAdapterCompatibilityCheckName
+  passed: boolean
+  detail?: string
+}
+
+export type CruiseAdapterCompatibilityReport = {
+  adapterName: string
+  adapterVersion: string
+  ok: boolean
+  checks: CruiseAdapterCompatibilityCheck[]
+}
+
+export async function validateCruiseAdapterCompatibility(
+  adapter: CruiseAdapter,
+  fixture: CruiseAdapterCompatibilityFixture,
+): Promise<CruiseAdapterCompatibilityReport> {
+  const checks: CruiseAdapterCompatibilityCheck[] = []
+
+  async function check(
+    name: CruiseAdapterCompatibilityCheckName,
+    run: () => Promise<void>,
+  ): Promise<void> {
+    try {
+      await run()
+      checks.push({ name, passed: true })
+    } catch (error) {
+      checks.push({
+        name,
+        passed: false,
+        detail: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  await check("sourceRef.roundTrip.listEntries", async () => {
+    const page = await adapter.listEntries({ limit: 100 })
+    assertHasRef(
+      page.entries.map((entry) => entry.sourceRef),
+      fixture.primaryCruiseRef,
+      "listEntries() must expose the primary cruise full SourceRef",
+    )
+    assertHasRef(
+      page.entries.map((entry) => entry.sourceRef),
+      fixture.alternateCruiseRef,
+      "listEntries() must keep same-externalId connection contexts distinct",
+    )
+  })
+
+  await check("sourceRef.roundTrip.searchProjection", async () => {
+    const refs: SourceRef[] = []
+    for await (const entry of adapter.searchProjection({ limit: 100 })) {
+      refs.push(entry.sourceRef)
+      if (refs.length >= 100) break
+    }
+    assertHasRef(refs, fixture.primaryCruiseRef, "searchProjection() must emit full SourceRef")
+    assertHasRef(
+      refs,
+      fixture.alternateCruiseRef,
+      "searchProjection() must not collapse same-externalId SourceRefs",
+    )
+  })
+
+  await check("sourceRef.multiConnection.fetchCruise", async () => {
+    const primary = await adapter.fetchCruise(fixture.primaryCruiseRef)
+    const alternate = await adapter.fetchCruise(fixture.alternateCruiseRef)
+    if (!primary) throw new Error("fetchCruise(primaryCruiseRef) returned null")
+    if (!alternate) throw new Error("fetchCruise(alternateCruiseRef) returned null")
+    assertSameRef(primary.sourceRef, fixture.primaryCruiseRef, "primary cruise SourceRef")
+    assertSameRef(alternate.sourceRef, fixture.alternateCruiseRef, "alternate cruise SourceRef")
+  })
+
+  await check("detail.fetchCruise", async () => {
+    const cruise = await adapter.fetchCruise(fixture.primaryCruiseRef)
+    if (!cruise) throw new Error("fetchCruise() returned null")
+    assertSameRef(cruise.sourceRef, fixture.primaryCruiseRef, "cruise SourceRef")
+    if (!cruise.name) throw new Error("fetchCruise() returned a cruise without a name")
+  })
+
+  await check("detail.fetchSailing", async () => {
+    const sailing = await adapter.fetchSailing(fixture.sailingRef)
+    if (!sailing) throw new Error("fetchSailing() returned null")
+    assertSameRef(sailing.sourceRef, fixture.sailingRef, "sailing SourceRef")
+    assertSameRef(sailing.cruiseRef, fixture.primaryCruiseRef, "sailing cruiseRef")
+    assertSameRef(sailing.shipRef, fixture.shipRef, "sailing shipRef")
+  })
+
+  await check("detail.listSailingsForCruise", async () => {
+    const sailings = await adapter.listSailingsForCruise(fixture.primaryCruiseRef)
+    const matching = sailings.find((sailing) => sameRef(sailing.sourceRef, fixture.sailingRef))
+    if (!matching) {
+      throw new Error("listSailingsForCruise() did not return the fixture sailing")
+    }
+    assertSameRef(matching.cruiseRef, fixture.primaryCruiseRef, "listed sailing cruiseRef")
+    assertSameRef(matching.shipRef, fixture.shipRef, "listed sailing shipRef")
+  })
+
+  await check("detail.fetchSailingItinerary", async () => {
+    const days = await adapter.fetchSailingItinerary(fixture.sailingRef)
+    const minimumDays = fixture.minimumItineraryDays ?? 1
+    if (days.length < minimumDays) {
+      throw new Error(
+        `fetchSailingItinerary() returned ${days.length} day(s); expected at least ${minimumDays}`,
+      )
+    }
+    if (days.some((day) => !Number.isInteger(day.dayNumber) || day.dayNumber < 1)) {
+      throw new Error("fetchSailingItinerary() returned a day without a positive dayNumber")
+    }
+  })
+
+  await check("detail.fetchShip", async () => {
+    const ship = await adapter.fetchShip(fixture.shipRef)
+    if (!ship) throw new Error("fetchShip() returned null")
+    assertSameRef(ship.sourceRef, fixture.shipRef, "ship SourceRef")
+    if (!ship.name) throw new Error("fetchShip() returned a ship without a name")
+  })
+
+  await check("pricing.fetchSailingPricing", async () => {
+    const prices = await adapter.fetchSailingPricing(fixture.sailingRef)
+    const matching = prices.find((price) => priceMatchesFixture(price, fixture))
+    if (!matching) {
+      throw new Error(
+        "fetchSailingPricing() did not return a row for the fixture cabin, composition, and fare",
+      )
+    }
+  })
+
+  await check("booking.createBooking", async () => {
+    const result = await adapter.createBooking(fixture.bookingInput)
+    if (!result.connectorBookingRef) {
+      throw new Error("createBooking() returned no connectorBookingRef")
+    }
+  })
+
+  return {
+    adapterName: adapter.name,
+    adapterVersion: adapter.version,
+    ok: checks.every((entry) => entry.passed),
+    checks,
+  }
+}
+
+export async function assertCruiseAdapterCompatibility(
+  adapter: CruiseAdapter,
+  fixture: CruiseAdapterCompatibilityFixture,
+): Promise<void> {
+  const report = await validateCruiseAdapterCompatibility(adapter, fixture)
+  if (report.ok) return
+  const failures = report.checks
+    .filter((entry) => !entry.passed)
+    .map((entry) => `- ${entry.name}: ${entry.detail ?? "failed"}`)
+    .join("\n")
+  throw new Error(
+    `CruiseAdapter compatibility failed for ${report.adapterName}@${report.adapterVersion}\n${failures}`,
+  )
+}
+
+function priceMatchesFixture(
+  price: ExternalPriceRow,
+  fixture: CruiseAdapterCompatibilityFixture,
+): boolean {
+  if (!sameRef(price.cabinCategoryRef, fixture.cabinCategoryRef)) return false
+  if (fixture.fareCode && price.fareCode !== fixture.fareCode) return false
+  if (fixture.passengerComposition && price.passengerComposition) {
+    return stableJson(price.passengerComposition) === stableJson(fixture.passengerComposition)
+  }
+  return !fixture.passengerComposition || !price.passengerComposition
+}
+
+function assertHasRef(refs: SourceRef[], expected: SourceRef, message: string): void {
+  if (!refs.some((ref) => sameRef(ref, expected))) {
+    throw new Error(`${message}: expected ${stableJson(expected)}`)
+  }
+}
+
+function assertSameRef(actual: SourceRef, expected: SourceRef, label: string): void {
+  if (!sameRef(actual, expected)) {
+    throw new Error(
+      `${label} mismatch: expected ${stableJson(expected)}, got ${stableJson(actual)}`,
+    )
+  }
+}
+
+function sameRef(a: SourceRef, b: SourceRef): boolean {
+  return stableJson(a) === stableJson(b)
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(sortValue(value))
+}
+
+function sortValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortValue)
+  if (!value || typeof value !== "object") return value
+  const out: Record<string, unknown> = {}
+  for (const key of Object.keys(value).sort()) {
+    out[key] = sortValue((value as Record<string, unknown>)[key])
+  }
+  return out
+}

--- a/packages/cruises/src/adapters/index.ts
+++ b/packages/cruises/src/adapters/index.ts
@@ -318,6 +318,15 @@ export interface CruiseAdapter {
 
 export type AdapterCallContext = { adapterName: string; method: string }
 
+export {
+  assertCruiseAdapterCompatibility,
+  type CruiseAdapterCompatibilityCheck,
+  type CruiseAdapterCompatibilityCheckName,
+  type CruiseAdapterCompatibilityFixture,
+  type CruiseAdapterCompatibilityReport,
+  validateCruiseAdapterCompatibility,
+} from "./contract-fixture.js"
+
 // ---------- catalog SourceAdapter shim ----------
 
 export {

--- a/packages/cruises/src/adapters/registry.ts
+++ b/packages/cruises/src/adapters/registry.ts
@@ -3,8 +3,10 @@
  *
  * Templates register adapters at app startup:
  *
- *   import { createConnectCruiseAdapter } from "@voyantjs/cruises-adapter-connect"
- *   registerCruiseAdapter(createConnectCruiseAdapter({ apiKey: env.VOYANT_CONNECT_API_KEY }))
+ *   import { registerCruiseAdapter } from "@voyantjs/cruises/adapters"
+ *   import { createCruiseAdapter } from "external-cruise-adapter"
+ *
+ *   registerCruiseAdapter(createCruiseAdapter({ token: env.CRUISE_ADAPTER_TOKEN }))
  *
  * The route layer resolves an adapter by `sourceProvider` (the prefix in the
  * unified key `<provider>:<ref>`) before dispatching detail reads, refresh,

--- a/packages/cruises/src/index.ts
+++ b/packages/cruises/src/index.ts
@@ -25,6 +25,10 @@ export type {
   AdapterCallContext,
   CreateExternalBookingInput,
   CruiseAdapter,
+  CruiseAdapterCompatibilityCheck,
+  CruiseAdapterCompatibilityCheckName,
+  CruiseAdapterCompatibilityFixture,
+  CruiseAdapterCompatibilityReport,
   CruiseSearchProjectionEntry,
   ExternalBookingResult,
   ExternalBookingTerms,
@@ -43,6 +47,10 @@ export type {
   ListEntriesOptions,
   ListEntriesResult,
   SourceRef,
+} from "./adapters/index.js"
+export {
+  assertCruiseAdapterCompatibility,
+  validateCruiseAdapterCompatibility,
 } from "./adapters/index.js"
 export { type MemoizeOptions, memoizeCruiseAdapter } from "./adapters/memoize.js"
 export { MockCruiseAdapter, type MockCruiseAdapterOptions } from "./adapters/mock.js"

--- a/packages/cruises/tests/unit/adapter-contract-fixture.test.ts
+++ b/packages/cruises/tests/unit/adapter-contract-fixture.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest"
+
+import type {
+  CreateExternalBookingInput,
+  ExternalBookingResult,
+  SourceRef,
+} from "../../src/adapters/index.js"
+import {
+  assertCruiseAdapterCompatibility,
+  validateCruiseAdapterCompatibility,
+} from "../../src/adapters/index.js"
+import { MockCruiseAdapter } from "../../src/adapters/mock.js"
+
+const primaryCruiseRef = {
+  externalId: "shared-cruise-id",
+  connectionId: "connection-a",
+  source: "catalog-a",
+}
+
+const alternateCruiseRef = {
+  externalId: "shared-cruise-id",
+  connectionId: "connection-b",
+  source: "catalog-a",
+}
+
+const shipRef = {
+  externalId: "ship-1",
+  connectionId: "connection-a",
+  source: "catalog-a",
+}
+
+const sailingRef = {
+  externalId: "sailing-1",
+  connectionId: "connection-a",
+  source: "catalog-a",
+}
+
+const cabinCategoryRef = {
+  externalId: "cat-balcony",
+  connectionId: "connection-a",
+  source: "catalog-a",
+}
+
+const bookingInput: CreateExternalBookingInput = {
+  sailingRef,
+  cabinCategoryRef,
+  occupancy: 2,
+  passengerComposition: { adults: 1, children: 1, childAges: [10] },
+  fareCode: "FLEX",
+  passengers: [
+    {
+      firstName: "Ada",
+      lastName: "Lovelace",
+      email: "ada@example.test",
+      travelerCategory: "adult",
+      isPrimary: true,
+    },
+    {
+      firstName: "Grace",
+      lastName: "Hopper",
+      travelerCategory: "child",
+    },
+  ],
+  contact: {
+    firstName: "Ada",
+    lastName: "Lovelace",
+    email: "ada@example.test",
+  },
+  bookingTerms: {
+    cancellationPolicy: { summary: "Sandbox terms" },
+  },
+}
+
+class RecordingMockCruiseAdapter extends MockCruiseAdapter {
+  lastBookingInput: CreateExternalBookingInput | null = null
+
+  async createBooking(input: CreateExternalBookingInput): Promise<ExternalBookingResult> {
+    this.lastBookingInput = input
+    return super.createBooking(input)
+  }
+}
+
+class ExternalIdOnlyAdapter extends RecordingMockCruiseAdapter {
+  async fetchCruise(ref: SourceRef) {
+    if (ref.externalId === primaryCruiseRef.externalId) {
+      return super.fetchCruise(primaryCruiseRef)
+    }
+    return super.fetchCruise(ref)
+  }
+}
+
+class MissingDetailMethodsAdapter extends RecordingMockCruiseAdapter {
+  async fetchSailingItinerary() {
+    throw new Error("itinerary not implemented")
+  }
+
+  async listSailingsForCruise() {
+    throw new Error("sailings not implemented")
+  }
+}
+
+function makeAdapter(Adapter = RecordingMockCruiseAdapter): RecordingMockCruiseAdapter {
+  const adapter = new Adapter({ name: "compat-fixture" })
+  adapter.addShip({
+    sourceRef: shipRef,
+    name: "MV Fixture",
+    slug: "mv-fixture",
+    shipType: "ocean",
+    categories: [
+      {
+        sourceRef: cabinCategoryRef,
+        code: "BAL",
+        name: "Balcony",
+        roomType: "balcony",
+        minOccupancy: 1,
+        maxOccupancy: 4,
+      },
+    ],
+  })
+  adapter.addCruise(
+    {
+      sourceRef: primaryCruiseRef,
+      name: "Primary Fixture Cruise",
+      slug: "primary-fixture-cruise",
+      cruiseType: "ocean",
+      lineName: "Fixture Line",
+      defaultShipRef: shipRef,
+      nights: 7,
+      status: "live",
+    },
+    [
+      {
+        sourceRef: sailingRef,
+        cruiseRef: primaryCruiseRef,
+        shipRef,
+        departureDate: "2027-07-01",
+        returnDate: "2027-07-08",
+        salesStatus: "open",
+      },
+    ],
+  )
+  adapter.addCruise({
+    sourceRef: alternateCruiseRef,
+    name: "Alternate Fixture Cruise",
+    slug: "alternate-fixture-cruise",
+    cruiseType: "ocean",
+    lineName: "Fixture Line",
+    defaultShipRef: shipRef,
+    nights: 7,
+    status: "live",
+  })
+  adapter.setSailingPricing(sailingRef, [
+    {
+      cabinCategoryRef,
+      occupancy: 2,
+      passengerComposition: { adults: 1, children: 1, childAges: [10] },
+      fareCode: "FLEX",
+      currency: "USD",
+      pricePerPerson: "1200.00",
+      availability: "available",
+    },
+  ])
+  adapter.setSailingItinerary(sailingRef, [
+    {
+      dayNumber: 1,
+      title: "Embarkation",
+      portName: "Athens",
+      departureTime: "17:00",
+    },
+    {
+      dayNumber: 2,
+      title: "At sea",
+      isSeaDay: true,
+    },
+  ])
+  adapter.setBookingResult(sailingRef, cabinCategoryRef, {
+    connectorBookingRef: "SANDBOX-123",
+    connectorStatus: "confirmed",
+  })
+  return adapter
+}
+
+describe("CruiseAdapter compatibility fixture", () => {
+  it("validates full SourceRef identity, pricing lookup, details, and booking payloads", async () => {
+    const adapter = makeAdapter()
+
+    await assertCruiseAdapterCompatibility(adapter, {
+      primaryCruiseRef,
+      alternateCruiseRef,
+      sailingRef,
+      shipRef,
+      cabinCategoryRef,
+      minimumItineraryDays: 2,
+      passengerComposition: { adults: 1, children: 1, childAges: [10] },
+      fareCode: "FLEX",
+      bookingInput,
+    })
+
+    expect(adapter.lastBookingInput).toEqual(bookingInput)
+  })
+
+  it("flags adapters that collapse same-externalId refs across connections", async () => {
+    const adapter = makeAdapter(ExternalIdOnlyAdapter)
+
+    const report = await validateCruiseAdapterCompatibility(adapter, {
+      primaryCruiseRef,
+      alternateCruiseRef,
+      sailingRef,
+      shipRef,
+      cabinCategoryRef,
+      minimumItineraryDays: 2,
+      passengerComposition: { adults: 1, children: 1, childAges: [10] },
+      fareCode: "FLEX",
+      bookingInput,
+    })
+
+    expect(report.ok).toBe(false)
+    expect(
+      report.checks.some(
+        (check) => check.name === "sourceRef.multiConnection.fetchCruise" && !check.passed,
+      ),
+    ).toBe(true)
+  })
+
+  it("flags adapters that do not implement required sailing and itinerary detail reads", async () => {
+    const adapter = makeAdapter(MissingDetailMethodsAdapter)
+
+    const report = await validateCruiseAdapterCompatibility(adapter, {
+      primaryCruiseRef,
+      alternateCruiseRef,
+      sailingRef,
+      shipRef,
+      cabinCategoryRef,
+      minimumItineraryDays: 2,
+      passengerComposition: { adults: 1, children: 1, childAges: [10] },
+      fareCode: "FLEX",
+      bookingInput,
+    })
+
+    expect(report.ok).toBe(false)
+    expect(
+      report.checks.some((check) => check.name === "detail.listSailingsForCruise" && !check.passed),
+    ).toBe(true)
+    expect(
+      report.checks.some((check) => check.name === "detail.fetchSailingItinerary" && !check.passed),
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Add a provider-neutral external cruise adapter contract document covering SourceRef semantics, method expectations, catalog shim usage, and registration wiring.
- Export a runner-agnostic cruise adapter compatibility fixture for external adapter packages.
- Add unit coverage for full SourceRef round-tripping, multi-connection identity, detail lookup, pricing lookup, and booking payload handling.
- Update the cruises README and design doc to point adapter authors at the contract and remove concrete adapter registration examples.

Closes #1389

## Verification
- pnpm --filter @voyantjs/cruises lint
- pnpm --filter @voyantjs/cruises typecheck
- pnpm --filter @voyantjs/cruises test
- commit hook affected checks passed
- pre-push full test task passed