### PR TITLE
Add finance schedule due date policy hook

### DIFF
--- a/.changeset/finance-schedule-due-date-policy.md
+++ b/.changeset/finance-schedule-due-date-policy.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/finance": patch
+"@voyantjs/finance-ui": patch
+---
+
+Expose invoice-from-booking due-date resolver hooks for schedule-derived documents and clamp overdue schedule dates in operator runtimes.

--- a/apps/dev/src/api/app.ts
+++ b/apps/dev/src/api/app.ts
@@ -77,6 +77,8 @@ const financeModule = createFinanceHonoModule({
       baseUrl: env.VOYANT_CLOUD_API_URL,
     })
   },
+  invoiceDueDateResolver: ({ issueDate, dueDate, bookingPaymentSchedule }) =>
+    bookingPaymentSchedule && dueDate < issueDate ? issueDate : dueDate,
 })
 
 const publicDocumentDeliveryModule = createPublicDocumentDeliveryHonoModule<CloudflareBindings>({

--- a/packages/finance-ui/src/components/booking-invoice-dialog.tsx
+++ b/packages/finance-ui/src/components/booking-invoice-dialog.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import {
+  type BookingPaymentScheduleRecord,
   type InvoiceRecord,
   type PaymentMethod,
   useBookingPaymentSchedules,
@@ -32,7 +33,7 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 
 import { useFinanceUiMessagesOrDefault } from "../i18n/index.js"
 
-type InvoiceTypeChoice = "invoice" | "proforma"
+export type InvoiceTypeChoice = "invoice" | "proforma"
 type SourceChoice = "custom" | "schedule"
 
 interface LineItemDraft {
@@ -48,6 +49,20 @@ export interface BookingInvoiceDialogUpload {
   mimeType: string
   fileSize: number
 }
+
+export interface BookingInvoiceDueDateResolverInput {
+  issueDate: string
+  dueDate: string
+  invoiceType: InvoiceTypeChoice
+  booking: {
+    id: string
+    currency: string
+    amountCents: number | null
+  }
+  bookingPaymentSchedule: BookingPaymentScheduleRecord
+}
+
+export type BookingInvoiceDueDateResolver = (input: BookingInvoiceDueDateResolverInput) => string
 
 export interface BookingInvoiceDialogProps {
   open: boolean
@@ -73,6 +88,12 @@ export interface BookingInvoiceDialogProps {
    * would apply server-side at issuance. Defaults to 0 when omitted.
    */
   defaultScheduleTaxRatePercent?: number
+  /**
+   * Resolve the legal document due date when an invoice/proforma is
+   * derived from a payment schedule. Defaults to the schedule due date
+   * for backwards compatibility.
+   */
+  resolveScheduleDueDate?: BookingInvoiceDueDateResolver
   onSuccess?: (invoice: InvoiceRecord) => void
 }
 
@@ -155,6 +176,7 @@ export function BookingInvoiceDialog({
   defaultAmountCents = null,
   uploadFile,
   defaultScheduleTaxRatePercent = 0,
+  resolveScheduleDueDate,
   onSuccess,
 }: BookingInvoiceDialogProps) {
   const { createFromBooking } = useInvoiceMutation()
@@ -237,7 +259,6 @@ export function BookingInvoiceDialog({
       return
     }
     setCurrency(selectedSchedule.currency)
-    setDueDate(selectedSchedule.dueDate)
     // The schedule amount is the gross (customer-facing) sum, so the
     // line item's net unit price is `amount / (1 + tax%)`. Without this
     // back-out the line would compute as `amount + amount * tax%`,
@@ -257,6 +278,32 @@ export function BookingInvoiceDialog({
       },
     ])
   }, [source, selectedSchedule, defaultScheduleTaxRatePercent])
+
+  useEffect(() => {
+    if (source !== "schedule" || !selectedSchedule) return
+    setDueDate(
+      resolveScheduleDueDate?.({
+        issueDate,
+        dueDate: selectedSchedule.dueDate,
+        invoiceType,
+        booking: {
+          id: bookingId,
+          currency: defaultCurrency,
+          amountCents: defaultAmountCents,
+        },
+        bookingPaymentSchedule: selectedSchedule,
+      }) ?? selectedSchedule.dueDate,
+    )
+  }, [
+    source,
+    selectedSchedule,
+    resolveScheduleDueDate,
+    issueDate,
+    invoiceType,
+    bookingId,
+    defaultCurrency,
+    defaultAmountCents,
+  ])
 
   // ---- line item totals ----------------------------------------------------
   // When the operator entered explicit line items, the global Subtotal/Tax/

--- a/packages/finance-ui/src/index.ts
+++ b/packages/finance-ui/src/index.ts
@@ -2,6 +2,9 @@ export {
   BookingInvoiceDialog,
   type BookingInvoiceDialogProps,
   type BookingInvoiceDialogUpload,
+  type BookingInvoiceDueDateResolver,
+  type BookingInvoiceDueDateResolverInput,
+  type InvoiceTypeChoice,
 } from "./components/booking-invoice-dialog.js"
 export {
   actionLedgerRiskVariant,

--- a/packages/finance/src/route-runtime.ts
+++ b/packages/finance/src/route-runtime.ts
@@ -4,6 +4,7 @@ import type { InvoiceFxOptions } from "./invoice-fx.js"
 import type { FinanceDocumentRouteOptions, InvoiceDocumentGenerator } from "./routes-documents.js"
 import type { FinanceSettlementRouteOptions, InvoiceSettlementPoller } from "./routes-settlement.js"
 import type {
+  InvoiceDueDateResolver,
   InvoiceLineDescriptionResolver,
   PaymentScheduleLineDescriptionFormat,
 } from "./service.js"
@@ -14,6 +15,7 @@ export type FinanceRouteRuntime = {
   invoiceSettlementPollers: Record<string, InvoiceSettlementPoller>
   eventBus?: EventBus
   descriptionResolver?: InvoiceLineDescriptionResolver
+  invoiceDueDateResolver?: InvoiceDueDateResolver
   paymentScheduleLineDescriptionFormat?: PaymentScheduleLineDescriptionFormat
 } & InvoiceFxOptions
 
@@ -24,6 +26,7 @@ export interface FinanceRuntimeOptions
     FinanceSettlementRouteOptions,
     InvoiceFxOptions {
   descriptionResolver?: InvoiceLineDescriptionResolver
+  invoiceDueDateResolver?: InvoiceDueDateResolver
   paymentScheduleLineDescriptionFormat?: PaymentScheduleLineDescriptionFormat
 }
 
@@ -39,6 +42,7 @@ export function buildFinanceRouteRuntime(
       options.resolveInvoiceSettlementPollers?.(bindings) ?? options.invoiceSettlementPollers ?? {},
     eventBus: options.resolveEventBus?.(bindings) ?? options.eventBus,
     descriptionResolver: options.descriptionResolver,
+    invoiceDueDateResolver: options.invoiceDueDateResolver,
     paymentScheduleLineDescriptionFormat: options.paymentScheduleLineDescriptionFormat,
     invoiceFxSettings: options.invoiceFxSettings,
     resolveInvoiceFxSettings: options.resolveInvoiceFxSettings,

--- a/packages/finance/src/routes-booking-create.ts
+++ b/packages/finance/src/routes-booking-create.ts
@@ -34,12 +34,7 @@ const createBookingRoutes = new Hono<{
 
     const outcome = await createBooking(c.get("db"), input, {
       userId: c.get("userId"),
-      runtime: runtime
-        ? {
-            eventBus: runtime.eventBus,
-            invoiceDocumentGenerator: runtime.invoiceDocumentGenerator,
-          }
-        : undefined,
+      runtime: runtime ?? undefined,
     })
 
     switch (outcome.status) {

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -11,7 +11,6 @@ import {
 import type { Booking, BookingGroupMember, BookingTraveler } from "@voyantjs/bookings/schema"
 import { bookingItems, bookingItemTravelers, bookingTravelers } from "@voyantjs/bookings/schema"
 import { bookingStatusSchema } from "@voyantjs/bookings/validation"
-import type { EventBus } from "@voyantjs/core"
 import { eq, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { z } from "zod"
@@ -24,7 +23,7 @@ import type {
   VoucherRedemption,
 } from "./schema.js"
 import { bookingPaymentSchedules, vouchers } from "./schema.js"
-import { financeService, toRows } from "./service.js"
+import { type FinanceServiceRuntime, financeService, toRows } from "./service.js"
 import { financeDocumentsService, type InvoiceDocumentGenerator } from "./service-documents.js"
 import { VoucherServiceError, vouchersService } from "./service-vouchers.js"
 import {
@@ -418,8 +417,7 @@ export type BookingCreateTravelerInput = z.infer<typeof travelerInputSchema>
  * with the booking service itself (the booking lands in `draft` status so no
  * `booking.confirmed` should fire here).
  */
-export interface BookingCreateRuntime {
-  eventBus?: EventBus
+export interface BookingCreateRuntime extends FinanceServiceRuntime {
   invoiceDocumentGenerator?: InvoiceDocumentGenerator
   bindings?: Record<string, unknown>
 }
@@ -1218,6 +1216,8 @@ export async function createBooking(
       input.paymentSchedules?.find((schedule) => schedule.dueDate)?.dueDate ??
       result.booking.endDate ??
       issueDate
+    const dueDatePaymentSchedule =
+      result.paymentSchedules.find((schedule) => schedule.dueDate === dueDate) ?? null
 
     const invoice = await financeService.createInvoiceFromBooking(
       db,
@@ -1229,7 +1229,8 @@ export async function createBooking(
         invoiceType: documentGeneration.invoiceType,
         notes: "Generated from booking create.",
       },
-      { booking: result.booking, items },
+      { booking: result.booking, dueDatePaymentSchedule, items },
+      runtime,
     )
 
     result = {

--- a/packages/finance/src/service.ts
+++ b/packages/finance/src/service.ts
@@ -439,6 +439,16 @@ export class InvoiceLineItemsPersistenceError extends Error {
 }
 
 /** Booking data needed for createInvoiceFromBooking — supplied by the caller (template). */
+export type InvoiceFromBookingPaymentScheduleData = {
+  id: string
+  bookingId: string
+  bookingItemId: string | null
+  scheduleType: "deposit" | "installment" | "balance" | "hold" | "other"
+  dueDate: string
+  currency: string
+  amountCents: number
+}
+
 export interface InvoiceFromBookingData {
   booking: {
     id: string
@@ -453,15 +463,8 @@ export interface InvoiceFromBookingData {
     sellAmountCents: number | null
     baseSellAmountCents: number | null
   }
-  paymentSchedule?: {
-    id: string
-    bookingId: string
-    bookingItemId: string | null
-    scheduleType: "deposit" | "installment" | "balance" | "hold" | "other"
-    dueDate: string
-    currency: string
-    amountCents: number
-  } | null
+  paymentSchedule?: InvoiceFromBookingPaymentScheduleData | null
+  dueDatePaymentSchedule?: InvoiceFromBookingPaymentScheduleData | null
   items: Array<{
     id: string
     title: string
@@ -743,7 +746,8 @@ async function resolveInvoiceFromBookingDueDate(
     dueDate: data.dueDate,
     invoiceType: data.invoiceType ?? "invoice",
     booking: bookingData.booking,
-    bookingPaymentSchedule: bookingData.paymentSchedule ?? undefined,
+    bookingPaymentSchedule:
+      bookingData.paymentSchedule ?? bookingData.dueDatePaymentSchedule ?? undefined,
   })
 
   if (!dueDate) {

--- a/packages/finance/src/service.ts
+++ b/packages/finance/src/service.ts
@@ -502,6 +502,18 @@ export type InvoiceLineDescriptionResolver = (
   input: InvoiceLineDescriptionResolverInput,
 ) => string | Promise<string>
 
+export interface InvoiceDueDateResolverInput {
+  issueDate: string
+  dueDate: string
+  invoiceType: NonNullable<CreateInvoiceFromBookingInput["invoiceType"]>
+  booking: InvoiceFromBookingData["booking"]
+  bookingPaymentSchedule?: NonNullable<InvoiceFromBookingData["paymentSchedule"]>
+}
+
+export type InvoiceDueDateResolver = (
+  input: InvoiceDueDateResolverInput,
+) => string | Promise<string>
+
 const PAYMENT_SCHEDULE_LINE_LABELS: Record<
   NonNullable<InvoiceFromBookingData["paymentSchedule"]>["scheduleType"],
   string
@@ -717,6 +729,34 @@ async function resolveInvoiceLineDescriptions(
         })) ?? line.description,
     })),
   )
+}
+
+async function resolveInvoiceFromBookingDueDate(
+  data: CreateInvoiceFromBookingInput,
+  bookingData: InvoiceFromBookingData,
+  runtime: FinanceServiceRuntime,
+) {
+  if (!runtime.invoiceDueDateResolver) return data.dueDate
+
+  const dueDate = await runtime.invoiceDueDateResolver({
+    issueDate: data.issueDate,
+    dueDate: data.dueDate,
+    invoiceType: data.invoiceType ?? "invoice",
+    booking: bookingData.booking,
+    bookingPaymentSchedule: bookingData.paymentSchedule ?? undefined,
+  })
+
+  if (!dueDate) {
+    throw new InvoiceFromBookingValidationError(
+      "Invoice due date resolver returned an empty date",
+      {
+        issueDate: data.issueDate,
+        dueDate: data.dueDate,
+      },
+    )
+  }
+
+  return dueDate
 }
 
 function assertInvoiceFromBookingOverrideTotals(
@@ -998,6 +1038,7 @@ export interface FinanceServiceRuntime extends InvoiceFxOptions {
   actionLedgerContext?: ActionLedgerRequestContextValues
   actionLedgerAuthorizationSource?: string | null
   descriptionResolver?: InvoiceLineDescriptionResolver
+  invoiceDueDateResolver?: InvoiceDueDateResolver
   paymentScheduleLineDescriptionFormat?: PaymentScheduleLineDescriptionFormat
 }
 
@@ -3848,6 +3889,7 @@ export const financeService = {
     runtime: FinanceServiceRuntime = {},
   ) {
     const { booking, items, paymentSchedule } = bookingData
+    const invoiceDueDate = await resolveInvoiceFromBookingDueDate(data, bookingData, runtime)
     const requestedCurrency = normalizeCurrencyCode(data.currency)
     const bookingSellCurrency = normalizeCurrencyCode(booking.sellCurrency) ?? booking.sellCurrency
     const invoiceCurrency =
@@ -4049,7 +4091,7 @@ export const financeService = {
             baseBalanceDueCents: hasBaseCurrency ? invoiceBaseAmountCents : null,
             commissionAmountCents: commissionAmountCents > 0 ? commissionAmountCents : null,
             issueDate: data.issueDate,
-            dueDate: data.dueDate,
+            dueDate: invoiceDueDate,
             notes: data.notes ?? null,
           })
           .returning()

--- a/packages/finance/tests/integration/booking-create.test.ts
+++ b/packages/finance/tests/integration/booking-create.test.ts
@@ -544,6 +544,46 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
     expect(renditionRows[0]?.status).toBe("pending")
   })
 
+  it("applies the invoice due-date resolver to schedule-derived booking-create invoices", async () => {
+    const { productId } = await seedProduct()
+    let resolverScheduleDueDate: string | null = null
+
+    const outcome = await createBooking(
+      db,
+      {
+        productId,
+        bookingNumber: nextBookingNumber(),
+        ...bookingParty(),
+        paymentSchedules: [
+          {
+            scheduleType: "balance",
+            dueDate: "2020-01-01",
+            currency: "EUR",
+            amountCents: 50000,
+          },
+        ],
+        documentGeneration: {
+          contractDocument: false,
+          invoiceDocument: true,
+        },
+      },
+      {
+        runtime: {
+          invoiceDueDateResolver: ({ issueDate, dueDate, bookingPaymentSchedule }) => {
+            resolverScheduleDueDate = bookingPaymentSchedule?.dueDate ?? null
+            return bookingPaymentSchedule && dueDate < issueDate ? issueDate : dueDate
+          },
+        },
+      },
+    )
+
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+    expect(resolverScheduleDueDate).toBe("2020-01-01")
+    expect(outcome.result.invoice?.issueDate).toBeTruthy()
+    expect(outcome.result.invoice?.dueDate).toBe(outcome.result.invoice?.issueDate)
+  })
+
   it("creates explicit booking item lines for multiple selected units", async () => {
     const { productId, optionId, unitId } = await seedProduct()
     const secondUnitId = `opun_bc_single_${productSeq}`

--- a/packages/finance/tests/unit/route-runtime.test.ts
+++ b/packages/finance/tests/unit/route-runtime.test.ts
@@ -3,14 +3,46 @@ import { describe, expect, it } from "vitest"
 import { buildFinanceRouteRuntime } from "../../src/route-runtime.js"
 
 describe("buildFinanceRouteRuntime", () => {
-  it("exposes invoice line description resolver options", async () => {
+  it("exposes invoice-from-booking resolver options", async () => {
     const descriptionResolver = () => "Custom legal line"
+    const invoiceDueDateResolver = () => "2026-05-23"
     const runtime = buildFinanceRouteRuntime(
       {},
-      { descriptionResolver, paymentScheduleLineDescriptionFormat: "product_only" },
+      {
+        descriptionResolver,
+        invoiceDueDateResolver,
+        paymentScheduleLineDescriptionFormat: "product_only",
+      },
     )
 
     expect(runtime.paymentScheduleLineDescriptionFormat).toBe("product_only")
+    expect(
+      runtime.invoiceDueDateResolver?.({
+        issueDate: "2026-05-23",
+        dueDate: "2026-05-01",
+        invoiceType: "invoice",
+        booking: {
+          id: "book_123",
+          bookingNumber: "BK-123",
+          personId: null,
+          organizationId: null,
+          sellCurrency: "RON",
+          baseCurrency: null,
+          fxRateSetId: null,
+          sellAmountCents: 12_000,
+          baseSellAmountCents: null,
+        },
+        bookingPaymentSchedule: {
+          id: "bps_123",
+          bookingId: "book_123",
+          bookingItemId: null,
+          scheduleType: "balance",
+          dueDate: "2026-05-01",
+          currency: "RON",
+          amountCents: 12_000,
+        },
+      }),
+    ).toBe("2026-05-23")
     expect(
       runtime.descriptionResolver?.({
         booking: {

--- a/packages/finance/tests/unit/service-invoice-number-allocation.test.ts
+++ b/packages/finance/tests/unit/service-invoice-number-allocation.test.ts
@@ -624,6 +624,54 @@ describe("financeService.createInvoiceFromBooking number allocation", () => {
     })
   })
 
+  it("lets callers resolve schedule-derived invoice due dates", async () => {
+    const { db, insertedInvoices } = makeDb({})
+    const invoiceDueDateResolver = vi.fn(({ issueDate }) => issueDate)
+
+    await financeService.createInvoiceFromBooking(
+      db,
+      {
+        bookingId: "book_123",
+        invoiceNumber: "MANUAL-1",
+        issueDate: "2026-05-23",
+        dueDate: "2026-05-01",
+        invoiceType: "proforma",
+      },
+      {
+        ...bookingData,
+        paymentSchedule: {
+          id: "bps_123",
+          bookingId: "book_123",
+          bookingItemId: null,
+          scheduleType: "balance",
+          dueDate: "2026-05-01",
+          currency: "RON",
+          amountCents: 12_000,
+        },
+      },
+      { invoiceDueDateResolver },
+    )
+
+    expect(invoiceDueDateResolver).toHaveBeenCalledWith({
+      issueDate: "2026-05-23",
+      dueDate: "2026-05-01",
+      invoiceType: "proforma",
+      booking: bookingData.booking,
+      bookingPaymentSchedule: {
+        id: "bps_123",
+        bookingId: "book_123",
+        bookingItemId: null,
+        scheduleType: "balance",
+        dueDate: "2026-05-01",
+        currency: "RON",
+        amountCents: 12_000,
+      },
+    })
+    expect(insertedInvoices[0]).toMatchObject({
+      dueDate: "2026-05-23",
+    })
+  })
+
   it("persists external refs in the invoice transaction", async () => {
     const { db, insertedInvoiceExternalRefs } = makeDb({})
 

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -236,6 +236,8 @@ const financeModule = createFinanceHonoModule({
     resolveOperatorDocumentDownloadUrl(bindings, storageKey),
   resolveInvoiceExchangeRateResolver: createOperatorInvoiceExchangeRateResolver,
   resolveInvoiceSettlementPollers: createOperatorInvoiceSettlementPollers,
+  invoiceDueDateResolver: ({ issueDate, dueDate, bookingPaymentSchedule }) =>
+    bookingPaymentSchedule && dueDate < issueDate ? issueDate : dueDate,
 })
 const legalModule = createLegalHonoModule({
   // KNOWN LEAK: same shape as the bookings `resolveDb` above — leaks a

--- a/templates/operator/src/components/voyant/bookings/booking-invoices-card.tsx
+++ b/templates/operator/src/components/voyant/bookings/booking-invoices-card.tsx
@@ -43,6 +43,10 @@ async function uploadInvoiceAttachment(file: File): Promise<BookingInvoiceDialog
   }
 }
 
+function clampScheduleInvoiceDueDate(input: { issueDate: string; dueDate: string }) {
+  return input.dueDate < input.issueDate ? input.issueDate : input.dueDate
+}
+
 interface InvoiceRow {
   id: string
   invoiceNumber: string
@@ -321,6 +325,7 @@ export function BookingInvoicesCard({
         defaultCurrency={defaultCurrency}
         defaultAmountCents={defaultAmountCents ?? null}
         defaultScheduleTaxRatePercent={scheduleTaxRatePercent}
+        resolveScheduleDueDate={clampScheduleInvoiceDueDate}
         uploadFile={uploadInvoiceAttachment}
       />
 


### PR DESCRIPTION
## Summary
- Add an invoice-from-booking due date resolver to the finance runtime and service path
- Expose a matching schedule due date resolver prop in the booking invoice dialog
- Clamp overdue schedule-derived due dates to the issue date in operator/dev runtimes

## Verification
- pnpm --filter @voyantjs/finance test -- tests/unit/route-runtime.test.ts tests/unit/service-invoice-number-allocation.test.ts
- pnpm --filter @voyantjs/finance typecheck
- pnpm --filter @voyantjs/finance-ui typecheck
- pnpm --filter operator typecheck
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter dev typecheck
- pnpm --filter @voyantjs/finance lint
- pnpm --filter @voyantjs/finance-ui lint
- pnpm --filter operator lint
- pnpm --filter dev lint
- pre-commit lint + full Turbo typecheck
- pre-push full test suite

Closes #1395