### PR TITLE
Extend contract-package pattern to accommodations, products, extras, charters

### DIFF
--- a/.changeset/vertical-contract-packages.md
+++ b/.changeset/vertical-contract-packages.md
@@ -1,0 +1,29 @@
+---
+"@voyantjs/accommodations-contracts": minor
+"@voyantjs/products-contracts": minor
+"@voyantjs/extras-contracts": minor
+"@voyantjs/charters-contracts": minor
+"@voyantjs/accommodations": minor
+"@voyantjs/products": minor
+"@voyantjs/extras": minor
+"@voyantjs/charters": minor
+---
+
+Extend the lightweight contract-package pattern to the remaining content
+verticals.
+
+`@voyantjs/accommodations-contracts`, `@voyantjs/products-contracts`,
+`@voyantjs/extras-contracts`, and `@voyantjs/charters-contracts` now own their
+respective `<vertical>/v1` rich content schema, version constant, types, and
+validator as zod-only packages, so external consumers (Voyant Connect, adapter
+authors, the Admin API SDK) can validate content payloads without installing the
+framework runtime.
+
+The runtime `@voyantjs/accommodations`, `@voyantjs/products`,
+`@voyantjs/extras`, and `@voyantjs/charters` packages re-export their content
+shape from the matching contract package, so existing
+`@voyantjs/<vertical>/content-shape` import paths are unchanged. The
+`mergeOverlaysInto<Vertical>Content` overlay composition stays in the runtime
+package.
+
+See `docs/adr/0002-contract-packages.md` for the codified pattern.

--- a/docs/adr/0002-contract-packages.md
+++ b/docs/adr/0002-contract-packages.md
@@ -1,0 +1,176 @@
+# ADR-0002: Pure framework contracts ship as standalone `*-contracts` packages
+
+- **Status:** Accepted (2026-05-31)
+- **Relates to:** [#1400](https://github.com/voyantjs/voyant/issues/1400), [#1411](https://github.com/voyantjs/voyant/issues/1411)
+
+## Context
+
+Voyant's domain packages (`catalog`, `cruises`, `accommodations`, `products`,
+`extras`, `charters`, …) each carry two very different kinds of code in one
+package:
+
+1. **Pure contracts** — Zod schemas, inferred types, schema-version
+   constants, validators, and small enum vocabularies. These describe the
+   payload shapes that flow across HTTP/queue/RPC boundaries (the source-adapter
+   contract, the `<vertical>/v1` rich-content aggregates).
+2. **Runtime** — Drizzle tables, Hono routes, services, booking engines,
+   catalog-projection policies, content-resolution read paths, adapter shims.
+
+External consumers increasingly need (1) without (2):
+
+- **Voyant Connect** validates provider mappers and `SourceAdapter` HTTP
+  responses against the framework contracts. It must not pull Drizzle, Hono,
+  or framework DB modules into its own runtime.
+- **Third-party adapter authors** need a stable, small public surface that says
+  "emit/consume these payloads" without implying they run the framework.
+- **The Admin API SDK** (#1411) is explicitly specified as follow-up that
+  "depends on #1400 for the reusable contract-package pattern."
+
+Before this ADR, importing `cruiseContentSchema` meant depending on
+`@voyantjs/cruises` — and transitively on `@voyantjs/catalog`,
+`@voyantjs/db`, `@voyantjs/hono`, Drizzle, and Hono. The pure contract was
+real but not *reachable* without the runtime.
+
+## Decision
+
+**Pure framework contracts live in dedicated, dependency-light `*-contracts`
+packages. Runtime packages depend on their contracts package and re-export
+from it; the dependency arrow only ever points runtime → contracts.**
+
+Concretely:
+
+- The shared source-adapter contract surface lives in
+  **`@voyantjs/catalog-contracts`** (adapter contracts, adapter Zod schemas,
+  field-policy contracts, provenance, drift event payloads, and the pure
+  content locale/overlay primitives).
+- Each vertical with a `<vertical>/v1` rich-content aggregate ships
+  **`@voyantjs/<vertical>-contracts`** owning that aggregate: the
+  `*_CONTENT_SCHEMA_VERSION` constant, every content schema, the inferred
+  types, the `validate<Vertical>Content` validator, and any pure facet
+  vocabularies (e.g. the cruise cabin bed/accessibility/view enums).
+- The runtime `@voyantjs/<vertical>` package keeps a `content-shape.ts` that
+  **re-exports** the whole contract surface, so existing
+  `@voyantjs/<vertical>/content-shape` and `@voyantjs/<vertical>` import paths
+  are unchanged.
+- `*-contracts` packages depend on **`zod` only** (plus, at most,
+  `@voyantjs/catalog-contracts`, which is itself zod-only). They never depend
+  on `@voyantjs/db`, `@voyantjs/hono`, `drizzle-orm`, `hono`, or any runtime
+  package.
+
+### What is "pure" (goes in `*-contracts`)
+
+- `*_CONTENT_SCHEMA_VERSION` constants.
+- Content/payload Zod schemas and their `z.infer` types.
+- `validate<Vertical>Content`-style validators (safeParse → tagged result).
+- Pure enum/vocabulary constants used by the schemas (cabin facets, etc.).
+
+### What stays in the runtime package
+
+- Drizzle tables, Hono routes, services, booking engines, catalog-projection
+  policies, content read/refresh paths, adapter shims.
+- The **overlay-merge composition** `mergeOverlaysInto<Vertical>Content`. It
+  composes the catalog overlay applier with the vertical validator and is a
+  read-path concern; keeping it in the runtime lets the contract package stay
+  strictly zod-only and free of any `@voyantjs/catalog*` dependency. (The pure
+  overlay applier itself, `mergeOverlaysIntoContent`, lives in
+  `@voyantjs/catalog-contracts`; the runtime composition is the thin wrapper.)
+
+### Coverage as of this ADR
+
+`catalog`, `cruises`, `accommodations`, `products`, `extras`, and `charters`
+all have a `*-contracts` package. Any new vertical that introduces a
+`<vertical>/v1` content aggregate ships its `*-contracts` package in the same
+change.
+
+## Consequences
+
+### Positive
+
+- **External consumers depend on a small, stable surface.** Connect, adapter
+  authors, and the future Admin SDK import `@voyantjs/<vertical>-contracts`
+  (zod + the schema) instead of the full runtime tree.
+- **One source of truth.** The schema is defined once in the contracts package
+  and re-exported; there is no second copy to drift. (This ADR's rollout also
+  collapsed a duplicated copy of the catalog content primitives.)
+- **Import paths are preserved.** Internal code and existing dependants keep
+  importing from `@voyantjs/<vertical>` unchanged — the runtime re-export
+  stub is API-compatible.
+- **Contract versioning is explicit.** The `<vertical>/v1` constant and schema
+  ship in a package whose version and changelog are about the contract, not
+  the runtime.
+
+### Negative
+
+- **More packages.** Each vertical with a content aggregate is now two packages
+  instead of one. That is more `package.json`/`tsconfig`/`changeset` surface
+  and a slightly larger workspace graph.
+- **A re-export indirection.** Reading a vertical's content shape means hopping
+  from the runtime stub to the contracts package. Mitigated by the stub being
+  a trivial, uniform file.
+- **Two places to look when adding a field.** A new content field is added in
+  the contracts package; if it needs a runtime projection it is wired in the
+  runtime package. The split is deliberate but must be understood.
+
+### Mitigations
+
+- **Uniform recipe.** Every `*-contracts` package is structurally identical
+  (`package.json`, `tsconfig.json`, `vitest.config.ts`, `README.md`,
+  `src/index.ts`, `src/content-shape.ts`, `src/content-shape.test.ts`), so the
+  extraction is mechanical and reviewable. See "How to apply" below.
+- **CI guards the boundary.** `pnpm verify:package-exports` checks the export
+  maps; typecheck across the workspace proves the runtime re-exports stay
+  API-compatible.
+
+## Alternatives considered
+
+### Alternative A: Keep contracts inside runtime packages (status quo ante)
+
+Leave schemas in `@voyantjs/<vertical>` and ask consumers to depend on the
+runtime package. **Rejected** — it forces Connect and adapter authors to pull
+Drizzle/Hono/DB into environments that never run the framework, and makes the
+Admin SDK (#1411) impossible to build without the same bloat.
+
+### Alternative B: One mega `@voyantjs/contracts` package
+
+Put every vertical's contracts in a single package. **Rejected** — it couples
+unrelated verticals into one version/changelog, and a consumer that only needs
+`cruises/v1` would still install `accommodations/v1`, `products/v1`, etc. The
+per-vertical split mirrors the runtime package boundaries consumers already
+reason about.
+
+### Alternative C: Put the overlay-merge composition in the contracts package
+
+Move `mergeOverlaysInto<Vertical>Content` into `*-contracts` too, making the
+contract package depend on `@voyantjs/catalog-contracts`. **Rejected for now**
+— it widens the contract package's dependency beyond zod for a helper that is a
+read-path concern, not a payload contract. The pure overlay applier is already
+available from `@voyantjs/catalog-contracts` for any consumer that wants to
+apply overlays itself. Revisit if an external consumer needs the composed
+helper without the runtime.
+
+## How to apply this decision
+
+When a vertical introduces (or already has) a `<vertical>/v1` content
+aggregate, ship `@voyantjs/<vertical>-contracts` alongside it:
+
+1. Create `packages/<vertical>-contracts/` mirroring any existing
+   `*-contracts` package: `package.json` (zod-only deps, `.` + `./content-shape`
+   exports, `publishConfig`), `tsconfig.json`, `vitest.config.ts`, `README.md`,
+   `src/index.ts` (`export * from "./content-shape.js"`).
+2. Move the **pure** content into `src/content-shape.ts`: the version constant,
+   schemas, types, validator, and any pure facet vocabularies. No
+   `@voyantjs/catalog` import; `zod` only.
+3. Add a `src/content-shape.test.ts` smoke test (version constant + a valid and
+   an invalid payload).
+4. Replace the runtime `packages/<vertical>/src/content-shape.ts` with a
+   re-export stub: re-export the whole surface from
+   `@voyantjs/<vertical>-contracts/content-shape`, keep
+   `mergeOverlaysInto<Vertical>Content` defined locally.
+5. Add `"@voyantjs/<vertical>-contracts": "workspace:*"` to the runtime
+   package's dependencies.
+
+When you are tempted to import a schema from a runtime package into an external
+consumer (Connect, an adapter, a Max tool, the Admin SDK), **stop and import
+from the `*-contracts` package instead.** If the contract you need isn't in a
+`*-contracts` package yet, extracting it is the task — not depending on the
+runtime.

--- a/packages/accommodations-contracts/README.md
+++ b/packages/accommodations-contracts/README.md
@@ -1,0 +1,31 @@
+# @voyantjs/accommodations-contracts
+
+Pure accommodation content contracts for adapter implementers and external
+consumers that need to validate `accommodations/v1` rich content payloads
+without installing the full accommodations runtime package.
+
+Use this package for `ACCOMMODATION_CONTENT_SCHEMA_VERSION`,
+`accommodationContentSchema`, `AccommodationContent`, nested content types, and
+`validateAccommodationContent`. Use `@voyantjs/accommodations` when you also need
+Drizzle schema, routes, services, booking integration, catalog projection, or
+runtime content resolution (including the `mergeOverlaysIntoAccommodationContent`
+overlay composition).
+
+## Install
+
+```bash
+pnpm add @voyantjs/accommodations-contracts zod
+```
+
+## Usage
+
+```ts
+import {
+  ACCOMMODATION_CONTENT_SCHEMA_VERSION,
+  accommodationContentSchema,
+  type AccommodationContent,
+} from "@voyantjs/accommodations-contracts"
+```
+
+Existing `@voyantjs/accommodations/content-shape` imports remain available for
+applications that already depend on the full runtime package.

--- a/packages/accommodations-contracts/package.json
+++ b/packages/accommodations-contracts/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@voyantjs/accommodations-contracts",
+  "version": "0.90.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./content-shape": "./src/content-shape.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check src/",
+    "test": "vitest run --passWithNoTests",
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "prepack": "pnpm run build"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      },
+      "./content-shape": {
+        "types": "./dist/content-shape.d.ts",
+        "import": "./dist/content-shape.js",
+        "default": "./dist/content-shape.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@voyantjs/voyant-typescript-config": "workspace:*",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyantjs/voyant.git",
+    "directory": "packages/accommodations-contracts"
+  }
+}

