### PR TITLE
Clean up deleted contract attachment files

### DIFF
--- a/.changeset/contract-attachment-delete-storage.md
+++ b/.changeset/contract-attachment-delete-storage.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/legal": patch
+---
+
+Delete contract attachment document storage objects when the attachment row is removed.

--- a/packages/legal/src/contracts/routes.ts
+++ b/packages/legal/src/contracts/routes.ts
@@ -406,6 +406,31 @@ async function replaceContractAttachmentUpload(
   return c.json({ data: row }, 200)
 }
 
+async function deleteContractAttachment(
+  c: Context<Env>,
+  options: ContractsRouteOptions,
+): Promise<Response> {
+  const attachmentId = c.req.param("attachmentId")!
+  const row = await contractsService.deleteAttachment(c.get("db"), attachmentId)
+  if (!row) return c.json({ error: "Attachment not found" }, 404)
+
+  const runtime = getRuntime(options, c.env, (key) => c.var.container?.resolve(key))
+  const storage = runtime.documentStorage
+  if (storage && row.storageKey) {
+    try {
+      await storage.delete(row.storageKey)
+    } catch (error) {
+      console.warn(
+        `[legal] failed to delete contract attachment object ${row.storageKey}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      )
+    }
+  }
+
+  return c.json({ success: true } as const, 200)
+}
+
 async function regenerateContractDocument(
   c: Context<Env>,
   options: ContractsRouteOptions,
@@ -1833,15 +1858,7 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
 
       return c.redirect(download.download.url, 302)
     })
-    .openapi(deleteAttachmentRoute, async (c) => {
-      const row = await contractsService.deleteAttachment(
-        c.get("db"),
-        c.req.valid("param").attachmentId,
-      )
-      return row
-        ? c.json({ success: true } as const, 200)
-        : c.json({ error: "Attachment not found" }, 404)
-    })
+    .openapi(deleteAttachmentRoute, (c) => asRouteResponse(deleteContractAttachment(c, options)))
 
   const parent = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
   // Preserve the original per-route idempotency guard on `POST /`. The

--- a/packages/legal/src/contracts/service-contracts.ts
+++ b/packages/legal/src/contracts/service-contracts.ts
@@ -533,7 +533,7 @@ export const contractRecordsService = {
     const [row] = await db
       .delete(contractAttachments)
       .where(eq(contractAttachments.id, attachmentId))
-      .returning({ id: contractAttachments.id })
+      .returning()
     return row ?? null
   },
 }

--- a/packages/legal/tests/contracts/unit/attachment-delete-storage.test.ts
+++ b/packages/legal/tests/contracts/unit/attachment-delete-storage.test.ts
@@ -1,0 +1,109 @@
+import type { StorageProvider } from "@voyant-travel/storage"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { Hono } from "hono"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { ContractAttachment } from "../../../src/contracts/schema.js"
+
+const contractServiceMocks = vi.hoisted(() => ({
+  deleteAttachment: vi.fn(),
+}))
+
+vi.mock("../../../src/contracts/service.js", () => ({
+  contractsService: {
+    deleteAttachment: contractServiceMocks.deleteAttachment,
+  },
+}))
+
+const { createContractsAdminRoutes } = await import("../../../src/contracts/routes.js")
+
+const attachment: ContractAttachment = {
+  id: "contract_attachments_000000000000000000",
+  contractId: "contracts_000000000000000000000000000",
+  kind: "document",
+  name: "replacement.txt",
+  mimeType: "text/plain",
+  fileSize: 12,
+  storageKey: "contracts/contracts_000000000000000000000000000/attachments/replacement.txt",
+  checksum: "sha256:replacement",
+  targetKind: null,
+  targetId: null,
+  targetProvider: null,
+  targetSourceRef: null,
+  legacyTransactionOfferId: null,
+  legacyTransactionOrderId: null,
+  metadata: null,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+}
+
+function createStorage(deleteObject: StorageProvider["delete"]): StorageProvider {
+  return {
+    name: "test-documents",
+    async upload(_body, options = {}) {
+      return { key: options.key ?? "uploaded" }
+    },
+    delete: deleteObject,
+    async signedUrl(key) {
+      return `https://signed.example.com/${key}`
+    },
+    async get() {
+      return null
+    },
+  }
+}
+
+function createApp(documentStorage: StorageProvider) {
+  const app = new Hono()
+  app.use("*", async (c, next) => {
+    c.set("db" as never, {} as PostgresJsDatabase)
+    await next()
+  })
+  app.route("/", createContractsAdminRoutes({ documentStorage }))
+  return app
+}
+
+describe("contract attachment delete storage cleanup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("deletes the stored document object for the removed attachment row", async () => {
+    const deleteObject = vi.fn<StorageProvider["delete"]>(async () => {})
+    contractServiceMocks.deleteAttachment.mockResolvedValue(attachment)
+
+    const res = await createApp(createStorage(deleteObject)).request(
+      `/attachments/${attachment.id}`,
+      {
+        method: "DELETE",
+      },
+    )
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ success: true })
+    expect(contractServiceMocks.deleteAttachment).toHaveBeenCalledWith(
+      expect.anything(),
+      attachment.id,
+    )
+    expect(deleteObject).toHaveBeenCalledWith(attachment.storageKey)
+  })
+
+  it("does not delete a storage object when the attachment row is missing", async () => {
+    const deleteObject = vi.fn<StorageProvider["delete"]>(async () => {})
+    contractServiceMocks.deleteAttachment.mockResolvedValue(null)
+
+    const res = await createApp(createStorage(deleteObject)).request(
+      `/attachments/${attachment.id}`,
+      {
+        method: "DELETE",
+      },
+    )
+
+    expect(res.status).toBe(404)
+    expect(await res.json()).toEqual({ error: "Attachment not found" })
+    expect(contractServiceMocks.deleteAttachment).toHaveBeenCalledWith(
+      expect.anything(),
+      attachment.id,
+    )
+    expect(deleteObject).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- delete the stored document object for a contract attachment after its row is removed
- keep deletion best-effort and log storage cleanup failures consistently with replacement cleanup
- add route-level regression coverage for deleted attachment storage cleanup

Fixes #2455

## Verification

- `pnpm --filter @voyant-travel/legal test -- attachment-delete-storage`
- `pnpm --filter @voyant-travel/legal lint`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/legal typecheck`
- `pnpm exec biome check packages/legal/tests/contracts/unit/attachment-delete-storage.test.ts .changeset/contract-attachment-delete-storage.md`
- commit hook: changed-file quality checks and affected Turbo build/typecheck tasks
- push hook: `pnpm test`