### PR TITLE
Commit typed currency in price catalog form (and fix label associations)

### DIFF
--- a/.changeset/price-catalog-currency-validation.md
+++ b/.changeset/price-catalog-currency-validation.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/commerce-react": patch
+"@voyant-travel/ui": patch
+---
+
+Fix the Settings → Price Catalogs create form silently dropping a typed currency. The currency control is a combobox whose committed value only changed when a row was picked from the list, so typing a code like `EUR` and submitting persisted a blank currency. The shared `CurrencyCombobox` now commits a fully-typed ISO code (case-insensitive) even when the matching row is never selected, and the price catalog form reuses that canonical picker instead of a local one that did not bind typed text to the form value. The currency input also forwards an `id`, and the price catalog dialog fields now associate their `<Label htmlFor>` with the inputs.

--- a/packages/commerce-react/src/pricing/components/price-catalogs-page.tsx
+++ b/packages/commerce-react/src/pricing/components/price-catalogs-page.tsx
@@ -23,19 +23,11 @@ import {
   SheetTitle,
   Switch,
 } from "@voyant-travel/ui/components"
-import {
-  Combobox,
-  ComboboxContent,
-  ComboboxEmpty,
-  ComboboxInput,
-  ComboboxItem,
-  ComboboxList,
-} from "@voyant-travel/ui/components/combobox"
+import { CurrencyCombobox } from "@voyant-travel/ui/components/currency-combobox"
 import { cn } from "@voyant-travel/ui/lib/utils"
 import { zodResolver } from "@voyant-travel/ui/lib/zod-resolver"
-import { currencies } from "@voyant-travel/utils/currencies"
 import { Loader2, MoreHorizontal, Pencil, Plus, Trash2 } from "lucide-react"
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useId, useMemo, useState } from "react"
 import { useForm } from "react-hook-form"
 import { z } from "zod/v4"
 import { usePricingUiMessagesOrDefault } from "../i18n/index.js"
@@ -45,11 +37,6 @@ import { type PriceCatalogRecord, usePriceCatalogMutation, usePriceCatalogs } fr
 const DEFAULT_PAGE_SIZE = 25
 
 const CATALOG_TYPES = ["public", "contract", "net", "gross", "promo", "internal", "other"] as const
-
-const CURRENCY_OPTIONS = Object.values(currencies).map((currency) => ({
-  value: currency.code,
-  label: `${currency.code} - ${currency.name} (${currency.symbol})`,
-}))
 
 type PriceCatalogsPageMessages = PricingUiMessages["priceCatalogsPage"]
 
@@ -238,38 +225,6 @@ function PriceCatalogsListLoading({ loadingLabel }: { loadingLabel: string }) {
   )
 }
 
