### PR TITLE
fix: return 409 on duplicate settings reference-data keys

### DIFF
--- a/.changeset/settings-duplicate-key-conflicts.md
+++ b/.changeset/settings-duplicate-key-conflicts.md
@@ -1,0 +1,13 @@
+---
+"@voyant-travel/commerce": patch
+"@voyant-travel/relationships": patch
+---
+
+Settings reference-data creates now return a deterministic 409 conflict on
+duplicate unique keys instead of a generic 500, so the admin UI can render an
+inline field error. `POST /v1/admin/pricing/price-catalogs` maps a duplicate
+`code` to `duplicate_price_catalog_code`, and
+`POST /v1/admin/relationships/custom-fields` maps a duplicate `(entityType,
+key)` to `duplicate_custom_field_key`. Both use `onConflictDoNothing` and throw
+a 409 `ApiHttpError` carrying `details.fields` / `details.issues`, matching the
+existing product-type / product-tag duplicate-error shape.

--- a/packages/commerce/src/pricing/duplicate-errors.ts
+++ b/packages/commerce/src/pricing/duplicate-errors.ts
@@ -1,0 +1,31 @@
+import { ApiHttpError } from "@voyant-travel/hono"
+
+type DuplicatePricingValueInput = {
+  code: string
+  message: string
+  resource: string
+  fields: string[][]
+}
+
+/**
+ * Translate a duplicate unique-key insert into a deterministic 409 the Settings
+ * UI can render as an inline field error, rather than letting the Postgres
+ * unique-violation (SQLSTATE 23505) bubble up as a generic 500. Mirrors the
+ * `duplicateInventoryValueError` helper so every reference-data create returns
+ * the same `{ error, code, details }` shape (voyant#2612).
+ */
+export function duplicatePricingValueError(input: DuplicatePricingValueInput): ApiHttpError {
+  return new ApiHttpError(input.message, {
+    status: 409,
+    code: input.code,
+    details: {
+      resource: input.resource,
+      issues: input.fields.map((path) => ({
+        code: input.code,
+        path,
+        message: input.message,
+      })),
+      fields: Object.fromEntries(input.fields.map((path) => [path.join("."), [input.message]])),
+    },
+  })
+}

--- a/packages/commerce/src/pricing/service-catalogs.test.ts
+++ b/packages/commerce/src/pricing/service-catalogs.test.ts
@@ -1,0 +1,61 @@
+import { ApiHttpError } from "@voyant-travel/hono"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { describe, expect, it } from "vitest"
+
+import { createPriceCatalog } from "./service-catalogs.js"
+import type { CreatePriceCatalogInput } from "./service-shared.js"
+
+const baseCatalog: CreatePriceCatalogInput = {
+  code: "rack",
+  name: "Rack rates",
+  catalogType: "public",
+  isDefault: false,
+  active: true,
+}
+
+/**
+ * A duplicate `code` insert hits `uidx_price_catalogs_code`; the service uses
+ * `onConflictDoNothing`, so the insert resolves to an empty `RETURNING` set.
+ * This mock reproduces that "no row returned" shape without a live database.
+ */
+function createConflictingInsertDb(): PostgresJsDatabase {
+  const insert: PostgresJsDatabase["insert"] = () =>
+    ({
+      values: () => ({
+        onConflictDoNothing: () => ({
+          returning: async () => [],
+        }),
+      }),
+    }) as never
+  return { insert } as PostgresJsDatabase
+}
+
+describe("createPriceCatalog duplicate code conflicts", () => {
+  it("maps a duplicate code to a 409 with a stable code and field context", async () => {
+    let caught: unknown
+    try {
+      await createPriceCatalog(createConflictingInsertDb(), baseCatalog)
+    } catch (error) {
+      caught = error
+    }
+
+    expect(caught).toBeInstanceOf(ApiHttpError)
+    const apiError = caught as ApiHttpError
+    expect(apiError.status).toBe(409)
+    expect(apiError.code).toBe("duplicate_price_catalog_code")
+    expect(apiError.message).toBe("Price catalog code already exists")
+    expect(apiError.details).toMatchObject({
+      resource: "price_catalog",
+      issues: [
+        {
+          code: "duplicate_price_catalog_code",
+          path: ["code"],
+          message: "Price catalog code already exists",
+        },
+      ],
+      fields: {
+        code: ["Price catalog code already exists"],
+      },
+    })
+  })
+})

