### PR TITLE
Fix booking child activity metadata

### DIFF
--- a/.changeset/booking-activity-child-mutations.md
+++ b/.changeset/booking-activity-child-mutations.md
@@ -1,0 +1,8 @@
+---
+"@voyant-travel/bookings": patch
+"@voyant-travel/bookings-react": patch
+"@voyant-travel/finance": patch
+"@voyant-travel/finance-react": patch
+---
+
+Keep booking activity and metadata current for note, document, supplier, invoice, and payment child mutations.

--- a/packages/bookings-react/src/admin/use-booking-action-ledger-events.tsx
+++ b/packages/bookings-react/src/admin/use-booking-action-ledger-events.tsx
@@ -85,7 +85,8 @@ function getLedgerTimelinePresentation(actionName: string): {
   if (
     actionName.startsWith("finance.invoice.") ||
     actionName.startsWith("finance.invoice_line_item.") ||
-    actionName.startsWith("finance.credit_note.")
+    actionName.startsWith("finance.credit_note.") ||
+    actionName.startsWith("finance.credit_note_line_item.")
   ) {
     return { source: "document", icon: FileText }
   }

--- a/packages/bookings-react/src/admin/use-booking-action-ledger-events.tsx
+++ b/packages/bookings-react/src/admin/use-booking-action-ledger-events.tsx
@@ -2,9 +2,9 @@
 
 import { useOperatorAdminMessages } from "@voyant-travel/admin"
 import { Button } from "@voyant-travel/ui/components/button"
-import { ScrollText } from "lucide-react"
+import { CreditCard, FileText, ScrollText } from "lucide-react"
 import { useMemo } from "react"
-import type { TimelineEvent } from "../components/booking-activity-timeline.js"
+import type { TimelineEvent, TimelineSource } from "../components/booking-activity-timeline.js"
 import {
   type BookingActionLedgerEntryRecord,
   type BookingActionLedgerTraveler,
@@ -39,9 +39,10 @@ export function useBookingActionLedgerEvents(bookingId: string): {
     for (const page of pages) {
       for (const entry of page.data) {
         const traveler = travelersById.get(entry.targetId) ?? null
+        const presentation = getLedgerTimelinePresentation(entry.actionName)
         all.push({
           id: `action:${entry.id}`,
-          source: "action",
+          source: presentation.source,
           title: formatActionName(entry.actionName),
           description: formatLedgerDescription(
             entry,
@@ -51,7 +52,7 @@ export function useBookingActionLedgerEvents(bookingId: string): {
           ),
           actorId: entry.principalId,
           timestamp: entry.occurredAt,
-          icon: ScrollText,
+          icon: presentation.icon,
         })
       }
     }
@@ -75,6 +76,29 @@ export function useBookingActionLedgerEvents(bookingId: string): {
 
 function formatActionName(value: string) {
   return value.replaceAll(".", " / ").replaceAll("_", " ")
+}
+
+function getLedgerTimelinePresentation(actionName: string): {
+  source: TimelineSource
+  icon: typeof ScrollText
+} {
+  if (
+    actionName.startsWith("finance.invoice.") ||
+    actionName.startsWith("finance.invoice_line_item.") ||
+    actionName.startsWith("finance.credit_note.")
+  ) {
+    return { source: "document", icon: FileText }
+  }
+
+  if (
+    actionName.startsWith("finance.payment") ||
+    actionName.startsWith("finance.booking_payment") ||
+    actionName.startsWith("finance.booking_guarantee")
+  ) {
+    return { source: "payment", icon: CreditCard }
+  }
+
+  return { source: "action", icon: ScrollText }
 }
 
 function formatTarget(

--- a/packages/bookings-react/src/components/booking-activity-timeline.tsx
+++ b/packages/bookings-react/src/components/booking-activity-timeline.tsx
@@ -129,7 +129,10 @@ export function BookingActivityTimeline({
         id: `activity:${entry.id}`,
         source: "activity",
         title:
-          messages.bookingActivityTimeline.activityTitles[entry.activityType] ?? entry.description,
+          entry.activityType === "note_added"
+            ? entry.description
+            : (messages.bookingActivityTimeline.activityTitles[entry.activityType] ??
+              entry.description),
         description: entry.description,
         // Prefer the hydrated display name; fall back to email then raw
         // id (system actors stay null and skip the "By …" render).

--- a/packages/bookings-react/src/hooks/use-booking-documents.ts
+++ b/packages/bookings-react/src/hooks/use-booking-documents.ts
@@ -43,7 +43,10 @@ export function useBookingTravelerDocumentMutation(bookingId: string) {
   const queryClient = useQueryClient()
 
   const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.booking(bookingId) })
+    void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.bookings() })
     void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.documents(bookingId) })
+    void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.activity(bookingId) })
   }
 
   const create = useMutation({

--- a/packages/bookings-react/src/hooks/use-booking-note-mutation.ts
+++ b/packages/bookings-react/src/hooks/use-booking-note-mutation.ts
@@ -28,8 +28,11 @@ export function useBookingNoteMutation(bookingId: string) {
   const queryClient = useQueryClient()
 
   const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.booking(bookingId) })
+    void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.bookings() })
     void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.notes(bookingId) })
     void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.activity(bookingId) })
+    void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.actionLedger(bookingId) })
   }
 
   const create = useMutation({

--- a/packages/bookings-react/src/hooks/use-supplier-status-mutation.ts
+++ b/packages/bookings-react/src/hooks/use-supplier-status-mutation.ts
@@ -30,6 +30,15 @@ export function useSupplierStatusMutation(bookingId: string) {
   const { baseUrl, fetcher } = useVoyantBookingsContext()
   const queryClient = useQueryClient()
 
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.booking(bookingId) })
+    void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.bookings() })
+    void queryClient.invalidateQueries({
+      queryKey: bookingsQueryKeys.supplierStatuses(bookingId),
+    })
+    void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.activity(bookingId) })
+  }
+
   const create = useMutation({
     mutationFn: async (input: CreateSupplierStatusInput) => {
       const { data } = await fetchWithValidation(
@@ -40,12 +49,7 @@ export function useSupplierStatusMutation(bookingId: string) {
       )
       return data
     },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({
-        queryKey: bookingsQueryKeys.supplierStatuses(bookingId),
-      })
-      void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.activity(bookingId) })
-    },
+    onSuccess: invalidate,
   })
 
   const update = useMutation({
@@ -58,12 +62,7 @@ export function useSupplierStatusMutation(bookingId: string) {
       )
       return data
     },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({
-        queryKey: bookingsQueryKeys.supplierStatuses(bookingId),
-      })
-      void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.activity(bookingId) })
-    },
+    onSuccess: invalidate,
   })
 
   return { create, update }

