### PR TITLE
Add storefront card projection to public catalog search

### DIFF
--- a/.changeset/catalog-storefront-card-search.md
+++ b/.changeset/catalog-storefront-card-search.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/catalog": minor
+"@voyantjs/catalog-react": minor
+---
+
+Add typed catalog search sort options and an optional storefront card projection for public listing pages.

--- a/packages/catalog-react/src/hooks/use-catalog-search.ts
+++ b/packages/catalog-react/src/hooks/use-catalog-search.ts
@@ -7,10 +7,17 @@ import { useVoyantCatalogContext } from "../provider.js"
 import { type CatalogSearchResponse, catalogSearchResponseSchema } from "../schemas.js"
 
 export type CatalogSearchMode = "keyword" | "hybrid" | "semantic"
+export type CatalogSearchSort =
+  | "relevance"
+  | "price-asc"
+  | "price-desc"
+  | "departure-asc"
+  | "newest"
+export type CatalogSearchProjection = "raw" | "storefront-card"
 
 export interface CatalogSearchFilter {
   field: string
-  // biome-ignore lint/suspicious/noExplicitAny: filter shape mirrors the SearchFilter union from @voyantjs/catalog
+  // biome-ignore lint/suspicious/noExplicitAny: reason: filter shape mirrors the SearchFilter union from @voyantjs/catalog
   [key: string]: any
 }
 
