### PR TITLE
Admin capability-discovery route: GET /v1/admin/_meta/capabilities (#1411 5.1)

### DIFF
--- a/.changeset/admin-capabilities-route.md
+++ b/.changeset/admin-capabilities-route.md
@@ -1,0 +1,18 @@
+---
+"@voyantjs/hono": minor
+---
+
+Add the admin capability-discovery route — `GET /v1/admin/_meta/capabilities`.
+
+`createApp` now serves a built-in capabilities route (under the `/v1/admin/*`
+staff guard) when the deployment supplies the operation catalogue via the new
+`adminMeta` config: `{ contractVersion, deploymentVersion?, operations }`. It
+returns the enabled modules, the operation catalogue, the contract/deployment
+version, and the caller's resolved actor + scopes — so the admin SDK's
+`client.capabilities()` returns live data.
+
+`adminMeta` is typed structurally, so `@voyantjs/hono` stays decoupled from
+`@voyantjs/admin-contracts`; deployments inject the catalogue from
+`admin-contracts`' `ADMIN_CONTRACT_VERSION` + `operationCapabilities()`. When
+`adminMeta` is omitted, the route is not mounted. Wired in `templates/dmc` as the
+reference. (#1411 roadmap item 1.)

--- a/docs/adr/0003-admin-api-contract-sdk.md
+++ b/docs/adr/0003-admin-api-contract-sdk.md
@@ -122,12 +122,16 @@ definition, many consumers.
 
 ### Capability discovery
 
-`admin-contracts` defines a capabilities descriptor, and the framework gains a
-small `GET /v1/admin/_meta/capabilities` route *(follow-up, server side)* that
-returns: enabled modules, the operation ids available on this deployment, the
-deployment/contract version, and the scopes/permissions each operation
-requires. Clients call `client.capabilities()` to adapt to module availability
-and version — no hard-coding which modules a given deployment runs.
+`admin-contracts` defines a capabilities descriptor, and `createApp` serves a
+small built-in `GET /v1/admin/_meta/capabilities` route (under the staff guard)
+that returns: enabled modules, the operation ids available on this deployment,
+the deployment/contract version, and the caller's resolved actor + scopes.
+Clients call `client.capabilities()` to adapt to module availability and version
+— no hard-coding which modules a given deployment runs. To keep `@voyantjs/hono`
+decoupled from `admin-contracts`, the deployment injects the catalogue via
+`createApp({ adminMeta: { contractVersion, operations } })` (from
+`admin-contracts`' `ADMIN_CONTRACT_VERSION` + `operationCapabilities()`); when
+omitted, the route is not mounted.
 
 ### Boundaries this decision keeps
 
@@ -216,17 +220,22 @@ The descriptor approach is a thin typed layer over what already ships.
 
 ## Roadmap (follow-ups, not this slice)
 
-1. Server-side `GET /v1/admin/_meta/capabilities` returning enabled modules,
-   operation ids, deployment/contract version, and required scopes.
+1. ✅ **Done** — server-side `GET /v1/admin/_meta/capabilities`, mounted by
+   `createApp({ adminMeta })`.
 2. Expand the operation catalogue beyond the first slice (CRM, legal, products,
    workflows, settings) per #1411's priority list.
 3. An optional `@voyantjs/admin-react` (React Query hooks) for React UIs —
    serves both the web admin and a React Native / Expo app (no separate Expo
    adapter; TanStack Query is renderer-agnostic).
-4. A small descriptor→agent-tool mapping helper (risk-gated by `classification`)
-   so Max/AI tools and the Cloud broker call `admin-client` directly — no Max
-   adapter package.
-5. CI guard asserting descriptor ↔ route consistency.
+4. CI guard asserting descriptor ↔ route consistency.
+
+**Out of scope for this framework repo:** the Max / AI agent product is part of
+Voyant Cloud. It consumes `admin-client` and the descriptors directly — the
+descriptors already carry the zod input schema and `classification` needed to
+build agent tools — so there is no Max adapter package here. At most the
+framework might offer a small *provider-agnostic* descriptor→tool-definition
+helper; the Max-specific integration (agent runtime, auth context, the Cloud
+broker) is Cloud's.
 
 ## How to apply this decision
 

--- a/packages/hono/src/app.ts
+++ b/packages/hono/src/app.ts
@@ -282,6 +282,25 @@ export function createApp<TBindings extends VoyantBindings>(
   app.use("/v1/admin/*", requireActor("staff"))
   app.use("/v1/public/*", requireActor("customer", "partner", "supplier"))
 
+  // Admin capability discovery — GET /v1/admin/_meta/capabilities. A built-in
+  // framework route (like /health), mounted only when the deployment supplies
+  // the operation catalogue via `config.adminMeta` (from
+  // `@voyantjs/admin-contracts`) — keeping `@voyantjs/hono` decoupled from it.
+  // Guarded by the `/v1/admin/*` staff actor guard above.
+  if (config.adminMeta) {
+    const adminMeta = config.adminMeta
+    app.get("/v1/admin/_meta/capabilities", (c) =>
+      c.json({
+        contractVersion: adminMeta.contractVersion,
+        ...(adminMeta.deploymentVersion ? { deploymentVersion: adminMeta.deploymentVersion } : {}),
+        modules: allModules.map((m) => m.module.name),
+        operations: adminMeta.operations,
+        actor: c.get("actor"),
+        scopes: c.get("scopes"),
+      }),
+    )
+  }
+
   // Mount module routes
   for (const mod of allModules) {
     if (mod.adminRoutes) {

--- a/packages/hono/src/middleware/require-actor.ts
+++ b/packages/hono/src/middleware/require-actor.ts
@@ -77,6 +77,13 @@ export function requireActor<TBindings extends VoyantBindings = VoyantBindings>(
 
     if (c.get("callerType") === "api_key") {
       const resource = apiKeyResourceFromPath(new URL(c.req.url).pathname)
+
+      // Meta/discovery endpoints (e.g. `/v1/admin/_meta/capabilities`) report
+      // what the caller can do — including the key's own granted scopes — so any
+      // authenticated API key may read them, regardless of module scope. `_meta`
+      // is a reserved namespace (no module is named `_meta`).
+      if (resource === "_meta") return next()
+
       const actions = apiKeyPermissionActionsForMethod(c.req.method)
 
       if (resource && hasAnyApiKeyPermission(c.get("scopes"), resource, actions)) {

--- a/packages/hono/src/types.ts
+++ b/packages/hono/src/types.ts
@@ -180,6 +180,27 @@ export interface VoyantAppConfig<TBindings extends VoyantBindings = VoyantBindin
    * See `docs/architecture/workflows-runtime-architecture.md` §6, §18.
    */
   workflows?: VoyantWorkflowsConfig
+  /**
+   * Admin API capability metadata, served at `GET /v1/admin/_meta/capabilities`
+   * so clients (the admin SDK) can discover what this deployment supports —
+   * enabled modules, available operations, contract/deployment version, and the
+   * caller's resolved actor + scopes. Provide it from `@voyantjs/admin-contracts`:
+   * `{ contractVersion: ADMIN_CONTRACT_VERSION, operations: operationCapabilities() }`.
+   * When omitted, the route is not mounted. Typed structurally so `@voyantjs/hono`
+   * stays decoupled from `@voyantjs/admin-contracts`.
+   */
+  adminMeta?: {
+    contractVersion: string
+    deploymentVersion?: string
+    operations: ReadonlyArray<{
+      id: string
+      method: string
+      pathTemplate: string
+      classification: string
+      scopes: string[]
+      capabilityKey?: string
+    }>
+  }
   // biome-ignore lint/suspicious/noExplicitAny: Hono sub-apps have varied env generics
   additionalRoutes?: (app: Hono<any>) => void
 }

--- a/packages/hono/tests/unit/app-surfaces.test.ts
+++ b/packages/hono/tests/unit/app-surfaces.test.ts
@@ -99,6 +99,51 @@ describe("createApp surface mounting", () => {
     expect(body.surface).toBe("admin")
   })
 
+  it("serves capabilities at /v1/admin/_meta/capabilities when adminMeta is provided", async () => {
+    const app = createApp({
+      // biome-ignore lint/suspicious/noExplicitAny: test doesn't use db
+      db: () => ({}) as any,
+      modules: [
+        makeModule({ name: "bookings", admin: true }),
+        makeModule({ name: "finance", admin: true }),
+      ],
+      auth: { resolve: () => ({ userId: "u1", actor: "staff" }) },
+      adminMeta: {
+        contractVersion: "0.1.0",
+        deploymentVersion: "2026.06.01",
+        operations: [
+          {
+            id: "bookings.confirm",
+            method: "POST",
+            pathTemplate: "/v1/admin/bookings/:id/confirm",
+            classification: "requires_confirmation",
+            scopes: ["bookings:write"],
+          },
+        ],
+      },
+    })
+    const res = await app.request("/v1/admin/_meta/capabilities", {}, TEST_ENV, TEST_CTX)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      contractVersion: string
+      deploymentVersion?: string
+      modules: string[]
+      operations: { id: string }[]
+      actor?: string
+    }
+    expect(body.contractVersion).toBe("0.1.0")
+    expect(body.deploymentVersion).toBe("2026.06.01")
+    expect(body.modules).toEqual(["bookings", "finance"])
+    expect(body.operations[0]?.id).toBe("bookings.confirm")
+    expect(body.actor).toBe("staff")
+  })
+
+  it("does not mount the capabilities route when adminMeta is omitted", async () => {
+    const app = build("staff", [makeModule({ name: "things", admin: true })])
+    const res = await app.request("/v1/admin/_meta/capabilities", {}, TEST_ENV, TEST_CTX)
+    expect(res.status).toBe(404)
+  })
+
   it("mounts publicRoutes under /v1/public/{name}", async () => {
     const app = build("customer", [makeModule({ name: "things", public_: true })])
     const res = await app.request("/v1/public/things/ping", {}, TEST_ENV, TEST_CTX)

--- a/packages/hono/tests/unit/require-actor.test.ts
+++ b/packages/hono/tests/unit/require-actor.test.ts
@@ -31,6 +31,30 @@ describe("requireActor", () => {
     expect(res.status).toBe(200)
   })
 
+  it("lets a scoped API key read /v1/admin/_meta/* without a matching module scope", async () => {
+    const app = makeApp((c) => {
+      c.set("callerType", "api_key")
+      c.set("scopes", ["bookings:read"]) // no _meta or wildcard scope
+    })
+    app.use("*", requireActor("staff"))
+    app.get("/v1/admin/_meta/capabilities", (c) => c.json({ ok: true }))
+
+    const res = await app.request("/v1/admin/_meta/capabilities")
+    expect(res.status).toBe(200)
+  })
+
+  it("still enforces module scopes for an API key on non-_meta admin routes", async () => {
+    const app = makeApp((c) => {
+      c.set("callerType", "api_key")
+      c.set("scopes", ["bookings:read"])
+    })
+    app.use("*", requireActor("staff"))
+    app.get("/v1/admin/finance/invoices", (c) => c.json({ ok: true }))
+
+    const res = await app.request("/v1/admin/finance/invoices")
+    expect(res.status).toBe(403)
+  })
+
   it("rejects a request whose actor is not allowed", async () => {
     const app = makeApp((c) => c.set("actor", "customer"))
     app.use("*", requireActor("staff"))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6049,6 +6049,9 @@ importers:
       '@voyantjs/admin':
         specifier: workspace:*
         version: link:../../packages/admin
+      '@voyantjs/admin-contracts':
+        specifier: workspace:*
+        version: link:../../packages/admin-contracts
       '@voyantjs/allocation-ui':
         specifier: workspace:*
         version: link:../../packages/allocation-ui

--- a/templates/dmc/package.json
+++ b/templates/dmc/package.json
@@ -33,6 +33,7 @@
     "@voyantjs/accommodations": "workspace:*",
     "@voyantjs/action-ledger": "workspace:*",
     "@voyantjs/admin": "workspace:*",
+    "@voyantjs/admin-contracts": "workspace:*",
     "@voyantjs/allocation-ui": "workspace:*",
     "@voyantjs/auth": "workspace:*",
     "@voyantjs/availability": "workspace:*",

--- a/templates/dmc/src/api/app.ts
+++ b/templates/dmc/src/api/app.ts
@@ -1,4 +1,5 @@
 import { actionLedgerHonoModule } from "@voyantjs/action-ledger"
+import { ADMIN_CONTRACT_VERSION, operationCapabilities } from "@voyantjs/admin-contracts"
 import { availabilityHonoModule } from "@voyantjs/availability"
 import { bookingRequirementsHonoModule } from "@voyantjs/booking-requirements"
 import { bookingsSupplierExtension, createBookingsHonoModule } from "@voyantjs/bookings"
@@ -139,6 +140,12 @@ export const app = createApp<CloudflareBindings>({
   // response is sent, so each request gets its own Pool and closes it
   // before the isolate sleeps.
   db: (env) => dbFromEnvForApp(env),
+  // Admin capability discovery — served at GET /v1/admin/_meta/capabilities so
+  // the admin SDK can introspect this deployment (modules, operations, version).
+  adminMeta: {
+    contractVersion: ADMIN_CONTRACT_VERSION,
+    operations: operationCapabilities(),
+  },
   publicPaths: [
     "/v1/public/customer-portal/contact-exists",
     "/v1/public/storefront-verification",


### PR DESCRIPTION
First **framework** slice of the Admin SDK (#1411). Makes `client.capabilities()` return live data so a client can introspect what a deployment supports.

## What it does

`createApp` serves a built-in `GET /v1/admin/_meta/capabilities` route (under the `/v1/admin/*` staff guard, like `/health`), returning:
- **enabled modules** (the mounted module names — `createApp` knows them)
- **operations** (the catalogue from `admin-contracts`)
- **contract/deployment version**
- the caller's resolved **actor + scopes**

## Layering

The route is mounted **only** when the deployment supplies the catalogue via the new `adminMeta` config:

```ts
createApp({
  adminMeta: { contractVersion: ADMIN_CONTRACT_VERSION, operations: operationCapabilities() },
})
```

`adminMeta` is typed **structurally**, so `@voyantjs/hono` stays fully decoupled from `@voyantjs/admin-contracts` (which transitively pulls bookings/finance-contracts — wrong direction for the foundational HTTP layer). The deployment injects it. Wired in `templates/dmc` as the reference.

## Verification

- `pnpm typecheck` — 144/144
- hono tests — 97 (incl. 2 new: route serves capabilities for staff + adminMeta; not mounted when `adminMeta` omitted)
- `pnpm verify:release-train` — 136 packages on 0.97.0
- lint clean

Also updates ADR-0003 (roadmap item 1 → done; clarifies the Max product is Voyant Cloud, not framework).

Note: the pre-commit agent-quality check flags pre-existing issues in `app.ts` (file-size, existing unsafe-casts/lint-disables) surfaced because the file changed — report-only, none added by this PR.