### PR TITLE
fix(operator): gate storefront trip composer behind a session

### DIFF
--- a/starters/operator/src/lib/storefront-i18n.tsx
+++ b/starters/operator/src/lib/storefront-i18n.tsx
@@ -230,6 +230,13 @@ const storefrontMessagesEn = {
   bookingJourney: {
     marketingLabel: "Email me occasional updates about new tours and promotions.",
   },
+  composer: {
+    gateTitle: "Sign in to build a trip",
+    gateBody:
+      "The trip composer saves a working draft against your account, so you need to be signed in before you can start one. Browsing and booking individual items stays open to everyone.",
+    gateSignIn: "Sign in to continue",
+    gateBrowse: "Back to browsing",
+  },
 }
 
 export type StorefrontMessages = typeof storefrontMessagesEn
@@ -439,6 +446,13 @@ const storefrontMessagesRo: StorefrontMessages = {
   },
   bookingJourney: {
     marketingLabel: "Trimite-mi ocazional noutati despre tururi noi si promotii.",
+  },
+  composer: {
+    gateTitle: "Autentifica-te pentru a construi o calatorie",
+    gateBody:
+      "Compozitorul de calatorie salveaza o ciorna de lucru in contul tau, asa ca trebuie sa fii autentificat inainte de a incepe. Navigarea si rezervarea produselor individuale raman deschise tuturor.",
+    gateSignIn: "Autentifica-te pentru a continua",
+    gateBrowse: "Inapoi la navigare",
   },
 }
 

--- a/starters/operator/src/routes/(storefront)/shop_.composer.tsx
+++ b/starters/operator/src/routes/(storefront)/shop_.composer.tsx
@@ -1,7 +1,59 @@
-import { createFileRoute } from "@tanstack/react-router"
+"use client"
+
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { buttonVariants } from "@voyant-travel/ui/components/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@voyant-travel/ui/components/card"
+import { LogIn, Route as RouteIcon } from "lucide-react"
 
 import { StorefrontComposerBlock } from "@/components/voyant/trips/storefront-composer-block"
+import { authClient } from "@/lib/auth"
+import { useStorefrontMessagesOrDefault } from "@/lib/storefront-i18n"
 
+/**
+ * The trip composer drives the authenticated `/v1/public/trips/*` surface
+ * (create → price → reserve → checkout). Those routes are deliberately NOT on
+ * the anonymous allow-list — `listTrips`/`getTrip` have no per-customer scoping,
+ * so opening the mount anonymously would leak every tenant trip (see #2642).
+ * Until a real customer session exists (#2621), we gate the composer behind a
+ * session so anonymous visitors get a clear sign-in prompt instead of a raw 401.
+ */
 export const Route = createFileRoute("/(storefront)/shop_/composer")({
-  component: StorefrontComposerBlock,
+  component: ComposerRoute,
 })
+
+function ComposerRoute(): React.ReactElement | null {
+  const { data: session, isPending } = authClient.useSession()
+
+  if (isPending) return null
+  if (!session) return <ComposerSignInGate />
+  return <StorefrontComposerBlock />
+}
+
+function ComposerSignInGate(): React.ReactElement {
+  const t = useStorefrontMessagesOrDefault().composer
+
+  return (
+    <div className="mx-auto max-w-xl py-12">
+      <Card>
+        <CardHeader className="space-y-3">
+          <div className="flex size-12 items-center justify-center rounded-md bg-muted">
+            <RouteIcon className="size-6 text-primary" aria-hidden="true" />
+          </div>
+          <CardTitle>{t.gateTitle}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-muted-foreground text-sm">{t.gateBody}</p>
+          <div className="flex flex-wrap gap-2">
+            <Link to="/sign-in" className={buttonVariants()}>
+              <LogIn className="size-4" aria-hidden="true" />
+              {t.gateSignIn}
+            </Link>
+            <Link to="/shop" className={buttonVariants({ variant: "outline" })}>
+              {t.gateBrowse}
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/starters/operator/src/routes/(storefront)/shop_.composer.tsx
+++ b/starters/operator/src/routes/(storefront)/shop_.composer.tsx
@@ -44,7 +44,7 @@ function ComposerSignInGate(): React.ReactElement {
         <CardContent className="space-y-4">
           <p className="text-muted-foreground text-sm">{t.gateBody}</p>
           <div className="flex flex-wrap gap-2">
-            <Link to="/sign-in" className={buttonVariants()}>
+            <Link to="/sign-in" search={{ next: "/shop/composer" }} className={buttonVariants()}>
               <LogIn className="size-4" aria-hidden="true" />
               {t.gateSignIn}
             </Link>


### PR DESCRIPTION
## Root cause

`/shop/composer` drives the `/v1/public/trips/*` create→price→reserve→checkout surface. Those routes are deliberately **not** on the anonymous allow-list: `listTrips`/`getTrip` have no per-customer scoping, so mounting them anonymously would leak every tenant trip. As a result the first action ("New trip") did `POST /v1/public/trips` and returned a raw `401 {"error":"Unauthorized"}`, leaving the composer stuck in its disabled state.

## Fix (option a — gate the UI)

Gate the composer route behind a session (`authClient.useSession()`). Anonymous visitors now get a clear sign-in prompt (with a link back to browsing) instead of a broken disabled/401 state. Browsing and booking individual items stay fully open to everyone.

I chose gating over "allow anonymous trip drafts" (option b) because trip create/list/get currently have no per-customer scoping — making them anonymous would be a tenant-data-leak, not a small change. A real customer sign-in/account flow (so the composer becomes usable, not just gated) is the proper follow-up and is tracked separately in #2621.

## Scope
Operator-starter-only, UI-level change (`shop_.composer.tsx` + storefront i18n en/ro). No package or API changes; no changeset needed (operator is changeset-ignored).

Fixes #2642
