### PR TITLE
Fix booking traveler pax assignments

### DIFF
--- a/.changeset/booking-traveler-pax-assignments.md
+++ b/.changeset/booking-traveler-pax-assignments.md
@@ -1,0 +1,9 @@
+---
+"@voyant-travel/bookings": patch
+"@voyant-travel/bookings-react": patch
+---
+
+Keep booking detail traveler additions in sync with booking pax, traveler category,
+and existing booking item traveler assignments. The traveler dialog now exposes
+category assignment, and the traveler table reflects revealed travel-document
+details when no uploaded document rows exist.

--- a/packages/bookings-react/src/components/traveler-dialog.tsx
+++ b/packages/bookings-react/src/components/traveler-dialog.tsx
@@ -41,11 +41,13 @@ import {
 } from "../index.js"
 
 const identityDocumentTypes = ["passport", "id_card", "driver_license", "visa", "other"] as const
+const travelerCategories = ["adult", "child", "infant", "senior", "other"] as const
 
 function createTravelerFormSchema(messages: ReturnType<typeof useBookingsUiMessagesOrDefault>) {
   return z.object({
     firstName: z.string().min(1, messages.travelerDialog.validation.firstNameRequired),
     lastName: z.string().min(1, messages.travelerDialog.validation.lastNameRequired),
+    travelerCategory: z.enum(travelerCategories).default("adult"),
     email: z.string().email().optional().or(z.literal("")).nullable(),
     phone: z.string().optional().nullable(),
     specialRequests: z.string().optional().nullable(),
@@ -72,6 +74,12 @@ const EMPTY_PII_FORM = {
   dateOfBirth: "",
   dietaryRequirements: "",
   accessibilityNeeds: "",
+}
+
+function normalizeTravelerCategory(value: string | null | undefined) {
+  return travelerCategories.includes(value as (typeof travelerCategories)[number])
+    ? (value as (typeof travelerCategories)[number])
+    : "adult"
 }
 
 export interface TravelerDialogProps {
@@ -116,6 +124,7 @@ export function TravelerDialog({
     defaultValues: {
       firstName: "",
       lastName: "",
+      travelerCategory: "adult",
       email: "",
       phone: "",
       specialRequests: "",
@@ -134,6 +143,7 @@ export function TravelerDialog({
       form.reset({
         firstName: traveler.firstName,
         lastName: traveler.lastName,
+        travelerCategory: normalizeTravelerCategory(traveler.travelerCategory),
         email: traveler.email ?? "",
         phone: traveler.phone ?? "",
         specialRequests: traveler.specialRequests ?? "",
@@ -150,6 +160,7 @@ export function TravelerDialog({
       form.reset({
         firstName: "",
         lastName: "",
+        travelerCategory: "adult",
         email: "",
         phone: "",
         specialRequests: "",
@@ -187,6 +198,7 @@ export function TravelerDialog({
       specialRequests: values.specialRequests || null,
       isPrimary: traveler?.isPrimary ?? false,
       participantType: "traveler",
+      travelerCategory: values.travelerCategory,
       documentType: values.documentType,
       documentNumber: trimOrNull(values.documentNumber),
       documentExpiry: trimOrNull(values.documentExpiry),
@@ -355,6 +367,34 @@ export function TravelerDialog({
                   onChange={(next) => form.setValue("phone", next, { shouldDirty: true })}
                 />
               </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label>{messages.travelerDialog.fields.travelerCategory}</Label>
+              <Select
+                value={form.watch("travelerCategory") ?? "adult"}
+                onValueChange={(nextValue) =>
+                  form.setValue(
+                    "travelerCategory",
+                    nextValue as (typeof travelerCategories)[number],
+                    {
+                      shouldDirty: true,
+                      shouldValidate: true,
+                    },
+                  )
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {travelerCategories.map((category) => (
+                    <SelectItem key={category} value={category}>
+                      {messages.travelerDialog.travelerCategoryLabels[category]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
 
             <div className="flex flex-col gap-2">

--- a/packages/bookings-react/src/components/traveler-list.tsx
+++ b/packages/bookings-react/src/components/traveler-list.tsx
@@ -83,8 +83,8 @@ export function TravelerList({ bookingId, autoReveal = false }: TravelerListProp
   }, [])
 
   const isRevealed = React.useCallback(
-    (travelerId: string) => autoReveal || revealedIds.has(travelerId),
-    [autoReveal, revealedIds],
+    (travelerId: string) => autoReveal || allAlreadyRevealed || revealedIds.has(travelerId),
+    [allAlreadyRevealed, autoReveal, revealedIds],
   )
 
   const deleteMessages = messages.travelerList.actions.deleteConfirm
@@ -151,24 +151,14 @@ export function TravelerList({ bookingId, autoReveal = false }: TravelerListProp
       {
         id: "documents",
         header: messages.travelerList.columns.documents,
-        cell: ({ row }) => {
-          const documents = documentsByTraveler.get(row.original.id) ?? []
-          if (documents.length === 0) {
-            return (
-              <span className="text-muted-foreground text-xs">
-                {messages.travelerList.values.documentsUnavailable}
-              </span>
-            )
-          }
-          return (
-            <div className="flex flex-wrap gap-1.5">
-              {documents.slice(0, 2).map((document) => (
-                <MiniPill key={document.id}>{document.type.replaceAll("_", " ")}</MiniPill>
-              ))}
-              {documents.length > 2 ? <MiniPill>+{documents.length - 2}</MiniPill> : null}
-            </div>
-          )
-        },
+        cell: ({ row }) => (
+          <TravelerDocumentsCell
+            bookingId={bookingId}
+            traveler={row.original}
+            revealed={isRevealed(row.original.id)}
+            documents={documentsByTraveler.get(row.original.id) ?? []}
+          />
+        ),
       },
       {
         id: "actions",
@@ -409,7 +399,13 @@ function RolePills({ traveler }: { traveler: BookingTravelerRecord }) {
   const messages = useBookingsUiMessagesOrDefault()
   const pills: string[] = []
   if (traveler.isPrimary) pills.push(messages.travelerList.roles.primary)
-  if (traveler.travelerCategory) pills.push(traveler.travelerCategory)
+  if (traveler.travelerCategory) {
+    pills.push(
+      messages.travelerDialog.travelerCategoryLabels[
+        traveler.travelerCategory as keyof typeof messages.travelerDialog.travelerCategoryLabels
+      ] ?? traveler.travelerCategory,
+    )
+  }
   if (pills.length === 0) return <span className="text-muted-foreground text-xs">—</span>
   return (
     <div className="flex flex-wrap gap-1.5">
@@ -418,6 +414,61 @@ function RolePills({ traveler }: { traveler: BookingTravelerRecord }) {
       ))}
     </div>
   )
+}
+
+function TravelerDocumentsCell({
+  bookingId,
+  traveler,
+  revealed,
+  documents,
+}: {
+  bookingId: string
+  traveler: BookingTravelerRecord
+  revealed: boolean
+  documents: BookingTravelerDocumentRecord[]
+}) {
+  const { travelDetails, loading } = useRevealed(bookingId, traveler, revealed)
+  const messages = useBookingsUiMessagesOrDefault()
+  const travelDocumentLabel = getTravelDocumentLabel(travelDetails, messages)
+
+  if (loading) return <RowLoading />
+  if (!revealed && documents.length === 0) {
+    return (
+      <span className="text-muted-foreground text-xs">
+        {messages.travelerList.values.documentsHidden}
+      </span>
+    )
+  }
+  if (documents.length === 0 && !travelDocumentLabel) {
+    return (
+      <span className="text-muted-foreground text-xs">
+        {messages.travelerList.values.documentsUnavailable}
+      </span>
+    )
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {travelDocumentLabel ? <MiniPill>{travelDocumentLabel}</MiniPill> : null}
+      {documents.slice(0, travelDocumentLabel ? 1 : 2).map((document) => (
+        <MiniPill key={document.id}>{document.type.replaceAll("_", " ")}</MiniPill>
+      ))}
+      {documents.length > (travelDocumentLabel ? 1 : 2) ? (
+        <MiniPill>+{documents.length - (travelDocumentLabel ? 1 : 2)}</MiniPill>
+      ) : null}
+    </div>
+  )
+}
+
+function getTravelDocumentLabel(
+  travelDetails: BookingTravelerRevealRecord["travelDetails"],
+  messages: ReturnType<typeof useBookingsUiMessagesOrDefault>,
+) {
+  if (!travelDetails) return null
+  if (!travelDetails.documentNumber && !travelDetails.documentExpiry) return null
+
+  const documentType = travelDetails.documentType ?? "passport"
+  return messages.travelerDialog.documentTypeLabels[documentType]
 }
 
 function TravelerSnapshotBody({
@@ -448,7 +499,13 @@ function TravelerSnapshotBody({
   const roles: string[] = []
   if (display.isPrimary) roles.push(messages.travelerList.roles.primary)
   if (travelDetails?.isLeadTraveler) roles.push(messages.travelerList.roles.lead)
-  if (display.travelerCategory) roles.push(display.travelerCategory)
+  if (display.travelerCategory) {
+    roles.push(
+      messages.travelerDialog.travelerCategoryLabels[
+        display.travelerCategory as keyof typeof messages.travelerDialog.travelerCategoryLabels
+      ] ?? display.travelerCategory,
+    )
+  }
 
   return (
     <div className="flex-1 overflow-y-auto px-4 pb-4">

--- a/packages/bookings-react/src/i18n/en-base.ts
+++ b/packages/bookings-react/src/i18n/en-base.ts
@@ -166,6 +166,7 @@ export const bookingsUiEnBase = {
     fields: {
       firstName: "First name",
       lastName: "Last name",
+      travelerCategory: "Traveler category",
       email: "Email",
       phone: "Phone",
       specialRequests: "Special requests",
@@ -179,6 +180,13 @@ export const bookingsUiEnBase = {
       dietaryRequirements: "Dietary requirements",
       accessibilityNeeds: "Accessibility needs",
       linkedPerson: "Linked CRM contact",
+    },
+    travelerCategoryLabels: {
+      adult: "Adult",
+      child: "Child",
+      infant: "Infant",
+      senior: "Senior",
+      other: "Other",
     },
     documentTypeLabels: {
       passport: "Passport",
@@ -222,6 +230,7 @@ export const bookingsUiEnBase = {
     values: {
       emailUnavailable: "-",
       phoneUnavailable: "-",
+      documentsHidden: "Reveal details",
       documentsUnavailable: "-",
       fieldUnavailable: "-",
       noAdditionalContext: "No additional traveler context",

--- a/packages/bookings-react/src/i18n/messages-base.ts
+++ b/packages/bookings-react/src/i18n/messages-base.ts
@@ -139,6 +139,7 @@ export type BookingsUiBaseMessages = {
     fields: {
       firstName: string
       lastName: string
+      travelerCategory: string
       email: string
       phone: string
       specialRequests: string
@@ -153,6 +154,7 @@ export type BookingsUiBaseMessages = {
       accessibilityNeeds: string
       linkedPerson: string
     }
+    travelerCategoryLabels: Record<"adult" | "child" | "infant" | "senior" | "other", string>
     documentTypeLabels: Record<"passport" | "id_card" | "driver_license" | "visa" | "other", string>
     placeholders: {
       firstName: string
@@ -189,6 +191,7 @@ export type BookingsUiBaseMessages = {
     values: {
       emailUnavailable: string
       phoneUnavailable: string
+      documentsHidden: string
       documentsUnavailable: string
       fieldUnavailable: string
       noAdditionalContext: string

--- a/packages/bookings-react/src/i18n/ro-base.ts
+++ b/packages/bookings-react/src/i18n/ro-base.ts
@@ -165,6 +165,7 @@ export const bookingsUiRoBase = {
     fields: {
       firstName: "Prenume",
       lastName: "Nume",
+      travelerCategory: "Categorie calator",
       email: "Email",
       phone: "Telefon",
       specialRequests: "Cerinte speciale",
@@ -178,6 +179,13 @@ export const bookingsUiRoBase = {
       dietaryRequirements: "Cerinte alimentare",
       accessibilityNeeds: "Cerinte de accesibilitate",
       linkedPerson: "Contact CRM asociat",
+    },
+    travelerCategoryLabels: {
+      adult: "Adult",
+      child: "Copil",
+      infant: "Infant",
+      senior: "Senior",
+      other: "Altul",
     },
     documentTypeLabels: {
       passport: "Pasaport",
@@ -221,6 +229,7 @@ export const bookingsUiRoBase = {
     values: {
       emailUnavailable: "-",
       phoneUnavailable: "-",
+      documentsHidden: "Afiseaza detalii",
       documentsUnavailable: "-",
       fieldUnavailable: "-",
       noAdditionalContext: "Nu exista context suplimentar pentru calator",

--- a/packages/bookings/src/service-core.ts
+++ b/packages/bookings/src/service-core.ts
@@ -535,6 +535,7 @@ export interface BookingTravelerSharingGroupSummary {
 }
 
 const travelerParticipantTypes = ["traveler", "occupant"] as const
+type TravelerParticipantType = (typeof travelerParticipantTypes)[number]
 const sharingGroupBookingStatuses = [
   "draft",
   "on_hold",
@@ -584,6 +585,10 @@ function toDateValueOrNull(value: Date | string | null) {
   return value instanceof Date ? value : new Date(value)
 }
 
+function isPaxParticipantType(value: string): value is TravelerParticipantType {
+  return travelerParticipantTypes.includes(value as TravelerParticipantType)
+}
+
 function toTravelerResponse(participant: typeof bookingTravelers.$inferSelect) {
   return {
     id: participant.id,
@@ -625,6 +630,56 @@ async function ensureParticipantFlags(
       .set({ isPrimary: false, updatedAt: new Date() })
       .where(and(eq(bookingTravelers.bookingId, bookingId), ne(bookingTravelers.id, travelerId)))
   }
+}
+
+async function recomputeBookingPaxFromTravelers(db: PostgresJsDatabase, bookingId: string) {
+  const [row] = await db
+    .select({ pax: sql<number>`count(*)::int` })
+    .from(bookingTravelers)
+    .where(
+      and(
+        eq(bookingTravelers.bookingId, bookingId),
+        inArray(bookingTravelers.participantType, [...travelerParticipantTypes]),
+      ),
+    )
+
+  const pax = row?.pax ?? 0
+  await db
+    .update(bookings)
+    .set({ pax: pax > 0 ? pax : null, updatedAt: new Date() })
+    .where(eq(bookings.id, bookingId))
+}
+
+async function assignTravelerToExistingBookingItems(
+  db: PostgresJsDatabase,
+  bookingId: string,
+  traveler: Pick<typeof bookingTravelers.$inferSelect, "id" | "participantType" | "isPrimary">,
+) {
+  if (!isPaxParticipantType(traveler.participantType)) return
+
+  const items = await db
+    .select({ id: bookingItems.id })
+    .from(bookingItems)
+    .where(eq(bookingItems.bookingId, bookingId))
+
+  if (items.length === 0) return
+
+  const itemIds = items.map((item) => item.id)
+  if (traveler.isPrimary) {
+    await db
+      .update(bookingItemTravelers)
+      .set({ isPrimary: false })
+      .where(inArray(bookingItemTravelers.bookingItemId, itemIds))
+  }
+
+  await db.insert(bookingItemTravelers).values(
+    items.map((item) => ({
+      bookingItemId: item.id,
+      travelerId: traveler.id,
+      role: traveler.participantType,
+      isPrimary: traveler.isPrimary,
+    })),
+  )
 }
 
 async function ensureBookingScopedLinks(
@@ -4046,13 +4101,19 @@ export const bookingsService = {
       return null
     }
 
+    const participantType = data.participantType
+    const travelerCategory =
+      data.travelerCategory == null && isPaxParticipantType(participantType)
+        ? "adult"
+        : (data.travelerCategory ?? null)
+
     const [row] = await db
       .insert(bookingTravelers)
       .values({
         bookingId,
         personId: data.personId ?? null,
-        participantType: data.participantType,
-        travelerCategory: data.travelerCategory ?? null,
+        participantType,
+        travelerCategory,
         firstName: data.firstName,
         lastName: data.lastName,
         email: data.email ?? null,
@@ -4069,15 +4130,16 @@ export const bookingsService = {
     }
 
     await ensureParticipantFlags(db, bookingId, row.id, data)
+    await assignTravelerToExistingBookingItems(db, bookingId, row)
+    await recomputeBookingPaxFromTravelers(db, bookingId)
 
     await db.insert(bookingActivityLog).values({
       bookingId,
       actorId: userId ?? "system",
       activityType: "traveler_update",
       description: `Traveler ${data.firstName} ${data.lastName} added`,
-      metadata: { travelerId: row.id, participantType: data.participantType },
+      metadata: { travelerId: row.id, participantType },
     })
-    await touchBookingUpdatedAt(db, bookingId)
 
     return row
   },
@@ -4098,7 +4160,7 @@ export const bookingsService = {
     }
 
     await ensureParticipantFlags(db, row.bookingId, row.id, data)
-    await touchBookingUpdatedAt(db, row.bookingId)
+    await recomputeBookingPaxFromTravelers(db, row.bookingId)
 
     return row
   },
@@ -4219,9 +4281,7 @@ export const bookingsService = {
       .where(eq(bookingTravelers.id, travelerId))
       .returning({ id: bookingTravelers.id, bookingId: bookingTravelers.bookingId })
 
-    if (row) {
-      await touchBookingUpdatedAt(db, row.bookingId)
-    }
+    if (row) await recomputeBookingPaxFromTravelers(db, row.bookingId)
 
     return row ?? null
   },

--- a/packages/bookings/tests/integration/routes.integration-suite.ts
+++ b/packages/bookings/tests/integration/routes.integration-suite.ts
@@ -30,6 +30,7 @@ import {
   bookingDocuments,
   bookingFulfillments,
   bookingItems,
+  bookingItemTravelers,
   bookingPiiAccessLog,
   bookingTravelers,
 } from "../../src/schema.js"
@@ -2369,6 +2370,52 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
       const body = await res.json()
       expect(body.data.firstName).toBe("John")
       expect(body.data.participantType).toBe("traveler")
+      expect(body.data.travelerCategory).toBe("adult")
+    })
+
+    it("keeps pax, traveler category, and item assignments in sync when adding traveler details", async () => {
+      const booking = await seedBooking({ pax: 1 })
+      await app.request(`/${booking.id}/travelers`, {
+        method: "POST",
+        ...json({ firstName: "Existing", lastName: "Traveler" }),
+      })
+      const itemRes = await app.request(`/${booking.id}/items`, {
+        method: "POST",
+        ...json({ title: "Tour", sellCurrency: "USD" }),
+      })
+      const { data: item } = await itemRes.json()
+
+      const res = await app.request(`/${booking.id}/travelers/with-travel-details`, {
+        method: "POST",
+        ...json({
+          firstName: "New",
+          lastName: "Traveler",
+          documentType: "passport",
+          documentNumber: "DOC-123",
+        }),
+      })
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.data.traveler.travelerCategory).toBe("adult")
+      expect(body.data.travelDetails.documentNumber).toBe("DOC-123")
+
+      const bookingRes = await app.request(`/${booking.id}`, { method: "GET" })
+      expect((await bookingRes.json()).data.pax).toBe(2)
+
+      const links = await db
+        .select()
+        .from(bookingItemTravelers)
+        .where(eq(bookingItemTravelers.bookingItemId, item.id))
+
+      expect(links).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            travelerId: body.data.traveler.id,
+            role: "traveler",
+          }),
+        ]),
+      )
     })
 
     it("lists travelers", async () => {


### PR DESCRIPTION
Closes #2437

## Summary
- default new booking-detail travelers to an adult traveler category and keep booking pax recomputed from traveler participants
- assign newly added travelers to existing booking items
- show category controls and document-detail indicators in the traveler UI

## Verification
- pnpm --filter @voyant-travel/bookings test -- --runInBand
- pnpm --filter @voyant-travel/bookings-react test -- --runInBand
- pnpm --filter @voyant-travel/bookings typecheck
- pnpm --filter @voyant-travel/bookings-react typecheck
- pre-commit affected verification passed