### PR TITLE
Add external cruise catalog refresh flow

### DIFF
--- a/.changeset/external-cruise-refresh.md
+++ b/.changeset/external-cruise-refresh.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/catalog": minor
+"@voyantjs/cruises": minor
+---
+
+Add provider-agnostic external cruise catalog refresh and reindex helpers.

--- a/docs/architecture/cruise-adapter-contract.md
+++ b/docs/architecture/cruise-adapter-contract.md
@@ -96,6 +96,42 @@ cancellation through the catalog source adapter remain explicit capability
 stubs; external cruise booking commits should use the cruises vertical booking
 path.
 
+## Refresh And Reindex
+
+External cruise adapters may sync upstream data on their own cadence. Voyant
+deployments still need a provider-neutral bridge that reconciles local browse
+and catalog search surfaces from adapter projections.
+
+The cruises package exposes `refreshExternalCruiseCatalog(...)` for that bridge.
+It performs two independent refreshes:
+
+- `cruise_search_index`: drains each registered `CruiseAdapter.searchProjection()`
+  stream, upserts emitted rows, then removes rows for that adapter that were not
+  emitted by the successful run.
+- Catalog plane: when the caller supplies a catalog `SourceAdapterRegistry`,
+  `IndexerService`, and field-policy registries, it runs `syncSources(...)` for
+  the `cruises` vertical, upserts `catalog_sourced_entries`, reindexes configured
+  catalog search slices, and marks missing sourced rows withdrawn.
+
+Pruning only runs after an adapter finishes successfully. A failed adapter is
+reported in the refresh summary and leaves existing indexed rows in place.
+Multiple connections stay isolated by full source identity: `cruise_search_index`
+matches by provider plus full `SourceRef`, while catalog rows prune by
+`source_kind`, `source_connection_id`, and `entity_module`.
+
+Manual operator refresh paths:
+
+- `POST /v1/admin/cruises/search-index/rebuild` refreshes the cruise vertical
+  browse index from registered cruise adapters.
+- `pnpm sync:sources` in `templates/operator` refreshes catalog sourced entries
+  and search slices from registered catalog source adapters.
+
+Scheduled refresh in `templates/operator` runs daily at `30 3 * * *` via
+`EXTERNAL_CRUISE_CATALOG_REFRESH_CRON`. Deployments can add adapter-specific
+webhook/event handlers that call the same `refreshExternalCruiseCatalog(...)`
+service for targeted near-real-time refreshes without coupling the framework to
+any provider.
+
 ## Compatibility Tests
 
 External adapter packages can run the framework compatibility fixture in their

