### PR TITLE
Fix pricing-grid room columns and constrain room allocation to booked type (#1476)

### DIFF
--- a/.changeset/room-pricing-columns-and-allocation.md
+++ b/.changeset/room-pricing-columns-and-allocation.md
@@ -1,9 +1,10 @@
 ---
 "@voyantjs/availability": minor
+"@voyantjs/availability-react": patch
 "@voyantjs/products-ui": patch
 ---
 
 Fix room-typed pricing categories leaking into the pricing grid, and make room allocation respect the booked room type (#1476).
 
 - **Pricing grid no longer shows a bogus price column per room type.** The rooms/seats grid built one traveler-type column from every in-scope pricing category, so a tenant whose data carries `room`/`vehicle`/`service`-typed categories — e.g. a global default set or legacy-migrated "Double room" categories — got a phantom price column for each room alongside the real Adult/Child split. Columns are now restricted to per-traveler categories via a new `isTravelerCategory` guard, with an escape hatch that still surfaces any category that actually has a price cell (no data loss). Applies to both the merged grid and the Advanced view.
-- **"Generate from rooms" now creates `room`-kind resource templates keyed by `option_unit`.** Previously each room type became its own distinct template `kind`, which the allocator couldn't use to constrain a traveler to their booked room type. Templates now share `kind: "room"` and carry `refType: "option_unit"` / `refId`, so the auto-allocator's unit match keeps a Double-booked traveler in a Double room. The `(product_option_id, kind)` unique index is widened to `(product_option_id, kind, coalesce(ref_id, ''))` to allow one room template per unit, and the per-slot materializer's skip-existing check is refined to `(kind, ref_id)`.
+- **"Generate from rooms" now creates `room`-kind resource templates keyed by `option_unit`.** Previously each room type became its own distinct template `kind`, which the allocator couldn't use to constrain a traveler to their booked room type. Templates now share `kind: "room"` and carry `refType: "option_unit"` / `refId`, so the auto-allocator's unit match keeps a Double-booked traveler in a Double room. The `(product_option_id, kind)` unique index is widened to `(product_option_id, kind, coalesce(ref_id, ''))` to allow one room template per unit, and the per-slot materializer's skip-existing check is refined to `(kind, ref_id)`. Template upsert and delete now resolve a row by `(option, kind, ref_id)` so editing or removing one room type no longer affects its siblings, and the panel labels each room template by its unit name.

--- a/.changeset/room-pricing-columns-and-allocation.md
+++ b/.changeset/room-pricing-columns-and-allocation.md
@@ -1,0 +1,9 @@
+---
+"@voyantjs/availability": minor
+"@voyantjs/products-ui": patch
+---
+
+Fix room-typed pricing categories leaking into the pricing grid, and make room allocation respect the booked room type (#1476).
+
+- **Pricing grid no longer shows a bogus price column per room type.** The rooms/seats grid built one traveler-type column from every in-scope pricing category, so a tenant whose data carries `room`/`vehicle`/`service`-typed categories — e.g. a global default set or legacy-migrated "Double room" categories — got a phantom price column for each room alongside the real Adult/Child split. Columns are now restricted to per-traveler categories via a new `isTravelerCategory` guard, with an escape hatch that still surfaces any category that actually has a price cell (no data loss). Applies to both the merged grid and the Advanced view.
+- **"Generate from rooms" now creates `room`-kind resource templates keyed by `option_unit`.** Previously each room type became its own distinct template `kind`, which the allocator couldn't use to constrain a traveler to their booked room type. Templates now share `kind: "room"` and carry `refType: "option_unit"` / `refId`, so the auto-allocator's unit match keeps a Double-booked traveler in a Double room. The `(product_option_id, kind)` unique index is widened to `(product_option_id, kind, coalesce(ref_id, ''))` to allow one room template per unit, and the per-slot materializer's skip-existing check is refined to `(kind, ref_id)`.

--- a/packages/availability-react/src/hooks/use-slot-allocation.ts
+++ b/packages/availability-react/src/hooks/use-slot-allocation.ts
@@ -166,9 +166,21 @@ export function useResourceTemplateMutation(productId: string) {
   })
 
   const remove = useMutation({
-    mutationFn: async ({ optionId, kind }: { optionId: string; kind: string }) =>
+    // refId targets a single template when an option holds several of the same
+    // kind (e.g. one "room" per option_unit); omit it for ref-less templates.
+    mutationFn: async ({
+      optionId,
+      kind,
+      refId,
+    }: {
+      optionId: string
+      kind: string
+      refId?: string | null
+    }) =>
       fetchWithValidation(
-        `/v1/admin/availability/products/${productId}/options/${optionId}/allocation/resource-templates/${kind}`,
+        `/v1/admin/availability/products/${productId}/options/${optionId}/allocation/resource-templates/${kind}${
+          refId ? `?refId=${encodeURIComponent(refId)}` : ""
+        }`,
         singleEnvelope(z.object({ productOptionId: z.string(), kind: z.string() })),
         { baseUrl, fetcher },
         { method: "DELETE" },

--- a/packages/availability/src/routes-allocation.ts
+++ b/packages/availability/src/routes-allocation.ts
@@ -150,6 +150,7 @@ export const availabilityAllocationRoutes = new Hono<Env>()
           c.req.param("productId"),
           c.req.param("optionId"),
           c.req.param("kind"),
+          c.req.query("refId") ?? null,
         )
         return data ? c.json({ data }) : c.json({ error: "Resource template not found" }, 404)
       } catch (error) {

--- a/packages/availability/src/schema.ts
+++ b/packages/availability/src/schema.ts
@@ -1,5 +1,5 @@
 import { typeId, typeIdRef } from "@voyantjs/db/lib/typeid-column"
-import { relations } from "drizzle-orm"
+import { relations, sql } from "drizzle-orm"
 import {
   boolean,
   date,
@@ -239,9 +239,15 @@ export const productOptionResourceTemplates = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
+    // Unique per (option, kind, ref) — `COALESCE(ref_id,'')` keeps "one
+    // non-ref template per kind" while allowing multiple unit-keyed room
+    // templates under one option (Single/Double/Triple all kind="room",
+    // distinguished by their option_unit ref). The allocator's option_unit
+    // matching depends on this.
     uniqueIndex("idx_product_option_resource_templates_option_kind").on(
       table.productOptionId,
       table.kind,
+      sql`coalesce(${table.refId}, '')`,
     ),
     index("idx_product_option_resource_templates_kind").on(table.kind, table.createdAt),
   ],

--- a/packages/availability/src/service-allocation-automation.ts
+++ b/packages/availability/src/service-allocation-automation.ts
@@ -139,33 +139,46 @@ export async function upsertProductOptionResourceTemplate(
 ): Promise<ResourceTemplate> {
   await assertProductOptionBelongsToProduct(db, productId, productOptionId)
 
-  const [row] = await db
-    .insert(productOptionResourceTemplates)
-    .values({
-      productOptionId,
-      kind,
-      refType: input.refType ?? null,
-      refId: input.refId ?? null,
-      capacity: input.capacity,
-      namePattern: input.namePattern,
-      layout: input.layout ?? null,
-      defaultCount: input.defaultCount ?? null,
-      flags: input.flags ?? {},
-    })
-    .onConflictDoUpdate({
-      target: [productOptionResourceTemplates.productOptionId, productOptionResourceTemplates.kind],
-      set: {
-        refType: input.refType ?? null,
-        refId: input.refId ?? null,
-        capacity: input.capacity,
-        namePattern: input.namePattern,
-        layout: input.layout ?? null,
-        defaultCount: input.defaultCount ?? null,
-        flags: input.flags ?? {},
-        updatedAt: new Date(),
-      },
-    })
-    .returning()
+  const refId = input.refId ?? null
+  const values = {
+    refType: input.refType ?? null,
+    refId,
+    capacity: input.capacity,
+    namePattern: input.namePattern,
+    layout: input.layout ?? null,
+    defaultCount: input.defaultCount ?? null,
+    flags: input.flags ?? {},
+  }
+
+  // An option can hold several templates of the same kind, one per option_unit
+  // (see the widened unique index in migration 0053:
+  // (product_option_id, kind, coalesce(ref_id, ''))). Drizzle 0.45 can't express
+  // that coalesce in an onConflict target, so we resolve the row by (option,
+  // kind, refId) ourselves — coalescing so a null refId matches the ref-less
+  // template — then update it in place or insert a new one. The unique index
+  // still guards against a concurrent duplicate.
+  const [existing] = await db
+    .select({ id: productOptionResourceTemplates.id })
+    .from(productOptionResourceTemplates)
+    .where(
+      and(
+        eq(productOptionResourceTemplates.productOptionId, productOptionId),
+        eq(productOptionResourceTemplates.kind, kind),
+        sql`coalesce(${productOptionResourceTemplates.refId}, '') = ${refId ?? ""}`,
+      ),
+    )
+    .limit(1)
+
+  const [row] = existing
+    ? await db
+        .update(productOptionResourceTemplates)
+        .set({ ...values, updatedAt: new Date() })
+        .where(eq(productOptionResourceTemplates.id, existing.id))
+        .returning()
+    : await db
+        .insert(productOptionResourceTemplates)
+        .values({ productOptionId, kind, ...values })
+        .returning()
 
   if (!row) throw new AllocationServiceError("Resource template upsert failed", 500)
   return {
@@ -189,15 +202,21 @@ export async function deleteProductOptionResourceTemplate(
   productId: string,
   productOptionId: string,
   kind: string,
+  refId?: string | null,
 ) {
   await assertProductOptionBelongsToProduct(db, productId, productOptionId)
 
+  // An option can hold several templates of the same kind (e.g. one "room"
+  // per option_unit), distinguished by ref_id. Match the specific row via
+  // coalesce so a null refId targets the ref-less template rather than wiping
+  // every row of that kind.
   const [row] = await db
     .delete(productOptionResourceTemplates)
     .where(
       and(
         eq(productOptionResourceTemplates.productOptionId, productOptionId),
         eq(productOptionResourceTemplates.kind, kind),
+        sql`coalesce(${productOptionResourceTemplates.refId}, '') = coalesce(${refId ?? null}, '')`,
       ),
     )
     .returning({ id: productOptionResourceTemplates.id })

--- a/packages/availability/src/service-allocation-automation.ts
+++ b/packages/availability/src/service-allocation-automation.ts
@@ -487,12 +487,16 @@ export async function materializeSlotResourcesFromTemplateDefaults(
 
   const skipExisting = opts.skipExisting !== false
   const existing = skipExisting
-    ? await executeRows<{ kind: string }>(
+    ? await executeRows<{ kind: string; ref_id: string | null }>(
         db,
-        sql`SELECT DISTINCT kind FROM allocation_resources WHERE slot_id = ${slotId}`,
+        sql`SELECT DISTINCT kind, ref_id FROM allocation_resources WHERE slot_id = ${slotId}`,
       )
     : []
-  const existingKinds = new Set(existing.map((row) => row.kind))
+  // Key by (kind, ref) — not kind alone — so a second room type (another
+  // option_unit, same kind="room") still materializes when re-applying, rather
+  // than the whole "room" kind being skipped once one room exists.
+  const templateKey = (kind: string, refId: string | null) => `${kind}::${refId ?? ""}`
+  const existingKeys = new Set(existing.map((row) => templateKey(row.kind, row.ref_id)))
 
   const resources: AllocationResource[] = []
   let sequence = 0
@@ -500,7 +504,7 @@ export async function materializeSlotResourcesFromTemplateDefaults(
   for (const template of templates) {
     if (template.defaultCount == null || template.defaultCount <= 0) continue
     if (template.kind === "vehicle_seat") continue
-    if (skipExisting && existingKinds.has(template.kind)) continue
+    if (skipExisting && existingKeys.has(templateKey(template.kind, template.refId))) continue
 
     for (let index = 0; index < template.defaultCount; index++) {
       sequence += 1

--- a/packages/products-ui/src/components/product-detail/pricing-grid-columns.test.ts
+++ b/packages/products-ui/src/components/product-detail/pricing-grid-columns.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+
+import { isTravelerCategory } from "./product-options-pricing.js"
+
+describe("isTravelerCategory", () => {
+  // Traveler/pax categories are the per-person price columns in the rooms/seats
+  // grid and must be kept.
+  it.each([
+    "adult",
+    "child",
+    "infant",
+    "senior",
+    "group",
+    "other",
+  ] as const)("treats %s as a traveler column", (categoryType) => {
+    expect(isTravelerCategory({ categoryType })).toBe(true)
+  })
+
+  // room/vehicle describe the unit dimension (already the grid rows) and
+  // `service` is a standalone add-on — none are per-traveler price columns.
+  // A product carrying these (e.g. a legacy "Double room" pricing category, or
+  // a tenant-wide default set) must not sprout a bogus column per room.
+  it.each([
+    "room",
+    "vehicle",
+    "service",
+  ] as const)("excludes %s from traveler columns", (categoryType) => {
+    expect(isTravelerCategory({ categoryType })).toBe(false)
+  })
+})

--- a/packages/products-ui/src/components/product-detail/product-option-pricing-grid.tsx
+++ b/packages/products-ui/src/components/product-detail/product-option-pricing-grid.tsx
@@ -20,6 +20,7 @@ import {
   ExtraPriceRulesPanel,
   formatProductMoney,
   getCategoryCondition,
+  isTravelerCategory,
   TravelerCategoryDialog,
 } from "./product-options-pricing.js"
 import {
@@ -160,7 +161,8 @@ export function OptionPricingGrid({
     .filter(
       (category) =>
         category.active &&
-        (((category.productId == null || category.productId === productId) &&
+        ((isTravelerCategory(category) &&
+          (category.productId == null || category.productId === productId) &&
           (category.optionId == null || category.optionId === optionId)) ||
           referencedCategoryIds.has(category.id)),
     )

--- a/packages/products-ui/src/components/product-detail/product-options-pricing.tsx
+++ b/packages/products-ui/src/components/product-detail/product-options-pricing.tsx
@@ -105,6 +105,24 @@ export function getUnitTypeLabel(
   }
 }
 
+// Pricing categories that describe the *unit* dimension (room/vehicle — already
+// the grid's rows) or a standalone add-on (`service`, handled by the extras
+// panel) are not per-traveler price columns. Excluding them stops a product
+// whose data carries such categories — e.g. legacy data migrated with a
+// "Double room" pricing category alongside the real Adult/Child split — from
+// rendering one bogus price column per room next to the traveler columns.
+const NON_TRAVELER_CATEGORY_TYPES = new Set<PricingCategoryRecord["categoryType"]>([
+  "room",
+  "vehicle",
+  "service",
+])
+
+export function isTravelerCategory(category: {
+  categoryType: PricingCategoryRecord["categoryType"]
+}) {
+  return !NON_TRAVELER_CATEGORY_TYPES.has(category.categoryType)
+}
+
 export function getCategoryCondition(metadata: Record<string, unknown> | null | undefined) {
   const condition = metadata?.condition
   return typeof condition === "string" && condition.trim().length > 0 ? condition : null
@@ -440,7 +458,8 @@ function UnitPriceMatrix({
   const categories = (categoriesData?.data ?? []).filter(
     (category) =>
       category.active &&
-      (((category.productId == null || category.productId === productId) &&
+      ((isTravelerCategory(category) &&
+        (category.productId == null || category.productId === productId) &&
         (category.optionId == null || category.optionId === optionId)) ||
         referencedCategoryIds.has(category.id)),
   )

--- a/templates/operator/migrations/0053_widen_resource_template_index.sql
+++ b/templates/operator/migrations/0053_widen_resource_template_index.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS "idx_product_option_resource_templates_option_kind";--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_product_option_resource_templates_option_kind" ON "product_option_resource_templates" USING btree ("product_option_id","kind",(COALESCE("ref_id", '')));

--- a/templates/operator/migrations/meta/_journal.json
+++ b/templates/operator/migrations/meta/_journal.json
@@ -365,6 +365,13 @@
       "when": 1780141900000,
       "tag": "0052_product_day_translations",
       "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1780142000000,
+      "tag": "0053_widen_resource_template_index",
+      "breakpoints": true
     }
   ]
 }

--- a/templates/operator/src/components/voyant/availability/option-resource-templates-panel.tsx
+++ b/templates/operator/src/components/voyant/availability/option-resource-templates-panel.tsx
@@ -79,18 +79,6 @@ const COMMON_KINDS: ReadonlyArray<{ value: ResourceTemplateKind; defaultPattern:
   { value: "flight_seat", defaultPattern: "Seat {sequence}" },
 ]
 
-// Derive a stable, unique resource `kind` from a room unit so each room type
-// (Single/Double/Triple) generates its own physical resources. The kind is a
-// free-text slug — distinct kinds avoid the (option, kind) unique constraint.
-function roomUnitToKind(unit: { code: string | null; name: string }): string {
-  const slug = (unit.code || unit.name || "room")
-    .toLowerCase()
-    .normalize("NFKD")
-    .replace(/[^a-z0-9]+/g, "_")
-    .replace(/^_+|_+$/g, "")
-  return slug || "room"
-}
-
 export function OptionResourceTemplatesPanel({
   productId,
   optionId,
@@ -207,14 +195,18 @@ export function OptionResourceTemplatesPanel({
       for (const unit of roomUnits) {
         await upsert.mutateAsync({
           optionId,
-          kind: roomUnitToKind(unit),
+          // All room types share kind "room"; they're distinguished — and
+          // travelers are constrained to their booked type — by the option_unit
+          // ref (allocator's groupUnitMatchScore: refType "option_unit" + refId
+          // === bookedOptionUnitId). The widened (option, kind, ref) unique
+          // index lets one option carry a "room" template per unit.
+          kind: "room",
           input: {
             capacity: unit.occupancyMax ?? unit.occupancyMin ?? 1,
             defaultCount: unit.maxQuantity ?? null,
-            namePattern: `${unit.name} {sequence}`,
-            // Link the template back to its option unit so the allocator can
-            // strongly match a traveler's booked room type to this inventory
-            // (groupUnitMatchScore: refType "option_unit" + refId === unitId).
+            // {index} numbers each room type from 1 (Double 1…20), not the
+            // global {sequence}, so the shared "room" pool reads cleanly.
+            namePattern: `${unit.name} {index}`,
             refType: "option_unit",
             refId: unit.id,
             flags: {},

--- a/templates/operator/src/components/voyant/availability/option-resource-templates-panel.tsx
+++ b/templates/operator/src/components/voyant/availability/option-resource-templates-panel.tsx
@@ -51,7 +51,9 @@ import { useAdminMessages } from "@/lib/admin-i18n"
  * for an option, no rooms/seats/etc. are materialized when bookings hit
  * a slot.
  *
- * Each template is identified by `(optionId, kind)`. Common kinds:
+ * Each template is identified by `(optionId, kind, refId)` — an option can
+ * hold several templates of the same kind, one per `option_unit` (e.g. a
+ * "room" template per room type), distinguished by `refId`. Common kinds:
  *   - `room` — accommodation rooms (default capacity 2)
  *   - `vehicle_seat` — coach/van seats (capacity 1)
  *   - `cabin` — cruise cabins
@@ -110,6 +112,11 @@ export function OptionResourceTemplatesPanel({
   const [dialogOpen, setDialogOpen] = useState(false)
   const [seatMapOpen, setSeatMapOpen] = useState(false)
   const [editingKind, setEditingKind] = useState<string | null>(null)
+  // The ref of the template being edited, so submit updates that exact
+  // (option, kind, refId) row rather than colliding with siblings of the same
+  // kind. Null for ref-less templates (the manual "Add" path).
+  const [editingRefType, setEditingRefType] = useState<string | null>(null)
+  const [editingRefId, setEditingRefId] = useState<string | null>(null)
   const [kindValue, setKindValue] = useState<string>("room")
   const [capacityValue, setCapacityValue] = useState<number>(2)
   const [defaultCountValue, setDefaultCountValue] = useState<number>(1)
@@ -123,6 +130,8 @@ export function OptionResourceTemplatesPanel({
 
   function openCreate() {
     setEditingKind(null)
+    setEditingRefType(null)
+    setEditingRefId(null)
     setKindValue("room")
     setCapacityValue(2)
     setDefaultCountValue(1)
@@ -134,12 +143,16 @@ export function OptionResourceTemplatesPanel({
 
   function openEdit(template: {
     kind: string
+    refType: string | null
+    refId: string | null
     capacity: number
     defaultCount: number | null
     namePattern: string
     flags: Record<string, unknown>
   }) {
     setEditingKind(template.kind)
+    setEditingRefType(template.refType)
+    setEditingRefId(template.refId)
     setKindValue(template.kind)
     setCapacityValue(template.capacity)
     setDefaultCountValue(template.defaultCount ?? 0)
@@ -171,6 +184,10 @@ export function OptionResourceTemplatesPanel({
           capacity: effectiveCapacity,
           defaultCount: defaultCountValue > 0 ? defaultCountValue : null,
           namePattern: trimmedPattern,
+          // Preserve the edited template's ref so the upsert targets its exact
+          // (option, kind, refId) row instead of clobbering a sibling.
+          refType: editingRefType,
+          refId: editingRefId,
           flags,
         },
       })
@@ -180,10 +197,10 @@ export function OptionResourceTemplatesPanel({
     }
   }
 
-  async function handleRemove(kind: string) {
-    if (!globalThis.confirm?.(formatMessage(t.deleteConfirm, { kind }))) return
+  async function handleRemove(kind: string, refId: string | null, label: string) {
+    if (!globalThis.confirm?.(formatMessage(t.deleteConfirm, { kind: label }))) return
     try {
-      await remove.mutateAsync({ optionId, kind })
+      await remove.mutateAsync({ optionId, kind, refId })
     } catch (err) {
       setError(err instanceof Error ? err.message : t.deleteFailed)
     }
@@ -313,57 +330,72 @@ export function OptionResourceTemplatesPanel({
               </p>
             ) : (
               <ul className="divide-y overflow-hidden rounded-md border">
-                {templates.map((template) => (
-                  <li
-                    key={template.kind}
-                    className="flex items-center justify-between gap-3 px-3 py-2.5"
-                  >
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2">
-                        <Badge variant="outline" className="text-[10px]">
-                          {(t.kinds as Record<string, string>)[template.kind] ?? template.kind}
-                        </Badge>
-                        <span className="text-sm">
-                          {formatMessage(t.capacitySummary, {
-                            capacity: template.capacity,
-                            count: template.defaultCount ?? 0,
-                            pattern: template.namePattern,
-                          })}
-                        </span>
-                        {template.kind === "vehicle_seat" ? (
-                          <SeatMapSummaryBadge flags={template.flags} messages={t} />
-                        ) : null}
+                {templates.map((template) => {
+                  const kindLabel =
+                    (t.kinds as Record<string, string>)[template.kind] ?? template.kind
+                  // Several "room" templates share a kind but map to different
+                  // option_units — surface the unit name so the operator can
+                  // tell Single / Double / Triple rows apart.
+                  const unit = template.refId
+                    ? roomUnits.find((entry) => entry.id === template.refId)
+                    : undefined
+                  const displayLabel = unit?.name ?? kindLabel
+                  return (
+                    <li
+                      key={template.id}
+                      className="flex items-center justify-between gap-3 px-3 py-2.5"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <Badge variant="outline" className="text-[10px]">
+                            {displayLabel}
+                          </Badge>
+                          <span className="text-sm">
+                            {formatMessage(t.capacitySummary, {
+                              capacity: template.capacity,
+                              count: template.defaultCount ?? 0,
+                              pattern: template.namePattern,
+                            })}
+                          </span>
+                          {template.kind === "vehicle_seat" ? (
+                            <SeatMapSummaryBadge flags={template.flags} messages={t} />
+                          ) : null}
+                        </div>
                       </div>
-                    </div>
-                    <div className="flex items-center gap-1">
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        className="h-7 px-2"
-                        onClick={() =>
-                          openEdit({
-                            kind: template.kind,
-                            capacity: template.capacity,
-                            defaultCount: template.defaultCount,
-                            namePattern: template.namePattern,
-                            flags: template.flags,
-                          })
-                        }
-                      >
-                        <Pencil className="size-3.5" aria-hidden="true" />
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        className="h-7 px-2 text-destructive hover:text-destructive"
-                        onClick={() => void handleRemove(template.kind)}
-                        disabled={remove.isPending}
-                      >
-                        <Trash2 className="size-3.5" aria-hidden="true" />
-                      </Button>
-                    </div>
-                  </li>
-                ))}
+                      <div className="flex items-center gap-1">
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="h-7 px-2"
+                          onClick={() =>
+                            openEdit({
+                              kind: template.kind,
+                              refType: template.refType,
+                              refId: template.refId,
+                              capacity: template.capacity,
+                              defaultCount: template.defaultCount,
+                              namePattern: template.namePattern,
+                              flags: template.flags,
+                            })
+                          }
+                        >
+                          <Pencil className="size-3.5" aria-hidden="true" />
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="h-7 px-2 text-destructive hover:text-destructive"
+                          onClick={() =>
+                            void handleRemove(template.kind, template.refId, displayLabel)
+                          }
+                          disabled={remove.isPending}
+                        >
+                          <Trash2 className="size-3.5" aria-hidden="true" />
+                        </Button>
+                      </div>
+                    </li>
+                  )
+                })}
               </ul>
             )}
           </div>


### PR DESCRIPTION
Two operator product-detail fixes, both surfaced while integrating Voyant into the Protravel client.

## 1. Pricing grid no longer shows a price column per room type

The rooms/seats pricing grid built one traveler-type column from **every** in-scope pricing category. Tenants whose data carries `room`/`vehicle`/`service`-typed pricing categories — e.g. a tenant-wide default set, or rooms migrated from a legacy system as "Double room" categories — therefore got a phantom price column for each room, sitting next to the real Adult/Senior/Child/Infant split (and the actual rooms were already the rows). On Protravel this hit **every** product option.

Columns are now restricted to per-traveler categories via a new `isTravelerCategory` guard (`room`/`vehicle` are the unit dimension — already the rows; `service` is an add-on handled by the extras panel). An escape hatch keeps surfacing any category that actually has a price cell, so no client loses data they priced. Applied to both the merged grid and the Advanced view, with unit tests covering all category types.

## 2. "Generate from rooms" constrains travelers to their booked room type (#1476)

Previously each room type became its own distinct resource-template `kind`, which the auto-allocator couldn't use to keep a traveler in the room type they booked. Templates now share `kind: "room"` and carry `refType: "option_unit"` / `refId`, so the allocator's unit match (`groupUnitMatchScore`) keeps a Double-booked traveler in a Double room.

- Widen the `(product_option_id, kind)` unique index to `(product_option_id, kind, coalesce(ref_id, ''))` so one option can hold a room template per unit — migration `0053_widen_resource_template_index` (more permissive, so existing rows can't violate it).
- Refine the per-slot materializer's skip-existing check to `(kind, ref_id)`.
- Slot allocation UI needs no change: one "Rooms" tab, already sub-grouped by `refId` (Single/Double/Triple).

## Verification
- typecheck: availability, availability-react, allocation-ui, products-ui, operator
- tests: availability 106 pass, products-ui 17 pass (incl. new guard tests)
- lint + build (availability, products-ui) clean
- migration applies cleanly; index change loses no data (room categories have no price cells)