### PR TITLE
Fix name-only booking traveler CRM resolution

### DIFF
--- a/.changeset/name-only-booking-travelers.md
+++ b/.changeset/name-only-booking-travelers.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/bookings": patch
+"@voyantjs/crm": patch
+---
+
+Prevent public booking session state saves from repeatedly resolving position-matched traveler people, and add a CRM option to skip creating people for name-only contact snapshots.

--- a/apps/dev/src/api/app.ts
+++ b/apps/dev/src/api/app.ts
@@ -87,10 +87,11 @@ const crmHonoModule = createCrmHonoModule()
 const bookingsHonoModule = createBookingsHonoModule({
   resolveTravelSnapshot: (db, personId, { kms }) =>
     crmService.loadPersonTravelSnapshot(db, personId, { kms }),
-  // See issue #961 — storefront booking flows resolve CRM people from
-  // billing contact + per-traveler snapshots, dedupe by normalized
-  // email/phone, upsert on miss. Mirrored from the DMC + operator
-  // templates so the dev playground sees the same shape.
+  // See issues #961 / #1399 — storefront booking flows resolve CRM
+  // people from billing contact + per-traveler snapshots, dedupe by
+  // normalized email/phone, and keep name-only traveler snapshots
+  // booking-only. Mirrored from the DMC + operator templates so the dev
+  // playground sees the same shape.
   resolveBillingPerson: async (db, contact, ctx) => {
     const person = await crmService.upsertPersonFromContact(db, contact, {
       source: ctx.source,
@@ -102,6 +103,7 @@ const bookingsHonoModule = createBookingsHonoModule({
     const person = await crmService.upsertPersonFromContact(db, contact, {
       source: ctx.source,
       sourceRef: ctx.sourceRef,
+      requireContactPoint: true,
     })
     return person?.id ?? null
   },

--- a/packages/bookings/src/service-public.ts
+++ b/packages/bookings/src/service-public.ts
@@ -319,8 +319,9 @@ async function syncTravelerRowsFromStatePayload(
       (participant.id
         ? undefined
         : existingTravelers.find((traveler) => !usedExistingIds.has(traveler.id)))
+    const hasStableContactPoint = Boolean(participant.email?.trim() || participant.phone?.trim())
     const reusablePersonId =
-      participant.id && matchingExisting?.id === participant.id ? matchingExisting.personId : null
+      participant.id || !hasStableContactPoint ? (matchingExisting?.personId ?? null) : null
     const personId = await resolveTravelerPersonForParticipant(
       db,
       resolvers.resolveTravelerPerson,

--- a/packages/bookings/tests/integration/public-routes.test.ts
+++ b/packages/bookings/tests/integration/public-routes.test.ts
@@ -714,6 +714,100 @@ describe.skipIf(!DB_AVAILABLE)("Public booking routes", () => {
     )
   })
 
+  it("preserves a position-matched traveler person link when state omits row ids", async () => {
+    const slot = await seedSlot()
+
+    const createRes = await app.request("/sessions", {
+      method: "POST",
+      ...json({
+        sellCurrency: "EUR",
+        items: [
+          {
+            title: "Sibiu weekend",
+            availabilitySlotId: slot.id,
+            quantity: 1,
+            totalSellAmountCents: 18000,
+            productId: slot.productId,
+            optionId: slot.optionId,
+          },
+        ],
+      }),
+    })
+
+    const session = (await createRes.json()).data
+
+    const firstStateRes = await app.request(`/sessions/${session.sessionId}/state`, {
+      method: "PUT",
+      headers: { ...json({}).headers, ...capabilityHeaders(session) },
+      body: JSON.stringify({
+        currentStep: "rooms",
+        completedSteps: ["travelers"],
+        payload: {
+          stepData: {
+            travelers: {
+              travelers: [
+                {
+                  firstName: "Companion",
+                  lastName: "One",
+                  travelerCategory: "adult",
+                },
+              ],
+            },
+          },
+        },
+      }),
+    })
+
+    expect(firstStateRes.status).toBe(200)
+
+    const [firstTraveler] = await db
+      .select()
+      .from(bookingTravelers)
+      .where(eq(bookingTravelers.bookingId, session.sessionId))
+
+    expect(firstTraveler?.personId).toBe(
+      travelerPersonId({ firstName: "Companion", lastName: "One" }),
+    )
+
+    const secondStateRes = await app.request(`/sessions/${session.sessionId}/state`, {
+      method: "PUT",
+      headers: { ...json({}).headers, ...capabilityHeaders(session) },
+      body: JSON.stringify({
+        currentStep: "rooms",
+        completedSteps: ["travelers"],
+        payload: {
+          stepData: {
+            travelers: {
+              travelers: [
+                {
+                  firstName: "Companion",
+                  lastName: "Edited",
+                  travelerCategory: "adult",
+                },
+              ],
+            },
+          },
+        },
+      }),
+    })
+
+    expect(secondStateRes.status).toBe(200)
+
+    const [updatedTraveler] = await db
+      .select()
+      .from(bookingTravelers)
+      .where(eq(bookingTravelers.bookingId, session.sessionId))
+
+    expect(updatedTraveler).toEqual(
+      expect.objectContaining({
+        id: firstTraveler?.id,
+        firstName: "Companion",
+        lastName: "Edited",
+        personId: firstTraveler?.personId,
+      }),
+    )
+  })
+
   it("syncs billing contact from wizard state into the booking snapshot", async () => {
     const slot = await seedSlot()
 

--- a/packages/crm/src/service/accounts-resolve.ts
+++ b/packages/crm/src/service/accounts-resolve.ts
@@ -34,6 +34,11 @@ export interface UpsertPersonFromContactOptions {
   tags?: string[]
   /** Status override; defaults to `"active"`. */
   status?: "active" | "inactive"
+  /**
+   * When true, returns `null` instead of creating a person if the
+   * snapshot has no email or phone dedupe key.
+   */
+  requireContactPoint?: boolean
 }
 
 function splitName(name: string | null | undefined): {
@@ -133,6 +138,10 @@ export async function upsertPersonFromContact(
   if (phone) {
     const existing = await findPersonByContactPoint(db, { kind: "phone", value: phone })
     if (existing) return existing
+  }
+
+  if (options.requireContactPoint && !email && !phone) {
+    return null
   }
 
   // No match — create a new person. `personNameFromContact` ensures

--- a/packages/crm/tests/integration/accounts-resolve.test.ts
+++ b/packages/crm/tests/integration/accounts-resolve.test.ts
@@ -102,4 +102,14 @@ describe.skipIf(!DB_AVAILABLE)("CRM person resolution helpers (issue #961)", () 
     expect(created?.firstName).toBe("lonely traveler")
     expect(created?.lastName).toBe("Guest")
   })
+
+  it("upsertPersonFromContact can skip name-only snapshots without a contact point", async () => {
+    const created = await upsertPersonFromContact(
+      db,
+      { firstName: "Name", lastName: "Only" },
+      { source: "storefront-booking", sourceRef: "book_100", requireContactPoint: true },
+    )
+
+    expect(created).toBeNull()
+  })
 })

--- a/templates/dmc/src/api/app.ts
+++ b/templates/dmc/src/api/app.ts
@@ -112,10 +112,10 @@ const bookingsHonoModule = createBookingsHonoModule({
   resolveTravelSnapshot: (db, personId, { kms }) =>
     crmService.loadPersonTravelSnapshot(db, personId, { kms }),
   // Storefront booking session bootstrap + update flows hand the
-  // billing contact and per-traveler snapshots to this resolver, which
-  // dedupes by normalized email/phone via `identity_contact_points` and
-  // upserts a CRM person on miss. Returns the resolved person id (or
-  // `null` to skip linkage on this row). See issue #961.
+  // billing contact and per-traveler snapshots to these resolvers. They
+  // dedupe by normalized email/phone via `identity_contact_points` and
+  // upsert a CRM person on miss; traveler snapshots without email/phone
+  // stay booking-only until explicitly linked. See issues #961 / #1399.
   resolveBillingPerson: async (db, contact, ctx) => {
     const person = await crmService.upsertPersonFromContact(db, contact, {
       source: ctx.source,
@@ -127,6 +127,7 @@ const bookingsHonoModule = createBookingsHonoModule({
     const person = await crmService.upsertPersonFromContact(db, contact, {
       source: ctx.source,
       sourceRef: ctx.sourceRef,
+      requireContactPoint: true,
     })
     return person?.id ?? null
   },

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -207,10 +207,10 @@ const bookingsHonoModule = createBookingsHonoModule({
   resolveTravelSnapshot: (db, personId, { kms }) =>
     crmService.loadPersonTravelSnapshot(db, personId, { kms }),
   // Storefront booking session bootstrap + update flows hand the
-  // billing contact and per-traveler snapshots to this resolver, which
-  // dedupes by normalized email/phone via `identity_contact_points` and
-  // upserts a CRM person on miss. Returns the resolved person id (or
-  // `null` to skip linkage on this row). See issue #961.
+  // billing contact and per-traveler snapshots to these resolvers. They
+  // dedupe by normalized email/phone via `identity_contact_points` and
+  // upsert a CRM person on miss; traveler snapshots without email/phone
+  // stay booking-only until explicitly linked. See issues #961 / #1399.
   resolveBillingPerson: async (db, contact, ctx) => {
     const person = await crmService.upsertPersonFromContact(db, contact, {
       source: ctx.source,
@@ -222,6 +222,7 @@ const bookingsHonoModule = createBookingsHonoModule({
     const person = await crmService.upsertPersonFromContact(db, contact, {
       source: ctx.source,
       sourceRef: ctx.sourceRef,
+      requireContactPoint: true,
     })
     return person?.id ?? null
   },


### PR DESCRIPTION
## Summary

- Add `requireContactPoint` to `upsertPersonFromContact` so CRM callers can skip creating people when a contact snapshot has no email or phone.
- Wire booking traveler CRM resolution in dev/operator/DMC apps to require a contact point, leaving name-only traveler snapshots booking-only.
- Preserve an existing traveler `person_id` for position-matched name-only wizard state updates when clients do not round-trip traveler row ids.

Closes #1399.

## Verification

- `pnpm --filter @voyantjs/bookings typecheck`
- `pnpm --filter @voyantjs/crm typecheck`
- `pnpm --filter @voyantjs/bookings test`
- `pnpm --filter @voyantjs/crm test`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter dev typecheck`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter dmc typecheck`
- `pnpm --filter operator typecheck`
- `pnpm lint:changed`
- `git diff --check`
- pre-push `pnpm test` hook