### PR TITLE
Add promotion fare scopes and eligibility flags

### DIFF
--- a/.changeset/promotions-fare-cabin-eligibility.md
+++ b/.changeset/promotions-fare-cabin-eligibility.md
@@ -1,0 +1,9 @@
+---
+"@voyantjs/promotions": minor
+"@voyantjs/promotions-react": minor
+"@voyantjs/promotions-ui": minor
+"@voyantjs/catalog": minor
+"@voyantjs/storefront": minor
+---
+
+Extend promotion scopes with fare-code and cabin-grade targeting, and add structured eligibility flags for past-guest, solo-traveler, child-traveler, and family offers.

--- a/docs/architecture/promotions-architecture.md
+++ b/docs/architecture/promotions-architecture.md
@@ -86,6 +86,8 @@ type PromotionalOfferScope =
   | { kind: "destinations"; destinationIds: string[] }
   | { kind: "markets"; marketIds: string[] }
   | { kind: "audiences"; audiences: Array<"staff" | "customer" | "partner" | "supplier"> }
+  | { kind: "fare_codes"; fareCodes: string[] }
+  | { kind: "cabin_grades"; cabinGradeCodes: string[] }
 ```
 
 **No `channels` scope kind in v1.** The natural fit (`channelScope`) lives on `market_product_rules` (`packages/markets/src/schema.ts:224`), not on `markets`, so a channel-scoped offer would need a per-(product, market) rule lookup. Worse, `IndexerSlice` (`packages/catalog/src/indexer/contract.ts:21`) has no channel dimension — `{ vertical, locale, audience, market }` only. Modeling channels properly means either a per-product rule join on the projection hot path or extending `IndexerSlice` to carry channel — both are larger work than promotions should drag in. Operators who need channel-wide promos in v1 model them via `audiences` (e.g., `partner` ≈ b2b) and / or per-market scoping. Tracked as a deferred follow-up in §14.
@@ -95,7 +97,7 @@ Two reasons for the JSONB shape over multiple link tables:
 1. **The evaluator's matching predicate is the same for every scope kind** (a `(productId, slice, scope)` tuple). One function with a `switch (scope.kind)` is clearer than five JOINs.
 2. **Adding a new scope kind doesn't migrate existing rows.** The discriminator is a new union variant; old offers stay valid.
 
-For the product-shaped scopes (`products`, `categories`, `destinations`), we additionally maintain a denormalized link table `promotional_offer_products` (offer_id, product_id) populated when an offer is created/edited. The denormalized table is what the catalog projection joins against — the JSON `scope` is the source of truth for editing, the link table is the index for matching. Categories and destinations are expanded to product IDs at write time, so taxonomy / destination membership changes don't silently change which products an offer applies to. Slice-shaped scopes (`global`, `markets`, `audiences`) leave the link table empty and are matched at evaluation time against `slice.market` / `slice.audience`.
+For the product-shaped scopes (`products`, `categories`, `destinations`), we additionally maintain a denormalized link table `promotional_offer_products` (offer_id, product_id) populated when an offer is created/edited. The denormalized table is what the catalog projection joins against — the JSON `scope` is the source of truth for editing, the link table is the index for matching. Categories and destinations are expanded to product IDs at write time, so taxonomy / destination membership changes don't silently change which products an offer applies to. Slice-shaped scopes (`global`, `markets`, `audiences`) leave the link table empty and are matched at evaluation time against `slice.market` / `slice.audience`. Fare-code and cabin-grade scopes also leave the link table empty; they are checkout-line dimensions supplied by vertical booking flows, not product-index dimensions.
 
 ### 3.3. Stacking is single-pick by default, with `stackable: true` as the explicit override
 
@@ -228,7 +230,7 @@ CREATE INDEX idx_pop_product ON promotional_offer_products (product_id);
 
 Populated by service-layer code on offer create/update for `scope.kind ∈ {products, categories, destinations}`. For `categories` and `destinations`, the service expands the scope IDs to the current product set at write time. Recomputation triggered by category- or destination-membership mutations is **out of scope for v1**; operators who add a product to a category / destination and want it picked up by an existing offer either re-save the offer or wait for the next offer edit. Tracked as a follow-up.
 
-Scopes that are not product-shaped (`global`, `markets`, `audiences`, `channels`) leave this table empty for that offer — they are matched at evaluation time against `slice.market` / `slice.audience` / market-channel lookup, not via the link table.
+Scopes that are not product-shaped (`global`, `markets`, `audiences`, `fare_codes`, `cabin_grades`) leave this table empty for that offer — they are matched at evaluation time against slice or booking-line context, not via the link table.
 
 ### 4.3. `promotional_offer_redemptions`
 
@@ -687,7 +689,7 @@ The validation schema enforces:
 
 Recorded here as the rationale trail. The two larger architectural threads have their full discussion in §15; the headline decisions appear as items 17 + 18 below.
 
-1. **Conditions schema** — typed JSONB validated by Zod, starting with `{ minPax?: number }` only. Date validity stays on the offer header (`valid_from` / `valid_until`); no `validDateRanges` duplication in `conditions` for v1.
+1. **Conditions schema** — typed JSONB validated by Zod, starting with `{ minPax?: number }` plus structured eligibility flags (`pastGuestOnly`, `soloTravelerOnly`, `childTravelerOnly`, `familyOnly`). Date validity stays on the offer header (`valid_from` / `valid_until`); no `validDateRanges` duplication in `conditions`.
 2. **Conditional-offer projection field shape** — single `conditionalOffer*` set on the catalog document, matching the `bestOffer*` budget. Richer merchandising goes through a future offer-detail endpoint, not by bloating every search document.
 3. **Materializing destination scope** — `products`, `categories`, *and* `destinations` all populate `promotional_offer_products` at write time. The projection path never has to traverse taxonomy / destination joins.
 4. **Code case-sensitivity** — store + compare lowercased for matching and uniqueness; preserve the customer's typed case in `promotional_offer_redemptions.code_used` for audit / debugging.

--- a/packages/catalog/src/booking-engine/promotions-contract.ts
+++ b/packages/catalog/src/booking-engine/promotions-contract.ts
@@ -21,7 +21,7 @@ export type CodeStatus =
   | { kind: "code_not_found" }
   | { kind: "code_expired" }
   | { kind: "code_not_yet_valid" }
-  | { kind: "code_not_applicable"; reason: "scope" | "min_pax" | "currency" }
+  | { kind: "code_not_applicable"; reason: "scope" | "min_pax" | "eligibility" | "currency" }
 
 /**
  * One offer that applied to the quote. Carried on `PricingBasis.appliedOffers`
@@ -51,6 +51,16 @@ export interface PromotionEvaluationInput {
   slice: {
     audience: "staff" | "customer" | "partner" | "supplier"
     market: string
+  }
+  /** Optional booking-line fare code, used by fare-scoped offers. */
+  fareCode?: string | null
+  /** Optional booking-line cabin grade code, used by cabin-grade-scoped offers. */
+  cabinGradeCode?: string | null
+  eligibility?: {
+    pastGuest?: boolean
+    soloTraveler?: boolean
+    hasChildTraveler?: boolean
+    family?: boolean
   }
   pax?: number
   date?: Date

--- a/packages/promotions-react/src/index.ts
+++ b/packages/promotions-react/src/index.ts
@@ -9,9 +9,11 @@ import {
 } from "@tanstack/react-query"
 import {
   type PromotionalOfferApplicationMode,
+  type PromotionalOfferConditions,
   type PromotionalOfferListStatus,
   type PromotionalOfferScope,
   type PromotionalOfferScopeKind,
+  promotionalOfferConditionsSchema,
   promotionalOfferScopeSchema,
 } from "@voyantjs/promotions/validation"
 import {
@@ -39,9 +41,11 @@ export {
 
 export {
   type PromotionalOfferApplicationMode,
+  type PromotionalOfferConditions,
   type PromotionalOfferListStatus,
   type PromotionalOfferScope,
   type PromotionalOfferScopeKind,
+  promotionalOfferConditionsSchema,
   promotionalOfferScopeSchema,
 } from "@voyantjs/promotions/validation"
 
@@ -55,7 +59,7 @@ const promotionalOfferRecordSchema = z.object({
   discountAmountCents: z.number().nullable(),
   currency: z.string().nullable(),
   scope: promotionalOfferScopeSchema,
-  conditions: z.object({ minPax: z.number().int().positive().optional() }).catchall(z.unknown()),
+  conditions: promotionalOfferConditionsSchema,
   validFrom: z.string().nullable(),
   validUntil: z.string().nullable(),
   code: z.string().nullable(),
@@ -240,7 +244,7 @@ export interface PromotionInsertInput {
   discountAmountCents?: number | null
   currency?: string | null
   scope: PromotionalOfferScope
-  conditions?: { minPax?: number }
+  conditions?: PromotionalOfferConditions
   validFrom?: string | null
   validUntil?: string | null
   code?: string | null

--- a/packages/promotions-ui/src/i18n/en.ts
+++ b/packages/promotions-ui/src/i18n/en.ts
@@ -28,6 +28,8 @@ export const promotionsUiEn: PromotionsUiMessages = {
       destinations: "Destinations",
       markets: "Markets",
       audiences: "Audiences",
+      fare_codes: "Fare codes",
+      cabin_grades: "Cabin grades",
     },
     audienceLabels: {
       staff: "Staff",
@@ -81,6 +83,8 @@ export const promotionsUiEn: PromotionsUiMessages = {
       destinationsScope: "{count} {noun}",
       marketsScope: "Markets: {markets}",
       audiencesScope: "Audiences: {audiences}",
+      fareCodesScope: "Fare codes: {fareCodes}",
+      cabinGradesScope: "Cabin grades: {cabinGradeCodes}",
       productNouns: { singular: "product", plural: "products" },
       categoryNouns: { singular: "category", plural: "categories" },
       destinationNouns: { singular: "destination", plural: "destinations" },
@@ -130,6 +134,8 @@ export const promotionsUiEn: PromotionsUiMessages = {
       categoryIds: "Add category references",
       destinationIds: "Add destination references",
       marketIds: "Add market references",
+      fareCodes: "Add fare codes",
+      cabinGradeCodes: "Add cabin grade codes",
     },
     hints: {
       globalScope: "Applies to every product.",

--- a/packages/promotions-ui/src/i18n/messages.ts
+++ b/packages/promotions-ui/src/i18n/messages.ts
@@ -62,6 +62,8 @@ export type PromotionsUiMessages = {
       destinationsScope: string
       marketsScope: string
       audiencesScope: string
+      fareCodesScope: string
+      cabinGradesScope: string
       productNouns: {
         singular: string
         plural: string
@@ -119,6 +121,8 @@ export type PromotionsUiMessages = {
       categoryIds: string
       destinationIds: string
       marketIds: string
+      fareCodes: string
+      cabinGradeCodes: string
     }
     hints: {
       globalScope: string

--- a/packages/promotions-ui/src/i18n/ro.ts
+++ b/packages/promotions-ui/src/i18n/ro.ts
@@ -28,6 +28,8 @@ export const promotionsUiRo: PromotionsUiMessages = {
       destinations: "Destinatii",
       markets: "Piete",
       audiences: "Audiente",
+      fare_codes: "Coduri tarifare",
+      cabin_grades: "Grade cabine",
     },
     audienceLabels: {
       staff: "Echipa",
@@ -81,6 +83,8 @@ export const promotionsUiRo: PromotionsUiMessages = {
       destinationsScope: "{count} {noun}",
       marketsScope: "Piete: {markets}",
       audiencesScope: "Audiente: {audiences}",
+      fareCodesScope: "Coduri tarifare: {fareCodes}",
+      cabinGradesScope: "Grade cabine: {cabinGradeCodes}",
       productNouns: { singular: "produs", plural: "produse" },
       categoryNouns: { singular: "categorie", plural: "categorii" },
       destinationNouns: { singular: "destinatie", plural: "destinatii" },
@@ -130,6 +134,8 @@ export const promotionsUiRo: PromotionsUiMessages = {
       categoryIds: "Adauga referinte de categorii",
       destinationIds: "Adauga referinte de destinatii",
       marketIds: "Adauga referinte de piete",
+      fareCodes: "Adauga coduri tarifare",
+      cabinGradeCodes: "Adauga coduri de grade cabine",
     },
     hints: {
       globalScope: "Se aplica tuturor produselor.",

--- a/packages/promotions-ui/src/promotion-dialog.tsx
+++ b/packages/promotions-ui/src/promotion-dialog.tsx
@@ -62,6 +62,8 @@ const SCOPE_KINDS: ScopeKind[] = [
   "destinations",
   "markets",
   "audiences",
+  "fare_codes",
+  "cabin_grades",
 ]
 
 const AUDIENCE_OPTIONS: Array<"staff" | "customer" | "partner" | "supplier"> = [
@@ -80,7 +82,7 @@ interface FormState {
   discountAmountCents: number | null
   currency: string
   scopeKind: ScopeKind
-  scopeIds: string // comma-separated for products/categories/destinations/markets
+  scopeIds: string // comma-separated for ID/code scopes
   scopeAudiences: Array<"staff" | "customer" | "partner" | "supplier">
   minPax: string
   validFrom: string
@@ -142,6 +144,10 @@ function scopeIdsToString(scope: PromotionalOfferScope): string {
       return scope.destinationIds.join(", ")
     case "markets":
       return scope.marketIds.join(", ")
+    case "fare_codes":
+      return scope.fareCodes.join(", ")
+    case "cabin_grades":
+      return scope.cabinGradeCodes.join(", ")
     default:
       return ""
   }
@@ -166,6 +172,10 @@ function buildScope(state: FormState): PromotionalOfferScope {
       return { kind: "markets", marketIds: parseIds(state.scopeIds) }
     case "audiences":
       return { kind: "audiences", audiences: state.scopeAudiences }
+    case "fare_codes":
+      return { kind: "fare_codes", fareCodes: parseIds(state.scopeIds) }
+    case "cabin_grades":
+      return { kind: "cabin_grades", cabinGradeCodes: parseIds(state.scopeIds) }
   }
 }
 
@@ -397,7 +407,9 @@ export function PromotionDialog({ open, onOpenChange, offer }: PromotionDialogPr
             {(state.scopeKind === "products" ||
               state.scopeKind === "categories" ||
               state.scopeKind === "destinations" ||
-              state.scopeKind === "markets") && (
+              state.scopeKind === "markets" ||
+              state.scopeKind === "fare_codes" ||
+              state.scopeKind === "cabin_grades") && (
               <div className="grid gap-1.5">
                 <Label htmlFor="promotion-scope-ids">
                   {formatMessage(dialogMessages.fields.scopeIds, {
@@ -523,14 +535,14 @@ export function PromotionDialog({ open, onOpenChange, offer }: PromotionDialogPr
 }
 
 function scopeIdsLabel(
-  kind: "products" | "categories" | "destinations" | "markets",
+  kind: "products" | "categories" | "destinations" | "markets" | "fare_codes" | "cabin_grades",
   labels: Record<PromotionalOfferScopeKind, string>,
 ): string {
   return labels[kind]
 }
 
 function scopeIdsPlaceholder(
-  kind: "products" | "categories" | "destinations" | "markets",
+  kind: "products" | "categories" | "destinations" | "markets" | "fare_codes" | "cabin_grades",
   placeholders: PromotionsUiMessages["promotionDialog"]["placeholders"],
 ): string {
   switch (kind) {
@@ -542,5 +554,9 @@ function scopeIdsPlaceholder(
       return placeholders.destinationIds
     case "markets":
       return placeholders.marketIds
+    case "fare_codes":
+      return placeholders.fareCodes
+    case "cabin_grades":
+      return placeholders.cabinGradeCodes
   }
 }

--- a/packages/promotions-ui/src/promotions-page.tsx
+++ b/packages/promotions-ui/src/promotions-page.tsx
@@ -63,6 +63,8 @@ const scopeKinds: PromotionalOfferScopeKind[] = [
   "destinations",
   "markets",
   "audiences",
+  "fare_codes",
+  "cabin_grades",
 ]
 
 const applicationModes: PromotionalOfferApplicationMode[] = ["auto", "code"]
@@ -569,6 +571,14 @@ function summarizeScope(scope: PromotionalOfferScope, messages: PromotionsUiMess
         audiences: scope.audiences
           .map((audience) => messages.common.audienceLabels[audience])
           .join(", "),
+      })
+    case "fare_codes":
+      return formatMessage(summary.fareCodesScope, {
+        fareCodes: scope.fareCodes.join(", "),
+      })
+    case "cabin_grades":
+      return formatMessage(summary.cabinGradesScope, {
+        cabinGradeCodes: scope.cabinGradeCodes.join(", "),
       })
   }
 }

--- a/packages/promotions/src/service-catalog-plane-promotions.ts
+++ b/packages/promotions/src/service-catalog-plane-promotions.ts
@@ -109,7 +109,8 @@ export function createProductPromotionsProjectionExtension(
         // these. minPax-conditioned offers land in `result.conditional`.
       })
 
-      const conditional = evaluation.conditional[0] ?? null
+      const conditional =
+        evaluation.conditional.find((offer) => offer.unmet.kind === "min_pax") ?? null
       // Surface `originalPriceFromAmountCents` ONLY when an offer applies —
       // §3.7 keeps the doc lean by leaving it null otherwise.
       const original = evaluation.best != null ? amountCents : null

--- a/packages/promotions/src/service-evaluator.ts
+++ b/packages/promotions/src/service-evaluator.ts
@@ -31,6 +31,16 @@ export interface OfferEvaluationContext {
     audience: "staff" | "customer" | "partner" | "supplier"
     market: string
   }
+  /** Optional booking-line fare code, used by fare-scoped offers. */
+  fareCode?: string | null
+  /** Optional cabin grade code, used by cruise cabin-grade-scoped offers. */
+  cabinGradeCode?: string | null
+  eligibility?: {
+    pastGuest?: boolean
+    soloTraveler?: boolean
+    hasChildTraveler?: boolean
+    family?: boolean
+  }
   /** Total travelers. Absent at catalog-index time; supplied at checkout. */
   pax?: number
   /** Defaults to `now()` when undefined. */
@@ -70,7 +80,12 @@ export interface ConditionalOffer {
   discountKind: "percentage" | "fixed_amount"
   discountPercent: number | null
   discountAmountCents: number | null
-  unmet: { kind: "min_pax"; required: number }
+  unmet:
+    | { kind: "min_pax"; required: number }
+    | { kind: "past_guest" }
+    | { kind: "solo_traveler" }
+    | { kind: "child_traveler" }
+    | { kind: "family" }
 }
 
 /** Outcome of code validation when `ctx.code` is supplied. `null` when ctx.code was not set. */
@@ -80,7 +95,7 @@ export type CodeStatus =
   | { kind: "code_not_found" }
   | { kind: "code_expired" }
   | { kind: "code_not_yet_valid" }
-  | { kind: "code_not_applicable"; reason: "scope" | "min_pax" | "currency" }
+  | { kind: "code_not_applicable"; reason: "scope" | "min_pax" | "eligibility" | "currency" }
 
 export interface EvaluationResult {
   /** All applied offers (1+ when stacking; 0 when no offer applies). May include a code-gated offer alongside auto offers. */
@@ -209,13 +224,17 @@ function matchesScope(
       return scope.marketIds.includes(ctx.slice.market)
     case "audiences":
       return scope.audiences.includes(ctx.slice.audience)
+    case "fare_codes":
+      return ctx.fareCode != null && scope.fareCodes.includes(ctx.fareCode)
+    case "cabin_grades":
+      return ctx.cabinGradeCode != null && scope.cabinGradeCodes.includes(ctx.cabinGradeCode)
   }
 }
 
 type ConditionsResult =
   | { kind: "ok" }
-  | { kind: "conditional"; unmet: { kind: "min_pax"; required: number } }
-  | { kind: "excluded"; reason: "min_pax" }
+  | { kind: "conditional"; unmet: ConditionalOffer["unmet"] }
+  | { kind: "excluded"; reason: "min_pax" | "eligibility" }
 
 function evaluateConditions(
   conditions: PromotionalOfferConditions,
@@ -229,7 +248,36 @@ function evaluateConditions(
       return { kind: "excluded", reason: "min_pax" }
     }
   }
+  if (conditions.pastGuestOnly === true) {
+    const result = evaluateEligibilityFlag(ctx.eligibility?.pastGuest, { kind: "past_guest" })
+    if (result.kind !== "ok") return result
+  }
+  if (conditions.soloTravelerOnly === true) {
+    const soloTraveler =
+      ctx.eligibility?.soloTraveler ?? (ctx.pax != null ? ctx.pax === 1 : undefined)
+    const result = evaluateEligibilityFlag(soloTraveler, { kind: "solo_traveler" })
+    if (result.kind !== "ok") return result
+  }
+  if (conditions.childTravelerOnly === true) {
+    const result = evaluateEligibilityFlag(ctx.eligibility?.hasChildTraveler, {
+      kind: "child_traveler",
+    })
+    if (result.kind !== "ok") return result
+  }
+  if (conditions.familyOnly === true) {
+    const result = evaluateEligibilityFlag(ctx.eligibility?.family, { kind: "family" })
+    if (result.kind !== "ok") return result
+  }
   return { kind: "ok" }
+}
+
+function evaluateEligibilityFlag(
+  value: boolean | undefined,
+  unmet: ConditionalOffer["unmet"],
+): ConditionsResult {
+  if (value === true) return { kind: "ok" }
+  if (value === false) return { kind: "excluded", reason: "eligibility" }
+  return { kind: "conditional", unmet }
 }
 
 function currencyMatches(offer: PromotionalOffer, ctx: OfferEvaluationContext): boolean {
@@ -355,7 +403,7 @@ export async function evaluateOffersForProduct(
   // Steps 3 + 4 + 5: scope / conditions / currency filter, partition.
   const applied: PromotionalOffer[] = []
   const conditional: ConditionalOffer[] = []
-  let codeOfferRejection: { kind: "scope" | "min_pax" | "currency" } | null = null
+  let codeOfferRejection: { kind: "scope" | "min_pax" | "eligibility" | "currency" } | null = null
 
   for (const offer of allCandidates) {
     if (!matchesScope(offer.scope, ctx, productMatchSet.has(offer.id))) {

--- a/packages/promotions/src/service-evaluator.ts
+++ b/packages/promotions/src/service-evaluator.ts
@@ -422,7 +422,7 @@ export async function evaluateOffersForProduct(
       continue
     }
     if (cond.kind === "excluded") {
-      if (offer === codeOffer) codeOfferRejection = { kind: "min_pax" }
+      if (offer === codeOffer) codeOfferRejection = { kind: cond.reason }
       continue
     }
 

--- a/packages/promotions/src/service-storefront.ts
+++ b/packages/promotions/src/service-storefront.ts
@@ -166,6 +166,10 @@ function matchesProduct(scope: PromotionalOfferScope, inLinkTable: boolean): boo
     // honored by the catalog projection (PR3) when products are indexed.
     case "markets":
     case "audiences":
+    // Fare/cabin-grade scopes need booking-line context and are evaluated
+    // by the checkout path rather than this product-listing endpoint.
+    case "fare_codes":
+    case "cabin_grades":
       return false
   }
 }

--- a/packages/promotions/src/service.ts
+++ b/packages/promotions/src/service.ts
@@ -82,7 +82,8 @@ function shouldEmitForUpdate(patch: Partial<UpdatePromotionalOffer>): boolean {
  * `recomputeOfferLinks` and by the event emitter to populate
  * `affected.productIds`.
  *
- * Returns `null` for slice-shaped scopes (`global`, `markets`, `audiences`)
+ * Returns `null` for slice-shaped or checkout-shaped scopes (`global`,
+ * `markets`, `audiences`, `fare_codes`, `cabin_grades`)
  * to signal that the link table should be empty AND that the event payload
  * should fall back to `affected: { kind: "all" }` — these scopes can match
  * an unbounded product set and we don't enumerate them at write time
@@ -114,6 +115,8 @@ export async function resolveScopeProductIds(
     case "global":
     case "markets":
     case "audiences":
+    case "fare_codes":
+    case "cabin_grades":
       return null
   }
 }

--- a/packages/promotions/src/validation.ts
+++ b/packages/promotions/src/validation.ts
@@ -41,6 +41,14 @@ export const promotionalOfferScopeSchema = z.discriminatedUnion("kind", [
     kind: z.literal("audiences"),
     audiences: z.array(audienceLiteral).min(1),
   }),
+  z.object({
+    kind: z.literal("fare_codes"),
+    fareCodes: z.array(z.string().min(1)).min(1),
+  }),
+  z.object({
+    kind: z.literal("cabin_grades"),
+    cabinGradeCodes: z.array(z.string().min(1)).min(1),
+  }),
 ])
 
 export type PromotionalOfferScope = z.infer<typeof promotionalOfferScopeSchema>
@@ -56,6 +64,14 @@ export const promotionalOfferConditionsSchema = z.object({
    *  conditional offer when pax is unknown; checkout treats below-minimum
    *  as a hard exclusion. */
   minPax: z.number().int().positive().optional(),
+  /** Requires a known past guest / loyalty customer signal. */
+  pastGuestOnly: z.boolean().optional(),
+  /** Requires a single-traveler party. Falls back to `pax === 1` when pax is known. */
+  soloTravelerOnly: z.boolean().optional(),
+  /** Requires at least one child traveler in the party. */
+  childTravelerOnly: z.boolean().optional(),
+  /** Requires the booking party to qualify as a family. */
+  familyOnly: z.boolean().optional(),
 })
 
 export type PromotionalOfferConditions = z.infer<typeof promotionalOfferConditionsSchema>
@@ -165,7 +181,16 @@ export const promotionalOfferListQuerySchema = z.object({
   applicationMode: z.enum(["auto", "code"]).optional(),
   status: z.enum(["active", "scheduled", "expired", "archived"]).optional(),
   scopeKind: z
-    .enum(["global", "products", "categories", "destinations", "markets", "audiences"])
+    .enum([
+      "global",
+      "products",
+      "categories",
+      "destinations",
+      "markets",
+      "audiences",
+      "fare_codes",
+      "cabin_grades",
+    ])
     .optional(),
   validFrom: z.string().date().optional(),
   validUntil: z.string().date().optional(),

--- a/packages/promotions/tests/unit/evaluator.test.ts
+++ b/packages/promotions/tests/unit/evaluator.test.ts
@@ -457,6 +457,15 @@ describe("code validation — every CodeStatus", () => {
     expect(result.codeStatus).toEqual({ kind: "code_not_applicable", reason: "min_pax" })
   })
 
+  it("returns code_not_applicable with reason='eligibility' when eligibility excludes", async () => {
+    const offer = makeOffer({ code: "family", conditions: { familyOnly: true } })
+    const result = await evaluateOffersForProduct(
+      makeSource({ coded: [offer] }),
+      baseCtx({ code: "FAMILY", eligibility: { family: false }, date: evalDate }),
+    )
+    expect(result.codeStatus).toEqual({ kind: "code_not_applicable", reason: "eligibility" })
+  })
+
   it("returns code_not_applicable with reason='currency' when fixed_amount currency mismatch", async () => {
     const offer = makeOffer({
       code: "fivebucks",

--- a/packages/promotions/tests/unit/evaluator.test.ts
+++ b/packages/promotions/tests/unit/evaluator.test.ts
@@ -203,6 +203,55 @@ describe("scope filter", () => {
       ).applied,
     ).toHaveLength(0)
   })
+
+  it("fare-code scope matches booking-line fareCode", async () => {
+    const offer = makeOffer({
+      scope: { kind: "fare_codes", fareCodes: ["EARLY_BIRD", "PAST_GUEST"] },
+    })
+
+    expect(
+      (
+        await evaluateOffersForProduct(
+          makeSource({ auto: [offer] }),
+          baseCtx({ fareCode: "EARLY_BIRD" }),
+        )
+      ).applied,
+    ).toHaveLength(1)
+    expect(
+      (
+        await evaluateOffersForProduct(
+          makeSource({ auto: [offer] }),
+          baseCtx({ fareCode: "STANDARD" }),
+        )
+      ).applied,
+    ).toHaveLength(0)
+    expect(
+      (await evaluateOffersForProduct(makeSource({ auto: [offer] }), baseCtx())).applied,
+    ).toHaveLength(0)
+  })
+
+  it("cabin-grade scope matches booking-line cabinGradeCode", async () => {
+    const offer = makeOffer({
+      scope: { kind: "cabin_grades", cabinGradeCodes: ["SUITE", "BALCONY"] },
+    })
+
+    expect(
+      (
+        await evaluateOffersForProduct(
+          makeSource({ auto: [offer] }),
+          baseCtx({ cabinGradeCode: "SUITE" }),
+        )
+      ).applied,
+    ).toHaveLength(1)
+    expect(
+      (
+        await evaluateOffersForProduct(
+          makeSource({ auto: [offer] }),
+          baseCtx({ cabinGradeCode: "OCEANVIEW" }),
+        )
+      ).applied,
+    ).toHaveLength(0)
+  })
 })
 
 describe("conditions filter — minPax", () => {
@@ -251,6 +300,60 @@ describe("conditions filter — minPax", () => {
       baseCtx({ pax: undefined }),
     )
     expect(result.conditional).toEqual([])
+  })
+
+  it("catalog-plane surfaces unknown eligibility flags as conditional offers", async () => {
+    const offer = makeOffer({ conditions: { pastGuestOnly: true } })
+    const result = await evaluateOffersForProduct(makeSource({ auto: [offer] }), baseCtx())
+
+    expect(result.applied).toEqual([])
+    expect(result.conditional[0]?.unmet).toEqual({ kind: "past_guest" })
+  })
+
+  it("checkout applies structured eligibility flags when satisfied", async () => {
+    const offer = makeOffer({
+      conditions: {
+        pastGuestOnly: true,
+        soloTravelerOnly: true,
+        childTravelerOnly: true,
+        familyOnly: true,
+      },
+    })
+    const result = await evaluateOffersForProduct(
+      makeSource({ auto: [offer] }),
+      baseCtx({
+        eligibility: {
+          pastGuest: true,
+          soloTraveler: true,
+          hasChildTraveler: true,
+          family: true,
+        },
+      }),
+    )
+
+    expect(result.applied).toHaveLength(1)
+    expect(result.conditional).toEqual([])
+  })
+
+  it("checkout excludes structured eligibility flags when unsatisfied", async () => {
+    const offer = makeOffer({ conditions: { familyOnly: true } })
+    const result = await evaluateOffersForProduct(
+      makeSource({ auto: [offer] }),
+      baseCtx({ eligibility: { family: false } }),
+    )
+
+    expect(result.applied).toEqual([])
+    expect(result.conditional).toEqual([])
+  })
+
+  it("soloTravelerOnly can be satisfied from pax", async () => {
+    const offer = makeOffer({ conditions: { soloTravelerOnly: true } })
+    const result = await evaluateOffersForProduct(
+      makeSource({ auto: [offer] }),
+      baseCtx({ pax: 1 }),
+    )
+
+    expect(result.applied).toHaveLength(1)
   })
 })
 

--- a/packages/promotions/tests/unit/validation.test.ts
+++ b/packages/promotions/tests/unit/validation.test.ts
@@ -46,6 +46,16 @@ describe("promotionalOfferScopeSchema", () => {
     expect(promotionalOfferScopeSchema.parse(scope)).toEqual(scope)
   })
 
+  it("accepts fare-code scope", () => {
+    const scope = { kind: "fare_codes" as const, fareCodes: ["EARLY_BIRD", "PAST_GUEST"] }
+    expect(promotionalOfferScopeSchema.parse(scope)).toEqual(scope)
+  })
+
+  it("accepts cabin-grade scope", () => {
+    const scope = { kind: "cabin_grades" as const, cabinGradeCodes: ["SUITE", "BALCONY"] }
+    expect(promotionalOfferScopeSchema.parse(scope)).toEqual(scope)
+  })
+
   it("rejects audiences scope with unknown audience literal", () => {
     expect(() =>
       promotionalOfferScopeSchema.parse({ kind: "audiences", audiences: ["nope"] }),
@@ -66,6 +76,22 @@ describe("promotionalOfferConditionsSchema", () => {
 
   it("accepts minPax as a positive integer", () => {
     expect(promotionalOfferConditionsSchema.parse({ minPax: 4 })).toEqual({ minPax: 4 })
+  })
+
+  it("accepts structured eligibility flags", () => {
+    expect(
+      promotionalOfferConditionsSchema.parse({
+        pastGuestOnly: true,
+        soloTravelerOnly: true,
+        childTravelerOnly: true,
+        familyOnly: true,
+      }),
+    ).toEqual({
+      pastGuestOnly: true,
+      soloTravelerOnly: true,
+      childTravelerOnly: true,
+      familyOnly: true,
+    })
   })
 
   it("rejects minPax = 0", () => {

--- a/packages/storefront/src/validation.ts
+++ b/packages/storefront/src/validation.ts
@@ -409,7 +409,7 @@ export const storefrontDeparturePriceExtraImpactSchema = z.object({
 export const storefrontDeparturePriceOfferImpactSchema = z.object({
   offer: z.lazy(() => storefrontPromotionalOfferSchema),
   status: z.enum(["applied", "not_applicable", "conflict"]),
-  reason: z.enum(["min_pax", "currency", "no_discount", "conflict"]).nullable(),
+  reason: z.enum(["min_pax", "eligibility", "currency", "no_discount", "conflict"]).nullable(),
   selected: z.boolean(),
   discountAppliedCents: z.number().int(),
   discountedPriceCents: z.number().int(),
@@ -678,6 +678,7 @@ export const storefrontOfferMutationReasonSchema = z
     "code_not_yet_valid",
     "scope",
     "min_pax",
+    "eligibility",
     "currency",
     "no_discount",
     "booking_mismatch",


### PR DESCRIPTION
## Summary
- add fare-code and cabin-grade promotion scope variants
- add structured eligibility flags for past-guest, solo-traveler, child-traveler, and family offers
- extend evaluator, catalog/storefront contracts, React schemas, operator UI labels, docs, and changeset coverage

Fixes #1420

## Verification
- pnpm --filter @voyantjs/promotions test
- pnpm --filter @voyantjs/promotions typecheck
- pnpm --filter @voyantjs/promotions-react typecheck
- pnpm --filter @voyantjs/promotions-ui typecheck
- pnpm --filter @voyantjs/catalog typecheck
- pnpm --filter @voyantjs/storefront typecheck
- pnpm lint:changed
- pre-commit hook: full package lint and full typecheck
- pre-push hook: full repository test suite