### PR TITLE
Derive admin-contracts operation inputs from the module contracts

### DIFF
--- a/.changeset/admin-contracts-derive-inputs.md
+++ b/.changeset/admin-contracts-derive-inputs.md
@@ -1,0 +1,23 @@
+---
+"@voyantjs/admin-contracts": minor
+"@voyantjs/admin-client": patch
+---
+
+Derive admin operation inputs from the module contracts (single source of truth).
+
+`@voyantjs/admin-contracts` now derives its operation **input** schemas from the
+canonical route validation in `@voyantjs/bookings-contracts` and
+`@voyantjs/finance-contracts` instead of re-declaring them:
+
+- `recordPaymentInput` / `createPaymentLinkInput` are now `.pick()`ed from the
+  finance route schemas (removing the duplicated `PAYMENT_METHODS` enum), and
+  `confirmBookingInput` / `cancelBookingInput` reuse the bookings route schemas.
+  This eliminates the descriptor↔route drift class by construction — the SDK
+  input is the route's schema.
+- Output DTOs (`BookingSummary`, `InvoiceSummary`, `Payment`) stay curated and
+  loose (`status: z.string()`) for forward-compatibility with server-added enum
+  values.
+
+`InferInput` now resolves to `z.input` (the caller-facing, pre-parse type) so
+schema defaults (e.g. a payment `status` that defaults to `"pending"`) are
+optional for the caller rather than required.

