### PR TITLE
Fix duplicate invoice number conflict detection

### DIFF
--- a/.changeset/fix-invoice-number-conflicts.md
+++ b/.changeset/fix-invoice-number-conflicts.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/finance": patch
+---
+
+Detect duplicate invoice number errors across nested Neon/serverless driver error shapes so invoice-from-booking returns a typed invoice number conflict.

--- a/packages/finance/src/invoice-number-errors.ts
+++ b/packages/finance/src/invoice-number-errors.ts
@@ -1,0 +1,73 @@
+const INVOICE_NUMBER_UNIQUE_TARGETS = [
+  "invoices_invoice_number_type_active_idx",
+  "invoices_invoice_number_type_unique",
+  "invoices_invoice_number_unique",
+  "invoices_invoice_number_key",
+  "invoice_number",
+]
+
+const UNIQUE_VIOLATION_SQLSTATE = "23505"
+
+interface ErrorSignals {
+  hasInvoiceNumberTarget: boolean
+  hasUniqueViolation: boolean
+}
+
+export function isInvoiceNumberUniqueConstraintError(error: unknown) {
+  const signals = collectErrorSignals(error, new Set(), 0)
+  return signals.hasUniqueViolation && signals.hasInvoiceNumberTarget
+}
+
+function collectErrorSignals(error: unknown, seen: Set<object>, depth: number): ErrorSignals {
+  if (!error || typeof error !== "object" || depth > 6 || seen.has(error)) {
+    return { hasInvoiceNumberTarget: false, hasUniqueViolation: false }
+  }
+  seen.add(error)
+
+  const record = error as Record<string, unknown>
+  const strings = errorStrings(record)
+  const signals = {
+    hasInvoiceNumberTarget: strings.some((value) =>
+      INVOICE_NUMBER_UNIQUE_TARGETS.some((target) => value.includes(target)),
+    ),
+    hasUniqueViolation: strings.some((value) => value.includes(UNIQUE_VIOLATION_SQLSTATE)),
+  }
+
+  for (const nested of nestedErrors(record)) {
+    const nestedSignals = collectErrorSignals(nested, seen, depth + 1)
+    signals.hasInvoiceNumberTarget ||= nestedSignals.hasInvoiceNumberTarget
+    signals.hasUniqueViolation ||= nestedSignals.hasUniqueViolation
+  }
+
+  return signals
+}
+
+function errorStrings(error: Record<string, unknown>) {
+  return [
+    error.code,
+    error.sqlState,
+    error.sqlstate,
+    error.sql_state,
+    error.constraint,
+    error.constraintName,
+    error.constraint_name,
+    error.detail,
+    error.message,
+    error.stack,
+  ].filter((value): value is string => typeof value === "string")
+}
+
+function nestedErrors(error: Record<string, unknown>) {
+  const values = [
+    error.cause,
+    error.originalError,
+    error.original,
+    error.error,
+    error.queryError,
+    error.sourceError,
+  ]
+  if (Array.isArray(error.errors)) {
+    values.push(...error.errors)
+  }
+  return values
+}

--- a/packages/finance/src/service-issue.ts
+++ b/packages/finance/src/service-issue.ts
@@ -5,6 +5,7 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { resolveBookingSellTaxRate } from "./booking-tax.js"
 import { resolveInvoiceFxContext } from "./invoice-fx.js"
