### PR TITLE
[codex] Fix notification reminder failed retries

### DIFF
--- a/.changeset/fix-notification-reminder-failed-retries.md
+++ b/.changeset/fix-notification-reminder-failed-retries.md
@@ -1,0 +1,7 @@
+---
+"@voyantjs/notifications": patch
+---
+
+Stop stage-based notification reminder sweeps from automatically retrying failed
+one-shot reminder runs, and treat queued/skipped/failed reminder runs as attempts
+for stage cadence and caps.

--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -87,6 +87,10 @@ Reminder rules can currently target:
 - `booking_payment_schedule`
 - `invoice`
 
+Stage cadence and `maxSendsInStage` are evaluated against reminder run attempts.
+A queued, sent, skipped, or failed run consumes the stage slot; failed runs are
+terminal until an operator or explicit recovery flow requeues them.
+
 For finance-aware collection sends, the routes also support:
 
 - `POST /payment-sessions/:id/send`

--- a/packages/notifications/src/service-deliveries.ts
+++ b/packages/notifications/src/service-deliveries.ts
@@ -262,9 +262,13 @@ export async function sendNotification(
     throw new NotificationError("Notification channel is required")
   }
 
-  const provider = input.provider ?? template?.provider ?? dispatcher.getProvider(channel)?.name
+  const defaultProvider = dispatcher.getProvider(channel)
+  const provider = input.provider ?? template?.provider ?? defaultProvider?.name
   if (!provider) {
     throw new NotificationError(`No notification provider available for channel "${channel}"`)
+  }
+  if (provider !== defaultProvider?.name && dispatcher.getProviderByName?.(provider) == null) {
+    throw new NotificationError(`No notification provider registered with name "${provider}"`)
   }
 
   const subject = input.subject ?? renderNotificationTemplate(template?.subjectTemplate, data)
