### PR TITLE
fix(operator): stop anonymous storefront from minting admin realtime tokens

### DIFF
--- a/starters/operator/src/components/realtime-live.tsx
+++ b/starters/operator/src/components/realtime-live.tsx
@@ -10,6 +10,7 @@ import {
   useLiveQueries,
 } from "@voyant-travel/realtime-react"
 import { useMemo } from "react"
+import { authClient } from "@/lib/auth"
 import { getApiUrl } from "@/lib/env"
 import { operatorFetcher } from "@/lib/voyant-fetcher"
 
@@ -58,7 +59,13 @@ function mapHintToKeys(hint: RealtimeInvalidationHint): ReadonlyArray<QueryKey> 
 }
 
 function AdminLiveRegion() {
-  useLiveQueries(ADMIN_CHANNELS, mapHintToKeys)
+  // Only staff surfaces have an admin session; anonymous storefront pages share
+  // this root provider but must not mint an admin realtime token (the
+  // `/v1/admin/realtime/token` route 401s without a session, spamming the
+  // console). Gate the subscription on a live session so no token is fetched
+  // until someone is signed in.
+  const { data: session } = authClient.useSession()
+  useLiveQueries(ADMIN_CHANNELS, mapHintToKeys, { enabled: Boolean(session) })
   return null
 }
 


### PR DESCRIPTION
## Root cause
`AdminLiveRegion` (in `starters/operator/src/components/realtime-live.tsx`) subscribes to the admin realtime channel via `useLiveQueries(ADMIN_CHANNELS, …)`, which POSTs `/v1/admin/realtime/token` to mint a channel token. That component lives in a root provider shared by the `(storefront)` route group, so **anonymous** storefront pages (`/shop`, `/shop/products/…`, `/shop/book/…`) fetched the admin token and got repeated `401 {"error":"Unauthorized"}` — spamming console/network and masking real checkout errors.

## Fix
Gate the subscription on a live session: `useLiveQueries(ADMIN_CHANNELS, mapHintToKeys, { enabled: Boolean(session) })` using `authClient.useSession()`. `useLiveQueries` returns before calling `fetchToken()` when `enabled` is false, so anonymous pages never POST the admin token endpoint. When a staff user is signed in, realtime subscribes exactly as before.

## Scope
Operator-starter-only, one-file change. No package or API changes; no changeset (operator is changeset-ignored). Realtime remains fully functional for authenticated admin surfaces.

Fixes #2641