--- a/packages/admin-contracts/package.json
+++ b/packages/admin-contracts/package.json
@@ -30,6 +30,8 @@
     "types": "./dist/index.d.ts"
   },
   "dependencies": {
+    "@voyantjs/bookings-contracts": "workspace:*",
+    "@voyantjs/finance-contracts": "workspace:*",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/admin-contracts/src/bookings.ts
+++ b/packages/admin-contracts/src/bookings.ts
@@ -1,12 +1,13 @@
 /**
  * Bookings admin operations (first slice: list, get, confirm, cancel).
  *
- * Output schemas are the curated client-facing projection of the booking
- * entity — not a 1:1 dump of `@voyantjs/bookings`' Drizzle row. When a
- * `@voyantjs/bookings-contracts` package exists, these should re-export from
- * it (see ADR-0002 / ADR-0003).
+ * Input schemas derive from `@voyantjs/bookings-contracts` (the canonical route
+ * validation) so the SDK can't drift from the routes. Output schemas stay a
+ * curated client-facing projection — loose where the field is a server-returned
+ * status, for forward-compatibility (see ADR-0002 / ADR-0003).
  */
 
+import { cancelBookingSchema, confirmBookingSchema } from "@voyantjs/bookings-contracts"
 import { z } from "zod"
 
 import { defineOperation } from "./core/operation.js"
@@ -40,14 +41,11 @@ export const bookingListInputSchema = pageQuerySchema.extend({
   dateTo: z.string().optional(),
 })
 
-export const confirmBookingInputSchema = z.object({
-  note: z.string().optional(),
-  suppressNotifications: z.boolean().optional(),
-})
-
-export const cancelBookingInputSchema = z.object({
-  note: z.string().optional(),
-})
+// Re-use the canonical route validation from @voyantjs/bookings-contracts so the
+// SDK input matches what the confirm/cancel routes accept (which also allow a
+// null note).
+export const confirmBookingInputSchema = confirmBookingSchema
+export const cancelBookingInputSchema = cancelBookingSchema
 
 const list = defineOperation({
   id: "bookings.list",

--- a/packages/admin-contracts/src/core/operation.ts
+++ b/packages/admin-contracts/src/core/operation.ts
@@ -91,7 +91,11 @@ type AnyOperation = OperationDescriptor<any, any, any>
 
 export type InferParams<D extends AnyOperation> =
   D extends OperationDescriptor<infer P, infer _I, infer _O> ? P : never
+// Input uses z.input (the caller-facing, pre-parse type) so schema defaults
+// (e.g. a status that defaults to "pending") are optional for the caller, not
+// required. Output uses z.infer (post-parse) since that's what the client
+// returns after parsing the response.
 export type InferInput<D extends AnyOperation> =
-  D extends OperationDescriptor<infer _P, infer I, infer _O> ? z.infer<I> : never
+  D extends OperationDescriptor<infer _P, infer I, infer _O> ? z.input<I> : never
 export type InferOutput<D extends AnyOperation> =
   D extends OperationDescriptor<infer _P, infer _I, infer O> ? z.infer<O> : never

--- a/packages/admin-contracts/src/finance.ts
+++ b/packages/admin-contracts/src/finance.ts
@@ -6,6 +6,10 @@
  * entities — not a 1:1 dump of `@voyantjs/finance`' Drizzle rows.
  */
 
+import {
+  createPaymentSessionFromInvoiceSchema,
+  insertPaymentSchema,
+} from "@voyantjs/finance-contracts"
 import { z } from "zod"
 
 import { defineOperation } from "./core/operation.js"
@@ -70,41 +74,31 @@ export const invoiceListInputSchema = pageQuerySchema.extend({
   search: z.string().optional(),
 })
 
-const PAYMENT_METHODS = [
-  "bank_transfer",
-  "credit_card",
-  "debit_card",
-  "cash",
-  "cheque",
-  "wallet",
-  "direct_bill",
-  "voucher",
-  "other",
-] as const
-
-export const recordPaymentInputSchema = z.object({
-  amountCents: z.number().int().positive(),
-  currency: z.string().length(3),
-  paymentMethod: z.enum(PAYMENT_METHODS),
-  paymentDate: z.string(),
-  status: z.enum(["pending", "completed", "failed", "refunded"]).optional(),
-  referenceNumber: z.string().max(255).optional(),
-  notes: z.string().optional(),
+// Derived from the route's canonical payment schema (`@voyantjs/finance-contracts`)
+// so the SDK input matches what `POST /invoices/:id/payments` accepts — single
+// source of truth, no re-declared payment-method / status enums.
+export const recordPaymentInputSchema = insertPaymentSchema.pick({
+  amountCents: true,
+  currency: true,
+  paymentMethod: true,
+  paymentDate: true,
+  status: true,
+  referenceNumber: true,
+  notes: true,
 })
 
-// The route derives currency + amount from the invoice balance, so they are
-// NOT accepted here. Fields mirror the route's payment-session provisioning
-// schema (all optional).
-export const createPaymentLinkInputSchema = z.object({
-  provider: z.string().optional(),
-  paymentMethod: z.enum(PAYMENT_METHODS).optional(),
-  payerEmail: z.string().email().optional(),
-  payerName: z.string().optional(),
-  returnUrl: z.string().url().optional(),
-  cancelUrl: z.string().url().optional(),
-  callbackUrl: z.string().url().optional(),
-  externalReference: z.string().optional(),
-  expiresAt: z.string().optional(),
+// Derived from the route's payment-session provisioning schema. The route
+// derives currency + amount from the invoice balance, so those are not picked.
+export const createPaymentLinkInputSchema = createPaymentSessionFromInvoiceSchema.pick({
+  provider: true,
+  paymentMethod: true,
+  payerEmail: true,
+  payerName: true,
+  returnUrl: true,
+  cancelUrl: true,
+  callbackUrl: true,
+  externalReference: true,
+  expiresAt: true,
 })
 
 const invoicesList = defineOperation({

--- a/packages/templating/package.json
+++ b/packages/templating/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyantjs/templating",
-  "version": "0.96.0",
+  "version": "0.97.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1082,6 +1082,12 @@ importers:
 
   packages/admin-contracts:
     dependencies:
+      '@voyantjs/bookings-contracts':
+        specifier: workspace:*
+        version: link:../bookings-contracts
+      '@voyantjs/finance-contracts':
+        specifier: workspace:*
+        version: link:../finance-contracts
       zod:
         specifier: ^4.3.6
         version: 4.3.6


### PR DESCRIPTION
Item #3 — closes the loop that motivated the whole module-contracts pass. `admin-contracts` had a comment literally saying *"when a bookings-contracts package exists, these should re-export from it."* Now it does.

## Approach (input/output asymmetry)

The key insight: a module's validation schema **is the route's validation schema**, so deriving the admin operation `input` from it eliminates descriptor↔route drift **by construction** — the same class of bug the Codex review caught by hand on #1446.

- **Inputs** derive from the canonical contracts:
  - `recordPaymentInput` = `insertPaymentSchema.pick({…})`, `createPaymentLinkInput` = `createPaymentSessionFromInvoiceSchema.pick({…})` — removes the duplicated `PAYMENT_METHODS` enum
  - `confirmBookingInput` / `cancelBookingInput` reuse `bookings-contracts`' route schemas (which also allow a `null` note — strictly more route-correct)
- **Outputs** stay curated + loose (`status: z.string()`) — they're admin-specific projections, and the SDK must tolerate server-added enum values (forward-compat). Deliberately *not* strict-typed.

## A latent bug this surfaced

Deriving exposed that `InferInput` used `z.infer` (= **output** type), which made a defaulted field like payment `status` *required* for the caller. Fixed to `z.input` (caller-facing, pre-parse) so schema defaults are optional. (admin-client typecheck caught it.)

## Also in this PR

Realign `@voyantjs/templating` `0.96.0 → 0.97.0` — it was stranded after the #1455 release bumped the fixed group post-#1456 merge (same recurring "branched-before-release" stranding). Needed for the train check to pass.

## Verification

- `pnpm typecheck` — 144/144
- admin tests — admin-contracts 6, admin-client 6 (incl. the payment-record input that no longer needs `status`)
- `pnpm verify:release-train` — 136 packages on 0.97.0
- lint clean