-function CurrencyCombobox({
-  value,
-  onChange,
-  emptyLabel,
-  inputPlaceholder,
-}: {
-  value: string
-  onChange: (value: string) => void
-  emptyLabel: string
-  inputPlaceholder: string
-}) {
-  return (
-    <Combobox
-      items={CURRENCY_OPTIONS}
-      value={value}
-      onValueChange={(next) => onChange(String(next ?? ""))}
-    >
-      <ComboboxInput placeholder={inputPlaceholder} />
-      <ComboboxContent>
-        <ComboboxEmpty>{emptyLabel}</ComboboxEmpty>
-        <ComboboxList>
-          {CURRENCY_OPTIONS.map((option) => (
-            <ComboboxItem key={option.value} value={option.value}>
-              {option.label}
-            </ComboboxItem>
-          ))}
-        </ComboboxList>
-      </ComboboxContent>
-    </Combobox>
-  )
-}
-
 function CatalogSheet({
   open,
   onOpenChange,
@@ -284,6 +239,7 @@ function CatalogSheet({
   const messages = usePricingUiMessagesOrDefault().priceCatalogsPage
   const { create, update } = usePriceCatalogMutation()
   const catalogFormSchema = useMemo(() => getCatalogFormSchema(messages), [messages])
+  const fieldId = useId()
 
   const form = useForm<CatalogFormValues, unknown, CatalogFormOutput>({
     resolver: zodResolver(catalogFormSchema),
@@ -348,8 +304,9 @@ function CatalogSheet({
           <SheetBody className="grid gap-4">
             <div className="grid grid-cols-2 gap-4">
               <div className="flex flex-col gap-2">
-                <Label>{messages.nameLabel}</Label>
+                <Label htmlFor={`${fieldId}-name`}>{messages.nameLabel}</Label>
                 <Input
+                  id={`${fieldId}-name`}
                   {...form.register("name")}
                   placeholder={messages.namePlaceholder}
                   autoFocus
@@ -359,8 +316,12 @@ function CatalogSheet({
                 ) : null}
               </div>
               <div className="flex flex-col gap-2">
-                <Label>{messages.codeLabel}</Label>
-                <Input {...form.register("code")} placeholder={messages.codePlaceholder} />
+                <Label htmlFor={`${fieldId}-code`}>{messages.codeLabel}</Label>
+                <Input
+                  id={`${fieldId}-code`}
+                  {...form.register("code")}
+                  placeholder={messages.codePlaceholder}
+                />
                 {form.formState.errors.code ? (
                   <p className="text-xs text-destructive">{form.formState.errors.code.message}</p>
                 ) : null}
@@ -369,14 +330,13 @@ function CatalogSheet({
 
             <div className="grid grid-cols-2 gap-4">
               <div className="flex flex-col gap-2">
-                <Label>{messages.currencyLabel}</Label>
+                <Label htmlFor={`${fieldId}-currency`}>{messages.currencyLabel}</Label>
                 <CurrencyCombobox
-                  value={form.watch("currencyCode") ?? ""}
-                  onChange={(value) =>
-                    form.setValue("currencyCode", value || null, { shouldDirty: true })
-                  }
+                  id={`${fieldId}-currency`}
+                  value={form.watch("currencyCode") ?? null}
+                  onChange={(value) => form.setValue("currencyCode", value, { shouldDirty: true })}
                   emptyLabel={messages.noCurrenciesFound}
-                  inputPlaceholder={messages.selectCurrencyPlaceholder}
+                  placeholder={messages.selectCurrencyPlaceholder}
                 />
                 {form.formState.errors.currencyCode ? (
                   <p className="text-xs text-destructive">
@@ -428,8 +388,12 @@ function CatalogSheet({
             </div>
 
             <div className="flex flex-col gap-2">
-              <Label>{messages.notesLabel}</Label>
-              <Input {...form.register("notes")} placeholder={messages.notesPlaceholder} />
+              <Label htmlFor={`${fieldId}-notes`}>{messages.notesLabel}</Label>
+              <Input
+                id={`${fieldId}-notes`}
+                {...form.register("notes")}
+                placeholder={messages.notesPlaceholder}
+              />
             </div>
           </SheetBody>
           <SheetFooter>

--- a/packages/ui/src/components/currency-combobox.tsx
+++ b/packages/ui/src/components/currency-combobox.tsx
@@ -71,14 +71,6 @@ export function CurrencyCombobox({
   id,
   emptyLabel = "No currencies found.",
 }: CurrencyComboboxProps) {
-  const [search, setSearch] = React.useState("")
-
-  const filtered = React.useMemo(() => {
-    const q = search.trim()
-    if (!q) return ALL_CURRENCIES
-    return ALL_CURRENCIES.filter((c) => matchesSearch(c, q))
-  }, [search])
-
   const selected = value ? currencies[value as CurrencyCode] : undefined
   const selectedLabel = triggerLabel(selected)
   const [inputValue, setInputValue] = React.useState(selectedLabel)
@@ -88,6 +80,17 @@ export function CurrencyCombobox({
     setInputValue(selectedLabel)
   }, [selectedLabel])
 
+  // Treat the input as an active search only when it differs from the selected
+  // value's display label. When it equals that label — right after a commit, or
+  // when opened with an existing value — show the full list rather than
+  // filtering by the label (e.g. "EUR (€)"), which matches no item and would
+  // leave the dropdown empty.
+  const query = inputValue.trim() === selectedLabel.trim() ? "" : inputValue.trim()
+  const filtered = React.useMemo(() => {
+    if (!query) return ALL_CURRENCIES
+    return ALL_CURRENCIES.filter((c) => matchesSearch(c, query))
+  }, [query])
+
   return (
     <Combobox
       items={filtered.map((c) => c.code)}
@@ -95,10 +98,12 @@ export function CurrencyCombobox({
       inputValue={inputValue}
       autoHighlight
       disabled={disabled}
+      // We filter `items` ourselves (see `query`); disable Base UI's built-in
+      // filtering so it doesn't re-filter by the input label and empty the list.
+      filter={null}
       itemToStringValue={(code) => triggerLabel(currencies[code as CurrencyCode])}
       onInputValueChange={(next) => {
         setInputValue(next)
-        setSearch(next)
         if (!next.trim()) {
           onChange(null)
           return

--- a/packages/ui/src/components/currency-combobox.tsx
+++ b/packages/ui/src/components/currency-combobox.tsx
@@ -38,12 +38,29 @@ export interface CurrencyComboboxProps {
   placeholder?: string
   disabled?: boolean
   className?: string
+  /** Forwarded to the input so a `<Label htmlFor>` can associate with it. */
+  id?: string
+  /** Message shown when no currencies match the search. */
+  emptyLabel?: string
+}
+
+/** Resolve typed text to a canonical currency code, or `null` if it is not one. */
+function resolveTypedCurrencyCode(text: string): CurrencyCode | null {
+  const code = text.trim().toUpperCase()
+  if (code.length === 3 && Object.hasOwn(currencies, code)) {
+    return code as CurrencyCode
+  }
+  return null
 }
 
 /**
  * Currency picker backed by the canonical `currencies` list from
  * `@voyant-travel/utils`. Trigger displays `CODE (symbol)`; items display
  * `CODE — Name (symbol)`. Searchable across code, name, and symbol.
+ *
+ * Typing a full ISO code (e.g. `EUR`, case-insensitive) commits it even if the
+ * user never picks the matching row from the list, so a typed value is never
+ * silently dropped on submit.
  */
 export function CurrencyCombobox({
   value,
@@ -51,6 +68,8 @@ export function CurrencyCombobox({
   placeholder = "Select currency…",
   disabled,
   className,
+  id,
+  emptyLabel = "No currencies found.",
 }: CurrencyComboboxProps) {
   const [search, setSearch] = React.useState("")
 
@@ -80,7 +99,14 @@ export function CurrencyCombobox({
       onInputValueChange={(next) => {
         setInputValue(next)
         setSearch(next)
-        if (!next) onChange(null)
+        if (!next.trim()) {
+          onChange(null)
+          return
+        }
+        // Commit a fully-typed ISO code even when the user never selects the
+        // matching row from the list, so typed input is not silently dropped.
+        const typedCode = resolveTypedCurrencyCode(next)
+        if (typedCode && typedCode !== value) onChange(typedCode)
       }}
       onValueChange={(next) => {
         const code = (next as string | null) ?? null
@@ -89,13 +115,14 @@ export function CurrencyCombobox({
       }}
     >
       <ComboboxInput
+        id={id}
         className={className ?? "w-full"}
         placeholder={placeholder}
         disabled={disabled}
         showClear={Boolean(value) && !disabled}
       />
       <ComboboxContent>
-        <ComboboxEmpty>No currencies found.</ComboboxEmpty>
+        <ComboboxEmpty>{emptyLabel}</ComboboxEmpty>
         <ComboboxList>
           <ComboboxCollection>
             {(code) => {

--- a/packages/ui/tests/currency-combobox.test.tsx
+++ b/packages/ui/tests/currency-combobox.test.tsx
@@ -1,0 +1,65 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { CurrencyCombobox } from "../src/components/currency-combobox.js"
+
+afterEach(() => {
+  cleanup()
+})
+
+describe("CurrencyCombobox", () => {
+  it("commits a typed ISO code without selecting from the list", () => {
+    const onChange = vi.fn()
+    render(<CurrencyCombobox value={null} onChange={onChange} placeholder="Select currency" />)
+
+    const input = screen.getByRole("combobox")
+    fireEvent.change(input, { target: { value: "EUR" } })
+
+    expect(onChange).toHaveBeenCalledWith("EUR")
+  })
+
+  it("normalizes a lowercase typed code to upper case", () => {
+    const onChange = vi.fn()
+    render(<CurrencyCombobox value={null} onChange={onChange} placeholder="Select currency" />)
+
+    const input = screen.getByRole("combobox")
+    fireEvent.change(input, { target: { value: "usd" } })
+
+    expect(onChange).toHaveBeenCalledWith("USD")
+  })
+
+  it("does not commit a value while the typed text is not a full valid code", () => {
+    const onChange = vi.fn()
+    render(<CurrencyCombobox value={null} onChange={onChange} placeholder="Select currency" />)
+
+    const input = screen.getByRole("combobox")
+    fireEvent.change(input, { target: { value: "eu" } })
+    fireEvent.change(input, { target: { value: "ZZZ" } })
+
+    expect(onChange).not.toHaveBeenCalledWith("EU")
+    expect(onChange).not.toHaveBeenCalledWith("ZZZ")
+  })
+
+  it("clears the value when the input is emptied", () => {
+    const onChange = vi.fn()
+    render(<CurrencyCombobox value="EUR" onChange={onChange} placeholder="Select currency" />)
+
+    const input = screen.getByRole("combobox")
+    fireEvent.change(input, { target: { value: "" } })
+
+    expect(onChange).toHaveBeenCalledWith(null)
+  })
+
+  it("forwards an id to the input so a label can associate with it", () => {
+    render(
+      <CurrencyCombobox
+        id="catalog-currency"
+        value={null}
+        onChange={() => {}}
+        placeholder="Select currency"
+      />,
+    )
+
+    expect(screen.getByRole("combobox").id).toBe("catalog-currency")
+  })
+})


### PR DESCRIPTION
## What
Settings → Price Catalogs "Add Catalog" let you type a currency code (e.g. `EUR`) but persisted a blank currency with no error. The dialog used a local combobox whose committed value only changed when a row was picked from the list — typed text only filtered, it was never bound to the form value (issue #2650).

`currency_code` is intentionally nullable (NULL = multi-currency catalog), so forcing "required" would break a legitimate case. Per the issue's first option, the fix commits the typed value.

## Change
- `@voyant-travel/ui` `CurrencyCombobox`: commit a fully-typed ISO code (case-insensitive, must be a known 3-letter currency) even when the matching row is never selected, so typed input is never silently dropped. Additive new optional props `id` (for label association) and `emptyLabel`. Strict improvement for every currency picker.
- `@voyant-travel/commerce-react` price catalog form: reuse the shared `CurrencyCombobox` (drops a duplicate local one) and associate every field's `<Label htmlFor>`/`id` (addresses the issue's label-association note).

## Verification
- `@voyant-travel/ui` + `@voyant-travel/commerce-react`: typecheck / lint / test — pass (5 new combobox tests: typed commit, lowercase normalization, no-commit on partial/invalid, clear→null, id forwarding)
- `pnpm i18n:check` — pass (reused existing keys)

Fixes #2650