### PR TITLE
fix(operator): list owned public products in storefront search

### DIFF
--- a/starters/operator/src/api/lib/catalog-listability.test.ts
+++ b/starters/operator/src/api/lib/catalog-listability.test.ts
@@ -1,0 +1,44 @@
+/**
+ * catalog-listability — owned-product storefront listability predicate.
+ *
+ * Regression cover for issue #2617: an active + public + activated owned
+ * product that is directly bookable must be listable in the *customer*
+ * (direct storefront) search slice without an explicit channel mapping.
+ * Channel mappings only gate distribution to external audiences
+ * (partner / supplier).
+ */
+
+import { describe, expect, it, vi } from "vitest"
+
+import { isOwnedProductStorefrontListable } from "./catalog-listability"
+
+describe("isOwnedProductStorefrontListable", () => {
+  it("lists an owned product in the customer slice without a channel mapping", async () => {
+    // The customer audience is the operator's own direct storefront: no channel
+    // lookup, always listable (the upstream gate already asserted
+    // active + public + activated).
+    const hasActiveChannelMapping = vi.fn(async () => false)
+
+    const listable = await isOwnedProductStorefrontListable({
+      audience: "customer",
+      hasActiveChannelMapping,
+    })
+
+    expect(listable).toBe(true)
+    expect(hasActiveChannelMapping).not.toHaveBeenCalled()
+  })
+
+  it("requires an active channel mapping for external (partner) slices", async () => {
+    const withMapping = await isOwnedProductStorefrontListable({
+      audience: "partner",
+      hasActiveChannelMapping: async () => true,
+    })
+    const withoutMapping = await isOwnedProductStorefrontListable({
+      audience: "partner",
+      hasActiveChannelMapping: async () => false,
+    })
+
+    expect(withMapping).toBe(true)
+    expect(withoutMapping).toBe(false)
+  })
+})

--- a/starters/operator/src/api/lib/catalog-listability.ts
+++ b/starters/operator/src/api/lib/catalog-listability.ts
@@ -1,0 +1,75 @@
+/**
+ * Owned-product catalog listability policy for the operator deployment.
+ *
+ * This is the deployment-owned rule the inventory document builder injects via
+ * its `isPublicAudienceListable` hook. It decides whether an owned product
+ * (already gated as active + public + activated upstream) should be emitted
+ * into a public-audience search slice.
+ *
+ * Kept in its own module so the audience decision can be unit-tested without
+ * dragging in the whole catalog-plane runtime graph (embeddings, policies,
+ * projection extensions).
+ */
+
+import type { IndexerSlice } from "@voyant-travel/catalog"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import { channelProductMappings, channels } from "@voyant-travel/distribution"
+import { and, eq } from "drizzle-orm"
+
+/**
+ * True when the product has at least one active `channel_product_mappings`
+ * row pointing at an active channel — i.e. it is published to a sales channel.
+ */
+export async function hasActiveSalesChannelMapping(
+  db: AnyDrizzleDb,
+  productId: string,
+): Promise<boolean> {
+  const rows = await db
+    .select({ id: channelProductMappings.id })
+    .from(channelProductMappings)
+    .innerJoin(channels, eq(channels.id, channelProductMappings.channelId))
+    .where(
+      and(
+        eq(channelProductMappings.productId, productId),
+        eq(channelProductMappings.active, true),
+        eq(channels.status, "active"),
+      ),
+    )
+    .limit(1)
+
+  return rows.length > 0
+}
+
+export type OwnedProductStorefrontListabilityInput = {
+  audience: IndexerSlice["audience"]
+  /** Resolves whether the product is published to an active sales channel. */
+  hasActiveChannelMapping: () => boolean | Promise<boolean>
+}
+
+/**
+ * Storefront/distribution listability predicate for owned products.
+ *
+ * The upstream inventory gate (`isPublicStorefrontProduct`) already requires
+ * `status = active`, `activated = true`, and `visibility = public` before this
+ * runs, so the caller only reaches here for an owned product that is otherwise
+ * publicly sellable.
+ *
+ * The `customer` slice is the operator's *own direct storefront*. Owned
+ * inventory that is active + public + activated is inherently sellable there —
+ * its public detail, quote, and booking already resolve without any channel
+ * mapping — so it MUST be listable in customer search without one. Requiring an
+ * explicit `channel_product_mappings` row for the direct storefront made owned
+ * products bookable-but-invisible (issue #2617).
+ *
+ * Channel mappings gate *distribution to external audiences* (partner /
+ * supplier slices), not visibility on the operator's own storefront. See
+ * docs/architecture/catalog-supply-models.md and federated-operating-mode.md:
+ * owned "sellable inventory" is directly bookable/listable; the marketplace /
+ * reseller channel graph governs everything downstream of the direct channel.
+ */
+export async function isOwnedProductStorefrontListable(
+  input: OwnedProductStorefrontListabilityInput,
+): Promise<boolean> {
+  if (input.audience === "customer") return true
+  return input.hasActiveChannelMapping()
+}

--- a/starters/operator/src/api/lib/catalog-runtime.ts
+++ b/starters/operator/src/api/lib/catalog-runtime.ts
@@ -37,7 +37,6 @@ import {
 } from "@voyant-travel/cruises/service-catalog-plane"
 import { createCruiseCabinFacetProjectionExtension } from "@voyant-travel/cruises/service-catalog-plane-cabins"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
