### PR TITLE
Fix catalog departure sort field

### DIFF
--- a/.changeset/catalog-departure-sort-date.md
+++ b/.changeset/catalog-departure-sort-date.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/catalog": patch
+---
+
+Map `departure-asc` catalog search sorting to `nextDepartureDate` before falling back to timestamp fields.

--- a/packages/catalog/README.md
+++ b/packages/catalog/README.md
@@ -171,7 +171,7 @@ await fetch("/v1/public/catalog/search", {
 
 Supported sort values are `relevance`, `price-asc`, `price-desc`,
 `departure-asc`, and `newest`. Sorts are translated by the indexer adapter to
-safe indexed fields such as `priceFromAmountCents` and `nextDepartureAt`; they
+safe indexed fields such as `priceFromAmountCents` and `nextDepartureDate`; they
 are not applied after app-side hydration.
 
 When `projection: "storefront-card"` is present, the response keeps the raw

--- a/packages/catalog/src/indexer/typesense-search-query.ts
+++ b/packages/catalog/src/indexer/typesense-search-query.ts
@@ -127,7 +127,7 @@ function resolveTypesenseSortBy(
 const SORT_FIELDS = {
   "price-asc": ["priceFromAmountCents", "sellAmountCents"],
   "price-desc": ["priceFromAmountCents", "sellAmountCents"],
-  "departure-asc": ["nextDepartureAt", "nextDepartureDate", "startDateEpochDays", "startDate"],
+  "departure-asc": ["nextDepartureDate", "nextDepartureAt", "startDateEpochDays", "startDate"],
   newest: ["publishedAt", "createdAt"],
 } as const satisfies Record<Exclude<SearchSortOption, "relevance">, readonly string[]>
 

--- a/packages/catalog/src/indexer/typesense.test.ts
+++ b/packages/catalog/src/indexer/typesense.test.ts
@@ -49,6 +49,16 @@ const registry = createFieldPolicyRegistry(
       visibility: ["customer"],
     },
     {
+      path: "nextDepartureDate",
+      class: "structural",
+      merge: "source-only",
+      editRole: "none",
+      overrideFriction: "none",
+      snapshot: "on-book",
+      query: "indexed-column",
+      visibility: ["customer"],
+    },
+    {
       path: "createdAt",
       class: "managed",
       merge: "source-only",
@@ -109,6 +119,7 @@ describe("Typesense catalog indexer", () => {
     expect(schema.fields.find((field) => field.name === "latitude")?.type).toBe("float")
     expect(schema.fields.find((field) => field.name === "hasOffer")?.type).toBe("bool")
     expect(schema.fields.find((field) => field.name === "nextDepartureAt")?.sort).toBe(true)
+    expect(schema.fields.find((field) => field.name === "nextDepartureDate")?.sort).toBe(true)
   })
 
   it("keeps non-text fields out of Typesense query_by", () => {
@@ -128,6 +139,16 @@ describe("Typesense catalog indexer", () => {
     )
 
     expect(query.sort_by).toBe("priceFromAmountCents:desc")
+  })
+
+  it("maps departure sort to the sortable local departure date", () => {
+    const query = buildSearchQuery(
+      { query: "", mode: "keyword", sort: "departure-asc" },
+      registry,
+      slice,
+    )
+
+    expect(query.sort_by).toBe("nextDepartureDate:asc")
   })
 
   it("normalizes list policy paths for facets and filters", () => {

--- a/packages/products/src/catalog-policy-departures.ts
+++ b/packages/products/src/catalog-policy-departures.ts
@@ -10,7 +10,7 @@
  *   - "departing in May" (filter: `departureMonths[]` includes "2026-05")
  *   - "available this weekend" (filter: `departureDates[]` overlap)
  *   - "available now" (filter: `hasUpcomingDeparture:true`)
- *   - sort by next departure (`nextDepartureAt` asc)
+ *   - sort by next departure (`nextDepartureDate` asc)
  *   - show capacity badge (`availableUnitsTotal`)
  *
  * Wire this policy into the products registry by composing with
@@ -46,9 +46,9 @@ import { defineFieldPolicy, type FieldPolicyInput } from "@voyantjs/catalog/cont
 
 const PRODUCT_DEPARTURES_FIELD_POLICY: FieldPolicyInput[] = [
   // ── Earliest open future departure ──────────────────────────────────────
-  // `nextDepartureAt` is the timestamptz for sort order (catalog sort by
-  // soonest available). `nextDepartureDate` is the same departure expressed
-  // as the slot's local calendar date — what the storefront card renders.
+  // `nextDepartureAt` is the timestamptz for storefront display metadata.
+  // `nextDepartureDate` is the slot's local calendar date and backs catalog
+  // sort by soonest available.
   {
     path: "nextDepartureAt",
     class: "structural",


### PR DESCRIPTION
## Summary

- Map `departure-asc` Typesense sorting to `nextDepartureDate` before timestamp fallbacks.
- Add regression coverage for the generated `sort_by` value.
- Update catalog/product departure docs to reference the sortable local departure date.

Fixes #1504

## Tests

- `pnpm --filter @voyantjs/catalog test`
- `pnpm --filter @voyantjs/catalog typecheck`
- `pnpm --filter @voyantjs/catalog lint`
- pre-commit affected lint/typecheck hook
- pre-push full test lane