--- a/packages/catalog/src/booking-engine/sync.test.ts
+++ b/packages/catalog/src/booking-engine/sync.test.ts
@@ -21,8 +21,10 @@ import { syncSources } from "./sync.js"
 function makeStubIndexer(slicesByVertical: Record<string, IndexerSlice[]>): {
   service: IndexerService
   upserted: Array<{ slice: IndexerSlice; doc: IndexerDocument }>
+  deleted: Array<{ entityModule: string; entityId: string }>
 } {
   const upserted: Array<{ slice: IndexerSlice; doc: IndexerDocument }> = []
+  const deleted: Array<{ entityModule: string; entityId: string }> = []
   const service: IndexerService = {
     async ensureCollections() {},
     async reindexEntity(entityModule, entityId, builder: DocumentBuilder) {
@@ -36,7 +38,9 @@ function makeStubIndexer(slicesByVertical: Record<string, IndexerSlice[]>): {
       const doc = await builder(entityId, slice)
       if (doc) upserted.push({ slice, doc })
     },
-    async deleteEntity() {},
+    async deleteEntity(entityModule, entityId) {
+      deleted.push({ entityModule, entityId })
+    },
     async search(_slice: IndexerSlice, _request: SearchRequest): Promise<SearchResults> {
       return { total: 0, hits: [] }
     },
@@ -44,7 +48,7 @@ function makeStubIndexer(slicesByVertical: Record<string, IndexerSlice[]>): {
       return slicesByVertical[entityModule] ?? []
     },
   }
-  return { service, upserted }
+  return { service, upserted, deleted }
 }
 
 /**
@@ -314,5 +318,105 @@ describe("syncSources", () => {
 
     expect(wrapped).toBe(1)
     expect(upserted[0]?.doc.fields.wrapped).toBe(true)
+  })
+
+  it("marks missing sourced rows withdrawn and deletes them from index slices after a successful pruned sync", async () => {
+    const registry = createSourceAdapterRegistry()
+    registry.register("conn-a", {
+      kind: "demo",
+      capabilities: {
+        verticals: ["products"],
+        supportsLiveResolution: false,
+        supportsDriftDetection: false,
+        supportsBookingForwarding: false,
+        postBookOperations: [],
+      },
+      connect: async () => undefined,
+      pause: async () => undefined,
+      disconnect: async () => undefined,
+      getState: async () => "active",
+      discover: async () => ({
+        projections: [
+          {
+            entity_module: "products",
+            entity_id: "active_a",
+            provenance: {
+              source_kind: "demo",
+              source_connection_id: "conn-a",
+              source_ref: "src-a",
+              source_freshness: "sync" as const,
+            },
+            fields: { id: "active_a", name: "Active A", status: "active" },
+          },
+        ],
+        next_cursor: undefined,
+      }),
+    })
+
+    const { service, deleted } = makeStubIndexer({
+      products: [{ vertical: "products", locale: "en-GB", audience: "staff", market: "default" }],
+    })
+    const fieldPolicyRegistries = new Map([["products", makePassthroughRegistry()]])
+
+    const updatedIds: string[][] = []
+    const stubDb = {
+      insert() {
+        return {
+          values() {
+            return {
+              onConflictDoUpdate() {
+                return {
+                  async returning() {
+                    return [{ id: "cse_active", entity_module: "products", entity_id: "active_a" }]
+                  },
+                }
+              },
+            }
+          },
+        }
+      },
+      select() {
+        return {
+          from() {
+            return {
+              async where() {
+                return [
+                  {
+                    id: "cse_stale",
+                    entity_module: "products",
+                    entity_id: "stale_b",
+                  },
+                ]
+              },
+            }
+          },
+        }
+      },
+      update() {
+        return {
+          set() {
+            return {
+              async where(condition: unknown) {
+                updatedIds.push([String(condition)])
+              },
+            }
+          },
+        }
+      },
+    }
+
+    const summary = await syncSources({
+      registry,
+      indexerService: service,
+      fieldPolicyRegistries,
+      // biome-ignore lint/suspicious/noExplicitAny: stub mirrors the drizzle chain shape
+      db: stubDb as any,
+      pruneMissing: true,
+      verticals: ["products"],
+    })
+
+    expect(summary.adapters[0]?.withdrawnProjections).toBe(1)
+    expect(deleted).toEqual([{ entityModule: "products", entityId: "stale_b" }])
+    expect(updatedIds).toHaveLength(1)
   })
 })

--- a/packages/catalog/src/booking-engine/sync.ts
+++ b/packages/catalog/src/booking-engine/sync.ts
@@ -33,7 +33,10 @@ import type { IndexerDocument, IndexerSlice } from "../indexer/contract.js"
 import { isOwned } from "../provenance.js"
 import type { DocumentBuilder, IndexerService } from "../services/indexer-service.js"
 import { buildIndexerDocument } from "../services/indexer-service.js"
-import { upsertSourcedEntry } from "../services/sourced-entry-service.js"
+import {
+  markMissingSourcedEntriesWithdrawn,
+  upsertSourcedEntry,
+} from "../services/sourced-entry-service.js"
 
 import type { SourceAdapterRegistry } from "./registry.js"
 
@@ -79,6 +82,17 @@ export interface SyncSourcesOptions {
   wrapBuilder?: (builder: DocumentBuilder) => DocumentBuilder
   /** Per-page log hook — called every page so callers can show progress. */
   onProgress?: (event: SyncProgressEvent) => void
+  /**
+   * Optional vertical allow-list. Scheduled vertical refreshes use this to run
+   * only the adapter projections relevant to the current job.
+   */
+  verticals?: ReadonlyArray<string>
+  /**
+   * When true, rows from the same source/connection/vertical that were not
+   * emitted by a successful discovery pass are marked withdrawn and deleted
+   * from catalog search slices. Failed adapter passes never prune.
+   */
+  pruneMissing?: boolean
 }
 
 export interface SyncProgressEvent {
@@ -116,6 +130,11 @@ export interface SyncAdapterSummary {
    * the indexer.
    */
   ownedProjections: number
+  /**
+   * Previously active sourced rows that were not emitted by a successful
+   * discovery pass, marked withdrawn and removed from search slices.
+   */
+  withdrawnProjections: number
 }
 
 export interface SyncSourcesSummary {
@@ -129,6 +148,7 @@ export interface SyncSourcesSummary {
  * adapters wishing to participate in the sync must implement it).
  */
 export async function syncSources(options: SyncSourcesOptions): Promise<SyncSourcesSummary> {
+  const verticalFilter = options.verticals ? new Set(options.verticals) : undefined
   // Iterate every registered (connection_id, adapter) pair — multiple
   // connections of the same kind each get their own discovery pass.
   // Skip adapters that don't implement `discover` (outbound-only
@@ -140,6 +160,11 @@ export async function syncSources(options: SyncSourcesOptions): Promise<SyncSour
       adapter: options.registry.resolveByConnectionOrThrow(connectionId),
     }))
     .filter((e) => typeof e.adapter.discover === "function")
+    .filter(
+      (e) =>
+        !verticalFilter ||
+        e.adapter.capabilities.verticals.some((vertical) => verticalFilter.has(vertical)),
+    )
   const adapterSummaries: SyncAdapterSummary[] = []
   let totalProjections = 0
 
