### PR TITLE
Expose persisted workflow schedule state

### DIFF
--- a/.changeset/sour-walls-fly.md
+++ b/.changeset/sour-walls-fly.md
@@ -1,0 +1,7 @@
+---
+"@voyantjs/workflows-orchestrator-cloudflare": patch
+"@voyantjs/workflows-react": patch
+"@voyantjs/workflows-ui": patch
+---
+
+Expose persisted workflow schedule execution state on schedule API rows and surface it in the schedules UI when run history is not wired.

--- a/apps/workflows-orchestrator-worker/README.md
+++ b/apps/workflows-orchestrator-worker/README.md
@@ -87,6 +87,11 @@ needed for `runtime: "node"` steps end-to-end:
    `<projectId>/<workflowVersion>/container.mjs` artifacts.
 4. **`BUNDLE_HASHES`** — KV namespace that stores each bundle's
    deploy-time SHA-256, keyed `<projectId>:<workflowVersion>`.
+5. **`WORKFLOW_MANIFESTS`** — optional KV namespace storing the active
+   manifest per environment for `/api/manifests`, `/api/events`, and
+   `/api/schedules/:env`.
+6. **`WORKFLOW_SCHEDULE_STATE`** — optional KV namespace storing
+   schedule fire/run/error state exposed on `/api/schedules/:env`.
 
 ### Who actually calls the container?
 

