### PR TITLE
Fix booking payment invoice eligibility

### DIFF
--- a/.changeset/record-booking-payments-issued-invoices.md
+++ b/.changeset/record-booking-payments-issued-invoices.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/finance-react": patch
+---
+
+Fix booking finance payment recording so issued unpaid invoices remain selectable when draft or pending-allocation invoices also exist, and clear stale invoice creation validation as operators switch source or choose dates.

--- a/packages/finance-react/src/booking-invoice-dialog.test.tsx
+++ b/packages/finance-react/src/booking-invoice-dialog.test.tsx
@@ -15,6 +15,7 @@ const testState = vi.hoisted(() => ({
     scheduleType: string
   }>,
   schedulesLoading: false,
+  schedulesError: null as Error | null,
   createFromBookingAsync: vi.fn(async () => ({
     id: "inv_123",
     totalCents: 10000,
@@ -29,8 +30,11 @@ const testState = vi.hoisted(() => ({
 
 vi.mock("./index.js", () => ({
   useBookingPaymentSchedules: () => ({
-    data: { data: testState.schedules },
+    data: testState.schedulesError ? undefined : { data: testState.schedules },
     isLoading: testState.schedulesLoading,
+    isError: testState.schedulesError != null,
+    isSuccess: !testState.schedulesLoading && testState.schedulesError == null,
+    error: testState.schedulesError,
   }),
   useInvoiceMutation: () => ({
     createFromBooking: {
@@ -187,6 +191,7 @@ describe("BookingInvoiceDialog", () => {
   beforeEach(() => {
     testState.schedules = []
     testState.schedulesLoading = false
+    testState.schedulesError = null
     testState.createFromBookingAsync.mockClear()
     testState.fetcher.mockClear()
     container = document.createElement("div")
@@ -206,6 +211,23 @@ describe("BookingInvoiceDialog", () => {
 
     expect(container.textContent).toContain("Add line item")
     expect(container.textContent).not.toContain("No unpaid schedules available.")
+  })
+
+  it("does not default to custom invoices when schedule loading fails", async () => {
+    testState.schedulesError = new Error("Schedule API unavailable")
+
+    await act(async () => {
+      root.render(<BookingInvoiceDialog open onOpenChange={() => {}} bookingId="book_123" />)
+    })
+
+    expect(container.textContent).toContain("Schedule API unavailable")
+    expect(container.textContent).not.toContain("Add line item")
+
+    await act(async () => {
+      clickButton(container, "Create Invoice")
+    })
+
+    expect(testState.createFromBookingAsync).not.toHaveBeenCalled()
   })
 
   it("clears the schedule validation message when switching to custom", async () => {

--- a/packages/finance-react/src/booking-invoice-dialog.test.tsx
+++ b/packages/finance-react/src/booking-invoice-dialog.test.tsx
@@ -1,0 +1,256 @@
+// @vitest-environment jsdom
+
+import type * as ReactTypes from "react"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const testState = vi.hoisted(() => ({
+  schedules: [] as Array<{
+    id: string
+    status: string
+    amountCents: number
+    currency: string
+    dueDate: string
+    scheduleType: string
+  }>,
+  schedulesLoading: false,
+  createFromBookingAsync: vi.fn(async () => ({
+    id: "inv_123",
+    totalCents: 10000,
+    currency: "EUR",
+  })),
+  fetcher: vi.fn(async () => ({ ok: true })),
+}))
+
+;(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock("./index.js", () => ({
+  useBookingPaymentSchedules: () => ({
+    data: { data: testState.schedules },
+    isLoading: testState.schedulesLoading,
+  }),
+  useInvoiceMutation: () => ({
+    createFromBooking: {
+      isPending: false,
+      mutateAsync: testState.createFromBookingAsync,
+    },
+  }),
+  useVoyantFinanceContext: () => ({
+    baseUrl: "",
+    fetcher: testState.fetcher,
+  }),
+}))
+
+vi.mock("@voyant-travel/ui/components", async () => {
+  return {
+    Button: ({ children, ...props }: ReactTypes.ButtonHTMLAttributes<HTMLButtonElement>) => (
+      <button {...props}>{children}</button>
+    ),
+    Dialog: ({
+      children,
+      open,
+    }: {
+      children: ReactTypes.ReactNode
+      open?: boolean
+      onOpenChange?: (open: boolean) => void
+    }) => (open ? <div>{children}</div> : null),
+    DialogContent: ({ children }: { children: ReactTypes.ReactNode }) => <div>{children}</div>,
+    DialogDescription: ({ children }: { children: ReactTypes.ReactNode }) => <p>{children}</p>,
+    DialogHeader: ({ children }: { children: ReactTypes.ReactNode }) => <div>{children}</div>,
+    DialogTitle: ({ children }: { children: ReactTypes.ReactNode }) => <h2>{children}</h2>,
+    Input: (props: ReactTypes.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+    Label: ({ children }: ReactTypes.LabelHTMLAttributes<HTMLLabelElement>) => (
+      <span>{children}</span>
+    ),
+    Select: ({
+      children,
+      onValueChange,
+      value,
+    }: {
+      children: ReactTypes.ReactNode
+      onValueChange?: (value: string) => void
+      value?: string
+    }) => (
+      <select value={value ?? ""} onChange={(event) => onValueChange?.(event.target.value)}>
+        {children}
+      </select>
+    ),
+    SelectContent: ({ children }: { children: ReactTypes.ReactNode }) => <>{children}</>,
+    SelectItem: ({ children, value }: { children: ReactTypes.ReactNode; value: string }) => (
+      <option value={value}>{children}</option>
+    ),
+    SelectTrigger: () => null,
+    SelectValue: () => null,
+    Switch: ({
+      checked,
+      onCheckedChange,
+    }: {
+      checked?: boolean
+      onCheckedChange?: (next: boolean) => void
+    }) => (
+      <input
+        type="checkbox"
+        checked={checked ?? false}
+        onChange={(event) => onCheckedChange?.(event.target.checked)}
+      />
+    ),
+    Textarea: (props: ReactTypes.TextareaHTMLAttributes<HTMLTextAreaElement>) => (
+      <textarea {...props} />
+    ),
+  }
+})
+
+vi.mock("@voyant-travel/ui/components/currency-combobox", () => ({
+  CurrencyCombobox: ({
+    disabled,
+    onChange,
+    value,
+  }: {
+    disabled?: boolean
+    onChange: (value: string | null) => void
+    value: string | null | undefined
+  }) => (
+    <select
+      aria-label="Currency"
+      disabled={disabled}
+      value={value ?? ""}
+      onChange={(event) => onChange(event.target.value || null)}
+    >
+      <option value="EUR">EUR</option>
+      <option value="RON">RON</option>
+    </select>
+  ),
+}))
+
+vi.mock("@voyant-travel/ui/components/currency-input", () => ({
+  CurrencyInput: ({
+    disabled,
+    onChange,
+    value,
+  }: {
+    disabled?: boolean
+    onChange: (value: number | null) => void
+    value: number | null | undefined
+  }) => (
+    <input
+      disabled={disabled}
+      value={value == null ? "" : String(value / 100)}
+      onChange={(event) => onChange(Math.round(Number(event.target.value) * 100))}
+    />
+  ),
+}))
+
+vi.mock("@voyant-travel/ui/components/date-picker", () => ({
+  DatePicker: ({
+    disabled,
+    onChange,
+    placeholder,
+    value,
+  }: {
+    disabled?: boolean
+    onChange: (value: string | null) => void
+    placeholder?: string
+    value: string | null | undefined
+  }) => (
+    <input
+      aria-label={placeholder}
+      disabled={disabled}
+      value={value ?? ""}
+      onChange={(event) => onChange(event.target.value || null)}
+    />
+  ),
+}))
+
+import { BookingInvoiceDialog } from "./components/booking-invoice-dialog.js"
+
+function clickButton(container: HTMLElement, text: string) {
+  const button = Array.from(container.querySelectorAll("button")).find(
+    (candidate) => candidate.textContent === text,
+  )
+  if (!button) throw new Error(`Button not found: ${text}`)
+  button.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+}
+
+function setNativeInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set
+  setter?.call(input, value)
+  input.dispatchEvent(new Event("input", { bubbles: true }))
+}
+
+describe("BookingInvoiceDialog", () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    testState.schedules = []
+    testState.schedulesLoading = false
+    testState.createFromBookingAsync.mockClear()
+    testState.fetcher.mockClear()
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it("defaults to custom invoices when no unpaid schedule is eligible", async () => {
+    await act(async () => {
+      root.render(<BookingInvoiceDialog open onOpenChange={() => {}} bookingId="book_123" />)
+    })
+
+    expect(container.textContent).toContain("Add line item")
+    expect(container.textContent).not.toContain("No unpaid schedules available.")
+  })
+
+  it("clears the schedule validation message when switching to custom", async () => {
+    testState.schedules = [
+      {
+        id: "sched_123",
+        status: "pending",
+        amountCents: 10000,
+        currency: "EUR",
+        dueDate: "2026-07-15",
+        scheduleType: "deposit",
+      },
+    ]
+
+    await act(async () => {
+      root.render(<BookingInvoiceDialog open onOpenChange={() => {}} bookingId="book_123" />)
+    })
+
+    await act(async () => {
+      clickButton(container, "Create Invoice")
+    })
+    expect(container.textContent).toContain("Select a payment schedule")
+
+    await act(async () => {
+      clickButton(container, "Custom")
+    })
+    expect(container.textContent).not.toContain("Select a payment schedule")
+  })
+
+  it("clears the due-date validation message after choosing a due date", async () => {
+    await act(async () => {
+      root.render(<BookingInvoiceDialog open onOpenChange={() => {}} bookingId="book_123" />)
+    })
+
+    await act(async () => {
+      clickButton(container, "Create Invoice")
+    })
+    expect(container.textContent).toContain("Due date is required")
+
+    await act(async () => {
+      const dueDate = container.querySelector<HTMLInputElement>('input[aria-label="Pick due date"]')
+      if (!dueDate) throw new Error("Due date input not found")
+      setNativeInputValue(dueDate, "2026-07-20")
+    })
+
+    expect(container.textContent).not.toContain("Due date is required")
+  })
+})

--- a/packages/finance-react/src/components/booking-invoice-dialog.tsx
+++ b/packages/finance-react/src/components/booking-invoice-dialog.tsx
@@ -207,6 +207,10 @@ export function BookingInvoiceDialog({
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  const clearError = useCallback(() => {
+    setError(null)
+  }, [])
+
   // ---- prefill / reset on open ---------------------------------------------
   useEffect(() => {
     if (!open) return
@@ -239,6 +243,15 @@ export function BookingInvoiceDialog({
       (schedulesQuery.data?.data ?? []).filter((s) => s.status === "pending" || s.status === "due"),
     [schedulesQuery.data],
   )
+
+  useEffect(() => {
+    if (!open || schedulesQuery.isLoading || unpaidSchedules.length > 0 || source !== "schedule") {
+      return
+    }
+    setSource("custom")
+    setScheduleId(null)
+    setError(null)
+  }, [open, schedulesQuery.isLoading, unpaidSchedules.length, source])
 
   // When the operator picks a schedule, lock the financial fields to it.
   // `useMemo` keeps the lookup cheap on every render.
@@ -486,6 +499,7 @@ export function BookingInvoiceDialog({
               <SegmentedChoice
                 value={source}
                 onChange={(next) => {
+                  clearError()
                   setSource(next)
                   if (next === "custom") setScheduleId(null)
                 }}
@@ -508,7 +522,10 @@ export function BookingInvoiceDialog({
                 <Label>{dialog.fields.schedule}</Label>
                 <Select
                   value={scheduleId ?? undefined}
-                  onValueChange={(v) => setScheduleId(v ?? null)}
+                  onValueChange={(v) => {
+                    clearError()
+                    setScheduleId(v ?? null)
+                  }}
                 >
                   <SelectTrigger className="w-full">
                     <SelectValue placeholder={dialog.schedulePlaceholder} />
@@ -751,7 +768,10 @@ export function BookingInvoiceDialog({
                 <Label>{dialog.fields.issueDate}</Label>
                 <DatePicker
                   value={issueDate || null}
-                  onChange={(next) => setIssueDate(next ?? "")}
+                  onChange={(next) => {
+                    clearError()
+                    setIssueDate(next ?? "")
+                  }}
                   placeholder={dialog.placeholders.issueDate}
                   className="w-full"
                 />
@@ -760,7 +780,10 @@ export function BookingInvoiceDialog({
                 <Label>{dialog.fields.dueDate}</Label>
                 <DatePicker
                   value={dueDate || null}
-                  onChange={(next) => setDueDate(next ?? "")}
+                  onChange={(next) => {
+                    clearError()
+                    setDueDate(next ?? "")
+                  }}
                   placeholder={dialog.placeholders.dueDate}
                   className="w-full"
                   disabled={scheduleLocked}

--- a/packages/finance-react/src/components/booking-invoice-dialog.tsx
+++ b/packages/finance-react/src/components/booking-invoice-dialog.tsx
@@ -243,15 +243,20 @@ export function BookingInvoiceDialog({
       (schedulesQuery.data?.data ?? []).filter((s) => s.status === "pending" || s.status === "due"),
     [schedulesQuery.data],
   )
+  const scheduleLoadError = schedulesQuery.isError
+    ? schedulesQuery.error instanceof Error
+      ? schedulesQuery.error.message
+      : dialog.scheduleLoadError
+    : null
 
   useEffect(() => {
-    if (!open || schedulesQuery.isLoading || unpaidSchedules.length > 0 || source !== "schedule") {
+    if (!open || !schedulesQuery.isSuccess || unpaidSchedules.length > 0 || source !== "schedule") {
       return
     }
     setSource("custom")
     setScheduleId(null)
     setError(null)
-  }, [open, schedulesQuery.isLoading, unpaidSchedules.length, source])
+  }, [open, schedulesQuery.isSuccess, unpaidSchedules.length, source])
 
   // When the operator picks a schedule, lock the financial fields to it.
   // `useMemo` keeps the lookup cheap on every render.
@@ -349,6 +354,10 @@ export function BookingInvoiceDialog({
     if (submitting) return
     setError(null)
 
+    if (source === "schedule" && scheduleLoadError) {
+      setError(scheduleLoadError)
+      return
+    }
     if (source === "schedule" && !selectedSchedule) {
       setError(dialog.schedulePlaceholder)
       return
@@ -470,6 +479,7 @@ export function BookingInvoiceDialog({
     linesDriveTotals,
     lineItems,
     dialog,
+    scheduleLoadError,
   ])
 
   // ---- render --------------------------------------------------------------
@@ -531,8 +541,10 @@ export function BookingInvoiceDialog({
                     <SelectValue placeholder={dialog.schedulePlaceholder} />
                   </SelectTrigger>
                   <SelectContent>
-                    {unpaidSchedules.length === 0 ? (
-                      <div className="px-3 py-2 text-sm text-muted-foreground">
+                    {scheduleLoadError ? (
+                      <div className="px-3 py-2 text-destructive text-sm">{scheduleLoadError}</div>
+                    ) : unpaidSchedules.length === 0 ? (
+                      <div className="px-3 py-2 text-muted-foreground text-sm">
                         {dialog.scheduleEmpty}
                       </div>
                     ) : (
@@ -547,6 +559,9 @@ export function BookingInvoiceDialog({
                 </Select>
                 {scheduleLocked ? (
                   <p className="text-xs text-muted-foreground">{dialog.scheduleLockedHint}</p>
+                ) : null}
+                {scheduleLoadError ? (
+                  <p className="text-destructive text-xs">{dialog.scheduleLoadError}</p>
                 ) : null}
               </div>
             ) : null}

--- a/packages/finance-react/src/components/record-booking-payment-dialog.tsx
+++ b/packages/finance-react/src/components/record-booking-payment-dialog.tsx
@@ -49,6 +49,8 @@ import {
   parseFxRate,
 } from "./record-booking-payment-dialog/shared.js"
 
+const PAYABLE_INVOICE_STATUSES = new Set(["issued", "partially_paid", "overdue"])
+
 export type {
   EditingPaymentSnapshot,
   RecordBookingPaymentDialogProps,
@@ -70,11 +72,14 @@ export function RecordBookingPaymentDialog({
 
   const invoicesQuery = useInvoices({ bookingId, enabled: open })
   const invoices = invoicesQuery.data?.data ?? []
-  // Operator records a payment AGAINST money still owed. Paid / voided
-  // invoices have no remaining balance to settle, so they don't belong
-  // in the picker — keep the surface focused on what's actionable.
+  // Operator records a payment against issued receivables still owed. Drafts
+  // and external-allocation placeholders are not payable yet, even when they
+  // carry a balance, so keep them out of the settlement picker.
   const selectableInvoices = invoices.filter(
-    (inv) => inv.status !== "void" && inv.balanceDueCents > 0,
+    (inv) => PAYABLE_INVOICE_STATUSES.has(inv.status) && inv.balanceDueCents > 0,
+  )
+  const hasExcludedInvoicesWithBalance = invoices.some(
+    (inv) => inv.balanceDueCents > 0 && !PAYABLE_INVOICE_STATUSES.has(inv.status),
   )
 
   const [state, setState] = React.useState<FormState>(() => buildInitialFormState(defaultCurrency))
@@ -286,6 +291,9 @@ export function RecordBookingPaymentDialog({
           <>
             <div className="px-6 py-6">
               <p className="text-sm text-muted-foreground">{dialog.noInvoices}</p>
+              {hasExcludedInvoicesWithBalance ? (
+                <p className="mt-2 text-xs text-muted-foreground">{dialog.payableStatusHint}</p>
+              ) : null}
             </div>
             <div className="flex items-center justify-end gap-2 px-6 pb-6">
               <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
@@ -334,6 +342,9 @@ export function RecordBookingPaymentDialog({
                     </SelectContent>
                   </Select>
                 )}
+                {hasExcludedInvoicesWithBalance ? (
+                  <p className="text-xs text-muted-foreground">{dialog.payableStatusHint}</p>
+                ) : null}
               </div>
 
               <div className="grid gap-4 sm:grid-cols-3">

--- a/packages/finance-react/src/i18n/en/invoices.ts
+++ b/packages/finance-react/src/i18n/en/invoices.ts
@@ -71,6 +71,7 @@ export const invoiceDialog = {
   },
   schedulePlaceholder: "Select a payment schedule",
   scheduleEmpty: "No unpaid schedules available.",
+  scheduleLoadError: "Could not load payment schedules. Try again before creating from schedule.",
   scheduleLockedHint: "Amounts, currency and due date are taken from the schedule.",
   attachmentsHint: "Attach supporting documents. Skipped when SmartBill sync is on.",
   invoiceNumberAutoHint: "SmartBill assigns the number from the next sequence on issue.",

--- a/packages/finance-react/src/i18n/en/numberingAndPayments.ts
+++ b/packages/finance-react/src/i18n/en/numberingAndPayments.ts
@@ -393,6 +393,8 @@ export const recordBookingPaymentDialog = {
   invoiceMeta: "Total {total} {currency} • paid {paid} {currency} • due {due} {currency}",
   loadingInvoices: "Loading invoices…",
   noInvoices: "No unpaid invoices on this booking.",
+  payableStatusHint:
+    "Payments can be recorded only against issued, partially paid, or overdue invoices with a positive balance. Draft and pending allocation invoices are excluded.",
   actions: {
     record: "Record payment",
     save: "Save changes",

--- a/packages/finance-react/src/i18n/messages/invoices.ts
+++ b/packages/finance-react/src/i18n/messages/invoices.ts
@@ -59,6 +59,7 @@ export type InvoiceDialogMessages = {
   }
   schedulePlaceholder: string
   scheduleEmpty: string
+  scheduleLoadError: string
   /** Description shown when source is "from schedule" — amounts are locked. */
   scheduleLockedHint: string
   attachmentsHint: string

--- a/packages/finance-react/src/i18n/messages/numberingAndPayments.ts
+++ b/packages/finance-react/src/i18n/messages/numberingAndPayments.ts
@@ -269,6 +269,8 @@ export type RecordBookingPaymentDialogMessages = {
   invoiceMeta: string
   loadingInvoices: string
   noInvoices: string
+  /** Explains why positive-balance draft / external-allocation rows are not payable here. */
+  payableStatusHint: string
   actions: {
     record: string
     save: string

--- a/packages/finance-react/src/i18n/ro/invoices.ts
+++ b/packages/finance-react/src/i18n/ro/invoices.ts
@@ -71,6 +71,8 @@ export const invoiceDialog = {
   },
   schedulePlaceholder: "Alege o linie din scadentar",
   scheduleEmpty: "Nu exista linii neplatite in scadentar.",
+  scheduleLoadError:
+    "Nu s-a putut incarca scadentarul. Incearca din nou inainte de a crea din scadentar.",
   scheduleLockedHint: "Sumele, moneda si data scadenta sunt preluate din scadentar.",
   attachmentsHint:
     "Ataseaza documente suport. Ignorate cand sincronizarea cu SmartBill este activa.",

--- a/packages/finance-react/src/i18n/ro/numberingAndPayments.ts
+++ b/packages/finance-react/src/i18n/ro/numberingAndPayments.ts
@@ -395,6 +395,8 @@ export const recordBookingPaymentDialog = {
   invoiceMeta: "Total {total} {currency} • platit {paid} {currency} • de incasat {due} {currency}",
   loadingInvoices: "Se incarca facturile…",
   noInvoices: "Nu exista facturi neachitate pe aceasta rezervare.",
+  payableStatusHint:
+    "Platile se pot inregistra doar pe facturi emise, partial platite sau scadente depasite cu rest de plata pozitiv. Ciornele si facturile in asteptarea alocarii sunt excluse.",
   actions: {
     record: "Inregistreaza plata",
     save: "Salveaza modificarile",

--- a/packages/finance-react/src/record-booking-payment-dialog.test.tsx
+++ b/packages/finance-react/src/record-booking-payment-dialog.test.tsx
@@ -10,7 +10,7 @@ const testState = vi.hoisted(() => ({
     {
       id: "inv_123",
       invoiceNumber: "PF-2026-001",
-      status: "draft",
+      status: "issued",
       currency: "EUR",
       totalCents: 66000,
       paidCents: 0,
@@ -205,7 +205,7 @@ describe("RecordBookingPaymentDialog", () => {
       {
         id: "inv_123",
         invoiceNumber: "PF-2026-001",
-        status: "draft",
+        status: "issued",
         currency: "EUR",
         totalCents: 66000,
         paidCents: 0,
@@ -269,12 +269,57 @@ describe("RecordBookingPaymentDialog", () => {
     )
   })
 
+  it("offers issued unpaid invoices while excluding pending allocation placeholders", async () => {
+    testState.invoices = [
+      {
+        id: "inv_pending",
+        invoiceNumber: "PENDING-INVOICE",
+        status: "pending_external_allocation",
+        currency: "EUR",
+        totalCents: 30000,
+        paidCents: 0,
+        balanceDueCents: 30000,
+      },
+      {
+        id: "inv_issued",
+        invoiceNumber: "INV-2026-010",
+        status: "issued",
+        currency: "EUR",
+        totalCents: 66000,
+        paidCents: 0,
+        balanceDueCents: 66000,
+      },
+    ]
+
+    await act(async () => {
+      root.render(
+        <RecordBookingPaymentDialog
+          open
+          onOpenChange={() => {}}
+          bookingId="book_123"
+          defaultCurrency="EUR"
+        />,
+      )
+    })
+
+    const optionText = Array.from(container.querySelectorAll("option")).map(
+      (option) => option.textContent ?? "",
+    )
+
+    expect(optionText).toContain("INV-2026-010 — issued — 660.00 EUR due")
+    expect(optionText).not.toContain(
+      "PENDING-INVOICE — pending_external_allocation — 300.00 EUR due",
+    )
+    expect(container.textContent).toContain("Draft and pending allocation invoices are excluded.")
+    expect(container.textContent).not.toContain("No unpaid invoices on this booking.")
+  })
+
   it("preserves invoice currency casing for same-currency payments", async () => {
     testState.invoices = [
       {
         id: "inv_123",
         invoiceNumber: "PF-2026-001",
-        status: "draft",
+        status: "issued",
         currency: "eur",
         totalCents: 66000,
         paidCents: 0,


### PR DESCRIPTION
## Summary
- Restrict booking finance payment recording to issued, partially paid, and overdue invoices with positive balance.
- Keep issued unpaid invoices selectable even when pending external allocation invoices also exist on the booking.
- Add helper copy explaining why draft and pending allocation invoices are excluded.
- Clean up New Invoice source/date validation so Custom is selected when no eligible schedule exists and stale validation clears when operators switch source or choose dates.

Fixes #2438

## Verification
- `pnpm --filter @voyant-travel/finance-react test`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/finance-react typecheck`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed` (0 errors; existing file-size warning for `record-booking-payment-dialog.tsx`)
- `git diff --check`

## Notes
- Commit hook `pnpm typecheck` was attempted and failed after broad unrelated packages were killed with exit 137 under memory pressure (`operations`, `distribution`, `operations-react`, `federated-operator`).
- Push hook `pnpm test` was attempted and failed on existing OpenAPI artifact drift in `@voyant-travel/openapi`; `@voyant-travel/finance-react` tests passed inside that run.