+import { isInvoiceNumberUniqueConstraintError } from "./invoice-number-errors.js"
 import {
   bookingItemTaxLines,
   bookingPaymentSchedules,
@@ -623,21 +624,6 @@ function deriveInvoiceNumberFromProforma(proformaNumber: string): string {
     return proformaNumber.replace(/^PRO-/i, "INV-")
   }
   return `${proformaNumber}-INV`
-}
-
-function isInvoiceNumberUniqueConstraintError(error: unknown) {
-  if (!error || typeof error !== "object") return false
-  const candidate = error as { code?: unknown; constraint?: unknown; detail?: unknown }
-  if (candidate.code !== "23505") return false
-  const constraint = typeof candidate.constraint === "string" ? candidate.constraint : ""
-  const detail = typeof candidate.detail === "string" ? candidate.detail : ""
-  return (
-    constraint === "invoices_invoice_number_type_active_idx" ||
-    constraint === "invoices_invoice_number_type_unique" ||
-    constraint === "invoices_invoice_number_unique" ||
-    constraint === "invoices_invoice_number_key" ||
-    detail.includes("invoice_number")
-  )
 }
 
 function buildClientName(booking: typeof bookings.$inferSelect | undefined): string {

--- a/packages/finance/src/service.ts
+++ b/packages/finance/src/service.ts
@@ -24,6 +24,7 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
 import { resolveFxMoneyBaseAmount } from "./fx-money.js"
 import type { InvoiceFxOptions } from "./invoice-fx.js"
+import { isInvoiceNumberUniqueConstraintError } from "./invoice-number-errors.js"
 import {
   bookingGuarantees,
   bookingItemCommissions,
@@ -851,21 +852,6 @@ function resolveBookingInvoiceBaseAmount(
   if (invoiceCurrency !== booking.sellCurrency || booking.baseSellAmountCents == null) return null
   if (!booking.sellAmountCents || booking.sellAmountCents <= 0) return booking.baseSellAmountCents
   return Math.round((amountCents / booking.sellAmountCents) * booking.baseSellAmountCents)
-}
-
-function isInvoiceNumberUniqueConstraintError(error: unknown) {
-  if (!error || typeof error !== "object") return false
-  const candidate = error as { code?: unknown; constraint?: unknown; detail?: unknown }
-  if (candidate.code !== "23505") return false
-  const constraint = typeof candidate.constraint === "string" ? candidate.constraint : ""
-  const detail = typeof candidate.detail === "string" ? candidate.detail : ""
-  return (
-    constraint === "invoices_invoice_number_type_active_idx" ||
-    constraint === "invoices_invoice_number_type_unique" ||
-    constraint === "invoices_invoice_number_unique" ||
-    constraint === "invoices_invoice_number_key" ||
-    detail.includes("invoice_number")
-  )
 }
 
 function toTimestamp(value?: string | null) {

--- a/packages/finance/tests/unit/service-invoice-number-allocation.test.ts
+++ b/packages/finance/tests/unit/service-invoice-number-allocation.test.ts
@@ -305,6 +305,56 @@ describe("financeService.createInvoiceFromBooking number allocation", () => {
     } satisfies Partial<InvoiceNumberConflictError>)
   })
 
+  it("normalizes message-only serverless duplicate invoice number errors into a typed conflict", async () => {
+    const { db } = makeDb({
+      invoiceInsertError: new Error(
+        'NeonDbError: duplicate key value violates unique index "invoices_invoice_number_type_active_idx" (SQLSTATE 23505)',
+      ),
+    })
+
+    await expect(
+      financeService.createInvoiceFromBooking(
+        db,
+        {
+          bookingId: "book_123",
+          invoiceNumber: "MANUAL-1",
+          issueDate: "2026-05-23",
+          dueDate: "2026-06-23",
+        },
+        bookingData,
+      ),
+    ).rejects.toMatchObject({
+      name: "InvoiceNumberConflictError",
+      code: "invoice_number_conflict",
+      invoiceNumber: "MANUAL-1",
+    } satisfies Partial<InvoiceNumberConflictError>)
+  })
+
+  it("does not normalize unrelated unique violations into invoice number conflicts", async () => {
+    const { db } = makeDb({
+      invoiceInsertError: {
+        code: "23505",
+        constraint: "invoice_external_refs_provider_external_id_unique",
+      },
+    })
+
+    await expect(
+      financeService.createInvoiceFromBooking(
+        db,
+        {
+          bookingId: "book_123",
+          invoiceNumber: "MANUAL-1",
+          issueDate: "2026-05-23",
+          dueDate: "2026-06-23",
+        },
+        bookingData,
+      ),
+    ).rejects.toMatchObject({
+      code: "23505",
+      constraint: "invoice_external_refs_provider_external_id_unique",
+    })
+  })
+
   it("uses override line items and computes cross-currency base totals", async () => {
     const { db, insertedInvoices, insertedInvoiceLineItems } = makeDb({})
 
@@ -1059,8 +1109,10 @@ describe("financeService.updateInvoice number writeback", () => {
 
   it("normalizes duplicate writeback numbers into a typed conflict", async () => {
     const db = makeUpdateInvoiceDb({
-      code: "23505",
-      constraint: "invoices_invoice_number_type_active_idx",
+      cause: {
+        code: "23505",
+        detail: "Key (invoice_number, invoice_type)=(B-0133, invoice) already exists.",
+      },
     })
 
     await expect(


### PR DESCRIPTION
## Summary
- Add a shared finance helper that recognizes invoice-number unique violations across nested driver error shapes, including Neon/serverless wrappers and message-only SQLSTATE/index-name errors.
- Reuse the helper from invoice creation/update and proforma conversion paths.
- Add regression coverage for serverless-style duplicate invoice errors and ensure unrelated unique violations are not normalized as invoice number conflicts.

Closes #1547

## Testing
- `pnpm --filter @voyantjs/finance exec vitest run tests/unit/service-invoice-number-allocation.test.ts`
- `pnpm --filter @voyantjs/finance lint`
- `pnpm --filter @voyantjs/finance typecheck`
- `pnpm verify:fast`