--- a/packages/accommodations-contracts/src/content-shape.test.ts
+++ b/packages/accommodations-contracts/src/content-shape.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  ACCOMMODATION_CONTENT_SCHEMA_VERSION,
+  type AccommodationContent,
+  accommodationContentSchema,
+  validateAccommodationContent,
+} from "./index.js"
+
+describe("@voyantjs/accommodations-contracts content shape", () => {
+  it("validates the accommodations/v1 rich content payload", () => {
+    const content = accommodationContentSchema.parse({
+      hotel: { id: "hrmt_abc", name: "Hotel Sample", star_rating: 4 },
+      room_types: [{ id: "hrmt_std", name: "Standard Double", max_adults: 2 }],
+      meal_plans: [{ id: "mp_bb", name: "Bed & Breakfast", basis: "bed_breakfast" }],
+      policies: [{ kind: "check_in", body: "Check-in from 14:00." }],
+    }) satisfies AccommodationContent
+
+    expect(ACCOMMODATION_CONTENT_SCHEMA_VERSION).toBe("accommodations/v1")
+    expect(validateAccommodationContent(content)).toMatchObject({ valid: true })
+    expect(content.rate_plans).toEqual([])
+    expect(content.room_types[0]?.amenities).toEqual([])
+  })
+
+  it("defaults rate-plan charge frequency to per_night", () => {
+    const content = accommodationContentSchema.parse({
+      hotel: { id: "hrmt_abc", name: "Hotel Sample" },
+      rate_plans: [{ id: "hrpl_bar", name: "Best Available Rate" }],
+    }) satisfies AccommodationContent
+
+    expect(content.rate_plans[0]?.charge_frequency).toBe("per_night")
+  })
+
+  it("rejects payloads missing the required hotel summary", () => {
+    expect(validateAccommodationContent({ room_types: [] })).toMatchObject({ valid: false })
+    expect(validateAccommodationContent({ hotel: { id: "h" } })).toMatchObject({ valid: false })
+  })
+
+  it("rejects unknown policy kinds", () => {
+    expect(
+      validateAccommodationContent({
+        hotel: { id: "hrmt_abc", name: "Hotel Sample" },
+        policies: [{ kind: "loyalty", body: "x" }],
+      }),
+    ).toMatchObject({ valid: false })
+  })
+})

--- a/packages/accommodations-contracts/src/content-shape.ts
+++ b/packages/accommodations-contracts/src/content-shape.ts
@@ -1,0 +1,135 @@
+/**
+ * Accommodation content shape — the rich detail-page content shape
+ * returned by `getContent` for sourced room types (bedbanks like
+ * Hotelbeds / Expedia, direct-property feeds, hotel groups via Voyant
+ * Connect).
+ *
+ * Per sourced-content §3.6, the accommodation content aggregate is
+ * `{ hotel, room_types[], rate_plans[], meal_plans[], amenities[],
+ * policies[] }` — one payload returned by a single `getContent`.
+ * Pricing stays out (volatile-live, flows through `liveResolve`).
+ *
+ * The aggregate is **per property** — one row per property × locale ×
+ * market — even though the sellable catalog entry is a room type.
+ * That's because bedbanks return whole-property payloads and splitting
+ * by room type would multiply cache writes and refresh work without
+ * benefit. The vertical's read service projects the cached property
+ * payload to the requested room-type detail page.
+ *
+ * This module is the pure content contract: schemas, types, version, and
+ * the validator. The `mergeOverlaysIntoAccommodationContent` overlay
+ * composition stays in the `@voyantjs/accommodations` runtime package.
+ *
+ * See `docs/architecture/catalog-sourced-content.md` §3.2, §3.5.4, §3.6.
+ */
+
+import { z } from "zod"
+
+export const ACCOMMODATION_CONTENT_SCHEMA_VERSION = "accommodations/v1"
+
+export const hotelSummarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  star_rating: z.number().min(0).max(5).nullable().optional(),
+  hero_image_url: z.string().nullable().optional(),
+  highlights: z.array(z.string()).optional(),
+  brand: z.string().nullable().optional(),
+  // Geo / location
+  country: z.string().nullable().optional(),
+  city: z.string().nullable().optional(),
+  address: z.string().nullable().optional(),
+  postal_code: z.string().nullable().optional(),
+  latitude: z.number().nullable().optional(),
+  longitude: z.number().nullable().optional(),
+  // Operational
+  check_in_time: z.string().nullable().optional(),
+  check_out_time: z.string().nullable().optional(),
+})
+
+export const accommodationRoomTypeSchema = z.object({
+  id: z.string(),
+  code: z.string().nullable().optional(),
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  room_class: z.string().nullable().optional(), // e.g. "deluxe", "suite"
+  /** Inside / outside / balcony / suite — bedbank conventions vary. */
+  view: z.string().nullable().optional(),
+  bedrooms: z.number().int().nonnegative().nullable().optional(),
+  beds: z.array(z.string()).optional().default([]),
+  size_sqm: z.number().int().nonnegative().nullable().optional(),
+  max_adults: z.number().int().nonnegative().nullable().optional(),
+  max_children: z.number().int().nonnegative().nullable().optional(),
+  max_occupancy: z.number().int().nonnegative().nullable().optional(),
+  amenities: z.array(z.string()).optional().default([]),
+  images: z.array(z.string()).optional().default([]),
+})
+
+export const accommodationRatePlanSchema = z.object({
+  id: z.string(),
+  code: z.string().nullable().optional(),
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  /** "per_night" | "per_stay" — the plan's charge frequency. */
+  charge_frequency: z.enum(["per_night", "per_stay"]).optional().default("per_night"),
+  /** Room types this plan is bookable on; empty = all. */
+  applies_to_room_type_ids: z.array(z.string()).optional().default([]),
+  cancellation_policy: z.string().nullable().optional(),
+  inclusions: z.array(z.string()).optional().default([]),
+})
+
+export const accommodationMealPlanSchema = z.object({
+  id: z.string(),
+  code: z.string().nullable().optional(),
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  /** "room_only" | "bed_breakfast" | "half_board" | "full_board" | "all_inclusive". */
+  basis: z.string(),
+  inclusions: z.array(z.string()).optional().default([]),
+})
+
+export const accommodationAmenitySchema = z.object({
+  id: z.string(),
+  /** "pool" | "spa" | "wifi" | … */
+  category: z.string().nullable().optional(),
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  is_free: z.boolean().optional(),
+})
+
+export const accommodationPolicySchema = z.object({
+  kind: z.enum(["cancellation", "payment", "supplier_notes", "requirements", "check_in"]),
+  body: z.string(),
+  rules: z.unknown().optional(),
+})
+
+export const accommodationContentSchema = z.object({
+  hotel: hotelSummarySchema,
+  room_types: z.array(accommodationRoomTypeSchema).default([]),
+  rate_plans: z.array(accommodationRatePlanSchema).default([]),
+  meal_plans: z.array(accommodationMealPlanSchema).default([]),
+  amenities: z.array(accommodationAmenitySchema).default([]),
+  policies: z.array(accommodationPolicySchema).default([]),
+})
+
+export type AccommodationContent = z.infer<typeof accommodationContentSchema>
+export type HotelSummary = z.infer<typeof hotelSummarySchema>
+export type AccommodationRoomType = z.infer<typeof accommodationRoomTypeSchema>
+export type AccommodationRatePlan = z.infer<typeof accommodationRatePlanSchema>
+export type AccommodationMealPlan = z.infer<typeof accommodationMealPlanSchema>
+export type AccommodationAmenity = z.infer<typeof accommodationAmenitySchema>
+export type AccommodationPolicy = z.infer<typeof accommodationPolicySchema>
+
+export function validateAccommodationContent(
+  payload: unknown,
+): { valid: true; content: AccommodationContent } | { valid: false; reason: string } {
+  const result = accommodationContentSchema.safeParse(payload)
+  if (result.success) {
+    return { valid: true, content: result.data }
+  }
+  const issue = result.error.issues[0]
+  return {
+    valid: false,
+    reason: issue ? `${issue.path.join(".")}: ${issue.message}` : "validation failed",
+  }
+}

