### PR TITLE
Cover tax class regime validation

### DIFF
--- a/packages/finance/tests/unit/service-reference-data.test.ts
+++ b/packages/finance/tests/unit/service-reference-data.test.ts
@@ -1,6 +1,8 @@
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { Hono } from "hono"
 import { describe, expect, it, vi } from "vitest"
 
+import { financeReferenceDataRoutes } from "../../src/routes-reference-data.js"
 import { financeReferenceDataService } from "../../src/service-reference-data.js"
 
 function makeTaxClassDb(existingRegimeIds: string[] = []) {
@@ -21,10 +23,30 @@ function makeTaxClassDb(existingRegimeIds: string[] = []) {
     db: { select, insert, update } as PostgresJsDatabase,
     insert,
     update,
+    values,
+    set,
   }
 }
 
 describe("financeReferenceDataService tax classes", () => {
+  it("rejects create payloads with nonexistent default regime references", async () => {
+    const { db, insert } = makeTaxClassDb()
+
+    await expect(
+      financeReferenceDataService.createTaxClass(db, {
+        code: "invalid-default-regime",
+        label: "Invalid default regime",
+        active: true,
+        defaultRegimeId: "txrg_missing",
+      }),
+    ).rejects.toMatchObject({
+      name: "ReferenceDataValidationError",
+      code: "invalid_reference",
+      details: { missingRegimeIds: ["txrg_missing"] },
+    })
+    expect(insert).not.toHaveBeenCalled()
+  })
+
   it("rejects create payloads with nonexistent line regime references", async () => {
     const { db, insert } = makeTaxClassDb()
 
@@ -57,5 +79,70 @@ describe("financeReferenceDataService tax classes", () => {
       details: { missingRegimeIds: ["txrg_missing"] },
     })
     expect(update).not.toHaveBeenCalled()
+  })
+
+  it("creates tax classes when all referenced tax regimes exist", async () => {
+    const { db, values } = makeTaxClassDb(["txrg_default", "txrg_line"])
+
+    await expect(
+      financeReferenceDataService.createTaxClass(db, {
+        code: "valid-regimes",
+        label: "Valid regimes",
+        active: true,
+        defaultRegimeId: "txrg_default",
+        lines: [{ regime_id: "txrg_line", applies_to: "base" }],
+      }),
+    ).resolves.toEqual({ id: "txcl_123" })
+
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultRegimeId: "txrg_default",
+        lines: [{ regime_id: "txrg_line", applies_to: "base" }],
+      }),
+    )
+  })
+
+  it("updates tax classes when submitted tax regime references exist", async () => {
+    const { db, set } = makeTaxClassDb(["txrg_existing"])
+
+    await expect(
+      financeReferenceDataService.updateTaxClass(db, "txcl_123", {
+        defaultRegimeId: "txrg_existing",
+      }),
+    ).resolves.toEqual({ id: "txcl_123" })
+
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultRegimeId: "txrg_existing",
+      }),
+    )
+  })
+
+  it("returns handled 400 responses for missing tax-regime references", async () => {
+    const { db } = makeTaxClassDb()
+    const app = new Hono()
+      .use("*", async (c, next) => {
+        c.set("db", db)
+        await next()
+      })
+      .route("/", financeReferenceDataRoutes)
+
+    const response = await app.request("/tax-classes", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        code: "invalid-default-regime",
+        label: "Invalid default regime",
+        active: true,
+        defaultRegimeId: "txrg_missing",
+      }),
+    })
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: "Tax class references unknown tax regimes",
+      code: "invalid_reference",
+      details: { missingRegimeIds: ["txrg_missing"] },
+    })
   })
 })


### PR DESCRIPTION
Fixes #2578

## Summary
- add regression coverage for missing tax-regime references on tax class create/update
- cover handled 400 route responses for invalid tax class regime references

## Verification
- pnpm --filter @voyant-travel/finance test -- tests/unit/service-reference-data.test.ts
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/finance typecheck
- pnpm exec biome check packages/finance/tests/unit/service-reference-data.test.ts
- git diff --check

No changeset: this PR only adds regression coverage for validation already present on main.