### PR TITLE
Rename CRM organization tax id field

### DIFF
--- a/.changeset/crm-organization-tax-id.md
+++ b/.changeset/crm-organization-tax-id.md
@@ -1,0 +1,9 @@
+---
+"@voyantjs/crm": minor
+"@voyantjs/crm-react": minor
+"@voyantjs/crm-ui": minor
+"@voyantjs/bookings-ui": patch
+"@voyantjs/flights-ui": patch
+---
+
+Rename CRM organization `vatNumber` to `taxId` and support exact organization lookup by tax id.

--- a/apps/dev/migrations/0043_organization_tax_id.sql
+++ b/apps/dev/migrations/0043_organization_tax_id.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "organizations" RENAME COLUMN "vat_number" TO "tax_id";
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_organizations_tax_id" ON "organizations" USING btree ("tax_id");

--- a/apps/dev/migrations/meta/_journal.json
+++ b/apps/dev/migrations/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1779905300000,
       "tag": "0042_billing_contact_party_type_tax_id",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1780141400000,
+      "tag": "0043_organization_tax_id",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/bookings-ui/src/components/booking-billing-dialog.tsx
+++ b/packages/bookings-ui/src/components/booking-billing-dialog.tsx
@@ -306,7 +306,7 @@ export function BookingBillingDialog({
     form.setValue("contactPartyType", "company", { shouldDirty: true })
     form.setValue("contactFirstName", organization.name, { shouldDirty: true })
     form.setValue("contactLastName", "", { shouldDirty: true })
-    form.setValue("contactTaxId", organization.vatNumber ?? "", { shouldDirty: true })
+    form.setValue("contactTaxId", organization.taxId ?? "", { shouldDirty: true })
     form.setValue("contactEmail", "", { shouldDirty: true, shouldValidate: true })
     form.setValue("contactPhone", "", { shouldDirty: true })
     setSelectedPersonId("")
@@ -435,9 +435,9 @@ export function BookingBillingDialog({
                                     <span className="truncate font-medium">
                                       {organization.name}
                                     </span>
-                                    {organization.vatNumber ? (
+                                    {organization.taxId ? (
                                       <span className="truncate text-xs text-muted-foreground">
-                                        {organization.vatNumber}
+                                        {organization.taxId}
                                       </span>
                                     ) : null}
                                   </div>

--- a/packages/bookings-ui/src/components/booking-create-sheet.tsx
+++ b/packages/bookings-ui/src/components/booking-create-sheet.tsx
@@ -965,7 +965,7 @@ export function BookingCreateForm({
         : billingOrganizationRecord
           ? {
               contactPartyType: "company",
-              contactTaxId: billingOrganizationRecord.vatNumber,
+              contactTaxId: billingOrganizationRecord.taxId,
               contactFirstName: billingOrganizationRecord.name,
               contactLastName: null,
               contactEmail: null,

--- a/packages/bookings-ui/src/components/booking-detail-page.tsx
+++ b/packages/bookings-ui/src/components/booking-detail-page.tsx
@@ -712,7 +712,7 @@ export function BookingBillingContextCard({
     ""
   const email = booking.contactEmail ?? person?.email ?? null
   const phone = booking.contactPhone ?? person?.phone ?? null
-  const taxId = booking.contactTaxId ?? organization?.vatNumber ?? null
+  const taxId = booking.contactTaxId ?? organization?.taxId ?? null
   const address = [
     booking.contactAddressLine1,
     booking.contactAddressLine2,

--- a/packages/bookings-ui/src/components/booking-list-filters.tsx
+++ b/packages/bookings-ui/src/components/booking-list-filters.tsx
@@ -383,7 +383,7 @@ export function BookingListFiltersPopover({
               selectedItem={selectedOrganization}
               getKey={(organization) => organization.id}
               getLabel={(organization) => organization.name}
-              getSecondary={(organization) => organization.vatNumber ?? undefined}
+              getSecondary={(organization) => organization.taxId ?? undefined}
               onSearchChange={setOrganizationSearch}
               placeholder={filterMessages.organization}
               emptyText={filterMessages.organizationEmpty}

--- a/packages/crm-react/src/hooks/use-organization-mutation.ts
+++ b/packages/crm-react/src/hooks/use-organization-mutation.ts
@@ -11,7 +11,7 @@ import { organizationSingleResponse } from "../schemas.js"
 export interface CreateOrganizationInput {
   name: string
   legalName?: string | null
-  vatNumber?: string | null
+  taxId?: string | null
   website?: string | null
   industry?: string | null
   relation?: string | null

--- a/packages/crm-react/src/hooks/use-organizations.ts
+++ b/packages/crm-react/src/hooks/use-organizations.ts
@@ -20,6 +20,7 @@ export function useOrganizations(options: UseOrganizationsOptions = {}) {
     queryFn: () => {
       const params = new URLSearchParams()
       if (filters.search) params.set("search", filters.search)
+      if (filters.taxId) params.set("taxId", filters.taxId)
       if (filters.ownerId) params.set("ownerId", filters.ownerId)
       if (filters.relation) params.set("relation", filters.relation)
       if (filters.status) params.set("status", filters.status)

--- a/packages/crm-react/src/query-keys.ts
+++ b/packages/crm-react/src/query-keys.ts
@@ -29,6 +29,7 @@ export type OrganizationsListSortDir = "asc" | "desc"
 
 export interface OrganizationsListFilters {
   search?: string | undefined
+  taxId?: string | undefined
   ownerId?: string | undefined
   relation?: string | undefined
   status?: string | undefined

--- a/packages/crm-react/src/query-options.ts
+++ b/packages/crm-react/src/query-options.ts
@@ -148,6 +148,7 @@ export function getOrganizationsQueryOptions(
     queryFn: () => {
       const params = new URLSearchParams()
       if (filters.search) params.set("search", filters.search)
+      if (filters.taxId) params.set("taxId", filters.taxId)
       if (filters.ownerId) params.set("ownerId", filters.ownerId)
       if (filters.relation) params.set("relation", filters.relation)
       if (filters.status) params.set("status", filters.status)

--- a/packages/crm-react/src/schemas.ts
+++ b/packages/crm-react/src/schemas.ts
@@ -74,7 +74,7 @@ export const organizationRecordSchema = z.object({
   name: z.string(),
   legalName: z.string().nullable(),
   website: z.string().nullable(),
-  vatNumber: z.string().nullable(),
+  taxId: z.string().nullable(),
   industry: z.string().nullable(),
   relation: z.string().nullable(),
   ownerId: z.string().nullable(),

--- a/packages/crm-ui/src/components/organization-card.tsx
+++ b/packages/crm-ui/src/components/organization-card.tsx
@@ -27,9 +27,9 @@ export function OrganizationCard({ organization, className, ...props }: Organiza
         </div>
         <div className="flex-1 min-w-0">
           <div className="font-semibold truncate">{organization.name}</div>
-          {organization.industry || organization.vatNumber ? (
+          {organization.industry || organization.taxId ? (
             <div className="text-sm text-muted-foreground truncate">
-              {[organization.industry, organization.vatNumber].filter(Boolean).join(" - ")}
+              {[organization.industry, organization.taxId].filter(Boolean).join(" - ")}
             </div>
           ) : null}
         </div>

--- a/packages/crm-ui/src/components/organization-combobox.tsx
+++ b/packages/crm-ui/src/components/organization-combobox.tsx
@@ -27,7 +27,7 @@ function compact(parts: Array<string | null | undefined>) {
 function formatOrganizationSecondary(organization: OrganizationRecord) {
   return compact([
     organization.legalName,
-    organization.vatNumber,
+    organization.taxId,
     organization.website,
     organization.industry,
     organization.defaultCurrency,

--- a/packages/crm-ui/src/components/organization-form.tsx
+++ b/packages/crm-ui/src/components/organization-form.tsx
@@ -33,7 +33,7 @@ export interface OrganizationFormProps {
 interface FormState {
   name: string
   legalName: string
-  vatNumber: string
+  taxId: string
   website: string
   industry: string
   billingEmail: string
@@ -51,7 +51,7 @@ function initialState(mode: Mode): FormState {
     return {
       name: org.name,
       legalName: org.legalName ?? "",
-      vatNumber: org.vatNumber ?? "",
+      taxId: org.taxId ?? "",
       website: org.website ?? "",
       industry: org.industry ?? "",
       billingEmail: "",
@@ -67,7 +67,7 @@ function initialState(mode: Mode): FormState {
   return {
     name: "",
     legalName: "",
-    vatNumber: "",
+    taxId: "",
     website: "",
     industry: "",
     billingEmail: "",
@@ -84,7 +84,7 @@ function toPayload(state: FormState): CreateOrganizationInput {
   return {
     name: state.name.trim(),
     legalName: state.legalName.trim() || null,
-    vatNumber: state.vatNumber.trim() || null,
+    taxId: state.taxId.trim() || null,
     website: state.website.trim() || null,
     industry: state.industry.trim() || null,
   }
@@ -279,14 +279,8 @@ export function OrganizationForm({ mode, onSuccess, onCancel }: OrganizationForm
           />
         </div>
         <div className="flex flex-col gap-1.5">
-          <Label htmlFor="organization-vat-number">
-            {messages.organizationForm.fields.vatNumber}
-          </Label>
-          <Input
-            id="organization-vat-number"
-            value={state.vatNumber}
-            onChange={field("vatNumber")}
-          />
+          <Label htmlFor="organization-tax-id">{messages.organizationForm.fields.taxId}</Label>
+          <Input id="organization-tax-id" value={state.taxId} onChange={field("taxId")} />
         </div>
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="organization-website">{messages.organizationForm.fields.website}</Label>

--- a/packages/crm-ui/src/components/organization-list.tsx
+++ b/packages/crm-ui/src/components/organization-list.tsx
@@ -337,8 +337,8 @@ export function OrganizationList({
                 >
                   <TableCell>
                     <div className="font-medium">{organization.name}</div>
-                    {organization.vatNumber ? (
-                      <div className="text-xs text-muted-foreground">{organization.vatNumber}</div>
+                    {organization.taxId ? (
+                      <div className="text-xs text-muted-foreground">{organization.taxId}</div>
                     ) : null}
                   </TableCell>
                   <TableCell>{organization.industry ?? messages.common.none}</TableCell>

--- a/packages/crm-ui/src/i18n/en.ts
+++ b/packages/crm-ui/src/i18n/en.ts
@@ -71,7 +71,7 @@ export const crmUiEn = {
     fields: {
       name: "Name",
       legalName: "Legal name",
-      vatNumber: "VAT number",
+      taxId: "Tax ID",
       website: "Website",
       industry: "Industry",
       billingEmail: "Billing email",

--- a/packages/crm-ui/src/i18n/messages.ts
+++ b/packages/crm-ui/src/i18n/messages.ts
@@ -54,7 +54,7 @@ export type CrmUiMessages = {
     fields: {
       name: string
       legalName: string
-      vatNumber: string
+      taxId: string
       website: string
       industry: string
       billingEmail: string

--- a/packages/crm-ui/src/i18n/ro.ts
+++ b/packages/crm-ui/src/i18n/ro.ts
@@ -71,7 +71,7 @@ export const crmUiRo = {
     fields: {
       name: "Nume",
       legalName: "Nume legal",
-      vatNumber: "Cod TVA",
+      taxId: "Cod fiscal",
       website: "Website",
       industry: "Industrie",
       billingEmail: "Email facturare",

--- a/packages/crm/src/schema-accounts.ts
+++ b/packages/crm/src/schema-accounts.ts
@@ -66,7 +66,7 @@ export const organizations = pgTable(
     legalName: text("legal_name"),
     website: text("website"),
     /** Tax / VAT identification number — used for billing + e-invoicing. */
-    vatNumber: text("vat_number"),
+    taxId: text("tax_id"),
     industry: text("industry"),
     relation: relationTypeEnum("relation"),
     ownerId: text("owner_id"),
@@ -86,6 +86,7 @@ export const organizations = pgTable(
     index("idx_organizations_name").on(table.name),
     index("idx_organizations_owner").on(table.ownerId),
     index("idx_organizations_status").on(table.status),
+    index("idx_organizations_tax_id").on(table.taxId),
     index("idx_organizations_owner_updated").on(table.ownerId, table.updatedAt),
     index("idx_organizations_relation_updated").on(table.relation, table.updatedAt),
     index("idx_organizations_status_updated").on(table.status, table.updatedAt),

--- a/packages/crm/src/service/accounts-organizations.ts
+++ b/packages/crm/src/service/accounts-organizations.ts
@@ -16,7 +16,10 @@ export const organizationAccountsService = {
     if (query.ownerId) conditions.push(eq(organizations.ownerId, query.ownerId))
     if (query.relation) conditions.push(eq(organizations.relation, query.relation))
     if (query.status) conditions.push(eq(organizations.status, query.status))
-    if (query.search) {
+    if (query.taxId) conditions.push(eq(organizations.taxId, query.taxId))
+    // Exact tax-id lookup is used for de-duplication; do not let a stale or
+    // fuzzy name search hide the matching organization.
+    if (query.search && !query.taxId) {
       const term = `%${query.search}%`
       conditions.push(
         or(

--- a/packages/crm/src/validation.ts
+++ b/packages/crm/src/validation.ts
@@ -58,6 +58,12 @@ export const customFieldTypeSchema = z.enum([
   "phone",
 ])
 
+const nullableTrimmedStringSchema = z
+  .string()
+  .nullable()
+  .optional()
+  .transform((value) => (typeof value === "string" ? value.trim() || null : value))
+
 export const organizationCoreSchema = z.object({
   name: z.string().min(1),
   legalName: z.string().nullable().optional(),
@@ -68,7 +74,7 @@ export const organizationCoreSchema = z.object({
     .optional()
     .or(z.literal(""))
     .transform((v) => v || null),
-  vatNumber: z.string().nullable().optional(),
+  taxId: nullableTrimmedStringSchema,
   industry: z.string().nullable().optional(),
   relation: relationTypeSchema.nullable().optional(),
   ownerId: z.string().nullable().optional(),
@@ -96,14 +102,21 @@ export const organizationListSortFieldSchema = z.enum([
 
 export const organizationListSortDirSchema = z.enum(["asc", "desc"])
 
-export const organizationListQuerySchema = paginationSchema.extend({
-  ownerId: z.string().optional(),
-  relation: relationTypeSchema.optional(),
-  status: recordStatusSchema.optional(),
-  search: z.string().optional(),
-  sortBy: organizationListSortFieldSchema.default("updatedAt"),
-  sortDir: organizationListSortDirSchema.default("desc"),
-})
+export const organizationListQuerySchema = paginationSchema
+  .extend({
+    ownerId: z.string().optional(),
+    relation: relationTypeSchema.optional(),
+    status: recordStatusSchema.optional(),
+    search: z.string().optional(),
+    taxId: z.string().optional(),
+    tax_id: z.string().optional(),
+    sortBy: organizationListSortFieldSchema.default("updatedAt"),
+    sortDir: organizationListSortDirSchema.default("desc"),
+  })
+  .transform(({ tax_id: taxIdSnake, ...query }) => ({
+    ...query,
+    taxId: query.taxId?.trim() || taxIdSnake?.trim() || undefined,
+  }))
 
 export const personCoreSchema = z.object({
   organizationId: z.string().nullable().optional(),

--- a/packages/crm/tests/integration/accounts.test.ts
+++ b/packages/crm/tests/integration/accounts.test.ts
@@ -81,6 +81,42 @@ describe.skipIf(!DB_AVAILABLE)("Account routes", () => {
       expect(body.total).toBe(2)
     })
 
+    it("finds organizations by exact tax id even when names do not match", async () => {
+      await app.request("/organizations", {
+        method: "POST",
+        ...json({
+          name: "Existing Travel Company",
+          legalName: "Existing Travel SRL",
+          taxId: "RO44255073",
+        }),
+      })
+      await app.request("/organizations", {
+        method: "POST",
+        ...json({ name: "Different Company", legalName: "Different SRL", taxId: "RO00000000" }),
+      })
+
+      const res = await app.request("/organizations?search=Missing&taxId=%20RO44255073%20", {
+        method: "GET",
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data).toHaveLength(1)
+      expect(body.data[0]).toMatchObject({
+        name: "Existing Travel Company",
+        taxId: "RO44255073",
+      })
+
+      const byTaxId = await app.request("/organizations?tax_id=RO44255073", { method: "GET" })
+      expect(byTaxId.status).toBe(200)
+      const byTaxIdBody = await byTaxId.json()
+      expect(byTaxIdBody.data).toHaveLength(1)
+      expect(byTaxIdBody.data[0]).toMatchObject({
+        name: "Existing Travel Company",
+        taxId: "RO44255073",
+      })
+    })
+
     it("gets an organization by id", async () => {
       const createRes = await app.request("/organizations", {
         method: "POST",

--- a/packages/crm/tests/unit/validation-accounts.test.ts
+++ b/packages/crm/tests/unit/validation-accounts.test.ts
@@ -33,6 +33,16 @@ describe("Organization schemas", () => {
     expect(result.website).toBe("https://acme.com")
   })
 
+  it("accepts taxId", () => {
+    const result = insertOrganizationSchema.parse({ name: "Acme", taxId: " RO44255073 " })
+    expect(result.taxId).toBe("RO44255073")
+  })
+
+  it("normalizes empty taxId to null", () => {
+    const result = insertOrganizationSchema.parse({ name: "Acme", taxId: "" })
+    expect(result.taxId).toBeNull()
+  })
+
   it("rejects invalid website URL", () => {
     expect(() => insertOrganizationSchema.parse({ name: "Acme", website: "not-a-url" })).toThrow()
   })

--- a/packages/crm/tests/unit/validation-queries.test.ts
+++ b/packages/crm/tests/unit/validation-queries.test.ts
@@ -156,6 +156,16 @@ describe("Organization list query", () => {
     expect(result.search).toBe("acme")
   })
 
+  it("accepts and trims taxId filter", () => {
+    const result = organizationListQuerySchema.parse({ taxId: " RO44255073 " })
+    expect(result.taxId).toBe("RO44255073")
+  })
+
+  it("accepts snake_case tax_id filter", () => {
+    const result = organizationListQuerySchema.parse({ tax_id: "44255073" })
+    expect(result.taxId).toBe("44255073")
+  })
+
   it("accepts ownerId filter", () => {
     const result = organizationListQuerySchema.parse({ ownerId: "user_123" })
     expect(result.ownerId).toBe("user_123")

--- a/packages/flights-ui/src/components/billing-pickers.tsx
+++ b/packages/flights-ui/src/components/billing-pickers.tsx
@@ -157,7 +157,7 @@ export function BillingOrgPicker({ apply }: BillingOrgPickerProps) {
                     apply({
                       mode: "company",
                       companyName: org.name,
-                      ...(org.vatNumber ? { vatNumber: org.vatNumber } : {}),
+                      ...(org.taxId ? { vatNumber: org.taxId } : {}),
                       email: contactPoints.email ?? "",
                       ...(contactPoints.phone ? { phone: contactPoints.phone } : {}),
                       line1: address?.line1 ?? "",

--- a/templates/dmc/migrations/0025_organization_tax_id.sql
+++ b/templates/dmc/migrations/0025_organization_tax_id.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "organizations" RENAME COLUMN "vat_number" TO "tax_id";
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_organizations_tax_id" ON "organizations" USING btree ("tax_id");

--- a/templates/dmc/migrations/meta/_journal.json
+++ b/templates/dmc/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1779905300000,
       "tag": "0024_billing_contact_party_type_tax_id",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1780141300000,
+      "tag": "0025_organization_tax_id",
+      "breakpoints": true
     }
   ]
 }

--- a/templates/operator/migrations/0046_organization_tax_id.sql
+++ b/templates/operator/migrations/0046_organization_tax_id.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "organizations" RENAME COLUMN "vat_number" TO "tax_id";
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_organizations_tax_id" ON "organizations" USING btree ("tax_id");

--- a/templates/operator/migrations/meta/_journal.json
+++ b/templates/operator/migrations/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1779905300000,
       "tag": "0044_billing_contact_party_type_tax_id",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1780141300000,
+      "tag": "0046_organization_tax_id",
+      "breakpoints": true
     }
   ]
 }

--- a/templates/operator/src/api/smartbill.ts
+++ b/templates/operator/src/api/smartbill.ts
@@ -504,7 +504,7 @@ async function resolveSmartbillClient(
 
   return {
     name: clientName,
-    vatCode: nonEmpty(booking.contactTaxId) ?? organizationRow?.vatNumber ?? undefined,
+    vatCode: nonEmpty(booking.contactTaxId) ?? organizationRow?.taxId ?? undefined,
     address: nonEmpty(primaryAddress?.fullText) ?? addressLine ?? bookingAddressLine ?? "-",
     city: nonEmpty(primaryAddress?.city) ?? nonEmpty(booking.contactCity) ?? "-",
     county: nonEmpty(primaryAddress?.region) ?? nonEmpty(booking.contactRegion),


### PR DESCRIPTION
## Summary
- Rename CRM organization `vatNumber` / `vat_number` to `taxId` / `tax_id`, including dev, operator, and DMC migrations.
- Add exact CRM organization lookup by `taxId` and `tax_id`, trimming query values and allowing tax id lookup to work even when a stale search term is present.
- Update CRM React/UI types, forms, labels, bookings, flights billing mapping, and SmartBill downstream consumers.

Fixes #1369

## Verification
- `pnpm --filter @voyantjs/crm exec vitest run tests/unit/validation-accounts.test.ts tests/unit/validation-queries.test.ts`
- `pnpm --filter @voyantjs/crm test`
- `pnpm --filter @voyantjs/crm typecheck`
- `pnpm --filter @voyantjs/crm-react typecheck`
- `pnpm --filter @voyantjs/crm-ui typecheck`
- `pnpm --filter @voyantjs/bookings-ui typecheck && pnpm --filter @voyantjs/flights-ui typecheck`
- `pnpm --filter operator typecheck`
- `pnpm --filter @voyantjs/crm lint`
- `pnpm --filter @voyantjs/crm-react lint`
- `pnpm --filter @voyantjs/crm-ui lint`
- `pnpm --filter @voyantjs/bookings-ui lint && pnpm --filter @voyantjs/flights-ui lint`
- `pnpm verify:architecture`
- `git diff --check`
- `pnpm test` (pre-push hook)

Note: `pnpm verify:fast` reaches an existing UI barrel export check failure for `packages/ui/src/components/*` exports unrelated to this change. A direct `pnpm --filter dev typecheck` hit Node heap exhaustion locally, but the commit hook workspace typecheck completed successfully.