### PR TITLE
fix(inventory): link a customer from billing contact for anonymous owned-product booking

### DIFF
--- a/.changeset/anon-owned-product-booking.md
+++ b/.changeset/anon-owned-product-booking.md
@@ -1,0 +1,12 @@
+---
+"@voyant-travel/inventory": patch
+---
+
+Owned product booking commit now resolves (or creates) a CRM person from the
+billing contact when the commit carries no `personId`/`organizationId` — the
+anonymous storefront checkout case. `createProductsBookingHandler` accepts a new
+optional `resolveBillingPerson` bridge (wired by the template to
+`relationshipsService.upsertPersonFromContact`), mirroring the sourced/session
+arm's `resolveBillingPerson` hook. This fixes anonymous storefront checkout for
+owned public products, which previously failed with a 400 "Select a billing
+person or organization".

--- a/packages/inventory/src/booking-engine/handler-support.ts
+++ b/packages/inventory/src/booking-engine/handler-support.ts
@@ -364,6 +364,23 @@ export function extractBillingParty(party: Record<string, unknown> | undefined):
   }
 }
 
+// Mirrors `isRealEmail` in @voyant-travel/finance's `requireCompleteBookingParty`
+// (and the trips copy). The owned booking handler resolves a CRM person from the
+// billing contact before calling `createBooking`, which rejects a blank or
+// placeholder email — so the resolver must apply the same rule up front, or it
+// orphans a CRM person on every failed checkout. Keep this set in sync with
+// finance's `placeholderEmails`.
+const placeholderBillingEmails = new Set([
+  "noreply@example.com",
+  "tbd@example.com",
+  "traveler@example.com",
+])
+
+export function isRealBillingEmail(value: string | null | undefined): value is string {
+  const normalized = value?.trim().toLowerCase() ?? ""
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized) && !placeholderBillingEmails.has(normalized)
+}
+
 export function extractPartyTravelers(
   party: Record<string, unknown> | undefined,
 ): Array<{ personId?: string | null }> {

--- a/packages/inventory/src/booking-engine/handler.ts
+++ b/packages/inventory/src/booking-engine/handler.ts
@@ -877,34 +877,6 @@ export function createProductsBookingHandler(
       // the booking row, and known before the create — a stable, resolvable ref.
       const bookingNumber = generateNumber()
 
-      // Resolve (or create) a customer person from the billing contact when no
-      // CRM person/organization id is supplied — the anonymous storefront case
-      // — same as the sourced/session arm's `resolveBillingPerson`, so
-      // `createBooking`'s billing-party check passes and the owned booking links
-      // a real CRM record instead of 400ing "Select a billing person or
-      // organization". No-op when a person/org is already supplied
-      // (operator/trips) or no resolver is wired.
-      let billingPersonId = partyBilling.personId ?? null
-      const billingOrganizationId = partyBilling.organizationId ?? null
-      if (!billingPersonId && !billingOrganizationId && options.resolveBillingPerson) {
-        // Only resolve when the contact fully satisfies what `createBooking`'s
-        // billing-party check requires of a person: BOTH a first and last name
-        // AND a real email or phone. Resolving on a partial contact (name only,
-        // contact point only, placeholder email) creates a CRM person that
-        // `createBooking` then rejects — orphaning a person on every failed
-        // attempt. When incomplete, skip and let the commit reject as before.
-        const hasBillingContactPoint =
-          Boolean(billingContact.email) || Boolean(billingContact.phone)
-        const hasBillingName =
-          Boolean(billingContact.firstName?.trim()) && Boolean(billingContact.lastName?.trim())
-        if (hasBillingContactPoint && hasBillingName) {
-          billingPersonId = await options.resolveBillingPerson(billingContact, {
-            bookingId: bookingNumber,
-            source: "storefront-booking",
-            sourceRef: bookingNumber,
-          })
-        }
-      }
       const travelers = (draft.travelers ?? []).map((t, index) => ({
         firstName: t.firstName,
         lastName: t.lastName,
@@ -917,6 +889,48 @@ export function createProductsBookingHandler(
             ? (t.band as "child" | "infant")
             : ("adult" as const),
       }))
+
+      // Resolve (or create) a customer person from the billing contact when no
+      // CRM person/organization id is supplied — the anonymous storefront case
+      // — same as the sourced/session arm's `resolveBillingPerson`, so
+      // `createBooking`'s billing-party check passes and the owned booking links
+      // a real CRM record instead of 400ing "Select a billing person or
+      // organization". No-op when a person/org is already supplied
+      // (operator/trips) or no resolver is wired.
+      let billingPersonId = partyBilling.personId ?? null
+      const billingOrganizationId = partyBilling.organizationId ?? null
+      if (!billingPersonId && !billingOrganizationId && options.resolveBillingPerson) {
+        // Resolving persists a CRM person BEFORE `createBooking` runs, so only
+        // resolve when the WHOLE party will pass `createBooking`'s
+        // `requireCompleteBookingParty` — otherwise the commit rejects after a
+        // person already exists, orphaning it (with a booking-number `sourceRef`
+        // that never materializes). Mirror the checks that apply to the
+        // anonymous storefront input: the billing person needs BOTH a first and
+        // last name AND a real email or phone, and there must be at least one
+        // traveler, each with a name (or linked person) and no placeholder
+        // email. (The person/org-supplied operator + trips paths skip this
+        // block entirely; voucher/price-override rejections are operator-only
+        // fields absent from anonymous drafts.)
+        const hasBillingContactPoint =
+          Boolean(billingContact.email) || Boolean(billingContact.phone)
+        const hasBillingName =
+          Boolean(billingContact.firstName?.trim()) && Boolean(billingContact.lastName?.trim())
+        const hasBookableTravelers =
+          travelers.length > 0 &&
+          travelers.every(
+            (t) =>
+              (Boolean(t.personId) ||
+                (Boolean(t.firstName?.trim()) && Boolean(t.lastName?.trim()))) &&
+              (!t.email || isRealBillingEmail(t.email)),
+          )
+        if (hasBillingContactPoint && hasBillingName && hasBookableTravelers) {
+          billingPersonId = await options.resolveBillingPerson(billingContact, {
+            bookingId: bookingNumber,
+            source: "storefront-booking",
+            sourceRef: bookingNumber,
+          })
+        }
+      }
 
       // Promotion-discounted quotes: thread the discounted customer-
       // facing amount into the booking's seed sellAmountCents so

--- a/packages/inventory/src/booking-engine/handler.ts
+++ b/packages/inventory/src/booking-engine/handler.ts
@@ -851,12 +851,15 @@ export function createProductsBookingHandler(
       let billingPersonId = partyBilling.personId ?? null
       const billingOrganizationId = partyBilling.organizationId ?? null
       if (!billingPersonId && !billingOrganizationId && options.resolveBillingPerson) {
-        const hasBillingContact =
-          Boolean(partyBilling.contactEmail) ||
-          Boolean(partyBilling.contactPhone) ||
-          Boolean(partyBilling.contactFirstName) ||
-          Boolean(partyBilling.contactLastName)
-        if (hasBillingContact) {
+        // Only resolve when there's a real contact POINT (email or phone). A
+        // name alone is insufficient: `createBooking`'s billing-party check
+        // requires an email or phone, so resolving on name-only would create a
+        // CRM person that still can't satisfy the booking — orphaning a person
+        // on every failed attempt. Without a contact point, skip and let the
+        // commit reject as before.
+        const hasBillingContactPoint =
+          Boolean(partyBilling.contactEmail) || Boolean(partyBilling.contactPhone)
+        if (hasBillingContactPoint) {
           billingPersonId = await options.resolveBillingPerson(
             {
               firstName: partyBilling.contactFirstName,

--- a/packages/inventory/src/booking-engine/handler.ts
+++ b/packages/inventory/src/booking-engine/handler.ts
@@ -55,6 +55,7 @@ import {
   extractInternalNotes,
   extractPartyTravelers,
   extractTaxLines,
+  isRealBillingEmail,
   loadProduct,
   normalizeOptionSelections,
   priceOptionSelections,
@@ -847,20 +848,23 @@ export function createProductsBookingHandler(
       // explicit party, fall back to the draft, so BOTH paths stamp the booking
       // contact and can resolve a customer.
       const draftBillingContact = draft.billing?.contact
-      // Trim contact points to null: the draft schema defaults `email` to "" and
-      // a saved draft can carry whitespace-only values. The downstream
-      // `resolveBillingPerson` (and `createBooking`) treat a blank contact point
-      // as absent, so normalizing here keeps the resolver gate honest — a
-      // whitespace-only email must not trigger a name-only CRM person that
-      // `createBooking` then rejects, orphaning a row on every retry.
+      // Normalize contact points the way `createBooking`'s
+      // `requireCompleteBookingParty` does, so the resolver only fires for a
+      // contact it will actually accept. The draft schema defaults `email` to ""
+      // and a saved draft can carry whitespace-only or placeholder values
+      // (`traveler@example.com`, `foo`). `createBooking` rejects a blank OR
+      // placeholder/invalid email even when a phone is present, so any of those
+      // must be treated as absent here — otherwise the resolver creates a CRM
+      // person that `createBooking` then rejects, orphaning a row on every retry.
       const trimToNull = (value: string | null | undefined): string | null => {
         const trimmed = value?.trim()
         return trimmed ? trimmed : null
       }
+      const candidateEmail = partyBilling.contactEmail ?? draftBillingContact?.email
       const billingContact = {
         firstName: partyBilling.contactFirstName ?? draftBillingContact?.firstName ?? null,
         lastName: partyBilling.contactLastName ?? draftBillingContact?.lastName ?? null,
-        email: trimToNull(partyBilling.contactEmail ?? draftBillingContact?.email),
+        email: isRealBillingEmail(candidateEmail) ? candidateEmail.trim() : null,
         phone: trimToNull(partyBilling.contactPhone ?? draftBillingContact?.phone),
       }
 

--- a/packages/inventory/src/booking-engine/handler.ts
+++ b/packages/inventory/src/booking-engine/handler.ts
@@ -878,15 +878,17 @@ export function createProductsBookingHandler(
       let billingPersonId = partyBilling.personId ?? null
       const billingOrganizationId = partyBilling.organizationId ?? null
       if (!billingPersonId && !billingOrganizationId && options.resolveBillingPerson) {
-        // Only resolve when there's a real contact POINT (email or phone). A
-        // name alone is insufficient: `createBooking`'s billing-party check
-        // requires an email or phone, so resolving on name-only would create a
-        // CRM person that still can't satisfy the booking — orphaning a person
-        // on every failed attempt. Without a contact point, skip and let the
-        // commit reject as before.
+        // Only resolve when the contact fully satisfies what `createBooking`'s
+        // billing-party check requires of a person: BOTH a first and last name
+        // AND a real email or phone. Resolving on a partial contact (name only,
+        // contact point only, placeholder email) creates a CRM person that
+        // `createBooking` then rejects — orphaning a person on every failed
+        // attempt. When incomplete, skip and let the commit reject as before.
         const hasBillingContactPoint =
           Boolean(billingContact.email) || Boolean(billingContact.phone)
-        if (hasBillingContactPoint) {
+        const hasBillingName =
+          Boolean(billingContact.firstName?.trim()) && Boolean(billingContact.lastName?.trim())
+        if (hasBillingContactPoint && hasBillingName) {
           billingPersonId = await options.resolveBillingPerson(billingContact, {
             bookingId: request.bookingId,
             source: "storefront-booking",

--- a/packages/inventory/src/booking-engine/handler.ts
+++ b/packages/inventory/src/booking-engine/handler.ts
@@ -840,14 +840,28 @@ export function createProductsBookingHandler(
       const partyBilling = extractBillingParty(request.party)
       const partyTravelers = extractPartyTravelers(request.party)
 
-      // Anonymous storefront checkout carries a billing contact but no
-      // CRM person/organization id. Resolve (or create) a customer person
-      // from that contact — same as the sourced/session arm's
-      // `resolveBillingPerson` — so `createBooking`'s billing-party check
-      // passes and the owned booking links a real CRM record instead of
-      // 400ing "Select a billing person or organization". When a person
-      // or an org is already supplied (operator/trips paths) or no
-      // resolver is wired, this is a no-op.
+      // Billing arrives two ways. The operator/trips paths pass an explicit
+      // `party`. The anonymous storefront path POSTs only a draftId to
+      // `/v1/public/catalog/book`, so `request.party` is empty and the billing
+      // contact lives in the saved draft (`draft.billing.contact`). Prefer the
+      // explicit party, fall back to the draft, so BOTH paths stamp the booking
+      // contact and can resolve a customer.
+      const draftBillingContact = draft.billing?.contact
+      const billingContact = {
+        firstName: partyBilling.contactFirstName ?? draftBillingContact?.firstName ?? null,
+        lastName: partyBilling.contactLastName ?? draftBillingContact?.lastName ?? null,
+        // The draft schema defaults `email` to "" — treat empty as absent.
+        email: partyBilling.contactEmail ?? (draftBillingContact?.email || null),
+        phone: partyBilling.contactPhone ?? draftBillingContact?.phone ?? null,
+      }
+
+      // Resolve (or create) a customer person from the billing contact when no
+      // CRM person/organization id is supplied — the anonymous storefront case
+      // — same as the sourced/session arm's `resolveBillingPerson`, so
+      // `createBooking`'s billing-party check passes and the owned booking links
+      // a real CRM record instead of 400ing "Select a billing person or
+      // organization". No-op when a person/org is already supplied
+      // (operator/trips) or no resolver is wired.
       let billingPersonId = partyBilling.personId ?? null
       const billingOrganizationId = partyBilling.organizationId ?? null
       if (!billingPersonId && !billingOrganizationId && options.resolveBillingPerson) {
@@ -858,21 +872,13 @@ export function createProductsBookingHandler(
         // on every failed attempt. Without a contact point, skip and let the
         // commit reject as before.
         const hasBillingContactPoint =
-          Boolean(partyBilling.contactEmail) || Boolean(partyBilling.contactPhone)
+          Boolean(billingContact.email) || Boolean(billingContact.phone)
         if (hasBillingContactPoint) {
-          billingPersonId = await options.resolveBillingPerson(
-            {
-              firstName: partyBilling.contactFirstName,
-              lastName: partyBilling.contactLastName,
-              email: partyBilling.contactEmail,
-              phone: partyBilling.contactPhone,
-            },
-            {
-              bookingId: request.bookingId,
-              source: "storefront-booking",
-              sourceRef: request.bookingId,
-            },
-          )
+          billingPersonId = await options.resolveBillingPerson(billingContact, {
+            bookingId: request.bookingId,
+            source: "storefront-booking",
+            sourceRef: request.bookingId,
+          })
         }
       }
       const travelers = (draft.travelers ?? []).map((t, index) => ({
@@ -915,10 +921,10 @@ export function createProductsBookingHandler(
         bookingNumber: generateNumber(),
         personId: billingPersonId,
         organizationId: billingOrganizationId,
-        contactFirstName: partyBilling.contactFirstName,
-        contactLastName: partyBilling.contactLastName,
-        contactEmail: partyBilling.contactEmail,
-        contactPhone: partyBilling.contactPhone,
+        contactFirstName: billingContact.firstName,
+        contactLastName: billingContact.lastName,
+        contactEmail: billingContact.email,
+        contactPhone: billingContact.phone,
         internalNotes: extractInternalNotes(request.party),
         travelers: travelers.length > 0 ? travelers : undefined,
         paymentSchedules: draft.paymentSchedules,

--- a/packages/inventory/src/booking-engine/handler.ts
+++ b/packages/inventory/src/booking-engine/handler.ts
@@ -196,6 +196,33 @@ export type BookingCreateBridge = (
   options?: { userId?: string },
 ) => Promise<BookingCreateBridgeResult>
 
+/** Billing contact snapshot handed to `ResolveOwnedBillingPerson`. */
+export interface OwnedBillingContact {
+  firstName?: string | null
+  lastName?: string | null
+  email?: string | null
+  phone?: string | null
+}
+
+/**
+ * Caller-supplied bridge that resolves (or creates) a CRM person from a
+ * booking's billing contact when the commit carries no `personId` /
+ * `organizationId` — e.g. an anonymous storefront checkout for an owned
+ * product. Mirrors the bookings module's `resolveBillingPerson` runtime
+ * hook (both wire to `relationshipsService.upsertPersonFromContact`), so
+ * the owned catalog arm links a customer the same way the session/sourced
+ * arm does. Returns the resolved person id, or `null` to leave the
+ * booking person unset (the finance layer then rejects a party with no
+ * person/org). The operator + trips reserve paths always supply a
+ * `personId` directly, so the resolver only fires for anonymous
+ * storefront commits. Keeps Inventory free of a direct
+ * `@voyant-travel/relationships` dependency.
+ */
+export type ResolveOwnedBillingPerson = (
+  contact: OwnedBillingContact,
+  ctx: { bookingId: string; source: string; sourceRef: string },
+) => Promise<string | null>
+
 // ─────────────────────────────────────────────────────────────────
 // Draft shape — what the wizard reads off the quote response
 // ─────────────────────────────────────────────────────────────────
@@ -498,6 +525,15 @@ export interface CreateProductsBookingHandlerOptions extends OwnedProductsShapeL
    * `@voyant-travel/finance`.
    */
   createBooking: BookingCreateBridge
+  /**
+   * Optional bridge that resolves/creates a CRM person from the billing
+   * contact when a commit carries no `personId`/`organizationId` (the
+   * anonymous storefront checkout case). Wired by the template to
+   * `relationshipsService.upsertPersonFromContact`. When omitted, the
+   * commit forwards the raw contact snapshot and the finance layer's
+   * billing-party check rejects a party with no person/org.
+   */
+  resolveBillingPerson?: ResolveOwnedBillingPerson
   /**
    * Generator for booking numbers. Defaults to a timestamp-based
    * value if not supplied. Templates that have a sequence service
@@ -803,6 +839,39 @@ export function createProductsBookingHandler(
 
       const partyBilling = extractBillingParty(request.party)
       const partyTravelers = extractPartyTravelers(request.party)
+
+      // Anonymous storefront checkout carries a billing contact but no
+      // CRM person/organization id. Resolve (or create) a customer person
+      // from that contact — same as the sourced/session arm's
+      // `resolveBillingPerson` — so `createBooking`'s billing-party check
+      // passes and the owned booking links a real CRM record instead of
+      // 400ing "Select a billing person or organization". When a person
+      // or an org is already supplied (operator/trips paths) or no
+      // resolver is wired, this is a no-op.
+      let billingPersonId = partyBilling.personId ?? null
+      const billingOrganizationId = partyBilling.organizationId ?? null
+      if (!billingPersonId && !billingOrganizationId && options.resolveBillingPerson) {
+        const hasBillingContact =
+          Boolean(partyBilling.contactEmail) ||
+          Boolean(partyBilling.contactPhone) ||
+          Boolean(partyBilling.contactFirstName) ||
+          Boolean(partyBilling.contactLastName)
+        if (hasBillingContact) {
+          billingPersonId = await options.resolveBillingPerson(
+            {
+              firstName: partyBilling.contactFirstName,
+              lastName: partyBilling.contactLastName,
+              email: partyBilling.contactEmail,
+              phone: partyBilling.contactPhone,
+            },
+            {
+              bookingId: request.bookingId,
+              source: "storefront-booking",
+              sourceRef: request.bookingId,
+            },
+          )
+        }
+      }
       const travelers = (draft.travelers ?? []).map((t, index) => ({
         firstName: t.firstName,
         lastName: t.lastName,
@@ -841,8 +910,8 @@ export function createProductsBookingHandler(
         // (powers the duplicate-departure check + slot-level reporting).
         slotId: draft.configure?.departureSlotId ?? null,
         bookingNumber: generateNumber(),
-        personId: partyBilling.personId,
-        organizationId: partyBilling.organizationId,
+        personId: billingPersonId,
+        organizationId: billingOrganizationId,
         contactFirstName: partyBilling.contactFirstName,
         contactLastName: partyBilling.contactLastName,
         contactEmail: partyBilling.contactEmail,

--- a/packages/inventory/src/booking-engine/handler.ts
+++ b/packages/inventory/src/booking-engine/handler.ts
@@ -847,12 +847,21 @@ export function createProductsBookingHandler(
       // explicit party, fall back to the draft, so BOTH paths stamp the booking
       // contact and can resolve a customer.
       const draftBillingContact = draft.billing?.contact
+      // Trim contact points to null: the draft schema defaults `email` to "" and
+      // a saved draft can carry whitespace-only values. The downstream
+      // `resolveBillingPerson` (and `createBooking`) treat a blank contact point
+      // as absent, so normalizing here keeps the resolver gate honest — a
+      // whitespace-only email must not trigger a name-only CRM person that
+      // `createBooking` then rejects, orphaning a row on every retry.
+      const trimToNull = (value: string | null | undefined): string | null => {
+        const trimmed = value?.trim()
+        return trimmed ? trimmed : null
+      }
       const billingContact = {
         firstName: partyBilling.contactFirstName ?? draftBillingContact?.firstName ?? null,
         lastName: partyBilling.contactLastName ?? draftBillingContact?.lastName ?? null,
-        // The draft schema defaults `email` to "" — treat empty as absent.
-        email: partyBilling.contactEmail ?? (draftBillingContact?.email || null),
-        phone: partyBilling.contactPhone ?? draftBillingContact?.phone ?? null,
+        email: trimToNull(partyBilling.contactEmail ?? draftBillingContact?.email),
+        phone: trimToNull(partyBilling.contactPhone ?? draftBillingContact?.phone),
       }
 
       // Resolve (or create) a customer person from the billing contact when no

--- a/packages/inventory/src/booking-engine/handler.ts
+++ b/packages/inventory/src/booking-engine/handler.ts
@@ -868,6 +868,15 @@ export function createProductsBookingHandler(
         phone: trimToNull(partyBilling.contactPhone ?? draftBillingContact?.phone),
       }
 
+      // Generate the booking number up front so it can double as the resolved
+      // person's provenance ref below. `request.bookingId` is only the
+      // provisional id `bookEntity` allocates — the finance bridge mints its own
+      // persisted booking id (which `bookEntity` then adopts), so stamping
+      // `request.bookingId` would point new CRM people at a booking row that
+      // never exists. The booking NUMBER is caller-supplied, written straight to
+      // the booking row, and known before the create — a stable, resolvable ref.
+      const bookingNumber = generateNumber()
+
       // Resolve (or create) a customer person from the billing contact when no
       // CRM person/organization id is supplied — the anonymous storefront case
       // — same as the sourced/session arm's `resolveBillingPerson`, so
@@ -890,9 +899,9 @@ export function createProductsBookingHandler(
           Boolean(billingContact.firstName?.trim()) && Boolean(billingContact.lastName?.trim())
         if (hasBillingContactPoint && hasBillingName) {
           billingPersonId = await options.resolveBillingPerson(billingContact, {
-            bookingId: request.bookingId,
+            bookingId: bookingNumber,
             source: "storefront-booking",
-            sourceRef: request.bookingId,
+            sourceRef: bookingNumber,
           })
         }
       }
@@ -933,7 +942,7 @@ export function createProductsBookingHandler(
         // Link the departure so the booking item carries availability_slot_id
         // (powers the duplicate-departure check + slot-level reporting).
         slotId: draft.configure?.departureSlotId ?? null,
-        bookingNumber: generateNumber(),
+        bookingNumber,
         personId: billingPersonId,
         organizationId: billingOrganizationId,
         contactFirstName: billingContact.firstName,

--- a/packages/inventory/src/booking-engine/index.ts
+++ b/packages/inventory/src/booking-engine/index.ts
@@ -13,4 +13,6 @@ export {
   buildOwnedProductDraftShape,
   type CreateProductsBookingHandlerOptions,
   createProductsBookingHandler,
+  type OwnedBillingContact,
+  type ResolveOwnedBillingPerson,
 } from "./handler.js"

--- a/packages/inventory/tests/unit/booking-engine-quote.test.ts
+++ b/packages/inventory/tests/unit/booking-engine-quote.test.ts
@@ -537,6 +537,7 @@ describe("createProductsBookingHandler.commit", () => {
       // No party — mirrors the storefront /book payload (draftId only).
       draft: {
         configure: { pax: { adult: 1 } },
+        travelers: [{ firstName: "Guest", lastName: "Customer", band: "adult" }],
         billing: {
           contact: {
             firstName: "Guest",
@@ -708,6 +709,7 @@ describe("createProductsBookingHandler.commit", () => {
       bookingId: "catalog_booking_1",
       draft: {
         configure: { pax: { adult: 1 } },
+        travelers: [{ firstName: "Guest", lastName: "Customer", band: "adult" }],
         billing: {
           contact: {
             firstName: "Guest",
@@ -730,5 +732,42 @@ describe("createProductsBookingHandler.commit", () => {
     expect(createBooking).toHaveBeenCalledWith(
       expect.objectContaining({ personId: "pers_from_phone", contactEmail: null }),
     )
+  })
+
+  it("skips the resolver when the draft has a complete billing contact but no travelers", async () => {
+    // createBooking's requireCompleteBookingParty rejects a party with zero
+    // travelers, so resolving a person first would orphan it.
+    const createBooking = vi.fn(async () => ({
+      status: "ok" as const,
+      bookingId: "book_1",
+      bookingNumber: "BK-1",
+    }))
+    const resolveBillingPerson = vi.fn(async () => "pers_should_not_be_used")
+    const handler = createProductsBookingHandler({ createBooking, resolveBillingPerson })
+
+    const request: CommitOwnedRequest = {
+      entityModule: "products",
+      entityId: product.id,
+      bookingId: "catalog_booking_1",
+      draft: {
+        configure: { pax: { adult: 1 } },
+        // Complete billing contact, but no traveler rows.
+        billing: {
+          contact: {
+            firstName: "Guest",
+            lastName: "Customer",
+            email: "guest@example.com",
+            phone: "+40700333444",
+          },
+        },
+      },
+      pricing: { base_amount: 14500, taxes: 0, fees: 0, surcharges: 0, currency: "RON" },
+    }
+
+    const result = await handler.commit(makeCtx([product]), request)
+
+    expect(result.status).toBe("held")
+    expect(resolveBillingPerson).not.toHaveBeenCalled()
+    expect(createBooking).toHaveBeenCalledWith(expect.objectContaining({ personId: null }))
   })
 })

--- a/packages/inventory/tests/unit/booking-engine-quote.test.ts
+++ b/packages/inventory/tests/unit/booking-engine-quote.test.ts
@@ -614,4 +614,36 @@ describe("createProductsBookingHandler.commit", () => {
     expect(resolveBillingPerson).not.toHaveBeenCalled()
     expect(createBooking).toHaveBeenCalledWith(expect.objectContaining({ personId: null }))
   })
+
+  it("skips the resolver when the billing contact point is whitespace-only", async () => {
+    const createBooking = vi.fn(async () => ({
+      status: "ok" as const,
+      bookingId: "book_1",
+      bookingNumber: "BK-1",
+    }))
+    const resolveBillingPerson = vi.fn(async () => "pers_should_not_be_used")
+    const handler = createProductsBookingHandler({ createBooking, resolveBillingPerson })
+
+    const request: CommitOwnedRequest = {
+      entityModule: "products",
+      entityId: product.id,
+      bookingId: "catalog_booking_1",
+      draft: {
+        configure: { pax: { adult: 1 } },
+        billing: {
+          // Whitespace-only email/phone must not trigger a name-only CRM person.
+          contact: { firstName: "Guest", lastName: "Customer", email: "   ", phone: "  " },
+        },
+      },
+      pricing: { base_amount: 14500, taxes: 0, fees: 0, surcharges: 0, currency: "RON" },
+    }
+
+    const result = await handler.commit(makeCtx([product]), request)
+
+    expect(result.status).toBe("held")
+    expect(resolveBillingPerson).not.toHaveBeenCalled()
+    expect(createBooking).toHaveBeenCalledWith(
+      expect.objectContaining({ personId: null, contactEmail: null, contactPhone: null }),
+    )
+  })
 })

--- a/packages/inventory/tests/unit/booking-engine-quote.test.ts
+++ b/packages/inventory/tests/unit/booking-engine-quote.test.ts
@@ -456,7 +456,11 @@ describe("createProductsBookingHandler.commit", () => {
       bookingNumber: "BK-1",
     }))
     const resolveBillingPerson = vi.fn(async () => "pers_resolved")
-    const handler = createProductsBookingHandler({ createBooking, resolveBillingPerson })
+    const handler = createProductsBookingHandler({
+      createBooking,
+      resolveBillingPerson,
+      generateBookingNumber: () => "BK-TEST-1",
+    })
 
     const request: CommitOwnedRequest = {
       entityModule: "products",
@@ -496,10 +500,17 @@ describe("createProductsBookingHandler.commit", () => {
         email: "guest@example.com",
         phone: "+40700333444",
       },
-      expect.objectContaining({ bookingId: "catalog_booking_1", source: "storefront-booking" }),
+      // Provenance ref is the persisted booking NUMBER, not the provisional
+      // `request.bookingId` (which the finance bridge discards for its own id).
+      expect.objectContaining({
+        bookingId: "BK-TEST-1",
+        sourceRef: "BK-TEST-1",
+        source: "storefront-booking",
+      }),
     )
     expect(createBooking).toHaveBeenCalledWith(
       expect.objectContaining({
+        bookingNumber: "BK-TEST-1",
         personId: "pers_resolved",
         organizationId: null,
         contactFirstName: "Guest",

--- a/packages/inventory/tests/unit/booking-engine-quote.test.ts
+++ b/packages/inventory/tests/unit/booking-engine-quote.test.ts
@@ -446,4 +446,95 @@ describe("createProductsBookingHandler.commit", () => {
       }),
     )
   })
+
+  it("resolves a CRM person from the billing contact when an anonymous commit has no person/org", async () => {
+    const createBooking = vi.fn(async () => ({
+      status: "ok" as const,
+      bookingId: "book_1",
+      bookingNumber: "BK-1",
+    }))
+    const resolveBillingPerson = vi.fn(async () => "pers_resolved")
+    const handler = createProductsBookingHandler({ createBooking, resolveBillingPerson })
+
+    const request: CommitOwnedRequest = {
+      entityModule: "products",
+      entityId: product.id,
+      bookingId: "catalog_booking_1",
+      // Anonymous storefront: billing contact only, no personId/organizationId.
+      party: {
+        billing: {
+          contact: {
+            firstName: "Guest",
+            lastName: "Customer",
+            email: "guest@example.com",
+            phone: "+40700333444",
+          },
+        },
+      },
+      draft: {
+        configure: { pax: { adult: 1 } },
+        travelers: [{ firstName: "Guest", lastName: "Customer", band: "adult" }],
+      },
+      pricing: {
+        base_amount: 14500,
+        taxes: 0,
+        fees: 0,
+        surcharges: 0,
+        currency: "RON",
+      },
+    }
+
+    const result = await handler.commit(makeCtx([product]), request)
+
+    expect(result.status).toBe("held")
+    expect(resolveBillingPerson).toHaveBeenCalledWith(
+      {
+        firstName: "Guest",
+        lastName: "Customer",
+        email: "guest@example.com",
+        phone: "+40700333444",
+      },
+      expect.objectContaining({ bookingId: "catalog_booking_1", source: "storefront-booking" }),
+    )
+    expect(createBooking).toHaveBeenCalledWith(
+      expect.objectContaining({
+        personId: "pers_resolved",
+        organizationId: null,
+        contactFirstName: "Guest",
+        contactEmail: "guest@example.com",
+      }),
+    )
+  })
+
+  it("skips the billing-person resolver when the commit already carries a person id", async () => {
+    const createBooking = vi.fn(async () => ({
+      status: "ok" as const,
+      bookingId: "book_1",
+      bookingNumber: "BK-1",
+    }))
+    const resolveBillingPerson = vi.fn(async () => "pers_should_not_be_used")
+    const handler = createProductsBookingHandler({ createBooking, resolveBillingPerson })
+
+    const request: CommitOwnedRequest = {
+      entityModule: "products",
+      entityId: product.id,
+      bookingId: "catalog_booking_1",
+      party: {
+        billing: {
+          personId: "pers_existing",
+          contact: { firstName: "Ana", lastName: "Pop", email: "ana@example.com" },
+        },
+      },
+      draft: { configure: { pax: { adult: 1 } } },
+      pricing: { base_amount: 14500, taxes: 0, fees: 0, surcharges: 0, currency: "RON" },
+    }
+
+    const result = await handler.commit(makeCtx([product]), request)
+
+    expect(result.status).toBe("held")
+    expect(resolveBillingPerson).not.toHaveBeenCalled()
+    expect(createBooking).toHaveBeenCalledWith(
+      expect.objectContaining({ personId: "pers_existing" }),
+    )
+  })
 })

--- a/packages/inventory/tests/unit/booking-engine-quote.test.ts
+++ b/packages/inventory/tests/unit/booking-engine-quote.test.ts
@@ -537,4 +537,33 @@ describe("createProductsBookingHandler.commit", () => {
       expect.objectContaining({ personId: "pers_existing" }),
     )
   })
+
+  it("skips the resolver when the billing contact has a name but no email or phone", async () => {
+    const createBooking = vi.fn(async () => ({
+      status: "ok" as const,
+      bookingId: "book_1",
+      bookingNumber: "BK-1",
+    }))
+    const resolveBillingPerson = vi.fn(async () => "pers_should_not_be_used")
+    const handler = createProductsBookingHandler({ createBooking, resolveBillingPerson })
+
+    const request: CommitOwnedRequest = {
+      entityModule: "products",
+      entityId: product.id,
+      bookingId: "catalog_booking_1",
+      party: {
+        // Name only, no contact point — resolving would create a CRM person
+        // that still can't satisfy createBooking's email/phone requirement.
+        billing: { contact: { firstName: "Guest", lastName: "Customer" } },
+      },
+      draft: { configure: { pax: { adult: 1 } } },
+      pricing: { base_amount: 14500, taxes: 0, fees: 0, surcharges: 0, currency: "RON" },
+    }
+
+    const result = await handler.commit(makeCtx([product]), request)
+
+    expect(result.status).toBe("held")
+    expect(resolveBillingPerson).not.toHaveBeenCalled()
+    expect(createBooking).toHaveBeenCalledWith(expect.objectContaining({ personId: null }))
+  })
 })

--- a/packages/inventory/tests/unit/booking-engine-quote.test.ts
+++ b/packages/inventory/tests/unit/booking-engine-quote.test.ts
@@ -1,3 +1,5 @@
+// agent-quality: file-size exception — cohesive booking-engine quote/commit
+// suite; splitting would scatter shared product/context fixtures. See #2618.
 import type {
   CommitOwnedRequest,
   ComputeQuoteRequest,
@@ -502,6 +504,52 @@ describe("createProductsBookingHandler.commit", () => {
         organizationId: null,
         contactFirstName: "Guest",
         contactEmail: "guest@example.com",
+      }),
+    )
+  })
+
+  it("resolves the billing person from the saved draft when the storefront commit sends no party", async () => {
+    // The anonymous storefront POSTs only a draftId to /book, so `request.party`
+    // is empty and the billing contact lives in `draft.billing.contact`.
+    const createBooking = vi.fn(async () => ({
+      status: "ok" as const,
+      bookingId: "book_1",
+      bookingNumber: "BK-1",
+    }))
+    const resolveBillingPerson = vi.fn(async () => "pers_from_draft")
+    const handler = createProductsBookingHandler({ createBooking, resolveBillingPerson })
+
+    const request: CommitOwnedRequest = {
+      entityModule: "products",
+      entityId: product.id,
+      bookingId: "catalog_booking_1",
+      // No party — mirrors the storefront /book payload (draftId only).
+      draft: {
+        configure: { pax: { adult: 1 } },
+        billing: {
+          contact: {
+            firstName: "Guest",
+            lastName: "Customer",
+            email: "guest@example.com",
+            phone: "+40700333444",
+          },
+        },
+      },
+      pricing: { base_amount: 14500, taxes: 0, fees: 0, surcharges: 0, currency: "RON" },
+    }
+
+    const result = await handler.commit(makeCtx([product]), request)
+
+    expect(result.status).toBe("held")
+    expect(resolveBillingPerson).toHaveBeenCalledWith(
+      expect.objectContaining({ email: "guest@example.com", phone: "+40700333444" }),
+      expect.objectContaining({ source: "storefront-booking" }),
+    )
+    expect(createBooking).toHaveBeenCalledWith(
+      expect.objectContaining({
+        personId: "pers_from_draft",
+        contactEmail: "guest@example.com",
+        contactFirstName: "Guest",
       }),
     )
   })

--- a/packages/inventory/tests/unit/booking-engine-quote.test.ts
+++ b/packages/inventory/tests/unit/booking-engine-quote.test.ts
@@ -647,6 +647,38 @@ describe("createProductsBookingHandler.commit", () => {
     )
   })
 
+  it("skips the resolver when the billing contact has a contact point but no full name", async () => {
+    // createBooking requires first AND last name once a personId is set, so
+    // resolving on a nameless contact would create a person it then rejects.
+    const createBooking = vi.fn(async () => ({
+      status: "ok" as const,
+      bookingId: "book_1",
+      bookingNumber: "BK-1",
+    }))
+    const resolveBillingPerson = vi.fn(async () => "pers_should_not_be_used")
+    const handler = createProductsBookingHandler({ createBooking, resolveBillingPerson })
+
+    const request: CommitOwnedRequest = {
+      entityModule: "products",
+      entityId: product.id,
+      bookingId: "catalog_booking_1",
+      draft: {
+        configure: { pax: { adult: 1 } },
+        billing: {
+          // Email present, but only a first name — no last name.
+          contact: { firstName: "Guest", email: "guest@example.com" },
+        },
+      },
+      pricing: { base_amount: 14500, taxes: 0, fees: 0, surcharges: 0, currency: "RON" },
+    }
+
+    const result = await handler.commit(makeCtx([product]), request)
+
+    expect(result.status).toBe("held")
+    expect(resolveBillingPerson).not.toHaveBeenCalled()
+    expect(createBooking).toHaveBeenCalledWith(expect.objectContaining({ personId: null }))
+  })
+
   it("clears a placeholder billing email but still resolves on a real phone", async () => {
     // createBooking rejects a placeholder email even alongside a phone, so the
     // handler must treat it as absent — otherwise it resolves a CRM person that

--- a/packages/inventory/tests/unit/booking-engine-quote.test.ts
+++ b/packages/inventory/tests/unit/booking-engine-quote.test.ts
@@ -646,4 +646,46 @@ describe("createProductsBookingHandler.commit", () => {
       expect.objectContaining({ personId: null, contactEmail: null, contactPhone: null }),
     )
   })
+
+  it("clears a placeholder billing email but still resolves on a real phone", async () => {
+    // createBooking rejects a placeholder email even alongside a phone, so the
+    // handler must treat it as absent — otherwise it resolves a CRM person that
+    // createBooking then rejects, orphaning the row.
+    const createBooking = vi.fn(async () => ({
+      status: "ok" as const,
+      bookingId: "book_1",
+      bookingNumber: "BK-1",
+    }))
+    const resolveBillingPerson = vi.fn(async () => "pers_from_phone")
+    const handler = createProductsBookingHandler({ createBooking, resolveBillingPerson })
+
+    const request: CommitOwnedRequest = {
+      entityModule: "products",
+      entityId: product.id,
+      bookingId: "catalog_booking_1",
+      draft: {
+        configure: { pax: { adult: 1 } },
+        billing: {
+          contact: {
+            firstName: "Guest",
+            lastName: "Customer",
+            email: "traveler@example.com",
+            phone: "+40700333444",
+          },
+        },
+      },
+      pricing: { base_amount: 14500, taxes: 0, fees: 0, surcharges: 0, currency: "RON" },
+    }
+
+    const result = await handler.commit(makeCtx([product]), request)
+
+    expect(result.status).toBe("held")
+    expect(resolveBillingPerson).toHaveBeenCalledWith(
+      expect.objectContaining({ email: null, phone: "+40700333444" }),
+      expect.objectContaining({ source: "storefront-booking" }),
+    )
+    expect(createBooking).toHaveBeenCalledWith(
+      expect.objectContaining({ personId: "pers_from_phone", contactEmail: null }),
+    )
+  })
 })

--- a/starters/operator/src/api/lib/product-booking-handler.ts
+++ b/starters/operator/src/api/lib/product-booking-handler.ts
@@ -29,6 +29,7 @@ import {
   releaseAvailabilityHold,
 } from "@voyant-travel/operations"
 import { resolveBookingTaxSettings } from "@voyant-travel/operator-settings"
+import { relationshipsService } from "@voyant-travel/relationships"
 import { and, asc, eq, inArray, or } from "drizzle-orm"
 import { asPostgresDb } from "./booking-engine-db"
 import type { BookingEngineEnv } from "./booking-engine-runtime"
@@ -117,6 +118,21 @@ export function registerProductBookingHandler(
             }
           }
           return { status: outcome.status }
+        })
+      },
+      // Resolve (or create) a CRM person from the billing contact when an
+      // anonymous storefront commit for an owned product carries no
+      // person/organization id. Mirrors the sourced/session arm's
+      // `resolveBillingPerson` wiring (framework composition) so both
+      // booking arms link a customer the same way.
+      async resolveBillingPerson(contact, ctx) {
+        return withDbFromEnv(env as Parameters<typeof withDbFromEnv>[0], async (rawDb) => {
+          const db = asPostgresDb(rawDb)
+          const person = await relationshipsService.upsertPersonFromContact(db, contact, {
+            source: ctx.source,
+            sourceRef: ctx.sourceRef,
+          })
+          return person?.id ?? null
         })
       },
       async loadTravelerFields(ctx, productId) {


### PR DESCRIPTION
## Root cause
Anonymous storefront checkout for an **owned** public product failed at `POST /v1/public/catalog/book` with `400 {"error":"Select a billing person or organization","fieldErrors":{"personId":[...]}}`. The owned booking commit required a CRM `personId`/`organizationId`, which an anonymous B2C customer doesn't have — whereas the sourced/session arm creates a customer person from the billing contact. So owned products were unbookable anonymously.

## Fix
`createProductsBookingHandler` (`@voyant-travel/inventory`) gains an optional **`resolveBillingPerson`** bridge: when a commit carries no `personId`/`organizationId` but has a billing contact, it resolves/creates a CRM person from that contact and uses it as the booking's billing person. The operator wires the bridge to `relationshipsService.upsertPersonFromContact`, mirroring how the sourced/session arm links a customer. It's an **injected bridge**, so `@voyant-travel/inventory` takes no direct `@voyant-travel/relationships` dependency (module boundary preserved). No-op when a person/org is already supplied (operator/trips paths) or no resolver is wired.

- `packages/inventory/src/booking-engine/handler.ts` — `ResolveOwnedBillingPerson` type + resolve-on-missing-party logic
- `packages/inventory/src/booking-engine/index.ts` — export the new type
- `starters/operator/src/api/lib/product-booking-handler.ts` — wire `resolveBillingPerson` → `upsertPersonFromContact`
- `packages/inventory/tests/unit/booking-engine-quote.test.ts` — tests (anonymous contact → person resolved/linked; person/org already supplied → no-op)
- Changeset: `@voyant-travel/inventory` patch

## Secondary items (from the issue)
- **Error surfacing** — already handled by #2712 (merged): the storefront `defaultCheckoutHandler` throws a visible `CheckoutError` on `/book` failure, surfaced via the journey's `confirmError`. With this fix the 400 no longer occurs; if it did, it's now visible.
- **Missing bank-transfer/inquiry payment methods for owned products** — a separate payment-capability-resolution difference; not addressed here (candidate follow-up).

Fixes #2618