--- a/packages/accommodations-contracts/src/index.ts
+++ b/packages/accommodations-contracts/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./content-shape.js"

--- a/packages/accommodations-contracts/tsconfig.json
+++ b/packages/accommodations-contracts/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@voyantjs/voyant-typescript-config/base.json",
+  "compilerOptions": {
+    "composite": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/accommodations-contracts/vitest.config.ts
+++ b/packages/accommodations-contracts/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+})

--- a/packages/accommodations/package.json
+++ b/packages/accommodations/package.json
@@ -24,6 +24,7 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
+    "@voyantjs/accommodations-contracts": "workspace:*",
     "@voyantjs/bookings": "workspace:*",
     "@voyantjs/catalog": "workspace:*",
     "@voyantjs/db": "workspace:*",

--- a/packages/accommodations/src/content-shape.ts
+++ b/packages/accommodations/src/content-shape.ts
@@ -1,139 +1,32 @@
-/**
- * Accommodation content shape — the rich detail-page content shape
- * returned by `getContent` for sourced room types (bedbanks like
- * Hotelbeds / Expedia, direct-property feeds, hotel groups via Voyant
- * Connect).
- *
- * Per sourced-content §3.6, the accommodation content aggregate is
- * `{ hotel, room_types[], rate_plans[], meal_plans[], amenities[],
- * policies[] }` — one payload returned by a single `getContent`.
- * Pricing stays out (volatile-live, flows through `liveResolve`).
- *
- * The aggregate is **per property** — one row per property × locale ×
- * market — even though the sellable catalog entry is a room type.
- * That's because bedbanks return whole-property payloads and splitting
- * by room type would multiply cache writes and refresh work without
- * benefit. The vertical's read service projects the cached property
- * payload to the requested room-type detail page.
- *
- * See `docs/architecture/catalog-sourced-content.md` §3.2, §3.5.4, §3.6.
- */
-
+import {
+  type AccommodationContent,
+  accommodationContentSchema,
+  validateAccommodationContent,
+} from "@voyantjs/accommodations-contracts/content-shape"
 import {
   type ContentOverlay,
   type MergeOverlaysOptions,
   mergeOverlaysIntoContent,
 } from "@voyantjs/catalog"
-import { z } from "zod"
 
-export const ACCOMMODATION_CONTENT_SCHEMA_VERSION = "accommodations/v1"
-
-export const hotelSummarySchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  description: z.string().nullable().optional(),
-  star_rating: z.number().min(0).max(5).nullable().optional(),
-  hero_image_url: z.string().nullable().optional(),
-  highlights: z.array(z.string()).optional(),
-  brand: z.string().nullable().optional(),
-  // Geo / location
-  country: z.string().nullable().optional(),
-  city: z.string().nullable().optional(),
-  address: z.string().nullable().optional(),
-  postal_code: z.string().nullable().optional(),
-  latitude: z.number().nullable().optional(),
-  longitude: z.number().nullable().optional(),
-  // Operational
-  check_in_time: z.string().nullable().optional(),
-  check_out_time: z.string().nullable().optional(),
-})
-
-export const accommodationRoomTypeSchema = z.object({
-  id: z.string(),
-  code: z.string().nullable().optional(),
-  name: z.string(),
-  description: z.string().nullable().optional(),
-  room_class: z.string().nullable().optional(), // e.g. "deluxe", "suite"
-  /** Inside / outside / balcony / suite — bedbank conventions vary. */
-  view: z.string().nullable().optional(),
-  bedrooms: z.number().int().nonnegative().nullable().optional(),
-  beds: z.array(z.string()).optional().default([]),
-  size_sqm: z.number().int().nonnegative().nullable().optional(),
-  max_adults: z.number().int().nonnegative().nullable().optional(),
-  max_children: z.number().int().nonnegative().nullable().optional(),
-  max_occupancy: z.number().int().nonnegative().nullable().optional(),
-  amenities: z.array(z.string()).optional().default([]),
-  images: z.array(z.string()).optional().default([]),
-})
-
-export const accommodationRatePlanSchema = z.object({
-  id: z.string(),
-  code: z.string().nullable().optional(),
-  name: z.string(),
-  description: z.string().nullable().optional(),
-  /** "per_night" | "per_stay" — the plan's charge frequency. */
-  charge_frequency: z.enum(["per_night", "per_stay"]).optional().default("per_night"),
-  /** Room types this plan is bookable on; empty = all. */
-  applies_to_room_type_ids: z.array(z.string()).optional().default([]),
-  cancellation_policy: z.string().nullable().optional(),
-  inclusions: z.array(z.string()).optional().default([]),
-})
-
-export const accommodationMealPlanSchema = z.object({
-  id: z.string(),
-  code: z.string().nullable().optional(),
-  name: z.string(),
-  description: z.string().nullable().optional(),
-  /** "room_only" | "bed_breakfast" | "half_board" | "full_board" | "all_inclusive". */
-  basis: z.string(),
-  inclusions: z.array(z.string()).optional().default([]),
-})
-
-export const accommodationAmenitySchema = z.object({
-  id: z.string(),
-  /** "pool" | "spa" | "wifi" | … */
-  category: z.string().nullable().optional(),
-  name: z.string(),
-  description: z.string().nullable().optional(),
-  is_free: z.boolean().optional(),
-})
-
-export const accommodationPolicySchema = z.object({
-  kind: z.enum(["cancellation", "payment", "supplier_notes", "requirements", "check_in"]),
-  body: z.string(),
-  rules: z.unknown().optional(),
-})
-
-export const accommodationContentSchema = z.object({
-  hotel: hotelSummarySchema,
-  room_types: z.array(accommodationRoomTypeSchema).default([]),
-  rate_plans: z.array(accommodationRatePlanSchema).default([]),
-  meal_plans: z.array(accommodationMealPlanSchema).default([]),
-  amenities: z.array(accommodationAmenitySchema).default([]),
-  policies: z.array(accommodationPolicySchema).default([]),
-})
-
-export type AccommodationContent = z.infer<typeof accommodationContentSchema>
-export type HotelSummary = z.infer<typeof hotelSummarySchema>
-export type AccommodationRoomType = z.infer<typeof accommodationRoomTypeSchema>
-export type AccommodationRatePlan = z.infer<typeof accommodationRatePlanSchema>
-export type AccommodationMealPlan = z.infer<typeof accommodationMealPlanSchema>
-export type AccommodationAmenity = z.infer<typeof accommodationAmenitySchema>
-export type AccommodationPolicy = z.infer<typeof accommodationPolicySchema>
-
-export function validateAccommodationContent(
-  payload: unknown,
-): { valid: true; content: AccommodationContent } | { valid: false; reason: string } {
-  const result = accommodationContentSchema.safeParse(payload)
-  if (result.success) {
-    return { valid: true, content: result.data }
-  }
-  const issue = result.error.issues[0]
-  return {
-    valid: false,
-    reason: issue ? `${issue.path.join(".")}: ${issue.message}` : "validation failed",
-  }
-}
+export {
+  ACCOMMODATION_CONTENT_SCHEMA_VERSION,
+  type AccommodationAmenity,
+  type AccommodationContent,
+  type AccommodationMealPlan,
+  type AccommodationPolicy,
+  type AccommodationRatePlan,
+  type AccommodationRoomType,
+  accommodationAmenitySchema,
+  accommodationContentSchema,
+  accommodationMealPlanSchema,
+  accommodationPolicySchema,
+  accommodationRatePlanSchema,
+  accommodationRoomTypeSchema,
+  type HotelSummary,
+  hotelSummarySchema,
+  validateAccommodationContent,
+} from "@voyantjs/accommodations-contracts/content-shape"
 
 export function mergeOverlaysIntoAccommodationContent(
   payload: AccommodationContent,

--- a/packages/charters-contracts/README.md
+++ b/packages/charters-contracts/README.md
@@ -1,0 +1,31 @@
+# @voyantjs/charters-contracts
+
+Pure charter content contracts for adapter implementers and external
+consumers that need to validate `charters/v1` rich content payloads
+without installing the full charters runtime package.
+
+Use this package for `CHARTERS_CONTENT_SCHEMA_VERSION`,
+`charterContentSchema`, `CharterContent`, nested content types, and
+`validateCharterContent`. Use `@voyantjs/charters` when you also need
+Drizzle schema, routes, services, booking integration, catalog projection, or
+runtime content resolution (including the `mergeOverlaysIntoCharterContent`
+overlay composition).
+
+## Install
+
+```bash
+pnpm add @voyantjs/charters-contracts zod
+```
+
+## Usage
+
+```ts
+import {
+  CHARTERS_CONTENT_SCHEMA_VERSION,
+  charterContentSchema,
+  type CharterContent,
+} from "@voyantjs/charters-contracts"
+```
+
+Existing `@voyantjs/charters/content-shape` imports remain available for
+applications that already depend on the full runtime package.

--- a/packages/charters-contracts/package.json
+++ b/packages/charters-contracts/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@voyantjs/charters-contracts",
+  "version": "0.90.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./content-shape": "./src/content-shape.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check src/",
+    "test": "vitest run --passWithNoTests",
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "prepack": "pnpm run build"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      },
+      "./content-shape": {
+        "types": "./dist/content-shape.d.ts",
+        "import": "./dist/content-shape.js",
+        "default": "./dist/content-shape.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@voyantjs/voyant-typescript-config": "workspace:*",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyantjs/voyant.git",
+    "directory": "packages/charters-contracts"
+  }
+}

