### PR TITLE
fix(finance,pricing): reject invalid and dangling settings reference-data

### DIFF
--- a/.changeset/settings-invalid-pricing-tax-config.md
+++ b/.changeset/settings-invalid-pricing-tax-config.md
@@ -1,0 +1,14 @@
+---
+"@voyant-travel/commerce": patch
+"@voyant-travel/finance": patch
+"@voyant-travel/finance-contracts": patch
+---
+
+Reject invalid or dangling pricing and tax reference-data before writing.
+`POST /v1/admin/pricing/price-schedules` now rejects a nonexistent
+`priceCatalogId` with a deterministic `invalid_reference` 400 instead of a 500.
+Tax regime rates are bounded to the 0..100 percent domain (matching the
+booking-tax calculator that divides by 100), and `POST
+/v1/admin/finance/tax-policy-rules` rejects dangling `profileId`/`taxRegimeId`
+references with an `invalid_reference` 400 (mirroring the existing tax-class
+regime guard).

--- a/packages/commerce/src/pricing/service-catalogs.ts
+++ b/packages/commerce/src/pricing/service-catalogs.ts
@@ -1,3 +1,4 @@
+import { ApiHttpError } from "@voyant-travel/hono"
 import { and, asc, desc, eq, ilike, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
@@ -113,8 +114,31 @@ export async function getPriceScheduleById(db: PostgresJsDatabase, id: string) {
   return row ?? null
 }
 
+/**
+ * A price schedule stores its owning catalog as a plain text id (module
+ * decoupling — no DB FK), so a nonexistent `priceCatalogId` would otherwise
+ * either materialize a dangling row or surface as a NOT-NULL/DB fault (500).
+ * Guard it before writing and reject with a deterministic `invalid_reference`
+ * 400 that matches the finance reference-data dangling-FK contract.
+ */
+async function assertPriceCatalogExists(db: PostgresJsDatabase, priceCatalogId: string) {
+  const [catalog] = await db
+    .select({ id: priceCatalogs.id })
+    .from(priceCatalogs)
+    .where(eq(priceCatalogs.id, priceCatalogId))
+    .limit(1)
+  if (!catalog) {
+    throw new ApiHttpError("Price schedule references unknown price catalog", {
+      status: 400,
+      code: "invalid_reference",
+      details: { missingPriceCatalogId: priceCatalogId },
+    })
+  }
+}
+
 export async function createPriceSchedule(db: PostgresJsDatabase, data: CreatePriceScheduleInput) {
   assertPricingValidation(validateMergedPriceSchedule(data), "Invalid price schedule")
+  await assertPriceCatalogExists(db, data.priceCatalogId)
   const [row] = await db.insert(priceSchedules).values(data).returning()
   return row ?? null
 }
@@ -144,6 +168,10 @@ export async function updatePriceSchedule(
     }),
     "Invalid price schedule",
   )
+
+  if (data.priceCatalogId != null) {
+    await assertPriceCatalogExists(db, data.priceCatalogId)
+  }
 
   const [row] = await db
     .update(priceSchedules)