--- a/packages/bookings-react/src/hooks/use-traveler-mutation.ts
+++ b/packages/bookings-react/src/hooks/use-traveler-mutation.ts
@@ -25,6 +25,14 @@ export function useTravelerMutation(bookingId: string) {
   const { baseUrl, fetcher } = useVoyantBookingsContext()
   const queryClient = useQueryClient()
 
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.booking(bookingId) })
+    void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.bookings() })
+    void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.travelers(bookingId) })
+    void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.activity(bookingId) })
+    void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.actionLedger(bookingId) })
+  }
+
   const create = useMutation({
     mutationFn: async (input: CreateTravelerInput) => {
       const { data } = await fetchWithValidation(
@@ -37,10 +45,7 @@ export function useTravelerMutation(bookingId: string) {
       )
       return data
     },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.travelers(bookingId) })
-      void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.activity(bookingId) })
-    },
+    onSuccess: invalidate,
   })
 
   const update = useMutation({
@@ -55,10 +60,7 @@ export function useTravelerMutation(bookingId: string) {
       )
       return data
     },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.travelers(bookingId) })
-      void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.activity(bookingId) })
-    },
+    onSuccess: invalidate,
   })
 
   const remove = useMutation({
@@ -69,10 +71,7 @@ export function useTravelerMutation(bookingId: string) {
         { baseUrl, fetcher },
         { method: "DELETE" },
       ),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.travelers(bookingId) })
-      void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.activity(bookingId) })
-    },
+    onSuccess: invalidate,
   })
 
   return { create, update, remove }

--- a/packages/bookings-react/src/hooks/use-traveler-with-travel-details-mutation.ts
+++ b/packages/bookings-react/src/hooks/use-traveler-with-travel-details-mutation.ts
@@ -59,8 +59,11 @@ export function useTravelerWithTravelDetailsMutation(bookingId: string) {
   const queryClient = useQueryClient()
 
   const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.booking(bookingId) })
+    void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.bookings() })
     void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.travelers(bookingId) })
     void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.activity(bookingId) })
+    void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.actionLedger(bookingId) })
   }
 
   const create = useMutation({

--- a/packages/bookings-react/tests/unit/booking-activity-timeline.test.tsx
+++ b/packages/bookings-react/tests/unit/booking-activity-timeline.test.tsx
@@ -7,6 +7,11 @@ const financeHooks = vi.hoisted(() => ({
   usePublicBookingPayments: vi.fn(),
 }))
 
+const bookingHooks = vi.hoisted(() => ({
+  activity: [] as Array<Record<string, unknown>>,
+  documents: [] as Array<Record<string, unknown>>,
+}))
+
 vi.mock("@voyant-travel/finance-react", () => ({
   useAdminBookingPayments: financeHooks.useAdminBookingPayments,
   usePublicBookingPayments: financeHooks.usePublicBookingPayments,
@@ -33,8 +38,8 @@ vi.mock("@voyant-travel/ui/components/pagination", () => ({
 }))
 
 vi.mock("../../src/index.js", () => ({
-  useBookingActivity: () => ({ data: { data: [] } }),
-  useBookingTravelerDocuments: () => ({ data: { data: [] } }),
+  useBookingActivity: () => ({ data: { data: bookingHooks.activity } }),
+  useBookingTravelerDocuments: () => ({ data: { data: bookingHooks.documents } }),
 }))
 
 import { BookingActivityTimeline } from "../../src/components/booking-activity-timeline.js"
@@ -44,6 +49,8 @@ beforeEach(() => {
   financeHooks.usePublicBookingPayments.mockReset()
   financeHooks.useAdminBookingPayments.mockReturnValue({ data: { data: { payments: [] } } })
   financeHooks.usePublicBookingPayments.mockReturnValue({ data: { data: { payments: [] } } })
+  bookingHooks.activity = []
+  bookingHooks.documents = []
 })
 
 describe("BookingActivityTimeline", () => {
@@ -67,5 +74,23 @@ describe("BookingActivityTimeline", () => {
     expect(financeHooks.useAdminBookingPayments).toHaveBeenCalledWith("book_123", {
       enabled: true,
     })
+  })
+
+  it("uses the activity description for note lifecycle rows", () => {
+    bookingHooks.activity = [
+      {
+        id: "act_note_updated",
+        bookingId: "book_123",
+        actorId: "user_123",
+        activityType: "note_added",
+        description: "Note updated",
+        metadata: { noteId: "note_123" },
+        createdAt: "2026-07-01T12:00:00.000Z",
+      },
+    ]
+
+    const html = renderToStaticMarkup(<BookingActivityTimeline bookingId="book_123" />)
+
+    expect(html).toContain("Note updated")
   })
 })

--- a/packages/bookings-react/tests/unit/use-booking-action-ledger-events.test.tsx
+++ b/packages/bookings-react/tests/unit/use-booking-action-ledger-events.test.tsx
@@ -1,0 +1,95 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const ledgerState = vi.hoisted(() => ({
+  entries: [] as Array<Record<string, unknown>>,
+}))
+
+vi.mock("@voyant-travel/admin", () => ({
+  useOperatorAdminMessages: () => ({
+    bookings: {
+      detail: {
+        actionLedger: {
+          travelerFallback: "Traveler",
+          targetBooking: "Booking",
+          loadingMore: "Loading",
+          loadMore: "Load more",
+        },
+      },
+    },
+  }),
+}))
+
+vi.mock("@voyant-travel/ui/components/button", () => ({
+  Button: ({ children }: { children?: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}))
+
+vi.mock("../../src/index.js", () => ({
+  useBookingActionLedger: () => ({
+    data: {
+      pages: [
+        {
+          data: ledgerState.entries,
+          travelers: [],
+          pageInfo: { nextCursor: null },
+        },
+      ],
+    },
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+  }),
+}))
+
+import { useBookingActionLedgerEvents } from "../../src/admin/use-booking-action-ledger-events.js"
+
+function EventsProbe() {
+  const { events } = useBookingActionLedgerEvents("book_123")
+  return (
+    <div>
+      {events.map((event) => (
+        <span key={event.id} data-source={event.source}>
+          {event.title}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+describe("useBookingActionLedgerEvents", () => {
+  beforeEach(() => {
+    ledgerState.entries = []
+  })
+
+  it("classifies finance invoice and payment ledger entries into timeline filters", () => {
+    ledgerState.entries = [
+      {
+        id: "act_invoice",
+        actionName: "finance.invoice.issue_from_booking",
+        targetId: "book_123",
+        targetType: "booking",
+        status: "succeeded",
+        evaluatedRisk: "high",
+        principalId: "user_123",
+        occurredAt: "2026-07-01T12:00:00.000Z",
+      },
+      {
+        id: "act_payment",
+        actionName: "finance.payment.record",
+        targetId: "book_123",
+        targetType: "booking",
+        status: "succeeded",
+        evaluatedRisk: "medium",
+        principalId: "user_123",
+        occurredAt: "2026-07-01T12:01:00.000Z",
+      },
+    ]
+
+    const html = renderToStaticMarkup(<EventsProbe />)
+
+    expect(html).toContain('data-source="document"')
+    expect(html).toContain('data-source="payment"')
+  })
+})

--- a/packages/bookings-react/tests/unit/use-booking-action-ledger-events.test.tsx
+++ b/packages/bookings-react/tests/unit/use-booking-action-ledger-events.test.tsx
@@ -85,11 +85,21 @@ describe("useBookingActionLedgerEvents", () => {
         principalId: "user_123",
         occurredAt: "2026-07-01T12:01:00.000Z",
       },
+      {
+        id: "act_credit_note_line_item",
+        actionName: "finance.credit_note_line_item.create",
+        targetId: "book_123",
+        targetType: "booking",
+        status: "succeeded",
+        evaluatedRisk: "low",
+        principalId: "user_123",
+        occurredAt: "2026-07-01T12:02:00.000Z",
+      },
     ]
 
     const html = renderToStaticMarkup(<EventsProbe />)
 
-    expect(html).toContain('data-source="document"')
+    expect(html.match(/data-source="document"/g)).toHaveLength(2)
     expect(html).toContain('data-source="payment"')
   })
 })

--- a/packages/bookings-react/tests/unit/use-booking-note-mutation.test.ts
+++ b/packages/bookings-react/tests/unit/use-booking-note-mutation.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const testState = vi.hoisted(() => ({
+  invalidateQueries: vi.fn(async () => undefined),
+  mutations: [] as Array<{ onSuccess?: () => void }>,
+}))
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({
+    invalidateQueries: testState.invalidateQueries,
+  }),
+  useMutation: (options: { onSuccess?: () => void }) => {
+    testState.mutations.push(options)
+    return {
+      mutate: vi.fn(),
+      mutateAsync: vi.fn(),
+    }
+  },
+}))
+
+vi.mock("../../src/provider.js", () => ({
+  useVoyantBookingsContext: () => ({
+    baseUrl: "",
+    fetcher: vi.fn(),
+  }),
+}))
+
+describe("useBookingNoteMutation", () => {
+  beforeEach(() => {
+    testState.invalidateQueries.mockReset()
+    testState.invalidateQueries.mockResolvedValue(undefined)
+    testState.mutations.length = 0
+  })
+
+  it("refreshes notes plus parent booking, activity, and action ledger", async () => {
+    const { useBookingNoteMutation } = await import("../../src/hooks/use-booking-note-mutation.js")
+
+    useBookingNoteMutation("book_123")
+
+    expect(testState.mutations).toHaveLength(3)
+
+    for (const mutation of testState.mutations) {
+      mutation.onSuccess?.()
+    }
+
+    expect(testState.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["voyant", "bookings", "bookings", "detail", "book_123"],
+    })
+    expect(testState.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["voyant", "bookings", "bookings"],
+    })
+    expect(testState.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["voyant", "bookings", "bookings", "detail", "book_123", "notes"],
+    })
+    expect(testState.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["voyant", "bookings", "bookings", "detail", "book_123", "activity"],
+    })
+    expect(testState.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["voyant", "bookings", "bookings", "detail", "book_123", "action-ledger"],
+    })
+    expect(testState.invalidateQueries).toHaveBeenCalledTimes(15)
+  })
+})