--- a/packages/charters-contracts/src/content-shape.test.ts
+++ b/packages/charters-contracts/src/content-shape.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  CHARTERS_CONTENT_SCHEMA_VERSION,
+  type CharterContent,
+  charterContentSchema,
+  validateCharterContent,
+} from "./index.js"
+
+describe("@voyantjs/charters-contracts content shape", () => {
+  it("validates the charters/v1 rich content payload", () => {
+    const content = charterContentSchema.parse({
+      charter: { id: "chrt_abc", name: "Aegean Escape", duration_nights: 7 },
+      yacht: { name: "MY Serenity", type: "motor", capacity_guests: 12 },
+      voyages: [{ id: "chvy_001", departure_date: "2026-06-01" }],
+      schedule_days: [{ day_number: 1, port_or_anchorage: "Athens" }],
+      policies: [{ kind: "apa", body: "APA is 30% of charter fee." }],
+    }) satisfies CharterContent
+
+    expect(CHARTERS_CONTENT_SCHEMA_VERSION).toBe("charters/v1")
+    expect(validateCharterContent(content)).toMatchObject({ valid: true })
+    expect(content.suites).toEqual([])
+    expect(content.yacht?.amenities).toEqual([])
+  })
+
+  it("defaults schedule-day is_at_sea to false", () => {
+    const content = charterContentSchema.parse({
+      charter: { id: "chrt_abc", name: "Aegean Escape" },
+      schedule_days: [{ day_number: 2 }],
+    }) satisfies CharterContent
+
+    expect(content.schedule_days[0]?.is_at_sea).toBe(false)
+  })
+
+  it("rejects payloads missing the required charter summary", () => {
+    expect(validateCharterContent({ voyages: [] })).toMatchObject({ valid: false })
+    expect(validateCharterContent({ charter: { id: "c" } })).toMatchObject({ valid: false })
+  })
+
+  it("rejects unknown policy kinds", () => {
+    expect(
+      validateCharterContent({
+        charter: { id: "chrt_abc", name: "Aegean Escape" },
+        policies: [{ kind: "loyalty", body: "x" }],
+      }),
+    ).toMatchObject({ valid: false })
+  })
+})

--- a/packages/charters-contracts/src/content-shape.ts
+++ b/packages/charters-contracts/src/content-shape.ts
@@ -1,0 +1,124 @@
+/**
+ * Charters content shape — the rich detail-page content shape returned
+ * by `getContent` for sourced charter products.
+ *
+ * The charters content aggregate is `{ charter, yacht, voyages[],
+ * suites[], schedule_days[], policies[] }` — one payload returned by a
+ * single `getContent`. Pricing stays out (volatile-live, flows through
+ * `liveResolve`). Voyages here carry departure dates and structural
+ * info; their fares come through `liveResolve`.
+ *
+ * Charters' MYBA-style products often include APA (Advance
+ * Provisioning Allowance) terms in the policy block — captured under
+ * `policies[].kind: "supplier_notes"` or a structured rule shape. The
+ * synthesizer flattens what the projection knows.
+ *
+ * This module is the pure content contract: schemas, types, version, and
+ * the validator. The `mergeOverlaysIntoCharterContent` overlay
+ * composition stays in the `@voyantjs/charters` runtime package.
+ *
+ * See `docs/architecture/catalog-sourced-content.md` §3.2, §3.5.4, §3.6.
+ */
+
+import { z } from "zod"
+
+export const CHARTERS_CONTENT_SCHEMA_VERSION = "charters/v1"
+
+export const charterSummarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  status: z.string().optional(),
+  description: z.string().nullable().optional(),
+  charter_type: z.string().nullable().optional(), // "per_suite" | "whole_yacht"
+  hero_image_url: z.string().nullable().optional(),
+  highlights: z.array(z.string()).optional(),
+  cruising_area: z.string().nullable().optional(),
+  base_port: z.string().nullable().optional(),
+  duration_nights: z.number().int().nonnegative().nullable().optional(),
+})
+
+export const charterYachtSchema = z.object({
+  id: z.string().nullable().optional(),
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  type: z.string().nullable().optional(), // motor / sail / catamaran
+  length_meters: z.number().nullable().optional(),
+  beam_meters: z.number().nullable().optional(),
+  capacity_guests: z.number().int().nonnegative().nullable().optional(),
+  capacity_crew: z.number().int().nonnegative().nullable().optional(),
+  cabins: z.number().int().nonnegative().nullable().optional(),
+  year_built: z.number().int().nonnegative().nullable().optional(),
+  builder: z.string().nullable().optional(),
+  flag: z.string().nullable().optional(),
+  amenities: z.array(z.string()).optional().default([]),
+  images: z.array(z.string()).optional().default([]),
+})
+
+export const charterVoyageSchema = z.object({
+  id: z.string(),
+  source_ref: z.string().nullable().optional(),
+  departure_date: z.string(),
+  return_date: z.string().nullable().optional(),
+  duration_nights: z.number().int().nonnegative().nullable().optional(),
+  status: z.string().nullable().optional(), // "open" | "on_request" | "sold_out"
+  embarkation_port: z.string().nullable().optional(),
+  disembarkation_port: z.string().nullable().optional(),
+  /** Whole-yacht voyages set this to false; per-suite voyages set true. */
+  per_suite_bookable: z.boolean().optional(),
+})
+
+export const charterSuiteSchema = z.object({
+  id: z.string(),
+  code: z.string().nullable().optional(),
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  category: z.string().nullable().optional(), // "owner" | "vip" | "guest"
+  capacity: z.number().int().nonnegative().nullable().optional(),
+  has_balcony: z.boolean().optional(),
+  size_sqm: z.number().int().nonnegative().nullable().optional(),
+})
+
+export const charterScheduleDaySchema = z.object({
+  day_number: z.number().int().positive(),
+  date: z.string().nullable().optional(),
+  port_or_anchorage: z.string().nullable().optional(),
+  description: z.string().nullable().optional(),
+  is_at_sea: z.boolean().optional().default(false),
+})
+
+export const charterPolicySchema = z.object({
+  kind: z.enum(["cancellation", "payment", "supplier_notes", "requirements", "apa"]),
+  body: z.string(),
+  rules: z.unknown().optional(),
+})
+
+export const charterContentSchema = z.object({
+  charter: charterSummarySchema,
+  yacht: charterYachtSchema.nullable().optional(),
+  voyages: z.array(charterVoyageSchema).default([]),
+  suites: z.array(charterSuiteSchema).default([]),
+  schedule_days: z.array(charterScheduleDaySchema).default([]),
+  policies: z.array(charterPolicySchema).default([]),
+})
+
+export type CharterContent = z.infer<typeof charterContentSchema>
+export type CharterSummary = z.infer<typeof charterSummarySchema>
+export type CharterYachtContent = z.infer<typeof charterYachtSchema>
+export type CharterVoyageContent = z.infer<typeof charterVoyageSchema>
+export type CharterSuiteContent = z.infer<typeof charterSuiteSchema>
+export type CharterScheduleDay = z.infer<typeof charterScheduleDaySchema>
+export type CharterPolicy = z.infer<typeof charterPolicySchema>
+
+export function validateCharterContent(
+  payload: unknown,
+): { valid: true; content: CharterContent } | { valid: false; reason: string } {
+  const result = charterContentSchema.safeParse(payload)
+  if (result.success) {
+    return { valid: true, content: result.data }
+  }
+  const issue = result.error.issues[0]
+  return {
+    valid: false,
+    reason: issue ? `${issue.path.join(".")}: ${issue.message}` : "validation failed",
+  }
+}

--- a/packages/charters-contracts/src/index.ts
+++ b/packages/charters-contracts/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./content-shape.js"

--- a/packages/charters-contracts/tsconfig.json
+++ b/packages/charters-contracts/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@voyantjs/voyant-typescript-config/base.json",
+  "compilerOptions": {
+    "composite": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/charters-contracts/vitest.config.ts
+++ b/packages/charters-contracts/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+})

--- a/packages/charters/package.json
+++ b/packages/charters/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@voyantjs/bookings": "workspace:*",
+    "@voyantjs/charters-contracts": "workspace:*",
     "@voyantjs/core": "workspace:*",
     "@voyantjs/db": "workspace:*",
     "@voyantjs/hono": "workspace:*",

--- a/packages/charters/src/content-shape.ts
+++ b/packages/charters/src/content-shape.ts
@@ -1,128 +1,32 @@
-/**
- * Charters content shape — the rich detail-page content shape returned
- * by `getContent` for sourced charter products.
- *
- * The charters content aggregate is `{ charter, yacht, voyages[],
- * suites[], schedule_days[], policies[] }` — one payload returned by a
- * single `getContent`. Pricing stays out (volatile-live, flows through
- * `liveResolve`). Voyages here carry departure dates and structural
- * info; their fares come through `liveResolve`.
- *
- * Charters' MYBA-style products often include APA (Advance
- * Provisioning Allowance) terms in the policy block — captured under
- * `policies[].kind: "supplier_notes"` or a structured rule shape. The
- * synthesizer flattens what the projection knows.
- *
- * See `docs/architecture/catalog-sourced-content.md` §3.2, §3.5.4, §3.6.
- */
-
 import {
   type ContentOverlay,
   type MergeOverlaysOptions,
   mergeOverlaysIntoContent,
 } from "@voyantjs/catalog"
-import { z } from "zod"
+import {
+  type CharterContent,
+  charterContentSchema,
+  validateCharterContent,
+} from "@voyantjs/charters-contracts/content-shape"
 
