### PR TITLE
Phase 0: establish Quote sales artifact language

### DIFF
--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -13,7 +13,7 @@ platform. Terms are grouped by subdomain. Use the **bold** term; treat
 | **Person**        | An individual contact known to the operator — the canonical CRM identity record.                      | *customer, client, contact*     |
 | **Organization** | A company or legal entity — represents a buyer, supplier, agency, or other counterparty.             | *account, company, client*      |
 | **Traveler**      | A person who actually travels on a booking; carries category (adult/child/infant/senior) and PII.     | *guest, pax, passenger*         |
-| **Participant**   | A role-bearer on an opportunity, offer, order, or booking item (traveler, booker, decision-maker, finance). | *contact-on-deal*          |
+| **Participant**   | A role-bearer on a Quote, Quote Version, offer, order, or booking item (traveler, booker, decision-maker, finance). | *contact-on-deal*          |
 | **User**          | An authentication identity in the system; orthogonal to Person — staff and customers can both be Users. | *login, account*              |
 | **Supplier**      | An operational vendor we contract directly for delivery of owned or assembled products.                | *vendor, provider, source*      |
 | **Channel**       | A distribution counterparty selling our inventory (direct, OTA, affiliate, reseller, marketplace, API partner). | *partner, distributor*    |
@@ -35,14 +35,14 @@ platform. Terms are grouped by subdomain. Use the **bold** term; treat
 
 ## Sales pipeline (pre-commitment)
 
-| Term            | Definition                                                                                       | Aliases to avoid       |
-| --------------- | ------------------------------------------------------------------------------------------------ | ---------------------- |
-| **Opportunity** | A tracked sales deal with a Person/Organization — moves through Stages, may close won/lost.       | *lead, deal*           |
-| **Pipeline**    | An ordered set of Stages a deal moves through.                                                   | *funnel, board*        |
-| **Stage**       | A step within a Pipeline (e.g. Qualified → Proposal → Negotiation), with win/lost flags.         | *step, status*         |
-| **Quote**       | A pre-sales pricing proposal attached to an Opportunity; informational, not transactable.        | *proposal, estimate*   |
-| **Activity**    | A logged interaction (call, email, meeting, task, follow-up) on an Opportunity or Person.        | *event, log entry*     |
-| **Segment**     | A named list of People or Organizations grouped by criteria, used for targeting or bulk action.  | *list, group*          |
+| Term              | Definition                                                                                       | Aliases to avoid       |
+| ----------------- | ------------------------------------------------------------------------------------------------ | ---------------------- |
+| **Quote**         | A tracked travel sales pursuit with a Person/Organization; moves through Stages, owns value, participants, activities, and one or more Quote Versions, and may close won/lost. | *opportunity, deal* |
+| **Quote Version** | An immutable proposal revision or alternative sent to the client; freezes a Trip / Package Envelope snapshot, pricing, validity, and decision state. | *proposal, estimate, package offer* |
+| **Pipeline**      | An ordered set of Stages a Quote moves through.                                                  | *funnel, board*        |
+| **Stage**         | A step within a Pipeline (e.g. Qualified -> Proposal -> Negotiation), with win/lost flags.       | *step, status*         |
+| **Activity**      | A logged interaction (call, email, meeting, task, follow-up) on a Quote or Person.               | *event, log entry*     |
+| **Segment**       | A named list of People or Organizations grouped by criteria, used for targeting or bulk action.  | *list, group*          |
 
 ## Catalog (what we sell)
 
@@ -57,7 +57,7 @@ platform. Terms are grouped by subdomain. Use the **bold** term; treat
 | **Room Option**       | A bookable accommodation option for resale or trip composition, usually with occupancy and board/rate choices. | *room unit (unless physical ops)* |
 | **Rate Plan**         | A resale/commercial accommodation price and policy choice, usually from a Supplier or Inventory Source. | *tariff*                      |
 | **Board Basis**       | The included-meals tier for an accommodation component (breakfast, half-board, full-board, all-inclusive). | *meal plan (when ambiguous)* |