--- a/packages/bookings/src/extensions/suppliers.ts
+++ b/packages/bookings/src/extensions/suppliers.ts
@@ -34,6 +34,10 @@ const updateSupplierStatusSchema = supplierStatusCoreSchema.partial().extend({
 
 // ---------- service ----------
 
+async function touchBookingUpdatedAt(db: PostgresJsDatabase, bookingId: string, now = new Date()) {
+  await db.update(bookings).set({ updatedAt: now }).where(eq(bookings.id, bookingId))
+}
+
 const supplierStatusService = {
   listSupplierStatuses(db: PostgresJsDatabase, bookingId: string) {
     return db
@@ -70,6 +74,7 @@ const supplierStatusService = {
       activityType: "supplier_update",
       description: `Supplier status for "${data.serviceName}" added`,
     })
+    await touchBookingUpdatedAt(db, bookingId)
 
     return row
   },
@@ -105,6 +110,7 @@ const supplierStatusService = {
         metadata: { supplierStatusId: statusId, newStatus: data.status },
       })
     }
+    await touchBookingUpdatedAt(db, bookingId)
 
     return row
   },

--- a/packages/bookings/src/routes-admin.ts
+++ b/packages/bookings/src/routes-admin.ts
@@ -3923,12 +3923,14 @@ const notesRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
     return c.json({ data: row }, 201)
   })
   .openapi(updateNoteRoute, async (c) => {
+    const userId = requireUserId(c)
     const bookingId = c.req.valid("param").id
     const noteId = c.req.valid("param").noteId
     const row = await bookingsService.updateNote(
       c.get("db"),
       bookingId,
       noteId,
+      userId,
       c.req.valid("json"),
     )
     if (!row) {
@@ -3949,11 +3951,13 @@ const notesRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
     return c.json({ data: row }, 200)
   })
   .openapi(deleteNoteRoute, async (c) => {
+    const userId = requireUserId(c)
     const bookingId = c.req.valid("param").id
     const row = await bookingsService.deleteNote(
       c.get("db"),
       bookingId,
       c.req.valid("param").noteId,
+      userId,
     )
     if (!row) {
       return c.json({ error: "Note not found" }, 404)

--- a/packages/bookings/src/service-core.ts
+++ b/packages/bookings/src/service-core.ts
@@ -680,6 +680,10 @@ function mapDeliveryFormatToFulfillment(format: string) {
   }
 }
 
+async function touchBookingUpdatedAt(db: PostgresJsDatabase, bookingId: string, now = new Date()) {
+  await db.update(bookings).set({ updatedAt: now }).where(eq(bookings.id, bookingId))
+}
+
 async function getConvertProductData(
   db: PostgresJsDatabase,
   data: ConvertProductInput,
@@ -4073,6 +4077,7 @@ export const bookingsService = {
       description: `Traveler ${data.firstName} ${data.lastName} added`,
       metadata: { travelerId: row.id, participantType: data.participantType },
     })
+    await touchBookingUpdatedAt(db, bookingId)
 
     return row
   },
@@ -4093,6 +4098,7 @@ export const bookingsService = {
     }
 
     await ensureParticipantFlags(db, row.bookingId, row.id, data)
+    await touchBookingUpdatedAt(db, row.bookingId)
 
     return row
   },
@@ -4211,7 +4217,11 @@ export const bookingsService = {
     const [row] = await db
       .delete(bookingTravelers)
       .where(eq(bookingTravelers.id, travelerId))
-      .returning({ id: bookingTravelers.id })
+      .returning({ id: bookingTravelers.id, bookingId: bookingTravelers.bookingId })
+
+    if (row) {
+      await touchBookingUpdatedAt(db, row.bookingId)
+    }
 
     return row ?? null
   },
@@ -4856,6 +4866,7 @@ export const bookingsService = {
       activityType: "supplier_update",
       description: `Supplier status for "${data.serviceName}" added`,
     })
