### PR TITLE
Fix booking payment link checkout provider handling

### DIFF
--- a/.changeset/payment-link-checkout-provider.md
+++ b/.changeset/payment-link-checkout-provider.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/finance": patch
+"@voyant-travel/finance-react": patch
+---
+
+Show a clear checkout-provider configuration error when payment-link generation is attempted without a registered checkout runtime, and label the booking payment-link full-amount selector with user-facing copy instead of its internal sentinel.

--- a/packages/finance-react/src/checkout-components/collect-payment-dialog.test.tsx
+++ b/packages/finance-react/src/checkout-components/collect-payment-dialog.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const hookMocks = vi.hoisted(() => ({
+  useBookingPaymentSchedules: vi.fn(),
+  useCheckoutPaymentLinkConfig: vi.fn(),
+  useCollectPayment: vi.fn(),
+}))
+
+vi.mock("../hooks/use-booking-payment-schedules.js", () => ({
+  useBookingPaymentSchedules: hookMocks.useBookingPaymentSchedules,
+}))
+
+vi.mock("../checkout-hooks/index.js", () => ({
+  useCheckoutPaymentLinkConfig: hookMocks.useCheckoutPaymentLinkConfig,
+  useCollectPayment: hookMocks.useCollectPayment,
+}))
+
+import { CollectPaymentDialog } from "./collect-payment-dialog.js"
+
+;(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
+
+describe("CollectPaymentDialog", () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+    hookMocks.useBookingPaymentSchedules.mockReturnValue({
+      data: {
+        data: [
+          {
+            id: "bps_123",
+            bookingId: "book_123",
+            bookingItemId: null,
+            scheduleType: "deposit",
+            status: "pending",
+            dueDate: "2026-07-15",
+            currency: "EUR",
+            amountCents: 5000,
+            notes: null,
+            createdAt: "2026-07-01T00:00:00.000Z",
+            updatedAt: "2026-07-01T00:00:00.000Z",
+          },
+        ],
+      },
+    })
+    hookMocks.useCheckoutPaymentLinkConfig.mockReturnValue({ data: null })
+    hookMocks.useCollectPayment.mockReturnValue({
+      isPending: false,
+      mutateAsync: vi.fn(),
+      reset: vi.fn(),
+    })
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    vi.clearAllMocks()
+  })
+
+  it("labels the full-amount charge option instead of exposing its sentinel value", async () => {
+    await act(async () => {
+      root.render(
+        <CollectPaymentDialog
+          open
+          onOpenChange={() => {}}
+          bookingId="book_123"
+          defaultCurrency="EUR"
+          defaultAmountCents={12345}
+        />,
+      )
+    })
+
+    expect(document.body.textContent).toContain("Full amount")
+    expect(document.body.textContent).not.toContain("__full__")
+  })
+})

