### PR TITLE
fix(operator): hide non-bookable verticals (charters) from storefront search

### DIFF
--- a/starters/operator/src/routes/(storefront)/shop.test.ts
+++ b/starters/operator/src/routes/(storefront)/shop.test.ts
@@ -1,0 +1,30 @@
+import { storefrontCustomerBookableProductVerticals } from "@voyant-travel/storefront-react"
+import { describe, expect, it } from "vitest"
+
+import { shopSearchSchema } from "./shop"
+
+/**
+ * Storefront search must only surface verticals that have a working customer
+ * detail + booking page. Charters (and flights) have no storefront `/content`
+ * endpoint or booking flow, so they must not be selectable or reachable via a
+ * crafted `?vertical=` URL (voyant#2640).
+ */
+describe("shopSearchSchema vertical", () => {
+  it("accepts supported bookable verticals", () => {
+    for (const vertical of storefrontCustomerBookableProductVerticals) {
+      expect(shopSearchSchema.parse({ vertical }).vertical).toBe(vertical)
+    }
+  })
+
+  it("does not surface charters", () => {
+    expect(storefrontCustomerBookableProductVerticals).not.toContain("charters")
+    // A stale/crafted ?vertical=charters URL degrades to the default vertical
+    // instead of surfacing unbookable charter results or erroring.
+    expect(shopSearchSchema.parse({ vertical: "charters" }).vertical).toBeUndefined()
+  })
+
+  it("drops any other unsupported vertical to the default", () => {
+    expect(shopSearchSchema.parse({ vertical: "flights" }).vertical).toBeUndefined()
+    expect(shopSearchSchema.parse({}).vertical).toBeUndefined()
+  })
+})

--- a/starters/operator/src/routes/(storefront)/shop.tsx
+++ b/starters/operator/src/routes/(storefront)/shop.tsx
@@ -2,7 +2,10 @@
 
 import { createFileRoute, Link } from "@tanstack/react-router"
 import { useCatalogSearch } from "@voyant-travel/catalog-react"
-import { getStorefrontCustomerProductDetailRoute } from "@voyant-travel/storefront-react"
+import {
+  getStorefrontCustomerProductDetailRoute,
+  storefrontCustomerBookableProductVerticals,
+} from "@voyant-travel/storefront-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@voyant-travel/ui/components/card"
 import { Input } from "@voyant-travel/ui/components/input"
 import { Skeleton } from "@voyant-travel/ui/components/skeleton"
@@ -20,10 +23,19 @@ import { useStorefrontScope } from "@/lib/storefront-scope"
  * When the deployment hasn't configured Typesense (no
  * `TYPESENSE_HOST`), the search route 503s and we render an
  * instructions block instead — a usable experience either way.
+ *
+ * Search only offers verticals that have a working customer detail + booking
+ * page. Charters (and flights) have no storefront `/content` endpoint or
+ * booking flow yet, so surfacing them produced dead result cards and a broken
+ * detail page (voyant#2640). Deriving the accepted verticals from
+ * `storefrontCustomerBookableProductVerticals` keeps search in sync
+ * automatically as new verticals gain detail pages, and `.catch(undefined)`
+ * gracefully drops any stale/crafted `?vertical=charters` URL back to the
+ * default vertical instead of erroring.
  */
-const shopSearchSchema = z.object({
+export const shopSearchSchema = z.object({
   q: z.string().optional(),
-  vertical: z.enum(["products", "cruises", "accommodations", "charters", "flights"]).optional(),
+  vertical: z.enum(storefrontCustomerBookableProductVerticals).optional().catch(undefined),
 })
 
 export const Route = createFileRoute("/(storefront)/shop")({
@@ -88,7 +100,6 @@ function StorefrontIndex(): React.ReactElement {
           <option value="products">{t.verticalProducts}</option>
           <option value="cruises">{t.verticalCruises}</option>
           <option value="accommodations">{t.verticalAccommodations}</option>
-          <option value="charters">{t.verticalCharters}</option>
         </select>
       </div>
 


### PR DESCRIPTION
## Root cause
Storefront search offered `charters` (and `flights`) as selectable verticals, but those verticals have **no storefront `/content` endpoint or booking flow**. Selecting `?vertical=charters` returned charter ids (`chrt_…`) that:
- render as dead result cards (`getStorefrontCustomerProductDetailRoute` already returns `null` for non-bookable verticals, so cards can't link), and
- if navigated to, fall through to the generic product-detail page which calls `GET /v1/public/products/:id/content` → `404 not_found` ("Detail content isn't available", "No upcoming departures", disabled Book).

## Fix (hide until supported)
`packages/storefront-react` already exposes `storefrontCustomerBookableProductVerticals` (`products`, `cruises`, `accommodations`) — the source of truth that also gates result-card detail links. This wires the storefront search schema + selector to it:
- `vertical` enum is derived from that constant (so search stays in sync automatically as verticals gain detail pages),
- `.catch(undefined)` degrades a stale/crafted `?vertical=charters` (or `flights`) URL to the default vertical instead of surfacing unbookable results,
- the `charters` option is removed from the vertical selector.

Added `shop.test.ts` asserting supported verticals parse, and `charters`/`flights`/unknown degrade to the default.

Charter storefront support (a real charter detail/content/booking flow) is separate, larger work; this stops the storefront from surfacing an unbookable dead-end.

## Scope
Operator-starter-only (uses an existing `storefront-react` export). No package/API change; no changeset.

Fixes #2640
