### PR TITLE
Fix legal policy PATCH and delete errors

### DIFF
--- a/.changeset/legal-policy-patch-delete-conflicts.md
+++ b/.changeset/legal-policy-patch-delete-conflicts.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/legal-contracts": patch
+"@voyant-travel/legal": patch
+---
+
+Fix legal policy PATCH schemas so omitted fields do not receive create defaults, and return a 409 conflict when deleting policies with recorded acceptances.

--- a/packages/legal-contracts/src/policies/validation.test.ts
+++ b/packages/legal-contracts/src/policies/validation.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+
+import { updatePolicyRuleSchema, updatePolicySchema } from "./validation.js"
+
+describe("policy update validation", () => {
+  it("does not apply create defaults to partial policy updates", () => {
+    expect(updatePolicySchema.parse({ description: "Updated" })).toEqual({
+      description: "Updated",
+    })
+  })
+
+  it("does not apply create defaults to partial policy rule updates", () => {
+    expect(updatePolicyRuleSchema.parse({ label: "Updated" })).toEqual({
+      label: "Updated",
+    })
+  })
+})

--- a/packages/legal-contracts/src/policies/validation.ts
+++ b/packages/legal-contracts/src/policies/validation.ts
@@ -43,6 +43,22 @@ const paginationSchema = z.object({
   offset: z.coerce.number().int().min(0).default(0),
 })
 
