### PR TITLE
Tighten finance admin AP actions

### DIFF
--- a/.changeset/finance-admin-ap-actions.md
+++ b/.changeset/finance-admin-ap-actions.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/finance-react": patch
+---
+
+Tighten finance admin UI actions by disabling invoice deletes the API rejects, replacing blocking browser prompts with app-native dialogs, creating supplier invoice drafts with initial AP lines from totals, and blocking negative AP money inputs client-side.

--- a/packages/finance-react/src/admin/invoice-detail-host.tsx
+++ b/packages/finance-react/src/admin/invoice-detail-host.tsx
@@ -109,6 +109,8 @@ export function InvoiceDetailHost({ id }: InvoiceDetailHostProps) {
   const [noteDialogOpen, setNoteDialogOpen] = useState(false)
   const [noteContent, setNoteContent] = useState("")
   const [actionError, setActionError] = useState<string | null>(null)
+  const [convertDialogOpen, setConvertDialogOpen] = useState(false)
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [voidDialogOpen, setVoidDialogOpen] = useState(false)
   const [voidReason, setVoidReason] = useState("")
 
@@ -156,6 +158,7 @@ export function InvoiceDetailHost({ id }: InvoiceDetailHostProps) {
     invoice.status,
   )
   const canConvertProforma = invoice.invoiceType === "proforma" && invoice.status !== "void"
+  const canDeleteInvoice = invoice.status === "draft"
 
   const getMutationErrorMessage = (fallback: string) => (error: unknown) =>
     error instanceof Error ? error.message : fallback
@@ -174,34 +177,57 @@ export function InvoiceDetailHost({ id }: InvoiceDetailHostProps) {
         </div>
         <div className="flex flex-wrap items-center gap-2">
           {canConvertProforma ? (
-            <Button
-              variant="outline"
-              disabled={convertToInvoice.isPending}
-              onClick={() => {
-                if (!confirm(messages.finance.convertConfirm)) return
-                setActionError(null)
-                convertToInvoice.mutate(
-                  { id },
-                  {
-                    onSuccess: (converted) => {
-                      navigateTo("invoice.detail", { invoiceId: converted.id })
-                    },
-                    onError: (error) => {
-                      setActionError(
-                        getMutationErrorMessage(messages.finance.detailPage.convertFailed)(error),
+            <AlertDialog open={convertDialogOpen} onOpenChange={setConvertDialogOpen}>
+              <AlertDialogTrigger
+                disabled={convertToInvoice.isPending}
+                render={<Button type="button" variant="outline" />}
+              >
+                {convertToInvoice.isPending ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                ) : (
+                  <ArrowRightLeft className="mr-2 h-4 w-4" />
+                )}
+                {messages.finance.convertToInvoice}
+              </AlertDialogTrigger>
+              <AlertDialogContent size="sm">
+                <AlertDialogHeader>
+                  <AlertDialogTitle>{messages.finance.convertToInvoice}</AlertDialogTitle>
+                  <AlertDialogDescription>{messages.finance.convertConfirm}</AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel disabled={convertToInvoice.isPending}>
+                    {messages.finance.detailPage.cancel}
+                  </AlertDialogCancel>
+                  <AlertDialogAction
+                    disabled={convertToInvoice.isPending}
+                    onClick={() => {
+                      setActionError(null)
+                      convertToInvoice.mutate(
+                        { id },
+                        {
+                          onSuccess: (converted) => {
+                            setConvertDialogOpen(false)
+                            navigateTo("invoice.detail", { invoiceId: converted.id })
+                          },
+                          onError: (error) => {
+                            setActionError(
+                              getMutationErrorMessage(messages.finance.detailPage.convertFailed)(
+                                error,
+                              ),
+                            )
+                          },
+                        },
                       )
-                    },
-                  },
-                )
-              }}
-            >
-              {convertToInvoice.isPending ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
-              ) : (
-                <ArrowRightLeft className="mr-2 h-4 w-4" />
-              )}
-              {messages.finance.convertToInvoice}
-            </Button>
+                    }}
+                  >
+                    {convertToInvoice.isPending ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                    ) : null}
+                    {messages.finance.convertToInvoice}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           ) : null}
           <Button variant="outline" onClick={() => setEditOpen(true)}>
             <Pencil className="mr-2 h-4 w-4" />
