### PR TITLE
Split local cloud service keys

### DIFF
--- a/starters/operator/.dev.vars.example
+++ b/starters/operator/.dev.vars.example
@@ -34,11 +34,19 @@ CORS_ALLOWLIST="http://localhost:3100"
 
 # Voyant API (canonical email / sms / verify / vault / connect provider).
 # Optional for local/self-hosted no-cloud development. Leave unset/empty to
-# disable Cloud-backed FX, realtime, and notification delivery.
+# disable Cloud-backed realtime and notification delivery. Do not use a dummy
+# local placeholder; older generated VOYANT_API_KEY="local-dev" values are
+# treated as unset, and Cloud-backed capabilities now have their own opt-in keys.
 # Self-hosters who want a different transport can swap the provider in
 # src/lib/notifications.ts (see @voyant-travel/notifications for the
 # NotificationProvider interface).
 # VOYANT_API_KEY="vc_..."
+# Styled legal/invoice PDF rendering via Voyant Cloud Browser Rendering.
+# Leave unset/empty locally to use the bundled basic PDF fallback.
+# VOYANT_CLOUD_PDF_API_KEY="vc_..."
+# Hosted Voyant Data FX lookup for finance invoice/payment rates.
+# Leave unset/empty locally to disable hosted FX lookup.
+# VOYANT_DATA_API_KEY="vd_..."
 # VOYANT_CLOUD_API_URL="https://api.voyant.travel"
 # VOYANT_CLOUD_VAULT_SLUG="main"
 

--- a/starters/operator/README.md
+++ b/starters/operator/README.md
@@ -21,6 +21,26 @@ pnpm -F operator dev:worker   # Voyant Workflows dev loop
 Dev server runs on port `3300`.
 The local workflows runtime listens on port `3310`.
 
+## Optional Cloud Services
+
+Local and self-hosted deployments can run without a Voyant Cloud API key. Leave
+`VOYANT_API_KEY` unset unless you want Cloud-backed notifications, realtime, or
+Vault KMS.
+
+Cloud-backed legal PDF rendering and finance FX lookup are configured
+separately:
+
+```bash
+# Styled legal/invoice PDF rendering. Omit for the local basic PDF fallback.
+VOYANT_CLOUD_PDF_API_KEY="vc_..."
+
+# Hosted Voyant Data FX lookup for finance invoice/payment rates.
+VOYANT_DATA_API_KEY="vd_..."
+```
+
+In `VOYANT_ADMIN_AUTH_MODE="voyant-cloud"` deployments, `VOYANT_API_KEY` remains
+a legacy fallback for both of those specialized keys.
+
 ## Flights Demo API
 
 The operator starter is wired to the standalone flights demo API when

