### PR TITLE
Fix durable outbox delivery bookkeeping

### DIFF
--- a/.changeset/outbox-delivery-bookkeeping.md
+++ b/.changeset/outbox-delivery-bookkeeping.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/core": patch
+"@voyant-travel/hono": patch
+---
+
+Keep durable event outbox rows tied to subscriber delivery when request schedulers fail after capture.

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -307,6 +307,18 @@ export function createEventBus(options: EventBusOptions = {}): EventBus {
     return { ...(metadata ?? {}), eventId: generateEventId() }
   }
 
+  async function scheduleOrAwait(
+    schedule: (pending: Promise<unknown>) => void,
+    pending: Promise<unknown>,
+  ) {
+    try {
+      schedule(pending)
+    } catch (err) {
+      console.error("[events] scheduler rejected deferred delivery; awaiting inline:", err)
+      await pending
+    }
+  }
+
   return {
     async emit<TData, TMetadata extends EventMetadata | undefined = EventMetadata | undefined>(
       event: string,
@@ -334,7 +346,7 @@ export function createEventBus(options: EventBusOptions = {}): EventBus {
 
       if (!store) {
         if (emitOptions?.schedule && deferrable.length > 0) {
-          emitOptions.schedule(run(deferrable))
+          await scheduleOrAwait(emitOptions.schedule, run(deferrable))
           if (inline.length > 0) await run(inline)
           return
         }
@@ -365,7 +377,8 @@ export function createEventBus(options: EventBusOptions = {}): EventBus {
 
       if (emitOptions.schedule && deferrable.length > 0) {
         const inlineErrors = inline.length > 0 ? await run(inline) : []
-        emitOptions.schedule(
+        await scheduleOrAwait(
+          emitOptions.schedule,
           run(deferrable).then((deferredErrors) => settle([...inlineErrors, ...deferredErrors])),
         )
         return

--- a/packages/core/tests/unit/events.test.ts
+++ b/packages/core/tests/unit/events.test.ts
@@ -223,6 +223,29 @@ describe("createEventBus", () => {
       expect(errorSpy).toHaveBeenCalled()
       errorSpy.mockRestore()
     })
+
+    it("awaits deferred handlers inline when the scheduler throws", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+      const bus = createEventBus()
+      let deferredRan = false
+      bus.subscribe("x", async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        deferredRan = true
+      })
+
+      await bus.emit("x", {}, undefined, {
+        schedule: () => {
+          throw new Error("waitUntil unavailable")
+        },
+      })
+
+      expect(deferredRan).toBe(true)
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("scheduler rejected deferred delivery"),
+        expect.any(Error),
+      )
+      errorSpy.mockRestore()
+    })
   })
 })
 
@@ -313,6 +336,32 @@ describe("durable emit via EmitOptions.store (transactional outbox)", () => {
     await Promise.all(scheduled)
     expect(deferredDone).toBe(true)
     expect(store.complete).toHaveBeenCalledWith("evob_1")
+  })
+
+  it("settles the row when the scheduler throws after capture", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const bus = createEventBus()
+    const store = fakeStore()
+    const handler = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    })
+    bus.subscribe("x", handler)
+
+    await bus.emit("x", {}, undefined, {
+      store,
+      schedule: () => {
+        throw new Error("waitUntil unavailable")
+      },
+    })
+
+    expect(handler).toHaveBeenCalledOnce()
+    expect(store.complete).toHaveBeenCalledWith("evob_1")
+    expect(store.fail).not.toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("scheduler rejected deferred delivery"),
+      expect.any(Error),
+    )
+    errorSpy.mockRestore()
   })
 })
 

--- a/packages/hono/src/lib/request-event-bus.ts
+++ b/packages/hono/src/lib/request-event-bus.ts
@@ -11,9 +11,10 @@ import type { EmitOptions, EventBus, EventMetadata, OutboxEventStore } from "@vo
  * With a `store` (transactional outbox), emits are also DURABLE: the
  * envelope is persisted before any handler runs, and failed deliveries
  * are retried by the drain. If the durable capture itself fails (DB
- * unreachable), the emit falls back to direct (non-durable) delivery —
- * losing durability for that one event is strictly better than losing
- * the event, and an order of magnitude better than failing the request.
+ * unreachable), the emit falls back to direct (non-durable) delivery.
+ * Once capture has succeeded, the wrapper must not redeliver directly:
+ * the stored row owns completion/retry, and direct fallback would make
+ * subscriber side effects ambiguous.
  *
  * Buses that predate the {@link EmitOptions} parameter simply ignore it
  * and keep awaiting all handlers — a safe degradation.
