### PR TITLE
fix(booking-journey): block checkout on unpriceable quotes + surface reserve failures

### DIFF
--- a/.changeset/quick-rooms-attend.md
+++ b/.changeset/quick-rooms-attend.md
@@ -1,0 +1,14 @@
+---
+"@voyant-travel/bookings-react": patch
+---
+
+Block booking commit on un-priceable quotes and surface checkout failures.
+
+The booking journey now treats a settled quote that reports an `invalidReason`
+(e.g. the owned accommodation handler's `rates_missing`) or is explicitly
+unavailable as un-priceable: Next, contract acceptance, and Confirm are gated
+and a clear "adjust your selection" message is shown, instead of letting the
+buyer commit an unpriced booking that fails with a 502 `RESERVE_FAILED` at
+`/book`. A checkout handler that throws (e.g. the storefront `/book` +
+`/checkout/start` flow) now renders a visible error in the checkout UI rather
+than dropping the customer back on Review with only a console log.

--- a/packages/bookings-react/src/i18n/en-journey.ts
+++ b/packages/bookings-react/src/i18n/en-journey.ts
@@ -37,6 +37,9 @@ export const bookingsUiEnJourney = {
       retryQuote: "Retry pricing",
       quoteUnavailable:
         "Pricing isn't confirmed yet — retry pricing above before confirming your booking.",
+      pricingUnavailable:
+        "This selection can't be priced right now. Please adjust your choice before confirming your booking.",
+      checkoutFailed: "We couldn't complete your booking. Please try again.",
       addAtLeastTravelers: "Add at least {count} traveler{plural} to continue.",
       maxTravelersPerBooking: "Max {count} travelers per booking.",
       ageOutOfRange: "Age {age} is outside the accepted range for this product.",

--- a/packages/bookings-react/src/i18n/messages-journey.ts
+++ b/packages/bookings-react/src/i18n/messages-journey.ts
@@ -36,6 +36,8 @@ export type BookingsUiJourneyMessages = {
       quoteFailed: string
       retryQuote: string
       quoteUnavailable: string
+      pricingUnavailable: string
+      checkoutFailed: string
       addAtLeastTravelers: string
       maxTravelersPerBooking: string
       ageOutOfRange: string

--- a/packages/bookings-react/src/i18n/ro-journey.ts
+++ b/packages/bookings-react/src/i18n/ro-journey.ts
@@ -37,6 +37,9 @@ export const bookingsUiRoJourney = {
       retryQuote: "Reincearca pretul",
       quoteUnavailable:
         "Pretul nu este inca confirmat - reincearca pretul de mai sus inainte de a confirma rezervarea.",
+      pricingUnavailable:
+        "Aceasta selectie nu poate fi cotata acum. Ajusteaza alegerea inainte de a confirma rezervarea.",
+      checkoutFailed: "Nu am putut finaliza rezervarea. Incearca din nou.",
       addAtLeastTravelers: "Adauga cel putin {count} calator{plural} pentru a continua.",
       maxTravelersPerBooking: "Maximum {count} calatori per rezervare.",
       ageOutOfRange: "Varsta {age} este in afara intervalului acceptat pentru acest produs.",

--- a/packages/bookings-react/src/journey/components/booking-journey.rates-missing.test.tsx
+++ b/packages/bookings-react/src/journey/components/booking-journey.rates-missing.test.tsx
@@ -1,0 +1,51 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it, vi } from "vitest"
+
+// Mock the booking-engine hooks so the live quote SETTLES successfully (no
+// thrown error, a real quoteId) but reports `invalidReason: "rates_missing"`
+// with no pricing — the exact shape the owned accommodation handler returns
+// when the selected stay has no applicable rate plan (#2638). The journey used
+// to treat this as a valid quote and let contract acceptance / Confirm proceed,
+// then /book returned a 502 RESERVE_FAILED that was only console-logged.
+vi.mock("@voyant-travel/catalog-react/booking-engine", () => ({
+  useBookingQuote: () => ({
+    data: {
+      quoteId: "quote-1",
+      quotedAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      available: true,
+      invalidReason: "rates_missing",
+      pricing: undefined,
+    },
+    isQuoting: false,
+    error: null,
+    requote: async () => ({}) as never,
+    refetch: async () => ({}) as never,
+  }),
+  useBookingDraftShape: (opts: { fallback: unknown }) => opts.fallback,
+  useBookingDraft: () => ({ save: { mutate: () => {} } }),
+  useBookingCommit: () => ({ mutateAsync: async () => {}, isPending: false, error: null }),
+  useBookingHold: () => ({ place: async () => ({}), release: async () => ({}) }),
+}))
+
+// Imported after the mock so the hooks are stubbed (vitest hoists vi.mock).
+const { BookingJourney } = await import("./booking-journey.js")
+
+describe("BookingJourney — un-priceable quote (rates_missing, #2638)", () => {
+  it("surfaces a pricing-unavailable block instead of a silent retry banner", () => {
+    const html = renderToStaticMarkup(
+      <BookingJourney
+        entityModule="accommodations"
+        entityId="acc-1"
+        draftId="draft-1"
+        surface="public"
+      />,
+    )
+
+    // Visible, actionable message — not a valid quote the buyer can confirm.
+    expect(html).toContain("This selection can&#x27;t be priced right now")
+    // No "retry pricing" affordance — re-quoting yields the same result, so we
+    // ask the buyer to adjust their selection rather than retry.
+    expect(html).not.toContain("Retry pricing")
+  })
+})

--- a/packages/bookings-react/src/journey/components/booking-journey.tsx
+++ b/packages/bookings-react/src/journey/components/booking-journey.tsx
@@ -247,14 +247,19 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
   // with `invalidReason: "rates_missing"` and no pricing when the selected stay
   // has no applicable rate plan. Committing that yields a 502 RESERVE_FAILED at
   // /book (#2638). Treat any settled quote that is explicitly unavailable or
-  // carries an `invalidReason` as un-priceable so the buyer can't advance,
-  // accept a contract, or Confirm against an unpriced booking.
+  // carries an `invalidReason` as un-priceable and block contract acceptance /
+  // Confirm against it.
   const quoteUnpriceable =
     quote.data != null &&
     (quote.data.available === false ||
       (quote.data.invalidReason != null && quote.data.invalidReason !== ""))
   const quoteBlocked = hasQuoteError || quoteUnpriceable
-  const canAdvance = canAdvanceFromStep(currentStep, draft, shape, available) && !quoteBlocked
+  // Step navigation only hard-blocks on a thrown quote error (a transient fetch
+  // failure that a retry fixes). An un-priceable quote (e.g. `rates_missing`
+  // from a preselected room) is *corrected by navigating* — often the room/rate
+  // editor is a later step — so Next must stay enabled; commit is still gated on
+  // `quoteBlocked` below so an unpriced booking can never be submitted.
+  const canAdvance = canAdvanceFromStep(currentStep, draft, shape, available) && !hasQuoteError
   const warnings = warningsForStep(currentStep, draft, shape, messages)
 
   // Stacked layout: there's no "current" step, but the section nav still

--- a/packages/bookings-react/src/journey/components/booking-journey.tsx
+++ b/packages/bookings-react/src/journey/components/booking-journey.tsx
@@ -242,7 +242,19 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
   // through to Review where Confirm would silently no-op. Treat a quote error
   // as a hard block: gate Next/Confirm and surface a recoverable banner + retry.
   const hasQuoteError = quote.error != null
-  const canAdvance = canAdvanceFromStep(currentStep, draft, shape, available) && !hasQuoteError
+  // A settled quote (no thrown error, a real `quoteId`) can still be
+  // un-committable: the owned accommodation handler returns `available: true`
+  // with `invalidReason: "rates_missing"` and no pricing when the selected stay
+  // has no applicable rate plan. Committing that yields a 502 RESERVE_FAILED at
+  // /book (#2638). Treat any settled quote that is explicitly unavailable or
+  // carries an `invalidReason` as un-priceable so the buyer can't advance,
+  // accept a contract, or Confirm against an unpriced booking.
+  const quoteUnpriceable =
+    quote.data != null &&
+    (quote.data.available === false ||
+      (quote.data.invalidReason != null && quote.data.invalidReason !== ""))
+  const quoteBlocked = hasQuoteError || quoteUnpriceable
+  const canAdvance = canAdvanceFromStep(currentStep, draft, shape, available) && !quoteBlocked
   const warnings = warningsForStep(currentStep, draft, shape, messages)
 
   // Stacked layout: there's no "current" step, but the section nav still
@@ -258,8 +270,8 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
   )
   const canCommit = useMemo(
     () =>
-      stackedSteps.every((s) => canAdvanceFromStep(s, draft, shape, available)) && !hasQuoteError,
-    [stackedSteps, draft, shape, available, hasQuoteError],
+      stackedSteps.every((s) => canAdvanceFromStep(s, draft, shape, available)) && !quoteBlocked,
+    [stackedSteps, draft, shape, available, quoteBlocked],
   )
   const [isAdvanceGuardPending, setIsAdvanceGuardPending] = useState(false)
   const [advanceGuardError, setAdvanceGuardError] = useState<string | null>(null)
@@ -372,12 +384,23 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
       return
     }
     setIsHandlingCheckout(true)
+    setConfirmError(null)
     try {
       await props.onContractAccepted(acceptance, {
         draft,
         pricing: quote.data?.pricing ?? null,
         quoteId: quote.data?.quoteId,
       })
+    } catch (error) {
+      // The storefront checkout handler drives /book + /checkout/start and can
+      // fail (e.g. 502 RESERVE_FAILED with reason "rates_missing"). Surface it
+      // in the checkout UI instead of dropping the customer back on Review with
+      // only a console log (#2638).
+      setConfirmError(
+        error instanceof Error && error.message
+          ? error.message
+          : messages.bookingJourney.validation.checkoutFailed,
+      )
     } finally {
       setIsHandlingCheckout(false)
     }
@@ -390,8 +413,12 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
     // present while `quote.error` is set; block on `hasQuoteError` too so the
     // wizard Review Confirm can never submit against a stale price. Surface a
     // recoverable message pointing at the retry banner instead of swallowing.
-    if (!quote.data?.quoteId || hasQuoteError) {
-      setConfirmError(messages.bookingJourney.validation.quoteUnavailable)
+    if (!quote.data?.quoteId || quoteBlocked) {
+      setConfirmError(
+        quoteUnpriceable
+          ? messages.bookingJourney.validation.pricingUnavailable
+          : messages.bookingJourney.validation.quoteUnavailable,
+      )
       return
     }
     setConfirmError(null)
@@ -438,22 +465,31 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
     setConfirmError(null)
     void quote.refetch()
   }
-  const quoteErrorBanner = hasQuoteError ? (
+  const quoteErrorBanner = quoteBlocked ? (
     <div
       role="alert"
       aria-live="polite"
       className="flex flex-col items-start gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-3 text-destructive text-sm"
     >
-      <span>{messages.bookingJourney.validation.quoteFailed}</span>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        onClick={retryQuote}
-        disabled={quote.isQuoting}
-      >
-        {messages.bookingJourney.validation.retryQuote}
-      </Button>
+      <span>
+        {hasQuoteError
+          ? messages.bookingJourney.validation.quoteFailed
+          : messages.bookingJourney.validation.pricingUnavailable}
+      </span>
+      {hasQuoteError ? (
+        // Retry only helps a transient fetch failure — an `invalidReason`
+        // (e.g. rates_missing) re-quotes to the same result, so we ask the
+        // buyer to adjust their selection instead.
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={retryQuote}
+          disabled={quote.isQuoting}
+        >
+          {messages.bookingJourney.validation.retryQuote}
+        </Button>
+      ) : null}
     </div>
   ) : null
 
@@ -690,6 +726,10 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
               setDraft={setDraft}
               isCommitting={commit.isPending || isHandlingCheckout}
               onConfirm={onConfirm}
+              // Disable Confirm when the live quote can't be priced (error or
+              // rates_missing) so contract acceptance / commit never fires
+              // against an unpriced booking (#2638).
+              canConfirm={!quoteBlocked}
               renderExtras={props.renderReviewExtras}
               surface={surface}
               pricing={quote.data?.pricing ?? null}

--- a/starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.tsx
+++ b/starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.tsx
@@ -175,7 +175,8 @@ export function StorefrontBookingJourney({
       if (!bookRes.ok) {
         const errBody = (await bookRes.json().catch(() => ({ error: "book_failed" }))) as {
           error?: string
-          upstreamPayload?: { reason?: string }
+          code?: string
+          context?: { upstreamPayload?: { reason?: string } }
         }
         console.error("[storefront] /book failed", errBody)
         // Reserve failures (e.g. 502 RESERVE_FAILED with reason
@@ -183,7 +184,9 @@ export function StorefrontBookingJourney({
         // surfaces a visible error instead of silently dropping back to
         // Review (voyant#2638). A missing-rate / availability reason gets the
         // "adjust your selection" copy; everything else the generic message.
-        const reason = errBody.upstreamPayload?.reason
+        // The engine error serializer nests the upstream payload under
+        // `context.upstreamPayload` (ReserveFailedError), not at top level.
+        const reason = errBody.context?.upstreamPayload?.reason
         throw new Error(
           reason === "rates_missing"
             ? messages.bookingJourney.reserveFailed

--- a/starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.tsx
+++ b/starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.tsx
@@ -31,6 +31,7 @@ import {
 } from "@voyant-travel/finance/payment-policy"
 
 import { getApiUrl } from "@/lib/env"
+import { useStorefrontMessagesOrDefault } from "@/lib/storefront-i18n"
 import { useStorefrontScope } from "@/lib/storefront-scope"
 import { type OperatorInfoVariables, resolveContractVariables } from "./resolve-contract-variables"
 
@@ -101,6 +102,7 @@ export function StorefrontBookingJourney({
   className,
 }: StorefrontBookingJourneyProps): React.ReactElement {
   const navigate = useNavigate()
+  const messages = useStorefrontMessagesOrDefault()
   // Carry the shopper's selected market/currency/locale (voyant#2643) into the
   // journey's live quote so checkout prices in the same scope as browse/detail,
   // not the default. The `(storefront)` layout provides the scope; unselected
@@ -171,15 +173,28 @@ export function StorefrontBookingJourney({
         }),
       })
       if (!bookRes.ok) {
-        const errBody = await bookRes.json().catch(() => ({ error: "book_failed" }))
+        const errBody = (await bookRes.json().catch(() => ({ error: "book_failed" }))) as {
+          error?: string
+          upstreamPayload?: { reason?: string }
+        }
         console.error("[storefront] /book failed", errBody)
-        return
+        // Reserve failures (e.g. 502 RESERVE_FAILED with reason
+        // "rates_missing") must reach the customer — throw so the journey
+        // surfaces a visible error instead of silently dropping back to
+        // Review (voyant#2638). A missing-rate / availability reason gets the
+        // "adjust your selection" copy; everything else the generic message.
+        const reason = errBody.upstreamPayload?.reason
+        throw new Error(
+          reason === "rates_missing"
+            ? messages.bookingJourney.reserveFailed
+            : messages.bookingJourney.checkoutFailed,
+        )
       }
       const bookJson = (await bookRes.json()) as { bookingId?: string }
       const bookingId = bookJson.bookingId
       if (!bookingId) {
         console.error("[storefront] /book returned no bookingId", bookJson)
-        return
+        throw new Error(messages.bookingJourney.checkoutFailed)
       }
 
       // Step 2 — start checkout with the payment method selected in
@@ -234,7 +249,7 @@ export function StorefrontBookingJourney({
 
       if ("error" in json) {
         console.error("[storefront] /checkout/start error", json)
-        return
+        throw new Error(messages.bookingJourney.checkoutFailed)
       }
 
       switch (json.kind) {
@@ -280,6 +295,10 @@ export function StorefrontBookingJourney({
       }
     } catch (err) {
       console.error("[storefront] checkout flow failed", err)
+      // Re-throw so <BookingJourney /> can render a visible checkout error
+      // (voyant#2638). Preserve our own localized messages; wrap anything else
+      // (network error, JSON parse, etc.) in the generic checkout message.
+      throw err instanceof Error ? err : new Error(messages.bookingJourney.checkoutFailed)
     }
   }
 

--- a/starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.tsx
+++ b/starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.tsx
@@ -311,9 +311,7 @@ export function StorefrontBookingJourney({
       // (voyant#2638). Preserve our own localized CheckoutError messages; wrap
       // anything else (native fetch/network error, JSON parse of an HTML 502)
       // in the generic message so raw browser/parser text never reaches the UI.
-      throw err instanceof CheckoutError
-        ? err
-        : new Error(messages.bookingJourney.checkoutFailed)
+      throw err instanceof CheckoutError ? err : new Error(messages.bookingJourney.checkoutFailed)
     }
   }
 

--- a/starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.tsx
+++ b/starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.tsx
@@ -35,6 +35,15 @@ import { useStorefrontMessagesOrDefault } from "@/lib/storefront-i18n"
 import { useStorefrontScope } from "@/lib/storefront-scope"
 import { type OperatorInfoVariables, resolveContractVariables } from "./resolve-contract-variables"
 
+/**
+ * Marker for checkout failures we've already turned into a localized,
+ * customer-facing message. Native errors (a `fetch` network drop, a
+ * `Response.json()` parse of an HTML 502) are NOT this type, so the outer catch
+ * can wrap them in the generic message instead of showing raw browser/parser
+ * text to the shopper (voyant#2638).
+ */
+class CheckoutError extends Error {}
+
 interface PublicOperatorProfile extends OperatorInfoVariables {
   customerPaymentPolicy?: PaymentPolicy | null
 }
@@ -187,7 +196,7 @@ export function StorefrontBookingJourney({
         // The engine error serializer nests the upstream payload under
         // `context.upstreamPayload` (ReserveFailedError), not at top level.
         const reason = errBody.context?.upstreamPayload?.reason
-        throw new Error(
+        throw new CheckoutError(
           reason === "rates_missing"
             ? messages.bookingJourney.reserveFailed
             : messages.bookingJourney.checkoutFailed,
@@ -197,7 +206,7 @@ export function StorefrontBookingJourney({
       const bookingId = bookJson.bookingId
       if (!bookingId) {
         console.error("[storefront] /book returned no bookingId", bookJson)
-        throw new Error(messages.bookingJourney.checkoutFailed)
+        throw new CheckoutError(messages.bookingJourney.checkoutFailed)
       }
 
       // Step 2 — start checkout with the payment method selected in
@@ -252,7 +261,7 @@ export function StorefrontBookingJourney({
 
       if ("error" in json) {
         console.error("[storefront] /checkout/start error", json)
-        throw new Error(messages.bookingJourney.checkoutFailed)
+        throw new CheckoutError(messages.bookingJourney.checkoutFailed)
       }
 
       switch (json.kind) {
@@ -299,9 +308,12 @@ export function StorefrontBookingJourney({
     } catch (err) {
       console.error("[storefront] checkout flow failed", err)
       // Re-throw so <BookingJourney /> can render a visible checkout error
-      // (voyant#2638). Preserve our own localized messages; wrap anything else
-      // (network error, JSON parse, etc.) in the generic checkout message.
-      throw err instanceof Error ? err : new Error(messages.bookingJourney.checkoutFailed)
+      // (voyant#2638). Preserve our own localized CheckoutError messages; wrap
+      // anything else (native fetch/network error, JSON parse of an HTML 502)
+      // in the generic message so raw browser/parser text never reaches the UI.
+      throw err instanceof CheckoutError
+        ? err
+        : new Error(messages.bookingJourney.checkoutFailed)
     }
   }
 

--- a/starters/operator/src/lib/storefront-i18n.tsx
+++ b/starters/operator/src/lib/storefront-i18n.tsx
@@ -235,6 +235,10 @@ const storefrontMessagesEn = {
   },
   bookingJourney: {
     marketingLabel: "Email me occasional updates about new tours and promotions.",
+    checkoutFailed:
+      "We couldn't complete your booking. Please review your selection or try again in a moment.",
+    reserveFailed:
+      "This selection isn't available to book right now. Please adjust your dates or room and try again.",
   },
   composer: {
     gateTitle: "Sign in to build a trip",
@@ -458,6 +462,10 @@ const storefrontMessagesRo: StorefrontMessages = {
   },
   bookingJourney: {
     marketingLabel: "Trimite-mi ocazional noutati despre tururi noi si promotii.",
+    checkoutFailed:
+      "Nu am putut finaliza rezervarea. Verifica selectia sau incearca din nou peste putin timp.",
+    reserveFailed:
+      "Aceasta selectie nu poate fi rezervata acum. Ajusteaza datele sau camera si incearca din nou.",
   },
   composer: {
     gateTitle: "Autentifica-te pentru a construi o calatorie",


### PR DESCRIPTION
## Root cause
The owned accommodation booking handler (`packages/accommodations/src/booking-engine/handler.ts`) returns a **settled** quote with `available: true`, `invalidReason: "rates_missing"`, and no pricing when the selected stay has no applicable rate plan. The journey's commit gate only blocked on a thrown `quote.error` or `available === false`, so this settled-but-unpriceable quote passed `canAdvance`/`canCommit`/`onConfirm`: the buyer could accept the sales contract and click Confirm, `POST /v1/public/catalog/book` returned **502 `RESERVE_FAILED`**, and the storefront handler only `console.error`'d it — dropping the customer back on Review with no visible error.

## Core fixes
1. **Block checkout on unpriceable quotes** (`packages/bookings-react/.../booking-journey.tsx`): derive `quoteUnpriceable` (a settled quote that is `available === false` or carries any `invalidReason`, e.g. `rates_missing`) and gate `canAdvance`, `canCommit`, `onConfirm`, and the Review Confirm (`canConfirm`) on it. Show a distinct "adjust your selection" banner **without** a retry button (a re-quote yields the same reason).
2. **Surface reserve failures**: `handleAccepted` now catches checkout-handler throws and surfaces them via `confirmError`; the storefront `defaultCheckoutHandler` throws localized errors on `/book` failure (distinct reserve-failed copy for `rates_missing`), missing `bookingId`, and `/checkout/start` error, and rethrows in the outer catch — so `<BookingJourney/>` renders a visible error instead of silently returning to Review.

## i18n / tests
- Added `pricingUnavailable`/`checkoutFailed` (bookings-react journey) + `checkoutFailed`/`reserveFailed` (operator storefront), en + ro; `pnpm i18n:check` passes.
- New `booking-journey.rates-missing.test.tsx`; all 85 bookings-react journey tests pass.
- Changeset: `@voyant-travel/bookings-react` patch.

## Secondary / deferred (from the issue)
- Auto-selecting the first room that has an applicable rate plan, and showing room/rate **names** (not raw IDs) in Review — deferred as follow-up UX.
- The React `Cannot update a component (BookingJourney) while rendering (PaymentStep)` warning is already fixed (intent-snap runs in a `useEffect`).

Fixes #2638
