### PR TITLE
Fix booking documents guidance

### DIFF
--- a/.changeset/booking-documents-upload-contract-ux.md
+++ b/.changeset/booking-documents-upload-contract-ux.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/bookings-react": patch
+"@voyant-travel/i18n": patch
+---
+
+Improve booking Documents tab guidance by disabling traveler document submission until a file upload exists, clearing upload form state when the selected file is removed, aligning empty-state copy with the Add contract action, and explaining unavailable generated-contract preview setup.

--- a/packages/bookings-react/src/admin/booking-contract-dialog.tsx
+++ b/packages/bookings-react/src/admin/booking-contract-dialog.tsx
@@ -20,6 +20,7 @@ import {
 } from "@voyant-travel/ui/components"
 import { FileText, Loader2, Paperclip, X } from "lucide-react"
 import { useEffect, useState } from "react"
+import { VoyantApiError } from "../client.js"
 import { useBookingContractGenerationMutation } from "../index.js"
 
 type ContractDialogMode = "generate" | "upload"
@@ -139,12 +140,14 @@ export function BookingContractDialog({
   const submitting = generate.isPending || uploading
   const previewReady = preview.data != null
   const canSubmit = mode === "generate" ? previewReady && !submitting : file != null && !submitting
+  const previewSetupMissing =
+    preview.error instanceof VoyantApiError && preview.error.status === 404
   const showPreviewSetupHint =
     mode === "generate" &&
     previewRequested &&
     !preview.isPending &&
-    !preview.isError &&
-    !preview.data
+    !preview.data &&
+    (!preview.isError || previewSetupMissing)
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -180,7 +183,7 @@ export function BookingContractDialog({
                       <Skeleton className="h-4 w-4/5" />
                       <Skeleton className="h-4 w-full" />
                     </div>
-                  ) : preview.isError ? (
+                  ) : preview.isError && !previewSetupMissing ? (
                     <p className="p-6 text-destructive text-sm">
                       {t.previewErrorPrefix}{" "}
                       {preview.error instanceof Error ? preview.error.message : t.previewFailed}

--- a/packages/bookings-react/src/admin/booking-contract-dialog.tsx
+++ b/packages/bookings-react/src/admin/booking-contract-dialog.tsx
@@ -61,6 +61,7 @@ export function BookingContractDialog({
   const [mode, setMode] = useState<ContractDialogMode>("generate")
   const [uploading, setUploading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [previewRequested, setPreviewRequested] = useState(false)
 
   // Upload form state
   const [title, setTitle] = useState("")
@@ -76,6 +77,7 @@ export function BookingContractDialog({
     setFile(null)
     setError(null)
     setUploading(false)
+    setPreviewRequested(false)
     resetPreview()
   }, [open, resetPreview])
 
@@ -85,6 +87,7 @@ export function BookingContractDialog({
   const fetchPreview = preview.mutate
   useEffect(() => {
     if (!open || mode !== "generate") return
+    setPreviewRequested(true)
     fetchPreview()
   }, [open, mode, fetchPreview])
 
@@ -136,6 +139,12 @@ export function BookingContractDialog({
   const submitting = generate.isPending || uploading
   const previewReady = preview.data != null
   const canSubmit = mode === "generate" ? previewReady && !submitting : file != null && !submitting
+  const showPreviewSetupHint =
+    mode === "generate" &&
+    previewRequested &&
+    !preview.isPending &&
+    !preview.isError &&
+    !preview.data
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -183,12 +192,17 @@ export function BookingContractDialog({
                       sandbox=""
                       className="h-[60vh] w-full border-0 bg-white"
                     />
-                  ) : null}
+                  ) : (
+                    <div className="p-6 text-muted-foreground text-sm">{t.previewUnavailable}</div>
+                  )}
                 </div>
                 {preview.data?.templateName ? (
                   <p className="text-muted-foreground text-xs">
                     {t.previewTemplateLabel} {preview.data.templateName}
                   </p>
+                ) : null}
+                {showPreviewSetupHint ? (
+                  <p className="text-muted-foreground text-xs">{t.previewSetupHint}</p>
                 ) : null}
               </div>
             ) : (

--- a/packages/bookings-react/src/components/booking-document-dialog.tsx
+++ b/packages/bookings-react/src/components/booking-document-dialog.tsx
@@ -38,7 +38,10 @@ function createDocumentFormSchema(messages: ReturnType<typeof useBookingsUiMessa
       .string()
       .min(1, messages.bookingDocumentDialog.validation.fileNameRequired)
       .max(500),
-    fileUrl: z.string().url(messages.bookingDocumentDialog.validation.fileUrlInvalid),
+    fileUrl: z
+      .string()
+      .min(1, messages.bookingDocumentDialog.validation.fileRequired)
+      .url(messages.bookingDocumentDialog.validation.fileUrlInvalid),
     travelerId: z.string().optional().nullable(),
     expiresAt: z.string().optional().nullable(),
     notes: z.string().optional().nullable(),
@@ -119,6 +122,8 @@ export function BookingDocumentDialog({
     onOpenChange(false)
     onSuccess?.()
   }
+  const uploadedFileUrl = form.watch("fileUrl")
+  const canSubmit = Boolean(uploadedFileUrl) && !create.isPending
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -186,6 +191,10 @@ export function BookingDocumentDialog({
                   form.setValue("fileUrl", upload.url, { shouldValidate: true })
                   form.setValue("fileName", upload.name, { shouldValidate: true })
                 }}
+                onCleared={() => {
+                  form.setValue("fileUrl", "", { shouldDirty: true, shouldValidate: true })
+                  form.setValue("fileName", "", { shouldDirty: true, shouldValidate: true })
+                }}
                 helperText={messages.bookingDocumentDialog.placeholders.helperText}
               />
               {form.formState.errors.fileUrl && (
@@ -220,7 +229,7 @@ export function BookingDocumentDialog({
             <Button type="button" variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
               {messages.common.cancel}
             </Button>
-            <Button type="submit" size="sm" disabled={create.isPending}>
+            <Button type="submit" size="sm" disabled={!canSubmit}>
               {create.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               {messages.bookingDocumentDialog.actions.addDocument}
             </Button>

--- a/packages/bookings-react/src/components/file-dropzone.tsx
+++ b/packages/bookings-react/src/components/file-dropzone.tsx
@@ -25,6 +25,8 @@ export interface FileDropzoneProps {
   maxSize?: number
   /** Called after a successful upload. */
   onUploaded: (file: UploadedFile) => void
+  /** Called after a previously uploaded file is cleared from the dropzone. */
+  onCleared?: () => void
   /** Called when an error occurs (validation, upload failure). */
   onError?: (message: string) => void
   /** Helper text shown in the idle state. */
@@ -38,6 +40,7 @@ export function FileDropzone({
   accept,
   maxSize,
   onUploaded,
+  onCleared,
   onError,
   helperText,
   disabled,
@@ -149,6 +152,7 @@ export function FileDropzone({
   const reset = () => {
     setUploaded(null)
     setError(null)
+    onCleared?.()
   }
 
   if (uploaded) {

--- a/packages/bookings-react/src/i18n/en-sections.ts
+++ b/packages/bookings-react/src/i18n/en-sections.ts
@@ -331,6 +331,7 @@ export const bookingsUiEnSections = {
       notes: "Additional notes...",
     },
     validation: {
+      fileRequired: "Choose a file before adding the document.",
       fileNameRequired: "File name is required",
       fileUrlInvalid: "Must be a valid URL",
     },

--- a/packages/bookings-react/src/i18n/messages-sections.ts
+++ b/packages/bookings-react/src/i18n/messages-sections.ts
@@ -311,6 +311,7 @@ export type BookingsUiSectionsMessages = {
       notes: string
     }
     validation: {
+      fileRequired: string
       fileNameRequired: string
       fileUrlInvalid: string
     }

--- a/packages/bookings-react/src/i18n/ro-sections.ts
+++ b/packages/bookings-react/src/i18n/ro-sections.ts
@@ -331,6 +331,7 @@ export const bookingsUiRoSections = {
       notes: "Note suplimentare...",
     },
     validation: {
+      fileRequired: "Alege un fisier inainte de a adauga documentul.",
       fileNameRequired: "Numele fisierului este obligatoriu",
       fileUrlInvalid: "Trebuie sa fie un URL valid",
     },

--- a/packages/bookings-react/tests/unit/booking-documents-dialogs.test.tsx
+++ b/packages/bookings-react/tests/unit/booking-documents-dialogs.test.tsx
@@ -179,6 +179,7 @@ vi.mock("@voyant-travel/ui/components", () => ({
 }))
 
 import { BookingContractDialog } from "../../src/admin/booking-contract-dialog.js"
+import { VoyantApiError } from "../../src/client.js"
 import { BookingDocumentDialog } from "../../src/components/booking-document-dialog.js"
 
 function getButton(container: HTMLElement, label: string): HTMLButtonElement {
@@ -253,6 +254,29 @@ describe("booking document dialogs", () => {
     expect(testState.previewMutate).toHaveBeenCalledOnce()
     expect(container.textContent).toContain("Contract generation is not ready for this booking.")
     expect(container.textContent).toContain("Legal > Templates")
+    expect(getButton(container, "Create contract").disabled).toBe(true)
+  })
+
+  it("shows contract setup guidance when preview returns missing template", () => {
+    testState.previewState.isError = true
+    testState.previewState.error = new VoyantApiError("No active customer template", 404, {
+      error: { message: "No active customer template" },
+    })
+
+    act(() => {
+      root.render(
+        <BookingContractDialog
+          open
+          onOpenChange={() => undefined}
+          bookingId="book_123"
+          bookingNumber="BK-123"
+        />,
+      )
+    })
+
+    expect(container.textContent).toContain("Contract generation is not ready for this booking.")
+    expect(container.textContent).toContain("Legal > Templates")
+    expect(container.textContent).not.toContain("Preview error:")
     expect(getButton(container, "Create contract").disabled).toBe(true)
   })
 })

--- a/packages/bookings-react/tests/unit/booking-documents-dialogs.test.tsx
+++ b/packages/bookings-react/tests/unit/booking-documents-dialogs.test.tsx
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+
+import type * as ReactTypes from "react"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const testState = vi.hoisted(() => ({
+  createDocument: vi.fn(async () => ({ id: "bdoc_123" })),
+  uploadContract: vi.fn(async () => ({ id: "att_123" })),
+  createContract: vi.fn(async () => ({ id: "ctr_123" })),
+  invalidateQueries: vi.fn(async () => undefined),
+  previewMutate: vi.fn(),
+  previewReset: vi.fn(),
+  generateContract: vi.fn(async () => ({ contractId: "ctr_123", attachmentId: "att_123" })),
+  previewState: {
+    data: undefined as undefined | { html: string; templateName?: string },
+    isPending: false,
+    isError: false,
+    error: null as unknown,
+  },
+}))
+
+;(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
+
+const adminMessages = {
+  bookings: {
+    detail: {
+      contractDialog: {
+        title: "Add contract",
+        description: "Generate a contract from the configured template or upload a signed PDF.",
+        modeLabel: "Source",
+        modeGenerate: "Generate",
+        modeUpload: "Upload",
+        previewLabel: "Preview",
+        previewIframeFallback: "Contract preview",
+        previewTemplateLabel: "Template:",
+        previewFailed: "Could not render the contract preview.",
+        previewErrorPrefix: "Preview error:",
+        previewUnavailable: "Contract generation is not ready for this booking.",
+        previewSetupHint:
+          "Configure an active customer contract template with a published version in Legal > Templates, and make sure the deployment has contract document generation configured.",
+        uploadTitleLabel: "Title",
+        uploadTitlePlaceholder: "Contract title",
+        uploadTitleHint: "Defaults to the booking reference when left empty.",
+        uploadFileLabel: "PDF file",
+        uploadFileRequired: "Choose a PDF to upload.",
+        generateAction: "Create contract",
+        uploadAction: "Upload contract",
+        cancel: "Cancel",
+      },
+    },
+  },
+}
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: testState.invalidateQueries }),
+}))
+
+vi.mock("@voyant-travel/admin", () => ({
+  useOperatorAdminMessages: () => adminMessages,
+}))
+
+vi.mock("@voyant-travel/legal-react", () => ({
+  legalQueryKeys: {
+    contracts: () => ["legal", "contracts"],
+  },
+  useLegalContractAttachmentMutation: () => ({
+    upload: { mutateAsync: testState.uploadContract },
+  }),
+  useLegalContractMutation: () => ({
+    create: { mutateAsync: testState.createContract },
+  }),
+}))
+
+vi.mock("../../src/index.js", () => ({
+  useBookingContractGenerationMutation: () => ({
+    preview: {
+      ...testState.previewState,
+      mutate: testState.previewMutate,
+      reset: testState.previewReset,
+    },
+    generate: {
+      isPending: false,
+      mutateAsync: testState.generateContract,
+    },
+  }),
+  useBookingTravelerDocumentMutation: () => ({
+    create: {
+      isPending: false,
+      mutateAsync: testState.createDocument,
+    },
+  }),
+  useTravelers: () => ({ data: { data: [] } }),
+}))
+
+vi.mock("@voyant-travel/ui/components/date-picker", () => ({
+  DatePicker: ({
+    placeholder,
+  }: {
+    value?: string | null
+    onChange?: (next: string | null) => void
+    placeholder?: string
+  }) => <input aria-label={placeholder} />,
+}))
+
+vi.mock("../../src/components/file-dropzone.js", () => ({
+  FileDropzone: ({
+    helperText,
+    onUploaded,
+    onCleared,
+  }: {
+    helperText?: string
+    onUploaded: (upload: {
+      key: string
+      url: string
+      mimeType: string
+      size: number
+      name: string
+    }) => void
+    onCleared?: () => void
+  }) => (
+    <div>
+      <p>{helperText}</p>
+      <button
+        type="button"
+        onClick={() =>
+          onUploaded({
+            key: "upload_123",
+            url: "https://cdn.example.test/passport.pdf",
+            mimeType: "application/pdf",
+            size: 1234,
+            name: "passport.pdf",
+          })
+        }
+      >
+        Mock upload
+      </button>
+      <button type="button" onClick={() => onCleared?.()}>
+        Mock clear
+      </button>
+    </div>
+  ),
+}))
+
+vi.mock("@voyant-travel/ui/components", () => ({
+  Button: ({ children, ...props }: ReactTypes.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+  Dialog: ({
+    children,
+    open,
+  }: {
+    children?: ReactTypes.ReactNode
+    open?: boolean
+    onOpenChange?: (open: boolean) => void
+  }) => (open ? <div>{children}</div> : null),
+  DialogBody: ({ children }: { children?: ReactTypes.ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children?: ReactTypes.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children?: ReactTypes.ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children?: ReactTypes.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children?: ReactTypes.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children?: ReactTypes.ReactNode }) => <h2>{children}</h2>,
+  Input: (props: ReactTypes.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+  Label: ({ children }: { children?: ReactTypes.ReactNode }) => <span>{children}</span>,
+  Select: ({ children }: { children?: ReactTypes.ReactNode }) => <div>{children}</div>,
+  SelectContent: ({ children }: { children?: ReactTypes.ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children }: { children?: ReactTypes.ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children?: ReactTypes.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+  SelectValue: () => null,
+  Skeleton: () => <div />,
+  Textarea: (props: ReactTypes.TextareaHTMLAttributes<HTMLTextAreaElement>) => (
+    <textarea {...props} />
+  ),
+}))
+
+import { BookingContractDialog } from "../../src/admin/booking-contract-dialog.js"
+import { BookingDocumentDialog } from "../../src/components/booking-document-dialog.js"
+
+function getButton(container: HTMLElement, label: string): HTMLButtonElement {
+  const button = [...container.querySelectorAll("button")].find((candidate) =>
+    candidate.textContent?.includes(label),
+  )
+  if (!button) throw new Error(`Button not found: ${label}`)
+  return button
+}
+
+describe("booking document dialogs", () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    testState.createDocument.mockClear()
+    testState.uploadContract.mockClear()
+    testState.createContract.mockClear()
+    testState.invalidateQueries.mockClear()
+    testState.previewMutate.mockClear()
+    testState.previewReset.mockClear()
+    testState.generateContract.mockClear()
+    testState.previewState.data = undefined
+    testState.previewState.isPending = false
+    testState.previewState.isError = false
+    testState.previewState.error = null
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it("keeps document upload submit disabled until an uploaded file exists", () => {
+    act(() => {
+      root.render(
+        <BookingDocumentDialog open onOpenChange={() => undefined} bookingId="book_123" />,
+      )
+    })
+
+    expect(getButton(container, "Add document").disabled).toBe(true)
+    expect(container.textContent).not.toContain("Must be a valid URL")
+
+    act(() => {
+      getButton(container, "Mock upload").click()
+    })
+
+    expect(getButton(container, "Add document").disabled).toBe(false)
+
+    act(() => {
+      getButton(container, "Mock clear").click()
+    })
+
+    expect(getButton(container, "Add document").disabled).toBe(true)
+  })
+
+  it("explains why generated contract creation is disabled without preview content", () => {
+    act(() => {
+      root.render(
+        <BookingContractDialog
+          open
+          onOpenChange={() => undefined}
+          bookingId="book_123"
+          bookingNumber="BK-123"
+        />,
+      )
+    })
+
+    expect(testState.previewMutate).toHaveBeenCalledOnce()
+    expect(container.textContent).toContain("Contract generation is not ready for this booking.")
+    expect(container.textContent).toContain("Legal > Templates")
+    expect(getButton(container, "Create contract").disabled).toBe(true)
+  })
+})

--- a/packages/i18n/src/admin/bookings/en-part-1.ts
+++ b/packages/i18n/src/admin/bookings/en-part-1.ts
@@ -267,7 +267,7 @@ export const adminBookingsMessagesEnPart1 = {
       uploadDocument: "Upload document",
       loading: "Loading documents…",
       empty:
-        'No documents on this booking yet. Use "Generate contract" above, or upload traveler documents (passport, visa, insurance). Invoices are generated per payment from the Finance tab.',
+        'No documents on this booking yet. Use "Add contract" above, or upload traveler documents (passport, visa, insurance). Invoices are generated per payment from the Finance tab.',
       headerCategory: "Category",
       headerDocument: "Document",
       headerFor: "For",
@@ -310,6 +310,9 @@ export const adminBookingsMessagesEnPart1 = {
       previewTemplateLabel: "Template:",
       previewFailed: "Could not render the contract preview.",
       previewErrorPrefix: "Preview error:",
+      previewUnavailable: "Contract generation is not ready for this booking.",
+      previewSetupHint:
+        "Configure an active customer contract template with a published version in Legal > Templates, and make sure the deployment has contract document generation configured.",
       uploadTitleLabel: "Title",
       uploadTitlePlaceholder: "Contract title",
       uploadTitleHint: "Defaults to the booking reference when left empty.",

--- a/packages/i18n/src/admin/bookings/ro-part-1.ts
+++ b/packages/i18n/src/admin/bookings/ro-part-1.ts
@@ -267,7 +267,7 @@ export const adminBookingsMessagesRoPart1 = {
       uploadDocument: "Incarca document",
       loading: "Se incarca documentele…",
       empty:
-        'Nu exista inca documente pentru aceasta rezervare. Foloseste "Genereaza contractul" mai sus sau incarca documentele calatorilor (pasaport, viza, asigurare). Facturile se genereaza per plata din tab-ul Plati.',
+        'Nu exista inca documente pentru aceasta rezervare. Foloseste "Adauga contract" mai sus sau incarca documentele calatorilor (pasaport, viza, asigurare). Facturile se genereaza per plata din tab-ul Plati.',
       headerCategory: "Categorie",
       headerDocument: "Document",
       headerFor: "Pentru",
@@ -310,6 +310,9 @@ export const adminBookingsMessagesRoPart1 = {
       previewTemplateLabel: "Sablon:",
       previewFailed: "Nu am putut genera previzualizarea contractului.",
       previewErrorPrefix: "Eroare previzualizare:",
+      previewUnavailable: "Generarea contractului nu este pregatita pentru aceasta rezervare.",
+      previewSetupHint:
+        "Configureaza un sablon activ de contract pentru clienti, cu versiune publicata, in Legal > Sabloane si verifica daca deployment-ul are generarea documentelor de contract configurata.",
       uploadTitleLabel: "Titlu",
       uploadTitlePlaceholder: "Titlu contract",
       uploadTitleHint: "Implicit foloseste numarul rezervarii cand este gol.",


### PR DESCRIPTION
Fixes #2440

## Summary
- require a completed uploaded file before saving booking documents
- show contract preview guidance when setup is missing
- update booking document and contract empty-state copy

## Verification
- pnpm --filter @voyant-travel/bookings-react exec vitest run tests/unit/booking-documents-dialogs.test.tsx
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/bookings-react typecheck
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/i18n typecheck
- pnpm exec biome check .changeset/booking-documents-upload-contract-ux.md packages/bookings-react/src/admin/booking-contract-dialog.tsx packages/bookings-react/src/components/booking-document-dialog.tsx packages/bookings-react/src/components/file-dropzone.tsx packages/bookings-react/src/i18n/en-sections.ts packages/bookings-react/src/i18n/messages-sections.ts packages/bookings-react/src/i18n/ro-sections.ts packages/bookings-react/tests/unit/booking-documents-dialogs.test.tsx packages/i18n/src/admin/bookings/en-part-1.ts packages/i18n/src/admin/bookings/ro-part-1.ts
- pnpm lint:changed
- pnpm verify:agent-quality:changed