--- a/starters/operator/env.d.ts
+++ b/starters/operator/env.d.ts
@@ -75,6 +75,18 @@ interface CloudflareBindings {
   VOYANT_API_KEY?: string
   /** Legacy alias for VOYANT_API_KEY. */
   VOYANT_CLOUD_API_KEY?: string
+  /**
+   * Voyant Cloud Browser Rendering credential for styled PDF generation.
+   * Local/self-hosted deployments can leave this unset to use the bundled
+   * basic PDF fallback while still configuring other Voyant-backed providers.
+   */
+  VOYANT_CLOUD_PDF_API_KEY?: string
+  /**
+   * Voyant Data credential for hosted FX lookups. Local/self-hosted deployments
+   * can leave this unset to disable hosted invoice FX without affecting PDF
+   * rendering or notification providers.
+   */
+  VOYANT_DATA_API_KEY?: string
   VOYANT_CLOUD_API_URL?: string
   VOYANT_CLOUD_VAULT_SLUG?: string
   EMAIL_FROM: string

--- a/starters/operator/src/api/runtime/contract-document-runtime.ts
+++ b/starters/operator/src/api/runtime/contract-document-runtime.ts
@@ -7,7 +7,7 @@ import {
 } from "@voyant-travel/legal"
 import { createContractDocumentService } from "@voyant-travel/legal/contract-document"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-import { tryGetCloudClient } from "../../lib/voyant-cloud"
+import { tryGetCloudPdfClient } from "../../lib/voyant-cloud"
 import { createDocumentStorage, guessMimeType } from "../lib/storage"
 import {
   AUTO_GENERATE_CONTRACT_OPTIONS,
@@ -33,7 +33,7 @@ export function resolveContractDocumentGenerator(
   if (!storage) return null
 
   return async (context) => {
-    const cloud = tryGetCloudClient(env)
+    const cloud = tryGetCloudPdfClient(env)
     const legal = await import("@voyant-travel/legal")
     if (cloud) {
       const generator = legal.createStorageBackedContractDocumentGenerator({
@@ -45,12 +45,13 @@ export function resolveContractDocumentGenerator(
       return generator(context)
     }
 
-    // Local dev / no cloud key — fall back to the basic pdf-lib
-    // serializer. Contract PDFs will be plain text but the worker
-    // boots and downstream flows complete. Prod deploys MUST set
-    // VOYANT_API_KEY.
+    // Local dev / no PDF-rendering key — fall back to the basic pdf-lib
+    // serializer. Contract PDFs will be plain text but the worker boots and
+    // downstream flows complete. Cloud deployments can keep using VOYANT_API_KEY
+    // in voyant-cloud auth mode; local/self-hosted deployments should opt in
+    // explicitly with VOYANT_CLOUD_PDF_API_KEY.
     console.warn(
-      "[operator] VOYANT_API_KEY not set — using basic pdf-lib serializer. " +
+      "[operator] VOYANT_CLOUD_PDF_API_KEY not set — using basic pdf-lib serializer. " +
         "Contract PDFs will be unstyled. Set the key to enable browser-rendered output.",
     )
     const generator = legal.createPdfContractDocumentGenerator({ storage })

--- a/starters/operator/src/api/runtime/operator-runtime-adapter.test.ts
+++ b/starters/operator/src/api/runtime/operator-runtime-adapter.test.ts
@@ -9,8 +9,24 @@ describe("createOperatorInvoiceExchangeRateResolver", () => {
     expect(createOperatorInvoiceExchangeRateResolver({ VOYANT_API_KEY: "   " })).toBeUndefined()
   })
 
-  it("uses a configured Voyant API key", () => {
+  it("does not treat a local broad Cloud placeholder as a Voyant Data key", () => {
+    expect(
+      createOperatorInvoiceExchangeRateResolver({ VOYANT_API_KEY: "local-dev" }),
+    ).toBeUndefined()
+  })
+
+  it("uses a configured Voyant Data API key", () => {
     const resolver = createOperatorInvoiceExchangeRateResolver({
+      VOYANT_DATA_API_KEY: "vd_test",
+      VOYANT_CLOUD_API_URL: "https://api.example.test",
+    })
+
+    expect(resolver).toEqual(expect.any(Function))
+  })
+
+  it("keeps the broad Cloud key as a legacy Data key in Cloud admin auth mode", () => {
+    const resolver = createOperatorInvoiceExchangeRateResolver({
+      VOYANT_ADMIN_AUTH_MODE: "voyant-cloud",
       VOYANT_API_KEY: "vc_test",
       VOYANT_CLOUD_API_URL: "https://api.example.test",
     })

--- a/starters/operator/src/api/runtime/operator-runtime-adapter.ts
+++ b/starters/operator/src/api/runtime/operator-runtime-adapter.ts
@@ -7,7 +7,7 @@ import {
 } from "@voyant-travel/workflows/client"
 import { createInMemoryDriver } from "@voyant-travel/workflows-orchestrator/in-memory"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-import { resolveVoyantApiKey } from "../../lib/voyant-cloud"
+import { resolveVoyantDataApiKey } from "../../lib/voyant-cloud"
 import { getDbFromEnv } from "../lib/db"
 import {
   createDocumentStorage,
@@ -66,7 +66,7 @@ export async function createOperatorBookingPiiService(bindings: unknown) {
 
 export function createOperatorInvoiceExchangeRateResolver(bindings: unknown) {
   const env = operatorBindings(bindings)
-  const apiKey = resolveVoyantApiKey(env)
+  const apiKey = resolveVoyantDataApiKey(env)
   if (!apiKey) return undefined
   return createVoyantDataFxExchangeRateResolver({
     apiKey,

--- a/starters/operator/src/api/runtime/trips-checkout-runtime.ts
+++ b/starters/operator/src/api/runtime/trips-checkout-runtime.ts
@@ -22,7 +22,7 @@ import {
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
 
-import { resolveVoyantApiKey } from "../../lib/voyant-cloud"
+import { resolveVoyantDataApiKey } from "../../lib/voyant-cloud"
 import { cardPaymentStarter } from "./card-payment"
 
 /** Build the deployment-specific trip-checkout dependencies for a request. */
@@ -71,11 +71,13 @@ async function quoteFx(
   const env = c.env as {
     VOYANT_API_KEY?: string
     VOYANT_CLOUD_API_KEY?: string
+    VOYANT_DATA_API_KEY?: string
     VOYANT_CLOUD_API_URL?: string
+    VOYANT_ADMIN_AUTH_MODE?: string
   }
-  const apiKey = resolveVoyantApiKey(env)
+  const apiKey = resolveVoyantDataApiKey(env)
   if (!apiKey) {
-    throw new Error("trip_checkout_fx_requires_voyant_api_key")
+    throw new Error("trip_checkout_fx_requires_voyant_data_api_key")
   }
 
   const baseUrl = (env.VOYANT_CLOUD_API_URL ?? "https://api.voyant.travel").replace(/\/$/, "")

--- a/starters/operator/src/lib/voyant-cloud.test.ts
+++ b/starters/operator/src/lib/voyant-cloud.test.ts
@@ -1,12 +1,20 @@
 import { describe, expect, it } from "vitest"
 
-import { isVoyantCloudAdminAuthMode, resolveVoyantApiKey, tryGetCloudClient } from "./voyant-cloud"
+import {
+  isVoyantCloudAdminAuthMode,
+  resolveVoyantApiKey,
+  resolveVoyantCloudPdfApiKey,
+  resolveVoyantDataApiKey,
+  tryGetCloudClient,
+  tryGetCloudPdfClient,
+} from "./voyant-cloud"
 
 describe("voyant cloud env helpers", () => {
-  it("treats missing, empty, and whitespace API keys as unconfigured", () => {
+  it("treats missing, empty, whitespace, and local placeholder API keys as unconfigured", () => {
     expect(resolveVoyantApiKey({})).toBeUndefined()
     expect(resolveVoyantApiKey({ VOYANT_API_KEY: "" })).toBeUndefined()
     expect(resolveVoyantApiKey({ VOYANT_API_KEY: "   " })).toBeUndefined()
+    expect(resolveVoyantApiKey({ VOYANT_API_KEY: "local-dev" })).toBeUndefined()
   })
 
   it("prefers the canonical key and trims configured values", () => {
@@ -25,7 +33,49 @@ describe("voyant cloud env helpers", () => {
     expect(isVoyantCloudAdminAuthMode({ VOYANT_ADMIN_AUTH_MODE: "voyant-cloud" })).toBe(true)
   })
 
+  it("resolves the Voyant Data key independently from the broad Cloud key in local mode", () => {
+    expect(resolveVoyantDataApiKey({ VOYANT_API_KEY: "local-dev" })).toBeUndefined()
+    expect(
+      resolveVoyantDataApiKey({
+        VOYANT_API_KEY: "local-dev",
+        VOYANT_DATA_API_KEY: " vd_data ",
+      }),
+    ).toBe("vd_data")
+  })
+
+  it("keeps legacy broad Cloud keys working for Data in Cloud admin mode", () => {
+    expect(
+      resolveVoyantDataApiKey({
+        VOYANT_ADMIN_AUTH_MODE: "voyant-cloud",
+        VOYANT_API_KEY: " vc_cloud ",
+      }),
+    ).toBe("vc_cloud")
+  })
+
+  it("resolves the Cloud PDF key independently from the broad Cloud key in local mode", () => {
+    expect(resolveVoyantCloudPdfApiKey({ VOYANT_API_KEY: "local-dev" })).toBeUndefined()
+    expect(
+      resolveVoyantCloudPdfApiKey({
+        VOYANT_API_KEY: "local-dev",
+        VOYANT_CLOUD_PDF_API_KEY: " vc_pdf ",
+      }),
+    ).toBe("vc_pdf")
+  })
+
+  it("keeps legacy broad Cloud keys working for PDF rendering in Cloud admin mode", () => {
+    expect(
+      resolveVoyantCloudPdfApiKey({
+        VOYANT_ADMIN_AUTH_MODE: "voyant-cloud",
+        VOYANT_API_KEY: " vc_cloud ",
+      }),
+    ).toBe("vc_cloud")
+  })
+
   it("does not pass whitespace-only legacy API keys through to the Cloud SDK", () => {
     expect(tryGetCloudClient({ VOYANT_CLOUD_API_KEY: "   " })).toBeNull()
+  })
+
+  it("does not create a PDF Cloud client from a local broad placeholder key", () => {
+    expect(tryGetCloudPdfClient({ VOYANT_API_KEY: "local-dev" })).toBeNull()
   })
 })

--- a/starters/operator/src/lib/voyant-cloud.ts
+++ b/starters/operator/src/lib/voyant-cloud.ts
@@ -1,14 +1,13 @@
 /**
- * Lazy accessor for the Voyant Cloud SDK client. Other modules (the
- * legal contract PDF generator, future SMS / verification flows)
- * should call `getCloudClient(env)` rather than instantiating their
- * own — the SDK caches state internally and we want a single
- * shared client per isolate.
+ * Lazy accessor for the Voyant Cloud SDK client. Other modules should call the
+ * resolver for the capability they need rather than instantiating their own
+ * client. The SDK caches state internally and we keep one shared client per
+ * env/key pair per isolate.
  *
- * `tryGetCloudClient(env)` returns `null` when `VOYANT_API_KEY`
- * is unset — useful for local dev where the cloud-backed feature
- * (e.g. browser-rendered PDFs) gracefully degrades to the basic
- * pdf-lib fallback rather than crashing the whole worker.
+ * `tryGetCloudClient(env)` returns `null` when `VOYANT_API_KEY` is unset. More
+ * specific helpers such as `tryGetCloudPdfClient(env)` intentionally use their
+ * own env vars so local/self-hosted deployments can enable one Cloud-backed
+ * concern without accidentally enabling another.
  */
 
 import {
@@ -17,13 +16,16 @@ import {
   type VoyantCloudClient,
 } from "@voyant-travel/cloud-sdk"
 
-const CLIENT_CACHE = new WeakMap<object, VoyantCloudClient>()
+const CLIENT_CACHE = new WeakMap<object, Map<string, VoyantCloudClient>>()
+const LOCAL_PLACEHOLDER_KEYS = new Set(["local-dev"])
 type CloudClientEnv = Parameters<typeof getVoyantCloudClient>[0]
 type TryCloudClientEnv = Parameters<typeof tryGetVoyantCloudClient>[0]
 
 export type VoyantApiEnv = {
   VOYANT_API_KEY?: unknown
   VOYANT_CLOUD_API_KEY?: unknown
+  VOYANT_CLOUD_PDF_API_KEY?: unknown
+  VOYANT_DATA_API_KEY?: unknown
   VOYANT_CLOUD_API_URL?: unknown
   VOYANT_CLOUD_USER_AGENT?: unknown
   VOYANT_ADMIN_AUTH_MODE?: unknown
@@ -37,27 +39,47 @@ export function isVoyantCloudAdminAuthMode(env: VoyantApiEnv): boolean {
   return nonEmpty(env.VOYANT_ADMIN_AUTH_MODE) === "voyant-cloud"
 }
 
+export function resolveVoyantDataApiKey(env: VoyantApiEnv): string | undefined {
+  return nonEmpty(env.VOYANT_DATA_API_KEY) ?? cloudModeLegacyApiKey(env)
+}
+
+export function resolveVoyantCloudPdfApiKey(env: VoyantApiEnv): string | undefined {
+  return nonEmpty(env.VOYANT_CLOUD_PDF_API_KEY) ?? cloudModeLegacyApiKey(env)
+}
+
 export function getCloudClient(env: VoyantApiEnv): VoyantCloudClient {
-  const cached = CLIENT_CACHE.get(env)
-  if (cached) return cached
   const apiKey = resolveVoyantApiKey(env)
+  const cached = getCachedClient(env, apiKey)
+  if (cached) return cached
   const client = getVoyantCloudClient(
     asCloudClientEnv(env, apiKey),
     apiKey ? { apiKey } : undefined,
   )
-  CLIENT_CACHE.set(env, client)
+  setCachedClient(env, apiKey, client)
   return client
 }
 
 export function tryGetCloudClient(env: VoyantApiEnv): VoyantCloudClient | null {
-  const cached = CLIENT_CACHE.get(env)
-  if (cached) return cached
   const apiKey = resolveVoyantApiKey(env)
+  const cached = getCachedClient(env, apiKey)
+  if (cached) return cached
   const client = tryGetVoyantCloudClient(
     asTryCloudClientEnv(env, apiKey),
     apiKey ? { apiKey } : undefined,
   )
-  if (client) CLIENT_CACHE.set(env, client)
+  if (client) setCachedClient(env, apiKey, client)
+  return client
+}
+
+export function tryGetCloudPdfClient(env: VoyantApiEnv): VoyantCloudClient | null {
+  const apiKey = resolveVoyantCloudPdfApiKey(env)
+  const cached = getCachedClient(env, apiKey)
+  if (cached) return cached
+  const client = tryGetVoyantCloudClient(
+    asTryCloudClientEnv(env, apiKey),
+    apiKey ? { apiKey } : undefined,
+  )
+  if (client) setCachedClient(env, apiKey, client)
   return client
 }
 
@@ -85,5 +107,33 @@ function sanitizeCloudClientEnv(
 function nonEmpty(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined
   const trimmed = value.trim()
-  return trimmed.length > 0 ? trimmed : undefined
+  if (trimmed.length === 0) return undefined
+  return LOCAL_PLACEHOLDER_KEYS.has(trimmed) ? undefined : trimmed
+}
+
+function cloudModeLegacyApiKey(env: VoyantApiEnv): string | undefined {
+  return isVoyantCloudAdminAuthMode(env) ? resolveVoyantApiKey(env) : undefined
+}
+
+function cacheKey(apiKey: string | undefined): string {
+  return apiKey ?? ""
+}
+
+function getCachedClient(env: VoyantApiEnv, apiKey: string | undefined): VoyantCloudClient | null {
+  if (!apiKey) return null
+  return CLIENT_CACHE.get(env)?.get(cacheKey(apiKey)) ?? null
+}
+
+function setCachedClient(
+  env: VoyantApiEnv,
+  apiKey: string | undefined,
+  client: VoyantCloudClient,
+): void {
+  if (!apiKey) return
+  const existing = CLIENT_CACHE.get(env)
+  if (existing) {
+    existing.set(cacheKey(apiKey), client)
+    return
+  }
+  CLIENT_CACHE.set(env, new Map([[cacheKey(apiKey), client]]))
 }


### PR DESCRIPTION
## Summary
- split local/self-hosted Cloud configuration by capability: Data FX uses `VOYANT_DATA_API_KEY`, legal PDF rendering uses `VOYANT_CLOUD_PDF_API_KEY`
- treat legacy `VOYANT_API_KEY="local-dev"` as unset so local starters use the basic PDF fallback instead of Cloud rendering
- keep `VOYANT_API_KEY` as a legacy fallback for specialized services only in `VOYANT_ADMIN_AUTH_MODE="voyant-cloud"`
- document the supported local configuration and update operator env typing

## Verification
- `pnpm --filter operator exec vitest run src/lib/voyant-cloud.test.ts src/api/runtime/operator-runtime-adapter.test.ts src/lib/realtime.test.ts src/lib/notifications.test.ts`
- `pnpm --filter operator lint`
- `pnpm exec biome check starters/operator/src/lib/voyant-cloud.ts starters/operator/src/lib/voyant-cloud.test.ts starters/operator/src/api/runtime/operator-runtime-adapter.ts starters/operator/src/api/runtime/operator-runtime-adapter.test.ts starters/operator/src/api/runtime/contract-document-runtime.ts starters/operator/src/api/runtime/trips-checkout-runtime.ts starters/operator/env.d.ts starters/operator/.dev.vars.example starters/operator/README.md`
- `timeout 180s pnpm --filter operator typecheck` timed out with no diagnostics before SIGTERM

Fixes #2588
