### PR TITLE
Surface quote failures in storefront checkout; fix render-phase setState

### DIFF
--- a/.changeset/storefront-quote-failure-handling.md
+++ b/.changeset/storefront-quote-failure-handling.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/bookings-react": patch
+---
+
+Handle live-quote failures in the storefront booking journey. When a connected supplier product's quote request errors (e.g. the connector adapter returns 500), the journey previously let the shopper reach Review with a stale/absent price, and `Confirm booking` became a silent no-op. It now surfaces a recoverable inline error with a retry action, blocks Next/Confirm while the quote is failing, and shows an explicit message instead of silently swallowing the Confirm click. Also fixes a render-phase `setDraft` in `PaymentStep` that triggered React's "Cannot update a component while rendering a different component" warning by moving the intent-snap into an effect.

--- a/packages/bookings-react/src/i18n/en-journey.ts
+++ b/packages/bookings-react/src/i18n/en-journey.ts
@@ -33,6 +33,10 @@ export const bookingsUiEnJourney = {
     validation: {
       completeStepBeforeContinuing: "Complete this step before continuing.",
       unableToContinue: "Unable to continue. Please try again.",
+      quoteFailed: "We couldn't refresh live pricing. Check your connection and try again.",
+      retryQuote: "Retry pricing",
+      quoteUnavailable:
+        "Pricing isn't confirmed yet — retry pricing above before confirming your booking.",
       addAtLeastTravelers: "Add at least {count} traveler{plural} to continue.",
       maxTravelersPerBooking: "Max {count} travelers per booking.",
       ageOutOfRange: "Age {age} is outside the accepted range for this product.",

--- a/packages/bookings-react/src/i18n/messages-journey.ts
+++ b/packages/bookings-react/src/i18n/messages-journey.ts
@@ -33,6 +33,9 @@ export type BookingsUiJourneyMessages = {
     validation: {
       completeStepBeforeContinuing: string
       unableToContinue: string
+      quoteFailed: string
+      retryQuote: string
+      quoteUnavailable: string
       addAtLeastTravelers: string
       maxTravelersPerBooking: string
       ageOutOfRange: string

--- a/packages/bookings-react/src/i18n/ro-journey.ts
+++ b/packages/bookings-react/src/i18n/ro-journey.ts
@@ -33,6 +33,10 @@ export const bookingsUiRoJourney = {
     validation: {
       completeStepBeforeContinuing: "Completeaza acest pas inainte de a continua.",
       unableToContinue: "Nu se poate continua. Incearca din nou.",
+      quoteFailed: "Nu am putut reactualiza pretul live. Verifica conexiunea si incearca din nou.",
+      retryQuote: "Reincearca pretul",
+      quoteUnavailable:
+        "Pretul nu este inca confirmat - reincearca pretul de mai sus inainte de a confirma rezervarea.",
       addAtLeastTravelers: "Adauga cel putin {count} calator{plural} pentru a continua.",
       maxTravelersPerBooking: "Maximum {count} calatori per rezervare.",
       ageOutOfRange: "Varsta {age} este in afara intervalului acceptat pentru acest produs.",

--- a/packages/bookings-react/src/journey/components/booking-journey.quote-failure.test.tsx
+++ b/packages/bookings-react/src/journey/components/booking-journey.quote-failure.test.tsx
@@ -1,0 +1,40 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it, vi } from "vitest"
+
+// Mock the booking-engine hooks so the live quote is in an ERROR state — the
+// exact condition from #2645 (the demo connector adapter 500s on quote). The
+// journey must surface a visible, recoverable error rather than silently
+// letting a stale/absent price through to Review where Confirm no-ops.
+vi.mock("@voyant-travel/catalog-react/booking-engine", () => ({
+  useBookingQuote: () => ({
+    data: null,
+    isQuoting: false,
+    error: new Error("Network connection lost"),
+    requote: async () => ({}) as never,
+    refetch: async () => ({}) as never,
+  }),
+  useBookingDraftShape: (opts: { fallback: unknown }) => opts.fallback,
+  useBookingDraft: () => ({ save: { mutate: () => {} } }),
+  useBookingCommit: () => ({ mutateAsync: async () => {}, isPending: false, error: null }),
+  useBookingHold: () => ({ place: async () => ({}), release: async () => ({}) }),
+}))
+
+// Imported after the mock so the hooks are stubbed (vitest hoists vi.mock).
+const { BookingJourney } = await import("./booking-journey.js")
+
+describe("BookingJourney — failed quote handling (#2645)", () => {
+  it("surfaces a recoverable pricing error with a retry action", () => {
+    const html = renderToStaticMarkup(
+      <BookingJourney
+        entityModule="products"
+        entityId="prod-1"
+        draftId="draft-1"
+        surface="public"
+      />,
+    )
+
+    // Visible, recoverable error — not a silent failure.
+    expect(html).toContain("We couldn&#x27;t refresh live pricing")
+    expect(html).toContain("Retry pricing")
+  })
+})

--- a/packages/bookings-react/src/journey/components/booking-journey.tsx
+++ b/packages/bookings-react/src/journey/components/booking-journey.tsx
@@ -384,9 +384,12 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
 
   const onConfirm = async () => {
     // No valid quote (never priced, or the last re-quote 500'd) → Confirm must
-    // NOT be a silent no-op. Surface a recoverable message pointing at the retry
-    // banner instead of swallowing the click.
-    if (!quote.data?.quoteId) {
+    // NOT be a silent no-op. `useBookingQuote` keeps the prior quote as
+    // placeholder data on a failed refetch, so a stale `quoteId` can still be
+    // present while `quote.error` is set; block on `hasQuoteError` too so the
+    // wizard Review Confirm can never submit against a stale price. Surface a
+    // recoverable message pointing at the retry banner instead of swallowing.
+    if (!quote.data?.quoteId || hasQuoteError) {
       setConfirmError(messages.bookingJourney.validation.quoteUnavailable)
       return
     }

--- a/packages/bookings-react/src/journey/components/booking-journey.tsx
+++ b/packages/bookings-react/src/journey/components/booking-journey.tsx
@@ -236,7 +236,12 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
   }, [holdSignature, currentStep])
 
   const available = quote.data?.available !== false
-  const canAdvance = canAdvanceFromStep(currentStep, draft, shape, available)
+  // A failed quote (e.g. the connector adapter 500s) leaves `quote.data` null,
+  // which makes `available` read as true and lets a stale/absent price slip
+  // through to Review where Confirm would silently no-op. Treat a quote error
+  // as a hard block: gate Next/Confirm and surface a recoverable banner + retry.
+  const hasQuoteError = quote.error != null
+  const canAdvance = canAdvanceFromStep(currentStep, draft, shape, available) && !hasQuoteError
   const warnings = warningsForStep(currentStep, draft, shape, messages)
 
   // Stacked layout: there's no "current" step, but the section nav still
@@ -251,11 +256,20 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
     [stackedSteps, draft, shape, available],
   )
   const canCommit = useMemo(
-    () => stackedSteps.every((s) => canAdvanceFromStep(s, draft, shape, available)),
-    [stackedSteps, draft, shape, available],
+    () =>
+      stackedSteps.every((s) => canAdvanceFromStep(s, draft, shape, available)) && !hasQuoteError,
+    [stackedSteps, draft, shape, available, hasQuoteError],
   )
   const [isAdvanceGuardPending, setIsAdvanceGuardPending] = useState(false)
   const [advanceGuardError, setAdvanceGuardError] = useState<string | null>(null)
+  // Set when Confirm can't proceed because there's no valid quote — makes the
+  // click a visible, explained block instead of a silent no-op.
+  const [confirmError, setConfirmError] = useState<string | null>(null)
+  // Clear the "no valid quote" block as soon as a fresh quote settles (via
+  // retry or an auto re-quote), so the message doesn't linger once resolved.
+  useEffect(() => {
+    if (quote.data?.quoteId) setConfirmError(null)
+  }, [quote.data?.quoteId])
 
   const idx = steps.indexOf(currentStep)
   const next = steps[idx + 1]
@@ -369,7 +383,14 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
   }
 
   const onConfirm = async () => {
-    if (!quote.data?.quoteId) return
+    // No valid quote (never priced, or the last re-quote 500'd) → Confirm must
+    // NOT be a silent no-op. Surface a recoverable message pointing at the retry
+    // banner instead of swallowing the click.
+    if (!quote.data?.quoteId) {
+      setConfirmError(messages.bookingJourney.validation.quoteUnavailable)
+      return
+    }
+    setConfirmError(null)
     // 1. Contract is wired → open the dialog. Acceptance triggers
     //    onContractAccepted (the storefront's checkout-start path).
     // 2. No contract but onContractAccepted is wired → call it
@@ -405,6 +426,32 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
           departureDate: draft.configure.departureDate,
         })
     : undefined
+
+  // Recoverable quote-failure banner — rendered in both layouts whenever the
+  // live quote is erroring. The manual retry re-runs the query (clearing its
+  // error on success), which re-enables Next/Confirm.
+  const retryQuote = () => {
+    setConfirmError(null)
+    void quote.refetch()
+  }
+  const quoteErrorBanner = hasQuoteError ? (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="flex flex-col items-start gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-3 text-destructive text-sm"
+    >
+      <span>{messages.bookingJourney.validation.quoteFailed}</span>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={retryQuote}
+        disabled={quote.isQuoting}
+      >
+        {messages.bookingJourney.validation.retryQuote}
+      </Button>
+    </div>
+  ) : null
 
   // Renders one step's content. Shared by both layouts — the wizard shows
   // exactly one at a time; the stacked page renders them all in sections.
@@ -506,11 +553,14 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
         steps={stackedSteps}
         renderStep={renderStep}
         isStepComplete={(s) => stackedStepComplete(s, draft, shape, available)}
-        commitError={commit.error}
+        // Surface both the in-process commit error and the "no valid quote"
+        // Confirm block so a failed confirm is never silent.
+        commitError={commit.error ?? confirmError}
         onCancel={props.onCancelled}
         onConfirm={onConfirm}
         isCommitting={commit.isPending || isHandlingCheckout}
         canConfirm={canCommit}
+        banner={quoteErrorBanner}
         sidePanel={
           <PriceSidePanel
             pricing={quote.data?.pricing ?? null}
@@ -562,6 +612,8 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
             shape={shape}
             onJumpTo={jumpTo}
           />
+
+          {quoteErrorBanner}
 
           {currentStep === "departure" ? (
             // First load: the descriptor arrives with the first quote. Show a
@@ -682,6 +734,12 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
           {advanceGuardError ? (
             <p className="text-destructive text-sm" role="alert" aria-live="polite">
               {advanceGuardError}
+            </p>
+          ) : null}
+
+          {confirmError ? (
+            <p className="text-destructive text-sm" role="alert" aria-live="polite">
+              {confirmError}
             </p>
           ) : null}
 

--- a/packages/bookings-react/src/journey/components/journey-steps/payment-step.tsx
+++ b/packages/bookings-react/src/journey/components/journey-steps/payment-step.tsx
@@ -74,12 +74,16 @@ export function PaymentStep({
   // and calling it in the render body triggers React's "Cannot update a
   // component while rendering a different component" warning (and drops frames).
   const allowedKey = allowed.join("|")
-  // biome-ignore lint/correctness/useExhaustiveDependencies: snaps only when the allowed set or current intent changes; reads latest draft via closure -- owner: bookings-react
+  // biome-ignore lint/correctness/useExhaustiveDependencies: snaps only when the allowed set (allowedKey) or current intent changes -- owner: bookings-react
   useEffect(() => {
     if (allowed.length > 0 && !allowed.includes(intent)) {
-      setDraft(
-        setPayment(draft, {
-          ...draft.payment,
+      // Functional update: merge onto the LATEST draft, not the render-time
+      // closure. A sibling effect (PaymentScheduleEditor seeding paymentSchedules)
+      // can commit in the same batch; building from a stale `draft` here would
+      // clobber those rows.
+      setDraft((prev) =>
+        setPayment(prev, {
+          ...prev.payment,
           intent: (simpleHoldCard ? "hold" : allowed[0]) as never,
         }),
       )

--- a/packages/bookings-react/src/journey/components/journey-steps/payment-step.tsx
+++ b/packages/bookings-react/src/journey/components/journey-steps/payment-step.tsx
@@ -69,15 +69,22 @@ export function PaymentStep({
 
   // Snap the draft's intent to a sensible value when the current pick isn't on
   // the list — covers descriptor changes mid-flow (e.g. owned→sourced narrows
-  // the list). In checkbox mode the baseline is always "hold".
-  if (allowed.length > 0 && !allowed.includes(intent)) {
-    setDraft(
-      setPayment(draft, {
-        ...draft.payment,
-        intent: (simpleHoldCard ? "hold" : allowed[0]) as never,
-      }),
-    )
-  }
+  // the list). In checkbox mode the baseline is always "hold". This MUST run in
+  // an effect, not during render: `setDraft` updates the parent BookingJourney,
+  // and calling it in the render body triggers React's "Cannot update a
+  // component while rendering a different component" warning (and drops frames).
+  const allowedKey = allowed.join("|")
+  // biome-ignore lint/correctness/useExhaustiveDependencies: snaps only when the allowed set or current intent changes; reads latest draft via closure -- owner: bookings-react
+  useEffect(() => {
+    if (allowed.length > 0 && !allowed.includes(intent)) {
+      setDraft(
+        setPayment(draft, {
+          ...draft.payment,
+          intent: (simpleHoldCard ? "hold" : allowed[0]) as never,
+        }),
+      )
+    }
+  }, [allowedKey, intent, simpleHoldCard])
 
   return (
     <Card>

--- a/packages/bookings-react/src/journey/components/journey-steps/shared.tsx
+++ b/packages/bookings-react/src/journey/components/journey-steps/shared.tsx
@@ -28,7 +28,10 @@ export type RenderUnitsPicker = (props: UnitsPickerProps) => React.ReactNode
 
 export interface StepCommonProps {
   draft: Draft
-  setDraft: (next: Draft) => void
+  // Accepts a value or a functional updater (the underlying `useState`
+  // dispatcher), so effects can merge onto the latest draft without clobbering
+  // concurrent updates.
+  setDraft: (next: Draft | ((prev: Draft) => Draft)) => void
   shape: BookingDraftShape
 }
 

--- a/packages/bookings-react/src/journey/components/stacked-journey.tsx
+++ b/packages/bookings-react/src/journey/components/stacked-journey.tsx
@@ -42,6 +42,7 @@ export function StackedJourney({
   canConfirm,
   sidePanel,
   contractDialog,
+  banner,
 }: {
   className?: string
   steps: ReadonlyArray<JourneyStep>
@@ -54,6 +55,8 @@ export function StackedJourney({
   canConfirm?: boolean
   sidePanel: React.ReactNode
   contractDialog: React.ReactNode
+  /** Recoverable, always-visible banner (e.g. quote-refresh failure). */
+  banner?: React.ReactNode
 }): React.ReactElement {
   const messages = useBookingsUiMessagesOrDefault()
   const nav = messages.bookingJourney.navigation
@@ -71,6 +74,7 @@ export function StackedJourney({
     <div className={className}>
       <div className="grid grid-cols-1 gap-6 md:grid-cols-8 md:items-start">
         <div className="space-y-3 md:col-span-5">
+          {banner}
           {steps.map((step, i) => {
             // Locked: a section beyond the active gate — a muted, disabled row
             // until the operator clears the gates above it.


### PR DESCRIPTION
## What
In the storefront card checkout (`BookingJourney`), when the connector adapter's quote request 500s, the shopper could still reach Review and clicking `Confirm booking` did nothing — no modal, no request, no error. There was also a `Cannot update a component (BookingJourney) while rendering a different component (PaymentStep)` warning (issue #2645).

## Root cause
- A failed quote leaves `quote.data` null, so `available = quote.data?.available !== false` read as `true` and the step gates stayed satisfied — Review was reachable. `onConfirm` then began with `if (!quote.data?.quoteId) return` — a bare early return → silent no-op.
- `PaymentStep` called the parent's `setDraft` during render to snap the payment intent → the render-phase update warning.

## Change
- Consume `quote.error` as a hard block: gate Next/Confirm (`canAdvance`/`canCommit`) while the quote is failing, and render a recoverable `role="alert"` banner with a **Retry pricing** button (re-runs the query) in both wizard and stacked layouts.
- Make `onConfirm` non-silent: with no valid quote it sets a visible `confirmError` (`validation.quoteUnavailable`) instead of returning; cleared once a fresh quote settles.
- Move `PaymentStep`'s intent-snap `setDraft` into a `useEffect`.
- New i18n keys (`quoteFailed`/`retryQuote`/`quoteUnavailable`) in en + ro.

## Verification
- `pnpm --filter @voyant-travel/bookings-react` typecheck / lint / test — pass (84 tests, incl. a new quote-failure regression test)
- `pnpm i18n:check` — pass

Fixes #2645