@@ -267,36 +293,60 @@ export function InvoiceDetailHost({ id }: InvoiceDetailHostProps) {
               </AlertDialogFooter>
             </AlertDialogContent>
           </AlertDialog>
-          <Button
-            variant="destructive"
-            onClick={() => {
-              if (invoice.status !== "draft") {
-                alert(messages.finance.detailPage.deleteOnlyDraftAlert)
-                return
-              }
-              if (confirm(messages.finance.detailPage.deleteConfirm)) {
-                setActionError(null)
-                deleteInvoice.mutate(id, {
-                  onSuccess: () => {
-                    navigateTo("invoice.list", {})
-                  },
-                  onError: (error) => {
-                    setActionError(
-                      getMutationErrorMessage(messages.finance.detailPage.deleteOnlyDraftAlert)(
-                        error,
-                      ),
-                    )
-                  },
-                })
-              }
-            }}
-            disabled={deleteInvoice.isPending}
-          >
-            <Trash2 className="mr-2 h-4 w-4" />
-            {messages.finance.detailPage.delete}
-          </Button>
+          <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+            <AlertDialogTrigger
+              disabled={!canDeleteInvoice || deleteInvoice.isPending}
+              render={<Button type="button" variant="destructive" />}
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              {messages.finance.detailPage.delete}
+            </AlertDialogTrigger>
+            <AlertDialogContent size="sm">
+              <AlertDialogHeader>
+                <AlertDialogTitle>{messages.finance.detailPage.delete}</AlertDialogTitle>
+                <AlertDialogDescription>
+                  {messages.finance.detailPage.deleteConfirm}
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel disabled={deleteInvoice.isPending}>
+                  {messages.finance.detailPage.cancel}
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  variant="destructive"
+                  disabled={deleteInvoice.isPending}
+                  onClick={() => {
+                    setActionError(null)
+                    deleteInvoice.mutate(id, {
+                      onSuccess: () => {
+                        setDeleteDialogOpen(false)
+                        navigateTo("invoice.list", {})
+                      },
+                      onError: (error) => {
+                        setActionError(
+                          getMutationErrorMessage(messages.finance.detailPage.deleteOnlyDraftAlert)(
+                            error,
+                          ),
+                        )
+                      },
+                    })
+                  }}
+                >
+                  {deleteInvoice.isPending ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                  ) : null}
+                  {messages.finance.detailPage.delete}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         </div>
       </div>
