### PR TITLE
Fix booking contract variable defaults

### DIFF
--- a/.changeset/contract-booking-variable-bag.md
+++ b/.changeset/contract-booking-variable-bag.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/legal": patch
+---
+
+Populate booking-derived contract variables for product, destination, departure slot, and traveler identity snapshots.

--- a/packages/legal/package.json
+++ b/packages/legal/package.json
@@ -24,6 +24,7 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
+    "@voyantjs/action-ledger": "workspace:^",
     "@voyantjs/bookings": "workspace:^",
     "@voyantjs/core": "workspace:^",
     "@voyantjs/crm": "workspace:^",

--- a/packages/legal/src/contracts/route-runtime.ts
+++ b/packages/legal/src/contracts/route-runtime.ts
@@ -1,3 +1,4 @@
+import type { BookingPiiService } from "@voyantjs/bookings"
 import type { EventBus } from "@voyantjs/core"
 import type { StorageProvider } from "@voyantjs/storage"
 
@@ -10,6 +11,8 @@ export type ContractsRouteRuntime = {
   resolveDocumentDownloadUrl?: ContractsRouteOptions["resolveDocumentDownloadUrl"]
   eventBus?: EventBus
   lifecycleHooks?: readonly ContractLifecycleHook[]
+  bookingPiiService?: BookingPiiService | null
+  resolveBookingPiiService?: ContractsRouteOptions["resolveBookingPiiService"]
 }
 
 export const CONTRACTS_ROUTE_RUNTIME_CONTAINER_KEY = "providers.legal.contracts.runtime"
@@ -24,5 +27,7 @@ export function buildContractsRouteRuntime(
     resolveDocumentDownloadUrl: options.resolveDocumentDownloadUrl,
     eventBus: options.resolveEventBus?.(bindings) ?? options.eventBus,
     lifecycleHooks: options.resolveLifecycleHooks?.(bindings) ?? options.lifecycleHooks,
+    bookingPiiService: options.bookingPiiService,
+    resolveBookingPiiService: options.resolveBookingPiiService,
   }
 }

--- a/packages/legal/src/contracts/routes.ts
+++ b/packages/legal/src/contracts/routes.ts
@@ -1,3 +1,5 @@
+import type { ActionLedgerRequestContextValues } from "@voyantjs/action-ledger"
+import { type BookingPiiService, shouldRevealBookingPii } from "@voyantjs/bookings"
 import type { EventBus, ModuleContainer } from "@voyantjs/core"
 import {
   createDrizzlePublicDocumentDeliveryGrantStore,
@@ -49,6 +51,19 @@ type Env = {
     container: ModuleContainer
     db: PostgresJsDatabase
     userId?: string
+    agentId?: string
+    workflowPrincipalId?: string
+    principalSubtype?: string
+    sessionId?: string
+    apiTokenId?: string
+    apiKeyId?: string
+    callerType?: string
+    actor?: string
+    scopes?: string[]
+    isInternalRequest?: boolean
+    organizationId?: string
+    workflowRunId?: string
+    workflowStepId?: string
   }
 }
 
@@ -73,6 +88,10 @@ export interface ContractsRouteOptions {
   resolveLifecycleHooks?: (
     bindings: Record<string, unknown>,
   ) => readonly ContractLifecycleHook[] | undefined
+  bookingPiiService?: BookingPiiService | null
+  resolveBookingPiiService?: (
+    bindings: Record<string, unknown>,
+  ) => BookingPiiService | Promise<BookingPiiService | null | undefined> | null | undefined
 }
 
 function getRuntime(
@@ -84,6 +103,39 @@ function getRuntime(
     resolveFromContainer?.(CONTRACTS_ROUTE_RUNTIME_CONTAINER_KEY) ??
     buildContractsRouteRuntime(bindings, options)
   )
+}
+
+function getActionLedgerRequestContext(c: Context<Env>): ActionLedgerRequestContextValues {
+  return {
+    userId: c.get("userId") ?? null,
+    agentId: c.get("agentId") ?? null,
+    workflowPrincipalId: c.get("workflowPrincipalId") ?? null,
+    principalSubtype: c.get("principalSubtype") ?? null,
+    sessionId: c.get("sessionId") ?? null,
+    apiTokenId: c.get("apiTokenId") ?? c.get("apiKeyId") ?? null,
+    callerType: c.get("callerType") ?? null,
+    actor: c.get("actor") ?? null,
+    isInternalRequest: c.get("isInternalRequest") ?? false,
+    organizationId: c.get("organizationId") ?? null,
+    workflowRunId: c.get("workflowRunId") ?? null,
+    workflowStepId: c.get("workflowStepId") ?? null,
+    correlationId: c.req.header("x-correlation-id") ?? c.req.header("x-request-id") ?? null,
+  }
+}
+
+async function resolveAuthorizedBookingPiiService(
+  c: Context<Env>,
+  runtime: ContractsRouteRuntime,
+): Promise<BookingPiiService | null> {
+  const reveal = shouldRevealBookingPii({
+    actor: c.get("actor"),
+    scopes: c.get("scopes"),
+    callerType: c.get("callerType"),
+    isInternalRequest: c.get("isInternalRequest"),
+  })
+  if (!reveal) return null
+
+  return runtime.bookingPiiService ?? (await runtime.resolveBookingPiiService?.(c.env)) ?? null
 }
 
 function getMultipartString(value: unknown) {
@@ -303,6 +355,8 @@ async function generateContractDocumentForBooking(c: Context<Env>, options: Cont
       bindings: c.env,
       eventBus: runtime.eventBus,
       lifecycleHooks: runtime.lifecycleHooks,
+      bookingPiiService: await resolveAuthorizedBookingPiiService(c, runtime),
+      actionLedgerContext: getActionLedgerRequestContext(c),
     },
     c.get("userId") ?? null,
   )

