### PR TITLE
Validate resource assignment lifecycle

### DIFF
--- a/.changeset/resource-assignment-lifecycle.md
+++ b/.changeset/resource-assignment-lifecycle.md
@@ -1,0 +1,8 @@
+---
+"@voyant-travel/operations": patch
+"@voyant-travel/operations-react": patch
+"@voyant-travel/i18n": patch
+"@voyant-travel/openapi": patch
+---
+
+Align resource assignment detail schemas around `assignedAt`, reject orphan or incoherent slot assignment lifecycle payloads, and surface assignment target validation in the admin UI.

--- a/packages/i18n/src/admin/resources.ts
+++ b/packages/i18n/src/admin/resources.ts
@@ -142,6 +142,7 @@ export const adminResourcesMessages = {
         },
         assignment: {
           validationSlotRequired: "Slot is required",
+          validationTargetRequired: "Select a pool or resource",
           editTitle: "Edit Assignment",
           newTitle: "New Assignment",
           slotLabel: "Slot",
@@ -382,6 +383,7 @@ export const adminResourcesMessages = {
         },
         assignment: {
           validationSlotRequired: "Slotul este obligatoriu",
+          validationTargetRequired: "Selecteaza un pool sau o resursa",
           editTitle: "Editeaza asignarea",
           newTitle: "Asignare noua",
           slotLabel: "Slot",

--- a/packages/openapi/spec/admin/operations.json
+++ b/packages/openapi/spec/admin/operations.json
@@ -19294,6 +19294,10 @@
                     ],
                     "default": "reserved"
                   },