+type StripDefault<T extends z.core.SomeType> = T extends z.ZodDefault<infer U> ? U : T
+type StripDefaultShape<T extends z.ZodRawShape> = {
+  [K in keyof T]: StripDefault<T[K]>
+}
+
+const stripDefaultsFromShape = <T extends z.ZodRawShape>(shape: T): StripDefaultShape<T> =>
+  Object.fromEntries(
+    Object.entries(shape).map(([key, schema]) => [
+      key,
+      schema instanceof z.ZodDefault ? schema.unwrap() : schema,
+    ]),
+  ) as StripDefaultShape<T>
+
+const partialWithoutDefaults = <T extends z.ZodRawShape>(schema: z.ZodObject<T>) =>
+  z.object(stripDefaultsFromShape(schema.shape)).partial()
+
 // ---------- policies ----------
 
 const policyCoreSchema = z.object({
@@ -59,7 +75,7 @@ const policyCoreSchema = z.object({
 })
 
 export const insertPolicySchema = policyCoreSchema
-export const updatePolicySchema = policyCoreSchema.partial()
+export const updatePolicySchema = partialWithoutDefaults(policyCoreSchema)
 
 export const policyListQuerySchema = paginationSchema.extend({
   kind: policyKindSchema.optional(),
@@ -96,7 +112,7 @@ const policyRuleCoreSchema = z.object({
 })
 
 export const insertPolicyRuleSchema = policyRuleCoreSchema
-export const updatePolicyRuleSchema = policyRuleCoreSchema.partial()
+export const updatePolicyRuleSchema = partialWithoutDefaults(policyRuleCoreSchema)
 
 // ---------- policy_assignments ----------
 

--- a/packages/legal/src/policies/routes.ts
+++ b/packages/legal/src/policies/routes.ts
@@ -754,6 +754,10 @@ const deletePolicyRoute = createRoute({
       description: "Policy not found",
       content: { "application/json": { schema: errorResponseSchema } },
     },
+    409: {
+      description: "Policy has recorded acceptances and cannot be deleted",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
   },
 })
 
@@ -809,8 +813,12 @@ const policyRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook }
     return row ? c.json({ data: row }, 200) : c.json({ error: "Policy not found" }, 404)
   })
   .openapi(deletePolicyRoute, async (c) => {
-    const row = await policiesService.deletePolicy(c.get("db"), c.req.valid("param").id)
-    return row ? c.json({ success: true }, 200) : c.json({ error: "Policy not found" }, 404)
+    const result = await policiesService.deletePolicy(c.get("db"), c.req.valid("param").id)
+    if (result.status === "deleted") return c.json({ success: true }, 200)
+    if (result.status === "has_acceptances") {
+      return c.json({ error: "Policy has recorded acceptances and cannot be deleted" }, 409)
+    }
+    return c.json({ error: "Policy not found" }, 404)
   })
   .openapi(evaluatePolicyRoute, async (c) => {
     const result = await policiesService.evaluateCancellation(
@@ -894,7 +902,7 @@ export const policiesPublicRoutes = new OpenAPIHono<Env>({ defaultHook: openApiV
       return c.json({ error: "Policy has no published version" }, 404)
     }
     const version = await policiesService.getPolicyVersionById(c.get("db"), policy.currentVersionId)
-    if (!version || version.status !== "published") {
+    if (version?.status !== "published") {
       return c.json({ error: "Policy has no published version" }, 404)
     }
     cachePublicLegalRead(c)

--- a/packages/legal/src/policies/service-core.ts
+++ b/packages/legal/src/policies/service-core.ts
@@ -82,11 +82,37 @@ export const policiesCoreService = {
     return row ?? null
   },
   async deletePolicy(db: PostgresJsDatabase, id: string) {
+    const [policy] = await db
+      .select({ id: policies.id })
+      .from(policies)
+      .where(eq(policies.id, id))
+      .limit(1)
+    if (!policy) return { status: "not_found" as const }
+
+    const [acceptance] = await db
+      .select({ id: policyAcceptances.id })
+      .from(policyAcceptances)
+      .where(
+        exists(
+          db
+            .select({ id: policyVersions.id })
+            .from(policyVersions)
+            .where(
+              and(
+                eq(policyVersions.policyId, id),
+                eq(policyVersions.id, policyAcceptances.policyVersionId),
+              ),
+            ),
+        ),
+      )
+      .limit(1)
+    if (acceptance) return { status: "has_acceptances" as const }
+
     const [row] = await db
       .delete(policies)
       .where(eq(policies.id, id))
       .returning({ id: policies.id })
-    return row ?? null
+    return row ? { status: "deleted" as const, id: row.id } : { status: "not_found" as const }
   },
   listPolicyVersions(db: PostgresJsDatabase, policyId: string) {
     return db

--- a/packages/legal/tests/integration/policy-routes.test.ts
+++ b/packages/legal/tests/integration/policy-routes.test.ts
@@ -1,0 +1,134 @@
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { Hono } from "hono"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { policiesAdminRoutes } from "../../src/policies/routes.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+const json = (body: Record<string, unknown>) => ({
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(body),
+})
+
+async function createPolicy(app: Hono, slug: string, language = "en") {
+  const res = await app.request("/", {
+    method: "POST",
+    ...json({
+      kind: "cancellation",
+      name: slug,
+      slug,
+      language,
+    }),
+  })
+  expect(res.status).toBe(201)
+  return (await res.json()).data as { id: string; language: string }
+}
+
+async function createPolicyVersion(app: Hono, policyId: string, title: string) {
+  const res = await app.request(`/${policyId}/versions`, {
+    method: "POST",
+    ...json({
+      title,
+      body: `${title} body`,
+    }),
+  })
+  expect(res.status).toBe(201)
+  return (await res.json()).data as { id: string }
+}
+
+describe.skipIf(!DB_AVAILABLE)("Legal policy admin routes", () => {
+  let app: Hono
+  let db: PostgresJsDatabase
+
+  beforeAll(async () => {
+    const { createTestDb, cleanupTestDb } = await import("@voyant-travel/db/test-utils")
+    db = createTestDb()
+    await cleanupTestDb(db)
+
+    app = new Hono()
+    app.use("*", async (c, next) => {
+      c.set("db" as never, db)
+      await next()
+    })
+    app.route("/", policiesAdminRoutes)
+  })
+
+  beforeEach(async () => {
+    const { cleanupTestDb } = await import("@voyant-travel/db/test-utils")
+    await cleanupTestDb(db)
+  })
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyant-travel/db/test-utils")
+    await closeTestDb()
+  })
+
+  it("preserves policy language when PATCH omits language", async () => {
+    const policy = await createPolicy(app, "partial-policy-ro", "ro")
+
+    const res = await app.request(`/${policy.id}`, {
+      method: "PATCH",
+      ...json({ description: "Descriere actualizata" }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toEqual(
+      expect.objectContaining({
+        description: "Descriere actualizata",
+        language: "ro",
+      }),
+    )
+  })
+
+  it("preserves policy rule sort order when PATCH omits sortOrder", async () => {
+    const policy = await createPolicy(app, "partial-rule-sort")
+    const version = await createPolicyVersion(app, policy.id, "Cancellation")
+    const created = await app.request(`/versions/${version.id}/rules`, {
+      method: "POST",
+      ...json({
+        ruleType: "window",
+        label: "Original",
+        sortOrder: 3,
+      }),
+    })
+    expect(created.status).toBe(201)
+    const rule = (await created.json()).data as { id: string }
+
+    const res = await app.request(`/rules/${rule.id}`, {
+      method: "PATCH",
+      ...json({ label: "Updated" }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toEqual(
+      expect.objectContaining({
+        label: "Updated",
+        sortOrder: 3,
+      }),
+    )
+  })
+
+  it("returns 409 instead of deleting a policy with recorded acceptances", async () => {
+    const policy = await createPolicy(app, "policy-with-acceptance")
+    const version = await createPolicyVersion(app, policy.id, "Accepted terms")
+    const acceptance = await app.request("/acceptances", {
+      method: "POST",
+      ...json({
+        policyVersionId: version.id,
+        personId: "people_policy_delete_conflict",
+        method: "explicit_checkbox",
+      }),
+    })
+    expect(acceptance.status).toBe(201)
+
+    const res = await app.request(`/${policy.id}`, { method: "DELETE" })
+
+    expect(res.status).toBe(409)
+    await expect(res.json()).resolves.toEqual({
+      error: "Policy has recorded acceptances and cannot be deleted",
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- prevent legal policy and policy rule PATCH schemas from applying create defaults to omitted fields
- return a documented 409 conflict when deleting a policy with recorded acceptances, preserving acceptance history
- add focused regression coverage and patch changesets for legal contracts/legal

Fixes #2460

## Checks
- pnpm --filter @voyant-travel/legal-contracts test
- pnpm --filter @voyant-travel/legal test -- tests/integration/policy-routes.test.ts
- pnpm --filter @voyant-travel/legal-contracts typecheck
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/legal typecheck
- pnpm --filter @voyant-travel/legal-contracts lint
- pnpm --filter @voyant-travel/legal lint
- pnpm lint:changed
- pnpm verify:agent-quality:changed
- pnpm changeset status --since=origin/main

Note: TEST_DATABASE_URL was unset locally, so DB-gated legal integration tests were skipped.