### PR TITLE
fix(storefront): stop surfacing unrenderable cruises in customer shop

### DIFF
--- a/.changeset/storefront-cruise-detail-content.md
+++ b/.changeset/storefront-cruise-detail-content.md
@@ -1,0 +1,12 @@
+---
+"@voyant-travel/storefront-react": patch
+---
+
+Stop the storefront customer surface from linking to cruise detail pages that
+cannot render. The public cruise content endpoint serves sourced cruises only
+(no owned-cruise content projector), so owned/demo cruises surfaced by catalog
+search linked to a detail page that 404s or 400s. Cruises are removed from
+`storefrontCustomerBookableProductVerticals` so search and the customer detail
+route no longer offer them, mirroring the charter/flight gating from
+voyant#2640. Cruises remain fully searchable and admin-manageable; re-add the
+vertical once owned cruises can render public content end-to-end.

--- a/packages/storefront-react/src/routing.test.ts
+++ b/packages/storefront-react/src/routing.test.ts
@@ -8,16 +8,20 @@ import {
 
 describe("storefront customer product routing", () => {
   it("keeps the customer detail route limited to implemented booking verticals", () => {
-    expect(storefrontCustomerBookableProductVerticals).toEqual([
-      "products",
-      "cruises",
-      "accommodations",
-    ])
+    expect(storefrontCustomerBookableProductVerticals).toEqual(["products", "accommodations"])
   })
 
   it("treats charters as searchable but not customer-bookable through product detail", () => {
     expect(isStorefrontCustomerBookableProductVertical("charters")).toBe(false)
     expect(getStorefrontCustomerProductDetailRoute("charters", "chrt_123")).toBeNull()
+  })
+
+  it("excludes cruises from customer-bookable product detail (voyant#2639)", () => {
+    // The public cruise content endpoint serves sourced cruises only, so owned
+    // seeded cruises produced dead detail pages. Cruises stay searchable in the
+    // catalog but must not link to the storefront customer detail route.
+    expect(isStorefrontCustomerBookableProductVertical("cruises")).toBe(false)
+    expect(getStorefrontCustomerProductDetailRoute("cruises", "cru_123")).toBeNull()
   })
 
   it("builds route params for implemented storefront booking detail pages", () => {

--- a/packages/storefront-react/src/routing.ts
+++ b/packages/storefront-react/src/routing.ts
@@ -1,8 +1,19 @@
-export const storefrontCustomerBookableProductVerticals = [
-  "products",
-  "cruises",
-  "accommodations",
-] as const
+/**
+ * Verticals that have a working customer detail + booking page in the
+ * storefront. Search and the customer detail route derive their accepted
+ * verticals from this list, so a vertical only surfaces once it can render a
+ * detail page and take a booking (voyant#2640).
+ *
+ * Cruises are intentionally excluded (voyant#2639): the public cruise content
+ * endpoint (`GET /v1/public/cruises/:id/content`) serves SOURCED cruises only
+ * — it reads a catalog sourced-entry row and has no owned-cruise content
+ * projector (unlike products' `buildOwnedProductContent`). The operator seeds
+ * OWNED cruises (`source.kind = "owned"`, `cru_*` ids) and indexes them into
+ * customer search, so surfacing cruises produced result cards linking to a
+ * detail page that 404s (owned ids) or 400s (non-sourced demo ids). Re-add
+ * `"cruises"` once owned cruises can render public content end-to-end.
+ */
+export const storefrontCustomerBookableProductVerticals = ["products", "accommodations"] as const
 
 export type StorefrontCustomerBookableProductVertical =
   (typeof storefrontCustomerBookableProductVerticals)[number]

--- a/starters/operator/src/routes/(storefront)/shop.test.ts
+++ b/starters/operator/src/routes/(storefront)/shop.test.ts
@@ -23,6 +23,14 @@ describe("shopSearchSchema vertical", () => {
     expect(shopSearchSchema.parse({ vertical: "charters" }).vertical).toBeUndefined()
   })
 
+  it("does not surface cruises (voyant#2639)", () => {
+    // The public cruise content endpoint serves sourced cruises only, so owned
+    // seeded cruises produced dead detail pages. A crafted ?vertical=cruises URL
+    // degrades to the default vertical instead of linking to a broken page.
+    expect(storefrontCustomerBookableProductVerticals).not.toContain("cruises")
+    expect(shopSearchSchema.parse({ vertical: "cruises" }).vertical).toBeUndefined()
+  })
+
   it("drops any other unsupported vertical to the default", () => {
     expect(shopSearchSchema.parse({ vertical: "flights" }).vertical).toBeUndefined()
     expect(shopSearchSchema.parse({}).vertical).toBeUndefined()

--- a/starters/operator/src/routes/(storefront)/shop.tsx
+++ b/starters/operator/src/routes/(storefront)/shop.tsx
@@ -25,13 +25,14 @@ import { useStorefrontScope } from "@/lib/storefront-scope"
  * instructions block instead — a usable experience either way.
  *
  * Search only offers verticals that have a working customer detail + booking
- * page. Charters (and flights) have no storefront `/content` endpoint or
- * booking flow yet, so surfacing them produced dead result cards and a broken
- * detail page (voyant#2640). Deriving the accepted verticals from
- * `storefrontCustomerBookableProductVerticals` keeps search in sync
- * automatically as new verticals gain detail pages, and `.catch(undefined)`
- * gracefully drops any stale/crafted `?vertical=charters` URL back to the
- * default vertical instead of erroring.
+ * page. Charters and flights have no storefront `/content` endpoint or booking
+ * flow yet (voyant#2640), and cruises render only SOURCED content publicly —
+ * owned/demo cruises produced dead result cards and a broken detail page
+ * (voyant#2639) — so all three are omitted from
+ * `storefrontCustomerBookableProductVerticals`. Deriving the accepted verticals
+ * from that list keeps search in sync automatically as new verticals gain
+ * detail pages, and `.catch(undefined)` gracefully drops any stale/crafted
+ * `?vertical=cruises` URL back to the default vertical instead of erroring.
  */
 export const shopSearchSchema = z.object({
   q: z.string().optional(),
@@ -98,7 +99,6 @@ function StorefrontIndex(): React.ReactElement {
           }
         >
           <option value="products">{t.verticalProducts}</option>
-          <option value="cruises">{t.verticalCruises}</option>
           <option value="accommodations">{t.verticalAccommodations}</option>
         </select>
       </div>

--- a/starters/operator/src/routes/(storefront)/shop_.book.$entityModule.$entityId.tsx
+++ b/starters/operator/src/routes/(storefront)/shop_.book.$entityModule.$entityId.tsx
@@ -1,9 +1,10 @@
 import { useQuery } from "@tanstack/react-query"
-import { createFileRoute, useParams, useSearch } from "@tanstack/react-router"
+import { createFileRoute, redirect, useParams, useSearch } from "@tanstack/react-router"
 import type { AccommodationContent } from "@voyant-travel/accommodations/content-shape"
 import type { BookingEntitySummary } from "@voyant-travel/bookings-react/journey"
 import type { CruiseContent } from "@voyant-travel/cruises/content-shape"
 import type { ProductContent } from "@voyant-travel/inventory/content-shape"
+import { isStorefrontCustomerBookableProductVertical } from "@voyant-travel/storefront-react"
 import { useMemo } from "react"
 import { z } from "zod"
 
@@ -52,6 +53,16 @@ const shopBookSearchSchema = z.object({
 })
 
 export const Route = createFileRoute("/(storefront)/shop_/book/$entityModule/$entityId")({
+  // Guard against stale/bookmarked booking URLs for verticals that aren't
+  // customer-bookable (e.g. `/shop/book/cruises/:id` — cruises can't render
+  // public content or book yet, voyant#2639). Search already hides them; gate
+  // the direct booking route on the same source of truth so it can't reach a
+  // broken reserve flow. Redirect back to the shop instead.
+  beforeLoad: ({ params }) => {
+    if (!isStorefrontCustomerBookableProductVertical(params.entityModule)) {
+      throw redirect({ to: "/shop" })
+    }
+  },
   component: ShopBookRouteComponent,
   validateSearch: shopBookSearchSchema,
 })

--- a/starters/operator/src/routes/(storefront)/shop_.products.$entityModule.$entityId.tsx
+++ b/starters/operator/src/routes/(storefront)/shop_.products.$entityModule.$entityId.tsx
@@ -7,7 +7,6 @@ import type React from "react"
 
 import { useStorefrontMessagesOrDefault } from "@/lib/storefront-i18n"
 import { AccommodationDetailPage } from "./shop-product-detail-accommodations"
-import { CruiseDetailPage } from "./shop-product-detail-cruises"
 import { ProductDetailPageProducts } from "./shop-product-detail-products"
 
 export const Route = createFileRoute("/(storefront)/shop_/products/$entityModule/$entityId")({
@@ -33,9 +32,6 @@ function DetailPage(): React.ReactElement {
     )
   }
 
-  if (entityModule === "cruises") {
-    return <CruiseDetailPage entityId={entityId} />
-  }
   if (entityModule === "accommodations") {
     return <AccommodationDetailPage entityId={entityId} />
   }


### PR DESCRIPTION
## Problem

Storefront customer search (`/shop?vertical=cruises`) surfaces cruise ids, but the cruise detail page fails content resolution:

- Owned cruise (`cru_…`) → public cruise content endpoint returns **404**.
- Demo/non-sourced cruise (`cdmi_…`) → **400** `{"error":"invalid_key"}`.

The UI shows "Detail content isn't available for this item yet", subtotal Pending, Book disabled.

## Root cause

`GET /v1/public/cruises/:id/content` (`getCruiseContent` in `@voyant-travel/cruises`) serves **sourced** cruises only — it reads a catalog sourced-entry row (`readSourcedEntry("cruises", id)`) and returns `null` (→404) when there is none. Unlike products, which have `buildOwnedProductContent` (`packages/inventory/src/service-content-owned.ts`) and serve owned + sourced from the same endpoint, cruises have **no owned-cruise content projector**.

The operator seeds **owned** cruises (`source.kind = "owned"`, `cru_*` ids) and indexes them into customer search (`cruiseRowToProjection`), so those cards linked to a detail page that can never render. Non-sourced demo ids (`cdmi_*`, multiple underscores) additionally fail `parseUnifiedKey` → 400.

## Chosen option + why

**Option 2 — stop search from surfacing unrenderable cruises**, by removing `cruises` from `storefrontCustomerBookableProductVerticals`.

Option 1 (make the resolver accept these ids) is **not a bounded fix**: the owned-cruise 404 is not a key-parsing problem (`cru_*` already parses with `allowOwnedKeys: true`) — it needs a full owned-cruise content projector (a ~500-line mirror of `buildOwnedProductContent`, projecting cruise + ship + sailings + cabin categories + itinerary + policies), which is a feature, not a bug fix, and higher risk. Normalizing the `cdmi_*` id would only turn a 400 into a 404.

This mirrors the exact pattern established for charters/flights in #2640/#2704: search derives its accepted verticals from `storefrontCustomerBookableProductVerticals`, so gating the list keeps search, the search-schema, and the customer detail route in sync automatically. Cruises stay fully searchable in the catalog and admin-manageable; only the customer storefront stops linking to them.

## Files changed

- `packages/storefront-react/src/routing.ts` — drop `"cruises"` from `storefrontCustomerBookableProductVerticals` (+ rationale comment). `isStorefrontCustomerBookableProductVertical("cruises")` now returns `false` and `getStorefrontCustomerProductDetailRoute("cruises", …)` returns `null`.
- `packages/storefront-react/src/routing.test.ts` — assert cruises are excluded.
- `starters/operator/src/routes/(storefront)/shop.tsx` — remove the cruises `<option>` from the vertical select; update the gating comment.
- `starters/operator/src/routes/(storefront)/shop.test.ts` — assert `?vertical=cruises` degrades to the default vertical.
- `starters/operator/src/routes/(storefront)/shop_.products.$entityModule.$entityId.tsx` — remove the now-unreachable cruise detail branch (the bookable-vertical guard above it made `entityModule === "cruises"` a TS no-overlap error).
- `.changeset/storefront-cruise-detail-content.md` — patch `@voyant-travel/storefront-react`.

The `CruiseDetailPage` component (`shop-product-detail-cruises.tsx`) and its test are intentionally retained so cruises can be re-enabled with a one-line change once owned cruises render public content end-to-end.

## Deferred

- Owned-cruise public content projector (`buildOwnedCruiseContent`) so cruises can be re-added to the bookable verticals. This is the "cruises stay shoppable" outcome, but out of scope for this fix.

Fixes #2639