@@ -316,7 +320,7 @@ export async function sendNotification(
 
   try {
     const result =
-      provider === dispatcher.getProvider(channel)?.name
+      provider === defaultProvider?.name
         ? await dispatcher.send({
             to: input.to,
             channel,

--- a/packages/notifications/src/service-reminders.ts
+++ b/packages/notifications/src/service-reminders.ts
@@ -791,10 +791,7 @@ export async function deliverReminderRun(
     .where(
       and(
         eq(notificationReminderRuns.id, input.reminderRunId),
-        or(
-          eq(notificationReminderRuns.status, "queued"),
-          eq(notificationReminderRuns.status, "failed"),
-        ),
+        eq(notificationReminderRuns.status, "queued"),
       ),
     )
     .returning()
@@ -894,7 +891,7 @@ async function emitStageChannelRun(
     .from(notificationReminderRuns)
     .where(eq(notificationReminderRuns.dedupeKey, dedupeKey))
     .limit(1)
-  if (existingRun && existingRun.status !== "failed") {
+  if (existingRun) {
     return { status: "skipped", runId: existingRun.id }
   }
 
@@ -924,32 +921,20 @@ async function emitStageChannelRun(
   }
 
   if (!recipient?.email) {
-    const [run] = existingRun
-      ? await db
-          .update(notificationReminderRuns)
-          .set({ ...baseValues, status: "skipped", errorMessage: "no_recipient" })
-          .where(eq(notificationReminderRuns.id, existingRun.id))
-          .returning()
-      : await db
-          .insert(notificationReminderRuns)
-          .values({ ...baseValues, status: "skipped", errorMessage: "no_recipient" })
-          .onConflictDoNothing({ target: notificationReminderRuns.dedupeKey })
-          .returning()
+    const [run] = await db
+      .insert(notificationReminderRuns)
+      .values({ ...baseValues, status: "skipped", errorMessage: "no_recipient" })
+      .onConflictDoNothing({ target: notificationReminderRuns.dedupeKey })
+      .returning()
     return { status: "skipped", runId: run?.id ?? null }
   }
 
   if (enqueueDelivery && !dispatcher) {
-    const [queuedRun] = existingRun
-      ? await db
-          .update(notificationReminderRuns)
-          .set({ ...baseValues, status: "queued" })
-          .where(eq(notificationReminderRuns.id, existingRun.id))
-          .returning()
-      : await db
-          .insert(notificationReminderRuns)
-          .values({ ...baseValues, status: "queued" })
-          .onConflictDoNothing({ target: notificationReminderRuns.dedupeKey })
-          .returning()
+    const [queuedRun] = await db
+      .insert(notificationReminderRuns)
+      .values({ ...baseValues, status: "queued" })
+      .onConflictDoNothing({ target: notificationReminderRuns.dedupeKey })
+      .returning()
     if (!queuedRun) return { status: "skipped", runId: null }
     try {
       await enqueueDelivery({ reminderRunId: queuedRun.id })
@@ -965,17 +950,11 @@ async function emitStageChannelRun(
     return { status: "skipped", runId: null }
   }
 
-  const [processingRun] = existingRun
-    ? await db
-        .update(notificationReminderRuns)
-        .set({ ...baseValues, status: "processing" })
-        .where(eq(notificationReminderRuns.id, existingRun.id))
-        .returning()
-    : await db
-        .insert(notificationReminderRuns)
-        .values({ ...baseValues, status: "processing" })
-        .onConflictDoNothing({ target: notificationReminderRuns.dedupeKey })
-        .returning()
+  const [processingRun] = await db
+    .insert(notificationReminderRuns)
+    .values({ ...baseValues, status: "processing" })
+    .onConflictDoNothing({ target: notificationReminderRuns.dedupeKey })
+    .returning()
 
   if (!processingRun) {
     return { status: "skipped", runId: null }

--- a/packages/notifications/src/service-sequence.ts
+++ b/packages/notifications/src/service-sequence.ts
@@ -95,18 +95,28 @@ export async function listChannelsForStage(
 
 export function pickActiveStage(
   stages: NotificationReminderRuleStage[],
-  sendsSoFar: number,
+  attemptsSoFar: number,
 ): NotificationReminderRuleStage | null {
   if (stages.length === 0) return null
   let cumulative = 0
   for (const stage of stages) {
     const cap = stage.maxSendsInStage ?? Number.POSITIVE_INFINITY
-    if (sendsSoFar < cumulative + cap) {
+    if (attemptsSoFar < cumulative + cap) {
       return stage
     }
     cumulative += cap
   }
   return null
+}
+
+function isDeliveryAttempt(status: string) {
+  return (
+    status === "queued" ||
+    status === "processing" ||
+    status === "sent" ||
+    status === "skipped" ||
+    status === "failed"
+  )
 }
 
 export function inWindow(today: Date, anchorDate: Date, stage: NotificationReminderRuleStage) {
@@ -208,8 +218,8 @@ export function evaluateStage(
   if (target.isTerminal) {
     return { fire: false, reason: "target_terminal_state" }
   }
-  const sentHistory = history.filter((h) => h.status === "sent")
-  const stage = pickActiveStage(stages, sentHistory.length)
+  const attemptHistory = history.filter((h) => isDeliveryAttempt(h.status))
+  const stage = pickActiveStage(stages, attemptHistory.length)
   if (!stage) {
     return { fire: false, reason: "no_active_stage" }
   }
@@ -221,7 +231,7 @@ export function evaluateStage(
     return { fire: false, reason: "outside_window", stage }
   }
 
-  const lastSent = sentHistory.reduce<Date | null>((acc, e) => {
+  const lastAttempt = attemptHistory.reduce<Date | null>((acc, e) => {
     const stamp = e.sentAt ?? e.scheduledFor
     return acc && acc > stamp ? acc : stamp
   }, null)
@@ -231,11 +241,11 @@ export function evaluateStage(
     daysUntilDue = daysBetweenUtc(new Date(`${target.dueDate}T00:00:00Z`), today)
   }
 
-  if (!cadenceElapsed(today, lastSent, stage, daysUntilDue)) {
+  if (!cadenceElapsed(today, lastAttempt, stage, daysUntilDue)) {
     return { fire: false, reason: "cadence_not_elapsed", stage }
   }
 
-  return { fire: true, stage, anchorDate, sendCountAtFire: sentHistory.length + 1 }
+  return { fire: true, stage, anchorDate, sendCountAtFire: attemptHistory.length + 1 }
 }
 
 function parseTimeOfDayUtcMinutes(value: string): number {

--- a/packages/notifications/src/service-shared.ts
+++ b/packages/notifications/src/service-shared.ts
@@ -90,6 +90,7 @@ export interface NotificationService {
   send(payload: NotificationPayload): Promise<NotificationResult>
   sendWith(providerName: string, payload: NotificationPayload): Promise<NotificationResult>
   getProvider(channel: NotificationChannel): NotificationProvider | undefined
+  getProviderByName?(providerName: string): NotificationProvider | undefined
 }
 
 export function createNotificationService(
@@ -126,6 +127,9 @@ export function createNotificationService(
     },
     getProvider(channel) {
       return byChannel.get(channel)
+    },
+    getProviderByName(providerName) {
+      return byName.get(providerName)
     },
   }
 }

--- a/packages/notifications/tests/integration/reminder-sequences.test.ts
+++ b/packages/notifications/tests/integration/reminder-sequences.test.ts
@@ -3,6 +3,20 @@ import { describe, expect, it } from "vitest"
 
 import { createNotificationsTestContext, DB_AVAILABLE, json } from "./test-helpers"
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function queryRows(result: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(result)) {
+    return result.filter(isRecord)
+  }
+  if (isRecord(result) && Array.isArray(result.rows)) {
+    return result.rows.filter(isRecord)
+  }
+  return []
+}
+
 describe.skipIf(!DB_AVAILABLE)("Reminder sequences (stage-based dispatcher)", () => {
   const ctx = createNotificationsTestContext()
 
@@ -125,9 +139,7 @@ describe.skipIf(!DB_AVAILABLE)("Reminder sequences (stage-based dispatcher)", ()
       FROM notification_reminder_runs
       WHERE reminder_rule_id = ${rule.id}
     `)
-    const rows =
-      (runs as unknown as { rows?: Array<Record<string, unknown>> }).rows ??
-      (runs as unknown as Array<Record<string, unknown>>)
+    const rows = queryRows(runs)
     expect(rows.length).toBe(1)
     expect(rows[0]!.status).toBe("sent")
     expect(rows[0]!.recipient).toBe("ana@example.com")
@@ -325,9 +337,7 @@ describe.skipIf(!DB_AVAILABLE)("Reminder sequences (stage-based dispatcher)", ()
       SELECT status, metadata FROM notification_reminder_runs
       WHERE reminder_rule_id = ${rule.id}
     `)
-    const queuedRowsAny =
-      (queuedRows as unknown as { rows?: Array<Record<string, unknown>> }).rows ??
-      (queuedRows as unknown as Array<Record<string, unknown>>)
+    const queuedRowsAny = queryRows(queuedRows)
     expect(queuedRowsAny.length).toBe(1)
     expect(queuedRowsAny[0]!.status).toBe("queued")
     const queuedMeta = queuedRowsAny[0]!.metadata as Record<string, unknown>
@@ -351,5 +361,142 @@ describe.skipIf(!DB_AVAILABLE)("Reminder sequences (stage-based dispatcher)", ()
     expect(sent.subject).toContain("Stage payment due")
     expect(sent.text).toContain("Stage delivery")
     expect(sent.to).toBe("cara@example.com")
+  })
+
+  it("does not requeue failed one-shot reminder runs on later sweeps", async () => {
+    const tmplRes = await ctx.request("/templates", {
+      method: "POST",
+      ...json({
+        slug: "missing-provider-reminder",
+        name: "Missing provider reminder",
+        channel: "email",
+        provider: "local",
+        status: "active",
+        subjectTemplate: "Payment due",
+        textTemplate: "Payment due",
+      }),
+    })
+    expect(tmplRes.status).toBe(201)
+    const { data: template } = await tmplRes.json()
+
+    await ctx.db.execute(sql`
+      INSERT INTO bookings (id, booking_number, person_id, sell_currency, sell_amount_cents, start_date)
+      VALUES ('book_failed_retry_1', 'BK-FAILED-RETRY-1', 'person_failed_retry_1', 'EUR', 45000, DATE '2026-05-01')
+    `)
+    await ctx.db.execute(sql`
+      INSERT INTO booking_travelers (id, booking_id, first_name, last_name, email, participant_type, is_primary)
+      VALUES ('bkpt_failed_retry_1', 'book_failed_retry_1', 'Dana', 'Retry', 'dana@example.com', 'traveler', true)
+    `)
+    await ctx.db.execute(sql`
+      INSERT INTO booking_payment_schedules (
+        id, booking_id, schedule_type, status, due_date, currency, amount_cents
+      )
+      VALUES ('bkps_failed_retry_1', 'book_failed_retry_1', 'balance', 'pending', DATE '2026-04-10', 'EUR', 25000)
+    `)
+
+    const ruleRes = await ctx.request("/reminder-rules", {
+      method: "POST",
+      ...json({
+        slug: "failed-retry-rule",
+        name: "Failed retry rule",
+        status: "active",
+        targetType: "booking_payment_schedule",
+        channel: "email",
+        provider: "local",
+      }),
+    })
+    expect(ruleRes.status).toBe(201)
+    const { data: rule } = await ruleRes.json()
+
+    const stageRes = await ctx.request(`/reminder-rules/${rule.id}/stages`, {
+      method: "POST",
+      ...json({
+        orderIndex: 0,
+        anchor: "due_date",
+        windowStartDays: -7,
+        windowEndDays: 0,
+        cadenceKind: "once",
+        maxSendsInStage: 1,
+        respectQuietHours: false,
+      }),
+    })
+    expect(stageRes.status).toBe(201)
+    const { data: stage } = await stageRes.json()
+
+    await ctx.request(`/reminder-rules/${rule.id}/stages/${stage.id}/channels`, {
+      method: "POST",
+      ...json({
+        orderIndex: 0,
+        channel: "email",
+        provider: "voyant-cloud-email",
+        templateId: template.id,
+        recipientKind: "primary",
+      }),
+    })
+
+    const { queueDueReminders, deliverReminderRun } = await import("../../src/service-reminders.js")
+    const { createNotificationService } = await import("../../src/service.js")
+    const { createLocalProvider } = await import("../../src/providers/local.js")
+
+    const enqueued: { reminderRunId: string }[] = []
+    const firstQueue = await queueDueReminders(
+      ctx.db as never,
+      { now: "2026-04-08T09:00:00.000Z" },
+      async (job) => {
+        enqueued.push(job)
+      },
+    )
+    expect(firstQueue.processed).toBe(1)
+    expect(firstQueue.queued).toBe(1)
+    expect(enqueued).toHaveLength(1)
+
+    const localDispatcher = createNotificationService([
+      createLocalProvider({ sink: () => undefined, channels: ["email"] }),
+    ])
+    const failed = await deliverReminderRun(ctx.db as never, localDispatcher, {
+      reminderRunId: enqueued[0]!.reminderRunId,
+    })
+    expect(failed?.status).toBe("failed")
+    expect(failed?.errorMessage).toContain(
+      'No notification provider registered with name "voyant-cloud-email"',
+    )
+
+    const sameDayQueue = await queueDueReminders(
+      ctx.db as never,
+      { now: "2026-04-08T18:00:00.000Z" },
+      async (job) => {
+        enqueued.push(job)
+      },
+    )
+    expect(sameDayQueue.processed).toBe(0)
+    expect(sameDayQueue.queued).toBe(0)
+
+    const nextDayQueue = await queueDueReminders(
+      ctx.db as never,
+      { now: "2026-04-09T09:00:00.000Z" },
+      async (job) => {
+        enqueued.push(job)
+      },
+    )
+    expect(nextDayQueue.processed).toBe(0)
+    expect(nextDayQueue.queued).toBe(0)
+    expect(enqueued).toHaveLength(1)
+
+    const rowsResult = await ctx.db.execute(sql`
+      SELECT status, error_message
+      FROM notification_reminder_runs
+      WHERE reminder_rule_id = ${rule.id}
+    `)
+    const rows = queryRows(rowsResult)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.status).toBe("failed")
+
+    const deliveryCountResult = await ctx.db.execute(sql`
+      SELECT count(*)::int AS count
+      FROM notification_deliveries
+      WHERE target_id = 'bkps_failed_retry_1'
+    `)
+    const deliveryCountRows = queryRows(deliveryCountResult)
+    expect(deliveryCountRows[0]!.count).toBe(0)
   })
 })

--- a/packages/notifications/tests/unit/sequence.test.ts
+++ b/packages/notifications/tests/unit/sequence.test.ts
@@ -227,6 +227,44 @@ describe("evaluateStage", () => {
     expect(decision.fire).toBe(false)
     expect(decision.fire ? "" : decision.reason).toBe("cadence_not_elapsed")
   })
+
+  it("counts failed attempts against once cadence", () => {
+    const stage = {
+      ...baseStage,
+      windowStartDays: -10,
+      windowEndDays: 0,
+      cadenceKind: "once" as const,
+    }
+    const attemptedAt = new Date("2026-05-09T00:00:00Z")
+    const decision = evaluateStage(
+      baseRule,
+      [stage],
+      baseTarget,
+      [{ scheduledFor: attemptedAt, sentAt: null, status: "failed" }],
+      today,
+    )
+    expect(decision.fire).toBe(false)
+    expect(decision.fire ? "" : decision.reason).toBe("cadence_not_elapsed")
+  })
+
+  it("counts queued attempts against stage caps", () => {
+    const stage = {
+      ...baseStage,
+      windowStartDays: -10,
+      windowEndDays: 0,
+      maxSendsInStage: 1,
+    }
+    const attemptedAt = new Date("2026-05-09T00:00:00Z")
+    const decision = evaluateStage(
+      baseRule,
+      [stage],
+      baseTarget,
+      [{ scheduledFor: attemptedAt, sentAt: null, status: "queued" }],
+      today,
+    )
+    expect(decision.fire).toBe(false)
+    expect(decision.fire ? "" : decision.reason).toBe("no_active_stage")
+  })
 })
 
 describe("applyQuietHours", () => {

--- a/packages/notifications/tests/unit/service.test.ts
+++ b/packages/notifications/tests/unit/service.test.ts
@@ -87,6 +87,15 @@ describe("createNotificationService", () => {
     expect(service.getProvider("slack")).toBeUndefined()
   })
 
+  it("getProviderByName returns a named provider", () => {
+    const resend = fakeProvider("resend", ["email"])
+    const local = fakeProvider("local", ["email"])
+    const service = createNotificationService([resend, local])
+    expect(service.getProviderByName?.("resend")).toBe(resend)
+    expect(service.getProviderByName?.("local")).toBe(local)
+    expect(service.getProviderByName?.("missing")).toBeUndefined()
+  })
+
   it("integrates with the local provider end-to-end", async () => {
     const sink = vi.fn()
     const service = createNotificationService([createLocalProvider({ sink, channels: ["email"] })])


### PR DESCRIPTION
## Summary

Fixes #1486.

Stage-based notification reminders no longer retry failed one-shot runs on every due-reminder sweep. The reminder sequence evaluator now treats queued, processing, sent, skipped, and failed reminder runs as delivery attempts for cadence and stage caps. Failed queued reminder runs remain terminal unless an explicit recovery path requeues them.

The delivery path also preflights explicitly named providers before inserting a `notification_deliveries` row, so a missing provider such as `voyant-cloud-email` records the reminder run failure without creating duplicate delivery attempts.

## Root Cause

The sweep and delivery worker had two retry-enabling behaviors:

- `evaluateStage` only counted `sent` history for `once` cadence and `maxSendsInStage`, so a failed run did not consume the one-shot slot.
- `deliverReminderRun` claimed both `queued` and `failed` rows, while the stage emitter rewrote existing failed dedupe-key rows back to `queued`.

That combination let each scheduled sweep reprocess the same failed target/template/recipient group and create another delivery attempt.

## Validation

- `pnpm --filter @voyantjs/notifications typecheck`
- `pnpm --filter @voyantjs/notifications lint`
- `pnpm --filter @voyantjs/notifications test -- tests/unit/sequence.test.ts tests/unit/service.test.ts tests/integration/reminder-sequences.test.ts`
- Commit hook: changed-file lint, agent-quality report-only, full repo lint, full repo typecheck
- Push hook: full repo test

`pnpm verify:fast` was also run locally and still stops at the existing unrelated `@voyantjs/ui` component barrel check for missing exports in `packages/ui/src/components/index.tsx`.