### PR TITLE
Add cruise voyage grouping model

### DIFF
--- a/.changeset/cruise-voyage-groups.md
+++ b/.changeset/cruise-voyage-groups.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/cruises": minor
+"@voyantjs/db": patch
+---
+
+Add cruise voyage group schema, validation, service helpers, and admin routes for combined voyages, grand voyages, world cruises, cruise-tours, and pre/post extensions.

--- a/docs/architecture/cruises-module.md
+++ b/docs/architecture/cruises-module.md
@@ -254,6 +254,52 @@ The `externalRefs` JSONB is deliberate. The same cruise can be pulled from multi
 
 Indexes: `(cruiseId, departureDate)`, `(shipId, departureDate)`, `(salesStatus, departureDate)`, unique `(cruiseId, departureDate, shipId)`.
 
+#### `cruise_voyage_groups` — composite voyage identity
+
+Some upstream sources sell products above a single cruise template: back-to-back
+combinations, grand/world cruises, and cruise-tours with land before or after
+the sailing. These rows give that composite product its own identity, status,
+marketing copy, source refs, and price/date roll-ups without overloading
+`cruises`.
+
+| column | type | notes |
+|---|---|---|
+| `id` | typeId("cruise_voyage_groups") | prefix `crvg` |
+| `slug` / `name` | text not null | group-level URL/display identity |
+| `groupKind` | enum | `combination`, `grand_voyage`, `world_cruise`, `cruise_tour` |
+| `lineSupplierId` | text | soft FK to suppliers, same rule as `cruises.lineSupplierId` |
+| `nights` | integer not null | total composite duration |
+| `embarkPortFacilityId` / `disembarkPortFacilityId` | text | overall journey endpoints |
+| `description`, `shortDescription`, `highlights`, `regions`, `themes`, media URLs | mixed | group-level merchandising fields |
+| `status` | cruise_status enum | draft/review/live/archive lifecycle |
+| `lowestPriceCached`, `lowestPriceCurrencyCached` | numeric/text | group pricing roll-up |
+| `earliestDepartureCached`, `latestDepartureCached` | date | group date roll-up |
+| `externalRefs` | jsonb | provider IDs for the composite product |
+| `createdAt` / `updatedAt` | timestamptz | |
+
+#### `cruise_voyage_group_segments` — ordered constituents and extensions
+
+Segments are the ordered itinerary surface for a voyage group. A segment can
+point at a local cruise template and/or sailing when the constituent is a cruise
+leg, or it can stand alone as a land/hotel/transfer/rail/air segment. `segmentRole`
+flags core voyage content versus pre- and post-extensions.
+
+| column | type | notes |
+|---|---|---|
+| `id` | typeId("cruise_voyage_group_segments") | prefix `crvs` |
+| `voyageGroupId` | text not null | FK to `cruise_voyage_groups` |
+| `sortOrder` | integer not null | unique inside a voyage group |
+| `segmentKind` | enum | `cruise`, `land`, `hotel`, `transfer`, `rail`, `air`, `other` |
+| `segmentRole` | enum | `core`, `pre_extension`, `post_extension` |
+| `title`, `description` | text | display copy for this leg |
+| `cruiseId`, `sailingId` | text | optional same-package FKs for cruise constituents |
+| `startDay`, `endDay` | integer | group-relative itinerary range |
+| `startDate`, `endDate` | date | dated range when the group is departure-specific |
+| `embarkPortFacilityId`, `disembarkPortFacilityId` | text | segment endpoints |
+| `nights` | integer | segment duration |
+| `externalRefs`, `metadata` | jsonb | provider IDs and provider-neutral extra shape |
+| `createdAt` / `updatedAt` | timestamptz | |
+
 #### `cruise_ships`
 
 | column | type | notes |
@@ -816,7 +862,7 @@ Lead-gen is therefore not a "mode" of the cruises module — it's a state on the
 | **suppliers** | cruise lines are `suppliers` rows, linked from `cruises.lineSupplierId` (soft FK, schema-discipline rule) |
 | **finance** | bookings → invoices via existing finance module; cruise-specific line items live in the booking quote snapshot, not finance |
 | **pricing** | `cruise_prices.priceCatalogId` and `cruise_prices.priceScheduleId` soft-FK into `pricing.price_catalogs` / `pricing.price_schedules`. Same pattern accommodations already use. No promo/discount primitives are reinvented in cruises. |
-| **products** | pre/post Cruise Extensions (a 3-night Reykjavik hotel before the cruise) are reusable `products` rows linked to one or more cruises/sailings via a template link such as `cruiseProductExtensionLink` |
+| **products** | voyage-group segments model the cruise-side itinerary/extension structure. When a pre/post extension is also a reusable sellable `products` row, link it via a template link such as `cruiseProductExtensionLink`; do not add a cross-package FK in cruises. |
 | **identity / facilities** | ports are `facilities` rows; cruise schema soft-FKs by `facilityId` |
 | **storage** | `cruise_media` uses the same R2/S3 pattern as `product_media`, no new infra |
 | **availability** | not used (cruise availability is per-price-row, not per-product-day) |

--- a/packages/cruises/src/index.ts
+++ b/packages/cruises/src/index.ts
@@ -125,6 +125,13 @@ export const cruiseLinkable: LinkableDefinition = {
   idPrefix: "cru",
 }
 