@@ -18,6 +25,8 @@ export interface UseCatalogSearchOptions {
   vertical: string
   query?: string
   mode?: CatalogSearchMode
+  sort?: CatalogSearchSort
+  projection?: CatalogSearchProjection
   filters?: CatalogSearchFilter[]
   facets?: Array<{ field: string }>
   pagination?: { limit?: number; cursor?: string }
@@ -50,6 +59,8 @@ export function useCatalogSearch(options: UseCatalogSearchOptions) {
     vertical,
     query = "",
     mode = "keyword",
+    sort,
+    projection,
     filters,
     facets,
     pagination,
@@ -70,6 +81,8 @@ export function useCatalogSearch(options: UseCatalogSearchOptions) {
       vertical,
       query,
       mode,
+      sort,
+      projection,
       filters,
       facets,
       pagination,
@@ -90,6 +103,8 @@ export function useCatalogSearch(options: UseCatalogSearchOptions) {
             vertical,
             query,
             mode,
+            sort,
+            projection,
             filters,
             facets,
             pagination,

--- a/packages/catalog-react/src/schemas.ts
+++ b/packages/catalog-react/src/schemas.ts
@@ -19,15 +19,71 @@ const facetBucketSchema = z.object({
   count: z.number(),
 })
 
+const storefrontCatalogCardTaxonSchema = z.object({
+  id: z.string().nullable(),
+  name: z.string().nullable(),
+  slug: z.string().nullable(),
+})
+
+const storefrontCatalogCardOfferSchema = z.object({
+  id: z.string().nullable(),
+  name: z.string().nullable(),
+  discountKind: z.string().nullable(),
+  discountPercent: z.number().nullable(),
+  discountAmountCents: z.number().nullable(),
+  minPax: z.number().nullable().optional(),
+})
+
+const storefrontCatalogCardSchema = z.object({
+  id: z.string(),
+  name: z.string().nullable(),
+  slug: z.string().nullable(),
+  primaryCategory: storefrontCatalogCardTaxonSchema.nullable(),
+  media: z.object({
+    thumbnailUrl: z.string().nullable(),
+    coverMediaUrl: z.string().nullable(),
+  }),
+  priceFrom: z
+    .object({
+      amountCents: z.number(),
+      currency: z.string().nullable(),
+      originalAmountCents: z.number().nullable(),
+    })
+    .nullable(),
+  offerBadges: z.array(storefrontCatalogCardOfferSchema),
+  departures: z.object({
+    upcomingCount: z.number().nullable(),
+    nextDepartureAt: z.string().nullable(),
+    nextDepartureDate: z.string().nullable(),
+    months: z.array(z.string()),
+    dates: z.array(z.string()),
+  }),
+  destinations: z.object({
+    regions: z.array(z.string()),
+    countries: z.array(z.string()),
+    cities: z.array(z.string()),
+    ids: z.array(z.string()),
+    slugs: z.array(z.string()),
+  }),
+  coordinates: z
+    .object({
+      latitude: z.number(),
+      longitude: z.number(),
+    })
+    .nullable(),
+})
+
 export const catalogSearchResponseSchema = z.object({
   vertical: z.string(),
   mode: z.enum(["keyword", "hybrid", "semantic"]),
   total: z.number(),
   hits: z.array(searchHitSchema),
+  cards: z.array(storefrontCatalogCardSchema).optional(),
   facets: z.record(z.string(), z.array(facetBucketSchema)).optional(),
 })
 
 export type CatalogSearchResponse = z.infer<typeof catalogSearchResponseSchema>
 export type CatalogSearchHit = z.infer<typeof searchHitSchema>
 export type CatalogSearchDocument = z.infer<typeof indexerDocumentSchema>
+export type StorefrontCatalogCard = z.infer<typeof storefrontCatalogCardSchema>
 export type CatalogFacetBucket = z.infer<typeof facetBucketSchema>

--- a/packages/catalog/README.md
+++ b/packages/catalog/README.md
@@ -140,3 +140,32 @@ export const catalogSearchModule = createCatalogSearchHonoModule({
 Search defaults to hybrid mode, downgrades to keyword when no embeddings are
 available, and retries semantic/hybrid execution as keyword when the semantic
 path fails. Pass `fallbackToKeywordOnSearchError: false` to fail closed instead.
+
+Storefront listing pages can request typed index-layer sorting and a compact
+card projection from the public route:
+
+```typescript
+await fetch("/v1/public/catalog/search", {
+  method: "POST",
+  body: JSON.stringify({
+    vertical: "products",
+    query: "",
+    mode: "keyword",
+    sort: "price-asc",
+    projection: "storefront-card",
+    pagination: { limit: 12 },
+    facets: [{ field: "categorySlugs[]" }, { field: "departureMonths[]" }],
+  }),
+})
+```
+
+Supported sort values are `relevance`, `price-asc`, `price-desc`,
+`departure-asc`, and `newest`. Sorts are translated by the indexer adapter to
+safe indexed fields such as `priceFromAmountCents` and `nextDepartureAt`; they
+are not applied after app-side hydration.
+
+When `projection: "storefront-card"` is present, the response keeps the raw
+`hits`, `total`, and engine facet counts, and also includes `cards` with the
+fields storefront product grids commonly need: localized name/slug, primary
+category, media URLs, price-from and offer badge data, departure aggregates,
+destinations, and coordinates.

--- a/packages/catalog/src/indexer/contract.ts
+++ b/packages/catalog/src/indexer/contract.ts
@@ -51,6 +51,12 @@ export interface IndexerDocument {
 /** Search query mode. Phase 1 ships keyword + hybrid; semantic is Phase 2. */
 export type SearchMode = "keyword" | "semantic" | "hybrid"
 
+/**
+ * Storefront-safe sort options. Adapters translate these to engine fields
+ * that are present in the indexed slice instead of exposing raw field names.
+ */
+export type SearchSortOption = "relevance" | "price-asc" | "price-desc" | "departure-asc" | "newest"
+
 /** Pagination shape. Cursor-based by default; page/offset is engine-dependent. */
 export interface SearchPagination {
   cursor?: string
@@ -82,6 +88,7 @@ export interface SearchRequest {
   /** Optional caller-supplied query embedding (BYO vector). */
   query_embedding?: number[]
   mode: SearchMode
+  sort?: SearchSortOption
   filters?: SearchFilter[]
   facets?: FacetRequest[]
   pagination?: SearchPagination

--- a/packages/catalog/src/indexer/typesense-search-query.ts
+++ b/packages/catalog/src/indexer/typesense-search-query.ts
@@ -1,0 +1,208 @@
+import type { FieldPolicyRegistry } from "../contract.js"
+import type { IndexerSlice, SearchFilter, SearchRequest, SearchSortOption } from "./contract.js"
+
+export interface TypesenseSearchQuery {
+  q: string
+  query_by: string
+  filter_by?: string
+  facet_by?: string
+  sort_by?: string
+  per_page?: number
+  page?: number
+  vector_query?: string
+  prefix?: boolean
+  exclude_fields?: string
+  drop_tokens_threshold?: number
+}
+
+/**
+ * Translates the catalog plane's `SearchRequest` into a Typesense query.
+ * Converts the filter expression tree, the audience-scoped query, and the
+ * pagination shape.
+ */
+export function buildSearchQuery(
+  request: SearchRequest,
+  registry: FieldPolicyRegistry,
+  slice?: IndexerSlice,
+): TypesenseSearchQuery {
+  // Build query_by from indexed text fields only. Typesense rejects numeric
+  // and boolean fields in query_by even when those fields are filterable.
+  const queryFields = registry.policies
+    .filter(
+      (p) =>
+        p.query === "indexed-column" && (p.class === "merchandisable" || p.class === "structural"),
+    )
+    .map((p) => normalizeTypesenseField(p.path))
+    .filter((field) => isTextSearchableField(field) && !SORTABLE_STRING_FIELD_NAMES.has(field))
+    .join(",")
+
+  const perPage = request.pagination?.limit ?? 20
+  // Cursor doubles as the 1-indexed page number for Typesense's `page`
+  // parameter. Callers wanting a different cursor strategy (e.g. opaque
+  // cursor for streaming results) write a different adapter.
+  const page = parsePageCursor(request.pagination?.cursor) ?? 1
+
+  const query: TypesenseSearchQuery = {
+    q: request.query.length > 0 ? request.query : "*",
+    query_by: queryFields || "title",
+    per_page: perPage,
+    page,
+    // Strip the vector field from response payloads. At e.g. 3072-dim that's
+    // roughly 12 KB per hit of float-array noise the caller never reads.
+    exclude_fields: "text_embedding,embedding_model_id",
+  }
+
+  if (request.filters && request.filters.length > 0) {
+    query.filter_by = serializeFilters(request.filters)
+  }
+
+  if (request.facets && request.facets.length > 0) {
+    query.facet_by = request.facets.map((f) => normalizeTypesenseField(f.field)).join(",")
+  }
+
+  const sortBy = resolveTypesenseSortBy(request.sort, registry, slice)
+  if (sortBy) {
+    query.sort_by = sortBy
+  }
+
+  // Hybrid / semantic mode: attach the vector query if an embedding was
+  // provided. The actual embedding generation for the query string lives in
+  // the search/semantic helper (Phase 2); this adapter just relays it.
+  if ((request.mode === "hybrid" || request.mode === "semantic") && request.query_embedding) {
+    // Ground the ANN search against a candidate pool larger than `per_page`
+    // so caller-side pagination has actual results to walk through. Typesense
+    // resolves `max(k, per_page)` per the docs, so we lift the floor.
+    const k = Math.max(perPage * 10, 100)
+    const vectorOpts: string[] = [`k:${k}`]
+    if (request.alpha != null) vectorOpts.push(`alpha:${request.alpha}`)
+    if (request.distance_threshold != null) {
+      vectorOpts.push(`distance_threshold:${request.distance_threshold}`)
+    }
+    query.vector_query = `text_embedding:([${request.query_embedding.join(",")}], ${vectorOpts.join(", ")})`
+  }
+
+  // For multi-token hybrid queries, the docs warn that the default
+  // `drop_tokens_threshold` (10) leads to redundant internal keyword
+  // re-runs. Disable token drop entirely for short catalog queries.
+  if (request.mode === "hybrid" && request.query.length > 0) {
+    query.drop_tokens_threshold = 0
+  }
+
+  return query
+}
+
+export function typesenseTypeForField(
+  name: string,
+  isList: boolean,
+): "string" | "string[]" | "int32" | "int64" | "float" | "bool" | "object" | "float[]" {
+  if (isList) return "string[]"
+  if (BOOLEAN_FIELD_NAMES.has(name) || /^(has|is)[A-Z]/.test(name)) return "bool"
+  if (FLOAT_FIELD_NAMES.has(name) || /(Latitude|Longitude)$/.test(name)) return "float"
+  if (
+    INTEGER_FIELD_NAMES.has(name) ||
+    INTEGER_FIELD_SUFFIXES.some((suffix) => name.endsWith(suffix))
+  ) {
+    return "int64"
+  }
+  return "string"
+}
+
+export function isTypesenseSortableStringField(field: string): boolean {
+  return SORTABLE_STRING_FIELD_NAMES.has(field)
+}
+
+function resolveTypesenseSortBy(
+  sort: SearchSortOption | undefined,
+  registry: FieldPolicyRegistry,
+  slice: IndexerSlice | undefined,
+): string | undefined {
+  if (!sort || sort === "relevance") return undefined
+  const fields = SORT_FIELDS[sort]
+  const field = fields.find((candidate) => isSortableField(candidate, registry, slice))
+  if (!field) return undefined
+  const direction = sort === "price-desc" || sort === "newest" ? "desc" : "asc"
+  return `${field}:${direction}`
+}
+
+const SORT_FIELDS = {
+  "price-asc": ["priceFromAmountCents", "sellAmountCents"],
+  "price-desc": ["priceFromAmountCents", "sellAmountCents"],
+  "departure-asc": ["nextDepartureAt", "nextDepartureDate", "startDateEpochDays", "startDate"],
+  newest: ["publishedAt", "createdAt"],
+} as const satisfies Record<Exclude<SearchSortOption, "relevance">, readonly string[]>
+
+function isSortableField(
+  field: string,
+  registry: FieldPolicyRegistry,
+  slice: IndexerSlice | undefined,
+): boolean {
+  const policy = registry.resolve(field)
+  if (!policy) return false
+  if (!slice || slice.audience === "staff-admin") return true
+  return policy.visibility.includes(slice.audience)
+}
+
+function parsePageCursor(cursor: string | undefined): number | undefined {
+  if (!cursor) return undefined
+  const n = Number(cursor)
+  return Number.isFinite(n) && n >= 1 ? Math.floor(n) : undefined
+}
+
+function serializeFilters(filters: SearchFilter[]): string {
+  return filters.map(serializeFilter).filter(Boolean).join(" && ")
+}
+
+function serializeFilter(filter: SearchFilter): string {
+  switch (filter.kind) {
+    case "eq":
+      return `${normalizeTypesenseField(filter.field)}:=${typeof filter.value === "string" ? `"${filter.value}"` : filter.value}`
+    case "in":
+      return `${normalizeTypesenseField(filter.field)}:[${filter.values.map((v) => (typeof v === "string" ? `"${v}"` : v)).join(",")}]`
+    case "range": {
+      const parts: string[] = []
+      const field = normalizeTypesenseField(filter.field)
+      if (filter.gte != null) parts.push(`${field}:>=${filter.gte}`)
+      if (filter.lte != null) parts.push(`${field}:<=${filter.lte}`)
+      return parts.join(" && ")
+    }
+    case "and":
+      return filter.clauses.map(serializeFilter).join(" && ")
+    case "or":
+      return `(${filter.clauses.map(serializeFilter).join(" || ")})`
+  }
+}
+
+function normalizeTypesenseField(field: string): string {
+  return field.endsWith("[]") ? field.slice(0, -2) : field
+}
+
+function isTextSearchableField(name: string): boolean {
+  const type = typesenseTypeForField(name, false)
+  return type === "string" || type === "string[]"
+}
+
+const BOOLEAN_FIELD_NAMES = new Set(["activated"])
+
+const FLOAT_FIELD_NAMES = new Set(["latitude", "longitude"])
+
+const INTEGER_FIELD_NAMES = new Set(["pax"])
+
+const INTEGER_FIELD_SUFFIXES = [
+  "AmountCents",
+  "Percent",
+  "Count",
+  "Days",
+  "EpochDays",
+  "EpochMs",
+  "Minutes",
+  "Total",
+]
+
+const SORTABLE_STRING_FIELD_NAMES = new Set([
+  "createdAt",
+  "endDate",
+  "nextDepartureAt",
+  "nextDepartureDate",
+  "publishedAt",
+  "startDate",
+])

--- a/packages/catalog/src/indexer/typesense.test.ts
+++ b/packages/catalog/src/indexer/typesense.test.ts
@@ -39,6 +39,26 @@ const registry = createFieldPolicyRegistry(
       visibility: ["customer"],
     },
     {
+      path: "nextDepartureAt",
+      class: "structural",
+      merge: "source-only",
+      editRole: "none",
+      overrideFriction: "none",
+      snapshot: "on-book",
+      query: "indexed-column",
+      visibility: ["customer"],
+    },
+    {
+      path: "createdAt",
+      class: "managed",
+      merge: "source-only",
+      editRole: "none",
+      overrideFriction: "none",
+      snapshot: "on-book",
+      query: "indexed-column",
+      visibility: ["staff"],
+    },
+    {
       path: "durationDays",
       class: "structural",
       merge: "source-only",
@@ -68,6 +88,16 @@ const registry = createFieldPolicyRegistry(
       query: "indexed-column",
       visibility: ["customer"],
     },
+    {
+      path: "categorySlugs[]",
+      class: "structural",
+      merge: "source-only",
+      editRole: "none",
+      overrideFriction: "none",
+      snapshot: "on-book",
+      query: "indexed-column",
+      visibility: ["customer"],
+    },
   ]),
 )
 
@@ -78,14 +108,52 @@ describe("Typesense catalog indexer", () => {
     expect(schema.fields.find((field) => field.name === "durationDays")?.type).toBe("int64")
     expect(schema.fields.find((field) => field.name === "latitude")?.type).toBe("float")
     expect(schema.fields.find((field) => field.name === "hasOffer")?.type).toBe("bool")
+    expect(schema.fields.find((field) => field.name === "nextDepartureAt")?.sort).toBe(true)
   })
 
   it("keeps non-text fields out of Typesense query_by", () => {
     const query = buildSearchQuery({ query: "retreat", mode: "keyword" }, registry)
-    expect(query.query_by).toBe("name")
+    expect(query.query_by).toBe("name,categorySlugs")
+    expect(query.query_by).not.toContain("categorySlugs[]")
     expect(query.query_by).not.toContain("priceFromAmountCents")
     expect(query.query_by).not.toContain("durationDays")
     expect(query.query_by).not.toContain("hasOffer")
+  })
+
+  it("maps typed storefront sort options to engine sort fields", () => {
+    const query = buildSearchQuery(
+      { query: "", mode: "keyword", sort: "price-desc" },
+      registry,
+      slice,
+    )
+
+    expect(query.sort_by).toBe("priceFromAmountCents:desc")
+  })
+
+  it("normalizes list policy paths for facets and filters", () => {
+    const query = buildSearchQuery(
+      {
+        query: "",
+        mode: "keyword",
+        facets: [{ field: "categorySlugs[]" }],
+        filters: [
+          { kind: "in", field: "categorySlugs[]", values: ["cruises", "sailing"] },
+          { kind: "eq", field: "departureMonths[]", value: "2026-06" },
+        ],
+      },
+      registry,
+    )
+
+    expect(query.facet_by).toBe("categorySlugs")
+    expect(query.filter_by).toBe(
+      'categorySlugs:["cruises","sailing"] && departureMonths:="2026-06"',
+    )
+  })
+
+  it("does not sort public slices by staff-only newest fields", () => {
+    const query = buildSearchQuery({ query: "", mode: "keyword", sort: "newest" }, registry, slice)
+
+    expect(query.sort_by).toBeUndefined()
   })
 
   it("upserts storefront card values without stringifying typed fields", async () => {

--- a/packages/catalog/src/indexer/typesense.ts
+++ b/packages/catalog/src/indexer/typesense.ts
@@ -15,10 +15,16 @@ import type {
   IndexerCapabilities,
   IndexerDocument,
   IndexerSlice,
-  SearchFilter,
-  SearchRequest,
   SearchResults,
 } from "./contract.js"
+import {
+  buildSearchQuery,
+  isTypesenseSortableStringField,
+  type TypesenseSearchQuery,
+  typesenseTypeForField,
+} from "./typesense-search-query.js"
+
+export { buildSearchQuery, type TypesenseSearchQuery } from "./typesense-search-query.js"
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Injected client interface
@@ -53,6 +59,7 @@ export interface TypesenseFieldSchema {
   facet?: boolean
   index?: boolean
   optional?: boolean
+  sort?: boolean
   num_dim?: number
   vec_dist?: "cosine" | "ip"
 }
@@ -62,19 +69,6 @@ export interface TypesenseCollectionSchema {
   fields: TypesenseFieldSchema[]
   default_sorting_field?: string
   enable_nested_fields?: boolean
-}
-
-export interface TypesenseSearchQuery {
-  q: string
-  query_by: string
-  filter_by?: string
-  facet_by?: string
-  per_page?: number
-  page?: number
-  vector_query?: string
-  prefix?: boolean
-  exclude_fields?: string
-  drop_tokens_threshold?: number
 }
 
 export interface TypesenseSearchHit {
@@ -177,98 +171,8 @@ function typesenseFieldFromPolicy(policy: FieldPolicy): TypesenseFieldSchema {
     type,
     facet: isFacet,
     optional: true,
+    sort: type === "string" && isTypesenseSortableStringField(baseName) ? true : undefined,
   }
-}
-
-function typesenseTypeForField(name: string, isList: boolean): TypesenseFieldSchema["type"] {
-  if (isList) return "string[]"
-  if (BOOLEAN_FIELD_NAMES.has(name) || /^(has|is)[A-Z]/.test(name)) return "bool"
-  if (FLOAT_FIELD_NAMES.has(name) || /(Latitude|Longitude)$/.test(name)) return "float"
-  if (
-    INTEGER_FIELD_NAMES.has(name) ||
-    INTEGER_FIELD_SUFFIXES.some((suffix) => name.endsWith(suffix))
-  ) {
-    return "int64"
-  }
-  return "string"
-}
-
-/**
- * Translates the catalog plane's `SearchRequest` into a Typesense query.
- * Converts the filter expression tree, the audience-scoped query, and the
- * pagination shape.
- */
-export function buildSearchQuery(
-  request: SearchRequest,
-  registry: FieldPolicyRegistry,
-): TypesenseSearchQuery {
-  // Build query_by from indexed text fields only. Typesense rejects numeric
-  // and boolean fields in query_by even when those fields are filterable.
-  const queryFields = registry.policies
-    .filter(
-      (p) =>
-        p.query === "indexed-column" && (p.class === "merchandisable" || p.class === "structural"),
-    )
-    .map((p) => (p.path.endsWith("[]") ? p.path.slice(0, -2) : p.path))
-    .filter((field) => isTextSearchableField(field))
-    .join(",")
-
-  const perPage = request.pagination?.limit ?? 20
-  // Cursor doubles as the 1-indexed page number for Typesense's `page`
-  // parameter. Callers wanting a different cursor strategy (e.g. opaque
-  // cursor for streaming results) write a different adapter.
-  const page = parsePageCursor(request.pagination?.cursor) ?? 1
-
-  const query: TypesenseSearchQuery = {
-    q: request.query.length > 0 ? request.query : "*",
-    query_by: queryFields || "title",
-    per_page: perPage,
-    page,
-    // Strip the vector field from response payloads — at e.g. 3072-dim that's
-    // ~12 KB per hit of float-array noise the caller never reads. The catalog
-    // plane re-resolves entities via `resolveEntity` for full views.
-    exclude_fields: "text_embedding,embedding_model_id",
-  }
-
-  if (request.filters && request.filters.length > 0) {
-    query.filter_by = serializeFilters(request.filters)
-  }
-
-  if (request.facets && request.facets.length > 0) {
-    query.facet_by = request.facets.map((f) => f.field).join(",")
-  }
-
-  // Hybrid / semantic mode: attach the vector query if an embedding was
-  // provided. The actual embedding generation for the query string lives in
-  // the search/semantic helper (Phase 2); this adapter just relays it.
-  if ((request.mode === "hybrid" || request.mode === "semantic") && request.query_embedding) {
-    // Ground the ANN search against a candidate pool larger than `per_page`
-    // so caller-side pagination has actual results to walk through. Typesense
-    // resolves `max(k, per_page)` per the docs, so we lift the floor.
-    const k = Math.max(perPage * 10, 100)
-    const vectorOpts: string[] = [`k:${k}`]
-    if (request.alpha != null) vectorOpts.push(`alpha:${request.alpha}`)
-    if (request.distance_threshold != null) {
-      vectorOpts.push(`distance_threshold:${request.distance_threshold}`)
-    }
-    query.vector_query = `text_embedding:([${request.query_embedding.join(",")}], ${vectorOpts.join(", ")})`
-  }
-
-  // For multi-token hybrid queries, the docs warn that the default
-  // `drop_tokens_threshold` (10) leads to redundant internal keyword
-  // re-runs. We disable token drop entirely — catalog queries tend to be
-  // short and we'd rather return zero hits than spend CPU on permutations.
-  if (request.mode === "hybrid" && request.query.length > 0) {
-    query.drop_tokens_threshold = 0
-  }
-
-  return query
-}
-
-function parsePageCursor(cursor: string | undefined): number | undefined {
-  if (!cursor) return undefined
-  const n = Number(cursor)
-  return Number.isFinite(n) && n >= 1 ? Math.floor(n) : undefined
 }
 
 /**
@@ -325,29 +229,6 @@ async function inferRegistryFromCollection(
     policies,
     byPath,
     resolve: (path: string) => byPath.get(path),
-  }
-}
-
-function serializeFilters(filters: SearchFilter[]): string {
-  return filters.map(serializeFilter).filter(Boolean).join(" && ")
-}
-
-function serializeFilter(filter: SearchFilter): string {
-  switch (filter.kind) {
-    case "eq":
-      return `${filter.field}:=${typeof filter.value === "string" ? `"${filter.value}"` : filter.value}`
-    case "in":
-      return `${filter.field}:[${filter.values.map((v) => (typeof v === "string" ? `"${v}"` : v)).join(",")}]`
-    case "range": {
-      const parts: string[] = []
-      if (filter.gte != null) parts.push(`${filter.field}:>=${filter.gte}`)
-      if (filter.lte != null) parts.push(`${filter.field}:<=${filter.lte}`)
-      return parts.join(" && ")
-    }
-    case "and":
-      return filter.clauses.map(serializeFilter).join(" && ")
-    case "or":
-      return `(${filter.clauses.map(serializeFilter).join(" || ")})`
   }
 }
 
@@ -419,7 +300,8 @@ export function createTypesenseIndexer(options: TypesenseIndexerOptions): Indexe
         }
         if (
           current.type !== desired.type ||
-          (current.facet ?? false) !== (desired.facet ?? false)
+          (current.facet ?? false) !== (desired.facet ?? false) ||
+          (current.sort ?? false) !== (desired.sort ?? false)
         ) {
           updates.push({ name: desired.name, type: desired.type, drop: true })
           updates.push(desired)
@@ -468,7 +350,7 @@ export function createTypesenseIndexer(options: TypesenseIndexerOptions): Indexe
           throw err
         }
       }
-      const query = buildSearchQuery(request, registry)
+      const query = buildSearchQuery(request, registry, slice)
       try {
         const response = await client.collections(name).documents().search(query)
         return mapTypesenseResponse(response)
@@ -542,11 +424,6 @@ function coerceForTypesense(path: string, value: unknown): unknown {
   return String(value)
 }
 
-function isTextSearchableField(name: string): boolean {
-  const type = typesenseTypeForField(name, false)
-  return type === "string" || type === "string[]"
-}
-
 function coerceNumber(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) return value
   if (typeof value === "string" && value.trim().length > 0) {
@@ -570,23 +447,6 @@ function coerceBool(value: unknown): boolean | undefined {
   }
   return undefined
 }
-
-const BOOLEAN_FIELD_NAMES = new Set(["activated"])
-
-const FLOAT_FIELD_NAMES = new Set(["latitude", "longitude"])
-
-const INTEGER_FIELD_NAMES = new Set(["pax"])
-
-const INTEGER_FIELD_SUFFIXES = [
-  "AmountCents",
-  "Percent",
-  "Count",
-  "Days",
-  "EpochDays",
-  "EpochMs",
-  "Minutes",
-  "Total",
-]
 
 function mapTypesenseResponse(response: TypesenseSearchResponse): SearchResults {
   const hits = response.hits.map((hit) => ({

--- a/packages/catalog/src/search/routes.test.ts
+++ b/packages/catalog/src/search/routes.test.ts
@@ -192,6 +192,164 @@ describe("createCatalogSearchRoutes", () => {
     )
   })
 
+  it("passes typed storefront sort options into the search request", async () => {
+    const executeSearch = vi.fn(
+      async (_input: CatalogSearchExecuteInput): Promise<SearchResults> => emptyResults,
+    )
+    const app = routeApp({
+      surface: "public",
+      resolveRuntime: () => ({
+        indexer: createIndexer(),
+        defaultScope: { locale: "en-GB", audience: "staff", market: "default" },
+      }),
+      executeSearch,
+    })
+
+    const response = await app.request("/v1/admin/catalog/search", {
+      method: "POST",
+      body: JSON.stringify({
+        vertical: "products",
+        mode: "keyword",
+        sort: "price-asc",
+        pagination: { limit: 12 },
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(executeSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        request: expect.objectContaining({
+          sort: "price-asc",
+          pagination: { limit: 12 },
+        }),
+      }),
+    )
+  })
+
+  it("projects storefront cards from indexed fields when requested", async () => {
+    const executeSearch = vi.fn(
+      async (_input: CatalogSearchExecuteInput): Promise<SearchResults> => ({
+        total: 1,
+        facets: {
+          "categorySlugs[]": [{ value: "cruises", count: 4 }],
+        },
+        hits: [
+          {
+            id: "prod_abc",
+            score: 12,
+            document: {
+              id: "prod_abc",
+              fields: {
+                name: "Danube Cruise",
+                slug: "danube-cruise",
+                primaryCategoryId: "cat_cruises",
+                primaryCategoryName: "Cruises",
+                primaryCategorySlug: "cruises",
+                thumbnailUrl: "https://cdn.example/thumb.jpg",
+                coverMediaUrl: "https://cdn.example/cover.jpg",
+                priceFromAmountCents: 125000,
+                priceFromCurrency: "EUR",
+                originalPriceFromAmountCents: 150000,
+                hasOffer: true,
+                bestOfferId: "offer_spring",
+                bestOfferName: "Spring Sale",
+                bestOfferDiscountKind: "percentage",
+                bestOfferDiscountPercent: 15,
+                upcomingDepartureCount: 3,
+                nextDepartureAt: "2026-06-01T09:00:00Z",
+                nextDepartureDate: "2026-06-01",
+                "departureMonths[]": ["2026-06", "2026-07"],
+                "departureDates[]": ["2026-06-01", "2026-07-15"],
+                "regions[]": ["Europe"],
+                "countries[]": ["Romania"],
+                "cities[]": ["Tulcea"],
+                "destinationIds[]": ["dest_ro"],
+                "destinationSlugs[]": ["romania"],
+                latitude: 45.18,
+                longitude: 28.8,
+              },
+            },
+          },
+        ],
+      }),
+    )
+    const module = createCatalogSearchHonoModule({
+      resolveRuntime: () => ({
+        indexer: createIndexer(),
+        defaultScope: { locale: "en-GB", audience: "staff", market: "default" },
+      }),
+      executeSearch,
+    })
+    const app = new Hono()
+    app.route("/v1/public/catalog", module.publicRoutes!)
+
+    const response = await app.request("/v1/public/catalog/search", {
+      method: "POST",
+      body: JSON.stringify({
+        vertical: "products",
+        mode: "keyword",
+        projection: "storefront-card",
+        pagination: { limit: 12 },
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      total: 1,
+      facets: {
+        "categorySlugs[]": [{ value: "cruises", count: 4 }],
+      },
+      cards: [
+        {
+          id: "prod_abc",
+          name: "Danube Cruise",
+          slug: "danube-cruise",
+          primaryCategory: {
+            id: "cat_cruises",
+            name: "Cruises",
+            slug: "cruises",
+          },
+          media: {
+            thumbnailUrl: "https://cdn.example/thumb.jpg",
+            coverMediaUrl: "https://cdn.example/cover.jpg",
+          },
+          priceFrom: {
+            amountCents: 125000,
+            currency: "EUR",
+            originalAmountCents: 150000,
+          },
+          offerBadges: [
+            {
+              id: "offer_spring",
+              name: "Spring Sale",
+              discountKind: "percentage",
+              discountPercent: 15,
+              discountAmountCents: null,
+            },
+          ],
+          departures: {
+            upcomingCount: 3,
+            nextDepartureAt: "2026-06-01T09:00:00Z",
+            nextDepartureDate: "2026-06-01",
+            months: ["2026-06", "2026-07"],
+            dates: ["2026-06-01", "2026-07-15"],
+          },
+          destinations: {
+            regions: ["Europe"],
+            countries: ["Romania"],
+            cities: ["Tulcea"],
+            ids: ["dest_ro"],
+            slugs: ["romania"],
+          },
+          coordinates: {
+            latitude: 45.18,
+            longitude: 28.8,
+          },
+        },
+      ],
+    })
+  })
+
   it("retries hybrid searches as keyword when semantic execution fails", async () => {
     const executeSearch = vi
       .fn(async (_input: CatalogSearchExecuteInput): Promise<SearchResults> => emptyResults)

--- a/packages/catalog/src/search/routes.ts
+++ b/packages/catalog/src/search/routes.ts
@@ -11,9 +11,12 @@ import type {
   SearchMode,
   SearchRequest,
   SearchResults,
+  SearchSortOption,
 } from "../indexer/contract.js"
 
 const searchModeSchema = z.enum(["keyword", "semantic", "hybrid"])
+const searchSortSchema = z.enum(["relevance", "price-asc", "price-desc", "departure-asc", "newest"])
+const searchProjectionSchema = z.enum(["raw", "storefront-card"])
 const searchFilterSchema: z.ZodType<SearchFilter> = z.lazy(() =>
   z.union([
     z.object({
@@ -47,6 +50,8 @@ const catalogSearchBodySchema = z.object({
   vertical: z.string().min(1).optional(),
   query: z.string().optional(),
   mode: searchModeSchema.optional(),
+  sort: searchSortSchema.optional(),
+  projection: searchProjectionSchema.optional(),
   filters: z.array(searchFilterSchema).optional(),
   facets: z
     .array(z.object({ field: z.string().min(1), limit: z.number().int().positive().optional() }))
@@ -65,6 +70,58 @@ const catalogSearchBodySchema = z.object({
 })
 
 export type CatalogSearchBody = z.infer<typeof catalogSearchBodySchema>
+export type CatalogSearchProjection = z.infer<typeof searchProjectionSchema>
+export type CatalogSearchSort = SearchSortOption
+
+export interface StorefrontCatalogCard {
+  id: string
+  name: string | null
+  slug: string | null
+  primaryCategory: StorefrontCatalogCardTaxon | null
+  media: {
+    thumbnailUrl: string | null
+    coverMediaUrl: string | null
+  }
+  priceFrom: {
+    amountCents: number
+    currency: string | null
+    originalAmountCents: number | null
+  } | null
+  offerBadges: StorefrontCatalogCardOffer[]
+  departures: {
+    upcomingCount: number | null
+    nextDepartureAt: string | null
+    nextDepartureDate: string | null
+    months: string[]
+    dates: string[]
+  }
+  destinations: {
+    regions: string[]
+    countries: string[]
+    cities: string[]
+    ids: string[]
+    slugs: string[]
+  }
+  coordinates: {
+    latitude: number
+    longitude: number
+  } | null
+}
+
+export interface StorefrontCatalogCardTaxon {
+  id: string | null
+  name: string | null
+  slug: string | null
+}
+
+export interface StorefrontCatalogCardOffer {
+  id: string | null
+  name: string | null
+  discountKind: string | null
+  discountPercent: number | null
+  discountAmountCents: number | null
+  minPax?: number | null
+}
 
 export interface CatalogSearchRuntime {
   indexer?: IndexerAdapter
@@ -182,6 +239,10 @@ async function handleSearch(
       mode: responseMode,
       total: results.total,
       hits: results.hits,
+      cards:
+        body.projection === "storefront-card"
+          ? results.hits.map((hit) => projectStorefrontCatalogCard(hit.document))
+          : undefined,
       facets: results.facets ?? {},
     })
   } catch (err) {
@@ -202,6 +263,7 @@ function buildSearchRequest(body: CatalogSearchBody, mode: SearchMode): SearchRe
   return {
     query: body.query ?? "",
     mode,
+    sort: body.sort,
     filters: body.filters,
     facets: body.facets,
     pagination: body.pagination,
@@ -255,4 +317,133 @@ function shouldUseEmbeddingMode(mode: SearchMode): boolean {
 
 async function defaultExecuteSearch(input: CatalogSearchExecuteInput): Promise<SearchResults> {
   return input.adapter.search(input.slice, input.request)
+}
+
+function projectStorefrontCatalogCard(
+  document: SearchResults["hits"][number]["document"],
+): StorefrontCatalogCard {
+  const fields = document.fields
+  const priceAmount = numberField(fields, "priceFromAmountCents", "sellAmountCents")
+  const latitude = numberField(fields, "latitude")
+  const longitude = numberField(fields, "longitude")
+
+  return {
+    id: document.id,
+    name: stringField(fields, "name", "title"),
+    slug: stringField(fields, "slug"),
+    primaryCategory: taxonFromFields(fields),
+    media: {
+      thumbnailUrl: stringField(fields, "thumbnailUrl", "primaryMediaUrl", "coverMediaUrl"),
+      coverMediaUrl: stringField(fields, "coverMediaUrl", "primaryMediaUrl", "thumbnailUrl"),
+    },
+    priceFrom:
+      priceAmount == null
+        ? null
+        : {
+            amountCents: priceAmount,
+            currency: stringField(fields, "priceFromCurrency", "sellCurrency"),
+            originalAmountCents: numberField(fields, "originalPriceFromAmountCents"),
+          },
+    offerBadges: offerBadgesFromFields(fields),
+    departures: {
+      upcomingCount: numberField(
+        fields,
+        "upcomingDepartureCount",
+        "availableDeparturesCount",
+        "availableUnitsTotal",
+      ),
+      nextDepartureAt: stringField(fields, "nextDepartureAt"),
+      nextDepartureDate: stringField(fields, "nextDepartureDate"),
+      months: stringArrayField(fields, "departureMonths"),
+      dates: stringArrayField(fields, "departureDates"),
+    },
+    destinations: {
+      regions: stringArrayField(fields, "regions"),
+      countries: stringArrayField(fields, "countries"),
+      cities: stringArrayField(fields, "cities"),
+      ids: stringArrayField(fields, "destinationIds"),
+      slugs: stringArrayField(fields, "destinationSlugs"),
+    },
+    coordinates:
+      latitude == null || longitude == null
+        ? null
+        : {
+            latitude,
+            longitude,
+          },
+  }
+}
+
+function taxonFromFields(fields: Record<string, unknown>): StorefrontCatalogCardTaxon | null {
+  const id = stringField(fields, "primaryCategoryId", "categoryIds")
+  const name = stringField(fields, "primaryCategoryName", "categories", "categoryNames")
+  const slug = stringField(fields, "primaryCategorySlug", "categorySlugs")
+  if (!id && !name && !slug) return null
+  return { id, name, slug }
+}
+
+function offerBadgesFromFields(fields: Record<string, unknown>): StorefrontCatalogCardOffer[] {
+  const badges: StorefrontCatalogCardOffer[] = []
+  if (booleanField(fields, "hasOffer")) {
+    badges.push({
+      id: stringField(fields, "bestOfferId"),
+      name: stringField(fields, "bestOfferName"),
+      discountKind: stringField(fields, "bestOfferDiscountKind"),
+      discountPercent: numberField(fields, "bestOfferDiscountPercent"),
+      discountAmountCents: numberField(fields, "bestOfferDiscountAmountCents"),
+    })
+  }
+  if (booleanField(fields, "hasConditionalOffer")) {
+    badges.push({
+      id: stringField(fields, "conditionalOfferId"),
+      name: stringField(fields, "conditionalOfferName"),
+      discountKind: stringField(fields, "conditionalOfferDiscountKind"),
+      discountPercent: numberField(fields, "conditionalOfferDiscountPercent"),
+      discountAmountCents: numberField(fields, "conditionalOfferDiscountAmountCents"),
+      minPax: numberField(fields, "conditionalOfferMinPax"),
+    })
+  }
+  return badges
+}
+
+function stringField(fields: Record<string, unknown>, ...keys: string[]): string | null {
+  for (const key of keys) {
+    const value = fieldValue(fields, key)
+    if (typeof value === "string" && value.length > 0) return value
+    if (Array.isArray(value)) {
+      const first = value.find((item) => typeof item === "string" && item.length > 0)
+      if (typeof first === "string") return first
+    }
+  }
+  return null
+}
+
+function stringArrayField(fields: Record<string, unknown>, key: string): string[] {
+  const value = fieldValue(fields, key)
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is string => typeof item === "string" && item.length > 0)
+}
+
+function numberField(fields: Record<string, unknown>, ...keys: string[]): number | null {
+  for (const key of keys) {
+    const value = fieldValue(fields, key)
+    if (typeof value === "number" && Number.isFinite(value)) return value
+    if (typeof value === "string" && value.trim().length > 0) {
+      const parsed = Number(value)
+      if (Number.isFinite(parsed)) return parsed
+    }
+  }
+  return null
+}
+
+function booleanField(fields: Record<string, unknown>, key: string): boolean {
+  const value = fieldValue(fields, key)
+  return value === true || value === "true"
+}
+
+function fieldValue(fields: Record<string, unknown>, key: string): unknown {
+  if (key in fields) return fields[key]
+  const collectionKey = `${key}[]`
+  if (collectionKey in fields) return fields[collectionKey]
+  return undefined
 }


### PR DESCRIPTION
## Summary
- add typed catalog search sort options and pass them through to the indexer layer
- add optional `projection: "storefront-card"` cards alongside raw search hits/facets
- update catalog-react validation/hooks and document public storefront usage

Closes #1408

## Verification
- pnpm --filter @voyantjs/catalog test
- pnpm --filter @voyantjs/catalog typecheck
- pnpm --filter @voyantjs/catalog lint
- pnpm --filter @voyantjs/catalog-react typecheck
- pnpm --filter @voyantjs/catalog-react lint
- pnpm --filter @voyantjs/catalog-react test
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- git diff --check
- commit hook: full lint and typecheck
- push hook: full test suite

Note: `pnpm verify:fast` still stops on an unrelated pre-existing `verify:ui-components-barrel` finding for `packages/ui/src/components/index.tsx`.