@@ -155,8 +180,10 @@ export async function syncSources(options: SyncSourcesOptions): Promise<SyncSour
       skippedNoRegistry: 0,
       sourcedEntriesUpserted: 0,
       ownedProjections: 0,
+      withdrawnProjections: 0,
     }
     const verticals = new Set<string>()
+    const seenBySource = new Map<string, SourcedSeenSet>()
 
     let cursor: string | undefined
     do {
@@ -173,6 +200,9 @@ export async function syncSources(options: SyncSourcesOptions): Promise<SyncSour
       })
 
       for (const projection of page.projections) {
+        if (verticalFilter && !verticalFilter.has(projection.entity_module)) {
+          continue
+        }
         const registry = options.fieldPolicyRegistries.get(projection.entity_module)
         if (!registry) {
           summary.skippedNoRegistry += 1
@@ -191,6 +221,14 @@ export async function syncSources(options: SyncSourcesOptions): Promise<SyncSour
         } else if (options.db) {
           await upsertSourcedEntry(options.db, { projection })
           summary.sourcedEntriesUpserted += 1
+          if (options.pruneMissing) {
+            trackSeenSourcedProjection(seenBySource, {
+              entityModule: projection.entity_module,
+              entityId: projection.entity_id,
+              sourceKind: projection.provenance.source_kind,
+              sourceConnectionId: projection.provenance.source_connection_id,
+            })
+          }
         }
 
         const projectionMap = toProjectionMap(projection.fields)
@@ -213,6 +251,22 @@ export async function syncSources(options: SyncSourcesOptions): Promise<SyncSour
       cursor = page.next_cursor
     } while (cursor)
 
+    if (options.pruneMissing && options.db) {
+      ensureAdapterVerticalPruneScopes(seenBySource, adapter, connectionId, verticalFilter)
+      for (const seen of seenBySource.values()) {
+        const withdrawn = await markMissingSourcedEntriesWithdrawn(options.db, {
+          entityModule: seen.entityModule,
+          sourceKind: seen.sourceKind,
+          sourceConnectionId: seen.sourceConnectionId,
+          seenEntityIds: seen.entityIds,
+        })
+        for (const row of withdrawn) {
+          await options.indexerService.deleteEntity(row.entity_module, row.entity_id)
+        }
+        summary.withdrawnProjections += withdrawn.length
+      }
+    }
+
     summary.verticalsTouched = [...verticals]
     adapterSummaries.push(summary)
   }
@@ -222,4 +276,66 @@ export async function syncSources(options: SyncSourcesOptions): Promise<SyncSour
 
 function toProjectionMap(fields: Record<string, unknown>): ReadonlyMap<string, unknown> {
   return new Map(Object.entries(fields))
+}
+
+type SourcedSeenSet = {
+  entityModule: string
+  sourceKind: string
+  sourceConnectionId?: string | null
+  entityIds: Set<string>
+}
+
+function trackSeenSourcedProjection(
+  seenBySource: Map<string, SourcedSeenSet>,
+  input: {
+    entityModule: string
+    entityId: string
+    sourceKind: string
+    sourceConnectionId?: string | null
+  },
+): void {
+  const key = sourceScopeKey(input)
+  let seen = seenBySource.get(key)
+  if (!seen) {
+    seen = {
+      entityModule: input.entityModule,
+      sourceKind: input.sourceKind,
+      sourceConnectionId: input.sourceConnectionId,
+      entityIds: new Set(),
+    }
+    seenBySource.set(key, seen)
+  }
+  seen.entityIds.add(input.entityId)
+}
+
+function ensureAdapterVerticalPruneScopes(
+  seenBySource: Map<string, SourcedSeenSet>,
+  adapter: SourceAdapter,
+  connectionId: string,
+  verticalFilter: Set<string> | undefined,
+): void {
+  const verticals = adapter.capabilities.verticals.filter(
+    (vertical) => !verticalFilter || verticalFilter.has(vertical),
+  )
+  for (const entityModule of verticals) {
+    const input = {
+      entityModule,
+      sourceKind: adapter.kind,
+      sourceConnectionId: connectionId,
+    }
+    const key = sourceScopeKey(input)
+    if (seenBySource.has(key)) continue
+    seenBySource.set(key, {
+      ...input,
+      entityIds: new Set(),
+    })
+  }
+}
+
+function sourceScopeKey(input: {
+  entityModule: string
+  sourceKind: string
+  sourceConnectionId?: string | null
+}): string {
+  return `${input.entityModule}\u0000${input.sourceKind}\u0000${input.sourceConnectionId ?? ""}`
 }