--- a/packages/legal/src/contracts/service-auto-generate.ts
+++ b/packages/legal/src/contracts/service-auto-generate.ts
@@ -1,6 +1,12 @@
-import { bookingsService } from "@voyantjs/bookings"
+import { type ActionLedgerRequestContextValues, ledgerSensitiveRead } from "@voyantjs/action-ledger"
+import {
+  BOOKING_PII_READ_CAPABILITY,
+  type BookingPiiService,
+  bookingsService,
+} from "@voyantjs/bookings"
+import { bookingPiiAccessLog } from "@voyantjs/bookings/schema"
 import { invoices, payments } from "@voyantjs/finance/schema"
-import { and, desc, eq, ne } from "drizzle-orm"
+import { and, desc, eq, ne, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import type { ContractLifecycleHook } from "./lifecycle.js"
@@ -401,6 +407,13 @@ export interface AutoGenerateContractRuntime {
   eventBus?: import("@voyantjs/core").EventBus
   lifecycleHooks?: readonly ContractLifecycleHook[]
   /**
+   * Optional sensitive booking-traveler reader. When supplied, the default
+   * resolver can include traveler DOB/document snapshots in the template bag.
+   * When absent, those fields keep their empty-string fallbacks.
+   */
+  bookingPiiService?: BookingPiiService | null
+  actionLedgerContext?: ActionLedgerRequestContextValues | null
+  /**
    * Runtime bindings forwarded into `resolveVariables` so consumers
    * can read deploy-specific env vars (e.g. `DOCUMENTS_BASE_URL`)
    * without restructuring every auto-generate call site to know
@@ -581,11 +594,22 @@ export async function autoGenerateContractForBooking(
   }
 
   const travelers = await bookingsService.listTravelers(db, event.bookingId)
+  const travelerTravelDetails = await resolveTravelerTravelDetails(
+    db,
+    booking.id,
+    travelers,
+    runtime.bookingPiiService,
+    event.actorId,
+    runtime.actionLedgerContext,
+  )
   const leadTraveler =
+    travelers.find((t) => travelerTravelDetails.get(t.id)?.isLeadTraveler) ??
     travelers.find((t) => t.isPrimary) ??
     travelers.find((t) => t.participantType === "traveler") ??
     travelers[0] ??
     null
+  const leadTravelerDetails = leadTraveler ? travelerTravelDetails.get(leadTraveler.id) : null
+  const bookingItemContext = await resolveBookingItemContext(db, booking.id)
 
   const now = new Date()
   const todayIso = now.toISOString().slice(0, 10)
@@ -601,6 +625,7 @@ export async function autoGenerateContractForBooking(
 
   const mappedTravelers: ContractTravelerVariable[] = travelers.map((t, i) => {
     const fullName = [t.firstName, t.lastName].filter(Boolean).join(" ").trim()
+    const travelDetails = travelerTravelDetails.get(t.id)
     return {
       id: t.id,
       index: i + 1,
@@ -613,14 +638,14 @@ export async function autoGenerateContractForBooking(
       fullName,
       email: t.email ?? "",
       phone: t.phone ?? "",
-      dateOfBirth: "",
+      dateOfBirth: travelDetails?.dateOfBirth ?? "",
       document: {
-        type: "",
-        number: "",
-        country: "",
-        issuingAuthority: "",
+        type: travelDetails?.documentType ?? "",
+        number: travelDetails?.documentNumber ?? "",
+        country: travelDetails?.documentIssuingCountry ?? "",
+        issuingAuthority: travelDetails?.documentIssuingAuthority ?? "",
         issueDate: "",
-        expiryDate: "",
+        expiryDate: travelDetails?.documentExpiry ?? "",
       },
     }
   })
@@ -656,12 +681,12 @@ export async function autoGenerateContractForBooking(
       id: booking.id,
       status: booking.status,
 
-      entityModule: "",
-      entityId: "",
-      vertical: "",
-      productName: "",
-      productSubtitle: "",
-      destination: "",
+      entityModule: bookingItemContext.entityModule,
+      entityId: bookingItemContext.entityId,
+      vertical: bookingItemContext.vertical,
+      productName: bookingItemContext.productTitle,
+      productSubtitle: bookingItemContext.productSubtitle,
+      destination: bookingItemContext.destination,
 
       pax: booking.pax,
       paxTotal: booking.pax ?? 0,
@@ -728,7 +753,7 @@ export async function autoGenerateContractForBooking(
       fullName: customerFullName,
       email: booking.contactEmail ?? "",
       phone: booking.contactPhone ?? "",
-      dateOfBirth: "",
+      dateOfBirth: leadTravelerDetails?.dateOfBirth ?? "",
       companyName: "",
       vatId: "",
       registrationNumber: "",
@@ -741,12 +766,12 @@ export async function autoGenerateContractForBooking(
         country: booking.contactCountry ?? "",
       },
       document: {
-        type: "",
-        number: "",
-        country: "",
-        issuingAuthority: "",
+        type: leadTravelerDetails?.documentType ?? "",
+        number: leadTravelerDetails?.documentNumber ?? "",
+        country: leadTravelerDetails?.documentIssuingCountry ?? "",
+        issuingAuthority: leadTravelerDetails?.documentIssuingAuthority ?? "",
         issueDate: "",
-        expiryDate: "",
+        expiryDate: leadTravelerDetails?.documentExpiry ?? "",
       },
     },
 
@@ -767,25 +792,25 @@ export async function autoGenerateContractForBooking(
     travelers: mappedTravelers,
     passengers: mappedTravelers,
 
-    items: [],
+    items: bookingItemContext.items,
     addons: [],
 
     product: {
-      title: "",
-      subtitle: "",
-      destination: "",
-      module: "",
-      id: "",
-      vertical: "",
+      title: bookingItemContext.productTitle,
+      subtitle: bookingItemContext.productSubtitle,
+      destination: bookingItemContext.destination,
+      module: bookingItemContext.entityModule,
+      id: bookingItemContext.entityId,
+      vertical: bookingItemContext.vertical,
       heroImageUrl: "",
     },
 
     departureSlot: {
-      slotId: "",
-      startAt: startDate,
-      endAt: endDate,
-      durationDays: durationNights,
-      departureCity: "",
+      slotId: bookingItemContext.departureSlot.slotId,
+      startAt: bookingItemContext.departureSlot.startAt || startDate,
+      endAt: bookingItemContext.departureSlot.endAt || endDate,
+      durationDays: bookingItemContext.departureSlot.durationDays ?? durationNights,
+      departureCity: bookingItemContext.departureSlot.departureCity,
     },
     sailing: {
       sailingId: "",
@@ -970,6 +995,366 @@ export async function autoGenerateContractForBooking(
 
 function defaultVariablesToRecord(defaults: DefaultContractVariables): Record<string, unknown> {
   return { ...defaults }
+}
+
+type BookingItemRow = Awaited<ReturnType<typeof bookingsService.listItems>>[number]
+type BookingTravelerRow = Awaited<ReturnType<typeof bookingsService.listTravelers>>[number]
+type BookingTravelerTravelDetails = NonNullable<
+  Awaited<ReturnType<BookingPiiService["getTravelerTravelDetails"]>>
+>
+
+interface BookingItemContext {
+  entityModule: string
+  entityId: string
+  vertical: string
+  productTitle: string
+  productSubtitle: string
+  destination: string
+  departureSlot: {
+    slotId: string
+    startAt: string
+    endAt: string
+    durationDays: number | null
+    departureCity: string
+  }
+  items: ContractItemVariable[]
+}
+
+async function resolveTravelerTravelDetails(
+  db: PostgresJsDatabase,
+  bookingId: string,
+  travelers: BookingTravelerRow[],
+  pii: BookingPiiService | null | undefined,
+  actorId: string | null,
+  actionLedgerContext: ActionLedgerRequestContextValues | null | undefined,
+): Promise<Map<string, BookingTravelerTravelDetails>> {
+  const detailsByTraveler = new Map<string, BookingTravelerTravelDetails>()
+  if (!pii || travelers.length === 0) return detailsByTraveler
+
+  await Promise.all(
+    travelers.map(async (traveler) => {
+      const details = await ledgerSensitiveRead(
+        db,
+        {
+          context: actionLedgerContext ?? {
+            userId: actorId,
+            actor: actorId ? "staff" : "system",
+            callerType: actorId ? "staff" : "internal",
+            isInternalRequest: actorId == null,
+          },
+          actionName: "booking.pii.read",
+          actionVersion: "v1",
+          targetType: "booking_traveler",
+          targetId: traveler.id,
+          routeOrToolName: "legal.contracts.bookings.generate-document",
+          capabilityId: BOOKING_PII_READ_CAPABILITY.id,
+          capabilityVersion: BOOKING_PII_READ_CAPABILITY.version,
+          authorizationSource: "legal.contract.auto_generate",
+          reasonCode: "contract_variable_resolution",
+          disclosedFieldSet: ["dateOfBirth", "document"],
+          disclosureSummary: "Contract variable traveler identity snapshot",
+          decisionPolicy: "bookings-pii-scope-or-staff-v1",
+          fallbackPrincipalId: actorId ?? "legal_contract_auto_generate",
+        },
+        () => pii.getTravelerTravelDetails(db, traveler.id, actorId),
+      )
+      await logBookingPiiContractRead(db, {
+        bookingId,
+        travelerId: traveler.id,
+        actorId,
+        actionLedgerContext,
+      })
+      if (details) {
+        detailsByTraveler.set(traveler.id, details)
+      }
+    }),
+  )
+
+  return detailsByTraveler
+}
+
+async function logBookingPiiContractRead(
+  db: PostgresJsDatabase,
+  input: {
+    bookingId: string
+    travelerId: string
+    actorId: string | null
+    actionLedgerContext: ActionLedgerRequestContextValues | null | undefined
+  },
+) {
+  await db.insert(bookingPiiAccessLog).values({
+    bookingId: input.bookingId,
+    travelerId: input.travelerId,
+    actorId: input.actionLedgerContext?.userId ?? input.actorId,
+    actorType: input.actionLedgerContext?.actor ?? (input.actorId ? "staff" : "system"),
+    callerType: input.actionLedgerContext?.callerType ?? (input.actorId ? "staff" : "internal"),
+    action: "read",
+    outcome: "allowed",
+    reason: "contract_variable_resolution",
+    metadata: {
+      routeOrToolName: "legal.contracts.bookings.generate-document",
+      capabilityId: BOOKING_PII_READ_CAPABILITY.id,
+      capabilityVersion: BOOKING_PII_READ_CAPABILITY.version,
+    },
+  })
+}
+
+async function resolveBookingItemContext(
+  db: PostgresJsDatabase,
+  bookingId: string,
+): Promise<BookingItemContext> {
+  const items = await bookingsService.listItems(db, bookingId)
+  const primaryItem =
+    items.find((item) => item.productNameSnapshot || item.productId || item.availabilitySlotId) ??
+    items[0] ??
+    null
+
+  if (!primaryItem) {
+    return emptyBookingItemContext()
+  }
+
+  const metadata = recordValue(primaryItem.metadata)
+  const productId = primaryItem.productId ?? ""
+  const linkedProductTitle =
+    productId && !primaryItem.productNameSnapshot
+      ? await resolveLinkedProductTitle(db, productId)
+      : ""
+  const destination = firstString(
+    pickString(metadata, [
+      "destination",
+      "destinationName",
+      "destination_name",
+      "productDestination",
+      "product_destination",
+    ]),
+    productId ? await resolveLinkedProductDestination(db, productId) : "",
+  )
+
+  const entityModule = firstString(
+    pickString(metadata, ["entityModule", "entity_module", "module"]),
+    productId ? "products" : "",
+  )
+  const entityId = firstString(pickString(metadata, ["entityId", "entity_id"]), productId)
+  const vertical = firstString(
+    pickString(metadata, ["vertical", "entityVertical", "entity_vertical", "productType"]),
+    entityModule,
+  )
+  const productTitle = firstString(
+    primaryItem.productNameSnapshot,
+    linkedProductTitle,
+    primaryItem.title,
+  )
+  const productSubtitle = firstString(
+    primaryItem.optionNameSnapshot,
+    primaryItem.unitNameSnapshot,
+    primaryItem.description,
+  )
+  const departureSlot = await resolveDepartureSlotContext(db, primaryItem)
+
+  return {
+    entityModule,
+    entityId,
+    vertical,
+    productTitle,
+    productSubtitle,
+    destination,
+    departureSlot,
+    items: items.map(mapBookingItemToContractItem),
+  }
+}
+
+function emptyBookingItemContext(): BookingItemContext {
+  return {
+    entityModule: "",
+    entityId: "",
+    vertical: "",
+    productTitle: "",
+    productSubtitle: "",
+    destination: "",
+    departureSlot: {
+      slotId: "",
+      startAt: "",
+      endAt: "",
+      durationDays: null,
+      departureCity: "",
+    },
+    items: [],
+  }
+}
+
+function mapBookingItemToContractItem(item: BookingItemRow, index: number): ContractItemVariable {
+  const quantity = item.quantity ?? 1
+  const unitAmountCents =
+    item.unitSellAmountCents ??
+    (item.totalSellAmountCents != null && quantity > 0
+      ? Math.round(item.totalSellAmountCents / quantity)
+      : 0)
+
+  return {
+    index: index + 1,
+    kind: item.itemType,
+    description: firstString(item.productNameSnapshot, item.title, item.description),
+    quantity,
+    unitAmountCents,
+    totalAmountCents: item.totalSellAmountCents ?? unitAmountCents * quantity,
+    currency: item.sellCurrency,
+    taxIncluded: false,
+  }
+}
+
+async function resolveDepartureSlotContext(
+  db: PostgresJsDatabase,
+  item: BookingItemRow,
+): Promise<BookingItemContext["departureSlot"]> {
+  const slotId = item.availabilitySlotId ?? ""
+  const linkedSlot = slotId ? await resolveLinkedAvailabilitySlot(db, slotId) : null
+  const startAt = normalizeDateTime(linkedSlot?.starts_at ?? item.startsAt)
+  const endAt = normalizeDateTime(linkedSlot?.ends_at ?? item.endsAt)
+  const durationDays =
+    numberValue(linkedSlot?.days) ??
+    (startAt && endAt
+      ? Math.max(1, computeNights(startAt.slice(0, 10), endAt.slice(0, 10)) + 1)
+      : null)
+
+  return {
+    slotId,
+    startAt,
+    endAt,
+    durationDays,
+    departureCity: extractDepartureCity(item.departureLabelSnapshot),
+  }
+}
+
+async function resolveLinkedProductTitle(
+  db: PostgresJsDatabase,
+  productId: string,
+): Promise<string> {
+  try {
+    const result = await db.execute<{ name: string | null }>(
+      sql`select name from products where id = ${productId} limit 1`,
+    )
+    return toRows<{ name: string | null }>(result)[0]?.name ?? ""
+  } catch (error) {
+    if (isUndefinedTableError(error)) return ""
+    throw error
+  }
+}
+
+async function resolveLinkedProductDestination(
+  db: PostgresJsDatabase,
+  productId: string,
+): Promise<string> {
+  try {
+    const result = await db.execute<{ destination: string | null }>(sql`
+      select coalesce(dt.name, d.slug) as destination
+      from product_destinations pd
+      inner join destinations d on d.id = pd.destination_id
+      left join destination_translations dt on dt.destination_id = d.id
+      where pd.product_id = ${productId}
+      order by
+        pd.sort_order asc,
+        case when dt.language_tag = 'en' then 0 else 1 end,
+        dt.language_tag asc nulls last,
+        d.slug asc
+      limit 1
+    `)
+    return toRows<{ destination: string | null }>(result)[0]?.destination ?? ""
+  } catch (error) {
+    if (isUndefinedTableError(error)) return ""
+    throw error
+  }
+}
+
+async function resolveLinkedAvailabilitySlot(
+  db: PostgresJsDatabase,
+  slotId: string,
+): Promise<{
+  starts_at: Date | string | null
+  ends_at: Date | string | null
+  days: number | null
+} | null> {
+  try {
+    const result = await db.execute<{
+      starts_at: Date | string | null
+      ends_at: Date | string | null
+      days: number | null
+    }>(sql`
+      select starts_at, ends_at, days
+      from availability_slots
+      where id = ${slotId}
+      limit 1
+    `)
+    return (
+      toRows<{
+        starts_at: Date | string | null
+        ends_at: Date | string | null
+        days: number | null
+      }>(result)[0] ?? null
+    )
+  } catch (error) {
+    if (isUndefinedTableError(error)) return null
+    throw error
+  }
+}
+
+function recordValue(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+}
+
+function pickString(record: Record<string, unknown>, keys: readonly string[]): string {
+  for (const key of keys) {
+    const value = record[key]
+    if (typeof value === "string" && value.trim()) return value.trim()
+  }
+  return ""
+}
+
+function firstString(...values: Array<string | null | undefined>): string {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value.trim()
+  }
+  return ""
+}
+
+function normalizeDateTime(value: Date | string | null | undefined): string {
+  if (!value) return ""
+  return value instanceof Date ? value.toISOString() : value
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null
+}
+
+function extractDepartureCity(label: string | null | undefined): string {
+  const normalized = firstString(label)
+  if (!normalized) return ""
+  const separator = normalized.includes("—") ? "—" : normalized.includes("-") ? "-" : ""
+  if (!separator) return ""
+  const parts = normalized
+    .split(separator)
+    .map((part) => part.trim())
+    .filter(Boolean)
+  return parts.length > 1 ? (parts[parts.length - 1] ?? "") : ""
+}
+
+function toRows<T>(result: unknown): T[] {
+  if (Array.isArray(result)) return result as T[]
+  if (result && typeof result === "object" && "rows" in result) {
+    const rows = (result as { rows: unknown }).rows
+    return Array.isArray(rows) ? (rows as T[]) : []
+  }
+  return []
+}
+
+function isUndefinedTableError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: string }).code === "42P01"
+  )
 }
 
 type SettlementInvoiceRow = Pick<

--- a/packages/legal/src/index.ts
+++ b/packages/legal/src/index.ts
@@ -102,6 +102,16 @@ export function createLegalHonoModule(options: CreateLegalHonoModuleOptions = {}
                 eventBus,
                 lifecycleHooks: contractsRuntime.lifecycleHooks,
                 bindings: bindingsRecord,
+                bookingPiiService:
+                  contractsRuntime.bookingPiiService ??
+                  (await contractsRuntime.resolveBookingPiiService?.(bindingsRecord)) ??
+                  null,
+                actionLedgerContext: {
+                  userId: event.data.actorId,
+                  actor: event.data.actorId ? "staff" : "system",
+                  callerType: "internal",
+                  isInternalRequest: true,
+                },
               })
               if (result.status !== "ok") {
                 console.error(

--- a/packages/legal/tests/integration/auto-generate.test.ts
+++ b/packages/legal/tests/integration/auto-generate.test.ts
@@ -1,4 +1,5 @@
-import { bookings, bookingTravelers } from "@voyantjs/bookings/schema"
+import type { BookingPiiService } from "@voyantjs/bookings"
+import { bookingItems, bookings, bookingTravelers } from "@voyantjs/bookings/schema"
 import { createEventBus } from "@voyantjs/core"
 import { invoices, payments } from "@voyantjs/finance/schema"
 import { eq } from "drizzle-orm"
@@ -162,6 +163,133 @@ describe.skipIf(!DB_AVAILABLE)("autoGenerateContractForBooking", () => {
     expect(body).toContain("Ana Primary")
     expect(body).toContain("Ana, Bob")
     expect(body).toContain("1,250.00") // 125000 cents → 1,250.00 EUR
+  })
+
+  it("populates product, departure, and traveler identity variables from the booking", async () => {
+    const { template, version } = await seedTemplate("cust-booking-bag-1")
+    await db
+      .update(contractTemplateVersions)
+      .set({
+        body: [
+          "{{ product.title }}",
+          "{{ booking.productName }}",
+          "{{ product.destination }}",
+          "{{ departureSlot.slotId }}",
+          "{{ departureSlot.departureCity }}",
+          "{{ customer.dateOfBirth }}",
+          "{{ customer.document.number }}",
+        ].join(" | "),
+      })
+      .where(eq(contractTemplateVersions.id, version.id))
+
+    const booking = await seedBooking()
+    await db.insert(bookingItems).values({
+      bookingId: booking.id,
+      title: "Fallback title",
+      itemType: "unit",
+      status: "confirmed",
+      quantity: 2,
+      sellCurrency: "EUR",
+      unitSellAmountCents: 62500,
+      totalSellAmountCents: 125000,
+      productId: "prod_romania_loop",
+      availabilitySlotId: "slot_bucharest_1",
+      productNameSnapshot: "Romania Heritage Loop",
+      optionNameSnapshot: "Standard cabin",
+      departureLabelSnapshot: "Jul 1, 2026 09:00 — Bucharest",
+      startsAt: new Date("2026-07-01T06:00:00.000Z"),
+      endsAt: new Date("2026-07-08T06:00:00.000Z"),
+      metadata: { destination: "Romania", vertical: "tour" },
+    })
+    const [lead] = await db
+      .insert(bookingTravelers)
+      .values({
+        bookingId: booking.id,
+        participantType: "traveler",
+        firstName: "Ana",
+        lastName: "Primary",
+        isPrimary: true,
+      })
+      .returning()
+
+    const pii: BookingPiiService = {
+      async getTravelerTravelDetails(_db, travelerId) {
+        if (travelerId !== lead!.id) return null
+        return {
+          travelerId,
+          nationality: "RO",
+          documentType: "passport",
+          documentNumber: "P1234567",
+          documentExpiry: "2031-01-02",
+          documentIssuingCountry: "RO",
+          documentIssuingAuthority: "DEPABD",
+          documentPersonDocumentId: "pdoc_1",
+          dateOfBirth: "1990-02-03",
+          dietaryRequirements: null,
+          accessibilityNeeds: null,
+          isLeadTraveler: true,
+          sharingGroupId: null,
+          roomTypeId: null,
+          bedPreference: null,
+          allocations: {},
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+        }
+      },
+      async upsertTravelerTravelDetails() {
+        throw new Error("not used")
+      },
+      async deleteTravelerTravelDetails() {
+        throw new Error("not used")
+      },
+    }
+
+    const bodies: string[] = []
+    const outcome = await autoGenerateContractForBooking(
+      db,
+      { bookingId: booking.id, bookingNumber: booking.bookingNumber, actorId: "usrp_tester" },
+      { enabled: true, templateSlug: template.slug },
+      { generator: makeGenerator(bodies), bookingPiiService: pii },
+    )
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+
+    const contract = await contractRecordsService.getContractById(db, outcome.contractId)
+    const variables = contract?.variables as Record<string, unknown>
+    expect(variables.product).toMatchObject({
+      title: "Romania Heritage Loop",
+      subtitle: "Standard cabin",
+      destination: "Romania",
+      id: "prod_romania_loop",
+      module: "products",
+      vertical: "tour",
+    })
+    expect(variables.booking).toMatchObject({
+      productName: "Romania Heritage Loop",
+      productSubtitle: "Standard cabin",
+      destination: "Romania",
+      entityModule: "products",
+      entityId: "prod_romania_loop",
+      vertical: "tour",
+    })
+    expect(variables.departureSlot).toMatchObject({
+      slotId: "slot_bucharest_1",
+      departureCity: "Bucharest",
+    })
+    expect(variables.customer).toMatchObject({
+      dateOfBirth: "1990-02-03",
+      document: {
+        type: "passport",
+        number: "P1234567",
+        country: "RO",
+        issuingAuthority: "DEPABD",
+        issueDate: "",
+        expiryDate: "2031-01-02",
+      },
+    })
+    expect(bodies[0]).toContain(
+      "Romania Heritage Loop | Romania Heritage Loop | Romania | slot_bucharest_1 | Bucharest | 1990-02-03 | P1234567",
+    )
   })
 
   it("emits contract.document.generated event on the runtime bus", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3728,6 +3728,9 @@ importers:
 
   packages/legal:
     dependencies:
+      '@voyantjs/action-ledger':
+        specifier: workspace:^
+        version: link:../action-ledger
       '@voyantjs/bookings':
         specifier: workspace:^
         version: link:../bookings

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -65,6 +65,7 @@ import { createDocumentStorage } from "./lib/storage"
 import { mountCatalogMcpRoutes } from "./mcp"
 import { mountOperatorMediaUploadRoutes } from "./media-upload-routes"
 import {
+  createOperatorBookingPiiService,
   createOperatorDocumentStorage,
   createOperatorInvoiceExchangeRateResolver,
   createOperatorInvoiceSettlementPollers,
@@ -251,6 +252,7 @@ const legalModule = createLegalHonoModule({
     resolveOperatorDocumentDownloadUrl(bindings, storageKey),
   resolveDocumentStorage: createOperatorDocumentStorage,
   resolveDocumentGenerator: resolveOperatorContractDocumentGenerator,
+  resolveBookingPiiService: createOperatorBookingPiiService,
   autoGenerateContractOnConfirmed: AUTO_GENERATE_CONTRACT_OPTIONS,
 })
 

--- a/templates/operator/src/api/contract-document-runtime.ts
+++ b/templates/operator/src/api/contract-document-runtime.ts
@@ -1,3 +1,4 @@
+import { buildBookingRouteRuntime, createBookingPiiService } from "@voyantjs/bookings"
 import { bookings } from "@voyantjs/bookings/schema"
 import type { EventBus } from "@voyantjs/core"
 import type { ContractDocumentGenerator } from "@voyantjs/legal"
@@ -85,7 +86,17 @@ export async function generateContractPdfForBooking(
     db,
     { bookingId, bookingNumber: bookingRow.bookingNumber, actorId: null },
     AUTO_GENERATE_CONTRACT_OPTIONS,
-    { generator, eventBus, bindings: contractVariableBindings(env) },
+    {
+      generator,
+      eventBus,
+      bindings: contractVariableBindings(env),
+      bookingPiiService: await createContractBookingPiiService(env),
+      actionLedgerContext: {
+        actor: "system",
+        callerType: "internal",
+        isInternalRequest: true,
+      },
+    },
   )
 
   if (result.status === "ok") {
@@ -126,7 +137,16 @@ export async function previewContractForBooking(
     db,
     { bookingId, bookingNumber: bookingRow.bookingNumber, actorId: null },
     { ...AUTO_GENERATE_CONTRACT_OPTIONS, previewMode: true },
-    { generator: previewGenerator, bindings: contractVariableBindings(env) },
+    {
+      generator: previewGenerator,
+      bindings: contractVariableBindings(env),
+      bookingPiiService: await createContractBookingPiiService(env),
+      actionLedgerContext: {
+        actor: "system",
+        callerType: "internal",
+        isInternalRequest: true,
+      },
+    },
   )
 
   if (result.status === "preview") {
@@ -143,6 +163,15 @@ export async function previewContractForBooking(
 
   const reason = "reason" in result && typeof result.reason === "string" ? result.reason : "unknown"
   throw new Error(`Contract preview failed: ${result.status} (${reason})`)
+}
+
+async function createContractBookingPiiService(env: CloudflareBindings) {
+  const runtime = buildBookingRouteRuntime(env)
+  try {
+    return createBookingPiiService({ kms: await runtime.getKmsProvider() })
+  } catch {
+    return null
+  }
 }
 
 async function ensureDefaultContractSeries(db: PostgresJsDatabase): Promise<void> {

--- a/templates/operator/src/api/operator-runtime-adapter.ts
+++ b/templates/operator/src/api/operator-runtime-adapter.ts
@@ -1,3 +1,4 @@
+import { buildBookingRouteRuntime, createBookingPiiService } from "@voyantjs/bookings"
 import { createVoyantDataFxExchangeRateResolver } from "@voyantjs/finance"
 import type { VoyantDb } from "@voyantjs/hono"
 import { createCloudflareEdgeDriver } from "@voyantjs/workflows-orchestrator-cloudflare"
@@ -47,6 +48,16 @@ export function createOperatorDocumentStorage(bindings: unknown) {
 
 export function resolveOperatorContractDocumentGenerator(bindings: unknown) {
   return resolveContractDocumentGenerator(operatorBindings(bindings)) ?? undefined
+}
+
+export async function createOperatorBookingPiiService(bindings: unknown) {
+  const env = operatorBindings(bindings)
+  const runtime = buildBookingRouteRuntime(env)
+  try {
+    return createBookingPiiService({ kms: await runtime.getKmsProvider() })
+  } catch {
+    return null
+  }
 }
 
 export function createOperatorInvoiceExchangeRateResolver(bindings: unknown) {


### PR DESCRIPTION
## Summary

- Populate contract auto-generate variables from booking items for product title, product subtitle, entity context, destination, line items, and departure slot fields.
- Add optional booking PII runtime support so traveler DOB/document snapshots populate when a booking PII service is configured, while keeping empty-string fallbacks when unavailable.
- Wire the operator runtime to provide booking PII access for generated contract PDFs and previews.

## Verification

- `pnpm --filter @voyantjs/legal lint`
- `pnpm --filter @voyantjs/legal typecheck`
- `pnpm --filter operator typecheck`
- `pnpm --filter @voyantjs/legal test`
- `pnpm verify:fast`

Closes #1528