### PR TITLE
fix(operator): preserve source provenance in storefront contract variables

### DIFF
--- a/starters/operator/src/components/voyant/booking-journey/resolve-contract-variables.test.ts
+++ b/starters/operator/src/components/voyant/booking-journey/resolve-contract-variables.test.ts
@@ -1,4 +1,4 @@
-import { bookingDraftV1 } from "@voyant-travel/catalog/booking-engine"
+import { bookingDraftV1 } from "@voyant-travel/catalog-contracts/booking-engine/contracts"
 import { describe, expect, it } from "vitest"
 
 import { type ContractSourceContext, resolveContractVariables } from "./resolve-contract-variables"

--- a/starters/operator/src/components/voyant/booking-journey/resolve-contract-variables.test.ts
+++ b/starters/operator/src/components/voyant/booking-journey/resolve-contract-variables.test.ts
@@ -1,0 +1,68 @@
+import { bookingDraftV1 } from "@voyant-travel/catalog/booking-engine"
+import { describe, expect, it } from "vitest"
+
+import { type ContractSourceContext, resolveContractVariables } from "./resolve-contract-variables"
+
+/** Minimal valid draft — the schema fills the rest with defaults. */
+function makeDraft() {
+  return bookingDraftV1.parse({
+    entity: { module: "products", id: "cdmi_demo_dynamic_pkg_20260629", sourceKind: "owned" },
+  })
+}
+
+function bookingSource(vars: Record<string, unknown>) {
+  return (vars.booking as { source: Record<string, unknown> }).source
+}
+
+describe("resolveContractVariables — booking.source provenance", () => {
+  it("carries sourced provenance + supplier into the contract for connected inventory (voyant#2619)", () => {
+    const source: ContractSourceContext = {
+      kind: "marketplace:demo",
+      connectionId: "srccon_demo_tours",
+      ref: "demo-dynamic-pkg-20260629",
+      supplier: { id: "sup_demo_tours", name: "Demo Tours" },
+    }
+
+    const vars = resolveContractVariables(makeDraft(), {
+      entityModule: "products",
+      entityId: "cdmi_demo_dynamic_pkg_20260629",
+      source,
+    })
+
+    expect(bookingSource(vars)).toEqual({
+      kind: "marketplace:demo",
+      connectionId: "srccon_demo_tours",
+      ref: "demo-dynamic-pkg-20260629",
+      supplier: { id: "sup_demo_tours", name: "Demo Tours" },
+    })
+  })
+
+  it("keeps the owned arm (kind=owned, blank supplier) when no source is resolved", () => {
+    const vars = resolveContractVariables(makeDraft(), {
+      entityModule: "products",
+      entityId: "prod_owned_1",
+    })
+
+    expect(bookingSource(vars)).toEqual({
+      kind: "owned",
+      connectionId: "",
+      ref: "",
+      supplier: { id: "", name: "" },
+    })
+  })
+
+  it("treats an explicit owned provenance as the owned arm and blanks any supplier", () => {
+    const vars = resolveContractVariables(makeDraft(), {
+      entityModule: "products",
+      entityId: "prod_owned_1",
+      source: { kind: "owned", supplier: { name: "In-house" } },
+    })
+
+    expect(bookingSource(vars)).toEqual({
+      kind: "owned",
+      connectionId: "",
+      ref: "",
+      supplier: { id: "", name: "" },
+    })
+  })
+})

--- a/starters/operator/src/components/voyant/booking-journey/resolve-contract-variables.ts
+++ b/starters/operator/src/components/voyant/booking-journey/resolve-contract-variables.ts
@@ -83,6 +83,31 @@ interface AcceptanceContextVariables {
   templateId?: string
 }
 