-| **Stay Component**    | A date-range accommodation line within a Product, Offer, Booking, or sourced Catalog Item.        | *hotel reservation*            |
+| **Stay Component**    | A date-range accommodation line within a Product, Quote Version, Offer, Booking, or sourced Catalog Item. | *hotel reservation*            |
 | **Product Version**   | An immutable snapshot of a Product's structure at a point in time.                               | *revision, snapshot*           |
 | **Product Media**     | An image, video, or document attached to a Product or one of its Days.                           | *asset, attachment*            |
 | **Operated Group Departure** | A fixed Product instance/departure with capacity and product-internal components such as bus transport, stays, included excursions, guide assignment, rooming list, and dependent Extras. | *package when used for the aggregate* |
@@ -95,12 +95,12 @@ platform. Terms are grouped by subdomain. Use the **bold** term; treat
 
 ## Transaction chain (the commitment ladder)
 
-The five-step ladder is **Quote → Offer → Order → Booking → Fulfillment**. Each step hardens the commitment.
+For travel-native bespoke sales, the ladder is **Quote -> accepted Quote Version -> reserve workflow -> Order / Booking -> Fulfillment**. Each step hardens the commitment, but accepting a Quote Version is not the same as supplier confirmation.
 
 | Term                    | Definition                                                                                       | Aliases to avoid         |
 | ----------------------- | ------------------------------------------------------------------------------------------------ | ------------------------ |
-| **Offer**               | A priced, dated, sellability-resolved proposal — sendable, acceptable, convertible to an Order.  | *quote (overloaded)*     |
-| **Order**               | A confirmed commitment to deliver — created from an accepted Offer or directly; hosts Order Terms. | *purchase order*       |
+| **Offer**               | The transactions-package priced proposal primitive for existing offer-to-order flows; not the bespoke travel sales artifact staff agents call a Quote. | *quote, package offer* |
+| **Order**               | A confirmed commitment to deliver — created from an accepted Quote Version reserve workflow, an accepted Offer, or directly; hosts Order Terms. | *purchase order* |
 | **Booking**             | The fulfillment-side record of an Order: Travelers, Allocations, Fulfillments, redemptions.      | *reservation, booking-record* |
 | **Offer Item / Order Item / Booking Item** | A line-item on its parent (unit, service, extra, fee, tax, discount, accommodation, transport). | *line, row*  |
 | **Allocation**          | A capacity hold against a Slot, Pickup, or Resource — `held` → `confirmed` → `fulfilled`.        | *reservation-line, hold-record* |
@@ -181,11 +181,12 @@ The five-step ladder is **Quote → Offer → Order → Booking → Fulfillment*
 | **Issue**      | Produce a deliverable artifact (voucher, invoice, contract, policy version).                     | Fulfillment, Invoice, Contract, Policy Version |
 | **Fulfill**    | Mark operational delivery complete.                                                              | Booking Item, Allocation                 |
 | **Deliver**    | Push an issued artifact to the recipient over a channel (email, download, wallet, API).          | Fulfillment, Notification                |
+| **Accept**     | Record that the client chose a Quote Version or accepted required commercial terms; does not by itself mean every supplier component is confirmed. | Quote Version, Offer                     |
 | **Redeem**     | Consume a Fulfillment at point of service.                                                       | Fulfillment                              |
 | **Cancel**     | Operationally reverse a commitment.                                                              | Booking, Order, Allocation, Supplier status |
 | **Void**       | Financially reverse a document — distinct from Cancel.                                           | Invoice, Payment                         |
-| **Close**      | End an Opportunity with an outcome (won/lost/archived).                                          | Opportunity                              |
-| **Convert**    | Promote one entity to the next on the commitment ladder.                                         | Offer → Order, Product → Booking         |
+| **Close**      | End a Quote with an outcome (won/lost/archived).                                                 | Quote                                    |
+| **Convert**    | Promote one entity to the next on the commitment ladder.                                         | Quote Version -> reserve workflow, Offer -> Order, Product -> Booking |
 | **Reconcile**  | Compare expected vs. actual and emit Issues.                                                     | Channel Settlement                       |
 | **Settle**     | Post the financial outcome of Reconciliation.                                                    | Channel Settlement                       |
 | **Override**   | Manually set a Booking's status, bypassing the transition graph. Admin-only; always audit-logged with a required reason. | Booking |