-export const CHARTERS_CONTENT_SCHEMA_VERSION = "charters/v1"
-
-export const charterSummarySchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  status: z.string().optional(),
-  description: z.string().nullable().optional(),
-  charter_type: z.string().nullable().optional(), // "per_suite" | "whole_yacht"
-  hero_image_url: z.string().nullable().optional(),
-  highlights: z.array(z.string()).optional(),
-  cruising_area: z.string().nullable().optional(),
-  base_port: z.string().nullable().optional(),
-  duration_nights: z.number().int().nonnegative().nullable().optional(),
-})
-
-export const charterYachtSchema = z.object({
-  id: z.string().nullable().optional(),
-  name: z.string(),
-  description: z.string().nullable().optional(),
-  type: z.string().nullable().optional(), // motor / sail / catamaran
-  length_meters: z.number().nullable().optional(),
-  beam_meters: z.number().nullable().optional(),
-  capacity_guests: z.number().int().nonnegative().nullable().optional(),
-  capacity_crew: z.number().int().nonnegative().nullable().optional(),
-  cabins: z.number().int().nonnegative().nullable().optional(),
-  year_built: z.number().int().nonnegative().nullable().optional(),
-  builder: z.string().nullable().optional(),
-  flag: z.string().nullable().optional(),
-  amenities: z.array(z.string()).optional().default([]),
-  images: z.array(z.string()).optional().default([]),
-})
-
-export const charterVoyageSchema = z.object({
-  id: z.string(),
-  source_ref: z.string().nullable().optional(),
-  departure_date: z.string(),
-  return_date: z.string().nullable().optional(),
-  duration_nights: z.number().int().nonnegative().nullable().optional(),
-  status: z.string().nullable().optional(), // "open" | "on_request" | "sold_out"
-  embarkation_port: z.string().nullable().optional(),
-  disembarkation_port: z.string().nullable().optional(),
-  /** Whole-yacht voyages set this to false; per-suite voyages set true. */
-  per_suite_bookable: z.boolean().optional(),
-})
-
-export const charterSuiteSchema = z.object({
-  id: z.string(),
-  code: z.string().nullable().optional(),
-  name: z.string(),
-  description: z.string().nullable().optional(),
-  category: z.string().nullable().optional(), // "owner" | "vip" | "guest"
-  capacity: z.number().int().nonnegative().nullable().optional(),
-  has_balcony: z.boolean().optional(),
-  size_sqm: z.number().int().nonnegative().nullable().optional(),
-})
-
-export const charterScheduleDaySchema = z.object({
-  day_number: z.number().int().positive(),
-  date: z.string().nullable().optional(),
-  port_or_anchorage: z.string().nullable().optional(),
-  description: z.string().nullable().optional(),
-  is_at_sea: z.boolean().optional().default(false),
-})
-
-export const charterPolicySchema = z.object({
-  kind: z.enum(["cancellation", "payment", "supplier_notes", "requirements", "apa"]),
-  body: z.string(),
-  rules: z.unknown().optional(),
-})
-
-export const charterContentSchema = z.object({
-  charter: charterSummarySchema,
-  yacht: charterYachtSchema.nullable().optional(),
-  voyages: z.array(charterVoyageSchema).default([]),
-  suites: z.array(charterSuiteSchema).default([]),
-  schedule_days: z.array(charterScheduleDaySchema).default([]),
-  policies: z.array(charterPolicySchema).default([]),
-})
-
-export type CharterContent = z.infer<typeof charterContentSchema>
-export type CharterSummary = z.infer<typeof charterSummarySchema>
-export type CharterYachtContent = z.infer<typeof charterYachtSchema>
-export type CharterVoyageContent = z.infer<typeof charterVoyageSchema>
-export type CharterSuiteContent = z.infer<typeof charterSuiteSchema>
-export type CharterScheduleDay = z.infer<typeof charterScheduleDaySchema>
-export type CharterPolicy = z.infer<typeof charterPolicySchema>
-
-export function validateCharterContent(
-  payload: unknown,
-): { valid: true; content: CharterContent } | { valid: false; reason: string } {
-  const result = charterContentSchema.safeParse(payload)
-  if (result.success) {
-    return { valid: true, content: result.data }
-  }
-  const issue = result.error.issues[0]
-  return {
-    valid: false,
-    reason: issue ? `${issue.path.join(".")}: ${issue.message}` : "validation failed",
-  }
-}
+export {
+  CHARTERS_CONTENT_SCHEMA_VERSION,
+  type CharterContent,
+  type CharterPolicy,
+  type CharterScheduleDay,
+  type CharterSuiteContent,
+  type CharterSummary,
+  type CharterVoyageContent,
+  type CharterYachtContent,
+  charterContentSchema,
+  charterPolicySchema,
+  charterScheduleDaySchema,
+  charterSuiteSchema,
+  charterSummarySchema,
+  charterVoyageSchema,
+  charterYachtSchema,
+  validateCharterContent,
+} from "@voyantjs/charters-contracts/content-shape"
 
 export function mergeOverlaysIntoCharterContent(
   payload: CharterContent,

--- a/packages/extras-contracts/README.md
+++ b/packages/extras-contracts/README.md
@@ -1,0 +1,30 @@
+# @voyantjs/extras-contracts
+
+Pure extras content contracts for adapter implementers and external consumers
+that need to validate `extras/v1` rich content payloads without installing the
+full extras runtime package.
+
+Use this package for `EXTRAS_CONTENT_SCHEMA_VERSION`, `extraContentSchema`,
+`ExtraContent`, nested content types, and `validateExtraContent`. Use
+`@voyantjs/extras` when you also need Drizzle schema, routes, services, booking
+integration, catalog projection, or runtime content resolution (including the
+`mergeOverlaysIntoExtraContent` overlay composition).
+
+## Install
+
+```bash
+pnpm add @voyantjs/extras-contracts zod
+```
+
+## Usage
+
+```ts
+import {
+  EXTRAS_CONTENT_SCHEMA_VERSION,
+  extraContentSchema,
+  type ExtraContent,
+} from "@voyantjs/extras-contracts"
+```
+
+Existing `@voyantjs/extras/content-shape` imports remain available for
+applications that already depend on the full runtime package.

--- a/packages/extras-contracts/package.json
+++ b/packages/extras-contracts/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@voyantjs/extras-contracts",
+  "version": "0.90.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./content-shape": "./src/content-shape.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check src/",
+    "test": "vitest run --passWithNoTests",
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "prepack": "pnpm run build"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      },
+      "./content-shape": {
+        "types": "./dist/content-shape.d.ts",
+        "import": "./dist/content-shape.js",
+        "default": "./dist/content-shape.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@voyantjs/voyant-typescript-config": "workspace:*",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyantjs/voyant.git",
+    "directory": "packages/extras-contracts"
+  }
+}

--- a/packages/extras-contracts/src/content-shape.test.ts
+++ b/packages/extras-contracts/src/content-shape.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  EXTRAS_CONTENT_SCHEMA_VERSION,
+  type ExtraContent,
+  extraContentSchema,
+  validateExtraContent,
+} from "./index.js"
+
+describe("@voyantjs/extras-contracts content shape", () => {
+  it("validates the extras/v1 rich content payload", () => {
+    const content = extraContentSchema.parse({
+      extra: { id: "prx_abc", name: "Airport Transfer", category: "transfer" },
+      options: [{ id: "opt_private", name: "Private Vehicle" }],
+      media: [{ url: "https://cdn.example.com/transfer.jpg" }],
+      policies: [{ kind: "cancellation", body: "Free up to 24h before." }],
+    }) satisfies ExtraContent
+
+    expect(EXTRAS_CONTENT_SCHEMA_VERSION).toBe("extras/v1")
+    expect(validateExtraContent(content)).toMatchObject({ valid: true })
+    expect(content.options).toHaveLength(1)
+    expect(content.media[0]?.type).toBe("image")
+  })
+
+  it("defaults the options, media, and policies arrays to empty", () => {
+    const content = extraContentSchema.parse({
+      extra: { id: "prx_abc", name: "Spa Day Pass" },
+    }) satisfies ExtraContent
+
+    expect(content.options).toEqual([])
+    expect(content.media).toEqual([])
+    expect(content.policies).toEqual([])
+  })
+
+  it("rejects payloads missing the required extra summary", () => {
+    expect(validateExtraContent({ options: [] })).toMatchObject({ valid: false })
+    expect(validateExtraContent({ extra: { id: "x" } })).toMatchObject({ valid: false })
+  })
+
+  it("rejects unknown policy kinds and media types", () => {
+    expect(
+      validateExtraContent({
+        extra: { id: "prx_abc", name: "Airport Transfer" },
+        policies: [{ kind: "loyalty", body: "x" }],
+      }),
+    ).toMatchObject({ valid: false })
+    expect(
+      validateExtraContent({
+        extra: { id: "prx_abc", name: "Airport Transfer" },
+        media: [{ url: "https://cdn.example.com/x.bin", type: "audio" }],
+      }),
+    ).toMatchObject({ valid: false })
+  })
+})

--- a/packages/extras-contracts/src/content-shape.ts
+++ b/packages/extras-contracts/src/content-shape.ts
@@ -1,0 +1,107 @@
+/**
+ * Extras content shape — the rich detail-page content shape returned
+ * by `getContent` for sourced extras (excursions, transfers, add-on
+ * services).
+ *
+ * The extras content aggregate is `{ extra, options[], media[],
+ * policies[] }` — one payload returned by a single `getContent`.
+ * Pricing stays out (volatile-live, flows through `liveResolve`).
+ *
+ * Extras are simpler than the other verticals because they're add-ons,
+ * not standalone products. There's no day-by-day itinerary, no
+ * room-type / cabin-category map, no ship spec — just an extra
+ * description, optional sub-options (e.g. "half-day vs full-day"),
+ * media, and the operational/cancellation policies.
+ *
+ * This module is the pure content contract: schemas, types, version, and
+ * the validator. The `mergeOverlaysIntoExtraContent` overlay composition
+ * stays in the `@voyantjs/extras` runtime package.
+ *
+ * See `docs/architecture/catalog-sourced-content.md` §3.2, §3.5.4, §3.6.
+ */
+
+import { z } from "zod"
+
+export const EXTRAS_CONTENT_SCHEMA_VERSION = "extras/v1"
+
+export const extraSummarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  status: z.string().optional(),
+  description: z.string().nullable().optional(),
+  /**
+   * Selection type — mirrors the owned `extra_selection_type` enum:
+   * "optional" | "required" | "default_selected" | "unavailable".
+   * Sourced adapters set what they support; thin synthesis defaults to
+   * "optional".
+   */
+  selection_type: z.string().optional(),
+  /**
+   * Pricing mode — mirrors the owned `extra_pricing_mode` enum:
+   * "included" | "per_person" | "per_booking" | "quantity_based" |
+   * "on_request" | "free". Captures the structural pricing model the
+   * upstream advertises; actual prices come through `liveResolve`.
+   */
+  pricing_mode: z.string().optional(),
+  /** Hint — true when the extra is priced per traveler, not per booking. */
+  priced_per_person: z.boolean().optional(),
+  /** Service category (e.g. "transfer", "excursion", "insurance", "spa"). */
+  category: z.string().nullable().optional(),
+  /** Hero media URL. */
+  hero_image_url: z.string().nullable().optional(),
+  highlights: z.array(z.string()).optional(),
+  /** Free-form supplier hint surfaced to ops (not customer-facing). */
+  supplier: z.string().nullable().optional(),
+  /** Estimated duration in minutes for time-bound extras (excursions). */
+  duration_minutes: z.number().int().nonnegative().nullable().optional(),
+  /** Constraints / requirements summary surfaced on the booking flow. */
+  requirements_summary: z.string().nullable().optional(),
+})
+
+export const extraOptionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  /** Whether this option auto-selects when the extra is selected. */
+  default_selected: z.boolean().optional(),
+})
+
+export const extraMediaItemSchema = z.object({
+  url: z.string(),
+  type: z.enum(["image", "video", "document"]).default("image"),
+  caption: z.string().nullable().optional(),
+  alt: z.string().nullable().optional(),
+})
+
+export const extraPolicySchema = z.object({
+  kind: z.enum(["cancellation", "payment", "supplier_notes", "requirements"]),
+  body: z.string(),
+  rules: z.unknown().optional(),
+})
+
+export const extraContentSchema = z.object({
+  extra: extraSummarySchema,
+  options: z.array(extraOptionSchema).default([]),
+  media: z.array(extraMediaItemSchema).default([]),
+  policies: z.array(extraPolicySchema).default([]),
+})
+
+export type ExtraContent = z.infer<typeof extraContentSchema>
+export type ExtraSummary = z.infer<typeof extraSummarySchema>
+export type ExtraOption = z.infer<typeof extraOptionSchema>
+export type ExtraMediaItem = z.infer<typeof extraMediaItemSchema>
+export type ExtraPolicy = z.infer<typeof extraPolicySchema>
+
+export function validateExtraContent(
+  payload: unknown,
+): { valid: true; content: ExtraContent } | { valid: false; reason: string } {
+  const result = extraContentSchema.safeParse(payload)
+  if (result.success) {
+    return { valid: true, content: result.data }
+  }
+  const issue = result.error.issues[0]
+  return {
+    valid: false,
+    reason: issue ? `${issue.path.join(".")}: ${issue.message}` : "validation failed",
+  }
+}