-import { channelProductMappings, channels } from "@voyant-travel/distribution"
 import { productCatalogPolicy } from "@voyant-travel/inventory/catalog-policy"
 import { productDeparturesCatalogPolicy } from "@voyant-travel/inventory/catalog-policy-departures"
 import { productDestinationsCatalogPolicy } from "@voyant-travel/inventory/catalog-policy-destinations"
@@ -52,7 +51,12 @@ import {
 import { createProductDestinationsProjectionExtension } from "@voyant-travel/inventory/service-catalog-plane-destinations"
 import { createProductTaxonomyProjectionExtension } from "@voyant-travel/inventory/service-catalog-plane-taxonomy"
 import { createProductDeparturesProjectionExtension } from "@voyant-travel/operations"
-import { and, asc, eq } from "drizzle-orm"
+import { asc, eq } from "drizzle-orm"
+
+import {
+  hasActiveSalesChannelMapping,
+  isOwnedProductStorefrontListable,
+} from "./catalog-listability.js"
 
 export const CATALOG_VERTICALS = [
   "products",
@@ -354,23 +358,6 @@ export function getFieldPolicyRegistries(): Map<string, FieldPolicyRegistry> {
   return _registries
 }
 
-async function hasActiveSalesChannelMapping(db: AnyDrizzleDb, productId: string): Promise<boolean> {
-  const rows = await db
-    .select({ id: channelProductMappings.id })
-    .from(channelProductMappings)
-    .innerJoin(channels, eq(channels.id, channelProductMappings.channelId))
-    .where(
-      and(
-        eq(channelProductMappings.productId, productId),
-        eq(channelProductMappings.active, true),
-        eq(channels.status, "active"),
-      ),
-    )
-    .limit(1)
-
-  return rows.length > 0
-}
-
 /**
  * Build the products `DocumentBuilder` with all child-entity projection
  * extensions wired in. Single source of truth for both the live catalog
@@ -397,7 +384,11 @@ export function createProductsDocumentBuilder(
       createProductPricingProjectionExtension(),
       createProductPromotionsProjectionExtension({ loadOriginalPrice: loadProductPriceFrom }),
     ],
-    isPublicAudienceListable: ({ db, product }) => hasActiveSalesChannelMapping(db, product.id),
+    isPublicAudienceListable: ({ db, product, slice }) =>
+      isOwnedProductStorefrontListable({
+        audience: slice.audience,
+        hasActiveChannelMapping: () => hasActiveSalesChannelMapping(db, product.id),
+      }),
   })
 }
 


### PR DESCRIPTION
## Summary

Fixes #2617 — active **owned** public products were directly bookable but never appeared in the customer storefront search.

## Root cause: a listability GATE, not an indexing gap

Owned products **are** indexed by the product document builder. The problem is the operator's `isPublicAudienceListable` predicate, which the builder injects. Since #2347 it was wired to `hasActiveSalesChannelMapping`, requiring an active `channel_product_mappings` row to an active channel before a product could be emitted into the **customer** (direct storefront) search slice.

`prod_01kwa15bmeexwr3t57d3p0y442` (`London 3-Day Essentials`) is `active` / `public` / `activated` and its public detail, GBP quote, and booking all resolve — but it has no channel mapping, so the customer-slice document was tombstoned. Result: bookable-but-invisible in search.

The connected/demo `cdmi_*` products were unaffected because they index via the separate `sync-sources` (mirrored connected-inventory) path, which does not apply this predicate — hence "search only returns `cdmi_*`".

## Fix

The **customer** slice is the operator's own direct storefront. Owned "sellable inventory" that is active + public + activated is inherently listable there (see `docs/architecture/catalog-supply-models.md` and `federated-operating-mode.md`) — it must not require an explicit channel mapping. Channel mappings gate **distribution to external audiences** (partner/supplier), not visibility on the operator's own storefront.

- Extracted the predicate into `starters/operator/src/api/lib/catalog-listability.ts`.
- `isOwnedProductStorefrontListable` now returns `true` for the `customer` audience and only requires an active channel mapping for external (partner/supplier) audiences.
- The channel-mapping check is injected as a function so the audience decision is unit-testable without the full catalog-plane runtime graph.

This is additive for the customer slice: no product that was previously listed becomes hidden; owned active+public+activated products that lacked a mapping now become listable — matching how they already render/book directly.

## Files changed

- `starters/operator/src/api/lib/catalog-listability.ts` (new) — extracted `hasActiveSalesChannelMapping` + `isOwnedProductStorefrontListable`
- `starters/operator/src/api/lib/catalog-runtime.ts` — wire the predicate, branch on slice audience
- `starters/operator/src/api/lib/catalog-listability.test.ts` (new) — regression test: customer slice lists an owned product without a channel mapping; partner slice still requires one

## Notes

- Only the private `operator` starter changed — no publishable `@voyant-travel/*` package, so no changeset. No route/response schema touched, so no OpenAPI regeneration.
- Out of scope (deferred, per the issue): the anonymous market/locale/currency-selector gap (#2701 / #2643-adjacent).

## Verification

- `starters/operator` unit tests: `catalog-listability.test.ts`, `catalog-bridge.publication.test.ts`, `booking-engine-runtime.test.ts` pass.
- biome + agent-quality checks clean on changed files.