@@ -193,9 +194,11 @@ The five-step ladder is **Quote → Offer → Order → Booking → Fulfillment*
 ## Relationships (the domain laws)
 
 - A **Person** may belong to zero or more **Organizations**; both can appear on Bookings and Orders.
-- An **Opportunity** belongs to one Person and/or Organization; produces zero or more **Quotes**.
-- A **Quote** is informational; an **Offer** is the transactable equivalent — a Quote does not become an Offer automatically.
-- An **Offer** converts to exactly one **Order**; an Order may be created without a prior Offer (direct booking).
+- A **Quote** belongs to one Person and/or Organization, moves through a Pipeline, and produces zero or more **Quote Versions**.
+- A **Quote Version** freezes a Trip / Package Envelope snapshot; editing a sent Version creates another Version.
+- Accepting a **Quote Version** marks that Version accepted, closes the Quote won, and seeds the reserve workflow; it does not mean every live or manual component is supplier-confirmed.
+- A transactions **Offer** may still convert to exactly one **Order** in existing offer-to-order flows; it is not the bespoke travel sales artifact called Quote.
+- An **Order** may be created from an accepted Quote Version reserve workflow, an accepted Offer, or directly.
 - An **Order** produces one or more **Bookings**; a Booking is the fulfillment side of one Order.
 - A **Booking** holds **Allocations** against **Slots** (or Pickups, or Resources); each Allocation belongs to exactly one Booking Item.
 - Accommodation may be sold as **Sourced Inventory** or as a component of a **Product**, but hotel/property operations are not a first-party implementation scenario.
@@ -214,13 +217,13 @@ The five-step ladder is **Quote → Offer → Order → Booking → Fulfillment*
 
 ## Example dialogue
 
-> **Sales agent:** "I've got a hot **Opportunity** with the Henderson family — eight **Travelers**, two weeks in Egypt. I sent them a **Quote** last week."
+> **Sales agent:** "I've got a hot **Quote** with the Henderson family — eight **Travelers**, two weeks in Egypt. I sent them a **Quote Version** last week."
 
-> **Operations manager:** "Good. If they're ready to commit, build them an **Offer** — that pulls live **Sellability** for the dates and locks the **Cost** from our Cairo **Suppliers**. Once they accept, it converts to an **Order**."
+> **Operations manager:** "Good. If they accept that Version, run reserve. Live lines must recheck **Sellability** and **Cost** from our Cairo **Suppliers**; manual lines move into supplier confirmation."
 
-> **Sales agent:** "And the **Booking** is created from the **Order**?"
+> **Sales agent:** "And the **Booking** is created immediately?"
 
-> **Operations manager:** "Yes - the Order is the commercial commitment with the **Order Terms** they have to accept. The **Booking** is operational: it holds **Allocations** against the **Slots** for each guided day, includes a **Stay Component** in Aswan, and sets up **Dispatches** with **Vehicles** and **Drivers** for the transfers."
+> **Operations manager:** "Only after reserve can secure the component commitments. The **Booking** is operational: it holds **Allocations** against the **Slots** for each guided day, includes a **Stay Component** in Aswan, and sets up **Dispatches** with **Vehicles** and **Drivers** for the transfers."
 
 > **Sales agent:** "What about the cancellation thing they asked about?"
 
@@ -243,10 +246,11 @@ These terms are used loosely in conversation. Pick the canonical form below; tre
 - **Customer / client / buyer** — none are first-class entities. The canonical CRM record is **Person** (with optional **Organization**). On a Booking, the buyer is captured as `personId` + `organizationId` snapshot fields. Avoid "customer" / "client" except in UI copy facing the operator's own staff.
 - **Tour / experience** — usually collapse to **Product**. **Trip** and **package** are overloaded: use **Product** for an operator-sold offering, **Operated Group Departure** for a fixed-capacity product instance, and **Trip / Package Envelope** for a customer-facing aggregate of multiple component commitments.
 - **Accommodation vs. hotel operations** — accommodation is valid as catalog inventory, sourced resale, or trip composition. Hotel/property operations are not a first-party Voyant implementation scenario.