--- a/packages/extras-contracts/src/index.ts
+++ b/packages/extras-contracts/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./content-shape.js"

--- a/packages/extras-contracts/tsconfig.json
+++ b/packages/extras-contracts/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@voyantjs/voyant-typescript-config/base.json",
+  "compilerOptions": {
+    "composite": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/extras-contracts/vitest.config.ts
+++ b/packages/extras-contracts/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+})

--- a/packages/extras/package.json
+++ b/packages/extras/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@voyantjs/core": "workspace:*",
     "@voyantjs/db": "workspace:*",
+    "@voyantjs/extras-contracts": "workspace:*",
     "@voyantjs/hono": "workspace:*",
     "@voyantjs/catalog": "workspace:*",
     "drizzle-orm": "^0.45.2",

--- a/packages/extras/src/content-shape.ts
+++ b/packages/extras/src/content-shape.ts
@@ -1,111 +1,28 @@
-/**
- * Extras content shape — the rich detail-page content shape returned
- * by `getContent` for sourced extras (excursions, transfers, add-on
- * services).
- *
- * The extras content aggregate is `{ extra, options[], media[],
- * policies[] }` — one payload returned by a single `getContent`.
- * Pricing stays out (volatile-live, flows through `liveResolve`).
- *
- * Extras are simpler than the other verticals because they're add-ons,
- * not standalone products. There's no day-by-day itinerary, no
- * room-type / cabin-category map, no ship spec — just an extra
- * description, optional sub-options (e.g. "half-day vs full-day"),
- * media, and the operational/cancellation policies.
- *
- * See `docs/architecture/catalog-sourced-content.md` §3.2, §3.5.4, §3.6.
- */
-
 import {
   type ContentOverlay,
   type MergeOverlaysOptions,
   mergeOverlaysIntoContent,
 } from "@voyantjs/catalog"
-import { z } from "zod"
+import {
+  type ExtraContent,
+  extraContentSchema,
+  validateExtraContent,
+} from "@voyantjs/extras-contracts/content-shape"
 
-export const EXTRAS_CONTENT_SCHEMA_VERSION = "extras/v1"
-
-export const extraSummarySchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  status: z.string().optional(),
-  description: z.string().nullable().optional(),
-  /**
-   * Selection type — mirrors the owned `extra_selection_type` enum:
-   * "optional" | "required" | "default_selected" | "unavailable".
-   * Sourced adapters set what they support; thin synthesis defaults to
-   * "optional".
-   */
-  selection_type: z.string().optional(),
-  /**
-   * Pricing mode — mirrors the owned `extra_pricing_mode` enum:
-   * "included" | "per_person" | "per_booking" | "quantity_based" |
-   * "on_request" | "free". Captures the structural pricing model the
-   * upstream advertises; actual prices come through `liveResolve`.
-   */
-  pricing_mode: z.string().optional(),
-  /** Hint — true when the extra is priced per traveler, not per booking. */
-  priced_per_person: z.boolean().optional(),
-  /** Service category (e.g. "transfer", "excursion", "insurance", "spa"). */
-  category: z.string().nullable().optional(),
-  /** Hero media URL. */
-  hero_image_url: z.string().nullable().optional(),
-  highlights: z.array(z.string()).optional(),
-  /** Free-form supplier hint surfaced to ops (not customer-facing). */
-  supplier: z.string().nullable().optional(),
-  /** Estimated duration in minutes for time-bound extras (excursions). */
-  duration_minutes: z.number().int().nonnegative().nullable().optional(),
-  /** Constraints / requirements summary surfaced on the booking flow. */
-  requirements_summary: z.string().nullable().optional(),
-})
-
-export const extraOptionSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  description: z.string().nullable().optional(),
-  /** Whether this option auto-selects when the extra is selected. */
-  default_selected: z.boolean().optional(),
-})
-
-export const extraMediaItemSchema = z.object({
-  url: z.string(),
-  type: z.enum(["image", "video", "document"]).default("image"),
-  caption: z.string().nullable().optional(),
-  alt: z.string().nullable().optional(),
-})
-
-export const extraPolicySchema = z.object({
-  kind: z.enum(["cancellation", "payment", "supplier_notes", "requirements"]),
-  body: z.string(),
-  rules: z.unknown().optional(),
-})
-
-export const extraContentSchema = z.object({
-  extra: extraSummarySchema,
-  options: z.array(extraOptionSchema).default([]),
-  media: z.array(extraMediaItemSchema).default([]),
-  policies: z.array(extraPolicySchema).default([]),
-})
-
-export type ExtraContent = z.infer<typeof extraContentSchema>
-export type ExtraSummary = z.infer<typeof extraSummarySchema>
-export type ExtraOption = z.infer<typeof extraOptionSchema>
-export type ExtraMediaItem = z.infer<typeof extraMediaItemSchema>
-export type ExtraPolicy = z.infer<typeof extraPolicySchema>
-
-export function validateExtraContent(
-  payload: unknown,
-): { valid: true; content: ExtraContent } | { valid: false; reason: string } {
-  const result = extraContentSchema.safeParse(payload)
-  if (result.success) {
-    return { valid: true, content: result.data }
-  }
-  const issue = result.error.issues[0]
-  return {
-    valid: false,
-    reason: issue ? `${issue.path.join(".")}: ${issue.message}` : "validation failed",
-  }
-}
+export {
+  EXTRAS_CONTENT_SCHEMA_VERSION,
+  type ExtraContent,
+  type ExtraMediaItem,
+  type ExtraOption,
+  type ExtraPolicy,
+  type ExtraSummary,
+  extraContentSchema,
+  extraMediaItemSchema,
+  extraOptionSchema,
+  extraPolicySchema,
+  extraSummarySchema,
+  validateExtraContent,
+} from "@voyantjs/extras-contracts/content-shape"
 
 export function mergeOverlaysIntoExtraContent(
   payload: ExtraContent,

--- a/packages/products-contracts/README.md
+++ b/packages/products-contracts/README.md
@@ -1,0 +1,31 @@
+# @voyantjs/products-contracts
+
+Pure product content contracts for adapter implementers and external
+consumers that need to validate `products/v1` rich content payloads
+without installing the full products runtime package.
+
+Use this package for `PRODUCTS_CONTENT_SCHEMA_VERSION`,
+`productContentSchema`, `ProductContent`, nested content types, and
+`validateProductContent`. Use `@voyantjs/products` when you also need
+Drizzle schema, routes, services, booking integration, catalog projection, or
+runtime content resolution (including the `mergeOverlaysIntoProductContent`
+overlay composition).
+
+## Install
+
+```bash
+pnpm add @voyantjs/products-contracts zod
+```
+
+## Usage
+
+```ts
+import {
+  PRODUCTS_CONTENT_SCHEMA_VERSION,
+  productContentSchema,
+  type ProductContent,
+} from "@voyantjs/products-contracts"
+```
+
+Existing `@voyantjs/products/content-shape` imports remain available for
+applications that already depend on the full runtime package.

--- a/packages/products-contracts/package.json
+++ b/packages/products-contracts/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@voyantjs/products-contracts",
+  "version": "0.90.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./content-shape": "./src/content-shape.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check src/",
+    "test": "vitest run --passWithNoTests",
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "prepack": "pnpm run build"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      },
+      "./content-shape": {
+        "types": "./dist/content-shape.d.ts",
+        "import": "./dist/content-shape.js",
+        "default": "./dist/content-shape.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@voyantjs/voyant-typescript-config": "workspace:*",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyantjs/voyant.git",
+    "directory": "packages/products-contracts"
+  }
+}

