### PR TITLE
Add legal paid-in-full contract variables

### DIFF
--- a/.changeset/legal-paid-in-full-vars.md
+++ b/.changeset/legal-paid-in-full-vars.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/legal": patch
+---
+
+Add paid-in-full and amount-due contract variables, and clarify scheduled payment aliases.

--- a/packages/legal/src/contracts/service-auto-generate.ts
+++ b/packages/legal/src/contracts/service-auto-generate.ts
@@ -182,10 +182,14 @@ export interface DefaultContractVariables {
 
     // Settlement
     paidAmountCents: number
+    /** Current remaining amount owed after completed payments / invoice balance. */
+    amountDueCents: number
     balanceDueCents: number
+    isPaidInFull: boolean
 
-    // Payment-schedule-derived (deposit + balance from
-    // booking_payment_schedules). Empty when no schedule exists.
+    // Gross scheduled installments from booking_payment_schedules. These are
+    // payment-plan amounts, not net remaining balances; use amountDueCents /
+    // balanceDueCents / isPaidInFull for current settlement state.
     depositAmountCents: number
     depositDueDate: string
     balanceAmountCents: number
@@ -622,6 +626,12 @@ export async function autoGenerateContractForBooking(
   const endDate = booking.endDate ?? ""
   const durationNights = computeNights(startDate, endDate)
   const settlement = await resolveBookingSettlementVariables(db, booking.id, sellCurrency)
+  const amountDueCents = computeAmountDueCents(settlement, totalCents)
+  const isPaidInFull =
+    amountDueCents <= 0 ||
+    (settlement.balanceDueCents == null &&
+      totalCents > 0 &&
+      settlement.paidAmountCents >= totalCents)
   const paymentSchedule = await resolveBookingPaymentScheduleVariables(db, booking.id)
   const roomsSummary = deriveRoomsSummary(
     bookingItemContext.rawItems,
@@ -726,7 +736,9 @@ export async function autoGenerateContractForBooking(
       discountAmountCents: 0,
 
       paidAmountCents: settlement.paidAmountCents,
-      balanceDueCents: settlement.balanceDueCents ?? totalCents,
+      amountDueCents,
+      balanceDueCents: amountDueCents,
+      isPaidInFull,
 
       depositAmountCents: paymentSchedule.depositAmountCents,
       depositDueDate: paymentSchedule.depositDueDate,
@@ -1542,6 +1554,14 @@ async function resolveBookingSettlementVariables(
         }
       : undefined,
   }
+}
+
+function computeAmountDueCents(
+  settlement: { paidAmountCents: number; balanceDueCents: number | null },
+  totalCents: number,
+): number {
+  if (settlement.balanceDueCents != null) return Math.max(0, settlement.balanceDueCents)
+  return Math.max(0, totalCents - settlement.paidAmountCents)
 }
 
 function amountInCurrency(payment: SettlementPaymentRow, currency: string): number {

--- a/packages/legal/src/contracts/template-authoring.ts
+++ b/packages/legal/src/contracts/template-authoring.ts
@@ -220,7 +220,24 @@ export const contractTemplateVariableCatalog: ContractTemplateVariableCategory[]
         label: "Balance due",
         example: "199900",
         type: "cents",
-        description: "Current customer balance from non-void invoice balances.",
+        description:
+          "Current remaining amount owed after completed payments / invoice balances. Use this, `amountDueCents`, or `isPaidInFull` for settlement state.",
+      },
+      {
+        key: "booking.amountDueCents",
+        label: "Amount still due",
+        example: "199900",
+        type: "cents",
+        description:
+          "Alias for the current remaining amount owed. This is payment-aware; unlike scheduled installment amounts, it drops to 0 once settled.",
+      },
+      {
+        key: "booking.isPaidInFull",
+        label: "Paid in full",
+        example: "false",
+        type: "boolean",
+        description:
+          "True when the current amount due is 0 or completed payments cover the booking total.",
       },
       // Payment-schedule-derived (deposit / balance from
       // booking_payment_schedules)
@@ -230,7 +247,7 @@ export const contractTemplateVariableCatalog: ContractTemplateVariableCategory[]
         example: "50000",
         type: "cents",
         description:
-          "Pulled from the `deposit` row in booking_payment_schedules. 0 when no schedule is set.",
+          "Gross scheduled deposit installment from booking_payment_schedules. Not reduced by payments; use paidAmountCents / amountDueCents / isPaidInFull for current settlement state.",
       },
       {
         key: "booking.depositDueDate",
@@ -243,7 +260,8 @@ export const contractTemplateVariableCatalog: ContractTemplateVariableCategory[]
         label: "Balance amount",
         example: "199900",
         type: "cents",
-        description: "Pulled from the `balance` row in booking_payment_schedules.",
+        description:
+          "Gross scheduled balance installment from booking_payment_schedules. Not the remaining amount owed; use balanceDueCents or amountDueCents for that.",
       },
       {
         key: "booking.balanceDueDate",
@@ -837,10 +855,19 @@ Diferență de plată: {{ booking.balanceDueCents | cents: booking.currency, "ro
     id: "deposit-balance",
     label: "Deposit + balance line",
     description:
-      "Render the scheduled advance + remainder policy. Use the settlement snippet for current paid/remaining state.",
-    code: `{% if booking.depositAmountCents > 0 %}
-Avansul este: {{ booking.depositAmountCents | cents: booking.currency, "ro-RO" }}, achitat cu {{ payment.method }} în data de {{ payment.capturedAt | format_date: "long", "ro-RO" }}.
-Diferență plată {{ booking.balanceAmountCents | cents: booking.currency, "ro-RO" }} până la data de {{ booking.balanceDueDate | format_date: "long", "ro-RO" }}.
+      "Render the scheduled advance + balance policy without mistaking scheduled installments for the current amount still owed.",
+    code: `{% if booking.isPaidInFull %}
+Achitat integral: {{ booking.paidAmountCents | cents: booking.currency, "ro-RO" }}{% if payment.latestCompleted %} prin {{ payment.latestCompleted.methodLabel }} în data de {{ payment.latestCompleted.date | format_date: "long", "ro-RO" }}{% endif %}.
+{% else %}
+{% if booking.depositAmountCents > 0 %}
+Avans programat: {{ booking.depositAmountCents | cents: booking.currency, "ro-RO" }}{% if booking.depositDueDate %}, scadent la {{ booking.depositDueDate | format_date: "long", "ro-RO" }}{% endif %}.
+{% endif %}
+{% if booking.balanceAmountCents > 0 %}
+Diferență programată: {{ booking.balanceAmountCents | cents: booking.currency, "ro-RO" }}{% if booking.balanceDueDate %}, scadentă la {{ booking.balanceDueDate | format_date: "long", "ro-RO" }}{% endif %}.
+{% endif %}
+{% if booking.amountDueCents > 0 %}
+Suma rămasă de plată: {{ booking.amountDueCents | cents: booking.currency, "ro-RO" }}.
+{% endif %}
 {% endif %}`,
   },
   {

--- a/packages/legal/tests/integration/auto-generate.test.ts
+++ b/packages/legal/tests/integration/auto-generate.test.ts
@@ -402,6 +402,8 @@ describe.skipIf(!DB_AVAILABLE)("autoGenerateContractForBooking", () => {
         body: [
           "Paid {{ booking.paidAmountCents }}",
           "Balance {{ booking.balanceDueCents }}",
+          "Due {{ booking.amountDueCents }}",
+          "Full {{ booking.isPaidInFull }}",
           "Latest {{ payment.latestCompleted.methodLabel }}",
           "Date {{ payment.latestCompleted.date }}",
         ].join(" | "),
@@ -455,6 +457,8 @@ describe.skipIf(!DB_AVAILABLE)("autoGenerateContractForBooking", () => {
 
     expect(bookingVariables.paidAmountCents).toBe(32000)
     expect(bookingVariables.balanceDueCents).toBe(0)
+    expect(bookingVariables.amountDueCents).toBe(0)
+    expect(bookingVariables.isPaidInFull).toBe(true)
     expect(latestCompleted).toMatchObject({
       method: "bank_transfer",
       methodLabel: "Bank Transfer",
@@ -462,7 +466,150 @@ describe.skipIf(!DB_AVAILABLE)("autoGenerateContractForBooking", () => {
     })
     expect(paymentVariables.method).toBe("Bank Transfer")
     expect(paymentVariables.capturedAt).toBe("2026-05-04")
-    expect(bodies[0]).toContain("Paid 32000 | Balance 0 | Latest Bank Transfer")
+    expect(bodies[0]).toContain("Paid 32000 | Balance 0 | Due 0 | Full true")
+  })
+
+  it("separates scheduled balance from current amount due for paid-in-full bookings", async () => {
+    const { template, version } = await seedTemplate("cust-paid-full-balance-1")
+    await db
+      .update(contractTemplateVersions)
+      .set({
+        body: [
+          "PaidFull {{ booking.isPaidInFull }}",
+          "Due {{ booking.amountDueCents }}",
+          "BalanceDue {{ booking.balanceDueCents }}",
+          "ScheduledBalance {{ booking.balanceAmountCents }}",
+        ].join(" | "),
+      })
+      .where(eq(contractTemplateVersions.id, version.id))
+
+    const booking = await seedBooking({
+      sellCurrency: "RON",
+      sellAmountCents: 32000,
+    })
+    await db.insert(bookingPaymentSchedules).values({
+      bookingId: booking.id,
+      scheduleType: "balance",
+      status: "paid",
+      dueDate: "2026-05-10",
+      currency: "RON",
+      amountCents: 32000,
+    })
+    const [invoice] = await db
+      .insert(invoices)
+      .values({
+        invoiceNumber: `INV-${booking.bookingNumber}`,
+        bookingId: booking.id,
+        status: "paid",
+        currency: "RON",
+        subtotalCents: 32000,
+        taxCents: 0,
+        totalCents: 32000,
+        paidCents: 32000,
+        balanceDueCents: 0,
+        issueDate: "2026-05-01",
+        dueDate: "2026-05-10",
+      })
+      .returning()
+    await db.insert(payments).values({
+      invoiceId: invoice!.id,
+      amountCents: 32000,
+      currency: "RON",
+      paymentMethod: "bank_transfer",
+      status: "completed",
+      paymentDate: "2026-05-04",
+    })
+
+    const bodies: string[] = []
+    const outcome = await autoGenerateContractForBooking(
+      db,
+      { bookingId: booking.id, bookingNumber: booking.bookingNumber, actorId: null },
+      { enabled: true, templateSlug: template.slug },
+      { generator: makeGenerator(bodies) },
+    )
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+
+    const contract = await contractRecordsService.getContractById(db, outcome.contractId)
+    const variables = contract?.variables as Record<string, unknown>
+    const bookingVariables = variables.booking as Record<string, unknown>
+
+    expect(bookingVariables).toMatchObject({
+      paidAmountCents: 32000,
+      amountDueCents: 0,
+      balanceDueCents: 0,
+      isPaidInFull: true,
+      depositAmountCents: 0,
+      balanceAmountCents: 32000,
+      balanceDueDate: "2026-05-10",
+    })
+    expect(bodies[0]).toContain("PaidFull true | Due 0 | BalanceDue 0 | ScheduledBalance 32000")
+  })
+
+  it("does not mark paid in full when invoices still have a positive balance", async () => {
+    const { template, version } = await seedTemplate("cust-adjusted-invoice-balance-1")
+    await db
+      .update(contractTemplateVersions)
+      .set({
+        body: [
+          "PaidFull {{ booking.isPaidInFull }}",
+          "Due {{ booking.amountDueCents }}",
+          "BalanceDue {{ booking.balanceDueCents }}",
+          "Paid {{ booking.paidAmountCents }}",
+        ].join(" | "),
+      })
+      .where(eq(contractTemplateVersions.id, version.id))
+
+    const booking = await seedBooking({
+      sellCurrency: "RON",
+      sellAmountCents: 32000,
+    })
+    const [invoice] = await db
+      .insert(invoices)
+      .values({
+        invoiceNumber: `INV-${booking.bookingNumber}`,
+        bookingId: booking.id,
+        status: "issued",
+        currency: "RON",
+        subtotalCents: 37000,
+        taxCents: 0,
+        totalCents: 37000,
+        paidCents: 32000,
+        balanceDueCents: 5000,
+        issueDate: "2026-05-01",
+        dueDate: "2026-05-10",
+      })
+      .returning()
+    await db.insert(payments).values({
+      invoiceId: invoice!.id,
+      amountCents: 32000,
+      currency: "RON",
+      paymentMethod: "bank_transfer",
+      status: "completed",
+      paymentDate: "2026-05-04",
+    })
+
+    const bodies: string[] = []
+    const outcome = await autoGenerateContractForBooking(
+      db,
+      { bookingId: booking.id, bookingNumber: booking.bookingNumber, actorId: null },
+      { enabled: true, templateSlug: template.slug },
+      { generator: makeGenerator(bodies) },
+    )
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+
+    const contract = await contractRecordsService.getContractById(db, outcome.contractId)
+    const variables = contract?.variables as Record<string, unknown>
+    const bookingVariables = variables.booking as Record<string, unknown>
+
+    expect(bookingVariables).toMatchObject({
+      paidAmountCents: 32000,
+      amountDueCents: 5000,
+      balanceDueCents: 5000,
+      isPaidInFull: false,
+    })
+    expect(bodies[0]).toContain("PaidFull false | Due 5000 | BalanceDue 5000 | Paid 32000")
   })
 
   it("derives payment schedule aliases and rooms summary from the booking", async () => {


### PR DESCRIPTION
## Summary

- Add `booking.amountDueCents` and `booking.isPaidInFull` to auto-generated legal contract variables.
- Keep `balanceDueCents` aligned with the current remaining amount owed, including the no-invoice fallback.
- Clarify that `depositAmountCents` and `balanceAmountCents` are gross scheduled installment amounts, not payment-aware balances.
- Update the deposit/balance authoring snippet to branch on paid-in-full state and use `amountDueCents` for remaining money.
- Add integration coverage for a paid-in-full booking with a single scheduled balance row.

Closes #1543

## Verification

- `pnpm --filter @voyantjs/legal typecheck`
- `pnpm --filter @voyantjs/legal test`
- `pnpm --filter @voyantjs/legal lint`

Note: the repository-wide pre-commit hook is currently blocked by unrelated finance/operator module-resolution errors on `main` (`fflate`, `recharts`, and `@voyantjs/availability/schema`).