### PR TITLE
Fix CRM people search tokenization

### DIFF
--- a/.changeset/bright-people-search.md
+++ b/.changeset/bright-people-search.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/crm": patch
+"@voyantjs/db": patch
+---
+
+Make CRM people search tokenize whitespace-separated names and compare unaccented person fields so family-first names and diacritic variants match.

--- a/apps/dev/migrations/0046_enable_unaccent.sql
+++ b/apps/dev/migrations/0046_enable_unaccent.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION IF NOT EXISTS "unaccent";

--- a/apps/dev/migrations/meta/_journal.json
+++ b/apps/dev/migrations/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1780141600000,
       "tag": "0045_cruise_search_index_cents_departures",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1780771200000,
+      "tag": "0046_enable_unaccent",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/crm/src/service/accounts-people.ts
+++ b/packages/crm/src/service/accounts-people.ts
@@ -1,5 +1,6 @@
 import { identityContactPoints } from "@voyantjs/identity/schema"
 import { identityService } from "@voyantjs/identity/service"
+import type { AnyColumn } from "drizzle-orm"
 import { and, asc, desc, eq, exists, gte, ilike, lte, or, type SQL, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
@@ -38,9 +39,23 @@ import {
 } from "./accounts-shared.js"
 import { paginate } from "./helpers.js"
 
+function unaccentedIlike(column: AnyColumn, term: string): SQL {
+  return sql`unaccent(coalesce(${column}, '')) ILIKE unaccent(${term})`
+}
+
 function buildPersonSearchCondition(db: PostgresJsDatabase, search: string): SQL | undefined {
-  const term = `%${search}%`
-  const digits = search.replace(/\D/g, "")
+  const trimmedSearch = search.trim()
+  if (!trimmedSearch) return undefined
+
+  const term = `%${trimmedSearch}%`
+  const tokens = trimmedSearch.split(/\s+/).filter(Boolean)
+  const digits = trimmedSearch.replace(/\D/g, "")
+  const searchablePersonColumns = [
+    people.firstName,
+    people.middleName,
+    people.lastName,
+    people.jobTitle,
+  ]
   const contactPointConditions: SQL[] = [
     ilike(identityContactPoints.value, term),
     ilike(identityContactPoints.normalizedValue, term),
@@ -54,10 +69,16 @@ function buildPersonSearchCondition(db: PostgresJsDatabase, search: string): SQL
     )
   }
 
+  const tokenizedPersonCondition = tokens.length
+    ? and(
+        ...tokens.map((token) =>
+          or(...searchablePersonColumns.map((column) => unaccentedIlike(column, `%${token}%`))),
+        ),
+      )
+    : undefined
+
   return or(
-    ilike(people.firstName, term),
-    ilike(people.lastName, term),
-    ilike(people.jobTitle, term),
+    tokenizedPersonCondition,
     exists(
       db
         .select({ one: sql`1` })

--- a/packages/crm/tests/integration/accounts.test.ts
+++ b/packages/crm/tests/integration/accounts.test.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm"
 import { Hono } from "hono"
 import { beforeAll, beforeEach, describe, expect, it } from "vitest"
 
@@ -19,6 +20,7 @@ describe.skipIf(!DB_AVAILABLE)("Account routes", () => {
   beforeAll(async () => {
     const { createTestDb, cleanupTestDb } = await import("@voyantjs/db/test-utils")
     const db = createTestDb()
+    await db.execute(sql`CREATE EXTENSION IF NOT EXISTS "unaccent"`)
     await cleanupTestDb(db)
 
     app = new Hono()
@@ -321,6 +323,47 @@ describe.skipIf(!DB_AVAILABLE)("Account routes", () => {
       const body = await res.json()
       expect(body.total).toBe(1)
       expect(body.data[0]?.phone).toBe("+40 (712) 345-678")
+    })
+
+    it("searches people by name tokens regardless of order or diacritics", async () => {
+      await app.request("/people", {
+        method: "POST",
+        ...json({ firstName: "Ion", lastName: "Gheorghiță" }),
+      })
+      await app.request("/people", {
+        method: "POST",
+        ...json({ firstName: "Ioana", lastName: "Popescu" }),
+      })
+
+      const familyFirst = await app.request(
+        `/people?search=${encodeURIComponent("Gheorghita Ion")}`,
+        {
+          method: "GET",
+        },
+      )
+
+      expect(familyFirst.status).toBe(200)
+      const familyFirstBody = await familyFirst.json()
+      expect(familyFirstBody.total).toBe(1)
+      expect(familyFirstBody.data[0]).toMatchObject({
+        firstName: "Ion",
+        lastName: "Gheorghiță",
+      })
+
+      const givenFirst = await app.request(
+        `/people?search=${encodeURIComponent("Ion Gheorghita")}`,
+        {
+          method: "GET",
+        },
+      )
+
+      expect(givenFirst.status).toBe(200)
+      const givenFirstBody = await givenFirst.json()
+      expect(givenFirstBody.total).toBe(1)
+      expect(givenFirstBody.data[0]).toMatchObject({
+        firstName: "Ion",
+        lastName: "Gheorghiță",
+      })
     })
 
     it("lists people", async () => {

--- a/packages/db/src/schema/00_ensure_schemas.ts
+++ b/packages/db/src/schema/00_ensure_schemas.ts
@@ -1,5 +1,6 @@
 import { sql } from "drizzle-orm"
 
 export const ensurePgcryptoExtension = sql`CREATE EXTENSION IF NOT EXISTS "pgcrypto";`
+export const ensureUnaccentExtension = sql`CREATE EXTENSION IF NOT EXISTS "unaccent";`
 export const ensureIamSchema = sql`CREATE SCHEMA IF NOT EXISTS "iam";`
 export const ensureInfraSchema = sql`CREATE SCHEMA IF NOT EXISTS "infra";`

--- a/templates/dmc/migrations/0026_enable_unaccent.sql
+++ b/templates/dmc/migrations/0026_enable_unaccent.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION IF NOT EXISTS "unaccent";

--- a/templates/dmc/migrations/meta/_journal.json
+++ b/templates/dmc/migrations/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1780141300000,
       "tag": "0025_organization_tax_id",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1780771200000,
+      "tag": "0026_enable_unaccent",
+      "breakpoints": true
     }
   ]
 }

--- a/templates/operator/migrations/0057_enable_unaccent.sql
+++ b/templates/operator/migrations/0057_enable_unaccent.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION IF NOT EXISTS "unaccent";

--- a/templates/operator/migrations/meta/_journal.json
+++ b/templates/operator/migrations/meta/_journal.json
@@ -393,6 +393,13 @@
 			"when": 1780142300000,
 			"tag": "0056_cruise_search_index_cents_departures",
 			"breakpoints": true
+		},
+		{
+			"idx": 55,
+			"version": "7",
+			"when": 1780771200000,
+			"tag": "0057_enable_unaccent",
+			"breakpoints": true
 		}
 	]
 }


### PR DESCRIPTION
## Summary

- tokenize CRM people search terms across person fields so family-first and given-first names both match
- compare person-field search with Postgres `unaccent` to handle diacritic variants
- add `unaccent` extension migrations for operator, DMC, and dev databases
- add route regression coverage and a patch changeset

Closes #1523.

## Verification

- `pnpm --filter @voyantjs/crm typecheck`
- `pnpm --filter @voyantjs/crm test -- tests/integration/accounts.test.ts`
- `pnpm --filter @voyantjs/crm lint`
- `pnpm --filter @voyantjs/db lint`
- `pnpm lint:changed`
- `pnpm test:affected`
- `pnpm verify:architecture`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter dmc typecheck`

Note: `pnpm verify:fast` initially hit a Node heap OOM in `dmc:typecheck`; rerunning that typecheck with an 8 GB heap passed, and the remaining fast-lane checks passed separately.