--- a/packages/catalog/src/index.ts
+++ b/packages/catalog/src/index.ts
@@ -239,6 +239,7 @@ export {
 } from "./services/snapshot-service.js"
 export {
   createReadProvenance,
+  markMissingSourcedEntriesWithdrawn,
   markSourcedEntryWithdrawn,
   type OwnedChecker,
   type ProvenanceReadResult,

--- a/packages/catalog/src/services/sourced-entry-service.ts
+++ b/packages/catalog/src/services/sourced-entry-service.ts
@@ -28,7 +28,7 @@
  */
 
 import type { AnyDrizzleDb } from "@voyantjs/db"
-import { and, eq, sql } from "drizzle-orm"
+import { and, eq, inArray, isNull, notInArray, type SQL, sql } from "drizzle-orm"
 
 import type { CatalogProjection } from "../adapter/contract.js"
 import type { SourceFreshness } from "../contract.js"
@@ -291,4 +291,53 @@ export async function markSourcedEntryWithdrawn(
         eq(catalogSourcedEntriesTable.entity_id, entityId),
       ),
     )
+}
+
+/**
+ * Mark active sourced rows missing from a successful full-source discovery pass
+ * as withdrawn. Callers should invoke this only after an adapter completed its
+ * projection stream; failed refreshes must leave existing rows untouched.
+ */
+export async function markMissingSourcedEntriesWithdrawn(
+  db: AnyDrizzleDb,
+  input: {
+    entityModule: string
+    sourceKind: string
+    sourceConnectionId?: string | null
+    seenEntityIds: ReadonlySet<string>
+  },
+): Promise<SelectCatalogSourcedEntry[]> {
+  const conditions: SQL[] = [
+    eq(catalogSourcedEntriesTable.entity_module, input.entityModule),
+    eq(catalogSourcedEntriesTable.source_kind, input.sourceKind as SourceKind),
+    eq(catalogSourcedEntriesTable.status, "active"),
+    input.sourceConnectionId == null
+      ? isNull(catalogSourcedEntriesTable.source_connection_id)
+      : eq(catalogSourcedEntriesTable.source_connection_id, input.sourceConnectionId),
+  ]
+
+  const seen = [...input.seenEntityIds]
+  if (seen.length > 0) {
+    conditions.push(notInArray(catalogSourcedEntriesTable.entity_id, seen))
+  }
+
+  const rows = await db
+    .select()
+    .from(catalogSourcedEntriesTable)
+    .where(and(...conditions))
+
+  if (rows.length === 0) return []
+
+  const now = new Date()
+  await db
+    .update(catalogSourcedEntriesTable)
+    .set({ status: "withdrawn", updated_at: now })
+    .where(
+      inArray(
+        catalogSourcedEntriesTable.id,
+        rows.map((row) => row.id),
+      ),
+    )
+
+  return rows
 }

--- a/packages/cruises/package.json
+++ b/packages/cruises/package.json
@@ -15,6 +15,7 @@
     "./service-catalog-plane": "./src/service-catalog-plane.ts",
     "./content-shape": "./src/content-shape.ts",
     "./service-content": "./src/service-content.ts",
+    "./service-external-refresh": "./src/service-external-refresh.ts",
     "./service-content-synthesizer": "./src/service-content-synthesizer.ts",
     "./routes-content": "./src/routes-content.ts",
     "./draft-shape": "./src/draft-shape.ts",
@@ -105,6 +106,11 @@
         "types": "./dist/service-content.d.ts",
         "import": "./dist/service-content.js",
         "default": "./dist/service-content.js"
