### PR TITLE
Add admin-contracts descriptor consistency guard (#1411 slice 5.4)

### DIFF
--- a/.changeset/admin-contracts-consistency-guard.md
+++ b/.changeset/admin-contracts-consistency-guard.md
@@ -1,0 +1,11 @@
+---
+"@voyantjs/admin-contracts": patch
+---
+
+Add a descriptor consistency guard (test): asserts every admin operation
+descriptor is well-formed and internally consistent — unique ids, an
+`/v1/admin/<domain>` path matching the operation's id prefix, a valid
+method/classification, `resource:action` scopes, and a `path()` builder that
+substitutes every template param. Catches the authoring-drift class that makes a
+descriptor diverge from the API surface. (The complementary live route-existence
+check belongs in a deployment test; #1411 5.4.)

--- a/packages/admin-contracts/src/consistency.test.ts
+++ b/packages/admin-contracts/src/consistency.test.ts
@@ -21,6 +21,13 @@ const VALID_CLASSIFICATIONS: ActionClassification[] = [
   "requires_confirmation",
 ]
 
+// Mirrors the canonical API-key scope grammar (`permissionStringPattern` in
+// `packages/types/src/api-keys.ts`): a lowercase, hyphen-allowed `resource:action`
+// pair — so PII-aware scopes like `bookings-pii:read` are accepted. Descriptors
+// always name concrete scopes, so the `*` wildcards the canonical pattern allows
+// are intentionally disallowed here (a wildcard in a descriptor is a bug).
+const SCOPE = /^[a-z][a-z0-9-]*:[a-z][a-z0-9-]*$/
+
 describe("admin-contracts descriptor consistency", () => {
   it("has unique operation ids", () => {
     const ids = allOperations.map((op) => op.id)
@@ -41,21 +48,29 @@ describe("admin-contracts descriptor consistency", () => {
       expect(VALID_METHODS, op.id).toContain(op.method)
       expect(VALID_CLASSIFICATIONS, op.id).toContain(op.classification)
 
-      // Scopes are `resource:action`.
+      // Scopes are a canonical `resource:action` pair (hyphens allowed).
       for (const scope of op.scopes) {
-        expect(scope, `${op.id} scope`).toMatch(/^[a-z_]+:[a-z_]+$/)
+        expect(scope, `${op.id} scope`).toMatch(SCOPE)
       }
 
-      // `path()` substitutes every `:param` from the template and leaves no
-      // unresolved params — so the descriptor's path builder matches its
-      // declared template shape.
+      // `path()` must reproduce `pathTemplate` exactly once every `:param` is
+      // substituted by a distinct sample value. Comparing the whole built path
+      // to the substituted template catches omitted, reordered, AND
+      // unsubstituted params — not just a leftover `/:`. (e.g. a `/:id/confirm`
+      // template whose builder returns `.../confirm` would slip past a mere
+      // "no leftover colon" check but calls the wrong route.)
       const params: Record<string, string> = {}
-      for (const seg of op.pathTemplate.split("/")) {
-        if (seg.startsWith(":")) params[seg.slice(1)] = "sample"
-      }
+      const expectedPath = op.pathTemplate
+        .split("/")
+        .map((seg) => {
+          if (!seg.startsWith(":")) return seg
+          const name = seg.slice(1)
+          params[name] = `sample-${name}`
+          return params[name]
+        })
+        .join("/")
       const built = op.path(params as never)
-      expect(built.startsWith("/v1/admin/"), op.id).toBe(true)
-      expect(built.includes("/:"), `${op.id} has an unsubstituted param`).toBe(false)
+      expect(built, `${op.id} path() must match its declared template`).toBe(expectedPath)
     }
   })
 })

--- a/packages/admin-contracts/src/consistency.test.ts
+++ b/packages/admin-contracts/src/consistency.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+
+import { type ActionClassification, allOperations, type HttpMethod } from "./index.js"
+
+/**
+ * Descriptor drift guard. Asserts every admin operation descriptor is
+ * well-formed and internally consistent — catching the authoring mistakes that
+ * make a descriptor diverge from the API surface (bad path, wrong module
+ * segment, malformed scope, unsubstituted param).
+ *
+ * The complementary route-EXISTENCE check (every descriptor resolves to a
+ * mounted admin route on a live app) belongs in a deployment test where
+ * `@voyantjs/hono` + the domain modules are available; this pure layer runs
+ * with no cross-package wiring.
+ */
+const VALID_METHODS: HttpMethod[] = ["GET", "POST", "PATCH", "PUT", "DELETE"]
+const VALID_CLASSIFICATIONS: ActionClassification[] = [
+  "read",
+  "routine_write",
+  "destructive",
+  "requires_confirmation",
+]
+
+describe("admin-contracts descriptor consistency", () => {
+  it("has unique operation ids", () => {
+    const ids = allOperations.map((op) => op.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it("every descriptor is well-formed and internally consistent", () => {
+    for (const op of allOperations) {
+      // Admin surface path.
+      expect(op.pathTemplate, op.id).toMatch(/^\/v1\/admin\//)
+
+      // The path's module segment matches the operation id's domain prefix
+      // (e.g. `finance.invoices.list` → `/v1/admin/finance/...`).
+      const domain = op.id.split(".")[0]
+      expect(op.pathTemplate.startsWith(`/v1/admin/${domain}`), op.id).toBe(true)
+
+      // Valid method + classification.
+      expect(VALID_METHODS, op.id).toContain(op.method)
+      expect(VALID_CLASSIFICATIONS, op.id).toContain(op.classification)
+
+      // Scopes are `resource:action`.
+      for (const scope of op.scopes) {
+        expect(scope, `${op.id} scope`).toMatch(/^[a-z_]+:[a-z_]+$/)
+      }
+
+      // `path()` substitutes every `:param` from the template and leaves no
+      // unresolved params — so the descriptor's path builder matches its
+      // declared template shape.
+      const params: Record<string, string> = {}
+      for (const seg of op.pathTemplate.split("/")) {
+        if (seg.startsWith(":")) params[seg.slice(1)] = "sample"
+      }
+      const built = op.path(params as never)
+      expect(built.startsWith("/v1/admin/"), op.id).toBe(true)
+      expect(built.includes("/:"), `${op.id} has an unsubstituted param`).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
A pure, dependency-free **descriptor consistency guard** for the Admin API contract (`@voyantjs/admin-contracts`). A vitest test walks every `OperationDescriptor` in `allOperations` and asserts it is well-formed and internally consistent:

- **Unique operation ids** across the registry.
- **Module segment matches id prefix** — e.g. `finance.invoices.list` → `/v1/admin/finance/...`.
- **Valid `method` + `classification`**.
- **Canonical `resource:action` scopes** — mirrors the API-key scope grammar (hyphens allowed, so `bookings-pii:read` is accepted).
- **`path()` reproduces `pathTemplate`** once each `:param` is substituted with a distinct sample value — catching omitted/reordered/unsubstituted params, not just a leftover `/:`.

This is slice **5.4** of #1411. #3 already eliminated the input-schema drift class (admin inputs derive from the module-contracts route schemas); this guard closes the remaining authoring-drift class at the layer where the descriptors live. The complementary live route-existence check is deferred to a deployment test.

Both Codex P2s addressed (scope grammar + path/template comparison).

> Note: the catalogue expansion (CRM/legal/products) and the `@voyantjs/admin-react` package (slices 5.2/5.3) are **not** in this PR — they land separately. An earlier edit briefly mis-scoped this title; corrected.
