### PR TITLE
Admin API contract + SDK (first slice) — design + bookings/finance

### DIFF
--- a/.changeset/admin-api-contract.md
+++ b/.changeset/admin-api-contract.md
@@ -1,0 +1,24 @@
+---
+"@voyantjs/admin-contracts": minor
+"@voyantjs/admin-client": minor
+---
+
+Introduce the Admin API contract + SDK (first slice).
+
+`@voyantjs/admin-contracts` defines admin operations as typed, versioned,
+transport-agnostic descriptors — `OperationDescriptor` + `defineOperation()`,
+action classification (`read | routine_write | destructive |
+requires_confirmation`), shared error/pagination envelopes, and a
+capability-discovery descriptor. It ships the first operation catalogue for
+bookings (list/get/confirm/cancel) and finance (invoice list/get, record
+payment, create payment link). Pure and zod-only.
+
+`@voyantjs/admin-client` is a framework-neutral client (`createAdminClient`)
+that executes those descriptors from Expo, Node, Workers, and Max/AI tools — no
+React or framework runtime deps. It handles auth (API key / bearer / custom),
+typed `AdminApiError`s, pagination, idempotency keys, and capability discovery.
+
+The architecture, package boundaries, and roadmap (server `_meta/capabilities`
+route, more domains, React/Expo adapters, Max-tool wrappers) are documented in
+`docs/adr/0003-admin-api-contract-sdk.md`. Web admin, mobile, Max tools, and
+brokers consume one surface, keeping permission and audit semantics consistent.

--- a/docs/adr/0003-admin-api-contract-sdk.md
+++ b/docs/adr/0003-admin-api-contract-sdk.md
@@ -84,12 +84,19 @@ identical across callers.**
   injection (API key **or** bearer/session), typed errors, pagination,
   idempotency keys, and capability discovery. **No React, no web-UI, no
   framework runtime deps** — runs in Expo, Node, Workers, and Max tools.
-- **`@voyantjs/admin-react`** / **`@voyantjs/admin-expo`** *(follow-up)* — thin
-  adapter layers (React Query hooks; Expo-friendly helpers). Max-tool wrappers
-  and the Cloud broker caller also build on `admin-client`.
+- **`@voyantjs/admin-react`** *(optional, follow-up)* — React Query hooks over
+  `admin-client` for React UIs. TanStack Query is renderer-agnostic, so the one
+  package serves the web admin **and** a React Native / Expo app.
+
+There is deliberately **no `admin-expo` and no Max adapter package**. Expo (React
+Native is just TypeScript), Max/AI tools, and the Voyant Cloud broker are all
+TypeScript + zod and call `admin-client` directly. Max in particular needs no
+wrapper layer: a descriptor already carries the zod input schema and
+`classification`, so turning the catalogue into agent tool definitions is a small
+mapping helper, not an adapter.
 
 The naming uses the `-contracts` suffix established by ADR-0002 (so the family
-reads `admin-contracts` / `admin-client` / `admin-react` / `admin-expo`),
+reads `admin-contracts` / `admin-client`, plus an optional `admin-react`),
 rather than the alternative per-domain `bookings-client` / `finance-client`
 split — see Alternatives.
 
@@ -213,9 +220,12 @@ The descriptor approach is a thin typed layer over what already ships.
    operation ids, deployment/contract version, and required scopes.
 2. Expand the operation catalogue beyond the first slice (CRM, legal, products,
    workflows, settings) per #1411's priority list.
-3. `@voyantjs/admin-react` (React Query hooks) and `@voyantjs/admin-expo`.
-4. Max-tool wrappers that turn descriptors into agent tools with risk gating
-   from `classification`, and the Cloud broker caller.
+3. An optional `@voyantjs/admin-react` (React Query hooks) for React UIs —
+   serves both the web admin and a React Native / Expo app (no separate Expo
+   adapter; TanStack Query is renderer-agnostic).
+4. A small descriptor→agent-tool mapping helper (risk-gated by `classification`)
+   so Max/AI tools and the Cloud broker call `admin-client` directly — no Max
+   adapter package.
 5. CI guard asserting descriptor ↔ route consistency.
 
 ## How to apply this decision

