### PR TITLE
Add CRM record merge support

### DIFF
--- a/.changeset/merge-crm-records.md
+++ b/.changeset/merge-crm-records.md
@@ -1,0 +1,8 @@
+---
+"@voyantjs/crm-contracts": minor
+"@voyantjs/crm": minor
+"@voyantjs/crm-react": minor
+"@voyantjs/crm-ui": minor
+---
+
+Add CRM people and organization merge contracts, routes, React mutations, and detail-page UI actions.

--- a/packages/crm-contracts/src/validation.ts
+++ b/packages/crm-contracts/src/validation.ts
@@ -90,6 +90,9 @@ export const organizationCoreSchema = z.object({
 
 export const insertOrganizationSchema = organizationCoreSchema
 export const updateOrganizationSchema = organizationCoreSchema.partial()
+export const mergeOrganizationSchema = z.object({
+  mergeId: z.string().min(1),
+})
 
 export const organizationListSortFieldSchema = z.enum([
   "name",
@@ -159,6 +162,9 @@ export const personCoreSchema = z.object({
 
 export const insertPersonSchema = personCoreSchema
 export const updatePersonSchema = personCoreSchema.partial()
+export const mergePersonSchema = z.object({
+  mergeId: z.string().min(1),
+})
 
 export const personListSortFieldSchema = z.enum([
   "name",

--- a/packages/crm-react/src/hooks/use-organization-mutation.ts
+++ b/packages/crm-react/src/hooks/use-organization-mutation.ts
@@ -23,6 +23,11 @@ export interface CreateOrganizationInput {
 
 export type UpdateOrganizationInput = Partial<CreateOrganizationInput>
 
+export interface MergeOrganizationInput {
+  keepId: string
+  mergeId: string
+}
+
 const deleteResponseSchema = z.object({ success: z.boolean() })
 
 export function useOrganizationMutation() {
@@ -75,5 +80,23 @@ export function useOrganizationMutation() {
     },
   })
 
-  return { create, update, remove }
+  const merge = useMutation({
+    mutationFn: async ({ keepId, mergeId }: MergeOrganizationInput) => {
+      const { data } = await fetchWithValidation(
+        `/v1/crm/organizations/${keepId}/merge`,
+        organizationSingleResponse,
+        { baseUrl, fetcher },
+        { method: "POST", body: JSON.stringify({ mergeId }) },
+      )
+      return data
+    },
+    onSuccess: (data, variables) => {
+      void queryClient.invalidateQueries({ queryKey: crmQueryKeys.organizations() })
+      void queryClient.invalidateQueries({ queryKey: crmQueryKeys.people() })
+      queryClient.setQueryData(crmQueryKeys.organization(data.id), data)
+      queryClient.removeQueries({ queryKey: crmQueryKeys.organization(variables.mergeId) })
+    },
+  })
+
+  return { create, update, remove, merge }
 }

--- a/packages/crm-react/src/hooks/use-person-mutation.ts
+++ b/packages/crm-react/src/hooks/use-person-mutation.ts
@@ -36,6 +36,11 @@ export interface UpdatePersonProfilePiiInput {
   insurance?: string | null
 }
 
+export interface MergePersonInput {
+  keepId: string
+  mergeId: string
+}
+
 const deleteResponseSchema = z.object({ success: z.boolean() })
 const successResponseSchema = z.object({ success: z.boolean() })
 
@@ -94,6 +99,23 @@ export function usePersonMutation() {
     },
   })
 
+  const merge = useMutation({
+    mutationFn: async ({ keepId, mergeId }: MergePersonInput) => {
+      const { data } = await fetchWithValidation(
+        `/v1/crm/people/${keepId}/merge`,
+        personSingleResponse,
+        { baseUrl, fetcher },
+        { method: "POST", body: JSON.stringify({ mergeId }) },
+      )
+      return data
+    },
+    onSuccess: (data, variables) => {
+      void queryClient.invalidateQueries({ queryKey: crmQueryKeys.people() })
+      queryClient.setQueryData(crmQueryKeys.person(data.id), data)
+      queryClient.removeQueries({ queryKey: crmQueryKeys.person(variables.mergeId) })
+    },
+  })
+
   /**
    * Plaintext PATCH for the four free-text PII slots. Server-side
    * encryption against the people KMS key. Used by the operator
@@ -122,5 +144,5 @@ export function usePersonMutation() {
     },
   })
 
-  return { create, update, remove, updateProfilePii }
+  return { create, update, remove, merge, updateProfilePii }
 }

--- a/packages/crm-react/src/index.ts
+++ b/packages/crm-react/src/index.ts
@@ -54,6 +54,7 @@ export {
 } from "./hooks/use-organization.js"
 export {
   type CreateOrganizationInput,
+  type MergeOrganizationInput,
   type UpdateOrganizationInput,
   useOrganizationMutation,
 } from "./hooks/use-organization-mutation.js"
@@ -76,6 +77,7 @@ export {
 } from "./hooks/use-person-documents.js"
 export {
   type CreatePersonInput,
+  type MergePersonInput,
   type UpdatePersonInput,
   type UpdatePersonProfilePiiInput,
   usePersonMutation,

--- a/packages/crm-ui/src/components/merge-dialogs.tsx
+++ b/packages/crm-ui/src/components/merge-dialogs.tsx
@@ -1,0 +1,207 @@
+"use client"
+
+import type { OrganizationRecord, PersonRecord } from "@voyantjs/crm-react"
+import { useOrganizationMutation, usePersonMutation } from "@voyantjs/crm-react"
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@voyantjs/ui/components"
+import { Alert, AlertDescription } from "@voyantjs/ui/components/alert"
+import { Loader2 } from "lucide-react"
+import { useState } from "react"
+
+import { useCrmUiMessagesOrDefault } from "../i18n/index.js"
+import { OrganizationCombobox } from "./organization-combobox.js"
+import { PersonCombobox } from "./person-combobox.js"
+
+export interface PersonMergeDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  keepPerson: Pick<PersonRecord, "id" | "firstName" | "lastName" | "email">
+  onMerged?: (person: PersonRecord) => void
+}
+
+export function PersonMergeDialog({
+  open,
+  onOpenChange,
+  keepPerson,
+  onMerged,
+}: PersonMergeDialogProps) {
+  const messages = useCrmUiMessagesOrDefault()
+  const dialogMessages = messages.personDetail.mergeDialog
+  const { merge } = usePersonMutation()
+  const [mergeId, setMergeId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const invalidSelection = !mergeId || mergeId === keepPerson.id
+
+  async function submit() {
+    if (invalidSelection) return
+    setError(null)
+    try {
+      const person = await merge.mutateAsync({ keepId: keepPerson.id, mergeId })
+      onMerged?.(person)
+      setMergeId(null)
+      onOpenChange(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : messages.common.unknownError)
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        onOpenChange(next)
+        if (!next) {
+          setMergeId(null)
+          setError(null)
+        }
+      }}
+    >
+      <DialogContent data-slot="person-merge-dialog" className="sm:max-w-[520px]">
+        <DialogHeader>
+          <DialogTitle>{dialogMessages.title}</DialogTitle>
+          <DialogDescription>{dialogMessages.description}</DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-3">
+          <div className="rounded-md border bg-muted/30 p-3 text-sm">
+            <div className="font-medium">{dialogMessages.keepLabel}</div>
+            <div className="mt-1 text-muted-foreground">
+              {formatPersonName(keepPerson) || keepPerson.email || keepPerson.id}
+            </div>
+          </div>
+          <div className="grid gap-2">
+            <div className="text-sm font-medium">{dialogMessages.mergeLabel}</div>
+            <PersonCombobox
+              value={mergeId}
+              onChange={setMergeId}
+              placeholder={dialogMessages.placeholder}
+              emptyText={dialogMessages.empty}
+              triggerClassName="w-full"
+            />
+            {mergeId === keepPerson.id ? (
+              <p className="text-sm text-destructive">{dialogMessages.selfError}</p>
+            ) : null}
+          </div>
+          {error ? (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          ) : null}
+        </div>
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+            {messages.common.cancel}
+          </Button>
+          <Button type="button" disabled={invalidSelection || merge.isPending} onClick={submit}>
+            {merge.isPending ? (
+              <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+            ) : null}
+            {dialogMessages.action}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export interface OrganizationMergeDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  keepOrganization: Pick<OrganizationRecord, "id" | "name">
+  onMerged?: (organization: OrganizationRecord) => void
+}
+
+export function OrganizationMergeDialog({
+  open,
+  onOpenChange,
+  keepOrganization,
+  onMerged,
+}: OrganizationMergeDialogProps) {
+  const messages = useCrmUiMessagesOrDefault()
+  const dialogMessages = messages.organizationDetail.mergeDialog
+  const { merge } = useOrganizationMutation()
+  const [mergeId, setMergeId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const invalidSelection = !mergeId || mergeId === keepOrganization.id
+
+  async function submit() {
+    if (invalidSelection) return
+    setError(null)
+    try {
+      const organization = await merge.mutateAsync({ keepId: keepOrganization.id, mergeId })
+      onMerged?.(organization)
+      setMergeId(null)
+      onOpenChange(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : messages.common.unknownError)
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        onOpenChange(next)
+        if (!next) {
+          setMergeId(null)
+          setError(null)
+        }
+      }}
+    >
+      <DialogContent data-slot="organization-merge-dialog" className="sm:max-w-[520px]">
+        <DialogHeader>
+          <DialogTitle>{dialogMessages.title}</DialogTitle>
+          <DialogDescription>{dialogMessages.description}</DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-3">
+          <div className="rounded-md border bg-muted/30 p-3 text-sm">
+            <div className="font-medium">{dialogMessages.keepLabel}</div>
+            <div className="mt-1 text-muted-foreground">{keepOrganization.name}</div>
+          </div>
+          <div className="grid gap-2">
+            <div className="text-sm font-medium">{dialogMessages.mergeLabel}</div>
+            <OrganizationCombobox
+              value={mergeId}
+              onChange={setMergeId}
+              placeholder={dialogMessages.placeholder}
+              emptyText={dialogMessages.empty}
+              triggerClassName="w-full"
+            />
+            {mergeId === keepOrganization.id ? (
+              <p className="text-sm text-destructive">{dialogMessages.selfError}</p>
+            ) : null}
+          </div>
+          {error ? (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          ) : null}
+        </div>
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+            {messages.common.cancel}
+          </Button>
+          <Button type="button" disabled={invalidSelection || merge.isPending} onClick={submit}>
+            {merge.isPending ? (
+              <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+            ) : null}
+            {dialogMessages.action}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function formatPersonName(person: Pick<PersonRecord, "firstName" | "lastName">) {
+  return [person.firstName, person.lastName]
+    .map((part) => part?.trim())
+    .filter(Boolean)
+    .join(" ")
+}

--- a/packages/crm-ui/src/components/organization-detail-page.tsx
+++ b/packages/crm-ui/src/components/organization-detail-page.tsx
@@ -13,6 +13,7 @@ import { Loader2 } from "lucide-react"
 import { useEffect, useState } from "react"
 
 import { useCrmUiMessagesOrDefault } from "../i18n/index.js"
+import { OrganizationMergeDialog } from "./merge-dialogs.js"
 import {
   type OrganizationDetailPageSlots,
   type OrganizationDetailTab,
@@ -40,6 +41,7 @@ export function OrganizationDetailPage({
 }: OrganizationDetailPageProps) {
   const messages = useCrmUiMessagesOrDefault()
   const [activeTab, setActiveTab] = useState<OrganizationDetailTab>("overview")
+  const [mergeOpen, setMergeOpen] = useState(false)
   const orgQuery = useOrganization(id)
   const { remove, update } = useOrganizationMutation()
 
@@ -115,6 +117,7 @@ export function OrganizationDetailPage({
       <OrganizationTopBar
         orgName={org.name}
         onBack={() => onBack?.()}
+        onMerge={() => setMergeOpen(true)}
         deletePending={remove.isPending}
         onDelete={async () => {
           await remove.mutateAsync(id)
@@ -145,6 +148,11 @@ export function OrganizationDetailPage({
           slots={slots}
         />
       </div>
+      <OrganizationMergeDialog
+        open={mergeOpen}
+        onOpenChange={setMergeOpen}
+        keepOrganization={org}
+      />
     </div>
   )
 }

--- a/packages/crm-ui/src/components/organization-detail-sections.tsx
+++ b/packages/crm-ui/src/components/organization-detail-sections.tsx
@@ -25,6 +25,7 @@ import {
   Building,
   Calendar,
   CircleDot,
+  GitMerge,
   Globe,
   Hash,
   Languages,
@@ -120,6 +121,7 @@ export interface OrganizationDetailPageSlots {
 export interface OrganizationTopBarProps {
   orgName: string
   onBack: () => void
+  onMerge?: () => void
   onDelete: () => Promise<void>
   deletePending: boolean
 }
@@ -127,6 +129,7 @@ export interface OrganizationTopBarProps {
 export function OrganizationTopBar({
   orgName,
   onBack,
+  onMerge,
   onDelete,
   deletePending,
 }: OrganizationTopBarProps) {
@@ -145,6 +148,12 @@ export function OrganizationTopBar({
         <span className="text-foreground">{orgName}</span>
       </div>
       <div className="ml-auto flex items-center gap-2">
+        {onMerge ? (
+          <Button variant="outline" size="sm" onClick={onMerge}>
+            <GitMerge className="size-4" aria-hidden="true" />
+            {messages.organizationDetail.topBar.merge}
+          </Button>
+        ) : null}
         <ConfirmActionButton
           buttonLabel={messages.organizationDetail.topBar.delete}
           confirmLabel={messages.organizationDetail.topBar.delete}

--- a/packages/crm-ui/src/components/person-detail-page.tsx
+++ b/packages/crm-ui/src/components/person-detail-page.tsx
@@ -44,6 +44,7 @@ import {
   Eye,
   EyeOff,
   FileText,
+  GitMerge,
   Globe,
   Languages,
   Loader2,
@@ -63,6 +64,7 @@ import { InlineCurrencyField } from "./inline-currency-field.js"
 import { InlineField } from "./inline-field.js"
 import { InlineLanguageField } from "./inline-language-field.js"
 import { InlineSelectField } from "./inline-select-field.js"
+import { PersonMergeDialog } from "./merge-dialogs.js"
 import { PersonAddressesSection } from "./person-addresses-section.js"
 import { PersonDialog } from "./person-dialog.js"
 import { PersonDocumentDialog } from "./person-document-dialog.js"
@@ -197,6 +199,7 @@ export function PersonDetailPage({
   const messages = useCrmUiMessagesOrDefault()
   const [activeTab, setActiveTab] = useState<PersonDetailTab>("overview")
   const [editOpen, setEditOpen] = useState(false)
+  const [mergeOpen, setMergeOpen] = useState(false)
   const personQuery = usePerson(id)
   const { remove, update } = usePersonMutation()
   const person = personQuery.data
@@ -275,6 +278,7 @@ export function PersonDetailPage({
         personName={displayName}
         onBack={() => onBack?.()}
         onEdit={() => setEditOpen(true)}
+        onMerge={() => setMergeOpen(true)}
         deletePending={remove.isPending}
         onDelete={async () => {
           await remove.mutateAsync(id)
@@ -313,6 +317,7 @@ export function PersonDetailPage({
       </div>
 
       <PersonDialog open={editOpen} onOpenChange={setEditOpen} person={person} />
+      <PersonMergeDialog open={mergeOpen} onOpenChange={setMergeOpen} keepPerson={person} />
     </div>
   )
 }
@@ -321,6 +326,7 @@ export interface PersonTopBarProps {
   personName: string
   onBack: () => void
   onEdit: () => void
+  onMerge: () => void
   onDelete: () => Promise<void>
   deletePending: boolean
 }
@@ -329,6 +335,7 @@ export function PersonTopBar({
   personName,
   onBack,
   onEdit,
+  onMerge,
   onDelete,
   deletePending,
 }: PersonTopBarProps) {
@@ -350,6 +357,10 @@ export function PersonTopBar({
         <Button variant="outline" size="sm" onClick={onEdit}>
           <Pencil className="size-4" aria-hidden="true" />
           {messages.personDetail.topBar.edit}
+        </Button>
+        <Button variant="outline" size="sm" onClick={onMerge}>
+          <GitMerge className="size-4" aria-hidden="true" />
+          {messages.personDetail.topBar.merge}
         </Button>
         <ConfirmActionButton
           buttonLabel={messages.personDetail.topBar.delete}

--- a/packages/crm-ui/src/i18n/en.ts
+++ b/packages/crm-ui/src/i18n/en.ts
@@ -327,10 +327,22 @@ export const crmUiEn = {
   organizationDetail: {
     topBar: {
       organizations: "Organizations",
+      merge: "Merge",
       delete: "Delete",
       deleteTitle: "Delete this organization?",
       deleteDescription:
         "This will permanently remove the organization. People linked to it will remain.",
+    },
+    mergeDialog: {
+      title: "Merge organization",
+      description:
+        "Move CRM history and references from a duplicate organization into this organization.",
+      keepLabel: "Keep",
+      mergeLabel: "Duplicate to merge",
+      placeholder: "Search organizations...",
+      empty: "No organizations found.",
+      selfError: "Choose a different organization to merge.",
+      action: "Merge organization",
     },
     sidebar: {
       about: "About",
@@ -385,10 +397,22 @@ export const crmUiEn = {
     topBar: {
       people: "People",
       edit: "Edit",
+      merge: "Merge",
       delete: "Delete",
       deleteTitle: "Delete this person?",
       deleteDescription:
         "This will permanently remove the person and their CRM links from this workspace.",
+    },
+    mergeDialog: {
+      title: "Merge person",
+      description:
+        "Move bookings, invoices, notes, and CRM history from a duplicate into this person.",
+      keepLabel: "Keep",
+      mergeLabel: "Duplicate to merge",
+      placeholder: "Search people...",
+      empty: "No people found.",
+      selfError: "Choose a different person to merge.",
+      action: "Merge person",
     },
     sidebar: {
       about: "About",

--- a/packages/crm-ui/src/i18n/messages.ts
+++ b/packages/crm-ui/src/i18n/messages.ts
@@ -310,9 +310,20 @@ export type CrmUiMessages = {
   organizationDetail: {
     topBar: {
       organizations: string
+      merge: string
       delete: string
       deleteTitle: string
       deleteDescription: string
+    }
+    mergeDialog: {
+      title: string
+      description: string
+      keepLabel: string
+      mergeLabel: string
+      placeholder: string
+      empty: string
+      selfError: string
+      action: string
     }
     sidebar: {
       about: string
@@ -367,9 +378,20 @@ export type CrmUiMessages = {
     topBar: {
       people: string
       edit: string
+      merge: string
       delete: string
       deleteTitle: string
       deleteDescription: string
+    }
+    mergeDialog: {
+      title: string
+      description: string
+      keepLabel: string
+      mergeLabel: string
+      placeholder: string
+      empty: string
+      selfError: string
+      action: string
     }
     sidebar: {
       about: string

--- a/packages/crm-ui/src/i18n/ro.ts
+++ b/packages/crm-ui/src/i18n/ro.ts
@@ -327,10 +327,22 @@ export const crmUiRo = {
   organizationDetail: {
     topBar: {
       organizations: "Organizatii",
+      merge: "Uneste",
       delete: "Sterge",
       deleteTitle: "Stergi aceasta organizatie?",
       deleteDescription:
         "Aceasta actiune va sterge definitiv organizatia. Persoanele asociate vor ramane.",
+    },
+    mergeDialog: {
+      title: "Uneste organizatia",
+      description:
+        "Muta istoricul CRM si referintele dintr-o organizatie duplicat in aceasta organizatie.",
+      keepLabel: "Pastreaza",
+      mergeLabel: "Duplicatul de unit",
+      placeholder: "Cauta organizatii...",
+      empty: "Nu s-au gasit organizatii.",
+      selfError: "Alege o alta organizatie pentru unire.",
+      action: "Uneste organizatia",
     },
     sidebar: {
       about: "Despre",
@@ -385,10 +397,22 @@ export const crmUiRo = {
     topBar: {
       people: "Persoane",
       edit: "Editeaza",
+      merge: "Uneste",
       delete: "Sterge",
       deleteTitle: "Stergi aceasta persoana?",
       deleteDescription:
         "Aceasta actiune va sterge definitiv persoana si legaturile CRM din acest workspace.",
+    },
+    mergeDialog: {
+      title: "Uneste persoana",
+      description:
+        "Muta rezervarile, facturile, notele si istoricul CRM dintr-un duplicat in aceasta persoana.",
+      keepLabel: "Pastreaza",
+      mergeLabel: "Duplicatul de unit",
+      placeholder: "Cauta persoane...",
+      empty: "Nu s-au gasit persoane.",
+      selfError: "Alege o alta persoana pentru unire.",
+      action: "Uneste persoana",
     },
     sidebar: {
       about: "Despre",

--- a/packages/crm-ui/src/index.ts
+++ b/packages/crm-ui/src/index.ts
@@ -6,6 +6,12 @@ export {
   type CreateQuoteDialogProps,
 } from "./components/create-quote-dialog.js"
 export {
+  OrganizationMergeDialog,
+  type OrganizationMergeDialogProps,
+  PersonMergeDialog,
+  type PersonMergeDialogProps,
+} from "./components/merge-dialogs.js"
+export {
   OpportunitiesBoard,
   type OpportunitiesBoardProps,
 } from "./components/opportunities-board.js"

--- a/packages/crm/src/routes/accounts.ts
+++ b/packages/crm/src/routes/accounts.ts
@@ -6,8 +6,10 @@ import {
   updateContactPointSchema,
 } from "@voyantjs/identity/validation"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import type { Context } from "hono"
 import { Hono } from "hono"
 
+import { CrmMergeError } from "../service/accounts-merge.js"
 import { crmService } from "../service/index.js"
 import {
   communicationListQuerySchema,
@@ -18,6 +20,8 @@ import {
   insertPersonPaymentMethodSchema,
   insertPersonSchema,
   insertSegmentSchema,
+  mergeOrganizationSchema,
+  mergePersonSchema,
   organizationListQuerySchema,
   personListQuerySchema,
   updateOrganizationNoteSchema,
@@ -36,6 +40,13 @@ type Env = {
 
 const organizationEntity = "organization" as const
 const personEntity = "person" as const
+
+function mergeErrorResponse(c: Context<Env>, error: unknown) {
+  if (error instanceof CrmMergeError) {
+    return c.json({ error: error.message }, error.status)
+  }
+  throw error
+}
 
 export const accountRoutes = new Hono<Env>()
   // Organizations
@@ -71,6 +82,15 @@ export const accountRoutes = new Hono<Env>()
     )
     if (!row) return c.json({ error: "Organization not found" }, 404)
     return c.json({ data: row })
+  })
+  .post("/organizations/:id/merge", async (c) => {
+    try {
+      const body = await parseJsonBody(c, mergeOrganizationSchema)
+      const row = await crmService.mergeOrganization(c.get("db"), c.req.param("id"), body.mergeId)
+      return c.json({ data: row })
+    } catch (error) {
+      return mergeErrorResponse(c, error)
+    }
   })
   .delete("/organizations/:id", async (c) => {
     const row = await crmService.deleteOrganization(c.get("db"), c.req.param("id"))
@@ -174,6 +194,15 @@ export const accountRoutes = new Hono<Env>()
     )
     if (!row) return c.json({ error: "Person not found" }, 404)
     return c.json({ data: row })
+  })
+  .post("/people/:id/merge", async (c) => {
+    try {
+      const body = await parseJsonBody(c, mergePersonSchema)
+      const row = await crmService.mergePerson(c.get("db"), c.req.param("id"), body.mergeId)
+      return c.json({ data: row })
+    } catch (error) {
+      return mergeErrorResponse(c, error)
+    }
   })
   .delete("/people/:id", async (c) => {
     const row = await crmService.deletePerson(c.get("db"), c.req.param("id"))

--- a/packages/crm/src/service/accounts-merge.ts
+++ b/packages/crm/src/service/accounts-merge.ts
@@ -1,0 +1,554 @@
+import {
+  identityAddresses,
+  identityContactPoints,
+  identityNamedContacts,
+} from "@voyantjs/identity/schema"
+import { and, eq, inArray, ne, or, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import {
+  activityLinks,
+  activityParticipants,
+  communicationLog,
+  customerSignals,
+  customFieldValues,
+  opportunities,
+  opportunityParticipants,
+  organizationNotes,
+  organizations,
+  people,
+  personDocuments,
+  personNotes,
+  personPaymentMethods,
+  personRelationships,
+  segmentMembers,
+} from "../schema.js"
+import { hydratePeople, organizationEntityType, personEntityType } from "./accounts-shared.js"
+
+export class CrmMergeError extends Error {
+  readonly status: 400 | 404
+
+  constructor(message: string, status: 400 | 404) {
+    super(message)
+    this.name = "CrmMergeError"
+    this.status = status
+  }
+}
+
+type OptionalReference = {
+  table: string
+  column: string
+}
+
+type OptionalEntityTargetReference = {
+  table: string
+  entityType: "person" | "organization"
+}
+
+const OPTIONAL_PERSON_REFERENCES: OptionalReference[] = [
+  { table: "bookings", column: "person_id" },
+  { table: "booking_travelers", column: "person_id" },
+  { table: "booking_staff_assignments", column: "person_id" },
+  { table: "offers", column: "person_id" },
+  { table: "offer_participants", column: "person_id" },
+  { table: "offer_contact_assignments", column: "person_id" },
+  { table: "offer_staff_assignments", column: "person_id" },
+  { table: "orders", column: "person_id" },
+  { table: "order_participants", column: "person_id" },
+  { table: "order_contact_assignments", column: "person_id" },
+  { table: "order_staff_assignments", column: "person_id" },
+  { table: "order_terms", column: "accepted_by" },
+  { table: "invoices", column: "person_id" },
+  { table: "vouchers", column: "issued_to_person_id" },
+  { table: "payment_instruments", column: "person_id" },
+  { table: "payment_sessions", column: "payer_person_id" },
+  { table: "contracts", column: "person_id" },
+  { table: "contract_signatures", column: "person_id" },
+  { table: "policy_acceptances", column: "person_id" },
+  { table: "policy_acceptances", column: "accepted_by" },
+  { table: "notification_deliveries", column: "person_id" },
+  { table: "notification_reminder_runs", column: "person_id" },
+]
+
+const OPTIONAL_ORGANIZATION_REFERENCES: OptionalReference[] = [
+  { table: "bookings", column: "organization_id" },
+  { table: "offers", column: "organization_id" },
+  { table: "orders", column: "organization_id" },
+  { table: "invoices", column: "organization_id" },
+  { table: "vouchers", column: "issued_to_organization_id" },
+  { table: "payment_instruments", column: "organization_id" },
+  { table: "payment_sessions", column: "payer_organization_id" },
+  { table: "contracts", column: "organization_id" },
+  { table: "policy_assignments", column: "organization_id" },
+  { table: "notification_deliveries", column: "organization_id" },
+  { table: "notification_reminder_runs", column: "organization_id" },
+]
+
+const OPTIONAL_PERSON_ENTITY_TARGET_REFERENCES: OptionalEntityTargetReference[] = [
+  { table: "notification_deliveries", entityType: "person" },
+]
+
+const OPTIONAL_ORGANIZATION_ENTITY_TARGET_REFERENCES: OptionalEntityTargetReference[] = [
+  { table: "notification_deliveries", entityType: "organization" },
+]
+
+function quoteIdentifier(identifier: string) {
+  return `"${identifier.replaceAll('"', '""')}"`
+}
+
+function mergeTags(
+  keepTags: string[] | null | undefined,
+  mergeTags: string[] | null | undefined,
+): string[] {
+  return [...new Set([...(keepTags ?? []), ...(mergeTags ?? [])])]
+}
+
+function backfill<T extends Record<string, unknown>>(
+  keep: T,
+  merge: T,
+  keys: Array<keyof T>,
+): Partial<T> {
+  const patch: Partial<T> = {}
+
+  for (const key of keys) {
+    const keepValue = keep[key]
+    const mergeValue = merge[key]
+    if (
+      (keepValue === null || keepValue === undefined || keepValue === "") &&
+      mergeValue !== null &&
+      mergeValue !== undefined &&
+      mergeValue !== ""
+    ) {
+      patch[key] = mergeValue
+    }
+  }
+
+  return patch
+}
+
+async function tableHasColumn(db: PostgresJsDatabase, table: string, column: string) {
+  const rows = await db.execute<{ exists: boolean }>(sql`
+    SELECT EXISTS (
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = ${table}
+        AND column_name = ${column}
+    ) AS "exists"
+  `)
+  return Boolean(rows[0]?.exists)
+}
+
+async function updateOptionalReference(
+  db: PostgresJsDatabase,
+  reference: OptionalReference,
+  keepId: string,
+  mergeId: string,
+) {
+  if (!(await tableHasColumn(db, reference.table, reference.column))) return
+
+  await db.execute(sql`
+    UPDATE ${sql.raw(quoteIdentifier(reference.table))}
+    SET ${sql.raw(quoteIdentifier(reference.column))} = ${keepId}
+    WHERE ${sql.raw(quoteIdentifier(reference.column))} = ${mergeId}
+  `)
+}
+
+async function updateOptionalReferences(
+  db: PostgresJsDatabase,
+  references: OptionalReference[],
+  keepId: string,
+  mergeId: string,
+) {
+  for (const reference of references) {
+    await updateOptionalReference(db, reference, keepId, mergeId)
+  }
+}
+
+async function updateOptionalEntityTargetReference(
+  db: PostgresJsDatabase,
+  reference: OptionalEntityTargetReference,
+  keepId: string,
+  mergeId: string,
+) {
+  const hasTargetType = await tableHasColumn(db, reference.table, "target_type")
+  const hasTargetId = await tableHasColumn(db, reference.table, "target_id")
+  if (!hasTargetType || !hasTargetId) return
+
+  await db.execute(sql`
+    UPDATE ${sql.raw(quoteIdentifier(reference.table))}
+    SET target_id = ${keepId}
+    WHERE target_type = ${reference.entityType}
+      AND target_id = ${mergeId}
+  `)
+}
+
+async function updateOptionalEntityTargetReferences(
+  db: PostgresJsDatabase,
+  references: OptionalEntityTargetReference[],
+  keepId: string,
+  mergeId: string,
+) {
+  for (const reference of references) {
+    await updateOptionalEntityTargetReference(db, reference, keepId, mergeId)
+  }
+}
+
+async function mergeIdentityRows(
+  db: PostgresJsDatabase,
+  entityType: string,
+  keepId: string,
+  mergeId: string,
+) {
+  await db.delete(identityContactPoints).where(
+    and(
+      eq(identityContactPoints.entityType, entityType),
+      eq(identityContactPoints.entityId, mergeId),
+      sql`EXISTS (
+          SELECT 1
+          FROM identity_contact_points keep_point
+          WHERE keep_point.entity_type = ${entityType}
+            AND keep_point.entity_id = ${keepId}
+            AND keep_point.kind = ${identityContactPoints.kind}
+            AND keep_point.value = ${identityContactPoints.value}
+        )`,
+    ),
+  )
+
+  await db
+    .update(identityContactPoints)
+    .set({ entityId: keepId, updatedAt: new Date() })
+    .where(
+      and(
+        eq(identityContactPoints.entityType, entityType),
+        eq(identityContactPoints.entityId, mergeId),
+      ),
+    )
+
+  await db
+    .update(identityAddresses)
+    .set({ entityId: keepId, updatedAt: new Date() })
+    .where(
+      and(eq(identityAddresses.entityType, entityType), eq(identityAddresses.entityId, mergeId)),
+    )
+
+  await db
+    .update(identityNamedContacts)
+    .set({ entityId: keepId, updatedAt: new Date() })
+    .where(
+      and(
+        eq(identityNamedContacts.entityType, entityType),
+        eq(identityNamedContacts.entityId, mergeId),
+      ),
+    )
+}
+
+async function mergeEntityLinks(
+  db: PostgresJsDatabase,
+  entityType: "person" | "organization",
+  keepId: string,
+  mergeId: string,
+) {
+  await db
+    .update(activityLinks)
+    .set({ entityId: keepId })
+    .where(and(eq(activityLinks.entityType, entityType), eq(activityLinks.entityId, mergeId)))
+
+  await db
+    .update(customFieldValues)
+    .set({ entityId: keepId, updatedAt: new Date() })
+    .where(
+      and(eq(customFieldValues.entityType, entityType), eq(customFieldValues.entityId, mergeId)),
+    )
+}
+
+async function dedupePersonJoinTables(db: PostgresJsDatabase, keepId: string, mergeId: string) {
+  await db.delete(opportunityParticipants).where(
+    and(
+      eq(opportunityParticipants.personId, mergeId),
+      sql`EXISTS (
+          SELECT 1
+          FROM opportunity_participants keep_participant
+          WHERE keep_participant.opportunity_id = ${opportunityParticipants.opportunityId}
+            AND keep_participant.person_id = ${keepId}
+        )`,
+    ),
+  )
+
+  await db.delete(activityParticipants).where(
+    and(
+      eq(activityParticipants.personId, mergeId),
+      sql`EXISTS (
+          SELECT 1
+          FROM activity_participants keep_participant
+          WHERE keep_participant.activity_id = ${activityParticipants.activityId}
+            AND keep_participant.person_id = ${keepId}
+        )`,
+    ),
+  )
+
+  await db
+    .delete(personRelationships)
+    .where(
+      or(
+        and(
+          eq(personRelationships.fromPersonId, mergeId),
+          eq(personRelationships.toPersonId, keepId),
+        ),
+        and(
+          eq(personRelationships.fromPersonId, keepId),
+          eq(personRelationships.toPersonId, mergeId),
+        ),
+        and(
+          eq(personRelationships.fromPersonId, mergeId),
+          eq(personRelationships.toPersonId, mergeId),
+        ),
+      ),
+    )
+
+  await db.delete(personRelationships).where(
+    and(
+      eq(personRelationships.fromPersonId, mergeId),
+      ne(personRelationships.toPersonId, mergeId),
+      sql`EXISTS (
+          SELECT 1
+          FROM person_relationships keep_relationship
+          WHERE keep_relationship.from_person_id = ${keepId}
+            AND keep_relationship.to_person_id = ${personRelationships.toPersonId}
+            AND keep_relationship.kind = ${personRelationships.kind}
+        )`,
+    ),
+  )
+
+  await db.delete(personRelationships).where(
+    and(
+      eq(personRelationships.toPersonId, mergeId),
+      ne(personRelationships.fromPersonId, mergeId),
+      sql`EXISTS (
+          SELECT 1
+          FROM person_relationships keep_relationship
+          WHERE keep_relationship.from_person_id = ${personRelationships.fromPersonId}
+            AND keep_relationship.to_person_id = ${keepId}
+            AND keep_relationship.kind = ${personRelationships.kind}
+        )`,
+    ),
+  )
+}
+
+export const accountMergeService = {
+  async mergePerson(db: PostgresJsDatabase, keepId: string, mergeId: string) {
+    if (keepId === mergeId) {
+      throw new CrmMergeError("Cannot merge a person into itself", 400)
+    }
+
+    return db.transaction(async (tx) => {
+      const [keep, merge] = await tx
+        .select()
+        .from(people)
+        .where(inArray(people.id, [keepId, mergeId]))
+        .for("update")
+
+      const keepPerson = keep?.id === keepId ? keep : merge?.id === keepId ? merge : null
+      const mergePerson = keep?.id === mergeId ? keep : merge?.id === mergeId ? merge : null
+
+      if (!keepPerson) throw new CrmMergeError("Person to keep not found", 404)
+      if (!mergePerson) throw new CrmMergeError("Person to merge not found", 404)
+
+      await tx
+        .update(people)
+        .set({
+          ...backfill(keepPerson, mergePerson, [
+            "organizationId",
+            "middleName",
+            "gender",
+            "jobTitle",
+            "relation",
+            "preferredLanguage",
+            "preferredCurrency",
+            "ownerId",
+            "source",
+            "sourceRef",
+            "dateOfBirth",
+            "notes",
+            "accessibilityEncrypted",
+            "dietaryEncrypted",
+            "loyaltyEncrypted",
+            "insuranceEncrypted",
+          ]),
+          tags: mergeTags(keepPerson.tags, mergePerson.tags),
+          updatedAt: new Date(),
+        })
+        .where(eq(people.id, keepId))
+
+      await dedupePersonJoinTables(tx as PostgresJsDatabase, keepId, mergeId)
+      await mergeIdentityRows(tx as PostgresJsDatabase, personEntityType, keepId, mergeId)
+      await mergeEntityLinks(tx as PostgresJsDatabase, "person", keepId, mergeId)
+
+      await tx
+        .update(personNotes)
+        .set({ personId: keepId })
+        .where(eq(personNotes.personId, mergeId))
+      await tx
+        .update(personDocuments)
+        .set({ isPrimary: false, updatedAt: new Date() })
+        .where(
+          and(
+            eq(personDocuments.personId, mergeId),
+            eq(personDocuments.isPrimary, true),
+            sql`EXISTS (
+              SELECT 1
+              FROM person_documents keep_document
+              WHERE keep_document.person_id = ${keepId}
+                AND keep_document.type = ${personDocuments.type}
+                AND keep_document.is_primary = true
+            )`,
+          ),
+        )
+      await tx
+        .update(personDocuments)
+        .set({ personId: keepId, updatedAt: new Date() })
+        .where(eq(personDocuments.personId, mergeId))
+      await tx
+        .update(personPaymentMethods)
+        .set({ personId: keepId })
+        .where(eq(personPaymentMethods.personId, mergeId))
+      await tx
+        .update(communicationLog)
+        .set({ personId: keepId })
+        .where(eq(communicationLog.personId, mergeId))
+      await tx
+        .update(opportunities)
+        .set({ personId: keepId, updatedAt: new Date() })
+        .where(eq(opportunities.personId, mergeId))
+      await tx
+        .update(opportunityParticipants)
+        .set({ personId: keepId })
+        .where(eq(opportunityParticipants.personId, mergeId))
+      await tx
+        .update(activityParticipants)
+        .set({ personId: keepId })
+        .where(eq(activityParticipants.personId, mergeId))
+      await tx
+        .update(personRelationships)
+        .set({ fromPersonId: keepId, updatedAt: new Date() })
+        .where(eq(personRelationships.fromPersonId, mergeId))
+      await tx
+        .update(personRelationships)
+        .set({ toPersonId: keepId, updatedAt: new Date() })
+        .where(eq(personRelationships.toPersonId, mergeId))
+      await tx
+        .update(segmentMembers)
+        .set({ personId: keepId })
+        .where(eq(segmentMembers.personId, mergeId))
+      await tx
+        .update(customerSignals)
+        .set({ personId: keepId, updatedAt: new Date() })
+        .where(eq(customerSignals.personId, mergeId))
+
+      await updateOptionalReferences(
+        tx as PostgresJsDatabase,
+        OPTIONAL_PERSON_REFERENCES,
+        keepId,
+        mergeId,
+      )
+      await updateOptionalEntityTargetReferences(
+        tx as PostgresJsDatabase,
+        OPTIONAL_PERSON_ENTITY_TARGET_REFERENCES,
+        keepId,
+        mergeId,
+      )
+
+      await tx.delete(people).where(eq(people.id, mergeId))
+
+      const [row] = await tx.select().from(people).where(eq(people.id, keepId)).limit(1)
+      if (!row) throw new Error("Merged person disappeared")
+      const [hydrated] = await hydratePeople(tx as PostgresJsDatabase, [row])
+      return hydrated ?? row
+    })
+  },
+
+  async mergeOrganization(db: PostgresJsDatabase, keepId: string, mergeId: string) {
+    if (keepId === mergeId) {
+      throw new CrmMergeError("Cannot merge an organization into itself", 400)
+    }
+
+    return db.transaction(async (tx) => {
+      const [keep, merge] = await tx
+        .select()
+        .from(organizations)
+        .where(inArray(organizations.id, [keepId, mergeId]))
+        .for("update")
+
+      const keepOrganization = keep?.id === keepId ? keep : merge?.id === keepId ? merge : null
+      const mergeOrganization = keep?.id === mergeId ? keep : merge?.id === mergeId ? merge : null
+
+      if (!keepOrganization) throw new CrmMergeError("Organization to keep not found", 404)
+      if (!mergeOrganization) throw new CrmMergeError("Organization to merge not found", 404)
+
+      await tx
+        .update(organizations)
+        .set({
+          ...backfill(keepOrganization, mergeOrganization, [
+            "legalName",
+            "website",
+            "taxId",
+            "industry",
+            "relation",
+            "ownerId",
+            "defaultCurrency",
+            "preferredLanguage",
+            "paymentTerms",
+            "source",
+            "sourceRef",
+            "notes",
+          ]),
+          tags: mergeTags(keepOrganization.tags, mergeOrganization.tags),
+          updatedAt: new Date(),
+        })
+        .where(eq(organizations.id, keepId))
+
+      await mergeIdentityRows(tx as PostgresJsDatabase, organizationEntityType, keepId, mergeId)
+      await mergeEntityLinks(tx as PostgresJsDatabase, "organization", keepId, mergeId)
+
+      await tx
+        .update(people)
+        .set({ organizationId: keepId, updatedAt: new Date() })
+        .where(eq(people.organizationId, mergeId))
+      await tx
+        .update(organizationNotes)
+        .set({ organizationId: keepId })
+        .where(eq(organizationNotes.organizationId, mergeId))
+      await tx
+        .update(communicationLog)
+        .set({ organizationId: keepId })
+        .where(eq(communicationLog.organizationId, mergeId))
+      await tx
+        .update(opportunities)
+        .set({ organizationId: keepId, updatedAt: new Date() })
+        .where(eq(opportunities.organizationId, mergeId))
+
+      await updateOptionalReferences(
+        tx as PostgresJsDatabase,
+        OPTIONAL_ORGANIZATION_REFERENCES,
+        keepId,
+        mergeId,
+      )
+      await updateOptionalEntityTargetReferences(
+        tx as PostgresJsDatabase,
+        OPTIONAL_ORGANIZATION_ENTITY_TARGET_REFERENCES,
+        keepId,
+        mergeId,
+      )
+
+      await tx.delete(organizations).where(eq(organizations.id, mergeId))
+
+      const [row] = await tx
+        .select()
+        .from(organizations)
+        .where(eq(organizations.id, keepId))
+        .limit(1)
+      if (!row) throw new Error("Merged organization disappeared")
+      return row
+    })
+  },
+}

--- a/packages/crm/src/service/accounts-merge.ts
+++ b/packages/crm/src/service/accounts-merge.ts
@@ -254,6 +254,20 @@ async function mergeEntityLinks(
     .set({ entityId: keepId })
     .where(and(eq(activityLinks.entityType, entityType), eq(activityLinks.entityId, mergeId)))
 
+  await db.delete(customFieldValues).where(
+    and(
+      eq(customFieldValues.entityType, entityType),
+      eq(customFieldValues.entityId, mergeId),
+      sql`EXISTS (
+          SELECT 1
+          FROM custom_field_values keep_value
+          WHERE keep_value.definition_id = ${customFieldValues.definitionId}
+            AND keep_value.entity_type = ${entityType}
+            AND keep_value.entity_id = ${keepId}
+        )`,
+    ),
+  )
+
   await db
     .update(customFieldValues)
     .set({ entityId: keepId, updatedAt: new Date() })

--- a/packages/crm/src/service/accounts.ts
+++ b/packages/crm/src/service/accounts.ts
@@ -1,3 +1,4 @@
+import { accountMergeService } from "./accounts-merge.js"
 import { organizationAccountsService } from "./accounts-organizations.js"
 import { peopleAccountsService } from "./accounts-people.js"
 import {
@@ -9,10 +10,12 @@ import {
 export const accountsService = {
   ...organizationAccountsService,
   ...peopleAccountsService,
+  ...accountMergeService,
   findPersonByContactPoint,
   upsertPersonFromContact,
 }
 
+export { accountMergeService, CrmMergeError } from "./accounts-merge.js"
 export type {
   PersonContactInput,
   UpsertPersonFromContactOptions,

--- a/packages/crm/tests/integration/accounts.test.ts
+++ b/packages/crm/tests/integration/accounts.test.ts
@@ -199,6 +199,46 @@ describe.skipIf(!DB_AVAILABLE)("Account routes", () => {
           'EUR'
         )
       `)
+      await db.execute(sql`
+        INSERT INTO custom_field_definitions (
+          id,
+          entity_type,
+          key,
+          label,
+          field_type
+        )
+        VALUES (
+          'cfdef_merge_org_tier_000000000001',
+          'organization',
+          'merge_org_tier',
+          'Merge organization tier',
+          'text'
+        )
+      `)
+      await db.execute(sql`
+        INSERT INTO custom_field_values (
+          id,
+          definition_id,
+          entity_type,
+          entity_id,
+          text_value
+        )
+        VALUES
+          (
+            'cfval_merge_org_keep_000000000001',
+            'cfdef_merge_org_tier_000000000001',
+            'organization',
+            ${keep.id},
+            'gold'
+          ),
+          (
+            'cfval_merge_org_dup_000000000001',
+            'cfdef_merge_org_tier_000000000001',
+            'organization',
+            ${merge.id},
+            'silver'
+          )
+      `)
 
       const res = await app.request(`/organizations/${keep.id}/merge`, {
         method: "POST",
@@ -227,6 +267,13 @@ describe.skipIf(!DB_AVAILABLE)("Account routes", () => {
         WHERE id = 'book_merge_org_000000000000000000001'
       `)
       expect(bookingRows[0]?.organization_id).toBe(keep.id)
+
+      const customFieldRows = await db.execute<{ entity_id: string; text_value: string }>(sql`
+        SELECT entity_id, text_value
+        FROM custom_field_values
+        WHERE definition_id = 'cfdef_merge_org_tier_000000000001'
+      `)
+      expect(customFieldRows).toEqual([{ entity_id: keep.id, text_value: "gold" }])
     })
 
     it("deletes an organization", async () => {
@@ -329,6 +376,46 @@ describe.skipIf(!DB_AVAILABLE)("Account routes", () => {
           'EUR'
         )
       `)
+      await db.execute(sql`
+        INSERT INTO custom_field_definitions (
+          id,
+          entity_type,
+          key,
+          label,
+          field_type
+        )
+        VALUES (
+          'cfdef_merge_person_pref_00000001',
+          'person',
+          'merge_person_pref',
+          'Merge person preference',
+          'text'
+        )
+      `)
+      await db.execute(sql`
+        INSERT INTO custom_field_values (
+          id,
+          definition_id,
+          entity_type,
+          entity_id,
+          text_value
+        )
+        VALUES
+          (
+            'cfval_merge_person_keep_00000001',
+            'cfdef_merge_person_pref_00000001',
+            'person',
+            ${keep.id},
+            'window'
+          ),
+          (
+            'cfval_merge_person_dup_00000001',
+            'cfdef_merge_person_pref_00000001',
+            'person',
+            ${merge.id},
+            'aisle'
+          )
+      `)
 
       const res = await app.request(`/people/${keep.id}/merge`, {
         method: "POST",
@@ -354,6 +441,13 @@ describe.skipIf(!DB_AVAILABLE)("Account routes", () => {
         WHERE id = 'book_merge_person_000000000000000001'
       `)
       expect(bookingRows[0]?.person_id).toBe(keep.id)
+
+      const customFieldRows = await db.execute<{ entity_id: string; text_value: string }>(sql`
+        SELECT entity_id, text_value
+        FROM custom_field_values
+        WHERE definition_id = 'cfdef_merge_person_pref_00000001'
+      `)
+      expect(customFieldRows).toEqual([{ entity_id: keep.id, text_value: "window" }])
     })
 
     it("rejects self person merges", async () => {

--- a/packages/crm/tests/integration/accounts.test.ts
+++ b/packages/crm/tests/integration/accounts.test.ts
@@ -150,6 +150,85 @@ describe.skipIf(!DB_AVAILABLE)("Account routes", () => {
       expect(body.data.name).toBe("New Name")
     })
 
+    it("merges duplicate organizations and repoints people and booking references", async () => {
+      const { createTestDb } = await import("@voyantjs/db/test-utils")
+      const db = createTestDb()
+
+      const keepRes = await app.request("/organizations", {
+        method: "POST",
+        ...json({ name: "Acme Travel", tags: ["agency"] }),
+      })
+      const mergeRes = await app.request("/organizations", {
+        method: "POST",
+        ...json({
+          name: "Acme Travel SRL",
+          legalName: "Acme Travel SRL",
+          taxId: "RO123456",
+          paymentTerms: 14,
+          tags: ["billing"],
+        }),
+      })
+      const keep = (await keepRes.json()).data
+      const merge = (await mergeRes.json()).data
+
+      const personRes = await app.request("/people", {
+        method: "POST",
+        ...json({
+          firstName: "Org",
+          lastName: "Contact",
+          organizationId: merge.id,
+        }),
+      })
+      const person = (await personRes.json()).data
+
+      await db.execute(sql`
+        INSERT INTO bookings (
+          id,
+          booking_number,
+          status,
+          organization_id,
+          source_type,
+          sell_currency
+        )
+        VALUES (
+          'book_merge_org_000000000000000000001',
+          'B-MERGE-ORG-1',
+          'draft',
+          ${merge.id},
+          'manual',
+          'EUR'
+        )
+      `)
+
+      const res = await app.request(`/organizations/${keep.id}/merge`, {
+        method: "POST",
+        ...json({ mergeId: merge.id }),
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data.id).toBe(keep.id)
+      expect(body.data.name).toBe("Acme Travel")
+      expect(body.data.legalName).toBe("Acme Travel SRL")
+      expect(body.data.taxId).toBe("RO123456")
+      expect(body.data.paymentTerms).toBe(14)
+      expect(body.data.tags).toEqual(["agency", "billing"])
+
+      const duplicate = await app.request(`/organizations/${merge.id}`, { method: "GET" })
+      expect(duplicate.status).toBe(404)
+
+      const personAfterMerge = await app.request(`/people/${person.id}`, { method: "GET" })
+      expect(personAfterMerge.status).toBe(200)
+      expect((await personAfterMerge.json()).data.organizationId).toBe(keep.id)
+
+      const bookingRows = await db.execute<{ organization_id: string }>(sql`
+        SELECT organization_id
+        FROM bookings
+        WHERE id = 'book_merge_org_000000000000000000001'
+      `)
+      expect(bookingRows[0]?.organization_id).toBe(keep.id)
+    })
+
     it("deletes an organization", async () => {
       const createRes = await app.request("/organizations", {
         method: "POST",
@@ -202,6 +281,94 @@ describe.skipIf(!DB_AVAILABLE)("Account routes", () => {
       expect(body.data.firstName).toBe("John")
       expect(body.data.lastName).toBe("Doe")
       expect(body.data.id).toBeTruthy()
+    })
+
+    it("merges duplicate people and repoints booking references", async () => {
+      const { createTestDb } = await import("@voyantjs/db/test-utils")
+      const db = createTestDb()
+
+      const keepRes = await app.request("/people", {
+        method: "POST",
+        ...json({
+          firstName: "Ana",
+          lastName: "Ionescu",
+          email: "ana@example.com",
+          tags: ["vip"],
+        }),
+      })
+      const mergeRes = await app.request("/people", {
+        method: "POST",
+        ...json({
+          firstName: "Ana Maria",
+          middleName: "Maria",
+          lastName: "Ionescu",
+          phone: "+40 700 000 000",
+          dateOfBirth: "1990-03-12",
+          notes: "Duplicate traveler profile",
+          tags: ["repeat"],
+        }),
+      })
+      const keep = (await keepRes.json()).data
+      const merge = (await mergeRes.json()).data
+
+      await db.execute(sql`
+        INSERT INTO bookings (
+          id,
+          booking_number,
+          status,
+          person_id,
+          source_type,
+          sell_currency
+        )
+        VALUES (
+          'book_merge_person_000000000000000001',
+          'B-MERGE-PERSON-1',
+          'draft',
+          ${merge.id},
+          'manual',
+          'EUR'
+        )
+      `)
+
+      const res = await app.request(`/people/${keep.id}/merge`, {
+        method: "POST",
+        ...json({ mergeId: merge.id }),
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data.id).toBe(keep.id)
+      expect(body.data.email).toBe("ana@example.com")
+      expect(body.data.phone).toBe("+40 700 000 000")
+      expect(body.data.middleName).toBe("Maria")
+      expect(body.data.dateOfBirth).toBe("1990-03-12")
+      expect(body.data.notes).toBe("Duplicate traveler profile")
+      expect(body.data.tags).toEqual(["vip", "repeat"])
+
+      const duplicate = await app.request(`/people/${merge.id}`, { method: "GET" })
+      expect(duplicate.status).toBe(404)
+
+      const bookingRows = await db.execute<{ person_id: string }>(sql`
+        SELECT person_id
+        FROM bookings
+        WHERE id = 'book_merge_person_000000000000000001'
+      `)
+      expect(bookingRows[0]?.person_id).toBe(keep.id)
+    })
+
+    it("rejects self person merges", async () => {
+      const createRes = await app.request("/people", {
+        method: "POST",
+        ...json({ firstName: "Self", lastName: "Merge" }),
+      })
+      const person = (await createRes.json()).data
+
+      const res = await app.request(`/people/${person.id}/merge`, {
+        method: "POST",
+        ...json({ mergeId: person.id }),
+      })
+
+      expect(res.status).toBe(400)
     })
 
     it("replays person creates with the same idempotency key", async () => {


### PR DESCRIPTION
## Summary

- Add CRM merge contracts and `POST /v1/crm/people/:id/merge` / `POST /v1/crm/organizations/:id/merge` routes.
- Merge survivor fields conservatively, move identity/contact/address rows, dedupe constrained participant/document rows, repoint CRM-owned and known optional module references, and delete the duplicate record in one transaction.
- Add `crm-react` merge mutations and `crm-ui` detail-page merge dialogs/actions for people and organizations.
- Add DB-gated integration coverage for people and organization merge flows plus a changeset.

Closes #1524

## Verification

- `pnpm --filter @voyantjs/crm-contracts typecheck`
- `pnpm --filter @voyantjs/crm typecheck`
- `pnpm --filter @voyantjs/crm-react typecheck`
- `pnpm --filter @voyantjs/crm-ui typecheck`
- `pnpm --filter @voyantjs/crm-contracts lint`
- `pnpm --filter @voyantjs/crm lint`
- `pnpm --filter @voyantjs/crm-react lint`
- `pnpm --filter @voyantjs/crm-ui lint`
- `pnpm --filter @voyantjs/crm-contracts test`
- `pnpm --filter @voyantjs/crm test`
- `pnpm verify:fast`

Note: CRM integration tests that require `TEST_DATABASE_URL` are skipped in this environment, including the new merge route integration tests.