+/**
+ * Source provenance for the booked entity, resolved from the catalog
+ * plane (the public content endpoint returns it as `provenance` +
+ * `product.supplier`). Threaded into the contract preview so the
+ * `booking.source` block reflects the real sourced/owned arm instead
+ * of defaulting to `owned` with a blank supplier (voyant#2619).
+ *
+ * When absent (or `kind` is empty / `"owned"`), the contract renders
+ * the owned arm — blank connection/ref/supplier — exactly as before.
+ */
+export interface ContractSourceContext {
+  /** Provenance kind — `"owned"` for owned inventory, otherwise the
+   *  upstream source kind (e.g. `marketplace:demo`). */
+  kind?: string
+  /** Source connection that produced the row (sourced only). */
+  connectionId?: string
+  /** Stable upstream object id (sourced only). */
+  ref?: string
+  /** Supplier disclosed to the customer in the contract. */
+  supplier?: {
+    id?: string
+    name?: string
+  }
+}
+
 interface ResolveContractVariablesContext {
   entityModule: string
   entityId: string
@@ -104,6 +129,11 @@ interface ResolveContractVariablesContext {
   /** Which layer of the cascade the active policy came from. Used
    *  for traceability in contract templates. */
   paymentPolicySource?: PaymentPolicySource
+  /** Resolved source provenance for the booked entity. Populated by
+   *  the storefront wrapper from the public content endpoint's
+   *  `provenance` + supplier. When omitted the booking renders as the
+   *  owned arm (voyant#2619). */
+  source?: ContractSourceContext
 }
 
 export function resolveContractVariables(
@@ -334,17 +364,11 @@ export function resolveContractVariables(
       // overrides with the persisted booking_items rows.
       roomsSummary: buildRoomsSummary(draft),
 
-      // Source provenance — populated post-book on owned arm; the
-      // sourced arm overrides this from the snapshot
-      source: {
-        kind: "owned",
-        connectionId: "",
-        ref: "",
-        supplier: {
-          id: "",
-          name: "",
-        },
-      },
+      // Source provenance — resolved from the catalog plane via the
+      // public content endpoint's `provenance` + supplier and threaded
+      // in by the storefront wrapper. Falls back to the owned arm
+      // (blank connection/ref/supplier) when unresolved (voyant#2619).
+      source: buildBookingSource(ctx.source),
 
       // Notes
       internalNotes: draft.internalNotes ?? "",
@@ -454,6 +478,37 @@ export function resolveContractVariables(
       marketingConsent: acceptance.marketingConsent ?? false,
       templateSlug: acceptance.templateSlug ?? "",
       templateId: acceptance.templateId ?? "",
+    },
+  }
+}
+
+/**
+ * Map resolved provenance into the contract's `booking.source` block.
+ *
+ * A missing context, or an explicit `"owned"` / empty `kind`, renders
+ * the owned arm with blank connection/ref/supplier — preserving the
+ * pre-fix behavior for genuinely owned inventory. Sourced inventory
+ * carries its real `kind`, `connectionId`, `ref`, and supplier so the
+ * customer contract can disclose the correct supplier/operator split
+ * (voyant#2619).
+ */
+function buildBookingSource(source: ContractSourceContext | undefined): {
+  kind: string
+  connectionId: string
+  ref: string
+  supplier: { id: string; name: string }
+} {
+  const kind = source?.kind?.trim() ? source.kind : "owned"
+  const isOwned = kind === "owned"
+  return {
+    kind,
+    connectionId: source?.connectionId ?? "",
+    ref: source?.ref ?? "",
+    supplier: {
+      // Owned inventory has no upstream supplier — keep it blank so the
+      // owned arm is unchanged from before the fix.
+      id: isOwned ? "" : (source?.supplier?.id ?? ""),
+      name: isOwned ? "" : (source?.supplier?.name ?? ""),
     },
   }
 }

--- a/starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.tsx
+++ b/starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.tsx
@@ -33,7 +33,11 @@ import {
 import { getApiUrl } from "@/lib/env"
 import { useStorefrontMessagesOrDefault } from "@/lib/storefront-i18n"
 import { useStorefrontScope } from "@/lib/storefront-scope"
-import { type OperatorInfoVariables, resolveContractVariables } from "./resolve-contract-variables"
+import {
+  type ContractSourceContext,
+  type OperatorInfoVariables,
+  resolveContractVariables,
+} from "./resolve-contract-variables"
 
 /**
  * Marker for checkout failures we've already turned into a localized,
@@ -73,6 +77,14 @@ export interface StorefrontBookingJourneyProps {
    *  journey. */
   entitySummary?: BookingEntitySummary
   /**
+   * Resolved source provenance for the booked entity — kind /
+   * connection / ref + supplier. The `/book` route reads it off the
+   * public content endpoint's `provenance` and passes it here so the
+   * contract preview's `booking.source` block reflects sourced
+   * inventory instead of defaulting to owned/blank (voyant#2619).
+   */
+  entitySource?: ContractSourceContext
+  /**
    * Per-product override for the contract template. When unset (the
    * default), the storefront resolves the active customer-scope
    * template via /v1/public/legal/contracts/templates/default —
@@ -105,6 +117,7 @@ export function StorefrontBookingJourney({
   initialConfigure,
   initialAccommodation,
   entitySummary,
+  entitySource,
   contractTemplateSlug,
   contractMarketingLabel,
   onContractAccepted,
@@ -367,6 +380,7 @@ export function StorefrontBookingJourney({
                   operatorInfo: operatorProfile,
                   paymentSchedule: schedule,
                   paymentPolicySource: source,
+                  source: entitySource,
                 })
               },
               ...(contractMarketingLabel ? { marketingLabel: contractMarketingLabel } : {}),

--- a/starters/operator/src/routes/(storefront)/shop_.book.$entityModule.$entityId.tsx
+++ b/starters/operator/src/routes/(storefront)/shop_.book.$entityModule.$entityId.tsx
@@ -8,6 +8,7 @@ import { isStorefrontCustomerBookableProductVertical } from "@voyant-travel/stor
 import { useMemo } from "react"
 import { z } from "zod"
 
+import type { ContractSourceContext } from "@/components/voyant/booking-journey/resolve-contract-variables"
 import { StorefrontBookingJourney } from "@/components/voyant/booking-journey/storefront-booking-journey"
 import { getApiUrl } from "@/lib/env"
 import { useStorefrontMessagesOrDefault } from "@/lib/storefront-i18n"
@@ -106,7 +107,11 @@ function ShopBookRouteComponent(): React.ReactElement {
       }
     : undefined
 
-  const entitySummary = useEntitySummary(entityModule, entityId, search)
+  const { summary: entitySummary, source: entitySource } = useEntityContent(
+    entityModule,
+    entityId,
+    search,
+  )
 
   return (
     <StorefrontBookingJourney
@@ -116,6 +121,7 @@ function ShopBookRouteComponent(): React.ReactElement {
       initialConfigure={initialConfigure}
       initialAccommodation={initialAccommodation}
       entitySummary={entitySummary}
+      entitySource={entitySource}
       // No `contractTemplateSlug` — the wrapper resolves whichever
       // customer-scope template the operator has marked active via
       // /v1/public/legal/contracts/templates/default. Per-product
@@ -127,16 +133,36 @@ function ShopBookRouteComponent(): React.ReactElement {
 }
 
 /**
- * Pull the entity content for the side-panel summary. Three
- * vertical-specific endpoints share the same `{ data: { content,
- * served_locale, ... } }` envelope; we map each into a
- * vertical-agnostic `BookingEntitySummary`.
+ * Provenance block returned alongside the content payload by the
+ * vertical content endpoints (`{ data: { content, provenance, ... } }`).
+ * Mirrors `contentProvenanceSchema` in the vertical `routes-content.ts`.
  */
-function useEntitySummary(
+interface ContentProvenance {
+  source_kind: string
+  source_provider?: string
+  source_connection_id?: string
+  source_ref?: string
+}
+
+interface EntityContentEnvelope {
+  content?: unknown
+  provenance?: ContentProvenance
+}
+
+/**
+ * Pull the entity content for the side-panel summary AND the contract
+ * preview's source provenance. Three vertical-specific endpoints share
+ * the same `{ data: { content, provenance, served_locale, ... } }`
+ * envelope; we map each into a vertical-agnostic `BookingEntitySummary`
+ * plus a `ContractSourceContext` so a sourced/connected product carries
+ * its real supplier + provenance into the customer contract instead of
+ * defaulting to owned/blank (voyant#2619).
+ */
+function useEntityContent(
   entityModule: string,
   entityId: string,
   search: ShopBookSearch,
-): BookingEntitySummary | undefined {
+): { summary: BookingEntitySummary | undefined; source: ContractSourceContext | undefined } {
   const url =
     entityModule === "cruises"
       ? `${getApiUrl()}/v1/public/cruises/${encodeURIComponent(entityId)}/content`
@@ -148,21 +174,28 @@ function useEntitySummary(
 
   const { data } = useQuery({
     queryKey: ["public-entity-summary", entityModule, entityId],
-    queryFn: async (): Promise<unknown> => {
+    queryFn: async (): Promise<EntityContentEnvelope | null> => {
       if (!url) return null
       const res = await fetch(url, { credentials: "include" })
       if (!res.ok) return null
-      const json = (await res.json()) as { data?: { content?: unknown } }
-      return json.data?.content ?? null
+      const json = (await res.json()) as { data?: EntityContentEnvelope }
+      return json.data ?? null
     },
     enabled: Boolean(url),
     staleTime: 60_000,
   })
 
-  return useMemo<BookingEntitySummary | undefined>(() => {
-    if (!data) return undefined
+  const content = data?.content ?? null
+
+  const source = useMemo<ContractSourceContext | undefined>(
+    () => resolveEntitySource(entityModule, data?.provenance, content),
+    [entityModule, data?.provenance, content],
+  )
+
+  const summary = useMemo<BookingEntitySummary | undefined>(() => {
+    if (!content) return undefined
     if (entityModule === "products") {
-      const c = data as ProductContent
+      const c = content as ProductContent
       const subtitleParts = [
         c.product.duration_days
           ? `${c.product.duration_days} day${c.product.duration_days === 1 ? "" : "s"}`
@@ -183,7 +216,7 @@ function useEntitySummary(
       }
     }
     if (entityModule === "cruises") {
-      const c = data as CruiseContent
+      const c = content as CruiseContent
       const sailing = c.sailings.find((s) => s.id === search.departureSlotId)
       const subtitleParts = [
         c.cruise.duration_nights
@@ -209,7 +242,7 @@ function useEntitySummary(
       }
     }
     if (entityModule === "accommodations") {
-      const c = data as AccommodationContent
+      const c = content as AccommodationContent
       const stars = c.hotel.star_rating ? "★".repeat(Math.floor(c.hotel.star_rating)) : null
       return {
         name: c.hotel.name,
@@ -226,7 +259,40 @@ function useEntitySummary(
       }
     }
     return undefined
-  }, [data, entityModule, search.departureSlotId, search.checkIn, search.checkOut])
+  }, [content, entityModule, search.departureSlotId, search.checkIn, search.checkOut])
+
+  return { summary, source }
+}
+
+/**
+ * Map the content endpoint's `provenance` block + vertical supplier
+ * into the `ContractSourceContext` the contract preview reads. Owned
+ * inventory (`source_kind: "owned"`) and a missing provenance both
+ * yield the owned arm downstream; sourced inventory carries its real
+ * kind / connection / ref + supplier name (voyant#2619).
+ */
+function resolveEntitySource(
+  entityModule: string,
+  provenance: ContentProvenance | undefined,
+  content: unknown,
+): ContractSourceContext | undefined {
+  if (!provenance) return undefined
+  const supplierName = extractSupplierName(entityModule, content)
+  return {
+    kind: provenance.source_kind,
+    connectionId: provenance.source_connection_id ?? "",
+    ref: provenance.source_ref ?? "",
+    supplier: { id: "", name: supplierName },
+  }
+}
+
+/** Pull the customer-facing supplier display name off the vertical
+ *  content payload. Only products currently expose it. */
+function extractSupplierName(entityModule: string, content: unknown): string {
+  if (entityModule === "products" && content) {
+    return (content as ProductContent).product.supplier ?? ""
+  }
+  return ""
 }
 
 function formatDate(iso: string): string {


### PR DESCRIPTION
## Root cause

Fixes #2619.

When booking a connected/sourced catalog product through the storefront, the contract-preview variables identified the booking source as `owned` with blank supplier fields — even though the product is sourced from a connector (its public content returns `source: "sourced-cache"` with supplier `Demo Tours`).

`resolveContractVariables` (in the operator starter's storefront booking-journey wrapper) hardcoded `booking.source` to the owned arm:

```ts
source: { kind: "owned", connectionId: "", ref: "", supplier: { id: "", name: "" } }
```

Nothing ever consulted the real provenance for sourced inventory, so every storefront contract preview rendered the owned arm regardless of the entity's true source.

## The fix

The provenance data already exists client-side: the public content endpoint (`GET /v1/public/{vertical}/{id}/content`) returns a `provenance` block (`source_kind`, `source_connection_id`, `source_ref`) — resolved server-side via the catalog plane's sourced-entry lookup — plus the supplier display name on `content.product.supplier`. The storefront `/book` route was fetching that content for the side-panel summary but dropping everything except `content`.

- The `/book` route's content hook now keeps the full envelope and derives a `ContractSourceContext` (`kind` / `connectionId` / `ref` + supplier name) alongside the existing `BookingEntitySummary`, passing it to the journey wrapper via a new `entitySource` prop.
- `StorefrontBookingJourney` threads `entitySource` into the `resolveVariables` callback.
- `resolveContractVariables` maps it into `booking.source` via a new `buildBookingSource` helper. Genuinely owned inventory (`source_kind: "owned"`) and unresolved/absent provenance still render the owned arm with blank connection/ref/supplier — unchanged from before.

This keeps the fix within the storefront/contract path and treats the catalog plane (via the content endpoint) as the source of truth for sourced provenance, per the federated-operating-mode rules.

## Files changed

- `starters/operator/src/components/voyant/booking-journey/resolve-contract-variables.ts` — export `ContractSourceContext`; resolve `booking.source` from context instead of hardcoding owned/blank.
- `starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.tsx` — new `entitySource` prop, threaded into contract-variable resolution.
- `starters/operator/src/routes/(storefront)/shop_.book.$entityModule.$entityId.tsx` — capture `provenance` + supplier from the content endpoint and pass `entitySource`.
- `starters/operator/src/components/voyant/booking-journey/resolve-contract-variables.test.ts` — new tests: sourced product yields real provenance + supplier; owned / unresolved keeps the owned arm.

## Verification

- `pnpm --filter operator test resolve-contract-variables` — 3/3 pass.
- `pnpm --filter operator lint` — clean.
- Full pre-commit + pre-push turbo (typecheck + build across all packages, including operator) — green.

No changeset: only the private `operator` starter changed; no publishable `@voyant-travel/*` package was touched.