-- **Quote vs. Offer** — both look like "a price proposal". **Quote** is a CRM artifact attached to an Opportunity (informational, pre-sales). **Offer** is the transactional, sellability-resolved, sendable, acceptable document on the commitment ladder. They are not synonyms.
+- **Quote vs. Opportunity** — the canonical sales pursuit is **Quote**. Opportunity is the old generic CRM name and should not appear in new public package surfaces.
+- **Quote Version vs. Offer** — both look like "a price proposal". **Quote Version** is the travel-native proposal candidate that freezes a Trip / Package Envelope snapshot and can be accepted into reserve. **Offer** is the transactions-package primitive for existing offer-to-order flows. They are not synonyms.
 - **Order vs. Booking** — both are post-sale. **Order** is the commercial commitment (with Order Terms, links to Invoices); **Booking** is the operational record (Travelers, Allocations, Fulfillments). One Order produces one Booking in normal flows; do not use them interchangeably.
 - **Reservation** — overloaded between "Hold" (a temporary inventory claim) and "Booking" (the persistent record). Use **Hold** or **Booking** — never "Reservation".
-- **Cancel vs. Void vs. Close** — different verbs for different domains. **Cancel** = operational reversal (Booking, Order, Allocation). **Void** = financial reversal (Invoice, Payment). **Close** = end an Opportunity with an outcome. Don't blend them.
+- **Cancel vs. Void vs. Close** — different verbs for different domains. **Cancel** = operational reversal (Booking, Order, Allocation). **Void** = financial reversal (Invoice, Payment). **Close** = end a Quote with an outcome. Don't blend them.
 - **Hold vs. Allocation vs. Reservation** — **Hold** is the temporal status of a Booking before confirmation (`hold_expires_at`). **Allocation** is the inventory-line entity (`held` → `confirmed` → `fulfilled`). Avoid "Reservation".
 - **Supplier vs. Partner vs. Provider** — **Supplier** is the entity that sells us services. **Partner** is a relationship type on Organizations. **Provider** is for tech integrations (notification provider, storage provider) — do not call a hotel a "provider".
 - **Channel vs. Distribution vs. Partner** — **Channel** is the entity (the OTA, the affiliate, the marketplace). **Distribution** is the subdomain. Don't say "Partner" when you mean Channel.

--- a/docs/adr/0004-quotes-as-travel-native-sales-artifact.md
+++ b/docs/adr/0004-quotes-as-travel-native-sales-artifact.md
@@ -1,6 +1,6 @@
 # ADR-0004: Quotes are the travel-native sales artifact
 