+      },
+      "./service-external-refresh": {
+        "types": "./dist/service-external-refresh.d.ts",
+        "import": "./dist/service-external-refresh.js",
+        "default": "./dist/service-external-refresh.js"
       },
       "./service-content-synthesizer": {
         "types": "./dist/service-content-synthesizer.d.ts",

--- a/packages/cruises/src/index.ts
+++ b/packages/cruises/src/index.ts
@@ -103,6 +103,11 @@ export {
 } from "./service-bookings.js"
 export { detachExternalCruise } from "./service-detach.js"
 export {
+  type ExternalCruiseCatalogRefreshOptions,
+  type ExternalCruiseCatalogRefreshResult,
+  refreshExternalCruiseCatalog,
+} from "./service-external-refresh.js"
+export {
   type ComposeQuoteInput,
   composeQuote,
   type GridCell,

--- a/packages/cruises/src/service-external-refresh.ts
+++ b/packages/cruises/src/service-external-refresh.ts
@@ -1,0 +1,88 @@
+/**
+ * Provider-agnostic external cruise catalog refresh.
+ *
+ * Reconciles both local browse/search projections (`cruise_search_index`) and,
+ * when catalog runtime dependencies are supplied, catalog sourced entries plus
+ * catalog search slices. The service never imports a concrete provider.
+ */
+
+import type { DocumentBuilder, FieldPolicyRegistry, IndexerService } from "@voyantjs/catalog"
+import {
+  type SourceAdapterRegistry,
+  type SyncProgressEvent,
+  type SyncSourcesSummary,
+  syncSources,
+} from "@voyantjs/catalog/booking-engine"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { listCruiseAdapters } from "./adapters/registry.js"
+import { cruisesSearchService, type ExternalAdapterRefreshResult } from "./service-search.js"
+
+export interface ExternalCruiseCatalogRefreshOptions {
+  db: PostgresJsDatabase
+  /**
+   * Optional catalog source registry. Supplying it lets the refresh update
+   * `catalog_sourced_entries` and catalog search slices from cruise shims.
+   */
+  sourceAdapterRegistry?: SourceAdapterRegistry
+  indexerService?: IndexerService
+  fieldPolicyRegistries?: ReadonlyMap<string, FieldPolicyRegistry>
+  wrapCatalogBuilder?: (builder: DocumentBuilder) => DocumentBuilder
+  onCatalogProgress?: (event: SyncProgressEvent) => void
+}
+
+export interface ExternalCruiseCatalogRefreshResult {
+  cruiseSearchIndex: {
+    adapters: Array<
+      {
+        adapter: string
+      } & ExternalAdapterRefreshResult
+    >
+    upserted: number
+    removed: number
+    errors: Array<{ adapter: string; error: string }>
+  }
+  catalog?: SyncSourcesSummary
+}
+
+export async function refreshExternalCruiseCatalog(
+  options: ExternalCruiseCatalogRefreshOptions,
+): Promise<ExternalCruiseCatalogRefreshResult> {
+  const adapters = listCruiseAdapters()
+  const cruiseSearchIndex: ExternalCruiseCatalogRefreshResult["cruiseSearchIndex"] = {
+    adapters: [],
+    upserted: 0,
+    removed: 0,
+    errors: [],
+  }
+
+  for (const adapter of adapters) {
+    try {
+      const result = await cruisesSearchService.refreshExternalForAdapter(options.db, adapter)
+      cruiseSearchIndex.adapters.push({ adapter: adapter.name, ...result })
+      cruiseSearchIndex.upserted += result.upserted
+      cruiseSearchIndex.removed += result.removed
+    } catch (err) {
+      cruiseSearchIndex.errors.push({
+        adapter: adapter.name,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  let catalog: SyncSourcesSummary | undefined
+  if (options.sourceAdapterRegistry && options.indexerService && options.fieldPolicyRegistries) {
+    catalog = await syncSources({
+      registry: options.sourceAdapterRegistry,
+      indexerService: options.indexerService,
+      fieldPolicyRegistries: options.fieldPolicyRegistries,
+      db: options.db,
+      verticals: ["cruises"],
+      pruneMissing: true,
+      ...(options.wrapCatalogBuilder ? { wrapBuilder: options.wrapCatalogBuilder } : {}),
+      ...(options.onCatalogProgress ? { onProgress: options.onCatalogProgress } : {}),
+    })
+  }
+
+  return { cruiseSearchIndex, ...(catalog ? { catalog } : {}) }
+}

--- a/packages/cruises/src/service-search.ts
+++ b/packages/cruises/src/service-search.ts
@@ -12,7 +12,7 @@
  *     `searchProjection()` deltas) to keep external entries fresh.
  */
 
-import { and, asc, eq, gte, ilike, lte, or, type SQL, sql } from "drizzle-orm"
+import { and, asc, eq, gte, ilike, lte, notInArray, or, type SQL, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import type { CruiseAdapter, SourceRef } from "./adapters/index.js"
@@ -64,7 +64,13 @@ export type BulkSearchIndexEntry = {
 export type RebuildResult = {
   localUpserted: number
   externalUpserted: number
+  externalRemoved: number
   externalErrors: Array<{ adapter: string; error: string }>
+}
+
+export type ExternalAdapterRefreshResult = {
+  upserted: number
+  removed: number
 }
 
 export const cruisesSearchService = {
@@ -214,6 +220,49 @@ export const cruisesSearchService = {
     return { removed: result.length }
   },
 
+  async removeExternalByIdsExcept(
+    db: PostgresJsDatabase,
+    sourceProvider: string,
+    keepIds: ReadonlyArray<string>,
+    sourceConnectionId?: string | null,
+  ): Promise<{ removed: number }> {
+    const conditions: SQL[] = [
+      eq(cruiseSearchIndex.source, "external"),
+      eq(cruiseSearchIndex.sourceProvider, sourceProvider),
+      sourceConnectionId == null
+        ? sql`coalesce(${cruiseSearchIndex.sourceRef}->>'connectionId', '') = ''`
+        : sql`${cruiseSearchIndex.sourceRef}->>'connectionId' = ${sourceConnectionId}`,
+    ]
+    if (keepIds.length > 0) {
+      conditions.push(notInArray(cruiseSearchIndex.id, [...keepIds]))
+    }
+    const result = await db
+      .delete(cruiseSearchIndex)
+      .where(and(...conditions))
+      .returning({ id: cruiseSearchIndex.id })
+    return { removed: result.length }
+  },
+
+  async listExternalConnectionIds(
+    db: PostgresJsDatabase,
+    sourceProvider: string,
+  ): Promise<Array<string | null>> {
+    const connectionId = sql<
+      string | null
+    >`nullif(${cruiseSearchIndex.sourceRef}->>'connectionId', '')`
+    const rows = await db
+      .select({ connectionId })
+      .from(cruiseSearchIndex)
+      .where(
+        and(
+          eq(cruiseSearchIndex.source, "external"),
+          eq(cruiseSearchIndex.sourceProvider, sourceProvider),
+        ),
+      )
+      .groupBy(connectionId)
+    return rows.map((row) => row.connectionId)
+  },
+
   // ---------- projection from local cruises ----------
 
   /**
@@ -272,9 +321,26 @@ export const cruisesSearchService = {
     db: PostgresJsDatabase,
     adapter: CruiseAdapter,
   ): Promise<{ upserted: number }> {
+    const result = await this.refreshExternalForAdapter(db, adapter)
+    return { upserted: result.upserted }
+  },
+
+  /**
+   * Drain `searchProjection()` from a single adapter and reconcile the local
+   * external search-index rows for that provider. Existing rows stay intact
+   * until the adapter stream completes; only then are missing rows removed.
+   */
+  async refreshExternalForAdapter(
+    db: PostgresJsDatabase,
+    adapter: CruiseAdapter,
+  ): Promise<ExternalAdapterRefreshResult> {
     let upserted = 0
+    const keptIdsByConnection = new Map<string | null, string[]>()
+    const pruneConnectionIds = new Set<string | null>(
+      await this.listExternalConnectionIds(db, adapter.name),
+    )
     for await (const entry of adapter.searchProjection()) {
-      await this.upsertEntry(db, {
+      const row = await this.upsertEntry(db, {
         source: "external",
         sourceProvider: adapter.name,
         sourceRef: entry.sourceRef,
@@ -295,9 +361,21 @@ export const cruisesSearchService = {
         salesStatus: entry.salesStatus ?? null,
         heroImageUrl: entry.heroImageUrl ?? null,
       })
+      const connectionId = sourceRefConnectionId(entry.sourceRef)
+      const keptIds = keptIdsByConnection.get(connectionId) ?? []
+      keptIds.push(row.id)
+      keptIdsByConnection.set(connectionId, keptIds)
+      pruneConnectionIds.add(connectionId)
       upserted++
     }
-    return { upserted }
+
+    let removed = 0
+    for (const connectionId of pruneConnectionIds) {
+      const keptIds = keptIdsByConnection.get(connectionId) ?? []
+      const result = await this.removeExternalByIdsExcept(db, adapter.name, keptIds, connectionId)
+      removed += result.removed
+    }
+    return { upserted, removed }
   },
 
   /**
@@ -308,18 +386,12 @@ export const cruisesSearchService = {
     const localResult = await this.rebuildLocal(db)
     const externalErrors: RebuildResult["externalErrors"] = []
     let externalUpserted = 0
+    let externalRemoved = 0
     for (const adapter of listCruiseAdapters()) {
       try {
-        await db
-          .delete(cruiseSearchIndex)
-          .where(
-            and(
-              eq(cruiseSearchIndex.source, "external"),
-              eq(cruiseSearchIndex.sourceProvider, adapter.name),
-            ),
-          )
-        const result = await this.rebuildExternalForAdapter(db, adapter)
+        const result = await this.refreshExternalForAdapter(db, adapter)
         externalUpserted += result.upserted
+        externalRemoved += result.removed
       } catch (err) {
         externalErrors.push({ adapter: adapter.name, error: (err as Error).message })
       }
@@ -327,6 +399,7 @@ export const cruisesSearchService = {
     return {
       localUpserted: localResult.upserted,
       externalUpserted,
+      externalRemoved,
       externalErrors,
     }
   },
@@ -371,6 +444,10 @@ async function findExisting(
 
 export function sourceRefIdentityJson(sourceRef: SourceRef): string {
   return JSON.stringify(sortValue(sourceRef))
+}
+
+function sourceRefConnectionId(sourceRef: SourceRef): string | null {
+  return typeof sourceRef.connectionId === "string" ? sourceRef.connectionId : null
 }
 
 function sortValue(value: unknown): unknown {

--- a/packages/cruises/tests/unit/service-search.test.ts
+++ b/packages/cruises/tests/unit/service-search.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
-import { sourceRefIdentityJson } from "../../src/service-search.js"
+import type { CruiseAdapter, CruiseSearchProjectionEntry } from "../../src/adapters/index.js"
+import { cruisesSearchService, sourceRefIdentityJson } from "../../src/service-search.js"
 
 describe("cruisesSearchService sourceRef identity", () => {
   it("keeps connection and provider context in external search-index identity", () => {
@@ -31,3 +32,102 @@ describe("cruisesSearchService sourceRef identity", () => {
     expect(first).toBe(second)
   })
 })
+
+describe("cruisesSearchService external refresh pruning", () => {
+  it("prunes existing provider scopes when a successful projection yields no entries", async () => {
+    const db = {} as Parameters<typeof cruisesSearchService.refreshExternalForAdapter>[0]
+    const calls: Array<{ sourceProvider: string; keepIds: string[]; connectionId: string | null }> =
+      []
+    const originalListExternalConnectionIds = cruisesSearchService.listExternalConnectionIds
+    const originalRemoveExternalByIdsExcept = cruisesSearchService.removeExternalByIdsExcept
+
+    cruisesSearchService.listExternalConnectionIds = async () => ["conn-a", null]
+    cruisesSearchService.removeExternalByIdsExcept = async (
+      _db,
+      sourceProvider,
+      keepIds,
+      connectionId,
+    ) => {
+      calls.push({ sourceProvider, keepIds: [...keepIds], connectionId })
+      return { removed: 1 }
+    }
+
+    try {
+      const result = await cruisesSearchService.refreshExternalForAdapter(
+        db,
+        makeAdapter(async function* () {}),
+      )
+
+      expect(result).toEqual({ upserted: 0, removed: 2 })
+      expect(calls).toEqual([
+        { sourceProvider: "test-cruises", keepIds: [], connectionId: "conn-a" },
+        { sourceProvider: "test-cruises", keepIds: [], connectionId: null },
+      ])
+    } finally {
+      cruisesSearchService.listExternalConnectionIds = originalListExternalConnectionIds
+      cruisesSearchService.removeExternalByIdsExcept = originalRemoveExternalByIdsExcept
+    }
+  })
+
+  it("prunes missing existing scopes while keeping refreshed entries", async () => {
+    const db = {} as Parameters<typeof cruisesSearchService.refreshExternalForAdapter>[0]
+    const calls: Array<{ keepIds: string[]; connectionId: string | null }> = []
+    const originalListExternalConnectionIds = cruisesSearchService.listExternalConnectionIds
+    const originalRemoveExternalByIdsExcept = cruisesSearchService.removeExternalByIdsExcept
+    const originalUpsertEntry = cruisesSearchService.upsertEntry
+
+    cruisesSearchService.listExternalConnectionIds = async () => ["conn-a", "conn-b"]
+    cruisesSearchService.upsertEntry = async () =>
+      ({ id: "kept-row" }) as Awaited<ReturnType<typeof cruisesSearchService.upsertEntry>>
+    cruisesSearchService.removeExternalByIdsExcept = async (
+      _db,
+      _sourceProvider,
+      keepIds,
+      connectionId,
+    ) => {
+      calls.push({ keepIds: [...keepIds], connectionId })
+      return { removed: keepIds.length === 0 ? 2 : 1 }
+    }
+
+    try {
+      const result = await cruisesSearchService.refreshExternalForAdapter(
+        db,
+        makeAdapter(async function* () {
+          yield searchProjectionEntry({ externalId: "cruise-1", connectionId: "conn-a" })
+        }),
+      )
+
+      expect(result).toEqual({ upserted: 1, removed: 3 })
+      expect(calls).toEqual([
+        { keepIds: ["kept-row"], connectionId: "conn-a" },
+        { keepIds: [], connectionId: "conn-b" },
+      ])
+    } finally {
+      cruisesSearchService.listExternalConnectionIds = originalListExternalConnectionIds
+      cruisesSearchService.removeExternalByIdsExcept = originalRemoveExternalByIdsExcept
+      cruisesSearchService.upsertEntry = originalUpsertEntry
+    }
+  })
+})
+
+function makeAdapter(searchProjection: CruiseAdapter["searchProjection"]): CruiseAdapter {
+  return {
+    name: "test-cruises",
+    version: "1.0.0",
+    searchProjection,
+  } as CruiseAdapter
+}
+
+function searchProjectionEntry(
+  sourceRef: CruiseSearchProjectionEntry["sourceRef"],
+): CruiseSearchProjectionEntry {
+  return {
+    sourceRef,
+    slug: `cruise-${sourceRef.externalId}`,
+    name: "Test Cruise",
+    cruiseType: "ocean",
+    lineName: "Test Line",
+    shipName: "Test Ship",
+    nights: 7,
+  }
+}

--- a/templates/operator/src/api/external-cruise-refresh-scheduled.ts
+++ b/templates/operator/src/api/external-cruise-refresh-scheduled.ts
@@ -1,0 +1,57 @@
+/**
+ * External cruise catalog refresh cron.
+ *
+ * Reconciles configured cruise adapters into `cruise_search_index` and, when
+ * the catalog search runtime is configured, the catalog sourced-entry/search
+ * slices used by admin and storefront catalog browsing.
+ */
+
+import { createIndexerService } from "@voyantjs/catalog"
+import { refreshExternalCruiseCatalog } from "@voyantjs/cruises/service-external-refresh"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { getBookingEngineRegistry } from "./lib/booking-engine-runtime"
+import {
+  buildEmbeddingProvider,
+  buildTypesenseIndexer,
+  getFieldPolicyRegistries,
+  loadCatalogSlices,
+  withEmbedding,
+} from "./lib/catalog-runtime"
+import { withDbFromEnv } from "./lib/db"
+
+export { EXTERNAL_CRUISE_CATALOG_REFRESH_CRON } from "../scheduled-crons"
+
+export async function runScheduledExternalCruiseCatalogRefresh(
+  _event: ScheduledController,
+  env: CloudflareBindings,
+) {
+  return withDbFromEnv(env, async (rawDb) => {
+    const db = rawDb as unknown as PostgresJsDatabase
+    const embeddings = buildEmbeddingProvider(env)
+    const indexer = buildTypesenseIndexer(env, embeddings)
+
+    if (!indexer) {
+      return refreshExternalCruiseCatalog({ db })
+    }
+
+    const indexerService = createIndexerService({
+      adapter: indexer,
+      slices: await loadCatalogSlices(rawDb),
+      registries: getFieldPolicyRegistries(),
+    })
+    await indexerService.ensureCollections()
+
+    return refreshExternalCruiseCatalog({
+      db,
+      sourceAdapterRegistry: getBookingEngineRegistry(
+        env as unknown as Parameters<typeof getBookingEngineRegistry>[0],
+      ),
+      indexerService,
+      fieldPolicyRegistries: getFieldPolicyRegistries(),
+      wrapCatalogBuilder: (builder) => withEmbedding(builder, embeddings),
+      onCatalogProgress(event) {
+        console.info("[external-cruise-refresh] catalog page", event)
+      },
+    })
+  })
+}

--- a/templates/operator/src/entry.ts
+++ b/templates/operator/src/entry.ts
@@ -11,6 +11,7 @@ import {
   CHANNEL_PUSH_BOOKING_LINK_CRON,
   CHANNEL_PUSH_CONTENT_CRON,
   DRAFT_REAPER_CRON,
+  EXTERNAL_CRUISE_CATALOG_REFRESH_CRON,
   PROMOTION_BOUNDARY_SCHEDULER_CRON,
 } from "./scheduled-crons"
 
@@ -84,6 +85,16 @@ export default {
         import("./api/channel-push-scheduled").then((mod) =>
           mod.runScheduledChannelPushReconciler(event, env),
         ),
+      )
+      return
+    }
+    if (event.cron === EXTERNAL_CRUISE_CATALOG_REFRESH_CRON) {
+      ctx.waitUntil(
+        import("./api/external-cruise-refresh-scheduled")
+          .then((mod) => mod.runScheduledExternalCruiseCatalogRefresh(event, env))
+          .then((result) => {
+            console.info("[external-cruise-refresh] result", result)
+          }),
       )
       return
     }

--- a/templates/operator/src/scheduled-crons.ts
+++ b/templates/operator/src/scheduled-crons.ts
@@ -1,5 +1,6 @@
 export const CHANNEL_PUSH_BOOKING_LINK_CRON = "*/15 * * * *"
 export const CHANNEL_PUSH_AVAILABILITY_CRON = "0 * * * *"
 export const CHANNEL_PUSH_CONTENT_CRON = "0 3 * * *"
+export const EXTERNAL_CRUISE_CATALOG_REFRESH_CRON = "30 3 * * *"
 export const DRAFT_REAPER_CRON = "5 * * * *"
 export const PROMOTION_BOUNDARY_SCHEDULER_CRON = "*/5 * * * *"

--- a/templates/operator/wrangler.jsonc
+++ b/templates/operator/wrangler.jsonc
@@ -67,6 +67,10 @@
       "*/15 * * * *",
       "0 * * * *",
       "0 3 * * *",
+      // External cruise catalog refresh — runs after the generic nightly
+      // content push so adapter projections are visible in cruise browse
+      // and catalog search surfaces.
+      "30 3 * * *",
       // Draft reaper (per booking-journey-architecture.md §5.7) — drops
       // expired booking_drafts hourly at :05 to avoid colliding with the
       // hourly availability reconciler at :00.


### PR DESCRIPTION
## Summary

- add a provider-agnostic external cruise refresh service that reconciles `cruise_search_index` from registered cruise adapter projections
- extend catalog source sync with cruise-scoped refresh, stale sourced-entry withdrawal, and index deletion after successful discovery
- wire the operator template scheduled refresh and document manual, scheduled, and event/webhook refresh paths

Closes #1391

## Verification

- `pnpm --filter @voyantjs/catalog typecheck`
- `pnpm --filter @voyantjs/catalog lint`
- `pnpm --filter @voyantjs/catalog test -- sync`
- `pnpm --filter @voyantjs/cruises typecheck`
- `pnpm --filter @voyantjs/cruises lint`
- `pnpm --filter @voyantjs/cruises test -- service-search`
- `pnpm --filter operator typecheck`
- `pnpm --filter operator lint`
- pre-push `pnpm test` lane: 127 tasks successful