### PR TITLE
Align Quote ladder phrasing

### DIFF
--- a/docs/architecture/ai-travel-experience-composition.md
+++ b/docs/architecture/ai-travel-experience-composition.md
@@ -424,7 +424,7 @@ Current caveats:
 
 ADR-0004 makes the travel-native bespoke sales ladder:
 
-**Quote -> Quote Version -> reserve workflow -> Order / Booking -> Fulfillment**
+**Quote -> accepted Quote Version -> reserve workflow -> Order / Booking -> Fulfillment**
 
 The composer sits before and around that ladder:
 


### PR DESCRIPTION
## Summary

- Use the same canonical Quote ladder string in the composer architecture doc as the glossary.

## Context

PR #1556 merged before the final ladder phrasing tweak landed on its old head branch, so this follow-up carries just that one-line fix into `feature/quotes-travel-native-sales-artifact`.

## Validation

- `pnpm verify:fast`