+    await touchBookingUpdatedAt(db, bookingId)
 
     return row ?? null
   },
@@ -4910,6 +4921,7 @@ export const bookingsService = {
         metadata: { supplierStatusId: statusId, newStatus: data.status },
       })
     }
+    await touchBookingUpdatedAt(db, bookingId)
 
     return row
   },
@@ -5228,12 +5240,18 @@ export const bookingsService = {
       })
       .returning()
 
+    if (!row) {
+      return null
+    }
+
     await db.insert(bookingActivityLog).values({
       bookingId,
       actorId: userId,
       activityType: "note_added",
       description: "Note added",
+      metadata: { noteId: row.id },
     })
+    await touchBookingUpdatedAt(db, bookingId)
 
     return row
   },
@@ -5242,6 +5260,7 @@ export const bookingsService = {
     db: PostgresJsDatabase,
     bookingId: string,
     noteId: string,
+    userId: string,
     data: UpdateBookingNoteInput,
   ) {
     // Scope the update to (booking, note) so a stale / cross-booking
@@ -5254,17 +5273,39 @@ export const bookingsService = {
       .where(and(eq(bookingNotes.id, noteId), eq(bookingNotes.bookingId, bookingId)))
       .returning()
 
+    if (row) {
+      await db.insert(bookingActivityLog).values({
+        bookingId,
+        actorId: userId,
+        activityType: "note_added",
+        description: "Note updated",
+        metadata: { noteId },
+      })
+      await touchBookingUpdatedAt(db, bookingId)
+    }
+
     return row ?? null
   },
 
-  async deleteNote(db: PostgresJsDatabase, bookingId: string, noteId: string) {
+  async deleteNote(db: PostgresJsDatabase, bookingId: string, noteId: string, userId: string) {
     // Same scoping as `updateNote` — guards against deleting a note
     // that belongs to a different booking when the audit entry would
     // get filed under the route's `:id`.
     const [row] = await db
       .delete(bookingNotes)
       .where(and(eq(bookingNotes.id, noteId), eq(bookingNotes.bookingId, bookingId)))
-      .returning({ id: bookingNotes.id })
+      .returning({ id: bookingNotes.id, authorId: bookingNotes.authorId })
+
+    if (row) {
+      await db.insert(bookingActivityLog).values({
+        bookingId,
+        actorId: userId,
+        activityType: "note_added",
+        description: "Note deleted",
+        metadata: { noteId },
+      })
+      await touchBookingUpdatedAt(db, bookingId)
+    }
 
     return row ?? null
   },
@@ -5305,6 +5346,10 @@ export const bookingsService = {
       })
       .returning()
 
+    if (row) {
+      await touchBookingUpdatedAt(db, bookingId)
+    }
+
     return row
   },
 
@@ -5312,7 +5357,11 @@ export const bookingsService = {
     const [row] = await db
       .delete(bookingDocuments)
       .where(eq(bookingDocuments.id, documentId))
-      .returning({ id: bookingDocuments.id })
+      .returning({ id: bookingDocuments.id, bookingId: bookingDocuments.bookingId })
+
+    if (row) {
+      await touchBookingUpdatedAt(db, row.bookingId)
+    }
 
     return row ?? null
   },

--- a/packages/bookings/tests/integration/routes.integration-suite.ts
+++ b/packages/bookings/tests/integration/routes.integration-suite.ts
@@ -3218,6 +3218,70 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
       expect((await res.json()).data.length).toBe(1)
     })
 