--- a/apps/workflows-orchestrator-worker/src/worker.ts
+++ b/apps/workflows-orchestrator-worker/src/worker.ts
@@ -36,6 +36,7 @@ import { Container } from "@cloudflare/containers"
 import { createBearerVerifier } from "@voyantjs/workflows/auth"
 import {
   createKvManifestStore,
+  createKvScheduleStateStore,
   createServiceBindingDispatcher,
   handleDurableObjectAlarm,
   handleDurableObjectRequest,
@@ -65,6 +66,12 @@ export interface Env {
    */
   WORKFLOW_MANIFESTS?: KVNamespace
   /**
+   * KV namespace storing schedule fire/run/error state keyed by schedule id.
+   * Optional — when unset, `/api/schedules/:env` only returns manifest
+   * projection fields.
+   */
+  WORKFLOW_SCHEDULE_STATE?: KVNamespace
+  /**
    * Comma-separated bearer tokens accepted on the public
    * `/api/runs/*` + `/api/events` + `/api/manifests*` surfaces. Unset =
    * no auth (fine for local dev, dangerous in production). A control
@@ -84,6 +91,9 @@ export default {
       verifyRequest: tokens.length > 0 ? createBearerVerifier(tokens) : undefined,
       manifestStore: env.WORKFLOW_MANIFESTS
         ? createKvManifestStore({ kv: env.WORKFLOW_MANIFESTS })
+        : undefined,
+      scheduleStateStore: env.WORKFLOW_SCHEDULE_STATE
+        ? createKvScheduleStateStore({ kv: env.WORKFLOW_SCHEDULE_STATE })
         : undefined,
     })
   },

--- a/apps/workflows-orchestrator-worker/wrangler.jsonc
+++ b/apps/workflows-orchestrator-worker/wrangler.jsonc
@@ -81,6 +81,9 @@
   //                          Last 3 versions retained per environment via
   //                          `pruneToVersions`. KV's eventual consistency
   //                          is acceptable for the manifest read path.
+  //   WORKFLOW_SCHEDULE_STATE — persisted scheduler fire/run/error state
+  //                          keyed by schedule id and exposed by
+  //                          GET /api/schedules/:env when configured.
   "kv_namespaces": [
     {
       "binding": "BUNDLE_HASHES",
@@ -88,6 +91,10 @@
     },
     {
       "binding": "WORKFLOW_MANIFESTS",
+      "id": "replace-me-after-wrangler-kv-namespace-create"
+    },
+    {
+      "binding": "WORKFLOW_SCHEDULE_STATE",
       "id": "replace-me-after-wrangler-kv-namespace-create"
     }
   ],

--- a/packages/workflows-orchestrator-cloudflare/README.md
+++ b/packages/workflows-orchestrator-cloudflare/README.md
@@ -65,6 +65,10 @@ export class WorkflowRunDO implements DurableObject {
 |---|---|
 | `POST /api/runs` | Trigger a new run. Body: `{ workflowId, workflowVersion, input, tenantMeta, runId? }`. |
 | `GET  /api/runs/:id` | Fetch the current `RunRecord`. |
+| `POST /api/manifests` | Register a workflow manifest for an environment when `manifestStore` is configured. |
+| `GET  /api/manifests/:env` | Fetch the current workflow manifest for an environment. |
+| `GET  /api/schedules/:env` | List manifest schedules with computed `nextRunAt`; when `scheduleStateStore` is configured, rows also include `lastFireAt`, `lastRunId`, `lastError`, `lockedUntil`, and `lastSuccessfulRunAt`. |
+| `POST /api/events` | Route an event through the registered manifest and trigger matching workflows. |
 | `POST /api/runs/:id/resume` | Start a new run from a failed parent run. Body: `{ input?, workflowId?, resumeFromStep?, seedResults?, runId?, tags?, triggeredByUserId? }`. |
 | `POST /api/runs/:id/events` | Inject an `EVENT` waitpoint resolution. |
 | `POST /api/runs/:id/signals` | Inject a `SIGNAL` waitpoint resolution. |

--- a/packages/workflows-orchestrator-cloudflare/src/__tests__/adapter.test.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/__tests__/adapter.test.ts
@@ -337,6 +337,89 @@ describe("handleWorkerRequest (Worker → DO → tenant)", () => {
     })
   })
 
+  it("defaults scheduled trigger state to development when environment is omitted", async () => {
+    workflow<{ n: number }, { doubled: number }>({
+      id: "scheduled-default-env",
+      async run(input) {
+        return { doubled: input.n * 2 }
+      },
+    })
+    const runDO = inProcessRunDONamespace()
+    const scheduleStateStore = createKvScheduleStateStore({ kv: createInMemoryKv() })
+    const now = Date.UTC(2026, 4, 30, 12, 0, 0)
+
+    const res = await handleWorkerRequest(
+      new Request("https://orch/api/runs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          workflowId: "scheduled-default-env",
+          workflowVersion: "v1",
+          input: { n: 21 },
+          tenantMeta,
+          runId: "run_scheduled_default_env",
+          triggeredBy: { kind: "schedule", scheduleId: "v_1:scheduled-default-env:hourly" },
+        }),
+      }),
+      { runDO, scheduleStateStore, now: () => now },
+    )
+
+    expect(res.status).toBe(200)
+    const states = await scheduleStateStore.getStates("development", [
+      "v_1:scheduled-default-env:hourly",
+    ])
+    expect(states.get("v_1:scheduled-default-env:hourly")).toMatchObject({
+      scheduleId: "v_1:scheduled-default-env:hourly",
+      environment: "development",
+      lastFireAt: now,
+      lastRunId: "run_scheduled_default_env",
+      lastError: null,
+      updatedAt: now,
+    })
+  })
+
+  it("records failed scheduled run outcomes in schedule dispatch state", async () => {
+    workflow({
+      id: "scheduled-fail",
+      async run() {
+        throw new Error("scheduled boom")
+      },
+    })
+    const runDO = inProcessRunDONamespace()
+    const scheduleStateStore = createKvScheduleStateStore({ kv: createInMemoryKv() })
+    const now = Date.UTC(2026, 4, 30, 13, 0, 0)
+
+    const res = await handleWorkerRequest(
+      new Request("https://orch/api/runs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          workflowId: "scheduled-fail",
+          workflowVersion: "v1",
+          input: null,
+          tenantMeta,
+          environment: "production",
+          runId: "run_scheduled_fail",
+          triggeredBy: { kind: "schedule", scheduleId: "v_1:scheduled-fail:hourly" },
+        }),
+      }),
+      { runDO, scheduleStateStore, now: () => now },
+    )
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as RunRecord
+    expect(body.status).toBe("failed")
+    const states = await scheduleStateStore.getStates("production", ["v_1:scheduled-fail:hourly"])
+    expect(states.get("v_1:scheduled-fail:hourly")).toMatchObject({
+      scheduleId: "v_1:scheduled-fail:hourly",
+      environment: "production",
+      lastFireAt: now,
+      lastRunId: "run_scheduled_fail",
+      lastError: "scheduled boom",
+      updatedAt: now,
+    })
+  })
+
   it("parks a run on a waitpoint and serves GET /api/runs/:id", async () => {
     workflow({
       id: "wait",

--- a/packages/workflows-orchestrator-cloudflare/src/__tests__/adapter.test.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/__tests__/adapter.test.ts
@@ -5,6 +5,8 @@ import { beforeEach, describe, expect, it } from "vitest"
 import {
   createDurableObjectRunStore,
   createInlineDispatcher,
+  createInMemoryKv,
+  createKvScheduleStateStore,
   createServiceBindingDispatcher,
   type DurableObjectNamespaceLike,
   type DurableObjectStorageLike,
@@ -293,6 +295,46 @@ describe("handleWorkerRequest (Worker → DO → tenant)", () => {
     const body = (await res.json()) as RunRecord
     expect(body.status).toBe("completed")
     expect(body.output).toEqual({ doubled: 42 })
+  })
+
+  it("records schedule dispatch state for scheduled triggers", async () => {
+    workflow<{ n: number }, { doubled: number }>({
+      id: "scheduled-double",
+      async run(input) {
+        return { doubled: input.n * 2 }
+      },
+    })
+    const runDO = inProcessRunDONamespace()
+    const scheduleStateStore = createKvScheduleStateStore({ kv: createInMemoryKv() })
+    const now = Date.UTC(2026, 4, 30, 11, 0, 0)
+
+    const res = await handleWorkerRequest(
+      new Request("https://orch/api/runs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          workflowId: "scheduled-double",
+          workflowVersion: "v1",
+          input: { n: 21 },
+          tenantMeta,
+          environment: "production",
+          runId: "run_scheduled",
+          triggeredBy: { kind: "schedule", scheduleId: "v_1:scheduled-double:hourly" },
+        }),
+      }),
+      { runDO, scheduleStateStore, now: () => now },
+    )
+
+    expect(res.status).toBe(200)
+    const states = await scheduleStateStore.getStates("production", ["v_1:scheduled-double:hourly"])
+    expect(states.get("v_1:scheduled-double:hourly")).toMatchObject({
+      scheduleId: "v_1:scheduled-double:hourly",
+      environment: "production",
+      lastFireAt: now,
+      lastRunId: "run_scheduled",
+      lastError: null,
+      updatedAt: now,
+    })
   })
 
   it("parks a run on a waitpoint and serves GET /api/runs/:id", async () => {

--- a/packages/workflows-orchestrator-cloudflare/src/__tests__/schedule-handler.test.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/__tests__/schedule-handler.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest"
 
 import { createInMemoryKv, createKvManifestStore } from "../manifest-kv-store.js"
 import { handleGetSchedules, type ScheduleListResponse } from "../schedule-handler.js"
+import { createKvScheduleStateStore } from "../schedule-state-store.js"
 
 function makeManifest(
   versionId: string,
@@ -179,5 +180,57 @@ describe("handleGetSchedules", () => {
     const res = await handleGetSchedules("production", { manifestStore: store, now: () => NOW })
     const body = (await res.json()) as ScheduleListResponse
     expect(body.data[0]?.nextRunAt).toBeNull()
+  })
+
+  test("merges persisted scheduler state into schedule rows", async () => {
+    const manifestKv = createInMemoryKv()
+    const stateKv = createInMemoryKv()
+    const store = createKvManifestStore({ kv: manifestKv })
+    const scheduleStateStore = createKvScheduleStateStore({ kv: stateKv })
+    await store.registerManifest({
+      environment: "production",
+      versionId: "v_6",
+      manifest: makeManifest("v_6", [
+        { id: "wf.stateful", schedules: [{ cron: "0 * * * *", name: "hourly" }] },
+        { id: "wf.empty", schedules: [{ every: "30s" }] },
+      ]),
+    })
+    await scheduleStateStore.putState("production", {
+      scheduleId: "v_6:wf.stateful:hourly",
+      workflowId: "wf.stateful",
+      versionId: "v_6",
+      lastFireAt: NOW - 60_000,
+      lastRunId: "run_123",
+      lastError: "dispatch failed",
+      lockedUntil: NOW + 15_000,
+      lastSuccessfulRunAt: NOW - 120_000,
+      updatedAt: NOW - 30_000,
+    })
+
+    const res = await handleGetSchedules("production", {
+      manifestStore: store,
+      scheduleStateStore,
+      now: () => NOW,
+    })
+    const body = (await res.json()) as ScheduleListResponse
+    const stateful = body.data.find((row) => row.workflowId === "wf.stateful")
+    const empty = body.data.find((row) => row.workflowId === "wf.empty")
+
+    expect(stateful).toMatchObject({
+      lastFireAt: NOW - 60_000,
+      lastRunId: "run_123",
+      lastError: "dispatch failed",
+      lockedUntil: NOW + 15_000,
+      lastSuccessfulRunAt: NOW - 120_000,
+      stateUpdatedAt: NOW - 30_000,
+    })
+    expect(empty).toMatchObject({
+      lastFireAt: null,
+      lastRunId: null,
+      lastError: null,
+      lockedUntil: null,
+      lastSuccessfulRunAt: null,
+      stateUpdatedAt: null,
+    })
   })
 })

--- a/packages/workflows-orchestrator-cloudflare/src/index.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/index.ts
@@ -83,6 +83,12 @@ export {
   type ScheduleListResponse,
   type ScheduleSummary,
 } from "./schedule-handler.js"
+export {
+  type CfScheduleStateStore,
+  type CreateKvScheduleStateStoreOptions,
+  createKvScheduleStateStore,
+  type ScheduleStateRecord,
+} from "./schedule-state-store.js"
 export * from "./types.js"
 export {
   type DurableObjectNamespaceLike,

--- a/packages/workflows-orchestrator-cloudflare/src/schedule-handler.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/schedule-handler.ts
@@ -1,20 +1,23 @@
 // HTTP handler for `/api/schedules/:env`. Reads the registered manifest
 // for the requested environment, projects each workflow's schedule blocks
-// into a flat list, and computes `nextRun` per entry via the same cron /
-// every / at logic the live scheduler uses.
-//
-// Aggregate "lastRun" is intentionally out of scope here — runs in the
-// Cloudflare orchestrator live in per-run Durable Objects, indexed by
-// runId, with no list-by-workflow path. The UI is expected to fetch
-// last-run state separately from the template-side `workflow-runs`
-// admin API (`/v1/admin/workflow-runs?workflowName=…&limit=1`).
+// into a flat list, computes `nextRun` per entry via the same cron / every /
+// at logic the live scheduler uses, and optionally merges persisted scheduler
+// dispatch state when a control plane provides it.
 
-import type { ManifestSchedule, WorkflowManifest } from "@voyantjs/workflows/protocol"
+import type { ManifestSchedule } from "@voyantjs/workflows/protocol"
 import { computeNextFire } from "@voyantjs/workflows-orchestrator"
 
 import type { CfManifestStore } from "./manifest-kv-store.js"
+import type { CfScheduleStateStore, ScheduleStateRecord } from "./schedule-state-store.js"
 
-const ALLOWED_ENVS = new Set(["production", "preview", "development"])
+const ALLOWED_ENVS = ["production", "preview", "development"] as const
+
+type AllowedEnvironment = (typeof ALLOWED_ENVS)[number]
+
+interface ManifestWorkflowScheduleEntry {
+  id: string
+  schedules: ManifestSchedule[]
+}
 
 export interface ScheduleHandlerDeps {
   manifestStore: CfManifestStore
@@ -28,6 +31,11 @@ export interface ScheduleHandlerDeps {
    * UIs can ignore the field.
    */
   schedulesEnabledByEnv?: boolean
+  /**
+   * Optional state store populated by the runtime scheduler/control plane.
+   * When present, each schedule row includes last-fire/run/error fields.
+   */
+  scheduleStateStore?: CfScheduleStateStore
   now?: () => number
   logger?: (level: "info" | "warn" | "error", msg: string, data?: object) => void
 }
@@ -45,6 +53,18 @@ export interface ScheduleSummary {
    */
   enabled: boolean
   disabledReason?: "registration_disabled" | "env_filtered"
+  /** Epoch millis of the last scheduler dispatch attempt, when known. */
+  lastFireAt?: number | null
+  /** Run id produced by the last scheduler dispatch attempt, when known. */
+  lastRunId?: string | null
+  /** Last scheduler dispatch/lock error, when known. */
+  lastError?: string | null
+  /** Epoch millis until which this schedule is locked, when known. */
+  lockedUntil?: number | null
+  /** Epoch millis of the last successful scheduled run, when known. */
+  lastSuccessfulRunAt?: number | null
+  /** Epoch millis when the persisted scheduler state was last updated. */
+  stateUpdatedAt?: number | null
 }
 
 export interface ScheduleListResponse {
@@ -62,10 +82,10 @@ export async function handleGetSchedules(
   environment: string,
   deps: ScheduleHandlerDeps,
 ): Promise<Response> {
-  if (!ALLOWED_ENVS.has(environment)) {
+  if (!isAllowedEnvironment(environment)) {
     return json(400, {
       error: "invalid_environment",
-      message: `environment must be one of ${[...ALLOWED_ENVS].join(", ")}`,
+      message: `environment must be one of ${ALLOWED_ENVS.join(", ")}`,
     })
   }
 
@@ -75,16 +95,14 @@ export async function handleGetSchedules(
   }
 
   const now = deps.now ? deps.now() : Date.now()
-  const manifest = envelope.manifest as unknown as WorkflowManifest
   const data: ScheduleSummary[] = []
 
-  for (const workflow of manifest.workflows ?? []) {
-    const schedules = Array.isArray(workflow.schedules) ? workflow.schedules : []
-    schedules.forEach((schedule, index) => {
+  for (const workflow of readManifestWorkflows(envelope.manifest)) {
+    workflow.schedules.forEach((schedule, index) => {
       const scheduleId = `${envelope.versionId}:${workflow.id}:${schedule.name ?? index}`
       const registrationDisabled = schedule.enabled === false
       const envFiltered = Array.isArray(schedule.environments)
-        ? !schedule.environments.includes(environment as never)
+        ? !schedule.environments.includes(environment)
         : false
 
       let nextRunAt: number | null = null
@@ -120,6 +138,22 @@ export async function handleGetSchedules(
     })
   }
 
+  if (deps.scheduleStateStore) {
+    const scheduleIds = data.map((row) => row.scheduleId)
+    let states = new Map<string, ScheduleStateRecord>()
+    try {
+      states = await deps.scheduleStateStore.getStates(environment, scheduleIds)
+    } catch (err) {
+      deps.logger?.("warn", "schedules: cannot load scheduler state", {
+        environment,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+    for (const row of data) {
+      attachState(row, states.get(row.scheduleId))
+    }
+  }
+
   const response: ScheduleListResponse = {
     environment,
     versionId: envelope.versionId,
@@ -129,6 +163,35 @@ export async function handleGetSchedules(
       : {}),
   }
   return json(200, response)
+}
+
+function isAllowedEnvironment(value: string): value is AllowedEnvironment {
+  return ALLOWED_ENVS.includes(value as AllowedEnvironment)
+}
+
+function readManifestWorkflows(manifest: Record<string, unknown>): ManifestWorkflowScheduleEntry[] {
+  const workflows = manifest.workflows
+  if (!Array.isArray(workflows)) return []
+  return workflows.flatMap((workflow): ManifestWorkflowScheduleEntry[] => {
+    if (!isRecord(workflow) || typeof workflow.id !== "string") return []
+    const schedules = Array.isArray(workflow.schedules)
+      ? workflow.schedules.filter(isManifestSchedule)
+      : []
+    return [{ id: workflow.id, schedules }]
+  })
+}
+
+function isManifestSchedule(value: unknown): value is ManifestSchedule {
+  return isRecord(value)
+}
+
+function attachState(row: ScheduleSummary, state: ScheduleStateRecord | undefined): void {
+  row.lastFireAt = state?.lastFireAt ?? null
+  row.lastRunId = state?.lastRunId ?? null
+  row.lastError = state?.lastError ?? null
+  row.lockedUntil = state?.lockedUntil ?? null
+  row.lastSuccessfulRunAt = state?.lastSuccessfulRunAt ?? null
+  row.stateUpdatedAt = state?.updatedAt ?? null
 }
 
 function json(status: number, body: unknown): Response {
@@ -141,4 +204,8 @@ function json(status: number, body: unknown): Response {
       "access-control-allow-headers": "content-type, x-voyant-protocol",
     },
   })
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
 }

--- a/packages/workflows-orchestrator-cloudflare/src/schedule-state-store.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/schedule-state-store.ts
@@ -1,0 +1,132 @@
+// KV-backed persisted state for workflow schedule dispatches.
+//
+// The manifest store answers "what schedules are registered?". This store
+// answers "what has the scheduler actually attempted recently?", keyed by
+// the stable schedule id emitted by manifestScheduleSources / schedule-handler.
+
+import type { KvNamespaceLike } from "./manifest-kv-store.js"
+
+export interface ScheduleStateRecord {
+  scheduleId: string
+  workflowId?: string
+  environment?: string
+  versionId?: string
+  lastFireAt?: number | null
+  lastRunId?: string | null
+  lastError?: string | null
+  lockedUntil?: number | null
+  lastSuccessfulRunAt?: number | null
+  updatedAt?: number | null
+}
+
+export interface CfScheduleStateStore {
+  getStates(
+    environment: string,
+    scheduleIds: readonly string[],
+  ): Promise<Map<string, ScheduleStateRecord>>
+  putState(environment: string, state: ScheduleStateRecord): Promise<void>
+}
+
+interface RawScheduleStateRecord {
+  scheduleId: string
+  workflowId?: unknown
+  environment?: unknown
+  versionId?: unknown
+  lastFireAt?: unknown
+  lastRunId?: unknown
+  lastError?: unknown
+  lockedUntil?: unknown
+  lastSuccessfulRunAt?: unknown
+  updatedAt?: unknown
+}
+
+export interface CreateKvScheduleStateStoreOptions {
+  kv: KvNamespaceLike
+}
+
+export function createKvScheduleStateStore(
+  opts: CreateKvScheduleStateStoreOptions,
+): CfScheduleStateStore {
+  const kv = opts.kv
+
+  return {
+    async getStates(environment, scheduleIds) {
+      const out = new Map<string, ScheduleStateRecord>()
+      await Promise.all(
+        scheduleIds.map(async (scheduleId) => {
+          const raw = await kv.get(scheduleStateKey(environment, scheduleId))
+          if (!raw) return
+          const parsed = parseScheduleState(raw)
+          if (!parsed || parsed.scheduleId !== scheduleId) return
+          out.set(scheduleId, parsed)
+        }),
+      )
+      return out
+    },
+
+    async putState(environment, state) {
+      await kv.put(
+        scheduleStateKey(environment, state.scheduleId),
+        JSON.stringify(normalizeScheduleState(environment, state)),
+      )
+    },
+  }
+}
+
+function scheduleStateKey(environment: string, scheduleId: string): string {
+  return `schedule-state:${environment}:${encodeURIComponent(scheduleId)}`
+}
+
+function parseScheduleState(raw: string): ScheduleStateRecord | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (!isRecord(parsed) || typeof parsed.scheduleId !== "string") return null
+    const state: RawScheduleStateRecord = {
+      scheduleId: parsed.scheduleId,
+      workflowId: typeof parsed.workflowId === "string" ? parsed.workflowId : undefined,
+      versionId: typeof parsed.versionId === "string" ? parsed.versionId : undefined,
+      lastFireAt: parsed.lastFireAt,
+      lastRunId: parsed.lastRunId,
+      lastError: parsed.lastError,
+      lockedUntil: parsed.lockedUntil,
+      lastSuccessfulRunAt: parsed.lastSuccessfulRunAt,
+      updatedAt: parsed.updatedAt,
+    }
+    return normalizeScheduleState(
+      typeof parsed.environment === "string" ? parsed.environment : undefined,
+      state,
+    )
+  } catch {
+    return null
+  }
+}
+
+function normalizeScheduleState(
+  environment: string | undefined,
+  state: RawScheduleStateRecord,
+): ScheduleStateRecord {
+  return {
+    scheduleId: state.scheduleId,
+    ...(typeof state.workflowId === "string" ? { workflowId: state.workflowId } : {}),
+    ...(environment !== undefined ? { environment } : {}),
+    ...(typeof state.versionId === "string" ? { versionId: state.versionId } : {}),
+    lastFireAt: nullableFiniteNumber(state.lastFireAt),
+    lastRunId: nullableString(state.lastRunId),
+    lastError: nullableString(state.lastError),
+    lockedUntil: nullableFiniteNumber(state.lockedUntil),
+    lastSuccessfulRunAt: nullableFiniteNumber(state.lastSuccessfulRunAt),
+    updatedAt: nullableFiniteNumber(state.updatedAt),
+  }
+}
+
+function nullableFiniteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}

--- a/packages/workflows-orchestrator-cloudflare/src/worker.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/worker.ts
@@ -188,11 +188,14 @@ export async function handleWorkerRequest<Id>(
     try {
       const triggerRes = await forwardToRunDO(runId, forward, deps)
       const runResult = triggerRes.ok ? await safeResponseJson(triggerRes.clone()) : undefined
+      const runError = triggerRes.ok
+        ? failedRunError(runResult)
+        : `do_returned_${triggerRes.status}`
       await recordScheduleDispatch(deps, {
         scheduleTrigger,
-        runId,
+        runId: triggerRes.ok ? runId : null,
         fireAt,
-        error: triggerRes.ok ? null : `do_returned_${triggerRes.status}`,
+        error: runError,
         lastSuccessfulRunAt: completedRunAt(runResult),
       })
       return triggerRes
@@ -534,7 +537,7 @@ function getScheduleTrigger(payload: Record<string, unknown>): {
   scheduleId: string
 } | null {
   const triggeredBy = payload.triggeredBy
-  const environment = payload.environment
+  const environment = payload.environment ?? "development"
   if (
     typeof triggeredBy !== "object" ||
     triggeredBy === null ||
@@ -575,7 +578,7 @@ async function recordScheduleDispatch<Id>(
       scheduleId: args.scheduleTrigger.scheduleId,
       environment: args.scheduleTrigger.environment,
       lastFireAt: args.fireAt,
-      lastRunId: args.error ? null : args.runId,
+      lastRunId: args.runId,
       lastError: args.error,
       ...(args.lastSuccessfulRunAt !== undefined
         ? { lastSuccessfulRunAt: args.lastSuccessfulRunAt }
@@ -612,6 +615,23 @@ function completedRunAt(value: unknown): number | undefined {
     return value.completedAt
   }
   return undefined
+}
+
+function failedRunError(value: unknown): string | null {
+  if (typeof value !== "object" || value === null || !("status" in value)) return null
+  const status = value.status
+  if (status !== "failed" && status !== "compensation_failed") return null
+  const error = "error" in value ? value.error : undefined
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof error.message === "string" &&
+    error.message.length > 0
+  ) {
+    return error.message
+  }
+  return `run_${status}`
 }
 
 function json(status: number, body: unknown): Response {

--- a/packages/workflows-orchestrator-cloudflare/src/worker.ts
+++ b/packages/workflows-orchestrator-cloudflare/src/worker.ts
@@ -23,6 +23,7 @@ import { handleIngestEvent } from "./event-handler.js"
 import { handleGetManifest, handleRegisterManifest } from "./manifest-handler.js"
 import type { CfManifestStore } from "./manifest-kv-store.js"
 import { handleGetSchedules } from "./schedule-handler.js"
+import type { CfScheduleStateStore } from "./schedule-state-store.js"
 
 const DEFAULT_TENANT_META = {
   tenantId: "default",
@@ -68,6 +69,11 @@ export interface WorkerFetchDeps<Id = unknown> {
    * When omitted, the schedules response leaves the flag out.
    */
   schedulesEnabledByEnv?: boolean
+  /**
+   * Optional persisted scheduler execution state read by
+   * `/api/schedules/:env`.
+   */
+  scheduleStateStore?: CfScheduleStateStore
   /**
    * Tenant metadata stamped on event-triggered runs. Defaults to
    * `{ tenantId: "default", projectId: "default", organizationId: "default" }`.
@@ -139,6 +145,7 @@ export async function handleWorkerRequest<Id>(
       return handleGetSchedules(env, {
         manifestStore: deps.manifestStore,
         schedulesEnabledByEnv: deps.schedulesEnabledByEnv,
+        scheduleStateStore: deps.scheduleStateStore,
         now: deps.now,
         logger: deps.logger,
       })
@@ -176,7 +183,28 @@ export async function handleWorkerRequest<Id>(
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ ...publicPayload, runId }),
     })
-    return forwardToRunDO(runId, forward, deps)
+    const fireAt = deps.now ? deps.now() : Date.now()
+    const scheduleTrigger = getScheduleTrigger(publicPayload)
+    try {
+      const triggerRes = await forwardToRunDO(runId, forward, deps)
+      const runResult = triggerRes.ok ? await safeResponseJson(triggerRes.clone()) : undefined
+      await recordScheduleDispatch(deps, {
+        scheduleTrigger,
+        runId,
+        fireAt,
+        error: triggerRes.ok ? null : `do_returned_${triggerRes.status}`,
+        lastSuccessfulRunAt: completedRunAt(runResult),
+      })
+      return triggerRes
+    } catch (err) {
+      await recordScheduleDispatch(deps, {
+        scheduleTrigger,
+        runId: null,
+        fireAt,
+        error: errMsg(err),
+      })
+      throw err
+    }
   }
 
   // Everything below operates on a specific runId.
@@ -499,6 +527,91 @@ function sanitizePublicTriggerPayload(payload: Record<string, unknown>): Record<
     ...publicPayload
   } = payload
   return publicPayload
+}
+
+function getScheduleTrigger(payload: Record<string, unknown>): {
+  environment: "production" | "preview" | "development"
+  scheduleId: string
+} | null {
+  const triggeredBy = payload.triggeredBy
+  const environment = payload.environment
+  if (
+    typeof triggeredBy !== "object" ||
+    triggeredBy === null ||
+    !("kind" in triggeredBy) ||
+    triggeredBy.kind !== "schedule" ||
+    !("scheduleId" in triggeredBy) ||
+    typeof triggeredBy.scheduleId !== "string" ||
+    triggeredBy.scheduleId.length === 0 ||
+    (environment !== "production" && environment !== "preview" && environment !== "development")
+  ) {
+    return null
+  }
+  return {
+    environment,
+    scheduleId: triggeredBy.scheduleId,
+  }
+}
+
+async function recordScheduleDispatch<Id>(
+  deps: WorkerFetchDeps<Id>,
+  args: {
+    scheduleTrigger: ReturnType<typeof getScheduleTrigger>
+    runId: string | null
+    fireAt: number
+    error: string | null
+    lastSuccessfulRunAt?: number
+  },
+): Promise<void> {
+  if (!deps.scheduleStateStore || !args.scheduleTrigger) return
+  try {
+    const existing = (
+      await deps.scheduleStateStore.getStates(args.scheduleTrigger.environment, [
+        args.scheduleTrigger.scheduleId,
+      ])
+    ).get(args.scheduleTrigger.scheduleId)
+    await deps.scheduleStateStore.putState(args.scheduleTrigger.environment, {
+      ...existing,
+      scheduleId: args.scheduleTrigger.scheduleId,
+      environment: args.scheduleTrigger.environment,
+      lastFireAt: args.fireAt,
+      lastRunId: args.error ? null : args.runId,
+      lastError: args.error,
+      ...(args.lastSuccessfulRunAt !== undefined
+        ? { lastSuccessfulRunAt: args.lastSuccessfulRunAt }
+        : {}),
+      updatedAt: deps.now ? deps.now() : Date.now(),
+    })
+  } catch (err) {
+    deps.logger?.("warn", "schedules: cannot persist scheduler dispatch state", {
+      environment: args.scheduleTrigger.environment,
+      scheduleId: args.scheduleTrigger.scheduleId,
+      error: errMsg(err),
+    })
+  }
+}
+
+async function safeResponseJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json()
+  } catch {
+    return undefined
+  }
+}
+
+function completedRunAt(value: unknown): number | undefined {
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "status" in value &&
+    value.status === "completed" &&
+    "completedAt" in value &&
+    typeof value.completedAt === "number" &&
+    Number.isFinite(value.completedAt)
+  ) {
+    return value.completedAt
+  }
+  return undefined
 }
 
 function json(status: number, body: unknown): Response {

--- a/packages/workflows-react/src/workflow-schedules-client.ts
+++ b/packages/workflows-react/src/workflow-schedules-client.ts
@@ -23,6 +23,18 @@ export interface WorkflowScheduleSummary {
   nextRunAt: number | null
   enabled: boolean
   disabledReason?: "registration_disabled" | "env_filtered"
+  /** Epoch millis of the last scheduler dispatch attempt, when known. */
+  lastFireAt?: number | null
+  /** Run id produced by the last scheduler dispatch attempt, when known. */
+  lastRunId?: string | null
+  /** Last scheduler dispatch/lock error, when known. */
+  lastError?: string | null
+  /** Epoch millis until which this schedule is locked, when known. */
+  lockedUntil?: number | null
+  /** Epoch millis of the last successful scheduled run, when known. */
+  lastSuccessfulRunAt?: number | null
+  /** Epoch millis when the persisted scheduler state was last updated. */
+  stateUpdatedAt?: number | null
 }
 
 export interface ListWorkflowSchedulesResponse {

--- a/packages/workflows-ui/src/components/workflow-schedules-page.tsx
+++ b/packages/workflows-ui/src/components/workflow-schedules-page.tsx
@@ -255,7 +255,7 @@ function ScheduleRow({
       <td className="px-3 py-2 text-xs text-muted-foreground">
         {formatNextRun(row, messages, rootMessages)}
       </td>
-      <td className="px-3 py-2 text-xs">{formatLastRun(lastRun, messages, rootMessages)}</td>
+      <td className="px-3 py-2 text-xs">{formatLastRun(lastRun, row, messages, rootMessages)}</td>
       <td className="px-3 py-2">
         <StatusPill row={row} envFlagDisabled={envFlagDisabled} messages={messages} />
       </td>
@@ -336,18 +336,48 @@ function formatNextRun(
 
 function formatLastRun(
   lastRun: WorkflowRun | null,
+  row: WorkflowScheduleSummary,
   messages: SchedulesMessages,
   rootMessages: WorkflowRunsUiMessages,
 ) {
-  if (!lastRun) return <span className="text-muted-foreground">{messages.lastRunNone}</span>
-  const relative = formatRelative(lastRun.startedAt, rootMessages)
-  const label = lastRunLabel(lastRun.status, relative, messages)
-  return (
-    <span className="inline-flex items-center gap-1.5">
-      <StatusIcon status={lastRun.status} />
-      {label}
-    </span>
-  )
+  if (lastRun) {
+    const relative = formatRelative(lastRun.startedAt, rootMessages)
+    const label = lastRunLabel(lastRun.status, relative, messages)
+    return (
+      <span className="inline-flex items-center gap-1.5">
+        <StatusIcon status={lastRun.status} />
+        {label}
+      </span>
+    )
+  }
+  if (row.lastError && row.lastFireAt !== undefined && row.lastFireAt !== null) {
+    const relative = formatRelative(new Date(row.lastFireAt).toISOString(), rootMessages)
+    return (
+      <span className="inline-flex items-center gap-1.5" title={row.lastError}>
+        <StatusIcon status="failed" />
+        {messages.lastRunFailed(relative)}
+      </span>
+    )
+  }
+  if (row.lastSuccessfulRunAt !== undefined && row.lastSuccessfulRunAt !== null) {
+    const relative = formatRelative(new Date(row.lastSuccessfulRunAt).toISOString(), rootMessages)
+    return (
+      <span className="inline-flex items-center gap-1.5">
+        <StatusIcon status="succeeded" />
+        {messages.lastRunSucceeded(relative)}
+      </span>
+    )
+  }
+  if (row.lastFireAt !== undefined && row.lastFireAt !== null) {
+    const relative = formatRelative(new Date(row.lastFireAt).toISOString(), rootMessages)
+    return (
+      <span className="inline-flex items-center gap-1.5">
+        <CalendarClock className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
+        {messages.lastFireRecorded(relative)}
+      </span>
+    )
+  }
+  return <span className="text-muted-foreground">{messages.lastRunNone}</span>
 }
 
 function lastRunLabel(

--- a/packages/workflows-ui/src/i18n/en.ts
+++ b/packages/workflows-ui/src/i18n/en.ts
@@ -134,6 +134,7 @@ export const workflowRunsUiEn: WorkflowRunsUiMessages = {
     lastRunFailed: (relative) => `failed ${relative} ago`,
     lastRunRunning: "running",
     lastRunCancelled: (relative) => `cancelled ${relative} ago`,
+    lastFireRecorded: (relative) => `fired ${relative} ago`,
     lastRunNone: "never run",
   },
 }

--- a/packages/workflows-ui/src/i18n/messages.ts
+++ b/packages/workflows-ui/src/i18n/messages.ts
@@ -119,6 +119,7 @@ export type WorkflowRunsUiMessages = {
     lastRunFailed: (relative: string) => string
     lastRunRunning: string
     lastRunCancelled: (relative: string) => string
+    lastFireRecorded: (relative: string) => string
     lastRunNone: string
   }
 }

--- a/packages/workflows-ui/src/i18n/ro.ts
+++ b/packages/workflows-ui/src/i18n/ro.ts
@@ -136,6 +136,7 @@ export const workflowRunsUiRo: WorkflowRunsUiMessages = {
     lastRunFailed: (relative) => `esuata acum ${relative}`,
     lastRunRunning: "in rulare",
     lastRunCancelled: (relative) => `anulata acum ${relative}`,
+    lastFireRecorded: (relative) => `declansata acum ${relative}`,
     lastRunNone: "nu a rulat niciodata",
   },
 }


### PR DESCRIPTION
## Summary

- add a KV-backed workflow schedule state store for last fire/run/error data
- merge persisted scheduler state into `GET /api/schedules/:env` rows
- record scheduled `POST /api/runs` dispatch attempts into the state store when configured
- surface schedule-state fallback data in the schedules UI when run history is not wired

Closes #1406.

## Verification

- `pnpm --filter @voyantjs/workflows-orchestrator-cloudflare test`
- `pnpm --filter @voyantjs/workflows-orchestrator-cloudflare check-types`
- `pnpm --filter @voyantjs/workflows-react typecheck`
- `pnpm --filter @voyantjs/workflows-ui typecheck`
- `pnpm --filter @voyantjs/workflows-orchestrator-worker test`
- `pnpm test` (pre-push hook)