### PR TITLE
Fix booking item refresh and delete activity

### DIFF
--- a/.changeset/booking-item-refresh-audit.md
+++ b/.changeset/booking-item-refresh-audit.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/bookings": patch
+"@voyant-travel/bookings-react": patch
+---
+
+Refresh booking detail caches after booking item mutations and record booking item deletions in the booking activity log.

--- a/packages/bookings-react/src/hooks/use-booking-item-mutation.ts
+++ b/packages/bookings-react/src/hooks/use-booking-item-mutation.ts
@@ -19,6 +19,20 @@ import { bookingItemsResponse, bookingSingleResponse, successEnvelope } from "..
 export type CreateBookingItemInput = z.input<typeof insertBookingItemSchema>
 export type UpdateBookingItemInput = z.input<typeof updateBookingItemSchema>
 
+function invalidateBookingItemMutationQueries(
+  queryClient: ReturnType<typeof useQueryClient>,
+  bookingId: string,
+) {
+  void queryClient.invalidateQueries({
+    queryKey: bookingsQueryKeys.booking(bookingId),
+    exact: true,
+  })
+  void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.bookings() })
+  void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.items(bookingId) })
+  void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.activity(bookingId) })
+  void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.actionLedger(bookingId) })
+}
+
 export function useBookingItemMutation(bookingId: string) {
   const { baseUrl, fetcher } = useVoyantBookingsContext()
   const queryClient = useQueryClient()
@@ -36,8 +50,7 @@ export function useBookingItemMutation(bookingId: string) {
       return data
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.items(bookingId) })
-      void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.activity(bookingId) })
+      invalidateBookingItemMutationQueries(queryClient, bookingId)
     },
   })
 
@@ -54,8 +67,7 @@ export function useBookingItemMutation(bookingId: string) {
       return data
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.items(bookingId) })
-      void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.activity(bookingId) })
+      invalidateBookingItemMutationQueries(queryClient, bookingId)
     },
   })
 
@@ -68,8 +80,7 @@ export function useBookingItemMutation(bookingId: string) {
         { method: "DELETE" },
       ),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.items(bookingId) })
-      void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.activity(bookingId) })
+      invalidateBookingItemMutationQueries(queryClient, bookingId)
     },
   })
 

--- a/packages/bookings-react/tests/unit/use-booking-item-mutation.test.ts
+++ b/packages/bookings-react/tests/unit/use-booking-item-mutation.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const testState = vi.hoisted(() => ({
+  invalidateQueries: vi.fn(async () => undefined),
+  mutations: [] as Array<{ onSuccess?: () => void }>,
+}))
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({
+    invalidateQueries: testState.invalidateQueries,
+  }),
+  useMutation: (options: { onSuccess?: () => void }) => {
+    testState.mutations.push(options)
+    return {
+      mutate: vi.fn(),
+      mutateAsync: vi.fn(),
+    }
+  },
+}))
+
+vi.mock("../../src/provider.js", () => ({
+  useVoyantBookingsContext: () => ({
+    baseUrl: "",
+    fetcher: vi.fn(),
+  }),
+}))
+
+describe("useBookingItemMutation", () => {
+  beforeEach(() => {
+    testState.invalidateQueries.mockReset()
+    testState.invalidateQueries.mockResolvedValue(undefined)
+    testState.mutations.length = 0
+  })
+
+  it("refreshes the parent booking, lists, items, activity, and action ledger", async () => {
+    const { useBookingItemMutation } = await import("../../src/hooks/use-booking-item-mutation.js")
+
+    useBookingItemMutation("book_123")
+
+    expect(testState.mutations).toHaveLength(3)
+
+    for (const mutation of testState.mutations) {
+      mutation.onSuccess?.()
+    }
+
+    expect(testState.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["voyant", "bookings", "bookings", "detail", "book_123"],
+      exact: true,
+    })
+    expect(testState.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["voyant", "bookings", "bookings"],
+    })
+    expect(testState.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["voyant", "bookings", "bookings", "detail", "book_123", "items"],
+    })
+    expect(testState.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["voyant", "bookings", "bookings", "detail", "book_123", "activity"],
+    })
+    expect(testState.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["voyant", "bookings", "bookings", "detail", "book_123", "action-ledger"],
+    })
+
+    expect(testState.invalidateQueries).toHaveBeenCalledTimes(15)
+  })
+})

