### PR TITLE
Fix payment reminders for terminal bookings

### DIFF
--- a/.changeset/payment-reminders-terminal-bookings.md
+++ b/.changeset/payment-reminders-terminal-bookings.md
@@ -1,0 +1,6 @@
+---
+"@voyantjs/bookings": patch
+"@voyantjs/notifications": patch
+---
+
+Stop payment-schedule reminders from sending for terminal bookings by closing open schedules during cancelled/expired booking transitions and by skipping payment reminders when the parent booking is not payable.

--- a/apps/dev/src/api/app.ts
+++ b/apps/dev/src/api/app.ts
@@ -28,6 +28,7 @@ import { suppliersHonoModule } from "@voyantjs/suppliers"
 import { transactionsBookingExtension, transactionsHonoModule } from "@voyantjs/transactions"
 import { resolveNotificationProviders } from "../lib/notifications"
 import authHandler, { hasAuthPermission, resolveAuthRequest } from "./auth/handler"
+import { closeTerminalBookingPaymentSchedules } from "./booking-payment-cleanup"
 import { getDashboardSummary } from "./dashboard-summary"
 import { createInvitationsRoutes } from "./invitations"
 import { getDbFromHyperdrive } from "./lib/db"
@@ -109,6 +110,7 @@ const bookingsHonoModule = createBookingsHonoModule({
     })
     return person?.id ?? null
   },