-- **Status:** Proposed (2026-06-08)
+- **Status:** Accepted (2026-06-08)
 - **Relates to:** [#1541](https://github.com/voyantjs/voyant/issues/1541), [AI travel experience composition](../architecture/ai-travel-experience-composition.md), [travel composer implementation plan](../architecture/travel-composer-implementation-plan.md)
 - **Builds on:** [ADR-0001](./0001-tenant-scoping.md) (deployment = tenancy boundary), [ADR-0002](./0002-contract-packages.md) (contract/runtime package split)
 

--- a/docs/adr/0004-quotes-as-travel-native-sales-artifact.md
+++ b/docs/adr/0004-quotes-as-travel-native-sales-artifact.md
@@ -1,0 +1,160 @@
+# ADR-0004: Quotes are the travel-native sales artifact
+
+- **Status:** Proposed (2026-06-08)
+- **Relates to:** [#1541](https://github.com/voyantjs/voyant/issues/1541), [AI travel experience composition](../architecture/ai-travel-experience-composition.md), [travel composer implementation plan](../architecture/travel-composer-implementation-plan.md)
+- **Builds on:** [ADR-0001](./0001-tenant-scoping.md) (deployment = tenancy boundary), [ADR-0002](./0002-contract-packages.md) (contract/runtime package split)
+
+## Context
+
+Voyant currently has several overlapping "priced proposal" concepts:
+
+- CRM **Opportunity** tracks the sales pursuit: pipeline, stage, owner, value,
+  person/organization, participants, products, and activities.
+- CRM **Quote** is a thin informational proposal attached to an Opportunity.
+- Transactions **Offer** is a richer priced proposal that can convert to an
+  Order.
+- The travel composer **Trip / Package Envelope** carries itinerary content,
+  travelers, manual services, component pricing, and reserve/checkout flow, but
+  it is a live working object rather than a frozen proposal artifact.
+
+That language is backward for bespoke travel work. Travel consultants build and
+track quotes. A quote is not just an informational price estimate; it is the
+tracked pursuit, the sendable proposal, and the artifact the client accepts or
+declines. The travel composer already has the itinerary and reserve workflow;
+the missing piece is a versioned proposal that freezes the Trip content the
+client saw.
+
+The previous ubiquitous language said:
+
+- Opportunity = the tracked sales deal.
+- Quote = informational, not transactable.
+- Offer = the transactable equivalent.
+- The composition ladder was Quote -> Offer -> Order -> Booking -> Fulfillment,
+  with `PackageOffer` left open as a future proposal artifact.
+
+This ADR deliberately reverses that vocabulary for travel-native sales.
+
+## Decision
+
+**A Quote is the travel-native sales artifact.** It is the tracked pursuit that
+moves through a pipeline, owns sales activity, and carries one or more
+versioned proposal candidates. The generic CRM term **Opportunity** is retired
+from the supported domain language.
+
+**A Quote Version is the immutable proposal revision or alternative sent to the
+client.** It freezes the relevant Trip / Package Envelope snapshot, including
+components, manual services, travelers, pricing, currency, validity, and
+proposal metadata. Editing a sent proposal mints a new Quote Version; it never
+mutates the already-sent version.
+
+Acceptance is whole-version for v1:
+
+1. The client accepts exactly one Quote Version.
+2. The accepted Version is recorded on the Quote.
+3. Other open Versions on the same Quote are declined or superseded.
+4. The Quote closes won.
+5. The accepted Version seeds the composer reserve workflow.
+
+Acceptance is not the same as confirmed fulfillment. Live catalog-backed lines
+must be repriced and rechecked. Manual placeholders keep their quoted price but
+move into staff supplier-confirmation work. The reserve workflow materializes
+component Bookings and/or Orders under the Trip / Package Envelope and surfaces
+pending supplier confirmation instead of pretending every component is secured.
+
+Transactions **Offer** is not retired by this decision. It remains the
+transactions package primitive for existing offer-to-order flows,
+`orders.offerId`, and `order_terms`. It is no longer the name of the bespoke
+travel sales artifact that staff agents build and clients accept. Any
+retirement, rewrite, or repurposing of transactions Offer requires a separate
+ADR.
+
+## Consequences
+
+### Positive
+
+- The staff-facing language matches travel agency practice: agents track
+  Quotes, send Quote Versions, and win or lose the Quote.
+- The proposal artifact reuses the travel composer instead of inventing a
+  parallel line model. A Version freezes a Trip snapshot rather than copying
+  every itinerary concept into CRM.
+- Revisions and alternatives share one primitive: a candidate Quote Version.
+  A `supersedes` link models revisions; labels model side-by-side options.
+- The acceptance workflow stays honest about travel operations. Accepted means
+  "the client chose this Version"; confirmed means "the component suppliers and
+  inventory commitments are secured."
+
+### Negative
+
+- This is a repository-wide vocabulary break. Code, contracts, routes, hooks,
+  UI labels, links, and generated schema artifacts that currently say
+  Opportunity must be renamed in planned slices.
+- The term Quote becomes broader than the thin CRM table that exists today.
+  Reviewers must watch for accidental half-renames where a Quote still means
+  only an informational line list.
+- The old Quote/Offer disambiguation is invalid. Documentation and future code
+  must be explicit when talking about the transactions Offer primitive.
+
+### Scope boundaries
+
+This ADR decides language and target architecture. It does not perform the
+schema rename by itself.
+
+The implementation order is:
+
+1. Rename CRM Opportunity to Quote.
+2. Repurpose the existing thin CRM quotes table as Quote Versions.
+3. Add Quote Version status, validity, sent/viewed/decided timestamps, labels,
+   supersession, and Trip snapshot reference.
+4. Update CRM contracts and backend routes.
+5. Follow with client, UI, cross-package reference-grain cleanup, template
+   migrations, Trip snapshot freezing, send/view/accept lifecycle, and
+   accept-to-reserve wiring.
+
+Migrations remain template-owned. The package schema changes are exported by
+the package; `templates/operator` and `templates/dmc` own migration generation
+and application.
+
+## Alternatives considered
+
+### Alternative A: Keep Opportunity and add a new Quotes module
+
+Rejected. It would create another sales artifact while leaving the existing
+Opportunity/Quote/Offer/Trip overlap in place. The repository already has the
+sales tracker and the trip composer; the missing concept is versioning and
+freezing, not another module boundary.
+
+### Alternative B: Keep Quote informational and use transactions Offer for custom travel
+
+Rejected. Transactions Offer is useful, but it is not the shape staff agents
+use to assemble bespoke itineraries with manual placeholders and component
+reserve workflows. Forcing custom travel through Offer would duplicate Trip
+component structure and keep staff vocabulary misaligned.
+
+### Alternative C: Introduce `PackageOffer`
+
+Rejected for now. `PackageOffer` named the right gap, but it adds a fourth
+commercial proposal primitive. The same gap is better filled by Quote Version:
+the CRM pursuit stays Quote, the proposal candidate is a Version, and the
+Version freezes a Trip snapshot.
+
+### Alternative D: Treat "Quote" as a UI label over Opportunity
+
+Rejected. A UI-only label would leave public package APIs, routes, contracts,
+and schema terms using Opportunity. That preserves the wrong ubiquitous
+language and makes every integration translate the same concept twice.
+
+## How to apply this decision
+
+Use **Quote** for the tracked travel sales pursuit. Do not introduce new
+Opportunity symbols, routes, contracts, or public exports.
+
+Use **Quote Version** for a sent or sendable proposal candidate. A Version may
+be a revision or an alternative, but it is immutable once sent.
+
+Use **Transactions Offer** only when referring to the existing transactions
+package primitive. Do not use Offer as the name of a staff-composed bespoke
+travel proposal.
+
+When a client accepts a Quote Version, route the outcome through the composer
+reserve workflow. Do not silently create a confirmed Booking for manual or
+unverified live components.

--- a/docs/architecture/ai-travel-experience-composition.md
+++ b/docs/architecture/ai-travel-experience-composition.md
@@ -144,7 +144,6 @@ Package name:
 Alternative names:
 
 - `@voyantjs/itinerary-composer`
-- `@voyantjs/package-offers`
 - `@voyantjs/travel-experiences`
 
 Recommendation: use a domain name, not an AI name. The module's job is
@@ -322,9 +321,10 @@ A Trip whose selected components have been held or booked upstream and converted
 into Voyant's Booking Session / Booking / Order structures as appropriate.
 
 A Reserved Trip may resolve to one Booking with many items, multiple Bookings
-under a booking group, or a future package-level transactional record. The
-composer must keep that grouping decision behind its service interface until a
-formal `PackageOffer` / composite package vertical exists.
+under a booking group, or component Orders/Bookings under a Quote Version
+snapshot. The composer must keep that grouping decision behind its service
+interface so the accepted proposal can preserve the Trip snapshot without
+erasing component lifecycle boundaries.
 
 Default grouping decision for cross-vertical composition:
 
@@ -422,22 +422,23 @@ Current caveats:
 
 ### 5.4. Commercial ladder
 
-Voyant's ladder remains:
+ADR-0004 makes the travel-native bespoke sales ladder:
 
-**Quote -> Offer -> Order -> Booking -> Fulfillment**
+**Quote -> Quote Version -> reserve workflow -> Order / Booking -> Fulfillment**
 
 The composer sits before and around that ladder:
 
 - Trip Envelope in `draft` status is pre-commitment.
-- Priced Trip is a customer-facing priced proposal, but not necessarily a
-  formal Offer record.
-- Reserved Trip creates holds and/or Booking Session state.
+- Priced Trip can be frozen into a Quote Version, which is the sendable,
+  acceptable proposal snapshot.
+- Accepting a Quote Version starts reserve; it does not mean every live or
+  manual component is supplier-confirmed.
+- Reserved Trip creates holds and/or Booking Session / Booking / Order state.
 - Checkout turns the held/reserved commitment into collection.
 
-Open design question: whether a formal `PackageOffer` should be introduced as
-the cross-vertical transactional artifact. If package-level cancellation,
-terms, pricing, margin, and snapshot semantics become non-trivial, a dedicated
-composite package vertical likely earns its keep.
+Transactions Offer remains a separate transactions package primitive for
+existing offer-to-order flows. It is not the bespoke travel proposal artifact
+for the composer.
 
 ### 5.5. Booking Sessions
 
@@ -660,8 +661,9 @@ Booking Session state until the customer asks to reserve or buy.
 
 Avoid making the Trip Envelope depend on exactly one Booking. Multi-line
 composition may need one Booking with many items, several Bookings under a
-group, or a later `PackageOffer`/package vertical. The schema should preserve
-line-level commit references and an optional aggregate reference.
+group, or several component Orders/Bookings under an accepted Quote Version.
+The schema should preserve line-level commit references and an optional
+aggregate reference.
 
 For MVP, bias toward several component bookings/orders under one envelope for
 FIT composition, while allowing a component itself to contain child booking
@@ -703,47 +705,40 @@ High-level buy flow:
 
 ## 11. Open questions
 
-1. **Future package-offer artifact.** `travel-composer` is the package name.
-   If the primary output later becomes a formal transactable proposal, add a
-   `PackageOffer` artifact inside or alongside the composer rather than
-   renaming the package.
-2. **PackageOffer vs Trip Envelope only.** If cross-vertical pricing,
-   cancellation, and terms need a durable transactable proposal, introduce
-   `PackageOffer`. If not, keep Trip Envelope + Booking Session.
-3. **Where to store conversation state.** The composer should store structured
+1. **Where to store conversation state.** The composer should store structured
    summaries and decisions, not raw prompt dependence. Raw transcript retention
    may be app-owned or configurable.
-4. **Staff handoff shape.** Could use CRM Opportunity, Quote, Activity, or a
-   dedicated support task depending on operator workflow.
-5. **Public vs admin AI tools.** Customer agents need strict customer-audience
+2. **Staff handoff shape.** Could use Quote, Quote Activity, or a dedicated
+   support task depending on operator workflow.
+3. **Public vs admin AI tools.** Customer agents need strict customer-audience
    access. Staff agents may federate across audience pools and see operational
    fields.
-6. **Flights in public surface.** The `@voyantjs/flights` package now provides
+4. **Flights in public surface.** The `@voyantjs/flights` package now provides
    contracts, fan-out, snapshots, and reference-data providers, but AI
    storefront use still needs public-safe route mounting for search, price,
    reserve, and order-status surfaces. The operator template has flight UI/API
    wiring, but the composer should not assume a customer-safe flight route
    family exists yet.
-7. **Manual placeholders.** Real operators often need "we will confirm this
+5. **Manual placeholders.** Real operators often need "we will confirm this
    hotel manually." The composer should support placeholders without pretending
    they are live inventory.
-8. **Ground transport boundary.** `@voyantjs/ground` is an operational module.
+6. **Ground transport boundary.** `@voyantjs/ground` is an operational module.
    The composer still needs a sellable transfer/search surface before it can
    treat ground services like normal Trip Components.
-9. **Hold-release primitive for sourced drafts.** The draft reaper can release
+7. **Hold-release primitive for sourced drafts.** The draft reaper can release
    owned holds through owned handlers and can honor
    `AdapterCapabilities.holdReleaseGraceMs`. Sourced adapters currently expose
    `cancel`, not a hold-only release primitive, so sourced soft-hold cleanup
    still needs a SourceAdapter contract addition before broad multi-source
    reserve flows are safe.
-10. **Aggregate commit shape.** Decide whether MVP reserve produces one Booking
-    with many Booking Items, several Bookings in a booking group, or a narrower
-    package-level artifact. Current default: several component bookings/orders
-    under one Trip / Package Envelope for FIT composition; one booking with
-    child items/Extras for operated products and dependent upsells. The
-    composer interface can hide this, but checkout, documents, cancellation,
-    and support UI need a consistent target.
-11. **Template-owned checkout extraction.** `POST
+8. **Aggregate commit shape.** Decide whether MVP reserve produces one Booking
+   with many Booking Items, several Bookings in a booking group, or several
+   component Orders/Bookings under an accepted Quote Version. Current default:
+   several component bookings/orders under one Trip / Package Envelope for FIT
+   composition; one booking with child items/Extras for operated products and
+   dependent upsells. The composer interface can hide this, but checkout,
+   documents, cancellation, and support UI need a consistent target.
+9. **Template-owned checkout extraction.** `POST
     /v1/public/catalog/checkout/start` exists in the operator template. The
     current operator adapter can call the extracted `startCatalogCheckout(...)`
     service from that template, which is enough for the integration branch.
@@ -783,7 +778,7 @@ that component's supplier lifecycle.
   while the adapter wiring is proven; the hardening slice should move the
   generic parts into framework-owned catalog/checkout services.
 - Preserve template ownership of Netopia config, bank details, contract template
-  choice, CRM opportunity creation, and storefront URLs.
+  choice, CRM Quote creation, and storefront URLs.
 - Expose a service-level `startCheckout({ bookingId, paymentIntent, ... })`
   that the composer can call after reserve.
 
@@ -818,7 +813,7 @@ that component's supplier lifecycle.
 - Place holds/bookings in dependency order, with compensation on partial
   failure.
 - Preserve line-level references and optional aggregate references
-  (`bookingId`, `bookingGroupId`, or future package artifact).
+  (`bookingId`, `bookingGroupId`, or accepted Quote Version).
 - Cover owned-hold release, quote expiry, one-line success, one-line failure,
   and sourced-hold unsupported behavior in tests.
 

--- a/docs/architecture/travel-composer-implementation-plan.md
+++ b/docs/architecture/travel-composer-implementation-plan.md
@@ -272,7 +272,7 @@ Scope:
   - payment provider config
   - bank-transfer details
   - per-booking contract template choice
-  - CRM opportunity creation
+  - CRM Quote creation
   - storefront URLs
 - Expose a service callable by both the existing single-line journey and the
   future composer checkout step.
@@ -598,6 +598,6 @@ before requiring `verify:full`.
   surfaces before treating flights as live composer components.
 - Build support/admin UI for component-level cancellation preview, cancellation
   execution, and staff-remediation queues.
-- Decide whether the next commercial artifact is still only Trip Envelope +
-  Component refs, or whether a formal `PackageOffer` proposal artifact is
-  needed for quote approval, documents, and longer sales cycles.
+- Implement Quote Versions per ADR-0004 for quote approval, proposal
+  documents, and longer sales cycles while keeping reserve materialization at
+  component lifecycle boundaries.


### PR DESCRIPTION
## Summary

- Add ADR-0004 to ratify Quote as the travel-native sales artifact and Quote Version as the immutable proposal candidate.
- Rewrite the ubiquitous language entries that previously treated Opportunity as the deal and Quote as informational.
- Align the travel composer architecture docs with Quote Versions instead of a future PackageOffer artifact.

## Impact

This is the Phase 0 decision slice for issue #1541. It does not rename schema, routes, contracts, hooks, UI, or template migrations. Follow-up implementation PRs can target `feature/quotes-travel-native-sales-artifact` once this vocabulary decision lands there.

## Validation

- `pnpm verify:fast`
- broad pre-push test hook completed successfully when creating `feature/quotes-travel-native-sales-artifact`
