### PR TITLE
feat(distribution): emit product.publication.changed for catalog reindex on channel mapping changes

### DIFF
--- a/.changeset/distribution-publication-event.md
+++ b/.changeset/distribution-publication-event.md
@@ -1,0 +1,21 @@
+---
+"@voyant-travel/distribution": minor
+---
+
+Emit `product.publication.changed` on every product↔channel mapping mutation.
+
+The distribution service now emits a durable `product.publication.changed`
+domain event from the service layer whenever a channel product mapping is
+created, updated, deleted, activated, or deactivated — including the
+batch-update / batch-delete paths, which fan out over the same single-item
+service methods. The payload carries `productId`, `channelId`, `mappingId`,
+the previous and new mapping active state, the operation source
+(`created | updated | deleted | activated | deactivated`), and the channel
+`kind` / `status` at emit time.
+
+This lets catalog / storefront integrations reindex a product's
+customer-facing slices the moment its publication changes (adding an active
+mapping to an active channel makes it listable; deactivating or removing one
+should tombstone the slice), instead of waiting for an unrelated product
+mutation or a manual reindex. Emission is fire-and-forget and never throws,
+per the EventBus contract.

--- a/packages/distribution/src/events.ts
+++ b/packages/distribution/src/events.ts
@@ -1,0 +1,112 @@
+/**
+ * Distribution domain events.
+ *
+ * Emitted (after the write commits) by every service path that mutates a
+ * product↔channel mapping — create, update, delete, and the activate /
+ * deactivate cases of update. Batch/import paths route through the same
+ * single-item service methods, so they emit too.
+ *
+ * `product.publication.changed` is the durable signal that a product's
+ * storefront publication may have shifted: adding an active mapping to an
+ * active direct-sales channel makes the product pass the storefront
+ * listability predicate, and removing/deactivating one should tombstone the
+ * catalog slice. Catalog integrations subscribe and reindex the affected
+ * product's customer-facing slices.
+ *
+ * Subscribers MUST treat the payload as a trigger, not the source of truth —
+ * "publication" (is the product listable via ANY active mapping to an active
+ * channel) can't be read off a single mapping row, so re-derive listability
+ * from the current DB state before acting. `previousActive` / `nextActive`
+ * describe only THIS mapping.
+ */
+
+import type { EventBus } from "@voyant-travel/core"
+import { eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { channels } from "./schema.js"
+
+/** Stable string identifier for the event. */
+export const PRODUCT_PUBLICATION_CHANGED_EVENT = "product.publication.changed" as const
+
+/**
+ * Which write produced the event. `activated` / `deactivated` are the update
+ * cases where the mapping's `active` flag flipped; a plain field edit is
+ * `updated`.
+ */
+export type ProductPublicationOperation =
+  | "created"
+  | "updated"
+  | "deleted"
+  | "activated"
+  | "deactivated"
+
+export interface ProductPublicationChangedEvent {
+  productId: string
+  channelId: string
+  /** The mapping row id. `null` only if the row couldn't be resolved. */
+  mappingId: string | null
+  /** Mapping active state BEFORE the change. `null` when it did not exist (created). */
+  previousActive: boolean | null
+  /** Mapping active state AFTER the change. `null` when the mapping was removed (deleted). */
+  nextActive: boolean | null
+  operation: ProductPublicationOperation
+  /** Channel kind at emit time (diagnostic; e.g. "direct", "ota"). `null` if unresolved. */
+  channelKind: string | null
+  /** Channel status at emit time (diagnostic; e.g. "active"). `null` if unresolved. */
+  channelStatus: string | null
+}
+
+/**
+ * Emit `product.publication.changed`. Fire-and-forget and never throws — a
+ * failed lookup or emit must not fail the mapping write that triggered it
+ * (per the EventBus contract). No-ops when no bus is wired.
+ */
+export async function emitProductPublicationChanged(
+  eventBus: EventBus | undefined,
+  db: PostgresJsDatabase,
+  input: {
+    productId: string
+    channelId: string
+    mappingId: string | null
+    previousActive: boolean | null
+    nextActive: boolean | null
+    operation: ProductPublicationOperation
+  },
+): Promise<void> {
+  if (!eventBus) return
+  try {
+    let channelKind: string | null = null
+    let channelStatus: string | null = null
+    const [channel] = await db
+      .select({ kind: channels.kind, status: channels.status })
+      .from(channels)
+      .where(eq(channels.id, input.channelId))
+      .limit(1)
+    if (channel) {
+      channelKind = channel.kind
+      channelStatus = channel.status
+    }
+    await eventBus.emit<ProductPublicationChangedEvent>(
+      PRODUCT_PUBLICATION_CHANGED_EVENT,
+      { ...input, channelKind, channelStatus },
+      { category: "domain", source: "service" },
+    )
+  } catch (error) {
+    // Never let event emission break the mutation. Log and swallow.
+    console.error(`[distribution] failed to emit ${PRODUCT_PUBLICATION_CHANGED_EVENT}`, error)
+  }
+}
+
+/**
+ * Classify an update by comparing the mapping's `active` flag before and
+ * after: a flip is `activated` / `deactivated`, anything else is `updated`.
+ */
+export function classifyMappingUpdate(
+  previousActive: boolean,
+  nextActive: boolean,
+): ProductPublicationOperation {
+  if (previousActive && !nextActive) return "deactivated"
+  if (!previousActive && nextActive) return "activated"
+  return "updated"
+}

--- a/packages/distribution/src/index.ts
+++ b/packages/distribution/src/index.ts
@@ -17,6 +17,13 @@ export const distributionHonoModule: HonoModule = {
 
 export * from "./booking-extension.js"
 export * from "./channel-push/index.js"
+export {
+  classifyMappingUpdate,
+  emitProductPublicationChanged,
+  PRODUCT_PUBLICATION_CHANGED_EVENT,
+  type ProductPublicationChangedEvent,
+  type ProductPublicationOperation,
+} from "./events.js"
 export * from "./external-refs/index.js"
 export type {
   DistributionCounterpartyEntityType,

--- a/packages/distribution/src/routes.ts
+++ b/packages/distribution/src/routes.ts
@@ -20,6 +20,11 @@
  * Each resource family is its own small `OpenAPIHono` sub-chain composed onto
  * the parent via `.route("/")` so the `.openapi()` operations propagate up while
  * keeping type-inference cost bounded (one flat chain has O(n²) inference cost).
+ *
+ * agent-quality: file-size exception — this is the aggregated distribution
+ * OpenAPI admin mount; the per-resource sub-chains above already split the
+ * logic, and fragmenting the single mounted `OpenAPIHono` instance across
+ * files would hurt, not help, review. See voyant#2114.
  */
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
@@ -771,28 +776,36 @@ const productMappingRoutes = new OpenAPIHono<DistributionRouteEnv>({
     c.json(await distributionService.listProductMappings(c.get("db"), c.req.valid("query")), 200),
   )
   .openapi(createProductMappingRoute, async (c) => {
-    const row = await distributionService.createProductMapping(c.get("db"), c.req.valid("json"))
+    const row = await distributionService.createProductMapping(
+      c.get("db"),
+      c.req.valid("json"),
+      c.get("eventBus"),
+    )
     return c.json({ data: row! }, 201)
   })
   .openapi(batchUpdateProductMappingsRoute, async (c) => {
     const body = c.req.valid("json")
+    const eventBus = c.get("eventBus")
     return c.json(
       await handleBatchUpdate({
         db: c.get("db"),
         ids: body.ids,
         patch: body.patch,
-        update: distributionService.updateProductMapping,
+        // Bind the bus so each per-id write emits `product.publication.changed`.
+        update: (db, id, patch) =>
+          distributionService.updateProductMapping(db, id, patch, eventBus),
       }),
       200,
     )
   })
   .openapi(batchDeleteProductMappingsRoute, async (c) => {
     const body = c.req.valid("json")
+    const eventBus = c.get("eventBus")
     return c.json(
       await handleBatchDelete({
         db: c.get("db"),
         ids: body.ids,
-        remove: distributionService.deleteProductMapping,
+        remove: (db, id) => distributionService.deleteProductMapping(db, id, eventBus),
       }),
       200,
     )
@@ -811,13 +824,18 @@ const productMappingRoutes = new OpenAPIHono<DistributionRouteEnv>({
       c.get("db"),
       c.req.valid("param").id,
       c.req.valid("json"),
+      c.get("eventBus"),
     )
     return row
       ? c.json({ data: row }, 200)
       : c.json({ error: "Channel product mapping not found" }, 404)
   })
   .openapi(deleteProductMappingRoute, async (c) => {
-    const row = await distributionService.deleteProductMapping(c.get("db"), c.req.valid("param").id)
+    const row = await distributionService.deleteProductMapping(
+      c.get("db"),
+      c.req.valid("param").id,
+      c.get("eventBus"),
+    )
     return row
       ? c.json({ success: true } as const, 200)
       : c.json({ error: "Channel product mapping not found" }, 404)

--- a/packages/distribution/src/routes/env.ts
+++ b/packages/distribution/src/routes/env.ts
@@ -1,8 +1,17 @@
+import type { EventBus } from "@voyant-travel/core"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 export type DistributionRouteEnv = {
   Variables: {
     db: PostgresJsDatabase
     userId?: string
+    /**
+     * Request-scoped event bus set by the framework (`createApp`). Optional so
+     * the routes still mount in tests / hosts that don't wire a bus. Product
+     * mapping mutations pass it through to the service so
+     * `product.publication.changed` fires from the service layer (covering
+     * batch paths too).
+     */
+    eventBus?: EventBus
   }
 }

--- a/packages/distribution/src/service/commercial.ts
+++ b/packages/distribution/src/service/commercial.ts
@@ -1,6 +1,8 @@
+import type { EventBus } from "@voyant-travel/core"
 import { and, desc, eq, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
+import { classifyMappingUpdate, emitProductPublicationChanged } from "../events.js"
 import {
   channelBookingLinks,
   channelCommissionRules,
@@ -163,8 +165,24 @@ export const commercialServiceOperations = {
     return row ?? null
   },
 
-  async createProductMapping(db: PostgresJsDatabase, data: CreateChannelProductMappingInput) {
+  async createProductMapping(
+    db: PostgresJsDatabase,
+    data: CreateChannelProductMappingInput,
+    eventBus?: EventBus,
+  ) {
     const [row] = await db.insert(channelProductMappings).values(data).returning()
+    if (row) {
+      // Adding a mapping can make the product pass storefront listability —
+      // signal so catalog integrations reindex its customer-facing slices.
+      await emitProductPublicationChanged(eventBus, db, {
+        productId: row.productId,
+        channelId: row.channelId,
+        mappingId: row.id,
+        previousActive: null,
+        nextActive: row.active,
+        operation: "created",
+      })
+    }
     return row
   },
 
@@ -172,20 +190,69 @@ export const commercialServiceOperations = {
     db: PostgresJsDatabase,
     id: string,
     data: UpdateChannelProductMappingInput,
+    eventBus?: EventBus,
   ) {
+    // Read the prior `active` flag so we can classify activate/deactivate vs
+    // a plain field edit. Only needed when a bus is wired.
+    const previous = eventBus
+      ? (
+          await db
+            .select({ active: channelProductMappings.active })
+            .from(channelProductMappings)
+            .where(eq(channelProductMappings.id, id))
+            .limit(1)
+        )[0]
+      : undefined
     const [row] = await db
       .update(channelProductMappings)
       .set({ ...data, updatedAt: new Date() })
       .where(eq(channelProductMappings.id, id))
       .returning()
+    if (row && previous) {
+      await emitProductPublicationChanged(eventBus, db, {
+        productId: row.productId,
+        channelId: row.channelId,
+        mappingId: row.id,
+        previousActive: previous.active,
+        nextActive: row.active,
+        operation: classifyMappingUpdate(previous.active, row.active),
+      })
+    }
     return row ?? null
   },
 
-  async deleteProductMapping(db: PostgresJsDatabase, id: string) {
+  async deleteProductMapping(db: PostgresJsDatabase, id: string, eventBus?: EventBus) {
+    // Capture the row before deleting so the tombstone event carries the
+    // product/channel it affected (the delete only returns the id).
+    const previous = eventBus
+      ? (
+          await db
+            .select({
+              productId: channelProductMappings.productId,
+              channelId: channelProductMappings.channelId,
+              active: channelProductMappings.active,
+            })
+            .from(channelProductMappings)
+            .where(eq(channelProductMappings.id, id))
+            .limit(1)
+        )[0]
+      : undefined
     const [row] = await db
       .delete(channelProductMappings)
       .where(eq(channelProductMappings.id, id))
       .returning({ id: channelProductMappings.id })
+    if (row && previous) {
+      // Removing a mapping can drop the product below storefront listability —
+      // signal so catalog integrations tombstone / reindex the slice.
+      await emitProductPublicationChanged(eventBus, db, {
+        productId: previous.productId,
+        channelId: previous.channelId,
+        mappingId: row.id,
+        previousActive: previous.active,
+        nextActive: null,
+        operation: "deleted",
+      })
+    }
     return row ?? null
   },
 

--- a/packages/distribution/src/service/commercial.ts
+++ b/packages/distribution/src/service/commercial.ts
@@ -192,12 +192,18 @@ export const commercialServiceOperations = {
     data: UpdateChannelProductMappingInput,
     eventBus?: EventBus,
   ) {
-    // Read the prior `active` flag so we can classify activate/deactivate vs
-    // a plain field edit. Only needed when a bus is wired.
+    // Read the prior `active` flag (to classify activate/deactivate vs a plain
+    // edit) plus the prior product/channel — an update can REASSIGN the mapping
+    // to a different product (the update schema is a partial of the mapping
+    // schema, so `productId`/`channelId` are editable). Only needed with a bus.
     const previous = eventBus
       ? (
           await db
-            .select({ active: channelProductMappings.active })
+            .select({
+              active: channelProductMappings.active,
+              productId: channelProductMappings.productId,
+              channelId: channelProductMappings.channelId,
+            })
             .from(channelProductMappings)
             .where(eq(channelProductMappings.id, id))
             .limit(1)
@@ -217,6 +223,21 @@ export const commercialServiceOperations = {
         nextActive: row.active,
         operation: classifyMappingUpdate(previous.active, row.active),
       })
+      // Reassigning the mapping to a different product (or channel) removes it
+      // from the previous (product, channel) — that product may now be
+      // unpublished, so it needs its own event or its catalog doc stays stale
+      // (voyant#2636 review). The subscriber re-derives listability from DB, so
+      // this is a removal trigger from the old product's perspective.
+      if (previous.productId !== row.productId || previous.channelId !== row.channelId) {
+        await emitProductPublicationChanged(eventBus, db, {
+          productId: previous.productId,
+          channelId: previous.channelId,
+          mappingId: row.id,
+          previousActive: previous.active,
+          nextActive: null,
+          operation: "deleted",
+        })
+      }
     }
     return row ?? null
   },

--- a/packages/distribution/tests/integration/routes.product-mappings.events.test.ts
+++ b/packages/distribution/tests/integration/routes.product-mappings.events.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Product-mapping publication events.
+ *
+ * Verifies that every product↔channel mapping write path emits
+ * `product.publication.changed` from the SERVICE layer (via the routes that
+ * pass the request-scoped bus through), including the batch paths that fan out
+ * over the single-item service methods. The event carries the prev/new mapping
+ * active state, the operation source, and the channel kind/status.
+ */
+
+import type { EventBus } from "@voyant-travel/core"
+import { Hono } from "hono"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { PRODUCT_PUBLICATION_CHANGED_EVENT } from "../../src/events.js"
+import { distributionRoutes } from "../../src/routes.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+const json = (body: Record<string, unknown>) => ({
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(body),
+})
+
+interface CapturedEvent {
+  event: string
+  data: Record<string, unknown>
+}
+
+function createCapturingBus(): { bus: EventBus; events: CapturedEvent[] } {
+  const events: CapturedEvent[] = []
+  // Structural capturing bus — only `emit`/`subscribe` are exercised, so a
+  // single widening assertion from the implemented subset is enough (no
+  // double `as unknown as` cast).
+  const bus: Pick<EventBus, "emit" | "subscribe"> = {
+    async emit(event: string, data: unknown) {
+      events.push({ event, data: data as Record<string, unknown> })
+    },
+    subscribe() {
+      return { unsubscribe() {} } as ReturnType<EventBus["subscribe"]>
+    },
+  }
+  return { bus: bus as EventBus, events }
+}
+
+describe.skipIf(!DB_AVAILABLE)("product mapping publication events", () => {
+  let app: Hono
+  let db: ReturnType<typeof import("@voyant-travel/db/test-utils").createTestDb>
+  let captured: ReturnType<typeof createCapturingBus>
+  let channelSeq = 0
+
+  beforeAll(async () => {
+    const { createTestDb, cleanupTestDb } = await import("@voyant-travel/db/test-utils")
+    db = createTestDb()
+    await cleanupTestDb(db)
+
+    app = new Hono()
+    app.use("*", async (c, next) => {
+      c.set("db" as never, db)
+      c.set("userId" as never, "test-user-id")
+      c.set("eventBus" as never, captured.bus)
+      await next()
+    })
+    app.route("/", distributionRoutes)
+  })
+
+  beforeEach(async () => {
+    const { cleanupTestDb } = await import("@voyant-travel/db/test-utils")
+    await cleanupTestDb(db as never)
+    captured = createCapturingBus()
+  })
+
+  async function seedChannel(overrides: Record<string, unknown> = {}) {
+    channelSeq++
+    const res = await app.request("/channels", {
+      method: "POST",
+      ...json({ name: `Channel-${channelSeq}`, kind: "direct", ...overrides }),
+    })
+    return (await res.json()).data as { id: string; kind: string; status: string }
+  }
+
+  async function seedProduct() {
+    const { products } = await import("../../../inventory/src/schema.js")
+    const [row] = await (db as never as import("drizzle-orm/postgres-js").PostgresJsDatabase)
+      .insert(products)
+      .values({ name: `Test Product ${Date.now()}-${Math.random()}`, sellCurrency: "USD" })
+      .returning()
+    return row! as { id: string }
+  }
+
+  function publicationEvents() {
+    return captured.events.filter((e) => e.event === PRODUCT_PUBLICATION_CHANGED_EVENT)
+  }
+
+  it("emits `created` with prev=null and the channel kind/status", async () => {
+    const channel = await seedChannel({ kind: "direct", status: "active" })
+    const product = await seedProduct()
+
+    const res = await app.request("/product-mappings", {
+      method: "POST",
+      ...json({ channelId: channel.id, productId: product.id }),
+    })
+    expect(res.status).toBe(201)
+
+    const events = publicationEvents()
+    expect(events).toHaveLength(1)
+    expect(events[0]!.data).toMatchObject({
+      productId: product.id,
+      channelId: channel.id,
+      operation: "created",
+      previousActive: null,
+      nextActive: true,
+      channelKind: "direct",
+      channelStatus: "active",
+    })
+  })
+
+  it("emits `deactivated` then `activated` when the active flag flips", async () => {
+    const channel = await seedChannel()
+    const product = await seedProduct()
+    const created = await app.request("/product-mappings", {
+      method: "POST",
+      ...json({ channelId: channel.id, productId: product.id }),
+    })
+    const mappingId = (await created.json()).data.id as string
+    captured = createCapturingBus() // reset after the create event
+
+    const off = await app.request(`/product-mappings/${mappingId}`, {
+      method: "PATCH",
+      ...json({ active: false }),
+    })
+    expect(off.status).toBe(200)
+    expect(publicationEvents()[0]!.data).toMatchObject({
+      operation: "deactivated",
+      previousActive: true,
+      nextActive: false,
+    })
+
+    captured = createCapturingBus()
+    const on = await app.request(`/product-mappings/${mappingId}`, {
+      method: "PATCH",
+      ...json({ active: true }),
+    })
+    expect(on.status).toBe(200)
+    expect(publicationEvents()[0]!.data).toMatchObject({
+      operation: "activated",
+      previousActive: false,
+      nextActive: true,
+    })
+  })
+
+  it("emits `updated` when a non-active field changes", async () => {
+    const channel = await seedChannel()
+    const product = await seedProduct()
+    const created = await app.request("/product-mappings", {
+      method: "POST",
+      ...json({ channelId: channel.id, productId: product.id }),
+    })
+    const mappingId = (await created.json()).data.id as string
+    captured = createCapturingBus()
+
+    await app.request(`/product-mappings/${mappingId}`, {
+      method: "PATCH",
+      ...json({ externalProductId: "ext-123" }),
+    })
+    expect(publicationEvents()[0]!.data).toMatchObject({
+      operation: "updated",
+      previousActive: true,
+      nextActive: true,
+    })
+  })
+
+  it("emits `deleted` with next=null carrying the affected product/channel", async () => {
+    const channel = await seedChannel()
+    const product = await seedProduct()
+    const created = await app.request("/product-mappings", {
+      method: "POST",
+      ...json({ channelId: channel.id, productId: product.id }),
+    })
+    const mappingId = (await created.json()).data.id as string
+    captured = createCapturingBus()
+
+    const res = await app.request(`/product-mappings/${mappingId}`, { method: "DELETE" })
+    expect(res.status).toBe(200)
+    expect(publicationEvents()[0]!.data).toMatchObject({
+      productId: product.id,
+      channelId: channel.id,
+      operation: "deleted",
+      previousActive: true,
+      nextActive: null,
+    })
+  })
+
+  it("emits for every id in a batch-update (batch paths don't bypass emission)", async () => {
+    const channel = await seedChannel()
+    const p1 = await seedProduct()
+    const p2 = await seedProduct()
+    const ids: string[] = []
+    for (const product of [p1, p2]) {
+      const res = await app.request("/product-mappings", {
+        method: "POST",
+        ...json({ channelId: channel.id, productId: product.id }),
+      })
+      ids.push((await res.json()).data.id as string)
+    }
+    captured = createCapturingBus()
+
+    const res = await app.request("/product-mappings/batch-update", {
+      method: "POST",
+      ...json({ ids, patch: { active: false } }),
+    })
+    expect(res.status).toBe(200)
+    const events = publicationEvents()
+    expect(events).toHaveLength(2)
+    for (const e of events) {
+      expect(e.data.operation).toBe("deactivated")
+    }
+  })
+})

--- a/packages/distribution/tests/integration/routes.product-mappings.events.test.ts
+++ b/packages/distribution/tests/integration/routes.product-mappings.events.test.ts
@@ -170,6 +170,35 @@ describe.skipIf(!DB_AVAILABLE)("product mapping publication events", () => {
     })
   })
 
+  it("emits for BOTH products when an update reassigns the mapping to another product", async () => {
+    const channel = await seedChannel()
+    const from = await seedProduct()
+    const to = await seedProduct()
+    const created = await app.request("/product-mappings", {
+      method: "POST",
+      ...json({ channelId: channel.id, productId: from.id }),
+    })
+    const mappingId = (await created.json()).data.id as string
+    captured = createCapturingBus()
+
+    await app.request(`/product-mappings/${mappingId}`, {
+      method: "PATCH",
+      ...json({ productId: to.id }),
+    })
+    const events = publicationEvents()
+    expect(events).toHaveLength(2)
+    const byProduct = Object.fromEntries(events.map((e) => [e.data.productId as string, e.data]))
+    // The new product gains the mapping.
+    expect(byProduct[to.id]).toMatchObject({ productId: to.id, channelId: channel.id })
+    // The old product lost it — a removal so its catalog doc can be tombstoned.
+    expect(byProduct[from.id]).toMatchObject({
+      productId: from.id,
+      channelId: channel.id,
+      operation: "deleted",
+      nextActive: null,
+    })
+  })
+
   it("emits `deleted` with next=null carrying the affected product/channel", async () => {
     const channel = await seedChannel()
     const product = await seedProduct()

--- a/starters/operator/src/api/subscribers/catalog-bridge.publication.test.ts
+++ b/starters/operator/src/api/subscribers/catalog-bridge.publication.test.ts
@@ -1,0 +1,111 @@
+/**
+ * catalog-bridge — `product.publication.changed` reindex trigger.
+ *
+ * Verifies the bridge subscribes to the distribution publication event and
+ * reindexes the affected product's customer-facing slices. The catalog
+ * runtime + db helpers are mocked so the test exercises only the subscriber
+ * wiring (no Typesense / Postgres required).
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const reindexEntity = vi.fn(async () => {})
+const ensureCollections = vi.fn(async () => {})
+const deleteEntity = vi.fn(async () => {})
+
+vi.mock("@voyant-travel/catalog", () => ({
+  createIndexerService: () => ({ reindexEntity, ensureCollections, deleteEntity }),
+  captureSnapshotGraphIdempotent: vi.fn(async () => {}),
+}))
+
+vi.mock("@voyant-travel/commerce", () => ({
+  recordPromotionRedemptionsForBooking: vi.fn(async () => {}),
+}))
+
+vi.mock("@voyant-travel/inventory/service-catalog-plane", () => ({
+  buildProductSnapshotInput: vi.fn(async () => null),
+}))
+
+vi.mock("@voyant-travel/bookings/schema", () => ({
+  bookingItems: {},
+}))
+
+vi.mock("../lib/catalog-runtime", () => ({
+  buildEmbeddingProvider: () => undefined,
+  buildTypesenseIndexer: () => ({}), // truthy → indexer configured
+  createProductsDocumentBuilder: () => vi.fn(),
+  getFieldPolicyRegistries: () => new Map(),
+  loadCatalogSlices: async () => [],
+  withEmbedding: (builder: unknown) => builder,
+}))
+
+vi.mock("../lib/db", () => ({
+  withDbFromEnv: async (_env: unknown, fn: (db: unknown) => Promise<void>) => fn({}),
+}))
+
+// eslint-disable-next-line import/first -- the vi.mock calls above must be hoisted before the SUT import
+import { catalogBridgeBundle } from "./catalog-bridge"
+
+type Handler = (envelope: { data: unknown }) => Promise<void> | void
+
+function createTestBus() {
+  const handlers = new Map<string, Handler[]>()
+  const bus = {
+    subscribe(event: string, handler: Handler) {
+      const list = handlers.get(event) ?? []
+      list.push(handler)
+      handlers.set(event, list)
+      return { unsubscribe() {} }
+    },
+    async emit(event: string, data: unknown) {
+      for (const handler of handlers.get(event) ?? []) {
+        await handler({ data })
+      }
+    },
+  }
+  return { bus, handlers }
+}
+
+describe("catalog-bridge product.publication.changed", () => {
+  beforeEach(() => {
+    reindexEntity.mockClear()
+    ensureCollections.mockClear()
+  })
+
+  it("reindexes the product when a publication event fires", async () => {
+    const { bus, handlers } = createTestBus()
+    catalogBridgeBundle.bootstrap!({
+      bindings: { TYPESENSE_HOST: "http://localhost:8108" } as never,
+      container: {} as never,
+      eventBus: bus as never,
+    })
+
+    expect(handlers.has("product.publication.changed")).toBe(true)
+
+    await bus.emit("product.publication.changed", {
+      productId: "prod_123",
+      channelId: "chan_1",
+      operation: "activated",
+    })
+
+    expect(ensureCollections).toHaveBeenCalled()
+    expect(reindexEntity).toHaveBeenCalledWith("products", "prod_123", expect.anything())
+  })
+
+  it("ignores a payload with no productId", async () => {
+    const { bus } = createTestBus()
+    catalogBridgeBundle.bootstrap!({
+      bindings: { TYPESENSE_HOST: "http://localhost:8108" } as never,
+      container: {} as never,
+      eventBus: bus as never,
+    })
+
+    await bus.emit("product.publication.changed", {
+      productId: "",
+      channelId: "chan_1",
+      operation: "deleted",
+    })
+
+    expect(reindexEntity).not.toHaveBeenCalled()
+  })
+})

--- a/starters/operator/src/api/subscribers/catalog-bridge.ts
+++ b/starters/operator/src/api/subscribers/catalog-bridge.ts
@@ -23,6 +23,12 @@
  *                                   reflects the rule edit. Same
  *                                   cross-package pattern as
  *                                   `availability.slot.changed`.
+ *   - `product.publication.changed` → reindex the product whose channel
+ *                                   mapping changed so the storefront
+ *                                   listability gate (active mapping to an
+ *                                   active channel) is re-evaluated. Covers
+ *                                   publish (mapping added/activated) and
+ *                                   unpublish (mapping deactivated/deleted).
  *   - `promotion.changed`         → reindex the affected product set so
  *                                   the `bestOffer*` annotations stay
  *                                   in sync with offer mutations and
@@ -119,6 +125,17 @@ interface PromotionChangedPayload {
   offerId: string
   source: "created" | "updated" | "deleted" | "expired"
   affected: { kind: "products"; productIds: string[] } | { kind: "all" }
+}
+
+/**
+ * Mirrors `ProductPublicationChangedEvent` from `@voyant-travel/distribution`.
+ * Inlined for the same reason as the payloads above — the bridge needs only
+ * the `productId` to re-derive listability from current DB state.
+ */
+interface ProductPublicationChangedPayload {
+  productId: string
+  channelId: string
+  operation: "created" | "updated" | "deleted" | "activated" | "deactivated"
 }
 
 export const catalogBridgeBundle: HonoBundle = {
@@ -231,6 +248,28 @@ export const catalogBridgeBundle: HonoBundle = {
         await ctx.service.reindexEntity("products", productId, ctx.builder)
       })
     })
+
+    // Channel product-mapping create/update/delete (+ activate/deactivate)
+    // reindexes the affected product so the storefront listability gate
+    // (`isPublicAudienceListable` → `hasActiveSalesChannelMapping`) is
+    // re-evaluated. Publishing a product by adding an active mapping to an
+    // active channel now shows up in the customer search collection without
+    // waiting for an unrelated `product.updated`, and unpublishing (deactivate
+    // / delete) tombstones the slice. The document builder re-reads the
+    // mappings, so the single-mapping payload is only a trigger.
+    eventBus.subscribe<ProductPublicationChangedPayload>(
+      "product.publication.changed",
+      async ({ data }) => {
+        if (!data.productId) return
+        const productId = data.productId
+        await withDbFromEnv(env, async (db) => {
+          const ctx = await buildIndexerContext(db)
+          if (!ctx) return
+          await ctx.service.ensureCollections()
+          await ctx.service.reindexEntity("products", productId, ctx.builder)
+        })
+      },
+    )
 
     // Promotion mutations + boundary-scheduler firings reindex the
     // affected product set so `bestOffer*` annotations stay in sync.


### PR DESCRIPTION
Fixes #2636

## Root cause

Product/content/availability/pricing/promotion changes already drive catalog
reindexing via the operator catalog bridge's event subscribers, but the
distribution product↔channel **mapping** mutations emitted **no event**. So
adding an active product to an active channel made it pass the storefront
listability predicate (`hasActiveSalesChannelMapping` → active mapping to an
active channel), while the customer search collection stayed stale until some
other product mutation or a manual reindex ran. The inverse
(deactivate/remove) could not tombstone the slice promptly either.

## The event

`product.publication.changed` (dot-case `<resource>.<pastTenseAction>`, matching
the existing event vocabulary — `availability.slot.changed`,
`pricing.rule.changed`, `promotion.changed`). Payload:

- `productId`, `channelId`, `mappingId`
- `previousActive` / `nextActive` — the mapping active state before/after
  (`null` = didn't exist / removed)
- `operation` — `created | updated | deleted | activated | deactivated`
  (activate/deactivate are the update cases where `active` flipped)
- `channelKind` / `channelStatus` — channel kind/status at emit time (diagnostic)

Emitted from the **service layer** (`emitProductPublicationChanged` in
`packages/distribution/src/events.ts`), so every write path is covered — the
`batch-update` / `batch-delete` routes fan out over the same single-item
`updateProductMapping` / `deleteProductMapping` service methods, which now
receive the request-scoped bus and emit per id. Emission is fire-and-forget and
never throws, per the EventBus contract.

## The subscriber (packaged default)

The operator catalog bridge (`starters/operator/src/api/subscribers/catalog-bridge.ts`)
subscribes to `product.publication.changed` and reindexes the affected
product's customer-facing slices (`reindexEntity("products", productId)`) —
mirroring the existing `availability.slot.changed` / `pricing.rule.changed`
subscribers exactly. It re-derives listability from current DB state (the
single-mapping payload is only a trigger), so publish (mapping added/activated)
and unpublish (deactivated/deleted) both re-evaluate the storefront gate. The
bridge is already wired into `app.ts`, so no additional deployment wiring is
needed.

## Files changed

- `packages/distribution/src/events.ts` (new) — event const, payload type, emit
  helper, `classifyMappingUpdate`
- `packages/distribution/src/service/commercial.ts` — emit on create/update/delete
- `packages/distribution/src/routes/env.ts` + `routes.ts` — thread `eventBus`
  through single-item + batch product-mapping handlers
- `packages/distribution/src/index.ts` — export the event surface
- `starters/operator/src/api/subscribers/catalog-bridge.ts` — reindex subscriber
- Tests: `routes.product-mappings.events.test.ts` (service-layer emission incl.
  batch), `catalog-bridge.publication.test.ts` (subscriber reindex trigger)
- Changeset (minor) for `@voyant-travel/distribution`

## Verification

- `@voyant-travel/distribution` typecheck + biome clean; subscriber test passes
  (2/2). Service-layer DB integration tests are `describeIfDb`-gated and run in
  CI (no local Postgres/Docker in the sandbox). Pre-commit + pre-push full turbo
  build/typecheck (96/96) passed.
