### PR TITLE
Add notification reminder rule compose endpoint

### DIFF
--- a/.changeset/notifications-reminder-rule-compose.md
+++ b/.changeset/notifications-reminder-rule-compose.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/notifications": patch
+---
+
+Add composite reminder-rule authoring with recoverable validation issues, idempotent replay, and hard-delete routes for notification templates and reminder rules.

--- a/apps/dev/migrations/0044_notification_reminder_rule_authoring_requests.sql
+++ b/apps/dev/migrations/0044_notification_reminder_rule_authoring_requests.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS "notification_reminder_rule_authoring_requests" (
+	"idempotency_key" text PRIMARY KEY NOT NULL,
+	"reminder_rule_id" text NOT NULL,
+	"operation" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$
+BEGIN
+	ALTER TABLE "notification_reminder_rule_authoring_requests"
+		ADD CONSTRAINT "notification_reminder_rule_authoring_requests_reminder_rule_id_notification_reminder_rules_id_fk"
+		FOREIGN KEY ("reminder_rule_id") REFERENCES "public"."notification_reminder_rules"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+	WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_notification_reminder_rule_authoring_rule" ON "notification_reminder_rule_authoring_requests" USING btree ("reminder_rule_id");

--- a/apps/dev/migrations/meta/_journal.json
+++ b/apps/dev/migrations/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1780141400000,
       "tag": "0043_organization_tax_id",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1780141500000,
+      "tag": "0044_notification_reminder_rule_authoring_requests",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/notifications/src/routes.ts
+++ b/packages/notifications/src/routes.ts
@@ -8,6 +8,7 @@ import type { BookingDocumentAttachmentResolver } from "./service-booking-docume
 import type { NotificationProvider } from "./types.js"
 import {
   bookingDocumentBundleSchema,
+  composeNotificationReminderRuleSchema,
   confirmAndDispatchBookingResultSchema,
   confirmAndDispatchBookingSchema,
   insertNotificationReminderRuleSchema,
@@ -92,6 +93,13 @@ function getRuntime(
   }
 }
 
+function idempotencyKey(
+  c: { req: { header: (name: string) => string | undefined } },
+  bodyKey?: string,
+) {
+  return c.req.header("Idempotency-Key") ?? bodyKey
+}
+
 export function createNotificationsRoutes(options?: NotificationsRoutesOptions) {
   return new Hono<Env>()
     .get("/templates", async (c) => {
@@ -118,6 +126,11 @@ export function createNotificationsRoutes(options?: NotificationsRoutesOptions) 
       )
       if (!row) return c.json({ error: "Notification template not found" }, 404)
       return c.json({ data: row })
+    })
+    .delete("/templates/:id", async (c) => {
+      const ok = await notificationsService.deleteTemplate(c.get("db"), c.req.param("id"))
+      if (!ok) return c.json({ error: "Notification template not found" }, 404)
+      return c.body(null, 204)
     })
     .post("/preview", async (c) => {
       const rendered = notificationsService.previewNotificationTemplate(
@@ -161,6 +174,22 @@ export function createNotificationsRoutes(options?: NotificationsRoutesOptions) 
       )
       return c.json({ data: row }, 201)
     })
+    .post("/reminder-rules/compose", async (c) => {
+      const body = await parseJsonBody(c, composeNotificationReminderRuleSchema)
+      const outcome = await notificationsService.composeNotificationReminderRule(
+        c.get("db"),
+        body,
+        {
+          idempotencyKey: idempotencyKey(c, body.idempotencyKey),
+        },
+      )
+
+      if (outcome.status === "invalid") {
+        return c.json({ error: "invalid_reminder_rule_graph", issues: outcome.issues }, 422)
+      }
+
+      return c.json({ data: outcome.result }, outcome.reused ? 200 : 201)
+    })
     .get("/reminder-rules/:id", async (c) => {
       const row = await notificationsService.getReminderRuleById(c.get("db"), c.req.param("id"))
       if (!row) return c.json({ error: "Notification reminder rule not found" }, 404)
@@ -174,6 +203,11 @@ export function createNotificationsRoutes(options?: NotificationsRoutesOptions) 
       )
       if (!row) return c.json({ error: "Notification reminder rule not found" }, 404)
       return c.json({ data: row })
+    })
+    .delete("/reminder-rules/:id", async (c) => {
+      const ok = await notificationsService.deleteReminderRule(c.get("db"), c.req.param("id"))
+      if (!ok) return c.json({ error: "Notification reminder rule not found" }, 404)
+      return c.body(null, 204)
     })
     .get("/reminder-rules/:id/stages", async (c) => {
       const stages = await notificationsService.listReminderRuleStages(

--- a/packages/notifications/src/schema.ts
+++ b/packages/notifications/src/schema.ts
@@ -359,6 +359,29 @@ export const notificationSettings = pgTable(
 export type NotificationSettings = typeof notificationSettings.$inferSelect
 export type NewNotificationSettings = typeof notificationSettings.$inferInsert
 
+/**
+ * Dedup ledger for composite reminder-rule authoring. A compose request creates
+ * several rows, so retried calls need a stable way to return the original rule
+ * instead of building a second graph.
+ */
+export const notificationReminderRuleAuthoringRequests = pgTable(
+  "notification_reminder_rule_authoring_requests",
+  {
+    idempotencyKey: text("idempotency_key").primaryKey(),
+    reminderRuleId: typeIdRef("reminder_rule_id")
+      .notNull()
+      .references(() => notificationReminderRules.id, { onDelete: "cascade" }),
+    operation: text("operation").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("idx_notification_reminder_rule_authoring_rule").on(table.reminderRuleId)],
+)
+
+export type NotificationReminderRuleAuthoringRequest =
+  typeof notificationReminderRuleAuthoringRequests.$inferSelect
+export type NewNotificationReminderRuleAuthoringRequest =
+  typeof notificationReminderRuleAuthoringRequests.$inferInsert
+
 export const notificationTemplatesRelations = relations(notificationTemplates, ({ many }) => ({
   deliveries: many(notificationDeliveries),
   reminderRules: many(notificationReminderRules),

--- a/packages/notifications/src/service-reminder-authoring.ts
+++ b/packages/notifications/src/service-reminder-authoring.ts
@@ -1,0 +1,468 @@
+import { asc, eq, inArray, or, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import type { z } from "zod"
+
+import {
+  type NotificationTemplate,
+  notificationReminderRuleAuthoringRequests,
+  notificationReminderRuleStages,
+  notificationReminderRules,
+  notificationReminderStageChannels,
+  notificationTemplates,
+} from "./schema.js"
+import type { composeNotificationReminderRuleSchema } from "./validation.js"
+
+export interface ReminderRuleAuthoringIssue {
+  code: string
+  field?: string
+  message: string
+  fix?: string
+}
+
+export type ComposeNotificationReminderRuleInput = z.infer<
+  typeof composeNotificationReminderRuleSchema
+>
+
+export type ComposeNotificationReminderRuleResult = {
+  ruleId: string
+  stages: Array<{
+    id: string
+    orderIndex: number
+    channels: Array<{
+      id: string
+      orderIndex: number
+    }>
+  }>
+}
+
+export type ComposeNotificationReminderRuleOutcome =
+  | { status: "ok"; result: ComposeNotificationReminderRuleResult; reused: boolean }
+  | { status: "invalid"; issues: ReminderRuleAuthoringIssue[] }
+
+type TemplateRef = {
+  templateId?: string | null
+  templateSlug?: string | null
+}
+
+type ResolvedTemplateRef = {
+  id: string
+  slug: string
+  channel: NotificationTemplate["channel"]
+}
+
+type NormalizedTemplateRef = {
+  templateId: string
+  templateSlug: string
+  template: ResolvedTemplateRef
+}
+
+function field(path: Array<string | number>) {
+  return path
+    .map((segment) => (typeof segment === "number" ? `[${segment}]` : segment))
+    .join(".")
+    .replaceAll(".[", "[")
+}
+
+function issue(
+  issues: ReminderRuleAuthoringIssue[],
+  code: string,
+  path: Array<string | number>,
+  message: string,
+  fix: string,
+) {
+  issues.push({ code, field: field(path), message, fix })
+}
+
+async function resolveTemplateRefs(
+  db: PostgresJsDatabase,
+  refs: TemplateRef[],
+): Promise<Map<string, ResolvedTemplateRef>> {
+  const ids = [...new Set(refs.map((ref) => ref.templateId).filter((id): id is string => !!id))]
+  const slugs = [
+    ...new Set(refs.map((ref) => ref.templateSlug).filter((slug): slug is string => !!slug)),
+  ]
+
+  if (ids.length === 0 && slugs.length === 0) {
+    return new Map()
+  }
+
+  const rows = await db
+    .select({
+      id: notificationTemplates.id,
+      slug: notificationTemplates.slug,
+      channel: notificationTemplates.channel,
+    })
+    .from(notificationTemplates)
+    .where(
+      or(
+        ids.length > 0 ? inArray(notificationTemplates.id, ids) : undefined,
+        slugs.length > 0 ? inArray(notificationTemplates.slug, slugs) : undefined,
+      ),
+    )
+
+  const resolved = new Map<string, ResolvedTemplateRef>()
+  for (const row of rows) {
+    resolved.set(`id:${row.id}`, row)
+    resolved.set(`slug:${row.slug}`, row)
+  }
+  return resolved
+}
+
+function normalizeTemplateRef(
+  ref: TemplateRef,
+  path: Array<string | number>,
+  resolved: Map<string, ResolvedTemplateRef>,
+  issues: ReminderRuleAuthoringIssue[],
+): NormalizedTemplateRef | null {
+  const idMatch = ref.templateId ? resolved.get(`id:${ref.templateId}`) : null
+  const slugMatch = ref.templateSlug ? resolved.get(`slug:${ref.templateSlug}`) : null
+
+  if (ref.templateId && !idMatch) {
+    issue(
+      issues,
+      "template_not_found",
+      [...path, "templateId"],
+      `Notification template "${ref.templateId}" was not found.`,
+      "Use an existing templateId or omit it and provide a resolvable templateSlug.",
+    )
+  }
+  if (ref.templateSlug && !slugMatch) {
+    issue(
+      issues,
+      "template_not_found",
+      [...path, "templateSlug"],
+      `Notification template "${ref.templateSlug}" was not found.`,
+      "Use an existing templateSlug or omit it and provide a resolvable templateId.",
+    )
+  }
+  if (idMatch && slugMatch && idMatch.id !== slugMatch.id) {
+    issue(
+      issues,
+      "template_ref_mismatch",
+      path,
+      "templateId and templateSlug resolve to different notification templates.",
+      "Keep only one template reference or make both references point at the same template.",
+    )
+  }
+
+  const template = idMatch ?? slugMatch
+  if (!template) return null
+
+  return {
+    templateId: template.id,
+    templateSlug: template.slug,
+    template,
+  }
+}
+
+async function validateAndNormalizeComposeInput(
+  db: PostgresJsDatabase,
+  input: ComposeNotificationReminderRuleInput,
+): Promise<
+  | {
+      ok: true
+      input: ComposeNotificationReminderRuleInput
+      ruleTemplate: NormalizedTemplateRef | null
+      channels: NormalizedTemplateRef[][]
+    }
+  | { ok: false; issues: ReminderRuleAuthoringIssue[] }
+> {
+  const issues: ReminderRuleAuthoringIssue[] = []
+  const refs: TemplateRef[] = [input.rule]
+  for (const stage of input.stages) {
+    refs.push(...stage.channels)
+  }
+  const resolved = await resolveTemplateRefs(db, refs)
+  const ruleTemplate = normalizeTemplateRef(input.rule, ["rule"], resolved, issues)
+
+  const stageOrderIndexes = new Set<number>()
+  const normalizedChannels: NormalizedTemplateRef[][] = []
+
+  input.stages.forEach((stage, stageIndex) => {
+    const stagePath = ["stages", stageIndex]
+    if (stageOrderIndexes.has(stage.orderIndex)) {
+      issue(
+        issues,
+        "duplicate_stage_order",
+        [...stagePath, "orderIndex"],
+        `Stage orderIndex ${stage.orderIndex} is used more than once.`,
+        "Give each stage a unique orderIndex.",
+      )
+    }
+    stageOrderIndexes.add(stage.orderIndex)
+
+    if (stage.windowEndDays < stage.windowStartDays) {
+      issue(
+        issues,
+        "invalid_stage_window",
+        [...stagePath, "windowEndDays"],
+        "windowEndDays must be greater than or equal to windowStartDays.",
+        "Set windowEndDays to the same value as windowStartDays or a later day offset.",
+      )
+    }
+    if (stage.cadenceKind === "every_n_days" && !stage.cadenceEveryDays) {
+      issue(
+        issues,
+        "cadence_every_days_required",
+        [...stagePath, "cadenceEveryDays"],
+        "cadenceEveryDays is required when cadenceKind is every_n_days.",
+        "Set cadenceEveryDays to a positive integer or change cadenceKind.",
+      )
+    }
+    if (
+      stage.cadenceKind === "escalating" &&
+      (!stage.cadenceIntervals || stage.cadenceIntervals.length === 0)
+    ) {
+      issue(
+        issues,
+        "cadence_intervals_required",
+        [...stagePath, "cadenceIntervals"],
+        "cadenceIntervals is required when cadenceKind is escalating.",
+        "Provide at least one escalation interval or change cadenceKind.",
+      )
+    }
+
+    const channelOrderIndexes = new Set<number>()
+    normalizedChannels[stageIndex] = []
+
+    stage.channels.forEach((channel, channelIndex) => {
+      const channelPath = [...stagePath, "channels", channelIndex]
+      if (channelOrderIndexes.has(channel.orderIndex)) {
+        issue(
+          issues,
+          "duplicate_channel_order",
+          [...channelPath, "orderIndex"],
+          `Channel orderIndex ${channel.orderIndex} is used more than once in this stage.`,
+          "Give each channel in the stage a unique orderIndex.",
+        )
+      }
+      channelOrderIndexes.add(channel.orderIndex)
+
+      if (channel.channel !== input.rule.channel) {
+        issue(
+          issues,
+          "channel_mismatch",
+          [...channelPath, "channel"],
+          `Stage channel "${channel.channel}" does not match rule channel "${input.rule.channel}".`,
+          "Use the same channel on the rule and all stage channels.",
+        )
+      }
+
+      const channelTemplate =
+        normalizeTemplateRef(channel, channelPath, resolved, issues) ?? ruleTemplate
+      if (!channelTemplate) {
+        issue(
+          issues,
+          "template_required",
+          channelPath,
+          "Each stage channel needs a resolvable template from the channel or rule default.",
+          "Set templateId or templateSlug on this channel, or set a rule-level template.",
+        )
+        return
+      }
+
+      if (channelTemplate.template.channel !== channel.channel) {
+        issue(
+          issues,
+          "template_channel_mismatch",
+          channel.templateId || channel.templateSlug ? channelPath : ["rule"],
+          `Template "${channelTemplate.template.slug}" is ${channelTemplate.template.channel}, but the channel is ${channel.channel}.`,
+          "Use a template whose channel matches the stage channel.",
+        )
+      }
+
+      normalizedChannels[stageIndex]![channelIndex] = channelTemplate
+    })
+  })
+
+  if (ruleTemplate && ruleTemplate.template.channel !== input.rule.channel) {
+    issue(
+      issues,
+      "template_channel_mismatch",
+      ["rule"],
+      `Rule template "${ruleTemplate.template.slug}" is ${ruleTemplate.template.channel}, but the rule channel is ${input.rule.channel}.`,
+      "Use a rule-level template whose channel matches the rule channel.",
+    )
+  }
+
+  if (issues.length > 0) {
+    return { ok: false, issues }
+  }
+
+  return { ok: true, input, ruleTemplate, channels: normalizedChannels }
+}
+
+async function loadComposeResult(
+  db: PostgresJsDatabase,
+  ruleId: string,
+): Promise<ComposeNotificationReminderRuleResult> {
+  const stages = await db
+    .select({
+      id: notificationReminderRuleStages.id,
+      orderIndex: notificationReminderRuleStages.orderIndex,
+    })
+    .from(notificationReminderRuleStages)
+    .where(eq(notificationReminderRuleStages.reminderRuleId, ruleId))
+    .orderBy(asc(notificationReminderRuleStages.orderIndex))
+
+  const stageIds = stages.map((stage) => stage.id)
+  const channels =
+    stageIds.length > 0
+      ? await db
+          .select({
+            id: notificationReminderStageChannels.id,
+            stageId: notificationReminderStageChannels.stageId,
+            orderIndex: notificationReminderStageChannels.orderIndex,
+          })
+          .from(notificationReminderStageChannels)
+          .where(inArray(notificationReminderStageChannels.stageId, stageIds))
+          .orderBy(
+            asc(notificationReminderStageChannels.stageId),
+            asc(notificationReminderStageChannels.orderIndex),
+          )
+      : []
+
+  return {
+    ruleId,
+    stages: stages.map((stage) => ({
+      id: stage.id,
+      orderIndex: stage.orderIndex,
+      channels: channels
+        .filter((channel) => channel.stageId === stage.id)
+        .map((channel) => ({ id: channel.id, orderIndex: channel.orderIndex })),
+    })),
+  }
+}
+
+async function withIdempotency(
+  tx: PostgresJsDatabase,
+  key: string | undefined,
+  build: () => Promise<ComposeNotificationReminderRuleResult>,
+): Promise<{ result: ComposeNotificationReminderRuleResult; reused: boolean }> {
+  if (!key) {
+    return { result: await build(), reused: false }
+  }
+
+  await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(${key}, 0))`)
+
+  const [existing] = await tx
+    .select({ reminderRuleId: notificationReminderRuleAuthoringRequests.reminderRuleId })
+    .from(notificationReminderRuleAuthoringRequests)
+    .where(eq(notificationReminderRuleAuthoringRequests.idempotencyKey, key))
+    .limit(1)
+
+  if (existing) {
+    return { result: await loadComposeResult(tx, existing.reminderRuleId), reused: true }
+  }
+
+  const result = await build()
+  await tx.insert(notificationReminderRuleAuthoringRequests).values({
+    idempotencyKey: key,
+    reminderRuleId: result.ruleId,
+    operation: "compose",
+  })
+
+  return { result, reused: false }
+}
+
+async function buildReminderRuleGraph(
+  tx: PostgresJsDatabase,
+  normalized: Extract<Awaited<ReturnType<typeof validateAndNormalizeComposeInput>>, { ok: true }>,
+): Promise<ComposeNotificationReminderRuleResult> {
+  const [rule] = await tx
+    .insert(notificationReminderRules)
+    .values({
+      slug: normalized.input.rule.slug,
+      name: normalized.input.rule.name,
+      status: normalized.input.rule.status,
+      targetType: normalized.input.rule.targetType,
+      channel: normalized.input.rule.channel,
+      provider: normalized.input.rule.provider ?? null,
+      templateId: normalized.ruleTemplate?.templateId ?? null,
+      templateSlug: normalized.ruleTemplate?.templateSlug ?? null,
+      priority: normalized.input.rule.priority,
+      suppressionGroup: normalized.input.rule.suppressionGroup ?? null,
+      isSystem: normalized.input.rule.isSystem,
+      metadata: normalized.input.rule.metadata ?? null,
+    })
+    .returning({ id: notificationReminderRules.id })
+
+  if (!rule) throw new Error("Failed to create notification reminder rule")
+
+  const result: ComposeNotificationReminderRuleResult = { ruleId: rule.id, stages: [] }
+
+  for (let stageIndex = 0; stageIndex < normalized.input.stages.length; stageIndex += 1) {
+    const stage = normalized.input.stages[stageIndex]!
+    const [stageRow] = await tx
+      .insert(notificationReminderRuleStages)
+      .values({
+        reminderRuleId: rule.id,
+        orderIndex: stage.orderIndex,
+        name: stage.name ?? null,
+        anchor: stage.anchor,
+        windowStartDays: stage.windowStartDays,
+        windowEndDays: stage.windowEndDays,
+        cadenceKind: stage.cadenceKind,
+        cadenceEveryDays: stage.cadenceEveryDays ?? null,
+        cadenceIntervals: stage.cadenceIntervals ?? null,
+        maxSendsInStage: stage.maxSendsInStage ?? null,
+        respectQuietHours: stage.respectQuietHours,
+        metadata: stage.metadata ?? null,
+      })
+      .returning({ id: notificationReminderRuleStages.id })
+
+    if (!stageRow) throw new Error("Failed to create notification reminder stage")
+
+    const stageResult: ComposeNotificationReminderRuleResult["stages"][number] = {
+      id: stageRow.id,
+      orderIndex: stage.orderIndex,
+      channels: [],
+    }
+
+    for (let channelIndex = 0; channelIndex < stage.channels.length; channelIndex += 1) {
+      const channel = stage.channels[channelIndex]!
+      const template = normalized.channels[stageIndex]![channelIndex]!
+      const [channelRow] = await tx
+        .insert(notificationReminderStageChannels)
+        .values({
+          stageId: stageRow.id,
+          orderIndex: channel.orderIndex,
+          channel: channel.channel,
+          provider: channel.provider ?? null,
+          templateId: template.templateId,
+          templateSlug: template.templateSlug,
+          recipientKind: channel.recipientKind,
+          recipientRole: channel.recipientRole ?? null,
+          metadata: channel.metadata ?? null,
+        })
+        .returning({
+          id: notificationReminderStageChannels.id,
+          orderIndex: notificationReminderStageChannels.orderIndex,
+        })
+
+      if (!channelRow) throw new Error("Failed to create notification reminder stage channel")
+      stageResult.channels.push({ id: channelRow.id, orderIndex: channelRow.orderIndex })
+    }
+
+    result.stages.push(stageResult)
+  }
+
+  return result
+}
+
+export async function composeNotificationReminderRule(
+  db: PostgresJsDatabase,
+  input: ComposeNotificationReminderRuleInput,
+  options: { idempotencyKey?: string } = {},
+): Promise<ComposeNotificationReminderRuleOutcome> {
+  const normalized = await validateAndNormalizeComposeInput(db, input)
+  if (!normalized.ok) return { status: "invalid", issues: normalized.issues }
+
+  const { result, reused } = await db.transaction((tx) =>
+    withIdempotency(tx, options.idempotencyKey ?? input.idempotencyKey, () =>
+      buildReminderRuleGraph(tx, normalized),
+    ),
+  )
+
+  return { status: "ok", result, reused }
+}

--- a/packages/notifications/src/service-templates.ts
+++ b/packages/notifications/src/service-templates.ts
@@ -182,6 +182,14 @@ export async function updateTemplate(
   return row ?? null
 }
 
+export async function deleteTemplate(db: PostgresJsDatabase, id: string): Promise<boolean> {
+  const rows = await db
+    .delete(notificationTemplates)
+    .where(eq(notificationTemplates.id, id))
+    .returning({ id: notificationTemplates.id })
+  return rows.length > 0
+}
+
 export async function listReminderRules(
   db: PostgresJsDatabase,
   query: NotificationReminderRuleListQuery,
@@ -240,6 +248,14 @@ export async function updateReminderRule(
     .where(eq(notificationReminderRules.id, id))
     .returning()
   return row ?? null
+}
+
+export async function deleteReminderRule(db: PostgresJsDatabase, id: string): Promise<boolean> {
+  const rows = await db
+    .delete(notificationReminderRules)
+    .where(eq(notificationReminderRules.id, id))
+    .returning({ id: notificationReminderRules.id })
+  return rows.length > 0
 }
 
 export async function listReminderRuns(

--- a/packages/notifications/src/service.ts
+++ b/packages/notifications/src/service.ts
@@ -20,6 +20,7 @@ import {
   sendNotification,
   sendPaymentSessionNotification,
 } from "./service-deliveries.js"
+import { composeNotificationReminderRule } from "./service-reminder-authoring.js"
 import { runDueReminders } from "./service-reminders.js"
 import { previewReminders } from "./service-sequence.js"
 import { previewNotificationTemplate } from "./service-shared.js"
@@ -40,6 +41,8 @@ import {
 import {
   createReminderRule,
   createTemplate,
+  deleteReminderRule,
+  deleteTemplate,
   getReminderRuleById,
   getReminderRunById,
   getTemplateById,
@@ -57,6 +60,7 @@ export const notificationsService = {
   getTemplateBySlug,
   createTemplate,
   updateTemplate,
+  deleteTemplate,
   previewNotificationTemplate,
   listDeliveries,
   getDeliveryById,
@@ -66,7 +70,9 @@ export const notificationsService = {
   getReminderRuleById,
   getReminderRunById,
   createReminderRule,
+  composeNotificationReminderRule,
   updateReminderRule,
+  deleteReminderRule,
   listReminderRuns,
   runDueReminders,
   previewReminders,

--- a/packages/notifications/src/validation.ts
+++ b/packages/notifications/src/validation.ts
@@ -134,7 +134,7 @@ export const insertNotificationReminderRuleSchema = notificationReminderRuleCore
 
 export const updateNotificationReminderRuleSchema = notificationReminderRuleCoreSchema.partial()
 
-const notificationReminderRuleStageBaseSchema = z.object({
+export const notificationReminderRuleStageBaseSchema = z.object({
   name: z.string().max(255).optional().nullable(),
   orderIndex: z.coerce.number().int().min(0).max(1000),
   anchor: notificationReminderStageAnchorSchema,
@@ -188,7 +188,7 @@ export const reorderReminderRuleStagesSchema = z.object({
   stageIds: z.array(z.string().min(1)).min(1).max(50),
 })
 
-const notificationReminderStageChannelBaseSchema = z.object({
+export const notificationReminderStageChannelBaseSchema = z.object({
   orderIndex: z.coerce.number().int().min(0).max(50).default(0),
   channel: notificationChannelSchema,
   provider: z.string().max(255).optional().nullable(),
@@ -210,6 +210,17 @@ export const insertNotificationReminderStageChannelSchema =
 
 export const updateNotificationReminderStageChannelSchema =
   notificationReminderStageChannelBaseSchema.partial()
+
+export const composeNotificationReminderRuleStageSchema =
+  notificationReminderRuleStageBaseSchema.extend({
+    channels: z.array(notificationReminderStageChannelBaseSchema).min(1).max(50),
+  })
+
+export const composeNotificationReminderRuleSchema = z.object({
+  rule: insertNotificationReminderRuleSchema,
+  stages: z.array(composeNotificationReminderRuleStageSchema).min(1).max(50),
+  idempotencyKey: z.string().min(1).max(255).optional(),
+})
 
 const notificationQuietHoursConfigSchema = z.object({
   start: z.string().regex(/^\d{2}:\d{2}$/),

--- a/packages/notifications/tests/integration/reminder-rule-authoring.test.ts
+++ b/packages/notifications/tests/integration/reminder-rule-authoring.test.ts
@@ -1,0 +1,256 @@
+import { sql } from "drizzle-orm"
+import { describe, expect, it } from "vitest"
+
+import { createNotificationsTestContext, DB_AVAILABLE, json } from "./test-helpers"
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function queryRows(result: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(result)) {
+    return result.filter(isRecord)
+  }
+  if (isRecord(result) && Array.isArray(result.rows)) {
+    return result.rows.filter(isRecord)
+  }
+  return []
+}
+
+describe.skipIf(!DB_AVAILABLE)("Notification reminder rule authoring", () => {
+  const ctx = createNotificationsTestContext()
+
+  it("composes a full reminder rule graph from one request", async () => {
+    const templateRes = await ctx.request("/templates", {
+      method: "POST",
+      ...json({
+        slug: "compose-payment-reminder",
+        name: "Compose payment reminder",
+        channel: "email",
+        provider: "local",
+        status: "active",
+        subjectTemplate: "Payment due",
+        textTemplate: "Please pay",
+      }),
+    })
+    expect(templateRes.status).toBe(201)
+    const { data: template } = await templateRes.json()
+
+    const composeRes = await ctx.request("/reminder-rules/compose", {
+      method: "POST",
+      ...json({
+        rule: {
+          slug: "compose-payment-rule",
+          name: "Compose payment rule",
+          status: "active",
+          targetType: "booking_payment_schedule",
+          channel: "email",
+          provider: "local",
+          templateSlug: "compose-payment-reminder",
+          priority: 20,
+          suppressionGroup: "booking-payment",
+        },
+        stages: [
+          {
+            orderIndex: 0,
+            name: "First touch",
+            anchor: "due_date",
+            windowStartDays: -7,
+            windowEndDays: 0,
+            cadenceKind: "once",
+            respectQuietHours: false,
+            channels: [
+              {
+                orderIndex: 0,
+                channel: "email",
+                provider: "local",
+                recipientKind: "primary",
+              },
+            ],
+          },
+        ],
+      }),
+    })
+
+    expect(composeRes.status).toBe(201)
+    const { data } = await composeRes.json()
+    expect(data.ruleId).toMatch(/^ntrl_/)
+    expect(data.stages).toHaveLength(1)
+    expect(data.stages[0].channels).toHaveLength(1)
+
+    const stagesRes = await ctx.request(`/reminder-rules/${data.ruleId}/stages`)
+    const { data: stages } = await stagesRes.json()
+    expect(stages[0]).toMatchObject({
+      id: data.stages[0].id,
+      orderIndex: 0,
+      cadenceKind: "once",
+    })
+
+    const channelsRes = await ctx.request(
+      `/reminder-rules/${data.ruleId}/stages/${data.stages[0].id}/channels`,
+    )
+    const { data: channels } = await channelsRes.json()
+    expect(channels[0]).toMatchObject({
+      id: data.stages[0].channels[0].id,
+      templateId: template.id,
+      templateSlug: "compose-payment-reminder",
+      channel: "email",
+    })
+  })
+
+  it("returns recoverable validation issues without inserting a partial graph", async () => {
+    await ctx.request("/templates", {
+      method: "POST",
+      ...json({
+        slug: "compose-sms-template",
+        name: "Compose SMS template",
+        channel: "sms",
+        provider: "local",
+        status: "active",
+        textTemplate: "SMS",
+      }),
+    })
+
+    const composeRes = await ctx.request("/reminder-rules/compose", {
+      method: "POST",
+      ...json({
+        rule: {
+          slug: "bad-compose-rule",
+          name: "Bad compose rule",
+          status: "active",
+          targetType: "booking_payment_schedule",
+          channel: "email",
+        },
+        stages: [
+          {
+            orderIndex: 0,
+            anchor: "due_date",
+            windowStartDays: 3,
+            windowEndDays: 1,
+            cadenceKind: "every_n_days",
+            respectQuietHours: true,
+            channels: [
+              {
+                orderIndex: 0,
+                channel: "email",
+                templateSlug: "compose-sms-template",
+                recipientKind: "primary",
+              },
+            ],
+          },
+        ],
+      }),
+    })
+
+    expect(composeRes.status).toBe(422)
+    const body = await composeRes.json()
+    const codes = body.issues.map((issue: { code: string }) => issue.code)
+    expect(codes).toContain("invalid_stage_window")
+    expect(codes).toContain("cadence_every_days_required")
+    expect(codes).toContain("template_channel_mismatch")
+    expect(body.issues[0]).toHaveProperty("fix")
+
+    const rows = queryRows(
+      await ctx.db.execute(sql`
+        SELECT id FROM notification_reminder_rules WHERE slug = 'bad-compose-rule'
+      `),
+    )
+    expect(rows).toHaveLength(0)
+  })
+
+  it("replays a compose request by idempotency key", async () => {
+    await ctx.request("/templates", {
+      method: "POST",
+      ...json({
+        slug: "compose-idempotent-template",
+        name: "Compose idempotent template",
+        channel: "email",
+        provider: "local",
+        status: "active",
+        textTemplate: "Reminder",
+      }),
+    })
+
+    const init = {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Idempotency-Key": "compose-reminder-rule-once",
+      },
+      body: JSON.stringify({
+        rule: {
+          slug: "compose-idempotent-rule",
+          name: "Compose idempotent rule",
+          status: "active",
+          targetType: "booking_payment_schedule",
+          channel: "email",
+          templateSlug: "compose-idempotent-template",
+        },
+        stages: [
+          {
+            orderIndex: 0,
+            anchor: "due_date",
+            windowStartDays: -3,
+            windowEndDays: 0,
+            cadenceKind: "once",
+            respectQuietHours: true,
+            channels: [{ orderIndex: 0, channel: "email", recipientKind: "primary" }],
+          },
+        ],
+      }),
+    }
+
+    const firstRes = await ctx.request("/reminder-rules/compose", init)
+    expect(firstRes.status).toBe(201)
+    const firstBody = await firstRes.json()
+
+    const secondRes = await ctx.request("/reminder-rules/compose", init)
+    expect(secondRes.status).toBe(200)
+    const secondBody = await secondRes.json()
+    expect(secondBody.data).toEqual(firstBody.data)
+
+    const rows = queryRows(
+      await ctx.db.execute(sql`
+        SELECT id FROM notification_reminder_rules WHERE slug = 'compose-idempotent-rule'
+      `),
+    )
+    expect(rows).toHaveLength(1)
+  })
+
+  it("hard-deletes templates and reminder rules", async () => {
+    const templateRes = await ctx.request("/templates", {
+      method: "POST",
+      ...json({
+        slug: "delete-template",
+        name: "Delete template",
+        channel: "email",
+        provider: "local",
+        status: "draft",
+        textTemplate: "Delete",
+      }),
+    })
+    const { data: template } = await templateRes.json()
+
+    const deleteTemplateRes = await ctx.request(`/templates/${template.id}`, { method: "DELETE" })
+    expect(deleteTemplateRes.status).toBe(204)
+    const missingTemplateRes = await ctx.request(`/templates/${template.id}`)
+    expect(missingTemplateRes.status).toBe(404)
+
+    const ruleRes = await ctx.request("/reminder-rules", {
+      method: "POST",
+      ...json({
+        slug: "delete-rule",
+        name: "Delete rule",
+        status: "draft",
+        targetType: "booking_payment_schedule",
+        channel: "email",
+      }),
+    })
+    const { data: rule } = await ruleRes.json()
+
+    const deleteRuleRes = await ctx.request(`/reminder-rules/${rule.id}`, { method: "DELETE" })
+    expect(deleteRuleRes.status).toBe(204)
+    const missingRuleRes = await ctx.request(`/reminder-rules/${rule.id}`)
+    expect(missingRuleRes.status).toBe(404)
+  })
+})

--- a/packages/notifications/tests/integration/test-helpers.ts
+++ b/packages/notifications/tests/integration/test-helpers.ts
@@ -20,6 +20,7 @@ async function cleanupNotificationsTestData(
   await db.execute(sql`
     TRUNCATE
       notification_reminder_runs,
+      notification_reminder_rule_authoring_requests,
       notification_reminder_stage_channels,
       notification_reminder_rule_stages,
       notification_reminder_rules,
@@ -431,6 +432,18 @@ export function createNotificationsTestContext(options?: { eventBus?: EventBus }
         created_at timestamp with time zone DEFAULT now() NOT NULL,
         updated_at timestamp with time zone DEFAULT now() NOT NULL
       )
+    `)
+    await db.execute(sql`
+      CREATE TABLE IF NOT EXISTS notification_reminder_rule_authoring_requests (
+        idempotency_key text PRIMARY KEY NOT NULL,
+        reminder_rule_id text NOT NULL,
+        operation text NOT NULL,
+        created_at timestamp with time zone DEFAULT now() NOT NULL
+      )
+    `)
+    await db.execute(sql`
+      CREATE INDEX IF NOT EXISTS idx_notification_reminder_rule_authoring_rule
+        ON notification_reminder_rule_authoring_requests (reminder_rule_id)
     `)
     await db.execute(sql`
       CREATE TABLE IF NOT EXISTS notification_settings (

--- a/templates/operator/migrations/0055_notification_reminder_rule_authoring_requests.sql
+++ b/templates/operator/migrations/0055_notification_reminder_rule_authoring_requests.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS "notification_reminder_rule_authoring_requests" (
+	"idempotency_key" text PRIMARY KEY NOT NULL,
+	"reminder_rule_id" text NOT NULL,
+	"operation" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$
+BEGIN
+	ALTER TABLE "notification_reminder_rule_authoring_requests"
+		ADD CONSTRAINT "notification_reminder_rule_authoring_requests_reminder_rule_id_notification_reminder_rules_id_fk"
+		FOREIGN KEY ("reminder_rule_id") REFERENCES "public"."notification_reminder_rules"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+	WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_notification_reminder_rule_authoring_rule" ON "notification_reminder_rule_authoring_requests" USING btree ("reminder_rule_id");

--- a/templates/operator/migrations/meta/_journal.json
+++ b/templates/operator/migrations/meta/_journal.json
@@ -379,6 +379,13 @@
 			"when": 1780142100000,
 			"tag": "0054_catalog_authoring_requests",
 			"breakpoints": true
+		},
+		{
+			"idx": 53,
+			"version": "7",
+			"when": 1780142200000,
+			"tag": "0055_notification_reminder_rule_authoring_requests",
+			"breakpoints": true
 		}
 	]
 }


### PR DESCRIPTION
## Summary

- Add `POST /v1/admin/notifications/reminder-rules/compose` for atomic reminder-rule graph authoring with idempotent replay.
- Add recoverable 422 validation issues for stage windows, cadence requirements, required/resolved templates, and channel/template consistency.
- Add hard-delete routes for notification templates and reminder rules.
- Add a patch changeset and integration coverage for compose, validation, replay, and deletes.

Closes #1515.

## Verification

- `pnpm --filter @voyantjs/notifications lint`
- `pnpm --filter @voyantjs/notifications typecheck`
- `pnpm --filter @voyantjs/notifications test` (DB-backed integration tests skipped without `TEST_DATABASE_URL`)
- `pnpm test:affected`
- `pnpm verify:architecture`
- push hook: `pnpm test` passed

`pnpm verify:fast` reached affected typecheck and failed on an unrelated existing `operator:typecheck` error in `templates/operator/src/api/lib/geo-resolver.ts`: `Property 'air' does not exist on type 'VoyantDataClient'`.