### PR TITLE
fix(inventory): offer bank transfer and inquiry on owned-product storefront checkout

### DIFF
--- a/.changeset/owned-product-checkout-payment-intents.md
+++ b/.changeset/owned-product-checkout-payment-intents.md
@@ -1,0 +1,18 @@
+---
+"@voyant-travel/catalog-contracts": patch
+"@voyant-travel/catalog": patch
+"@voyant-travel/inventory": patch
+"@voyant-travel/bookings-react": patch
+---
+
+Offer bank transfer and inquiry on owned-product storefront checkout.
+
+The owned-product booking draft shape hardcoded `paymentIntents: ["hold",
+"card"]`, so the storefront Payment step collapsed to card-only for owned
+products even though the deployment advertised bank transfer and inquiry
+(sourced products already offered all three). Both product draft shapes now
+declare the full engine allow list via a shared `DEFAULT_PAYMENT_INTENTS`
+constant, and deployment/surface `PaymentProviderCapabilities` narrow it at
+render time — so owned and sourced products offer the same payment paths. The
+`/checkout/start` flow already handled bank transfer and inquiry generically on
+the booking row, so no server change was needed.

--- a/packages/bookings-react/src/journey/components/booking-journey-rules.ts
+++ b/packages/bookings-react/src/journey/components/booking-journey-rules.ts
@@ -1,6 +1,7 @@
 import {
   type BookingDraftShape,
   DEFAULT_PAX_BANDS,
+  DEFAULT_PAYMENT_INTENTS,
   defaultBookingFields,
   defaultDraftShapeFlags,
   defaultTravelerFields,
@@ -276,6 +277,6 @@ export function defaultMinimalShape(): BookingDraftShape {
     // narrow further at render time — listing every supported intent
     // here means consumers can opt in via PaymentProviderCapabilities
     // without needing a custom fallbackShape.
-    paymentIntents: ["card", "bank_transfer", "hold", "inquiry", "ticket_on_credit"],
+    paymentIntents: DEFAULT_PAYMENT_INTENTS,
   }
 }

