### PR TITLE
Fix legal contract booking variables

### DIFF
--- a/.changeset/legal-autogen-booking-vars.md
+++ b/.changeset/legal-autogen-booking-vars.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/legal": patch
+---
+
+Populate auto-generated contract booking payment schedule aliases and room summaries from persisted booking data.

--- a/packages/legal/src/contracts/service-auto-generate.ts
+++ b/packages/legal/src/contracts/service-auto-generate.ts
@@ -5,8 +5,8 @@ import {
   bookingsService,
 } from "@voyantjs/bookings"
 import { bookingPiiAccessLog } from "@voyantjs/bookings/schema"
-import { invoices, payments } from "@voyantjs/finance/schema"
-import { and, desc, eq, ne, sql } from "drizzle-orm"
+import { bookingPaymentSchedules, invoices, payments } from "@voyantjs/finance/schema"
+import { and, asc, desc, eq, ne, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import type { ContractLifecycleHook } from "./lifecycle.js"
@@ -622,6 +622,11 @@ export async function autoGenerateContractForBooking(
   const endDate = booking.endDate ?? ""
   const durationNights = computeNights(startDate, endDate)
   const settlement = await resolveBookingSettlementVariables(db, booking.id, sellCurrency)
+  const paymentSchedule = await resolveBookingPaymentScheduleVariables(db, booking.id)
+  const roomsSummary = deriveRoomsSummary(
+    bookingItemContext.rawItems,
+    bookingItemContext.roomOptionUnitIds,
+  )
 
   const mappedTravelers: ContractTravelerVariable[] = travelers.map((t, i) => {
     const fullName = [t.firstName, t.lastName].filter(Boolean).join(" ").trim()
@@ -723,15 +728,15 @@ export async function autoGenerateContractForBooking(
       paidAmountCents: settlement.paidAmountCents,
       balanceDueCents: settlement.balanceDueCents ?? totalCents,
 
-      depositAmountCents: 0,
-      depositDueDate: "",
-      balanceAmountCents: 0,
-      balanceDueDate: "",
+      depositAmountCents: paymentSchedule.depositAmountCents,
+      depositDueDate: paymentSchedule.depositDueDate,
+      balanceAmountCents: paymentSchedule.balanceAmountCents,
+      balanceDueDate: paymentSchedule.balanceDueDate,
       paymentPolicy: {
         source: "operator_default",
       },
 
-      roomsSummary: "",
+      roomsSummary,
 
       source: {
         kind: booking.sourceType ?? "",
@@ -836,7 +841,7 @@ export async function autoGenerateContractForBooking(
       method: settlement.latestCompleted?.methodLabel ?? "",
       amountCents: totalCents,
       currency: sellCurrency,
-      schedule: [],
+      schedule: paymentSchedule.entries,
       capturedAt: settlement.latestCompleted?.date ?? "",
       createdAt: settlement.latestCompleted?.date ?? "",
       latestCompleted: settlement.latestCompleted,
@@ -1018,6 +1023,16 @@ interface BookingItemContext {
     departureCity: string
   }
   items: ContractItemVariable[]
+  rawItems: BookingItemRow[]
+  roomOptionUnitIds: ReadonlySet<string>
+}
+
+interface PaymentScheduleSummary {
+  entries: DefaultContractVariables["payment"]["schedule"]
+  depositAmountCents: number
+  depositDueDate: string
+  balanceAmountCents: number
+  balanceDueDate: string
 }
 
 async function resolveTravelerTravelDetails(
@@ -1150,6 +1165,7 @@ async function resolveBookingItemContext(
     primaryItem.description,
   )
   const departureSlot = await resolveDepartureSlotContext(db, primaryItem)
+  const roomOptionUnitIds = await resolveRoomOptionUnitIds(db, items)
 
   return {
     entityModule,
@@ -1160,6 +1176,8 @@ async function resolveBookingItemContext(
     destination,
     departureSlot,
     items: items.map(mapBookingItemToContractItem),
+    rawItems: items,
+    roomOptionUnitIds,
   }
 }
 
@@ -1179,6 +1197,101 @@ function emptyBookingItemContext(): BookingItemContext {
       departureCity: "",
     },
     items: [],
+    rawItems: [],
+    roomOptionUnitIds: new Set(),
+  }
+}
+
+async function resolveBookingPaymentScheduleVariables(
+  db: PostgresJsDatabase,
+  bookingId: string,
+): Promise<PaymentScheduleSummary> {
+  const rows = await db
+    .select()
+    .from(bookingPaymentSchedules)
+    .where(eq(bookingPaymentSchedules.bookingId, bookingId))
+    .orderBy(asc(bookingPaymentSchedules.dueDate), asc(bookingPaymentSchedules.createdAt))
+
+  const deposit = rows.find((row) => row.scheduleType === "deposit")
+  const balance = rows.find((row) => row.scheduleType === "balance")
+
+  return {
+    entries: rows.map((row, index) => ({
+      index: index + 1,
+      type: row.scheduleType,
+      amountCents: row.amountCents,
+      currency: row.currency,
+      dueDate: row.dueDate,
+      status: row.status,
+    })),
+    depositAmountCents: deposit?.amountCents ?? 0,
+    depositDueDate: deposit?.dueDate ?? "",
+    balanceAmountCents: balance?.amountCents ?? 0,
+    balanceDueDate: balance?.dueDate ?? "",
+  }
+}
+
+function deriveRoomsSummary(
+  items: BookingItemRow[],
+  roomOptionUnitIds: ReadonlySet<string>,
+): string {
+  const lines = items
+    .filter((item) => isAccommodationLikeItem(item, roomOptionUnitIds))
+    .map((item) => {
+      const label = firstString(item.unitNameSnapshot, item.optionNameSnapshot, item.title)
+      if (!label) return ""
+      return `${item.quantity ?? 1}× ${label}`
+    })
+    .filter(Boolean)
+
+  return lines.join(", ")
+}
+
+function isAccommodationLikeItem(
+  item: BookingItemRow,
+  roomOptionUnitIds: ReadonlySet<string>,
+): boolean {
+  if (item.itemType === "accommodation") return true
+  if (item.optionUnitId && roomOptionUnitIds.has(item.optionUnitId)) return true
+
+  const metadata = recordValue(item.metadata)
+  const unitType = pickString(metadata, [
+    "unitType",
+    "unit_type",
+    "optionUnitType",
+    "option_unit_type",
+  ]).toLowerCase()
+
+  return unitType === "room" || unitType === "accommodation"
+}
+
+async function resolveRoomOptionUnitIds(
+  db: PostgresJsDatabase,
+  items: BookingItemRow[],
+): Promise<Set<string>> {
+  const optionUnitIds = [
+    ...new Set(
+      items
+        .map((item) => item.optionUnitId)
+        .filter((id): id is string => typeof id === "string" && id.trim().length > 0),
+    ),
+  ]
+  if (optionUnitIds.length === 0) return new Set()
+
+  try {
+    const result = await db.execute(sql`
+      SELECT id
+      FROM option_units
+      WHERE id IN (${sql.join(
+        optionUnitIds.map((id) => sql`${id}`),
+        sql`, `,
+      )})
+        AND unit_type IN ('room', 'accommodation')
+    `)
+    return new Set(toRows<{ id: string }>(result).map((row) => row.id))
+  } catch (error) {
+    if (isUndefinedTableError(error)) return new Set()
+    throw error
   }
 }
 

--- a/packages/legal/tests/integration/auto-generate.test.ts
+++ b/packages/legal/tests/integration/auto-generate.test.ts
@@ -1,8 +1,8 @@
 import type { BookingPiiService } from "@voyantjs/bookings"
 import { bookingItems, bookings, bookingTravelers } from "@voyantjs/bookings/schema"
 import { createEventBus } from "@voyantjs/core"
-import { invoices, payments } from "@voyantjs/finance/schema"
-import { eq } from "drizzle-orm"
+import { bookingPaymentSchedules, invoices, payments } from "@voyantjs/finance/schema"
+import { eq, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
 
@@ -463,6 +463,132 @@ describe.skipIf(!DB_AVAILABLE)("autoGenerateContractForBooking", () => {
     expect(paymentVariables.method).toBe("Bank Transfer")
     expect(paymentVariables.capturedAt).toBe("2026-05-04")
     expect(bodies[0]).toContain("Paid 32000 | Balance 0 | Latest Bank Transfer")
+  })
+
+  it("derives payment schedule aliases and rooms summary from the booking", async () => {
+    const { template, version } = await seedTemplate("cust-schedule-rooms-1")
+    await db
+      .update(contractTemplateVersions)
+      .set({
+        body: [
+          "Deposit {{ booking.depositAmountCents }} due {{ booking.depositDueDate }}",
+          "Balance {{ booking.balanceAmountCents }} due {{ booking.balanceDueDate }}",
+          "Rooms {{ booking.roomsSummary }}",
+          "Schedule {% for line in payment.schedule %}{{ line.type }}:{{ line.amountCents }}{% unless forloop.last %}, {% endunless %}{% endfor %}",
+        ].join(" | "),
+      })
+      .where(eq(contractTemplateVersions.id, version.id))
+
+    const booking = await seedBooking({
+      sellCurrency: "RON",
+      sellAmountCents: 120000,
+    })
+    await db.execute(sql`
+      INSERT INTO products (id, name, sell_currency)
+      VALUES ('prod_contract_room_units', 'Moldova Circuit', 'RON')
+    `)
+    await db.execute(sql`
+      INSERT INTO product_options (id, product_id, name)
+      VALUES ('opto_contract_room_units', 'prod_contract_room_units', 'Standard package')
+    `)
+    await db.execute(sql`
+      INSERT INTO option_units (id, option_id, name, unit_type)
+      VALUES
+        ('unit_contract_adult', 'opto_contract_room_units', 'Adult', 'person'),
+        ('unit_contract_dbl_room', 'opto_contract_room_units', 'DBL room', 'room')
+    `)
+    await db.insert(bookingItems).values([
+      {
+        bookingId: booking.id,
+        title: "Tour package",
+        itemType: "unit",
+        status: "confirmed",
+        quantity: 2,
+        sellCurrency: "RON",
+        unitSellAmountCents: 30000,
+        totalSellAmountCents: 60000,
+        productNameSnapshot: "Moldova Circuit",
+        optionNameSnapshot: "Standard package",
+        optionUnitId: "unit_contract_adult",
+        unitNameSnapshot: "Adult",
+      },
+      {
+        bookingId: booking.id,
+        title: "DBL room",
+        itemType: "unit",
+        status: "confirmed",
+        quantity: 1,
+        sellCurrency: "RON",
+        unitSellAmountCents: 60000,
+        totalSellAmountCents: 60000,
+        productNameSnapshot: "Moldova Circuit",
+        optionNameSnapshot: "DBL",
+        optionUnitId: "unit_contract_dbl_room",
+        unitNameSnapshot: "DBL room",
+      },
+    ])
+    await db.insert(bookingPaymentSchedules).values([
+      {
+        bookingId: booking.id,
+        scheduleType: "deposit",
+        status: "paid",
+        dueDate: "2026-05-01",
+        currency: "RON",
+        amountCents: 30000,
+      },
+      {
+        bookingId: booking.id,
+        scheduleType: "balance",
+        status: "pending",
+        dueDate: "2026-06-01",
+        currency: "RON",
+        amountCents: 90000,
+      },
+    ])
+
+    const bodies: string[] = []
+    const outcome = await autoGenerateContractForBooking(
+      db,
+      { bookingId: booking.id, bookingNumber: booking.bookingNumber, actorId: null },
+      { enabled: true, templateSlug: template.slug },
+      { generator: makeGenerator(bodies) },
+    )
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+
+    const contract = await contractRecordsService.getContractById(db, outcome.contractId)
+    const variables = contract?.variables as Record<string, unknown>
+    const bookingVariables = variables.booking as Record<string, unknown>
+    const paymentVariables = variables.payment as Record<string, unknown>
+
+    expect(bookingVariables).toMatchObject({
+      depositAmountCents: 30000,
+      depositDueDate: "2026-05-01",
+      balanceAmountCents: 90000,
+      balanceDueDate: "2026-06-01",
+      roomsSummary: "1× DBL room",
+    })
+    expect(paymentVariables.schedule).toMatchObject([
+      {
+        index: 1,
+        type: "deposit",
+        amountCents: 30000,
+        currency: "RON",
+        dueDate: "2026-05-01",
+        status: "paid",
+      },
+      {
+        index: 2,
+        type: "balance",
+        amountCents: 90000,
+        currency: "RON",
+        dueDate: "2026-06-01",
+        status: "pending",
+      },
+    ])
+    expect(bodies[0]).toContain(
+      "Deposit 30000 due 2026-05-01 | Balance 90000 due 2026-06-01 | Rooms 1× DBL room | Schedule deposit:30000, balance:90000",
+    )
   })
 
   it("resolves a series by name and writes seriesId onto the contract", async () => {


### PR DESCRIPTION
## Summary

- Populate auto-generated legal contract deposit and balance aliases from persisted booking payment schedules.
- Populate `payment.schedule` in the default contract variable payload.
- Derive `booking.roomsSummary` from persisted accommodation/room booking item snapshots.
- Add integration coverage for schedule aliases, schedule entries, and room summaries.

Closes #1539

## Verification

- `pnpm --filter @voyantjs/legal typecheck`
- `pnpm --filter @voyantjs/legal test`
- `pnpm --filter @voyantjs/legal lint`