### PR TITLE
Map cruise port facility ids into catalog projections

### DIFF
--- a/.changeset/cruise-catalog-port-facility-ids.md
+++ b/.changeset/cruise-catalog-port-facility-ids.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/cruises": patch
+---
+
+Map sourced cruise embark and disembark port facility ids into catalog projections.

--- a/packages/cruises/src/adapters/index.ts
+++ b/packages/cruises/src/adapters/index.ts
@@ -222,8 +222,10 @@ export type CruiseSearchProjectionEntry = {
   shipExternalId?: string
   nights: number
   embarkPortName?: string | null
+  embarkPortFacilityId?: string | null
   embarkPortCanonicalPlaceId?: string | null
   disembarkPortName?: string | null
+  disembarkPortFacilityId?: string | null
   disembarkPortCanonicalPlaceId?: string | null
   regionIds?: string[]
   waterwayIds?: string[]

--- a/packages/cruises/src/adapters/source-adapter-shim.ts
+++ b/packages/cruises/src/adapters/source-adapter-shim.ts
@@ -456,7 +456,9 @@ function toCatalogProjection(
       defaultShipId: entry.shipExternalId ?? null,
       heroImageUrl: entry.heroImageUrl ?? null,
       thumbnailUrl: entry.heroImageUrl ?? null,
+      embarkPortFacilityId: entry.embarkPortFacilityId ?? null,
       embarkPortCanonicalPlaceId: entry.embarkPortCanonicalPlaceId ?? null,
+      disembarkPortFacilityId: entry.disembarkPortFacilityId ?? null,
       disembarkPortCanonicalPlaceId: entry.disembarkPortCanonicalPlaceId ?? null,
       // Canonical geography — the policy paths for these arrays are snake_case
       // (`region_ids[]` …), so the keys stay snake_case here (issue #1466).

--- a/packages/cruises/tests/unit/source-adapter-shim.test.ts
+++ b/packages/cruises/tests/unit/source-adapter-shim.test.ts
@@ -26,7 +26,9 @@ function makeProjectionEntries(count: number): CruiseSearchProjectionEntry[] {
       shipExternalId: "ms-sample",
       nights: 7,
       embarkPortName: "Athens",
+      embarkPortFacilityId: "port-facility:GRATH",
       disembarkPortName: "Athens",
+      disembarkPortFacilityId: "port-facility:GRATH",
       regionIds: ["region:mediterranean"],
       waterwayIds: ["sea:aegean"],
       portIds: ["port:GRATH"],
@@ -208,6 +210,8 @@ describe("cruiseAdapterToSourceAdapter.discover", () => {
     expect(page.projections[0]?.fields.nights).toBe(7)
     expect(page.projections[0]?.fields.lineSupplierId).toBe("sample-line")
     expect(page.projections[0]?.fields.defaultShipId).toBe("ms-sample")
+    expect(page.projections[0]?.fields.embarkPortFacilityId).toBe("port-facility:GRATH")
+    expect(page.projections[0]?.fields.disembarkPortFacilityId).toBe("port-facility:GRATH")
     expect(page.projections[0]?.fields.heroImageUrl).toBe("https://cdn/c0.jpg")
     expect(page.projections[0]?.fields.thumbnailUrl).toBe("https://cdn/c0.jpg")
     expect(page.projections[0]?.fields.status).toBe("open")
@@ -251,6 +255,8 @@ describe("cruiseAdapterToSourceAdapter.discover", () => {
     expect(doc.fields.thumbnailUrl).toBe("https://cdn/c0.jpg")
     expect(doc.fields.lineSupplierId).toBe("sample-line")
     expect(doc.fields.defaultShipId).toBe("ms-sample")
+    expect(doc.fields.embarkPortFacilityId).toBe("port-facility:GRATH")
+    expect(doc.fields.disembarkPortFacilityId).toBe("port-facility:GRATH")
   })
 
   it("emits a cursor when more pages exist", async () => {


### PR DESCRIPTION
## Summary
- Extend `CruiseSearchProjectionEntry` with embark and disembark port facility ids.
- Map those ids through `cruiseAdapterToSourceAdapter` into the catalog field-policy paths used by cruise filters.
- Add shim/indexer coverage and a patch changeset for `@voyantjs/cruises`.

Closes #1466.

## Verification
- `pnpm --filter @voyantjs/cruises test -- source-adapter-shim.test.ts`
- `pnpm --filter @voyantjs/cruises typecheck`
- `pnpm verify:fast`
- pre-push `pnpm test` hook: 147 successful tasks