--- a/packages/finance-react/src/checkout-components/collect-payment-dialog.tsx
+++ b/packages/finance-react/src/checkout-components/collect-payment-dialog.tsx
@@ -93,6 +93,9 @@ export function CollectPaymentDialog({
   const [scheduleId, setScheduleId] = useState<string>(FULL_AMOUNT_VALUE)
   const [currency, setCurrency] = useState<string>(defaultCurrency)
   const [result, setResult] = useState<InitiatedCheckoutCollectionRecord | null>(null)
+  const fullAmountLabel = formatMessage(messages.scheduleFullAmount, {
+    amount: formatAmount(defaultAmountCents ?? 0, defaultCurrency),
+  })
 
   const schedulesQuery = useBookingPaymentSchedules(bookingId, { enabled: open })
   // Only the open schedules are useful pre-fills. Paid / waived /
@@ -131,6 +134,21 @@ export function CollectPaymentDialog({
     setCurrency(defaultCurrency)
     setResult(null)
     collect.reset()
+  }
+
+  function selectSchedule(next: string) {
+    setScheduleId(next)
+    if (next === FULL_AMOUNT_VALUE) {
+      setAmountCents(defaultAmountCents ?? 0)
+      setCurrency(defaultCurrency)
+      return
+    }
+
+    const schedule = schedules.find((s) => s.id === next)
+    if (schedule) {
+      setAmountCents(schedule.amountCents)
+      setCurrency(schedule.currency)
+    }
   }
 
   async function submit() {
@@ -173,22 +191,13 @@ export function CollectPaymentDialog({
                 <div className="flex items-center gap-2">
                   <Select
                     value={scheduleId}
-                    onValueChange={(v) => {
-                      const next = v ?? FULL_AMOUNT_VALUE
-                      setScheduleId(next)
-                      if (next !== FULL_AMOUNT_VALUE) {
-                        const schedule = schedules.find((s) => s.id === next)
-                        if (schedule) {
-                          setAmountCents(schedule.amountCents)
-                          setCurrency(schedule.currency)
-                        }
-                      }
-                    }}
+                    onValueChange={(v) => selectSchedule(v ?? FULL_AMOUNT_VALUE)}
                   >
                     <SelectTrigger id="collect-schedule" className="w-full">
                       <SelectValue placeholder={messages.scheduleCustomPlaceholder} />
                     </SelectTrigger>
                     <SelectContent>
+                      <SelectItem value={FULL_AMOUNT_VALUE}>{fullAmountLabel}</SelectItem>
                       {schedules.map((schedule) => (
                         <SelectItem key={schedule.id} value={schedule.id}>
                           {formatScheduleOption(schedule, messages.scheduleTypeLabels)}

--- a/packages/finance/src/checkout-routes.ts
+++ b/packages/finance/src/checkout-routes.ts
@@ -82,6 +82,14 @@ export type CheckoutRouteRuntime = {
 }
 
 export const CHECKOUT_ROUTE_RUNTIME_CONTAINER_KEY = "providers.finance.checkout.runtime"
+export const CHECKOUT_ROUTE_RUNTIME_NOT_CONFIGURED_MESSAGE =
+  "Checkout payment links require a configured checkout provider. Configure a Finance checkout runtime with a card payment starter before generating payment links."
+
+class CheckoutRouteRuntimeNotConfiguredError extends Error {
+  constructor() {
+    super(CHECKOUT_ROUTE_RUNTIME_NOT_CONFIGURED_MESSAGE)
+  }
+}
 
 function runtimeEnv(c: { env: Record<string, unknown> }): Record<string, string | undefined> {
   return c.env as Record<string, string | undefined>
@@ -108,14 +116,10 @@ function attachCollectionRoutes<TEnv extends Env>(app: Hono<TEnv>, options: Chec
   // Pin the middleware to this module's Env so Hono doesn't intersect the
   // middleware's default VoyantBindings into the handlers' `c.env` type.
   const collectionIdempotency = () => idempotencyKey<Env["Bindings"], Env["Variables"]>()
-  function getRuntime(
-    bindings: Record<string, unknown>,
-    resolveFromContainer?: (key: string) => CheckoutRouteRuntime | undefined,
-  ) {
-    return (
-      resolveFromContainer?.(CHECKOUT_ROUTE_RUNTIME_CONTAINER_KEY) ??
-      buildCheckoutRouteRuntime(bindings, options)
-    )
+  function getRuntime(bindings: Record<string, unknown>, container?: ModuleContainer) {
+    return resolveCheckoutRouteRuntime(bindings, options, container, {
+      requireRegisteredRuntime: true,
+    })
   }
 
   return (
@@ -145,7 +149,7 @@ function attachCollectionRoutes<TEnv extends Env>(app: Hono<TEnv>, options: Chec
       })
       .post("/bookings/:bookingId/initiate-collection", collectionIdempotency(), async (c) => {
         try {
-          const runtime = getRuntime(c.env, (key) => c.var.container?.resolve(key))
+          const runtime = getRuntime(c.env, c.var.container)
           const result = await initiateCheckoutCollection(
             c.get("db"),
             c.req.param("bookingId")!,
@@ -165,12 +169,15 @@ function attachCollectionRoutes<TEnv extends Env>(app: Hono<TEnv>, options: Chec
           if (message.includes("Booking not found")) {
             return c.json({ error: message }, 404)
           }
+          if (error instanceof CheckoutRouteRuntimeNotConfiguredError) {
+            return c.json({ error: message }, 501)
+          }
           return c.json({ error: message }, 409)
         }
       })
       .post("/collections/bootstrap", collectionIdempotency(), async (c) => {
         try {
-          const runtime = getRuntime(c.env, (key) => c.var.container?.resolve(key))
+          const runtime = getRuntime(c.env, c.var.container)
           const result = await bootstrapCheckoutCollection(
             c.get("db"),
             await parseJsonBody(c, bootstrapCheckoutCollectionSchema),
@@ -189,6 +196,9 @@ function attachCollectionRoutes<TEnv extends Env>(app: Hono<TEnv>, options: Chec
           if (message.includes("Booking not found")) {
             return c.json({ error: message }, 404)
           }
+          if (error instanceof CheckoutRouteRuntimeNotConfiguredError) {
+            return c.json({ error: message }, 501)
+          }
           return c.json({ error: message }, 409)
         }
       })
@@ -205,9 +215,7 @@ export function createCheckoutRoutes(options: CheckoutRoutesOptions = {}) {
 export function createCheckoutAdminRoutes(options: CheckoutRoutesOptions = {}) {
   const app = new Hono<Env>().get("/bookings/:bookingId/reminder-runs", async (c) => {
     const query = parseQuery(c, checkoutReminderRunListQuerySchema)
-    const runtime =
-      c.var.container?.resolve<CheckoutRouteRuntime>(CHECKOUT_ROUTE_RUNTIME_CONTAINER_KEY) ??
-      buildCheckoutRouteRuntime(c.env, options)
+    const runtime = resolveCheckoutRouteRuntime(c.env, options, c.var.container)
 
     if (!runtime.listBookingReminderRuns) {
       return c.json({ data: [], total: 0, limit: query.limit, offset: query.offset })
@@ -218,6 +226,23 @@ export function createCheckoutAdminRoutes(options: CheckoutRoutesOptions = {}) {
     )
   })
   return attachCollectionRoutes(app, options)
+}
+
+function resolveCheckoutRouteRuntime(
+  bindings: Record<string, unknown>,
+  options: CheckoutRoutesOptions,
+  container?: ModuleContainer,
+  opts: { requireRegisteredRuntime?: boolean } = {},
+): CheckoutRouteRuntime {
+  if (container?.has(CHECKOUT_ROUTE_RUNTIME_CONTAINER_KEY)) {
+    return container.resolve<CheckoutRouteRuntime>(CHECKOUT_ROUTE_RUNTIME_CONTAINER_KEY)
+  }
+
+  const runtime = buildCheckoutRouteRuntime(bindings, options)
+  if (opts.requireRegisteredRuntime && Object.keys(runtime.paymentStarters).length === 0) {
+    throw new CheckoutRouteRuntimeNotConfiguredError()
+  }
+  return runtime
 }
 
 export function buildCheckoutRouteRuntime(

--- a/packages/finance/src/checkout-routes.ts
+++ b/packages/finance/src/checkout-routes.ts
@@ -116,9 +116,13 @@ function attachCollectionRoutes<TEnv extends Env>(app: Hono<TEnv>, options: Chec
   // Pin the middleware to this module's Env so Hono doesn't intersect the
   // middleware's default VoyantBindings into the handlers' `c.env` type.
   const collectionIdempotency = () => idempotencyKey<Env["Bindings"], Env["Variables"]>()
-  function getRuntime(bindings: Record<string, unknown>, container?: ModuleContainer) {
+  function getRuntime(
+    bindings: Record<string, unknown>,
+    container: ModuleContainer | undefined,
+    opts: { requirePaymentStarter: boolean },
+  ) {
     return resolveCheckoutRouteRuntime(bindings, options, container, {
-      requireRegisteredRuntime: true,
+      requirePaymentStarter: opts.requirePaymentStarter,
     })
   }
 
@@ -149,11 +153,14 @@ function attachCollectionRoutes<TEnv extends Env>(app: Hono<TEnv>, options: Chec
       })
       .post("/bookings/:bookingId/initiate-collection", collectionIdempotency(), async (c) => {
         try {
-          const runtime = getRuntime(c.env, c.var.container)
+          const input = await parseJsonBody(c, initiateCheckoutCollectionSchema)
+          const runtime = getRuntime(c.env, c.var.container, {
+            requirePaymentStarter: input.method === "card",
+          })
           const result = await initiateCheckoutCollection(
             c.get("db"),
             c.req.param("bookingId")!,
-            await parseJsonBody(c, initiateCheckoutCollectionSchema),
+            input,
             options.policy,
             runtime,
           )
@@ -177,10 +184,13 @@ function attachCollectionRoutes<TEnv extends Env>(app: Hono<TEnv>, options: Chec
       })
       .post("/collections/bootstrap", collectionIdempotency(), async (c) => {
         try {
-          const runtime = getRuntime(c.env, c.var.container)
+          const input = await parseJsonBody(c, bootstrapCheckoutCollectionSchema)
+          const runtime = getRuntime(c.env, c.var.container, {
+            requirePaymentStarter: input.method === "card",
+          })
           const result = await bootstrapCheckoutCollection(
             c.get("db"),
-            await parseJsonBody(c, bootstrapCheckoutCollectionSchema),
+            input,
             options.policy,
             runtime,
           )
@@ -232,14 +242,16 @@ function resolveCheckoutRouteRuntime(
   bindings: Record<string, unknown>,
   options: CheckoutRoutesOptions,
   container?: ModuleContainer,
-  opts: { requireRegisteredRuntime?: boolean } = {},
+  opts: { requirePaymentStarter?: boolean } = {},
 ): CheckoutRouteRuntime {
+  let runtime: CheckoutRouteRuntime
   if (container?.has(CHECKOUT_ROUTE_RUNTIME_CONTAINER_KEY)) {
-    return container.resolve<CheckoutRouteRuntime>(CHECKOUT_ROUTE_RUNTIME_CONTAINER_KEY)
+    runtime = container.resolve<CheckoutRouteRuntime>(CHECKOUT_ROUTE_RUNTIME_CONTAINER_KEY)
+  } else {
+    runtime = buildCheckoutRouteRuntime(bindings, options)
   }
 
-  const runtime = buildCheckoutRouteRuntime(bindings, options)
-  if (opts.requireRegisteredRuntime && Object.keys(runtime.paymentStarters).length === 0) {
+  if (opts.requirePaymentStarter && Object.keys(runtime.paymentStarters).length === 0) {
     throw new CheckoutRouteRuntimeNotConfiguredError()
   }
   return runtime

--- a/packages/finance/src/checkout-routes.ts
+++ b/packages/finance/src/checkout-routes.ts
@@ -116,14 +116,8 @@ function attachCollectionRoutes<TEnv extends Env>(app: Hono<TEnv>, options: Chec
   // Pin the middleware to this module's Env so Hono doesn't intersect the
   // middleware's default VoyantBindings into the handlers' `c.env` type.
   const collectionIdempotency = () => idempotencyKey<Env["Bindings"], Env["Variables"]>()
-  function getRuntime(
-    bindings: Record<string, unknown>,
-    container: ModuleContainer | undefined,
-    opts: { requirePaymentStarter: boolean },
-  ) {
-    return resolveCheckoutRouteRuntime(bindings, options, container, {
-      requirePaymentStarter: opts.requirePaymentStarter,
-    })
+  function getRuntime(bindings: Record<string, unknown>, container?: ModuleContainer) {
+    return resolveCheckoutRouteRuntime(bindings, options, container)
   }
 
   return (
@@ -154,9 +148,8 @@ function attachCollectionRoutes<TEnv extends Env>(app: Hono<TEnv>, options: Chec
       .post("/bookings/:bookingId/initiate-collection", collectionIdempotency(), async (c) => {
         try {
           const input = await parseJsonBody(c, initiateCheckoutCollectionSchema)
-          const runtime = getRuntime(c.env, c.var.container, {
-            requirePaymentStarter: input.method === "card",
-          })
+          const runtime = getRuntime(c.env, c.var.container)
+          assertCheckoutRuntimeSupportsCollection(runtime, input)
           const result = await initiateCheckoutCollection(
             c.get("db"),
             c.req.param("bookingId")!,
@@ -185,9 +178,8 @@ function attachCollectionRoutes<TEnv extends Env>(app: Hono<TEnv>, options: Chec
       .post("/collections/bootstrap", collectionIdempotency(), async (c) => {
         try {
           const input = await parseJsonBody(c, bootstrapCheckoutCollectionSchema)
-          const runtime = getRuntime(c.env, c.var.container, {
-            requirePaymentStarter: input.method === "card",
-          })
+          const runtime = getRuntime(c.env, c.var.container)
+          assertCheckoutRuntimeSupportsCollection(runtime, input)
           const result = await bootstrapCheckoutCollection(
             c.get("db"),
             input,
@@ -242,19 +234,21 @@ function resolveCheckoutRouteRuntime(
   bindings: Record<string, unknown>,
   options: CheckoutRoutesOptions,
   container?: ModuleContainer,
-  opts: { requirePaymentStarter?: boolean } = {},
 ): CheckoutRouteRuntime {
-  let runtime: CheckoutRouteRuntime
   if (container?.has(CHECKOUT_ROUTE_RUNTIME_CONTAINER_KEY)) {
-    runtime = container.resolve<CheckoutRouteRuntime>(CHECKOUT_ROUTE_RUNTIME_CONTAINER_KEY)
-  } else {
-    runtime = buildCheckoutRouteRuntime(bindings, options)
+    return container.resolve<CheckoutRouteRuntime>(CHECKOUT_ROUTE_RUNTIME_CONTAINER_KEY)
   }
 
-  if (opts.requirePaymentStarter && Object.keys(runtime.paymentStarters).length === 0) {
+  return buildCheckoutRouteRuntime(bindings, options)
+}
+
+function assertCheckoutRuntimeSupportsCollection(
+  runtime: CheckoutRouteRuntime,
+  input: { method: "card" | "bank_transfer" },
+) {
+  if (input.method === "card" && Object.keys(runtime.paymentStarters).length === 0) {
     throw new CheckoutRouteRuntimeNotConfiguredError()
   }
-  return runtime
 }
 
 export function buildCheckoutRouteRuntime(

--- a/packages/finance/tests/unit/checkout-routes.test.ts
+++ b/packages/finance/tests/unit/checkout-routes.test.ts
@@ -2,6 +2,7 @@ import {
   issueCheckoutCapability,
   issueGuestBookingAccess,
 } from "@voyant-travel/bookings/checkout-capability"
+import { createContainer } from "@voyant-travel/core"
 import { handleApiError } from "@voyant-travel/hono"
 import { Hono } from "hono"
 import { beforeEach, describe, expect, it, vi } from "vitest"
@@ -19,6 +20,7 @@ vi.mock("../../src/checkout-service.js", () => ({
 }))
 
 import {
+  CHECKOUT_ROUTE_RUNTIME_NOT_CONFIGURED_MESSAGE,
   createFinanceCheckoutAdminRoutes,
   createFinanceCheckoutRoutes,
 } from "../../src/checkout-routes.js"
@@ -131,6 +133,38 @@ describe("createFinanceCheckoutRoutes", () => {
       publicCheckoutBaseUrl: "https://brand.example.com",
     })
     expect(runtime.paymentStarters.netopia).toBe(paymentStarter)
+  })
+
+  it("returns setup guidance when the checkout runtime provider is not registered", async () => {
+    const routes = createFinanceCheckoutAdminRoutes()
+    const app = new Hono()
+    app.onError(handleApiError)
+    app.use("*", async (c, next) => {
+      c.set("db", {} as never)
+      c.set("container", createContainer())
+      await next()
+    })
+    app.route("/", routes)
+
+    const res = await app.request(
+      "/bookings/book_123/initiate-collection",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json", ...(await capabilityHeaders()) },
+        body: JSON.stringify({
+          method: "card",
+          stage: "manual",
+          amountCents: 12345,
+          ensureDefaultPaymentPlan: true,
+          paymentSession: { provider: "netopia" },
+        }),
+      },
+      TEST_CAPABILITY_ENV,
+    )
+
+    expect(res.status).toBe(501)
+    expect(await res.json()).toEqual({ error: CHECKOUT_ROUTE_RUNTIME_NOT_CONFIGURED_MESSAGE })
+    expect(serviceMocks.initiateCheckoutCollection).not.toHaveBeenCalled()
   })
 
   it("rejects booking collection routes without a checkout capability", async () => {

--- a/packages/finance/tests/unit/checkout-routes.test.ts
+++ b/packages/finance/tests/unit/checkout-routes.test.ts
@@ -20,6 +20,7 @@ vi.mock("../../src/checkout-service.js", () => ({
 }))
 
 import {
+  CHECKOUT_ROUTE_RUNTIME_CONTAINER_KEY,
   CHECKOUT_ROUTE_RUNTIME_NOT_CONFIGURED_MESSAGE,
   createFinanceCheckoutAdminRoutes,
   createFinanceCheckoutRoutes,
@@ -165,6 +166,107 @@ describe("createFinanceCheckoutRoutes", () => {
     expect(res.status).toBe(501)
     expect(await res.json()).toEqual({ error: CHECKOUT_ROUTE_RUNTIME_NOT_CONFIGURED_MESSAGE })
     expect(serviceMocks.initiateCheckoutCollection).not.toHaveBeenCalled()
+  })
+
+  it("returns setup guidance when the registered checkout runtime has no card starters", async () => {
+    const routes = createFinanceCheckoutAdminRoutes()
+    const container = createContainer()
+    container.register(CHECKOUT_ROUTE_RUNTIME_CONTAINER_KEY, {
+      bindings: {},
+      notificationDispatcher: null,
+      paymentStarters: {},
+      bankTransferDetails: null,
+    })
+    const app = new Hono()
+    app.onError(handleApiError)
+    app.use("*", async (c, next) => {
+      c.set("db", {} as never)
+      c.set("container", container)
+      await next()
+    })
+    app.route("/", routes)
+
+    const res = await app.request(
+      "/bookings/book_123/initiate-collection",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json", ...(await capabilityHeaders()) },
+        body: JSON.stringify({
+          method: "card",
+          stage: "manual",
+          amountCents: 12345,
+          ensureDefaultPaymentPlan: true,
+          paymentSession: { provider: "netopia" },
+        }),
+      },
+      TEST_CAPABILITY_ENV,
+    )
+
+    expect(res.status).toBe(501)
+    expect(await res.json()).toEqual({ error: CHECKOUT_ROUTE_RUNTIME_NOT_CONFIGURED_MESSAGE })
+    expect(serviceMocks.initiateCheckoutCollection).not.toHaveBeenCalled()
+  })
+
+  it("allows bank-transfer collection when no card starter is configured", async () => {
+    serviceMocks.initiateCheckoutCollection.mockResolvedValue({
+      plan: {
+        bookingId: "book_123",
+        method: "bank_transfer",
+        stage: "manual",
+        paymentSessionTarget: "invoice",
+        documentType: "invoice",
+        willCreateDefaultPaymentPlan: false,
+        selectedSchedule: null,
+        selectedInvoice: null,
+        amountCents: 12345,
+        currency: "EUR",
+        recommendedAction: "create_bank_transfer_document",
+      },
+      invoice: null,
+      paymentSession: null,
+      invoiceNotification: null,
+      paymentSessionNotification: null,
+      bankTransferInstructions: {
+        provider: "manual",
+        beneficiary: "Program Travel",
+        iban: "RO49RNCB0857180852250001",
+        amountCents: 12345,
+        currency: "EUR",
+        reference: "BK-123",
+        notes: null,
+      },
+      providerStart: null,
+    })
+    const routes = createFinanceCheckoutAdminRoutes()
+    const app = new Hono()
+    app.onError(handleApiError)
+    app.use("*", async (c, next) => {
+      c.set("db", {} as never)
+      c.set("container", createContainer())
+      await next()
+    })
+    app.route("/", routes)
+
+    const res = await app.request(
+      "/bookings/book_123/initiate-collection",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json", ...(await capabilityHeaders()) },
+        body: JSON.stringify({
+          method: "bank_transfer",
+          stage: "manual",
+          amountCents: 12345,
+          ensureDefaultPaymentPlan: true,
+        }),
+      },
+      TEST_CAPABILITY_ENV,
+    )
+
+    expect(res.status).toBe(201)
+    expect(serviceMocks.initiateCheckoutCollection).toHaveBeenCalledTimes(1)
+    expect(serviceMocks.initiateCheckoutCollection.mock.calls[0]?.[4]).toMatchObject({
+      paymentStarters: {},
+    })
   })
 
   it("rejects booking collection routes without a checkout capability", async () => {


### PR DESCRIPTION
## Summary

- Adds a clear checkout-provider configuration response when booking payment-link generation is attempted without a registered Finance checkout runtime.
- Labels the booking payment-link charge selector's full-amount option with user-facing text instead of exposing the internal sentinel value.
- Adds focused regressions for the missing runtime response and full-amount selector label.

Fixes #2439

## Verification

- `pnpm --filter @voyant-travel/finance test -- checkout-routes.test.ts`
- `pnpm --filter @voyant-travel/finance-react test -- collect-payment-dialog.test.tsx`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/finance typecheck`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/finance-react typecheck`
- `pnpm lint:changed`
- `git diff --check`
- `pnpm verify:agent-quality:changed`

## Notes

The default-heap package typechecks OOMed locally; rerunning each touched package with `NODE_OPTIONS=--max-old-space-size=8192` passed. The commit/pre-push hooks were not usable end to end locally because they launched broad unrelated affected checks: the commit hook hit existing build errors in unrelated `bookings-react`/`finance-react` pagination/button call sites plus several memory-killed tasks, and the pre-push full test hook hit a Vitest worker startup timeout in `@voyant-travel/hono`. The focused checks above passed after rebasing onto current `origin/main`.
