### PR TITLE
Guard booking create duplicates

### DIFF
--- a/.changeset/quiet-bookings-guard.md
+++ b/.changeset/quiet-bookings-guard.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/finance": patch
+"@voyantjs/bookings-react": patch
+---
+
+Add an overridable duplicate guard for booking create requests.

--- a/packages/bookings-react/src/hooks/use-booking-create-mutation.ts
+++ b/packages/bookings-react/src/hooks/use-booking-create-mutation.ts
@@ -163,6 +163,11 @@ export interface BookingCreateInput {
    */
   suppressNotifications?: boolean
   /**
+   * Allows a second active booking for the same billing party and departure.
+   * Leave unset for retry/double-submit protection.
+   */
+  allowDuplicate?: boolean
+  /**
    * Billing-contact snapshot. Caller (typically the create dialog)
    * reads the linked CRM person/org and supplies what it knows so the
    * booking detail page renders the right payer even if those CRM

--- a/packages/finance/src/routes-booking-create.ts
+++ b/packages/finance/src/routes-booking-create.ts
@@ -57,6 +57,17 @@ const createBookingRoutes = new Hono<{
           },
           400,
         )
+      case "duplicate_booking":
+        return c.json(
+          {
+            error: "Duplicate booking",
+            code: "duplicate_booking",
+            existingBookingId: outcome.existingBooking.id,
+            existingBookingNumber: outcome.existingBooking.bookingNumber,
+            existingBookingStatus: outcome.existingBooking.status,
+          },
+          409,
+        )
       case "product_not_found":
         return c.json({ error: "Product not found or unavailable" }, 404)
       case "voucher_not_found":
@@ -119,6 +130,18 @@ const createBookingRoutes = new Hono<{
             mismatches: reason.mismatches,
           },
           400,
+        )
+      case "duplicate_booking":
+        return c.json(
+          {
+            ...body,
+            error: `${which}: duplicate booking`,
+            code: "duplicate_booking",
+            existingBookingId: reason.existingBooking.id,
+            existingBookingNumber: reason.existingBooking.bookingNumber,
+            existingBookingStatus: reason.existingBooking.status,
+          },
+          409,
         )
       case "product_not_found":
         return c.json({ ...body, error: `${which}: product not found or unavailable` }, 404)

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -366,6 +366,13 @@ const bookingCreateBaseSchema = z.object({
    * bundles. Operators can confirm a booking silently this way.
    */
   suppressNotifications: z.boolean().optional(),
+  /**
+   * Explicit operator override for same billing party + departure creates.
+   * Defaults to guarded behavior so retries and concurrent double-submit
+   * attempts return a structured duplicate signal instead of minting another
+   * active booking.
+   */
+  allowDuplicate: z.boolean().optional(),
   // Billing-contact snapshot — captured at create time. Caller (the
   // dialog) reads the linked CRM person/org and supplies what it
   // knows; the convertProductToBooking helper writes everything
@@ -482,6 +489,7 @@ export type BookingCreateOutcome =
   | { status: "ok"; result: BookingCreateResult }
   | { status: "invalid_payment_schedules"; issues: BookingCreateValidationIssue[] }
   | { status: "payload_resolver_mismatch"; mismatches: BookingDraftMismatch[] }
+  | { status: "duplicate_booking"; existingBooking: DuplicateBookingMatch }
   | { status: "product_not_found" }
   | { status: "voucher_not_found" }
   | { status: "voucher_inactive" }
@@ -532,6 +540,12 @@ class BookingCreateValidationError extends Error {
   }
 }
 
