### PR TITLE
Fix CRM people hydration fallback

### DIFF
--- a/.changeset/soft-crm-people-hydration.md
+++ b/.changeset/soft-crm-people-hydration.md
@@ -1,0 +1,5 @@
+---
+"@voyantjs/crm": patch
+---
+
+Keep CRM people list responses available when identity hydration fails by returning base people rows with empty inline identity fields.

--- a/packages/crm/src/service/accounts-people.ts
+++ b/packages/crm/src/service/accounts-people.ts
@@ -142,7 +142,7 @@ export const peopleAccountsService = {
 
     return {
       ...result,
-      data: await hydratePeople(db, result.data),
+      data: await hydratePeople(db, result.data, { fallbackOnError: true }),
     }
   },
 

--- a/packages/crm/src/service/accounts-shared.ts
+++ b/packages/crm/src/service/accounts-shared.ts
@@ -52,6 +52,10 @@ export type PersonHydratedFields = {
   website: string | null
 }
 
+type HydratePeopleOptions = {
+  fallbackOnError?: boolean
+}
+
 function emptyPersonHydratedFields(): PersonHydratedFields {
   return {
     email: null,
@@ -197,16 +201,32 @@ export async function deletePersonIdentity(db: PostgresJsDatabase, personId: str
 export async function hydratePeople<T extends { id: string }>(
   db: PostgresJsDatabase,
   rows: T[],
+  options: HydratePeopleOptions = {},
 ): Promise<Array<T & PersonHydratedFields>> {
-  if (rows.length === 0) {
-    return rows.map((row) => ({
+  const emptyHydratedRows = () =>
+    rows.map((row) => ({
       ...row,
       ...emptyPersonHydratedFields(),
     }))
+
+  if (rows.length === 0) {
+    return emptyHydratedRows()
   }
 
   const ids = rows.map((row) => row.id)
-  const directoryMap = await loadPersonDirectoryMap(db, ids)
+  let directoryMap: Map<string, PersonHydratedFields>
+  try {
+    directoryMap = await loadPersonDirectoryMap(db, ids)
+  } catch (error) {
+    if (!options.fallbackOnError) {
+      throw error
+    }
+    console.warn("[crm] person identity hydration failed; returning base people rows", {
+      error,
+      personCount: rows.length,
+    })
+    return emptyHydratedRows()
+  }
 
   return rows.map((row) => {
     return {

--- a/packages/crm/tests/unit/accounts-shared.test.ts
+++ b/packages/crm/tests/unit/accounts-shared.test.ts
@@ -1,0 +1,62 @@
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { hydratePeople } from "../../src/service/accounts-shared.js"
+
+describe("hydratePeople", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("throws by default when directory hydration fails", async () => {
+    const expectedError = new Error("identity binding unavailable")
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: async () => {
+            throw expectedError
+          },
+        }),
+      }),
+    } as PostgresJsDatabase
+
+    await expect(hydratePeople(db, [{ id: "crm_ppl_1", firstName: "Ada" }])).rejects.toBe(
+      expectedError,
+    )
+  })
+
+  it("returns base people rows with empty identity fields when fallback is enabled", async () => {
+    const expectedError = new Error("identity binding unavailable")
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: async () => {
+            throw expectedError
+          },
+        }),
+      }),
+    } as PostgresJsDatabase
+
+    const rows = await hydratePeople(db, [{ id: "crm_ppl_1", firstName: "Ada" }], {
+      fallbackOnError: true,
+    })
+
+    expect(rows).toEqual([
+      {
+        id: "crm_ppl_1",
+        firstName: "Ada",
+        email: null,
+        phone: null,
+        website: null,
+      },
+    ])
+    expect(warn).toHaveBeenCalledWith(
+      "[crm] person identity hydration failed; returning base people rows",
+      {
+        error: expectedError,
+        personCount: 1,
+      },
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Keep CRM people responses available when person directory identity hydration fails.
- Log the hydration failure and return base people rows with empty inline identity fields.
- Add a regression test for fallback hydration behavior.

Fixes #1548

## Verification
- `pnpm --filter @voyantjs/crm test -- --runInBand`
- `pnpm --filter @voyantjs/crm typecheck`
- `pnpm --filter @voyantjs/crm lint`
- `pnpm verify:fast`