@@ -37,11 +38,29 @@ export function requestScopedEventBus(
       if (!store) {
         return bus.emit(event, data, metadata, { ...base, ...options })
       }
+      let captureFailed = false
+      const guardedStore: OutboxEventStore = {
+        async insert(envelope) {
+          try {
+            return await store.insert(envelope)
+          } catch (err) {
+            captureFailed = true
+            throw err
+          }
+        },
+        complete: (id) => store.complete(id),
+        fail: (id, error) => store.fail(id, error),
+      }
       try {
-        return await bus.emit(event, data, metadata, { ...base, store, ...options })
+        return await bus.emit(event, data, metadata, { ...base, store: guardedStore, ...options })
       } catch (err) {
-        // Only the outbox insert can reject (handler errors are
-        // collected, bookkeeping failures are swallowed inside the bus).
+        if (!captureFailed) {
+          console.error(
+            `[events] durable delivery failed for "${event}" after outbox capture:`,
+            err,
+          )
+          return
+        }
         console.error(
           `[events] outbox capture failed for "${event}" — falling back to direct delivery:`,
           err,

--- a/packages/hono/tests/unit/request-event-bus.test.ts
+++ b/packages/hono/tests/unit/request-event-bus.test.ts
@@ -1,4 +1,4 @@
-import type { EventBus } from "@voyant-travel/core"
+import type { EventBus, OutboxEventStore } from "@voyant-travel/core"
 import { describe, expect, it, vi } from "vitest"
 
 import { requestScopedEventBus } from "../../src/lib/request-event-bus.js"
@@ -23,16 +23,30 @@ describe("requestScopedEventBus", () => {
       "x",
       { a: 1 },
       { correlationId: "c1" },
-      expect.objectContaining({ schedule, store }),
+      expect.objectContaining({ schedule, store: expect.any(Object) }),
     )
+    const options = inner.emit.mock.calls[0]?.[3] as { store?: OutboxEventStore }
+    expect(options.store).not.toBe(store)
   })
 
   it("falls back to direct (non-durable) delivery when outbox capture fails", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
-    const store = { insert: vi.fn(), complete: vi.fn(), fail: vi.fn() }
+    const store = {
+      insert: vi.fn(async () => {
+        throw new Error("db unreachable")
+      }),
+      complete: vi.fn(),
+      fail: vi.fn(),
+    }
     const inner = fakeBus(async (...args: unknown[]) => {
       const options = args[3] as { store?: unknown } | undefined
-      if (options?.store) throw new Error("db unreachable")
+      if (options?.store) {
+        await (options.store as OutboxEventStore).insert({
+          name: "x",
+          data: {},
+          emittedAt: new Date().toISOString(),
+        })
+      }
     })
 
     const bus = requestScopedEventBus(inner, vi.fn(), store)
@@ -43,6 +57,36 @@ describe("requestScopedEventBus", () => {
     expect(retryOptions.store).toBeUndefined()
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining("outbox capture failed"),
+      expect.any(Error),
+    )
+    errorSpy.mockRestore()
+  })
+
+  it("does not fall back to direct delivery after durable capture succeeds", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const store = {
+      insert: vi.fn(async () => ({ id: "evob_1" })),
+      complete: vi.fn(),
+      fail: vi.fn(),
+    }
+    const inner = fakeBus(async (...args: unknown[]) => {
+      const options = args[3] as { store?: OutboxEventStore } | undefined
+      if (options?.store) {
+        await options.store.insert({
+          name: "x",
+          data: {},
+          emittedAt: new Date().toISOString(),
+        })
+        throw new Error("scheduler unavailable")
+      }
+    })
+
+    const bus = requestScopedEventBus(inner, vi.fn(), store)
+    await expect(bus.emit("x", {})).resolves.toBeUndefined()
+
+    expect(inner.emit).toHaveBeenCalledTimes(1)
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("durable delivery failed"),
       expect.any(Error),
     )
     errorSpy.mockRestore()
@@ -64,7 +108,8 @@ describe("requestScopedEventBus", () => {
     await bus.emit("x", {})
 
     const options = inner.emit.mock.calls[0]?.[3] as { store?: unknown; schedule?: unknown }
-    expect(options.store).toBe(store)
+    expect(options.store).toEqual(expect.any(Object))
+    expect(options.store).not.toBe(store)
     expect(options.schedule).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

- make deferred event delivery fall back to inline waiting when the request scheduler throws, so durable outbox settlement still runs
- prevent Hono's request-scoped event bus from doing non-durable direct fallback after outbox capture has succeeded
- add regression coverage for scheduler failures and post-capture wrapper failures
- add a patch changeset for `@voyant-travel/core` and `@voyant-travel/hono`

## Root Cause

A scheduler failure after durable outbox insert could escape the core emit path. The Hono request wrapper caught that as an outbox failure and redelivered directly without the store, which could execute subscriber side effects while leaving the original outbox row `pending` with `attempts = 0`.

## Verification

Passed:

- `pnpm --filter @voyant-travel/core test`
- `pnpm --filter @voyant-travel/hono test`
- `pnpm --filter @voyant-travel/core typecheck`
- `pnpm --filter @voyant-travel/hono typecheck`
- `pnpm --filter @voyant-travel/core build`
- `pnpm --filter @voyant-travel/hono build`
- `pnpm --filter @voyant-travel/core lint`
- `pnpm --filter @voyant-travel/hono lint` (exits 0; reports existing `public-cache.ts` optional-chain warning)
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm verify:date-picker-single-source`
- `pnpm verify:ui-components-barrel`
- `pnpm verify:ui-orientation-selectors`
- `pnpm verify:native-date-inputs`
- `pnpm verify:raw-minor-unit-labels`
- `pnpm verify:architecture` (migration replay parity skipped because `TEST_DATABASE_URL` is unset)

Caveat:

- `pnpm verify:fast` could not complete locally under the default 2GB Node heap. Turbo affected typecheck reached 94 successful tasks, then multiple broad package builds/typechecks failed with Node heap OOM exit 134. A follow-up full typecheck under `NODE_OPTIONS=--max-old-space-size=8192` progressed further but the OS killed concurrent tasks with exit 137, so I kept the focused package and checker results above as the reliable local signal.

Closes #2443