--- a/packages/products-contracts/src/content-shape.test.ts
+++ b/packages/products-contracts/src/content-shape.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  PRODUCTS_CONTENT_SCHEMA_VERSION,
+  type ProductContent,
+  productContentSchema,
+  validateProductContent,
+} from "./index.js"
+
+describe("@voyantjs/products-contracts content shape", () => {
+  it("validates the products/v1 rich content payload", () => {
+    const content = productContentSchema.parse({
+      product: { id: "prod_abc", name: "Sahara Desert Trek" },
+      options: [{ id: "opt_std", name: "Standard Departure" }],
+      days: [{ day_number: 1, title: "Arrival in Marrakech" }],
+      policies: [{ kind: "cancellation", body: "Free cancellation up to 30 days." }],
+    }) satisfies ProductContent
+
+    expect(PRODUCTS_CONTENT_SCHEMA_VERSION).toBe("products/v1")
+    expect(validateProductContent(content)).toMatchObject({ valid: true })
+    expect(content.media).toEqual([])
+    expect(content.departures).toEqual([])
+    expect(content.options[0]?.units).toEqual([])
+  })
+
+  it("defaults a media item type to image", () => {
+    const content = productContentSchema.parse({
+      product: { id: "prod_abc", name: "Sahara Desert Trek" },
+      media: [{ url: "https://cdn.example.com/hero.jpg" }],
+    }) satisfies ProductContent
+
+    expect(content.media[0]?.type).toBe("image")
+  })
+
+  it("rejects payloads missing the required product summary", () => {
+    expect(validateProductContent({ options: [] })).toMatchObject({ valid: false })
+    expect(validateProductContent({ product: { name: "No id" } })).toMatchObject({ valid: false })
+  })
+
+  it("rejects unknown policy kinds", () => {
+    expect(
+      validateProductContent({
+        product: { id: "prod_abc", name: "Sahara Desert Trek" },
+        policies: [{ kind: "loyalty", body: "x" }],
+      }),
+    ).toMatchObject({ valid: false })
+  })
+})

--- a/packages/products-contracts/src/content-shape.ts
+++ b/packages/products-contracts/src/content-shape.ts
@@ -1,0 +1,161 @@
+/**
+ * Products content shape — the rich detail-page content shape returned
+ * by `getContent` and stored in `products_sourced_content.payload`.
+ *
+ * Schema versions are managed by this module: the constant
+ * `PRODUCTS_CONTENT_SCHEMA_VERSION` stamps every cache write; reads
+ * skip rows with an unrecognized version (treated as cache miss). Bump
+ * the version when the shape changes; old cache rows are then evicted
+ * by a single `DELETE WHERE content_schema_version != current`.
+ *
+ * This module is the pure content contract: schemas, types, version, and
+ * the validator. The `mergeOverlaysIntoProductContent` overlay
+ * composition stays in the `@voyantjs/products` runtime package.
+ *
+ * See `docs/architecture/catalog-sourced-content.md` §3.2, §3.5.4, §3.6.
+ */
+
+import { z } from "zod"
+
+/**
+ * The current content-schema version. Stamped on every cache write.
+ * Bump when the `productContentSchema` shape changes incompatibly.
+ */
+export const PRODUCTS_CONTENT_SCHEMA_VERSION = "products/v1"
+
+/**
+ * Top-level product summary fields. Maps loosely to the owned `products`
+ * table — the read service synthesizes from indexed projection + overlay
+ * for thin adapters, or stores adapter-served data for rich ones.
+ */
+export const productSummarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  status: z.string().optional(),
+  description: z.string().nullable().optional(),
+  inclusions_html: z.string().nullable().optional(),
+  exclusions_html: z.string().nullable().optional(),
+  terms_html: z.string().nullable().optional(),
+  contract_template_id: z.string().nullable().optional(),
+  contractTemplateId: z.string().nullable().optional(),
+  highlights: z.array(z.string()).optional(),
+  hero_image_url: z.string().nullable().optional(),
+  duration_days: z.number().int().nonnegative().nullable().optional(),
+  start_date: z.string().nullable().optional(),
+  end_date: z.string().nullable().optional(),
+  sell_currency: z.string().nullable().optional(),
+  supplier: z.string().nullable().optional(),
+  country: z.string().nullable().optional(),
+  departure_city: z.string().nullable().optional(),
+  tags: z.array(z.string()).optional(),
+})
+
+export const productMediaItemSchema = z.object({
+  url: z.string(),
+  type: z.enum(["image", "video", "document"]).default("image"),
+  caption: z.string().nullable().optional(),
+  alt: z.string().nullable().optional(),
+})
+
+export const productOptionUnitSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  label: z.string().optional(),
+  description: z.string().nullable().optional(),
+  capacity: z.number().int().nonnegative().nullable().optional(),
+})
+
+export const productOptionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  units: z.array(productOptionUnitSchema).optional().default([]),
+  inclusions: z.array(z.string()).optional().default([]),
+})
+
+export const productDaySchema = z.object({
+  day_number: z.number().int().positive(),
+  title: z.string().nullable().optional(),
+  description: z.string().nullable().optional(),
+  location: z.string().nullable().optional(),
+  /** Day-level hero image (catalog detail sheet thumbnail). */
+  hero_image_url: z.string().nullable().optional(),
+  services: z.array(z.string()).optional().default([]),
+})
+
+export const productPolicySchema = z.object({
+  kind: z.enum(["cancellation", "payment", "supplier_notes", "requirements"]),
+  body: z.string(),
+  /** Optional structured rules — vertical-specific. */
+  rules: z.unknown().optional(),
+})
+
+/**
+ * A single bookable departure / time slot — the "when" surface of the
+ * product. ISO 8601 timestamps for `starts_at` / `ends_at` so locale
+ * formatting happens at render time, never in the cache.
+ *
+ * Owned products derive these from `availability_slots`; sourced
+ * adapters return them via `getContent`. Empty array = "always-on"
+ * product (e.g. an evergreen transfer service) or one whose schedule
+ * is on-request.
+ */
+export const productDepartureSchema = z.object({
+  id: z.string(),
+  starts_at: z.string(),
+  ends_at: z.string().nullable().optional(),
+  /** "open" | "limited" | "sold_out" | "closed" | "on_request" — display only. */
+  status: z.string().nullable().optional(),
+  /** Total capacity for the slot, when known. */
+  capacity: z.number().int().nonnegative().nullable().optional(),
+  /** Remaining capacity. Null = unknown / not surfaced; 0 = sold out. */
+  remaining: z.number().int().nonnegative().nullable().optional(),
+  /** Lowest pricing hint in cents — display only. Real price comes via liveResolve. */
+  lowest_price_cents: z.number().int().nonnegative().nullable().optional(),
+  currency: z.string().nullable().optional(),
+  /** Free-form note (weather caveat, sales window, etc). */
+  note: z.string().nullable().optional(),
+})
+
+/**
+ * The product content payload. Cache writes validate against this
+ * schema; cache reads skip rows that don't validate (treated as cache
+ * miss to surface adapter integration bugs without corrupting reads).
+ */
+export const productContentSchema = z.object({
+  product: productSummarySchema,
+  options: z.array(productOptionSchema).default([]),
+  days: z.array(productDaySchema).default([]),
+  media: z.array(productMediaItemSchema).default([]),
+  policies: z.array(productPolicySchema).default([]),
+  departures: z.array(productDepartureSchema).default([]),
+})
+
+export type ProductContent = z.infer<typeof productContentSchema>
+export type ProductSummary = z.infer<typeof productSummarySchema>
+export type ProductMediaItem = z.infer<typeof productMediaItemSchema>
+export type ProductOption = z.infer<typeof productOptionSchema>
+export type ProductDeparture = z.infer<typeof productDepartureSchema>
+export type ProductDay = z.infer<typeof productDaySchema>
+export type ProductPolicy = z.infer<typeof productPolicySchema>
+
+/**
+ * Validate a `ProductContent` payload. Returns the parsed result on
+ * success or a structured failure on rejection. Used by the cache write
+ * path and by `mergeOverlaysIntoProductContent` to gate overlay merges.
+ */
+export function validateProductContent(
+  payload: unknown,
+): { valid: true; content: ProductContent } | { valid: false; reason: string } {
+  const result = productContentSchema.safeParse(payload)
+  if (result.success) {
+    return { valid: true, content: result.data }
+  }
+  // Take the first issue's message — that's enough signal for ops; full
+  // detail is available on `result.error.issues` if a caller cares.
+  const issue = result.error.issues[0]
+  return {
+    valid: false,
+    reason: issue ? `${issue.path.join(".")}: ${issue.message}` : "validation failed",
+  }
+}

--- a/packages/products-contracts/src/index.ts
+++ b/packages/products-contracts/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./content-shape.js"

--- a/packages/products-contracts/tsconfig.json
+++ b/packages/products-contracts/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@voyantjs/voyant-typescript-config/base.json",
+  "compilerOptions": {
+    "composite": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/products-contracts/vitest.config.ts
+++ b/packages/products-contracts/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+})

--- a/packages/products/package.json
+++ b/packages/products/package.json
@@ -42,6 +42,7 @@
     "@voyantjs/core": "workspace:*",
     "@voyantjs/db": "workspace:*",
     "@voyantjs/hono": "workspace:*",
+    "@voyantjs/products-contracts": "workspace:*",
     "@voyantjs/utils": "workspace:*",
     "@voyantjs/catalog": "workspace:*",
     "@voyantjs/storage": "workspace:*",

--- a/packages/products/src/content-shape.ts
+++ b/packages/products/src/content-shape.ts
@@ -1,169 +1,33 @@
-/**
- * Products content shape — the rich detail-page content shape returned
- * by `getContent` and stored in `products_sourced_content.payload`.
- *
- * Schema versions are managed by this module: the constant
- * `PRODUCTS_CONTENT_SCHEMA_VERSION` stamps every cache write; reads
- * skip rows with an unrecognized version (treated as cache miss). Bump
- * the version when the shape changes; old cache rows are then evicted
- * by a single `DELETE WHERE content_schema_version != current`.
- *
- * Pure types + Zod + a vertical-specific `mergeOverlaysIntoProductContent`
- * that wraps the catalog plane's content-shape-aware merger with this
- * vertical's validator.
- *
- * See `docs/architecture/catalog-sourced-content.md` §3.2, §3.5.4, §3.6.
- */
-
 import {
   type ContentOverlay,
   type MergeOverlaysOptions,
   mergeOverlaysIntoContent,
 } from "@voyantjs/catalog"
-import { z } from "zod"
+import {
+  type ProductContent,
+  productContentSchema,
+  validateProductContent,
+} from "@voyantjs/products-contracts/content-shape"
 