+export const cruiseVoyageGroupLinkable: LinkableDefinition = {
+  module: "cruises",
+  entity: "cruise_voyage_group",
+  table: "cruise_voyage_groups",
+  idPrefix: "crvg",
+}
+
 export const cruiseSailingLinkable: LinkableDefinition = {
   module: "cruises",
   entity: "cruise_sailing",
@@ -143,6 +150,7 @@ export const cruisesModule: Module = {
   name: "cruises",
   linkable: {
     cruise: cruiseLinkable,
+    cruise_voyage_group: cruiseVoyageGroupLinkable,
     cruise_sailing: cruiseSailingLinkable,
     cruise_ship: cruiseShipLinkable,
   },
@@ -188,12 +196,18 @@ export {
 export type {
   Cruise,
   CruiseSailing,
+  CruiseVoyageGroup,
+  CruiseVoyageGroupSegment,
   NewCruise,
   NewCruiseSailing,
+  NewCruiseVoyageGroup,
+  NewCruiseVoyageGroupSegment,
 } from "./schema-core.js"
 export {
   cruiseSailings,
   cruises,
+  cruiseVoyageGroupSegments,
+  cruiseVoyageGroups,
 } from "./schema-core.js"
 export type {
   CruiseDay,
@@ -228,6 +242,9 @@ export {
   cruiseSourceEnum,
   cruiseStatusEnum,
   cruiseTypeEnum,
+  cruiseVoyageGroupKindEnum,
+  cruiseVoyageSegmentKindEnum,
+  cruiseVoyageSegmentRoleEnum,
   enrichmentProgramKindEnum,
   priceAvailabilityEnum,
   priceComponentDirectionEnum,

--- a/packages/cruises/src/routes.ts
+++ b/packages/cruises/src/routes.ts
@@ -32,9 +32,15 @@ import {
   cruiseListQuerySchema,
   insertCruiseSchema,
   insertSailingSchema,
+  insertVoyageGroupSchema,
+  insertVoyageGroupScopedSegmentSchema,
   sailingListQuerySchema,
   updateCruiseSchema,
   updateSailingSchema,
+  updateVoyageGroupSchema,
+  updateVoyageGroupSegmentSchema,
+  voyageGroupListQuerySchema,
+  voyageGroupSegmentListQuerySchema,
 } from "./validation-core.js"
 import { replaceCruiseDaysSchema, replaceSailingDaysSchema } from "./validation-itinerary.js"
 import {
@@ -415,6 +421,72 @@ export const cruiseAdminRoutes = new Hono<Env>()
       eventBus: c.get("eventBus"),
     })
     return c.json({ data: row }, 201)
+  })
+  // --- voyage groups ---
+  .get("/voyage-groups", async (c) => {
+    const query = parseQuery(c, voyageGroupListQuerySchema)
+    const result = await cruisesService.listVoyageGroups(c.get("db"), query)
+    return c.json(result)
+  })
+  .post("/voyage-groups", async (c) => {
+    const data = await parseJsonBody(c, insertVoyageGroupSchema)
+    const row = await cruisesService.createVoyageGroup(c.get("db"), data)
+    return c.json({ data: row }, 201)
+  })
+  .get("/voyage-groups/:id", async (c) => {
+    const includes = new Set(
+      (c.req.query("include") ?? "")
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
+    )
+    const row = await cruisesService.getVoyageGroupById(c.get("db"), c.req.param("id"), {
+      withSegments: includes.has("segments"),
+    })
+    if (!row) return c.json({ error: "not_found" }, 404)
+    return c.json({ data: row })
+  })
+  .put("/voyage-groups/:id", async (c) => {
+    const data = await parseJsonBody(c, updateVoyageGroupSchema)
+    const row = await cruisesService.updateVoyageGroup(c.get("db"), c.req.param("id"), data)
+    if (!row) return c.json({ error: "not_found" }, 404)
+    return c.json({ data: row })
+  })
+  .delete("/voyage-groups/:id", async (c) => {
+    const row = await cruisesService.archiveVoyageGroup(c.get("db"), c.req.param("id"))
+    if (!row) return c.json({ error: "not_found" }, 404)
+    return c.json({ data: row })
+  })
+  .get("/voyage-groups/:id/segments", async (c) => {
+    const query = parseQuery(c, voyageGroupSegmentListQuerySchema)
+    const result = await cruisesService.listVoyageGroupSegments(c.get("db"), {
+      ...query,
+      voyageGroupId: c.req.param("id"),
+    })
+    return c.json(result)
+  })
+  .post("/voyage-groups/:id/segments", async (c) => {
+    const data = await parseJsonBody(c, insertVoyageGroupScopedSegmentSchema)
+    const row = await cruisesService.createVoyageGroupSegment(c.get("db"), {
+      ...data,
+      voyageGroupId: c.req.param("id"),
+    })
+    return c.json({ data: row }, 201)
+  })
+  .put("/voyage-group-segments/:segmentId", async (c) => {
+    const data = await parseJsonBody(c, updateVoyageGroupSegmentSchema)
+    const row = await cruisesService.updateVoyageGroupSegment(
+      c.get("db"),
+      c.req.param("segmentId"),
+      data,
+    )
+    if (!row) return c.json({ error: "not_found" }, 404)
+    return c.json({ data: row })
+  })
+  .delete("/voyage-group-segments/:segmentId", async (c) => {
+    const ok = await cruisesService.deleteVoyageGroupSegment(c.get("db"), c.req.param("segmentId"))
+    if (!ok) return c.json({ error: "not_found" }, 404)
+    return c.body(null, 204)
   })
   .put("/enrichment/:programId", async (c) => {
     const data = await parseJsonBody(c, updateEnrichmentProgramSchema)

--- a/packages/cruises/src/schema-core.ts
+++ b/packages/cruises/src/schema-core.ts
@@ -16,8 +16,53 @@ import {
   cruiseSailingDirectionEnum,
   cruiseStatusEnum,
   cruiseTypeEnum,
+  cruiseVoyageGroupKindEnum,
+  cruiseVoyageSegmentKindEnum,
+  cruiseVoyageSegmentRoleEnum,
   sailingSalesStatusEnum,
 } from "./schema-shared.js"
+
+export const cruiseVoyageGroups = pgTable(
+  "cruise_voyage_groups",
+  {
+    id: typeId("cruise_voyage_groups"),
+    slug: text("slug").notNull(),
+    name: text("name").notNull(),
+    groupKind: cruiseVoyageGroupKindEnum("group_kind").notNull(),
+    lineSupplierId: text("line_supplier_id"),
+    nights: integer("nights").notNull(),
+    embarkPortFacilityId: text("embark_port_facility_id"),
+    disembarkPortFacilityId: text("disembark_port_facility_id"),
+    description: text("description"),
+    shortDescription: text("short_description"),
+    highlights: jsonb("highlights").$type<string[]>().default([]),
+    regions: jsonb("regions").$type<string[]>().default([]),
+    themes: jsonb("themes").$type<string[]>().default([]),
+    heroImageUrl: text("hero_image_url"),
+    mapImageUrl: text("map_image_url"),
+    status: cruiseStatusEnum("status").notNull().default("draft"),
+    lowestPriceCached: numeric("lowest_price_cached", { precision: 12, scale: 2 }),
+    lowestPriceCurrencyCached: text("lowest_price_currency_cached"),
+    earliestDepartureCached: date("earliest_departure_cached"),
+    latestDepartureCached: date("latest_departure_cached"),
+    externalRefs: jsonb("external_refs").$type<Record<string, string>>().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("uidx_cruise_voyage_groups_slug").on(table.slug),
+    index("idx_cruise_voyage_groups_kind_status").on(table.groupKind, table.status),
+    index("idx_cruise_voyage_groups_supplier_status").on(table.lineSupplierId, table.status),
+    index("idx_cruise_voyage_groups_earliest_status").on(
+      table.earliestDepartureCached,
+      table.status,
+    ),
+    index("idx_cruise_voyage_groups_status_created").on(table.status, table.createdAt),
+  ],
+)
+
+export type CruiseVoyageGroup = typeof cruiseVoyageGroups.$inferSelect
+export type NewCruiseVoyageGroup = typeof cruiseVoyageGroups.$inferInsert
 
 export const cruises = pgTable(
   "cruises",
@@ -113,3 +158,42 @@ export const cruiseSailings = pgTable(
 
 export type CruiseSailing = typeof cruiseSailings.$inferSelect
 export type NewCruiseSailing = typeof cruiseSailings.$inferInsert
+
+export const cruiseVoyageGroupSegments = pgTable(
+  "cruise_voyage_group_segments",
+  {
+    id: typeId("cruise_voyage_group_segments"),
+    voyageGroupId: typeIdRef("voyage_group_id")
+      .notNull()
+      .references(() => cruiseVoyageGroups.id, { onDelete: "cascade" }),
+    sortOrder: integer("sort_order").notNull(),
+    segmentKind: cruiseVoyageSegmentKindEnum("segment_kind").notNull(),
+    segmentRole: cruiseVoyageSegmentRoleEnum("segment_role").notNull().default("core"),
+    title: text("title").notNull(),
+    description: text("description"),
+    cruiseId: typeIdRef("cruise_id").references(() => cruises.id, { onDelete: "set null" }),
+    sailingId: typeIdRef("sailing_id").references(() => cruiseSailings.id, {
+      onDelete: "set null",
+    }),
+    startDay: integer("start_day"),
+    endDay: integer("end_day"),
+    startDate: date("start_date"),
+    endDate: date("end_date"),
+    embarkPortFacilityId: text("embark_port_facility_id"),
+    disembarkPortFacilityId: text("disembark_port_facility_id"),
+    nights: integer("nights"),
+    externalRefs: jsonb("external_refs").$type<Record<string, string>>().default({}),
+    metadata: jsonb("metadata").$type<Record<string, unknown>>().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("uidx_cruise_voyage_segments_group_sort").on(table.voyageGroupId, table.sortOrder),
+    index("idx_cruise_voyage_segments_group_role").on(table.voyageGroupId, table.segmentRole),
+    index("idx_cruise_voyage_segments_cruise").on(table.cruiseId),
+    index("idx_cruise_voyage_segments_sailing").on(table.sailingId),
+  ],
+)
+
+export type CruiseVoyageGroupSegment = typeof cruiseVoyageGroupSegments.$inferSelect
+export type NewCruiseVoyageGroupSegment = typeof cruiseVoyageGroupSegments.$inferInsert

--- a/packages/cruises/src/schema-shared.ts
+++ b/packages/cruises/src/schema-shared.ts
@@ -11,6 +11,29 @@ export const cruiseStatusEnum = pgEnum("cruise_status", [
 
 export const cruiseSourceEnum = pgEnum("cruise_source", ["local", "external"])
 
+export const cruiseVoyageGroupKindEnum = pgEnum("cruise_voyage_group_kind", [
+  "combination",
+  "grand_voyage",
+  "world_cruise",
+  "cruise_tour",
+])
+
+export const cruiseVoyageSegmentKindEnum = pgEnum("cruise_voyage_segment_kind", [
+  "cruise",
+  "land",
+  "hotel",
+  "transfer",
+  "rail",
+  "air",
+  "other",
+])
+
+export const cruiseVoyageSegmentRoleEnum = pgEnum("cruise_voyage_segment_role", [
+  "core",
+  "pre_extension",
+  "post_extension",
+])
+
 export const shipTypeEnum = pgEnum("cruise_ship_type", [
   "ocean",
   "river",

--- a/packages/cruises/src/service.ts
+++ b/packages/cruises/src/service.ts
@@ -22,10 +22,16 @@ import { type CruiseEnrichmentProgram, cruiseEnrichmentPrograms } from "./schema
 import {
   type Cruise,
   type CruiseSailing,
+  type CruiseVoyageGroup,
+  type CruiseVoyageGroupSegment,
   cruiseSailings,
   cruises,
+  cruiseVoyageGroupSegments,
+  cruiseVoyageGroups,
   type NewCruise,
   type NewCruiseSailing,
+  type NewCruiseVoyageGroup,
+  type NewCruiseVoyageGroupSegment,
 } from "./schema-core.js"
 import {
   type CruiseDay,
@@ -61,9 +67,15 @@ import type {
   CruiseListQuery,
   InsertCruise,
   InsertSailing,
+  InsertVoyageGroup,
+  InsertVoyageGroupSegment,
   SailingListQuery,
   UpdateCruise,
   UpdateSailing,
+  UpdateVoyageGroup,
+  UpdateVoyageGroupSegment,
+  VoyageGroupListQuery,
+  VoyageGroupSegmentListQuery,
 } from "./validation-core.js"
 import type { ReplaceCruiseDays, ReplaceSailingDays } from "./validation-itinerary.js"
 import type {
@@ -111,6 +123,167 @@ async function reprojectIfPossible(db: PostgresJsDatabase, cruiseId: string | nu
 // ---------- cruises ----------
 
 export const cruisesService = {
+  async listVoyageGroups(db: PostgresJsDatabase, query: VoyageGroupListQuery) {
+    const conditions = []
+    if (query.groupKind) conditions.push(eq(cruiseVoyageGroups.groupKind, query.groupKind))
+    if (query.status) conditions.push(eq(cruiseVoyageGroups.status, query.status))
+    if (query.lineSupplierId) {
+      conditions.push(eq(cruiseVoyageGroups.lineSupplierId, query.lineSupplierId))
+    }
+    if (query.region) {
+      conditions.push(
+        sql`${cruiseVoyageGroups.regions} @> ${JSON.stringify([query.region])}::jsonb`,
+      )
+    }
+    if (query.search) {
+      const term = `%${query.search}%`
+      conditions.push(
+        or(ilike(cruiseVoyageGroups.name, term), ilike(cruiseVoyageGroups.description, term)),
+      )
+    }
+    const where = conditions.length > 0 ? and(...conditions) : undefined
+    const { limit, offset } = paginate(query)
+
+    const [rows, totalRows] = await Promise.all([
+      db
+        .select()
+        .from(cruiseVoyageGroups)
+        .where(where)
+        .orderBy(desc(cruiseVoyageGroups.createdAt))
+        .limit(limit)
+        .offset(offset),
+      db.select({ value: count() }).from(cruiseVoyageGroups).where(where),
+    ])
+    return { data: rows, total: totalRows[0]?.value ?? 0, limit, offset }
+  },
+
+  async getVoyageGroupById(
+    db: PostgresJsDatabase,
+    id: string,
+    options: { withSegments?: boolean } = {},
+  ): Promise<
+    | (CruiseVoyageGroup & {
+        segments?: CruiseVoyageGroupSegment[]
+      })
+    | null
+  > {
+    const [row] = await db
+      .select()
+      .from(cruiseVoyageGroups)
+      .where(eq(cruiseVoyageGroups.id, id))
+      .limit(1)
+    if (!row) return null
+
+    const out: CruiseVoyageGroup & { segments?: CruiseVoyageGroupSegment[] } = { ...row }
+    if (options.withSegments) {
+      out.segments = await db
+        .select()
+        .from(cruiseVoyageGroupSegments)
+        .where(eq(cruiseVoyageGroupSegments.voyageGroupId, id))
+        .orderBy(asc(cruiseVoyageGroupSegments.sortOrder))
+    }
+    return out
+  },
+
+  async createVoyageGroup(
+    db: PostgresJsDatabase,
+    data: InsertVoyageGroup,
+  ): Promise<CruiseVoyageGroup> {
+    const [row] = await db
+      .insert(cruiseVoyageGroups)
+      .values(data as NewCruiseVoyageGroup)
+      .returning()
+    if (!row) throw new Error("Failed to create voyage group")
+    return row
+  },
+
+  async updateVoyageGroup(
+    db: PostgresJsDatabase,
+    id: string,
+    data: UpdateVoyageGroup,
+  ): Promise<CruiseVoyageGroup | null> {
+    const [row] = await db
+      .update(cruiseVoyageGroups)
+      .set({ ...data, ...setUpdated })
+      .where(eq(cruiseVoyageGroups.id, id))
+      .returning()
+    return row ?? null
+  },
+
+  async archiveVoyageGroup(db: PostgresJsDatabase, id: string): Promise<CruiseVoyageGroup | null> {
+    const [row] = await db
+      .update(cruiseVoyageGroups)
+      .set({ status: "archived", ...setUpdated })
+      .where(eq(cruiseVoyageGroups.id, id))
+      .returning()
+    return row ?? null
+  },
+
+  async listVoyageGroupSegments(db: PostgresJsDatabase, query: VoyageGroupSegmentListQuery) {
+    const conditions = []
+    if (query.voyageGroupId) {
+      conditions.push(eq(cruiseVoyageGroupSegments.voyageGroupId, query.voyageGroupId))
+    }
+    if (query.cruiseId) conditions.push(eq(cruiseVoyageGroupSegments.cruiseId, query.cruiseId))
+    if (query.sailingId) conditions.push(eq(cruiseVoyageGroupSegments.sailingId, query.sailingId))
+    if (query.segmentKind) {
+      conditions.push(eq(cruiseVoyageGroupSegments.segmentKind, query.segmentKind))
+    }
+    if (query.segmentRole) {
+      conditions.push(eq(cruiseVoyageGroupSegments.segmentRole, query.segmentRole))
+    }
+    const where = conditions.length > 0 ? and(...conditions) : undefined
+    const { limit, offset } = paginate(query)
+
+    const [rows, totalRows] = await Promise.all([
+      db
+        .select()
+        .from(cruiseVoyageGroupSegments)
+        .where(where)
+        .orderBy(
+          asc(cruiseVoyageGroupSegments.voyageGroupId),
+          asc(cruiseVoyageGroupSegments.sortOrder),
+        )
+        .limit(limit)
+        .offset(offset),
+      db.select({ value: count() }).from(cruiseVoyageGroupSegments).where(where),
+    ])
+    return { data: rows, total: totalRows[0]?.value ?? 0, limit, offset }
+  },
+
+  async createVoyageGroupSegment(
+    db: PostgresJsDatabase,
+    data: InsertVoyageGroupSegment,
+  ): Promise<CruiseVoyageGroupSegment> {
+    const [row] = await db
+      .insert(cruiseVoyageGroupSegments)
+      .values(data as NewCruiseVoyageGroupSegment)
+      .returning()
+    if (!row) throw new Error("Failed to create voyage group segment")
+    return row
+  },
+
+  async updateVoyageGroupSegment(
+    db: PostgresJsDatabase,
+    id: string,
+    data: UpdateVoyageGroupSegment,
+  ): Promise<CruiseVoyageGroupSegment | null> {
+    const [row] = await db
+      .update(cruiseVoyageGroupSegments)
+      .set({ ...data, ...setUpdated })
+      .where(eq(cruiseVoyageGroupSegments.id, id))
+      .returning()
+    return row ?? null
+  },
+
+  async deleteVoyageGroupSegment(db: PostgresJsDatabase, id: string): Promise<boolean> {
+    const rows = await db
+      .delete(cruiseVoyageGroupSegments)
+      .where(eq(cruiseVoyageGroupSegments.id, id))
+      .returning({ id: cruiseVoyageGroupSegments.id })
+    return rows.length > 0
+  },
+
   async listCruises(db: PostgresJsDatabase, query: CruiseListQuery) {
     const conditions = []
     if (query.cruiseType) conditions.push(eq(cruises.cruiseType, query.cruiseType))

--- a/packages/cruises/src/validation-core.ts
+++ b/packages/cruises/src/validation-core.ts
@@ -2,12 +2,57 @@ import {
   cruiseSailingDirectionSchema,
   cruiseStatusSchema,
   cruiseTypeSchema,
+  cruiseVoyageGroupKindSchema,
+  cruiseVoyageSegmentKindSchema,
+  cruiseVoyageSegmentRoleSchema,
+  currencyCodeSchema,
   externalRefsSchema,
   isoDateSchema,
+  moneyStringSchema,
   sailingSalesStatusSchema,
   slugSchema,
   z,
 } from "./validation-shared.js"
+
+const voyageGroupCoreSchema = z.object({
+  slug: slugSchema,
+  name: z.string().min(1).max(255),
+  groupKind: cruiseVoyageGroupKindSchema,
+  lineSupplierId: z.string().optional().nullable(),
+  nights: z.number().int().min(0),
+  embarkPortFacilityId: z.string().optional().nullable(),
+  disembarkPortFacilityId: z.string().optional().nullable(),
+  description: z.string().optional().nullable(),
+  shortDescription: z.string().optional().nullable(),
+  highlights: z.array(z.string()).default([]),
+  regions: z.array(z.string()).default([]),
+  themes: z.array(z.string()).default([]),
+  heroImageUrl: z.string().url().optional().nullable(),
+  mapImageUrl: z.string().url().optional().nullable(),
+  status: cruiseStatusSchema.default("draft"),
+  lowestPriceCached: moneyStringSchema.optional().nullable(),
+  lowestPriceCurrencyCached: currencyCodeSchema.optional().nullable(),
+  earliestDepartureCached: isoDateSchema.optional().nullable(),
+  latestDepartureCached: isoDateSchema.optional().nullable(),
+  externalRefs: externalRefsSchema,
+})
+
+export const insertVoyageGroupSchema = voyageGroupCoreSchema
+export const updateVoyageGroupSchema = voyageGroupCoreSchema.partial()
+
+export const voyageGroupListQuerySchema = z.object({
+  groupKind: cruiseVoyageGroupKindSchema.optional(),
+  status: cruiseStatusSchema.optional(),
+  lineSupplierId: z.string().optional(),
+  region: z.string().optional(),
+  search: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+})
+
+export type InsertVoyageGroup = z.infer<typeof insertVoyageGroupSchema>
+export type UpdateVoyageGroup = z.infer<typeof updateVoyageGroupSchema>
+export type VoyageGroupListQuery = z.infer<typeof voyageGroupListQuerySchema>
 
 const cruiseCoreSchema = z.object({
   slug: slugSchema,
@@ -79,3 +124,78 @@ export const sailingListQuerySchema = z.object({
 export type InsertSailing = z.infer<typeof insertSailingSchema>
 export type UpdateSailing = z.infer<typeof updateSailingSchema>
 export type SailingListQuery = z.infer<typeof sailingListQuerySchema>
+
+const voyageGroupSegmentFields = {
+  voyageGroupId: z.string(),
+  sortOrder: z.number().int().min(0),
+  segmentKind: cruiseVoyageSegmentKindSchema,
+  segmentRole: cruiseVoyageSegmentRoleSchema.default("core"),
+  title: z.string().min(1).max(255),
+  description: z.string().optional().nullable(),
+  cruiseId: z.string().optional().nullable(),
+  sailingId: z.string().optional().nullable(),
+  startDay: z.number().int().positive().optional().nullable(),
+  endDay: z.number().int().positive().optional().nullable(),
+  startDate: isoDateSchema.optional().nullable(),
+  endDate: isoDateSchema.optional().nullable(),
+  embarkPortFacilityId: z.string().optional().nullable(),
+  disembarkPortFacilityId: z.string().optional().nullable(),
+  nights: z.number().int().min(0).optional().nullable(),
+  externalRefs: externalRefsSchema,
+  metadata: z.record(z.string(), z.unknown()).default({}),
+} satisfies z.ZodRawShape
+
+function validateVoyageSegmentRange(
+  value: {
+    startDay?: number | null
+    endDay?: number | null
+    startDate?: string | null
+    endDate?: string | null
+  },
+  ctx: z.RefinementCtx,
+) {
+  if (value.startDay && value.endDay && value.endDay < value.startDay) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["endDay"],
+      message: "endDay must be greater than or equal to startDay",
+    })
+  }
+  if (value.startDate && value.endDate && value.endDate < value.startDate) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["endDate"],
+      message: "endDate must be greater than or equal to startDate",
+    })
+  }
+}
+
+const voyageGroupSegmentBaseSchema = z.object(voyageGroupSegmentFields)
+const voyageGroupSegmentCoreSchema = voyageGroupSegmentBaseSchema.superRefine(
+  validateVoyageSegmentRange,
+)
+
+export const insertVoyageGroupSegmentSchema = voyageGroupSegmentCoreSchema
+export const insertVoyageGroupScopedSegmentSchema = z
+  .object({
+    ...voyageGroupSegmentFields,
+    voyageGroupId: z.string().optional(),
+  })
+  .superRefine(validateVoyageSegmentRange)
+export const updateVoyageGroupSegmentSchema = voyageGroupSegmentBaseSchema
+  .partial()
+  .superRefine(validateVoyageSegmentRange)
+
+export const voyageGroupSegmentListQuerySchema = z.object({
+  voyageGroupId: z.string().optional(),
+  cruiseId: z.string().optional(),
+  sailingId: z.string().optional(),
+  segmentKind: cruiseVoyageSegmentKindSchema.optional(),
+  segmentRole: cruiseVoyageSegmentRoleSchema.optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+})
+
+export type InsertVoyageGroupSegment = z.infer<typeof insertVoyageGroupSegmentSchema>
+export type UpdateVoyageGroupSegment = z.infer<typeof updateVoyageGroupSegmentSchema>
+export type VoyageGroupSegmentListQuery = z.infer<typeof voyageGroupSegmentListQuerySchema>

--- a/packages/cruises/src/validation-shared.ts
+++ b/packages/cruises/src/validation-shared.ts
@@ -7,6 +7,22 @@ export { booleanQueryParam, typeIdSchema, z }
 export const cruiseTypeSchema = z.enum(["ocean", "river", "expedition", "coastal"])
 export const cruiseStatusSchema = z.enum(["draft", "awaiting_review", "live", "archived"])
 export const cruiseSourceSchema = z.enum(["local", "external"])
+export const cruiseVoyageGroupKindSchema = z.enum([
+  "combination",
+  "grand_voyage",
+  "world_cruise",
+  "cruise_tour",
+])
+export const cruiseVoyageSegmentKindSchema = z.enum([
+  "cruise",
+  "land",
+  "hotel",
+  "transfer",
+  "rail",
+  "air",
+  "other",
+])
+export const cruiseVoyageSegmentRoleSchema = z.enum(["core", "pre_extension", "post_extension"])
 
 export const shipTypeSchema = z.enum([
   "ocean",

--- a/packages/cruises/tests/unit/routes-shape.test.ts
+++ b/packages/cruises/tests/unit/routes-shape.test.ts
@@ -74,6 +74,119 @@ describe("admin routes — static subresource ordering", () => {
     await expect(shipsRes.json()).resolves.toMatchObject({ data: [] })
     await expect(pricesRes.json()).resolves.toMatchObject({ data: [] })
   })
+
+  it("routes voyage group collections ahead of GET /:key", async () => {
+    const listVoyageGroups = vi.spyOn(cruisesService, "listVoyageGroups").mockResolvedValueOnce({
+      data: [],
+      total: 0,
+      limit: 25,
+      offset: 0,
+    })
+
+    const res = await app.request("/voyage-groups?limit=25&offset=0")
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toMatchObject({ data: [] })
+    expect(listVoyageGroups).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("admin routes — voyage groups", () => {
+  const app = mountTestApp(cruiseAdminRoutes, { db: undefined })
+
+  it("creates voyage groups with composite voyage fields", async () => {
+    vi.spyOn(cruisesService, "createVoyageGroup").mockResolvedValueOnce({
+      id: "crvg_123",
+      slug: "world-cruise-2027",
+      name: "World Cruise 2027",
+      groupKind: "world_cruise",
+      lineSupplierId: null,
+      nights: 120,
+      embarkPortFacilityId: null,
+      disembarkPortFacilityId: null,
+      description: null,
+      shortDescription: null,
+      highlights: [],
+      regions: [],
+      themes: [],
+      heroImageUrl: null,
+      mapImageUrl: null,
+      status: "draft",
+      lowestPriceCached: null,
+      lowestPriceCurrencyCached: null,
+      earliestDepartureCached: null,
+      latestDepartureCached: null,
+      externalRefs: {},
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    })
+
+    const res = await app.request("/voyage-groups", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        slug: "world-cruise-2027",
+        name: "World Cruise 2027",
+        groupKind: "world_cruise",
+        nights: 120,
+      }),
+    })
+
+    expect(res.status).toBe(201)
+    expect(cruisesService.createVoyageGroup).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ groupKind: "world_cruise", nights: 120 }),
+    )
+  })
+
+  it("creates scoped pre-extension segments from the voyage group route", async () => {
+    vi.spyOn(cruisesService, "createVoyageGroupSegment").mockResolvedValueOnce({
+      id: "crvs_123",
+      voyageGroupId: "crvg_123",
+      sortOrder: 0,
+      segmentKind: "land",
+      segmentRole: "pre_extension",
+      title: "Reykjavik pre-tour",
+      description: null,
+      cruiseId: null,
+      sailingId: null,
+      startDay: 1,
+      endDay: 3,
+      startDate: null,
+      endDate: null,
+      embarkPortFacilityId: null,
+      disembarkPortFacilityId: null,
+      nights: 2,
+      externalRefs: {},
+      metadata: {},
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    })
+
+    const res = await app.request("/voyage-groups/crvg_123/segments", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sortOrder: 0,
+        segmentKind: "land",
+        segmentRole: "pre_extension",
+        title: "Reykjavik pre-tour",
+        startDay: 1,
+        endDay: 3,
+        nights: 2,
+      }),
+    })
+
+    expect(res.status).toBe(201)
+    expect(cruisesService.createVoyageGroupSegment).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({
+        voyageGroupId: "crvg_123",
+        segmentKind: "land",
+        segmentRole: "pre_extension",
+      }),
+    )
+  })
 })
 
 describe("admin routes — external key dispatch (no catalog registry configured)", () => {

--- a/packages/cruises/tests/unit/voyage-groups-validation.test.ts
+++ b/packages/cruises/tests/unit/voyage-groups-validation.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  insertVoyageGroupSchema,
+  insertVoyageGroupScopedSegmentSchema,
+} from "../../src/validation-core.js"
+
+describe("voyage group validation", () => {
+  it("accepts composite voyage group kinds", () => {
+    const parsed = insertVoyageGroupSchema.parse({
+      slug: "grand-voyage-2027",
+      name: "Grand Voyage 2027",
+      groupKind: "grand_voyage",
+      nights: 45,
+    })
+
+    expect(parsed).toMatchObject({
+      groupKind: "grand_voyage",
+      status: "draft",
+      externalRefs: {},
+    })
+  })
+
+  it("accepts scoped land extension segments without duplicating the group id in the body", () => {
+    const parsed = insertVoyageGroupScopedSegmentSchema.parse({
+      sortOrder: 0,
+      segmentKind: "land",
+      segmentRole: "pre_extension",
+      title: "Patagonia pre-tour",
+      startDay: 1,
+      endDay: 4,
+      nights: 3,
+    })
+
+    expect(parsed).toMatchObject({
+      segmentKind: "land",
+      segmentRole: "pre_extension",
+      metadata: {},
+    })
+  })
+
+  it("rejects inverted segment day ranges", () => {
+    expect(() =>
+      insertVoyageGroupScopedSegmentSchema.parse({
+        sortOrder: 2,
+        segmentKind: "cruise",
+        title: "Main sailing",
+        startDay: 10,
+        endDay: 3,
+      }),
+    ).toThrow(/endDay/)
+  })
+})

--- a/packages/db/src/lib/typeid-prefixes.ts
+++ b/packages/db/src/lib/typeid-prefixes.ts
@@ -312,6 +312,8 @@ export const PREFIXES = {
 
   // --- CRUISES ---
   cruises: "cru",
+  cruise_voyage_groups: "crvg",
+  cruise_voyage_group_segments: "crvs",
   cruise_sailings: "crsl",
   cruise_ships: "crsh",
   cruise_decks: "crdk",

--- a/templates/operator/migrations/0047_cruise_voyage_groups.sql
+++ b/templates/operator/migrations/0047_cruise_voyage_groups.sql
@@ -1,0 +1,64 @@
+CREATE TYPE "public"."cruise_voyage_group_kind" AS ENUM('combination', 'grand_voyage', 'world_cruise', 'cruise_tour');--> statement-breakpoint
+CREATE TYPE "public"."cruise_voyage_segment_kind" AS ENUM('cruise', 'land', 'hotel', 'transfer', 'rail', 'air', 'other');--> statement-breakpoint
+CREATE TYPE "public"."cruise_voyage_segment_role" AS ENUM('core', 'pre_extension', 'post_extension');--> statement-breakpoint
+CREATE TABLE "cruise_voyage_groups" (
+	"id" text PRIMARY KEY NOT NULL,
+	"slug" text NOT NULL,
+	"name" text NOT NULL,
+	"group_kind" "cruise_voyage_group_kind" NOT NULL,
+	"line_supplier_id" text,
+	"nights" integer NOT NULL,
+	"embark_port_facility_id" text,
+	"disembark_port_facility_id" text,
+	"description" text,
+	"short_description" text,
+	"highlights" jsonb DEFAULT '[]'::jsonb,
+	"regions" jsonb DEFAULT '[]'::jsonb,
+	"themes" jsonb DEFAULT '[]'::jsonb,
+	"hero_image_url" text,
+	"map_image_url" text,
+	"status" "cruise_status" DEFAULT 'draft' NOT NULL,
+	"lowest_price_cached" numeric(12, 2),
+	"lowest_price_currency_cached" text,
+	"earliest_departure_cached" date,
+	"latest_departure_cached" date,
+	"external_refs" jsonb DEFAULT '{}'::jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "cruise_voyage_group_segments" (
+	"id" text PRIMARY KEY NOT NULL,
+	"voyage_group_id" text NOT NULL,
+	"sort_order" integer NOT NULL,
+	"segment_kind" "cruise_voyage_segment_kind" NOT NULL,
+	"segment_role" "cruise_voyage_segment_role" DEFAULT 'core' NOT NULL,
+	"title" text NOT NULL,
+	"description" text,
+	"cruise_id" text,
+	"sailing_id" text,
+	"start_day" integer,
+	"end_day" integer,
+	"start_date" date,
+	"end_date" date,
+	"embark_port_facility_id" text,
+	"disembark_port_facility_id" text,
+	"nights" integer,
+	"external_refs" jsonb DEFAULT '{}'::jsonb,
+	"metadata" jsonb DEFAULT '{}'::jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "cruise_voyage_group_segments" ADD CONSTRAINT "cruise_voyage_group_segments_voyage_group_id_cruise_voyage_groups_id_fk" FOREIGN KEY ("voyage_group_id") REFERENCES "public"."cruise_voyage_groups"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cruise_voyage_group_segments" ADD CONSTRAINT "cruise_voyage_group_segments_cruise_id_cruises_id_fk" FOREIGN KEY ("cruise_id") REFERENCES "public"."cruises"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cruise_voyage_group_segments" ADD CONSTRAINT "cruise_voyage_group_segments_sailing_id_cruise_sailings_id_fk" FOREIGN KEY ("sailing_id") REFERENCES "public"."cruise_sailings"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_cruise_voyage_groups_slug" ON "cruise_voyage_groups" USING btree ("slug");--> statement-breakpoint
+CREATE INDEX "idx_cruise_voyage_groups_kind_status" ON "cruise_voyage_groups" USING btree ("group_kind","status");--> statement-breakpoint
+CREATE INDEX "idx_cruise_voyage_groups_supplier_status" ON "cruise_voyage_groups" USING btree ("line_supplier_id","status");--> statement-breakpoint
+CREATE INDEX "idx_cruise_voyage_groups_earliest_status" ON "cruise_voyage_groups" USING btree ("earliest_departure_cached","status");--> statement-breakpoint
+CREATE INDEX "idx_cruise_voyage_groups_status_created" ON "cruise_voyage_groups" USING btree ("status","created_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_cruise_voyage_segments_group_sort" ON "cruise_voyage_group_segments" USING btree ("voyage_group_id","sort_order");--> statement-breakpoint
+CREATE INDEX "idx_cruise_voyage_segments_group_role" ON "cruise_voyage_group_segments" USING btree ("voyage_group_id","segment_role");--> statement-breakpoint
+CREATE INDEX "idx_cruise_voyage_segments_cruise" ON "cruise_voyage_group_segments" USING btree ("cruise_id");--> statement-breakpoint
+CREATE INDEX "idx_cruise_voyage_segments_sailing" ON "cruise_voyage_group_segments" USING btree ("sailing_id");

--- a/templates/operator/migrations/meta/_journal.json
+++ b/templates/operator/migrations/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1780141300000,
       "tag": "0046_organization_tax_id",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1780141400000,
+      "tag": "0047_cruise_voyage_groups",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add cruise voyage group and ordered segment schema for combinations, grand/world cruises, cruise-tours, and pre/post extensions
- expose validation, service helpers, admin routes, TypeID prefixes, and linkable metadata for voyage groups
- document the cruise architecture update and add the operator migration

## Verification
- pnpm --filter @voyantjs/cruises lint
- pnpm --filter @voyantjs/cruises typecheck
- pnpm --filter @voyantjs/cruises test -- voyage-groups-validation routes-shape
- pnpm --filter @voyantjs/db typecheck
- pre-commit hook: workspace lint + typecheck
- pre-push hook: workspace test

Fixes #1422