+                  "assignedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
                   "assignedBy": {
                     "type": [
                       "string",
@@ -19499,6 +19503,10 @@
                           "completed"
                         ],
                         "default": "reserved"
+                      },
+                      "assignedAt": {
+                        "type": "string",
+                        "format": "date-time"
                       },
                       "assignedBy": {
                         "type": [
@@ -19933,6 +19941,10 @@
                       "completed"
                     ],
                     "default": "reserved"
+                  },
+                  "assignedAt": {
+                    "type": "string",
+                    "format": "date-time"
                   },
                   "assignedBy": {
                     "type": [

--- a/packages/operations-react/src/resources/admin/resources-dialogs-ops.tsx
+++ b/packages/operations-react/src/resources/admin/resources-dialogs-ops.tsx
@@ -44,16 +44,31 @@ import {
 import { sendResourcesMutation } from "./resources-admin-api.js"
 
 const getAssignmentFormSchema = (messages: ReturnType<typeof useOperatorAdminMessages>) =>
-  z.object({
-    slotId: z.string().min(1, messages.resources.dialogs.assignment.validationSlotRequired),
-    poolId: z.string().optional(),
-    resourceId: z.string().optional(),
-    bookingId: z.string().optional(),
-    status: z.enum(["reserved", "assigned", "released", "cancelled", "completed"]),
-    assignedBy: z.string().optional(),
-    releasedAt: z.string().optional(),
-    notes: z.string().optional(),
-  })
+  z
+    .object({
+      slotId: z.string().min(1, messages.resources.dialogs.assignment.validationSlotRequired),
+      poolId: z.string().optional(),
+      resourceId: z.string().optional(),
+      bookingId: z.string().optional(),
+      status: z.enum(["reserved", "assigned", "released", "cancelled", "completed"]),
+      assignedBy: z.string().optional(),
+      releasedAt: z.string().optional(),
+      notes: z.string().optional(),
+    })
+    .superRefine((values, ctx) => {
+      if (
+        (!values.poolId || values.poolId === NONE_VALUE) &&
+        (!values.resourceId || values.resourceId === NONE_VALUE)
+      ) {
+        const issue = {
+          code: "custom" as const,
+          message: messages.resources.dialogs.assignment.validationTargetRequired,
+        }
+
+        ctx.addIssue({ ...issue, path: ["poolId"] })
+        ctx.addIssue({ ...issue, path: ["resourceId"] })
+      }
+    })
 
 export function ResourceSlotAssignmentDialog({
   open,
@@ -173,7 +188,9 @@ export function ResourceSlotAssignmentDialog({
                 <Label>{dialogMessages.poolLabel}</Label>
                 <Select
                   value={form.watch("poolId")}
-                  onValueChange={(value) => form.setValue("poolId", value ?? NONE_VALUE)}
+                  onValueChange={(value) =>
+                    form.setValue("poolId", value ?? NONE_VALUE, { shouldValidate: true })
+                  }
                 >
                   <SelectTrigger className="w-full">
                     <SelectValue />
@@ -187,12 +204,17 @@ export function ResourceSlotAssignmentDialog({
                     ))}
                   </SelectContent>
                 </Select>
+                {form.formState.errors.poolId ? (
+                  <p className="text-destructive text-xs">{form.formState.errors.poolId.message}</p>
+                ) : null}
               </div>
               <div className="grid gap-2">
                 <Label>{dialogMessages.resourceLabel}</Label>
                 <Select
                   value={form.watch("resourceId")}
-                  onValueChange={(value) => form.setValue("resourceId", value ?? NONE_VALUE)}
+                  onValueChange={(value) =>
+                    form.setValue("resourceId", value ?? NONE_VALUE, { shouldValidate: true })
+                  }
                 >
                   <SelectTrigger className="w-full">
                     <SelectValue />
@@ -206,6 +228,11 @@ export function ResourceSlotAssignmentDialog({
                     ))}
                   </SelectContent>
                 </Select>
+                {form.formState.errors.resourceId ? (
+                  <p className="text-destructive text-xs">
+                    {form.formState.errors.resourceId.message}
+                  </p>
+                ) : null}
               </div>
               <div className="grid gap-2">
                 <Label>{dialogMessages.bookingLabel}</Label>

--- a/packages/operations-react/src/resources/components/resource-assignment-detail-page.tsx
+++ b/packages/operations-react/src/resources/components/resource-assignment-detail-page.tsx
@@ -163,11 +163,8 @@ export function ResourceAssignmentDetailPage({
               formatDateTime: i18n.formatDateTime,
             })}
           </ResourceDetailField>
-          <ResourceDetailField label={page.common.created}>
-            {i18n.formatDateTime(assignment.createdAt)}
-          </ResourceDetailField>
-          <ResourceDetailField label={page.common.updated}>
-            {i18n.formatDateTime(assignment.updatedAt)}
+          <ResourceDetailField label={page.assignment.assignedAt}>
+            {i18n.formatDateTime(assignment.assignedAt)}
           </ResourceDetailField>
         </div>
       </ResourceDetailCard>

--- a/packages/operations-react/src/resources/i18n/en.ts
+++ b/packages/operations-react/src/resources/i18n/en.ts
@@ -363,6 +363,7 @@ export const resourcesUiEn: ResourcesUiMessages = {
       startTime: "Start Time",
     },
     assignment: {
+      assignedAt: "Assigned At",
       assignedBy: "Assigned By",
       deleteConfirm: "Delete assignment {name}?",
       deleteFailed: "Assignment could not be deleted.",

--- a/packages/operations-react/src/resources/i18n/messages.ts
+++ b/packages/operations-react/src/resources/i18n/messages.ts
@@ -287,6 +287,7 @@ export type ResourcesUiMessages = {
       startTime: string
     }
     assignment: {
+      assignedAt: string
       assignedBy: string
       deleteConfirm: string
       deleteFailed: string

--- a/packages/operations-react/src/resources/i18n/ro.ts
+++ b/packages/operations-react/src/resources/i18n/ro.ts
@@ -364,6 +364,7 @@ export const resourcesUiRo: ResourcesUiMessages = {
       startTime: "Ora de Start",
     },
     assignment: {
+      assignedAt: "Asignat La",
       assignedBy: "Asignat De",
       deleteConfirm: "Stergi asignarea {name}?",
       deleteFailed: "Asignarea nu a putut fi stearsa.",

--- a/packages/operations-react/src/resources/schemas.test.ts
+++ b/packages/operations-react/src/resources/schemas.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+
+import { resourceSlotAssignmentSingleResponse } from "./schemas.js"
+
+describe("resource assignment schemas", () => {
+  it("parses the backend assignment detail timestamp shape", () => {
+    const parsed = resourceSlotAssignmentSingleResponse.safeParse({
+      data: {
+        id: "resa_1",
+        slotId: "slot_1",
+        poolId: "pool_1",
+        resourceId: null,
+        bookingId: null,
+        status: "reserved",
+        assignedAt: "2025-06-15T10:00:00.000Z",
+        assignedBy: null,
+        releasedAt: null,
+        notes: null,
+      },
+    })
+
+    expect(parsed.success ? parsed.data.data.assignedAt : null).toBe("2025-06-15T10:00:00.000Z")
+  })
+})

--- a/packages/operations-react/src/resources/schemas.ts
+++ b/packages/operations-react/src/resources/schemas.ts
@@ -130,6 +130,7 @@ export const resourceSlotAssignmentRecordSchema = z.object({
   resourceId: z.string().nullable(),
   bookingId: z.string().nullable(),
   status: resourceStatusSchema,
+  assignedAt: z.string(),
   assignedBy: z.string().nullable(),
   releasedAt: z.string().nullable(),
   notes: z.string().nullable(),
@@ -137,10 +138,7 @@ export const resourceSlotAssignmentRecordSchema = z.object({
 
 export type ResourceSlotAssignmentRow = z.infer<typeof resourceSlotAssignmentRecordSchema>
 
-export const resourceSlotAssignmentDetailSchema = resourceSlotAssignmentRecordSchema.extend({
-  createdAt: z.string(),
-  updatedAt: z.string(),
-})
+export const resourceSlotAssignmentDetailSchema = resourceSlotAssignmentRecordSchema
 
 export type ResourceSlotAssignmentDetail = z.infer<typeof resourceSlotAssignmentDetailSchema>
 

--- a/packages/operations/src/resources/routes.ts
+++ b/packages/operations/src/resources/routes.ts
@@ -169,6 +169,14 @@ function handleResourcesNotFoundRouteError(c: Context<Env>, error: unknown) {
   throw error
 }
 
+function handleSlotAssignmentRouteError(c: Context<Env>, error: unknown) {
+  if (error instanceof ResourcesServiceError) {
+    if (error.status === 400) return c.json({ error: error.message }, 400)
+    if (error.status === 404) return c.json({ error: error.message }, 404)
+  }
+  throw error
+}
+
 /** Envelope returned by the shared batch-update handler. */
 function batchUpdateResponseSchema<T extends z.ZodTypeAny>(row: T) {
   return z.object({
@@ -1239,7 +1247,7 @@ const slotAssignmentRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidati
       const row = await resourcesService.createSlotAssignment(c.get("db"), c.req.valid("json"))
       return c.json({ data: row! }, 201)
     } catch (error) {
-      return handleResourcesNotFoundRouteError(c, error)
+      return handleSlotAssignmentRouteError(c, error)
     }
   })
   .openapi(batchUpdateSlotAssignmentsRoute, async (c) => {
@@ -1282,7 +1290,7 @@ const slotAssignmentRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidati
         ? c.json({ data: row }, 200)
         : c.json({ error: "Resource slot assignment not found" }, 404)
     } catch (error) {
-      return handleResourcesNotFoundRouteError(c, error)
+      return handleSlotAssignmentRouteError(c, error)
     }
   })
   .openapi(deleteSlotAssignmentRoute, async (c) => {

--- a/packages/operations/src/resources/service.ts
+++ b/packages/operations/src/resources/service.ts
@@ -51,7 +51,7 @@ type UpdateResourceCloseoutInput = z.infer<typeof updateResourceCloseoutSchema>
 export class ResourcesServiceError extends Error {
   constructor(
     message: string,
-    public readonly status: 404 | 409,
+    public readonly status: 400 | 404 | 409,
   ) {
     super(message)
     this.name = "ResourcesServiceError"
@@ -70,6 +70,34 @@ async function paginate<T extends object>(
 
 function toDateOrNull(value: string | null | undefined) {
   return value ? new Date(value) : null
+}
+
+function toDateOrUndefined(value: string | undefined) {
+  return value === undefined ? undefined : new Date(value)
+}
+
+function validateSlotAssignmentState(data: {
+  poolId: string | null
+  resourceId: string | null
+  status: CreateResourceSlotAssignmentInput["status"]
+  assignedAt: Date
+  releasedAt: Date | null
+}) {
+  if (!data.poolId && !data.resourceId) {
+    throw new ResourcesServiceError("Either poolId or resourceId is required", 400)
+  }
+
+  if (data.releasedAt && data.releasedAt < data.assignedAt) {
+    throw new ResourcesServiceError("releasedAt must be after assignedAt", 400)
+  }
+
+  if (data.status === "released" && !data.releasedAt) {
+    throw new ResourcesServiceError("releasedAt is required when status is released", 400)
+  }
+
+  if (data.status !== "released" && data.releasedAt) {
+    throw new ResourcesServiceError("releasedAt is only allowed when status is released", 400)
+  }
 }
 
 function isPostgresError(error: unknown, code: string, constraint?: string) {
@@ -377,9 +405,19 @@ export const resourcesService = {
   async createSlotAssignment(db: PostgresJsDatabase, data: CreateResourceSlotAssignmentInput) {
     if (data.poolId) await ensurePoolExists(db, data.poolId)
     if (data.resourceId) await ensureResourceExists(db, data.resourceId)
+    const assignedAt = toDateOrUndefined(data.assignedAt) ?? new Date()
+    const releasedAt = toDateOrNull(data.releasedAt)
+    validateSlotAssignmentState({
+      poolId: data.poolId ?? null,
+      resourceId: data.resourceId ?? null,
+      status: data.status,
+      assignedAt,
+      releasedAt,
+    })
+
     const [row] = await db
       .insert(resourceSlotAssignments)
-      .values({ ...data, releasedAt: toDateOrNull(data.releasedAt) })
+      .values({ ...data, assignedAt, releasedAt })
       .returning()
     return row
   },
@@ -389,13 +427,30 @@ export const resourcesService = {
     id: string,
     data: UpdateResourceSlotAssignmentInput,
   ) {
-    if (data.poolId) await ensurePoolExists(db, data.poolId)
-    if (data.resourceId) await ensureResourceExists(db, data.resourceId)
+    if (data.poolId !== undefined && data.poolId !== null) await ensurePoolExists(db, data.poolId)
+    if (data.resourceId !== undefined && data.resourceId !== null) {
+      await ensureResourceExists(db, data.resourceId)
+    }
+    const existing = await this.getSlotAssignmentById(db, id)
+    if (!existing) return null
+
+    const assignedAt = toDateOrUndefined(data.assignedAt) ?? existing.assignedAt
+    const releasedAt =
+      data.releasedAt === undefined ? existing.releasedAt : toDateOrNull(data.releasedAt)
+    validateSlotAssignmentState({
+      poolId: data.poolId === undefined ? existing.poolId : data.poolId,
+      resourceId: data.resourceId === undefined ? existing.resourceId : data.resourceId,
+      status: data.status ?? existing.status,
+      assignedAt,
+      releasedAt,
+    })
+
     const [row] = await db
       .update(resourceSlotAssignments)
       .set({
         ...data,
-        releasedAt: data.releasedAt === undefined ? undefined : toDateOrNull(data.releasedAt),
+        assignedAt: toDateOrUndefined(data.assignedAt),
+        releasedAt: data.releasedAt === undefined ? undefined : releasedAt,
       })
       .where(eq(resourceSlotAssignments.id, id))
       .returning()

--- a/packages/operations/src/resources/validation.ts
+++ b/packages/operations/src/resources/validation.ts
@@ -95,12 +95,54 @@ export const resourceSlotAssignmentCoreSchema = z.object({
   resourceId: z.string().nullable().optional(),
   bookingId: z.string().nullable().optional(),
   status: resourceAssignmentStatusSchema.default("reserved"),
+  assignedAt: isoDateTimeSchema.optional(),
   assignedBy: z.string().nullable().optional(),
   releasedAt: isoDateTimeSchema.nullable().optional(),
   notes: z.string().nullable().optional(),
 })
 
-export const insertResourceSlotAssignmentSchema = resourceSlotAssignmentCoreSchema
+function validateSlotAssignmentLifecycle(
+  data: z.infer<typeof resourceSlotAssignmentCoreSchema>,
+  ctx: z.RefinementCtx,
+) {
+  if (!data.poolId && !data.resourceId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Either poolId or resourceId is required",
+      path: ["resourceId"],
+    })
+  }
+
+  const releasedAt = data.releasedAt ? new Date(data.releasedAt) : null
+  const assignedAt = data.assignedAt ? new Date(data.assignedAt) : null
+  if (releasedAt && assignedAt && releasedAt < assignedAt) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "releasedAt must be after assignedAt",
+      path: ["releasedAt"],
+    })
+  }
+
+  if (data.status === "released" && !releasedAt) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "releasedAt is required when status is released",
+      path: ["releasedAt"],
+    })
+  }
+
+  if (data.status !== "released" && releasedAt) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "releasedAt is only allowed when status is released",
+      path: ["releasedAt"],
+    })
+  }
+}
+
+export const insertResourceSlotAssignmentSchema = resourceSlotAssignmentCoreSchema.superRefine(
+  validateSlotAssignmentLifecycle,
+)
 export const updateResourceSlotAssignmentSchema = resourceSlotAssignmentCoreSchema.partial()
 export const resourceSlotAssignmentListQuerySchema = paginationSchema.extend({
   slotId: z.string().optional(),

--- a/packages/operations/tests/resources/integration/assignments-and-closeouts.test.ts
+++ b/packages/operations/tests/resources/integration/assignments-and-closeouts.test.ts
@@ -12,6 +12,7 @@ describe.skipIf(!DB_AVAILABLE)("Slot assignment and closeout routes", () => {
       const assignment = await ctx.seedSlotAssignment(slot.id)
       expect(assignment.id).toMatch(/^resa_/)
       expect(assignment.slotId).toBe(slot.id)
+      expect(assignment.assignedAt).toBeTruthy()
       expect(assignment.status).toBe("reserved")
     })
 
@@ -34,6 +35,56 @@ describe.skipIf(!DB_AVAILABLE)("Slot assignment and closeout routes", () => {
       })
       expect(missingResource.status).toBe(404)
       await expect(missingResource.json()).resolves.toEqual({ error: "Resource not found" })
+    })
+
+    it("POST /slot-assignments → 400 when poolId and resourceId are both null", async () => {
+      const product = await ctx.seedProductDirect()
+      const slot = await ctx.seedAvailabilitySlotDirect(product.id)
+      const res = await ctx.request("/slot-assignments", {
+        method: "POST",
+        ...json({ slotId: slot.id, poolId: null, resourceId: null }),
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it("POST /slot-assignments → 400 when releasedAt predates assignedAt", async () => {
+      const product = await ctx.seedProductDirect()
+      const slot = await ctx.seedAvailabilitySlotDirect(product.id)
+      const pool = await ctx.seedPool()
+      const res = await ctx.request("/slot-assignments", {
+        method: "POST",
+        ...json({
+          slotId: slot.id,
+          poolId: pool.id,
+          status: "released",
+          assignedAt: "2025-06-15T10:00:00.000Z",
+          releasedAt: "2025-06-15T09:00:00.000Z",
+        }),
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it("POST /slot-assignments → 400 for incoherent status/releasedAt payloads", async () => {
+      const product = await ctx.seedProductDirect()
+      const slot = await ctx.seedAvailabilitySlotDirect(product.id)
+      const pool = await ctx.seedPool()
+
+      const releasedWithoutTimestamp = await ctx.request("/slot-assignments", {
+        method: "POST",
+        ...json({ slotId: slot.id, poolId: pool.id, status: "released" }),
+      })
+      expect(releasedWithoutTimestamp.status).toBe(400)
+
+      const timestampWithoutReleasedStatus = await ctx.request("/slot-assignments", {
+        method: "POST",
+        ...json({
+          slotId: slot.id,
+          poolId: pool.id,
+          status: "reserved",
+          releasedAt: "2025-06-15T11:00:00.000Z",
+        }),
+      })
+      expect(timestampWithoutReleasedStatus.status).toBe(400)
     })
 
     it("GET /slot-assignments/:id → 200", async () => {
@@ -63,6 +114,35 @@ describe.skipIf(!DB_AVAILABLE)("Slot assignment and closeout routes", () => {
       const body = await res.json()
       expect(body.data.status).toBe("assigned")
       expect(body.data.notes).toBe("Confirmed")
+    })
+
+    it("PATCH /slot-assignments/:id → 400 when final lifecycle state is incoherent", async () => {
+      const product = await ctx.seedProductDirect()
+      const slot = await ctx.seedAvailabilitySlotDirect(product.id)
+      const assignment = await ctx.seedSlotAssignment(slot.id, {
+        assignedAt: "2025-06-15T10:00:00.000Z",
+      })
+
+      const releaseBeforeAssigned = await ctx.request(`/slot-assignments/${assignment.id}`, {
+        method: "PATCH",
+        ...json({ status: "released", releasedAt: "2025-06-15T09:00:00.000Z" }),
+      })
+      expect(releaseBeforeAssigned.status).toBe(400)
+
+      const releasedWithoutTimestamp = await ctx.request(`/slot-assignments/${assignment.id}`, {
+        method: "PATCH",
+        ...json({ status: "released" }),
+      })
+      expect(releasedWithoutTimestamp.status).toBe(400)
+
+      const timestampWithoutReleasedStatus = await ctx.request(
+        `/slot-assignments/${assignment.id}`,
+        {
+          method: "PATCH",
+          ...json({ releasedAt: "2025-06-15T11:00:00.000Z" }),
+        },
+      )
+      expect(timestampWithoutReleasedStatus.status).toBe(400)
     })
 
     it("PATCH /slot-assignments/:id → 404 for missing", async () => {

--- a/packages/operations/tests/resources/integration/test-helpers.ts
+++ b/packages/operations/tests/resources/integration/test-helpers.ts
@@ -122,10 +122,13 @@ export function createResourcesTestContext() {
   }
 
   async function seedSlotAssignment(slotId: string, overrides: Record<string, unknown> = {}) {
+    const target =
+      "poolId" in overrides || "resourceId" in overrides ? {} : { poolId: (await seedPool()).id }
     const res = await app.request("/slot-assignments", {
       method: "POST",
       ...json({
         slotId,
+        ...target,
         ...overrides,
       }),
     })

--- a/packages/operations/tests/resources/unit/slot-assignment-validation.test.ts
+++ b/packages/operations/tests/resources/unit/slot-assignment-validation.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+
+import { insertResourceSlotAssignmentSchema } from "../../../src/resources/validation.js"
+
+const validAssignment = {
+  slotId: "slot_1",
+  poolId: "pool_1",
+  assignedAt: "2025-06-15T10:00:00.000Z",
+}
+
+describe("resource slot assignment validation", () => {
+  it("requires a pool or resource on create", () => {
+    expect(
+      insertResourceSlotAssignmentSchema.safeParse({
+        slotId: "slot_1",
+        poolId: null,
+        resourceId: null,
+      }).success,
+    ).toBe(false)
+  })
+
+  it("rejects releasedAt before assignedAt on create", () => {
+    expect(
+      insertResourceSlotAssignmentSchema.safeParse({
+        ...validAssignment,
+        status: "released",
+        releasedAt: "2025-06-15T09:00:00.000Z",
+      }).success,
+    ).toBe(false)
+  })
+
+  it("requires released status and releasedAt to agree on create", () => {
+    expect(
+      insertResourceSlotAssignmentSchema.safeParse({
+        ...validAssignment,
+        status: "released",
+      }).success,
+    ).toBe(false)
+
+    expect(
+      insertResourceSlotAssignmentSchema.safeParse({
+        ...validAssignment,
+        status: "reserved",
+        releasedAt: "2025-06-15T11:00:00.000Z",
+      }).success,
+    ).toBe(false)
+  })
+
+  it("accepts a coherent released assignment on create", () => {
+    expect(
+      insertResourceSlotAssignmentSchema.safeParse({
+        ...validAssignment,
+        status: "released",
+        releasedAt: "2025-06-15T11:00:00.000Z",
+      }).success,
+    ).toBe(true)
+  })
+})

--- a/starters/operator/openapi/admin/operations.json
+++ b/starters/operator/openapi/admin/operations.json
@@ -19294,6 +19294,10 @@
                     ],
                     "default": "reserved"
                   },
+                  "assignedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
                   "assignedBy": {
                     "type": [
                       "string",
@@ -19499,6 +19503,10 @@
                           "completed"
                         ],
                         "default": "reserved"
+                      },
+                      "assignedAt": {
+                        "type": "string",
+                        "format": "date-time"
                       },
                       "assignedBy": {
                         "type": [
@@ -19933,6 +19941,10 @@
                       "completed"
                     ],
                     "default": "reserved"
+                  },
+                  "assignedAt": {
+                    "type": "string",
+                    "format": "date-time"
                   },
                   "assignedBy": {
                     "type": [


### PR DESCRIPTION
Fixes #2572

## Summary
- validate slot assignment lifecycle invariants on create/update
- align operations-react assignment detail schema with backend assignedAt shape
- update generated OpenAPI artifacts

## Verification
- pnpm --filter @voyant-travel/operations exec vitest run tests/resources/unit/slot-assignment-validation.test.ts tests/resources/unit/routes-contract.test.ts
- pnpm --filter @voyant-travel/operations-react exec vitest run src/resources/schemas.test.ts
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/operations typecheck
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/operations-react typecheck
- pnpm --filter @voyant-travel/openapi test
- pnpm --filter operator test -- src/api/openapi.test.ts
- pre-push pnpm test