### PR TITLE
Sync SmartBill invoice payments

### DIFF
--- a/.changeset/smartbill-payment-sync.md
+++ b/.changeset/smartbill-payment-sync.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/finance": patch
+---
+
+Emit an `invoice.payment.recorded` domain event when a completed customer payment is recorded against an invoice.

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -387,6 +387,7 @@ export type {
   InvoiceFromBookingData,
   InvoiceLineDescriptionResolver,
   InvoiceLineDescriptionResolverInput,
+  InvoicePaymentRecordedEvent,
   InvoiceRenderedEvent,
   InvoiceVoidedEvent,
   PaymentCompletedEvent,

--- a/packages/finance/src/service-invoice-payments.ts
+++ b/packages/finance/src/service-invoice-payments.ts
@@ -1,6 +1,7 @@
 import type {
   CreatePaymentInput,
   FinanceServiceRuntime,
+  InvoicePaymentRecordedEvent,
   PaymentListQuery,
   PostgresJsDatabase,
   RawUnifiedPaymentRow,
@@ -306,7 +307,8 @@ export const financeInvoicePaymentService = {
 
     const paymentId = newId("payments")
 
-    return db.transaction(async (tx) => {
+    let recordedPaymentEvent: InvoicePaymentRecordedEvent | null = null
+    const payment = await db.transaction(async (tx) => {
       if (runtime.actionLedgerContext) {
         const ledgerResult = await appendActionLedgerMutation(
           tx,
@@ -344,6 +346,10 @@ export const financeInvoicePaymentService = {
         })
         .returning()
 
+      if (!payment) {
+        throw new Error("Failed to insert invoice payment")
+      }
+
       const [sumResult] = await tx
         .select({ total: paymentSettlementAmountSql(invoice.currency) })
         .from(payments)
@@ -364,8 +370,39 @@ export const financeInvoicePaymentService = {
         .set({ paidCents, balanceDueCents, status: newStatus, updatedAt: new Date() })
         .where(eq(invoices.id, invoiceId))
 
+      if (payment.status === "completed") {
+        recordedPaymentEvent = {
+          invoiceId: invoice.id,
+          invoiceNumber: invoice.invoiceNumber,
+          invoiceType: invoice.invoiceType,
+          bookingId: invoice.bookingId,
+          invoiceCurrency: invoice.currency,
+          invoiceTotalCents: invoice.totalCents,
+          invoicePaidCents: paidCents,
+          invoiceBalanceDueCents: balanceDueCents,
+          paymentId: payment.id,
+          amountCents: payment.amountCents,
+          currency: payment.currency,
+          baseCurrency: payment.baseCurrency ?? null,
+          baseAmountCents: payment.baseAmountCents ?? null,
+          paymentMethod: payment.paymentMethod,
+          status: payment.status,
+          referenceNumber: payment.referenceNumber ?? null,
+          paymentDate: payment.paymentDate,
+        }
+      }
+
       return payment
     })
+
+    if (recordedPaymentEvent) {
+      await runtime.eventBus?.emit("invoice.payment.recorded", recordedPaymentEvent, {
+        category: "domain",
+        source: "service",
+      })
+    }
+
+    return payment
   },
 
   async updatePayment(

--- a/packages/finance/src/service-payment-session-completion.ts
+++ b/packages/finance/src/service-payment-session-completion.ts
@@ -2,6 +2,7 @@ import type {
   BookingPaymentSchedulePaidEvent,
   CompletePaymentSessionInput,
   FinanceServiceRuntime,
+  InvoicePaymentRecordedEvent,
   InvoiceSettledEvent,
   PostgresJsDatabase,
 } from "./service-shared.js"
@@ -72,6 +73,7 @@ export const financePaymentSessionCompletionService = {
       // a consistent post-update view. Stays null when this call doesn't
       // result in a new payment being applied to an invoice.
       let settlementForEmit: InvoiceSettledEvent | null = null
+      let recordedPaymentForEmit: InvoicePaymentRecordedEvent | null = null
       let bookingSchedulePaidForEmit: BookingPaymentSchedulePaidEvent | null = null
 
       if (!authorizationId) {
@@ -161,7 +163,7 @@ export const financePaymentSessionCompletionService = {
               .slice(0, 10),
             notes: data.notes ?? session.notes ?? null,
           })
-          .returning({ id: payments.id })
+          .returning()
 
         paymentId = payment?.id ?? null
 
@@ -190,14 +192,33 @@ export const financePaymentSessionCompletionService = {
           })
           .where(eq(invoices.id, invoiceForPayment.id))
 
-        if (paymentId) {
+        if (payment) {
           settlementForEmit = {
             invoiceId: invoiceForPayment.id,
-            paymentId,
+            paymentId: payment.id,
             provider: session.provider ?? "internal",
             newlyAppliedAmountCents: session.amountCents,
             paidCents,
             balanceDueCents,
+          }
+          recordedPaymentForEmit = {
+            invoiceId: invoiceForPayment.id,
+            invoiceNumber: invoiceForPayment.invoiceNumber,
+            invoiceType: invoiceForPayment.invoiceType,
+            bookingId: invoiceForPayment.bookingId,
+            invoiceCurrency: invoiceForPayment.currency,
+            invoiceTotalCents: invoiceForPayment.totalCents,
+            invoicePaidCents: paidCents,
+            invoiceBalanceDueCents: balanceDueCents,
+            paymentId: payment.id,
+            amountCents: payment.amountCents,
+            currency: payment.currency,
+            baseCurrency: payment.baseCurrency ?? null,
+            baseAmountCents: payment.baseAmountCents ?? null,
+            paymentMethod: payment.paymentMethod,
+            status: payment.status,
+            referenceNumber: payment.referenceNumber ?? null,
+            paymentDate: payment.paymentDate,
           }
         }
       }
@@ -293,9 +314,17 @@ export const financePaymentSessionCompletionService = {
       return {
         updated: updated ?? null,
         settlement: settlementForEmit,
+        recordedPayment: recordedPaymentForEmit,
         bookingSchedulePaid: bookingSchedulePaidForEmit,
       }
     })
+
+    if (txResult.recordedPayment) {
+      await runtime.eventBus?.emit("invoice.payment.recorded", txResult.recordedPayment, {
+        category: "domain",
+        source: "service",
+      })
+    }
 
     if (txResult.settlement) {
       await runtime.eventBus?.emit("invoice.settled", txResult.settlement, {

--- a/packages/finance/src/service-shared.ts
+++ b/packages/finance/src/service-shared.ts
@@ -1064,6 +1064,26 @@ export interface PaymentCompletedEvent {
   provider: string | null
 }
 
+export interface InvoicePaymentRecordedEvent {
+  invoiceId: string
+  invoiceNumber: string
+  invoiceType: (typeof invoices.$inferSelect)["invoiceType"]
+  bookingId: string | null
+  invoiceCurrency: string
+  invoiceTotalCents: number
+  invoicePaidCents: number
+  invoiceBalanceDueCents: number
+  paymentId: string
+  amountCents: number
+  currency: string
+  baseCurrency: string | null
+  baseAmountCents: number | null
+  paymentMethod: (typeof payments.$inferSelect)["paymentMethod"]
+  status: (typeof payments.$inferSelect)["status"]
+  referenceNumber: string | null
+  paymentDate: string
+}
+
 export type BookingGuaranteeRecord = typeof bookingGuarantees.$inferSelect
 
 export interface BindInvoiceRenditionInput {

--- a/packages/finance/tests/integration/routes.test.ts
+++ b/packages/finance/tests/integration/routes.test.ts
@@ -123,6 +123,7 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
   const invoiceVoidedEvents: Array<Record<string, unknown>> = []
   const invoiceIssuedEvents: Array<Record<string, unknown>> = []
   const proformaConvertedEvents: Array<Record<string, unknown>> = []
+  const invoicePaymentRecordedEvents: Array<Record<string, unknown>> = []
   const autoRenditionBookings = new Map<string, { delayMs: number; storageKey: string }>()
 
   beforeAll(async () => {
@@ -297,6 +298,9 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
         })
       }, request.delayMs)
     })
+    eventBus.subscribe("invoice.payment.recorded", (event) => {
+      invoicePaymentRecordedEvents.push(event as Record<string, unknown>)
+    })
     const financeRouteRuntime = {
       eventBus,
       invoiceSettlementPollers: {},
@@ -333,6 +337,7 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
     invoiceVoidedEvents.length = 0
     invoiceIssuedEvents.length = 0
     proformaConvertedEvents.length = 0
+    invoicePaymentRecordedEvents.length = 0
     autoRenditionBookings.clear()
   })
 
@@ -696,6 +701,24 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
         newlyAppliedAmountCents: 110000,
         paidCents: 110000,
         balanceDueCents: 0,
+      })
+      expect(invoicePaymentRecordedEvents).toHaveLength(1)
+      expect(invoicePaymentRecordedEvents[0]).toMatchObject({
+        invoiceId: invoice.id,
+        invoiceNumber: invoice.invoiceNumber,
+        invoiceType: "invoice",
+        bookingId: booking.id,
+        invoiceCurrency: "USD",
+        invoiceTotalCents: 110000,
+        invoicePaidCents: 110000,
+        invoiceBalanceDueCents: 0,
+        paymentId: data.paymentId,
+        amountCents: 110000,
+        currency: "USD",
+        paymentMethod: "credit_card",
+        status: "completed",
+        referenceNumber: "REF-1",
+        paymentDate: "2025-06-02",
       })
     })
 
@@ -2265,6 +2288,25 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       expect(data.id).toMatch(/^pay_/)
       expect(data.amountCents).toBe(20000)
       expect(data.invoiceId).toBe(inv.id)
+      expect(invoicePaymentRecordedEvents).toHaveLength(1)
+      expect(invoicePaymentRecordedEvents[0]?.data).toEqual(
+        expect.objectContaining({
+          invoiceId: inv.id,
+          invoiceNumber: inv.invoiceNumber,
+          invoiceType: "invoice",
+          bookingId: booking.id,
+          invoiceCurrency: "USD",
+          invoiceTotalCents: 50000,
+          invoicePaidCents: 20000,
+          invoiceBalanceDueCents: 30000,
+          paymentId: data.id,
+          amountCents: 20000,
+          currency: "USD",
+          paymentMethod: "bank_transfer",
+          status: "completed",
+          paymentDate: "2025-06-15",
+        }),
+      )
     })
 
     it("replays duplicate payment records with derived idempotency", async () => {
@@ -2285,6 +2327,7 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       })
       expect(firstRes.status).toBe(201)
       const { data: firstPayment } = await firstRes.json()