-/**
- * The current content-schema version. Stamped on every cache write.
- * Bump when the `productContentSchema` shape changes incompatibly.
- */
-export const PRODUCTS_CONTENT_SCHEMA_VERSION = "products/v1"
-
-/**
- * Top-level product summary fields. Maps loosely to the owned `products`
- * table — the read service synthesizes from indexed projection + overlay
- * for thin adapters, or stores adapter-served data for rich ones.
- */
-export const productSummarySchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  status: z.string().optional(),
-  description: z.string().nullable().optional(),
-  inclusions_html: z.string().nullable().optional(),
-  exclusions_html: z.string().nullable().optional(),
-  terms_html: z.string().nullable().optional(),
-  contract_template_id: z.string().nullable().optional(),
-  contractTemplateId: z.string().nullable().optional(),
-  highlights: z.array(z.string()).optional(),
-  hero_image_url: z.string().nullable().optional(),
-  duration_days: z.number().int().nonnegative().nullable().optional(),
-  start_date: z.string().nullable().optional(),
-  end_date: z.string().nullable().optional(),
-  sell_currency: z.string().nullable().optional(),
-  supplier: z.string().nullable().optional(),
-  country: z.string().nullable().optional(),
-  departure_city: z.string().nullable().optional(),
-  tags: z.array(z.string()).optional(),
-})
-
-export const productMediaItemSchema = z.object({
-  url: z.string(),
-  type: z.enum(["image", "video", "document"]).default("image"),
-  caption: z.string().nullable().optional(),
-  alt: z.string().nullable().optional(),
-})
-
-export const productOptionUnitSchema = z.object({
-  id: z.string(),
-  type: z.string(),
-  label: z.string().optional(),
-  description: z.string().nullable().optional(),
-  capacity: z.number().int().nonnegative().nullable().optional(),
-})
-
-export const productOptionSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  description: z.string().nullable().optional(),
-  units: z.array(productOptionUnitSchema).optional().default([]),
-  inclusions: z.array(z.string()).optional().default([]),
-})
-
-export const productDaySchema = z.object({
-  day_number: z.number().int().positive(),
-  title: z.string().nullable().optional(),
-  description: z.string().nullable().optional(),
-  location: z.string().nullable().optional(),
-  /** Day-level hero image (catalog detail sheet thumbnail). */
-  hero_image_url: z.string().nullable().optional(),
-  services: z.array(z.string()).optional().default([]),
-})
-
-export const productPolicySchema = z.object({
-  kind: z.enum(["cancellation", "payment", "supplier_notes", "requirements"]),
-  body: z.string(),
-  /** Optional structured rules — vertical-specific. */
-  rules: z.unknown().optional(),
-})
-
-/**
- * A single bookable departure / time slot — the "when" surface of the
- * product. ISO 8601 timestamps for `starts_at` / `ends_at` so locale
- * formatting happens at render time, never in the cache.
- *
- * Owned products derive these from `availability_slots`; sourced
- * adapters return them via `getContent`. Empty array = "always-on"
- * product (e.g. an evergreen transfer service) or one whose schedule
- * is on-request.
- */
-export const productDepartureSchema = z.object({
-  id: z.string(),
-  starts_at: z.string(),
-  ends_at: z.string().nullable().optional(),
-  /** "open" | "limited" | "sold_out" | "closed" | "on_request" — display only. */
-  status: z.string().nullable().optional(),
-  /** Total capacity for the slot, when known. */
-  capacity: z.number().int().nonnegative().nullable().optional(),
-  /** Remaining capacity. Null = unknown / not surfaced; 0 = sold out. */
-  remaining: z.number().int().nonnegative().nullable().optional(),
-  /** Lowest pricing hint in cents — display only. Real price comes via liveResolve. */
-  lowest_price_cents: z.number().int().nonnegative().nullable().optional(),
-  currency: z.string().nullable().optional(),
-  /** Free-form note (weather caveat, sales window, etc). */
-  note: z.string().nullable().optional(),
-})
-
-/**
- * The product content payload. Cache writes validate against this
- * schema; cache reads skip rows that don't validate (treated as cache
- * miss to surface adapter integration bugs without corrupting reads).
- */
-export const productContentSchema = z.object({
-  product: productSummarySchema,
-  options: z.array(productOptionSchema).default([]),
-  days: z.array(productDaySchema).default([]),
-  media: z.array(productMediaItemSchema).default([]),
-  policies: z.array(productPolicySchema).default([]),
-  departures: z.array(productDepartureSchema).default([]),
-})
-
-export type ProductContent = z.infer<typeof productContentSchema>
-export type ProductSummary = z.infer<typeof productSummarySchema>
-export type ProductMediaItem = z.infer<typeof productMediaItemSchema>
-export type ProductOption = z.infer<typeof productOptionSchema>
-export type ProductDeparture = z.infer<typeof productDepartureSchema>
-export type ProductDay = z.infer<typeof productDaySchema>
-export type ProductPolicy = z.infer<typeof productPolicySchema>
-
-/**
- * Validate a `ProductContent` payload. Returns the parsed result on
- * success or a structured failure on rejection. Used by the cache write
- * path and by `mergeOverlaysIntoProductContent` to gate overlay merges.
- */
-export function validateProductContent(
-  payload: unknown,
-): { valid: true; content: ProductContent } | { valid: false; reason: string } {
-  const result = productContentSchema.safeParse(payload)
-  if (result.success) {
-    return { valid: true, content: result.data }
-  }
-  // Take the first issue's message — that's enough signal for ops; full
-  // detail is available on `result.error.issues` if a caller cares.
-  const issue = result.error.issues[0]
-  return {
-    valid: false,
-    reason: issue ? `${issue.path.join(".")}: ${issue.message}` : "validation failed",
-  }
-}
+export {
+  PRODUCTS_CONTENT_SCHEMA_VERSION,
+  type ProductContent,
+  type ProductDay,
+  type ProductDeparture,
+  type ProductMediaItem,
+  type ProductOption,
+  type ProductPolicy,
+  type ProductSummary,
+  productContentSchema,
+  productDaySchema,
+  productDepartureSchema,
+  productMediaItemSchema,
+  productOptionSchema,
+  productOptionUnitSchema,
+  productPolicySchema,
+  productSummarySchema,
+  validateProductContent,
+} from "@voyantjs/products-contracts/content-shape"
 
 /**
  * Apply a list of editorial overlays to a product content payload via

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -927,6 +927,9 @@ importers:
 
   packages/accommodations:
     dependencies:
+      '@voyantjs/accommodations-contracts':
+        specifier: workspace:*
+        version: link:../accommodations-contracts
       '@voyantjs/bookings':
         specifier: workspace:*
         version: link:../bookings
@@ -945,6 +948,22 @@ importers:
       hono:
         specifier: ^4.12.10
         version: 4.12.10
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@voyantjs/voyant-typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/accommodations-contracts:
+    dependencies:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1766,6 +1785,9 @@ importers:
       '@voyantjs/catalog':
         specifier: workspace:*
         version: link:../catalog
+      '@voyantjs/charters-contracts':
+        specifier: workspace:*
+        version: link:../charters-contracts
       '@voyantjs/core':
         specifier: workspace:*
         version: link:../core
@@ -1796,6 +1818,22 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.0.0
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/charters-contracts:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@voyantjs/voyant-typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      vitest:
+        specifier: ^4.1.2
         version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/charters-react:
@@ -2657,6 +2695,9 @@ importers:
       '@voyantjs/db':
         specifier: workspace:*
         version: link:../db
+      '@voyantjs/extras-contracts':
+        specifier: workspace:*
+        version: link:../extras-contracts
       '@voyantjs/hono':
         specifier: workspace:*
         version: link:../hono
@@ -2685,6 +2726,22 @@ importers:
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
+
+  packages/extras-contracts:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@voyantjs/voyant-typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/extras-react:
     dependencies:
@@ -4164,6 +4221,9 @@ importers:
       '@voyantjs/hono':
         specifier: workspace:*
         version: link:../hono
+      '@voyantjs/products-contracts':
+        specifier: workspace:*
+        version: link:../products-contracts
       '@voyantjs/storage':
         specifier: workspace:*
         version: link:../storage
@@ -4198,6 +4258,22 @@ importers:
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
+
+  packages/products-contracts:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@voyantjs/voyant-typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/products-react:
     dependencies:


### PR DESCRIPTION
## Summary

Follow-up to #1432 (now merged) that completes the **reusable contract-package pattern** #1400 was meant to establish — and that #1411 (Admin API SDK) explicitly depends on. Targets `main` directly.

### What this adds

- **Four new zod-only contract packages**, mirroring `@voyantjs/cruises-contracts`:
  - `@voyantjs/accommodations-contracts` (`accommodations/v1`)
  - `@voyantjs/products-contracts` (`products/v1`)
  - `@voyantjs/extras-contracts` (`extras/v1`)
  - `@voyantjs/charters-contracts` (`charters/v1`)

  Each owns its content schema, `*_CONTENT_SCHEMA_VERSION` constant, inferred types, and `validate<Vertical>Content` validator. Dependencies: `zod` only.

- **Runtime packages re-export** from their contracts package, so existing `@voyantjs/<vertical>/content-shape` import paths are unchanged. The `mergeOverlaysInto<Vertical>Content` overlay composition stays in the runtime.

- **ADR-0002** (`docs/adr/0002-contract-packages.md`) codifies the boundary: what is pure vs runtime, the `runtime → contracts` dependency direction, the per-vertical (not mega-package) split, and the re-export-stub recipe — so new verticals and the Admin SDK follow one documented pattern instead of reinventing it.

### Why

After #1432, only `catalog` + `cruises` had contract packages. The other content verticals are structurally identical, and external consumers (Voyant Connect, third-party adapter authors, the Admin API SDK) need the same small surface for them. `charters` wasn't even in #1400's "later" list — it landed afterward, which is the tell that doing this piecemeal leaves new verticals un-contracted. All six content verticals now have contract packages.

## Verification

- `pnpm typecheck` — 132/132
- `pnpm test` — 133/133 (full workspace)
- `pnpm lint` — 0 errors (1 pre-existing unrelated warning in `products-ui`)
- `pnpm verify:package-exports` — clean
- New contract packages each ship a smoke test; runtime verticals' existing content-shape tests pass through the re-export stubs

## Related

- Builds on #1432 / #1400
- Unblocks #1411 (Admin API SDK contract pattern)