+    it("records note edit/delete activity and advances the booking updated timestamp", async () => {
+      const booking = await seedBooking()
+      const initialUpdatedAt = new Date(booking.updatedAt).getTime()
+
+      const createRes = await app.request(`/${booking.id}/notes`, {
+        method: "POST",
+        ...json({ content: "Original note" }),
+      })
+      expect(createRes.status).toBe(201)
+      const createdNote = (await createRes.json()).data
+
+      const afterCreate = await bookingsService.getBookingById(db, booking.id)
+      expect(afterCreate).toBeTruthy()
+      expect(afterCreate?.updatedAt.getTime()).toBeGreaterThanOrEqual(initialUpdatedAt)
+
+      const updateRes = await app.request(`/${booking.id}/notes/${createdNote.id}`, {
+        method: "PATCH",
+        ...json({ content: "Edited note" }),
+      })
+      expect(updateRes.status).toBe(200)
+
+      const afterUpdate = await bookingsService.getBookingById(db, booking.id)
+      expect(afterUpdate?.updatedAt.getTime()).toBeGreaterThanOrEqual(
+        afterCreate?.updatedAt.getTime() ?? initialUpdatedAt,
+      )
+
+      const deleteRes = await app.request(`/${booking.id}/notes/${createdNote.id}`, {
+        method: "DELETE",
+      })
+      expect(deleteRes.status).toBe(200)
+
+      const afterDelete = await bookingsService.getBookingById(db, booking.id)
+      expect(afterDelete?.updatedAt.getTime()).toBeGreaterThanOrEqual(
+        afterUpdate?.updatedAt.getTime() ?? initialUpdatedAt,
+      )
+
+      const activityRes = await app.request(`/${booking.id}/activity`, { method: "GET" })
+      expect(activityRes.status).toBe(200)
+      const activityBody = await activityRes.json()
+      const noteActivity = activityBody.data.filter(
+        (entry: Record<string, unknown>) =>
+          entry.activityType === "note_added" &&
+          (entry.metadata as Record<string, unknown> | null)?.noteId === createdNote.id,
+      )
+
+      expect(noteActivity.map((entry: Record<string, unknown>) => entry.description)).toEqual([
+        "Note deleted",
+        "Note updated",
+        "Note added",
+      ])
+      expect(noteActivity).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            actorId: "test-user-id",
+            description: "Note updated",
+          }),
+          expect.objectContaining({
+            actorId: "test-user-id",
+            description: "Note deleted",
+          }),
+        ]),
+      )
+    })
+
     it("returns 404 when adding note to non-existent booking", async () => {
       const res = await app.request("/book_00000000000000000000000000/notes", {
         method: "POST",

--- a/packages/bookings/tests/unit/service-notes.test.ts
+++ b/packages/bookings/tests/unit/service-notes.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { bookingActivityLog, bookingNotes, bookings } from "../../src/schema.js"
+import { bookingsService } from "../../src/service.js"
+
+function makeDb() {
+  const activityRows: Array<Record<string, unknown>> = []
+  const bookingTouches: Array<Record<string, unknown>> = []
+
+  const db = {
+    update: vi.fn((table) => ({
+      set: vi.fn((values: Record<string, unknown>) => ({
+        where: vi.fn(() => {
+          if (table === bookingNotes) {
+            return {
+              returning: vi.fn(async () => [
+                {
+                  id: "note_123",
+                  bookingId: "book_123",
+                  authorId: "author_123",
+                  content: values.content,
+                  createdAt: new Date("2026-07-01T10:00:00.000Z"),
+                },
+              ]),
+            }
+          }
+
+          if (table === bookings) {
+            bookingTouches.push(values)
+          }
+
+          return Promise.resolve()
+        }),
+      })),
+    })),
+    delete: vi.fn((table) => ({
+      where: vi.fn(() => ({
+        returning: vi.fn(async () => {
+          if (table === bookingNotes) {
+            return [{ id: "note_123", authorId: "author_123" }]
+          }
+          return []
+        }),
+      })),
+    })),
+    insert: vi.fn((table) => ({
+      values: vi.fn((values: Record<string, unknown>) => {
+        if (table === bookingActivityLog) {
+          activityRows.push(values)
+        }
+        return Promise.resolve(values)
+      }),
+    })),
+  }
+
+  return { db: db as never, activityRows, bookingTouches }
+}
+
+describe("bookingsService note activity", () => {
+  it("records activity and touches the booking when a note is updated", async () => {
+    const { db, activityRows, bookingTouches } = makeDb()
+
+    const row = await bookingsService.updateNote(db, "book_123", "note_123", "user_123", {
+      content: "Edited note",
+    })
+
+    expect(row?.content).toBe("Edited note")
+    expect(activityRows).toEqual([
+      expect.objectContaining({
+        bookingId: "book_123",
+        actorId: "user_123",
+        activityType: "note_added",
+        description: "Note updated",
+        metadata: { noteId: "note_123" },
+      }),
+    ])
+    expect(bookingTouches).toHaveLength(1)
+    expect(bookingTouches[0]?.updatedAt).toBeInstanceOf(Date)
+  })
+
+  it("records activity and touches the booking when a note is deleted", async () => {
+    const { db, activityRows, bookingTouches } = makeDb()
+
+    const row = await bookingsService.deleteNote(db, "book_123", "note_123", "user_123")
+
+    expect(row?.id).toBe("note_123")
+    expect(activityRows).toEqual([
+      expect.objectContaining({
+        bookingId: "book_123",
+        actorId: "user_123",
+        activityType: "note_added",
+        description: "Note deleted",
+        metadata: { noteId: "note_123" },
+      }),
+    ])
+    expect(bookingTouches).toHaveLength(1)
+    expect(bookingTouches[0]?.updatedAt).toBeInstanceOf(Date)
+  })
+})

--- a/packages/finance-react/src/hooks/use-invoice-mutation.ts
+++ b/packages/finance-react/src/hooks/use-invoice-mutation.ts
@@ -31,9 +31,32 @@ export interface VoidInvoiceInput {
   reason?: string | null
 }
 
+const linkedBookingQueryKeys = {
+  booking: (bookingId: string) => ["voyant", "bookings", "bookings", "detail", bookingId] as const,
+  activity: (bookingId: string) =>
+    [...linkedBookingQueryKeys.booking(bookingId), "activity"] as const,
+  actionLedger: (bookingId: string) =>
+    [...linkedBookingQueryKeys.booking(bookingId), "action-ledger"] as const,
+}
+
 export function useInvoiceMutation() {
   const { baseUrl, fetcher } = useVoyantFinanceContext()
   const queryClient = useQueryClient()
+
+  const invalidateLinkedBooking = (bookingId: string | null | undefined) => {
+    if (!bookingId) return
+    void queryClient.invalidateQueries({ queryKey: linkedBookingQueryKeys.booking(bookingId) })
+    void queryClient.invalidateQueries({ queryKey: linkedBookingQueryKeys.activity(bookingId) })
+    void queryClient.invalidateQueries({
+      queryKey: linkedBookingQueryKeys.actionLedger(bookingId),
+    })
+    void queryClient.invalidateQueries({
+      queryKey: financeQueryKeys.adminBookingPayments(bookingId),
+    })
+    void queryClient.invalidateQueries({
+      queryKey: financeQueryKeys.publicBookingPayments(bookingId),
+    })
+  }
 
   const create = useMutation({
     mutationFn: async (input: CreateInvoiceInput) => {
@@ -48,6 +71,7 @@ export function useInvoiceMutation() {
     onSuccess: (data) => {
       void queryClient.invalidateQueries({ queryKey: financeQueryKeys.invoices() })
       queryClient.setQueryData(financeQueryKeys.invoice(data.id), { data })
+      invalidateLinkedBooking(data.bookingId)
     },
   })
 
@@ -64,6 +88,7 @@ export function useInvoiceMutation() {
     onSuccess: (data) => {
       void queryClient.invalidateQueries({ queryKey: financeQueryKeys.invoices() })
       queryClient.setQueryData(financeQueryKeys.invoice(data.id), { data })
+      invalidateLinkedBooking(data.bookingId)
     },
   })
 
@@ -100,6 +125,7 @@ export function useInvoiceMutation() {
     onSuccess: (data) => {
       void queryClient.invalidateQueries({ queryKey: financeQueryKeys.invoices() })
       queryClient.setQueryData(financeQueryKeys.invoice(data.id), { data })
+      invalidateLinkedBooking(data.bookingId)
     },
   })
 
@@ -121,6 +147,7 @@ export function useInvoiceMutation() {
     onSuccess: (data) => {
       void queryClient.invalidateQueries({ queryKey: financeQueryKeys.invoices() })
       queryClient.setQueryData(financeQueryKeys.invoice(data.id), { data })
+      invalidateLinkedBooking(data.bookingId)
     },
   })
 
@@ -153,6 +180,7 @@ export function useInvoiceMutation() {
       void queryClient.invalidateQueries({ queryKey: financeQueryKeys.payments(variables.id) })
       queryClient.setQueryData(financeQueryKeys.invoice(data.id), { data })
       void queryClient.invalidateQueries({ queryKey: financeQueryKeys.payments(data.id) })
+      invalidateLinkedBooking(data.bookingId)
     },
   })
 

--- a/packages/finance-react/tests/unit/use-invoice-mutation.test.ts
+++ b/packages/finance-react/tests/unit/use-invoice-mutation.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const testState = vi.hoisted(() => ({
+  invalidateQueries: vi.fn(async () => undefined),
+  setQueryData: vi.fn(),
+  removeQueries: vi.fn(),
+  mutations: [] as Array<{
+    onSuccess?: (data: Record<string, unknown>, variables?: unknown) => void
+  }>,
+}))
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({
+    invalidateQueries: testState.invalidateQueries,
+    setQueryData: testState.setQueryData,
+    removeQueries: testState.removeQueries,
+  }),
+  useMutation: (options: {
+    onSuccess?: (data: Record<string, unknown>, variables?: unknown) => void
+  }) => {
+    testState.mutations.push(options)
+    return {
+      mutate: vi.fn(),
+      mutateAsync: vi.fn(),
+    }
+  },
+}))
+
+vi.mock("../../src/provider.js", () => ({
+  useVoyantFinanceContext: () => ({
+    baseUrl: "",
+    fetcher: vi.fn(),
+  }),
+}))
+
+describe("useInvoiceMutation", () => {
+  beforeEach(() => {
+    testState.invalidateQueries.mockReset()
+    testState.invalidateQueries.mockResolvedValue(undefined)
+    testState.setQueryData.mockReset()
+    testState.removeQueries.mockReset()
+    testState.mutations.length = 0
+  })
+
+  it("refreshes booking-scoped caches after issuing an invoice from a booking", async () => {
+    const { useInvoiceMutation } = await import("../../src/hooks/use-invoice-mutation.js")
+
+    useInvoiceMutation()
+
+    const createFromBooking = testState.mutations[4]
+    expect(createFromBooking).toBeTruthy()
+    createFromBooking?.onSuccess?.({
+      id: "inv_123",
+      bookingId: "book_123",
+      invoiceNumber: "INV-123",
+    })
+
+    expect(testState.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["voyant", "finance", "invoices"],
+    })
+    expect(testState.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["voyant", "bookings", "bookings", "detail", "book_123"],
+    })
+    expect(testState.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["voyant", "bookings", "bookings", "detail", "book_123", "activity"],
+    })
+    expect(testState.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["voyant", "bookings", "bookings", "detail", "book_123", "action-ledger"],
+    })
+    expect(testState.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["voyant", "finance", "admin-booking-payments", "book_123"],
+    })
+  })
+})