--- a/packages/catalog-contracts/src/booking-engine/draft-shape.ts
+++ b/packages/catalog-contracts/src/booking-engine/draft-shape.ts
@@ -334,6 +334,19 @@ export const DEFAULT_PAX_BANDS: ReadonlyArray<PaxBandSpec> = [
 export const DEFAULT_PAX_TOTAL = { min: 1, max: 8 } as const
 
 /**
+ * Canonical engine-level allow list of payment intents a booking
+ * shape exposes. This is intentionally the *full* set the engine can
+ * handle — deployment/surface `PaymentProviderCapabilities` narrow it
+ * further at render time (see the payment step), so listing every
+ * supported intent here lets consumers opt in via capabilities without
+ * needing a custom shape. Owned + sourced product shapes both use this
+ * so the storefront offers the same payment paths regardless of source.
+ */
+export const DEFAULT_PAYMENT_INTENTS: ReadonlyArray<
+  "hold" | "card" | "bank_transfer" | "ticket_on_credit" | "inquiry"
+> = ["card", "bank_transfer", "hold", "inquiry", "ticket_on_credit"]
+
+/**
  * Compute the aggregate min/max from a list of pax bands. Min is the
  * sum of `minCount`; max is the sum of `maxCount`. Verticals can
  * narrow further (e.g. "max 4 cabins per booking" overrides the

--- a/packages/catalog/src/booking-engine/index.ts
+++ b/packages/catalog/src/booking-engine/index.ts
@@ -89,6 +89,7 @@ export {
   type ConfigureSubStep,
   DEFAULT_PAX_BANDS,
   DEFAULT_PAX_TOTAL,
+  DEFAULT_PAYMENT_INTENTS,
   defaultBookingFields,
   defaultDraftShapeFlags,
   defaultTravelerFields,

--- a/packages/inventory/src/booking-engine/handler.ts
+++ b/packages/inventory/src/booking-engine/handler.ts
@@ -34,6 +34,7 @@ import {
   type ComputeQuoteRequest,
   type ComputeQuoteResult,
   DEFAULT_PAX_BANDS,
+  DEFAULT_PAYMENT_INTENTS,
   defaultBookingFields,
   defaultDraftShapeFlags,
   defaultTravelerFields,
@@ -327,7 +328,11 @@ export function buildOwnedProductDraftShape(
       : {}),
     travelerFields: fields,
     bookingFields: defaultBookingFields(),
-    paymentIntents: ["hold", "card"],
+    // Full engine allow list; deployment/surface capabilities narrow it
+    // at render time (storefront → card + bank transfer + inquiry). Owned
+    // products previously hardcoded ["hold", "card"], which collapsed the
+    // storefront's Payment step to card-only (voyant#2741).
+    paymentIntents: DEFAULT_PAYMENT_INTENTS,
     configureSubSteps: [
       ...(variants.length > 0 ? [{ kind: "product-option" as const, options: variants }] : []),
       // Owned products are scheduled — the operator picks a real departure.

--- a/packages/inventory/src/draft-shape.ts
+++ b/packages/inventory/src/draft-shape.ts
@@ -22,6 +22,7 @@
 import {
   type BookingDraftShape,
   DEFAULT_PAX_BANDS,
+  DEFAULT_PAYMENT_INTENTS,
   defaultBookingFields,
   defaultDraftShapeFlags,
   defaultTravelerFields,
@@ -67,7 +68,10 @@ export function buildProductDraftShape(
     paxBandsAllowedTotal: total,
     travelerFields: defaultTravelerFields(),
     bookingFields: defaultBookingFields(),
-    paymentIntents: ["hold", "card"],
+    // Full engine allow list; capabilities narrow it at render time so the
+    // storefront offers card + bank transfer + inquiry, matching sourced
+    // products (voyant#2741).
+    paymentIntents: DEFAULT_PAYMENT_INTENTS,
     configureSubSteps: [
       ...(productOptions.length > 0
         ? [{ kind: "product-option" as const, options: productOptions }]

--- a/packages/inventory/tests/unit/booking-engine-handler.test.ts
+++ b/packages/inventory/tests/unit/booking-engine-handler.test.ts
@@ -11,7 +11,12 @@ describe("buildOwnedProductDraftShape", () => {
     expect(shape.showsReview).toBe(true)
     expect(shape.showsAddons).toBe(false)
     expect(shape.travelerFields.length).toBeGreaterThan(0)
-    expect(shape.paymentIntents).toContain("hold")
+    // Full engine allow list — deployment/surface capabilities narrow it
+    // at render time. The storefront (card + bank transfer + inquiry) must
+    // not collapse to card-only for owned products (voyant#2741).
+    expect(shape.paymentIntents).toEqual(
+      expect.arrayContaining(["hold", "card", "bank_transfer", "inquiry"]),
+    )
   })
 
   it("widens travelerFields with caller-supplied requirements", () => {

--- a/packages/inventory/tests/unit/draft-shape.test.ts
+++ b/packages/inventory/tests/unit/draft-shape.test.ts
@@ -76,8 +76,13 @@ describe("buildProductDraftShape", () => {
     expect(shape.paxBandsAllowedTotal).toEqual({ min: 2, max: 6 })
   })
 
-  it("declares hold + card payment intents", () => {
+  it("declares the full engine payment-intent allow list", () => {
+    // Capabilities narrow this at render time; the shape lists every
+    // supported intent so the storefront can offer card + bank transfer +
+    // inquiry for owned products, matching sourced ones (voyant#2741).
     const shape = buildProductDraftShape(minimalContent)
-    expect(shape.paymentIntents).toEqual(["hold", "card"])
+    expect(shape.paymentIntents).toEqual(
+      expect.arrayContaining(["hold", "card", "bank_transfer", "inquiry"]),
+    )
   })
 })


### PR DESCRIPTION
## What

Fixes #2741. On the storefront, an **owned** product's Payment step only offered "Pay by card", while sourced/connected products offered card + bank transfer + inquiry.

## Root cause

Both owned-product booking draft-shape builders hardcoded `paymentIntents: ["hold", "card"]`:

- `buildOwnedProductDraftShape` (`packages/inventory/src/booking-engine/handler.ts`) — the primary owned-products quote handler.
- `buildProductDraftShape` (`packages/inventory/src/draft-shape.ts`) — the product quote-shape fallback used by the operator's shape enricher.

The Payment step renders `shape.paymentIntents ∩ PaymentProviderCapabilities`. Sourced products carry no shape, so the journey falls back to `defaultMinimalShape()` — which lists the **full** engine intent set and lets capabilities narrow it. Owned products' `["hold", "card"]` intersected with the storefront capabilities (`card` + `bank_transfer` + `inquiry`, no `hold`) collapsed to card-only.

## Fix

- Add a shared `DEFAULT_PAYMENT_INTENTS` constant to `@voyant-travel/catalog-contracts` (re-exported from `@voyant-travel/catalog`) — the canonical full engine allow list.
- Both product draft shapes now declare `DEFAULT_PAYMENT_INTENTS`; deployment/surface `PaymentProviderCapabilities` narrow it at render time, so owned and sourced products offer the same payment paths.
- `defaultMinimalShape()` now references the same constant (DRY; value unchanged).

The `/checkout/start` service already handled `bank_transfer` and `inquiry` generically on the booking row (owned bookings have a real row written on `/book`; the proforma/inquiry paths read booking + items), and the storefront handler already routes all four result kinds — so **no server change was needed**.

## Scope note

The sibling sourced verticals (`accommodations`/`charters`/`cruises`) still hardcode `["hold", "card"]` in their own draft shapes; those are out of scope for this issue (which is specifically about products) and can be aligned in a follow-up.

## Testing

- `pnpm --filter @voyant-travel/inventory typecheck && test` — pass (updated the two owned-shape unit tests to assert the broadened intent set).
- `pnpm --filter @voyant-travel/bookings-react test -- journey payment` — 92 pass.
- `pnpm --filter @voyant-travel/catalog-contracts test` — pass.
- `pnpm release:plan` — clean.

Pre-existing failures on `main` (commerce `service-price-schedules.test.ts` typecheck, operator OpenAPI drift, bookings-react `booking-contract-dialog` typecheck) are unrelated to this change and reproduce on a clean checkout.