+export interface DuplicateBookingMatch {
+  id: string
+  bookingNumber: string
+  status: string
+}
+
 interface AlreadyPaidScheduleMetadata {
   alreadyPaid?: boolean
   paymentDate?: string | null
@@ -552,6 +566,49 @@ function parseAlreadyPaidScheduleMetadata(notes: string | null | undefined) {
 function isAlreadyPaidSchedule(schedule: BookingCreatePaymentScheduleInput) {
   const metadata = parseAlreadyPaidScheduleMetadata(schedule.notes)
   return schedule.status === "paid" || metadata?.alreadyPaid === true
+}
+
+function duplicateBookingGuardKey(input: BookingCreateInput) {
+  if (!input.slotId) return null
+  if (input.personId) return `booking-create:person:${input.personId}:slot:${input.slotId}`
+  if (input.organizationId) {
+    return `booking-create:organization:${input.organizationId}:slot:${input.slotId}`
+  }
+  return null
+}
+
+async function findDuplicateBookingForCreate(
+  tx: PostgresJsDatabase,
+  input: BookingCreateInput,
+): Promise<DuplicateBookingMatch | null> {
+  const guardKey = duplicateBookingGuardKey(input)
+  if (!guardKey || input.allowDuplicate) return null
+
+  await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(${guardKey}, 0))`)
+
+  const partyCondition = input.personId
+    ? sql`b.person_id = ${input.personId}`
+    : sql`b.organization_id = ${input.organizationId}`
+
+  const rows = await tx.execute(sql`
+    SELECT
+      b.id AS "id",
+      b.booking_number AS "bookingNumber",
+      b.status AS "status"
+    FROM bookings b
+    WHERE b.status <> 'cancelled'
+      AND ${partyCondition}
+      AND EXISTS (
+        SELECT 1
+        FROM booking_items bi
+        WHERE bi.booking_id = b.id
+          AND bi.availability_slot_id = ${input.slotId}
+      )
+    ORDER BY b.created_at ASC
+    LIMIT 1
+  `)
+
+  return toRows<DuplicateBookingMatch>(rows)[0] ?? null
 }
 
 /**
@@ -936,6 +993,14 @@ export async function createBooking(
   let result: BookingCreateResult
   try {
     result = await db.transaction(async (tx) => {
+      const duplicateBooking = await findDuplicateBookingForCreate(tx, input)
+      if (duplicateBooking) {
+        throw new BookingCreateAbort({
+          status: "duplicate_booking",
+          existingBooking: duplicateBooking,
+        })
+      }
+
       const productOptionUnits = input.itemLines?.length
         ? await loadProductOptionUnits(tx, input.productId)
         : []

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -596,7 +596,7 @@ async function findDuplicateBookingForCreate(
       b.booking_number AS "bookingNumber",
       b.status AS "status"
     FROM bookings b
-    WHERE b.status <> 'cancelled'
+    WHERE b.status NOT IN ('cancelled', 'expired')
       AND ${partyCondition}
       AND EXISTS (
         SELECT 1

--- a/packages/finance/tests/integration/booking-create.test.ts
+++ b/packages/finance/tests/integration/booking-create.test.ts
@@ -538,6 +538,38 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
     expect(bookingRows).toHaveLength(2)
   })
 
+  it("ignores expired bookings when checking duplicates", async () => {
+    const { productId, optionId } = await seedProduct()
+    const slot = await seedSlot({ productId, optionId })
+
+    const first = await createBooking(db, {
+      productId,
+      optionId,
+      slotId: slot.id,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+    })
+    expect(first.status).toBe("ok")
+    if (first.status !== "ok") return
+
+    await db
+      .update(bookings)
+      .set({ status: "expired" })
+      .where(eq(bookings.id, first.result.booking.id))
+
+    const second = await createBooking(db, {
+      productId,
+      optionId,
+      slotId: slot.id,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+    })
+
+    expect(second.status).toBe("ok")
+    const bookingRows = await db.select().from(bookings)
+    expect(bookingRows).toHaveLength(2)
+  })
+
   it("rejects payment schedules in a currency different from booking sell currency", async () => {
     const { productId } = await seedProduct()
 

--- a/packages/finance/tests/integration/booking-create.test.ts
+++ b/packages/finance/tests/integration/booking-create.test.ts
@@ -43,6 +43,7 @@ async function resetTables(
     "booking_supplier_statuses",
     "booking_items",
     "bookings",
+    "availability_slots",
     "option_units",
     "product_day_services",
     "product_days",
@@ -250,6 +251,47 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
     return group!
   }
 
+  async function seedSlot(input: { productId: string; optionId?: string | null }) {
+    const slotId = `avsl_bc_${productSeq}_${Date.now()}`
+    const rows = await db.execute<{ id: string }>(sql`
+      INSERT INTO availability_slots (
+        id,
+        product_id,
+        option_id,
+        date_local,
+        starts_at,
+        ends_at,
+        timezone,
+        status,
+        unlimited,
+        initial_pax,
+        remaining_pax,
+        created_at,
+        updated_at
+      )
+      VALUES (
+        ${slotId},
+        ${input.productId},
+        ${input.optionId ?? null},
+        '2026-07-01',
+        '2026-07-01T09:00:00.000Z',
+        '2026-07-01T11:00:00.000Z',
+        'Europe/Bucharest',
+        'open',
+        false,
+        10,
+        10,
+        now(),
+        now()
+      )
+      RETURNING id
+    `)
+
+    const slot = rows[0]
+    if (!slot) throw new Error("seedSlot: insert returned no rows")
+    return slot
+  }
+
   function bookingParty() {
     return {
       personId: "pers_booking_create",
@@ -400,6 +442,100 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
       .from(bookingPaymentSchedules)
       .where(eq(bookingPaymentSchedules.bookingId, outcome.result.booking.id))
     expect(scheduleRows).toHaveLength(2)
+  })
+
+  it("rejects duplicate active bookings for the same billing party and slot", async () => {
+    const { productId, optionId } = await seedProduct()
+    const slot = await seedSlot({ productId, optionId })
+
+    const first = await createBooking(db, {
+      productId,
+      optionId,
+      slotId: slot.id,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+    })
+
+    expect(first.status).toBe("ok")
+    if (first.status !== "ok") return
+
+    const duplicate = await createBooking(db, {
+      productId,
+      optionId,
+      slotId: slot.id,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+    })
+
+    expect(duplicate.status).toBe("duplicate_booking")
+    if (duplicate.status !== "duplicate_booking") return
+    expect(duplicate.existingBooking).toMatchObject({
+      id: first.result.booking.id,
+      bookingNumber: first.result.booking.bookingNumber,
+      status: first.result.booking.status,
+    })
+
+    const bookingRows = await db.select().from(bookings)
+    expect(bookingRows).toHaveLength(1)
+  })
+
+  it("allows duplicate active bookings when explicitly overridden", async () => {
+    const { productId, optionId } = await seedProduct()
+    const slot = await seedSlot({ productId, optionId })
+
+    const first = await createBooking(db, {
+      productId,
+      optionId,
+      slotId: slot.id,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+    })
+    expect(first.status).toBe("ok")
+
+    const second = await createBooking(db, {
+      productId,
+      optionId,
+      slotId: slot.id,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+      allowDuplicate: true,
+    })
+
+    expect(second.status).toBe("ok")
+    const bookingRows = await db.select().from(bookings)
+    expect(bookingRows).toHaveLength(2)
+  })
+
+  it("ignores cancelled bookings when checking duplicates", async () => {
+    const { productId, optionId } = await seedProduct()
+    const slot = await seedSlot({ productId, optionId })
+
+    const first = await createBooking(db, {
+      productId,
+      optionId,
+      slotId: slot.id,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+    })
+    expect(first.status).toBe("ok")
+    if (first.status !== "ok") return
+
+    await db
+      .update(bookings)
+      .set({ status: "cancelled" })
+      .where(eq(bookings.id, first.result.booking.id))
+
+    const second = await createBooking(db, {
+      productId,
+      optionId,
+      slotId: slot.id,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+    })
+
+    expect(second.status).toBe("ok")
+    const bookingRows = await db.select().from(bookings)
+    expect(bookingRows).toHaveLength(2)
   })
 
   it("rejects payment schedules in a currency different from booking sell currency", async () => {

--- a/packages/finance/tests/unit/validation-booking-create.test.ts
+++ b/packages/finance/tests/unit/validation-booking-create.test.ts
@@ -82,6 +82,15 @@ describe("bookingCreateSchema", () => {
     })
   })
 
+  it("accepts explicit duplicate overrides", () => {
+    const result = bookingCreateSchema.parse({
+      ...valid,
+      allowDuplicate: true,
+    })
+
+    expect(result.allowDuplicate).toBe(true)
+  })
+
   it("requires billing and travelers", () => {
     expect(() =>
       bookingCreateSchema.parse({


### PR DESCRIPTION
## Summary
- add an overridable duplicate guard to booking create requests keyed by billing party and departure slot
- return a structured duplicate_booking 409 with the existing booking identifiers
- expose allowDuplicate on the bookings-react create input and cover reject, override, and cancelled-booking cases

Fixes #1491

## Verification
- pnpm --filter @voyantjs/finance exec vitest run tests/unit/validation-booking-create.test.ts
- pnpm --filter @voyantjs/finance typecheck
- pnpm --filter @voyantjs/bookings-react typecheck
- pnpm --filter @voyantjs/finance exec vitest run tests/integration/booking-create.test.ts (skipped: TEST_DATABASE_URL not set)
- pre-commit hook: workspace lint and typecheck
- pre-push hook: workspace tests