### PR TITLE
Realign stragglers to release train 0.96.0

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -123,7 +123,10 @@
       "@voyantjs/suppliers-contracts",
       "@voyantjs/identity-contracts",
       "@voyantjs/bookings-contracts",
-      "@voyantjs/legal-contracts"
+      "@voyantjs/legal-contracts",
+      "@voyantjs/admin-contracts",
+      "@voyantjs/admin-client",
+      "@voyantjs/flights-contracts"
     ]
   ],
   "linked": [],

--- a/packages/admin-client/package.json
+++ b/packages/admin-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/admin-client",
-  "version": "0.90.0",
+  "version": "0.96.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/admin-contracts/package.json
+++ b/packages/admin-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/admin-contracts",
-  "version": "0.90.0",
+  "version": "0.96.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/bookings-contracts/package.json
+++ b/packages/bookings-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/bookings-contracts",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/crm-contracts/package.json
+++ b/packages/crm-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/crm-contracts",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/finance-contracts/package.json
+++ b/packages/finance-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/finance-contracts",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/flights-contracts/package.json
+++ b/packages/flights-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/flights-contracts",
-  "version": "0.90.0",
+  "version": "0.96.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/identity-contracts/package.json
+++ b/packages/identity-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/identity-contracts",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/legal-contracts/package.json
+++ b/packages/legal-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/legal-contracts",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/schema-kit/package.json
+++ b/packages/schema-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/schema-kit",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/suppliers-contracts/package.json
+++ b/packages/suppliers-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/suppliers-contracts",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/transactions-contracts/package.json
+++ b/packages/transactions-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/transactions-contracts",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {


### PR DESCRIPTION
Fixes the broken `verify:release-train` on main. After #1450 bumped the train to 0.96.0, three packages from #1446/#1447 (admin-contracts, admin-client, flights-contracts — at 0.90.0, never in the `fixed` group) and the eight from #1451 (schema-kit + 7 module-contracts, at 0.95.0) merged off-train.

This bumps all 11 to **0.96.0** and adds the three missing packages to the `fixed` group. `verify:release-train` → 135 publishable packages on 0.96.0.