--- a/docs/adr/0003-admin-api-contract-sdk.md
+++ b/docs/adr/0003-admin-api-contract-sdk.md
@@ -1,0 +1,228 @@
+# ADR-0003: Admin API contract + SDK for non-web admin clients
+
+- **Status:** Proposed (2026-06-01)
+- **Relates to:** [#1411](https://github.com/voyantjs/voyant/issues/1411)
+- **Builds on:** [ADR-0002](./0002-contract-packages.md) (the `*-contracts` pattern), [ADR-0001](./0001-tenant-scoping.md) (deployment = tenancy boundary)
+
+## Context
+
+Voyant deployments expose rich admin functionality over `/v1/admin/*`. Today
+the only first-class consumer is the web admin (TanStack Router + Better Auth +
+local shadcn components), which talks to those routes with bespoke per-route
+fetch code.
+
+New consumers need the *same* operations without the web stack:
+
+- a **React Native + Expo** mobile admin app (native operator workflows, not
+  just an AI chat),
+- **Max / AI agents** invoking admin actions as tools,
+- **automation workers** and **Voyant Cloud brokers** forwarding operator
+  intent to a deployment.
+
+If mobile UI, web UI, Max tools, and brokers each invent their own per-route
+integration layer, the operation surface, permission semantics, and audit
+attribution drift four ways. #1411 asks for a shared **Admin API contract** and
+**SDK** so every caller speaks one typed, versioned surface.
+
+### What already exists (from codebase recon)
+
+- **Routes:** each `HonoModule` exposes `adminRoutes` mounted at
+  `/v1/admin/{module}` (`packages/hono/src/app.ts`). Bookings has ~33 admin
+  operations; finance ~130+.
+- **Auth:** a 4-strategy chain (`packages/hono/src/middleware/auth.ts`) —
+  internal key, core-owned `voy_` API keys (SHA-256 hashed, scoped), a custom
+  `auth.resolve()` integration, and session JWT bearer. Context carries
+  `userId`, `actor`, `callerType`, `scopes`, `organizationId`.
+- **Actors:** `staff | customer | partner | supplier` (+ `agent | system`
+  extended per-module). `/v1/admin/*` requires `staff`
+  (`require-actor.ts`).
+- **Scopes:** API keys carry `resource:action` scopes
+  (`@voyantjs/types/api-keys`) — 18 resources × {read, write, delete, trigger,
+  relay, search}, with wildcards and presets.
+- **Audit:** `@voyantjs/action-ledger` records every mutation with a principal
+  type (`user | api_key | agent | workflow | system`), action kind, evaluated
+  risk, approvals, and causation/correlation IDs.
+- **Confirmation gates:** status mutations (confirm/cancel/override/…) are
+  capability-gated and, for `agent`/`workflow` callers, can require an
+  **approval** — returning `202` with an approval payload instead of performing
+  the action. This is exactly the "requires confirmation" semantics #1411 wants.
+- **Conventions:** offset pagination `{ data, total, limit, offset }`; error
+  shape `{ error, code?, requestId?, details? }` (`@voyantjs/types`); zod input
+  validation per package; `Idempotency-Key` on mutations.
+- **Gap:** there is **no capability-discovery endpoint** — nothing surfaces
+  enabled modules, supported operations, deployment version, or required scopes
+  to a client.
+
+## Decision
+
+**Ship a dedicated `@voyantjs/admin-*` package family that defines admin
+operations as typed, versioned, transport-agnostic descriptors, plus a
+framework-neutral client that executes them. Web, Expo, Max tools, and brokers
+all consume the same descriptors, so permission and audit semantics are
+identical across callers.**
+
+### Package family
+
+- **`@voyantjs/admin-contracts`** — the contract layer. Pure, `zod`-only (plus
+  the relevant `*-contracts` domain packages for payload shapes). Owns:
+  - shared envelopes: error, offset + cursor pagination, the approval/`202`
+    result, idempotency semantics;
+  - the **`OperationDescriptor`** type and `defineOperation()` helper —
+    `{ id, method, path(params), input, output, classification, scopes,
+    capabilityKey? }`;
+  - **action classification** metadata (`read | routine_write | destructive |
+    requires_confirmation`) so the same descriptor can drive native buttons,
+    Max tool risk gating, audit `actionKind`, and confirmation UI;
+  - the **capability-discovery** descriptor (enabled modules, available
+    operations, deployment version, required scopes/permissions);
+  - the per-domain operation catalogues (`bookings.*`, `finance.*`, …),
+    referencing domain payload types from the `*-contracts` packages rather
+    than redeclaring them.
+- **`@voyantjs/admin-client`** — a framework-neutral TypeScript client.
+  `createAdminClient({ baseUrl, auth, fetch? })` returns typed operation
+  namespaces built from the descriptors. Handles base URL, auth header
+  injection (API key **or** bearer/session), typed errors, pagination,
+  idempotency keys, and capability discovery. **No React, no web-UI, no
+  framework runtime deps** — runs in Expo, Node, Workers, and Max tools.
+- **`@voyantjs/admin-react`** / **`@voyantjs/admin-expo`** *(follow-up)* — thin
+  adapter layers (React Query hooks; Expo-friendly helpers). Max-tool wrappers
+  and the Cloud broker caller also build on `admin-client`.
+
+The naming uses the `-contracts` suffix established by ADR-0002 (so the family
+reads `admin-contracts` / `admin-client` / `admin-react` / `admin-expo`),
+rather than the alternative per-domain `bookings-client` / `finance-client`
+split — see Alternatives.
+
+### Operation descriptor (the load-bearing shape)
+
+```ts
+const confirmBooking = defineOperation({
+  id: "bookings.confirm",
+  method: "POST",
+  path: (p: { id: string }) => `/v1/admin/bookings/${p.id}/confirm`,
+  input: confirmBookingInput,          // zod
+  output: bookingOutput,               // zod, references @voyantjs/bookings shapes
+  classification: "requires_confirmation",
+  scopes: ["bookings:write"],          // resource:action, matches API-key scopes
+  capabilityKey: "booking.status.confirm",
+})
+```
+
+A descriptor is data: the client turns it into a typed call; a Max-tool wrapper
+turns it into a tool definition with risk metadata; the capabilities endpoint
+lists it; the audit layer reads its `classification`/`capabilityKey`. One
+definition, many consumers.
+
+### Capability discovery
+
+`admin-contracts` defines a capabilities descriptor, and the framework gains a
+small `GET /v1/admin/_meta/capabilities` route *(follow-up, server side)* that
+returns: enabled modules, the operation ids available on this deployment, the
+deployment/contract version, and the scopes/permissions each operation
+requires. Clients call `client.capabilities()` to adapt to module availability
+and version — no hard-coding which modules a given deployment runs.
+
+### Boundaries this decision keeps
+
+- **Deployment isolation (ADR-0001) is unchanged.** The client targets one
+  deployment `baseUrl` (or a broker that forwards to one). No operational admin
+  data is centralized in Voyant Cloud.
+- **Web admin UI packages stay decoupled** from the SDK — they may adopt
+  `admin-client` over time, but the contract does not depend on them.
+- **Domain business logic stays in the domain packages.** `admin-contracts`
+  describes the existing routes; it does not reimplement services.
+- **Audit/permission semantics are the server's.** The SDK carries the caller's
+  credentials and idempotency/approval context; the server's action-ledger and
+  scope checks remain the enforcement point. The contract just makes the
+  classification and required scopes *legible* to clients ahead of the call.
+
+### Scope of the first slice
+
+The first implementation slice covers **bookings** (list, get, confirm, cancel)
+and **finance** (invoice list/get, record payment, create payment link), per
+#1411's priority. The full operation catalogue, the server-side capabilities
+route, and the React/Expo/Max adapters are explicit follow-ups (see Roadmap).
+
+## Consequences
+
+### Positive
+
+- **One surface, many callers.** Mobile, web, Max, and brokers invoke the same
+  typed operations with consistent permission + audit semantics.
+- **Risk is legible before the call.** `classification` lets a client show a
+  confirm dialog, a Max tool require approval, and audit tag the action —
+  driven by one piece of metadata, not four hand-maintained lists.
+- **Capability discovery decouples clients from deployment config.** A client
+  adapts to enabled modules and version instead of assuming them.
+- **Reuses the contract-package discipline.** Payload shapes come from the
+  `*-contracts` packages (ADR-0002); the SDK is zod-only and runs anywhere.
+
+### Negative
+
+- **A second description of the routes.** The descriptors must track the actual
+  handlers. Mitigated by keeping descriptors thin (path + zod + metadata) and,
+  over time, by generating/asserting them against the routes in CI.
+- **Surface curation.** Not every internal route should be public SDK surface;
+  deciding what is admin-public is ongoing work (the issue lists priorities).
+- **New packages + a new server meta route.** More workspace surface and one
+  new framework endpoint.
+
+### Mitigations
+
+- **Descriptor/route drift:** a CI check (follow-up) asserts every descriptor's
+  `path`/`method` resolves to a mounted admin route, and that its input schema
+  matches the route's validator where both exist.
+- **Versioning:** the capabilities descriptor carries a contract version; the
+  client warns on major-version skew with the target deployment.
+
+## Alternatives considered
+
+### Alternative A: one mega `@voyantjs/admin` package (contract + client + hooks)
+
+Reject — it forces an Expo or Node caller to pull React Query and web concerns,
+and couples the framework-neutral client to UI adapter churn. The
+contract/client/adapter split keeps the neutral core installable everywhere.
+
+### Alternative B: per-domain client packages (`bookings-client`, `finance-client`)
+
+The issue floats this. Reject as the *primary* surface — mobile and Max want a
+**single** admin client with cross-module capability discovery and one auth/base
+config, not N clients to wire up. Per-domain *namespaces* inside one
+`admin-client` (`client.bookings.*`, `client.finance.*`) give the modularity
+without N packages. (Per-domain contract *packages* already exist for payload
+shapes via ADR-0002; this is about the operation/SDK layer.)
+
+### Alternative C: generate the SDK from Hono RPC types
+
+Voyant's routes use Hono's chained-RPC types. A generated client is appealing
+but (a) leaks server/runtime types into clients, (b) can't express
+classification/scope/capability metadata, and (c) doesn't give a stable,
+reviewable versioned contract. Hand-authored descriptors that *reference*
+`*-contracts` payload types are the stable public surface; RPC-type assertions
+can be a CI guard, not the public API.
+
+### Alternative D: GraphQL / OpenAPI gateway
+
+Reject for this issue — it introduces a new runtime/build surface and doesn't
+align with the existing Hono `/v1/admin/*` reality or the per-deployment model.
+The descriptor approach is a thin typed layer over what already ships.
+
+## Roadmap (follow-ups, not this slice)
+
+1. Server-side `GET /v1/admin/_meta/capabilities` returning enabled modules,
+   operation ids, deployment/contract version, and required scopes.
+2. Expand the operation catalogue beyond the first slice (CRM, legal, products,
+   workflows, settings) per #1411's priority list.
+3. `@voyantjs/admin-react` (React Query hooks) and `@voyantjs/admin-expo`.
+4. Max-tool wrappers that turn descriptors into agent tools with risk gating
+   from `classification`, and the Cloud broker caller.
+5. CI guard asserting descriptor ↔ route consistency.
+
+## How to apply this decision
+
+When exposing an admin operation to non-web clients, **add an
+`OperationDescriptor` to `@voyantjs/admin-contracts`** (input/output zod,
+`classification`, `scopes`, `capabilityKey`) rather than writing bespoke fetch
+code in the client. Reference payload types from the relevant `*-contracts`
+package. Consumers (mobile, Max, brokers, web) get the operation for free
+through `@voyantjs/admin-client`; do not hand-roll a parallel integration layer.

--- a/packages/admin-client/README.md
+++ b/packages/admin-client/README.md
@@ -1,0 +1,54 @@
+# @voyantjs/admin-client
+
+A framework-neutral TypeScript client for the Voyant Admin API. Built on the
+typed operation descriptors in [`@voyantjs/admin-contracts`](../admin-contracts/README.md),
+it runs in **Expo, Node, Cloudflare Workers, and Max/AI tools** — no React, no
+web-UI, no framework runtime dependencies.
+
+See [`docs/adr/0003-admin-api-contract-sdk.md`](../../docs/adr/0003-admin-api-contract-sdk.md).
+
+## Usage
+
+```ts
+import { createAdminClient } from "@voyantjs/admin-client"
+
+const client = createAdminClient({
+  baseUrl: "https://acme.voyant.app",
+  auth: { type: "apiKey", apiKey: "voy_live_..." },
+  idempotencyKey: (op) => `${op}:${crypto.randomUUID()}`,
+})
+
+// Discover what this deployment supports
+const caps = await client.capabilities()
+
+// Bookings
+const { data, total } = await client.bookings.list({ status: "on_hold", limit: 20 })
+const booking = await client.bookings.get({ id: "book_123" })
+await client.bookings.confirm({ id: "book_123" }, { note: "supplier confirmed" })
+
+// Finance
+await client.finance.payments.record(
+  { id: "inv_9" },
+  { amountCents: 50000, currency: "EUR", paymentMethod: "bank_transfer", paymentDate: "2026-06-01" },
+)
+const link = await client.finance.paymentLinks.create(
+  { id: "inv_9" },
+  { amountCents: 50000, currency: "EUR", returnUrl: "https://acme.app/thanks" },
+)
+```
+
+## What it handles
+
+- **Auth** — `apiKey` (`voy_` keys), `bearer` (session JWT), or `custom` header
+  injection.
+- **Typed errors** — non-2xx responses throw `AdminApiError` carrying `status`,
+  `code`, and `requestId`.
+- **Pagination** — list operations return the `{ data, total, limit, offset }`
+  envelope; query params are serialized for you.
+- **Idempotency** — an `Idempotency-Key` header is attached to idempotent
+  operations when you supply `idempotencyKey`.
+- **Capability discovery** — `client.capabilities()` reports enabled modules,
+  operations, deployment version, and required scopes.
+
+The same operation invoked here is the same descriptor a Max-tool wrapper uses,
+so permission and audit semantics stay identical across callers.

--- a/packages/admin-client/README.md
+++ b/packages/admin-client/README.md
@@ -43,6 +43,9 @@ const link = await client.finance.paymentLinks.create(
   injection.
 - **Typed errors** — non-2xx responses throw `AdminApiError` carrying `status`,
   `code`, and `requestId`.
+- **Approval flow** — a `requires_confirmation` operation that returns HTTP 202
+  (an agent/workflow caller hitting an approval gate) throws
+  `AdminApprovalRequiredError`; read `.approvalId` to continue the flow.
 - **Pagination** — list operations return the `{ data, total, limit, offset }`
   envelope; query params are serialized for you.
 - **Idempotency** — an `Idempotency-Key` header is attached to idempotent

--- a/packages/admin-client/package.json
+++ b/packages/admin-client/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@voyantjs/admin-client",
+  "version": "0.90.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check src/",
+    "test": "vitest run --passWithNoTests",
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "prepack": "pnpm run build"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "dependencies": {
+    "@voyantjs/admin-contracts": "workspace:*",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@voyantjs/voyant-typescript-config": "workspace:*",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyantjs/voyant.git",
+    "directory": "packages/admin-client"
+  }
+}

--- a/packages/admin-client/src/auth.ts
+++ b/packages/admin-client/src/auth.ts
@@ -1,0 +1,30 @@
+/**
+ * Auth strategies for the admin client. The framework accepts core-owned
+ * `voy_` API keys, session JWT bearer tokens, and app-specific resolution; the
+ * `custom` strategy covers anything bespoke (cookies, signed headers).
+ */
+export type AdminAuth =
+  | {
+      type: "apiKey"
+      apiKey: string
+      /** Header name to carry the key (default `authorization`). */
+      header?: string
+      /** Scheme prefix (default `Bearer`; pass `""` for a bare value). */
+      scheme?: string
+    }
+  | { type: "bearer"; token: string }
+  | { type: "custom"; headers: () => Record<string, string> | Promise<Record<string, string>> }
+
+export async function authHeaders(auth: AdminAuth): Promise<Record<string, string>> {
+  switch (auth.type) {
+    case "apiKey": {
+      const header = (auth.header ?? "authorization").toLowerCase()
+      const scheme = auth.scheme ?? "Bearer"
+      return { [header]: scheme ? `${scheme} ${auth.apiKey}` : auth.apiKey }
+    }
+    case "bearer":
+      return { authorization: `Bearer ${auth.token}` }
+    case "custom":
+      return await auth.headers()
+  }
+}

--- a/packages/admin-client/src/client.test.ts
+++ b/packages/admin-client/src/client.test.ts
@@ -1,4 +1,4 @@
-import { AdminApiError } from "@voyantjs/admin-contracts"
+import { AdminApiError, AdminApprovalRequiredError } from "@voyantjs/admin-contracts"
 import { describe, expect, it } from "vitest"
 import type { FetchLike } from "./http.js"
 import { createAdminClient } from "./index.js"
@@ -132,6 +132,39 @@ describe("createAdminClient", () => {
 
     expect(result.id).toBe("pay_1")
     expect(calls[0]?.url).toBe("https://acme.voyant.app/v1/admin/finance/invoices/inv_9/payments")
+  })
+
+  it("surfaces a 202 approval-required response as AdminApprovalRequiredError", async () => {
+    const { fetchImpl } = mockFetch(() => ({
+      status: 202,
+      body: {
+        data: {
+          approvalRequired: true,
+          requestedAction: {
+            id: "act_1",
+            status: "pending_approval",
+            actionName: "booking.status.confirm",
+          },
+          approval: { id: "appr_1", status: "pending", requestedActionId: "act_1" },
+          replayed: false,
+        },
+      },
+    }))
+    const client = createAdminClient({
+      baseUrl: "https://acme.voyant.app",
+      auth: { type: "apiKey", apiKey: "voy_test" },
+      fetch: fetchImpl,
+    })
+
+    await expect(client.bookings.confirm({ id: "book_123" }, {})).rejects.toBeInstanceOf(
+      AdminApprovalRequiredError,
+    )
+    try {
+      await client.bookings.confirm({ id: "book_123" }, {})
+    } catch (err) {
+      expect(err).toBeInstanceOf(AdminApprovalRequiredError)
+      expect((err as AdminApprovalRequiredError).approvalId).toBe("appr_1")
+    }
   })
 
   it("discovers deployment capabilities", async () => {

--- a/packages/admin-client/src/client.test.ts
+++ b/packages/admin-client/src/client.test.ts
@@ -1,0 +1,165 @@
+import { AdminApiError } from "@voyantjs/admin-contracts"
+import { describe, expect, it } from "vitest"
+import type { FetchLike } from "./http.js"
+import { createAdminClient } from "./index.js"
+
+interface Recorded {
+  url: string
+  method: string
+  headers: Record<string, string>
+  body?: string
+}
+
+function mockFetch(responder: (req: Recorded) => { status: number; body: unknown }) {
+  const calls: Recorded[] = []
+  const fetchImpl: FetchLike = async (url, init) => {
+    const req: Recorded = { url, method: init.method, headers: init.headers, body: init.body }
+    calls.push(req)
+    const { status, body } = responder(req)
+    return { ok: status >= 200 && status < 300, status, json: async () => body }
+  }
+  return { fetchImpl, calls }
+}
+
+const booking = {
+  id: "book_123",
+  bookingNumber: "B-123",
+  status: "confirmed",
+  contactEmail: "a@b.com",
+  sellCurrency: "EUR",
+  sellAmountCents: 10000,
+  createdAt: "2026-06-01T00:00:00Z",
+  updatedAt: "2026-06-01T00:00:00Z",
+}
+
+describe("createAdminClient", () => {
+  it("confirms a booking: POST, auth + idempotency headers, JSON body, data-unwrapped result", async () => {
+    const { fetchImpl, calls } = mockFetch(() => ({ status: 200, body: { data: booking } }))
+    const client = createAdminClient({
+      baseUrl: "https://acme.voyant.app/",
+      auth: { type: "apiKey", apiKey: "voy_test" },
+      fetch: fetchImpl,
+      idempotencyKey: (op) => `idem-${op}`,
+    })
+
+    const result = await client.bookings.confirm({ id: "book_123" }, { note: "ok" })
+
+    expect(result.bookingNumber).toBe("B-123") // { data } unwrapped + output-parsed
+    const [req] = calls
+    expect(req?.method).toBe("POST")
+    expect(req?.url).toBe("https://acme.voyant.app/v1/admin/bookings/book_123/confirm")
+    expect(req?.headers.authorization).toBe("Bearer voy_test")
+    expect(req?.headers["content-type"]).toBe("application/json")
+    expect(req?.headers["idempotency-key"]).toBe("idem-bookings.confirm")
+    expect(JSON.parse(req?.body ?? "{}")).toEqual({ note: "ok" })
+  })
+
+  it("lists bookings: GET with query string, raw paginated envelope", async () => {
+    const { fetchImpl, calls } = mockFetch(() => ({
+      status: 200,
+      body: { data: [booking], total: 1, limit: 20, offset: 0 },
+    }))
+    const client = createAdminClient({
+      baseUrl: "https://acme.voyant.app",
+      auth: { type: "bearer", token: "jwt123" },
+      fetch: fetchImpl,
+    })
+
+    const page = await client.bookings.list({ status: "on_hold", limit: 20, offset: 0 })
+
+    expect(page.total).toBe(1)
+    expect(page.data[0]?.id).toBe("book_123")
+    const [req] = calls
+    expect(req?.method).toBe("GET")
+    expect(req?.url).toContain("/v1/admin/bookings?")
+    expect(req?.url).toContain("status=on_hold")
+    expect(req?.url).toContain("limit=20")
+    expect(req?.headers.authorization).toBe("Bearer jwt123")
+    expect(req?.body).toBeUndefined()
+  })
+
+  it("throws a typed AdminApiError on non-2xx", async () => {
+    const { fetchImpl } = mockFetch(() => ({
+      status: 404,
+      body: { error: "Booking not found", code: "not_found", requestId: "req_1" },
+    }))
+    const client = createAdminClient({
+      baseUrl: "https://acme.voyant.app",
+      auth: { type: "apiKey", apiKey: "voy_test" },
+      fetch: fetchImpl,
+    })
+
+    await expect(client.bookings.get({ id: "missing" })).rejects.toMatchObject({
+      name: "AdminApiError",
+      status: 404,
+    })
+    try {
+      await client.bookings.get({ id: "missing" })
+    } catch (err) {
+      expect(err).toBeInstanceOf(AdminApiError)
+      expect((err as AdminApiError).code).toBe("not_found")
+      expect((err as AdminApiError).requestId).toBe("req_1")
+    }
+  })
+
+  it("records a payment against an invoice", async () => {
+    const payment = {
+      id: "pay_1",
+      invoiceId: "inv_9",
+      amountCents: 50000,
+      currency: "EUR",
+      paymentMethod: "bank_transfer",
+      status: "completed",
+      paymentDate: "2026-06-01",
+      createdAt: "2026-06-01T00:00:00Z",
+    }
+    const { fetchImpl, calls } = mockFetch(() => ({ status: 201, body: { data: payment } }))
+    const client = createAdminClient({
+      baseUrl: "https://acme.voyant.app",
+      auth: { type: "apiKey", apiKey: "voy_test" },
+      fetch: fetchImpl,
+    })
+
+    const result = await client.finance.payments.record(
+      { id: "inv_9" },
+      {
+        amountCents: 50000,
+        currency: "EUR",
+        paymentMethod: "bank_transfer",
+        paymentDate: "2026-06-01",
+      },
+    )
+
+    expect(result.id).toBe("pay_1")
+    expect(calls[0]?.url).toBe("https://acme.voyant.app/v1/admin/finance/invoices/inv_9/payments")
+  })
+
+  it("discovers deployment capabilities", async () => {
+    const { fetchImpl, calls } = mockFetch(() => ({
+      status: 200,
+      body: {
+        contractVersion: "0.1.0",
+        modules: ["bookings", "finance"],
+        operations: [
+          {
+            id: "bookings.confirm",
+            method: "POST",
+            pathTemplate: "/v1/admin/bookings/:id/confirm",
+            classification: "requires_confirmation",
+            scopes: ["bookings:write"],
+          },
+        ],
+      },
+    }))
+    const client = createAdminClient({
+      baseUrl: "https://acme.voyant.app",
+      auth: { type: "apiKey", apiKey: "voy_test" },
+      fetch: fetchImpl,
+    })
+
+    const caps = await client.capabilities()
+    expect(caps.modules).toContain("finance")
+    expect(caps.operations[0]?.id).toBe("bookings.confirm")
+    expect(calls[0]?.url).toBe("https://acme.voyant.app/v1/admin/_meta/capabilities")
+  })
+})

--- a/packages/admin-client/src/client.ts
+++ b/packages/admin-client/src/client.ts
@@ -1,0 +1,64 @@
+import {
+  bookingsOperations,
+  type DeploymentCapabilities,
+  financeOperations,
+  type InferInput,
+} from "@voyantjs/admin-contracts"
+
+import { type AdminClientConfig, createExecutor, fetchCapabilities } from "./http.js"
+
+/**
+ * Create a framework-neutral admin client for a Voyant deployment. Runs in
+ * Expo, Node, Workers, and Max tools — no React or framework runtime deps.
+ *
+ * ```ts
+ * const client = createAdminClient({
+ *   baseUrl: "https://acme.voyant.app",
+ *   auth: { type: "apiKey", apiKey: "voy_..." },
+ * })
+ * const { data } = await client.bookings.list({ status: "on_hold" })
+ * await client.bookings.confirm({ id: "book_123" }, { note: "ok" })
+ * ```
+ */
+export function createAdminClient(config: AdminClientConfig) {
+  const execute = createExecutor(config)
+
+  return {
+    /** Escape hatch: run any operation descriptor directly. */
+    execute,
+    /** Discover enabled modules, operations, version, and required scopes. */
+    capabilities: (): Promise<DeploymentCapabilities> => fetchCapabilities(config),
+
+    bookings: {
+      list: (input?: InferInput<typeof bookingsOperations.list>) =>
+        execute(bookingsOperations.list, undefined, input),
+      get: (params: { id: string }) => execute(bookingsOperations.get, params),
+      confirm: (params: { id: string }, input?: InferInput<typeof bookingsOperations.confirm>) =>
+        execute(bookingsOperations.confirm, params, input),
+      cancel: (params: { id: string }, input?: InferInput<typeof bookingsOperations.cancel>) =>
+        execute(bookingsOperations.cancel, params, input),
+    },
+
+    finance: {
+      invoices: {
+        list: (input?: InferInput<typeof financeOperations.invoices.list>) =>
+          execute(financeOperations.invoices.list, undefined, input),
+        get: (params: { id: string }) => execute(financeOperations.invoices.get, params),
+      },
+      payments: {
+        record: (
+          params: { id: string },
+          input: InferInput<typeof financeOperations.payments.record>,
+        ) => execute(financeOperations.payments.record, params, input),
+      },
+      paymentLinks: {
+        create: (
+          params: { id: string },
+          input: InferInput<typeof financeOperations.paymentLinks.create>,
+        ) => execute(financeOperations.paymentLinks.create, params, input),
+      },
+    },
+  }
+}
+
+export type AdminClient = ReturnType<typeof createAdminClient>

--- a/packages/admin-client/src/client.ts
+++ b/packages/admin-client/src/client.ts
@@ -54,7 +54,7 @@ export function createAdminClient(config: AdminClientConfig) {
       paymentLinks: {
         create: (
           params: { id: string },
-          input: InferInput<typeof financeOperations.paymentLinks.create>,
+          input?: InferInput<typeof financeOperations.paymentLinks.create>,
         ) => execute(financeOperations.paymentLinks.create, params, input),
       },
     },

--- a/packages/admin-client/src/http.ts
+++ b/packages/admin-client/src/http.ts
@@ -1,0 +1,139 @@
+import {
+  AdminApiError,
+  type AnyOperation,
+  CAPABILITIES_PATH,
+  type DeploymentCapabilities,
+  deploymentCapabilitiesSchema,
+  type InferInput,
+  type InferOutput,
+  type InferParams,
+  toAdminError,
+} from "@voyantjs/admin-contracts"
+
+import { type AdminAuth, authHeaders } from "./auth.js"
+
+/**
+ * Minimal `fetch` shape the client needs. Keeping it narrow (instead of the DOM
+ * `fetch` type) keeps the package free of `lib.dom` and trivial to mock.
+ */
+export type FetchLike = (
+  url: string,
+  init: {
+    method: string
+    headers: Record<string, string>
+    body?: string
+  },
+) => Promise<{
+  ok: boolean
+  status: number
+  json: () => Promise<unknown>
+}>
+
+export interface AdminClientConfig {
+  /** Base URL of the target admin deployment (or a broker forwarding to one). */
+  baseUrl: string
+  auth: AdminAuth
+  /** Fetch implementation (defaults to `globalThis.fetch`). */
+  fetch?: FetchLike
+  /** Extra headers merged into every request. */
+  headers?: Record<string, string>
+  /** Produce an `Idempotency-Key` for an idempotent operation invocation. */
+  idempotencyKey?: (operationId: string) => string
+}
+
+function resolveFetch(config: AdminClientConfig): FetchLike {
+  const impl = config.fetch ?? (globalThis as { fetch?: FetchLike }).fetch
+  if (!impl) {
+    throw new Error("@voyantjs/admin-client: no fetch implementation; pass config.fetch")
+  }
+  return impl
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url.slice(0, -1) : url
+}
+
+function toQueryString(input: Record<string, unknown>): string {
+  const params: string[] = []
+  for (const [key, value] of Object.entries(input)) {
+    if (value === undefined || value === null) continue
+    params.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`)
+  }
+  return params.join("&")
+}
+
+function unwrapData(raw: unknown): unknown {
+  if (raw && typeof raw === "object" && "data" in raw) {
+    return (raw as { data: unknown }).data
+  }
+  return raw
+}
+
+async function readJson(res: { json: () => Promise<unknown> }): Promise<unknown> {
+  try {
+    return await res.json()
+  } catch {
+    return {}
+  }
+}
+
+async function baseHeaders(config: AdminClientConfig): Promise<Record<string, string>> {
+  return {
+    accept: "application/json",
+    ...config.headers,
+    ...(await authHeaders(config.auth)),
+  }
+}
+
+/** Build the operation executor bound to a client config. */
+export function createExecutor(config: AdminClientConfig) {
+  const doFetch = resolveFetch(config)
+
+  return async function execute<D extends AnyOperation>(
+    op: D,
+    params: InferParams<D>,
+    input?: InferInput<D>,
+  ): Promise<InferOutput<D>> {
+    let url = stripTrailingSlash(config.baseUrl) + op.path((params ?? {}) as InferParams<D>)
+    const headers = await baseHeaders(config)
+    let body: string | undefined
+
+    if (input !== undefined) {
+      const parsed = op.input.parse(input) as Record<string, unknown>
+      if (op.inputLocation === "query") {
+        const qs = toQueryString(parsed)
+        if (qs) url += (url.includes("?") ? "&" : "?") + qs
+      } else {
+        headers["content-type"] = "application/json"
+        body = JSON.stringify(parsed)
+      }
+    }
+
+    if (op.idempotent && config.idempotencyKey) {
+      headers["idempotency-key"] = config.idempotencyKey(op.id)
+    }
+
+    const res = await doFetch(url, { method: op.method, headers, body })
+    const raw = await readJson(res)
+    if (!res.ok) {
+      throw new AdminApiError(res.status, toAdminError(res.status, raw))
+    }
+
+    const payload = op.envelope === "data" ? unwrapData(raw) : raw
+    return op.output.parse(payload) as InferOutput<D>
+  }
+}
+
+/** Fetch the deployment's capability descriptor (`GET /v1/admin/_meta/capabilities`). */
+export async function fetchCapabilities(
+  config: AdminClientConfig,
+): Promise<DeploymentCapabilities> {
+  const doFetch = resolveFetch(config)
+  const url = stripTrailingSlash(config.baseUrl) + CAPABILITIES_PATH
+  const res = await doFetch(url, { method: "GET", headers: await baseHeaders(config) })
+  const raw = await readJson(res)
+  if (!res.ok) {
+    throw new AdminApiError(res.status, toAdminError(res.status, raw))
+  }
+  return deploymentCapabilitiesSchema.parse(unwrapData(raw))
+}

--- a/packages/admin-client/src/http.ts
+++ b/packages/admin-client/src/http.ts
@@ -1,6 +1,8 @@
 import {
   AdminApiError,
+  AdminApprovalRequiredError,
   type AnyOperation,
+  approvalRequiredSchema,
   CAPABILITIES_PATH,
   type DeploymentCapabilities,
   deploymentCapabilitiesSchema,
@@ -117,6 +119,17 @@ export function createExecutor(config: AdminClientConfig) {
     const raw = await readJson(res)
     if (!res.ok) {
       throw new AdminApiError(res.status, toAdminError(res.status, raw))
+    }
+
+    // A gated operation may return HTTP 202 with an approval-required envelope
+    // instead of the entity (agent/workflow callers on confirm/cancel etc.).
+    // Surface it as a typed error so callers can continue the approval flow
+    // rather than hit a generic output-parse failure.
+    if (res.status === 202) {
+      const approval = approvalRequiredSchema.safeParse(unwrapData(raw))
+      if (approval.success) {
+        throw new AdminApprovalRequiredError(approval.data)
+      }
     }
 
     const payload = op.envelope === "data" ? unwrapData(raw) : raw

--- a/packages/admin-client/src/index.ts
+++ b/packages/admin-client/src/index.ts
@@ -1,0 +1,6 @@
+// Re-export the contract surface so consumers import descriptors, types, and
+// `AdminApiError` from one place.
+export * from "@voyantjs/admin-contracts"
+export * from "./auth.js"
+export * from "./client.js"
+export * from "./http.js"

--- a/packages/admin-client/tsconfig.json
+++ b/packages/admin-client/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@voyantjs/voyant-typescript-config/base.json",
+  "compilerOptions": {
+    "composite": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/admin-client/vitest.config.ts
+++ b/packages/admin-client/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+})

--- a/packages/admin-contracts/README.md
+++ b/packages/admin-contracts/README.md
@@ -1,0 +1,38 @@
+# @voyantjs/admin-contracts
+
+The Admin API contract layer for Voyant — typed, versioned, transport-agnostic
+descriptors for the operations an authenticated operator can perform against a
+Voyant-powered admin deployment. Web admin, the Expo mobile admin, Max/AI tool
+wrappers, and Voyant Cloud brokers all consume the same descriptors, so
+permission and audit semantics stay identical across callers.
+
+Pure and `zod`-only. No framework runtime (Drizzle/Hono/DB), no React, no
+web-UI dependencies. See [`docs/adr/0003-admin-api-contract-sdk.md`](../../docs/adr/0003-admin-api-contract-sdk.md).
+
+## What's here
+
+- **Core** — `OperationDescriptor` + `defineOperation()`, action classification
+  (`read | routine_write | destructive | requires_confirmation`), the shared
+  error and pagination envelopes, and the capability-discovery descriptor.
+- **Operation catalogues** — `bookingsOperations`, `financeOperations`
+  (first slice: list/get/confirm/cancel and invoice list/get, record payment,
+  create payment link).
+
+Execute these with [`@voyantjs/admin-client`](../admin-client/README.md).
+
+## Usage
+
+```ts
+import { bookingsOperations, type InferInput } from "@voyantjs/admin-contracts"
+
+const op = bookingsOperations.confirm
+op.id            // "bookings.confirm"
+op.classification // "requires_confirmation"
+op.scopes        // ["bookings:write"]
+op.path({ id: "book_123" }) // "/v1/admin/bookings/book_123/confirm"
+type ConfirmInput = InferInput<typeof op>
+```
+
+The descriptors are data: the client turns them into typed calls, a Max-tool
+wrapper turns them into agent tools with risk gating from `classification`, and
+the capabilities endpoint lists them.

--- a/packages/admin-contracts/package.json
+++ b/packages/admin-contracts/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@voyantjs/admin-contracts",
+  "version": "0.90.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check src/",
+    "test": "vitest run --passWithNoTests",
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "prepack": "pnpm run build"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@voyantjs/voyant-typescript-config": "workspace:*",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyantjs/voyant.git",
+    "directory": "packages/admin-contracts"
+  }
+}

--- a/packages/admin-contracts/src/bookings.ts
+++ b/packages/admin-contracts/src/bookings.ts
@@ -1,0 +1,105 @@
+/**
+ * Bookings admin operations (first slice: list, get, confirm, cancel).
+ *
+ * Output schemas are the curated client-facing projection of the booking
+ * entity — not a 1:1 dump of `@voyantjs/bookings`' Drizzle row. When a
+ * `@voyantjs/bookings-contracts` package exists, these should re-export from
+ * it (see ADR-0002 / ADR-0003).
+ */
+
+import { z } from "zod"
+
+import { defineOperation } from "./core/operation.js"
+import { pageQuerySchema, paginated } from "./core/pagination.js"
+
+export const bookingSummarySchema = z.object({
+  id: z.string(),
+  bookingNumber: z.string(),
+  status: z.string(),
+  personId: z.string().nullable().optional(),
+  organizationId: z.string().nullable().optional(),
+  contactEmail: z.string().nullable().optional(),
+  sellCurrency: z.string().nullable().optional(),
+  sellAmountCents: z.number().int().nullable().optional(),
+  startDate: z.string().nullable().optional(),
+  endDate: z.string().nullable().optional(),
+  pax: z.number().int().nullable().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+
+export type BookingSummary = z.infer<typeof bookingSummarySchema>
+
+export const bookingListInputSchema = pageQuerySchema.extend({
+  status: z.string().optional(),
+  search: z.string().optional(),
+  productId: z.string().optional(),
+  personId: z.string().optional(),
+  organizationId: z.string().optional(),
+  dateFrom: z.string().optional(),
+  dateTo: z.string().optional(),
+})
+
+export const confirmBookingInputSchema = z.object({
+  note: z.string().optional(),
+  suppressNotifications: z.boolean().optional(),
+})
+
+export const cancelBookingInputSchema = z.object({
+  note: z.string().optional(),
+})
+
+const list = defineOperation({
+  id: "bookings.list",
+  method: "GET",
+  path: () => "/v1/admin/bookings",
+  pathTemplate: "/v1/admin/bookings",
+  input: bookingListInputSchema,
+  output: paginated(bookingSummarySchema),
+  classification: "read",
+  scopes: ["bookings:read"],
+  envelope: "raw",
+  summary: "List bookings with filters and offset pagination.",
+})
+
+const get = defineOperation({
+  id: "bookings.get",
+  method: "GET",
+  path: (p: { id: string }) => `/v1/admin/bookings/${p.id}`,
+  pathTemplate: "/v1/admin/bookings/:id",
+  input: z.object({}),
+  output: bookingSummarySchema,
+  classification: "read",
+  scopes: ["bookings:read"],
+  summary: "Get a single booking by id.",
+})
+
+const confirm = defineOperation({
+  id: "bookings.confirm",
+  method: "POST",
+  path: (p: { id: string }) => `/v1/admin/bookings/${p.id}/confirm`,
+  pathTemplate: "/v1/admin/bookings/:id/confirm",
+  input: confirmBookingInputSchema,
+  output: bookingSummarySchema,
+  classification: "requires_confirmation",
+  scopes: ["bookings:write"],
+  capabilityKey: "booking.status.confirm",
+  idempotent: true,
+  summary: "Confirm an on-hold booking. May require approval (HTTP 202).",
+})
+
+const cancel = defineOperation({
+  id: "bookings.cancel",
+  method: "POST",
+  path: (p: { id: string }) => `/v1/admin/bookings/${p.id}/cancel`,
+  pathTemplate: "/v1/admin/bookings/:id/cancel",
+  input: cancelBookingInputSchema,
+  output: bookingSummarySchema,
+  classification: "requires_confirmation",
+  scopes: ["bookings:write"],
+  capabilityKey: "booking.status.cancel",
+  idempotent: true,
+  summary: "Cancel a booking. May require approval (HTTP 202).",
+})
+
+export const bookingsOperations = { list, get, confirm, cancel } as const

--- a/packages/admin-contracts/src/contracts.test.ts
+++ b/packages/admin-contracts/src/contracts.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  allOperations,
+  bookingsOperations,
+  deploymentCapabilitiesSchema,
+  financeOperations,
+  getOperation,
+  type InferInput,
+  type InferOutput,
+  operationCapabilities,
+} from "./index.js"
+
+describe("@voyantjs/admin-contracts operation descriptors", () => {
+  it("applies defineOperation defaults (inputLocation / envelope / idempotent)", () => {
+    const get = bookingsOperations.get
+    expect(get.inputLocation).toBe("query") // GET → query
+    expect(get.envelope).toBe("data")
+    expect(get.idempotent).toBe(false)
+
+    const confirm = bookingsOperations.confirm
+    expect(confirm.inputLocation).toBe("body") // POST → body
+    expect(confirm.idempotent).toBe(true)
+    expect(confirm.classification).toBe("requires_confirmation")
+    expect(confirm.capabilityKey).toBe("booking.status.confirm")
+  })
+
+  it("builds paths from params and exposes stable templates", () => {
+    expect(bookingsOperations.confirm.path({ id: "book_123" })).toBe(
+      "/v1/admin/bookings/book_123/confirm",
+    )
+    expect(bookingsOperations.confirm.pathTemplate).toBe("/v1/admin/bookings/:id/confirm")
+    expect(financeOperations.payments.record.path({ id: "inv_9" })).toBe(
+      "/v1/admin/finance/invoices/inv_9/payments",
+    )
+  })
+
+  it("validates input against the operation schema", () => {
+    type ConfirmInput = InferInput<typeof bookingsOperations.confirm>
+    const input: ConfirmInput = { note: "ok", suppressNotifications: true }
+    expect(bookingsOperations.confirm.input.parse(input)).toMatchObject({ note: "ok" })
+
+    const bad = financeOperations.payments.record.input.safeParse({
+      amountCents: -1,
+      currency: "EUR",
+      paymentMethod: "cash",
+      paymentDate: "2026-06-01",
+    })
+    expect(bad.success).toBe(false) // negative amount rejected
+  })
+
+  it("parses a list (raw envelope) and a single (data envelope) output shape", () => {
+    const list: InferOutput<typeof bookingsOperations.list> = bookingsOperations.list.output.parse({
+      data: [
+        {
+          id: "book_1",
+          bookingNumber: "B-1",
+          status: "confirmed",
+          createdAt: "2026-06-01T00:00:00Z",
+          updatedAt: "2026-06-01T00:00:00Z",
+        },
+      ],
+      total: 1,
+      limit: 50,
+      offset: 0,
+    })
+    expect(list.data[0]?.bookingNumber).toBe("B-1")
+    expect(bookingsOperations.list.envelope).toBe("raw")
+
+    const invoice = financeOperations.invoices.get.output.parse({
+      id: "inv_1",
+      invoiceNumber: "INV-1",
+      invoiceType: "invoice",
+      status: "issued",
+      bookingId: "book_1",
+      currency: "EUR",
+      totalCents: 10000,
+      paidCents: 0,
+      balanceDueCents: 10000,
+      issueDate: "2026-06-01",
+      dueDate: "2026-06-30",
+      createdAt: "2026-06-01T00:00:00Z",
+      updatedAt: "2026-06-01T00:00:00Z",
+    })
+    expect(invoice.invoiceType).toBe("invoice")
+  })
+})
+
+describe("@voyantjs/admin-contracts registry", () => {
+  it("flattens every domain operation and looks them up by id", () => {
+    const ids = allOperations.map((op) => op.id).sort()
+    expect(ids).toEqual([
+      "bookings.cancel",
+      "bookings.confirm",
+      "bookings.get",
+      "bookings.list",
+      "finance.invoices.get",
+      "finance.invoices.list",
+      "finance.paymentLinks.create",
+      "finance.payments.record",
+    ])
+    expect(getOperation("finance.payments.record")?.scopes).toEqual(["finance:write"])
+    expect(getOperation("nope.missing")).toBeUndefined()
+  })
+
+  it("projects to a deployment capability descriptor", () => {
+    const capabilities = {
+      contractVersion: "0.1.0",
+      modules: ["bookings", "finance"],
+      operations: operationCapabilities(),
+    }
+    expect(deploymentCapabilitiesSchema.safeParse(capabilities).success).toBe(true)
+    const confirm = capabilities.operations.find((o) => o.id === "bookings.confirm")
+    expect(confirm).toMatchObject({
+      method: "POST",
+      pathTemplate: "/v1/admin/bookings/:id/confirm",
+      classification: "requires_confirmation",
+    })
+  })
+})

--- a/packages/admin-contracts/src/core/capabilities.ts
+++ b/packages/admin-contracts/src/core/capabilities.ts
@@ -1,0 +1,41 @@
+import { z } from "zod"
+
+/** Path of the (follow-up) server capability-discovery endpoint. */
+export const CAPABILITIES_PATH = "/v1/admin/_meta/capabilities"
+
+/** Semver of the admin contract surface this client/build was compiled against. */
+export const ADMIN_CONTRACT_VERSION = "0.1.0"
+
+/** One operation as advertised by a deployment's capability descriptor. */
+export const operationCapabilitySchema = z.object({
+  id: z.string(),
+  method: z.string(),
+  pathTemplate: z.string(),
+  classification: z.string(),
+  scopes: z.array(z.string()),
+  capabilityKey: z.string().optional(),
+})
+
+export type OperationCapability = z.infer<typeof operationCapabilitySchema>
+
+/**
+ * What a deployment advertises about itself so clients can adapt to module
+ * availability and version instead of hard-coding them. Returned by
+ * `GET /v1/admin/_meta/capabilities` (server route is a follow-up).
+ */
+export const deploymentCapabilitiesSchema = z.object({
+  /** Admin contract semver the deployment implements. */
+  contractVersion: z.string(),
+  /** Deployment/build version, when surfaced. */
+  deploymentVersion: z.string().optional(),
+  /** Enabled module names (e.g. `["bookings", "finance", "crm"]`). */
+  modules: z.array(z.string()),
+  /** Operations available on this deployment. */
+  operations: z.array(operationCapabilitySchema),
+  /** The resolved actor for the calling credentials. */
+  actor: z.string().optional(),
+  /** The caller's granted scopes (for API-key callers). */
+  scopes: z.array(z.string()).optional(),
+})
+
+export type DeploymentCapabilities = z.infer<typeof deploymentCapabilitiesSchema>

--- a/packages/admin-contracts/src/core/error.ts
+++ b/packages/admin-contracts/src/core/error.ts
@@ -48,3 +48,45 @@ export function toAdminError(status: number, body: unknown): AdminError {
   if (typeof body === "string" && body.length > 0) return { error: body }
   return { error: `Request failed with status ${status}` }
 }
+
+/**
+ * The approval-required envelope a gated mutation returns (HTTP 202) when the
+ * action needs human approval before it runs — e.g. an agent/workflow caller
+ * confirming or cancelling a booking. Carries the approval id the caller needs
+ * to continue the flow. Mirrors the booking action-ledger approval response.
+ */
+export const approvalRequiredSchema = z.object({
+  approvalRequired: z.literal(true),
+  requestedAction: z.object({
+    id: z.string(),
+    status: z.string(),
+    actionName: z.string().optional(),
+    targetType: z.string().nullable().optional(),
+    targetId: z.string().nullable().optional(),
+  }),
+  approval: z.object({
+    id: z.string(),
+    status: z.string(),
+    requestedActionId: z.string().optional(),
+    expiresAt: z.string().nullable().optional(),
+  }),
+  replayed: z.boolean().optional(),
+})
+
+export type ApprovalRequired = z.infer<typeof approvalRequiredSchema>
+
+/**
+ * Thrown by `@voyantjs/admin-client` when a `requires_confirmation` operation
+ * returns HTTP 202 with an approval-required envelope instead of the entity.
+ * Catch it to drive the approval flow — the approval id is on `.approvalId`.
+ */
+export class AdminApprovalRequiredError extends Error {
+  constructor(public readonly approval: ApprovalRequired) {
+    super(`Action requires approval (${approval.approval.id})`)
+    this.name = "AdminApprovalRequiredError"
+  }
+
+  get approvalId(): string {
+    return this.approval.approval.id
+  }
+}

--- a/packages/admin-contracts/src/core/error.ts
+++ b/packages/admin-contracts/src/core/error.ts
@@ -1,0 +1,50 @@
+import { z } from "zod"
+
+/**
+ * Admin API error envelope. Wire-compatible with `@voyantjs/types`'
+ * `apiErrorSchema` (`{ error, code?, requestId?, details? }`); defined here so
+ * the contract package stays zod-only and owns its client-facing error shape.
+ */
+export const adminErrorSchema = z.object({
+  error: z.string(),
+  code: z.string().optional(),
+  requestId: z.string().optional(),
+  details: z.record(z.string(), z.unknown()).optional(),
+})
+
+export type AdminError = z.infer<typeof adminErrorSchema>
+
+/**
+ * Thrown by `@voyantjs/admin-client` when a deployment returns a non-2xx
+ * response. Carries the HTTP status and the parsed error envelope so callers
+ * can branch on `status` / `code` without re-reading the body.
+ */
+export class AdminApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly body: AdminError,
+  ) {
+    super(body.error)
+    this.name = "AdminApiError"
+  }
+
+  get code(): string | undefined {
+    return this.body.code
+  }
+
+  get requestId(): string | undefined {
+    return this.body.requestId
+  }
+}
+
+/**
+ * Parse an arbitrary response body into an `AdminError`, tolerating non-conforming
+ * bodies (falls back to a stringified message). Used by clients to normalize
+ * error responses.
+ */
+export function toAdminError(status: number, body: unknown): AdminError {
+  const parsed = adminErrorSchema.safeParse(body)
+  if (parsed.success) return parsed.data
+  if (typeof body === "string" && body.length > 0) return { error: body }
+  return { error: `Request failed with status ${status}` }
+}

--- a/packages/admin-contracts/src/core/operation.ts
+++ b/packages/admin-contracts/src/core/operation.ts
@@ -1,0 +1,97 @@
+import type { z } from "zod"
+
+export type HttpMethod = "GET" | "POST" | "PATCH" | "PUT" | "DELETE"
+
+/**
+ * How cautious an operation is — drives confirm dialogs in native UIs, risk
+ * gating in Max/AI tool wrappers, and the audit `actionKind`. A single,
+ * escalating ladder:
+ *
+ *   - `read`                  — no mutation.
+ *   - `routine_write`         — ordinary create/update.
+ *   - `destructive`           — irreversible data loss (delete).
+ *   - `requires_confirmation` — the server may demand an approval (HTTP 202 +
+ *                               approval payload) before performing the action;
+ *                               callers must be prepared to handle that flow.
+ */
+export type ActionClassification =
+  | "read"
+  | "routine_write"
+  | "destructive"
+  | "requires_confirmation"
+
+/** `resource:action` scope string, matching `@voyantjs/types` API-key scopes. */
+export type Scope = string
+
+/** Where the operation's `input` travels: query string (GET) or JSON body. */
+export type InputLocation = "query" | "body"
+
+/**
+ * How the payload is wrapped on the wire:
+ *   - `data` — response is `{ data: <output> }`; the client returns `.data`.
+ *   - `raw`  — response IS the output (paginated envelopes, `{ success }`).
+ */
+export type Envelope = "data" | "raw"
+
+export interface OperationDescriptor<
+  TParams = unknown,
+  TInput extends z.ZodTypeAny = z.ZodTypeAny,
+  TOutput extends z.ZodTypeAny = z.ZodTypeAny,
+> {
+  /** Stable dotted id, e.g. `"bookings.confirm"`. */
+  id: string
+  method: HttpMethod
+  /** Build the request path from route params. */
+  path: (params: TParams) => string
+  /** A stable, param-templated path (`/v1/admin/bookings/:id/confirm`) for capability listing. */
+  pathTemplate: string
+  /** Request body (POST/PATCH/PUT) or query (GET) schema. */
+  input: TInput
+  /** Response payload schema (after envelope handling). */
+  output: TOutput
+  classification: ActionClassification
+  /** `resource:action` scopes a caller needs. */
+  scopes: Scope[]
+  /** Action-ledger capability key when the op is capability-gated. */
+  capabilityKey?: string
+  inputLocation: InputLocation
+  envelope: Envelope
+  /** Whether the op accepts an `Idempotency-Key` header. */
+  idempotent: boolean
+  summary?: string
+}
+
+/**
+ * Define an operation descriptor with sensible defaults: `inputLocation`
+ * follows the method (GET → query, else body), `envelope` defaults to `data`,
+ * and `idempotent` defaults to false.
+ */
+export function defineOperation<TParams, TInput extends z.ZodTypeAny, TOutput extends z.ZodTypeAny>(
+  spec: Omit<
+    OperationDescriptor<TParams, TInput, TOutput>,
+    "inputLocation" | "envelope" | "idempotent"
+  > &
+    Partial<
+      Pick<
+        OperationDescriptor<TParams, TInput, TOutput>,
+        "inputLocation" | "envelope" | "idempotent"
+      >
+    >,
+): OperationDescriptor<TParams, TInput, TOutput> {
+  return {
+    ...spec,
+    inputLocation: spec.inputLocation ?? (spec.method === "GET" ? "query" : "body"),
+    envelope: spec.envelope ?? "data",
+    idempotent: spec.idempotent ?? false,
+  }
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: descriptor type extractors need the any-positioned infer
+type AnyOperation = OperationDescriptor<any, any, any>
+
+export type InferParams<D extends AnyOperation> =
+  D extends OperationDescriptor<infer P, infer _I, infer _O> ? P : never
+export type InferInput<D extends AnyOperation> =
+  D extends OperationDescriptor<infer _P, infer I, infer _O> ? z.infer<I> : never
+export type InferOutput<D extends AnyOperation> =
+  D extends OperationDescriptor<infer _P, infer _I, infer O> ? z.infer<O> : never

--- a/packages/admin-contracts/src/core/pagination.ts
+++ b/packages/admin-contracts/src/core/pagination.ts
@@ -1,0 +1,50 @@
+import { z } from "zod"
+
+/**
+ * Offset pagination query, matching the framework's admin-route convention
+ * (`limit`/`offset`/`sortBy`/`sortDir`). Domain list inputs extend this.
+ */
+export const pageQuerySchema = z.object({
+  limit: z.number().int().min(1).max(100).default(50),
+  offset: z.number().int().min(0).default(0),
+  sortBy: z.string().optional(),
+  sortDir: z.enum(["asc", "desc"]).optional(),
+})
+
+export type PageQuery = z.infer<typeof pageQuerySchema>
+
+/**
+ * The framework's list response envelope: `{ data, total, limit, offset }`.
+ * Build a concrete schema with `paginated(itemSchema)`.
+ */
+export function paginated<TItem extends z.ZodTypeAny>(item: TItem) {
+  return z.object({
+    data: z.array(item),
+    total: z.number().int().nonnegative(),
+    limit: z.number().int().nonnegative(),
+    offset: z.number().int().nonnegative(),
+  })
+}
+
+export interface Paginated<TItem> {
+  data: TItem[]
+  total: number
+  limit: number
+  offset: number
+}
+
+/**
+ * Cursor pagination query, matching the action-ledger-style endpoints that
+ * page by opaque cursor (`limit` up to 199).
+ */
+export const cursorPageQuerySchema = z.object({
+  cursor: z.string().optional(),
+  limit: z.number().int().min(1).max(199).default(50),
+})
+
+export type CursorPageQuery = z.infer<typeof cursorPageQuerySchema>
+
+export interface CursorPage<TItem> {
+  data: TItem[]
+  pageInfo: { nextCursor: string | null }
+}

--- a/packages/admin-contracts/src/finance.ts
+++ b/packages/admin-contracts/src/finance.ts
@@ -59,12 +59,15 @@ export const paymentLinkSchema = z.object({
 
 export type PaymentLink = z.infer<typeof paymentLinkSchema>
 
+// Fields mirror the route's `invoiceListQuerySchema` (no `invoiceType` filter
+// exists server-side — `invoiceType` is an output field, not a list filter).
 export const invoiceListInputSchema = pageQuerySchema.extend({
   status: z.string().optional(),
-  invoiceType: z.enum(["invoice", "proforma"]).optional(),
   bookingId: z.string().optional(),
   personId: z.string().optional(),
   organizationId: z.string().optional(),
+  currency: z.string().optional(),
+  search: z.string().optional(),
 })
 
 const PAYMENT_METHODS = [
@@ -89,14 +92,19 @@ export const recordPaymentInputSchema = z.object({
   notes: z.string().optional(),
 })
 
+// The route derives currency + amount from the invoice balance, so they are
+// NOT accepted here. Fields mirror the route's payment-session provisioning
+// schema (all optional).
 export const createPaymentLinkInputSchema = z.object({
-  currency: z.string().length(3),
-  amountCents: z.number().int().positive(),
+  provider: z.string().optional(),
   paymentMethod: z.enum(PAYMENT_METHODS).optional(),
   payerEmail: z.string().email().optional(),
   payerName: z.string().optional(),
   returnUrl: z.string().url().optional(),
   cancelUrl: z.string().url().optional(),
+  callbackUrl: z.string().url().optional(),
+  externalReference: z.string().optional(),
+  expiresAt: z.string().optional(),
 })
 
 const invoicesList = defineOperation({
@@ -147,7 +155,8 @@ const paymentLinksCreate = defineOperation({
   classification: "routine_write",
   scopes: ["finance:write"],
   idempotent: true,
-  summary: "Create a payment link (payment session) for an invoice.",
+  summary:
+    "Create a payment link (payment session) for an invoice. Amount and currency are taken from the invoice balance.",
 })
 
 export const financeOperations = {

--- a/packages/admin-contracts/src/finance.ts
+++ b/packages/admin-contracts/src/finance.ts
@@ -1,0 +1,157 @@
+/**
+ * Finance admin operations (first slice: invoice list/get, record payment,
+ * create payment link).
+ *
+ * Output schemas are the curated client-facing projection of the finance
+ * entities — not a 1:1 dump of `@voyantjs/finance`' Drizzle rows.
+ */
+
+import { z } from "zod"
+
+import { defineOperation } from "./core/operation.js"
+import { pageQuerySchema, paginated } from "./core/pagination.js"
+
+export const invoiceSummarySchema = z.object({
+  id: z.string(),
+  invoiceNumber: z.string(),
+  invoiceType: z.enum(["invoice", "proforma"]),
+  status: z.string(),
+  bookingId: z.string(),
+  personId: z.string().nullable().optional(),
+  organizationId: z.string().nullable().optional(),
+  currency: z.string(),
+  totalCents: z.number().int(),
+  paidCents: z.number().int(),
+  balanceDueCents: z.number().int(),
+  issueDate: z.string(),
+  dueDate: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+
+export type InvoiceSummary = z.infer<typeof invoiceSummarySchema>
+
+export const paymentSchema = z.object({
+  id: z.string(),
+  invoiceId: z.string(),
+  amountCents: z.number().int(),
+  currency: z.string(),
+  paymentMethod: z.string(),
+  status: z.string(),
+  paymentDate: z.string(),
+  referenceNumber: z.string().nullable().optional(),
+  createdAt: z.string(),
+})
+
+export type Payment = z.infer<typeof paymentSchema>
+
+export const paymentLinkSchema = z.object({
+  id: z.string(),
+  status: z.string(),
+  invoiceId: z.string().nullable().optional(),
+  currency: z.string(),
+  amountCents: z.number().int(),
+  redirectUrl: z.string().nullable().optional(),
+  provider: z.string().nullable().optional(),
+  expiresAt: z.string().nullable().optional(),
+  createdAt: z.string(),
+})
+
+export type PaymentLink = z.infer<typeof paymentLinkSchema>
+
+export const invoiceListInputSchema = pageQuerySchema.extend({
+  status: z.string().optional(),
+  invoiceType: z.enum(["invoice", "proforma"]).optional(),
+  bookingId: z.string().optional(),
+  personId: z.string().optional(),
+  organizationId: z.string().optional(),
+})
+
+const PAYMENT_METHODS = [
+  "bank_transfer",
+  "credit_card",
+  "debit_card",
+  "cash",
+  "cheque",
+  "wallet",
+  "direct_bill",
+  "voucher",
+  "other",
+] as const
+
+export const recordPaymentInputSchema = z.object({
+  amountCents: z.number().int().positive(),
+  currency: z.string().length(3),
+  paymentMethod: z.enum(PAYMENT_METHODS),
+  paymentDate: z.string(),
+  status: z.enum(["pending", "completed", "failed", "refunded"]).optional(),
+  referenceNumber: z.string().max(255).optional(),
+  notes: z.string().optional(),
+})
+
+export const createPaymentLinkInputSchema = z.object({
+  currency: z.string().length(3),
+  amountCents: z.number().int().positive(),
+  paymentMethod: z.enum(PAYMENT_METHODS).optional(),
+  payerEmail: z.string().email().optional(),
+  payerName: z.string().optional(),
+  returnUrl: z.string().url().optional(),
+  cancelUrl: z.string().url().optional(),
+})
+
+const invoicesList = defineOperation({
+  id: "finance.invoices.list",
+  method: "GET",
+  path: () => "/v1/admin/finance/invoices",
+  pathTemplate: "/v1/admin/finance/invoices",
+  input: invoiceListInputSchema,
+  output: paginated(invoiceSummarySchema),
+  classification: "read",
+  scopes: ["finance:read"],
+  envelope: "raw",
+  summary: "List invoices and proformas with filters and offset pagination.",
+})
+
+const invoicesGet = defineOperation({
+  id: "finance.invoices.get",
+  method: "GET",
+  path: (p: { id: string }) => `/v1/admin/finance/invoices/${p.id}`,
+  pathTemplate: "/v1/admin/finance/invoices/:id",
+  input: z.object({}),
+  output: invoiceSummarySchema,
+  classification: "read",
+  scopes: ["finance:read"],
+  summary: "Get a single invoice by id.",
+})
+
+const paymentsRecord = defineOperation({
+  id: "finance.payments.record",
+  method: "POST",
+  path: (p: { id: string }) => `/v1/admin/finance/invoices/${p.id}/payments`,
+  pathTemplate: "/v1/admin/finance/invoices/:id/payments",
+  input: recordPaymentInputSchema,
+  output: paymentSchema,
+  classification: "routine_write",
+  scopes: ["finance:write"],
+  idempotent: true,
+  summary: "Record a payment against an invoice.",
+})
+
+const paymentLinksCreate = defineOperation({
+  id: "finance.paymentLinks.create",
+  method: "POST",
+  path: (p: { id: string }) => `/v1/admin/finance/invoices/${p.id}/payment-session`,
+  pathTemplate: "/v1/admin/finance/invoices/:id/payment-session",
+  input: createPaymentLinkInputSchema,
+  output: paymentLinkSchema,
+  classification: "routine_write",
+  scopes: ["finance:write"],
+  idempotent: true,
+  summary: "Create a payment link (payment session) for an invoice.",
+})
+
+export const financeOperations = {
+  invoices: { list: invoicesList, get: invoicesGet },
+  payments: { record: paymentsRecord },
+  paymentLinks: { create: paymentLinksCreate },
+} as const

--- a/packages/admin-contracts/src/index.ts
+++ b/packages/admin-contracts/src/index.ts
@@ -1,0 +1,7 @@
+export * from "./bookings.js"
+export * from "./core/capabilities.js"
+export * from "./core/error.js"
+export * from "./core/operation.js"
+export * from "./core/pagination.js"
+export * from "./finance.js"
+export * from "./registry.js"

--- a/packages/admin-contracts/src/registry.ts
+++ b/packages/admin-contracts/src/registry.ts
@@ -1,0 +1,55 @@
+import { bookingsOperations } from "./bookings.js"
+import type { OperationCapability } from "./core/capabilities.js"
+import type { OperationDescriptor } from "./core/operation.js"
+import { financeOperations } from "./finance.js"
+
+// biome-ignore lint/suspicious/noExplicitAny: heterogeneous descriptor registry
+export type AnyOperation = OperationDescriptor<any, any, any>
+
+function isOperation(value: unknown): value is AnyOperation {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    "id" in value &&
+    "pathTemplate" in value &&
+    typeof (value as { path?: unknown }).path === "function"
+  )
+}
+
+function collect(node: unknown, out: AnyOperation[]): void {
+  if (isOperation(node)) {
+    out.push(node)
+    return
+  }
+  if (node && typeof node === "object") {
+    for (const child of Object.values(node)) collect(child, out)
+  }
+}
+
+/** Every operation descriptor across all domains, flattened. */
+export const allOperations: AnyOperation[] = (() => {
+  const out: AnyOperation[] = []
+  collect(bookingsOperations, out)
+  collect(financeOperations, out)
+  return out
+})()
+
+/** Lookup a descriptor by its dotted id (`"bookings.confirm"`). */
+export function getOperation(id: string): AnyOperation | undefined {
+  return allOperations.find((op) => op.id === id)
+}
+
+/**
+ * Project the registry to the capability-descriptor shape a deployment
+ * advertises via `GET /v1/admin/_meta/capabilities`.
+ */
+export function operationCapabilities(): OperationCapability[] {
+  return allOperations.map((op) => ({
+    id: op.id,
+    method: op.method,
+    pathTemplate: op.pathTemplate,
+    classification: op.classification,
+    scopes: op.scopes,
+    capabilityKey: op.capabilityKey,
+  }))
+}

--- a/packages/admin-contracts/tsconfig.json
+++ b/packages/admin-contracts/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@voyantjs/voyant-typescript-config/base.json",
+  "compilerOptions": {
+    "composite": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/admin-contracts/vitest.config.ts
+++ b/packages/admin-contracts/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1061,6 +1061,41 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@25.0.1)(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/admin-client:
+    dependencies:
+      '@voyantjs/admin-contracts':
+        specifier: workspace:*
+        version: link:../admin-contracts
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@voyantjs/voyant-typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/admin-contracts:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@voyantjs/voyant-typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.2))(vite@8.0.10(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/allocation-ui:
     devDependencies:
       '@tanstack/react-query':


### PR DESCRIPTION
**Draft for design review.** This is the first slice of #1411 (the Admin API contract + SDK). The architecture is the substance here — please review **ADR-0003** before the code. The full operation catalogue, the server-side capabilities route, and an optional React Query adapter are explicit follow-ups (see the ADR roadmap; no separate Expo or Max adapter packages — both consume the client directly), not this PR.

## What's here

- **`docs/adr/0003-admin-api-contract-sdk.md`** — the design (the issue's first acceptance criterion). Grounds the decisions in how the admin surface actually works today (4-strategy auth, `resource:action` scopes, the `action-ledger` + approval/`202` confirmation flow, `{data,total,limit,offset}` pagination, `{error,code,...}` errors). Covers package boundaries, the operation-descriptor shape, action classification, capability discovery, alternatives, and the roadmap.

- **`@voyantjs/admin-contracts`** (zod-only) — `OperationDescriptor` + `defineOperation()`, action classification (`read | routine_write | destructive | requires_confirmation`), shared error/pagination envelopes, the capability-discovery descriptor, and the first operation catalogue:
  - bookings: `list`, `get`, `confirm`, `cancel`
  - finance: `invoices.list`, `invoices.get`, `payments.record`, `paymentLinks.create`

- **`@voyantjs/admin-client`** — framework-neutral `createAdminClient({ baseUrl, auth, fetch? })`. Runs in Expo/Node/Workers/Max tools (no React, no framework runtime). Handles auth (apiKey/bearer/custom), typed `AdminApiError`, query/body serialization, the `{data}`-vs-raw envelope, idempotency-key headers, and `client.capabilities()`.

## Key design decisions (call these out in review)

1. **Dedicated `admin-*` family** (`admin-contracts` / `admin-client` / later `admin-react` / `admin-expo`) over per-domain `bookings-client`/`finance-client`. Mobile + Max want **one** client with cross-module capability discovery; domains are namespaces inside it (`client.bookings.*`). Naming uses the `-contracts` suffix from ADR-0002.
2. **Operations are data** (descriptors), so the same definition drives the SDK call, a Max-tool wrapper (with risk gating from `classification`), the capabilities listing, and audit `actionKind` — no four parallel integration layers.
3. **Capability discovery** is defined in the contract now; the server `GET /v1/admin/_meta/capabilities` route is a follow-up.

## Verification

- `pnpm typecheck` — 134/134
- `pnpm test` — 135/135 (admin-contracts 6, admin-client 5, both with zod-validated I/O and a mock-fetch client suite)
- `pnpm lint` — 0 errors (1 pre-existing unrelated `products-ui` warning)

## Open question for reviewers

Package naming/shape is the one decision the issue explicitly left open. I went with the dedicated `admin-*` family (rationale in ADR-0003 §Alternatives). If you'd prefer per-domain client packages, it's a cheap change at this stage.

Closes none yet — this is the first slice toward #1411.