--- a/packages/bookings/src/routes-admin.ts
+++ b/packages/bookings/src/routes-admin.ts
@@ -3532,7 +3532,11 @@ const itemsRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
     }
     const ledgerContext = getActionLedgerRequestContext(c)
     const row = await c.get("db").transaction(async (tx) => {
-      const row = await bookingsService.deleteItem(tx as PostgresJsDatabase, itemId)
+      const row = await bookingsService.deleteItem(
+        tx as PostgresJsDatabase,
+        itemId,
+        c.get("userId"),
+      )
       if (!row) return null
       await appendBookingMutationLedgerEntryToDb(tx as AnyDrizzleDb, ledgerContext, {
         action: "delete",

--- a/packages/bookings/src/service-core.ts
+++ b/packages/bookings/src/service-core.ts
@@ -4703,12 +4703,16 @@ export const bookingsService = {
     })
   },
 
-  async deleteItem(db: PostgresJsDatabase, itemId: string) {
+  async deleteItem(db: PostgresJsDatabase, itemId: string, userId?: string) {
     return db.transaction(async (tx) => {
       // Look up the parent booking BEFORE the delete so we can roll up
       // afterwards.
       const [item] = await tx
-        .select({ bookingId: bookingItems.bookingId })
+        .select({
+          bookingId: bookingItems.bookingId,
+          title: bookingItems.title,
+          itemType: bookingItems.itemType,
+        })
         .from(bookingItems)
         .where(eq(bookingItems.id, itemId))
         .limit(1)
@@ -4718,8 +4722,15 @@ export const bookingsService = {
         .where(eq(bookingItems.id, itemId))
         .returning({ id: bookingItems.id })
 
-      if (item) {
+      if (item && row) {
         await bookingsService.recomputeBookingTotal(tx as PostgresJsDatabase, item.bookingId)
+        await tx.insert(bookingActivityLog).values({
+          bookingId: item.bookingId,
+          actorId: userId ?? "system",
+          activityType: "item_update",
+          description: `Booking item "${item.title}" deleted`,
+          metadata: { bookingItemId: itemId, itemType: item.itemType },
+        })
       }
 
       return row ?? null

--- a/packages/bookings/tests/integration/routes.integration-suite.ts
+++ b/packages/bookings/tests/integration/routes.integration-suite.ts
@@ -2944,6 +2944,18 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
       const res = await app.request(`/${booking.id}/items/${item.id}`, { method: "DELETE" })
       expect(res.status).toBe(200)
       expect((await res.json()).success).toBe(true)
+
+      const activityRes = await app.request(`/${booking.id}/activity`, { method: "GET" })
+      expect(activityRes.status).toBe(200)
+      const activityBody = await activityRes.json()
+      expect(
+        activityBody.data.some(
+          (entry: Record<string, unknown>) =>
+            entry.activityType === "item_update" &&
+            entry.description === 'Booking item "Transfer" deleted' &&
+            (entry.metadata as Record<string, unknown> | null)?.bookingItemId === item.id,
+        ),
+      ).toBe(true)
     })
 
     it("returns 404 when adding item to non-existent booking", async () => {


### PR DESCRIPTION
## Summary
- Refresh the booking detail, booking list, item, activity, and action-ledger queries after booking item create/update/delete mutations so header aggregate cards refetch without a reload.
- Record booking item deletions in the booking activity log with the deleted item id/type snapshot.
- Add regression coverage for item-mutation query invalidation and deletion activity logging.

Closes #2442.

## Verification
- `pnpm exec biome check --write packages/bookings-react/src/hooks/use-booking-item-mutation.ts packages/bookings-react/tests/unit/use-booking-item-mutation.test.ts packages/bookings/src/service-core.ts packages/bookings/src/routes-admin.ts packages/bookings/tests/integration/routes.integration-suite.ts .changeset/booking-item-refresh-audit.md`
- `pnpm --filter @voyant-travel/bookings-react exec vitest run tests/unit/use-booking-item-mutation.test.ts`
- `pnpm --filter @voyant-travel/bookings exec vitest run tests/integration/routes.test.ts` (skipped locally; `TEST_DATABASE_URL` not set)
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/bookings typecheck`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/bookings-react typecheck`
- `pnpm --filter @voyant-travel/bookings lint && pnpm --filter @voyant-travel/bookings-react lint`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- Pre-commit hook completed broad workspace lint/typecheck/build checks successfully during commit.
- Pre-push hook completed broad workspace test checks successfully before branch publish.