+      {!canDeleteInvoice ? (
+        <div className="rounded-md border px-3 py-2 text-muted-foreground text-sm">
+          {messages.finance.detailPage.deleteOnlyDraftAlert}
+        </div>
+      ) : null}
       {actionError ? (
         <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-destructive text-sm">
           {actionError}

--- a/packages/finance-react/src/components/supplier-invoice-detail-page/dialogs.tsx
+++ b/packages/finance-react/src/components/supplier-invoice-detail-page/dialogs.tsx
@@ -30,12 +30,13 @@ import { AsyncCombobox, type AsyncComboboxOption } from "../async-combobox.js"
 import {
   LINE_CATEGORY_NONE,
   PAYMENT_METHODS,
+  parseNonNegativeCents,
+  parseOptionalNonNegativeCents,
   SEARCHABLE_TARGETS,
   type SupplierInvoiceTargetSearch,
   TARGET_TYPES,
   type TargetType,
   targetIdFor,
-  toCents,
 } from "./shared.js"
 
 export function LineDialog({
@@ -77,16 +78,22 @@ export function LineDialog({
     setTotal(line ? (line.totalAmountCents / 100).toFixed(2) : "")
   }
 
+  const unitCents = parseOptionalNonNegativeCents(unit)
+  const taxCents = parseOptionalNonNegativeCents(tax)
+  const totalCents = parseNonNegativeCents(total)
+  const moneyValid = unitCents != null && taxCents != null && totalCents != null
+
   const submit = () => {
+    if (!moneyValid) return
     if (!description.trim()) return
     onSubmit({
       description: description.trim(),
       serviceType,
       costCategoryId: costCategoryId || null,
       quantity: Math.max(1, Number.parseInt(quantity, 10) || 1),
-      unitAmountCents: toCents(unit),
-      taxAmountCents: toCents(tax),
-      totalAmountCents: toCents(total),
+      unitAmountCents: unitCents,
+      taxAmountCents: taxCents,
+      totalAmountCents: totalCents,
     })
   }
 
@@ -130,19 +137,38 @@ export function LineDialog({
           </div>
           <div className="flex flex-col gap-2">
             <Label>{`${t.unitAmount} (${currency})`}</Label>
-            <Input inputMode="decimal" value={unit} onChange={(e) => setUnit(e.target.value)} />
+            <Input
+              inputMode="decimal"
+              min="0"
+              value={unit}
+              onChange={(e) => setUnit(e.target.value)}
+            />
           </div>
           <div className="flex flex-col gap-2">
             <Label>{`${t.taxAmount} (${currency})`}</Label>
-            <Input inputMode="decimal" value={tax} onChange={(e) => setTax(e.target.value)} />
+            <Input
+              inputMode="decimal"
+              min="0"
+              value={tax}
+              onChange={(e) => setTax(e.target.value)}
+            />
           </div>
           <div className="col-span-2 flex flex-col gap-2">
             <Label>{`${t.total} (${currency})`}</Label>
-            <Input inputMode="decimal" value={total} onChange={(e) => setTotal(e.target.value)} />
+            <Input
+              inputMode="decimal"
+              min="0"
+              value={total}
+              onChange={(e) => setTotal(e.target.value)}
+            />
           </div>
         </DialogBody>
         <DialogFooter>
-          <Button type="button" disabled={!description.trim() || pending} onClick={submit}>
+          <Button
+            type="button"
+            disabled={!description.trim() || !moneyValid || pending}
+            onClick={submit}
+          >
             {t.save}
           </Button>
         </DialogFooter>
@@ -200,11 +226,13 @@ export function AllocationDialog({
   const twoStepDeparture =
     targetType === "departure" && Boolean(searchTargets) && Boolean(listDeparturesForProduct)
 
+  const amountCents = parseNonNegativeCents(amount)
+
   const submit = () => {
-    if (!amount) return
+    if (amountCents == null) return
     onSubmit({
       targetType,
-      amountCents: toCents(amount),
+      amountCents,
       splitMethod: "manual",
       ...targetIdFor(targetType, targetId.trim()),
     })
@@ -240,7 +268,12 @@ export function AllocationDialog({
           </div>
           <div className="flex flex-col gap-2">
             <Label>{formatMessage(t.amountLabel, { currency })}</Label>
-            <Input inputMode="decimal" value={amount} onChange={(e) => setAmount(e.target.value)} />
+            <Input
+              inputMode="decimal"
+              min="0"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+            />
           </div>
           {targetType === "unattributed" ? null : twoStepDeparture ? (
             <>
@@ -292,7 +325,9 @@ export function AllocationDialog({
         <DialogFooter>
           <Button
             type="button"
-            disabled={!amount || (targetType !== "unattributed" && !targetId.trim()) || pending}
+            disabled={
+              amountCents == null || (targetType !== "unattributed" && !targetId.trim()) || pending
+            }
             onClick={submit}
           >
             {pending ? t.saving : t.save}
@@ -339,10 +374,12 @@ export function PaymentDialog({
     }
   }
 
+  const amountCents = parseNonNegativeCents(amount)
+
   const submit = () => {
-    if (!amount) return
+    if (amountCents == null) return
     onSubmit({
-      amountCents: toCents(amount),
+      amountCents,
       paymentMethod: method,
       status: "completed",
       paymentDate: date || new Date().toISOString().slice(0, 10),
@@ -358,7 +395,12 @@ export function PaymentDialog({
         <DialogBody className="grid grid-cols-2 gap-3">
           <div className="flex flex-col gap-2">
             <Label>{formatMessage(t.amountLabel, { currency })}</Label>
-            <Input inputMode="decimal" value={amount} onChange={(e) => setAmount(e.target.value)} />
+            <Input
+              inputMode="decimal"
+              min="0"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+            />
           </div>
           <div className="flex flex-col gap-2">
             <Label>{t.methodLabel}</Label>
@@ -385,7 +427,7 @@ export function PaymentDialog({
           </div>
         </DialogBody>
         <DialogFooter>
-          <Button type="button" disabled={!amount || pending} onClick={submit}>
+          <Button type="button" disabled={amountCents == null || pending} onClick={submit}>
             {pending ? t.recording : t.record}
           </Button>
         </DialogFooter>

--- a/packages/finance-react/src/components/supplier-invoice-detail-page/shared.tsx
+++ b/packages/finance-react/src/components/supplier-invoice-detail-page/shared.tsx
@@ -45,6 +45,18 @@ export function toCents(major: string): number {
   return Number.isFinite(n) ? Math.round(n * 100) : 0
 }
 
+export function parseNonNegativeCents(major: string): number | null {
+  if (!major.trim()) return null
+  const n = Number.parseFloat(major)
+  if (!Number.isFinite(n) || n < 0) return null
+  return Math.round(n * 100)
+}
+
+export function parseOptionalNonNegativeCents(major: string): number | null {
+  if (!major.trim()) return 0
+  return parseNonNegativeCents(major)
+}
+
 export function targetIdFor(
   targetType: TargetType,
   targetId: string,

--- a/packages/finance-react/src/components/supplier-invoice-form-dialog.test.tsx
+++ b/packages/finance-react/src/components/supplier-invoice-form-dialog.test.tsx
@@ -1,0 +1,208 @@
+// @vitest-environment jsdom
+
+import type * as ReactTypes from "react"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const testState = vi.hoisted(() => ({
+  createMutate: vi.fn(),
+  updateMutate: vi.fn(),
+}))
+
+;(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock("../index.js", () => ({
+  useSupplierInvoiceMutation: () => ({
+    create: { isPending: false, mutate: testState.createMutate },
+    update: { isPending: false, mutate: testState.updateMutate },
+  }),
+}))
+
+vi.mock("@voyant-travel/ui/components", () => ({
+  Button: ({ children, ...props }: ReactTypes.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+  Dialog: ({
+    children,
+    open,
+  }: {
+    children: ReactTypes.ReactNode
+    open?: boolean
+    onOpenChange?: (open: boolean) => void
+  }) => (open ? <div>{children}</div> : null),
+  DialogBody: ({ children }: { children: ReactTypes.ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children: ReactTypes.ReactNode; className?: string }) => (
+    <div>{children}</div>
+  ),
+  DialogFooter: ({ children }: { children: ReactTypes.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactTypes.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactTypes.ReactNode }) => <h2>{children}</h2>,
+  Input: (props: ReactTypes.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+  Label: ({ children }: ReactTypes.LabelHTMLAttributes<HTMLLabelElement>) => (
+    <span>{children}</span>
+  ),
+  Select: ({
+    children,
+    onValueChange,
+    value,
+  }: {
+    children: ReactTypes.ReactNode
+    onValueChange?: (value: string) => void
+    value?: string
+  }) => (
+    <select value={value} onChange={(event) => onValueChange?.(event.target.value)}>
+      {children}
+    </select>
+  ),
+  SelectContent: ({ children }: { children: ReactTypes.ReactNode }) => <>{children}</>,
+  SelectItem: ({ children, value }: { children: ReactTypes.ReactNode; value: string }) => (
+    <option value={value}>{children}</option>
+  ),
+  SelectTrigger: ({ children }: { children?: ReactTypes.ReactNode }) => <>{children}</>,
+  SelectValue: () => null,
+  Textarea: (props: ReactTypes.TextareaHTMLAttributes<HTMLTextAreaElement>) => (
+    <textarea {...props} />
+  ),
+}))
+
+vi.mock("@voyant-travel/ui/components/currency-combobox", () => ({
+  CurrencyCombobox: ({
+    onChange,
+    value,
+  }: {
+    onChange?: (value: string | null) => void
+    value?: string | null
+  }) => (
+    <input
+      aria-label="Currency"
+      value={value ?? ""}
+      onChange={(event) => onChange?.(event.target.value || null)}
+    />
+  ),
+}))
+
+vi.mock("@voyant-travel/ui/components/date-picker", () => ({
+  DatePicker: ({
+    onChange,
+    value,
+  }: {
+    onChange?: (value: string | null) => void
+    value?: string | null
+  }) => (
+    <input
+      aria-label="Date"
+      value={value ?? ""}
+      onChange={(event) => onChange?.(event.target.value || null)}
+    />
+  ),
+}))
+
+vi.mock("./async-combobox.js", () => ({
+  AsyncCombobox: ({
+    onChange,
+    placeholder,
+    value,
+  }: {
+    onChange?: (value: string | null) => void
+    placeholder?: string
+    value?: string | null
+  }) => (
+    <input
+      aria-label={placeholder ?? "Async combobox"}
+      value={value ?? ""}
+      onChange={(event) => onChange?.(event.target.value || null)}
+    />
+  ),
+}))
+
+import { SupplierInvoiceFormDialog } from "./supplier-invoice-form-dialog.js"
+
+function setNativeInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set
+  setter?.call(input, value)
+  input.dispatchEvent(new Event("input", { bubbles: true }))
+  input.dispatchEvent(new Event("change", { bubbles: true }))
+}
+
+describe("SupplierInvoiceFormDialog", () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    testState.createMutate.mockReset()
+    testState.updateMutate.mockReset()
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it("creates a draft supplier invoice with an initial line from the entered total", async () => {
+    await act(async () => {
+      root.render(
+        <SupplierInvoiceFormDialog open onOpenChange={() => {}} searchProducts={async () => []} />,
+      )
+    })
+
+    const inputs = container.querySelectorAll<HTMLInputElement>("input")
+    await act(async () => {
+      setNativeInputValue(inputs[0]!, "SUP-2026-001")
+      setNativeInputValue(inputs[1]!, "sup_123")
+      setNativeInputValue(inputs[3]!, "2026-06-01")
+      setNativeInputValue(inputs[6]!, "125.50")
+    })
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("button")!.click()
+    })
+
+    expect(testState.createMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "draft",
+        supplierInvoiceNo: "SUP-2026-001",
+        totalCents: 12550,
+        lines: [
+          expect.objectContaining({
+            description: "SUP-2026-001",
+            unitAmountCents: 12550,
+            taxAmountCents: 0,
+            totalAmountCents: 12550,
+          }),
+        ],
+      }),
+      expect.anything(),
+    )
+  })
+
+  it("blocks negative create totals before mutation", async () => {
+    await act(async () => {
+      root.render(
+        <SupplierInvoiceFormDialog open onOpenChange={() => {}} searchProducts={async () => []} />,
+      )
+    })
+
+    const inputs = container.querySelectorAll<HTMLInputElement>("input")
+    await act(async () => {
+      setNativeInputValue(inputs[0]!, "SUP-2026-001")
+      setNativeInputValue(inputs[1]!, "sup_123")
+      setNativeInputValue(inputs[3]!, "2026-06-01")
+      setNativeInputValue(inputs[6]!, "-1")
+    })
+
+    const save = container.querySelector<HTMLButtonElement>("button")!
+    expect(save.disabled).toBe(true)
+
+    await act(async () => {
+      save.click()
+    })
+
+    expect(testState.createMutate).not.toHaveBeenCalled()
+  })
+})

--- a/packages/finance-react/src/components/supplier-invoice-form-dialog.tsx
+++ b/packages/finance-react/src/components/supplier-invoice-form-dialog.tsx
@@ -28,6 +28,7 @@ import {
   useSupplierInvoiceMutation,
 } from "../index.js"
 import { AsyncCombobox, type AsyncComboboxOption } from "./async-combobox.js"
+import { parseNonNegativeCents } from "./supplier-invoice-detail-page/shared.js"
 
 const STATUS_ORDER: SupplierInvoiceStatus[] = [
   "draft",
@@ -113,7 +114,7 @@ function seed(invoice?: SupplierInvoiceRecord): FormState {
   return {
     supplierInvoiceNo: invoice?.supplierInvoiceNo ?? "",
     supplierId: invoice?.supplierId ?? "",
-    status: invoice?.status ?? "received",
+    status: invoice?.status ?? "draft",
     currency: invoice?.currency ?? "EUR",
     issueDate: invoice?.issueDate ?? "",
     dueDate: invoice?.dueDate ?? "",
@@ -123,12 +124,6 @@ function seed(invoice?: SupplierInvoiceRecord): FormState {
     departureId: "",
     total: "",
   }
-}
-
-/** Parse a major-unit amount string ("1250.00") to integer cents. */
-function toCents(major: string): number {
-  const n = Number.parseFloat(major)
-  return Number.isFinite(n) ? Math.round(n * 100) : 0
 }
 
 export function SupplierInvoiceFormDialog({
@@ -181,7 +176,16 @@ export function SupplierInvoiceFormDialog({
 
   const set = (patch: Partial<FormState>) => setForm((prev) => ({ ...prev, ...patch }))
 
-  const canSave = form.supplierInvoiceNo.trim() && form.supplierId.trim() && form.issueDate
+  const totalCents = parseNonNegativeCents(form.total)
+  const hasTotal = form.total.trim().length > 0
+  const totalValid = !hasTotal || totalCents != null
+  const allocationNeedsTotal = !isEdit && Boolean(form.productId || form.departureId)
+  const canSave =
+    form.supplierInvoiceNo.trim() &&
+    form.supplierId.trim() &&
+    form.issueDate &&
+    totalValid &&
+    (!allocationNeedsTotal || totalCents != null)
 
   const submit = () => {
     if (!canSave) return
@@ -207,13 +211,12 @@ export function SupplierInvoiceFormDialog({
     } else {
       // Attribute the whole invoice to the picked departure (or, failing that,
       // product) as a single manual cost allocation, seeded with the total.
-      const totalCents = toCents(form.total)
       const allocations = form.departureId
         ? [
             {
               targetType: "departure" as const,
               departureId: form.departureId,
-              amountCents: totalCents,
+              amountCents: totalCents ?? 0,
               splitMethod: "manual" as const,
             },
           ]
@@ -222,15 +225,28 @@ export function SupplierInvoiceFormDialog({
               {
                 targetType: "product" as const,
                 productId: form.productId,
-                amountCents: totalCents,
+                amountCents: totalCents ?? 0,
                 splitMethod: "manual" as const,
+              },
+            ]
+          : undefined
+      const lines =
+        totalCents != null
+          ? [
+              {
+                description: form.supplierInvoiceNo.trim(),
+                serviceType: "other" as const,
+                quantity: 1,
+                unitAmountCents: totalCents,
+                taxAmountCents: 0,
+                totalAmountCents: totalCents,
               },
             ]
           : undefined
       create.mutate(
         {
           ...payload,
-          ...(form.total ? { totalCents } : {}),
+          ...(totalCents != null ? { totalCents, lines } : {}),
           ...(allocations ? { allocations } : {}),
         },
         { onSuccess: (row) => row && onDone(row.id) },
@@ -359,6 +375,7 @@ export function SupplierInvoiceFormDialog({
               >
                 <Input
                   inputMode="decimal"
+                  min="0"
                   value={form.total}
                   onChange={(e) => set({ total: e.target.value })}
                 />


### PR DESCRIPTION
Fixes #2580

## Summary
- disable invoice deletion when the API would reject non-draft invoices and replace blocking prompts with app-native dialogs
- default supplier invoice creation to draft and seed an initial AP line from the entered total
- block negative AP line, allocation, payment, and create-total amounts client-side

## Verification
- pnpm --filter @voyant-travel/finance-react test -- supplier-invoice-form-dialog.test.tsx
- pnpm --filter @voyant-travel/finance-react typecheck
- pnpm exec biome check packages/finance-react/src/admin/invoice-detail-host.tsx packages/finance-react/src/components/supplier-invoice-form-dialog.tsx packages/finance-react/src/components/supplier-invoice-detail-page/dialogs.tsx packages/finance-react/src/components/supplier-invoice-detail-page/shared.tsx packages/finance-react/src/components/supplier-invoice-form-dialog.test.tsx
- git diff --check