### PR TITLE
Fix local no-cloud operator runtime wiring

### DIFF
--- a/starters/operator/.dev.vars.example
+++ b/starters/operator/.dev.vars.example
@@ -33,11 +33,12 @@ API_BASE_URL="http://localhost:3100/api"
 CORS_ALLOWLIST="http://localhost:3100"
 
 # Voyant API (canonical email / sms / verify / vault / connect provider).
-# Required — templates do not fall back to direct Resend/Twilio.
+# Optional for local/self-hosted no-cloud development. Leave unset/empty to
+# disable Cloud-backed FX, realtime, and notification delivery.
 # Self-hosters who want a different transport can swap the provider in
 # src/lib/notifications.ts (see @voyant-travel/notifications for the
 # NotificationProvider interface).
-VOYANT_API_KEY="vc_..."
+# VOYANT_API_KEY="vc_..."
 # VOYANT_CLOUD_API_URL="https://api.voyant.travel"
 # VOYANT_CLOUD_VAULT_SLUG="main"
 

--- a/starters/operator/env.d.ts
+++ b/starters/operator/env.d.ts
@@ -69,8 +69,10 @@ interface CloudflareBindings {
   VOYANT_OPERATOR_BROWSER_EVIDENCE?: string
   VOYANT_AUTH_LOG_SECRET_FALLBACKS?: string
 
-  // Voyant API (canonical email/sms/verify/vault/connect provider)
-  VOYANT_API_KEY: string
+  // Voyant API (canonical email/sms/verify/vault/connect provider). Optional
+  // for local/self-hosted deployments that do not use Voyant Cloud-backed
+  // providers.
+  VOYANT_API_KEY?: string
   /** Legacy alias for VOYANT_API_KEY. */
   VOYANT_CLOUD_API_KEY?: string
   VOYANT_CLOUD_API_URL?: string

--- a/starters/operator/src/api/runtime/operator-runtime-adapter.test.ts
+++ b/starters/operator/src/api/runtime/operator-runtime-adapter.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+
+import { createOperatorInvoiceExchangeRateResolver } from "./operator-runtime-adapter"
+
+describe("createOperatorInvoiceExchangeRateResolver", () => {
+  it("disables Voyant Data FX when no API key is configured", () => {
+    expect(createOperatorInvoiceExchangeRateResolver({})).toBeUndefined()
+    expect(createOperatorInvoiceExchangeRateResolver({ VOYANT_API_KEY: "" })).toBeUndefined()
+    expect(createOperatorInvoiceExchangeRateResolver({ VOYANT_API_KEY: "   " })).toBeUndefined()
+  })
+
+  it("uses a configured Voyant API key", () => {
+    const resolver = createOperatorInvoiceExchangeRateResolver({
+      VOYANT_API_KEY: "vc_test",
+      VOYANT_CLOUD_API_URL: "https://api.example.test",
+    })
+
+    expect(resolver).toEqual(expect.any(Function))
+  })
+})

--- a/starters/operator/src/api/runtime/operator-runtime-adapter.ts
+++ b/starters/operator/src/api/runtime/operator-runtime-adapter.ts
@@ -67,7 +67,7 @@ export async function createOperatorBookingPiiService(bindings: unknown) {
 export function createOperatorInvoiceExchangeRateResolver(bindings: unknown) {
   const env = operatorBindings(bindings)
   const apiKey = resolveVoyantApiKey(env)
-  if (!apiKey) throw new Error("VOYANT_API_KEY is not set")
+  if (!apiKey) return undefined
   return createVoyantDataFxExchangeRateResolver({
     apiKey,
     baseUrl: env.VOYANT_CLOUD_API_URL,

--- a/starters/operator/src/lib/notifications.test.ts
+++ b/starters/operator/src/lib/notifications.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveNotificationProviders } from "./notifications"
+
+describe("resolveNotificationProviders", () => {
+  it("leaves notification delivery unconfigured without a Voyant API key", () => {
+    expect(resolveNotificationProviders({})).toEqual([])
+    expect(resolveNotificationProviders({ VOYANT_API_KEY: "" })).toEqual([])
+    expect(resolveNotificationProviders({ VOYANT_API_KEY: "   " })).toEqual([])
+  })
+
+  it("configures Voyant Cloud notification providers when a key is present", () => {
+    const providers = resolveNotificationProviders({
+      VOYANT_API_KEY: "vc_test",
+      EMAIL_FROM: "Voyant <noreply@example.test>",
+    })
+
+    expect(providers.map((provider) => provider.name)).toEqual([
+      "voyant-cloud-email",
+      "voyant-cloud-sms",
+    ])
+  })
+})

--- a/starters/operator/src/lib/notifications.ts
+++ b/starters/operator/src/lib/notifications.ts
@@ -6,11 +6,12 @@ import {
   type NotificationProvider,
   type NotificationTaskRuntimeOptions,
 } from "@voyant-travel/notifications"
-import { getCloudClient } from "./voyant-cloud"
+import { getCloudClient, resolveVoyantApiKey } from "./voyant-cloud"
 
 export const resolveNotificationProviders = (
   env: Record<string, unknown>,
 ): ReadonlyArray<NotificationProvider> => {
+  if (!resolveVoyantApiKey(env)) return []
   const cloud = getCloudClient(env)
   const from =
     typeof env.EMAIL_FROM === "string" && env.EMAIL_FROM.length > 0

--- a/starters/operator/src/lib/realtime.test.ts
+++ b/starters/operator/src/lib/realtime.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveRealtimeProviders } from "./realtime"
+
+describe("resolveRealtimeProviders", () => {
+  it("leaves realtime unconfigured without a Voyant API key", () => {
+    expect(resolveRealtimeProviders({})).toEqual([])
+    expect(resolveRealtimeProviders({ VOYANT_API_KEY: "" })).toEqual([])
+  })
+
+  it("does not call Voyant Cloud in local admin auth mode, even with a placeholder key", () => {
+    expect(
+      resolveRealtimeProviders({
+        VOYANT_ADMIN_AUTH_MODE: "local",
+        VOYANT_API_KEY: "local-dev",
+      }),
+    ).toEqual([])
+  })
+
+  it("configures Voyant Cloud realtime only in cloud admin auth mode with a key", () => {
+    const providers = resolveRealtimeProviders({
+      VOYANT_ADMIN_AUTH_MODE: "voyant-cloud",
+      VOYANT_API_KEY: "vc_test",
+    })
+
+    expect(providers).toHaveLength(1)
+    expect(providers[0]?.name).toBe("voyant-cloud")
+  })
+})

--- a/starters/operator/src/lib/realtime.ts
+++ b/starters/operator/src/lib/realtime.ts
@@ -1,17 +1,17 @@
 import type { RealtimeProvider, RealtimeRouteResult, RealtimeRoutes } from "@voyant-travel/realtime"
 import { createVoyantCloudRealtimeProvider } from "@voyant-travel/realtime/providers/voyant-cloud"
 
-import { getCloudClient } from "./voyant-cloud"
+import { getCloudClient, isVoyantCloudAdminAuthMode, resolveVoyantApiKey } from "./voyant-cloud"
 
 /**
- * Resolve the realtime transport for this deployment — the Voyant Cloud
- * provider backed by the shared cloud client (mirrors
- * `resolveNotificationProviders`). The SDK's `client.realtime` namespace
- * satisfies the provider's structural contract directly, so no cast is needed.
+ * Resolve the realtime transport for this deployment. Local/self-hosted
+ * operator deployments deliberately leave realtime unconfigured so routine
+ * admin page loads do not call Voyant Cloud with empty or placeholder keys.
  */
 export function resolveRealtimeProviders(
   env: Record<string, unknown>,
 ): ReadonlyArray<RealtimeProvider> {
+  if (!isVoyantCloudAdminAuthMode(env) || !resolveVoyantApiKey(env)) return []
   return [createVoyantCloudRealtimeProvider({ client: getCloudClient(env) })]
 }
 

--- a/starters/operator/src/lib/voyant-cloud.test.ts
+++ b/starters/operator/src/lib/voyant-cloud.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+
+import { isVoyantCloudAdminAuthMode, resolveVoyantApiKey, tryGetCloudClient } from "./voyant-cloud"
+
+describe("voyant cloud env helpers", () => {
+  it("treats missing, empty, and whitespace API keys as unconfigured", () => {
+    expect(resolveVoyantApiKey({})).toBeUndefined()
+    expect(resolveVoyantApiKey({ VOYANT_API_KEY: "" })).toBeUndefined()
+    expect(resolveVoyantApiKey({ VOYANT_API_KEY: "   " })).toBeUndefined()
+  })
+
+  it("prefers the canonical key and trims configured values", () => {
+    expect(
+      resolveVoyantApiKey({
+        VOYANT_API_KEY: " vc_primary ",
+        VOYANT_CLOUD_API_KEY: "vc_legacy",
+      }),
+    ).toBe("vc_primary")
+    expect(resolveVoyantApiKey({ VOYANT_CLOUD_API_KEY: " vc_legacy " })).toBe("vc_legacy")
+  })
+
+  it("recognizes only explicit Voyant Cloud admin auth mode", () => {
+    expect(isVoyantCloudAdminAuthMode({})).toBe(false)
+    expect(isVoyantCloudAdminAuthMode({ VOYANT_ADMIN_AUTH_MODE: "local" })).toBe(false)
+    expect(isVoyantCloudAdminAuthMode({ VOYANT_ADMIN_AUTH_MODE: "voyant-cloud" })).toBe(true)
+  })
+
+  it("does not pass whitespace-only legacy API keys through to the Cloud SDK", () => {
+    expect(tryGetCloudClient({ VOYANT_CLOUD_API_KEY: "   " })).toBeNull()
+  })
+})

--- a/starters/operator/src/lib/voyant-cloud.ts
+++ b/starters/operator/src/lib/voyant-cloud.ts
@@ -22,21 +22,29 @@ type CloudClientEnv = Parameters<typeof getVoyantCloudClient>[0]
 type TryCloudClientEnv = Parameters<typeof tryGetVoyantCloudClient>[0]
 
 export type VoyantApiEnv = {
-  VOYANT_API_KEY?: string
-  VOYANT_CLOUD_API_KEY?: string
-  VOYANT_CLOUD_API_URL?: string
-  VOYANT_CLOUD_USER_AGENT?: string
+  VOYANT_API_KEY?: unknown
+  VOYANT_CLOUD_API_KEY?: unknown
+  VOYANT_CLOUD_API_URL?: unknown
+  VOYANT_CLOUD_USER_AGENT?: unknown
+  VOYANT_ADMIN_AUTH_MODE?: unknown
 }
 
 export function resolveVoyantApiKey(env: VoyantApiEnv): string | undefined {
   return nonEmpty(env.VOYANT_API_KEY) ?? nonEmpty(env.VOYANT_CLOUD_API_KEY)
 }
 
+export function isVoyantCloudAdminAuthMode(env: VoyantApiEnv): boolean {
+  return nonEmpty(env.VOYANT_ADMIN_AUTH_MODE) === "voyant-cloud"
+}
+
 export function getCloudClient(env: VoyantApiEnv): VoyantCloudClient {
   const cached = CLIENT_CACHE.get(env)
   if (cached) return cached
   const apiKey = resolveVoyantApiKey(env)
-  const client = getVoyantCloudClient(asCloudClientEnv(env), apiKey ? { apiKey } : undefined)
+  const client = getVoyantCloudClient(
+    asCloudClientEnv(env, apiKey),
+    apiKey ? { apiKey } : undefined,
+  )
   CLIENT_CACHE.set(env, client)
   return client
 }
@@ -45,19 +53,37 @@ export function tryGetCloudClient(env: VoyantApiEnv): VoyantCloudClient | null {
   const cached = CLIENT_CACHE.get(env)
   if (cached) return cached
   const apiKey = resolveVoyantApiKey(env)
-  const client = tryGetVoyantCloudClient(asTryCloudClientEnv(env), apiKey ? { apiKey } : undefined)
+  const client = tryGetVoyantCloudClient(
+    asTryCloudClientEnv(env, apiKey),
+    apiKey ? { apiKey } : undefined,
+  )
   if (client) CLIENT_CACHE.set(env, client)
   return client
 }
 
-function asCloudClientEnv(env: VoyantApiEnv): CloudClientEnv {
-  return env as CloudClientEnv
+function asCloudClientEnv(env: VoyantApiEnv, apiKey: string | undefined): CloudClientEnv {
+  return sanitizeCloudClientEnv(env, apiKey) as CloudClientEnv
 }
 
-function asTryCloudClientEnv(env: VoyantApiEnv): TryCloudClientEnv {
-  return env as TryCloudClientEnv
+function asTryCloudClientEnv(env: VoyantApiEnv, apiKey: string | undefined): TryCloudClientEnv {
+  return sanitizeCloudClientEnv(env, apiKey) as TryCloudClientEnv
 }
 
-function nonEmpty(value: string | undefined): string | undefined {
-  return typeof value === "string" && value.length > 0 ? value : undefined
+function sanitizeCloudClientEnv(
+  env: VoyantApiEnv,
+  apiKey: string | undefined,
+): Pick<VoyantApiEnv, "VOYANT_CLOUD_API_KEY" | "VOYANT_CLOUD_API_URL" | "VOYANT_CLOUD_USER_AGENT"> {
+  const baseUrl = nonEmpty(env.VOYANT_CLOUD_API_URL)
+  const userAgent = nonEmpty(env.VOYANT_CLOUD_USER_AGENT)
+  return {
+    ...(apiKey ? { VOYANT_CLOUD_API_KEY: apiKey } : {}),
+    ...(baseUrl ? { VOYANT_CLOUD_API_URL: baseUrl } : {}),
+    ...(userAgent ? { VOYANT_CLOUD_USER_AGENT: userAgent } : {}),
+  }
+}
+
+function nonEmpty(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
 }


### PR DESCRIPTION
## Summary

- Allow the operator starter to run without Voyant Cloud credentials by treating empty or whitespace Voyant API keys as unconfigured.
- Disable the Voyant Data invoice FX resolver when no API key is configured instead of failing finance route bootstrap.
- Keep admin realtime unconfigured for local/self-hosted admin auth mode, even if a placeholder API key is present, so routine page loads do not call Voyant Cloud.
- Return no Cloud notification providers when no API key is configured, preserving the existing empty-provider degradation paths.

Closes #2448.

## Validation

- `pnpm --dir starters/operator exec vitest run src/lib/voyant-cloud.test.ts src/lib/realtime.test.ts src/lib/notifications.test.ts src/api/runtime/operator-runtime-adapter.test.ts --pool=threads --maxWorkers=2`
- `pnpm --dir starters/operator exec biome check src/lib/voyant-cloud.ts src/lib/realtime.ts src/lib/notifications.ts src/api/runtime/operator-runtime-adapter.ts src/lib/voyant-cloud.test.ts src/lib/realtime.test.ts src/lib/notifications.test.ts src/api/runtime/operator-runtime-adapter.test.ts`
- Pre-push hook ran `pnpm test` successfully (`96 successful` Turbo tasks).

## Changeset

No changeset is required: this only changes private `starters/operator` runtime wiring, env docs, and starter tests. No publishable package source or package metadata changed.

## Caveat

An earlier full commit hook run expanded into broad repo type/build checks and hit environment OOM kills (`exit 137`) in unrelated package typechecks before I stopped it. The focused checks above and the later pre-push test hook completed successfully.