--- a/packages/commerce/src/pricing/service-price-schedules.test.ts
+++ b/packages/commerce/src/pricing/service-price-schedules.test.ts
@@ -1,0 +1,57 @@
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { describe, expect, it, vi } from "vitest"
+
+import { createPriceSchedule } from "./service-catalogs.js"
+import { insertPriceScheduleSchema } from "./validation.js"
+
+/**
+ * `createPriceSchedule` runs a pre-write existence check on `priceCatalogId`
+ * (`select().from().where().limit()`) before inserting. The mock resolves that
+ * lookup to either an existing catalog row or an empty result.
+ */
+function makePriceScheduleDb(opts: { catalogExists: boolean }) {
+  const limit = vi.fn().mockResolvedValue(opts.catalogExists ? [{ id: "price_catalogs_1" }] : [])
+  const where = vi.fn(() => ({ limit }))
+  const from = vi.fn(() => ({ where }))
+  const select = vi.fn(() => ({ from }))
+
+  const returning = vi.fn().mockResolvedValue([{ id: "price_schedules_1" }])
+  const values = vi.fn(() => ({ returning }))
+  const insert = vi.fn(() => ({ values }))
+
+  const updateReturning = vi.fn().mockResolvedValue([{ id: "price_schedules_1" }])
+  const updateWhere = vi.fn(() => ({ returning: updateReturning }))
+  const set = vi.fn(() => ({ where: updateWhere }))
+  const update = vi.fn(() => ({ set }))
+
+  return { db: { select, insert, update } as PostgresJsDatabase, insert }
+}
+
+const validScheduleInput = insertPriceScheduleSchema.parse({
+  priceCatalogId: "price_catalogs_00000000000000000000000",
+  name: "High season",
+  recurrenceRule: "FREQ=DAILY",
+})
+
+describe("createPriceSchedule dangling catalog guard", () => {
+  it("rejects a nonexistent priceCatalogId with a deterministic invalid_reference 400", async () => {
+    const { db, insert } = makePriceScheduleDb({ catalogExists: false })
+
+    await expect(createPriceSchedule(db, validScheduleInput)).rejects.toMatchObject({
+      name: "ApiHttpError",
+      status: 400,
+      code: "invalid_reference",
+      details: { missingPriceCatalogId: "price_catalogs_00000000000000000000000" },
+    })
+    expect(insert).not.toHaveBeenCalled()
+  })
+
+  it("inserts when the referenced price catalog exists", async () => {
+    const { db, insert } = makePriceScheduleDb({ catalogExists: true })
+
+    await expect(createPriceSchedule(db, validScheduleInput)).resolves.toEqual({
+      id: "price_schedules_1",
+    })
+    expect(insert).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/finance-contracts/src/contracts.test.ts
+++ b/packages/finance-contracts/src/contracts.test.ts
@@ -6,12 +6,14 @@ import {
   insertPaymentAuthorizationSchema,
   insertPaymentCaptureSchema,
   insertPaymentSchema,
+  insertTaxRegimeSchema,
   invoiceStatusSchema,
   paymentMethodSchema,
   taxClassListQuerySchema,
   updateBookingItemCommissionSchema,
   updateBookingItemTaxLineSchema,
   updatePaymentSchema,
+  updateTaxRegimeSchema,
 } from "./index.js"
 
 describe("finance-contracts", () => {
@@ -65,6 +67,33 @@ describe("finance-contracts", () => {
         amountCents: 0,
       }).success,
     ).toBe(false)
+  })
+
+  it("rejects tax regime rates outside the 0..100 percent domain", () => {
+    expect(
+      insertTaxRegimeSchema.safeParse({ code: "standard", name: "Bogus", ratePercent: 1000 })
+        .success,
+    ).toBe(false)
+    expect(updateTaxRegimeSchema.safeParse({ ratePercent: 1000 }).success).toBe(false)
+    expect(
+      insertTaxRegimeSchema.safeParse({ code: "standard", name: "Neg", ratePercent: -1 }).success,
+    ).toBe(false)
+  })
+
+  it("accepts tax regime rates within the 0..100 percent domain", () => {
+    const result = insertTaxRegimeSchema.parse({
+      code: "standard",
+      name: "TVA Standard",
+      ratePercent: 21,
+    })
+
+    expect(result.ratePercent).toBe(21)
+    expect(
+      insertTaxRegimeSchema.parse({ code: "zero_rated", name: "Zero", ratePercent: 0 }).ratePercent,
+    ).toBe(0)
+    expect(
+      insertTaxRegimeSchema.parse({ code: "standard", name: "Full", ratePercent: 100 }).ratePercent,
+    ).toBe(100)
   })
 
   it("parses false tax-class active query filters as false", () => {

--- a/packages/finance-contracts/src/validation-billing.ts
+++ b/packages/finance-contracts/src/validation-billing.ts
@@ -405,7 +405,10 @@ const taxRegimeCoreSchema = z.object({
   code: taxRegimeCodeSchema,
   name: z.string().min(1).max(255),
   jurisdiction: z.string().max(10).optional().nullable(),
-  ratePercent: z.number().int().min(0).max(10000).optional().nullable(),
+  // `ratePercent` is a whole-number percentage (e.g. 21 = 21% VAT); the booking
+  // tax calculator divides it by 100 to derive the fraction. Bound it to the
+  // 0..100 percent domain so an out-of-range value (e.g. 1000) cannot be stored.
+  ratePercent: z.number().int().min(0).max(100).optional().nullable(),
   description: z.string().max(2000).optional().nullable(),
   legalReference: z.string().max(500).optional().nullable(),
   active: z.boolean().default(true),

--- a/packages/finance/src/routes-reference-data.ts
+++ b/packages/finance/src/routes-reference-data.ts
@@ -948,23 +948,45 @@ const taxPolicyRuleRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidatio
   .openapi(listTaxPolicyRulesRoute, async (c) =>
     c.json(await financeService.listTaxPolicyRules(c.get("db"), c.req.valid("query")), 200),
   )
-  .openapi(createTaxPolicyRuleRoute, async (c) =>
-    c.json(
-      { data: created(await financeService.createTaxPolicyRule(c.get("db"), c.req.valid("json"))) },
-      201,
-    ),
-  )
+  .openapi(createTaxPolicyRuleRoute, async (c) => {
+    try {
+      return c.json(
+        {
+          data: created(await financeService.createTaxPolicyRule(c.get("db"), c.req.valid("json"))),
+        },
+        201,
+      )
+    } catch (error) {
+      if (error instanceof ReferenceDataValidationError) {
+        return c.json(
+          { error: error.message, code: error.code, details: error.details },
+          error.status,
+        )
+      }
+      throw error
+    }
+  })
   .openapi(getTaxPolicyRuleRoute, async (c) => {
     const row = await financeService.getTaxPolicyRuleById(c.get("db"), c.req.valid("param").id)
     return row ? c.json({ data: row }, 200) : notFound(c, "Tax policy rule not found")
   })
   .openapi(updateTaxPolicyRuleRoute, async (c) => {
-    const row = await financeService.updateTaxPolicyRule(
-      c.get("db"),
-      c.req.valid("param").id,
-      c.req.valid("json"),
-    )
-    return row ? c.json({ data: row }, 200) : notFound(c, "Tax policy rule not found")
+    try {
+      const row = await financeService.updateTaxPolicyRule(
+        c.get("db"),
+        c.req.valid("param").id,
+        c.req.valid("json"),
+      )
+      return row ? c.json({ data: row }, 200) : notFound(c, "Tax policy rule not found")
+    } catch (error) {
+      if (error instanceof ReferenceDataValidationError) {
+        return c.json(
+          { error: error.message, code: error.code, details: error.details },
+          error.status,
+        )
+      }
+      throw error
+    }
   })
   .openapi(deleteTaxPolicyRuleRoute, async (c) => {
     const row = await financeService.deleteTaxPolicyRule(c.get("db"), c.req.valid("param").id)

--- a/packages/finance/src/service-reference-data.ts
+++ b/packages/finance/src/service-reference-data.ts
@@ -73,6 +73,41 @@ async function assertTaxClassRegimesExist(
   }
 }
 
+type TaxPolicyRuleReferenceInput = Pick<CreateTaxPolicyRuleInput, "profileId" | "taxRegimeId">
+
+async function assertTaxPolicyRuleReferencesExist(
+  db: PostgresJsDatabase,
+  data: Partial<TaxPolicyRuleReferenceInput>,
+) {
+  const missing: { missingProfileId?: string; missingTaxRegimeId?: string } = {}
+
+  if (data.profileId) {
+    const [profile] = await db
+      .select({ id: taxPolicyProfiles.id })
+      .from(taxPolicyProfiles)
+      .where(eq(taxPolicyProfiles.id, data.profileId))
+      .limit(1)
+    if (!profile) missing.missingProfileId = data.profileId
+  }
+
+  if (data.taxRegimeId) {
+    const [regime] = await db
+      .select({ id: taxRegimes.id })
+      .from(taxRegimes)
+      .where(eq(taxRegimes.id, data.taxRegimeId))
+      .limit(1)
+    if (!regime) missing.missingTaxRegimeId = data.taxRegimeId
+  }
+
+  if (missing.missingProfileId || missing.missingTaxRegimeId) {
+    throw new ReferenceDataValidationError(
+      "Tax policy rule references unknown records",
+      missing,
+      "invalid_reference",
+    )
+  }
+}
+
 export const financeReferenceDataService = {
   async listTaxRegimes(db: PostgresJsDatabase, query: TaxRegimeListQuery) {
     const conditions = []
@@ -297,6 +332,8 @@ export const financeReferenceDataService = {
   },
 
   async createTaxPolicyRule(db: PostgresJsDatabase, data: CreateTaxPolicyRuleInput) {
+    await assertTaxPolicyRuleReferencesExist(db, data)
+
     const [row] = await db
       .insert(taxPolicyRules)
       .values({
@@ -314,6 +351,8 @@ export const financeReferenceDataService = {
   },
 
   async updateTaxPolicyRule(db: PostgresJsDatabase, id: string, data: UpdateTaxPolicyRuleInput) {
+    await assertTaxPolicyRuleReferencesExist(db, data)
+
     const [row] = await db
       .update(taxPolicyRules)
       .set({ ...data, updatedAt: new Date() })

--- a/packages/finance/tests/unit/service-reference-data.test.ts
+++ b/packages/finance/tests/unit/service-reference-data.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest"
 
 import { financeReferenceDataRoutes } from "../../src/routes-reference-data.js"
 import { financeReferenceDataService } from "../../src/service-reference-data.js"
+import { taxPolicyProfiles, taxRegimes } from "../../src/service-shared.js"
 
 function makeTaxClassDb(existingRegimeIds: string[] = []) {
   const where = vi.fn().mockResolvedValue(existingRegimeIds.map((id) => ({ id })))
@@ -144,5 +145,91 @@ describe("financeReferenceDataService tax classes", () => {
       code: "invalid_reference",
       details: { missingRegimeIds: ["txrg_missing"] },
     })
+  })
+})
+
+/**
+ * Existence lookups for a tax policy rule hit two different tables
+ * (`tax_policy_profiles` for `profileId`, `tax_regimes` for `taxRegimeId`), so
+ * the mock resolves each `select().from(table).where().limit()` chain by the
+ * table it was pointed at.
+ */
+function makeTaxPolicyRuleDb(opts: { profileExists: boolean; regimeExists: boolean }) {
+  const rowsFor = (table: unknown) => {
+    if (table === taxPolicyProfiles) return opts.profileExists ? [{ id: "txpp_existing" }] : []
+    if (table === taxRegimes) return opts.regimeExists ? [{ id: "txrg_existing" }] : []
+    return []
+  }
+  const from = vi.fn((table: unknown) => ({
+    where: vi.fn(() => ({ limit: vi.fn().mockResolvedValue(rowsFor(table)) })),
+  }))
+  const select = vi.fn(() => ({ from }))
+
+  const returning = vi.fn().mockResolvedValue([{ id: "txpr_123" }])
+  const values = vi.fn(() => ({ returning }))
+  const insert = vi.fn(() => ({ values }))
+
+  const updateReturning = vi.fn().mockResolvedValue([{ id: "txpr_123" }])
+  const updateWhere = vi.fn(() => ({ returning: updateReturning }))
+  const set = vi.fn(() => ({ where: updateWhere }))
+  const update = vi.fn(() => ({ set }))
+
+  return { db: { select, insert, update } as PostgresJsDatabase, insert, update }
+}
+
+describe("financeReferenceDataService tax policy rules", () => {
+  const basePayload = {
+    profileId: "txpp_existing",
+    side: "sell" as const,
+    priority: 100,
+    name: "Standard sell",
+    appliesTo: "all" as const,
+    taxRegimeId: "txrg_existing",
+    active: true,
+  }
+
+  it("rejects create payloads with nonexistent profile and regime references", async () => {
+    const { db, insert } = makeTaxPolicyRuleDb({ profileExists: false, regimeExists: false })
+
+    await expect(
+      financeReferenceDataService.createTaxPolicyRule(db, {
+        ...basePayload,
+        profileId: "txpp_missing",
+        taxRegimeId: "txrg_missing",
+      }),
+    ).rejects.toMatchObject({
+      name: "ReferenceDataValidationError",
+      code: "invalid_reference",
+      status: 400,
+      details: { missingProfileId: "txpp_missing", missingTaxRegimeId: "txrg_missing" },
+    })
+    expect(insert).not.toHaveBeenCalled()
+  })
+
+  it("rejects create payloads when only the regime reference is dangling", async () => {
+    const { db, insert } = makeTaxPolicyRuleDb({ profileExists: true, regimeExists: false })
+
+    await expect(
+      financeReferenceDataService.createTaxPolicyRule(db, {
+        ...basePayload,
+        taxRegimeId: "txrg_missing",
+      }),
+    ).rejects.toMatchObject({
+      name: "ReferenceDataValidationError",
+      code: "invalid_reference",
+      details: { missingTaxRegimeId: "txrg_missing" },
+    })
+    expect(insert).not.toHaveBeenCalled()
+  })
+
+  it("inserts when both profile and regime references exist", async () => {
+    const { db, insert } = makeTaxPolicyRuleDb({ profileExists: true, regimeExists: true })
+
+    await expect(financeReferenceDataService.createTaxPolicyRule(db, basePayload)).resolves.toEqual(
+      {
+        id: "txpr_123",
+      },
+    )
+    expect(insert).toHaveBeenCalledOnce()
   })
 })


### PR DESCRIPTION
## Summary
Enforce cross-reference and domain semantics on Settings/reference-data creates before writing, so consumers cannot read back invalid or dangling configuration.

- **price-schedules** — reject a nonexistent `priceCatalogId` with a deterministic `invalid_reference` 400 (was a 500). Plain text id, no DB FK, so existence is guarded in the service on create + update.
- **tax-regimes** — bound `ratePercent` to the 0..100 percent domain (the booking-tax calculator divides it by 100); an out-of-range value like `1000` is now rejected (was 201).
- **tax-policy-rules** — reject dangling `profileId`/`taxRegimeId` references with an `invalid_reference` 400 (was 201), mirroring the existing tax-class regime guard.

The issue's other cases were already enforced on current `main` and verified: pricing-category `minAge <= maxAge` (`validateMergedPricingCategory`, wired at `createPricingCategory`), price-schedule `validFrom <= validTo` (`collectPriceScheduleIssues`), and tax-class dangling `defaultRegimeId` (`assertTaxClassRegimesExist`).

## Tests
- `finance-contracts`: tax-regime rate-domain schema tests (rejects 1000/-1, accepts 21).
- `finance`: tax-policy-rule dangling-reference service tests.
- `commerce`: price-schedule dangling-catalog guard test.

Fixes #2611