--- a/packages/commerce/src/pricing/service-catalogs.ts
+++ b/packages/commerce/src/pricing/service-catalogs.ts
@@ -1,6 +1,7 @@
 import { and, asc, desc, eq, ilike, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
+import { duplicatePricingValueError } from "./duplicate-errors.js"
 import { priceCatalogs, priceSchedules } from "./schema.js"
 import type {
   CreatePriceCatalogInput,
@@ -44,8 +45,22 @@ export async function getPriceCatalogById(db: PostgresJsDatabase, id: string) {
 }
 
 export async function createPriceCatalog(db: PostgresJsDatabase, data: CreatePriceCatalogInput) {
-  const [row] = await db.insert(priceCatalogs).values(data).returning()
-  return row ?? null
+  const [row] = await db
+    .insert(priceCatalogs)
+    .values(data)
+    .onConflictDoNothing({ target: priceCatalogs.code })
+    .returning()
+
+  if (!row) {
+    throw duplicatePricingValueError({
+      code: "duplicate_price_catalog_code",
+      message: "Price catalog code already exists",
+      resource: "price_catalog",
+      fields: [["code"]],
+    })
+  }
+
+  return row
 }
 
 export async function updatePriceCatalog(

--- a/packages/relationships/src/service/custom-fields.ts
+++ b/packages/relationships/src/service/custom-fields.ts
@@ -19,6 +19,7 @@ import {
   type TypedValueColumns,
   typedFromJsonbValue,
 } from "./custom-fields-value-mapping.js"
+import { duplicateRelationshipsValueError } from "./duplicate-errors.js"
 import { paginate } from "./helpers.js"
 
 type CustomFieldDefinitionListQuery = z.infer<typeof customFieldDefinitionListQuerySchema>
@@ -59,7 +60,23 @@ export const customFieldsService = {
     db: PostgresJsDatabase,
     data: CreateCustomFieldDefinitionInput,
   ) {
-    const [row] = await db.insert(customFieldDefinitions).values(data).returning()
+    const [row] = await db
+      .insert(customFieldDefinitions)
+      .values(data)
+      .onConflictDoNothing({
+        target: [customFieldDefinitions.entityType, customFieldDefinitions.key],
+      })
+      .returning()
+
+    if (!row) {
+      throw duplicateRelationshipsValueError({
+        code: "duplicate_custom_field_key",
+        message: "Custom field key already exists for this entity type",
+        resource: "custom_field_definition",
+        fields: [["key"]],
+      })
+    }
+
     return row
   },
 

--- a/packages/relationships/src/service/duplicate-errors.ts
+++ b/packages/relationships/src/service/duplicate-errors.ts
@@ -1,0 +1,33 @@
+import { ApiHttpError } from "@voyant-travel/hono"
+
+type DuplicateRelationshipsValueInput = {
+  code: string
+  message: string
+  resource: string
+  fields: string[][]
+}
+
+/**
+ * Translate a duplicate unique-key insert into a deterministic 409 the Settings
+ * UI can render as an inline field error, rather than letting the Postgres
+ * unique-violation (SQLSTATE 23505) bubble up as a generic 500. Mirrors the
+ * `duplicateInventoryValueError` helper so every reference-data create returns
+ * the same `{ error, code, details }` shape (voyant#2612).
+ */
+export function duplicateRelationshipsValueError(
+  input: DuplicateRelationshipsValueInput,
+): ApiHttpError {
+  return new ApiHttpError(input.message, {
+    status: 409,
+    code: input.code,
+    details: {
+      resource: input.resource,
+      issues: input.fields.map((path) => ({
+        code: input.code,
+        path,
+        message: input.message,
+      })),
+      fields: Object.fromEntries(input.fields.map((path) => [path.join("."), [input.message]])),
+    },
+  })
+}

--- a/packages/relationships/tests/integration/custom-fields.test.ts
+++ b/packages/relationships/tests/integration/custom-fields.test.ts
@@ -56,6 +56,32 @@ describe.skipIf(!DB_AVAILABLE)("Custom field routes", () => {
       expect(body.data.id).toBeTruthy()
     })
 
+    it("rejects a duplicate (entityType, key) with a 409 field error", async () => {
+      const first = await app.request("/custom-fields", { method: "POST", ...json(validDef) })
+      expect(first.status).toBe(201)
+
+      const res = await app.request("/custom-fields", {
+        method: "POST",
+        ...json({ ...validDef, label: "Industry Code (dup)" }),
+      })
+
+      expect(res.status).toBe(409)
+      const body = await res.json()
+      expect(body.code).toBe("duplicate_custom_field_key")
+      expect(body.error).toBe("Custom field key already exists for this entity type")
+      expect(body.details.resource).toBe("custom_field_definition")
+      expect(body.details.fields).toEqual({
+        key: ["Custom field key already exists for this entity type"],
+      })
+      expect(body.details.issues).toEqual([
+        {
+          code: "duplicate_custom_field_key",
+          path: ["key"],
+          message: "Custom field key already exists for this entity type",
+        },
+      ])
+    })
+
     it("lists definitions filtered by entityType", async () => {
       await app.request("/custom-fields", {
         method: "POST",

--- a/packages/relationships/tests/unit/custom-fields-duplicate.test.ts
+++ b/packages/relationships/tests/unit/custom-fields-duplicate.test.ts
@@ -1,0 +1,58 @@
+import { ApiHttpError } from "@voyant-travel/hono"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { describe, expect, it } from "vitest"
+
+import { customFieldsService } from "../../src/service/custom-fields.js"
+
+/**
+ * A duplicate `(entity_type, key)` insert hits
+ * `uidx_custom_field_definitions_key`; the service uses `onConflictDoNothing`,
+ * so the insert resolves to an empty `RETURNING` set. This mock reproduces that
+ * "no row returned" shape without a live database (voyant#2612).
+ */
+function createConflictingInsertDb(): PostgresJsDatabase {
+  const insert: PostgresJsDatabase["insert"] = () =>
+    ({
+      values: () => ({
+        onConflictDoNothing: () => ({
+          returning: async () => [],
+        }),
+      }),
+    }) as never
+  return { insert } as PostgresJsDatabase
+}
+
+describe("createCustomFieldDefinition duplicate key conflicts", () => {
+  it("maps a duplicate (entityType, key) to a 409 with a stable code and field context", async () => {
+    let caught: unknown
+    try {
+      await customFieldsService.createCustomFieldDefinition(createConflictingInsertDb(), {
+        entityType: "organization",
+        key: "industry_code",
+        label: "Industry Code",
+        fieldType: "varchar",
+      } as never)
+    } catch (error) {
+      caught = error
+    }
+
+    expect(caught).toBeInstanceOf(ApiHttpError)
+    const apiError = caught as ApiHttpError
+    expect(apiError.status).toBe(409)
+    expect(apiError.code).toBe("duplicate_custom_field_key")
+    expect(apiError.message).toBe("Custom field key already exists for this entity type")
+    expect(apiError.details).toMatchObject({
+      resource: "custom_field_definition",
+      issues: [
+        {
+          code: "duplicate_custom_field_key",
+          path: ["key"],
+          message: "Custom field key already exists for this entity type",
+        },
+      ],
+      fields: {
+        key: ["Custom field key already exists for this entity type"],
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Several Settings reference-data create endpoints returned a generic **500** on a duplicate unique key (a Postgres unique-violation, SQLSTATE 23505, bubbling up) instead of a deterministic conflict the admin UI can render as an inline field error. This fixes the two remaining endpoints.

The other two endpoints in the issue — `POST /v1/admin/products/product-types` (`duplicate_product_type_code`) and `POST /v1/admin/products/product-tags` (`duplicate_product_tag_name`) — were already fixed in #2674 with the same `onConflictDoNothing` + `duplicate*ValueError` (409) pattern. This PR mirrors that established pattern for the last two:

| Endpoint | Unique key | Status | Stable code |
| --- | --- | --- | --- |
| `POST /v1/admin/pricing/price-catalogs` | `code` (`uidx_price_catalogs_code`) | 409 | `duplicate_price_catalog_code` |
| `POST /v1/admin/relationships/custom-fields` | `(entityType, key)` (`uidx_custom_field_definitions_key`) | 409 | `duplicate_custom_field_key` |

Each create now uses `onConflictDoNothing` on the unique target and, when no row is returned, throws a 409 `ApiHttpError` carrying `details.resource`, `details.fields`, and `details.issues` — the same response shape as the inventory duplicate errors, so the UI can consume all four endpoints uniformly.

## Changes

- `packages/commerce`: new `pricing/duplicate-errors.ts` helper; `createPriceCatalog` maps duplicate `code` to a 409.
- `packages/relationships`: new `service/duplicate-errors.ts` helper; `createCustomFieldDefinition` maps duplicate `(entityType, key)` to a 409.

## Tests

- `commerce`: unit test (mock DB) asserting the 409 + `duplicate_price_catalog_code` + field details.
- `relationships`: unit test (mock DB) for the 409 + `duplicate_custom_field_key`, plus a real-DB integration test in `tests/integration/custom-fields.test.ts` (runs in CI with `voyant_test`).

Typecheck, lint, and the new/targeted tests pass for both packages.

Fixes #2612