### PR TITLE
Honor catalog:search scope on admin catalog search

### DIFF
--- a/.changeset/catalog-search-scope-api-key.md
+++ b/.changeset/catalog-search-scope-api-key.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/hono": patch
+---
+
+Honor the `search` action for API-key/staff scopes on `POST /v1/<surface>/*/search` routes. Search endpoints are exposed as POST (complex bodies) but are read-family operations, so a token scoped `catalog:search`/`catalog:read` was previously rejected with 403 on `POST /v1/admin/catalog/search`. Non-search POST routes (product writes, bookings, pricing, …) stay gated on their normal write actions.

--- a/packages/hono/src/middleware/require-actor.ts
+++ b/packages/hono/src/middleware/require-actor.ts
@@ -15,7 +15,7 @@ function apiKeyResourceFromPath(pathname: string): string | null {
   return null
 }
 
-function apiKeyPermissionActionsForMethod(method: string): string[] {
+function baseApiKeyPermissionActionsForMethod(method: string): string[] {
   switch (method.toUpperCase()) {
     case "GET":
     case "HEAD":
@@ -30,6 +30,26 @@ function apiKeyPermissionActionsForMethod(method: string): string[] {
     default:
       return []
   }
+}
+
+/**
+ * Search endpoints accept complex request bodies, so they're exposed as `POST`
+ * even though they're read-family operations. Without this, `POST
+ * /v1/<surface>/catalog/search` would only accept `write`/`trigger`/`relay`,
+ * and a `catalog:search`/`catalog:read`-scoped token would be rejected
+ * (voyant#2649). Matching only `/search` sub-paths keeps every other POST route
+ * (product writes, bookings, pricing, …) gated on its normal write actions.
+ */
+function isSearchPath(pathname: string): boolean {
+  return /\/search(?:\/|$)/.test(pathname)
+}
+
+function apiKeyPermissionActionsForMethod(method: string, pathname: string): string[] {
+  const actions = baseApiKeyPermissionActionsForMethod(method)
+  if (isSearchPath(pathname)) {
+    return Array.from(new Set([...actions, "search", "read"]))
+  }
+  return actions
 }
 
 function hasAnyApiKeyPermission(
@@ -129,7 +149,7 @@ export function requireActor<TBindings extends VoyantBindings = VoyantBindings>(
       // is a reserved namespace (no module is named `_meta`).
       if (resource === "_meta") return next()
 
-      const actions = apiKeyPermissionActionsForMethod(c.req.method)
+      const actions = apiKeyPermissionActionsForMethod(c.req.method, pathname)
 
       if (resource && hasAnyApiKeyPermission(c.get("scopes"), resource, actions)) {
         return next()
@@ -167,7 +187,7 @@ export function requireActor<TBindings extends VoyantBindings = VoyantBindings>(
       })
       const resource = apiKeyResourceFromPath(pathname)
       if (resource && resource !== "_meta") {
-        const actions = apiKeyPermissionActionsForMethod(c.req.method)
+        const actions = apiKeyPermissionActionsForMethod(c.req.method, pathname)
         if (!hasAnyApiKeyPermission(scopes, resource, actions)) {
           return c.json({ error: "Forbidden: missing required permission" }, 403)
         }

--- a/packages/hono/src/middleware/require-actor.ts
+++ b/packages/hono/src/middleware/require-actor.ts
@@ -37,11 +37,14 @@ function baseApiKeyPermissionActionsForMethod(method: string): string[] {
  * even though they're read-family operations. Without this, `POST
  * /v1/<surface>/catalog/search` would only accept `write`/`trigger`/`relay`,
  * and a `catalog:search`/`catalog:read`-scoped token would be rejected
- * (voyant#2649). Matching only `/search` sub-paths keeps every other POST route
+ * (voyant#2649). Matching a `search` / `*-search` path segment (e.g.
+ * `/catalog/search`, `/catalog/package-search`) keeps every other POST route
  * (product writes, bookings, pricing, …) gated on its normal write actions.
  */
 function isSearchPath(pathname: string): boolean {
-  return /\/search(?:\/|$)/.test(pathname)
+  // A segment that is `search` or ends in `-search` (e.g. `package-search`),
+  // bounded so `/searchable` or `/researcher` don't count.
+  return /(?:\/|-)search(?:\/|$)/.test(pathname)
 }
 
 function apiKeyPermissionActionsForMethod(method: string, pathname: string): string[] {

--- a/packages/hono/tests/unit/require-actor.test.ts
+++ b/packages/hono/tests/unit/require-actor.test.ts
@@ -214,6 +214,56 @@ describe("requireActor", () => {
     expect(webhook.status).toBe(200)
   })
 
+  it("honors the search action on a POST /search endpoint (voyant#2649)", async () => {
+    // Catalog search is exposed as POST (complex body) but is a read-family
+    // operation, so a `catalog:search`/`catalog:read` token must reach it.
+    const searchToken = () =>
+      makeApp((c) => {
+        c.set("callerType", "api_key")
+        c.set("scopes", ["catalog:read", "catalog:search"])
+      })
+
+    const admin = searchToken()
+    admin.use("*", requireActor("staff"))
+    admin.post("/v1/admin/catalog/search", (c) => c.json({ ok: true }))
+    expect((await admin.request("/v1/admin/catalog/search", { method: "POST" })).status).toBe(200)
+
+    const publicApp = searchToken()
+    publicApp.use("*", requireActor("customer", "partner", "supplier"))
+    publicApp.post("/v1/public/catalog/search", (c) => c.json({ ok: true }))
+    expect((await publicApp.request("/v1/public/catalog/search", { method: "POST" })).status).toBe(
+      200,
+    )
+
+    // A bare `catalog:search` scope alone is sufficient.
+    const searchOnly = makeApp((c) => {
+      c.set("callerType", "api_key")
+      c.set("scopes", ["catalog:search"])
+    })
+    searchOnly.use("*", requireActor("staff"))
+    searchOnly.post("/v1/admin/catalog/search", (c) => c.json({ ok: true }))
+    expect((await searchOnly.request("/v1/admin/catalog/search", { method: "POST" })).status).toBe(
+      200,
+    )
+  })
+
+  it("still gates non-search POST routes for a search/read-only token (voyant#2649)", async () => {
+    // The search relaxation must not leak into write routes.
+    const build = () => {
+      const app = makeApp((c) => {
+        c.set("callerType", "api_key")
+        c.set("scopes", ["catalog:read", "catalog:search", "products:read"])
+      })
+      app.use("*", requireActor("staff"))
+      app.post("/v1/admin/products", (c) => c.json({ ok: true }))
+      app.post("/v1/admin/bookings", (c) => c.json({ ok: true }))
+      return app
+    }
+
+    expect((await build().request("/v1/admin/products", { method: "POST" })).status).toBe(403)
+    expect((await build().request("/v1/admin/bookings", { method: "POST" })).status).toBe(403)
+  })
+
   it("passes through OPTIONS preflight requests", async () => {
     const app = makeApp((c) => c.set("actor", "customer"))
     app.use("*", requireActor("staff"))

--- a/packages/hono/tests/unit/require-actor.test.ts
+++ b/packages/hono/tests/unit/require-actor.test.ts
@@ -242,9 +242,14 @@ describe("requireActor", () => {
     })
     searchOnly.use("*", requireActor("staff"))
     searchOnly.post("/v1/admin/catalog/search", (c) => c.json({ ok: true }))
+    // Hyphenated search endpoints (e.g. POST /catalog/package-search) count too.
+    searchOnly.post("/v1/admin/catalog/package-search", (c) => c.json({ ok: true }))
     expect((await searchOnly.request("/v1/admin/catalog/search", { method: "POST" })).status).toBe(
       200,
     )
+    expect(
+      (await searchOnly.request("/v1/admin/catalog/package-search", { method: "POST" })).status,
+    ).toBe(200)
   })
 
   it("still gates non-search POST routes for a search/read-only token (voyant#2649)", async () => {
@@ -257,11 +262,16 @@ describe("requireActor", () => {
       app.use("*", requireActor("staff"))
       app.post("/v1/admin/products", (c) => c.json({ ok: true }))
       app.post("/v1/admin/bookings", (c) => c.json({ ok: true }))
+      // A write route whose name merely contains "search" must stay gated.
+      app.post("/v1/admin/products/searchable", (c) => c.json({ ok: true }))
       return app
     }
 
     expect((await build().request("/v1/admin/products", { method: "POST" })).status).toBe(403)
     expect((await build().request("/v1/admin/bookings", { method: "POST" })).status).toBe(403)
+    expect(
+      (await build().request("/v1/admin/products/searchable", { method: "POST" })).status,
+    ).toBe(403)
   })
 
   it("passes through OPTIONS preflight requests", async () => {


### PR DESCRIPTION
## What
An API token with the `Catalog read` preset (which includes `catalog:search`) got `403` on `POST /v1/admin/catalog/search`, even though the same token could read products and sessions worked fine (issue #2649).

## Root cause
The API-key scope guard in `packages/hono/src/middleware/require-actor.ts` derives the required *action* purely from the HTTP method: `POST → write/trigger/relay`. Catalog search is exposed as `POST` (it takes a complex JSON body) but is a **read-family** operation, so the guard only ever accepted `catalog:write`-family scopes — a `catalog:search`/`catalog:read` token was rejected.

## Change
Make the action derivation path-aware: for `/search` path segments, additionally accept the `search` and `read` actions. Purely additive and scoped to `/search` routes — every non-search `POST` (product writes, bookings, suppliers, pricing) stays gated on `write` exactly as before. Applied at both guard call sites (api-key and staff-session RBAC).

## Verification
- `pnpm --filter @voyant-travel/hono` typecheck / lint / test — pass (251 tests). New regression tests: `catalog:search`/`catalog:read` (and bare `catalog:search`) authorized for admin+public catalog search; a search/read-only token still `403` on `POST /v1/admin/products` and `/v1/admin/bookings`.

Fixes #2649