### PR TITLE
Fix release train: add contract packages, align to 0.95.0

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -109,7 +109,13 @@
       "@voyantjs/workflows-orchestrator-cloudflare",
       "@voyantjs/workflows-orchestrator-node",
       "@voyantjs/workflows-react",
-      "@voyantjs/workflows-ui"
+      "@voyantjs/workflows-ui",
+      "@voyantjs/accommodations-contracts",
+      "@voyantjs/catalog-contracts",
+      "@voyantjs/charters-contracts",
+      "@voyantjs/cruises-contracts",
+      "@voyantjs/extras-contracts",
+      "@voyantjs/products-contracts"
     ]
   ],
   "linked": [],

--- a/packages/accommodations-contracts/package.json
+++ b/packages/accommodations-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/accommodations-contracts",
-  "version": "0.90.0",
+  "version": "0.95.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/catalog-contracts/package.json
+++ b/packages/catalog-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/catalog-contracts",
-  "version": "0.90.0",
+  "version": "0.95.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/charters-contracts/package.json
+++ b/packages/charters-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/charters-contracts",
-  "version": "0.90.0",
+  "version": "0.95.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/cruises-contracts/package.json
+++ b/packages/cruises-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/cruises-contracts",
-  "version": "0.90.0",
+  "version": "0.95.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/extras-contracts/package.json
+++ b/packages/extras-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/extras-contracts",
-  "version": "0.90.0",
+  "version": "0.95.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/products-contracts/package.json
+++ b/packages/products-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/products-contracts",
-  "version": "0.90.0",
+  "version": "0.95.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Problem

`verify:release-train` is failing on `main`, blocking releases:

```
Expected one shared release train version across publishable packages.
0.90.0: @voyantjs/accommodations-contracts, …catalog-contracts, …charters-contracts,
        …cruises-contracts, …extras-contracts, …products-contracts
0.95.0: <everything else>
```

The six `*-contracts` packages were created at `0.90.0` and were never added to the changeset `fixed` group, so they sit off the shared release train.

## Fix

- Add the six contract packages to the `fixed` group in `.changeset/config.json` so they version in lockstep with the rest of the workspace.
- Bump their `package.json` version `0.90.0 → 0.95.0` to match the current train.

`pnpm verify:release-train` now passes: **124 publishable packages on shared release train 0.95.0**.

Minimal diff — only version lines + the six `fixed`-group additions (7 files).

## Follow-up (separate PRs)

The same fix is needed for the not-yet-merged contract packages so they don't re-break the train on merge:
- #1447 — `@voyantjs/flights-contracts`
- #1446 — `@voyantjs/admin-contracts`, `@voyantjs/admin-client`

I'll align those branches too.