--- a/packages/finance/src/service-invoice-core.ts
+++ b/packages/finance/src/service-invoice-core.ts
@@ -182,6 +182,14 @@ export const financeInvoiceCoreService = {
     data: UpdateInvoiceInput,
     runtime: FinanceServiceRuntime = {},
   ) {
+    const readExistingBookingId = async (reader: PostgresJsDatabase) => {
+      const [existing] = await reader
+        .select({ bookingId: invoices.bookingId })
+        .from(invoices)
+        .where(eq(invoices.id, id))
+        .limit(1)
+      return existing?.bookingId ?? null
+    }
     const updateInvoiceRow = (writer: PostgresJsDatabase) =>
       writer
         .update(invoices)
@@ -193,10 +201,11 @@ export const financeInvoiceCoreService = {
       const actionLedgerContext = runtime.actionLedgerContext
       if (actionLedgerContext) {
         return await db.transaction(async (tx) => {
+          const previousBookingId = await readExistingBookingId(tx)
           const [row] = await updateInvoiceRow(tx)
 
           if (row) {
-            await touchLinkedBookingUpdatedAt(tx, row.bookingId)
+            await touchInvoiceBookingLinks(tx, previousBookingId, row.bookingId)
             await appendActionLedgerMutation(
               tx,
               buildInvoiceUpdateActionLedgerInput(
@@ -211,8 +220,9 @@ export const financeInvoiceCoreService = {
         })
       }
 
+      const previousBookingId = await readExistingBookingId(db)
       const [row] = await updateInvoiceRow(db)
-      await touchLinkedBookingUpdatedAt(db, row?.bookingId)
+      await touchInvoiceBookingLinks(db, previousBookingId, row?.bookingId)
       return row ?? null
     } catch (error) {
       if (data.invoiceNumber && isInvoiceNumberUniqueConstraintError(error)) {
@@ -413,4 +423,15 @@ export const financeInvoiceCoreService = {
 
     return result
   },
+}
+
+async function touchInvoiceBookingLinks(
+  db: PostgresJsDatabase,
+  previousBookingId: string | null | undefined,
+  nextBookingId: string | null | undefined,
+) {
+  await touchLinkedBookingUpdatedAt(db, nextBookingId)
+  if (previousBookingId && previousBookingId !== nextBookingId) {
+    await touchLinkedBookingUpdatedAt(db, previousBookingId)
+  }
 }

--- a/packages/finance/src/service-invoice-core.ts
+++ b/packages/finance/src/service-invoice-core.ts
@@ -32,6 +32,7 @@ import {
   payments,
   readStringMetadata,
   sql,
+  touchLinkedBookingUpdatedAt,
 } from "./service-shared.js"
 
 export const financeInvoiceCoreService = {
@@ -152,6 +153,7 @@ export const financeInvoiceCoreService = {
 
   async createInvoice(db: PostgresJsDatabase, data: CreateInvoiceInput) {
     const [row] = await db.insert(invoices).values(data).returning()
+    await touchLinkedBookingUpdatedAt(db, row?.bookingId)
     return row
   },
   async getInvoiceById(db: PostgresJsDatabase, id: string) {
@@ -194,6 +196,7 @@ export const financeInvoiceCoreService = {
           const [row] = await updateInvoiceRow(tx)
 
           if (row) {
+            await touchLinkedBookingUpdatedAt(tx, row.bookingId)
             await appendActionLedgerMutation(
               tx,
               buildInvoiceUpdateActionLedgerInput(
@@ -209,6 +212,7 @@ export const financeInvoiceCoreService = {
       }
 
       const [row] = await updateInvoiceRow(db)
+      await touchLinkedBookingUpdatedAt(db, row?.bookingId)
       return row ?? null
     } catch (error) {
       if (data.invoiceNumber && isInvoiceNumberUniqueConstraintError(error)) {
@@ -233,6 +237,7 @@ export const financeInvoiceCoreService = {
         }
 
         await tx.delete(invoices).where(eq(invoices.id, id))
+        await touchLinkedBookingUpdatedAt(tx, existing.bookingId)
         await appendActionLedgerMutation(
           tx,
           buildInvoiceDeleteActionLedgerInput(
@@ -246,7 +251,7 @@ export const financeInvoiceCoreService = {
     }
 
     const [existing] = await db
-      .select({ id: invoices.id, status: invoices.status })
+      .select({ id: invoices.id, status: invoices.status, bookingId: invoices.bookingId })
       .from(invoices)
       .where(eq(invoices.id, id))
       .limit(1)
@@ -260,6 +265,7 @@ export const financeInvoiceCoreService = {
     }
 
     await db.delete(invoices).where(eq(invoices.id, id))
+    await touchLinkedBookingUpdatedAt(db, existing.bookingId)
     return { status: "deleted" as const }
   },
 
@@ -339,6 +345,8 @@ export const financeInvoiceCoreService = {
       if (!invoice) {
         return { status: "not_found" as const }
       }
+
+      await touchLinkedBookingUpdatedAt(tx, invoice.bookingId)
 
       const actionLedgerContext = runtime.actionLedgerContext
       if (actionLedgerContext) {

--- a/packages/finance/src/service-invoice-from-booking.ts
+++ b/packages/finance/src/service-invoice-from-booking.ts
@@ -31,6 +31,7 @@ import {
   resolveInvoiceFromBookingDueDate,
   resolveInvoiceLineDescriptions,
   resolvePaymentScheduleDisplayItem,
+  touchLinkedBookingUpdatedAt,
 } from "./service-shared.js"
 
 async function resolveInvoiceNumberForBooking(
@@ -354,6 +355,8 @@ export const financeInvoiceFromBookingService = {
             insertedLineItems.length,
           )
         }
+
+        await touchLinkedBookingUpdatedAt(tx, booking.id)
 
         return invoice
       })

--- a/packages/finance/src/service-invoice-payments.ts
+++ b/packages/finance/src/service-invoice-payments.ts
@@ -29,6 +29,7 @@ import {
   shouldNormalizeBaseAmount,
   sql,
   toRows,
+  touchLinkedBookingUpdatedAt,
 } from "./service-shared.js"
 
 export const financeInvoicePaymentService = {
@@ -369,6 +370,7 @@ export const financeInvoicePaymentService = {
         .update(invoices)
         .set({ paidCents, balanceDueCents, status: newStatus, updatedAt: new Date() })
         .where(eq(invoices.id, invoiceId))
+      await touchLinkedBookingUpdatedAt(tx, invoice.bookingId)
 
       if (payment.status === "completed") {
         recordedPaymentEvent = {
@@ -481,6 +483,7 @@ export const financeInvoicePaymentService = {
       }
 
       await recomputeInvoiceTotalsAfterPaymentChange(tx, invoice)
+      await touchLinkedBookingUpdatedAt(tx, invoice.bookingId)
 
       if (runtime.actionLedgerContext) {
         await appendActionLedgerMutation(
@@ -516,6 +519,7 @@ export const financeInvoicePaymentService = {
       await tx.delete(payments).where(eq(payments.id, id))
 
       await recomputeInvoiceTotalsAfterPaymentChange(tx, invoice)
+      await touchLinkedBookingUpdatedAt(tx, invoice.bookingId)
 
       if (runtime.actionLedgerContext) {
         await appendActionLedgerMutation(

--- a/packages/finance/src/service-issue.ts
+++ b/packages/finance/src/service-issue.ts
@@ -22,6 +22,7 @@ import {
   financeService,
   type InvoiceFromBookingData,
   InvoiceNumberConflictError,
+  touchLinkedBookingUpdatedAt,
 } from "./service.js"
 
 /**
@@ -173,6 +174,7 @@ export async function issueInvoiceFromBooking(
         const [row] = await updateIssuedInvoice(tx)
 
         if (row) {
+          await touchLinkedBookingUpdatedAt(tx, row.bookingId)
           await appendActionLedgerMutation(
             tx,
             await buildInvoiceIssuedActionLedgerInput(
@@ -188,6 +190,9 @@ export async function issueInvoiceFromBooking(
     : (await updateIssuedInvoice(db))[0]
 
   const row = issued ?? draft
+  if (!actionLedgerContext) {
+    await touchLinkedBookingUpdatedAt(db, row.bookingId)
+  }
   await emitIssued(db, runtime, ISSUED_EVENT, row, { skipExternalSync: input.skipExternalSync })
   return row
 }
@@ -221,6 +226,7 @@ export async function issueProformaFromBooking(
         const [row] = await updateIssuedInvoice(tx)
 
         if (row) {
+          await touchLinkedBookingUpdatedAt(tx, row.bookingId)
           await appendActionLedgerMutation(
             tx,
             await buildInvoiceIssuedActionLedgerInput(
@@ -236,6 +242,9 @@ export async function issueProformaFromBooking(
     : (await updateIssuedInvoice(db))[0]
 
   const row = issued ?? draft
+  if (!actionLedgerContext) {
+    await touchLinkedBookingUpdatedAt(db, row.bookingId)
+  }
   await emitIssued(db, runtime, PROFORMA_ISSUED_EVENT, row, {
     skipExternalSync: input.skipExternalSync,
   })
@@ -641,6 +650,8 @@ export async function convertProformaToInvoice(
           updatedAt: now,
         })
         .where(eq(invoices.id, lockedProforma.id))
+
+      await touchLinkedBookingUpdatedAt(tx, inserted.bookingId, now)
 
       return { status: "ok" as const, invoice: inserted, proforma: lockedProforma }
     })

--- a/packages/finance/src/service-payment-sessions.ts
+++ b/packages/finance/src/service-payment-sessions.ts
@@ -25,6 +25,7 @@ import {
   paymentSessions,
   sql,
   toTimestamp,
+  touchLinkedBookingUpdatedAt,
 } from "./service-shared.js"
 
 type PaymentSessionTargetColumns = {
@@ -33,6 +34,13 @@ type PaymentSessionTargetColumns = {
   bookingPaymentScheduleId?: string
   bookingGuaranteeId?: string
   orderId?: string
+}
+
+async function touchPaymentSessionBooking(
+  db: PostgresJsDatabase,
+  session: typeof paymentSessions.$inferSelect | undefined,
+) {
+  await touchLinkedBookingUpdatedAt(db, session?.bookingId)
 }
 
 function derivePaymentSessionTargetColumns(
@@ -155,6 +163,7 @@ export const financePaymentSessionService = {
         const created = await createSession(tx)
 
         if (created[0]) {
+          await touchPaymentSessionBooking(tx, created[0])
           await appendActionLedgerMutation(
             tx,
             await buildPaymentSessionCreateActionLedgerInput(
@@ -172,6 +181,7 @@ export const financePaymentSessionService = {
     }
 
     const [row] = await createSession(db)
+    await touchPaymentSessionBooking(db, row)
     return row ?? null
   },
 
@@ -220,6 +230,7 @@ export const financePaymentSessionService = {
         const updated = await updateSession(tx)
 
         if (updated[0]) {
+          await touchPaymentSessionBooking(tx, updated[0])
           await appendActionLedgerMutation(
             tx,
             buildPaymentSessionUpdateActionLedgerInput(
@@ -237,6 +248,7 @@ export const financePaymentSessionService = {
     }
 
     const [row] = await updateSession(db)
+    await touchPaymentSessionBooking(db, row)
     return row ?? null
   },
 
@@ -274,6 +286,7 @@ export const financePaymentSessionService = {
         const updated = await markRequiresRedirect(tx)
 
         if (updated[0]) {
+          await touchPaymentSessionBooking(tx, updated[0])
           await appendActionLedgerMutation(
             tx,
             buildPaymentSessionRequiresRedirectActionLedgerInput(
@@ -291,6 +304,7 @@ export const financePaymentSessionService = {
     }
 
     const [row] = await markRequiresRedirect(db)
+    await touchPaymentSessionBooking(db, row)
     return row ?? null
   },
 
@@ -325,6 +339,7 @@ export const financePaymentSessionService = {
         const updated = await failSession(tx)
 
         if (updated[0]) {
+          await touchPaymentSessionBooking(tx, updated[0])
           await appendActionLedgerMutation(
             tx,
             buildPaymentSessionFailedActionLedgerInput(
@@ -342,6 +357,7 @@ export const financePaymentSessionService = {
     }
 
     const [row] = await failSession(db)
+    await touchPaymentSessionBooking(db, row)
     return row ?? null
   },
 
@@ -371,6 +387,7 @@ export const financePaymentSessionService = {
         const updated = await cancelSession(tx)
 
         if (updated[0]) {
+          await touchPaymentSessionBooking(tx, updated[0])
           await appendActionLedgerMutation(
             tx,
             buildPaymentSessionCancelledActionLedgerInput(
@@ -388,6 +405,7 @@ export const financePaymentSessionService = {
     }
 
     const [row] = await cancelSession(db)
+    await touchPaymentSessionBooking(db, row)
     return row ?? null
   },
 
@@ -417,6 +435,7 @@ export const financePaymentSessionService = {
         const updated = await expireSession(tx)
 
         if (updated[0]) {
+          await touchPaymentSessionBooking(tx, updated[0])
           await appendActionLedgerMutation(
             tx,
             buildPaymentSessionExpiredActionLedgerInput(
@@ -434,6 +453,7 @@ export const financePaymentSessionService = {
     }
 
     const [row] = await expireSession(db)
+    await touchPaymentSessionBooking(db, row)
     return row ?? null
   },
 }

--- a/packages/finance/src/service-shared.ts
+++ b/packages/finance/src/service-shared.ts
@@ -1010,6 +1010,15 @@ export async function paginate<T extends object>(
   return listResponse(data, { total: countResult[0]?.count ?? 0, limit, offset })
 }
 
+export async function touchLinkedBookingUpdatedAt(
+  db: PostgresJsDatabase,
+  bookingId: string | null | undefined,
+  now = new Date(),
+) {
+  if (!bookingId) return
+  await db.update(bookings).set({ updatedAt: now }).where(eq(bookings.id, bookingId))
+}
+
 /**
  * Runtime context for finance service methods that need to emit lifecycle
  * events (e.g. `invoice.settled`). Optional — methods fall back to a no-op

--- a/packages/finance/tests/unit/service-invoice-number-allocation.test.ts
+++ b/packages/finance/tests/unit/service-invoice-number-allocation.test.ts
@@ -1123,6 +1123,13 @@ describe("financeService.applyExternalInvoiceAllocation", () => {
 describe("financeService.updateInvoice number writeback", () => {
   function makeUpdateInvoiceDb(updateError: unknown) {
     return {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(async () => [{ bookingId: "book_existing" }]),
+          })),
+        })),
+      })),
       update: vi.fn(() => ({
         set: vi.fn(() => ({
           where: vi.fn(() => ({

--- a/packages/finance/tests/unit/service-issue.test.ts
+++ b/packages/finance/tests/unit/service-issue.test.ts
@@ -15,6 +15,7 @@ vi.mock("../../src/service.js", () => ({
   financeService: {
     createInvoiceFromBooking: vi.fn(),
   },
+  touchLinkedBookingUpdatedAt: vi.fn(),
 }))
 
 describe("issueInvoiceFromBooking", () => {


### PR DESCRIPTION
Fixes #2441

## Summary
- Add booking activity rows for note update/delete and preserve note lifecycle descriptions in the booking timeline.
- Touch the parent booking updated timestamp for booking child mutations, including notes, travelers, supplier statuses, booking documents, invoices, payments, invoice issue/void/delete, and booking-target payment sessions.
- Classify finance action-ledger entries so invoice/document actions appear under Document filters and payment-related actions appear under Payment filters.
- Invalidate booking detail/activity/ledger/payment queries after related React mutations so metadata and timelines refresh.

## Verification
- PASS: `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/bookings typecheck`
- PASS: `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/bookings-react typecheck`
- PASS: `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/finance typecheck`
- PASS: `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/finance-react typecheck`
- PASS: `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/bookings exec vitest run tests/unit/service-notes.test.ts`
- PASS: `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/bookings-react exec vitest run tests/unit/booking-activity-timeline.test.tsx tests/unit/use-booking-note-mutation.test.ts tests/unit/use-booking-action-ledger-events.test.tsx`
- PASS: `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/finance-react exec vitest run tests/unit/use-invoice-mutation.test.ts`
- PASS, skipped without DB: `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/bookings exec vitest run tests/integration/routes.test.ts`
- PASS: `pnpm lint:changed`
- PASS with existing warning: `pnpm verify:agent-quality:changed` (`packages/finance/src/service-invoice-payments.ts` exceeds 500 lines)
- PASS: `git diff --check`

## Local hook notes
- Default-heap parallel package typechecks OOMed locally with exit 134; the same package typechecks passed sequentially with `NODE_OPTIONS=--max-old-space-size=8192`.
- The broad pre-commit affected build/typecheck hook was interrupted after repeated local OOM kills, including `@voyant-travel/finance-react:build`, `@voyant-travel/operations:build`, `@voyant-travel/finance:build`, `@voyant-travel/operations:typecheck`, `@voyant-travel/distribution:typecheck`, `@voyant-travel/distribution:build`, and `@voyant-travel/accommodations:build`.
- The pre-push full repository test hook was stopped because it launches the broad repository test lane locally; focused changed-package checks above passed.