+      expect(invoicePaymentRecordedEvents).toHaveLength(1)
 
       const retryRes = await app.request(`/invoices/${inv.id}/payments`, {
         method: "POST",
@@ -2296,6 +2339,7 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
 
       const paymentRows = await db.select().from(payments).where(eq(payments.invoiceId, inv.id))
       expect(paymentRows).toHaveLength(1)
+      expect(invoicePaymentRecordedEvents).toHaveLength(1)
 
       const check = await app.request(`/invoices/${inv.id}`, { method: "GET" })
       const { data: invoiceAfterRetry } = await check.json()

--- a/starters/operator/src/api/subscribers/smartbill.test.ts
+++ b/starters/operator/src/api/subscribers/smartbill.test.ts
@@ -1,0 +1,236 @@
+import { financeService, type InvoicePaymentRecordedEvent } from "@voyant-travel/finance"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import {
+  buildSmartbillPaymentBody,
+  mapSmartbillPaymentType,
+  resolveSmartbillPaymentInvoiceRef,
+  syncRecordedInvoicePaymentWithDb,
+} from "./smartbill"
+
+const payload: InvoicePaymentRecordedEvent = {
+  invoiceId: "inv_1",
+  invoiceNumber: "SB-42",
+  invoiceType: "invoice",
+  bookingId: "book_1",
+  invoiceCurrency: "RON",
+  invoiceTotalCents: 12500,
+  invoicePaidCents: 12500,
+  invoiceBalanceDueCents: 0,
+  paymentId: "pay_1",
+  amountCents: 12500,
+  currency: "RON",
+  baseCurrency: null,
+  baseAmountCents: null,
+  paymentMethod: "bank_transfer",
+  status: "completed",
+  referenceNumber: "BT-99",
+  paymentDate: "2026-06-30",
+}
+
+const runtime = {
+  username: "user@example.test",
+  apiToken: "token",
+  companyVatCode: "RO12345678",
+  invoiceSeriesName: "SB",
+  proformaSeriesName: "PF",
+  apiUrl: "https://smartbill.test/api",
+  language: "RO",
+  art311SpecialRegime: false,
+  client: {},
+}
+
+describe("SmartBill payment sync", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("builds SmartBill collection bodies from completed invoice payments", () => {
+    expect(mapSmartbillPaymentType("bank_transfer")).toBe("Ordin plata")
+    expect(mapSmartbillPaymentType("credit_card")).toBe("Card")
+    expect(mapSmartbillPaymentType("cheque")).toBe("CEC")
+    expect(mapSmartbillPaymentType("other")).toBe("Alta incasare")
+
+    expect(
+      resolveSmartbillPaymentInvoiceRef({
+        externalId: null,
+        externalNumber: "42",
+        metadata: { seriesName: "SB", number: "42" },
+      }),
+    ).toEqual({ seriesName: "SB", number: "42" })
+
+    expect(buildSmartbillPaymentBody(runtime, payload, { seriesName: "SB", number: "42" })).toEqual(
+      {
+        companyVatCode: "RO12345678",
+        issueDate: "2026-06-30",
+        currency: "RON",
+        value: 125,
+        type: "Ordin plata",
+        isCash: false,
+        observation: "Voyant payment pay_1 (BT-99)",
+        useInvoiceDetails: true,
+        invoicesList: [{ seriesName: "SB", number: "42" }],
+      },
+    )
+  })
+
+  it("pushes completed local invoice payments to SmartBill and marks the ref paid", async () => {
+    const listRefs = vi.spyOn(financeService, "listInvoiceExternalRefs").mockResolvedValue([
+      {
+        id: "iner_1",
+        invoiceId: payload.invoiceId,
+        provider: "smartbill",
+        externalId: "42",
+        externalNumber: "42",
+        externalUrl: "https://smartbill.test/invoice/42",
+        status: "issued",
+        metadata: { seriesName: "SB", number: "42", documentType: "invoice" },
+        syncedAt: null,
+        syncError: null,
+        createdAt: new Date("2026-06-01T00:00:00Z"),
+        updatedAt: new Date("2026-06-01T00:00:00Z"),
+      },
+    ])
+    const registerRef = vi
+      .spyOn(financeService, "registerInvoiceExternalRef")
+      .mockResolvedValue(null)
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ message: "ok", number: "RCPT-1" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    )
+
+    await syncRecordedInvoicePaymentWithDb({} as never, runtime as never, payload)
+
+    expect(listRefs).toHaveBeenCalledWith({}, payload.invoiceId)
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://smartbill.test/api/payment",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          companyVatCode: "RO12345678",
+          issueDate: "2026-06-30",
+          currency: "RON",
+          value: 125,
+          type: "Ordin plata",
+          isCash: false,
+          observation: "Voyant payment pay_1 (BT-99)",
+          useInvoiceDetails: true,
+          invoicesList: [{ seriesName: "SB", number: "42" }],
+        }),
+      }),
+    )
+    expect(registerRef).toHaveBeenCalledWith(
+      {},
+      payload.invoiceId,
+      expect.objectContaining({
+        provider: "smartbill",
+        externalId: "42",
+        externalNumber: "42",
+        externalUrl: "https://smartbill.test/invoice/42",
+        status: "paid",
+        syncError: null,
+        metadata: expect.objectContaining({
+          documentType: "invoice",
+          lastPaymentSync: expect.objectContaining({
+            paymentId: "pay_1",
+            smartbillValue: 125,
+            smartbillCurrency: "RON",
+            type: "Ordin plata",
+          }),
+        }),
+      }),
+    )
+  })
+
+  it("does not post duplicate SmartBill payments for a redelivered payment event", async () => {
+    vi.spyOn(financeService, "listInvoiceExternalRefs").mockResolvedValue([
+      {
+        id: "iner_1",
+        invoiceId: payload.invoiceId,
+        provider: "smartbill",
+        externalId: "42",
+        externalNumber: "42",
+        externalUrl: "https://smartbill.test/invoice/42",
+        status: "paid",
+        metadata: {
+          seriesName: "SB",
+          number: "42",
+          documentType: "invoice",
+          lastPaymentSync: { paymentId: payload.paymentId },
+        },
+        syncedAt: null,
+        syncError: null,
+        createdAt: new Date("2026-06-01T00:00:00Z"),
+        updatedAt: new Date("2026-06-01T00:00:00Z"),
+      },
+    ])
+    const registerRef = vi.spyOn(financeService, "registerInvoiceExternalRef")
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+
+    await syncRecordedInvoicePaymentWithDb({} as never, runtime as never, payload)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(registerRef).not.toHaveBeenCalled()
+  })
+
+  it("stores SmartBill payment failures in metadata without blocking later payments", async () => {
+    vi.spyOn(financeService, "listInvoiceExternalRefs").mockResolvedValue([
+      {
+        id: "iner_1",
+        invoiceId: payload.invoiceId,
+        provider: "smartbill",
+        externalId: "42",
+        externalNumber: "42",
+        externalUrl: "https://smartbill.test/invoice/42",
+        status: "issued",
+        metadata: { seriesName: "SB", number: "42", documentType: "invoice" },
+        syncedAt: null,
+        syncError: null,
+        createdAt: new Date("2026-06-01T00:00:00Z"),
+        updatedAt: new Date("2026-06-01T00:00:00Z"),
+      },
+    ])
+    const registerRef = vi
+      .spyOn(financeService, "registerInvoiceExternalRef")
+      .mockResolvedValue(null)
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ errorText: "temporary SmartBill outage" }), { status: 503 }),
+    )
+
+    await syncRecordedInvoicePaymentWithDb({} as never, runtime as never, payload)
+
+    expect(registerRef).toHaveBeenCalledWith(
+      {},
+      payload.invoiceId,
+      expect.objectContaining({
+        provider: "smartbill",
+        status: "issued",
+        syncError: null,
+        metadata: expect.objectContaining({
+          lastPaymentSyncError: expect.objectContaining({
+            paymentId: payload.paymentId,
+            message: "temporary SmartBill outage",
+          }),
+        }),
+      }),
+    )
+  })
+
+  it("skips SmartBill payment pushes for non-invoice or non-completed events", async () => {
+    const listRefs = vi.spyOn(financeService, "listInvoiceExternalRefs")
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+
+    await syncRecordedInvoicePaymentWithDb({} as never, runtime as never, {
+      ...payload,
+      status: "pending",
+    })
+    await syncRecordedInvoicePaymentWithDb({} as never, runtime as never, {
+      ...payload,
+      invoiceType: "proforma",
+    })
+
+    expect(listRefs).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/starters/operator/src/api/subscribers/smartbill.ts
+++ b/starters/operator/src/api/subscribers/smartbill.ts
@@ -2,6 +2,7 @@
 import { bookings } from "@voyant-travel/bookings/schema"
 import {
   financeService,
+  type InvoicePaymentRecordedEvent,
   type InvoiceSettlementPoller,
   invoiceLineItems,
   invoices,
@@ -45,6 +46,8 @@ type InvoiceIssuedPayload = {
 
 type SmartbillRuntime = {
   client: ReturnType<typeof createSmartbillClient>
+  username: string
+  apiToken: string
   companyVatCode: string
   invoiceSeriesName: string
   proformaSeriesName: string
@@ -56,6 +59,29 @@ type SmartbillRuntime = {
 type SmartbillTaxRegime = {
   name: string
   ratePercent: number | null
+}
+
+type SmartbillPaymentType =
+  | "Card"
+  | "CEC"
+  | "Bilet ordin"
+  | "Ordin plata"
+  | "Mandat postal"
+  | "Alta incasare"
+
+type SmartbillPaymentBody = {
+  companyVatCode: string
+  issueDate: string
+  currency: string
+  value: number
+  type: SmartbillPaymentType
+  isCash: boolean
+  observation?: string
+  useInvoiceDetails: boolean
+  invoicesList: Array<{
+    seriesName: string
+    number: string
+  }>
 }
 
 export const smartbillOperatorBundle: HonoBundle = {
@@ -79,6 +105,13 @@ export const smartbillOperatorBundle: HonoBundle = {
     eventBus.subscribe<InvoiceIssuedPayload>("invoice.proforma.issued", async ({ data }) => {
       await syncIssuedInvoice(env, runtime, data, "proforma")
     })
+
+    eventBus.subscribe<InvoicePaymentRecordedEvent>(
+      "invoice.payment.recorded",
+      async ({ data }) => {
+        await syncRecordedInvoicePayment(env, runtime, data)
+      },
+    )
   },
 }
 
@@ -103,7 +136,7 @@ export function createSmartbillSettlementPollers(
 async function ensureSmartbillInvoiceNumberSeries(env: SmartbillEnv, runtime: SmartbillRuntime) {
   try {
     await withDbFromEnv(env, async (rawDb) => {
-      const db = rawDb as unknown as PostgresJsDatabase
+      const db = asFinanceDb(rawDb)
       await financeService.ensureExternalInvoiceNumberSeries(db, [
         {
           provider: "smartbill",
@@ -175,7 +208,7 @@ async function syncIssuedInvoice(
   const invoiceId = payload.invoiceId
   if (!invoiceId) return
   await withDbFromEnv(env, async (rawDb) => {
-    const db = rawDb as unknown as PostgresJsDatabase
+    const db = asFinanceDb(rawDb)
     await syncIssuedInvoiceWithDb(env, db, runtime, invoiceId, documentType)
   })
 }
@@ -261,6 +294,194 @@ async function syncIssuedInvoiceWithDb(
       syncError: error instanceof Error ? error.message : String(error),
     })
   }
+}
+
+async function syncRecordedInvoicePayment(
+  env: SmartbillEnv,
+  runtime: SmartbillRuntime,
+  payload: InvoicePaymentRecordedEvent,
+) {
+  if (payload.status !== "completed") return
+  await withDbFromEnv(env, async (rawDb) => {
+    const db = asFinanceDb(rawDb)
+    await syncRecordedInvoicePaymentWithDb(db, runtime, payload)
+  })
+}
+
+export async function syncRecordedInvoicePaymentWithDb(
+  db: PostgresJsDatabase,
+  runtime: SmartbillRuntime,
+  payload: InvoicePaymentRecordedEvent,
+) {
+  if (payload.status !== "completed" || payload.invoiceType !== "invoice") return
+
+  const externalRefs = await financeService.listInvoiceExternalRefs(db, payload.invoiceId)
+  const smartbillRef = externalRefs.find((ref) => ref.provider === "smartbill")
+  if (!smartbillRef) return
+
+  const invoiceRef = resolveSmartbillPaymentInvoiceRef(smartbillRef)
+  if (!invoiceRef) return
+
+  const metadata = toRecord(smartbillRef.metadata)
+  if (smartbillRef.syncError && !isPaymentSyncError(metadata, smartbillRef.syncError)) return
+  if (metadata?.documentType === "proforma") return
+  if (hasSyncedSmartbillPayment(metadata, payload.paymentId)) return
+
+  const body = buildSmartbillPaymentBody(runtime, payload, invoiceRef)
+  if (!body) return
+
+  try {
+    const result = await createSmartbillPayment(runtime, body)
+    const nextMetadata = {
+      ...withoutLastPaymentSyncError(metadata),
+      lastPaymentSync: {
+        paymentId: payload.paymentId,
+        paymentDate: payload.paymentDate,
+        amountCents: payload.amountCents,
+        currency: payload.currency,
+        smartbillValue: body.value,
+        smartbillCurrency: body.currency,
+        type: body.type,
+        message: typeof result.message === "string" ? result.message : null,
+        number: typeof result.number === "string" ? result.number : null,
+        syncedAt: new Date().toISOString(),
+      },
+    }
+    await financeService.registerInvoiceExternalRef(db, payload.invoiceId, {
+      provider: "smartbill",
+      externalId: smartbillRef.externalId,
+      externalNumber: smartbillRef.externalNumber,
+      externalUrl: smartbillRef.externalUrl,
+      status: payload.invoiceBalanceDueCents <= 0 ? "paid" : "partially_paid",
+      metadata: nextMetadata,
+      syncedAt: new Date().toISOString(),
+      syncError: null,
+    })
+  } catch (error) {
+    await financeService.registerInvoiceExternalRef(db, payload.invoiceId, {
+      provider: "smartbill",
+      externalId: smartbillRef.externalId,
+      externalNumber: smartbillRef.externalNumber,
+      externalUrl: smartbillRef.externalUrl,
+      status: smartbillRef.status,
+      metadata: {
+        ...(metadata ?? {}),
+        lastPaymentSyncError: {
+          paymentId: payload.paymentId,
+          message: error instanceof Error ? error.message : String(error),
+          syncedAt: new Date().toISOString(),
+        },
+      },
+      syncedAt: new Date().toISOString(),
+      syncError: null,
+    })
+  }
+}
+
+function hasSyncedSmartbillPayment(
+  metadata: Record<string, unknown> | null,
+  paymentId: string,
+): boolean {
+  const lastPaymentSync = toRecord(metadata?.lastPaymentSync)
+  return readString(lastPaymentSync, "paymentId") === paymentId
+}
+
+function isPaymentSyncError(
+  metadata: Record<string, unknown> | null,
+  syncError: string | null,
+): boolean {
+  return (
+    Boolean(toRecord(metadata?.lastPaymentSyncError)) ||
+    Boolean(syncError?.startsWith("Payment sync failed:"))
+  )
+}
+
+function withoutLastPaymentSyncError(
+  metadata: Record<string, unknown> | null,
+): Record<string, unknown> {
+  const { lastPaymentSyncError: _lastPaymentSyncError, ...rest } = metadata ?? {}
+  return rest
+}
+
+export function buildSmartbillPaymentBody(
+  runtime: Pick<SmartbillRuntime, "companyVatCode">,
+  payload: InvoicePaymentRecordedEvent,
+  invoiceRef: { seriesName: string; number: string },
+): SmartbillPaymentBody | null {
+  const amountCents =
+    payload.currency === payload.invoiceCurrency
+      ? payload.amountCents
+      : payload.baseCurrency === payload.invoiceCurrency
+        ? payload.baseAmountCents
+        : null
+  if (amountCents == null || amountCents <= 0) return null
+
+  return {
+    companyVatCode: runtime.companyVatCode,
+    issueDate: payload.paymentDate,
+    currency: payload.invoiceCurrency,
+    value: centsToMajor(amountCents),
+    type: mapSmartbillPaymentType(payload.paymentMethod),
+    isCash: payload.paymentMethod === "cash",
+    observation:
+      payload.referenceNumber && payload.referenceNumber.trim().length > 0
+        ? `Voyant payment ${payload.paymentId} (${payload.referenceNumber.trim()})`
+        : `Voyant payment ${payload.paymentId}`,
+    useInvoiceDetails: true,
+    invoicesList: [invoiceRef],
+  }
+}
+
+export function resolveSmartbillPaymentInvoiceRef(ref: {
+  externalId: string | null
+  externalNumber: string | null
+  metadata?: unknown
+}): { seriesName: string; number: string } | null {
+  const metadata = toRecord(ref.metadata)
+  const seriesName =
+    readString(metadata, "seriesName") ??
+    readString(metadata, "series") ??
+    readString(metadata, "invoiceSeriesName")
+  const number = readString(metadata, "number") ?? ref.externalNumber ?? ref.externalId
+  if (!seriesName || !number) return null
+  return { seriesName, number }
+}
+
+export function mapSmartbillPaymentType(
+  method: InvoicePaymentRecordedEvent["paymentMethod"],
+): SmartbillPaymentType {
+  switch (method) {
+    case "bank_transfer":
+    case "direct_bill":
+      return "Ordin plata"
+    case "credit_card":
+    case "debit_card":
+    case "wallet":
+      return "Card"
+    case "cheque":
+      return "CEC"
+    default:
+      return "Alta incasare"
+  }
+}
+
+async function createSmartbillPayment(runtime: SmartbillRuntime, body: SmartbillPaymentBody) {
+  const apiUrl = (runtime.apiUrl ?? "https://ws.smartbill.ro/SBORO/api").replace(/\/$/, "")
+  const response = await fetch(`${apiUrl}/payment`, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${btoa(`${runtime.username}:${runtime.apiToken}`)}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(body),
+  })
+  const text = await response.text()
+  const parsed = toRecord(parseJson(text))
+  if (!response.ok || isSmartbillError(parsed)) {
+    throw new Error(readString(parsed, "errorText") ?? `SmartBill payment sync failed: ${text}`)
+  }
+  return parsed ?? {}
 }
 
 /**
@@ -533,4 +754,33 @@ function formatExternalInvoiceNumber(seriesName: string | undefined, number: str
 
 function parseBoolean(value: unknown): boolean {
   return value === true || value === "true" || value === "1" || value === "yes"
+}
+
+function asFinanceDb(db: unknown): PostgresJsDatabase {
+  return db as PostgresJsDatabase
+}
+
+function toRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function readString(value: unknown, key: string): string | null {
+  const record = toRecord(value)
+  const raw = record?.[key]
+  return typeof raw === "string" && raw.trim().length > 0 ? raw.trim() : null
+}
+
+function parseJson(text: string): unknown {
+  try {
+    return text ? JSON.parse(text) : null
+  } catch {
+    return null
+  }
+}
+
+function isSmartbillError(value: unknown): boolean {
+  const record = toRecord(value)
+  return record?.status === "Error" || Boolean(readString(record, "errorText"))
 }


### PR DESCRIPTION
## Summary

- Emit an `invoice.payment.recorded` domain event when a completed invoice payment is recorded locally.
- Subscribe the operator SmartBill integration to that event and push completed invoice payments to SmartBill via the documented `/payment` collection endpoint.
- Update SmartBill external refs to `paid` / `partially_paid` after successful payment push, preserving payment sync metadata and recording sync errors on failure.
- Add regression coverage for the finance event path and SmartBill payment body/push behavior.

Fixes #2450

## Verification

- `pnpm --filter operator test src/api/subscribers/smartbill.test.ts`
- `NODE_OPTIONS=--max-old-space-size=14336 pnpm --filter @voyant-travel/finance typecheck`
- `pnpm exec biome check packages/finance/src/index.ts packages/finance/src/service-invoice-payments.ts packages/finance/src/service-shared.ts packages/finance/tests/integration/routes.test.ts starters/operator/src/api/subscribers/smartbill.ts starters/operator/src/api/subscribers/smartbill.test.ts`
- `pnpm --filter @voyant-travel/finance test tests/integration/routes.test.ts` skipped because `TEST_DATABASE_URL` is not set.
- Pre-push `pnpm test` ran the full workspace lane and failed in unrelated operator timeout tests: `src/workflows-import.test.ts` and `src/api/lib/booking-engine-runtime.test.ts`.
