### PR TITLE
Fix contract traveler count fallback

### DIFF
--- a/.changeset/fuzzy-keys-travel.md
+++ b/.changeset/fuzzy-keys-travel.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/legal": patch
+---
+
+Prevent the seeded customer sales agreement traveler heading from rendering the missing-value placeholder when traveler counts are unknown.

--- a/packages/legal/tests/unit/render-template.test.ts
+++ b/packages/legal/tests/unit/render-template.test.ts
@@ -122,6 +122,55 @@ describe("renderTemplate — mustache (markdown/html)", () => {
     ).toBe("Alice, Bob")
     expect(renderTemplate(body, "markdown", { travelers: [] })).toBe("No travelers")
   })
+
+  it("renders the default customer agreement traveler heading without the missing-value placeholder", () => {
+    const body = `<h2>Travelers ({% if booking.pax != nil and booking.pax != "" and booking.pax > 0 %}{{ booking.pax }}{% elsif travelers.size > 0 %}{{ travelers.size }}{% else %}TBD{% endif %})</h2>
+<ol>
+{% for t in travelers %}
+  <li>{{ t.firstName }} {{ t.lastName }}{% if t.participantType != "traveler" %} — {{ t.participantType }}{% endif %}</li>
+{% endfor %}
+</ol>
+
+<ul>
+  <li>Pax: {{ booking.pax | default: "TBD" }}</li>
+</ul>`
+
+    expect(renderTemplate(body, "html", { booking: { pax: null }, travelers: [] })).toContain(
+      "<h2>Travelers (TBD)</h2>",
+    )
+    expect(renderTemplate(body, "html", { booking: { pax: null }, travelers: [] })).toContain(
+      "<li>Pax: TBD</li>",
+    )
+    expect(renderTemplate(body, "html", { booking: { pax: null }, travelers: [] })).not.toContain(
+      "Travelers (-)",
+    )
+
+    expect(renderTemplate(body, "html", { booking: { pax: 2 }, travelers: [] })).toContain(
+      "<h2>Travelers (2)</h2>",
+    )
+    expect(renderTemplate(body, "html", { booking: { pax: 0 }, travelers: [] })).toContain(
+      "<h2>Travelers (TBD)</h2>",
+    )
+
+    const renderedWithTravelers = renderTemplate(body, "html", {
+      booking: { pax: null },
+      travelers: [
+        { firstName: "Ada", lastName: "Lovelace", participantType: "traveler" },
+        { firstName: "Grace", lastName: "Hopper", participantType: "child" },
+      ],
+    })
+    expect(renderedWithTravelers).toContain("<h2>Travelers (2)</h2>")
+    expect(renderedWithTravelers).toContain("<li>Ada Lovelace</li>")
+    expect(renderedWithTravelers).toContain("<li>Grace Hopper — child</li>")
+    expect(renderedWithTravelers).not.toContain("Travelers (-)")
+
+    expect(
+      renderTemplate(body, "html", {
+        booking: { pax: 0 },
+        travelers: [{ firstName: "Ada", lastName: "Lovelace", participantType: "traveler" }],
+      }),
+    ).toContain("<h2>Travelers (1)</h2>")
+  })
 })
 
 describe("renderTemplate — lexical_json", () => {

--- a/starters/operator/scripts/seed.ts
+++ b/starters/operator/scripts/seed.ts
@@ -2280,7 +2280,7 @@ async function seedLegal() {
 <p><em>No lead traveler on file.</em></p>
 {% endif %}
 
-<h2>Travelers ({{ travelers.size }})</h2>
+<h2>Travelers ({% if booking.pax != nil and booking.pax != "" and booking.pax > 0 %}{{ booking.pax }}{% elsif travelers.size > 0 %}{{ travelers.size }}{% else %}TBD{% endif %})</h2>
 <ol>
 {% for t in travelers %}
   <li>{{ t.firstName }} {{ t.lastName }}{% if t.participantType != "traveler" %} — {{ t.participantType }}{% endif %}</li>


### PR DESCRIPTION
## Summary

- Update the seeded customer sales agreement traveler heading so unknown traveler counts render as `TBD` instead of the missing-value placeholder.
- Preserve named traveler list rendering and use the persisted booking pax value when it is present.
- Add a legal renderer regression test and a patch changeset.

Fixes #2457.

## Verification

- `pnpm --filter @voyant-travel/legal test -- tests/unit/render-template.test.ts`
- `NODE_OPTIONS=--max-old-space-size=14336 pnpm --filter @voyant-travel/legal typecheck`
- `pnpm --filter @voyant-travel/legal lint`
- `pnpm --filter operator lint`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm changeset status --since=origin/main`

Notes: `pnpm --filter operator typecheck` and a split `tsc -p starters/operator/tsconfig.server.json` run were both SIGKILLed by the environment. The default pre-commit/pre-push hooks also triggered broad repository lanes and were stopped after unrelated packages hit resource limits or unrelated test failures.