+  closePaymentSchedulesForBooking: closeTerminalBookingPaymentSchedules,
 })
 
 export const app = createApp<CloudflareBindings>({

--- a/apps/dev/src/api/booking-payment-cleanup.ts
+++ b/apps/dev/src/api/booking-payment-cleanup.ts
@@ -1,0 +1,40 @@
+import { bookingPaymentSchedules } from "@voyantjs/finance/schema"
+import { notificationReminderRuns } from "@voyantjs/notifications/schema"
+import { and, eq, inArray } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+type TerminalPaymentScheduleStatus = "cancelled" | "expired"
+
+export async function closeTerminalBookingPaymentSchedules(
+  db: PostgresJsDatabase,
+  bookingId: string,
+  status: TerminalPaymentScheduleStatus,
+) {
+  const now = new Date()
+
+  await db
+    .update(bookingPaymentSchedules)
+    .set({ status, updatedAt: now })
+    .where(
+      and(
+        eq(bookingPaymentSchedules.bookingId, bookingId),
+        inArray(bookingPaymentSchedules.status, ["pending", "due"]),
+      ),
+    )
+
+  await db
+    .update(notificationReminderRuns)
+    .set({
+      status: "skipped",
+      errorMessage: `booking_status_${status}`,
+      processedAt: now,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(notificationReminderRuns.bookingId, bookingId),
+        eq(notificationReminderRuns.targetType, "booking_payment_schedule"),
+        eq(notificationReminderRuns.status, "queued"),
+      ),
+    )
+}

--- a/apps/dev/src/workflows.ts
+++ b/apps/dev/src/workflows.ts
@@ -9,6 +9,7 @@ import { generateProductPdf } from "@voyantjs/products/tasks"
 import { workflow } from "@voyantjs/workflows"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
+import { closeTerminalBookingPaymentSchedules } from "./api/booking-payment-cleanup.js"
 import { getNotificationTaskRuntime } from "./lib/notifications.js"
 
 function getDb() {
@@ -50,7 +51,9 @@ workflow<
   defaultRuntime: "node",
   schedule: { cron: "*/5 * * * *" },
   async run(input) {
-    return expireStaleBookingHolds(getDb(), input, "system")
+    return expireStaleBookingHolds(getDb(), input, "system", {
+      closePaymentSchedulesForBooking: closeTerminalBookingPaymentSchedules,
+    })
   },
 })
 

--- a/packages/bookings/src/index.ts
+++ b/packages/bookings/src/index.ts
@@ -113,6 +113,7 @@ export type {
   BookingPersonResolverContact,
   BookingRouteRuntime,
   BookingRouteRuntimeOptions,
+  ClosePaymentSchedulesForBooking,
   ResolveBookingBillingOrganizationById,
   ResolveBookingBillingPerson,
   ResolveBookingBillingPersonById,

--- a/packages/bookings/src/route-runtime.ts
+++ b/packages/bookings/src/route-runtime.ts
@@ -3,6 +3,7 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import type { BookingTravelerSnapshot } from "./pii.js"
 import type { KmsBindings } from "./routes-shared.js"
+import type { BookingStatus } from "./state-machine.js"
 
 export const BOOKING_ROUTE_RUNTIME_CONTAINER_KEY = "runtime.bookings.routes"
 
@@ -72,6 +73,12 @@ export type ResolveBookingBillingOrganizationById = (
   organizationId: string,
 ) => Promise<boolean>
 
+export type ClosePaymentSchedulesForBooking = (
+  db: PostgresJsDatabase,
+  bookingId: string,
+  status: Extract<BookingStatus, "cancelled" | "expired">,
+) => Promise<void> | void
+
 export interface BookingRouteRuntime {
   getKmsProvider(): Promise<KmsProvider>
   resolveTravelSnapshot?: ResolveBookingTravelSnapshot
@@ -79,6 +86,7 @@ export interface BookingRouteRuntime {
   resolveTravelerPerson?: ResolveBookingTravelerPerson
   resolveBillingPersonById?: ResolveBookingBillingPersonById
   resolveBillingOrganizationById?: ResolveBookingBillingOrganizationById
+  closePaymentSchedulesForBooking?: ClosePaymentSchedulesForBooking
 }
 
 /**
@@ -99,6 +107,7 @@ export interface BookingRouteRuntimeOptions {
   resolveTravelerPerson?: ResolveBookingTravelerPerson
   resolveBillingPersonById?: ResolveBookingBillingPersonById
   resolveBillingOrganizationById?: ResolveBookingBillingOrganizationById
+  closePaymentSchedulesForBooking?: ClosePaymentSchedulesForBooking
 }
 
 function buildRuntimeEnv(bindings: KmsBindings): Record<string, string | undefined> {
@@ -133,5 +142,6 @@ export function buildBookingRouteRuntime(
     resolveTravelerPerson: options.resolveTravelerPerson,
     resolveBillingPersonById: options.resolveBillingPersonById,
     resolveBillingOrganizationById: options.resolveBillingOrganizationById,
+    closePaymentSchedulesForBooking: options.closePaymentSchedulesForBooking,
   }
 }

--- a/packages/bookings/src/routes-public.ts
+++ b/packages/bookings/src/routes-public.ts
@@ -342,6 +342,10 @@ export const publicBookingRoutes = new Hono<Env>()
         c.req.param("sessionId"),
         await parseJsonBody(c, publicBookingSessionMutationSchema),
         c.get("userId"),
+        {
+          eventBus: c.get("eventBus"),
+          closePaymentSchedulesForBooking: getRouteRuntime(c).closePaymentSchedulesForBooking,
+        },
       )
 
       if (result.status === "not_found") {

--- a/packages/bookings/src/routes.ts
+++ b/packages/bookings/src/routes.ts
@@ -838,6 +838,7 @@ function bookingStatusMutationRuntime(
 
   return {
     eventBus: c.get("eventBus"),
+    closePaymentSchedulesForBooking: getRouteRuntime(c).closePaymentSchedulesForBooking,
     actionLedgerContext: getActionLedgerRequestContext(c),
     actionLedgerAuthorizationSource: auth.access.authorizationSource,
     actionLedgerCausationActionId: approvedExecution?.causationActionId ?? null,
@@ -1764,7 +1765,10 @@ export const bookingRoutes = new Hono<Env>()
         c.get("db"),
         await parseJsonBody(c, expireStaleBookingsSchema),
         c.get("userId"),
-        { eventBus: c.get("eventBus") },
+        {
+          eventBus: c.get("eventBus"),
+          closePaymentSchedulesForBooking: getRouteRuntime(c).closePaymentSchedulesForBooking,
+        },
       ),
     )
   })

--- a/packages/bookings/src/service-public.ts
+++ b/packages/bookings/src/service-public.ts
@@ -25,7 +25,7 @@ import {
   bookings,
   bookingTravelers,
 } from "./schema.js"
-import { bookingsService } from "./service.js"
+import { type BookingServiceRuntime, bookingsService } from "./service.js"
 import type {
   InternalBookingOverviewLookupQuery,
   PublicBookingOverviewAccessQuery,
@@ -1740,8 +1740,9 @@ export const publicBookingsService = {
     bookingId: string,
     input: PublicBookingSessionMutationInput,
     userId?: string,
+    runtime: BookingServiceRuntime = {},
   ) {
-    const result = await bookingsService.expireBooking(db, bookingId, input, userId)
+    const result = await bookingsService.expireBooking(db, bookingId, input, userId, runtime)
     if (result.status !== "ok") {
       return result
     }

--- a/packages/bookings/src/service.ts
+++ b/packages/bookings/src/service.ts
@@ -333,6 +333,11 @@ export interface BookingServiceRuntime {
     db: PostgresJsDatabase,
     bookingId: string,
   ) => Promise<void> | void
+  closePaymentSchedulesForBooking?: (
+    db: PostgresJsDatabase,
+    bookingId: string,
+    status: Extract<BookingStatus, "cancelled" | "expired">,
+  ) => Promise<void> | void
 }
 
 type BookingStatusActionName =
@@ -4050,6 +4055,7 @@ export const bookingsService = {
           .returning()
 
         await syncTransactionOnBookingExpired(tx as PostgresJsDatabase, id)
+        await runtime.closePaymentSchedulesForBooking?.(tx as PostgresJsDatabase, id, "expired")
 
         await tx.insert(bookingActivityLog).values({
           bookingId: id,
@@ -4219,6 +4225,7 @@ export const bookingsService = {
           .returning()
 
         await syncTransactionOnBookingCancelled(tx as PostgresJsDatabase, id)
+        await runtime.closePaymentSchedulesForBooking?.(tx as PostgresJsDatabase, id, "cancelled")
 
         await tx.insert(bookingActivityLog).values({
           bookingId: id,
@@ -4569,6 +4576,9 @@ export const bookingsService = {
         }
 
         const [row] = await tx.update(bookings).set(updates).where(eq(bookings.id, id)).returning()
+        if (data.status === "cancelled" || data.status === "expired") {
+          await runtime.closePaymentSchedulesForBooking?.(tx as PostgresJsDatabase, id, data.status)
+        }
 
         await tx.insert(bookingActivityLog).values({
           bookingId: id,

--- a/packages/notifications/src/service-reminders.ts
+++ b/packages/notifications/src/service-reminders.ts
@@ -58,8 +58,43 @@ type BookingEventReminderTargetType = Extract<
   "booking_confirmed" | "payment_complete" | "booking_cancelled_non_payment"
 >
 
+const PAYABLE_BOOKING_STATUSES = new Set([
+  "on_hold",
+  "awaiting_payment",
+  "confirmed",
+  "in_progress",
+])
+const OPEN_PAYMENT_SCHEDULE_STATUSES = new Set(["pending", "due"])
+
 export interface BookingEventReminderRuntimeOptions {
   documentAttachmentResolver?: BookingDocumentAttachmentResolver
+}
+
+function paymentScheduleStatusSkipReason(status: string) {
+  return `payment_schedule_status_${status}`
+}
+
+function bookingStatusSkipReason(status: string) {
+  return `booking_status_${status}`
+}
+
+async function getPaymentReminderBookingStatusSkipReason(
+  db: PostgresJsDatabase,
+  bookingId: string,
+) {
+  const [booking] = await db
+    .select({ status: bookings.status })
+    .from(bookings)
+    .where(eq(bookings.id, bookingId))
+    .limit(1)
+
+  if (!booking) {
+    return "booking_not_found"
+  }
+
+  return PAYABLE_BOOKING_STATUSES.has(booking.status)
+    ? null
+    : bookingStatusSkipReason(booking.status)
 }
 
 async function getBookingPaymentNotificationContext(db: PostgresJsDatabase, bookingId: string) {
@@ -405,6 +440,9 @@ async function sendQueuedBookingPaymentScheduleReminder(
       "Booking payment schedule not found for reminder run",
     )
   }
+  if (!OPEN_PAYMENT_SCHEDULE_STATUSES.has(schedule.status)) {
+    return markReminderRunSkipped(db, run.id, now, paymentScheduleStatusSkipReason(schedule.status))
+  }
 
   const [booking] = await db
     .select({
@@ -429,6 +467,9 @@ async function sendQueuedBookingPaymentScheduleReminder(
 
   if (!booking) {
     return markReminderRunSkipped(db, run.id, now, "Booking not found for payment schedule")
+  }
+  if (!PAYABLE_BOOKING_STATUSES.has(booking.status)) {
+    return markReminderRunSkipped(db, run.id, now, bookingStatusSkipReason(booking.status))
   }
 
   const [participants, items, paymentContext] = await Promise.all([
@@ -996,6 +1037,32 @@ async function emitStageChannelRun(
           status: "skipped",
           runId:
             (await markReminderRunSkipped(db, processingRun.id, new Date(), "schedule_not_found"))
+              ?.id ?? null,
+        }
+      }
+      if (!OPEN_PAYMENT_SCHEDULE_STATUSES.has(schedule.status)) {
+        return {
+          status: "skipped",
+          runId:
+            (
+              await markReminderRunSkipped(
+                db,
+                processingRun.id,
+                new Date(),
+                paymentScheduleStatusSkipReason(schedule.status),
+              )
+            )?.id ?? null,
+        }
+      }
+      const bookingSkipReason = await getPaymentReminderBookingStatusSkipReason(
+        db,
+        schedule.bookingId,
+      )
+      if (bookingSkipReason) {
+        return {
+          status: "skipped",
+          runId:
+            (await markReminderRunSkipped(db, processingRun.id, new Date(), bookingSkipReason))
               ?.id ?? null,
         }
       }

--- a/packages/notifications/src/service-sequence.ts
+++ b/packages/notifications/src/service-sequence.ts
@@ -1,6 +1,6 @@
 import { bookings } from "@voyantjs/bookings/schema"
 import { bookingPaymentSchedules, invoices } from "@voyantjs/finance"
-import { and, asc, eq, gt, gte, lte, or, sql } from "drizzle-orm"
+import { and, asc, eq, gt, gte, inArray, lte, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import {
@@ -449,12 +449,20 @@ export type DateEnvelopes = {
   invoiceIssueDate?: { from: string; to: string }
 }
 
+const PAYABLE_BOOKING_STATUSES = [
+  "on_hold",
+  "awaiting_payment",
+  "confirmed",
+  "in_progress",
+] as const
+
 export async function fetchOpenPaymentScheduleTargets(
   db: PostgresJsDatabase,
   envelopes: DateEnvelopes = {},
 ): Promise<ReminderTargetSnapshot[]> {
   const conditions = [
     or(eq(bookingPaymentSchedules.status, "pending"), eq(bookingPaymentSchedules.status, "due")),
+    inArray(bookings.status, PAYABLE_BOOKING_STATUSES),
   ]
   if (envelopes.paymentScheduleDueDate) {
     conditions.push(

--- a/packages/notifications/tests/integration/reminder-sequences.test.ts
+++ b/packages/notifications/tests/integration/reminder-sequences.test.ts
@@ -229,6 +229,84 @@ describe.skipIf(!DB_AVAILABLE)("Reminder sequences (stage-based dispatcher)", ()
     expect(body.data.sent).toBe(0)
   })
 
+  it("does not fire payment schedule reminders for cancelled bookings", async () => {
+    const tmplRes = await ctx.request("/templates", {
+      method: "POST",
+      ...json({
+        slug: "tpl-cancelled-booking-payment",
+        name: "Cancelled booking payment reminder",
+        channel: "email",
+        provider: "local",
+        status: "active",
+        subjectTemplate: "Payment due",
+        textTemplate: "Payment due",
+      }),
+    })
+    const { data: template } = await tmplRes.json()
+
+    await ctx.db.execute(sql`
+      INSERT INTO bookings (id, booking_number, status, sell_currency)
+      VALUES ('book_cancelled_seq_1', 'BK-CAN-1', 'cancelled', 'EUR')
+    `)
+    await ctx.db.execute(sql`
+      INSERT INTO booking_travelers (id, booking_id, first_name, last_name, email, participant_type, is_primary)
+      VALUES ('bkpt_cancelled_seq_1', 'book_cancelled_seq_1', 'Ana', 'Cancelled', 'ana-cancelled@example.com', 'traveler', true)
+    `)
+    await ctx.db.execute(sql`
+      INSERT INTO booking_payment_schedules (
+        id, booking_id, schedule_type, status, due_date, currency, amount_cents
+      )
+      VALUES ('bkps_cancelled_seq_1', 'book_cancelled_seq_1', 'balance', 'due', DATE '2026-04-10', 'EUR', 25000)
+    `)
+
+    const ruleRes = await ctx.request("/reminder-rules", {
+      method: "POST",
+      ...json({
+        slug: "cancelled-payment-balance-sequence",
+        name: "Cancelled payment balance sequence",
+        status: "active",
+        targetType: "booking_payment_schedule",
+        channel: "email",
+        provider: "local",
+      }),
+    })
+    const { data: rule } = await ruleRes.json()
+
+    const stageRes = await ctx.request(`/reminder-rules/${rule.id}/stages`, {
+      method: "POST",
+      ...json({
+        orderIndex: 0,
+        anchor: "due_date",
+        windowStartDays: -7,
+        windowEndDays: 0,
+        cadenceKind: "once",
+        respectQuietHours: false,
+      }),
+    })
+    const { data: stage } = await stageRes.json()
+
+    await ctx.request(`/reminder-rules/${rule.id}/stages/${stage.id}/channels`, {
+      method: "POST",
+      ...json({
+        orderIndex: 0,
+        channel: "email",
+        provider: "local",
+        templateId: template.id,
+        recipientKind: "primary",
+      }),
+    })
+
+    const sweepRes = await ctx.request("/reminders/run-due", {
+      method: "POST",
+      ...json({ now: "2026-04-08T09:00:00.000Z" }),
+    })
+    expect(sweepRes.status).toBe(200)
+    const body = await sweepRes.json()
+    expect(body.data.processed).toBe(0)
+    expect(body.data.sent).toBe(0)
+    expect(ctx.sink).not.toHaveBeenCalled()
+  })
+
   it("queues per-channel and uses the stage channel's template at delivery time", async () => {
     // Two templates: one is the rule's default fallback that should NEVER be
     // used, the other lives on the stage channel and is the one we expect to
@@ -361,6 +439,85 @@ describe.skipIf(!DB_AVAILABLE)("Reminder sequences (stage-based dispatcher)", ()
     expect(sent.subject).toContain("Stage payment due")
     expect(sent.text).toContain("Stage delivery")
     expect(sent.to).toBe("cara@example.com")
+  })
+
+  it("skips queued payment schedule reminder runs when the booking was cancelled before delivery", async () => {
+    const tmplRes = await ctx.request("/templates", {
+      method: "POST",
+      ...json({
+        slug: "queued-cancelled-template",
+        name: "Queued cancelled template",
+        channel: "email",
+        provider: "local",
+        status: "active",
+        subjectTemplate: "Payment due",
+        textTemplate: "Payment due",
+      }),
+    })
+    const { data: template } = await tmplRes.json()
+
+    const ruleRes = await ctx.request("/reminder-rules", {
+      method: "POST",
+      ...json({
+        slug: "queued-cancelled-rule",
+        name: "Queued cancelled rule",
+        status: "active",
+        targetType: "booking_payment_schedule",
+        channel: "email",
+        provider: "local",
+        templateId: template.id,
+      }),
+    })
+    const { data: rule } = await ruleRes.json()
+
+    await ctx.db.execute(sql`
+      INSERT INTO bookings (id, booking_number, status, sell_currency)
+      VALUES ('book_queued_cancelled_1', 'BK-Q-CAN-1', 'cancelled', 'EUR')
+    `)
+    await ctx.db.execute(sql`
+      INSERT INTO booking_travelers (id, booking_id, first_name, last_name, email, participant_type, is_primary)
+      VALUES ('bkpt_queued_cancelled_1', 'book_queued_cancelled_1', 'Quinn', 'Cancelled', 'quinn@example.com', 'traveler', true)
+    `)
+    await ctx.db.execute(sql`
+      INSERT INTO booking_payment_schedules (
+        id, booking_id, schedule_type, status, due_date, currency, amount_cents
+      )
+      VALUES ('bkps_queued_cancelled_1', 'book_queued_cancelled_1', 'balance', 'due', DATE '2026-04-12', 'EUR', 18000)
+    `)
+    await ctx.db.execute(sql`
+      INSERT INTO notification_reminder_runs (
+        id, reminder_rule_id, target_type, target_id, dedupe_key, booking_id, status, recipient, scheduled_for
+      )
+      VALUES (
+        'nrr_queued_cancelled_1',
+        ${rule.id},
+        'booking_payment_schedule',
+        'bkps_queued_cancelled_1',
+        'queued-cancelled-dedupe',
+        'book_queued_cancelled_1',
+        'queued',
+        'quinn@example.com',
+        TIMESTAMPTZ '2026-04-09T09:00:00.000Z'
+      )
+    `)
+
+    const { deliverReminderRun } = await import("../../src/service-reminders.js")
+    const { createNotificationService } = await import("../../src/service.js")
+    const { createLocalProvider } = await import("../../src/providers/local.js")
+    const recordedSends: Array<Record<string, unknown>> = []
+    const localDispatcher = createNotificationService([
+      createLocalProvider({
+        sink: (payload) => recordedSends.push(payload as Record<string, unknown>),
+        channels: ["email"],
+      }),
+    ])
+
+    const delivered = await deliverReminderRun(ctx.db as never, localDispatcher, {
+      reminderRunId: "nrr_queued_cancelled_1",
+    })
+    expect(delivered?.status).toBe("skipped")
+    expect(delivered?.errorMessage).toBe("booking_status_cancelled")
+    expect(recordedSends).toHaveLength(0)
   })
 
   it("does not requeue failed one-shot reminder runs on later sweeps", async () => {

--- a/templates/operator/src/api/app.ts
+++ b/templates/operator/src/api/app.ts
@@ -40,6 +40,7 @@ import authHandler, {
   resolveAuthRequest,
   validateApiTokenAccess,
 } from "./auth/handler"
+import { closeTerminalBookingPaymentSchedules } from "./booking-payment-cleanup"
 import {
   bookingScheduleBundle,
   mountBookingPaymentScheduleRoutes,
@@ -233,6 +234,7 @@ const bookingsHonoModule = createBookingsHonoModule({
     (await crmService.getPersonById(db, personId)) != null,
   resolveBillingOrganizationById: async (db, organizationId) =>
     (await crmService.getOrganizationById(db, organizationId)) != null,
+  closePaymentSchedulesForBooking: closeTerminalBookingPaymentSchedules,
 })
 
 const financeModule = createFinanceHonoModule({

--- a/templates/operator/src/api/booking-payment-cleanup.ts
+++ b/templates/operator/src/api/booking-payment-cleanup.ts
@@ -1,0 +1,40 @@
+import { bookingPaymentSchedules } from "@voyantjs/finance/schema"
+import { notificationReminderRuns } from "@voyantjs/notifications/schema"
+import { and, eq, inArray } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+type TerminalPaymentScheduleStatus = "cancelled" | "expired"
+
+export async function closeTerminalBookingPaymentSchedules(
+  db: PostgresJsDatabase,
+  bookingId: string,
+  status: TerminalPaymentScheduleStatus,
+) {
+  const now = new Date()
+
+  await db
+    .update(bookingPaymentSchedules)
+    .set({ status, updatedAt: now })
+    .where(
+      and(
+        eq(bookingPaymentSchedules.bookingId, bookingId),
+        inArray(bookingPaymentSchedules.status, ["pending", "due"]),
+      ),
+    )
+
+  await db
+    .update(notificationReminderRuns)
+    .set({
+      status: "skipped",
+      errorMessage: `booking_status_${status}`,
+      processedAt: now,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(notificationReminderRuns.bookingId, bookingId),
+        eq(notificationReminderRuns.targetType, "booking_payment_schedule"),
+        eq(notificationReminderRuns.status, "queued"),
+      ),
+    )
+}

--- a/templates/operator/src/workflows.ts
+++ b/templates/operator/src/workflows.ts
@@ -15,6 +15,7 @@ import { workflow } from "@voyantjs/workflows"
 import { and, eq, inArray } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
+import { closeTerminalBookingPaymentSchedules } from "./api/booking-payment-cleanup.js"
 import { createProductBrochurePrinter } from "./lib/brochure-printer.js"
 import { getNotificationTaskRuntime } from "./lib/notifications.js"
 
@@ -68,6 +69,7 @@ workflow<
           })
         }
       },
+      closePaymentSchedulesForBooking: closeTerminalBookingPaymentSchedules,
     })
   },
 })


### PR DESCRIPTION
## Summary

- close open booking payment schedules when bookings are cancelled or expired through service, route, public-session, stale-expiry, or terminal override paths
- skip queued and immediate payment-schedule reminders when the schedule is no longer open or the parent booking is not payable
- wire operator/dev runtimes to close schedules and mark queued payment reminder runs skipped with a booking-status reason

Closes #1532.

## Verification

- `pnpm --filter @voyantjs/bookings typecheck`
- `pnpm --filter @voyantjs/notifications typecheck`
- `pnpm --filter @voyantjs/notifications test`
- `pnpm --filter operator typecheck`
- `pnpm --filter dev typecheck`
- `pnpm --filter @voyantjs/bookings test`
- commit hook: staged-file quality checks, lint, full typecheck
- pre-push hook: full test lane